### PR TITLE
feat(research): final research fleet versioned binding completion v0

### DIFF
--- a/scripts/ops/materialize_final_research_fleet_versioned_binding_completion_v0.py
+++ b/scripts/ops/materialize_final_research_fleet_versioned_binding_completion_v0.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Materialize final research fleet versioned binding completion v0.
+
+Offline-first: reads production universe manifest, panel, and lifecycle staging
+artifacts. Emits fleet binding completion manifest with full versioned bindings.
+No network, no economic evaluation, no runtime effect.
+Operator GO: GO_BOUNDED_FINAL_RESEARCH_FLEET_VERSIONED_BINDING_COMPLETION_V0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+CONFIRM_GO = "GO_BOUNDED_FINAL_RESEARCH_FLEET_VERSIONED_BINDING_COMPLETION_V0"
+
+from src.research.final_research_fleet_versioned_binding_completion_v0 import (  # noqa: E402
+    BINDING_STATUS_READY_FOR_EVAL_RATIFICATION,
+    SCHEMA_VERSION,
+    ValidationVerdict,
+    materialize_final_research_fleet_versioned_binding_completion_v0,
+    serialize_completion_canonical_v0,
+    validate_final_research_fleet_versioned_binding_completion_v0,
+)
+from src.research.pit_futures_cross_sectional_research_data_digest_period_split_materialization_v0 import (  # noqa: E402
+    load_panel_series_from_staging,
+)
+from src.research.pit_futures_universe_manifest_dataset_period_binding_v0 import (  # noqa: E402
+    envelope_from_dict,
+    manifest_from_dict,
+)
+
+
+def _utc_now_z() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        _die(f"ERR: not_object:{path}")
+    return payload
+
+
+def _load_source_registration(staging_root: Path) -> tuple[str, str]:
+    source_reg_path = staging_root / "lifecycle" / "SOURCE_REGISTRATION.json"
+    if not source_reg_path.is_file():
+        _die(f"ERR: missing_source_registration:{source_reg_path}")
+    payload = _load_json(source_reg_path)
+    return str(payload["source_snapshot_ref"]), str(payload["source_snapshot_digest"])
+
+
+def run_materialization(
+    *,
+    confirm: str,
+    staging_root: Path,
+    durable_evidence_root: Path,
+) -> dict[str, Any]:
+    if confirm != CONFIRM_GO:
+        _die(f"ERR: confirm_go_token_required:{CONFIRM_GO}")
+
+    manifest_path = staging_root / "universe" / "pit_futures_universe_manifest_v1.json"
+    envelope_path = staging_root / "universe" / "production_materialization_envelope_v1.json"
+    if not manifest_path.is_file():
+        _die(f"ERR: missing_production_manifest:{manifest_path}")
+    if not envelope_path.is_file():
+        _die(f"ERR: missing_production_envelope:{envelope_path}")
+
+    production_manifest = manifest_from_dict(_load_json(manifest_path))
+    production_envelope = envelope_from_dict(_load_json(envelope_path))
+
+    panel_series = None
+    try:
+        panel_series, _panel_ref = load_panel_series_from_staging(staging_root)
+    except FileNotFoundError:
+        panel_series = None
+
+    source_ref, source_digest = _load_source_registration(staging_root)
+
+    completion = materialize_final_research_fleet_versioned_binding_completion_v0(
+        repo_root=_REPO_ROOT,
+        production_manifest=production_manifest,
+        production_envelope=production_envelope,
+        panel_series=panel_series,
+        source_registration_ref=source_ref,
+        source_registration_digest=source_digest,
+    )
+    validation = validate_final_research_fleet_versioned_binding_completion_v0(
+        completion,
+        repo_root=_REPO_ROOT,
+        require_ready_for_eval=True,
+    )
+    if validation.verdict != ValidationVerdict.ACCEPTED:
+        _die(f"ERR: binding_completion_validation_failed:{validation.fail_reasons}")
+
+    output_dir = staging_root / "research_materialization"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "final_research_fleet_versioned_binding_completion_v0.json").write_text(
+        serialize_completion_canonical_v0(completion),
+        encoding="utf-8",
+    )
+
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    evidence_dir = (
+        durable_evidence_root
+        / "planning"
+        / f"bounded_final_research_fleet_versioned_binding_completion_v0_{ts_slug}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    for rel in (
+        "universe/pit_futures_universe_manifest_v1.json",
+        "universe/production_materialization_envelope_v1.json",
+        "research_materialization/final_research_fleet_versioned_binding_completion_v0.json",
+    ):
+        src = staging_root / rel
+        if src.is_file():
+            dst = evidence_dir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(src.read_bytes())
+
+    from scripts.ops import primary_evidence_retention_v0 as retention
+
+    rc, verify_msg = retention.finalize_durable_bundle_manifest(evidence_dir)
+
+    payload = {
+        "verdict": "FINAL_RESEARCH_FLEET_VERSIONED_BINDING_COMPLETION_PASS",
+        "schema_version": SCHEMA_VERSION,
+        "binding_materialization_status": completion.get("binding_materialization_status"),
+        "completion_digest": completion["completion_digest"],
+        "candidate_count": len(completion["candidates"]),
+        "binding_status_ready": completion.get("binding_materialization_status")
+        == BINDING_STATUS_READY_FOR_EVAL_RATIFICATION,
+        "economic_evaluation_authorized": completion.get("economic_evaluation_authorized"),
+        "staging_root": str(staging_root),
+        "durable_evidence_path": str(evidence_dir),
+        "manifest_verify_rc": rc,
+        "manifest_verify_msg": verify_msg,
+        "generated_at_utc": _utc_now_z(),
+    }
+    (evidence_dir / "COMPLETION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _emit_machine_lines(payload)
+    return payload
+
+
+def _emit_machine_lines(result: Mapping[str, Any]) -> None:
+    for key in (
+        "verdict",
+        "binding_materialization_status",
+        "completion_digest",
+        "candidate_count",
+        "binding_status_ready",
+        "economic_evaluation_authorized",
+        "manifest_verify_rc",
+    ):
+        print(f"{key.upper()}={result.get(key)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Materialize final research fleet versioned binding completion v0."
+    )
+    parser.add_argument("--confirm-go-token", required=True, choices=[CONFIRM_GO])
+    parser.add_argument("--staging-root", type=Path, required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, required=True)
+    args = parser.parse_args()
+    run_materialization(
+        confirm=args.confirm_go_token,
+        staging_root=args.staging_root,
+        durable_evidence_root=args.durable_evidence_root,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/research/final_research_fleet_versioned_binding_completion_v0.py
+++ b/src/research/final_research_fleet_versioned_binding_completion_v0.py
@@ -1,0 +1,847 @@
+"""Final Research Fleet versioned binding completion v0.
+
+Deterministic, fail-closed materialization and validation of complete versioned
+bindings for trend_following/v1, bollinger_bands/v1, and momentum_1h/v1 wired
+to PIT cross-sectional dataset/period/instrument owners from PRs #4782–#4784.
+
+Research-only. No economic evaluation execution, no runtime or order effect.
+ECONOMIC_EVALUATION_AUTHORIZED=false for all candidates in this scope.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.backtest.strategy_signal_binding_v1 import resolve_effective_strategy_params_v1
+from src.research.final_research_fleet_v0_versioned_binding_manifest_contract_v0 import (
+    FLEET_CANDIDATES,
+    FLEET_ID,
+    FLEET_VERSION,
+    OPERATOR_RATIFICATION_REF,
+    STEP31F_CONFIG_PATHS,
+    compute_config_digest_v1,
+    load_step31f_evaluation_config_v0,
+)
+from src.research.pit_futures_cross_sectional_research_data_digest_period_split_materialization_v0 import (
+    MaterializationStatus,
+    dataset_envelope_to_dict,
+    materialize_cross_sectional_research_data_digest_and_period_split_v0,
+    period_split_to_dict,
+)
+from src.research.pit_futures_universe_manifest_dataset_period_binding_v0 import (
+    BINDING_STATUS_BLOCKED,
+    BINDING_STATUS_NOT_READY,
+    BINDING_STATUS_READY,
+    materialize_pit_futures_universe_manifest_dataset_period_binding_v0,
+    materialize_pit_futures_universe_manifest_dataset_period_binding_with_research_materialization_v0,
+)
+from src.research.pit_futures_universe_manifest_production_materialization_v1 import (
+    ProductionManifestMaterializationEnvelopeV1,
+)
+from src.research.pit_futures_universe_manifest_v1 import (
+    PointInTimeFuturesUniverseManifestV1,
+    is_valid_digest,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+from src.strategies.registry import get_strategy_registry_entry, resolve_strategy_id
+
+PACKAGE_MARKER = "FINAL_RESEARCH_FLEET_VERSIONED_BINDING_COMPLETION_V0=true"
+
+SCHEMA_VERSION = "final_research_fleet_versioned_binding_completion.v0"
+COMPLETION_ID = "final_research_fleet_versioned_binding_completion_v0"
+CANONICAL_SERIALIZATION_VERSION = "research_binding_completion_canonical_json_v1"
+CANONICAL_TRADING_LOGIC_BINDING_VERSION = "strategy_signal_binding_v1"
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+ORDER_EFFECT = "NONE"
+
+ECONOMIC_EVALUATION_AUTHORIZED = False
+ECONOMIC_VALIDITY_OFFLINE_GATE_PASS = False
+RUNTIME_REWIRE_ADMISSIBLE = False
+
+FUTURES_ONLY = True
+BITCOIN_DIRECTION_ALLOWED = False
+SPOT_ALLOWED = False
+SYNTHETIC_SPOT_ALLOWED = False
+
+BINDING_STATUS_INCOMPLETE = "BINDING_INCOMPLETE"
+BINDING_STATUS_VALID = "BINDING_VALID"
+BINDING_STATUS_READY_FOR_EVAL_RATIFICATION = "READY_FOR_SEPARATE_OFFLINE_EVALUATION_RATIFICATION"
+
+FAILED_HISTORICAL_CANDIDATES: tuple[tuple[str, str], ...] = (
+    ("macd", "v1"),
+    ("macd", "v2"),
+    ("macd", "v3"),
+    ("breakout_donchian", "v1"),
+    ("ma_crossover", "v1"),
+    ("rsi_reversion", "step30a"),
+    ("composite_breakout_confirmation_vol_gated_donchian_v1", "v1"),
+)
+
+FORBIDDEN_INSTRUMENT_TOKENS = frozenset(
+    {"btc", "xbt", "bitcoin", "spot", "synthetic_spot", "synthetic-spot"}
+)
+_ABSOLUTE_PATH_PATTERN = re.compile(r"(^/|^\\\\|^[A-Za-z]:[/\\\\])")
+
+REASON_UNKNOWN_STRATEGY = "UNKNOWN_STRATEGY"
+REASON_WRONG_STRATEGY_VERSION = "WRONG_STRATEGY_VERSION"
+REASON_FAILED_HISTORICAL_CANDIDATE = "FAILED_HISTORICAL_CANDIDATE_EXCLUDED"
+REASON_MISSING_CANDIDATE = "MISSING_FLEET_CANDIDATE"
+REASON_EXTRA_CANDIDATE = "EXTRA_FLEET_CANDIDATE"
+REASON_DUPLICATE_CANDIDATE = "DUPLICATE_FLEET_CANDIDATE"
+REASON_MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD"
+REASON_UNKNOWN_SCHEMA_VERSION = "UNKNOWN_SCHEMA_VERSION"
+REASON_COMPLETION_NOT_OBJECT = "COMPLETION_NOT_OBJECT"
+REASON_EFFECT_NOT_NONE = "AUTHORITY_RUNTIME_ORDER_EFFECT_NOT_NONE"
+REASON_BINDING_REPAIR_REJECTED = "BINDING_REPAIR_REJECTED"
+REASON_SHARED_BINDING_MISMATCH = "SHARED_BINDING_MISMATCH"
+REASON_ECONOMIC_POLICY_MISMATCH = "ECONOMIC_POLICY_MISMATCH"
+REASON_ECONOMIC_EVALUATION_AUTHORIZED = "ECONOMIC_EVALUATION_AUTHORIZED_MUST_BE_FALSE"
+REASON_BINDING_INCOMPLETE = "BINDING_INCOMPLETE"
+REASON_BINDING_NOT_VALID = "BINDING_NOT_VALID"
+REASON_BINDING_NOT_READY_FOR_EVAL = "BINDING_NOT_READY_FOR_EVALUATION_RATIFICATION"
+REASON_WRONG_COMPLETION_DIGEST = "WRONG_COMPLETION_DIGEST"
+REASON_WRONG_BINDING_SEMANTIC_DIGEST = "WRONG_BINDING_SEMANTIC_DIGEST"
+REASON_WRONG_CONFIG_DIGEST = "WRONG_CONFIG_DIGEST"
+REASON_WRONG_IMPLEMENTATION_DIGEST = "WRONG_IMPLEMENTATION_DIGEST"
+REASON_WRONG_DATA_DIGEST = "WRONG_DATA_DIGEST"
+REASON_WRONG_PARAMETER_BINDING = "WRONG_PARAMETER_BINDING"
+REASON_WRONG_STRATEGY_PARAMS_DIGEST = "WRONG_STRATEGY_PARAMS_DIGEST"
+REASON_FUTURES_ONLY_VIOLATION = "FUTURES_ONLY_VIOLATION"
+REASON_SPOT_BINDING = "SPOT_BINDING_REJECTED"
+REASON_SYNTHETIC_SPOT_BINDING = "SYNTHETIC_SPOT_BINDING_REJECTED"
+REASON_BITCOIN_DIRECTION_BINDING = "BITCOIN_DIRECTION_BINDING_REJECTED"
+REASON_BITCOIN_INSTRUMENT_PRESENT = "BITCOIN_INSTRUMENT_PRESENT"
+REASON_ZERO_FEE = "ZERO_FEE_REJECTED"
+REASON_ZERO_SLIPPAGE = "ZERO_SLIPPAGE_REJECTED"
+REASON_DATASET_PERIOD_CONTRACT_INVALID = "DATASET_PERIOD_CONTRACT_INVALID"
+REASON_NON_CANONICAL_SERIALIZATION = "NON_CANONICAL_SERIALIZATION"
+REASON_AMBIGUOUS_BINDING = "AMBIGUOUS_BINDING"
+REASON_NOT_RATIFIED = "CANDIDATE_NOT_RATIFIED"
+REASON_RATIFICATION_REF_MISMATCH = "OPERATOR_RATIFICATION_REF_MISMATCH"
+
+CANDIDATE_REQUIRED_FIELDS = (
+    "canonical_candidate_identifier",
+    "strategy_id",
+    "strategy_version",
+    "parameter_schema_version",
+    "parameter_binding",
+    "dataset_binding",
+    "dataset_version",
+    "dataset_provenance",
+    "period_binding",
+    "training_period",
+    "validation_period",
+    "out_of_sample_period",
+    "instrument_binding",
+    "fee_model_binding",
+    "slippage_model_binding",
+    "funding_model_binding",
+    "execution_model_binding",
+    "economic_policy_binding",
+    "canonical_trading_logic_version",
+    "implementation_digest",
+    "config_digest",
+    "data_digest",
+    "binding_semantic_digest",
+    "reproducibility_metadata",
+    "binding_status",
+    "economic_evaluation_authorized",
+    "operator_ratification_ref",
+    "ratified",
+    "strategy_params_digest",
+    "source_config_ref",
+)
+
+COMPLETION_REQUIRED_FIELDS = (
+    "schema_version",
+    "completion_id",
+    "fleet_id",
+    "fleet_version",
+    "candidates",
+    "shared_bindings",
+    "excluded_failed_historical_candidates",
+    "canonical_serialization_version",
+    "completion_digest",
+    "authority_effect",
+    "runtime_effect",
+    "order_effect",
+    "economic_evaluation_authorized",
+    "economic_validity_offline_gate_pass",
+    "runtime_rewire_admissible",
+    "futures_only",
+    "bitcoin_direction_allowed",
+    "spot_allowed",
+    "synthetic_spot_allowed",
+    "dataset_period_binding_contract_digest",
+)
+
+
+class ValidationVerdict(str, Enum):
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True)
+class BindingCompletionValidationResultV0:
+    verdict: ValidationVerdict
+    valid: bool
+    fail_reasons: tuple[str, ...]
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_implementation_digest_v0() -> str:
+    return _stable_digest(
+        {
+            "module": "final_research_fleet_versioned_binding_completion_v0",
+            "schema_version": SCHEMA_VERSION,
+        }
+    )
+
+
+def dumps_completion_canonical_v1(obj: Mapping[str, Any]) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str, ensure_ascii=False)
+
+
+def compute_completion_digest_v0(completion_body: Mapping[str, Any]) -> str:
+    body = dict(completion_body)
+    body.pop("completion_digest", None)
+    return hashlib.sha256(dumps_completion_canonical_v1(body).encode("utf-8")).hexdigest()
+
+
+def serialize_completion_canonical_v0(completion: Mapping[str, Any]) -> str:
+    return dumps_completion_canonical_v1(completion) + "\n"
+
+
+def canonical_candidate_identifier(strategy_id: str, strategy_version: str) -> str:
+    return f"{strategy_id}/{strategy_version}"
+
+
+def _reject_repair_keys(obj: Mapping[str, Any], *, path: str, reasons: list[str]) -> None:
+    for key in obj:
+        if key in {"repair", "fallback", "auto_fix", "default_if_missing"}:
+            reasons.append(f"{REASON_BINDING_REPAIR_REJECTED}:{path}.{key}")
+
+
+def _contains_forbidden_token(value: str) -> bool:
+    lowered = value.lower()
+    return any(token in lowered for token in FORBIDDEN_INSTRUMENT_TOKENS)
+
+
+def _build_dataset_provenance(
+    *,
+    dataset_binding: Mapping[str, Any],
+    dataset_envelope: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    provenance: dict[str, Any] = {
+        "dataset_profile": dataset_binding.get("dataset_profile"),
+        "instrument_metadata_source": dataset_binding.get("instrument_metadata_source"),
+        "panel_dataset_ref": dataset_binding.get("panel_dataset_ref"),
+        "panel_dataset_digest": dataset_binding.get("panel_dataset_digest"),
+        "evaluation_period_binding": dataset_binding.get("evaluation_period_binding"),
+        "pit_safe": True,
+        "cross_branch_evidence_forbidden": True,
+    }
+    if dataset_envelope is not None:
+        provenance.update(
+            {
+                "dataset_id": dataset_envelope.get("dataset_id"),
+                "source_registration_ref": dataset_envelope.get("source_registration_ref"),
+                "source_registration_digest": dataset_envelope.get("source_registration_digest"),
+                "universe_manifest_ref": dataset_envelope.get("universe_manifest_ref"),
+                "universe_manifest_digest": dataset_envelope.get("universe_manifest_digest"),
+                "ingestion_contract_version": dataset_envelope.get("ingestion_contract_version"),
+            }
+        )
+    return provenance
+
+
+def _build_reproducibility_metadata(
+    *,
+    repo_root: Path,
+    dataset_period_contract: Mapping[str, Any],
+    dataset_envelope: Mapping[str, Any] | None,
+    period_split: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "repo_root_relative": True,
+        "materialization_module": "final_research_fleet_versioned_binding_completion_v0",
+        "dataset_period_binding_schema": dataset_period_contract.get("schema_version"),
+        "dataset_period_binding_contract_digest": dataset_period_contract.get("contract_digest"),
+        "research_materialization_version": dataset_period_contract.get(
+            "research_materialization_version"
+        ),
+        "policy_config_refs": [
+            "config/research/pit_futures_universe_manifest_dataset_period_binding_policy_v1.json",
+            "config/research/pit_cross_sectional_research_data_digest_period_split_policy_v1.json",
+        ],
+        "step31f_config_refs": [STEP31F_CONFIG_PATHS[sid] for sid, _ in FLEET_CANDIDATES],
+        "data_digest_materialization_rule": (
+            "pit_futures_cross_sectional_research_data_digest_period_split_materialization_v0."
+            "compute_semantic_data_digest_v0"
+        ),
+        "binding_semantic_digest_rule": (
+            "SHA-256 over canonical JSON of semantic binding payload excluding "
+            "binding_semantic_digest and completion_digest"
+        ),
+        "dataset_envelope_digest": (
+            dataset_envelope.get("data_digest") if dataset_envelope is not None else None
+        ),
+        "period_split_digest": period_split.get("period_digest")
+        if period_split is not None
+        else None,
+        "implementation_digest": compute_implementation_digest_v0(),
+        "repo_root_marker": str(repo_root.name),
+    }
+
+
+def compute_binding_semantic_digest_v0(candidate: Mapping[str, Any]) -> str:
+    payload = {
+        "canonical_candidate_identifier": candidate.get("canonical_candidate_identifier"),
+        "strategy_id": candidate.get("strategy_id"),
+        "strategy_version": candidate.get("strategy_version"),
+        "parameter_schema_version": candidate.get("parameter_schema_version"),
+        "parameter_binding": candidate.get("parameter_binding"),
+        "dataset_binding": candidate.get("dataset_binding"),
+        "dataset_version": candidate.get("dataset_version"),
+        "dataset_provenance": candidate.get("dataset_provenance"),
+        "period_binding": candidate.get("period_binding"),
+        "training_period": candidate.get("training_period"),
+        "validation_period": candidate.get("validation_period"),
+        "out_of_sample_period": candidate.get("out_of_sample_period"),
+        "instrument_binding": candidate.get("instrument_binding"),
+        "fee_model_binding": candidate.get("fee_model_binding"),
+        "slippage_model_binding": candidate.get("slippage_model_binding"),
+        "funding_model_binding": candidate.get("funding_model_binding"),
+        "execution_model_binding": candidate.get("execution_model_binding"),
+        "economic_policy_binding": candidate.get("economic_policy_binding"),
+        "canonical_trading_logic_version": candidate.get("canonical_trading_logic_version"),
+        "implementation_digest": candidate.get("implementation_digest"),
+        "config_digest": candidate.get("config_digest"),
+        "data_digest": candidate.get("data_digest"),
+        "strategy_params_digest": candidate.get("strategy_params_digest"),
+        "economic_evaluation_authorized": candidate.get("economic_evaluation_authorized"),
+    }
+    return _stable_digest(payload)
+
+
+def _resolve_binding_status(
+    *,
+    dataset_period_status: str,
+    research_success: bool,
+) -> str:
+    if dataset_period_status == BINDING_STATUS_BLOCKED:
+        return BINDING_STATUS_INCOMPLETE
+    if dataset_period_status == BINDING_STATUS_NOT_READY:
+        return BINDING_STATUS_INCOMPLETE
+    if dataset_period_status == BINDING_STATUS_READY and research_success:
+        return BINDING_STATUS_READY_FOR_EVAL_RATIFICATION
+    if dataset_period_status == BINDING_STATUS_READY:
+        return BINDING_STATUS_VALID
+    return BINDING_STATUS_INCOMPLETE
+
+
+def _build_candidate_from_dataset_period(
+    *,
+    repo_root: Path,
+    dataset_candidate: Mapping[str, Any],
+    dataset_envelope: Mapping[str, Any] | None,
+    period_split: Mapping[str, Any] | None,
+    binding_status: str,
+) -> dict[str, Any]:
+    strategy_id = str(dataset_candidate["strategy_id"])
+    strategy_version = str(dataset_candidate["strategy_version"])
+    cfg = load_step31f_evaluation_config_v0(repo_root, strategy_id)
+    entry = get_strategy_registry_entry(strategy_id)
+    parameter_binding = dict(dataset_candidate["parameter_binding"])
+    _, strategy_params_digest = resolve_effective_strategy_params_v1(
+        strategy_id,
+        parameter_binding,
+    )
+    dataset_binding = dict(dataset_candidate["dataset_binding"])
+    dataset_provenance = _build_dataset_provenance(
+        dataset_binding=dataset_binding,
+        dataset_envelope=dataset_envelope,
+    )
+    data_digest_value = dataset_candidate.get("data_digest")
+    if isinstance(data_digest_value, Mapping) and data_digest_value.get("status") == "MATERIALIZED":
+        data_digest = str(data_digest_value["value"])
+    elif isinstance(data_digest_value, str):
+        data_digest = data_digest_value
+    else:
+        data_digest = ""
+
+    candidate: dict[str, Any] = {
+        "canonical_candidate_identifier": canonical_candidate_identifier(
+            strategy_id, strategy_version
+        ),
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        "parameter_schema_version": str(cfg.get("config_schema_version", "")),
+        "parameter_binding": parameter_binding,
+        "dataset_binding": dataset_binding,
+        "dataset_version": str(dataset_candidate.get("dataset_version", "")),
+        "dataset_provenance": dataset_provenance,
+        "period_binding": dict(dataset_candidate["period_binding"]),
+        "training_period": dict(dataset_candidate["training_period"]),
+        "validation_period": dict(dataset_candidate["validation_period"]),
+        "out_of_sample_period": dict(dataset_candidate["out_of_sample_period"]),
+        "instrument_binding": dict(dataset_candidate["instrument_binding"]),
+        "fee_model_binding": dict(dataset_candidate["fee_model_binding"]),
+        "slippage_model_binding": dict(dataset_candidate["slippage_model_binding"]),
+        "funding_model_binding": dict(dataset_candidate["funding_model_binding"]),
+        "execution_model_binding": dict(dataset_candidate["execution_model_binding"]),
+        "economic_policy_binding": dict(dataset_candidate["economic_policy_binding"]),
+        "canonical_trading_logic_version": entry.semantic_digest,
+        "canonical_trading_logic_binding_version": CANONICAL_TRADING_LOGIC_BINDING_VERSION,
+        "implementation_digest": str(dataset_candidate["implementation_digest"]),
+        "config_digest": str(dataset_candidate["config_digest"]),
+        "data_digest": data_digest,
+        "strategy_params_digest": strategy_params_digest,
+        "reproducibility_metadata": _build_reproducibility_metadata(
+            repo_root=repo_root,
+            dataset_period_contract={},
+            dataset_envelope=dataset_envelope,
+            period_split=period_split,
+        ),
+        "binding_status": binding_status,
+        "economic_evaluation_authorized": ECONOMIC_EVALUATION_AUTHORIZED,
+        "operator_ratification_ref": OPERATOR_RATIFICATION_REF,
+        "ratified": True,
+        "source_config_ref": STEP31F_CONFIG_PATHS[strategy_id],
+        "period_digest": dataset_candidate.get("period_digest"),
+        "reason_codes": list(dataset_candidate.get("reason_codes") or []),
+    }
+    candidate["binding_semantic_digest"] = compute_binding_semantic_digest_v0(candidate)
+    return candidate
+
+
+def materialize_final_research_fleet_versioned_binding_completion_v0(
+    *,
+    repo_root: Path,
+    production_manifest: PointInTimeFuturesUniverseManifestV1 | None = None,
+    production_envelope: ProductionManifestMaterializationEnvelopeV1 | None = None,
+    panel_series: Sequence[InstrumentPanelSeriesV1] | None = None,
+    source_registration_ref: str = "",
+    source_registration_digest: str = "",
+) -> dict[str, Any]:
+    """Materialize fleet binding completion from PIT owners and STEP31F configs."""
+    research_success = False
+    dataset_envelope_dict: dict[str, Any] | None = None
+    period_split_dict: dict[str, Any] | None = None
+
+    if (
+        production_manifest is not None
+        and production_envelope is not None
+        and panel_series is not None
+        and source_registration_ref
+        and source_registration_digest
+    ):
+        research_result = materialize_cross_sectional_research_data_digest_and_period_split_v0(
+            repo_root=repo_root,
+            production_manifest=production_manifest,
+            production_envelope=production_envelope,
+            panel_series=panel_series,
+            source_registration_ref=source_registration_ref,
+            source_registration_digest=source_registration_digest,
+        )
+        research_success = research_result.success
+        if research_result.dataset_envelope is not None:
+            dataset_envelope_dict = dataset_envelope_to_dict(research_result.dataset_envelope)
+        if research_result.period_split is not None:
+            period_split_dict = period_split_to_dict(research_result.period_split)
+        dataset_period_contract = materialize_pit_futures_universe_manifest_dataset_period_binding_with_research_materialization_v0(
+            repo_root=repo_root,
+            production_manifest=production_manifest,
+            production_envelope=production_envelope,
+            research_materialization_result=research_result,
+        )
+    elif production_manifest is not None and production_envelope is not None:
+        dataset_period_contract = (
+            materialize_pit_futures_universe_manifest_dataset_period_binding_v0(
+                repo_root=repo_root,
+                production_manifest=production_manifest,
+                production_envelope=production_envelope,
+            )
+        )
+    else:
+        raise ValueError(REASON_MISSING_REQUIRED_FIELD + ":production_manifest_and_envelope")
+
+    dataset_period_status = str(
+        dataset_period_contract.get("binding_materialization_status", BINDING_STATUS_NOT_READY)
+    )
+    overall_binding_status = _resolve_binding_status(
+        dataset_period_status=dataset_period_status,
+        research_success=research_success,
+    )
+
+    shared_bindings = dict(dataset_period_contract.get("shared_bindings") or {})
+    if dataset_envelope_dict is not None:
+        shared_bindings["dataset_envelope"] = dataset_envelope_dict
+    if period_split_dict is not None:
+        shared_bindings["period_split"] = period_split_dict
+
+    candidates = [
+        _build_candidate_from_dataset_period(
+            repo_root=repo_root,
+            dataset_candidate=candidate,
+            dataset_envelope=dataset_envelope_dict,
+            period_split=period_split_dict,
+            binding_status=overall_binding_status,
+        )
+        for candidate in dataset_period_contract["candidates"]
+    ]
+    for candidate in candidates:
+        candidate["reproducibility_metadata"] = _build_reproducibility_metadata(
+            repo_root=repo_root,
+            dataset_period_contract=dataset_period_contract,
+            dataset_envelope=dataset_envelope_dict,
+            period_split=period_split_dict,
+        )
+        candidate["binding_semantic_digest"] = compute_binding_semantic_digest_v0(candidate)
+
+    completion_body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "completion_id": COMPLETION_ID,
+        "fleet_id": FLEET_ID,
+        "fleet_version": FLEET_VERSION,
+        "candidates": candidates,
+        "shared_bindings": shared_bindings,
+        "excluded_failed_historical_candidates": [
+            {"strategy_id": sid, "strategy_version": ver, "retry_forbidden": True}
+            for sid, ver in FAILED_HISTORICAL_CANDIDATES
+        ],
+        "canonical_serialization_version": CANONICAL_SERIALIZATION_VERSION,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "economic_evaluation_authorized": ECONOMIC_EVALUATION_AUTHORIZED,
+        "economic_validity_offline_gate_pass": ECONOMIC_VALIDITY_OFFLINE_GATE_PASS,
+        "runtime_rewire_admissible": RUNTIME_REWIRE_ADMISSIBLE,
+        "futures_only": FUTURES_ONLY,
+        "bitcoin_direction_allowed": BITCOIN_DIRECTION_ALLOWED,
+        "spot_allowed": SPOT_ALLOWED,
+        "synthetic_spot_allowed": SYNTHETIC_SPOT_ALLOWED,
+        "dataset_period_binding_contract_digest": dataset_period_contract.get("contract_digest"),
+        "dataset_period_binding_schema_version": dataset_period_contract.get("schema_version"),
+        "binding_materialization_status": overall_binding_status,
+        "research_materialization_success": research_success,
+        "implementation_digest": compute_implementation_digest_v0(),
+        "digest_semantics": {
+            "completion_digest": "COMPLETION_BODY_CANONICAL_JSON_v0",
+            "binding_semantic_digest": "CANDIDATE_SEMANTIC_BINDING_PAYLOAD_v0",
+            "config_digest": "CANONICAL_PARSED_EVALUATION_CONFIG_v1",
+            "implementation_digest": "STRATEGY_REGISTRY_IMPLEMENTATION_REF_v1",
+            "data_digest": "PIT_CROSS_SECTIONAL_SEMANTIC_DATA_DIGEST_v0",
+        },
+    }
+    completion_body["completion_digest"] = compute_completion_digest_v0(completion_body)
+    return completion_body
+
+
+def _validate_positive_cost(value: Any, *, field: str, reasons: list[str]) -> None:
+    if not isinstance(value, (int, float)) or float(value) <= 0.0:
+        reasons.append(f"{REASON_ZERO_FEE if 'fee' in field else REASON_ZERO_SLIPPAGE}:{field}")
+
+
+def _validate_instrument_binding(binding: Mapping[str, Any], reasons: list[str]) -> None:
+    if binding.get("futures_only") is not True:
+        reasons.append(REASON_FUTURES_ONLY_VIOLATION)
+    if binding.get("spot_allowed") is True:
+        reasons.append(REASON_SPOT_BINDING)
+    if binding.get("synthetic_spot_allowed") is True:
+        reasons.append(REASON_SYNTHETIC_SPOT_BINDING)
+    if binding.get("bitcoin_direction_allowed") is True:
+        reasons.append(REASON_BITCOIN_DIRECTION_BINDING)
+    for instrument_id in binding.get("eligible_instrument_ids", ()):
+        if isinstance(instrument_id, str) and _contains_forbidden_token(instrument_id):
+            reasons.append(f"{REASON_BITCOIN_INSTRUMENT_PRESENT}:{instrument_id}")
+
+
+def _validate_materialized_period(field: Any, *, name: str, reasons: list[str]) -> None:
+    if not isinstance(field, Mapping):
+        reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{name}")
+        return
+    if field.get("status") != "MATERIALIZED":
+        reasons.append(f"{REASON_BINDING_INCOMPLETE}:{name}")
+        return
+    for key in ("start", "end"):
+        raw = field.get(key)
+        if not isinstance(raw, str) or not raw.strip():
+            reasons.append(f"{REASON_BINDING_INCOMPLETE}:{name}.{key}")
+
+
+def validate_final_research_fleet_versioned_binding_completion_v0(
+    completion: Any,
+    *,
+    repo_root: Path,
+    require_ready_for_eval: bool = True,
+    allow_recompute_digests: bool = True,
+) -> BindingCompletionValidationResultV0:
+    reasons: list[str] = []
+    if not isinstance(completion, Mapping):
+        return BindingCompletionValidationResultV0(
+            verdict=ValidationVerdict.REJECTED,
+            valid=False,
+            fail_reasons=(REASON_COMPLETION_NOT_OBJECT,),
+        )
+
+    _reject_repair_keys(completion, path="$", reasons=reasons)
+
+    if completion.get("schema_version") != SCHEMA_VERSION:
+        reasons.append(REASON_UNKNOWN_SCHEMA_VERSION)
+
+    for field in COMPLETION_REQUIRED_FIELDS:
+        if field not in completion:
+            reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{field}")
+
+    for effect_field, expected in (
+        ("authority_effect", AUTHORITY_EFFECT),
+        ("runtime_effect", RUNTIME_EFFECT),
+        ("order_effect", ORDER_EFFECT),
+    ):
+        if completion.get(effect_field) != expected:
+            reasons.append(f"{REASON_EFFECT_NOT_NONE}:{effect_field}")
+
+    if completion.get("economic_evaluation_authorized") is not False:
+        reasons.append(REASON_ECONOMIC_EVALUATION_AUTHORIZED)
+    if completion.get("futures_only") is not True:
+        reasons.append(REASON_FUTURES_ONLY_VIOLATION)
+    if completion.get("bitcoin_direction_allowed") is not False:
+        reasons.append(REASON_BITCOIN_DIRECTION_BINDING)
+    if completion.get("spot_allowed") is not False:
+        reasons.append(REASON_SPOT_BINDING)
+    if completion.get("synthetic_spot_allowed") is not False:
+        reasons.append(REASON_SYNTHETIC_SPOT_BINDING)
+
+    excluded = completion.get("excluded_failed_historical_candidates")
+    if isinstance(excluded, list):
+        excluded_pairs = {
+            (item.get("strategy_id"), item.get("strategy_version"))
+            for item in excluded
+            if isinstance(item, Mapping)
+        }
+        for pair in FAILED_HISTORICAL_CANDIDATES:
+            if pair not in excluded_pairs:
+                reasons.append(f"{REASON_FAILED_HISTORICAL_CANDIDATE}:{pair[0]}")
+
+    raw_candidates = completion.get("candidates")
+    if not isinstance(raw_candidates, list):
+        reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:candidates")
+        raw_candidates = []
+
+    expected_ids = {sid for sid, _ in FLEET_CANDIDATES}
+    seen_ids: set[str] = set()
+    parsed_candidates: list[Mapping[str, Any]] = []
+
+    for index, candidate in enumerate(raw_candidates):
+        path = f"candidates[{index}]"
+        if not isinstance(candidate, Mapping):
+            reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{path}")
+            continue
+        _reject_repair_keys(candidate, path=path, reasons=reasons)
+
+        strategy_id = candidate.get("strategy_id")
+        strategy_version = candidate.get("strategy_version")
+        if not isinstance(strategy_id, str) or not isinstance(strategy_version, str):
+            reasons.append(f"{REASON_AMBIGUOUS_BINDING}:{path}.strategy_identity")
+            continue
+
+        if (strategy_id, strategy_version) in FAILED_HISTORICAL_CANDIDATES:
+            reasons.append(f"{REASON_FAILED_HISTORICAL_CANDIDATE}:{strategy_id}")
+
+        if (strategy_id, strategy_version) not in FLEET_CANDIDATES:
+            if strategy_id in expected_ids:
+                reasons.append(f"{REASON_WRONG_STRATEGY_VERSION}:{strategy_id}")
+            else:
+                reasons.append(f"{REASON_UNKNOWN_STRATEGY}:{strategy_id}")
+
+        expected_identifier = canonical_candidate_identifier(strategy_id, strategy_version)
+        if candidate.get("canonical_candidate_identifier") != expected_identifier:
+            reasons.append(
+                f"{REASON_AMBIGUOUS_BINDING}:canonical_candidate_identifier:{strategy_id}"
+            )
+
+        if strategy_id in seen_ids:
+            reasons.append(f"{REASON_DUPLICATE_CANDIDATE}:{strategy_id}")
+        seen_ids.add(strategy_id)
+
+        for field in CANDIDATE_REQUIRED_FIELDS:
+            if field not in candidate:
+                reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{path}.{field}")
+
+        if candidate.get("economic_evaluation_authorized") is not False:
+            reasons.append(f"{REASON_ECONOMIC_EVALUATION_AUTHORIZED}:{strategy_id}")
+
+        if candidate.get("ratified") is not True:
+            reasons.append(f"{REASON_NOT_RATIFIED}:{strategy_id}")
+        if candidate.get("operator_ratification_ref") != OPERATOR_RATIFICATION_REF:
+            reasons.append(f"{REASON_RATIFICATION_REF_MISMATCH}:{strategy_id}")
+
+        binding_status = candidate.get("binding_status")
+        if require_ready_for_eval:
+            if binding_status != BINDING_STATUS_READY_FOR_EVAL_RATIFICATION:
+                reasons.append(
+                    f"{REASON_BINDING_NOT_READY_FOR_EVAL}:{strategy_id}:{binding_status}"
+                )
+        elif binding_status == BINDING_STATUS_INCOMPLETE:
+            reasons.append(f"{REASON_BINDING_INCOMPLETE}:{strategy_id}")
+
+        instrument = candidate.get("instrument_binding")
+        if isinstance(instrument, Mapping):
+            _validate_instrument_binding(instrument, reasons)
+        else:
+            reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{path}.instrument_binding")
+
+        fee = candidate.get("fee_model_binding")
+        if isinstance(fee, Mapping):
+            _validate_positive_cost(fee.get("fee_bps"), field="fee_bps", reasons=reasons)
+        else:
+            reasons.append(f"{REASON_ZERO_FEE}:{strategy_id}")
+
+        slippage = candidate.get("slippage_model_binding")
+        if isinstance(slippage, Mapping):
+            _validate_positive_cost(
+                slippage.get("slippage_bps"), field="slippage_bps", reasons=reasons
+            )
+        else:
+            reasons.append(f"{REASON_ZERO_SLIPPAGE}:{strategy_id}")
+
+        if binding_status in (
+            BINDING_STATUS_VALID,
+            BINDING_STATUS_READY_FOR_EVAL_RATIFICATION,
+        ):
+            _validate_materialized_period(
+                candidate.get("training_period"), name="training_period", reasons=reasons
+            )
+            _validate_materialized_period(
+                candidate.get("validation_period"), name="validation_period", reasons=reasons
+            )
+            _validate_materialized_period(
+                candidate.get("out_of_sample_period"),
+                name="out_of_sample_period",
+                reasons=reasons,
+            )
+            data_digest = candidate.get("data_digest")
+            if not isinstance(data_digest, str) or not is_valid_digest(data_digest.strip().lower()):
+                reasons.append(f"{REASON_WRONG_DATA_DIGEST}:{strategy_id}")
+            shared = completion.get("shared_bindings")
+            if isinstance(shared, Mapping):
+                envelope = shared.get("dataset_envelope")
+                if isinstance(envelope, Mapping):
+                    expected_data_digest = envelope.get("data_digest")
+                    if (
+                        isinstance(expected_data_digest, str)
+                        and data_digest != expected_data_digest
+                    ):
+                        reasons.append(f"{REASON_WRONG_DATA_DIGEST}:{strategy_id}")
+
+        if allow_recompute_digests and strategy_id in STEP31F_CONFIG_PATHS:
+            try:
+                cfg = load_step31f_evaluation_config_v0(repo_root, strategy_id)
+                if candidate.get("config_digest") != compute_config_digest_v1(cfg):
+                    reasons.append(f"{REASON_WRONG_CONFIG_DIGEST}:{strategy_id}")
+                entry = get_strategy_registry_entry(strategy_id)
+                if candidate.get("implementation_digest") != entry.implementation_digest:
+                    reasons.append(f"{REASON_WRONG_IMPLEMENTATION_DIGEST}:{strategy_id}")
+                resolution = resolve_strategy_id(strategy_id)
+                if resolution.canonical_strategy_id != strategy_id:
+                    reasons.append(f"{REASON_UNKNOWN_STRATEGY}:{strategy_id}")
+                expected_semantic = compute_binding_semantic_digest_v0(candidate)
+                if candidate.get("binding_semantic_digest") != expected_semantic:
+                    reasons.append(f"{REASON_WRONG_BINDING_SEMANTIC_DIGEST}:{strategy_id}")
+            except (FileNotFoundError, ValueError, KeyError) as exc:
+                reasons.append(f"{REASON_AMBIGUOUS_BINDING}:{strategy_id}:{exc}")
+
+        parsed_candidates.append(candidate)
+
+    missing = sorted(expected_ids - seen_ids)
+    for strategy_id in missing:
+        reasons.append(f"{REASON_MISSING_CANDIDATE}:{strategy_id}")
+    for strategy_id in sorted(seen_ids - expected_ids):
+        reasons.append(f"{REASON_EXTRA_CANDIDATE}:{strategy_id}")
+
+    if len(parsed_candidates) >= 2:
+        reference = parsed_candidates[0]
+        for field in (
+            "dataset_binding",
+            "period_binding",
+            "instrument_binding",
+            "economic_policy_binding",
+            "data_digest",
+        ):
+            ref_value = reference.get(field)
+            for candidate in parsed_candidates[1:]:
+                if candidate.get(field) != ref_value:
+                    if field == "economic_policy_binding":
+                        reasons.append(REASON_ECONOMIC_POLICY_MISMATCH)
+                    else:
+                        reasons.append(
+                            f"{REASON_SHARED_BINDING_MISMATCH}:{field}:{candidate.get('strategy_id')}"
+                        )
+
+    expected_completion_digest = compute_completion_digest_v0(completion)
+    if completion.get("completion_digest") != expected_completion_digest:
+        reasons.append(REASON_WRONG_COMPLETION_DIGEST)
+
+    canonical = dumps_completion_canonical_v1(completion)
+    if canonical != dumps_completion_canonical_v1(json.loads(canonical)):
+        reasons.append(REASON_NON_CANONICAL_SERIALIZATION)
+    if _ABSOLUTE_PATH_PATTERN.search(canonical):
+        reasons.append(REASON_NON_CANONICAL_SERIALIZATION + ":absolute_path_in_completion")
+
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    if unique_reasons:
+        return BindingCompletionValidationResultV0(
+            verdict=ValidationVerdict.REJECTED,
+            valid=False,
+            fail_reasons=unique_reasons,
+        )
+    return BindingCompletionValidationResultV0(
+        verdict=ValidationVerdict.ACCEPTED,
+        valid=True,
+        fail_reasons=(),
+    )
+
+
+def clone_completion(completion: Mapping[str, Any]) -> dict[str, Any]:
+    return deepcopy(dict(completion))
+
+
+__all__ = [
+    "AUTHORITY_EFFECT",
+    "BINDING_STATUS_INCOMPLETE",
+    "BINDING_STATUS_READY_FOR_EVAL_RATIFICATION",
+    "BINDING_STATUS_VALID",
+    "BindingCompletionValidationResultV0",
+    "CANONICAL_SERIALIZATION_VERSION",
+    "COMPLETION_ID",
+    "ECONOMIC_EVALUATION_AUTHORIZED",
+    "FAILED_HISTORICAL_CANDIDATES",
+    "FLEET_CANDIDATES",
+    "FLEET_ID",
+    "FUTURES_ONLY",
+    "ORDER_EFFECT",
+    "RUNTIME_EFFECT",
+    "SCHEMA_VERSION",
+    "ValidationVerdict",
+    "canonical_candidate_identifier",
+    "clone_completion",
+    "compute_binding_semantic_digest_v0",
+    "compute_completion_digest_v0",
+    "materialize_final_research_fleet_versioned_binding_completion_v0",
+    "serialize_completion_canonical_v0",
+    "validate_final_research_fleet_versioned_binding_completion_v0",
+]

--- a/tests/research/test_final_research_fleet_versioned_binding_completion_v0.py
+++ b/tests/research/test_final_research_fleet_versioned_binding_completion_v0.py
@@ -1,0 +1,618 @@
+"""Contract tests for final_research_fleet_versioned_binding_completion_v0."""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.research.final_research_fleet_v0_versioned_binding_manifest_contract_v0 import (
+    FLEET_CANDIDATES,
+)
+from src.research.final_research_fleet_versioned_binding_completion_v0 import (
+    AUTHORITY_EFFECT,
+    BINDING_STATUS_INCOMPLETE,
+    BINDING_STATUS_READY_FOR_EVAL_RATIFICATION,
+    CANONICAL_SERIALIZATION_VERSION,
+    COMPLETION_ID,
+    ECONOMIC_EVALUATION_AUTHORIZED,
+    FAILED_HISTORICAL_CANDIDATES,
+    FLEET_ID,
+    FUTURES_ONLY,
+    ORDER_EFFECT,
+    REASON_BINDING_INCOMPLETE,
+    REASON_BINDING_NOT_READY_FOR_EVAL,
+    REASON_BINDING_REPAIR_REJECTED,
+    REASON_BITCOIN_DIRECTION_BINDING,
+    REASON_DUPLICATE_CANDIDATE,
+    REASON_ECONOMIC_EVALUATION_AUTHORIZED,
+    REASON_ECONOMIC_POLICY_MISMATCH,
+    REASON_EFFECT_NOT_NONE,
+    REASON_EXTRA_CANDIDATE,
+    REASON_FAILED_HISTORICAL_CANDIDATE,
+    REASON_FUTURES_ONLY_VIOLATION,
+    REASON_MISSING_CANDIDATE,
+    REASON_MISSING_REQUIRED_FIELD,
+    REASON_SHARED_BINDING_MISMATCH,
+    REASON_SPOT_BINDING,
+    REASON_SYNTHETIC_SPOT_BINDING,
+    REASON_UNKNOWN_SCHEMA_VERSION,
+    REASON_UNKNOWN_STRATEGY,
+    REASON_WRONG_BINDING_SEMANTIC_DIGEST,
+    REASON_WRONG_COMPLETION_DIGEST,
+    REASON_WRONG_CONFIG_DIGEST,
+    REASON_WRONG_DATA_DIGEST,
+    REASON_WRONG_IMPLEMENTATION_DIGEST,
+    REASON_WRONG_STRATEGY_VERSION,
+    REASON_ZERO_FEE,
+    REASON_ZERO_SLIPPAGE,
+    RUNTIME_EFFECT,
+    SCHEMA_VERSION,
+    ValidationVerdict,
+    canonical_candidate_identifier,
+    clone_completion,
+    compute_binding_semantic_digest_v0,
+    compute_completion_digest_v0,
+    materialize_final_research_fleet_versioned_binding_completion_v0,
+    serialize_completion_canonical_v0,
+    validate_final_research_fleet_versioned_binding_completion_v0,
+)
+from src.research.pit_futures_universe_manifest_production_materialization_v1 import (
+    DEFAULT_MINIMUM_HISTORY_BARS,
+    DEFAULT_MINIMUM_REQUIRED_MEMBER_COUNT,
+    EVALUATION_PERIOD_BINDING,
+    EXCLUSION_POLICY_VERSION,
+    INCLUSION_POLICY_VERSION,
+    INPUT_CONTRACT_VERSION,
+    MATERIALIZATION_VERSION,
+    ProductionMaterializationEpochV1,
+    PitFuturesUniverseManifestProductionMaterializationInputV1,
+    assemble_production_registry_from_observations_v1,
+    materialize_production_pit_futures_universe_manifest_v1,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import (
+    InstrumentPanelSeriesV1,
+    PanelBarV1,
+    compute_series_digest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_GENERATED_AT = "2026-07-03T04:00:00Z"
+_BAR_CLOSE = "2024-06-01T01:00:00Z"
+_PERIOD_START = "2024-05-25T00:00:00Z"
+_PERIOD_END = _BAR_CLOSE
+_PANEL_DIGEST = "b" * 64
+_SOURCE_REF = "okx_public_instruments_swap:test"
+_SOURCE_DIGEST = "c" * 64
+_REGISTRY_CONFIG = "d" * 64
+_REGISTRY_IMPL = "e" * 64
+
+
+def _live_inst(base: str, *, inst_id: str | None = None) -> dict[str, str]:
+    symbol = inst_id or f"{base}-USDT-SWAP"
+    return {
+        "instId": symbol,
+        "instType": "SWAP",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "baseCcy": base,
+        "state": "live",
+        "listTime": "1609459200000",
+        "expTime": "",
+    }
+
+
+def _hourly_bars(instrument_id: str, *, count: int, end: str) -> tuple[PanelBarV1, ...]:
+    end_dt = datetime.strptime(end, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    bars: list[PanelBarV1] = []
+    for offset in range(count):
+        ts = end_dt - timedelta(hours=count - 1 - offset)
+        ts_str = ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+        bars.append(
+            PanelBarV1(
+                instrument_id=instrument_id,
+                timestamp_utc=ts_str,
+                open="1",
+                high="2",
+                low="0.5",
+                close="1.5",
+                volume="10",
+                is_final=True,
+            )
+        )
+    return tuple(bars)
+
+
+def _build_registry_and_panel(
+    instruments: list[dict[str, str]],
+) -> tuple[object, tuple[InstrumentPanelSeriesV1, ...], str]:
+    from src.research.instrument_id_canonicalization_v1 import (
+        InstrumentIdCanonicalizationInputV1,
+        canonicalize_instrument_id_v1,
+    )
+    from src.research.okx_production_instrument_lifecycle_source_v1 import (
+        build_lifecycle_source_observations_v1,
+        build_okx_lifecycle_source_snapshot_v1,
+    )
+
+    snapshot = build_okx_lifecycle_source_snapshot_v1(
+        instruments,
+        retrieval_timestamp_utc=_GENERATED_AT,
+        source_snapshot_ref=_SOURCE_REF,
+    )
+    observations = build_lifecycle_source_observations_v1(snapshot)
+    registry, errors = assemble_production_registry_from_observations_v1(
+        observations,
+        generated_at=_GENERATED_AT,
+        lifecycle_source_snapshot_digest=snapshot.raw_snapshot_digest,
+        config_digest=_REGISTRY_CONFIG,
+        implementation_digest=_REGISTRY_IMPL,
+    )
+    assert errors == (), errors
+    assert registry is not None
+    panel_series: list[InstrumentPanelSeriesV1] = []
+    for metadata in snapshot.eligible_instruments:
+        canon = canonicalize_instrument_id_v1(
+            InstrumentIdCanonicalizationInputV1(
+                venue_id="okx",
+                market_type="futures",
+                contract_type="linear_perpetual",
+                base_asset=metadata.base_asset,
+                quote_asset="USDT",
+                settlement_asset="USDT",
+                venue_symbol=metadata.inst_id,
+            )
+        )
+        assert canon.success and canon.instrument_id is not None
+        panel_series.append(
+            InstrumentPanelSeriesV1(
+                instrument_id=canon.instrument_id,
+                native_instrument_id=metadata.inst_id,
+                bars=_hourly_bars(canon.instrument_id, count=30, end=_BAR_CLOSE),
+                series_digest="0" * 64,
+            )
+        )
+    for index, series in enumerate(panel_series):
+        panel_series[index] = InstrumentPanelSeriesV1(
+            instrument_id=series.instrument_id,
+            native_instrument_id=series.native_instrument_id,
+            bars=series.bars,
+            series_digest=compute_series_digest(series),
+        )
+    return registry, tuple(panel_series), snapshot.raw_snapshot_digest
+
+
+def _default_instruments() -> list[dict[str, str]]:
+    return [
+        _live_inst("BTC"),
+        *[_live_inst(base) for base in ("ETH", "SOL", "ADA", "DOT", "LINK", "AVAX")],
+    ]
+
+
+def _build_production_result():
+    registry, panel_series, source_digest = _build_registry_and_panel(_default_instruments())
+    inp = PitFuturesUniverseManifestProductionMaterializationInputV1(
+        input_contract_version=INPUT_CONTRACT_VERSION,
+        materialization_version=MATERIALIZATION_VERSION,
+        generated_at=_GENERATED_AT,
+        universe_policy_id="pit_okx_linear_usdt_non_bitcoin_perpetual_cross_sectional_universe",
+        universe_policy_version="v1",
+        inclusion_policy_version=INCLUSION_POLICY_VERSION,
+        exclusion_policy_version=EXCLUSION_POLICY_VERSION,
+        lifecycle_source_id="okx_production_instrument_lifecycle_historical_as_of_fail_closed.v1",
+        lifecycle_source_snapshot_ref=_SOURCE_REF,
+        lifecycle_source_snapshot_digest=source_digest,
+        registry_artifact_id="okx_production_lifecycle_v1",
+        registry_snapshot=registry,
+        panel_series=panel_series,
+        panel_dataset_ref="pit_okx_pt1h_panel_ohlcv_dataset_v1:test_panel:sha256:" + "a" * 64,
+        panel_dataset_digest=_PANEL_DIGEST,
+        period_binding_ref=EVALUATION_PERIOD_BINDING,
+        period_start_utc=_PERIOD_START,
+        period_end_utc=_PERIOD_END,
+        minimum_history_bars=DEFAULT_MINIMUM_HISTORY_BARS,
+        minimum_required_member_count=DEFAULT_MINIMUM_REQUIRED_MEMBER_COUNT,
+        registry_config_digest=_REGISTRY_CONFIG,
+        registry_implementation_digest=_REGISTRY_IMPL,
+        epochs=(
+            ProductionMaterializationEpochV1(
+                score_epoch=0,
+                finalized_bar_close=_BAR_CLOSE,
+            ),
+        ),
+    )
+    result = materialize_production_pit_futures_universe_manifest_v1(inp)
+    assert result.success is True
+    assert result.manifest is not None and result.envelope is not None
+    return result, panel_series
+
+
+@pytest.fixture(scope="module")
+def production_bundle():
+    return _build_production_result()
+
+
+@pytest.fixture(scope="module")
+def canonical_completion(production_bundle):
+    production, panel_series = production_bundle
+    return materialize_final_research_fleet_versioned_binding_completion_v0(
+        repo_root=REPO_ROOT,
+        production_manifest=production.manifest,
+        production_envelope=production.envelope,
+        panel_series=panel_series,
+        source_registration_ref=_SOURCE_REF,
+        source_registration_digest=_SOURCE_DIGEST,
+    )
+
+
+def _candidate(completion: dict, strategy_id: str) -> dict:
+    for candidate in completion["candidates"]:
+        if candidate["strategy_id"] == strategy_id:
+            return candidate
+    raise KeyError(strategy_id)
+
+
+def _validate(completion: dict, *, require_ready: bool = True):
+    return validate_final_research_fleet_versioned_binding_completion_v0(
+        completion,
+        repo_root=REPO_ROOT,
+        require_ready_for_eval=require_ready,
+    )
+
+
+def test_materialize_exactly_three_fleet_candidates(canonical_completion: dict) -> None:
+    assert len(canonical_completion["candidates"]) == 3
+    ids = {candidate["strategy_id"] for candidate in canonical_completion["candidates"]}
+    assert ids == {sid for sid, _ in FLEET_CANDIDATES}
+
+
+def test_candidate_ids_and_versions(canonical_completion: dict) -> None:
+    for strategy_id, strategy_version in FLEET_CANDIDATES:
+        candidate = _candidate(canonical_completion, strategy_id)
+        assert candidate["strategy_version"] == strategy_version
+        assert candidate["canonical_candidate_identifier"] == canonical_candidate_identifier(
+            strategy_id, strategy_version
+        )
+
+
+def test_deterministic_completion_generation(canonical_completion: dict, production_bundle) -> None:
+    production, panel_series = production_bundle
+    second = materialize_final_research_fleet_versioned_binding_completion_v0(
+        repo_root=REPO_ROOT,
+        production_manifest=production.manifest,
+        production_envelope=production.envelope,
+        panel_series=panel_series,
+        source_registration_ref=_SOURCE_REF,
+        source_registration_digest=_SOURCE_DIGEST,
+    )
+    assert serialize_completion_canonical_v0(
+        canonical_completion
+    ) == serialize_completion_canonical_v0(second)
+    assert canonical_completion["completion_digest"] == second["completion_digest"]
+
+
+def test_double_execution_produces_identical_bytes(
+    canonical_completion: dict, production_bundle
+) -> None:
+    production, panel_series = production_bundle
+    first_bytes = serialize_completion_canonical_v0(canonical_completion).encode("utf-8")
+    second_bytes = serialize_completion_canonical_v0(
+        materialize_final_research_fleet_versioned_binding_completion_v0(
+            repo_root=REPO_ROOT,
+            production_manifest=production.manifest,
+            production_envelope=production.envelope,
+            panel_series=panel_series,
+            source_registration_ref=_SOURCE_REF,
+            source_registration_digest=_SOURCE_DIGEST,
+        )
+    ).encode("utf-8")
+    assert first_bytes == second_bytes
+
+
+def test_binding_status_ready_for_eval_ratification(canonical_completion: dict) -> None:
+    assert (
+        canonical_completion["binding_materialization_status"]
+        == BINDING_STATUS_READY_FOR_EVAL_RATIFICATION
+    )
+    for candidate in canonical_completion["candidates"]:
+        assert candidate["binding_status"] == BINDING_STATUS_READY_FOR_EVAL_RATIFICATION
+
+
+def test_economic_evaluation_not_authorized(canonical_completion: dict) -> None:
+    assert canonical_completion["economic_evaluation_authorized"] is False
+    assert ECONOMIC_EVALUATION_AUTHORIZED is False
+    for candidate in canonical_completion["candidates"]:
+        assert candidate["economic_evaluation_authorized"] is False
+
+
+def test_futures_only_enforcement(canonical_completion: dict) -> None:
+    assert canonical_completion["futures_only"] is True
+    assert canonical_completion["bitcoin_direction_allowed"] is False
+    assert canonical_completion["spot_allowed"] is False
+    assert canonical_completion["synthetic_spot_allowed"] is False
+    for candidate in canonical_completion["candidates"]:
+        instrument = candidate["instrument_binding"]
+        assert instrument["futures_only"] is True
+        assert instrument["bitcoin_direction_allowed"] is False
+        assert instrument["spot_allowed"] is False
+        assert instrument["synthetic_spot_allowed"] is False
+
+
+def test_shared_economic_policy_binding(canonical_completion: dict) -> None:
+    policies = [
+        candidate["economic_policy_binding"] for candidate in canonical_completion["candidates"]
+    ]
+    assert len({str(policy) for policy in policies}) == 1
+
+
+def test_shared_cost_and_execution_bindings(canonical_completion: dict) -> None:
+    reference = canonical_completion["candidates"][0]
+    for candidate in canonical_completion["candidates"][1:]:
+        assert candidate["fee_model_binding"] == reference["fee_model_binding"]
+        assert candidate["slippage_model_binding"] == reference["slippage_model_binding"]
+        assert candidate["funding_model_binding"] == reference["funding_model_binding"]
+        assert candidate["execution_model_binding"] == reference["execution_model_binding"]
+
+
+def test_dataset_period_split_binding_present(canonical_completion: dict) -> None:
+    shared = canonical_completion["shared_bindings"]
+    assert "dataset_envelope" in shared
+    assert "period_split" in shared
+    for candidate in canonical_completion["candidates"]:
+        assert candidate["training_period"]["status"] == "MATERIALIZED"
+        assert candidate["validation_period"]["status"] == "MATERIALIZED"
+        assert candidate["out_of_sample_period"]["status"] == "MATERIALIZED"
+        assert len(candidate["data_digest"]) == 64
+
+
+def test_required_candidate_fields_present(canonical_completion: dict) -> None:
+    required = {
+        "parameter_schema_version",
+        "dataset_provenance",
+        "canonical_trading_logic_version",
+        "binding_semantic_digest",
+        "reproducibility_metadata",
+        "strategy_params_digest",
+    }
+    for candidate in canonical_completion["candidates"]:
+        for field in required:
+            assert field in candidate, f"{candidate['strategy_id']} missing {field}"
+
+
+def test_failed_historical_candidates_excluded(canonical_completion: dict) -> None:
+    excluded = {
+        (item["strategy_id"], item["strategy_version"])
+        for item in canonical_completion["excluded_failed_historical_candidates"]
+    }
+    for pair in FAILED_HISTORICAL_CANDIDATES:
+        assert pair in excluded
+    fleet_ids = {candidate["strategy_id"] for candidate in canonical_completion["candidates"]}
+    for strategy_id, _ in FAILED_HISTORICAL_CANDIDATES:
+        assert strategy_id not in fleet_ids or strategy_id in {sid for sid, _ in FLEET_CANDIDATES}
+
+
+def test_effects_remain_none(canonical_completion: dict) -> None:
+    assert canonical_completion["authority_effect"] == AUTHORITY_EFFECT == "NONE"
+    assert canonical_completion["runtime_effect"] == RUNTIME_EFFECT == "NONE"
+    assert canonical_completion["order_effect"] == ORDER_EFFECT == "NONE"
+
+
+def test_validator_accepts_canonical_completion(canonical_completion: dict) -> None:
+    result = _validate(canonical_completion)
+    assert result.valid is True
+    assert result.verdict == ValidationVerdict.ACCEPTED
+    assert result.fail_reasons == ()
+
+
+def test_binding_semantic_digest_deterministic(canonical_completion: dict) -> None:
+    for candidate in canonical_completion["candidates"]:
+        expected = compute_binding_semantic_digest_v0(candidate)
+        assert candidate["binding_semantic_digest"] == expected
+
+
+def test_incomplete_without_panel(production_bundle) -> None:
+    production, _ = production_bundle
+    completion = materialize_final_research_fleet_versioned_binding_completion_v0(
+        repo_root=REPO_ROOT,
+        production_manifest=production.manifest,
+        production_envelope=production.envelope,
+    )
+    assert completion["binding_materialization_status"] == BINDING_STATUS_INCOMPLETE
+    result = _validate(completion, require_ready=True)
+    assert result.valid is False
+    assert any(
+        reason.startswith(REASON_BINDING_NOT_READY_FOR_EVAL) for reason in result.fail_reasons
+    )
+
+
+@pytest.mark.parametrize(
+    ("strategy_id", "mutator", "reason_prefix"),
+    [
+        ("trend_following", lambda c: c["candidates"].pop(0), REASON_MISSING_CANDIDATE),
+        (
+            "trend_following",
+            lambda c: c["candidates"].append(copy.deepcopy(c["candidates"][0])),
+            REASON_DUPLICATE_CANDIDATE,
+        ),
+        (
+            "trend_following",
+            lambda c: c["candidates"].append(
+                {
+                    **copy.deepcopy(c["candidates"][0]),
+                    "strategy_id": "macd",
+                    "strategy_version": "v1",
+                    "canonical_candidate_identifier": "macd/v1",
+                }
+            ),
+            REASON_UNKNOWN_STRATEGY,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update({"strategy_version": "v2"}),
+            REASON_WRONG_STRATEGY_VERSION,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update(
+                {"economic_evaluation_authorized": True}
+            ),
+            REASON_ECONOMIC_EVALUATION_AUTHORIZED,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["instrument_binding"].update(
+                {"spot_allowed": True}
+            ),
+            REASON_SPOT_BINDING,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["instrument_binding"].update(
+                {"synthetic_spot_allowed": True}
+            ),
+            REASON_SYNTHETIC_SPOT_BINDING,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["instrument_binding"].update(
+                {"bitcoin_direction_allowed": True}
+            ),
+            REASON_BITCOIN_DIRECTION_BINDING,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["instrument_binding"].update(
+                {"futures_only": False}
+            ),
+            REASON_FUTURES_ONLY_VIOLATION,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["fee_model_binding"].update({"fee_bps": 0}),
+            REASON_ZERO_FEE,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["slippage_model_binding"].update(
+                {"slippage_bps": 0}
+            ),
+            REASON_ZERO_SLIPPAGE,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "bollinger_bands")["economic_policy_binding"].update(
+                {"policy_version": "other_policy_v9"}
+            ),
+            REASON_ECONOMIC_POLICY_MISMATCH,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update({"data_digest": "0" * 64}),
+            REASON_WRONG_DATA_DIGEST,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update({"implementation_digest": "0" * 64}),
+            REASON_WRONG_IMPLEMENTATION_DIGEST,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update({"config_digest": "0" * 64}),
+            REASON_WRONG_CONFIG_DIGEST,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update(
+                {"binding_semantic_digest": "0" * 64}
+            ),
+            REASON_WRONG_BINDING_SEMANTIC_DIGEST,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following")["period_binding"].update(
+                {"period_binding_ref": "other_ref"}
+            ),
+            REASON_SHARED_BINDING_MISMATCH,
+        ),
+        (
+            "trend_following",
+            lambda c: c.update({"schema_version": "unknown.v9"}),
+            REASON_UNKNOWN_SCHEMA_VERSION,
+        ),
+        (
+            "trend_following",
+            lambda c: c.update({"authority_effect": "LIVE"}),
+            REASON_EFFECT_NOT_NONE,
+        ),
+        (
+            "trend_following",
+            lambda c: c.update({"completion_digest": "0" * 64}),
+            REASON_WRONG_COMPLETION_DIGEST,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update({"fallback": True}),
+            REASON_BINDING_REPAIR_REJECTED,
+        ),
+        (
+            "trend_following",
+            lambda c: _candidate(c, "trend_following").update(
+                {"binding_status": BINDING_STATUS_INCOMPLETE}
+            ),
+            REASON_BINDING_NOT_READY_FOR_EVAL,
+        ),
+    ],
+)
+def test_negative_validation_cases(
+    canonical_completion: dict,
+    strategy_id: str,
+    mutator,
+    reason_prefix: str,
+) -> None:
+    mutated = clone_completion(canonical_completion)
+    mutator(mutated)
+    if mutated.get("completion_digest") == canonical_completion["completion_digest"]:
+        mutated["completion_digest"] = compute_completion_digest_v0(mutated)
+    result = _validate(mutated)
+    assert result.valid is False
+    assert result.verdict == ValidationVerdict.REJECTED
+    assert any(reason.startswith(reason_prefix) for reason in result.fail_reasons)
+
+
+def test_extra_candidate_rejected(canonical_completion: dict) -> None:
+    mutated = clone_completion(canonical_completion)
+    extra = copy.deepcopy(mutated["candidates"][0])
+    extra["strategy_id"] = "rsi_reversion"
+    extra["strategy_version"] = "step30a"
+    extra["canonical_candidate_identifier"] = "rsi_reversion/step30a"
+    mutated["candidates"].append(extra)
+    mutated["completion_digest"] = compute_completion_digest_v0(mutated)
+    result = _validate(mutated)
+    assert any(reason.startswith(REASON_EXTRA_CANDIDATE) for reason in result.fail_reasons)
+
+
+def test_failed_historical_candidate_in_fleet_rejected(canonical_completion: dict) -> None:
+    mutated = clone_completion(canonical_completion)
+    extra = copy.deepcopy(mutated["candidates"][0])
+    extra["strategy_id"] = "macd"
+    extra["strategy_version"] = "v1"
+    extra["canonical_candidate_identifier"] = "macd/v1"
+    mutated["candidates"].append(extra)
+    mutated["completion_digest"] = compute_completion_digest_v0(mutated)
+    result = _validate(mutated)
+    assert any(
+        reason.startswith(REASON_FAILED_HISTORICAL_CANDIDATE) for reason in result.fail_reasons
+    )
+
+
+def test_completion_metadata_fields(canonical_completion: dict) -> None:
+    assert canonical_completion["schema_version"] == SCHEMA_VERSION
+    assert canonical_completion["completion_id"] == COMPLETION_ID
+    assert canonical_completion["fleet_id"] == FLEET_ID
+    assert (
+        canonical_completion["canonical_serialization_version"] == CANONICAL_SERIALIZATION_VERSION
+    )
+    assert canonical_completion["futures_only"] is FUTURES_ONLY


### PR DESCRIPTION
## Summary

- Materializes complete versioned bindings for the final research fleet candidates `trend_following/v1`, `bollinger_bands/v1`, and `momentum_1h/v1` by reusing the PIT cross-sectional dataset/period/digest owners from PRs #4782–#4784 and STEP31F strategy/cost configs.
- Adds fail-closed completion validation with explicit states `BINDING_INCOMPLETE`, `BINDING_VALID`, and `READY_FOR_SEPARATE_OFFLINE_EVALUATION_RATIFICATION`; all candidates remain `ECONOMIC_EVALUATION_AUTHORIZED=false`.
- Adds operator materialization script and 41 contract tests covering futures-only enforcement, shared economic policy, digest determinism, failed historical exclusions, and negative validation cases.

## Scope boundaries

- Binding completion only — no offline economic evaluation, no runtime/shadow/paper/testnet wiring, no promotion readiness claims.
- Primary worktree untouched; isolated feature worktree from `origin/main@6b339ab8`.

## Test plan

- [x] `pytest tests/research/test_final_research_fleet_versioned_binding_completion_v0.py` (41 passed)
- [x] Related research contract suite (134 passed)
- [x] `ruff format --check`, `ruff check`, `git diff --check`
- [x] Durable evidence bundle with `MANIFEST_VERIFY_RC=0`


Made with [Cursor](https://cursor.com)