### PR TITLE
docs: reject composite breakout confirmation vol-gated donchian v1

### DIFF
--- a/docs/governance/COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ARCHITECTURE_REJECTION_AND_RESEARCH_LINE_CLOSEOUT_V0.md
+++ b/docs/governance/COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ARCHITECTURE_REJECTION_AND_RESEARCH_LINE_CLOSEOUT_V0.md
@@ -1,0 +1,97 @@
+# Composite Breakout Confirmation Vol-Gated Donchian v1 — Architecture Rejection and Research Line Closeout v0
+
+## Scope
+
+- Candidate: `composite_breakout_confirmation_vol_gated_donchian_v1`
+- Instrument: `inst-eth-usdt-perp` on `OKX`
+- Architecture GO token (consumed): `GO_BOUNDED_COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ARCHITECTURE_RATIFICATION_AND_BINDING_V0`
+- Economic evaluation merge: PR `#4759` at `ec0842428b8420fb4d8193d69c307809bcabee75`
+- Architecture binding merge: PR `#4758` at `5eb28206fb49062049c89f43d77da2899f22c93d`
+- Closeout GO token (ratified): `GO_BOUNDED_COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ARCHITECTURE_REJECTION_RATIFICATION_AND_RESEARCH_LINE_CLOSEOUT_V0`
+
+## Ratified Fixed Architecture Binding
+
+- Composite type: `confirmed_filter_gated_signal_v1`
+- Composition rule: `confirmed_signal_times_filter_mask`
+- Signal: `breakout_donchian` (`lookback=20`, `price_col=close`)
+- Filter: `vol_regime_filter` (ATR percentile gating)
+- Confirmation epochs: `1`
+- Sizing: `risk_per_trade=0.005`, `stop_pct=0.02`, `max_position_pct=0.25`, `oversize_policy=REJECT_OVERSIZE`
+
+## Economic Evaluation Closeout (Ratified 2026-07-02)
+
+| Field | Value |
+|---|---|
+| `CANDIDATE_ID` | `composite_breakout_confirmation_vol_gated_donchian_v1` |
+| `ARCHITECTURE_BINDING_MERGE_COMMIT` | `5eb28206fb49062049c89f43d77da2899f22c93d` |
+| `ECONOMIC_EVALUATION_MERGE_COMMIT` | `ec0842428b8420fb4d8193d69c307809bcabee75` |
+| `ECONOMIC_EVALUATION_VERDICT` | `ECONOMIC_VALIDITY_OFFLINE_GATE_FAIL` |
+| `FAILURE_DECOMPOSITION_VERDICT` | `ECONOMIC_VALIDITY_FAILURE_DECOMPOSITION_COMPLETE` |
+| `ARCHITECTURE_DISPOSITION` | `ARCHITECTURE_HYPOTHESIS_FALSIFIED` |
+| `FINAL_RESEARCH_DISPOSITION` | `REJECTED_CLOSED` |
+| `RESEARCH_LINE_STATUS` | `CLOSED_REJECTED` |
+| `REJECTION_REASON` | `STRUCTURALLY_NEGATIVE_NET_EDGE_ACROSS_WALK_FORWARD_MONTE_CARLO_AND_STRESS` |
+| `TECHNICAL_EVALUATION_STATUS` | `PASS` |
+| `ECONOMIC_VALIDITY_STATUS` | `FAILED` |
+| `ECONOMIC_VALIDITY_OFFLINE_GATE_PASS` | `false` |
+| `EVALUATION_ID` | `econ_evidence_eval_v1_d618bf84626619d6` |
+
+### Headline evaluation results (immutable evidence; not recomputed)
+
+| Metric | Value |
+|---|---|
+| Trade count | `217` |
+| Net expectancy | `-1.0763` |
+| Profit factor | `0.7394` |
+| Sharpe | `-0.9290` |
+| Walk-forward pass ratio | `0.20` |
+| OOS pass ratio | `0.20` |
+| Monte Carlo pass ratio | `0.0` |
+| Monte Carlo median return | `-0.0205` |
+| Stress scenarios negative | `4/4` |
+| Cost grid negative | `9/9` |
+| Gross return equals net return | `true` (structural edge absence) |
+
+Primary failure cause: missing structural net edge, not cost drag, insufficient trade count, drawdown breach, or contract/data blocker.
+
+## Architecture Rejection Ratification
+
+Under fixed bindings on OKX ETH-USDT perpetual (~14-day economic research slice, `economic_validity_policy_v1`, realistic costs/funding/execution), admissible evidence falsifies the architecture hypothesis. The research line is closed as rejected.
+
+`ARCHITECTURE_HYPOTHESIS_FALSIFIED=true`
+`ARCHITECTURE_REJECTED=true`
+`RETRY_ALLOWED=false`
+
+## Governance and Authority
+
+- `evaluation_authorized=false`
+- `promotion_authorized=false`
+- `runtime_authorized=false`
+- `shadow_eligible=false`
+- `paper_eligible=false`
+- `testnet_eligible=false`
+- `parameter_tuning_allowed=false`
+- `threshold_relaxation_allowed=false`
+- `dataset_substitution_allowed=false`
+- `period_substitution_allowed=false`
+- `holdout_allowed=false`
+- `retry_allowed=false`
+- `reevaluation_allowed=false`
+- `NO_NEW_CANDIDATE_HOLD=ACTIVE`
+- `STEP29N_PROMOTION_GATE_STATUS=FAIL_CLOSED_BLOCKED`
+- `STEP29R_RUNTIME_REWIRE_ADMISSIBLE=false`
+- `DOWNSTREAM_AUTHORITY_EFFECT=NONE`
+
+No implicit follow-up candidate, retry, tuning, or promotion path is authorized.
+
+## Durable Evidence References
+
+- Architecture ratification: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_architecture_ratification_and_binding_v0_20260702T183549Z`
+- Offline evaluation: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_offline_economic_validity_evaluation_v0_20260702T185926Z` (`MANIFEST_VERIFY_RC=0`)
+- Economic evaluation merge closeout: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_pr_squash_merge_and_post_merge_closeout_v0_20260702T191014Z`
+- Failure decomposition: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/analysis/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_economic_validity_failure_decomposition_and_research_disposition_read_only_v0_20260702T211530Z` (`MANIFEST_VERIFY_RC=0`)
+
+## Derivation References
+
+- `operator_policy_decision:COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1`
+- `fleet_precedent:macd_v3_post_risk_limits_rewire`

