### PR TITLE
feat(research): add PIT futures universe manifest generator v1

### DIFF
--- a/src/research/pit_futures_universe_manifest_generator_v1.py
+++ b/src/research/pit_futures_universe_manifest_generator_v1.py
@@ -1,0 +1,748 @@
+"""Generic offline generator for point-in-time futures universe manifest v1.
+
+Research-only, non-authorizing. Side-effect-free core: no I/O, no network, no clock.
+Consumes explicit lifecycle records; does not fetch historical registry data.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from src.research.instrument_id_canonicalization_v1 import (
+    INSTRUMENT_ID_CANONICALIZATION_VERSION,
+    InstrumentIdCanonicalizationInputV1,
+    canonicalize_instrument_id_v1,
+)
+from src.research.pit_futures_universe_manifest_v1 import (
+    MARKET_TYPE,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    SCORE_EPOCH_SEMANTICS,
+    ContractType,
+    DataAvailabilityStatus,
+    EligibilityStatus,
+    MembershipStatus,
+    PointInTimeFuturesUniverseEpochV1,
+    PointInTimeFuturesUniverseExclusionV1,
+    PointInTimeFuturesUniverseManifestV1,
+    PointInTimeFuturesUniverseMemberV1,
+    attach_computed_digests,
+    compute_sha256_digest,
+    default_manifest_policy_constants,
+    format_pit_universe_manifest_reference_v1,
+    is_valid_digest,
+    is_valid_rfc3339_utc,
+)
+from src.research.pit_futures_universe_manifest_validator_v1 import (
+    ValidationVerdict,
+    validate_pit_futures_universe_manifest_v1,
+)
+
+PACKAGE_MARKER = "PIT_FUTURES_UNIVERSE_MANIFEST_GENERATOR_V1=true"
+GENERATOR_VERSION = "pit_futures_universe_manifest_generator.v1"
+INPUT_CONTRACT_VERSION = "pit_futures_universe_manifest_generator_input.v1"
+GENERATOR_MODULE_NAME = "pit_futures_universe_manifest_generator_v1"
+
+_PERPETUAL_TYPES = frozenset(
+    {ContractType.LINEAR_PERPETUAL.value, ContractType.INVERSE_PERPETUAL.value}
+)
+_DATED_TYPES = frozenset(
+    {ContractType.LINEAR_DATED_FUTURE.value, ContractType.INVERSE_DATED_FUTURE.value}
+)
+_ABSOLUTE_PATH_PATTERN = re.compile(r"(^/|^\\\\|^[A-Za-z]:[/\\\\])")
+_ARTIFACT_ID_PATTERN = re.compile(r"^[a-z0-9_\-]{1,128}$")
+_VENUE_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+class GeneratorErrorCode(str, Enum):
+    INVALID_INPUT_CONTRACT = "INVALID_INPUT_CONTRACT"
+    UNKNOWN_VENUE = "UNKNOWN_VENUE"
+    NON_FUTURES_INSTRUMENT = "NON_FUTURES_INSTRUMENT"
+    BITCOIN_INSTRUMENT_BLOCKED = "BITCOIN_INSTRUMENT_BLOCKED"
+    SPOT_INSTRUMENT_BLOCKED = "SPOT_INSTRUMENT_BLOCKED"
+    SYNTHETIC_SPOT_BLOCKED = "SYNTHETIC_SPOT_BLOCKED"
+    INVALID_CANONICAL_INSTRUMENT_ID = "INVALID_CANONICAL_INSTRUMENT_ID"
+    MISSING_LISTING_TIME = "MISSING_LISTING_TIME"
+    MISSING_EXPIRY_OR_PERPETUAL_CLASSIFICATION = "MISSING_EXPIRY_OR_PERPETUAL_CLASSIFICATION"
+    INVALID_LIFECYCLE_INTERVAL = "INVALID_LIFECYCLE_INTERVAL"
+    AMBIGUOUS_LIFECYCLE_STATE = "AMBIGUOUS_LIFECYCLE_STATE"
+    DUPLICATE_CANONICAL_INSTRUMENT_ID = "DUPLICATE_CANONICAL_INSTRUMENT_ID"
+    CONFLICTING_SOURCE_RECORDS = "CONFLICTING_SOURCE_RECORDS"
+    SOURCE_DIGEST_MISMATCH = "SOURCE_DIGEST_MISMATCH"
+    EMPTY_EPOCH = "EMPTY_EPOCH"
+    INVALID_EPOCH_ORDER = "INVALID_EPOCH_ORDER"
+    OUTPUT_VALIDATION_FAILED = "OUTPUT_VALIDATION_FAILED"
+
+
+@dataclass(frozen=True)
+class RawInstrumentRecordV1:
+    source_ref: str
+    record_digest: str
+    venue_id: str
+    market_type: str
+    contract_type: str
+    base_asset: str
+    quote_asset: str
+    settlement_asset: str
+    venue_symbol: str
+    native_instrument_id: str | None
+    contract_expiry: str | None
+    listing_time: str | None
+    delisting_time: str | None
+    eligible_from: str | None
+    eligible_until: str | None
+    expiry_time: str | None
+    history_bars_available: int
+    required_history_bars: int
+    data_availability_status: str
+
+
+@dataclass(frozen=True)
+class GeneratorEpochInputV1:
+    score_epoch: int
+    finalized_bar_close: str
+    raw_instrument_records: tuple[RawInstrumentRecordV1, ...]
+
+
+@dataclass(frozen=True)
+class PitFuturesUniverseManifestGeneratorInputV1:
+    input_contract_version: str
+    artifact_id: str
+    venue_id: str
+    universe_id: str
+    hypothesis_id: str
+    universe_policy_id: str
+    universe_policy_version: str
+    inclusion_policy_version: str
+    exclusion_policy_version: str
+    generator_version: str
+    generated_at: str
+    bar_interval: str
+    minimum_history_bars: int
+    minimum_required_member_count: int
+    venue_scope: tuple[str, ...]
+    source_snapshot_refs: tuple[str, ...]
+    source_digests: tuple[str, ...]
+    period_binding_ref: str
+    config_digest: str
+    implementation_digest: str
+    epochs: tuple[GeneratorEpochInputV1, ...]
+
+
+@dataclass(frozen=True)
+class PitFuturesUniverseManifestGeneratorResultV1:
+    success: bool
+    manifest: PointInTimeFuturesUniverseManifestV1 | None
+    manifest_reference: str | None
+    error_codes: tuple[str, ...]
+    validator_reason_codes: tuple[str, ...] = ()
+
+
+def _add(errors: list[str], code: GeneratorErrorCode) -> None:
+    value = code.value
+    if value not in errors:
+        errors.append(value)
+
+
+def _parse_utc_instant(value: str) -> tuple[int, int] | None:
+    if not is_valid_rfc3339_utc(value):
+        return None
+    date_part, time_part = value.split("T", 1)
+    year, month, day = (int(part) for part in date_part.split("-"))
+    hour = int(time_part[0:2])
+    minute = int(time_part[3:5])
+    second = int(time_part[6:8])
+    return (year * 10_000 + month * 100 + day, hour * 10_000 + minute * 100 + second)
+
+
+def _validate_source_ref(value: str, errors: list[str]) -> bool:
+    if not value.strip():
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+        return False
+    if _ABSOLUTE_PATH_PATTERN.search(value):
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+        return False
+    return True
+
+
+def _compute_config_digest_payload(
+    inp: PitFuturesUniverseManifestGeneratorInputV1,
+) -> dict[str, Any]:
+    return {
+        "artifact_id": inp.artifact_id.strip(),
+        "bar_interval": inp.bar_interval.strip(),
+        "exclusion_policy_version": inp.exclusion_policy_version.strip(),
+        "hypothesis_id": inp.hypothesis_id.strip(),
+        "inclusion_policy_version": inp.inclusion_policy_version.strip(),
+        "minimum_history_bars": inp.minimum_history_bars,
+        "minimum_required_member_count": inp.minimum_required_member_count,
+        "period_binding_ref": inp.period_binding_ref.strip(),
+        "universe_id": inp.universe_id.strip(),
+        "universe_policy_id": inp.universe_policy_id.strip(),
+        "universe_policy_version": inp.universe_policy_version.strip(),
+        "venue_id": inp.venue_id.strip().lower(),
+        "venue_scope": sorted({item.strip().lower() for item in inp.venue_scope if item.strip()}),
+    }
+
+
+def _compute_implementation_digest_payload() -> dict[str, str]:
+    return {
+        "generator_version": GENERATOR_VERSION,
+        "module": GENERATOR_MODULE_NAME,
+    }
+
+
+def _compute_source_data_digest_payload(
+    inp: PitFuturesUniverseManifestGeneratorInputV1,
+) -> dict[str, Any]:
+    return {
+        "source_digests": list(inp.source_digests),
+        "source_snapshot_refs": list(inp.source_snapshot_refs),
+    }
+
+
+def _compute_epoch_input_digest(
+    *,
+    score_epoch: int,
+    source_snapshot_refs: tuple[str, ...],
+    record_digests: tuple[str, ...],
+) -> str:
+    return compute_sha256_digest(
+        {
+            "record_digests": list(record_digests),
+            "score_epoch": score_epoch,
+            "source_snapshot_refs": list(source_snapshot_refs),
+        }
+    )
+
+
+def _record_semantic_key(record: RawInstrumentRecordV1) -> tuple[Any, ...]:
+    return (
+        record.source_ref.strip(),
+        record.venue_id.strip().lower(),
+        record.market_type.strip().lower(),
+        record.contract_type.strip().lower(),
+        record.base_asset.strip().upper(),
+        record.quote_asset.strip().upper(),
+        record.settlement_asset.strip().upper(),
+        record.venue_symbol.strip(),
+        record.native_instrument_id,
+        record.contract_expiry,
+        record.listing_time,
+        record.delisting_time,
+        record.eligible_from,
+        record.eligible_until,
+        record.expiry_time,
+        record.history_bars_available,
+        record.required_history_bars,
+        record.data_availability_status.strip().upper(),
+    )
+
+
+def _classify_market_input_errors(record: RawInstrumentRecordV1, errors: list[str]) -> bool:
+    market_type = record.market_type.strip().lower()
+    if market_type == "spot":
+        _add(errors, GeneratorErrorCode.SPOT_INSTRUMENT_BLOCKED)
+        return True
+    if market_type in {"synthetic_spot", "synthetic-spot"}:
+        _add(errors, GeneratorErrorCode.SYNTHETIC_SPOT_BLOCKED)
+        return True
+    if market_type not in {"futures", "futures_panel", "future", "perpetual"}:
+        _add(errors, GeneratorErrorCode.NON_FUTURES_INSTRUMENT)
+        return True
+    contract_type = record.contract_type.strip().lower()
+    if contract_type not in {item.value for item in ContractType}:
+        _add(errors, GeneratorErrorCode.NON_FUTURES_INSTRUMENT)
+        return True
+    return False
+
+
+def _validate_record_contract(
+    record: RawInstrumentRecordV1,
+    *,
+    venue_scope: frozenset[str],
+    minimum_history_bars: int,
+    errors: list[str],
+) -> None:
+    venue_id = record.venue_id.strip().lower()
+    if not venue_id or not _VENUE_ID_PATTERN.fullmatch(venue_id):
+        _add(errors, GeneratorErrorCode.UNKNOWN_VENUE)
+    elif venue_id not in venue_scope:
+        _add(errors, GeneratorErrorCode.UNKNOWN_VENUE)
+
+    if not _validate_source_ref(record.source_ref, errors):
+        return
+    if not is_valid_digest(record.record_digest.strip().lower()):
+        _add(errors, GeneratorErrorCode.SOURCE_DIGEST_MISMATCH)
+
+    if _classify_market_input_errors(record, errors):
+        return
+
+    if record.listing_time is None:
+        _add(errors, GeneratorErrorCode.MISSING_LISTING_TIME)
+    elif not is_valid_rfc3339_utc(record.listing_time):
+        _add(errors, GeneratorErrorCode.INVALID_LIFECYCLE_INTERVAL)
+
+    if record.eligible_from is None:
+        _add(errors, GeneratorErrorCode.INVALID_LIFECYCLE_INTERVAL)
+    elif not is_valid_rfc3339_utc(record.eligible_from):
+        _add(errors, GeneratorErrorCode.INVALID_LIFECYCLE_INTERVAL)
+
+    if record.delisting_time is not None and not is_valid_rfc3339_utc(record.delisting_time):
+        _add(errors, GeneratorErrorCode.INVALID_LIFECYCLE_INTERVAL)
+    if record.eligible_until is not None and not is_valid_rfc3339_utc(record.eligible_until):
+        _add(errors, GeneratorErrorCode.INVALID_LIFECYCLE_INTERVAL)
+    if record.expiry_time is not None and not is_valid_rfc3339_utc(record.expiry_time):
+        _add(errors, GeneratorErrorCode.INVALID_LIFECYCLE_INTERVAL)
+
+    contract_type = record.contract_type.strip().lower()
+    if contract_type in _DATED_TYPES:
+        if record.expiry_time is None and (
+            record.contract_expiry is None or not record.contract_expiry.strip()
+        ):
+            _add(errors, GeneratorErrorCode.MISSING_EXPIRY_OR_PERPETUAL_CLASSIFICATION)
+
+    if record.required_history_bars != minimum_history_bars:
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+
+    if record.history_bars_available < 0:
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+
+    try:
+        DataAvailabilityStatus(record.data_availability_status.strip().upper())
+    except ValueError:
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+
+    if record.listing_time and record.delisting_time:
+        lt = _parse_utc_instant(record.listing_time)
+        dt = _parse_utc_instant(record.delisting_time)
+        if lt is not None and dt is not None and lt >= dt:
+            _add(errors, GeneratorErrorCode.INVALID_LIFECYCLE_INTERVAL)
+
+    if record.eligible_from and record.eligible_until:
+        ef = _parse_utc_instant(record.eligible_from)
+        eu = _parse_utc_instant(record.eligible_until)
+        if ef is not None and eu is not None and ef >= eu:
+            _add(errors, GeneratorErrorCode.INVALID_LIFECYCLE_INTERVAL)
+
+
+def _canonicalize_record(
+    record: RawInstrumentRecordV1,
+    errors: list[str],
+) -> str | None:
+    if _classify_market_input_errors(record, errors):
+        return None
+    result = canonicalize_instrument_id_v1(
+        InstrumentIdCanonicalizationInputV1(
+            venue_id=record.venue_id.strip().lower(),
+            market_type=record.market_type.strip().lower(),
+            contract_type=record.contract_type.strip().lower(),
+            base_asset=record.base_asset.strip(),
+            quote_asset=record.quote_asset.strip(),
+            settlement_asset=record.settlement_asset.strip(),
+            venue_symbol=record.venue_symbol.strip(),
+            native_instrument_id=record.native_instrument_id,
+            contract_expiry=record.contract_expiry,
+        )
+    )
+    if not result.success or result.instrument_id is None:
+        for code in result.error_codes:
+            if code == "BITCOIN_DIRECTION_DISALLOWED":
+                _add(errors, GeneratorErrorCode.BITCOIN_INSTRUMENT_BLOCKED)
+            elif code == "SPOT_MARKET":
+                _add(errors, GeneratorErrorCode.SPOT_INSTRUMENT_BLOCKED)
+            elif code == "SYNTHETIC_SPOT_MARKET":
+                _add(errors, GeneratorErrorCode.SYNTHETIC_SPOT_BLOCKED)
+            elif code == "NON_FUTURES_MARKET":
+                _add(errors, GeneratorErrorCode.NON_FUTURES_INSTRUMENT)
+            else:
+                _add(errors, GeneratorErrorCode.INVALID_CANONICAL_INSTRUMENT_ID)
+        return None
+    return result.instrument_id
+
+
+def _determine_exclusion_reason_codes(
+    record: RawInstrumentRecordV1,
+    *,
+    finalized_bar_close: str,
+    minimum_history_bars: int,
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    close = _parse_utc_instant(finalized_bar_close)
+    if close is None:
+        return ("UNFINALIZED_EPOCH",)
+
+    listing = record.listing_time
+    if listing is None:
+        return ("INVALID_INSTRUMENT_ID",)
+    listing_instant = _parse_utc_instant(listing)
+    if listing_instant is None or listing_instant > close:
+        reasons.append("NOT_LISTED_AT_SCORE_EPOCH")
+
+    if record.delisting_time is not None:
+        delist = _parse_utc_instant(record.delisting_time)
+        if delist is not None and delist <= close:
+            reasons.append("DELISTED_AT_SCORE_EPOCH")
+
+    eligible_from = record.eligible_from
+    if eligible_from is None:
+        reasons.append("INVALID_INSTRUMENT_ID")
+    else:
+        ef = _parse_utc_instant(eligible_from)
+        if ef is None or ef > close:
+            reasons.append("NOT_LISTED_AT_SCORE_EPOCH")
+
+    if record.eligible_until is not None:
+        eu = _parse_utc_instant(record.eligible_until)
+        if eu is not None and eu <= close:
+            reasons.append("DELISTED_AT_SCORE_EPOCH")
+
+    contract_type = record.contract_type.strip().lower()
+    if contract_type in _DATED_TYPES and record.expiry_time is not None:
+        expiry = _parse_utc_instant(record.expiry_time)
+        if expiry is not None and expiry <= close:
+            reasons.append("DELISTED_AT_SCORE_EPOCH")
+
+    if record.history_bars_available < minimum_history_bars:
+        reasons.append("INSUFFICIENT_HISTORY")
+
+    status = record.data_availability_status.strip().upper()
+    if status == DataAvailabilityStatus.UNAVAILABLE.value:
+        reasons.append("DATA_UNAVAILABLE_AT_SCORE_EPOCH")
+    elif status == DataAvailabilityStatus.HALTED.value:
+        reasons.append("TRADING_HALT_AT_SCORE_EPOCH")
+    elif status == DataAvailabilityStatus.STALE.value:
+        reasons.append("STALE_DATA_AT_SCORE_EPOCH")
+
+    return tuple(sorted(set(reasons)))
+
+
+def _is_eligible_at_epoch(record: RawInstrumentRecordV1, *, finalized_bar_close: str) -> bool:
+    return not _determine_exclusion_reason_codes(
+        record,
+        finalized_bar_close=finalized_bar_close,
+        minimum_history_bars=record.required_history_bars,
+    )
+
+
+def _build_member(
+    record: RawInstrumentRecordV1,
+    *,
+    instrument_id: str,
+) -> PointInTimeFuturesUniverseMemberV1:
+    return PointInTimeFuturesUniverseMemberV1(
+        instrument_id=instrument_id,
+        venue_id=record.venue_id.strip().lower(),
+        venue_symbol=record.venue_symbol.strip(),
+        contract_type=record.contract_type.strip().lower(),
+        base_asset=record.base_asset.strip().upper(),
+        quote_asset=record.quote_asset.strip().upper(),
+        settlement_asset=record.settlement_asset.strip().upper(),
+        listing_time=record.listing_time,
+        delisting_time=record.delisting_time,
+        eligible_from=str(record.eligible_from),
+        eligible_until=record.eligible_until,
+        history_bars_available=record.history_bars_available,
+        required_history_bars=record.required_history_bars,
+        data_availability_status=record.data_availability_status.strip().upper(),
+        eligibility_status=EligibilityStatus.ELIGIBLE.value,
+        reason_codes=(),
+        source_ref=record.source_ref.strip(),
+        member_digest="0" * 64,
+    )
+
+
+def _validate_input_contract(inp: PitFuturesUniverseManifestGeneratorInputV1) -> list[str]:
+    errors: list[str] = []
+
+    if inp.input_contract_version != INPUT_CONTRACT_VERSION:
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+    if inp.generator_version != GENERATOR_VERSION:
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+
+    artifact_id = inp.artifact_id.strip()
+    if not artifact_id or not _ARTIFACT_ID_PATTERN.fullmatch(artifact_id):
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+
+    venue_id = inp.venue_id.strip().lower()
+    if not venue_id or not _VENUE_ID_PATTERN.fullmatch(venue_id):
+        _add(errors, GeneratorErrorCode.UNKNOWN_VENUE)
+
+    for field_name, value in (
+        ("universe_id", inp.universe_id),
+        ("hypothesis_id", inp.hypothesis_id),
+        ("universe_policy_id", inp.universe_policy_id),
+        ("universe_policy_version", inp.universe_policy_version),
+        ("inclusion_policy_version", inp.inclusion_policy_version),
+        ("exclusion_policy_version", inp.exclusion_policy_version),
+        ("bar_interval", inp.bar_interval),
+    ):
+        if not isinstance(value, str) or not value.strip():
+            _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+
+    if not is_valid_rfc3339_utc(inp.generated_at):
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+    if inp.minimum_history_bars <= 0:
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+    if inp.minimum_required_member_count < 5:
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+
+    normalized_scope = tuple(
+        sorted({item.strip().lower() for item in inp.venue_scope if item.strip()})
+    )
+    if not normalized_scope:
+        _add(errors, GeneratorErrorCode.UNKNOWN_VENUE)
+    for item in normalized_scope:
+        if not _VENUE_ID_PATTERN.fullmatch(item):
+            _add(errors, GeneratorErrorCode.UNKNOWN_VENUE)
+
+    normalized_refs = tuple(
+        sorted({item.strip() for item in inp.source_snapshot_refs if item.strip()})
+    )
+    normalized_digests = tuple(d.strip().lower() for d in inp.source_digests)
+    if len(normalized_refs) != len(normalized_digests):
+        _add(errors, GeneratorErrorCode.SOURCE_DIGEST_MISMATCH)
+    for digest in normalized_digests:
+        if not is_valid_digest(digest):
+            _add(errors, GeneratorErrorCode.SOURCE_DIGEST_MISMATCH)
+    for ref in normalized_refs:
+        _validate_source_ref(ref, errors)
+
+    if not _validate_source_ref(inp.period_binding_ref, errors):
+        pass
+
+    if not is_valid_digest(inp.config_digest.strip().lower()):
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+    if not is_valid_digest(inp.implementation_digest.strip().lower()):
+        _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+
+    if not errors:
+        expected_config = compute_sha256_digest(_compute_config_digest_payload(inp))
+        if expected_config != inp.config_digest.strip().lower():
+            _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+        expected_impl = compute_sha256_digest(_compute_implementation_digest_payload())
+        if expected_impl != inp.implementation_digest.strip().lower():
+            _add(errors, GeneratorErrorCode.INVALID_INPUT_CONTRACT)
+        if len(normalized_refs) != len(inp.source_snapshot_refs) or len(normalized_digests) != len(
+            inp.source_digests
+        ):
+            _add(errors, GeneratorErrorCode.SOURCE_DIGEST_MISMATCH)
+
+    if not inp.epochs:
+        _add(errors, GeneratorErrorCode.EMPTY_EPOCH)
+        return sorted(errors)
+
+    sorted_epochs = sorted(inp.epochs, key=lambda item: item.score_epoch)
+
+    previous_score: int | None = None
+    previous_close: tuple[int, int] | None = None
+    venue_scope_set = frozenset(normalized_scope) if normalized_scope else frozenset()
+
+    for epoch in sorted_epochs:
+        if previous_score is not None and epoch.score_epoch != previous_score + 1:
+            _add(errors, GeneratorErrorCode.INVALID_EPOCH_ORDER)
+        if previous_score is not None and epoch.score_epoch <= previous_score:
+            _add(errors, GeneratorErrorCode.INVALID_EPOCH_ORDER)
+        previous_score = epoch.score_epoch
+
+        close = _parse_utc_instant(epoch.finalized_bar_close)
+        if close is None:
+            _add(errors, GeneratorErrorCode.INVALID_EPOCH_ORDER)
+        elif previous_close is not None and close <= previous_close:
+            _add(errors, GeneratorErrorCode.INVALID_EPOCH_ORDER)
+        previous_close = close
+
+        if not epoch.raw_instrument_records:
+            _add(errors, GeneratorErrorCode.EMPTY_EPOCH)
+            continue
+
+        canonical_groups: dict[str, list[RawInstrumentRecordV1]] = {}
+        for record in epoch.raw_instrument_records:
+            _validate_record_contract(
+                record,
+                venue_scope=venue_scope_set,
+                minimum_history_bars=inp.minimum_history_bars,
+                errors=errors,
+            )
+            instrument_id = _canonicalize_record(record, errors)
+            if instrument_id is None:
+                continue
+            canonical_groups.setdefault(instrument_id, []).append(record)
+
+        for records in canonical_groups.values():
+            if len(records) <= 1:
+                continue
+            semantic_keys = {_record_semantic_key(item) for item in records}
+            digests = {item.record_digest.strip().lower() for item in records}
+            if len(semantic_keys) > 1:
+                _add(errors, GeneratorErrorCode.CONFLICTING_SOURCE_RECORDS)
+            elif len(digests) > 1:
+                _add(errors, GeneratorErrorCode.CONFLICTING_SOURCE_RECORDS)
+
+    return sorted(errors)
+
+
+def _resolve_epoch_records(
+    records: Sequence[RawInstrumentRecordV1],
+    errors: list[str],
+) -> dict[str, RawInstrumentRecordV1]:
+    resolved: dict[str, RawInstrumentRecordV1] = {}
+    canonical_groups: dict[str, list[RawInstrumentRecordV1]] = {}
+    for record in records:
+        instrument_id = _canonicalize_record(record, errors)
+        if instrument_id is None:
+            continue
+        canonical_groups.setdefault(instrument_id, []).append(record)
+
+    for instrument_id, grouped in canonical_groups.items():
+        semantic_keys = {_record_semantic_key(item) for item in grouped}
+        digests = {item.record_digest.strip().lower() for item in grouped}
+        if len(grouped) > 1 and (len(semantic_keys) > 1 or len(digests) > 1):
+            _add(errors, GeneratorErrorCode.CONFLICTING_SOURCE_RECORDS)
+            continue
+        resolved[instrument_id] = grouped[0]
+    return resolved
+
+
+def generate_pit_futures_universe_manifest_v1(
+    generator_input: PitFuturesUniverseManifestGeneratorInputV1 | Mapping[str, Any],
+) -> PitFuturesUniverseManifestGeneratorResultV1:
+    """Deterministically generate a PIT futures universe manifest from explicit inputs."""
+    if isinstance(generator_input, Mapping):
+        raise TypeError(
+            "Mapping input is not supported; pass PitFuturesUniverseManifestGeneratorInputV1"
+        )
+
+    errors = _validate_input_contract(generator_input)
+    if errors:
+        return PitFuturesUniverseManifestGeneratorResultV1(False, None, None, tuple(errors))
+
+    inp = generator_input
+    normalized_scope = tuple(sorted({item.strip().lower() for item in inp.venue_scope}))
+    normalized_refs = tuple(sorted({item.strip() for item in inp.source_snapshot_refs}))
+    sorted_epochs = tuple(sorted(inp.epochs, key=lambda item: item.score_epoch))
+
+    built_epochs: list[PointInTimeFuturesUniverseEpochV1] = []
+    for epoch in sorted_epochs:
+        epoch_errors: list[str] = []
+        resolved = _resolve_epoch_records(epoch.raw_instrument_records, epoch_errors)
+        if epoch_errors:
+            return PitFuturesUniverseManifestGeneratorResultV1(
+                False, None, None, tuple(sorted(set(epoch_errors)))
+            )
+
+        members: list[PointInTimeFuturesUniverseMemberV1] = []
+        exclusions: list[PointInTimeFuturesUniverseExclusionV1] = []
+
+        for instrument_id in sorted(resolved):
+            record = resolved[instrument_id]
+            if _is_eligible_at_epoch(record, finalized_bar_close=epoch.finalized_bar_close):
+                members.append(_build_member(record, instrument_id=instrument_id))
+            else:
+                reason_codes = _determine_exclusion_reason_codes(
+                    record,
+                    finalized_bar_close=epoch.finalized_bar_close,
+                    minimum_history_bars=inp.minimum_history_bars,
+                )
+                exclusions.append(
+                    PointInTimeFuturesUniverseExclusionV1(
+                        instrument_id=instrument_id,
+                        reason_codes=reason_codes,
+                        source_ref=record.source_ref.strip(),
+                        excluded_at_epoch=epoch.score_epoch,
+                    )
+                )
+
+        eligible_count = len(members)
+        membership_status = (
+            MembershipStatus.FINALIZED.value
+            if eligible_count >= inp.minimum_required_member_count
+            else MembershipStatus.INSUFFICIENT_PANEL.value
+        )
+
+        record_digests = tuple(
+            sorted(resolved[item].record_digest.strip().lower() for item in sorted(resolved))
+        )
+        built_epochs.append(
+            PointInTimeFuturesUniverseEpochV1(
+                score_epoch=epoch.score_epoch,
+                finalized_bar_close=epoch.finalized_bar_close,
+                eligible_member_count=eligible_count,
+                minimum_required_member_count=inp.minimum_required_member_count,
+                membership_status=membership_status,
+                members=tuple(members),
+                excluded_members=tuple(exclusions),
+                epoch_input_digest=_compute_epoch_input_digest(
+                    score_epoch=epoch.score_epoch,
+                    source_snapshot_refs=normalized_refs,
+                    record_digests=record_digests,
+                ),
+                epoch_membership_digest="0" * 64,
+            )
+        )
+
+    policy = default_manifest_policy_constants()
+    manifest = PointInTimeFuturesUniverseManifestV1(
+        schema_name=SCHEMA_NAME,
+        schema_version=SCHEMA_VERSION,
+        manifest_id=inp.artifact_id.strip(),
+        hypothesis_id=inp.hypothesis_id.strip(),
+        universe_policy_id=inp.universe_policy_id.strip(),
+        universe_policy_version=inp.universe_policy_version.strip(),
+        venue_scope=normalized_scope,
+        market_type=MARKET_TYPE,
+        generated_at=inp.generated_at,
+        score_epoch_semantics=SCORE_EPOCH_SEMANTICS,
+        bar_interval=inp.bar_interval.strip(),
+        minimum_history_bars=inp.minimum_history_bars,
+        futures_only=policy["futures_only"],
+        bitcoin_direction_allowed=policy["bitcoin_direction_allowed"],
+        spot_allowed=policy["spot_allowed"],
+        synthetic_spot_allowed=policy["synthetic_spot_allowed"],
+        non_authorizing=policy["non_authorizing"],
+        research_binding_only=policy["research_binding_only"],
+        instrument_id_canonicalization_version=INSTRUMENT_ID_CANONICALIZATION_VERSION,
+        source_dataset_refs=normalized_refs,
+        period_binding_ref=inp.period_binding_ref.strip(),
+        implementation_digest=inp.implementation_digest.strip().lower(),
+        config_digest=inp.config_digest.strip().lower(),
+        source_data_digest=compute_sha256_digest(_compute_source_data_digest_payload(inp)),
+        membership_digest="0" * 64,
+        manifest_digest="0" * 64,
+        epochs=tuple(built_epochs),
+    )
+    manifest = attach_computed_digests(manifest)
+
+    validation = validate_pit_futures_universe_manifest_v1(manifest)
+    if validation.verdict != ValidationVerdict.ACCEPTED:
+        return PitFuturesUniverseManifestGeneratorResultV1(
+            False,
+            None,
+            None,
+            (GeneratorErrorCode.OUTPUT_VALIDATION_FAILED.value,),
+            validation.reason_codes,
+        )
+
+    reference = format_pit_universe_manifest_reference_v1(
+        artifact_id=inp.artifact_id.strip(),
+        manifest_digest=manifest.manifest_digest,
+    )
+    return PitFuturesUniverseManifestGeneratorResultV1(
+        True,
+        manifest,
+        reference,
+        (),
+    )
+
+
+def compute_generator_config_digest(inp: PitFuturesUniverseManifestGeneratorInputV1) -> str:
+    """Expose config digest helper for tests and offline input construction."""
+    return compute_sha256_digest(_compute_config_digest_payload(inp))
+
+
+def compute_generator_implementation_digest() -> str:
+    """Expose implementation digest helper for tests and offline input construction."""
+    return compute_sha256_digest(_compute_implementation_digest_payload())

--- a/tests/research/test_pit_futures_universe_manifest_generator_v1.py
+++ b/tests/research/test_pit_futures_universe_manifest_generator_v1.py
@@ -1,0 +1,661 @@
+"""Contract tests for pit_futures_universe_manifest_generator_v1."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Callable
+
+import pytest
+
+from src.execution.replay_pack.canonical import dumps_canonical
+from src.research.pit_futures_universe_manifest_v1 import (
+    EXCLUSION_REASON_CODES,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    compute_manifest_digest,
+    compute_membership_digest,
+    manifest_from_dict,
+    manifest_to_dict,
+    parse_pit_universe_manifest_reference_v1,
+)
+from src.research.pit_futures_universe_manifest_generator_v1 import (
+    GENERATOR_VERSION,
+    INPUT_CONTRACT_VERSION,
+    GeneratorErrorCode,
+    GeneratorEpochInputV1,
+    PitFuturesUniverseManifestGeneratorInputV1,
+    RawInstrumentRecordV1,
+    compute_generator_config_digest,
+    compute_generator_implementation_digest,
+    generate_pit_futures_universe_manifest_v1,
+)
+from src.research.pit_futures_universe_manifest_validator_v1 import (
+    ValidationVerdict,
+    validate_pit_futures_universe_manifest_v1,
+)
+
+_SOURCE_REF = "synthetic:generator:test:record:v0"
+_DATASET_REF = "synthetic:generator:dataset:v0"
+_PERIOD_REF = "synthetic:generator:period:v0"
+_GENERATED_AT = "2026-07-03T00:00:00Z"
+_BAR_CLOSE_0 = "2024-06-01T01:00:00Z"
+_BAR_CLOSE_1 = "2024-06-01T02:00:00Z"
+_LISTING = "2024-01-01T00:00:00Z"
+_MIN_HISTORY = 21
+
+
+def _record_digest(payload: dict[str, object]) -> str:
+    from src.research.pit_futures_universe_manifest_v1 import compute_sha256_digest
+
+    return compute_sha256_digest(payload)
+
+
+def _base_record(
+    *,
+    venue_id: str = "okx",
+    market_type: str = "futures",
+    contract_type: str = "linear_perpetual",
+    base_asset: str = "ETH",
+    venue_symbol: str = "ETH-USDT-SWAP",
+    native_instrument_id: str | None = None,
+    contract_expiry: str | None = None,
+    listing_time: str = _LISTING,
+    delisting_time: str | None = None,
+    eligible_from: str = _LISTING,
+    eligible_until: str | None = None,
+    expiry_time: str | None = None,
+    history_bars_available: int = 30,
+    source_ref: str = _SOURCE_REF,
+    digest_suffix: str = "eth",
+) -> RawInstrumentRecordV1:
+    payload = {
+        "base_asset": base_asset,
+        "contract_type": contract_type,
+        "digest_suffix": digest_suffix,
+        "source_ref": source_ref,
+        "venue_id": venue_id,
+        "venue_symbol": venue_symbol,
+    }
+    return RawInstrumentRecordV1(
+        source_ref=source_ref,
+        record_digest=_record_digest(payload),
+        venue_id=venue_id,
+        market_type=market_type,
+        contract_type=contract_type,
+        base_asset=base_asset,
+        quote_asset="USDT",
+        settlement_asset="USDT",
+        venue_symbol=venue_symbol,
+        native_instrument_id=native_instrument_id,
+        contract_expiry=contract_expiry,
+        listing_time=listing_time,
+        delisting_time=delisting_time,
+        eligible_from=eligible_from,
+        eligible_until=eligible_until,
+        expiry_time=expiry_time,
+        history_bars_available=history_bars_available,
+        required_history_bars=_MIN_HISTORY,
+        data_availability_status="AVAILABLE",
+    )
+
+
+def _eligible_panel() -> tuple[RawInstrumentRecordV1, ...]:
+    specs = [
+        ("ETH", "ETH-USDT-SWAP", "eth"),
+        ("SOL", "SOL-USDT-SWAP", "sol"),
+        ("AVAX", "AVAX-USDT-SWAP", "avax"),
+        ("LINK", "LINK-USDT-SWAP", "link"),
+        ("DOT", "DOT-USDT-SWAP", "dot"),
+        ("ADA", "ADAUSDT", "ada", "binance_usdm"),
+    ]
+    records = []
+    for item in specs:
+        base = item[0]
+        symbol = item[1]
+        suffix = item[2]
+        venue = item[3] if len(item) > 3 else "okx"
+        records.append(
+            _base_record(
+                venue_id=venue,
+                base_asset=base,
+                venue_symbol=symbol,
+                digest_suffix=suffix,
+                source_ref=f"{_SOURCE_REF}:{suffix}",
+            )
+        )
+    return tuple(records)
+
+
+def _build_input(
+    *,
+    epochs: tuple[GeneratorEpochInputV1, ...] | None = None,
+    artifact_id: str = "synthetic_pit_generator_manifest_v0",
+    generated_at: str = _GENERATED_AT,
+    config_digest: str | None = None,
+    implementation_digest: str | None = None,
+) -> PitFuturesUniverseManifestGeneratorInputV1:
+    if epochs is None:
+        epochs = (
+            GeneratorEpochInputV1(
+                score_epoch=0,
+                finalized_bar_close=_BAR_CLOSE_0,
+                raw_instrument_records=_eligible_panel(),
+            ),
+        )
+    partial = PitFuturesUniverseManifestGeneratorInputV1(
+        input_contract_version=INPUT_CONTRACT_VERSION,
+        artifact_id=artifact_id,
+        venue_id="okx",
+        universe_id="synthetic_universe_v0",
+        hypothesis_id="CROSS_SECTIONAL_RELATIVE_STRENGTH_NON_BITCOIN_PERPETUALS_V0",
+        universe_policy_id="synthetic_cross_sectional_okx_non_btc_perp_v0",
+        universe_policy_version="v0",
+        inclusion_policy_version="v0",
+        exclusion_policy_version="v0",
+        generator_version=GENERATOR_VERSION,
+        generated_at=generated_at,
+        bar_interval="PT1H",
+        minimum_history_bars=_MIN_HISTORY,
+        minimum_required_member_count=5,
+        venue_scope=("binance_usdm", "okx"),
+        source_snapshot_refs=(_DATASET_REF,),
+        source_digests=(_record_digest({"source_dataset_refs": [_DATASET_REF]}),),
+        period_binding_ref=_PERIOD_REF,
+        config_digest="0" * 64,
+        implementation_digest="0" * 64,
+        epochs=epochs,
+    )
+    resolved_config = config_digest or compute_generator_config_digest(partial)
+    resolved_impl = implementation_digest or compute_generator_implementation_digest()
+    return dataclasses.replace(
+        partial,
+        config_digest=resolved_config,
+        implementation_digest=resolved_impl,
+    )
+
+
+def test_happy_path_full_validator_acceptance() -> None:
+    result = generate_pit_futures_universe_manifest_v1(_build_input())
+    assert result.success is True
+    assert result.manifest is not None
+    assert result.error_codes == ()
+    assert result.manifest_reference is not None
+    validation = validate_pit_futures_universe_manifest_v1(result.manifest)
+    assert validation.verdict == ValidationVerdict.ACCEPTED
+
+
+def test_input_contract_is_immutable_dataclass() -> None:
+    inp = _build_input()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        inp.artifact_id = "mutated"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda inp: dataclasses.replace(inp, input_contract_version="wrong"),
+        lambda inp: dataclasses.replace(inp, generator_version="wrong"),
+        lambda inp: dataclasses.replace(inp, artifact_id=""),
+        lambda inp: dataclasses.replace(inp, generated_at="not-a-time"),
+        lambda inp: dataclasses.replace(inp, minimum_history_bars=0),
+        lambda inp: dataclasses.replace(inp, minimum_required_member_count=4),
+        lambda inp: dataclasses.replace(inp, config_digest="bad"),
+    ],
+)
+def test_missing_or_invalid_required_fields_fail_closed(
+    mutator: Callable[
+        [PitFuturesUniverseManifestGeneratorInputV1], PitFuturesUniverseManifestGeneratorInputV1
+    ],
+) -> None:
+    result = generate_pit_futures_universe_manifest_v1(mutator(_build_input()))
+    assert result.success is False
+    assert result.manifest is None
+    assert GeneratorErrorCode.INVALID_INPUT_CONTRACT.value in result.error_codes
+
+
+def test_empty_epochs_fail_closed() -> None:
+    result = generate_pit_futures_universe_manifest_v1(_build_input(epochs=()))
+    assert result.success is False
+    assert GeneratorErrorCode.EMPTY_EPOCH.value in result.error_codes
+
+
+def test_invalid_epoch_sequence_non_contiguous() -> None:
+    epochs = (
+        GeneratorEpochInputV1(0, _BAR_CLOSE_0, _eligible_panel()),
+        GeneratorEpochInputV1(2, _BAR_CLOSE_1, _eligible_panel()),
+    )
+    result = generate_pit_futures_universe_manifest_v1(_build_input(epochs=epochs))
+    assert result.success is False
+    assert GeneratorErrorCode.INVALID_EPOCH_ORDER.value in result.error_codes
+
+
+def test_unsorted_epoch_inputs_are_normalized() -> None:
+    epochs = (
+        GeneratorEpochInputV1(1, _BAR_CLOSE_1, _eligible_panel()),
+        GeneratorEpochInputV1(0, _BAR_CLOSE_0, _eligible_panel()),
+    )
+    ordered = generate_pit_futures_universe_manifest_v1(_build_input(epochs=epochs))
+    shuffled_epochs = (
+        GeneratorEpochInputV1(0, _BAR_CLOSE_0, tuple(reversed(_eligible_panel()))),
+        GeneratorEpochInputV1(1, _BAR_CLOSE_1, tuple(reversed(_eligible_panel()))),
+    )
+    reversed_records = generate_pit_futures_universe_manifest_v1(
+        _build_input(epochs=shuffled_epochs)
+    )
+    assert ordered.success and reversed_records.success
+    assert ordered.manifest is not None and reversed_records.manifest is not None
+    assert ordered.manifest.manifest_digest == reversed_records.manifest.manifest_digest
+
+
+def test_linear_perpetual_canonicalization_reuse() -> None:
+    result = generate_pit_futures_universe_manifest_v1(_build_input())
+    assert result.success
+    assert result.manifest is not None
+    assert any(
+        member.contract_type == "linear_perpetual"
+        for epoch in result.manifest.epochs
+        for member in epoch.members
+    )
+
+
+def test_inverse_perpetual_member() -> None:
+    record = _base_record(
+        contract_type="inverse_perpetual",
+        base_asset="ETH",
+        venue_symbol="ETH-USD-SWAP",
+        digest_suffix="inv",
+    )
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(
+            epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, _eligible_panel() + (record,)),)
+        )
+    )
+    assert result.success
+    assert result.manifest is not None
+    assert any(
+        member.contract_type == "inverse_perpetual"
+        for epoch in result.manifest.epochs
+        for member in epoch.members
+    )
+
+
+def test_dated_future_linear_and_inverse() -> None:
+    linear = _base_record(
+        contract_type="linear_dated_future",
+        contract_expiry="20241227",
+        expiry_time="2024-12-27T08:00:00Z",
+        venue_symbol="ETH-USDT-241227",
+        digest_suffix="dated-linear",
+    )
+    inverse = _base_record(
+        contract_type="inverse_dated_future",
+        contract_expiry="20241227",
+        expiry_time="2024-12-27T08:00:00Z",
+        venue_symbol="ETH-USD-241227",
+        digest_suffix="dated-inverse",
+    )
+    panel = _eligible_panel()[:4] + (linear, inverse)
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, panel),))
+    )
+    assert result.success
+    assert result.manifest is not None
+    types = {member.contract_type for epoch in result.manifest.epochs for member in epoch.members}
+    assert "linear_dated_future" in types
+    assert "inverse_dated_future" in types
+
+
+def test_listing_boundary_inclusive() -> None:
+    record = _base_record(
+        base_asset="ATOM",
+        venue_symbol="ATOM-USDT-SWAP",
+        digest_suffix="atom-listing",
+        listing_time=_BAR_CLOSE_0,
+        eligible_from=_BAR_CLOSE_0,
+    )
+    panel = _eligible_panel() + (record,)
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, panel),))
+    )
+    assert result.success
+
+
+def test_delisting_boundary_exclusive() -> None:
+    record = _base_record(
+        base_asset="LTC",
+        venue_symbol="LTC-USDT-SWAP",
+        digest_suffix="ltc",
+        delisting_time=_BAR_CLOSE_0,
+    )
+    panel = _eligible_panel() + (record,)
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, panel),))
+    )
+    assert result.success
+    assert result.manifest is not None
+    excluded = result.manifest.epochs[0].excluded_members
+    assert any("DELISTED_AT_SCORE_EPOCH" in item.reason_codes for item in excluded)
+
+
+def test_expiry_boundary_exclusive() -> None:
+    record = _base_record(
+        contract_type="linear_dated_future",
+        contract_expiry="20240601",
+        expiry_time=_BAR_CLOSE_0,
+        venue_symbol="ETH-USDT-240601",
+        digest_suffix="expired",
+    )
+    panel = _eligible_panel() + (record,)
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, panel),))
+    )
+    assert result.success
+    assert any(
+        "DELISTED_AT_SCORE_EPOCH" in item.reason_codes
+        for item in result.manifest.epochs[0].excluded_members  # type: ignore[union-attr]
+    )
+
+
+def test_eligible_until_boundary_exclusive() -> None:
+    record = _base_record(
+        base_asset="LTC",
+        venue_symbol="LTC-USDT-SWAP",
+        digest_suffix="ltc2",
+        eligible_until=_BAR_CLOSE_0,
+    )
+    panel = _eligible_panel() + (record,)
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, panel),))
+    )
+    assert result.success
+    assert any(
+        "DELISTED_AT_SCORE_EPOCH" in item.reason_codes
+        for item in result.manifest.epochs[0].excluded_members  # type: ignore[union-attr]
+    )
+
+
+def test_multi_epoch_generation() -> None:
+    epochs = (
+        GeneratorEpochInputV1(0, _BAR_CLOSE_0, _eligible_panel()),
+        GeneratorEpochInputV1(1, _BAR_CLOSE_1, _eligible_panel()),
+    )
+    result = generate_pit_futures_universe_manifest_v1(_build_input(epochs=epochs))
+    assert result.success
+    assert result.manifest is not None
+    assert len(result.manifest.epochs) == 2
+
+
+def test_semantically_identical_input_permutation_invariant() -> None:
+    first = generate_pit_futures_universe_manifest_v1(_build_input())
+    shuffled = generate_pit_futures_universe_manifest_v1(
+        _build_input(
+            epochs=(
+                GeneratorEpochInputV1(
+                    0,
+                    _BAR_CLOSE_0,
+                    tuple(reversed(_eligible_panel())),
+                ),
+            )
+        )
+    )
+    assert first.success and shuffled.success
+    assert first.manifest is not None and shuffled.manifest is not None
+    assert first.manifest.manifest_digest == shuffled.manifest.manifest_digest
+    assert first.manifest_reference == shuffled.manifest_reference
+
+
+def test_conflicting_source_records_fail_closed() -> None:
+    first = _base_record(base_asset="NEAR", venue_symbol="NEAR-USDT-SWAP", digest_suffix="near-a")
+    second = _base_record(
+        base_asset="NEAR",
+        venue_symbol="NEAR-USDT-SWAP",
+        digest_suffix="near-b",
+        history_bars_available=10,
+    )
+    panel = _eligible_panel() + (first, second)
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, panel),))
+    )
+    assert result.success is False
+    assert GeneratorErrorCode.CONFLICTING_SOURCE_RECORDS.value in result.error_codes
+
+
+def test_missing_listing_time_fail_closed() -> None:
+    record = _base_record(listing_time=None)
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(
+            epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, _eligible_panel() + (record,)),)
+        )
+    )
+    assert result.success is False
+    assert GeneratorErrorCode.MISSING_LISTING_TIME.value in result.error_codes
+
+
+def test_missing_expiry_for_dated_future_fail_closed() -> None:
+    record = _base_record(
+        contract_type="linear_dated_future",
+        contract_expiry=None,
+        expiry_time=None,
+        venue_symbol="ETH-USDT-241227",
+        digest_suffix="no-expiry",
+    )
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(
+            epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, _eligible_panel() + (record,)),)
+        )
+    )
+    assert result.success is False
+    assert GeneratorErrorCode.MISSING_EXPIRY_OR_PERPETUAL_CLASSIFICATION.value in result.error_codes
+
+
+@pytest.mark.parametrize(
+    ("market_type", "expected"),
+    [
+        ("spot", GeneratorErrorCode.SPOT_INSTRUMENT_BLOCKED),
+        ("synthetic_spot", GeneratorErrorCode.SYNTHETIC_SPOT_BLOCKED),
+        ("equity", GeneratorErrorCode.NON_FUTURES_INSTRUMENT),
+    ],
+)
+def test_non_futures_and_spot_negative_cases(
+    market_type: str, expected: GeneratorErrorCode
+) -> None:
+    record = _base_record(market_type=market_type, digest_suffix=market_type)
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(
+            epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, _eligible_panel() + (record,)),)
+        )
+    )
+    assert result.success is False
+    assert expected.value in result.error_codes
+
+
+@pytest.mark.parametrize("base_asset", ["BTC", "XBT", "WBTC"])
+def test_bitcoin_direction_blocked(base_asset: str) -> None:
+    record = _base_record(
+        base_asset=base_asset,
+        venue_symbol=f"{base_asset}-USDT-SWAP",
+        digest_suffix=base_asset.lower(),
+    )
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(
+            epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, _eligible_panel() + (record,)),)
+        )
+    )
+    assert result.success is False
+    assert GeneratorErrorCode.BITCOIN_INSTRUMENT_BLOCKED.value in result.error_codes
+
+
+def test_exclusion_codes_remain_exactly_sixteen() -> None:
+    assert len(EXCLUSION_REASON_CODES) == 16
+
+
+def test_generator_error_code_taxonomy_has_exactly_seventeen_codes() -> None:
+    assert len(GeneratorErrorCode) == 17
+
+
+def test_generator_errors_occur_before_output() -> None:
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, ()),))
+    )
+    assert result.success is False
+    assert result.manifest is None
+    assert result.manifest_reference is None
+
+
+def test_validator_round_trip_accepted() -> None:
+    result = generate_pit_futures_universe_manifest_v1(_build_input())
+    assert result.manifest is not None
+    round_trip = manifest_from_dict(manifest_to_dict(result.manifest))
+    validation = validate_pit_futures_universe_manifest_v1(round_trip)
+    assert validation.verdict == ValidationVerdict.ACCEPTED
+
+
+def test_output_validation_failed_when_validator_rejects() -> None:
+    inp = _build_input()
+    broken = dataclasses.replace(inp, minimum_required_member_count=5)
+    result = generate_pit_futures_universe_manifest_v1(broken)
+    assert result.success
+    assert result.manifest is not None
+    tampered = dataclasses.replace(result.manifest, futures_only=False)
+    validation = validate_pit_futures_universe_manifest_v1(tampered)
+    assert validation.verdict == ValidationVerdict.REJECTED
+
+
+def test_no_successful_return_when_post_validation_would_reject(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import src.research.pit_futures_universe_manifest_generator_v1 as generator_module
+
+    def _reject(_manifest: object) -> object:
+        from src.research.pit_futures_universe_manifest_validator_v1 import (
+            PitFuturesUniverseManifestValidationResultV1,
+            ValidationVerdict,
+        )
+
+        return PitFuturesUniverseManifestValidationResultV1(
+            ValidationVerdict.REJECTED,
+            False,
+            ("POLICY_FLAG_VIOLATION",),
+        )
+
+    monkeypatch.setattr(generator_module, "validate_pit_futures_universe_manifest_v1", _reject)
+    result = generate_pit_futures_universe_manifest_v1(_build_input())
+    assert result.success is False
+    assert GeneratorErrorCode.OUTPUT_VALIDATION_FAILED.value in result.error_codes
+    assert result.manifest is None
+
+
+def test_attach_computed_digests_and_reference_reuse() -> None:
+    result = generate_pit_futures_universe_manifest_v1(_build_input())
+    assert result.success
+    assert result.manifest is not None
+    assert result.manifest_reference is not None
+    parsed = parse_pit_universe_manifest_reference_v1(result.manifest_reference)
+    assert parsed.success
+    assert parsed.reference is not None
+    assert parsed.reference.manifest_digest == result.manifest.manifest_digest
+
+
+def test_source_snapshot_refs_and_digests_bound() -> None:
+    result = generate_pit_futures_universe_manifest_v1(_build_input())
+    assert result.success
+    assert result.manifest is not None
+    assert result.manifest.source_dataset_refs == (_DATASET_REF,)
+
+
+def test_config_and_implementation_digest_binding() -> None:
+    inp = _build_input()
+    assert inp.config_digest == compute_generator_config_digest(inp)
+    assert inp.implementation_digest == compute_generator_implementation_digest()
+    wrong = dataclasses.replace(inp, config_digest="f" * 64)
+    result = generate_pit_futures_universe_manifest_v1(wrong)
+    assert result.success is False
+    assert GeneratorErrorCode.INVALID_INPUT_CONTRACT.value in result.error_codes
+
+
+def test_generated_at_is_input_bound_only() -> None:
+    first = generate_pit_futures_universe_manifest_v1(
+        _build_input(generated_at="2026-01-01T00:00:00Z")
+    )
+    second = generate_pit_futures_universe_manifest_v1(
+        _build_input(generated_at="2026-02-01T00:00:00Z")
+    )
+    assert first.success and second.success
+    assert first.manifest is not None and second.manifest is not None
+    assert first.manifest.generated_at != second.manifest.generated_at
+    assert compute_membership_digest(first.manifest) == compute_membership_digest(second.manifest)
+
+
+def test_manifest_schema_constants_unchanged() -> None:
+    result = generate_pit_futures_universe_manifest_v1(_build_input())
+    assert result.manifest is not None
+    assert result.manifest.schema_name == SCHEMA_NAME
+    assert result.manifest.schema_version == SCHEMA_VERSION
+
+
+def test_stable_canonical_serialization() -> None:
+    result = generate_pit_futures_universe_manifest_v1(_build_input())
+    assert result.manifest is not None
+    first = dumps_canonical(manifest_to_dict(result.manifest))
+    second = dumps_canonical(manifest_to_dict(result.manifest))
+    assert first == second
+
+
+def test_stable_manifest_digest_semantics() -> None:
+    result = generate_pit_futures_universe_manifest_v1(_build_input())
+    assert result.manifest is not None
+    assert compute_manifest_digest(result.manifest) == result.manifest.manifest_digest
+
+
+def test_input_records_not_mutated() -> None:
+    record = _base_record()
+    original = dataclasses.asdict(record)
+    generate_pit_futures_universe_manifest_v1(
+        _build_input(
+            epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, _eligible_panel() + (record,)),)
+        )
+    )
+    assert dataclasses.asdict(record) == original
+
+
+def test_unknown_venue_fail_closed() -> None:
+    record = _base_record(venue_id="unknown_venue", digest_suffix="unknown")
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(
+            epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, _eligible_panel() + (record,)),)
+        )
+    )
+    assert result.success is False
+    assert GeneratorErrorCode.UNKNOWN_VENUE.value in result.error_codes
+
+
+def test_invalid_lifecycle_interval_fail_closed() -> None:
+    record = _base_record(
+        listing_time="2024-06-02T00:00:00Z",
+        delisting_time="2024-06-01T00:00:00Z",
+        digest_suffix="bad-interval",
+    )
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(
+            epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, _eligible_panel() + (record,)),)
+        )
+    )
+    assert result.success is False
+    assert GeneratorErrorCode.INVALID_LIFECYCLE_INTERVAL.value in result.error_codes
+
+
+def test_excluded_members_use_only_existing_exclusion_codes() -> None:
+    record = _base_record(
+        base_asset="LTC",
+        venue_symbol="LTC-USDT-SWAP",
+        digest_suffix="ltc3",
+        delisting_time=_BAR_CLOSE_0,
+    )
+    panel = _eligible_panel() + (record,)
+    result = generate_pit_futures_universe_manifest_v1(
+        _build_input(epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE_0, panel),))
+    )
+    assert result.success
+    assert result.manifest is not None
+    for item in result.manifest.epochs[0].excluded_members:
+        assert set(item.reason_codes).issubset(EXCLUSION_REASON_CODES)


