### PR TITLE
docs(governance): STEP 29M operator input admissibility closure v0

### DIFF
--- a/config/governance/real_admissible_futures_economic_evaluation_operator_input_contract_v1.json
+++ b/config/governance/real_admissible_futures_economic_evaluation_operator_input_contract_v1.json
@@ -1,0 +1,683 @@
+{
+  "admissibility_verdict": "NO_REAL_ADMISSIBLE_EVIDENCE_PRESENT",
+  "authority_effect": "NONE",
+  "bitcoin_direction_allowed": false,
+  "contract_version": "real_admissible_futures_economic_evaluation_operator_input_contract_v1",
+  "economic_validity_result": "NOT_PROVEN",
+  "fields": [
+    {
+      "canonical_default": "inst-eth-usdt-perp",
+      "constraints": {
+        "forbidden_substrings": ["btc", "xbt", "bitcoin", "spot", "synthetic_spot"],
+        "must_equal_mv2_required_instrument": true
+      },
+      "data_type": "string",
+      "economic_effect": "Instrument universe for MV2 offline research wiring.",
+      "field_name": "instrument_id",
+      "rationale": "STEP 29L binds MV2 research wiring to a single canonical futures instrument.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Blocks BTC/XBT/spot instrument leakage into canonical economic path.",
+      "source_owner": "src/backtest/mv2_research_wiring_v1.py"
+    },
+    {
+      "canonical_default": "perpetual",
+      "constraints": {
+        "allowed_values": ["futures", "perpetual", "swap"]
+      },
+      "data_type": "string",
+      "economic_effect": "Contract type must be linear USDT-margined futures semantics.",
+      "field_name": "contract_type",
+      "rationale": "Admissible dataset descriptor requires explicit futures contract typing.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Rejects spot contract typing.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": true,
+      "constraints": {
+        "must_be": true
+      },
+      "data_type": "boolean",
+      "economic_effect": "Economic evaluation scope is futures-only.",
+      "field_name": "futures_only",
+      "rationale": "Runbook safety invariant for STEP 29M economic evaluation.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Fail-closed on non-futures data classes.",
+      "source_owner": "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+    },
+    {
+      "canonical_default": false,
+      "constraints": {
+        "must_be": false
+      },
+      "data_type": "boolean",
+      "economic_effect": "Bitcoin-direction strategies are out of scope.",
+      "field_name": "bitcoin_direction_allowed",
+      "rationale": "Runbook safety invariant forbids BTC/XBT direction in canonical path.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Fail-closed on BTC/XBT instrument and direction leakage.",
+      "source_owner": "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+    },
+    {
+      "canonical_default": "v1",
+      "constraints": {
+        "allowed_values": ["v1"]
+      },
+      "data_type": "string",
+      "economic_effect": "Dataset schema version gates required bar columns and digest semantics.",
+      "field_name": "dataset_schema_version",
+      "rationale": "Admissible versioned futures dataset binding is version-locked.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Unknown schema versions fail closed.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": "v1",
+      "constraints": {
+        "allowed_values": ["v1"]
+      },
+      "data_type": "string",
+      "economic_effect": "Dataset identity and manifest contract version.",
+      "field_name": "dataset_version",
+      "rationale": "Runner rejects unknown dataset versions.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Prevents unversioned dataset identity drift.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": "admissible_versioned_futures_dataset_manifest_v1",
+      "constraints": {
+        "allowed_values": ["admissible_versioned_futures_dataset_manifest_v1"]
+      },
+      "data_type": "string",
+      "economic_effect": "Manifest digest and provenance envelope version.",
+      "field_name": "dataset_manifest_version",
+      "rationale": "Runner validates manifest_version against canonical contract.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Unknown manifest versions fail closed.",
+      "source_owner": "scripts/ops/run_economic_viability_evidence_evaluation_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "format": "local_absolute_or_repo_relative_path",
+        "must_exist_before_evaluation": true,
+        "supported_suffixes": [".parquet", ".csv"],
+        "url_forbidden": true
+      },
+      "data_type": "path",
+      "economic_effect": "Primary bar series for offline economic evidence generation.",
+      "field_name": "dataset_path",
+      "rationale": "No real admissible futures dataset is bound in-repo; operator must stage curated export.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Blocks evaluation on missing or remote paths.",
+      "source_owner": "scripts/ops/run_economic_viability_evidence_evaluation_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "format": "local_absolute_or_repo_relative_path",
+        "must_exist_before_evaluation": true,
+        "requires_manifest_digest": true,
+        "url_forbidden": true
+      },
+      "data_type": "path",
+      "economic_effect": "Binds dataset identity, splits, and provenance digests.",
+      "field_name": "dataset_manifest_path",
+      "rationale": "Digest-verified manifest is mandatory for admissibility and reproducibility.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Missing or mismatched manifest digest fails closed.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "allowed_values": ["operator_staged_futures_v1"],
+        "forbidden_values": [
+          "spot",
+          "synthetic_spot",
+          "synthetic_contract_fixture",
+          "test_fixture",
+          "preview",
+          "preview_data",
+          "probe",
+          "probe_data",
+          "transport_fixture",
+          "transport",
+          "webui_fixture",
+          "webui"
+        ]
+      },
+      "data_type": "string",
+      "economic_effect": "Classifies dataset provenance for admissibility gating.",
+      "field_name": "provenance_source_type",
+      "rationale": "Runner rejects fixture, preview, probe, transport, and spot source types.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Prevents fixture and venue-transport leakage into canonical economic path.",
+      "source_owner": "scripts/ops/run_economic_viability_evidence_evaluation_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "forbidden_prefixes": ["tests/", "tests/fixtures/"],
+        "forbidden_substrings": ["kraken", "fixture", "webui", "probe", "preview"],
+        "min_length": 3,
+        "must_be_non_empty": true
+      },
+      "data_type": "string",
+      "economic_effect": "Traceable operator-curated export reference outside repo fixtures.",
+      "field_name": "provenance_ref",
+      "rationale": "Provenance must identify operator-staged real export, not in-repo test fixtures.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Blocks fixture and venue-specific canonicalization paths.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "forbidden_substrings": ["kraken", "btc", "xbt", "bitcoin", "spot"],
+        "must_be_non_empty": true,
+        "neutral_venue_required": true
+      },
+      "data_type": "string",
+      "economic_effect": "Venue identity for provenance only; not canonical venue logic.",
+      "field_name": "provenance_venue_id",
+      "rationale": "Venue id is recorded for traceability but must not drive venue-specific canonicalization.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Venue-specific canonical economic paths are forbidden.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "forbidden_substrings": ["test_fixture", "deterministic_test_fixture", "probe", "preview"],
+        "must_be_non_empty": true
+      },
+      "data_type": "string",
+      "economic_effect": "Documents how the staged dataset was produced.",
+      "field_name": "provenance_generation_method",
+      "rationale": "Generation method must not classify as synthetic or test fixture generation.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Rejects synthetic/test generation markers.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "format": "iso8601_utc",
+        "must_be_non_empty": true
+      },
+      "data_type": "string",
+      "economic_effect": "Ingestion timestamp for provenance audit trail.",
+      "field_name": "provenance_ingestion_timestamp",
+      "rationale": "Required provenance field for admissible dataset binding.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Missing provenance fails closed.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "derived_from_bars": true,
+        "must_cover_train_val_oos": true
+      },
+      "data_type": "time_range",
+      "economic_effect": "Full data coverage window for economic evidence.",
+      "field_name": "data_period",
+      "rationale": "Derived from staged bars once dataset exists; currently no bound real dataset.",
+      "required": true,
+      "resolution_class": "BLOCKED_NO_EVIDENCE",
+      "resolved": false,
+      "safety_effect": "Cannot assert coverage without staged real dataset.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "derived_from_bars": true,
+        "split_policy_version": "v1"
+      },
+      "data_type": "time_range",
+      "economic_effect": "Training split for walk-forward and leakage checks.",
+      "field_name": "training_period",
+      "rationale": "Computed by split policy once real bars are staged and admissible.",
+      "required": true,
+      "resolution_class": "BLOCKED_NO_EVIDENCE",
+      "resolved": false,
+      "safety_effect": "Temporal leakage checks require real split boundaries.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "derived_from_bars": true,
+        "split_policy_version": "v1"
+      },
+      "data_type": "time_range",
+      "economic_effect": "Validation split for robustness evidence.",
+      "field_name": "validation_period",
+      "rationale": "Computed by split policy once real bars are staged.",
+      "required": true,
+      "resolution_class": "BLOCKED_NO_EVIDENCE",
+      "resolved": false,
+      "safety_effect": "Leakage checks require real split boundaries.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "derived_from_bars": true,
+        "split_policy_version": "v1"
+      },
+      "data_type": "time_range",
+      "economic_effect": "Out-of-sample split for economic validity gate.",
+      "field_name": "out_of_sample_period",
+      "rationale": "Computed by split policy once real bars are staged.",
+      "required": true,
+      "resolution_class": "BLOCKED_NO_EVIDENCE",
+      "resolved": false,
+      "safety_effect": "OOS evidence requires real split boundaries.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": "1h",
+      "constraints": {
+        "must_match_staged_bars": true,
+        "required_columns_include": ["bar_interval"]
+      },
+      "data_type": "string",
+      "economic_effect": "Bar granularity drives funding interval alignment and replay cadence.",
+      "field_name": "bar_granularity",
+      "rationale": "Schema requires bar_interval column; exact value comes from staged dataset.",
+      "required": true,
+      "resolution_class": "BLOCKED_NO_EVIDENCE",
+      "resolved": false,
+      "safety_effect": "Mismatched granularity breaks funding and replay alignment.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": "backtest_cost_v0",
+      "constraints": {
+        "allowed_values": ["backtest_cost_v0"]
+      },
+      "data_type": "string",
+      "economic_effect": "Versioned cost binding envelope for fee, slippage, execution.",
+      "field_name": "cost_model_version",
+      "rationale": "Runner requires explicit versioned cost model binding.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Missing cost model version fails closed.",
+      "source_owner": "src/backtest/cost_config_v0.py"
+    },
+    {
+      "canonical_default": "backtest_fee_taker_symmetric_v0",
+      "constraints": {
+        "allowed_values": ["backtest_fee_taker_symmetric_v0"]
+      },
+      "data_type": "string",
+      "economic_effect": "Fee model version recorded in economic evidence.",
+      "field_name": "fee_model_version",
+      "rationale": "Canonical fee model version from cost config owner.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Unversioned fee model blocks economic claims.",
+      "source_owner": "src/backtest/cost_config_v0.py"
+    },
+    {
+      "canonical_default": "backtest_slippage_symmetric_v0",
+      "constraints": {
+        "allowed_values": ["backtest_slippage_symmetric_v0"]
+      },
+      "data_type": "string",
+      "economic_effect": "Slippage model version recorded in economic evidence.",
+      "field_name": "slippage_model_version",
+      "rationale": "Canonical slippage model version from cost config owner.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Unversioned slippage model blocks economic claims.",
+      "source_owner": "src/backtest/cost_config_v0.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "exclusive_min": 0.0,
+        "implicit_zero_forbidden": true,
+        "units": "basis_points"
+      },
+      "data_type": "float",
+      "economic_effect": "Explicit non-zero fee assumption for realistic economic evaluation.",
+      "field_name": "fee_bps",
+      "rationale": "Runner rejects missing or zero fee_bps; operator must supply realistic fee.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Implicit zero-cost evaluation is forbidden.",
+      "source_owner": "scripts/ops/run_economic_viability_evidence_evaluation_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "exclusive_min": 0.0,
+        "implicit_zero_forbidden": true,
+        "units": "basis_points"
+      },
+      "data_type": "float",
+      "economic_effect": "Explicit non-zero slippage assumption for realistic economic evaluation.",
+      "field_name": "slippage_bps",
+      "rationale": "Runner rejects missing or zero slippage_bps; operator must supply realistic slippage.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Implicit zero-cost evaluation is forbidden.",
+      "source_owner": "scripts/ops/run_economic_viability_evidence_evaluation_v1.py"
+    },
+    {
+      "canonical_default": "backtest_funding_perpetual_interval_v1",
+      "constraints": {
+        "allowed_values": ["backtest_funding_perpetual_interval_v1"],
+        "bind_required": true
+      },
+      "data_type": "string",
+      "economic_effect": "Funding drag model version and interval-aligned payments.",
+      "field_name": "funding_model_version",
+      "rationale": "Funding binding is canonical once bind=true in evaluation config.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Missing funding binding fails closed.",
+      "source_owner": "src/backtest/funding_model_v1.py"
+    },
+    {
+      "canonical_default": "paper_market_context_v0",
+      "constraints": {
+        "allowed_values": ["paper_market_context_v0"]
+      },
+      "data_type": "string",
+      "economic_effect": "Offline execution model version in economic evidence.",
+      "field_name": "execution_model_version",
+      "rationale": "Canonical execution model from cost config owner.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Unversioned execution model blocks economic claims.",
+      "source_owner": "src/backtest/cost_config_v0.py"
+    },
+    {
+      "canonical_default": "economic_validity_policy_v1",
+      "constraints": {
+        "allowed_values": ["economic_validity_policy_v1"],
+        "thresholds_must_be_configured": true
+      },
+      "data_type": "string",
+      "economic_effect": "Versioned economic validity gate thresholds and reason codes.",
+      "field_name": "economic_validity_policy_version",
+      "rationale": "Canonical policy with configured thresholds is bound in STEP 29M.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Unconfigured thresholds block economic validity claims.",
+      "source_owner": "src/backtest/economic_validity_policy_v1.py"
+    },
+    {
+      "canonical_default": "ma_crossover",
+      "constraints": {
+        "mv2_wiring_compatible": true
+      },
+      "data_type": "string",
+      "economic_effect": "Strategy identity for MV2 offline research replay chain.",
+      "field_name": "strategy_id",
+      "rationale": "Runner defaults to ma_crossover; operator may override within MV2 wiring compatibility.",
+      "required": true,
+      "resolution_class": "DETERMINISTICALLY_DERIVABLE",
+      "resolved": true,
+      "safety_effect": "Unsupported strategy/instrument pair fails closed in MV2 wiring.",
+      "source_owner": "src/backtest/mv2_research_wiring_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "bind_required": true,
+        "grid_version": "v1",
+        "must_define_parameter_names_and_values": true
+      },
+      "data_type": "object",
+      "economic_effect": "Parameter sensitivity grid for robustness evidence.",
+      "field_name": "parameter_sensitivity_grid",
+      "rationale": "Operator must supply realistic fee/slippage sensitivity grid in evaluation config.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Missing sensitivity binding blocks evaluation.",
+      "source_owner": "src/backtest/parameter_sensitivity_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "bind_required": true,
+        "positive_integers": ["train_bars", "test_bars", "step_bars"]
+      },
+      "data_type": "object",
+      "economic_effect": "Walk-forward window sizing for OOS stability evidence.",
+      "field_name": "walk_forward_binding",
+      "rationale": "Operator chooses window sizes appropriate to staged dataset length.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Missing walk-forward binding blocks evaluation.",
+      "source_owner": "scripts/ops/run_economic_viability_evidence_evaluation_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "bind_required": true,
+        "positive_integers": ["runs"],
+        "seed_required": true
+      },
+      "data_type": "object",
+      "economic_effect": "Monte Carlo robustness sample count and deterministic seed.",
+      "field_name": "monte_carlo_binding",
+      "rationale": "Operator configures MC runs/seed for staged dataset economics.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Missing MC binding blocks evaluation.",
+      "source_owner": "scripts/ops/run_economic_viability_evidence_evaluation_v1.py"
+    },
+    {
+      "canonical_default": true,
+      "constraints": {
+        "bind_required": true
+      },
+      "data_type": "boolean",
+      "economic_effect": "Stress suite binding for tail-risk evidence.",
+      "field_name": "stress_binding",
+      "rationale": "Stress bind=true is required; scenario set is canonical in policy.",
+      "required": true,
+      "resolution_class": "DETERMINISTICALLY_DERIVABLE",
+      "resolved": true,
+      "safety_effect": "Missing stress binding blocks evaluation.",
+      "source_owner": "src/backtest/economic_validity_policy_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "format": "local_absolute_or_repo_relative_path",
+        "must_exist_before_evaluation": true,
+        "supported_suffixes": [".json", ".toml", ".tml"],
+        "url_forbidden": true
+      },
+      "data_type": "path",
+      "economic_effect": "Versioned evaluation config binding all cost, funding, sensitivity, and splits.",
+      "field_name": "evaluation_config_path",
+      "rationale": "Runner requires explicit config_path with all bindings.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Missing config blocks evaluation.",
+      "source_owner": "scripts/ops/run_economic_viability_evidence_evaluation_v1.py"
+    },
+    {
+      "canonical_default": "use_canonical_policy_overlay",
+      "constraints": {
+        "canonical_overlay_allowed": true,
+        "policy_version": "economic_validity_policy_v1"
+      },
+      "data_type": "path_or_canonical",
+      "economic_effect": "Economic validity policy overlay or canonical use_canonical=true.",
+      "field_name": "policy_path",
+      "rationale": "Canonical policy overlay is deterministically resolvable without operator file.",
+      "required": false,
+      "resolution_class": "DETERMINISTICALLY_DERIVABLE",
+      "resolved": true,
+      "safety_effect": "Policy version mismatch fails closed.",
+      "source_owner": "src/backtest/economic_validity_policy_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "format": "local_absolute_path",
+        "must_be_under_durable_archive_root": true,
+        "url_forbidden": true
+      },
+      "data_type": "path",
+      "economic_effect": "Durable evidence output location with manifest verification.",
+      "field_name": "evidence_output_dir",
+      "rationale": "Real evaluation evidence must be persisted under operator durable archive root.",
+      "required": true,
+      "resolution_class": "OPERATOR_REQUIRED",
+      "resolved": false,
+      "safety_effect": "Tmp-only evidence is invalid for economic admissibility closure.",
+      "source_owner": "scripts/ops/primary_evidence_retention_v0.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "format": "sha256_hex",
+        "must_match_staged_dataset": true
+      },
+      "data_type": "string",
+      "economic_effect": "Dataset content digest for reproducibility and admissibility binding.",
+      "field_name": "dataset_digest",
+      "rationale": "Computed once real staged bars exist; currently no bound real dataset.",
+      "required": true,
+      "resolution_class": "BLOCKED_NO_EVIDENCE",
+      "resolved": false,
+      "safety_effect": "Digest mismatch fails closed.",
+      "source_owner": "src/backtest/admissible_versioned_futures_dataset_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "format": "sha256_hex",
+        "must_match_manifest": true
+      },
+      "data_type": "string",
+      "economic_effect": "Manifest digest for evidence bundle integrity.",
+      "field_name": "dataset_manifest_digest",
+      "rationale": "Computed once operator manifest is staged.",
+      "required": true,
+      "resolution_class": "BLOCKED_NO_EVIDENCE",
+      "resolved": false,
+      "safety_effect": "Manifest digest mismatch fails closed.",
+      "source_owner": "scripts/ops/run_economic_viability_evidence_evaluation_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "format": "sha256_hex",
+        "must_match_evaluation_config": true
+      },
+      "data_type": "string",
+      "economic_effect": "Config digest binds cost, funding, sensitivity, and evaluation parameters.",
+      "field_name": "config_digest",
+      "rationale": "Computed once operator evaluation config is staged.",
+      "required": true,
+      "resolution_class": "BLOCKED_NO_EVIDENCE",
+      "resolved": false,
+      "safety_effect": "Config digest mismatch fails closed.",
+      "source_owner": "scripts/ops/run_economic_viability_evidence_evaluation_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "minimum_trade_count_threshold": 50.0,
+        "policy_owner": "economic_validity_policy_v1"
+      },
+      "data_type": "integer",
+      "economic_effect": "Minimum trade count threshold from canonical economic validity policy.",
+      "field_name": "minimum_trade_count_policy",
+      "rationale": "Threshold is canonically bound; realized trade count requires real evaluation.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Low trade-count regimes fail economic validity gate.",
+      "source_owner": "src/backtest/economic_validity_policy_v1.py"
+    },
+    {
+      "canonical_default": null,
+      "constraints": {
+        "minimum_net_expectancy": 0.0,
+        "minimum_profit_factor": 1.3,
+        "maximum_max_drawdown": 0.25,
+        "minimum_walk_forward_pass_ratio": 0.5
+      },
+      "data_type": "object",
+      "economic_effect": "Canonical economic validity thresholds; evaluation applies after real run only.",
+      "field_name": "economic_validity_thresholds",
+      "rationale": "Threshold values are version-bound; pass/fail requires real evaluation output.",
+      "required": true,
+      "resolution_class": "CANONICALLY_BOUND",
+      "resolved": true,
+      "safety_effect": "Threshold tuning without versioned policy change is forbidden.",
+      "source_owner": "src/backtest/economic_validity_policy_v1.py"
+    }
+  ],
+  "futures_only": true,
+  "kraken_fixture_leak_into_canonical_economic_path": false,
+  "live_authorized": false,
+  "network_effect": false,
+  "operator_input_contract_complete": true,
+  "operator_input_required_for_real_evaluation": true,
+  "order_effect": false,
+  "owner": "backtest.real_admissible_futures_economic_evaluation_operator_input_contract_v1",
+  "profitability_claim_allowed": false,
+  "real_admissible_futures_evidence_bound": false,
+  "real_admissible_futures_evidence_present": false,
+  "real_evaluation_performed": false,
+  "real_evaluation_permitted": false,
+  "runtime_effect": false,
+  "scope_classification": "RUNBOOK_STEP_29M_REAL_ADMISSIBLE_FUTURES_ECONOMIC_EVALUATION_OPERATOR_INPUT_AND_ADMISSIBILITY_CLOSURE_V0",
+  "venue_specific_canonical_economic_path_allowed": false,
+  "verdict": "OPERATOR_INPUT_CONTRACT_COMPLETE"
+}

