### PR TITLE
docs(step29m): close registered strategy evaluation fleet

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -111,7 +111,7 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29L_COMPLETE` | `true` |
 | `STEP_29M_STARTED` | `true` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice,real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice,breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice,real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice,breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0,step29m_registered_strategy_evaluation_fleet_closeout_v0_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `true` |
 | `ECONOMIC_GATE_EVALUATOR_BOUND` | `true` |
@@ -127,17 +127,32 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `ECONOMIC_VALIDITY_OFFLINE_GATE_PASS` | `false` |
 | `CURRENT_PROMOTION_EVALUATION` | `INELIGIBLE` |
 | `OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION` | `false` |
-| `REAL_EVALUATION_INPUT_STATUS` | `MACD_V1_EVALUATION_V2_INVALIDATED_SIZING_ADMISSIBILITY_DEFECT` |
-| `LAST_EVALUATED_STRATEGY_ID` | `macd` |
+| `REAL_EVALUATION_INPUT_STATUS` | `REGISTERED_POLICY_RATIFIED_STRATEGY_FLEET_EVALUATION_COMPLETE` |
+| `LAST_EVALUATED_STRATEGY_ID` | `breakout_donchian` |
 | `LAST_EVALUATED_STRATEGY_VERSION` | `v1` |
-| `LAST_EVALUATED_CONFIG_VERSION` | `v2` |
-| `NEXT_EVALUATION_STRATEGY_ID` | `breakout_donchian` |
-| `NEXT_EVALUATION_STRATEGY_VERSION` | `v1` |
-| `NEXT_EVALUATION_INSTRUMENT_ID` | `inst-eth-usdt-perp` |
-| `NEXT_EVALUATION_VENUE` | `OKX` |
-| `NEXT_EVALUATION_CONFIG_VERSION` | `v1` |
-| `NEXT_EVALUATION_CONFIG_STATUS` | `POLICY_RATIFIED_CONFIG_ADMISSIBLE_AWAITING_SEPARATE_RUN` |
-| `NEXT_EVALUATION_CONFIG_PATH` | `config/ops/step29m_okx_inst_eth_usdt_perp_breakout_donchian_v1_economic_evaluation_v1.json` |
+| `LAST_EVALUATED_CONFIG_VERSION` | `v1` |
+| `NEXT_EVALUATION_STRATEGY_ID` | `none` |
+| `NEXT_EVALUATION_STRATEGY_VERSION` | `none` |
+| `NEXT_EVALUATION_INSTRUMENT_ID` | `none` |
+| `NEXT_EVALUATION_VENUE` | `none` |
+| `NEXT_EVALUATION_CONFIG_VERSION` | `none` |
+| `NEXT_EVALUATION_CONFIG_STATUS` | `EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE` |
+| `NEXT_EVALUATION_CONFIG_PATH` | `none` |
+| `STEP29M_REGISTERED_STRATEGY_FLEET_STATUS` | `EVALUATION_FLEET_COMPLETE_NO_ECONOMIC_VALIDITY_PASS` |
+| `REGISTERED_POLICY_RATIFIED_STRATEGY_COUNT` | `2` |
+| `COMPLETED_TECHNICALLY_VALID_EVALUATION_COUNT` | `2` |
+| `ECONOMIC_POLICY_PASS_COUNT` | `0` |
+| `ECONOMIC_POLICY_FAIL_COUNT` | `2` |
+| `PROMOTION_ELIGIBLE_COUNT` | `0` |
+| `BREAKOUT_DONCHIAN_V1_STATUS` | `TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL` |
+| `MACD_V1_CONFIG_V3_STATUS` | `TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL` |
+| `PRIMARY_FLEET_FINDING` | `NO_ADMISSIBLE_REGISTERED_STRATEGY_ECONOMICALLY_VIABLE_OFFLINE` |
+| `EVALUATION_EXECUTION_COMPLETE` | `true` |
+| `ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED` | `false` |
+| `NEXT_CANONICAL_STEP` | `BOUNDED_STEP29M_POST_FLEET_NO_PASS_CANONICAL_DECISION_READ_ONLY_V0` |
+| `STEP29N_AUTHORIZED` | `false` |
+| `STEP29R_AUTHORIZED` | `false` |
+| `RUNTIME_REWIRE_ALLOWED` | `false` |
 | `POLICY_INVARIANT` | `risk_per_trade <= max_position_pct * stop_pct` |
 | `POLICY_INVARIANT_RESULT` | `0.005 <= 0.25 * 0.02 = 0.005` |
 | `OPERATOR_POLICY_DECISION` | `RATIFIED` |
@@ -176,7 +191,10 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `V2_CONFIG_DISPOSITION` | `RETAIN_AS_NEGATIVE_INFEASIBILITY_FIXTURE` |
 | `ECONOMIC_REEVALUATION_ALLOWED` | `false` |
 | `MACD_V1_ADMISSIBILITY_CONTRACT_STATUS` | `PASS` |
-| `MACD_V1_REAL_EVALUATION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/step29m_macd_v1_real_admissible_futures_economic_reevaluation_v2_20260701T212345Z` |
+| `MACD_V1_REAL_EVALUATION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/economic/step29m_macd_v1_real_admissible_futures_economic_reevaluation_v3_after_risk_limits_rewire_single_rerun_v0_20260701T225645Z` |
+| `MACD_V1_CONFIG_V3_REAL_EVALUATION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/economic/step29m_macd_v1_real_admissible_futures_economic_reevaluation_v3_after_risk_limits_rewire_single_rerun_v0_20260701T225645Z` |
+| `BREAKOUT_DONCHIAN_V1_REAL_EVALUATION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/economic/step29m_breakout_donchian_v1_real_admissible_futures_economic_evaluation_v1_20260701T233425Z` |
+| `FLEET_ROOT_CAUSE_AND_RANKING_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_breakout_donchian_step29m_economic_result_root_cause_and_strategy_ranking_read_only_v0_20260701T234245Z` |
 | `INVALIDATED_EVALUATION_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/step29m_macd_v1_real_admissible_futures_economic_evaluation_v1_20260701T161757Z` |
 | `INVALIDATED_V2_EVALUATION_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/step29m_macd_v1_real_admissible_futures_economic_reevaluation_v2_20260701T212345Z` |
 | `INVALIDATED_EVALUATION_STATUS` | `TECHNICALLY_REPRODUCIBLE_ECONOMICALLY_INVALIDATED` |
@@ -1157,7 +1175,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `MERGE_COMMITS` | `5352d83f069b7d361e89c877ebe2d3d5ae161156`, `5d402a6a1fc2fb1a76af3a91223ac46ee9d80b72`, `72a33b0a85c76bc00fff482d7e88fda0db33c873`, `4ff161b3d005ff12e434982a108b22ef46165272`, `cd9474c820d500bbdbc09217b4c46f5e604f96b2`, `cf0ced2edff0a4baaf8d8fcd93d3e7476c13257e`, `49a7595cb5e6885fa2d003db74f07d6acf0d61cb`, `aa1a8fd9d3444e5d5f3dbe2386d4114b2e48b0c9` |
 | `DURABLE_EVIDENCE_REFS` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_viability_evidence_pr4700_squash_merge_closeout_v0_20260630T211900Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_residual_slice_pr4701squash_merge_closeout_v0_20260630T213300Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_validity_policy_v1_pr4702squash_merge_closeout_v0_20260630T214700Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_funding_binding_v1_pr4703_squash_merge_closeout_v0_20260630T220500Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_parameter_sensitivity_pr4704_squash_merge_closeout_v0_20260701T221500Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_admissible_versioned_futures_dataset_pr4705_squash_merge_closeout_v0_20260630T223551Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_economic_validity_policy_thresholds_pr4706_squash_merge_closeout_v0_20260630T225125Z (MANIFEST_VERIFY_RC=0); /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/runbook_step29m_real_admissible_futures_economic_evaluation_runner_pr4723_squash_merge_closeout_v0_20260701T072817Z (MANIFEST_VERIFY_RC=0); economic_viability_evidence_pr=4700; economic_viability_evidence_merge_commit=5352d83f069b7d361e89c877ebe2d3d5ae161156; persistence_load_reproducibility_pr=4701; persistence_load_reproducibility_merge_commit=5d402a6a1fc2fb1a76af3a91223ac46ee9d80b72; economic_validity_policy_v1_pr=4702; economic_validity_policy_v1_merge_commit=72a33b0a85c76bc00fff482d7e88fda0db33c873; funding_model_binding_pr=4703; funding_model_binding_merge_commit=4ff161b3d005ff12e434982a108b22ef46165272; parameter_sensitivity_evidence_pr=4704; parameter_sensitivity_evidence_merge_commit=cd9474c820d500bbdbc09217b4c46f5e604f96b2; admissible_versioned_futures_dataset_pr=4705; admissible_versioned_futures_dataset_merge_commit=cf0ced2edff0a4baaf8d8fcd93d3e7476c13257e; economic_validity_policy_threshold_values_pr=4706; economic_validity_policy_threshold_values_merge_commit=49a7595cb5e6885fa2d003db74f07d6acf0d61cb; economic_evaluation_runner_pr=4723; economic_evaluation_runner_merge_commit=aa1a8fd9d3444e5d5f3dbe2386d4114b2e48b0c9; economic_evaluation_runner_squash_parent=d2c505f86ec879d4fb71c4c531349552ed3e1634; canonical_scope=economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice; ECONOMIC_VIABILITY_EVIDENCE_V1_BOUND=true; ECONOMIC_GATE_EVALUATOR_BOUND=true; ECONOMIC_EVALUATION_RUNNER_V1_BOUND=true; REAL_EVALUATION_PERFORMED=false; OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION=true; STEP29M_IMPLEMENTATION_COMPLETE=true; TECHNICAL_ECONOMIC_VIABILITY_EVIDENCE_STACK_COMPLETE=true; ECONOMIC_VALIDITY_RESULT=NOT_PROVEN; REAL_ADMISSIBLE_FUTURES_EVIDENCE_REQUIRED=true; THRESHOLD_TUNING_ALLOWED=false; STEP_29N_STARTED=false; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_LIVE=true; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_RUNTIME=true; STEP_29M_COMPLETION_DOES_NOT_AUTHORIZE_ORDERS=true; STEP_29M_COMPLETION_DOES_NOT_CLAIM_ECONOMIC_VALIDITY=true; STEP_29M_COMPLETION_DOES_NOT_START_PROMOTION_GATE=true; PROMOTION_ELIGIBILITY_GRANTED=false; RUNTIME_AUTHORITY_GRANTED=false; UNIVERSE_SELECTION_UNCHANGED=true; offline_only=true; non_authorizing=true; runtime_process_started=false; scheduler_action_performed=false; venue_access_performed=false; credential_access_performed=false; trading_action_performed=false; progress_registry_closeout_status=COMPLETE; FUTURES_ONLY=true; BITCOIN_DIRECTION_ALLOWED=false; LIVE_AUTHORIZED=false; ORDERS_ALLOWED=false; SCHEDULER_RUNTIME_ALLOWED=false` |
 | `DEPENDENCIES` | RUNBOOK_STEP_29L |