--- a/docs/governance/COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ARCHITECTURE_REJECTION_AND_RESEARCH_LINE_CLOSEOUT_V0.md
+++ b/docs/governance/COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ARCHITECTURE_REJECTION_AND_RESEARCH_LINE_CLOSEOUT_V0.md
@@ -48,8 +48,8 @@
 | OOS pass ratio | `0.20` |
 | Monte Carlo pass ratio | `0.0` |
 | Monte Carlo median return | `-0.0205` |
-| Stress scenarios negative | `4/4` |
-| Cost grid negative | `9/9` |
+| Stress scenarios negative | `4&#47;4` |
+| Cost grid negative | `9&#47;9` |
 | Gross return equals net return | `true` (structural edge absence) |
 
 Primary failure cause: missing structural net edge, not cost drag, insufficient trade count, drawdown breach, or contract/data blocker.

--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -1650,8 +1650,8 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `OOS_PASS_RATIO` | `0.20` |
 | `MONTE_CARLO_PASS_RATIO` | `0.0` |
 | `MONTE_CARLO_MEDIAN_RETURN` | `-0.0205` |
-| `STRESS_SCENARIOS_NEGATIVE` | `4/4` |
-| `COST_GRID_NEGATIVE` | `9/9` |
+| `STRESS_SCENARIOS_NEGATIVE` | `4&#47;4` |
+| `COST_GRID_NEGATIVE` | `9&#47;9` |
 | `GROSS_RETURN_EQUALS_NET_RETURN` | `true` |
 | `PROMOTION_ELIGIBLE` | `false` |
 | `SHADOW_ELIGIBLE` | `false` |

--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -18,8 +18,8 @@ SCHEDULER_RUNTIME_ALLOWED: false
 
 | Feld | Wert |
 |---|---|
-| `LAST_VERIFIED_ORIGIN_MAIN` | `ca1dabbf2a6fb53b5b0d6bee3e3cf54d36977375` |
-| `LAST_VERIFIED_AT` | `2026-07-02T17:19:11Z` |
+| `LAST_VERIFIED_ORIGIN_MAIN` | `ec0842428b8420fb4d8193d69c307809bcabee75` |
+| `LAST_VERIFIED_AT` | `2026-07-02T22:00:00Z` |
 | `CURRENT_MAJOR_GAP_PACKAGE` | `MAJOR_GAP_COMPARISON_PROMOTION_POLICY_INPUT_BRIDGE_V0` |
 | `NEXT_RUNBOOK_STEP` | `RUNBOOK_STEP_29R_RUNTIME_REWIRE_V1_IMPLEMENTATION` |
 | `NEXT_RUNBOOK_STEP_STRUCTURAL_STATUS` | `OPEN_OR_IN_PROGRESS` |