--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -111,10 +111,12 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29L_COMPLETE` | `true` |
 | `STEP_29M_STARTED` | `true` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `true` |
 | `ECONOMIC_GATE_EVALUATOR_BOUND` | `true` |
+| `OPERATOR_INPUT_CONTRACT_V1_BOUND` | `true` |
+| `OPERATOR_INPUT_CONTRACT_COMPLETE` | `true` |
 | `REAL_EVALUATION_PERFORMED` | `false` |
 | `REAL_ADMISSIBLE_FUTURES_EVIDENCE_PRESENT` | `false` |
 | `REAL_ADMISSIBLE_FUTURES_EVIDENCE_BOUND` | `false` |
@@ -122,7 +124,7 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `ECONOMIC_VALIDITY_RESULT` | `NOT_PROVEN` |
 | `CURRENT_PROMOTION_EVALUATION` | `INELIGIBLE` |
 | `OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION` | `true` |
-| `REAL_EVALUATION_INPUT_STATUS` | `AWAITING_OPERATOR_DATASET_INPUT` |
+| `REAL_EVALUATION_INPUT_STATUS` | `OPERATOR_INPUT_CONTRACT_COMPLETE_AWAITING_DATASET_STAGING` |
 | `KRAKEN_FIXTURE_LEAK_INTO_CANONICAL_ECONOMIC_PATH` | `false` |
 | `VENUE_SPECIFIC_CANONICAL_ECONOMIC_PATH_ALLOWED` | `false` |
 | `ORDER_EFFECT` | `false` |
@@ -1097,7 +1099,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `MERGE_COMMITS` | `5352d83f069b7d361e89c877ebe2d3d5ae161156`, `5d402a6a1fc2fb1a76af3a91223ac46ee9d80b72`, `72a33b0a85c76bc00fff482d7e88fda0db33c873`, `4ff161b3d005ff12e434982a108b22ef46165272`, `cd9474c820d500bbdbc09217b4c46f5e604f96b2`, `cf0ced2edff0a4baaf8d8fcd93d3e7476c13257e`, `49a7595cb5e6885fa2d003db74f07d6acf0d61cb`, `aa1a8fd9d3444e5d5f3dbe2386d4114b2e48b0c9` |
 | `DURABLE_EVIDENCE_REFS` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_viability_evidence_pr4700_squash_merge_closeout_v0_20260630T211900Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_residual_slice_pr4701squash_merge_closeout_v0_20260630T213300Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_validity_policy_v1_pr4702squash_merge_closeout_v0_20260630T214700Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_funding_binding_v1_pr4703_squash_merge_closeout_v0_20260630T220500Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_parameter_sensitivity_pr4704_squash_merge_closeout_v0_20260701T221500Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_admissible_versioned_futures_dataset_pr4705_squash_merge_closeout_v0_20260630T223551Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_validity_policy_thresholds_pr4706_squash_merge_closeout_v0_20260630T225125Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_real_admissible_futures_economic_evaluation_runner_pr4723_squash_merge_closeout_v0_20260701T072817Z (MANIFEST_VERIFY_RC=0); economic_viability_evidence_pr=4700; economic_viability_evidence_merge_commit=5352d83f069b7d361e89c877ebe2d3d5ae161156; persistence_load_reproducibility_pr=4701; persistence_load_reproducibility_merge_commit=5d402a6a1fc2fb1a76af3a91223ac46ee9d80b72; economic_validity_policy_v1_pr=4702; economic_validity_policy_v1_merge_commit=72a33b0a85c76bc00fff482d7e88fda0db33c873; funding_model_binding_pr=4703; funding_model_binding_merge_commit=4ff161b3d005ff12e434982a108b22ef46165272; parameter_sensitivity_evidence_pr=4704; parameter_sensitivity_evidence_merge_commit=cd9474c820d500bbdbc09217b4c46f5e604f96b2; admissible_versioned_futures_dataset_pr=4705; admissible_versioned_futures_dataset_merge_commit=cf0ced2edff0a4baaf8d8fcd93d3e7476c13257e; economic_validity_policy_threshold_values_pr=4706; economic_validity_policy_threshold_values_merge_commit=49a7595cb5e6885fa2d003db74f07d6acf0d61cb; economic_evaluation_runner_pr=4723; economic_evaluation_runner_merge_commit=aa1a8fd9d3444e5d5f3dbe2386d4114b2e48b0c9; economic_evaluation_runner_squash_parent=d2c505f86ec879d4fb71c4c531349552ed3e1634; canonical_scope=economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice; ECONOMIC_VIABILITY_EVIDENCE_V1_BOUND=true; ECONOMIC_GATE_EVALUATOR_BOUND=true; ECONOMIC_EVALUATION_RUNNER_V1_BOUND=true; REAL_EVALUATION_PERFORMED=false; OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION=true; STEP29M_IMPLEMENTATION_COMPLETE=true; TECHNICAL_ECONOMIC_VIABILITY_EVIDENCE_STACK_COMPLETE=true; ECONOMIC_VALIDITY_RESULT=NOT_PROVEN; REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED=true; THRESHOLD_TUNING_ALLOWED=false; STEP_29N_STARTED=false; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_LIVE=true; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME=true; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS=true; STEP_29M_COMPLETION_DOES_NOT_CLAIM_ECONOMIC_VALIDITY=true; STEP_29M_COMPLETION_DOES_NOT_START_PROMOTION_GATE=true; PROMOTION_ELIGIBILITY_GRANTED=false; RUNTIME_AUTHORITY_GRANTED=false; UNIVERSE_SELECTION_UNCHANGED=true; offline_only=true; non_authorizing=true; runtime_process_started=false; scheduler_action_performed=false; venue_access_performed=false; credential_access_performed=false; trading_action_performed=false; progress_registry_closeout_status=COMPLETE; FUTURES_ONLY=true; BITCOIN_DIRECTION_ALLOWED=false; LIVE_AUTHORIZED=false; ORDERS_ALLOWED=false; SCHEDULER_RUNTIME_ALLOWED=false` |
 | `DEPENDENCIES` | RUNBOOK_STEP_29L |
