### PR TITLE
feat(research): composite breakout confirmation vol-gated donchian v1 architecture binding

### DIFF
--- a/config/ops/composite_breakout_confirmation_vol_gated_donchian_v1_architecture_binding_v1.json
+++ b/config/ops/composite_breakout_confirmation_vol_gated_donchian_v1_architecture_binding_v1.json
@@ -1,0 +1,115 @@
+{
+  "backtest": {
+    "cost_model_version": "backtest_cost_v0",
+    "dataset_admissibility": {
+      "bind": true,
+      "dataset_profile": "economic_research_v1",
+      "execution_cost_binding": {
+        "conservative_half_spread_bps": 5.0,
+        "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+        "spread_model_version": "research_conservative_bps_v1"
+      },
+      "profile_binding": {
+        "dataset_profile": "economic_research_v1",
+        "execution_cost_binding": {
+          "conservative_half_spread_bps": 5.0,
+          "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+          "spread_model_version": "research_conservative_bps_v1"
+        },
+        "l1_observation_status": "EXECUTION_MODEL_BOUND_NOT_OBSERVED"
+      }
+    },
+    "economic_research_execution_cost": {
+      "conservative_half_spread_bps": 5.0,
+      "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+      "fee_bps": 10.0,
+      "slippage_bps": 5.0,
+      "spread_model_version": "research_conservative_bps_v1"
+    },
+    "fee_bps": 10.0,
+    "fee_model_version": "backtest_fee_taker_symmetric_v0",
+    "funding": {
+      "bind": true,
+      "model_version": "backtest_funding_perpetual_interval_v1"
+    },
+    "initial_cash": 10000.0,
+    "slippage_bps": 5.0,
+    "slippage_model_version": "backtest_slippage_symmetric_v0"
+  },
+  "config_schema_version": "composite_breakout_confirmation_vol_gated_donchian_v1_architecture_binding_v1",
+  "economic_evaluation_v1": {
+    "economic_validity_policy_version": "economic_validity_policy_v1",
+    "engine_signal_source": "configured_strategy_signal",
+    "strategy_id": "composite",
+    "strategy_params": {
+      "composite_type": "confirmed_filter_gated_signal_v1",
+      "composition_rule": "confirmed_signal_times_filter_mask",
+      "signal_strategy_id": "breakout_donchian",
+      "filter_strategy_id": "vol_regime_filter",
+      "signal_strategy_params": {
+        "lookback": 20,
+        "price_col": "close"
+      },
+      "filter_strategy_params": {
+        "vol_window": 20,
+        "vol_method": "atr",
+        "vol_percentile_low": 25,
+        "vol_percentile_high": 75,
+        "min_bars": 30,
+        "lookback_percentile": 100,
+        "regime_mode": false
+      },
+      "aggregation": "weighted",
+      "signal_threshold": 0.3,
+      "confirmation_epochs": 1
+    },
+    "strategy_version": "v1"
+  },
+  "offline_evaluation_sizing_contract_v1": {
+    "dataset_digest": "b4cbe7fff81a137da055588231757937406d8cb30d531ee0aab41d95ee9b6c78",
+    "initial_equity": 10000.0,
+    "instrument_metadata_source": "versioned_dataset_manifest_v1",
+    "max_position_pct": 0.25,
+    "minimum_notional_policy": "USE_RISK_MIN_POSITION_VALUE_v1",
+    "minimum_quantity_policy": "REJECT_BELOW_MIN_NOTIONAL_v1",
+    "oversize_policy": "REJECT_OVERSIZE",
+    "price_source": "bar_close_v1",
+    "quantity_rounding_policy": "NONE_v1",
+    "risk_per_trade": 0.005,
+    "sizing_contract_version": "offline_evaluation_sizing_contract_v1",
+    "sizing_mode": "fixed_fractional_risk_per_trade_v1",
+    "sizing_owner": "backtest.offline_evaluation_sizing_contract_v1",
+    "stop_distance_policy": "FIXED_PCT_FROM_ENTRY_v1",
+    "stop_pct": 0.02,
+    "stop_pct_derivation_ref": "operator_policy_decision:COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1",
+    "strategy_params_digest": "6aac9760c6d35fdc45494c862acce6f4488a4e71612d3c7bffa3889bc371610e"
+  },
+  "real_admissible_futures_evaluation_binding_v1": {
+    "canonical_instrument_id": "inst-eth-usdt-perp",
+    "canonical_trading_logic_version": "integrated_offline_trading_logic_replay_v1",
+    "dataset_path": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/inst-eth-usdt-perp/v1/bars.parquet",
+    "dataset_profile": "economic_research_v1",
+    "effective_entry_cost_bps": 20.0,
+    "effective_exit_cost_bps": 20.0,
+    "execution_model_version": "backtest_execution_v0",
+    "expected_dataset_digest": "b4cbe7fff81a137da055588231757937406d8cb30d531ee0aab41d95ee9b6c78",
+    "expected_l1_observation_status": "EXECUTION_MODEL_BOUND_NOT_OBSERVED",
+    "expected_manifest_digest": "317105798c749943074911b1e9ea91ac9b94fab3b115fb7a64b692339426651a",
+    "native_instrument_id": "ETH-USDT-SWAP",
+    "out_of_sample_period": "2026-06-27 23:36:00+00:00..2026-07-01 10:07:00+00:00",
+    "require_dataset_admissible": true,
+    "require_integrity_pass": true,
+    "require_observed_l1_used_false": true,
+    "roundtrip_cost_bps": 40.0,
+    "source_venue": "OKX",
+    "training_period": "2026-06-17 16:00:00+00:00..2026-06-24 13:03:00+00:00",
+    "validation_period": "2026-06-24 13:04:00+00:00..2026-06-27 23:35:00+00:00"
+  },
+  "risk": {
+    "max_position_size": 0.25,
+    "min_position_value": 10.0,
+    "min_stop_distance": 0.0001,
+    "risk_per_trade": 0.005
+  },
+  "candidate_binding_id": "composite_breakout_confirmation_vol_gated_donchian_v1"
+}

