### PR TITLE
RUNBOOK STEP 29P: start capital risk sizing progress registry

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -16,8 +16,8 @@ SCHEDULER_RUNTIME_ALLOWED: false
 
 | Feld | Wert |
 |---|---|
-| `LAST_VERIFIED_ORIGIN_MAIN` | `8ef254621a7203a63a1bc106ec2f12192fdb553f` |
-| `LAST_VERIFIED_AT` | `2026-07-01T02:30:00Z` |
+| `LAST_VERIFIED_ORIGIN_MAIN` | `581fecffd60e9a8d7f6938672cafbd3d9dc56313` |
+| `LAST_VERIFIED_AT` | `2026-07-01T12:00:00Z` |
 | `CURRENT_MAJOR_GAP_PACKAGE` | `MAJOR_GAP_COMPARISON_PROMOTION_POLICY_INPUT_BRIDGE_V0` |
 | `NEXT_RUNBOOK_STEP` | `RUNBOOK_STEP_29P` |
 | `NEXT_CANONICAL_STEP` | `backtest_engine_rewire_binding` |
@@ -126,6 +126,12 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29O_COMPLETE` | `true` |
 | `STEP_29O_STARTED` | `true` |
 | `INTENT_COMPATIBILITY_FIREWALL_IMPLEMENTED` | `true` |
+| `RUNBOOK_STEP_29P_STARTED` | `true` |
+| `RUNBOOK_STEP_29P_IMPLEMENTATION_STARTED` | `false` |
+| `RUNBOOK_STEP_29P_IMPLEMENTED_SCOPE` | `none` |
+| `RUNBOOK_STEP_29P_COMPLETE` | `false` |
+| `STEP_29P_STARTED` | `true` |
+| `CAPITAL_RISK_SIZING_MATHEMATICS_CHANGED` | `false` |
 | `PROMOTION_ECONOMIC_GATE_BINDING_STATUS` | `PASS` |
 | `PROMOTION_CANDIDATE_STATUS` | `INELIGIBLE` |
 | `PROMOTION_CANDIDATE_ELIGIBLE` | `false` |
@@ -1218,6 +1224,74 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `STEP_29O_EXCLUDES_CAPITAL_RISK_SIZING_29P` | `true` |
 | `STEP_29O_EXCLUDES_CANONICAL_ORDER_INTENT_29Q` | `true` |
 | `STEP_29O_EXCLUDES_RUNTIME_REWIRE_29R` | `true` |
+| `offline_only` | `true` |
+| `non_authorizing` | `true` |
+| `SEPARATE_GO_REQUIRED` | `true` |
+
+#### RUNBOOK_STEP_29P — Capital Risk Sizing Mathematics v1
+
+| Feld | Wert |
+|---|---|
+| `RUNBOOK_PHASE` | 9 |
+| `RUNBOOK_STEP_ID` | `capital_risk_sizing_v1` |
+| `STATUS` | `IN_PROGRESS` |
+| `CANONICAL_OWNER` | `src&#47;governance&#47;capital_risk_sizing_v1.py` <!-- pt:ref-target-ignore --> |
+| `CANONICAL_OWNER_STATUS` | `PROPOSED_PENDING_IMPLEMENTATION` |
+| `CANONICAL_OWNER_RATIFIED` | `false` |
+| `MERGED_PRS` | `none` |
+| `MERGE_COMMITS` | `none` |
+| `DURABLE_EVIDENCE_REFS` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29o_intent_compatibility_firewall_registry_closeout_pr_squash_merge_closeout_v0_20260701T025815Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning_or_validation/runbook_step29o_intent_compatibility_firewall_read_only_scope_audit_v0_20260701T141500Z/STEP_BOUNDARY_29O_29P_29Q_29R.md (MANIFEST_VERIFY_RC=0); audit_verdict=RUNBOOK_STEP_29O_READ_ONLY_SCOPE_AUDIT_PASS; minimum_safe_slice=capital_risk_sizing_v1_offline_slice; STEP_29P_REGISTRY_START_ONLY=true; STEP_29P_IMPLEMENTATION_STARTED=false; STEP_29P_COMPLETION_DOES_NOT_AUTHORIZE_LIVE=true; STEP_29P_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME=true; STEP_29P_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS=true; STEP_29P_COMPLETION_DOES_NOT_START_STEP_29Q=true; STEP_29P_COMPLETION_DOES_NOT_START_STEP_29R=true; offline_only=true; non_authorizing=true; runtime_process_started=false; scheduler_action_performed=false; venue_access_performed=false; credential_access_performed=false; trading_action_performed=false; progress_registry_closeout_status=pending_separate_closeout; FUTURES_ONLY=true; BITCOIN_DIRECTION_ALLOWED=false; LIVE_AUTHORIZED=false; ORDERS_ALLOWED=false; SCHEDULER_RUNTIME_ALLOWED=false` |
+| `DEPENDENCIES` | RUNBOOK_STEP_29O |
+| `REMAINING_GAPS` | `capital_risk_sizing_v1_offline_slice_implementation_pending;progress_registry_closeout_pending` |
+| `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29P_CAPITAL_RISK_SIZING_MATHEMATICS_V1_IMPLEMENTATION` |
+| `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
+| `RUNBOOK_STEP_29P_STARTED` | `true` |
+| `RUNBOOK_STEP_29P_IMPLEMENTATION_STARTED` | `false` |
+| `RUNBOOK_STEP_29P_IMPLEMENTED_SCOPE` | `none` |
+| `RUNBOOK_STEP_29P_COMPLETE` | `false` |
+| `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `false` |
+| `RUNBOOK_STEP_29P_SCOPE` | `capital_risk_sizing_v1` |
+| `RUNBOOK_STEP_29P_PROCESS_CLASSIFICATION` | `ACTIVE_PROGRESS` |
+| `RUNBOOK_STEP_29P_SCOPE_CLASSIFICATION` | `PROGRESS_REGISTRY_START_ONLY` |
+| `RUNBOOK_STEP_29P_CANONICAL_DEFINITION` | `CAPITAL_RISK_SIZING_MATHEMATICS` |
+| `RUNBOOK_STEP_29P_MINIMUM_SAFE_SLICE` | `capital_risk_sizing_v1_offline_slice` |
+| `CAPITAL_RISK_SIZING_MATHEMATICS_CHANGED` | `false` |
+| `CANONICAL_ORDER_INTENT_DEFINED` | `false` |
+| `RUNTIME_REWIRE_PERFORMED` | `false` |
+| `NEXT_RUNBOOK_STEP` | `RUNBOOK_STEP_29P` |
+| `SEPARATE_GO_REQUIRED_FOR_RUNTIME_OR_EXECUTION_EFFECT` | `true` |
+| `SEPARATE_GO_REQUIRED_FOR_OFFLINE_CANONICAL_IMPLEMENTATION` | `false` |
+| `RUNTIME_EFFECT` | `false` |
+| `ORDER_EFFECT` | `false` |
+| `RISK_SIZING_EFFECT` | `false` |
+| `DEPLOYMENT_EFFECT` | `false` |
+| `AUTHORITY_EFFECT` | `false` |
+| `LIVE_AUTHORIZED` | `false` |
+| `FUTURES_ONLY` | `true` |
+| `BITCOIN_DIRECTION_ALLOWED` | `false` |
+| `THRESHOLD_TUNING_ALLOWED` | `false` |
+| `ECONOMIC_VALIDITY_PROVEN` | `false` |
+| `PROFITABILITY_CLAIM_ALLOWED` | `false` |
+| `PROMOTION_CANDIDATE_ELIGIBLE` | `false` |
+| `TECHNICAL_PROMOTION_GATE_STACK_COMPLETE` | `true` |
+| `INTENT_COMPATIBILITY_FIREWALL_IMPLEMENTED` | `true` |
+| `STEP_29P_QUANTITY_CHAIN` | `canonical_trading_decision,scope_capital_envelope,pre_sizing_risk,canonical_position_sizing,post_sizing_risk,quantity_provenance` |
+| `STEP_29P_RISK_ONLY_LIMITS_OR_REJECTS` | `true` |
+| `STEP_29P_SIZING_DOES_NOT_SELECT_DIRECTION` | `true` |
+| `STEP_29P_ROUNDING_NEVER_INCREASES_RISK` | `true` |
+| `STEP_29P_REQUIRES_FULL_QUANTITY_PROVENANCE` | `true` |
+| `STEP_29P_EXCLUDES_ADAPTER_COMPATIBILITY` | `true` |
+| `STEP_29P_EXCLUDES_ORDER_SUBMISSION` | `true` |
+| `STEP_29P_NO_IMPLICIT_DEFAULT_CAPITAL` | `true` |
+| `STEP_29P_RESPECTS_CANONICAL_LIMITS` | `true` |
+| `STEP_29P_SINGLE_SELECTED_FUTURE` | `true` |
+| `STEP_29P_MAX_POSITIONS` | `1` |
+| `STEP_29P_MAX_ACTIVE_DIRECTIONAL_SIDE` | `1` |
+| `STEP_29P_NO_SIMULTANEOUS_LONG_SHORT` | `true` |
+| `STEP_29P_EXCLUDES_CANONICAL_ORDER_INTENT_29Q` | `true` |
+| `STEP_29P_EXCLUDES_RUNTIME_REWIRE_29R` | `true` |
+| `STEP_29P_DOES_NOT_CREATE_ORDERS` | `true` |
+| `STEP_29P_DOES_NOT_GRANT_AUTHORITY` | `true` |
 | `offline_only` | `true` |
 | `non_authorizing` | `true` |
 | `SEPARATE_GO_REQUIRED` | `true` |

--- a/tests/ops/test_runbook_step29o_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29o_progress_registry_closeout_contract_v0.py
@@ -28,7 +28,7 @@ def _field_value(text: str, field: str) -> str:
 
 def _step_29o_section(text: str) -> str:
     start = text.index("#### RUNBOOK_STEP_29O — Intent Compatibility Firewall v1")
-    end = text.index("\n---\n\n## PR #4629 Evidence-Drift", start)
+    end = text.index("#### RUNBOOK_STEP_29P — Capital Risk Sizing Mathematics v1", start)
     return re.sub(r"\s<!--.*?-->", "", text[start:end])
 
 
@@ -125,15 +125,19 @@ def test_no_economic_validity_or_promotion_eligibility_claims() -> None:
     assert _field_value(section, "PROMOTION_CANDIDATE_ELIGIBLE") == "false"
 
 
-def test_no_step_29p_29q_29r_start_markers() -> None:
+def test_step_29p_not_started_in_29o_section_snapshot() -> None:
+    section = _step_29o_section(_read_registry())
+    assert _field_value(section, "STEP_29O_COMPLETION_DOES_NOT_START_STEP_29P") == "true"
+    assert "RUNBOOK_STEP_29P_IMPLEMENTED" not in section
+    assert "RUNBOOK_STEP_29P_COMPLETE" not in section
+
+
+def test_no_step_29q_29r_start_markers() -> None:
     text = _read_registry()
-    assert "RUNBOOK_STEP_29P_STARTED" not in text
     assert "RUNBOOK_STEP_29Q_STARTED" not in text
     assert "RUNBOOK_STEP_29R_STARTED" not in text
-    assert "STEP_29P_STARTED" not in text
     assert "STEP_29Q_STARTED" not in text
     assert "STEP_29R_STARTED" not in text
-    assert "#### RUNBOOK_STEP_29P" not in text
     assert "#### RUNBOOK_STEP_29Q" not in text
     assert "#### RUNBOOK_STEP_29R" not in text
 

--- a/tests/ops/test_runbook_step29p_progress_registry_start_contract_v0.py
+++ b/tests/ops/test_runbook_step29p_progress_registry_start_contract_v0.py
@@ -1,0 +1,216 @@
+"""Contract tests for RUNBOOK STEP 29P progress registry start v0.
+
+Verifies registry-start-only semantics for Capital Risk Sizing Mathematics without
+authorizing runtime, orders, authority, fachliche implementation, or STEP 29Q/29R.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROGRESS_REGISTRY = REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+
+STEP_29P_MINIMUM_SAFE_SLICE = "capital_risk_sizing_v1_offline_slice"
+STEP_29P_CANONICAL_DEFINITION = "CAPITAL_RISK_SIZING_MATHEMATICS"
+STEP_29P_CANONICAL_OWNER = "src&#47;governance&#47;capital_risk_sizing_v1.py"
+NEXT_REQUIRED_CONTRACT = "RUNBOOK_STEP_29P_CAPITAL_RISK_SIZING_MATHEMATICS_V1_IMPLEMENTATION"
+STEP_29P_QUANTITY_CHAIN = (
+    "canonical_trading_decision,scope_capital_envelope,pre_sizing_risk,"
+    "canonical_position_sizing,post_sizing_risk,quantity_provenance"
+)
+
+
+def _read_registry() -> str:
+    assert PROGRESS_REGISTRY.is_file(), f"missing canonical registry: {PROGRESS_REGISTRY}"
+    return PROGRESS_REGISTRY.read_text(encoding="utf-8")
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(rf"\| `{re.escape(field)}` \| `([^`]*)` \|", text)
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _step_29p_section(text: str) -> str:
+    start = text.index("#### RUNBOOK_STEP_29P — Capital Risk Sizing Mathematics v1")
+    end = text.index("\n---\n\n## PR #4629 Evidence-Drift", start)
+    return re.sub(r"\s<!--.*?-->", "", text[start:end])
+
+
+def test_progress_registry_is_canonical_single_ssot() -> None:
+    text = _read_registry()
+    assert text.count("STATUS: CANONICAL_RUNBOOK_PROGRESS_REGISTRY") == 1
+
+
+def test_exactly_one_step_29p_registry_start_section() -> None:
+    text = _read_registry()
+    assert text.count("#### RUNBOOK_STEP_29P — Capital Risk Sizing Mathematics v1") == 1
+
+
+def test_runbook_step_29p_started_true() -> None:
+    text = _read_registry()
+    section = _step_29p_section(text)
+    assert _field_value(text, "RUNBOOK_STEP_29P_STARTED") == "true"
+    assert _field_value(text, "STEP_29P_STARTED") == "true"
+    assert _field_value(section, "RUNBOOK_STEP_29P_STARTED") == "true"
+
+
+def test_runbook_step_29p_implementation_not_started() -> None:
+    text = _read_registry()
+    section = _step_29p_section(text)
+    assert _field_value(text, "RUNBOOK_STEP_29P_IMPLEMENTATION_STARTED") == "false"
+    assert _field_value(section, "RUNBOOK_STEP_29P_IMPLEMENTATION_STARTED") == "false"
+
+
+def test_runbook_step_29p_not_complete() -> None:
+    text = _read_registry()
+    section = _step_29p_section(text)
+    assert _field_value(text, "RUNBOOK_STEP_29P_COMPLETE") == "false"
+    assert _field_value(section, "RUNBOOK_STEP_29P_COMPLETE") == "false"
+
+
+def test_progress_registry_closeout_not_performed_for_step_29p() -> None:
+    section = _step_29p_section(_read_registry())
+    assert _field_value(section, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "false"
+
+
+def test_runbook_step_29p_canonical_definition() -> None:
+    section = _step_29p_section(_read_registry())
+    assert (
+        _field_value(section, "RUNBOOK_STEP_29P_CANONICAL_DEFINITION")
+        == STEP_29P_CANONICAL_DEFINITION
+    )
+
+
+def test_runbook_step_29p_canonical_owner_explicit_proposed_state() -> None:
+    section = _step_29p_section(_read_registry())
+    assert _field_value(section, "CANONICAL_OWNER") == STEP_29P_CANONICAL_OWNER
+    assert _field_value(section, "CANONICAL_OWNER_STATUS") == "PROPOSED_PENDING_IMPLEMENTATION"
+    assert _field_value(section, "CANONICAL_OWNER_RATIFIED") == "false"
+
+
+def test_step_29p_section_has_no_tbd_placeholders() -> None:
+    section = _step_29p_section(_read_registry()).upper()
+    assert "TBD" not in section
+    assert "TBC" not in section
+    assert "| `CANONICAL_OWNER` | TBD" not in section
+
+
+def test_runbook_step_29p_minimum_safe_slice() -> None:
+    section = _step_29p_section(_read_registry())
+    assert (
+        _field_value(section, "RUNBOOK_STEP_29P_MINIMUM_SAFE_SLICE") == STEP_29P_MINIMUM_SAFE_SLICE
+    )
+
+
+def test_capital_risk_sizing_mathematics_not_changed() -> None:
+    text = _read_registry()
+    section = _step_29p_section(text)
+    assert _field_value(text, "CAPITAL_RISK_SIZING_MATHEMATICS_CHANGED") == "false"
+    assert _field_value(section, "CAPITAL_RISK_SIZING_MATHEMATICS_CHANGED") == "false"
+
+
+def test_canonical_order_intent_not_defined() -> None:
+    section = _step_29p_section(_read_registry())
+    assert _field_value(section, "CANONICAL_ORDER_INTENT_DEFINED") == "false"
+
+
+def test_runtime_rewire_not_performed() -> None:
+    section = _step_29p_section(_read_registry())
+    assert _field_value(section, "RUNTIME_REWIRE_PERFORMED") == "false"
+
+
+def test_next_required_contract_is_implementation_slice() -> None:
+    text = _read_registry()
+    section = _step_29p_section(text)
+    assert _field_value(section, "NEXT_REQUIRED_CONTRACT") == NEXT_REQUIRED_CONTRACT
+
+
+def test_next_runbook_step_remains_29p() -> None:
+    text = _read_registry()
+    section = _step_29p_section(text)
+    assert _field_value(text, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29P"
+    assert _field_value(section, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29P"
+
+
+def test_quantity_chain_boundaries_declared() -> None:
+    section = _step_29p_section(_read_registry())
+    assert _field_value(section, "STEP_29P_QUANTITY_CHAIN") == STEP_29P_QUANTITY_CHAIN
+
+
+def test_step_29p_target_invariants_bound() -> None:
+    section = _step_29p_section(_read_registry())
+    assert _field_value(section, "STEP_29P_RISK_ONLY_LIMITS_OR_REJECTS") == "true"
+    assert _field_value(section, "STEP_29P_SIZING_DOES_NOT_SELECT_DIRECTION") == "true"
+    assert _field_value(section, "STEP_29P_ROUNDING_NEVER_INCREASES_RISK") == "true"
+    assert _field_value(section, "STEP_29P_REQUIRES_FULL_QUANTITY_PROVENANCE") == "true"
+    assert _field_value(section, "STEP_29P_NO_IMPLICIT_DEFAULT_CAPITAL") == "true"
+    assert _field_value(section, "STEP_29P_RESPECTS_CANONICAL_LIMITS") == "true"
+    assert _field_value(section, "STEP_29P_SINGLE_SELECTED_FUTURE") == "true"
+    assert _field_value(section, "STEP_29P_MAX_POSITIONS") == "1"
+    assert _field_value(section, "STEP_29P_MAX_ACTIVE_DIRECTIONAL_SIDE") == "1"
+    assert _field_value(section, "STEP_29P_NO_SIMULTANEOUS_LONG_SHORT") == "true"
+
+
+def test_no_runtime_order_risk_sizing_or_authority_effects() -> None:
+    section = _step_29p_section(_read_registry())
+    assert _field_value(section, "RUNTIME_EFFECT") == "false"
+    assert _field_value(section, "ORDER_EFFECT") == "false"
+    assert _field_value(section, "RISK_SIZING_EFFECT") == "false"
+    assert _field_value(section, "AUTHORITY_EFFECT") == "false"
+
+
+def test_futures_only_and_bitcoin_direction_forbidden() -> None:
+    section = _step_29p_section(_read_registry())
+    assert _field_value(section, "FUTURES_ONLY") == "true"
+    assert _field_value(section, "BITCOIN_DIRECTION_ALLOWED") == "false"
+
+
+def test_threshold_tuning_not_allowed() -> None:
+    section = _step_29p_section(_read_registry())
+    assert _field_value(section, "THRESHOLD_TUNING_ALLOWED") == "false"
+
+
+def test_no_economic_validity_or_promotion_eligibility_claims() -> None:
+    section = _step_29p_section(_read_registry())
+    assert _field_value(section, "ECONOMIC_VALIDITY_PROVEN") == "false"
+    assert _field_value(section, "PROFITABILITY_CLAIM_ALLOWED") == "false"
+    assert _field_value(section, "PROMOTION_CANDIDATE_ELIGIBLE") == "false"
+
+
+def test_no_step_29q_29r_start_markers() -> None:
+    text = _read_registry()
+    assert "RUNBOOK_STEP_29Q_STARTED" not in text
+    assert "RUNBOOK_STEP_29R_STARTED" not in text
+    assert "STEP_29Q_STARTED" not in text
+    assert "STEP_29R_STARTED" not in text
+    assert "#### RUNBOOK_STEP_29Q" not in text
+    assert "#### RUNBOOK_STEP_29R" not in text
+
+
+def test_scope_classification_registry_start_only() -> None:
+    section = _step_29p_section(_read_registry())
+    assert (
+        _field_value(section, "RUNBOOK_STEP_29P_SCOPE_CLASSIFICATION")
+        == "PROGRESS_REGISTRY_START_ONLY"
+    )
+    assert _field_value(section, "RUNBOOK_STEP_29P_IMPLEMENTED_SCOPE") == "none"
+    assert _field_value(section, "STATUS") == "IN_PROGRESS"
+
+
+def test_step_29o_complete_preserved() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29O_COMPLETE") == "true"
+    assert _field_value(text, "INTENT_COMPATIBILITY_FIREWALL_IMPLEMENTED") == "true"
+
+
+def test_no_runtime_deployment_adapter_or_order_authority() -> None:
+    section = _step_29p_section(_read_registry())
+    assert _field_value(section, "LIVE_AUTHORIZED") == "false"
+    assert _field_value(section, "DEPLOYMENT_EFFECT") == "false"
+    assert _field_value(section, "STEP_29P_DOES_NOT_CREATE_ORDERS") == "true"
+    assert _field_value(section, "STEP_29P_DOES_NOT_GRANT_AUTHORITY") == "true"
+    assert _field_value(section, "STEP_29P_EXCLUDES_ADAPTER_COMPATIBILITY") == "true"
+    assert _field_value(section, "STEP_29P_EXCLUDES_ORDER_SUBMISSION") == "true"


### PR DESCRIPTION
## Summary
- Start RUNBOOK STEP 29P (Capital Risk Sizing Mathematics v1) in the canonical progress registry with `PROGRESS_REGISTRY_START_ONLY` semantics.
- Bind quantity-chain target invariants and `NEXT_REQUIRED_CONTRACT=RUNBOOK_STEP_29P_CAPITAL_RISK_SIZING_MATHEMATICS_V1_IMPLEMENTATION` without fachliche implementation.
- Add fail-closed STEP 29P registry-start contract tests; minimally adjust STEP 29O closeout regression for post-29P-start snapshot boundaries.

## Scope boundary
Registry-start only — no capital allocation, risk math, sizing formulas, quantity computation, adapter compatibility, or runtime effect.

## Test plan
- [x] `pytest tests/ops/test_runbook_step29p_progress_registry_start_contract_v0.py`
- [x] `pytest tests/ops/test_runbook_step29o_progress_registry_closeout_contract_v0.py`
- [x] `pytest tests/ops/test_runbook_step29n_progress_registry_closeout_contract_v0.py`
- [x] `ruff format --check` / `ruff check` on changed Python
- [x] CI selector: `NO_OP` (docs + static contract tests only)


Made with [Cursor](https://cursor.com)