### PR TITLE
feat(governance): bind canonical order intent adapter transformation contract

### DIFF
--- a/src/governance/canonical_order_intent_v1.py
+++ b/src/governance/canonical_order_intent_v1.py
@@ -48,6 +48,7 @@ _FORBIDDEN_MARKET_TYPES = frozenset({"spot", "synthetic_spot", "synthetic-spot"}
 _FORBIDDEN_ADAPTER_TYPE_NAMES = frozenset(
     {
         "OrderIntent",
+        "OrderIntentV1",
         "OrderRequest",
         "Order",
         "AdapterRequest",
@@ -82,6 +83,39 @@ REASON_TRANSFORMATION_REQUIRED = "TRANSFORMATION_REQUIRED"
 REASON_VENUE_FIELD_IN_CANONICAL = "VENUE_FIELD_IN_CANONICAL"
 REASON_MUTABLE_INTENT = "MUTABLE_INTENT"
 REASON_MISSING_PROVENANCE = "MISSING_PROVENANCE"
+REASON_INVALID_INPUT_TYPE = "INVALID_INPUT_TYPE"
+REASON_INVALID_CANONICAL_INTENT_VERSION = "INVALID_CANONICAL_INTENT_VERSION"
+REASON_UNSUPPORTED_SIDE = "UNSUPPORTED_SIDE"
+REASON_UNSUPPORTED_ORDER_TYPE_POLICY = "UNSUPPORTED_ORDER_TYPE_POLICY"
+REASON_UNSUPPORTED_TIME_IN_FORCE_POLICY = "UNSUPPORTED_TIME_IN_FORCE_POLICY"
+REASON_UNBOUND_PRICE_POLICY = "UNBOUND_PRICE_POLICY"
+REASON_MISSING_INSTRUMENT = "MISSING_INSTRUMENT"
+REASON_QUANTITY_PRECISION_LOSS = "QUANTITY_PRECISION_LOSS"
+REASON_QUANTITY_ROUNDING_INCREASES_RISK = "QUANTITY_ROUNDING_INCREASES_RISK"
+REASON_CONTRADICTORY_REDUCE_ONLY_SEMANTICS = "CONTRADICTORY_REDUCE_ONLY_SEMANTICS"
+REASON_UNBOUND_ADAPTER_FIELD = "UNBOUND_ADAPTER_FIELD"
+REASON_UNBOUND_TRANSFORMATION = "UNBOUND_TRANSFORMATION"
+
+TRANSFORMATION_ID = "canonical_order_intent_v1_to_adapter_order_intent_v1"
+TRANSFORMATION_VERSION = "v1"
+FIELD_MAPPING_VERSION = "canonical_to_adapter_order_intent_field_mapping_v1"
+TARGET_CONTRACT_NAME = "adapter_order_intent_v1"
+TARGET_CONTRACT_VERSION = "v1"
+TARGET_OWNER_MODULE = "src.execution.adapters.base_v1"
+TARGET_TYPE_NAME = "OrderIntentV1"
+
+_ORDER_TYPE_POLICY_BINDINGS: dict[str, str] = {
+    "MARKET_ONLY": "market",
+    "LIMIT_ONLY": "limit",
+}
+_TIME_IN_FORCE_POLICY_BINDINGS: dict[str, str] = {
+    "GTC": "gtc",
+    "IOC": "ioc",
+    "FOK": "fok",
+}
+_PRICE_POLICY_EXPLICIT_NONE = "EXPLICIT_NONE"
+_PRICE_POLICY_EXPLICIT_PREFIX = "EXPLICIT_PRICE:"
+_POST_ONLY_POLICY = "POST_ONLY"
 
 
 class IntentAction(str, Enum):
@@ -195,6 +229,62 @@ class AdapterCompatibilityFirewallResultV1:
 
 class CanonicalOrderIntentError(ValueError):
     """Fail-closed canonical order intent contract error."""
+
+
+class CanonicalOrderIntentTransformOutcome(str, Enum):
+    PASS = "PASS"
+    BLOCKED = "BLOCKED"
+
+
+@dataclass(frozen=True)
+class AdapterOrderIntentV1StructuralV1:
+    """Offline structural mirror of adapter OrderIntentV1 — no submission effect."""
+
+    symbol: str
+    side: str
+    qty: float
+    order_type: str
+    price: Optional[float]
+    tif: str
+    post_only: bool
+    reduce_only: bool
+    client_id: Optional[str]
+    meta: Optional[tuple[tuple[str, str], ...]]
+
+
+@dataclass(frozen=True)
+class CanonicalOrderIntentTransformationDescriptorV1:
+    source_contract: str
+    source_version: str
+    target_contract: str
+    target_version: str
+    transformation_id: str
+    transformation_version: str
+    field_mapping_version: str
+    source_digest: str
+    target_digest: str
+    lossless_fields: tuple[str, ...]
+    rejected_unbound_fields: tuple[str, ...]
+    runtime_effect: bool
+    order_effect: bool
+    authority_effect: bool
+    network_effect: bool
+    adapter_submission_effect: bool
+    transformation_required_acknowledged: bool
+    source_quantity_provenance: str
+
+
+@dataclass(frozen=True)
+class CanonicalOrderIntentTransformResultV1:
+    outcome: CanonicalOrderIntentTransformOutcome
+    adapter_intent: Optional[AdapterOrderIntentV1StructuralV1]
+    descriptor: Optional[CanonicalOrderIntentTransformationDescriptorV1]
+    reason_codes: tuple[str, ...]
+    runtime_effect: bool = False
+    order_effect: bool = False
+    authority_effect: bool = False
+    network_effect: bool = False
+    adapter_submission_effect: bool = False
 
 
 def _sha256_hex(payload: Mapping[str, Any]) -> str:
@@ -709,6 +799,331 @@ def reject_direct_submission_v1(intent: CanonicalOrderIntentV1) -> None:
     raise CanonicalOrderIntentError(REASON_TRANSFORMATION_REQUIRED)
 
 
+def _blocked_transform_result(
+    reason_codes: tuple[str, ...],
+) -> CanonicalOrderIntentTransformResultV1:
+    return CanonicalOrderIntentTransformResultV1(
+        outcome=CanonicalOrderIntentTransformOutcome.BLOCKED,
+        adapter_intent=None,
+        descriptor=None,
+        reason_codes=reason_codes,
+    )
+
+
+def _adapter_intent_to_semantic_dict(intent: AdapterOrderIntentV1StructuralV1) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        field.name: getattr(intent, field.name)
+        for field in fields(AdapterOrderIntentV1StructuralV1)
+    }
+    if payload["meta"] is not None:
+        payload["meta"] = list(payload["meta"])
+    return payload
+
+
+def compute_adapter_order_intent_structural_digest(
+    intent: AdapterOrderIntentV1StructuralV1,
+) -> str:
+    return _sha256_hex(_adapter_intent_to_semantic_dict(intent))
+
+
+def compute_transformation_descriptor_digest(
+    descriptor: CanonicalOrderIntentTransformationDescriptorV1,
+) -> str:
+    payload = {
+        field.name: getattr(descriptor, field.name)
+        for field in fields(CanonicalOrderIntentTransformationDescriptorV1)
+    }
+    return _sha256_hex(payload)
+
+
+def _validate_instrument_for_transform(intent: CanonicalOrderIntentV1) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if not intent.instrument_id.strip():
+        reasons.append(REASON_MISSING_INSTRUMENT)
+    instrument_lower = intent.instrument_id.lower()
+    if any(marker in instrument_lower for marker in _FORBIDDEN_INSTRUMENT_MARKERS):
+        reasons.append(REASON_BITCOIN_SPECIFIC_DIRECTION)
+    metadata_lower = intent.instrument_metadata_ref.lower()
+    if any(marker in metadata_lower for marker in _FORBIDDEN_MARKET_TYPES):
+        reasons.append(REASON_NON_FUTURES_INSTRUMENT)
+    if "spot" in instrument_lower and "perp" not in instrument_lower:
+        reasons.append(REASON_NON_FUTURES_INSTRUMENT)
+    return tuple(dict.fromkeys(reasons))
+
+
+def _validate_reduce_only_semantics(intent: CanonicalOrderIntentV1) -> tuple[str, ...]:
+    reasons: list[str] = []
+    reduce_expected = intent.intent_action in {
+        IntentAction.REDUCE.value,
+        IntentAction.EXIT.value,
+    }
+    if reduce_expected and not intent.reduce_only:
+        reasons.append(REASON_CONTRADICTORY_REDUCE_ONLY_SEMANTICS)
+    if not reduce_expected and intent.reduce_only:
+        reasons.append(REASON_CONTRADICTORY_REDUCE_ONLY_SEMANTICS)
+    if intent.intent_action == IntentAction.EXIT.value:
+        if intent.position_effect != PositionEffect.CLOSE_ONLY.value:
+            reasons.append(REASON_CONTRADICTORY_REDUCE_ONLY_SEMANTICS)
+    if intent.intent_action == IntentAction.REDUCE.value:
+        if intent.position_effect != PositionEffect.REDUCE_ONLY.value:
+            reasons.append(REASON_CONTRADICTORY_REDUCE_ONLY_SEMANTICS)
+    return tuple(dict.fromkeys(reasons))
+
+
+def _adapter_side_for_intent(intent: CanonicalOrderIntentV1) -> Optional[str]:
+    action = intent.intent_action
+    if action == IntentAction.ENTER_LONG.value:
+        return "buy"
+    if action == IntentAction.ENTER_SHORT.value:
+        return "sell"
+    if action in {IntentAction.REDUCE.value, IntentAction.EXIT.value}:
+        if intent.side == IntentSide.LONG.value:
+            return "sell"
+        if intent.side == IntentSide.SHORT.value:
+            return "buy"
+    return None
+
+
+def _decimal_to_adapter_qty(quantity: Decimal) -> tuple[Optional[float], tuple[str, ...]]:
+    if quantity <= 0:
+        return None, (REASON_INVALID_QUANTITY,)
+    as_float = float(quantity)
+    roundtrip = Decimal(str(as_float))
+    if roundtrip > quantity:
+        return None, (REASON_QUANTITY_ROUNDING_INCREASES_RISK,)
+    if roundtrip != quantity:
+        return None, (REASON_QUANTITY_PRECISION_LOSS,)
+    return as_float, ()
+
+
+def _resolve_price_policy(
+    *,
+    order_type: str,
+    price_policy: str,
+) -> tuple[Optional[float], tuple[str, ...], tuple[str, ...]]:
+    rejected_unbound: list[str] = []
+    if order_type == "market":
+        if price_policy == _PRICE_POLICY_EXPLICIT_NONE:
+            return None, (), ()
+        rejected_unbound.append("price")
+        return None, (REASON_UNBOUND_PRICE_POLICY,), tuple(rejected_unbound)
+    if order_type == "limit":
+        if price_policy.startswith(_PRICE_POLICY_EXPLICIT_PREFIX):
+            raw = price_policy[len(_PRICE_POLICY_EXPLICIT_PREFIX) :]
+            try:
+                price_decimal = Decimal(raw)
+            except Exception:
+                return None, (REASON_UNBOUND_PRICE_POLICY,), ("price",)
+            if price_decimal <= 0:
+                return None, (REASON_UNBOUND_PRICE_POLICY,), ("price",)
+            price_float = float(price_decimal)
+            if Decimal(str(price_float)) != price_decimal:
+                return None, (REASON_QUANTITY_PRECISION_LOSS,), ("price",)
+            return price_float, (), ()
+        rejected_unbound.append("price")
+        return None, (REASON_UNBOUND_PRICE_POLICY,), tuple(rejected_unbound)
+    rejected_unbound.append("price")
+    return None, (REASON_UNBOUND_ADAPTER_FIELD,), tuple(rejected_unbound)
+
+
+def _build_adapter_meta(intent: CanonicalOrderIntentV1) -> tuple[tuple[str, str], ...]:
+    pairs = (
+        ("canonical_intent_id", intent.intent_id),
+        ("canonical_semantic_digest", intent.semantic_digest),
+        ("canonical_quantity_provenance", intent.quantity_provenance),
+        ("canonical_provenance_digest", intent.provenance_digest),
+        ("canonical_decision_id", intent.decision_id),
+        ("transformation_id", TRANSFORMATION_ID),
+        ("transformation_version", TRANSFORMATION_VERSION),
+        ("field_mapping_version", FIELD_MAPPING_VERSION),
+        ("transformation_required_acknowledged", "true"),
+        ("structural_adapter_compatibility_only", "true"),
+    )
+    return tuple(sorted(pairs))
+
+
+def transform_canonical_order_intent_v1_to_adapter_order_intent_v1(
+    intent: CanonicalOrderIntentV1,
+    *,
+    transformation_id: str = TRANSFORMATION_ID,
+) -> CanonicalOrderIntentTransformResultV1:
+    """Explicit offline transformation from canonical intent to adapter OrderIntentV1 shape."""
+
+    if not isinstance(intent, CanonicalOrderIntentV1):
+        return _blocked_transform_result((REASON_INVALID_INPUT_TYPE,))
+    if transformation_id != TRANSFORMATION_ID:
+        return _blocked_transform_result((REASON_UNBOUND_TRANSFORMATION,))
+    if intent.intent_version != INTENT_VERSION:
+        return _blocked_transform_result((REASON_INVALID_CANONICAL_INTENT_VERSION,))
+
+    validation = validate_canonical_order_intent_v1(intent)
+    if validation.validation_status != ValidationStatus.VALID.value:
+        return _blocked_transform_result(validation.reason_codes)
+
+    reasons: list[str] = []
+    reasons.extend(_validate_instrument_for_transform(intent))
+    reasons.extend(_validate_reduce_only_semantics(intent))
+
+    if not intent.quantity_provenance:
+        reasons.append(REASON_MISSING_QUANTITY_PROVENANCE)
+
+    adapter_side = _adapter_side_for_intent(intent)
+    if adapter_side is None:
+        reasons.append(REASON_UNSUPPORTED_SIDE)
+
+    order_type = _ORDER_TYPE_POLICY_BINDINGS.get(intent.order_type_policy)
+    if order_type is None:
+        reasons.append(REASON_UNSUPPORTED_ORDER_TYPE_POLICY)
+
+    tif = _TIME_IN_FORCE_POLICY_BINDINGS.get(intent.time_in_force_policy)
+    if tif is None:
+        reasons.append(REASON_UNSUPPORTED_TIME_IN_FORCE_POLICY)
+
+    qty: Optional[float] = None
+    qty_reasons: tuple[str, ...] = ()
+    if not reasons:
+        qty, qty_reasons = _decimal_to_adapter_qty(intent.quantity)
+        reasons.extend(qty_reasons)
+
+    price: Optional[float] = None
+    rejected_unbound_fields: list[str] = []
+    price_reasons: tuple[str, ...] = ()
+    if not reasons and order_type is not None:
+        price, price_reasons, rejected = _resolve_price_policy(
+            order_type=order_type,
+            price_policy=intent.price_policy,
+        )
+        reasons.extend(price_reasons)
+        rejected_unbound_fields.extend(rejected)
+
+    if intent.intent_action == IntentAction.NO_ACTION.value:
+        reasons.append(REASON_NO_ACTION_NOT_SUBMITTABLE)
+
+    if reasons:
+        return _blocked_transform_result(tuple(dict.fromkeys(reasons)))
+
+    assert adapter_side is not None
+    assert order_type is not None
+    assert tif is not None
+    assert qty is not None
+
+    post_only = intent.max_slippage_policy == _POST_ONLY_POLICY
+    rejected_unbound_fields.extend(
+        field_name
+        for field_name in ("client_id", "venue", "account")
+        if field_name not in {"client_id"}
+    )
+
+    adapter_intent = AdapterOrderIntentV1StructuralV1(
+        symbol=intent.instrument_id,
+        side=adapter_side,
+        qty=qty,
+        order_type=order_type,
+        price=price,
+        tif=tif,
+        post_only=post_only,
+        reduce_only=intent.reduce_only,
+        client_id=None,
+        meta=_build_adapter_meta(intent),
+    )
+    target_digest = compute_adapter_order_intent_structural_digest(adapter_intent)
+    lossless_fields = (
+        "instrument_id->symbol",
+        "side/intent_action->side",
+        "quantity->qty",
+        "order_type_policy->order_type",
+        "time_in_force_policy->tif",
+        "reduce_only",
+        "quantity_provenance->meta",
+        "semantic_digest->meta",
+        "provenance_digest->meta",
+    )
+    descriptor = CanonicalOrderIntentTransformationDescriptorV1(
+        source_contract=CONTRACT_NAME,
+        source_version=CONTRACT_VERSION,
+        target_contract=TARGET_CONTRACT_NAME,
+        target_version=TARGET_CONTRACT_VERSION,
+        transformation_id=TRANSFORMATION_ID,
+        transformation_version=TRANSFORMATION_VERSION,
+        field_mapping_version=FIELD_MAPPING_VERSION,
+        source_digest=intent.semantic_digest,
+        target_digest=target_digest,
+        lossless_fields=lossless_fields,
+        rejected_unbound_fields=tuple(
+            dict.fromkeys((*rejected_unbound_fields, "client_id", "venue", "account"))
+        ),
+        runtime_effect=False,
+        order_effect=False,
+        authority_effect=False,
+        network_effect=False,
+        adapter_submission_effect=False,
+        transformation_required_acknowledged=intent.transformation_required,
+        source_quantity_provenance=intent.quantity_provenance,
+    )
+
+    return CanonicalOrderIntentTransformResultV1(
+        outcome=CanonicalOrderIntentTransformOutcome.PASS,
+        adapter_intent=adapter_intent,
+        descriptor=descriptor,
+        reason_codes=(REASON_PASS,),
+    )
+
+
+def canonical_order_intent_transformation_schema_v1() -> dict[str, Any]:
+    return {
+        "transformation_id": TRANSFORMATION_ID,
+        "transformation_version": TRANSFORMATION_VERSION,
+        "field_mapping_version": FIELD_MAPPING_VERSION,
+        "source_contract": CONTRACT_NAME,
+        "source_version": CONTRACT_VERSION,
+        "target_contract": TARGET_CONTRACT_NAME,
+        "target_version": TARGET_CONTRACT_VERSION,
+        "target_owner_module": TARGET_OWNER_MODULE,
+        "target_type_name": TARGET_TYPE_NAME,
+        "invariants": {
+            "transformation_is_explicit": True,
+            "transformation_is_deterministic": True,
+            "transformation_is_side_effect_free": True,
+            "transformation_is_fail_closed": True,
+            "transformation_preserves_quantity_provenance": True,
+            "transformation_must_not_increase_risk": True,
+            "direct_cast_remains_forbidden": True,
+            "runtime_effect": False,
+            "order_effect": False,
+            "authority_effect": False,
+            "network_effect": False,
+            "adapter_submission_effect": False,
+            "structural_adapter_compatibility_only": True,
+            "full_adapter_compatibility_proven": False,
+        },
+        "order_type_policy_bindings": dict(_ORDER_TYPE_POLICY_BINDINGS),
+        "time_in_force_policy_bindings": dict(_TIME_IN_FORCE_POLICY_BINDINGS),
+        "reason_codes": sorted(
+            {
+                REASON_PASS,
+                REASON_INVALID_INPUT_TYPE,
+                REASON_INVALID_CANONICAL_INTENT_VERSION,
+                REASON_UNSUPPORTED_SIDE,
+                REASON_UNSUPPORTED_ORDER_TYPE_POLICY,
+                REASON_UNSUPPORTED_TIME_IN_FORCE_POLICY,
+                REASON_UNBOUND_PRICE_POLICY,
+                REASON_MISSING_INSTRUMENT,
+                REASON_QUANTITY_PRECISION_LOSS,
+                REASON_QUANTITY_ROUNDING_INCREASES_RISK,
+                REASON_CONTRADICTORY_REDUCE_ONLY_SEMANTICS,
+                REASON_UNBOUND_ADAPTER_FIELD,
+                REASON_UNBOUND_TRANSFORMATION,
+                REASON_MISSING_QUANTITY_PROVENANCE,
+                REASON_INVALID_QUANTITY,
+                REASON_ADAPTER_CAST_FORBIDDEN,
+                REASON_TRANSFORMATION_REQUIRED,
+                REASON_NON_FUTURES_INSTRUMENT,
+                REASON_BITCOIN_SPECIFIC_DIRECTION,
+            }
+        ),
+    }
+
+
 def canonical_order_intent_schema_v1() -> dict[str, Any]:
     return {
         "contract_name": CONTRACT_NAME,
@@ -774,6 +1189,19 @@ def canonical_order_intent_schema_v1() -> dict[str, Any]:
                 REASON_VENUE_FIELD_IN_CANONICAL,
                 REASON_MUTABLE_INTENT,
                 REASON_MISSING_PROVENANCE,
+                REASON_INVALID_INPUT_TYPE,
+                REASON_INVALID_CANONICAL_INTENT_VERSION,
+                REASON_UNSUPPORTED_SIDE,
+                REASON_UNSUPPORTED_ORDER_TYPE_POLICY,
+                REASON_UNSUPPORTED_TIME_IN_FORCE_POLICY,
+                REASON_UNBOUND_PRICE_POLICY,
+                REASON_MISSING_INSTRUMENT,
+                REASON_QUANTITY_PRECISION_LOSS,
+                REASON_QUANTITY_ROUNDING_INCREASES_RISK,
+                REASON_CONTRADICTORY_REDUCE_ONLY_SEMANTICS,
+                REASON_UNBOUND_ADAPTER_FIELD,
+                REASON_UNBOUND_TRANSFORMATION,
             }
         ),
+        "transformation_contract": canonical_order_intent_transformation_schema_v1(),
     }

