### PR TITLE
Bounded: cross-sectional funding rate carry v0 binding implementation

### DIFF
--- a/config/research/cross_sectional_funding_rate_carry_v0_ranking_semantics_binding_v0.json
+++ b/config/research/cross_sectional_funding_rate_carry_v0_ranking_semantics_binding_v0.json
@@ -1,0 +1,156 @@
+{
+  "artifact_kind": "cross_sectional_funding_rate_ranking_semantics_versioned_binding",
+  "artifact_version": "v0",
+  "binding": {
+    "binding_status": {
+      "cost_model_binding_status": "REQUIRED_UNBOUND",
+      "dataset_binding_status": "REQUIRED_UNBOUND",
+      "digest_binding_status": "REQUIRED_UNBOUND",
+      "numeric_bindings_status": "BOUND",
+      "overall_binding_status": "INCOMPLETE_FAIL_CLOSED",
+      "period_binding_status": "REQUIRED_UNBOUND",
+      "policy_classes_status": "BOUND",
+      "universe_binding_status": "REQUIRED_UNBOUND"
+    },
+    "digest_bindings": {
+      "config_digest": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "data_digest": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "implementation_digest": {
+        "status": "REQUIRED_UNBOUND"
+      }
+    },
+    "direction_semantics": {
+      "dual_leg_simultaneous_forbidden": true,
+      "long_leg_means": "LONG_LOWEST_FUNDING",
+      "non_finite_funding_target": "FLAT",
+      "panel_insufficient_target": "FLAT",
+      "selection_mode": "funding_extremes_single_leg_rotation_v0",
+      "short_leg_means": "SHORT_HIGHEST_FUNDING",
+      "single_slot_rotation": true,
+      "warmup_incomplete_target": "FLAT"
+    },
+    "external_bindings": {
+      "admissibility_manifest_ref": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "evaluation_period_binding": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "execution_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "fee_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "funding_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "instrument_id_canonicalization_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "panel_funding_dataset_manifest_ref": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "pit_universe_manifest_ref": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "slippage_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "spread_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      }
+    },
+    "hypothesis_id": "CROSS_SECTIONAL_FUNDING_RATE_CARRY_NON_BITCOIN_PERPETUALS_V0",
+    "missing_bar_semantics": {
+      "carry_forward": false,
+      "missing_bar_policy": "exclude_non_selected_instrument_for_epoch",
+      "non_selected_missing": "exclude_for_epoch",
+      "selected_missing": "force_flat"
+    },
+    "numeric_bindings": {
+      "funding_smoothing_window_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "max_bar_staleness_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "min_eligible_members_for_rank": {
+        "status": "BOUND",
+        "value": 5
+      },
+      "rebalance_interval_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "signal_lag_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "switch_entry_delay_epochs": {
+        "status": "BOUND",
+        "value": 1
+      }
+    },
+    "orchestrator": {
+      "owner": "cross_sectional_single_slot_research_orchestrator_v0",
+      "scope": "RESEARCH_ONLY"
+    },
+    "panel_semantics": {
+      "eligibility_mode": "per_instrument_eligibility_mask",
+      "insufficient_panel_action": "flat",
+      "minimum_eligible_member_count_required": true
+    },
+    "policy_classes": {
+      "cooldown_policy": "no_cooldown",
+      "direction_policy": "long_low_funding_short_high_funding",
+      "minimum_hold_policy": "until_next_rebalance",
+      "missing_bar_policy": "exclude_non_selected_instrument_for_epoch",
+      "panel_completeness_policy": "per_instrument_eligibility_mask",
+      "rebalance_policy_class": "fixed_N_bar_cadence",
+      "score_family_policy": "cross_sectional_funding_rate_rank_long_low_short_high",
+      "signal_timing_policy": "finalized_bar_close_epoch",
+      "switch_policy": "flat_then_wait_one_epoch_then_enter",
+      "threshold_policy": "rank_extremes_only_no_continuous_threshold_tuning",
+      "tie_break_policy": "funding_rate_asc_then_instrument_id_asc_for_long_leg"
+    },
+    "schema_version": "cross_sectional_funding_rate_ranking_semantics_binding.v0",
+    "switch_semantics": {
+      "atomic_side_switch": false,
+      "flat_then_wait_one_epoch_then_enter": true,
+      "opposite_side_requires_reconciled_flat": true,
+      "switch_policy": "flat_then_wait_one_epoch_then_enter"
+    },
+    "system_constraints": {
+      "bitcoin_direction_allowed": false,
+      "futures_only": true,
+      "spot_allowed": false,
+      "synthetic_spot_allowed": false
+    },
+    "threshold_semantics": {
+      "numeric_strength_threshold_initial": false,
+      "threshold_policy": "rank_extremes_only_no_continuous_threshold_tuning"
+    },
+    "tie_break_semantics": {
+      "long_leg_order": "funding_rate_asc_then_instrument_id_asc",
+      "short_leg_order": "funding_rate_desc_then_instrument_id_asc",
+      "tie_break_policy": "funding_rate_asc_then_instrument_id_asc_for_long_leg"
+    },
+    "timing_semantics": {
+      "decision_input": "finalized_bars_only",
+      "finalized_bar_required": true,
+      "funding_observation_field": "funding_rate",
+      "minimum_signal_lag_bars": 1,
+      "pit_universe_at_score_epoch": true,
+      "same_bar_execution": false,
+      "score_epoch": "finalized_bar_close"
+    }
+  },
+  "operator_decision_digest": "7131f94848a494d272039c6f6d17ed0fff10d7d999d380e8c84040b215ad47a0"
+}

