### PR TITLE
docs(governance): register STEP 29M economic evaluation runner

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -16,8 +16,8 @@ SCHEDULER_RUNTIME_ALLOWED: false
 
 | Feld | Wert |
 |---|---|
-| `LAST_VERIFIED_ORIGIN_MAIN` | `bbb500caa1997baee6ee6bca9656067ceca986f3` |
-| `LAST_VERIFIED_AT` | `2026-07-01T22:00:00Z` |
+| `LAST_VERIFIED_ORIGIN_MAIN` | `aa1a8fd9d3444e5d5f3dbe2386d4114b2e48b0c9` |
+| `LAST_VERIFIED_AT` | `2026-07-01T08:00:00Z` |
 | `CURRENT_MAJOR_GAP_PACKAGE` | `MAJOR_GAP_COMPARISON_PROMOTION_POLICY_INPUT_BRIDGE_V0` |
 | `NEXT_RUNBOOK_STEP` | `RUNBOOK_STEP_29R` |
 | `NEXT_CANONICAL_STEP` | `backtest_engine_rewire_binding` |
@@ -111,9 +111,26 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29L_COMPLETE` | `true` |
 | `STEP_29M_STARTED` | `true` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `true` |
+| `ECONOMIC_GATE_EVALUATOR_BOUND` | `true` |
+| `REAL_EVALUATION_PERFORMED` | `false` |
+| `REAL_ADMISSIBLE_FUTURES_EVIDENCE_PRESENT` | `false` |
+| `REAL_ADMISSIBLE_FUTURES_EVIDENCE_BOUND` | `false` |
+| `REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED` | `true` |
+| `ECONOMIC_VALIDITY_RESULT` | `NOT_PROVEN` |
+| `CURRENT_PROMOTION_EVALUATION` | `INELIGIBLE` |
+| `OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION` | `true` |
+| `REAL_EVALUATION_INPUT_STATUS` | `AWAITING_OPERATOR_DATASET_INPUT` |
+| `KRAKEN_FIXTURE_LEAK_INTO_CANONICAL_ECONOMIC_PATH` | `false` |
+| `VENUE_SPECIFIC_CANONICAL_ECONOMIC_PATH_ALLOWED` | `false` |
+| `ORDER_EFFECT` | `false` |
+| `NETWORK_EFFECT` | `false` |
+| `RUNTIME_EFFECT` | `false` |
+| `LIVE_AUTHORIZED` | `false` |
+| `FUTURES_ONLY` | `true` |
+| `BITCOIN_DIRECTION_ALLOWED` | `false` |
 | `STEP_29N_STARTED` | `true` |
 | `RUNBOOK_STEP_29N_STARTED` | `true` |
 | `RUNBOOK_STEP_29N_IMPLEMENTED_SCOPE` | `promotion_economic_gate_binding_v1_slice` |
@@ -1075,17 +1092,31 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `RUNBOOK_STEP_ID` | `economic_viability_evidence_v1` |
 | `STATUS` | `COMPLETE` |
 | `CANONICAL_OWNER` | `src/backtest/economic_viability_evidence_v1.py` |
-| `MERGED_PRS` | `#4700`, `#4701`, `#4702`, `#4703`, `#4704`, `#4705`, `#4706` |
-| `MERGE_COMMITS` | `5352d83f069b7d361e89c877ebe2d3d5ae161156`, `5d402a6a1fc2fb1a76af3a91223ac46ee9d80b72`, `72a33b0a85c76bc00fff482d7e88fda0db33c873`, `4ff161b3d005ff12e434982a108b22ef46165272`, `cd9474c820d500bbdbc09217b4c46f5e604f96b2`, `cf0ced2edff0a4baaf8d8fcd93d3e7476c13257e`, `49a7595cb5e6885fa2d003db74f07d6acf0d61cb` |
-| `DURABLE_EVIDENCE_REFS` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_viability_evidence_pr4700_squash_merge_closeout_v0_20260630T211900Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_residual_slice_pr4701squash_merge_closeout_v0_20260630T213300Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_validity_policy_v1_pr4702squash_merge_closeout_v0_20260630T214700Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_funding_binding_v1_pr4703_squash_merge_closeout_v0_20260630T220500Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_parameter_sensitivity_pr4704_squash_merge_closeout_v0_20260701T221500Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_admissible_versioned_futures_dataset_pr4705_squash_merge_closeout_v0_20260630T223551Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_validity_policy_thresholds_pr4706_squash_merge_closeout_v0_20260630T225125Z (MANIFEST_VERIFY_RC=0); economic_viability_evidence_pr=4700; economic_viability_evidence_merge_commit=5352d83f069b7d361e89c877ebe2d3d5ae161156; persistence_load_reproducibility_pr=4701; persistence_load_reproducibility_merge_commit=5d402a6a1fc2fb1a76af3a91223ac46ee9d80b72; economic_validity_policy_v1_pr=4702; economic_validity_policy_v1_merge_commit=72a33b0a85c76bc00fff482d7e88fda0db33c873; funding_model_binding_pr=4703; funding_model_binding_merge_commit=4ff161b3d005ff12e434982a108b22ef46165272; parameter_sensitivity_evidence_pr=4704; parameter_sensitivity_evidence_merge_commit=cd9474c820d500bbdbc09217b4c46f5e604f96b2; admissible_versioned_futures_dataset_pr=4705; admissible_versioned_futures_dataset_merge_commit=cf0ced2edff0a4baaf8d8fcd93d3e7476c13257e; economic_validity_policy_threshold_values_pr=4706; economic_validity_policy_threshold_values_merge_commit=49a7595cb5e6885fa2d003db74f07d6acf0d61cb; canonical_scope=economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice; ECONOMIC_VIABILITY_EVIDENCE_V1_BOUND=true; STEP29M_IMPLEMENTATION_COMPLETE=true; TECHNICAL_ECONOMIC_VIABILITY_EVIDENCE_STACK_COMPLETE=true; ECONOMIC_VALIDITY_RESULT=NOT_PROVEN; REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED=true; THRESHOLD_TUNING_ALLOWED=false; STEP_29N_STARTED=false; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_LIVE=true; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME=true; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS=true; STEP_29M_COMPLETION_DOES_NOT_CLAIM_ECONOMIC_VALIDITY=true; STEP_29M_COMPLETION_DOES_NOT_START_PROMOTION_GATE=true; PROMOTION_ELIGIBILITY_GRANTED=false; RUNTIME_AUTHORITY_GRANTED=false; UNIVERSE_SELECTION_UNCHANGED=true; offline_only=true; non_authorizing=true; runtime_process_started=false; scheduler_action_performed=false; venue_access_performed=false; credential_access_performed=false; trading_action_performed=false; progress_registry_closeout_status=COMPLETE; FUTURES_ONLY=true; BITCOIN_DIRECTION_ALLOWED=false; LIVE_AUTHORIZED=false; ORDERS_ALLOWED=false; SCHEDULER_RUNTIME_ALLOWED=false` |
+| `CANONICAL_RUNNER_OWNER` | `scripts/ops/run_economic_viability_evidence_evaluation_v1.py` |
+| `MERGED_PRS` | `#4700`, `#4701`, `#4702`, `#4703`, `#4704`, `#4705`, `#4706`, `#4723` |
+| `MERGE_COMMITS` | `5352d83f069b7d361e89c877ebe2d3d5ae161156`, `5d402a6a1fc2fb1a76af3a91223ac46ee9d80b72`, `72a33b0a85c76bc00fff482d7e88fda0db33c873`, `4ff161b3d005ff12e434982a108b22ef46165272`, `cd9474c820d500bbdbc09217b4c46f5e604f96b2`, `cf0ced2edff0a4baaf8d8fcd93d3e7476c13257e`, `49a7595cb5e6885fa2d003db74f07d6acf0d61cb`, `aa1a8fd9d3444e5d5f3dbe2386d4114b2e48b0c9` |
+| `DURABLE_EVIDENCE_REFS` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_viability_evidence_pr4700_squash_merge_closeout_v0_20260630T211900Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_residual_slice_pr4701squash_merge_closeout_v0_20260630T213300Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_validity_policy_v1_pr4702squash_merge_closeout_v0_20260630T214700Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_funding_binding_v1_pr4703_squash_merge_closeout_v0_20260630T220500Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_parameter_sensitivity_pr4704_squash_merge_closeout_v0_20260701T221500Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_admissible_versioned_futures_dataset_pr4705_squash_merge_closeout_v0_20260630T223551Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_validity_policy_thresholds_pr4706_squash_merge_closeout_v0_20260630T225125Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_real_admissible_futures_economic_evaluation_runner_pr4723_squash_merge_closeout_v0_20260701T072817Z (MANIFEST_VERIFY_RC=0); economic_viability_evidence_pr=4700; economic_viability_evidence_merge_commit=5352d83f069b7d361e89c877ebe2d3d5ae161156; persistence_load_reproducibility_pr=4701; persistence_load_reproducibility_merge_commit=5d402a6a1fc2fb1a76af3a91223ac46ee9d80b72; economic_validity_policy_v1_pr=4702; economic_validity_policy_v1_merge_commit=72a33b0a85c76bc00fff482d7e88fda0db33c873; funding_model_binding_pr=4703; funding_model_binding_merge_commit=4ff161b3d005ff12e434982a108b22ef46165272; parameter_sensitivity_evidence_pr=4704; parameter_sensitivity_evidence_merge_commit=cd9474c820d500bbdbc09217b4c46f5e604f96b2; admissible_versioned_futures_dataset_pr=4705; admissible_versioned_futures_dataset_merge_commit=cf0ced2edff0a4baaf8d8fcd93d3e7476c13257e; economic_validity_policy_threshold_values_pr=4706; economic_validity_policy_threshold_values_merge_commit=49a7595cb5e6885fa2d003db74f07d6acf0d61cb; economic_evaluation_runner_pr=4723; economic_evaluation_runner_merge_commit=aa1a8fd9d3444e5d5f3dbe2386d4114b2e48b0c9; economic_evaluation_runner_squash_parent=d2c505f86ec879d4fb71c4c531349552ed3e1634; canonical_scope=economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice; ECONOMIC_VIABILITY_EVIDENCE_V1_BOUND=true; ECONOMIC_GATE_EVALUATOR_BOUND=true; ECONOMIC_EVALUATION_RUNNER_V1_BOUND=true; REAL_EVALUATION_PERFORMED=false; OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION=true; STEP29M_IMPLEMENTATION_COMPLETE=true; TECHNICAL_ECONOMIC_VIABILITY_EVIDENCE_STACK_COMPLETE=true; ECONOMIC_VALIDITY_RESULT=NOT_PROVEN; REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED=true; THRESHOLD_TUNING_ALLOWED=false; STEP_29N_STARTED=false; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_LIVE=true; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME=true; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS=true; STEP_29M_COMPLETION_DOES_NOT_CLAIM_ECONOMIC_VALIDITY=true; STEP_29M_COMPLETION_DOES_NOT_START_PROMOTION_GATE=true; PROMOTION_ELIGIBILITY_GRANTED=false; RUNTIME_AUTHORITY_GRANTED=false; UNIVERSE_SELECTION_UNCHANGED=true; offline_only=true; non_authorizing=true; runtime_process_started=false; scheduler_action_performed=false; venue_access_performed=false; credential_access_performed=false; trading_action_performed=false; progress_registry_closeout_status=COMPLETE; FUTURES_ONLY=true; BITCOIN_DIRECTION_ALLOWED=false; LIVE_AUTHORIZED=false; ORDERS_ALLOWED=false; SCHEDULER_RUNTIME_ALLOWED=false` |
 | `DEPENDENCIES` | RUNBOOK_STEP_29L |
-| `REMAINING_GAPS` | — |
+| `REMAINING_GAPS` | `real admissible futures economic evidence evaluation awaiting operator dataset input; economic validity proof` |
 | `DATA_ADMISSIBILITY_STATUS` | `PASS` |
 | `POLICY_THRESHOLD_STATUS` | `PASS` |
 | `ECONOMIC_VALIDITY_EVALUATION_STATUS` | `RESEARCH_ONLY` |
 | `TECHNICAL_ECONOMIC_VIABILITY_EVIDENCE_STACK_COMPLETE` | `true` |
 | `ECONOMIC_VALIDITY_RESULT` | `NOT_PROVEN` |
 | `REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED` | `true` |
+| `ECONOMIC_GATE_EVALUATOR_BOUND` | `true` |
+| `REAL_EVALUATION_PERFORMED` | `false` |
+| `REAL_ADMISSIBLE_FUTURES_EVIDENCE_PRESENT` | `false` |
+| `REAL_ADMISSIBLE_FUTURES_EVIDENCE_BOUND` | `false` |
+| `ECONOMIC_VALIDITY_OFFLINE_GATE_PASS` | `false` |
+| `CURRENT_PROMOTION_EVALUATION` | `INELIGIBLE` |
+| `OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION` | `true` |
+| `REAL_EVALUATION_INPUT_STATUS` | `AWAITING_OPERATOR_DATASET_INPUT` |
+| `KRAKEN_FIXTURE_LEAK_INTO_CANONICAL_ECONOMIC_PATH` | `false` |
+| `VENUE_SPECIFIC_CANONICAL_ECONOMIC_PATH_ALLOWED` | `false` |
+| `ORDER_EFFECT` | `false` |
+| `NETWORK_EFFECT` | `false` |
+| `LIVE_AUTHORIZED` | `false` |
 | `THRESHOLD_TUNING_ALLOWED` | `false` |
 | `PROMOTION_ELIGIBILITY_GRANTED` | `false` |
 | `RUNTIME_AUTHORITY_GRANTED` | `false` |
@@ -1097,10 +1128,11 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `ECONOMIC_VALIDITY_PROVEN` | `false` |
 | `PROFITABILITY_CLAIM_ALLOWED` | `false` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `true` |
 | `ECONOMIC_VIABILITY_EVIDENCE_V1_IMPLEMENTED` | `true` |
+| `ECONOMIC_EVALUATION_RUNNER_V1_BOUND` | `true` |
 | `STEP_29N_STARTED` | `false` |
 | `PROGRESS_REGISTRY_CLOSEOUT_PERFORMED` | `true` |
 | `STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_LIVE` | `true` |

--- a/tests/ops/test_runbook_step29m_economic_evaluation_runner_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_economic_evaluation_runner_progress_registry_closeout_contract_v0.py
@@ -1,0 +1,220 @@
+"""Contract tests for RUNBOOK STEP 29M economic evaluation runner progress registry closeout v0.
+
+Verifies PR #4723 runner-slice registry closeout without claiming real evaluation,
+economic validity pass, promotion eligibility, or runtime authority.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROGRESS_REGISTRY = REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+
+RUNNER_SLICE = "real_admissible_futures_economic_evidence_evaluation_v1_offline_slice"
+STEP_29M_IMPLEMENTED_SCOPE = (
+    "economic_viability_evidence_v1_offline_slice,"
+    "economic_viability_evidence_v1_persistence_load_reproducibility_slice,"
+    "economic_validity_policy_v1_contract_slice,"
+    "funding_model_binding_v1_slice,"
+    "parameter_sensitivity_evidence_binding_v1_slice,"
+    "admissible_versioned_futures_dataset_binding_v1_slice,"
+    "economic_validity_policy_threshold_values_v1_slice,"
+    f"{RUNNER_SLICE}"
+)
+MERGE_COMMIT = "aa1a8fd9d3444e5d5f3dbe2386d4114b2e48b0c9"
+HISTORICAL_SLICES = tuple(
+    slice_name for slice_name in STEP_29M_IMPLEMENTED_SCOPE.split(",") if slice_name != RUNNER_SLICE
+)
+
+
+def _read_registry() -> str:
+    assert PROGRESS_REGISTRY.is_file(), f"missing canonical registry: {PROGRESS_REGISTRY}"
+    return PROGRESS_REGISTRY.read_text(encoding="utf-8")
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(rf"\| `{re.escape(field)}` \| `([^`]*)` \|", text)
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _step_29m_section(text: str) -> str:
+    start = text.index("#### RUNBOOK_STEP_29M — Economic Viability Evidence v1")
+    end = text.index("#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1", start)
+    return text[start:end]
+
+
+def _step_29n_section(text: str) -> str:
+    start = text.index("#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1")
+    end = text.index("#### RUNBOOK_STEP_29J (legacy heading)", start)
+    return text[start:end]
+
+
+def test_runbook_step_29m_complete_true() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "RUNBOOK_STEP_29M_COMPLETE") == "true"
+    assert _field_value(section, "RUNBOOK_STEP_29M_COMPLETE") == "true"
+    assert _field_value(section, "STATUS") == "COMPLETE"
+
+
+def test_economic_gate_evaluator_bound_true() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "ECONOMIC_GATE_EVALUATOR_BOUND") == "true"
+    assert _field_value(section, "ECONOMIC_GATE_EVALUATOR_BOUND") == "true"
+    assert _field_value(section, "ECONOMIC_EVALUATION_RUNNER_V1_BOUND") == "true"
+
+
+def test_runner_slice_registered_in_implemented_scope() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    global_scope = _field_value(text, "RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE")
+    section_scope = _field_value(section, "RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE")
+    assert global_scope == STEP_29M_IMPLEMENTED_SCOPE
+    assert section_scope == STEP_29M_IMPLEMENTED_SCOPE
+    assert RUNNER_SLICE in global_scope.split(",")
+    for historical_slice in HISTORICAL_SLICES:
+        assert historical_slice in global_scope
+
+
+def test_real_evaluation_not_performed() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "REAL_EVALUATION_PERFORMED") == "false"
+    assert _field_value(section, "REAL_EVALUATION_PERFORMED") == "false"
+
+
+def test_real_admissible_futures_evidence_absent_and_unbound() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_PRESENT") == "false"
+    assert _field_value(text, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_BOUND") == "false"
+    assert _field_value(section, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_PRESENT") == "false"
+    assert _field_value(section, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_BOUND") == "false"
+
+
+def test_real_admissible_futures_evidence_required_true() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED") == "true"
+    assert _field_value(section, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED") == "true"
+
+
+def test_economic_validity_not_proven_and_offline_gate_false() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "ECONOMIC_VALIDITY_RESULT") == "NOT_PROVEN"
+    assert _field_value(text, "ECONOMIC_VALIDITY_PROVEN") == "false"
+    assert _field_value(text, "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS") == "false"
+    assert _field_value(section, "ECONOMIC_VALIDITY_RESULT") == "NOT_PROVEN"
+    assert _field_value(section, "ECONOMIC_VALIDITY_PROVEN") == "false"
+    assert _field_value(section, "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS") == "false"
+
+
+def test_current_promotion_evaluation_ineligible() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "CURRENT_PROMOTION_EVALUATION") == "INELIGIBLE"
+    assert _field_value(section, "CURRENT_PROMOTION_EVALUATION") == "INELIGIBLE"
+    assert _field_value(text, "PROMOTION_CANDIDATE_ELIGIBLE") == "false"
+
+
+def test_operator_input_required_for_real_evaluation() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION") == "true"
+    assert _field_value(section, "OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION") == "true"
+    assert _field_value(text, "REAL_EVALUATION_INPUT_STATUS") == "AWAITING_OPERATOR_DATASET_INPUT"
+    assert (
+        _field_value(section, "REAL_EVALUATION_INPUT_STATUS") == "AWAITING_OPERATOR_DATASET_INPUT"
+    )
+
+
+def test_kraken_and_venue_fixtures_excluded_from_canonical_economic_path() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "KRAKEN_FIXTURE_LEAK_INTO_CANONICAL_ECONOMIC_PATH") == "false"
+    assert _field_value(text, "VENUE_SPECIFIC_CANONICAL_ECONOMIC_PATH_ALLOWED") == "false"
+    assert _field_value(section, "KRAKEN_FIXTURE_LEAK_INTO_CANONICAL_ECONOMIC_PATH") == "false"
+    assert _field_value(section, "VENUE_SPECIFIC_CANONICAL_ECONOMIC_PATH_ALLOWED") == "false"
+
+
+def test_runtime_rewire_and_step_29s_not_started() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNTIME_REWIRE_IMPLEMENTATION_ALLOWED") == "false"
+    assert _field_value(text, "RUNBOOK_STEP_29R_COMPLETE") == "false"
+    assert _field_value(text, "STEP_29S_STARTED") == "false"
+
+
+def test_progress_registry_closeout_performed_true() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
+    assert _field_value(section, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
+
+
+def test_registry_closeout_does_not_imply_economic_pass_or_promotion() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
+    assert _field_value(section, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
+    assert _field_value(text, "ECONOMIC_VALIDITY_RESULT") == "NOT_PROVEN"
+    assert _field_value(text, "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS") == "false"
+    assert _field_value(text, "CURRENT_PROMOTION_EVALUATION") == "INELIGIBLE"
+    assert _field_value(section, "PROMOTION_ELIGIBILITY_GRANTED") == "false"
+    assert _field_value(section, "RUNTIME_AUTHORITY_GRANTED") == "false"
+
+
+def test_step_29n_history_preserved() -> None:
+    text = _read_registry()
+    section = _step_29n_section(text)
+    assert _field_value(text, "RUNBOOK_STEP_29N_COMPLETE") == "true"
+    assert _field_value(section, "RUNBOOK_STEP_29N_COMPLETE") == "true"
+    assert _field_value(section, "PROGRESS_REGISTRY_CLOSEOUT_PERFORMED") == "true"
+    assert _field_value(section, "STATUS") == "COMPLETE"
+
+
+def test_global_closeout_not_permanently_bound_to_29m_section_snapshot() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(section, "STEP_29N_STARTED") == "false"
+    assert _field_value(text, "STEP_29N_STARTED") == "true"
+    assert _field_value(text, "RUNBOOK_STEP_29R_STARTED") == "true"
+
+
+def test_no_runtime_order_network_or_live_effects() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "RUNTIME_EFFECT") == "false"
+    assert _field_value(text, "ORDER_EFFECT") == "false"
+    assert _field_value(text, "NETWORK_EFFECT") == "false"
+    assert _field_value(text, "LIVE_AUTHORIZED") == "false"
+    assert _field_value(section, "RUNTIME_EFFECT") == "false"
+    assert _field_value(section, "ORDER_EFFECT") == "false"
+    assert _field_value(section, "NETWORK_EFFECT") == "false"
+    assert _field_value(section, "LIVE_AUTHORIZED") == "false"
+
+
+def test_futures_only_and_bitcoin_direction_forbidden() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "FUTURES_ONLY") == "true"
+    assert _field_value(section, "FUTURES_ONLY") == "true"
+    assert _field_value(section, "BITCOIN_DIRECTION_ALLOWED") == "false"
+
+
+def test_merged_pr_and_commit_bound() -> None:
+    section = _step_29m_section(_read_registry())
+    assert "#4723" in section
+    assert MERGE_COMMIT in section
+
+
+def test_canonical_runner_owner_bound() -> None:
+    section = _step_29m_section(_read_registry())
+    assert (
+        _field_value(section, "CANONICAL_RUNNER_OWNER")
+        == "scripts/ops/run_economic_viability_evidence_evaluation_v1.py"
+    )

--- a/tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py
@@ -19,7 +19,8 @@ STEP_29M_IMPLEMENTED_SCOPE = (
     "funding_model_binding_v1_slice,"
     "parameter_sensitivity_evidence_binding_v1_slice,"
     "admissible_versioned_futures_dataset_binding_v1_slice,"
-    "economic_validity_policy_threshold_values_v1_slice"
+    "economic_validity_policy_threshold_values_v1_slice,"
+    "real_admissible_futures_economic_evidence_evaluation_v1_offline_slice"
 )
 STEP_29M_SLICES = tuple(STEP_29M_IMPLEMENTED_SCOPE.split(","))
 


### PR DESCRIPTION
## Summary

- Progress-Registry-Closeout für den mit PR #4723 gemergten Offline-Economic-Evidence-Evaluation-Runner (`real_admissible_futures_economic_evidence_evaluation_v1_offline_slice`)
- Registry Before: STEP 29M COMPLETE ohne Runner-Slice; `ECONOMIC_GATE_EVALUATOR_BOUND` nicht registriert
- Registry After: kumulative `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE`-Erweiterung; `ECONOMIC_GATE_EVALUATOR_BOUND=true`; Operator-Input-Grenze dokumentiert
- Technische Runner-Bindung (`scripts/ops/run_economic_viability_evidence_evaluation_v1.py`) ohne reale Evaluation

## Semantische Abgrenzung

- **Nicht behauptet:** `REAL_EVALUATION_PERFORMED`, reale admissible Futures Evidence, Economic PASS, Promotion Eligibility, Runtime-Rewire
- `ECONOMIC_VALIDITY_RESULT=NOT_PROVEN`, `ECONOMIC_VALIDITY_OFFLINE_GATE_PASS=false`, `CURRENT_PROMOTION_EVALUATION=INELIGIBLE`
- `RUNTIME_REWIRE_IMPLEMENTATION_ALLOWED=false`, `RUNBOOK_STEP_29R_COMPLETE=false`, `STEP_29S_STARTED=false`
- Kraken-/Venue-Fixtures ausgeschlossen (`KRAKEN_FIXTURE_LEAK_INTO_CANONICAL_ECONOMIC_PATH=false`)

## Scope

- Nur `docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md` und Registry-Contract-Tests
- Keine `src/`-, `scripts/`- oder Config-Mutation
- Keine Runtime-/Order-/Netzwerk-/Live-Wirkung

## Test plan

- [x] STEP 29M Runner Registry Closeout Contracts (19 tests)
- [x] Bestehende STEP 29M Registry Contracts
- [x] STEP 29N Promotion Gate Contracts
- [x] STEP 29R Registry Contracts
- [x] Execution Governance Crosslink Contracts
- [x] `ruff format --check`, `ruff check`, `git diff --check`
- [x] CI selector: `NO_OP` (`docs_workflow_or_static_contract_only`)


Made with [Cursor](https://cursor.com)