-| `REMAINING_GAPS` | `real admissible futures economic evidence evaluation awaiting operator dataset input; economic validity proof` |
+| `REMAINING_GAPS` | `operator dataset staging for real admissible futures economic evaluation; economic validity proof` |
 | `DATA_ADMISSIBILITY_STATUS` | `PASS` |
 | `POLICY_THRESHOLD_STATUS` | `PASS` |
 | `ECONOMIC_VALIDITY_EVALUATION_STATUS` | `RESEARCH_ONLY` |
@@ -1111,7 +1113,9 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `ECONOMIC_VALIDITY_OFFLINE_GATE_PASS` | `false` |
 | `CURRENT_PROMOTION_EVALUATION` | `INELIGIBLE` |
 | `OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION` | `true` |
-| `REAL_EVALUATION_INPUT_STATUS` | `AWAITING_OPERATOR_DATASET_INPUT` |
+| `OPERATOR_INPUT_CONTRACT_V1_BOUND` | `true` |
+| `OPERATOR_INPUT_CONTRACT_COMPLETE` | `true` |
+| `REAL_EVALUATION_INPUT_STATUS` | `OPERATOR_INPUT_CONTRACT_COMPLETE_AWAITING_DATASET_STAGING` |
 | `KRAKEN_FIXTURE_LEAK_INTO_CANONICAL_ECONOMIC_PATH` | `false` |
 | `VENUE_SPECIFIC_CANONICAL_ECONOMIC_PATH_ALLOWED` | `false` |
 | `ORDER_EFFECT` | `false` |
