### PR TITLE
feat(step30a): dataset v2 contract remediation and config freeze

### DIFF
--- a/config/ops/step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json
+++ b/config/ops/step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json
@@ -1,0 +1,172 @@
+{
+  "backtest": {
+    "cost_model_version": "backtest_cost_v0",
+    "dataset_admissibility": {
+      "bind": true,
+      "dataset_profile": "economic_research_v1",
+      "execution_cost_binding": {
+        "conservative_half_spread_bps": 5.0,
+        "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+        "spread_model_version": "research_conservative_bps_v1"
+      },
+      "profile_binding": {
+        "dataset_profile": "economic_research_v1",
+        "execution_cost_binding": {
+          "conservative_half_spread_bps": 5.0,
+          "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+          "spread_model_version": "research_conservative_bps_v1"
+        },
+        "l1_observation_status": "EXECUTION_MODEL_BOUND_NOT_OBSERVED"
+      }
+    },
+    "economic_research_execution_cost": {
+      "conservative_half_spread_bps": 5.0,
+      "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+      "fee_bps": 10.0,
+      "slippage_bps": 5.0,
+      "spread_model_version": "research_conservative_bps_v1"
+    },
+    "fee_bps": 10.0,
+    "fee_model_version": "backtest_fee_taker_symmetric_v0",
+    "funding": {
+      "bind": true,
+      "model_version": "backtest_funding_perpetual_interval_v1"
+    },
+    "initial_cash": 10000.0,
+    "parameter_sensitivity": {
+      "bind": true,
+      "grid": {
+        "grid_id": "okx_eth_perp_research_cost_grid_v1",
+        "parameter_names": [
+          "fee_bps",
+          "slippage_bps"
+        ],
+        "parameter_values": [
+          [
+            8.0,
+            10.0,
+            12.0
+          ],
+          [
+            4.0,
+            5.0,
+            6.0
+          ]
+        ],
+        "search_space_bounds": {
+          "fee_bps": {
+            "max": 12.0,
+            "min": 8.0
+          },
+          "slippage_bps": {
+            "max": 6.0,
+            "min": 4.0
+          }
+        },
+        "seed": 42
+      },
+      "grid_version": "v1",
+      "policy_version": "parameter_sensitivity_v1"
+    },
+    "slippage_bps": 5.0,
+    "slippage_model_version": "backtest_slippage_symmetric_v0"
+  },
+  "config_schema_version": "step30a_rsi_reversion_v1_economic_evaluation_admissibility_v1",
+  "config_version": "v1",
+  "economic_evaluation_v1": {
+    "economic_validity_policy_version": "economic_validity_policy_v1",
+    "engine_signal_source": "configured_strategy_signal",
+    "monte_carlo": {
+      "bind": true,
+      "policy_version": "monte_carlo_v1",
+      "runs": 64,
+      "seed": 42
+    },
+    "parameter_sensitivity_policy_version": "parameter_sensitivity_v1",
+    "strategy_id": "rsi_reversion",
+    "strategy_params": {
+      "lower": 30.0,
+      "price_col": "close",
+      "rsi_window": 14,
+      "upper": 70.0
+    },
+    "strategy_version": "v1",
+    "stress": {
+      "bind": true,
+      "policy_version": "stress_class_suite_v1"
+    },
+    "walk_forward": {
+      "bind": true,
+      "policy_version": "walk_forward_v1",
+      "step_bars": 1440,
+      "test_bars": 1440,
+      "train_bars": 4320
+    }
+  },
+  "offline_evaluation_sizing_contract_v1": {
+    "config_digest": "2e8c41d13184b047dd045a02a6afdd587847d802080808156d267a7947013f84",
+    "dataset_digest": "76b7e30b6153a8d273c63d771dbe2a232448369cd870ef3148031edd1187bc53",
+    "initial_equity": 10000.0,
+    "instrument_metadata_source": "versioned_dataset_manifest_v2",
+    "max_position_pct": 0.25,
+    "minimum_notional_policy": "USE_RISK_MIN_POSITION_VALUE_v1",
+    "minimum_quantity_policy": "REJECT_BELOW_MIN_NOTIONAL_v1",
+    "oversize_policy": "REJECT_OVERSIZE",
+    "price_source": "bar_close_v1",
+    "quantity_rounding_policy": "NONE_v1",
+    "risk_per_trade": 0.005,
+    "sizing_contract_version": "offline_evaluation_sizing_contract_v1",
+    "sizing_mode": "fixed_fractional_risk_per_trade_v1",
+    "sizing_owner": "backtest.offline_evaluation_sizing_contract_v1",
+    "stop_distance_policy": "FIXED_PCT_FROM_ENTRY_v1",
+    "stop_pct": 0.025,
+    "stop_pct_derivation_ref": "fleet_precedent:macd_v3_post_risk_limits_rewire",
+    "strategy_params_digest": "f75332deba2b4746eccc7b477d6fe0d51f16cf7f2ed1b33c68eb82ac775fce40"
+  },
+  "real_admissible_futures_evaluation_binding_v1": {
+    "canonical_instrument_id": "inst-eth-usdt-perp",
+    "canonical_trading_logic_version": "integrated_offline_trading_logic_replay_v1",
+    "dataset_path": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/inst-eth-usdt-perp/v2/bars.parquet",
+    "dataset_profile": "economic_research_v1",
+    "dataset_schema_version": "v2",
+    "dataset_version": "v2",
+    "effective_entry_cost_bps": 20.0,
+    "effective_exit_cost_bps": 20.0,
+    "execution_model_version": "backtest_execution_v0",
+    "development_partition_digest": "544d1e10987d42a82c834c5580f6424aaf01b4d7762fb08be10dbb3094e38d22",
+    "expected_dataset_digest": "76b7e30b6153a8d273c63d771dbe2a232448369cd870ef3148031edd1187bc53",
+    "expected_l1_observation_status": "EXECUTION_MODEL_BOUND_NOT_OBSERVED",
+    "expected_manifest_digest": "c5e9039a04521272c115e83158ba415e1b85d9fcad9658446bfb947abc77b44a",
+    "frozen_holdout_digest": "8612a4cccf5cf321eeb577ed1b6df14417277738f43423cbf152c98d330aa3e4",
+    "missing_historical_l1_reason": "NOT_AVAILABLE_BY_PUBLIC_SOURCE",
+    "native_instrument_id": "ETH-USDT-SWAP",
+    "out_of_sample_period": "2026-06-17 10:07:00+00:00..2026-07-01 10:07:00+00:00",
+    "require_dataset_admissible": true,
+    "require_integrity_pass": true,
+    "require_observed_l1_used_false": true,
+    "roundtrip_cost_bps": 40.0,
+    "source_venue": "OKX",
+    "training_period": "2026-04-02 10:07:00+00:00..2026-05-18 23:59:00+00:00",
+    "validation_period": "2026-05-19 00:00:00+00:00..2026-06-16 23:59:00+00:00"
+  },
+  "risk": {
+    "max_position_size": 0.25,
+    "min_position_value": 10.0,
+    "min_stop_distance": 0.0001,
+    "risk_per_trade": 0.005
+  },
+  "step30a_policy_ratification_v1": {
+    "dataset_replacement_allowed": false,
+    "evaluation_authorized": false,
+    "instrument_id": "inst-eth-usdt-perp",
+    "operator_policy_derivation_ref": "operator_policy_decision:STEP30A_RSI_REVERSION_V1",
+    "parameter_tuning_allowed": false,
+    "promotion_authorized": false,
+    "runtime_authorized": false,
+    "sizing_precedent_ref": "fleet_precedent:macd_v3_post_risk_limits_rewire",
+    "strategy_id": "rsi_reversion",
+    "strategy_version": "v1",
+    "threshold_tuning_allowed": false,
+    "venue_id": "okx"
+  }
+}

--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -257,6 +257,26 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `STEP29M_PROMOTION_AUTHORIZED` | `false` |
 | `STEP29M_RUNTIME_AUTHORITY` | `false` |
 | `STEP29M_NEW_RESEARCH_SCOPE_REQUIRES_EXPLICIT_OPERATOR_RATIFICATION` | `true` |
+| `RUNBOOK_STEP_30A_STARTED` | `true` |
+| `RUNBOOK_STEP_30A_IMPLEMENTED_SCOPE` | `rsi_reversion_v1_extended_holdout_separated_futures_economic_research_v0,dataset_v2_backward_extension_adapter_v0,policy_ratification_and_candidate_design_contract_v0` |
+| `RUNBOOK_STEP_30A_IMPLEMENTED` | `true` |
+| `RUNBOOK_STEP_30A_COMPLETE` | `true` |
+| `STEP30A_SCOPE` | `RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0` |
+| `STEP30A_GO_TOKEN` | `GO_BOUNDED_STEP30A_RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0` |
+| `STEP30A_OPERATOR_POLICY_RATIFIED` | `true` |
+| `STEP30A_OPERATOR_POLICY_DECISION` | `RATIFIED` |
+| `STEP30A_OPERATOR_POLICY_DECISION_REF` | `operator_policy_decision:STEP30A_RSI_REVERSION_V1` |
+| `STEP30A_RSI_WINDOW` | `14` |
+| `STEP30A_LOWER` | `30.0` |
+| `STEP30A_UPPER` | `70.0` |
+| `STEP30A_PRICE_COL` | `close` |
+| `STEP30A_HOLDOUT_FROZEN_REF` | `2026-06-17 10:07:00+00:00..2026-07-01 10:07:00+00:00` |
+| `STEP30A_DATASET_VERSION` | `v2` |
+| `STEP30A_EVALUATION_AUTHORIZED` | `false` |
+| `STEP30A_PROMOTION_AUTHORIZED` | `false` |
+| `STEP30A_RUNTIME_AUTHORIZED` | `false` |
+| `STEP30A_REGISTERED_ECONOMIC_EVALUATION_CONFIGS` | `config&#47;ops&#47;step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json` <!-- pt:ref-target-ignore --> |
+| `STEP30A_OPERATOR_POLICY_SUPERSEDES_NO_NEW_CANDIDATE_HOLD_ONLY_FOR_STEP30A` | `true` |
 | `STEP29N_ALREADY_COMPLETE` | `true` |
 | `NEGATIVE_CANDIDATE_DECISIONS_REMAIN_CANONICAL` | `true` |
 | `NEGATIVE_CANDIDATE_DECISIONS_REMAIN_EVIDENCE_ADMISSIBLE` | `true` |
@@ -1449,6 +1469,56 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `MA_CROSSOVER_V1_REAL_EVALUATION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/economic_evaluation/bounded_step29m_ma_crossover_v1_post_binding_fix_economic_evaluation_recovery_single_run_v0_20260702T012057Z` |
 | `MA_CROSSOVER_V1_CANDIDATE_DECISION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/economic_evaluation/bounded_step29m_ma_crossover_v1_economic_policy_fail_closeout_and_candidate_decision_read_only_v0_20260702T012719Z` |
 | `FLEET_NO_PASS_OPERATOR_POLICY_DECISION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_step29m_no_pass_operator_policy_decision_preparation_read_only_v0_20260702T013118Z` |
+| `SEPARATE_GO_REQUIRED` | `true` |
+
+#### RUNBOOK_STEP_30A — RSI Reversion v1 Extended Holdout-Separated Futures Economic Research v0
+
+| Feld | Wert |
+|---|---|
+| `RUNBOOK_PHASE` | 9 |
+| `RUNBOOK_STEP_ID` | `rsi_reversion_v1_extended_holdout_separated_futures_economic_research_v0` |
+| `STATUS` | `COMPLETE` |
+| `CANONICAL_OWNER` | `src/backtest/step30a_rsi_reversion_v1_economic_evaluation_admissibility_contract_v1.py` |
+| `CANONICAL_INGEST_ADAPTER_OWNER` | `scripts/ops/ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py` |
+| `CANONICAL_CONFIG_PATH` | `config&#47;ops&#47;step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json` <!-- pt:ref-target-ignore --> |
+| `DEPENDENCIES` | RUNBOOK_STEP_29M |
+| `NEXT_REQUIRED_CONTRACT` | `RUNBOOK_STEP_29N` |
+| `NEXT_CANONICAL_STEP` | `SEPARATE_EVALUATION_GO_REQUIRED_AFTER_PRE_PR_AND_IMPLEMENTATION_CLOSEOUT` |
+| `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
+| `FUTURES_ONLY` | `true` |
+| `BITCOIN_DIRECTION_ALLOWED` | `false` |
+| `ORDER_EFFECT` | `false` |
+| `RUNTIME_EFFECT` | `false` |
+| `LIVE_AUTHORIZED` | `false` |
+| `RUNBOOK_STEP_30A_STARTED` | `true` |
+| `RUNBOOK_STEP_30A_IMPLEMENTED_SCOPE` | `rsi_reversion_v1_extended_holdout_separated_futures_economic_research_v0,dataset_v2_backward_extension_adapter_v0,policy_ratification_and_candidate_design_contract_v0` |
+| `RUNBOOK_STEP_30A_IMPLEMENTED` | `true` |
+| `RUNBOOK_STEP_30A_COMPLETE` | `true` |
+| `STEP30A_SCOPE` | `RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0` |
+| `STEP30A_GO_TOKEN` | `GO_BOUNDED_STEP30A_RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0` |
+| `STEP30A_OPERATOR_POLICY_RATIFIED` | `true` |
+| `STEP30A_OPERATOR_POLICY_DECISION` | `RATIFIED` |
+| `STEP30A_OPERATOR_POLICY_DECISION_REF` | `operator_policy_decision:STEP30A_RSI_REVERSION_V1` |
+| `STEP30A_FLEET_SIZING_PRECEDENT_REF` | `fleet_precedent:macd_v3_post_risk_limits_rewire` |
+| `STEP30A_RSI_WINDOW` | `14` |
+| `STEP30A_LOWER` | `30.0` |
+| `STEP30A_UPPER` | `70.0` |
+| `STEP30A_PRICE_COL` | `close` |
+| `STEP30A_SIGNAL_SEMANTICS` | `LONG_SHORT_REVERSION_-1_0_1` |
+| `STEP30A_USE_TREND_FILTER_FORBIDDEN_IN_CONFIG` | `true` |
+| `STEP30A_TRAINING_PERIOD` | `2026-04-02 10:07:00+00:00..2026-05-18 23:59:00+00:00` |
+| `STEP30A_VALIDATION_PERIOD` | `2026-05-19 00:00:00+00:00..2026-06-16 23:59:00+00:00` |
+| `STEP30A_HOLDOUT_FROZEN_REF` | `2026-06-17 10:07:00+00:00..2026-07-01 10:07:00+00:00` |
+| `STEP30A_DATASET_VERSION` | `v2` |
+| `STEP30A_DATASET_PATH` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/inst-eth-usdt-perp/v2/bars.parquet` |
+| `STEP30A_EVALUATION_AUTHORIZED` | `false` |
+| `STEP30A_PROMOTION_AUTHORIZED` | `false` |
+| `STEP30A_RUNTIME_AUTHORIZED` | `false` |
+| `STEP30A_PARAMETER_TUNING_ALLOWED` | `false` |
+| `STEP30A_THRESHOLD_TUNING_ALLOWED` | `false` |
+| `STEP30A_DATASET_REPLACEMENT_ALLOWED` | `false` |
+| `STEP30A_REGISTERED_ECONOMIC_EVALUATION_CONFIGS` | `config&#47;ops&#47;step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json` <!-- pt:ref-target-ignore --> |
+| `STEP30A_NO_NEW_CANDIDATE_HOLD_SUPERSEDED_SCOPE` | `STEP30A_ONLY` |
 | `SEPARATE_GO_REQUIRED` | `true` |
 
 #### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1

--- a/docs/governance/STEP30A_CANDIDATE_DESIGN_CONTRACT_V0.md
+++ b/docs/governance/STEP30A_CANDIDATE_DESIGN_CONTRACT_V0.md
@@ -1,0 +1,38 @@
+# STEP30A Candidate Design Contract v0
+
+## Candidate
+- Strategy: `rsi_reversion` (`v1`)
+- Owner: `src.strategies.rsi_reversion.RsiReversionStrategy`
+- Signal semantics: `LONG_SHORT_REVERSION_-1_0_1`
+
+## Ratified Strategy Parameters
+- `rsi_window=14`
+- `lower=30.0`
+- `upper=70.0`
+- `price_col=close`
+- Forbidden field in `economic_evaluation_v1.strategy_params`: `use_trend_filter`
+
+## Economic Evaluation Configuration
+- Canonical config path:
+  `config/ops/step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json`
+- Config schema:
+  `step30a_rsi_reversion_v1_economic_evaluation_admissibility_v1`
+
+## Split Policy (Holdout-Separated)
+- Training: `2026-04-02 10:07:00+00:00..2026-05-18 23:59:00+00:00`
+- Validation: `2026-05-19 00:00:00+00:00..2026-06-16 23:59:00+00:00`
+- Holdout/OOS: `2026-06-17 10:07:00+00:00..2026-07-01 10:07:00+00:00`
+- Contract condition: training and validation both end before holdout start
+
+## Dataset v2 and Placeholders
+- Dataset path:
+  `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/inst-eth-usdt-perp/v2/bars.parquet`
+- Placeholder digests (to be replaced post-ingestion):
+  - `PLACEHOLDER_V2_DATASET_DIGEST`
+  - `PLACEHOLDER_V2_MANIFEST_DIGEST`
+  - `PLACEHOLDER_SIZING_CONFIG_DIGEST`
+
+## Authority Constraints
+- `evaluation_authorized=false`
+- `promotion_authorized=false`
+- `runtime_authorized=false`

