### PR TITLE
feat(research): ratify final fleet offline economic evaluation scope v0

### DIFF
--- a/scripts/ops/materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0.py
+++ b/scripts/ops/materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Materialize final research fleet offline economic evaluation scope ratification v0.
+
+Offline-first: validates fleet binding completion and emits scope ratification
+contract. No economic evaluation execution, no runtime or order effect.
+Operator GO: GO_BOUNDED_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFICATION_V0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+CONFIRM_GO = "GO_BOUNDED_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFICATION_V0"
+
+from src.research.final_research_fleet_offline_economic_evaluation_scope_ratification_v0 import (  # noqa: E402
+    SCHEMA_VERSION,
+    ValidationVerdict,
+    materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0,
+    serialize_ratification_canonical_v0,
+    validate_final_research_fleet_offline_economic_evaluation_scope_ratification_v0,
+)
+from src.research.final_research_fleet_versioned_binding_completion_v0 import (  # noqa: E402
+    ValidationVerdict as BindingValidationVerdict,
+    validate_final_research_fleet_versioned_binding_completion_v0,
+)
+
+
+def _utc_now_z() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        _die(f"ERR: not_object:{path}")
+    return payload
+
+
+def run_materialization(
+    *,
+    confirm: str,
+    binding_completion_path: Path,
+    durable_evidence_root: Path,
+) -> dict[str, Any]:
+    if confirm != CONFIRM_GO:
+        _die(f"ERR: confirm_go_token_required:{CONFIRM_GO}")
+
+    if not binding_completion_path.is_file():
+        _die(f"ERR: missing_binding_completion:{binding_completion_path}")
+
+    fleet_binding_completion = _load_json(binding_completion_path)
+    binding_validation = validate_final_research_fleet_versioned_binding_completion_v0(
+        fleet_binding_completion,
+        repo_root=_REPO_ROOT,
+        require_ready_for_eval=True,
+    )
+    if binding_validation.verdict != BindingValidationVerdict.ACCEPTED:
+        _die(f"ERR: binding_completion_validation_failed:{binding_validation.fail_reasons}")
+
+    ratification = (
+        materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+            repo_root=_REPO_ROOT,
+            fleet_binding_completion=fleet_binding_completion,
+        )
+    )
+    validation = validate_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+        ratification,
+        repo_root=_REPO_ROOT,
+        expected_fleet_binding_completion=fleet_binding_completion,
+    )
+    if validation.verdict != ValidationVerdict.ACCEPTED:
+        _die(f"ERR: scope_ratification_validation_failed:{validation.fail_reasons}")
+
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    evidence_dir = (
+        durable_evidence_root
+        / "planning"
+        / f"bounded_final_research_fleet_offline_economic_evaluation_scope_ratification_v0_{ts_slug}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    ratification_path = (
+        evidence_dir / "final_research_fleet_offline_economic_evaluation_scope_ratification_v0.json"
+    )
+    ratification_path.write_text(
+        serialize_ratification_canonical_v0(ratification), encoding="utf-8"
+    )
+
+    binding_copy = evidence_dir / "final_research_fleet_versioned_binding_completion_v0.json"
+    binding_copy.write_bytes(binding_completion_path.read_bytes())
+
+    start_state = {
+        "origin_main_head": "5f4fa589f05f4f14b4d7500d75bb04fe0e988358",
+        "pr_4786_merged": True,
+        "economic_evaluation_executed": False,
+        "evaluation_execution_performed": False,
+    }
+    (evidence_dir / "START_STATE.json").write_text(
+        json.dumps(start_state, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    from scripts.ops import primary_evidence_retention_v0 as retention
+
+    rc, verify_msg = retention.finalize_durable_bundle_manifest(evidence_dir)
+
+    payload = {
+        "verdict": "FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFICATION_PASS",
+        "schema_version": SCHEMA_VERSION,
+        "ratification_digest": ratification["ratification_digest"],
+        "fleet_binding_digest": ratification["fleet_binding_digest"],
+        "candidate_count": len(ratification["candidate_refs"]),
+        "final_research_fleet_binding_ready": ratification["final_research_fleet_binding_ready"],
+        "offline_economic_evaluation_scope_ratified": ratification[
+            "offline_economic_evaluation_scope_ratified"
+        ],
+        "economic_evaluation_authorized": ratification["economic_evaluation_authorized"],
+        "economic_evaluation_executed": ratification["economic_evaluation_executed"],
+        "economic_validity_offline_gate_pass": ratification["economic_validity_offline_gate_pass"],
+        "runtime_rewire_admissible": ratification["runtime_rewire_admissible"],
+        "authority_effect": ratification["authority_effect"],
+        "runtime_effect": ratification["runtime_effect"],
+        "order_effect": ratification["order_effect"],
+        "durable_evidence_path": str(evidence_dir),
+        "manifest_verify_rc": rc,
+        "manifest_verify_msg": verify_msg,
+        "generated_at_utc": _utc_now_z(),
+    }
+    (evidence_dir / "RATIFICATION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _emit_machine_lines(payload)
+    return payload
+
+
+def _emit_machine_lines(result: Mapping[str, Any]) -> None:
+    for key in (
+        "verdict",
+        "ratification_digest",
+        "fleet_binding_digest",
+        "candidate_count",
+        "final_research_fleet_binding_ready",
+        "offline_economic_evaluation_scope_ratified",
+        "economic_evaluation_authorized",
+        "economic_evaluation_executed",
+        "economic_validity_offline_gate_pass",
+        "runtime_rewire_admissible",
+        "authority_effect",
+        "runtime_effect",
+        "manifest_verify_rc",
+    ):
+        print(f"{key.upper()}={result.get(key)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Materialize final research fleet offline economic evaluation scope ratification v0."
+        )
+    )
+    parser.add_argument("--confirm-go-token", required=True, choices=[CONFIRM_GO])
+    parser.add_argument("--binding-completion-path", type=Path, required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, required=True)
+    args = parser.parse_args()
+    run_materialization(
+        confirm=args.confirm_go_token,
+        binding_completion_path=args.binding_completion_path,
+        durable_evidence_root=args.durable_evidence_root,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/research/final_research_fleet_offline_economic_evaluation_scope_ratification_v0.py
+++ b/src/research/final_research_fleet_offline_economic_evaluation_scope_ratification_v0.py
@@ -1,0 +1,760 @@
+"""Final Research Fleet offline economic evaluation scope ratification v0.
+
+Deterministic, fail-closed ratification of a bounded offline-only economic
+evaluation scope for trend_following/v1, bollinger_bands/v1, and momentum_1h/v1.
+
+Ratifies evaluation contract, shared policies, admissible evaluation stages, and
+fail-closed execution boundaries only. Does not execute economic evaluation,
+backtest, walk-forward, Monte Carlo, stress, or parameter sensitivity.
+
+ECONOMIC_EVALUATION_AUTHORIZED=true at scope level authorizes a later separate
+offline execution GO only. ECONOMIC_EVALUATION_EXECUTED remains false.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.backtest.economic_validity_policy_v1 import ECONOMIC_VALIDITY_POLICY_VERSION
+from src.research.final_research_fleet_v0_versioned_binding_manifest_contract_v0 import (
+    FLEET_CANDIDATES,
+    FLEET_ID,
+    FLEET_VERSION,
+    OPERATOR_RATIFICATION_REF,
+    STEP31F_CONFIG_PATHS,
+    load_step31f_evaluation_config_v0,
+)
+from src.research.final_research_fleet_versioned_binding_completion_v0 import (
+    COMPLETION_ID,
+    FAILED_HISTORICAL_CANDIDATES,
+    ValidationVerdict as BindingValidationVerdict,
+    canonical_candidate_identifier,
+    compute_binding_semantic_digest_v0,
+    validate_final_research_fleet_versioned_binding_completion_v0,
+)
+
+PACKAGE_MARKER = "FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFICATION_V0=true"
+
+SCHEMA_VERSION = "final_research_fleet_offline_economic_evaluation_scope_ratification.v0"
+RATIFICATION_ID = "final_research_fleet_offline_economic_evaluation_scope_ratification_v0"
+RATIFICATION_VERSION = "v0"
+CANONICAL_SERIALIZATION_VERSION = "research_scope_ratification_canonical_json_v1"
+
+OPERATOR_SCOPE_RATIFICATION_REF = (
+    "bounded_final_research_fleet_offline_economic_evaluation_scope_ratification_v0_"
+    "20260703T050000Z"
+)
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+ORDER_EFFECT = "NONE"
+
+FINAL_RESEARCH_FLEET_BINDING_READY = True
+OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFIED = True
+ECONOMIC_EVALUATION_AUTHORIZED = True
+ECONOMIC_EVALUATION_EXECUTED = False
+ECONOMIC_VALIDITY_OFFLINE_GATE_PASS = False
+RUNTIME_REWIRE_ADMISSIBLE = False
+ALLOWED_AFTER_THIS_RATIFICATION = True
+
+EVALUATION_AUTHORIZATION_STATUS = "AUTHORIZED_PENDING_SEPARATE_OFFLINE_EXECUTION_GO"
+ECONOMIC_VALIDITY_STATUS = "NOT_EVALUATED"
+
+EVIDENCE_SCHEMA_REF = "economic_viability_evidence_schema_v1.json"
+EVIDENCE_MANIFEST_POLICY = "scripts.ops.primary_evidence_retention_v0"
+
+FUTURES_ONLY = True
+BITCOIN_DIRECTION_ALLOWED = False
+SPOT_ALLOWED = False
+SYNTHETIC_SPOT_ALLOWED = False
+
+ALLOWED_EVALUATION_STAGES: tuple[str, ...] = (
+    "OFFLINE_BACKTEST",
+    "WALK_FORWARD",
+    "MONTE_CARLO",
+    "STRESS",
+    "PARAMETER_SENSITIVITY",
+    "ECONOMIC_VIABILITY_EVIDENCE_MATERIALIZATION",
+)
+
+PROHIBITED_ACTIONS: tuple[str, ...] = (
+    "ECONOMIC_EVALUATION_EXECUTION",
+    "BACKTEST_EXECUTION",
+    "WALK_FORWARD_EXECUTION",
+    "MONTE_CARLO_EXECUTION",
+    "STRESS_EXECUTION",
+    "PARAMETER_SENSITIVITY_EXECUTION",
+    "RUNTIME_REWIRE",
+    "RUNTIME",
+    "SCHEDULER",
+    "SHADOW",
+    "PAPER",
+    "TESTNET",
+    "CANARY",
+    "LIVE",
+    "ADAPTER_SUBMISSION",
+    "NETWORK_ORDER_PATH",
+    "ORDERS",
+    "CANCELS",
+    "CREDENTIALS",
+    "ARMING",
+    "OPERATOR_LIMIT_CHANGE",
+    "CORE_SYSTEM_CHANGE",
+    "CANONICAL_TRADING_LOGIC_CHANGE",
+    "MASTER_V2_CHANGE",
+    "DOUBLE_PLAY_CHANGE",
+    "SCOPE_LOGIC_CHANGE",
+    "ENTRY_EXIT_REVERSAL_CHANGE",
+    "RISK_SIZING_CHANGE",
+    "SAFETY_KERNEL_CHANGE",
+    "RECONCILIATION_CHANGE",
+    "POLICY_THRESHOLD_RETROFIT",
+    "FAILED_BINDING_RETRY",
+    "CROSS_CANDIDATE_THRESHOLD_ABATEMENT",
+    "IMPLICIT_ZERO_COST",
+    "OUT_OF_SAMPLE_PARAMETER_OPTIMIZATION",
+    "TRAINING_VALIDATION_OOS_LEAKAGE",
+    "ECONOMIC_VALIDITY_WITHOUT_MANIFEST_EVIDENCE",
+    "FLEET_AGGREGATION_CANDIDATE_FAILURE_MASKING",
+)
+
+FORBIDDEN_INSTRUMENT_TOKENS = frozenset(
+    {"btc", "xbt", "bitcoin", "spot", "synthetic_spot", "synthetic-spot"}
+)
+_ABSOLUTE_PATH_PATTERN = re.compile(r"(^/|^\\\\|^[A-Za-z]:[/\\\\])")
+
+REASON_UNKNOWN_SCHEMA_VERSION = "UNKNOWN_SCHEMA_VERSION"
+REASON_RATIFICATION_NOT_OBJECT = "RATIFICATION_NOT_OBJECT"
+REASON_MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD"
+REASON_EFFECT_NOT_NONE = "AUTHORITY_RUNTIME_ORDER_EFFECT_NOT_NONE"
+REASON_BINDING_COMPLETION_INVALID = "FLEET_BINDING_COMPLETION_INVALID"
+REASON_BINDING_NOT_READY = "BINDING_NOT_READY_FOR_EVALUATION_RATIFICATION"
+REASON_MISSING_CANDIDATE = "MISSING_FLEET_CANDIDATE"
+REASON_EXTRA_CANDIDATE = "EXTRA_FLEET_CANDIDATE"
+REASON_DUPLICATE_CANDIDATE = "DUPLICATE_FLEET_CANDIDATE"
+REASON_FAILED_HISTORICAL_CANDIDATE = "FAILED_HISTORICAL_CANDIDATE_EXCLUDED"
+REASON_FLEET_BINDING_DIGEST_MISMATCH = "FLEET_BINDING_DIGEST_MISMATCH"
+REASON_POLICY_DRIFT = "COMMON_POLICY_DRIFT"
+REASON_ECONOMIC_POLICY_MISMATCH = "ECONOMIC_POLICY_MISMATCH"
+REASON_SHARED_BINDING_MISMATCH = "SHARED_BINDING_MISMATCH"
+REASON_FUTURES_ONLY_VIOLATION = "FUTURES_ONLY_VIOLATION"
+REASON_SPOT_BINDING = "SPOT_BINDING_REJECTED"
+REASON_SYNTHETIC_SPOT_BINDING = "SYNTHETIC_SPOT_BINDING_REJECTED"
+REASON_BITCOIN_DIRECTION_BINDING = "BITCOIN_DIRECTION_BINDING_REJECTED"
+REASON_BITCOIN_INSTRUMENT_PRESENT = "BITCOIN_INSTRUMENT_PRESENT"
+REASON_ZERO_FEE = "ZERO_FEE_REJECTED"
+REASON_ZERO_SLIPPAGE = "ZERO_SLIPPAGE_REJECTED"
+REASON_INCOMPLETE_PERIOD_SPLIT = "INCOMPLETE_PERIOD_SPLIT"
+REASON_EVALUATION_ALREADY_EXECUTED = "ECONOMIC_EVALUATION_ALREADY_EXECUTED"
+REASON_EVALUATION_NOT_AUTHORIZED = "ECONOMIC_EVALUATION_NOT_AUTHORIZED"
+REASON_SCOPE_NOT_RATIFIED = "OFFLINE_ECONOMIC_EVALUATION_SCOPE_NOT_RATIFIED"
+REASON_WRONG_RATIFICATION_DIGEST = "WRONG_RATIFICATION_DIGEST"
+REASON_WRONG_SEMANTIC_DIGEST = "WRONG_SEMANTIC_DIGEST"
+REASON_WRONG_CONFIG_DIGEST = "WRONG_CONFIG_DIGEST"
+REASON_WRONG_IMPLEMENTATION_DIGEST = "WRONG_IMPLEMENTATION_DIGEST"
+REASON_NON_CANONICAL_SERIALIZATION = "NON_CANONICAL_SERIALIZATION"
+REASON_BINDING_REPAIR_REJECTED = "BINDING_REPAIR_REJECTED"
+REASON_FORBIDDEN_STAGE_IN_RATIFICATION = "FORBIDDEN_EVALUATION_STAGE_EXECUTED_IN_RATIFICATION"
+REASON_PROHIBITED_ACTION_VIOLATION = "PROHIBITED_ACTION_VIOLATION"
+
+RATIFICATION_REQUIRED_FIELDS = (
+    "schema_version",
+    "ratification_id",
+    "ratification_version",
+    "fleet_binding_ref",
+    "fleet_binding_digest",
+    "candidate_refs",
+    "candidate_binding_digests",
+    "common_dataset_policy_ref",
+    "common_period_policy_ref",
+    "common_instrument_policy_ref",
+    "fee_model_binding",
+    "slippage_model_binding",
+    "funding_model_binding",
+    "execution_model_binding",
+    "economic_policy_binding",
+    "walk_forward_policy_binding",
+    "monte_carlo_policy_binding",
+    "stress_policy_binding",
+    "parameter_sensitivity_policy_binding",
+    "evidence_schema_ref",
+    "evidence_manifest_policy",
+    "allowed_evaluation_stages",
+    "prohibited_actions",
+    "evaluation_authorization_status",
+    "economic_validity_status",
+    "runtime_effect",
+    "authority_effect",
+    "implementation_digest",
+    "config_digest",
+    "semantic_digest",
+    "reason_codes",
+    "final_research_fleet_binding_ready",
+    "offline_economic_evaluation_scope_ratified",
+    "economic_evaluation_authorized",
+    "economic_evaluation_executed",
+    "economic_validity_offline_gate_pass",
+    "runtime_rewire_admissible",
+    "allowed_after_this_ratification",
+    "order_effect",
+    "futures_only",
+    "bitcoin_direction_allowed",
+    "spot_allowed",
+    "synthetic_spot_allowed",
+    "operator_scope_ratification_ref",
+    "operator_fleet_binding_ratification_ref",
+    "canonical_serialization_version",
+    "ratification_digest",
+)
+
+SCOPE_INVARIANT_REASON_CODES: tuple[str, ...] = (
+    "COMMON_ECONOMIC_VALIDITY_POLICY_FOR_ALL_CANDIDATES",
+    "VERSIONED_COMPARABLE_COST_FUNDING_EXECUTION_BINDINGS",
+    "NO_CANDIDATE_SPECIFIC_THRESHOLD_ABATEMENT",
+    "NO_POST_HOC_POLICY_ADJUSTMENT_FOR_RESULT_RESCUE",
+    "NO_UNCHANGED_RETRY_OF_FAILED_HISTORICAL_BINDINGS",
+    "NO_OUT_OF_SAMPLE_PARAMETER_OPTIMIZATION",
+    "NO_TRAINING_VALIDATION_OOS_LEAKAGE",
+    "NO_IMPLICIT_ZERO_COST",
+    "NO_ECONOMIC_VALIDITY_WITHOUT_MANIFEST_VERIFIED_NET_EVIDENCE",
+    "INDEPENDENT_CANDIDATE_PASS_FAIL_INCONCLUSIVE",
+    "FLEET_AGGREGATION_MUST_NOT_MASK_CANDIDATE_FAILURES",
+    "FULL_POLICY_PASS_REQUIRED_FOR_ECONOMICALLY_VIABLE_OFFLINE",
+    "OFFLINE_PASS_DOES_NOT_GRANT_RUNTIME_OR_ORDER_AUTHORITY",
+    "RATIFICATION_DOES_NOT_EXECUTE_EVALUATION_STAGES",
+)
+
+
+class ValidationVerdict(str, Enum):
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True)
+class ScopeRatificationValidationResultV0:
+    verdict: ValidationVerdict
+    valid: bool
+    fail_reasons: tuple[str, ...]
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_implementation_digest_v0() -> str:
+    return _stable_digest(
+        {
+            "module": RATIFICATION_ID,
+            "schema_version": SCHEMA_VERSION,
+        }
+    )
+
+
+def dumps_ratification_canonical_v1(obj: Mapping[str, Any]) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str, ensure_ascii=False)
+
+
+def compute_semantic_digest_v0(ratification_body: Mapping[str, Any]) -> str:
+    payload = {
+        "fleet_binding_digest": ratification_body.get("fleet_binding_digest"),
+        "candidate_refs": ratification_body.get("candidate_refs"),
+        "candidate_binding_digests": ratification_body.get("candidate_binding_digests"),
+        "common_dataset_policy_ref": ratification_body.get("common_dataset_policy_ref"),
+        "common_period_policy_ref": ratification_body.get("common_period_policy_ref"),
+        "common_instrument_policy_ref": ratification_body.get("common_instrument_policy_ref"),
+        "fee_model_binding": ratification_body.get("fee_model_binding"),
+        "slippage_model_binding": ratification_body.get("slippage_model_binding"),
+        "funding_model_binding": ratification_body.get("funding_model_binding"),
+        "execution_model_binding": ratification_body.get("execution_model_binding"),
+        "economic_policy_binding": ratification_body.get("economic_policy_binding"),
+        "walk_forward_policy_binding": ratification_body.get("walk_forward_policy_binding"),
+        "monte_carlo_policy_binding": ratification_body.get("monte_carlo_policy_binding"),
+        "stress_policy_binding": ratification_body.get("stress_policy_binding"),
+        "parameter_sensitivity_policy_binding": ratification_body.get(
+            "parameter_sensitivity_policy_binding"
+        ),
+        "allowed_evaluation_stages": ratification_body.get("allowed_evaluation_stages"),
+        "prohibited_actions": ratification_body.get("prohibited_actions"),
+        "evaluation_authorization_status": ratification_body.get("evaluation_authorization_status"),
+        "economic_validity_status": ratification_body.get("economic_validity_status"),
+    }
+    return _stable_digest(payload)
+
+
+def compute_config_digest_v0(ratification_body: Mapping[str, Any]) -> str:
+    payload = {
+        "step31f_config_refs": [
+            STEP31F_CONFIG_PATHS[strategy_id] for strategy_id, _ in FLEET_CANDIDATES
+        ],
+        "operator_scope_ratification_ref": ratification_body.get("operator_scope_ratification_ref"),
+        "operator_fleet_binding_ratification_ref": ratification_body.get(
+            "operator_fleet_binding_ratification_ref"
+        ),
+    }
+    return _stable_digest(payload)
+
+
+def compute_ratification_digest_v0(ratification_body: Mapping[str, Any]) -> str:
+    body = dict(ratification_body)
+    body.pop("ratification_digest", None)
+    return hashlib.sha256(dumps_ratification_canonical_v1(body).encode("utf-8")).hexdigest()
+
+
+def serialize_ratification_canonical_v0(ratification: Mapping[str, Any]) -> str:
+    return dumps_ratification_canonical_v1(ratification) + "\n"
+
+
+def _reject_repair_keys(obj: Mapping[str, Any], *, path: str, reasons: list[str]) -> None:
+    for key in obj:
+        if key in {"repair", "fallback", "auto_fix", "default_if_missing"}:
+            reasons.append(f"{REASON_BINDING_REPAIR_REJECTED}:{path}.{key}")
+
+
+def _contains_forbidden_token(value: str) -> bool:
+    lowered = value.lower()
+    return any(token in lowered for token in FORBIDDEN_INSTRUMENT_TOKENS)
+
+
+def _validate_positive_cost(value: Any, *, field: str, reasons: list[str]) -> None:
+    if not isinstance(value, (int, float)) or float(value) <= 0.0:
+        reasons.append(f"{REASON_ZERO_FEE if 'fee' in field else REASON_ZERO_SLIPPAGE}:{field}")
+
+
+def _validate_instrument_binding(binding: Mapping[str, Any], reasons: list[str]) -> None:
+    if binding.get("futures_only") is not True:
+        reasons.append(REASON_FUTURES_ONLY_VIOLATION)
+    if binding.get("spot_allowed") is True:
+        reasons.append(REASON_SPOT_BINDING)
+    if binding.get("synthetic_spot_allowed") is True:
+        reasons.append(REASON_SYNTHETIC_SPOT_BINDING)
+    if binding.get("bitcoin_direction_allowed") is True:
+        reasons.append(REASON_BITCOIN_DIRECTION_BINDING)
+    for instrument_id in binding.get("eligible_instrument_ids", ()):
+        if isinstance(instrument_id, str) and _contains_forbidden_token(instrument_id):
+            reasons.append(f"{REASON_BITCOIN_INSTRUMENT_PRESENT}:{instrument_id}")
+
+
+def _validate_materialized_period(field: Any, *, name: str, reasons: list[str]) -> None:
+    if not isinstance(field, Mapping):
+        reasons.append(f"{REASON_INCOMPLETE_PERIOD_SPLIT}:{name}")
+        return
+    if field.get("status") != "MATERIALIZED":
+        reasons.append(f"{REASON_INCOMPLETE_PERIOD_SPLIT}:{name}")
+        return
+    for key in ("start", "end"):
+        raw = field.get(key)
+        if not isinstance(raw, str) or not raw.strip():
+            reasons.append(f"{REASON_INCOMPLETE_PERIOD_SPLIT}:{name}.{key}")
+
+
+def _extract_policy_binding(cfg: Mapping[str, Any], *path: str) -> Mapping[str, Any]:
+    current: Any = cfg
+    for segment in path:
+        if not isinstance(current, Mapping):
+            return {}
+        current = current.get(segment)
+    if isinstance(current, Mapping):
+        return dict(current)
+    return {}
+
+
+def _build_common_policy_bindings(
+    *,
+    repo_root: Path,
+    reference_candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    strategy_id = str(reference_candidate["strategy_id"])
+    cfg = load_step31f_evaluation_config_v0(repo_root, strategy_id)
+    economic_eval = cfg.get("economic_evaluation_v1")
+    if not isinstance(economic_eval, Mapping):
+        economic_eval = {}
+    backtest = cfg.get("backtest")
+    if not isinstance(backtest, Mapping):
+        backtest = {}
+
+    return {
+        "common_dataset_policy_ref": dict(reference_candidate["dataset_binding"]),
+        "common_period_policy_ref": dict(reference_candidate["period_binding"]),
+        "common_instrument_policy_ref": dict(reference_candidate["instrument_binding"]),
+        "fee_model_binding": dict(reference_candidate["fee_model_binding"]),
+        "slippage_model_binding": dict(reference_candidate["slippage_model_binding"]),
+        "funding_model_binding": dict(reference_candidate["funding_model_binding"]),
+        "execution_model_binding": dict(reference_candidate["execution_model_binding"]),
+        "economic_policy_binding": dict(reference_candidate["economic_policy_binding"]),
+        "walk_forward_policy_binding": _extract_policy_binding(economic_eval, "walk_forward"),
+        "monte_carlo_policy_binding": _extract_policy_binding(economic_eval, "monte_carlo"),
+        "stress_policy_binding": _extract_policy_binding(economic_eval, "stress"),
+        "parameter_sensitivity_policy_binding": _extract_policy_binding(
+            backtest, "parameter_sensitivity"
+        ),
+    }
+
+
+def _validate_common_policies_uniform(
+    candidates: Sequence[Mapping[str, Any]],
+    *,
+    repo_root: Path,
+    reasons: list[str],
+) -> None:
+    if not candidates:
+        return
+    reference = candidates[0]
+    common = _build_common_policy_bindings(repo_root=repo_root, reference_candidate=reference)
+    candidate_field_map = {
+        "common_dataset_policy_ref": "dataset_binding",
+        "common_period_policy_ref": "period_binding",
+        "common_instrument_policy_ref": "instrument_binding",
+        "fee_model_binding": "fee_model_binding",
+        "slippage_model_binding": "slippage_model_binding",
+        "funding_model_binding": "funding_model_binding",
+        "execution_model_binding": "execution_model_binding",
+        "economic_policy_binding": "economic_policy_binding",
+    }
+    for field, candidate_key in candidate_field_map.items():
+        ref_value = common[field]
+        for candidate in candidates[1:]:
+            actual = candidate.get(candidate_key)
+            if actual != ref_value:
+                if candidate_key == "economic_policy_binding":
+                    reasons.append(
+                        f"{REASON_ECONOMIC_POLICY_MISMATCH}:{candidate.get('strategy_id')}"
+                    )
+                else:
+                    reasons.append(
+                        f"{REASON_SHARED_BINDING_MISMATCH}:{field}:{candidate.get('strategy_id')}"
+                    )
+
+    ref_cfg = load_step31f_evaluation_config_v0(repo_root, str(reference["strategy_id"]))
+    for candidate in candidates:
+        strategy_id = str(candidate["strategy_id"])
+        cfg = load_step31f_evaluation_config_v0(repo_root, strategy_id)
+        for policy_field, cfg_path in (
+            ("walk_forward_policy_binding", ("economic_evaluation_v1", "walk_forward")),
+            ("monte_carlo_policy_binding", ("economic_evaluation_v1", "monte_carlo")),
+            ("stress_policy_binding", ("economic_evaluation_v1", "stress")),
+            ("parameter_sensitivity_policy_binding", ("backtest", "parameter_sensitivity")),
+        ):
+            ref_policy = _extract_policy_binding(ref_cfg, *cfg_path)
+            actual_policy = _extract_policy_binding(cfg, *cfg_path)
+            if actual_policy != ref_policy:
+                reasons.append(f"{REASON_POLICY_DRIFT}:{policy_field}:{strategy_id}")
+
+
+def materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+    *,
+    repo_root: Path,
+    fleet_binding_completion: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Materialize scope ratification from a validated fleet binding completion."""
+    binding_validation = validate_final_research_fleet_versioned_binding_completion_v0(
+        fleet_binding_completion,
+        repo_root=repo_root,
+        require_ready_for_eval=True,
+    )
+    if binding_validation.verdict != BindingValidationVerdict.ACCEPTED:
+        raise ValueError(f"{REASON_BINDING_COMPLETION_INVALID}:{binding_validation.fail_reasons}")
+
+    candidates = list(fleet_binding_completion["candidates"])
+    candidate_refs = [
+        canonical_candidate_identifier(str(c["strategy_id"]), str(c["strategy_version"]))
+        for c in candidates
+    ]
+    candidate_binding_digests = {
+        ref: str(candidates[index]["binding_semantic_digest"])
+        for index, ref in enumerate(candidate_refs)
+    }
+
+    common_policies = _build_common_policy_bindings(
+        repo_root=repo_root,
+        reference_candidate=candidates[0],
+    )
+
+    ratification_body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "ratification_id": RATIFICATION_ID,
+        "ratification_version": RATIFICATION_VERSION,
+        "fleet_binding_ref": {
+            "completion_id": COMPLETION_ID,
+            "completion_digest": fleet_binding_completion["completion_digest"],
+            "fleet_id": FLEET_ID,
+            "fleet_version": FLEET_VERSION,
+            "schema_version": fleet_binding_completion.get("schema_version"),
+        },
+        "fleet_binding_digest": fleet_binding_completion["completion_digest"],
+        "candidate_refs": candidate_refs,
+        "candidate_binding_digests": candidate_binding_digests,
+        **common_policies,
+        "evidence_schema_ref": EVIDENCE_SCHEMA_REF,
+        "evidence_manifest_policy": EVIDENCE_MANIFEST_POLICY,
+        "allowed_evaluation_stages": list(ALLOWED_EVALUATION_STAGES),
+        "prohibited_actions": list(PROHIBITED_ACTIONS),
+        "evaluation_authorization_status": EVALUATION_AUTHORIZATION_STATUS,
+        "economic_validity_status": ECONOMIC_VALIDITY_STATUS,
+        "runtime_effect": RUNTIME_EFFECT,
+        "authority_effect": AUTHORITY_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "final_research_fleet_binding_ready": FINAL_RESEARCH_FLEET_BINDING_READY,
+        "offline_economic_evaluation_scope_ratified": OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFIED,
+        "economic_evaluation_authorized": ECONOMIC_EVALUATION_AUTHORIZED,
+        "economic_evaluation_executed": ECONOMIC_EVALUATION_EXECUTED,
+        "economic_validity_offline_gate_pass": ECONOMIC_VALIDITY_OFFLINE_GATE_PASS,
+        "runtime_rewire_admissible": RUNTIME_REWIRE_ADMISSIBLE,
+        "allowed_after_this_ratification": ALLOWED_AFTER_THIS_RATIFICATION,
+        "futures_only": FUTURES_ONLY,
+        "bitcoin_direction_allowed": BITCOIN_DIRECTION_ALLOWED,
+        "spot_allowed": SPOT_ALLOWED,
+        "synthetic_spot_allowed": SYNTHETIC_SPOT_ALLOWED,
+        "operator_scope_ratification_ref": OPERATOR_SCOPE_RATIFICATION_REF,
+        "operator_fleet_binding_ratification_ref": OPERATOR_RATIFICATION_REF,
+        "canonical_serialization_version": CANONICAL_SERIALIZATION_VERSION,
+        "reason_codes": list(SCOPE_INVARIANT_REASON_CODES),
+        "digest_semantics": {
+            "ratification_digest": "RATIFICATION_BODY_CANONICAL_JSON_v0",
+            "semantic_digest": "SCOPE_RATIFICATION_SEMANTIC_PAYLOAD_v0",
+            "config_digest": "STEP31F_CONFIG_REFS_AND_OPERATOR_REFS_v0",
+            "implementation_digest": "SCOPE_RATIFICATION_MODULE_REF_v0",
+            "fleet_binding_digest": "FLEET_BINDING_COMPLETION_DIGEST_v0",
+        },
+        "economic_policy_version": ECONOMIC_VALIDITY_POLICY_VERSION,
+        "evaluation_execution_performed": False,
+        "evaluation_modules_invoked": [],
+    }
+    ratification_body["implementation_digest"] = compute_implementation_digest_v0()
+    ratification_body["config_digest"] = compute_config_digest_v0(ratification_body)
+    ratification_body["semantic_digest"] = compute_semantic_digest_v0(ratification_body)
+    ratification_body["ratification_digest"] = compute_ratification_digest_v0(ratification_body)
+    return ratification_body
+
+
+def validate_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+    ratification: Any,
+    *,
+    repo_root: Path,
+    expected_fleet_binding_completion: Mapping[str, Any] | None = None,
+) -> ScopeRatificationValidationResultV0:
+    reasons: list[str] = []
+    if not isinstance(ratification, Mapping):
+        return ScopeRatificationValidationResultV0(
+            verdict=ValidationVerdict.REJECTED,
+            valid=False,
+            fail_reasons=(REASON_RATIFICATION_NOT_OBJECT,),
+        )
+
+    _reject_repair_keys(ratification, path="$", reasons=reasons)
+
+    if ratification.get("schema_version") != SCHEMA_VERSION:
+        reasons.append(REASON_UNKNOWN_SCHEMA_VERSION)
+
+    for field in RATIFICATION_REQUIRED_FIELDS:
+        if field not in ratification:
+            reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:{field}")
+
+    for effect_field, expected in (
+        ("authority_effect", AUTHORITY_EFFECT),
+        ("runtime_effect", RUNTIME_EFFECT),
+        ("order_effect", ORDER_EFFECT),
+    ):
+        if ratification.get(effect_field) != expected:
+            reasons.append(f"{REASON_EFFECT_NOT_NONE}:{effect_field}")
+
+    status_checks = (
+        ("final_research_fleet_binding_ready", FINAL_RESEARCH_FLEET_BINDING_READY),
+        ("offline_economic_evaluation_scope_ratified", OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFIED),
+        ("economic_evaluation_authorized", ECONOMIC_EVALUATION_AUTHORIZED),
+        ("economic_evaluation_executed", ECONOMIC_EVALUATION_EXECUTED),
+        ("economic_validity_offline_gate_pass", ECONOMIC_VALIDITY_OFFLINE_GATE_PASS),
+        ("runtime_rewire_admissible", RUNTIME_REWIRE_ADMISSIBLE),
+        ("allowed_after_this_ratification", ALLOWED_AFTER_THIS_RATIFICATION),
+        ("futures_only", FUTURES_ONLY),
+        ("bitcoin_direction_allowed", BITCOIN_DIRECTION_ALLOWED),
+        ("spot_allowed", SPOT_ALLOWED),
+        ("synthetic_spot_allowed", SYNTHETIC_SPOT_ALLOWED),
+    )
+    for field, expected in status_checks:
+        if ratification.get(field) is not expected:
+            if field == "economic_evaluation_authorized" and ratification.get(field) is not True:
+                reasons.append(REASON_EVALUATION_NOT_AUTHORIZED)
+            elif field == "economic_evaluation_executed" and ratification.get(field) is not False:
+                reasons.append(REASON_EVALUATION_ALREADY_EXECUTED)
+            elif (
+                field == "offline_economic_evaluation_scope_ratified"
+                and ratification.get(field) is not True
+            ):
+                reasons.append(REASON_SCOPE_NOT_RATIFIED)
+            elif field == "futures_only" and ratification.get(field) is not True:
+                reasons.append(REASON_FUTURES_ONLY_VIOLATION)
+            elif field == "bitcoin_direction_allowed" and ratification.get(field) is not False:
+                reasons.append(REASON_BITCOIN_DIRECTION_BINDING)
+            elif field == "spot_allowed" and ratification.get(field) is not False:
+                reasons.append(REASON_SPOT_BINDING)
+            elif field == "synthetic_spot_allowed" and ratification.get(field) is not False:
+                reasons.append(REASON_SYNTHETIC_SPOT_BINDING)
+
+    if ratification.get("evaluation_execution_performed") is True:
+        reasons.append(REASON_EVALUATION_ALREADY_EXECUTED)
+    invoked = ratification.get("evaluation_modules_invoked")
+    if isinstance(invoked, list) and invoked:
+        reasons.append(REASON_FORBIDDEN_STAGE_IN_RATIFICATION)
+
+    if list(ratification.get("allowed_evaluation_stages") or []) != list(ALLOWED_EVALUATION_STAGES):
+        reasons.append(REASON_POLICY_DRIFT + ":allowed_evaluation_stages")
+    if list(ratification.get("prohibited_actions") or []) != list(PROHIBITED_ACTIONS):
+        reasons.append(REASON_POLICY_DRIFT + ":prohibited_actions")
+
+    candidate_refs = ratification.get("candidate_refs")
+    if not isinstance(candidate_refs, list):
+        reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:candidate_refs")
+        candidate_refs = []
+
+    expected_refs = [canonical_candidate_identifier(sid, ver) for sid, ver in FLEET_CANDIDATES]
+    if sorted(candidate_refs) != sorted(expected_refs):
+        if len(candidate_refs) != len(set(candidate_refs)):
+            reasons.append(REASON_DUPLICATE_CANDIDATE)
+        missing = sorted(set(expected_refs) - set(candidate_refs))
+        for ref in missing:
+            reasons.append(f"{REASON_MISSING_CANDIDATE}:{ref}")
+        for ref in sorted(set(candidate_refs) - set(expected_refs)):
+            sid = ref.split("/")[0]
+            if (sid, ref.split("/")[1]) in FAILED_HISTORICAL_CANDIDATES:
+                reasons.append(f"{REASON_FAILED_HISTORICAL_CANDIDATE}:{ref}")
+            else:
+                reasons.append(f"{REASON_EXTRA_CANDIDATE}:{ref}")
+
+    binding_digests = ratification.get("candidate_binding_digests")
+    if isinstance(binding_digests, Mapping):
+        for ref in expected_refs:
+            if ref not in binding_digests:
+                reasons.append(f"{REASON_MISSING_REQUIRED_FIELD}:candidate_binding_digests.{ref}")
+
+    fleet_binding_digest = ratification.get("fleet_binding_digest")
+    fleet_binding_ref = ratification.get("fleet_binding_ref")
+    if isinstance(fleet_binding_ref, Mapping):
+        if fleet_binding_ref.get("completion_digest") != fleet_binding_digest:
+            reasons.append(REASON_FLEET_BINDING_DIGEST_MISMATCH)
+        if expected_fleet_binding_completion is not None:
+            expected_digest = expected_fleet_binding_completion.get("completion_digest")
+            if expected_digest != fleet_binding_digest:
+                reasons.append(REASON_FLEET_BINDING_DIGEST_MISMATCH)
+
+    fee = ratification.get("fee_model_binding")
+    if isinstance(fee, Mapping):
+        _validate_positive_cost(fee.get("fee_bps"), field="fee_bps", reasons=reasons)
+    else:
+        reasons.append(REASON_ZERO_FEE)
+
+    slippage = ratification.get("slippage_model_binding")
+    if isinstance(slippage, Mapping):
+        _validate_positive_cost(slippage.get("slippage_bps"), field="slippage_bps", reasons=reasons)
+    else:
+        reasons.append(REASON_ZERO_SLIPPAGE)
+
+    instrument = ratification.get("common_instrument_policy_ref")
+    if isinstance(instrument, Mapping):
+        _validate_instrument_binding(instrument, reasons=reasons)
+
+    if expected_fleet_binding_completion is not None:
+        for candidate in expected_fleet_binding_completion.get("candidates", ()):
+            if not isinstance(candidate, Mapping):
+                continue
+            strategy_id = str(candidate.get("strategy_id", ""))
+            ref = canonical_candidate_identifier(
+                strategy_id, str(candidate.get("strategy_version", ""))
+            )
+            if isinstance(binding_digests, Mapping) and ref in binding_digests:
+                expected_semantic = compute_binding_semantic_digest_v0(candidate)
+                if binding_digests[ref] != expected_semantic:
+                    reasons.append(f"{REASON_WRONG_SEMANTIC_DIGEST}:{ref}")
+
+        _validate_common_policies_uniform(
+            list(expected_fleet_binding_completion.get("candidates") or []),
+            repo_root=repo_root,
+            reasons=reasons,
+        )
+        for candidate in expected_fleet_binding_completion.get("candidates", ()):
+            if isinstance(candidate, Mapping):
+                _validate_materialized_period(
+                    candidate.get("training_period"), name="training_period", reasons=reasons
+                )
+                _validate_materialized_period(
+                    candidate.get("validation_period"), name="validation_period", reasons=reasons
+                )
+                _validate_materialized_period(
+                    candidate.get("out_of_sample_period"),
+                    name="out_of_sample_period",
+                    reasons=reasons,
+                )
+
+    expected_ratification_digest = compute_ratification_digest_v0(ratification)
+    if ratification.get("ratification_digest") != expected_ratification_digest:
+        reasons.append(REASON_WRONG_RATIFICATION_DIGEST)
+
+    expected_semantic = compute_semantic_digest_v0(ratification)
+    if ratification.get("semantic_digest") != expected_semantic:
+        reasons.append(REASON_WRONG_SEMANTIC_DIGEST)
+
+    expected_config = compute_config_digest_v0(ratification)
+    if ratification.get("config_digest") != expected_config:
+        reasons.append(REASON_WRONG_CONFIG_DIGEST)
+
+    expected_impl = compute_implementation_digest_v0()
+    if ratification.get("implementation_digest") != expected_impl:
+        reasons.append(REASON_WRONG_IMPLEMENTATION_DIGEST)
+
+    canonical = dumps_ratification_canonical_v1(ratification)
+    if canonical != dumps_ratification_canonical_v1(json.loads(canonical)):
+        reasons.append(REASON_NON_CANONICAL_SERIALIZATION)
+    if _ABSOLUTE_PATH_PATTERN.search(canonical):
+        reasons.append(REASON_NON_CANONICAL_SERIALIZATION + ":absolute_path_in_ratification")
+
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    if unique_reasons:
+        return ScopeRatificationValidationResultV0(
+            verdict=ValidationVerdict.REJECTED,
+            valid=False,
+            fail_reasons=unique_reasons,
+        )
+    return ScopeRatificationValidationResultV0(
+        verdict=ValidationVerdict.ACCEPTED,
+        valid=True,
+        fail_reasons=(),
+    )
+
+
+def clone_ratification(ratification: Mapping[str, Any]) -> dict[str, Any]:
+    return deepcopy(dict(ratification))
+
+
+__all__ = [
+    "ALLOWED_AFTER_THIS_RATIFICATION",
+    "ALLOWED_EVALUATION_STAGES",
+    "AUTHORITY_EFFECT",
+    "CANONICAL_SERIALIZATION_VERSION",
+    "ECONOMIC_EVALUATION_AUTHORIZED",
+    "ECONOMIC_EVALUATION_EXECUTED",
+    "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS",
+    "FINAL_RESEARCH_FLEET_BINDING_READY",
+    "OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFIED",
+    "ORDER_EFFECT",
+    "PROHIBITED_ACTIONS",
+    "RATIFICATION_ID",
+    "RATIFICATION_VERSION",
+    "RUNTIME_EFFECT",
+    "RUNTIME_REWIRE_ADMISSIBLE",
+    "SCHEMA_VERSION",
+    "ScopeRatificationValidationResultV0",
+    "ValidationVerdict",
+    "clone_ratification",
+    "compute_ratification_digest_v0",
+    "compute_semantic_digest_v0",
+    "materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0",
+    "serialize_ratification_canonical_v0",
+    "validate_final_research_fleet_offline_economic_evaluation_scope_ratification_v0",
+]

--- a/tests/research/test_final_research_fleet_offline_economic_evaluation_scope_ratification_v0.py
+++ b/tests/research/test_final_research_fleet_offline_economic_evaluation_scope_ratification_v0.py
@@ -1,0 +1,534 @@
+"""Contract tests for final_research_fleet_offline_economic_evaluation_scope_ratification_v0."""
+
+from __future__ import annotations
+
+import ast
+import copy
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.research.final_research_fleet_v0_versioned_binding_manifest_contract_v0 import (
+    FLEET_CANDIDATES,
+)
+from src.research.final_research_fleet_offline_economic_evaluation_scope_ratification_v0 import (
+    ALLOWED_EVALUATION_STAGES,
+    AUTHORITY_EFFECT,
+    ECONOMIC_EVALUATION_AUTHORIZED,
+    ECONOMIC_EVALUATION_EXECUTED,
+    ECONOMIC_VALIDITY_OFFLINE_GATE_PASS,
+    FINAL_RESEARCH_FLEET_BINDING_READY,
+    OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFIED,
+    ORDER_EFFECT,
+    PROHIBITED_ACTIONS,
+    RATIFICATION_ID,
+    REASON_BINDING_COMPLETION_INVALID,
+    REASON_BINDING_REPAIR_REJECTED,
+    REASON_BITCOIN_DIRECTION_BINDING,
+    REASON_DUPLICATE_CANDIDATE,
+    REASON_ECONOMIC_POLICY_MISMATCH,
+    REASON_EFFECT_NOT_NONE,
+    REASON_EVALUATION_ALREADY_EXECUTED,
+    REASON_FORBIDDEN_STAGE_IN_RATIFICATION,
+    REASON_FAILED_HISTORICAL_CANDIDATE,
+    REASON_FLEET_BINDING_DIGEST_MISMATCH,
+    REASON_FUTURES_ONLY_VIOLATION,
+    REASON_INCOMPLETE_PERIOD_SPLIT,
+    REASON_MISSING_CANDIDATE,
+    REASON_POLICY_DRIFT,
+    REASON_SHARED_BINDING_MISMATCH,
+    REASON_SPOT_BINDING,
+    REASON_SYNTHETIC_SPOT_BINDING,
+    REASON_UNKNOWN_SCHEMA_VERSION,
+    REASON_WRONG_RATIFICATION_DIGEST,
+    REASON_WRONG_SEMANTIC_DIGEST,
+    REASON_ZERO_FEE,
+    REASON_ZERO_SLIPPAGE,
+    RUNTIME_EFFECT,
+    RUNTIME_REWIRE_ADMISSIBLE,
+    SCHEMA_VERSION,
+    ValidationVerdict,
+    clone_ratification,
+    compute_ratification_digest_v0,
+    materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0,
+    serialize_ratification_canonical_v0,
+    validate_final_research_fleet_offline_economic_evaluation_scope_ratification_v0,
+)
+from src.research.final_research_fleet_versioned_binding_completion_v0 import (
+    BINDING_STATUS_INCOMPLETE,
+    BINDING_STATUS_READY_FOR_EVAL_RATIFICATION,
+    canonical_candidate_identifier,
+    compute_completion_digest_v0,
+    materialize_final_research_fleet_versioned_binding_completion_v0,
+)
+from src.research.pit_futures_universe_manifest_production_materialization_v1 import (
+    DEFAULT_MINIMUM_HISTORY_BARS,
+    DEFAULT_MINIMUM_REQUIRED_MEMBER_COUNT,
+    EVALUATION_PERIOD_BINDING,
+    EXCLUSION_POLICY_VERSION,
+    INCLUSION_POLICY_VERSION,
+    INPUT_CONTRACT_VERSION,
+    MATERIALIZATION_VERSION,
+    ProductionMaterializationEpochV1,
+    PitFuturesUniverseManifestProductionMaterializationInputV1,
+    assemble_production_registry_from_observations_v1,
+    materialize_production_pit_futures_universe_manifest_v1,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import (
+    InstrumentPanelSeriesV1,
+    PanelBarV1,
+    compute_series_digest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RATIFICATION_MODULE = (
+    REPO_ROOT
+    / "src"
+    / "research"
+    / "final_research_fleet_offline_economic_evaluation_scope_ratification_v0.py"
+)
+
+_GENERATED_AT = "2026-07-03T04:00:00Z"
+_BAR_CLOSE = "2024-06-01T01:00:00Z"
+_PERIOD_START = "2024-05-25T00:00:00Z"
+_PERIOD_END = _BAR_CLOSE
+_PANEL_DIGEST = "b" * 64
+_SOURCE_REF = "okx_public_instruments_swap:test"
+_SOURCE_DIGEST = "c" * 64
+_REGISTRY_CONFIG = "d" * 64
+_REGISTRY_IMPL = "e" * 64
+
+_FORBIDDEN_EVAL_IMPORTS = frozenset(
+    {
+        "src.backtest.engine",
+        "src.backtest.walkforward",
+        "src.experiments.monte_carlo",
+        "src.experiments.stress_tests",
+        "src.experiments.portfolio_robustness",
+        "src.backtest.economic_viability_evidence_v1",
+    }
+)
+
+
+def _live_inst(base: str, *, inst_id: str | None = None) -> dict[str, str]:
+    symbol = inst_id or f"{base}-USDT-SWAP"
+    return {
+        "instId": symbol,
+        "instType": "SWAP",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "baseCcy": base,
+        "state": "live",
+        "listTime": "1609459200000",
+        "expTime": "",
+    }
+
+
+def _hourly_bars(instrument_id: str, *, count: int, end: str) -> tuple[PanelBarV1, ...]:
+    end_dt = datetime.strptime(end, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    bars: list[PanelBarV1] = []
+    for offset in range(count):
+        ts = end_dt - timedelta(hours=count - 1 - offset)
+        ts_str = ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+        bars.append(
+            PanelBarV1(
+                instrument_id=instrument_id,
+                timestamp_utc=ts_str,
+                open="1",
+                high="2",
+                low="0.5",
+                close="1.5",
+                volume="10",
+                is_final=True,
+            )
+        )
+    return tuple(bars)
+
+
+def _build_registry_and_panel(
+    instruments: list[dict[str, str]],
+) -> tuple[object, tuple[InstrumentPanelSeriesV1, ...], str]:
+    from src.research.instrument_id_canonicalization_v1 import (
+        InstrumentIdCanonicalizationInputV1,
+        canonicalize_instrument_id_v1,
+    )
+    from src.research.okx_production_instrument_lifecycle_source_v1 import (
+        build_lifecycle_source_observations_v1,
+        build_okx_lifecycle_source_snapshot_v1,
+    )
+
+    snapshot = build_okx_lifecycle_source_snapshot_v1(
+        instruments,
+        retrieval_timestamp_utc=_GENERATED_AT,
+        source_snapshot_ref=_SOURCE_REF,
+    )
+    observations = build_lifecycle_source_observations_v1(snapshot)
+    registry, errors = assemble_production_registry_from_observations_v1(
+        observations,
+        generated_at=_GENERATED_AT,
+        lifecycle_source_snapshot_digest=snapshot.raw_snapshot_digest,
+        config_digest=_REGISTRY_CONFIG,
+        implementation_digest=_REGISTRY_IMPL,
+    )
+    assert errors == (), errors
+    assert registry is not None
+    panel_series: list[InstrumentPanelSeriesV1] = []
+    for metadata in snapshot.eligible_instruments:
+        canon = canonicalize_instrument_id_v1(
+            InstrumentIdCanonicalizationInputV1(
+                venue_id="okx",
+                market_type="futures",
+                contract_type="linear_perpetual",
+                base_asset=metadata.base_asset,
+                quote_asset="USDT",
+                settlement_asset="USDT",
+                venue_symbol=metadata.inst_id,
+            )
+        )
+        assert canon.success and canon.instrument_id is not None
+        panel_series.append(
+            InstrumentPanelSeriesV1(
+                instrument_id=canon.instrument_id,
+                native_instrument_id=metadata.inst_id,
+                bars=_hourly_bars(canon.instrument_id, count=30, end=_BAR_CLOSE),
+                series_digest="0" * 64,
+            )
+        )
+    for index, series in enumerate(panel_series):
+        panel_series[index] = InstrumentPanelSeriesV1(
+            instrument_id=series.instrument_id,
+            native_instrument_id=series.native_instrument_id,
+            bars=series.bars,
+            series_digest=compute_series_digest(series),
+        )
+    return registry, tuple(panel_series), snapshot.raw_snapshot_digest
+
+
+def _default_instruments() -> list[dict[str, str]]:
+    return [
+        _live_inst("BTC"),
+        *[_live_inst(base) for base in ("ETH", "SOL", "ADA", "DOT", "LINK", "AVAX")],
+    ]
+
+
+def _build_production_result():
+    registry, panel_series, source_digest = _build_registry_and_panel(_default_instruments())
+    inp = PitFuturesUniverseManifestProductionMaterializationInputV1(
+        input_contract_version=INPUT_CONTRACT_VERSION,
+        materialization_version=MATERIALIZATION_VERSION,
+        generated_at=_GENERATED_AT,
+        universe_policy_id="pit_okx_linear_usdt_non_bitcoin_perpetual_cross_sectional_universe",
+        universe_policy_version="v1",
+        inclusion_policy_version=INCLUSION_POLICY_VERSION,
+        exclusion_policy_version=EXCLUSION_POLICY_VERSION,
+        lifecycle_source_id="okx_production_instrument_lifecycle_historical_as_of_fail_closed.v1",
+        lifecycle_source_snapshot_ref=_SOURCE_REF,
+        lifecycle_source_snapshot_digest=source_digest,
+        registry_artifact_id="okx_production_lifecycle_v1",
+        registry_snapshot=registry,
+        panel_series=panel_series,
+        panel_dataset_ref="pit_okx_pt1h_panel_ohlcv_dataset_v1:test_panel:sha256:" + "a" * 64,
+        panel_dataset_digest=_PANEL_DIGEST,
+        period_binding_ref=EVALUATION_PERIOD_BINDING,
+        period_start_utc=_PERIOD_START,
+        period_end_utc=_PERIOD_END,
+        minimum_history_bars=DEFAULT_MINIMUM_HISTORY_BARS,
+        minimum_required_member_count=DEFAULT_MINIMUM_REQUIRED_MEMBER_COUNT,
+        registry_config_digest=_REGISTRY_CONFIG,
+        registry_implementation_digest=_REGISTRY_IMPL,
+        epochs=(
+            ProductionMaterializationEpochV1(
+                score_epoch=0,
+                finalized_bar_close=_BAR_CLOSE,
+            ),
+        ),
+    )
+    result = materialize_production_pit_futures_universe_manifest_v1(inp)
+    assert result.success is True
+    assert result.manifest is not None and result.envelope is not None
+    return result, panel_series
+
+
+@pytest.fixture(scope="module")
+def production_bundle():
+    return _build_production_result()
+
+
+@pytest.fixture(scope="module")
+def canonical_completion(production_bundle):
+    production, panel_series = production_bundle
+    return materialize_final_research_fleet_versioned_binding_completion_v0(
+        repo_root=REPO_ROOT,
+        production_manifest=production.manifest,
+        production_envelope=production.envelope,
+        panel_series=panel_series,
+        source_registration_ref=_SOURCE_REF,
+        source_registration_digest=_SOURCE_DIGEST,
+    )
+
+
+@pytest.fixture(scope="module")
+def canonical_ratification(canonical_completion):
+    return materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=REPO_ROOT,
+        fleet_binding_completion=canonical_completion,
+    )
+
+
+def _validate(ratification: dict, *, completion: dict | None = None):
+    return validate_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+        ratification,
+        repo_root=REPO_ROOT,
+        expected_fleet_binding_completion=completion,
+    )
+
+
+def test_ratification_module_does_not_import_evaluation_executors() -> None:
+    tree = ast.parse(RATIFICATION_MODULE.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    assert imported.isdisjoint(_FORBIDDEN_EVAL_IMPORTS)
+
+
+def test_materialize_exactly_three_candidates(canonical_ratification: dict) -> None:
+    assert len(canonical_ratification["candidate_refs"]) == 3
+    assert set(canonical_ratification["candidate_refs"]) == {
+        canonical_candidate_identifier(sid, ver) for sid, ver in FLEET_CANDIDATES
+    }
+
+
+def test_ratification_status_fields(canonical_ratification: dict) -> None:
+    assert (
+        canonical_ratification["final_research_fleet_binding_ready"]
+        is FINAL_RESEARCH_FLEET_BINDING_READY
+    )
+    assert (
+        canonical_ratification["offline_economic_evaluation_scope_ratified"]
+        is OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFIED
+    )
+    assert (
+        canonical_ratification["economic_evaluation_authorized"] is ECONOMIC_EVALUATION_AUTHORIZED
+    )
+    assert canonical_ratification["economic_evaluation_executed"] is ECONOMIC_EVALUATION_EXECUTED
+    assert (
+        canonical_ratification["economic_validity_offline_gate_pass"]
+        is ECONOMIC_VALIDITY_OFFLINE_GATE_PASS
+    )
+    assert canonical_ratification["runtime_rewire_admissible"] is RUNTIME_REWIRE_ADMISSIBLE
+    assert canonical_ratification["authority_effect"] == AUTHORITY_EFFECT
+    assert canonical_ratification["runtime_effect"] == RUNTIME_EFFECT
+    assert canonical_ratification["order_effect"] == ORDER_EFFECT
+    assert canonical_ratification["evaluation_execution_performed"] is False
+    assert canonical_ratification["evaluation_modules_invoked"] == []
+
+
+def test_allowed_stages_and_prohibited_actions(canonical_ratification: dict) -> None:
+    assert canonical_ratification["allowed_evaluation_stages"] == list(ALLOWED_EVALUATION_STAGES)
+    assert canonical_ratification["prohibited_actions"] == list(PROHIBITED_ACTIONS)
+
+
+def test_deterministic_ratification_generation(
+    canonical_ratification: dict, canonical_completion: dict
+) -> None:
+    second = materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=REPO_ROOT,
+        fleet_binding_completion=canonical_completion,
+    )
+    assert serialize_ratification_canonical_v0(
+        canonical_ratification
+    ) == serialize_ratification_canonical_v0(second)
+    assert canonical_ratification["ratification_digest"] == second["ratification_digest"]
+
+
+def test_validate_accepts_canonical_ratification(
+    canonical_ratification: dict, canonical_completion: dict
+) -> None:
+    result = _validate(canonical_ratification, completion=canonical_completion)
+    assert result.valid is True
+    assert result.verdict == ValidationVerdict.ACCEPTED
+
+
+def test_all_candidates_ready_for_eval_ratification(canonical_completion: dict) -> None:
+    for candidate in canonical_completion["candidates"]:
+        assert candidate["binding_status"] == BINDING_STATUS_READY_FOR_EVAL_RATIFICATION
+
+
+def test_materialize_rejects_incomplete_binding(production_bundle) -> None:
+    production, panel_series = production_bundle
+    incomplete = materialize_final_research_fleet_versioned_binding_completion_v0(
+        repo_root=REPO_ROOT,
+        production_manifest=production.manifest,
+        production_envelope=production.envelope,
+    )
+    assert incomplete["binding_materialization_status"] == BINDING_STATUS_INCOMPLETE
+    with pytest.raises(ValueError, match=REASON_BINDING_COMPLETION_INVALID):
+        materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+            repo_root=REPO_ROOT,
+            fleet_binding_completion=incomplete,
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutator", "reason_prefix"),
+    [
+        (lambda r: r.update({"schema_version": "unknown.v9"}), REASON_UNKNOWN_SCHEMA_VERSION),
+        (lambda r: r.update({"authority_effect": "LIVE"}), REASON_EFFECT_NOT_NONE),
+        (
+            lambda r: r.update({"economic_evaluation_executed": True}),
+            REASON_EVALUATION_ALREADY_EXECUTED,
+        ),
+        (
+            lambda r: r.update({"evaluation_execution_performed": True}),
+            REASON_EVALUATION_ALREADY_EXECUTED,
+        ),
+        (
+            lambda r: r.update({"evaluation_modules_invoked": ["backtest"]}),
+            REASON_FORBIDDEN_STAGE_IN_RATIFICATION,
+        ),
+        (lambda r: r["candidate_refs"].pop(0), REASON_MISSING_CANDIDATE),
+        (
+            lambda r: r["candidate_refs"].append(r["candidate_refs"][0]),
+            REASON_DUPLICATE_CANDIDATE,
+        ),
+        (
+            lambda r: r["candidate_refs"].append("rsi_reversion/step30a"),
+            REASON_FAILED_HISTORICAL_CANDIDATE,
+        ),
+        (
+            lambda r: r["fee_model_binding"].update({"fee_bps": 0}),
+            REASON_ZERO_FEE,
+        ),
+        (
+            lambda r: r["slippage_model_binding"].update({"slippage_bps": 0}),
+            REASON_ZERO_SLIPPAGE,
+        ),
+        (
+            lambda r: r["common_instrument_policy_ref"].update({"spot_allowed": True}),
+            REASON_SPOT_BINDING,
+        ),
+        (
+            lambda r: r["common_instrument_policy_ref"].update({"synthetic_spot_allowed": True}),
+            REASON_SYNTHETIC_SPOT_BINDING,
+        ),
+        (
+            lambda r: r["common_instrument_policy_ref"].update({"bitcoin_direction_allowed": True}),
+            REASON_BITCOIN_DIRECTION_BINDING,
+        ),
+        (
+            lambda r: r["common_instrument_policy_ref"].update({"futures_only": False}),
+            REASON_FUTURES_ONLY_VIOLATION,
+        ),
+        (
+            lambda r: r["allowed_evaluation_stages"].append("LIVE_TRADING"),
+            REASON_POLICY_DRIFT,
+        ),
+        (
+            lambda r: r.update({"fleet_binding_digest": "0" * 64}),
+            REASON_FLEET_BINDING_DIGEST_MISMATCH,
+        ),
+        (
+            lambda r: r.update({"semantic_digest": "0" * 64}),
+            REASON_WRONG_SEMANTIC_DIGEST,
+        ),
+        (
+            lambda r: r.update({"ratification_digest": "0" * 64}),
+            REASON_WRONG_RATIFICATION_DIGEST,
+        ),
+        (
+            lambda r: r.update({"fallback": True}),
+            REASON_BINDING_REPAIR_REJECTED,
+        ),
+    ],
+)
+def test_negative_validation_cases(
+    canonical_ratification: dict,
+    canonical_completion: dict,
+    mutator,
+    reason_prefix: str,
+) -> None:
+    mutated = clone_ratification(canonical_ratification)
+    mutator(mutated)
+    if mutated.get("ratification_digest") == canonical_ratification["ratification_digest"]:
+        mutated["ratification_digest"] = compute_ratification_digest_v0(mutated)
+    result = _validate(mutated, completion=canonical_completion)
+    assert result.valid is False
+    assert result.verdict == ValidationVerdict.REJECTED
+    assert any(reason.startswith(reason_prefix) for reason in result.fail_reasons)
+
+
+def test_failed_historical_candidate_rejected(
+    canonical_ratification: dict, canonical_completion: dict
+) -> None:
+    mutated = clone_ratification(canonical_ratification)
+    mutated["candidate_refs"] = list(mutated["candidate_refs"]) + ["macd/v1"]
+    mutated["ratification_digest"] = compute_ratification_digest_v0(mutated)
+    result = _validate(mutated, completion=canonical_completion)
+    assert any(
+        reason.startswith(REASON_FAILED_HISTORICAL_CANDIDATE) for reason in result.fail_reasons
+    )
+
+
+def test_policy_drift_rejected(canonical_completion: dict) -> None:
+    mutated_completion = copy.deepcopy(canonical_completion)
+    for candidate in mutated_completion["candidates"]:
+        if candidate["strategy_id"] == "bollinger_bands":
+            candidate["economic_policy_binding"] = {
+                **candidate["economic_policy_binding"],
+                "policy_version": "other_policy_v9",
+            }
+    mutated_completion["completion_digest"] = compute_completion_digest_v0(mutated_completion)
+    with pytest.raises(ValueError, match=REASON_ECONOMIC_POLICY_MISMATCH):
+        materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+            repo_root=REPO_ROOT,
+            fleet_binding_completion=mutated_completion,
+        )
+
+
+def test_incomplete_period_split_rejected(
+    canonical_ratification: dict, canonical_completion: dict
+) -> None:
+    mutated_completion = copy.deepcopy(canonical_completion)
+    for candidate in mutated_completion["candidates"]:
+        candidate["training_period"] = {"status": "INCOMPLETE"}
+    mutated_completion["completion_digest"] = compute_completion_digest_v0(mutated_completion)
+    with pytest.raises(ValueError, match=REASON_BINDING_COMPLETION_INVALID):
+        materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+            repo_root=REPO_ROOT,
+            fleet_binding_completion=mutated_completion,
+        )
+
+
+def test_shared_binding_mismatch_rejected(
+    canonical_ratification: dict, canonical_completion: dict, production_bundle
+) -> None:
+    production, panel_series = production_bundle
+    mutated_completion = copy.deepcopy(canonical_completion)
+    for candidate in mutated_completion["candidates"]:
+        if candidate["strategy_id"] == "bollinger_bands":
+            candidate["period_binding"] = {
+                **candidate["period_binding"],
+                "period_binding_ref": "other_period_ref",
+            }
+    mutated_completion["completion_digest"] = compute_completion_digest_v0(mutated_completion)
+    with pytest.raises(ValueError, match=REASON_BINDING_COMPLETION_INVALID):
+        materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+            repo_root=REPO_ROOT,
+            fleet_binding_completion=mutated_completion,
+        )
+
+
+def test_ratification_metadata(canonical_ratification: dict) -> None:
+    assert canonical_ratification["schema_version"] == SCHEMA_VERSION
+    assert canonical_ratification["ratification_id"] == RATIFICATION_ID
+    assert canonical_ratification["fee_model_binding"]["fee_bps"] > 0
+    assert canonical_ratification["slippage_model_binding"]["slippage_bps"] > 0
+    assert canonical_ratification["walk_forward_policy_binding"]["bind"] is True
+    assert canonical_ratification["monte_carlo_policy_binding"]["bind"] is True
+    assert canonical_ratification["stress_policy_binding"]["bind"] is True
+    assert canonical_ratification["parameter_sensitivity_policy_binding"]["bind"] is True


