### PR TITLE
docs(governance): RUNBOOK STEP 29M progress registry closeout v0

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -16,8 +16,8 @@ SCHEDULER_RUNTIME_ALLOWED: false
 
 | Feld | Wert |
 |---|---|
-| `LAST_VERIFIED_ORIGIN_MAIN` | `cf0ced2edff0a4baaf8d8fcd93d3e7476c13257e` |
-| `LAST_VERIFIED_AT` | `2026-07-01T00:00:00Z` |
+| `LAST_VERIFIED_ORIGIN_MAIN` | `49a7595cb5e6885fa2d003db74f07d6acf0d61cb` |
+| `LAST_VERIFIED_AT` | `2026-07-01T12:30:00Z` |
 | `CURRENT_MAJOR_GAP_PACKAGE` | `MAJOR_GAP_COMPARISON_PROMOTION_POLICY_INPUT_BRIDGE_V0` |
 | `NEXT_RUNBOOK_STEP` | `RUNBOOK_STEP_29N` |
 | `NEXT_CANONICAL_STEP` | `backtest_engine_rewire_binding` |
@@ -115,7 +115,7 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `true` |
 | `STEP_29N_STARTED` | `false` |
-| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `false` |
+| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `true` |
 | `FOLLOW_UP_DEVEX_SCOPE` | `CANONICAL_PRE_PR_RUFF_AND_DIFF_GUARD` |
 | `FOLLOW_UP_DEVEX_STATUS` | `PENDING_SEPARATE_PR` |
 | `SYSTEMWIDE_RANKING_REQUIRED` | `false` |
@@ -1020,12 +1020,22 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 |---|---|
 | `RUNBOOK_PHASE` | 9 |
 | `RUNBOOK_STEP_ID` | `economic_viability_evidence_v1` |
-| `STATUS` | `IN_PROGRESS` |
+| `STATUS` | `COMPLETE` |
 | `CANONICAL_OWNER` | `src/backtest/economic_viability_evidence_v1.py` |
+| `MERGED_PRS` | `#4700`, `#4701`, `#4702`, `#4703`, `#4704`, `#4705`, `#4706` |
+| `MERGE_COMMITS` | `5352d83f069b7d361e89c877ebe2d3d5ae161156`, `5d402a6a1fc2fb1a76af3a91223ac46ee9d80b72`, `72a33b0a85c76bc00fff482d7e88fda0db33c873`, `4ff161b3d005ff12e434982a108b22ef46165272`, `cd9474c820d500bbdbc09217b4c46f5e604f96b2`, `cf0ced2edff0a4baaf8d8fcd93d3e7476c13257e`, `49a7595cb5e6885fa2d003db74f07d6acf0d61cb` |
+| `DURABLE_EVIDENCE_REFS` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_viability_evidence_pr4700_squash_merge_closeout_v0_20260630T211900Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_residual_slice_pr4701squash_merge_closeout_v0_20260630T213300Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_validity_policy_v1_pr4702squash_merge_closeout_v0_20260630T214700Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_funding_binding_v1_pr4703_squash_merge_closeout_v0_20260630T220500Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_parameter_sensitivity_pr4704_squash_merge_closeout_v0_20260701T221500Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_admissible_versioned_futures_dataset_pr4705_squash_merge_closeout_v0_20260630T223551Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_validity_policy_thresholds_pr4706_squash_merge_closeout_v0_20260630T225125Z (MANIFEST_VERIFY_RC=0); economic_viability_evidence_pr=4700; economic_viability_evidence_merge_commit=5352d83f069b7d361e89c877ebe2d3d5ae161156; persistence_load_reproducibility_pr=4701; persistence_load_reproducibility_merge_commit=5d402a6a1fc2fb1a76af3a91223ac46ee9d80b72; economic_validity_policy_v1_pr=4702; economic_validity_policy_v1_merge_commit=72a33b0a85c76bc00fff482d7e88fda0db33c873; funding_model_binding_pr=4703; funding_model_binding_merge_commit=4ff161b3d005ff12e434982a108b22ef46165272; parameter_sensitivity_evidence_pr=4704; parameter_sensitivity_evidence_merge_commit=cd9474c820d500bbdbc09217b4c46f5e604f96b2; admissible_versioned_futures_dataset_pr=4705; admissible_versioned_futures_dataset_merge_commit=cf0ced2edff0a4baaf8d8fcd93d3e7476c13257e; economic_validity_policy_threshold_values_pr=4706; economic_validity_policy_threshold_values_merge_commit=49a7595cb5e6885fa2d003db74f07d6acf0d61cb; canonical_scope=economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice; ECONOMIC_VIABILITY_EVIDENCE_V1_BOUND=true; STEP29M_IMPLEMENTATION_COMPLETE=true; TECHNICAL_ECONOMIC_VIABILITY_EVIDENCE_STACK_COMPLETE=true; ECONOMIC_VALIDITY_RESULT=NOT_PROVEN; REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED=true; THRESHOLD_TUNING_ALLOWED=false; STEP_29N_STARTED=false; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_LIVE=true; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME=true; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS=true; STEP_29M_COMPLETION_DOES_NOT_CLAIM_ECONOMIC_VALIDITY=true; STEP_29M_COMPLETION_DOES_NOT_START_PROMOTION_GATE=true; PROMOTION_ELIGIBILITY_GRANTED=false; RUNTIME_AUTHORITY_GRANTED=false; UNIVERSE_SELECTION_UNCHANGED=true; offline_only=true; non_authorizing=true; runtime_process_started=false; scheduler_action_performed=false; venue_access_performed=false; credential_access_performed=false; trading_action_performed=false; progress_registry_closeout_status=COMPLETE; FUTURES_ONLY=true; BITCOIN_DIRECTION_ALLOWED=false; LIVE_AUTHORIZED=false; ORDERS_ALLOWED=false; SCHEDULER_RUNTIME_ALLOWED=false` |
 | `DEPENDENCIES` | RUNBOOK_STEP_29L |
-| `REMAINING_GAPS` | `` |
+| `REMAINING_GAPS` | — |
 | `DATA_ADMISSIBILITY_STATUS` | `PASS` |
 | `POLICY_THRESHOLD_STATUS` | `PASS` |
+| `ECONOMIC_VALIDITY_EVALUATION_STATUS` | `RESEARCH_ONLY` |
+| `TECHNICAL_ECONOMIC_VIABILITY_EVIDENCE_STACK_COMPLETE` | `true` |
+| `ECONOMIC_VALIDITY_RESULT` | `NOT_PROVEN` |
+| `REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED` | `true` |
+| `THRESHOLD_TUNING_ALLOWED` | `false` |
+| `PROMOTION_ELIGIBILITY_GRANTED` | `false` |
+| `RUNTIME_AUTHORITY_GRANTED` | `false` |
 | `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29N` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNTIME_EFFECT` | `false` |
