### PR TITLE
feat(research): PIT futures lifecycle registry slice C writer/reader/persistence v0

### DIFF
--- a/src/research/pit_futures_instrument_lifecycle_registry_persistence_v1.py
+++ b/src/research/pit_futures_instrument_lifecycle_registry_persistence_v1.py
@@ -1,0 +1,452 @@
+"""Offline persistence for pit_futures_instrument_lifecycle_registry snapshots v1 — Slice C.
+
+Research-only, non-authorizing. Validator-before-write and validator-after-read.
+Atomic replace writes within an explicit root directory. No current-state fallbacks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.execution.replay_pack.canonical import dumps_canonical
+from src.research.pit_futures_instrument_lifecycle_registry_v1 import (
+    InstrumentLifecycleIntervalV1,
+    LifecycleRegistryErrorCode,
+    RegistrySnapshotV1,
+    SuspensionSubIntervalV1,
+    registry_snapshot_to_dict,
+)
+from src.research.pit_futures_instrument_lifecycle_registry_validator_v1 import (
+    ValidationVerdict,
+    validate_pit_futures_instrument_lifecycle_registry_snapshot_v1,
+)
+
+PACKAGE_MARKER = "PIT_FUTURES_INSTRUMENT_LIFECYCLE_REGISTRY_PERSISTENCE_V1=true"
+PERSISTENCE_FORMAT_VERSION = "pit_futures_instrument_lifecycle_registry_persistence.v1"
+
+_SNAPSHOT_TOP_LEVEL_KEYS = frozenset(
+    {
+        "config_digest",
+        "conflict_resolution_policy_version",
+        "generated_at",
+        "implementation_digest",
+        "intervals",
+        "policy_version",
+        "registry_snapshot_digest",
+        "registry_snapshot_version",
+        "schema_name",
+        "schema_version",
+        "source_priority_policy_version",
+        "venue_scope",
+    }
+)
+_INTERVAL_KEYS = frozenset(
+    {
+        "base_asset",
+        "contract_expiry",
+        "contract_type",
+        "correction_provenance_ref",
+        "delisting_time",
+        "eligible_from",
+        "eligible_until",
+        "expiry_time",
+        "instrument_id",
+        "interval_sequence",
+        "listing_time",
+        "native_instrument_id",
+        "quote_asset",
+        "record_digest",
+        "registry_record_version",
+        "settlement_asset",
+        "source_digests",
+        "source_snapshot_refs",
+        "suspension_sub_intervals",
+        "superseded_by_version",
+        "venue_id",
+        "venue_symbol",
+    }
+)
+_SUSPENSION_KEYS = frozenset({"suspension_end", "suspension_start"})
+
+
+class PersistenceErrorCode(str, Enum):
+    VALIDATOR_REJECTED_BEFORE_WRITE = "VALIDATOR_REJECTED_BEFORE_WRITE"
+    VALIDATOR_REJECTED_AFTER_READ = "VALIDATOR_REJECTED_AFTER_READ"
+    PATH_TRAVERSAL_FORBIDDEN = "PATH_TRAVERSAL_FORBIDDEN"
+    PATH_OUTSIDE_ROOT = "PATH_OUTSIDE_ROOT"
+    SYMLINK_FORBIDDEN = "SYMLINK_FORBIDDEN"
+    TARGET_EXISTS = "TARGET_EXISTS"
+    FILE_NOT_FOUND = "FILE_NOT_FOUND"
+    CORRUPT_PERSISTED_FORMAT = "CORRUPT_PERSISTED_FORMAT"
+    UNKNOWN_SCHEMA_VERSION = "UNKNOWN_SCHEMA_VERSION"
+    UNKNOWN_FIELD = "UNKNOWN_FIELD"
+    INVALID_JSON = "INVALID_JSON"
+    TRUNCATED_FILE = "TRUNCATED_FILE"
+    IO_ERROR = "IO_ERROR"
+    MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD"
+
+
+class OverwritePolicy(str, Enum):
+    FAIL_IF_EXISTS = "FAIL_IF_EXISTS"
+    ALLOW_REPLACE = "ALLOW_REPLACE"
+
+
+@dataclass(frozen=True)
+class RegistryPersistenceWriteResultV1:
+    success: bool
+    path: str | None
+    bytes_written: int
+    error_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RegistryPersistenceReadResultV1:
+    success: bool
+    snapshot: RegistrySnapshotV1 | None
+    path: str | None
+    error_codes: tuple[str, ...]
+
+
+def _unknown_keys(data: Mapping[str, Any], allowed: frozenset[str]) -> tuple[str, ...]:
+    extras = sorted(set(data.keys()) - allowed)
+    return tuple(extras)
+
+
+def _parse_suspension_sub_interval(data: Mapping[str, Any]) -> SuspensionSubIntervalV1:
+    return SuspensionSubIntervalV1(
+        suspension_start=str(data["suspension_start"]),
+        suspension_end=str(data["suspension_end"]),
+    )
+
+
+def _parse_interval(data: Mapping[str, Any]) -> InstrumentLifecycleIntervalV1:
+    suspension_raw = data.get("suspension_sub_intervals", ())
+    suspension = tuple(_parse_suspension_sub_interval(item) for item in suspension_raw)
+    return InstrumentLifecycleIntervalV1(
+        instrument_id=str(data["instrument_id"]),
+        venue_id=str(data["venue_id"]),
+        contract_type=str(data["contract_type"]),
+        base_asset=str(data["base_asset"]),
+        quote_asset=str(data["quote_asset"]),
+        settlement_asset=str(data["settlement_asset"]),
+        listing_time=str(data["listing_time"]),
+        eligible_from=str(data["eligible_from"]),
+        interval_sequence=int(data["interval_sequence"]),
+        registry_record_version=int(data["registry_record_version"]),
+        record_digest=str(data["record_digest"]),
+        venue_symbol=str(data["venue_symbol"]) if data.get("venue_symbol") is not None else None,
+        native_instrument_id=(
+            str(data["native_instrument_id"])
+            if data.get("native_instrument_id") is not None
+            else None
+        ),
+        contract_expiry=(
+            str(data["contract_expiry"]) if data.get("contract_expiry") is not None else None
+        ),
+        delisting_time=(
+            str(data["delisting_time"]) if data.get("delisting_time") is not None else None
+        ),
+        eligible_until=(
+            str(data["eligible_until"]) if data.get("eligible_until") is not None else None
+        ),
+        expiry_time=str(data["expiry_time"]) if data.get("expiry_time") is not None else None,
+        suspension_sub_intervals=suspension,
+        source_snapshot_refs=tuple(str(item) for item in data.get("source_snapshot_refs", ())),
+        source_digests=tuple(str(item) for item in data.get("source_digests", ())),
+        superseded_by_version=(
+            int(data["superseded_by_version"])
+            if data.get("superseded_by_version") is not None
+            else None
+        ),
+        correction_provenance_ref=(
+            str(data["correction_provenance_ref"])
+            if data.get("correction_provenance_ref") is not None
+            else None
+        ),
+    )
+
+
+def parse_registry_snapshot_dict_v1(
+    data: Mapping[str, Any],
+) -> tuple[RegistrySnapshotV1 | None, tuple[str, ...]]:
+    """Fail-closed parse of persisted registry snapshot dict."""
+    errors: list[str] = []
+
+    unknown_top = _unknown_keys(data, _SNAPSHOT_TOP_LEVEL_KEYS)
+    if unknown_top:
+        errors.append(PersistenceErrorCode.UNKNOWN_FIELD.value)
+        return None, tuple(errors)
+
+    required_top = (
+        "schema_name",
+        "schema_version",
+        "registry_snapshot_version",
+        "policy_version",
+        "source_priority_policy_version",
+        "conflict_resolution_policy_version",
+        "venue_scope",
+        "generated_at",
+        "intervals",
+        "config_digest",
+        "implementation_digest",
+        "registry_snapshot_digest",
+    )
+    for field in required_top:
+        if field not in data:
+            errors.append(PersistenceErrorCode.MISSING_REQUIRED_FIELD.value)
+    if errors:
+        return None, tuple(sorted(set(errors)))
+
+    schema_version = str(data["schema_version"])
+    if schema_version != "v1":
+        errors.append(PersistenceErrorCode.UNKNOWN_SCHEMA_VERSION.value)
+        return None, tuple(sorted(set(errors)))
+
+    intervals_raw = data["intervals"]
+    if not isinstance(intervals_raw, list):
+        errors.append(PersistenceErrorCode.CORRUPT_PERSISTED_FORMAT.value)
+        return None, tuple(sorted(set(errors)))
+
+    intervals: list[InstrumentLifecycleIntervalV1] = []
+    for item in intervals_raw:
+        if not isinstance(item, dict):
+            errors.append(PersistenceErrorCode.CORRUPT_PERSISTED_FORMAT.value)
+            return None, tuple(sorted(set(errors)))
+        unknown_interval = _unknown_keys(item, _INTERVAL_KEYS)
+        if unknown_interval:
+            errors.append(PersistenceErrorCode.UNKNOWN_FIELD.value)
+            return None, tuple(sorted(set(errors)))
+        for sub in item.get("suspension_sub_intervals", ()):
+            if not isinstance(sub, dict):
+                errors.append(PersistenceErrorCode.CORRUPT_PERSISTED_FORMAT.value)
+                return None, tuple(sorted(set(errors)))
+            unknown_sub = _unknown_keys(sub, _SUSPENSION_KEYS)
+            if unknown_sub:
+                errors.append(PersistenceErrorCode.UNKNOWN_FIELD.value)
+                return None, tuple(sorted(set(errors)))
+        intervals.append(_parse_interval(item))
+
+    snapshot = RegistrySnapshotV1(
+        schema_name=str(data["schema_name"]),
+        schema_version=schema_version,
+        registry_snapshot_version=int(data["registry_snapshot_version"]),
+        policy_version=str(data["policy_version"]),
+        source_priority_policy_version=str(data["source_priority_policy_version"]),
+        conflict_resolution_policy_version=str(data["conflict_resolution_policy_version"]),
+        venue_scope=tuple(str(item) for item in data["venue_scope"]),
+        generated_at=str(data["generated_at"]),
+        intervals=tuple(intervals),
+        config_digest=str(data["config_digest"]),
+        implementation_digest=str(data["implementation_digest"]),
+        registry_snapshot_digest=str(data["registry_snapshot_digest"]),
+    )
+    return snapshot, ()
+
+
+def registry_snapshot_to_canonical_bytes(snapshot: RegistrySnapshotV1) -> bytes:
+    payload = registry_snapshot_to_dict(snapshot, include_digest=True)
+    return dumps_canonical(payload).encode("utf-8")
+
+
+def _resolve_bounded_path(
+    root_dir: Path, relative_path: Path
+) -> tuple[Path | None, tuple[str, ...]]:
+    if relative_path.is_absolute():
+        return None, (PersistenceErrorCode.PATH_OUTSIDE_ROOT.value,)
+    if ".." in relative_path.parts:
+        return None, (PersistenceErrorCode.PATH_TRAVERSAL_FORBIDDEN.value,)
+
+    root = root_dir.resolve()
+    cursor = root
+    for part in relative_path.parts:
+        if part == "..":
+            return None, (PersistenceErrorCode.PATH_TRAVERSAL_FORBIDDEN.value,)
+        next_cursor = cursor / part
+        if next_cursor.is_symlink():
+            return None, (PersistenceErrorCode.SYMLINK_FORBIDDEN.value,)
+        cursor = next_cursor
+
+    candidate = (root / relative_path).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None, (PersistenceErrorCode.PATH_OUTSIDE_ROOT.value,)
+
+    return candidate, ()
+
+
+def _atomic_write_bytes(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_path = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".tmp_{path.stem}_",
+        suffix=path.suffix or ".json",
+    )
+    closed = False
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            closed = True
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    except Exception as exc:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise OSError(str(exc)) from exc
+    finally:
+        if not closed:
+            os.close(fd)
+
+
+def write_registry_snapshot_v1(
+    snapshot: RegistrySnapshotV1,
+    *,
+    root_dir: Path | str,
+    relative_path: Path | str,
+    overwrite_policy: OverwritePolicy = OverwritePolicy.FAIL_IF_EXISTS,
+) -> RegistryPersistenceWriteResultV1:
+    """Validate, then atomically persist an accepted registry snapshot."""
+    validation = validate_pit_futures_instrument_lifecycle_registry_snapshot_v1(snapshot)
+    if validation.verdict != ValidationVerdict.ACCEPTED:
+        codes = tuple(
+            sorted(
+                {
+                    PersistenceErrorCode.VALIDATOR_REJECTED_BEFORE_WRITE.value,
+                    LifecycleRegistryErrorCode.PERSISTENCE_BEFORE_VALIDATION.value,
+                    *validation.error_codes,
+                }
+            )
+        )
+        return RegistryPersistenceWriteResultV1(False, None, 0, codes)
+
+    root = Path(root_dir)
+    rel = Path(relative_path)
+    target, path_errors = _resolve_bounded_path(root, rel)
+    if target is None:
+        return RegistryPersistenceWriteResultV1(False, None, 0, path_errors)
+
+    if target.exists() and overwrite_policy == OverwritePolicy.FAIL_IF_EXISTS:
+        return RegistryPersistenceWriteResultV1(
+            False,
+            str(target),
+            0,
+            (PersistenceErrorCode.TARGET_EXISTS.value,),
+        )
+
+    content = registry_snapshot_to_canonical_bytes(snapshot)
+    try:
+        _atomic_write_bytes(target, content)
+    except OSError:
+        return RegistryPersistenceWriteResultV1(
+            False,
+            str(target),
+            0,
+            (PersistenceErrorCode.IO_ERROR.value,),
+        )
+
+    return RegistryPersistenceWriteResultV1(True, str(target), len(content), ())
+
+
+def read_registry_snapshot_v1(
+    *,
+    root_dir: Path | str,
+    relative_path: Path | str,
+) -> RegistryPersistenceReadResultV1:
+    """Read and validator-gate a persisted registry snapshot."""
+    root = Path(root_dir)
+    rel = Path(relative_path)
+    target, path_errors = _resolve_bounded_path(root, rel)
+    if target is None:
+        return RegistryPersistenceReadResultV1(False, None, None, path_errors)
+
+    if not target.exists():
+        return RegistryPersistenceReadResultV1(
+            False,
+            None,
+            str(target),
+            (PersistenceErrorCode.FILE_NOT_FOUND.value,),
+        )
+
+    try:
+        raw = target.read_bytes()
+    except OSError:
+        return RegistryPersistenceReadResultV1(
+            False,
+            None,
+            str(target),
+            (PersistenceErrorCode.IO_ERROR.value,),
+        )
+
+    if not raw.strip():
+        return RegistryPersistenceReadResultV1(
+            False,
+            None,
+            str(target),
+            (PersistenceErrorCode.TRUNCATED_FILE.value,),
+        )
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return RegistryPersistenceReadResultV1(
+            False,
+            None,
+            str(target),
+            (PersistenceErrorCode.CORRUPT_PERSISTED_FORMAT.value,),
+        )
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return RegistryPersistenceReadResultV1(
+            False,
+            None,
+            str(target),
+            (PersistenceErrorCode.INVALID_JSON.value,),
+        )
+
+    if not isinstance(data, dict):
+        return RegistryPersistenceReadResultV1(
+            False,
+            None,
+            str(target),
+            (PersistenceErrorCode.CORRUPT_PERSISTED_FORMAT.value,),
+        )
+
+    snapshot, parse_errors = parse_registry_snapshot_dict_v1(data)
+    if snapshot is None:
+        return RegistryPersistenceReadResultV1(False, None, str(target), parse_errors)
+
+    validation = validate_pit_futures_instrument_lifecycle_registry_snapshot_v1(snapshot)
+    if validation.verdict != ValidationVerdict.ACCEPTED:
+        codes = tuple(
+            sorted(
+                {
+                    PersistenceErrorCode.VALIDATOR_REJECTED_AFTER_READ.value,
+                    *validation.error_codes,
+                }
+            )
+        )
+        return RegistryPersistenceReadResultV1(False, None, str(target), codes)
+
+    return RegistryPersistenceReadResultV1(True, snapshot, str(target), ())
+
+
+__all__ = [
+    "OverwritePolicy",
+    "PERSISTENCE_FORMAT_VERSION",
+    "PersistenceErrorCode",
+    "RegistryPersistenceReadResultV1",
+    "RegistryPersistenceWriteResultV1",
+    "parse_registry_snapshot_dict_v1",
+    "read_registry_snapshot_v1",
+    "registry_snapshot_to_canonical_bytes",
+    "write_registry_snapshot_v1",
+]

--- a/src/research/pit_futures_instrument_lifecycle_registry_v1.py
+++ b/src/research/pit_futures_instrument_lifecycle_registry_v1.py
@@ -1523,3 +1523,28 @@ def assemble_registry_snapshot_v1(
     )
     final_snapshot = attach_snapshot_digest(snapshot)
     return RegistryAssemblyResultV1(True, final_snapshot, (), ())
+
+
+def registry_snapshot_to_dict(
+    snapshot: RegistrySnapshotV1,
+    *,
+    include_digest: bool = True,
+) -> dict[str, Any]:
+    """Deterministic snapshot dict for canonical persistence (Slice C)."""
+    return {
+        "config_digest": snapshot.config_digest,
+        "conflict_resolution_policy_version": snapshot.conflict_resolution_policy_version,
+        "generated_at": snapshot.generated_at,
+        "implementation_digest": snapshot.implementation_digest,
+        "intervals": [
+            _interval_to_dict(interval, include_digest=include_digest)
+            for interval in snapshot.intervals
+        ],
+        "policy_version": snapshot.policy_version,
+        "registry_snapshot_digest": snapshot.registry_snapshot_digest,
+        "registry_snapshot_version": snapshot.registry_snapshot_version,
+        "schema_name": snapshot.schema_name,
+        "schema_version": snapshot.schema_version,
+        "source_priority_policy_version": snapshot.source_priority_policy_version,
+        "venue_scope": list(snapshot.venue_scope),
+    }

--- a/tests/research/test_pit_futures_instrument_lifecycle_registry_persistence_v1.py
+++ b/tests/research/test_pit_futures_instrument_lifecycle_registry_persistence_v1.py
@@ -1,0 +1,468 @@
+"""Contract tests for pit_futures_instrument_lifecycle_registry_persistence_v1 — Slice C."""
+
+from __future__ import annotations
+
+import dataclasses
+import itertools
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from src.research.pit_futures_instrument_lifecycle_registry_persistence_v1 import (
+    OverwritePolicy,
+    PersistenceErrorCode,
+    parse_registry_snapshot_dict_v1,
+    read_registry_snapshot_v1,
+    registry_snapshot_to_canonical_bytes,
+    write_registry_snapshot_v1,
+)
+from src.research.pit_futures_instrument_lifecycle_registry_v1 import (
+    INPUT_CONTRACT_VERSION,
+    REGISTRY_VERSION,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    InstrumentLifecycleIntervalV1,
+    LifecycleRegistryErrorCode,
+    ObservationKind,
+    RegistrySnapshotV1,
+    SourceObservationRecordV1,
+    SourceTrustLevel,
+    SuspensionSubIntervalV1,
+    assemble_registry_snapshot_v1,
+    assemble_registry_snapshot_v1,
+    attach_snapshot_digest,
+    build_interval_from_observation_v1,
+    compute_interval_digest,
+    compute_observation_digest,
+    compute_registry_snapshot_digest,
+    normalize_source_observation_record_v1,
+    registry_snapshot_to_dict,
+)
+from src.research.pit_futures_instrument_lifecycle_registry_validator_v1 import (
+    ValidationVerdict,
+    validate_pit_futures_instrument_lifecycle_registry_snapshot_v1,
+)
+
+_SOURCE_ID = "synthetic:test:record:v0"
+_SNAPSHOT_REF = "synthetic:test:snapshot:v0"
+_LISTING = "2024-01-01T00:00:00Z"
+_ELIGIBLE = "2024-01-02T00:00:00Z"
+_GENERATED_AT = "2026-07-03T02:00:00Z"
+_CONFIG_DIGEST = "b" * 64
+_IMPL_DIGEST = "c" * 64
+
+
+def _observation_payload(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "base_asset": "ETH",
+        "contract_type": "linear_perpetual",
+        "correction_provenance_ref": None,
+        "delisting_time": None,
+        "eligible_from": _ELIGIBLE,
+        "eligible_until": None,
+        "expiry_time": None,
+        "listing_time": _LISTING,
+        "market_type": "futures",
+        "native_instrument_id": None,
+        "observation_kind": ObservationKind.LISTING.value,
+        "quote_asset": "USDT",
+        "settlement_asset": "USDT",
+        "source_effective_at": _LISTING,
+        "source_id": _SOURCE_ID,
+        "source_observed_at": _LISTING,
+        "source_priority": 1,
+        "source_snapshot_digest": "a" * 64,
+        "source_snapshot_ref": _SNAPSHOT_REF,
+        "venue_id": "okx",
+        "venue_symbol": "ETH-USDT-SWAP",
+        "venue_timezone": "UTC",
+    }
+    base.update(overrides)
+    return base
+
+
+def _source_record(**overrides: object) -> SourceObservationRecordV1:
+    payload = _observation_payload(**overrides)
+    record = SourceObservationRecordV1(
+        input_contract_version=INPUT_CONTRACT_VERSION,
+        source_id=str(payload["source_id"]),
+        source_trust_level=SourceTrustLevel.TRUSTED.value,
+        source_priority=int(payload["source_priority"]),  # type: ignore[arg-type]
+        source_snapshot_ref=str(payload["source_snapshot_ref"]),
+        source_snapshot_digest=str(payload["source_snapshot_digest"]),
+        source_observed_at=str(payload["source_observed_at"]),
+        source_effective_at=str(payload["source_effective_at"]),
+        venue_id=str(payload["venue_id"]),
+        venue_timezone=str(payload["venue_timezone"]),
+        market_type=str(payload["market_type"]),
+        contract_type=str(payload["contract_type"]),
+        base_asset=str(payload["base_asset"]),
+        quote_asset=str(payload["quote_asset"]),
+        settlement_asset=str(payload["settlement_asset"]),
+        observation_kind=str(payload["observation_kind"]),
+        observation_digest="0" * 64,
+        venue_symbol=str(payload["venue_symbol"]) if payload.get("venue_symbol") else None,
+        native_instrument_id=(
+            str(payload["native_instrument_id"]) if payload.get("native_instrument_id") else None
+        ),
+        contract_expiry=str(payload["contract_expiry"]) if payload.get("contract_expiry") else None,
+        listing_time=str(payload["listing_time"]) if payload.get("listing_time") else None,
+        eligible_from=str(payload["eligible_from"]) if payload.get("eligible_from") else None,
+        delisting_time=str(payload["delisting_time"]) if payload.get("delisting_time") else None,
+        eligible_until=str(payload["eligible_until"]) if payload.get("eligible_until") else None,
+        expiry_time=str(payload["expiry_time"]) if payload.get("expiry_time") else None,
+        correction_provenance_ref=(
+            str(payload["correction_provenance_ref"])
+            if payload.get("correction_provenance_ref")
+            else None
+        ),
+    )
+    return dataclasses.replace(record, observation_digest=compute_observation_digest(record))
+
+
+def _normalize(**overrides: object):
+    result = normalize_source_observation_record_v1(_source_record(**overrides))
+    assert result.success, result.error_codes
+    assert result.observation is not None
+    return result.observation
+
+
+def _assembled_snapshot(*records: SourceObservationRecordV1) -> RegistrySnapshotV1:
+    result = assemble_registry_snapshot_v1(
+        records,
+        generated_at=_GENERATED_AT,
+        venue_scope=("okx",),
+        config_digest=_CONFIG_DIGEST,
+        implementation_digest=_IMPL_DIGEST,
+    )
+    assert result.success, result.error_codes
+    assert result.snapshot is not None
+    return result.snapshot
+
+
+def _manual_snapshot(*intervals: InstrumentLifecycleIntervalV1) -> RegistrySnapshotV1:
+    snap = RegistrySnapshotV1(
+        schema_name=SCHEMA_NAME,
+        schema_version=SCHEMA_VERSION,
+        registry_snapshot_version=1,
+        policy_version=REGISTRY_VERSION,
+        source_priority_policy_version="source_priority_policy.v1",
+        conflict_resolution_policy_version="conflict_resolution_policy.v1",
+        venue_scope=("okx",),
+        generated_at=_GENERATED_AT,
+        intervals=intervals,
+        config_digest=_CONFIG_DIGEST,
+        implementation_digest=_IMPL_DIGEST,
+        registry_snapshot_digest="0" * 64,
+    )
+    return attach_snapshot_digest(snap)
+
+
+def test_write_read_roundtrip_semantically_identical(tmp_path: Path) -> None:
+    original = _assembled_snapshot(_source_record())
+    write_result = write_registry_snapshot_v1(
+        original,
+        root_dir=tmp_path,
+        relative_path=Path("registry/v1/snapshot.json"),
+    )
+    assert write_result.success is True
+    assert write_result.bytes_written > 0
+
+    read_result = read_registry_snapshot_v1(
+        root_dir=tmp_path,
+        relative_path=Path("registry/v1/snapshot.json"),
+    )
+    assert read_result.success is True
+    assert read_result.snapshot is not None
+    assert read_result.snapshot == original
+
+
+def test_identical_input_produces_byte_identical_output(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    path_a = tmp_path / "a"
+    path_b = tmp_path / "b"
+    path_a.mkdir()
+    path_b.mkdir()
+
+    write_registry_snapshot_v1(snap, root_dir=path_a, relative_path=Path("snap.json"))
+    write_registry_snapshot_v1(snap, root_dir=path_b, relative_path=Path("snap.json"))
+
+    assert (path_a / "snap.json").read_bytes() == (path_b / "snap.json").read_bytes()
+    assert registry_snapshot_to_canonical_bytes(snap) == (path_a / "snap.json").read_bytes()
+
+
+def test_writer_rejects_invalid_snapshot_without_file_mutation(tmp_path: Path) -> None:
+    interval = build_interval_from_observation_v1(_normalize())
+    assert interval is not None
+    snap = _manual_snapshot(interval)
+    bad = dataclasses.replace(snap, registry_snapshot_digest="f" * 64)
+    target = Path("registry/bad.json")
+
+    result = write_registry_snapshot_v1(bad, root_dir=tmp_path, relative_path=target)
+    assert result.success is False
+    assert PersistenceErrorCode.VALIDATOR_REJECTED_BEFORE_WRITE.value in result.error_codes
+    assert LifecycleRegistryErrorCode.DIGEST_MISMATCH.value in result.error_codes
+    assert not (tmp_path / target).exists()
+    assert list(tmp_path.glob(".tmp_*")) == []
+
+
+def test_reader_rejects_manipulated_snapshot(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    target = tmp_path / "registry" / "snap.json"
+    write_registry_snapshot_v1(snap, root_dir=tmp_path, relative_path=Path("registry/snap.json"))
+
+    raw = json.loads(target.read_text(encoding="utf-8"))
+    raw["intervals"][0]["eligible_from"] = "2024-01-09T00:00:00Z"
+    target.write_text(json.dumps(raw), encoding="utf-8")
+
+    result = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=Path("registry/snap.json"))
+    assert result.success is False
+    assert PersistenceErrorCode.VALIDATOR_REJECTED_AFTER_READ.value in result.error_codes
+    assert LifecycleRegistryErrorCode.DIGEST_MISMATCH.value in result.error_codes
+
+
+def test_reader_rejects_truncated_file(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    rel = Path("registry/snap.json")
+    write_registry_snapshot_v1(snap, root_dir=tmp_path, relative_path=rel)
+    path = tmp_path / rel
+    path.write_bytes(path.read_bytes()[:20])
+
+    result = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=rel)
+    assert result.success is False
+    assert PersistenceErrorCode.INVALID_JSON.value in result.error_codes
+
+
+def test_reader_rejects_empty_file(tmp_path: Path) -> None:
+    rel = Path("registry/empty.json")
+    (tmp_path / "registry").mkdir(parents=True)
+    (tmp_path / rel).write_text("", encoding="utf-8")
+
+    result = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=rel)
+    assert result.success is False
+    assert PersistenceErrorCode.TRUNCATED_FILE.value in result.error_codes
+
+
+def test_reader_rejects_unknown_schema_version(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    payload = registry_snapshot_to_dict(snap)
+    payload["schema_version"] = "v99"
+    (tmp_path / "snap.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    result = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=Path("snap.json"))
+    assert result.success is False
+    assert PersistenceErrorCode.UNKNOWN_SCHEMA_VERSION.value in result.error_codes
+
+
+def test_reader_rejects_unknown_top_level_field(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    payload = registry_snapshot_to_dict(snap)
+    payload["unexpected_field"] = True
+    (tmp_path / "snap.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    result = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=Path("snap.json"))
+    assert result.success is False
+    assert PersistenceErrorCode.UNKNOWN_FIELD.value in result.error_codes
+
+
+def test_reader_rejects_unknown_interval_field(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    payload = registry_snapshot_to_dict(snap)
+    payload["intervals"][0]["extra"] = "x"
+    (tmp_path / "snap.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    result = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=Path("snap.json"))
+    assert result.success is False
+    assert PersistenceErrorCode.UNKNOWN_FIELD.value in result.error_codes
+
+
+def test_reader_rejects_digest_mismatch(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    payload = registry_snapshot_to_dict(snap)
+    payload["registry_snapshot_digest"] = "f" * 64
+    (tmp_path / "snap.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    result = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=Path("snap.json"))
+    assert result.success is False
+    assert LifecycleRegistryErrorCode.DIGEST_MISMATCH.value in result.error_codes
+
+
+def test_writer_rejects_path_traversal(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    result = write_registry_snapshot_v1(
+        snap,
+        root_dir=tmp_path,
+        relative_path=Path("../escape.json"),
+    )
+    assert result.success is False
+    assert PersistenceErrorCode.PATH_TRAVERSAL_FORBIDDEN.value in result.error_codes
+
+
+def test_writer_rejects_absolute_path(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    result = write_registry_snapshot_v1(
+        snap,
+        root_dir=tmp_path,
+        relative_path=Path("/etc/passwd"),
+    )
+    assert result.success is False
+    assert PersistenceErrorCode.PATH_OUTSIDE_ROOT.value in result.error_codes
+
+
+def test_existing_snapshot_immutable_without_overwrite_policy(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    rel = Path("registry/v1.json")
+    first = write_registry_snapshot_v1(snap, root_dir=tmp_path, relative_path=rel)
+    assert first.success is True
+    original_bytes = (tmp_path / rel).read_bytes()
+
+    second = write_registry_snapshot_v1(snap, root_dir=tmp_path, relative_path=rel)
+    assert second.success is False
+    assert PersistenceErrorCode.TARGET_EXISTS.value in second.error_codes
+    assert (tmp_path / rel).read_bytes() == original_bytes
+
+
+def test_correction_writes_new_version_path(tmp_path: Path) -> None:
+    prior = _assembled_snapshot(_source_record())
+    revised_result = assemble_registry_snapshot_v1(
+        (
+            _source_record(),
+            _source_record(base_asset="SOL", venue_symbol="SOL-USDT-SWAP"),
+        ),
+        generated_at="2026-07-03T03:00:00Z",
+        venue_scope=("okx",),
+        config_digest=_CONFIG_DIGEST,
+        implementation_digest=_IMPL_DIGEST,
+        registry_snapshot_version=2,
+    )
+    assert revised_result.success is True
+    assert revised_result.snapshot is not None
+    revised = revised_result.snapshot
+
+    v1_path = Path("registry/v1.json")
+    v2_path = Path("registry/v2.json")
+    assert write_registry_snapshot_v1(prior, root_dir=tmp_path, relative_path=v1_path).success
+    v1_bytes = (tmp_path / v1_path).read_bytes()
+    assert write_registry_snapshot_v1(revised, root_dir=tmp_path, relative_path=v2_path).success
+
+    v1_read = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=v1_path)
+    v2_read = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=v2_path)
+    assert v1_read.success and v2_read.success
+    assert v1_read.snapshot is not None and v2_read.snapshot is not None
+    assert v1_read.snapshot.registry_snapshot_version == 1
+    assert v2_read.snapshot.registry_snapshot_version == 2
+    assert (tmp_path / v1_path).read_bytes() == v1_bytes
+
+
+def test_atomic_write_leaves_no_partial_target_on_validation_failure(tmp_path: Path) -> None:
+    interval = build_interval_from_observation_v1(_normalize())
+    assert interval is not None
+    snap = _manual_snapshot(interval)
+    bad = dataclasses.replace(snap, registry_snapshot_digest="f" * 64)
+    rel = Path("registry/partial.json")
+    (tmp_path / "registry").mkdir(parents=True)
+    sentinel = tmp_path / "registry" / ".sentinel"
+    sentinel.write_text("ok", encoding="utf-8")
+
+    result = write_registry_snapshot_v1(bad, root_dir=tmp_path, relative_path=rel)
+    assert result.success is False
+    assert not (tmp_path / rel).exists()
+    assert sentinel.read_text(encoding="utf-8") == "ok"
+
+
+def test_atomic_replace_no_tmp_leftover(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    rel = Path("registry/snap.json")
+    result = write_registry_snapshot_v1(snap, root_dir=tmp_path, relative_path=rel)
+    assert result.success is True
+    assert list(tmp_path.rglob(".tmp_*")) == []
+
+
+def test_deterministic_serialization_independent_of_interval_input_order() -> None:
+    listing = _source_record()
+    sol = _source_record(base_asset="SOL", venue_symbol="SOL-USDT-SWAP")
+    digests: set[bytes] = set()
+    for batch in itertools.permutations((listing, sol)):
+        snap = _assembled_snapshot(*batch)
+        digests.add(registry_snapshot_to_canonical_bytes(snap))
+    assert len(digests) == 1
+
+
+def test_reader_result_revalidates_with_slice_b_validator(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    rel = Path("registry/snap.json")
+    write_registry_snapshot_v1(snap, root_dir=tmp_path, relative_path=rel)
+    read_result = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=rel)
+    assert read_result.success is True
+    assert read_result.snapshot is not None
+    validation = validate_pit_futures_instrument_lifecycle_registry_snapshot_v1(
+        read_result.snapshot
+    )
+    assert validation.verdict == ValidationVerdict.ACCEPTED
+
+
+def test_allow_replace_explicit_overwrite_policy(tmp_path: Path) -> None:
+    snap = _assembled_snapshot(_source_record())
+    rel = Path("registry/snap.json")
+    assert write_registry_snapshot_v1(snap, root_dir=tmp_path, relative_path=rel).success
+    first_bytes = (tmp_path / rel).read_bytes()
+
+    assert write_registry_snapshot_v1(
+        snap,
+        root_dir=tmp_path,
+        relative_path=rel,
+        overwrite_policy=OverwritePolicy.ALLOW_REPLACE,
+    ).success
+    second_bytes = (tmp_path / rel).read_bytes()
+    assert first_bytes == second_bytes
+
+
+def test_parse_registry_snapshot_dict_roundtrip() -> None:
+    snap = _assembled_snapshot(_source_record())
+    payload = registry_snapshot_to_dict(snap)
+    parsed, errors = parse_registry_snapshot_dict_v1(payload)
+    assert errors == ()
+    assert parsed == snap
+
+
+def test_reader_rejects_current_state_fallback_marker_in_persisted_file(
+    tmp_path: Path,
+) -> None:
+    interval = build_interval_from_observation_v1(_normalize())
+    assert interval is not None
+    bad = dataclasses.replace(
+        interval,
+        instrument_id="okx:linear_perpetual:current_state:USDT:USDT:perp",
+    )
+    bad = dataclasses.replace(bad, record_digest=compute_interval_digest(bad))
+    snap = _manual_snapshot(bad)
+    payload = registry_snapshot_to_dict(snap)
+    (tmp_path / "snap.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    result = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=Path("snap.json"))
+    assert result.success is False
+    assert LifecycleRegistryErrorCode.UNKNOWN_LIFECYCLE_STATE.value in result.error_codes
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics required")
+def test_writer_rejects_symlink_escape(tmp_path: Path) -> None:
+    outside = tmp_path.parent / f"{tmp_path.name}_outside"
+    outside.mkdir(exist_ok=True)
+    link = tmp_path / "link.json"
+    link.symlink_to(outside / "target.json")
+    snap = _assembled_snapshot(_source_record())
+
+    result = write_registry_snapshot_v1(snap, root_dir=tmp_path, relative_path=Path("link.json"))
+    assert result.success is False
+    assert PersistenceErrorCode.SYMLINK_FORBIDDEN.value in result.error_codes
+
+
+def test_registry_snapshot_digest_stable_across_to_dict_and_bytes() -> None:
+    snap = _assembled_snapshot(_source_record())
+    payload = registry_snapshot_to_dict(snap)
+    parsed, _ = parse_registry_snapshot_dict_v1(payload)
+    assert parsed is not None
+    assert parsed.registry_snapshot_digest == snap.registry_snapshot_digest
+    assert compute_registry_snapshot_digest(parsed) == snap.registry_snapshot_digest


### PR DESCRIPTION
## Summary
- Add bounded offline persistence (`write_registry_snapshot_v1` / `read_registry_snapshot_v1`) for validated historical PIT futures instrument lifecycle registry snapshots.
- Enforce validator-before-write and validator-after-read fail-closed semantics, canonical `dumps_canonical` serialization, atomic replace writes, and immutable overwrite defaults.
- Add focused Slice C contract tests (roundtrip, byte determinism, corruption/version/fallback/traversal negatives) plus `registry_snapshot_to_dict` export on the registry owner.

## Test plan
- [x] `pytest tests/research/test_pit_futures_instrument_lifecycle_registry_persistence_v1.py`
- [x] Slice A regression: `test_pit_futures_instrument_lifecycle_registry_v1.py`
- [x] Slice B regression: `test_pit_futures_instrument_lifecycle_registry_validator_v1.py`
- [x] Relevant PIT futures tests (manifest v1/validator/generator)
- [x] `ruff format --check` + `ruff check` on changed files


Made with [Cursor](https://cursor.com)