### PR TITLE
fix(ops): STEP-29O closeout contract 29Q transition compatibility

### DIFF
--- a/tests/ops/test_runbook_step29o_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29o_progress_registry_closeout_contract_v0.py
@@ -130,14 +130,32 @@ def test_step_29p_not_started_in_29o_section_snapshot() -> None:
     assert "RUNBOOK_STEP_29P_COMPLETE" not in section
 
 
-def test_no_step_29q_29r_start_markers() -> None:
+def test_step_29q_legitimately_started_global_transition() -> None:
     text = _read_registry()
-    assert "RUNBOOK_STEP_29Q_STARTED" not in text
+    assert _field_value(text, "RUNBOOK_STEP_29Q_STARTED") == "true"
+    assert _field_value(text, "STEP_29Q_STARTED") == "true"
+    assert _field_value(text, "RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED") == "false"
+    assert _field_value(text, "RUNBOOK_STEP_29Q_COMPLETE") == "false"
+    assert _field_value(text, "CANONICAL_ORDER_INTENT_IMPLEMENTED") == "false"
+    assert _field_value(text, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29Q"
+    assert "#### RUNBOOK_STEP_29Q" in text
+
+
+def test_step_29q_not_started_in_29o_section_snapshot() -> None:
+    section = _step_29o_section(_read_registry())
+    assert _field_value(section, "STEP_29O_EXCLUDES_CANONICAL_ORDER_INTENT_29Q") == "true"
+    assert "RUNBOOK_STEP_29Q_STARTED" not in section
+    assert "RUNBOOK_STEP_29Q_COMPLETE" not in section
+
+
+def test_no_step_29r_start_markers() -> None:
+    text = _read_registry()
+    section = _step_29o_section(text)
     assert "RUNBOOK_STEP_29R_STARTED" not in text
-    assert "STEP_29Q_STARTED" not in text
     assert "STEP_29R_STARTED" not in text
-    assert "#### RUNBOOK_STEP_29Q" not in text
     assert "#### RUNBOOK_STEP_29R" not in text
+    assert _field_value(section, "RUNTIME_REWIRE_PERFORMED") == "false"
+    assert _field_value(section, "STEP_29O_EXCLUDES_RUNTIME_REWIRE_29R") == "true"
 
 
 def test_capital_risk_sizing_mathematics_unchanged() -> None:


### PR DESCRIPTION
## Summary

- Nach Merge von PR #4716 (STEP 29Q Registry-Start) war die kombinierte Invariante `test_no_step_29q_29r_start_markers` im STEP-29O-Closeout-Contract veraltet.
- Ersetzt durch getrennte Assertions: globale 29Q-Start-Wahrheit, historischer 29O-Section-Snapshot (29Q nicht in 29O-Section), 29R weiterhin nicht gestartet.
- Keine Registry-, `src/`- oder Implementierungsänderung.

## Root Cause

`test_no_step_29q_29r_start_markers` erwartete fälschlich weiterhin globale Abwesenheit von `RUNBOOK_STEP_29Q_STARTED`, obwohl STEP 29Q nach PR #4716 kanonisch gestartet ist.

## Test plan

- [x] `pytest -q tests/ops/test_runbook_step29o_progress_registry_closeout_contract_v0.py` — 22 passed
- [x] `pytest -q tests/ops/test_runbook_step29p_progress_registry_closeout_contract_v0.py` — 20 passed
- [x] `pytest -q tests/ops/test_runbook_step29q_progress_registry_start_contract_v0.py` — 27 passed
- [x] `ruff format --check` / `ruff check` / `git diff --check` — PASS
- [x] CI selector: `NO_OP` (`docs_workflow_or_static_contract_only`)


Made with [Cursor](https://cursor.com)