-| `REMAINING_GAPS` | `operator dataset staging for real admissible futures economic evaluation; economic validity proof` |
+| `REMAINING_GAPS` | `post-fleet canonical decision without economic validity pass; no admissible registered strategy offline viability proven` |
 | `DATA_ADMISSIBILITY_STATUS` | `PASS` |
 | `POLICY_THRESHOLD_STATUS` | `PASS` |
 | `ECONOMIC_VALIDITY_EVALUATION_STATUS` | `RESEARCH_ONLY` |
@@ -1175,17 +1193,32 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION` | `false` |
 | `OPERATOR_INPUT_CONTRACT_V1_BOUND` | `true` |
 | `OPERATOR_INPUT_CONTRACT_COMPLETE` | `true` |
-| `REAL_EVALUATION_INPUT_STATUS` | `MACD_V1_EVALUATION_V2_INVALIDATED_SIZING_ADMISSIBILITY_DEFECT` |
-| `LAST_EVALUATED_STRATEGY_ID` | `macd` |
+| `REAL_EVALUATION_INPUT_STATUS` | `REGISTERED_POLICY_RATIFIED_STRATEGY_FLEET_EVALUATION_COMPLETE` |
+| `LAST_EVALUATED_STRATEGY_ID` | `breakout_donchian` |
 | `LAST_EVALUATED_STRATEGY_VERSION` | `v1` |
-| `LAST_EVALUATED_CONFIG_VERSION` | `v2` |
-| `NEXT_EVALUATION_STRATEGY_ID` | `breakout_donchian` |
-| `NEXT_EVALUATION_STRATEGY_VERSION` | `v1` |
-| `NEXT_EVALUATION_INSTRUMENT_ID` | `inst-eth-usdt-perp` |
-| `NEXT_EVALUATION_VENUE` | `OKX` |
-| `NEXT_EVALUATION_CONFIG_VERSION` | `v1` |
-| `NEXT_EVALUATION_CONFIG_STATUS` | `POLICY_RATIFIED_CONFIG_ADMISSIBLE_AWAITING_SEPARATE_RUN` |
-| `NEXT_EVALUATION_CONFIG_PATH` | `config/ops/step29m_okx_inst_eth_usdt_perp_breakout_donchian_v1_economic_evaluation_v1.json` |
+| `LAST_EVALUATED_CONFIG_VERSION` | `v1` |
+| `NEXT_EVALUATION_STRATEGY_ID` | `none` |
+| `NEXT_EVALUATION_STRATEGY_VERSION` | `none` |
+| `NEXT_EVALUATION_INSTRUMENT_ID` | `none` |
+| `NEXT_EVALUATION_VENUE` | `none` |
+| `NEXT_EVALUATION_CONFIG_VERSION` | `none` |
+| `NEXT_EVALUATION_CONFIG_STATUS` | `EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE` |
+| `NEXT_EVALUATION_CONFIG_PATH` | `none` |
+| `STEP29M_REGISTERED_STRATEGY_FLEET_STATUS` | `EVALUATION_FLEET_COMPLETE_NO_ECONOMIC_VALIDITY_PASS` |
+| `REGISTERED_POLICY_RATIFIED_STRATEGY_COUNT` | `2` |
+| `COMPLETED_TECHNICALLY_VALID_EVALUATION_COUNT` | `2` |
+| `ECONOMIC_POLICY_PASS_COUNT` | `0` |
+| `ECONOMIC_POLICY_FAIL_COUNT` | `2` |
+| `PROMOTION_ELIGIBLE_COUNT` | `0` |
+| `BREAKOUT_DONCHIAN_V1_STATUS` | `TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL` |
+| `MACD_V1_CONFIG_V3_STATUS` | `TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL` |
+| `PRIMARY_FLEET_FINDING` | `NO_ADMISSIBLE_REGISTERED_STRATEGY_ECONOMICALLY_VIABLE_OFFLINE` |
+| `EVALUATION_EXECUTION_COMPLETE` | `true` |
+| `ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED` | `false` |
+| `NEXT_CANONICAL_STEP` | `BOUNDED_STEP29M_POST_FLEET_NO_PASS_CANONICAL_DECISION_READ_ONLY_V0` |
+| `STEP29N_AUTHORIZED` | `false` |
+| `STEP29R_AUTHORIZED` | `false` |
+| `RUNTIME_REWIRE_ALLOWED` | `false` |
 | `POLICY_INVARIANT` | `risk_per_trade <= max_position_pct * stop_pct` |
 | `POLICY_INVARIANT_RESULT` | `0.005 <= 0.25 * 0.02 = 0.005` |
 | `OPERATOR_POLICY_DECISION` | `RATIFIED` |
@@ -1224,7 +1257,10 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `V2_CONFIG_DISPOSITION` | `RETAIN_AS_NEGATIVE_INFEASIBILITY_FIXTURE` |
 | `ECONOMIC_REEVALUATION_ALLOWED` | `false` |
 | `MACD_V1_ADMISSIBILITY_CONTRACT_STATUS` | `PASS` |
-| `MACD_V1_REAL_EVALUATION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/step29m_macd_v1_real_admissible_futures_economic_reevaluation_v2_20260701T212345Z` |
+| `MACD_V1_REAL_EVALUATION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/economic/step29m_macd_v1_real_admissible_futures_economic_reevaluation_v3_after_risk_limits_rewire_single_rerun_v0_20260701T225645Z` |
+| `MACD_V1_CONFIG_V3_REAL_EVALUATION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/economic/step29m_macd_v1_real_admissible_futures_economic_reevaluation_v3_after_risk_limits_rewire_single_rerun_v0_20260701T225645Z` |
+| `BREAKOUT_DONCHIAN_V1_REAL_EVALUATION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/economic/step29m_breakout_donchian_v1_real_admissible_futures_economic_evaluation_v1_20260701T233425Z` |
+| `FLEET_ROOT_CAUSE_AND_RANKING_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_breakout_donchian_step29m_economic_result_root_cause_and_strategy_ranking_read_only_v0_20260701T234245Z` |
 | `INVALIDATED_EVALUATION_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/step29m_macd_v1_real_admissible_futures_economic_evaluation_v1_20260701T161757Z` |
 | `INVALIDATED_V2_EVALUATION_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/step29m_macd_v1_real_admissible_futures_economic_reevaluation_v2_20260701T212345Z` |
 | `INVALIDATED_EVALUATION_STATUS` | `TECHNICALLY_REPRODUCIBLE_ECONOMICALLY_INVALIDATED` |
@@ -1248,7 +1284,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `ECONOMIC_VALIDITY_PROVEN` | `false` |
 | `PROFITABILITY_CLAIM_ALLOWED` | `false` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice,real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice,breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice,real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice,breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0,step29m_registered_strategy_evaluation_fleet_closeout_v0_slice` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `true` |
 | `ECONOMIC_VIABILITY_EVIDENCE_V1_IMPLEMENTED` | `true` |

