### PR TITLE
feat(execution): STEP29Q canonical order intent

### DIFF
--- a/src/governance/canonical_order_intent_v1.py
+++ b/src/governance/canonical_order_intent_v1.py
@@ -22,7 +22,7 @@ from src.governance.capital_risk_sizing_v1 import (
     CapitalRiskSizingDecisionV1,
     CapitalRiskSizingInputV1,
     CapitalRiskSizingOutcome,
-    SelectedSide,
+    QuantityProvenanceV1,
 )
 
 CONTRACT_NAME = "canonical_order_intent_v1"
@@ -196,7 +196,9 @@ class CanonicalOrderIntentV1:
     instrument_metadata_ref: str
     execution_eligible: bool = False
     adapter_compatible: bool = False
+    permission_required: bool = True
     submission_authorized: bool = False
+    submission_effect: str = "NONE"
     runtime_effect: str = RUNTIME_EFFECT_NONE
     authority_effect: str = AUTHORITY_EFFECT_NONE
     network_effect: str = NETWORK_EFFECT_NONE
@@ -297,55 +299,90 @@ def _digest_ref(payload: Mapping[str, Any]) -> str:
 
 
 def compute_capital_envelope_ref(decision: CapitalRiskSizingDecisionV1) -> str:
-    envelope = decision.capital_envelope
+    provenance = decision.quantity_provenance
+    if provenance is not None and provenance.capital_envelope_ref:
+        return provenance.capital_envelope_ref
+    envelope = decision.scope_capital_envelope
     return _digest_ref(
         {
-            "scope_capital_limit": str(envelope.scope_capital_limit),
-            "account_equity": str(envelope.account_equity),
+            "instrument_id": envelope.instrument_id,
+            "decision_id": envelope.decision_id,
             "total_capital_limit": str(envelope.total_capital_limit),
-            "within_envelope": envelope.within_envelope,
+            "available_capital": str(envelope.available_capital),
+            "remaining_capital": str(envelope.remaining_capital),
+            "per_order_cap": str(envelope.per_order_cap),
+            "status": envelope.status.value,
+            "input_digest": envelope.input_digest,
         }
     )
 
 
 def compute_pre_sizing_risk_ref(decision: CapitalRiskSizingDecisionV1) -> str:
+    provenance = decision.quantity_provenance
+    if provenance is not None and provenance.pre_sizing_risk_ref:
+        return provenance.pre_sizing_risk_ref
     pre = decision.pre_sizing_risk
     return _digest_ref(
         {
-            "outcome": pre.outcome.value,
-            "effective_trade_risk_budget": str(pre.effective_trade_risk_budget),
-            "effective_scope_capital_limit": str(pre.effective_scope_capital_limit),
-            "effective_total_capital_limit": str(pre.effective_total_capital_limit),
+            "decision_id": pre.decision_id,
+            "side": pre.side,
+            "status": pre.status.value,
+            "candidate_quantity_upper_bound": str(pre.candidate_quantity_upper_bound),
+            "input_digest": pre.input_digest,
         }
     )
 
 
 def compute_sizing_result_ref(decision: CapitalRiskSizingDecisionV1) -> str:
     provenance = decision.quantity_provenance
-    sizing = decision.canonical_sizing
-    if provenance is None or sizing is None:
+    if provenance is not None and provenance.sizing_ref:
+        return provenance.sizing_ref
+    sizing = decision.canonical_position_sizing
+    if sizing is None:
         return ""
     return _digest_ref(
         {
-            "final_quantity": str(provenance.final_quantity),
-            "binding_cap": provenance.binding_cap,
-            "output_digest": provenance.output_digest,
-            "candidate_quantity": str(sizing.candidate_quantity),
-            "binding_cap_kind": sizing.binding_cap.value,
+            "decision_id": sizing.decision_id,
+            "instrument_id": sizing.instrument_id,
+            "rounded_quantity": str(sizing.rounded_quantity),
+            "quantity_status": sizing.quantity_status.value,
+            "policy_digest": sizing.policy_digest,
+            "input_digest": sizing.input_digest,
         }
     )
 
 
 def compute_post_sizing_risk_ref(decision: CapitalRiskSizingDecisionV1) -> str:
+    provenance = decision.quantity_provenance
+    if provenance is not None and provenance.post_sizing_risk_ref:
+        return provenance.post_sizing_risk_ref
     post = decision.post_sizing_risk
     if post is None:
         return ""
     return _digest_ref(
         {
-            "outcome": post.outcome.value,
-            "projected_stop_loss": str(post.projected_stop_loss),
-            "projected_notional": str(post.projected_notional),
-            "projected_exposure": str(post.projected_exposure),
+            "final_allowed_quantity": str(post.final_allowed_quantity),
+            "status": post.status.value,
+            "resulting_notional": str(post.resulting_notional),
+            "input_digest": post.input_digest,
+        }
+    )
+
+
+def compute_quantity_provenance_ref(provenance: QuantityProvenanceV1) -> str:
+    return _digest_ref(
+        {
+            "decision_id": provenance.decision_id,
+            "final_quantity": str(provenance.final_quantity),
+            "capital_envelope_ref": provenance.capital_envelope_ref,
+            "pre_sizing_risk_ref": provenance.pre_sizing_risk_ref,
+            "sizing_ref": provenance.sizing_ref,
+            "post_sizing_risk_ref": provenance.post_sizing_risk_ref,
+            "instrument_metadata_ref": provenance.instrument_metadata_ref,
+            "policy_version": provenance.policy_version,
+            "config_digest": provenance.config_digest,
+            "implementation_digest": provenance.implementation_digest,
+            "final_quantity_status": provenance.final_quantity_status.value,
         }
     )
 
