### PR TITLE
feat(research): cross-sectional offline economic evaluation infrastructure completion v1

### DIFF
--- a/scripts/ops/materialize_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_infrastructure_v0.py
+++ b/scripts/ops/materialize_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_infrastructure_v0.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Materialize cross-sectional relative-strength v0 execution infrastructure v0.
+"""Materialize cross-sectional relative-strength v0 execution infrastructure v1.
 
-Bounded infrastructure completion for offline economic evaluation execution path.
-Does not execute full economic evaluation or emit PASS/FAIL/INCONCLUSIVE verdicts.
-Operator GO: GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_COMPLETION_V0
+Bounded infrastructure completion: bound-period panel materialization, source manifests,
+full evaluation entrypoint dry-run validation. No economic evaluation execution.
+Operator GO: GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_INFRASTRUCTURE_COMPLETION_V1
 """
 
 from __future__ import annotations
@@ -20,25 +20,52 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from scripts.ops import primary_evidence_retention_v0 as retention  # noqa: E402
+from src.research.cross_sectional_bound_period_panel_source_materialization_v1 import (  # noqa: E402
+    BoundPeriodSourceMaterializationStatus,
+    bound_period_source_result_to_dict,
+    materialize_bound_period_panel_from_raw_sources_v1,
+)
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (  # noqa: E402
+    materialize_panel_staging_source_manifests_v1,
+    source_manifest_result_to_dict,
+)
 from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (  # noqa: E402
+    MaterializationTerminalStatus,
     materialization_result_to_dict,
+    materialize_bound_panel_dataset_v0,
 )
 from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v0 import (  # noqa: E402
     AUTHORITY_EFFECT,
     INFRASTRUCTURE_GO_TOKEN,
     RUNTIME_EFFECT,
+    entrypoint_result_to_dict,
     materialize_infrastructure_summary_v0,
+    run_full_evaluation_entrypoint_dry_run_v1,
     verify_execution_start_state_v0,
 )
 from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_scope_ratification_v0 import (  # noqa: E402
     materialize_cross_sectional_offline_economic_evaluation_scope_ratification_v0,
 )
+from src.research.pit_futures_cross_sectional_research_data_digest_period_split_materialization_v0 import (  # noqa: E402
+    load_panel_series_from_staging,
+)
 
 CONFIRM_GO = INFRASTRUCTURE_GO_TOKEN
-
-
-def _utc_now_z() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+DEFAULT_SOURCE_STAGING = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_pt1h_panel/v1"
+)
+DEFAULT_BOUND_OUTPUT_REL = (
+    "datasets/admissible_futures/"
+    "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/v1"
+)
+PRIOR_BLOCKER_EVIDENCE = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "economic_evaluation/"
+    "bounded_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v1_"
+    "20260703T070255Z"
+)
 
 
 def _die(msg: str, code: int = 2) -> None:
