### PR TITLE
STEP29M: ratify ma_crossover v1 fixed economic evaluation config

### DIFF
--- a/config/ops/step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json
@@ -1,0 +1,166 @@
+{
+  "backtest": {
+    "cost_model_version": "backtest_cost_v0",
+    "dataset_admissibility": {
+      "bind": true,
+      "dataset_profile": "economic_research_v1",
+      "execution_cost_binding": {
+        "conservative_half_spread_bps": 5.0,
+        "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+        "spread_model_version": "research_conservative_bps_v1"
+      },
+      "profile_binding": {
+        "dataset_profile": "economic_research_v1",
+        "execution_cost_binding": {
+          "conservative_half_spread_bps": 5.0,
+          "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+          "spread_model_version": "research_conservative_bps_v1"
+        },
+        "l1_observation_status": "EXECUTION_MODEL_BOUND_NOT_OBSERVED"
+      }
+    },
+    "economic_research_execution_cost": {
+      "conservative_half_spread_bps": 5.0,
+      "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+      "fee_bps": 10.0,
+      "slippage_bps": 5.0,
+      "spread_model_version": "research_conservative_bps_v1"
+    },
+    "fee_bps": 10.0,
+    "fee_model_version": "backtest_fee_taker_symmetric_v0",
+    "funding": {
+      "bind": true,
+      "model_version": "backtest_funding_perpetual_interval_v1"
+    },
+    "initial_cash": 10000.0,
+    "parameter_sensitivity": {
+      "bind": true,
+      "grid": {
+        "grid_id": "okx_eth_perp_research_cost_grid_v1",
+        "parameter_names": [
+          "fee_bps",
+          "slippage_bps"
+        ],
+        "parameter_values": [
+          [
+            8.0,
+            10.0,
+            12.0
+          ],
+          [
+            4.0,
+            5.0,
+            6.0
+          ]
+        ],
+        "search_space_bounds": {
+          "fee_bps": {
+            "max": 12.0,
+            "min": 8.0
+          },
+          "slippage_bps": {
+            "max": 6.0,
+            "min": 4.0
+          }
+        },
+        "seed": 42
+      },
+      "grid_version": "v1",
+      "policy_version": "parameter_sensitivity_v1"
+    },
+    "slippage_bps": 5.0,
+    "slippage_model_version": "backtest_slippage_symmetric_v0"
+  },
+  "config_schema_version": "step29m_ma_crossover_v1_economic_evaluation_admissibility_v1",
+  "config_version": "v1",
+  "economic_evaluation_v1": {
+    "economic_validity_policy_version": "economic_validity_policy_v1",
+    "engine_signal_source": "configured_strategy_signal",
+    "monte_carlo": {
+      "bind": true,
+      "policy_version": "monte_carlo_v1",
+      "runs": 64,
+      "seed": 42
+    },
+    "parameter_sensitivity_policy_version": "parameter_sensitivity_v1",
+    "strategy_id": "ma_crossover",
+    "strategy_params": {
+      "fast_window": 20,
+      "price_col": "close",
+      "slow_window": 50
+    },
+    "strategy_version": "v1",
+    "stress": {
+      "bind": true,
+      "policy_version": "stress_class_suite_v1"
+    },
+    "walk_forward": {
+      "bind": true,
+      "policy_version": "walk_forward_v1",
+      "step_bars": 1440,
+      "test_bars": 1440,
+      "train_bars": 4320
+    }
+  },
+  "offline_evaluation_sizing_contract_v1": {
+    "config_digest": "85e6d33b670b6352f42a8b007f6acf3bb2a32735da623930f9a17cc617a563a1",
+    "dataset_digest": "b4cbe7fff81a137da055588231757937406d8cb30d531ee0aab41d95ee9b6c78",
+    "initial_equity": 10000.0,
+    "instrument_metadata_source": "versioned_dataset_manifest_v1",
+    "max_position_pct": 0.25,
+    "minimum_notional_policy": "USE_RISK_MIN_POSITION_VALUE_v1",
+    "minimum_quantity_policy": "REJECT_BELOW_MIN_NOTIONAL_v1",
+    "oversize_policy": "REJECT_OVERSIZE",
+    "price_source": "bar_close_v1",
+    "quantity_rounding_policy": "NONE_v1",
+    "risk_per_trade": 0.005,
+    "sizing_contract_version": "offline_evaluation_sizing_contract_v1",
+    "sizing_mode": "fixed_fractional_risk_per_trade_v1",
+    "sizing_owner": "backtest.offline_evaluation_sizing_contract_v1",
+    "stop_distance_policy": "FIXED_PCT_FROM_ENTRY_v1",
+    "stop_pct": 0.025,
+    "stop_pct_derivation_ref": "fleet_precedent:macd_v3_post_risk_limits_rewire",
+    "strategy_params_digest": "c6b61b7ace84ad69e89e869da9917134c7a798fb14870dd1576958bf70258ccf"
+  },
+  "real_admissible_futures_evaluation_binding_v1": {
+    "canonical_instrument_id": "inst-eth-usdt-perp",
+    "canonical_trading_logic_version": "integrated_offline_trading_logic_replay_v1",
+    "dataset_path": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/inst-eth-usdt-perp/v1/bars.parquet",
+    "dataset_profile": "economic_research_v1",
+    "effective_entry_cost_bps": 20.0,
+    "effective_exit_cost_bps": 20.0,
+    "execution_model_version": "backtest_execution_v0",
+    "expected_dataset_digest": "b4cbe7fff81a137da055588231757937406d8cb30d531ee0aab41d95ee9b6c78",
+    "expected_l1_observation_status": "EXECUTION_MODEL_BOUND_NOT_OBSERVED",
+    "expected_manifest_digest": "317105798c749943074911b1e9ea91ac9b94fab3b115fb7a64b692339426651a",
+    "native_instrument_id": "ETH-USDT-SWAP",
+    "out_of_sample_period": "2026-06-27 23:36:00+00:00..2026-07-01 10:07:00+00:00",
+    "require_dataset_admissible": true,
+    "require_integrity_pass": true,
+    "require_observed_l1_used_false": true,
+    "roundtrip_cost_bps": 40.0,
+    "source_venue": "OKX",
+    "training_period": "2026-06-17 16:00:00+00:00..2026-06-24 13:03:00+00:00",
+    "validation_period": "2026-06-24 13:04:00+00:00..2026-06-27 23:35:00+00:00"
+  },
+  "risk": {
+    "max_position_size": 0.25,
+    "min_position_value": 10.0,
+    "min_stop_distance": 0.0001,
+    "risk_per_trade": 0.005
+  },
+  "step29m_policy_ratification_v1": {
+    "dataset_replacement_allowed": false,
+    "evaluation_authorized": false,
+    "instrument_id": "inst-eth-usdt-perp",
+    "operator_policy_derivation_ref": "operator_policy_decision:STEP29M_MA_CROSSOVER_V1",
+    "parameter_tuning_allowed": false,
+    "promotion_authorized": false,
+    "runtime_authorized": false,
+    "sizing_precedent_ref": "fleet_precedent:macd_v3_post_risk_limits_rewire",
+    "strategy_id": "ma_crossover",
+    "strategy_version": "v1",
+    "threshold_tuning_allowed": false,
+    "venue_id": "okx"
+  }
+}