@@ -35,6 +35,8 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `STEP30A_POLICY_FAIL_REGISTRY_RECONCILIATION_PR4754_MERGE_COMMIT` | `ca1dabbf2a6fb53b5b0d6bee3e3cf54d36977375` |
 | `STEP30A_POLICY_FAIL_REGISTRY_RECONCILIATION_PR4754_CLOSEOUT_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_step30a_policy_fail_registry_post_merge_progress_registry_reconciliation_pr_squash_merge_and_post_merge_closeout_v0_20260702T171437Z (MANIFEST_VERIFY_RC=0; PR #4754; squash ca1dabbf; VERDICT=STEP30A_POLICY_FAIL_REGISTRY_RECONCILIATION_PR4754_SQUASH_MERGE_AND_POST_MERGE_CLOSEOUT_COMPLETE)` |
 | `POST_STEP30A_CANONICAL_CURRENT_STATE_REASSESSMENT_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_post_step30a_policy_fail_registry_merge_canonical_current_state_read_only_reassessment_v0_20260702T170526Z (MANIFEST_VERIFY_RC=0; VERDICT=POST_STEP30A_POLICY_FAIL_REGISTRY_MERGE_CANONICAL_CURRENT_STATE_READ_ONLY_REASSESSMENT_COMPLETE)` |
+| `COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ARCHITECTURE_REJECTION_CLOSEOUT_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/analysis/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_architecture_rejection_ratification_and_research_line_closeout_v0_20260702T192029Z (MANIFEST_VERIFY_RC=0)` |
+| `COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_FAILURE_DECOMPOSITION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/analysis/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_economic_validity_failure_decomposition_and_research_disposition_read_only_v0_20260702T211530Z (MANIFEST_VERIFY_RC=0)` |
 | `RETRY_ALLOWED` | `false` |
 | `REEVALUATION_ALLOWED` | `false` |
 | `PROMOTION_ELIGIBLE` | `false` |
@@ -318,6 +320,12 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `STEP30A_POLICY_FAIL_REGISTRY_MERGE_CLOSEOUT_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_step30a_rsi_reversion_v1_policy_fail_registry_pr_squash_merge_and_post_merge_closeout_v0_20260702T170255Z (MANIFEST_VERIFY_RC=0; PR #4753; squash 2952dc1e)` |
 | `POST_STEP30A_CANONICAL_CURRENT_STATE_REASSESSMENT_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_post_step30a_policy_fail_registry_merge_canonical_current_state_read_only_reassessment_v0_20260702T170526Z (MANIFEST_VERIFY_RC=0; VERDICT=POST_STEP30A_POLICY_FAIL_REGISTRY_MERGE_CANONICAL_CURRENT_STATE_READ_ONLY_REASSESSMENT_COMPLETE)` |
 | `STEP30A_REGISTERED_ECONOMIC_EVALUATION_CONFIGS` | `config&#47;ops&#47;step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json` <!-- pt:ref-target-ignore --> |
+| `COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_RESEARCH_LINE_STATUS` | `CLOSED_REJECTED` |
+| `COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ARCHITECTURE_DISPOSITION` | `ARCHITECTURE_HYPOTHESIS_FALSIFIED` |
+| `COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_FINAL_RESEARCH_DISPOSITION` | `REJECTED_CLOSED` |
+| `COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ECONOMIC_VALIDITY_STATUS` | `FAILED` |
+| `COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_PROMOTION_ELIGIBLE` | `false` |
+| `COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_RETRY_ALLOWED` | `false` |
 | `TECHNICAL_CAPABILITY_PRESENT_NOT_EQUAL_ECONOMIC_VALIDITY_PROVEN` | `true` |
 | `NEGATIVE_CANDIDATE_EVIDENCE_NOT_EQUAL_WHOLE_SYSTEM_UNPROFITABLE` | `true` |
 | `STEP29N_ALREADY_COMPLETE` | `true` |
@@ -1595,6 +1603,80 @@ Technische Zerlegung des Runbook-Übergangs: Promotion Eligibility → vollstän
 | `CONSUMED_EVALUATION_GO_TOKEN` | `GO_BOUNDED_STEP30A_SINGLE_ECONOMIC_EVALUATION_POST_RUNNER_MERGE_V1` |
 | `CONSUMED_GO_REUSABLE` | `false` |
 | `TECHNICAL_CAPABILITY_PRESENT_NOT_EQUAL_ECONOMIC_VALIDITY_PROVEN` | `true` |