--- a/docs/governance/STEP30A_RSI_REVERSION_V1_OPERATOR_POLICY_DECISION_V0.md
+++ b/docs/governance/STEP30A_RSI_REVERSION_V1_OPERATOR_POLICY_DECISION_V0.md
@@ -1,0 +1,32 @@
+# STEP30A RSI Reversion v1 Operator Policy Decision v0
+
+## Scope
+- Slice: `RUNBOOK_STEP_30A`
+- Strategy: `rsi_reversion` (`v1`)
+- Instrument: `inst-eth-usdt-perp` on `OKX`
+- GO token: `GO_BOUNDED_STEP30A_RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0`
+
+## Ratified Fixed Parameters
+- `rsi_window=14`
+- `lower=30.0`
+- `upper=70.0`
+- `price_col=close`
+- `use_trend_filter` is forbidden in `strategy_params` for this slice
+
+## Holdout and Dataset Binding
+- Frozen holdout: `2026-06-17 10:07:00+00:00..2026-07-01 10:07:00+00:00`
+- Training period: `2026-04-02 10:07:00+00:00..2026-05-18 23:59:00+00:00`
+- Validation period: `2026-05-19 00:00:00+00:00..2026-06-16 23:59:00+00:00`
+- Dataset version binding: `v2` (`inst-eth-usdt-perp`)
+
+## Governance and Authority
+- `evaluation_authorized=false`
+- `promotion_authorized=false`
+- `runtime_authorized=false`
+- `parameter_tuning_allowed=false`
+- `threshold_tuning_allowed=false`
+- `dataset_replacement_allowed=false`
+
+## Derivation References
+- `operator_policy_decision:STEP30A_RSI_REVERSION_V1`
+- `fleet_precedent:macd_v3_post_risk_limits_rewire`

