### PR TITLE
feat(research): PIT futures instrument lifecycle registry slice A v0

### DIFF
--- a/src/research/pit_futures_instrument_lifecycle_registry_v1.py
+++ b/src/research/pit_futures_instrument_lifecycle_registry_v1.py
@@ -1,0 +1,1040 @@
+"""Historical PIT futures instrument lifecycle registry v1 — Slice A contracts and pure core.
+
+Research-only, non-authorizing. No I/O, no network, no clock, no runtime authority.
+Provides immutable contracts, deterministic normalization, PIT query resolution,
+digest computation, and LifecycleRegistryErrorCode taxonomy (28 codes).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from src.research.instrument_id_canonicalization_v1 import (
+    InstrumentIdCanonicalizationInputV1,
+    canonicalize_instrument_id_v1,
+)
+from src.research.pit_futures_universe_manifest_v1 import (
+    ContractType,
+    compute_sha256_digest,
+    is_valid_digest,
+    is_valid_rfc3339_utc,
+)
+
+PACKAGE_MARKER = "PIT_FUTURES_INSTRUMENT_LIFECYCLE_REGISTRY_V1=true"
+INPUT_CONTRACT_VERSION = "pit_futures_instrument_lifecycle_registry_input.v1"
+SCHEMA_NAME = "pit_futures_instrument_lifecycle_registry"
+SCHEMA_VERSION = "v1"
+REGISTRY_VERSION = "pit_futures_instrument_lifecycle_registry.v1"
+SOURCE_PRIORITY_POLICY_VERSION = "source_priority_policy.v1"
+CONFLICT_RESOLUTION_POLICY_VERSION = "conflict_resolution_policy.v1"
+REFERENCE_PREFIX = "pit_futures_lifecycle_registry_v1"
+
+_PERPETUAL_TYPES = frozenset(
+    {ContractType.LINEAR_PERPETUAL.value, ContractType.INVERSE_PERPETUAL.value}
+)
+_DATED_TYPES = frozenset(
+    {ContractType.LINEAR_DATED_FUTURE.value, ContractType.INVERSE_DATED_FUTURE.value}
+)
+_FUTURES_MARKET_TYPES = frozenset({"futures", "futures_panel", "future", "perpetual"})
+_VENUE_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_ABSOLUTE_PATH_PATTERN = re.compile(r"(^/|^\\\\|^[A-Za-z]:[/\\\\])")
+_REGISTERED_SOURCES_V0 = frozenset({"synthetic:test:fixture:v0", "synthetic:test:record:v0"})
+
+
+class ObservationKind(str, Enum):
+    LISTING = "LISTING"
+    ELIGIBILITY = "ELIGIBILITY"
+    DELISTING = "DELISTING"
+    EXPIRY = "EXPIRY"
+    SUSPENSION_START = "SUSPENSION_START"
+    SUSPENSION_END = "SUSPENSION_END"
+    CORRECTION = "CORRECTION"
+    RELISTING = "RELISTING"
+
+
+class QueryState(str, Enum):
+    NOT_LISTED = "NOT_LISTED"
+    LISTED_INELIGIBLE = "LISTED_INELIGIBLE"
+    ELIGIBLE = "ELIGIBLE"
+    SUSPENDED = "SUSPENDED"
+    DELISTED = "DELISTED"
+    EXPIRED = "EXPIRED"
+    UNKNOWN = "UNKNOWN"
+
+
+class SourceTrustLevel(str, Enum):
+    TRUSTED = "TRUSTED"
+    UNTRUSTED = "UNTRUSTED"
+
+
+class LifecycleRegistryErrorCode(str, Enum):
+    INVALID_INPUT_CONTRACT = "INVALID_INPUT_CONTRACT"
+    MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD"
+    INVALID_VENUE_ID = "INVALID_VENUE_ID"
+    INVALID_INSTRUMENT_TYPE = "INVALID_INSTRUMENT_TYPE"
+    NON_FUTURES_INSTRUMENT = "NON_FUTURES_INSTRUMENT"
+    BITCOIN_DIRECTION_PROHIBITED = "BITCOIN_DIRECTION_PROHIBITED"
+    SPOT_INSTRUMENT_BLOCKED = "SPOT_INSTRUMENT_BLOCKED"
+    SYNTHETIC_SPOT_BLOCKED = "SYNTHETIC_SPOT_BLOCKED"
+    INVALID_TIMESTAMP = "INVALID_TIMESTAMP"
+    AMBIGUOUS_EFFECTIVE_TIME = "AMBIGUOUS_EFFECTIVE_TIME"
+    CONFLICTING_SOURCE_RECORDS = "CONFLICTING_SOURCE_RECORDS"
+    UNKNOWN_SOURCE = "UNKNOWN_SOURCE"
+    UNTRUSTED_SOURCE = "UNTRUSTED_SOURCE"
+    DUPLICATE_EVENT = "DUPLICATE_EVENT"
+    DUPLICATE_CANONICAL_INSTRUMENT_ID = "DUPLICATE_CANONICAL_INSTRUMENT_ID"
+    OVERLAPPING_LIFECYCLE_INTERVALS = "OVERLAPPING_LIFECYCLE_INTERVALS"
+    INVALID_TRANSITION = "INVALID_TRANSITION"
+    OUT_OF_ORDER_EVENT = "OUT_OF_ORDER_EVENT"
+    UNKNOWN_LIFECYCLE_STATE = "UNKNOWN_LIFECYCLE_STATE"
+    STALE_SOURCE_SNAPSHOT = "STALE_SOURCE_SNAPSHOT"
+    DIGEST_MISMATCH = "DIGEST_MISMATCH"
+    POLICY_MISMATCH = "POLICY_MISMATCH"
+    VALIDATOR_REJECTION = "VALIDATOR_REJECTION"
+    PERSISTENCE_BEFORE_VALIDATION = "PERSISTENCE_BEFORE_VALIDATION"
+    RETROACTIVE_CORRECTION_WITHOUT_PROVENANCE = "RETROACTIVE_CORRECTION_WITHOUT_PROVENANCE"
+    INVALID_CONTRACT_TYPE = "INVALID_CONTRACT_TYPE"
+    MISSING_EXPIRY_FOR_DATED_FUTURE = "MISSING_EXPIRY_FOR_DATED_FUTURE"
+    INVALID_SOURCE_REFERENCE = "INVALID_SOURCE_REFERENCE"
+
+
+@dataclass(frozen=True)
+class SuspensionSubIntervalV1:
+    suspension_start: str
+    suspension_end: str
+
+
+@dataclass(frozen=True)
+class SourceObservationRecordV1:
+    input_contract_version: str
+    source_id: str
+    source_trust_level: str
+    source_priority: int
+    source_snapshot_ref: str
+    source_snapshot_digest: str
+    source_observed_at: str
+    source_effective_at: str
+    venue_id: str
+    venue_timezone: str
+    market_type: str
+    contract_type: str
+    base_asset: str
+    quote_asset: str
+    settlement_asset: str
+    observation_kind: str
+    observation_digest: str
+    venue_symbol: str | None = None
+    native_instrument_id: str | None = None
+    contract_expiry: str | None = None
+    listing_time: str | None = None
+    eligible_from: str | None = None
+    delisting_time: str | None = None
+    eligible_until: str | None = None
+    expiry_time: str | None = None
+    correction_provenance_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class NormalizedLifecycleObservationV1:
+    input_contract_version: str
+    source_id: str
+    source_trust_level: str
+    source_priority: int
+    source_snapshot_ref: str
+    source_snapshot_digest: str
+    source_observed_at: str
+    source_effective_at: str
+    venue_id: str
+    venue_timezone: str
+    market_type: str
+    contract_type: str
+    base_asset: str
+    quote_asset: str
+    settlement_asset: str
+    observation_kind: str
+    observation_digest: str
+    instrument_id: str
+    venue_symbol: str | None = None
+    native_instrument_id: str | None = None
+    contract_expiry: str | None = None
+    listing_time: str | None = None
+    eligible_from: str | None = None
+    delisting_time: str | None = None
+    eligible_until: str | None = None
+    expiry_time: str | None = None
+    correction_provenance_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class InstrumentLifecycleIntervalV1:
+    instrument_id: str
+    venue_id: str
+    contract_type: str
+    base_asset: str
+    quote_asset: str
+    settlement_asset: str
+    listing_time: str
+    eligible_from: str
+    interval_sequence: int
+    registry_record_version: int
+    record_digest: str
+    venue_symbol: str | None = None
+    native_instrument_id: str | None = None
+    contract_expiry: str | None = None
+    delisting_time: str | None = None
+    eligible_until: str | None = None
+    expiry_time: str | None = None
+    suspension_sub_intervals: tuple[SuspensionSubIntervalV1, ...] = ()
+    source_snapshot_refs: tuple[str, ...] = ()
+    source_digests: tuple[str, ...] = ()
+    superseded_by_version: int | None = None
+    correction_provenance_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class RegistrySnapshotV1:
+    schema_name: str
+    schema_version: str
+    registry_snapshot_version: int
+    policy_version: str
+    source_priority_policy_version: str
+    conflict_resolution_policy_version: str
+    venue_scope: tuple[str, ...]
+    generated_at: str
+    intervals: tuple[InstrumentLifecycleIntervalV1, ...]
+    config_digest: str
+    implementation_digest: str
+    registry_snapshot_digest: str
+
+
+@dataclass(frozen=True)
+class RegistryReferenceV1:
+    schema_prefix: str
+    artifact_id: str
+    digest_algorithm: str
+    registry_snapshot_digest: str
+
+
+@dataclass(frozen=True)
+class LifecycleQueryResultV1:
+    query_state: str
+    instrument_id: str
+    query_instant: str
+    registry_snapshot_version: int
+    registry_snapshot_digest: str
+    interval: InstrumentLifecycleIntervalV1 | None = None
+    error_codes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class NormalizationResultV1:
+    success: bool
+    observation: NormalizedLifecycleObservationV1 | None
+    error_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ObservationConflictResultV1:
+    has_conflict: bool
+    error_codes: tuple[str, ...]
+    deduplicated: tuple[NormalizedLifecycleObservationV1, ...]
+
+
+@dataclass(frozen=True)
+class TransitionValidationResultV1:
+    valid: bool
+    error_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CorrectionVersionResultV1:
+    success: bool
+    snapshot: RegistrySnapshotV1 | None
+    error_codes: tuple[str, ...]
+
+
+def _add(errors: list[str], code: LifecycleRegistryErrorCode) -> None:
+    value = code.value
+    if value not in errors:
+        errors.append(value)
+
+
+def parse_utc_instant(value: str) -> tuple[int, int] | None:
+    if not is_valid_rfc3339_utc(value):
+        return None
+    date_part, time_part = value.split("T", 1)
+    year, month, day = (int(part) for part in date_part.split("-"))
+    hour = int(time_part[0:2])
+    minute = int(time_part[3:5])
+    second = int(time_part[6:8])
+    return (year * 10_000 + month * 100 + day, hour * 10_000 + minute * 100 + second)
+
+
+def _validate_source_ref(value: str, errors: list[str]) -> bool:
+    if not value.strip():
+        _add(errors, LifecycleRegistryErrorCode.INVALID_SOURCE_REFERENCE)
+        return False
+    if _ABSOLUTE_PATH_PATTERN.search(value):
+        _add(errors, LifecycleRegistryErrorCode.INVALID_SOURCE_REFERENCE)
+        return False
+    return True
+
+
+def _validate_timestamp(value: str | None, errors: list[str], *, required: bool) -> bool:
+    if value is None:
+        if required:
+            _add(errors, LifecycleRegistryErrorCode.MISSING_REQUIRED_FIELD)
+        return not required
+    if not is_valid_rfc3339_utc(value):
+        _add(errors, LifecycleRegistryErrorCode.INVALID_TIMESTAMP)
+        return False
+    return True
+
+
+def _classify_market_errors(market_type: str, contract_type: str, errors: list[str]) -> bool:
+    mt = market_type.strip().lower()
+    if mt == "spot":
+        _add(errors, LifecycleRegistryErrorCode.SPOT_INSTRUMENT_BLOCKED)
+        return True
+    if mt in {"synthetic_spot", "synthetic-spot"}:
+        _add(errors, LifecycleRegistryErrorCode.SYNTHETIC_SPOT_BLOCKED)
+        return True
+    if mt not in _FUTURES_MARKET_TYPES:
+        _add(errors, LifecycleRegistryErrorCode.NON_FUTURES_INSTRUMENT)
+        return True
+    ct = contract_type.strip().lower()
+    if ct not in {item.value for item in ContractType}:
+        _add(errors, LifecycleRegistryErrorCode.INVALID_CONTRACT_TYPE)
+        return True
+    return False
+
+
+def observation_semantic_payload(
+    obs: SourceObservationRecordV1 | NormalizedLifecycleObservationV1,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "base_asset": obs.base_asset.strip().upper(),
+        "contract_expiry": obs.contract_expiry,
+        "contract_type": obs.contract_type.strip().lower(),
+        "correction_provenance_ref": obs.correction_provenance_ref,
+        "delisting_time": obs.delisting_time,
+        "eligible_from": obs.eligible_from,
+        "eligible_until": obs.eligible_until,
+        "expiry_time": obs.expiry_time,
+        "listing_time": obs.listing_time,
+        "market_type": obs.market_type.strip().lower(),
+        "native_instrument_id": obs.native_instrument_id,
+        "observation_kind": obs.observation_kind.strip().upper(),
+        "quote_asset": obs.quote_asset.strip().upper(),
+        "settlement_asset": obs.settlement_asset.strip().upper(),
+        "source_effective_at": obs.source_effective_at,
+        "source_id": obs.source_id.strip(),
+        "source_observed_at": obs.source_observed_at,
+        "source_priority": obs.source_priority,
+        "source_snapshot_digest": obs.source_snapshot_digest.strip().lower(),
+        "source_snapshot_ref": obs.source_snapshot_ref.strip(),
+        "venue_id": obs.venue_id.strip().lower(),
+        "venue_symbol": obs.venue_symbol,
+        "venue_timezone": obs.venue_timezone.strip(),
+    }
+    if isinstance(obs, NormalizedLifecycleObservationV1):
+        payload["instrument_id"] = obs.instrument_id
+    return payload
+
+
+def compute_observation_digest(
+    obs: SourceObservationRecordV1 | NormalizedLifecycleObservationV1,
+) -> str:
+    return compute_sha256_digest(observation_semantic_payload(obs))
+
+
+def _interval_to_dict(
+    interval: InstrumentLifecycleIntervalV1, *, include_digest: bool
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "base_asset": interval.base_asset,
+        "contract_expiry": interval.contract_expiry,
+        "contract_type": interval.contract_type,
+        "correction_provenance_ref": interval.correction_provenance_ref,
+        "delisting_time": interval.delisting_time,
+        "eligible_from": interval.eligible_from,
+        "eligible_until": interval.eligible_until,
+        "expiry_time": interval.expiry_time,
+        "instrument_id": interval.instrument_id,
+        "interval_sequence": interval.interval_sequence,
+        "listing_time": interval.listing_time,
+        "native_instrument_id": interval.native_instrument_id,
+        "quote_asset": interval.quote_asset,
+        "registry_record_version": interval.registry_record_version,
+        "settlement_asset": interval.settlement_asset,
+        "source_digests": list(interval.source_digests),
+        "source_snapshot_refs": list(interval.source_snapshot_refs),
+        "suspension_sub_intervals": [
+            {"suspension_end": item.suspension_end, "suspension_start": item.suspension_start}
+            for item in interval.suspension_sub_intervals
+        ],
+        "superseded_by_version": interval.superseded_by_version,
+        "venue_id": interval.venue_id,
+        "venue_symbol": interval.venue_symbol,
+    }
+    if include_digest:
+        payload["record_digest"] = interval.record_digest
+    return {k: v for k, v in payload.items() if v is not None}
+
+
+def compute_interval_digest(interval: InstrumentLifecycleIntervalV1) -> str:
+    return compute_sha256_digest(_interval_to_dict(interval, include_digest=False))
+
+
+def compute_registry_snapshot_digest(snapshot: RegistrySnapshotV1) -> str:
+    payload: dict[str, Any] = {
+        "config_digest": snapshot.config_digest.strip().lower(),
+        "conflict_resolution_policy_version": snapshot.conflict_resolution_policy_version,
+        "generated_at": snapshot.generated_at,
+        "implementation_digest": snapshot.implementation_digest.strip().lower(),
+        "intervals": [
+            interval.record_digest.strip().lower()
+            for interval in sorted(
+                snapshot.intervals,
+                key=lambda item: (item.instrument_id, item.interval_sequence),
+            )
+        ],
+        "policy_version": snapshot.policy_version,
+        "registry_snapshot_version": snapshot.registry_snapshot_version,
+        "schema_name": snapshot.schema_name,
+        "schema_version": snapshot.schema_version,
+        "source_priority_policy_version": snapshot.source_priority_policy_version,
+        "venue_scope": list(snapshot.venue_scope),
+    }
+    return compute_sha256_digest(payload)
+
+
+def attach_snapshot_digest(snapshot: RegistrySnapshotV1) -> RegistrySnapshotV1:
+    intervals = tuple(
+        _attach_interval_digest(interval)
+        for interval in sorted(
+            snapshot.intervals, key=lambda i: (i.instrument_id, i.interval_sequence)
+        )
+    )
+    interim = RegistrySnapshotV1(
+        schema_name=snapshot.schema_name,
+        schema_version=snapshot.schema_version,
+        registry_snapshot_version=snapshot.registry_snapshot_version,
+        policy_version=snapshot.policy_version,
+        source_priority_policy_version=snapshot.source_priority_policy_version,
+        conflict_resolution_policy_version=snapshot.conflict_resolution_policy_version,
+        venue_scope=tuple(sorted(snapshot.venue_scope)),
+        generated_at=snapshot.generated_at,
+        intervals=intervals,
+        config_digest=snapshot.config_digest.strip().lower(),
+        implementation_digest=snapshot.implementation_digest.strip().lower(),
+        registry_snapshot_digest="0" * 64,
+    )
+    digest = compute_registry_snapshot_digest(interim)
+    return RegistrySnapshotV1(
+        schema_name=interim.schema_name,
+        schema_version=interim.schema_version,
+        registry_snapshot_version=interim.registry_snapshot_version,
+        policy_version=interim.policy_version,
+        source_priority_policy_version=interim.source_priority_policy_version,
+        conflict_resolution_policy_version=interim.conflict_resolution_policy_version,
+        venue_scope=interim.venue_scope,
+        generated_at=interim.generated_at,
+        intervals=interim.intervals,
+        config_digest=interim.config_digest,
+        implementation_digest=interim.implementation_digest,
+        registry_snapshot_digest=digest,
+    )
+
+
+def _attach_interval_digest(
+    interval: InstrumentLifecycleIntervalV1,
+) -> InstrumentLifecycleIntervalV1:
+    digest = compute_interval_digest(interval)
+    return InstrumentLifecycleIntervalV1(
+        instrument_id=interval.instrument_id,
+        venue_id=interval.venue_id,
+        contract_type=interval.contract_type,
+        base_asset=interval.base_asset,
+        quote_asset=interval.quote_asset,
+        settlement_asset=interval.settlement_asset,
+        listing_time=interval.listing_time,
+        eligible_from=interval.eligible_from,
+        interval_sequence=interval.interval_sequence,
+        registry_record_version=interval.registry_record_version,
+        record_digest=digest,
+        venue_symbol=interval.venue_symbol,
+        native_instrument_id=interval.native_instrument_id,
+        contract_expiry=interval.contract_expiry,
+        delisting_time=interval.delisting_time,
+        eligible_until=interval.eligible_until,
+        expiry_time=interval.expiry_time,
+        suspension_sub_intervals=interval.suspension_sub_intervals,
+        source_snapshot_refs=tuple(sorted(set(interval.source_snapshot_refs))),
+        source_digests=tuple(sorted(d.strip().lower() for d in interval.source_digests)),
+        superseded_by_version=interval.superseded_by_version,
+        correction_provenance_ref=interval.correction_provenance_ref,
+    )
+
+
+def observation_sort_key(obs: NormalizedLifecycleObservationV1) -> tuple[Any, ...]:
+    return (
+        obs.source_effective_at,
+        obs.source_priority,
+        obs.source_observed_at,
+        obs.source_id,
+        obs.observation_digest,
+    )
+
+
+def sort_normalized_observations(
+    observations: Sequence[NormalizedLifecycleObservationV1],
+) -> tuple[NormalizedLifecycleObservationV1, ...]:
+    return tuple(sorted(observations, key=observation_sort_key))
+
+
+def observation_identity_key(obs: NormalizedLifecycleObservationV1) -> tuple[Any, ...]:
+    return (
+        obs.instrument_id,
+        obs.observation_kind.strip().upper(),
+        obs.source_effective_at,
+        compute_observation_digest(obs),
+    )
+
+
+def observation_conflict_key(obs: NormalizedLifecycleObservationV1) -> tuple[Any, ...]:
+    return (
+        obs.instrument_id,
+        obs.observation_kind.strip().upper(),
+        obs.source_effective_at,
+    )
+
+
+def normalize_source_observation_record_v1(
+    record: SourceObservationRecordV1,
+    *,
+    registered_sources: frozenset[str] | None = None,
+    approved_snapshot_digests: frozenset[str] | None = None,
+) -> NormalizationResultV1:
+    errors: list[str] = []
+    sources = registered_sources if registered_sources is not None else _REGISTERED_SOURCES_V0
+
+    if record.input_contract_version != INPUT_CONTRACT_VERSION:
+        _add(errors, LifecycleRegistryErrorCode.INVALID_INPUT_CONTRACT)
+
+    if not record.source_id.strip():
+        _add(errors, LifecycleRegistryErrorCode.MISSING_REQUIRED_FIELD)
+    elif record.source_id.strip() not in sources:
+        _add(errors, LifecycleRegistryErrorCode.UNKNOWN_SOURCE)
+
+    trust = record.source_trust_level.strip().upper()
+    if trust != SourceTrustLevel.TRUSTED.value:
+        _add(errors, LifecycleRegistryErrorCode.UNTRUSTED_SOURCE)
+
+    venue_id = record.venue_id.strip().lower()
+    if not venue_id or not _VENUE_ID_PATTERN.fullmatch(venue_id):
+        _add(errors, LifecycleRegistryErrorCode.INVALID_VENUE_ID)
+
+    if not record.venue_timezone.strip():
+        _add(errors, LifecycleRegistryErrorCode.MISSING_REQUIRED_FIELD)
+
+    if not _validate_source_ref(record.source_snapshot_ref, errors):
+        pass
+    if not is_valid_digest(record.source_snapshot_digest.strip().lower()):
+        _add(errors, LifecycleRegistryErrorCode.DIGEST_MISMATCH)
+
+    if approved_snapshot_digests is not None:
+        if record.source_snapshot_digest.strip().lower() not in approved_snapshot_digests:
+            _add(errors, LifecycleRegistryErrorCode.STALE_SOURCE_SNAPSHOT)
+
+    _validate_timestamp(record.source_observed_at, errors, required=True)
+    if not _validate_timestamp(record.source_effective_at, errors, required=True):
+        pass
+    elif parse_utc_instant(record.source_effective_at) is None:
+        _add(errors, LifecycleRegistryErrorCode.AMBIGUOUS_EFFECTIVE_TIME)
+
+    try:
+        ObservationKind(record.observation_kind.strip().upper())
+    except ValueError:
+        _add(errors, LifecycleRegistryErrorCode.INVALID_INSTRUMENT_TYPE)
+
+    if _classify_market_errors(record.market_type, record.contract_type, errors):
+        return NormalizationResultV1(False, None, tuple(sorted(errors)))
+
+    contract_type = record.contract_type.strip().lower()
+    if contract_type in _PERPETUAL_TYPES:
+        if record.expiry_time is not None or record.contract_expiry is not None:
+            _add(errors, LifecycleRegistryErrorCode.INVALID_INSTRUMENT_TYPE)
+    elif contract_type in _DATED_TYPES:
+        if record.expiry_time is None or record.contract_expiry is None:
+            _add(errors, LifecycleRegistryErrorCode.MISSING_EXPIRY_FOR_DATED_FUTURE)
+
+    kind = record.observation_kind.strip().upper()
+    if kind in {
+        ObservationKind.LISTING.value,
+        ObservationKind.RELISTING.value,
+        ObservationKind.ELIGIBILITY.value,
+    }:
+        if record.listing_time is None:
+            _add(errors, LifecycleRegistryErrorCode.MISSING_REQUIRED_FIELD)
+        else:
+            _validate_timestamp(record.listing_time, errors, required=True)
+        if record.eligible_from is None:
+            _add(errors, LifecycleRegistryErrorCode.MISSING_REQUIRED_FIELD)
+        else:
+            _validate_timestamp(record.eligible_from, errors, required=True)
+
+    if record.delisting_time is not None:
+        _validate_timestamp(record.delisting_time, errors, required=True)
+    if record.eligible_until is not None:
+        _validate_timestamp(record.eligible_until, errors, required=True)
+    if record.expiry_time is not None:
+        _validate_timestamp(record.expiry_time, errors, required=True)
+
+    if kind == ObservationKind.CORRECTION.value and not record.correction_provenance_ref:
+        _add(errors, LifecycleRegistryErrorCode.RETROACTIVE_CORRECTION_WITHOUT_PROVENANCE)
+    elif record.correction_provenance_ref is not None:
+        _validate_source_ref(record.correction_provenance_ref, errors)
+
+    if errors:
+        return NormalizationResultV1(False, None, tuple(sorted(errors)))
+
+    canon = canonicalize_instrument_id_v1(
+        InstrumentIdCanonicalizationInputV1(
+            venue_id=venue_id,
+            market_type=record.market_type.strip().lower(),
+            contract_type=contract_type,
+            base_asset=record.base_asset.strip(),
+            quote_asset=record.quote_asset.strip(),
+            settlement_asset=record.settlement_asset.strip(),
+            venue_symbol=record.venue_symbol,
+            native_instrument_id=record.native_instrument_id,
+            contract_expiry=record.contract_expiry,
+        )
+    )
+    if not canon.success or canon.instrument_id is None:
+        for code in canon.error_codes:
+            if code == "BITCOIN_DIRECTION_DISALLOWED":
+                _add(errors, LifecycleRegistryErrorCode.BITCOIN_DIRECTION_PROHIBITED)
+            elif code == "SPOT_MARKET":
+                _add(errors, LifecycleRegistryErrorCode.SPOT_INSTRUMENT_BLOCKED)
+            elif code == "SYNTHETIC_SPOT_MARKET":
+                _add(errors, LifecycleRegistryErrorCode.SYNTHETIC_SPOT_BLOCKED)
+            elif code == "NON_FUTURES_MARKET":
+                _add(errors, LifecycleRegistryErrorCode.NON_FUTURES_INSTRUMENT)
+            else:
+                _add(errors, LifecycleRegistryErrorCode.INVALID_INSTRUMENT_TYPE)
+        return NormalizationResultV1(False, None, tuple(sorted(errors)))
+
+    expected_digest = compute_observation_digest(record)
+    if expected_digest != record.observation_digest.strip().lower():
+        _add(errors, LifecycleRegistryErrorCode.DIGEST_MISMATCH)
+        return NormalizationResultV1(False, None, tuple(sorted(errors)))
+
+    normalized = NormalizedLifecycleObservationV1(
+        input_contract_version=record.input_contract_version,
+        source_id=record.source_id.strip(),
+        source_trust_level=trust,
+        source_priority=record.source_priority,
+        source_snapshot_ref=record.source_snapshot_ref.strip(),
+        source_snapshot_digest=record.source_snapshot_digest.strip().lower(),
+        source_observed_at=record.source_observed_at,
+        source_effective_at=record.source_effective_at,
+        venue_id=venue_id,
+        venue_timezone=record.venue_timezone.strip(),
+        market_type=record.market_type.strip().lower(),
+        contract_type=contract_type,
+        base_asset=record.base_asset.strip().upper(),
+        quote_asset=record.quote_asset.strip().upper(),
+        settlement_asset=record.settlement_asset.strip().upper(),
+        observation_kind=kind,
+        observation_digest=expected_digest,
+        instrument_id=canon.instrument_id,
+        venue_symbol=record.venue_symbol.strip() if record.venue_symbol else None,
+        native_instrument_id=record.native_instrument_id,
+        contract_expiry=record.contract_expiry,
+        listing_time=record.listing_time,
+        eligible_from=record.eligible_from,
+        delisting_time=record.delisting_time,
+        eligible_until=record.eligible_until,
+        expiry_time=record.expiry_time,
+        correction_provenance_ref=record.correction_provenance_ref,
+    )
+    return NormalizationResultV1(True, normalized, ())
+
+
+def resolve_observation_conflicts_v1(
+    observations: Sequence[NormalizedLifecycleObservationV1],
+) -> ObservationConflictResultV1:
+    errors: list[str] = []
+    sorted_obs = sort_normalized_observations(observations)
+    seen_identity: set[tuple[Any, ...]] = set()
+    conflict_groups: dict[tuple[Any, ...], list[NormalizedLifecycleObservationV1]] = {}
+    deduplicated: list[NormalizedLifecycleObservationV1] = []
+
+    for obs in sorted_obs:
+        identity = observation_identity_key(obs)
+        if identity in seen_identity:
+            continue
+        conflict_key = observation_conflict_key(obs)
+        conflict_groups.setdefault(conflict_key, []).append(obs)
+
+    for key, group in conflict_groups.items():
+        digests = {item.observation_digest for item in group}
+        semantic = {compute_observation_digest(item) for item in group}
+        if len(group) > 1 and len(digests) > 1 and len(semantic) > 1:
+            priorities = {item.source_priority for item in group}
+            if len(priorities) == 1:
+                _add(errors, LifecycleRegistryErrorCode.CONFLICTING_SOURCE_RECORDS)
+            else:
+                winner = min(group, key=observation_sort_key)
+                deduplicated.append(winner)
+                seen_identity.add(observation_identity_key(winner))
+            continue
+        item = group[0]
+        deduplicated.append(item)
+        seen_identity.add(observation_identity_key(item))
+
+    if errors:
+        return ObservationConflictResultV1(True, tuple(sorted(errors)), ())
+    return ObservationConflictResultV1(False, (), tuple(sort_normalized_observations(deduplicated)))
+
+
+def _is_in_suspension(interval: InstrumentLifecycleIntervalV1, instant: tuple[int, int]) -> bool:
+    for sub in interval.suspension_sub_intervals:
+        start = parse_utc_instant(sub.suspension_start)
+        end = parse_utc_instant(sub.suspension_end)
+        if start is None or end is None:
+            continue
+        if start <= instant < end:
+            return True
+    return False
+
+
+def _exclusive_end_instant(interval: InstrumentLifecycleIntervalV1) -> tuple[int, int] | None:
+    candidates: list[tuple[int, int]] = []
+    for ts in (interval.delisting_time, interval.eligible_until, interval.expiry_time):
+        if ts is None:
+            continue
+        parsed = parse_utc_instant(ts)
+        if parsed is not None:
+            candidates.append(parsed)
+    if not candidates:
+        return None
+    return min(candidates)
+
+
+def query_lifecycle_state_at_instant_v1(
+    interval: InstrumentLifecycleIntervalV1,
+    query_instant: str,
+) -> QueryState:
+    instant = parse_utc_instant(query_instant)
+    if instant is None:
+        return QueryState.UNKNOWN
+
+    listing = parse_utc_instant(interval.listing_time)
+    eligible_from = parse_utc_instant(interval.eligible_from)
+    if listing is None or eligible_from is None:
+        return QueryState.UNKNOWN
+
+    if instant < listing:
+        return QueryState.NOT_LISTED
+    if instant < eligible_from:
+        return QueryState.LISTED_INELIGIBLE
+
+    if interval.delisting_time is not None:
+        delist = parse_utc_instant(interval.delisting_time)
+        if delist is not None and delist <= instant:
+            return QueryState.DELISTED
+
+    if interval.expiry_time is not None:
+        expiry = parse_utc_instant(interval.expiry_time)
+        if expiry is not None and expiry <= instant:
+            return QueryState.EXPIRED
+
+    if interval.eligible_until is not None:
+        eligible_until = parse_utc_instant(interval.eligible_until)
+        if eligible_until is not None and eligible_until <= instant:
+            return QueryState.DELISTED
+
+    end = _exclusive_end_instant(interval)
+    if end is not None and instant >= end:
+        if interval.expiry_time is not None:
+            return QueryState.EXPIRED
+        return QueryState.DELISTED
+
+    if _is_in_suspension(interval, instant):
+        return QueryState.SUSPENDED
+
+    return QueryState.ELIGIBLE
+
+
+def query_lifecycle_at_snapshot_v1(
+    snapshot: RegistrySnapshotV1,
+    *,
+    instrument_id: str,
+    query_instant: str,
+) -> LifecycleQueryResultV1:
+    if parse_utc_instant(query_instant) is None:
+        return LifecycleQueryResultV1(
+            query_state=QueryState.UNKNOWN.value,
+            instrument_id=instrument_id,
+            query_instant=query_instant,
+            registry_snapshot_version=snapshot.registry_snapshot_version,
+            registry_snapshot_digest=snapshot.registry_snapshot_digest,
+            error_codes=(LifecycleRegistryErrorCode.INVALID_TIMESTAMP.value,),
+        )
+
+    active_intervals = [
+        item
+        for item in snapshot.intervals
+        if item.instrument_id == instrument_id and item.superseded_by_version is None
+    ]
+    if not active_intervals:
+        return LifecycleQueryResultV1(
+            query_state=QueryState.UNKNOWN.value,
+            instrument_id=instrument_id,
+            query_instant=query_instant,
+            registry_snapshot_version=snapshot.registry_snapshot_version,
+            registry_snapshot_digest=snapshot.registry_snapshot_digest,
+            error_codes=(LifecycleRegistryErrorCode.UNKNOWN_LIFECYCLE_STATE.value,),
+        )
+
+    chosen = max(active_intervals, key=lambda i: i.interval_sequence)
+    state = query_lifecycle_state_at_instant_v1(chosen, query_instant)
+    return LifecycleQueryResultV1(
+        query_state=state.value,
+        instrument_id=instrument_id,
+        query_instant=query_instant,
+        registry_snapshot_version=snapshot.registry_snapshot_version,
+        registry_snapshot_digest=snapshot.registry_snapshot_digest,
+        interval=chosen,
+    )
+
+
+_ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
+    ObservationKind.LISTING.value: frozenset({ObservationKind.ELIGIBILITY.value}),
+    ObservationKind.ELIGIBILITY.value: frozenset(
+        {
+            ObservationKind.SUSPENSION_START.value,
+            ObservationKind.DELISTING.value,
+            ObservationKind.EXPIRY.value,
+            ObservationKind.CORRECTION.value,
+        }
+    ),
+    ObservationKind.SUSPENSION_START.value: frozenset({ObservationKind.SUSPENSION_END.value}),
+    ObservationKind.SUSPENSION_END.value: frozenset(
+        {
+            ObservationKind.SUSPENSION_START.value,
+            ObservationKind.DELISTING.value,
+            ObservationKind.EXPIRY.value,
+        }
+    ),
+    ObservationKind.DELISTING.value: frozenset(
+        {ObservationKind.RELISTING.value, ObservationKind.CORRECTION.value}
+    ),
+    ObservationKind.EXPIRY.value: frozenset(
+        {ObservationKind.RELISTING.value, ObservationKind.CORRECTION.value}
+    ),
+    ObservationKind.RELISTING.value: frozenset({ObservationKind.ELIGIBILITY.value}),
+    ObservationKind.CORRECTION.value: frozenset({kind.value for kind in ObservationKind}),
+}
+
+
+def validate_observation_transition_v1(
+    prior_kind: str | None,
+    next_kind: str,
+) -> TransitionValidationResultV1:
+    errors: list[str] = []
+    try:
+        next_enum = ObservationKind(next_kind.strip().upper())
+    except ValueError:
+        _add(errors, LifecycleRegistryErrorCode.INVALID_TRANSITION)
+        return TransitionValidationResultV1(False, tuple(errors))
+
+    if (
+        next_enum == ObservationKind.SUSPENSION_END
+        and prior_kind != ObservationKind.SUSPENSION_START.value
+    ):
+        _add(errors, LifecycleRegistryErrorCode.INVALID_TRANSITION)
+        return TransitionValidationResultV1(False, tuple(errors))
+
+    if prior_kind is None:
+        if next_enum not in {
+            ObservationKind.LISTING,
+            ObservationKind.RELISTING,
+            ObservationKind.CORRECTION,
+        }:
+            _add(errors, LifecycleRegistryErrorCode.INVALID_TRANSITION)
+        return TransitionValidationResultV1(not errors, tuple(errors))
+
+    prior = prior_kind.strip().upper()
+    allowed = _ALLOWED_TRANSITIONS.get(prior, frozenset())
+    if next_enum.value not in allowed and next_enum != ObservationKind.CORRECTION:
+        if next_enum == ObservationKind.RELISTING:
+            if prior not in {ObservationKind.DELISTING.value, ObservationKind.EXPIRY.value}:
+                _add(errors, LifecycleRegistryErrorCode.INVALID_TRANSITION)
+        elif next_enum in {ObservationKind.LISTING, ObservationKind.ELIGIBILITY}:
+            if prior in {ObservationKind.DELISTING.value, ObservationKind.EXPIRY.value}:
+                _add(errors, LifecycleRegistryErrorCode.INVALID_TRANSITION)
+        else:
+            _add(errors, LifecycleRegistryErrorCode.INVALID_TRANSITION)
+
+    return TransitionValidationResultV1(not errors, tuple(sorted(errors)))
+
+
+def build_interval_from_observation_v1(
+    obs: NormalizedLifecycleObservationV1,
+    *,
+    interval_sequence: int = 0,
+    registry_record_version: int = 1,
+    suspension_sub_intervals: tuple[SuspensionSubIntervalV1, ...] = (),
+) -> InstrumentLifecycleIntervalV1 | None:
+    if obs.listing_time is None or obs.eligible_from is None:
+        return None
+    interval = InstrumentLifecycleIntervalV1(
+        instrument_id=obs.instrument_id,
+        venue_id=obs.venue_id,
+        contract_type=obs.contract_type,
+        base_asset=obs.base_asset,
+        quote_asset=obs.quote_asset,
+        settlement_asset=obs.settlement_asset,
+        listing_time=obs.listing_time,
+        eligible_from=obs.eligible_from,
+        interval_sequence=interval_sequence,
+        registry_record_version=registry_record_version,
+        record_digest="0" * 64,
+        venue_symbol=obs.venue_symbol,
+        native_instrument_id=obs.native_instrument_id,
+        contract_expiry=obs.contract_expiry,
+        delisting_time=obs.delisting_time,
+        eligible_until=obs.eligible_until,
+        expiry_time=obs.expiry_time,
+        suspension_sub_intervals=suspension_sub_intervals,
+        source_snapshot_refs=(obs.source_snapshot_ref,),
+        source_digests=(obs.source_snapshot_digest,),
+        correction_provenance_ref=obs.correction_provenance_ref,
+    )
+    return _attach_interval_digest(interval)
+
+
+def create_correction_snapshot_version_v1(
+    prior: RegistrySnapshotV1,
+    *,
+    corrected_interval: InstrumentLifecycleIntervalV1,
+    correction_provenance_ref: str,
+    generated_at: str,
+) -> CorrectionVersionResultV1:
+    errors: list[str] = []
+    if not correction_provenance_ref.strip():
+        _add(errors, LifecycleRegistryErrorCode.RETROACTIVE_CORRECTION_WITHOUT_PROVENANCE)
+        return CorrectionVersionResultV1(False, None, tuple(errors))
+
+    if not is_valid_rfc3339_utc(generated_at):
+        _add(errors, LifecycleRegistryErrorCode.INVALID_TIMESTAMP)
+        return CorrectionVersionResultV1(False, None, tuple(errors))
+
+    new_version = prior.registry_snapshot_version + 1
+    new_record_version = corrected_interval.registry_record_version + 1
+    updated_intervals: list[InstrumentLifecycleIntervalV1] = []
+    replaced = False
+
+    for interval in prior.intervals:
+        if (
+            interval.instrument_id == corrected_interval.instrument_id
+            and interval.interval_sequence == corrected_interval.interval_sequence
+            and interval.superseded_by_version is None
+        ):
+            superseded = InstrumentLifecycleIntervalV1(
+                instrument_id=interval.instrument_id,
+                venue_id=interval.venue_id,
+                contract_type=interval.contract_type,
+                base_asset=interval.base_asset,
+                quote_asset=interval.quote_asset,
+                settlement_asset=interval.settlement_asset,
+                listing_time=interval.listing_time,
+                eligible_from=interval.eligible_from,
+                interval_sequence=interval.interval_sequence,
+                registry_record_version=interval.registry_record_version,
+                record_digest=interval.record_digest,
+                venue_symbol=interval.venue_symbol,
+                native_instrument_id=interval.native_instrument_id,
+                contract_expiry=interval.contract_expiry,
+                delisting_time=interval.delisting_time,
+                eligible_until=interval.eligible_until,
+                expiry_time=interval.expiry_time,
+                suspension_sub_intervals=interval.suspension_sub_intervals,
+                source_snapshot_refs=interval.source_snapshot_refs,
+                source_digests=interval.source_digests,
+                superseded_by_version=new_version,
+                correction_provenance_ref=interval.correction_provenance_ref,
+            )
+            updated_intervals.append(_attach_interval_digest(superseded))
+            corrected = InstrumentLifecycleIntervalV1(
+                instrument_id=corrected_interval.instrument_id,
+                venue_id=corrected_interval.venue_id,
+                contract_type=corrected_interval.contract_type,
+                base_asset=corrected_interval.base_asset,
+                quote_asset=corrected_interval.quote_asset,
+                settlement_asset=corrected_interval.settlement_asset,
+                listing_time=corrected_interval.listing_time,
+                eligible_from=corrected_interval.eligible_from,
+                interval_sequence=corrected_interval.interval_sequence,
+                registry_record_version=new_record_version,
+                record_digest="0" * 64,
+                venue_symbol=corrected_interval.venue_symbol,
+                native_instrument_id=corrected_interval.native_instrument_id,
+                contract_expiry=corrected_interval.contract_expiry,
+                delisting_time=corrected_interval.delisting_time,
+                eligible_until=corrected_interval.eligible_until,
+                expiry_time=corrected_interval.expiry_time,
+                suspension_sub_intervals=corrected_interval.suspension_sub_intervals,
+                source_snapshot_refs=corrected_interval.source_snapshot_refs,
+                source_digests=corrected_interval.source_digests,
+                correction_provenance_ref=correction_provenance_ref.strip(),
+            )
+            updated_intervals.append(_attach_interval_digest(corrected))
+            replaced = True
+        else:
+            updated_intervals.append(interval)
+
+    if not replaced:
+        _add(errors, LifecycleRegistryErrorCode.UNKNOWN_LIFECYCLE_STATE)
+        return CorrectionVersionResultV1(False, None, tuple(errors))
+
+    snapshot = RegistrySnapshotV1(
+        schema_name=SCHEMA_NAME,
+        schema_version=SCHEMA_VERSION,
+        registry_snapshot_version=new_version,
+        policy_version=prior.policy_version,
+        source_priority_policy_version=prior.source_priority_policy_version,
+        conflict_resolution_policy_version=prior.conflict_resolution_policy_version,
+        venue_scope=prior.venue_scope,
+        generated_at=generated_at,
+        intervals=tuple(updated_intervals),
+        config_digest=prior.config_digest,
+        implementation_digest=prior.implementation_digest,
+        registry_snapshot_digest="0" * 64,
+    )
+    return CorrectionVersionResultV1(True, attach_snapshot_digest(snapshot), ())
+
+
+def format_registry_reference_v1(*, artifact_id: str, registry_snapshot_digest: str) -> str:
+    return f"{REFERENCE_PREFIX}:{artifact_id.strip()}:sha256:{registry_snapshot_digest.strip().lower()}"
+
+
+def intervals_overlap_v1(
+    a: InstrumentLifecycleIntervalV1, b: InstrumentLifecycleIntervalV1
+) -> bool:
+    if a.instrument_id != b.instrument_id or a.interval_sequence != b.interval_sequence:
+        return False
+    a_start = parse_utc_instant(a.eligible_from)
+    a_end = _exclusive_end_instant(a) or (9999, 999999)
+    b_start = parse_utc_instant(b.eligible_from)
+    b_end = _exclusive_end_instant(b) or (9999, 999999)
+    if a_start is None or b_start is None:
+        return False
+    return a_start < b_end and b_start < a_end

--- a/tests/research/test_pit_futures_instrument_lifecycle_registry_v1.py
+++ b/tests/research/test_pit_futures_instrument_lifecycle_registry_v1.py
@@ -1,0 +1,493 @@
+"""Contract tests for pit_futures_instrument_lifecycle_registry_v1 — Slice A."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from src.research.pit_futures_instrument_lifecycle_registry_v1 import (
+    INPUT_CONTRACT_VERSION,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    InstrumentLifecycleIntervalV1,
+    LifecycleQueryResultV1,
+    LifecycleRegistryErrorCode,
+    NormalizedLifecycleObservationV1,
+    ObservationKind,
+    QueryState,
+    RegistrySnapshotV1,
+    SourceObservationRecordV1,
+    SourceTrustLevel,
+    SuspensionSubIntervalV1,
+    attach_snapshot_digest,
+    build_interval_from_observation_v1,
+    compute_interval_digest,
+    compute_observation_digest,
+    compute_registry_snapshot_digest,
+    create_correction_snapshot_version_v1,
+    intervals_overlap_v1,
+    normalize_source_observation_record_v1,
+    query_lifecycle_at_snapshot_v1,
+    query_lifecycle_state_at_instant_v1,
+    resolve_observation_conflicts_v1,
+    sort_normalized_observations,
+    validate_observation_transition_v1,
+)
+
+_SOURCE_ID = "synthetic:test:record:v0"
+_SNAPSHOT_REF = "synthetic:test:snapshot:v0"
+_LISTING = "2024-01-01T00:00:00Z"
+_ELIGIBLE = "2024-01-02T00:00:00Z"
+_QUERY = "2024-06-01T01:00:00Z"
+_GENERATED_AT = "2026-07-03T02:00:00Z"
+_APPROVED_DIGESTS = frozenset()
+
+
+def _observation_payload(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "base_asset": "ETH",
+        "contract_type": "linear_perpetual",
+        "correction_provenance_ref": None,
+        "delisting_time": None,
+        "eligible_from": _ELIGIBLE,
+        "eligible_until": None,
+        "expiry_time": None,
+        "listing_time": _LISTING,
+        "market_type": "futures",
+        "native_instrument_id": None,
+        "observation_kind": ObservationKind.LISTING.value,
+        "quote_asset": "USDT",
+        "settlement_asset": "USDT",
+        "source_effective_at": _LISTING,
+        "source_id": _SOURCE_ID,
+        "source_observed_at": _LISTING,
+        "source_priority": 1,
+        "source_snapshot_digest": "a" * 64,
+        "source_snapshot_ref": _SNAPSHOT_REF,
+        "venue_id": "okx",
+        "venue_symbol": "ETH-USDT-SWAP",
+        "venue_timezone": "UTC",
+    }
+    base.update(overrides)
+    return base
+
+
+def _source_record(**overrides: object) -> SourceObservationRecordV1:
+    payload = _observation_payload(**overrides)
+    digest = compute_observation_digest(
+        SourceObservationRecordV1(
+            input_contract_version=INPUT_CONTRACT_VERSION,
+            source_id=str(payload["source_id"]),
+            source_trust_level=SourceTrustLevel.TRUSTED.value,
+            source_priority=int(payload["source_priority"]),  # type: ignore[arg-type]
+            source_snapshot_ref=str(payload["source_snapshot_ref"]),
+            source_snapshot_digest=str(payload["source_snapshot_digest"]),
+            source_observed_at=str(payload["source_observed_at"]),
+            source_effective_at=str(payload["source_effective_at"]),
+            venue_id=str(payload["venue_id"]),
+            venue_timezone=str(payload["venue_timezone"]),
+            market_type=str(payload["market_type"]),
+            contract_type=str(payload["contract_type"]),
+            base_asset=str(payload["base_asset"]),
+            quote_asset=str(payload["quote_asset"]),
+            settlement_asset=str(payload["settlement_asset"]),
+            observation_kind=str(payload["observation_kind"]),
+            observation_digest="0" * 64,
+            venue_symbol=str(payload["venue_symbol"]) if payload.get("venue_symbol") else None,
+            native_instrument_id=(
+                str(payload["native_instrument_id"])
+                if payload.get("native_instrument_id")
+                else None
+            ),
+            contract_expiry=str(payload["contract_expiry"])
+            if payload.get("contract_expiry")
+            else None,
+            listing_time=str(payload["listing_time"]) if payload.get("listing_time") else None,
+            eligible_from=str(payload["eligible_from"]) if payload.get("eligible_from") else None,
+            delisting_time=str(payload["delisting_time"])
+            if payload.get("delisting_time")
+            else None,
+            eligible_until=str(payload["eligible_until"])
+            if payload.get("eligible_until")
+            else None,
+            expiry_time=str(payload["expiry_time"]) if payload.get("expiry_time") else None,
+            correction_provenance_ref=(
+                str(payload["correction_provenance_ref"])
+                if payload.get("correction_provenance_ref")
+                else None
+            ),
+        )
+    )
+    return SourceObservationRecordV1(
+        input_contract_version=INPUT_CONTRACT_VERSION,
+        source_id=str(payload["source_id"]),
+        source_trust_level=SourceTrustLevel.TRUSTED.value,
+        source_priority=int(payload["source_priority"]),  # type: ignore[arg-type]
+        source_snapshot_ref=str(payload["source_snapshot_ref"]),
+        source_snapshot_digest=str(payload["source_snapshot_digest"]),
+        source_observed_at=str(payload["source_observed_at"]),
+        source_effective_at=str(payload["source_effective_at"]),
+        venue_id=str(payload["venue_id"]),
+        venue_timezone=str(payload["venue_timezone"]),
+        market_type=str(payload["market_type"]),
+        contract_type=str(payload["contract_type"]),
+        base_asset=str(payload["base_asset"]),
+        quote_asset=str(payload["quote_asset"]),
+        settlement_asset=str(payload["settlement_asset"]),
+        observation_kind=str(payload["observation_kind"]),
+        observation_digest=digest,
+        venue_symbol=str(payload["venue_symbol"]) if payload.get("venue_symbol") else None,
+        native_instrument_id=(
+            str(payload["native_instrument_id"]) if payload.get("native_instrument_id") else None
+        ),
+        contract_expiry=str(payload["contract_expiry"]) if payload.get("contract_expiry") else None,
+        listing_time=str(payload["listing_time"]) if payload.get("listing_time") else None,
+        eligible_from=str(payload["eligible_from"]) if payload.get("eligible_from") else None,
+        delisting_time=str(payload["delisting_time"]) if payload.get("delisting_time") else None,
+        eligible_until=str(payload["eligible_until"]) if payload.get("eligible_until") else None,
+        expiry_time=str(payload["expiry_time"]) if payload.get("expiry_time") else None,
+        correction_provenance_ref=(
+            str(payload["correction_provenance_ref"])
+            if payload.get("correction_provenance_ref")
+            else None
+        ),
+    )
+
+
+def _normalize(**overrides: object) -> NormalizedLifecycleObservationV1:
+    result = normalize_source_observation_record_v1(_source_record(**overrides))
+    assert result.success, result.error_codes
+    assert result.observation is not None
+    return result.observation
+
+
+def _interval(**overrides: object) -> InstrumentLifecycleIntervalV1:
+    interval = build_interval_from_observation_v1(_normalize(**overrides))
+    assert interval is not None
+    return interval
+
+
+def _snapshot(*intervals: InstrumentLifecycleIntervalV1) -> RegistrySnapshotV1:
+    snap = RegistrySnapshotV1(
+        schema_name=SCHEMA_NAME,
+        schema_version=SCHEMA_VERSION,
+        registry_snapshot_version=1,
+        policy_version="policy.v0",
+        source_priority_policy_version="source_priority_policy.v1",
+        conflict_resolution_policy_version="conflict_resolution_policy.v1",
+        venue_scope=("okx",),
+        generated_at=_GENERATED_AT,
+        intervals=intervals,
+        config_digest="b" * 64,
+        implementation_digest="c" * 64,
+        registry_snapshot_digest="0" * 64,
+    )
+    return attach_snapshot_digest(snap)
+
+
+def test_observation_kind_count_exactly_eight() -> None:
+    assert len(ObservationKind) == 8
+
+
+def test_query_state_count_exactly_seven() -> None:
+    assert len(QueryState) == 7
+
+
+def test_error_code_count_exactly_twenty_eight() -> None:
+    assert len(LifecycleRegistryErrorCode) == 28
+
+
+def test_source_record_is_immutable() -> None:
+    record = _source_record()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        record.source_id = "mutated"  # type: ignore[misc]
+
+
+def test_normalize_happy_path_futures_perpetual() -> None:
+    result = normalize_source_observation_record_v1(_source_record())
+    assert result.success
+    assert result.observation is not None
+    assert result.observation.instrument_id.startswith("okx:linear_perpetual:")
+
+
+def test_spot_rejected() -> None:
+    result = normalize_source_observation_record_v1(_source_record(market_type="spot"))
+    assert not result.success
+    assert LifecycleRegistryErrorCode.SPOT_INSTRUMENT_BLOCKED.value in result.error_codes
+
+
+def test_synthetic_spot_rejected() -> None:
+    result = normalize_source_observation_record_v1(_source_record(market_type="synthetic_spot"))
+    assert not result.success
+    assert LifecycleRegistryErrorCode.SYNTHETIC_SPOT_BLOCKED.value in result.error_codes
+
+
+def test_non_futures_rejected() -> None:
+    result = normalize_source_observation_record_v1(_source_record(market_type="option"))
+    assert not result.success
+    assert LifecycleRegistryErrorCode.NON_FUTURES_INSTRUMENT.value in result.error_codes
+
+
+def test_bitcoin_base_rejected() -> None:
+    result = normalize_source_observation_record_v1(_source_record(base_asset="BTC"))
+    assert not result.success
+    assert LifecycleRegistryErrorCode.BITCOIN_DIRECTION_PROHIBITED.value in result.error_codes
+
+
+def test_xbt_base_rejected() -> None:
+    result = normalize_source_observation_record_v1(_source_record(base_asset="XBT"))
+    assert not result.success
+    assert LifecycleRegistryErrorCode.BITCOIN_DIRECTION_PROHIBITED.value in result.error_codes
+
+
+def test_invalid_timestamp_rejected() -> None:
+    result = normalize_source_observation_record_v1(
+        _source_record(source_effective_at="not-a-time")
+    )
+    assert not result.success
+    assert LifecycleRegistryErrorCode.INVALID_TIMESTAMP.value in result.error_codes
+
+
+def test_missing_listing_time_rejected() -> None:
+    result = normalize_source_observation_record_v1(_source_record(listing_time=None))
+    assert not result.success
+    assert LifecycleRegistryErrorCode.MISSING_REQUIRED_FIELD.value in result.error_codes
+
+
+def test_dated_future_requires_expiry() -> None:
+    result = normalize_source_observation_record_v1(
+        _source_record(contract_type="linear_dated_future", contract_expiry=None, expiry_time=None)
+    )
+    assert not result.success
+    assert LifecycleRegistryErrorCode.MISSING_EXPIRY_FOR_DATED_FUTURE.value in result.error_codes
+
+
+def test_correction_requires_provenance() -> None:
+    result = normalize_source_observation_record_v1(
+        _source_record(
+            observation_kind=ObservationKind.CORRECTION.value, correction_provenance_ref=None
+        )
+    )
+    assert not result.success
+    assert (
+        LifecycleRegistryErrorCode.RETROACTIVE_CORRECTION_WITHOUT_PROVENANCE.value
+        in result.error_codes
+    )
+
+
+def test_unknown_source_rejected() -> None:
+    result = normalize_source_observation_record_v1(_source_record(source_id="unknown:source:v0"))
+    assert not result.success
+    assert LifecycleRegistryErrorCode.UNKNOWN_SOURCE.value in result.error_codes
+
+
+def test_untrusted_source_rejected() -> None:
+    record = _source_record()
+    untrusted = dataclasses.replace(record, source_trust_level=SourceTrustLevel.UNTRUSTED.value)
+    result = normalize_source_observation_record_v1(untrusted)
+    assert not result.success
+    assert LifecycleRegistryErrorCode.UNTRUSTED_SOURCE.value in result.error_codes
+
+
+def test_digest_mismatch_rejected() -> None:
+    record = _source_record()
+    bad = dataclasses.replace(record, observation_digest="f" * 64)
+    result = normalize_source_observation_record_v1(bad)
+    assert not result.success
+    assert LifecycleRegistryErrorCode.DIGEST_MISMATCH.value in result.error_codes
+
+
+def test_same_semantic_observation_same_digest() -> None:
+    first = _source_record()
+    second = _source_record()
+    assert first.observation_digest == second.observation_digest
+
+
+def test_different_semantic_observation_different_digest() -> None:
+    first = _source_record()
+    second = _source_record(base_asset="SOL", venue_symbol="SOL-USDT-SWAP")
+    assert first.observation_digest != second.observation_digest
+
+
+def test_sort_observations_permutation_invariant_digest_set() -> None:
+    a = _normalize(source_priority=1, source_id="synthetic:test:record:v0")
+    b = _normalize(source_priority=2, source_effective_at="2024-01-03T00:00:00Z")
+    ordered = sort_normalized_observations((a, b))
+    reversed_order = sort_normalized_observations((b, a))
+    assert ordered == reversed_order
+
+
+def test_conflicting_equal_priority_observations_fail_closed() -> None:
+    first = _normalize(source_priority=1)
+    second = _normalize(source_priority=1, eligible_from="2024-01-05T00:00:00Z")
+    result = resolve_observation_conflicts_v1((first, second))
+    assert result.has_conflict
+    assert LifecycleRegistryErrorCode.CONFLICTING_SOURCE_RECORDS.value in result.error_codes
+
+
+def test_duplicate_identical_observations_deduplicated() -> None:
+    obs = _normalize()
+    result = resolve_observation_conflicts_v1((obs, obs))
+    assert not result.has_conflict
+    assert len(result.deduplicated) == 1
+
+
+def test_listing_boundary_inclusive() -> None:
+    interval = _interval(listing_time=_QUERY, eligible_from=_QUERY)
+    assert query_lifecycle_state_at_instant_v1(interval, _QUERY) == QueryState.ELIGIBLE
+
+
+def test_eligible_from_inclusive() -> None:
+    interval = _interval(listing_time=_LISTING, eligible_from=_QUERY)
+    assert query_lifecycle_state_at_instant_v1(interval, _QUERY) == QueryState.ELIGIBLE
+
+
+def test_listed_ineligible_before_eligible_from() -> None:
+    interval = _interval(listing_time=_LISTING, eligible_from="2024-06-02T00:00:00Z")
+    assert query_lifecycle_state_at_instant_v1(interval, _QUERY) == QueryState.LISTED_INELIGIBLE
+
+
+def test_not_listed_before_listing() -> None:
+    interval = _interval(listing_time="2024-06-02T00:00:00Z", eligible_from="2024-06-02T00:00:00Z")
+    assert query_lifecycle_state_at_instant_v1(interval, _QUERY) == QueryState.NOT_LISTED
+
+
+def test_delisting_boundary_exclusive() -> None:
+    interval = _interval(delisting_time=_QUERY)
+    assert query_lifecycle_state_at_instant_v1(interval, _QUERY) == QueryState.DELISTED
+
+
+def test_expiry_boundary_exclusive() -> None:
+    interval = _interval(
+        contract_type="linear_dated_future",
+        contract_expiry="20240601",
+        expiry_time=_QUERY,
+    )
+    assert query_lifecycle_state_at_instant_v1(interval, _QUERY) == QueryState.EXPIRED
+
+
+def test_eligible_until_boundary_exclusive() -> None:
+    interval = _interval(eligible_until=_QUERY)
+    assert query_lifecycle_state_at_instant_v1(interval, _QUERY) == QueryState.DELISTED
+
+
+def test_suspension_sub_interval() -> None:
+    interval = build_interval_from_observation_v1(
+        _normalize(),
+        suspension_sub_intervals=(
+            SuspensionSubIntervalV1("2024-05-01T00:00:00Z", "2024-07-01T00:00:00Z"),
+        ),
+    )
+    assert interval is not None
+    assert query_lifecycle_state_at_instant_v1(interval, _QUERY) == QueryState.SUSPENDED
+
+
+def test_unknown_historical_membership_fail_closed() -> None:
+    snap = _snapshot()
+    result = query_lifecycle_at_snapshot_v1(
+        snap,
+        instrument_id="okx:linear_perpetual:MISSING:USDT:USDT:perp",
+        query_instant=_QUERY,
+    )
+    assert result.query_state == QueryState.UNKNOWN.value
+    assert LifecycleRegistryErrorCode.UNKNOWN_LIFECYCLE_STATE.value in result.error_codes
+
+
+def test_query_bound_to_snapshot_version_and_digest() -> None:
+    interval = _interval()
+    snap = _snapshot(interval)
+    result = query_lifecycle_at_snapshot_v1(
+        snap,
+        instrument_id=interval.instrument_id,
+        query_instant=_QUERY,
+    )
+    assert isinstance(result, LifecycleQueryResultV1)
+    assert result.registry_snapshot_version == 1
+    assert result.registry_snapshot_digest == snap.registry_snapshot_digest
+
+
+def test_stable_interval_and_snapshot_digests() -> None:
+    interval = _interval()
+    snap = _snapshot(interval)
+    assert interval.record_digest == compute_interval_digest(interval)
+    assert snap.registry_snapshot_digest == compute_registry_snapshot_digest(snap)
+
+
+def test_snapshot_digest_permutation_invariant() -> None:
+    first = _interval(base_asset="ETH", venue_symbol="ETH-USDT-SWAP")
+    second = _interval(base_asset="SOL", venue_symbol="SOL-USDT-SWAP")
+    snap_a = _snapshot(first, second)
+    snap_b = _snapshot(second, first)
+    assert snap_a.registry_snapshot_digest == snap_b.registry_snapshot_digest
+
+
+def test_correction_creates_new_snapshot_version_no_inplace_rewrite() -> None:
+    interval = _interval()
+    prior = _snapshot(interval)
+    corrected = dataclasses.replace(
+        interval, eligible_from="2024-01-03T00:00:00Z", record_digest="0" * 64
+    )
+    corrected = build_interval_from_observation_v1(
+        _normalize(eligible_from="2024-01-03T00:00:00Z"),
+        interval_sequence=interval.interval_sequence,
+        registry_record_version=interval.registry_record_version,
+    )
+    assert corrected is not None
+    result = create_correction_snapshot_version_v1(
+        prior,
+        corrected_interval=corrected,
+        correction_provenance_ref="synthetic:correction:prov:v0",
+        generated_at="2026-07-03T03:00:00Z",
+    )
+    assert result.success
+    assert result.snapshot is not None
+    assert result.snapshot.registry_snapshot_version == 2
+    assert result.snapshot.registry_snapshot_digest != prior.registry_snapshot_digest
+    superseded = [i for i in result.snapshot.intervals if i.superseded_by_version == 2]
+    assert superseded
+
+
+def test_invalid_transition_suspension_end_without_start() -> None:
+    result = validate_observation_transition_v1(
+        ObservationKind.LISTING.value, ObservationKind.SUSPENSION_END.value
+    )
+    assert not result.valid
+    assert LifecycleRegistryErrorCode.INVALID_TRANSITION.value in result.error_codes
+
+
+def test_valid_transition_listing_to_eligibility() -> None:
+    result = validate_observation_transition_v1(
+        ObservationKind.LISTING.value, ObservationKind.ELIGIBILITY.value
+    )
+    assert result.valid
+
+
+def test_relisting_after_delisting_allowed() -> None:
+    result = validate_observation_transition_v1(
+        ObservationKind.DELISTING.value,
+        ObservationKind.RELISTING.value,
+    )
+    assert result.valid
+
+
+def test_delisted_to_eligible_without_relisting_forbidden() -> None:
+    result = validate_observation_transition_v1(
+        ObservationKind.DELISTING.value,
+        ObservationKind.ELIGIBILITY.value,
+    )
+    assert not result.valid
+
+
+def test_overlapping_intervals_detected() -> None:
+    a = _interval(eligible_from=_LISTING, eligible_until="2024-12-01T00:00:00Z")
+    b = _interval(
+        eligible_from="2024-06-01T00:00:00Z",
+        eligible_until="2025-01-01T00:00:00Z",
+    )
+    assert intervals_overlap_v1(a, b)
+
+
+def test_all_error_codes_are_unique_strings() -> None:
+    values = [item.value for item in LifecycleRegistryErrorCode]
+    assert len(values) == len(set(values))