+| `NEGATIVE_CANDIDATE_EVIDENCE_NOT_EQUAL_WHOLE_SYSTEM_UNPROFITABLE` | `true` |
+| `SEPARATE_GO_REQUIRED` | `false` |
+
+#### RUNBOOK_RESEARCH_LINE — Composite Breakout Confirmation Vol-Gated Donchian v1
+
+| Feld | Wert |
+|---|---|
+| `RUNBOOK_PHASE` | 9 |
+| `RUNBOOK_STEP_ID` | `composite_breakout_confirmation_vol_gated_donchian_v1_architecture_research_v0` |
+| `STATUS` | `CLOSED_REJECTED` |
+| `CANONICAL_OWNER` | `src/backtest/step29m_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_admissibility_contract_v1.py` |
+| `CANONICAL_ARCHITECTURE_BINDING_PATH` | `config&#47;ops&#47;composite_breakout_confirmation_vol_gated_donchian_v1_architecture_binding_v1.json` <!-- pt:ref-target-ignore --> |
+| `CANONICAL_EVALUATION_CONFIG_PATH` | `config&#47;ops&#47;step29m_okx_inst_eth_usdt_perp_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_v1.json` <!-- pt:ref-target-ignore --> |
+| `DEPENDENCIES` | RUNBOOK_STEP_30A |
+| `NEXT_REQUIRED_CONTRACT` | `NONE` |
+| `NEXT_CANONICAL_STEP` | `NO_FURTHER_COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_RESEARCH_ACTION_UNDER_NO_NEW_CANDIDATE_HOLD` |
+| `AUTHORITY_LEVEL` | `NON_AUTHORITIZING` |
+| `FUTURES_ONLY` | `true` |
+| `BITCOIN_DIRECTION_ALLOWED` | `false` |
+| `ORDER_EFFECT` | `false` |
+| `RUNTIME_EFFECT` | `false` |
+| `LIVE_AUTHORIZED` | `false` |
+| `CANDIDATE_ID` | `composite_breakout_confirmation_vol_gated_donchian_v1` |
+| `ARCHITECTURE_BINDING_MERGE_COMMIT` | `5eb28206fb49062049c89f43d77da2899f22c93d` |
+| `ECONOMIC_EVALUATION_MERGE_COMMIT` | `ec0842428b8420fb4d8193d69c307809bcabee75` |
+| `ARCHITECTURE_GO_TOKEN` | `GO_BOUNDED_COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ARCHITECTURE_RATIFICATION_AND_BINDING_V0` |
+| `CLOSEOUT_GO_TOKEN` | `GO_BOUNDED_COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ARCHITECTURE_REJECTION_RATIFICATION_AND_RESEARCH_LINE_CLOSEOUT_V0` |
+| `RESEARCH_LINE_STATUS` | `CLOSED_REJECTED` |
+| `ARCHITECTURE_HYPOTHESIS_FALSIFIED` | `true` |
+| `ARCHITECTURE_REJECTED` | `true` |
+| `ARCHITECTURE_DISPOSITION` | `ARCHITECTURE_HYPOTHESIS_FALSIFIED` |
+| `FINAL_RESEARCH_DISPOSITION` | `REJECTED_CLOSED` |
+| `REJECTION_REASON` | `STRUCTURALLY_NEGATIVE_NET_EDGE_ACROSS_WALK_FORWARD_MONTE_CARLO_AND_STRESS` |
+| `TECHNICAL_EVALUATION_STATUS` | `PASS` |
+| `ECONOMIC_VALIDITY_STATUS` | `FAILED` |
+| `ECONOMIC_EVALUATION_VERDICT` | `ECONOMIC_VALIDITY_OFFLINE_GATE_FAIL` |
+| `FAILURE_DECOMPOSITION_VERDICT` | `ECONOMIC_VALIDITY_FAILURE_DECOMPOSITION_COMPLETE` |
+| `ECONOMIC_VALIDITY_OFFLINE_GATE_PASS` | `false` |
+| `EVALUATION_ID` | `econ_evidence_eval_v1_d618bf84626619d6` |
+| `TRADE_COUNT` | `217` |
+| `NET_EXPECTANCY` | `-1.0763` |
+| `PROFIT_FACTOR` | `0.7394` |
+| `SHARPE` | `-0.9290` |
+| `WALK_FORWARD_PASS_RATIO` | `0.20` |
+| `OOS_PASS_RATIO` | `0.20` |
+| `MONTE_CARLO_PASS_RATIO` | `0.0` |
+| `MONTE_CARLO_MEDIAN_RETURN` | `-0.0205` |
+| `STRESS_SCENARIOS_NEGATIVE` | `4/4` |
+| `COST_GRID_NEGATIVE` | `9/9` |
+| `GROSS_RETURN_EQUALS_NET_RETURN` | `true` |
+| `PROMOTION_ELIGIBLE` | `false` |
+| `SHADOW_ELIGIBLE` | `false` |
+| `PAPER_ELIGIBLE` | `false` |
+| `TESTNET_ELIGIBLE` | `false` |
+| `RUNTIME_ELIGIBLE` | `false` |
+| `RETRY_ALLOWED` | `false` |
+| `HOLDOUT_ALLOWED` | `false` |
+| `PARAMETER_TUNING_ALLOWED` | `false` |
+| `THRESHOLD_RELAXATION_ALLOWED` | `false` |
+| `DATASET_SUBSTITUTION_ALLOWED` | `false` |
+| `PERIOD_SUBSTITUTION_ALLOWED` | `false` |
+| `EVALUATION_AUTHORIZED` | `false` |
+| `PROMOTION_AUTHORIZED` | `false` |
+| `RUNTIME_AUTHORIZED` | `false` |
+| `NO_NEW_CANDIDATE_HOLD` | `ACTIVE` |
+| `STEP29N_PROMOTION_GATE_STATUS` | `FAIL_CLOSED_BLOCKED` |
+| `STEP29R_RUNTIME_REWIRE_ADMISSIBLE` | `false` |
+| `DOWNSTREAM_AUTHORITY_EFFECT` | `NONE` |
+| `ARCHITECTURE_RATIFICATION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_architecture_ratification_and_binding_v0_20260702T183549Z` |
+| `OFFLINE_EVALUATION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_offline_economic_validity_evaluation_v0_20260702T185926Z (MANIFEST_VERIFY_RC=0)` |
+| `ECONOMIC_EVALUATION_MERGE_CLOSEOUT_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_pr_squash_merge_and_post_merge_closeout_v0_20260702T191014Z` |
+| `FAILURE_DECOMPOSITION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/analysis/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_economic_validity_failure_decomposition_and_research_disposition_read_only_v0_20260702T211530Z (MANIFEST_VERIFY_RC=0)` |
+| `ARCHITECTURE_REJECTION_CLOSEOUT_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/analysis/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_architecture_rejection_ratification_and_research_line_closeout_v0_20260702T192029Z (MANIFEST_VERIFY_RC=0)` |
+| `OPERATOR_POLICY_DECISION_REF` | `operator_policy_decision:COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1` |
 | `NEGATIVE_CANDIDATE_EVIDENCE_NOT_EQUAL_WHOLE_SYSTEM_UNPROFITABLE` | `true` |
 | `SEPARATE_GO_REQUIRED` | `false` |
 