@@ -1120,6 +1124,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `THRESHOLD_TUNING_ALLOWED` | `false` |
 | `PROMOTION_ELIGIBILITY_GRANTED` | `false` |
 | `RUNTIME_AUTHORITY_GRANTED` | `false` |
+| `CANONICAL_OPERATOR_INPUT_CONTRACT_OWNER` | `src/backtest/real_admissible_futures_economic_evaluation_operator_input_contract_v1.py` |
 | `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29N` |
 | `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
 | `RUNTIME_EFFECT` | `false` |
@@ -1128,7 +1133,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `ECONOMIC_VALIDITY_PROVEN` | `false` |
 | `PROFITABILITY_CLAIM_ALLOWED` | `false` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `true` |
 | `ECONOMIC_VIABILITY_EVIDENCE_V1_IMPLEMENTED` | `true` |

--- a/src/backtest/real_admissible_futures_economic_evaluation_operator_input_contract_v1.py
+++ b/src/backtest/real_admissible_futures_economic_evaluation_operator_input_contract_v1.py
@@ -1,0 +1,526 @@
+"""
+Real admissible futures economic evaluation operator input contract v1 (STEP 29M).
+
+Fail-closed, offline, non-authorizing contract that specifies and validates the
+operator inputs required before any real admissible futures economic evaluation.
+Does not fetch data, run evaluation, or claim profitability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional
+from urllib.parse import urlparse
+
+from src.backtest import mv2_research_wiring_v1 as mv2_wiring
+from src.backtest.admissible_versioned_futures_dataset_v1 import (
+    DATASET_SCHEMA_VERSION,
+    DEFAULT_DATASET_VERSION,
+)
+from src.backtest.cost_config_v0 import (
+    COST_MODEL_VERSION,
+    EXECUTION_MODEL_VERSION,
+    FEE_MODEL_VERSION,
+    SLIPPAGE_MODEL_VERSION,
+)
+from src.backtest.economic_validity_policy_v1 import (
+    ECONOMIC_VALIDITY_POLICY_VERSION,
+    canonical_economic_validity_policy_v1,
+)
+from src.backtest.funding_model_v1 import FUNDING_MODEL_VERSION
+
+CONTRACT_VERSION = "real_admissible_futures_economic_evaluation_operator_input_contract_v1"
+CONTRACT_OWNER = "backtest.real_admissible_futures_economic_evaluation_operator_input_contract_v1"
+CONTRACT_CONFIG_REL_PATH = (
+    "config/governance/real_admissible_futures_economic_evaluation_operator_input_contract_v1.json"
+)
+RUNNER_OWNER = "scripts.ops.run_economic_viability_evidence_evaluation_v1"
+
+_URL_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
+_FORBIDDEN_INSTRUMENT_SUBSTRINGS = frozenset({"btc", "xbt", "bitcoin", "spot", "synthetic_spot"})
+_FORBIDDEN_PROVENANCE_SUBSTRINGS = frozenset(
+    {"kraken", "fixture", "webui", "probe", "preview", "transport"}
+)
+_FORBIDDEN_SOURCE_TYPES = frozenset(
+    {
+        "spot",
+        "synthetic_spot",
+        "synthetic_contract_fixture",
+        "test_fixture",
+        "preview",
+        "preview_data",
+        "probe",
+        "probe_data",
+        "transport_fixture",
+        "transport",
+        "webui_fixture",
+        "webui",
+    }
+)
+_FORBIDDEN_GENERATION_MARKERS = frozenset(
+    {
+        "deterministic_test_fixture",
+        "test_fixture",
+        "probe",
+        "preview",
+        "transport_fixture",
+        "webui_fixture",
+    }
+)
+
+
+class OperatorInputContractError(ValueError):
+    """Fail-closed operator input contract error."""
+
+
+class OperatorInputResolutionClass(str, Enum):
+    CANONICALLY_BOUND = "CANONICALLY_BOUND"
+    DETERMINISTICALLY_DERIVABLE = "DETERMINISTICALLY_DERIVABLE"
+    OPERATOR_REQUIRED = "OPERATOR_REQUIRED"
+    BLOCKED_NO_EVIDENCE = "BLOCKED_NO_EVIDENCE"
+    POLICY_GAP = "POLICY_GAP"
+
+
+class OperatorInputReadinessVerdict(str, Enum):
+    OPERATOR_INPUT_CONTRACT_COMPLETE = "OPERATOR_INPUT_CONTRACT_COMPLETE"
+    REAL_ADMISSIBLE_EVIDENCE_ALREADY_PRESENT_BUT_UNBOUND = (
+        "REAL_ADMISSIBLE_EVIDENCE_ALREADY_PRESENT_BUT_UNBOUND"
+    )
+    NO_REAL_ADMISSIBLE_EVIDENCE_PRESENT = "NO_REAL_ADMISSIBLE_EVIDENCE_PRESENT"
+    BLOCKED_BY_CANONICAL_POLICY_GAP = "BLOCKED_BY_CANONICAL_POLICY_GAP"
+
+
+@dataclass(frozen=True)
+class OperatorInputFieldSpecV1:
+    field_name: str
+    data_type: str
+    required: bool
+    resolved: bool
+    resolution_class: OperatorInputResolutionClass
+    canonical_default: Any
+    source_owner: str
+    rationale: str
+    safety_effect: str
+    economic_effect: str
+    constraints: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "field_name": self.field_name,
+            "data_type": self.data_type,
+            "required": self.required,
+            "resolved": self.resolved,
+            "resolution_class": self.resolution_class.value,
+            "canonical_default": self.canonical_default,
+            "source_owner": self.source_owner,
+            "rationale": self.rationale,
+            "safety_effect": self.safety_effect,
+            "economic_effect": self.economic_effect,
+            "constraints": dict(self.constraints),
+        }
+
+
+@dataclass(frozen=True)
+class OperatorInputReadinessResultV1:
+    contract_version: str
+    owner: str
+    verdict: OperatorInputReadinessVerdict
+    admissibility_verdict: str
+    operator_input_contract_complete: bool
+    real_evaluation_permitted: bool
+    profitability_claim_allowed: bool
+    unresolved_operator_fields: tuple[str, ...]
+    blocked_no_evidence_fields: tuple[str, ...]
+    policy_gap_fields: tuple[str, ...]
+    resolved_field_count: int
+    required_field_count: int
+    reason_codes: tuple[str, ...]
+    futures_only: bool
+    bitcoin_direction_allowed: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "owner": self.owner,
+            "verdict": self.verdict.value,
+            "admissibility_verdict": self.admissibility_verdict,
+            "operator_input_contract_complete": self.operator_input_contract_complete,
+            "real_evaluation_permitted": self.real_evaluation_permitted,
+            "profitability_claim_allowed": self.profitability_claim_allowed,
+            "unresolved_operator_fields": list(self.unresolved_operator_fields),
+            "blocked_no_evidence_fields": list(self.blocked_no_evidence_fields),
+            "policy_gap_fields": list(self.policy_gap_fields),
+            "resolved_field_count": self.resolved_field_count,
+            "required_field_count": self.required_field_count,
+            "reason_codes": list(self.reason_codes),
+            "futures_only": self.futures_only,
+            "bitcoin_direction_allowed": self.bitcoin_direction_allowed,
+        }
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def default_contract_config_path(repo_root: Optional[Path] = None) -> Path:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    return root / CONTRACT_CONFIG_REL_PATH
+
+
+def load_operator_input_contract_v1(
+    path: Optional[Path] = None,
+    *,
+    repo_root: Optional[Path] = None,
+) -> dict[str, Any]:
+    contract_path = path or default_contract_config_path(repo_root)
+    if not contract_path.is_file():
+        raise OperatorInputContractError(f"contract_file_missing:{contract_path}")
+    try:
+        payload = json.loads(contract_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise OperatorInputContractError(f"contract_invalid_json:{contract_path}") from exc
+    if not isinstance(payload, dict):
+        raise OperatorInputContractError("contract_not_object")
+    if payload.get("contract_version") != CONTRACT_VERSION:
+        raise OperatorInputContractError("contract_version_mismatch")
+    if payload.get("owner") != CONTRACT_OWNER:
+        raise OperatorInputContractError("contract_owner_mismatch")
+    fields = payload.get("fields")
+    if not isinstance(fields, list) or not fields:
+        raise OperatorInputContractError("contract_fields_missing")
+    return payload
+
+
+def parse_operator_input_field_specs_v1(
+    contract: Mapping[str, Any],
+) -> tuple[OperatorInputFieldSpecV1, ...]:
+    specs: list[OperatorInputFieldSpecV1] = []
+    for raw in contract["fields"]:
+        if not isinstance(raw, Mapping):
+            raise OperatorInputContractError("contract_field_not_object")
+        field_name = str(raw.get("field_name", "")).strip()
+        if not field_name:
+            raise OperatorInputContractError("contract_field_name_missing")
+        try:
+            resolution_class = OperatorInputResolutionClass(str(raw["resolution_class"]))
+        except (KeyError, ValueError) as exc:
+            raise OperatorInputContractError(
+                f"contract_resolution_class_invalid:{field_name}"
+            ) from exc
+        specs.append(
+            OperatorInputFieldSpecV1(
+                field_name=field_name,
+                data_type=str(raw.get("data_type", "")),
+                required=bool(raw.get("required", True)),
+                resolved=bool(raw.get("resolved", False)),
+                resolution_class=resolution_class,
+                canonical_default=raw.get("canonical_default"),
+                source_owner=str(raw.get("source_owner", "")),
+                rationale=str(raw.get("rationale", "")),
+                safety_effect=str(raw.get("safety_effect", "")),
+                economic_effect=str(raw.get("economic_effect", "")),
+                constraints=dict(raw.get("constraints", {})),
+            )
+        )
+    return tuple(specs)
+
+
+def _reject_url_path(path_str: str, *, field_name: str) -> None:
+    if _URL_SCHEME_RE.match(path_str.strip()):
+        raise OperatorInputContractError(f"{field_name}_url_forbidden")
+    parsed = urlparse(path_str)
+    if parsed.scheme and parsed.scheme not in {"", "file"}:
+        raise OperatorInputContractError(f"{field_name}_url_forbidden")
+
+
+def _contains_forbidden_token(value: str, forbidden: frozenset[str]) -> bool:
+    lowered = value.lower()
+    return any(token in lowered for token in forbidden)
+
+
+def validate_canonical_safety_invariants_v1(contract: Mapping[str, Any]) -> list[str]:
+    violations: list[str] = []
+    if contract.get("futures_only") is not True:
+        violations.append("futures_only_not_true")
+    if contract.get("bitcoin_direction_allowed") is not False:
+        violations.append("bitcoin_direction_allowed_not_false")
+    if contract.get("real_evaluation_permitted") is not False:
+        violations.append("real_evaluation_permitted_not_false")
+    if contract.get("profitability_claim_allowed") is not False:
+        violations.append("profitability_claim_allowed_not_false")
+    if contract.get("kraken_fixture_leak_into_canonical_economic_path") is not False:
+        violations.append("kraken_fixture_leak_not_false")
+    if contract.get("venue_specific_canonical_economic_path_allowed") is not False:
+        violations.append("venue_specific_canonical_path_not_false")
+    if contract.get("runtime_effect") is not False:
+        violations.append("runtime_effect_not_false")
+    if contract.get("order_effect") is not False:
+        violations.append("order_effect_not_false")
+    if contract.get("network_effect") is not False:
+        violations.append("network_effect_not_false")
+    if contract.get("live_authorized") is not False:
+        violations.append("live_authorized_not_false")
+    return violations
+
+
+def validate_bound_canonical_defaults_v1() -> list[str]:
+    violations: list[str] = []
+    policy = canonical_economic_validity_policy_v1()
+    if not policy.is_version_bound():
+        violations.append("economic_validity_policy_unbound")
+    if not policy.thresholds_configured():
+        violations.append("economic_validity_policy_thresholds_unconfigured")
+    if policy.policy_version != ECONOMIC_VALIDITY_POLICY_VERSION:
+        violations.append("economic_validity_policy_version_mismatch")
+    if mv2_wiring.MV2_REQUIRED_INSTRUMENT_ID != "inst-eth-usdt-perp":
+        violations.append("mv2_required_instrument_changed")
+    if COST_MODEL_VERSION != "backtest_cost_v0":
+        violations.append("cost_model_version_changed")
+    if FEE_MODEL_VERSION != "backtest_fee_taker_symmetric_v0":
+        violations.append("fee_model_version_changed")
+    if SLIPPAGE_MODEL_VERSION != "backtest_slippage_symmetric_v0":
+        violations.append("slippage_model_version_changed")
+    if FUNDING_MODEL_VERSION != "backtest_funding_perpetual_interval_v1":
+        violations.append("funding_model_version_changed")
+    if EXECUTION_MODEL_VERSION != "paper_market_context_v0":
+        violations.append("execution_model_version_changed")
+    if DEFAULT_DATASET_VERSION != "v1":
+        violations.append("dataset_version_changed")
+    if DATASET_SCHEMA_VERSION != "v1":
+        violations.append("dataset_schema_version_changed")
+    return violations
+
+
+def evaluate_operator_input_readiness_v1(
+    contract: Optional[Mapping[str, Any]] = None,
+    *,
+    repo_root: Optional[Path] = None,
+) -> OperatorInputReadinessResultV1:
+    payload = dict(contract or load_operator_input_contract_v1(repo_root=repo_root))
+    specs = parse_operator_input_field_specs_v1(payload)
+    reason_codes: list[str] = []
+    reason_codes.extend(validate_canonical_safety_invariants_v1(payload))
+    reason_codes.extend(validate_bound_canonical_defaults_v1())
+
+    unresolved_operator = tuple(
+        spec.field_name
+        for spec in specs
+        if spec.required
+        and spec.resolution_class is OperatorInputResolutionClass.OPERATOR_REQUIRED
+        and not spec.resolved
+    )
+    blocked_no_evidence = tuple(
+        spec.field_name
+        for spec in specs
+        if spec.required
+        and spec.resolution_class is OperatorInputResolutionClass.BLOCKED_NO_EVIDENCE
+        and not spec.resolved
+    )
+    policy_gaps = tuple(
+        spec.field_name
+        for spec in specs
+        if spec.required
+        and spec.resolution_class is OperatorInputResolutionClass.POLICY_GAP
+        and not spec.resolved
+    )
+    resolved_count = sum(1 for spec in specs if spec.resolved)
+    required_count = sum(1 for spec in specs if spec.required)
+
+    if policy_gaps:
+        verdict = OperatorInputReadinessVerdict.BLOCKED_BY_CANONICAL_POLICY_GAP
+        reason_codes.append("policy_gap_fields_present")
+    elif payload.get("admissibility_verdict") == (
+        "REAL_ADMISSIBLE_EVIDENCE_ALREADY_PRESENT_BUT_UNBOUND"
+    ):
+        verdict = OperatorInputReadinessVerdict.REAL_ADMISSIBLE_EVIDENCE_ALREADY_PRESENT_BUT_UNBOUND
+        reason_codes.append("real_evidence_present_but_unbound")
+    elif unresolved_operator or blocked_no_evidence:
+        verdict = OperatorInputReadinessVerdict.OPERATOR_INPUT_CONTRACT_COMPLETE
+        if blocked_no_evidence:
+            reason_codes.append("no_real_admissible_evidence_present")
+        if unresolved_operator:
+            reason_codes.append("operator_inputs_unresolved")
+    else:
+        verdict = OperatorInputReadinessVerdict.OPERATOR_INPUT_CONTRACT_COMPLETE
+
+    contract_complete = (
+        payload.get("operator_input_contract_complete") is True
+        and not policy_gaps
+        and payload.get("verdict")
+        == OperatorInputReadinessVerdict.OPERATOR_INPUT_CONTRACT_COMPLETE.value
+    )
+    if not contract_complete:
+        reason_codes.append("operator_input_contract_incomplete")
+
+    return OperatorInputReadinessResultV1(
+        contract_version=CONTRACT_VERSION,
+        owner=CONTRACT_OWNER,
+        verdict=verdict,
+        admissibility_verdict=str(payload.get("admissibility_verdict", "")),
+        operator_input_contract_complete=contract_complete,
+        real_evaluation_permitted=False,
+        profitability_claim_allowed=False,
+        unresolved_operator_fields=unresolved_operator,
+        blocked_no_evidence_fields=blocked_no_evidence,
+        policy_gap_fields=policy_gaps,
+        resolved_field_count=resolved_count,
+        required_field_count=required_count,
+        reason_codes=tuple(dict.fromkeys(reason_codes)),
+        futures_only=True,
+        bitcoin_direction_allowed=False,
+    )
+
+
+def _require_positive_cost(value: Any, *, field_name: str) -> float:
+    if value is None:
+        raise OperatorInputContractError(f"{field_name}_missing")
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise OperatorInputContractError(f"{field_name}_invalid") from exc
+    if not math.isfinite(numeric) or numeric <= 0.0:
+        raise OperatorInputContractError(f"{field_name}_implicit_zero_forbidden")
+    return numeric
+
+
+def validate_staged_operator_inputs_v1(
+    operator_inputs: Mapping[str, Any],
+    *,
+    repo_root: Optional[Path] = None,
+    allow_real_evaluation: bool = False,
+) -> list[str]:
+    """Validate a concrete operator staging payload (fail-closed for real evaluation)."""
+    if allow_real_evaluation:
+        raise OperatorInputContractError("real_evaluation_not_permitted_in_this_contract")
+
+    violations: list[str] = []
+    readiness = evaluate_operator_input_readiness_v1(repo_root=repo_root)
+    if readiness.policy_gap_fields:
+        violations.append("policy_gap_blocks_staging")
+    if readiness.unresolved_operator_fields:
+        violations.extend(
+            f"operator_field_unresolved:{name}" for name in readiness.unresolved_operator_fields
+        )
+
+    instrument_id = str(operator_inputs.get("instrument_id", mv2_wiring.MV2_REQUIRED_INSTRUMENT_ID))
+    if instrument_id != mv2_wiring.MV2_REQUIRED_INSTRUMENT_ID:
+        violations.append("instrument_id_not_mv2_required")
+    if _contains_forbidden_token(instrument_id, _FORBIDDEN_INSTRUMENT_SUBSTRINGS):
+        violations.append("instrument_id_forbidden_token")
+
+    source_type = str(operator_inputs.get("provenance_source_type", "")).lower().strip()
+    if source_type in _FORBIDDEN_SOURCE_TYPES:
+        violations.append(f"provenance_source_type_forbidden:{source_type}")
+
+    provenance_ref = str(operator_inputs.get("provenance_ref", "")).strip()
+    if not provenance_ref:
+        violations.append("provenance_ref_missing")
+    elif provenance_ref.lower().startswith("tests/") or "/tests/" in provenance_ref.lower():
+        violations.append("provenance_ref_test_path_forbidden")
+    elif _contains_forbidden_token(provenance_ref, _FORBIDDEN_PROVENANCE_SUBSTRINGS):
+        violations.append("provenance_ref_forbidden_token")
+
+    generation_method = str(operator_inputs.get("provenance_generation_method", "")).lower()
+    for marker in _FORBIDDEN_GENERATION_MARKERS:
+        if marker in generation_method:
+            violations.append(f"provenance_generation_method_forbidden:{marker}")
+
+    venue_id = str(operator_inputs.get("provenance_venue_id", "")).strip()
+    if not venue_id:
+        violations.append("provenance_venue_id_missing")
+    elif _contains_forbidden_token(venue_id, _FORBIDDEN_PROVENANCE_SUBSTRINGS):
+        violations.append("provenance_venue_id_forbidden_token")
+
+    for path_field in (
+        "dataset_path",
+        "dataset_manifest_path",
+        "evaluation_config_path",
+        "evidence_output_dir",
+    ):
+        raw = operator_inputs.get(path_field)
+        if raw is None:
+            continue
+        path_str = str(raw).strip()
+        if not path_str:
+            violations.append(f"{path_field}_empty")
+            continue
+        try:
+            _reject_url_path(path_str, field_name=path_field)
+        except OperatorInputContractError:
+            violations.append(f"{path_field}_url_forbidden")
+
+    if "fee_bps" in operator_inputs:
+        try:
+            _require_positive_cost(operator_inputs["fee_bps"], field_name="fee_bps")
+        except OperatorInputContractError as exc:
+            violations.append(str(exc))
+    if "slippage_bps" in operator_inputs:
+        try:
+            _require_positive_cost(operator_inputs["slippage_bps"], field_name="slippage_bps")
+        except OperatorInputContractError as exc:
+            violations.append(str(exc))
+
+    if operator_inputs.get("profitability_claim_allowed") is True:
+        violations.append("profitability_claim_forbidden")
+    if operator_inputs.get("real_evaluation_performed") is True:
+        violations.append("real_evaluation_performed_forbidden")
+    if operator_inputs.get("economic_validity_result") == "PASS":
+        violations.append("economic_validity_pass_claim_forbidden_without_real_evaluation")
+
+    return violations
+
+
+def assert_operator_input_contract_ready_v1(
+    *,
+    repo_root: Optional[Path] = None,
+) -> OperatorInputReadinessResultV1:
+    result = evaluate_operator_input_readiness_v1(repo_root=repo_root)
+    if not result.operator_input_contract_complete:
+        raise OperatorInputContractError(
+            f"operator_input_contract_not_ready:{','.join(result.reason_codes)}"
+        )
+    if result.real_evaluation_permitted:
+        raise OperatorInputContractError("real_evaluation_permitted_forbidden")
+    if result.profitability_claim_allowed:
+        raise OperatorInputContractError("profitability_claim_allowed_forbidden")
+    return result
+
+
+def contract_implementation_digest() -> str:
+    return _stable_digest(
+        {
+            "owner": CONTRACT_OWNER,
+            "contract_version": CONTRACT_VERSION,
+            "runner_owner": RUNNER_OWNER,
+        }
+    )
+
+
+def serialize_operator_input_contract_manifest_v1(
+    *,
+    repo_root: Optional[Path] = None,
+) -> dict[str, Any]:
+    contract = load_operator_input_contract_v1(repo_root=repo_root)
+    readiness = evaluate_operator_input_readiness_v1(contract, repo_root=repo_root)
+    specs = parse_operator_input_field_specs_v1(contract)
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "owner": CONTRACT_OWNER,
+        "implementation_digest": contract_implementation_digest(),
+        "readiness": readiness.to_dict(),
+        "field_count": len(specs),
+        "resolved_fields": [spec.field_name for spec in specs if spec.resolved],
+        "unresolved_operator_fields": list(readiness.unresolved_operator_fields),
+        "blocked_no_evidence_fields": list(readiness.blocked_no_evidence_fields),
+        "futures_only": True,
+        "bitcoin_direction_allowed": False,
+        "real_evaluation_permitted": False,
+        "profitability_claim_allowed": False,
+    }

--- a/tests/ops/test_real_admissible_futures_economic_evaluation_operator_input_contract_v1.py
+++ b/tests/ops/test_real_admissible_futures_economic_evaluation_operator_input_contract_v1.py
@@ -1,0 +1,186 @@
+"""Contract tests for real admissible futures economic evaluation operator input v1."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.backtest import mv2_research_wiring_v1 as mv2_wiring
+from src.backtest import (
+    real_admissible_futures_economic_evaluation_operator_input_contract_v1 as contract,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = ROOT / contract.CONTRACT_CONFIG_REL_PATH
+RUNNER_SCRIPT = ROOT / "scripts" / "ops" / "run_economic_viability_evidence_evaluation_v1.py"
+
+
+def test_contract_config_exists_and_version_bound() -> None:
+    payload = contract.load_operator_input_contract_v1()
+    assert payload["contract_version"] == contract.CONTRACT_VERSION
+    assert payload["owner"] == contract.CONTRACT_OWNER
+    assert payload["verdict"] == "OPERATOR_INPUT_CONTRACT_COMPLETE"
+    assert payload["admissibility_verdict"] == "NO_REAL_ADMISSIBLE_EVIDENCE_PRESENT"
+
+
+def test_operator_input_contract_ready_fail_closed() -> None:
+    result = contract.assert_operator_input_contract_ready_v1()
+    assert result.operator_input_contract_complete is True
+    assert result.real_evaluation_permitted is False
+    assert result.profitability_claim_allowed is False
+    assert result.verdict.value == "OPERATOR_INPUT_CONTRACT_COMPLETE"
+    assert result.admissibility_verdict == "NO_REAL_ADMISSIBLE_EVIDENCE_PRESENT"
+    assert result.unresolved_operator_fields
+    assert result.blocked_no_evidence_fields
+
+
+def test_no_policy_gap_fields() -> None:
+    result = contract.evaluate_operator_input_readiness_v1()
+    assert not result.policy_gap_fields
+
+
+def test_resolved_canonical_bindings_present() -> None:
+    specs = contract.parse_operator_input_field_specs_v1(contract.load_operator_input_contract_v1())
+    resolved_names = {spec.field_name for spec in specs if spec.resolved}
+    for field_name in (
+        "instrument_id",
+        "contract_type",
+        "futures_only",
+        "bitcoin_direction_allowed",
+        "cost_model_version",
+        "fee_model_version",
+        "slippage_model_version",
+        "funding_model_version",
+        "execution_model_version",
+        "economic_validity_policy_version",
+        "economic_validity_thresholds",
+    ):
+        assert field_name in resolved_names
+
+
+def test_unresolved_operator_fields_are_required_staging_inputs() -> None:
+    result = contract.evaluate_operator_input_readiness_v1()
+    for field_name in (
+        "dataset_path",
+        "dataset_manifest_path",
+        "provenance_source_type",
+        "provenance_ref",
+        "fee_bps",
+        "slippage_bps",
+        "evaluation_config_path",
+        "evidence_output_dir",
+    ):
+        assert field_name in result.unresolved_operator_fields
+
+
+def test_fixture_and_spot_staging_rejected() -> None:
+    violations = contract.validate_staged_operator_inputs_v1(
+        {
+            "instrument_id": mv2_wiring.MV2_REQUIRED_INSTRUMENT_ID,
+            "provenance_source_type": "test_fixture",
+            "provenance_ref": "tests/fixtures/sample",
+            "provenance_venue_id": "neutral_offline_venue_v1",
+            "provenance_generation_method": "deterministic_test_fixture",
+            "fee_bps": 10.0,
+            "slippage_bps": 5.0,
+        }
+    )
+    assert any("provenance_source_type_forbidden" in item for item in violations)
+    assert any("provenance_ref_test_path_forbidden" in item for item in violations)
+    assert any("provenance_generation_method_forbidden" in item for item in violations)
+
+
+def test_kraken_and_btc_tokens_rejected_in_staging() -> None:
+    violations = contract.validate_staged_operator_inputs_v1(
+        {
+            "instrument_id": "inst-btc-usdt-perp",
+            "provenance_source_type": "operator_staged_futures_v1",
+            "provenance_ref": "operator/staged/kraken_export_v1",
+            "provenance_venue_id": "kraken_futures_v1",
+            "provenance_generation_method": "operator_curated_versioned_export",
+            "fee_bps": 10.0,
+            "slippage_bps": 5.0,
+        }
+    )
+    assert "instrument_id_not_mv2_required" in violations
+    assert "instrument_id_forbidden_token" in violations
+    assert "provenance_ref_forbidden_token" in violations
+    assert "provenance_venue_id_forbidden_token" in violations
+
+
+def test_implicit_zero_cost_rejected() -> None:
+    violations = contract.validate_staged_operator_inputs_v1(
+        {
+            "instrument_id": mv2_wiring.MV2_REQUIRED_INSTRUMENT_ID,
+            "provenance_source_type": "operator_staged_futures_v1",
+            "provenance_ref": "operator/staged/eth_perp_neutral_v1",
+            "provenance_venue_id": "neutral_offline_venue_v1",
+            "provenance_generation_method": "operator_curated_versioned_export",
+            "fee_bps": 0.0,
+            "slippage_bps": 5.0,
+        }
+    )
+    assert "fee_bps_implicit_zero_forbidden" in violations
+
+
+def test_profitability_claim_without_real_evaluation_rejected() -> None:
+    violations = contract.validate_staged_operator_inputs_v1(
+        {
+            "instrument_id": mv2_wiring.MV2_REQUIRED_INSTRUMENT_ID,
+            "provenance_source_type": "operator_staged_futures_v1",
+            "provenance_ref": "operator/staged/eth_perp_neutral_v1",
+            "provenance_venue_id": "neutral_offline_venue_v1",
+            "provenance_generation_method": "operator_curated_versioned_export",
+            "fee_bps": 10.0,
+            "slippage_bps": 5.0,
+            "profitability_claim_allowed": True,
+            "economic_validity_result": "PASS",
+        }
+    )
+    assert "profitability_claim_forbidden" in violations
+    assert "economic_validity_pass_claim_forbidden_without_real_evaluation" in violations
+
+
+def test_real_evaluation_flag_rejected() -> None:
+    with pytest.raises(contract.OperatorInputContractError, match="real_evaluation_not_permitted"):
+        contract.validate_staged_operator_inputs_v1({}, allow_real_evaluation=True)
+
+
+def test_runner_has_no_kraken_btc_spot_canonicalization() -> None:
+    source = RUNNER_SCRIPT.read_text(encoding="utf-8").lower()
+    assert "kraken" not in source
+    assert "xbt" not in source
+    assert "btc" not in source
+
+
+def test_contract_module_forbids_kraken_btc_spot_tokens_in_staging() -> None:
+    violations = contract.validate_staged_operator_inputs_v1(
+        {
+            "instrument_id": "inst-btc-usdt-perp",
+            "provenance_source_type": "operator_staged_futures_v1",
+            "provenance_ref": "operator/staged/kraken_export_v1",
+            "provenance_venue_id": "kraken_futures_v1",
+            "provenance_generation_method": "operator_curated_versioned_export",
+            "fee_bps": 10.0,
+            "slippage_bps": 5.0,
+        }
+    )
+    assert violations
+
+
+def test_serialize_manifest_is_deterministic() -> None:
+    first = contract.serialize_operator_input_contract_manifest_v1()
+    second = contract.serialize_operator_input_contract_manifest_v1()
+    assert first == second
+    assert first["implementation_digest"] == contract.contract_implementation_digest()
+
+
+def test_contract_json_matches_field_spec_count() -> None:
+    payload = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+    specs = contract.parse_operator_input_field_specs_v1(payload)
+    assert len(specs) == len(payload["fields"])
+    assert payload["operator_input_required_for_real_evaluation"] is True
+    assert payload["real_evaluation_performed"] is False
+    assert payload["real_admissible_futures_evidence_present"] is False

--- a/tests/ops/test_runbook_step29m_economic_evaluation_runner_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_economic_evaluation_runner_progress_registry_closeout_contract_v0.py
@@ -21,7 +21,8 @@ STEP_29M_IMPLEMENTED_SCOPE = (
     "parameter_sensitivity_evidence_binding_v1_slice,"
     "admissible_versioned_futures_dataset_binding_v1_slice,"
     "economic_validity_policy_threshold_values_v1_slice,"
-    f"{RUNNER_SLICE}"
+    f"{RUNNER_SLICE},"
+    "real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice"
 )
 MERGE_COMMIT = "aa1a8fd9d3444e5d5f3dbe2386d4114b2e48b0c9"
 HISTORICAL_SLICES = tuple(
@@ -127,10 +128,8 @@ def test_operator_input_required_for_real_evaluation() -> None:
     section = _step_29m_section(text)
     assert _field_value(text, "OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION") == "true"
     assert _field_value(section, "OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION") == "true"
-    assert _field_value(text, "REAL_EVALUATION_INPUT_STATUS") == "AWAITING_OPERATOR_DATASET_INPUT"
-    assert (
-        _field_value(section, "REAL_EVALUATION_INPUT_STATUS") == "AWAITING_OPERATOR_DATASET_INPUT"
-    )
+    assert _field_value(text, "REAL_EVALUATION_PERFORMED") == "false"
+    assert _field_value(section, "REAL_EVALUATION_PERFORMED") == "false"
 
 
 def test_kraken_and_venue_fixtures_excluded_from_canonical_economic_path() -> None:

--- a/tests/ops/test_runbook_step29m_operator_input_admissibility_closure_registry_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_operator_input_admissibility_closure_registry_contract_v0.py
@@ -1,0 +1,103 @@
+"""Registry contract tests for STEP 29M operator input admissibility closure slice."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROGRESS_REGISTRY = REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+
+OPERATOR_INPUT_SLICE = (
+    "real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice"
+)
+STEP_29M_IMPLEMENTED_SCOPE = (
+    "economic_viability_evidence_v1_offline_slice,"
+    "economic_viability_evidence_v1_persistence_load_reproducibility_slice,"
+    "economic_validity_policy_v1_contract_slice,"
+    "funding_model_binding_v1_slice,"
+    "parameter_sensitivity_evidence_binding_v1_slice,"
+    "admissible_versioned_futures_dataset_binding_v1_slice,"
+    "economic_validity_policy_threshold_values_v1_slice,"
+    "real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,"
+    f"{OPERATOR_INPUT_SLICE}"
+)
+
+
+def _read_registry() -> str:
+    assert PROGRESS_REGISTRY.is_file(), f"missing canonical registry: {PROGRESS_REGISTRY}"
+    return PROGRESS_REGISTRY.read_text(encoding="utf-8")
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(rf"\| `{re.escape(field)}` \| `([^`]*)` \|", text)
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _step_29m_section(text: str) -> str:
+    start = text.index("#### RUNBOOK_STEP_29M — Economic Viability Evidence v1")
+    end = text.index("#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1", start)
+    return text[start:end]
+
+
+def test_operator_input_slice_registered_in_implemented_scope() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    global_scope = _field_value(text, "RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE")
+    section_scope = _field_value(section, "RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE")
+    assert global_scope == STEP_29M_IMPLEMENTED_SCOPE
+    assert section_scope == STEP_29M_IMPLEMENTED_SCOPE
+    assert OPERATOR_INPUT_SLICE in global_scope.split(",")
+
+
+def test_step_29m_complete_remains_true() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "RUNBOOK_STEP_29M_COMPLETE") == "true"
+    assert _field_value(section, "RUNBOOK_STEP_29M_COMPLETE") == "true"
+
+
+def test_operator_input_contract_bound_without_real_evaluation() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert _field_value(text, "OPERATOR_INPUT_CONTRACT_V1_BOUND") == "true"
+    assert _field_value(section, "OPERATOR_INPUT_CONTRACT_V1_BOUND") == "true"
+    assert _field_value(text, "OPERATOR_INPUT_CONTRACT_COMPLETE") == "true"
+    assert _field_value(section, "OPERATOR_INPUT_CONTRACT_COMPLETE") == "true"
+    assert _field_value(text, "REAL_EVALUATION_PERFORMED") == "false"
+    assert _field_value(section, "REAL_EVALUATION_PERFORMED") == "false"
+    assert _field_value(text, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_PRESENT") == "false"
+    assert _field_value(text, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_BOUND") == "false"
+    assert _field_value(text, "ECONOMIC_VALIDITY_RESULT") == "NOT_PROVEN"
+    assert _field_value(text, "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS") == "false"
+    assert _field_value(text, "CURRENT_PROMOTION_EVALUATION") == "INELIGIBLE"
+    assert _field_value(text, "RUNTIME_REWIRE_IMPLEMENTATION_ALLOWED") == "false"
+
+
+def test_real_evaluation_input_status_updated() -> None:
+    text = _read_registry()
+    section = _step_29m_section(text)
+    assert (
+        _field_value(text, "REAL_EVALUATION_INPUT_STATUS")
+        == "OPERATOR_INPUT_CONTRACT_COMPLETE_AWAITING_DATASET_STAGING"
+    )
+    assert (
+        _field_value(section, "REAL_EVALUATION_INPUT_STATUS")
+        == "OPERATOR_INPUT_CONTRACT_COMPLETE_AWAITING_DATASET_STAGING"
+    )
+    assert _field_value(text, "OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION") == "true"
+
+
+def test_canonical_operator_input_contract_owner_bound() -> None:
+    section = _step_29m_section(_read_registry())
+    assert (
+        _field_value(section, "CANONICAL_OPERATOR_INPUT_CONTRACT_OWNER")
+        == "src/backtest/real_admissible_futures_economic_evaluation_operator_input_contract_v1.py"
+    )
+
+
+def test_no_step_29r_or_29s_started_by_this_slice() -> None:
+    text = _read_registry()
+    assert _field_value(text, "RUNBOOK_STEP_29R_COMPLETE") == "false"
+    assert _field_value(text, "STEP_29S_STARTED") == "false"


### PR DESCRIPTION
## Summary

- Adds a versioned, machine-readable operator input contract (`config/governance/real_admissible_futures_economic_evaluation_operator_input_contract_v1.json`) that fully specifies the inputs required before any real admissible futures economic evaluation.
- Introduces a fail-closed validator owner (`src/backtest/real_admissible_futures_economic_evaluation_operator_input_contract_v1.py`) with contract tests covering fixture/venue/BTC/spot rejection, implicit-zero-cost blocking, and no profitability claims without real evaluation.
- Updates the progress registry with the new STEP 29M slice while preserving `RUNBOOK_STEP_29M_COMPLETE=true`, `REAL_EVALUATION_PERFORMED=false`, and all safety invariants.

## Verdict

- `OPERATOR_INPUT_CONTRACT_COMPLETE`
- `NO_REAL_ADMISSIBLE_EVIDENCE_PRESENT`

## Test plan

- [x] `pytest tests/ops/test_real_admissible_futures_economic_evaluation_operator_input_contract_v1.py`
- [x] `pytest tests/ops/test_runbook_step29m_operator_input_admissibility_closure_registry_contract_v0.py`
- [x] `pytest tests/ops/test_runbook_step29m_economic_evaluation_runner_progress_registry_closeout_contract_v0.py`
- [x] `ruff format --check` and `ruff check` on changed Python files
- [x] CI selector: `PR_BOUNDED_FULL` (central `src/` change)

## Stop boundary

No merge in this slice. No real economic evaluation. No dataset acquisition. No STEP 29R/29S.


Made with [Cursor](https://cursor.com)