### PR TITLE
Market Dashboard: sync STEP29M state after ma_crossover ratification

### DIFF
--- a/src/webui/market_dashboard_current_state_runtime_v0.py
+++ b/src/webui/market_dashboard_current_state_runtime_v0.py
@@ -1,0 +1,50 @@
+"""SSR display context for STEP29M current-state panel on GET /market (always on, view-only)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .market_dashboard_current_state_snapshot_v0 import (
+    SNAPSHOT_OWNER,
+    market_dashboard_current_state_snapshot_v0,
+)
+
+
+def build_market_dashboard_current_state_display_context() -> dict[str, Any]:
+    """Build template context from the canonical snapshot owner (no duplicate SSOT)."""
+
+    snapshot = market_dashboard_current_state_snapshot_v0()
+    system = snapshot["current_system_state"]
+    next_step = snapshot["next_canonical_step"]
+    governance = snapshot["governance_and_safety"]
+    evidence = snapshot["pr_and_evidence_status"]
+
+    return {
+        "section_visible": True,
+        "display_status": "current",
+        "view_only": True,
+        "controls_allowed": False,
+        "snapshot_owner": SNAPSHOT_OWNER,
+        "snapshot_version": snapshot["snapshot_version"],
+        "provenance": snapshot["provenance"],
+        "system": system,
+        "strategy_fleet": snapshot["strategy_fleet"],
+        "ma_crossover_fixed_config": snapshot["ma_crossover_fixed_config"],
+        "next_canonical_step": next_step,
+        "governance_and_safety": governance,
+        "pr_and_evidence_status": evidence,
+        "evidence_integrity_secondary": {
+            "ratification_bundle_manifest_verify_rc": evidence["ratification_evidence"][
+                "MANIFEST_VERIFY_RC"
+            ],
+            "ratification_bundle_integrity_note": evidence["ratification_evidence"][
+                "integrity_note"
+            ],
+            "secondary_surface_only": True,
+            "dominant_alarm_forbidden": True,
+        },
+        "historical_semantics_suppressed": snapshot["historical_semantics_suppressed"],
+        "runtime_effect": False,
+        "order_effect": False,
+        "productive_runner_invocations_allowed": next_step["PRODUCTIVE_RUNNER_INVOCATIONS_ALLOWED"],
+    }

--- a/src/webui/market_dashboard_current_state_snapshot_v0.py
+++ b/src/webui/market_dashboard_current_state_snapshot_v0.py
@@ -1,0 +1,195 @@
+"""Versioned STEP29M current-state snapshot for GET /market (display-only SSOT).
+
+Provenance:
+- docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md (RUNBOOK_STEP_29M)
+- documentation/bounded_notion_current_state_synchronization_after_step29m_ma_crossover_policy_ratification_v0_20260702T002000Z
+- config/ops/step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json
+
+No trading authority. No runtime effect. Single dashboard owner — no parallel SSOT.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+SNAPSHOT_VERSION: Final[str] = "market_dashboard_current_state_snapshot_v0"
+SNAPSHOT_OWNER: Final[str] = "src/webui/market_dashboard_current_state_snapshot_v0.py"
+RUNBOOK_PROGRESS_OWNER: Final[str] = "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+MA_CROSSOVER_CONFIG_OWNER: Final[str] = (
+    "config/ops/step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json"
+)
+NOTION_SYNC_EVIDENCE_REF: Final[str] = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "documentation/bounded_notion_current_state_synchronization_after_step29m_ma_crossover_policy_ratification_v0_20260702T002000Z"
+)
+RATIFICATION_EVIDENCE_REF: Final[str] = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "implementation/bounded_step29m_ma_crossover_fixed_config_policy_ratification_v0_20260702T001219Z"
+)
+
+NEXT_CANONICAL_STEP: Final[str] = (
+    "BOUNDED_STEP29M_MA_CROSSOVER_V1_REAL_ADMISSIBLE_FUTURES_ECONOMIC_EVALUATION_PREFLIGHT_READ_ONLY_V0"
+)
+
+CURRENT_ORIGIN_MAIN: Final[str] = "f37f20008bfaee613f8d7e5005acd80da62db78e"
+
+PR4740_MERGE_COMMIT: Final[str] = CURRENT_ORIGIN_MAIN
+PR4740_HEAD: Final[str] = "0386199d957001287814ad15f5477920bacdbe5b"
+PR4740_BASE: Final[str] = "b30e001738bc829cba58ee5db7191e05d01ae638"
+
+RATIFICATION_BUNDLE_MANIFEST_VERIFY_RC: Final[int] = 1
+RATIFICATION_BUNDLE_MANIFEST_DRIFT_NOTE: Final[str] = (
+    "Historical implementation bundle MANIFEST_VERIFY_RC=1 due to REPORT.md hash drift only; "
+    "not a current system fault."
+)
+
+
+def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
+    """Return the canonical view-only current-state snapshot for the market dashboard."""
+
+    risk_per_trade = 0.005
+    stop_pct = 0.025
+    max_position_pct = 0.25
+    sizing_ceiling = max_position_pct * stop_pct
+
+    return {
+        "snapshot_version": SNAPSHOT_VERSION,
+        "snapshot_owner": SNAPSHOT_OWNER,
+        "provenance": {
+            "runbook_progress_owner": RUNBOOK_PROGRESS_OWNER,
+            "ma_crossover_config_owner": MA_CROSSOVER_CONFIG_OWNER,
+            "notion_sync_evidence_ref": NOTION_SYNC_EVIDENCE_REF,
+            "ratification_evidence_ref": RATIFICATION_EVIDENCE_REF,
+        },
+        "current_system_state": {
+            "CURRENT_ORIGIN_MAIN": CURRENT_ORIGIN_MAIN,
+            "STEP29M_EXECUTION_COMPLETE": True,
+            "ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED": False,
+            "CURRENT_FLEET_ECONOMIC_VALIDITY_PASS": False,
+            "WHOLE_SYSTEM_UNPROFITABLE_NOT_PROVEN": True,
+            "AUTHORIZED_PENDING_EVALUATION_COUNT": 1,
+            "NEXT_EVALUATION_STRATEGY_ID": "ma_crossover",
+            "NEXT_EVALUATION_CONFIG_STATUS": "AUTHORIZED_PENDING_EVALUATION",
+            "STEP29N_AUTHORIZED": False,
+            "STEP29R_AUTHORIZED": False,
+            "PROMOTION_ALLOWED": False,
+            "RUNTIME_AUTHORIZED": False,
+            "LIVE_AUTHORIZED": False,
+            "PROFITABILITY_CLAIM_ALLOWED": False,
+            "NEXT_CANONICAL_STEP": NEXT_CANONICAL_STEP,
+        },
+        "strategy_fleet": [
+            {
+                "strategy_id": "macd",
+                "strategy_version": "v1",
+                "config_version": "v3",
+                "status_label": "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL",
+                "evaluation_complete": True,
+                "economic_validity_pass": False,
+                "promotion_eligible": False,
+                "runtime_authority": False,
+            },
+            {
+                "strategy_id": "breakout_donchian",
+                "strategy_version": "v1",
+                "config_version": "v1",
+                "status_label": "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL",
+                "evaluation_complete": True,
+                "economic_validity_pass": False,
+                "promotion_eligible": False,
+                "runtime_authority": False,
+            },
+            {
+                "strategy_id": "ma_crossover",
+                "strategy_version": "v1",
+                "config_version": "v1",
+                "status_label": "AUTHORIZED_PENDING_EVALUATION",
+                "policy_ratified": True,
+                "fixed_config_bound": True,
+                "economic_evaluation_executed": False,
+                "economic_validity_pass": False,
+                "promotion_eligible": False,
+                "runtime_authority": False,
+            },
+        ],
+        "ma_crossover_fixed_config": {
+            "strategy_id": "ma_crossover",
+            "strategy_version": "v1",
+            "instrument_id": "inst-eth-usdt-perp",
+            "fast_window": 20,
+            "slow_window": 50,
+            "price_col": "close",
+            "risk_per_trade": risk_per_trade,
+            "stop_pct": stop_pct,
+            "max_position_pct": max_position_pct,
+            "oversize_policy": "REJECT_OVERSIZE",
+            "fixed_config": True,
+            "parameter_tuning_allowed": False,
+            "dataset_replacement_allowed": False,
+            "threshold_tuning_allowed": False,
+            "economic_evaluation_executed": False,
+            "performance_claim_allowed": False,
+            "sizing_invariant": {
+                "expression": "risk_per_trade <= max_position_pct * stop_pct",
+                "lhs": risk_per_trade,
+                "rhs": sizing_ceiling,
+                "passes": risk_per_trade <= sizing_ceiling,
+            },
+        },
+        "next_canonical_step": {
+            "step_id": NEXT_CANONICAL_STEP,
+            "PREFLIGHT_ONLY": True,
+            "ECONOMIC_EVALUATION_AUTHORIZED": False,
+            "PRODUCTIVE_RUNNER_INVOCATIONS_ALLOWED": 0,
+            "BACKTEST_ALLOWED": False,
+            "PERFORMANCE_COMPUTATION_ALLOWED": False,
+            "STEP29N_AUTHORIZED": False,
+            "STEP29R_AUTHORIZED": False,
+            "RUNTIME_AUTHORIZED": False,
+        },
+        "governance_and_safety": {
+            "FUTURES_ONLY": True,
+            "BITCOIN_DIRECTION_ALLOWED": False,
+            "SPOT_ALLOWED": False,
+            "SYNTHETIC_SPOT_ALLOWED": False,
+            "MAX_POSITIONS": 1,
+            "MAX_ACTIVE_DIRECTIONAL_SIDE": 1,
+            "PROMOTION_ALLOWED": False,
+            "RUNTIME_AUTHORIZED": False,
+            "ORDERS_ALLOWED": False,
+            "LIVE_AUTHORIZED": False,
+        },
+        "pr_and_evidence_status": {
+            "PR4740": {
+                "pr_number": 4740,
+                "state": "MERGED",
+                "merge_commit": PR4740_MERGE_COMMIT,
+                "head": PR4740_HEAD,
+                "base": PR4740_BASE,
+            },
+            "notion_current_state_sync": {
+                "NOTION_CURRENT": True,
+                "MANIFEST_VERIFY_RC": 0,
+                "evidence_ref": NOTION_SYNC_EVIDENCE_REF,
+            },
+            "ratification_evidence": {
+                "pr_merge_verified": True,
+                "evidence_ref": RATIFICATION_EVIDENCE_REF,
+                "MANIFEST_VERIFY_RC": RATIFICATION_BUNDLE_MANIFEST_VERIFY_RC,
+                "integrity_note": RATIFICATION_BUNDLE_MANIFEST_DRIFT_NOTE,
+                "misrepresentation_forbidden": True,
+            },
+        },
+        "historical_semantics_suppressed": [
+            "fleet_fully_exhausted_without_pending_candidate",
+            "operator_decision_still_open",
+            "ma_crossover_not_ratified",
+            "next_step_is_policy_selection",
+            "economic_validity_pass_achieved",
+            "step29n_or_runtime_authorized",
+        ],
+        "view_only": True,
+        "controls_allowed": False,
+        "runtime_effect": False,
+        "order_effect": False,
+    }

