### PR TITLE
docs(governance): RUNBOOK STEP 29N progress registry closeout v0

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -16,10 +16,10 @@ SCHEDULER_RUNTIME_ALLOWED: false
 
 | Feld | Wert |
 |---|---|
-| `LAST_VERIFIED_ORIGIN_MAIN` | `c8a6a275918b757422aa0b910b4ec00ea011f899` |
-| `LAST_VERIFIED_AT` | `2026-07-01T00:00:00Z` |
+| `LAST_VERIFIED_ORIGIN_MAIN` | `57c70513e8f0a31a7623c11ed2ad80e93aa42997` |
+| `LAST_VERIFIED_AT` | `2026-07-01T20:30:00Z` |
 | `CURRENT_MAJOR_GAP_PACKAGE` | `MAJOR_GAP_COMPARISON_PROMOTION_POLICY_INPUT_BRIDGE_V0` |
-| `NEXT_RUNBOOK_STEP` | `RUNBOOK_STEP_29N` |
+| `NEXT_RUNBOOK_STEP` | `RUNBOOK_STEP_29O` |
 | `NEXT_CANONICAL_STEP` | `backtest_engine_rewire_binding` |
 | `RUNBOOK_STEP_13_IMPLEMENTED` | `true` |
 | `TRADING_SESSION_SINGLE_WRITER_IMPLEMENTED` | `true` |
@@ -118,9 +118,10 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29N_STARTED` | `true` |
 | `RUNBOOK_STEP_29N_IMPLEMENTED_SCOPE` | `promotion_economic_gate_binding_v1_slice` |
 | `RUNBOOK_STEP_29N_IMPLEMENTED` | `true` |
-| `RUNBOOK_STEP_29N_COMPLETE` | `false` |
+| `RUNBOOK_STEP_29N_COMPLETE` | `true` |
 | `STEP_29O_STARTED` | `false` |
 | `PROMOTION_ECONOMIC_GATE_BINDING_STATUS` | `PASS` |
+| `PROMOTION_CANDIDATE_STATUS` | `INELIGIBLE` |
 | `PROMOTION_CANDIDATE_ELIGIBLE` | `false` |
 | `DEPLOYMENT_ELIGIBLE` | `false` |
 | `RUNTIME_ELIGIBLE` | `false` |
@@ -128,7 +129,7 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `EXECUTION_ALLOWED` | `false` |
 | `ECONOMIC_VALIDITY_PROVEN` | `false` |
 | `PROFITABILITY_CLAIM_ALLOWED` | `false` |
-| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `false` |
+| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `true` |
 | `FOLLOW_UP_DEVEX_SCOPE` | `CANONICAL_PRE_PR_RUFF_AND_DIFF_GUARD` |
 | `FOLLOW_UP_DEVEX_STATUS` | `PENDING_SEPARATE_PR` |
 | `SYSTEMWIDE_RANKING_REQUIRED` | `false` |
@@ -1078,11 +1079,14 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 |---|---|
 | `RUNBOOK_PHASE` | 9 |
 | `RUNBOOK_STEP_ID` | `promotion_economic_gate_binding_v1` |
-| `STATUS` | `IN_PROGRESS` |
+| `STATUS` | `COMPLETE` |
 | `CANONICAL_OWNER` | `src/governance/promotion_loop/promotion_economic_gate_v1.py` |
+| `MERGED_PRS` | `#4708` |
+| `MERGE_COMMITS` | `57c70513e8f0a31a7623c11ed2ad80e93aa42997` |
+| `DURABLE_EVIDENCE_REFS` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29n_promotion_economic_gate_binding_pr4708squash_merge_closeout_v0_20260630T231725Z (MANIFEST_VERIFY_RC=0); promotion_economic_gate_binding_pr=4708; promotion_economic_gate_binding_merge_commit=57c70513e8f0a31a7623c11ed2ad80e93aa42997; promotion_economic_gate_binding_squash_parent=c8a6a275918b757422aa0b910b4ec00ea011f899; canonical_scope=promotion_economic_gate_binding_v1_slice; PROMOTION_ECONOMIC_GATE_BINDING_V1_BOUND=true; STEP29N_IMPLEMENTATION_COMPLETE=true; TECHNICAL_PROMOTION_GATE_STACK_COMPLETE=true; CURRENT_PROMOTION_EVALUATION=INELIGIBLE; REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED=true; THRESHOLD_TUNING_ALLOWED=false; STEP_29O_STARTED=false; STEP_29N_COMPLETION_DOES_NOT_AUTHORIZE_LIVE=true; STEP_29N_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME=true; STEP_29N_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS=true; STEP_29N_COMPLETION_DOES_NOT_START_STEP_29O=true; PROMOTION_ELIGIBILITY_GRANTED=false; PROMOTION_AUTHORITY_GRANTED=false; DEPLOYMENT_AUTHORITY_GRANTED=false; RUNTIME_AUTHORITY_GRANTED=false; EXECUTION_AUTHORITY_GRANTED=false; UNIVERSE_SELECTION_UNCHANGED=true; offline_only=true; non_authorizing=true; runtime_process_started=false; scheduler_action_performed=false; venue_access_performed=false; credential_access_performed=false; trading_action_performed=false; progress_registry_closeout_status=COMPLETE; FUTURES_ONLY=true; BITCOIN_DIRECTION_ALLOWED=false; LIVE_AUTHORIZED=false; ORDERS_ALLOWED=false; SCHEDULER_RUNTIME_ALLOWED=false` |
 | `DEPENDENCIES` | RUNBOOK_STEP_29M |
-| `REMAINING_GAPS` | Registry closeout; real admissible futures economic evidence; economic validity proof |
-| `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29N` |
+| `REMAINING_GAPS` | real admissible futures economic evidence; economic validity proof |
+| `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29O` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNTIME_EFFECT` | `false` |
 | `ORDER_EFFECT` | `false` |