--- a/src/backtest/step29m_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_admissibility_contract_v1.py
@@ -84,6 +84,56 @@ CONFIG_SCHEMA_VERSION = (
     "economic_evaluation_admissibility_v1"
 )
 
+ARCHITECTURE_BINDING_MERGE_COMMIT = "5eb28206fb49062049c89f43d77da2899f22c93d"
+ECONOMIC_EVALUATION_MERGE_COMMIT = "ec0842428b8420fb4d8193d69c307809bcabee75"
+ARCHITECTURE_BINDING_CONFIG_PATH = (
+    "config/ops/composite_breakout_confirmation_vol_gated_donchian_v1_architecture_binding_v1.json"
+)
+
+ARCHITECTURE_HYPOTHESIS_FALSIFIED = True
+ARCHITECTURE_REJECTED = True
+RESEARCH_LINE_STATUS = "CLOSED_REJECTED"
+ECONOMIC_VALIDITY_STATUS = "FAILED"
+ECONOMIC_EVALUATION_VERDICT = "ECONOMIC_VALIDITY_OFFLINE_GATE_FAIL"
+FAILURE_DECOMPOSITION_VERDICT = "ECONOMIC_VALIDITY_FAILURE_DECOMPOSITION_COMPLETE"
+ARCHITECTURE_DISPOSITION = "ARCHITECTURE_HYPOTHESIS_FALSIFIED"
+FINAL_RESEARCH_DISPOSITION = "REJECTED_CLOSED"
+REJECTION_REASON = "STRUCTURALLY_NEGATIVE_NET_EDGE_ACROSS_WALK_FORWARD_MONTE_CARLO_AND_STRESS"
+
+PROMOTION_ELIGIBLE = False
+SHADOW_ELIGIBLE = False
+PAPER_ELIGIBLE = False
+TESTNET_ELIGIBLE = False
+RUNTIME_ELIGIBLE = False
+RETRY_ALLOWED = False
+HOLDOUT_ALLOWED = False
+PARAMETER_TUNING_ALLOWED = False
+THRESHOLD_RELAXATION_ALLOWED = False
+DATASET_SUBSTITUTION_ALLOWED = False
+PERIOD_SUBSTITUTION_ALLOWED = False
+
+ARCHITECTURE_RATIFICATION_EVIDENCE_REF = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "implementation/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_"
+    "architecture_ratification_and_binding_v0_20260702T183549Z"
+)
+OFFLINE_EVALUATION_EVIDENCE_REF = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "implementation/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_"
+    "offline_economic_validity_evaluation_v0_20260702T185926Z"
+)
+ECONOMIC_EVALUATION_MERGE_CLOSEOUT_EVIDENCE_REF = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "implementation/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_"
+    "economic_evaluation_pr_squash_merge_and_post_merge_closeout_v0_20260702T191014Z"
+)
+FAILURE_DECOMPOSITION_EVIDENCE_REF = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "analysis/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_"
+    "economic_validity_failure_decomposition_and_research_disposition_read_only_v0_"
+    "20260702T211530Z"
+)
+
 STEP29M_REGISTERED_ECONOMIC_EVALUATION_CONFIGS_V1: tuple[str, ...] = (
     "config/ops/step29m_okx_inst_eth_usdt_perp_economic_evaluation_v1.json",
     "config/ops/step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v1.json",

--- a/tests/ops/test_composite_breakout_confirmation_vol_gated_donchian_v1_architecture_rejection_and_research_line_closeout_contract_v0.py
+++ b/tests/ops/test_composite_breakout_confirmation_vol_gated_donchian_v1_architecture_rejection_and_research_line_closeout_contract_v0.py
@@ -1,0 +1,148 @@
+"""Contract tests for composite breakout confirmation vol-gated donchian v1 rejection closeout v0."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from src.backtest import (
+    step29m_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_admissibility_contract_v1 as contract,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROGRESS_REGISTRY = REPO_ROOT / "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+CLOSEOUT_RECORD = (
+    REPO_ROOT
+    / "docs/governance/COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_ARCHITECTURE_REJECTION_AND_RESEARCH_LINE_CLOSEOUT_V0.md"
+)
+
+FAILURE_DECOMPOSITION_EVIDENCE = Path(contract.FAILURE_DECOMPOSITION_EVIDENCE_REF)
+OFFLINE_EVALUATION_EVIDENCE = Path(contract.OFFLINE_EVALUATION_EVIDENCE_REF)
+ARCHITECTURE_RATIFICATION_EVIDENCE = Path(contract.ARCHITECTURE_RATIFICATION_EVIDENCE_REF)
+
+
+def _read_registry() -> str:
+    assert PROGRESS_REGISTRY.is_file(), f"missing canonical registry: {PROGRESS_REGISTRY}"
+    return PROGRESS_REGISTRY.read_text(encoding="utf-8")
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(
+        rf"\| `{re.escape(field)}` \| `([^`]*)`(?: <!--.*?-->)? \|",
+        text,
+    )
+    assert match, f"missing registry field: {field}"
+    return match.group(1)
+
+
+def _research_line_section(text: str) -> str:
+    start = text.index(
+        "#### RUNBOOK_RESEARCH_LINE — Composite Breakout Confirmation Vol-Gated Donchian v1"
+    )
+    end = text.index("#### RUNBOOK_STEP_29N — Promotion Economic Gate Binding v1", start)
+    return text[start:end]
+
+
+def test_disposition_constants_match_ratified_closeout() -> None:
+    assert contract.CANDIDATE_BINDING_ID == "composite_breakout_confirmation_vol_gated_donchian_v1"
+    assert contract.ARCHITECTURE_HYPOTHESIS_FALSIFIED is True
+    assert contract.ARCHITECTURE_REJECTED is True
+    assert contract.RESEARCH_LINE_STATUS == "CLOSED_REJECTED"
+    assert contract.ECONOMIC_VALIDITY_STATUS == "FAILED"
+    assert contract.ECONOMIC_EVALUATION_VERDICT == "ECONOMIC_VALIDITY_OFFLINE_GATE_FAIL"
+    assert contract.FINAL_RESEARCH_DISPOSITION == "REJECTED_CLOSED"
+    assert contract.REJECTION_REASON == (
+        "STRUCTURALLY_NEGATIVE_NET_EDGE_ACROSS_WALK_FORWARD_MONTE_CARLO_AND_STRESS"
+    )
+    assert contract.PROMOTION_ELIGIBLE is False
+    assert contract.RETRY_ALLOWED is False
+    assert contract.HOLDOUT_ALLOWED is False
+    assert contract.PARAMETER_TUNING_ALLOWED is False
+    assert contract.THRESHOLD_RELAXATION_ALLOWED is False
+
+
+def test_research_line_closed_rejected_without_retry_or_promotion() -> None:
+    section = _research_line_section(_read_registry())
+    assert _field_value(section, "RESEARCH_LINE_STATUS") == "CLOSED_REJECTED"
+    assert _field_value(section, "ARCHITECTURE_DISPOSITION") == "ARCHITECTURE_HYPOTHESIS_FALSIFIED"
+    assert _field_value(section, "FINAL_RESEARCH_DISPOSITION") == "REJECTED_CLOSED"
+    assert _field_value(section, "ECONOMIC_VALIDITY_STATUS") == "FAILED"
+    assert _field_value(section, "PROMOTION_ELIGIBLE") == "false"
+    assert _field_value(section, "RETRY_ALLOWED") == "false"
+    assert _field_value(section, "HOLDOUT_ALLOWED") == "false"
+    assert _field_value(section, "PARAMETER_TUNING_ALLOWED") == "false"
+    assert _field_value(section, "THRESHOLD_RELAXATION_ALLOWED") == "false"
+    assert _field_value(section, "DATASET_SUBSTITUTION_ALLOWED") == "false"
+    assert _field_value(section, "PERIOD_SUBSTITUTION_ALLOWED") == "false"
+    assert _field_value(section, "SHADOW_ELIGIBLE") == "false"
+    assert _field_value(section, "PAPER_ELIGIBLE") == "false"
+    assert _field_value(section, "TESTNET_ELIGIBLE") == "false"
+    assert _field_value(section, "RUNTIME_ELIGIBLE") == "false"
+
+
+def test_economic_evaluation_verdict_and_merge_commits_bound() -> None:
+    section = _research_line_section(_read_registry())
+    assert (
+        _field_value(section, "ECONOMIC_EVALUATION_VERDICT")
+        == "ECONOMIC_VALIDITY_OFFLINE_GATE_FAIL"
+    )
+    assert (
+        _field_value(section, "FAILURE_DECOMPOSITION_VERDICT")
+        == "ECONOMIC_VALIDITY_FAILURE_DECOMPOSITION_COMPLETE"
+    )
+    assert (
+        _field_value(section, "ARCHITECTURE_BINDING_MERGE_COMMIT")
+        == contract.ARCHITECTURE_BINDING_MERGE_COMMIT
+    )
+    assert (
+        _field_value(section, "ECONOMIC_EVALUATION_MERGE_COMMIT")
+        == contract.ECONOMIC_EVALUATION_MERGE_COMMIT
+    )
+    assert _field_value(section, "EVALUATION_ID") == "econ_evidence_eval_v1_d618bf84626619d6"
+
+
+def test_no_pending_or_promising_status_language() -> None:
+    section = _research_line_section(_read_registry())
+    status = _field_value(section, "STATUS")
+    assert status == "CLOSED_REJECTED"
+    forbidden = ("PENDING", "PROMISING", "INCONCLUSIVE", "RETRYABLE", "BLOCKED")
+    for token in forbidden:
+        assert token not in status
+
+
+def test_policy_convergence_no_new_candidate_hold() -> None:
+    section = _research_line_section(_read_registry())
+    assert _field_value(section, "NO_NEW_CANDIDATE_HOLD") == "ACTIVE"
+    assert _field_value(section, "EVALUATION_AUTHORIZED") == "false"
+    assert _field_value(section, "PROMOTION_AUTHORIZED") == "false"
+    assert _field_value(section, "RUNTIME_AUTHORIZED") == "false"
+    assert _field_value(section, "STEP29N_PROMOTION_GATE_STATUS") == "FAIL_CLOSED_BLOCKED"
+    assert _field_value(section, "STEP29R_RUNTIME_REWIRE_ADMISSIBLE") == "false"
+    assert _field_value(section, "DOWNSTREAM_AUTHORITY_EFFECT") == "NONE"
+    assert (
+        _field_value(section, "NEXT_CANONICAL_STEP")
+        == "NO_FURTHER_COMPOSITE_BREAKOUT_CONFIRMATION_VOL_GATED_DONCHIAN_V1_RESEARCH_ACTION_UNDER_NO_NEW_CANDIDATE_HOLD"
+    )
+
+
+def test_closeout_evidence_refs_bound() -> None:
+    section = _research_line_section(_read_registry())
+    assert str(FAILURE_DECOMPOSITION_EVIDENCE) in _field_value(
+        section, "FAILURE_DECOMPOSITION_EVIDENCE_REF"
+    )
+    assert str(OFFLINE_EVALUATION_EVIDENCE) in _field_value(
+        section, "OFFLINE_EVALUATION_EVIDENCE_REF"
+    )
+    assert str(ARCHITECTURE_RATIFICATION_EVIDENCE) in _field_value(
+        section, "ARCHITECTURE_RATIFICATION_EVIDENCE_REF"
+    )
+
+
+def test_closeout_record_exists_and_matches_disposition() -> None:
+    assert CLOSEOUT_RECORD.is_file(), f"missing: {CLOSEOUT_RECORD}"
+    body = CLOSEOUT_RECORD.read_text(encoding="utf-8")
+    assert "ARCHITECTURE_HYPOTHESIS_FALSIFIED" in body
+    assert "CLOSED_REJECTED" in body
+    assert "REJECTED_CLOSED" in body
+    assert "NO_NEW_CANDIDATE_HOLD=ACTIVE" in body
+    assert contract.CANDIDATE_BINDING_ID in body

--- a/tests/ops/test_step29m_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/tests/ops/test_step29m_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_admissibility_contract_v1.py
@@ -129,6 +129,14 @@ def test_full_admissibility_contract_passes() -> None:
     assert result.policy_invariant_result == contract.POLICY_INVARIANT_RESULT
 
 
+def test_ratified_research_disposition_constants() -> None:
+    assert contract.RESEARCH_LINE_STATUS == "CLOSED_REJECTED"
+    assert contract.ARCHITECTURE_REJECTED is True
+    assert contract.ECONOMIC_EVALUATION_VERDICT == "ECONOMIC_VALIDITY_OFFLINE_GATE_FAIL"
+    assert contract.PROMOTION_ELIGIBLE is False
+    assert contract.RETRY_ALLOWED is False
+
+
 def test_non_one_confirmation_epochs_fail_closed() -> None:
     bad_params = dict(contract.COMPOSITE_V1_CANONICAL_PARAMS)
     bad_params["confirmation_epochs"] = 2


### PR DESCRIPTION
## Summary

- Ratifies `ARCHITECTURE_HYPOTHESIS_FALSIFIED` and closes the research line for `composite_breakout_confirmation_vol_gated_donchian_v1` as `CLOSED_REJECTED` / `REJECTED_CLOSED`.
- Updates the canonical progress registry, admissibility contract disposition constants, and a dedicated closeout governance record with immutable evidence crosslinks (architecture binding `5eb28206`, economic evaluation `ec084242`, failure decomposition bundle MANIFEST_VERIFY_RC=0).
- Enforces `NO_NEW_CANDIDATE_HOLD`: no retry, tuning, holdout, promotion, shadow, paper, testnet, or runtime authority.

## Evidence

- Failure decomposition: `analysis/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_economic_validity_failure_decomposition_and_research_disposition_read_only_v0_20260702T211530Z`
- Offline evaluation: `implementation/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_offline_economic_validity_evaluation_v0_20260702T185926Z`
- Closeout bundle: `analysis/bounded_composite_breakout_confirmation_vol_gated_donchian_v1_architecture_rejection_ratification_and_research_line_closeout_v0_20260702T192029Z`

## Safety boundaries

NO_RUNTIME, NO_SCHEDULER, NO_ADAPTER_SUBMISSION, NO_ORDERS, NO_RETRY, NO_HOLDOUT, NO_NEW_ECONOMIC_EVALUATION, NO_PARAMETER_OPTIMIZATION, NO_THRESHOLD_RELAXATION, NO_DATASET_CHANGE, NO_PERIOD_CHANGE, NO_PRIMARY_WORKTREE_MUTATION.

## Test plan

- [x] `python -m pytest tests/ops/test_composite_breakout_confirmation_vol_gated_donchian_v1_architecture_rejection_and_research_line_closeout_contract_v0.py`
- [x] `python -m pytest tests/ops/test_step29m_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_admissibility_contract_v1.py`
- [x] `python -m pytest tests/ops/test_step29m_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_registry_contract_v1.py`
- [x] `ruff format --check` / `ruff check` on changed Python files
- [x] `git diff --check`


Made with [Cursor](https://cursor.com)