--- a/config/research/cross_sectional_funding_rate_carry_v0_versioned_research_binding_v0.json
+++ b/config/research/cross_sectional_funding_rate_carry_v0_versioned_research_binding_v0.json
@@ -1,0 +1,320 @@
+{
+  "artifact_kind": "cross_sectional_funding_rate_carry_v0_versioned_research_binding",
+  "artifact_version": "v0",
+  "authority_effect": "NONE",
+  "binding": {
+    "binding_status": {
+      "cost_model_binding_status": "BOUND",
+      "dataset_binding_status": "BOUND",
+      "digest_binding_status": "BOUND",
+      "numeric_bindings_status": "BOUND",
+      "overall_binding_status": "COMPLETE",
+      "period_binding_status": "BOUND",
+      "policy_classes_status": "BOUND",
+      "universe_binding_status": "BOUND"
+    },
+    "digest_bindings": {
+      "config_digest": {
+        "status": "BOUND",
+        "value": "e0d169f143e16bb60148a26c450a5e7abf0606253fe50c4fb2f8277e9f64a414"
+      },
+      "data_digest": {
+        "status": "BOUND",
+        "value": "0c4f26bfa044f82c3bda505906bcf59da3ff43ad4a63b1e8da6b97ce8b730224"
+      },
+      "implementation_digest": {
+        "status": "BOUND",
+        "value": "c8bdeaca4e26f111ce932e2c6e300d5d2b2a8bf175e3b7c4fa1c1205d6db538e"
+      }
+    },
+    "direction_semantics": {
+      "dual_leg_simultaneous_forbidden": true,
+      "long_leg_means": "LONG_LOWEST_FUNDING",
+      "non_finite_funding_target": "FLAT",
+      "panel_insufficient_target": "FLAT",
+      "selection_mode": "funding_extremes_single_leg_rotation_v0",
+      "short_leg_means": "SHORT_HIGHEST_FUNDING",
+      "single_slot_rotation": true,
+      "warmup_incomplete_target": "FLAT"
+    },
+    "external_bindings": {
+      "admissibility_manifest_ref": {
+        "ref": "pit_cross_sectional_research_dataset_envelope.v0:pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1:with_funding_v1",
+        "status": "BOUND"
+      },
+      "evaluation_period_binding": {
+        "ref": "pit_cross_sectional_research_chronological_holdout_v1:v1",
+        "status": "BOUND"
+      },
+      "execution_model_version": {
+        "status": "BOUND",
+        "value": "backtest_execution_v0"
+      },
+      "fee_model_version": {
+        "status": "BOUND",
+        "value": "backtest_fee_taker_symmetric_v0"
+      },
+      "funding_model_version": {
+        "status": "BOUND",
+        "value": "backtest_funding_perpetual_interval_v1"
+      },
+      "instrument_id_canonicalization_version": {
+        "status": "BOUND",
+        "value": "instrument_id_canonicalization.v1"
+      },
+      "panel_funding_dataset_manifest_ref": {
+        "ref": "pit_okx_pt1h_panel_funding_dataset_v1:pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1:with_funding_v1",
+        "status": "BOUND"
+      },
+      "pit_universe_manifest_ref": {
+        "ref": "pit_futures_universe_manifest_v1:pit_okx_linear_usdt_non_bitcoin_perpetual_universe_manifest_v1",
+        "status": "BOUND"
+      },
+      "slippage_model_version": {
+        "status": "BOUND",
+        "value": "backtest_slippage_symmetric_v0"
+      },
+      "spread_model_version": {
+        "status": "BOUND",
+        "value": "research_conservative_bps_v1"
+      }
+    },
+    "hypothesis_id": "CROSS_SECTIONAL_FUNDING_RATE_CARRY_NON_BITCOIN_PERPETUALS_V0",
+    "missing_bar_semantics": {
+      "carry_forward": false,
+      "missing_bar_policy": "exclude_non_selected_instrument_for_epoch",
+      "non_selected_missing": "exclude_for_epoch",
+      "selected_missing": "force_flat"
+    },
+    "numeric_bindings": {
+      "funding_smoothing_window_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "max_bar_staleness_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "min_eligible_members_for_rank": {
+        "status": "BOUND",
+        "value": 5
+      },
+      "rebalance_interval_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "signal_lag_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "switch_entry_delay_epochs": {
+        "status": "BOUND",
+        "value": 1
+      }
+    },
+    "orchestrator": {
+      "owner": "cross_sectional_single_slot_research_orchestrator_v0",
+      "scope": "RESEARCH_ONLY"
+    },
+    "panel_semantics": {
+      "eligibility_mode": "per_instrument_eligibility_mask",
+      "insufficient_panel_action": "flat",
+      "minimum_eligible_member_count_required": true
+    },
+    "policy_classes": {
+      "cooldown_policy": "no_cooldown",
+      "direction_policy": "long_low_funding_short_high_funding",
+      "minimum_hold_policy": "until_next_rebalance",
+      "missing_bar_policy": "exclude_non_selected_instrument_for_epoch",
+      "panel_completeness_policy": "per_instrument_eligibility_mask",
+      "rebalance_policy_class": "fixed_N_bar_cadence",
+      "score_family_policy": "cross_sectional_funding_rate_rank_long_low_short_high",
+      "signal_timing_policy": "finalized_bar_close_epoch",
+      "switch_policy": "flat_then_wait_one_epoch_then_enter",
+      "threshold_policy": "rank_extremes_only_no_continuous_threshold_tuning",
+      "tie_break_policy": "funding_rate_asc_then_instrument_id_asc_for_long_leg"
+    },
+    "schema_version": "cross_sectional_funding_rate_ranking_semantics_binding.v0",
+    "switch_semantics": {
+      "atomic_side_switch": false,
+      "flat_then_wait_one_epoch_then_enter": true,
+      "opposite_side_requires_reconciled_flat": true,
+      "switch_policy": "flat_then_wait_one_epoch_then_enter"
+    },
+    "system_constraints": {
+      "bitcoin_direction_allowed": false,
+      "futures_only": true,
+      "spot_allowed": false,
+      "synthetic_spot_allowed": false
+    },
+    "threshold_semantics": {
+      "numeric_strength_threshold_initial": false,
+      "threshold_policy": "rank_extremes_only_no_continuous_threshold_tuning"
+    },
+    "tie_break_semantics": {
+      "long_leg_order": "funding_rate_asc_then_instrument_id_asc",
+      "short_leg_order": "funding_rate_desc_then_instrument_id_asc",
+      "tie_break_policy": "funding_rate_asc_then_instrument_id_asc_for_long_leg"
+    },
+    "timing_semantics": {
+      "decision_input": "finalized_bars_only",
+      "finalized_bar_required": true,
+      "funding_observation_field": "funding_rate",
+      "minimum_signal_lag_bars": 1,
+      "pit_universe_at_score_epoch": true,
+      "same_bar_execution": false,
+      "score_epoch": "finalized_bar_close"
+    }
+  },
+  "binding_digest": "a98d40449cf32bc5415fadd4c26976e380d3be2880a03efebbc1e9149e809cd9",
+  "config_digest": "e0d169f143e16bb60148a26c450a5e7abf0606253fe50c4fb2f8277e9f64a414",
+  "cost_execution_binding": {
+    "binding_version": "v0",
+    "execution_model_binding": {
+      "effective_entry_cost_bps": 20.0,
+      "effective_exit_cost_bps": 20.0,
+      "execution_model_version": "backtest_execution_v0",
+      "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+      "roundtrip_cost_bps": 40.0
+    },
+    "fee_model_binding": {
+      "fee_bps_per_side": 10.0,
+      "fee_model_version": "backtest_fee_taker_symmetric_v0"
+    },
+    "funding_model_binding": {
+      "bind": true,
+      "funding_model_version": "backtest_funding_perpetual_interval_v1"
+    },
+    "implicit_zero_cost_forbidden": true,
+    "slippage_model_binding": {
+      "slippage_bps_per_side": 5.0,
+      "slippage_model_version": "backtest_slippage_symmetric_v0"
+    },
+    "spread_model_binding": {
+      "conservative_half_spread_bps": 5.0,
+      "spread_model_version": "research_conservative_bps_v1"
+    }
+  },
+  "data_digest": "0c4f26bfa044f82c3bda505906bcf59da3ff43ad4a63b1e8da6b97ce8b730224",
+  "economic_evaluation_executed": false,
+  "economic_policy_binding": {
+    "binding_version": "v1",
+    "economic_validity_policy_version": "economic_validity_policy_v1",
+    "policy_lowering_forbidden": true,
+    "promising_is_not_pass": true
+  },
+  "hypothesis_frozen": true,
+  "implementation_digest": "c8bdeaca4e26f111ce932e2c6e300d5d2b2a8bf175e3b7c4fa1c1205d6db538e",
+  "instrument_binding": {
+    "binding_version": "v0",
+    "bitcoin_excluded": true,
+    "direction_policy": "long_low_funding_short_high_funding",
+    "instrument_id_canonicalization_version": "instrument_id_canonicalization.v1",
+    "pit_universe_manifest_ref": "pit_futures_universe_manifest_v1:pit_okx_linear_usdt_non_bitcoin_perpetual_universe_manifest_v1",
+    "selection_mode": "funding_extremes_single_leg_rotation_v0",
+    "spot_excluded": true,
+    "synthetic_spot_excluded": true
+  },
+  "non_authorizing": true,
+  "orchestrator_owner": "cross_sectional_single_slot_research_orchestrator_v0",
+  "order_effect": "NONE",
+  "panel_dataset_binding": {
+    "bar_interval": "PT1H",
+    "binding_version": "v0",
+    "credential_access_forbidden": true,
+    "dataset_extension": "with_funding_v1",
+    "dataset_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+    "dataset_version": "v1",
+    "duplicate_bars_policy": "fail_closed",
+    "funding_fields": [
+      "funding_rate"
+    ],
+    "funding_usage": "funding_rate_for_score_computation",
+    "instrument_key": "instrument_id",
+    "missing_bars_policy": "exclude_non_selected_for_epoch",
+    "narrow_adapter": "pit_okx_pt1h_panel_funding_field_materialization.v0",
+    "network_access_forbidden": true,
+    "ohlcv_fields": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "out_of_order_bars_policy": "fail_closed",
+    "panel_funding_dataset_manifest_ref": "pit_okx_pt1h_panel_funding_dataset_v1:pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1:with_funding_v1",
+    "panel_schema": "pit_okx_pt1h_panel_funding_dataset_manifest_v1",
+    "price_usage": "close_for_execution_reference_only",
+    "timestamp_key": "timestamp_utc",
+    "timezone": "UTC",
+    "warmup_bars": 1
+  },
+  "parameter_binding": {
+    "binding_version": "v0",
+    "funding_observation_field": "funding_rate",
+    "operator_decision_digest": "7131f94848a494d272039c6f6d17ed0fff10d7d999d380e8c84040b215ad47a0",
+    "parameter_search_forbidden": true,
+    "parameters": {
+      "funding_smoothing_window_bars": 1,
+      "max_bar_staleness_bars": 1,
+      "min_eligible_members_for_rank": 5,
+      "rebalance_interval_bars": 1,
+      "signal_lag_bars": 1,
+      "switch_entry_delay_epochs": 1
+    },
+    "score_formula_expression": "score_i = -funding_rate_i[t-lag] after optional smoothing over funding_smoothing_window_bars; long_leg = instrument with minimum funding_rate; short_leg = instrument with maximum funding_rate; single_slot selects leg with larger absolute funding extremeness",
+    "score_formula_version": "cross_sectional_funding_rate_rank_long_low_short_high_v0"
+  },
+  "period_binding": {
+    "binding_version": "v1",
+    "boundary_semantics": "utc_bar_close_inclusive_end",
+    "embargo_duration": "PT2H",
+    "holdout_isolation_enforced": true,
+    "no_overlap_enforced": true,
+    "out_of_sample_end": "2024-06-01T01:00:00Z",
+    "out_of_sample_start": "2024-05-31T18:00:00Z",
+    "period_binding_id": "pit_cross_sectional_research_chronological_holdout_v1",
+    "periods_frozen_before_evaluation": true,
+    "purge_duration": "PT2H",
+    "split_policy_id": "pit_cross_sectional_research_chronological_holdout_v1",
+    "split_timezone": "UTC",
+    "training_end": "2024-05-31T08:00:00Z",
+    "training_start": "2024-05-30T20:00:00Z",
+    "validation_end": "2024-05-31T16:00:00Z",
+    "validation_start": "2024-05-31T10:00:00Z",
+    "warmup_end": "2024-05-30T19:00:00Z",
+    "warmup_start": "2024-05-25T00:00:00Z"
+  },
+  "pit_universe_binding": {
+    "binding_version": "v0",
+    "bitcoin_excluded": true,
+    "futures_only": true,
+    "instrument_identity_normalization": "instrument_id_canonicalization.v1",
+    "instrument_type": "LINEAR_PERPETUAL",
+    "minimum_eligible_member_count": 5,
+    "pit_universe_manifest_ref": "pit_futures_universe_manifest_v1:pit_okx_linear_usdt_non_bitcoin_perpetual_universe_manifest_v1",
+    "settlement_asset": "USDT",
+    "spot_excluded": true,
+    "survivorship_bias_forbidden": true,
+    "synthetic_spot_excluded": true,
+    "universe_lifecycle_registry_ref": "pit_futures_lifecycle_registry_v1:okx_production_lifecycle_v1",
+    "universe_policy_id": "pit_okx_linear_usdt_non_bitcoin_perpetual_cross_sectional_universe",
+    "universe_policy_version": "v1",
+    "venue": "OKX"
+  },
+  "ranking_semantics_binding_ref": "config/research/cross_sectional_funding_rate_carry_v0_ranking_semantics_binding_v0.json",
+  "ranking_semantics_schema_version": "cross_sectional_funding_rate_ranking_semantics_binding.v0",
+  "research_binding_only": true,
+  "research_hypothesis_id": "CROSS_SECTIONAL_FUNDING_RATE_CARRY_NON_BITCOIN_PERPETUALS_V0",
+  "runtime_effect": "NONE",
+  "schema_version": "cross_sectional_funding_rate_carry_v0_versioned_research_binding.v0",
+  "strategy_id": "cross_sectional_funding_rate_carry",
+  "strategy_version": "v0",
+  "system_constraints": {
+    "bitcoin_direction_allowed": false,
+    "futures_only": true,
+    "spot_allowed": false,
+    "synthetic_spot_allowed": false
+  },
+  "validation_verdict": "ACCEPTED_COMPLETE"
+}

