### PR TITLE
feat(governance): RUNBOOK STEP 29N promotion economic gate binding v1

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -16,8 +16,8 @@ SCHEDULER_RUNTIME_ALLOWED: false
 
 | Feld | Wert |
 |---|---|
-| `LAST_VERIFIED_ORIGIN_MAIN` | `49a7595cb5e6885fa2d003db74f07d6acf0d61cb` |
-| `LAST_VERIFIED_AT` | `2026-07-01T12:30:00Z` |
+| `LAST_VERIFIED_ORIGIN_MAIN` | `c8a6a275918b757422aa0b910b4ec00ea011f899` |
+| `LAST_VERIFIED_AT` | `2026-07-01T00:00:00Z` |
 | `CURRENT_MAJOR_GAP_PACKAGE` | `MAJOR_GAP_COMPARISON_PROMOTION_POLICY_INPUT_BRIDGE_V0` |
 | `NEXT_RUNBOOK_STEP` | `RUNBOOK_STEP_29N` |
 | `NEXT_CANONICAL_STEP` | `backtest_engine_rewire_binding` |
@@ -114,8 +114,21 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `true` |
-| `STEP_29N_STARTED` | `false` |
-| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `true` |
+| `STEP_29N_STARTED` | `true` |
+| `RUNBOOK_STEP_29N_STARTED` | `true` |
+| `RUNBOOK_STEP_29N_IMPLEMENTED_SCOPE` | `promotion_economic_gate_binding_v1_slice` |
+| `RUNBOOK_STEP_29N_IMPLEMENTED` | `true` |
+| `RUNBOOK_STEP_29N_COMPLETE` | `false` |
+| `STEP_29O_STARTED` | `false` |
+| `PROMOTION_ECONOMIC_GATE_BINDING_STATUS` | `PASS` |
+| `PROMOTION_CANDIDATE_ELIGIBLE` | `false` |
+| `DEPLOYMENT_ELIGIBLE` | `false` |
+| `RUNTIME_ELIGIBLE` | `false` |
+| `ACTIVATION_ALLOWED` | `false` |
+| `EXECUTION_ALLOWED` | `false` |
+| `ECONOMIC_VALIDITY_PROVEN` | `false` |
+| `PROFITABILITY_CLAIM_ALLOWED` | `false` |
+| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `false` |
 | `FOLLOW_UP_DEVEX_SCOPE` | `CANONICAL_PRE_PR_RUFF_AND_DIFF_GUARD` |
 | `FOLLOW_UP_DEVEX_STATUS` | `PENDING_SEPARATE_PR` |
 | `SYSTEMWIDE_RANKING_REQUIRED` | `false` |
@@ -1055,6 +1068,52 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS` | `true` |
 | `STEP_29M_COMPLETION_DOES_NOT_CLAIM_ECONOMIC_VALIDITY` | `true` |
 | `STEP_29M_COMPLETION_DOES_NOT_START_PROMOTION_GATE` | `true` |
+| `offline_only` | `true` |
+| `non_authorizing` | `true` |
+| `SEPARATE_GO_REQUIRED` | `true` |
+
+#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1
+
+| Feld | Wert |
+|---|---|
+| `RUNBOOK_PHASE` | 9 |
+| `RUNBOOK_STEP_ID` | `promotion_economic_gate_binding_v1` |
+| `STATUS` | `IN_PROGRESS` |
+| `CANONICAL_OWNER` | `src/governance/promotion_loop/promotion_economic_gate_v1.py` |
+| `DEPENDENCIES` | RUNBOOK_STEP_29M |
+| `REMAINING_GAPS` | Registry closeout; real admissible futures economic evidence; economic validity proof |
+| `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29N` |
+| `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
+| `RUNTIME_EFFECT` | `false` |
+| `ORDER_EFFECT` | `false` |
+| `FUTURES_ONLY` | `true` |
+| `BITCOIN_DIRECTION_ALLOWED` | `false` |
+| `ECONOMIC_VALIDITY_PROVEN` | `false` |
+| `PROFITABILITY_CLAIM_ALLOWED` | `false` |
+| `PROMOTION_ECONOMIC_GATE_BINDING_STATUS` | `PASS` |
+| `PROMOTION_CANDIDATE_ELIGIBLE` | `false` |
+| `PROMOTION_CANDIDATE_STATUS` | `INELIGIBLE` |
+| `DEPLOYMENT_ELIGIBLE` | `false` |
+| `RUNTIME_ELIGIBLE` | `false` |
+| `ACTIVATION_ALLOWED` | `false` |
+| `EXECUTION_ALLOWED` | `false` |
+| `LIVE_AUTHORIZED` | `false` |
+| `PROMOTION_ELIGIBILITY_GRANTED` | `false` |
+| `RUNTIME_AUTHORITY_GRANTED` | `false` |
+| `RUNBOOK_STEP_29N_STARTED` | `true` |
+| `RUNBOOK_STEP_29N_IMPLEMENTED_SCOPE` | `promotion_economic_gate_binding_v1_slice` |
+| `RUNBOOK_STEP_29N_IMPLEMENTED` | `true` |
+| `RUNBOOK_STEP_29N_COMPLETE` | `false` |
+| `STEP_29O_STARTED` | `false` |
+| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `false` |
+| `PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_DEPLOYMENT` | `true` |
+| `PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_RUNTIME` | `true` |
+| `PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_ACTIVATION` | `true` |
+| `PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_EXECUTION` | `true` |
+| `STEP_29N_COMPLETION_DOES_NOT_AUTHORIZE_LIVE` | `true` |
+| `STEP_29N_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME` | `true` |
+| `STEP_29N_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS` | `true` |
+| `STEP_29N_COMPLETION_DOES_NOT_START_STEP_29O` | `true` |
 | `offline_only` | `true` |
 | `non_authorizing` | `true` |
 | `SEPARATE_GO_REQUIRED` | `true` |