### PR DESCRIPTION
## Summary

- Materializes a versionierten, fail-closed **Offline-Economic-Evaluation-Scope-Ratification-Contract** für die final gebundene Research Fleet (`trend_following/v1`, `bollinger_bands/v1`, `momentum_1h/v1`) auf Basis des bestehenden `final_research_fleet_versioned_binding_completion_v0`-Owners.
- Ratifiziert ausschließlich Evaluationsvertrag, gemeinsame Policies, zulässige spätere Evaluation-Stufen und Ausführungsgrenzen — **keine** Economic Evaluation, kein Backtest, kein Walk-Forward, kein Monte Carlo, kein Stress, keine Parameter-Sensitivity-Ausführung.
- Setzt `ECONOMIC_EVALUATION_AUTHORIZED=true` nur im Sinne eines **späteren separaten Offline-Evaluation-GO**; `ECONOMIC_EVALUATION_EXECUTED=false`, `ECONOMIC_VALIDITY_OFFLINE_GATE_PASS=false`, `RUNTIME_REWIRE_ADMISSIBLE=false`, `AUTHORITY_EFFECT=NONE`, `RUNTIME_EFFECT=NONE`, `ORDER_EFFECT=NONE`.

## Scope-Grenzen (explizit ausgeschlossen)

- Kein Runtime, Scheduler, Shadow, Paper, Testnet, Canary, Live
- Keine Adapter-Submission, Orders, Cancels, Credentials, Arming
- Keine Core-/Trading-Logic-/Risk-/Safety-Kernel-Änderungen
- `FUTURES_ONLY=true`, `BITCOIN_DIRECTION_ALLOWED=false`, `SPOT_ALLOWED=false`

## Test plan

- [x] `ruff format --check` / `ruff check` auf geänderten Python-Dateien
- [x] `git diff --check`
- [x] Fokussierte Contract-Tests: `test_final_research_fleet_offline_economic_evaluation_scope_ratification_v0.py`
- [x] Regression: `test_final_research_fleet_versioned_binding_completion_v0.py`
- [x] Negative Tests: fehlende Bindings, Policy-Drift, Duplikate, Futures-only-Verstöße, Nullkosten, Periodensplits, verbotene Authority-/Runtime-Effekte
- [x] Statischer Nachweis: Ratification-Modul importiert keine Evaluation-Executor-Module
- [x] CI-Selector: `PR_BOUNDED_FULL` (central `src/`)


Made with [Cursor](https://cursor.com)