### PR DESCRIPTION
## Summary

- Materializes the generic offline PIT futures universe manifest generator v1 at `src/research/pit_futures_universe_manifest_generator_v1.py`.
- Adds focused contract tests (`47` test functions) covering input contract, lifecycle boundaries, determinism, negative futures/BTC/spot cases, validator gate, and digest/reference reuse.
- Pure generation core only: no writer, no network, no clock, no filesystem I/O, no runtime authority.

## Scope

- Generic offline generator consuming explicit lifecycle records and producing `PointInTimeFuturesUniverseManifestV1` via existing schema/digest owners.
- Mandatory post-generation validator gate (`ACCEPTED` only).

## Non-Goals

- Historical lifecycle registry
- Lifecycle data acquisition / venue crawlers / OKX ingest / new_listings binding
- Dataset binding, period binding, consumer binding
- Economic evaluation, runtime, fleet, strategy, promotion, orders, credentials

## Reuse Inventory

- `instrument_id_canonicalization_v1` — REUSE_AS_IS
- `pit_futures_universe_manifest_v1` — REUSE_AS_IS (schema, digests, reference formatting)
- `pit_futures_universe_manifest_validator_v1` — REUSE_AS_IS (mandatory post-check)
- `dumps_canonical` / replay_pack canonical JSON — REUSE_AS_IS

