### PR TITLE
feat(backtest): STEP 29M parameter sensitivity evidence binding v1 slice

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -111,7 +111,7 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29L_COMPLETE` | `true` |
 | `STEP_29M_STARTED` | `true` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `false` |
 | `STEP_29N_STARTED` | `false` |
@@ -1023,7 +1023,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `STATUS` | `IN_PROGRESS` |
 | `CANONICAL_OWNER` | `src/backtest/economic_viability_evidence_v1.py` |
 | `DEPENDENCIES` | RUNBOOK_STEP_29L |
-| `REMAINING_GAPS` | `admissible_versioned_futures_dataset,parameter_sensitivity_binding,economic_validity_policy_threshold_values` |
+| `REMAINING_GAPS` | `admissible_versioned_futures_dataset,economic_validity_policy_threshold_values` |
 | `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29M` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNTIME_EFFECT` | `false` |
@@ -1032,7 +1032,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `ECONOMIC_VALIDITY_PROVEN` | `false` |
 | `PROFITABILITY_CLAIM_ALLOWED` | `false` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `false` |
 | `STEP_29N_STARTED` | `false` |

--- a/src/backtest/economic_viability_evidence_v1.py
+++ b/src/backtest/economic_viability_evidence_v1.py
@@ -30,6 +30,12 @@ from src.backtest.funding_model_v1 import (
     compute_funding_drag_v1,
     load_funding_model_config_v1,
 )