--- a/scripts/ops/ingest_okx_futures_public_market_data_canonical_dataset_staging_v1.py
+++ b/scripts/ops/ingest_okx_futures_public_market_data_canonical_dataset_staging_v1.py
@@ -601,12 +601,14 @@ def build_availability_matrix(
         "best_bid": {
             "available": False,
             "row_count": 0,
-            "reason": bid_ask_capability.get("capability_verdict"),
+            "reason": "NOT_AVAILABLE_BY_PUBLIC_SOURCE",
+            "reason_detail": bid_ask_capability.get("capability_verdict"),
         },
         "best_ask": {
             "available": False,
             "row_count": 0,
-            "reason": bid_ask_capability.get("capability_verdict"),
+            "reason": "NOT_AVAILABLE_BY_PUBLIC_SOURCE",
+            "reason_detail": bid_ask_capability.get("capability_verdict"),
         },
         "is_final": {
             "available": ohlcv_rows > 0,
@@ -615,16 +617,44 @@ def build_availability_matrix(
     }
 
 
-def all_required_series_available(matrix: Mapping[str, Any]) -> bool:
-    for field in REQUIRED_BAR_FIELDS:
-        key = field
-        if field in {"open", "high", "low", "close", "volume"}:
-            key = "OHLCV" if field == "open" else field
-        if field in {"open", "high", "low", "close", "volume"}:
+_RUNTIME_REQUIRED_AVAILABILITY_FIELDS = (
+    "OHLCV",
+    "mark_price",
+    "index_price",
+    "best_bid",
+    "best_ask",
+    "funding_rate",
+    "is_final",
+)
+
+_ECONOMIC_RESEARCH_REQUIRED_AVAILABILITY_FIELDS = (
+    "OHLCV",
+    "mark_price",
+    "index_price",
+    "funding_rate",
+    "is_final",
+)
+
+
+def required_availability_fields_for_profile(
+    dataset_profile: str = "runtime_market_context_v1",
+) -> Tuple[str, ...]:
+    if dataset_profile == "economic_research_v1":
+        return _ECONOMIC_RESEARCH_REQUIRED_AVAILABILITY_FIELDS
+    return _RUNTIME_REQUIRED_AVAILABILITY_FIELDS
+
+
+def all_required_series_available(
+    matrix: Mapping[str, Any],
+    *,
+    dataset_profile: str = "runtime_market_context_v1",
+) -> bool:
+    for field in required_availability_fields_for_profile(dataset_profile):
+        if field == "OHLCV":
             if not matrix.get("OHLCV", {}).get("available"):
                 return False
             continue
-        entry = matrix.get(field) or matrix.get(key)
+        entry = matrix.get(field)
         if not isinstance(entry, Mapping) or not entry.get("available"):
             return False
     return True

--- a/scripts/ops/ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
+++ b/scripts/ops/ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
@@ -51,12 +51,12 @@ def _validate_holdout_constants_match_step29m_v1() -> None:
 
 def run_step30a_dataset_v2_backward_extension_ingestion_v0(
     *,
-    confirm_go_token: str,
+    confirm_go: str,
     skip_network: bool = False,
     raw_staging_root: Optional[Path] = None,
 ) -> Mapping[str, Any]:
-    if confirm_go_token != ADAPTER_CONFIRM_GO:
-        raise Step30aDatasetIngestionError("confirm_go_token_mismatch")
+    if confirm_go != ADAPTER_CONFIRM_GO:
+        raise Step30aDatasetIngestionError("confirm_go_mismatch")
     if not skip_network:
         raise Step30aDatasetIngestionError(
             "network_ingestion_forbidden_use_verified_raw_staging_promotion"
@@ -65,7 +65,7 @@ def run_step30a_dataset_v2_backward_extension_ingestion_v0(
     _validate_holdout_constants_match_step29m_v1()
 
     result = run_step30a_dataset_v2_promotion_v0(
-        confirm_go_token=PROMOTION_CONFIRM_GO,
+        confirm_go=PROMOTION_CONFIRM_GO,
         raw_staging_root=raw_staging_root,
         target_dataset_root=STEP30A_DATASET_V2_TARGET_ROOT,
         durable_evidence_root=STEP30A_DURABLE_EVIDENCE_ROOT,
@@ -102,7 +102,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         description="STEP30A bounded dataset v2 backward extension ingestion adapter."
     )
     parser.add_argument(
-        "--confirm-go-token",
+        "--confirm-go",
         required=True,
         choices=[ADAPTER_CONFIRM_GO],
     )
@@ -114,7 +114,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("--raw-staging-root", type=Path, default=None)
     ns = parser.parse_args(argv)
     result = run_step30a_dataset_v2_backward_extension_ingestion_v0(
-        confirm_go_token=ns.confirm_go_token,
+        confirm_go=ns.confirm_go,
         skip_network=ns.skip_network,
         raw_staging_root=ns.raw_staging_root,
     )

--- a/scripts/ops/ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
+++ b/scripts/ops/ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""STEP30A bounded adapter for OKX ETH-USDT-SWAP dataset v2 staging.
+
+Narrow wrapper over verified raw staging promotion runner.
+No economic evaluation execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.stage_step30a_okx_inst_eth_usdt_perp_dataset_v2_from_raw_staging_v0 import (
+    DEFAULT_DURABLE_EVIDENCE_ROOT,
+    DEFAULT_TARGET_DATASET_ROOT,
+    GO_TOKEN as PROMOTION_GO_TOKEN,
+    STEP30A_FROZEN_HOLDOUT_END_UTC,
+    STEP30A_FROZEN_HOLDOUT_START_UTC,
+    STEP30A_STAGING_WINDOW_DAYS,
+    run_step30a_dataset_v2_promotion_v0,
+)
+
+GO_TOKEN = (
+    "GO_BOUNDED_STEP30A_RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0"
+)
+
+STEP30A_DATASET_V2_WINDOW_DAYS = STEP30A_STAGING_WINDOW_DAYS
+STEP30A_DATASET_V2_TARGET_ROOT = DEFAULT_TARGET_DATASET_ROOT
+STEP30A_DURABLE_EVIDENCE_ROOT = DEFAULT_DURABLE_EVIDENCE_ROOT
+
+STEP29M_FROZEN_HOLDOUT_START_UTC = STEP30A_FROZEN_HOLDOUT_START_UTC
+STEP29M_FROZEN_HOLDOUT_END_UTC = STEP30A_FROZEN_HOLDOUT_END_UTC
+
+
+class Step30aDatasetIngestionError(ValueError):
+    """Fail-closed adapter contract error."""
+
+
+def _validate_holdout_constants_match_step29m_v1() -> None:
+    if STEP30A_FROZEN_HOLDOUT_START_UTC != STEP29M_FROZEN_HOLDOUT_START_UTC:
+        raise Step30aDatasetIngestionError("holdout_start_not_matching_step29m_frozen_constant")
+    if STEP30A_FROZEN_HOLDOUT_END_UTC != STEP29M_FROZEN_HOLDOUT_END_UTC:
+        raise Step30aDatasetIngestionError("holdout_end_not_matching_step29m_frozen_constant")
+
+
+def run_step30a_dataset_v2_backward_extension_ingestion_v0(
+    *,
+    confirm_go_token: str,
+    skip_network: bool = False,
+    raw_staging_root: Optional[Path] = None,
+) -> Mapping[str, Any]:
+    if confirm_go_token != GO_TOKEN:
+        raise Step30aDatasetIngestionError("confirm_go_token_mismatch")
+    if not skip_network:
+        raise Step30aDatasetIngestionError(
+            "network_ingestion_forbidden_use_verified_raw_staging_promotion"
+        )
+
+    _validate_holdout_constants_match_step29m_v1()
+
+    result = run_step30a_dataset_v2_promotion_v0(
+        confirm_go_token=PROMOTION_GO_TOKEN,
+        raw_staging_root=raw_staging_root,
+        target_dataset_root=STEP30A_DATASET_V2_TARGET_ROOT,
+        durable_evidence_root=STEP30A_DURABLE_EVIDENCE_ROOT,
+    )
+    result = dict(result)
+    result["step30a_go_token"] = GO_TOKEN
+    result["step30a_dataset_window_days"] = STEP30A_DATASET_V2_WINDOW_DAYS
+    result["step30a_target_dataset_root"] = str(STEP30A_DATASET_V2_TARGET_ROOT)
+    result["step30a_durable_evidence_root"] = str(STEP30A_DURABLE_EVIDENCE_ROOT)
+    result["step30a_frozen_holdout_start_utc"] = STEP30A_FROZEN_HOLDOUT_START_UTC
+    result["step30a_frozen_holdout_end_utc"] = STEP30A_FROZEN_HOLDOUT_END_UTC
+    optional_warning = result.get("optional_warning")
+    if optional_warning is not None:
+        result["step30a_optional_warning"] = optional_warning
+    return result
+
+
+def _emit_machine_lines(payload: Mapping[str, Any]) -> None:
+    lines = [
+        f"STEP30A_GO_TOKEN={GO_TOKEN}",
+        f"STEP30A_DATASET_V2_WINDOW_DAYS={STEP30A_DATASET_V2_WINDOW_DAYS}",
+        f"STEP30A_TARGET_DATASET_ROOT={STEP30A_DATASET_V2_TARGET_ROOT}",
+        f"STEP30A_DURABLE_EVIDENCE_ROOT={STEP30A_DURABLE_EVIDENCE_ROOT}",
+    ]
+    optional_warning = payload.get("step30a_optional_warning")
+    if optional_warning is not None:
+        lines.append(f"STEP30A_OPTIONAL_WARNING={optional_warning}")
+    for line in lines:
+        print(line)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="STEP30A bounded dataset v2 backward extension ingestion adapter."
+    )
+    parser.add_argument(
+        "--confirm-go-token",
+        required=True,
+        choices=[GO_TOKEN],
+    )
+    parser.add_argument(
+        "--skip-network",
+        action="store_true",
+        help="Offline contract path using verified raw staging only.",
+    )
+    parser.add_argument("--raw-staging-root", type=Path, default=None)
+    ns = parser.parse_args(argv)
+    result = run_step30a_dataset_v2_backward_extension_ingestion_v0(
+        confirm_go_token=ns.confirm_go_token,
+        skip_network=ns.skip_network,
+        raw_staging_root=ns.raw_staging_root,
+    )
+    _emit_machine_lines(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
+++ b/scripts/ops/ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
@@ -17,16 +17,16 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.ops.stage_step30a_okx_inst_eth_usdt_perp_dataset_v2_from_raw_staging_v0 import (
+    CONFIRM_GO as PROMOTION_CONFIRM_GO,
     DEFAULT_DURABLE_EVIDENCE_ROOT,
     DEFAULT_TARGET_DATASET_ROOT,
-    GO_TOKEN as PROMOTION_GO_TOKEN,
     STEP30A_FROZEN_HOLDOUT_END_UTC,
     STEP30A_FROZEN_HOLDOUT_START_UTC,
     STEP30A_STAGING_WINDOW_DAYS,
     run_step30a_dataset_v2_promotion_v0,
 )
 
-GO_TOKEN = (
+ADAPTER_CONFIRM_GO = (
     "GO_BOUNDED_STEP30A_RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0"
 )
 
@@ -55,7 +55,7 @@ def run_step30a_dataset_v2_backward_extension_ingestion_v0(
     skip_network: bool = False,
     raw_staging_root: Optional[Path] = None,
 ) -> Mapping[str, Any]:
-    if confirm_go_token != GO_TOKEN:
+    if confirm_go_token != ADAPTER_CONFIRM_GO:
         raise Step30aDatasetIngestionError("confirm_go_token_mismatch")
     if not skip_network:
         raise Step30aDatasetIngestionError(
@@ -65,13 +65,13 @@ def run_step30a_dataset_v2_backward_extension_ingestion_v0(
     _validate_holdout_constants_match_step29m_v1()
 
     result = run_step30a_dataset_v2_promotion_v0(
-        confirm_go_token=PROMOTION_GO_TOKEN,
+        confirm_go_token=PROMOTION_CONFIRM_GO,
         raw_staging_root=raw_staging_root,
         target_dataset_root=STEP30A_DATASET_V2_TARGET_ROOT,
         durable_evidence_root=STEP30A_DURABLE_EVIDENCE_ROOT,
     )
     result = dict(result)
-    result["step30a_go_token"] = GO_TOKEN
+    result["step30a_confirm_go"] = ADAPTER_CONFIRM_GO
     result["step30a_dataset_window_days"] = STEP30A_DATASET_V2_WINDOW_DAYS
     result["step30a_target_dataset_root"] = str(STEP30A_DATASET_V2_TARGET_ROOT)
     result["step30a_durable_evidence_root"] = str(STEP30A_DURABLE_EVIDENCE_ROOT)
@@ -85,7 +85,7 @@ def run_step30a_dataset_v2_backward_extension_ingestion_v0(
 
 def _emit_machine_lines(payload: Mapping[str, Any]) -> None:
     lines = [
-        f"STEP30A_GO_TOKEN={GO_TOKEN}",
+        f"STEP30A_CONFIRM_GO={ADAPTER_CONFIRM_GO}",
         f"STEP30A_DATASET_V2_WINDOW_DAYS={STEP30A_DATASET_V2_WINDOW_DAYS}",
         f"STEP30A_TARGET_DATASET_ROOT={STEP30A_DATASET_V2_TARGET_ROOT}",
         f"STEP30A_DURABLE_EVIDENCE_ROOT={STEP30A_DURABLE_EVIDENCE_ROOT}",
@@ -104,7 +104,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument(
         "--confirm-go-token",
         required=True,
-        choices=[GO_TOKEN],
+        choices=[ADAPTER_CONFIRM_GO],
     )
     parser.add_argument(
         "--skip-network",

--- a/scripts/ops/stage_step30a_okx_inst_eth_usdt_perp_dataset_v2_from_raw_staging_v0.py
+++ b/scripts/ops/stage_step30a_okx_inst_eth_usdt_perp_dataset_v2_from_raw_staging_v0.py
@@ -215,14 +215,14 @@ def _optional_v1_holdout_digest_check_v1(holdout_digest: str) -> Optional[str]:
 
 def run_step30a_dataset_v2_promotion_v0(
     *,
-    confirm_go_token: str,
+    confirm_go: str,
     raw_staging_root: Optional[Path] = None,
     target_dataset_root: Path = DEFAULT_TARGET_DATASET_ROOT,
     durable_evidence_root: Path = DEFAULT_DURABLE_EVIDENCE_ROOT,
     dataset_parent: Path = DEFAULT_DATASET_PARENT,
 ) -> Mapping[str, Any]:
-    if confirm_go_token != CONFIRM_GO:
-        raise Step30aDatasetPromotionError("confirm_go_token_mismatch")
+    if confirm_go != CONFIRM_GO:
+        raise Step30aDatasetPromotionError("confirm_go_mismatch")
 
     verify_holdout_constants_match_step29m_v1()
     resolved_raw = raw_staging_root or resolve_verified_raw_staging_root_v1(dataset_parent)
@@ -380,7 +380,7 @@ def run_step30a_dataset_v2_promotion_v0(
         "holdout_binding": holdout_binding,
     }
     staging_config = {
-        "go_token": CONFIRM_GO,
+        "confirm_go": CONFIRM_GO,
         "dataset_profile": ds.DatasetProfileV1.ECONOMIC_RESEARCH_V1.value,
         "dataset_version": STEP30A_DATASET_VERSION,
         "dataset_schema_version": STEP30A_DATASET_SCHEMA_VERSION,
@@ -517,7 +517,7 @@ def run_step30a_dataset_v2_promotion_v0(
     evidence_dir.mkdir(parents=True, exist_ok=True)
     result = {
         "verdict": "STEP30A_DATASET_V2_PROMOTION_COMPLETE",
-        "go_token": CONFIRM_GO,
+        "confirm_go": CONFIRM_GO,
         "dataset_path": str(target_dataset_root),
         "manifest_path": str(target_dataset_root / "dataset_manifest.json"),
         "raw_staging_root": str(resolved_raw),
@@ -584,7 +584,7 @@ def _load_existing_promotion_result(
     manifest = json.loads((target_dataset_root / "dataset_manifest.json").read_text())
     result = {
         "verdict": "STEP30A_DATASET_V2_PROMOTION_COMPLETE",
-        "go_token": CONFIRM_GO,
+        "confirm_go": CONFIRM_GO,
         "dataset_path": str(target_dataset_root),
         "manifest_path": str(target_dataset_root / "dataset_manifest.json"),
         "raw_staging_root": str(raw_staging_root),
@@ -640,14 +640,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description="STEP30A bounded dataset v2 promotion from verified OKX raw staging."
     )
-    parser.add_argument("--confirm-go-token", required=True, choices=[CONFIRM_GO])
+    parser.add_argument("--confirm-go", required=True, choices=[CONFIRM_GO])
     parser.add_argument("--raw-staging-root", type=Path, default=None)
     parser.add_argument("--target-dataset-root", type=Path, default=DEFAULT_TARGET_DATASET_ROOT)
     parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_EVIDENCE_ROOT)
     parser.add_argument("--dataset-parent", type=Path, default=DEFAULT_DATASET_PARENT)
     ns = parser.parse_args(argv)
     run_step30a_dataset_v2_promotion_v0(
-        confirm_go_token=ns.confirm_go_token,
+        confirm_go=ns.confirm_go,
         raw_staging_root=ns.raw_staging_root,
         target_dataset_root=ns.target_dataset_root,
         durable_evidence_root=ns.durable_evidence_root,

--- a/scripts/ops/stage_step30a_okx_inst_eth_usdt_perp_dataset_v2_from_raw_staging_v0.py
+++ b/scripts/ops/stage_step30a_okx_inst_eth_usdt_perp_dataset_v2_from_raw_staging_v0.py
@@ -1,0 +1,660 @@
+#!/usr/bin/env python3
+"""STEP30A bounded dataset v2 promotion from verified OKX raw staging v0.
+
+Offline-only: normalizes economic_research_v1 bars, binds frozen STEP29M holdout
+partition digests, validates admissibility, and atomically promotes dataset v2.
+No network, no economic evaluation, no runtime effect.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+import pandas as pd
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops import (
+    ingest_okx_futures_public_market_data_canonical_dataset_staging_v1 as okx_ingest,
+)
+from scripts.ops import stage_okx_economic_research_dataset_from_raw_staging_v1 as research_staging
+from src.backtest import admissible_versioned_futures_dataset_v1 as ds
+
+GO_TOKEN = "GO_BOUNDED_STEP30A_DATASET_V2_CONTRACT_REMEDIATION_PRE_PR_AND_PR_V0"
+
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+DEFAULT_DATASET_PARENT = ARCHIVE_ROOT / "datasets" / "admissible_futures" / "inst-eth-usdt-perp"
+DEFAULT_TARGET_DATASET_ROOT = DEFAULT_DATASET_PARENT / "v2"
+DEFAULT_DURABLE_EVIDENCE_ROOT = ARCHIVE_ROOT / "planning_or_validation"
+
+STEP30A_DATASET_VERSION = "v2"
+STEP30A_DATASET_SCHEMA_VERSION = ds.DATASET_SCHEMA_VERSION_V2
+STEP30A_STAGING_WINDOW_DAYS = 90
+
+STEP29M_FROZEN_HOLDOUT_START_UTC = "2026-06-17 10:07:00+00:00"
+STEP29M_FROZEN_HOLDOUT_END_UTC = "2026-07-01 10:07:00+00:00"
+STEP30A_FROZEN_HOLDOUT_START_UTC = STEP29M_FROZEN_HOLDOUT_START_UTC
+STEP30A_FROZEN_HOLDOUT_END_UTC = STEP29M_FROZEN_HOLDOUT_END_UTC
+STEP30A_FROZEN_HOLDOUT_PERIOD = (
+    f"{STEP30A_FROZEN_HOLDOUT_START_UTC}..{STEP30A_FROZEN_HOLDOUT_END_UTC}"
+)
+STEP30A_TRAINING_PERIOD = "2026-04-02 10:07:00+00:00..2026-05-18 23:59:00+00:00"
+STEP30A_VALIDATION_PERIOD = "2026-05-19 00:00:00+00:00..2026-06-16 23:59:00+00:00"
+STEP30A_DEVELOPMENT_PERIOD = (
+    f"{STEP30A_TRAINING_PERIOD.split('..')[0]}..{STEP30A_VALIDATION_PERIOD.split('..')[1]}"
+)
+
+V1_DATASET_ROOT = DEFAULT_DATASET_PARENT / "v1"
+V1_MANIFEST_PATH = V1_DATASET_ROOT / "dataset_manifest.json"
+EXPECTED_V1_DATASET_DIGEST_PREFIX = "b4cbe7fff81a"
+
+MISSING_HISTORICAL_L1_REASON = ds.MissingHistoricalL1ReasonV1.NOT_AVAILABLE_BY_PUBLIC_SOURCE.value
+
+
+class Step30aDatasetPromotionError(ValueError):
+    """Fail-closed STEP30A dataset v2 promotion error."""
+
+
+def _utc_now_z() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_period_bounds(period: str) -> tuple[pd.Timestamp, pd.Timestamp]:
+    if ".." not in period:
+        raise Step30aDatasetPromotionError(f"invalid_period_format:{period}")
+    left, right = period.split("..", 1)
+    start = pd.Timestamp(left)
+    end = pd.Timestamp(right)
+    if start.tzinfo is None or end.tzinfo is None:
+        raise Step30aDatasetPromotionError("period_timezone_missing")
+    return start, end
+
+
+def _slice_for_period(bars: pd.DataFrame, period: str) -> pd.DataFrame:
+    start, end = _parse_period_bounds(period)
+    frame = bars.sort_index()
+    mask = (frame.index >= start) & (frame.index <= end)
+    return frame.loc[mask]
+
+
+def resolve_verified_raw_staging_root_v1(
+    dataset_parent: Path,
+    *,
+    min_staging_window_days: int = STEP30A_STAGING_WINDOW_DAYS,
+) -> Path:
+    candidates = sorted(dataset_parent.glob(".tmp_*"), reverse=True)
+    for candidate in candidates:
+        config_path = candidate / "INGESTION_CONFIG.json"
+        if not config_path.is_file():
+            continue
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        if int(config.get("staging_window_days", 0)) < min_staging_window_days:
+            continue
+        digest_report = research_staging.verify_raw_staging_digests(candidate)
+        if digest_report.verified:
+            return candidate
+    raise Step30aDatasetPromotionError("verified_raw_staging_root_not_found")
+
+
+def verify_holdout_constants_match_step29m_v1() -> None:
+    if STEP30A_FROZEN_HOLDOUT_START_UTC != STEP29M_FROZEN_HOLDOUT_START_UTC:
+        raise Step30aDatasetPromotionError("holdout_start_not_matching_step29m_frozen_constant")
+    if STEP30A_FROZEN_HOLDOUT_END_UTC != STEP29M_FROZEN_HOLDOUT_END_UTC:
+        raise Step30aDatasetPromotionError("holdout_end_not_matching_step29m_frozen_constant")
+
+
+def verify_holdout_separation_v1(bars: pd.DataFrame) -> tuple[str, ...]:
+    reasons: list[str] = []
+    train = _slice_for_period(bars, STEP30A_TRAINING_PERIOD)
+    val = _slice_for_period(bars, STEP30A_VALIDATION_PERIOD)
+    holdout = _slice_for_period(bars, STEP30A_FROZEN_HOLDOUT_PERIOD)
+    if train.empty:
+        reasons.append("training_partition_empty")
+    if val.empty:
+        reasons.append("validation_partition_empty")
+    if holdout.empty:
+        reasons.append("holdout_partition_empty")
+    if not train.empty and not val.empty and train.index.max() >= val.index.min():
+        reasons.append("training_validation_overlap")
+    if not val.empty and not holdout.empty and val.index.max() >= holdout.index.min():
+        reasons.append("validation_holdout_overlap")
+    if not train.empty and not holdout.empty and train.index.max() >= holdout.index.min():
+        reasons.append("training_holdout_overlap")
+    return tuple(reasons)
+
+
+def assert_holdout_access_blocked_v1(
+    bars: pd.DataFrame,
+    *,
+    evaluation_authorized: bool,
+) -> None:
+    """Raise when pre-evaluation access includes frozen holdout timestamps."""
+    if evaluation_authorized:
+        return
+    holdout_start = pd.Timestamp(STEP30A_FROZEN_HOLDOUT_START_UTC)
+    if (bars.index >= holdout_start).any():
+        raise Step30aDatasetPromotionError("holdout_access_blocked_before_evaluation")
+
+
+def verify_holdout_access_guard_v1(bars: pd.DataFrame) -> tuple[str, ...]:
+    reasons: list[str] = []
+    development = slice_development_partition_v1(bars)
+    holdout_start = pd.Timestamp(STEP30A_FROZEN_HOLDOUT_START_UTC)
+    if (development.index >= holdout_start).any():
+        reasons.append("development_partition_includes_holdout")
+    try:
+        assert_holdout_access_blocked_v1(bars, evaluation_authorized=False)
+        reasons.append("holdout_access_guard_failed_to_block_full_dataset")
+    except Step30aDatasetPromotionError:
+        pass
+    holdout = slice_frozen_holdout_partition_v1(bars)
+    try:
+        assert_holdout_access_blocked_v1(holdout, evaluation_authorized=False)
+        reasons.append("holdout_access_guard_failed_to_block_holdout_partition")
+    except Step30aDatasetPromotionError:
+        pass
+    return tuple(reasons)
+
+
+def slice_development_partition_v1(bars: pd.DataFrame) -> pd.DataFrame:
+    holdout_start = pd.Timestamp(STEP30A_FROZEN_HOLDOUT_START_UTC)
+    return bars.sort_index().loc[bars.index < holdout_start]
+
+
+def slice_frozen_holdout_partition_v1(bars: pd.DataFrame) -> pd.DataFrame:
+    return _slice_for_period(bars, STEP30A_FROZEN_HOLDOUT_PERIOD)
+
+
+def compute_partition_digests_v1(
+    bars: pd.DataFrame,
+    *,
+    field_bindings: ds.DatasetFieldBindingsV1,
+) -> dict[str, str]:
+    development = slice_development_partition_v1(bars)
+    holdout = slice_frozen_holdout_partition_v1(bars)
+    return {
+        "development_partition_digest": ds.compute_versioned_dataset_digest(
+            development, field_bindings=field_bindings
+        ),
+        "frozen_holdout_digest": ds.compute_versioned_dataset_digest(
+            holdout, field_bindings=field_bindings
+        ),
+        "normalized_dataset_digest": ds.compute_versioned_dataset_digest(
+            bars, field_bindings=field_bindings
+        ),
+    }
+
+
+def _optional_v1_holdout_digest_check_v1(holdout_digest: str) -> Optional[str]:
+    if not V1_MANIFEST_PATH.is_file():
+        return "v1_holdout_manifest_absent_optional_check_skipped"
+    payload = json.loads(V1_MANIFEST_PATH.read_text(encoding="utf-8"))
+    v1_digest = str(payload.get("normalized_dataset_digest", ""))
+    if not v1_digest:
+        return "v1_manifest_missing_normalized_dataset_digest_optional_check_skipped"
+    if v1_digest.startswith(EXPECTED_V1_DATASET_DIGEST_PREFIX):
+        if holdout_digest != v1_digest:
+            return (
+                "warning:holdout_digest_differs_from_v1_optional:"
+                f"expected={v1_digest}:actual={holdout_digest}"
+            )
+        return None
+    return (
+        "warning:v1_digest_prefix_mismatch_optional:"
+        f"expected_prefix={EXPECTED_V1_DATASET_DIGEST_PREFIX}:actual_digest={v1_digest}"
+    )
+
+
+def run_step30a_dataset_v2_promotion_v0(
+    *,
+    confirm_go_token: str,
+    raw_staging_root: Optional[Path] = None,
+    target_dataset_root: Path = DEFAULT_TARGET_DATASET_ROOT,
+    durable_evidence_root: Path = DEFAULT_DURABLE_EVIDENCE_ROOT,
+    dataset_parent: Path = DEFAULT_DATASET_PARENT,
+) -> Mapping[str, Any]:
+    if confirm_go_token != GO_TOKEN:
+        raise Step30aDatasetPromotionError("confirm_go_token_mismatch")
+
+    verify_holdout_constants_match_step29m_v1()
+    resolved_raw = raw_staging_root or resolve_verified_raw_staging_root_v1(dataset_parent)
+
+    ingestion_config = json.loads((resolved_raw / "INGESTION_CONFIG.json").read_text())
+    data_period = ingestion_config["data_period"]
+    bars, integrity = research_staging.normalize_economic_research_bars(
+        raw_dir=resolved_raw / "raw",
+        start_utc=str(data_period["start_utc"]),
+        end_utc=str(data_period["end_utc"]),
+    )
+    if not integrity.passed:
+        return {
+            "verdict": "DATASET_INTEGRITY_FAILED",
+            "integrity_report": integrity.__dict__,
+            "manifest_verify_rc": 1,
+        }
+
+    holdout_reasons = verify_holdout_separation_v1(bars)
+    if holdout_reasons:
+        return {
+            "verdict": "HOLDOUT_SEPARATION_FAILED",
+            "reason_codes": list(holdout_reasons),
+            "manifest_verify_rc": 1,
+        }
+
+    access_reasons = verify_holdout_access_guard_v1(bars)
+    if access_reasons:
+        return {
+            "verdict": "HOLDOUT_ACCESS_BLOCK_FAILED",
+            "reason_codes": list(access_reasons),
+            "manifest_verify_rc": 1,
+        }
+
+    cost_binding = research_staging.build_cost_model_binding()
+    profile_binding = research_staging.build_profile_binding(cost_binding)
+    field_bindings = ds.field_bindings_for_profile(ds.DatasetProfileV1.ECONOMIC_RESEARCH_V1)
+    digests = compute_partition_digests_v1(bars, field_bindings=field_bindings)
+    optional_warning = _optional_v1_holdout_digest_check_v1(digests["frozen_holdout_digest"])
+
+    provenance = ds.DatasetProvenanceV1(
+        source_type="operator_staged_futures_v1",
+        venue_id="OKX",
+        ingestion_timestamp=str(
+            json.loads((resolved_raw / "reports" / "PROVENANCE.json").read_text())[
+                "ingestion_timestamp_utc"
+            ]
+        ),
+        generation_method="step30a_okx_economic_research_dataset_v2_staging_v0",
+        provenance_ref=str(resolved_raw / "reports" / "PROVENANCE.json"),
+    )
+    idx = bars.sort_index().index
+    descriptor = ds.VersionedFuturesDatasetDescriptorV1(
+        dataset_id=f"{okx_ingest.CANONICAL_INSTRUMENT_ID}_{STEP30A_DATASET_VERSION}",
+        dataset_version=STEP30A_DATASET_VERSION,
+        dataset_schema_version=STEP30A_DATASET_SCHEMA_VERSION,
+        dataset_digest=digests["normalized_dataset_digest"],
+        instrument_id=okx_ingest.CANONICAL_INSTRUMENT_ID,
+        contract_type=okx_ingest.CANONICAL_CONTRACT_TYPE,
+        futures_only=True,
+        bitcoin_direction_allowed=False,
+        venue_id="OKX",
+        start_time=str(idx[0]),
+        end_time=str(idx[-1]),
+        row_count=len(bars),
+        field_bindings=field_bindings,
+        training_period=STEP30A_TRAINING_PERIOD,
+        validation_period=STEP30A_VALIDATION_PERIOD,
+        out_of_sample_period=STEP30A_FROZEN_HOLDOUT_PERIOD,
+        split_policy_version=ds.SPLIT_POLICY_VERSION,
+        timestamp_semantics=ds.TIMESTAMP_SEMANTICS,
+        timezone=ds.TIMEZONE,
+        ordering_status=ds.ORDERING_STATUS_SORTED,
+        duplicate_policy=ds.DUPLICATE_POLICY,
+        missing_data_policy=ds.MISSING_DATA_POLICY,
+    )
+
+    admissibility = ds.evaluate_admissible_versioned_futures_dataset_v1(
+        bars=bars,
+        descriptor=descriptor,
+        provenance=provenance,
+        instrument_id=okx_ingest.CANONICAL_INSTRUMENT_ID,
+        profile_binding=profile_binding,
+    )
+    runtime_rejection = ds.evaluate_admissible_versioned_futures_dataset_v1(
+        bars=bars,
+        descriptor=descriptor,
+        provenance=provenance,
+        instrument_id=okx_ingest.CANONICAL_INSTRUMENT_ID,
+        profile_binding=ds.default_runtime_profile_binding_v1(),
+    )
+    if not admissibility.is_admissible():
+        return {
+            "verdict": "DATASET_PROFILE_ADMISSIBILITY_FAILED",
+            "admissibility_status": admissibility.admissibility_status.value,
+            "reason_codes": list(admissibility.reason_codes),
+            "manifest_verify_rc": 1,
+        }
+    if runtime_rejection.is_admissible():
+        return {
+            "verdict": "DATASET_PROFILE_ADMISSIBILITY_FAILED",
+            "reason_codes": ["runtime_profile_must_reject_research_dataset"],
+            "manifest_verify_rc": 1,
+        }
+
+    if target_dataset_root.exists():
+        existing_manifest = target_dataset_root / "dataset_manifest.json"
+        if existing_manifest.is_file():
+            existing = json.loads(existing_manifest.read_text(encoding="utf-8"))
+            if (
+                str(existing.get("normalized_dataset_digest"))
+                == digests["normalized_dataset_digest"]
+            ):
+                return _load_existing_promotion_result(
+                    target_dataset_root=target_dataset_root,
+                    raw_staging_root=resolved_raw,
+                    digests=digests,
+                    optional_warning=optional_warning,
+                )
+        raise Step30aDatasetPromotionError(f"target_dataset_root_exists:{target_dataset_root}")
+
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    tmp_root = target_dataset_root.parent / f".tmp_{ts_slug}"
+    if tmp_root.exists():
+        shutil.rmtree(tmp_root)
+    tmp_root.mkdir(parents=True)
+
+    instrument_binding = json.loads((resolved_raw / "INSTRUMENT_BINDING.json").read_text())
+    request_log = json.loads((resolved_raw / "reports" / "REQUEST_LOG.json").read_text())
+    raw_response_digests = {
+        str(entry.get("raw_response_path", "")): str(entry.get("raw_response_sha256", ""))
+        for entry in request_log
+        if entry.get("raw_response_sha256")
+    }
+
+    holdout_binding = {
+        "frozen_holdout_period": STEP30A_FROZEN_HOLDOUT_PERIOD,
+        "frozen_holdout_start_utc": STEP30A_FROZEN_HOLDOUT_START_UTC,
+        "frozen_holdout_end_utc": STEP30A_FROZEN_HOLDOUT_END_UTC,
+        "frozen_holdout_digest": digests["frozen_holdout_digest"],
+        "development_period": STEP30A_DEVELOPMENT_PERIOD,
+        "development_partition_digest": digests["development_partition_digest"],
+        "holdout_access_before_evaluation": "BLOCKED",
+        "step29m_v1_holdout_reference_root": str(V1_DATASET_ROOT),
+    }
+    split_binding = {
+        "split_policy_version": ds.SPLIT_POLICY_VERSION,
+        "training_period": STEP30A_TRAINING_PERIOD,
+        "validation_period": STEP30A_VALIDATION_PERIOD,
+        "out_of_sample_period": STEP30A_FROZEN_HOLDOUT_PERIOD,
+        "development_period": STEP30A_DEVELOPMENT_PERIOD,
+        "disjoint": True,
+        "temporally_ordered": True,
+        "leakage_free": admissibility.leakage_check_status == "PASS",
+        "holdout_binding": holdout_binding,
+    }
+    staging_config = {
+        "go_token": GO_TOKEN,
+        "dataset_profile": ds.DatasetProfileV1.ECONOMIC_RESEARCH_V1.value,
+        "dataset_version": STEP30A_DATASET_VERSION,
+        "dataset_schema_version": STEP30A_DATASET_SCHEMA_VERSION,
+        "l1_observation_status": ds.L1ObservationStatusV1.EXECUTION_MODEL_BOUND_NOT_OBSERVED.value,
+        "missing_historical_l1_reason": MISSING_HISTORICAL_L1_REASON,
+        "observed_l1_used": False,
+        "raw_staging_root": str(resolved_raw),
+        "target_dataset_root": str(target_dataset_root),
+        "staging_window_days": STEP30A_STAGING_WINDOW_DAYS,
+    }
+    data_quality = {
+        "dataset_admissible": True,
+        "integrity_pass": integrity.passed,
+        "raw_row_counts": integrity.raw_row_counts,
+        "join_row_count": integrity.join_row_count,
+        "discarded_rows": integrity.discarded_rows,
+        "gap_statistics": integrity.gap_statistics,
+        "missingness": integrity.missingness,
+        "staleness": integrity.staleness,
+        "data_period": integrity.data_period,
+        "bar_granularity": integrity.bar_granularity,
+        "reason_codes": list(integrity.reason_codes),
+        "missing_historical_l1_reason": MISSING_HISTORICAL_L1_REASON,
+    }
+
+    manifest_without_digest: dict[str, Any] = {
+        "manifest_version": research_staging.MANIFEST_VERSION,
+        "dataset_profile": ds.DatasetProfileV1.ECONOMIC_RESEARCH_V1.value,
+        "dataset_version": STEP30A_DATASET_VERSION,
+        "dataset_schema_version": STEP30A_DATASET_SCHEMA_VERSION,
+        "contract_version": ds.ADMISSIBLE_VERSIONED_FUTURES_DATASET_VERSION,
+        "instrument_id": okx_ingest.CANONICAL_INSTRUMENT_ID,
+        "native_instrument_id": okx_ingest.NATIVE_INSTRUMENT_ID,
+        "contract_type": okx_ingest.CANONICAL_CONTRACT_TYPE,
+        "futures_only": True,
+        "data_period": integrity.data_period,
+        "bar_granularity": integrity.bar_granularity,
+        "row_count": len(bars),
+        "required_columns": sorted(
+            ds.required_bar_columns_for_profile(ds.DatasetProfileV1.ECONOMIC_RESEARCH_V1)
+        ),
+        "optional_columns": [],
+        "l1_observation_status": ds.L1ObservationStatusV1.EXECUTION_MODEL_BOUND_NOT_OBSERVED.value,
+        "missing_historical_l1_reason": MISSING_HISTORICAL_L1_REASON,
+        "observed_l1_used": False,
+        "execution_cost_binding": cost_binding["execution_cost_binding"],
+        "fee_model_version": cost_binding["fee_model_version"],
+        "slippage_model_version": cost_binding["slippage_model_version"],
+        "spread_model_version": cost_binding["spread_model_version"],
+        "execution_model_version": cost_binding["execution_model_version"],
+        "source_endpoints": ingestion_config.get("acquisition_endpoint_order", []),
+        "acquisition_timestamps": {
+            "ingestion_timestamp_utc": provenance.ingestion_timestamp,
+            "staging_timestamp_utc": _utc_now_z(),
+        },
+        "provenance": {
+            "source_type": provenance.source_type,
+            "source_venue": provenance.venue_id,
+            "native_instrument_id": okx_ingest.NATIVE_INSTRUMENT_ID,
+            "canonical_instrument_id": okx_ingest.CANONICAL_INSTRUMENT_ID,
+            "contract_type": okx_ingest.CANONICAL_CONTRACT_TYPE,
+            "acquisition_method": "okx_public_rest_api_v5",
+            "authenticated": False,
+            "credentials_used": False,
+            "dataset_profile": ds.DatasetProfileV1.ECONOMIC_RESEARCH_V1.value,
+            "l1_observation_status": ds.L1ObservationStatusV1.EXECUTION_MODEL_BOUND_NOT_OBSERVED.value,
+            "missing_historical_l1_reason": MISSING_HISTORICAL_L1_REASON,
+            "observed_l1_used": False,
+            "generation_method": "step30a_okx_economic_research_dataset_v2_staging_v0",
+            "staging_timestamp_utc": _utc_now_z(),
+            "raw_staging_root": str(resolved_raw),
+        },
+        "instrument_metadata": instrument_binding.get("instrument_metadata", {}),
+        "join_policies": ingestion_config.get("join_policies", {}),
+        "staleness_limits": {
+            "max_mark_index_staleness_ms": okx_ingest.MAX_MARK_INDEX_STALENESS_MS,
+            "max_funding_staleness_ms": okx_ingest.MAX_FUNDING_STALENESS_MS,
+        },
+        "integrity_results": data_quality,
+        "training_period": STEP30A_TRAINING_PERIOD,
+        "validation_period": STEP30A_VALIDATION_PERIOD,
+        "out_of_sample_period": STEP30A_FROZEN_HOLDOUT_PERIOD,
+        "development_period": STEP30A_DEVELOPMENT_PERIOD,
+        "holdout_binding": holdout_binding,
+        "raw_response_digests": raw_response_digests,
+        "normalized_dataset_digest": digests["normalized_dataset_digest"],
+        "development_partition_digest": digests["development_partition_digest"],
+        "frozen_holdout_digest": digests["frozen_holdout_digest"],
+        "implementation_digest": admissibility.implementation_digest,
+        "config_digest": admissibility.config_digest,
+        "profile_binding": profile_binding.to_dict(),
+        "profile_binding_digest": admissibility.profile_binding_digest,
+    }
+    manifest_digest = okx_ingest._stable_digest(manifest_without_digest)
+    manifest = {**manifest_without_digest, "manifest_digest": manifest_digest}
+
+    bars_out = bars.reset_index().rename(columns={"index": "timestamp"})
+    if "timestamp" not in bars_out.columns:
+        bars_out = bars.reset_index()
+    bars_out["timestamp"] = pd.to_datetime(bars_out["timestamp"], utc=True).map(
+        lambda ts: ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    bars_out.to_parquet(tmp_root / "bars.parquet", index=False)
+
+    for name, payload in (
+        ("dataset_manifest.json", manifest),
+        ("STAGING_CONFIG.json", staging_config),
+        ("DATA_QUALITY_REPORT.json", data_quality),
+        ("INSTRUMENT_BINDING.json", instrument_binding),
+        ("COST_MODEL_BINDING.json", cost_binding),
+        ("SPLIT_BINDING.json", split_binding),
+        ("HOLDOUT_BINDING.json", holdout_binding),
+        ("PROVENANCE.json", manifest["provenance"]),
+    ):
+        (tmp_root / name).write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    post_manifest = json.loads((tmp_root / "dataset_manifest.json").read_text(encoding="utf-8"))
+    post_digest = okx_ingest._stable_digest(
+        {k: v for k, v in post_manifest.items() if k != "manifest_digest"}
+    )
+    if post_digest != post_manifest["manifest_digest"]:
+        raise Step30aDatasetPromotionError("manifest_digest_mismatch_after_write")
+
+    target_dataset_root.parent.mkdir(parents=True, exist_ok=True)
+    tmp_root.rename(target_dataset_root)
+
+    evidence_dir = (
+        durable_evidence_root
+        / "implementation"
+        / f"step30a_okx_inst_eth_usdt_perp_dataset_v2_promotion_v0_{ts_slug}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    result = {
+        "verdict": "STEP30A_DATASET_V2_PROMOTION_COMPLETE",
+        "go_token": GO_TOKEN,
+        "dataset_path": str(target_dataset_root),
+        "manifest_path": str(target_dataset_root / "dataset_manifest.json"),
+        "raw_staging_root": str(resolved_raw),
+        "dataset_digest": digests["normalized_dataset_digest"],
+        "manifest_digest": manifest_digest,
+        "development_partition_digest": digests["development_partition_digest"],
+        "frozen_holdout_digest": digests["frozen_holdout_digest"],
+        "dataset_version": STEP30A_DATASET_VERSION,
+        "dataset_schema_version": STEP30A_DATASET_SCHEMA_VERSION,
+        "row_count": len(bars),
+        "raw_response_count": len(raw_response_digests),
+        "raw_bar_count": integrity.raw_row_counts.get("ohlcv", 0),
+        "normalized_bar_count": len(bars),
+        "missing_historical_l1_reason": MISSING_HISTORICAL_L1_REASON,
+        "holdout_period": STEP30A_FROZEN_HOLDOUT_PERIOD,
+        "holdout_separation_pass": True,
+        "holdout_access_block_pass": True,
+        "admissibility_status": admissibility.admissibility_status.value,
+        "runtime_rejection_status": runtime_rejection.admissibility_status.value,
+        "integrity_report": integrity.__dict__,
+        "cost_binding": cost_binding,
+        "split_binding": split_binding,
+        "holdout_binding": holdout_binding,
+        "real_admissible_futures_dataset_found": True,
+        "real_admissible_futures_evidence_present": True,
+        "real_evaluation_performed": False,
+        "economic_validity_result": "NOT_PROVEN",
+        "economic_evaluation_executed": False,
+        "order_effect": False,
+        "runtime_effect": False,
+    }
+    if optional_warning is not None:
+        result["optional_warning"] = optional_warning
+
+    (evidence_dir / "PROMOTION_RESULT.json").write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    for rel in (
+        "dataset_manifest.json",
+        "STAGING_CONFIG.json",
+        "DATA_QUALITY_REPORT.json",
+        "HOLDOUT_BINDING.json",
+        "SPLIT_BINDING.json",
+    ):
+        shutil.copy2(target_dataset_root / rel, evidence_dir / rel)
+
+    from scripts.ops import primary_evidence_retention_v0 as retention
+
+    rc, verify_msg = retention.finalize_durable_bundle_manifest(evidence_dir)
+    result["durable_evidence_path"] = str(evidence_dir)
+    result["manifest_verify_rc"] = rc
+    result["manifest_verify_msg"] = verify_msg
+    _emit_machine_lines(result)
+    return result
+
+
+def _load_existing_promotion_result(
+    *,
+    target_dataset_root: Path,
+    raw_staging_root: Path,
+    digests: Mapping[str, str],
+    optional_warning: Optional[str],
+) -> dict[str, Any]:
+    manifest = json.loads((target_dataset_root / "dataset_manifest.json").read_text())
+    result = {
+        "verdict": "STEP30A_DATASET_V2_PROMOTION_COMPLETE",
+        "go_token": GO_TOKEN,
+        "dataset_path": str(target_dataset_root),
+        "manifest_path": str(target_dataset_root / "dataset_manifest.json"),
+        "raw_staging_root": str(raw_staging_root),
+        "dataset_digest": digests["normalized_dataset_digest"],
+        "manifest_digest": str(manifest.get("manifest_digest", "")),
+        "development_partition_digest": digests["development_partition_digest"],
+        "frozen_holdout_digest": digests["frozen_holdout_digest"],
+        "dataset_version": STEP30A_DATASET_VERSION,
+        "dataset_schema_version": STEP30A_DATASET_SCHEMA_VERSION,
+        "row_count": int(manifest.get("row_count", 0)),
+        "normalized_bar_count": int(manifest.get("row_count", 0)),
+        "missing_historical_l1_reason": MISSING_HISTORICAL_L1_REASON,
+        "holdout_period": STEP30A_FROZEN_HOLDOUT_PERIOD,
+        "holdout_separation_pass": True,
+        "holdout_access_block_pass": True,
+        "real_admissible_futures_dataset_found": True,
+        "real_evaluation_performed": False,
+        "economic_evaluation_executed": False,
+        "idempotent_reuse": True,
+        "manifest_verify_rc": 0,
+    }
+    if optional_warning is not None:
+        result["optional_warning"] = optional_warning
+    _emit_machine_lines(result)
+    return result
+
+
+def _emit_machine_lines(result: Mapping[str, Any]) -> None:
+    lines = [
+        f"STEP30A_GO_TOKEN={GO_TOKEN}",
+        f"VERDICT={result.get('verdict')}",
+        f"DATASET_V2_PATH={result.get('dataset_path', '')}",
+        f"DATASET_V2_DIGEST={result.get('dataset_digest', '')}",
+        f"DEVELOPMENT_PARTITION_DIGEST={result.get('development_partition_digest', '')}",
+        f"FROZEN_HOLDOUT_DIGEST={result.get('frozen_holdout_digest', '')}",
+        f"HOLDOUT_PERIOD={result.get('holdout_period', STEP30A_FROZEN_HOLDOUT_PERIOD)}",
+        f"NORMALIZED_BAR_COUNT={result.get('normalized_bar_count', 0)}",
+        f"RAW_BAR_COUNT={result.get('raw_bar_count', 0)}",
+        f"MISSING_HISTORICAL_L1_REASON={MISSING_HISTORICAL_L1_REASON}",
+        f"MANIFEST_VERIFY_RC={result.get('manifest_verify_rc', 1)}",
+        "ECONOMIC_EVALUATION_EXECUTED=false",
+        "ORDER_EFFECT=false",
+        "RUNTIME_EFFECT=false",
+    ]
+    optional_warning = result.get("optional_warning")
+    if optional_warning is not None:
+        lines.append(f"STEP30A_OPTIONAL_WARNING={optional_warning}")
+    for line in lines:
+        print(line)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="STEP30A bounded dataset v2 promotion from verified OKX raw staging."
+    )
+    parser.add_argument("--confirm-go-token", required=True, choices=[GO_TOKEN])
+    parser.add_argument("--raw-staging-root", type=Path, default=None)
+    parser.add_argument("--target-dataset-root", type=Path, default=DEFAULT_TARGET_DATASET_ROOT)
+    parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_EVIDENCE_ROOT)
+    parser.add_argument("--dataset-parent", type=Path, default=DEFAULT_DATASET_PARENT)
+    ns = parser.parse_args(argv)
+    run_step30a_dataset_v2_promotion_v0(
+        confirm_go_token=ns.confirm_go_token,
+        raw_staging_root=ns.raw_staging_root,
+        target_dataset_root=ns.target_dataset_root,
+        durable_evidence_root=ns.durable_evidence_root,
+        dataset_parent=ns.dataset_parent,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/stage_step30a_okx_inst_eth_usdt_perp_dataset_v2_from_raw_staging_v0.py
+++ b/scripts/ops/stage_step30a_okx_inst_eth_usdt_perp_dataset_v2_from_raw_staging_v0.py
@@ -28,7 +28,7 @@ from scripts.ops import (
 from scripts.ops import stage_okx_economic_research_dataset_from_raw_staging_v1 as research_staging
 from src.backtest import admissible_versioned_futures_dataset_v1 as ds
 
-GO_TOKEN = "GO_BOUNDED_STEP30A_DATASET_V2_CONTRACT_REMEDIATION_PRE_PR_AND_PR_V0"
+CONFIRM_GO = "GO_BOUNDED_STEP30A_DATASET_V2_CONTRACT_REMEDIATION_PRE_PR_AND_PR_V0"
 
 ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
 DEFAULT_DATASET_PARENT = ARCHIVE_ROOT / "datasets" / "admissible_futures" / "inst-eth-usdt-perp"
@@ -221,7 +221,7 @@ def run_step30a_dataset_v2_promotion_v0(
     durable_evidence_root: Path = DEFAULT_DURABLE_EVIDENCE_ROOT,
     dataset_parent: Path = DEFAULT_DATASET_PARENT,
 ) -> Mapping[str, Any]:
-    if confirm_go_token != GO_TOKEN:
+    if confirm_go_token != CONFIRM_GO:
         raise Step30aDatasetPromotionError("confirm_go_token_mismatch")
 
     verify_holdout_constants_match_step29m_v1()
@@ -380,7 +380,7 @@ def run_step30a_dataset_v2_promotion_v0(
         "holdout_binding": holdout_binding,
     }
     staging_config = {
-        "go_token": GO_TOKEN,
+        "go_token": CONFIRM_GO,
         "dataset_profile": ds.DatasetProfileV1.ECONOMIC_RESEARCH_V1.value,
         "dataset_version": STEP30A_DATASET_VERSION,
         "dataset_schema_version": STEP30A_DATASET_SCHEMA_VERSION,
@@ -517,7 +517,7 @@ def run_step30a_dataset_v2_promotion_v0(
     evidence_dir.mkdir(parents=True, exist_ok=True)
     result = {
         "verdict": "STEP30A_DATASET_V2_PROMOTION_COMPLETE",
-        "go_token": GO_TOKEN,
+        "go_token": CONFIRM_GO,
         "dataset_path": str(target_dataset_root),
         "manifest_path": str(target_dataset_root / "dataset_manifest.json"),
         "raw_staging_root": str(resolved_raw),
@@ -584,7 +584,7 @@ def _load_existing_promotion_result(
     manifest = json.loads((target_dataset_root / "dataset_manifest.json").read_text())
     result = {
         "verdict": "STEP30A_DATASET_V2_PROMOTION_COMPLETE",
-        "go_token": GO_TOKEN,
+        "go_token": CONFIRM_GO,
         "dataset_path": str(target_dataset_root),
         "manifest_path": str(target_dataset_root / "dataset_manifest.json"),
         "raw_staging_root": str(raw_staging_root),
@@ -614,7 +614,7 @@ def _load_existing_promotion_result(
 
 def _emit_machine_lines(result: Mapping[str, Any]) -> None:
     lines = [
-        f"STEP30A_GO_TOKEN={GO_TOKEN}",
+        f"STEP30A_CONFIRM_GO={CONFIRM_GO}",
         f"VERDICT={result.get('verdict')}",
         f"DATASET_V2_PATH={result.get('dataset_path', '')}",
         f"DATASET_V2_DIGEST={result.get('dataset_digest', '')}",
@@ -640,7 +640,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description="STEP30A bounded dataset v2 promotion from verified OKX raw staging."
     )
-    parser.add_argument("--confirm-go-token", required=True, choices=[GO_TOKEN])
+    parser.add_argument("--confirm-go-token", required=True, choices=[CONFIRM_GO])
     parser.add_argument("--raw-staging-root", type=Path, default=None)
     parser.add_argument("--target-dataset-root", type=Path, default=DEFAULT_TARGET_DATASET_ROOT)
     parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_EVIDENCE_ROOT)

--- a/src/backtest/admissible_versioned_futures_dataset_v1.py
+++ b/src/backtest/admissible_versioned_futures_dataset_v1.py
@@ -20,6 +20,8 @@ ADMISSIBLE_VERSIONED_FUTURES_DATASET_VERSION = "backtest_admissible_versioned_fu
 ADMISSIBLE_VERSIONED_FUTURES_DATASET_OWNER = "backtest.admissible_versioned_futures_dataset_v1"
 DEFAULT_DATASET_VERSION = "v1"
 DATASET_SCHEMA_VERSION = "v1"
+DATASET_SCHEMA_VERSION_V2 = "v2"
+ALLOWED_DATASET_SCHEMA_VERSIONS = frozenset({DATASET_SCHEMA_VERSION, DATASET_SCHEMA_VERSION_V2})
 SPLIT_POLICY_VERSION = "v1"
 TIMESTAMP_SEMANTICS = "utc_bar_close_exclusive_end"
 TIMEZONE = "UTC"
@@ -76,6 +78,10 @@ class DatasetProfileV1(str, Enum):
 class L1ObservationStatusV1(str, Enum):
     OBSERVED_HISTORICAL_L1 = "OBSERVED_HISTORICAL_L1"
     EXECUTION_MODEL_BOUND_NOT_OBSERVED = "EXECUTION_MODEL_BOUND_NOT_OBSERVED"
+
+
+class MissingHistoricalL1ReasonV1(str, Enum):
+    NOT_AVAILABLE_BY_PUBLIC_SOURCE = "NOT_AVAILABLE_BY_PUBLIC_SOURCE"
 
 
 class AdmissibilityStatus(str, Enum):
@@ -931,7 +937,7 @@ def evaluate_admissible_versioned_futures_dataset_v1(
     if descriptor.instrument_id != instrument_id:
         reason_codes.append("instrument_id_mismatch")
 
-    if descriptor.dataset_schema_version != DATASET_SCHEMA_VERSION:
+    if descriptor.dataset_schema_version not in ALLOWED_DATASET_SCHEMA_VERSIONS:
         status = AdmissibilityStatus.BLOCKED_SCHEMA_MISMATCH
         reason_codes.append("dataset_schema_version_mismatch")
 

--- a/src/backtest/offline_evaluation_sizing_contract_v1.py
+++ b/src/backtest/offline_evaluation_sizing_contract_v1.py
@@ -31,7 +31,9 @@ ALLOWED_STOP_DISTANCE_POLICIES = frozenset({"FIXED_PCT_FROM_ENTRY_v1"})
 ALLOWED_QUANTITY_ROUNDING_POLICIES = frozenset({"NONE_v1"})
 ALLOWED_MINIMUM_QUANTITY_POLICIES = frozenset({"REJECT_BELOW_MIN_NOTIONAL_v1"})
 ALLOWED_MINIMUM_NOTIONAL_POLICIES = frozenset({"USE_RISK_MIN_POSITION_VALUE_v1"})
-ALLOWED_INSTRUMENT_METADATA_SOURCES = frozenset({"versioned_dataset_manifest_v1"})
+ALLOWED_INSTRUMENT_METADATA_SOURCES = frozenset(
+    {"versioned_dataset_manifest_v1", "versioned_dataset_manifest_v2"}
+)
 ALLOWED_PRICE_SOURCES = frozenset({"bar_close_v1"})
 ALLOWED_SIZING_MODES = frozenset({"fixed_fractional_risk_per_trade_v1"})
 

--- a/src/backtest/step30a_rsi_reversion_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step30a_rsi_reversion_v1_economic_evaluation_admissibility_contract_v1.py
@@ -1,0 +1,503 @@
+"""
+STEP 30A rsi_reversion v1 economic evaluation admissibility contract v1.
+
+Read-only contract diagnostics for operator-ratified fixed-config policy,
+parameter binding, split/holdout separation, and staged config readiness.
+No economic evaluation execution.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import pandas as pd
+
+from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 import (
+    compute_evaluation_config_digest_v1,
+    verify_cost_binding_v1,
+)
+from src.backtest.strategy_signal_binding_v1 import (
+    ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    StrategySignalBindingError,
+    collect_configured_strategy_params_v1,
+    compute_required_warmup_rows_v1,
+    project_strategy_params_for_binding_v1,
+    resolve_effective_strategy_params_v1,
+)
+from src.strategies.registry import get_strategy_registry_entry, resolve_strategy_id
+
+CONTRACT_LAYER_VERSION = "v1"
+CONTRACT_OWNER = "backtest.step30a_rsi_reversion_v1_economic_evaluation_admissibility_contract_v1"
+
+RSI_REVERSION_V1_STRATEGY_ID = "rsi_reversion"
+RSI_REVERSION_V1_STRATEGY_VERSION = "v1"
+RSI_REVERSION_V1_STRATEGY_OWNER = "src.strategies.rsi_reversion.RsiReversionStrategy"
+RSI_REVERSION_V1_CANONICAL_PARAMS = {
+    "rsi_window": 14,
+    "lower": 30.0,
+    "upper": 70.0,
+    "price_col": "close",
+}
+SIGNAL_SEMANTICS = "LONG_SHORT_REVERSION_-1_0_1"
+
+RSI_WINDOW_MIN = 2
+RSI_WINDOW_MAX = 100
+ALLOWED_PRICE_COLS = frozenset({"open", "high", "low", "close"})
+
+OPERATOR_RATIFIED_RISK_PER_TRADE = 0.005
+OPERATOR_RATIFIED_STOP_PCT = 0.025
+OPERATOR_RATIFIED_MAX_POSITION_PCT = 0.25
+OFFLINE_BOUND_OVERSIZE_POLICY = "REJECT_OVERSIZE"
+POLICY_INVARIANT = "risk_per_trade <= max_position_pct * stop_pct"
+POLICY_INVARIANT_RESULT = "0.005 <= 0.25 * 0.025 = 0.00625"
+OPERATOR_POLICY_DERIVATION_REF = "operator_policy_decision:STEP30A_RSI_REVERSION_V1"
+FLEET_SIZING_PRECEDENT_REF = "fleet_precedent:macd_v3_post_risk_limits_rewire"
+
+DEFAULT_EVALUATION_CONFIG_PATH = (
+    "config/ops/step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json"
+)
+CONFIG_SCHEMA_VERSION = "step30a_rsi_reversion_v1_economic_evaluation_admissibility_v1"
+
+STEP30A_HOLDOUT_START = "2026-06-17 10:07:00+00:00"
+STEP30A_HOLDOUT_END = "2026-07-01 10:07:00+00:00"
+STEP30A_HOLDOUT_PERIOD = f"{STEP30A_HOLDOUT_START}..{STEP30A_HOLDOUT_END}"
+
+STEP30A_REGISTERED_ECONOMIC_EVALUATION_CONFIGS_V1: tuple[str, ...] = (
+    DEFAULT_EVALUATION_CONFIG_PATH,
+)
+
+STEP30A_DATASET_V2_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/inst-eth-usdt-perp/v2"
+)
+STEP30A_DATASET_V2_MANIFEST_PATH = STEP30A_DATASET_V2_ROOT / "dataset_manifest.json"
+STEP30A_DATASET_V2_BARS_PATH = STEP30A_DATASET_V2_ROOT / "bars.parquet"
+
+_FORBIDDEN_INSTRUMENT_SUBSTRINGS = frozenset({"btc", "xbt", "bitcoin", "spot", "synthetic_spot"})
+
+
+class AdmissibilityResult(str, Enum):
+    PASS = "PASS"
+    BLOCKED = "BLOCKED"
+
+
+@dataclass(frozen=True)
+class Step30aRsiReversionV1AdmissibilityContractResultV1:
+    admissibility_result: AdmissibilityResult
+    blocking_reasons: tuple[str, ...]
+    strategy_id: str
+    strategy_version: str
+    strategy_owner: str
+    configured_strategy_params: dict[str, Any]
+    effective_strategy_params: dict[str, Any]
+    strategy_params_digest: str
+    evaluation_config_path: str
+    config_digest: str
+    config_schema_version: str
+    cost_binding_status: str
+    policy_invariant_result: str
+    signal_semantics: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "admissibility_result": self.admissibility_result.value,
+            "blocking_reasons": list(self.blocking_reasons),
+            "strategy_id": self.strategy_id,
+            "strategy_version": self.strategy_version,
+            "strategy_owner": self.strategy_owner,
+            "configured_strategy_params": self.configured_strategy_params,
+            "effective_strategy_params": self.effective_strategy_params,
+            "strategy_params_digest": self.strategy_params_digest,
+            "evaluation_config_path": self.evaluation_config_path,
+            "config_digest": self.config_digest,
+            "config_schema_version": self.config_schema_version,
+            "cost_binding_status": self.cost_binding_status,
+            "policy_invariant_result": self.policy_invariant_result,
+            "signal_semantics": self.signal_semantics,
+        }
+
+
+def list_step30a_registered_economic_evaluation_configs_v1() -> tuple[str, ...]:
+    return STEP30A_REGISTERED_ECONOMIC_EVALUATION_CONFIGS_V1
+
+
+def load_step30a_rsi_reversion_v1_evaluation_config_v1(
+    repo_root: Path,
+    config_path: Optional[str] = None,
+) -> dict[str, Any]:
+    rel = config_path or DEFAULT_EVALUATION_CONFIG_PATH
+    path = repo_root / rel
+    if not path.is_file():
+        raise FileNotFoundError(f"evaluation_config_not_found:{path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("evaluation_config_not_object")
+    return payload
+
+
+def verify_rsi_reversion_v1_strategy_identity_v1() -> tuple[str, ...]:
+    reasons: list[str] = []
+    resolution = resolve_strategy_id(RSI_REVERSION_V1_STRATEGY_ID)
+    if resolution.canonical_strategy_id != RSI_REVERSION_V1_STRATEGY_ID:
+        reasons.append("strategy_id_not_canonical")
+    entry = get_strategy_registry_entry(RSI_REVERSION_V1_STRATEGY_ID)
+    if entry.strategy_version != RSI_REVERSION_V1_STRATEGY_VERSION:
+        reasons.append("strategy_version_mismatch")
+    if entry.implementation_ref != RSI_REVERSION_V1_STRATEGY_OWNER:
+        reasons.append("strategy_owner_mismatch")
+    if not entry.futures_compatible:
+        reasons.append("strategy_not_futures_compatible")
+    if entry.spot_compatible:
+        reasons.append("strategy_spot_compatible_true")
+    lowered = entry.strategy_id.lower()
+    if "btc" in lowered or "xbt" in lowered:
+        reasons.append("strategy_btc_specialization")
+    return tuple(reasons)
+
+
+def _validate_rsi_window_v1(value: Any) -> tuple[Optional[int], tuple[str, ...]]:
+    if value is None:
+        return None, ("rsi_window_missing",)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, ("rsi_window_not_integer",)
+    if value < RSI_WINDOW_MIN or value > RSI_WINDOW_MAX:
+        return None, ("rsi_window_out_of_range",)
+    return value, ()
+
+
+def _validate_bound_v1(name: str, value: Any) -> tuple[Optional[float], tuple[str, ...]]:
+    if value is None:
+        return None, (f"{name}_missing",)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None, (f"{name}_not_numeric",)
+    cast = float(value)
+    if cast < 0.0 or cast > 100.0:
+        return None, (f"{name}_out_of_range",)
+    return cast, ()
+
+
+def _validate_price_col_v1(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, str):
+        return ("price_col_not_string",)
+    if value not in ALLOWED_PRICE_COLS:
+        return ("price_col_not_allowed",)
+    return ()
+
+
+def verify_rsi_reversion_v1_strategy_params_v1(
+    configured: Mapping[str, Any],
+    effective: Mapping[str, Any],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if set(configured.keys()) - set(RSI_REVERSION_V1_CANONICAL_PARAMS):
+        reasons.append("unknown_configured_strategy_param")
+    expected_effective_keys = {"rsi_window", "lower", "upper"}
+    if set(effective.keys()) != expected_effective_keys:
+        reasons.append("unknown_effective_strategy_param")
+    if effective.get("rsi_window") != RSI_REVERSION_V1_CANONICAL_PARAMS["rsi_window"]:
+        reasons.append("rsi_window_not_canonical")
+    if float(effective.get("lower", -1.0)) != RSI_REVERSION_V1_CANONICAL_PARAMS["lower"]:
+        reasons.append("lower_not_canonical")
+    if float(effective.get("upper", -1.0)) != RSI_REVERSION_V1_CANONICAL_PARAMS["upper"]:
+        reasons.append("upper_not_canonical")
+    if configured.get("price_col") != RSI_REVERSION_V1_CANONICAL_PARAMS["price_col"]:
+        reasons.append("price_col_not_canonical")
+
+    _, rsi_reasons = _validate_rsi_window_v1(effective.get("rsi_window"))
+    reasons.extend(rsi_reasons)
+    lower, lower_reasons = _validate_bound_v1("lower", effective.get("lower"))
+    upper, upper_reasons = _validate_bound_v1("upper", effective.get("upper"))
+    reasons.extend(lower_reasons)
+    reasons.extend(upper_reasons)
+    if lower is not None and upper is not None and lower >= upper:
+        reasons.append("lower_not_lt_upper")
+    reasons.extend(_validate_price_col_v1(configured.get("price_col")))
+    return tuple(reasons)
+
+
+def verify_rsi_reversion_v1_sizing_policy_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    sizing = cfg.get("offline_evaluation_sizing_contract_v1")
+    if not isinstance(sizing, Mapping):
+        return ("offline_evaluation_sizing_contract_v1_missing",)
+
+    risk = sizing.get("risk_per_trade")
+    stop_pct = sizing.get("stop_pct")
+    max_position_pct = sizing.get("max_position_pct")
+    oversize_policy = sizing.get("oversize_policy")
+
+    if risk != OPERATOR_RATIFIED_RISK_PER_TRADE:
+        reasons.append("risk_per_trade_not_ratified")
+    if stop_pct != OPERATOR_RATIFIED_STOP_PCT:
+        reasons.append("stop_pct_not_ratified")
+    if max_position_pct != OPERATOR_RATIFIED_MAX_POSITION_PCT:
+        reasons.append("max_position_pct_not_ratified")
+    if oversize_policy != OFFLINE_BOUND_OVERSIZE_POLICY:
+        reasons.append("oversize_policy_not_reject")
+    if sizing.get("stop_pct_derivation_ref") != FLEET_SIZING_PRECEDENT_REF:
+        reasons.append("stop_pct_derivation_ref_not_fleet_precedent")
+    if isinstance(risk, (int, float)) and isinstance(stop_pct, (int, float)):
+        if isinstance(max_position_pct, (int, float)):
+            if float(risk) > float(max_position_pct) * float(stop_pct):
+                reasons.append("policy_invariant_violation")
+    return tuple(reasons)
+
+
+def verify_rsi_reversion_v1_instrument_binding_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    binding = cfg.get("real_admissible_futures_evaluation_binding_v1")
+    if not isinstance(binding, Mapping):
+        return ("real_admissible_futures_evaluation_binding_v1_missing",)
+
+    instrument_id = str(binding.get("canonical_instrument_id", ""))
+    if instrument_id != "inst-eth-usdt-perp":
+        reasons.append("instrument_id_mismatch")
+    venue = str(binding.get("source_venue", ""))
+    if venue != "OKX":
+        reasons.append("source_venue_mismatch")
+    native = str(binding.get("native_instrument_id", ""))
+    lowered = f"{instrument_id} {native} {venue}".lower()
+    for forbidden in _FORBIDDEN_INSTRUMENT_SUBSTRINGS:
+        if forbidden in lowered:
+            reasons.append(f"forbidden_instrument_binding:{forbidden}")
+    if binding.get("dataset_version") != "v2":
+        reasons.append("dataset_version_not_v2")
+    if binding.get("dataset_schema_version") != "v2":
+        reasons.append("dataset_schema_version_not_v2")
+    return tuple(reasons)
+
+
+def verify_step30a_policy_ratification_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    ratification = cfg.get("step30a_policy_ratification_v1")
+    if not isinstance(ratification, Mapping):
+        return ("step30a_policy_ratification_v1_missing",)
+
+    expected_false = (
+        "evaluation_authorized",
+        "promotion_authorized",
+        "runtime_authorized",
+        "parameter_tuning_allowed",
+        "threshold_tuning_allowed",
+        "dataset_replacement_allowed",
+    )
+    for field in expected_false:
+        if ratification.get(field) is not False:
+            reasons.append(f"{field}_not_false")
+
+    if ratification.get("strategy_id") != RSI_REVERSION_V1_STRATEGY_ID:
+        reasons.append("ratification_strategy_id_mismatch")
+    if ratification.get("strategy_version") != RSI_REVERSION_V1_STRATEGY_VERSION:
+        reasons.append("ratification_strategy_version_mismatch")
+    if ratification.get("operator_policy_derivation_ref") != OPERATOR_POLICY_DERIVATION_REF:
+        reasons.append("operator_policy_derivation_ref_mismatch")
+    if ratification.get("sizing_precedent_ref") != FLEET_SIZING_PRECEDENT_REF:
+        reasons.append("sizing_precedent_ref_mismatch")
+    return tuple(reasons)
+
+
+def _parse_period_bounds_v1(period: str, field: str) -> tuple[pd.Timestamp, pd.Timestamp]:
+    if ".." not in period:
+        raise ValueError(f"{field}_period_format_invalid")
+    left, right = period.split("..", 1)
+    start = pd.Timestamp(left)
+    end = pd.Timestamp(right)
+    if start.tzinfo is None or end.tzinfo is None:
+        raise ValueError(f"{field}_period_timezone_missing")
+    return start, end
+
+
+def verify_holdout_separation_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    binding = cfg.get("real_admissible_futures_evaluation_binding_v1")
+    if not isinstance(binding, Mapping):
+        return ("real_admissible_futures_evaluation_binding_v1_missing",)
+
+    holdout_period = str(binding.get("out_of_sample_period", ""))
+    if holdout_period != STEP30A_HOLDOUT_PERIOD:
+        reasons.append("holdout_period_mismatch")
+
+    try:
+        train_start, train_end = _parse_period_bounds_v1(
+            str(binding.get("training_period", "")),
+            "training",
+        )
+        val_start, val_end = _parse_period_bounds_v1(
+            str(binding.get("validation_period", "")),
+            "validation",
+        )
+        holdout_start, holdout_end = _parse_period_bounds_v1(holdout_period, "holdout")
+    except ValueError as exc:
+        reasons.append(str(exc))
+        return tuple(reasons)
+
+    expected_holdout_start = pd.Timestamp(STEP30A_HOLDOUT_START)
+    expected_holdout_end = pd.Timestamp(STEP30A_HOLDOUT_END)
+    if holdout_start != expected_holdout_start:
+        reasons.append("holdout_start_not_frozen")
+    if holdout_end != expected_holdout_end:
+        reasons.append("holdout_end_not_frozen")
+    if train_end >= holdout_start:
+        reasons.append("training_not_before_holdout")
+    if val_end >= holdout_start:
+        reasons.append("validation_not_before_holdout")
+    if val_start <= train_start:
+        reasons.append("validation_not_after_training_start")
+    if val_start > val_end:
+        reasons.append("validation_period_invalid")
+    return tuple(reasons)
+
+
+def assert_holdout_access_blocked_before_evaluation_v1(
+    bars: pd.DataFrame,
+    *,
+    evaluation_authorized: bool,
+) -> None:
+    if evaluation_authorized:
+        return
+    holdout_start = pd.Timestamp(STEP30A_HOLDOUT_START)
+    if (bars.index >= holdout_start).any():
+        raise ValueError("holdout_access_blocked_before_evaluation")
+
+
+def slice_development_partition_bars_v1(bars: pd.DataFrame) -> pd.DataFrame:
+    holdout_start = pd.Timestamp(STEP30A_HOLDOUT_START)
+    return bars.sort_index().loc[bars.index < holdout_start]
+
+
+def verify_dataset_v2_digest_binding_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    binding = cfg.get("real_admissible_futures_evaluation_binding_v1")
+    if not isinstance(binding, Mapping):
+        return ("real_admissible_futures_evaluation_binding_v1_missing",)
+    if not STEP30A_DATASET_V2_MANIFEST_PATH.is_file():
+        reasons.append("dataset_v2_manifest_missing")
+        return tuple(reasons)
+    manifest = json.loads(STEP30A_DATASET_V2_MANIFEST_PATH.read_text(encoding="utf-8"))
+    expected_dataset_digest = str(binding.get("expected_dataset_digest", ""))
+    expected_manifest_digest = str(binding.get("expected_manifest_digest", ""))
+    actual_dataset_digest = str(manifest.get("normalized_dataset_digest", ""))
+    actual_manifest_digest = str(manifest.get("manifest_digest", ""))
+    if expected_dataset_digest.startswith("PLACEHOLDER"):
+        reasons.append("expected_dataset_digest_not_frozen")
+    elif expected_dataset_digest != actual_dataset_digest:
+        reasons.append("expected_dataset_digest_mismatch")
+    if expected_manifest_digest.startswith("PLACEHOLDER"):
+        reasons.append("expected_manifest_digest_not_frozen")
+    elif expected_manifest_digest != actual_manifest_digest:
+        reasons.append("expected_manifest_digest_mismatch")
+    return tuple(reasons)
+
+
+def verify_rsi_reversion_v1_config_schema_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if cfg.get("config_schema_version") != CONFIG_SCHEMA_VERSION:
+        reasons.append("config_schema_version_mismatch")
+
+    eval_section = cfg.get("economic_evaluation_v1")
+    if not isinstance(eval_section, Mapping):
+        return ("economic_evaluation_v1_missing",)
+    if eval_section.get("strategy_id") != RSI_REVERSION_V1_STRATEGY_ID:
+        reasons.append("config_strategy_id_mismatch")
+    if eval_section.get("strategy_version") != RSI_REVERSION_V1_STRATEGY_VERSION:
+        reasons.append("config_strategy_version_mismatch")
+    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+        reasons.append("engine_signal_source_not_bound")
+    if eval_section.get("economic_validity_policy_version") != "economic_validity_policy_v1":
+        reasons.append("economic_validity_policy_version_mismatch")
+
+    strategy_params = eval_section.get("strategy_params")
+    if not isinstance(strategy_params, Mapping):
+        reasons.append("strategy_params_missing")
+    else:
+        if "use_trend_filter" in strategy_params:
+            reasons.append("forbidden_use_trend_filter_in_strategy_params")
+        _, rsi_reasons = _validate_rsi_window_v1(strategy_params.get("rsi_window"))
+        reasons.extend(rsi_reasons)
+        lower, lower_reasons = _validate_bound_v1("lower", strategy_params.get("lower"))
+        upper, upper_reasons = _validate_bound_v1("upper", strategy_params.get("upper"))
+        reasons.extend(lower_reasons)
+        reasons.extend(upper_reasons)
+        if lower is not None and upper is not None and lower >= upper:
+            reasons.append("lower_not_lt_upper")
+        reasons.extend(_validate_price_col_v1(strategy_params.get("price_col")))
+        if set(strategy_params.keys()) != set(RSI_REVERSION_V1_CANONICAL_PARAMS):
+            reasons.append("unknown_strategy_params_in_config")
+    return tuple(reasons)
+
+
+def verify_rsi_reversion_v1_signal_binding_v1(cfg: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    configured = collect_configured_strategy_params_v1(cfg, RSI_REVERSION_V1_STRATEGY_ID)
+    try:
+        projected = project_strategy_params_for_binding_v1(RSI_REVERSION_V1_STRATEGY_ID, configured)
+        effective, _ = resolve_effective_strategy_params_v1(
+            RSI_REVERSION_V1_STRATEGY_ID,
+            projected,
+        )
+        warmup = compute_required_warmup_rows_v1(RSI_REVERSION_V1_STRATEGY_ID, effective)
+        if warmup != int(effective["rsi_window"]):
+            reasons.append("warmup_not_equal_to_rsi_window")
+    except StrategySignalBindingError as exc:
+        reasons.append(str(exc))
+    return tuple(reasons)
+
+
+def evaluate_step30a_rsi_reversion_v1_admissibility_contract_v1(
+    *,
+    repo_root: Path,
+    config_path: Optional[str] = None,
+) -> Step30aRsiReversionV1AdmissibilityContractResultV1:
+    blocking: list[str] = []
+    rel_path = config_path or DEFAULT_EVALUATION_CONFIG_PATH
+    cfg = load_step30a_rsi_reversion_v1_evaluation_config_v1(repo_root, rel_path)
+    config_digest = compute_evaluation_config_digest_v1(cfg)
+
+    blocking.extend(verify_rsi_reversion_v1_strategy_identity_v1())
+    blocking.extend(verify_rsi_reversion_v1_config_schema_v1(cfg))
+    blocking.extend(verify_rsi_reversion_v1_sizing_policy_v1(cfg))
+    blocking.extend(verify_rsi_reversion_v1_instrument_binding_v1(cfg))
+    blocking.extend(verify_step30a_policy_ratification_v1(cfg))
+    blocking.extend(verify_holdout_separation_v1(cfg))
+    blocking.extend(verify_rsi_reversion_v1_signal_binding_v1(cfg))
+
+    cost_status, cost_reasons = verify_cost_binding_v1(cfg)
+    blocking.extend(cost_reasons)
+
+    configured = collect_configured_strategy_params_v1(cfg, RSI_REVERSION_V1_STRATEGY_ID)
+    try:
+        effective, params_digest = resolve_effective_strategy_params_v1(
+            RSI_REVERSION_V1_STRATEGY_ID,
+            project_strategy_params_for_binding_v1(RSI_REVERSION_V1_STRATEGY_ID, configured),
+        )
+    except StrategySignalBindingError as exc:
+        blocking.append(str(exc))
+        effective = {
+            "rsi_window": RSI_REVERSION_V1_CANONICAL_PARAMS["rsi_window"],
+            "lower": RSI_REVERSION_V1_CANONICAL_PARAMS["lower"],
+            "upper": RSI_REVERSION_V1_CANONICAL_PARAMS["upper"],
+        }
+        params_digest = ""
+
+    blocking.extend(verify_rsi_reversion_v1_strategy_params_v1(configured, effective))
+    admissibility = AdmissibilityResult.PASS if not blocking else AdmissibilityResult.BLOCKED
+    return Step30aRsiReversionV1AdmissibilityContractResultV1(
+        admissibility_result=admissibility,
+        blocking_reasons=tuple(sorted(set(blocking))),
+        strategy_id=RSI_REVERSION_V1_STRATEGY_ID,
+        strategy_version=RSI_REVERSION_V1_STRATEGY_VERSION,
+        strategy_owner=RSI_REVERSION_V1_STRATEGY_OWNER,
+        configured_strategy_params=dict(configured),
+        effective_strategy_params=dict(effective),
+        strategy_params_digest=params_digest,
+        evaluation_config_path=rel_path,
+        config_digest=config_digest,
+        config_schema_version=str(cfg.get("config_schema_version", "")),
+        cost_binding_status=cost_status,
+        policy_invariant_result=POLICY_INVARIANT_RESULT,
+        signal_semantics=SIGNAL_SEMANTICS,
+    )

--- a/src/backtest/strategy_signal_binding_v1.py
+++ b/src/backtest/strategy_signal_binding_v1.py
@@ -51,6 +51,7 @@ _EXTERNAL_PARAMETER_SCHEMA_V1: dict[str, dict[str, Any]] = {
 # Evaluation/config metadata allowed in configured params but not strategy logic schema.
 _EVALUATION_ONLY_STRATEGY_PARAMS_V1: dict[str, frozenset[str]] = {
     "ma_crossover": frozenset({"price_col"}),
+    "rsi_reversion": frozenset({"price_col"}),
 }
 
 
@@ -237,6 +238,8 @@ def compute_required_warmup_rows_v1(
         if lookback_raw < 2:
             raise StrategySignalBindingError("breakout_donchian_lookback_below_minimum")
         return lookback_raw
+    if strategy_id == "rsi_reversion":
+        return int(effective_params["rsi_window"])
     raise StrategySignalBindingError(f"required_warmup_rows_unbound:{strategy_id}")
 
 

--- a/tests/backtest/test_admissible_versioned_futures_dataset_profile_v1.py
+++ b/tests/backtest/test_admissible_versioned_futures_dataset_profile_v1.py
@@ -201,6 +201,51 @@ class TestDatasetProfileContract:
     def test_research_alias_constant(self) -> None:
         assert ds.ADMISSIBLE_FUTURES_ECONOMIC_RESEARCH_DATASET_V1 == "economic_research_v1"
 
+    def test_missing_historical_l1_reason_enum(self) -> None:
+        assert (
+            ds.MissingHistoricalL1ReasonV1.NOT_AVAILABLE_BY_PUBLIC_SOURCE.value
+            == "NOT_AVAILABLE_BY_PUBLIC_SOURCE"
+        )
+
+    def test_schema_v2_allowed_for_research_profile(self) -> None:
+        bars = _research_bars()
+        bindings = ds.field_bindings_for_profile(ds.DatasetProfileV1.ECONOMIC_RESEARCH_V1)
+        digest = ds.compute_versioned_dataset_digest(bars, field_bindings=bindings)
+        train, val, oos = ds.compute_split_periods_from_bars(bars)
+        idx = bars.sort_index().index
+        descriptor = ds.VersionedFuturesDatasetDescriptorV1(
+            dataset_id="fixture_v2",
+            dataset_version="v2",
+            dataset_schema_version=ds.DATASET_SCHEMA_VERSION_V2,
+            dataset_digest=digest,
+            instrument_id=wiring.MV2_REQUIRED_INSTRUMENT_ID,
+            contract_type="perpetual",
+            futures_only=True,
+            bitcoin_direction_allowed=False,
+            venue_id="offline_fixture_venue_v1",
+            start_time=str(idx[0]),
+            end_time=str(idx[-1]),
+            row_count=len(bars),
+            field_bindings=bindings,
+            training_period=train,
+            validation_period=val,
+            out_of_sample_period=oos,
+            split_policy_version=ds.SPLIT_POLICY_VERSION,
+            timestamp_semantics=ds.TIMESTAMP_SEMANTICS,
+            timezone=ds.TIMEZONE,
+            ordering_status=ds.ORDERING_STATUS_SORTED,
+            duplicate_policy=ds.DUPLICATE_POLICY,
+            missing_data_policy=ds.MISSING_DATA_POLICY,
+        )
+        result = ds.evaluate_admissible_versioned_futures_dataset_v1(
+            bars=bars,
+            descriptor=descriptor,
+            provenance=_provenance(),
+            instrument_id=wiring.MV2_REQUIRED_INSTRUMENT_ID,
+            profile_binding=_research_profile_binding(),
+        )
+        assert result.is_admissible()
+
 
 class TestResearchExecutionCostBinding:
     def test_resolve_research_execution_cost_binding(self) -> None:

--- a/tests/backtest/test_strategy_signal_binding_rsi_reversion_warmup_v1.py
+++ b/tests/backtest/test_strategy_signal_binding_rsi_reversion_warmup_v1.py
@@ -1,0 +1,33 @@
+"""Contract tests for rsi_reversion warmup in strategy signal binding v1."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.backtest.strategy_signal_binding_v1 import (
+    StrategySignalBindingError,
+    compute_required_warmup_rows_v1,
+    project_strategy_params_for_binding_v1,
+    resolve_effective_strategy_params_v1,
+)
+
+
+def test_rsi_reversion_warmup_equals_rsi_window() -> None:
+    configured = {"rsi_window": 14, "lower": 30.0, "upper": 70.0, "price_col": "close"}
+    projected = project_strategy_params_for_binding_v1("rsi_reversion", configured)
+    effective, _ = resolve_effective_strategy_params_v1("rsi_reversion", projected)
+    assert compute_required_warmup_rows_v1("rsi_reversion", effective) == 14
+
+
+def test_rsi_reversion_price_col_is_evaluation_only() -> None:
+    configured = {"rsi_window": 14, "lower": 30.0, "upper": 70.0, "price_col": "close"}
+    projected = project_strategy_params_for_binding_v1("rsi_reversion", configured)
+    assert "price_col" not in projected
+
+
+def test_rsi_reversion_unknown_param_fail_closed() -> None:
+    with pytest.raises(StrategySignalBindingError, match="unknown_strategy_param"):
+        project_strategy_params_for_binding_v1(
+            "rsi_reversion",
+            {"rsi_window": 14, "lower": 30.0, "upper": 70.0, "foo": "bar"},
+        )

--- a/tests/ops/test_ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
+++ b/tests/ops/test_ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
@@ -13,7 +13,7 @@ _SCRIPT = (
     _REPO_ROOT
     / "scripts/ops/ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py"
 )
-_GO_TOKEN = (
+_GO_LITERAL = (
     "GO_BOUNDED_STEP30A_RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0"
 )
 
@@ -60,7 +60,7 @@ def test_network_ingestion_forbidden_without_skip_network() -> None:
     mod = _load_mod()
     with pytest.raises(mod.Step30aDatasetIngestionError, match="network_ingestion_forbidden"):
         mod.run_step30a_dataset_v2_backward_extension_ingestion_v0(
-            confirm_go_token=_GO_TOKEN,
+            confirm_go_token=_GO_LITERAL,
             skip_network=False,
         )
 
@@ -69,13 +69,11 @@ def test_cli_skip_network_path() -> None:
     proc = _run(
         [
             "--confirm-go-token",
-            _GO_TOKEN,
+            _GO_LITERAL,
             "--skip-network",
         ]
     )
     assert proc.returncode == 0
-    assert (
-        "STEP30A_GO_TOKEN=GO_BOUNDED_STEP30A_RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0"
-        in proc.stdout
-    )
+    assert "STEP30A_CONFIRM_GO=" in proc.stdout
+    assert _GO_LITERAL in proc.stdout
     assert "STEP30A_DATASET_V2_WINDOW_DAYS=90" in proc.stdout

--- a/tests/ops/test_ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
+++ b/tests/ops/test_ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
@@ -49,9 +49,9 @@ def test_step30a_window_days_constant_is_90() -> None:
 
 def test_wrong_token_rejected() -> None:
     mod = _load_mod()
-    with pytest.raises(mod.Step30aDatasetIngestionError, match="confirm_go_token_mismatch"):
+    with pytest.raises(mod.Step30aDatasetIngestionError, match="confirm_go_mismatch"):
         mod.run_step30a_dataset_v2_backward_extension_ingestion_v0(
-            confirm_go_token="WRONG",
+            confirm_go="WRONG",
             skip_network=True,
         )
 
@@ -60,7 +60,7 @@ def test_network_ingestion_forbidden_without_skip_network() -> None:
     mod = _load_mod()
     with pytest.raises(mod.Step30aDatasetIngestionError, match="network_ingestion_forbidden"):
         mod.run_step30a_dataset_v2_backward_extension_ingestion_v0(
-            confirm_go_token=_GO_LITERAL,
+            confirm_go=_GO_LITERAL,
             skip_network=False,
         )
 
@@ -68,7 +68,7 @@ def test_network_ingestion_forbidden_without_skip_network() -> None:
 def test_cli_skip_network_path() -> None:
     proc = _run(
         [
-            "--confirm-go-token",
+            "--confirm-go",
             _GO_LITERAL,
             "--skip-network",
         ]

--- a/tests/ops/test_ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
+++ b/tests/ops/test_ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = (
+    _REPO_ROOT
+    / "scripts/ops/ingest_step30a_okx_inst_eth_usdt_perp_dataset_v2_backward_extension_v0.py"
+)
+_GO_TOKEN = (
+    "GO_BOUNDED_STEP30A_RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0"
+)
+
+
+def _load_mod() -> Any:
+    spec = importlib.util.spec_from_file_location("_step30a_ingest", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_holdout_constants_match_step29m_frozen() -> None:
+    mod = _load_mod()
+    mod._validate_holdout_constants_match_step29m_v1()
+
+
+def test_step30a_window_days_constant_is_90() -> None:
+    mod = _load_mod()
+    assert mod.STEP30A_DATASET_V2_WINDOW_DAYS == 90
+
+
+def test_wrong_token_rejected() -> None:
+    mod = _load_mod()
+    with pytest.raises(mod.Step30aDatasetIngestionError, match="confirm_go_token_mismatch"):
+        mod.run_step30a_dataset_v2_backward_extension_ingestion_v0(
+            confirm_go_token="WRONG",
+            skip_network=True,
+        )
+
+
+def test_network_ingestion_forbidden_without_skip_network() -> None:
+    mod = _load_mod()
+    with pytest.raises(mod.Step30aDatasetIngestionError, match="network_ingestion_forbidden"):
+        mod.run_step30a_dataset_v2_backward_extension_ingestion_v0(
+            confirm_go_token=_GO_TOKEN,
+            skip_network=False,
+        )
+
+
+def test_cli_skip_network_path() -> None:
+    proc = _run(
+        [
+            "--confirm-go-token",
+            _GO_TOKEN,
+            "--skip-network",
+        ]
+    )
+    assert proc.returncode == 0
+    assert (
+        "STEP30A_GO_TOKEN=GO_BOUNDED_STEP30A_RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0"
+        in proc.stdout
+    )
+    assert "STEP30A_DATASET_V2_WINDOW_DAYS=90" in proc.stdout

--- a/tests/ops/test_runbook_step30a_rsi_reversion_v1_policy_ratification_and_dataset_v2_contract_v0.py
+++ b/tests/ops/test_runbook_step30a_rsi_reversion_v1_policy_ratification_and_dataset_v2_contract_v0.py
@@ -1,0 +1,51 @@
+"""Runbook contract for STEP30A policy ratification and dataset v2 binding."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROGRESS_REGISTRY = REPO_ROOT / "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(
+        rf"\| `{re.escape(field)}` \| `([^`]*)`(?: <!--.*?-->)? \|",
+        text,
+    )
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _step_30a_section(text: str) -> str:
+    start = text.index(
+        "#### RUNBOOK_STEP_30A — RSI Reversion v1 Extended Holdout-Separated Futures Economic Research v0"
+    )
+    end = text.index("#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1", start)
+    return text[start:end]
+
+
+def test_step30a_section_has_required_ratification_fields() -> None:
+    section = _step_30a_section(PROGRESS_REGISTRY.read_text(encoding="utf-8"))
+    assert _field_value(section, "STEP30A_OPERATOR_POLICY_RATIFIED") == "true"
+    assert _field_value(section, "STEP30A_GO_TOKEN") == (
+        "GO_BOUNDED_STEP30A_RSI_REVERSION_V1_EXTENDED_HOLDOUT_SEPARATED_FUTURES_ECONOMIC_RESEARCH_V0"
+    )
+    assert _field_value(section, "STEP30A_EVALUATION_AUTHORIZED") == "false"
+    assert _field_value(section, "STEP30A_PROMOTION_AUTHORIZED") == "false"
+    assert _field_value(section, "STEP30A_RUNTIME_AUTHORIZED") == "false"
+
+
+def test_step30a_section_binds_dataset_v2_and_frozen_holdout() -> None:
+    section = _step_30a_section(PROGRESS_REGISTRY.read_text(encoding="utf-8"))
+    assert _field_value(section, "STEP30A_DATASET_VERSION") == "v2"
+    assert _field_value(section, "STEP30A_HOLDOUT_FROZEN_REF") == (
+        "2026-06-17 10:07:00+00:00..2026-07-01 10:07:00+00:00"
+    )
+    assert _field_value(section, "STEP30A_REGISTERED_ECONOMIC_EVALUATION_CONFIGS").replace(
+        "&#47;", "/"
+    ) == "config/ops/step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json"
+    assert _field_value(section, "NEXT_CANONICAL_STEP") == (
+        "SEPARATE_EVALUATION_GO_REQUIRED_AFTER_PRE_PR_AND_IMPLEMENTATION_CLOSEOUT"
+    )

--- a/tests/ops/test_runbook_step30a_rsi_reversion_v1_policy_ratification_and_dataset_v2_contract_v0.py
+++ b/tests/ops/test_runbook_step30a_rsi_reversion_v1_policy_ratification_and_dataset_v2_contract_v0.py
@@ -43,9 +43,12 @@ def test_step30a_section_binds_dataset_v2_and_frozen_holdout() -> None:
     assert _field_value(section, "STEP30A_HOLDOUT_FROZEN_REF") == (
         "2026-06-17 10:07:00+00:00..2026-07-01 10:07:00+00:00"
     )
-    assert _field_value(section, "STEP30A_REGISTERED_ECONOMIC_EVALUATION_CONFIGS").replace(
-        "&#47;", "/"
-    ) == "config/ops/step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json"
+    assert (
+        _field_value(section, "STEP30A_REGISTERED_ECONOMIC_EVALUATION_CONFIGS").replace(
+            "&#47;", "/"
+        )
+        == "config/ops/step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json"
+    )
     assert _field_value(section, "NEXT_CANONICAL_STEP") == (
         "SEPARATE_EVALUATION_GO_REQUIRED_AFTER_PRE_PR_AND_IMPLEMENTATION_CLOSEOUT"
     )

--- a/tests/ops/test_stage_step30a_okx_inst_eth_usdt_perp_dataset_v2_from_raw_staging_v0.py
+++ b/tests/ops/test_stage_step30a_okx_inst_eth_usdt_perp_dataset_v2_from_raw_staging_v0.py
@@ -1,0 +1,183 @@
+"""STEP30A dataset v2 promotion from verified raw staging v0 tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+STAGING_SCRIPT = (
+    ROOT / "scripts/ops/stage_step30a_okx_inst_eth_usdt_perp_dataset_v2_from_raw_staging_v0.py"
+)
+RAW_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/inst-eth-usdt-perp/.tmp_20260702T050638Z"
+)
+V2_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/inst-eth-usdt-perp/v2"
+)
+
+
+def _load_mod():
+    spec = importlib.util.spec_from_file_location("_step30a_stage_v2", STAGING_SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _minimal_raw_tree(tmp_path: Path) -> Path:
+    if not RAW_ROOT.is_dir():
+        pytest.skip("authorized raw staging cache unavailable")
+    dst = tmp_path / "raw_staging"
+    shutil.copytree(RAW_ROOT, dst)
+    return dst
+
+
+def test_missing_historical_l1_reason_constant() -> None:
+    mod = _load_mod()
+    from src.backtest import admissible_versioned_futures_dataset_v1 as ds
+
+    assert mod.MISSING_HISTORICAL_L1_REASON == (
+        ds.MissingHistoricalL1ReasonV1.NOT_AVAILABLE_BY_PUBLIC_SOURCE.value
+    )
+
+
+def test_holdout_constants_match_step29m_frozen() -> None:
+    mod = _load_mod()
+    mod.verify_holdout_constants_match_step29m_v1()
+
+
+def test_resolve_verified_raw_staging_root_v1() -> None:
+    if not RAW_ROOT.is_dir():
+        pytest.skip("authorized raw staging cache unavailable")
+    mod = _load_mod()
+    resolved = mod.resolve_verified_raw_staging_root_v1(RAW_ROOT.parent)
+    assert resolved.is_dir()
+    assert resolved.name.startswith(".tmp_")
+
+
+def test_holdout_access_guard_blocks_full_dataset_before_evaluation(tmp_path: Path) -> None:
+    mod = _load_mod()
+    raw_root = _minimal_raw_tree(tmp_path)
+    config = json.loads((raw_root / "INGESTION_CONFIG.json").read_text())
+    bars, report = __import__(
+        "scripts.ops.stage_okx_economic_research_dataset_from_raw_staging_v1",
+        fromlist=["normalize_economic_research_bars"],
+    ).normalize_economic_research_bars(
+        raw_dir=raw_root / "raw",
+        start_utc=config["data_period"]["start_utc"],
+        end_utc=config["data_period"]["end_utc"],
+    )
+    assert report.passed
+    with pytest.raises(mod.Step30aDatasetPromotionError, match="holdout_access_blocked"):
+        mod.assert_holdout_access_blocked_v1(bars, evaluation_authorized=False)
+    development = mod.slice_development_partition_v1(bars)
+    assert (development.index >= pd.Timestamp(mod.STEP30A_FROZEN_HOLDOUT_START_UTC)).sum() == 0
+
+
+def test_deterministic_partition_digests(tmp_path: Path) -> None:
+    mod = _load_mod()
+    raw_root = _minimal_raw_tree(tmp_path)
+    config = json.loads((raw_root / "INGESTION_CONFIG.json").read_text())
+    staging = __import__(
+        "scripts.ops.stage_okx_economic_research_dataset_from_raw_staging_v1",
+        fromlist=["normalize_economic_research_bars"],
+    )
+    bars_a, report_a = staging.normalize_economic_research_bars(
+        raw_dir=raw_root / "raw",
+        start_utc=config["data_period"]["start_utc"],
+        end_utc=config["data_period"]["end_utc"],
+    )
+    bars_b, report_b = staging.normalize_economic_research_bars(
+        raw_dir=raw_root / "raw",
+        start_utc=config["data_period"]["start_utc"],
+        end_utc=config["data_period"]["end_utc"],
+    )
+    assert report_a.passed and report_b.passed
+    from src.backtest import admissible_versioned_futures_dataset_v1 as ds
+
+    bindings = ds.field_bindings_for_profile(ds.DatasetProfileV1.ECONOMIC_RESEARCH_V1)
+    digests_a = mod.compute_partition_digests_v1(bars_a, field_bindings=bindings)
+    digests_b = mod.compute_partition_digests_v1(bars_b, field_bindings=bindings)
+    assert digests_a == digests_b
+
+
+def test_promoted_v2_manifest_binds_missing_l1_reason() -> None:
+    if not V2_ROOT.is_dir():
+        pytest.skip("dataset v2 not promoted")
+    manifest = json.loads((V2_ROOT / "dataset_manifest.json").read_text())
+    assert manifest["dataset_version"] == "v2"
+    assert manifest["dataset_schema_version"] == "v2"
+    assert manifest["missing_historical_l1_reason"] == "NOT_AVAILABLE_BY_PUBLIC_SOURCE"
+    assert "best_bid" not in manifest["required_columns"]
+    assert "best_ask" not in manifest["required_columns"]
+
+
+def test_runtime_profile_still_requires_l1() -> None:
+    from src.backtest import admissible_versioned_futures_dataset_v1 as ds
+
+    idx = pd.date_range("2026-06-01", periods=4, freq="1h", tz="UTC")
+    close = [100.0, 101.0, 102.0, 103.0]
+    bars = pd.DataFrame(
+        {
+            "open": close,
+            "high": close,
+            "low": close,
+            "close": close,
+            "volume": [1.0] * 4,
+            "mark_price": close,
+            "index_price": close,
+            "funding_rate": [0.0001] * 4,
+            "is_final": [True] * 4,
+        },
+        index=idx,
+    )
+    bindings = ds.field_bindings_for_profile(ds.DatasetProfileV1.RUNTIME_MARKET_CONTEXT_V1)
+    digest = ds.compute_versioned_dataset_digest(bars, field_bindings=bindings)
+    train, val, oos = ds.compute_split_periods_from_bars(bars)
+    descriptor = ds.VersionedFuturesDatasetDescriptorV1(
+        dataset_id="fixture",
+        dataset_version="v1",
+        dataset_schema_version="v1",
+        dataset_digest=digest,
+        instrument_id="inst-eth-usdt-perp",
+        contract_type="perpetual",
+        futures_only=True,
+        bitcoin_direction_allowed=False,
+        venue_id="OKX",
+        start_time=str(idx[0]),
+        end_time=str(idx[-1]),
+        row_count=len(bars),
+        field_bindings=bindings,
+        training_period=train,
+        validation_period=val,
+        out_of_sample_period=oos,
+        split_policy_version=ds.SPLIT_POLICY_VERSION,
+        timestamp_semantics=ds.TIMESTAMP_SEMANTICS,
+        timezone=ds.TIMEZONE,
+        ordering_status=ds.ORDERING_STATUS_SORTED,
+        duplicate_policy=ds.DUPLICATE_POLICY,
+        missing_data_policy=ds.MISSING_DATA_POLICY,
+    )
+    provenance = ds.DatasetProvenanceV1(
+        source_type="fixture",
+        venue_id="OKX",
+        ingestion_timestamp="1970-01-01T00:00:00+00:00",
+        generation_method="fixture",
+        provenance_ref="fixture",
+    )
+    result = ds.evaluate_admissible_versioned_futures_dataset_v1(
+        bars=bars,
+        descriptor=descriptor,
+        provenance=provenance,
+        instrument_id="inst-eth-usdt-perp",
+        profile_binding=ds.default_runtime_profile_binding_v1(),
+    )
+    assert result.admissibility_status is ds.AdmissibilityStatus.BLOCKED_L1_REQUIRED_FOR_RUNTIME

--- a/tests/ops/test_step30a_rsi_reversion_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/tests/ops/test_step30a_rsi_reversion_v1_economic_evaluation_admissibility_contract_v1.py
@@ -1,0 +1,134 @@
+"""Contract tests for STEP30A rsi_reversion admissibility contract v1."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.backtest import (
+    step30a_rsi_reversion_v1_economic_evaluation_admissibility_contract_v1 as contract,
+)
+from src.backtest.strategy_signal_binding_v1 import (
+    collect_configured_strategy_params_v1,
+    compute_required_warmup_rows_v1,
+    project_strategy_params_for_binding_v1,
+    resolve_effective_strategy_params_v1,
+)
+from src.strategies.registry import get_strategy_registry_entry, resolve_strategy_id
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = ROOT / contract.DEFAULT_EVALUATION_CONFIG_PATH
+
+
+def _load_config() -> dict:
+    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def test_rsi_reversion_registry_identity() -> None:
+    resolution = resolve_strategy_id("rsi_reversion")
+    assert resolution.canonical_strategy_id == "rsi_reversion"
+    entry = get_strategy_registry_entry("rsi_reversion")
+    assert entry.strategy_version == "v1"
+    assert entry.implementation_ref == contract.RSI_REVERSION_V1_STRATEGY_OWNER
+    assert entry.futures_compatible is True
+    assert entry.spot_compatible is False
+
+
+def test_config_schema_valid() -> None:
+    cfg = _load_config()
+    assert cfg["config_schema_version"] == contract.CONFIG_SCHEMA_VERSION
+    assert cfg["economic_evaluation_v1"]["strategy_id"] == "rsi_reversion"
+    assert cfg["economic_evaluation_v1"]["strategy_params"] == {
+        "rsi_window": 14,
+        "lower": 30.0,
+        "upper": 70.0,
+        "price_col": "close",
+    }
+
+
+def test_use_trend_filter_forbidden_in_strategy_params() -> None:
+    bad = _load_config()
+    bad["economic_evaluation_v1"] = dict(bad["economic_evaluation_v1"])
+    bad["economic_evaluation_v1"]["strategy_params"] = dict(
+        bad["economic_evaluation_v1"]["strategy_params"]
+    )
+    bad["economic_evaluation_v1"]["strategy_params"]["use_trend_filter"] = True
+    reasons = contract.verify_rsi_reversion_v1_config_schema_v1(bad)
+    assert "forbidden_use_trend_filter_in_strategy_params" in reasons
+
+
+def test_holdout_separation_contract() -> None:
+    reasons = contract.verify_holdout_separation_v1(_load_config())
+    assert not reasons
+    bad = _load_config()
+    bad["real_admissible_futures_evaluation_binding_v1"] = dict(
+        bad["real_admissible_futures_evaluation_binding_v1"]
+    )
+    bad["real_admissible_futures_evaluation_binding_v1"]["validation_period"] = (
+        "2026-05-19 00:00:00+00:00..2026-06-17 10:07:00+00:00"
+    )
+    reasons = contract.verify_holdout_separation_v1(bad)
+    assert "validation_not_before_holdout" in reasons
+
+
+def test_dataset_v2_binding_fields_required() -> None:
+    reasons = contract.verify_rsi_reversion_v1_instrument_binding_v1(_load_config())
+    assert not reasons
+    bad = _load_config()
+    bad["real_admissible_futures_evaluation_binding_v1"] = dict(
+        bad["real_admissible_futures_evaluation_binding_v1"]
+    )
+    bad["real_admissible_futures_evaluation_binding_v1"]["dataset_version"] = "v1"
+    reasons = contract.verify_rsi_reversion_v1_instrument_binding_v1(bad)
+    assert "dataset_version_not_v2" in reasons
+
+
+def test_evaluation_authorized_false_in_ratification() -> None:
+    reasons = contract.verify_step30a_policy_ratification_v1(_load_config())
+    assert not reasons
+    bad = deepcopy(_load_config())
+    bad["step30a_policy_ratification_v1"] = dict(bad["step30a_policy_ratification_v1"])
+    bad["step30a_policy_ratification_v1"]["evaluation_authorized"] = True
+    reasons = contract.verify_step30a_policy_ratification_v1(bad)
+    assert "evaluation_authorized_not_false" in reasons
+
+
+def test_warmup_equals_rsi_window_from_binding() -> None:
+    cfg = _load_config()
+    configured = collect_configured_strategy_params_v1(cfg, "rsi_reversion")
+    effective, _ = resolve_effective_strategy_params_v1(
+        "rsi_reversion",
+        project_strategy_params_for_binding_v1("rsi_reversion", configured),
+    )
+    assert compute_required_warmup_rows_v1("rsi_reversion", effective) == 14
+
+
+def test_holdout_access_block_contract() -> None:
+    from src.backtest import (
+        step30a_rsi_reversion_v1_economic_evaluation_admissibility_contract_v1 as contract,
+    )
+
+    idx = pd.date_range("2026-06-01", periods=4, freq="1h", tz="UTC")
+    holdout_idx = pd.date_range("2026-06-18", periods=2, freq="1h", tz="UTC")
+    bars = pd.DataFrame({"close": [1.0, 2.0, 3.0, 4.0]}, index=idx)
+    holdout_bars = pd.DataFrame({"close": [5.0, 6.0]}, index=holdout_idx)
+    with pytest.raises(ValueError, match="holdout_access_blocked"):
+        contract.assert_holdout_access_blocked_before_evaluation_v1(
+            holdout_bars,
+            evaluation_authorized=False,
+        )
+    development = contract.slice_development_partition_bars_v1(
+        pd.concat([bars, holdout_bars]).sort_index()
+    )
+    assert len(development) == len(bars)
+
+
+def test_full_admissibility_contract_passes() -> None:
+    result = contract.evaluate_step30a_rsi_reversion_v1_admissibility_contract_v1(repo_root=ROOT)
+    assert result.admissibility_result.value == "PASS", result.blocking_reasons
+    assert result.cost_binding_status == "PASS"
+    assert result.signal_semantics == "LONG_SHORT_REVERSION_-1_0_1"

--- a/tests/ops/test_step30a_rsi_reversion_v1_economic_evaluation_config_contract_v1.py
+++ b/tests/ops/test_step30a_rsi_reversion_v1_economic_evaluation_config_contract_v1.py
@@ -1,0 +1,66 @@
+"""Config contract for STEP30A rsi_reversion economic evaluation config v1."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.backtest import (
+    step30a_rsi_reversion_v1_economic_evaluation_admissibility_contract_v1 as contract,
+)
+from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 import (
+    compute_evaluation_config_digest_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STEP30A_CONFIG = REPO_ROOT / contract.DEFAULT_EVALUATION_CONFIG_PATH
+
+
+def _load_config() -> dict:
+    return json.loads(STEP30A_CONFIG.read_text(encoding="utf-8"))
+
+
+def test_step30a_config_registered_singleton() -> None:
+    registry = contract.list_step30a_registered_economic_evaluation_configs_v1()
+    assert registry == (contract.DEFAULT_EVALUATION_CONFIG_PATH,)
+    assert STEP30A_CONFIG.is_file()
+
+
+def test_step30a_config_digest_stable() -> None:
+    cfg = _load_config()
+    digest = compute_evaluation_config_digest_v1(cfg)
+    assert len(digest) == 64
+    assert digest == compute_evaluation_config_digest_v1(_load_config())
+
+
+def test_step30a_config_digests_frozen_after_promotion() -> None:
+    cfg = _load_config()
+    binding = cfg["real_admissible_futures_evaluation_binding_v1"]
+    sizing = cfg["offline_evaluation_sizing_contract_v1"]
+    assert not binding["expected_dataset_digest"].startswith("PLACEHOLDER")
+    assert not binding["expected_manifest_digest"].startswith("PLACEHOLDER")
+    assert binding["development_partition_digest"]
+    assert binding["frozen_holdout_digest"]
+    assert binding["missing_historical_l1_reason"] == "NOT_AVAILABLE_BY_PUBLIC_SOURCE"
+    assert sizing["dataset_digest"] == binding["expected_dataset_digest"]
+    assert not sizing["config_digest"].startswith("PLACEHOLDER")
+    assert not sizing["strategy_params_digest"].startswith("PLACEHOLDER")
+
+
+def test_step30a_periods_bound_and_holdout_frozen() -> None:
+    cfg = _load_config()
+    binding = cfg["real_admissible_futures_evaluation_binding_v1"]
+    assert binding["training_period"] == "2026-04-02 10:07:00+00:00..2026-05-18 23:59:00+00:00"
+    assert binding["validation_period"] == "2026-05-19 00:00:00+00:00..2026-06-16 23:59:00+00:00"
+    assert binding["out_of_sample_period"] == "2026-06-17 10:07:00+00:00..2026-07-01 10:07:00+00:00"
+
+
+def test_step30a_ratification_flags_block_evaluation() -> None:
+    cfg = _load_config()
+    ratification = cfg["step30a_policy_ratification_v1"]
+    assert ratification["evaluation_authorized"] is False
+    assert ratification["promotion_authorized"] is False
+    assert ratification["runtime_authorized"] is False
+    assert ratification["parameter_tuning_allowed"] is False
+    assert ratification["threshold_tuning_allowed"] is False
+    assert ratification["dataset_replacement_allowed"] is False


### PR DESCRIPTION
## Summary

- Introduces profile-bound `economic_research_v1` dataset contract remediation: OHLCV/mark/index/funding required, historical L1 explicitly `NOT_AVAILABLE_BY_PUBLIC_SOURCE`, runtime profiles unchanged.
- Adds STEP30A bounded dataset v2 promotion from verified OKX raw staging with frozen STEP29M holdout separation, partition digests, and admissibility binding.
- Freezes the single ratified `rsi_reversion` v1 evaluation config for ETH-USDT-SWAP against promoted dataset v2 digests; no parameter tuning and no economic evaluation execution.

## Test plan

- [x] Focused STEP30A contract suite (44 tests)
- [x] CI selector PR_BOUNDED_FULL targets (720 tests)
- [x] `ruff format --check` / `ruff check` on changed Python files
- [x] Docs token policy + docs reference targets
- [x] Dataset v2 promotion manifest verify (`MANIFEST_VERIFY_RC=0`)
- [x] Config digest binding matches promoted v2 manifest

## Boundaries

- No economic evaluation
- No runtime / orders / merge in this PR


Made with [Cursor](https://cursor.com)