@@ -1037,7 +1047,9 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `true` |
+| `ECONOMIC_VIABILITY_EVIDENCE_V1_IMPLEMENTED` | `true` |
 | `STEP_29N_STARTED` | `false` |
+| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `true` |
 | `STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_LIVE` | `true` |
 | `STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME` | `true` |
 | `STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS` | `true` |
@@ -1045,6 +1057,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `STEP_29M_COMPLETION_DOES_NOT_START_PROMOTION_GATE` | `true` |
 | `offline_only` | `true` |
 | `non_authorizing` | `true` |
+| `SEPARATE_GO_REQUIRED` | `true` |
 
 #### RUNBOOK_STEP_29J (legacy heading) — Backtest Engine Rewire Binding
 

--- a/tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py
@@ -1,0 +1,130 @@
+"""Contract tests for RUNBOOK STEP 29M progress registry closeout v0.
+
+Verifies technical completion closeout semantics without authorizing runtime,
+profitability claims, or STEP 29N implementation.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROGRESS_REGISTRY = REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+
+STEP_29M_IMPLEMENTED_SCOPE = (
+    "economic_viability_evidence_v1_offline_slice,"
+    "economic_viability_evidence_v1_persistence_load_reproducibility_slice,"
+    "economic_validity_policy_v1_contract_slice,"
+    "funding_model_binding_v1_slice,"
+    "parameter_sensitivity_evidence_binding_v1_slice,"
+    "admissible_versioned_futures_dataset_binding_v1_slice,"
+    "economic_validity_policy_threshold_values_v1_slice"
+)
+STEP_29M_SLICES = tuple(STEP_29M_IMPLEMENTED_SCOPE.split(","))
+
+
+def _read_registry() -> str:
+    assert PROGRESS_REGISTRY.is_file(), f"missing canonical registry: {PROGRESS_REGISTRY}"
+    return PROGRESS_REGISTRY.read_text(encoding="utf-8")
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(rf"\| `{re.escape(field)}` \| `([^`]*)` \|", text)
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _step_29m_section(text: str) -> str:
+    start = text.index("#### RUNBOOK_STEP_29M — Economic Viability Evidence v1")
+    end = text.index("#### RUNBOOK_STEP_29J (legacy heading)", start)
+    return text[start:end]
+
+
+def test_progress_registry_is_canonical_single_ssot() -> None:
+    text = _read_registry()
+    assert text.count("STATUS: CANONICAL_RUNBOOK_PROGRESS_REGISTRY") == 1
+    assert "PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md" not in text.replace(
+        "PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1", ""
+    )
+
+
+def test_runbook_step_29m_complete_true() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29M_COMPLETE") == "true"
+
+
+def test_progress_registry_closeout_performed_true() -> None:
+    text = _read_registry()
+    assert _field_value(text, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
+
+
+def test_step_29n_not_started() -> None:
+    text = _read_registry()
+    assert _field_value(text, "STEP_29N_STARTED") == "false"
+
+
+def test_next_runbook_step_is_29n() -> None:
+    text = _read_registry()
+    assert _field_value(text, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29N"
+
+
+def test_economic_validity_not_proven() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "ECONOMIC_VALIDITY_PROVEN") == "false"
+    assert _field_value(section, "ECONOMIC_VALIDITY_RESULT") == "NOT_PROVEN"
+
+
+def test_profitability_claim_not_allowed() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "PROFITABILITY_CLAIM_ALLOWED") == "false"
+
+
+def test_policy_and_admissibility_status_pass() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "POLICY_THRESHOLD_STATUS") == "PASS"
+    assert _field_value(section, "DATA_ADMISSIBILITY_STATUS") == "PASS"
+
+
+def test_all_registered_step_29m_slices_preserved() -> None:
+    text = _read_registry()
+    scope = _field_value(text, "RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE")
+    assert scope == STEP_29M_IMPLEMENTED_SCOPE
+    for slice_name in STEP_29M_SLICES:
+        assert slice_name in scope
+
+
+def test_no_step_29n_implementation_markers() -> None:
+    text = _read_registry()
+    assert "RUNBOOK_STEP_29N_IMPLEMENTED" not in text
+    assert "RUNBOOK_STEP_29N_COMPLETE" not in text
+    assert _field_value(text, "STEP_29N_STARTED") == "false"
+
+
+def test_no_promotion_eligibility_or_runtime_authority() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "PROMOTION_ELIGIBILITY_GRANTED") == "false"
+    assert _field_value(section, "RUNTIME_AUTHORITY_GRANTED") == "false"
+    assert _field_value(section, "RUNTIME_EFFECT") == "false"
+    assert _field_value(section, "STEP_29M_COMPLETION_DOES_NOT_START_PROMOTION_GATE") == "true"
+
+
+def test_futures_only_and_bitcoin_direction_forbidden() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "FUTURES_ONLY") == "true"
+    assert _field_value(section, "BITCOIN_DIRECTION_ALLOWED") == "false"
+
+
+def test_technical_stack_complete_without_economic_pass() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "TECHNICAL_ECONOMIC_VIABILITY_EVIDENCE_STACK_COMPLETE") == "true"
+    assert _field_value(section, "ECONOMIC_VALIDITY_PROVEN") == "false"
+    assert _field_value(section, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED") == "true"
+    assert _field_value(section, "THRESHOLD_TUNING_ALLOWED") == "false"
+
+
+def test_step_29m_section_status_complete_with_closeout() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "STATUS") == "COMPLETE"
+    assert _field_value(section, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
+    assert _field_value(section, "NEXT_REQUIRED_CONTRACT") == "RUNBOOK_STEP_29N"


### PR DESCRIPTION
## Summary

- Closes the canonical progress registry state for **RUNBOOK_STEP_29M** after verified squash merges of PRs #4700–#4706.
- Sets `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED=true`, `STATUS=COMPLETE`, and explicit technical-vs-economic semantics (`TECHNICAL_ECONOMIC_VIABILITY_EVIDENCE_STACK_COMPLETE=true`, `ECONOMIC_VALIDITY_RESULT=NOT_PROVEN`).
- Preserves safety invariants: `ECONOMIC_VALIDITY_PROVEN=false`, `PROFITABILITY_CLAIM_ALLOWED=false`, `STEP_29N_STARTED=false`, no promotion/runtime authority.

## Scope

Registry docs + contract tests only. No production code, trading logic, threshold tuning, or STEP 29N implementation.

## Test plan

- [x] `tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py` (14 tests)
- [x] `tests/ops/test_runbook_execution_governance_and_progress_registry_static_crosslink_contract_v0.py` (7 tests)
- [x] ruff format/check on changed Python
- [x] `git diff --check`
- [x] CI selector: `NO_OP` (docs/static contract only)
- [x] Durable evidence: `planning_or_validation/runbook_step29m_progress_registry_closeout_v0_20260630T225626Z` (`MANIFEST_VERIFY_RC=0`)


Made with [Cursor](https://cursor.com)