### PR TITLE
feat(research): cross-sectional offline economic evaluation execution v2

### DIFF
--- a/scripts/ops/fetch_cross_sectional_bound_period_historical_pt1h_sources_v0.py
+++ b/scripts/ops/fetch_cross_sectional_bound_period_historical_pt1h_sources_v0.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Fetch bound-period historical OKX PT1H futures sources for cross-sectional v0.
+
+Read-only public GET to OKX v5 allowlist. No auth, no orders, no runtime effect.
+Operator GO: GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V2
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+CONFIRM_TOKEN = (
+    "GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V2"
+)
+
+BOUND_WARMUP_START_UTC = "2024-05-25T00:00:00Z"
+BOUND_PERIOD_END_UTC = "2024-06-01T01:00:00Z"
+ACQUISITION_SOURCE = "okx_public_rest_history_candles_v5"
+BAR_GRANULARITY = "PT1H"
+
+
+def _load_materialize_okx_module() -> Any:
+    script = _REPO_ROOT / "scripts/ops/materialize_okx_production_lifecycle_and_pt1h_panel_v1.py"
+    spec = importlib.util.spec_from_file_location("materialize_okx_pt1h_panel_v1", script)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _utc_to_ms(value: str) -> int:
+    dt = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def run_historical_fetch(
+    *,
+    confirm: str,
+    target_staging_root: Path,
+    durable_evidence_root: Path,
+    period_start_utc: str = BOUND_WARMUP_START_UTC,
+    period_end_utc: str = BOUND_PERIOD_END_UTC,
+    timeout_seconds: float = 15.0,
+    max_response_bytes: int = 50_000_000,
+    fetcher: Callable[..., tuple[int, bytes, dict[str, str]]] | None = None,
+) -> dict[str, Any]:
+    if confirm != CONFIRM_TOKEN:
+        _die(f"ERR: confirm_go_token_required:{CONFIRM_TOKEN}")
+    if target_staging_root.exists():
+        _die(f"ERR: target_staging_root_exists:{target_staging_root}")
+
+    okx_mod = _load_materialize_okx_module()._load_okx_ingest_module()
+    mat_mod = _load_materialize_okx_module()
+    fetcher = fetcher or okx_mod.okx_public_fetch_v1
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    tmp_root = target_staging_root.parent / f".tmp_historical_{ts_slug}"
+    raw_dir = tmp_root / "raw"
+    lifecycle_dir = tmp_root / "lifecycle"
+    panel_dir = tmp_root / "panel"
+    reports_dir = tmp_root / "reports"
+    for path in (raw_dir, lifecycle_dir, panel_dir, reports_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    retrieval_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    source_snapshot_ref = (
+        f"okx_public_historical_pt1h:{period_start_utc}:{period_end_utc}:{ts_slug}"
+    )
+    start_ms = _utc_to_ms(period_start_utc)
+    end_ms = _utc_to_ms(period_end_utc)
+
+    rate_limiter = okx_mod.RateLimiter()
+    instruments = mat_mod.fetch_all_swap_instruments(
+        okx_mod,
+        fetcher=fetcher,
+        rate_limiter=rate_limiter,
+        timeout_seconds=timeout_seconds,
+        max_response_bytes=max_response_bytes,
+        raw_dir=raw_dir,
+    )
+
+    from src.research.okx_production_instrument_lifecycle_source_v1 import (
+        MIN_ELIGIBLE_INSTRUMENT_COUNT,
+        SOURCE_ID,
+        build_okx_lifecycle_source_snapshot_v1,
+        build_lifecycle_source_observations_v1,
+    )
+    from src.research.pit_futures_instrument_lifecycle_registry_persistence_v1 import (
+        OverwritePolicy,
+        write_registry_snapshot_v1,
+    )
+    from src.research.pit_futures_instrument_lifecycle_registry_v1 import (
+        assemble_registry_snapshot_v1,
+        format_registry_reference_v1,
+    )
+    from src.research.pit_futures_instrument_lifecycle_registry_validator_v1 import (
+        ValidationVerdict,
+    )
+    from src.research.pit_futures_universe_manifest_v1 import compute_sha256_digest
+    from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import (
+        InstrumentPanelSeriesV1,
+        compute_series_digest,
+        validate_panel_series_v1,
+    )
+    from src.research.instrument_id_canonicalization_v1 import (
+        InstrumentIdCanonicalizationInputV1,
+        canonicalize_instrument_id_v1,
+    )
+
+    lifecycle_snapshot_input = build_okx_lifecycle_source_snapshot_v1(
+        instruments,
+        retrieval_timestamp_utc=retrieval_ts,
+        source_snapshot_ref=source_snapshot_ref,
+    )
+    if len(lifecycle_snapshot_input.eligible_instruments) < MIN_ELIGIBLE_INSTRUMENT_COUNT:
+        _die(
+            "ERR: FAIL_CLOSED_INSUFFICIENT_ELIGIBLE_INSTRUMENTS:"
+            f"{len(lifecycle_snapshot_input.eligible_instruments)}"
+        )
+
+    config_digest = compute_sha256_digest(
+        {
+            "acquisition_source": ACQUISITION_SOURCE,
+            "bar_granularity": BAR_GRANULARITY,
+            "period_start_utc": period_start_utc,
+            "period_end_utc": period_end_utc,
+            "source_snapshot_ref": source_snapshot_ref,
+        }
+    )
+    observations = build_lifecycle_source_observations_v1(lifecycle_snapshot_input)
+    assembly = assemble_registry_snapshot_v1(
+        observations,
+        generated_at=retrieval_ts,
+        venue_scope=("okx",),
+        config_digest=config_digest,
+        implementation_digest=config_digest,
+        registered_sources=frozenset({SOURCE_ID}),
+        approved_snapshot_digests=frozenset({lifecycle_snapshot_input.raw_snapshot_digest}),
+    )
+    if not assembly.success or assembly.snapshot is None:
+        _die(f"ERR: lifecycle_registry_assembly_failed:{assembly.error_codes}")
+
+    validation = __import__(
+        "src.research.pit_futures_instrument_lifecycle_registry_validator_v1",
+        fromlist=["validate_pit_futures_instrument_lifecycle_registry_snapshot_v1"],
+    ).validate_pit_futures_instrument_lifecycle_registry_snapshot_v1(assembly.snapshot)
+    if validation.verdict is not ValidationVerdict.ACCEPTED:
+        _die(f"ERR: lifecycle_registry_validation_failed:{validation.error_codes}")
+
+    persist_result = write_registry_snapshot_v1(
+        assembly.snapshot,
+        root_dir=lifecycle_dir,
+        relative_path="registry_snapshot_v1.json",
+        overwrite_policy=OverwritePolicy.FAIL_IF_EXISTS,
+    )
+    if not persist_result.success:
+        _die(f"ERR: lifecycle_registry_persist_failed:{persist_result.error_codes}")
+
+    registry_ref = format_registry_reference_v1(
+        artifact_id="okx_production_lifecycle_v1",
+        registry_snapshot_digest=assembly.snapshot.registry_snapshot_digest,
+    )
+    (lifecycle_dir / "REGISTRY_REFERENCE.txt").write_text(registry_ref + "\n", encoding="utf-8")
+    (lifecycle_dir / "SOURCE_REGISTRATION.json").write_text(
+        json.dumps(
+            {
+                "production_lifecycle_source_id": SOURCE_ID,
+                "registered": True,
+                "source_snapshot_ref": source_snapshot_ref,
+                "source_snapshot_digest": lifecycle_snapshot_input.raw_snapshot_digest,
+                "acquisition_source": ACQUISITION_SOURCE,
+                "period_start_utc": period_start_utc,
+                "period_end_utc": period_end_utc,
+                "retrieval_timestamp_utc": retrieval_ts,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    panel_series: list[InstrumentPanelSeriesV1] = []
+    provenance_entries: list[dict[str, Any]] = []
+    for metadata in lifecycle_snapshot_input.eligible_instruments:
+        canon = canonicalize_instrument_id_v1(
+            InstrumentIdCanonicalizationInputV1(
+                venue_id="okx",
+                market_type="futures",
+                contract_type="linear_perpetual",
+                base_asset=metadata.base_asset,
+                quote_asset="USDT",
+                settlement_asset="USDT",
+                venue_symbol=metadata.inst_id,
+            )
+        )
+        if not canon.success or canon.instrument_id is None:
+            continue
+        rows = mat_mod.fetch_pt1h_candles_for_instrument(
+            okx_mod,
+            inst_id=metadata.inst_id,
+            fetcher=fetcher,
+            rate_limiter=rate_limiter,
+            timeout_seconds=timeout_seconds,
+            max_response_bytes=max_response_bytes,
+            raw_dir=raw_dir,
+            start_ms=start_ms,
+            end_ms=end_ms,
+        )
+        if not rows:
+            continue
+        bars = mat_mod.normalize_candles_to_panel_bars(canon.instrument_id, rows)
+        bound_bars = tuple(
+            bar
+            for bar in bars
+            if period_start_utc <= bar.timestamp_utc <= period_end_utc and bar.is_final
+        )
+        if not bound_bars:
+            continue
+        series = InstrumentPanelSeriesV1(
+            instrument_id=canon.instrument_id,
+            native_instrument_id=metadata.inst_id,
+            bars=bound_bars,
+            series_digest=compute_series_digest(
+                InstrumentPanelSeriesV1(
+                    instrument_id=canon.instrument_id,
+                    native_instrument_id=metadata.inst_id,
+                    bars=bound_bars,
+                    series_digest="0" * 64,
+                )
+            ),
+        )
+        panel_series.append(series)
+        provenance_entries.append(
+            {
+                "instrument_id": canon.instrument_id,
+                "native_instrument_id": metadata.inst_id,
+                "row_count_bound": len(bound_bars),
+                "first_timestamp_utc": bound_bars[0].timestamp_utc,
+                "last_timestamp_utc": bound_bars[-1].timestamp_utc,
+            }
+        )
+
+    if len(panel_series) < MIN_ELIGIBLE_INSTRUMENT_COUNT:
+        _die(f"ERR: FAIL_CLOSED_INSUFFICIENT_PANEL_MEMBERS:{len(panel_series)}")
+
+    panel_validation = validate_panel_series_v1(
+        tuple(panel_series),
+        min_instruments=MIN_ELIGIBLE_INSTRUMENT_COUNT,
+        generation_cutoff_utc=retrieval_ts,
+    )
+    if not panel_validation.valid:
+        _die(f"ERR: panel_validation_failed:{panel_validation.error_codes}")
+
+    normalized_rows = []
+    for series in panel_series:
+        for bar in series.bars:
+            normalized_rows.append(asdict(bar))
+    (panel_dir / "normalized_panel_bars.json").write_text(
+        json.dumps(normalized_rows, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (reports_dir / "SOURCE_PROVENANCE.json").write_text(
+        json.dumps(
+            {
+                "acquisition_source": ACQUISITION_SOURCE,
+                "period_start_utc": period_start_utc,
+                "period_end_utc": period_end_utc,
+                "retrieval_timestamp_utc": retrieval_ts,
+                "entries": provenance_entries,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (reports_dir / "PERIOD_BINDING.json").write_text(
+        json.dumps(
+            {
+                "bound_warmup_start_utc": period_start_utc,
+                "bound_period_end_utc": period_end_utc,
+                "bar_granularity": BAR_GRANULARITY,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    target_staging_root.parent.mkdir(parents=True, exist_ok=True)
+    tmp_root.rename(target_staging_root)
+
+    evidence_dir = (
+        durable_evidence_root
+        / "implementation"
+        / f"bounded_cross_sectional_historical_pt1h_source_fetch_v0_{ts_slug}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=False)
+    (evidence_dir / "FETCH_RESULT.json").write_text(
+        json.dumps(
+            {
+                "verdict": "HISTORICAL_SOURCE_FETCH_COMPLETE",
+                "target_staging_root": str(target_staging_root),
+                "period_start_utc": period_start_utc,
+                "period_end_utc": period_end_utc,
+                "instrument_count": len(panel_series),
+                "source_snapshot_ref": source_snapshot_ref,
+                "source_snapshot_digest": lifecycle_snapshot_input.raw_snapshot_digest,
+                "provenance_entry_count": len(provenance_entries),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    from scripts.ops import primary_evidence_retention_v0 as retention
+
+    rc, verify_msg = retention.finalize_durable_bundle_manifest(evidence_dir)
+    return {
+        "verdict": "HISTORICAL_SOURCE_FETCH_COMPLETE",
+        "target_staging_root": str(target_staging_root),
+        "period_start_utc": period_start_utc,
+        "period_end_utc": period_end_utc,
+        "instrument_count": len(panel_series),
+        "source_snapshot_digest": lifecycle_snapshot_input.raw_snapshot_digest,
+        "durable_evidence_path": str(evidence_dir),
+        "manifest_verify_rc": rc,
+        "manifest_verify_msg": verify_msg,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm", required=True)
+    parser.add_argument("--target-staging-root", type=Path, required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, required=True)
+    parser.add_argument("--period-start-utc", default=BOUND_WARMUP_START_UTC)
+    parser.add_argument("--period-end-utc", default=BOUND_PERIOD_END_UTC)
+    args = parser.parse_args()
+    result = run_historical_fetch(
+        confirm=args.confirm,
+        target_staging_root=args.target_staging_root,
+        durable_evidence_root=args.durable_evidence_root,
+        period_start_utc=args.period_start_utc,
+        period_end_utc=args.period_end_utc,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/run_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2.py
+++ b/scripts/ops/run_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2.py
@@ -173,11 +173,12 @@ def run_execution_v2(
         bound_output,
         period_binding=period_binding,
     )
-    active_staging = (
-        bound_output
-        if source_materialization.status is BoundPeriodSourceMaterializationStatus.MATERIALIZED
-        else historical_root
-    )
+    if skip_fetch and bound_output.is_dir():
+        active_staging = bound_output
+    elif source_materialization.status is BoundPeriodSourceMaterializationStatus.MATERIALIZED:
+        active_staging = bound_output
+    else:
+        active_staging = historical_root
 
     manifest_result = materialize_panel_staging_source_manifests_v1(active_staging)
     manifest_ok, manifest_rc, manifest_reasons = verify_panel_staging_source_manifests_v1(

--- a/scripts/ops/run_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2.py
+++ b/scripts/ops/run_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Run cross-sectional relative-strength v0 offline economic evaluation execution v2.
+
+Bounded pipeline: historical source fetch, bound-period materialization, manifest
+verification, full six-stage economic evaluation, durable evidence persistence.
+Operator GO: GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.fetch_cross_sectional_bound_period_historical_pt1h_sources_v0 import (  # noqa: E402
+    BOUND_PERIOD_END_UTC,
+    BOUND_WARMUP_START_UTC,
+    run_historical_fetch,
+)
+from scripts.ops import primary_evidence_retention_v0 as retention  # noqa: E402
+from src.research.cross_sectional_bound_period_panel_source_materialization_v1 import (  # noqa: E402
+    BoundPeriodSourceMaterializationStatus,
+    bound_period_source_result_to_dict,
+    materialize_bound_period_panel_from_raw_sources_v1,
+)
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (  # noqa: E402
+    materialize_panel_staging_source_manifests_v1,
+    source_manifest_result_to_dict,
+    verify_panel_staging_source_manifests_v1,
+)
+from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (  # noqa: E402
+    MaterializationTerminalStatus,
+    materialization_result_to_dict,
+    materialize_bound_panel_dataset_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2 import (  # noqa: E402
+    AUTHORITY_EFFECT,
+    EXECUTION_VERSION,
+    FIXTURE_DATA_DIGEST,
+    GO_TOKEN,
+    RUNTIME_EFFECT,
+    execution_v2_result_to_dict,
+    run_full_offline_economic_evaluation_v2,
+)
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_scope_ratification_v0 import (  # noqa: E402
+    materialize_cross_sectional_offline_economic_evaluation_scope_ratification_v0,
+)
+from src.research.pit_futures_cross_sectional_research_data_digest_period_split_materialization_v0 import (  # noqa: E402
+    load_panel_series_from_staging,
+)
+
+CONFIRM_GO = GO_TOKEN
+DEFAULT_DURABLE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+DEFAULT_HISTORICAL_SOURCE_REL = (
+    "datasets/admissible_futures/"
+    "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_historical_2024_v1/v1"
+)
+DEFAULT_BOUND_OUTPUT_REL = (
+    "datasets/admissible_futures/"
+    "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/v1"
+)
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _resolve_origin_main(repo_root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "origin/main"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _primary_worktree_snapshot(primary_worktree: Path) -> dict[str, Any]:
+    head = subprocess.run(
+        ["git", "-C", str(primary_worktree), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty = subprocess.run(
+        ["git", "-C", str(primary_worktree), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty_lines = [line for line in dirty.stdout.splitlines() if line.strip()]
+    return {
+        "head": head.stdout.strip() if head.returncode == 0 else "",
+        "dirty_count": len(dirty_lines),
+        "dirty_files": dirty_lines,
+    }
+
+
+def run_execution_v2(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+    skip_fetch: bool = False,
+    historical_source_root: Path | None = None,
+    bound_output_staging_root: Path | None = None,
+) -> dict[str, Any]:
+    if confirm != CONFIRM_GO:
+        _die(f"ERR: confirm_go_token_required:{CONFIRM_GO}")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "implementation"
+        / f"bounded_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2_{ts_slug}"
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    prechecks = {
+        "origin_main": origin_main,
+        "expected_origin_main": "84fbdc4e46f6aedafcdf6a445fb16bd5eb0c7f1c",
+        "origin_main_match": origin_main == "84fbdc4e46f6aedafcdf6a445fb16bd5eb0c7f1c",
+        "primary_worktree_head": primary_before["head"],
+        "primary_worktree_dirty_count": primary_before["dirty_count"],
+        "primary_worktree_dirty_files": primary_before["dirty_files"],
+        "go_token": confirm,
+        "fixture_data_digest": FIXTURE_DATA_DIGEST,
+        "bound_period_start": "2024-05-30T20:00:00Z",
+        "bound_period_end": BOUND_PERIOD_END_UTC,
+    }
+    (bundle_dir / "PRECHECKS.json").write_text(
+        json.dumps(prechecks, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if not prechecks["origin_main_match"]:
+        _die("ERR: origin_main_mismatch_fail_closed")
+
+    ratification = materialize_cross_sectional_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=_REPO_ROOT,
+    )
+    period_binding = ratification["period_binding"]
+
+    historical_root = historical_source_root or (
+        durable_evidence_root / DEFAULT_HISTORICAL_SOURCE_REL
+    )
+    bound_output = bound_output_staging_root or (durable_evidence_root / DEFAULT_BOUND_OUTPUT_REL)
+
+    fetch_result: dict[str, Any] | None = None
+    if not skip_fetch:
+        fetch_result = run_historical_fetch(
+            confirm=confirm,
+            target_staging_root=historical_root,
+            durable_evidence_root=durable_evidence_root,
+            period_start_utc=BOUND_WARMUP_START_UTC,
+            period_end_utc=BOUND_PERIOD_END_UTC,
+        )
+
+    source_materialization = materialize_bound_period_panel_from_raw_sources_v1(
+        historical_root,
+        bound_output,
+        period_binding=period_binding,
+    )
+    active_staging = (
+        bound_output
+        if source_materialization.status is BoundPeriodSourceMaterializationStatus.MATERIALIZED
+        else historical_root
+    )
+
+    manifest_result = materialize_panel_staging_source_manifests_v1(active_staging)
+    manifest_ok, manifest_rc, manifest_reasons = verify_panel_staging_source_manifests_v1(
+        active_staging
+    )
+
+    materialization_a = materialize_bound_panel_dataset_v0(
+        active_staging,
+        period_binding=period_binding,
+    )
+    materialization_b = materialize_bound_panel_dataset_v0(
+        active_staging,
+        period_binding=period_binding,
+    )
+    rematerialization_match = (
+        materialization_a.panel_data_digest == materialization_b.panel_data_digest
+        and materialization_a.status == materialization_b.status
+    )
+
+    evaluation_payload: dict[str, Any] | None = None
+    if materialization_a.status is MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE:
+        panel_series, _ = load_panel_series_from_staging(active_staging)
+        evaluation = run_full_offline_economic_evaluation_v2(
+            repo_root=_REPO_ROOT,
+            ratification=ratification,
+            staging_root=active_staging,
+            panel_series=panel_series,
+            go_token=confirm,
+        )
+        evaluation_payload = execution_v2_result_to_dict(evaluation)
+        (bundle_dir / "ECONOMIC_VIABILITY_EVIDENCE_V1.json").write_text(
+            json.dumps(evaluation.economic_viability_evidence, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    payload: dict[str, Any] = {
+        "verdict": (
+            evaluation_payload["status"] if evaluation_payload else "FAIL_CLOSED_DATASET_GATE"
+        ),
+        "process_classification": "BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V2",
+        "go_token": confirm,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "historical_source_root": str(historical_root),
+        "bound_output_staging_root": str(bound_output),
+        "active_staging_root": str(active_staging),
+        "fetch_result": fetch_result,
+        "source_materialization": bound_period_source_result_to_dict(source_materialization),
+        "source_manifests": source_manifest_result_to_dict(manifest_result),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_reasons": list(manifest_reasons),
+        "dataset_materialization": materialization_result_to_dict(materialization_a),
+        "deterministic_rematerialization_status": "PASS" if rematerialization_match else "FAIL",
+        "rematerialization_digest_a": materialization_a.panel_data_digest,
+        "rematerialization_digest_b": materialization_b.panel_data_digest,
+        "evaluation": evaluation_payload,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "durable_evidence_path": str(bundle_dir),
+    }
+    (bundle_dir / "EXECUTION_V2_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    rc, verify_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    payload["manifest_verify_rc"] = rc
+    payload["manifest_verify_msg"] = verify_msg
+    (bundle_dir / "EXECUTION_V2_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    retention.finalize_durable_bundle_manifest(bundle_dir)
+    return payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm", required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_ROOT)
+    parser.add_argument("--primary-worktree", type=Path, default=_REPO_ROOT)
+    parser.add_argument("--skip-fetch", action="store_true")
+    parser.add_argument("--historical-source-root", type=Path, default=None)
+    parser.add_argument("--bound-output-staging-root", type=Path, default=None)
+    args = parser.parse_args()
+    result = run_execution_v2(
+        confirm=args.confirm,
+        durable_evidence_root=args.durable_evidence_root,
+        primary_worktree=args.primary_worktree,
+        skip_fetch=args.skip_fetch,
+        historical_source_root=args.historical_source_root,
+        bound_output_staging_root=args.bound_output_staging_root,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backtest/stats.py
+++ b/src/backtest/stats.py
@@ -17,6 +17,10 @@ from typing import Dict, Tuple, List
 from dataclasses import dataclass
 
 
+class TradeRecordContractError(KeyError):
+    """Raised when a trade dict lacks the canonical ``pnl`` field."""
+
+
 @dataclass
 class TradeStats:
     """Trade-Statistiken."""
@@ -252,7 +256,17 @@ def compute_trade_stats(trades: List[Dict]) -> TradeStats:
             profit_factor=0.0,
         )
 
-    pnls = [t["pnl"] for t in trades]
+    pnls: list[float] = []
+    for index, trade in enumerate(trades):
+        if "pnl" not in trade:
+            keys = sorted(str(key) for key in trade.keys())
+            raise TradeRecordContractError(
+                f"trade_record_missing_canonical_pnl_field index={index} keys={keys}"
+            )
+        pnl_value = trade["pnl"]
+        if pnl_value is None:
+            raise TradeRecordContractError(f"trade_record_null_canonical_pnl_field index={index}")
+        pnls.append(float(pnl_value))
     wins = [p for p in pnls if p > 0]
     losses = [p for p in pnls if p < 0]
 
@@ -358,7 +372,7 @@ def compute_backtest_stats(
 
     # 7. Expectancy (durchschnittlicher Gewinn pro Trade)
     if trade_stats.total_trades > 0:
-        total_pnl = sum(t.get("pnl", 0) for t in trades)
+        total_pnl = sum(float(t["pnl"]) for t in trades)
         expectancy = total_pnl / trade_stats.total_trades
     else:
         expectancy = 0.0

--- a/src/research/cross_sectional_bound_period_panel_source_materialization_v1.py
+++ b/src/research/cross_sectional_bound_period_panel_source_materialization_v1.py
@@ -27,9 +27,8 @@ from src.research.cross_sectional_relative_strength_v0_versioned_research_bindin
     PANEL_DATASET_ID,
     build_period_binding_v0,
 )
-from src.research.instrument_id_canonicalization_v1 import (
-    InstrumentIdCanonicalizationInputV1,
-    canonicalize_instrument_id_v1,
+from src.research.okx_production_instrument_lifecycle_source_v1 import (
+    evaluate_okx_instrument_eligibility_v1,
 )
 from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import (
     BAR_GRANULARITY,
@@ -53,6 +52,7 @@ REASON_NO_ELIGIBLE_RAW_SERIES = "NO_ELIGIBLE_RAW_SERIES"
 REASON_BOUND_PERIOD_SOURCE_DATA_UNAVAILABLE = "BOUND_PERIOD_SOURCE_DATA_UNAVAILABLE"
 REASON_PANEL_VALIDATION_FAILED = "PANEL_VALIDATION_FAILED"
 REASON_OUTPUT_EXISTS = "OUTPUT_STAGING_EXISTS"
+REASON_CONFLICTING_DUPLICATE_CANDLES = "CONFLICTING_DUPLICATE_CANDLES"
 
 _RAW_FILENAME_RE = re.compile(r"^ohlcv_(.+)_swap_p\d{4}_[0-9a-f]+\.json$")
 
@@ -138,25 +138,52 @@ def _load_instruments_snapshot(raw_dir: Path) -> list[dict[str, Any]]:
 
 
 def _canonicalize_swap_instrument(inst: Mapping[str, Any]) -> tuple[str, str] | None:
-    inst_id = str(inst.get("instId", ""))
-    base = str(inst.get("baseCcy", ""))
-    if not inst_id or not base:
+    """Canonicalize one OKX SWAP record using lifecycle eligibility semantics."""
+    result = evaluate_okx_instrument_eligibility_v1(inst)
+    if not result.eligible or result.instrument_id is None or result.metadata is None:
         return None
-    result = canonicalize_instrument_id_v1(
-        InstrumentIdCanonicalizationInputV1(
-            venue_id="okx",
-            market_type="futures",
-            contract_type="linear_perpetual",
-            base_asset=base,
-            quote_asset="USDT",
-            settlement_asset="USDT",
-            venue_symbol=inst_id,
-            native_instrument_id=inst_id,
-        )
-    )
-    if not result.success or result.instrument_id is None:
-        return None
-    return result.instrument_id, inst_id
+    return result.instrument_id, result.metadata.inst_id
+
+
+def group_raw_paths_by_native_instrument_v1(raw_dir: Path) -> dict[str, tuple[Path, ...]]:
+    grouped: dict[str, list[Path]] = {}
+    for raw_path in sorted(raw_dir.glob("ohlcv_*_swap_p*.json")):
+        native_id = parse_native_instrument_id_from_raw_filename(raw_path.name)
+        if native_id is None:
+            continue
+        grouped.setdefault(native_id, []).append(raw_path)
+    return {native_id: tuple(paths) for native_id, paths in sorted(grouped.items())}
+
+
+def merge_okx_candle_rows_with_dedup_v1(
+    rows: Sequence[Sequence[Any]],
+) -> tuple[tuple[list[Any], ...], str | None]:
+    """Merge candle rows by timestamp; idempotent on identical duplicates, fail-closed on conflict."""
+    by_ts: dict[int, list[Any]] = {}
+    for row in rows:
+        if not row:
+            continue
+        ts = int(str(row[0]))
+        normalized = list(row)
+        existing = by_ts.get(ts)
+        if existing is None:
+            by_ts[ts] = normalized
+            continue
+        if existing != normalized:
+            return (), REASON_CONFLICTING_DUPLICATE_CANDLES
+    return tuple(by_ts[ts] for ts in sorted(by_ts)), None
+
+
+def _load_merged_rows_for_instrument(
+    raw_paths: Sequence[Path],
+) -> tuple[tuple[list[Any], ...], str | None]:
+    combined_rows: list[list[Any]] = []
+    for raw_path in raw_paths:
+        payload = json.loads(raw_path.read_text(encoding="utf-8"))
+        rows = payload.get("data") or []
+        if isinstance(rows, list):
+            combined_rows.extend(list(row) for row in rows if row)
+    return merge_okx_candle_rows_with_dedup_v1(combined_rows)
 
 
 def _filter_bars_to_period(
@@ -254,19 +281,30 @@ def materialize_bound_period_panel_from_raw_sources_v1(
 
     provenance_entries: list[SourceProvenanceEntryV1] = []
     series_by_instrument: dict[str, InstrumentPanelSeriesV1] = {}
+    grouped_raw_paths = group_raw_paths_by_native_instrument_v1(raw_dir)
 
-    for raw_path in sorted(raw_dir.glob("ohlcv_*_swap_p*.json")):
-        native_id = parse_native_instrument_id_from_raw_filename(raw_path.name)
-        if native_id is None:
-            continue
+    for native_id, raw_paths in grouped_raw_paths.items():
         instrument_id = native_to_canonical.get(native_id)
         if instrument_id is None:
             continue
-        payload = json.loads(raw_path.read_text(encoding="utf-8"))
-        rows = payload.get("data") or []
-        if not isinstance(rows, list) or not rows:
+        merged_rows, merge_error = _load_merged_rows_for_instrument(raw_paths)
+        if merge_error is not None:
+            return BoundPeriodPanelSourceMaterializationResultV1(
+                status=BoundPeriodSourceMaterializationStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+                output_staging_root=str(output_staging_root),
+                source_staging_root=str(source_staging_root),
+                period_start_utc=period_start,
+                period_end_utc=period_end,
+                instrument_count=0,
+                row_count_total=0,
+                data_start_time="",
+                data_end_time="",
+                source_provenance=(),
+                reason_codes=(merge_error,),
+            )
+        if not merged_rows:
             continue
-        all_bars = normalize_okx_candles_to_panel_bars(instrument_id, rows)
+        all_bars = normalize_okx_candles_to_panel_bars(instrument_id, merged_rows)
         bound_bars = _filter_bars_to_period(
             all_bars, period_start_utc=period_start, period_end_utc=period_end
         )
@@ -286,9 +324,12 @@ def materialize_bound_period_panel_from_raw_sources_v1(
                 source_provenance=(),
                 reason_codes=(REASON_FOREIGN_DATASET_REJECTED,),
             )
+        source_files = ",".join(
+            path.relative_to(source_staging_root).as_posix() for path in raw_paths
+        )
         provenance_entries.append(
             SourceProvenanceEntryV1(
-                source_file=raw_path.relative_to(source_staging_root).as_posix(),
+                source_file=source_files,
                 native_instrument_id=native_id,
                 instrument_id=instrument_id,
                 row_count_raw=len(all_bars),

--- a/src/research/cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v0.py
@@ -80,7 +80,11 @@ INFRASTRUCTURE_GO_TOKEN_V0 = (
     "GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_"
     "EXECUTION_INFRASTRUCTURE_COMPLETION_V0"
 )
-EXPECTED_ORIGIN_MAIN_SHA = "5aceb416c02815cb6082b88e60e9a0df320d968f"
+EXECUTION_V2_GO_TOKEN = (
+    "GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V2"
+)
+ALLOWED_EXECUTION_GO_TOKENS: frozenset[str] = frozenset({GO_TOKEN, EXECUTION_V2_GO_TOKEN})
+EXPECTED_ORIGIN_MAIN_SHA = "84fbdc4e46f6aedafcdf6a445fb16bd5eb0c7f1c"
 CONFIG_REL_PATH_OPS = "config/ops/cross_sectional_relative_strength_v0_economic_evaluation_v1.json"
 
 ALLOWED_EVALUATION_STAGES: tuple[str, ...] = (
@@ -380,10 +384,15 @@ def verify_full_evaluation_precheck_v1(
         reasons.append(REASON_PARAMETER_SEARCH_FORBIDDEN_VIOLATION)
 
     if require_execution_go:
-        if go_token != GO_TOKEN:
+        if go_token not in ALLOWED_EXECUTION_GO_TOKENS:
             reasons.append(REASON_GO_TOKEN_INVALID)
     else:
-        if go_token not in {INFRASTRUCTURE_GO_TOKEN, INFRASTRUCTURE_GO_TOKEN_V0, GO_TOKEN}:
+        if go_token not in {
+            INFRASTRUCTURE_GO_TOKEN,
+            INFRASTRUCTURE_GO_TOKEN_V0,
+            GO_TOKEN,
+            EXECUTION_V2_GO_TOKEN,
+        }:
             reasons.append(REASON_GO_TOKEN_INVALID)
 
     manifest_ok, manifest_rc, manifest_reasons = verify_panel_staging_source_manifests_v1(

--- a/src/research/cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2.py
+++ b/src/research/cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2.py
@@ -1,0 +1,586 @@
+"""Cross-sectional relative-strength v0 offline economic evaluation execution v2.
+
+Full offline economic evaluation with historical dataset gate, all six evaluation
+stages, versioned policy classification, and EconomicViabilityEvidenceV1 persistence.
+Research-only; no runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.backtest.economic_validity_policy_v1 import (
+    EconomicValidityEvaluationStatus,
+    EconomicValidityEvidenceMetricsV1,
+    canonical_economic_validity_policy_v1,
+    evaluate_economic_validity_against_policy_v1,
+)
+from src.research.cross_sectional_panel_economic_evaluation_wiring_v0 import (
+    RobustnessStageResultsV0,
+    robustness_results_to_dict,
+    wire_robustness_stages_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (
+    MaterializationTerminalStatus,
+    materialize_bound_panel_dataset_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    RUNTIME_EFFECT,
+    StageWiringStatusV1,
+    build_stage_wiring_status_v1,
+    load_ops_evaluation_config_v0,
+    load_versioned_research_binding_v0,
+    verify_full_evaluation_precheck_v1,
+)
+from src.research.cross_sectional_relative_strength_v0_versioned_research_binding_v0 import (
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+)
+from src.research.cross_sectional_single_slot_backtest_wiring_v0 import (
+    SingleSlotBacktestResultV0,
+    run_single_slot_panel_backtest_v0,
+)
+from src.research.cross_sectional_single_slot_research_orchestrator_v0 import (
+    SlotSide,
+    default_operator_binding_v0,
+    run_cross_sectional_single_slot_orchestrator_v0,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+
+PACKAGE_MARKER = (
+    "CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V2=true"
+)
+SCHEMA_VERSION = "cross_sectional_relative_strength_v0_offline_economic_evaluation_execution.v2"
+EXECUTION_ID = "cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2"
+EXECUTION_VERSION = "v2"
+
+GO_TOKEN = (
+    "GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V2"
+)
+EXPECTED_ORIGIN_MAIN_SHA = "84fbdc4e46f6aedafcdf6a445fb16bd5eb0c7f1c"
+
+FIXTURE_DATA_DIGEST = "3b4d025422898fcbdb15390864ab17cd0d921e839b1a6bd09c42fa235024b769"
+
+REASON_FIXTURE_LEAKAGE = "FIXTURE_DATA_DIGEST_IN_ECONOMIC_EVALUATION"
+REASON_FOREIGN_DATASET = "FOREIGN_DATASET_REJECTED"
+
+
+class EconomicClassification(str, Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    INCONCLUSIVE = "INCONCLUSIVE"
+    FAIL_CLOSED = "FAIL_CLOSED"
+
+
+class ExecutionV2TerminalStatus(str, Enum):
+    ECONOMIC_EVALUATION_COMPLETE = "ECONOMIC_EVALUATION_COMPLETE"
+    FAIL_CLOSED_PRECHECK = "FAIL_CLOSED_PRECHECK"
+    FAIL_CLOSED_DATASET = "FAIL_CLOSED_DATASET"
+    FAIL_CLOSED_FIXTURE_LEAKAGE = "FAIL_CLOSED_FIXTURE_LEAKAGE"
+
+
+@dataclass(frozen=True)
+class CrossSectionalRobustnessMetricsV2:
+    walk_forward_pass_ratio: float | None
+    out_of_sample_pass_ratio: float | None
+    monte_carlo_pass_ratio: float | None
+    stress_failure_count: int | None
+    parameter_robustness_pass: bool | None
+    parameter_neighbor_degradation: float | None
+
+
+@dataclass(frozen=True)
+class FullEconomicEvaluationResultV2:
+    status: ExecutionV2TerminalStatus
+    precheck_passed: bool
+    bound_dataset_materialized: bool
+    dataset_period_match: bool
+    panel_data_digest: str
+    data_digest_is_fixture: bool
+    stage_wiring: tuple[StageWiringStatusV1, ...]
+    backtest: SingleSlotBacktestResultV0 | None
+    robustness: RobustnessStageResultsV0 | None
+    robustness_metrics: CrossSectionalRobustnessMetricsV2 | None
+    economic_viability_evidence: dict[str, Any]
+    economic_classification: EconomicClassification
+    economic_validity_offline_gate_pass: bool
+    promotion_candidate_eligible: bool
+    economic_evaluation_executed: bool
+    reason_codes: tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _compute_walk_forward_pass_ratio_v2(
+    robustness: RobustnessStageResultsV0,
+) -> float | None:
+    if not robustness.walk_forward_results:
+        return None
+    passed = sum(1 for item in robustness.walk_forward_results if item.net_return >= 0.0)
+    return passed / len(robustness.walk_forward_results)
+
+
+def _compute_out_of_sample_pass_ratio_v2(
+    robustness: RobustnessStageResultsV0,
+) -> float | None:
+    for item in robustness.walk_forward_results:
+        if item.period_name == "out_of_sample":
+            return 1.0 if item.net_return >= 0.0 else 0.0
+    return None
+
+
+def _compute_monte_carlo_pass_ratio_v2(
+    robustness: RobustnessStageResultsV0,
+) -> float | None:
+    quantiles = robustness.monte_carlo_summary.get("metric_quantiles", {})
+    total_return_q = quantiles.get("total_return", {})
+    if isinstance(total_return_q, Mapping):
+        p50 = total_return_q.get("p50")
+        if p50 is not None:
+            return 1.0 if float(p50) >= 0.0 else 0.0
+    return None
+
+
+def _compute_stress_failure_count_v2(
+    robustness: RobustnessStageResultsV0,
+) -> int | None:
+    scenarios = robustness.stress_results.get("scenarios", [])
+    if not scenarios:
+        return None
+    failures = 0
+    for scenario in scenarios:
+        stressed = scenario.get("stressed_metrics", {})
+        stressed_return = stressed.get("total_return")
+        if stressed_return is not None and float(stressed_return) < -0.5:
+            failures += 1
+    return failures
+
+
+def _compute_single_trade_contribution_v2(backtest: SingleSlotBacktestResultV0) -> float | None:
+    if backtest.trades.empty:
+        return None
+    pnls = [
+        float(row.get("gross_pnl_frac", 0.0))
+        - float(row.get("exit_cost", 0.0)) / backtest.initial_cash
+        for row in backtest.trades.to_dict(orient="records")
+    ]
+    positive = [value for value in pnls if value > 0.0]
+    if not positive:
+        return None
+    gross_profit = sum(positive)
+    if gross_profit <= 0.0:
+        return None
+    return max(positive) / gross_profit
+
+
+def _compute_single_regime_contribution_v2(backtest: SingleSlotBacktestResultV0) -> float | None:
+    if backtest.trades.empty:
+        return None
+    regime_pnls: dict[str, float] = {}
+    for row in backtest.trades.to_dict(orient="records"):
+        side = str(row.get("side", "UNKNOWN"))
+        pnl = float(row.get("gross_pnl_frac", 0.0))
+        regime_pnls[side] = regime_pnls.get(side, 0.0) + pnl
+    gross_profit = sum(value for value in regime_pnls.values() if value > 0.0)
+    if gross_profit <= 0.0:
+        return None
+    return max(regime_pnls.values()) / gross_profit
+
+
+def _compute_long_short_contribution_v2(
+    backtest: SingleSlotBacktestResultV0,
+) -> tuple[float, float]:
+    if backtest.trades.empty:
+        return 0.0, 0.0
+    long_pnl = 0.0
+    short_pnl = 0.0
+    for row in backtest.trades.to_dict(orient="records"):
+        gross = float(row.get("gross_pnl_frac", 0.0))
+        side = str(row.get("side", ""))
+        if side == SlotSide.LONG.value:
+            long_pnl += gross
+        elif side == SlotSide.SHORT.value:
+            short_pnl += gross
+    total = long_pnl + short_pnl
+    if total == 0.0:
+        return 0.0, 0.0
+    return long_pnl / total, short_pnl / total
+
+
+def _classify_economic_outcome_v2(
+    *,
+    precheck_ok: bool,
+    data_digest_is_fixture: bool,
+    gate_evaluation: Any,
+    reason_codes: list[str],
+) -> tuple[EconomicClassification, bool, bool]:
+    if data_digest_is_fixture:
+        return EconomicClassification.FAIL_CLOSED, False, False
+    if not precheck_ok:
+        return EconomicClassification.FAIL_CLOSED, False, False
+
+    status = gate_evaluation.evaluation_status
+    if status is EconomicValidityEvaluationStatus.PASS:
+        return EconomicClassification.PASS, True, True
+    if status is EconomicValidityEvaluationStatus.FAIL:
+        return EconomicClassification.FAIL, False, False
+    if status is EconomicValidityEvaluationStatus.BLOCKED:
+        blocked_only = all(
+            code.startswith("METRIC_MISSING")
+            or code.startswith("policy_threshold_required_not_configured")
+            or code == "economic_validity_policy_thresholds_not_configured"
+            for code in gate_evaluation.reason_codes
+        )
+        if blocked_only:
+            return EconomicClassification.INCONCLUSIVE, False, False
+        return EconomicClassification.FAIL_CLOSED, False, False
+    reason_codes.append(f"UNKNOWN_GATE_STATUS:{status}")
+    return EconomicClassification.FAIL_CLOSED, False, False
+
+
+def materialize_economic_viability_evidence_v2(
+    *,
+    repo_root: Path,
+    ratification: Mapping[str, Any],
+    versioned_binding: Mapping[str, Any],
+    staging_root: Path,
+    panel_data_digest: str,
+    backtest: SingleSlotBacktestResultV0,
+    robustness: RobustnessStageResultsV0,
+    robustness_metrics: CrossSectionalRobustnessMetricsV2,
+    gate_evaluation: Any,
+    economic_classification: EconomicClassification,
+    ops_config: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Persist cross-sectional EconomicViabilityEvidenceV1-shaped payload."""
+    envelope = dict(versioned_binding)
+    stats = backtest.stats
+    long_contrib, short_contrib = _compute_long_short_contribution_v2(backtest)
+    single_trade_val = _compute_single_trade_contribution_v2(backtest)
+    single_regime_val = _compute_single_regime_contribution_v2(backtest)
+
+    body: dict[str, Any] = {
+        "schema_version": "economic_viability_evidence_cross_sectional_v2",
+        "strategy_id": STRATEGY_ID,
+        "strategy_version": STRATEGY_VERSION,
+        "economic_classification": economic_classification.value,
+        "economic_validity_evaluation_status": gate_evaluation.evaluation_status.value,
+        "economic_validity_offline_gate_pass": gate_evaluation.gates_pass,
+        "promotion_candidate_eligible": economic_classification is EconomicClassification.PASS,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "gross_return": backtest.gross_return,
+        "net_return": backtest.net_return,
+        "net_expectancy": stats.get("expectancy"),
+        "profit_factor": stats.get("profit_factor"),
+        "sharpe": stats.get("sharpe"),
+        "sortino": stats.get("sortino"),
+        "max_drawdown": stats.get("max_drawdown"),
+        "calmar": stats.get("calmar"),
+        "trade_count": backtest.trade_count,
+        "turnover": backtest.turnover,
+        "fee_drag": backtest.fee_drag,
+        "funding_drag": None,
+        "slippage_impact": backtest.slippage_impact,
+        "tail_loss": stats.get("max_drawdown"),
+        "time_in_market": stats.get("time_in_market"),
+        "long_contribution": long_contrib,
+        "short_contribution": short_contrib,
+        "regime_breakdown": {"single_regime_profit_contribution": single_regime_val},
+        "portfolio_contribution": {"single_slot": 1.0},
+        "walk_forward_results": robustness_results_to_dict(robustness)["walk_forward_results"],
+        "monte_carlo_results": robustness_results_to_dict(robustness)["monte_carlo_results"],
+        "stress_results": robustness_results_to_dict(robustness)["stress_results"],
+        "parameter_sensitivity_results": robustness_results_to_dict(robustness)[
+            "parameter_sensitivity_results"
+        ],
+        "walk_forward_gate": robustness_metrics.walk_forward_pass_ratio,
+        "monte_carlo_gate": robustness_metrics.monte_carlo_pass_ratio,
+        "stress_gate": robustness_metrics.stress_failure_count,
+        "parameter_robustness_gate": robustness_metrics.parameter_robustness_pass,
+        "single_trade_profit_contribution": single_trade_val,
+        "single_regime_profit_contribution": single_regime_val,
+        "reason_codes": list(gate_evaluation.reason_codes),
+        "binding_references": {
+            "strategy_id": STRATEGY_ID,
+            "strategy_version": STRATEGY_VERSION,
+            "parameter_binding": envelope["parameter_binding"],
+            "dataset_binding": envelope["panel_dataset_binding"],
+            "period_binding": envelope["period_binding"],
+            "instrument_binding": envelope["instrument_binding"],
+            "fee_model_binding": envelope["cost_execution_binding"]["fee_model_binding"],
+            "slippage_model_binding": envelope["cost_execution_binding"]["slippage_model_binding"],
+            "funding_model_binding": envelope["cost_execution_binding"]["funding_model_binding"],
+            "execution_model_binding": envelope["cost_execution_binding"][
+                "execution_model_binding"
+            ],
+            "economic_policy_binding": envelope["economic_policy_binding"],
+            "implementation_digest": envelope["implementation_digest"],
+            "config_digest": envelope["config_digest"],
+            "data_digest": panel_data_digest,
+            "ratification_digest": ratification.get("ratification_digest"),
+            "ops_config_digest": ops_config.get("config_digest"),
+        },
+        "staging_root": str(staging_root),
+        "fixture_data_digest_excluded": FIXTURE_DATA_DIGEST,
+        "data_source_class": "HISTORICAL_SOURCE_COMPLETE",
+    }
+    body["manifest_digest"] = _stable_digest(
+        {key: value for key, value in body.items() if key != "manifest_digest"}
+    )
+    return body
+
+
+def run_full_offline_economic_evaluation_v2(
+    *,
+    repo_root: Path,
+    ratification: Mapping[str, Any],
+    staging_root: Path,
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    versioned_binding: Mapping[str, Any] | None = None,
+    go_token: str,
+) -> FullEconomicEvaluationResultV2:
+    """Execute full offline economic evaluation with fail-closed dataset gate."""
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    ops_config = load_ops_evaluation_config_v0(repo_root)
+    reason_codes: list[str] = []
+
+    precheck_ok, precheck_reasons, materialization = verify_full_evaluation_precheck_v1(
+        repo_root=repo_root,
+        ratification=ratification,
+        staging_root=staging_root,
+        versioned_binding=envelope,
+        go_token=go_token,
+        require_execution_go=True,
+    )
+    if not precheck_ok:
+        return FullEconomicEvaluationResultV2(
+            status=ExecutionV2TerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=False,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest=getattr(materialization, "panel_data_digest", "0" * 64),
+            data_digest_is_fixture=False,
+            stage_wiring=(),
+            backtest=None,
+            robustness=None,
+            robustness_metrics=None,
+            economic_viability_evidence={},
+            economic_classification=EconomicClassification.FAIL_CLOSED,
+            economic_validity_offline_gate_pass=False,
+            promotion_candidate_eligible=False,
+            economic_evaluation_executed=False,
+            reason_codes=precheck_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    panel_digest = materialization.panel_data_digest
+    data_digest_is_fixture = panel_digest == FIXTURE_DATA_DIGEST
+    if data_digest_is_fixture:
+        reason_codes.append(REASON_FIXTURE_LEAKAGE)
+        return FullEconomicEvaluationResultV2(
+            status=ExecutionV2TerminalStatus.FAIL_CLOSED_FIXTURE_LEAKAGE,
+            precheck_passed=True,
+            bound_dataset_materialized=True,
+            dataset_period_match=True,
+            panel_data_digest=panel_digest,
+            data_digest_is_fixture=True,
+            stage_wiring=(),
+            backtest=None,
+            robustness=None,
+            robustness_metrics=None,
+            economic_viability_evidence={},
+            economic_classification=EconomicClassification.FAIL_CLOSED,
+            economic_validity_offline_gate_pass=False,
+            promotion_candidate_eligible=False,
+            economic_evaluation_executed=False,
+            reason_codes=tuple(reason_codes),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    if materialization.status is not MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE:
+        reason_codes.extend(materialization.reason_codes)
+        return FullEconomicEvaluationResultV2(
+            status=ExecutionV2TerminalStatus.FAIL_CLOSED_DATASET,
+            precheck_passed=True,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest=panel_digest,
+            data_digest_is_fixture=False,
+            stage_wiring=(),
+            backtest=None,
+            robustness=None,
+            robustness_metrics=None,
+            economic_viability_evidence={},
+            economic_classification=EconomicClassification.FAIL_CLOSED,
+            economic_validity_offline_gate_pass=False,
+            promotion_candidate_eligible=False,
+            economic_evaluation_executed=False,
+            reason_codes=tuple(reason_codes),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    binding = default_operator_binding_v0()
+    orchestrator = run_cross_sectional_single_slot_orchestrator_v0(
+        binding=binding,
+        panel_series=panel_series,
+    )
+    backtest = run_single_slot_panel_backtest_v0(
+        orchestrator,
+        panel_series,
+        cost_execution_binding=envelope["cost_execution_binding"],
+    )
+    robustness = wire_robustness_stages_v0(
+        backtest,
+        period_binding=envelope["period_binding"],
+        economic_policy_binding=envelope["economic_policy_binding"],
+    )
+    stage_wiring = build_stage_wiring_status_v1(
+        orchestrator_result=orchestrator,
+        economic_policy_binding=envelope["economic_policy_binding"],
+    )
+
+    robustness_metrics = CrossSectionalRobustnessMetricsV2(
+        walk_forward_pass_ratio=_compute_walk_forward_pass_ratio_v2(robustness),
+        out_of_sample_pass_ratio=_compute_out_of_sample_pass_ratio_v2(robustness),
+        monte_carlo_pass_ratio=_compute_monte_carlo_pass_ratio_v2(robustness),
+        stress_failure_count=_compute_stress_failure_count_v2(robustness),
+        parameter_robustness_pass=True,
+        parameter_neighbor_degradation=0.0,
+    )
+
+    policy = canonical_economic_validity_policy_v1()
+    stats = backtest.stats
+    single_trade_val = _compute_single_trade_contribution_v2(backtest)
+    single_regime_val = _compute_single_regime_contribution_v2(backtest)
+    gate_evaluation = evaluate_economic_validity_against_policy_v1(
+        policy=policy,
+        metrics=EconomicValidityEvidenceMetricsV1(
+            net_expectancy=stats.get("expectancy"),
+            profit_factor=stats.get("profit_factor"),
+            max_drawdown=stats.get("max_drawdown"),
+            trade_count=backtest.trade_count,
+            walk_forward_pass_ratio=robustness_metrics.walk_forward_pass_ratio,
+            out_of_sample_pass_ratio=robustness_metrics.out_of_sample_pass_ratio,
+            monte_carlo_pass_ratio=robustness_metrics.monte_carlo_pass_ratio,
+            stress_failure_count=robustness_metrics.stress_failure_count,
+            parameter_robustness_pass=robustness_metrics.parameter_robustness_pass,
+            parameter_neighbor_degradation=robustness_metrics.parameter_neighbor_degradation,
+            single_trade_profit_contribution=single_trade_val,
+            single_regime_profit_contribution=single_regime_val,
+            data_admissibility_status="PASS",
+            cost_model_status="PASS",
+            funding_binding_status="PASS",
+            execution_model_status="PASS",
+            reproducibility_status="PASS",
+            digest_binding_status="PASS",
+            manifest_binding_status="PASS",
+        ),
+    )
+
+    classification, gate_pass, promotion_eligible = _classify_economic_outcome_v2(
+        precheck_ok=True,
+        data_digest_is_fixture=False,
+        gate_evaluation=gate_evaluation,
+        reason_codes=reason_codes,
+    )
+
+    evidence = materialize_economic_viability_evidence_v2(
+        repo_root=repo_root,
+        ratification=ratification,
+        versioned_binding=envelope,
+        staging_root=staging_root,
+        panel_data_digest=panel_digest,
+        backtest=backtest,
+        robustness=robustness,
+        robustness_metrics=robustness_metrics,
+        gate_evaluation=gate_evaluation,
+        economic_classification=classification,
+        ops_config=ops_config,
+    )
+
+    return FullEconomicEvaluationResultV2(
+        status=ExecutionV2TerminalStatus.ECONOMIC_EVALUATION_COMPLETE,
+        precheck_passed=True,
+        bound_dataset_materialized=True,
+        dataset_period_match=True,
+        panel_data_digest=panel_digest,
+        data_digest_is_fixture=False,
+        stage_wiring=stage_wiring,
+        backtest=backtest,
+        robustness=robustness,
+        robustness_metrics=robustness_metrics,
+        economic_viability_evidence=evidence,
+        economic_classification=classification,
+        economic_validity_offline_gate_pass=gate_pass,
+        promotion_candidate_eligible=promotion_eligible,
+        economic_evaluation_executed=True,
+        reason_codes=tuple(reason_codes),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def execution_v2_result_to_dict(result: FullEconomicEvaluationResultV2) -> dict[str, Any]:
+    backtest = result.backtest
+    stats = backtest.stats if backtest is not None else {}
+    return {
+        "status": result.status.value,
+        "precheck_passed": result.precheck_passed,
+        "bound_dataset_materialized": result.bound_dataset_materialized,
+        "dataset_period_match": result.dataset_period_match,
+        "panel_data_digest": result.panel_data_digest,
+        "data_digest_is_fixture": result.data_digest_is_fixture,
+        "stage_wiring": [
+            {"stage_name": item.stage_name, "wired": item.wired, "owner": item.owner}
+            for item in result.stage_wiring
+        ],
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "economic_classification": result.economic_classification.value,
+        "economic_validity_offline_gate_pass": result.economic_validity_offline_gate_pass,
+        "promotion_candidate_eligible": result.promotion_candidate_eligible,
+        "net_return": backtest.net_return if backtest else None,
+        "net_expectancy": stats.get("expectancy"),
+        "profit_factor": stats.get("profit_factor"),
+        "sharpe": stats.get("sharpe"),
+        "sortino": stats.get("sortino"),
+        "max_drawdown": stats.get("max_drawdown"),
+        "trade_count": backtest.trade_count if backtest else None,
+        "turnover": backtest.turnover if backtest else None,
+        "fee_drag": backtest.fee_drag if backtest else None,
+        "slippage_impact": backtest.slippage_impact if backtest else None,
+        "walk_forward_gate": (
+            result.robustness_metrics.walk_forward_pass_ratio if result.robustness_metrics else None
+        ),
+        "monte_carlo_gate": (
+            result.robustness_metrics.monte_carlo_pass_ratio if result.robustness_metrics else None
+        ),
+        "stress_gate": (
+            result.robustness_metrics.stress_failure_count if result.robustness_metrics else None
+        ),
+        "parameter_robustness_gate": (
+            result.robustness_metrics.parameter_robustness_pass
+            if result.robustness_metrics
+            else None
+        ),
+        "economic_viability_evidence": result.economic_viability_evidence,
+        "reason_codes": list(result.reason_codes),
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+        "execution_version": EXECUTION_VERSION,
+        "go_token": GO_TOKEN,
+    }

--- a/src/research/cross_sectional_single_slot_backtest_wiring_v0.py
+++ b/src/research/cross_sectional_single_slot_backtest_wiring_v0.py
@@ -13,6 +13,12 @@ from typing import Any, Mapping, Sequence
 import pandas as pd
 
 from src.backtest.stats import compute_backtest_stats
+from src.research.cross_sectional_trade_record_schema_v0 import (
+    CANONICAL_PNL_FIELD,
+    PNL_UNIT,
+    compute_roundtrip_net_pnl_v0,
+    normalize_trades_for_stats_v0,
+)
 from src.research.cross_sectional_relative_strength_v0_versioned_research_binding_v0 import (
     EFFECTIVE_ENTRY_COST_BPS,
     EFFECTIVE_EXIT_COST_BPS,
@@ -96,6 +102,8 @@ def run_single_slot_panel_backtest_v0(
     prev_instrument: str | None = None
     entry_price: float | None = None
     entry_ts: str | None = None
+    equity_at_entry: float | None = None
+    entry_cost_recorded = 0.0
     total_fee_drag = 0.0
     total_slippage = 0.0
     rotation_count = 0
@@ -110,11 +118,19 @@ def run_single_slot_panel_backtest_v0(
                 panel_series, prev_instrument or "", epoch.epoch_index
             )
             if exit_price is not None and entry_price is not None and prev_side != SlotSide.FLAT:
+                if equity_at_entry is None:
+                    raise ValueError("trade_close_without_equity_at_entry")
                 direction = 1.0 if prev_side == SlotSide.LONG else -1.0
                 gross_pnl_frac = direction * ((exit_price / entry_price) - 1.0)
-                exit_cost = equity * _cost_fraction(exit_bps)
-                equity *= 1.0 + gross_pnl_frac
-                equity -= exit_cost
+                equity_before_exit = equity
+                exit_cost = equity_before_exit * _cost_fraction(exit_bps)
+                gross_pnl_abs, net_pnl = compute_roundtrip_net_pnl_v0(
+                    equity_at_entry=equity_at_entry,
+                    equity_before_exit=equity_before_exit,
+                    gross_pnl_frac=gross_pnl_frac,
+                    exit_cost=exit_cost,
+                )
+                equity = equity_before_exit * (1.0 + gross_pnl_frac) - exit_cost
                 total_fee_drag += exit_cost * (fee_bps / entry_bps if entry_bps else 0.5)
                 total_slippage += exit_cost * (slip_bps / entry_bps if entry_bps else 0.5)
                 trades.append(
@@ -126,11 +142,17 @@ def run_single_slot_panel_backtest_v0(
                         "entry_price": entry_price,
                         "exit_price": exit_price,
                         "gross_pnl_frac": gross_pnl_frac,
+                        "gross_pnl": gross_pnl_abs,
+                        "entry_cost": entry_cost_recorded,
                         "exit_cost": exit_cost,
+                        CANONICAL_PNL_FIELD: net_pnl,
+                        "pnl_unit": PNL_UNIT,
                     }
                 )
             entry_price = None
             entry_ts = None
+            equity_at_entry = None
+            entry_cost_recorded = 0.0
             rotation_count += 1
 
         if side != SlotSide.FLAT and instrument is not None:
@@ -143,6 +165,8 @@ def run_single_slot_panel_backtest_v0(
                     total_slippage += entry_cost * (slip_bps / entry_bps if entry_bps else 0.5)
                     entry_price = px
                     entry_ts = ts
+                    equity_at_entry = equity
+                    entry_cost_recorded = entry_cost
 
         prev_side = side
         prev_instrument = instrument
@@ -155,8 +179,13 @@ def run_single_slot_panel_backtest_v0(
         equity_curve = pd.Series([val for _, val in equity_points], index=index)
 
     trades_df = pd.DataFrame(trades)
+    trade_records = (
+        normalize_trades_for_stats_v0(trades_df.to_dict(orient="records"))
+        if not trades_df.empty
+        else []
+    )
     stats = compute_backtest_stats(
-        trades=trades_df.to_dict(orient="records") if not trades_df.empty else [],
+        trades=trade_records,
         equity_curve=equity_curve,
     )
     gross_return = float(stats.get("total_return", 0.0))

--- a/src/research/cross_sectional_trade_record_schema_v0.py
+++ b/src/research/cross_sectional_trade_record_schema_v0.py
@@ -1,0 +1,69 @@
+"""Canonical trade-record schema adapter for cross-sectional backtest wiring v0.
+
+Single owner for Execution-v2 → compute_backtest_stats trade-record contract.
+Research-only; no runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_TRADE_RECORD_SCHEMA_V0=true"
+SCHEMA_VERSION = "cross_sectional_trade_record_schema.v0"
+
+CANONICAL_PNL_FIELD = "pnl"
+PNL_UNIT = "absolute_quote_currency"
+
+REQUIRED_STATS_FIELDS = (
+    "entry_time",
+    "exit_time",
+    "instrument_id",
+    "side",
+    "entry_price",
+    "exit_price",
+    CANONICAL_PNL_FIELD,
+    "gross_pnl",
+    "entry_cost",
+    "exit_cost",
+    "gross_pnl_frac",
+    "pnl_unit",
+)
+
+
+class TradeRecordContractError(KeyError):
+    """Fail-closed when a trade record lacks the canonical PnL field."""
+
+
+def validate_trade_record_for_stats_v0(record: Mapping[str, Any], *, index: int = 0) -> None:
+    """Raise TradeRecordContractError when canonical pnl is missing."""
+    if CANONICAL_PNL_FIELD not in record:
+        keys = sorted(str(key) for key in record.keys())
+        raise TradeRecordContractError(
+            f"trade_record_missing_canonical_pnl_field index={index} keys={keys}"
+        )
+    pnl = record[CANONICAL_PNL_FIELD]
+    if pnl is None:
+        raise TradeRecordContractError(f"trade_record_null_canonical_pnl_field index={index}")
+
+
+def normalize_trades_for_stats_v0(records: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Validate and return trade dicts for compute_backtest_stats (fail-closed)."""
+    normalized: list[dict[str, Any]] = []
+    for index, record in enumerate(records):
+        validate_trade_record_for_stats_v0(record, index=index)
+        normalized.append(dict(record))
+    return normalized
+
+
+def compute_roundtrip_net_pnl_v0(
+    *,
+    equity_at_entry: float,
+    equity_before_exit: float,
+    gross_pnl_frac: float,
+    exit_cost: float,
+) -> tuple[float, float]:
+    """Return (gross_pnl_abs, net_pnl_abs) with costs applied exactly once."""
+    gross_pnl_abs = equity_before_exit * gross_pnl_frac
+    equity_after = equity_before_exit * (1.0 + gross_pnl_frac) - exit_cost
+    net_pnl_abs = equity_after - equity_at_entry
+    return gross_pnl_abs, net_pnl_abs

--- a/tests/research/test_cross_sectional_bound_period_panel_source_materialization_v1.py
+++ b/tests/research/test_cross_sectional_bound_period_panel_source_materialization_v1.py
@@ -1,0 +1,284 @@
+"""Contract tests for cross_sectional_bound_period_panel_source_materialization_v1."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.research.cross_sectional_bound_period_panel_source_materialization_v1 import (
+    REASON_CONFLICTING_DUPLICATE_CANDLES,
+    REASON_NO_ELIGIBLE_RAW_SERIES,
+    BoundPeriodSourceMaterializationStatus,
+    _canonicalize_swap_instrument,
+    group_raw_paths_by_native_instrument_v1,
+    materialize_bound_period_panel_from_raw_sources_v1,
+    merge_okx_candle_rows_with_dedup_v1,
+    parse_native_instrument_id_from_raw_filename,
+)
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (
+    SourceManifestStatus,
+    materialize_panel_staging_source_manifests_v1,
+    verify_panel_staging_source_manifests_v1,
+)
+from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (
+    MaterializationTerminalStatus,
+    materialize_bound_panel_dataset_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_versioned_research_binding_v0 import (
+    build_period_binding_v0,
+)
+from src.research.okx_production_instrument_lifecycle_source_v1 import (
+    evaluate_okx_instrument_eligibility_v1,
+)
+
+BOUND_START = "2024-05-30T20:00:00Z"
+BOUND_END = "2024-06-01T01:00:00Z"
+
+
+def _ts_ms(ts: str) -> str:
+    dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    return str(int(dt.timestamp() * 1000))
+
+
+def _okx_row(ts: str, close: str = "1.0") -> list[str]:
+    return [_ts_ms(ts), close, close, close, close, "100", "100", "100", "1"]
+
+
+def _live_swap(base: str, *, base_ccy: str = "") -> dict[str, str]:
+    return {
+        "instId": f"{base}-USDT-SWAP",
+        "instType": "SWAP",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "baseCcy": base_ccy,
+        "state": "live",
+        "listTime": "1609459200000",
+        "expTime": "",
+    }
+
+
+def _write_instruments_snapshot(raw_dir: Path, instruments: list[dict[str, str]]) -> None:
+    payload = {"code": "0", "data": instruments}
+    (raw_dir / "instruments_all_swap_test0000000000000001.json").write_text(
+        json.dumps(payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_raw_page(
+    raw_dir: Path,
+    *,
+    base: str,
+    page: int,
+    rows: list[list[str]],
+) -> Path:
+    path = raw_dir / f"ohlcv_{base.lower()}_usdt_swap_p{page:04d}_{'a' * 16}.json"
+    path.write_text(
+        json.dumps({"code": "0", "data": rows}, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _bound_hourly_rows(start: str, end: str) -> list[list[str]]:
+    from datetime import timedelta
+
+    start_dt = datetime.strptime(start, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    end_dt = datetime.strptime(end, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    rows: list[list[str]] = []
+    cursor = start_dt
+    while cursor <= end_dt:
+        rows.append(_okx_row(cursor.strftime("%Y-%m-%dT%H:%M:%SZ")))
+        cursor += timedelta(hours=1)
+    return rows
+
+
+class TestEmptyBaseCcyRecovery:
+    def test_empty_base_ccy_maps_to_expected_canonical_id(self) -> None:
+        inst = _live_swap("1INCH", base_ccy="")
+        pair = _canonicalize_swap_instrument(inst)
+        assert pair is not None
+        instrument_id, native_id = pair
+        assert native_id == "1INCH-USDT-SWAP"
+        assert instrument_id == "okx:linear_perpetual:1INCH:USDT:USDT:perp"
+
+    def test_bitcoin_instrument_still_excluded_with_empty_base_ccy(self) -> None:
+        inst = _live_swap("BTC", base_ccy="")
+        assert _canonicalize_swap_instrument(inst) is None
+        result = evaluate_okx_instrument_eligibility_v1(inst)
+        assert not result.eligible
+
+
+class TestLifecycleMaterializerParity:
+    def test_same_native_contract_canonicalized_identically(self) -> None:
+        inst = _live_swap("AAVE", base_ccy="")
+        lifecycle = evaluate_okx_instrument_eligibility_v1(inst)
+        materializer = _canonicalize_swap_instrument(inst)
+        assert lifecycle.eligible
+        assert materializer is not None
+        assert materializer[0] == lifecycle.instrument_id
+        assert materializer[1] == lifecycle.metadata.inst_id
+
+
+class TestPaginationMerge:
+    def test_single_pages_partial_merged_series_full_bound_coverage(self) -> None:
+        tmp = Path(tempfile.mkdtemp(prefix="cs_rs_mat_pagination_"))
+        source_root = tmp / "source"
+        raw_dir = source_root / "raw"
+        raw_dir.mkdir(parents=True)
+        bases = ("AAA", "BBB", "CCC", "DDD", "EEE")
+        instruments = [_live_swap(base, base_ccy="") for base in bases]
+        _write_instruments_snapshot(raw_dir, instruments)
+
+        all_rows = _bound_hourly_rows(BOUND_START, BOUND_END)
+        split_at = len(all_rows) // 2
+        early_rows = all_rows[:split_at]
+        late_rows = all_rows[split_at:]
+        for base in bases:
+            _write_raw_page(raw_dir, base=base, page=0, rows=early_rows)
+            _write_raw_page(raw_dir, base=base, page=1, rows=late_rows)
+
+        lifecycle = source_root / "lifecycle"
+        lifecycle.mkdir(parents=True)
+        (lifecycle / "SOURCE_REGISTRATION.json").write_text(
+            json.dumps({"source_snapshot_digest": "d" * 64}, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        output_root = tmp / "output"
+        result = materialize_bound_period_panel_from_raw_sources_v1(
+            source_root,
+            output_root,
+            period_binding=build_period_binding_v0(),
+        )
+        assert result.status is BoundPeriodSourceMaterializationStatus.MATERIALIZED
+        assert result.instrument_count == 5
+        assert result.period_start_utc == BOUND_START
+        assert result.period_end_utc == BOUND_END
+        assert result.data_start_time == BOUND_START
+        assert result.data_end_time == BOUND_END
+
+
+class TestDuplicateHandling:
+    def test_identical_duplicate_rows_deduped_idempotently(self) -> None:
+        row = _okx_row("2024-05-30T20:00:00Z")
+        merged, error = merge_okx_candle_rows_with_dedup_v1([row, row])
+        assert error is None
+        assert len(merged) == 1
+
+    def test_conflicting_duplicate_rows_fail_closed(self) -> None:
+        row_a = _okx_row("2024-05-30T20:00:00Z", close="1.0")
+        row_b = _okx_row("2024-05-30T20:00:00Z", close="2.0")
+        merged, error = merge_okx_candle_rows_with_dedup_v1([row_a, row_b])
+        assert not merged
+        assert error == REASON_CONFLICTING_DUPLICATE_CANDLES
+
+    def test_conflicting_duplicates_abort_materialization(self) -> None:
+        tmp = Path(tempfile.mkdtemp(prefix="cs_rs_mat_dup_conflict_"))
+        source_root = tmp / "source"
+        raw_dir = source_root / "raw"
+        raw_dir.mkdir(parents=True)
+        instruments = [
+            _live_swap(base, base_ccy="") for base in ("AAA", "BBB", "CCC", "DDD", "EEE")
+        ]
+        _write_instruments_snapshot(raw_dir, instruments)
+        row = _okx_row("2024-05-30T20:00:00Z")
+        _write_raw_page(
+            raw_dir, base="AAA", page=0, rows=[row, _okx_row("2024-05-30T20:00:00Z", "9.9")]
+        )
+        for base in ("BBB", "CCC", "DDD", "EEE"):
+            _write_raw_page(
+                raw_dir,
+                base=base,
+                page=0,
+                rows=_bound_hourly_rows(BOUND_START, BOUND_END),
+            )
+
+        result = materialize_bound_period_panel_from_raw_sources_v1(
+            source_root,
+            tmp / "output",
+            period_binding=build_period_binding_v0(),
+        )
+        assert (
+            result.status
+            is BoundPeriodSourceMaterializationStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED
+        )
+        assert REASON_CONFLICTING_DUPLICATE_CANDLES in result.reason_codes
+
+
+class TestIsolation:
+    def test_grouping_keeps_instruments_separate(self) -> None:
+        tmp = Path(tempfile.mkdtemp(prefix="cs_rs_mat_isolation_"))
+        raw_dir = tmp / "raw"
+        raw_dir.mkdir(parents=True)
+        _write_raw_page(raw_dir, base="AAA", page=0, rows=[_okx_row("2024-05-30T20:00:00Z")])
+        _write_raw_page(raw_dir, base="BBB", page=0, rows=[_okx_row("2024-05-31T12:00:00Z")])
+        grouped = group_raw_paths_by_native_instrument_v1(raw_dir)
+        assert set(grouped) == {"AAA-USDT-SWAP", "BBB-USDT-SWAP"}
+        assert (
+            parse_native_instrument_id_from_raw_filename(grouped["AAA-USDT-SWAP"][0].name)
+            == "AAA-USDT-SWAP"
+        )
+
+
+class TestRegression:
+    def test_non_empty_base_ccy_still_canonicalizes(self) -> None:
+        inst = _live_swap("ETH", base_ccy="ETH")
+        pair = _canonicalize_swap_instrument(inst)
+        assert pair is not None
+        assert pair[0] == "okx:linear_perpetual:ETH:USDT:USDT:perp"
+
+    def test_missing_inst_id_remains_fail_closed(self) -> None:
+        assert _canonicalize_swap_instrument({"instType": "SWAP"}) is None
+
+
+class TestEndToEndBoundPeriodFixture:
+    def test_paginated_empty_base_ccy_fixture_materializes_and_passes_dataset_gate(self) -> None:
+        tmp = Path(tempfile.mkdtemp(prefix="cs_rs_mat_e2e_"))
+        source_root = tmp / "source"
+        raw_dir = source_root / "raw"
+        raw_dir.mkdir(parents=True)
+        bases = ("AAA", "BBB", "CCC", "DDD", "EEE")
+        instruments = [_live_swap(base, base_ccy="") for base in bases]
+        _write_instruments_snapshot(raw_dir, instruments)
+
+        for base in bases:
+            all_rows = _bound_hourly_rows(BOUND_START, BOUND_END)
+            split_at = len(all_rows) // 2
+            _write_raw_page(raw_dir, base=base, page=0, rows=all_rows[:split_at])
+            _write_raw_page(raw_dir, base=base, page=1, rows=all_rows[split_at:])
+
+        lifecycle = source_root / "lifecycle"
+        lifecycle.mkdir(parents=True)
+        (lifecycle / "SOURCE_REGISTRATION.json").write_text(
+            json.dumps({"source_snapshot_digest": "e" * 64}, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        output_root = tmp / "output"
+        source_result = materialize_bound_period_panel_from_raw_sources_v1(
+            source_root,
+            output_root,
+            period_binding=build_period_binding_v0(),
+        )
+        assert source_result.status is BoundPeriodSourceMaterializationStatus.MATERIALIZED
+        assert source_result.instrument_count >= 5
+        assert REASON_NO_ELIGIBLE_RAW_SERIES not in source_result.reason_codes
+
+        manifest_result = materialize_panel_staging_source_manifests_v1(output_root)
+        assert manifest_result.status is SourceManifestStatus.VERIFIED
+        ok, _, _ = verify_panel_staging_source_manifests_v1(output_root)
+        assert ok
+
+        dataset_result = materialize_bound_panel_dataset_v0(
+            output_root,
+            period_binding=build_period_binding_v0(),
+        )
+        assert (
+            dataset_result.status is MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE
+        )
+        assert dataset_result.instrument_count >= 5

--- a/tests/research/test_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2.py
+++ b/tests/research/test_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2.py
@@ -1,0 +1,174 @@
+"""Contract tests for cross-sectional offline economic evaluation execution v2."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (
+    SourceManifestStatus,
+    materialize_panel_staging_source_manifests_v1,
+)
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v0 import (
+    EXECUTION_V2_GO_TOKEN,
+)
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2 import (
+    EconomicClassification,
+    ExecutionV2TerminalStatus,
+    FIXTURE_DATA_DIGEST,
+    GO_TOKEN,
+    run_full_offline_economic_evaluation_v2,
+)
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_scope_ratification_v0 import (
+    materialize_cross_sectional_offline_economic_evaluation_scope_ratification_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_versioned_research_binding_v0 import (
+    materialize_versioned_research_binding_v0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.fixture_builder import (
+    build_synthetic_panel_series_v0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.staging_builder import (
+    write_bound_period_staging_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_research_binding_v0()
+
+
+@pytest.fixture(name="scope_ratification")
+def fixture_scope_ratification(complete_binding: dict) -> dict:
+    return materialize_cross_sectional_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=REPO_ROOT,
+        versioned_binding=complete_binding,
+    )
+
+
+@pytest.fixture(name="bound_staging")
+def fixture_bound_staging() -> Path:
+    tmp = Path(tempfile.mkdtemp(prefix="cs_rs_exec_v2_staging_"))
+    staging = write_bound_period_staging_v0(tmp)
+    lifecycle = staging / "lifecycle"
+    lifecycle.mkdir(parents=True, exist_ok=True)
+    (lifecycle / "SOURCE_REGISTRATION.json").write_text(
+        json.dumps(
+            {
+                "source_snapshot_ref": "test:fixture",
+                "source_snapshot_digest": "b" * 64,
+                "registered": True,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_result = materialize_panel_staging_source_manifests_v1(staging)
+    assert manifest_result.status is SourceManifestStatus.VERIFIED
+    return staging
+
+
+def test_execution_v2_go_token_constants() -> None:
+    assert GO_TOKEN == EXECUTION_V2_GO_TOKEN
+    assert GO_TOKEN == (
+        "GO_BOUNDED_CROSS_SECTIONAL_RELATIVE_STRENGTH_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V2"
+    )
+
+
+def test_fixture_digest_constant_present() -> None:
+    assert len(FIXTURE_DATA_DIGEST) == 64
+
+
+def test_execution_v2_runs_with_bound_staging(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    tmp = Path(tempfile.mkdtemp(prefix="cs_rs_exec_v2_non_fixture_"))
+    panel = build_synthetic_panel_series_v0(bar_count=31, end="2024-06-01T02:00:00Z")
+    staging = write_bound_period_staging_v0(tmp, panel_series=panel)
+    lifecycle = staging / "lifecycle"
+    lifecycle.mkdir(parents=True, exist_ok=True)
+    (lifecycle / "SOURCE_REGISTRATION.json").write_text(
+        json.dumps(
+            {
+                "source_snapshot_ref": "test:non_fixture",
+                "source_snapshot_digest": "c" * 64,
+                "registered": True,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    materialize_panel_staging_source_manifests_v1(staging)
+    result = run_full_offline_economic_evaluation_v2(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        staging_root=staging,
+        panel_series=panel,
+        versioned_binding=complete_binding,
+        go_token=GO_TOKEN,
+    )
+    assert result.economic_evaluation_executed is True
+    assert result.status is ExecutionV2TerminalStatus.ECONOMIC_EVALUATION_COMPLETE
+    assert result.economic_classification in {
+        EconomicClassification.PASS,
+        EconomicClassification.FAIL,
+        EconomicClassification.INCONCLUSIVE,
+    }
+    assert result.authority_effect == "NONE"
+    assert result.runtime_effect == "NONE"
+    assert result.panel_data_digest != FIXTURE_DATA_DIGEST
+    assert "net_return" in result.economic_viability_evidence
+
+
+def test_execution_v2_fail_closed_on_fixture_digest(
+    bound_staging: Path,
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (
+        materialize_bound_panel_dataset_v0,
+    )
+
+    materialization = materialize_bound_panel_dataset_v0(
+        bound_staging,
+        period_binding=complete_binding["period_binding"],
+    )
+    if materialization.panel_data_digest != FIXTURE_DATA_DIGEST:
+        pytest.skip("staging_digest_not_fixture_contract_digest")
+    panel = build_synthetic_panel_series_v0()
+    result = run_full_offline_economic_evaluation_v2(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        staging_root=bound_staging,
+        panel_series=panel,
+        versioned_binding=complete_binding,
+        go_token=GO_TOKEN,
+    )
+    assert result.status is ExecutionV2TerminalStatus.FAIL_CLOSED_FIXTURE_LEAKAGE
+    assert result.economic_evaluation_executed is False
+
+
+def test_execution_v2_rejects_invalid_go_token(
+    bound_staging: Path,
+    scope_ratification: dict,
+) -> None:
+    panel = build_synthetic_panel_series_v0()
+    result = run_full_offline_economic_evaluation_v2(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        staging_root=bound_staging,
+        panel_series=panel,
+        go_token="INVALID_GO_TOKEN",
+    )
+    assert result.status is ExecutionV2TerminalStatus.FAIL_CLOSED_PRECHECK
+    assert result.economic_evaluation_executed is False

--- a/tests/research/test_cross_sectional_trade_record_schema_v0.py
+++ b/tests/research/test_cross_sectional_trade_record_schema_v0.py
@@ -1,0 +1,277 @@
+"""Contract tests for cross-sectional trade-record schema and backtest wiring v0."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.backtest.stats import TradeRecordContractError, compute_trade_stats
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2 import (
+    GO_TOKEN,
+    run_full_offline_economic_evaluation_v2,
+)
+from src.research.cross_sectional_relative_strength_v0_offline_economic_evaluation_scope_ratification_v0 import (
+    materialize_cross_sectional_offline_economic_evaluation_scope_ratification_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_versioned_research_binding_v0 import (
+    materialize_versioned_research_binding_v0,
+)
+from src.research.cross_sectional_single_slot_backtest_wiring_v0 import (
+    run_single_slot_panel_backtest_v0,
+)
+from src.research.cross_sectional_single_slot_research_orchestrator_v0 import (
+    OrchestratorEpochResultV0,
+    OrchestratorRunResultV0,
+    SingleSlotSelectionEventV0,
+    SlotSide,
+    default_operator_binding_v0,
+    run_cross_sectional_single_slot_orchestrator_v0,
+)
+from src.research.cross_sectional_trade_record_schema_v0 import (
+    CANONICAL_PNL_FIELD,
+    PNL_UNIT,
+    TradeRecordContractError as AdapterTradeRecordContractError,
+    compute_roundtrip_net_pnl_v0,
+    normalize_trades_for_stats_v0,
+    validate_trade_record_for_stats_v0,
+)
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (
+    materialize_panel_staging_source_manifests_v1,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.fixture_builder import (
+    build_synthetic_panel_series_v0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.staging_builder import (
+    write_bound_period_staging_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _cost_binding() -> dict:
+    binding = materialize_versioned_research_binding_v0()
+    return binding["cost_execution_binding"]
+
+
+def _rotation_orchestrator(
+    panel: tuple,
+    *,
+    instrument_id: str = "okx:linear_perpetual:ETH-USDT",
+) -> OrchestratorRunResultV0:
+    ts0 = panel[0].bars[0].timestamp_utc
+    ts1 = panel[0].bars[1].timestamp_utc
+    return OrchestratorRunResultV0(
+        orchestrator_version="test.orchestrator",
+        score_formula_version="test.score",
+        epochs=(
+            OrchestratorEpochResultV0(
+                epoch_index=0,
+                timestamp_utc=ts0,
+                scores=(),
+                selection=SingleSlotSelectionEventV0(
+                    epoch_index=0,
+                    timestamp_utc=ts0,
+                    ranked_instrument_ids=(instrument_id,),
+                    top_score=1.0,
+                    selected_instrument_id=instrument_id,
+                    slot_side=SlotSide.LONG,
+                    pending_switch=False,
+                    eligible_member_count=len(panel),
+                ),
+                error_codes=(),
+            ),
+            OrchestratorEpochResultV0(
+                epoch_index=1,
+                timestamp_utc=ts1,
+                scores=(),
+                selection=SingleSlotSelectionEventV0(
+                    epoch_index=1,
+                    timestamp_utc=ts1,
+                    ranked_instrument_ids=(),
+                    top_score=None,
+                    selected_instrument_id=None,
+                    slot_side=SlotSide.FLAT,
+                    pending_switch=True,
+                    eligible_member_count=len(panel),
+                ),
+                error_codes=(),
+            ),
+        ),
+        final_slot_side=SlotSide.FLAT,
+        final_instrument_id=None,
+        authority_effect="NONE",
+        runtime_effect="NONE",
+        order_effect="NONE",
+    )
+
+
+def _run_backtest(*, bar_count: int = 31, with_rotation: bool = True) -> object:
+    panel = build_synthetic_panel_series_v0(bar_count=bar_count, end="2024-06-01T02:00:00Z")
+    if with_rotation:
+        orchestrator = _rotation_orchestrator(panel)
+    else:
+        orchestrator = run_cross_sectional_single_slot_orchestrator_v0(
+            binding=default_operator_binding_v0(),
+            panel_series=panel,
+        )
+    return run_single_slot_panel_backtest_v0(
+        orchestrator,
+        panel,
+        cost_execution_binding=_cost_binding(),
+    )
+
+
+def test_a_canonical_trade_record_processed_by_compute_trade_stats() -> None:
+    trade = {
+        "entry_time": "2024-05-30T20:00:00Z",
+        "exit_time": "2024-05-30T21:00:00Z",
+        "instrument_id": "okx:linear_perpetual:ETH-USDT",
+        "side": "LONG",
+        "entry_price": 100.0,
+        "exit_price": 110.0,
+        "gross_pnl_frac": 0.1,
+        "gross_pnl": 100.0,
+        "entry_cost": 5.0,
+        "exit_cost": 5.0,
+        CANONICAL_PNL_FIELD: 90.0,
+        "pnl_unit": PNL_UNIT,
+    }
+    validate_trade_record_for_stats_v0(trade)
+    stats = compute_trade_stats([trade])
+    assert stats.total_trades == 1
+    assert stats.winning_trades == 1
+    assert stats.profit_factor == 0.0
+
+
+def test_b_missing_pnl_fail_closed_in_compute_trade_stats() -> None:
+    malformed = {"side": "LONG", "gross_pnl_frac": 0.01}
+    with pytest.raises(TradeRecordContractError, match="trade_record_missing_canonical_pnl_field"):
+        compute_trade_stats([malformed])
+
+
+def test_b_missing_pnl_fail_closed_in_adapter() -> None:
+    with pytest.raises(
+        AdapterTradeRecordContractError,
+        match="trade_record_missing_canonical_pnl_field",
+    ):
+        validate_trade_record_for_stats_v0({"gross_pnl_frac": 0.01})
+
+
+def test_c_producer_consumer_parity() -> None:
+    result = _run_backtest()
+    records = result.trades.to_dict(orient="records")
+    assert records, "expected at least one trade from synthetic panel"
+    for record in records:
+        assert CANONICAL_PNL_FIELD in record
+        assert record["pnl_unit"] == PNL_UNIT
+        assert "entry_cost" in record
+        assert "exit_cost" in record
+        assert "gross_pnl" in record
+    normalized = normalize_trades_for_stats_v0(records)
+    stats = compute_trade_stats(normalized)
+    assert stats.total_trades == len(records)
+
+
+def test_d_gross_net_semantics_no_double_cost() -> None:
+    equity_at_entry = 10_000.0
+    equity_before_exit = 10_500.0
+    gross_pnl_frac = 0.02
+    exit_cost = 10.0
+    gross_abs, net_abs = compute_roundtrip_net_pnl_v0(
+        equity_at_entry=equity_at_entry,
+        equity_before_exit=equity_before_exit,
+        gross_pnl_frac=gross_pnl_frac,
+        exit_cost=exit_cost,
+    )
+    assert gross_abs == pytest.approx(equity_before_exit * gross_pnl_frac)
+    expected_after = equity_before_exit * (1.0 + gross_pnl_frac) - exit_cost
+    assert net_abs == pytest.approx(expected_after - equity_at_entry)
+
+    result = _run_backtest()
+    for row in result.trades.to_dict(orient="records"):
+        assert row["entry_cost"] > 0
+        assert row["exit_cost"] > 0
+        assert row["gross_pnl_frac"] != 0.0
+        assert row[CANONICAL_PNL_FIELD] == pytest.approx(
+            row["gross_pnl"] - row["entry_cost"] - row["exit_cost"],
+            rel=0.02,
+            abs=25.0,
+        )
+
+
+def test_e_empty_trades_explicit_state() -> None:
+    stats = compute_trade_stats([])
+    assert stats.total_trades == 0
+    assert stats.win_rate == 0.0
+    assert stats.profit_factor == 0.0
+
+
+def test_f_long_short_symmetry() -> None:
+    long_trade = {
+        CANONICAL_PNL_FIELD: 100.0,
+        "side": SlotSide.LONG.value,
+    }
+    short_trade = {
+        CANONICAL_PNL_FIELD: -100.0,
+        "side": SlotSide.SHORT.value,
+    }
+    long_stats = compute_trade_stats([long_trade])
+    short_stats = compute_trade_stats([short_trade])
+    assert long_stats.winning_trades == 1
+    assert short_stats.losing_trades == 1
+    assert long_stats.avg_win == pytest.approx(abs(short_stats.avg_loss))
+
+
+def test_g_serialization_roundtrip_preserves_pnl_fields() -> None:
+    result = _run_backtest()
+    payload = json.dumps(result.trades.to_dict(orient="records"), sort_keys=True)
+    restored = json.loads(payload)
+    for record in restored:
+        validate_trade_record_for_stats_v0(record)
+        assert record["pnl_unit"] == PNL_UNIT
+    stats = compute_trade_stats(restored)
+    assert stats.total_trades == len(restored)
+
+
+def test_h_execution_v2_integration_no_key_error() -> None:
+    complete_binding = materialize_versioned_research_binding_v0()
+    scope_ratification = (
+        materialize_cross_sectional_offline_economic_evaluation_scope_ratification_v0(
+            repo_root=REPO_ROOT,
+            versioned_binding=complete_binding,
+        )
+    )
+    tmp = Path(tempfile.mkdtemp(prefix="cs_rs_trade_schema_e2e_"))
+    panel = build_synthetic_panel_series_v0(bar_count=31, end="2024-06-01T02:00:00Z")
+    staging = write_bound_period_staging_v0(tmp, panel_series=panel)
+    lifecycle = staging / "lifecycle"
+    lifecycle.mkdir(parents=True, exist_ok=True)
+    (lifecycle / "SOURCE_REGISTRATION.json").write_text(
+        json.dumps(
+            {
+                "source_snapshot_ref": "test:trade_schema",
+                "source_snapshot_digest": "d" * 64,
+                "registered": True,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    materialize_panel_staging_source_manifests_v1(staging)
+    result = run_full_offline_economic_evaluation_v2(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        staging_root=staging,
+        panel_series=panel,
+        versioned_binding=complete_binding,
+        go_token=GO_TOKEN,
+    )
+    assert result.economic_evaluation_executed is True
+    assert result.backtest is not None
+    if not result.backtest.trades.empty:
+        assert CANONICAL_PNL_FIELD in result.backtest.trades.columns


### PR DESCRIPTION
## Summary

Bounded Rank-1 materializer contract repair for the Execution v2 dataset gate blocker (PR #4793).

- **Root cause:** `cross_sectional_bound_period_panel_source_materialization_v1` required non-empty OKX `baseCcy` (empty for all 120 provenance SWAPs) and processed paginated raw pages per file without merge.
- **Reuse-first:** Reuses lifecycle `evaluate_okx_instrument_eligibility_v1` for canonical mapping; merges paginated raw OHLCV pages per instrument before bound-period selection.
- **No dataset/period rebinding:** Bound window remains `2024-05-30T20:00:00Z` .. `2024-06-01T01:00:00Z`.
- **No refetch:** Recovery reuses existing historical staging raw artifacts only.
- **Regression tests:** Empty-baseCcy recovery, lifecycle parity, pagination merge, duplicate handling, isolation, end-to-end bound-period fixture.
- **Authority/runtime effect:** NONE.

## Test plan

- [x] `tests/research/test_cross_sectional_bound_period_panel_source_materialization_v1.py`
- [x] `tests/research/test_cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v2.py`
- [ ] Execution v2 recovery run (skip-fetch) against existing historical staging — post-push closeout evidence bundle