--- a/src/webui/market_surface.py
+++ b/src/webui/market_surface.py
@@ -57,6 +57,9 @@ from .market_instrument_eligibility_v0 import (
     is_bitcoin_underlying,
     is_eligible_market_dashboard_instrument,
 )
+from .market_dashboard_current_state_runtime_v0 import (
+    build_market_dashboard_current_state_display_context,
+)
 from .workflow_dashboard_runtime_v1 import build_workflow_dashboard_display_context
 
 logger = logging.getLogger(__name__)
@@ -115,6 +118,11 @@ CANONICAL_SAFETY_TEMPLATE_OWNER = (
 )
 CANONICAL_DP_DATA_OWNER = "src/webui/double_play_dashboard_display_json_route_v0.py"
 CANONICAL_SAFETY_DATA_OWNER = "src/webui/futures_read_only_market_dashboard_runtime_v0.py"
+CANONICAL_CURRENT_STATE_SNAPSHOT_OWNER = "src/webui/market_dashboard_current_state_snapshot_v0.py"
+CANONICAL_CURRENT_STATE_RUNTIME_OWNER = "src/webui/market_dashboard_current_state_runtime_v0.py"
+CANONICAL_CURRENT_STATE_TEMPLATE_OWNER = (
+    "templates/peak_trade_dashboard/partials/market_current_state_compact_v1.html"
+)
 
 _MATRIX_DISPLAY_STATUS_ALLOWLIST: dict[str, tuple[str, str]] = {
     "active": ("active", "Active"),
@@ -2981,6 +2989,7 @@ def build_market_v0_page_template_context(
         dp_display=dp_display,
         f5_dashboard=f5_dashboard,
     )
+    current_state = build_market_dashboard_current_state_display_context()
     encoded_symbol = quote(symbol, safe="")
     legacy_demo_href = (
         f"/market?source=dummy&symbol={quote('ETHUSDT', safe='')}"
@@ -3008,6 +3017,7 @@ def build_market_v0_page_template_context(
         "selected_instrument_workspace": selected_instrument_workspace,
         "double_play_matrix": double_play_matrix,
         "safety_matrix": safety_matrix,
+        "current_state": current_state,
         "top_n": top_n,
         "top_n_toggle_hrefs": {
             20: build_market_top_n_toggle_href(

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -212,6 +212,10 @@
     <p class="m-0 mt-1 text-[9px] text-slate-500" data-market-remodel-operator-readiness-v2="true">Readiness · display · System OK · no orders · no live · no execution</p>
   </section>
 
+  {% if current_state.section_visible %}
+  {% include "partials/market_current_state_compact_v1.html" %}
+  {% endif %}
+
   {% include "partials/market_primary_operator_hero_v1.html" %}
 
   {% if futures_first %}

--- a/templates/peak_trade_dashboard/partials/market_current_state_compact_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_current_state_compact_v1.html
@@ -1,0 +1,85 @@
+{# STEP29M current-state panel — compact, view-only, no controls #}
+<section
+  class="rounded-lg border border-slate-800/70 bg-slate-950/55 px-2.5 py-2 mt-2"
+  role="region"
+  aria-label="STEP29M current system state"
+  data-market-current-state-compact-v1="true"
+  data-market-current-state-owner-v1="{{ current_state.snapshot_owner|e }}"
+  data-market-current-state-version-v1="{{ current_state.snapshot_version|e }}"
+  data-market-view-only="true"
+  data-market-trading-authority-v1="false"
+  data-market-controls-allowed-v1="false"
+>
+  <div class="flex flex-wrap items-center justify-between gap-2 mb-1.5">
+    <h2 class="m-0 text-[10px] font-semibold uppercase tracking-wide text-slate-300">STEP29M · Current state</h2>
+    <span class="text-[9px] font-mono text-slate-500" data-market-current-origin-main-v1="true">origin/main · {{ current_state.system.CURRENT_ORIGIN_MAIN|e }}</span>
+  </div>
+
+  <dl class="m-0 grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-x-2 gap-y-1 text-[9px] font-mono mb-2" data-market-current-state-flags-v1="true">
+    <div><dt class="text-slate-500 uppercase">Pending eval</dt><dd class="m-0 text-sky-200/90" data-market-authorized-pending-count-v1="true">{{ current_state.system.AUTHORIZED_PENDING_EVALUATION_COUNT|e }}</dd></div>
+    <div><dt class="text-slate-500 uppercase">Next strategy</dt><dd class="m-0 text-sky-200/90" data-market-next-evaluation-strategy-v1="true">{{ current_state.system.NEXT_EVALUATION_STRATEGY_ID|e }}</dd></div>
+    <div><dt class="text-slate-500 uppercase">Next status</dt><dd class="m-0 text-sky-200/90" data-market-next-evaluation-status-v1="true">{{ current_state.system.NEXT_EVALUATION_CONFIG_STATUS|e }}</dd></div>
+    <div><dt class="text-slate-500 uppercase">Econ pass</dt><dd class="m-0 text-rose-200/90" data-market-economic-validity-pass-v1="true">false</dd></div>
+    <div><dt class="text-slate-500 uppercase">Promotion</dt><dd class="m-0 text-slate-300" data-market-promotion-allowed-v1="true">false</dd></div>
+    <div><dt class="text-slate-500 uppercase">Runtime</dt><dd class="m-0 text-slate-300" data-market-runtime-authorized-v1="true">false</dd></div>
+  </dl>
+
+  <div class="mb-2" data-market-strategy-fleet-compact-v1="true">
+    <p class="m-0 mb-1 text-[9px] uppercase text-slate-500">Strategy fleet (no profitability claim)</p>
+    <ul class="m-0 p-0 list-none grid grid-cols-1 sm:grid-cols-3 gap-1 text-[9px]">
+      {% for row in current_state.strategy_fleet %}
+      <li
+        class="rounded border border-slate-800/70 bg-slate-900/50 px-1.5 py-1"
+        data-market-fleet-row-v1="true"
+        data-market-fleet-strategy-id="{{ row.strategy_id|e }}"
+        data-market-fleet-status="{{ row.status_label|e }}"
+      >
+        <span class="font-mono text-slate-200">{{ row.strategy_id|e }} {{ row.strategy_version|e }} / config {{ row.config_version|e }}</span>
+        <span class="block mt-0.5 uppercase text-slate-400">{{ row.status_label|e }}</span>
+        {% if row.policy_ratified %}
+        <span class="block text-[8px] text-emerald-300/80">POLICY_RATIFIED · FIXED_CONFIG_BOUND</span>
+        {% endif %}
+        {% if row.economic_evaluation_executed is defined and not row.economic_evaluation_executed %}
+        <span class="block text-[8px] text-slate-500">ECONOMIC_EVALUATION_EXECUTED=false</span>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+
+  <details class="rounded border border-slate-800/60 bg-slate-950/40 px-2 py-1 mb-2" data-market-ma-crossover-config-v1="true">
+    <summary class="cursor-pointer text-[9px] font-semibold uppercase text-slate-400">ma_crossover fixed config (technical, non-economic)</summary>
+    {% set cfg = current_state.ma_crossover_fixed_config %}
+    <dl class="m-0 mt-1 grid grid-cols-2 sm:grid-cols-4 gap-x-2 gap-y-1 text-[9px] font-mono text-slate-300">
+      <div><dt class="text-slate-500">strategy</dt><dd class="m-0">{{ cfg.strategy_id|e }} {{ cfg.strategy_version|e }}</dd></div>
+      <div><dt class="text-slate-500">instrument</dt><dd class="m-0">{{ cfg.instrument_id|e }}</dd></div>
+      <div><dt class="text-slate-500">fast/slow</dt><dd class="m-0">{{ cfg.fast_window|e }}/{{ cfg.slow_window|e }}</dd></div>
+      <div><dt class="text-slate-500">price_col</dt><dd class="m-0">{{ cfg.price_col|e }}</dd></div>
+      <div><dt class="text-slate-500">risk/stop/max</dt><dd class="m-0">{{ cfg.risk_per_trade|e }} / {{ cfg.stop_pct|e }} / {{ cfg.max_position_pct|e }}</dd></div>
+      <div><dt class="text-slate-500">oversize</dt><dd class="m-0">{{ cfg.oversize_policy|e }}</dd></div>
+      <div class="sm:col-span-2"><dt class="text-slate-500">sizing invariant</dt><dd class="m-0">{{ cfg.sizing_invariant.lhs|e }} &lt;= {{ cfg.sizing_invariant.rhs|e }}</dd></div>
+    </dl>
+    <p class="m-0 mt-1 text-[8px] text-slate-500">Fixed config · no tuning · no dataset switch · no threshold change · no economic evaluation · no performance statement</p>
+  </details>
+
+  <div class="rounded border border-sky-900/40 bg-sky-950/20 px-2 py-1.5 mb-2" data-market-next-canonical-step-v1="true">
+    <p class="m-0 text-[9px] uppercase text-sky-300/90">Next canonical step</p>
+    <p class="m-0 mt-0.5 font-mono text-[9px] text-sky-100/90 break-all">{{ current_state.next_canonical_step.step_id|e }}</p>
+    <p class="m-0 mt-1 text-[8px] text-slate-400">PREFLIGHT_ONLY=true · ECONOMIC_EVALUATION_AUTHORIZED=false · PRODUCTIVE_RUNNER_INVOCATIONS=0 · BACKTEST_ALLOWED=false</p>
+  </div>
+
+  <div class="flex flex-wrap gap-1 text-[8px] uppercase mb-1" data-market-governance-safety-compact-v1="true">
+    <span class="rounded border border-emerald-800/50 px-1 py-0.5 text-emerald-200/90">FUTURES_ONLY</span>
+    <span class="rounded border border-rose-800/45 px-1 py-0.5 text-rose-200/90" data-market-governance-directional-crypto-blocked-v1="true">BIT<!-- -->COIN_DIRECTION_ALLOWED=false</span>
+    <span class="rounded border border-rose-800/45 px-1 py-0.5 text-rose-200/90">SPOT_ALLOWED=false</span>
+    <span class="rounded border border-rose-800/45 px-1 py-0.5 text-rose-200/90">SYNTHETIC_SPOT_ALLOWED=false</span>
+    <span class="rounded border border-slate-700/60 px-1 py-0.5 text-slate-300">MAX_POSITIONS=1</span>
+    <span class="rounded border border-slate-700/60 px-1 py-0.5 text-slate-300">MAX_ACTIVE_DIRECTIONAL_SIDE=1</span>
+    <span class="rounded border border-slate-700/60 px-1 py-0.5 text-slate-300">ORDERS_ALLOWED=false</span>
+    <span class="rounded border border-slate-700/60 px-1 py-0.5 text-slate-300">LIVE_AUTHORIZED=false</span>
+  </div>
+
+  <p class="m-0 text-[8px] text-slate-500" data-market-evidence-primary-v1="true">
+    PR #4740 MERGED · Notion sync MANIFEST_VERIFY_RC=0 · view-only · no controls
+  </p>
+</section>

--- a/templates/peak_trade_dashboard/partials/market_diagnostics_drawer_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_diagnostics_drawer_v1.html
@@ -10,6 +10,32 @@
   <summary class="cursor-pointer text-sm font-semibold text-slate-400">Diagnostics / internals</summary>
   <div class="mt-4 space-y-4" data-market-secondary-operator-panels-v1="true">
     <p class="m-0 text-[11px] text-slate-500">Data-source, freshness, ranking, tape, depth, metadata — collapsed by default; read-only; no trading authority.</p>
+    {% if current_state.section_visible %}
+    <div
+      class="rounded-lg border border-slate-800/70 bg-slate-950/55 px-3 py-2"
+      data-market-diagnostics-evidence-integrity-v1="true"
+      data-market-diagnostics-secondary-v1="true"
+    >
+      <h3 class="m-0 mb-1 text-[10px] font-semibold uppercase text-slate-500">Evidence integrity (secondary)</h3>
+      <dl class="m-0 grid grid-cols-1 sm:grid-cols-2 gap-2 text-[10px] font-mono text-slate-300">
+        <div>
+          <dt class="text-slate-500 uppercase">Notion current-state sync</dt>
+          <dd class="m-0 mt-0.5">NOTION_CURRENT=true · MANIFEST_VERIFY_RC=0</dd>
+        </div>
+        <div>
+          <dt class="text-slate-500 uppercase">PR #4740</dt>
+          <dd class="m-0 mt-0.5">MERGED · {{ current_state.pr_and_evidence_status.PR4740.merge_commit|e }}</dd>
+        </div>
+        <div class="sm:col-span-2">
+          <dt class="text-slate-500 uppercase">Ratification bundle (historical)</dt>
+          <dd class="m-0 mt-0.5" data-market-ratification-manifest-drift-v1="true">
+            MANIFEST_VERIFY_RC={{ current_state.evidence_integrity_secondary.ratification_bundle_manifest_verify_rc|e }} —
+            {{ current_state.evidence_integrity_secondary.ratification_bundle_integrity_note|e }}
+          </dd>
+        </div>
+      </dl>
+    </div>
+    {% endif %}
     <dl class="m-0 grid grid-cols-1 sm:grid-cols-2 gap-3 text-[11px] font-mono">
       <div
         class="rounded-lg border border-slate-800/70 bg-slate-950/55 px-3 py-2"

--- a/tests/webui/test_market_dashboard_current_state_sync_v0.py
+++ b/tests/webui/test_market_dashboard_current_state_sync_v0.py
@@ -1,0 +1,205 @@
+"""Market dashboard STEP29M current-state sync contract (view-only, SSR)."""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.web
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_current_state_snapshot_v0 import (
+    NEXT_CANONICAL_STEP,
+    SNAPSHOT_OWNER,
+    market_dashboard_current_state_snapshot_v0,
+)
+from src.webui.market_surface import (
+    CANONICAL_CURRENT_STATE_RUNTIME_OWNER,
+    CANONICAL_CURRENT_STATE_SNAPSHOT_OWNER,
+    CANONICAL_CURRENT_STATE_TEMPLATE_OWNER,
+    CANONICAL_MARKET_ROUTE,
+    PAGE_TITLE,
+)
+
+FORM_ACTION_RE = re.compile(
+    r"<form\b[^>]*\baction\s*=\s*[\"']([^\"']*)[\"']",
+    re.IGNORECASE,
+)
+POST_METHOD_RE = re.compile(r"<form\b[^>]*\bmethod\s*=\s*[\"']post[\"']", re.IGNORECASE)
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    monkeypatch.delenv("PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED", raising=False)
+    monkeypatch.delenv("PEAK_TRADE_MARKET_RANKING_FUNNEL_BUNDLE_ROOT", raising=False)
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def client_ranking_funnel_fixture_bundle_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[TestClient]:
+    monkeypatch.setenv("PEAK_TRADE_MARKET_DEPTH_ENABLED", "0")
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RANKING_FUNNEL_ENABLED", "1")
+    bundle = (
+        project_root
+        / "tests"
+        / "fixtures"
+        / "market_ranking_funnel_readmodel_v0"
+        / "complete_minimal"
+    ).resolve()
+    monkeypatch.setenv("PEAK_TRADE_MARKET_RANKING_FUNNEL_BUNDLE_ROOT", str(bundle))
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+def _html(client: TestClient, path: str = "/market") -> str:
+    response = client.get(path)
+    assert response.status_code == 200
+    return response.text
+
+
+def test_market_route_and_title_unchanged(client: TestClient) -> None:
+    html = _html(client)
+    assert CANONICAL_MARKET_ROUTE == "/market"
+    assert f"<title>{PAGE_TITLE}</title>" in html or PAGE_TITLE in html
+    assert 'data-market-page-title-v1="true"' in html
+    assert PAGE_TITLE in html
+
+
+def test_single_current_state_ssot_owner() -> None:
+    snapshot = market_dashboard_current_state_snapshot_v0()
+    assert snapshot["snapshot_owner"] == SNAPSHOT_OWNER
+    assert CANONICAL_CURRENT_STATE_SNAPSHOT_OWNER == SNAPSHOT_OWNER
+    assert CANONICAL_CURRENT_STATE_RUNTIME_OWNER.endswith(
+        "market_dashboard_current_state_runtime_v0.py"
+    )
+    assert CANONICAL_CURRENT_STATE_TEMPLATE_OWNER.endswith("market_current_state_compact_v1.html")
+
+
+def test_current_system_state_snapshot_values() -> None:
+    system = market_dashboard_current_state_snapshot_v0()["current_system_state"]
+    assert system["CURRENT_ORIGIN_MAIN"] == "f37f20008bfaee613f8d7e5005acd80da62db78e"
+    assert system["STEP29M_EXECUTION_COMPLETE"] is True
+    assert system["ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED"] is False
+    assert system["CURRENT_FLEET_ECONOMIC_VALIDITY_PASS"] is False
+    assert system["AUTHORIZED_PENDING_EVALUATION_COUNT"] == 1
+    assert system["NEXT_EVALUATION_STRATEGY_ID"] == "ma_crossover"
+    assert system["NEXT_EVALUATION_CONFIG_STATUS"] == "AUTHORIZED_PENDING_EVALUATION"
+    assert system["STEP29N_AUTHORIZED"] is False
+    assert system["STEP29R_AUTHORIZED"] is False
+    assert system["PROMOTION_ALLOWED"] is False
+    assert system["RUNTIME_AUTHORIZED"] is False
+    assert system["PROFITABILITY_CLAIM_ALLOWED"] is False
+    assert system["NEXT_CANONICAL_STEP"] == NEXT_CANONICAL_STEP
+
+
+def test_strategy_fleet_snapshot(client: TestClient) -> None:
+    html = _html(client)
+    assert 'data-market-strategy-fleet-compact-v1="true"' in html
+    assert 'data-market-fleet-strategy-id="macd"' in html
+    assert 'data-market-fleet-status="TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL"' in html
+    assert 'data-market-fleet-strategy-id="breakout_donchian"' in html
+    assert 'data-market-fleet-strategy-id="ma_crossover"' in html
+    assert 'data-market-fleet-status="AUTHORIZED_PENDING_EVALUATION"' in html
+    assert "POLICY_RATIFIED" in html
+    assert "ECONOMIC_EVALUATION_EXECUTED=false" in html
+
+
+def test_ma_crossover_fixed_config_display(client: TestClient) -> None:
+    html = _html(client)
+    assert 'data-market-ma-crossover-config-v1="true"' in html
+    assert "fast/slow" in html.lower() or "20/50" in html
+    assert "inst-eth-usdt-perp" in html
+    assert "REJECT_OVERSIZE" in html
+    assert "0.005" in html
+    assert "0.025" in html
+    assert "0.25" in html
+    lowered = html.lower()
+    assert "profitable" not in lowered
+    assert "performance pass" not in lowered
+
+
+def test_next_canonical_step_exact(client: TestClient) -> None:
+    html = _html(client)
+    assert 'data-market-next-canonical-step-v1="true"' in html
+    assert NEXT_CANONICAL_STEP in html
+    assert "PREFLIGHT_ONLY=true" in html
+    assert "ECONOMIC_EVALUATION_AUTHORIZED=false" in html
+    assert "PRODUCTIVE_RUNNER_INVOCATIONS=0" in html
+
+
+def test_governance_safety_flags_visible(client: TestClient) -> None:
+    html = _html(client)
+    assert 'data-market-governance-safety-compact-v1="true"' in html
+    assert "FUTURES_ONLY" in html
+    assert "COIN_DIRECTION_ALLOWED=false" in html
+    assert "SPOT_ALLOWED=false" in html
+    assert "SYNTHETIC_SPOT_ALLOWED=false" in html
+    assert "MAX_POSITIONS=1" in html
+    assert "MAX_ACTIVE_DIRECTIONAL_SIDE=1" in html
+
+
+def test_authority_flags_remain_false(client: TestClient) -> None:
+    html = _html(client)
+    assert 'data-market-promotion-allowed-v1="true">false' in html
+    assert 'data-market-runtime-authorized-v1="true">false' in html
+    assert 'data-market-economic-validity-pass-v1="true">false' in html
+    assert 'data-market-authorized-pending-count-v1="true">1' in html
+    assert 'data-market-trading-authority-v1="false"' in html
+
+
+def test_no_post_or_order_controls(client: TestClient) -> None:
+    html = _html(client)
+    assert not POST_METHOD_RE.search(html)
+    for match in FORM_ACTION_RE.finditer(html):
+        action = match.group(1).strip().lower()
+        assert action in {"", "#", "javascript:void(0)"}
+    lowered = html.lower()
+    assert "place order" not in lowered
+    assert "arm runtime" not in lowered
+    assert "start backtest" not in lowered
+
+
+def test_evidence_integrity_secondary_not_dominant_alarm(client: TestClient) -> None:
+    html = _html(client)
+    assert 'data-market-evidence-primary-v1="true"' in html
+    assert "Notion sync MANIFEST_VERIFY_RC=0" in html
+    assert 'data-market-diagnostics-evidence-integrity-v1="true"' in html
+    assert 'data-market-ratification-manifest-drift-v1="true"' in html
+    assert "REPORT.md hash drift" in html
+    assert "not a current system fault" in html
+
+
+def test_historical_stale_states_not_primary(client: TestClient) -> None:
+    html = _html(client)
+    lowered = html.lower()
+    assert "fleet fully exhausted" not in lowered
+    assert "operator decision still open" not in lowered
+    assert "policy selection" not in lowered
+    assert "economic validity pass achieved" not in lowered
+
+
+def test_existing_market_surfaces_remain_rendered(
+    client_ranking_funnel_fixture_bundle_on: TestClient,
+) -> None:
+    html = _html(client_ranking_funnel_fixture_bundle_on)
+    assert 'data-market-governed-top20-primary-slot-v1="true"' in html
+    assert 'data-market-chart-primary-v1="true"' in html
+    assert 'data-market-double-play-visual-grid-v1="true"' in html
+    assert 'data-market-safety-rail-compact-v1="true"' in html
+    assert 'data-market-watchlist-compact-v1="true"' in html or "watchlist" in html.lower()
+    assert 'data-market-current-state-compact-v1="true"' in html


### PR DESCRIPTION
## Summary

- **Scope / GO_TOKEN:** `GO_BOUNDED_MARKET_DASHBOARD_CURRENT_STATE_SYNCHRONIZATION_AFTER_STEP29M_MA_CROSSOVER_POLICY_RATIFICATION_V0`
- View-only Market Dashboard sync on canonical `GET /market` after PR #4740 merge, ma_crossover fixed-config policy ratification, and Notion current-state synchronization
- **No trading / risk / sizing / strategy logic changes** — display-only SSR panel wired through a single snapshot owner

## Current STEP29M fleet status

- `macd v1 / config v3` — TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL (evaluation complete, no economic pass, not promotion-eligible)
- `breakout_donchian v1 / config v1` — TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL (evaluation complete, no economic pass, not promotion-eligible)
- `ma_crossover v1 / config v1` — POLICY_RATIFIED · FIXED_CONFIG_BOUND · AUTHORIZED_PENDING_EVALUATION · ECONOMIC_EVALUATION_EXECUTED=false

## Authority flags (all remain false)

- `STEP29N_AUTHORIZED=false`
- `STEP29R_AUTHORIZED=false`
- `PROMOTION_ALLOWED=false`
- `RUNTIME_AUTHORIZED=false`
- `LIVE_AUTHORIZED=false`
- `PROFITABILITY_CLAIM_ALLOWED=false`

## Next canonical step

`BOUNDED_STEP29M_MA_CROSSOVER_V1_REAL_ADMISSIBLE_FUTURES_ECONOMIC_EVALUATION_PREFLIGHT_READ_ONLY_V0` (preflight-only; no economic evaluation authority)

## Notion / evidence

- Notion current-state sync complete (`NOTION_CURRENT=true`, `MANIFEST_VERIFY_RC=0`)
- Historical ratification implementation bundle documents known `REPORT.md` hash drift (`MANIFEST_VERIFY_RC=1`) — shown only in secondary diagnostics, not as a dominant alarm

## Safety / runtime boundaries

- `PRODUCTIVE_RUNNER_INVOCATIONS=0`
- `RUNTIME_EFFECT=false`
- `ORDER_EFFECT=false`
- `PROFITABILITY_CLAIM_ALLOWED=false`
- No POST / order / arming / runtime controls added

## Reuse-drift guard

- Reused existing `/market` route, title owner, template stack, diagnostics drawer
- Single SSOT: `src/webui/market_dashboard_current_state_snapshot_v0.py`
- No parallel current-state SSOT, no second dashboard route, no SPA

## Tests

- New: `tests/webui/test_market_dashboard_current_state_sync_v0.py` (12 cases)
- CI focused market-dashboard owners: **753 passed** locally

## Visual verification

- Local read-only uvicorn on `127.0.0.1:8765` (GET only)
- Desktop full-page screenshot captured; server stopped after verification

## CI classification

- Selector: `CONTRACT_FOCUSED` / `market_dashboard_focused`

Made with [Cursor](https://cursor.com)