### PR TITLE
feat(research): materialize cross-sectional ranking semantics versioned binding v0

### DIFF
--- a/config/research/cross_sectional_relative_strength_non_bitcoin_perpetuals_v0_ranking_semantics_binding_v0.json
+++ b/config/research/cross_sectional_relative_strength_non_bitcoin_perpetuals_v0_ranking_semantics_binding_v0.json
@@ -1,0 +1,210 @@
+{
+  "artifact_kind": "cross_sectional_ranking_semantics_versioned_binding",
+  "artifact_version": "v0",
+  "binding": {
+    "binding_status": {
+      "cost_model_binding_status": "REQUIRED_UNBOUND",
+      "dataset_binding_status": "REQUIRED_UNBOUND",
+      "digest_binding_status": "REQUIRED_UNBOUND",
+      "numeric_bindings_status": "BOUND",
+      "overall_binding_status": "INCOMPLETE_FAIL_CLOSED",
+      "period_binding_status": "REQUIRED_UNBOUND",
+      "policy_classes_status": "BOUND",
+      "universe_binding_status": "REQUIRED_UNBOUND"
+    },
+    "digest_bindings": {
+      "config_digest": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "data_digest": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "implementation_digest": {
+        "status": "REQUIRED_UNBOUND"
+      }
+    },
+    "direction_semantics": {
+      "ascending_rank_for_short_selection_forbidden": true,
+      "bottom1_selection_allowed": false,
+      "dual_rank_forbidden": true,
+      "negative_top1_means": "SHORT_TOP1",
+      "non_finite_score_target": "FLAT",
+      "panel_insufficient_target": "FLAT",
+      "positive_top1_means": "LONG_TOP1",
+      "selection_mode": "single_top1_by_score_desc",
+      "warmup_incomplete_target": "FLAT",
+      "zero_score_target": "FLAT"
+    },
+    "external_bindings": {
+      "admissibility_manifest_ref": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "evaluation_period_binding": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "execution_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "fee_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "funding_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "instrument_id_canonicalization_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "panel_ohlcv_dataset_manifest_ref": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "pit_universe_manifest_ref": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "slippage_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "spread_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      }
+    },
+    "hypothesis_id": "CROSS_SECTIONAL_RELATIVE_STRENGTH_NON_BITCOIN_PERPETUALS_V0",
+    "minimum_hold_semantics": {
+      "default_hold": "until_next_rebalance",
+      "risk_exit_override": true,
+      "safety_exit_override": true
+    },
+    "missing_bar_semantics": {
+      "carry_forward": false,
+      "missing_bar_policy": "exclude_non_selected_instrument_for_epoch",
+      "non_selected_missing": "exclude_for_epoch",
+      "selected_missing": "force_flat"
+    },
+    "numeric_bindings": {
+      "lookback_N": {
+        "status": "BOUND",
+        "value": 20
+      },
+      "max_bar_staleness_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "min_abs_score_strength": {
+        "status": "NOT_APPLICABLE"
+      },
+      "min_eligible_members_for_rank": {
+        "status": "BOUND",
+        "value": 5
+      },
+      "rebalance_interval_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "signal_lag_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "switch_entry_delay_epochs": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "vol_epsilon": {
+        "status": "BOUND",
+        "value": 1e-08
+      },
+      "vol_return_method": {
+        "status": "BOUND",
+        "value": "log_return"
+      },
+      "vol_window_V": {
+        "status": "BOUND",
+        "value": 20
+      }
+    },
+    "orchestrator": {
+      "owner": "cross_sectional_single_slot_research_orchestrator_v0",
+      "scope": "RESEARCH_ONLY"
+    },
+    "panel_semantics": {
+      "eligibility_mode": "per_instrument_eligibility_mask",
+      "insufficient_panel_action": "flat",
+      "minimum_eligible_member_count_required": true
+    },
+    "policy_classes": {
+      "cooldown_policy": "no_cooldown",
+      "direction_policy": "symmetric_top1_sign",
+      "minimum_hold_policy": "until_next_rebalance",
+      "missing_bar_policy": "exclude_non_selected_instrument_for_epoch",
+      "panel_completeness_policy": "per_instrument_eligibility_mask",
+      "rebalance_policy_class": "fixed_N_bar_cadence",
+      "score_family_policy": "volatility_normalized_fixed_lookback_return",
+      "signal_timing_policy": "finalized_bar_close_epoch",
+      "switch_policy": "flat_then_wait_one_epoch_then_enter",
+      "threshold_policy": "sign_boundary_only",
+      "tie_break_policy": "score_desc_then_instrument_id_asc"
+    },
+    "schema_version": "cross_sectional_ranking_semantics_binding.v0",
+    "switch_semantics": {
+      "atomic_side_switch": false,
+      "flat_then_wait_one_epoch_then_enter": true,
+      "opposite_side_requires_reconciled_flat": true,
+      "switch_policy": "flat_then_wait_one_epoch_then_enter"
+    },
+    "system_constraints": {
+      "bitcoin_direction_allowed": false,
+      "futures_only": true,
+      "spot_allowed": false,
+      "synthetic_spot_allowed": false
+    },
+    "threshold_semantics": {
+      "numeric_strength_threshold_initial": false,
+      "threshold_policy": "sign_boundary_only"
+    },
+    "tie_break_semantics": {
+      "primary_order": "score_desc",
+      "score_representation": "unrounded_internal_score",
+      "secondary_order": "instrument_id_asc",
+      "tie_break_policy": "score_desc_then_instrument_id_asc"
+    },
+    "timing_semantics": {
+      "decision_input": "finalized_bars_only",
+      "finalized_bar_required": true,
+      "immutable_score_ledger": true,
+      "minimum_signal_lag_bars": 1,
+      "pit_universe_at_score_epoch": true,
+      "same_bar_execution": false,
+      "score_epoch": "finalized_bar_close"
+    }
+  },
+  "derived_fields": {
+    "minimum_history_bars": 21,
+    "turnover_cadence_bars": 1
+  },
+  "envelope_digests": {
+    "config_digest": {
+      "status": "REQUIRED_UNBOUND_DIGEST"
+    },
+    "manifest_digest": {
+      "status": "REQUIRED_UNBOUND_DIGEST"
+    },
+    "operator_decision_digest": {
+      "status": "BOUND",
+      "value": "82e4a28813d72f6b9f54db15cb5729763648bc148f6eac3b445be6dab6cc107a"
+    },
+    "semantic_digest": {
+      "status": "REQUIRED_UNBOUND_DIGEST"
+    }
+  },
+  "hypothesis_id": "CROSS_SECTIONAL_RELATIVE_STRENGTH_NON_BITCOIN_PERPETUALS_V0",
+  "materialization_scope": "NUMERIC_ENUM_RATIFICATION_ONLY",
+  "non_authorizing": true,
+  "ratification_payload_version": "cross_sectional_ranking_semantics_operator_ratification_payload.v0",
+  "research_binding_only": true,
+  "schema_version": "cross_sectional_ranking_semantics_binding.v0",
+  "scope_classification": {
+    "candidate_binding_effect": "NONE",
+    "economic_policy_effect": "NONE",
+    "fleet_binding_effect": "NONE",
+    "runtime_effect": "NONE",
+    "universe_binding_effect": "DEFERRED_UPSTREAM"
+  }
+}