### PR DESCRIPTION
## Summary

- **Slice A only**: immutable lifecycle registry contracts, pure normalization core, PIT query/transition helpers, and the 28-code `LifecycleRegistryErrorCode` taxonomy.
- Adds `src/research/pit_futures_instrument_lifecycle_registry_v1.py` with 8 observation kinds, 7 query states, digest computation reusing existing `dumps_canonical` / manifest utilities, and fail-closed historical query semantics.
- Adds focused contract tests (`41` cases) covering boundaries, determinism, futures-only guards, and correction versioning.

## Scope boundaries (explicit)

- `FUTURES_ONLY=true`, `BITCOIN_DIRECTION_ALLOWED=false`
- **No** file I/O, network, runtime, dataset binding, or economic evaluation
- **No** validator owner (`pit_futures_instrument_lifecycle_registry_validator_v1.py`) — deferred to Slice B
- **No** writer/reader persistence — deferred to Slice C
- **No** generator binding — deferred to Slice D
- **No** source adapters/backfill — deferred to Slice E
- **No** current-state fallback for historical queries

## Test plan

- [x] `pytest tests/research/test_pit_futures_instrument_lifecycle_registry_v1.py`
- [x] Adjacent PIT manifest/generator/validator/canonicalization tests
- [x] `ruff format --check`, `ruff check`, `git diff --check`


Made with [Cursor](https://cursor.com)