## Owner Decision

- `CANONICAL_GENERATOR_OWNER_PATH=src/research/pit_futures_universe_manifest_generator_v1.py`
- `NEW_OWNER_JUSTIFIED=true` (distinct validation boundary + distinct persistence lifecycle)
- Import direction: canonicalization + manifest → generator → validator (no reverse imports)

## Input / Output Contract

- Versioned immutable `PitFuturesUniverseManifestGeneratorInputV1` with explicit digests, timestamps, policy versions, epochs, and raw lifecycle records.
- Output: existing manifest dataclass only, `attach_computed_digests`, `format_pit_universe_manifest_reference_v1`.
- `GENERATOR_OUTPUT_MUST_VALIDATE=true`; invalid output never returned as success.

## Determinism & Lifecycle

- Internal canonical sorting; permutation-invariant manifest/reference digests for semantically identical input.
- Listing/eligible_from inclusive at epoch boundary; delisting/expiry/eligible_until exclusive.
- INELIGIBLE mapped only to existing 16 exclusion codes (unchanged).

## Safety / Authority

- `FUTURES_ONLY=true`, `BITCOIN_DIRECTION_ALLOWED=false`, `SPOT_ALLOWED=false`, `SYNTHETIC_SPOT_ALLOWED=false`
- `NON_AUTHORIZING=true`, `RESEARCH_BINDING_ONLY=true`
- `CONSUMER_BINDING_EFFECT=NONE`, `RUNTIME_EFFECT=NONE`, `ECONOMIC_EVALUATION_EXECUTED=false`
- `REAL_HISTORICAL_PIT_GENERATION_BLOCKED=true`, `HISTORICAL_LIFECYCLE_OWNER_STATUS=ABSENT`

## Changed Files

1. `src/research/pit_futures_universe_manifest_generator_v1.py` (new)
2. `tests/research/test_pit_futures_universe_manifest_generator_v1.py` (new)

## Tests

- New generator tests: 47
- Local focused run: `uv run pytest tests/research/test_pit_futures_universe_manifest_generator_v1.py -q` → PASS
- Adjacent contracts: `uv run pytest tests/research/test_instrument_id_canonicalization_v1.py tests/research/test_pit_futures_universe_manifest_v1.py tests/research/test_pit_futures_universe_manifest_validator_v1.py tests/research/test_pit_futures_universe_manifest_generator_v1.py -q` → 105 passed
- `ruff format --check`, `ruff check`, `git diff --check` → PASS

## CI Classification

- Selector result: `PR_BOUNDED_FULL` (`category_central_src_requires_full`)
- Root cause: new file under central `src/research/` triggers bounded full path per canonical selector policy (not workflow mutation).

## Test plan

- [x] Generator happy path + validator ACCEPTED
- [x] Input contract fail-closed cases
- [x] Lifecycle boundary semantics
- [x] Determinism / permutation invariance
- [x] BTC/spot/non-futures negatives
- [x] Existing manifest/validator regression suites

Made with [Cursor](https://cursor.com)