--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -111,7 +111,7 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `RUNBOOK_STEP_29L_COMPLETE` | `true` |
 | `STEP_29M_STARTED` | `true` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice,real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice,breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0,step29m_registered_strategy_evaluation_fleet_closeout_v0_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice,real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice,breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0,step29m_registered_strategy_evaluation_fleet_closeout_v0_slice,ma_crossover_v1_operator_policy_ratification_and_config_registry_slice_v0` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `true` |
 | `ECONOMIC_GATE_EVALUATOR_BOUND` | `true` |
@@ -131,25 +131,54 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `LAST_EVALUATED_STRATEGY_ID` | `breakout_donchian` |
 | `LAST_EVALUATED_STRATEGY_VERSION` | `v1` |
 | `LAST_EVALUATED_CONFIG_VERSION` | `v1` |
-| `NEXT_EVALUATION_STRATEGY_ID` | `none` |
-| `NEXT_EVALUATION_STRATEGY_VERSION` | `none` |
-| `NEXT_EVALUATION_INSTRUMENT_ID` | `none` |
-| `NEXT_EVALUATION_VENUE` | `none` |
-| `NEXT_EVALUATION_CONFIG_VERSION` | `none` |
-| `NEXT_EVALUATION_CONFIG_STATUS` | `EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE` |
-| `NEXT_EVALUATION_CONFIG_PATH` | `none` |
+| `NEXT_EVALUATION_STRATEGY_ID` | `ma_crossover` |
+| `NEXT_EVALUATION_STRATEGY_VERSION` | `v1` |
+| `NEXT_EVALUATION_INSTRUMENT_ID` | `inst-eth-usdt-perp` |
+| `NEXT_EVALUATION_VENUE` | `okx` |
+| `NEXT_EVALUATION_CONFIG_VERSION` | `v1` |
+| `NEXT_EVALUATION_CONFIG_STATUS` | `AUTHORIZED_PENDING_EVALUATION` |
+| `NEXT_EVALUATION_CONFIG_PATH` | `config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json` <!-- pt:ref-target-ignore --> |
+| `AUTHORIZED_PENDING_EVALUATION_COUNT` | `1` |
 | `STEP29M_REGISTERED_STRATEGY_FLEET_STATUS` | `EVALUATION_FLEET_COMPLETE_NO_ECONOMIC_VALIDITY_PASS` |
-| `REGISTERED_POLICY_RATIFIED_STRATEGY_COUNT` | `2` |
+| `REGISTERED_POLICY_RATIFIED_STRATEGY_COUNT` | `3` |
 | `COMPLETED_TECHNICALLY_VALID_EVALUATION_COUNT` | `2` |
 | `ECONOMIC_POLICY_PASS_COUNT` | `0` |
 | `ECONOMIC_POLICY_FAIL_COUNT` | `2` |
 | `PROMOTION_ELIGIBLE_COUNT` | `0` |
 | `BREAKOUT_DONCHIAN_V1_STATUS` | `TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL` |
 | `MACD_V1_CONFIG_V3_STATUS` | `TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL` |
+| `PRE_RATIFICATION_FLEET_EXHAUSTED` | `true` |
+| `POST_RATIFICATION_AUTHORIZED_PENDING_CANDIDATE_EXISTS` | `true` |
+| `HISTORICAL_FLEET_RESULTS_UNCHANGED` | `true` |
+| `MA_CROSSOVER_V1_POLICY_RATIFIED` | `true` |
+| `MA_CROSSOVER_V1_FIXED_CONFIG_BOUND` | `true` |
+| `MA_CROSSOVER_V1_ECONOMIC_EVALUATION_EXECUTED` | `false` |
+| `MA_CROSSOVER_V1_ECONOMIC_VALIDITY_OFFLINE_GATE_PASS` | `false` |
+| `MA_CROSSOVER_V1_PROMOTION_ELIGIBLE` | `false` |
+| `MA_CROSSOVER_V1_RUNTIME_AUTHORIZED` | `false` |
+| `MA_CROSSOVER_V1_STATUS` | `AUTHORIZED_PENDING_EVALUATION` |
+| `MA_CROSSOVER_V1_ADMISSIBILITY_CONTRACT_STATUS` | `PASS` |
+| `MA_CROSSOVER_V1_CONFIG_SCHEMA_VERSION` | `step29m_ma_crossover_v1_economic_evaluation_admissibility_v1` |
+| `MA_CROSSOVER_FAST_WINDOW` | `20` |
+| `MA_CROSSOVER_SLOW_WINDOW` | `50` |
+| `MA_CROSSOVER_PRICE_COL` | `close` |
+| `MA_CROSSOVER_RISK_PER_TRADE` | `0.005` |
+| `MA_CROSSOVER_STOP_PCT` | `0.025` |
+| `MA_CROSSOVER_MAX_POSITION_PCT` | `0.25` |
+| `MA_CROSSOVER_OFFLINE_OVERSIZE_POLICY` | `REJECT_OVERSIZE` |
+| `MA_CROSSOVER_SIZING_PRECEDENT_REF` | `fleet_precedent:macd_v3_post_risk_limits_rewire` |
+| `MA_CROSSOVER_V1_RANK1_CANDIDATE_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_step29m_additional_existing_strategy_policy_ratification_candidate_decision_read_only_v0_20260702T010015Z` |
+| `MA_CROSSOVER_FAST_WINDOW_DERIVATION_REF` | `operator_policy_decision:STEP29M_MA_CROSSOVER_V1` |
+| `MA_CROSSOVER_SLOW_WINDOW_DERIVATION_REF` | `operator_policy_decision:STEP29M_MA_CROSSOVER_V1` |
+| `MA_CROSSOVER_PRICE_COL_DERIVATION_REF` | `operator_policy_decision:STEP29M_MA_CROSSOVER_V1` |
+| `MA_CROSSOVER_RISK_PER_TRADE_DERIVATION_REF` | `fleet_precedent:macd_v3_post_risk_limits_rewire` |
+| `MA_CROSSOVER_STOP_PCT_DERIVATION_REF` | `fleet_precedent:macd_v3_post_risk_limits_rewire` |
+| `MA_CROSSOVER_POLICY_INVARIANT_RESULT` | `0.005 <= 0.25 * 0.025 = 0.00625` |
+| `MA_CROSSOVER_MAX_POSITION_PCT_DERIVATION_REF` | `fleet_precedent:macd_v3_post_risk_limits_rewire` |
 | `PRIMARY_FLEET_FINDING` | `NO_ADMISSIBLE_REGISTERED_STRATEGY_ECONOMICALLY_VIABLE_OFFLINE` |
 | `EVALUATION_EXECUTION_COMPLETE` | `true` |
 | `ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED` | `false` |
-| `NEXT_CANONICAL_STEP` | `BOUNDED_STEP29M_POST_FLEET_NO_PASS_CANONICAL_DECISION_READ_ONLY_V0` |
+| `NEXT_CANONICAL_STEP` | `BOUNDED_STEP29M_MA_CROSSOVER_V1_REAL_ADMISSIBLE_FUTURES_ECONOMIC_EVALUATION_PREFLIGHT_READ_ONLY_V0` |
 | `STEP29N_AUTHORIZED` | `false` |
 | `STEP29R_AUTHORIZED` | `false` |
 | `RUNTIME_REWIRE_ALLOWED` | `false` |
@@ -158,7 +187,7 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `OPERATOR_POLICY_DECISION` | `RATIFIED` |
 | `OPERATOR_POLICY_DECISION_OWNER` | `Frank Rauter` |
 | `OPERATOR_POLICY_DECISION_DATE` | `2026-07-02` |
-| `OPERATOR_POLICY_DECISION_SCOPE` | `STEP29M_BREAKOUT_DONCHIAN_V1_OKX_INST_ETH_USDT_PERP` |
+| `OPERATOR_POLICY_DECISION_SCOPE` | `STEP29M_MA_CROSSOVER_V1_OKX_INST_ETH_USDT_PERP` |
 | `BREAKOUT_DONCHIAN_LOOKBACK` | `20` |
 | `BREAKOUT_DONCHIAN_PRICE_COL` | `close` |
 | `BREAKOUT_DONCHIAN_RISK_PER_TRADE` | `0.005` |
@@ -179,7 +208,7 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `ECONOMIC_RESULT_USED_FOR_POLICY_SELECTION` | `false` |
 | `ECONOMIC_EVALUATION_ALLOWED` | `false` |
 | `PROMOTION_ALLOWED` | `false` |
-| `STEP29M_REGISTERED_ECONOMIC_EVALUATION_CONFIGS` | `config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_economic_evaluation_v1.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v1.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v2.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v3.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_breakout_donchian_v1_economic_evaluation_v1.json` <!-- pt:ref-target-ignore --> |
+| `STEP29M_REGISTERED_ECONOMIC_EVALUATION_CONFIGS` | `config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_economic_evaluation_v1.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v1.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v2.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v3.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_breakout_donchian_v1_economic_evaluation_v1.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json` <!-- pt:ref-target-ignore --> |
 | `BREAKOUT_DONCHIAN_V1_ADMISSIBILITY_CONTRACT_STATUS` | `PASS` |
 | `BREAKOUT_DONCHIAN_V1_CONFIG_SCHEMA_VERSION` | `step29m_breakout_donchian_v1_economic_evaluation_admissibility_v1` |
 | `V3_RISK_PER_TRADE` | `0.005` |
@@ -1197,25 +1226,54 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `LAST_EVALUATED_STRATEGY_ID` | `breakout_donchian` |
 | `LAST_EVALUATED_STRATEGY_VERSION` | `v1` |
 | `LAST_EVALUATED_CONFIG_VERSION` | `v1` |
-| `NEXT_EVALUATION_STRATEGY_ID` | `none` |
-| `NEXT_EVALUATION_STRATEGY_VERSION` | `none` |
-| `NEXT_EVALUATION_INSTRUMENT_ID` | `none` |
-| `NEXT_EVALUATION_VENUE` | `none` |
-| `NEXT_EVALUATION_CONFIG_VERSION` | `none` |
-| `NEXT_EVALUATION_CONFIG_STATUS` | `EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE` |
-| `NEXT_EVALUATION_CONFIG_PATH` | `none` |
+| `NEXT_EVALUATION_STRATEGY_ID` | `ma_crossover` |
+| `NEXT_EVALUATION_STRATEGY_VERSION` | `v1` |
+| `NEXT_EVALUATION_INSTRUMENT_ID` | `inst-eth-usdt-perp` |
+| `NEXT_EVALUATION_VENUE` | `okx` |
+| `NEXT_EVALUATION_CONFIG_VERSION` | `v1` |
+| `NEXT_EVALUATION_CONFIG_STATUS` | `AUTHORIZED_PENDING_EVALUATION` |
+| `NEXT_EVALUATION_CONFIG_PATH` | `config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json` <!-- pt:ref-target-ignore --> |
+| `AUTHORIZED_PENDING_EVALUATION_COUNT` | `1` |
 | `STEP29M_REGISTERED_STRATEGY_FLEET_STATUS` | `EVALUATION_FLEET_COMPLETE_NO_ECONOMIC_VALIDITY_PASS` |
-| `REGISTERED_POLICY_RATIFIED_STRATEGY_COUNT` | `2` |
+| `REGISTERED_POLICY_RATIFIED_STRATEGY_COUNT` | `3` |
 | `COMPLETED_TECHNICALLY_VALID_EVALUATION_COUNT` | `2` |
 | `ECONOMIC_POLICY_PASS_COUNT` | `0` |
 | `ECONOMIC_POLICY_FAIL_COUNT` | `2` |
 | `PROMOTION_ELIGIBLE_COUNT` | `0` |
 | `BREAKOUT_DONCHIAN_V1_STATUS` | `TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL` |
 | `MACD_V1_CONFIG_V3_STATUS` | `TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL` |
+| `PRE_RATIFICATION_FLEET_EXHAUSTED` | `true` |
+| `POST_RATIFICATION_AUTHORIZED_PENDING_CANDIDATE_EXISTS` | `true` |
+| `HISTORICAL_FLEET_RESULTS_UNCHANGED` | `true` |
+| `MA_CROSSOVER_V1_POLICY_RATIFIED` | `true` |
+| `MA_CROSSOVER_V1_FIXED_CONFIG_BOUND` | `true` |
+| `MA_CROSSOVER_V1_ECONOMIC_EVALUATION_EXECUTED` | `false` |
+| `MA_CROSSOVER_V1_ECONOMIC_VALIDITY_OFFLINE_GATE_PASS` | `false` |
+| `MA_CROSSOVER_V1_PROMOTION_ELIGIBLE` | `false` |
+| `MA_CROSSOVER_V1_RUNTIME_AUTHORIZED` | `false` |
+| `MA_CROSSOVER_V1_STATUS` | `AUTHORIZED_PENDING_EVALUATION` |
+| `MA_CROSSOVER_V1_ADMISSIBILITY_CONTRACT_STATUS` | `PASS` |
+| `MA_CROSSOVER_V1_CONFIG_SCHEMA_VERSION` | `step29m_ma_crossover_v1_economic_evaluation_admissibility_v1` |
+| `MA_CROSSOVER_FAST_WINDOW` | `20` |
+| `MA_CROSSOVER_SLOW_WINDOW` | `50` |
+| `MA_CROSSOVER_PRICE_COL` | `close` |
+| `MA_CROSSOVER_RISK_PER_TRADE` | `0.005` |
+| `MA_CROSSOVER_STOP_PCT` | `0.025` |
+| `MA_CROSSOVER_MAX_POSITION_PCT` | `0.25` |
+| `MA_CROSSOVER_OFFLINE_OVERSIZE_POLICY` | `REJECT_OVERSIZE` |
+| `MA_CROSSOVER_SIZING_PRECEDENT_REF` | `fleet_precedent:macd_v3_post_risk_limits_rewire` |
+| `MA_CROSSOVER_V1_RANK1_CANDIDATE_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_step29m_additional_existing_strategy_policy_ratification_candidate_decision_read_only_v0_20260702T010015Z` |
+| `MA_CROSSOVER_FAST_WINDOW_DERIVATION_REF` | `operator_policy_decision:STEP29M_MA_CROSSOVER_V1` |
+| `MA_CROSSOVER_SLOW_WINDOW_DERIVATION_REF` | `operator_policy_decision:STEP29M_MA_CROSSOVER_V1` |
+| `MA_CROSSOVER_PRICE_COL_DERIVATION_REF` | `operator_policy_decision:STEP29M_MA_CROSSOVER_V1` |
+| `MA_CROSSOVER_RISK_PER_TRADE_DERIVATION_REF` | `fleet_precedent:macd_v3_post_risk_limits_rewire` |
+| `MA_CROSSOVER_STOP_PCT_DERIVATION_REF` | `fleet_precedent:macd_v3_post_risk_limits_rewire` |
+| `MA_CROSSOVER_POLICY_INVARIANT_RESULT` | `0.005 <= 0.25 * 0.025 = 0.00625` |
+| `MA_CROSSOVER_MAX_POSITION_PCT_DERIVATION_REF` | `fleet_precedent:macd_v3_post_risk_limits_rewire` |
 | `PRIMARY_FLEET_FINDING` | `NO_ADMISSIBLE_REGISTERED_STRATEGY_ECONOMICALLY_VIABLE_OFFLINE` |
 | `EVALUATION_EXECUTION_COMPLETE` | `true` |
 | `ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED` | `false` |
-| `NEXT_CANONICAL_STEP` | `BOUNDED_STEP29M_POST_FLEET_NO_PASS_CANONICAL_DECISION_READ_ONLY_V0` |
+| `NEXT_CANONICAL_STEP` | `BOUNDED_STEP29M_MA_CROSSOVER_V1_REAL_ADMISSIBLE_FUTURES_ECONOMIC_EVALUATION_PREFLIGHT_READ_ONLY_V0` |
 | `STEP29N_AUTHORIZED` | `false` |
 | `STEP29R_AUTHORIZED` | `false` |
 | `RUNTIME_REWIRE_ALLOWED` | `false` |
@@ -1224,7 +1282,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `OPERATOR_POLICY_DECISION` | `RATIFIED` |
 | `OPERATOR_POLICY_DECISION_OWNER` | `Frank Rauter` |
 | `OPERATOR_POLICY_DECISION_DATE` | `2026-07-02` |
-| `OPERATOR_POLICY_DECISION_SCOPE` | `STEP29M_BREAKOUT_DONCHIAN_V1_OKX_INST_ETH_USDT_PERP` |
+| `OPERATOR_POLICY_DECISION_SCOPE` | `STEP29M_MA_CROSSOVER_V1_OKX_INST_ETH_USDT_PERP` |
 | `BREAKOUT_DONCHIAN_LOOKBACK` | `20` |
 | `BREAKOUT_DONCHIAN_PRICE_COL` | `close` |
 | `BREAKOUT_DONCHIAN_RISK_PER_TRADE` | `0.005` |
@@ -1245,7 +1303,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `ECONOMIC_RESULT_USED_FOR_POLICY_SELECTION` | `false` |
 | `ECONOMIC_EVALUATION_ALLOWED` | `false` |
 | `PROMOTION_ALLOWED` | `false` |
-| `STEP29M_REGISTERED_ECONOMIC_EVALUATION_CONFIGS` | `config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_economic_evaluation_v1.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v1.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v2.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v3.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_breakout_donchian_v1_economic_evaluation_v1.json` <!-- pt:ref-target-ignore --> |
+| `STEP29M_REGISTERED_ECONOMIC_EVALUATION_CONFIGS` | `config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_economic_evaluation_v1.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v1.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v2.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v3.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_breakout_donchian_v1_economic_evaluation_v1.json,config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json` <!-- pt:ref-target-ignore --> |
 | `BREAKOUT_DONCHIAN_V1_ADMISSIBILITY_CONTRACT_STATUS` | `PASS` |
 | `BREAKOUT_DONCHIAN_V1_CONFIG_SCHEMA_VERSION` | `step29m_breakout_donchian_v1_economic_evaluation_admissibility_v1` |
 | `V3_RISK_PER_TRADE` | `0.005` |
@@ -1284,7 +1342,7 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `ECONOMIC_VALIDITY_PROVEN` | `false` |
 | `PROFITABILITY_CLAIM_ALLOWED` | `false` |
 | `RUNBOOK_STEP_29M_STARTED` | `true` |
-| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice,real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice,breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0,step29m_registered_strategy_evaluation_fleet_closeout_v0_slice` |
+| `RUNBOOK_STEP_29M_IMPLEMENTED_SCOPE` | `economic_viability_evidence_v1_offline_slice,economic_viability_evidence_v1_persistence_load_reproducibility_slice,economic_validity_policy_v1_contract_slice,funding_model_binding_v1_slice,parameter_sensitivity_evidence_binding_v1_slice,admissible_versioned_futures_dataset_binding_v1_slice,economic_validity_policy_threshold_values_v1_slice,real_admissible_futures_economic_evidence_evaluation_v1_offline_slice,real_admissible_futures_economic_evaluation_operator_input_and_admissibility_closure_v0_slice,real_okx_inst_eth_usdt_perp_economic_evaluation_v1_offline_slice,breakout_donchian_v1_operator_policy_ratification_and_config_registry_slice_v0,step29m_registered_strategy_evaluation_fleet_closeout_v0_slice,ma_crossover_v1_operator_policy_ratification_and_config_registry_slice_v0` |
 | `RUNBOOK_STEP_29M_IMPLEMENTED` | `true` |
 | `RUNBOOK_STEP_29M_COMPLETE` | `true` |
 | `ECONOMIC_VIABILITY_EVIDENCE_V1_IMPLEMENTED` | `true` |

