### PR TITLE
feat(research): OKX production lifecycle source + PT1H panel ingest v0

### DIFF
--- a/config/research/pit_okx_production_lifecycle_pt1h_panel_policy_v1.json
+++ b/config/research/pit_okx_production_lifecycle_pt1h_panel_policy_v1.json
@@ -1,0 +1,10 @@
+{
+  "bar_granularity": "PT1H",
+  "futures_only": true,
+  "bitcoin_direction_allowed": false,
+  "min_eligible_instruments": 5,
+  "production_lifecycle_source_id": "okx_production_instrument_lifecycle_historical_as_of_fail_closed.v1",
+  "universe_policy_id": "pit_okx_linear_usdt_non_bitcoin_perpetual_cross_sectional_universe",
+  "universe_policy_version": "v1",
+  "venue_scope": "okx_linear_usdt_perpetuals"
+}

--- a/scripts/ops/materialize_okx_production_lifecycle_and_pt1h_panel_v1.py
+++ b/scripts/ops/materialize_okx_production_lifecycle_and_pt1h_panel_v1.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Materialize OKX production lifecycle source and PT1H multi-instrument panel v1.
+
+Public GET allowlist only. No auth, no orders, no runtime effect.
+Operator GO: GO_BOUNDED_OKX_PRODUCTION_LIFECYCLE_SOURCE_REGISTRATION_AND_PT1H_PANEL_OHLCV_INGEST_V0
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+CONFIRM_TOKEN = (
+    "GO_BOUNDED_OKX_PRODUCTION_LIFECYCLE_SOURCE_REGISTRATION_AND_PT1H_PANEL_OHLCV_INGEST_V0"
+)
+DEFAULT_STAGING_WINDOW_DAYS = 14
+MIN_ELIGIBLE_INSTRUMENTS = 5
+
+from src.research.okx_production_instrument_lifecycle_source_v1 import (  # noqa: E402
+    MIN_ELIGIBLE_INSTRUMENT_COUNT,
+    OkxLifecycleSourceErrorCode,
+    SOURCE_ID,
+    UNIVERSE_POLICY_ID,
+    UNIVERSE_POLICY_VERSION,
+    build_lifecycle_source_observations_v1,
+    build_okx_lifecycle_source_snapshot_v1,
+    compute_raw_instruments_snapshot_digest,
+)
+from src.research.pit_futures_instrument_lifecycle_registry_persistence_v1 import (  # noqa: E402
+    OverwritePolicy,
+    write_registry_snapshot_v1,
+)
+from src.research.pit_futures_instrument_lifecycle_registry_v1 import (  # noqa: E402
+    assemble_registry_snapshot_v1,
+    format_registry_reference_v1,
+    registry_snapshot_to_dict,
+)
+from src.research.pit_futures_instrument_lifecycle_registry_validator_v1 import (  # noqa: E402
+    ValidationVerdict,
+    validate_pit_futures_instrument_lifecycle_registry_snapshot_v1,
+)
+from src.research.pit_futures_universe_manifest_v1 import compute_sha256_digest  # noqa: E402
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import (  # noqa: E402
+    BAR_GRANULARITY,
+    OKX_BAR_PARAM,
+    PANEL_ID,
+    InstrumentPanelSeriesV1,
+    PanelBarV1,
+    build_panel_dataset_manifest_v1,
+    compute_implementation_digest,
+    compute_series_digest,
+    panel_manifest_to_dict,
+    validate_panel_series_v1,
+)
+
+
+def _load_okx_ingest_module() -> Any:
+    script = (
+        _REPO_ROOT
+        / "scripts/ops/ingest_okx_futures_public_market_data_canonical_dataset_staging_v1.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "ingest_okx_futures_public_market_data_canonical_dataset_staging_v1", script
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _utc_now_z() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ms_to_rfc3339_utc(ms: int) -> str:
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def fetch_all_swap_instruments(
+    okx_mod: Any,
+    *,
+    fetcher: Callable[..., tuple[int, bytes, dict[str, str]]],
+    rate_limiter: Any,
+    timeout_seconds: float,
+    max_response_bytes: int,
+    raw_dir: Path,
+) -> list[dict[str, Any]]:
+    params = {"instType": "SWAP"}
+    url = okx_mod._build_url("/api/v5/public/instruments", params)
+    req_at = _utc_now_z()
+    status, body, _ = okx_mod.fetch_with_retry(
+        url,
+        timeout_seconds=timeout_seconds,
+        max_response_bytes=max_response_bytes,
+        rate_limiter=rate_limiter,
+        fetcher=fetcher,
+    )
+    resp_at = _utc_now_z()
+    digest = okx_mod._sha256_bytes(body)
+    raw_path = raw_dir / f"instruments_all_swap_{digest[:16]}.json"
+    raw_path.write_bytes(body)
+    payload = okx_mod._parse_okx_json(body)
+    okx_code = str(payload.get("code", ""))
+    data = payload.get("data") or []
+    if status < 200 or status >= 300 or okx_code != "0" or not isinstance(data, list):
+        _die(f"ERR: instruments_fetch_failed:http_{status}:code_{okx_code}")
+    return [dict(item) for item in data if isinstance(item, Mapping)]
+
+
+def fetch_pt1h_candles_for_instrument(
+    okx_mod: Any,
+    *,
+    inst_id: str,
+    fetcher: Callable[..., tuple[int, bytes, dict[str, str]]],
+    rate_limiter: Any,
+    timeout_seconds: float,
+    max_response_bytes: int,
+    raw_dir: Path,
+    start_ms: int,
+    end_ms: int,
+) -> list[list[Any]]:
+    request_log: list[Any] = []
+    return okx_mod.paginate_candles(
+        path="/api/v5/market/history-candles",
+        params_base={"instId": inst_id, "bar": OKX_BAR_PARAM},
+        fetcher=fetcher,
+        rate_limiter=rate_limiter,
+        timeout_seconds=timeout_seconds,
+        max_response_bytes=max_response_bytes,
+        raw_dir=raw_dir,
+        request_log=request_log,
+        start_ms=start_ms,
+        end_ms=end_ms,
+        series_name=f"ohlcv_{inst_id.replace('-', '_').lower()}",
+    )
+
+
+def normalize_candles_to_panel_bars(
+    instrument_id: str,
+    rows: Sequence[Sequence[Any]],
+) -> tuple[PanelBarV1, ...]:
+    bars: list[PanelBarV1] = []
+    for row in rows:
+        ts = _ms_to_rfc3339_utc(int(str(row[0])))
+        is_final = str(row[8]) == "1" if len(row) >= 9 else str(row[5]) == "1"
+        bars.append(
+            PanelBarV1(
+                instrument_id=instrument_id,
+                timestamp_utc=ts,
+                open=str(row[1]),
+                high=str(row[2]),
+                low=str(row[3]),
+                close=str(row[4]),
+                volume=str(row[5]),
+                is_final=is_final,
+            )
+        )
+    return tuple(bars)
+
+
+def compute_common_period_bounds(
+    series_list: Sequence[InstrumentPanelSeriesV1],
+) -> tuple[str, str]:
+    if not series_list:
+        _die("ERR: no_panel_series")
+    common_starts = [series.bars[0].timestamp_utc for series in series_list if series.bars]
+    common_ends = [series.bars[-1].timestamp_utc for series in series_list if series.bars]
+    if not common_starts or not common_ends:
+        _die("ERR: empty_panel_series")
+    return max(common_starts), min(common_ends)
+
+
+def align_series_to_common_period(
+    series_list: Sequence[InstrumentPanelSeriesV1],
+    *,
+    period_start_utc: str,
+    period_end_utc: str,
+) -> tuple[InstrumentPanelSeriesV1, ...]:
+    aligned: list[InstrumentPanelSeriesV1] = []
+    for series in series_list:
+        bars = tuple(
+            bar for bar in series.bars if period_start_utc <= bar.timestamp_utc <= period_end_utc
+        )
+        aligned.append(
+            InstrumentPanelSeriesV1(
+                instrument_id=series.instrument_id,
+                native_instrument_id=series.native_instrument_id,
+                bars=bars,
+                series_digest=compute_series_digest(
+                    InstrumentPanelSeriesV1(
+                        instrument_id=series.instrument_id,
+                        native_instrument_id=series.native_instrument_id,
+                        bars=bars,
+                        series_digest="0" * 64,
+                    )
+                ),
+            )
+        )
+    return tuple(aligned)
+
+
+def run_materialization(
+    *,
+    confirm: str,
+    target_staging_root: Path,
+    durable_evidence_root: Path,
+    staging_window_days: int = DEFAULT_STAGING_WINDOW_DAYS,
+    timeout_seconds: float = 15.0,
+    max_response_bytes: int = 50_000_000,
+    fetcher: Callable[..., tuple[int, bytes, dict[str, str]]] | None = None,
+    skip_network: bool = False,
+) -> dict[str, Any]:
+    if confirm != CONFIRM_TOKEN:
+        _die("ERR: confirm token required")
+    if target_staging_root.exists():
+        _die(f"ERR: target_staging_root_exists:{target_staging_root}")
+
+    okx_mod = _load_okx_ingest_module()
+    fetcher = fetcher or okx_mod.okx_public_fetch_v1
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    tmp_root = target_staging_root.parent / f".tmp_{ts_slug}"
+    raw_dir = tmp_root / "raw"
+    lifecycle_dir = tmp_root / "lifecycle"
+    panel_dir = tmp_root / "panel"
+    reports_dir = tmp_root / "reports"
+    for path in (raw_dir, lifecycle_dir, panel_dir, reports_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    retrieval_ts = _utc_now_z()
+    source_snapshot_ref = f"okx_public_instruments_swap:{ts_slug}"
+
+    if skip_network:
+        _die("ERR: skip_network_not_supported_for_production_materialization")
+
+    rate_limiter = okx_mod.RateLimiter()
+    instruments = fetch_all_swap_instruments(
+        okx_mod,
+        fetcher=fetcher,
+        rate_limiter=rate_limiter,
+        timeout_seconds=timeout_seconds,
+        max_response_bytes=max_response_bytes,
+        raw_dir=raw_dir,
+    )
+    lifecycle_snapshot_input = build_okx_lifecycle_source_snapshot_v1(
+        instruments,
+        retrieval_timestamp_utc=retrieval_ts,
+        source_snapshot_ref=source_snapshot_ref,
+    )
+    if len(lifecycle_snapshot_input.eligible_instruments) < MIN_ELIGIBLE_INSTRUMENT_COUNT:
+        _die(
+            "ERR: FAIL_CLOSED_INSUFFICIENT_ELIGIBLE_INSTRUMENTS:"
+            f"{len(lifecycle_snapshot_input.eligible_instruments)}"
+        )
+
+    config_digest = compute_sha256_digest(
+        {
+            "bar_granularity": BAR_GRANULARITY,
+            "min_eligible_instruments": MIN_ELIGIBLE_INSTRUMENT_COUNT,
+            "source_id": SOURCE_ID,
+            "staging_window_days": staging_window_days,
+            "universe_policy_id": UNIVERSE_POLICY_ID,
+            "universe_policy_version": UNIVERSE_POLICY_VERSION,
+        }
+    )
+    implementation_digest = compute_implementation_digest()
+    observations = build_lifecycle_source_observations_v1(lifecycle_snapshot_input)
+    assembly = assemble_registry_snapshot_v1(
+        observations,
+        generated_at=retrieval_ts,
+        venue_scope=("okx",),
+        config_digest=config_digest,
+        implementation_digest=implementation_digest,
+        registered_sources=frozenset({SOURCE_ID}),
+        approved_snapshot_digests=frozenset({lifecycle_snapshot_input.raw_snapshot_digest}),
+    )
+    if not assembly.success or assembly.snapshot is None:
+        _die(f"ERR: lifecycle_registry_assembly_failed:{assembly.error_codes}")
+
+    validation = validate_pit_futures_instrument_lifecycle_registry_snapshot_v1(assembly.snapshot)
+    if validation.verdict is not ValidationVerdict.ACCEPTED:
+        _die(f"ERR: lifecycle_registry_validation_failed:{validation.error_codes}")
+
+    registry_path = lifecycle_dir / "registry_snapshot_v1.json"
+    persist_result = write_registry_snapshot_v1(
+        assembly.snapshot,
+        root_dir=lifecycle_dir,
+        relative_path="registry_snapshot_v1.json",
+        overwrite_policy=OverwritePolicy.FAIL_IF_EXISTS,
+    )
+    if not persist_result.success:
+        _die(f"ERR: lifecycle_registry_persist_failed:{persist_result.error_codes}")
+
+    registry_ref = format_registry_reference_v1(
+        artifact_id="okx_production_lifecycle_v1",
+        registry_snapshot_digest=assembly.snapshot.registry_snapshot_digest,
+    )
+    (lifecycle_dir / "REGISTRY_REFERENCE.txt").write_text(registry_ref + "\n", encoding="utf-8")
+    (lifecycle_dir / "SOURCE_REGISTRATION.json").write_text(
+        json.dumps(
+            {
+                "production_lifecycle_source_id": SOURCE_ID,
+                "registered": True,
+                "source_snapshot_ref": source_snapshot_ref,
+                "source_snapshot_digest": lifecycle_snapshot_input.raw_snapshot_digest,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    end_dt = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0) - timedelta(
+        hours=1
+    )
+    start_dt = end_dt - timedelta(days=staging_window_days)
+    start_ms = int(start_dt.timestamp() * 1000)
+    end_ms = int(end_dt.timestamp() * 1000)
+
+    panel_series: list[InstrumentPanelSeriesV1] = []
+    eligible_members: list[dict[str, str]] = []
+    for metadata in lifecycle_snapshot_input.eligible_instruments:
+        from src.research.instrument_id_canonicalization_v1 import (
+            InstrumentIdCanonicalizationInputV1,
+            canonicalize_instrument_id_v1,
+        )
+
+        canon = canonicalize_instrument_id_v1(
+            InstrumentIdCanonicalizationInputV1(
+                venue_id="okx",
+                market_type="futures",
+                contract_type="linear_perpetual",
+                base_asset=metadata.base_asset,
+                quote_asset="USDT",
+                settlement_asset="USDT",
+                venue_symbol=metadata.inst_id,
+            )
+        )
+        if not canon.success or canon.instrument_id is None:
+            continue
+        rows = fetch_pt1h_candles_for_instrument(
+            okx_mod,
+            inst_id=metadata.inst_id,
+            fetcher=fetcher,
+            rate_limiter=rate_limiter,
+            timeout_seconds=timeout_seconds,
+            max_response_bytes=max_response_bytes,
+            raw_dir=raw_dir,
+            start_ms=start_ms,
+            end_ms=end_ms,
+        )
+        if not rows:
+            continue
+        bars = normalize_candles_to_panel_bars(canon.instrument_id, rows)
+        series = InstrumentPanelSeriesV1(
+            instrument_id=canon.instrument_id,
+            native_instrument_id=metadata.inst_id,
+            bars=bars,
+            series_digest=compute_series_digest(
+                InstrumentPanelSeriesV1(
+                    instrument_id=canon.instrument_id,
+                    native_instrument_id=metadata.inst_id,
+                    bars=bars,
+                    series_digest="0" * 64,
+                )
+            ),
+        )
+        panel_series.append(series)
+        eligible_members.append(
+            {
+                "instrument_id": canon.instrument_id,
+                "native_instrument_id": metadata.inst_id,
+                "list_time_utc": metadata.list_time_utc,
+            }
+        )
+
+    if len(panel_series) < MIN_ELIGIBLE_INSTRUMENT_COUNT:
+        _die(f"ERR: FAIL_CLOSED_INSUFFICIENT_PANEL_MEMBERS:{len(panel_series)}")
+
+    period_start, period_end = compute_common_period_bounds(panel_series)
+    aligned_series = align_series_to_common_period(
+        panel_series, period_start_utc=period_start, period_end_utc=period_end
+    )
+    panel_validation = validate_panel_series_v1(
+        aligned_series,
+        min_instruments=MIN_ELIGIBLE_INSTRUMENT_COUNT,
+        generation_cutoff_utc=retrieval_ts,
+    )
+    if not panel_validation.valid:
+        _die(f"ERR: panel_validation_failed:{panel_validation.error_codes}")
+
+    source_provenance_digest = compute_sha256_digest(
+        {
+            "acquisition_method": "okx_public_rest_api_v5",
+            "bar_param": OKX_BAR_PARAM,
+            "raw_instruments_digest": lifecycle_snapshot_input.raw_snapshot_digest,
+            "source_id": SOURCE_ID,
+        }
+    )
+    panel_manifest = build_panel_dataset_manifest_v1(
+        series_list=aligned_series,
+        lifecycle_registry_ref=registry_ref,
+        lifecycle_registry_digest=assembly.snapshot.registry_snapshot_digest,
+        period_start_utc=period_start,
+        period_end_utc=period_end,
+        config_digest=config_digest,
+        source_provenance_digest=source_provenance_digest,
+    )
+    (panel_dir / "panel_dataset_manifest.json").write_text(
+        json.dumps(panel_manifest_to_dict(panel_manifest), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    normalized_rows = []
+    for series in aligned_series:
+        for bar in series.bars:
+            normalized_rows.append(asdict(bar))
+    (panel_dir / "normalized_panel_bars.json").write_text(
+        json.dumps(normalized_rows, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (panel_dir / "INSTRUMENT_MEMBERSHIP.json").write_text(
+        json.dumps(
+            {
+                "eligible_instrument_count": len(eligible_members),
+                "eligible_instruments": sorted(
+                    eligible_members, key=lambda item: item["instrument_id"]
+                ),
+                "universe_policy_id": UNIVERSE_POLICY_ID,
+                "universe_policy_version": UNIVERSE_POLICY_VERSION,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (reports_dir / "PERIOD_BINDING.json").write_text(
+        json.dumps(
+            {
+                "evaluation_period_binding": "pit_cross_sectional_panel_common_coverage_period.v1",
+                "period_start_utc": period_start,
+                "period_end_utc": period_end,
+                "bar_granularity": BAR_GRANULARITY,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    target_staging_root.parent.mkdir(parents=True, exist_ok=True)
+    tmp_root.rename(target_staging_root)
+
+    evidence_dir = (
+        durable_evidence_root
+        / "planning"
+        / f"bounded_okx_production_lifecycle_source_registration_and_pt1h_panel_ohlcv_ingest_v0_{ts_slug}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    for rel in (
+        "lifecycle/registry_snapshot_v1.json",
+        "lifecycle/REGISTRY_REFERENCE.txt",
+        "lifecycle/SOURCE_REGISTRATION.json",
+        "panel/panel_dataset_manifest.json",
+        "panel/INSTRUMENT_MEMBERSHIP.json",
+        "reports/PERIOD_BINDING.json",
+    ):
+        src = target_staging_root / rel
+        if src.is_file():
+            dst = evidence_dir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(src.read_bytes())
+
+    from scripts.ops import primary_evidence_retention_v0 as retention
+
+    rc, verify_msg = retention.finalize_durable_bundle_manifest(evidence_dir)
+
+    result = {
+        "verdict": "OKX_PRODUCTION_LIFECYCLE_AND_PT1H_PANEL_MATERIALIZATION_COMPLETE",
+        "production_lifecycle_source_id": SOURCE_ID,
+        "production_lifecycle_source_bound": True,
+        "lifecycle_registry_snapshot_materialized": True,
+        "lifecycle_registry_ref": registry_ref,
+        "lifecycle_data_digest": assembly.snapshot.registry_snapshot_digest,
+        "eligible_instrument_count": len(eligible_members),
+        "eligible_instruments": [item["instrument_id"] for item in eligible_members],
+        "panel_dataset_manifest_materialized": True,
+        "panel_dataset_ref": (
+            f"pit_okx_pt1h_panel_ohlcv_dataset_v1:{PANEL_ID}:sha256:{panel_manifest.manifest_digest}"
+        ),
+        "panel_data_digest": panel_manifest.normalized_panel_digest,
+        "panel_period_start": period_start,
+        "panel_period_end": period_end,
+        "bar_granularity": BAR_GRANULARITY,
+        "target_staging_root": str(target_staging_root),
+        "durable_evidence_path": str(evidence_dir),
+        "manifest_verify_rc": rc,
+        "manifest_verify_msg": verify_msg,
+        "panel_validation": {
+            "duplicate_check": panel_validation.duplicate_check,
+            "gap_check": panel_validation.gap_check,
+            "out_of_order_check": panel_validation.out_of_order_check,
+            "future_leakage_check": panel_validation.future_leakage_check,
+        },
+        "registry_snapshot": registry_snapshot_to_dict(assembly.snapshot),
+    }
+    (evidence_dir / "MATERIALIZATION_RESULT.json").write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    retention.finalize_durable_bundle_manifest(evidence_dir)
+    _emit_machine_lines(result)
+    return result
+
+
+def _emit_machine_lines(result: Mapping[str, Any]) -> None:
+    for key in (
+        "verdict",
+        "production_lifecycle_source_id",
+        "production_lifecycle_source_bound",
+        "lifecycle_registry_snapshot_materialized",
+        "eligible_instrument_count",
+        "panel_dataset_manifest_materialized",
+        "panel_dataset_ref",
+        "panel_data_digest",
+        "lifecycle_data_digest",
+        "bar_granularity",
+        "panel_period_start",
+        "panel_period_end",
+        "manifest_verify_rc",
+    ):
+        print(f"{key.upper()}={result.get(key)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Materialize OKX production lifecycle source and PT1H panel v1."
+    )
+    parser.add_argument("--confirm-go-token", required=True, choices=[CONFIRM_TOKEN])
+    parser.add_argument("--target-staging-root", type=Path, required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, required=True)
+    parser.add_argument("--staging-window-days", type=int, default=DEFAULT_STAGING_WINDOW_DAYS)
+    parser.add_argument("--timeout-seconds", type=float, default=15.0)
+    parser.add_argument("--max-response-bytes", type=int, default=50_000_000)
+    ns = parser.parse_args(argv)
+    run_materialization(
+        confirm=ns.confirm_go_token,
+        target_staging_root=ns.target_staging_root,
+        durable_evidence_root=ns.durable_evidence_root,
+        staging_window_days=ns.staging_window_days,
+        timeout_seconds=ns.timeout_seconds,
+        max_response_bytes=ns.max_response_bytes,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/okx_production_instrument_lifecycle_source_v1.py
+++ b/src/research/okx_production_instrument_lifecycle_source_v1.py
@@ -1,0 +1,352 @@
+"""OKX production instrument lifecycle source v1 — pure core for PIT registry assembly.
+
+Research-only, non-authorizing. No network, no I/O, no runtime authority.
+Converts OKX public instrument metadata snapshots into lifecycle source observations
+for `okx_production_instrument_lifecycle_historical_as_of_fail_closed.v1`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from src.research.instrument_id_canonicalization_v1 import (
+    InstrumentIdCanonicalizationInputV1,
+    canonicalize_instrument_id_v1,
+)
+from src.research.pit_futures_instrument_lifecycle_registry_v1 import (
+    INPUT_CONTRACT_VERSION,
+    OKX_PRODUCTION_INSTRUMENT_LIFECYCLE_HISTORICAL_AS_OF_FAIL_CLOSED_V1,
+    ObservationKind,
+    SourceObservationRecordV1,
+    SourceTrustLevel,
+    compute_observation_digest,
+)
+from src.research.pit_futures_universe_manifest_v1 import ContractType, compute_sha256_digest
+
+PACKAGE_MARKER = "OKX_PRODUCTION_INSTRUMENT_LIFECYCLE_SOURCE_V1=true"
+SOURCE_ID = OKX_PRODUCTION_INSTRUMENT_LIFECYCLE_HISTORICAL_AS_OF_FAIL_CLOSED_V1
+SOURCE_PRIORITY = 10
+VENUE_ID = "okx"
+VENUE_TIMEZONE = "UTC"
+MARKET_TYPE = "futures"
+CONTRACT_TYPE = ContractType.LINEAR_PERPETUAL.value
+UNIVERSE_POLICY_ID = "pit_okx_linear_usdt_non_bitcoin_perpetual_cross_sectional_universe"
+UNIVERSE_POLICY_VERSION = "v1"
+MIN_ELIGIBLE_INSTRUMENT_COUNT = 5
+
+_FORBIDDEN_INSTRUMENT_SUBSTRINGS = frozenset({"btc", "xbt", "bitcoin", "spot", "synthetic_spot"})
+_FORBIDDEN_BASE_ASSETS = frozenset({"BTC", "XBT", "WBTC", "TBTC", "RBTC", "BTCB"})
+_INST_ID_PATTERN = re.compile(r"^[A-Z0-9]+-USDT-SWAP$")
+
+
+class OkxLifecycleSourceErrorCode(str, Enum):
+    INVALID_INSTRUMENT_RECORD = "INVALID_INSTRUMENT_RECORD"
+    NON_LINEAR_USDT_SWAP = "NON_LINEAR_USDT_SWAP"
+    BITCOIN_INSTRUMENT_BLOCKED = "BITCOIN_INSTRUMENT_BLOCKED"
+    SPOT_OR_INVERSE_BLOCKED = "SPOT_OR_INVERSE_BLOCKED"
+    MISSING_LIST_TIME = "MISSING_LIST_TIME"
+    INVALID_LIST_TIME = "INVALID_LIST_TIME"
+    NON_LIVE_STATE_BLOCKED = "NON_LIVE_STATE_BLOCKED"
+    UNKNOWN_LIFECYCLE_FIELD = "UNKNOWN_LIFECYCLE_FIELD"
+    CANONICALIZATION_FAILED = "CANONICALIZATION_FAILED"
+    INSUFFICIENT_ELIGIBLE_INSTRUMENTS = "INSUFFICIENT_ELIGIBLE_INSTRUMENTS"
+
+
+@dataclass(frozen=True)
+class OkxInstrumentMetadataV1:
+    inst_id: str
+    inst_type: str
+    base_asset: str
+    quote_asset: str
+    settlement_asset: str
+    state: str
+    list_time_utc: str
+    exp_time: str
+    ct_type: str
+    raw_record_digest: str
+
+
+@dataclass(frozen=True)
+class OkxInstrumentEligibilityResultV1:
+    eligible: bool
+    instrument_id: str | None
+    metadata: OkxInstrumentMetadataV1 | None
+    error_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class OkxLifecycleSourceSnapshotV1:
+    source_id: str
+    retrieval_timestamp_utc: str
+    raw_snapshot_digest: str
+    source_snapshot_ref: str
+    eligible_instruments: tuple[OkxInstrumentMetadataV1, ...]
+    excluded_count: int
+    exclusion_reason_counts: dict[str, int]
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _ms_to_rfc3339_utc(value: str) -> str | None:
+    raw = str(value or "").strip()
+    if not raw or not raw.isdigit():
+        return None
+    ms = int(raw)
+    if ms <= 0:
+        return None
+    dt = datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _extract_base_asset(inst: Mapping[str, Any], inst_id: str) -> str:
+    base = str(inst.get("baseCcy") or "").strip().upper()
+    if base:
+        return base
+    parts = inst_id.split("-")
+    if len(parts) >= 1:
+        return parts[0].upper()
+    return ""
+
+
+def is_forbidden_okx_instrument_token(*values: str | None) -> bool:
+    combined = " ".join(v for v in values if v).lower()
+    return any(token in combined for token in _FORBIDDEN_INSTRUMENT_SUBSTRINGS)
+
+
+def is_okx_linear_usdt_perpetual(inst: Mapping[str, Any]) -> bool:
+    inst_id = str(inst.get("instId", "")).strip()
+    inst_type = str(inst.get("instType", "")).strip().upper()
+    settle = str(inst.get("settleCcy", "")).strip().upper()
+    ct_type = str(inst.get("ctType", "linear")).strip().lower()
+    exp = str(inst.get("expTime") or inst.get("expiry") or "").strip()
+    if inst_type != "SWAP":
+        return False
+    if settle != "USDT":
+        return False
+    if ct_type and ct_type != "linear":
+        return False
+    if exp not in ("", "0", "None", "null"):
+        return False
+    if not _INST_ID_PATTERN.fullmatch(inst_id):
+        return False
+    return True
+
+
+def evaluate_okx_instrument_eligibility_v1(
+    inst: Mapping[str, Any],
+    *,
+    raw_record_digest: str | None = None,
+) -> OkxInstrumentEligibilityResultV1:
+    """Fail-closed eligibility for one OKX public instrument record."""
+    errors: list[str] = []
+    inst_id = str(inst.get("instId", "")).strip()
+    if not inst_id:
+        return OkxInstrumentEligibilityResultV1(
+            False, None, None, (OkxLifecycleSourceErrorCode.INVALID_INSTRUMENT_RECORD.value,)
+        )
+
+    if not is_okx_linear_usdt_perpetual(inst):
+        errors.append(OkxLifecycleSourceErrorCode.NON_LINEAR_USDT_SWAP.value)
+
+    base_asset = _extract_base_asset(inst, inst_id)
+    if base_asset in _FORBIDDEN_BASE_ASSETS or is_forbidden_okx_instrument_token(
+        inst_id, base_asset, str(inst.get("uly", ""))
+    ):
+        errors.append(OkxLifecycleSourceErrorCode.BITCOIN_INSTRUMENT_BLOCKED.value)
+
+    state = str(inst.get("state", "")).strip().lower()
+    if state != "live":
+        errors.append(OkxLifecycleSourceErrorCode.NON_LIVE_STATE_BLOCKED.value)
+
+    list_time_raw = str(inst.get("listTime", "")).strip()
+    if not list_time_raw:
+        errors.append(OkxLifecycleSourceErrorCode.MISSING_LIST_TIME.value)
+    list_time_utc = _ms_to_rfc3339_utc(list_time_raw)
+    if list_time_raw and list_time_utc is None:
+        errors.append(OkxLifecycleSourceErrorCode.INVALID_LIST_TIME.value)
+
+    if errors:
+        return OkxInstrumentEligibilityResultV1(False, None, None, tuple(sorted(set(errors))))
+
+    canon = canonicalize_instrument_id_v1(
+        InstrumentIdCanonicalizationInputV1(
+            venue_id=VENUE_ID,
+            market_type=MARKET_TYPE,
+            contract_type=CONTRACT_TYPE,
+            base_asset=base_asset,
+            quote_asset="USDT",
+            settlement_asset="USDT",
+            venue_symbol=inst_id,
+        )
+    )
+    if not canon.success or canon.instrument_id is None:
+        return OkxInstrumentEligibilityResultV1(
+            False,
+            None,
+            None,
+            (OkxLifecycleSourceErrorCode.CANONICALIZATION_FAILED.value,),
+        )
+
+    digest = raw_record_digest or _stable_digest(dict(inst))
+    metadata = OkxInstrumentMetadataV1(
+        inst_id=inst_id,
+        inst_type=str(inst.get("instType", "")),
+        base_asset=base_asset,
+        quote_asset="USDT",
+        settlement_asset="USDT",
+        state=state,
+        list_time_utc=list_time_utc or "",
+        exp_time=str(inst.get("expTime") or ""),
+        ct_type=str(inst.get("ctType") or "linear"),
+        raw_record_digest=digest,
+    )
+    return OkxInstrumentEligibilityResultV1(True, canon.instrument_id, metadata, ())
+
+
+def select_eligible_okx_instruments_v1(
+    instruments: Sequence[Mapping[str, Any]],
+    *,
+    min_count: int = MIN_ELIGIBLE_INSTRUMENT_COUNT,
+) -> tuple[tuple[OkxInstrumentMetadataV1, ...], dict[str, int]]:
+    eligible: list[tuple[str, OkxInstrumentMetadataV1]] = []
+    exclusion_counts: dict[str, int] = {}
+    for inst in instruments:
+        digest = _stable_digest(dict(inst))
+        result = evaluate_okx_instrument_eligibility_v1(inst, raw_record_digest=digest)
+        if result.eligible and result.metadata is not None and result.instrument_id is not None:
+            eligible.append((result.instrument_id, result.metadata))
+            continue
+        for code in result.error_codes:
+            exclusion_counts[code] = exclusion_counts.get(code, 0) + 1
+    selected = tuple(meta for _, meta in sorted(eligible, key=lambda item: item[0]))
+    if len(selected) < min_count:
+        exclusion_counts[OkxLifecycleSourceErrorCode.INSUFFICIENT_ELIGIBLE_INSTRUMENTS.value] = (
+            min_count - len(selected)
+        )
+    return selected, exclusion_counts
+
+
+def compute_raw_instruments_snapshot_digest(instruments: Sequence[Mapping[str, Any]]) -> str:
+    payload = [
+        {
+            "instId": str(item.get("instId", "")),
+            "instType": str(item.get("instType", "")),
+            "settleCcy": str(item.get("settleCcy", "")),
+            "state": str(item.get("state", "")),
+            "listTime": str(item.get("listTime", "")),
+            "expTime": str(item.get("expTime", "")),
+            "ctType": str(item.get("ctType", "")),
+        }
+        for item in sorted(instruments, key=lambda row: str(row.get("instId", "")))
+    ]
+    return compute_sha256_digest({"instruments": payload, "source_id": SOURCE_ID})
+
+
+def build_okx_lifecycle_source_snapshot_v1(
+    instruments: Sequence[Mapping[str, Any]],
+    *,
+    retrieval_timestamp_utc: str,
+    source_snapshot_ref: str,
+) -> OkxLifecycleSourceSnapshotV1:
+    raw_digest = compute_raw_instruments_snapshot_digest(instruments)
+    eligible, exclusion_counts = select_eligible_okx_instruments_v1(instruments)
+    return OkxLifecycleSourceSnapshotV1(
+        source_id=SOURCE_ID,
+        retrieval_timestamp_utc=retrieval_timestamp_utc,
+        raw_snapshot_digest=raw_digest,
+        source_snapshot_ref=source_snapshot_ref,
+        eligible_instruments=eligible,
+        excluded_count=len(instruments) - len(eligible),
+        exclusion_reason_counts=exclusion_counts,
+    )
+
+
+def _build_observation_record(
+    metadata: OkxInstrumentMetadataV1,
+    *,
+    observation_kind: str,
+    source_snapshot_ref: str,
+    source_snapshot_digest: str,
+    source_observed_at: str,
+    source_effective_at: str,
+    listing_time: str | None = None,
+    eligible_from: str | None = None,
+) -> SourceObservationRecordV1:
+    interim = SourceObservationRecordV1(
+        input_contract_version=INPUT_CONTRACT_VERSION,
+        source_id=SOURCE_ID,
+        source_trust_level=SourceTrustLevel.TRUSTED.value,
+        source_priority=SOURCE_PRIORITY,
+        source_snapshot_ref=source_snapshot_ref,
+        source_snapshot_digest=source_snapshot_digest,
+        source_observed_at=source_observed_at,
+        source_effective_at=source_effective_at,
+        venue_id=VENUE_ID,
+        venue_timezone=VENUE_TIMEZONE,
+        market_type=MARKET_TYPE,
+        contract_type=CONTRACT_TYPE,
+        base_asset=metadata.base_asset,
+        quote_asset=metadata.quote_asset,
+        settlement_asset=metadata.settlement_asset,
+        observation_kind=observation_kind,
+        observation_digest="0" * 64,
+        venue_symbol=metadata.inst_id,
+        native_instrument_id=None,
+        listing_time=listing_time,
+        eligible_from=eligible_from,
+    )
+    digest = compute_observation_digest(interim)
+    return SourceObservationRecordV1(
+        input_contract_version=interim.input_contract_version,
+        source_id=interim.source_id,
+        source_trust_level=interim.source_trust_level,
+        source_priority=interim.source_priority,
+        source_snapshot_ref=interim.source_snapshot_ref,
+        source_snapshot_digest=interim.source_snapshot_digest,
+        source_observed_at=interim.source_observed_at,
+        source_effective_at=interim.source_effective_at,
+        venue_id=interim.venue_id,
+        venue_timezone=interim.venue_timezone,
+        market_type=interim.market_type,
+        contract_type=interim.contract_type,
+        base_asset=interim.base_asset,
+        quote_asset=interim.quote_asset,
+        settlement_asset=interim.settlement_asset,
+        observation_kind=interim.observation_kind,
+        observation_digest=digest,
+        venue_symbol=interim.venue_symbol,
+        native_instrument_id=interim.native_instrument_id,
+        listing_time=interim.listing_time,
+        eligible_from=interim.eligible_from,
+    )
+
+
+def build_lifecycle_source_observations_v1(
+    snapshot: OkxLifecycleSourceSnapshotV1,
+) -> tuple[SourceObservationRecordV1, ...]:
+    """Build LISTING observations with conservative eligible_from=listTime semantics."""
+    records: list[SourceObservationRecordV1] = []
+    for metadata in snapshot.eligible_instruments:
+        listing = metadata.list_time_utc
+        records.append(
+            _build_observation_record(
+                metadata,
+                observation_kind=ObservationKind.LISTING.value,
+                source_snapshot_ref=snapshot.source_snapshot_ref,
+                source_snapshot_digest=snapshot.raw_snapshot_digest,
+                source_observed_at=snapshot.retrieval_timestamp_utc,
+                source_effective_at=listing,
+                listing_time=listing,
+                eligible_from=listing,
+            )
+        )
+    return tuple(records)

--- a/src/research/pit_futures_instrument_lifecycle_registry_v1.py
+++ b/src/research/pit_futures_instrument_lifecycle_registry_v1.py
@@ -43,7 +43,16 @@ _DATED_TYPES = frozenset(
 _FUTURES_MARKET_TYPES = frozenset({"futures", "futures_panel", "future", "perpetual"})
 _VENUE_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 _ABSOLUTE_PATH_PATTERN = re.compile(r"(^/|^\\\\|^[A-Za-z]:[/\\\\])")
-_REGISTERED_SOURCES_V0 = frozenset({"synthetic:test:fixture:v0", "synthetic:test:record:v0"})
+OKX_PRODUCTION_INSTRUMENT_LIFECYCLE_HISTORICAL_AS_OF_FAIL_CLOSED_V1 = (
+    "okx_production_instrument_lifecycle_historical_as_of_fail_closed.v1"
+)
+_REGISTERED_SOURCES_V0 = frozenset(
+    {
+        "synthetic:test:fixture:v0",
+        "synthetic:test:record:v0",
+        OKX_PRODUCTION_INSTRUMENT_LIFECYCLE_HISTORICAL_AS_OF_FAIL_CLOSED_V1,
+    }
+)
 
 
 class ObservationKind(str, Enum):

--- a/src/research/pit_okx_pt1h_panel_ohlcv_dataset_v1.py
+++ b/src/research/pit_okx_pt1h_panel_ohlcv_dataset_v1.py
@@ -1,0 +1,407 @@
+"""PT1H multi-instrument OKX panel OHLCV dataset v1 — pure validation and manifest core.
+
+Research-only, non-authorizing. No network, no I/O, no runtime authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from src.research.pit_futures_universe_manifest_v1 import (
+    compute_sha256_digest,
+    is_valid_rfc3339_utc,
+)
+
+PACKAGE_MARKER = "PIT_OKX_PT1H_PANEL_OHLCV_DATASET_V1=true"
+MANIFEST_VERSION = "pit_okx_pt1h_panel_ohlcv_dataset_manifest_v1"
+PANEL_DATASET_VERSION = "v1"
+BAR_GRANULARITY = "PT1H"
+OKX_BAR_PARAM = "1H"
+BAR_GRANULARITY_SECONDS = 3600
+PANEL_ID = "pit_okx_linear_usdt_non_bitcoin_pt1h_panel"
+PANEL_ALIGNMENT_SEMANTICS = "common_utc_hourly_close_intersection_no_forward_fill"
+TIMESTAMP_SEMANTICS = "utc_bar_close_exclusive_end"
+TIMEZONE = "UTC"
+
+
+class PanelValidationErrorCode(str, Enum):
+    INVALID_BAR_GRANULARITY = "INVALID_BAR_GRANULARITY"
+    INSUFFICIENT_INSTRUMENTS = "INSUFFICIENT_INSTRUMENTS"
+    DUPLICATE_TIMESTAMP = "DUPLICATE_TIMESTAMP"
+    OUT_OF_ORDER_TIMESTAMP = "OUT_OF_ORDER_TIMESTAMP"
+    GAP_DETECTED = "GAP_DETECTED"
+    OHLC_INCONSISTENT = "OHLC_INCONSISTENT"
+    INVALID_VOLUME = "INVALID_VOLUME"
+    NON_FINAL_BAR = "NON_FINAL_BAR"
+    BITCOIN_INSTRUMENT_PRESENT = "BITCOIN_INSTRUMENT_PRESENT"
+    PANEL_ALIGNMENT_MISMATCH = "PANEL_ALIGNMENT_MISMATCH"
+    FUTURE_LEAKAGE = "FUTURE_LEAKAGE"
+    MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD"
+
+
+@dataclass(frozen=True)
+class PanelBarV1:
+    instrument_id: str
+    timestamp_utc: str
+    open: str
+    high: str
+    low: str
+    close: str
+    volume: str
+    is_final: bool
+
+
+@dataclass(frozen=True)
+class InstrumentPanelSeriesV1:
+    instrument_id: str
+    native_instrument_id: str
+    bars: tuple[PanelBarV1, ...]
+    series_digest: str
+
+
+@dataclass(frozen=True)
+class PanelValidationResultV1:
+    valid: bool
+    error_codes: tuple[str, ...]
+    duplicate_check: str
+    gap_check: str
+    out_of_order_check: str
+    future_leakage_check: str
+    ohlc_consistency_check: str
+    volume_validation_check: str
+    panel_alignment_check: str
+
+
+@dataclass(frozen=True)
+class PanelDatasetManifestV1:
+    manifest_version: str
+    panel_id: str
+    dataset_version: str
+    bar_granularity: str
+    panel_alignment_semantics: str
+    timestamp_semantics: str
+    timezone: str
+    instrument_ids: tuple[str, ...]
+    native_instrument_ids: tuple[str, ...]
+    lifecycle_registry_ref: str
+    lifecycle_registry_digest: str
+    period_start_utc: str
+    period_end_utc: str
+    panel_row_count: int
+    config_digest: str
+    implementation_digest: str
+    source_provenance_digest: str
+    normalized_panel_digest: str
+    manifest_digest: str
+
+
+def compute_implementation_digest() -> str:
+    return compute_sha256_digest(
+        {
+            "module": "pit_okx_pt1h_panel_ohlcv_dataset_v1",
+            "manifest_version": MANIFEST_VERSION,
+            "bar_granularity": BAR_GRANULARITY,
+        }
+    )
+
+
+def _parse_float(value: str) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _validate_single_series(
+    series: InstrumentPanelSeriesV1,
+    *,
+    expected_timestamps: Sequence[str] | None = None,
+) -> tuple[list[str], str, str, str, str, str, str]:
+    errors: list[str] = []
+    duplicate_check = "PASS"
+    gap_check = "PASS"
+    out_of_order_check = "PASS"
+    ohlc_check = "PASS"
+    volume_check = "PASS"
+    alignment_check = "PASS"
+
+    seen_ts: set[str] = set()
+    prev_ts: str | None = None
+    prev_epoch: int | None = None
+    for bar in series.bars:
+        if not is_valid_rfc3339_utc(bar.timestamp_utc):
+            errors.append(PanelValidationErrorCode.MISSING_REQUIRED_FIELD.value)
+            continue
+        if bar.timestamp_utc in seen_ts:
+            duplicate_check = "FAIL"
+            errors.append(PanelValidationErrorCode.DUPLICATE_TIMESTAMP.value)
+        seen_ts.add(bar.timestamp_utc)
+
+        epoch = int(
+            bar.timestamp_utc.replace("-", "").replace(":", "").replace("T", "").replace("Z", "")
+        )
+        if prev_epoch is not None and epoch < prev_epoch:
+            out_of_order_check = "FAIL"
+            errors.append(PanelValidationErrorCode.OUT_OF_ORDER_TIMESTAMP.value)
+        if prev_ts is not None:
+            from datetime import datetime, timezone
+
+            prev_dt = datetime.strptime(prev_ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+            cur_dt = datetime.strptime(bar.timestamp_utc, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+            gap_seconds = (cur_dt - prev_dt).total_seconds()
+            if gap_seconds > BAR_GRANULARITY_SECONDS:
+                gap_check = "FAIL"
+                errors.append(PanelValidationErrorCode.GAP_DETECTED.value)
+        prev_ts = bar.timestamp_utc
+        prev_epoch = epoch
+
+        o = _parse_float(bar.open)
+        h = _parse_float(bar.high)
+        low = _parse_float(bar.low)
+        c = _parse_float(bar.close)
+        vol = _parse_float(bar.volume)
+        if None in (o, h, low, c, vol):
+            errors.append(PanelValidationErrorCode.MISSING_REQUIRED_FIELD.value)
+            continue
+        assert (
+            o is not None
+            and h is not None
+            and low is not None
+            and c is not None
+            and vol is not None
+        )
+        if not (low <= o <= h and low <= c <= h):
+            ohlc_check = "FAIL"
+            errors.append(PanelValidationErrorCode.OHLC_INCONSISTENT.value)
+        if vol < 0:
+            volume_check = "FAIL"
+            errors.append(PanelValidationErrorCode.INVALID_VOLUME.value)
+        if not bar.is_final:
+            errors.append(PanelValidationErrorCode.NON_FINAL_BAR.value)
+
+    if expected_timestamps is not None:
+        actual = [bar.timestamp_utc for bar in series.bars]
+        if actual != list(expected_timestamps):
+            alignment_check = "FAIL"
+            errors.append(PanelValidationErrorCode.PANEL_ALIGNMENT_MISMATCH.value)
+
+    return (
+        errors,
+        duplicate_check,
+        gap_check,
+        out_of_order_check,
+        ohlc_check,
+        volume_check,
+        alignment_check,
+    )
+
+
+def validate_panel_series_v1(
+    series_list: Sequence[InstrumentPanelSeriesV1],
+    *,
+    min_instruments: int = 5,
+    forbidden_instrument_substrings: frozenset[str] = frozenset({"btc", "xbt", "bitcoin"}),
+    generation_cutoff_utc: str | None = None,
+) -> PanelValidationResultV1:
+    errors: list[str] = []
+    if len(series_list) < min_instruments:
+        errors.append(PanelValidationErrorCode.INSUFFICIENT_INSTRUMENTS.value)
+
+    for series in series_list:
+        lowered = series.instrument_id.lower()
+        if any(token in lowered for token in forbidden_instrument_substrings):
+            errors.append(PanelValidationErrorCode.BITCOIN_INSTRUMENT_PRESENT.value)
+
+    canonical_ts: list[str] | None = None
+    if series_list:
+        canonical_ts = [bar.timestamp_utc for bar in series_list[0].bars]
+
+    dup = gap = ooo = ohlc = vol = align = "PASS"
+    for series in series_list:
+        series_errors, d, g, o, oh, v, a = _validate_single_series(
+            series, expected_timestamps=canonical_ts
+        )
+        errors.extend(series_errors)
+        for label, current in (
+            (d, "duplicate"),
+            (g, "gap"),
+            (o, "ooo"),
+            (oh, "ohlc"),
+            (v, "vol"),
+            (a, "align"),
+        ):
+            if label == "FAIL":
+                if current == "duplicate":
+                    dup = "FAIL"
+                elif current == "gap":
+                    gap = "FAIL"
+                elif current == "ooo":
+                    ooo = "FAIL"
+                elif current == "ohlc":
+                    ohlc = "FAIL"
+                elif current == "vol":
+                    vol = "FAIL"
+                elif current == "align":
+                    align = "FAIL"
+
+    future_check = "PASS"
+    if generation_cutoff_utc and canonical_ts:
+        if canonical_ts[-1] > generation_cutoff_utc:
+            future_check = "FAIL"
+            errors.append(PanelValidationErrorCode.FUTURE_LEAKAGE.value)
+
+    unique_errors = tuple(sorted(set(errors)))
+    return PanelValidationResultV1(
+        valid=not unique_errors,
+        error_codes=unique_errors,
+        duplicate_check=dup,
+        gap_check=gap,
+        out_of_order_check=ooo,
+        future_leakage_check=future_check,
+        ohlc_consistency_check=ohlc,
+        volume_validation_check=vol,
+        panel_alignment_check=align,
+    )
+
+
+def compute_series_digest(series: InstrumentPanelSeriesV1) -> str:
+    payload = {
+        "bars": [
+            {
+                "close": bar.close,
+                "high": bar.high,
+                "instrument_id": bar.instrument_id,
+                "is_final": bar.is_final,
+                "low": bar.low,
+                "open": bar.open,
+                "timestamp_utc": bar.timestamp_utc,
+                "volume": bar.volume,
+            }
+            for bar in series.bars
+        ],
+        "instrument_id": series.instrument_id,
+        "native_instrument_id": series.native_instrument_id,
+    }
+    return compute_sha256_digest(payload)
+
+
+def compute_panel_digest(series_list: Sequence[InstrumentPanelSeriesV1]) -> str:
+    return compute_sha256_digest(
+        {
+            "series_digests": [
+                compute_series_digest(series)
+                for series in sorted(series_list, key=lambda item: item.instrument_id)
+            ]
+        }
+    )
+
+
+def build_panel_dataset_manifest_v1(
+    *,
+    series_list: Sequence[InstrumentPanelSeriesV1],
+    lifecycle_registry_ref: str,
+    lifecycle_registry_digest: str,
+    period_start_utc: str,
+    period_end_utc: str,
+    config_digest: str,
+    source_provenance_digest: str,
+) -> PanelDatasetManifestV1:
+    normalized_panel_digest = compute_panel_digest(series_list)
+    implementation_digest = compute_implementation_digest()
+    instrument_ids = tuple(sorted(series.instrument_id for series in series_list))
+    native_ids = tuple(
+        series.native_instrument_id
+        for series in sorted(series_list, key=lambda item: item.instrument_id)
+    )
+    panel_row_count = sum(len(series.bars) for series in series_list)
+    interim = PanelDatasetManifestV1(
+        manifest_version=MANIFEST_VERSION,
+        panel_id=PANEL_ID,
+        dataset_version=PANEL_DATASET_VERSION,
+        bar_granularity=BAR_GRANULARITY,
+        panel_alignment_semantics=PANEL_ALIGNMENT_SEMANTICS,
+        timestamp_semantics=TIMESTAMP_SEMANTICS,
+        timezone=TIMEZONE,
+        instrument_ids=instrument_ids,
+        native_instrument_ids=native_ids,
+        lifecycle_registry_ref=lifecycle_registry_ref,
+        lifecycle_registry_digest=lifecycle_registry_digest,
+        period_start_utc=period_start_utc,
+        period_end_utc=period_end_utc,
+        panel_row_count=panel_row_count,
+        config_digest=config_digest,
+        implementation_digest=implementation_digest,
+        source_provenance_digest=source_provenance_digest,
+        normalized_panel_digest=normalized_panel_digest,
+        manifest_digest="0" * 64,
+    )
+    manifest_digest = compute_sha256_digest(
+        {
+            "bar_granularity": interim.bar_granularity,
+            "config_digest": interim.config_digest,
+            "dataset_version": interim.dataset_version,
+            "implementation_digest": interim.implementation_digest,
+            "instrument_ids": list(interim.instrument_ids),
+            "lifecycle_registry_digest": interim.lifecycle_registry_digest,
+            "lifecycle_registry_ref": interim.lifecycle_registry_ref,
+            "manifest_version": interim.manifest_version,
+            "normalized_panel_digest": interim.normalized_panel_digest,
+            "panel_alignment_semantics": interim.panel_alignment_semantics,
+            "panel_id": interim.panel_id,
+            "panel_row_count": interim.panel_row_count,
+            "period_end_utc": interim.period_end_utc,
+            "period_start_utc": interim.period_start_utc,
+            "source_provenance_digest": interim.source_provenance_digest,
+            "timestamp_semantics": interim.timestamp_semantics,
+            "timezone": interim.timezone,
+        }
+    )
+    return PanelDatasetManifestV1(
+        manifest_version=interim.manifest_version,
+        panel_id=interim.panel_id,
+        dataset_version=interim.dataset_version,
+        bar_granularity=interim.bar_granularity,
+        panel_alignment_semantics=interim.panel_alignment_semantics,
+        timestamp_semantics=interim.timestamp_semantics,
+        timezone=interim.timezone,
+        instrument_ids=interim.instrument_ids,
+        native_instrument_ids=interim.native_instrument_ids,
+        lifecycle_registry_ref=interim.lifecycle_registry_ref,
+        lifecycle_registry_digest=interim.lifecycle_registry_digest,
+        period_start_utc=interim.period_start_utc,
+        period_end_utc=interim.period_end_utc,
+        panel_row_count=interim.panel_row_count,
+        config_digest=interim.config_digest,
+        implementation_digest=interim.implementation_digest,
+        source_provenance_digest=interim.source_provenance_digest,
+        normalized_panel_digest=interim.normalized_panel_digest,
+        manifest_digest=manifest_digest,
+    )
+
+
+def panel_manifest_to_dict(manifest: PanelDatasetManifestV1) -> dict[str, Any]:
+    return {
+        "bar_granularity": manifest.bar_granularity,
+        "config_digest": manifest.config_digest,
+        "dataset_version": manifest.dataset_version,
+        "implementation_digest": manifest.implementation_digest,
+        "instrument_ids": list(manifest.instrument_ids),
+        "lifecycle_registry_digest": manifest.lifecycle_registry_digest,
+        "lifecycle_registry_ref": manifest.lifecycle_registry_ref,
+        "manifest_digest": manifest.manifest_digest,
+        "manifest_version": manifest.manifest_version,
+        "native_instrument_ids": list(manifest.native_instrument_ids),
+        "normalized_panel_digest": manifest.normalized_panel_digest,
+        "panel_alignment_semantics": manifest.panel_alignment_semantics,
+        "panel_id": manifest.panel_id,
+        "panel_row_count": manifest.panel_row_count,
+        "period_end_utc": manifest.period_end_utc,
+        "period_start_utc": manifest.period_start_utc,
+        "source_provenance_digest": manifest.source_provenance_digest,
+        "timestamp_semantics": manifest.timestamp_semantics,
+        "timezone": manifest.timezone,
+    }

--- a/tests/ops/test_materialize_okx_production_lifecycle_and_pt1h_panel_v1.py
+++ b/tests/ops/test_materialize_okx_production_lifecycle_and_pt1h_panel_v1.py
@@ -1,0 +1,83 @@
+"""Contract tests for materialize_okx_production_lifecycle_and_pt1h_panel_v1."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts/ops/materialize_okx_production_lifecycle_and_pt1h_panel_v1.py"
+_GO = "GO_BOUNDED_OKX_PRODUCTION_LIFECYCLE_SOURCE_REGISTRATION_AND_PT1H_PANEL_OHLCV_INGEST_V0"
+
+
+def _load_mod():
+    spec = importlib.util.spec_from_file_location(
+        "materialize_okx_production_lifecycle_and_pt1h_panel_v1", _SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _live_inst(base: str) -> dict[str, str]:
+    return {
+        "instId": f"{base}-USDT-SWAP",
+        "instType": "SWAP",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "baseCcy": base,
+        "state": "live",
+        "listTime": "1609459200000",
+        "expTime": "",
+    }
+
+
+def _mock_fetcher(instruments: list[dict[str, str]]):
+    from datetime import datetime, timedelta, timezone
+
+    end_dt = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0) - timedelta(
+        hours=1
+    )
+    ts_start = int((end_dt - timedelta(hours=5)).timestamp() * 1000)
+
+    def _fetch(url: str, *, timeout_seconds: float, max_response_bytes: int, headers=None):
+        path = url.split("?", 1)[0].split(".com", 1)[-1]
+        if path.endswith("/public/instruments"):
+            payload = {"code": "0", "data": instruments}
+            return 200, json.dumps(payload).encode(), {}
+        if path.endswith("/history-candles"):
+            rows = [
+                [str(ts_start + i * 3_600_000), "1", "2", "0.5", "1.5", "10", "0", "0", "1"]
+                for i in range(5)
+            ]
+            return 200, json.dumps({"code": "0", "data": rows}).encode(), {}
+        raise ValueError(path)
+
+    return _fetch
+
+
+class TestMaterializationOffline:
+    def test_materialization_success_with_mock_fetcher(self, tmp_path: Path) -> None:
+        mod = _load_mod()
+        instruments = [_live_inst(base) for base in ("ETH", "SOL", "ADA", "DOT", "LINK", "AVAX")]
+        target = tmp_path / "staging" / "pit_okx_pt1h_panel" / "v1"
+        evidence = tmp_path / "evidence"
+        result = mod.run_materialization(
+            confirm=_GO,
+            target_staging_root=target,
+            durable_evidence_root=evidence,
+            staging_window_days=1,
+            fetcher=_mock_fetcher(instruments),
+        )
+        assert result["production_lifecycle_source_bound"] is True
+        assert result["eligible_instrument_count"] >= 5
+        assert result["panel_dataset_manifest_materialized"] is True
+        assert result["manifest_verify_rc"] == 0
+        assert (target / "panel/panel_dataset_manifest.json").is_file()
+        assert (target / "lifecycle/registry_snapshot_v1.json").is_file()

--- a/tests/research/test_okx_production_instrument_lifecycle_source_v1.py
+++ b/tests/research/test_okx_production_instrument_lifecycle_source_v1.py
@@ -1,0 +1,126 @@
+"""Contract tests for okx_production_instrument_lifecycle_source_v1."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.research.okx_production_instrument_lifecycle_source_v1 import (
+    MIN_ELIGIBLE_INSTRUMENT_COUNT,
+    SOURCE_ID,
+    OkxLifecycleSourceErrorCode,
+    build_lifecycle_source_observations_v1,
+    build_okx_lifecycle_source_snapshot_v1,
+    evaluate_okx_instrument_eligibility_v1,
+    is_forbidden_okx_instrument_token,
+    is_okx_linear_usdt_perpetual,
+    select_eligible_okx_instruments_v1,
+)
+from src.research.pit_futures_instrument_lifecycle_registry_v1 import (
+    OKX_PRODUCTION_INSTRUMENT_LIFECYCLE_HISTORICAL_AS_OF_FAIL_CLOSED_V1,
+    _REGISTERED_SOURCES_V0,
+    assemble_registry_snapshot_v1,
+)
+
+
+def _live_inst(base: str, *, inst_id: str | None = None) -> dict[str, str]:
+    symbol = inst_id or f"{base}-USDT-SWAP"
+    return {
+        "instId": symbol,
+        "instType": "SWAP",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "baseCcy": base,
+        "state": "live",
+        "listTime": "1609459200000",
+        "expTime": "",
+    }
+
+
+class TestProductionSourceRegistration:
+    def test_production_source_registered_in_registry_owner(self) -> None:
+        assert (
+            OKX_PRODUCTION_INSTRUMENT_LIFECYCLE_HISTORICAL_AS_OF_FAIL_CLOSED_V1
+            in _REGISTERED_SOURCES_V0
+        )
+        assert SOURCE_ID == OKX_PRODUCTION_INSTRUMENT_LIFECYCLE_HISTORICAL_AS_OF_FAIL_CLOSED_V1
+
+
+class TestNegativeEligibility:
+    @pytest.mark.parametrize(
+        "inst,expected",
+        [
+            (_live_inst("BTC"), OkxLifecycleSourceErrorCode.BITCOIN_INSTRUMENT_BLOCKED.value),
+            (
+                {**_live_inst("ETH"), "instType": "SPOT"},
+                OkxLifecycleSourceErrorCode.NON_LINEAR_USDT_SWAP.value,
+            ),
+            (
+                {**_live_inst("ETH"), "settleCcy": "ETH"},
+                OkxLifecycleSourceErrorCode.NON_LINEAR_USDT_SWAP.value,
+            ),
+            (
+                {**_live_inst("ETH"), "state": "suspend"},
+                OkxLifecycleSourceErrorCode.NON_LIVE_STATE_BLOCKED.value,
+            ),
+            (
+                {**_live_inst("ETH"), "listTime": ""},
+                OkxLifecycleSourceErrorCode.MISSING_LIST_TIME.value,
+            ),
+        ],
+    )
+    def test_fail_closed_exclusions(self, inst: dict[str, str], expected: str) -> None:
+        result = evaluate_okx_instrument_eligibility_v1(inst)
+        assert not result.eligible
+        assert expected in result.error_codes
+
+    def test_bitcoin_alias_blocked(self) -> None:
+        assert is_forbidden_okx_instrument_token("XBT-USDT-SWAP", "XBT")
+
+
+class TestDeterministicSelection:
+    def test_selects_at_least_five_non_bitcoin_instruments(self) -> None:
+        instruments = [
+            _live_inst("BTC"),
+            _live_inst("ETH"),
+            _live_inst("SOL"),
+            _live_inst("ADA"),
+            _live_inst("DOT"),
+            _live_inst("LINK"),
+            _live_inst("AVAX"),
+        ]
+        selected, exclusions = select_eligible_okx_instruments_v1(instruments)
+        assert len(selected) >= MIN_ELIGIBLE_INSTRUMENT_COUNT
+        assert OkxLifecycleSourceErrorCode.BITCOIN_INSTRUMENT_BLOCKED.value in exclusions
+        assert all("btc" not in item.inst_id.lower() for item in selected)
+
+    def test_selection_is_deterministic_by_instrument_id(self) -> None:
+        instruments = [_live_inst(base) for base in ("ETH", "SOL", "ADA", "DOT", "LINK", "AVAX")]
+        first, _ = select_eligible_okx_instruments_v1(instruments)
+        second, _ = select_eligible_okx_instruments_v1(list(reversed(instruments)))
+        assert [item.inst_id for item in first] == [item.inst_id for item in second]
+
+
+class TestLifecycleAssembly:
+    def test_builds_registry_snapshot_from_production_source(self) -> None:
+        instruments = [_live_inst(base) for base in ("ETH", "SOL", "ADA", "DOT", "LINK", "AVAX")]
+        snapshot = build_okx_lifecycle_source_snapshot_v1(
+            instruments,
+            retrieval_timestamp_utc="2026-07-03T03:30:00Z",
+            source_snapshot_ref="okx_public_instruments_swap:test",
+        )
+        observations = build_lifecycle_source_observations_v1(snapshot)
+        assembly = assemble_registry_snapshot_v1(
+            observations,
+            generated_at="2026-07-03T03:30:00Z",
+            venue_scope=("okx",),
+            config_digest="d" * 64,
+            implementation_digest="e" * 64,
+            registered_sources=frozenset({SOURCE_ID}),
+            approved_snapshot_digests=frozenset({snapshot.raw_snapshot_digest}),
+        )
+        assert assembly.success
+        assert assembly.snapshot is not None
+        assert len(assembly.snapshot.intervals) >= MIN_ELIGIBLE_INSTRUMENT_COUNT
+
+    def test_is_okx_linear_usdt_perpetual_positive(self) -> None:
+        assert is_okx_linear_usdt_perpetual(_live_inst("ETH"))

--- a/tests/research/test_pit_okx_pt1h_panel_ohlcv_dataset_v1.py
+++ b/tests/research/test_pit_okx_pt1h_panel_ohlcv_dataset_v1.py
@@ -1,0 +1,113 @@
+"""Contract tests for pit_okx_pt1h_panel_ohlcv_dataset_v1."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import (
+    BAR_GRANULARITY,
+    InstrumentPanelSeriesV1,
+    PanelBarV1,
+    PanelValidationErrorCode,
+    build_panel_dataset_manifest_v1,
+    compute_panel_digest,
+    validate_panel_series_v1,
+)
+
+
+def _bar(
+    instrument_id: str,
+    hour: int,
+    *,
+    open_: str = "100",
+    high: str = "101",
+    low: str = "99",
+    close: str = "100.5",
+    volume: str = "1000",
+) -> PanelBarV1:
+    return PanelBarV1(
+        instrument_id=instrument_id,
+        timestamp_utc=f"2026-06-01T{hour:02d}:00:00Z",
+        open=open_,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+        is_final=True,
+    )
+
+
+def _series(inst: str, hours: range) -> InstrumentPanelSeriesV1:
+    bars = tuple(_bar(inst, hour) for hour in hours)
+    return InstrumentPanelSeriesV1(
+        instrument_id=inst,
+        native_instrument_id=f"{inst.split(':')[2]}-USDT-SWAP",
+        bars=bars,
+        series_digest="0" * 64,
+    )
+
+
+class TestPanelValidation:
+    def test_valid_multi_instrument_panel_passes(self) -> None:
+        hours = range(0, 6)
+        series = [
+            _series(f"okx:linear_perpetual:{base}:USDT:USDT:perp", hours)
+            for base in ("ETH", "SOL", "ADA", "DOT", "LINK")
+        ]
+        result = validate_panel_series_v1(series, min_instruments=5)
+        assert result.valid
+        assert result.duplicate_check == "PASS"
+        assert result.gap_check == "PASS"
+        assert result.out_of_order_check == "PASS"
+
+    def test_duplicate_timestamp_fails(self) -> None:
+        inst = "okx:linear_perpetual:ETH:USDT:USDT:perp"
+        bars = (_bar(inst, 1), _bar(inst, 1))
+        series = [
+            InstrumentPanelSeriesV1(
+                instrument_id=inst,
+                native_instrument_id="ETH-USDT-SWAP",
+                bars=bars,
+                series_digest="0" * 64,
+            )
+        ]
+        result = validate_panel_series_v1(series, min_instruments=1)
+        assert not result.valid
+        assert PanelValidationErrorCode.DUPLICATE_TIMESTAMP.value in result.error_codes
+
+    def test_bitcoin_instrument_fails(self) -> None:
+        series = [_series("okx:linear_perpetual:BTC:USDT:USDT:perp", range(3))]
+        result = validate_panel_series_v1(series, min_instruments=1)
+        assert PanelValidationErrorCode.BITCOIN_INSTRUMENT_PRESENT.value in result.error_codes
+
+    def test_gap_detection_fails(self) -> None:
+        inst = "okx:linear_perpetual:ETH:USDT:USDT:perp"
+        bars = (_bar(inst, 1), _bar(inst, 3))
+        series = [
+            InstrumentPanelSeriesV1(
+                instrument_id=inst,
+                native_instrument_id="ETH-USDT-SWAP",
+                bars=bars,
+                series_digest="0" * 64,
+            )
+        ]
+        result = validate_panel_series_v1(series, min_instruments=1)
+        assert PanelValidationErrorCode.GAP_DETECTED.value in result.error_codes
+
+    def test_manifest_digest_is_deterministic(self) -> None:
+        hours = range(0, 3)
+        series = [
+            _series(f"okx:linear_perpetual:{base}:USDT:USDT:perp", hours)
+            for base in ("ETH", "SOL", "ADA", "DOT", "LINK")
+        ]
+        manifest = build_panel_dataset_manifest_v1(
+            series_list=series,
+            lifecycle_registry_ref="pit_futures_lifecycle_registry_v1:test:sha256:" + ("a" * 64),
+            lifecycle_registry_digest="a" * 64,
+            period_start_utc="2026-06-01T00:00:00Z",
+            period_end_utc="2026-06-01T02:00:00Z",
+            config_digest="b" * 64,
+            source_provenance_digest="c" * 64,
+        )
+        assert manifest.bar_granularity == BAR_GRANULARITY
+        assert compute_panel_digest(series) == manifest.normalized_panel_digest


### PR DESCRIPTION
## Summary

- Registers `okx_production_instrument_lifecycle_historical_as_of_fail_closed.v1` in the canonical PIT futures lifecycle registry owner (`_REGISTERED_SOURCES_V0`).
- Adds bounded OKX public-metadata lifecycle source adapter with fail-closed eligibility (non-Bitcoin linear USDT perpetuals only; `state=live`; conservative `listTime` semantics).
- Adds PT1H multi-instrument panel OHLCV dataset owner + materialization script producing digest-bound lifecycle registry snapshot and panel manifest.

## Scope / invariants

- `FUTURES_ONLY=true`, `BITCOIN_DIRECTION_ALLOWED=false`, no synthetic production sources
- Public read-only OKX REST only; no credentials/orders/runtime authority
- **Does not** materialize PIT universe manifest, cross-sectional binding updates, or economic evaluation
- Primary worktree untouched; all work in feature worktree from `origin/main` @ `9f7bfc35`

## Production materialization evidence

- Durable evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/planning/bounded_okx_production_lifecycle_source_registration_and_pt1h_panel_ohlcv_ingest_v0_20260703T031526Z`
- Staged dataset: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_pt1h_panel/v1`
- `MANIFEST_VERIFY_RC=0`
- `ELIGIBLE_INSTRUMENT_COUNT=391`, `BAR_GRANULARITY=PT1H`
- Panel period: `2026-07-02T12:00:00Z` .. `2026-07-03T02:00:00Z`

## CI selection

- Selector: `PR_BOUNDED_FULL` (`category_central_src_requires_full`) — central `src/research` diff; no required-context mutation

## Test plan

- [x] `tests/research/test_okx_production_instrument_lifecycle_source_v1.py`
- [x] `tests/research/test_pit_okx_pt1h_panel_ohlcv_dataset_v1.py`
- [x] `tests/ops/test_materialize_okx_production_lifecycle_and_pt1h_panel_v1.py`
- [x] Lifecycle registry regression suites
- [x] `ruff format --check`, `ruff check`, `git diff --check`
- [x] Live OKX materialization run (public REST)


Made with [Cursor](https://cursor.com)