+from src.backtest.parameter_sensitivity_v1 import (
+    ParameterSensitivityError,
+    parameter_sensitivity_binding_requested,
+    run_parameter_sensitivity_v1,
+    serialize_parameter_sensitivity_results_v1,
+)
 from src.backtest.economic_validity_policy_v1 import (
     ECONOMIC_VALIDITY_POLICY_VERSION,
     evaluate_economic_validity_gates_v1,
@@ -434,6 +440,12 @@ def build_economic_viability_evidence_v1(
     stats = mv2_wiring.compute_mv2_backtest_metrics_v1(wiring_result.backtest_result)
     cost = wiring_result.effective_cost_config
 
+    strategy_version = "unknown"
+    for entry in wiring_result.registry_snapshot.entries:
+        if entry.strategy_id == strategy_id:
+            strategy_version = entry.strategy_version
+            break
+
     wf_result: Optional[mv2_wiring.MV2WalkForwardWiringResultV1] = None
     mc_result: Optional[MonteCarloSummaryResult] = None
     stress_result: Optional[mv2_wiring.StressClassBindingOutcomeV1] = None
@@ -483,7 +495,9 @@ def build_economic_viability_evidence_v1(
         reason_codes.append("funding_model_not_bound")
     if cost.zero_cost_explicitly_requested:
         reason_codes.append("explicit_zero_cost_non_economic_mode")
-    reason_codes.append("parameter_sensitivity_not_bound_in_step29m_scope")
+    sensitivity_requested = parameter_sensitivity_binding_requested(cfg)
+    if not sensitivity_requested:
+        reason_codes.append("parameter_sensitivity_not_bound_in_step29m_scope")
 
     robustness_failures = _evaluate_robustness_failures(
         wf=wf_result, mc=mc_result, stress=stress_result
@@ -504,6 +518,10 @@ def build_economic_viability_evidence_v1(
     policy_version_bound = policy.is_version_bound()
     funding_bound = cost.funding_model_version != "NOT_BOUND"
     parameter_sensitivity_bound = False
+    parameter_sensitivity_payload: dict[str, Any] = {
+        "semantic": MetricSemantic.NOT_COMPUTED.value,
+        "reason_code": "parameter_sensitivity_not_bound_in_step29m_scope",
+    }
 
     funding_drag_result = None
     funding_drag_metric = _not_computed_metric("funding_drag_not_bound")
@@ -525,6 +543,37 @@ def build_economic_viability_evidence_v1(
             reason_codes.append(f"funding_drag_compute_failed:{exc}")
             funding_bound = False
             reason_codes.append("funding_model_not_bound")
+
+    if sensitivity_requested:
+        try:
+            sensitivity_result = run_parameter_sensitivity_v1(
+                bars=bars,
+                cfg=cfg,
+                strategy_id=strategy_id,
+                strategy_version=strategy_version,
+                data_digest=computed_data_digest,
+                instrument_id=instrument_id,
+                explicit_zero_cost_non_economic=explicit_zero_cost_non_economic,
+                policy=policy,
+            )
+            parameter_sensitivity_payload = serialize_parameter_sensitivity_results_v1(
+                sensitivity_result
+            )
+            parameter_sensitivity_bound = True
+            reason_codes = [
+                code
+                for code in reason_codes
+                if code != "parameter_sensitivity_not_bound_in_step29m_scope"
+            ]
+            reason_codes.append("parameter_sensitivity_pipeline_bound")
+            if not sensitivity_result.parameter_robustness_policy_pass:
+                reason_codes.append("parameter_robustness_policy_blocked_missing_thresholds")
+        except ParameterSensitivityError as exc:
+            reason_codes.append(f"parameter_sensitivity_failed:{exc}")
+            parameter_sensitivity_payload = {
+                "semantic": MetricSemantic.NOT_COMPUTED.value,
+                "reason_code": f"parameter_sensitivity_failed:{exc}",
+            }
 
     status = _resolve_status(
         reason_codes=reason_codes,
@@ -568,12 +617,6 @@ def build_economic_viability_evidence_v1(
         ),
         metrics_digest=_stable_digest({k: float(v) for k, v in stats.items()}),
     )
-
-    strategy_version = "unknown"
-    for entry in wiring_result.registry_snapshot.entries:
-        if entry.strategy_id == strategy_id:
-            strategy_version = entry.strategy_version
-            break
 
     semantic_payload = {
         "strategy_id": strategy_id,
@@ -659,10 +702,7 @@ def build_economic_viability_evidence_v1(
             if stress_result is not None
             else {"semantic": MetricSemantic.NOT_COMPUTED.value, "reason_code": "stress_not_run"}
         ),
-        parameter_sensitivity_results={
-            "semantic": MetricSemantic.NOT_COMPUTED.value,
-            "reason_code": "parameter_sensitivity_not_bound_in_step29m_scope",
-        },
+        parameter_sensitivity_results=parameter_sensitivity_payload,
         status=status,
         reason_codes=tuple(sorted(set(reason_codes))),
         manifest_digest=manifest_digest,
@@ -1109,6 +1149,12 @@ def persist_economic_viability_evidence_bundle_v1(
         json.dumps(evidence.parameter_sensitivity_results, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+    grid_payload = evidence.parameter_sensitivity_results.get("grid")
+    if isinstance(grid_payload, Mapping):
+        (output_dir / "PARAMETER_GRID.json").write_text(
+            json.dumps(dict(grid_payload), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
 
     write_manifest_sha256(output_dir)
     ok, message = verify_manifest_sha256(output_dir)

--- a/src/backtest/parameter_sensitivity_v1.py
+++ b/src/backtest/parameter_sensitivity_v1.py
@@ -1,0 +1,707 @@
+"""
+Deterministic offline parameter sensitivity v1 (RUNBOOK STEP 29M).
+
+Fail-closed bounded grid contract, full-grid persistence, and train/validation/OOS
+evaluation binding for EconomicViabilityEvidenceV1. Pipeline pass does not imply
+parameter-robustness policy pass or economic validity.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import itertools
+import json
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Optional, Sequence
+
+import pandas as pd
+
+from src.backtest import mv2_research_wiring_v1 as mv2_wiring
+from src.backtest.cost_config_v0 import FUNDING_MODEL_VERSION
+from src.backtest.economic_validity_policy_v1 import (
+    POLICY_THRESHOLD_STATUS_BLOCKED,
+    EconomicValidityPolicyV1,
+    load_economic_validity_policy_v1,
+)
+from src.trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
+    INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
+)
+
+PARAMETER_SENSITIVITY_VERSION = "backtest_parameter_sensitivity_v1"
+PARAMETER_SENSITIVITY_OWNER = "backtest.parameter_sensitivity_v1"
+DEFAULT_GRID_ID = "step29m_bounded_cost_sensitivity_v1"
+DEFAULT_GRID_VERSION = "v1"
+MIN_BARS_PER_SPLIT = 4
+TRAIN_FRACTION = 0.50
+VALIDATION_FRACTION = 0.25
+
+_FORBIDDEN_INSTRUMENT_SUBSTRINGS = frozenset({"btc", "xbt", "bitcoin", "spot", "synthetic_spot"})
+_CFG_PARAM_PATHS: dict[str, tuple[str, ...]] = {
+    "fee_bps": ("backtest", "fee_bps"),
+    "slippage_bps": ("backtest", "slippage_bps"),
+    "risk_per_trade": ("risk", "risk_per_trade"),
+}
+
+
+class ParameterSensitivityError(ValueError):
+    """Fail-closed parameter sensitivity error."""
+
+
+class PipelineStatus(str, Enum):
+    PIPELINE_PASS = "PIPELINE_PASS"
+    PIPELINE_BLOCKED = "PIPELINE_BLOCKED"
+    PIPELINE_FAILED = "PIPELINE_FAILED"
+
+
+class EvaluationStatus(str, Enum):
+    EVALUATED = "EVALUATED"
+    FAILED = "FAILED"
+    BLOCKED = "BLOCKED"
+
+
+class MetricValueStatus(str, Enum):
+    COMPUTED = "COMPUTED"
+    UNKNOWN = "UNKNOWN"
+    NOT_COMPUTED = "NOT_COMPUTED"
+    BLOCKED = "BLOCKED"
+
+
+@dataclass(frozen=True)
+class ParameterSensitivityGridV1:
+    grid_id: str
+    grid_version: str
+    strategy_id: str
+    strategy_version: str
+    canonical_trading_logic_version: str
+    parameter_names: tuple[str, ...]
+    parameter_values: tuple[tuple[float, ...], ...]
+    combination_count: int
+    search_space_bounds: Mapping[str, Mapping[str, float]]
+    seed: int
+    train_period: str
+    validation_period: str
+    out_of_sample_period: str
+    config_digest: str
+    implementation_digest: str
+    data_digest_or_explicit_missing: str
+    grid_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "grid_id": self.grid_id,
+            "grid_version": self.grid_version,
+            "strategy_id": self.strategy_id,
+            "strategy_version": self.strategy_version,
+            "canonical_trading_logic_version": self.canonical_trading_logic_version,
+            "parameter_names": list(self.parameter_names),
+            "parameter_values": [list(values) for values in self.parameter_values],
+            "combination_count": self.combination_count,
+            "search_space_bounds": {
+                key: dict(bounds) for key, bounds in self.search_space_bounds.items()
+            },
+            "seed": self.seed,
+            "train_period": self.train_period,
+            "validation_period": self.validation_period,
+            "out_of_sample_period": self.out_of_sample_period,
+            "config_digest": self.config_digest,
+            "implementation_digest": self.implementation_digest,
+            "data_digest_or_explicit_missing": self.data_digest_or_explicit_missing,
+            "grid_digest": self.grid_digest,
+        }
+
+
+@dataclass(frozen=True)
+class ParameterSensitivityPointV1:
+    parameter_set_id: str
+    parameter_values: Mapping[str, float]
+    evaluation_status: EvaluationStatus
+    reason_codes: tuple[str, ...]
+    train_result_ref: str
+    validation_result_ref: str
+    out_of_sample_result_ref: str
+    net_return: MetricValueStatus
+    net_return_value: Optional[float]
+    net_expectancy: MetricValueStatus
+    net_expectancy_value: Optional[float]
+    profit_factor: MetricValueStatus
+    profit_factor_value: Optional[float]
+    max_drawdown: MetricValueStatus
+    max_drawdown_value: Optional[float]
+    trade_count: MetricValueStatus
+    trade_count_value: Optional[float]
+    walk_forward_status: str
+    monte_carlo_status: str
+    stress_status: str
+    cost_model_ref: str
+    funding_model_ref: str
+    config_digest: str
+    implementation_digest: str
+    data_digest: str
+    result_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "parameter_set_id": self.parameter_set_id,
+            "parameter_values": dict(self.parameter_values),
+            "evaluation_status": self.evaluation_status.value,
+            "reason_codes": list(self.reason_codes),
+            "train_result_ref": self.train_result_ref,
+            "validation_result_ref": self.validation_result_ref,
+            "out_of_sample_result_ref": self.out_of_sample_result_ref,
+            "net_return": _metric_payload(self.net_return, self.net_return_value),
+            "net_expectancy": _metric_payload(self.net_expectancy, self.net_expectancy_value),
+            "profit_factor": _metric_payload(self.profit_factor, self.profit_factor_value),
+            "max_drawdown": _metric_payload(self.max_drawdown, self.max_drawdown_value),
+            "trade_count": _metric_payload(self.trade_count, self.trade_count_value),
+            "walk_forward_status": self.walk_forward_status,
+            "monte_carlo_status": self.monte_carlo_status,
+            "stress_status": self.stress_status,
+            "cost_model_ref": self.cost_model_ref,
+            "funding_model_ref": self.funding_model_ref,
+            "config_digest": self.config_digest,
+            "implementation_digest": self.implementation_digest,
+            "data_digest": self.data_digest,
+            "result_digest": self.result_digest,
+        }
+
+
+@dataclass(frozen=True)
+class ParameterSensitivityResultV1:
+    contract_version: str
+    owner: str
+    pipeline_status: PipelineStatus
+    parameter_robustness_policy_pass: bool
+    parameter_robustness_policy_status: str
+    grid: ParameterSensitivityGridV1
+    grid_digest: str
+    result_digest: str
+    combination_count: int
+    points: tuple[ParameterSensitivityPointV1, ...]
+    failed_point_count: int
+    blocked_point_count: int
+    seed: int
+    reason_codes: tuple[str, ...]
+    oos_tuning_forbidden: bool = True
+    full_grid_persisted: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "owner": self.owner,
+            "pipeline_status": self.pipeline_status.value,
+            "parameter_robustness_policy_pass": self.parameter_robustness_policy_pass,
+            "parameter_robustness_policy_status": self.parameter_robustness_policy_status,
+            "grid": self.grid.to_dict(),
+            "grid_digest": self.grid_digest,
+            "result_digest": self.result_digest,
+            "combination_count": self.combination_count,
+            "points": [point.to_dict() for point in self.points],
+            "failed_point_count": self.failed_point_count,
+            "blocked_point_count": self.blocked_point_count,
+            "seed": self.seed,
+            "reason_codes": list(self.reason_codes),
+            "oos_tuning_forbidden": self.oos_tuning_forbidden,
+            "full_grid_persisted": self.full_grid_persisted,
+        }
+
+    def evidence_digest(self) -> str:
+        payload = self.to_dict()
+        payload.pop("points", None)
+        return _stable_digest(payload)
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _metric_payload(status: MetricValueStatus, value: Optional[float]) -> dict[str, Any]:
+    payload: dict[str, Any] = {"semantic": status.value}
+    if value is not None:
+        payload["value"] = value
+    return payload
+
+
+def _reject_forbidden_instrument(instrument_id: str) -> None:
+    lowered = instrument_id.lower()
+    for token in _FORBIDDEN_INSTRUMENT_SUBSTRINGS:
+        if token in lowered:
+            raise ParameterSensitivityError(f"instrument_kind_forbidden:{instrument_id}")
+
+
+def parameter_sensitivity_binding_requested(cfg: Mapping[str, Any]) -> bool:
+    backtest = cfg.get("backtest")
+    if not isinstance(backtest, Mapping):
+        return False
+    section = backtest.get("parameter_sensitivity")
+    if not isinstance(section, Mapping):
+        return False
+    if section.get("bind") is True:
+        return True
+    return str(section.get("grid_version", "")) == DEFAULT_GRID_VERSION
+
+
+def _deep_copy_cfg(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    return copy.deepcopy(dict(cfg))
+
+
+def _apply_cfg_param(cfg: dict[str, Any], param_name: str, value: float) -> None:
+    if param_name not in _CFG_PARAM_PATHS:
+        raise ParameterSensitivityError(f"parameter_not_cfg_bound:{param_name}")
+    path = _CFG_PARAM_PATHS[param_name]
+    node: dict[str, Any] = cfg
+    for key in path[:-1]:
+        child = node.get(key)
+        if not isinstance(child, dict):
+            child = {}
+            node[key] = child
+        node = child
+    node[path[-1]] = float(value)
+
+
+def _canonicalize_values(values: Sequence[float]) -> tuple[float, ...]:
+    if not values:
+        raise ParameterSensitivityError("empty_parameter_values")
+    canonical: list[float] = []
+    seen: set[float] = set()
+    for raw in values:
+        numeric = float(raw)
+        if not math.isfinite(numeric):
+            raise ParameterSensitivityError(f"parameter_value_non_finite:{raw!r}")
+        if numeric in seen:
+            raise ParameterSensitivityError(f"duplicate_parameter_value:{numeric}")
+        seen.add(numeric)
+        canonical.append(numeric)
+    return tuple(sorted(canonical))
+
+
+def _validate_bounds(
+    parameter_names: Sequence[str],
+    parameter_values: Sequence[Sequence[float]],
+    search_space_bounds: Mapping[str, Mapping[str, float]],
+) -> None:
+    if not parameter_names:
+        raise ParameterSensitivityError("empty_parameter_list")
+    if len(parameter_names) != len(parameter_values):
+        raise ParameterSensitivityError("parameter_names_values_length_mismatch")
+    for name in parameter_names:
+        if name not in _CFG_PARAM_PATHS:
+            raise ParameterSensitivityError(f"parameter_not_allowed:{name}")
+        bounds = search_space_bounds.get(name)
+        if bounds is None:
+            raise ParameterSensitivityError(f"search_space_bounds_missing:{name}")
+        lower = float(bounds.get("min", float("-inf")))
+        upper = float(bounds.get("max", float("inf")))
+        if not math.isfinite(lower) or not math.isfinite(upper):
+            raise ParameterSensitivityError(f"search_space_bounds_non_finite:{name}")
+        if lower >= upper:
+            raise ParameterSensitivityError(f"search_space_bounds_invalid:{name}")
+        for value in parameter_values[list(parameter_names).index(name)]:
+            if value < lower or value > upper:
+                raise ParameterSensitivityError(f"parameter_value_out_of_bounds:{name}:{value}")
+
+
+def _iter_grid_combinations(
+    parameter_names: Sequence[str],
+    parameter_values: Sequence[Sequence[float]],
+) -> list[dict[str, float]]:
+    canonical_values = [_canonicalize_values(values) for values in parameter_values]
+    expected_count = math.prod(len(values) for values in canonical_values)
+    combos: list[dict[str, float]] = []
+    for combo in itertools.product(*canonical_values):
+        combos.append(
+            {name: float(value) for name, value in zip(parameter_names, combo, strict=True)}
+        )
+    if len(combos) != expected_count:
+        raise ParameterSensitivityError("combination_count_mismatch")
+    return combos
+
+
+def _period_label(bars: pd.DataFrame) -> str:
+    if bars.empty:
+        return "empty"
+    return f"{bars.index[0]}..{bars.index[-1]}"
+
+
+def split_bars_train_validation_oos_v1(
+    bars: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    if bars.empty:
+        raise ParameterSensitivityError("bars_empty")
+    total = len(bars)
+    train_end = max(MIN_BARS_PER_SPLIT, int(total * TRAIN_FRACTION))
+    val_end = train_end + max(MIN_BARS_PER_SPLIT, int(total * VALIDATION_FRACTION))
+    if val_end + MIN_BARS_PER_SPLIT > total:
+        raise ParameterSensitivityError("insufficient_bars_for_train_validation_oos")
+    train = bars.iloc[:train_end]
+    validation = bars.iloc[train_end:val_end]
+    oos = bars.iloc[val_end:]
+    return train, validation, oos
+
+
+def build_parameter_grid_v1(
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    cfg: Mapping[str, Any],
+    bars: pd.DataFrame,
+    data_digest: str,
+    instrument_id: str,
+    grid_spec: Mapping[str, Any] | None = None,
+) -> ParameterSensitivityGridV1:
+    _reject_forbidden_instrument(instrument_id)
+    spec = dict(grid_spec or {})
+    grid_id = str(spec.get("grid_id", DEFAULT_GRID_ID))
+    grid_version = str(spec.get("grid_version", DEFAULT_GRID_VERSION))
+    parameter_names = tuple(
+        str(name) for name in spec.get("parameter_names", ("fee_bps", "slippage_bps"))
+    )
+    raw_values = spec.get(
+        "parameter_values",
+        ([8.0, 10.0, 12.0], [3.0, 5.0, 7.0]),
+    )
+    parameter_values = tuple(_canonicalize_values(values) for values in raw_values)
+    search_space_bounds = dict(
+        spec.get(
+            "search_space_bounds",
+            {
+                "fee_bps": {"min": 8.0, "max": 12.0},
+                "slippage_bps": {"min": 3.0, "max": 7.0},
+            },
+        )
+    )
+    seed = int(spec.get("seed", 42))
+    _validate_bounds(parameter_names, parameter_values, search_space_bounds)
+    combinations = _iter_grid_combinations(parameter_names, parameter_values)
+    train, validation, oos = split_bars_train_validation_oos_v1(bars)
+    config_digest = _stable_digest({"cfg": dict(cfg), "owner": PARAMETER_SENSITIVITY_OWNER})
+    implementation_digest = _stable_digest(
+        {
+            "owner": PARAMETER_SENSITIVITY_OWNER,
+            "version": PARAMETER_SENSITIVITY_VERSION,
+            "canonical_trading_logic_version": INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
+        }
+    )
+    grid_payload = {
+        "grid_id": grid_id,
+        "grid_version": grid_version,
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        "parameter_names": list(parameter_names),
+        "parameter_values": [list(values) for values in parameter_values],
+        "search_space_bounds": search_space_bounds,
+        "seed": seed,
+    }
+    grid_digest = _stable_digest(grid_payload)
+    return ParameterSensitivityGridV1(
+        grid_id=grid_id,
+        grid_version=grid_version,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        canonical_trading_logic_version=INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
+        parameter_names=parameter_names,
+        parameter_values=parameter_values,
+        combination_count=len(combinations),
+        search_space_bounds=search_space_bounds,
+        seed=seed,
+        train_period=_period_label(train),
+        validation_period=_period_label(validation),
+        out_of_sample_period=_period_label(oos),
+        config_digest=config_digest,
+        implementation_digest=implementation_digest,
+        data_digest_or_explicit_missing=data_digest or "MISSING",
+        grid_digest=grid_digest,
+    )
+
+
+def load_parameter_grid_v1(
+    cfg: Mapping[str, Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    bars: pd.DataFrame,
+    data_digest: str,
+    instrument_id: str,
+) -> ParameterSensitivityGridV1:
+    backtest = cfg.get("backtest")
+    if not isinstance(backtest, Mapping):
+        raise ParameterSensitivityError("missing_parameter_grid")
+    section = backtest.get("parameter_sensitivity")
+    if not isinstance(section, Mapping):
+        raise ParameterSensitivityError("missing_parameter_grid")
+    grid_spec = section.get("grid")
+    if grid_spec is not None and not isinstance(grid_spec, Mapping):
+        raise ParameterSensitivityError("parameter_grid_not_mapping")
+    return build_parameter_grid_v1(
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        cfg=cfg,
+        bars=bars,
+        data_digest=data_digest,
+        instrument_id=instrument_id,
+        grid_spec=grid_spec if isinstance(grid_spec, Mapping) else None,
+    )
+
+
+def _metric_from_stats(
+    key: str, stats: Mapping[str, float]
+) -> tuple[MetricValueStatus, Optional[float]]:
+    if key not in stats:
+        return MetricValueStatus.UNKNOWN, None
+    value = float(stats[key])
+    if not math.isfinite(value):
+        return MetricValueStatus.NOT_COMPUTED, None
+    return MetricValueStatus.COMPUTED, value
+
+
+def _evaluate_split(
+    *,
+    bars: pd.DataFrame,
+    strategy_id: str,
+    cfg: Mapping[str, Any],
+    instrument_id: str,
+    split_name: str,
+    parameter_set_id: str,
+    explicit_zero_cost_non_economic: bool,
+) -> tuple[str, Mapping[str, float], str, str]:
+    ref = f"{parameter_set_id}:{split_name}"
+    if bars.empty or len(bars) < MIN_BARS_PER_SPLIT:
+        return ref, {}, "NOT_BOUND", FUNDING_MODEL_VERSION
+    wiring = mv2_wiring.run_mv2_research_backtest_wiring_v1(
+        bars,
+        strategy_id=strategy_id,
+        cfg=cfg,
+        instrument_id=instrument_id,
+        explicit_zero_cost_non_economic=explicit_zero_cost_non_economic,
+    )
+    stats = mv2_wiring.compute_mv2_backtest_metrics_v1(wiring.backtest_result)
+    cost_ref = wiring.effective_cost_config.cost_model_version
+    funding_ref = wiring.effective_cost_config.funding_model_version
+    return ref, stats, cost_ref, funding_ref
+
+
+def _evaluate_parameter_point_v1(
+    *,
+    grid: ParameterSensitivityGridV1,
+    parameter_values: Mapping[str, float],
+    bars: pd.DataFrame,
+    base_cfg: Mapping[str, Any],
+    strategy_id: str,
+    instrument_id: str,
+    data_digest: str,
+    explicit_zero_cost_non_economic: bool,
+) -> ParameterSensitivityPointV1:
+    parameter_set_id = _stable_digest(
+        {"grid_digest": grid.grid_digest, "parameter_values": dict(parameter_values)}
+    )
+    cfg = _deep_copy_cfg(base_cfg)
+    reason_codes: list[str] = []
+    try:
+        for name, value in sorted(parameter_values.items()):
+            _apply_cfg_param(cfg, name, value)
+        train, validation, oos = split_bars_train_validation_oos_v1(bars)
+        train_ref, train_stats, cost_ref, funding_ref = _evaluate_split(
+            bars=train,
+            strategy_id=strategy_id,
+            cfg=cfg,
+            instrument_id=instrument_id,
+            split_name="train",
+            parameter_set_id=parameter_set_id,
+            explicit_zero_cost_non_economic=explicit_zero_cost_non_economic,
+        )
+        val_ref, val_stats, _, _ = _evaluate_split(
+            bars=validation,
+            strategy_id=strategy_id,
+            cfg=cfg,
+            instrument_id=instrument_id,
+            split_name="validation",
+            parameter_set_id=parameter_set_id,
+            explicit_zero_cost_non_economic=explicit_zero_cost_non_economic,
+        )
+        oos_ref, oos_stats, _, _ = _evaluate_split(
+            bars=oos,
+            strategy_id=strategy_id,
+            cfg=cfg,
+            instrument_id=instrument_id,
+            split_name="out_of_sample",
+            parameter_set_id=parameter_set_id,
+            explicit_zero_cost_non_economic=explicit_zero_cost_non_economic,
+        )
+        evaluation_status = EvaluationStatus.EVALUATED
+        metric_stats = oos_stats
+    except Exception as exc:  # noqa: BLE001 - persist failed points
+        evaluation_status = EvaluationStatus.FAILED
+        reason_codes.append(f"evaluation_failed:{exc}")
+        train_ref = f"{parameter_set_id}:train"
+        val_ref = f"{parameter_set_id}:validation"
+        oos_ref = f"{parameter_set_id}:out_of_sample"
+        metric_stats = {}
+        cost_ref = "NOT_BOUND"
+        funding_ref = FUNDING_MODEL_VERSION
+
+    net_return_status, net_return_value = _metric_from_stats("total_return", metric_stats)
+    net_expectancy_status, net_expectancy_value = _metric_from_stats("expectancy", metric_stats)
+    profit_factor_status, profit_factor_value = _metric_from_stats("profit_factor", metric_stats)
+    max_drawdown_status, max_drawdown_value = _metric_from_stats("max_drawdown", metric_stats)
+    trade_count_status, trade_count_value = _metric_from_stats("total_trades", metric_stats)
+
+    point_payload = {
+        "parameter_set_id": parameter_set_id,
+        "parameter_values": dict(parameter_values),
+        "evaluation_status": evaluation_status.value,
+        "train_result_ref": train_ref,
+        "validation_result_ref": val_ref,
+        "out_of_sample_result_ref": oos_ref,
+    }
+    result_digest = _stable_digest(point_payload)
+    return ParameterSensitivityPointV1(
+        parameter_set_id=parameter_set_id,
+        parameter_values=dict(parameter_values),
+        evaluation_status=evaluation_status,
+        reason_codes=tuple(reason_codes),
+        train_result_ref=train_ref,
+        validation_result_ref=val_ref,
+        out_of_sample_result_ref=oos_ref,
+        net_return=net_return_status,
+        net_return_value=net_return_value,
+        net_expectancy=net_expectancy_status,
+        net_expectancy_value=net_expectancy_value,
+        profit_factor=profit_factor_status,
+        profit_factor_value=profit_factor_value,
+        max_drawdown=max_drawdown_status,
+        max_drawdown_value=max_drawdown_value,
+        trade_count=trade_count_status,
+        trade_count_value=trade_count_value,
+        walk_forward_status="NOT_COMPUTED",
+        monte_carlo_status="NOT_COMPUTED",
+        stress_status="NOT_COMPUTED",
+        cost_model_ref=cost_ref,
+        funding_model_ref=funding_ref,
+        config_digest=grid.config_digest,
+        implementation_digest=grid.implementation_digest,
+        data_digest=data_digest,
+        result_digest=result_digest,
+    )
+
+
+def resolve_parameter_robustness_policy_status_v1(policy: EconomicValidityPolicyV1) -> str:
+    if policy.thresholds_configured():
+        return "CONFIGURED"
+    return POLICY_THRESHOLD_STATUS_BLOCKED
+
+
+def run_parameter_sensitivity_v1(
+    *,
+    bars: pd.DataFrame,
+    cfg: Mapping[str, Any],
+    strategy_id: str,
+    strategy_version: str,
+    data_digest: str,
+    instrument_id: str = mv2_wiring.MV2_REQUIRED_INSTRUMENT_ID,
+    explicit_zero_cost_non_economic: bool = False,
+    policy: EconomicValidityPolicyV1 | None = None,
+) -> ParameterSensitivityResultV1:
+    _reject_forbidden_instrument(instrument_id)
+    if bars.empty:
+        raise ParameterSensitivityError("bars_empty")
+    if not data_digest:
+        raise ParameterSensitivityError("missing_data_digest")
+
+    loaded_policy = policy or load_economic_validity_policy_v1(cfg)
+    policy_status = resolve_parameter_robustness_policy_status_v1(loaded_policy)
+    parameter_robustness_policy_pass = loaded_policy.thresholds_configured()
+
+    try:
+        grid = load_parameter_grid_v1(
+            cfg,
+            strategy_id=strategy_id,
+            strategy_version=strategy_version,
+            bars=bars,
+            data_digest=data_digest,
+            instrument_id=instrument_id,
+        )
+    except ParameterSensitivityError as exc:
+        raise ParameterSensitivityError(f"missing_or_invalid_grid:{exc}") from exc
+
+    combinations = _iter_grid_combinations(grid.parameter_names, grid.parameter_values)
+    if grid.combination_count != len(combinations):
+        raise ParameterSensitivityError("grid_combination_count_mismatch")
+
+    points: list[ParameterSensitivityPointV1] = []
+    failed_count = 0
+    blocked_count = 0
+    for combo in combinations:
+        point = _evaluate_parameter_point_v1(
+            grid=grid,
+            parameter_values=combo,
+            bars=bars,
+            base_cfg=cfg,
+            strategy_id=strategy_id,
+            instrument_id=instrument_id,
+            data_digest=data_digest,
+            explicit_zero_cost_non_economic=explicit_zero_cost_non_economic,
+        )
+        points.append(point)
+        if point.evaluation_status is EvaluationStatus.FAILED:
+            failed_count += 1
+        if point.evaluation_status is EvaluationStatus.BLOCKED:
+            blocked_count += 1
+
+    reason_codes = ["parameter_sensitivity_pipeline_executed"]
+    if not parameter_robustness_policy_pass:
+        reason_codes.append("parameter_robustness_policy_blocked_missing_thresholds")
+    if failed_count:
+        reason_codes.append("parameter_points_failed")
+    pipeline_status = PipelineStatus.PIPELINE_PASS
+    if failed_count == len(points) and points:
+        pipeline_status = PipelineStatus.PIPELINE_FAILED
+
+    result_payload = {
+        "grid_digest": grid.grid_digest,
+        "combination_count": len(points),
+        "seed": grid.seed,
+        "pipeline_status": pipeline_status.value,
+    }
+    result_digest = _stable_digest(
+        {**result_payload, "points": [point.to_dict() for point in points]}
+    )
+    return ParameterSensitivityResultV1(
+        contract_version=PARAMETER_SENSITIVITY_VERSION,
+        owner=PARAMETER_SENSITIVITY_OWNER,
+        pipeline_status=pipeline_status,
+        parameter_robustness_policy_pass=parameter_robustness_policy_pass,
+        parameter_robustness_policy_status=policy_status,
+        grid=grid,
+        grid_digest=grid.grid_digest,
+        result_digest=result_digest,
+        combination_count=len(points),
+        points=tuple(points),
+        failed_point_count=failed_count,
+        blocked_point_count=blocked_count,
+        seed=grid.seed,
+        reason_codes=tuple(sorted(set(reason_codes))),
+    )
+
+
+def serialize_parameter_sensitivity_results_v1(
+    result: ParameterSensitivityResultV1,
+) -> dict[str, Any]:
+    return result.to_dict()
+
+
+def parameter_sensitivity_schema_v1() -> dict[str, Any]:
+    return {
+        "contract_name": "parameter_sensitivity_v1",
+        "contract_version": PARAMETER_SENSITIVITY_VERSION,
+        "owner": PARAMETER_SENSITIVITY_OWNER,
+        "allowed_pipeline_statuses": [status.value for status in PipelineStatus],
+        "allowed_evaluation_statuses": [status.value for status in EvaluationStatus],
+        "oos_tuning_forbidden": True,
+        "full_grid_persistence_required": True,
+        "authority_effect": "NONE",
+        "runtime_effect": False,
+        "order_effect": False,
+    }

--- a/tests/backtest/test_economic_viability_evidence_v1.py
+++ b/tests/backtest/test_economic_viability_evidence_v1.py
@@ -39,6 +39,27 @@ def _cfg_with_funding(**kwargs: Any) -> Mapping[str, Any]:
     return cfg
 
 
+def _cfg_with_parameter_sensitivity(**kwargs: Any) -> Mapping[str, Any]:
+    cfg = dict(_cfg(**kwargs))
+    backtest = dict(cfg["backtest"])
+    backtest["parameter_sensitivity"] = {
+        "bind": True,
+        "grid_version": "v1",
+        "grid": {
+            "grid_id": "test_evidence_grid_v1",
+            "parameter_names": ["fee_bps", "slippage_bps"],
+            "parameter_values": [[8.0, 10.0], [4.0, 6.0]],
+            "search_space_bounds": {
+                "fee_bps": {"min": 8.0, "max": 10.0},
+                "slippage_bps": {"min": 4.0, "max": 6.0},
+            },
+            "seed": 42,
+        },
+    }
+    cfg["backtest"] = backtest
+    return cfg
+
+
 def _bars(n: int = 20) -> pd.DataFrame:
     idx = pd.date_range("2026-06-01", periods=n, freq="1h", tz="UTC")
     close = [100.0 + float(i) for i in range(n)]
@@ -245,9 +266,36 @@ def test_walk_forward_insufficient_bars_reason() -> None:
     assert "walk_forward_insufficient_bars" in result.reason_codes
 
 
-def test_parameter_sensitivity_not_computed() -> None:
+def test_parameter_sensitivity_not_computed_without_binding() -> None:
     result = _build()
     assert result.parameter_sensitivity_results["semantic"] == "NOT_COMPUTED"
+
+
+def test_parameter_sensitivity_binding_full_grid() -> None:
+    result = _build(cfg=_cfg_with_parameter_sensitivity())
+    payload = result.parameter_sensitivity_results
+    assert payload["pipeline_status"] == "PIPELINE_PASS"
+    assert payload["combination_count"] == 4
+    assert len(payload["points"]) == 4
+    assert payload["parameter_robustness_policy_pass"] is False
+    assert "parameter_sensitivity_pipeline_bound" in result.reason_codes
+    assert "parameter_sensitivity_not_bound_in_step29m_scope" not in result.reason_codes
+
+
+def test_parameter_sensitivity_binding_still_research_only() -> None:
+    result = _build(cfg=_cfg_with_parameter_sensitivity())
+    assert result.status is ev.EconomicViabilityStatus.RESEARCH_ONLY
+    assert result.economic_validity_proven is False
+    assert result.profitability_claim_allowed is False
+
+
+def test_parameter_sensitivity_binding_deterministic() -> None:
+    a = _build(cfg=_cfg_with_parameter_sensitivity())
+    b = _build(cfg=_cfg_with_parameter_sensitivity())
+    assert (
+        a.parameter_sensitivity_results["result_digest"]
+        == b.parameter_sensitivity_results["result_digest"]
+    )
 
 
 def test_status_never_exceeds_step29m_allowed_set() -> None:

--- a/tests/backtest/test_parameter_sensitivity_v1.py
+++ b/tests/backtest/test_parameter_sensitivity_v1.py
@@ -1,0 +1,305 @@
+"""RUNBOOK STEP 29M — deterministic offline parameter sensitivity v1 tests."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Mapping
+
+import pandas as pd
+import pytest
+
+from src.backtest import economic_validity_policy_v1 as policy_mod
+from src.backtest import mv2_research_wiring_v1 as wiring
+from src.backtest import parameter_sensitivity_v1 as ps
+
+
+def _bars(n: int = 24) -> pd.DataFrame:
+    idx = pd.date_range("2026-06-01", periods=n, freq="1h", tz="UTC")
+    close = [100.0 + float(i) for i in range(n)]
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [v + 0.5 for v in close],
+            "low": [v - 0.5 for v in close],
+            "close": close,
+            "mark_price": close,
+            "index_price": [v - 0.1 for v in close],
+            "best_bid": [v - 0.05 for v in close],
+            "best_ask": [v + 0.05 for v in close],
+            "spread": [0.1 for _ in close],
+            "volume": [1000.0 for _ in close],
+            "open_interest": [10000.0 for _ in close],
+            "funding_rate": [0.0001 for _ in close],
+            "volatility_estimate": [0.2 for _ in close],
+            "is_final": [True for _ in close],
+            "bar_interval": ["1h" for _ in close],
+        },
+        index=idx,
+    )
+
+
+def _cfg(*, bind: bool = True) -> Mapping[str, Any]:
+    payload: dict[str, Any] = {
+        "backtest": {
+            "initial_cash": 10_000.0,
+            "cost_model_version": "backtest_cost_v0",
+            "fee_bps": 10.0,
+            "slippage_bps": 5.0,
+        },
+        "risk": {
+            "risk_per_trade": 0.02,
+            "max_position_size": 0.25,
+            "min_position_value": 10.0,
+            "min_stop_distance": 0.0001,
+        },
+    }
+    if bind:
+        payload["backtest"]["parameter_sensitivity"] = {
+            "bind": True,
+            "grid_version": ps.DEFAULT_GRID_VERSION,
+            "grid": {
+                "grid_id": "test_grid_v1",
+                "parameter_names": ["fee_bps", "slippage_bps"],
+                "parameter_values": [[8.0, 10.0], [4.0, 6.0]],
+                "search_space_bounds": {
+                    "fee_bps": {"min": 8.0, "max": 10.0},
+                    "slippage_bps": {"min": 4.0, "max": 6.0},
+                },
+                "seed": 42,
+            },
+        }
+    return payload
+
+
+class TestParameterGridContract:
+    def test_binding_requested(self) -> None:
+        assert ps.parameter_sensitivity_binding_requested(_cfg()) is True
+        assert ps.parameter_sensitivity_binding_requested(_cfg(bind=False)) is False
+
+    def test_cartesian_product_count(self) -> None:
+        grid = ps.build_parameter_grid_v1(
+            strategy_id="ma_crossover",
+            strategy_version="v1",
+            cfg=_cfg(),
+            bars=_bars(),
+            data_digest="abc",
+            instrument_id=wiring.MV2_REQUIRED_INSTRUMENT_ID,
+            grid_spec=_cfg()["backtest"]["parameter_sensitivity"]["grid"],
+        )
+        assert grid.combination_count == 4
+
+    def test_stable_grid_order(self) -> None:
+        spec = _cfg()["backtest"]["parameter_sensitivity"]["grid"]
+        a = ps._iter_grid_combinations(spec["parameter_names"], spec["parameter_values"])
+        b = ps._iter_grid_combinations(spec["parameter_names"], spec["parameter_values"])
+        assert a == b
+
+    def test_duplicate_values_rejected(self) -> None:
+        with pytest.raises(ps.ParameterSensitivityError, match="duplicate_parameter_value"):
+            ps._canonicalize_values([1.0, 1.0])
+
+    def test_nan_rejected(self) -> None:
+        with pytest.raises(ps.ParameterSensitivityError, match="parameter_value_non_finite"):
+            ps._canonicalize_values([1.0, float("nan")])
+
+    def test_inf_rejected(self) -> None:
+        with pytest.raises(ps.ParameterSensitivityError, match="parameter_value_non_finite"):
+            ps._canonicalize_values([1.0, float("inf")])
+
+    def test_empty_parameter_list_rejected(self) -> None:
+        with pytest.raises(ps.ParameterSensitivityError, match="empty_parameter_list"):
+            ps.build_parameter_grid_v1(
+                strategy_id="ma_crossover",
+                strategy_version="v1",
+                cfg=_cfg(),
+                bars=_bars(),
+                data_digest="abc",
+                instrument_id=wiring.MV2_REQUIRED_INSTRUMENT_ID,
+                grid_spec={"parameter_names": [], "parameter_values": []},
+            )
+
+    def test_out_of_bounds_rejected(self) -> None:
+        spec = dict(_cfg()["backtest"]["parameter_sensitivity"]["grid"])
+        spec["parameter_values"] = [[100.0], [5.0]]
+        with pytest.raises(ps.ParameterSensitivityError, match="parameter_value_out_of_bounds"):
+            ps.build_parameter_grid_v1(
+                strategy_id="ma_crossover",
+                strategy_version="v1",
+                cfg=_cfg(),
+                bars=_bars(),
+                data_digest="abc",
+                instrument_id=wiring.MV2_REQUIRED_INSTRUMENT_ID,
+                grid_spec=spec,
+            )
+
+    def test_forbidden_bitcoin_instrument(self) -> None:
+        with pytest.raises(ps.ParameterSensitivityError, match="instrument_kind_forbidden"):
+            ps.build_parameter_grid_v1(
+                strategy_id="ma_crossover",
+                strategy_version="v1",
+                cfg=_cfg(),
+                bars=_bars(),
+                data_digest="abc",
+                instrument_id="inst-btc-usdt-perp",
+            )
+
+
+class TestParameterSensitivityExecution:
+    def test_run_full_grid_persistence(self) -> None:
+        bars = _bars()
+        digest = "0" * 64
+        result = ps.run_parameter_sensitivity_v1(
+            bars=bars,
+            cfg=_cfg(),
+            strategy_id="ma_crossover",
+            strategy_version="v1",
+            data_digest=digest,
+        )
+        assert result.combination_count == 4
+        assert len(result.points) == 4
+        assert result.full_grid_persisted is True
+        assert result.pipeline_status is ps.PipelineStatus.PIPELINE_PASS
+
+    def test_failed_points_persisted(self) -> None:
+        bars = _bars(6)
+        with pytest.raises(ps.ParameterSensitivityError, match="insufficient_bars"):
+            ps.run_parameter_sensitivity_v1(
+                bars=bars,
+                cfg=_cfg(),
+                strategy_id="ma_crossover",
+                strategy_version="v1",
+                data_digest="0" * 64,
+            )
+
+    def test_missing_data_fail_closed(self) -> None:
+        with pytest.raises(ps.ParameterSensitivityError, match="missing_data_digest"):
+            ps.run_parameter_sensitivity_v1(
+                bars=_bars(),
+                cfg=_cfg(),
+                strategy_id="ma_crossover",
+                strategy_version="v1",
+                data_digest="",
+            )
+
+    def test_missing_grid_fail_closed(self) -> None:
+        cfg = _cfg(bind=False)
+        with pytest.raises(ps.ParameterSensitivityError, match="missing_parameter_grid"):
+            ps.load_parameter_grid_v1(
+                cfg,
+                strategy_id="ma_crossover",
+                strategy_version="v1",
+                bars=_bars(),
+                data_digest="0" * 64,
+                instrument_id=wiring.MV2_REQUIRED_INSTRUMENT_ID,
+            )
+
+    def test_deterministic_seed_and_digest(self) -> None:
+        bars = _bars()
+        digest = "abc123"
+        a = ps.run_parameter_sensitivity_v1(
+            bars=bars,
+            cfg=_cfg(),
+            strategy_id="ma_crossover",
+            strategy_version="v1",
+            data_digest=digest,
+        )
+        b = ps.run_parameter_sensitivity_v1(
+            bars=bars,
+            cfg=_cfg(),
+            strategy_id="ma_crossover",
+            strategy_version="v1",
+            data_digest=digest,
+        )
+        assert a.result_digest == b.result_digest
+        assert a.grid_digest == b.grid_digest
+
+    def test_no_best_result_only_serialization(self) -> None:
+        result = ps.run_parameter_sensitivity_v1(
+            bars=_bars(),
+            cfg=_cfg(),
+            strategy_id="ma_crossover",
+            strategy_version="v1",
+            data_digest="0" * 64,
+        )
+        payload = result.to_dict()
+        assert "points" in payload
+        assert len(payload["points"]) == result.combination_count
+        assert "best_parameter" not in payload
+
+    def test_policy_robustness_blocked_without_thresholds(self) -> None:
+        result = ps.run_parameter_sensitivity_v1(
+            bars=_bars(),
+            cfg=_cfg(),
+            strategy_id="ma_crossover",
+            strategy_version="v1",
+            data_digest="0" * 64,
+        )
+        assert result.parameter_robustness_policy_pass is False
+        assert (
+            result.parameter_robustness_policy_status == policy_mod.POLICY_THRESHOLD_STATUS_BLOCKED
+        )
+
+    def test_pipeline_pass_not_policy_pass(self) -> None:
+        result = ps.run_parameter_sensitivity_v1(
+            bars=_bars(),
+            cfg=_cfg(),
+            strategy_id="ma_crossover",
+            strategy_version="v1",
+            data_digest="0" * 64,
+        )
+        assert result.pipeline_status is ps.PipelineStatus.PIPELINE_PASS
+        assert result.parameter_robustness_policy_pass is False
+
+    def test_oos_isolation_metadata(self) -> None:
+        result = ps.run_parameter_sensitivity_v1(
+            bars=_bars(),
+            cfg=_cfg(),
+            strategy_id="ma_crossover",
+            strategy_version="v1",
+            data_digest="0" * 64,
+        )
+        assert result.oos_tuning_forbidden is True
+        for point in result.points:
+            assert point.out_of_sample_result_ref.endswith(":out_of_sample")
+
+    def test_non_finite_metrics_not_zero_filled(self) -> None:
+        result = ps.run_parameter_sensitivity_v1(
+            bars=_bars(),
+            cfg=_cfg(),
+            strategy_id="ma_crossover",
+            strategy_version="v1",
+            data_digest="0" * 64,
+        )
+        for point in result.points:
+            if point.net_return is ps.MetricValueStatus.COMPUTED:
+                assert point.net_return_value is not None
+                assert math.isfinite(point.net_return_value)
+            else:
+                assert point.net_return_value is None or math.isfinite(point.net_return_value)
+
+    def test_serialization_round_trip(self) -> None:
+        result = ps.run_parameter_sensitivity_v1(
+            bars=_bars(),
+            cfg=_cfg(),
+            strategy_id="ma_crossover",
+            strategy_version="v1",
+            data_digest="0" * 64,
+        )
+        payload = ps.serialize_parameter_sensitivity_results_v1(result)
+        encoded = json.dumps(payload, sort_keys=True)
+        decoded = json.loads(encoded)
+        assert decoded["combination_count"] == 4
+        assert decoded["pipeline_status"] == "PIPELINE_PASS"
+
+
+class TestTrainValidationOosSplit:
+    def test_split_lengths(self) -> None:
+        train, validation, oos = ps.split_bars_train_validation_oos_v1(_bars(24))
+        assert len(train) >= ps.MIN_BARS_PER_SPLIT
+        assert len(validation) >= ps.MIN_BARS_PER_SPLIT
+        assert len(oos) >= ps.MIN_BARS_PER_SPLIT
+
+    def test_insufficient_bars_fail_closed(self) -> None:
+        with pytest.raises(ps.ParameterSensitivityError, match="insufficient_bars"):
+            ps.split_bars_train_validation_oos_v1(_bars(8))


### PR DESCRIPTION
## Summary
- Add canonical `parameter_sensitivity_v1` offline contract with bounded grid validation, deterministic Cartesian iteration, train/validation/OOS split evaluation, and full-grid persistence (including failed points).
- Bind parameter sensitivity results into `EconomicViabilityEvidenceV1` when `backtest.parameter_sensitivity.bind=true`; pipeline pass remains distinct from parameter-robustness policy pass and economic validity.
- Append-only registry update: `parameter_sensitivity_evidence_binding_v1_slice`; STEP 29M remains incomplete (policy thresholds + admissible data still blocked).

## Test plan
- [x] `pytest tests/backtest/test_parameter_sensitivity_v1.py tests/backtest/test_economic_viability_evidence_v1.py` (56 passed)
- [x] `ruff format --check` and `ruff check` on changed Python files
- [x] `git diff --check`
- [ ] CI fast-lane / tests (FOCUSED expected)

## Safety
- No runtime, order, risk, scheduler, promotion, live, testnet, or dataset-download effect.
- `PARAMETER_ROBUSTNESS_POLICY_PASS` blocked without versioned policy values.
- `ECONOMIC_VALIDITY_PROVEN=false`; futures-only; no BTC/spot instruments.


Made with [Cursor](https://cursor.com)