--- a/tests/backtest/test_offline_evaluation_sizing_contract_v1.py
+++ b/tests/backtest/test_offline_evaluation_sizing_contract_v1.py
@@ -555,14 +555,14 @@ def test_registry_v2_reevaluation_complete() -> None:
     assert field("REAL_EVALUATION_PERFORMED") == "true"
     assert field("REAL_ADMISSIBLE_FUTURES_EVIDENCE_BOUND") == "true"
     assert field("REAL_EVALUATION_INPUT_STATUS") == (
-        "MACD_V1_EVALUATION_V2_INVALIDATED_SIZING_ADMISSIBILITY_DEFECT"
+        "REGISTERED_POLICY_RATIFIED_STRATEGY_FLEET_EVALUATION_COMPLETE"
     )
     assert field("ECONOMIC_VALIDITY_RESULT") == "FAILED"
     assert field("PROFITABILITY_CLAIM_ALLOWED") == "false"
-    assert field("LAST_EVALUATED_CONFIG_VERSION") == "v2"
-    assert field("NEXT_EVALUATION_CONFIG_VERSION") == "v3"
+    assert field("LAST_EVALUATED_CONFIG_VERSION") == "v1"
+    assert field("NEXT_EVALUATION_CONFIG_VERSION") == "none"
     assert field("NEXT_EVALUATION_CONFIG_STATUS") == (
-        "POLICY_RATIFIED_CONFIG_ADMISSIBLE_AWAITING_SEPARATE_RUN"
+        "EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE"
     )
     assert field("POLICY_INVARIANT") == "risk_per_trade <= max_position_pct * stop_pct"
     assert field("OPERATOR_POLICY_DECISION") == "RATIFIED"
