### PR TITLE
Add cross-sectional ranking semantics binding schema and validator v0

### DIFF
--- a/src/research/cross_sectional_ranking_semantics_binding_v0.py
+++ b/src/research/cross_sectional_ranking_semantics_binding_v0.py
@@ -1,0 +1,228 @@
+"""Cross-sectional ranking semantics declarative binding schema (v0).
+
+Pure offline schema materialization for ratified policy classes. Does not compute
+scores, rank instruments, run backtests, or authorize runtime execution.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from enum import Enum
+from typing import Any, Mapping
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_RANKING_SEMANTICS_BINDING_V0=true"
+SCHEMA_VERSION = "cross_sectional_ranking_semantics_binding.v0"
+HYPOTHESIS_ID = "CROSS_SECTIONAL_RELATIVE_STRENGTH_NON_BITCOIN_PERPETUALS_V0"
+
+# Ratified policy class values (immutable for v0 materialization).
+SCORE_FAMILY_POLICY = "volatility_normalized_fixed_lookback_return"
+DIRECTION_POLICY = "symmetric_top1_sign"
+NEGATIVE_TOP1_MEANS = "SHORT_TOP1"
+BOTTOM1_SELECTION_ALLOWED = False
+ZERO_SCORE_TARGET = "FLAT"
+NON_FINITE_SCORE_TARGET = "FLAT"
+WARMUP_INCOMPLETE_TARGET = "FLAT"
+PANEL_INSUFFICIENT_TARGET = "FLAT"
+
+SIGNAL_TIMING_POLICY = "finalized_bar_close_epoch"
+MINIMUM_SIGNAL_LAG_BARS = 1
+SAME_BAR_EXECUTION_ALLOWED = False
+
+REBALANCE_POLICY_CLASS = "fixed_N_bar_cadence"
+
+SWITCH_POLICY = "flat_then_wait_one_epoch_then_enter"
+OPPOSITE_SIDE_REQUIRES_RECONCILED_FLAT = True
+ATOMIC_SIDE_SWITCH_ALLOWED = False
+
+COOLDOWN_POLICY = "no_cooldown"
+MINIMUM_HOLD_POLICY = "until_next_rebalance"
+RISK_AND_SAFETY_EXITS_OVERRIDE_MINIMUM_HOLD = True
+
+PANEL_COMPLETENESS_POLICY = "per_instrument_eligibility_mask"
+MINIMUM_ELIGIBLE_COUNT_REQUIRED = True
+
+MISSING_BAR_POLICY = "exclude_non_selected_instrument_for_epoch"
+SELECTED_INSTRUMENT_MISSING_ACTION = "FORCE_FLAT"
+BAR_CARRY_FORWARD_ALLOWED = False
+
+TIE_BREAK_POLICY = "score_desc_then_instrument_id_asc"
+TIE_BREAK_SCORE_SOURCE = "unrounded_internal_score"
+
+THRESHOLD_POLICY = "sign_boundary_only"
+NUMERIC_STRENGTH_THRESHOLD_INITIAL = False
+
+ORCHESTRATOR_OWNER = "cross_sectional_single_slot_research_orchestrator_v0"
+ORCHESTRATOR_SCOPE = "RESEARCH_ONLY"
+
+NUMERIC_BINDING_KEYS = (
+    "lookback_N",
+    "vol_window_V",
+    "vol_epsilon",
+    "vol_return_method",
+    "rebalance_interval_bars",
+    "signal_lag_bars",
+    "min_eligible_members_for_rank",
+    "switch_entry_delay_epochs",
+    "max_bar_staleness_bars",
+    "min_abs_score_strength",
+)
+
+EXTERNAL_BINDING_KEYS = (
+    "pit_universe_manifest_ref",
+    "instrument_id_canonicalization_version",
+    "panel_ohlcv_dataset_manifest_ref",
+    "admissibility_manifest_ref",
+    "evaluation_period_binding",
+    "fee_model_version",
+    "slippage_model_version",
+    "funding_model_version",
+    "spread_model_version",
+    "execution_model_version",
+)
+
+DIGEST_BINDING_KEYS = (
+    "implementation_digest",
+    "config_digest",
+    "data_digest",
+)
+
+
+class BindingFieldStatus(str, Enum):
+    REQUIRED_UNBOUND = "REQUIRED_UNBOUND"
+    BOUND = "BOUND"
+    INVALID = "INVALID"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+
+
+class AggregateBindingStatus(str, Enum):
+    BOUND = "BOUND"
+    REQUIRED_UNBOUND = "REQUIRED_UNBOUND"
+    INCOMPLETE_FAIL_CLOSED = "INCOMPLETE_FAIL_CLOSED"
+    COMPLETE = "COMPLETE"
+
+
+def _field(
+    status: BindingFieldStatus,
+    *,
+    value: Any = None,
+    ref: str = "",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": status.value}
+    if value is not None:
+        payload["value"] = value
+    if ref:
+        payload["ref"] = ref
+    return payload
+
+
+def materialize_cross_sectional_ranking_semantics_binding_v0() -> dict[str, Any]:
+    """Materialize ratified policy classes with fail-closed unbound numeric/external fields."""
+    numeric_bindings: dict[str, dict[str, Any]] = {
+        key: _field(BindingFieldStatus.REQUIRED_UNBOUND) for key in NUMERIC_BINDING_KEYS
+    }
+    numeric_bindings["min_abs_score_strength"] = _field(BindingFieldStatus.NOT_APPLICABLE)
+
+    external_bindings = {
+        key: _field(BindingFieldStatus.REQUIRED_UNBOUND) for key in EXTERNAL_BINDING_KEYS
+    }
+    digest_bindings = {
+        key: _field(BindingFieldStatus.REQUIRED_UNBOUND) for key in DIGEST_BINDING_KEYS
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "hypothesis_id": HYPOTHESIS_ID,
+        "policy_classes": {
+            "score_family_policy": SCORE_FAMILY_POLICY,
+            "direction_policy": DIRECTION_POLICY,
+            "signal_timing_policy": SIGNAL_TIMING_POLICY,
+            "rebalance_policy_class": REBALANCE_POLICY_CLASS,
+            "switch_policy": SWITCH_POLICY,
+            "cooldown_policy": COOLDOWN_POLICY,
+            "minimum_hold_policy": MINIMUM_HOLD_POLICY,
+            "panel_completeness_policy": PANEL_COMPLETENESS_POLICY,
+            "missing_bar_policy": MISSING_BAR_POLICY,
+            "tie_break_policy": TIE_BREAK_POLICY,
+            "threshold_policy": THRESHOLD_POLICY,
+        },
+        "system_constraints": {
+            "futures_only": True,
+            "bitcoin_direction_allowed": False,
+            "spot_allowed": False,
+            "synthetic_spot_allowed": False,
+        },
+        "direction_semantics": {
+            "selection_mode": "single_top1_by_score_desc",
+            "ascending_rank_for_short_selection_forbidden": True,
+            "bottom1_selection_allowed": BOTTOM1_SELECTION_ALLOWED,
+            "dual_rank_forbidden": True,
+            "negative_top1_means": NEGATIVE_TOP1_MEANS,
+            "positive_top1_means": "LONG_TOP1",
+            "zero_score_target": ZERO_SCORE_TARGET,
+            "non_finite_score_target": NON_FINITE_SCORE_TARGET,
+            "warmup_incomplete_target": WARMUP_INCOMPLETE_TARGET,
+            "panel_insufficient_target": PANEL_INSUFFICIENT_TARGET,
+        },
+        "timing_semantics": {
+            "decision_input": "finalized_bars_only",
+            "score_epoch": "finalized_bar_close",
+            "minimum_signal_lag_bars": MINIMUM_SIGNAL_LAG_BARS,
+            "same_bar_execution": SAME_BAR_EXECUTION_ALLOWED,
+            "finalized_bar_required": True,
+            "pit_universe_at_score_epoch": True,
+            "immutable_score_ledger": True,
+        },
+        "switch_semantics": {
+            "switch_policy": SWITCH_POLICY,
+            "opposite_side_requires_reconciled_flat": OPPOSITE_SIDE_REQUIRES_RECONCILED_FLAT,
+            "flat_then_wait_one_epoch_then_enter": True,
+            "atomic_side_switch": ATOMIC_SIDE_SWITCH_ALLOWED,
+        },
+        "missing_bar_semantics": {
+            "missing_bar_policy": MISSING_BAR_POLICY,
+            "non_selected_missing": "exclude_for_epoch",
+            "selected_missing": SELECTED_INSTRUMENT_MISSING_ACTION.lower(),
+            "carry_forward": BAR_CARRY_FORWARD_ALLOWED,
+        },
+        "panel_semantics": {
+            "eligibility_mode": PANEL_COMPLETENESS_POLICY,
+            "minimum_eligible_member_count_required": MINIMUM_ELIGIBLE_COUNT_REQUIRED,
+            "insufficient_panel_action": "flat",
+        },
+        "minimum_hold_semantics": {
+            "default_hold": MINIMUM_HOLD_POLICY,
+            "risk_exit_override": RISK_AND_SAFETY_EXITS_OVERRIDE_MINIMUM_HOLD,
+            "safety_exit_override": RISK_AND_SAFETY_EXITS_OVERRIDE_MINIMUM_HOLD,
+        },
+        "tie_break_semantics": {
+            "primary_order": "score_desc",
+            "secondary_order": "instrument_id_asc",
+            "score_representation": TIE_BREAK_SCORE_SOURCE,
+            "tie_break_policy": TIE_BREAK_POLICY,
+        },
+        "threshold_semantics": {
+            "threshold_policy": THRESHOLD_POLICY,
+            "numeric_strength_threshold_initial": NUMERIC_STRENGTH_THRESHOLD_INITIAL,
+        },
+        "orchestrator": {
+            "owner": ORCHESTRATOR_OWNER,
+            "scope": ORCHESTRATOR_SCOPE,
+        },
+        "numeric_bindings": numeric_bindings,
+        "external_bindings": external_bindings,
+        "digest_bindings": digest_bindings,
+        "binding_status": {
+            "policy_classes_status": AggregateBindingStatus.BOUND.value,
+            "numeric_bindings_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "universe_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "dataset_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "period_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "cost_model_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "digest_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "overall_binding_status": AggregateBindingStatus.INCOMPLETE_FAIL_CLOSED.value,
+        },
+    }
+
+
+def clone_binding(binding: Mapping[str, Any]) -> dict[str, Any]:
+    return deepcopy(dict(binding))

--- a/src/research/cross_sectional_ranking_semantics_binding_validator_v0.py
+++ b/src/research/cross_sectional_ranking_semantics_binding_validator_v0.py
@@ -1,0 +1,440 @@
+"""Fail-closed validator for cross_sectional_ranking_semantics_binding.v0.
+
+Schema, contract, and binding-status validation only. Does not compute scores,
+rank instruments, generate signals, load datasets, or invoke runtime paths.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+from src.research.cross_sectional_ranking_semantics_binding_v0 import (
+    DIGEST_BINDING_KEYS,
+    DIRECTION_POLICY,
+    EXTERNAL_BINDING_KEYS,
+    HYPOTHESIS_ID,
+    MINIMUM_SIGNAL_LAG_BARS,
+    NUMERIC_BINDING_KEYS,
+    SCHEMA_VERSION,
+    SCORE_FAMILY_POLICY,
+    BindingFieldStatus,
+    materialize_cross_sectional_ranking_semantics_binding_v0,
+)
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_RANKING_SEMANTICS_BINDING_VALIDATOR_V0=true"
+
+REASON_UNKNOWN_POLICY_ENUM = "UNKNOWN_POLICY_ENUM"
+REASON_MISSING_RATIFIED_POLICY_FIELD = "MISSING_RATIFIED_POLICY_FIELD"
+REASON_BOTTOM1_SEMANTICS = "BOTTOM1_SEMANTICS_REJECTED"
+REASON_DUAL_RANK_SEMANTICS = "DUAL_RANK_SEMANTICS_REJECTED"
+REASON_ZERO_SCORE_NOT_FLAT = "ZERO_SCORE_NOT_FLAT"
+REASON_NON_FINITE_SCORE_NOT_FLAT = "NON_FINITE_SCORE_NOT_FLAT"
+REASON_SAME_BAR_EXECUTION = "SAME_BAR_EXECUTION_REJECTED"
+REASON_SIGNAL_LAG_ZERO = "SIGNAL_LAG_ZERO_REJECTED"
+REASON_SIGNAL_LAG_BELOW_MINIMUM = "SIGNAL_LAG_BELOW_MINIMUM_REJECTED"
+REASON_ATOMIC_SIDE_SWITCH = "ATOMIC_SIDE_SWITCH_REJECTED"
+REASON_SIDE_FLIP_WITHOUT_RECONCILED_FLAT = "SIDE_FLIP_WITHOUT_RECONCILED_FLAT_REJECTED"
+REASON_MISSING_WAIT_EPOCH = "MISSING_WAIT_EPOCH_REJECTED"
+REASON_MISSING_BAR_CARRY_FORWARD = "MISSING_BAR_CARRY_FORWARD_REJECTED"
+REASON_SELECTED_MISSING_WITHOUT_FORCE_FLAT = "SELECTED_MISSING_WITHOUT_FORCE_FLAT_REJECTED"
+REASON_INSUFFICIENT_PANEL_WITHOUT_FLAT = "INSUFFICIENT_PANEL_WITHOUT_FLAT_REJECTED"
+REASON_UNSTABLE_TIE_BREAK = "UNSTABLE_TIE_BREAK_REJECTED"
+REASON_ROUNDED_SCORE_TIE_BREAK = "ROUNDED_SCORE_TIE_BREAK_REJECTED"
+REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED = "NUMERIC_STRENGTH_THRESHOLD_ENABLED_REJECTED"
+REASON_UNVERSIONED_UNIVERSE_BINDING = "UNVERSIONED_UNIVERSE_BINDING_REJECTED"
+REASON_MISSING_DATASET_MANIFEST = "MISSING_DATASET_MANIFEST_REJECTED"
+REASON_MISSING_PERIOD_BINDING = "MISSING_PERIOD_BINDING_REJECTED"
+REASON_MISSING_COST_MODEL_BINDING = "MISSING_COST_MODEL_BINDING_REJECTED"
+REASON_MISSING_DIGEST = "MISSING_DIGEST_REJECTED"
+REASON_INCOMPLETE_BINDING_MARKED_COMPLETE = "INCOMPLETE_BINDING_MARKED_COMPLETE_REJECTED"
+REASON_NON_FINITE_NUMERIC = "NON_FINITE_NUMERIC_REJECTED"
+REASON_NON_POSITIVE_WINDOW = "NON_POSITIVE_WINDOW_OR_INTERVAL_REJECTED"
+REASON_CONFLICTING_BINDING_STATUS = "CONFLICTING_BINDING_STATUS_REJECTED"
+REASON_INVALID_SCHEMA_VERSION = "INVALID_SCHEMA_VERSION"
+REASON_UNKNOWN_BINDING_FIELD_STATUS = "UNKNOWN_BINDING_FIELD_STATUS"
+REASON_SWITCH_DELAY_TOO_SHORT = "SWITCH_ENTRY_DELAY_TOO_SHORT_REJECTED"
+REASON_NEGATIVE_TOP1_SEMANTICS_MISMATCH = "NEGATIVE_TOP1_SEMANTICS_MISMATCH"
+
+RATIFIED_POLICY_CLASS_VALUES = {
+    "score_family_policy": {SCORE_FAMILY_POLICY},
+    "direction_policy": {DIRECTION_POLICY},
+    "signal_timing_policy": {"finalized_bar_close_epoch"},
+    "rebalance_policy_class": {"fixed_N_bar_cadence"},
+    "switch_policy": {"flat_then_wait_one_epoch_then_enter"},
+    "cooldown_policy": {"no_cooldown"},
+    "minimum_hold_policy": {"until_next_rebalance"},
+    "panel_completeness_policy": {"per_instrument_eligibility_mask"},
+    "missing_bar_policy": {"exclude_non_selected_instrument_for_epoch"},
+    "tie_break_policy": {"score_desc_then_instrument_id_asc"},
+    "threshold_policy": {"sign_boundary_only"},
+}
+
+POSITIVE_NUMERIC_KEYS = frozenset(
+    {
+        "lookback_N",
+        "vol_window_V",
+        "vol_epsilon",
+        "rebalance_interval_bars",
+        "signal_lag_bars",
+        "min_eligible_members_for_rank",
+        "switch_entry_delay_epochs",
+        "max_bar_staleness_bars",
+    }
+)
+
+
+class ValidationVerdict(str, Enum):
+    ACCEPTED_INCOMPLETE = "ACCEPTED_INCOMPLETE"
+    ACCEPTED_COMPLETE = "ACCEPTED_COMPLETE"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True)
+class CrossSectionalRankingSemanticsBindingValidationResult:
+    verdict: ValidationVerdict
+    valid: bool
+    fail_reasons: tuple[str, ...]
+    binding_status: Mapping[str, Any]
+
+
+def _is_finite_number(value: Any) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    return False
+
+
+def _field_status(field: Mapping[str, Any]) -> str | None:
+    status = field.get("status")
+    return status if isinstance(status, str) else None
+
+
+def _field_value(field: Mapping[str, Any]) -> Any:
+    return field.get("value")
+
+
+def _field_ref(field: Mapping[str, Any]) -> str:
+    ref = field.get("ref", "")
+    return ref if isinstance(ref, str) else ""
+
+
+def _require_mapping(value: Any, path: str, reasons: list[str]) -> Mapping[str, Any] | None:
+    if not isinstance(value, Mapping):
+        reasons.append(f"{REASON_MISSING_RATIFIED_POLICY_FIELD}:{path}")
+        return None
+    return value
+
+
+def _validate_binding_field(
+    field: Any,
+    *,
+    path: str,
+    reasons: list[str],
+    allow_not_applicable: bool = False,
+) -> Mapping[str, Any] | None:
+    mapping = _require_mapping(field, path, reasons)
+    if mapping is None:
+        return None
+    status = _field_status(mapping)
+    allowed = {s.value for s in BindingFieldStatus}
+    if status not in allowed:
+        reasons.append(f"{REASON_UNKNOWN_BINDING_FIELD_STATUS}:{path}")
+        return mapping
+    if status == BindingFieldStatus.NOT_APPLICABLE.value and not allow_not_applicable:
+        reasons.append(f"{REASON_CONFLICTING_BINDING_STATUS}:{path}")
+    return mapping
+
+
+def _validate_bound_numeric(
+    key: str,
+    field: Mapping[str, Any],
+    reasons: list[str],
+) -> None:
+    status = _field_status(field)
+    if status != BindingFieldStatus.BOUND.value:
+        return
+    value = _field_value(field)
+    if key == "vol_return_method":
+        if not isinstance(value, str) or not value.strip():
+            reasons.append(f"{REASON_NON_FINITE_NUMERIC}:{key}")
+        return
+    if key == "min_abs_score_strength":
+        reasons.append(REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED)
+        return
+    if not _is_finite_number(value):
+        reasons.append(f"{REASON_NON_FINITE_NUMERIC}:{key}")
+        return
+    if key in POSITIVE_NUMERIC_KEYS and float(value) <= 0:
+        reasons.append(f"{REASON_NON_POSITIVE_WINDOW}:{key}")
+    if key == "signal_lag_bars" and float(value) < MINIMUM_SIGNAL_LAG_BARS:
+        reasons.append(REASON_SIGNAL_LAG_BELOW_MINIMUM)
+    if key == "switch_entry_delay_epochs" and float(value) < 1:
+        reasons.append(REASON_SWITCH_DELAY_TOO_SHORT)
+
+
+def _validate_bound_external(key: str, field: Mapping[str, Any], reasons: list[str]) -> None:
+    status = _field_status(field)
+    if status != BindingFieldStatus.BOUND.value:
+        return
+    ref = _field_ref(field)
+    value = _field_value(field)
+    token = ref or (value if isinstance(value, str) else "")
+    if not token.strip():
+        if key == "pit_universe_manifest_ref":
+            reasons.append(REASON_UNVERSIONED_UNIVERSE_BINDING)
+        elif key == "panel_ohlcv_dataset_manifest_ref":
+            reasons.append(REASON_MISSING_DATASET_MANIFEST)
+        elif key == "evaluation_period_binding":
+            reasons.append(REASON_MISSING_PERIOD_BINDING)
+        elif key.endswith("_model_version") or key == "execution_model_version":
+            reasons.append(REASON_MISSING_COST_MODEL_BINDING)
+        else:
+            reasons.append(f"{REASON_MISSING_RATIFIED_POLICY_FIELD}:{key}")
+
+
+def _validate_bound_digest(field: Mapping[str, Any], reasons: list[str]) -> None:
+    if _field_status(field) != BindingFieldStatus.BOUND.value:
+        return
+    token = _field_ref(field) or _field_value(field)
+    if not isinstance(token, str) or not token.strip():
+        reasons.append(REASON_MISSING_DIGEST)
+
+
+def _external_group_complete(external: Mapping[str, Any], keys: tuple[str, ...]) -> bool:
+    return all(
+        _field_status(external[k]) == BindingFieldStatus.BOUND.value
+        and (_field_ref(external[k]) or _field_value(external[k]))
+        for k in keys
+        if k in external
+    )
+
+
+def validate_cross_sectional_ranking_semantics_binding_v0(
+    binding: Mapping[str, Any],
+) -> CrossSectionalRankingSemanticsBindingValidationResult:
+    reasons: list[str] = []
+
+    if binding.get("schema_version") != SCHEMA_VERSION:
+        reasons.append(REASON_INVALID_SCHEMA_VERSION)
+    if binding.get("hypothesis_id") != HYPOTHESIS_ID:
+        reasons.append(f"{REASON_MISSING_RATIFIED_POLICY_FIELD}:hypothesis_id")
+
+    policy_classes = _require_mapping(binding.get("policy_classes"), "policy_classes", reasons)
+    if policy_classes is not None:
+        for key, allowed in RATIFIED_POLICY_CLASS_VALUES.items():
+            value = policy_classes.get(key)
+            if value not in allowed:
+                reasons.append(f"{REASON_UNKNOWN_POLICY_ENUM}:{key}={value!r}")
+
+    direction = _require_mapping(binding.get("direction_semantics"), "direction_semantics", reasons)
+    if direction is not None:
+        if direction.get("bottom1_selection_allowed") is not False:
+            reasons.append(REASON_BOTTOM1_SEMANTICS)
+        if direction.get("dual_rank_forbidden") is not True:
+            reasons.append(REASON_DUAL_RANK_SEMANTICS)
+        if direction.get("ascending_rank_for_short_selection_forbidden") is not True:
+            reasons.append(REASON_DUAL_RANK_SEMANTICS)
+        if direction.get("selection_mode") != "single_top1_by_score_desc":
+            reasons.append(REASON_DUAL_RANK_SEMANTICS)
+        if direction.get("zero_score_target") != "FLAT":
+            reasons.append(REASON_ZERO_SCORE_NOT_FLAT)
+        if direction.get("non_finite_score_target") != "FLAT":
+            reasons.append(REASON_NON_FINITE_SCORE_NOT_FLAT)
+        if direction.get("negative_top1_means") != "SHORT_TOP1":
+            reasons.append(REASON_NEGATIVE_TOP1_SEMANTICS_MISMATCH)
+
+    timing = _require_mapping(binding.get("timing_semantics"), "timing_semantics", reasons)
+    if timing is not None:
+        if timing.get("same_bar_execution") is not False:
+            reasons.append(REASON_SAME_BAR_EXECUTION)
+        min_lag = timing.get("minimum_signal_lag_bars")
+        if not isinstance(min_lag, int) or min_lag < MINIMUM_SIGNAL_LAG_BARS:
+            reasons.append(REASON_SIGNAL_LAG_BELOW_MINIMUM)
+
+    switch = _require_mapping(binding.get("switch_semantics"), "switch_semantics", reasons)
+    if switch is not None:
+        if switch.get("atomic_side_switch") is not False:
+            reasons.append(REASON_ATOMIC_SIDE_SWITCH)
+        if switch.get("opposite_side_requires_reconciled_flat") is not True:
+            reasons.append(REASON_SIDE_FLIP_WITHOUT_RECONCILED_FLAT)
+        if switch.get("flat_then_wait_one_epoch_then_enter") is not True:
+            reasons.append(REASON_MISSING_WAIT_EPOCH)
+
+    missing = _require_mapping(
+        binding.get("missing_bar_semantics"), "missing_bar_semantics", reasons
+    )
+    if missing is not None:
+        if missing.get("carry_forward") is not False:
+            reasons.append(REASON_MISSING_BAR_CARRY_FORWARD)
+        selected = missing.get("selected_missing")
+        if selected not in {"force_flat", "FORCE_FLAT"}:
+            reasons.append(REASON_SELECTED_MISSING_WITHOUT_FORCE_FLAT)
+
+    panel = _require_mapping(binding.get("panel_semantics"), "panel_semantics", reasons)
+    if panel is not None:
+        if panel.get("insufficient_panel_action") != "flat":
+            reasons.append(REASON_INSUFFICIENT_PANEL_WITHOUT_FLAT)
+
+    tie_break = _require_mapping(binding.get("tie_break_semantics"), "tie_break_semantics", reasons)
+    if tie_break is not None:
+        if (
+            tie_break.get("primary_order") != "score_desc"
+            or tie_break.get("secondary_order") != "instrument_id_asc"
+        ):
+            reasons.append(REASON_UNSTABLE_TIE_BREAK)
+        if tie_break.get("score_representation") != "unrounded_internal_score":
+            reasons.append(REASON_ROUNDED_SCORE_TIE_BREAK)
+
+    threshold = _require_mapping(binding.get("threshold_semantics"), "threshold_semantics", reasons)
+    if threshold is not None:
+        if threshold.get("threshold_policy") != "sign_boundary_only":
+            reasons.append(REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED)
+        if threshold.get("numeric_strength_threshold_initial") is not False:
+            reasons.append(REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED)
+
+    numeric = _require_mapping(binding.get("numeric_bindings"), "numeric_bindings", reasons)
+    if numeric is not None:
+        for key in NUMERIC_BINDING_KEYS:
+            field = numeric.get(key)
+            validated = _validate_binding_field(
+                field,
+                path=f"numeric_bindings.{key}",
+                reasons=reasons,
+                allow_not_applicable=(key == "min_abs_score_strength"),
+            )
+            if validated is None:
+                continue
+            status = _field_status(validated)
+            if key == "min_abs_score_strength":
+                if status == BindingFieldStatus.BOUND.value:
+                    reasons.append(REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED)
+                elif status not in {
+                    BindingFieldStatus.NOT_APPLICABLE.value,
+                    BindingFieldStatus.REQUIRED_UNBOUND.value,
+                }:
+                    reasons.append(REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED)
+            if status == BindingFieldStatus.BOUND.value and key == "signal_lag_bars":
+                value = _field_value(validated)
+                if value == 0:
+                    reasons.append(REASON_SIGNAL_LAG_ZERO)
+            _validate_bound_numeric(key, validated, reasons)
+
+    external = _require_mapping(binding.get("external_bindings"), "external_bindings", reasons)
+    if external is not None:
+        for key in EXTERNAL_BINDING_KEYS:
+            field = external.get(key)
+            validated = _validate_binding_field(
+                field, path=f"external_bindings.{key}", reasons=reasons
+            )
+            if validated is not None:
+                _validate_bound_external(key, validated, reasons)
+
+    digest = _require_mapping(binding.get("digest_bindings"), "digest_bindings", reasons)
+    if digest is not None:
+        for key in DIGEST_BINDING_KEYS:
+            field = digest.get(key)
+            validated = _validate_binding_field(
+                field, path=f"digest_bindings.{key}", reasons=reasons
+            )
+            if validated is not None:
+                _validate_bound_digest(validated, reasons)
+
+    binding_status = (
+        _require_mapping(binding.get("binding_status"), "binding_status", reasons) or {}
+    )
+
+    numeric_complete = numeric is not None and all(
+        _field_status(numeric[k]) == BindingFieldStatus.BOUND.value
+        for k in NUMERIC_BINDING_KEYS
+        if k != "min_abs_score_strength"
+    )
+    universe_complete = (
+        external is not None
+        and _field_status(external["pit_universe_manifest_ref"]) == BindingFieldStatus.BOUND.value
+        and bool(
+            _field_ref(external["pit_universe_manifest_ref"])
+            or _field_value(external["pit_universe_manifest_ref"])
+        )
+    )
+    dataset_complete = external is not None and _external_group_complete(
+        external, ("panel_ohlcv_dataset_manifest_ref", "admissibility_manifest_ref")
+    )
+    period_complete = (
+        external is not None
+        and _field_status(external["evaluation_period_binding"]) == BindingFieldStatus.BOUND.value
+        and bool(
+            _field_ref(external["evaluation_period_binding"])
+            or _field_value(external["evaluation_period_binding"])
+        )
+    )
+    cost_complete = external is not None and _external_group_complete(
+        external,
+        (
+            "fee_model_version",
+            "slippage_model_version",
+            "funding_model_version",
+            "spread_model_version",
+            "execution_model_version",
+        ),
+    )
+    digest_complete = digest is not None and all(
+        _field_status(digest[k]) == BindingFieldStatus.BOUND.value
+        and bool(_field_ref(digest[k]) or _field_value(digest[k]))
+        for k in DIGEST_BINDING_KEYS
+    )
+
+    overall = binding_status.get("overall_binding_status")
+    if overall == "COMPLETE":
+        if not all(
+            [
+                numeric_complete,
+                universe_complete,
+                dataset_complete,
+                period_complete,
+                cost_complete,
+                digest_complete,
+            ]
+        ):
+            reasons.append(REASON_INCOMPLETE_BINDING_MARKED_COMPLETE)
+
+    if binding_status.get("policy_classes_status") != "BOUND":
+        reasons.append(f"{REASON_CONFLICTING_BINDING_STATUS}:policy_classes_status")
+
+    strength_field = numeric.get("min_abs_score_strength") if numeric else None
+    if strength_field and _field_status(strength_field) == BindingFieldStatus.BOUND.value:
+        reasons.append(REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED)
+
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    if unique_reasons:
+        return CrossSectionalRankingSemanticsBindingValidationResult(
+            verdict=ValidationVerdict.REJECTED,
+            valid=False,
+            fail_reasons=unique_reasons,
+            binding_status=binding_status,
+        )
+
+    if (
+        overall == "COMPLETE"
+        and numeric_complete
+        and universe_complete
+        and dataset_complete
+        and period_complete
+        and cost_complete
+        and digest_complete
+    ):
+        verdict = ValidationVerdict.ACCEPTED_COMPLETE
+    else:
+        verdict = ValidationVerdict.ACCEPTED_INCOMPLETE
+
+    return CrossSectionalRankingSemanticsBindingValidationResult(
+        verdict=verdict,
+        valid=True,
+        fail_reasons=(),
+        binding_status=binding_status,
+    )