--- a/src/governance/intent_compatibility_firewall_v1.py
+++ b/src/governance/intent_compatibility_firewall_v1.py
@@ -18,6 +18,10 @@ CONTRACT_NAME = "intent_compatibility_firewall_v1"
 CONTRACT_VERSION = "v1"
 SCHEMA_VERSION = "intent_compatibility_firewall_schema_v1"
 
+CANONICAL_ORDER_INTENT_OWNER_MODULE = "src.governance.canonical_order_intent_v1"
+CANONICAL_TO_ADAPTER_TRANSFORMATION_ID = "canonical_order_intent_v1_to_adapter_order_intent_v1"
+CANONICAL_TO_ADAPTER_TRANSFORMATION_VERSION = "v1"
+CANONICAL_TO_ADAPTER_FIELD_MAPPING_VERSION = "canonical_to_adapter_order_intent_field_mapping_v1"
 CANONICAL_IDENTITY_OWNER_MODULE = "src.meta.learning_loop.canonical_order_lifecycle_v1"
 CANONICAL_IDENTITY_SYMBOL = "CanonicalOrderIntentIdentity"
 CANONICAL_IDENTITY_CONTRACT_VERSION = "canonical_order_intent_identity_contract_v1"
@@ -70,6 +74,26 @@ class IntentCompatibilityVerdictV1(str, Enum):
     BLOCKED_ADAPTER_SUBMISSION_EFFECT = "BLOCKED_ADAPTER_SUBMISSION_EFFECT"
     BLOCKED_NON_FUTURES_INTENT = "BLOCKED_NON_FUTURES_INTENT"
     BLOCKED_BITCOIN_SPECIFIC_DIRECTION = "BLOCKED_BITCOIN_SPECIFIC_DIRECTION"
