### PR TITLE
feat(research): PIT futures lifecycle registry slice D generator read-only binding v0

### DIFF
--- a/src/research/pit_futures_universe_manifest_generator_registry_consumer_binding_v1.py
+++ b/src/research/pit_futures_universe_manifest_generator_registry_consumer_binding_v1.py
@@ -1,0 +1,486 @@
+"""Read-only registry consumer binding for pit_futures_universe_manifest_generator_v1 — Slice D.
+
+Research-only, non-authorizing. Pure offline binding: no I/O, no network, no clock.
+Consumes an explicit validated registry snapshot; never writes, repairs, or reconstructs registry data.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from src.research.pit_futures_instrument_lifecycle_registry_v1 import (
+    SCHEMA_VERSION,
+    InstrumentLifecycleIntervalV1,
+    RegistrySnapshotV1,
+    format_registry_reference_v1,
+    query_lifecycle_at_snapshot_v1,
+)
+from src.research.pit_futures_instrument_lifecycle_registry_validator_v1 import (
+    ValidationVerdict,
+    validate_pit_futures_instrument_lifecycle_registry_snapshot_v1,
+)
+from src.research.pit_futures_universe_manifest_generator_v1 import (
+    GENERATOR_VERSION,
+    INPUT_CONTRACT_VERSION,
+    GeneratorEpochInputV1,
+    PitFuturesUniverseManifestGeneratorInputV1,
+    PitFuturesUniverseManifestGeneratorResultV1,
+    RawInstrumentRecordV1,
+    generate_pit_futures_universe_manifest_v1,
+)
+from src.research.pit_futures_universe_manifest_v1 import (
+    PointInTimeFuturesUniverseManifestV1,
+    compute_sha256_digest,
+    is_valid_digest,
+    is_valid_rfc3339_utc,
+)
+
+PACKAGE_MARKER = "PIT_FUTURES_UNIVERSE_MANIFEST_GENERATOR_REGISTRY_CONSUMER_BINDING_V1=true"
+BINDING_VERSION = "pit_futures_universe_manifest_generator_registry_consumer_binding.v1"
+BINDING_INPUT_CONTRACT_VERSION = (
+    "pit_futures_universe_manifest_generator_registry_consumer_binding_input.v1"
+)
+BINDING_MODULE_NAME = "pit_futures_universe_manifest_generator_registry_consumer_binding_v1"
+
+_SUPPORTED_REGISTRY_SCHEMA_VERSIONS = frozenset({SCHEMA_VERSION})
+_CURRENT_STATE_FALLBACK_MARKERS = frozenset(
+    {"current_state", "use_current_state", "fallback_to_current", "now()", "latest"}
+)
+_ABSOLUTE_PATH_PATTERN = re.compile(r"(^/|^\\\\|^[A-Za-z]:[/\\\\])")
+
+
+class RegistryBindingErrorCode(str, Enum):
+    INVALID_BINDING_INPUT = "INVALID_BINDING_INPUT"
+    MISSING_REGISTRY = "MISSING_REGISTRY"
+    CORRUPT_REGISTRY = "CORRUPT_REGISTRY"
+    REGISTRY_DIGEST_MISMATCH = "REGISTRY_DIGEST_MISMATCH"
+    REGISTRY_VERSION_MISMATCH = "REGISTRY_VERSION_MISMATCH"
+    UNSUPPORTED_REGISTRY_VERSION = "UNSUPPORTED_REGISTRY_VERSION"
+    UNKNOWN_HISTORICAL_MEMBERSHIP = "UNKNOWN_HISTORICAL_MEMBERSHIP"
+    AMBIGUOUS_INSTRUMENT_LIFECYCLE = "AMBIGUOUS_INSTRUMENT_LIFECYCLE"
+    MISSING_SUPPLEMENTARY_MARKET_DATA = "MISSING_SUPPLEMENTARY_MARKET_DATA"
+    CURRENT_STATE_FALLBACK_BLOCKED = "CURRENT_STATE_FALLBACK_BLOCKED"
+    GENERATOR_FAILED = "GENERATOR_FAILED"
+
+
+@dataclass(frozen=True)
+class SupplementaryInstrumentMarketDataV1:
+    instrument_id: str
+    source_ref: str
+    record_digest: str
+    market_type: str
+    history_bars_available: int
+    required_history_bars: int
+    data_availability_status: str
+
+
+@dataclass(frozen=True)
+class RegistryBoundEpochInputV1:
+    score_epoch: int
+    finalized_bar_close: str
+    historical_as_of_time: str
+
+
+@dataclass(frozen=True)
+class PitFuturesUniverseManifestGeneratorRegistryBindingInputV1:
+    binding_input_contract_version: str
+    binding_version: str
+    registry_artifact_id: str
+    bound_registry_schema_version: str
+    bound_registry_snapshot_version: int
+    bound_registry_snapshot_digest: str
+    registry_snapshot: RegistrySnapshotV1 | None
+    input_contract_version: str
+    artifact_id: str
+    venue_id: str
+    universe_id: str
+    hypothesis_id: str
+    universe_policy_id: str
+    universe_policy_version: str
+    inclusion_policy_version: str
+    exclusion_policy_version: str
+    generator_version: str
+    generated_at: str
+    bar_interval: str
+    minimum_history_bars: int
+    minimum_required_member_count: int
+    venue_scope: tuple[str, ...]
+    source_snapshot_refs: tuple[str, ...]
+    source_digests: tuple[str, ...]
+    period_binding_ref: str
+    config_digest: str
+    implementation_digest: str
+    supplementary_market_data: tuple[SupplementaryInstrumentMarketDataV1, ...]
+    epochs: tuple[RegistryBoundEpochInputV1, ...]
+
+
+@dataclass(frozen=True)
+class RegistryBindingProvenanceV1:
+    registry_schema_version: str
+    registry_schema_name: str
+    registry_artifact_id: str
+    registry_snapshot_version: int
+    registry_content_digest: str
+    registry_reference: str
+    registry_policy_version: str
+    historical_as_of_times: tuple[str, ...]
+    generator_config_digest: str
+    generator_implementation_digest: str
+    binding_version: str
+    binding_implementation_digest: str
+    output_manifest_digest: str | None
+
+
+@dataclass(frozen=True)
+class PitFuturesUniverseManifestGeneratorRegistryBindingResultV1:
+    success: bool
+    manifest: PointInTimeFuturesUniverseManifestV1 | None
+    manifest_reference: str | None
+    generator_result: PitFuturesUniverseManifestGeneratorResultV1 | None
+    provenance: RegistryBindingProvenanceV1 | None
+    error_codes: tuple[str, ...]
+    generator_error_codes: tuple[str, ...] = ()
+    validator_reason_codes: tuple[str, ...] = ()
+
+
+def _add(errors: list[str], code: RegistryBindingErrorCode) -> None:
+    value = code.value
+    if value not in errors:
+        errors.append(value)
+
+
+def _validate_source_ref(value: str, errors: list[str]) -> bool:
+    if not value.strip():
+        _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+        return False
+    if _ABSOLUTE_PATH_PATTERN.search(value):
+        _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+        return False
+    lowered = value.strip().lower()
+    for marker in _CURRENT_STATE_FALLBACK_MARKERS:
+        if marker in lowered:
+            _add(errors, RegistryBindingErrorCode.CURRENT_STATE_FALLBACK_BLOCKED)
+            return False
+    return True
+
+
+def _compute_binding_implementation_digest_payload() -> dict[str, str]:
+    return {
+        "binding_version": BINDING_VERSION,
+        "module": BINDING_MODULE_NAME,
+    }
+
+
+def compute_binding_implementation_digest() -> str:
+    return compute_sha256_digest(_compute_binding_implementation_digest_payload())
+
+
+def _active_intervals(snapshot: RegistrySnapshotV1) -> dict[str, InstrumentLifecycleIntervalV1]:
+    grouped: dict[str, list[InstrumentLifecycleIntervalV1]] = {}
+    for interval in snapshot.intervals:
+        if interval.superseded_by_version is not None:
+            continue
+        grouped.setdefault(interval.instrument_id, []).append(interval)
+
+    resolved: dict[str, InstrumentLifecycleIntervalV1] = {}
+    for instrument_id, intervals in grouped.items():
+        if len(intervals) > 1:
+            return {"__AMBIGUOUS__": intervals[0]}
+        resolved[instrument_id] = intervals[0]
+    return resolved
+
+
+def _interval_to_raw_record(
+    interval: InstrumentLifecycleIntervalV1,
+    supplementary: SupplementaryInstrumentMarketDataV1,
+) -> RawInstrumentRecordV1:
+    return RawInstrumentRecordV1(
+        source_ref=supplementary.source_ref.strip(),
+        record_digest=supplementary.record_digest.strip().lower(),
+        venue_id=interval.venue_id.strip().lower(),
+        market_type=supplementary.market_type.strip().lower(),
+        contract_type=interval.contract_type.strip().lower(),
+        base_asset=interval.base_asset.strip().upper(),
+        quote_asset=interval.quote_asset.strip().upper(),
+        settlement_asset=interval.settlement_asset.strip().upper(),
+        venue_symbol=(interval.venue_symbol or "").strip(),
+        native_instrument_id=interval.native_instrument_id,
+        contract_expiry=interval.contract_expiry,
+        listing_time=interval.listing_time,
+        delisting_time=interval.delisting_time,
+        eligible_from=interval.eligible_from,
+        eligible_until=interval.eligible_until,
+        expiry_time=interval.expiry_time,
+        history_bars_available=supplementary.history_bars_available,
+        required_history_bars=supplementary.required_history_bars,
+        data_availability_status=supplementary.data_availability_status.strip().upper(),
+    )
+
+
+def _validate_binding_input(
+    inp: PitFuturesUniverseManifestGeneratorRegistryBindingInputV1,
+) -> list[str]:
+    errors: list[str] = []
+
+    if inp.binding_input_contract_version != BINDING_INPUT_CONTRACT_VERSION:
+        _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+    if inp.binding_version != BINDING_VERSION:
+        _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+    if inp.input_contract_version != INPUT_CONTRACT_VERSION:
+        _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+    if inp.generator_version != GENERATOR_VERSION:
+        _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+
+    if not inp.registry_artifact_id.strip():
+        _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+    if inp.bound_registry_schema_version not in _SUPPORTED_REGISTRY_SCHEMA_VERSIONS:
+        _add(errors, RegistryBindingErrorCode.UNSUPPORTED_REGISTRY_VERSION)
+    if not is_valid_digest(inp.bound_registry_snapshot_digest.strip().lower()):
+        _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+    if inp.bound_registry_snapshot_version < 1:
+        _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+
+    if inp.registry_snapshot is None:
+        _add(errors, RegistryBindingErrorCode.MISSING_REGISTRY)
+        return sorted(errors)
+
+    snapshot = inp.registry_snapshot
+    if snapshot.schema_version != inp.bound_registry_schema_version:
+        _add(errors, RegistryBindingErrorCode.UNSUPPORTED_REGISTRY_VERSION)
+    if snapshot.registry_snapshot_version != inp.bound_registry_snapshot_version:
+        _add(errors, RegistryBindingErrorCode.REGISTRY_VERSION_MISMATCH)
+    if snapshot.registry_snapshot_digest != inp.bound_registry_snapshot_digest.strip().lower():
+        _add(errors, RegistryBindingErrorCode.REGISTRY_DIGEST_MISMATCH)
+
+    for ref in inp.source_snapshot_refs:
+        _validate_source_ref(ref, errors)
+    _validate_source_ref(inp.period_binding_ref, errors)
+
+    if not inp.epochs:
+        _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+
+    for epoch in inp.epochs:
+        if not is_valid_rfc3339_utc(epoch.finalized_bar_close):
+            _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+        if not is_valid_rfc3339_utc(epoch.historical_as_of_time):
+            _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+        if epoch.finalized_bar_close != epoch.historical_as_of_time:
+            _add(errors, RegistryBindingErrorCode.INVALID_BINDING_INPUT)
+
+    if not errors and snapshot is not None:
+        validation = validate_pit_futures_instrument_lifecycle_registry_snapshot_v1(snapshot)
+        if validation.verdict != ValidationVerdict.ACCEPTED:
+            _add(errors, RegistryBindingErrorCode.CORRUPT_REGISTRY)
+
+    return sorted(errors)
+
+
+def _resolve_epoch_records(
+    *,
+    snapshot: RegistrySnapshotV1,
+    supplementary_by_id: dict[str, SupplementaryInstrumentMarketDataV1],
+    active_by_id: dict[str, InstrumentLifecycleIntervalV1],
+    query_instant: str,
+    errors: list[str],
+) -> tuple[RawInstrumentRecordV1, ...]:
+    records: list[RawInstrumentRecordV1] = []
+
+    for instrument_id in sorted(active_by_id):
+        interval = active_by_id[instrument_id]
+        query = query_lifecycle_at_snapshot_v1(
+            snapshot,
+            instrument_id=instrument_id,
+            query_instant=query_instant,
+        )
+        if query.error_codes:
+            if RegistryBindingErrorCode.UNKNOWN_HISTORICAL_MEMBERSHIP.value not in errors:
+                _add(errors, RegistryBindingErrorCode.UNKNOWN_HISTORICAL_MEMBERSHIP)
+            continue
+
+        supplementary = supplementary_by_id.get(instrument_id)
+        if supplementary is None:
+            _add(errors, RegistryBindingErrorCode.MISSING_SUPPLEMENTARY_MARKET_DATA)
+            continue
+
+        records.append(_interval_to_raw_record(interval, supplementary))
+
+    return tuple(records)
+
+
+def generate_pit_futures_universe_manifest_from_registry_binding_v1(
+    binding_input: PitFuturesUniverseManifestGeneratorRegistryBindingInputV1,
+) -> PitFuturesUniverseManifestGeneratorRegistryBindingResultV1:
+    """Bind an explicit validated registry snapshot to the offline manifest generator."""
+    errors = _validate_binding_input(binding_input)
+    if errors:
+        return PitFuturesUniverseManifestGeneratorRegistryBindingResultV1(
+            False,
+            None,
+            None,
+            None,
+            None,
+            tuple(errors),
+        )
+
+    assert binding_input.registry_snapshot is not None
+    snapshot = binding_input.registry_snapshot
+
+    active_by_id = _active_intervals(snapshot)
+    if "__AMBIGUOUS__" in active_by_id:
+        return PitFuturesUniverseManifestGeneratorRegistryBindingResultV1(
+            False,
+            None,
+            None,
+            None,
+            None,
+            (RegistryBindingErrorCode.AMBIGUOUS_INSTRUMENT_LIFECYCLE.value,),
+        )
+
+    supplementary_by_id: dict[str, SupplementaryInstrumentMarketDataV1] = {}
+    for item in binding_input.supplementary_market_data:
+        key = item.instrument_id.strip()
+        if key in supplementary_by_id:
+            return PitFuturesUniverseManifestGeneratorRegistryBindingResultV1(
+                False,
+                None,
+                None,
+                None,
+                None,
+                (RegistryBindingErrorCode.INVALID_BINDING_INPUT.value,),
+            )
+        supplementary_by_id[key] = item
+
+    for instrument_id in sorted(supplementary_by_id):
+        if instrument_id not in active_by_id:
+            return PitFuturesUniverseManifestGeneratorRegistryBindingResultV1(
+                False,
+                None,
+                None,
+                None,
+                None,
+                (RegistryBindingErrorCode.UNKNOWN_HISTORICAL_MEMBERSHIP.value,),
+            )
+
+    registry_reference = format_registry_reference_v1(
+        artifact_id=binding_input.registry_artifact_id.strip(),
+        registry_snapshot_digest=snapshot.registry_snapshot_digest,
+    )
+    merged_refs = tuple(
+        sorted({registry_reference, *(ref.strip() for ref in binding_input.source_snapshot_refs)})
+    )
+    merged_digests = tuple(
+        digest.strip().lower()
+        for digest in (
+            snapshot.registry_snapshot_digest,
+            *binding_input.source_digests,
+        )
+    )
+
+    generator_epochs: list[GeneratorEpochInputV1] = []
+    for epoch in sorted(binding_input.epochs, key=lambda item: item.score_epoch):
+        epoch_errors: list[str] = []
+        raw_records = _resolve_epoch_records(
+            snapshot=snapshot,
+            supplementary_by_id=supplementary_by_id,
+            active_by_id=active_by_id,
+            query_instant=epoch.historical_as_of_time,
+            errors=epoch_errors,
+        )
+        if epoch_errors:
+            return PitFuturesUniverseManifestGeneratorRegistryBindingResultV1(
+                False,
+                None,
+                None,
+                None,
+                None,
+                tuple(sorted(set(epoch_errors))),
+            )
+        generator_epochs.append(
+            GeneratorEpochInputV1(
+                score_epoch=epoch.score_epoch,
+                finalized_bar_close=epoch.finalized_bar_close,
+                raw_instrument_records=raw_records,
+            )
+        )
+
+    generator_input = PitFuturesUniverseManifestGeneratorInputV1(
+        input_contract_version=binding_input.input_contract_version,
+        artifact_id=binding_input.artifact_id.strip(),
+        venue_id=binding_input.venue_id.strip().lower(),
+        universe_id=binding_input.universe_id.strip(),
+        hypothesis_id=binding_input.hypothesis_id.strip(),
+        universe_policy_id=binding_input.universe_policy_id.strip(),
+        universe_policy_version=binding_input.universe_policy_version.strip(),
+        inclusion_policy_version=binding_input.inclusion_policy_version.strip(),
+        exclusion_policy_version=binding_input.exclusion_policy_version.strip(),
+        generator_version=binding_input.generator_version,
+        generated_at=binding_input.generated_at,
+        bar_interval=binding_input.bar_interval.strip(),
+        minimum_history_bars=binding_input.minimum_history_bars,
+        minimum_required_member_count=binding_input.minimum_required_member_count,
+        venue_scope=binding_input.venue_scope,
+        source_snapshot_refs=merged_refs,
+        source_digests=merged_digests,
+        period_binding_ref=binding_input.period_binding_ref.strip(),
+        config_digest=binding_input.config_digest.strip().lower(),
+        implementation_digest=binding_input.implementation_digest.strip().lower(),
+        epochs=tuple(generator_epochs),
+    )
+
+    generator_result = generate_pit_futures_universe_manifest_v1(generator_input)
+    if not generator_result.success or generator_result.manifest is None:
+        return PitFuturesUniverseManifestGeneratorRegistryBindingResultV1(
+            False,
+            None,
+            None,
+            generator_result,
+            None,
+            (RegistryBindingErrorCode.GENERATOR_FAILED.value,),
+            generator_result.error_codes,
+            generator_result.validator_reason_codes,
+        )
+
+    provenance = RegistryBindingProvenanceV1(
+        registry_schema_version=snapshot.schema_version,
+        registry_schema_name=snapshot.schema_name,
+        registry_artifact_id=binding_input.registry_artifact_id.strip(),
+        registry_snapshot_version=snapshot.registry_snapshot_version,
+        registry_content_digest=snapshot.registry_snapshot_digest,
+        registry_reference=registry_reference,
+        registry_policy_version=snapshot.policy_version,
+        historical_as_of_times=tuple(
+            epoch.historical_as_of_time
+            for epoch in sorted(binding_input.epochs, key=lambda item: item.score_epoch)
+        ),
+        generator_config_digest=generator_input.config_digest,
+        generator_implementation_digest=generator_input.implementation_digest,
+        binding_version=BINDING_VERSION,
+        binding_implementation_digest=compute_binding_implementation_digest(),
+        output_manifest_digest=generator_result.manifest.manifest_digest,
+    )
+
+    return PitFuturesUniverseManifestGeneratorRegistryBindingResultV1(
+        True,
+        generator_result.manifest,
+        generator_result.manifest_reference,
+        generator_result,
+        provenance,
+        (),
+        generator_result.error_codes,
+        generator_result.validator_reason_codes,
+    )
+
+
+__all__ = [
+    "BINDING_INPUT_CONTRACT_VERSION",
+    "BINDING_VERSION",
+    "RegistryBindingErrorCode",
+    "RegistryBindingProvenanceV1",
+    "RegistryBoundEpochInputV1",
+    "PitFuturesUniverseManifestGeneratorRegistryBindingInputV1",
+    "PitFuturesUniverseManifestGeneratorRegistryBindingResultV1",
+    "SupplementaryInstrumentMarketDataV1",
+    "compute_binding_implementation_digest",
+    "generate_pit_futures_universe_manifest_from_registry_binding_v1",
+]

--- a/tests/research/test_pit_futures_universe_manifest_generator_registry_consumer_binding_v1.py
+++ b/tests/research/test_pit_futures_universe_manifest_generator_registry_consumer_binding_v1.py
@@ -1,0 +1,570 @@
+"""Contract tests for pit_futures_universe_manifest_generator_registry_consumer_binding_v1 — Slice D."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from src.execution.replay_pack.canonical import dumps_canonical
+from src.research.pit_futures_instrument_lifecycle_registry_persistence_v1 import (
+    OverwritePolicy,
+    read_registry_snapshot_v1,
+    write_registry_snapshot_v1,
+)
+from src.research.pit_futures_instrument_lifecycle_registry_v1 import (
+    INPUT_CONTRACT_VERSION,
+    REGISTRY_VERSION,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    InstrumentLifecycleIntervalV1,
+    RegistrySnapshotV1,
+    ObservationKind,
+    QueryState,
+    SourceObservationRecordV1,
+    SourceTrustLevel,
+    assemble_registry_snapshot_v1,
+    attach_snapshot_digest,
+    build_interval_from_observation_v1,
+    compute_observation_digest,
+    query_lifecycle_at_snapshot_v1,
+)
+from src.research.pit_futures_instrument_lifecycle_registry_validator_v1 import (
+    ValidationVerdict,
+    validate_pit_futures_instrument_lifecycle_registry_snapshot_v1,
+)
+from src.research.pit_futures_universe_manifest_generator_registry_consumer_binding_v1 import (
+    BINDING_INPUT_CONTRACT_VERSION,
+    BINDING_VERSION,
+    RegistryBindingErrorCode,
+    RegistryBoundEpochInputV1,
+    PitFuturesUniverseManifestGeneratorRegistryBindingInputV1,
+    SupplementaryInstrumentMarketDataV1,
+    compute_binding_implementation_digest,
+    generate_pit_futures_universe_manifest_from_registry_binding_v1,
+)
+from src.research.pit_futures_universe_manifest_generator_v1 import (
+    GENERATOR_VERSION,
+    INPUT_CONTRACT_VERSION as GENERATOR_INPUT_CONTRACT_VERSION,
+    compute_generator_config_digest,
+    compute_generator_implementation_digest,
+)
+from src.research.pit_futures_universe_manifest_v1 import (
+    compute_manifest_digest,
+    compute_sha256_digest,
+)
+from src.research.pit_futures_universe_manifest_validator_v1 import (
+    ValidationVerdict as ManifestValidationVerdict,
+    validate_pit_futures_universe_manifest_v1,
+)
+
+_SOURCE_ID = "synthetic:test:record:v0"
+_SNAPSHOT_REF = "synthetic:test:snapshot:v0"
+_DATASET_REF = "synthetic:generator:dataset:v0"
+_PERIOD_REF = "synthetic:generator:period:v0"
+_GENERATED_AT = "2026-07-03T03:00:00Z"
+_LISTING = "2024-01-01T00:00:00Z"
+_ELIGIBLE = "2024-01-02T00:00:00Z"
+_BAR_CLOSE = "2024-06-01T01:00:00Z"
+_MIN_HISTORY = 21
+_CONFIG_DIGEST = "b" * 64
+_IMPL_DIGEST = "c" * 64
+_REGISTRY_ARTIFACT_ID = "synthetic_pit_lifecycle_registry_v0"
+
+
+def _source_record(**overrides: object) -> SourceObservationRecordV1:
+    payload = {
+        "base_asset": overrides.get("base_asset", "ETH"),
+        "contract_type": overrides.get("contract_type", "linear_perpetual"),
+        "correction_provenance_ref": None,
+        "delisting_time": overrides.get("delisting_time"),
+        "eligible_from": overrides.get("eligible_from", _ELIGIBLE),
+        "eligible_until": overrides.get("eligible_until"),
+        "expiry_time": overrides.get("expiry_time"),
+        "listing_time": overrides.get("listing_time", _LISTING),
+        "market_type": "futures",
+        "native_instrument_id": None,
+        "observation_kind": overrides.get("observation_kind", ObservationKind.LISTING.value),
+        "quote_asset": "USDT",
+        "settlement_asset": "USDT",
+        "source_effective_at": overrides.get(
+            "source_effective_at", overrides.get("listing_time", _LISTING)
+        ),
+        "source_id": _SOURCE_ID,
+        "source_observed_at": _LISTING,
+        "source_priority": 1,
+        "source_snapshot_digest": "a" * 64,
+        "source_snapshot_ref": _SNAPSHOT_REF,
+        "venue_id": overrides.get("venue_id", "okx"),
+        "venue_symbol": overrides.get("venue_symbol", "ETH-USDT-SWAP"),
+        "venue_timezone": "UTC",
+    }
+    record = SourceObservationRecordV1(
+        input_contract_version=INPUT_CONTRACT_VERSION,
+        source_id=str(payload["source_id"]),
+        source_trust_level=SourceTrustLevel.TRUSTED.value,
+        source_priority=1,
+        source_snapshot_ref=_SNAPSHOT_REF,
+        source_snapshot_digest="a" * 64,
+        source_observed_at=_LISTING,
+        source_effective_at=str(payload["source_effective_at"]),
+        venue_id=str(payload["venue_id"]),
+        venue_timezone="UTC",
+        market_type="futures",
+        contract_type=str(payload["contract_type"]),
+        base_asset=str(payload["base_asset"]),
+        quote_asset="USDT",
+        settlement_asset="USDT",
+        observation_kind=str(payload["observation_kind"]),
+        observation_digest="0" * 64,
+        venue_symbol=str(payload["venue_symbol"]),
+        listing_time=str(payload["listing_time"]) if payload.get("listing_time") else None,
+        eligible_from=str(payload["eligible_from"]) if payload.get("eligible_from") else None,
+        delisting_time=str(payload["delisting_time"]) if payload.get("delisting_time") else None,
+        eligible_until=str(payload["eligible_until"]) if payload.get("eligible_until") else None,
+        expiry_time=str(payload["expiry_time"]) if payload.get("expiry_time") else None,
+    )
+    return dataclasses.replace(record, observation_digest=compute_observation_digest(record))
+
+
+def _assembled_snapshot(*records: SourceObservationRecordV1):
+    result = assemble_registry_snapshot_v1(
+        records,
+        generated_at=_GENERATED_AT,
+        venue_scope=("okx", "binance_usdm"),
+        config_digest=_CONFIG_DIGEST,
+        implementation_digest=_IMPL_DIGEST,
+    )
+    assert result.success, result.error_codes
+    assert result.snapshot is not None
+    return result.snapshot
+
+
+def _supplementary(
+    instrument_id: str, *, suffix: str = "eth", history: int = 30
+) -> SupplementaryInstrumentMarketDataV1:
+    payload = {"instrument_id": instrument_id, "suffix": suffix}
+    return SupplementaryInstrumentMarketDataV1(
+        instrument_id=instrument_id,
+        source_ref=f"synthetic:binding:market:{suffix}",
+        record_digest=compute_sha256_digest(payload),
+        market_type="futures",
+        history_bars_available=history,
+        required_history_bars=_MIN_HISTORY,
+        data_availability_status="AVAILABLE",
+    )
+
+
+def _panel_registry():
+    specs = [
+        ("ETH", "ETH-USDT-SWAP", "eth"),
+        ("SOL", "SOL-USDT-SWAP", "sol"),
+        ("AVAX", "AVAX-USDT-SWAP", "avax"),
+        ("LINK", "LINK-USDT-SWAP", "link"),
+        ("DOT", "DOT-USDT-SWAP", "dot"),
+        ("ADA", "ADAUSDT", "ada", "binance_usdm"),
+    ]
+    records = []
+    supplementary = []
+    for item in specs:
+        base = item[0]
+        symbol = item[1]
+        suffix = item[2]
+        venue = item[3] if len(item) > 3 else "okx"
+        records.append(_source_record(base_asset=base, venue_symbol=symbol, venue_id=venue))
+    snapshot = _assembled_snapshot(*records)
+    for interval in snapshot.intervals:
+        suffix = interval.base_asset.lower()
+        supplementary.append(_supplementary(interval.instrument_id, suffix=suffix))
+    return snapshot, tuple(supplementary)
+
+
+def _manual_snapshot(*intervals: InstrumentLifecycleIntervalV1) -> RegistrySnapshotV1:
+    snap = RegistrySnapshotV1(
+        schema_name=SCHEMA_NAME,
+        schema_version=SCHEMA_VERSION,
+        registry_snapshot_version=1,
+        policy_version=REGISTRY_VERSION,
+        source_priority_policy_version="source_priority_policy.v1",
+        conflict_resolution_policy_version="conflict_resolution_policy.v1",
+        venue_scope=("okx", "binance_usdm"),
+        generated_at=_GENERATED_AT,
+        intervals=intervals,
+        config_digest=_CONFIG_DIGEST,
+        implementation_digest=_IMPL_DIGEST,
+        registry_snapshot_digest="0" * 64,
+    )
+    return attach_snapshot_digest(snap)
+
+
+def _interval_from_source(**overrides: object) -> InstrumentLifecycleIntervalV1:
+    from src.research.pit_futures_instrument_lifecycle_registry_v1 import (
+        normalize_source_observation_record_v1,
+    )
+
+    result = normalize_source_observation_record_v1(_source_record(**overrides))
+    assert result.success, result.error_codes
+    assert result.observation is not None
+    interval = build_interval_from_observation_v1(result.observation)
+    assert interval is not None
+    return interval
+
+
+def _ltc_with_delisting_snapshot(*, delisting_time: str) -> RegistrySnapshotV1:
+    interval = _interval_from_source(
+        base_asset="LTC",
+        venue_symbol="LTC-USDT-SWAP",
+        delisting_time=delisting_time,
+    )
+    return _manual_snapshot(interval)
+
+
+def _build_binding_input(
+    *,
+    snapshot=None,
+    supplementary=None,
+    bound_digest: str | None = None,
+    bound_version: int | None = None,
+    epochs=None,
+):
+    if snapshot is None or supplementary is None:
+        snapshot, supplementary = _panel_registry()
+    partial = PitFuturesUniverseManifestGeneratorRegistryBindingInputV1(
+        binding_input_contract_version=BINDING_INPUT_CONTRACT_VERSION,
+        binding_version=BINDING_VERSION,
+        registry_artifact_id=_REGISTRY_ARTIFACT_ID,
+        bound_registry_schema_version=SCHEMA_VERSION,
+        bound_registry_snapshot_version=bound_version or snapshot.registry_snapshot_version,
+        bound_registry_snapshot_digest=bound_digest or snapshot.registry_snapshot_digest,
+        registry_snapshot=snapshot,
+        input_contract_version=GENERATOR_INPUT_CONTRACT_VERSION,
+        artifact_id="synthetic_pit_generator_registry_binding_manifest_v0",
+        venue_id="okx",
+        universe_id="synthetic_universe_v0",
+        hypothesis_id="CROSS_SECTIONAL_RELATIVE_STRENGTH_NON_BITCOIN_PERPETUALS_V0",
+        universe_policy_id="synthetic_cross_sectional_okx_non_btc_perp_v0",
+        universe_policy_version="v0",
+        inclusion_policy_version="v0",
+        exclusion_policy_version="v0",
+        generator_version=GENERATOR_VERSION,
+        generated_at=_GENERATED_AT,
+        bar_interval="PT1H",
+        minimum_history_bars=_MIN_HISTORY,
+        minimum_required_member_count=5,
+        venue_scope=("binance_usdm", "okx"),
+        source_snapshot_refs=(_DATASET_REF,),
+        source_digests=(compute_sha256_digest({"source_dataset_refs": [_DATASET_REF]}),),
+        period_binding_ref=_PERIOD_REF,
+        config_digest="0" * 64,
+        implementation_digest="0" * 64,
+        supplementary_market_data=supplementary,
+        epochs=epochs
+        or (
+            RegistryBoundEpochInputV1(
+                score_epoch=0,
+                finalized_bar_close=_BAR_CLOSE,
+                historical_as_of_time=_BAR_CLOSE,
+            ),
+        ),
+    )
+    from src.research.pit_futures_universe_manifest_generator_v1 import (
+        PitFuturesUniverseManifestGeneratorInputV1,
+        GeneratorEpochInputV1,
+    )
+
+    gen_partial = PitFuturesUniverseManifestGeneratorInputV1(
+        input_contract_version=partial.input_contract_version,
+        artifact_id=partial.artifact_id,
+        venue_id=partial.venue_id,
+        universe_id=partial.universe_id,
+        hypothesis_id=partial.hypothesis_id,
+        universe_policy_id=partial.universe_policy_id,
+        universe_policy_version=partial.universe_policy_version,
+        inclusion_policy_version=partial.inclusion_policy_version,
+        exclusion_policy_version=partial.exclusion_policy_version,
+        generator_version=partial.generator_version,
+        generated_at=partial.generated_at,
+        bar_interval=partial.bar_interval,
+        minimum_history_bars=partial.minimum_history_bars,
+        minimum_required_member_count=partial.minimum_required_member_count,
+        venue_scope=partial.venue_scope,
+        source_snapshot_refs=partial.source_snapshot_refs,
+        source_digests=partial.source_digests,
+        period_binding_ref=partial.period_binding_ref,
+        config_digest="0" * 64,
+        implementation_digest="0" * 64,
+        epochs=(GeneratorEpochInputV1(0, _BAR_CLOSE, ()),),
+    )
+    return dataclasses.replace(
+        partial,
+        config_digest=compute_generator_config_digest(gen_partial),
+        implementation_digest=compute_generator_implementation_digest(),
+    )
+
+
+def test_happy_path_active_instrument_included() -> None:
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(_build_binding_input())
+    assert result.success is True
+    assert result.manifest is not None
+    assert result.provenance is not None
+    assert result.provenance.registry_content_digest == result.provenance.registry_content_digest
+    assert len(result.manifest.epochs[0].members) >= 5
+    validation = validate_pit_futures_universe_manifest_v1(result.manifest)
+    assert validation.verdict == ManifestValidationVerdict.ACCEPTED
+
+
+def test_not_yet_listed_instrument_excluded_by_generator() -> None:
+    future_listing = "2024-07-01T00:00:00Z"
+    record = _source_record(
+        base_asset="LTC",
+        venue_symbol="LTC-USDT-SWAP",
+        listing_time=future_listing,
+        eligible_from=future_listing,
+    )
+    snapshot = _assembled_snapshot(*[_source_record(), record])
+    ltc = next(i for i in snapshot.intervals if i.base_asset == "LTC")
+    supplementary = (
+        _supplementary(snapshot.intervals[0].instrument_id, suffix="eth"),
+        _supplementary(ltc.instrument_id, suffix="ltc"),
+    )
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=snapshot, supplementary=supplementary)
+    )
+    assert result.success
+    assert result.manifest is not None
+    excluded_ids = {item.instrument_id for item in result.manifest.epochs[0].excluded_members}
+    assert ltc.instrument_id in excluded_ids
+
+
+def test_delisted_instrument_excluded() -> None:
+    snapshot = _ltc_with_delisting_snapshot(delisting_time=_BAR_CLOSE)
+    ltc = snapshot.intervals[0]
+    supplementary = (_supplementary(ltc.instrument_id, suffix="ltc"),)
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=snapshot, supplementary=supplementary)
+    )
+    assert result.success
+    assert result.manifest is not None
+    excluded_ids = {item.instrument_id for item in result.manifest.epochs[0].excluded_members}
+    assert ltc.instrument_id in excluded_ids
+
+
+def test_listing_boundary_inclusive() -> None:
+    listing = _BAR_CLOSE
+    record = _source_record(
+        base_asset="LTC", venue_symbol="LTC-USDT-SWAP", listing_time=listing, eligible_from=listing
+    )
+    snapshot = _assembled_snapshot(record)
+    supplementary = (_supplementary(snapshot.intervals[0].instrument_id, suffix="ltc"),)
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=snapshot, supplementary=supplementary)
+    )
+    assert result.success
+    assert result.manifest is not None
+    member_ids = {item.instrument_id for item in result.manifest.epochs[0].members}
+    assert snapshot.intervals[0].instrument_id in member_ids
+
+
+def test_delisting_boundary_exclusive() -> None:
+    snapshot = _ltc_with_delisting_snapshot(delisting_time=_BAR_CLOSE)
+    supplementary = (_supplementary(snapshot.intervals[0].instrument_id, suffix="ltc"),)
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=snapshot, supplementary=supplementary)
+    )
+    assert result.success
+    assert result.manifest is not None
+    excluded_ids = {item.instrument_id for item in result.manifest.epochs[0].excluded_members}
+    assert snapshot.intervals[0].instrument_id in excluded_ids
+
+
+def test_unknown_supplementary_membership_fail_closed() -> None:
+    snapshot, supplementary = _panel_registry()
+    ghost = _supplementary("okx:linear_perpetual:GHOST:USDT:USDT:perp", suffix="ghost")
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=snapshot, supplementary=supplementary + (ghost,))
+    )
+    assert not result.success
+    assert RegistryBindingErrorCode.UNKNOWN_HISTORICAL_MEMBERSHIP.value in result.error_codes
+
+
+def test_missing_registry_fail_closed() -> None:
+    inp = _build_binding_input()
+    broken = dataclasses.replace(inp, registry_snapshot=None)
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(broken)
+    assert not result.success
+    assert RegistryBindingErrorCode.MISSING_REGISTRY.value in result.error_codes
+
+
+def test_corrupt_registry_fail_closed() -> None:
+    snapshot, supplementary = _panel_registry()
+    bad = dataclasses.replace(snapshot, registry_snapshot_digest="f" * 64)
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=bad, supplementary=supplementary)
+    )
+    assert not result.success
+    assert RegistryBindingErrorCode.CORRUPT_REGISTRY.value in result.error_codes
+
+
+def test_digest_mismatch_fail_closed() -> None:
+    snapshot, supplementary = _panel_registry()
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(
+            snapshot=snapshot,
+            supplementary=supplementary,
+            bound_digest="f" * 64,
+        )
+    )
+    assert not result.success
+    assert RegistryBindingErrorCode.REGISTRY_DIGEST_MISMATCH.value in result.error_codes
+
+
+def test_unsupported_registry_version_fail_closed() -> None:
+    snapshot, supplementary = _panel_registry()
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(
+            snapshot=snapshot,
+            supplementary=supplementary,
+            bound_version=999,
+        )
+    )
+    assert not result.success
+    assert RegistryBindingErrorCode.REGISTRY_VERSION_MISMATCH.value in result.error_codes
+
+
+def test_current_state_fallback_blocked() -> None:
+    snapshot, supplementary = _panel_registry()
+    inp = _build_binding_input(snapshot=snapshot, supplementary=supplementary)
+    broken = dataclasses.replace(inp, period_binding_ref="synthetic:use_current_state:v0")
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(broken)
+    assert not result.success
+    assert RegistryBindingErrorCode.CURRENT_STATE_FALLBACK_BLOCKED.value in result.error_codes
+
+
+def test_registry_validation_before_consumption() -> None:
+    snapshot, supplementary = _panel_registry()
+    corrupt = dataclasses.replace(snapshot.intervals[0], eligible_from="2024-01-09T00:00:00Z")
+    bad_snap = dataclasses.replace(snapshot, intervals=(corrupt, *snapshot.intervals[1:]))
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=bad_snap, supplementary=supplementary)
+    )
+    assert not result.success
+    assert RegistryBindingErrorCode.CORRUPT_REGISTRY.value in result.error_codes
+
+
+def test_generator_does_not_mutate_registry_snapshot() -> None:
+    snapshot, supplementary = _panel_registry()
+    before = dumps_canonical(
+        {
+            "digest": snapshot.registry_snapshot_digest,
+            "version": snapshot.registry_snapshot_version,
+            "intervals": [interval.record_digest for interval in snapshot.intervals],
+        }
+    )
+    generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=snapshot, supplementary=supplementary)
+    )
+    after = dumps_canonical(
+        {
+            "digest": snapshot.registry_snapshot_digest,
+            "version": snapshot.registry_snapshot_version,
+            "intervals": [interval.record_digest for interval in snapshot.intervals],
+        }
+    )
+    assert before == after
+
+
+def test_deterministic_output_and_provenance() -> None:
+    first = generate_pit_futures_universe_manifest_from_registry_binding_v1(_build_binding_input())
+    second = generate_pit_futures_universe_manifest_from_registry_binding_v1(_build_binding_input())
+    assert first.success and second.success
+    assert first.manifest is not None and second.manifest is not None
+    assert first.manifest.manifest_digest == second.manifest.manifest_digest
+    assert first.provenance is not None and second.provenance is not None
+    assert first.provenance.output_manifest_digest == second.provenance.output_manifest_digest
+    assert first.provenance.binding_implementation_digest == compute_binding_implementation_digest()
+
+
+def test_changed_registry_binding_changes_output_digest() -> None:
+    snapshot, supplementary = _panel_registry()
+    first = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=snapshot, supplementary=supplementary)
+    )
+    second_record = _source_record(base_asset="NEAR", venue_symbol="NEAR-USDT-SWAP")
+    second_snapshot = _assembled_snapshot(*[_source_record(), second_record])
+    second_supplementary = (
+        _supplementary(second_snapshot.intervals[0].instrument_id, suffix="eth"),
+        _supplementary(second_snapshot.intervals[1].instrument_id, suffix="near"),
+    )
+    second = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=second_snapshot, supplementary=second_supplementary)
+    )
+    assert first.success and second.success
+    assert first.manifest is not None and second.manifest is not None
+    assert first.manifest.manifest_digest != second.manifest.manifest_digest
+    assert first.provenance is not None and second.provenance is not None
+    assert first.provenance.registry_content_digest != second.provenance.registry_content_digest
+
+
+def test_provenance_binds_registry_fields() -> None:
+    snapshot, supplementary = _panel_registry()
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=snapshot, supplementary=supplementary)
+    )
+    assert result.provenance is not None
+    prov = result.provenance
+    assert prov.registry_schema_version == SCHEMA_VERSION
+    assert prov.registry_artifact_id == _REGISTRY_ARTIFACT_ID
+    assert prov.registry_snapshot_version == snapshot.registry_snapshot_version
+    assert prov.registry_content_digest == snapshot.registry_snapshot_digest
+    assert prov.historical_as_of_times == (_BAR_CLOSE,)
+    assert prov.output_manifest_digest == result.manifest.manifest_digest
+
+
+def test_registry_reference_in_manifest_source_refs() -> None:
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(_build_binding_input())
+    assert result.success and result.manifest is not None and result.provenance is not None
+    assert result.provenance.registry_reference in result.manifest.source_dataset_refs
+
+
+def test_persistence_read_only_consumer_no_registry_write(tmp_path: Path) -> None:
+    snapshot, supplementary = _panel_registry()
+    rel = Path("registry_snapshot.json")
+    write_result = write_registry_snapshot_v1(
+        snapshot,
+        root_dir=tmp_path,
+        relative_path=rel,
+        overwrite_policy=OverwritePolicy.FAIL_IF_EXISTS,
+    )
+    assert write_result.success
+    path = tmp_path / rel
+    before_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+    read_result = read_registry_snapshot_v1(root_dir=tmp_path, relative_path=rel)
+    assert read_result.success and read_result.snapshot is not None
+    result = generate_pit_futures_universe_manifest_from_registry_binding_v1(
+        _build_binding_input(snapshot=read_result.snapshot, supplementary=supplementary)
+    )
+    assert result.success
+    after_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+    assert before_hash == after_hash
+
+
+def test_binding_error_code_taxonomy_has_exactly_eleven_codes() -> None:
+    assert len(RegistryBindingErrorCode) == 11
+
+
+def test_slice_abc_regression_registry_validator_still_accepts_assembled() -> None:
+    snapshot = _assembled_snapshot(_source_record())
+    result = validate_pit_futures_instrument_lifecycle_registry_snapshot_v1(snapshot)
+    assert result.verdict == ValidationVerdict.ACCEPTED
+
+
+def test_unknown_historical_membership_query_fail_closed() -> None:
+    snapshot = _assembled_snapshot(_source_record())
+    query = query_lifecycle_at_snapshot_v1(
+        snapshot,
+        instrument_id="okx:linear_perpetual:MISSING:USDT:USDT:perp",
+        query_instant=_BAR_CLOSE,
+    )
+    assert query.query_state == QueryState.UNKNOWN.value


### PR DESCRIPTION
## Summary
- Adds `pit_futures_universe_manifest_generator_registry_consumer_binding_v1` as a pure offline read-only consumer binding between the existing PIT futures universe manifest generator and the Slice A–C lifecycle registry.
- Binds explicit registry schema/version/digest, historical as-of times, and provenance into generator inputs/output without mutating registry state or introducing parallel SSOT owners.
- Adds focused Slice D contract tests covering membership boundaries, fail-closed error paths, determinism, persistence non-mutation, and Slice A–C regressions.

## Test plan
- [x] `pytest tests/research/test_pit_futures_universe_manifest_generator_registry_consumer_binding_v1.py`
- [x] Slice A–C + generator regressions (165 tests)
- [x] `ruff format --check` / `ruff check` on changed files
- [x] `git diff --check`
- [x] CI selector: `PR_BOUNDED_FULL` (`category_central_src_requires_full`)


Made with [Cursor](https://cursor.com)