### PR TITLE
feat(devex): canonical pre-PR ruff and diff-check guard v0

### DIFF
--- a/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
+++ b/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
@@ -3913,6 +3913,19 @@ ruff format --check .
 bash scripts/ops/check_no_black_enforcement.sh
 ```
 
+## Canonical pre-PR diff-scoped Ruff + diff-check guard v0
+
+**Scope:** `PREFLIGHT_PRE_PR_RUFF_AND_DIFF_GUARD_V0=true` · **Owner:** `scripts/ops/preflight_pre_pr_ruff_and_diff_guard_v0.py`
+
+Diff-scoped local pre-PR entrypoint (offline DevEx only). Complements — does **not** replace — blocking CI `lint_gate.yml` or `verify_pre_pr_validation_result_v0.py` envelope verification.
+
+```bash
+python3 scripts/ops/preflight_pre_pr_ruff_and_diff_guard_v0.py --base-ref origin/main
+python3 scripts/ops/preflight_pre_pr_ruff_and_diff_guard_v0.py --include-staged --include-unstaged
+```
+
+**Non-authorizing:** local lint/format/diff-check helper only; no workflow mutation, no runtime/trading/strategy/economic scope.
+
 ## Blocking model
 - Technically enforced:
   - `pip-audit` in `.github/workflows/audit.yml` when dependency-relevant files changed.

--- a/scripts/ops/preflight_pre_pr_ruff_and_diff_guard_v0.py
+++ b/scripts/ops/preflight_pre_pr_ruff_and_diff_guard_v0.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Canonical local pre-PR Ruff + git diff --check guard (v0).
+
+Diff-scoped offline DevEx entrypoint. Reuses pyproject.toml Ruff config and
+complements (does not replace) lint_gate.yml CI enforcement.
+
+Exit 0 only when all mandatory checks pass. Fail-closed on Git or Ruff errors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Sequence
+
+PACKAGE_MARKER = "PREFLIGHT_PRE_PR_RUFF_AND_DIFF_GUARD_V0=true"
+DEFAULT_BASE_REF = "origin/main"
+DEFAULT_HEAD_REF = "HEAD"
+
+
+class PreflightGuardError(Exception):
+    """Non-recoverable guard failure."""
+
+
+@dataclass(frozen=True)
+class PathChangeSummary:
+    changed_paths: tuple[str, ...]
+    python_paths: tuple[str, ...]
+    deleted_paths: tuple[str, ...]
+    renamed_count: int
+
+
+@dataclass
+class GuardResult:
+    base_ref: str
+    head_ref: str
+    merge_base: str
+    summary: PathChangeSummary
+    ruff_format_check_rc: int = 0
+    ruff_check_rc: int = 0
+    git_diff_check_rc: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def verdict(self) -> str:
+        if self.errors:
+            return "FAIL"
+        if self.ruff_format_check_rc != 0 or self.ruff_check_rc != 0 or self.git_diff_check_rc != 0:
+            return "FAIL"
+        return "PASS"
+
+    def exit_code(self) -> int:
+        return 0 if self.verdict == "PASS" else 1
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "BASE_REF": self.base_ref,
+            "HEAD_REF": self.head_ref,
+            "MERGE_BASE": self.merge_base,
+            "CHANGED_PATH_COUNT": len(self.summary.changed_paths),
+            "PYTHON_PATH_COUNT": len(self.summary.python_paths),
+            "DELETED_PATH_COUNT": len(self.summary.deleted_paths),
+            "RENAMED_PATH_COUNT": self.summary.renamed_count,
+            "RUFF_FORMAT_CHECK_RC": self.ruff_format_check_rc,
+            "RUFF_CHECK_RC": self.ruff_check_rc,
+            "GIT_DIFF_CHECK_RC": self.git_diff_check_rc,
+            "VERDICT": self.verdict,
+            "ERRORS": list(self.errors),
+            "PYTHON_PATHS": list(self.summary.python_paths),
+            "CHANGED_PATHS": list(self.summary.changed_paths),
+        }
+
+
+def _run_git(
+    args: Sequence[str],
+    *,
+    repo_root: Path,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    cmd = ["git", *args]
+    proc = subprocess.run(
+        cmd,
+        cwd=str(repo_root),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and proc.returncode != 0:
+        stderr = proc.stderr.strip() or proc.stdout.strip() or f"git {' '.join(args)} failed"
+        raise PreflightGuardError(stderr)
+    return proc
+
+
+def _resolve_ref(ref: str, *, repo_root: Path) -> str:
+    proc = _run_git(["rev-parse", "--verify", ref], repo_root=repo_root)
+    return proc.stdout.strip()
+
+
+def _merge_base(base: str, head: str, *, repo_root: Path) -> str:
+    proc = _run_git(["merge-base", base, head], repo_root=repo_root)
+    return proc.stdout.strip()
+
+
+def _parse_name_status(text: str) -> tuple[set[str], set[str], int]:
+    """Return changed paths, deleted paths, rename count from git name-status output."""
+    changed: set[str] = set()
+    deleted: set[str] = set()
+    renamed = 0
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\n")
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status = parts[0]
+        if status.startswith("R") and len(parts) >= 3:
+            renamed += 1
+            old_path, new_path = parts[1], parts[2]
+            changed.add(old_path)
+            changed.add(new_path)
+            if old_path.endswith(".py") and not new_path.endswith(".py"):
+                deleted.add(old_path)
+            continue
+        path = parts[1]
+        changed.add(path)
+        if status.startswith("D"):
+            deleted.add(path)
+    return changed, deleted, renamed
+
+
+def _collect_name_status_paths(
+    *,
+    repo_root: Path,
+    base: str,
+    head: str,
+    include_staged: bool,
+    include_unstaged: bool,
+) -> PathChangeSummary:
+    changed: set[str] = set()
+    deleted: set[str] = set()
+    renamed = 0
+
+    range_proc = _run_git(
+        ["diff", "--name-status", f"{base}...{head}"],
+        repo_root=repo_root,
+        check=False,
+    )
+    if range_proc.returncode not in {0, 1}:
+        raise PreflightGuardError(
+            range_proc.stderr.strip() or "git diff --name-status for base...head failed"
+        )
+    c, d, r = _parse_name_status(range_proc.stdout)
+    changed |= c
+    deleted |= d
+    renamed += r
+
+    if include_staged:
+        staged_proc = _run_git(
+            ["diff", "--name-status", "--cached"],
+            repo_root=repo_root,
+            check=False,
+        )
+        if staged_proc.returncode not in {0, 1}:
+            raise PreflightGuardError(
+                staged_proc.stderr.strip() or "git diff --name-status --cached failed"
+            )
+        c, d, r = _parse_name_status(staged_proc.stdout)
+        changed |= c
+        deleted |= d
+        renamed += r
+
+    if include_unstaged:
+        unstaged_proc = _run_git(
+            ["diff", "--name-status"],
+            repo_root=repo_root,
+            check=False,
+        )
+        if unstaged_proc.returncode not in {0, 1}:
+            raise PreflightGuardError(
+                unstaged_proc.stderr.strip() or "git diff --name-status failed"
+            )
+        c, d, r = _parse_name_status(unstaged_proc.stdout)
+        changed |= c
+        deleted |= d
+        renamed += r
+
+        untracked_proc = _run_git(
+            ["ls-files", "--others", "--exclude-standard"],
+            repo_root=repo_root,
+            check=False,
+        )
+        if untracked_proc.returncode != 0:
+            raise PreflightGuardError(
+                untracked_proc.stderr.strip() or "git ls-files --others failed"
+            )
+        for path in untracked_proc.stdout.splitlines():
+            if path.strip():
+                changed.add(path.strip())
+
+    sorted_changed = tuple(sorted(changed))
+    python_paths = tuple(
+        sorted(
+            path for path in sorted_changed if path.endswith(".py") and (repo_root / path).is_file()
+        )
+    )
+    return PathChangeSummary(
+        changed_paths=sorted_changed,
+        python_paths=python_paths,
+        deleted_paths=tuple(sorted(deleted)),
+        renamed_count=renamed,
+    )
+
+
+def _run_ruff(args: Sequence[str], *, repo_root: Path) -> int:
+    for cmd in (["ruff", *args], [sys.executable, "-m", "ruff", *args]):
+        proc = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode == 127 and cmd[0] == "ruff":
+            continue
+        if proc.returncode != 0 and proc.stderr:
+            sys.stderr.write(proc.stderr)
+        if proc.returncode != 0 and proc.stdout:
+            sys.stderr.write(proc.stdout)
+        return proc.returncode
+    raise PreflightGuardError("ruff executable not found")
+
+
+def _run_ruff_on_paths(
+    subcommand: Sequence[str],
+    paths: Sequence[str],
+    *,
+    repo_root: Path,
+) -> int:
+    if not paths:
+        return 0
+    return _run_ruff([*subcommand, *paths], repo_root=repo_root)
+
+
+def _run_git_diff_check_scopes(
+    *,
+    repo_root: Path,
+    base: str,
+    head: str,
+    include_staged: bool,
+    include_unstaged: bool,
+) -> int:
+    worst = 0
+    scopes: list[list[str]] = [["diff", "--check", f"{base}...{head}"]]
+    if include_staged:
+        scopes.append(["diff", "--check", "--cached"])
+    if include_unstaged:
+        scopes.append(["diff", "--check"])
+    for scope in scopes:
+        proc = _run_git(scope, repo_root=repo_root, check=False)
+        if proc.returncode != 0:
+            if proc.stderr:
+                sys.stderr.write(proc.stderr)
+            if proc.stdout:
+                sys.stderr.write(proc.stdout)
+            worst = proc.returncode if proc.returncode > worst else worst
+            if worst == 0:
+                worst = 1
+    return worst
+
+
+def run_guard(
+    *,
+    repo_root: Path,
+    base_ref: str = DEFAULT_BASE_REF,
+    head_ref: str = DEFAULT_HEAD_REF,
+    include_staged: bool = False,
+    include_unstaged: bool = False,
+    apply_format: bool = False,
+) -> GuardResult:
+    base_sha = _resolve_ref(base_ref, repo_root=repo_root)
+    head_sha = _resolve_ref(head_ref, repo_root=repo_root)
+    merge_base_sha = _merge_base(base_sha, head_sha, repo_root=repo_root)
+
+    summary = _collect_name_status_paths(
+        repo_root=repo_root,
+        base=base_sha,
+        head=head_sha,
+        include_staged=include_staged,
+        include_unstaged=include_unstaged,
+    )
+
+    result = GuardResult(
+        base_ref=base_ref,
+        head_ref=head_ref,
+        merge_base=merge_base_sha,
+        summary=summary,
+    )
+
+    if apply_format and summary.python_paths:
+        fmt_apply_rc = _run_ruff_on_paths(["format"], summary.python_paths, repo_root=repo_root)
+        if fmt_apply_rc != 0:
+            result.errors.append(f"ruff format apply failed with rc={fmt_apply_rc}")
+            result.ruff_format_check_rc = fmt_apply_rc
+            result.ruff_check_rc = fmt_apply_rc
+            result.git_diff_check_rc = fmt_apply_rc
+            return result
+
+    result.ruff_format_check_rc = _run_ruff_on_paths(
+        ["format", "--check"],
+        summary.python_paths,
+        repo_root=repo_root,
+    )
+    result.ruff_check_rc = _run_ruff_on_paths(
+        ["check"],
+        summary.python_paths,
+        repo_root=repo_root,
+    )
+    result.git_diff_check_rc = _run_git_diff_check_scopes(
+        repo_root=repo_root,
+        base=base_sha,
+        head=head_sha,
+        include_staged=include_staged,
+        include_unstaged=include_unstaged,
+    )
+    return result
+
+
+def _format_human(result: GuardResult) -> str:
+    lines = [
+        f"BASE_REF={result.base_ref}",
+        f"HEAD_REF={result.head_ref}",
+        f"MERGE_BASE={result.merge_base}",
+        f"CHANGED_PATH_COUNT={len(result.summary.changed_paths)}",
+        f"PYTHON_PATH_COUNT={len(result.summary.python_paths)}",
+        f"DELETED_PATH_COUNT={len(result.summary.deleted_paths)}",
+        f"RENAMED_PATH_COUNT={result.summary.renamed_count}",
+        f"RUFF_FORMAT_CHECK_RC={result.ruff_format_check_rc}",
+        f"RUFF_CHECK_RC={result.ruff_check_rc}",
+        f"GIT_DIFF_CHECK_RC={result.git_diff_check_rc}",
+        f"VERDICT={result.verdict}",
+    ]
+    for err in result.errors:
+        lines.append(f"ERROR={err}")
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-ref",
+        default=DEFAULT_BASE_REF,
+        help=f"Git base ref (default: {DEFAULT_BASE_REF})",
+    )
+    parser.add_argument(
+        "--head-ref",
+        default=DEFAULT_HEAD_REF,
+        help=f"Git head ref (default: {DEFAULT_HEAD_REF})",
+    )
+    parser.add_argument(
+        "--include-staged",
+        action="store_true",
+        help="Include staged working-tree changes in path selection and diff --check",
+    )
+    parser.add_argument(
+        "--include-unstaged",
+        action="store_true",
+        help="Include unstaged working-tree changes in path selection and diff --check",
+    )
+    parser.add_argument(
+        "--format",
+        dest="apply_format",
+        action="store_true",
+        help="Apply ruff format to changed Python files, then re-run all checks",
+    )
+    parser.add_argument(
+        "--json-output",
+        action="store_true",
+        help="Emit machine-readable JSON summary on stdout",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (default: current working directory)",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve()
+
+    try:
+        result = run_guard(
+            repo_root=repo_root,
+            base_ref=args.base_ref,
+            head_ref=args.head_ref,
+            include_staged=args.include_staged,
+            include_unstaged=args.include_unstaged,
+            apply_format=args.apply_format,
+        )
+    except PreflightGuardError as exc:
+        payload = {
+            "BASE_REF": args.base_ref,
+            "HEAD_REF": args.head_ref,
+            "MERGE_BASE": "",
+            "CHANGED_PATH_COUNT": 0,
+            "PYTHON_PATH_COUNT": 0,
+            "DELETED_PATH_COUNT": 0,
+            "RENAMED_PATH_COUNT": 0,
+            "RUFF_FORMAT_CHECK_RC": 1,
+            "RUFF_CHECK_RC": 1,
+            "GIT_DIFF_CHECK_RC": 1,
+            "VERDICT": "FAIL",
+            "ERRORS": [str(exc)],
+        }
+        if args.json_output:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            for key, value in payload.items():
+                if key == "ERRORS":
+                    for err in value:
+                        print(f"ERROR={err}")
+                else:
+                    print(f"{key}={value}")
+        return 1
+
+    if args.json_output:
+        print(json.dumps(result.as_dict(), indent=2, sort_keys=True))
+    else:
+        print(_format_human(result))
+    return result.exit_code()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_preflight_pre_pr_ruff_and_diff_guard_v0.py
+++ b/tests/ci/test_preflight_pre_pr_ruff_and_diff_guard_v0.py
@@ -1,0 +1,377 @@
+"""Contract tests for preflight_pre_pr_ruff_and_diff_guard_v0 (v0)."""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD_MODULE = REPO_ROOT / "scripts" / "ops" / "preflight_pre_pr_ruff_and_diff_guard_v0.py"
+GUARD_SCRIPT = GUARD_MODULE
+CI_AUDIT = REPO_ROOT / "docs" / "ops" / "CI_AUDIT_KNOWN_ISSUES.md"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ops"))
+import preflight_pre_pr_ruff_and_diff_guard_v0 as guard  # noqa: E402
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and proc.returncode != 0:
+        raise RuntimeError(proc.stderr or proc.stdout or "git failed")
+    return proc
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "branch", "-M", "main")
+    return repo
+
+
+def _commit_all(repo: Path, message: str) -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", message)
+
+
+def _run_guard(
+    repo: Path,
+    *extra_args: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, str(GUARD_SCRIPT), "--repo-root", str(repo), *extra_args]
+    return subprocess.run(
+        cmd,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_package_marker_present() -> None:
+    text = GUARD_MODULE.read_text(encoding="utf-8")
+    assert guard.PACKAGE_MARKER in text
+    assert "PREFLIGHT_PRE_PR_RUFF_AND_DIFF_GUARD_V0" in text
+
+
+def test_ci_audit_crosslink_present() -> None:
+    text = CI_AUDIT.read_text(encoding="utf-8")
+    assert "preflight_pre_pr_ruff_and_diff_guard_v0.py" in text
+    assert "PREFLIGHT_PRE_PR_RUFF_AND_DIFF_GUARD_V0" in text
+
+
+def test_no_forbidden_imports_in_guard_module() -> None:
+    tree = ast.parse(GUARD_MODULE.read_text(encoding="utf-8"))
+    forbidden = {"requests", "httpx", "urllib3", "socket", "credentials"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not any(token in alias.name for token in forbidden)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert not any(token in node.module for token in forbidden)
+
+
+def test_no_changed_files_passes(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    proc = _run_guard(repo, "--base-ref", "main", "--head-ref", "HEAD")
+    assert proc.returncode == 0
+    assert "VERDICT=PASS" in proc.stdout
+    assert "PYTHON_PATH_COUNT=0" in proc.stdout
+
+
+def test_modified_python_file(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    py = repo / "module.py"
+    py.write_text("x=1\n", encoding="utf-8")
+    _commit_all(repo, "add module")
+    py.write_text("x = 1\n", encoding="utf-8")
+    proc = _run_guard(
+        repo,
+        "--base-ref",
+        "main",
+        "--head-ref",
+        "HEAD",
+        "--include-unstaged",
+    )
+    assert proc.returncode == 0
+    assert "PYTHON_PATH_COUNT=1" in proc.stdout
+
+
+def test_added_python_file(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "new_module.py").write_text("value = 2\n", encoding="utf-8")
+    proc = _run_guard(repo, "--base-ref", "main", "--include-unstaged")
+    assert proc.returncode == 0
+    assert "PYTHON_PATH_COUNT=1" in proc.stdout
+
+
+def test_deleted_python_file_not_passed_to_ruff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _init_repo(tmp_path)
+    target = repo / "remove_me.py"
+    target.write_text("a = 1\n", encoding="utf-8")
+    _commit_all(repo, "track file")
+    target.unlink()
+    _commit_all(repo, "delete file")
+
+    seen: list[list[str]] = []
+
+    def fake_ruff(args: Sequence[str], *, repo_root: Path) -> int:
+        seen.append(list(args))
+        return 0
+
+    monkeypatch.setattr(guard, "_run_ruff", fake_ruff)
+    result = guard.run_guard(repo_root=repo, base_ref="main~1", head_ref="HEAD")
+    assert result.summary.deleted_paths == ("remove_me.py",)
+    assert result.summary.python_paths == ()
+    assert not any("remove_me.py" in call for call in seen)
+
+
+def test_renamed_python_file_checks_destination(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    src = repo / "old_name.py"
+    src.write_text("val = 1\n", encoding="utf-8")
+    _commit_all(repo, "old")
+    dst = repo / "new name.py"
+    _git(repo, "mv", "old_name.py", "new name.py")
+    _commit_all(repo, "rename")
+    proc = _run_guard(repo, "--base-ref", "main~1", "--head-ref", "HEAD")
+    assert proc.returncode == 0
+    assert "RENAMED_PATH_COUNT=1" in proc.stdout
+    assert "PYTHON_PATH_COUNT=1" in proc.stdout
+
+
+def test_rename_python_to_non_python(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "code.py").write_text("x = 1\n", encoding="utf-8")
+    _commit_all(repo, "py")
+    _git(repo, "mv", "code.py", "code.txt")
+    _commit_all(repo, "to txt")
+
+    seen: list[list[str]] = []
+
+    def fake_ruff(args: Sequence[str], *, repo_root: Path) -> int:
+        seen.append(list(args))
+        return 0
+
+    monkeypatch.setattr(guard, "_run_ruff", fake_ruff)
+    result = guard.run_guard(repo_root=repo, base_ref="main~1", head_ref="HEAD")
+    assert result.summary.python_paths == ()
+    assert "code.py" in result.summary.deleted_paths
+    assert not any("code.py" in call for call in seen)
+
+
+def test_rename_non_python_to_python(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "notes.txt").write_text("note\n", encoding="utf-8")
+    _commit_all(repo, "txt")
+    _git(repo, "mv", "notes.txt", "notes.py")
+    (repo / "notes.py").write_text("value = 3\n", encoding="utf-8")
+    _commit_all(repo, "to py")
+    proc = _run_guard(repo, "--base-ref", "main~1", "--head-ref", "HEAD")
+    assert proc.returncode == 0
+    assert "PYTHON_PATH_COUNT=1" in proc.stdout
+
+
+def test_non_python_only_diff(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "doc.md").write_text("hello\n", encoding="utf-8")
+    _commit_all(repo, "doc")
+
+    seen: list[list[str]] = []
+
+    def fake_ruff(args: Sequence[str], *, repo_root: Path) -> int:
+        seen.append(list(args))
+        return 0
+
+    monkeypatch.setattr(guard, "_run_ruff", fake_ruff)
+    result = guard.run_guard(repo_root=repo, base_ref="main~1", head_ref="HEAD")
+    assert result.summary.python_paths == ()
+    assert seen == []
+
+
+def test_mixed_diff(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "a.py").write_text("a = 1\n", encoding="utf-8")
+    (repo / "b.md").write_text("b\n", encoding="utf-8")
+    _commit_all(repo, "mixed")
+    proc = _run_guard(repo, "--base-ref", "main~1", "--head-ref", "HEAD")
+    assert proc.returncode == 0
+    assert "PYTHON_PATH_COUNT=1" in proc.stdout
+    assert "CHANGED_PATH_COUNT=2" in proc.stdout
+
+
+def test_path_with_spaces(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    spaced = repo / "my module.py"
+    spaced.write_text("z = 0\n", encoding="utf-8")
+    _commit_all(repo, "space")
+    proc = _run_guard(repo, "--base-ref", "main~1", "--head-ref", "HEAD")
+    assert proc.returncode == 0
+    assert "PYTHON_PATH_COUNT=1" in proc.stdout
+
+
+def test_staged_changes(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "staged.py").write_text("s = 1\n", encoding="utf-8")
+    _git(repo, "add", "staged.py")
+    proc = _run_guard(repo, "--base-ref", "main", "--include-staged")
+    assert proc.returncode == 0
+    assert "PYTHON_PATH_COUNT=1" in proc.stdout
+
+
+def test_unstaged_changes(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "tracked.py").write_text("t = 1\n", encoding="utf-8")
+    _commit_all(repo, "track")
+    (repo / "tracked.py").write_text("t = 2\n", encoding="utf-8")
+    proc = _run_guard(repo, "--base-ref", "main", "--include-unstaged")
+    assert proc.returncode == 0
+    assert "PYTHON_PATH_COUNT=1" in proc.stdout
+
+
+def test_staged_and_unstaged_deduplicated(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    target = repo / "dup.py"
+    target.write_text("d = 1\n", encoding="utf-8")
+    _git(repo, "add", "dup.py")
+    target.write_text("d = 2\n", encoding="utf-8")
+    proc = _run_guard(repo, "--base-ref", "main", "--include-staged", "--include-unstaged")
+    assert proc.returncode == 0
+    assert "PYTHON_PATH_COUNT=1" in proc.stdout
+
+
+def test_invalid_base_ref_fails_closed(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    proc = _run_guard(repo, "--base-ref", "does-not-exist", "--head-ref", "HEAD")
+    assert proc.returncode == 1
+    assert "VERDICT=FAIL" in proc.stdout or "VERDICT" in proc.stdout
+
+
+def test_git_command_error_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_repo(tmp_path)
+
+    def boom(
+        args: Sequence[str], *, repo_root: Path, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        raise guard.PreflightGuardError("simulated git failure")
+
+    monkeypatch.setattr(guard, "_run_git", boom)
+    rc = guard.main(["--repo-root", str(repo), "--base-ref", "main", "--head-ref", "HEAD"])
+    assert rc == 1
+
+
+def test_ruff_format_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "bad.py").write_text("x=1\n", encoding="utf-8")
+    _commit_all(repo, "bad")
+
+    def fake_ruff(args: Sequence[str], *, repo_root: Path) -> int:
+        if "format" in args and "--check" in args:
+            return 1
+        return 0
+
+    monkeypatch.setattr(guard, "_run_ruff", fake_ruff)
+    result = guard.run_guard(repo_root=repo, base_ref="main~1", head_ref="HEAD")
+    assert result.ruff_format_check_rc == 1
+    assert result.verdict == "FAIL"
+
+
+def test_ruff_check_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "lint.py").write_text("x=1\n", encoding="utf-8")
+    _commit_all(repo, "lint")
+
+    def fake_ruff(args: Sequence[str], *, repo_root: Path) -> int:
+        if args[:1] == ["check"]:
+            return 1
+        return 0
+
+    monkeypatch.setattr(guard, "_run_ruff", fake_ruff)
+    result = guard.run_guard(repo_root=repo, base_ref="main~1", head_ref="HEAD")
+    assert result.ruff_check_rc == 1
+    assert result.verdict == "FAIL"
+
+
+def test_git_diff_check_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "ws.py").write_text("x=1\n", encoding="utf-8")
+    _commit_all(repo, "ws")
+
+    def fake_diff(
+        *, repo_root: Path, base: str, head: str, include_staged: bool, include_unstaged: bool
+    ) -> int:
+        return 2
+
+    monkeypatch.setattr(guard, "_run_git_diff_check_scopes", fake_diff)
+    result = guard.run_guard(repo_root=repo, base_ref="main~1", head_ref="HEAD")
+    assert result.git_diff_check_rc == 2
+    assert result.verdict == "FAIL"
+
+
+def test_stable_path_ordering(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / "b.py").write_text("b = 1\n", encoding="utf-8")
+    (repo / "a.py").write_text("a = 1\n", encoding="utf-8")
+    _commit_all(repo, "two files")
+    summary = guard._collect_name_status_paths(
+        repo_root=repo,
+        base=_git(repo, "rev-parse", "main~1").stdout.strip(),
+        head=_git(repo, "rev-parse", "HEAD").stdout.strip(),
+        include_staged=False,
+        include_unstaged=False,
+    )
+    assert summary.python_paths == ("a.py", "b.py")
+    assert summary.changed_paths == ("a.py", "b.py")
+
+
+def test_json_output(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    proc = _run_guard(repo, "--base-ref", "main", "--json-output")
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["VERDICT"] == "PASS"
+    assert payload["CHANGED_PATH_COUNT"] == 0
+
+
+def test_format_flag_applies_then_rechecks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _init_repo(tmp_path)
+    target = repo / "fmt.py"
+    target.write_text("x=1\n", encoding="utf-8")
+    _commit_all(repo, "fmt")
+    calls: list[list[str]] = []
+
+    def fake_ruff(args: Sequence[str], *, repo_root: Path) -> int:
+        calls.append(list(args))
+        return 0
+
+    monkeypatch.setattr(guard, "_run_ruff", fake_ruff)
+    result = guard.run_guard(
+        repo_root=repo,
+        base_ref="main~1",
+        head_ref="HEAD",
+        apply_format=True,
+    )
+    assert result.verdict == "PASS"
+    assert calls[0][:1] == ["format"]
+    assert ["format", "--check"] == calls[1][:2]
+    assert calls[2][:1] == ["check"]


### PR DESCRIPTION
## Summary

- Add `scripts/ops/preflight_pre_pr_ruff_and_diff_guard_v0.py`: diff-scoped local pre-PR entrypoint running `ruff format --check`, `ruff check` on changed existing `.py` files, and `git diff --check` on the relevant merge-base diff scope.
- Add contract tests in `tests/ci/test_preflight_pre_pr_ruff_and_diff_guard_v0.py` covering rename/delete/staged/unstaged/space paths and fail-closed semantics.
- Minimal CI_AUDIT crosslink documenting reuse of existing Ruff SSOT and non-authorizing DevEx-only scope.

## Exclusions (explicit)

- No workflow / required-context changes
- No auto-PR wiring
- No trading, strategy, risk, economic, runtime, scheduler, adapter, order, credential, or live scope
- Registry `FOLLOW_UP_DEVEX_STATUS` update deferred to merge closeout

## Reuse

- CI blocking lint: `.github/workflows/lint_gate.yml`
- Ruff config: `pyproject.toml`
- Formatter policy: `scripts/ops/check_no_black_enforcement.sh`
- PRE_PR envelope: `scripts/ops/verify_pre_pr_validation_result_v0.py` (unchanged)

## Test plan

- [x] `pytest tests/ci/test_preflight_pre_pr_ruff_and_diff_guard_v0.py`
- [x] `ruff format --check` + `ruff check` on changed Python files
- [x] `git diff --check origin/main...HEAD`
- [x] Self-guard: `preflight_pre_pr_ruff_and_diff_guard_v0.py --base-ref origin/main`
- [x] CI selector: `CONTRACT_FOCUSED`


Made with [Cursor](https://cursor.com)