@@ -572,7 +572,7 @@ def test_registry_v2_reevaluation_complete() -> None:
     assert str(MACD_EVIDENCE) in field("INVALIDATED_EVALUATION_REF")
     assert str(V2_EVIDENCE) in field("INVALIDATED_V2_EVALUATION_REF")
     assert str(ROOT_CAUSE_EVIDENCE) in field("ROOT_CAUSE_EVIDENCE_REF")
-    assert (
-        field("NEXT_EVALUATION_CONFIG_PATH")
-        == "config/ops/step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v3.json"
+    assert field("NEXT_EVALUATION_CONFIG_PATH") == "none"
+    assert field("STEP29M_REGISTERED_STRATEGY_FLEET_STATUS") == (
+        "EVALUATION_FLEET_COMPLETE_NO_ECONOMIC_VALIDITY_PASS"
     )

--- a/tests/ops/test_runbook_step29m_economic_evaluation_runner_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_economic_evaluation_runner_progress_registry_closeout_contract_v0.py
@@ -23,7 +23,9 @@ STEP_29M_IMPLEMENTED_SCOPE = (
     "economic_validity_policy_threshold_values_v1_slice,"
     f"{RUNNER_SLICE},"
     "real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice,"
-    "real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice"
+    "real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice,"
+    "breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0,"
+    "step29m_registered_strategy_evaluation_fleet_closeout_v0_slice"
 )
 MERGE_COMMIT = "aa1a8fd9d3444e5d5f3dbe2386d4114b2e48b0c9"
 HISTORICAL_SLICES = tuple(
@@ -136,7 +138,7 @@ def test_operator_input_not_required_after_macd_v1_v2_evaluation() -> None:
     assert _field_value(text, "REAL_EVALUATION_PERFORMED") == "true"
     assert _field_value(section, "REAL_EVALUATION_PERFORMED") == "true"
     assert _field_value(text, "REAL_EVALUATION_INPUT_STATUS") == (
-        "MACD_V1_EVALUATION_V2_INVALIDATED_SIZING_ADMISSIBILITY_DEFECT"
+        "REGISTERED_POLICY_RATIFIED_STRATEGY_FLEET_EVALUATION_COMPLETE"
     )
 
 

--- a/tests/ops/test_runbook_step29m_operator_input_admissibility_closure_registry_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_operator_input_admissibility_closure_registry_contract_v0.py
@@ -22,7 +22,8 @@ STEP_29M_IMPLEMENTED_SCOPE = (
     "real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,"
     f"{OPERATOR_INPUT_SLICE},"
     "real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice,"
-    "breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0"
+    "breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0,"
+    "step29m_registered_strategy_evaluation_fleet_closeout_v0_slice"
 )
 
 
@@ -83,10 +84,10 @@ def test_real_evaluation_input_status_updated() -> None:
     text = _read_registry()
     section = _step_29m_section(text)
     assert _field_value(text, "REAL_EVALUATION_INPUT_STATUS") == (
-        "MACD_V1_EVALUATION_V2_INVALIDATED_SIZING_ADMISSIBILITY_DEFECT"
+        "REGISTERED_POLICY_RATIFIED_STRATEGY_FLEET_EVALUATION_COMPLETE"
     )
     assert _field_value(section, "REAL_EVALUATION_INPUT_STATUS") == (
-        "MACD_V1_EVALUATION_V2_INVALIDATED_SIZING_ADMISSIBILITY_DEFECT"
+        "REGISTERED_POLICY_RATIFIED_STRATEGY_FLEET_EVALUATION_COMPLETE"
     )
     assert _field_value(text, "OPERATOR_INPUT_REQUIRED_FOR_REAL_EVALUATION") == "false"
 

--- a/tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_progress_registry_closeout_contract_v0.py
@@ -23,7 +23,8 @@ STEP_29M_IMPLEMENTED_SCOPE = (
     "real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,"
     "real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice,"
     "real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice,"
-    "breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0"
+    "breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0,"
+    "step29m_registered_strategy_evaluation_fleet_closeout_v0_slice"
 )
 STEP_29M_SLICES = tuple(STEP_29M_IMPLEMENTED_SCOPE.split(","))
 

--- a/tests/ops/test_runbook_step29m_registered_strategy_evaluation_fleet_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_registered_strategy_evaluation_fleet_closeout_contract_v0.py
@@ -1,0 +1,132 @@
+"""Contract tests for STEP 29M registered strategy evaluation fleet closeout v0.
+
+Verifies fleet-complete registry truth without authorizing promotion, runtime,
+profitability claims, or new strategy evaluation.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROGRESS_REGISTRY = REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+
+FLEET_SLICE = "step29m_registered_strategy_evaluation_fleet_closeout_v0_slice"
+MACD_V3_EVIDENCE = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "economic/step29m_macd_v1_real_admissible_futures_economic_reevaluation_v3_after_risk_limits_rewire_single_rerun_v0_20260701T225645Z"
+)
+BREAKOUT_EVIDENCE = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "economic/step29m_breakout_donchian_v1_real_admissible_futures_economic_evaluation_v1_20260701T233425Z"
+)
+FLEET_ANALYSIS_EVIDENCE = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "planning/bounded_breakout_donchian_step29m_economic_result_root_cause_and_strategy_ranking_read_only_v0_20260701T234245Z"
+)
+
+
+def _read_registry() -> str:
+    assert PROGRESS_REGISTRY.is_file(), f"missing canonical registry: {PROGRESS_REGISTRY}"
+    return PROGRESS_REGISTRY.read_text(encoding="utf-8")
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(
+        rf"\| `{re.escape(field)}` \| `([^`]*)`(?: <!--.*?-->)? \|",
+        text,
+    )
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _step_29m_section(text: str) -> str:
+    start = text.index("#### RUNBOOK_STEP_29M — Economic Viability Evidence v1")
+    end = text.index("#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1", start)
+    return text[start:end]
+
+
+def test_fleet_slice_registered_in_implemented_scope() -> None:
+    text = _read_registry()
+    scope = _field_value(text, "RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE")
+    assert FLEET_SLICE in scope.split(",")
+
+
+def test_registered_strategy_fleet_complete_no_economic_validity_pass() -> None:
+    section = _step_29m_section(_read_registry())
+    assert (
+        _field_value(section, "STEP29M_REGISTERED_STRATEGY_FLEET_STATUS")
+        == "EVALUATION_FLEET_COMPLETE_NO_ECONOMIC_VALIDITY_PASS"
+    )
+    assert _field_value(section, "REGISTERED_POLICY_RATIFIED_STRATEGY_COUNT") == "2"
+    assert _field_value(section, "COMPLETED_TECHNICALLY_VALID_EVALUATION_COUNT") == "2"
+    assert _field_value(section, "ECONOMIC_POLICY_PASS_COUNT") == "0"
+    assert _field_value(section, "ECONOMIC_POLICY_FAIL_COUNT") == "2"
+    assert _field_value(section, "PROMOTION_ELIGIBLE_COUNT") == "0"
+
+
+def test_both_registered_candidates_technically_valid_policy_fails() -> None:
+    section = _step_29m_section(_read_registry())
+    assert (
+        _field_value(section, "BREAKOUT_DONCHIAN_V1_STATUS")
+        == "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL"
+    )
+    assert (
+        _field_value(section, "MACD_V1_CONFIG_V3_STATUS")
+        == "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL"
+    )
+    assert (
+        _field_value(section, "PRIMARY_FLEET_FINDING")
+        == "NO_ADMISSIBLE_REGISTERED_STRATEGY_ECONOMICALLY_VIABLE_OFFLINE"
+    )
+
+
+def test_evaluation_execution_complete_without_economic_validity_objective() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "EVALUATION_EXECUTION_COMPLETE") == "true"
+    assert _field_value(section, "ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED") == "false"
+    assert _field_value(section, "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS") == "false"
+    assert _field_value(section, "ECONOMIC_VALIDITY_PROVEN") == "false"
+
+
+def test_no_pending_next_evaluation_candidate() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "none"
+    assert _field_value(section, "NEXT_EVALUATION_CONFIG_STATUS") == (
+        "EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE"
+    )
+    assert _field_value(section, "NEXT_EVALUATION_CONFIG_PATH") == "none"
+    assert _field_value(section, "LAST_EVALUATED_STRATEGY_ID") == "breakout_donchian"
+    assert _field_value(section, "LAST_EVALUATED_CONFIG_VERSION") == "v1"
+
+
+def test_fleet_evidence_refs_bound() -> None:
+    section = _step_29m_section(_read_registry())
+    assert str(MACD_V3_EVIDENCE) in _field_value(
+        section, "MACD_V1_CONFIG_V3_REAL_EVALUATION_EVIDENCE_REF"
+    )
+    assert str(BREAKOUT_EVIDENCE) in _field_value(
+        section, "BREAKOUT_DONCHIAN_V1_REAL_EVALUATION_EVIDENCE_REF"
+    )
+    assert str(FLEET_ANALYSIS_EVIDENCE) in _field_value(
+        section, "FLEET_ROOT_CAUSE_AND_RANKING_EVIDENCE_REF"
+    )
+
+
+def test_post_fleet_next_canonical_step_read_only_decision() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "NEXT_CANONICAL_STEP") == (
+        "BOUNDED_STEP29M_POST_FLEET_NO_PASS_CANONICAL_DECISION_READ_ONLY_V0"
+    )
+
+
+def test_promotion_runtime_and_step29nr_blocked() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "PROMOTION_ALLOWED") == "false"
+    assert _field_value(section, "PROFITABILITY_CLAIM_ALLOWED") == "false"
+    assert _field_value(section, "STEP29N_AUTHORIZED") == "false"
+    assert _field_value(section, "STEP29R_AUTHORIZED") == "false"
+    assert _field_value(section, "RUNTIME_REWIRE_ALLOWED") == "false"
+    assert _field_value(section, "ECONOMIC_EVALUATION_ALLOWED") == "false"
+    assert _field_value(section, "ECONOMIC_REEVALUATION_ALLOWED") == "false"

--- a/tests/ops/test_step29m_breakout_donchian_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/tests/ops/test_step29m_breakout_donchian_v1_economic_evaluation_admissibility_contract_v1.py
@@ -189,9 +189,10 @@ def test_progress_registry_ratified_policy_fields() -> None:
     section = _step_29m_section(PROGRESS_REGISTRY.read_text(encoding="utf-8"))
     assert _field_value(section, "OPERATOR_POLICY_DECISION") == "RATIFIED"
     assert _field_value(section, "OPERATOR_POLICY_DECISION_OWNER") == "Frank Rauter"
-    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "breakout_donchian"
-    assert _field_value(section, "NEXT_EVALUATION_INSTRUMENT_ID") == "inst-eth-usdt-perp"
-    assert _field_value(section, "NEXT_EVALUATION_VENUE") == "OKX"
+    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "none"
+    assert _field_value(section, "NEXT_EVALUATION_CONFIG_STATUS") == (
+        "EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE"
+    )
     assert _field_value(section, "BREAKOUT_DONCHIAN_LOOKBACK") == "20"
     assert _field_value(section, "BREAKOUT_DONCHIAN_PRICE_COL") == "close"
     assert _field_value(section, "BREAKOUT_DONCHIAN_RISK_PER_TRADE") == "0.005"
@@ -203,14 +204,17 @@ def test_progress_registry_ratified_policy_fields() -> None:
     assert _field_value(section, "PARAMETER_TUNING_PERFORMED") == "false"
     assert _field_value(section, "ECONOMIC_EVALUATION_ALLOWED") == "false"
     assert _field_value(section, "PROMOTION_ALLOWED") == "false"
-    assert "breakout_donchian" in _field_value(section, "NEXT_EVALUATION_CONFIG_PATH")
-    assert "macd" not in _field_value(section, "NEXT_EVALUATION_CONFIG_PATH")
+    assert _field_value(section, "BREAKOUT_DONCHIAN_V1_STATUS") == (
+        "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL"
+    )
 
 
-def test_macd_contract_unchanged_for_last_evaluated() -> None:
+def test_macd_contract_unchanged_for_admissibility_status() -> None:
     section = _step_29m_section(PROGRESS_REGISTRY.read_text(encoding="utf-8"))
-    assert _field_value(section, "LAST_EVALUATED_STRATEGY_ID") == "macd"
     assert _field_value(section, "MACD_V1_ADMISSIBILITY_CONTRACT_STATUS") == "PASS"
+    assert _field_value(section, "MACD_V1_CONFIG_V3_STATUS") == (
+        "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL"
+    )
 
 
 def test_config_params_from_evaluation_section(cfg: dict) -> None:

--- a/tests/ops/test_step29m_breakout_donchian_v1_economic_evaluation_registry_contract_v1.py
+++ b/tests/ops/test_step29m_breakout_donchian_v1_economic_evaluation_registry_contract_v1.py
@@ -46,9 +46,6 @@ def test_breakout_config_registered_in_canonical_registry() -> None:
 
 def test_breakout_config_path_bound_in_progress_registry() -> None:
     section = _step_29m_section(_read_registry())
-    assert _field_value(section, "NEXT_EVALUATION_CONFIG_PATH") == (
-        contract.DEFAULT_EVALUATION_CONFIG_PATH
-    )
     registered = _field_value(section, "STEP29M_REGISTERED_ECONOMIC_EVALUATION_CONFIGS").replace(
         "&#47;", "/"
     )
@@ -76,10 +73,13 @@ def test_breakout_config_digest_stable() -> None:
     assert sizing["config_digest"] == compute_sizing_contract_digest_v1(contract)
 
 
-def test_breakout_next_evaluation_strategy_binding() -> None:
+def test_breakout_fleet_evaluation_complete_no_pending_next_candidate() -> None:
     section = _step_29m_section(_read_registry())
-    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "breakout_donchian"
-    assert _field_value(section, "NEXT_EVALUATION_CONFIG_VERSION") == "v1"
+    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "none"
+    assert _field_value(section, "NEXT_EVALUATION_CONFIG_VERSION") == "none"
     assert _field_value(section, "NEXT_EVALUATION_CONFIG_STATUS") == (
-        "POLICY_RATIFIED_CONFIG_ADMISSIBLE_AWAITING_SEPARATE_RUN"
+        "EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE"
+    )
+    assert _field_value(section, "BREAKOUT_DONCHIAN_V1_STATUS") == (
+        "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL"
     )

--- a/tests/ops/test_step29m_invalidated_evaluation_registry_contract_v0.py
+++ b/tests/ops/test_step29m_invalidated_evaluation_registry_contract_v0.py
@@ -40,17 +40,17 @@ def _step_29m_section(text: str) -> str:
     return text[start:end]
 
 
-def test_step_29m_macd_v1_evaluation_v2_complete_registry_truth() -> None:
+def test_step_29m_macd_v1_evaluation_fleet_complete_registry_truth() -> None:
     section = _step_29m_section(_read_registry())
     assert _field_value(section, "REAL_EVALUATION_ATTEMPTED") == "true"
     assert _field_value(section, "REAL_EVALUATION_PERFORMED") == "true"
     assert _field_value(section, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_BOUND") == "true"
     assert _field_value(section, "REAL_EVALUATION_INPUT_STATUS") == (
-        "MACD_V1_EVALUATION_V2_INVALIDATED_SIZING_ADMISSIBILITY_DEFECT"
+        "REGISTERED_POLICY_RATIFIED_STRATEGY_FLEET_EVALUATION_COMPLETE"
     )
     assert _field_value(section, "ECONOMIC_VALIDITY_RESULT") == "FAILED"
     assert _field_value(section, "PROFITABILITY_CLAIM_ALLOWED") == "false"
-    assert _field_value(section, "LAST_EVALUATED_CONFIG_VERSION") == "v2"
+    assert _field_value(section, "LAST_EVALUATED_CONFIG_VERSION") == "v1"
     assert _field_value(section, "RUNBOOK_STEP_29M_COMPLETE") == "true"
 
 

--- a/tests/ops/test_step29m_macd_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/tests/ops/test_step29m_macd_v1_economic_evaluation_admissibility_contract_v1.py
@@ -321,14 +321,15 @@ def test_registry_truth_after_macd_v1_real_evaluation() -> None:
     assert _field_value(section, "REAL_ADMISSIBLE_FUTURES_EVIDENCE_BOUND") == "true"
     assert _field_value(section, "ECONOMIC_VALIDITY_RESULT") == "FAILED"
     assert _field_value(section, "PROFITABILITY_CLAIM_ALLOWED") == "false"
-    assert _field_value(section, "LAST_EVALUATED_STRATEGY_ID") == "macd"
+    assert _field_value(section, "LAST_EVALUATED_STRATEGY_ID") == "breakout_donchian"
     assert _field_value(section, "LAST_EVALUATED_STRATEGY_VERSION") == "v1"
-    assert _field_value(section, "LAST_EVALUATED_CONFIG_VERSION") == "v2"
+    assert _field_value(section, "LAST_EVALUATED_CONFIG_VERSION") == "v1"
     assert _field_value(section, "REAL_EVALUATION_INPUT_STATUS") == (
-        "MACD_V1_EVALUATION_V2_INVALIDATED_SIZING_ADMISSIBILITY_DEFECT"
+        "REGISTERED_POLICY_RATIFIED_STRATEGY_FLEET_EVALUATION_COMPLETE"
     )
-    assert "step29m_macd_v1_real_admissible_futures_economic_reevaluation_v2_20260701T212345Z" in (
-        _field_value(section, "MACD_V1_REAL_EVALUATION_EVIDENCE_REF")
+    assert (
+        "step29m_macd_v1_real_admissible_futures_economic_reevaluation_v3_after_risk_limits_rewire_single_rerun_v0_20260701T225645Z"
+        in (_field_value(section, "MACD_V1_CONFIG_V3_REAL_EVALUATION_EVIDENCE_REF"))
     )
 
 

--- a/tests/ops/test_step29m_macd_v1_real_economic_evaluation_registry_contract_v1.py
+++ b/tests/ops/test_step29m_macd_v1_real_economic_evaluation_registry_contract_v1.py
@@ -21,6 +21,10 @@ POLICY_DECISION_EVIDENCE = Path(
 )
 EXPECTED_V2_FILE_SHA256 = "fe5b3ed1ea174e242f5a821971d94b47eb544c6fe4ec3eb99a8ceef06e3e094b"
 EXPECTED_V3_CONFIG_DIGEST = "e1d923de8e5f44bc873c15008bc895b8b3542a326e9c39521e4860ba091b6b82"
+MACD_V3_EVIDENCE_DIR = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "economic/step29m_macd_v1_real_admissible_futures_economic_reevaluation_v3_after_risk_limits_rewire_single_rerun_v0_20260701T225645Z"
+)
 V2_EVIDENCE_DIR = Path(
     "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
     "implementation/step29m_macd_v1_real_admissible_futures_economic_reevaluation_v2_20260701T212345Z"
@@ -48,7 +52,7 @@ def _step_29m_section(text: str) -> str:
     return text[start:end]
 
 
-def test_macd_v1_real_evaluation_registry_truth_v2_complete() -> None:
+def test_macd_v1_real_evaluation_registry_truth_v3_canonical_and_fleet_complete() -> None:
     text = _read_registry()
     section = _step_29m_section(text)
     for scope in (text, section):
@@ -58,33 +62,34 @@ def test_macd_v1_real_evaluation_registry_truth_v2_complete() -> None:
         assert _field_value(scope, "PROFITABILITY_CLAIM_ALLOWED") == "false"
         assert (
             _field_value(scope, "REAL_EVALUATION_INPUT_STATUS")
-            == "MACD_V1_EVALUATION_V2_INVALIDATED_SIZING_ADMISSIBILITY_DEFECT"
+            == "REGISTERED_POLICY_RATIFIED_STRATEGY_FLEET_EVALUATION_COMPLETE"
         )
-        assert _field_value(scope, "LAST_EVALUATED_STRATEGY_ID") == "macd"
-        assert _field_value(scope, "LAST_EVALUATED_STRATEGY_VERSION") == "v1"
-        assert _field_value(scope, "LAST_EVALUATED_CONFIG_VERSION") == "v2"
+        assert _field_value(scope, "MACD_V1_CONFIG_V3_STATUS") == (
+            "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL"
+        )
+        assert _field_value(scope, "STEP29M_REGISTERED_STRATEGY_FLEET_STATUS") == (
+            "EVALUATION_FLEET_COMPLETE_NO_ECONOMIC_VALIDITY_PASS"
+        )
 
 
 def test_macd_v1_real_evaluation_evidence_ref_bound() -> None:
     section = _step_29m_section(_read_registry())
-    assert str(V2_EVIDENCE_DIR) in _field_value(section, "MACD_V1_REAL_EVALUATION_EVIDENCE_REF")
+    assert str(MACD_V3_EVIDENCE_DIR) in _field_value(
+        section, "MACD_V1_CONFIG_V3_REAL_EVALUATION_EVIDENCE_REF"
+    )
     assert str(INVALIDATED_EVIDENCE_DIR) in _field_value(section, "INVALIDATED_EVALUATION_REF")
     assert str(V2_EVIDENCE_DIR) in _field_value(section, "INVALIDATED_V2_EVALUATION_REF")
 
 
-def test_macd_v1_v3_policy_registry_ratified_historical_and_breakout_next() -> None:
+def test_macd_v1_v3_policy_registry_ratified_and_fleet_complete() -> None:
     section = _step_29m_section(_read_registry())
     assert _field_value(section, "OPERATOR_POLICY_DECISION") == "RATIFIED"
     assert _field_value(section, "POLICY_INVARIANT") == (
         "risk_per_trade <= max_position_pct * stop_pct"
     )
-    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "breakout_donchian"
-    assert _field_value(section, "NEXT_EVALUATION_CONFIG_VERSION") == "v1"
+    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "none"
     assert _field_value(section, "NEXT_EVALUATION_CONFIG_STATUS") == (
-        "POLICY_RATIFIED_CONFIG_ADMISSIBLE_AWAITING_SEPARATE_RUN"
-    )
-    assert _field_value(section, "NEXT_EVALUATION_CONFIG_PATH") == (
-        "config/ops/step29m_okx_inst_eth_usdt_perp_breakout_donchian_v1_economic_evaluation_v1.json"
+        "EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE"
     )
     assert _field_value(section, "ECONOMIC_REEVALUATION_ALLOWED") == "false"
     assert _field_value(section, "PROFITABILITY_CLAIM_ALLOWED") == "false"


### PR DESCRIPTION
## Summary

- Closeout des STEP29M Registered-Strategy-Evaluation-Fleet-Zustands in der kanonischen Progress Registry (`PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md`).
- Beide policy-ratifizierten Kandidaten (macd v1 config v3, breakout_donchian v1) sind als technisch valide `ECONOMIC_POLICY_FAIL` dokumentiert.
- Stale `NEXT_EVALUATION=breakout_donchian` entfernt; Fleet-Status `EVALUATION_FLEET_COMPLETE_NO_ECONOMIC_VALIDITY_PASS`.
- Neuer Contract-Test `test_runbook_step29m_registered_strategy_evaluation_fleet_closeout_contract_v0.py` plus Anpassungen bestehender Registry-Contract-Tests.

## Fleet status

- `REGISTERED_POLICY_RATIFIED_STRATEGY_COUNT=2`
- `COMPLETED_TECHNICALLY_VALID_EVALUATION_COUNT=2`
- `ECONOMIC_POLICY_PASS_COUNT=0`
- `ECONOMIC_POLICY_FAIL_COUNT=2`
- `PROMOTION_ELIGIBLE_COUNT=0`
- `EVALUATION_EXECUTION_COMPLETE=true`
- `ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED=false`
- `ECONOMIC_VALIDITY_OFFLINE_GATE_PASS=false`

## Safety / scope

- Keine Economic-Policy-, Trading-Logic-, Sizing-, Risk- oder Runtime-Änderung.
- `PROMOTION_ALLOWED=false`, `PROFITABILITY_CLAIM_ALLOWED=false`
- `STEP29N_AUTHORIZED=false`, `STEP29R_AUTHORIZED=false`, `RUNTIME_REWIRE_ALLOWED=false`

## Test plan

- [x] 113 fokussierte Registry-/Contract-Tests grün (siehe Durable Evidence)
- [x] `ruff format --check` / `ruff check` auf geänderte Python-Dateien
- [x] Docs token policy + docs reference targets
- [x] CI selector: `CONTRACT_FOCUSED` (`focused_script_or_test_diff`)

## Durable evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/closeout/step29m_registered_strategy_evaluation_fleet_progress_registry_runbook_closeout_v0_20260701T234933Z` (MANIFEST_VERIFY_RC=0)

## Next canonical step

`BOUNDED_STEP29M_POST_FLEET_NO_PASS_CANONICAL_DECISION_READ_ONLY_V0`


Made with [Cursor](https://cursor.com)