--- a/src/governance/promotion_loop/promotion_economic_gate_v1.py
+++ b/src/governance/promotion_loop/promotion_economic_gate_v1.py
@@ -1,0 +1,665 @@
+"""
+Promotion Economic Gate v1 (RUNBOOK STEP 29N).
+
+Fail-closed, non-authorizing promotion *candidate* eligibility evaluation.
+A positive result grants PROMOTION_CANDIDATE_ELIGIBLE only — never deployment,
+runtime, activation, or execution authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Optional, Sequence
+
+from src.backtest.economic_validity_policy_v1 import (
+    ECONOMIC_VALIDITY_POLICY_VERSION,
+    canonical_economic_validity_policy_v1,
+)
+
+PROMOTION_ECONOMIC_GATE_POLICY_ID = "promotion_economic_gate"
+PROMOTION_ECONOMIC_GATE_POLICY_VERSION = "promotion_economic_gate_v1"
+PROMOTION_ECONOMIC_GATE_POLICY_SCHEMA_VERSION = "1"
+PROMOTION_ECONOMIC_GATE_POLICY_OWNER = "governance.promotion_loop.promotion_economic_gate_v1"
+PROMOTION_ECONOMIC_GATE_POLICY_EFFECTIVE_FROM = "2026-07-01"
+
+AUTHORITY_EFFECT_NONE = "NONE"
+RUNTIME_EFFECT_NONE = "NONE"
+DEPLOYMENT_EFFECT_NONE = "NONE"
+ACTIVATION_EFFECT_NONE = "NONE"
+
+PASS_STATUS = "PASS"
+FAIL_STATUS = "FAIL"
+
+PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_DEPLOYMENT = True
+PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_RUNTIME = True
+PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_ACTIVATION = True
+PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_EXECUTION = True
+
+REASON_ECONOMIC_VALIDITY_NOT_PROVEN = "ECONOMIC_VALIDITY_NOT_PROVEN"
+REASON_PROFITABILITY_CLAIM_NOT_ALLOWED = "PROFITABILITY_CLAIM_NOT_ALLOWED"
+REASON_ECONOMIC_EVIDENCE_MISSING = "ECONOMIC_EVIDENCE_MISSING"
+REASON_ECONOMIC_EVIDENCE_INADMISSIBLE = "ECONOMIC_EVIDENCE_INADMISSIBLE"
+REASON_DATA_ADMISSIBILITY_FAILED = "DATA_ADMISSIBILITY_FAILED"
+REASON_POLICY_THRESHOLD_FAILED = "POLICY_THRESHOLD_FAILED"
+REASON_WALK_FORWARD_FAILED = "WALK_FORWARD_FAILED"
+REASON_OUT_OF_SAMPLE_FAILED = "OUT_OF_SAMPLE_FAILED"
+REASON_MONTE_CARLO_FAILED = "MONTE_CARLO_FAILED"
+REASON_STRESS_FAILED = "STRESS_FAILED"
+REASON_PARAMETER_SENSITIVITY_FAILED = "PARAMETER_SENSITIVITY_FAILED"
+REASON_ROBUSTNESS_FAILED = "ROBUSTNESS_FAILED"
+REASON_REPRODUCIBILITY_FAILED = "REPRODUCIBILITY_FAILED"
+REASON_DIGEST_BINDING_FAILED = "DIGEST_BINDING_FAILED"
+REASON_MANIFEST_BINDING_FAILED = "MANIFEST_BINDING_FAILED"
+REASON_SAFETY_POLICY_FAILED = "SAFETY_POLICY_FAILED"
+REASON_NON_FUTURES_CANDIDATE = "NON_FUTURES_CANDIDATE"
+REASON_BITCOIN_DIRECTION_FORBIDDEN = "BITCOIN_DIRECTION_FORBIDDEN"
+REASON_POLICY_VERSION_MISSING = "POLICY_VERSION_MISSING"
+REASON_POLICY_DIGEST_MISMATCH = "POLICY_DIGEST_MISMATCH"
+REASON_EVIDENCE_DIGEST_MISMATCH = "EVIDENCE_DIGEST_MISMATCH"
+REASON_REQUIRED_INPUT_MISSING = "REQUIRED_INPUT_MISSING"
+REASON_REQUIRED_STATUS_UNKNOWN = "REQUIRED_STATUS_UNKNOWN"
+REASON_NON_FINITE_METRIC = "NON_FINITE_METRIC"
+REASON_RUNTIME_AUTHORITY_REQUEST_FORBIDDEN = "RUNTIME_AUTHORITY_REQUEST_FORBIDDEN"
+REASON_DEPLOYMENT_ACTIVATION_FORBIDDEN = "DEPLOYMENT_ACTIVATION_FORBIDDEN"
+
+_BLOCKED_REASON_CODES = frozenset(
+    {
+        REASON_REQUIRED_INPUT_MISSING,
+        REASON_REQUIRED_STATUS_UNKNOWN,
+        REASON_NON_FINITE_METRIC,
+        REASON_POLICY_VERSION_MISSING,
+        REASON_POLICY_DIGEST_MISMATCH,
+        REASON_EVIDENCE_DIGEST_MISMATCH,
+        REASON_DIGEST_BINDING_FAILED,
+        REASON_MANIFEST_BINDING_FAILED,
+        REASON_ECONOMIC_EVIDENCE_MISSING,
+    }
+)
+
+_REQUIRED_INPUT_FIELDS = (
+    "strategy_id",
+    "strategy_version",
+    "candidate_id",
+    "economic_viability_evidence_ref",
+    "economic_validity_status",
+    "robustness_status",
+    "data_admissibility_status",
+    "evidence_admissibility_status",
+    "policy_threshold_status",
+    "walk_forward_status",
+    "out_of_sample_status",
+    "monte_carlo_status",
+    "stress_status",
+    "parameter_sensitivity_status",
+    "reproducibility_status",
+    "digest_binding_status",
+    "manifest_binding_status",
+    "safety_policy_status",
+    "config_digest",
+    "implementation_digest",
+    "policy_digest",
+    "evidence_manifest_digest",
+)
+
+_ROBUSTNESS_STATUS_FIELDS = (
+    ("walk_forward_status", REASON_WALK_FORWARD_FAILED),
+    ("out_of_sample_status", REASON_OUT_OF_SAMPLE_FAILED),
+    ("monte_carlo_status", REASON_MONTE_CARLO_FAILED),
+    ("stress_status", REASON_STRESS_FAILED),
+    ("parameter_sensitivity_status", REASON_PARAMETER_SENSITIVITY_FAILED),
+    ("reproducibility_status", REASON_REPRODUCIBILITY_FAILED),
+)
+
+
+class PromotionCandidateStatus(str, Enum):
+    ELIGIBLE = "ELIGIBLE"
+    INELIGIBLE = "INELIGIBLE"
+    BLOCKED = "BLOCKED"
+
+
+class PromotionEconomicGateError(ValueError):
+    """Fail-closed promotion economic gate error."""
+
+
+@dataclass(frozen=True)
+class PromotionEconomicGatePolicyV1:
+    policy_id: str = PROMOTION_ECONOMIC_GATE_POLICY_ID
+    policy_version: str = PROMOTION_ECONOMIC_GATE_POLICY_VERSION
+    policy_schema_version: str = PROMOTION_ECONOMIC_GATE_POLICY_SCHEMA_VERSION
+    owner: str = PROMOTION_ECONOMIC_GATE_POLICY_OWNER
+    effective_from: str = PROMOTION_ECONOMIC_GATE_POLICY_EFFECTIVE_FROM
+    economic_validity_policy_version: str = ECONOMIC_VALIDITY_POLICY_VERSION
+    futures_only: bool = True
+    bitcoin_direction_allowed: bool = False
+    require_real_admissible_futures_evidence: bool = True
+    require_profitability_claim_allowed: bool = True
+    authority_effect: str = AUTHORITY_EFFECT_NONE
+    runtime_effect: str = RUNTIME_EFFECT_NONE
+    deployment_effect: str = DEPLOYMENT_EFFECT_NONE
+    activation_effect: str = ACTIVATION_EFFECT_NONE
+
+    def is_version_bound(self) -> bool:
+        return (
+            self.policy_id == PROMOTION_ECONOMIC_GATE_POLICY_ID
+            and self.policy_version == PROMOTION_ECONOMIC_GATE_POLICY_VERSION
+            and self.owner == PROMOTION_ECONOMIC_GATE_POLICY_OWNER
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "policy_id": self.policy_id,
+            "policy_version": self.policy_version,
+            "policy_schema_version": self.policy_schema_version,
+            "owner": self.owner,
+            "effective_from": self.effective_from,
+            "economic_validity_policy_version": self.economic_validity_policy_version,
+            "futures_only": self.futures_only,
+            "bitcoin_direction_allowed": self.bitcoin_direction_allowed,
+            "require_real_admissible_futures_evidence": self.require_real_admissible_futures_evidence,
+            "require_profitability_claim_allowed": self.require_profitability_claim_allowed,
+            "authority_effect": self.authority_effect,
+            "runtime_effect": self.runtime_effect,
+            "deployment_effect": self.deployment_effect,
+            "activation_effect": self.activation_effect,
+        }
+
+    def policy_digest(self) -> str:
+        return compute_promotion_economic_gate_policy_digest(self)
+
+
+@dataclass(frozen=True)
+class PromotionEconomicGateInputV1:
+    strategy_id: str
+    strategy_version: str
+    candidate_id: str
+    economic_viability_evidence_ref: str
+    economic_validity_status: str
+    robustness_status: str
+    data_admissibility_status: str
+    evidence_admissibility_status: str
+    policy_threshold_status: str
+    walk_forward_status: str
+    out_of_sample_status: str
+    monte_carlo_status: str
+    stress_status: str
+    parameter_sensitivity_status: str
+    reproducibility_status: str
+    digest_binding_status: str
+    manifest_binding_status: str
+    safety_policy_status: str
+    futures_only: bool
+    bitcoin_direction_allowed: bool
+    config_digest: str
+    implementation_digest: str
+    policy_digest: str
+    evidence_manifest_digest: str
+    economic_validity_proven: bool = False
+    profitability_claim_allowed: bool = False
+    dataset_digest: str = ""
+    robustness_result_digests: tuple[str, ...] = ()
+    safety_policy_digest: str = ""
+    required_metrics: Mapping[str, Optional[float]] = field(default_factory=dict)
+    evidence_admissible: Optional[bool] = None
+    request_runtime_authority: bool = False
+    request_deployment_activation: bool = False
+
+    def to_evaluation_dict(self) -> dict[str, Any]:
+        return {
+            "strategy_id": self.strategy_id,
+            "strategy_version": self.strategy_version,
+            "candidate_id": self.candidate_id,
+            "economic_viability_evidence_ref": self.economic_viability_evidence_ref,
+            "economic_validity_status": self.economic_validity_status,
+            "economic_validity_proven": self.economic_validity_proven,
+            "profitability_claim_allowed": self.profitability_claim_allowed,
+            "robustness_status": self.robustness_status,
+            "data_admissibility_status": self.data_admissibility_status,
+            "evidence_admissibility_status": self.evidence_admissibility_status,
+            "policy_threshold_status": self.policy_threshold_status,
+            "walk_forward_status": self.walk_forward_status,
+            "out_of_sample_status": self.out_of_sample_status,
+            "monte_carlo_status": self.monte_carlo_status,
+            "stress_status": self.stress_status,
+            "parameter_sensitivity_status": self.parameter_sensitivity_status,
+            "reproducibility_status": self.reproducibility_status,
+            "digest_binding_status": self.digest_binding_status,
+            "manifest_binding_status": self.manifest_binding_status,
+            "safety_policy_status": self.safety_policy_status,
+            "futures_only": self.futures_only,
+            "bitcoin_direction_allowed": self.bitcoin_direction_allowed,
+            "config_digest": self.config_digest,
+            "implementation_digest": self.implementation_digest,
+            "policy_digest": self.policy_digest,
+            "dataset_digest": self.dataset_digest,
+            "evidence_manifest_digest": self.evidence_manifest_digest,
+            "robustness_result_digests": list(self.robustness_result_digests),
+            "safety_policy_digest": self.safety_policy_digest,
+            "required_metrics": dict(sorted(self.required_metrics.items())),
+            "evidence_admissible": self.evidence_admissible,
+            "request_runtime_authority": self.request_runtime_authority,
+            "request_deployment_activation": self.request_deployment_activation,
+        }
+
+
+@dataclass(frozen=True)
+class PromotionEconomicGateResultV1:
+    gate_result_id: str
+    gate_policy_id: str
+    gate_policy_version: str
+    promotion_candidate_status: PromotionCandidateStatus
+    eligible_for_promotion_candidate: bool
+    blocking_reasons: tuple[str, ...]
+    reason_codes: tuple[str, ...]
+    evaluated_evidence_refs: tuple[str, ...]
+    evaluation_timestamp: str
+    evaluation_digest: str
+    authority_effect: str
+    runtime_effect: str
+    deployment_effect: str
+    activation_effect: str
+    deployment_eligible: bool = False
+    runtime_eligible: bool = False
+    activation_allowed: bool = False
+    execution_allowed: bool = False
+    gate_policy_digest: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "gate_result_id": self.gate_result_id,
+            "gate_policy_id": self.gate_policy_id,
+            "gate_policy_version": self.gate_policy_version,
+            "gate_policy_digest": self.gate_policy_digest,
+            "promotion_candidate_status": self.promotion_candidate_status.value,
+            "eligible_for_promotion_candidate": self.eligible_for_promotion_candidate,
+            "blocking_reasons": list(self.blocking_reasons),
+            "reason_codes": list(self.reason_codes),
+            "evaluated_evidence_refs": list(self.evaluated_evidence_refs),
+            "evaluation_timestamp": self.evaluation_timestamp,
+            "evaluation_digest": self.evaluation_digest,
+            "authority_effect": self.authority_effect,
+            "runtime_effect": self.runtime_effect,
+            "deployment_effect": self.deployment_effect,
+            "activation_effect": self.activation_effect,
+            "deployment_eligible": self.deployment_eligible,
+            "runtime_eligible": self.runtime_eligible,
+            "activation_allowed": self.activation_allowed,
+            "execution_allowed": self.execution_allowed,
+        }
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def compute_promotion_economic_gate_policy_digest(
+    policy: PromotionEconomicGatePolicyV1,
+) -> str:
+    return _stable_digest(policy.to_dict())
+
+
+def canonical_promotion_economic_gate_policy_v1() -> PromotionEconomicGatePolicyV1:
+    return PromotionEconomicGatePolicyV1()
+
+
+def validate_promotion_economic_gate_policy_v1(policy: PromotionEconomicGatePolicyV1) -> None:
+    if not policy.is_version_bound():
+        raise PromotionEconomicGateError("policy_version_not_bound")
+    if not policy.policy_version:
+        raise PromotionEconomicGateError("policy_version_missing")
+    if policy.bitcoin_direction_allowed:
+        raise PromotionEconomicGateError("bitcoin_direction_must_be_forbidden")
+    if not policy.futures_only:
+        raise PromotionEconomicGateError("futures_only_required")
+
+
+def _normalize_status(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text.upper()
+
+
+def _status_is_pass(value: Any) -> Optional[bool]:
+    normalized = _normalize_status(value)
+    if normalized is None:
+        return None
+    if normalized == PASS_STATUS:
+        return True
+    if normalized in {FAIL_STATUS, "FAILED", "NOT_PROVEN", "INELIGIBLE"}:
+        return False
+    return None
+
+
+def _append_missing(field_name: str, reason_codes: list[str]) -> None:
+    reason_codes.append(f"{REASON_REQUIRED_INPUT_MISSING}:{field_name}")
+
+
+def _append_unknown(field_name: str, reason_codes: list[str]) -> None:
+    reason_codes.append(f"{REASON_REQUIRED_STATUS_UNKNOWN}:{field_name}")
+
+
+def _check_status_field(
+    *,
+    field_name: str,
+    value: Any,
+    reason_codes: list[str],
+    fail_code: str,
+) -> None:
+    outcome = _status_is_pass(value)
+    if outcome is None:
+        if value is None or str(value).strip() == "":
+            _append_missing(field_name, reason_codes)
+        else:
+            _append_unknown(field_name, reason_codes)
+        return
+    if not outcome:
+        reason_codes.append(fail_code)
+
+
+def _check_required_text(field_name: str, value: Any, reason_codes: list[str]) -> None:
+    if value is None or str(value).strip() == "":
+        _append_missing(field_name, reason_codes)
+
+
+def _check_required_metrics(
+    metrics: Mapping[str, Optional[float]], reason_codes: list[str]
+) -> None:
+    for field_name, value in sorted(metrics.items()):
+        if value is None:
+            _append_missing(f"required_metric:{field_name}", reason_codes)
+        elif not math.isfinite(float(value)):
+            reason_codes.append(f"{REASON_NON_FINITE_METRIC}:{field_name}")
+
+
+def _derive_robustness_pass(input_data: PromotionEconomicGateInputV1) -> Optional[bool]:
+    aggregate = _status_is_pass(input_data.robustness_status)
+    component_outcomes = [
+        _status_is_pass(getattr(input_data, field_name))
+        for field_name, _ in _ROBUSTNESS_STATUS_FIELDS
+    ]
+    if any(outcome is None for outcome in component_outcomes):
+        return None
+    components_pass = all(component_outcomes)
+    if aggregate is None:
+        return components_pass
+    return aggregate and components_pass
+
+
+def compute_promotion_economic_gate_evaluation_digest(
+    *,
+    policy: PromotionEconomicGatePolicyV1,
+    input_data: PromotionEconomicGateInputV1,
+) -> str:
+    payload = {
+        "policy_digest": policy.policy_digest(),
+        "input": input_data.to_evaluation_dict(),
+    }
+    return _stable_digest(payload)
+
+
+def evaluate_promotion_economic_gate_v1(
+    *,
+    policy: PromotionEconomicGatePolicyV1,
+    input_data: PromotionEconomicGateInputV1,
+    evaluation_timestamp: str,
+    expected_policy_digest: str = "",
+    expected_evidence_manifest_digest: str = "",
+) -> PromotionEconomicGateResultV1:
+    """Evaluate promotion candidate eligibility against versioned economic gate policy."""
+    validate_promotion_economic_gate_policy_v1(policy)
+    reason_codes: list[str] = []
+
+    if not policy.policy_version:
+        reason_codes.append(REASON_POLICY_VERSION_MISSING)
+
+    for field_name in _REQUIRED_INPUT_FIELDS:
+        _check_required_text(field_name, getattr(input_data, field_name), reason_codes)
+
+    if input_data.request_runtime_authority:
+        reason_codes.append(REASON_RUNTIME_AUTHORITY_REQUEST_FORBIDDEN)
+    if input_data.request_deployment_activation:
+        reason_codes.append(REASON_DEPLOYMENT_ACTIVATION_FORBIDDEN)
+
+    if expected_policy_digest and expected_policy_digest != input_data.policy_digest:
+        reason_codes.append(REASON_POLICY_DIGEST_MISMATCH)
+    if expected_evidence_manifest_digest and (
+        expected_evidence_manifest_digest != input_data.evidence_manifest_digest
+    ):
+        reason_codes.append(REASON_EVIDENCE_DIGEST_MISMATCH)
+
+    _check_status_field(
+        field_name="economic_validity_status",
+        value=input_data.economic_validity_status,
+        reason_codes=reason_codes,
+        fail_code=REASON_ECONOMIC_VALIDITY_NOT_PROVEN,
+    )
+    if input_data.economic_validity_proven is False:
+        reason_codes.append(REASON_ECONOMIC_VALIDITY_NOT_PROVEN)
+    elif input_data.economic_validity_proven is None:
+        _append_unknown("economic_validity_proven", reason_codes)
+
+    if policy.require_profitability_claim_allowed and not input_data.profitability_claim_allowed:
+        reason_codes.append(REASON_PROFITABILITY_CLAIM_NOT_ALLOWED)
+
+    if policy.require_real_admissible_futures_evidence:
+        if not input_data.economic_viability_evidence_ref.strip():
+            reason_codes.append(REASON_ECONOMIC_EVIDENCE_MISSING)
+        if input_data.evidence_admissible is False:
+            reason_codes.append(REASON_ECONOMIC_EVIDENCE_INADMISSIBLE)
+        elif (
+            input_data.evidence_admissible is None
+            and _status_is_pass(input_data.evidence_admissibility_status) is False
+        ):
+            reason_codes.append(REASON_ECONOMIC_EVIDENCE_INADMISSIBLE)
+
+    _check_status_field(
+        field_name="data_admissibility_status",
+        value=input_data.data_admissibility_status,
+        reason_codes=reason_codes,
+        fail_code=REASON_DATA_ADMISSIBILITY_FAILED,
+    )
+    _check_status_field(
+        field_name="evidence_admissibility_status",
+        value=input_data.evidence_admissibility_status,
+        reason_codes=reason_codes,
+        fail_code=REASON_ECONOMIC_EVIDENCE_INADMISSIBLE,
+    )
+    _check_status_field(
+        field_name="policy_threshold_status",
+        value=input_data.policy_threshold_status,
+        reason_codes=reason_codes,
+        fail_code=REASON_POLICY_THRESHOLD_FAILED,
+    )
+    for field_name, fail_code in _ROBUSTNESS_STATUS_FIELDS:
+        _check_status_field(
+            field_name=field_name,
+            value=getattr(input_data, field_name),
+            reason_codes=reason_codes,
+            fail_code=fail_code,
+        )
+
+    robustness_pass = _derive_robustness_pass(input_data)
+    if robustness_pass is None:
+        _append_unknown("robustness_status", reason_codes)
+    elif not robustness_pass:
+        reason_codes.append(REASON_ROBUSTNESS_FAILED)
+
+    _check_status_field(
+        field_name="digest_binding_status",
+        value=input_data.digest_binding_status,
+        reason_codes=reason_codes,
+        fail_code=REASON_DIGEST_BINDING_FAILED,
+    )
+    _check_status_field(
+        field_name="manifest_binding_status",
+        value=input_data.manifest_binding_status,
+        reason_codes=reason_codes,
+        fail_code=REASON_MANIFEST_BINDING_FAILED,
+    )
+    _check_status_field(
+        field_name="safety_policy_status",
+        value=input_data.safety_policy_status,
+        reason_codes=reason_codes,
+        fail_code=REASON_SAFETY_POLICY_FAILED,
+    )
+
+    if policy.futures_only and not input_data.futures_only:
+        reason_codes.append(REASON_NON_FUTURES_CANDIDATE)
+    if input_data.bitcoin_direction_allowed or policy.bitcoin_direction_allowed:
+        reason_codes.append(REASON_BITCOIN_DIRECTION_FORBIDDEN)
+
+    _check_required_metrics(input_data.required_metrics, reason_codes)
+
+    unique_reasons = tuple(sorted(set(reason_codes)))
+    blocked = any(
+        code == blocked_code or code.startswith(f"{blocked_code}:")
+        for code in unique_reasons
+        for blocked_code in _BLOCKED_REASON_CODES
+    )
+    if blocked:
+        status = PromotionCandidateStatus.BLOCKED
+    elif unique_reasons:
+        status = PromotionCandidateStatus.INELIGIBLE
+    else:
+        status = PromotionCandidateStatus.ELIGIBLE
+
+    eligible = status is PromotionCandidateStatus.ELIGIBLE
+    evaluation_digest = compute_promotion_economic_gate_evaluation_digest(
+        policy=policy,
+        input_data=input_data,
+    )
+    gate_result_id = f"promotion_economic_gate_v1:{evaluation_digest[:16]}"
+
+    evidence_refs: list[str] = []
+    if input_data.economic_viability_evidence_ref.strip():
+        evidence_refs.append(input_data.economic_viability_evidence_ref.strip())
+
+    return PromotionEconomicGateResultV1(
+        gate_result_id=gate_result_id,
+        gate_policy_id=policy.policy_id,
+        gate_policy_version=policy.policy_version,
+        gate_policy_digest=policy.policy_digest(),
+        promotion_candidate_status=status,
+        eligible_for_promotion_candidate=eligible,
+        blocking_reasons=unique_reasons,
+        reason_codes=unique_reasons,
+        evaluated_evidence_refs=tuple(evidence_refs),
+        evaluation_timestamp=evaluation_timestamp,
+        evaluation_digest=evaluation_digest,
+        authority_effect=AUTHORITY_EFFECT_NONE,
+        runtime_effect=RUNTIME_EFFECT_NONE,
+        deployment_effect=DEPLOYMENT_EFFECT_NONE,
+        activation_effect=ACTIVATION_EFFECT_NONE,
+        deployment_eligible=False,
+        runtime_eligible=False,
+        activation_allowed=False,
+        execution_allowed=False,
+    )
+
+
+def evaluate_current_repo_promotion_gate_v1(
+    *,
+    evaluation_timestamp: str = "2026-07-01T00:00:00Z",
+) -> PromotionEconomicGateResultV1:
+    """Fail-closed evaluation for the current repo posture (STEP 29N slice)."""
+    economic_policy = canonical_economic_validity_policy_v1()
+    gate_policy = canonical_promotion_economic_gate_policy_v1()
+    input_data = PromotionEconomicGateInputV1(
+        strategy_id="mv2_offline_research",
+        strategy_version="v1",
+        candidate_id="repo_current_state",
+        economic_viability_evidence_ref="",
+        economic_validity_status=FAIL_STATUS,
+        economic_validity_proven=False,
+        profitability_claim_allowed=False,
+        robustness_status=PASS_STATUS,
+        data_admissibility_status=PASS_STATUS,
+        evidence_admissibility_status=PASS_STATUS,
+        policy_threshold_status=PASS_STATUS,
+        walk_forward_status=PASS_STATUS,
+        out_of_sample_status=PASS_STATUS,
+        monte_carlo_status=PASS_STATUS,
+        stress_status=PASS_STATUS,
+        parameter_sensitivity_status=PASS_STATUS,
+        reproducibility_status=PASS_STATUS,
+        digest_binding_status=PASS_STATUS,
+        manifest_binding_status=PASS_STATUS,
+        safety_policy_status=PASS_STATUS,
+        futures_only=True,
+        bitcoin_direction_allowed=False,
+        config_digest="0" * 64,
+        implementation_digest="1" * 64,
+        policy_digest=economic_policy.policy_digest(),
+        evidence_manifest_digest="2" * 64,
+        evidence_admissible=False,
+    )
+    return evaluate_promotion_economic_gate_v1(
+        policy=gate_policy,
+        input_data=input_data,
+        evaluation_timestamp=evaluation_timestamp,
+        expected_policy_digest=economic_policy.policy_digest(),
+    )
+
+
+def promotion_economic_gate_schema_v1() -> dict[str, Any]:
+    return {
+        "contract_name": "promotion_economic_gate_v1",
+        "policy_id": PROMOTION_ECONOMIC_GATE_POLICY_ID,
+        "policy_version": PROMOTION_ECONOMIC_GATE_POLICY_VERSION,
+        "owner": PROMOTION_ECONOMIC_GATE_POLICY_OWNER,
+        "candidate_statuses": [status.value for status in PromotionCandidateStatus],
+        "required_input_fields": list(_REQUIRED_INPUT_FIELDS),
+        "reason_codes": sorted(
+            {
+                REASON_ECONOMIC_VALIDITY_NOT_PROVEN,
+                REASON_PROFITABILITY_CLAIM_NOT_ALLOWED,
+                REASON_ECONOMIC_EVIDENCE_MISSING,
+                REASON_ECONOMIC_EVIDENCE_INADMISSIBLE,
+                REASON_DATA_ADMISSIBILITY_FAILED,
+                REASON_POLICY_THRESHOLD_FAILED,
+                REASON_WALK_FORWARD_FAILED,
+                REASON_OUT_OF_SAMPLE_FAILED,
+                REASON_MONTE_CARLO_FAILED,
+                REASON_STRESS_FAILED,
+                REASON_PARAMETER_SENSITIVITY_FAILED,
+                REASON_ROBUSTNESS_FAILED,
+                REASON_REPRODUCIBILITY_FAILED,
+                REASON_DIGEST_BINDING_FAILED,
+                REASON_MANIFEST_BINDING_FAILED,
+                REASON_SAFETY_POLICY_FAILED,
+                REASON_NON_FUTURES_CANDIDATE,
+                REASON_BITCOIN_DIRECTION_FORBIDDEN,
+                REASON_POLICY_VERSION_MISSING,
+                REASON_POLICY_DIGEST_MISMATCH,
+                REASON_EVIDENCE_DIGEST_MISMATCH,
+                REASON_REQUIRED_INPUT_MISSING,
+                REASON_REQUIRED_STATUS_UNKNOWN,
+                REASON_NON_FINITE_METRIC,
+                REASON_RUNTIME_AUTHORITY_REQUEST_FORBIDDEN,
+                REASON_DEPLOYMENT_ACTIVATION_FORBIDDEN,
+            }
+        ),
+        "authority_effect": AUTHORITY_EFFECT_NONE,
+        "runtime_effect": RUNTIME_EFFECT_NONE,
+        "deployment_effect": DEPLOYMENT_EFFECT_NONE,
+        "activation_effect": ACTIVATION_EFFECT_NONE,
+        "promotion_candidate_eligibility_does_not_imply_deployment": (
+            PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_DEPLOYMENT
+        ),
+        "promotion_candidate_eligibility_does_not_imply_runtime": (
+            PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_RUNTIME
+        ),
+        "promotion_candidate_eligibility_does_not_imply_activation": (
+            PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_ACTIVATION
+        ),
+        "promotion_candidate_eligibility_does_not_imply_execution": (
+            PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_EXECUTION
+        ),
+    }

--- a/tests/governance/test_promotion_economic_gate_v1.py
+++ b/tests/governance/test_promotion_economic_gate_v1.py
@@ -1,0 +1,311 @@
+"""RUNBOOK STEP 29N — promotion economic gate binding v1 tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.backtest.economic_validity_policy_v1 import canonical_economic_validity_policy_v1
+from src.governance.promotion_loop import promotion_economic_gate_v1 as gate
+
+EVAL_TS = "2026-07-01T12:00:00Z"
+
+
+def _policy() -> gate.PromotionEconomicGatePolicyV1:
+    return gate.canonical_promotion_economic_gate_policy_v1()
+
+
+def _economic_policy_digest() -> str:
+    return canonical_economic_validity_policy_v1().policy_digest()
+
+
+def _valid_input(**overrides: Any) -> gate.PromotionEconomicGateInputV1:
+    base = {
+        "strategy_id": "mv2_offline_research",
+        "strategy_version": "v1",
+        "candidate_id": "candidate-001",
+        "economic_viability_evidence_ref": "evidence://admissible/futures/v1/bundle-001",
+        "economic_validity_status": gate.PASS_STATUS,
+        "economic_validity_proven": True,
+        "profitability_claim_allowed": True,
+        "robustness_status": gate.PASS_STATUS,
+        "data_admissibility_status": gate.PASS_STATUS,
+        "evidence_admissibility_status": gate.PASS_STATUS,
+        "policy_threshold_status": gate.PASS_STATUS,
+        "walk_forward_status": gate.PASS_STATUS,
+        "out_of_sample_status": gate.PASS_STATUS,
+        "monte_carlo_status": gate.PASS_STATUS,
+        "stress_status": gate.PASS_STATUS,
+        "parameter_sensitivity_status": gate.PASS_STATUS,
+        "reproducibility_status": gate.PASS_STATUS,
+        "digest_binding_status": gate.PASS_STATUS,
+        "manifest_binding_status": gate.PASS_STATUS,
+        "safety_policy_status": gate.PASS_STATUS,
+        "futures_only": True,
+        "bitcoin_direction_allowed": False,
+        "config_digest": "a" * 64,
+        "implementation_digest": "b" * 64,
+        "policy_digest": _economic_policy_digest(),
+        "evidence_manifest_digest": "c" * 64,
+        "dataset_digest": "d" * 64,
+        "robustness_result_digests": ("wf:" + "e" * 61,),
+        "safety_policy_digest": "f" * 64,
+        "evidence_admissible": True,
+    }
+    base.update(overrides)
+    return gate.PromotionEconomicGateInputV1(**base)
+
+
+def _evaluate(**overrides: Any) -> gate.PromotionEconomicGateResultV1:
+    return gate.evaluate_promotion_economic_gate_v1(
+        policy=_policy(),
+        input_data=_valid_input(**overrides),
+        evaluation_timestamp=EVAL_TS,
+    )
+
+
+class TestPromotionGatePolicyContract:
+    def test_policy_version_bound(self) -> None:
+        policy = _policy()
+        assert policy.is_version_bound() is True
+        assert policy.policy_id == gate.PROMOTION_ECONOMIC_GATE_POLICY_ID
+
+    def test_policy_digest_deterministic(self) -> None:
+        assert _policy().policy_digest() == _policy().policy_digest()
+
+    def test_no_authority_effects(self) -> None:
+        policy = _policy()
+        assert policy.authority_effect == gate.AUTHORITY_EFFECT_NONE
+        assert policy.runtime_effect == gate.RUNTIME_EFFECT_NONE
+        assert policy.deployment_effect == gate.DEPLOYMENT_EFFECT_NONE
+        assert policy.activation_effect == gate.ACTIVATION_EFFECT_NONE
+
+
+class TestPromotionGateEvaluation:
+    def test_all_hard_gates_pass_eligible(self) -> None:
+        result = _evaluate()
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.ELIGIBLE
+        assert result.eligible_for_promotion_candidate is True
+        assert result.reason_codes == ()
+        assert result.authority_effect == gate.AUTHORITY_EFFECT_NONE
+        assert result.runtime_effect == gate.RUNTIME_EFFECT_NONE
+
+    def test_economic_validity_false_ineligible(self) -> None:
+        result = _evaluate(
+            economic_validity_status=gate.FAIL_STATUS,
+            economic_validity_proven=False,
+        )
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_ECONOMIC_VALIDITY_NOT_PROVEN in result.reason_codes
+
+    def test_economic_validity_missing_blocked(self) -> None:
+        result = _evaluate(economic_validity_status="")
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.BLOCKED
+        assert any(
+            code.startswith(gate.REASON_REQUIRED_INPUT_MISSING) for code in result.reason_codes
+        )
+
+    def test_profitability_claim_false_ineligible(self) -> None:
+        result = _evaluate(profitability_claim_allowed=False)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_PROFITABILITY_CLAIM_NOT_ALLOWED in result.reason_codes
+
+    def test_economic_evidence_missing_blocked(self) -> None:
+        result = _evaluate(economic_viability_evidence_ref="")
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.BLOCKED
+        assert gate.REASON_ECONOMIC_EVIDENCE_MISSING in result.reason_codes
+
+    def test_economic_evidence_inadmissible_ineligible(self) -> None:
+        result = _evaluate(
+            evidence_admissible=False,
+            evidence_admissibility_status=gate.FAIL_STATUS,
+        )
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_ECONOMIC_EVIDENCE_INADMISSIBLE in result.reason_codes
+
+    def test_data_admissibility_fail_ineligible(self) -> None:
+        result = _evaluate(data_admissibility_status=gate.FAIL_STATUS)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_DATA_ADMISSIBILITY_FAILED in result.reason_codes
+
+    def test_policy_threshold_fail_ineligible(self) -> None:
+        result = _evaluate(policy_threshold_status=gate.FAIL_STATUS)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_POLICY_THRESHOLD_FAILED in result.reason_codes
+
+    def test_walk_forward_fail_ineligible(self) -> None:
+        result = _evaluate(walk_forward_status=gate.FAIL_STATUS)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_WALK_FORWARD_FAILED in result.reason_codes
+
+    def test_oos_fail_ineligible(self) -> None:
+        result = _evaluate(out_of_sample_status=gate.FAIL_STATUS)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_OUT_OF_SAMPLE_FAILED in result.reason_codes
+
+    def test_monte_carlo_fail_ineligible(self) -> None:
+        result = _evaluate(monte_carlo_status=gate.FAIL_STATUS)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_MONTE_CARLO_FAILED in result.reason_codes
+
+    def test_stress_fail_ineligible(self) -> None:
+        result = _evaluate(stress_status=gate.FAIL_STATUS)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_STRESS_FAILED in result.reason_codes
+
+    def test_parameter_sensitivity_fail_ineligible(self) -> None:
+        result = _evaluate(parameter_sensitivity_status=gate.FAIL_STATUS)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_PARAMETER_SENSITIVITY_FAILED in result.reason_codes
+
+    def test_reproducibility_fail_ineligible(self) -> None:
+        result = _evaluate(reproducibility_status=gate.FAIL_STATUS)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_REPRODUCIBILITY_FAILED in result.reason_codes
+
+    def test_digest_binding_fail_blocked(self) -> None:
+        result = _evaluate(digest_binding_status=gate.FAIL_STATUS)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.BLOCKED
+        assert gate.REASON_DIGEST_BINDING_FAILED in result.reason_codes
+
+    def test_manifest_binding_fail_blocked(self) -> None:
+        result = _evaluate(manifest_binding_status=gate.FAIL_STATUS)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.BLOCKED
+        assert gate.REASON_MANIFEST_BINDING_FAILED in result.reason_codes
+
+    def test_safety_policy_fail_ineligible(self) -> None:
+        result = _evaluate(safety_policy_status=gate.FAIL_STATUS)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_SAFETY_POLICY_FAILED in result.reason_codes
+
+    def test_non_futures_candidate_ineligible(self) -> None:
+        result = _evaluate(futures_only=False)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_NON_FUTURES_CANDIDATE in result.reason_codes
+
+    def test_bitcoin_direction_forbidden_ineligible(self) -> None:
+        result = _evaluate(bitcoin_direction_allowed=True)
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.INELIGIBLE
+        assert gate.REASON_BITCOIN_DIRECTION_FORBIDDEN in result.reason_codes
+
+    def test_missing_required_input_blocked(self) -> None:
+        result = _evaluate(candidate_id="")
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.BLOCKED
+        assert any(
+            code.startswith(gate.REASON_REQUIRED_INPUT_MISSING) for code in result.reason_codes
+        )
+
+    def test_non_finite_metric_blocked(self) -> None:
+        result = _evaluate(required_metrics={"net_expectancy": float("nan")})
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.BLOCKED
+        assert any(code.startswith(gate.REASON_NON_FINITE_METRIC) for code in result.reason_codes)
+
+    def test_policy_digest_mismatch_blocked(self) -> None:
+        result = gate.evaluate_promotion_economic_gate_v1(
+            policy=_policy(),
+            input_data=_valid_input(),
+            evaluation_timestamp=EVAL_TS,
+            expected_policy_digest="deadbeef" * 8,
+        )
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.BLOCKED
+        assert gate.REASON_POLICY_DIGEST_MISMATCH in result.reason_codes
+
+    def test_evidence_digest_mismatch_blocked(self) -> None:
+        result = gate.evaluate_promotion_economic_gate_v1(
+            policy=_policy(),
+            input_data=_valid_input(),
+            evaluation_timestamp=EVAL_TS,
+            expected_evidence_manifest_digest="feedface" * 8,
+        )
+        assert result.promotion_candidate_status is gate.PromotionCandidateStatus.BLOCKED
+        assert gate.REASON_EVIDENCE_DIGEST_MISMATCH in result.reason_codes
+
+    def test_hard_fail_not_compensated_by_other_passes(self) -> None:
+        result = _evaluate(
+            economic_validity_status=gate.FAIL_STATUS,
+            economic_validity_proven=False,
+            walk_forward_status=gate.PASS_STATUS,
+            out_of_sample_status=gate.PASS_STATUS,
+            monte_carlo_status=gate.PASS_STATUS,
+        )
+        assert result.eligible_for_promotion_candidate is False
+        assert gate.REASON_ECONOMIC_VALIDITY_NOT_PROVEN in result.reason_codes
+
+    def test_input_order_does_not_change_result(self) -> None:
+        kwargs_a = {
+            "strategy_id": "mv2_offline_research",
+            "candidate_id": "candidate-001",
+            "strategy_version": "v1",
+        }
+        kwargs_b = {
+            "candidate_id": "candidate-001",
+            "strategy_version": "v1",
+            "strategy_id": "mv2_offline_research",
+        }
+        result_a = _evaluate(**kwargs_a)
+        result_b = _evaluate(**kwargs_b)
+        assert result_a.evaluation_digest == result_b.evaluation_digest
+        assert result_a.promotion_candidate_status == result_b.promotion_candidate_status
+
+    def test_identical_inputs_identical_evaluation_digest(self) -> None:
+        first = _evaluate()
+        second = _evaluate()
+        assert first.evaluation_digest == second.evaluation_digest
+
+    def test_input_mutation_changes_evaluation_digest(self) -> None:
+        first = _evaluate()
+        second = _evaluate(strategy_version="v2")
+        assert first.evaluation_digest != second.evaluation_digest
+
+    def test_eligible_does_not_imply_deployment(self) -> None:
+        result = _evaluate()
+        assert result.eligible_for_promotion_candidate is True
+        assert result.deployment_eligible is False
+        assert result.deployment_effect == gate.DEPLOYMENT_EFFECT_NONE
+
+    def test_eligible_does_not_imply_runtime(self) -> None:
+        result = _evaluate()
+        assert result.runtime_eligible is False
+        assert result.runtime_effect == gate.RUNTIME_EFFECT_NONE
+
+    def test_eligible_does_not_imply_activation(self) -> None:
+        result = _evaluate()
+        assert result.activation_allowed is False
+        assert result.activation_effect == gate.ACTIVATION_EFFECT_NONE
+
+    def test_eligible_does_not_imply_execution(self) -> None:
+        result = _evaluate()
+        assert result.execution_allowed is False
+
+    def test_current_repo_state_fail_closed(self) -> None:
+        result = gate.evaluate_current_repo_promotion_gate_v1(evaluation_timestamp=EVAL_TS)
+        assert result.eligible_for_promotion_candidate is False
+        assert result.promotion_candidate_status is not gate.PromotionCandidateStatus.ELIGIBLE
+        assert gate.REASON_ECONOMIC_VALIDITY_NOT_PROVEN in result.reason_codes
+        assert gate.REASON_PROFITABILITY_CLAIM_NOT_ALLOWED in result.reason_codes
+
+    def test_futures_only_preserved(self) -> None:
+        policy = _policy()
+        result = _evaluate()
+        assert policy.futures_only is True
+        assert result.eligible_for_promotion_candidate is True
+
+    def test_bitcoin_direction_forbidden_preserved(self) -> None:
+        policy = _policy()
+        assert policy.bitcoin_direction_allowed is False
+        result = gate.evaluate_current_repo_promotion_gate_v1(evaluation_timestamp=EVAL_TS)
+        assert result.eligible_for_promotion_candidate is False
+
+
+class TestPromotionGateRegistryBoundaries:
+    def test_runtime_authority_request_forbidden(self) -> None:
+        result = _evaluate(request_runtime_authority=True)
+        assert gate.REASON_RUNTIME_AUTHORITY_REQUEST_FORBIDDEN in result.reason_codes
+
+    def test_deployment_activation_request_forbidden(self) -> None:
+        result = _evaluate(request_deployment_activation=True)
+        assert gate.REASON_DEPLOYMENT_ACTIVATION_FORBIDDEN in result.reason_codes
+
+    def test_schema_contract(self) -> None:
+        schema = gate.promotion_economic_gate_schema_v1()
+        assert schema["policy_version"] == gate.PROMOTION_ECONOMIC_GATE_POLICY_VERSION
+        assert gate.REASON_ECONOMIC_VALIDITY_NOT_PROVEN in schema["reason_codes"]