+
+
+@dataclass(frozen=True)
+class IntentTransformationDescriptorV1:
+    source_contract: str
+    source_version: str
+    target_contract: str
+    target_version: str
+    transformation_id: str
+    transformation_version: str
+    field_mapping_version: str
+    source_digest: str
+    target_digest: str
+    lossless_fields: tuple[str, ...]
+    rejected_unbound_fields: tuple[str, ...]
+    runtime_effect: bool
+    order_effect: bool
+    authority_effect: bool
+    network_effect: bool
+    adapter_submission_effect: bool
 
 
 @dataclass(frozen=True)
@@ -609,6 +633,21 @@ INTENT_TYPE_DESCRIPTOR_REGISTRY_V1: dict[str, IntentTypeDescriptorV1] = {
         client_order_id_binding_present=True,
         order_effect=True,
     ),
+    "CANONICAL_ORDER_INTENT_V1": _descriptor(
+        intent_type_id="CANONICAL_ORDER_INTENT_V1",
+        owner_module=CANONICAL_ORDER_INTENT_OWNER_MODULE,
+        producer_domain="governance.canonical_order_intent",
+        consumer_domain="governance.offline_transformation",
+        persistence_lifecycle="durable_evidence",
+        quantity_semantics="decimal",
+        side_semantics="LONG_SHORT",
+        reduce_only_semantics="present",
+        instrument_binding_present=True,
+        trading_epoch_binding_present=True,
+        intent_id_binding_present=True,
+        quantity_provenance_present=True,
+        canonical_identity_compatible=True,
+    ),
     "CANONICAL_ORDER_INTENT_IDENTITY": _descriptor(
         intent_type_id="CANONICAL_ORDER_INTENT_IDENTITY",
         owner_module=CANONICAL_IDENTITY_OWNER_MODULE,
@@ -647,6 +686,92 @@ INTENT_TYPE_DESCRIPTOR_REGISTRY_V1: dict[str, IntentTypeDescriptorV1] = {
 }
 
 
+def build_canonical_to_adapter_transformation_descriptor_v1(
+    *,
+    source_digest: str,
+    target_digest: str,
+    lossless_fields: tuple[str, ...],
+    rejected_unbound_fields: tuple[str, ...],
+) -> IntentTransformationDescriptorV1:
+    return IntentTransformationDescriptorV1(
+        source_contract="canonical_order_intent_v1",
+        source_version="v1",
+        target_contract="adapter_order_intent_v1",
+        target_version="v1",
+        transformation_id=CANONICAL_TO_ADAPTER_TRANSFORMATION_ID,
+        transformation_version=CANONICAL_TO_ADAPTER_TRANSFORMATION_VERSION,
+        field_mapping_version=CANONICAL_TO_ADAPTER_FIELD_MAPPING_VERSION,
+        source_digest=source_digest,
+        target_digest=target_digest,
+        lossless_fields=lossless_fields,
+        rejected_unbound_fields=rejected_unbound_fields,
+        runtime_effect=False,
+        order_effect=False,
+        authority_effect=False,
+        network_effect=False,
+        adapter_submission_effect=False,
+    )
+
+
+def evaluate_explicit_canonical_to_adapter_transformation_firewall_v1(
+    *,
+    source_digest: str,
+    target_digest: str,
+    transformation_id: str,
+) -> IntentCompatibilityResultV1:
+    """Fail-closed offline guard for explicit canonical-to-adapter transformation only."""
+
+    source = INTENT_TYPE_DESCRIPTOR_REGISTRY_V1["CANONICAL_ORDER_INTENT_V1"]
+    target = INTENT_TYPE_DESCRIPTOR_REGISTRY_V1["ADAPTER_ORDER_INTENT_V1"]
+    edge = with_computed_conversion_edge_digest(
+        IntentConversionEdgeV1(
+            source_intent_type_id="CANONICAL_ORDER_INTENT_V1",
+            target_intent_type_id="ADAPTER_ORDER_INTENT_V1",
+            conversion_kind="EXPLICIT_ADAPTER",
+            explicit_adapter_id=transformation_id,
+            explicit_policy_id="",
+            preserves_quantity_semantics=False,
+            preserves_side_semantics=False,
+            preserves_reduce_only_semantics=True,
+            preserves_instrument_binding=True,
+            preserves_venue_binding=False,
+            preserves_account_binding=False,
+            preserves_identity_binding=False,
+            preserves_authority_binding=False,
+            semantic_digest="",
+        )
+    )
+    source_digest_computed = compute_intent_type_descriptor_digest(source)
+    target_digest_computed = compute_intent_type_descriptor_digest(target)
+    edge_digest = compute_intent_conversion_edge_digest(edge)
+
+    if transformation_id != CANONICAL_TO_ADAPTER_TRANSFORMATION_ID:
+        return _result(
+            verdict=IntentCompatibilityVerdictV1.BLOCKED_IMPLICIT_CONVERSION,
+            reason_codes=[IntentCompatibilityVerdictV1.BLOCKED_IMPLICIT_CONVERSION.value],
+            source_digest=source_digest_computed,
+            target_digest=target_digest_computed,
+            edge_digest=edge_digest,
+        )
+
+    if not source_digest or not target_digest:
+        return _result(
+            verdict=IntentCompatibilityVerdictV1.BLOCKED_QUANTITY_PROVENANCE,
+            reason_codes=[IntentCompatibilityVerdictV1.BLOCKED_QUANTITY_PROVENANCE.value],
+            source_digest=source_digest_computed,
+            target_digest=target_digest_computed,
+            edge_digest=edge_digest,
+        )
+
+    return _result(
+        verdict=IntentCompatibilityVerdictV1.ADMISSIBLE,
+        reason_codes=[IntentCompatibilityVerdictV1.ADMISSIBLE.value],
+        source_digest=source_digest_computed,
+        target_digest=target_digest_computed,
+        edge_digest=edge_digest,
+    )
+
+
 def intent_compatibility_firewall_schema_v1() -> dict[str, object]:
     return {
         "contract_name": CONTRACT_NAME,
@@ -654,6 +779,7 @@ def intent_compatibility_firewall_schema_v1() -> dict[str, object]:
         "schema_version": SCHEMA_VERSION,
         "canonical_identity_reference": CANONICAL_IDENTITY_REFERENCE,
         "referenced_owners": {
+            "canonical_order_intent_v1": CANONICAL_ORDER_INTENT_OWNER_MODULE,
             "canonical_order_intent_identity": CANONICAL_IDENTITY_OWNER_MODULE,
             "order_intent_idempotency_v1": ORDER_INTENT_IDEMPOTENCY_OWNER_MODULE,
             "canonical_order_lifecycle_v1": CANONICAL_ORDER_LIFECYCLE_OWNER_MODULE,

--- a/tests/governance/test_canonical_order_intent_v1.py
+++ b/tests/governance/test_canonical_order_intent_v1.py
@@ -8,11 +8,13 @@ import inspect
 import json
 from decimal import Decimal
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 import src.governance.canonical_order_intent_v1 as intent_mod
 import src.governance.capital_risk_sizing_v1 as sizing
+from src.execution.adapters.base_v1 import OrderIntentV1
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[2] / "src" / "governance" / "canonical_order_intent_v1.py"
@@ -108,8 +110,8 @@ def _build_input(
         "canonical_trading_logic_version": "trading_logic_v1_test",
         "intent_action": intent_action,
         "policy_digest": "policy_digest_test",
-        "order_type_policy": "LIMIT_ONLY",
-        "price_policy": "REFERENCE_PRICE",
+        "order_type_policy": "MARKET_ONLY",
+        "price_policy": "EXPLICIT_NONE",
         "time_in_force_policy": "GTC",
         "max_slippage_policy": "ZERO",
         "expected_position_side": expected_side,
@@ -577,3 +579,359 @@ def test_schema_contract_complete() -> None:
 def test_import_smoke() -> None:
     mod = importlib.import_module("src.governance.canonical_order_intent_v1")
     assert inspect.isfunction(mod.build_canonical_order_intent_v1)
+    assert inspect.isfunction(mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1)
+
+
+# --- STEP 29R: canonical -> adapter transformation contract ---
+
+
+def _mutated_intent(
+    intent: intent_mod.CanonicalOrderIntentV1,
+    **kwargs: object,
+) -> intent_mod.CanonicalOrderIntentV1:
+    mutated = intent_mod.replace(intent, **kwargs)  # type: ignore[arg-type]
+    if "semantic_digest" not in kwargs:
+        mutated = intent_mod.replace(
+            mutated,
+            semantic_digest=intent_mod.compute_semantic_digest(mutated),
+        )
+    return mutated
+
+
+def _transformable_intent(**kwargs: object) -> intent_mod.CanonicalOrderIntentV1:
+    build_kwargs: dict[str, object] = {
+        "order_type_policy": "MARKET_ONLY",
+        "price_policy": "EXPLICIT_NONE",
+        "time_in_force_policy": "GTC",
+    }
+    build_kwargs.update(kwargs)
+    return _intent(**build_kwargs)
+
+
+def _transform(**kwargs: object) -> intent_mod.CanonicalOrderIntentTransformResultV1:
+    return intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(
+        _transformable_intent(**kwargs)
+    )
+
+
+def _as_order_intent_v1(
+    structural: intent_mod.AdapterOrderIntentV1StructuralV1,
+) -> OrderIntentV1:
+    meta = dict(structural.meta) if structural.meta is not None else None
+    return OrderIntentV1(
+        symbol=structural.symbol,
+        side=structural.side,  # type: ignore[arg-type]
+        qty=structural.qty,
+        order_type=structural.order_type,  # type: ignore[arg-type]
+        price=structural.price,
+        tif=structural.tif,  # type: ignore[arg-type]
+        post_only=structural.post_only,
+        reduce_only=structural.reduce_only,
+        client_id=structural.client_id,
+        meta=meta,
+    )
+
+
+def test_transform_01_long_entry_deterministic_success() -> None:
+    result = _transform(intent_action=intent_mod.IntentAction.ENTER_LONG.value)
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.PASS
+    assert result.adapter_intent is not None
+    assert result.descriptor is not None
+    adapter = _as_order_intent_v1(result.adapter_intent)
+    assert adapter.side == "buy"
+    assert adapter.reduce_only is False
+    assert adapter.symbol == "ETH-USD-PERP"
+    assert adapter.order_type == "market"
+    assert adapter.tif == "gtc"
+    assert result.descriptor.transformation_required_acknowledged is True
+
+
+def test_transform_02_short_entry_deterministic_success() -> None:
+    result = _transform(
+        intent_action=intent_mod.IntentAction.ENTER_SHORT.value,
+        sizing_overrides={
+            "selected_side": sizing.SelectedSide.SHORT.value,
+            "protective_stop_price": Decimal("2100"),
+        },
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.PASS
+    assert result.adapter_intent is not None
+    adapter = _as_order_intent_v1(result.adapter_intent)
+    assert adapter.side == "sell"
+    assert adapter.reduce_only is False
+
+
+def test_transform_03_reduce_only_exit_stays_reduce_only() -> None:
+    result = _transform(
+        intent_action=intent_mod.IntentAction.EXIT.value,
+        sizing_overrides={
+            "current_reconciled_exposure": Decimal("0.5"),
+            "current_open_positions_count": 1,
+            "current_open_side": sizing.SelectedSide.LONG.value,
+            "maximum_positions": 2,
+        },
+        current_reconciled_exposure=Decimal("0.5"),
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.PASS
+    assert result.adapter_intent is not None
+    assert result.adapter_intent.reduce_only is True
+    assert result.adapter_intent.side == "sell"
+
+
+def test_transform_04_identical_input_identical_output_and_descriptor() -> None:
+    intent = _transformable_intent()
+    first = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(intent)
+    second = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(intent)
+    assert first == second
+    assert first.descriptor is not None
+    assert second.descriptor is not None
+    assert first.descriptor.target_digest == second.descriptor.target_digest
+    assert first.descriptor.source_digest == intent.semantic_digest
+
+
+def test_transform_05_direct_cast_remains_forbidden() -> None:
+    built = _transformable_intent()
+    with pytest.raises(intent_mod.CanonicalOrderIntentError):
+        intent_mod.reject_direct_adapter_cast_v1(built, OrderIntentV1)
+
+
+def test_transform_06_missing_quantity_provenance_rejected() -> None:
+    intent = _transformable_intent()
+    bad = _mutated_intent(intent, quantity_provenance="")
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(bad)
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.BLOCKED
+    assert intent_mod.REASON_MISSING_QUANTITY_PROVENANCE in result.reason_codes
+
+
+def test_transform_07_invalid_quantity_rejected() -> None:
+    intent = _transformable_intent()
+    bad = _mutated_intent(intent, quantity=Decimal("0"))
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(bad)
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.BLOCKED
+    assert intent_mod.REASON_INVALID_QUANTITY in result.reason_codes
+
+
+def test_transform_08_risk_increasing_rounding_rejected() -> None:
+    intent = _transformable_intent()
+    bad = _mutated_intent(intent, quantity=Decimal("0.10000000000000001"))
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(bad)
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.BLOCKED
+    assert (
+        intent_mod.REASON_QUANTITY_PRECISION_LOSS in result.reason_codes
+        or intent_mod.REASON_QUANTITY_ROUNDING_INCREASES_RISK in result.reason_codes
+    )
+
+
+def test_transform_09_unbound_order_type_rejected() -> None:
+    intent = _transformable_intent()
+    bad = _mutated_intent(intent, order_type_policy="UNKNOWN_ORDER_TYPE")
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(bad)
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.BLOCKED
+    assert intent_mod.REASON_UNSUPPORTED_ORDER_TYPE_POLICY in result.reason_codes
+
+
+def test_transform_10_unbound_time_in_force_rejected() -> None:
+    intent = _transformable_intent()
+    bad = _mutated_intent(intent, time_in_force_policy="DAY")
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(bad)
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.BLOCKED
+    assert intent_mod.REASON_UNSUPPORTED_TIME_IN_FORCE_POLICY in result.reason_codes
+
+
+def test_transform_11_missing_instrument_rejected() -> None:
+    intent = _transformable_intent()
+    bad = _mutated_intent(intent, instrument_id="")
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(bad)
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.BLOCKED
+    assert intent_mod.REASON_MISSING_INSTRUMENT in result.reason_codes
+
+
+def test_transform_12_spot_rejected() -> None:
+    intent = _mutated_intent(
+        _transformable_intent(),
+        instrument_id="ETH-USD",
+        instrument_metadata_ref="spot_metadata_v1",
+    )
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(intent)
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.BLOCKED
+    assert intent_mod.REASON_NON_FUTURES_INSTRUMENT in result.reason_codes
+
+
+def test_transform_13_synthetic_spot_rejected() -> None:
+    intent = _mutated_intent(
+        _transformable_intent(),
+        instrument_id="ETH-SYN-PERP",
+        instrument_metadata_ref="synthetic_spot_metadata_v1",
+    )
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(intent)
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.BLOCKED
+    assert intent_mod.REASON_NON_FUTURES_INSTRUMENT in result.reason_codes
+
+
+def test_transform_14_contradictory_reduce_only_rejected() -> None:
+    intent = _transformable_intent(intent_action=intent_mod.IntentAction.ENTER_LONG.value)
+    bad = _mutated_intent(intent, reduce_only=True)
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(bad)
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.BLOCKED
+    assert (
+        intent_mod.REASON_CONTRADICTORY_REDUCE_ONLY_SEMANTICS in result.reason_codes
+        or intent_mod.REASON_INVALID_SIDE_ACTION_COMBINATION in result.reason_codes
+    )
+
+
+def test_transform_15_unbound_adapter_fields_not_guessed() -> None:
+    intent = _transformable_intent()
+    bad = _mutated_intent(
+        intent,
+        order_type_policy="LIMIT_ONLY",
+        price_policy="REFERENCE_PRICE",
+    )
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(bad)
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.BLOCKED
+    assert intent_mod.REASON_UNBOUND_PRICE_POLICY in result.reason_codes
+    assert result.adapter_intent is None
+
+
+def test_transform_16_no_runtime_submission_functions_called(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[str] = []
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        called.append("place_order")
+        raise AssertionError("runtime submission must not be called")
+
+    monkeypatch.setattr(
+        "src.execution.adapters.base_v1.ExecutionAdapterV1.place_order",
+        _boom,
+        raising=False,
+    )
+    result = _transform()
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.PASS
+    assert called == []
+
+
+def test_transform_17_no_permission_or_authority_fields() -> None:
+    result = _transform()
+    assert result.authority_effect is False
+    assert result.runtime_effect is False
+    assert result.order_effect is False
+    assert result.adapter_submission_effect is False
+    assert result.descriptor is not None
+    assert result.descriptor.authority_effect is False
+
+
+def test_transform_18_descriptor_has_full_provenance() -> None:
+    intent = _transformable_intent()
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(intent)
+    assert result.descriptor is not None
+    descriptor = result.descriptor
+    assert descriptor.source_contract == intent_mod.CONTRACT_NAME
+    assert descriptor.target_contract == intent_mod.TARGET_CONTRACT_NAME
+    assert descriptor.transformation_id == intent_mod.TRANSFORMATION_ID
+    assert descriptor.source_digest == intent.semantic_digest
+    assert descriptor.target_digest
+    assert descriptor.source_quantity_provenance == intent.quantity_provenance
+    assert descriptor.network_effect is False
+    assert descriptor.adapter_submission_effect is False
+
+
+def test_transform_19_source_intent_unchanged() -> None:
+    intent = _transformable_intent()
+    before = intent_mod.canonical_order_intent_to_json(intent)
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(intent)
+    after = intent_mod.canonical_order_intent_to_json(intent)
+    assert before == after
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.PASS
+
+
+@pytest.mark.parametrize(
+    "quantity",
+    [
+        Decimal("0.01"),
+        Decimal("0.50"),
+        Decimal("1.00"),
+        Decimal("12.34"),
+        Decimal("99.99"),
+    ],
+)
+def test_transform_20_output_quantity_never_exceeds_input(quantity: Decimal) -> None:
+    decision = _passing_sizing_decision()
+    assert decision.quantity_provenance is not None
+    provenance = sizing.QuantityProvenanceV1(
+        **{
+            **{
+                field.name: getattr(decision.quantity_provenance, field.name)
+                for field in sizing.QuantityProvenanceV1.__dataclass_fields__.values()
+            },
+            "final_quantity": quantity,
+            "output_digest": f"digest-{quantity}",
+        }
+    )
+    blocked = sizing.CapitalRiskSizingDecisionV1(
+        outcome=decision.outcome,
+        final_quantity=quantity,
+        selected_side=decision.selected_side,
+        capital_envelope=decision.capital_envelope,
+        pre_sizing_risk=decision.pre_sizing_risk,
+        canonical_sizing=decision.canonical_sizing,
+        post_sizing_risk=decision.post_sizing_risk,
+        quantity_provenance=provenance,
+        reason_codes=decision.reason_codes,
+    )
+    build = intent_mod.build_canonical_order_intent_v1(
+        intent_mod.CanonicalOrderIntentBuildInputV1(
+            sizing_input=_sizing_input(),
+            sizing_decision=blocked,
+            intent_id="intent-prop",
+            trading_epoch="epoch-001",
+            canonical_trading_logic_version="trading_logic_v1_test",
+            intent_action=intent_mod.IntentAction.ENTER_LONG.value,
+            policy_digest="policy_digest_test",
+            order_type_policy="MARKET_ONLY",
+            price_policy="EXPLICIT_NONE",
+            time_in_force_policy="GTC",
+            max_slippage_policy="ZERO",
+            expected_position_side=intent_mod.IntentSide.LONG.value,
+            current_reconciled_exposure=Decimal("0"),
+        )
+    )
+    if build.intent is None:
+        return
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(build.intent)
+    if result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.PASS:
+        assert result.adapter_intent is not None
+        assert Decimal(str(result.adapter_intent.qty)) <= build.intent.quantity
+
+
+def test_transform_21_long_short_symmetry() -> None:
+    long_result = _transform(intent_action=intent_mod.IntentAction.ENTER_LONG.value)
+    short_result = _transform(
+        intent_action=intent_mod.IntentAction.ENTER_SHORT.value,
+        sizing_overrides={
+            "selected_side": sizing.SelectedSide.SHORT.value,
+            "protective_stop_price": Decimal("2100"),
+        },
+    )
+    assert long_result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.PASS
+    assert short_result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.PASS
+    assert long_result.adapter_intent is not None
+    assert short_result.adapter_intent is not None
+    assert long_result.adapter_intent.side == "buy"
+    assert short_result.adapter_intent.side == "sell"
+
+
+def test_transform_22_futures_only_and_no_bitcoin_direction() -> None:
+    schema = intent_mod.canonical_order_intent_transformation_schema_v1()
+    assert intent_mod.FUTURES_ONLY is True
+    assert intent_mod.BITCOIN_DIRECTION_ALLOWED is False
+    assert schema["invariants"]["full_adapter_compatibility_proven"] is False
+    result = intent_mod.transform_canonical_order_intent_v1_to_adapter_order_intent_v1(
+        _mutated_intent(
+            _transformable_intent(),
+            instrument_id="BTC-USD-PERP",
+            instrument_metadata_ref="btc_perp_metadata_v1",
+        )
+    )
+    assert result.outcome is intent_mod.CanonicalOrderIntentTransformOutcome.BLOCKED
+    assert intent_mod.REASON_BITCOIN_SPECIFIC_DIRECTION in result.reason_codes

--- a/tests/governance/test_intent_compatibility_firewall_v1.py
+++ b/tests/governance/test_intent_compatibility_firewall_v1.py
@@ -444,3 +444,45 @@ def test_deterministic_double_run_of_full_test_module() -> None:
             )
         )
     assert payloads[0] == payloads[1]
+
+
+def test_29_canonical_order_intent_v1_registry_entry_present() -> None:
+    assert "CANONICAL_ORDER_INTENT_V1" in firewall.INTENT_TYPE_DESCRIPTOR_REGISTRY_V1
+    descriptor = firewall.INTENT_TYPE_DESCRIPTOR_REGISTRY_V1["CANONICAL_ORDER_INTENT_V1"]
+    assert descriptor.owner_module == firewall.CANONICAL_ORDER_INTENT_OWNER_MODULE
+    assert descriptor.quantity_provenance_present is True
+
+
+def test_30_explicit_canonical_to_adapter_transformation_firewall_admissible() -> None:
+    result = firewall.evaluate_explicit_canonical_to_adapter_transformation_firewall_v1(
+        source_digest="a" * 64,
+        target_digest="b" * 64,
+        transformation_id=firewall.CANONICAL_TO_ADAPTER_TRANSFORMATION_ID,
+    )
+    assert result.verdict is firewall.IntentCompatibilityVerdictV1.ADMISSIBLE
+    assert result.runtime_effect is False
+    assert result.order_effect is False
+    assert result.authority_effect is False
+    assert result.transformation_performed is False
+
+
+def test_31_unknown_transformation_id_blocks() -> None:
+    result = firewall.evaluate_explicit_canonical_to_adapter_transformation_firewall_v1(
+        source_digest="a" * 64,
+        target_digest="b" * 64,
+        transformation_id="unknown.transformation.v0",
+    )
+    assert result.verdict is firewall.IntentCompatibilityVerdictV1.BLOCKED_IMPLICIT_CONVERSION
+
+
+def test_32_transformation_descriptor_builder_fields() -> None:
+    descriptor = firewall.build_canonical_to_adapter_transformation_descriptor_v1(
+        source_digest="source",
+        target_digest="target",
+        lossless_fields=("instrument_id->symbol",),
+        rejected_unbound_fields=("client_id",),
+    )
+    assert descriptor.transformation_id == firewall.CANONICAL_TO_ADAPTER_TRANSFORMATION_ID
+    assert descriptor.runtime_effect is False
+    assert descriptor.adapter_submission_effect is False
+    assert descriptor.network_effect is False


### PR DESCRIPTION
## Summary

- Binds the previously unbound offline transformation between `CanonicalOrderIntentV1` (STEP 29Q) and adapter-near `OrderIntentV1` via explicit entrypoint `transform_canonical_order_intent_v1_to_adapter_order_intent_v1`.
- Extends the intent compatibility firewall with `CANONICAL_ORDER_INTENT_V1` registry entry and explicit transformation guard; direct cast remains forbidden.
- Proves **structural** adapter field mapping with deterministic descriptor/provenance; does **not** claim full semantic/runtime/submission compatibility.

## Problem

STEP 29Q introduced a fail-closed canonical intent with `transformation_required=true`, but no explicit offline transform to the adapter `OrderIntentV1` shape existed. Implicit casts were correctly rejected; the transformation seam remained unbound.

## Reuse decision

- **REUSE_AS_IS**: canonical intent builder/validator, reject-only cast firewall, STEP 29O firewall evaluation patterns.
- **REUSE_WITH_NARROW_ADAPTER**: `AdapterOrderIntentV1StructuralV1` mirrors `OrderIntentV1` fields without importing runtime adapter code into governance modules.
- **No new canonical intent owner**; transformation owner remains `src/governance/canonical_order_intent_v1.py`.

## Transformation contract

- Explicit id: `canonical_order_intent_v1_to_adapter_order_intent_v1` (`v1`)
- Deterministic, side-effect-free, I/O-free, no runtime/submission calls
- Descriptor documents source/target digests, field mapping version, lossless fields, rejected unbound fields, and `transformation_required_acknowledged`
- Policy bindings: `MARKET_ONLY`/`LIMIT_ONLY`, `GTC`/`IOC`/`FOK`, `EXPLICIT_NONE` / `EXPLICIT_PRICE:<decimal>`; unbound policies fail closed
- Quantity: exact Decimal→float representability required; precision loss or risk-increasing rounding rejected

## Fail-closed matrix

Rejects wrong input type, invalid intent version, missing quantity provenance, invalid/non-positive quantity, unsupported side/order-type/TIF, contradictory reduce-only semantics, missing instrument, spot/synthetic spot, bitcoin-specific instruments, unbound price/client/venue/account fields, unknown transformation id, and direct cast paths.

## Tests

- 22 new transformation contract tests in `test_canonical_order_intent_v1.py`
- 4 firewall extension tests in `test_intent_compatibility_firewall_v1.py`
- Local: **189 passed**, scope tests all green

## Known pre-existing non-scope deviation

`tests/ops/test_runbook_step29n_progress_registry_closeout_contract_v0.py::test_progress_registry_closeout_performed_true` expects global `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED=true`, while STEP 29R registry start correctly keeps global value `false`. This conflict exists on `origin/main` and was **not** introduced or repaired by this slice (`KNOWN_PRE_EXISTING_NON_SCOPE_CONFLICT=true`).

## Safety / registry boundary

- **No runtime rewire** — `RUNTIME_REWIRE_IMPLEMENTATION_ALLOWED=false` unchanged
- **No registry file changes** in this implementation slice
- `CANONICAL_ORDER_INTENT_TRANSFORMATION_BOUND=true` (offline contract only)
- `CANONICAL_ORDER_INTENT_STRUCTURAL_ADAPTER_COMPATIBILITY_PROVEN=true`
- `CANONICAL_ORDER_INTENT_ADAPTER_COMPATIBILITY_PROVEN=false`
- `ECONOMIC_VALIDITY_OFFLINE_GATE_PASS=false` unchanged
- `RUNTIME_EFFECT=false`, `ORDER_EFFECT=false`, `AUTHORITY_EFFECT=false`, `LIVE_AUTHORIZED=false`

## Test plan

- [x] `pytest tests/governance/test_canonical_order_intent_v1.py tests/governance/test_intent_compatibility_firewall_v1.py`
- [x] STEP 29O/29Q/29R registry contract tests (1 known pre-existing 29N global conflict)
- [x] `ruff format --check` + `ruff check` on changed files
- [x] CI selector: `PR_BOUNDED_FULL` (`category_central_src_requires_full`)


Made with [Cursor](https://cursor.com)