--- a/src/backtest/strategy_signal_binding_v1.py
+++ b/src/backtest/strategy_signal_binding_v1.py
@@ -18,6 +18,10 @@ from typing import Any, Mapping, Optional, Sequence
 import pandas as pd
 
 from src.strategies import load_strategy
+from src.strategies.breakout_confirmation_v1 import (
+    CONFIRMATION_EPOCHS_V1,
+    generate_confirmed_breakout_signals_v1,
+)
 from src.strategies.composite import CompositeStrategy
 from src.strategies.registry import (
     get_strategy_registry_entry,
@@ -67,9 +71,27 @@ _EXTERNAL_PARAMETER_SCHEMA_V1: dict[str, dict[str, Any]] = {
 
 COMPOSITE_STRATEGY_ID = "composite"
 COMPOSITE_BINDING_TYPE_FILTER_GATED_SIGNAL_V1 = "filter_gated_signal_v1"
+COMPOSITE_BINDING_TYPE_CONFIRMED_FILTER_GATED_SIGNAL_V1 = "confirmed_filter_gated_signal_v1"
 COMPOSITION_RULE_SIGNAL_TIMES_FILTER_MASK = "signal_times_filter_mask"
-_ALLOWED_COMPOSITE_BINDING_TYPES = frozenset({COMPOSITE_BINDING_TYPE_FILTER_GATED_SIGNAL_V1})
-_ALLOWED_COMPOSITION_RULES = frozenset({COMPOSITION_RULE_SIGNAL_TIMES_FILTER_MASK})
+COMPOSITION_RULE_CONFIRMED_SIGNAL_TIMES_FILTER_MASK = "confirmed_signal_times_filter_mask"
+_ALLOWED_COMPOSITE_BINDING_TYPES = frozenset(
+    {
+        COMPOSITE_BINDING_TYPE_FILTER_GATED_SIGNAL_V1,
+        COMPOSITE_BINDING_TYPE_CONFIRMED_FILTER_GATED_SIGNAL_V1,
+    }
+)
+_ALLOWED_COMPOSITION_RULES = frozenset(
+    {
+        COMPOSITION_RULE_SIGNAL_TIMES_FILTER_MASK,
+        COMPOSITION_RULE_CONFIRMED_SIGNAL_TIMES_FILTER_MASK,
+    }
+)
+_COMPOSITE_TYPE_TO_COMPOSITION_RULE = {
+    COMPOSITE_BINDING_TYPE_FILTER_GATED_SIGNAL_V1: COMPOSITION_RULE_SIGNAL_TIMES_FILTER_MASK,
+    COMPOSITE_BINDING_TYPE_CONFIRMED_FILTER_GATED_SIGNAL_V1: (
+        COMPOSITION_RULE_CONFIRMED_SIGNAL_TIMES_FILTER_MASK
+    ),
+}
 _ALLOWED_COMPOSITE_SIGNAL_OWNERS = frozenset(
     {"breakout_donchian", "macd", "ma_crossover", "rsi_reversion"}
 )
@@ -88,6 +110,7 @@ _COMPOSITE_BINDING_TOP_LEVEL_KEYS = frozenset(
         "filter_strategy_params",
         "aggregation",
         "signal_threshold",
+        "confirmation_epochs",
         "binding_semantic_digest",
         "required_warmup_rows",
     }
@@ -279,9 +302,10 @@ class CompositeStrategyBindingV1:
     filter_effective_params: Mapping[str, Any]
     signal_params_digest: str
     filter_params_digest: str
+    confirmation_epochs: Optional[int] = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "composite_type": self.composite_type,
             "composition_rule": self.composition_rule,
             "signal_strategy_id": self.signal_strategy_id,
@@ -297,6 +321,9 @@ class CompositeStrategyBindingV1:
             "signal_params_digest": self.signal_params_digest,
             "filter_params_digest": self.filter_params_digest,
         }
+        if self.confirmation_epochs is not None:
+            payload["confirmation_epochs"] = self.confirmation_epochs
+        return payload
 
 
 def _reject_forbidden_binding_identity(value: str, *, field_name: str) -> None:
@@ -353,6 +380,24 @@ def parse_composite_strategy_binding_v1(
         composition_rule not in _ALLOWED_COMPOSITION_RULES,
         f"unknown_composition_rule:{composition_rule or 'missing'}",
     )
+    expected_rule = _COMPOSITE_TYPE_TO_COMPOSITION_RULE.get(composite_type)
+    _fail_closed(
+        expected_rule is None or composition_rule != expected_rule,
+        f"composite_type_composition_rule_mismatch:{composite_type}:{composition_rule}",
+    )
+
+    confirmation_epochs: Optional[int] = None
+    if composite_type == COMPOSITE_BINDING_TYPE_CONFIRMED_FILTER_GATED_SIGNAL_V1:
+        if "confirmation_epochs" not in configured_params:
+            raise StrategySignalBindingError("composite_confirmation_epochs_missing")
+        raw_epochs = configured_params["confirmation_epochs"]
+        if isinstance(raw_epochs, bool) or not isinstance(raw_epochs, int):
+            raise StrategySignalBindingError("composite_confirmation_epochs_not_integer")
+        if raw_epochs != CONFIRMATION_EPOCHS_V1:
+            raise StrategySignalBindingError("composite_confirmation_epochs_not_allowed")
+        confirmation_epochs = CONFIRMATION_EPOCHS_V1
+    elif "confirmation_epochs" in configured_params:
+        raise StrategySignalBindingError("composite_confirmation_epochs_not_allowed_for_type")
 
     signal_strategy_id = str(configured_params.get("signal_strategy_id", "")).strip()
     filter_strategy_id = str(configured_params.get("filter_strategy_id", "")).strip()
@@ -366,10 +411,16 @@ def parse_composite_strategy_binding_v1(
     canonical_signal_id = signal_resolution.canonical_strategy_id
     canonical_filter_id = filter_resolution.canonical_strategy_id
 
-    _fail_closed(
-        canonical_signal_id not in _ALLOWED_COMPOSITE_SIGNAL_OWNERS,
-        f"composite_signal_owner_not_allowed:{canonical_signal_id}",
-    )
+    if composite_type == COMPOSITE_BINDING_TYPE_CONFIRMED_FILTER_GATED_SIGNAL_V1:
+        _fail_closed(
+            canonical_signal_id != "breakout_donchian",
+            f"confirmed_composite_signal_owner_not_allowed:{canonical_signal_id}",
+        )
+    else:
+        _fail_closed(
+            canonical_signal_id not in _ALLOWED_COMPOSITE_SIGNAL_OWNERS,
+            f"composite_signal_owner_not_allowed:{canonical_signal_id}",
+        )
     _fail_closed(
         canonical_filter_id not in _ALLOWED_COMPOSITE_FILTER_OWNERS,
         f"composite_filter_owner_not_allowed:{canonical_filter_id}",
@@ -433,6 +484,8 @@ def parse_composite_strategy_binding_v1(
     signal_warmup = compute_required_warmup_rows_v1(canonical_signal_id, signal_effective)
     filter_warmup = compute_required_warmup_rows_v1(canonical_filter_id, filter_effective)
     required_warmup_rows = max(signal_warmup, filter_warmup)
+    if confirmation_epochs is not None:
+        required_warmup_rows = max(required_warmup_rows, signal_warmup + confirmation_epochs)
 
     if "required_warmup_rows" in configured_params:
         declared_warmup = configured_params["required_warmup_rows"]
@@ -454,6 +507,8 @@ def parse_composite_strategy_binding_v1(
         "signal_threshold": signal_threshold,
         "required_warmup_rows": required_warmup_rows,
     }
+    if confirmation_epochs is not None:
+        semantic_payload["confirmation_epochs"] = confirmation_epochs
     binding_semantic_digest = compute_composite_binding_semantic_digest_v1(semantic_payload)
 
     expected_digest = configured_params.get("binding_semantic_digest")
@@ -476,6 +531,7 @@ def parse_composite_strategy_binding_v1(
         filter_effective_params=filter_effective,
         signal_params_digest=signal_digest,
         filter_params_digest=filter_digest,
+        confirmation_epochs=confirmation_epochs,
     )
 
 
@@ -487,29 +543,58 @@ def _instantiate_bound_strategy_v1(
     return spec.cls(config=dict(effective_params))
 
 
+def _apply_composite_threshold_and_filter_v1(
+    *,
+    signal_values: pd.Series,
+    signal_threshold: float,
+    filter_strategy,
+    bars: pd.DataFrame,
+) -> pd.Series:
+    aggregated = signal_values.astype(float)
+    final_signals = pd.Series(0, index=bars.index, dtype=int)
+    final_signals = final_signals.where(~(aggregated > signal_threshold), 1)
+    final_signals = final_signals.where(~(aggregated < -signal_threshold), -1)
+    filter_mask = filter_strategy.generate_signals(bars)
+    return (final_signals * filter_mask).astype(int)
+
+
 def execute_composite_strategy_signal_series_v1(
     bars: pd.DataFrame,
     *,
     configured_params: Mapping[str, Any],
     configured_strategy_id: str = COMPOSITE_STRATEGY_ID,
 ) -> StrategySignalBindingResultV1:
-    """Execute filter-gated composite binding via canonical CompositeStrategy owner."""
+    """Execute filter-gated composite binding via canonical strategy owners."""
     binding = parse_composite_strategy_binding_v1(configured_params)
-    signal_strategy = _instantiate_bound_strategy_v1(
-        binding.signal_strategy_id,
-        binding.signal_effective_params,
-    )
     filter_strategy = _instantiate_bound_strategy_v1(
         binding.filter_strategy_id,
         binding.filter_effective_params,
     )
-    composite = CompositeStrategy(
-        strategies=[(signal_strategy, 1.0)],
-        aggregation=binding.aggregation,
-        signal_threshold=binding.signal_threshold,
-        filter_strategy=filter_strategy,
-    )
-    raw_signals = composite.generate_signals(bars)
+    if binding.composite_type == COMPOSITE_BINDING_TYPE_CONFIRMED_FILTER_GATED_SIGNAL_V1:
+        confirmed_signals = generate_confirmed_breakout_signals_v1(
+            bars,
+            lookback=int(binding.signal_effective_params["lookback"]),
+            price_col=str(binding.signal_effective_params["price_col"]),
+            confirmation_epochs=CONFIRMATION_EPOCHS_V1,
+        )
+        raw_signals = _apply_composite_threshold_and_filter_v1(
+            signal_values=confirmed_signals,
+            signal_threshold=binding.signal_threshold,
+            filter_strategy=filter_strategy,
+            bars=bars,
+        )
+    else:
+        signal_strategy = _instantiate_bound_strategy_v1(
+            binding.signal_strategy_id,
+            binding.signal_effective_params,
+        )
+        composite = CompositeStrategy(
+            strategies=[(signal_strategy, 1.0)],
+            aggregation=binding.aggregation,
+            signal_threshold=binding.signal_threshold,
+            filter_strategy=filter_strategy,
+        )
+        raw_signals = composite.generate_signals(bars)
     if not isinstance(raw_signals, pd.Series):
         raise StrategySignalBindingError("composite_signal_not_series")
 

--- a/src/strategies/breakout_confirmation_v1.py
+++ b/src/strategies/breakout_confirmation_v1.py
@@ -1,0 +1,149 @@
+"""
+Deterministic Donchian breakout confirmation v1 (offline research architecture).
+
+Fail-closed, bar-close-only confirmation semantics for composite signal binding.
+No runtime, order, risk, sizing, or promotion authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+import pandas as pd
+
+CONFIRMATION_EPOCHS_V1 = 1
+CONFIRMATION_OWNER = "src.strategies.breakout_confirmation_v1"
+
+
+class BreakoutConfirmationError(ValueError):
+    """Fail-closed breakout confirmation error."""
+
+
+class PendingDirection(str, Enum):
+    LONG = "long"
+    SHORT = "short"
+
+
+@dataclass(frozen=True)
+class PendingCandidateV1:
+    direction: PendingDirection
+    boundary_reference: float
+    candidate_index_pos: int
+
+
+def _fail_closed(condition: bool, reason: str) -> None:
+    if condition:
+        raise BreakoutConfirmationError(reason)
+
+
+def compute_donchian_channel_bounds_v1(
+    price: pd.Series,
+    *,
+    lookback: int,
+) -> tuple[pd.Series, pd.Series]:
+    """Donchian bounds from prior finalized bars only (excludes current bar)."""
+    _fail_closed(lookback < 2, "lookback_below_minimum")
+    rolling_high = price.shift(1).rolling(lookback, min_periods=lookback).max()
+    rolling_low = price.shift(1).rolling(lookback, min_periods=lookback).min()
+    return rolling_high, rolling_low
+
+
+def _bar_is_finalized(data: pd.DataFrame, index_pos: int) -> bool:
+    if "is_final" not in data.columns:
+        return True
+    value = data["is_final"].iloc[index_pos]
+    if pd.isna(value):
+        return False
+    return bool(value)
+
+
+def _scalar_value(series: pd.Series, index_pos: int) -> Optional[float]:
+    value = series.iloc[index_pos]
+    if pd.isna(value):
+        return None
+    return float(value)
+
+
+def generate_confirmed_breakout_signals_v1(
+    data: pd.DataFrame,
+    *,
+    lookback: int,
+    price_col: str = "close",
+    confirmation_epochs: int = CONFIRMATION_EPOCHS_V1,
+) -> pd.Series:
+    """
+    Generate confirmed breakout position signals with immutable candidate boundaries.
+
+    Semantics:
+    - Breach on bar t creates a candidate only (no entry signal on t).
+    - Confirmation on bar t+confirmation_epochs when close remains beyond bound reference.
+    - Bound reference is frozen at candidate creation and never replaced by moving bands.
+    - Opposite breach resets an open candidate.
+    - Unfinalized bars never confirm or create candidates.
+    """
+    _fail_closed(price_col not in data.columns, f"price_col_missing:{price_col}")
+    _fail_closed(confirmation_epochs != CONFIRMATION_EPOCHS_V1, "confirmation_epochs_not_allowed")
+    _fail_closed(len(data.index) == 0, "bars_empty")
+    if not isinstance(data.index, pd.DatetimeIndex):
+        raise BreakoutConfirmationError("index_not_datetime")
+
+    price = data[price_col].astype(float)
+    rolling_high, rolling_low = compute_donchian_channel_bounds_v1(price, lookback=lookback)
+
+    output = pd.Series(0, index=data.index, dtype="int64")
+    position = 0
+    pending: Optional[PendingCandidateV1] = None
+
+    for index_pos in range(len(data.index)):
+        if not _bar_is_finalized(data, index_pos):
+            pending = None
+            output.iloc[index_pos] = position
+            continue
+
+        close_value = _scalar_value(price, index_pos)
+        high_bound = _scalar_value(rolling_high, index_pos)
+        low_bound = _scalar_value(rolling_low, index_pos)
+        if close_value is None or high_bound is None or low_bound is None:
+            pending = None
+            output.iloc[index_pos] = position
+            continue
+
+        if pending is not None:
+            confirm_pos = pending.candidate_index_pos + confirmation_epochs
+            if index_pos == confirm_pos:
+                if pending.direction is PendingDirection.LONG:
+                    if close_value >= pending.boundary_reference:
+                        position = 1
+                elif close_value <= pending.boundary_reference:
+                    position = -1
+                pending = None
+            elif index_pos > confirm_pos:
+                pending = None
+
+        long_breach = close_value > high_bound
+        short_breach = close_value < low_bound
+        if long_breach and short_breach:
+            pending = None
+        elif long_breach:
+            if pending is not None and pending.direction is PendingDirection.SHORT:
+                pending = None
+            pending = PendingCandidateV1(
+                direction=PendingDirection.LONG,
+                boundary_reference=high_bound,
+                candidate_index_pos=index_pos,
+            )
+        elif short_breach:
+            if pending is not None and pending.direction is PendingDirection.LONG:
+                pending = None
+            pending = PendingCandidateV1(
+                direction=PendingDirection.SHORT,
+                boundary_reference=low_bound,
+                candidate_index_pos=index_pos,
+            )
+
+        output.iloc[index_pos] = position
+
+    output.name = "signal"
+    return output.astype(int)

--- a/tests/backtest/test_composite_breakout_confirmation_vol_gated_binding_v0.py
+++ b/tests/backtest/test_composite_breakout_confirmation_vol_gated_binding_v0.py
@@ -1,0 +1,282 @@
+"""Bounded composite breakout confirmation + vol-gated binding contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.backtest.strategy_signal_binding_v1 import (
+    COMPOSITE_BINDING_TYPE_CONFIRMED_FILTER_GATED_SIGNAL_V1,
+    COMPOSITE_BINDING_TYPE_FILTER_GATED_SIGNAL_V1,
+    COMPOSITE_STRATEGY_ID,
+    COMPOSITION_RULE_CONFIRMED_SIGNAL_TIMES_FILTER_MASK,
+    StrategySignalBindingError,
+    compute_composite_required_warmup_rows_v1,
+    execute_composite_strategy_signal_series_v1,
+    execute_configured_strategy_signal_series_v1,
+    parse_composite_strategy_binding_v1,
+)
+from src.strategies.breakout_confirmation_v1 import (
+    CONFIRMATION_EPOCHS_V1,
+    compute_donchian_channel_bounds_v1,
+    generate_confirmed_breakout_signals_v1,
+)
+
+
+def _frame(closes: list[float], *, finals: list[bool] | None = None) -> pd.DataFrame:
+    idx = pd.date_range("2026-06-01", periods=len(closes), freq="1h", tz="UTC")
+    if finals is None:
+        finals = [True] * len(closes)
+    close = [float(v) for v in closes]
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [v + 0.5 for v in close],
+            "low": [v - 0.5 for v in close],
+            "close": close,
+            "is_final": finals,
+        },
+        index=idx,
+    )
+
+
+def _confirmed_binding(**overrides: object) -> dict:
+    payload: dict = {
+        "composite_type": COMPOSITE_BINDING_TYPE_CONFIRMED_FILTER_GATED_SIGNAL_V1,
+        "composition_rule": COMPOSITION_RULE_CONFIRMED_SIGNAL_TIMES_FILTER_MASK,
+        "signal_strategy_id": "breakout_donchian",
+        "filter_strategy_id": "vol_regime_filter",
+        "signal_strategy_params": {"lookback": 3, "price_col": "close"},
+        "filter_strategy_params": {
+            "vol_window": 3,
+            "vol_method": "range",
+            "vol_percentile_low": 0,
+            "vol_percentile_high": 100,
+            "min_bars": 3,
+            "lookback_percentile": 3,
+            "regime_mode": False,
+        },
+        "aggregation": "weighted",
+        "signal_threshold": 0.3,
+        "confirmation_epochs": CONFIRMATION_EPOCHS_V1,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _legacy_binding(**overrides: object) -> dict:
+    payload: dict = {
+        "composite_type": COMPOSITE_BINDING_TYPE_FILTER_GATED_SIGNAL_V1,
+        "composition_rule": "signal_times_filter_mask",
+        "signal_strategy_id": "breakout_donchian",
+        "filter_strategy_id": "vol_regime_filter",
+        "signal_strategy_params": {"lookback": 20, "price_col": "close"},
+        "filter_strategy_params": {
+            "vol_window": 20,
+            "vol_method": "atr",
+            "vol_percentile_low": 25,
+            "vol_percentile_high": 75,
+            "min_bars": 30,
+            "lookback_percentile": 100,
+            "regime_mode": False,
+        },
+        "aggregation": "weighted",
+        "signal_threshold": 0.3,
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestBreakoutConfirmationSemantics:
+    def test_long_candidate_then_confirmation_on_next_bar(self) -> None:
+        closes = [10, 10, 10, 10, 10.6, 10.7, 10.7, 10.7]
+        signals = generate_confirmed_breakout_signals_v1(
+            _frame(closes),
+            lookback=3,
+            price_col="close",
+        )
+        assert signals.iloc[4] == 0
+        assert signals.iloc[5] == 1
+
+    def test_long_reset_when_confirmation_fails(self) -> None:
+        closes = [10, 10, 10, 10, 10.6, 9.8, 9.8, 9.8]
+        signals = generate_confirmed_breakout_signals_v1(
+            _frame(closes),
+            lookback=3,
+            price_col="close",
+        )
+        assert signals.iloc[4] == 0
+        assert signals.iloc[5] == 0
+
+    def test_short_candidate_and_confirmation_mirrored(self) -> None:
+        closes = [10, 10, 10, 10, 9.4, 9.3, 9.3, 9.3]
+        signals = generate_confirmed_breakout_signals_v1(
+            _frame(closes),
+            lookback=3,
+            price_col="close",
+        )
+        assert signals.iloc[4] == 0
+        assert signals.iloc[5] == -1
+
+    def test_short_reset_mirrored(self) -> None:
+        closes = [10, 10, 10, 10, 9.4, 10.2, 10.2, 10.2]
+        signals = generate_confirmed_breakout_signals_v1(
+            _frame(closes),
+            lookback=3,
+            price_col="close",
+        )
+        assert signals.iloc[4] == 0
+        assert signals.iloc[5] == 0
+
+    def test_candidate_boundary_is_immutable_when_channel_moves(self) -> None:
+        closes = [10, 10, 10, 10, 10.6, 10.05, 10.05, 10.05]
+        frame = _frame(closes)
+        rolling_high, _ = compute_donchian_channel_bounds_v1(frame["close"], lookback=3)
+        bound_at_candidate = float(rolling_high.iloc[4])
+        assert bound_at_candidate == 10.0
+        assert float(rolling_high.iloc[5]) != bound_at_candidate
+        signals = generate_confirmed_breakout_signals_v1(frame, lookback=3, price_col="close")
+        assert signals.iloc[5] == 1
+
+    def test_unfinalized_bar_does_not_confirm(self) -> None:
+        closes = [10, 10, 10, 10, 10.6, 10.7, 10.7]
+        finals = [True, True, True, True, True, False, True]
+        signals = generate_confirmed_breakout_signals_v1(
+            _frame(closes, finals=finals),
+            lookback=3,
+            price_col="close",
+        )
+        assert signals.iloc[5] == 0
+        assert signals.iloc[6] == 0
+
+    def test_invalid_data_blocks_candidate_and_confirmation(self) -> None:
+        closes = [10, 10, float("nan"), 10, 10.6, 10.7, 10.7]
+        signals = generate_confirmed_breakout_signals_v1(
+            _frame(closes),
+            lookback=3,
+            price_col="close",
+        )
+        assert signals.iloc[5] == 0
+
+    def test_opposite_breach_resets_pending_candidate(self) -> None:
+        closes = [10, 10, 10, 10, 10.6, 9.3, 9.2, 9.2]
+        signals = generate_confirmed_breakout_signals_v1(
+            _frame(closes),
+            lookback=3,
+            price_col="close",
+        )
+        assert signals.iloc[4] == 0
+        assert signals.iloc[5] == 0
+        assert signals.iloc[6] == -1
+
+    def test_no_signal_before_confirmation(self) -> None:
+        closes = [10, 10, 10, 10, 10.6, 10.7]
+        signals = generate_confirmed_breakout_signals_v1(
+            _frame(closes),
+            lookback=3,
+            price_col="close",
+        )
+        assert signals.iloc[4] == 0
+
+    def test_deterministic_repeat(self) -> None:
+        frame = _frame([10, 10, 10, 10, 10.6, 10.7, 10.7, 10.7])
+        first = generate_confirmed_breakout_signals_v1(frame, lookback=3, price_col="close")
+        second = generate_confirmed_breakout_signals_v1(frame, lookback=3, price_col="close")
+        assert first.equals(second)
+
+    def test_confirmation_epochs_other_than_one_blocked(self) -> None:
+        with pytest.raises(Exception, match="confirmation_epochs_not_allowed"):
+            generate_confirmed_breakout_signals_v1(
+                _frame([10, 10, 10, 10, 10.6, 10.7]),
+                lookback=3,
+                confirmation_epochs=2,
+            )
+
+
+class TestConfirmedCompositeBinding:
+    def test_parse_and_execute_confirmed_binding(self) -> None:
+        binding = parse_composite_strategy_binding_v1(_confirmed_binding())
+        assert binding.composite_type == COMPOSITE_BINDING_TYPE_CONFIRMED_FILTER_GATED_SIGNAL_V1
+        assert binding.confirmation_epochs == CONFIRMATION_EPOCHS_V1
+        result = execute_composite_strategy_signal_series_v1(
+            _frame([10, 10, 10, 10, 10.6, 10.7, 10.7, 10.7, 10.7, 10.7] * 3),
+            configured_params=_confirmed_binding(),
+        )
+        assert result.provenance.strategy_execution_status.value == "EXECUTED"
+
+    def test_vol_regime_filter_remains_bound(self) -> None:
+        binding = parse_composite_strategy_binding_v1(_confirmed_binding())
+        assert binding.filter_strategy_id == "vol_regime_filter"
+
+    def test_registry_binding_unique_from_legacy(self) -> None:
+        legacy = parse_composite_strategy_binding_v1(_legacy_binding())
+        confirmed = parse_composite_strategy_binding_v1(_confirmed_binding())
+        assert legacy.binding_semantic_digest != confirmed.binding_semantic_digest
+
+    def test_legacy_binding_unchanged(self) -> None:
+        legacy = parse_composite_strategy_binding_v1(_legacy_binding())
+        assert legacy.composite_type == COMPOSITE_BINDING_TYPE_FILTER_GATED_SIGNAL_V1
+        assert legacy.confirmation_epochs is None
+
+    def test_bitcoin_identity_blocked(self) -> None:
+        with pytest.raises(StrategySignalBindingError, match="binding_identity_forbidden"):
+            parse_composite_strategy_binding_v1(
+                _confirmed_binding(signal_strategy_id="breakout_btc_usdt")
+            )
+
+    def test_spot_identity_blocked(self) -> None:
+        with pytest.raises(StrategySignalBindingError, match="binding_identity_forbidden"):
+            parse_composite_strategy_binding_v1(
+                _confirmed_binding(filter_strategy_id="eth_spot_filter")
+            )
+
+    def test_non_one_confirmation_epochs_fail_closed(self) -> None:
+        with pytest.raises(
+            StrategySignalBindingError,
+            match="composite_confirmation_epochs_not_allowed",
+        ):
+            parse_composite_strategy_binding_v1(_confirmed_binding(confirmation_epochs=2))
+
+    def test_warmup_includes_confirmation_epoch(self) -> None:
+        warmup = compute_composite_required_warmup_rows_v1(_confirmed_binding())
+        assert warmup >= 3 + CONFIRMATION_EPOCHS_V1
+
+    def test_configured_strategy_execution_has_no_runtime_authority_fields(self) -> None:
+        result = execute_configured_strategy_signal_series_v1(
+            _frame([10, 10, 10, 10, 10.6, 10.7, 10.7, 10.7] * 5),
+            strategy_id=COMPOSITE_STRATEGY_ID,
+            cfg={"economic_evaluation_v1": {"strategy_params": _confirmed_binding()}},
+        )
+        payload = result.provenance.to_dict()
+        assert payload["strategy_execution_status"] == "EXECUTED"
+        assert "runtime" not in json.dumps(payload).lower()
+        assert "order_effect" not in payload
+
+    def test_architecture_binding_config_present_and_distinct(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        new_path = (
+            repo_root
+            / "config/ops/composite_breakout_confirmation_vol_gated_donchian_v1_architecture_binding_v1.json"
+        )
+        old_path = (
+            repo_root
+            / "config/ops/composite_vol_gated_breakout_donchian_v1_economic_evaluation_v1.json"
+        )
+        assert new_path.exists()
+        new_cfg = json.loads(new_path.read_text(encoding="utf-8"))
+        old_cfg = json.loads(old_path.read_text(encoding="utf-8"))
+        assert (
+            new_cfg["candidate_binding_id"]
+            == "composite_breakout_confirmation_vol_gated_donchian_v1"
+        )
+        assert old_cfg["candidate_binding_id"] == "composite_vol_gated_breakout_donchian_v1"
+        assert (
+            new_cfg["economic_evaluation_v1"]["strategy_params"]["composite_type"]
+            == COMPOSITE_BINDING_TYPE_CONFIRMED_FILTER_GATED_SIGNAL_V1
+        )
+        assert "monte_carlo" not in new_cfg["economic_evaluation_v1"]
+        assert "walk_forward" not in new_cfg["economic_evaluation_v1"]
+        assert "stress" not in new_cfg["economic_evaluation_v1"]


### PR DESCRIPTION
## Summary

- Adds deterministic one-epoch Donchian breakout confirmation semantics (`confirmed_filter_gated_signal_v1`) to reduce unconfirmed breakout churn identified in the predecessor development fail root-cause analysis.
- Registers new candidate binding `composite_breakout_confirmation_vol_gated_donchian_v1` via offline architecture config while preserving `composite_vol_gated_breakout_donchian_v1` unchanged.
- Reuses existing owners: `CompositeStrategy` filter path, `breakout_donchian` parameter contract, `vol_regime_filter`, and `strategy_signal_binding_v1` — no parallel registry/metrics/evidence owners.

## Root-cause basis

- Source evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/bounded_composite_vol_gated_breakout_donchian_v1_development_fail_root_cause_and_architecture_admissibility_read_only_v0_20260702T182721Z` (`MANIFEST_VERIFY_RC=0`)
- Predecessor fail was architecture/economic (negative pre-cost edge, WF/MC/stress robustness), not implementation or config binding defect.

## Confirmation semantics (frozen)

- `CONFIRMATION_EPOCHS=1`
- Candidate on finalized bar `t` when Donchian breach occurs; bound reference frozen at candidate creation
- Confirmation only on finalized bar `t+1` when close remains beyond bound reference
- Opposite breach resets pending candidate; no intrabar confirmation; no look-ahead
- Composition: confirmed breakout signal → existing `vol_regime_filter` → thresholded composite output

## Reuse decisions

| Component | Decision |
|---|---|
| `CompositeStrategy` filter/threshold path | REUSE_WITH_NARROW_ADAPTER |
| `breakout_donchian` params | REUSE_AS_IS |
| `vol_regime_filter` | REUSE_AS_IS |
| `strategy_signal_binding_v1` | REWIRE_EXISTING_COMPONENT |
| `breakout_confirmation_v1` signal state machine | NEW_IMPLEMENTATION_ONLY_IF_JUSTIFIED |

## Frozen bindings (unchanged from predecessor)

| Binding | Value |
|---|---|
| Dataset | `inst-eth-usdt-perp` v1 (`b4cbe7f…`) |
| Training | `2026-06-17 16:00:00+00:00..2026-06-24 13:03:00+00:00` |
| Validation | `2026-06-24 13:04:00+00:00..2026-06-27 23:35:00+00:00` |
| Cost model | 40 bps roundtrip (`backtest_cost_v0`) |
| Donchian lookback | 20 |
| Vol regime | ATR 20, percentile 25–75, min_bars 30 |
| stop_pct | 0.02 offline contract only |

## Explicit prohibitions

- No economic evaluation, backtest, walk-forward, Monte Carlo, stress, or parameter sensitivity runs in this PR
- No holdout access, threshold mutation, dataset/period/cost changes, promotion, runtime, or order authority
- `FUTURES_ONLY=true`, `BITCOIN_DIRECTION_ALLOWED=false`

## Test plan

- [x] `pytest tests/backtest/test_composite_breakout_confirmation_vol_gated_binding_v0.py` (21 passed)
- [x] `pytest tests/backtest/test_composite_vol_regime_binding_robustness_wiring_v0.py` (21 passed, regression)
- [x] `ruff format --check` / `ruff check` on changed Python files
- [x] `git diff --check`
- [ ] CI PR_BOUNDED_FULL (central `src/` path)


Made with [Cursor](https://cursor.com)