### PR TITLE
RUNBOOK STEP 29Q: implement offline canonical order intent v1

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -135,11 +135,12 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `CAPITAL_RISK_SIZING_MATHEMATICS_IMPLEMENTED` | `true` |
 | `CAPITAL_RISK_SIZING_MATHEMATICS_CHANGED` | `false` |
 | `RUNBOOK_STEP_29Q_STARTED` | `true` |
-| `RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED` | `false` |
-| `RUNBOOK_STEP_29Q_IMPLEMENTED_SCOPE` | `none` |
+| `RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED` | `true` |
+| `RUNBOOK_STEP_29Q_IMPLEMENTED_SCOPE` | `canonical_order_intent_v1_offline_slice` |
+| `RUNBOOK_STEP_29Q_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29Q_COMPLETE` | `false` |
 | `STEP_29Q_STARTED` | `true` |
-| `CANONICAL_ORDER_INTENT_IMPLEMENTED` | `false` |
+| `CANONICAL_ORDER_INTENT_IMPLEMENTED` | `true` |
 | `CANONICAL_ORDER_INTENT_ADAPTER_COMPATIBILITY_PROVEN` | `false` |
 | `CANONICAL_ORDER_INTENT_TRANSFORMATION_BOUND` | `false` |
 | `PROMOTION_ECONOMIC_GATE_BINDING_STATUS` | `PASS` |
@@ -1316,27 +1317,28 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `RUNBOOK_STEP_ID` | `canonical_order_intent_v1` |
 | `STATUS` | `IN_PROGRESS` |
 | `CANONICAL_OWNER` | `src&#47;governance&#47;canonical_order_intent_v1.py` <!-- pt:ref-target-ignore --> |
-| `CANONICAL_OWNER_STATUS` | `PROPOSED_PENDING_IMPLEMENTATION` |
-| `CANONICAL_OWNER_RATIFIED` | `false` |
+| `CANONICAL_OWNER_STATUS` | `IMPLEMENTED` |
+| `CANONICAL_OWNER_RATIFIED` | `true` |
 | `MERGED_PRS` | `none` |
 | `MERGE_COMMITS` | `none` |
-| `DURABLE_EVIDENCE_REFS` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29p_capital_risk_sizing_progress_registry_closeout_pr_squash_merge_closeout_v0_20260701T033637Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning_or_validation/runbook_step29o_intent_compatibility_firewall_read_only_scope_audit_v0_20260701T141500Z/STEP_BOUNDARY_29O_29P_29Q_29R.md (MANIFEST_VERIFY_RC=0); audit_verdict=RUNBOOK_STEP_29O_READ_ONLY_SCOPE_AUDIT_PASS; minimum_safe_slice=canonical_order_intent_v1_offline_slice; STEP_29Q_REGISTRY_START_ONLY=true; STEP_29Q_IMPLEMENTATION_STARTED=false; STEP_29Q_COMPLETION_DOES_NOT_AUTHORIZE_LIVE=true; STEP_29Q_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME=true; STEP_29Q_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS=true; STEP_29Q_COMPLETION_DOES_NOT_START_STEP_29R=true; offline_only=true; non_authorizing=true; runtime_process_started=false; scheduler_action_performed=false; venue_access_performed=false; credential_access_performed=false; trading_action_performed=false; progress_registry_closeout_status=pending_separate_closeout; FUTURES_ONLY=true; BITCOIN_DIRECTION_ALLOWED=false; LIVE_AUTHORIZED=false; ORDERS_ALLOWED=false; SCHEDULER_RUNTIME_ALLOWED=false` |
+| `DURABLE_EVIDENCE_REFS` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29p_capital_risk_sizing_progress_registry_closeout_pr_squash_merge_closeout_v0_20260701T033637Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning_or_validation/runbook_step29o_intent_compatibility_firewall_read_only_scope_audit_v0_20260701T141500Z/STEP_BOUNDARY_29O_29P_29Q_29R.md (MANIFEST_VERIFY_RC=0); audit_verdict=RUNBOOK_STEP_29O_READ_ONLY_SCOPE_AUDIT_PASS; minimum_safe_slice=canonical_order_intent_v1_offline_slice; STEP_29Q_IMPLEMENTATION_STARTED=true; STEP_29Q_IMPLEMENTED_SCOPE=canonical_order_intent_v1_offline_slice; CANONICAL_ORDER_INTENT_IMPLEMENTED=true; STEP_29Q_COMPLETION_DOES_NOT_AUTHORIZE_LIVE=true; STEP_29Q_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME=true; STEP_29Q_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS=true; STEP_29Q_COMPLETION_DOES_NOT_START_STEP_29R=true; offline_only=true; non_authorizing=true; runtime_process_started=false; scheduler_action_performed=false; venue_access_performed=false; credential_access_performed=false; trading_action_performed=false; progress_registry_closeout_status=pending_separate_closeout; FUTURES_ONLY=true; BITCOIN_DIRECTION_ALLOWED=false; LIVE_AUTHORIZED=false; ORDERS_ALLOWED=false; SCHEDULER_RUNTIME_ALLOWED=false` |
 | `DEPENDENCIES` | RUNBOOK_STEP_29P |
-| `REMAINING_GAPS` | `canonical_order_intent_v1_implementation_pending;progress_registry_closeout_pending` |
-| `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29Q_CANONICAL_ORDER_INTENT_V1_IMPLEMENTATION` |
+| `REMAINING_GAPS` | `progress_registry_closeout_pending` |
+| `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29Q_PROGRESS_REGISTRY_CLOSEOUT` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNBOOK_STEP_29Q_STARTED` | `true` |
-| `RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED` | `false` |
-| `RUNBOOK_STEP_29Q_IMPLEMENTED_SCOPE` | `none` |
+| `RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED` | `true` |
+| `RUNBOOK_STEP_29Q_IMPLEMENTED_SCOPE` | `canonical_order_intent_v1_offline_slice` |
+| `RUNBOOK_STEP_29Q_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29Q_COMPLETE` | `false` |
 | `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `false` |
 | `RUNBOOK_STEP_29Q_SCOPE` | `canonical_order_intent_v1` |
 | `RUNBOOK_STEP_29Q_PROCESS_CLASSIFICATION` | `ACTIVE_PROGRESS` |
-| `RUNBOOK_STEP_29Q_SCOPE_CLASSIFICATION` | `PROGRESS_REGISTRY_START_ONLY` |
+| `RUNBOOK_STEP_29Q_SCOPE_CLASSIFICATION` | `CANONICAL_ORDER_INTENT_V1_OFFLINE_SLICE` |
 | `RUNBOOK_STEP_29Q_CANONICAL_DEFINITION` | `CANONICAL_ORDER_INTENT` |
 | `RUNBOOK_STEP_29Q_MINIMUM_SAFE_SLICE` | `canonical_order_intent_v1_offline_slice` |
-| `CANONICAL_ORDER_INTENT_IMPLEMENTED` | `false` |
-| `CANONICAL_ORDER_INTENT_DEFINED` | `false` |
+| `CANONICAL_ORDER_INTENT_IMPLEMENTED` | `true` |
+| `CANONICAL_ORDER_INTENT_DEFINED` | `true` |
 | `CANONICAL_ORDER_INTENT_ADAPTER_COMPATIBILITY_PROVEN` | `false` |
 | `CANONICAL_ORDER_INTENT_TRANSFORMATION_BOUND` | `false` |
 | `CAPITAL_RISK_SIZING_MATHEMATICS_IMPLEMENTED` | `true` |
@@ -1368,7 +1370,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `STEP_29Q_REFERENCES_ORDER_INTENT_IDEMPOTENCY_V1` | `true` |
 | `STEP_29Q_REFERENCES_CANONICAL_ORDER_LIFECYCLE_V1` | `true` |
 | `STEP_29Q_REFERENCES_TRADING_CORE_DECISION_ATTESTATION_V1` | `true` |
-| `STEP_29Q_DOES_NOT_IMPLEMENT_ORDER_INTENT` | `true` |
+| `STEP_29Q_DOES_NOT_IMPLEMENT_ORDER_INTENT` | `false` |
 | `STEP_29Q_DOES_NOT_IMPLEMENT_ADAPTER_TRANSFORMATION` | `true` |
 | `STEP_29Q_DOES_NOT_CLAIM_ADAPTER_COMPATIBILITY` | `true` |
 | `STEP_29Q_DOES_NOT_CHANGE_QUANTITY_RISK_SIZING_SEMANTICS` | `true` |

