### PR TITLE
fix(step29m): wire ma crossover parameter projection

### DIFF
--- a/src/backtest/step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1.py
@@ -23,6 +23,7 @@ from src.backtest.strategy_signal_binding_v1 import (
     StrategySignalBindingError,
     collect_configured_strategy_params_v1,
     compute_required_warmup_rows_v1,
+    project_strategy_params_for_binding_v1,
     resolve_effective_strategy_params_v1,
 )
 from src.strategies.registry import get_strategy_registry_entry, resolve_strategy_id
@@ -188,10 +189,6 @@ def _validate_price_col_v1(value: Any) -> tuple[str, ...]:
     if value not in ALLOWED_PRICE_COLS:
         return ("price_col_not_allowed",)
     return ()
-
-
-def _window_params_for_binding_v1(configured: Mapping[str, Any]) -> dict[str, Any]:
-    return {key: configured[key] for key in ("fast_window", "slow_window") if key in configured}
 
 
 def verify_ma_crossover_v1_strategy_params_v1(
@@ -366,7 +363,10 @@ def verify_ma_crossover_v1_signal_binding_v1(cfg: Mapping[str, Any]) -> tuple[st
     try:
         effective, _ = resolve_effective_strategy_params_v1(
             MA_CROSSOVER_V1_STRATEGY_ID,
-            _window_params_for_binding_v1(configured),
+            project_strategy_params_for_binding_v1(
+                MA_CROSSOVER_V1_STRATEGY_ID,
+                configured,
+            ),
         )
         warmup = compute_required_warmup_rows_v1(MA_CROSSOVER_V1_STRATEGY_ID, effective)
         if warmup != int(effective["slow_window"]):
@@ -400,7 +400,10 @@ def evaluate_ma_crossover_v1_admissibility_contract_v1(
     try:
         effective, params_digest = resolve_effective_strategy_params_v1(
             MA_CROSSOVER_V1_STRATEGY_ID,
-            _window_params_for_binding_v1(configured),
+            project_strategy_params_for_binding_v1(
+                MA_CROSSOVER_V1_STRATEGY_ID,
+                configured,
+            ),
         )
     except StrategySignalBindingError as exc:
         blocking.append(str(exc))

--- a/src/backtest/strategy_signal_binding_v1.py
+++ b/src/backtest/strategy_signal_binding_v1.py
@@ -48,6 +48,11 @@ _EXTERNAL_PARAMETER_SCHEMA_V1: dict[str, dict[str, Any]] = {
     },
 }
 
+# Evaluation/config metadata allowed in configured params but not strategy logic schema.
+_EVALUATION_ONLY_STRATEGY_PARAMS_V1: dict[str, frozenset[str]] = {
+    "ma_crossover": frozenset({"price_col"}),
+}
+
 
 class StrategySignalBindingError(ValueError):
     """Fail-closed strategy signal binding error."""
@@ -235,6 +240,23 @@ def compute_required_warmup_rows_v1(
     raise StrategySignalBindingError(f"required_warmup_rows_unbound:{strategy_id}")
 
 
+def project_strategy_params_for_binding_v1(
+    strategy_id: str,
+    configured_params: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Project configured evaluation params to strategy-logic params for binding."""
+    evaluation_only = _EVALUATION_ONLY_STRATEGY_PARAMS_V1.get(strategy_id, frozenset())
+    aliases = _CANONICAL_PARAM_ALIASES_V1.get(strategy_id, {})
+    allowed_input_keys = (
+        set(_schema_param_names(strategy_id)) | set(aliases.keys()) | evaluation_only
+    )
+
+    for key in configured_params:
+        _fail_closed(key not in allowed_input_keys, f"unknown_strategy_param:{key}")
+
+    return {key: value for key, value in configured_params.items() if key not in evaluation_only}
+
+
 def _validate_macd_parameter_invariants_v1(effective_params: Mapping[str, Any]) -> None:
     fast = int(effective_params["fast_ema"])
     slow = int(effective_params["slow_ema"])
@@ -351,9 +373,13 @@ def execute_configured_strategy_signal_series_v1(
     resolution = resolve_strategy_id(strategy_id)
     canonical_id = resolution.canonical_strategy_id
     configured_params = collect_configured_strategy_params_v1(cfg, canonical_id)
-    effective_params, params_digest = resolve_effective_strategy_params_v1(
+    binding_params = project_strategy_params_for_binding_v1(
         canonical_id,
         configured_params,
+    )
+    effective_params, params_digest = resolve_effective_strategy_params_v1(
+        canonical_id,
+        binding_params,
     )
 
     strategy_fn = load_strategy(canonical_id)

--- a/tests/backtest/test_strategy_signal_binding_v1.py
+++ b/tests/backtest/test_strategy_signal_binding_v1.py
@@ -14,6 +14,7 @@ from src.backtest.strategy_signal_binding_v1 import (
     collect_configured_strategy_params_v1,
     compute_required_warmup_rows_v1,
     execute_configured_strategy_signal_series_v1,
+    project_strategy_params_for_binding_v1,
     resolve_effective_strategy_params_v1,
 )
 
@@ -87,6 +88,77 @@ def test_legacy_alias_fast_period_maps_to_fast_window() -> None:
 def test_unknown_strategy_param_fail_closed() -> None:
     with pytest.raises(StrategySignalBindingError, match="unknown_strategy_param"):
         resolve_effective_strategy_params_v1("ma_crossover", {"not_a_param": 1})
+
+
+def test_resolve_effective_params_rejects_price_col_directly() -> None:
+    with pytest.raises(StrategySignalBindingError, match="unknown_strategy_param:price_col"):
+        resolve_effective_strategy_params_v1(
+            "ma_crossover",
+            {"fast_window": 20, "slow_window": 50, "price_col": "close"},
+        )
+
+
+def test_project_ma_crossover_strips_price_col_for_binding() -> None:
+    projected = project_strategy_params_for_binding_v1(
+        "ma_crossover",
+        {"fast_window": 20, "slow_window": 50, "price_col": "close"},
+    )
+    assert projected == {"fast_window": 20, "slow_window": 50}
+
+
+def test_project_ma_crossover_rejects_unexpected_param() -> None:
+    with pytest.raises(StrategySignalBindingError, match="unknown_strategy_param:unexpected_param"):
+        project_strategy_params_for_binding_v1(
+            "ma_crossover",
+            {
+                "fast_window": 20,
+                "slow_window": 50,
+                "price_col": "close",
+                "unexpected_param": 1,
+            },
+        )
+
+
+def test_execute_ma_crossover_step29m_canonical_config_with_price_col() -> None:
+    cfg = _cfg(fast_window=20, slow_window=50)
+    cfg["economic_evaluation_v1"]["strategy_params"]["price_col"] = "close"
+    result = execute_configured_strategy_signal_series_v1(
+        _bars(120),
+        strategy_id="ma_crossover",
+        cfg=cfg,
+    )
+    assert result.provenance.strategy_execution_status.value == "EXECUTED"
+    assert result.provenance.configured_strategy_params == {
+        "fast_window": 20,
+        "slow_window": 50,
+        "price_col": "close",
+    }
+    assert result.provenance.effective_strategy_params == {
+        "fast_window": 20,
+        "slow_window": 50,
+    }
+    assert result.provenance.strategy_nonzero_signal_count >= 0
+
+
+def test_execute_ma_crossover_rejects_unexpected_param_with_price_col() -> None:
+    cfg = _cfg(fast_window=20, slow_window=50)
+    cfg["economic_evaluation_v1"]["strategy_params"]["price_col"] = "close"
+    cfg["economic_evaluation_v1"]["strategy_params"]["unexpected_param"] = 1
+    with pytest.raises(StrategySignalBindingError, match="unknown_strategy_param:unexpected_param"):
+        execute_configured_strategy_signal_series_v1(
+            _bars(),
+            strategy_id="ma_crossover",
+            cfg=cfg,
+        )
+
+
+def test_resolve_breakout_donchian_preserves_price_col_directly() -> None:
+    effective, _ = resolve_effective_strategy_params_v1(
+        "breakout_donchian",
+        {"lookback": 20, "price_col": "close"},
+    )
+    assert effective["price_col"] == "close"
+    assert effective["lookback"] == 20
 
 
 def test_execute_ma_crossover_produces_nonzero_signals_on_trending_fixture() -> None:

--- a/tests/ops/test_step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/tests/ops/test_step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1.py
@@ -16,6 +16,7 @@ from src.backtest.strategy_signal_binding_v1 import (
     StrategySignalBindingError,
     collect_configured_strategy_params_v1,
     compute_required_warmup_rows_v1,
+    project_strategy_params_for_binding_v1,
     resolve_effective_strategy_params_v1,
 )
 from src.strategies.registry import get_strategy_registry_entry, resolve_strategy_id
@@ -205,7 +206,7 @@ def test_config_params_from_evaluation_section(cfg: dict) -> None:
     configured = collect_configured_strategy_params_v1(cfg, "ma_crossover")
     effective, _ = resolve_effective_strategy_params_v1(
         "ma_crossover",
-        contract._window_params_for_binding_v1(configured),
+        project_strategy_params_for_binding_v1("ma_crossover", configured),
     )
     assert effective == {"fast_window": 20, "slow_window": 50}
     assert configured["price_col"] == "close"


### PR DESCRIPTION
## Summary

- **Root cause:** The ratified STEP29M `ma_crossover` evaluation config includes `price_col="close"` as evaluation/config metadata, but `ma_crossover` strategy logic accepts only `fast_window` and `slow_window`. The existing narrow adapter `_window_params_for_binding_v1` was wired only in the admissibility contract path; the productive binding path passed full configured params to `resolve_effective_strategy_params_v1` and failed fail-closed with `unknown_strategy_param:price_col`.
- **Fix:** Move parameter projection to the canonical owner `strategy_signal_binding_v1` as `project_strategy_params_for_binding_v1`, apply it in `execute_configured_strategy_signal_series_v1` before parameter resolution, and reuse the same helper from the admissibility contract path.
- **Preserved:** No strategy logic, config schema, or `MACrossoverStrategy.parameter_schema` changes. Fail-closed behavior for truly unknown parameters remains. Cross-strategy semantics unchanged (`breakout_donchian` still passes `price_col` through).

## Test plan

- [x] Productive path integration: `execute_configured_strategy_signal_series_v1` with canonical STEP29M config including `price_col="close"`
- [x] Fail-closed negative: `unexpected_param` still raises `unknown_strategy_param:unexpected_param`
- [x] Direct `resolve_effective_strategy_params_v1("ma_crossover", ..., price_col=...)` still fail-closed
- [x] Cross-strategy regression: `breakout_donchian` retains `price_col`
- [x] Admissibility contract tests remain green and use the same canonical projection helper
- [x] `ruff format --check`, `ruff check`, `git diff --check`

## CI selector

- Changed files: 4 (2 src/backtest, 2 tests)
- Selector result: `PR_BOUNDED_FULL` (`category_central_src_requires_full`)
- No required-check context changes

## Safety

- No economic evaluation executed
- Futures-only; no runtime, order, scheduler, testnet, shadow, paper, or live effect
- No config digest, policy binding, or strategy ID/version changes


Made with [Cursor](https://cursor.com)