@@ -1091,6 +1095,10 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `ECONOMIC_VALIDITY_PROVEN` | `false` |
 | `PROFITABILITY_CLAIM_ALLOWED` | `false` |
 | `PROMOTION_ECONOMIC_GATE_BINDING_STATUS` | `PASS` |
+| `TECHNICAL_PROMOTION_GATE_STACK_COMPLETE` | `true` |
+| `CURRENT_PROMOTION_EVALUATION` | `INELIGIBLE` |
+| `REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED` | `true` |
+| `THRESHOLD_TUNING_ALLOWED` | `false` |
 | `PROMOTION_CANDIDATE_ELIGIBLE` | `false` |
 | `PROMOTION_CANDIDATE_STATUS` | `INELIGIBLE` |
 | `DEPLOYMENT_ELIGIBLE` | `false` |
@@ -1099,13 +1107,17 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `EXECUTION_ALLOWED` | `false` |
 | `LIVE_AUTHORIZED` | `false` |
 | `PROMOTION_ELIGIBILITY_GRANTED` | `false` |
+| `PROMOTION_AUTHORITY_GRANTED` | `false` |
+| `DEPLOYMENT_AUTHORITY_GRANTED` | `false` |
 | `RUNTIME_AUTHORITY_GRANTED` | `false` |
+| `EXECUTION_AUTHORITY_GRANTED` | `false` |
 | `RUNBOOK_STEP_29N_STARTED` | `true` |
 | `RUNBOOK_STEP_29N_IMPLEMENTED_SCOPE` | `promotion_economic_gate_binding_v1_slice` |
 | `RUNBOOK_STEP_29N_IMPLEMENTED` | `true` |