--- a/src/governance/canonical_order_intent_v1.py
+++ b/src/governance/canonical_order_intent_v1.py
@@ -1,0 +1,779 @@
+"""
+Offline Canonical Order Intent v1 (RUNBOOK STEP 29Q).
+
+Pure, deterministic, fail-closed venue-neutral order intent contract built from
+validated STEP-29P capital/risk/sizing output. No adapter compatibility,
+submission, runtime authority, or venue effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, fields, replace
+from decimal import Decimal
+from enum import Enum
+from typing import Any, Mapping, Optional, Type
+
+from src.governance.capital_risk_sizing_v1 import (
+    AUTHORITY_EFFECT_NONE as SIZING_AUTHORITY_EFFECT_NONE,
+)
+from src.governance.capital_risk_sizing_v1 import (
+    CapitalRiskSizingDecisionV1,
+    CapitalRiskSizingInputV1,
+    CapitalRiskSizingOutcome,
+    SelectedSide,
+)
+
+CONTRACT_NAME = "canonical_order_intent_v1"
+CONTRACT_VERSION = "v1"
+SCHEMA_VERSION = "canonical_order_intent_schema_v1"
+IMPLEMENTATION_DIGEST = "canonical_order_intent_v1_offline_slice"
+DETERMINISTIC_SERIALIZATION_VERSION = "canonical_order_intent_deterministic_serialization_v1"
+INTENT_VERSION = "canonical_order_intent_v1"
+
+PACKAGE_MARKER = "CANONICAL_ORDER_INTENT_V1=true"
+FUTURES_ONLY = True
+BITCOIN_DIRECTION_ALLOWED = False
+SPOT_ALLOWED = False
+SYNTHETIC_SPOT_ALLOWED = False
+
+AUTHORITY_EFFECT_NONE = "NONE"
+RUNTIME_EFFECT_NONE = "NONE"
+NETWORK_EFFECT_NONE = "NONE"
+CREDENTIAL_EFFECT_NONE = "NONE"
+
+_FORBIDDEN_INSTRUMENT_MARKERS = frozenset({"btc", "xbt", "bitcoin"})
+_FORBIDDEN_MARKET_TYPES = frozenset({"spot", "synthetic_spot", "synthetic-spot"})
+_FORBIDDEN_ADAPTER_TYPE_NAMES = frozenset(
+    {
+        "OrderIntent",
+        "OrderRequest",
+        "Order",
+        "AdapterRequest",
+        "VenuePayload",
+        "ExecutionIntent",
+    }
+)
+
+REASON_PASS = "PASS"
+REASON_MISSING_QUANTITY_PROVENANCE = "MISSING_QUANTITY_PROVENANCE"
+REASON_INVALID_QUANTITY = "INVALID_QUANTITY"
+REASON_SIZING_NOT_PASS = "SIZING_NOT_PASS"
+REASON_MISSING_DECISION_REF = "MISSING_DECISION_REF"
+REASON_MISSING_CAPITAL_ENVELOPE_REF = "MISSING_CAPITAL_ENVELOPE_REF"
+REASON_MISSING_PRE_SIZING_RISK_REF = "MISSING_PRE_SIZING_RISK_REF"
+REASON_MISSING_SIZING_RESULT_REF = "MISSING_SIZING_RESULT_REF"
+REASON_MISSING_POST_SIZING_RISK_REF = "MISSING_POST_SIZING_RISK_REF"
+REASON_INVALID_SIDE_ACTION_COMBINATION = "INVALID_SIDE_ACTION_COMBINATION"
+REASON_EXIT_WITHOUT_REDUCE_ONLY = "EXIT_WITHOUT_REDUCE_ONLY"
+REASON_REDUCE_EXPOSURE_INCREASE = "REDUCE_EXPOSURE_INCREASE"
+REASON_ENTER_LONG_WRONG_POSITION_EFFECT = "ENTER_LONG_WRONG_POSITION_EFFECT"
+REASON_ENTER_SHORT_WRONG_POSITION_EFFECT = "ENTER_SHORT_WRONG_POSITION_EFFECT"
+REASON_IMPLICIT_REVERSAL = "IMPLICIT_REVERSAL"
+REASON_NON_FUTURES_INSTRUMENT = "NON_FUTURES_INSTRUMENT"
+REASON_BITCOIN_SPECIFIC_DIRECTION = "BITCOIN_SPECIFIC_DIRECTION"
+REASON_INVALID_DIGEST = "INVALID_DIGEST"
+REASON_NO_ACTION_NOT_SUBMITTABLE = "NO_ACTION_NOT_SUBMITTABLE"
+REASON_DEFAULT_QUANTITY_FORBIDDEN = "DEFAULT_QUANTITY_FORBIDDEN"
+REASON_ADAPTER_CAST_FORBIDDEN = "ADAPTER_CAST_FORBIDDEN"
+REASON_DIRECT_SUBMISSION_FORBIDDEN = "DIRECT_SUBMISSION_FORBIDDEN"
+REASON_TRANSFORMATION_REQUIRED = "TRANSFORMATION_REQUIRED"
+REASON_VENUE_FIELD_IN_CANONICAL = "VENUE_FIELD_IN_CANONICAL"
+REASON_MUTABLE_INTENT = "MUTABLE_INTENT"
+REASON_MISSING_PROVENANCE = "MISSING_PROVENANCE"
+
+
+class IntentAction(str, Enum):
+    ENTER_LONG = "ENTER_LONG"
+    ENTER_SHORT = "ENTER_SHORT"
+    REDUCE = "REDUCE"
+    EXIT = "EXIT"
+    NO_ACTION = "NO_ACTION"
+
+
+class PositionEffect(str, Enum):
+    OPEN_OR_INCREASE = "OPEN_OR_INCREASE"
+    REDUCE_ONLY = "REDUCE_ONLY"
+    CLOSE_ONLY = "CLOSE_ONLY"
+
+
+class IntentSide(str, Enum):
+    LONG = "LONG"
+    SHORT = "SHORT"
+
+
+class ValidationStatus(str, Enum):
+    VALID = "VALID"
+    INVALID = "INVALID"
+
+
+class CanonicalOrderIntentBuildOutcome(str, Enum):
+    PASS = "PASS"
+    BLOCKED = "BLOCKED"
+
+
+@dataclass(frozen=True)
+class CanonicalOrderIntentBuildInputV1:
+    sizing_input: CapitalRiskSizingInputV1
+    sizing_decision: CapitalRiskSizingDecisionV1
+    intent_id: str
+    trading_epoch: str
+    canonical_trading_logic_version: str
+    intent_action: str
+    policy_digest: str
+    order_type_policy: str
+    price_policy: str
+    time_in_force_policy: str
+    max_slippage_policy: str
+    expected_position_side: str
+    current_reconciled_exposure: Decimal
+    current_open_side: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CanonicalOrderIntentV1:
+    intent_id: str
+    intent_version: str
+    decision_id: str
+    instrument_id: str
+    trading_epoch: str
+    canonical_trading_logic_version: str
+    capital_envelope_ref: str
+    pre_sizing_risk_ref: str
+    sizing_result_ref: str
+    post_sizing_risk_ref: str
+    policy_digest: str
+    config_digest: str
+    implementation_digest: str
+    provenance_digest: str
+    side: str
+    intent_action: str
+    quantity: Decimal
+    quantity_unit: str
+    quantity_provenance: str
+    reduce_only: bool
+    position_effect: str
+    order_type_policy: str
+    price_policy: str
+    time_in_force_policy: str
+    max_slippage_policy: str
+    expected_position_side: str
+    instrument_metadata_ref: str
+    execution_eligible: bool = False
+    adapter_compatible: bool = False
+    submission_authorized: bool = False
+    runtime_effect: str = RUNTIME_EFFECT_NONE
+    authority_effect: str = AUTHORITY_EFFECT_NONE
+    network_effect: str = NETWORK_EFFECT_NONE
+    credential_effect: str = CREDENTIAL_EFFECT_NONE
+    transformation_required: bool = True
+    validation_status: str = ValidationStatus.VALID.value
+    reason_codes: tuple[str, ...] = (REASON_PASS,)
+    semantic_digest: str = ""
+    deterministic_serialization_version: str = DETERMINISTIC_SERIALIZATION_VERSION
+
+
+@dataclass(frozen=True)
+class CanonicalOrderIntentBuildResultV1:
+    outcome: CanonicalOrderIntentBuildOutcome
+    intent: Optional[CanonicalOrderIntentV1]
+    reason_codes: tuple[str, ...]
+    execution_eligible: bool = False
+    adapter_compatible: bool = False
+    submission_authorized: bool = False
+    runtime_effect: str = RUNTIME_EFFECT_NONE
+    authority_effect: str = AUTHORITY_EFFECT_NONE
+
+
+@dataclass(frozen=True)
+class AdapterCompatibilityFirewallResultV1:
+    admissible: bool
+    reason_codes: tuple[str, ...]
+    target_type_name: str
+
+
+class CanonicalOrderIntentError(ValueError):
+    """Fail-closed canonical order intent contract error."""
+
+
+def _sha256_hex(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _digest_ref(payload: Mapping[str, Any]) -> str:
+    return _sha256_hex(payload)
+
+
+def compute_capital_envelope_ref(decision: CapitalRiskSizingDecisionV1) -> str:
+    envelope = decision.capital_envelope
+    return _digest_ref(
+        {
+            "scope_capital_limit": str(envelope.scope_capital_limit),
+            "account_equity": str(envelope.account_equity),
+            "total_capital_limit": str(envelope.total_capital_limit),
+            "within_envelope": envelope.within_envelope,
+        }
+    )
+
+
+def compute_pre_sizing_risk_ref(decision: CapitalRiskSizingDecisionV1) -> str:
+    pre = decision.pre_sizing_risk
+    return _digest_ref(
+        {
+            "outcome": pre.outcome.value,
+            "effective_trade_risk_budget": str(pre.effective_trade_risk_budget),
+            "effective_scope_capital_limit": str(pre.effective_scope_capital_limit),
+            "effective_total_capital_limit": str(pre.effective_total_capital_limit),
+        }
+    )
+
+
+def compute_sizing_result_ref(decision: CapitalRiskSizingDecisionV1) -> str:
+    provenance = decision.quantity_provenance
+    sizing = decision.canonical_sizing
+    if provenance is None or sizing is None:
+        return ""
+    return _digest_ref(
+        {
+            "final_quantity": str(provenance.final_quantity),
+            "binding_cap": provenance.binding_cap,
+            "output_digest": provenance.output_digest,
+            "candidate_quantity": str(sizing.candidate_quantity),
+            "binding_cap_kind": sizing.binding_cap.value,
+        }
+    )
+
+
+def compute_post_sizing_risk_ref(decision: CapitalRiskSizingDecisionV1) -> str:
+    post = decision.post_sizing_risk
+    if post is None:
+        return ""
+    return _digest_ref(
+        {
+            "outcome": post.outcome.value,
+            "projected_stop_loss": str(post.projected_stop_loss),
+            "projected_notional": str(post.projected_notional),
+            "projected_exposure": str(post.projected_exposure),
+        }
+    )
+
+
+def _derive_position_effect(intent_action: str) -> str:
+    if intent_action == IntentAction.ENTER_LONG.value:
+        return PositionEffect.OPEN_OR_INCREASE.value
+    if intent_action == IntentAction.ENTER_SHORT.value:
+        return PositionEffect.OPEN_OR_INCREASE.value
+    if intent_action == IntentAction.REDUCE.value:
+        return PositionEffect.REDUCE_ONLY.value
+    if intent_action == IntentAction.EXIT.value:
+        return PositionEffect.CLOSE_ONLY.value
+    return ""
+
+
+def _derive_reduce_only(intent_action: str) -> bool:
+    return intent_action in {
+        IntentAction.REDUCE.value,
+        IntentAction.EXIT.value,
+    }
+
+
+def _derive_side(intent_action: str, selected_side: str) -> str:
+    if intent_action == IntentAction.ENTER_LONG.value:
+        return IntentSide.LONG.value
+    if intent_action == IntentAction.ENTER_SHORT.value:
+        return IntentSide.SHORT.value
+    return selected_side
+
+
+def _blocked_result(reason_codes: tuple[str, ...]) -> CanonicalOrderIntentBuildResultV1:
+    return CanonicalOrderIntentBuildResultV1(
+        outcome=CanonicalOrderIntentBuildOutcome.BLOCKED,
+        intent=None,
+        reason_codes=reason_codes,
+    )
+
+
+def _validate_instrument_futures_only(inp: CapitalRiskSizingInputV1) -> tuple[str, ...]:
+    reasons: list[str] = []
+    instrument = inp.instrument
+    market_type = (instrument.market_type if instrument else "").lower()
+    if market_type in _FORBIDDEN_MARKET_TYPES or market_type != "futures":
+        reasons.append(REASON_NON_FUTURES_INSTRUMENT)
+    instrument_lower = inp.instrument_id.lower()
+    if any(marker in instrument_lower for marker in _FORBIDDEN_INSTRUMENT_MARKERS):
+        reasons.append(REASON_BITCOIN_SPECIFIC_DIRECTION)
+    return tuple(dict.fromkeys(reasons))
+
+
+def _validate_action_semantics(
+    *,
+    intent_action: str,
+    selected_side: str,
+    position_effect: str,
+    reduce_only: bool,
+    quantity: Decimal,
+    current_reconciled_exposure: Decimal,
+    current_open_side: Optional[str],
+    expected_position_side: str,
+    check_exposure: bool = True,
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+
+    if intent_action == IntentAction.NO_ACTION.value:
+        reasons.append(REASON_NO_ACTION_NOT_SUBMITTABLE)
+
+    side = _derive_side(intent_action, selected_side)
+
+    if intent_action == IntentAction.ENTER_LONG.value:
+        if side != IntentSide.LONG.value:
+            reasons.append(REASON_INVALID_SIDE_ACTION_COMBINATION)
+        if position_effect != PositionEffect.OPEN_OR_INCREASE.value:
+            reasons.append(REASON_ENTER_LONG_WRONG_POSITION_EFFECT)
+        if reduce_only:
+            reasons.append(REASON_INVALID_SIDE_ACTION_COMBINATION)
+
+    if intent_action == IntentAction.ENTER_SHORT.value:
+        if side != IntentSide.SHORT.value:
+            reasons.append(REASON_INVALID_SIDE_ACTION_COMBINATION)
+        if position_effect != PositionEffect.OPEN_OR_INCREASE.value:
+            reasons.append(REASON_ENTER_SHORT_WRONG_POSITION_EFFECT)
+        if reduce_only:
+            reasons.append(REASON_INVALID_SIDE_ACTION_COMBINATION)
+
+    if intent_action == IntentAction.REDUCE.value:
+        if not reduce_only:
+            reasons.append(REASON_INVALID_SIDE_ACTION_COMBINATION)
+        if position_effect != PositionEffect.REDUCE_ONLY.value:
+            reasons.append(REASON_INVALID_SIDE_ACTION_COMBINATION)
+        if check_exposure and quantity > current_reconciled_exposure:
+            reasons.append(REASON_REDUCE_EXPOSURE_INCREASE)
+
+    if intent_action == IntentAction.EXIT.value:
+        if not reduce_only:
+            reasons.append(REASON_EXIT_WITHOUT_REDUCE_ONLY)
+        if position_effect != PositionEffect.CLOSE_ONLY.value:
+            reasons.append(REASON_INVALID_SIDE_ACTION_COMBINATION)
+
+    if (
+        current_open_side is not None
+        and current_open_side in {IntentSide.LONG.value, IntentSide.SHORT.value}
+        and current_reconciled_exposure > 0
+        and current_open_side != side
+        and intent_action in {IntentAction.ENTER_LONG.value, IntentAction.ENTER_SHORT.value}
+    ):
+        reasons.append(REASON_IMPLICIT_REVERSAL)
+
+    if expected_position_side not in {IntentSide.LONG.value, IntentSide.SHORT.value}:
+        reasons.append(REASON_INVALID_SIDE_ACTION_COMBINATION)
+
+    return tuple(dict.fromkeys(reasons))
+
+
+def build_canonical_order_intent_v1(
+    build_input: CanonicalOrderIntentBuildInputV1,
+) -> CanonicalOrderIntentBuildResultV1:
+    """Build a canonical order intent from validated STEP-29P sizing output."""
+
+    inp = build_input.sizing_input
+    decision = build_input.sizing_decision
+    reasons: list[str] = []
+
+    reasons.extend(_validate_instrument_futures_only(inp))
+
+    if decision.outcome is not CapitalRiskSizingOutcome.PASS:
+        reasons.append(REASON_SIZING_NOT_PASS)
+
+    provenance = decision.quantity_provenance
+    if provenance is None:
+        reasons.append(REASON_MISSING_QUANTITY_PROVENANCE)
+    else:
+        quantity = provenance.final_quantity
+        if quantity is None or quantity <= 0:
+            reasons.append(REASON_INVALID_QUANTITY)
+        if provenance.output_digest == "":
+            reasons.append(REASON_MISSING_QUANTITY_PROVENANCE)
+
+    if not inp.decision_id:
+        reasons.append(REASON_MISSING_DECISION_REF)
+
+    capital_envelope_ref = compute_capital_envelope_ref(decision)
+    pre_sizing_risk_ref = compute_pre_sizing_risk_ref(decision)
+    sizing_result_ref = compute_sizing_result_ref(decision)
+    post_sizing_risk_ref = compute_post_sizing_risk_ref(decision)
+
+    if not capital_envelope_ref:
+        reasons.append(REASON_MISSING_CAPITAL_ENVELOPE_REF)
+    if not pre_sizing_risk_ref:
+        reasons.append(REASON_MISSING_PRE_SIZING_RISK_REF)
+    if not sizing_result_ref:
+        reasons.append(REASON_MISSING_SIZING_RESULT_REF)
+    if not post_sizing_risk_ref:
+        reasons.append(REASON_MISSING_POST_SIZING_RISK_REF)
+
+    intent_action = build_input.intent_action
+    position_effect = _derive_position_effect(intent_action)
+    reduce_only = _derive_reduce_only(intent_action)
+    side = _derive_side(intent_action, decision.selected_side)
+
+    quantity = provenance.final_quantity if provenance is not None else Decimal("0")
+    reasons.extend(
+        _validate_action_semantics(
+            intent_action=intent_action,
+            selected_side=decision.selected_side,
+            position_effect=position_effect,
+            reduce_only=reduce_only,
+            quantity=quantity,
+            current_reconciled_exposure=build_input.current_reconciled_exposure,
+            current_open_side=build_input.current_open_side,
+            expected_position_side=build_input.expected_position_side,
+        )
+    )
+
+    if not build_input.policy_digest or not inp.config_digest:
+        reasons.append(REASON_MISSING_PROVENANCE)
+
+    if reasons:
+        return _blocked_result(tuple(dict.fromkeys(reasons)))
+
+    provenance_digest = _digest_ref(
+        {
+            "capital_envelope_ref": capital_envelope_ref,
+            "pre_sizing_risk_ref": pre_sizing_risk_ref,
+            "sizing_result_ref": sizing_result_ref,
+            "post_sizing_risk_ref": post_sizing_risk_ref,
+            "policy_digest": build_input.policy_digest,
+            "config_digest": inp.config_digest,
+            "implementation_digest": IMPLEMENTATION_DIGEST,
+            "input_digest": inp.input_digest,
+        }
+    )
+
+    intent_without_digest = CanonicalOrderIntentV1(
+        intent_id=build_input.intent_id,
+        intent_version=INTENT_VERSION,
+        decision_id=inp.decision_id,
+        instrument_id=inp.instrument_id,
+        trading_epoch=build_input.trading_epoch,
+        canonical_trading_logic_version=build_input.canonical_trading_logic_version,
+        capital_envelope_ref=capital_envelope_ref,
+        pre_sizing_risk_ref=pre_sizing_risk_ref,
+        sizing_result_ref=sizing_result_ref,
+        post_sizing_risk_ref=post_sizing_risk_ref,
+        policy_digest=build_input.policy_digest,
+        config_digest=inp.config_digest,
+        implementation_digest=IMPLEMENTATION_DIGEST,
+        provenance_digest=provenance_digest,
+        side=side,
+        intent_action=intent_action,
+        quantity=quantity,
+        quantity_unit="CONTRACTS",
+        quantity_provenance=provenance.output_digest,
+        reduce_only=reduce_only,
+        position_effect=position_effect,
+        order_type_policy=build_input.order_type_policy,
+        price_policy=build_input.price_policy,
+        time_in_force_policy=build_input.time_in_force_policy,
+        max_slippage_policy=build_input.max_slippage_policy,
+        expected_position_side=build_input.expected_position_side,
+        instrument_metadata_ref=provenance.instrument_metadata_ref,
+    )
+
+    semantic_digest = compute_semantic_digest(intent_without_digest)
+    intent = replace(intent_without_digest, semantic_digest=semantic_digest)
+
+    validation = validate_canonical_order_intent_v1(intent)
+    if validation.validation_status != ValidationStatus.VALID.value:
+        return _blocked_result(validation.reason_codes)
+
+    return CanonicalOrderIntentBuildResultV1(
+        outcome=CanonicalOrderIntentBuildOutcome.PASS,
+        intent=intent,
+        reason_codes=(REASON_PASS,),
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalOrderIntentValidationResultV1:
+    validation_status: str
+    reason_codes: tuple[str, ...]
+
+
+def validate_canonical_order_intent_v1(
+    intent: CanonicalOrderIntentV1,
+) -> CanonicalOrderIntentValidationResultV1:
+    """Fail-closed validation of a canonical order intent."""
+
+    reasons: list[str] = []
+
+    if intent.execution_eligible:
+        reasons.append(REASON_DIRECT_SUBMISSION_FORBIDDEN)
+    if intent.adapter_compatible:
+        reasons.append(REASON_ADAPTER_CAST_FORBIDDEN)
+    if intent.submission_authorized:
+        reasons.append(REASON_DIRECT_SUBMISSION_FORBIDDEN)
+    if not intent.transformation_required:
+        reasons.append(REASON_TRANSFORMATION_REQUIRED)
+    if intent.runtime_effect != RUNTIME_EFFECT_NONE:
+        reasons.append(REASON_DIRECT_SUBMISSION_FORBIDDEN)
+    if intent.authority_effect != AUTHORITY_EFFECT_NONE:
+        reasons.append(REASON_DIRECT_SUBMISSION_FORBIDDEN)
+    if intent.network_effect != NETWORK_EFFECT_NONE:
+        reasons.append(REASON_DIRECT_SUBMISSION_FORBIDDEN)
+    if intent.credential_effect != CREDENTIAL_EFFECT_NONE:
+        reasons.append(REASON_DIRECT_SUBMISSION_FORBIDDEN)
+
+    if intent.quantity <= 0:
+        reasons.append(REASON_INVALID_QUANTITY)
+    if not intent.quantity_provenance:
+        reasons.append(REASON_MISSING_QUANTITY_PROVENANCE)
+
+    if not intent.decision_id:
+        reasons.append(REASON_MISSING_DECISION_REF)
+    if not intent.capital_envelope_ref:
+        reasons.append(REASON_MISSING_CAPITAL_ENVELOPE_REF)
+    if not intent.pre_sizing_risk_ref:
+        reasons.append(REASON_MISSING_PRE_SIZING_RISK_REF)
+    if not intent.sizing_result_ref:
+        reasons.append(REASON_MISSING_SIZING_RESULT_REF)
+    if not intent.post_sizing_risk_ref:
+        reasons.append(REASON_MISSING_POST_SIZING_RISK_REF)
+
+    if intent.semantic_digest:
+        expected = compute_semantic_digest(
+            replace(intent, semantic_digest="", validation_status=ValidationStatus.VALID.value)
+        )
+        if intent.semantic_digest != expected:
+            reasons.append(REASON_INVALID_DIGEST)
+
+    reasons.extend(
+        _validate_action_semantics(
+            intent_action=intent.intent_action,
+            selected_side=intent.side,
+            position_effect=intent.position_effect,
+            reduce_only=intent.reduce_only,
+            quantity=intent.quantity,
+            current_reconciled_exposure=Decimal("0"),
+            current_open_side=None,
+            expected_position_side=intent.expected_position_side,
+            check_exposure=False,
+        )
+    )
+
+    if reasons:
+        return CanonicalOrderIntentValidationResultV1(
+            validation_status=ValidationStatus.INVALID.value,
+            reason_codes=tuple(dict.fromkeys(reasons)),
+        )
+    return CanonicalOrderIntentValidationResultV1(
+        validation_status=ValidationStatus.VALID.value,
+        reason_codes=(REASON_PASS,),
+    )
+
+
+def canonical_order_intent_to_semantic_dict(intent: CanonicalOrderIntentV1) -> dict[str, Any]:
+    payload = {
+        field.name: getattr(intent, field.name)
+        for field in fields(CanonicalOrderIntentV1)
+        if field.name not in {"semantic_digest", "validation_status", "reason_codes"}
+    }
+    payload["quantity"] = str(payload["quantity"])
+    return payload
+
+
+def compute_semantic_digest(intent: CanonicalOrderIntentV1) -> str:
+    base = replace(intent, semantic_digest="", validation_status=ValidationStatus.VALID.value)
+    return _sha256_hex(canonical_order_intent_to_semantic_dict(base))
+
+
+def canonical_order_intent_to_json(intent: CanonicalOrderIntentV1) -> str:
+    return json.dumps(
+        canonical_order_intent_to_semantic_dict(intent),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def canonical_order_intent_from_dict(payload: Mapping[str, Any]) -> CanonicalOrderIntentV1:
+    quantity_raw = payload.get("quantity")
+    intent = CanonicalOrderIntentV1(
+        intent_id=str(payload["intent_id"]),
+        intent_version=str(payload["intent_version"]),
+        decision_id=str(payload["decision_id"]),
+        instrument_id=str(payload["instrument_id"]),
+        trading_epoch=str(payload["trading_epoch"]),
+        canonical_trading_logic_version=str(payload["canonical_trading_logic_version"]),
+        capital_envelope_ref=str(payload["capital_envelope_ref"]),
+        pre_sizing_risk_ref=str(payload["pre_sizing_risk_ref"]),
+        sizing_result_ref=str(payload["sizing_result_ref"]),
+        post_sizing_risk_ref=str(payload["post_sizing_risk_ref"]),
+        policy_digest=str(payload["policy_digest"]),
+        config_digest=str(payload["config_digest"]),
+        implementation_digest=str(payload["implementation_digest"]),
+        provenance_digest=str(payload["provenance_digest"]),
+        side=str(payload["side"]),
+        intent_action=str(payload["intent_action"]),
+        quantity=Decimal(str(quantity_raw)),
+        quantity_unit=str(payload["quantity_unit"]),
+        quantity_provenance=str(payload["quantity_provenance"]),
+        reduce_only=bool(payload["reduce_only"]),
+        position_effect=str(payload["position_effect"]),
+        order_type_policy=str(payload["order_type_policy"]),
+        price_policy=str(payload["price_policy"]),
+        time_in_force_policy=str(payload["time_in_force_policy"]),
+        max_slippage_policy=str(payload["max_slippage_policy"]),
+        expected_position_side=str(payload["expected_position_side"]),
+        instrument_metadata_ref=str(payload["instrument_metadata_ref"]),
+        execution_eligible=bool(payload.get("execution_eligible", False)),
+        adapter_compatible=bool(payload.get("adapter_compatible", False)),
+        submission_authorized=bool(payload.get("submission_authorized", False)),
+        runtime_effect=str(payload.get("runtime_effect", RUNTIME_EFFECT_NONE)),
+        authority_effect=str(payload.get("authority_effect", AUTHORITY_EFFECT_NONE)),
+        network_effect=str(payload.get("network_effect", NETWORK_EFFECT_NONE)),
+        credential_effect=str(payload.get("credential_effect", CREDENTIAL_EFFECT_NONE)),
+        transformation_required=bool(payload.get("transformation_required", True)),
+        validation_status=str(payload.get("validation_status", ValidationStatus.VALID.value)),
+        reason_codes=tuple(str(code) for code in payload.get("reason_codes", (REASON_PASS,))),
+        semantic_digest=str(payload.get("semantic_digest", "")),
+        deterministic_serialization_version=str(
+            payload.get(
+                "deterministic_serialization_version",
+                DETERMINISTIC_SERIALIZATION_VERSION,
+            )
+        ),
+    )
+    if not intent.semantic_digest:
+        intent = replace(intent, semantic_digest=compute_semantic_digest(intent))
+    return intent
+
+
+def assert_canonical_order_intent_immutable(intent: CanonicalOrderIntentV1) -> None:
+    """Raise if the intent dataclass is not frozen/immutable."""
+
+    if not getattr(intent, "__dataclass_fields__", None):
+        raise CanonicalOrderIntentError(REASON_MUTABLE_INTENT)
+    params = getattr(intent.__class__, "__dataclass_params__", None)
+    if params is None or not getattr(params, "frozen", False):
+        raise CanonicalOrderIntentError(REASON_MUTABLE_INTENT)
+
+
+def evaluate_adapter_compatibility_firewall_v1(
+    intent: CanonicalOrderIntentV1,
+    *,
+    target_type_name: str,
+) -> AdapterCompatibilityFirewallResultV1:
+    """Explicit fail-closed boundary against direct adapter/payload casting."""
+
+    reasons: list[str] = []
+    if target_type_name in _FORBIDDEN_ADAPTER_TYPE_NAMES:
+        reasons.append(REASON_ADAPTER_CAST_FORBIDDEN)
+    if intent.adapter_compatible:
+        reasons.append(REASON_ADAPTER_CAST_FORBIDDEN)
+    if not intent.transformation_required:
+        reasons.append(REASON_TRANSFORMATION_REQUIRED)
+    if intent.execution_eligible or intent.submission_authorized:
+        reasons.append(REASON_DIRECT_SUBMISSION_FORBIDDEN)
+    if reasons:
+        return AdapterCompatibilityFirewallResultV1(
+            admissible=False,
+            reason_codes=tuple(dict.fromkeys(reasons)),
+            target_type_name=target_type_name,
+        )
+    return AdapterCompatibilityFirewallResultV1(
+        admissible=False,
+        reason_codes=(REASON_TRANSFORMATION_REQUIRED,),
+        target_type_name=target_type_name,
+    )
+
+
+def reject_direct_adapter_cast_v1(
+    intent: CanonicalOrderIntentV1,
+    target_type: Type[Any],
+) -> None:
+    """Raise CanonicalOrderIntentError on forbidden direct adapter cast."""
+
+    result = evaluate_adapter_compatibility_firewall_v1(
+        intent,
+        target_type_name=target_type.__name__,
+    )
+    if not result.admissible:
+        raise CanonicalOrderIntentError(",".join(result.reason_codes))
+
+
+def reject_direct_submission_v1(intent: CanonicalOrderIntentV1) -> None:
+    """Raise CanonicalOrderIntentError if submission is attempted."""
+
+    if intent.execution_eligible or intent.submission_authorized:
+        raise CanonicalOrderIntentError(REASON_DIRECT_SUBMISSION_FORBIDDEN)
+    raise CanonicalOrderIntentError(REASON_TRANSFORMATION_REQUIRED)
+
+
+def canonical_order_intent_schema_v1() -> dict[str, Any]:
+    return {
+        "contract_name": CONTRACT_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "schema_version": SCHEMA_VERSION,
+        "package_marker": PACKAGE_MARKER,
+        "implementation_digest": IMPLEMENTATION_DIGEST,
+        "deterministic_serialization_version": DETERMINISTIC_SERIALIZATION_VERSION,
+        "invariants": {
+            "futures_only": FUTURES_ONLY,
+            "bitcoin_direction_allowed": BITCOIN_DIRECTION_ALLOWED,
+            "spot_allowed": SPOT_ALLOWED,
+            "synthetic_spot_allowed": SYNTHETIC_SPOT_ALLOWED,
+            "no_order_without_quantity_provenance": True,
+            "execution_eligible": False,
+            "adapter_compatible": False,
+            "submission_authorized": False,
+            "transformation_required": True,
+            "authority_effect": AUTHORITY_EFFECT_NONE,
+            "runtime_effect": RUNTIME_EFFECT_NONE,
+            "network_effect": NETWORK_EFFECT_NONE,
+            "credential_effect": CREDENTIAL_EFFECT_NONE,
+            "no_default_quantity": True,
+            "no_implicit_adapter_compatibility": True,
+            "no_direct_submission": True,
+        },
+        "intent_actions": [action.value for action in IntentAction],
+        "position_effects": [effect.value for effect in PositionEffect],
+        "quantity_chain_upstream": [
+            "canonical_trading_decision",
+            "capital_envelope",
+            "pre_sizing_risk",
+            "canonical_position_sizing",
+            "post_sizing_risk",
+            "canonical_order_intent",
+            "explicit_adapter_transformation",
+        ],
+        "reason_codes": sorted(
+            {
+                REASON_PASS,
+                REASON_MISSING_QUANTITY_PROVENANCE,
+                REASON_INVALID_QUANTITY,
+                REASON_SIZING_NOT_PASS,
+                REASON_MISSING_DECISION_REF,
+                REASON_MISSING_CAPITAL_ENVELOPE_REF,
+                REASON_MISSING_PRE_SIZING_RISK_REF,
+                REASON_MISSING_SIZING_RESULT_REF,
+                REASON_MISSING_POST_SIZING_RISK_REF,
+                REASON_INVALID_SIDE_ACTION_COMBINATION,
+                REASON_EXIT_WITHOUT_REDUCE_ONLY,
+                REASON_REDUCE_EXPOSURE_INCREASE,
+                REASON_ENTER_LONG_WRONG_POSITION_EFFECT,
+                REASON_ENTER_SHORT_WRONG_POSITION_EFFECT,
+                REASON_IMPLICIT_REVERSAL,
+                REASON_NON_FUTURES_INSTRUMENT,
+                REASON_BITCOIN_SPECIFIC_DIRECTION,
+                REASON_INVALID_DIGEST,
+                REASON_NO_ACTION_NOT_SUBMITTABLE,
+                REASON_DEFAULT_QUANTITY_FORBIDDEN,
+                REASON_ADAPTER_CAST_FORBIDDEN,
+                REASON_DIRECT_SUBMISSION_FORBIDDEN,
+                REASON_TRANSFORMATION_REQUIRED,
+                REASON_VENUE_FIELD_IN_CANONICAL,
+                REASON_MUTABLE_INTENT,
+                REASON_MISSING_PROVENANCE,
+            }
+        ),
+    }

--- a/tests/governance/test_canonical_order_intent_v1.py
+++ b/tests/governance/test_canonical_order_intent_v1.py
@@ -1,0 +1,579 @@
+"""Contract tests for offline canonical order intent v1 (RUNBOOK STEP 29Q)."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+import src.governance.canonical_order_intent_v1 as intent_mod
+import src.governance.capital_risk_sizing_v1 as sizing
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2] / "src" / "governance" / "canonical_order_intent_v1.py"
+)
+
+_FORBIDDEN_RUNTIME_MODULES = frozenset(
+    {
+        "src.execution.orchestrator",
+        "src.execution.pipeline",
+        "src.live.orders",
+        "src.execution.adapters.base_v1",
+        "src.orders.base",
+    }
+)
+
+TOTAL_LIMIT_USD = Decimal("500")
+ORDER_LIMIT_USD = Decimal("25")
+DAILY_LOSS_LIMIT_USD = Decimal("25")
+
+
+def _instrument(**overrides: object) -> sizing.InstrumentQuantityConstraintsV1:
+    base: dict[str, object] = {
+        "instrument_id": "ETH-USD-PERP",
+        "market_type": "futures",
+        "contract_kind": "LINEAR",
+        "contract_multiplier": Decimal("1"),
+        "quantity_step": Decimal("0.01"),
+        "minimum_quantity": Decimal("0.01"),
+        "maximum_quantity": Decimal("100"),
+        "minimum_notional": Decimal("5"),
+        "instrument_metadata_version": "futures_metadata_v1_test",
+    }
+    base.update(overrides)
+    return sizing.InstrumentQuantityConstraintsV1(**base)  # type: ignore[arg-type]
+
+
+def _sizing_input(**overrides: object) -> sizing.CapitalRiskSizingInputV1:
+    instrument = _instrument()
+    base: dict[str, object] = {
+        "decision_id": "decision-001",
+        "instrument_id": instrument.instrument_id,
+        "selected_side": sizing.SelectedSide.LONG.value,
+        "reference_price": Decimal("2000"),
+        "protective_stop_price": Decimal("1900"),
+        "stop_distance": None,
+        "account_equity": TOTAL_LIMIT_USD,
+        "scope_capital_limit": ORDER_LIMIT_USD,
+        "per_trade_risk_limit": ORDER_LIMIT_USD,
+        "total_capital_limit": TOTAL_LIMIT_USD,
+        "daily_loss_remaining_budget": DAILY_LOSS_LIMIT_USD,
+        "current_reconciled_exposure": Decimal("0"),
+        "maximum_positions": 1,
+        "current_open_positions_count": 0,
+        "current_open_side": None,
+        "configured_quantity_cap": None,
+        "leverage_ceiling": Decimal("5"),
+        "reconciliation_status": "RECONCILED",
+        "policy_version": "capital_risk_sizing_policy_v1",
+        "config_digest": "cfg_digest_test",
+        "input_digest": "input_digest_test",
+        "instrument": instrument,
+    }
+    base.update(overrides)
+    return sizing.CapitalRiskSizingInputV1(**base)  # type: ignore[arg-type]
+
+
+def _passing_sizing_decision(**overrides: object) -> sizing.CapitalRiskSizingDecisionV1:
+    return sizing.evaluate_capital_risk_sizing_v1(_sizing_input(**overrides))
+
+
+def _build_input(
+    *,
+    intent_action: str = intent_mod.IntentAction.ENTER_LONG.value,
+    sizing_overrides: dict[str, object] | None = None,
+    **overrides: object,
+) -> intent_mod.CanonicalOrderIntentBuildInputV1:
+    sizing_overrides = sizing_overrides or {}
+    sizing_input = _sizing_input(**sizing_overrides)
+    sizing_decision = sizing.evaluate_capital_risk_sizing_v1(sizing_input)
+    side = sizing_overrides.get("selected_side", sizing.SelectedSide.LONG.value)
+    expected_side = (
+        intent_mod.IntentSide.LONG.value
+        if intent_action == intent_mod.IntentAction.ENTER_LONG.value
+        else intent_mod.IntentSide.SHORT.value
+        if intent_action == intent_mod.IntentAction.ENTER_SHORT.value
+        else str(side)
+    )
+    base: dict[str, object] = {
+        "sizing_input": sizing_input,
+        "sizing_decision": sizing_decision,
+        "intent_id": "intent-001",
+        "trading_epoch": "epoch-001",
+        "canonical_trading_logic_version": "trading_logic_v1_test",
+        "intent_action": intent_action,
+        "policy_digest": "policy_digest_test",
+        "order_type_policy": "LIMIT_ONLY",
+        "price_policy": "REFERENCE_PRICE",
+        "time_in_force_policy": "GTC",
+        "max_slippage_policy": "ZERO",
+        "expected_position_side": expected_side,
+        "current_reconciled_exposure": sizing_input.current_reconciled_exposure,
+        "current_open_side": sizing_input.current_open_side,
+    }
+    base.update(overrides)
+    return intent_mod.CanonicalOrderIntentBuildInputV1(**base)  # type: ignore[arg-type]
+
+
+def _build(**kwargs: object) -> intent_mod.CanonicalOrderIntentBuildResultV1:
+    return intent_mod.build_canonical_order_intent_v1(_build_input(**kwargs))  # type: ignore[arg-type]
+
+
+def _intent(**kwargs: object) -> intent_mod.CanonicalOrderIntentV1:
+    result = _build(**kwargs)
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.PASS
+    assert result.intent is not None
+    return result.intent
+
+
+# --- Positive contracts ---
+
+
+def test_positive_deterministic_intent_generation() -> None:
+    first = _build()
+    second = _build()
+    assert first == second
+    assert first.intent == second.intent
+
+
+def test_positive_stable_semantic_digests() -> None:
+    first = _intent()
+    second = _intent()
+    assert first.semantic_digest == second.semantic_digest
+    assert first.semantic_digest != ""
+
+
+def test_positive_complete_provenance() -> None:
+    built = _intent()
+    assert built.capital_envelope_ref
+    assert built.pre_sizing_risk_ref
+    assert built.sizing_result_ref
+    assert built.post_sizing_risk_ref
+    assert built.provenance_digest
+    assert built.quantity_provenance
+
+
+def test_positive_provenance_refs_bound() -> None:
+    built = _intent()
+    decision = _passing_sizing_decision()
+    assert built.capital_envelope_ref == intent_mod.compute_capital_envelope_ref(decision)
+    assert built.pre_sizing_risk_ref == intent_mod.compute_pre_sizing_risk_ref(decision)
+    assert built.sizing_result_ref == intent_mod.compute_sizing_result_ref(decision)
+    assert built.post_sizing_risk_ref == intent_mod.compute_post_sizing_risk_ref(decision)
+    assert built.decision_id == "decision-001"
+
+
+def test_positive_enter_long_semantics() -> None:
+    built = _intent(intent_action=intent_mod.IntentAction.ENTER_LONG.value)
+    assert built.intent_action == intent_mod.IntentAction.ENTER_LONG.value
+    assert built.side == intent_mod.IntentSide.LONG.value
+    assert built.position_effect == intent_mod.PositionEffect.OPEN_OR_INCREASE.value
+    assert built.reduce_only is False
+
+
+def test_positive_enter_short_semantics() -> None:
+    built = _intent(
+        intent_action=intent_mod.IntentAction.ENTER_SHORT.value,
+        sizing_overrides={
+            "selected_side": sizing.SelectedSide.SHORT.value,
+            "protective_stop_price": Decimal("2100"),
+        },
+    )
+    assert built.intent_action == intent_mod.IntentAction.ENTER_SHORT.value
+    assert built.side == intent_mod.IntentSide.SHORT.value
+    assert built.position_effect == intent_mod.PositionEffect.OPEN_OR_INCREASE.value
+    assert built.reduce_only is False
+
+
+def test_positive_reduce_semantics() -> None:
+    built = _intent(
+        intent_action=intent_mod.IntentAction.REDUCE.value,
+        sizing_overrides={
+            "current_reconciled_exposure": Decimal("1.0"),
+            "current_open_positions_count": 1,
+            "current_open_side": sizing.SelectedSide.LONG.value,
+            "maximum_positions": 2,
+        },
+        current_reconciled_exposure=Decimal("1.0"),
+    )
+    assert built.intent_action == intent_mod.IntentAction.REDUCE.value
+    assert built.reduce_only is True
+    assert built.position_effect == intent_mod.PositionEffect.REDUCE_ONLY.value
+
+
+def test_positive_exit_semantics() -> None:
+    built = _intent(
+        intent_action=intent_mod.IntentAction.EXIT.value,
+        sizing_overrides={
+            "current_reconciled_exposure": Decimal("0.5"),
+            "current_open_positions_count": 1,
+            "current_open_side": sizing.SelectedSide.LONG.value,
+            "maximum_positions": 2,
+        },
+        current_reconciled_exposure=Decimal("0.5"),
+    )
+    assert built.intent_action == intent_mod.IntentAction.EXIT.value
+    assert built.reduce_only is True
+    assert built.position_effect == intent_mod.PositionEffect.CLOSE_ONLY.value
+
+
+def test_positive_quantity_positive_and_sizing_bound() -> None:
+    built = _intent()
+    assert built.quantity > 0
+    decision = _passing_sizing_decision()
+    assert decision.quantity_provenance is not None
+    assert built.quantity == decision.quantity_provenance.final_quantity
+    assert built.quantity_provenance == decision.quantity_provenance.output_digest
+
+
+def test_positive_futures_instrument_accepted() -> None:
+    built = _intent()
+    assert built.instrument_id == "ETH-USD-PERP"
+
+
+def test_positive_immutable_contract() -> None:
+    built = _intent()
+    intent_mod.assert_canonical_order_intent_immutable(built)
+    with pytest.raises(Exception):
+        built.quantity = Decimal("999")  # type: ignore[misc]
+
+
+def test_positive_serialization_roundtrip() -> None:
+    built = _intent()
+    payload = json.loads(intent_mod.canonical_order_intent_to_json(built))
+    restored = intent_mod.canonical_order_intent_from_dict(payload)
+    assert restored.semantic_digest == built.semantic_digest
+    assert restored.intent_id == built.intent_id
+    assert restored.quantity == built.quantity
+
+
+def test_positive_execution_eligible_false() -> None:
+    built = _intent()
+    assert built.execution_eligible is False
+
+
+def test_positive_adapter_compatible_false() -> None:
+    built = _intent()
+    assert built.adapter_compatible is False
+
+
+def test_positive_submission_authorized_false() -> None:
+    built = _intent()
+    assert built.submission_authorized is False
+
+
+def test_positive_no_runtime_or_authority_effect() -> None:
+    built = _intent()
+    assert built.runtime_effect == intent_mod.RUNTIME_EFFECT_NONE
+    assert built.authority_effect == intent_mod.AUTHORITY_EFFECT_NONE
+    assert built.network_effect == intent_mod.NETWORK_EFFECT_NONE
+    assert built.credential_effect == intent_mod.CREDENTIAL_EFFECT_NONE
+    assert built.transformation_required is True
+
+
+# --- Negative / fail-closed ---
+
+
+def test_negative_missing_quantity_provenance() -> None:
+    decision = _passing_sizing_decision()
+    assert decision.quantity_provenance is not None
+    blocked = sizing.CapitalRiskSizingDecisionV1(
+        outcome=decision.outcome,
+        final_quantity=decision.final_quantity,
+        selected_side=decision.selected_side,
+        capital_envelope=decision.capital_envelope,
+        pre_sizing_risk=decision.pre_sizing_risk,
+        canonical_sizing=decision.canonical_sizing,
+        post_sizing_risk=decision.post_sizing_risk,
+        quantity_provenance=None,
+        reason_codes=decision.reason_codes,
+    )
+    result = intent_mod.build_canonical_order_intent_v1(
+        intent_mod.CanonicalOrderIntentBuildInputV1(
+            sizing_input=_sizing_input(),
+            sizing_decision=blocked,
+            intent_id="intent-001",
+            trading_epoch="epoch-001",
+            canonical_trading_logic_version="trading_logic_v1_test",
+            intent_action=intent_mod.IntentAction.ENTER_LONG.value,
+            policy_digest="policy_digest_test",
+            order_type_policy="LIMIT_ONLY",
+            price_policy="REFERENCE_PRICE",
+            time_in_force_policy="GTC",
+            max_slippage_policy="ZERO",
+            expected_position_side=intent_mod.IntentSide.LONG.value,
+            current_reconciled_exposure=Decimal("0"),
+        )
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.BLOCKED
+    assert intent_mod.REASON_MISSING_QUANTITY_PROVENANCE in result.reason_codes
+
+
+def test_negative_quantity_zero_or_negative() -> None:
+    decision = _passing_sizing_decision()
+    assert decision.quantity_provenance is not None
+    bad_provenance = sizing.QuantityProvenanceV1(
+        **{
+            **{
+                field.name: getattr(decision.quantity_provenance, field.name)
+                for field in sizing.QuantityProvenanceV1.__dataclass_fields__.values()
+            },
+            "final_quantity": Decimal("0"),
+            "output_digest": "",
+        }
+    )
+    blocked = sizing.CapitalRiskSizingDecisionV1(
+        outcome=decision.outcome,
+        final_quantity=Decimal("0"),
+        selected_side=decision.selected_side,
+        capital_envelope=decision.capital_envelope,
+        pre_sizing_risk=decision.pre_sizing_risk,
+        canonical_sizing=decision.canonical_sizing,
+        post_sizing_risk=decision.post_sizing_risk,
+        quantity_provenance=bad_provenance,
+        reason_codes=decision.reason_codes,
+    )
+    result = intent_mod.build_canonical_order_intent_v1(
+        intent_mod.CanonicalOrderIntentBuildInputV1(
+            sizing_input=_sizing_input(),
+            sizing_decision=blocked,
+            intent_id="intent-001",
+            trading_epoch="epoch-001",
+            canonical_trading_logic_version="trading_logic_v1_test",
+            intent_action=intent_mod.IntentAction.ENTER_LONG.value,
+            policy_digest="policy_digest_test",
+            order_type_policy="LIMIT_ONLY",
+            price_policy="REFERENCE_PRICE",
+            time_in_force_policy="GTC",
+            max_slippage_policy="ZERO",
+            expected_position_side=intent_mod.IntentSide.LONG.value,
+            current_reconciled_exposure=Decimal("0"),
+        )
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.BLOCKED
+    assert intent_mod.REASON_INVALID_QUANTITY in result.reason_codes
+
+
+def test_negative_exit_without_reduce_only_semantics() -> None:
+    result = intent_mod.build_canonical_order_intent_v1(
+        _build_input(intent_action=intent_mod.IntentAction.EXIT.value)
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.PASS
+    bad = intent_mod.replace(result.intent, reduce_only=False)  # type: ignore[arg-type]
+    validation = intent_mod.validate_canonical_order_intent_v1(bad)
+    assert validation.validation_status == intent_mod.ValidationStatus.INVALID.value
+    assert intent_mod.REASON_EXIT_WITHOUT_REDUCE_ONLY in validation.reason_codes
+
+
+def test_negative_reduce_exposure_increase() -> None:
+    result = intent_mod.build_canonical_order_intent_v1(
+        _build_input(
+            intent_action=intent_mod.IntentAction.REDUCE.value,
+            sizing_overrides={
+                "current_reconciled_exposure": Decimal("0.05"),
+                "current_open_positions_count": 1,
+                "current_open_side": sizing.SelectedSide.LONG.value,
+                "maximum_positions": 2,
+            },
+            current_reconciled_exposure=Decimal("0.005"),
+        )
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.BLOCKED
+    assert intent_mod.REASON_REDUCE_EXPOSURE_INCREASE in result.reason_codes
+
+
+def test_negative_enter_long_wrong_position_effect() -> None:
+    result = intent_mod.build_canonical_order_intent_v1(
+        _build_input(intent_action=intent_mod.IntentAction.ENTER_LONG.value)
+    )
+    assert result.intent is not None
+    bad = intent_mod.replace(
+        result.intent,
+        position_effect=intent_mod.PositionEffect.REDUCE_ONLY.value,
+    )
+    validation = intent_mod.validate_canonical_order_intent_v1(bad)
+    assert intent_mod.REASON_ENTER_LONG_WRONG_POSITION_EFFECT in validation.reason_codes
+
+
+def test_negative_enter_short_wrong_position_effect() -> None:
+    result = intent_mod.build_canonical_order_intent_v1(
+        _build_input(
+            intent_action=intent_mod.IntentAction.ENTER_SHORT.value,
+            sizing_overrides={
+                "selected_side": sizing.SelectedSide.SHORT.value,
+                "protective_stop_price": Decimal("2100"),
+            },
+        )
+    )
+    assert result.intent is not None
+    bad = intent_mod.replace(
+        result.intent,
+        position_effect=intent_mod.PositionEffect.OPEN_OR_INCREASE.value,
+        side=intent_mod.IntentSide.SHORT.value,
+        intent_action=intent_mod.IntentAction.ENTER_SHORT.value,
+    )
+    validation = intent_mod.validate_canonical_order_intent_v1(bad)
+    assert validation.validation_status == intent_mod.ValidationStatus.VALID.value
+
+
+def test_negative_implicit_reversal() -> None:
+    result = intent_mod.build_canonical_order_intent_v1(
+        _build_input(
+            intent_action=intent_mod.IntentAction.ENTER_SHORT.value,
+            sizing_overrides={
+                "selected_side": sizing.SelectedSide.SHORT.value,
+                "protective_stop_price": Decimal("2100"),
+                "current_reconciled_exposure": Decimal("1"),
+                "current_open_positions_count": 1,
+                "current_open_side": sizing.SelectedSide.LONG.value,
+            },
+            current_open_side=sizing.SelectedSide.LONG.value,
+            current_reconciled_exposure=Decimal("1"),
+        )
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.BLOCKED
+    assert intent_mod.REASON_IMPLICIT_REVERSAL in result.reason_codes
+
+
+def test_negative_missing_decision_ref() -> None:
+    result = intent_mod.build_canonical_order_intent_v1(
+        _build_input(sizing_overrides={"decision_id": ""})
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.BLOCKED
+    assert intent_mod.REASON_MISSING_DECISION_REF in result.reason_codes
+
+
+def test_negative_invalid_digest() -> None:
+    built = _intent()
+    bad = intent_mod.replace(built, semantic_digest="deadbeef")
+    validation = intent_mod.validate_canonical_order_intent_v1(bad)
+    assert intent_mod.REASON_INVALID_DIGEST in validation.reason_codes
+
+
+def test_negative_spot_instrument() -> None:
+    result = intent_mod.build_canonical_order_intent_v1(
+        _build_input(
+            sizing_overrides={
+                "instrument_id": "ETH-USD",
+                "instrument": _instrument(market_type="spot", instrument_id="ETH-USD"),
+            }
+        )
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.BLOCKED
+    assert intent_mod.REASON_NON_FUTURES_INSTRUMENT in result.reason_codes
+
+
+def test_negative_synthetic_spot_instrument() -> None:
+    result = intent_mod.build_canonical_order_intent_v1(
+        _build_input(
+            sizing_overrides={
+                "instrument_id": "ETH-SYN",
+                "instrument": _instrument(market_type="synthetic_spot", instrument_id="ETH-SYN"),
+            }
+        )
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.BLOCKED
+    assert intent_mod.REASON_NON_FUTURES_INSTRUMENT in result.reason_codes
+
+
+def test_negative_bitcoin_direction() -> None:
+    result = intent_mod.build_canonical_order_intent_v1(
+        _build_input(
+            sizing_overrides={
+                "instrument_id": "BTC-USD-PERP",
+                "instrument": _instrument(instrument_id="BTC-USD-PERP"),
+            }
+        )
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.BLOCKED
+    assert intent_mod.REASON_BITCOIN_SPECIFIC_DIRECTION in result.reason_codes
+
+
+def test_negative_direct_adapter_cast() -> None:
+    built = _intent()
+    firewall = intent_mod.evaluate_adapter_compatibility_firewall_v1(
+        built,
+        target_type_name="OrderRequest",
+    )
+    assert firewall.admissible is False
+    assert intent_mod.REASON_ADAPTER_CAST_FORBIDDEN in firewall.reason_codes
+    with pytest.raises(intent_mod.CanonicalOrderIntentError):
+        intent_mod.reject_direct_adapter_cast_v1(built, dict)
+
+
+def test_negative_direct_submission() -> None:
+    built = _intent()
+    with pytest.raises(intent_mod.CanonicalOrderIntentError):
+        intent_mod.reject_direct_submission_v1(built)
+
+
+def test_negative_no_action_not_submittable() -> None:
+    result = intent_mod.build_canonical_order_intent_v1(
+        _build_input(intent_action=intent_mod.IntentAction.NO_ACTION.value)
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.BLOCKED
+    assert intent_mod.REASON_NO_ACTION_NOT_SUBMITTABLE in result.reason_codes
+
+
+def test_negative_sizing_not_pass() -> None:
+    blocked_decision = sizing.evaluate_capital_risk_sizing_v1(
+        _sizing_input(scope_capital_limit=Decimal("0"))
+    )
+    assert blocked_decision.outcome is sizing.CapitalRiskSizingOutcome.BLOCKED
+    result = intent_mod.build_canonical_order_intent_v1(
+        intent_mod.CanonicalOrderIntentBuildInputV1(
+            sizing_input=_sizing_input(scope_capital_limit=Decimal("0")),
+            sizing_decision=blocked_decision,
+            intent_id="intent-001",
+            trading_epoch="epoch-001",
+            canonical_trading_logic_version="trading_logic_v1_test",
+            intent_action=intent_mod.IntentAction.ENTER_LONG.value,
+            policy_digest="policy_digest_test",
+            order_type_policy="LIMIT_ONLY",
+            price_policy="REFERENCE_PRICE",
+            time_in_force_policy="GTC",
+            max_slippage_policy="ZERO",
+            expected_position_side=intent_mod.IntentSide.LONG.value,
+            current_reconciled_exposure=Decimal("0"),
+        )
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentBuildOutcome.BLOCKED
+    assert intent_mod.REASON_SIZING_NOT_PASS in result.reason_codes
+
+
+def test_negative_deterministic_serialization_stable() -> None:
+    built = _intent()
+    first = intent_mod.canonical_order_intent_to_json(built)
+    second = intent_mod.canonical_order_intent_to_json(built)
+    assert first == second
+
+
+def test_negative_no_runtime_imports() -> None:
+    source = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(source):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name)
+    for forbidden in _FORBIDDEN_RUNTIME_MODULES:
+        assert forbidden not in imported
+
+
+def test_schema_contract_complete() -> None:
+    schema = intent_mod.canonical_order_intent_schema_v1()
+    assert schema["contract_name"] == intent_mod.CONTRACT_NAME
+    assert schema["invariants"]["execution_eligible"] is False
+    assert schema["invariants"]["adapter_compatible"] is False
+    assert schema["invariants"]["no_order_without_quantity_provenance"] is True
+
+
+def test_import_smoke() -> None:
+    mod = importlib.import_module("src.governance.canonical_order_intent_v1")
+    assert inspect.isfunction(mod.build_canonical_order_intent_v1)

--- a/tests/ops/test_runbook_step29o_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29o_progress_registry_closeout_contract_v0.py
@@ -134,9 +134,9 @@ def test_step_29q_legitimately_started_global_transition() -> None:
     text = _read_registry()
     assert _field_value(text, "RUNBOOK_STEP_29Q_STARTED") == "true"
     assert _field_value(text, "STEP_29Q_STARTED") == "true"
-    assert _field_value(text, "RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED") == "false"
+    assert _field_value(text, "RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED") == "true"
     assert _field_value(text, "RUNBOOK_STEP_29Q_COMPLETE") == "false"
-    assert _field_value(text, "CANONICAL_ORDER_INTENT_IMPLEMENTED") == "false"
+    assert _field_value(text, "CANONICAL_ORDER_INTENT_IMPLEMENTED") == "true"
     assert _field_value(text, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29Q"
     assert "#### RUNBOOK_STEP_29Q" in text
 

--- a/tests/ops/test_runbook_step29q_canonical_order_intent_implementation_contract_v0.py
+++ b/tests/ops/test_runbook_step29q_canonical_order_intent_implementation_contract_v0.py
@@ -1,0 +1,162 @@
+"""Contract tests for RUNBOOK STEP 29Q canonical order intent implementation v0.
+
+Verifies implemented-scope semantics without authorizing runtime, orders, adapter
+compatibility, transformation binding, registry closeout, or STEP 29R.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROGRESS_REGISTRY = REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+CANONICAL_OWNER = REPO_ROOT / "src" / "governance" / "canonical_order_intent_v1.py"
+
+STEP_29Q_IMPLEMENTED_SCOPE = "canonical_order_intent_v1_offline_slice"
+STEP_29Q_CANONICAL_DEFINITION = "CANONICAL_ORDER_INTENT"
+STEP_29Q_CANONICAL_OWNER = "src&#47;governance&#47;canonical_order_intent_v1.py"
+
+
+def _read_registry() -> str:
+    assert PROGRESS_REGISTRY.is_file(), f"missing canonical registry: {PROGRESS_REGISTRY}"
+    return PROGRESS_REGISTRY.read_text(encoding="utf-8")
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(rf"\| `{re.escape(field)}` \| `([^`]*)` \|", text)
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _step_29q_section(text: str) -> str:
+    start = text.index("#### RUNBOOK_STEP_29Q — Canonical Order Intent v1")
+    end = text.index("\n---\n\n## PR #4629 Evidence-Drift", start)
+    return re.sub(r"\s<!--.*?-->", "", text[start:end])
+
+
+def test_canonical_owner_module_exists() -> None:
+    assert CANONICAL_OWNER.is_file(), f"missing canonical owner: {CANONICAL_OWNER}"
+
+
+def test_runbook_step_29q_implementation_started_true() -> None:
+    text = _read_registry()
+    section = _step_29q_section(text)
+    assert _field_value(text, "RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED") == "true"
+    assert _field_value(section, "RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED") == "true"
+
+
+def test_runbook_step_29q_implemented_scope_bound() -> None:
+    text = _read_registry()
+    section = _step_29q_section(text)
+    assert _field_value(text, "RUNBOOK_STEP_29Q_IMPLEMENTED_SCOPE") == STEP_29Q_IMPLEMENTED_SCOPE
+    assert _field_value(section, "RUNBOOK_STEP_29Q_IMPLEMENTED_SCOPE") == STEP_29Q_IMPLEMENTED_SCOPE
+
+
+def test_runbook_step_29q_implemented_true_not_complete() -> None:
+    text = _read_registry()
+    section = _step_29q_section(text)
+    assert _field_value(text, "RUNBOOK_STEP_29Q_IMPLEMENTED") == "true"
+    assert _field_value(section, "RUNBOOK_STEP_29Q_IMPLEMENTED") == "true"
+    assert _field_value(text, "RUNBOOK_STEP_29Q_COMPLETE") == "false"
+    assert _field_value(section, "RUNBOOK_STEP_29Q_COMPLETE") == "false"
+
+
+def test_canonical_order_intent_implemented_true() -> None:
+    text = _read_registry()
+    section = _step_29q_section(text)
+    assert _field_value(text, "CANONICAL_ORDER_INTENT_IMPLEMENTED") == "true"
+    assert _field_value(section, "CANONICAL_ORDER_INTENT_IMPLEMENTED") == "true"
+    assert _field_value(section, "CANONICAL_ORDER_INTENT_DEFINED") == "true"
+
+
+def test_canonical_owner_ratified() -> None:
+    section = _step_29q_section(_read_registry())
+    assert _field_value(section, "CANONICAL_OWNER") == STEP_29Q_CANONICAL_OWNER
+    assert _field_value(section, "CANONICAL_OWNER_STATUS") == "IMPLEMENTED"
+    assert _field_value(section, "CANONICAL_OWNER_RATIFIED") == "true"
+
+
+def test_adapter_compatibility_and_transformation_not_proven_or_bound() -> None:
+    text = _read_registry()
+    section = _step_29q_section(text)
+    assert _field_value(text, "CANONICAL_ORDER_INTENT_ADAPTER_COMPATIBILITY_PROVEN") == "false"
+    assert _field_value(section, "CANONICAL_ORDER_INTENT_ADAPTER_COMPATIBILITY_PROVEN") == "false"
+    assert _field_value(text, "CANONICAL_ORDER_INTENT_TRANSFORMATION_BOUND") == "false"
+    assert _field_value(section, "CANONICAL_ORDER_INTENT_TRANSFORMATION_BOUND") == "false"
+    assert _field_value(section, "IMPLICIT_ADAPTER_COMPATIBILITY_ALLOWED") == "false"
+    assert _field_value(section, "ADAPTER_TRANSFORMATION_IMPLEMENTED") == "false"
+
+
+def test_scope_classification_offline_slice() -> None:
+    section = _step_29q_section(_read_registry())
+    assert (
+        _field_value(section, "RUNBOOK_STEP_29Q_SCOPE_CLASSIFICATION")
+        == "CANONICAL_ORDER_INTENT_V1_OFFLINE_SLICE"
+    )
+    assert (
+        _field_value(section, "RUNBOOK_STEP_29Q_CANONICAL_DEFINITION")
+        == STEP_29Q_CANONICAL_DEFINITION
+    )
+
+
+def test_progress_registry_closeout_not_performed() -> None:
+    text = _read_registry()
+    section = _step_29q_section(text)
+    assert _field_value(text, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "false"
+    assert _field_value(section, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "false"
+
+
+def test_next_runbook_step_remains_29q() -> None:
+    text = _read_registry()
+    section = _step_29q_section(text)
+    assert _field_value(text, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29Q"
+    assert _field_value(section, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29Q"
+
+
+def test_no_runtime_order_or_authority_effects() -> None:
+    section = _step_29q_section(_read_registry())
+    assert _field_value(section, "RUNTIME_EFFECT") == "false"
+    assert _field_value(section, "ORDER_EFFECT") == "false"
+    assert _field_value(section, "AUTHORITY_EFFECT") == "false"
+    assert _field_value(section, "ADAPTER_SUBMISSION_EFFECT") == "false"
+    assert _field_value(section, "NETWORK_EFFECT") == "false"
+
+
+def test_futures_only_and_bitcoin_direction_forbidden() -> None:
+    section = _step_29q_section(_read_registry())
+    assert _field_value(section, "FUTURES_ONLY") == "true"
+    assert _field_value(section, "BITCOIN_DIRECTION_ALLOWED") == "false"
+
+
+def test_capital_risk_sizing_mathematics_not_changed() -> None:
+    text = _read_registry()
+    section = _step_29q_section(text)
+    assert _field_value(text, "CAPITAL_RISK_SIZING_MATHEMATICS_CHANGED") == "false"
+    assert _field_value(section, "CAPITAL_RISK_SIZING_MATHEMATICS_CHANGED") == "false"
+
+
+def test_no_step_29r_start_markers() -> None:
+    text = _read_registry()
+    assert "RUNBOOK_STEP_29R_STARTED" not in text
+    assert "STEP_29R_STARTED" not in text
+    assert "#### RUNBOOK_STEP_29R" not in text
+
+
+def test_step_29p_and_29o_complete_preserved() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29P_COMPLETE") == "true"
+    assert _field_value(text, "RUNBOOK_STEP_29O_COMPLETE") == "true"
+
+
+def test_implementation_does_not_claim_adapter_compatibility() -> None:
+    section = _step_29q_section(_read_registry())
+    assert _field_value(section, "STEP_29Q_DOES_NOT_CLAIM_ADAPTER_COMPATIBILITY") == "true"
+    assert _field_value(section, "STEP_29Q_DOES_NOT_IMPLEMENT_ADAPTER_TRANSFORMATION") == "true"
+
+
+def test_implementation_does_not_create_orders_or_grant_authority() -> None:
+    section = _step_29q_section(_read_registry())
+    assert _field_value(section, "STEP_29Q_DOES_NOT_CREATE_ORDERS") == "true"
+    assert _field_value(section, "STEP_29Q_DOES_NOT_GRANT_AUTHORITY") == "true"
+    assert _field_value(section, "LIVE_AUTHORIZED") == "false"

--- a/tests/ops/test_runbook_step29q_progress_registry_start_contract_v0.py
+++ b/tests/ops/test_runbook_step29q_progress_registry_start_contract_v0.py
@@ -54,11 +54,11 @@ def test_runbook_step_29q_started_true() -> None:
     assert _field_value(section, "RUNBOOK_STEP_29Q_STARTED") == "true"
 
 
-def test_runbook_step_29q_implementation_not_started() -> None:
+def test_runbook_step_29q_implementation_started() -> None:
     text = _read_registry()
     section = _step_29q_section(text)
-    assert _field_value(text, "RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED") == "false"
-    assert _field_value(section, "RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED") == "false"
+    assert _field_value(text, "RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED") == "true"
+    assert _field_value(section, "RUNBOOK_STEP_29Q_IMPLEMENTATION_STARTED") == "true"
 
 
 def test_runbook_step_29q_not_complete() -> None:
@@ -83,11 +83,11 @@ def test_runbook_step_29q_canonical_definition() -> None:
     )
 
 
-def test_runbook_step_29q_canonical_owner_explicit_proposed_state() -> None:
+def test_runbook_step_29q_canonical_owner_implemented() -> None:
     section = _step_29q_section(_read_registry())
     assert _field_value(section, "CANONICAL_OWNER") == STEP_29Q_CANONICAL_OWNER
-    assert _field_value(section, "CANONICAL_OWNER_STATUS") == "PROPOSED_PENDING_IMPLEMENTATION"
-    assert _field_value(section, "CANONICAL_OWNER_RATIFIED") == "false"
+    assert _field_value(section, "CANONICAL_OWNER_STATUS") == "IMPLEMENTED"
+    assert _field_value(section, "CANONICAL_OWNER_RATIFIED") == "true"
 
 
 def test_step_29q_section_has_no_tbd_placeholders() -> None:
@@ -104,16 +104,16 @@ def test_runbook_step_29q_minimum_safe_slice() -> None:
     )
 
 
-def test_canonical_order_intent_not_implemented() -> None:
+def test_canonical_order_intent_implemented() -> None:
     text = _read_registry()
     section = _step_29q_section(text)
-    assert _field_value(text, "CANONICAL_ORDER_INTENT_IMPLEMENTED") == "false"
-    assert _field_value(section, "CANONICAL_ORDER_INTENT_IMPLEMENTED") == "false"
+    assert _field_value(text, "CANONICAL_ORDER_INTENT_IMPLEMENTED") == "true"
+    assert _field_value(section, "CANONICAL_ORDER_INTENT_IMPLEMENTED") == "true"
 
 
-def test_canonical_order_intent_not_defined() -> None:
+def test_canonical_order_intent_defined() -> None:
     section = _step_29q_section(_read_registry())
-    assert _field_value(section, "CANONICAL_ORDER_INTENT_DEFINED") == "false"
+    assert _field_value(section, "CANONICAL_ORDER_INTENT_DEFINED") == "true"
 
 
 def test_adapter_compatibility_and_transformation_not_proven_or_bound() -> None:
@@ -139,10 +139,12 @@ def test_runtime_rewire_not_performed() -> None:
     assert _field_value(section, "RUNTIME_REWIRE_PERFORMED") == "false"
 
 
-def test_next_required_contract_is_implementation_slice() -> None:
-    text = _read_registry()
-    section = _step_29q_section(text)
-    assert _field_value(section, "NEXT_REQUIRED_CONTRACT") == NEXT_REQUIRED_CONTRACT
+def test_next_required_contract_is_progress_registry_closeout() -> None:
+    section = _step_29q_section(_read_registry())
+    assert (
+        _field_value(section, "NEXT_REQUIRED_CONTRACT")
+        == "RUNBOOK_STEP_29Q_PROGRESS_REGISTRY_CLOSEOUT"
+    )
 
 
 def test_next_runbook_step_remains_29q() -> None:
@@ -152,9 +154,8 @@ def test_next_runbook_step_remains_29q() -> None:
     assert _field_value(section, "NEXT_RUNBOOK_STEP") == "RUNBOOK_STEP_29Q"
 
 
-def test_registry_start_does_not_implement_order_intent_or_adapter_paths() -> None:
+def test_registry_start_does_not_implement_adapter_paths() -> None:
     section = _step_29q_section(_read_registry())
-    assert _field_value(section, "STEP_29Q_DOES_NOT_IMPLEMENT_ORDER_INTENT") == "true"
     assert _field_value(section, "STEP_29Q_DOES_NOT_IMPLEMENT_ADAPTER_TRANSFORMATION") == "true"
     assert _field_value(section, "STEP_29Q_DOES_NOT_CLAIM_ADAPTER_COMPATIBILITY") == "true"
     assert (
@@ -197,13 +198,15 @@ def test_no_step_29r_start_markers() -> None:
     assert "#### RUNBOOK_STEP_29R" not in text
 
 
-def test_scope_classification_registry_start_only() -> None:
+def test_scope_classification_implemented_offline_slice() -> None:
     section = _step_29q_section(_read_registry())
     assert (
         _field_value(section, "RUNBOOK_STEP_29Q_SCOPE_CLASSIFICATION")
-        == "PROGRESS_REGISTRY_START_ONLY"
+        == "CANONICAL_ORDER_INTENT_V1_OFFLINE_SLICE"
     )
-    assert _field_value(section, "RUNBOOK_STEP_29Q_IMPLEMENTED_SCOPE") == "none"
+    assert (
+        _field_value(section, "RUNBOOK_STEP_29Q_IMPLEMENTED_SCOPE") == STEP_29Q_MINIMUM_SAFE_SLICE
+    )
     assert _field_value(section, "STATUS") == "IN_PROGRESS"
 
 


### PR DESCRIPTION
## Summary
- Implement `CanonicalOrderIntentV1` as offline, venue-neutral intent contract in `src/governance/canonical_order_intent_v1.py`, built deterministically from validated STEP-29P capital/risk/sizing output with full provenance refs and semantic digests.
- Add fail-closed validators and explicit adapter-cast/submission firewall (no runtime wiring, no adapter transformation, no submission authority).
- Update progress registry to implementation-started/implemented-scope (not COMPLETE) and add STEP-29Q implementation + updated registry contract tests.

## Test plan
- [x] `tests/governance/test_canonical_order_intent_v1.py` (36 tests: positive + negative)
- [x] `tests/governance/test_capital_risk_sizing_v1.py` (STEP 29P regression)
- [x] `tests/governance/test_intent_compatibility_firewall_v1.py` (STEP 29O regression)
- [x] STEP-29O/29P/29Q registry contract tests (199 total in bounded bundle)
- [x] `ruff format --check`, `ruff check`, `git diff --check`
- [x] CI selector: `PR_BOUNDED_FULL` (central `src/governance/` owner)

## Safety
- FUTURES_ONLY, no runtime/order/adapter/network/credential effects
- `CANONICAL_ORDER_INTENT_ADAPTER_COMPATIBILITY_PROVEN=false`
- `CANONICAL_ORDER_INTENT_TRANSFORMATION_BOUND=false`
- `RUNBOOK_STEP_29Q_COMPLETE=false` (no registry closeout, no STEP 29R)


Made with [Cursor](https://cursor.com)