--- a/src/research/cross_sectional_ranking_semantics_binding_v0.py
+++ b/src/research/cross_sectional_ranking_semantics_binding_v0.py
@@ -6,6 +6,8 @@ scores, rank instruments, run backtests, or authorize runtime execution.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from copy import deepcopy
 from enum import Enum
 from typing import Any, Mapping
@@ -85,6 +87,87 @@ DIGEST_BINDING_KEYS = (
     "config_digest",
     "data_digest",
 )
+
+RATIFICATION_PAYLOAD_VERSION = "cross_sectional_ranking_semantics_operator_ratification_payload.v0"
+VERSIONED_BINDING_ARTIFACT_KIND = "cross_sectional_ranking_semantics_versioned_binding"
+VERSIONED_BINDING_ARTIFACT_VERSION = "v0"
+VERSIONED_BINDING_CONFIG_REL_PATH = (
+    "config/research/"
+    "cross_sectional_relative_strength_non_bitcoin_perpetuals_v0_"
+    "ranking_semantics_binding_v0.json"
+)
+
+RATIFIED_OPERATOR_BINDING_VALUES: dict[str, int | float | str] = {
+    "lookback_N": 20,
+    "vol_window_V": 20,
+    "vol_epsilon": 1e-8,
+    "rebalance_interval_bars": 1,
+    "signal_lag_bars": 1,
+    "min_eligible_members_for_rank": 5,
+    "switch_entry_delay_epochs": 1,
+    "max_bar_staleness_bars": 1,
+    "vol_return_method": "log_return",
+}
+
+RATIFIED_OPERATOR_RATIONALES: dict[str, str] = {
+    "lookback_N": (
+        "Ein festes Fenster von 20 finalisierten Trading-Epochen bindet eine "
+        "ausreichend begrenzte mittlere Momentum-Historie, ohne einen impliziten "
+        "oder adaptiven Default zuzulassen. Die Wahl ist eine neue "
+        "Operator-Policy-Bindung und keine automatische Übernahme aus momentum.py."
+    ),
+    "vol_window_V": (
+        "Die Volatilitätsschätzung verwendet ein gleich langes, explizit "
+        "versioniertes Fenster wie die Ranking-Historie. Dadurch bleiben "
+        "Zeitbasis und Normalisierung nachvollziehbar. Die Wahl ist keine "
+        "automatische Übernahme aus vol_regime_filter.py."
+    ),
+    "vol_epsilon": (
+        "Ein strikt positiver numerischer Floor von 1e-8 verhindert Division "
+        "durch null beziehungsweise numerisch instabile Skalierung, ohne normale "
+        "Volatilitätswerte materiell zu übersteuern."
+    ),
+    "rebalance_interval_bars": (
+        "Das Ranking wird in jeder finalisierten Trading-Epoche neu berechnet. "
+        "Order-, Runtime- oder Execution-Wirkung entsteht daraus nicht. Die Wahl "
+        "ist eine explizite Operator-Bindung und keine automatische Übernahme aus "
+        "backtest/engine.py."
+    ),
+    "signal_lag_bars": (
+        "Ein vollständiger Bar Lag verhindert Look-ahead und bindet Signale "
+        "ausschließlich an Informationen, die vor der bewerteten Trading-Epoche "
+        "final verfügbar waren."
+    ),
+    "min_eligible_members_for_rank": (
+        "Ein Cross-Sectional Ranking ist nur bei mindestens fünf gleichzeitig "
+        "zulässigen Futures-Mitgliedern gültig. Kleinere Querschnitte werden "
+        "fail-closed blockiert, statt ein instabiles oder faktisch paarweises "
+        "Ranking zu erzeugen."
+    ),
+    "switch_entry_delay_epochs": (
+        "Nach einem Ranking- beziehungsweise Selektionswechsel ist mindestens "
+        "eine vollständig finalisierte Trading-Epoche abzuwarten. Dies reduziert "
+        "unmittelbares Umschalten und erzeugt keine Reversal-, Order- oder "
+        "Runtime-Authority."
+    ),
+    "max_bar_staleness_bars": (
+        "Es wird höchstens eine Bar zeitlicher Rückstand toleriert. Ältere "
+        "Mitglieder werden als nicht zulässig behandelt und dürfen weder Ranking "
+        "noch Selektion speisen."
+    ),
+    "vol_return_method": (
+        "Die Volatilitätsnormalisierung verwendet logarithmische "
+        "Einperiodenrenditen aus finalisierten Bars. Die Methode ist explizit "
+        "gebunden, dimensionslos und symmetrisch für positive und negative "
+        "Preisbewegungen. Sie ist keine Übernahme eines adjacent Default-Werts."
+    ),
+}
+
+ATTESTED_OPERATOR_DECISION_DIGEST = (
+    "82e4a28813d72f6b9f54db15cb5729763648bc148f6eac3b445be6dab6cc107a"
+)
+
+ENVELOPE_DIGEST_STATUS_REQUIRED_UNBOUND = "REQUIRED_UNBOUND_DIGEST"
 
 
 class BindingFieldStatus(str, Enum):
