### PR TITLE
feat(research): PIT universe manifest dataset/period/instrument binding v0

### DIFF
--- a/config/research/pit_futures_universe_manifest_dataset_period_binding_policy_v1.json
+++ b/config/research/pit_futures_universe_manifest_dataset_period_binding_policy_v1.json
@@ -1,0 +1,13 @@
+{
+  "binding_contract_version": "pit_futures_universe_manifest_dataset_period_binding.v0",
+  "candidate_binding_version": "v0",
+  "dataset_binding_version": "v0",
+  "dataset_profile": "cross_sectional_research_staging_v1",
+  "fleet_id": "final_research_fleet_v0",
+  "fleet_version": "v0",
+  "instrument_binding_version": "v0",
+  "period_binding_version": "v0",
+  "policy_version": "pit_futures_universe_manifest_dataset_period_binding_policy.v1",
+  "universe_policy_id": "pit_okx_linear_usdt_non_bitcoin_perpetual_cross_sectional_universe",
+  "universe_policy_version": "v1"
+}

--- a/scripts/ops/materialize_pit_futures_universe_manifest_dataset_period_binding_v0.py
+++ b/scripts/ops/materialize_pit_futures_universe_manifest_dataset_period_binding_v0.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Materialize PIT futures universe manifest dataset/period/instrument binding v0.
+
+Offline-first: reads production universe manifest + materialization envelope from an
+explicit staging root produced by materialize_pit_futures_universe_manifest_production_v1.
+No network, no orders, no runtime effect, no economic evaluation execution.
+Operator GO: GO_BOUNDED_PIT_FUTURES_UNIVERSE_MANIFEST_DATASET_PERIOD_BINDING_V0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+CONFIRM_GO = "GO_BOUNDED_PIT_FUTURES_UNIVERSE_MANIFEST_DATASET_PERIOD_BINDING_V0"
+
+from src.research.pit_futures_universe_manifest_dataset_period_binding_v0 import (  # noqa: E402
+    CONTRACT_ID,
+    SCHEMA_VERSION,
+    UNIVERSE_POLICY_ID,
+    UNIVERSE_POLICY_VERSION,
+    ValidationVerdict,
+    envelope_from_dict,
+    manifest_from_dict,
+    materialize_pit_futures_universe_manifest_dataset_period_binding_v0,
+    serialize_contract_canonical_v0,
+    validate_pit_futures_universe_manifest_dataset_period_binding_v0,
+)
+
+
+def _utc_now_z() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        _die(f"ERR: not_object:{path}")
+    return payload
+
+
+def run_materialization(
+    *,
+    confirm: str,
+    staging_root: Path,
+    durable_evidence_root: Path,
+) -> dict[str, Any]:
+    if confirm != CONFIRM_GO:
+        _die(f"ERR: confirm_go_token_required:{CONFIRM_GO}")
+
+    manifest_path = staging_root / "universe" / "pit_futures_universe_manifest_v1.json"
+    envelope_path = staging_root / "universe" / "production_materialization_envelope_v1.json"
+    if not manifest_path.is_file():
+        _die(f"ERR: missing_production_manifest:{manifest_path}")
+    if not envelope_path.is_file():
+        _die(f"ERR: missing_production_envelope:{envelope_path}")
+
+    production_manifest = manifest_from_dict(_load_json(manifest_path))
+    production_envelope = envelope_from_dict(_load_json(envelope_path))
+
+    contract = materialize_pit_futures_universe_manifest_dataset_period_binding_v0(
+        repo_root=_REPO_ROOT,
+        production_manifest=production_manifest,
+        production_envelope=production_envelope,
+    )
+    validation = validate_pit_futures_universe_manifest_dataset_period_binding_v0(
+        contract,
+        repo_root=_REPO_ROOT,
+        expected_manifest=production_manifest,
+        expected_envelope=production_envelope,
+    )
+    if validation.verdict != ValidationVerdict.ACCEPTED:
+        _die(f"ERR: binding_contract_validation_failed:{validation.fail_reasons}")
+
+    binding_dir = staging_root / "binding"
+    binding_dir.mkdir(parents=True, exist_ok=True)
+    contract_path = binding_dir / "pit_futures_universe_manifest_dataset_period_binding_v0.json"
+    contract_path.write_text(serialize_contract_canonical_v0(contract), encoding="utf-8")
+
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    evidence_dir = (
+        durable_evidence_root
+        / "planning"
+        / f"bounded_pit_futures_universe_manifest_dataset_period_binding_v0_{ts_slug}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    for rel in (
+        "universe/pit_futures_universe_manifest_v1.json",
+        "universe/production_materialization_envelope_v1.json",
+        "binding/pit_futures_universe_manifest_dataset_period_binding_v0.json",
+    ):
+        src = staging_root / rel
+        if src.is_file():
+            dst = evidence_dir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(src.read_bytes())
+
+    from scripts.ops import primary_evidence_retention_v0 as retention
+
+    rc, verify_msg = retention.finalize_durable_bundle_manifest(evidence_dir)
+
+    payload = {
+        "verdict": "PIT_FUTURES_UNIVERSE_MANIFEST_DATASET_PERIOD_BINDING_COMPLETE",
+        "schema_version": SCHEMA_VERSION,
+        "contract_id": CONTRACT_ID,
+        "universe_policy_id": UNIVERSE_POLICY_ID,
+        "universe_policy_version": UNIVERSE_POLICY_VERSION,
+        "production_universe_manifest_ref": contract["production_universe_manifest_ref"],
+        "production_universe_manifest_digest": contract["production_universe_manifest_digest"],
+        "contract_digest": contract["contract_digest"],
+        "candidate_count": len(contract["candidates"]),
+        "candidate_strategy_ids": [item["strategy_id"] for item in contract["candidates"]],
+        "staging_root": str(staging_root),
+        "durable_evidence_path": str(evidence_dir),
+        "manifest_verify_rc": rc,
+        "manifest_verify_msg": verify_msg,
+    }
+    (evidence_dir / "BINDING_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _emit_machine_lines(payload)
+    return payload
+
+
+def _emit_machine_lines(result: Mapping[str, Any]) -> None:
+    for key in (
+        "verdict",
+        "universe_policy_id",
+        "universe_policy_version",
+        "production_universe_manifest_digest",
+        "contract_digest",
+        "manifest_verify_rc",
+    ):
+        print(f"{key.upper()}={result.get(key)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Materialize PIT futures universe manifest dataset/period/instrument binding v0."
+        )
+    )
+    parser.add_argument("--confirm-go-token", required=True, choices=[CONFIRM_GO])
+    parser.add_argument("--staging-root", type=Path, required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, required=True)
+    args = parser.parse_args()
+    run_materialization(
+        confirm=args.confirm_go_token,
+        staging_root=args.staging_root,
+        durable_evidence_root=args.durable_evidence_root,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/research/pit_futures_universe_manifest_dataset_period_binding_v0.py
+++ b/src/research/pit_futures_universe_manifest_dataset_period_binding_v0.py
@@ -1,0 +1,866 @@
+"""Production PIT universe manifest dataset/period/instrument binding contract v0.
+
+Deterministic, fail-closed staging bindings for final_research_fleet_v0 candidates
+(trend_following/v1, bollinger_bands/v1, momentum_1h/v1) wired to the production
+materialized point-in-time OKX futures universe manifest from PR #4782.
+
+Research-only, non-authorizing. No economic evaluation, no runtime or order effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.backtest.strategy_signal_binding_v1 import (
+    collect_configured_strategy_params_v1,
+    resolve_effective_strategy_params_v1,
+)
+from src.research.final_research_fleet_v0_versioned_binding_manifest_contract_v0 import (
+    ECONOMIC_POLICY_VERSION,
+    FLEET_CANDIDATES,
+    STEP31F_CONFIG_PATHS,
+    compute_config_digest_v1,
+    load_step31f_evaluation_config_v0,
+)
+from src.research.pit_futures_universe_manifest_production_materialization_v1 import (
+    EVALUATION_PERIOD_BINDING,
+    FUTURES_ONLY,
+    ProductionManifestMaterializationEnvelopeV1,
+    UNIVERSE_POLICY_ID,
+    UNIVERSE_POLICY_VERSION,
+)
+from src.research.pit_futures_universe_manifest_v1 import (
+    PointInTimeFuturesUniverseManifestV1,
+    compute_manifest_digest,
+    is_valid_digest,
+    is_valid_rfc3339_utc,
+    manifest_from_dict,
+)
+from src.research.pit_futures_universe_manifest_validator_v1 import (
+    ValidationVerdict as ManifestValidationVerdict,
+    validate_pit_futures_universe_manifest_v1,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import BAR_GRANULARITY, PANEL_DATASET_VERSION
+from src.strategies.registry import get_strategy_registry_entry, resolve_strategy_id
+
+PACKAGE_MARKER = "PIT_FUTURES_UNIVERSE_MANIFEST_DATASET_PERIOD_BINDING_V0=true"
+
+SCHEMA_VERSION = "pit_futures_universe_manifest_dataset_period_binding.v0"
+CONTRACT_ID = "pit_futures_universe_manifest_dataset_period_binding_v0"
+CANONICAL_SERIALIZATION_VERSION = "research_binding_manifest_canonical_json_v1"
+POLICY_CONFIG_REL_PATH = (
+    "config/research/pit_futures_universe_manifest_dataset_period_binding_policy_v1.json"
+)
+
+CANDIDATE_BINDING_VERSION = "v0"
+DATASET_BINDING_VERSION = "v0"
+PERIOD_BINDING_VERSION = "v0"
+INSTRUMENT_BINDING_VERSION = "v0"
+FLEET_ID = "final_research_fleet_v0"
+FLEET_VERSION = "v0"
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+ORDER_EFFECT = "NONE"
+
+DATASET_PROFILE = "cross_sectional_research_staging_v1"
+INSTRUMENT_BINDING_MODE = "production_universe_manifest_cross_sectional"
+INSTRUMENT_SELECTION_OWNER = "production_pit_universe_manifest_v1"
+
+NOT_YET_MATERIALIZED = {"status": "NOT_YET_MATERIALIZED"}
+BINDING_STATUS_NOT_READY = "NOT_READY"
+
+FORBIDDEN_INSTRUMENT_TOKENS = frozenset(
+    {"btc", "xbt", "bitcoin", "spot", "synthetic_spot", "synthetic-spot"}
+)
+_ABSOLUTE_PATH_PATTERN = re.compile(r"(^/|^\\\\|^[A-Za-z]:[/\\\\])")
+
+REASON_UNKNOWN_STRATEGY = "UNKNOWN_STRATEGY"
+REASON_WRONG_STRATEGY_VERSION = "WRONG_STRATEGY_VERSION"
+REASON_MISSING_CANDIDATE = "MISSING_FLEET_CANDIDATE"
+REASON_EXTRA_CANDIDATE = "EXTRA_FLEET_CANDIDATE"
+REASON_DUPLICATE_CANDIDATE = "DUPLICATE_FLEET_CANDIDATE"
+REASON_MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD"
+REASON_UNKNOWN_SCHEMA_VERSION = "UNKNOWN_SCHEMA_VERSION"
+REASON_MANIFEST_NOT_OBJECT = "CONTRACT_NOT_OBJECT"
+REASON_EFFECT_NOT_NONE = "AUTHORITY_RUNTIME_ORDER_EFFECT_NOT_NONE"
+REASON_WRONG_CONTRACT_DIGEST = "WRONG_CONTRACT_DIGEST"
+REASON_NON_CANONICAL_SERIALIZATION = "NON_CANONICAL_SERIALIZATION"
+REASON_BINDING_REPAIR_REJECTED = "BINDING_REPAIR_REJECTED"
+REASON_SHARED_BINDING_MISMATCH = "SHARED_BINDING_MISMATCH"
+REASON_PRODUCTION_MANIFEST_DIGEST_MISMATCH = "PRODUCTION_MANIFEST_DIGEST_MISMATCH"
+REASON_PRODUCTION_MANIFEST_REF_MISMATCH = "PRODUCTION_MANIFEST_REF_MISMATCH"
+REASON_UNKNOWN_UNIVERSE_POLICY = "UNKNOWN_UNIVERSE_POLICY"
+REASON_UNKNOWN_UNIVERSE_POLICY_VERSION = "UNKNOWN_UNIVERSE_POLICY_VERSION"
+REASON_BITCOIN_INSTRUMENT_PRESENT = "BITCOIN_INSTRUMENT_PRESENT"
+REASON_SPOT_BINDING = "SPOT_BINDING_REJECTED"
+REASON_SYNTHETIC_SPOT_BINDING = "SYNTHETIC_SPOT_BINDING_REJECTED"
+REASON_BITCOIN_DIRECTION_BINDING = "BITCOIN_DIRECTION_BINDING_REJECTED"
+REASON_FUTURES_ONLY_VIOLATION = "FUTURES_ONLY_VIOLATION"
+REASON_MISSING_PERIOD_COVERAGE = "MISSING_PERIOD_COVERAGE"
+REASON_INVALID_PERIOD_COVERAGE = "INVALID_PERIOD_COVERAGE"
+REASON_MISSING_PANEL_DATASET_DIGEST = "MISSING_PANEL_DATASET_DIGEST"
+REASON_MANIFEST_VALIDATION_FAILED = "PRODUCTION_MANIFEST_VALIDATION_FAILED"
+REASON_MANIFEST_TAMPERED = "PRODUCTION_MANIFEST_TAMPERED"
+REASON_ENVELOPE_MANIFEST_DIGEST_MISMATCH = "ENVELOPE_MANIFEST_DIGEST_MISMATCH"
+REASON_WRONG_CONFIG_DIGEST = "WRONG_CONFIG_DIGEST"
+REASON_WRONG_IMPLEMENTATION_DIGEST = "WRONG_IMPLEMENTATION_DIGEST"
+REASON_WRONG_PARAMETER_BINDING = "WRONG_PARAMETER_BINDING"
+REASON_ZERO_FEE = "ZERO_FEE_REJECTED"
+REASON_ZERO_SLIPPAGE = "ZERO_SLIPPAGE_REJECTED"
+REASON_DATA_DIGEST_NOT_MATERIALIZED = "DATA_DIGEST_NOT_YET_MATERIALIZED"
+REASON_PERIOD_SPLIT_NOT_MATERIALIZED = "PERIOD_SPLIT_NOT_YET_MATERIALIZED"
+
+CANDIDATE_REQUIRED_FIELDS = (
+    "strategy_id",
+    "strategy_version",
+    "candidate_binding_version",
+    "parameter_binding",
+    "dataset_binding",
+    "dataset_version",
+    "period_binding",
+    "training_period",
+    "validation_period",
+    "out_of_sample_period",
+    "instrument_binding",
+    "universe_policy_id",
+    "universe_policy_version",
+    "production_universe_manifest_ref",
+    "production_universe_manifest_digest",
+    "fee_model_binding",
+    "slippage_model_binding",
+    "funding_model_binding",
+    "execution_model_binding",
+    "economic_policy_binding",
+    "implementation_digest",
+    "config_digest",
+    "data_digest",
+    "binding_status",
+    "reason_codes",
+)
+
+CONTRACT_REQUIRED_FIELDS = (
+    "schema_version",
+    "contract_id",
+    "fleet_id",
+    "fleet_version",
+    "candidate_binding_version",
+    "dataset_binding_version",
+    "period_binding_version",
+    "instrument_binding_version",
+    "production_universe_manifest_ref",
+    "production_universe_manifest_digest",
+    "shared_bindings",
+    "candidates",
+    "canonical_serialization_version",
+    "contract_digest",
+    "authority_effect",
+    "runtime_effect",
+    "order_effect",
+    "config_digest",
+    "implementation_digest",
+)
+
+
+class ValidationVerdict(str, Enum):
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True)
+class DatasetPeriodBindingValidationResultV0:
+    verdict: ValidationVerdict
+    valid: bool
+    fail_reasons: tuple[str, ...]
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_implementation_digest_v0() -> str:
+    return _stable_digest(
+        {
+            "module": "pit_futures_universe_manifest_dataset_period_binding_v0",
+            "schema_version": SCHEMA_VERSION,
+        }
+    )
+
+
+def compute_policy_config_digest_v0(repo_root: Path | None = None) -> str:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    path = root / POLICY_CONFIG_REL_PATH
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(REASON_MISSING_REQUIRED_FIELD + ":policy_config")
+    return _stable_digest(payload)
+
+
+def dumps_contract_canonical_v1(obj: Mapping[str, Any]) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str, ensure_ascii=False)
+
+
+def compute_contract_digest_v0(contract_body: Mapping[str, Any]) -> str:
+    body = dict(contract_body)
+    body.pop("contract_digest", None)
+    return hashlib.sha256(dumps_contract_canonical_v1(body).encode("utf-8")).hexdigest()
+
+
+def serialize_contract_canonical_v0(contract: Mapping[str, Any]) -> str:
+    return dumps_contract_canonical_v1(contract) + "\n"
+
+
+def envelope_from_dict(data: Mapping[str, Any]) -> ProductionManifestMaterializationEnvelopeV1:
+    return ProductionManifestMaterializationEnvelopeV1(
+        materialization_version=str(data["materialization_version"]),
+        universe_policy_id=str(data["universe_policy_id"]),
+        universe_policy_version=str(data["universe_policy_version"]),
+        inclusion_policy_version=str(data["inclusion_policy_version"]),
+        exclusion_policy_version=str(data["exclusion_policy_version"]),
+        venue_id=str(data["venue_id"]),
+        venue_family=str(data["venue_family"]),
+        market_type=str(data["market_type"]),
+        settlement_asset=str(data["settlement_asset"]),
+        quote_asset=str(data["quote_asset"]),
+        contract_type=str(data["contract_type"]),
+        perpetual_only=bool(data["perpetual_only"]),
+        linear_contract=bool(data["linear_contract"]),
+        futures_only=bool(data["futures_only"]),
+        bitcoin_direction_allowed=bool(data["bitcoin_direction_allowed"]),
+        spot_allowed=bool(data["spot_allowed"]),
+        synthetic_spot_allowed=bool(data["synthetic_spot_allowed"]),
+        instrument_metadata_source_id=str(data["instrument_metadata_source_id"]),
+        lifecycle_source_snapshot_ref=str(data["lifecycle_source_snapshot_ref"]),
+        lifecycle_source_snapshot_digest=str(data["lifecycle_source_snapshot_digest"]),
+        registry_reference=str(data["registry_reference"]),
+        registry_snapshot_digest=str(data["registry_snapshot_digest"]),
+        panel_dataset_ref=str(data["panel_dataset_ref"]),
+        panel_dataset_digest=str(data["panel_dataset_digest"]),
+        period_binding_ref=str(data["period_binding_ref"]),
+        period_start_utc=str(data["period_start_utc"]),
+        period_end_utc=str(data["period_end_utc"]),
+        materialization_config_digest=str(data["materialization_config_digest"]),
+        materialization_implementation_digest=str(data["materialization_implementation_digest"]),
+        binding_implementation_digest=str(data["binding_implementation_digest"]),
+        reproducibility_inputs_digest=str(data["reproducibility_inputs_digest"]),
+        manifest_reference=data.get("manifest_reference"),
+        manifest_digest=data.get("manifest_digest"),
+        generated_at=str(data["generated_at"]),
+        eligible_instrument_count=int(data["eligible_instrument_count"]),
+        excluded_instrument_count=int(data["excluded_instrument_count"]),
+        pit_semantics_enforced=bool(data["pit_semantics_enforced"]),
+        non_authorizing=bool(data["non_authorizing"]),
+        no_runtime_effect=bool(data["no_runtime_effect"]),
+    )
+
+
+def _contains_forbidden_token(value: str) -> bool:
+    lowered = value.lower()
+    return any(token in lowered for token in FORBIDDEN_INSTRUMENT_TOKENS)
+
+
+def _reject_repair_keys(obj: Mapping[str, Any], *, path: str, reasons: list[str]) -> None:
+    for key in obj:
+        if key in {"repair", "fallback", "auto_fix", "default_if_missing"}:
+            reasons.append(f"{REASON_BINDING_REPAIR_REJECTED}:{path}.{key}")
+
+
+def _extract_parameter_binding(cfg: Mapping[str, Any], strategy_id: str) -> dict[str, Any]:
+    params = collect_configured_strategy_params_v1(cfg, strategy_id)
+    if not params:
+        eval_section = cfg.get("economic_evaluation_v1")
+        if isinstance(eval_section, Mapping):
+            raw = eval_section.get("strategy_params")
+            if isinstance(raw, Mapping):
+                params = dict(raw)
+    return dict(params)
+
+
+def _extract_fee_model_binding(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    backtest = cfg.get("backtest")
+    if not isinstance(backtest, Mapping):
+        raise ValueError(REASON_MISSING_REQUIRED_FIELD + ":fee_model_binding")
+    return {
+        "fee_bps": backtest.get("fee_bps"),
+        "fee_model_version": str(backtest.get("fee_model_version", "")),
+    }
+
+
+def _extract_slippage_model_binding(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    backtest = cfg.get("backtest")
+    if not isinstance(backtest, Mapping):
+        raise ValueError(REASON_MISSING_REQUIRED_FIELD + ":slippage_model_binding")
+    return {
+        "slippage_bps": backtest.get("slippage_bps"),
+        "slippage_model_version": str(backtest.get("slippage_model_version", "")),
+    }
+
+
+def _extract_funding_model_binding(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    backtest = cfg.get("backtest")
+    if not isinstance(backtest, Mapping):
+        raise ValueError(REASON_MISSING_REQUIRED_FIELD + ":funding_model_binding")
+    funding = backtest.get("funding")
+    if not isinstance(funding, Mapping):
+        raise ValueError(REASON_MISSING_REQUIRED_FIELD + ":funding_model_binding")
+    return {
+        "bind": bool(funding.get("bind")),
+        "model_version": str(funding.get("model_version", "")),
+    }
+
+
+def _extract_execution_model_binding(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    real = cfg.get("real_admissible_futures_evaluation_binding_v1")
+    if not isinstance(real, Mapping):
+        raise ValueError(REASON_MISSING_REQUIRED_FIELD + ":execution_model_binding")
+    return {
+        "execution_model_version": str(real.get("execution_model_version", "")),
+        "roundtrip_cost_bps": real.get("roundtrip_cost_bps"),
+    }
+
+
+def _extract_economic_policy_binding(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    eval_section = cfg.get("economic_evaluation_v1")
+    version = ECONOMIC_POLICY_VERSION
+    if isinstance(eval_section, Mapping):
+        raw = eval_section.get("economic_validity_policy_version")
+        if isinstance(raw, str) and raw.strip():
+            version = raw
+    return {"policy_version": version}
+
+
+def _build_dataset_binding(
+    envelope: ProductionManifestMaterializationEnvelopeV1,
+) -> dict[str, Any]:
+    return {
+        "dataset_binding_version": DATASET_BINDING_VERSION,
+        "dataset_version": PANEL_DATASET_VERSION,
+        "dataset_profile": DATASET_PROFILE,
+        "bar_granularity": BAR_GRANULARITY,
+        "panel_dataset_ref": envelope.panel_dataset_ref.strip(),
+        "panel_dataset_digest": envelope.panel_dataset_digest.strip().lower(),
+        "instrument_metadata_source": INSTRUMENT_SELECTION_OWNER,
+        "evaluation_period_binding": envelope.period_binding_ref.strip(),
+    }
+
+
+def _build_period_binding(
+    envelope: ProductionManifestMaterializationEnvelopeV1,
+) -> dict[str, Any]:
+    return {
+        "period_binding_version": PERIOD_BINDING_VERSION,
+        "period_binding_ref": envelope.period_binding_ref.strip(),
+        "coverage_period_start_utc": envelope.period_start_utc,
+        "coverage_period_end_utc": envelope.period_end_utc,
+    }
+
+
+def _build_instrument_binding(
+    *,
+    production_manifest: PointInTimeFuturesUniverseManifestV1,
+    envelope: ProductionManifestMaterializationEnvelopeV1,
+) -> dict[str, Any]:
+    if not production_manifest.epochs:
+        raise ValueError(REASON_MISSING_REQUIRED_FIELD + ":production_manifest.epochs")
+    members = production_manifest.epochs[0].members
+    eligible_instrument_ids = tuple(sorted(member.instrument_id for member in members))
+    native_by_id = {member.instrument_id: member.venue_symbol for member in members}
+    return {
+        "instrument_binding_version": INSTRUMENT_BINDING_VERSION,
+        "binding_mode": INSTRUMENT_BINDING_MODE,
+        "instrument_selection_owner": INSTRUMENT_SELECTION_OWNER,
+        "no_parallel_universe_ssot": True,
+        "universe_policy_id": production_manifest.universe_policy_id,
+        "universe_policy_version": production_manifest.universe_policy_version,
+        "production_universe_manifest_ref": envelope.manifest_reference or "",
+        "production_universe_manifest_digest": production_manifest.manifest_digest,
+        "venue_id": envelope.venue_id,
+        "eligible_instrument_ids": list(eligible_instrument_ids),
+        "eligible_native_instrument_ids": [
+            native_by_id[instrument_id] for instrument_id in eligible_instrument_ids
+        ],
+        "eligible_instrument_count": len(eligible_instrument_ids),
+        "futures_only": FUTURES_ONLY,
+        "bitcoin_direction_allowed": False,
+        "spot_allowed": False,
+        "synthetic_spot_allowed": False,
+    }
+
+
+def _build_data_digest(envelope: ProductionManifestMaterializationEnvelopeV1) -> dict[str, Any]:
+    return {
+        "status": "NOT_YET_MATERIALIZED",
+        "bound_panel_dataset_digest": envelope.panel_dataset_digest.strip().lower(),
+    }
+
+
+def _build_reason_codes() -> list[str]:
+    return sorted(
+        [
+            REASON_DATA_DIGEST_NOT_MATERIALIZED,
+            REASON_PERIOD_SPLIT_NOT_MATERIALIZED,
+        ]
+    )
+
+
+def _build_candidate_binding_v0(
+    *,
+    repo_root: Path,
+    strategy_id: str,
+    strategy_version: str,
+    shared_dataset_binding: Mapping[str, Any],
+    shared_period_binding: Mapping[str, Any],
+    shared_instrument_binding: Mapping[str, Any],
+    data_digest: Mapping[str, Any],
+    envelope: ProductionManifestMaterializationEnvelopeV1,
+    production_manifest: PointInTimeFuturesUniverseManifestV1,
+) -> dict[str, Any]:
+    cfg = load_step31f_evaluation_config_v0(repo_root, strategy_id)
+    eval_section = cfg.get("economic_evaluation_v1")
+    if not isinstance(eval_section, Mapping):
+        raise ValueError(REASON_MISSING_REQUIRED_FIELD + ":economic_evaluation_v1")
+    if str(eval_section.get("strategy_id", "")) != strategy_id:
+        raise ValueError(f"{REASON_UNKNOWN_STRATEGY}:{strategy_id}")
+    if str(eval_section.get("strategy_version", "")) != strategy_version:
+        raise ValueError(f"{REASON_WRONG_STRATEGY_VERSION}:{strategy_id}")
+
+    resolution = resolve_strategy_id(strategy_id)
+    if resolution.canonical_strategy_id != strategy_id:
+        raise ValueError(f"{REASON_UNKNOWN_STRATEGY}:{strategy_id}")
+    entry = get_strategy_registry_entry(strategy_id)
+    if entry.strategy_version != strategy_version:
+        raise ValueError(f"{REASON_WRONG_STRATEGY_VERSION}:{strategy_id}")
+
+    parameter_binding = _extract_parameter_binding(cfg, strategy_id)
+    _, strategy_params_digest = resolve_effective_strategy_params_v1(
+        strategy_id,
+        parameter_binding,
+    )
+
+    return {
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        "candidate_binding_version": CANDIDATE_BINDING_VERSION,
+        "parameter_binding": parameter_binding,
+        "dataset_binding": dict(shared_dataset_binding),
+        "dataset_version": PANEL_DATASET_VERSION,
+        "period_binding": dict(shared_period_binding),
+        "training_period": dict(NOT_YET_MATERIALIZED),
+        "validation_period": dict(NOT_YET_MATERIALIZED),
+        "out_of_sample_period": dict(NOT_YET_MATERIALIZED),
+        "instrument_binding": dict(shared_instrument_binding),
+        "universe_policy_id": production_manifest.universe_policy_id,
+        "universe_policy_version": production_manifest.universe_policy_version,
+        "production_universe_manifest_ref": envelope.manifest_reference or "",
+        "production_universe_manifest_digest": production_manifest.manifest_digest,
+        "fee_model_binding": _extract_fee_model_binding(cfg),
+        "slippage_model_binding": _extract_slippage_model_binding(cfg),
+        "funding_model_binding": _extract_funding_model_binding(cfg),
+        "execution_model_binding": _extract_execution_model_binding(cfg),
+        "economic_policy_binding": _extract_economic_policy_binding(cfg),
+        "implementation_digest": entry.implementation_digest,
+        "config_digest": compute_config_digest_v1(cfg),
+        "data_digest": dict(data_digest),
+        "strategy_params_digest": strategy_params_digest,
+        "binding_status": BINDING_STATUS_NOT_READY,
+        "reason_codes": _build_reason_codes(),
+        "source_config_ref": STEP31F_CONFIG_PATHS[strategy_id],
+    }
+
+
+def materialize_pit_futures_universe_manifest_dataset_period_binding_v0(
+    *,
+    repo_root: Path,
+    production_manifest: PointInTimeFuturesUniverseManifestV1,
+    production_envelope: ProductionManifestMaterializationEnvelopeV1,
+) -> dict[str, Any]:
+    """Materialize deterministic dataset/period/instrument binding contract."""
+    manifest_validation = validate_pit_futures_universe_manifest_v1(production_manifest)
+    if manifest_validation.verdict != ManifestValidationVerdict.ACCEPTED:
+        raise ValueError(
+            f"{REASON_MANIFEST_VALIDATION_FAILED}:{','.join(manifest_validation.reason_codes)}"
+        )
+
+    if production_manifest.manifest_digest != compute_manifest_digest(production_manifest):
+        raise ValueError(REASON_MANIFEST_TAMPERED)
+
+    if production_envelope.manifest_digest != production_manifest.manifest_digest:
+        raise ValueError(REASON_ENVELOPE_MANIFEST_DIGEST_MISMATCH)
+
+    if production_manifest.universe_policy_id != UNIVERSE_POLICY_ID:
+        raise ValueError(REASON_UNKNOWN_UNIVERSE_POLICY)
+    if production_manifest.universe_policy_version != UNIVERSE_POLICY_VERSION:
+        raise ValueError(REASON_UNKNOWN_UNIVERSE_POLICY_VERSION)
+
+    dataset_binding = _build_dataset_binding(production_envelope)
+    period_binding = _build_period_binding(production_envelope)
+    instrument_binding = _build_instrument_binding(
+        production_manifest=production_manifest,
+        envelope=production_envelope,
+    )
+    data_digest = _build_data_digest(production_envelope)
+
+    candidates = [
+        _build_candidate_binding_v0(
+            repo_root=repo_root,
+            strategy_id=strategy_id,
+            strategy_version=strategy_version,
+            shared_dataset_binding=dataset_binding,
+            shared_period_binding=period_binding,
+            shared_instrument_binding=instrument_binding,
+            data_digest=data_digest,
+            envelope=production_envelope,
+            production_manifest=production_manifest,
+        )
+        for strategy_id, strategy_version in FLEET_CANDIDATES
+    ]
+    candidates.sort(key=lambda item: item["strategy_id"])
+
+    contract_body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "contract_id": CONTRACT_ID,
+        "fleet_id": FLEET_ID,
+        "fleet_version": FLEET_VERSION,
+        "candidate_binding_version": CANDIDATE_BINDING_VERSION,
+        "dataset_binding_version": DATASET_BINDING_VERSION,
+        "period_binding_version": PERIOD_BINDING_VERSION,
+        "instrument_binding_version": INSTRUMENT_BINDING_VERSION,
+        "production_universe_manifest_ref": production_envelope.manifest_reference or "",
+        "production_universe_manifest_digest": production_manifest.manifest_digest,
+        "shared_bindings": {
+            "dataset_binding": dataset_binding,
+            "period_binding": period_binding,
+            "instrument_binding": instrument_binding,
+        },
+        "candidates": candidates,
+        "canonical_serialization_version": CANONICAL_SERIALIZATION_VERSION,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "config_digest": compute_policy_config_digest_v0(repo_root),
+        "implementation_digest": compute_implementation_digest_v0(),
+        "evaluation_period_binding": EVALUATION_PERIOD_BINDING,
+        "futures_only": FUTURES_ONLY,
+        "bitcoin_direction_allowed": False,
+        "spot_allowed": False,
+        "synthetic_spot_allowed": False,
+        "non_authorizing": True,
+        "no_runtime_effect": True,
+        "no_economic_evaluation_execution": True,
+    }
+    contract_body["contract_digest"] = compute_contract_digest_v0(contract_body)
+    return contract_body
+
+
+def _validate_positive_cost(value: Any, *, field: str, reasons: list[str]) -> None:
+    if not isinstance(value, (int, float)) or float(value) <= 0.0:
+        reasons.append(f"{REASON_ZERO_FEE if 'fee' in field else REASON_ZERO_SLIPPAGE}:{field}")
+
+
+def _validate_instrument_binding(binding: Mapping[str, Any], reasons: list[str]) -> None:
+    if binding.get("futures_only") is not True:
+        reasons.append(REASON_FUTURES_ONLY_VIOLATION)
+    if binding.get("spot_allowed") is True:
+        reasons.append(REASON_SPOT_BINDING)
+    if binding.get("synthetic_spot_allowed") is True:
+        reasons.append(REASON_SYNTHETIC_SPOT_BINDING)
+    if binding.get("bitcoin_direction_allowed") is True:
+        reasons.append(REASON_BITCOIN_DIRECTION_BINDING)
+    for instrument_id in binding.get("eligible_instrument_ids", ()):
+        if isinstance(instrument_id, str) and _contains_forbidden_token(instrument_id):
+            reasons.append(f"{REASON_BITCOIN_INSTRUMENT_PRESENT}:{instrument_id}")
+
+
+def _validate_period_binding(binding: Mapping[str, Any], reasons: list[str]) -> None:
+    start = binding.get("coverage_period_start_utc")
+    end = binding.get("coverage_period_end_utc")
+    ref = binding.get("period_binding_ref")
+    if not isinstance(ref, str) or not ref.strip():
+        reasons.append(REASON_MISSING_PERIOD_COVERAGE + ":period_binding_ref")
+    if not isinstance(start, str) or not start.strip():
+        reasons.append(REASON_MISSING_PERIOD_COVERAGE + ":coverage_period_start_utc")
+    elif not is_valid_rfc3339_utc(start):
+        reasons.append(REASON_INVALID_PERIOD_COVERAGE + ":coverage_period_start_utc")
+    if not isinstance(end, str) or not end.strip():
+        reasons.append(REASON_MISSING_PERIOD_COVERAGE + ":coverage_period_end_utc")
+    elif not is_valid_rfc3339_utc(end):
+        reasons.append(REASON_INVALID_PERIOD_COVERAGE + ":coverage_period_end_utc")
+
+
+def _validate_dataset_binding(binding: Mapping[str, Any], reasons: list[str]) -> None:
+    digest = binding.get("panel_dataset_digest")
+    ref = binding.get("panel_dataset_ref")
+    if not isinstance(ref, str) or not ref.strip():
+        reasons.append(REASON_MISSING_REQUIRED_FIELD + ":panel_dataset_ref")
+    if not isinstance(digest, str) or not is_valid_digest(digest.strip().lower()):
+        reasons.append(REASON_MISSING_PANEL_DATASET_DIGEST)
+
+
+def _validate_deferred_period_field(field: Any, *, name: str, reasons: list[str]) -> None:
+    if not isinstance(field, Mapping):
+        reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{name}")
+        return
+    if field.get("status") != "NOT_YET_MATERIALIZED":
+        reasons.append(f"{REASON_PERIOD_SPLIT_NOT_MATERIALIZED}:{name}")
+
+
+def _validate_data_digest(field: Any, reasons: list[str]) -> None:
+    if not isinstance(field, Mapping):
+        reasons.append(REASON_MISSING_REQUIRED_FIELD + ":data_digest")
+        return
+    if field.get("status") != "NOT_YET_MATERIALIZED":
+        reasons.append(REASON_DATA_DIGEST_NOT_MATERIALIZED)
+        return
+    bound = field.get("bound_panel_dataset_digest")
+    if not isinstance(bound, str) or not is_valid_digest(bound.strip().lower()):
+        reasons.append(REASON_MISSING_PANEL_DATASET_DIGEST)
+
+
+def _validate_shared_candidate_bindings(
+    candidates: Sequence[Mapping[str, Any]],
+    reasons: list[str],
+) -> None:
+    if len(candidates) < 2:
+        return
+    reference = candidates[0]
+    for field in (
+        "dataset_binding",
+        "period_binding",
+        "instrument_binding",
+        "production_universe_manifest_ref",
+        "production_universe_manifest_digest",
+        "data_digest",
+    ):
+        ref_value = reference.get(field)
+        for candidate in candidates[1:]:
+            if candidate.get(field) != ref_value:
+                reasons.append(
+                    f"{REASON_SHARED_BINDING_MISMATCH}:{field}:{candidate.get('strategy_id')}"
+                )
+
+
+def validate_pit_futures_universe_manifest_dataset_period_binding_v0(
+    contract: Any,
+    *,
+    repo_root: Path,
+    expected_manifest: PointInTimeFuturesUniverseManifestV1 | None = None,
+    expected_envelope: ProductionManifestMaterializationEnvelopeV1 | None = None,
+    allow_recompute_digests: bool = True,
+) -> DatasetPeriodBindingValidationResultV0:
+    reasons: list[str] = []
+    if not isinstance(contract, Mapping):
+        return DatasetPeriodBindingValidationResultV0(
+            verdict=ValidationVerdict.REJECTED,
+            valid=False,
+            fail_reasons=(REASON_MANIFEST_NOT_OBJECT,),
+        )
+
+    _reject_repair_keys(contract, path="$", reasons=reasons)
+
+    if contract.get("schema_version") != SCHEMA_VERSION:
+        reasons.append(REASON_UNKNOWN_SCHEMA_VERSION)
+
+    for field in CONTRACT_REQUIRED_FIELDS:
+        if field not in contract:
+            reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{field}")
+
+    for effect_field, expected in (
+        ("authority_effect", AUTHORITY_EFFECT),
+        ("runtime_effect", RUNTIME_EFFECT),
+        ("order_effect", ORDER_EFFECT),
+    ):
+        if contract.get(effect_field) != expected:
+            reasons.append(f"{REASON_EFFECT_NOT_NONE}:{effect_field}")
+
+    manifest_ref = contract.get("production_universe_manifest_ref")
+    manifest_digest = contract.get("production_universe_manifest_digest")
+    if expected_envelope is not None:
+        if manifest_ref != (expected_envelope.manifest_reference or ""):
+            reasons.append(REASON_PRODUCTION_MANIFEST_REF_MISMATCH)
+        if expected_envelope.manifest_digest != manifest_digest:
+            reasons.append(REASON_PRODUCTION_MANIFEST_DIGEST_MISMATCH)
+    if expected_manifest is not None:
+        if expected_manifest.manifest_digest != manifest_digest:
+            reasons.append(REASON_PRODUCTION_MANIFEST_DIGEST_MISMATCH)
+        if expected_manifest.manifest_digest != compute_manifest_digest(expected_manifest):
+            reasons.append(REASON_MANIFEST_TAMPERED)
+
+    shared = contract.get("shared_bindings")
+    if isinstance(shared, Mapping):
+        dataset = shared.get("dataset_binding")
+        period = shared.get("period_binding")
+        instrument = shared.get("instrument_binding")
+        if isinstance(dataset, Mapping):
+            _validate_dataset_binding(dataset, reasons)
+        else:
+            reasons.append(REASON_MISSING_REQUIRED_FIELD + ":shared_bindings.dataset_binding")
+        if isinstance(period, Mapping):
+            _validate_period_binding(period, reasons)
+        else:
+            reasons.append(REASON_MISSING_REQUIRED_FIELD + ":shared_bindings.period_binding")
+        if isinstance(instrument, Mapping):
+            _validate_instrument_binding(instrument, reasons)
+        else:
+            reasons.append(REASON_MISSING_REQUIRED_FIELD + ":shared_bindings.instrument_binding")
+    else:
+        reasons.append(REASON_MISSING_REQUIRED_FIELD + ":shared_bindings")
+
+    raw_candidates = contract.get("candidates")
+    if not isinstance(raw_candidates, list):
+        reasons.append(REASON_MISSING_REQUIRED_FIELD + ":candidates")
+        raw_candidates = []
+
+    expected_ids = {sid for sid, _ in FLEET_CANDIDATES}
+    seen_ids: set[str] = set()
+    parsed_candidates: list[Mapping[str, Any]] = []
+
+    for index, candidate in enumerate(raw_candidates):
+        path = f"candidates[{index}]"
+        if not isinstance(candidate, Mapping):
+            reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{path}")
+            continue
+        _reject_repair_keys(candidate, path=path, reasons=reasons)
+
+        strategy_id = candidate.get("strategy_id")
+        strategy_version = candidate.get("strategy_version")
+        if not isinstance(strategy_id, str) or not isinstance(strategy_version, str):
+            reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{path}.strategy_identity")
+            continue
+
+        if (strategy_id, strategy_version) not in FLEET_CANDIDATES:
+            if strategy_id in expected_ids:
+                reasons.append(f"{REASON_WRONG_STRATEGY_VERSION}:{strategy_id}")
+            else:
+                reasons.append(f"{REASON_UNKNOWN_STRATEGY}:{strategy_id}")
+
+        if strategy_id in seen_ids:
+            reasons.append(f"{REASON_DUPLICATE_CANDIDATE}:{strategy_id}")
+        seen_ids.add(strategy_id)
+
+        for field in CANDIDATE_REQUIRED_FIELDS:
+            if field not in candidate:
+                reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{path}.{field}")
+
+        if candidate.get("binding_status") != BINDING_STATUS_NOT_READY:
+            reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{path}.binding_status")
+
+        _validate_deferred_period_field(
+            candidate.get("training_period"), name="training_period", reasons=reasons
+        )
+        _validate_deferred_period_field(
+            candidate.get("validation_period"), name="validation_period", reasons=reasons
+        )
+        _validate_deferred_period_field(
+            candidate.get("out_of_sample_period"), name="out_of_sample_period", reasons=reasons
+        )
+        _validate_data_digest(candidate.get("data_digest"), reasons)
+
+        if isinstance(candidate.get("dataset_binding"), Mapping):
+            _validate_dataset_binding(candidate["dataset_binding"], reasons)
+        if isinstance(candidate.get("period_binding"), Mapping):
+            _validate_period_binding(candidate["period_binding"], reasons)
+        if isinstance(candidate.get("instrument_binding"), Mapping):
+            _validate_instrument_binding(candidate["instrument_binding"], reasons)
+
+        fee = candidate.get("fee_model_binding")
+        if isinstance(fee, Mapping):
+            _validate_positive_cost(fee.get("fee_bps"), field="fee_bps", reasons=reasons)
+        else:
+            reasons.append(REASON_ZERO_FEE + f":{strategy_id}")
+
+        slippage = candidate.get("slippage_model_binding")
+        if isinstance(slippage, Mapping):
+            _validate_positive_cost(
+                slippage.get("slippage_bps"), field="slippage_bps", reasons=reasons
+            )
+        else:
+            reasons.append(REASON_ZERO_SLIPPAGE + f":{strategy_id}")
+
+        if allow_recompute_digests and strategy_id in STEP31F_CONFIG_PATHS:
+            try:
+                cfg = load_step31f_evaluation_config_v0(repo_root, strategy_id)
+                if candidate.get("config_digest") != compute_config_digest_v1(cfg):
+                    reasons.append(f"{REASON_WRONG_CONFIG_DIGEST}:{strategy_id}")
+                entry = get_strategy_registry_entry(strategy_id)
+                if candidate.get("implementation_digest") != entry.implementation_digest:
+                    reasons.append(f"{REASON_WRONG_IMPLEMENTATION_DIGEST}:{strategy_id}")
+                expected_params = _extract_parameter_binding(cfg, strategy_id)
+                if candidate.get("parameter_binding") != expected_params:
+                    reasons.append(f"{REASON_WRONG_PARAMETER_BINDING}:{strategy_id}")
+            except (FileNotFoundError, ValueError, KeyError) as exc:
+                reasons.append(f"{REASON_WRONG_CONFIG_DIGEST}:{strategy_id}:{exc}")
+
+        parsed_candidates.append(candidate)
+
+    for strategy_id in sorted(expected_ids - seen_ids):
+        reasons.append(f"{REASON_MISSING_CANDIDATE}:{strategy_id}")
+    for strategy_id in sorted(seen_ids - expected_ids):
+        reasons.append(f"{REASON_EXTRA_CANDIDATE}:{strategy_id}")
+
+    _validate_shared_candidate_bindings(parsed_candidates, reasons)
+
+    expected_contract_digest = compute_contract_digest_v0(contract)
+    if contract.get("contract_digest") != expected_contract_digest:
+        reasons.append(REASON_WRONG_CONTRACT_DIGEST)
+
+    canonical = dumps_contract_canonical_v1(contract)
+    if canonical != dumps_contract_canonical_v1(json.loads(canonical)):
+        reasons.append(REASON_NON_CANONICAL_SERIALIZATION)
+    if _ABSOLUTE_PATH_PATTERN.search(canonical):
+        reasons.append(REASON_NON_CANONICAL_SERIALIZATION + ":absolute_path_in_contract")
+
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    if unique_reasons:
+        return DatasetPeriodBindingValidationResultV0(
+            verdict=ValidationVerdict.REJECTED,
+            valid=False,
+            fail_reasons=unique_reasons,
+        )
+    return DatasetPeriodBindingValidationResultV0(
+        verdict=ValidationVerdict.ACCEPTED,
+        valid=True,
+        fail_reasons=(),
+    )
+
+
+def clone_contract(contract: Mapping[str, Any]) -> dict[str, Any]:
+    return deepcopy(dict(contract))
+
+
+__all__ = [
+    "AUTHORITY_EFFECT",
+    "BINDING_STATUS_NOT_READY",
+    "CANDIDATE_BINDING_VERSION",
+    "CONTRACT_ID",
+    "DATASET_BINDING_VERSION",
+    "DatasetPeriodBindingValidationResultV0",
+    "FLEET_CANDIDATES",
+    "FLEET_ID",
+    "INSTRUMENT_BINDING_VERSION",
+    "NOT_YET_MATERIALIZED",
+    "ORDER_EFFECT",
+    "PERIOD_BINDING_VERSION",
+    "POLICY_CONFIG_REL_PATH",
+    "RUNTIME_EFFECT",
+    "SCHEMA_VERSION",
+    "UNIVERSE_POLICY_ID",
+    "UNIVERSE_POLICY_VERSION",
+    "ValidationVerdict",
+    "clone_contract",
+    "compute_contract_digest_v0",
+    "compute_implementation_digest_v0",
+    "compute_policy_config_digest_v0",
+    "envelope_from_dict",
+    "manifest_from_dict",
+    "materialize_pit_futures_universe_manifest_dataset_period_binding_v0",
+    "serialize_contract_canonical_v0",
+    "validate_pit_futures_universe_manifest_dataset_period_binding_v0",
+]

--- a/tests/ops/test_materialize_pit_futures_universe_manifest_dataset_period_binding_v0.py
+++ b/tests/ops/test_materialize_pit_futures_universe_manifest_dataset_period_binding_v0.py
@@ -1,0 +1,80 @@
+"""Ops contract tests for materialize_pit_futures_universe_manifest_dataset_period_binding_v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ops.materialize_pit_futures_universe_manifest_dataset_period_binding_v0 import (
+    CONFIRM_GO,
+    run_materialization,
+)
+from src.research.pit_futures_universe_manifest_dataset_period_binding_v0 import (
+    FLEET_CANDIDATES,
+    serialize_contract_canonical_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_run_materialization_requires_go_token(tmp_path: Path) -> None:
+    staging_root = tmp_path / "staging"
+    staging_root.mkdir()
+    with pytest.raises(SystemExit):
+        run_materialization(
+            confirm="WRONG_TOKEN",
+            staging_root=staging_root,
+            durable_evidence_root=tmp_path / "evidence",
+        )
+
+
+def test_run_materialization_end_to_end_from_production_staging(tmp_path: Path) -> None:
+    from tests.research.test_pit_futures_universe_manifest_dataset_period_binding_v0 import (
+        _build_production_result,
+    )
+    from src.research.pit_futures_universe_manifest_production_materialization_v1 import (
+        production_materialization_envelope_to_dict,
+    )
+    from src.research.pit_futures_universe_manifest_v1 import manifest_to_dict
+
+    production = _build_production_result()
+    staging_root = tmp_path / "staging"
+    universe_dir = staging_root / "universe"
+    universe_dir.mkdir(parents=True)
+    (universe_dir / "pit_futures_universe_manifest_v1.json").write_text(
+        json.dumps(manifest_to_dict(production.manifest), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (universe_dir / "production_materialization_envelope_v1.json").write_text(
+        json.dumps(
+            production_materialization_envelope_to_dict(production.envelope),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    evidence_root = tmp_path / "evidence"
+    payload = run_materialization(
+        confirm=CONFIRM_GO,
+        staging_root=staging_root,
+        durable_evidence_root=evidence_root,
+    )
+    assert payload["verdict"] == "PIT_FUTURES_UNIVERSE_MANIFEST_DATASET_PERIOD_BINDING_COMPLETE"
+    assert payload["candidate_count"] == 3
+    assert payload["candidate_strategy_ids"] == sorted(sid for sid, _ in FLEET_CANDIDATES)
+
+    contract_path = (
+        staging_root / "binding" / "pit_futures_universe_manifest_dataset_period_binding_v0.json"
+    )
+    assert contract_path.is_file()
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    assert contract["production_universe_manifest_digest"] == production.manifest.manifest_digest
+    assert serialize_contract_canonical_v0(contract).endswith("\n")
+
+    evidence_dir = Path(payload["durable_evidence_path"])
+    assert (evidence_dir / "MANIFEST.sha256").is_file()
+    assert payload["manifest_verify_rc"] == 0

--- a/tests/research/test_pit_futures_universe_manifest_dataset_period_binding_v0.py
+++ b/tests/research/test_pit_futures_universe_manifest_dataset_period_binding_v0.py
@@ -1,0 +1,583 @@
+"""Contract tests for pit_futures_universe_manifest_dataset_period_binding_v0."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.research.final_research_fleet_v0_versioned_binding_manifest_contract_v0 import (
+    FLEET_CANDIDATES,
+)
+from src.research.okx_production_instrument_lifecycle_source_v1 import (
+    MIN_ELIGIBLE_INSTRUMENT_COUNT,
+    build_lifecycle_source_observations_v1,
+    build_okx_lifecycle_source_snapshot_v1,
+)
+from src.research.pit_futures_universe_manifest_dataset_period_binding_v0 import (
+    AUTHORITY_EFFECT,
+    BINDING_STATUS_NOT_READY,
+    CANDIDATE_BINDING_VERSION,
+    DATASET_BINDING_VERSION,
+    FLEET_ID,
+    INSTRUMENT_BINDING_VERSION,
+    NOT_YET_MATERIALIZED,
+    ORDER_EFFECT,
+    PERIOD_BINDING_VERSION,
+    REASON_BITCOIN_INSTRUMENT_PRESENT,
+    REASON_BINDING_REPAIR_REJECTED,
+    REASON_DATA_DIGEST_NOT_MATERIALIZED,
+    REASON_DUPLICATE_CANDIDATE,
+    REASON_EFFECT_NOT_NONE,
+    REASON_ENVELOPE_MANIFEST_DIGEST_MISMATCH,
+    REASON_EXTRA_CANDIDATE,
+    REASON_MANIFEST_TAMPERED,
+    REASON_MISSING_CANDIDATE,
+    REASON_MISSING_PANEL_DATASET_DIGEST,
+    REASON_MISSING_PERIOD_COVERAGE,
+    REASON_MISSING_REQUIRED_FIELD,
+    REASON_PERIOD_SPLIT_NOT_MATERIALIZED,
+    REASON_PRODUCTION_MANIFEST_DIGEST_MISMATCH,
+    REASON_SHARED_BINDING_MISMATCH,
+    REASON_SPOT_BINDING,
+    REASON_SYNTHETIC_SPOT_BINDING,
+    REASON_UNKNOWN_SCHEMA_VERSION,
+    REASON_UNKNOWN_STRATEGY,
+    REASON_WRONG_CONFIG_DIGEST,
+    REASON_WRONG_CONTRACT_DIGEST,
+    REASON_WRONG_IMPLEMENTATION_DIGEST,
+    REASON_WRONG_PARAMETER_BINDING,
+    REASON_WRONG_STRATEGY_VERSION,
+    REASON_ZERO_FEE,
+    REASON_ZERO_SLIPPAGE,
+    RUNTIME_EFFECT,
+    SCHEMA_VERSION,
+    UNIVERSE_POLICY_ID,
+    UNIVERSE_POLICY_VERSION,
+    ValidationVerdict,
+    clone_contract,
+    compute_contract_digest_v0,
+    materialize_pit_futures_universe_manifest_dataset_period_binding_v0,
+    serialize_contract_canonical_v0,
+    validate_pit_futures_universe_manifest_dataset_period_binding_v0,
+)
+from src.research.pit_futures_universe_manifest_production_materialization_v1 import (
+    DEFAULT_MINIMUM_HISTORY_BARS,
+    DEFAULT_MINIMUM_REQUIRED_MEMBER_COUNT,
+    EVALUATION_PERIOD_BINDING,
+    EXCLUSION_POLICY_VERSION,
+    INCLUSION_POLICY_VERSION,
+    INPUT_CONTRACT_VERSION,
+    MATERIALIZATION_VERSION,
+    ProductionMaterializationEpochV1,
+    PitFuturesUniverseManifestProductionMaterializationInputV1,
+    assemble_production_registry_from_observations_v1,
+    materialize_production_pit_futures_universe_manifest_v1,
+)
+from src.research.pit_futures_universe_manifest_v1 import manifest_to_dict
+from src.research.pit_futures_universe_manifest_validator_v1 import (
+    ValidationVerdict as ManifestValidationVerdict,
+    validate_pit_futures_universe_manifest_v1,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import (
+    InstrumentPanelSeriesV1,
+    PanelBarV1,
+    compute_series_digest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_GENERATED_AT = "2026-07-03T04:00:00Z"
+_BAR_CLOSE = "2024-06-01T01:00:00Z"
+_PERIOD_START = "2024-05-25T00:00:00Z"
+_PERIOD_END = _BAR_CLOSE
+_PANEL_REF = "pit_okx_pt1h_panel_ohlcv_dataset_v1:test_panel:sha256:" + "a" * 64
+_PANEL_DIGEST = "b" * 64
+_SOURCE_REF = "okx_public_instruments_swap:test"
+_SOURCE_DIGEST = "c" * 64
+_REGISTRY_CONFIG = "d" * 64
+_REGISTRY_IMPL = "e" * 64
+
+
+def _live_inst(base: str, *, inst_id: str | None = None) -> dict[str, str]:
+    symbol = inst_id or f"{base}-USDT-SWAP"
+    return {
+        "instId": symbol,
+        "instType": "SWAP",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "baseCcy": base,
+        "state": "live",
+        "listTime": "1609459200000",
+        "expTime": "",
+    }
+
+
+def _hourly_bars(instrument_id: str, *, count: int, end: str) -> tuple[PanelBarV1, ...]:
+    end_dt = datetime.strptime(end, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    bars: list[PanelBarV1] = []
+    for offset in range(count):
+        ts = end_dt - timedelta(hours=count - 1 - offset)
+        ts_str = ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+        bars.append(
+            PanelBarV1(
+                instrument_id=instrument_id,
+                timestamp_utc=ts_str,
+                open="1",
+                high="2",
+                low="0.5",
+                close="1.5",
+                volume="10",
+                is_final=True,
+            )
+        )
+    return tuple(bars)
+
+
+def _panel_series_for_instrument(instrument_id: str, native_id: str) -> InstrumentPanelSeriesV1:
+    interim = InstrumentPanelSeriesV1(
+        instrument_id=instrument_id,
+        native_instrument_id=native_id,
+        bars=_hourly_bars(instrument_id, count=30, end=_BAR_CLOSE),
+        series_digest="0" * 64,
+    )
+    return InstrumentPanelSeriesV1(
+        instrument_id=interim.instrument_id,
+        native_instrument_id=interim.native_instrument_id,
+        bars=interim.bars,
+        series_digest=compute_series_digest(interim),
+    )
+
+
+def _build_registry_and_panel(
+    instruments: list[dict[str, str]],
+) -> tuple[object, tuple[InstrumentPanelSeriesV1, ...], str]:
+    from src.research.instrument_id_canonicalization_v1 import (
+        InstrumentIdCanonicalizationInputV1,
+        canonicalize_instrument_id_v1,
+    )
+
+    snapshot = build_okx_lifecycle_source_snapshot_v1(
+        instruments,
+        retrieval_timestamp_utc=_GENERATED_AT,
+        source_snapshot_ref=_SOURCE_REF,
+    )
+    observations = build_lifecycle_source_observations_v1(snapshot)
+    registry, errors = assemble_production_registry_from_observations_v1(
+        observations,
+        generated_at=_GENERATED_AT,
+        lifecycle_source_snapshot_digest=snapshot.raw_snapshot_digest,
+        config_digest=_REGISTRY_CONFIG,
+        implementation_digest=_REGISTRY_IMPL,
+    )
+    assert errors == (), errors
+    assert registry is not None
+    panel_series: list[InstrumentPanelSeriesV1] = []
+    for metadata in snapshot.eligible_instruments:
+        canon = canonicalize_instrument_id_v1(
+            InstrumentIdCanonicalizationInputV1(
+                venue_id="okx",
+                market_type="futures",
+                contract_type="linear_perpetual",
+                base_asset=metadata.base_asset,
+                quote_asset="USDT",
+                settlement_asset="USDT",
+                venue_symbol=metadata.inst_id,
+            )
+        )
+        assert canon.success and canon.instrument_id is not None
+        panel_series.append(_panel_series_for_instrument(canon.instrument_id, metadata.inst_id))
+    return registry, tuple(panel_series), snapshot.raw_snapshot_digest
+
+
+def _default_instruments() -> list[dict[str, str]]:
+    return [
+        _live_inst("BTC"),
+        *[_live_inst(base) for base in ("ETH", "SOL", "ADA", "DOT", "LINK", "AVAX")],
+    ]
+
+
+def _build_production_result():
+    registry, panel_series, source_digest = _build_registry_and_panel(_default_instruments())
+    inp = PitFuturesUniverseManifestProductionMaterializationInputV1(
+        input_contract_version=INPUT_CONTRACT_VERSION,
+        materialization_version=MATERIALIZATION_VERSION,
+        generated_at=_GENERATED_AT,
+        universe_policy_id=UNIVERSE_POLICY_ID,
+        universe_policy_version=UNIVERSE_POLICY_VERSION,
+        inclusion_policy_version=INCLUSION_POLICY_VERSION,
+        exclusion_policy_version=EXCLUSION_POLICY_VERSION,
+        lifecycle_source_id="okx_production_instrument_lifecycle_historical_as_of_fail_closed.v1",
+        lifecycle_source_snapshot_ref=_SOURCE_REF,
+        lifecycle_source_snapshot_digest=source_digest,
+        registry_artifact_id="okx_production_lifecycle_v1",
+        registry_snapshot=registry,
+        panel_series=panel_series,
+        panel_dataset_ref=_PANEL_REF,
+        panel_dataset_digest=_PANEL_DIGEST,
+        period_binding_ref=EVALUATION_PERIOD_BINDING,
+        period_start_utc=_PERIOD_START,
+        period_end_utc=_PERIOD_END,
+        minimum_history_bars=DEFAULT_MINIMUM_HISTORY_BARS,
+        minimum_required_member_count=DEFAULT_MINIMUM_REQUIRED_MEMBER_COUNT,
+        registry_config_digest=_REGISTRY_CONFIG,
+        registry_implementation_digest=_REGISTRY_IMPL,
+        epochs=(
+            ProductionMaterializationEpochV1(
+                score_epoch=0,
+                finalized_bar_close=_BAR_CLOSE,
+            ),
+        ),
+    )
+    result = materialize_production_pit_futures_universe_manifest_v1(inp)
+    assert result.success is True
+    assert result.manifest is not None and result.envelope is not None
+    return result
+
+
+@pytest.fixture(scope="module")
+def canonical_contract() -> dict:
+    production = _build_production_result()
+    return materialize_pit_futures_universe_manifest_dataset_period_binding_v0(
+        repo_root=REPO_ROOT,
+        production_manifest=production.manifest,
+        production_envelope=production.envelope,
+    )
+
+
+def _candidate(contract: dict, strategy_id: str) -> dict:
+    for candidate in contract["candidates"]:
+        if candidate["strategy_id"] == strategy_id:
+            return candidate
+    raise KeyError(strategy_id)
+
+
+def _validate(contract: dict, *, production=None):
+    kwargs = {"repo_root": REPO_ROOT, "allow_recompute_digests": True}
+    if production is not None:
+        kwargs["expected_manifest"] = production.manifest
+        kwargs["expected_envelope"] = production.envelope
+    return validate_pit_futures_universe_manifest_dataset_period_binding_v0(contract, **kwargs)
+
+
+def test_materialize_exactly_three_fleet_candidates(canonical_contract: dict) -> None:
+    assert len(canonical_contract["candidates"]) == 3
+    ids = {candidate["strategy_id"] for candidate in canonical_contract["candidates"]}
+    assert ids == {sid for sid, _ in FLEET_CANDIDATES}
+
+
+def test_deterministic_contract_generation(canonical_contract: dict) -> None:
+    production = _build_production_result()
+    second = materialize_pit_futures_universe_manifest_dataset_period_binding_v0(
+        repo_root=REPO_ROOT,
+        production_manifest=production.manifest,
+        production_envelope=production.envelope,
+    )
+    assert serialize_contract_canonical_v0(canonical_contract) == serialize_contract_canonical_v0(
+        second
+    )
+    assert canonical_contract["contract_digest"] == second["contract_digest"]
+
+
+def test_candidate_order_is_canonical_sorted(canonical_contract: dict) -> None:
+    strategy_ids = [candidate["strategy_id"] for candidate in canonical_contract["candidates"]]
+    assert strategy_ids == sorted(strategy_ids)
+
+
+def test_production_universe_manifest_digest_bound(canonical_contract: dict) -> None:
+    production = _build_production_result()
+    assert (
+        canonical_contract["production_universe_manifest_digest"]
+        == production.manifest.manifest_digest
+    )
+    for strategy_id, _ in FLEET_CANDIDATES:
+        candidate = _candidate(canonical_contract, strategy_id)
+        assert (
+            candidate["production_universe_manifest_digest"] == production.manifest.manifest_digest
+        )
+        assert (
+            candidate["production_universe_manifest_ref"] == production.envelope.manifest_reference
+        )
+
+
+def test_futures_only_and_bitcoin_exclusion(canonical_contract: dict) -> None:
+    assert canonical_contract["futures_only"] is True
+    assert canonical_contract["bitcoin_direction_allowed"] is False
+    instrument_binding = canonical_contract["shared_bindings"]["instrument_binding"]
+    assert instrument_binding["futures_only"] is True
+    assert instrument_binding["bitcoin_direction_allowed"] is False
+    for instrument_id in instrument_binding["eligible_instrument_ids"]:
+        assert "btc" not in instrument_id.lower()
+        assert "xbt" not in instrument_id.lower()
+        assert "bitcoin" not in instrument_id.lower()
+
+
+def test_deferred_periods_and_data_digest_fail_closed(canonical_contract: dict) -> None:
+    for strategy_id, _ in FLEET_CANDIDATES:
+        candidate = _candidate(canonical_contract, strategy_id)
+        assert candidate["training_period"] == NOT_YET_MATERIALIZED
+        assert candidate["validation_period"] == NOT_YET_MATERIALIZED
+        assert candidate["out_of_sample_period"] == NOT_YET_MATERIALIZED
+        assert candidate["data_digest"]["status"] == "NOT_YET_MATERIALIZED"
+        assert candidate["binding_status"] == BINDING_STATUS_NOT_READY
+        assert REASON_DATA_DIGEST_NOT_MATERIALIZED in candidate["reason_codes"]
+        assert REASON_PERIOD_SPLIT_NOT_MATERIALIZED in candidate["reason_codes"]
+
+
+def test_shared_bindings_identical_across_candidates(canonical_contract: dict) -> None:
+    first = canonical_contract["candidates"][0]
+    for candidate in canonical_contract["candidates"][1:]:
+        assert candidate["dataset_binding"] == first["dataset_binding"]
+        assert candidate["period_binding"] == first["period_binding"]
+        assert candidate["instrument_binding"] == first["instrument_binding"]
+        assert candidate["data_digest"] == first["data_digest"]
+
+
+def test_effects_remain_none(canonical_contract: dict) -> None:
+    assert canonical_contract["authority_effect"] == AUTHORITY_EFFECT == "NONE"
+    assert canonical_contract["runtime_effect"] == RUNTIME_EFFECT == "NONE"
+    assert canonical_contract["order_effect"] == ORDER_EFFECT == "NONE"
+    assert canonical_contract["no_runtime_effect"] is True
+    assert canonical_contract["no_economic_evaluation_execution"] is True
+
+
+def test_validator_accepts_canonical_contract(canonical_contract: dict) -> None:
+    production = _build_production_result()
+    result = _validate(canonical_contract, production=production)
+    assert result.valid is True
+    assert result.verdict == ValidationVerdict.ACCEPTED
+    assert result.fail_reasons == ()
+
+
+def test_version_fields_present(canonical_contract: dict) -> None:
+    assert canonical_contract["schema_version"] == SCHEMA_VERSION
+    assert canonical_contract["fleet_id"] == FLEET_ID
+    assert canonical_contract["candidate_binding_version"] == CANDIDATE_BINDING_VERSION
+    assert canonical_contract["dataset_binding_version"] == DATASET_BINDING_VERSION
+    assert canonical_contract["period_binding_version"] == PERIOD_BINDING_VERSION
+    assert canonical_contract["instrument_binding_version"] == INSTRUMENT_BINDING_VERSION
+
+
+def test_tampered_production_manifest_digest_rejected(canonical_contract: dict) -> None:
+    mutated = clone_contract(canonical_contract)
+    mutated["production_universe_manifest_digest"] = "f" * 64
+    mutated["contract_digest"] = compute_contract_digest_v0(mutated)
+    production = _build_production_result()
+    result = _validate(mutated, production=production)
+    assert result.valid is False
+    assert REASON_PRODUCTION_MANIFEST_DIGEST_MISMATCH in result.fail_reasons
+
+
+def test_materialize_rejects_tampered_manifest() -> None:
+    production = _build_production_result()
+    tampered = dataclasses.replace(
+        production.manifest,
+        manifest_digest="f" * 64,
+    )
+    with pytest.raises(ValueError, match="PRODUCTION_MANIFEST_VALIDATION_FAILED|PRODUCTION_MANIFEST_TAMPERED"):
+        materialize_pit_futures_universe_manifest_dataset_period_binding_v0(
+            repo_root=REPO_ROOT,
+            production_manifest=tampered,
+            production_envelope=production.envelope,
+        )
+
+
+def test_materialize_rejects_envelope_manifest_digest_mismatch() -> None:
+    production = _build_production_result()
+    tampered_envelope = dataclasses.replace(
+        production.envelope,
+        manifest_digest="f" * 64,
+    )
+    with pytest.raises(ValueError, match=REASON_ENVELOPE_MANIFEST_DIGEST_MISMATCH):
+        materialize_pit_futures_universe_manifest_dataset_period_binding_v0(
+            repo_root=REPO_ROOT,
+            production_manifest=production.manifest,
+            production_envelope=tampered_envelope,
+        )
+
+
+def test_production_manifest_validation_required() -> None:
+    production = _build_production_result()
+    manifest_dict = manifest_to_dict(production.manifest)
+    manifest_dict["futures_only"] = False
+    broken = validate_pit_futures_universe_manifest_v1(
+        __import__(
+            "src.research.pit_futures_universe_manifest_v1",
+            fromlist=["manifest_from_dict"],
+        ).manifest_from_dict(manifest_dict)
+    )
+    assert broken.verdict != ManifestValidationVerdict.ACCEPTED
+
+
+def test_eligible_instrument_count_meets_minimum(canonical_contract: dict) -> None:
+    count = canonical_contract["shared_bindings"]["instrument_binding"]["eligible_instrument_count"]
+    assert count >= MIN_ELIGIBLE_INSTRUMENT_COUNT
+
+
+@pytest.mark.parametrize(
+    ("strategy_id", "mutator", "reason_prefix"),
+    [
+        ("trend_following", lambda c: c["candidates"].pop(0), REASON_MISSING_CANDIDATE),
+        (
+            "trend_following",
+            lambda c: c["candidates"].append(copy.deepcopy(c["candidates"][0])),
+            REASON_DUPLICATE_CANDIDATE,
+        ),
+        (
+            "trend_following",
+            lambda c: c["candidates"].append(
+                {
+                    **_candidate(c, "bollinger_bands"),
+                    "strategy_id": "macd",
+                    "strategy_version": "v1",
+                }
+            ),
+            REASON_UNKNOWN_STRATEGY,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update({"strategy_version": "v2"}),
+            REASON_WRONG_STRATEGY_VERSION,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").pop("parameter_binding", None),
+            REASON_MISSING_REQUIRED_FIELD,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update(
+                {"parameter_binding": {"adx_period": 99}}
+            ),
+            REASON_WRONG_PARAMETER_BINDING,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["period_binding"].update(
+                {"coverage_period_start_utc": ""}
+            ),
+            REASON_MISSING_PERIOD_COVERAGE,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["dataset_binding"].update(
+                {"panel_dataset_digest": "not-a-digest"}
+            ),
+            REASON_MISSING_PANEL_DATASET_DIGEST,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["instrument_binding"].update(
+                {"spot_allowed": True}
+            ),
+            REASON_SPOT_BINDING,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["instrument_binding"].update(
+                {"synthetic_spot_allowed": True}
+            ),
+            REASON_SYNTHETIC_SPOT_BINDING,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["instrument_binding"].update(
+                {"eligible_instrument_ids": ["inst-btc-usdt-perp"]}
+            ),
+            REASON_BITCOIN_INSTRUMENT_PRESENT,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["fee_model_binding"].update({"fee_bps": 0}),
+            REASON_ZERO_FEE,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["slippage_model_binding"].update(
+                {"slippage_bps": 0}
+            ),
+            REASON_ZERO_SLIPPAGE,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "bollinger_bands")["period_binding"].update(
+                {"coverage_period_end_utc": "1970-01-01T00:00:00Z"}
+            ),
+            REASON_SHARED_BINDING_MISMATCH,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update({"implementation_digest": "0" * 64}),
+            REASON_WRONG_IMPLEMENTATION_DIGEST,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update({"config_digest": "0" * 64}),
+            REASON_WRONG_CONFIG_DIGEST,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update(
+                {"training_period": {"status": "BOUND", "value": "2020..2021"}}
+            ),
+            REASON_PERIOD_SPLIT_NOT_MATERIALIZED,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update(
+                {"data_digest": {"status": "BOUND", "value": "0" * 64}}
+            ),
+            REASON_DATA_DIGEST_NOT_MATERIALIZED,
+        ),
+        (
+            "trend_following",
+            lambda c: c.update({"schema_version": "unknown.v9"}),
+            REASON_UNKNOWN_SCHEMA_VERSION,
+        ),
+        (
+            "trend_following",
+            lambda c: c.update({"authority_effect": "LIVE"}),
+            REASON_EFFECT_NOT_NONE,
+        ),
+        (
+            "trend_following",
+            lambda c: c.update({"contract_digest": "0" * 64}),
+            REASON_WRONG_CONTRACT_DIGEST,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update({"fallback": True}),
+            REASON_BINDING_REPAIR_REJECTED,
+        ),
+    ],
+)
+def test_negative_validation_cases(
+    canonical_contract: dict,
+    strategy_id: str,
+    mutator,
+    reason_prefix: str,
+) -> None:
+    mutated = clone_contract(canonical_contract)
+    mutator(mutated)
+    if mutated.get("contract_digest") == canonical_contract["contract_digest"]:
+        mutated["contract_digest"] = compute_contract_digest_v0(mutated)
+    production = _build_production_result()
+    result = _validate(mutated, production=production)
+    assert result.valid is False
+    assert result.verdict == ValidationVerdict.REJECTED
+    assert any(reason.startswith(reason_prefix) for reason in result.fail_reasons)
+
+
+def test_extra_candidate_rejected(canonical_contract: dict) -> None:
+    mutated = clone_contract(canonical_contract)
+    extra = copy.deepcopy(mutated["candidates"][0])
+    extra["strategy_id"] = "rsi_reversion"
+    extra["strategy_version"] = "v1"
+    mutated["candidates"].append(extra)
+    mutated["contract_digest"] = compute_contract_digest_v0(mutated)
+    production = _build_production_result()
+    result = _validate(mutated, production=production)
+    assert any(reason.startswith(REASON_EXTRA_CANDIDATE) for reason in result.fail_reasons)

--- a/tests/research/test_pit_futures_universe_manifest_dataset_period_binding_v0.py
+++ b/tests/research/test_pit_futures_universe_manifest_dataset_period_binding_v0.py
@@ -377,7 +377,9 @@ def test_materialize_rejects_tampered_manifest() -> None:
         production.manifest,
         manifest_digest="f" * 64,
     )
-    with pytest.raises(ValueError, match="PRODUCTION_MANIFEST_VALIDATION_FAILED|PRODUCTION_MANIFEST_TAMPERED"):
+    with pytest.raises(
+        ValueError, match="PRODUCTION_MANIFEST_VALIDATION_FAILED|PRODUCTION_MANIFEST_TAMPERED"
+    ):
         materialize_pit_futures_universe_manifest_dataset_period_binding_v0(
             repo_root=REPO_ROOT,
             production_manifest=tampered,


### PR DESCRIPTION
## Summary
- Adds deterministic, fail-closed dataset/period/instrument staging bindings for `final_research_fleet_v0` candidates (`trend_following`, `bollinger_bands`, `momentum_1h`) wired to the production materialized PIT OKX futures universe manifest from PR #4782.
- Introduces `pit_futures_universe_manifest_dataset_period_binding_v0` contract owner, policy config, ops materializer, and contract tests covering digest tampering, futures-only/Bitcoin exclusion, deferred period splits, and shared cross-sectional bindings.
- Research-only scope: no economic evaluation execution, no runtime/scheduler/adapter/order effect.

## Test plan
- [x] `pytest tests/research/test_pit_futures_universe_manifest_dataset_period_binding_v0.py tests/ops/test_materialize_pit_futures_universe_manifest_dataset_period_binding_v0.py`
- [x] `ruff format --check` and `ruff check` on changed Python files
- [x] CI selector: PR_BOUNDED_FULL (central `src/` change)
- [x] Durable evidence bundle with `MANIFEST_VERIFY_RC=0`


Made with [Cursor](https://cursor.com)