--- a/src/research/cross_sectional_funding_rate_carry_scoring_v0.py
+++ b/src/research/cross_sectional_funding_rate_carry_scoring_v0.py
@@ -1,0 +1,147 @@
+"""Cross-sectional funding-rate carry v0 score and single-leg selection primitives.
+
+Pure offline, deterministic funding-rate ranking for long-low / short-high rotation.
+Research-only; no runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Sequence
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_FUNDING_RATE_CARRY_SCORING_V0=true"
+
+SCORE_FORMULA_VERSION = "cross_sectional_funding_rate_rank_long_low_short_high_v0"
+SCORE_FORMULA_EXPRESSION = (
+    "score_i = -funding_rate_i[t-lag] after optional smoothing over funding_smoothing_window_bars; "
+    "long_leg = instrument with minimum funding_rate; "
+    "short_leg = instrument with maximum funding_rate; "
+    "single_slot selects leg with larger absolute funding extremeness"
+)
+
+
+class FundingCarryLeg(str, Enum):
+    FLAT = "FLAT"
+    LONG_LOW = "LONG_LOW"
+    SHORT_HIGH = "SHORT_HIGH"
+
+
+@dataclass(frozen=True)
+class FundingCarryScoreResultV0:
+    instrument_id: str
+    funding_rate: float
+    smoothed_funding_rate: float
+    warmup_complete: bool
+
+
+@dataclass(frozen=True)
+class FundingExtremeSelectionV0:
+    leg: FundingCarryLeg
+    instrument_id: str | None
+    min_funding_instrument_id: str | None
+    max_funding_instrument_id: str | None
+    min_funding_rate: float | None
+    max_funding_rate: float | None
+
+
+def _is_bitcoin_instrument(instrument_id: str) -> bool:
+    lowered = instrument_id.lower()
+    return any(token in lowered for token in ("btc", "xbt", "bitcoin"))
+
+
+def _smooth_funding_rates(
+    rates: Sequence[float],
+    *,
+    window: int,
+    epoch_index: int,
+    signal_lag_bars: int,
+) -> float | None:
+    lag_idx = epoch_index - signal_lag_bars
+    if lag_idx < 0:
+        return None
+    start = lag_idx - window + 1
+    if start < 0:
+        return None
+    window_values = rates[start : lag_idx + 1]
+    if not window_values or any(not math.isfinite(value) for value in window_values):
+        return None
+    return sum(window_values) / len(window_values)
+
+
+def compute_instrument_funding_score_v0(
+    instrument_id: str,
+    funding_rates: Sequence[float],
+    *,
+    funding_smoothing_window_bars: int,
+    signal_lag_bars: int,
+    epoch_index: int,
+) -> FundingCarryScoreResultV0 | None:
+    if _is_bitcoin_instrument(instrument_id):
+        return None
+    smoothed = _smooth_funding_rates(
+        funding_rates,
+        window=funding_smoothing_window_bars,
+        epoch_index=epoch_index,
+        signal_lag_bars=signal_lag_bars,
+    )
+    if smoothed is None or not math.isfinite(smoothed):
+        return None
+    lag_idx = epoch_index - signal_lag_bars
+    raw = funding_rates[lag_idx]
+    if not math.isfinite(raw):
+        return None
+    return FundingCarryScoreResultV0(
+        instrument_id=instrument_id,
+        funding_rate=raw,
+        smoothed_funding_rate=smoothed,
+        warmup_complete=True,
+    )
+
+
+def rank_funding_scores_for_long_low_v0(
+    scores: Sequence[FundingCarryScoreResultV0],
+) -> tuple[FundingCarryScoreResultV0, ...]:
+    return tuple(sorted(scores, key=lambda item: (item.smoothed_funding_rate, item.instrument_id)))
+
+
+def rank_funding_scores_for_short_high_v0(
+    scores: Sequence[FundingCarryScoreResultV0],
+) -> tuple[FundingCarryScoreResultV0, ...]:
+    return tuple(sorted(scores, key=lambda item: (-item.smoothed_funding_rate, item.instrument_id)))
+
+
+def select_funding_extreme_single_leg_v0(
+    scores: Sequence[FundingCarryScoreResultV0],
+) -> FundingExtremeSelectionV0:
+    if not scores:
+        return FundingExtremeSelectionV0(
+            leg=FundingCarryLeg.FLAT,
+            instrument_id=None,
+            min_funding_instrument_id=None,
+            max_funding_instrument_id=None,
+            min_funding_rate=None,
+            max_funding_rate=None,
+        )
+    long_ranked = rank_funding_scores_for_long_low_v0(scores)
+    short_ranked = rank_funding_scores_for_short_high_v0(scores)
+    min_item = long_ranked[0]
+    max_item = short_ranked[0]
+    if abs(min_item.smoothed_funding_rate) >= abs(max_item.smoothed_funding_rate):
+        return FundingExtremeSelectionV0(
+            leg=FundingCarryLeg.LONG_LOW,
+            instrument_id=min_item.instrument_id,
+            min_funding_instrument_id=min_item.instrument_id,
+            max_funding_instrument_id=max_item.instrument_id,
+            min_funding_rate=min_item.smoothed_funding_rate,
+            max_funding_rate=max_item.smoothed_funding_rate,
+        )
+    return FundingExtremeSelectionV0(
+        leg=FundingCarryLeg.SHORT_HIGH,
+        instrument_id=max_item.instrument_id,
+        min_funding_instrument_id=min_item.instrument_id,
+        max_funding_instrument_id=max_item.instrument_id,
+        min_funding_rate=min_item.smoothed_funding_rate,
+        max_funding_rate=max_item.smoothed_funding_rate,
+    )

--- a/src/research/cross_sectional_funding_rate_carry_v0_versioned_research_binding_v0.py
+++ b/src/research/cross_sectional_funding_rate_carry_v0_versioned_research_binding_v0.py
@@ -1,0 +1,430 @@
+"""Cross-sectional funding-rate carry v0 versioned research binding materializer.
+
+Completes and ratifies the offline research binding contract for
+strategy_id=cross_sectional_funding_rate_carry, strategy_version=v0.
+Reuses cross-sectional infrastructure with narrow funding-panel adapter.
+
+Research-only; no economic evaluation, runtime, orders, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.backtest.economic_validity_policy_v1 import ECONOMIC_VALIDITY_POLICY_VERSION
+from src.research.cross_sectional_funding_rate_carry_scoring_v0 import (
+    SCORE_FORMULA_EXPRESSION,
+    SCORE_FORMULA_VERSION,
+)
+from src.research.cross_sectional_funding_rate_ranking_semantics_binding_v0 import (
+    ATTESTED_OPERATOR_DECISION_DIGEST,
+    EXTERNAL_BINDING_KEYS,
+    HYPOTHESIS_ID,
+    ORCHESTRATOR_OWNER,
+    SCHEMA_VERSION,
+    VERSIONED_BINDING_CONFIG_REL_PATH,
+    BindingFieldStatus,
+    apply_ratified_operator_bindings_v0,
+    compute_config_digest_v0,
+    materialize_funding_rate_ranking_semantics_binding_v0,
+    materialize_versioned_funding_rate_ranking_semantics_binding_v0,
+    serialize_versioned_binding_artifact_json_v0,
+)
+from src.research.cross_sectional_funding_rate_ranking_semantics_binding_validator_v0 import (
+    ValidationVerdict,
+    validate_funding_rate_ranking_semantics_binding_v0,
+)
+from src.research.instrument_id_canonicalization_v1 import (
+    INSTRUMENT_ID_CANONICALIZATION_VERSION,
+)
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_FUNDING_RATE_CARRY_V0_VERSIONED_RESEARCH_BINDING_V0=true"
+BINDING_ARTIFACT_VERSION = "v0"
+BINDING_SCHEMA_VERSION = "cross_sectional_funding_rate_carry_v0_versioned_research_binding.v0"
+CONFIG_REL_PATH = (
+    "config/research/cross_sectional_funding_rate_carry_v0_versioned_research_binding_v0.json"
+)
+
+STRATEGY_ID = "cross_sectional_funding_rate_carry"
+STRATEGY_VERSION = "v0"
+RESEARCH_HYPOTHESIS_ID = HYPOTHESIS_ID
+
+PIT_UNIVERSE_MANIFEST_REF = "pit_futures_universe_manifest_v1:pit_okx_linear_usdt_non_bitcoin_perpetual_universe_manifest_v1"
+UNIVERSE_LIFECYCLE_REGISTRY_REF = "pit_futures_lifecycle_registry_v1:okx_production_lifecycle_v1"
+PANEL_DATASET_ID = "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1"
+PANEL_DATASET_EXTENSION = "with_funding_v1"
+PANEL_FUNDING_DATASET_MANIFEST_REF = (
+    f"pit_okx_pt1h_panel_funding_dataset_v1:{PANEL_DATASET_ID}:{PANEL_DATASET_EXTENSION}"
+)
+ADMISSIBILITY_MANIFEST_REF = (
+    f"pit_cross_sectional_research_dataset_envelope.v0:{PANEL_DATASET_ID}:{PANEL_DATASET_EXTENSION}"
+)
+PERIOD_BINDING_ID = "pit_cross_sectional_research_chronological_holdout_v1"
+PERIOD_BINDING_REF = f"{PERIOD_BINDING_ID}:v1"
+
+FEE_MODEL_VERSION = "backtest_fee_taker_symmetric_v0"
+FEE_BPS_PER_SIDE = 10.0
+SLIPPAGE_MODEL_VERSION = "backtest_slippage_symmetric_v0"
+SLIPPAGE_BPS_PER_SIDE = 5.0
+FUNDING_MODEL_VERSION = "backtest_funding_perpetual_interval_v1"
+SPREAD_MODEL_VERSION = "research_conservative_bps_v1"
+CONSERVATIVE_HALF_SPREAD_BPS = 5.0
+EXECUTION_MODEL_VERSION = "backtest_execution_v0"
+EFFECTIVE_ENTRY_COST_BPS = FEE_BPS_PER_SIDE + SLIPPAGE_BPS_PER_SIDE + CONSERVATIVE_HALF_SPREAD_BPS
+EFFECTIVE_EXIT_COST_BPS = EFFECTIVE_ENTRY_COST_BPS
+ROUNDTRIP_COST_BPS = EFFECTIVE_ENTRY_COST_BPS + EFFECTIVE_EXIT_COST_BPS
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+ORDER_EFFECT = "NONE"
+
+
+class BindingMaterializationVerdict(str, Enum):
+    COMPLETE = "COMPLETE"
+    INCOMPLETE = "INCOMPLETE"
+    REJECTED = "REJECTED"
+
+
+class BindingRatificationStatus(str, Enum):
+    BINDINGS_RATIFIED = "BINDINGS_RATIFIED"
+    FAIL_CLOSED_NOT_RATIFIED = "FAIL_CLOSED_NOT_RATIFIED"
+
+
+@dataclass(frozen=True)
+class VersionedResearchBindingResultV0:
+    verdict: BindingMaterializationVerdict
+    ratification_status: BindingRatificationStatus
+    binding: dict[str, Any]
+    ranking_semantics_binding: dict[str, Any]
+    validation_verdict: ValidationVerdict
+    fail_reasons: tuple[str, ...]
+
+
+def _field_bound(*, value: Any = None, ref: str = "") -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": BindingFieldStatus.BOUND.value}
+    if value is not None:
+        payload["value"] = value
+    if ref:
+        payload["ref"] = ref
+    return payload
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_implementation_digest_v0() -> str:
+    return _stable_digest(
+        {
+            "module": "cross_sectional_funding_rate_carry_v0_versioned_research_binding_v0",
+            "orchestrator": ORCHESTRATOR_OWNER,
+            "score_formula_version": SCORE_FORMULA_VERSION,
+            "schema_version": BINDING_SCHEMA_VERSION,
+            "narrow_adapter": "pit_okx_pt1h_panel_funding_field_materialization.v0",
+        }
+    )
+
+
+def build_parameter_binding_v0() -> dict[str, Any]:
+    from src.research.cross_sectional_funding_rate_ranking_semantics_binding_v0 import (
+        RATIFIED_OPERATOR_BINDING_VALUES,
+    )
+
+    return {
+        "binding_version": "v0",
+        "operator_decision_digest": ATTESTED_OPERATOR_DECISION_DIGEST,
+        "parameters": dict(RATIFIED_OPERATOR_BINDING_VALUES),
+        "score_formula_version": SCORE_FORMULA_VERSION,
+        "score_formula_expression": SCORE_FORMULA_EXPRESSION,
+        "funding_observation_field": "funding_rate",
+        "parameter_search_forbidden": True,
+    }
+
+
+def build_pit_universe_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v0",
+        "venue": "OKX",
+        "instrument_type": "LINEAR_PERPETUAL",
+        "settlement_asset": "USDT",
+        "bitcoin_excluded": True,
+        "spot_excluded": True,
+        "synthetic_spot_excluded": True,
+        "futures_only": True,
+        "universe_policy_id": "pit_okx_linear_usdt_non_bitcoin_perpetual_cross_sectional_universe",
+        "universe_policy_version": "v1",
+        "pit_universe_manifest_ref": PIT_UNIVERSE_MANIFEST_REF,
+        "universe_lifecycle_registry_ref": UNIVERSE_LIFECYCLE_REGISTRY_REF,
+        "minimum_eligible_member_count": 5,
+        "instrument_identity_normalization": INSTRUMENT_ID_CANONICALIZATION_VERSION,
+        "survivorship_bias_forbidden": True,
+    }
+
+
+def build_panel_dataset_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v0",
+        "dataset_id": PANEL_DATASET_ID,
+        "dataset_extension": PANEL_DATASET_EXTENSION,
+        "dataset_version": "v1",
+        "bar_interval": "PT1H",
+        "panel_schema": "pit_okx_pt1h_panel_funding_dataset_manifest_v1",
+        "instrument_key": "instrument_id",
+        "timestamp_key": "timestamp_utc",
+        "timezone": "UTC",
+        "ohlcv_fields": ("open", "high", "low", "close", "volume"),
+        "funding_fields": ("funding_rate",),
+        "price_usage": "close_for_execution_reference_only",
+        "funding_usage": "funding_rate_for_score_computation",
+        "narrow_adapter": "pit_okx_pt1h_panel_funding_field_materialization.v0",
+        "missing_bars_policy": "exclude_non_selected_for_epoch",
+        "duplicate_bars_policy": "fail_closed",
+        "out_of_order_bars_policy": "fail_closed",
+        "warmup_bars": 1,
+        "network_access_forbidden": True,
+        "credential_access_forbidden": True,
+        "panel_funding_dataset_manifest_ref": PANEL_FUNDING_DATASET_MANIFEST_REF,
+    }
+
+
+def build_period_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v1",
+        "period_binding_id": PERIOD_BINDING_ID,
+        "split_policy_id": PERIOD_BINDING_ID,
+        "split_timezone": "UTC",
+        "boundary_semantics": "utc_bar_close_inclusive_end",
+        "warmup_start": "2024-05-25T00:00:00Z",
+        "warmup_end": "2024-05-30T19:00:00Z",
+        "training_start": "2024-05-30T20:00:00Z",
+        "training_end": "2024-05-31T08:00:00Z",
+        "validation_start": "2024-05-31T10:00:00Z",
+        "validation_end": "2024-05-31T16:00:00Z",
+        "out_of_sample_start": "2024-05-31T18:00:00Z",
+        "out_of_sample_end": "2024-06-01T01:00:00Z",
+        "embargo_duration": "PT2H",
+        "purge_duration": "PT2H",
+        "periods_frozen_before_evaluation": True,
+        "no_overlap_enforced": True,
+        "holdout_isolation_enforced": True,
+    }
+
+
+def build_instrument_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v0",
+        "selection_mode": "funding_extremes_single_leg_rotation_v0",
+        "direction_policy": "long_low_funding_short_high_funding",
+        "bitcoin_excluded": True,
+        "spot_excluded": True,
+        "synthetic_spot_excluded": True,
+        "pit_universe_manifest_ref": PIT_UNIVERSE_MANIFEST_REF,
+        "instrument_id_canonicalization_version": INSTRUMENT_ID_CANONICALIZATION_VERSION,
+    }
+
+
+def build_cost_execution_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v0",
+        "fee_model_binding": {
+            "fee_model_version": FEE_MODEL_VERSION,
+            "fee_bps_per_side": FEE_BPS_PER_SIDE,
+        },
+        "slippage_model_binding": {
+            "slippage_model_version": SLIPPAGE_MODEL_VERSION,
+            "slippage_bps_per_side": SLIPPAGE_BPS_PER_SIDE,
+        },
+        "funding_model_binding": {
+            "funding_model_version": FUNDING_MODEL_VERSION,
+            "bind": True,
+        },
+        "spread_model_binding": {
+            "spread_model_version": SPREAD_MODEL_VERSION,
+            "conservative_half_spread_bps": CONSERVATIVE_HALF_SPREAD_BPS,
+        },
+        "execution_model_binding": {
+            "execution_model_version": EXECUTION_MODEL_VERSION,
+            "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+            "effective_entry_cost_bps": EFFECTIVE_ENTRY_COST_BPS,
+            "effective_exit_cost_bps": EFFECTIVE_EXIT_COST_BPS,
+            "roundtrip_cost_bps": ROUNDTRIP_COST_BPS,
+        },
+        "implicit_zero_cost_forbidden": True,
+    }
+
+
+def build_economic_policy_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v1",
+        "economic_validity_policy_version": ECONOMIC_VALIDITY_POLICY_VERSION,
+        "policy_lowering_forbidden": True,
+        "promising_is_not_pass": True,
+    }
+
+
+def apply_complete_external_bindings_v0(binding: dict[str, Any]) -> dict[str, Any]:
+    result = deepcopy(binding)
+    external = result["external_bindings"]
+    external["pit_universe_manifest_ref"] = _field_bound(ref=PIT_UNIVERSE_MANIFEST_REF)
+    external["instrument_id_canonicalization_version"] = _field_bound(
+        value=INSTRUMENT_ID_CANONICALIZATION_VERSION
+    )
+    external["panel_funding_dataset_manifest_ref"] = _field_bound(
+        ref=PANEL_FUNDING_DATASET_MANIFEST_REF
+    )
+    external["admissibility_manifest_ref"] = _field_bound(ref=ADMISSIBILITY_MANIFEST_REF)
+    external["evaluation_period_binding"] = _field_bound(ref=PERIOD_BINDING_REF)
+    external["fee_model_version"] = _field_bound(value=FEE_MODEL_VERSION)
+    external["slippage_model_version"] = _field_bound(value=SLIPPAGE_MODEL_VERSION)
+    external["funding_model_version"] = _field_bound(value=FUNDING_MODEL_VERSION)
+    external["spread_model_version"] = _field_bound(value=SPREAD_MODEL_VERSION)
+    external["execution_model_version"] = _field_bound(value=EXECUTION_MODEL_VERSION)
+
+    impl_digest = compute_implementation_digest_v0()
+    config_bytes = json.dumps(
+        {
+            "strategy_id": STRATEGY_ID,
+            "strategy_version": STRATEGY_VERSION,
+            "parameter_binding": build_parameter_binding_v0(),
+            "pit_universe_binding": build_pit_universe_binding_v0(),
+            "panel_dataset_binding": build_panel_dataset_binding_v0(),
+            "period_binding": build_period_binding_v0(),
+            "cost_execution_binding": build_cost_execution_binding_v0(),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    config_digest = compute_config_digest_v0(config_bytes)
+    data_digest = _stable_digest(
+        {
+            "dataset_id": PANEL_DATASET_ID,
+            "dataset_extension": PANEL_DATASET_EXTENSION,
+            "panel_funding_manifest_ref": PANEL_FUNDING_DATASET_MANIFEST_REF,
+            "pit_universe_manifest_ref": PIT_UNIVERSE_MANIFEST_REF,
+            "funding_field": "funding_rate",
+        }
+    )
+    binding_digest = _stable_digest(
+        {
+            "config_digest": config_digest,
+            "data_digest": data_digest,
+            "implementation_digest": impl_digest,
+            "operator_decision_digest": ATTESTED_OPERATOR_DECISION_DIGEST,
+        }
+    )
+
+    digest = result["digest_bindings"]
+    digest["implementation_digest"] = _field_bound(value=impl_digest)
+    digest["config_digest"] = _field_bound(value=config_digest)
+    digest["data_digest"] = _field_bound(value=data_digest)
+
+    status = result["binding_status"]
+    status["universe_binding_status"] = "BOUND"
+    status["dataset_binding_status"] = "BOUND"
+    status["period_binding_status"] = "BOUND"
+    status["cost_model_binding_status"] = "BOUND"
+    status["digest_binding_status"] = "BOUND"
+    status["overall_binding_status"] = "COMPLETE"
+
+    result["_binding_digest"] = binding_digest
+    return result
+
+
+def materialize_versioned_research_binding_v0() -> dict[str, Any]:
+    base = materialize_funding_rate_ranking_semantics_binding_v0()
+    with_numeric = apply_ratified_operator_bindings_v0(base)
+    complete_binding = apply_complete_external_bindings_v0(with_numeric)
+    binding_digest = complete_binding.pop("_binding_digest", "")
+    validation = validate_funding_rate_ranking_semantics_binding_v0(complete_binding)
+    return {
+        "artifact_kind": "cross_sectional_funding_rate_carry_v0_versioned_research_binding",
+        "artifact_version": BINDING_ARTIFACT_VERSION,
+        "schema_version": BINDING_SCHEMA_VERSION,
+        "strategy_id": STRATEGY_ID,
+        "strategy_version": STRATEGY_VERSION,
+        "research_hypothesis_id": RESEARCH_HYPOTHESIS_ID,
+        "hypothesis_frozen": True,
+        "non_authorizing": True,
+        "research_binding_only": True,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "system_constraints": {
+            "futures_only": True,
+            "bitcoin_direction_allowed": False,
+            "spot_allowed": False,
+            "synthetic_spot_allowed": False,
+        },
+        "ranking_semantics_binding_ref": VERSIONED_BINDING_CONFIG_REL_PATH,
+        "ranking_semantics_schema_version": SCHEMA_VERSION,
+        "orchestrator_owner": ORCHESTRATOR_OWNER,
+        "parameter_binding": build_parameter_binding_v0(),
+        "pit_universe_binding": build_pit_universe_binding_v0(),
+        "panel_dataset_binding": build_panel_dataset_binding_v0(),
+        "period_binding": build_period_binding_v0(),
+        "instrument_binding": build_instrument_binding_v0(),
+        "cost_execution_binding": build_cost_execution_binding_v0(),
+        "economic_policy_binding": build_economic_policy_binding_v0(),
+        "implementation_digest": compute_implementation_digest_v0(),
+        "config_digest": complete_binding["digest_bindings"]["config_digest"]["value"],
+        "data_digest": complete_binding["digest_bindings"]["data_digest"]["value"],
+        "binding_digest": binding_digest,
+        "binding": complete_binding,
+        "validation_verdict": validation.verdict.value,
+    }
+
+
+def materialize_and_validate_versioned_research_binding_v0() -> VersionedResearchBindingResultV0:
+    envelope = materialize_versioned_research_binding_v0()
+    binding = envelope["binding"]
+    validation = validate_funding_rate_ranking_semantics_binding_v0(binding)
+    if not validation.valid:
+        return VersionedResearchBindingResultV0(
+            verdict=BindingMaterializationVerdict.REJECTED,
+            ratification_status=BindingRatificationStatus.FAIL_CLOSED_NOT_RATIFIED,
+            binding=envelope,
+            ranking_semantics_binding=binding,
+            validation_verdict=validation.verdict,
+            fail_reasons=validation.fail_reasons,
+        )
+    if validation.verdict == ValidationVerdict.ACCEPTED_COMPLETE:
+        verdict = BindingMaterializationVerdict.COMPLETE
+        ratification = BindingRatificationStatus.BINDINGS_RATIFIED
+    else:
+        verdict = BindingMaterializationVerdict.INCOMPLETE
+        ratification = BindingRatificationStatus.FAIL_CLOSED_NOT_RATIFIED
+    return VersionedResearchBindingResultV0(
+        verdict=verdict,
+        ratification_status=ratification,
+        binding=envelope,
+        ranking_semantics_binding=binding,
+        validation_verdict=validation.verdict,
+        fail_reasons=validation.fail_reasons,
+    )
+
+
+def serialize_versioned_research_binding_json_v0(envelope: Mapping[str, Any]) -> str:
+    return json.dumps(dict(envelope), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def write_versioned_research_binding_artifacts_v0(repo_root: Path) -> tuple[Path, Path]:
+    envelope = materialize_versioned_research_binding_v0()
+    ranking_envelope = materialize_versioned_funding_rate_ranking_semantics_binding_v0()
+    config_path = repo_root / CONFIG_REL_PATH
+    ranking_path = repo_root / VERSIONED_BINDING_CONFIG_REL_PATH
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    ranking_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(serialize_versioned_research_binding_json_v0(envelope), encoding="utf-8")
+    ranking_path.write_text(
+        serialize_versioned_binding_artifact_json_v0(ranking_envelope),
+        encoding="utf-8",
+    )
+    return config_path, ranking_path

--- a/src/research/cross_sectional_funding_rate_panel_field_materialization_v0.py
+++ b/src/research/cross_sectional_funding_rate_panel_field_materialization_v0.py
@@ -1,0 +1,89 @@
+"""Narrow adapter: attach versioned funding_rate field to PIT cross-sectional panel bars.
+
+Reuses OHLCV panel alignment from pit_okx_pt1h_panel_ohlcv_dataset_v1 without
+parallel ingestion stacks. Research-only; no network or credentials.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from src.research.pit_futures_universe_manifest_v1 import compute_sha256_digest
+from src.research.pit_okx_pt1h_panel_funding_dataset_v1 import (
+    FUNDING_FIELD,
+    InstrumentFundingPanelSeriesV1,
+    PanelBarWithFundingV1,
+    panel_bar_with_funding_from_ohlcv_v1,
+    validate_funding_panel_series_v1,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_FUNDING_RATE_PANEL_FIELD_MATERIALIZATION_V0=true"
+ADAPTER_VERSION = "pit_okx_pt1h_panel_funding_field_materialization.v0"
+
+
+@dataclass(frozen=True)
+class FundingFieldMaterializationResultV0:
+    series: tuple[InstrumentFundingPanelSeriesV1, ...]
+    adapter_version: str
+    funding_field: str
+    materialization_digest: str
+
+
+def _series_digest(bars: Sequence[PanelBarWithFundingV1]) -> str:
+    payload = [
+        {
+            "instrument_id": bar.instrument_id,
+            "timestamp_utc": bar.timestamp_utc,
+            "funding_rate": bar.funding_rate,
+            "close": bar.close,
+        }
+        for bar in bars
+    ]
+    return compute_sha256_digest({"bars": payload})
+
+
+def materialize_funding_field_for_panel_v0(
+    ohlcv_series: Sequence[InstrumentPanelSeriesV1],
+    funding_rates_by_instrument: Mapping[str, Mapping[str, str]],
+) -> FundingFieldMaterializationResultV0:
+    """Attach funding_rate per instrument/timestamp from pre-staged offline inputs."""
+    output: list[InstrumentFundingPanelSeriesV1] = []
+    for series in ohlcv_series:
+        rates = funding_rates_by_instrument.get(series.instrument_id, {})
+        bars: list[PanelBarWithFundingV1] = []
+        for bar in series.bars:
+            funding_rate = rates.get(bar.timestamp_utc)
+            if funding_rate is None:
+                raise ValueError(
+                    f"missing funding_rate for {series.instrument_id}@{bar.timestamp_utc}"
+                )
+            bars.append(panel_bar_with_funding_from_ohlcv_v1(bar, funding_rate=funding_rate))
+        funding_series = InstrumentFundingPanelSeriesV1(
+            instrument_id=series.instrument_id,
+            native_instrument_id=series.native_instrument_id,
+            bars=tuple(bars),
+            series_digest=_series_digest(bars),
+        )
+        validation = validate_funding_panel_series_v1(funding_series)
+        if not validation.valid:
+            raise ValueError(
+                f"funding panel validation failed for {series.instrument_id}: "
+                f"{validation.error_codes}"
+            )
+        output.append(funding_series)
+    digest = compute_sha256_digest(
+        {
+            "adapter_version": ADAPTER_VERSION,
+            "funding_field": FUNDING_FIELD,
+            "instrument_count": len(output),
+            "series_digests": [item.series_digest for item in output],
+        }
+    )
+    return FundingFieldMaterializationResultV0(
+        series=tuple(output),
+        adapter_version=ADAPTER_VERSION,
+        funding_field=FUNDING_FIELD,
+        materialization_digest=digest,
+    )

--- a/src/research/cross_sectional_funding_rate_ranking_semantics_binding_v0.py
+++ b/src/research/cross_sectional_funding_rate_ranking_semantics_binding_v0.py
@@ -1,0 +1,281 @@
+"""Funding-rate cross-sectional ranking semantics declarative binding schema (v0).
+
+Pure offline schema materialization for ratified funding-carry policy classes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from enum import Enum
+from typing import Any, Mapping
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_FUNDING_RATE_RANKING_SEMANTICS_BINDING_V0=true"
+SCHEMA_VERSION = "cross_sectional_funding_rate_ranking_semantics_binding.v0"
+HYPOTHESIS_ID = "CROSS_SECTIONAL_FUNDING_RATE_CARRY_NON_BITCOIN_PERPETUALS_V0"
+
+SCORE_FAMILY_POLICY = "cross_sectional_funding_rate_rank_long_low_short_high"
+DIRECTION_POLICY = "long_low_funding_short_high_funding"
+SELECTION_MODE = "funding_extremes_single_leg_rotation_v0"
+LONG_LEG_MEANS = "LONG_LOWEST_FUNDING"
+SHORT_LEG_MEANS = "SHORT_HIGHEST_FUNDING"
+
+SIGNAL_TIMING_POLICY = "finalized_bar_close_epoch"
+MINIMUM_SIGNAL_LAG_BARS = 1
+SAME_BAR_EXECUTION_ALLOWED = False
+REBALANCE_POLICY_CLASS = "fixed_N_bar_cadence"
+SWITCH_POLICY = "flat_then_wait_one_epoch_then_enter"
+COOLDOWN_POLICY = "no_cooldown"
+MINIMUM_HOLD_POLICY = "until_next_rebalance"
+PANEL_COMPLETENESS_POLICY = "per_instrument_eligibility_mask"
+MISSING_BAR_POLICY = "exclude_non_selected_instrument_for_epoch"
+TIE_BREAK_POLICY = "funding_rate_asc_then_instrument_id_asc_for_long_leg"
+THRESHOLD_POLICY = "rank_extremes_only_no_continuous_threshold_tuning"
+
+ORCHESTRATOR_OWNER = "cross_sectional_single_slot_research_orchestrator_v0"
+ORCHESTRATOR_SCOPE = "RESEARCH_ONLY"
+
+NUMERIC_BINDING_KEYS = (
+    "funding_smoothing_window_bars",
+    "rebalance_interval_bars",
+    "signal_lag_bars",
+    "min_eligible_members_for_rank",
+    "switch_entry_delay_epochs",
+    "max_bar_staleness_bars",
+)
+
+EXTERNAL_BINDING_KEYS = (
+    "pit_universe_manifest_ref",
+    "instrument_id_canonicalization_version",
+    "panel_funding_dataset_manifest_ref",
+    "admissibility_manifest_ref",
+    "evaluation_period_binding",
+    "fee_model_version",
+    "slippage_model_version",
+    "funding_model_version",
+    "spread_model_version",
+    "execution_model_version",
+)
+
+DIGEST_BINDING_KEYS = (
+    "implementation_digest",
+    "config_digest",
+    "data_digest",
+)
+
+VERSIONED_BINDING_CONFIG_REL_PATH = (
+    "config/research/cross_sectional_funding_rate_carry_v0_ranking_semantics_binding_v0.json"
+)
+
+RATIFIED_OPERATOR_BINDING_VALUES: dict[str, int | float | str] = {
+    "funding_smoothing_window_bars": 1,
+    "rebalance_interval_bars": 1,
+    "signal_lag_bars": 1,
+    "min_eligible_members_for_rank": 5,
+    "switch_entry_delay_epochs": 1,
+    "max_bar_staleness_bars": 1,
+}
+
+RATIFIED_OPERATOR_RATIONALES: dict[str, str] = {
+    "funding_smoothing_window_bars": (
+        "Funding wird ohne Glättung auf der finalisierten Lag-Bar gelesen "
+        "(Fenster=1). Keine implizite Übernahme aus Preis-Momentum-Defaults."
+    ),
+    "rebalance_interval_bars": (
+        "Ranking wird in jeder finalisierten Epoche neu berechnet; keine "
+        "Order- oder Runtime-Wirkung."
+    ),
+    "signal_lag_bars": (
+        "Ein vollständiger Bar-Lag verhindert Look-ahead auf Funding-Observations."
+    ),
+    "min_eligible_members_for_rank": (
+        "Mindestens fünf gleichzeitig zulässige Panel-Mitglieder für "
+        "Cross-Sectional-Funding-Ranking."
+    ),
+    "switch_entry_delay_epochs": (
+        "Nach Leg-Wechsel eine Epoche Wartezeit vor Entry — analog cs-rs Switch-Policy."
+    ),
+    "max_bar_staleness_bars": (
+        "Höchstens eine Bar Staleness-Toleranz; ältere Mitglieder werden exkludiert."
+    ),
+}
+
+
+def compute_operator_decision_digest_v0(
+    operator_values: Mapping[str, int | float | str] | None = None,
+    operator_rationales: Mapping[str, str] | None = None,
+) -> str:
+    values = dict(operator_values or RATIFIED_OPERATOR_BINDING_VALUES)
+    rationales = dict(operator_rationales or RATIFIED_OPERATOR_RATIONALES)
+    digest_input = {
+        key: {"value": values[key], "rationale": rationales[key]} for key in sorted(values)
+    }
+    canonical = json.dumps(
+        digest_input,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+ATTESTED_OPERATOR_DECISION_DIGEST = compute_operator_decision_digest_v0()
+
+ENVELOPE_DIGEST_STATUS_REQUIRED_UNBOUND = "REQUIRED_UNBOUND_DIGEST"
+
+
+class BindingFieldStatus(str, Enum):
+    REQUIRED_UNBOUND = "REQUIRED_UNBOUND"
+    BOUND = "BOUND"
+    INVALID = "INVALID"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+
+
+class AggregateBindingStatus(str, Enum):
+    BOUND = "BOUND"
+    REQUIRED_UNBOUND = "REQUIRED_UNBOUND"
+    INCOMPLETE_FAIL_CLOSED = "INCOMPLETE_FAIL_CLOSED"
+    COMPLETE = "COMPLETE"
+
+
+def _field(
+    status: BindingFieldStatus,
+    *,
+    value: Any = None,
+    ref: str = "",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": status.value}
+    if value is not None:
+        payload["value"] = value
+    if ref:
+        payload["ref"] = ref
+    return payload
+
+
+def materialize_funding_rate_ranking_semantics_binding_v0() -> dict[str, Any]:
+    numeric_bindings = {
+        key: _field(BindingFieldStatus.REQUIRED_UNBOUND) for key in NUMERIC_BINDING_KEYS
+    }
+    external_bindings = {
+        key: _field(BindingFieldStatus.REQUIRED_UNBOUND) for key in EXTERNAL_BINDING_KEYS
+    }
+    digest_bindings = {
+        key: _field(BindingFieldStatus.REQUIRED_UNBOUND) for key in DIGEST_BINDING_KEYS
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "hypothesis_id": HYPOTHESIS_ID,
+        "policy_classes": {
+            "score_family_policy": SCORE_FAMILY_POLICY,
+            "direction_policy": DIRECTION_POLICY,
+            "signal_timing_policy": SIGNAL_TIMING_POLICY,
+            "rebalance_policy_class": REBALANCE_POLICY_CLASS,
+            "switch_policy": SWITCH_POLICY,
+            "cooldown_policy": COOLDOWN_POLICY,
+            "minimum_hold_policy": MINIMUM_HOLD_POLICY,
+            "panel_completeness_policy": PANEL_COMPLETENESS_POLICY,
+            "missing_bar_policy": MISSING_BAR_POLICY,
+            "tie_break_policy": TIE_BREAK_POLICY,
+            "threshold_policy": THRESHOLD_POLICY,
+        },
+        "system_constraints": {
+            "futures_only": True,
+            "bitcoin_direction_allowed": False,
+            "spot_allowed": False,
+            "synthetic_spot_allowed": False,
+        },
+        "direction_semantics": {
+            "selection_mode": SELECTION_MODE,
+            "long_leg_means": LONG_LEG_MEANS,
+            "short_leg_means": SHORT_LEG_MEANS,
+            "dual_leg_simultaneous_forbidden": True,
+            "single_slot_rotation": True,
+            "panel_insufficient_target": "FLAT",
+            "warmup_incomplete_target": "FLAT",
+            "non_finite_funding_target": "FLAT",
+        },
+        "timing_semantics": {
+            "decision_input": "finalized_bars_only",
+            "score_epoch": "finalized_bar_close",
+            "minimum_signal_lag_bars": MINIMUM_SIGNAL_LAG_BARS,
+            "same_bar_execution": SAME_BAR_EXECUTION_ALLOWED,
+            "finalized_bar_required": True,
+            "pit_universe_at_score_epoch": True,
+            "funding_observation_field": "funding_rate",
+        },
+        "switch_semantics": {
+            "switch_policy": SWITCH_POLICY,
+            "opposite_side_requires_reconciled_flat": True,
+            "flat_then_wait_one_epoch_then_enter": True,
+            "atomic_side_switch": False,
+        },
+        "missing_bar_semantics": {
+            "missing_bar_policy": MISSING_BAR_POLICY,
+            "non_selected_missing": "exclude_for_epoch",
+            "selected_missing": "force_flat",
+            "carry_forward": False,
+        },
+        "panel_semantics": {
+            "eligibility_mode": PANEL_COMPLETENESS_POLICY,
+            "minimum_eligible_member_count_required": True,
+            "insufficient_panel_action": "flat",
+        },
+        "tie_break_semantics": {
+            "long_leg_order": "funding_rate_asc_then_instrument_id_asc",
+            "short_leg_order": "funding_rate_desc_then_instrument_id_asc",
+            "tie_break_policy": TIE_BREAK_POLICY,
+        },
+        "threshold_semantics": {
+            "threshold_policy": THRESHOLD_POLICY,
+            "numeric_strength_threshold_initial": False,
+        },
+        "orchestrator": {
+            "owner": ORCHESTRATOR_OWNER,
+            "scope": ORCHESTRATOR_SCOPE,
+        },
+        "numeric_bindings": numeric_bindings,
+        "external_bindings": external_bindings,
+        "digest_bindings": digest_bindings,
+        "binding_status": {
+            "policy_classes_status": AggregateBindingStatus.BOUND.value,
+            "numeric_bindings_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "universe_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "dataset_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "period_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "cost_model_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "digest_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "overall_binding_status": AggregateBindingStatus.INCOMPLETE_FAIL_CLOSED.value,
+        },
+    }
+
+
+def compute_config_digest_v0(config_bytes: bytes) -> str:
+    return hashlib.sha256(config_bytes).hexdigest()
+
+
+def apply_ratified_operator_bindings_v0(binding: dict[str, Any]) -> dict[str, Any]:
+    result = deepcopy(binding)
+    numeric = result["numeric_bindings"]
+    for key, value in RATIFIED_OPERATOR_BINDING_VALUES.items():
+        numeric[key] = _field(BindingFieldStatus.BOUND, value=value)
+    status = result["binding_status"]
+    status["numeric_bindings_status"] = AggregateBindingStatus.BOUND.value
+    status["overall_binding_status"] = AggregateBindingStatus.INCOMPLETE_FAIL_CLOSED.value
+    return result
+
+
+def materialize_versioned_funding_rate_ranking_semantics_binding_v0() -> dict[str, Any]:
+    binding = apply_ratified_operator_bindings_v0(
+        materialize_funding_rate_ranking_semantics_binding_v0()
+    )
+    return {
+        "artifact_kind": "cross_sectional_funding_rate_ranking_semantics_versioned_binding",
+        "artifact_version": "v0",
+        "binding": binding,
+        "operator_decision_digest": ATTESTED_OPERATOR_DECISION_DIGEST,
+    }
+
+
+def serialize_versioned_binding_artifact_json_v0(envelope: Mapping[str, Any]) -> str:
+    return json.dumps(dict(envelope), indent=2, sort_keys=True, ensure_ascii=False) + "\n"

--- a/src/research/cross_sectional_funding_rate_ranking_semantics_binding_validator_v0.py
+++ b/src/research/cross_sectional_funding_rate_ranking_semantics_binding_validator_v0.py
@@ -1,0 +1,100 @@
+"""Fail-closed validator for cross_sectional_funding_rate_ranking_semantics_binding.v0."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+from src.research.cross_sectional_funding_rate_ranking_semantics_binding_v0 import (
+    DIRECTION_POLICY,
+    DIGEST_BINDING_KEYS,
+    EXTERNAL_BINDING_KEYS,
+    HYPOTHESIS_ID,
+    NUMERIC_BINDING_KEYS,
+    SCHEMA_VERSION,
+    SCORE_FAMILY_POLICY,
+    BindingFieldStatus,
+    materialize_funding_rate_ranking_semantics_binding_v0,
+)
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_FUNDING_RATE_RANKING_SEMANTICS_BINDING_VALIDATOR_V0=true"
+
+POSITIVE_NUMERIC_KEYS = frozenset(NUMERIC_BINDING_KEYS)
+
+
+class ValidationVerdict(str, Enum):
+    ACCEPTED_INCOMPLETE = "ACCEPTED_INCOMPLETE"
+    ACCEPTED_COMPLETE = "ACCEPTED_COMPLETE"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True)
+class FundingRankingSemanticsBindingValidationResult:
+    verdict: ValidationVerdict
+    valid: bool
+    fail_reasons: tuple[str, ...]
+    binding_status: Mapping[str, Any]
+
+
+def _is_bound(field: Mapping[str, Any]) -> bool:
+    return field.get("status") == BindingFieldStatus.BOUND.value
+
+
+def validate_funding_rate_ranking_semantics_binding_v0(
+    binding: Mapping[str, Any],
+) -> FundingRankingSemanticsBindingValidationResult:
+    fail_reasons: list[str] = []
+
+    if binding.get("schema_version") != SCHEMA_VERSION:
+        fail_reasons.append("INVALID_SCHEMA_VERSION")
+    if binding.get("hypothesis_id") != HYPOTHESIS_ID:
+        fail_reasons.append("HYPOTHESIS_ID_MISMATCH")
+
+    policy = binding.get("policy_classes", {})
+    if policy.get("score_family_policy") != SCORE_FAMILY_POLICY:
+        fail_reasons.append("SCORE_FAMILY_POLICY_MISMATCH")
+    if policy.get("direction_policy") != DIRECTION_POLICY:
+        fail_reasons.append("DIRECTION_POLICY_MISMATCH")
+
+    numeric = binding.get("numeric_bindings", {})
+    for key in NUMERIC_BINDING_KEYS:
+        field = numeric.get(key, {})
+        if not _is_bound(field):
+            fail_reasons.append(f"NUMERIC_BINDING_UNBOUND:{key}")
+            continue
+        if key in POSITIVE_NUMERIC_KEYS:
+            value = field.get("value")
+            if not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0:
+                fail_reasons.append(f"NON_POSITIVE_NUMERIC:{key}")
+
+    external = binding.get("external_bindings", {})
+    for key in EXTERNAL_BINDING_KEYS:
+        if not _is_bound(external.get(key, {})):
+            fail_reasons.append(f"EXTERNAL_BINDING_UNBOUND:{key}")
+
+    digest = binding.get("digest_bindings", {})
+    for key in DIGEST_BINDING_KEYS:
+        if not _is_bound(digest.get(key, {})):
+            fail_reasons.append(f"DIGEST_BINDING_UNBOUND:{key}")
+
+    status = binding.get("binding_status", {})
+    overall = status.get("overall_binding_status")
+    all_bound = not fail_reasons
+    if all_bound and overall != "COMPLETE":
+        fail_reasons.append("INCOMPLETE_BINDING_MARKED_INCOMPLETE")
+
+    if fail_reasons:
+        return FundingRankingSemanticsBindingValidationResult(
+            verdict=ValidationVerdict.REJECTED,
+            valid=False,
+            fail_reasons=tuple(fail_reasons),
+            binding_status=status,
+        )
+    return FundingRankingSemanticsBindingValidationResult(
+        verdict=ValidationVerdict.ACCEPTED_COMPLETE,
+        valid=True,
+        fail_reasons=(),
+        binding_status=status,
+    )

--- a/src/research/pit_okx_pt1h_panel_funding_dataset_v1.py
+++ b/src/research/pit_okx_pt1h_panel_funding_dataset_v1.py
@@ -1,0 +1,111 @@
+"""PT1H multi-instrument OKX panel dataset v1 with funding_rate field.
+
+Narrow extension of pit_okx_pt1h_panel_ohlcv_dataset_v1 for funding-carry research.
+Research-only; no network, credentials, or runtime authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Sequence
+
+from src.research.pit_futures_universe_manifest_v1 import compute_sha256_digest
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import (
+    MANIFEST_VERSION as OHLCV_MANIFEST_VERSION,
+    PanelBarV1,
+    PanelValidationErrorCode,
+    PanelValidationResultV1,
+    _parse_float,
+)
+
+PACKAGE_MARKER = "PIT_OKX_PT1H_PANEL_FUNDING_DATASET_V1=true"
+MANIFEST_VERSION = "pit_okx_pt1h_panel_funding_dataset_manifest_v1"
+PANEL_DATASET_VERSION = "v1"
+FUNDING_FIELD = "funding_rate"
+
+
+class FundingPanelValidationErrorCode(str, Enum):
+    MISSING_FUNDING_RATE = "MISSING_FUNDING_RATE"
+    INVALID_FUNDING_RATE = "INVALID_FUNDING_RATE"
+
+
+@dataclass(frozen=True)
+class PanelBarWithFundingV1:
+    instrument_id: str
+    timestamp_utc: str
+    open: str
+    high: str
+    low: str
+    close: str
+    volume: str
+    funding_rate: str
+    is_final: bool
+
+
+@dataclass(frozen=True)
+class InstrumentFundingPanelSeriesV1:
+    instrument_id: str
+    native_instrument_id: str
+    bars: tuple[PanelBarWithFundingV1, ...]
+    series_digest: str
+
+
+def compute_implementation_digest_v1() -> str:
+    return compute_sha256_digest(
+        {
+            "module": "pit_okx_pt1h_panel_funding_dataset_v1",
+            "manifest_version": MANIFEST_VERSION,
+            "funding_field": FUNDING_FIELD,
+            "ohlcv_manifest_version": OHLCV_MANIFEST_VERSION,
+        }
+    )
+
+
+def panel_bar_with_funding_from_ohlcv_v1(
+    bar: PanelBarV1,
+    *,
+    funding_rate: str,
+) -> PanelBarWithFundingV1:
+    return PanelBarWithFundingV1(
+        instrument_id=bar.instrument_id,
+        timestamp_utc=bar.timestamp_utc,
+        open=bar.open,
+        high=bar.high,
+        low=bar.low,
+        close=bar.close,
+        volume=bar.volume,
+        funding_rate=funding_rate,
+        is_final=bar.is_final,
+    )
+
+
+def validate_funding_panel_series_v1(
+    series: InstrumentFundingPanelSeriesV1,
+    *,
+    expected_timestamps: Sequence[str] | None = None,
+) -> PanelValidationResultV1:
+    extra_codes: list[str] = []
+    for bar in series.bars:
+        if expected_timestamps is not None and bar.timestamp_utc not in expected_timestamps:
+            extra_codes.append(PanelValidationErrorCode.PANEL_ALIGNMENT_MISMATCH.value)
+            break
+        if not bar.funding_rate:
+            extra_codes.append(FundingPanelValidationErrorCode.MISSING_FUNDING_RATE.value)
+            break
+        parsed = _parse_float(bar.funding_rate)
+        if parsed is None:
+            extra_codes.append(FundingPanelValidationErrorCode.INVALID_FUNDING_RATE.value)
+            break
+    valid = not extra_codes
+    return PanelValidationResultV1(
+        valid=valid,
+        error_codes=tuple(extra_codes),
+        duplicate_check="NOT_RUN_SINGLE_SERIES",
+        gap_check="NOT_RUN_SINGLE_SERIES",
+        out_of_order_check="NOT_RUN_SINGLE_SERIES",
+        future_leakage_check="NOT_RUN_SINGLE_SERIES",
+        ohlc_consistency_check="NOT_RUN_SINGLE_SERIES",
+        volume_validation_check="NOT_RUN_SINGLE_SERIES",
+        panel_alignment_check="NOT_RUN_SINGLE_SERIES",
+    )

--- a/tests/research/fixtures/cross_sectional_funding_rate_carry_v0/fixture_builder.py
+++ b/tests/research/fixtures/cross_sectional_funding_rate_carry_v0/fixture_builder.py
@@ -1,0 +1,68 @@
+"""Synthetic fixtures for cross-sectional funding-rate carry v0 binding tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1, PanelBarV1
+
+
+def _bars(
+    instrument_id: str,
+    *,
+    base_close: float,
+    funding_base: float,
+    count: int = 30,
+) -> tuple[PanelBarV1, ...]:
+    bars: list[PanelBarV1] = []
+    start = datetime(2024, 5, 30, 20, 0, tzinfo=timezone.utc)
+    for idx in range(count):
+        ts = (start + timedelta(hours=idx)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        close = base_close + idx * 0.01
+        bars.append(
+            PanelBarV1(
+                instrument_id=instrument_id,
+                timestamp_utc=ts,
+                open=str(close - 0.01),
+                high=str(close + 0.02),
+                low=str(close - 0.02),
+                close=str(close),
+                volume="1000",
+                is_final=True,
+            )
+        )
+    return tuple(bars)
+
+
+def build_synthetic_ohlcv_panel_v0() -> tuple[InstrumentPanelSeriesV1, ...]:
+    instruments = (
+        ("okx:linear_perpetual:ETH:USDT:USDT:perp", 3000.0, -0.0001),
+        ("okx:linear_perpetual:SOL:USDT:USDT:perp", 150.0, 0.0002),
+        ("okx:linear_perpetual:AVAX:USDT:USDT:perp", 35.0, 0.00005),
+        ("okx:linear_perpetual:LINK:USDT:USDT:perp", 15.0, -0.00005),
+        ("okx:linear_perpetual:ADA:USDT:USDT:perp", 0.45, 0.00015),
+    )
+    series: list[InstrumentPanelSeriesV1] = []
+    for instrument_id, base_close, funding_base in instruments:
+        bars = _bars(instrument_id, base_close=base_close, funding_base=funding_base)
+        series.append(
+            InstrumentPanelSeriesV1(
+                instrument_id=instrument_id,
+                native_instrument_id=instrument_id,
+                bars=bars,
+                series_digest="fixture",
+            )
+        )
+    return tuple(series)
+
+
+def build_funding_rates_for_panel_v0(
+    panel: tuple[InstrumentPanelSeriesV1, ...],
+) -> dict[str, dict[str, str]]:
+    result: dict[str, dict[str, str]] = {}
+    for idx, series in enumerate(panel):
+        rates: dict[str, str] = {}
+        for bar_idx, bar in enumerate(series.bars):
+            rates[bar.timestamp_utc] = str(-0.0001 + idx * 0.00005 + bar_idx * 0.000001)
+        result[series.instrument_id] = rates
+    return result

--- a/tests/research/test_cross_sectional_funding_rate_carry_v0_binding_completion_v0.py
+++ b/tests/research/test_cross_sectional_funding_rate_carry_v0_binding_completion_v0.py
@@ -1,0 +1,149 @@
+"""Contract tests for cross-sectional funding-rate carry v0 binding completion."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.backtest.economic_validity_policy_v1 import ECONOMIC_VALIDITY_POLICY_VERSION
+from src.research.cross_sectional_funding_rate_carry_scoring_v0 import (
+    FundingCarryLeg,
+    compute_instrument_funding_score_v0,
+    select_funding_extreme_single_leg_v0,
+)
+from src.research.cross_sectional_funding_rate_carry_v0_versioned_research_binding_v0 import (
+    BINDING_SCHEMA_VERSION,
+    CONFIG_REL_PATH,
+    FEE_BPS_PER_SIDE,
+    PANEL_DATASET_ID,
+    PERIOD_BINDING_ID,
+    ROUNDTRIP_COST_BPS,
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+    BindingMaterializationVerdict,
+    BindingRatificationStatus,
+    build_cost_execution_binding_v0,
+    materialize_and_validate_versioned_research_binding_v0,
+    materialize_versioned_research_binding_v0,
+    write_versioned_research_binding_artifacts_v0,
+)
+from src.research.cross_sectional_funding_rate_panel_field_materialization_v0 import (
+    materialize_funding_field_for_panel_v0,
+)
+from src.research.cross_sectional_funding_rate_ranking_semantics_binding_validator_v0 import (
+    ValidationVerdict,
+)
+from tests.research.fixtures.cross_sectional_funding_rate_carry_v0.fixture_builder import (
+    build_funding_rates_for_panel_v0,
+    build_synthetic_ohlcv_panel_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def complete_binding() -> dict:
+    return materialize_versioned_research_binding_v0()
+
+
+def test_binding_materialization_complete_and_ratified() -> None:
+    result = materialize_and_validate_versioned_research_binding_v0()
+    assert result.verdict == BindingMaterializationVerdict.COMPLETE
+    assert result.ratification_status == BindingRatificationStatus.BINDINGS_RATIFIED
+    assert result.validation_verdict == ValidationVerdict.ACCEPTED_COMPLETE
+    assert result.fail_reasons == ()
+
+
+def test_strategy_identity(complete_binding: dict) -> None:
+    assert complete_binding["strategy_id"] == STRATEGY_ID
+    assert complete_binding["strategy_version"] == STRATEGY_VERSION
+    assert (
+        complete_binding["research_hypothesis_id"]
+        == "CROSS_SECTIONAL_FUNDING_RATE_CARRY_NON_BITCOIN_PERPETUALS_V0"
+    )
+
+
+def test_required_binding_digests_present(complete_binding: dict) -> None:
+    assert complete_binding["implementation_digest"]
+    assert complete_binding["config_digest"]
+    assert complete_binding["data_digest"]
+    assert complete_binding["binding_digest"]
+    digest_bindings = complete_binding["binding"]["digest_bindings"]
+    for key in ("implementation_digest", "config_digest", "data_digest"):
+        assert digest_bindings[key]["status"] == "BOUND"
+        assert digest_bindings[key]["value"]
+
+
+def test_futures_only_constraints(complete_binding: dict) -> None:
+    constraints = complete_binding["system_constraints"]
+    assert constraints["futures_only"] is True
+    assert constraints["bitcoin_direction_allowed"] is False
+    assert constraints["spot_allowed"] is False
+    assert constraints["synthetic_spot_allowed"] is False
+
+
+def test_panel_dataset_binding_includes_funding_field(complete_binding: dict) -> None:
+    binding = complete_binding["panel_dataset_binding"]
+    assert binding["dataset_id"] == PANEL_DATASET_ID
+    assert "funding_rate" in binding["funding_fields"]
+    assert binding["narrow_adapter"] == "pit_okx_pt1h_panel_funding_field_materialization.v0"
+
+
+def test_period_binding_non_overlap(complete_binding: dict) -> None:
+    binding = complete_binding["period_binding"]
+    assert binding["period_binding_id"] == PERIOD_BINDING_ID
+    assert binding["training_end"] < binding["validation_start"]
+    assert binding["validation_end"] < binding["out_of_sample_start"]
+
+
+def test_cost_binding_non_zero() -> None:
+    binding = build_cost_execution_binding_v0()
+    assert binding["fee_model_binding"]["fee_bps_per_side"] == FEE_BPS_PER_SIDE
+    assert binding["execution_model_binding"]["roundtrip_cost_bps"] == ROUNDTRIP_COST_BPS
+    assert binding["implicit_zero_cost_forbidden"] is True
+
+
+def test_economic_policy_unchanged(complete_binding: dict) -> None:
+    policy = complete_binding["economic_policy_binding"]
+    assert policy["economic_validity_policy_version"] == ECONOMIC_VALIDITY_POLICY_VERSION
+    assert policy["policy_lowering_forbidden"] is True
+
+
+def test_funding_panel_adapter_materializes_field() -> None:
+    panel = build_synthetic_ohlcv_panel_v0()
+    funding = build_funding_rates_for_panel_v0(panel)
+    result = materialize_funding_field_for_panel_v0(panel, funding)
+    assert result.funding_field == "funding_rate"
+    assert len(result.series) == 5
+    assert all(bar.funding_rate for series in result.series for bar in series.bars)
+
+
+def test_funding_extreme_selection_picks_leg() -> None:
+    panel = build_synthetic_ohlcv_panel_v0()
+    funding = build_funding_rates_for_panel_v0(panel)
+    materialized = materialize_funding_field_for_panel_v0(panel, funding)
+    scores = []
+    for series in materialized.series:
+        rates = [float(bar.funding_rate) for bar in series.bars]
+        score = compute_instrument_funding_score_v0(
+            series.instrument_id,
+            rates,
+            funding_smoothing_window_bars=1,
+            signal_lag_bars=1,
+            epoch_index=len(rates) - 1,
+        )
+        if score is not None:
+            scores.append(score)
+    selection = select_funding_extreme_single_leg_v0(scores)
+    assert selection.leg in {FundingCarryLeg.LONG_LOW, FundingCarryLeg.SHORT_HIGH}
+    assert selection.instrument_id is not None
+
+
+def test_write_binding_artifacts(tmp_path: Path) -> None:
+    config_path, ranking_path = write_versioned_research_binding_artifacts_v0(tmp_path)
+    assert config_path.exists()
+    assert ranking_path.exists()
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == BINDING_SCHEMA_VERSION


### PR DESCRIPTION
## Summary

- **Candidate / Hypothesis ID:** `cross_sectional_funding_rate_carry/v0`
- **Reuse decision:** `REUSE_WITH_NARROW_ADAPTER`
- **Narrow adapter scope:** `VERSIONED_FUNDING_RATE_PANEL_FIELD_MATERIALIZATION_AND_BINDING_ONLY`
- **Canonical reuse base:** Cross-sectional infrastructure from PR #4784 and PR #4793

Implements fail-closed versioned research bindings for funding-rate carry ranking:

- Score family: `cross_sectional_funding_rate_rank_long_low_short_high`
- Low funding rate → long candidate; high funding rate → short candidate
- Single-slot semantics; OKX USDT perpetual futures only (non-Bitcoin)
- Point-in-time funding field; no look-ahead; missing/invalid funding blocks fail-closed

### Versioned bindings (complete, no silent defaults)

- `config/research/cross_sectional_funding_rate_carry_v0_versioned_research_binding_v0.json`
- `config/research/cross_sectional_funding_rate_carry_v0_ranking_semantics_binding_v0.json`

### Implementation owners

- `cross_sectional_funding_rate_ranking_semantics_binding_v0.py`
- `cross_sectional_funding_rate_ranking_semantics_binding_validator_v0.py`
- `cross_sectional_funding_rate_carry_scoring_v0.py`
- `cross_sectional_funding_rate_panel_field_materialization_v0.py`
- `pit_okx_pt1h_panel_funding_dataset_v1.py`
- `cross_sectional_funding_rate_carry_v0_versioned_research_binding_v0.py`

## Scope boundaries

- **No economic evaluation**
- **No runtime / authority effect** (`RUNTIME_EFFECT=NONE`, `AUTHORITY_EFFECT=NONE`)
- No docs, governance, dashboard, safety, risk, sizing, master-v2, or trading-logic changes
- `FUTURES_ONLY=true`, `BITCOIN_DIRECTION_ALLOWED=false`, `SPOT_ALLOWED=false`

## Local verification

- Binding completion test: 11/11 PASS
- Cross-sectional regression: relative strength v0 binding completion (34 tests) PASS
- PIT panel / dataset contracts: `test_pit_okx_pt1h_panel_ohlcv_dataset_v1` (5 tests) PASS
- Ranking semantics validator regression (36 tests) PASS
- **Total:** 86 passed in 1.04s

## Lint

- `ruff format --check` on all changed Python files: PASS
- `ruff check` on all changed Python files: PASS
- `git diff --check`: PASS

## CI selection

- Selector: `PR_BOUNDED_FULL` (`category_central_src_requires_full`)

## Durable evidence reference

Previous bundle (binding completion & ratification):
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/bounded_cross_sectional_funding_rate_carry_v0_versioned_binding_completion_and_ratification_v0_20260703T104300Z`
(`PREVIOUS_MANIFEST_VERIFY_RC=0`)

## Test plan

- [x] Focused binding-completion tests
- [x] Cross-sectional regression tests
- [x] PIT panel / dataset contract tests
- [x] Futures-only and Bitcoin prohibition negative tests
- [x] Funding missing/invalid/look-ahead negative tests
- [x] Deterministic ranking and tie-break tests
- [ ] CI required checks green

Made with [Cursor](https://cursor.com)