--- a/src/backtest/step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1.py
@@ -1,0 +1,431 @@
+"""
+STEP 29M ma_crossover v1 economic evaluation admissibility contract v1.
+
+Read-only contract diagnostics for operator-ratified fixed-config policy,
+parameter binding, sizing invariants, signal-binding provenance, and staged
+config readiness. No economic evaluation execution.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 import (
+    compute_evaluation_config_digest_v1,
+    verify_cost_binding_v1,
+)
+from src.backtest.strategy_signal_binding_v1 import (
+    ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    StrategySignalBindingError,
+    collect_configured_strategy_params_v1,
+    compute_required_warmup_rows_v1,
+    resolve_effective_strategy_params_v1,
+)
+from src.strategies.registry import get_strategy_registry_entry, resolve_strategy_id
+
+CONTRACT_LAYER_VERSION = "v1"
+CONTRACT_OWNER = "backtest.step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1"
+
+MA_CROSSOVER_V1_STRATEGY_ID = "ma_crossover"
+MA_CROSSOVER_V1_STRATEGY_VERSION = "v1"
+MA_CROSSOVER_V1_STRATEGY_OWNER = "src.strategies.ma_crossover.MACrossoverStrategy"
+MA_CROSSOVER_V1_CANONICAL_PARAMS = {
+    "fast_window": 20,
+    "slow_window": 50,
+    "price_col": "close",
+}
+
+FAST_WINDOW_MIN = 2
+SLOW_WINDOW_MIN = 3
+WINDOW_MAX = 500
+ALLOWED_PRICE_COLS = frozenset({"open", "high", "low", "close"})
+ALLOWED_MA_CROSSOVER_SIGNAL_VALUES = frozenset({0, 1})
+
+OPERATOR_RATIFIED_RISK_PER_TRADE = 0.005
+OPERATOR_RATIFIED_STOP_PCT = 0.025
+OPERATOR_RATIFIED_MAX_POSITION_PCT = 0.25
+OFFLINE_BOUND_OVERSIZE_POLICY = "REJECT_OVERSIZE"
+POLICY_INVARIANT = "risk_per_trade <= max_position_pct * stop_pct"
+POLICY_INVARIANT_RESULT = "0.005 <= 0.25 * 0.025 = 0.00625"
+OPERATOR_POLICY_DERIVATION_REF = "operator_policy_decision:STEP29M_MA_CROSSOVER_V1"
+FLEET_SIZING_PRECEDENT_REF = "fleet_precedent:macd_v3_post_risk_limits_rewire"
+
+DEFAULT_EVALUATION_CONFIG_PATH = (
+    "config/ops/step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json"
+)
+CONFIG_SCHEMA_VERSION = "step29m_ma_crossover_v1_economic_evaluation_admissibility_v1"
+
+STEP29M_REGISTERED_ECONOMIC_EVALUATION_CONFIGS_V1: tuple[str, ...] = (
+    "config/ops/step29m_okx_inst_eth_usdt_perp_economic_evaluation_v1.json",
+    "config/ops/step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v1.json",
+    "config/ops/step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v2.json",
+    "config/ops/step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v3.json",
+    "config/ops/step29m_okx_inst_eth_usdt_perp_breakout_donchian_v1_economic_evaluation_v1.json",
+    DEFAULT_EVALUATION_CONFIG_PATH,
+)
+
+_FORBIDDEN_INSTRUMENT_SUBSTRINGS = frozenset({"btc", "xbt", "bitcoin", "spot", "synthetic_spot"})
+
+RATIFICATION_SLICE_SAFETY_FLAGS: dict[str, Any] = {
+    "futures_only": True,
+    "bitcoin_direction_allowed": False,
+    "spot_allowed": False,
+    "synthetic_spot_allowed": False,
+    "fixed_config_required": True,
+    "parameter_tuning_allowed": False,
+    "dataset_change_allowed": False,
+    "policy_threshold_change_allowed": False,
+    "productive_runner_invocations_allowed": 0,
+    "economic_evaluation_allowed": False,
+    "promotion_allowed": False,
+    "runtime_effect": False,
+    "order_effect": False,
+    "profitability_claim_allowed": False,
+}
+
+
+class AdmissibilityResult(str, Enum):
+    PASS = "PASS"
+    BLOCKED = "BLOCKED"
+
+
+@dataclass(frozen=True)
+class MaCrossoverV1AdmissibilityContractResultV1:
+    admissibility_result: AdmissibilityResult
+    blocking_reasons: tuple[str, ...]
+    strategy_id: str
+    strategy_version: str
+    strategy_owner: str
+    configured_strategy_params: dict[str, Any]
+    effective_strategy_params: dict[str, Any]
+    strategy_params_digest: str
+    evaluation_config_path: str
+    config_digest: str
+    config_schema_version: str
+    cost_binding_status: str
+    policy_invariant_result: str
+    signal_semantics: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "admissibility_result": self.admissibility_result.value,
+            "blocking_reasons": list(self.blocking_reasons),
+            "strategy_id": self.strategy_id,
+            "strategy_version": self.strategy_version,
+            "strategy_owner": self.strategy_owner,
+            "configured_strategy_params": self.configured_strategy_params,
+            "effective_strategy_params": self.effective_strategy_params,
+            "strategy_params_digest": self.strategy_params_digest,
+            "evaluation_config_path": self.evaluation_config_path,
+            "config_digest": self.config_digest,
+            "config_schema_version": self.config_schema_version,
+            "cost_binding_status": self.cost_binding_status,
+            "policy_invariant_result": self.policy_invariant_result,
+            "signal_semantics": self.signal_semantics,
+        }
+
+
+def list_step29m_registered_economic_evaluation_configs_v1() -> tuple[str, ...]:
+    return STEP29M_REGISTERED_ECONOMIC_EVALUATION_CONFIGS_V1
+
+
+def load_ma_crossover_v1_evaluation_config_v1(
+    repo_root: Path,
+    config_path: Optional[str] = None,
+) -> dict[str, Any]:
+    rel = config_path or DEFAULT_EVALUATION_CONFIG_PATH
+    path = repo_root / rel
+    if not path.is_file():
+        raise FileNotFoundError(f"evaluation_config_not_found:{path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("evaluation_config_not_object")
+    return payload
+
+
+def verify_ma_crossover_v1_strategy_identity_v1() -> tuple[str, ...]:
+    reasons: list[str] = []
+    resolution = resolve_strategy_id(MA_CROSSOVER_V1_STRATEGY_ID)
+    if resolution.canonical_strategy_id != MA_CROSSOVER_V1_STRATEGY_ID:
+        reasons.append("strategy_id_not_canonical")
+    entry = get_strategy_registry_entry(MA_CROSSOVER_V1_STRATEGY_ID)
+    if entry.strategy_version != MA_CROSSOVER_V1_STRATEGY_VERSION:
+        reasons.append("strategy_version_mismatch")
+    if entry.implementation_ref != MA_CROSSOVER_V1_STRATEGY_OWNER:
+        reasons.append("strategy_owner_mismatch")
+    if not entry.futures_compatible:
+        reasons.append("strategy_not_futures_compatible")
+    if entry.spot_compatible:
+        reasons.append("strategy_spot_compatible_true")
+    lowered = entry.strategy_id.lower()
+    if "btc" in lowered or "xbt" in lowered:
+        reasons.append("strategy_btc_specialization")
+    return tuple(reasons)
+
+
+def _validate_window_v1(
+    name: str,
+    value: Any,
+    *,
+    minimum: int,
+) -> tuple[Optional[int], tuple[str, ...]]:
+    if value is None:
+        return None, (f"{name}_missing",)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, (f"{name}_not_integer",)
+    if value < minimum or value > WINDOW_MAX:
+        return None, (f"{name}_out_of_range",)
+    return value, ()
+
+
+def _validate_price_col_v1(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, str):
+        return ("price_col_not_string",)
+    if value not in ALLOWED_PRICE_COLS:
+        return ("price_col_not_allowed",)
+    return ()
+
+
+def _window_params_for_binding_v1(configured: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: configured[key] for key in ("fast_window", "slow_window") if key in configured}
+
+
+def verify_ma_crossover_v1_strategy_params_v1(
+    configured: Mapping[str, Any],
+    effective: Mapping[str, Any],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if set(configured.keys()) - set(MA_CROSSOVER_V1_CANONICAL_PARAMS):
+        reasons.append("unknown_configured_strategy_param")
+    expected_window_keys = {"fast_window", "slow_window"}
+    if set(effective.keys()) != expected_window_keys:
+        reasons.append("unknown_effective_strategy_param")
+    if effective.get("fast_window") != MA_CROSSOVER_V1_CANONICAL_PARAMS["fast_window"]:
+        reasons.append("fast_window_not_canonical")
+    if effective.get("slow_window") != MA_CROSSOVER_V1_CANONICAL_PARAMS["slow_window"]:
+        reasons.append("slow_window_not_canonical")
+
+    _, fast_reasons = _validate_window_v1(
+        "fast_window", effective.get("fast_window"), minimum=FAST_WINDOW_MIN
+    )
+    reasons.extend(fast_reasons)
+    _, slow_reasons = _validate_window_v1(
+        "slow_window", effective.get("slow_window"), minimum=SLOW_WINDOW_MIN
+    )
+    reasons.extend(slow_reasons)
+
+    fast = effective.get("fast_window")
+    slow = effective.get("slow_window")
+    if isinstance(fast, int) and isinstance(slow, int) and fast >= slow:
+        reasons.append("fast_window_not_lt_slow_window")
+
+    if configured.get("price_col") != MA_CROSSOVER_V1_CANONICAL_PARAMS["price_col"]:
+        reasons.append("price_col_not_canonical")
+    reasons.extend(_validate_price_col_v1(configured.get("price_col")))
+    return tuple(reasons)
+
+
+def verify_ma_crossover_v1_sizing_policy_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    sizing = cfg.get("offline_evaluation_sizing_contract_v1")
+    if not isinstance(sizing, Mapping):
+        return ("offline_evaluation_sizing_contract_v1_missing",)
+
+    risk = sizing.get("risk_per_trade")
+    stop_pct = sizing.get("stop_pct")
+    max_position_pct = sizing.get("max_position_pct")
+    oversize_policy = sizing.get("oversize_policy")
+
+    if risk != OPERATOR_RATIFIED_RISK_PER_TRADE:
+        reasons.append("risk_per_trade_not_ratified")
+    if stop_pct != OPERATOR_RATIFIED_STOP_PCT:
+        reasons.append("stop_pct_not_ratified")
+    if max_position_pct != OPERATOR_RATIFIED_MAX_POSITION_PCT:
+        reasons.append("max_position_pct_not_ratified")
+    if oversize_policy != OFFLINE_BOUND_OVERSIZE_POLICY:
+        reasons.append("oversize_policy_not_reject")
+    if not isinstance(risk, (int, float)) or float(risk) <= 0:
+        reasons.append("risk_per_trade_non_positive")
+    if not isinstance(stop_pct, (int, float)) or float(stop_pct) <= 0:
+        reasons.append("stop_pct_non_positive")
+    if not isinstance(max_position_pct, (int, float)) or float(max_position_pct) <= 0:
+        reasons.append("max_position_pct_non_positive")
+    if isinstance(risk, (int, float)) and isinstance(stop_pct, (int, float)):
+        if isinstance(max_position_pct, (int, float)):
+            if float(risk) > float(max_position_pct) * float(stop_pct):
+                reasons.append("policy_invariant_violation")
+    if sizing.get("stop_pct_derivation_ref") != FLEET_SIZING_PRECEDENT_REF:
+        reasons.append("stop_pct_derivation_ref_not_fleet_precedent")
+    return tuple(reasons)
+
+
+def verify_ma_crossover_v1_instrument_binding_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    binding = cfg.get("real_admissible_futures_evaluation_binding_v1")
+    if not isinstance(binding, Mapping):
+        return ("real_admissible_futures_evaluation_binding_v1_missing",)
+
+    instrument_id = str(binding.get("canonical_instrument_id", ""))
+    if instrument_id != "inst-eth-usdt-perp":
+        reasons.append("instrument_id_mismatch")
+    venue = str(binding.get("source_venue", ""))
+    if venue != "OKX":
+        reasons.append("source_venue_mismatch")
+    native = str(binding.get("native_instrument_id", ""))
+    lowered = f"{instrument_id} {native} {venue}".lower()
+    for forbidden in _FORBIDDEN_INSTRUMENT_SUBSTRINGS:
+        if forbidden in lowered:
+            reasons.append(f"forbidden_instrument_binding:{forbidden}")
+    return tuple(reasons)
+
+
+def verify_ma_crossover_v1_ratification_authority_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    ratification = cfg.get("step29m_policy_ratification_v1")
+    if not isinstance(ratification, Mapping):
+        return ("step29m_policy_ratification_v1_missing",)
+
+    expected_false = (
+        "evaluation_authorized",
+        "promotion_authorized",
+        "runtime_authorized",
+        "parameter_tuning_allowed",
+        "threshold_tuning_allowed",
+        "dataset_replacement_allowed",
+    )
+    for field in expected_false:
+        if ratification.get(field) is not False:
+            reasons.append(f"{field}_not_false")
+
+    if ratification.get("instrument_id") != "inst-eth-usdt-perp":
+        reasons.append("ratification_instrument_id_mismatch")
+    if ratification.get("strategy_id") != MA_CROSSOVER_V1_STRATEGY_ID:
+        reasons.append("ratification_strategy_id_mismatch")
+    if ratification.get("strategy_version") != MA_CROSSOVER_V1_STRATEGY_VERSION:
+        reasons.append("ratification_strategy_version_mismatch")
+    if ratification.get("venue_id") != "okx":
+        reasons.append("ratification_venue_id_mismatch")
+    if ratification.get("operator_policy_derivation_ref") != OPERATOR_POLICY_DERIVATION_REF:
+        reasons.append("operator_policy_derivation_ref_mismatch")
+    if ratification.get("sizing_precedent_ref") != FLEET_SIZING_PRECEDENT_REF:
+        reasons.append("sizing_precedent_ref_mismatch")
+    return tuple(reasons)
+
+
+def verify_ma_crossover_v1_config_schema_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if cfg.get("config_schema_version") != CONFIG_SCHEMA_VERSION:
+        reasons.append("config_schema_version_mismatch")
+
+    eval_section = cfg.get("economic_evaluation_v1")
+    if not isinstance(eval_section, Mapping):
+        return ("economic_evaluation_v1_missing",)
+    if eval_section.get("strategy_id") != MA_CROSSOVER_V1_STRATEGY_ID:
+        reasons.append("config_strategy_id_mismatch")
+    if eval_section.get("strategy_version") != MA_CROSSOVER_V1_STRATEGY_VERSION:
+        reasons.append("config_strategy_version_mismatch")
+    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+        reasons.append("engine_signal_source_not_bound")
+    if eval_section.get("economic_validity_policy_version") != "economic_validity_policy_v1":
+        reasons.append("economic_validity_policy_version_mismatch")
+
+    strategy_params = eval_section.get("strategy_params")
+    if not isinstance(strategy_params, Mapping):
+        reasons.append("strategy_params_missing")
+    else:
+        _, fast_reasons = _validate_window_v1(
+            "fast_window",
+            strategy_params.get("fast_window"),
+            minimum=FAST_WINDOW_MIN,
+        )
+        reasons.extend(fast_reasons)
+        _, slow_reasons = _validate_window_v1(
+            "slow_window",
+            strategy_params.get("slow_window"),
+            minimum=SLOW_WINDOW_MIN,
+        )
+        reasons.extend(slow_reasons)
+        fast = strategy_params.get("fast_window")
+        slow = strategy_params.get("slow_window")
+        if isinstance(fast, int) and isinstance(slow, int) and fast >= slow:
+            reasons.append("fast_window_not_lt_slow_window")
+        reasons.extend(_validate_price_col_v1(strategy_params.get("price_col")))
+        if set(strategy_params.keys()) != set(MA_CROSSOVER_V1_CANONICAL_PARAMS):
+            reasons.append("unknown_strategy_params_in_config")
+
+    return tuple(reasons)
+
+
+def verify_ma_crossover_v1_signal_binding_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    configured = collect_configured_strategy_params_v1(cfg, MA_CROSSOVER_V1_STRATEGY_ID)
+    try:
+        effective, _ = resolve_effective_strategy_params_v1(
+            MA_CROSSOVER_V1_STRATEGY_ID,
+            _window_params_for_binding_v1(configured),
+        )
+        warmup = compute_required_warmup_rows_v1(MA_CROSSOVER_V1_STRATEGY_ID, effective)
+        if warmup != int(effective["slow_window"]):
+            reasons.append("warmup_not_equal_to_slow_window")
+    except StrategySignalBindingError as exc:
+        reasons.append(str(exc))
+    return tuple(reasons)
+
+
+def evaluate_ma_crossover_v1_admissibility_contract_v1(
+    *,
+    repo_root: Path,
+    config_path: Optional[str] = None,
+) -> MaCrossoverV1AdmissibilityContractResultV1:
+    blocking: list[str] = []
+    rel_path = config_path or DEFAULT_EVALUATION_CONFIG_PATH
+    cfg = load_ma_crossover_v1_evaluation_config_v1(repo_root, rel_path)
+    config_digest = compute_evaluation_config_digest_v1(cfg)
+
+    blocking.extend(verify_ma_crossover_v1_strategy_identity_v1())
+    blocking.extend(verify_ma_crossover_v1_config_schema_v1(cfg))
+    blocking.extend(verify_ma_crossover_v1_sizing_policy_v1(cfg))
+    blocking.extend(verify_ma_crossover_v1_instrument_binding_v1(cfg))
+    blocking.extend(verify_ma_crossover_v1_ratification_authority_v1(cfg))
+    blocking.extend(verify_ma_crossover_v1_signal_binding_v1(cfg))
+
+    cost_status, cost_reasons = verify_cost_binding_v1(cfg)
+    blocking.extend(cost_reasons)
+
+    configured = collect_configured_strategy_params_v1(cfg, MA_CROSSOVER_V1_STRATEGY_ID)
+    try:
+        effective, params_digest = resolve_effective_strategy_params_v1(
+            MA_CROSSOVER_V1_STRATEGY_ID,
+            _window_params_for_binding_v1(configured),
+        )
+    except StrategySignalBindingError as exc:
+        blocking.append(str(exc))
+        effective = {
+            "fast_window": MA_CROSSOVER_V1_CANONICAL_PARAMS["fast_window"],
+            "slow_window": MA_CROSSOVER_V1_CANONICAL_PARAMS["slow_window"],
+        }
+        params_digest = ""
+
+    blocking.extend(verify_ma_crossover_v1_strategy_params_v1(configured, effective))
+
+    admissibility = AdmissibilityResult.PASS if not blocking else AdmissibilityResult.BLOCKED
+    return MaCrossoverV1AdmissibilityContractResultV1(
+        admissibility_result=admissibility,
+        blocking_reasons=tuple(sorted(set(blocking))),
+        strategy_id=MA_CROSSOVER_V1_STRATEGY_ID,
+        strategy_version=MA_CROSSOVER_V1_STRATEGY_VERSION,
+        strategy_owner=MA_CROSSOVER_V1_STRATEGY_OWNER,
+        configured_strategy_params=dict(configured),
+        effective_strategy_params=dict(effective),
+        strategy_params_digest=params_digest,
+        evaluation_config_path=rel_path,
+        config_digest=config_digest,
+        config_schema_version=str(cfg.get("config_schema_version", "")),
+        cost_binding_status=cost_status,
+        policy_invariant_result=POLICY_INVARIANT_RESULT,
+        signal_semantics="LONG_OR_FLAT_ONLY_0_1",
+    )

--- a/tests/ops/test_runbook_step29m_registered_strategy_evaluation_fleet_closeout_contract_v0.py
+++ b/tests/ops/test_runbook_step29m_registered_strategy_evaluation_fleet_closeout_contract_v0.py
@@ -59,7 +59,6 @@ def test_registered_strategy_fleet_complete_no_economic_validity_pass() -> None:
         _field_value(section, "STEP29M_REGISTERED_STRATEGY_FLEET_STATUS")
         == "EVALUATION_FLEET_COMPLETE_NO_ECONOMIC_VALIDITY_PASS"
     )
-    assert _field_value(section, "REGISTERED_POLICY_RATIFIED_STRATEGY_COUNT") == "2"
     assert _field_value(section, "COMPLETED_TECHNICALLY_VALID_EVALUATION_COUNT") == "2"
     assert _field_value(section, "ECONOMIC_POLICY_PASS_COUNT") == "0"
     assert _field_value(section, "ECONOMIC_POLICY_FAIL_COUNT") == "2"
@@ -90,15 +89,37 @@ def test_evaluation_execution_complete_without_economic_validity_objective() -> 
     assert _field_value(section, "ECONOMIC_VALIDITY_PROVEN") == "false"
 
 
-def test_no_pending_next_evaluation_candidate() -> None:
+def test_post_ratification_authorized_pending_candidate_exists() -> None:
     section = _step_29m_section(_read_registry())
-    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "none"
-    assert _field_value(section, "NEXT_EVALUATION_CONFIG_STATUS") == (
-        "EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE"
-    )
-    assert _field_value(section, "NEXT_EVALUATION_CONFIG_PATH") == "none"
+    assert _field_value(section, "PRE_RATIFICATION_FLEET_EXHAUSTED") == "true"
+    assert _field_value(section, "POST_RATIFICATION_AUTHORIZED_PENDING_CANDIDATE_EXISTS") == "true"
+    assert _field_value(section, "HISTORICAL_FLEET_RESULTS_UNCHANGED") == "true"
+    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "ma_crossover"
+    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_VERSION") == "v1"
+    assert _field_value(section, "NEXT_EVALUATION_CONFIG_STATUS") == "AUTHORIZED_PENDING_EVALUATION"
+    assert _field_value(section, "AUTHORIZED_PENDING_EVALUATION_COUNT") == "1"
     assert _field_value(section, "LAST_EVALUATED_STRATEGY_ID") == "breakout_donchian"
     assert _field_value(section, "LAST_EVALUATED_CONFIG_VERSION") == "v1"
+
+
+def test_historical_fleet_results_unchanged_after_ratification() -> None:
+    section = _step_29m_section(_read_registry())
+    assert (
+        _field_value(section, "STEP29M_REGISTERED_STRATEGY_FLEET_STATUS")
+        == "EVALUATION_FLEET_COMPLETE_NO_ECONOMIC_VALIDITY_PASS"
+    )
+    assert _field_value(section, "REGISTERED_POLICY_RATIFIED_STRATEGY_COUNT") == "3"
+    assert _field_value(section, "COMPLETED_TECHNICALLY_VALID_EVALUATION_COUNT") == "2"
+    assert _field_value(section, "ECONOMIC_POLICY_PASS_COUNT") == "0"
+    assert _field_value(section, "ECONOMIC_POLICY_FAIL_COUNT") == "2"
+    assert _field_value(section, "PROMOTION_ELIGIBLE_COUNT") == "0"
+
+
+def test_post_ratification_next_canonical_step_preflight_read_only() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "NEXT_CANONICAL_STEP") == (
+        "BOUNDED_STEP29M_MA_CROSSOVER_V1_REAL_ADMISSIBLE_FUTURES_ECONOMIC_EVALUATION_PREFLIGHT_READ_ONLY_V0"
+    )
 
 
 def test_fleet_evidence_refs_bound() -> None:
@@ -111,13 +132,6 @@ def test_fleet_evidence_refs_bound() -> None:
     )
     assert str(FLEET_ANALYSIS_EVIDENCE) in _field_value(
         section, "FLEET_ROOT_CAUSE_AND_RANKING_EVIDENCE_REF"
-    )
-
-
-def test_post_fleet_next_canonical_step_read_only_decision() -> None:
-    section = _step_29m_section(_read_registry())
-    assert _field_value(section, "NEXT_CANONICAL_STEP") == (
-        "BOUNDED_STEP29M_POST_FLEET_NO_PASS_CANONICAL_DECISION_READ_ONLY_V0"
     )
 
 

--- a/tests/ops/test_step29m_breakout_donchian_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/tests/ops/test_step29m_breakout_donchian_v1_economic_evaluation_admissibility_contract_v1.py
@@ -189,10 +189,6 @@ def test_progress_registry_ratified_policy_fields() -> None:
     section = _step_29m_section(PROGRESS_REGISTRY.read_text(encoding="utf-8"))
     assert _field_value(section, "OPERATOR_POLICY_DECISION") == "RATIFIED"
     assert _field_value(section, "OPERATOR_POLICY_DECISION_OWNER") == "Frank Rauter"
-    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "none"
-    assert _field_value(section, "NEXT_EVALUATION_CONFIG_STATUS") == (
-        "EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE"
-    )
     assert _field_value(section, "BREAKOUT_DONCHIAN_LOOKBACK") == "20"
     assert _field_value(section, "BREAKOUT_DONCHIAN_PRICE_COL") == "close"
     assert _field_value(section, "BREAKOUT_DONCHIAN_RISK_PER_TRADE") == "0.005"

--- a/tests/ops/test_step29m_breakout_donchian_v1_economic_evaluation_registry_contract_v1.py
+++ b/tests/ops/test_step29m_breakout_donchian_v1_economic_evaluation_registry_contract_v1.py
@@ -73,13 +73,10 @@ def test_breakout_config_digest_stable() -> None:
     assert sizing["config_digest"] == compute_sizing_contract_digest_v1(contract)
 
 
-def test_breakout_fleet_evaluation_complete_no_pending_next_candidate() -> None:
+def test_breakout_fleet_historical_results_unchanged() -> None:
     section = _step_29m_section(_read_registry())
-    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "none"
-    assert _field_value(section, "NEXT_EVALUATION_CONFIG_VERSION") == "none"
-    assert _field_value(section, "NEXT_EVALUATION_CONFIG_STATUS") == (
-        "EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE"
-    )
     assert _field_value(section, "BREAKOUT_DONCHIAN_V1_STATUS") == (
         "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL"
     )
+    assert _field_value(section, "LAST_EVALUATED_STRATEGY_ID") == "breakout_donchian"
+    assert _field_value(section, "HISTORICAL_FLEET_RESULTS_UNCHANGED") == "true"

--- a/tests/ops/test_step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/tests/ops/test_step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1.py
@@ -1,0 +1,211 @@
+"""Contract tests for STEP 29M ma_crossover v1 economic evaluation admissibility v1."""
+
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from src.backtest import (
+    step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1 as contract,
+)
+from src.backtest.strategy_signal_binding_v1 import (
+    StrategySignalBindingError,
+    collect_configured_strategy_params_v1,
+    compute_required_warmup_rows_v1,
+    resolve_effective_strategy_params_v1,
+)
+from src.strategies.registry import get_strategy_registry_entry, resolve_strategy_id
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = (
+    ROOT / "config/ops/step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json"
+)
+PROGRESS_REGISTRY = ROOT / "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+
+
+def _load_config() -> dict:
+    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(
+        rf"\| `{re.escape(field)}` \| `([^`]*)`(?: <!--.*?-->)? \|",
+        text,
+    )
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _step_29m_section(text: str) -> str:
+    start = text.index("#### RUNBOOK_STEP_29M — Economic Viability Evidence v1")
+    end = text.index("#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1", start)
+    return text[start:end]
+
+
+@pytest.fixture
+def cfg() -> dict:
+    return _load_config()
+
+
+def test_ma_crossover_registry_identity() -> None:
+    resolution = resolve_strategy_id("ma_crossover")
+    assert resolution.canonical_strategy_id == "ma_crossover"
+    entry = get_strategy_registry_entry("ma_crossover")
+    assert entry.strategy_version == "v1"
+    assert entry.implementation_ref == contract.MA_CROSSOVER_V1_STRATEGY_OWNER
+    assert entry.futures_compatible is True
+    assert entry.spot_compatible is False
+
+
+def test_config_schema_valid(cfg: dict) -> None:
+    assert (
+        cfg["config_schema_version"]
+        == "step29m_ma_crossover_v1_economic_evaluation_admissibility_v1"
+    )
+    assert cfg["economic_evaluation_v1"]["strategy_id"] == "ma_crossover"
+    assert cfg["economic_evaluation_v1"]["strategy_params"] == {
+        "fast_window": 20,
+        "slow_window": 50,
+        "price_col": "close",
+    }
+
+
+def test_wrong_strategy_id_rejected() -> None:
+    bad = _load_config()
+    bad["economic_evaluation_v1"] = dict(bad["economic_evaluation_v1"])
+    bad["economic_evaluation_v1"]["strategy_id"] = "macd"
+    reasons = contract.verify_ma_crossover_v1_config_schema_v1(bad)
+    assert "config_strategy_id_mismatch" in reasons
+
+
+def test_fast_window_gte_slow_window_rejected() -> None:
+    bad = _load_config()
+    bad["economic_evaluation_v1"] = dict(bad["economic_evaluation_v1"])
+    bad["economic_evaluation_v1"]["strategy_params"] = {
+        "fast_window": 50,
+        "slow_window": 20,
+        "price_col": "close",
+    }
+    reasons = contract.verify_ma_crossover_v1_config_schema_v1(bad)
+    assert "fast_window_not_lt_slow_window" in reasons
+
+
+def test_missing_fast_window_rejected() -> None:
+    bad = _load_config()
+    bad["economic_evaluation_v1"] = dict(bad["economic_evaluation_v1"])
+    bad["economic_evaluation_v1"]["strategy_params"] = {"slow_window": 50, "price_col": "close"}
+    reasons = contract.verify_ma_crossover_v1_config_schema_v1(bad)
+    assert "fast_window_missing" in reasons
+
+
+def test_invalid_price_col_rejected() -> None:
+    bad = _load_config()
+    bad["economic_evaluation_v1"] = dict(bad["economic_evaluation_v1"])
+    bad["economic_evaluation_v1"]["strategy_params"] = {
+        "fast_window": 20,
+        "slow_window": 50,
+        "price_col": "volume",
+    }
+    reasons = contract.verify_ma_crossover_v1_config_schema_v1(bad)
+    assert "price_col_not_allowed" in reasons
+
+
+def test_risk_per_trade_invariant(cfg: dict) -> None:
+    reasons = contract.verify_ma_crossover_v1_sizing_policy_v1(cfg)
+    assert not reasons
+    bad = deepcopy(cfg)
+    bad["offline_evaluation_sizing_contract_v1"] = dict(
+        bad["offline_evaluation_sizing_contract_v1"]
+    )
+    bad["offline_evaluation_sizing_contract_v1"]["risk_per_trade"] = 0.01
+    reasons = contract.verify_ma_crossover_v1_sizing_policy_v1(bad)
+    assert "policy_invariant_violation" in reasons
+
+
+def test_oversize_policy_must_reject_offline_binding(cfg: dict) -> None:
+    assert (
+        cfg["offline_evaluation_sizing_contract_v1"]["oversize_policy"]
+        == contract.OFFLINE_BOUND_OVERSIZE_POLICY
+    )
+
+
+def test_no_btc_or_spot_binding(cfg: dict) -> None:
+    reasons = contract.verify_ma_crossover_v1_instrument_binding_v1(cfg)
+    assert not reasons
+    bad = deepcopy(cfg)
+    bad["real_admissible_futures_evaluation_binding_v1"] = dict(
+        bad["real_admissible_futures_evaluation_binding_v1"]
+    )
+    bad["real_admissible_futures_evaluation_binding_v1"]["native_instrument_id"] = "BTC-USDT-SWAP"
+    reasons = contract.verify_ma_crossover_v1_instrument_binding_v1(bad)
+    assert any("forbidden_instrument_binding" in r for r in reasons)
+
+
+def test_ratification_authority_blocked_in_slice(cfg: dict) -> None:
+    reasons = contract.verify_ma_crossover_v1_ratification_authority_v1(cfg)
+    assert not reasons
+    bad = deepcopy(cfg)
+    bad["step29m_policy_ratification_v1"] = dict(bad["step29m_policy_ratification_v1"])
+    bad["step29m_policy_ratification_v1"]["evaluation_authorized"] = True
+    reasons = contract.verify_ma_crossover_v1_ratification_authority_v1(bad)
+    assert "evaluation_authorized_not_false" in reasons
+
+
+def test_realistic_cost_fields_present(cfg: dict) -> None:
+    status, reasons = contract.verify_cost_binding_v1(cfg)
+    assert status == "PASS"
+    assert not reasons
+
+
+def test_warmup_for_slow_window_50() -> None:
+    effective, _ = resolve_effective_strategy_params_v1(
+        "ma_crossover",
+        {"fast_window": 20, "slow_window": 50},
+    )
+    assert compute_required_warmup_rows_v1("ma_crossover", effective) == 50
+
+
+def test_unknown_strategy_param_fail_closed() -> None:
+    with pytest.raises(StrategySignalBindingError, match="unknown_strategy_param"):
+        resolve_effective_strategy_params_v1("ma_crossover", {"lookback": 12})
+
+
+def test_full_admissibility_contract_passes() -> None:
+    result = contract.evaluate_ma_crossover_v1_admissibility_contract_v1(repo_root=ROOT)
+    assert result.admissibility_result.value == "PASS", result.blocking_reasons
+    assert result.cost_binding_status == "PASS"
+    assert result.policy_invariant_result == contract.POLICY_INVARIANT_RESULT
+    assert result.signal_semantics == "LONG_OR_FLAT_ONLY_0_1"
+
+
+def test_progress_registry_ratified_pending_evaluation_fields() -> None:
+    section = _step_29m_section(PROGRESS_REGISTRY.read_text(encoding="utf-8"))
+    assert _field_value(section, "MA_CROSSOVER_V1_POLICY_RATIFIED") == "true"
+    assert _field_value(section, "MA_CROSSOVER_V1_FIXED_CONFIG_BOUND") == "true"
+    assert _field_value(section, "MA_CROSSOVER_V1_ECONOMIC_EVALUATION_EXECUTED") == "false"
+    assert _field_value(section, "MA_CROSSOVER_V1_STATUS") == "AUTHORIZED_PENDING_EVALUATION"
+    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "ma_crossover"
+    assert _field_value(section, "NEXT_EVALUATION_CONFIG_STATUS") == "AUTHORIZED_PENDING_EVALUATION"
+    assert _field_value(section, "AUTHORIZED_PENDING_EVALUATION_COUNT") == "1"
+    assert _field_value(section, "MACD_V1_CONFIG_V3_STATUS") == (
+        "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL"
+    )
+    assert _field_value(section, "BREAKOUT_DONCHIAN_V1_STATUS") == (
+        "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL"
+    )
+    assert _field_value(section, "ECONOMIC_EVALUATION_ALLOWED") == "false"
+    assert _field_value(section, "PROMOTION_ALLOWED") == "false"
+
+
+def test_config_params_from_evaluation_section(cfg: dict) -> None:
+    configured = collect_configured_strategy_params_v1(cfg, "ma_crossover")
+    effective, _ = resolve_effective_strategy_params_v1(
+        "ma_crossover",
+        contract._window_params_for_binding_v1(configured),
+    )
+    assert effective == {"fast_window": 20, "slow_window": 50}
+    assert configured["price_col"] == "close"

--- a/tests/ops/test_step29m_ma_crossover_v1_economic_evaluation_config_contract_v1.py
+++ b/tests/ops/test_step29m_ma_crossover_v1_economic_evaluation_config_contract_v1.py
@@ -1,0 +1,125 @@
+"""Config contract for STEP 29M ma_crossover v1 economic evaluation config v1."""
+
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from pathlib import Path
+
+from src.backtest import (
+    step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1 as contract,
+)
+from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 import (
+    compute_evaluation_config_digest_v1,
+)
+from src.backtest.offline_evaluation_sizing_contract_v1 import (
+    compute_sizing_contract_digest_v1,
+    load_offline_evaluation_sizing_contract_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROGRESS_REGISTRY = REPO_ROOT / "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+MA_CROSSOVER_CONFIG = REPO_ROOT / contract.DEFAULT_EVALUATION_CONFIG_PATH
+RANK1_EVIDENCE = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "planning/bounded_step29m_additional_existing_strategy_policy_ratification_candidate_decision_read_only_v0_20260702T010015Z"
+)
+
+
+def _read_registry() -> str:
+    assert PROGRESS_REGISTRY.is_file()
+    return PROGRESS_REGISTRY.read_text(encoding="utf-8")
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(
+        rf"\| `{re.escape(field)}` \| `([^`]*)`(?: <!--.*?-->)? \|",
+        text,
+    )
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _step_29m_section(text: str) -> str:
+    start = text.index("#### RUNBOOK_STEP_29M — Economic Viability Evidence v1")
+    end = text.index("#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1", start)
+    return text[start:end]
+
+
+def test_ma_crossover_config_registered_in_canonical_registry() -> None:
+    registry = contract.list_step29m_registered_economic_evaluation_configs_v1()
+    assert contract.DEFAULT_EVALUATION_CONFIG_PATH in registry
+    assert MA_CROSSOVER_CONFIG.is_file()
+
+
+def test_ma_crossover_config_path_bound_in_progress_registry() -> None:
+    section = _step_29m_section(_read_registry())
+    registered = _field_value(section, "STEP29M_REGISTERED_ECONOMIC_EVALUATION_CONFIGS").replace(
+        "&#47;", "/"
+    )
+    assert contract.DEFAULT_EVALUATION_CONFIG_PATH in registered.split(",")
+    assert _field_value(section, "NEXT_EVALUATION_CONFIG_PATH").replace("&#47;", "/") == (
+        contract.DEFAULT_EVALUATION_CONFIG_PATH
+    )
+
+
+def test_ma_crossover_config_digest_stable() -> None:
+    cfg = json.loads(MA_CROSSOVER_CONFIG.read_text(encoding="utf-8"))
+    digest = compute_evaluation_config_digest_v1(cfg)
+    assert len(digest) == 64
+    assert digest == compute_evaluation_config_digest_v1(
+        json.loads(MA_CROSSOVER_CONFIG.read_text(encoding="utf-8"))
+    )
+    sizing = cfg["offline_evaluation_sizing_contract_v1"]
+    sizing_contract = load_offline_evaluation_sizing_contract_v1(
+        cfg,
+        strategy_params_digest=sizing["strategy_params_digest"],
+        dataset_digest=sizing["dataset_digest"],
+    )
+    assert sizing["config_digest"] == compute_sizing_contract_digest_v1(sizing_contract)
+
+
+def test_ma_crossover_ratification_config_flags_explicit() -> None:
+    cfg = json.loads(MA_CROSSOVER_CONFIG.read_text(encoding="utf-8"))
+    ratification = cfg["step29m_policy_ratification_v1"]
+    assert ratification["evaluation_authorized"] is False
+    assert ratification["promotion_authorized"] is False
+    assert ratification["runtime_authorized"] is False
+    assert ratification["parameter_tuning_allowed"] is False
+    assert ratification["threshold_tuning_allowed"] is False
+    assert ratification["dataset_replacement_allowed"] is False
+
+
+def test_changed_economic_policy_rejected() -> None:
+    bad = json.loads(MA_CROSSOVER_CONFIG.read_text(encoding="utf-8"))
+    bad["economic_evaluation_v1"] = dict(bad["economic_evaluation_v1"])
+    bad["economic_evaluation_v1"]["economic_validity_policy_version"] = (
+        "economic_validity_policy_v2"
+    )
+    reasons = contract.verify_ma_crossover_v1_config_schema_v1(bad)
+    assert "economic_validity_policy_version_mismatch" in reasons
+
+
+def test_conflicting_sizing_values_rejected() -> None:
+    bad = deepcopy(json.loads(MA_CROSSOVER_CONFIG.read_text(encoding="utf-8")))
+    bad["offline_evaluation_sizing_contract_v1"] = dict(
+        bad["offline_evaluation_sizing_contract_v1"]
+    )
+    bad["offline_evaluation_sizing_contract_v1"]["stop_pct"] = 0.02
+    reasons = contract.verify_ma_crossover_v1_sizing_policy_v1(bad)
+    assert "stop_pct_not_ratified" in reasons
+
+
+def test_rank1_evidence_ref_bound_in_registry() -> None:
+    section = _step_29m_section(_read_registry())
+    assert str(RANK1_EVIDENCE) in _field_value(
+        section, "MA_CROSSOVER_V1_RANK1_CANDIDATE_EVIDENCE_REF"
+    )
+
+
+def test_next_canonical_step_preflight_read_only() -> None:
+    section = _step_29m_section(_read_registry())
+    assert _field_value(section, "NEXT_CANONICAL_STEP") == (
+        "BOUNDED_STEP29M_MA_CROSSOVER_V1_REAL_ADMISSIBLE_FUTURES_ECONOMIC_EVALUATION_PREFLIGHT_READ_ONLY_V0"
+    )

--- a/tests/ops/test_step29m_macd_v1_real_economic_evaluation_registry_contract_v1.py
+++ b/tests/ops/test_step29m_macd_v1_real_economic_evaluation_registry_contract_v1.py
@@ -81,16 +81,13 @@ def test_macd_v1_real_evaluation_evidence_ref_bound() -> None:
     assert str(V2_EVIDENCE_DIR) in _field_value(section, "INVALIDATED_V2_EVALUATION_REF")
 
 
-def test_macd_v1_v3_policy_registry_ratified_and_fleet_complete() -> None:
+def test_macd_v1_v3_policy_registry_ratified_and_historical_fleet_unchanged() -> None:
     section = _step_29m_section(_read_registry())
     assert _field_value(section, "OPERATOR_POLICY_DECISION") == "RATIFIED"
     assert _field_value(section, "POLICY_INVARIANT") == (
         "risk_per_trade <= max_position_pct * stop_pct"
     )
-    assert _field_value(section, "NEXT_EVALUATION_STRATEGY_ID") == "none"
-    assert _field_value(section, "NEXT_EVALUATION_CONFIG_STATUS") == (
-        "EVALUATION_FLEET_COMPLETE_NO_PENDING_CANDIDATE"
-    )
+    assert _field_value(section, "HISTORICAL_FLEET_RESULTS_UNCHANGED") == "true"
     assert _field_value(section, "ECONOMIC_REEVALUATION_ALLOWED") == "false"
     assert _field_value(section, "PROFITABILITY_CLAIM_ALLOWED") == "false"
     assert _field_value(section, "V2_CONFIG_DISPOSITION") == (


### PR DESCRIPTION
## Summary

- **Scope / GO_TOKEN:** `GO_BOUNDED_STEP29M_MA_CROSSOVER_FIXED_CONFIG_POLICY_RATIFICATION_V0`
- Ratifies **ma_crossover v1** as the sole admissible Rank-1 pending STEP29M evaluation candidate on **inst-eth-usdt-perp** (OKX futures-only)
- Fixed parameters: `fast_window=20`, `slow_window=50`, `price_col=close`
- Unchanged **economic_validity_policy_v1**, dataset binding, fee/slippage/funding/execution model owners
- Sizing / RiskLimits provenance: **MACD v3 post–RiskLimits-rewire fleet precedent** (`risk_per_trade=0.005`, `stop_pct=0.025`, `max_position_pct=0.25`, `REJECT_OVERSIZE`)

## Safety boundaries (this slice)

- `PRODUCTIVE_RUNNER_INVOCATIONS=0`
- `ECONOMIC_EVALUATION_EXECUTED=false`
- `PROFITABILITY_CLAIM_ALLOWED=false`
- `STEP29N_AUTHORIZED=false`
- `STEP29R_AUTHORIZED=false`
- `RUNTIME_EFFECT=false`
- `ORDER_EFFECT=false`

## Tests / CI

- New ops contract tests for admissibility + config registry
- Updated fleet-closeout + MACD/Breakout registry regression tests
- Local focused gate: 82 tests passed
- CI selector (canonical): `PR_BOUNDED_FULL` (`category_central_src_requires_full`) — not manually downgraded

## Reuse-drift guard

No new registry, loader, signal-binding, sizing, RiskLimits, operator-input, economic-policy, promotion-gate, or evaluation-runner owners.

## Durable evidence

Input bundles (MANIFEST_VERIFY_RC=0):
- `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_step29m_no_pass_operator_policy_decision_preparation_v0_20260702T000002Z`
- `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_step29m_additional_existing_strategy_policy_ratification_candidate_decision_read_only_v0_20260702T010015Z`

Implementation bundle will be written at merge closeout under `implementation/bounded_step29m_ma_crossover_fixed_config_policy_ratification_v0_*`.

## Test plan

- [x] `test_step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1.py`
- [x] `test_step29m_ma_crossover_v1_economic_evaluation_config_contract_v1.py`
- [x] Fleet closeout + MACD/Breakout registry regressions
- [x] `test_strategy_signal_binding_v1.py`
- [x] ruff format/check on changed Python files

Made with [Cursor](https://cursor.com)