-| `RUNBOOK_STEP_29N_COMPLETE` | `false` |
+| `RUNBOOK_STEP_29N_COMPLETE` | `true` |
+| `PROMOTION_ECONOMIC_GATE_BINDING_V1_IMPLEMENTED` | `true` |
 | `STEP_29O_STARTED` | `false` |
-| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `false` |
+| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `true` |
 | `PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_DEPLOYMENT` | `true` |
 | `PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_RUNTIME` | `true` |
 | `PROMOTION_CANDIDATE_ELIGIBILITY_DOES_NOT_IMPLY_ACTIVATION` | `true` |

--- a/tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py
@@ -64,9 +64,9 @@ def test_step_29n_not_started() -> None:
     assert _field_value(section, "STEP_29N_STARTED") == "false"
 
 
-def test_next_runbook_step_is_29n() -> None:
-    text = _read_registry()
-    assert _field_value(text, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29N"
+def test_next_required_contract_is_29n_in_section() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "NEXT_REQUIRED_CONTRACT") == "RUNBOOK_STEP_29N"
 
 
 def test_economic_validity_not_proven() -> None:

--- a/tests/ops/test_runbook_step29n_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29n_progress_registry_closeout_contract_v0.py
@@ -1,0 +1,167 @@
+"""Contract tests for RUNBOOK STEP 29N progress registry closeout v0.
+
+Verifies technical completion closeout semantics without authorizing runtime,
+profitability claims, promotion authority, or STEP 29O implementation.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROGRESS_REGISTRY = REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+
+STEP_29N_IMPLEMENTED_SCOPE = "promotion_economic_gate_binding_v1_slice"
+
+
+def _read_registry() -> str:
+    assert PROGRESS_REGISTRY.is_file(), f"missing canonical registry: {PROGRESS_REGISTRY}"
+    return PROGRESS_REGISTRY.read_text(encoding="utf-8")
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(rf"\| `{re.escape(field)}` \| `([^`]*)` \|", text)
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _step_29n_section(text: str) -> str:
+    start = text.index("#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1")
+    end = text.index("#### RUNBOOK_STEP_29J (legacy heading)", start)
+    return text[start:end]
+
+
+def test_progress_registry_is_canonical_single_ssot() -> None:
+    text = _read_registry()
+    assert text.count("STATUS: CANONICAL_RUNBOOK_PROGRESS_REGISTRY") == 1
+
+
+def test_runbook_step_29n_started_true() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29N_STARTED") == "true"
+    assert _field_value(text, "STEP_29N_STARTED") == "true"
+
+
+def test_runbook_step_29n_complete_true() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29N_COMPLETE") == "true"
+
+
+def test_progress_registry_closeout_performed_true() -> None:
+    text = _read_registry()
+    section = _step_29n_section(text)
+    assert _field_value(text, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
+    assert _field_value(section, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
+
+
+def test_step_29o_not_started() -> None:
+    text = _read_registry()
+    section = _step_29n_section(text)
+    assert _field_value(text, "STEP_29O_STARTED") == "false"
+    assert _field_value(section, "STEP_29O_STARTED") == "false"
+
+
+def test_next_runbook_step_is_29o() -> None:
+    text = _read_registry()
+    assert _field_value(text, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29O"
+
+
+def test_promotion_gate_binding_status_pass() -> None:
+    section = _step_29n_section(_read_registry())
+    assert _field_value(section, "PROMOTION_ECONOMIC_GATE_BINDING_STATUS") == "PASS"
+
+
+def test_economic_validity_not_proven() -> None:
+    text = _read_registry()
+    section = _step_29n_section(text)
+    assert _field_value(text, "ECONOMIC_VALIDITY_PROVEN") == "false"
+    assert _field_value(section, "ECONOMIC_VALIDITY_PROVEN") == "false"
+
+
+def test_profitability_claim_not_allowed() -> None:
+    text = _read_registry()
+    section = _step_29n_section(text)
+    assert _field_value(text, "PROFITABILITY_CLAIM_ALLOWED") == "false"
+    assert _field_value(section, "PROFITABILITY_CLAIM_ALLOWED") == "false"
+
+
+def test_promotion_candidate_not_eligible() -> None:
+    text = _read_registry()
+    section = _step_29n_section(text)
+    assert _field_value(text, "PROMOTION_CANDIDATE_ELIGIBLE") == "false"
+    assert _field_value(section, "PROMOTION_CANDIDATE_ELIGIBLE") == "false"
+    assert _field_value(section, "PROMOTION_CANDIDATE_STATUS") == "INELIGIBLE"
+    assert _field_value(section, "CURRENT_PROMOTION_EVALUATION") == "INELIGIBLE"
+
+
+def test_no_deployment_runtime_activation_execution() -> None:
+    text = _read_registry()
+    section = _step_29n_section(text)
+    assert _field_value(text, "DEPLOYMENT_ELIGIBLE") == "false"
+    assert _field_value(text, "RUNTIME_ELIGIBLE") == "false"
+    assert _field_value(text, "ACTIVATION_ALLOWED") == "false"
+    assert _field_value(text, "EXECUTION_ALLOWED") == "false"
+    assert _field_value(section, "DEPLOYMENT_ELIGIBLE") == "false"
+    assert _field_value(section, "RUNTIME_ELIGIBLE") == "false"
+    assert _field_value(section, "ACTIVATION_ALLOWED") == "false"
+    assert _field_value(section, "EXECUTION_ALLOWED") == "false"
+
+
+def test_step_29m_complete_preserved() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29M_COMPLETE") == "true"
+
+
+def test_implemented_scope_preserved() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29N_IMPLEMENTED_SCOPE") == STEP_29N_IMPLEMENTED_SCOPE
+    section = _step_29n_section(text)
+    assert _field_value(section, "RUNBOOK_STEP_29N_IMPLEMENTED_SCOPE") == STEP_29N_IMPLEMENTED_SCOPE
+
+
+def test_no_step_29o_implementation_markers() -> None:
+    section = _step_29n_section(_read_registry())
+    assert "RUNBOOK_STEP_29O_IMPLEMENTED" not in section
+    assert "RUNBOOK_STEP_29O_COMPLETE" not in section
+
+
+def test_no_promotion_runtime_or_execution_authority() -> None:
+    section = _step_29n_section(_read_registry())
+    assert _field_value(section, "PROMOTION_ELIGIBILITY_GRANTED") == "false"
+    assert _field_value(section, "PROMOTION_AUTHORITY_GRANTED") == "false"
+    assert _field_value(section, "DEPLOYMENT_AUTHORITY_GRANTED") == "false"
+    assert _field_value(section, "RUNTIME_AUTHORITY_GRANTED") == "false"
+    assert _field_value(section, "EXECUTION_AUTHORITY_GRANTED") == "false"
+    assert _field_value(section, "RUNTIME_EFFECT") == "false"
+    assert _field_value(section, "STEP_29N_COMPLETION_DOES_NOT_START_STEP_29O") == "true"
+
+
+def test_futures_only_and_bitcoin_direction_forbidden() -> None:
+    section = _step_29n_section(_read_registry())
+    assert _field_value(section, "FUTURES_ONLY") == "true"
+    assert _field_value(section, "BITCOIN_DIRECTION_ALLOWED") == "false"
+
+
+def test_technical_stack_complete_without_promotion_pass() -> None:
+    section = _step_29n_section(_read_registry())
+    assert _field_value(section, "TECHNICAL_PROMOTION_GATE_STACK_COMPLETE") == "true"
+    assert _field_value(section, "ECONOMIC_VALIDITY_PROVEN") == "false"
+    assert _field_value(section, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED") == "true"
+    assert _field_value(section, "THRESHOLD_TUNING_ALLOWED") == "false"
+    assert _field_value(section, "PROMOTION_CANDIDATE_ELIGIBLE") == "false"
+
+
+def test_technical_completion_not_equated_with_promotion_eligibility() -> None:
+    section = _step_29n_section(_read_registry())
+    assert _field_value(section, "RUNBOOK_STEP_29N_COMPLETE") == "true"
+    assert _field_value(section, "TECHNICAL_PROMOTION_GATE_STACK_COMPLETE") == "true"
+    assert _field_value(section, "CURRENT_PROMOTION_EVALUATION") == "INELIGIBLE"
+    assert _field_value(section, "PROMOTION_CANDIDATE_ELIGIBLE") == "false"
+
+
+def test_step_29n_section_status_complete_with_closeout() -> None:
+    section = _step_29n_section(_read_registry())
+    assert _field_value(section, "STATUS") == "COMPLETE"
+    assert _field_value(section, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
+    assert _field_value(section, "NEXT_REQUIRED_CONTRACT") == "RUNBOOK_STEP_29O"

--- a/tests/ops/test_runbook_step29n_promotion_economic_gate_binding_registry_contract_v0.py
+++ b/tests/ops/test_runbook_step29n_promotion_economic_gate_binding_registry_contract_v0.py
@@ -39,21 +39,6 @@ def test_runbook_step_29n_implemented_scope() -> None:
     assert _field_value(text, "RUNBOOK_STEP_29N_IMPLEMENTED_SCOPE") == STEP_29N_IMPLEMENTED_SCOPE
 
 
-def test_runbook_step_29n_complete_false() -> None:
-    text = _read_registry()
-    assert _field_value(text, "RUNBOOK_STEP_29N_COMPLETE") == "false"
-
-
-def test_step_29o_not_started() -> None:
-    text = _read_registry()
-    assert _field_value(text, "STEP_29O_STARTED") == "false"
-
-
-def test_next_runbook_step_is_29n() -> None:
-    text = _read_registry()
-    assert _field_value(text, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29N"
-
-
 def test_promotion_gate_binding_status_pass() -> None:
     text = _read_registry()
     assert _field_value(text, "PROMOTION_ECONOMIC_GATE_BINDING_STATUS") == "PASS"
@@ -91,13 +76,6 @@ def test_profitability_claim_not_allowed() -> None:
 def test_step_29m_complete_preserved() -> None:
     text = _read_registry()
     assert _field_value(text, "RUNBOOK_STEP_29M_COMPLETE") == "true"
-
-
-def test_progress_registry_closeout_not_performed_for_step_29n() -> None:
-    text = _read_registry()
-    section = _step_29n_section(text)
-    assert _field_value(text, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "false"
-    assert _field_value(section, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "false"
 
 
 def test_futures_only_and_bitcoin_direction_forbidden() -> None:


### PR DESCRIPTION
## Summary

- Schließt den kanonischen Progress-Registry-Zustand für RUNBOOK_STEP_29N nach technischem Completion-Audit von PR #4708 ab.
- Setzt `RUNBOOK_STEP_29N_COMPLETE=true`, `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED=true` und `NEXT_RUNBOOK_STEP=RUNBOOK_STEP_29O`.
- Erhält alle negativen Promotion-/Authority-Invarianten (`ECONOMIC_VALIDITY_PROVEN=false`, `PROMOTION_CANDIDATE_ELIGIBLE=false`, keine Deployment/Runtime/Execution-Authority).

## Test plan

- [x] `tests/ops/test_runbook_step29n_progress_registry_closeout_contract_v0.py`
- [x] `tests/ops/test_runbook_step29n_promotion_economic_gate_binding_registry_contract_v0.py`
- [x] `tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py`
- [x] `tests/ops/test_runbook_execution_governance_and_progress_registry_static_crosslink_contract_v0.py`
- [x] ruff format/check, git diff --check, docs token policy, docs reference targets
- [x] CI selector: NO_OP


Made with [Cursor](https://cursor.com)