@@ -222,6 +305,133 @@ def materialize_cross_sectional_ranking_semantics_binding_v0() -> dict[str, Any]
             "overall_binding_status": AggregateBindingStatus.INCOMPLETE_FAIL_CLOSED.value,
         },
     }
+
+
+def build_operator_decision_digest_input_v0(
+    operator_values: Mapping[str, int | float | str] | None = None,
+    operator_rationales: Mapping[str, str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Build canonical operator-decision digest payload (sorted slot keys)."""
+    values = dict(operator_values or RATIFIED_OPERATOR_BINDING_VALUES)
+    rationales = dict(operator_rationales or RATIFIED_OPERATOR_RATIONALES)
+    missing = sorted(set(values) - set(rationales))
+    if missing:
+        raise ValueError(f"missing operator rationales for slots: {missing}")
+    return {key: {"value": values[key], "rationale": rationales[key]} for key in sorted(values)}
+
+
+def compute_operator_decision_digest_v0(
+    operator_values: Mapping[str, int | float | str] | None = None,
+    operator_rationales: Mapping[str, str] | None = None,
+) -> str:
+    """SHA-256 digest of ratified operator slot values and rationales."""
+    digest_input = build_operator_decision_digest_input_v0(
+        operator_values=operator_values,
+        operator_rationales=operator_rationales,
+    )
+    canonical = json.dumps(
+        digest_input,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_minimum_history_bars_v0(
+    lookback_n: int,
+    vol_window_v: int,
+    signal_lag_bars: int,
+) -> int:
+    return max(lookback_n, vol_window_v) + signal_lag_bars
+
+
+def apply_ratified_operator_bindings_v0(binding: dict[str, Any]) -> dict[str, Any]:
+    """Apply ratified operator numeric/enum bindings to a materialized binding."""
+    result = deepcopy(binding)
+    numeric = result["numeric_bindings"]
+    for key, value in RATIFIED_OPERATOR_BINDING_VALUES.items():
+        numeric[key] = _field(BindingFieldStatus.BOUND, value=value)
+    numeric["min_abs_score_strength"] = _field(BindingFieldStatus.NOT_APPLICABLE)
+    status = result["binding_status"]
+    status["numeric_bindings_status"] = AggregateBindingStatus.BOUND.value
+    status["overall_binding_status"] = AggregateBindingStatus.INCOMPLETE_FAIL_CLOSED.value
+    return result
+
+
+def build_envelope_digests_v0(
+    operator_decision_digest: str,
+) -> dict[str, dict[str, Any]]:
+    return {
+        "operator_decision_digest": {
+            "status": BindingFieldStatus.BOUND.value,
+            "value": operator_decision_digest,
+        },
+        "semantic_digest": {"status": ENVELOPE_DIGEST_STATUS_REQUIRED_UNBOUND},
+        "config_digest": {"status": ENVELOPE_DIGEST_STATUS_REQUIRED_UNBOUND},
+        "manifest_digest": {"status": ENVELOPE_DIGEST_STATUS_REQUIRED_UNBOUND},
+    }
+
+
+def compute_derived_binding_fields_v0(
+    operator_values: Mapping[str, int | float | str] | None = None,
+) -> dict[str, int]:
+    values = dict(operator_values or RATIFIED_OPERATOR_BINDING_VALUES)
+    lookback_n = int(values["lookback_N"])
+    vol_window_v = int(values["vol_window_V"])
+    signal_lag_bars = int(values["signal_lag_bars"])
+    return {
+        "minimum_history_bars": compute_minimum_history_bars_v0(
+            lookback_n,
+            vol_window_v,
+            signal_lag_bars,
+        ),
+        "turnover_cadence_bars": int(values["rebalance_interval_bars"]),
+    }
+
+
+def materialize_versioned_cross_sectional_ranking_semantics_binding_v0() -> dict[str, Any]:
+    """Materialize versioned research binding envelope with ratified operator slots."""
+    binding = apply_ratified_operator_bindings_v0(
+        materialize_cross_sectional_ranking_semantics_binding_v0()
+    )
+    operator_digest = compute_operator_decision_digest_v0()
+    if operator_digest != ATTESTED_OPERATOR_DECISION_DIGEST:
+        raise ValueError(
+            "operator decision digest mismatch: "
+            f"computed={operator_digest} attested={ATTESTED_OPERATOR_DECISION_DIGEST}"
+        )
+    return {
+        "artifact_kind": VERSIONED_BINDING_ARTIFACT_KIND,
+        "artifact_version": VERSIONED_BINDING_ARTIFACT_VERSION,
+        "schema_version": SCHEMA_VERSION,
+        "ratification_payload_version": RATIFICATION_PAYLOAD_VERSION,
+        "hypothesis_id": HYPOTHESIS_ID,
+        "materialization_scope": "NUMERIC_ENUM_RATIFICATION_ONLY",
+        "non_authorizing": True,
+        "research_binding_only": True,
+        "scope_classification": {
+            "candidate_binding_effect": "NONE",
+            "fleet_binding_effect": "NONE",
+            "universe_binding_effect": "DEFERRED_UPSTREAM",
+            "economic_policy_effect": "NONE",
+            "runtime_effect": "NONE",
+        },
+        "envelope_digests": build_envelope_digests_v0(operator_digest),
+        "derived_fields": compute_derived_binding_fields_v0(),
+        "binding": binding,
+    }
+
+
+def serialize_versioned_binding_artifact_json_v0(
+    envelope: Mapping[str, Any],
+) -> str:
+    """Serialize versioned binding artifact with stable key order and indentation."""
+    return json.dumps(dict(envelope), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def compute_config_digest_v0(canonical_json_bytes: bytes) -> str:
+    return hashlib.sha256(canonical_json_bytes).hexdigest()
 
 
 def clone_binding(binding: Mapping[str, Any]) -> dict[str, Any]:

--- a/tests/research/test_cross_sectional_ranking_semantics_binding_materialization_v0.py
+++ b/tests/research/test_cross_sectional_ranking_semantics_binding_materialization_v0.py
@@ -1,0 +1,192 @@
+"""Contract tests for versioned cross-sectional ranking semantics binding materialization v0."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from src.research.cross_sectional_ranking_semantics_binding_v0 import (
+    ATTESTED_OPERATOR_DECISION_DIGEST,
+    ENVELOPE_DIGEST_STATUS_REQUIRED_UNBOUND,
+    EXTERNAL_BINDING_KEYS,
+    DIGEST_BINDING_KEYS,
+    RATIFIED_OPERATOR_BINDING_VALUES,
+    RATIFIED_OPERATOR_RATIONALES,
+    THRESHOLD_POLICY,
+    VERSIONED_BINDING_CONFIG_REL_PATH,
+    build_operator_decision_digest_input_v0,
+    compute_minimum_history_bars_v0,
+    compute_operator_decision_digest_v0,
+    materialize_versioned_cross_sectional_ranking_semantics_binding_v0,
+    serialize_versioned_binding_artifact_json_v0,
+)
+from src.research.cross_sectional_ranking_semantics_binding_validator_v0 import (
+    REASON_INCOMPLETE_BINDING_MARKED_COMPLETE,
+    REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED,
+    ValidationVerdict,
+    validate_cross_sectional_ranking_semantics_binding_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_ARTIFACT_PATH = REPO_ROOT / VERSIONED_BINDING_CONFIG_REL_PATH
+
+
+@pytest.fixture
+def versioned_envelope() -> dict:
+    return materialize_versioned_cross_sectional_ranking_semantics_binding_v0()
+
+
+def test_operator_decision_digest_matches_attestation() -> None:
+    computed = compute_operator_decision_digest_v0()
+    assert computed == ATTESTED_OPERATOR_DECISION_DIGEST
+
+
+def test_operator_decision_digest_changes_when_value_changes() -> None:
+    base = compute_operator_decision_digest_v0()
+    mutated_values = dict(RATIFIED_OPERATOR_BINDING_VALUES)
+    mutated_values["lookback_N"] = 21
+    mutated = compute_operator_decision_digest_v0(operator_values=mutated_values)
+    assert mutated != base
+
+
+def test_operator_decision_digest_changes_when_rationale_changes() -> None:
+    base = compute_operator_decision_digest_v0()
+    mutated_rationales = dict(RATIFIED_OPERATOR_RATIONALES)
+    mutated_rationales["lookback_N"] = mutated_rationales["lookback_N"] + " x"
+    mutated = compute_operator_decision_digest_v0(operator_rationales=mutated_rationales)
+    assert mutated != base
+
+
+def test_ratified_values_materialized_with_exact_types(versioned_envelope: dict) -> None:
+    numeric = versioned_envelope["binding"]["numeric_bindings"]
+    assert numeric["lookback_N"] == {"status": "BOUND", "value": 20}
+    assert numeric["vol_window_V"] == {"status": "BOUND", "value": 20}
+    assert numeric["rebalance_interval_bars"] == {"status": "BOUND", "value": 1}
+    assert numeric["signal_lag_bars"] == {"status": "BOUND", "value": 1}
+    assert numeric["min_eligible_members_for_rank"] == {"status": "BOUND", "value": 5}
+    assert numeric["switch_entry_delay_epochs"] == {"status": "BOUND", "value": 1}
+    assert numeric["max_bar_staleness_bars"] == {"status": "BOUND", "value": 1}
+    assert numeric["vol_return_method"] == {"status": "BOUND", "value": "log_return"}
+    assert isinstance(numeric["lookback_N"]["value"], int)
+    assert isinstance(numeric["vol_window_V"]["value"], int)
+    assert isinstance(numeric["vol_epsilon"]["value"], float)
+    assert numeric["vol_epsilon"]["value"] == 1e-8
+
+
+def test_min_abs_score_strength_remains_not_applicable(versioned_envelope: dict) -> None:
+    field = versioned_envelope["binding"]["numeric_bindings"]["min_abs_score_strength"]
+    assert field == {"status": "NOT_APPLICABLE"}
+    assert "value" not in field
+    assert versioned_envelope["binding"]["threshold_semantics"]["threshold_policy"] == (
+        THRESHOLD_POLICY
+    )
+
+
+def test_minimum_history_bars_derived_as_21(versioned_envelope: dict) -> None:
+    assert versioned_envelope["derived_fields"]["minimum_history_bars"] == 21
+    assert compute_minimum_history_bars_v0(20, 20, 1) == 21
+
+
+def test_external_bindings_remain_required_unbound(versioned_envelope: dict) -> None:
+    external = versioned_envelope["binding"]["external_bindings"]
+    for key in EXTERNAL_BINDING_KEYS:
+        assert external[key]["status"] == "REQUIRED_UNBOUND"
+
+
+def test_schema_digest_bindings_remain_required_unbound(versioned_envelope: dict) -> None:
+    digest = versioned_envelope["binding"]["digest_bindings"]
+    for key in DIGEST_BINDING_KEYS:
+        assert digest[key]["status"] == "REQUIRED_UNBOUND"
+
+
+def test_envelope_digests_bound_and_unbound(versioned_envelope: dict) -> None:
+    envelope_digests = versioned_envelope["envelope_digests"]
+    assert envelope_digests["operator_decision_digest"] == {
+        "status": "BOUND",
+        "value": ATTESTED_OPERATOR_DECISION_DIGEST,
+    }
+    for key in ("semantic_digest", "config_digest", "manifest_digest"):
+        assert envelope_digests[key]["status"] == ENVELOPE_DIGEST_STATUS_REQUIRED_UNBOUND
+
+
+def test_validator_accepts_incomplete(versioned_envelope: dict) -> None:
+    result = validate_cross_sectional_ranking_semantics_binding_v0(versioned_envelope["binding"])
+    assert result.valid is True
+    assert result.verdict == ValidationVerdict.ACCEPTED_INCOMPLETE
+    assert result.fail_reasons == ()
+
+
+def test_complete_rejected_when_externals_unbound(versioned_envelope: dict) -> None:
+    binding = deepcopy(versioned_envelope["binding"])
+    binding["binding_status"]["overall_binding_status"] = "COMPLETE"
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is False
+    assert REASON_INCOMPLETE_BINDING_MARKED_COMPLETE in result.fail_reasons
+
+
+def test_missing_rationale_rejected_by_digest_helper() -> None:
+    rationales = dict(RATIFIED_OPERATOR_RATIONALES)
+    rationales.pop("lookback_N")
+    with pytest.raises(ValueError, match="missing operator rationales"):
+        build_operator_decision_digest_input_v0(operator_rationales=rationales)
+
+
+def test_wrong_operator_value_rejected_by_digest_mismatch() -> None:
+    mutated_values = dict(RATIFIED_OPERATOR_BINDING_VALUES)
+    mutated_values["lookback_N"] = 21
+    digest = compute_operator_decision_digest_v0(operator_values=mutated_values)
+    assert digest != ATTESTED_OPERATOR_DECISION_DIGEST
+
+
+def test_min_abs_score_strength_bound_rejected(versioned_envelope: dict) -> None:
+    binding = deepcopy(versioned_envelope["binding"])
+    binding["numeric_bindings"]["min_abs_score_strength"] = {
+        "status": "BOUND",
+        "value": 0.1,
+    }
+    result = validate_cross_sectional_ranking_semantics_binding_v0(binding)
+    assert result.valid is False
+    assert REASON_NUMERIC_STRENGTH_THRESHOLD_ENABLED in result.fail_reasons
+
+
+def test_futures_only_and_bitcoin_prohibition(versioned_envelope: dict) -> None:
+    constraints = versioned_envelope["binding"]["system_constraints"]
+    assert constraints == {
+        "futures_only": True,
+        "bitcoin_direction_allowed": False,
+        "spot_allowed": False,
+        "synthetic_spot_allowed": False,
+    }
+
+
+def test_no_fleet_candidate_dataset_or_economic_bindings(versioned_envelope: dict) -> None:
+    scope = versioned_envelope["scope_classification"]
+    assert scope["candidate_binding_effect"] == "NONE"
+    assert scope["fleet_binding_effect"] == "NONE"
+    assert scope["economic_policy_effect"] == "NONE"
+    assert scope["runtime_effect"] == "NONE"
+    binding = versioned_envelope["binding"]
+    assert "strategy_id" not in binding
+    assert "fleet_rank" not in binding
+
+
+def test_deterministic_serialization(versioned_envelope: dict) -> None:
+    first = serialize_versioned_binding_artifact_json_v0(versioned_envelope)
+    second = serialize_versioned_binding_artifact_json_v0(
+        materialize_versioned_cross_sectional_ranking_semantics_binding_v0()
+    )
+    assert first == second
+
+
+def test_config_artifact_matches_materializer(versioned_envelope: dict) -> None:
+    assert CONFIG_ARTIFACT_PATH.is_file()
+    on_disk = json.loads(CONFIG_ARTIFACT_PATH.read_text(encoding="utf-8"))
+    assert on_disk == versioned_envelope
+
+
+def test_digest_input_sorted_keys() -> None:
+    payload = build_operator_decision_digest_input_v0()
+    assert list(payload.keys()) == sorted(RATIFIED_OPERATOR_BINDING_VALUES.keys())


### PR DESCRIPTION
## Summary
- Extend the canonical cross-sectional ranking semantics binding schema owner with ratification applier, operator-decision digest helper, and versioned envelope materializer.
- Add deterministic JSON artifact `config/research/cross_sectional_relative_strength_non_bitcoin_perpetuals_v0_ranking_semantics_binding_v0.json` binding all nine ratified operator slots while leaving external and digest bindings REQUIRED_UNBOUND.
- Add contract tests verifying ACCEPTED_INCOMPLETE validator verdict, digest attestation, N/A semantics, futures-only constraints, and reproducible serialization.

## Test plan
- [x] `pytest tests/research/test_cross_sectional_ranking_semantics_binding_materialization_v0.py tests/research/test_cross_sectional_ranking_semantics_binding_validator_v0.py`
- [x] PR-bounded FULL selector path (775 tests, 44s local)
- [x] `ruff format --check` / `ruff check` on changed Python files
- [ ] GitHub CI FULL matrix confirmation


Made with [Cursor](https://cursor.com)