@@ -56,21 +83,44 @@ def _resolve_origin_main(repo_root: Path) -> str:
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
+def _primary_worktree_snapshot(primary_worktree: Path) -> dict[str, Any]:
+    head = subprocess.run(
+        ["git", "-C", str(primary_worktree), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty = subprocess.run(
+        ["git", "-C", str(primary_worktree), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty_count = len([line for line in dirty.stdout.splitlines() if line.strip()])
+    return {
+        "head": head.stdout.strip() if head.returncode == 0 else "",
+        "dirty_count": dirty_count,
+    }
+
+
 def run_materialization(
     *,
     confirm: str,
     durable_evidence_root: Path,
     primary_worktree: Path,
-    panel_staging_root: Path | None = None,
+    source_staging_root: Path | None = None,
+    bound_output_staging_root: Path | None = None,
 ) -> dict[str, Any]:
     if confirm != CONFIRM_GO:
         _die(f"ERR: confirm_go_token_required:{CONFIRM_GO}")
 
     origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
     ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     bundle_dir = (
         durable_evidence_root
-        / f"bounded_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_infrastructure_completion_v0_{ts_slug}"
+        / "implementation"
+        / f"bounded_cross_sectional_relative_strength_v0_offline_economic_evaluation_infrastructure_completion_v1_{ts_slug}"
     )
     bundle_dir.mkdir(parents=True, exist_ok=False)
 
@@ -80,64 +130,43 @@ def run_materialization(
     start_state = verify_execution_start_state_v0(
         repo_root=_REPO_ROOT,
         ratification=ratification,
+        origin_main_sha=origin_main,
     )
-
-    from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (  # noqa: E402
-        materialize_bound_panel_dataset_v0,
-    )
-
     period_binding = ratification["period_binding"]
-    staging = panel_staging_root or Path(
-        "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
-        "datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_pt1h_panel/v1"
-    )
-    materialization = materialize_bound_panel_dataset_v0(staging, period_binding=period_binding)
 
-    (bundle_dir / "START_HEAD.txt").write_text(
-        subprocess.run(
-            ["git", "-C", str(_REPO_ROOT), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            check=False,
-        ).stdout,
-        encoding="utf-8",
+    source_root = source_staging_root or DEFAULT_SOURCE_STAGING
+    output_root = bound_output_staging_root or (durable_evidence_root / DEFAULT_BOUND_OUTPUT_REL)
+    source_materialization = materialize_bound_period_panel_from_raw_sources_v1(
+        source_root,
+        output_root,
+        period_binding=period_binding,
     )
-    (bundle_dir / "ORIGIN_MAIN.txt").write_text(origin_main + "\n", encoding="utf-8")
-    (bundle_dir / "SCOPE_AND_GO.txt").write_text(
-        f"GO_TOKEN={CONFIRM_GO}\nPROCESS=INFRASTRUCTURE_COMPLETION\n",
-        encoding="utf-8",
+
+    active_staging = output_root
+    if source_materialization.status is not BoundPeriodSourceMaterializationStatus.MATERIALIZED:
+        active_staging = source_root
+
+    manifest_result = materialize_panel_staging_source_manifests_v1(active_staging)
+    materialization = materialize_bound_panel_dataset_v0(
+        active_staging,
+        period_binding=period_binding,
     )
-    (bundle_dir / "BINDING_VALIDATION.txt").write_text(
-        f"START_STATE_VALID={start_state.valid}\nFAIL_REASONS={start_state.fail_reasons}\n",
-        encoding="utf-8",
-    )
-    (bundle_dir / "VERSIONED_CONFIG.json").write_text(
-        json.dumps(
-            json.loads(
-                (
-                    _REPO_ROOT
-                    / "config/ops/cross_sectional_relative_strength_v0_economic_evaluation_v1.json"
-                ).read_text(encoding="utf-8")
-            ),
-            indent=2,
-            sort_keys=True,
+
+    entrypoint_payload: dict[str, Any] | None = None
+    if materialization.status is MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE:
+        panel_series, _ = load_panel_series_from_staging(active_staging)
+        entrypoint = run_full_evaluation_entrypoint_dry_run_v1(
+            repo_root=_REPO_ROOT,
+            ratification=ratification,
+            staging_root=active_staging,
+            panel_series=panel_series,
+            go_token=confirm,
         )
-        + "\n",
-        encoding="utf-8",
-    )
-    (bundle_dir / "DATASET_MATERIALIZATION_RESULT.json").write_text(
-        json.dumps(materialization_result_to_dict(materialization), indent=2, sort_keys=True)
-        + "\n",
-        encoding="utf-8",
-    )
-    (bundle_dir / "DATA_DIGEST.txt").write_text(
-        f"PANEL_DATA_DIGEST={materialization.panel_data_digest}\nSTATUS={materialization.status.value}\n",
-        encoding="utf-8",
-    )
+        entrypoint_payload = entrypoint_result_to_dict(entrypoint)
 
     from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v0 import (  # noqa: E402
-        InfrastructureTerminalStatus,
         InfrastructureReadinessResultV0,
+        InfrastructureTerminalStatus,
     )
 
     if materialization.status.value == "DATASET_MATERIALIZATION_COMPLETE":
@@ -177,16 +206,75 @@ def run_materialization(
         origin_main_sha=origin_main,
         execution_bundle_dir=str(bundle_dir),
     )
+
+    (bundle_dir / "GIT_PROVENANCE.txt").write_text(
+        "\n".join(
+            [
+                f"START_HEAD={subprocess.run(['git', '-C', str(_REPO_ROOT), 'rev-parse', 'HEAD'], capture_output=True, text=True).stdout.strip()}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"PRIMARY_WORKTREE={primary_worktree}",
+                f"PRIMARY_WORKTREE_HEAD_BEFORE={primary_before['head']}",
+                f"PRIMARY_WORKTREE_DIRTY_COUNT_BEFORE={primary_before['dirty_count']}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "SCOPE_AND_GO.txt").write_text(
+        f"GO_TOKEN={CONFIRM_GO}\nGO_TOKEN_CONSUMPTION=CONSUMED_ONCE\n"
+        f"PRIOR_BLOCKER_EVIDENCE={PRIOR_BLOCKER_EVIDENCE}\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "SOURCE_MATERIALIZATION_RESULT.json").write_text(
+        json.dumps(
+            bound_period_source_result_to_dict(source_materialization), indent=2, sort_keys=True
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "SOURCE_MANIFEST_RESULT.json").write_text(
+        json.dumps(source_manifest_result_to_dict(manifest_result), indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "DATASET_MATERIALIZATION_RESULT.json").write_text(
+        json.dumps(materialization_result_to_dict(materialization), indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
     (bundle_dir / "INFRASTRUCTURE_SUMMARY.json").write_text(
         json.dumps(summary, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+    if entrypoint_payload is not None:
+        (bundle_dir / "ENTRYPOINT_DRY_RUN_RESULT.json").write_text(
+            json.dumps(entrypoint_payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
+        "ECONOMIC_EVALUATION_EXECUTED=false\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+
+    verdict = "INFRASTRUCTURE_COMPLETION_PASS"
+    if materialization.status is not MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE:
+        verdict = "INFRASTRUCTURE_COMPLETION_FAIL_CLOSED_BOUND_DATA_UNAVAILABLE"
 
     return {
+        "verdict": verdict,
         "bundle_dir": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
         "start_state_valid": start_state.valid,
+        "source_materialization_status": source_materialization.status.value,
         "materialization_status": materialization.status.value,
         "infrastructure_status": readiness.status.value,
+        "entrypoint_status": entrypoint_payload.get("status") if entrypoint_payload else "NOT_RUN",
+        "panel_data_digest": materialization.panel_data_digest,
+        "dataset_period_match": readiness.dataset_period_match,
+        "economic_evaluation_executed": False,
         "authority_effect": AUTHORITY_EFFECT,
         "runtime_effect": RUNTIME_EFFECT,
         "primary_worktree": str(primary_worktree),
@@ -198,13 +286,15 @@ def main() -> None:
     parser.add_argument("--confirm", required=True)
     parser.add_argument("--durable-evidence-root", type=Path, required=True)
     parser.add_argument("--primary-worktree", type=Path, required=True)
-    parser.add_argument("--panel-staging-root", type=Path, default=None)
+    parser.add_argument("--source-staging-root", type=Path, default=None)
+    parser.add_argument("--bound-output-staging-root", type=Path, default=None)
     args = parser.parse_args()
     result = run_materialization(
         confirm=args.confirm,
         durable_evidence_root=args.durable_evidence_root,
         primary_worktree=args.primary_worktree,
-        panel_staging_root=args.panel_staging_root,
+        source_staging_root=args.source_staging_root,
+        bound_output_staging_root=args.bound_output_staging_root,
     )
     print(json.dumps(result, indent=2, sort_keys=True))
 

--- a/scripts/ops/run_cross_sectional_relative_strength_v0_offline_economic_evaluation_dry_run_v0.py
+++ b/scripts/ops/run_cross_sectional_relative_strength_v0_offline_economic_evaluation_dry_run_v0.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Dry-run entrypoint for cross-sectional relative-strength v0 offline economic evaluation.
+
+Validates bindings, manifests, dataset materialization, and stage wiring.
+Stops before economic evaluation execution. No runtime or order effect.
+Operator GO (infrastructure): GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_INFRASTRUCTURE_COMPLETION_V1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (  # noqa: E402
+    materialize_panel_staging_source_manifests_v1,
+    source_manifest_result_to_dict,
+)
+from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (  # noqa: E402
+    materialization_result_to_dict,
+    materialize_bound_panel_dataset_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v0 import (  # noqa: E402
+    AUTHORITY_EFFECT,
+    INFRASTRUCTURE_GO_TOKEN,
+    RUNTIME_EFFECT,
+    entrypoint_result_to_dict,
+    run_full_evaluation_entrypoint_dry_run_v1,
+)
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_scope_ratification_v0 import (  # noqa: E402
+    materialize_cross_sectional_offline_economic_evaluation_scope_ratification_v0,
+)
+from src.research.pit_futures_cross_sectional_research_data_digest_period_split_materialization_v0 import (  # noqa: E402
+    load_panel_series_from_staging,
+)
+
+CONFIRM_GO = INFRASTRUCTURE_GO_TOKEN
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _resolve_origin_main(repo_root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "origin/main"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def run_dry_run(
+    *,
+    confirm: str,
+    staging_root: Path,
+    durable_evidence_root: Path | None = None,
+    write_evidence: bool = False,
+) -> dict[str, Any]:
+    if confirm != CONFIRM_GO:
+        _die(f"ERR: confirm_go_token_required:{CONFIRM_GO}")
+
+    ratification = materialize_cross_sectional_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=_REPO_ROOT,
+    )
+    manifest_result = materialize_panel_staging_source_manifests_v1(staging_root)
+    panel_series, _ = load_panel_series_from_staging(staging_root)
+    entrypoint = run_full_evaluation_entrypoint_dry_run_v1(
+        repo_root=_REPO_ROOT,
+        ratification=ratification,
+        staging_root=staging_root,
+        panel_series=panel_series,
+        go_token=confirm,
+    )
+    materialization = materialize_bound_panel_dataset_v0(
+        staging_root,
+        period_binding=ratification["period_binding"],
+    )
+
+    payload: dict[str, Any] = {
+        "verdict": entrypoint.status.value,
+        "confirm_go_token": confirm,
+        "origin_main_sha": _resolve_origin_main(_REPO_ROOT),
+        "staging_root": str(staging_root),
+        "source_manifests": source_manifest_result_to_dict(manifest_result),
+        "dataset_materialization": materialization_result_to_dict(materialization),
+        "entrypoint": entrypoint_result_to_dict(entrypoint),
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+    }
+
+    if write_evidence and durable_evidence_root is not None:
+        ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        bundle_dir = (
+            durable_evidence_root
+            / f"bounded_cross_sectional_relative_strength_v0_offline_economic_evaluation_infrastructure_completion_v1_{ts_slug}"
+        )
+        bundle_dir.mkdir(parents=True, exist_ok=False)
+        (bundle_dir / "DRY_RUN_RESULT.json").write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        payload["durable_evidence_path"] = str(bundle_dir)
+
+    return payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm", required=True)
+    parser.add_argument("--staging-root", type=Path, required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, default=None)
+    parser.add_argument("--write-evidence", action="store_true")
+    args = parser.parse_args()
+    result = run_dry_run(
+        confirm=args.confirm,
+        staging_root=args.staging_root,
+        durable_evidence_root=args.durable_evidence_root,
+        write_evidence=args.write_evidence,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/research/cross_sectional_bound_period_panel_source_materialization_v1.py
+++ b/src/research/cross_sectional_bound_period_panel_source_materialization_v1.py
@@ -1,0 +1,488 @@
+"""Bound-period panel source materialization for cross-sectional relative-strength v1.
+
+Offline-first: materializes PT1H panel staging for the frozen chronological holdout
+window from existing raw OHLCV source files. No network, no synthetic data.
+Research-only; no runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (
+    FORBIDDEN_FOREIGN_FIRST_TIMESTAMP,
+    REASON_FOREIGN_DATASET_REJECTED,
+    REASON_INSUFFICIENT_COVERAGE,
+    REASON_MISSING_STAGING,
+    verify_panel_covers_period_binding_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_versioned_research_binding_v0 import (
+    PANEL_DATASET_ID,
+    build_period_binding_v0,
+)
+from src.research.instrument_id_canonicalization_v1 import (
+    InstrumentIdCanonicalizationInputV1,
+    canonicalize_instrument_id_v1,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import (
+    BAR_GRANULARITY,
+    PANEL_DATASET_VERSION,
+    InstrumentPanelSeriesV1,
+    PanelBarV1,
+    build_panel_dataset_manifest_v1,
+    compute_implementation_digest,
+    compute_series_digest,
+    panel_manifest_to_dict,
+    validate_panel_series_v1,
+)
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_BOUND_PERIOD_PANEL_SOURCE_MATERIALIZATION_V1=true"
+MATERIALIZATION_VERSION = "cross_sectional_bound_period_panel_source_materialization.v1"
+MIN_ELIGIBLE_INSTRUMENTS = 5
+
+REASON_MISSING_RAW_DIR = "MISSING_RAW_DIR"
+REASON_MISSING_INSTRUMENTS_SNAPSHOT = "MISSING_INSTRUMENTS_SNAPSHOT"
+REASON_NO_ELIGIBLE_RAW_SERIES = "NO_ELIGIBLE_RAW_SERIES"
+REASON_BOUND_PERIOD_SOURCE_DATA_UNAVAILABLE = "BOUND_PERIOD_SOURCE_DATA_UNAVAILABLE"
+REASON_PANEL_VALIDATION_FAILED = "PANEL_VALIDATION_FAILED"
+REASON_OUTPUT_EXISTS = "OUTPUT_STAGING_EXISTS"
+
+_RAW_FILENAME_RE = re.compile(r"^ohlcv_(.+)_swap_p\d{4}_[0-9a-f]+\.json$")
+
+
+class BoundPeriodSourceMaterializationStatus(str, Enum):
+    MATERIALIZED = "MATERIALIZED"
+    BOUND_DATA_UNAVAILABLE_FAIL_CLOSED = "BOUND_DATA_UNAVAILABLE_FAIL_CLOSED"
+
+
+@dataclass(frozen=True)
+class SourceProvenanceEntryV1:
+    source_file: str
+    native_instrument_id: str
+    instrument_id: str
+    row_count_raw: int
+    row_count_bound: int
+    first_timestamp_utc: str
+    last_timestamp_utc: str
+
+
+@dataclass(frozen=True)
+class BoundPeriodPanelSourceMaterializationResultV1:
+    status: BoundPeriodSourceMaterializationStatus
+    output_staging_root: str
+    source_staging_root: str
+    period_start_utc: str
+    period_end_utc: str
+    instrument_count: int
+    row_count_total: int
+    data_start_time: str
+    data_end_time: str
+    source_provenance: tuple[SourceProvenanceEntryV1, ...]
+    reason_codes: tuple[str, ...]
+
+
+def _ms_to_rfc3339_utc(ms: int) -> str:
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def parse_native_instrument_id_from_raw_filename(filename: str) -> str | None:
+    match = _RAW_FILENAME_RE.match(filename)
+    if not match:
+        return None
+    token = match.group(1).replace("_", "-").upper()
+    return f"{token}-SWAP"
+
+
+def normalize_okx_candles_to_panel_bars(
+    instrument_id: str,
+    rows: Sequence[Sequence[Any]],
+) -> tuple[PanelBarV1, ...]:
+    bars: list[PanelBarV1] = []
+    for row in rows:
+        ts = _ms_to_rfc3339_utc(int(str(row[0])))
+        is_final = str(row[8]) == "1" if len(row) >= 9 else str(row[5]) == "1"
+        bars.append(
+            PanelBarV1(
+                instrument_id=instrument_id,
+                timestamp_utc=ts,
+                open=str(row[1]),
+                high=str(row[2]),
+                low=str(row[3]),
+                close=str(row[4]),
+                volume=str(row[5]),
+                is_final=is_final,
+            )
+        )
+    return tuple(sorted(bars, key=lambda item: item.timestamp_utc))
+
+
+def _load_instruments_snapshot(raw_dir: Path) -> list[dict[str, Any]]:
+    candidates = sorted(raw_dir.glob("instruments_all_swap_*.json"))
+    if not candidates:
+        return []
+    payload = json.loads(candidates[0].read_text(encoding="utf-8"))
+    data = payload.get("data") or []
+    return [dict(item) for item in data if isinstance(item, Mapping)]
+
+
+def _canonicalize_swap_instrument(inst: Mapping[str, Any]) -> tuple[str, str] | None:
+    inst_id = str(inst.get("instId", ""))
+    base = str(inst.get("baseCcy", ""))
+    if not inst_id or not base:
+        return None
+    result = canonicalize_instrument_id_v1(
+        InstrumentIdCanonicalizationInputV1(
+            venue_id="okx",
+            market_type="futures",
+            contract_type="linear_perpetual",
+            base_asset=base,
+            quote_asset="USDT",
+            settlement_asset="USDT",
+            venue_symbol=inst_id,
+            native_instrument_id=inst_id,
+        )
+    )
+    if not result.success or result.instrument_id is None:
+        return None
+    return result.instrument_id, inst_id
+
+
+def _filter_bars_to_period(
+    bars: Sequence[PanelBarV1],
+    *,
+    period_start_utc: str,
+    period_end_utc: str,
+) -> tuple[PanelBarV1, ...]:
+    return tuple(
+        bar
+        for bar in bars
+        if period_start_utc <= bar.timestamp_utc <= period_end_utc and bar.is_final
+    )
+
+
+def _copy_lifecycle_tree(source_root: Path, output_root: Path) -> None:
+    source_lifecycle = source_root / "lifecycle"
+    output_lifecycle = output_root / "lifecycle"
+    output_lifecycle.mkdir(parents=True, exist_ok=True)
+    if not source_lifecycle.is_dir():
+        return
+    for path in sorted(source_lifecycle.rglob("*")):
+        if path.is_file():
+            rel = path.relative_to(source_lifecycle)
+            dst = output_lifecycle / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(path.read_bytes())
+
+
+def materialize_bound_period_panel_from_raw_sources_v1(
+    source_staging_root: Path,
+    output_staging_root: Path,
+    *,
+    period_binding: Mapping[str, Any] | None = None,
+    min_instruments: int = MIN_ELIGIBLE_INSTRUMENTS,
+) -> BoundPeriodPanelSourceMaterializationResultV1:
+    """Materialize bound-period panel staging from offline raw OHLCV sources."""
+    period = dict(period_binding or build_period_binding_v0())
+    period_start = str(period["training_start"])
+    period_end = str(period["out_of_sample_end"])
+    source_staging_root = source_staging_root.resolve()
+
+    if output_staging_root.exists() and any(output_staging_root.iterdir()):
+        return BoundPeriodPanelSourceMaterializationResultV1(
+            status=BoundPeriodSourceMaterializationStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            output_staging_root=str(output_staging_root),
+            source_staging_root=str(source_staging_root),
+            period_start_utc=period_start,
+            period_end_utc=period_end,
+            instrument_count=0,
+            row_count_total=0,
+            data_start_time="",
+            data_end_time="",
+            source_provenance=(),
+            reason_codes=(REASON_OUTPUT_EXISTS,),
+        )
+
+    raw_dir = source_staging_root / "raw"
+    if not raw_dir.is_dir():
+        return BoundPeriodPanelSourceMaterializationResultV1(
+            status=BoundPeriodSourceMaterializationStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            output_staging_root=str(output_staging_root),
+            source_staging_root=str(source_staging_root),
+            period_start_utc=period_start,
+            period_end_utc=period_end,
+            instrument_count=0,
+            row_count_total=0,
+            data_start_time="",
+            data_end_time="",
+            source_provenance=(),
+            reason_codes=(REASON_MISSING_RAW_DIR, REASON_MISSING_STAGING),
+        )
+
+    instruments = _load_instruments_snapshot(raw_dir)
+    if not instruments:
+        return BoundPeriodPanelSourceMaterializationResultV1(
+            status=BoundPeriodSourceMaterializationStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            output_staging_root=str(output_staging_root),
+            source_staging_root=str(source_staging_root),
+            period_start_utc=period_start,
+            period_end_utc=period_end,
+            instrument_count=0,
+            row_count_total=0,
+            data_start_time="",
+            data_end_time="",
+            source_provenance=(),
+            reason_codes=(REASON_MISSING_INSTRUMENTS_SNAPSHOT,),
+        )
+
+    native_to_canonical: dict[str, str] = {}
+    for inst in instruments:
+        pair = _canonicalize_swap_instrument(inst)
+        if pair is not None:
+            native_to_canonical[pair[1]] = pair[0]
+
+    provenance_entries: list[SourceProvenanceEntryV1] = []
+    series_by_instrument: dict[str, InstrumentPanelSeriesV1] = {}
+
+    for raw_path in sorted(raw_dir.glob("ohlcv_*_swap_p*.json")):
+        native_id = parse_native_instrument_id_from_raw_filename(raw_path.name)
+        if native_id is None:
+            continue
+        instrument_id = native_to_canonical.get(native_id)
+        if instrument_id is None:
+            continue
+        payload = json.loads(raw_path.read_text(encoding="utf-8"))
+        rows = payload.get("data") or []
+        if not isinstance(rows, list) or not rows:
+            continue
+        all_bars = normalize_okx_candles_to_panel_bars(instrument_id, rows)
+        bound_bars = _filter_bars_to_period(
+            all_bars, period_start_utc=period_start, period_end_utc=period_end
+        )
+        if not bound_bars:
+            continue
+        if bound_bars[0].timestamp_utc >= FORBIDDEN_FOREIGN_FIRST_TIMESTAMP:
+            return BoundPeriodPanelSourceMaterializationResultV1(
+                status=BoundPeriodSourceMaterializationStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+                output_staging_root=str(output_staging_root),
+                source_staging_root=str(source_staging_root),
+                period_start_utc=period_start,
+                period_end_utc=period_end,
+                instrument_count=0,
+                row_count_total=0,
+                data_start_time=all_bars[0].timestamp_utc,
+                data_end_time=all_bars[-1].timestamp_utc,
+                source_provenance=(),
+                reason_codes=(REASON_FOREIGN_DATASET_REJECTED,),
+            )
+        provenance_entries.append(
+            SourceProvenanceEntryV1(
+                source_file=raw_path.relative_to(source_staging_root).as_posix(),
+                native_instrument_id=native_id,
+                instrument_id=instrument_id,
+                row_count_raw=len(all_bars),
+                row_count_bound=len(bound_bars),
+                first_timestamp_utc=bound_bars[0].timestamp_utc,
+                last_timestamp_utc=bound_bars[-1].timestamp_utc,
+            )
+        )
+        interim = InstrumentPanelSeriesV1(
+            instrument_id=instrument_id,
+            native_instrument_id=native_id,
+            bars=bound_bars,
+            series_digest="0" * 64,
+        )
+        series_by_instrument[instrument_id] = InstrumentPanelSeriesV1(
+            instrument_id=interim.instrument_id,
+            native_instrument_id=interim.native_instrument_id,
+            bars=interim.bars,
+            series_digest=compute_series_digest(interim),
+        )
+
+    if len(series_by_instrument) < min_instruments:
+        return BoundPeriodPanelSourceMaterializationResultV1(
+            status=BoundPeriodSourceMaterializationStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            output_staging_root=str(output_staging_root),
+            source_staging_root=str(source_staging_root),
+            period_start_utc=period_start,
+            period_end_utc=period_end,
+            instrument_count=len(series_by_instrument),
+            row_count_total=sum(len(s.bars) for s in series_by_instrument.values()),
+            data_start_time="",
+            data_end_time="",
+            source_provenance=tuple(provenance_entries),
+            reason_codes=(
+                REASON_NO_ELIGIBLE_RAW_SERIES,
+                REASON_BOUND_PERIOD_SOURCE_DATA_UNAVAILABLE,
+            ),
+        )
+
+    panel_series = tuple(series_by_instrument[iid] for iid in sorted(series_by_instrument))
+    validation = validate_panel_series_v1(panel_series, min_instruments=min_instruments)
+    if not validation.valid:
+        return BoundPeriodPanelSourceMaterializationResultV1(
+            status=BoundPeriodSourceMaterializationStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            output_staging_root=str(output_staging_root),
+            source_staging_root=str(source_staging_root),
+            period_start_utc=period_start,
+            period_end_utc=period_end,
+            instrument_count=len(panel_series),
+            row_count_total=sum(len(s.bars) for s in panel_series),
+            data_start_time=panel_series[0].bars[0].timestamp_utc if panel_series else "",
+            data_end_time=panel_series[0].bars[-1].timestamp_utc if panel_series else "",
+            source_provenance=tuple(provenance_entries),
+            reason_codes=(REASON_PANEL_VALIDATION_FAILED, *validation.error_codes),
+        )
+
+    covers, cover_reasons = verify_panel_covers_period_binding_v0(
+        panel_series, period_binding=period
+    )
+    if not covers:
+        return BoundPeriodPanelSourceMaterializationResultV1(
+            status=BoundPeriodSourceMaterializationStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            output_staging_root=str(output_staging_root),
+            source_staging_root=str(source_staging_root),
+            period_start_utc=period_start,
+            period_end_utc=period_end,
+            instrument_count=len(panel_series),
+            row_count_total=sum(len(s.bars) for s in panel_series),
+            data_start_time=panel_series[0].bars[0].timestamp_utc,
+            data_end_time=panel_series[0].bars[-1].timestamp_utc,
+            source_provenance=tuple(provenance_entries),
+            reason_codes=cover_reasons,
+        )
+
+    output_staging_root.mkdir(parents=True, exist_ok=True)
+    panel_dir = output_staging_root / "panel"
+    panel_dir.mkdir(parents=True, exist_ok=True)
+    _copy_lifecycle_tree(source_staging_root, output_staging_root)
+
+    rows: list[dict[str, object]] = []
+    for series in panel_series:
+        for bar in series.bars:
+            rows.append(
+                {
+                    "instrument_id": bar.instrument_id,
+                    "timestamp_utc": bar.timestamp_utc,
+                    "open": bar.open,
+                    "high": bar.high,
+                    "low": bar.low,
+                    "close": bar.close,
+                    "volume": bar.volume,
+                    "is_final": bar.is_final,
+                }
+            )
+    rows.sort(key=lambda item: (str(item["instrument_id"]), str(item["timestamp_utc"])))
+
+    source_provenance_digest = _stable_digest(
+        {
+            "entries": [
+                {
+                    "source_file": entry.source_file,
+                    "instrument_id": entry.instrument_id,
+                    "row_count_bound": entry.row_count_bound,
+                }
+                for entry in provenance_entries
+            ]
+        }
+    )
+    lifecycle_ref = "pit_futures_lifecycle_registry_v1:okx_production_lifecycle_v1"
+    lifecycle_digest = "0" * 64
+    source_reg = source_staging_root / "lifecycle" / "SOURCE_REGISTRATION.json"
+    if source_reg.is_file():
+        reg_payload = json.loads(source_reg.read_text(encoding="utf-8"))
+        lifecycle_digest = str(reg_payload.get("source_snapshot_digest", lifecycle_digest))
+
+    manifest_obj = build_panel_dataset_manifest_v1(
+        series_list=panel_series,
+        lifecycle_registry_ref=lifecycle_ref,
+        lifecycle_registry_digest=lifecycle_digest,
+        period_start_utc=period_start,
+        period_end_utc=period_end,
+        config_digest=_stable_digest({"period_binding_id": period["period_binding_id"]}),
+        source_provenance_digest=source_provenance_digest,
+    )
+    manifest_dict = panel_manifest_to_dict(manifest_obj)
+    manifest_dict["panel_id"] = PANEL_DATASET_ID
+    manifest_dict["dataset_version"] = PANEL_DATASET_VERSION
+    manifest_dict["bar_granularity"] = BAR_GRANULARITY
+
+    (panel_dir / "normalized_panel_bars.json").write_text(
+        json.dumps(rows, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (panel_dir / "panel_dataset_manifest.json").write_text(
+        json.dumps(manifest_dict, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_staging_root / "SOURCE_PROVENANCE.json").write_text(
+        json.dumps(
+            {
+                "materialization_version": MATERIALIZATION_VERSION,
+                "implementation_digest": compute_implementation_digest(),
+                "source_staging_root": str(source_staging_root),
+                "entries": [
+                    {
+                        "source_file": entry.source_file,
+                        "native_instrument_id": entry.native_instrument_id,
+                        "instrument_id": entry.instrument_id,
+                        "row_count_raw": entry.row_count_raw,
+                        "row_count_bound": entry.row_count_bound,
+                        "first_timestamp_utc": entry.first_timestamp_utc,
+                        "last_timestamp_utc": entry.last_timestamp_utc,
+                    }
+                    for entry in provenance_entries
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    data_start = min(bar.timestamp_utc for series in panel_series for bar in series.bars)
+    data_end = max(bar.timestamp_utc for series in panel_series for bar in series.bars)
+    return BoundPeriodPanelSourceMaterializationResultV1(
+        status=BoundPeriodSourceMaterializationStatus.MATERIALIZED,
+        output_staging_root=str(output_staging_root),
+        source_staging_root=str(source_staging_root),
+        period_start_utc=period_start,
+        period_end_utc=period_end,
+        instrument_count=len(panel_series),
+        row_count_total=sum(len(s.bars) for s in panel_series),
+        data_start_time=data_start,
+        data_end_time=data_end,
+        source_provenance=tuple(provenance_entries),
+        reason_codes=(),
+    )
+
+
+def bound_period_source_result_to_dict(
+    result: BoundPeriodPanelSourceMaterializationResultV1,
+) -> dict[str, object]:
+    return {
+        "materialization_version": MATERIALIZATION_VERSION,
+        "status": result.status.value,
+        "output_staging_root": result.output_staging_root,
+        "source_staging_root": result.source_staging_root,
+        "period_start_utc": result.period_start_utc,
+        "period_end_utc": result.period_end_utc,
+        "instrument_count": result.instrument_count,
+        "row_count_total": result.row_count_total,
+        "data_start_time": result.data_start_time,
+        "data_end_time": result.data_end_time,
+        "source_provenance_count": len(result.source_provenance),
+        "reason_codes": list(result.reason_codes),
+    }

--- a/src/research/cross_sectional_panel_staging_source_manifest_v1.py
+++ b/src/research/cross_sectional_panel_staging_source_manifest_v1.py
@@ -1,0 +1,198 @@
+"""Source manifest generation and verification for cross-sectional panel staging v1.
+
+Deterministic MANIFEST.sha256 for staging, panel, and lifecycle roots.
+Research-only; no runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_PANEL_STAGING_SOURCE_MANIFEST_V1=true"
+MANIFEST_VERSION = "cross_sectional_panel_staging_source_manifest.v1"
+MANIFEST_FILENAME = "MANIFEST.sha256"
+
+REASON_MISSING_PANEL_DIR = "MISSING_PANEL_DIR"
+REASON_MISSING_LIFECYCLE_DIR = "MISSING_LIFECYCLE_DIR"
+REASON_MANIFEST_VERIFY_FAILED = "MANIFEST_VERIFY_FAILED"
+
+
+class SourceManifestStatus(str, Enum):
+    VERIFIED = "VERIFIED"
+    FAIL_CLOSED = "FAIL_CLOSED"
+
+
+@dataclass(frozen=True)
+class SubdirectoryManifestResultV1:
+    root_name: str
+    root_path: str
+    manifest_written: bool
+    manifest_verify_rc: int
+    file_count: int
+
+
+@dataclass(frozen=True)
+class SourceManifestMaterializationResultV1:
+    status: SourceManifestStatus
+    staging_root: str
+    staging_manifest: SubdirectoryManifestResultV1
+    panel_manifest: SubdirectoryManifestResultV1
+    lifecycle_manifest: SubdirectoryManifestResultV1
+    combined_verify_rc: int
+    reason_codes: tuple[str, ...]
+
+
+def _write_manifest_sha256(root: Path) -> int:
+    lines: list[str] = []
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        if path.name == MANIFEST_FILENAME:
+            continue
+        rel = path.relative_to(root).as_posix()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        lines.append(f"{digest}  {rel}")
+    manifest = root / MANIFEST_FILENAME
+    manifest.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return len(lines)
+
+
+def verify_manifest_sha256(root: Path) -> tuple[bool, str]:
+    manifest = root / MANIFEST_FILENAME
+    if not manifest.is_file():
+        return False, "MANIFEST.sha256 missing"
+    for raw in manifest.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            return False, f"invalid manifest line: {line!r}"
+        digest, rel = parts
+        path = root / rel
+        if not path.is_file():
+            return False, f"missing manifest entry: {rel}"
+        actual = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual != digest:
+            return False, f"checksum mismatch: {rel}"
+    return True, ""
+
+
+def materialize_subdirectory_manifest_v1(
+    root: Path, *, root_name: str
+) -> SubdirectoryManifestResultV1:
+    file_count = _write_manifest_sha256(root)
+    verify_ok, _ = verify_manifest_sha256(root)
+    return SubdirectoryManifestResultV1(
+        root_name=root_name,
+        root_path=str(root),
+        manifest_written=True,
+        manifest_verify_rc=0 if verify_ok else 1,
+        file_count=file_count,
+    )
+
+
+def materialize_panel_staging_source_manifests_v1(
+    staging_root: Path,
+) -> SourceManifestMaterializationResultV1:
+    """Write and verify MANIFEST.sha256 for staging, panel, and lifecycle roots."""
+    staging_root = staging_root.resolve()
+    reasons: list[str] = []
+    panel_dir = staging_root / "panel"
+    lifecycle_dir = staging_root / "lifecycle"
+
+    if not panel_dir.is_dir():
+        reasons.append(REASON_MISSING_PANEL_DIR)
+    if not lifecycle_dir.is_dir():
+        reasons.append(REASON_MISSING_LIFECYCLE_DIR)
+
+    if reasons:
+        empty = SubdirectoryManifestResultV1(
+            root_name="",
+            root_path="",
+            manifest_written=False,
+            manifest_verify_rc=1,
+            file_count=0,
+        )
+        return SourceManifestMaterializationResultV1(
+            status=SourceManifestStatus.FAIL_CLOSED,
+            staging_root=str(staging_root),
+            staging_manifest=empty,
+            panel_manifest=empty,
+            lifecycle_manifest=empty,
+            combined_verify_rc=1,
+            reason_codes=tuple(reasons),
+        )
+
+    panel_result = materialize_subdirectory_manifest_v1(panel_dir, root_name="panel")
+    lifecycle_result = materialize_subdirectory_manifest_v1(lifecycle_dir, root_name="lifecycle")
+    staging_result = materialize_subdirectory_manifest_v1(staging_root, root_name="staging")
+
+    verify_results = (
+        panel_result.manifest_verify_rc,
+        lifecycle_result.manifest_verify_rc,
+        staging_result.manifest_verify_rc,
+    )
+    if any(rc != 0 for rc in verify_results):
+        reasons.append(REASON_MANIFEST_VERIFY_FAILED)
+
+    combined_rc = 0 if not reasons else 1
+    return SourceManifestMaterializationResultV1(
+        status=SourceManifestStatus.VERIFIED
+        if combined_rc == 0
+        else SourceManifestStatus.FAIL_CLOSED,
+        staging_root=str(staging_root),
+        staging_manifest=staging_result,
+        panel_manifest=panel_result,
+        lifecycle_manifest=lifecycle_result,
+        combined_verify_rc=combined_rc,
+        reason_codes=tuple(reasons),
+    )
+
+
+def verify_panel_staging_source_manifests_v1(
+    staging_root: Path,
+) -> tuple[bool, int, tuple[str, ...]]:
+    """Verify existing manifests without rewriting. Returns (ok, rc, reason_codes)."""
+    staging_root = staging_root.resolve()
+    reasons: list[str] = []
+    for subdir in ("panel", "lifecycle"):
+        path = staging_root / subdir
+        if not path.is_dir():
+            reasons.append(f"MISSING_{subdir.upper()}_DIR")
+            continue
+        ok, msg = verify_manifest_sha256(path)
+        if not ok:
+            reasons.append(f"{subdir}:{msg}")
+
+    ok_staging, msg_staging = verify_manifest_sha256(staging_root)
+    if not ok_staging:
+        reasons.append(f"staging:{msg_staging}")
+
+    rc = 0 if not reasons else 1
+    return rc == 0, rc, tuple(reasons)
+
+
+def source_manifest_result_to_dict(
+    result: SourceManifestMaterializationResultV1,
+) -> dict[str, object]:
+    def _sub(item: SubdirectoryManifestResultV1) -> dict[str, object]:
+        return {
+            "root_name": item.root_name,
+            "root_path": item.root_path,
+            "manifest_written": item.manifest_written,
+            "manifest_verify_rc": item.manifest_verify_rc,
+            "file_count": item.file_count,
+        }
+
+    return {
+        "manifest_version": MANIFEST_VERSION,
+        "status": result.status.value,
+        "staging_root": result.staging_root,
+        "staging_manifest": _sub(result.staging_manifest),
+        "panel_manifest": _sub(result.panel_manifest),
+        "lifecycle_manifest": _sub(result.lifecycle_manifest),
+        "combined_verify_rc": result.combined_verify_rc,
+        "reason_codes": list(result.reason_codes),
+    }

--- a/src/research/cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v0.py
@@ -19,6 +19,16 @@ from src.research.cross_sectional_panel_economic_evaluation_wiring_v0 import (
     robustness_results_to_dict,
     wire_robustness_stages_v0,
 )
+from src.research.cross_sectional_panel_robustness_adapter_v0 import (
+    build_economic_viability_evidence_adapter_input_v0,
+    build_monte_carlo_adapter_input_v0,
+    build_parameter_sensitivity_adapter_input_v0,
+    build_stress_adapter_input_v0,
+    build_walk_forward_adapter_input_v0,
+)
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (
+    verify_panel_staging_source_manifests_v1,
+)
 from src.research.cross_sectional_ranking_semantics_binding_validator_v0 import (
     ValidationVerdict,
     validate_cross_sectional_ranking_semantics_binding_v0,
@@ -64,10 +74,30 @@ GO_TOKEN = (
 )
 INFRASTRUCTURE_GO_TOKEN = (
     "GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_"
+    "INFRASTRUCTURE_COMPLETION_V1"
+)
+INFRASTRUCTURE_GO_TOKEN_V0 = (
+    "GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_"
     "EXECUTION_INFRASTRUCTURE_COMPLETION_V0"
 )
-EXPECTED_ORIGIN_MAIN_SHA = "ce59011e1ba5057ad4cfc53b6c7bb115456f67cd"
+EXPECTED_ORIGIN_MAIN_SHA = "5aceb416c02815cb6082b88e60e9a0df320d968f"
 CONFIG_REL_PATH_OPS = "config/ops/cross_sectional_relative_strength_v0_economic_evaluation_v1.json"
+
+ALLOWED_EVALUATION_STAGES: tuple[str, ...] = (
+    "OFFLINE_BACKTEST",
+    "WALK_FORWARD",
+    "MONTE_CARLO",
+    "STRESS",
+    "PARAMETER_SENSITIVITY",
+    "ECONOMIC_VIABILITY_EVIDENCE_MATERIALIZATION",
+)
+
+RUNNER_OWNER = (
+    "scripts.ops.run_cross_sectional_relative_strength_v0_offline_economic_evaluation_dry_run_v0"
+)
+RUNNER_SCRIPT = (
+    "scripts/ops/run_cross_sectional_relative_strength_v0_offline_economic_evaluation_dry_run_v0.py"
+)
 
 REASON_BINDING_INCOMPLETE = "BINDING_INCOMPLETE"
 REASON_RATIFICATION_INVALID = "RATIFICATION_INVALID"
@@ -75,6 +105,12 @@ REASON_DATASET_UNAVAILABLE = "BOUND_DATA_UNAVAILABLE"
 REASON_DATASET_PERIOD_MISMATCH = "DATASET_PERIOD_MISMATCH"
 REASON_FOREIGN_DATASET = "FOREIGN_DATASET_REJECTED"
 REASON_INFRASTRUCTURE_INCOMPLETE = "EXECUTION_INFRASTRUCTURE_INCOMPLETE"
+REASON_SOURCE_MANIFEST_MISSING = "SOURCE_MANIFEST_MISSING"
+REASON_SOURCE_MANIFEST_VERIFY_FAILED = "SOURCE_MANIFEST_VERIFY_FAILED"
+REASON_DATA_DIGEST_NULL = "DATA_DIGEST_NULL"
+REASON_PARAMETER_SEARCH_FORBIDDEN_VIOLATION = "PARAMETER_SEARCH_FORBIDDEN_VIOLATION"
+REASON_GO_TOKEN_INVALID = "GO_TOKEN_INVALID"
+REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED = "ECONOMIC_EVALUATION_NOT_AUTHORIZED"
 
 
 class InfrastructureTerminalStatus(str, Enum):
@@ -287,3 +323,245 @@ def verify_foreign_dataset_rejected_v0(
     if result.status is MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE:
         return False, ("FOREIGN_DATASET_NOT_REJECTED",)
     return True, result.reason_codes
+
+
+class EvaluationEntrypointTerminalStatus(str, Enum):
+    ENTRYPOINT_READY_DRY_RUN_STOPPED = "ENTRYPOINT_READY_DRY_RUN_STOPPED"
+    FAIL_CLOSED_PRECHECK = "FAIL_CLOSED_PRECHECK"
+    FAIL_CLOSED_BOUND_DATA_UNAVAILABLE = "FAIL_CLOSED_BOUND_DATA_UNAVAILABLE"
+
+
+@dataclass(frozen=True)
+class StageWiringStatusV1:
+    stage_name: str
+    wired: bool
+    owner: str
+
+
+@dataclass(frozen=True)
+class FullEvaluationEntrypointResultV1:
+    status: EvaluationEntrypointTerminalStatus
+    precheck_passed: bool
+    source_manifests_verified: bool
+    bound_dataset_materialized: bool
+    dataset_period_match: bool
+    panel_data_digest: str
+    stage_wiring: tuple[StageWiringStatusV1, ...]
+    dry_run_stopped_before_execution: bool
+    economic_evaluation_executed: bool
+    reason_codes: tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+
+
+def verify_full_evaluation_precheck_v1(
+    *,
+    repo_root: Path,
+    ratification: Mapping[str, Any],
+    staging_root: Path,
+    versioned_binding: Mapping[str, Any] | None = None,
+    go_token: str | None = None,
+    require_execution_go: bool = False,
+) -> tuple[bool, tuple[str, ...], Any]:
+    """Fail-closed precheck before any economic evaluation stage."""
+    reasons: list[str] = []
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    ops_cfg = load_ops_evaluation_config_v0(repo_root)
+
+    start_state = verify_execution_start_state_v0(
+        repo_root=repo_root,
+        ratification=ratification,
+        versioned_binding=envelope,
+    )
+    if not start_state.valid:
+        reasons.extend(start_state.fail_reasons)
+
+    if envelope.get("parameter_binding", {}).get("parameter_search_forbidden") is not True:
+        reasons.append(REASON_PARAMETER_SEARCH_FORBIDDEN_VIOLATION)
+
+    if require_execution_go:
+        if go_token != GO_TOKEN:
+            reasons.append(REASON_GO_TOKEN_INVALID)
+    else:
+        if go_token not in {INFRASTRUCTURE_GO_TOKEN, INFRASTRUCTURE_GO_TOKEN_V0, GO_TOKEN}:
+            reasons.append(REASON_GO_TOKEN_INVALID)
+
+    manifest_ok, manifest_rc, manifest_reasons = verify_panel_staging_source_manifests_v1(
+        staging_root
+    )
+    if not manifest_ok:
+        if any("missing" in item.lower() for item in manifest_reasons):
+            reasons.append(REASON_SOURCE_MANIFEST_MISSING)
+        else:
+            reasons.append(REASON_SOURCE_MANIFEST_VERIFY_FAILED)
+        reasons.extend(manifest_reasons)
+    if manifest_rc != 0:
+        reasons.append(REASON_SOURCE_MANIFEST_VERIFY_FAILED)
+
+    period_binding = envelope["period_binding"]
+    materialization = materialize_bound_panel_dataset_v0(
+        staging_root,
+        period_binding=period_binding,
+    )
+    if materialization.status is not MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE:
+        reasons.extend(materialization.reason_codes)
+        reasons.append(REASON_DATASET_UNAVAILABLE)
+    elif materialization.panel_data_digest == "0" * 64:
+        reasons.append(REASON_DATA_DIGEST_NULL)
+    elif not materialization.idempotent_digest_stable:
+        reasons.append("DATA_DIGEST_NOT_IDEMPOTENT")
+
+    expected_data_digest = str(
+        ops_cfg.get("cross_sectional_evaluation_binding_v1", {}).get("data_contract_digest", "")
+    )
+    if expected_data_digest and materialization.panel_data_digest not in {
+        expected_data_digest,
+        materialization.panel_data_digest,
+    }:
+        # Contract digest differs from semantic panel digest by design; only reject null digest.
+        pass
+
+    return not reasons, tuple(reasons), materialization
+
+
+def build_stage_wiring_status_v1(
+    *,
+    orchestrator_result: Any,
+    economic_policy_binding: Mapping[str, Any],
+) -> tuple[StageWiringStatusV1, ...]:
+    return (
+        StageWiringStatusV1(
+            stage_name="OFFLINE_BACKTEST",
+            wired=True,
+            owner="cross_sectional_single_slot_backtest_wiring_v0",
+        ),
+        StageWiringStatusV1(
+            stage_name="WALK_FORWARD",
+            wired=True,
+            owner="cross_sectional_panel_economic_evaluation_wiring_v0",
+        ),
+        StageWiringStatusV1(
+            stage_name="MONTE_CARLO",
+            wired=True,
+            owner="src.experiments.monte_carlo",
+        ),
+        StageWiringStatusV1(
+            stage_name="STRESS",
+            wired=True,
+            owner="src.experiments.stress_tests",
+        ),
+        StageWiringStatusV1(
+            stage_name="PARAMETER_SENSITIVITY",
+            wired=True,
+            owner="cross_sectional_panel_robustness_adapter_v0",
+        ),
+        StageWiringStatusV1(
+            stage_name="ECONOMIC_VIABILITY_EVIDENCE_MATERIALIZATION",
+            wired=True,
+            owner="src.backtest.economic_viability_evidence_v1",
+        ),
+    )
+
+
+def run_full_evaluation_entrypoint_dry_run_v1(
+    *,
+    repo_root: Path,
+    ratification: Mapping[str, Any],
+    staging_root: Path,
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    versioned_binding: Mapping[str, Any] | None = None,
+    go_token: str = INFRASTRUCTURE_GO_TOKEN,
+) -> FullEvaluationEntrypointResultV1:
+    """Validate full evaluation entrypoint wiring; stop before economic classification."""
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    precheck_ok, precheck_reasons, materialization = verify_full_evaluation_precheck_v1(
+        repo_root=repo_root,
+        ratification=ratification,
+        staging_root=staging_root,
+        versioned_binding=envelope,
+        go_token=go_token,
+        require_execution_go=False,
+    )
+
+    manifest_ok, _, _ = verify_panel_staging_source_manifests_v1(staging_root)
+
+    if not precheck_ok:
+        return FullEvaluationEntrypointResultV1(
+            status=EvaluationEntrypointTerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=False,
+            source_manifests_verified=manifest_ok,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest=getattr(materialization, "panel_data_digest", "0" * 64),
+            stage_wiring=(),
+            dry_run_stopped_before_execution=True,
+            economic_evaluation_executed=False,
+            reason_codes=precheck_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    binding = default_operator_binding_v0()
+    orchestrator = run_cross_sectional_single_slot_orchestrator_v0(
+        binding=binding,
+        panel_series=panel_series,
+    )
+    _ = build_walk_forward_adapter_input_v0(
+        orchestrator, economic_policy_binding=envelope["economic_policy_binding"]
+    )
+    _ = build_monte_carlo_adapter_input_v0(
+        orchestrator, economic_policy_binding=envelope["economic_policy_binding"]
+    )
+    _ = build_stress_adapter_input_v0(
+        orchestrator, economic_policy_binding=envelope["economic_policy_binding"]
+    )
+    _ = build_parameter_sensitivity_adapter_input_v0(
+        economic_policy_binding=envelope["economic_policy_binding"],
+    )
+    _ = build_economic_viability_evidence_adapter_input_v0(
+        orchestrator,
+        economic_policy_binding=envelope["economic_policy_binding"],
+    )
+
+    stage_wiring = build_stage_wiring_status_v1(
+        orchestrator_result=orchestrator,
+        economic_policy_binding=envelope["economic_policy_binding"],
+    )
+
+    return FullEvaluationEntrypointResultV1(
+        status=EvaluationEntrypointTerminalStatus.ENTRYPOINT_READY_DRY_RUN_STOPPED,
+        precheck_passed=True,
+        source_manifests_verified=manifest_ok,
+        bound_dataset_materialized=True,
+        dataset_period_match=True,
+        panel_data_digest=materialization.panel_data_digest,
+        stage_wiring=stage_wiring,
+        dry_run_stopped_before_execution=True,
+        economic_evaluation_executed=False,
+        reason_codes=(),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def entrypoint_result_to_dict(result: FullEvaluationEntrypointResultV1) -> dict[str, Any]:
+    return {
+        "status": result.status.value,
+        "precheck_passed": result.precheck_passed,
+        "source_manifests_verified": result.source_manifests_verified,
+        "bound_dataset_materialized": result.bound_dataset_materialized,
+        "dataset_period_match": result.dataset_period_match,
+        "panel_data_digest": result.panel_data_digest,
+        "stage_wiring": [
+            {"stage_name": item.stage_name, "wired": item.wired, "owner": item.owner}
+            for item in result.stage_wiring
+        ],
+        "allowed_evaluation_stages": list(ALLOWED_EVALUATION_STAGES),
+        "dry_run_stopped_before_execution": result.dry_run_stopped_before_execution,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "reason_codes": list(result.reason_codes),
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+        "runner_owner": RUNNER_OWNER,
+        "runner_script": RUNNER_SCRIPT,
+    }

--- a/tests/research/test_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_infrastructure_v0.py
+++ b/tests/research/test_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_infrastructure_v0.py
@@ -77,13 +77,22 @@ def fixture_scope_ratification(complete_binding: dict) -> dict:
 @pytest.fixture(name="bound_staging")
 def fixture_bound_staging() -> Path:
     tmp = Path(tempfile.mkdtemp(prefix="cs_rs_bound_staging_"))
-    return write_bound_period_staging_v0(tmp)
+    staging = write_bound_period_staging_v0(tmp)
+    lifecycle = staging / "lifecycle"
+    lifecycle.mkdir(parents=True, exist_ok=True)
+    lifecycle.joinpath("SOURCE_REGISTRATION.json").write_text(
+        '{"source_snapshot_ref":"test:fixture","source_snapshot_digest":"'
+        + "a" * 64
+        + '","registered":true}\n',
+        encoding="utf-8",
+    )
+    return staging
 
 
 def test_infrastructure_go_token_constant() -> None:
     assert (
         INFRASTRUCTURE_GO_TOKEN
-        == "GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_COMPLETION_V0"
+        == "GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_INFRASTRUCTURE_COMPLETION_V1"
     )
 
 
@@ -281,7 +290,7 @@ def test_infrastructure_summary_flags_no_economic_evaluation(
     summary = materialize_infrastructure_summary_v0(
         ratification=scope_ratification,
         readiness=readiness,
-        origin_main_sha="ce59011e1ba5057ad4cfc53b6c7bb115456f67cd",
+        origin_main_sha="5aceb416c02815cb6082b88e60e9a0df320d968f",
         execution_bundle_dir="/tmp/cs_rs_infra",
     )
     assert summary["economic_evaluation_executed"] is False

--- a/tests/research/test_cross_sectional_relative_strength_v0_offline_economic_evaluation_infrastructure_completion_v1.py
+++ b/tests/research/test_cross_sectional_relative_strength_v0_offline_economic_evaluation_infrastructure_completion_v1.py
@@ -1,0 +1,246 @@
+"""Contract tests for cross-sectional infrastructure completion v1."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.research.cross_sectional_bound_period_panel_source_materialization_v1 import (
+    BoundPeriodSourceMaterializationStatus,
+    materialize_bound_period_panel_from_raw_sources_v1,
+    parse_native_instrument_id_from_raw_filename,
+)
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (
+    SourceManifestStatus,
+    materialize_panel_staging_source_manifests_v1,
+    verify_panel_staging_source_manifests_v1,
+)
+from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (
+    MaterializationTerminalStatus,
+    materialize_bound_panel_dataset_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v0 import (
+    ALLOWED_EVALUATION_STAGES,
+    INFRASTRUCTURE_GO_TOKEN,
+    RUNNER_SCRIPT,
+    EvaluationEntrypointTerminalStatus,
+    run_full_evaluation_entrypoint_dry_run_v1,
+    verify_full_evaluation_precheck_v1,
+)
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_scope_ratification_v0 import (
+    materialize_cross_sectional_offline_economic_evaluation_scope_ratification_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_versioned_research_binding_v0 import (
+    materialize_versioned_research_binding_v0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.fixture_builder import (
+    build_synthetic_panel_series_v0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.staging_builder import (
+    write_bound_period_staging_v0,
+    write_foreign_2026_staging_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+FOREIGN_SOURCE_ROOT = (
+    ARCHIVE_ROOT / "datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_pt1h_panel/v1"
+)
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_research_binding_v0()
+
+
+@pytest.fixture(name="scope_ratification")
+def fixture_scope_ratification(complete_binding: dict) -> dict:
+    return materialize_cross_sectional_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=REPO_ROOT,
+        versioned_binding=complete_binding,
+    )
+
+
+@pytest.fixture(name="bound_staging")
+def fixture_bound_staging() -> Path:
+    tmp = Path(tempfile.mkdtemp(prefix="cs_rs_bound_staging_v1_"))
+    staging = write_bound_period_staging_v0(tmp)
+    lifecycle = staging / "lifecycle"
+    lifecycle.mkdir(parents=True, exist_ok=True)
+    (lifecycle / "SOURCE_REGISTRATION.json").write_text(
+        json.dumps(
+            {
+                "source_snapshot_ref": "test:fixture",
+                "source_snapshot_digest": "a" * 64,
+                "registered": True,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_result = materialize_panel_staging_source_manifests_v1(staging)
+    assert manifest_result.status is SourceManifestStatus.VERIFIED
+    return staging
+
+
+def test_infrastructure_go_token_v1_constant() -> None:
+    assert (
+        INFRASTRUCTURE_GO_TOKEN
+        == "GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_INFRASTRUCTURE_COMPLETION_V1"
+    )
+
+
+def test_parse_native_instrument_id_from_raw_filename() -> None:
+    assert (
+        parse_native_instrument_id_from_raw_filename("ohlcv_eth_usdt_swap_p0000_abc.json")
+        == "ETH-USDT-SWAP"
+    )
+
+
+def test_source_manifest_generation_and_verify(bound_staging: Path) -> None:
+    ok, rc, reasons = verify_panel_staging_source_manifests_v1(bound_staging)
+    assert ok is True
+    assert rc == 0
+    assert reasons == ()
+    assert (bound_staging / "MANIFEST.sha256").is_file()
+    assert (bound_staging / "panel" / "MANIFEST.sha256").is_file()
+    assert (bound_staging / "lifecycle" / "MANIFEST.sha256").is_file()
+
+
+def test_bound_period_materialization_from_archive_raw_fail_closed(
+    complete_binding: dict,
+) -> None:
+    if not FOREIGN_SOURCE_ROOT.is_dir():
+        pytest.skip("foreign source archive not present")
+    with tempfile.TemporaryDirectory() as tmp:
+        output = Path(tmp) / "bound_output"
+        result = materialize_bound_period_panel_from_raw_sources_v1(
+            FOREIGN_SOURCE_ROOT,
+            output,
+            period_binding=complete_binding["period_binding"],
+        )
+        assert (
+            result.status
+            is BoundPeriodSourceMaterializationStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED
+        )
+        assert "FOREIGN_DATASET_PERIOD_REJECTED" in result.reason_codes or (
+            "BOUND_PERIOD_SOURCE_DATA_UNAVAILABLE" in result.reason_codes
+        )
+
+
+def test_foreign_panel_rejected_after_manifests(complete_binding: dict) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        foreign = write_foreign_2026_staging_v0(Path(tmp) / "foreign")
+        materialize_panel_staging_source_manifests_v1(foreign)
+        result = materialize_bound_panel_dataset_v0(
+            foreign,
+            period_binding=complete_binding["period_binding"],
+        )
+        assert result.status is MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED
+
+
+def test_full_precheck_passes_with_bound_staging(
+    bound_staging: Path,
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    ok, reasons, materialization = verify_full_evaluation_precheck_v1(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        staging_root=bound_staging,
+        versioned_binding=complete_binding,
+        go_token=INFRASTRUCTURE_GO_TOKEN,
+    )
+    assert ok is True, reasons
+    assert materialization.status is MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE
+    assert materialization.panel_data_digest != "0" * 64
+
+
+def test_full_evaluation_entrypoint_dry_run_stops_before_execution(
+    bound_staging: Path,
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    panel = build_synthetic_panel_series_v0()
+    result = run_full_evaluation_entrypoint_dry_run_v1(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        staging_root=bound_staging,
+        panel_series=panel,
+        versioned_binding=complete_binding,
+        go_token=INFRASTRUCTURE_GO_TOKEN,
+    )
+    assert result.status is EvaluationEntrypointTerminalStatus.ENTRYPOINT_READY_DRY_RUN_STOPPED
+    assert result.dry_run_stopped_before_execution is True
+    assert result.economic_evaluation_executed is False
+    assert len(result.stage_wiring) == len(ALLOWED_EVALUATION_STAGES)
+    assert all(item.wired for item in result.stage_wiring)
+
+
+def test_precheck_fails_without_manifests(
+    complete_binding: dict,
+    scope_ratification: dict,
+) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        staging = write_bound_period_staging_v0(Path(tmp))
+        ok, reasons, _ = verify_full_evaluation_precheck_v1(
+            repo_root=REPO_ROOT,
+            ratification=scope_ratification,
+            staging_root=staging,
+            versioned_binding=complete_binding,
+            go_token=INFRASTRUCTURE_GO_TOKEN,
+        )
+        assert ok is False
+        assert any("SOURCE_MANIFEST" in reason for reason in reasons)
+
+
+def test_economic_evaluation_not_executed_regression(
+    bound_staging: Path,
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    panel = build_synthetic_panel_series_v0()
+    result = run_full_evaluation_entrypoint_dry_run_v1(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        staging_root=bound_staging,
+        panel_series=panel,
+        versioned_binding=complete_binding,
+    )
+    assert result.economic_evaluation_executed is False
+
+
+def test_runner_script_exists() -> None:
+    assert (REPO_ROOT / RUNNER_SCRIPT).is_file()
+
+
+def test_allowed_evaluation_stages_complete() -> None:
+    assert ALLOWED_EVALUATION_STAGES == (
+        "OFFLINE_BACKTEST",
+        "WALK_FORWARD",
+        "MONTE_CARLO",
+        "STRESS",
+        "PARAMETER_SENSITIVITY",
+        "ECONOMIC_VIABILITY_EVIDENCE_MATERIALIZATION",
+    )
+
+
+def test_bound_staging_dataset_digest_deterministic(
+    bound_staging: Path,
+    complete_binding: dict,
+) -> None:
+    first = materialize_bound_panel_dataset_v0(
+        bound_staging,
+        period_binding=complete_binding["period_binding"],
+    )
+    second = materialize_bound_panel_dataset_v0(
+        bound_staging,
+        period_binding=complete_binding["period_binding"],
+    )
+    assert first.panel_data_digest == second.panel_data_digest
+    assert first.idempotent_digest_stable is True


### PR DESCRIPTION
## Summary

- Add bound-period panel source materialization from offline raw OHLCV sources with fail-closed foreign-panel rejection.
- Add deterministic source manifests (`MANIFEST.sha256`) for staging, panel, and lifecycle roots.
- Wire full offline evaluation entrypoint with fail-closed prechecks and dry-run stage orchestration (no economic evaluation execution).

## Test plan

- [x] `pytest tests/research/test_cross_sectional_relative_strength_v0_offline_economic_evaluation_infrastructure_completion_v1.py`
- [x] `pytest tests/research/test_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_infrastructure_v0.py`
- [x] `ruff format --check` and `ruff check` on changed Python files
- [x] `git diff --check`
- [x] Durable evidence bundle with `MANIFEST_VERIFY_RC=0`

## Notes

- Archive raw PT1H sources remain 2026-only; bound 2024 panel materialization correctly fails closed until historical sources are available.
- `ECONOMIC_EVALUATION_EXECUTED=false`; no runtime/order/authority effect.


Made with [Cursor](https://cursor.com)