--- a/tests/research/test_cross_sectional_ranking_semantics_binding_validator_v0.py
+++ b/tests/research/test_cross_sectional_ranking_semantics_binding_validator_v0.py
@@ -1,0 +1,288 @@
+"""Contract tests for cross_sectional_ranking_semantics_binding.v0 and validator v0."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from src.research.cross_sectional_ranking_semantics_binding_v0 import (
+    SCHEMA_VERSION,
+    materialize_cross_sectional_ranking_semantics_binding_v0,
+)
+from src.research.cross_sectional_ranking_semantics_binding_validator_v0 import (
+    REASON_ATOMIC_SIDE_SWITCH,
+    REASON_BOTTOM1_SEMANTICS,
+    REASON_DUAL_RANK_SEMANTICS,
+    REASON_INCOMPLETE_BINDING_MARKED_COMPLETE,
+    REASON_INSUFFICIENT_PANEL_WITHOUT_FLAT,
+    REASON_MISSING_BAR_CARRY_FORWARD,
+    REASON_MISSING_COST_MODEL_BINDING,
+    REASON_MISSING_DATASET_MANIFEST,
+    REASON_MISSING_DIGEST,
+    REASON_MISSING_PERIOD_BINDING,
+    REASON_MISSING_WAIT_EPOCH,
+    REASON_NON_FINITE_SCORE_NOT_FLAT,
+    REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED,
+    REASON_ROUNDED_SCORE_TIE_BREAK,
+    REASON_SAME_BAR_EXECUTION,
+    REASON_SELECTED_MISSING_WITHOUT_FORCE_FLAT,
+    REASON_SIDE_FLIP_WITHOUT_RECONCILED_FLAT,
+    REASON_SIGNAL_LAG_BELOW_MINIMUM,
+    REASON_SIGNAL_LAG_ZERO,
+    REASON_UNSTABLE_TIE_BREAK,
+    REASON_UNVERSIONED_UNIVERSE_BINDING,
+    REASON_ZERO_SCORE_NOT_FLAT,
+    ValidationVerdict,
+    validate_cross_sectional_ranking_semantics_binding_v0,
+)
+
+
+def _materialized() -> dict:
+    return materialize_cross_sectional_ranking_semantics_binding_v0()
+
+
+def _mutated(**patches: object) -> dict:
+    binding = deepcopy(_materialized())
+    for path, value in patches.items():
+        node = binding
+        parts = path.split(".")
+        for part in parts[:-1]:
+            node = node[part]
+        node[parts[-1]] = value
+    return binding
+
+
+def test_ratified_policy_classes_materialize_successfully() -> None:
+    binding = _materialized()
+    assert binding["schema_version"] == SCHEMA_VERSION
+    assert binding["policy_classes"]["score_family_policy"] == (
+        "volatility_normalized_fixed_lookback_return"
+    )
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is True
+    assert result.verdict == ValidationVerdict.ACCEPTED_INCOMPLETE
+
+
+def test_fully_unbound_numeric_schema_is_valid_but_incomplete() -> None:
+    binding = _materialized()
+    status = binding["binding_status"]
+    assert status["policy_classes_status"] == "BOUND"
+    assert status["numeric_bindings_status"] == "REQUIRED_UNBOUND"
+    assert status["overall_binding_status"] == "INCOMPLETE_FAIL_CLOSED"
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is True
+    assert result.verdict == ValidationVerdict.ACCEPTED_INCOMPLETE
+
+
+def test_sign_boundary_only_is_accepted() -> None:
+    binding = _materialized()
+    assert binding["threshold_semantics"]["threshold_policy"] == "sign_boundary_only"
+    assert binding["numeric_bindings"]["min_abs_score_strength"]["status"] == "NOT_APPLICABLE"
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is True
+
+
+def test_negative_top1_maps_to_short_same_instrument() -> None:
+    binding = _materialized()
+    direction = binding["direction_semantics"]
+    assert direction["negative_top1_means"] == "SHORT_TOP1"
+    assert direction["bottom1_selection_allowed"] is False
+    assert direction["dual_rank_forbidden"] is True
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is True
+
+
+def test_deterministic_tie_break_contract_is_accepted() -> None:
+    binding = _materialized()
+    tie = binding["tie_break_semantics"]
+    assert tie["primary_order"] == "score_desc"
+    assert tie["secondary_order"] == "instrument_id_asc"
+    assert tie["score_representation"] == "unrounded_internal_score"
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is True
+
+
+def test_selected_missing_force_flat_contract_is_accepted() -> None:
+    binding = _materialized()
+    missing = binding["missing_bar_semantics"]
+    assert missing["selected_missing"] == "force_flat"
+    assert missing["carry_forward"] is False
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is True
+
+
+def test_reconciled_flat_wait_epoch_contract_is_accepted() -> None:
+    binding = _materialized()
+    switch = binding["switch_semantics"]
+    assert switch["opposite_side_requires_reconciled_flat"] is True
+    assert switch["flat_then_wait_one_epoch_then_enter"] is True
+    assert switch["atomic_side_switch"] is False
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is True
+
+
+@pytest.mark.parametrize(
+    ("patch_path", "patch_value", "reason"),
+    [
+        ("direction_semantics.bottom1_selection_allowed", True, REASON_BOTTOM1_SEMANTICS),
+        ("direction_semantics.dual_rank_forbidden", False, REASON_DUAL_RANK_SEMANTICS),
+        (
+            "direction_semantics.ascending_rank_for_short_selection_forbidden",
+            False,
+            REASON_DUAL_RANK_SEMANTICS,
+        ),
+        ("direction_semantics.selection_mode", "top_or_bottom", REASON_DUAL_RANK_SEMANTICS),
+        ("direction_semantics.zero_score_target", "HOLD", REASON_ZERO_SCORE_NOT_FLAT),
+        ("direction_semantics.non_finite_score_target", "HOLD", REASON_NON_FINITE_SCORE_NOT_FLAT),
+        ("timing_semantics.same_bar_execution", True, REASON_SAME_BAR_EXECUTION),
+        ("timing_semantics.minimum_signal_lag_bars", 0, REASON_SIGNAL_LAG_BELOW_MINIMUM),
+        ("switch_semantics.atomic_side_switch", True, REASON_ATOMIC_SIDE_SWITCH),
+        (
+            "switch_semantics.opposite_side_requires_reconciled_flat",
+            False,
+            REASON_SIDE_FLIP_WITHOUT_RECONCILED_FLAT,
+        ),
+        ("switch_semantics.flat_then_wait_one_epoch_then_enter", False, REASON_MISSING_WAIT_EPOCH),
+        ("missing_bar_semantics.carry_forward", True, REASON_MISSING_BAR_CARRY_FORWARD),
+        (
+            "missing_bar_semantics.selected_missing",
+            "exclude",
+            REASON_SELECTED_MISSING_WITHOUT_FORCE_FLAT,
+        ),
+        (
+            "panel_semantics.insufficient_panel_action",
+            "hold",
+            REASON_INSUFFICIENT_PANEL_WITHOUT_FLAT,
+        ),
+        ("tie_break_semantics.primary_order", "score_asc", REASON_UNSTABLE_TIE_BREAK),
+        (
+            "tie_break_semantics.score_representation",
+            "rounded_display_score",
+            REASON_ROUNDED_SCORE_TIE_BREAK,
+        ),
+        (
+            "threshold_semantics.threshold_policy",
+            "fixed_policy_threshold",
+            REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED,
+        ),
+        (
+            "threshold_semantics.numeric_strength_threshold_initial",
+            True,
+            REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED,
+        ),
+    ],
+)
+def test_negative_policy_semantics_rejected(
+    patch_path: str, patch_value: object, reason: str
+) -> None:
+    binding = _mutated(**{patch_path: patch_value})
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is False
+    assert reason in result.fail_reasons
+
+
+def test_bottom_1_semantics_rejected() -> None:
+    binding = _mutated(**{"direction_semantics.bottom1_selection_allowed": True})
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert REASON_BOTTOM1_SEMANTICS in result.fail_reasons
+
+
+def test_dual_rank_semantics_rejected() -> None:
+    binding = _mutated(**{"direction_semantics.selection_mode": "dual_rank_top_bottom"})
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert REASON_DUAL_RANK_SEMANTICS in result.fail_reasons
+
+
+def test_signal_lag_zero_rejected() -> None:
+    binding = _mutated(
+        **{
+            "numeric_bindings.signal_lag_bars": {"status": "BOUND", "value": 0},
+        }
+    )
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is False
+    assert REASON_SIGNAL_LAG_ZERO in result.fail_reasons
+
+
+def test_numeric_strength_threshold_enabled_rejected() -> None:
+    binding = _mutated(
+        **{
+            "numeric_bindings.min_abs_score_strength": {"status": "BOUND", "value": 0.1},
+        }
+    )
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is False
+    assert REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED in result.fail_reasons
+
+
+def test_unversioned_universe_binding_rejected() -> None:
+    binding = _mutated(
+        **{
+            "external_bindings.pit_universe_manifest_ref": {"status": "BOUND", "ref": ""},
+        }
+    )
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is False
+    assert REASON_UNVERSIONED_UNIVERSE_BINDING in result.fail_reasons
+
+
+def test_missing_dataset_manifest_rejected() -> None:
+    binding = _mutated(
+        **{
+            "external_bindings.panel_ohlcv_dataset_manifest_ref": {"status": "BOUND", "ref": ""},
+        }
+    )
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is False
+    assert REASON_MISSING_DATASET_MANIFEST in result.fail_reasons
+
+
+def test_missing_period_binding_rejected() -> None:
+    binding = _mutated(
+        **{
+            "external_bindings.evaluation_period_binding": {"status": "BOUND", "ref": ""},
+        }
+    )
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is False
+    assert REASON_MISSING_PERIOD_BINDING in result.fail_reasons
+
+
+def test_missing_cost_model_binding_rejected() -> None:
+    binding = _mutated(
+        **{
+            "external_bindings.fee_model_version": {"status": "BOUND", "ref": ""},
+        }
+    )
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is False
+    assert REASON_MISSING_COST_MODEL_BINDING in result.fail_reasons
+
+
+def test_missing_digest_rejected() -> None:
+    binding = _mutated(
+        **{
+            "digest_bindings.implementation_digest": {"status": "BOUND", "ref": ""},
+        }
+    )
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is False
+    assert REASON_MISSING_DIGEST in result.fail_reasons
+
+
+def test_incomplete_binding_marked_complete_rejected() -> None:
+    binding = _mutated(**{"binding_status.overall_binding_status": "COMPLETE"})
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is False
+    assert REASON_INCOMPLETE_BINDING_MARKED_COMPLETE in result.fail_reasons
+
+
+def test_bound_signal_lag_at_least_one_accepted() -> None:
+    binding = _mutated(
+        **{
+            "numeric_bindings.signal_lag_bars": {"status": "BOUND", "value": 1},
+        }
+    )
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is True


### PR DESCRIPTION
## Summary
- Materialize declarative `cross_sectional_ranking_semantics_binding.v0` schema with ratified policy classes and fail-closed unbound numeric/external fields.
- Add offline-only `cross_sectional_ranking_semantics_binding_validator_v0` with comprehensive contract tests (36 cases).
- No numeric parameter binding, no orchestrator implementation, no runtime/strategy/fleet mutations.

## Binding status (initial)
- `POLICY_CLASSES_STATUS=BOUND`
- `NUMERIC_BINDINGS_STATUS=REQUIRED_UNBOUND`
- `OVERALL_BINDING_STATUS=INCOMPLETE_FAIL_CLOSED`

## Test plan
- [x] `pytest tests/research/test_cross_sectional_ranking_semantics_binding_validator_v0.py`
- [x] `ruff format --check` / `ruff check` on changed Python files
- [ ] CI PR_BOUNDED_FULL (selector: central_src)


Made with [Cursor](https://cursor.com)