@@ -482,7 +519,7 @@ def build_canonical_order_intent_v1(
         quantity = provenance.final_quantity
         if quantity is None or quantity <= 0:
             reasons.append(REASON_INVALID_QUANTITY)
-        if provenance.output_digest == "":
+        if not compute_quantity_provenance_ref(provenance):
             reasons.append(REASON_MISSING_QUANTITY_PROVENANCE)
 
     if not inp.decision_id:
@@ -559,7 +596,7 @@ def build_canonical_order_intent_v1(
         intent_action=intent_action,
         quantity=quantity,
         quantity_unit="CONTRACTS",
-        quantity_provenance=provenance.output_digest,
+        quantity_provenance=compute_quantity_provenance_ref(provenance),
         reduce_only=reduce_only,
         position_effect=position_effect,
         order_type_policy=build_input.order_type_policy,
@@ -717,7 +754,9 @@ def canonical_order_intent_from_dict(payload: Mapping[str, Any]) -> CanonicalOrd
         instrument_metadata_ref=str(payload["instrument_metadata_ref"]),
         execution_eligible=bool(payload.get("execution_eligible", False)),
         adapter_compatible=bool(payload.get("adapter_compatible", False)),
+        permission_required=bool(payload.get("permission_required", True)),
         submission_authorized=bool(payload.get("submission_authorized", False)),
+        submission_effect=str(payload.get("submission_effect", "NONE")),
         runtime_effect=str(payload.get("runtime_effect", RUNTIME_EFFECT_NONE)),
         authority_effect=str(payload.get("authority_effect", AUTHORITY_EFFECT_NONE)),
         network_effect=str(payload.get("network_effect", NETWORK_EFFECT_NONE)),

--- a/tests/governance/test_canonical_order_intent_v1.py
+++ b/tests/governance/test_canonical_order_intent_v1.py
@@ -35,16 +35,21 @@ ORDER_LIMIT_USD = Decimal("25")
 DAILY_LOSS_LIMIT_USD = Decimal("25")
 
 
+SIDE_LONG = "LONG"
+SIDE_SHORT = "SHORT"
+
+
 def _instrument(**overrides: object) -> sizing.InstrumentQuantityConstraintsV1:
     base: dict[str, object] = {
         "instrument_id": "ETH-USD-PERP",
         "market_type": "futures",
         "contract_kind": "LINEAR",
         "contract_multiplier": Decimal("1"),
-        "quantity_step": Decimal("0.01"),
+        "lot_size": Decimal("0.01"),
         "minimum_quantity": Decimal("0.01"),
         "maximum_quantity": Decimal("100"),
         "minimum_notional": Decimal("5"),
+        "tick_size": Decimal("0.01"),
         "instrument_metadata_version": "futures_metadata_v1_test",
     }
     base.update(overrides)
@@ -56,7 +61,7 @@ def _sizing_input(**overrides: object) -> sizing.CapitalRiskSizingInputV1:
     base: dict[str, object] = {
         "decision_id": "decision-001",
         "instrument_id": instrument.instrument_id,
-        "selected_side": sizing.SelectedSide.LONG.value,
+        "selected_side": SIDE_LONG,
         "reference_price": Decimal("2000"),
         "protective_stop_price": Decimal("1900"),
         "stop_distance": None,
@@ -73,8 +78,8 @@ def _sizing_input(**overrides: object) -> sizing.CapitalRiskSizingInputV1:
         "leverage_ceiling": Decimal("5"),
         "reconciliation_status": "RECONCILED",
         "policy_version": "capital_risk_sizing_policy_v1",
-        "config_digest": "cfg_digest_test",
-        "input_digest": "input_digest_test",
+        "config_digest": "b" * 64,
+        "input_digest": "a" * 64,
         "instrument": instrument,
     }
     base.update(overrides)
@@ -91,10 +96,15 @@ def _build_input(
     sizing_overrides: dict[str, object] | None = None,
     **overrides: object,
 ) -> intent_mod.CanonicalOrderIntentBuildInputV1:
-    sizing_overrides = sizing_overrides or {}
+    sizing_overrides = dict(sizing_overrides or {})
+    if intent_action == intent_mod.IntentAction.ENTER_SHORT.value:
+        sizing_overrides.setdefault("selected_side", SIDE_SHORT)
+        sizing_overrides.setdefault("decision_outcome", "enter_short")
+    elif intent_action == intent_mod.IntentAction.ENTER_LONG.value:
+        sizing_overrides.setdefault("decision_outcome", "enter_long")
     sizing_input = _sizing_input(**sizing_overrides)
     sizing_decision = sizing.evaluate_capital_risk_sizing_v1(sizing_input)
-    side = sizing_overrides.get("selected_side", sizing.SelectedSide.LONG.value)
+    side = sizing_overrides.get("selected_side", SIDE_LONG)
     expected_side = (
         intent_mod.IntentSide.LONG.value
         if intent_action == intent_mod.IntentAction.ENTER_LONG.value
@@ -182,7 +192,7 @@ def test_positive_enter_short_semantics() -> None:
     built = _intent(
         intent_action=intent_mod.IntentAction.ENTER_SHORT.value,
         sizing_overrides={
-            "selected_side": sizing.SelectedSide.SHORT.value,
+            "selected_side": SIDE_SHORT,
             "protective_stop_price": Decimal("2100"),
         },
     )
@@ -198,7 +208,7 @@ def test_positive_reduce_semantics() -> None:
         sizing_overrides={
             "current_reconciled_exposure": Decimal("1.0"),
             "current_open_positions_count": 1,
-            "current_open_side": sizing.SelectedSide.LONG.value,
+            "current_open_side": SIDE_LONG,
             "maximum_positions": 2,
         },
         current_reconciled_exposure=Decimal("1.0"),
@@ -214,7 +224,7 @@ def test_positive_exit_semantics() -> None:
         sizing_overrides={
             "current_reconciled_exposure": Decimal("0.5"),
             "current_open_positions_count": 1,
-            "current_open_side": sizing.SelectedSide.LONG.value,
+            "current_open_side": SIDE_LONG,
             "maximum_positions": 2,
         },
         current_reconciled_exposure=Decimal("0.5"),
@@ -230,7 +240,9 @@ def test_positive_quantity_positive_and_sizing_bound() -> None:
     decision = _passing_sizing_decision()
     assert decision.quantity_provenance is not None
     assert built.quantity == decision.quantity_provenance.final_quantity
-    assert built.quantity_provenance == decision.quantity_provenance.output_digest
+    assert built.quantity_provenance == intent_mod.compute_quantity_provenance_ref(
+        decision.quantity_provenance
+    )
 
 
 def test_positive_futures_instrument_accepted() -> None:
@@ -267,6 +279,8 @@ def test_positive_adapter_compatible_false() -> None:
 def test_positive_submission_authorized_false() -> None:
     built = _intent()
     assert built.submission_authorized is False
+    assert built.permission_required is True
+    assert built.submission_effect == "NONE"
 
 
 def test_positive_no_runtime_or_authority_effect() -> None:
@@ -288,9 +302,9 @@ def test_negative_missing_quantity_provenance() -> None:
         outcome=decision.outcome,
         final_quantity=decision.final_quantity,
         selected_side=decision.selected_side,
-        capital_envelope=decision.capital_envelope,
+        scope_capital_envelope=decision.scope_capital_envelope,
         pre_sizing_risk=decision.pre_sizing_risk,
-        canonical_sizing=decision.canonical_sizing,
+        canonical_position_sizing=decision.canonical_position_sizing,
         post_sizing_risk=decision.post_sizing_risk,
         quantity_provenance=None,
         reason_codes=decision.reason_codes,
@@ -326,16 +340,15 @@ def test_negative_quantity_zero_or_negative() -> None:
                 for field in sizing.QuantityProvenanceV1.__dataclass_fields__.values()
             },
             "final_quantity": Decimal("0"),
-            "output_digest": "",
         }
     )
     blocked = sizing.CapitalRiskSizingDecisionV1(
         outcome=decision.outcome,
         final_quantity=Decimal("0"),
         selected_side=decision.selected_side,
-        capital_envelope=decision.capital_envelope,
+        scope_capital_envelope=decision.scope_capital_envelope,
         pre_sizing_risk=decision.pre_sizing_risk,
-        canonical_sizing=decision.canonical_sizing,
+        canonical_position_sizing=decision.canonical_position_sizing,
         post_sizing_risk=decision.post_sizing_risk,
         quantity_provenance=bad_provenance,
         reason_codes=decision.reason_codes,
@@ -379,7 +392,7 @@ def test_negative_reduce_exposure_increase() -> None:
             sizing_overrides={
                 "current_reconciled_exposure": Decimal("0.05"),
                 "current_open_positions_count": 1,
-                "current_open_side": sizing.SelectedSide.LONG.value,
+                "current_open_side": SIDE_LONG,
                 "maximum_positions": 2,
             },
             current_reconciled_exposure=Decimal("0.005"),
@@ -407,7 +420,7 @@ def test_negative_enter_short_wrong_position_effect() -> None:
         _build_input(
             intent_action=intent_mod.IntentAction.ENTER_SHORT.value,
             sizing_overrides={
-                "selected_side": sizing.SelectedSide.SHORT.value,
+                "selected_side": SIDE_SHORT,
                 "protective_stop_price": Decimal("2100"),
             },
         )
@@ -428,13 +441,13 @@ def test_negative_implicit_reversal() -> None:
         _build_input(
             intent_action=intent_mod.IntentAction.ENTER_SHORT.value,
             sizing_overrides={
-                "selected_side": sizing.SelectedSide.SHORT.value,
+                "selected_side": SIDE_SHORT,
                 "protective_stop_price": Decimal("2100"),
                 "current_reconciled_exposure": Decimal("1"),
                 "current_open_positions_count": 1,
-                "current_open_side": sizing.SelectedSide.LONG.value,
+                "current_open_side": SIDE_LONG,
             },
-            current_open_side=sizing.SelectedSide.LONG.value,
+            current_open_side=SIDE_LONG,
             current_reconciled_exposure=Decimal("1"),
         )
     )