--- a/tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py
@@ -37,7 +37,7 @@ def _field_value(text: str, field: str) -> str:
 
 def _step_29m_section(text: str) -> str:
     start = text.index("#### RUNBOOK_STEP_29M — Economic Viability Evidence v1")
-    end = text.index("#### RUNBOOK_STEP_29J (legacy heading)", start)
+    end = text.index("#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1", start)
     return text[start:end]
 
 
@@ -55,13 +55,13 @@ def test_runbook_step_29m_complete_true() -> None:
 
 
 def test_progress_registry_closeout_performed_true() -> None:
-    text = _read_registry()
-    assert _field_value(text, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
 
 
 def test_step_29n_not_started() -> None:
-    text = _read_registry()
-    assert _field_value(text, "STEP_29N_STARTED") == "false"
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "STEP_29N_STARTED") == "false"
 
 
 def test_next_runbook_step_is_29n() -> None:
@@ -95,10 +95,10 @@ def test_all_registered_step_29m_slices_preserved() -> None:
 
 
 def test_no_step_29n_implementation_markers() -> None:
-    text = _read_registry()
-    assert "RUNBOOK_STEP_29N_IMPLEMENTED" not in text
-    assert "RUNBOOK_STEP_29N_COMPLETE" not in text
-    assert _field_value(text, "STEP_29N_STARTED") == "false"
+    section = _step_29m_section(_read_registry())
+    assert "RUNBOOK_STEP_29N_IMPLEMENTED" not in section
+    assert "RUNBOOK_STEP_29N_COMPLETE" not in section
+    assert _field_value(section, "STEP_29N_STARTED") == "false"
 
 
 def test_no_promotion_eligibility_or_runtime_authority() -> None:

--- a/tests/ops/test_runbook_step29n_promotion_economic_gate_binding_registry_contract_v0.py
+++ b/tests/ops/test_runbook_step29n_promotion_economic_gate_binding_registry_contract_v0.py
@@ -1,0 +1,120 @@
+"""Contract tests for RUNBOOK STEP 29N promotion economic gate binding registry slice."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROGRESS_REGISTRY = REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+
+STEP_29N_IMPLEMENTED_SCOPE = "promotion_economic_gate_binding_v1_slice"
+
+
+def _read_registry() -> str:
+    assert PROGRESS_REGISTRY.is_file(), f"missing canonical registry: {PROGRESS_REGISTRY}"
+    return PROGRESS_REGISTRY.read_text(encoding="utf-8")
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(rf"\| `{re.escape(field)}` \| `([^`]*)` \|", text)
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _step_29n_section(text: str) -> str:
+    start = text.index("#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1")
+    end = text.index("#### RUNBOOK_STEP_29J (legacy heading)", start)
+    return text[start:end]
+
+
+def test_runbook_step_29n_started_true() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29N_STARTED") == "true"
+    assert _field_value(text, "STEP_29N_STARTED") == "true"
+
+
+def test_runbook_step_29n_implemented_scope() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29N_IMPLEMENTED_SCOPE") == STEP_29N_IMPLEMENTED_SCOPE
+
+
+def test_runbook_step_29n_complete_false() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29N_COMPLETE") == "false"
+
+
+def test_step_29o_not_started() -> None:
+    text = _read_registry()
+    assert _field_value(text, "STEP_29O_STARTED") == "false"
+
+
+def test_next_runbook_step_is_29n() -> None:
+    text = _read_registry()
+    assert _field_value(text, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29N"
+
+
+def test_promotion_gate_binding_status_pass() -> None:
+    text = _read_registry()
+    assert _field_value(text, "PROMOTION_ECONOMIC_GATE_BINDING_STATUS") == "PASS"
+
+
+def test_promotion_candidate_not_eligible() -> None:
+    text = _read_registry()
+    section = _step_29n_section(text)
+    assert _field_value(text, "PROMOTION_CANDIDATE_ELIGIBLE") == "false"
+    assert _field_value(section, "PROMOTION_CANDIDATE_ELIGIBLE") == "false"
+
+
+def test_no_deployment_runtime_activation_execution() -> None:
+    text = _read_registry()
+    assert _field_value(text, "DEPLOYMENT_ELIGIBLE") == "false"
+    assert _field_value(text, "RUNTIME_ELIGIBLE") == "false"
+    assert _field_value(text, "ACTIVATION_ALLOWED") == "false"
+    assert _field_value(text, "EXECUTION_ALLOWED") == "false"
+
+
+def test_economic_validity_not_proven() -> None:
+    text = _read_registry()
+    section = _step_29n_section(text)
+    assert _field_value(text, "ECONOMIC_VALIDITY_PROVEN") == "false"
+    assert _field_value(section, "ECONOMIC_VALIDITY_PROVEN") == "false"
+
+
+def test_profitability_claim_not_allowed() -> None:
+    text = _read_registry()
+    section = _step_29n_section(text)
+    assert _field_value(text, "PROFITABILITY_CLAIM_ALLOWED") == "false"
+    assert _field_value(section, "PROFITABILITY_CLAIM_ALLOWED") == "false"
+
+
+def test_step_29m_complete_preserved() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29M_COMPLETE") == "true"
+
+
+def test_progress_registry_closeout_not_performed_for_step_29n() -> None:
+    text = _read_registry()
+    section = _step_29n_section(text)
+    assert _field_value(text, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "false"
+    assert _field_value(section, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "false"
+
+
+def test_futures_only_and_bitcoin_direction_forbidden() -> None:
+    section = _step_29n_section(_read_registry())
+    assert _field_value(section, "FUTURES_ONLY") == "true"
+    assert _field_value(section, "BITCOIN_DIRECTION_ALLOWED") == "false"
+
+
+def test_candidate_eligibility_does_not_imply_authority() -> None:
+    section = _step_29n_section(_read_registry())
+    assert (
+        _field_value(section, "PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_DEPLOYMENT") == "true"
+    )
+    assert _field_value(section, "PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_RUNTIME") == "true"
+    assert (
+        _field_value(section, "PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_ACTIVATION") == "true"
+    )
+    assert (
+        _field_value(section, "PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_EXECUTION") == "true"
+    )


### PR DESCRIPTION
## Summary
- Implement fail-closed `PromotionEconomicGatePolicyV1` / `PromotionEconomicGateResultV1` under the existing promotion loop owner.
- Bind promotion candidate eligibility to economic validity, robustness, admissibility, digest/manifest binding, and safety policy without runtime/deployment/execution authority.
- Update canonical progress registry for STEP 29N start (complete=false, closeout not performed) and add focused contract tests.

## Test plan
- [x] `pytest tests/governance/test_promotion_economic_gate_v1.py`
- [x] `pytest tests/ops/test_runbook_step29n_promotion_economic_gate_binding_registry_contract_v0.py`
- [x] `pytest tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py`
- [x] `pytest tests/backtest/test_economic_validity_policy_v1.py`
- [x] `ruff format --check` / `ruff check` on changed Python files
- [x] CI selector: `PR_BOUNDED_FULL` (central `src/` change)

## Safety
- `RUNTIME_EFFECT=false`, `ORDER_EFFECT=false`, `LIVE_AUTHORIZED=false`
- Current repo posture evaluates `PROMOTION_CANDIDATE_ELIGIBLE=false` (economic validity not proven)
- No STEP 29N registry closeout, no STEP 29O


Made with [Cursor](https://cursor.com)