### PR TITLE
fix(step29m): bind MV2 research RiskLimits from cfg max_position_size

### DIFF
--- a/src/backtest/mv2_research_wiring_v1.py
+++ b/src/backtest/mv2_research_wiring_v1.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
@@ -57,6 +58,7 @@ from src.experiments.stress_tests import (
     StressTestSuiteResult,
     run_stress_test_suite,
 )
+from src.risk.limits import RiskLimits, RiskLimitsConfig
 from src.strategies.registry import (
     REGISTRY_SCHEMA_VERSION,
     StrategyRegistrySnapshotV1,
@@ -222,6 +224,29 @@ class MV2WalkForwardWiringResultV1:
 def _fail_closed(condition: bool, reason: str) -> None:
     if condition:
         raise ValueError(reason)
+
+
+def risk_max_position_fraction_to_percent_v1(fraction: float) -> float:
+    """Convert cfg.risk.max_position_size fraction (0, 1] to RiskLimits percent scale."""
+    if not isinstance(fraction, (int, float)) or not math.isfinite(float(fraction)):
+        raise ValueError("risk_max_position_size_invalid")
+    value = float(fraction)
+    if value <= 0.0 or value > 1.0:
+        raise ValueError("risk_max_position_size_out_of_range")
+    return value * 100.0
+
+
+def build_mv2_research_risk_limits_v1(cfg: Mapping[str, Any]) -> RiskLimits:
+    """Bind BacktestEngine RiskLimits from canonical cfg.risk.max_position_size fraction."""
+    risk_section = cfg.get("risk")
+    if not isinstance(risk_section, Mapping):
+        raise ValueError("risk_section_missing")
+    if risk_section.get("max_position_size") is None:
+        raise ValueError("risk_max_position_size_missing")
+    max_position_pct = risk_max_position_fraction_to_percent_v1(
+        float(risk_section["max_position_size"])
+    )
+    return RiskLimits(RiskLimitsConfig(max_position_pct=max_position_pct))
 
 
 def _stable_digest(payload: Mapping[str, Any]) -> str:
@@ -932,7 +957,10 @@ def run_mv2_research_backtest_wiring_v1(
         strategy_params["stop_pct"] = contract.stop_pct
         engine_cfg["offline_evaluation_sizing_contract_v1"] = contract.to_dict()
 
-    engine = BacktestEngine(use_execution_pipeline=False)
+    engine = BacktestEngine(
+        use_execution_pipeline=False,
+        risk_limits=build_mv2_research_risk_limits_v1(cfg),
+    )
     engine.config = engine_cfg
     backtest_result = engine.run_realistic(
         df=bars,

--- a/tests/backtest/test_mv2_research_wiring_v1.py
+++ b/tests/backtest/test_mv2_research_wiring_v1.py
@@ -577,3 +577,53 @@ def test_decision_parity_runtime_vs_research_with_observed_l1() -> None:
     assert [outcome.position_signal for outcome in runtime.bar_outcomes] == [
         outcome.position_signal for outcome in research.bar_outcomes
     ]
+
+
+def test_risk_max_position_fraction_to_percent_v1_converts_ratified_fractions() -> None:
+    assert wiring.risk_max_position_fraction_to_percent_v1(0.25) == pytest.approx(25.0)
+    assert wiring.risk_max_position_fraction_to_percent_v1(0.10) == pytest.approx(10.0)
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [0.0, -0.1, 1.01, float("nan"), float("inf")],
+)
+def test_risk_max_position_fraction_to_percent_v1_rejects_invalid(invalid: float) -> None:
+    with pytest.raises(ValueError, match="risk_max_position_size"):
+        wiring.risk_max_position_fraction_to_percent_v1(invalid)
+
+
+def test_build_mv2_research_risk_limits_v1_binds_cfg_fraction() -> None:
+    limits = wiring.build_mv2_research_risk_limits_v1(_cfg())
+    assert limits.config.max_position_pct == pytest.approx(25.0)
+
+
+def test_build_mv2_research_risk_limits_v1_fail_closed_missing_risk_section() -> None:
+    with pytest.raises(ValueError, match="risk_section_missing"):
+        wiring.build_mv2_research_risk_limits_v1({})
+
+
+def test_mv2_wiring_passes_explicit_risk_limits_to_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.backtest.engine import BacktestEngine
+    from src.risk import RiskLimits
+
+    captured: dict[str, object] = {}
+    original_init = BacktestEngine.__init__
+
+    def _capturing_init(self, *args: object, **kwargs: object) -> None:
+        captured["risk_limits"] = kwargs.get("risk_limits")
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(BacktestEngine, "__init__", _capturing_init)
+    _run()
+    risk_limits = captured.get("risk_limits")
+    assert isinstance(risk_limits, RiskLimits)
+    assert risk_limits.config.max_position_pct == pytest.approx(25.0)
+
+
+def test_backtest_engine_default_risk_limits_regression() -> None:
+    from src.backtest.engine import BacktestEngine
+    from src.risk import RiskLimitsConfig
+
+    engine = BacktestEngine(use_execution_pipeline=False)
+    assert engine.risk_limits.config.max_position_pct == RiskLimitsConfig().max_position_pct == 10.0

--- a/tests/backtest/test_offline_evaluation_sizing_contract_v1.py
+++ b/tests/backtest/test_offline_evaluation_sizing_contract_v1.py
@@ -446,6 +446,83 @@ def test_mv2_wiring_emits_sizing_provenance_when_contract_bound() -> None:
     )
 
 
+def test_mv2_wiring_v3_near_twenty_percent_entry_executes_trade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """~20% notional (v3 policy) must pass sizing and bound RiskLimits via MV2 wiring."""
+    from src.backtest import strategy_signal_binding_v1 as signal_binding
+    from src.backtest.strategy_signal_binding_v1 import (
+        SignalAlignmentStatus,
+        SignalContractStatus,
+        StrategyExecutionStatus,
+        StrategySignalBindingResultV1,
+        StrategySignalProvenanceV1,
+    )
+
+    cfg = json.loads(V3_CONFIG.read_text(encoding="utf-8"))
+    cfg["economic_evaluation_v1"] = {
+        "strategy_id": "ma_crossover",
+        "strategy_params": {"fast_period": 2, "slow_period": 3},
+    }
+    bars = _minimal_bars(6)
+    bars["mark_price"] = bars["close"]
+    bars["index_price"] = bars["close"]
+    bars["best_bid"] = bars["close"] - 0.05
+    bars["best_ask"] = bars["close"] + 0.05
+    bars["spread"] = 0.1
+    bars["funding_rate"] = 0.0001
+    bars["is_final"] = True
+    impulse = pd.Series([0, 1, 0, 0, -1, 0], index=bars.index, dtype=int)
+    provenance = StrategySignalProvenanceV1(
+        configured_strategy_id="ma_crossover",
+        executed_strategy_id="ma_crossover",
+        strategy_version="v1",
+        strategy_owner="src.strategies.ma_crossover",
+        configured_strategy_params={"fast_period": 2, "slow_period": 3},
+        effective_strategy_params={"fast_period": 2, "slow_period": 3},
+        strategy_params_digest="test",
+        strategy_execution_status=StrategyExecutionStatus.EXECUTED,
+        strategy_signal_source="canonical_strategy_signal_series",
+        strategy_signal_digest="test",
+        strategy_signal_count=len(impulse),
+        strategy_nonzero_signal_count=int((impulse != 0).sum()),
+        strategy_signal_transition_count=2,
+        engine_signal_source="configured_strategy_signal",
+        engine_signal_digest="test",
+        engine_input_nonzero_signal_count=int((impulse != 0).sum()),
+        signal_alignment_status=SignalAlignmentStatus.ALIGNED,
+        signal_contract_status=SignalContractStatus.PASS,
+        all_flat_signal_reason=signal_binding.AllFlatSignalReason.NONE,
+    )
+
+    def _fake_execute(
+        bars_in: pd.DataFrame,
+        *,
+        strategy_id: str,
+        cfg: dict,
+    ) -> StrategySignalBindingResultV1:
+        return StrategySignalBindingResultV1(signals=impulse, provenance=provenance)
+
+    monkeypatch.setattr(
+        wiring,
+        "execute_configured_strategy_signal_series_v1",
+        _fake_execute,
+    )
+    result = wiring.run_mv2_research_backtest_wiring_v1(
+        bars,
+        strategy_id="ma_crossover",
+        cfg=cfg,
+        instrument_id="inst-eth-usdt-perp",
+        explicit_zero_cost_non_economic=True,
+    )
+    prov = result.sizing_provenance
+    assert prov["entry_sizing_pass_count"] == 1
+    assert result.backtest_result.stats["total_trades"] >= 1
+    assert wiring.build_mv2_research_risk_limits_v1(cfg).config.max_position_pct == pytest.approx(
+        25.0
+    )
+
+
 def test_v2_config_digest_differs_from_v1() -> None:
     v1 = json.loads(V1_CONFIG.read_text(encoding="utf-8"))
     v2 = json.loads(V2_CONFIG.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- Bind `BacktestEngine` `RiskLimits` explicitly in `run_mv2_research_backtest_wiring_v1` from `cfg.risk.max_position_size` (fraction 0–1) via a single fail-closed boundary (`risk_max_position_fraction_to_percent_v1` → `build_mv2_research_risk_limits_v1`).
- Fixes STEP29M v3 zero-trade root cause: offline sizing passed ~20% notional entries but default runtime `RiskLimitsConfig(max_position_pct=10.0)` blocked all 822 candidates at the risk-limits gate.
- Add focused contract tests for fraction→percent conversion, MV2 wiring injection, v3-near 20% entry trade path, and legacy default regression.

## Test plan

- [x] `test_risk_max_position_fraction_to_percent_v1_*`
- [x] `test_build_mv2_research_risk_limits_v1_*`
- [x] `test_mv2_wiring_passes_explicit_risk_limits_to_engine`
- [x] `test_mv2_wiring_v3_near_twenty_percent_entry_executes_trade`
- [x] `test_backtest_engine_default_risk_limits_regression`
- [x] ruff format/check on changed files
- [x] CI selector: PR_BOUNDED_FULL (central `src/` change)

## Out of scope

- No economic reevaluation / v3 dataset rerun
- No `blocked_trades` evidence export
- No policy threshold or MACD parameter changes


Made with [Cursor](https://cursor.com)