@@ -523,13 +536,15 @@ def test_negative_no_action_not_submittable() -> None:
 
 
 def test_negative_sizing_not_pass() -> None:
-    blocked_decision = sizing.evaluate_capital_risk_sizing_v1(
-        _sizing_input(scope_capital_limit=Decimal("0"))
+    blocked_input = _sizing_input(
+        scope_capital_limit=Decimal("0.01"),
+        instrument=_instrument(minimum_quantity=Decimal("1")),
     )
+    blocked_decision = sizing.evaluate_capital_risk_sizing_v1(blocked_input)
     assert blocked_decision.outcome is sizing.CapitalRiskSizingOutcome.BLOCKED
     result = intent_mod.build_canonical_order_intent_v1(
         intent_mod.CanonicalOrderIntentBuildInputV1(
-            sizing_input=_sizing_input(scope_capital_limit=Decimal("0")),
+            sizing_input=blocked_input,
             sizing_decision=blocked_decision,
             intent_id="intent-001",
             trading_epoch="epoch-001",
@@ -650,7 +665,7 @@ def test_transform_02_short_entry_deterministic_success() -> None:
     result = _transform(
         intent_action=intent_mod.IntentAction.ENTER_SHORT.value,
         sizing_overrides={
-            "selected_side": sizing.SelectedSide.SHORT.value,
+            "selected_side": SIDE_SHORT,
             "protective_stop_price": Decimal("2100"),
         },
     )
@@ -667,7 +682,7 @@ def test_transform_03_reduce_only_exit_stays_reduce_only() -> None:
         sizing_overrides={
             "current_reconciled_exposure": Decimal("0.5"),
             "current_open_positions_count": 1,
-            "current_open_side": sizing.SelectedSide.LONG.value,
+            "current_open_side": SIDE_LONG,
             "maximum_positions": 2,
         },
         current_reconciled_exposure=Decimal("0.5"),
@@ -865,16 +880,15 @@ def test_transform_20_output_quantity_never_exceeds_input(quantity: Decimal) -> 
                 for field in sizing.QuantityProvenanceV1.__dataclass_fields__.values()
             },
             "final_quantity": quantity,
-            "output_digest": f"digest-{quantity}",
         }
     )
     blocked = sizing.CapitalRiskSizingDecisionV1(
         outcome=decision.outcome,
         final_quantity=quantity,
         selected_side=decision.selected_side,
-        capital_envelope=decision.capital_envelope,
+        scope_capital_envelope=decision.scope_capital_envelope,
         pre_sizing_risk=decision.pre_sizing_risk,
-        canonical_sizing=decision.canonical_sizing,
+        canonical_position_sizing=decision.canonical_position_sizing,
         post_sizing_risk=decision.post_sizing_risk,
         quantity_provenance=provenance,
         reason_codes=decision.reason_codes,
@@ -909,7 +923,7 @@ def test_transform_21_long_short_symmetry() -> None:
     short_result = _transform(
         intent_action=intent_mod.IntentAction.ENTER_SHORT.value,
         sizing_overrides={
-            "selected_side": sizing.SelectedSide.SHORT.value,
+            "selected_side": SIDE_SHORT,
             "protective_stop_price": Decimal("2100"),
         },
     )


### PR DESCRIPTION
## Summary

- Rebinds `CanonicalOrderIntentV1` to the STEP29P capital/risk/sizing chain after #4763 API changes (scope envelope, position sizing, quantity provenance refs).
- Preserves offline-only STEP29Q safety defaults: `execution_eligible=false`, `adapter_compatible=false`, `permission_required=true`, `authority/runtime/submission_effect=NONE`.
- Updates focused contract/regression tests (STEP29Q, STEP29O firewall, STEP29P sizing) — 190 tests pass locally.

## Scope

Bounded offline STEP29Q canonical order intent implementation. No runtime rewire, adapter submission, orders, credentials, or authority issuance.

## Reuse Decisions

- Canonical owner: `src/governance/canonical_order_intent_v1.py` (existing SSOT, no parallel owner).
- STEP29P `capital_risk_sizing_v1.py`: reused as-is; only STEP29Q binding layer updated.
- STEP29O `intent_compatibility_firewall_v1.py`: reused as-is.

## Canonical Order Intent Contract

Offline chain: Decision Evidence → ScopeCapitalEnvelope → PreSizingRisk → CanonicalPositionSizing → PostSizingRisk → QuantityProvenance → CanonicalOrderIntentV1.

## Quantity Provenance Binding

Quantity binds exclusively via `QuantityProvenanceV1`; new `compute_quantity_provenance_ref()` replaces stale `output_digest` field.

## Action / Position Effect Matrix

ENTER_LONG/ENTER_SHORT → OPEN_OR_INCREASE; REDUCE → REDUCE_ONLY; EXIT → CLOSE_ONLY; NO_ACTION blocked.

## Order Type / Price Semantics

Explicit policy bindings only; unbound fields remain non-executable.

## Compatibility Firewall Binding

CanonicalOrderIntentV1 remains structurally recognized but adapter_compatible=false in STEP29Q.

## Bypass Guards

Direct adapter cast/submission rejected; transformation required for any future adapter path.

## Tests

```
pytest tests/governance/test_canonical_order_intent_v1.py \
  tests/ops/test_runbook_step29q_canonical_order_intent_implementation_contract_v0.py \
  tests/governance/test_intent_compatibility_firewall_v1.py \
  tests/governance/test_step29o_intent_compatibility_firewall_consolidation_contract_v0.py \
  tests/governance/test_capital_risk_sizing_v1.py
```
190 passed.

## CI Selection

PR_BOUNDED_FULL (`category_central_src_requires_full`) — central `src/governance/` owner change.

## Durable Bundle

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/runbook_step29q_canonical_order_intent_offline_v0_20260702T203839Z` (MANIFEST_VERIFY_RC=0)

## Safety Boundaries

FUTURES_ONLY=true, LIVE_AUTHORIZED=false, ORDERS_ALLOWED=false, no runtime/network/credential effects.

## Test plan

- [x] STEP29Q contract tests
- [x] STEP29O firewall regression
- [x] STEP29P sizing regression
- [x] ruff format/check
- [ ] Await CI terminal status


Made with [Cursor](https://cursor.com)