### PR TITLE
feat(ops): add offline economic evidence evaluation runner

### DIFF
--- a/scripts/ops/run_economic_viability_evidence_evaluation_v1.py
+++ b/scripts/ops/run_economic_viability_evidence_evaluation_v1.py
@@ -1,0 +1,868 @@
+#!/usr/bin/env python3
+"""Offline economic viability evidence evaluation runner v1 (RUNBOOK STEP 29M).
+
+Thin ops orchestrator over existing library owners. Strictly offline: no network,
+no credentials, no runtime/order/venue effects. Non-authorizing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional
+from urllib.parse import urlparse
+
+import pandas as pd
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SRC_ROOT = _REPO_ROOT / "src"
+for _path in (_SRC_ROOT, _REPO_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from scripts.ops.primary_evidence_retention_v0 import (  # noqa: E402
+    MANIFEST_FILENAME,
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.backtest import admissible_versioned_futures_dataset_v1 as ds  # noqa: E402
+from src.backtest import economic_validity_policy_v1 as policy_mod  # noqa: E402
+from src.backtest import economic_viability_evidence_v1 as ev  # noqa: E402
+from src.backtest import mv2_research_wiring_v1 as mv2_wiring  # noqa: E402
+from src.backtest import parameter_sensitivity_v1 as ps  # noqa: E402
+from src.backtest.economic_validity_policy_v1 import (  # noqa: E402
+    ECONOMIC_VALIDITY_POLICY_VERSION,
+    EconomicValidityEvaluationStatus,
+    EconomicValidityEvidenceMetricsV1,
+    evaluate_economic_validity_against_policy_v1,
+    validate_economic_validity_policy_v1,
+)
+from src.backtest.funding_model_v1 import load_funding_model_config_v1  # noqa: E402
+from src.trading.master_v2.integrated_offline_trading_logic_replay_v1 import (  # noqa: E402
+    INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
+)
+
+RUNNER_VERSION = "run_economic_viability_evidence_evaluation_v1"
+RUNNER_OWNER = "scripts.ops.run_economic_viability_evidence_evaluation_v1"
+MANIFEST_CONTRACT_VERSION = "admissible_versioned_futures_dataset_manifest_v1"
+OFFLINE_CREATED_AT_UTC = ev.OFFLINE_DETERMINISTIC_CREATED_AT
+
+USAGE_EXIT = 2
+VALIDATION_EXIT = 1
+
+_URL_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
+_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+
+_FORBIDDEN_SOURCE_TYPES = frozenset(
+    {
+        "spot",
+        "synthetic_spot",
+        "synthetic_contract_fixture",
+        "test_fixture",
+        "preview",
+        "preview_data",
+        "probe",
+        "probe_data",
+        "transport_fixture",
+        "transport",
+        "webui_fixture",
+        "webui",
+    }
+)
+_FORBIDDEN_GENERATION_MARKERS = frozenset(
+    {
+        "deterministic_test_fixture",
+        "test_fixture",
+        "probe",
+        "preview",
+        "transport_fixture",
+        "webui_fixture",
+    }
+)
+
+
+class DatasetFixtureClass(str, Enum):
+    REAL_ADMISSIBLE_VERSIONED_FUTURES_DATASET = "REAL_ADMISSIBLE_VERSIONED_FUTURES_DATASET"
+    TEST_FIXTURE = "TEST_FIXTURE"
+    SYNTHETIC_FIXTURE = "SYNTHETIC_FIXTURE"
+    PREVIEW_DATA = "PREVIEW_DATA"
+    PROBE_DATA = "PROBE_DATA"
+    TRANSPORT_FIXTURE = "TRANSPORT_FIXTURE"
+    WEBUI_FIXTURE = "WEBUI_FIXTURE"
+    SPOT_DATA = "SPOT_DATA"
+    SYNTHETIC_SPOT_DATA = "SYNTHETIC_SPOT_DATA"
+    UNKNOWN_DATA_CLASS = "UNKNOWN_DATA_CLASS"
+
+
+class RunnerError(Exception):
+    """Fail-closed runner validation error."""
+
+
+@dataclass(frozen=True)
+class ValidationPlanV1:
+    run_id: str
+    dataset_path: str
+    dataset_manifest_path: str
+    config_path: str
+    policy_path: str
+    output_dir: str
+    dataset_fixture_class: str
+    dataset_admissible: bool
+    owners: tuple[str, ...]
+    planned_outputs: tuple[str, ...]
+    validate_only: bool
+
+
+@dataclass(frozen=True)
+class RunOutcomeV1:
+    run_id: str
+    dataset_id: str
+    dataset_version: str
+    dataset_fixture_class: DatasetFixtureClass
+    dataset_admissible: bool
+    economic_evidence_built: bool
+    economic_gate_evaluated: bool
+    economic_validity_result: str
+    economic_validity_offline_gate_pass: bool
+    promotion_eligibility: bool
+    runner_execution_success: bool
+    manifest_verify_rc: int
+    output_dir: Path
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _reject_url_path(path_str: str) -> None:
+    if _URL_SCHEME_RE.match(path_str.strip()):
+        raise RunnerError(f"url_path_forbidden:{path_str}")
+    parsed = urlparse(path_str)
+    if parsed.scheme and parsed.scheme not in {"", "file"}:
+        raise RunnerError(f"url_path_forbidden:{path_str}")
+
+
+def _resolve_local_path(path_str: str, *, field_name: str) -> Path:
+    if not path_str or not str(path_str).strip():
+        raise RunnerError(f"{field_name}_missing")
+    _reject_url_path(path_str)
+    path = Path(path_str).expanduser()
+    if not path.is_absolute():
+        path = (_REPO_ROOT / path).resolve()
+    else:
+        path = path.resolve()
+    return path
+
+
+def _load_json_file(path: Path, *, field_name: str) -> dict[str, Any]:
+    if not path.is_file():
+        raise RunnerError(f"{field_name}_not_found:{path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RunnerError(f"{field_name}_invalid_json:{path}") from exc
+    if not isinstance(payload, dict):
+        raise RunnerError(f"{field_name}_not_object:{path}")
+    return payload
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    if path.suffix.lower() == ".json":
+        return _load_json_file(path, field_name="config")
+    if path.suffix.lower() in {".toml", ".tml"}:
+        try:
+            import tomllib
+        except ModuleNotFoundError:  # pragma: no cover
+            import tomli as tomllib  # type: ignore[no-redef]
+        try:
+            return tomllib.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise RunnerError(f"config_invalid_toml:{path}") from exc
+    raise RunnerError(f"config_unsupported_format:{path.suffix}")
+
+
+def _load_policy_overlay(path: Path) -> dict[str, Any]:
+    payload = _load_json_file(path, field_name="policy")
+    if payload.get("use_canonical") is True:
+        if str(payload.get("policy_version", ECONOMIC_VALIDITY_POLICY_VERSION)) != (
+            ECONOMIC_VALIDITY_POLICY_VERSION
+        ):
+            raise RunnerError("policy_version_mismatch")
+        return {}
+    section = payload.get("economic_validity_policy", payload)
+    if not isinstance(section, Mapping):
+        raise RunnerError("policy_section_missing")
+    return {"economic_validity_policy": dict(section)}
+
+
+def _merge_policy_into_config(cfg: dict[str, Any], policy_path: Optional[Path]) -> dict[str, Any]:
+    merged = dict(cfg)
+    if policy_path is None:
+        return merged
+    overlay = _load_policy_overlay(policy_path)
+    merged.update(overlay)
+    return merged
+
+
+def classify_dataset_fixture_class_v1(
+    *,
+    descriptor: ds.VersionedFuturesDatasetDescriptorV1,
+    provenance: ds.DatasetProvenanceV1,
+    dataset_path: Path,
+    manifest_path: Path,
+) -> DatasetFixtureClass:
+    source = provenance.source_type.lower().strip()
+    generation = provenance.generation_method.lower().strip()
+    provenance_ref = provenance.provenance_ref.lower().strip()
+    path_text = f"{dataset_path} {manifest_path}".lower()
+
+    if source == "spot":
+        return DatasetFixtureClass.SPOT_DATA
+    if source == "synthetic_spot":
+        return DatasetFixtureClass.SYNTHETIC_SPOT_DATA
+    if source == "synthetic_contract_fixture":
+        return DatasetFixtureClass.SYNTHETIC_FIXTURE
+    if source in {"preview", "preview_data"}:
+        return DatasetFixtureClass.PREVIEW_DATA
+    if source in {"probe", "probe_data"}:
+        return DatasetFixtureClass.PROBE_DATA
+    if source in {"transport_fixture", "transport"}:
+        return DatasetFixtureClass.TRANSPORT_FIXTURE
+    if source in {"webui_fixture", "webui"}:
+        return DatasetFixtureClass.WEBUI_FIXTURE
+    if source == "test_fixture":
+        return DatasetFixtureClass.TEST_FIXTURE
+
+    if provenance_ref.startswith("tests/") or "/tests/" in provenance_ref:
+        return DatasetFixtureClass.TEST_FIXTURE
+    if "tests/fixtures" in path_text or "/fixtures/" in path_text:
+        return DatasetFixtureClass.TEST_FIXTURE
+    if "webui" in provenance_ref and "fixture" in provenance_ref:
+        return DatasetFixtureClass.WEBUI_FIXTURE
+
+    for marker in _FORBIDDEN_GENERATION_MARKERS:
+        if marker in generation:
+            if "test" in marker:
+                return DatasetFixtureClass.TEST_FIXTURE
+            if "probe" in marker:
+                return DatasetFixtureClass.PROBE_DATA
+            if "preview" in marker:
+                return DatasetFixtureClass.PREVIEW_DATA
+            if "transport" in marker:
+                return DatasetFixtureClass.TRANSPORT_FIXTURE
+            if "webui" in marker:
+                return DatasetFixtureClass.WEBUI_FIXTURE
+            return DatasetFixtureClass.SYNTHETIC_FIXTURE
+
+    if descriptor.contract_type.lower() == "spot" or not descriptor.futures_only:
+        return DatasetFixtureClass.SPOT_DATA
+
+    return DatasetFixtureClass.REAL_ADMISSIBLE_VERSIONED_FUTURES_DATASET
+
+
+def _fixture_class_blocks_evaluation(fixture_class: DatasetFixtureClass) -> bool:
+    return fixture_class is not DatasetFixtureClass.REAL_ADMISSIBLE_VERSIONED_FUTURES_DATASET
+
+
+def _compute_manifest_digest(payload: Mapping[str, Any]) -> str:
+    body = {key: value for key, value in payload.items() if key != "manifest_digest"}
+    return _stable_digest(body)
+
+
+def _load_dataset_manifest(path: Path) -> dict[str, Any]:
+    manifest = _load_json_file(path, field_name="dataset_manifest")
+    version = str(manifest.get("manifest_version", ""))
+    if version and version != MANIFEST_CONTRACT_VERSION:
+        raise RunnerError(f"manifest_version_unknown:{version}")
+    expected = manifest.get("manifest_digest")
+    if expected:
+        if not _SHA256_HEX_RE.match(str(expected)):
+            raise RunnerError("manifest_digest_invalid")
+        computed = _compute_manifest_digest(manifest)
+        if computed != str(expected):
+            raise RunnerError("manifest_digest_mismatch")
+    return manifest
+
+
+def _descriptor_from_manifest(
+    manifest: Mapping[str, Any],
+) -> ds.VersionedFuturesDatasetDescriptorV1:
+    dataset_raw = manifest.get("dataset")
+    if not isinstance(dataset_raw, Mapping):
+        raise RunnerError("manifest_dataset_missing")
+    provenance_raw = manifest.get("provenance")
+    if not isinstance(provenance_raw, Mapping):
+        raise RunnerError("manifest_provenance_missing")
+    cfg = {
+        "backtest": {
+            "dataset_admissibility": {
+                "bind": True,
+                "dataset": dict(dataset_raw),
+                "provenance": dict(provenance_raw),
+            }
+        }
+    }
+    descriptor, _provenance = ds.load_dataset_admissibility_from_cfg(cfg)
+    if descriptor.dataset_version != ds.DEFAULT_DATASET_VERSION:
+        raise RunnerError(f"dataset_version_unknown:{descriptor.dataset_version}")
+    if descriptor.dataset_schema_version != ds.DATASET_SCHEMA_VERSION:
+        raise RunnerError(f"dataset_schema_version_unknown:{descriptor.dataset_schema_version}")
+    return descriptor
+
+
+def _provenance_from_manifest(manifest: Mapping[str, Any]) -> ds.DatasetProvenanceV1:
+    provenance_raw = manifest.get("provenance")
+    if not isinstance(provenance_raw, Mapping):
+        raise RunnerError("manifest_provenance_missing")
+    if not str(provenance_raw.get("source_type", "")).strip():
+        raise RunnerError("provenance_source_type_missing")
+    if not str(provenance_raw.get("provenance_ref", "")).strip():
+        raise RunnerError("provenance_ref_missing")
+    return ds.DatasetProvenanceV1(
+        source_type=str(provenance_raw["source_type"]),
+        venue_id=str(provenance_raw["venue_id"]),
+        ingestion_timestamp=str(provenance_raw["ingestion_timestamp"]),
+        generation_method=str(provenance_raw["generation_method"]),
+        provenance_ref=str(provenance_raw["provenance_ref"]),
+    )
+
+
+def _load_bars_from_dataset_path(path: Path) -> pd.DataFrame:
+    if not path.is_file():
+        raise RunnerError(f"dataset_path_not_found:{path}")
+    suffix = path.suffix.lower()
+    if suffix == ".parquet":
+        frame = pd.read_parquet(path)
+    elif suffix == ".csv":
+        frame = pd.read_csv(path, index_col=0, parse_dates=True)
+    else:
+        raise RunnerError(f"dataset_format_unsupported:{suffix}")
+    if not isinstance(frame.index, pd.DatetimeIndex):
+        if "timestamp" in frame.columns:
+            frame = frame.set_index("timestamp")
+            frame.index = pd.to_datetime(frame.index, utc=True)
+        else:
+            raise RunnerError("dataset_index_not_datetime")
+    if frame.index.tz is None:
+        frame.index = frame.index.tz_localize("UTC")
+    return frame.sort_index()
+
+
+def _validate_evaluation_config(cfg: Mapping[str, Any]) -> None:
+    backtest = cfg.get("backtest")
+    if not isinstance(backtest, Mapping):
+        raise RunnerError("config_backtest_missing")
+    if not str(backtest.get("cost_model_version", "")).strip():
+        raise RunnerError("cost_model_version_missing")
+    fee_bps = backtest.get("fee_bps")
+    slippage_bps = backtest.get("slippage_bps")
+    if fee_bps is None or slippage_bps is None:
+        raise RunnerError("fee_or_slippage_binding_missing")
+    if float(fee_bps) <= 0.0 or float(slippage_bps) <= 0.0:
+        raise RunnerError("implicit_zero_cost_forbidden")
+    funding = backtest.get("funding")
+    if not isinstance(funding, Mapping) or funding.get("bind") is not True:
+        raise RunnerError("funding_binding_missing")
+    try:
+        load_funding_model_config_v1(cfg)
+    except Exception as exc:
+        raise RunnerError(f"funding_binding_invalid:{exc}") from exc
+    if not ps.parameter_sensitivity_binding_requested(cfg):
+        raise RunnerError("parameter_sensitivity_binding_missing")
+    eval_section = cfg.get("economic_evaluation_v1")
+    if not isinstance(eval_section, Mapping):
+        raise RunnerError("economic_evaluation_v1_missing")
+    for section_name in ("walk_forward", "monte_carlo", "stress"):
+        section = eval_section.get(section_name)
+        if not isinstance(section, Mapping) or section.get("bind") is not True:
+            raise RunnerError(f"{section_name}_binding_missing")
+    if not ds.dataset_admissibility_binding_requested(cfg):
+        raise RunnerError("dataset_admissibility_binding_missing")
+
+
+def _resolve_strategy_id(cfg: Mapping[str, Any]) -> str:
+    eval_section = cfg.get("economic_evaluation_v1")
+    if isinstance(eval_section, Mapping) and eval_section.get("strategy_id"):
+        return str(eval_section["strategy_id"])
+    return "ma_crossover"
+
+
+def _evaluation_params(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    section = cfg["economic_evaluation_v1"]
+    wf = section["walk_forward"]
+    mc = section["monte_carlo"]
+    return {
+        "walk_forward_train_bars": int(wf.get("train_bars", 8)),
+        "walk_forward_test_bars": int(wf.get("test_bars", 4)),
+        "walk_forward_step_bars": int(wf.get("step_bars", 4)),
+        "monte_carlo_runs": int(mc.get("runs", 16)),
+        "monte_carlo_seed": int(mc.get("seed", 42)),
+    }
+
+
+def _derive_run_id(
+    *,
+    explicit_run_id: str,
+    dataset_digest: str,
+    config_digest: str,
+    policy_digest: str,
+) -> str:
+    if explicit_run_id.strip():
+        return explicit_run_id.strip()
+    digest = _stable_digest(
+        {
+            "runner": RUNNER_VERSION,
+            "dataset_digest": dataset_digest,
+            "config_digest": config_digest,
+            "policy_digest": policy_digest,
+        }
+    )
+    return f"econ_evidence_eval_v1_{digest[:16]}"
+
+
+def _resolve_policy(cfg: Mapping[str, Any]) -> policy_mod.EconomicValidityPolicyV1:
+    policy = policy_mod.resolve_economic_validity_policy_v1(cfg)
+    validate_economic_validity_policy_v1(policy)
+    if not policy.is_version_bound():
+        raise RunnerError("policy_version_unbound")
+    if not policy.thresholds_configured():
+        raise RunnerError("policy_thresholds_not_configured")
+    return policy
+
+
+def _validate_output_dir(path: Path, *, allow_existing: bool) -> None:
+    if path.exists():
+        if not allow_existing:
+            raise RunnerError(f"output_dir_exists:{path}")
+        if any(path.iterdir()):
+            raise RunnerError(f"output_dir_nonempty:{path}")
+
+
+def _map_validity_result(status: EconomicValidityEvaluationStatus) -> str:
+    return status.value
+
+
+def _wf_pass_ratio_from_evidence(wf_payload: Any) -> Optional[float]:
+    if not isinstance(wf_payload, Mapping):
+        return None
+    windows = wf_payload.get("windows")
+    if not isinstance(windows, list) or not windows:
+        return None
+    passed = sum(1 for window in windows if float(window.get("oos_total_return", -1.0)) >= 0.0)
+    return passed / len(windows)
+
+
+def _mc_pass_ratio_from_evidence(mc_payload: Any) -> Optional[float]:
+    if not isinstance(mc_payload, Mapping):
+        return None
+    quantiles = mc_payload.get("metric_quantiles")
+    if not isinstance(quantiles, Mapping):
+        return None
+    total_return = quantiles.get("total_return")
+    if not isinstance(total_return, Mapping):
+        return None
+    p50 = total_return.get("p50")
+    if p50 is None:
+        return None
+    return 1.0 if float(p50) >= 0.0 else 0.0
+
+
+def _stress_failure_count_from_evidence(stress_payload: Any) -> Optional[int]:
+    if not isinstance(stress_payload, Mapping):
+        return None
+    suite = stress_payload.get("suite")
+    if not isinstance(suite, Mapping):
+        return None
+    scenarios = suite.get("scenarios")
+    if not isinstance(scenarios, list):
+        return None
+    failures = 0
+    for scenario in scenarios:
+        if not isinstance(scenario, Mapping):
+            continue
+        stressed_return = scenario.get("stressed_total_return")
+        if stressed_return is None or float(stressed_return) < 0.0:
+            failures += 1
+    return failures
+
+
+def _build_gate_metrics_from_evidence(
+    evidence: ev.EconomicViabilityEvidenceV1,
+) -> EconomicValidityEvidenceMetricsV1:
+    wf = evidence.walk_forward_results
+    mc = evidence.monte_carlo_results
+    stress = evidence.stress_results
+    ps_payload = evidence.parameter_sensitivity_results
+    funding_bound = evidence.cost_binding.get("funding_binding_status") == "BOUND"
+    return EconomicValidityEvidenceMetricsV1(
+        net_expectancy=evidence.net_expectancy.value,
+        profit_factor=evidence.profit_factor.value,
+        max_drawdown=evidence.max_drawdown.value,
+        trade_count=int(evidence.trade_count.value or 0),
+        walk_forward_pass_ratio=_wf_pass_ratio_from_evidence(wf),
+        out_of_sample_pass_ratio=_wf_pass_ratio_from_evidence(wf),
+        monte_carlo_pass_ratio=_mc_pass_ratio_from_evidence(mc),
+        stress_failure_count=_stress_failure_count_from_evidence(stress),
+        parameter_robustness_pass=(
+            bool(ps_payload.get("parameter_robustness_policy_pass"))
+            if isinstance(ps_payload, Mapping)
+            else None
+        ),
+        data_admissibility_status=(
+            "PASS" if evidence.data_admissibility.get("binding_status") == "PASS" else "FAIL"
+        ),
+        cost_model_status="PASS" if evidence.fee_model_version != "NOT_BOUND" else "FAIL",
+        funding_binding_status="PASS" if funding_bound else "FAIL",
+        execution_model_status=(
+            "PASS" if evidence.execution_model_version != "NOT_BOUND" else "FAIL"
+        ),
+        reproducibility_status="PASS",
+        digest_binding_status="PASS",
+        manifest_binding_status="PASS",
+    )
+
+
+def _write_run_summary_env(path: Path, fields: Mapping[str, Any]) -> None:
+    lines = [f"{key}={value}" for key, value in fields.items()]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Offline economic viability evidence evaluation runner v1 "
+            "(STEP 29M; non-authorizing; no network/runtime effects)."
+        )
+    )
+    parser.add_argument("--dataset-path", required=True, help="Local futures bar dataset file.")
+    parser.add_argument(
+        "--dataset-manifest-path",
+        required=True,
+        help="Versioned dataset manifest JSON (descriptor + provenance).",
+    )
+    parser.add_argument(
+        "--config-path", required=True, help="Versioned evaluation config JSON/TOML."
+    )
+    parser.add_argument(
+        "--policy-path",
+        default="",
+        help="Optional versioned economic validity policy JSON overlay.",
+    )
+    parser.add_argument(
+        "--output-dir", required=True, help="Output directory for evidence artifacts."
+    )
+    parser.add_argument(
+        "--run-id",
+        default="",
+        help="Explicit run id; otherwise derived deterministically from digests.",
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Validate inputs and bindings only; do not build economic evidence.",
+    )
+    parser.add_argument(
+        "--allow-existing-output",
+        action="store_true",
+        help="Allow writing to an existing empty output directory.",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable plan/result JSON."
+    )
+    return parser
+
+
+def build_validation_plan(args: argparse.Namespace) -> ValidationPlanV1:
+    dataset_path = _resolve_local_path(args.dataset_path, field_name="dataset_path")
+    manifest_path = _resolve_local_path(args.dataset_manifest_path, field_name="dataset_manifest")
+    config_path = _resolve_local_path(args.config_path, field_name="config_path")
+    output_dir = _resolve_local_path(args.output_dir, field_name="output_dir")
+    policy_path = (
+        _resolve_local_path(args.policy_path, field_name="policy_path")
+        if args.policy_path
+        else None
+    )
+
+    if not dataset_path.is_file():
+        raise RunnerError(f"dataset_path_not_found:{dataset_path}")
+    manifest = _load_dataset_manifest(manifest_path)
+    descriptor = _descriptor_from_manifest(manifest)
+    provenance = _provenance_from_manifest(manifest)
+    fixture_class = classify_dataset_fixture_class_v1(
+        descriptor=descriptor,
+        provenance=provenance,
+        dataset_path=dataset_path,
+        manifest_path=manifest_path,
+    )
+    if provenance.source_type.lower() in _FORBIDDEN_SOURCE_TYPES:
+        raise RunnerError(f"source_type_forbidden:{provenance.source_type}")
+    if _fixture_class_blocks_evaluation(fixture_class):
+        raise RunnerError(f"dataset_fixture_class_forbidden:{fixture_class.value}")
+
+    cfg = _merge_policy_into_config(_load_config(config_path), policy_path)
+    _validate_evaluation_config(cfg)
+    policy = _resolve_policy(cfg)
+
+    bars = _load_bars_from_dataset_path(dataset_path)
+    admissibility = ds.evaluate_admissible_versioned_futures_dataset_v1(
+        bars=bars,
+        descriptor=descriptor,
+        provenance=provenance,
+        instrument_id=descriptor.instrument_id,
+    )
+    if not admissibility.is_admissible():
+        raise RunnerError(f"dataset_not_admissible:{admissibility.admissibility_status.value}")
+
+    config_digest = _stable_digest(cfg)
+    run_id = _derive_run_id(
+        explicit_run_id=str(args.run_id),
+        dataset_digest=admissibility.dataset_digest,
+        config_digest=config_digest,
+        policy_digest=policy.policy_digest(),
+    )
+    _validate_output_dir(output_dir, allow_existing=bool(args.allow_existing_output))
+
+    return ValidationPlanV1(
+        run_id=run_id,
+        dataset_path=str(dataset_path),
+        dataset_manifest_path=str(manifest_path),
+        config_path=str(config_path),
+        policy_path=str(policy_path) if policy_path else "",
+        output_dir=str(output_dir),
+        dataset_fixture_class=fixture_class.value,
+        dataset_admissible=admissibility.is_admissible(),
+        owners=(
+            ev.ECONOMIC_VIABILITY_EVIDENCE_OWNER,
+            ds.ADMISSIBLE_VERSIONED_FUTURES_DATASET_OWNER,
+            mv2_wiring.MV2_RESEARCH_WIRING_OWNER,
+            policy_mod.ECONOMIC_VALIDITY_POLICY_OWNER,
+        ),
+        planned_outputs=(
+            ev.ARTIFACT_FILENAME,
+            "economic_validity_evaluation_v1.json",
+            "dataset_admissibility_result_v1.json",
+            "run_summary.env",
+            MANIFEST_FILENAME,
+        ),
+        validate_only=bool(args.validate_only),
+    )
+
+
+def execute_evaluation(args: argparse.Namespace) -> RunOutcomeV1:
+    plan = build_validation_plan(args)
+    if plan.validate_only:
+        return RunOutcomeV1(
+            run_id=plan.run_id,
+            dataset_id="",
+            dataset_version="",
+            dataset_fixture_class=DatasetFixtureClass(plan.dataset_fixture_class),
+            dataset_admissible=plan.dataset_admissible,
+            economic_evidence_built=False,
+            economic_gate_evaluated=False,
+            economic_validity_result="NOT_PROVEN",
+            economic_validity_offline_gate_pass=False,
+            promotion_eligibility=False,
+            runner_execution_success=True,
+            manifest_verify_rc=0,
+            output_dir=Path(plan.output_dir),
+        )
+
+    dataset_path = Path(plan.dataset_path)
+    manifest_path = Path(plan.dataset_manifest_path)
+    config_path = Path(plan.config_path)
+    output_dir = Path(plan.output_dir)
+    policy_path = Path(plan.policy_path) if plan.policy_path else None
+
+    manifest = _load_dataset_manifest(manifest_path)
+    descriptor = _descriptor_from_manifest(manifest)
+    provenance = _provenance_from_manifest(manifest)
+    fixture_class = DatasetFixtureClass(plan.dataset_fixture_class)
+    cfg = _merge_policy_into_config(_load_config(config_path), policy_path)
+    policy = _resolve_policy(cfg)
+    bars = _load_bars_from_dataset_path(dataset_path)
+    admissibility = ds.evaluate_admissible_versioned_futures_dataset_v1(
+        bars=bars,
+        descriptor=descriptor,
+        provenance=provenance,
+        instrument_id=descriptor.instrument_id,
+    )
+    admissibility_payload = ds.serialize_dataset_admissibility_binding_v1(admissibility)
+
+    cfg = dict(cfg)
+    backtest = dict(cfg.get("backtest", {}))
+    dataset_section = dict(backtest.get("dataset_admissibility", {}))
+    dataset_section["bind"] = True
+    dataset_section["dataset"] = descriptor.to_dict()
+    dataset_section["provenance"] = provenance.to_dict()
+    backtest["dataset_admissibility"] = dataset_section
+    cfg["backtest"] = backtest
+
+    strategy_id = _resolve_strategy_id(cfg)
+    params = _evaluation_params(cfg)
+    data_admissibility = ev.DataAdmissibilityV1(
+        source_kind=ev.DataSourceKind.VERSIONED_CANONICAL_FUTURES,
+        instrument_id=descriptor.instrument_id,
+        data_digest=ev.compute_bars_data_digest(bars),
+        data_ref=str(dataset_path),
+        versioned_dataset_id=descriptor.dataset_id,
+    )
+    input_provenance = {
+        "dataset_path": str(dataset_path),
+        "dataset_manifest_path": str(manifest_path),
+        "config_path": str(config_path),
+        "policy_path": str(policy_path) if policy_path else "",
+        "dataset_digest": admissibility.dataset_digest,
+        "dataset_manifest_digest": manifest.get("manifest_digest", ""),
+        "config_digest": _stable_digest(cfg),
+        "policy_digest": policy.policy_digest(),
+        "implementation_digest": admissibility.implementation_digest,
+        "canonical_trading_logic_version": INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_LAYER_VERSION,
+        "run_id": plan.run_id,
+        "created_at_utc": OFFLINE_CREATED_AT_UTC,
+        "runner_version": RUNNER_VERSION,
+        "runner_owner": RUNNER_OWNER,
+    }
+
+    bundle, _repro = ev.build_and_persist_economic_viability_evidence_bundle_v1(
+        output_dir,
+        bars=bars,
+        data_admissibility=data_admissibility,
+        strategy_id=strategy_id,
+        cfg=cfg,
+        input_provenance=input_provenance,
+        instrument_id=descriptor.instrument_id,
+        **params,
+    )
+    loaded = ev.load_economic_viability_evidence_bundle_v1(output_dir)
+    evidence = loaded.evidence
+    gate_eval = evaluate_economic_validity_against_policy_v1(
+        policy=policy,
+        metrics=_build_gate_metrics_from_evidence(evidence),
+        expected_policy_digest=policy.policy_digest(),
+    )
+    evaluation_payload = {
+        "contract_version": "economic_validity_evaluation_v1",
+        "owner": RUNNER_OWNER,
+        "evaluation_status": gate_eval.evaluation_status.value,
+        "gates_pass": gate_eval.gates_pass,
+        "policy_threshold_status": gate_eval.policy_threshold_status,
+        "reason_codes": list(gate_eval.reason_codes),
+        "economic_validity_offline_gate_pass": gate_eval.gates_pass,
+        "policy_digest": policy.policy_digest(),
+        "config_digest": input_provenance["config_digest"],
+        "dataset_digest": admissibility.dataset_digest,
+        "implementation_digest": evidence.implementation_digest,
+        "run_id": plan.run_id,
+        "created_at_utc": OFFLINE_CREATED_AT_UTC,
+        "runtime_effect": False,
+        "order_effect": False,
+        "promotion_effect": False,
+    }
+    (output_dir / "economic_validity_evaluation_v1.json").write_text(
+        json.dumps(evaluation_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "dataset_admissibility_result_v1.json").write_text(
+        json.dumps(admissibility_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    write_manifest_sha256(output_dir)
+    ok, _message = verify_manifest_sha256(output_dir)
+    manifest_verify_rc = 0 if ok else 1
+    if not ok:
+        raise RunnerError("manifest_verify_failed")
+
+    summary_fields = {
+        "PROCESS_CLASSIFICATION": "ACTIVE_PROGRESS",
+        "SCOPE_CLASSIFICATION": (
+            "RUNBOOK_STEP_29M_REAL_ADMISSIBLE_FUTURES_ECONOMIC_EVIDENCE_EVALUATION_V1_OFFLINE_SLICE"
+        ),
+        "RUN_ID": plan.run_id,
+        "DATASET_ID": descriptor.dataset_id,
+        "DATASET_VERSION": descriptor.dataset_version,
+        "DATASET_ADMISSIBLE": str(admissibility.is_admissible()).lower(),
+        "DATASET_FIXTURE_CLASS": fixture_class.value,
+        "FUTURES_ONLY": "true",
+        "BITCOIN_DIRECTION_ALLOWED": "false",
+        "ECONOMIC_EVIDENCE_BUILT": "true",
+        "ECONOMIC_GATE_EVALUATED": "true",
+        "ECONOMIC_VALIDITY_RESULT": _map_validity_result(gate_eval.evaluation_status),
+        "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS": str(gate_eval.gates_pass).lower(),
+        "PROMOTION_ELIGIBILITY": "false",
+        "RUNNER_EXECUTION_SUCCESS": "true",
+        "RUNTIME_EFFECT": "false",
+        "ORDER_EFFECT": "false",
+        "NETWORK_EFFECT": "false",
+        "LIVE_AUTHORIZED": "false",
+        "MANIFEST_VERIFY_RC": str(manifest_verify_rc),
+    }
+    _write_run_summary_env(output_dir / "run_summary.env", summary_fields)
+
+    return RunOutcomeV1(
+        run_id=plan.run_id,
+        dataset_id=descriptor.dataset_id,
+        dataset_version=descriptor.dataset_version,
+        dataset_fixture_class=fixture_class,
+        dataset_admissible=admissibility.is_admissible(),
+        economic_evidence_built=True,
+        economic_gate_evaluated=True,
+        economic_validity_result=_map_validity_result(gate_eval.evaluation_status),
+        economic_validity_offline_gate_pass=gate_eval.gates_pass,
+        promotion_eligibility=False,
+        runner_execution_success=True,
+        manifest_verify_rc=manifest_verify_rc,
+        output_dir=output_dir,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.validate_only:
+            plan = build_validation_plan(args)
+            if args.json:
+                print(json.dumps(plan.__dict__, indent=2, sort_keys=True))
+            else:
+                print(json.dumps(plan.__dict__, indent=2, sort_keys=True))
+            return 0
+        outcome = execute_evaluation(args)
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "runner_execution_success": outcome.runner_execution_success,
+                        "economic_validity_result": outcome.economic_validity_result,
+                        "economic_validity_offline_gate_pass": (
+                            outcome.economic_validity_offline_gate_pass
+                        ),
+                        "output_dir": str(outcome.output_dir),
+                        "manifest_verify_rc": outcome.manifest_verify_rc,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        return 0
+    except RunnerError as exc:
+        print(str(exc), file=sys.stderr)
+        return VALIDATION_EXIT
+    except (
+        ds.AdmissibleVersionedFuturesDatasetError,
+        ev.EconomicViabilityEvidenceError,
+        policy_mod.EconomicValidityPolicyError,
+    ) as exc:
+        print(str(exc), file=sys.stderr)
+        return VALIDATION_EXIT
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backtest/parameter_sensitivity_v1.py
+++ b/src/backtest/parameter_sensitivity_v1.py
@@ -313,9 +313,9 @@ def _iter_grid_combinations(
     expected_count = math.prod(len(values) for values in canonical_values)
     combos: list[dict[str, float]] = []
     for combo in itertools.product(*canonical_values):
-        combos.append(
-            {name: float(value) for name, value in zip(parameter_names, combo, strict=True)}
-        )
+        if len(parameter_names) != len(combo):
+            raise ParameterSensitivityError("parameter_name_value_length_mismatch")
+        combos.append({name: float(value) for name, value in zip(parameter_names, combo)})
     if len(combos) != expected_count:
         raise ParameterSensitivityError("combination_count_mismatch")
     return combos

--- a/tests/ops/test_run_economic_viability_evidence_evaluation_v1.py
+++ b/tests/ops/test_run_economic_viability_evidence_evaluation_v1.py
@@ -1,0 +1,698 @@
+"""Tests for run_economic_viability_evidence_evaluation_v1 (offline STEP 29M runner)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.backtest import admissible_versioned_futures_dataset_v1 as ds
+from src.backtest import economic_viability_evidence_v1 as ev
+from src.backtest import mv2_research_wiring_v1 as wiring
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER_SCRIPT = ROOT / "scripts" / "ops" / "run_economic_viability_evidence_evaluation_v1.py"
+TEST_PACKAGE_MARKER = "RUN_ECONOMIC_VIABILITY_EVIDENCE_EVALUATION_V1_TEST=true"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location(
+        "run_economic_viability_evidence_evaluation_v1", RUNNER_SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _bars(n: int = 24) -> pd.DataFrame:
+    idx = pd.date_range("2026-06-01", periods=n, freq="1h", tz="UTC")
+    close = [100.0 + float(i) for i in range(n)]
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [v + 0.5 for v in close],
+            "low": [v - 0.5 for v in close],
+            "close": close,
+            "mark_price": close,
+            "index_price": [v - 0.1 for v in close],
+            "best_bid": [v - 0.05 for v in close],
+            "best_ask": [v + 0.05 for v in close],
+            "spread": [0.1 for _ in close],
+            "volume": [1000.0 for _ in close],
+            "open_interest": [10000.0 for _ in close],
+            "funding_rate": [0.0001 for _ in close],
+            "volatility_estimate": [0.2 for _ in close],
+            "is_final": [True for _ in close],
+            "bar_interval": ["1h" for _ in close],
+        },
+        index=idx,
+    )
+
+
+def _provenance(**overrides: Any) -> dict[str, str]:
+    payload = {
+        "source_type": "operator_staged_futures_v1",
+        "venue_id": "neutral_offline_venue_v1",
+        "ingestion_timestamp": "2026-06-01T00:00:00+00:00",
+        "generation_method": "operator_curated_versioned_export",
+        "provenance_ref": "operator/staged/eth_perp_neutral_v1",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _descriptor_dict(bars: pd.DataFrame, **overrides: Any) -> dict[str, Any]:
+    bindings = ds.default_field_bindings_v1()
+    digest = ds.compute_versioned_dataset_digest(bars, field_bindings=bindings)
+    train, val, oos = ds.compute_split_periods_from_bars(bars)
+    idx = bars.sort_index().index
+    payload: dict[str, Any] = {
+        "dataset_id": "neutral_eth_perp_operator_staged_v1",
+        "dataset_version": ds.DEFAULT_DATASET_VERSION,
+        "dataset_schema_version": ds.DATASET_SCHEMA_VERSION,
+        "dataset_digest": digest,
+        "instrument_id": wiring.MV2_REQUIRED_INSTRUMENT_ID,
+        "contract_type": "perpetual",
+        "futures_only": True,
+        "bitcoin_direction_allowed": False,
+        "venue_id": "neutral_offline_venue_v1",
+        "start_time": str(idx[0]),
+        "end_time": str(idx[-1]),
+        "row_count": len(bars),
+        "field_bindings": bindings.to_dict(),
+        "training_period": train,
+        "validation_period": val,
+        "out_of_sample_period": oos,
+        "split_policy_version": ds.SPLIT_POLICY_VERSION,
+        "timestamp_semantics": ds.TIMESTAMP_SEMANTICS,
+        "timezone": ds.TIMEZONE,
+        "ordering_status": ds.ORDERING_STATUS_SORTED,
+        "duplicate_policy": ds.DUPLICATE_POLICY,
+        "missing_data_policy": ds.MISSING_DATA_POLICY,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _manifest_payload(bars: pd.DataFrame, **overrides: Any) -> dict[str, Any]:
+    manifest = {
+        "manifest_version": "admissible_versioned_futures_dataset_manifest_v1",
+        "dataset": _descriptor_dict(bars, **overrides.get("descriptor_overrides", {})),
+        "provenance": _provenance(**overrides.get("provenance_overrides", {})),
+    }
+    manifest["manifest_digest"] = _load_runner()._compute_manifest_digest(manifest)
+    return manifest
+
+
+def _evaluation_config(bars: pd.DataFrame | None = None, **overrides: Any) -> dict[str, Any]:
+    frame = _bars() if bars is None else bars
+    descriptor = _descriptor_dict(frame)
+    cfg: dict[str, Any] = {
+        "backtest": {
+            "initial_cash": 10_000.0,
+            "cost_model_version": "backtest_cost_v0",
+            "fee_bps": 10.0,
+            "slippage_bps": 5.0,
+            "funding": {"bind": True, "model_version": "backtest_funding_perpetual_interval_v1"},
+            "parameter_sensitivity": {
+                "bind": True,
+                "grid_version": "v1",
+                "grid": {
+                    "grid_id": "runner_contract_grid_v1",
+                    "parameter_names": ["fee_bps", "slippage_bps"],
+                    "parameter_values": [[8.0, 10.0], [4.0, 6.0]],
+                    "search_space_bounds": {
+                        "fee_bps": {"min": 8.0, "max": 10.0},
+                        "slippage_bps": {"min": 4.0, "max": 6.0},
+                    },
+                    "seed": 42,
+                },
+            },
+            "dataset_admissibility": {
+                "bind": True,
+                "dataset": descriptor,
+                "provenance": _provenance(),
+            },
+        },
+        "risk": {
+            "risk_per_trade": 0.02,
+            "max_position_size": 0.25,
+            "min_position_value": 10.0,
+            "min_stop_distance": 0.0001,
+        },
+        "economic_evaluation_v1": {
+            "strategy_id": "ma_crossover",
+            "walk_forward": {"bind": True, "train_bars": 8, "test_bars": 4, "step_bars": 4},
+            "monte_carlo": {"bind": True, "runs": 16, "seed": 42},
+            "stress": {"bind": True},
+        },
+    }
+    if "backtest" in overrides:
+        cfg["backtest"].update(overrides.pop("backtest"))
+    cfg.update(overrides)
+    return cfg
+
+
+def _stage_run_inputs(
+    tmp_path: Path,
+    *,
+    bars: pd.DataFrame | None = None,
+    manifest_overrides: dict[str, Any] | None = None,
+    config_overrides: dict[str, Any] | None = None,
+) -> dict[str, Path]:
+    frame = _bars() if bars is None else bars
+    staging = tmp_path / "staging"
+    staging.mkdir(parents=True, exist_ok=True)
+    dataset_path = staging / "bars.parquet"
+    frame.to_parquet(dataset_path)
+    manifest = _manifest_payload(frame, **(manifest_overrides or {}))
+    manifest_path = staging / "dataset_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    config = _evaluation_config(frame, **(config_overrides or {}))
+    config_path = staging / "evaluation_config.json"
+    config_path.write_text(json.dumps(config, indent=2, sort_keys=True), encoding="utf-8")
+    policy_path = staging / "policy_canonical.json"
+    policy_path.write_text(
+        json.dumps(
+            {"use_canonical": True, "policy_version": "economic_validity_policy_v1"},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "output"
+    return {
+        "dataset_path": dataset_path,
+        "manifest_path": manifest_path,
+        "config_path": config_path,
+        "policy_path": policy_path,
+        "output_dir": output_dir,
+    }
+
+
+def _argv(paths: dict[str, Path], **extra: Any) -> list[str]:
+    argv = [
+        "--dataset-path",
+        str(paths["dataset_path"]),
+        "--dataset-manifest-path",
+        str(paths["manifest_path"]),
+        "--config-path",
+        str(paths["config_path"]),
+        "--policy-path",
+        str(paths["policy_path"]),
+        "--output-dir",
+        str(paths["output_dir"]),
+        "--run-id",
+        "runner_contract_test_v1",
+    ]
+    if extra.get("validate_only"):
+        argv.append("--validate-only")
+    if extra.get("allow_existing_output"):
+        argv.append("--allow-existing-output")
+    return argv
+
+
+@pytest.fixture
+def runner():
+    return _load_runner()
+
+
+def test_scripts_exist() -> None:
+    assert TEST_PACKAGE_MARKER
+    assert RUNNER_SCRIPT.is_file()
+
+
+def test_help_smoke() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(RUNNER_SCRIPT), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "--dataset-path" in proc.stdout
+    assert "--validate-only" in proc.stdout
+
+
+def test_missing_dataset_path_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    rc = runner.main(
+        _argv(paths) + ["--dataset-path", str(tmp_path / "missing.parquet"), "--validate-only"]
+    )
+    assert rc != 0
+
+
+def test_url_dataset_path_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    rc = runner.main(
+        _argv(paths) + ["--dataset-path", "https://example.com/data.parquet", "--validate-only"]
+    )
+    assert rc != 0
+
+
+def test_missing_manifest_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    rc = runner.main(
+        _argv(paths)
+        + [
+            "--dataset-manifest-path",
+            str(tmp_path / "missing_manifest.json"),
+            "--validate-only",
+        ]
+    )
+    assert rc != 0
+
+
+def test_manifest_digest_mismatch_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    manifest = json.loads(paths["manifest_path"].read_text(encoding="utf-8"))
+    manifest["manifest_digest"] = "0" * 64
+    paths["manifest_path"].write_text(json.dumps(manifest), encoding="utf-8")
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+
+
+def test_unknown_dataset_version_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(
+        tmp_path,
+        manifest_overrides={"descriptor_overrides": {"dataset_version": "v999"}},
+    )
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+
+
+def test_real_admissible_validate_only_accepted(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc == 0
+
+
+def test_test_fixture_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(
+        tmp_path,
+        manifest_overrides={
+            "provenance_overrides": {
+                "source_type": "test_fixture",
+                "provenance_ref": "tests/backtest/fixture_only",
+            }
+        },
+    )
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+
+
+def test_synthetic_fixture_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(
+        tmp_path,
+        manifest_overrides={
+            "provenance_overrides": {
+                "source_type": "synthetic_contract_fixture",
+                "generation_method": "deterministic_test_fixture",
+            }
+        },
+    )
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+
+
+def test_preview_probe_data_rejected(runner, tmp_path: Path) -> None:
+    for source_type in ("preview_data", "probe_data"):
+        case_root = tmp_path / source_type
+        paths = _stage_run_inputs(
+            case_root,
+            manifest_overrides={"provenance_overrides": {"source_type": source_type}},
+        )
+        rc = runner.main(_argv(paths) + ["--validate-only"])
+        assert rc != 0
+
+
+def test_spot_and_synthetic_spot_rejected(runner, tmp_path: Path) -> None:
+    for source_type in ("spot", "synthetic_spot"):
+        case_root = tmp_path / source_type
+        paths = _stage_run_inputs(
+            case_root,
+            manifest_overrides={"provenance_overrides": {"source_type": source_type}},
+        )
+        rc = runner.main(_argv(paths) + ["--validate-only"])
+        assert rc != 0
+
+
+def test_kraken_u5d_fixture_rejected_via_generic_classification(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(
+        tmp_path,
+        manifest_overrides={
+            "provenance_overrides": {
+                "source_type": "transport_fixture",
+                "generation_method": "offline_transform_probe",
+                "provenance_ref": (
+                    "tests/fixtures/u5d_offline_transform_v1/minimal/"
+                    "kraken_futures_tickers.raw.v1.json"
+                ),
+            }
+        },
+    )
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+    source = RUNNER_SCRIPT.read_text(encoding="utf-8")
+    assert "kraken" not in source.lower()
+
+
+def test_no_kraken_venue_specific_production_logic(runner) -> None:
+    source = RUNNER_SCRIPT.read_text(encoding="utf-8").lower()
+    assert "kraken" not in source
+    assert "xbt" not in source
+    assert "btc" not in source
+
+
+def test_missing_provenance_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(
+        tmp_path,
+        manifest_overrides={"provenance_overrides": {"provenance_ref": ""}},
+    )
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+
+
+def test_missing_versioned_config_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    rc = runner.main(
+        _argv(paths) + ["--config-path", str(tmp_path / "missing_config.json"), "--validate-only"]
+    )
+    assert rc != 0
+
+
+def test_missing_policy_thresholds_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    bad_policy = paths["policy_path"].parent / "bad_policy.json"
+    bad_policy.write_text(
+        json.dumps(
+            {
+                "economic_validity_policy": {
+                    "policy_version": "economic_validity_policy_v1",
+                    "owner": "backtest.economic_validity_policy_v1",
+                    "thresholds": {},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    argv = _argv(paths) + ["--validate-only"]
+    argv[argv.index(str(paths["policy_path"]))] = str(bad_policy)
+    rc = runner.main(argv)
+    assert rc != 0
+
+
+def test_zero_cost_config_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path, config_overrides={"backtest": {"fee_bps": 0.0}})
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+
+
+def test_missing_funding_binding_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path, config_overrides={"backtest": {"funding": {"bind": False}}})
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+
+
+def test_missing_parameter_sensitivity_binding_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(
+        tmp_path, config_overrides={"backtest": {"parameter_sensitivity": {"bind": False}}}
+    )
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+
+
+def test_missing_walk_forward_binding_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(
+        tmp_path,
+        config_overrides={"economic_evaluation_v1": {"walk_forward": {"bind": False}}},
+    )
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+
+
+def test_missing_monte_carlo_binding_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(
+        tmp_path,
+        config_overrides={"economic_evaluation_v1": {"monte_carlo": {"bind": False}}},
+    )
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+
+
+def test_missing_stress_binding_rejected(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(
+        tmp_path,
+        config_overrides={"economic_evaluation_v1": {"stress": {"bind": False}}},
+    )
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc != 0
+
+
+def test_existing_output_fail_closed(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    paths["output_dir"].mkdir()
+    (paths["output_dir"] / "existing.txt").write_text("x", encoding="utf-8")
+    rc = runner.main(_argv(paths))
+    assert rc != 0
+
+
+def test_runner_uses_existing_library_owners(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    parser = runner.build_arg_parser()
+    args = parser.parse_args(_argv(paths) + ["--validate-only"])
+    plan = runner.build_validation_plan(args)
+    assert ev.ECONOMIC_VIABILITY_EVIDENCE_OWNER in plan.owners
+    assert ds.ADMISSIBLE_VERSIONED_FUTURES_DATASET_OWNER in plan.owners
+
+
+def test_technical_success_economic_fail_exit_zero(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    rc = runner.main(_argv(paths))
+    assert rc == 0
+    summary = (paths["output_dir"] / "run_summary.env").read_text(encoding="utf-8")
+    assert "RUNNER_EXECUTION_SUCCESS=true" in summary
+    assert "ECONOMIC_EVIDENCE_BUILT=true" in summary
+    assert "ECONOMIC_GATE_EVALUATED=true" in summary
+    # Economic FAIL is expected for small fixture data
+    assert re.search(r"ECONOMIC_VALIDITY_RESULT=(FAIL|BLOCKED)", summary)
+
+
+def test_technical_error_exit_nonzero(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    rc = runner.main(
+        _argv(paths) + ["--dataset-path", "ftp://invalid.example/data.parquet", "--validate-only"]
+    )
+    assert rc != 0
+
+
+def test_economic_pass_does_not_imply_promotion_or_runtime(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    runner.main(_argv(paths))
+    summary = (paths["output_dir"] / "run_summary.env").read_text(encoding="utf-8")
+    assert "PROMOTION_ELIGIBILITY=false" in summary
+    assert "RUNTIME_EFFECT=false" in summary
+    assert "LIVE_AUTHORIZED=false" in summary
+
+
+def test_economic_fail_no_runtime_effect(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    runner.main(_argv(paths))
+    summary = (paths["output_dir"] / "run_summary.env").read_text(encoding="utf-8")
+    assert "RUNTIME_EFFECT=false" in summary
+    assert "ORDER_EFFECT=false" in summary
+
+
+def test_output_manifest_created_and_verified(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    runner.main(_argv(paths))
+    ok, _msg = verify_manifest_sha256(paths["output_dir"])
+    assert ok is True
+    assert (paths["output_dir"] / "MANIFEST.sha256").is_file()
+
+
+def test_deterministic_repeat_produces_identical_core_artifacts(runner, tmp_path: Path) -> None:
+    paths_a = _stage_run_inputs(tmp_path / "a")
+    paths_b = _stage_run_inputs(tmp_path / "b")
+    runner.main(_argv(paths_a))
+    runner.main(_argv(paths_b))
+    for name in (
+        "economic_viability_evidence_v1.json",
+        "dataset_admissibility_result_v1.json",
+        "economic_validity_evaluation_v1.json",
+    ):
+        a = json.loads((paths_a["output_dir"] / name).read_text(encoding="utf-8"))
+        b = json.loads((paths_b["output_dir"] / name).read_text(encoding="utf-8"))
+        assert a == b
+
+
+def test_no_network_calls_in_runner_source(runner) -> None:
+    source = RUNNER_SCRIPT.read_text(encoding="utf-8")
+    for token in ("requests.", "urllib.request", "httpx", "aiohttp", "socket."):
+        assert token not in source
+
+
+def test_no_credential_env_reads(runner) -> None:
+    source = RUNNER_SCRIPT.read_text(encoding="utf-8")
+    assert "os.environ" not in source
+    assert "getenv" not in source
+
+
+def test_no_runtime_adapter_imports(runner) -> None:
+    source = RUNNER_SCRIPT.read_text(encoding="utf-8")
+    forbidden = (
+        "ccxt",
+        "live_runtime",
+        "order_submission",
+        "adapter_submission",
+        "websocket",
+    )
+    for token in forbidden:
+        assert token not in source.lower()
+
+
+def test_futures_only_and_no_bitcoin_direction(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    runner.main(_argv(paths))
+    summary = (paths["output_dir"] / "run_summary.env").read_text(encoding="utf-8")
+    assert "FUTURES_ONLY=true" in summary
+    assert "BITCOIN_DIRECTION_ALLOWED=false" in summary
+
+
+def test_digest_bindings_present(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    runner.main(_argv(paths))
+    provenance = json.loads(
+        (paths["output_dir"] / "INPUT_PROVENANCE.json").read_text(encoding="utf-8")
+    )
+    for key in (
+        "dataset_digest",
+        "config_digest",
+        "policy_digest",
+        "implementation_digest",
+        "canonical_trading_logic_version",
+        "run_id",
+    ):
+        assert provenance.get(key)
+
+
+def test_validate_only_does_not_build_evidence(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    rc = runner.main(_argv(paths) + ["--validate-only"])
+    assert rc == 0
+    assert not paths["output_dir"].exists()
+
+
+def test_source_dataset_unchanged(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    before = paths["dataset_path"].read_bytes()
+    runner.main(_argv(paths))
+    after = paths["dataset_path"].read_bytes()
+    assert before == after
+
+
+def test_real_owner_graph_validate_only_integration(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    bars = pd.read_parquet(paths["dataset_path"])
+    manifest = json.loads(paths["manifest_path"].read_text(encoding="utf-8"))
+    descriptor = runner._descriptor_from_manifest(manifest)
+    provenance = runner._provenance_from_manifest(manifest)
+    fixture_class = runner.classify_dataset_fixture_class_v1(
+        descriptor=descriptor,
+        provenance=provenance,
+        dataset_path=paths["dataset_path"],
+        manifest_path=paths["manifest_path"],
+    )
+    assert fixture_class.value == "REAL_ADMISSIBLE_VERSIONED_FUTURES_DATASET"
+    result = ds.evaluate_admissible_versioned_futures_dataset_v1(
+        bars=bars,
+        descriptor=descriptor,
+        provenance=provenance,
+        instrument_id=descriptor.instrument_id,
+    )
+    assert result.is_admissible() is True
+
+
+def test_fixture_classification_matrix(runner, tmp_path: Path) -> None:
+    bars = _bars()
+    raw = _descriptor_dict(bars)
+    bindings = ds.DatasetFieldBindingsV1(**raw.pop("field_bindings"))
+    descriptor = ds.VersionedFuturesDatasetDescriptorV1(field_bindings=bindings, **raw)
+    cases = {
+        "synthetic_contract_fixture": runner.DatasetFixtureClass.SYNTHETIC_FIXTURE,
+        "spot": runner.DatasetFixtureClass.SPOT_DATA,
+        "synthetic_spot": runner.DatasetFixtureClass.SYNTHETIC_SPOT_DATA,
+        "preview_data": runner.DatasetFixtureClass.PREVIEW_DATA,
+        "probe_data": runner.DatasetFixtureClass.PROBE_DATA,
+        "transport_fixture": runner.DatasetFixtureClass.TRANSPORT_FIXTURE,
+        "webui_fixture": runner.DatasetFixtureClass.WEBUI_FIXTURE,
+        "test_fixture": runner.DatasetFixtureClass.TEST_FIXTURE,
+    }
+    for source_type, expected in cases.items():
+        provenance = ds.DatasetProvenanceV1(
+            source_type=source_type,
+            venue_id="neutral",
+            ingestion_timestamp="2026-06-01T00:00:00+00:00",
+            generation_method="x",
+            provenance_ref="operator/staged/x",
+        )
+        got = runner.classify_dataset_fixture_class_v1(
+            descriptor=descriptor,
+            provenance=provenance,
+            dataset_path=tmp_path / "data.parquet",
+            manifest_path=tmp_path / "manifest.json",
+        )
+        assert got is expected
+
+
+def test_runner_does_not_duplicate_build_logic(runner) -> None:
+    source = RUNNER_SCRIPT.read_text(encoding="utf-8")
+    assert "build_and_persist_economic_viability_evidence_bundle_v1" in source
+    assert "evaluate_economic_validity_against_policy_v1" in source
+    assert "def compute_funding_drag_v1" not in source
+    assert "def run_mv2_research_backtest_wiring_v1" not in source
+
+
+def test_mocked_owner_orchestration_contract(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    captured: dict[str, Any] = {}
+
+    def _fake_build_and_persist(output_dir, **kwargs):
+        captured.update(kwargs)
+        build_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key not in {"input_provenance", "verify_reproducibility"}
+        }
+        evidence = ev.build_economic_viability_evidence_v1(**build_kwargs)
+        bundle = ev.persist_economic_viability_evidence_bundle_v1(
+            output_dir,
+            evidence,
+            config_snapshot={"cfg": dict(kwargs["cfg"]), "strategy_id": kwargs["strategy_id"]},
+            metrics={"trade_count": evidence.trade_count.to_dict()},
+            input_provenance=dict(kwargs["input_provenance"]),
+        )
+        repro = ev.verify_economic_viability_evidence_reproducibility_v1(
+            persisted=evidence,
+            rebuilt=ev.build_economic_viability_evidence_v1(**build_kwargs),
+        )
+        return bundle, repro
+
+    with patch.object(
+        ev, "build_and_persist_economic_viability_evidence_bundle_v1", _fake_build_and_persist
+    ):
+        rc = runner.main(_argv(paths))
+    assert rc == 0
+    assert captured.get("strategy_id") == "ma_crossover"
+    assert captured.get("cfg") is not None


### PR DESCRIPTION
## Summary

- Implements Rank-1 scope `real_admissible_futures_economic_evidence_evaluation_v1_offline_slice` from forensic audit `economic_validity_offline_gate_next_admissible_slice_forensic_ranking_after_step29r_v0_20260701T070000Z`.
- Adds canonical offline ops runner `scripts/ops/run_economic_viability_evidence_evaluation_v1.py` as a thin orchestrator over existing STEP-29M library owners (no parallel economic SSOT).
- Adds focused contract tests in `tests/ops/test_run_economic_viability_evidence_evaluation_v1.py` (42 cases).

## Reuse-first owners

- `admissible_versioned_futures_dataset_v1`
- `mv2_research_wiring_v1` (via `build_economic_viability_evidence_v1`)
- `build_economic_viability_evidence_v1` / `build_and_persist_economic_viability_evidence_bundle_v1`
- `evaluate_economic_validity_against_policy_v1` / `canonical_economic_validity_policy_v1`
- `primary_evidence_retention_v0` manifest helpers

## CLI contract

Required: `--dataset-path`, `--dataset-manifest-path`, `--config-path`, `--output-dir`.
Optional: `--policy-path`, `--run-id`, `--validate-only`, `--allow-existing-output`.
No implicit dataset defaults, no URLs, no stdin feed.

## Input admissibility / fixture policy

Generic provenance/path classification rejects `TEST_FIXTURE`, `SYNTHETIC_FIXTURE`, `PREVIEW_DATA`, `PROBE_DATA`, `TRANSPORT_FIXTURE`, `WEBUI_FIXTURE`, `SPOT_DATA`, `SYNTHETIC_SPOT_DATA`.
Kraken U5D minimal fixtures rejected via `transport_fixture` + `tests/fixtures` provenance — no Kraken hardcoding in production code.

## Output / manifest

Persists canonical evidence artifacts (`economic_viability_evidence_v1.json`, `economic_validity_evaluation_v1.json`, `dataset_admissibility_result_v1.json`, `run_summary.env`, `MANIFEST.sha256`).

## Exit semantics

- `0`: technical runner success (economic result may be PASS/FAIL/BLOCKED)
- non-zero: input/contract/admissibility/config/persistence/manifest errors

## Explicit non-goals (this PR)

- No real economic evaluation with operator-staged production datasets
- No dataset staging/download
- No registry updates (`ECONOMIC_VALIDITY_RESULT` remains `NOT_PROVEN`, gate remains false)
- No runtime/order/network/live authority effects
- Operator input required only for later real dataset execution

## Test plan

- [x] `pytest tests/ops/test_run_economic_viability_evidence_evaluation_v1.py`
- [x] Related owners: admissible dataset, economic viability evidence, economic validity policy, promotion gate contract tests
- [x] `ruff format` / `ruff check` on changed files
- [x] CI selector: `CONTRACT_FOCUSED`


Made with [Cursor](https://cursor.com)