### PR TITLE
Bounded cross-sectional funding panel fetch recovery v0

### DIFF
--- a/config/ops/cross_sectional_funding_rate_delta_momentum_v0_economic_evaluation_v1.json
+++ b/config/ops/cross_sectional_funding_rate_delta_momentum_v0_economic_evaluation_v1.json
@@ -1,0 +1,80 @@
+{
+  "binding_digest": "0e69aa7e94ac81cc20ef9a572701098ff0c009aef0512c51e4a97a4161d9b71c",
+  "config_digest": "b6f3890379bec953ef8930d64ea50fd262b80d8b9067628c90c3d2da59913f3b",
+  "config_schema_version": "cross_sectional_funding_rate_delta_momentum_v0_economic_evaluation_admissibility_v1",
+  "config_version": "v1",
+  "cross_sectional_evaluation_binding_v1": {
+    "binding_digest": "0e69aa7e94ac81cc20ef9a572701098ff0c009aef0512c51e4a97a4161d9b71c",
+    "candidate_binding_ref": "config/research/cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0.json",
+    "candidate_id": "cross_sectional_funding_rate_delta_momentum/v0",
+    "config_digest": "b6f3890379bec953ef8930d64ea50fd262b80d8b9067628c90c3d2da59913f3b",
+    "data_digest": "fe2cb0975f73a4c115ce14d230e74869155afeaaff973c22dbb89175bfa5137f",
+    "dataset_binding": {
+      "bar_interval": "PT1H",
+      "binding_version": "v0",
+      "credential_access_forbidden": true,
+      "dataset_extension": "extended_chronological_with_funding_v1",
+      "dataset_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+      "dataset_version": "v1",
+      "duplicate_bars_policy": "fail_closed",
+      "funding_fields": [
+        "funding_rate"
+      ],
+      "funding_usage": "funding_rate_for_score_computation",
+      "instrument_key": "instrument_id",
+      "missing_bars_policy": "exclude_non_selected_for_epoch",
+      "narrow_adapter": "pit_okx_pt1h_panel_funding_field_materialization.v0",
+      "network_access_forbidden": true,
+      "ohlcv_fields": [
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume"
+      ],
+      "out_of_order_bars_policy": "fail_closed",
+      "panel_calendar_end_utc": "2024-09-01T00:00:00Z",
+      "panel_calendar_start_utc": "2024-05-01T00:00:00Z",
+      "panel_funding_dataset_manifest_ref": "pit_okx_pt1h_panel_funding_dataset_v1:pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1:extended_chronological_with_funding_v1",
+      "panel_schema": "pit_okx_pt1h_panel_funding_dataset_manifest_v1",
+      "price_usage": "close_for_execution_reference_only",
+      "timestamp_key": "timestamp_utc",
+      "timezone": "UTC",
+      "warmup_bars": 5
+    },
+    "hypothesis_id": "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_NON_BITCOIN_PERPETUALS_V0",
+    "implementation_digest": "7103a4331436cd00ea0e1a7e77cdb6d468f33400c0d6ad7aba4387b0ba4804a2",
+    "parameter_binding": {
+      "binding_version": "v0",
+      "funding_delta_lookback_k": 4,
+      "funding_observation_field": "funding_rate",
+      "funding_signal_lag": 1,
+      "operator_decision_digest": "da52a9956189c2d10263b715240ecbca2ff0cf26188c7bee2fedb6699ce88597",
+      "parameter_search_forbidden": true,
+      "parameters": {
+        "funding_delta_lookback_k": 4,
+        "max_bar_staleness_bars": 1,
+        "min_eligible_members_for_rank": 5,
+        "rebalance_interval_bars": 1,
+        "signal_lag_bars": 1,
+        "switch_entry_delay_epochs": 1
+      },
+      "score_formula_expression": "delta_i(t) = funding_rate_i[t-lag] - funding_rate_i[t-lag-K]; long_leg = instrument with minimum delta; short_leg = instrument with maximum delta; single_slot selects leg with larger absolute delta",
+      "score_formula_version": "cross_sectional_funding_rate_delta_rank_v0"
+    },
+    "period_binding_id": "pit_cross_sectional_research_chronological_holdout_v1"
+  },
+  "fail_closed_contract": {
+    "economic_evaluation_executed_must_be_false_for_recovery": true,
+    "forbid_parameter_search": true,
+    "forbid_runtime_or_order_effect": true,
+    "require_bound_data_digest_match": true
+  },
+  "implementation_digest": "7103a4331436cd00ea0e1a7e77cdb6d468f33400c0d6ad7aba4387b0ba4804a2",
+  "strategy_id": "cross_sectional_funding_rate_delta_momentum",
+  "strategy_version": "v0",
+  "timeout_contract": {
+    "max_runtime_seconds": 1500,
+    "timeout_policy": "fail_closed"
+  }
+}

--- a/config/research/cross_sectional_funding_rate_delta_momentum_v0_ranking_semantics_binding_v0.json
+++ b/config/research/cross_sectional_funding_rate_delta_momentum_v0_ranking_semantics_binding_v0.json
@@ -1,0 +1,157 @@
+{
+  "artifact_kind": "cross_sectional_funding_rate_delta_momentum_ranking_semantics_versioned_binding",
+  "artifact_version": "v0",
+  "binding": {
+    "binding_status": {
+      "cost_model_binding_status": "REQUIRED_UNBOUND",
+      "dataset_binding_status": "REQUIRED_UNBOUND",
+      "digest_binding_status": "REQUIRED_UNBOUND",
+      "numeric_bindings_status": "BOUND",
+      "overall_binding_status": "INCOMPLETE_FAIL_CLOSED",
+      "period_binding_status": "REQUIRED_UNBOUND",
+      "policy_classes_status": "BOUND",
+      "universe_binding_status": "REQUIRED_UNBOUND"
+    },
+    "digest_bindings": {
+      "config_digest": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "data_digest": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "implementation_digest": {
+        "status": "REQUIRED_UNBOUND"
+      }
+    },
+    "direction_semantics": {
+      "dual_leg_simultaneous_forbidden": true,
+      "long_leg_means": "LONG_MINIMUM_FUNDING_DELTA",
+      "non_finite_funding_target": "FLAT",
+      "panel_insufficient_target": "FLAT",
+      "selection_mode": "funding_delta_extremes_single_leg_rotation_v0",
+      "short_leg_means": "SHORT_MAXIMUM_FUNDING_DELTA",
+      "single_slot_rotation": true,
+      "warmup_incomplete_target": "FLAT"
+    },
+    "external_bindings": {
+      "admissibility_manifest_ref": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "evaluation_period_binding": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "execution_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "fee_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "funding_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "instrument_id_canonicalization_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "panel_funding_dataset_manifest_ref": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "pit_universe_manifest_ref": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "slippage_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      },
+      "spread_model_version": {
+        "status": "REQUIRED_UNBOUND"
+      }
+    },
+    "hypothesis_id": "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_NON_BITCOIN_PERPETUALS_V0",
+    "missing_bar_semantics": {
+      "carry_forward": false,
+      "missing_bar_policy": "exclude_non_selected_instrument_for_epoch",
+      "non_selected_missing": "exclude_for_epoch",
+      "selected_missing": "force_flat"
+    },
+    "numeric_bindings": {
+      "funding_delta_lookback_k": {
+        "status": "BOUND",
+        "value": 4
+      },
+      "max_bar_staleness_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "min_eligible_members_for_rank": {
+        "status": "BOUND",
+        "value": 5
+      },
+      "rebalance_interval_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "signal_lag_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "switch_entry_delay_epochs": {
+        "status": "BOUND",
+        "value": 1
+      }
+    },
+    "orchestrator": {
+      "owner": "cross_sectional_funding_rate_delta_momentum_single_slot_research_orchestrator_v0",
+      "scope": "RESEARCH_ONLY"
+    },
+    "panel_semantics": {
+      "eligibility_mode": "per_instrument_eligibility_mask",
+      "insufficient_panel_action": "flat",
+      "minimum_eligible_member_count_required": true
+    },
+    "policy_classes": {
+      "cooldown_policy": "no_cooldown",
+      "direction_policy": "symmetric_funding_delta_extremum_mean_reversion_single_leg_rotation_v0",
+      "minimum_hold_policy": "until_next_rebalance",
+      "missing_bar_policy": "exclude_non_selected_instrument_for_epoch",
+      "panel_completeness_policy": "per_instrument_eligibility_mask",
+      "rebalance_policy_class": "fixed_N_bar_cadence",
+      "score_family_policy": "cross_sectional_funding_rate_delta_rank_v0",
+      "signal_timing_policy": "finalized_bar_close_epoch",
+      "switch_policy": "flat_then_wait_one_epoch_then_enter",
+      "threshold_policy": "rank_extremes_only_no_continuous_threshold_tuning",
+      "tie_break_policy": "funding_delta_asc_then_instrument_id_asc_for_long_leg"
+    },
+    "schema_version": "cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding.v0",
+    "switch_semantics": {
+      "atomic_side_switch": false,
+      "flat_then_wait_one_epoch_then_enter": true,
+      "opposite_side_requires_reconciled_flat": true,
+      "switch_policy": "flat_then_wait_one_epoch_then_enter"
+    },
+    "system_constraints": {
+      "bitcoin_direction_allowed": false,
+      "futures_only": true,
+      "spot_allowed": false,
+      "synthetic_spot_allowed": false
+    },
+    "threshold_semantics": {
+      "numeric_strength_threshold_initial": false,
+      "threshold_policy": "rank_extremes_only_no_continuous_threshold_tuning"
+    },
+    "tie_break_semantics": {
+      "abs_delta_tie_leg_order": "instrument_id_asc",
+      "long_leg_order": "funding_delta_asc_then_instrument_id_asc",
+      "short_leg_order": "funding_delta_desc_then_instrument_id_asc",
+      "tie_break_policy": "funding_delta_asc_then_instrument_id_asc_for_long_leg"
+    },
+    "timing_semantics": {
+      "decision_input": "finalized_bars_only",
+      "finalized_bar_required": true,
+      "funding_observation_field": "funding_rate",
+      "minimum_signal_lag_bars": 1,
+      "pit_universe_at_score_epoch": true,
+      "same_bar_execution": false,
+      "score_epoch": "finalized_bar_close"
+    }
+  },
+  "operator_decision_digest": "da52a9956189c2d10263b715240ecbca2ff0cf26188c7bee2fedb6699ce88597"
+}

--- a/config/research/cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0.json
+++ b/config/research/cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0.json
@@ -1,0 +1,326 @@
+{
+  "artifact_kind": "cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding",
+  "artifact_version": "v0",
+  "authority_effect": "NONE",
+  "binding": {
+    "binding_status": {
+      "cost_model_binding_status": "BOUND",
+      "dataset_binding_status": "BOUND",
+      "digest_binding_status": "BOUND",
+      "numeric_bindings_status": "BOUND",
+      "overall_binding_status": "COMPLETE",
+      "period_binding_status": "BOUND",
+      "policy_classes_status": "BOUND",
+      "universe_binding_status": "BOUND"
+    },
+    "digest_bindings": {
+      "config_digest": {
+        "status": "BOUND",
+        "value": "b6f3890379bec953ef8930d64ea50fd262b80d8b9067628c90c3d2da59913f3b"
+      },
+      "data_digest": {
+        "status": "BOUND",
+        "value": "fe2cb0975f73a4c115ce14d230e74869155afeaaff973c22dbb89175bfa5137f"
+      },
+      "implementation_digest": {
+        "status": "BOUND",
+        "value": "7103a4331436cd00ea0e1a7e77cdb6d468f33400c0d6ad7aba4387b0ba4804a2"
+      }
+    },
+    "direction_semantics": {
+      "dual_leg_simultaneous_forbidden": true,
+      "long_leg_means": "LONG_MINIMUM_FUNDING_DELTA",
+      "non_finite_funding_target": "FLAT",
+      "panel_insufficient_target": "FLAT",
+      "selection_mode": "funding_delta_extremes_single_leg_rotation_v0",
+      "short_leg_means": "SHORT_MAXIMUM_FUNDING_DELTA",
+      "single_slot_rotation": true,
+      "warmup_incomplete_target": "FLAT"
+    },
+    "external_bindings": {
+      "admissibility_manifest_ref": {
+        "ref": "pit_cross_sectional_research_dataset_envelope.v0:pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1:extended_chronological_with_funding_v1",
+        "status": "BOUND"
+      },
+      "evaluation_period_binding": {
+        "ref": "pit_cross_sectional_research_chronological_holdout_v1:v1",
+        "status": "BOUND"
+      },
+      "execution_model_version": {
+        "status": "BOUND",
+        "value": "backtest_execution_v0"
+      },
+      "fee_model_version": {
+        "status": "BOUND",
+        "value": "backtest_fee_taker_symmetric_v0"
+      },
+      "funding_model_version": {
+        "status": "BOUND",
+        "value": "backtest_funding_perpetual_interval_v1"
+      },
+      "instrument_id_canonicalization_version": {
+        "status": "BOUND",
+        "value": "instrument_id_canonicalization.v1"
+      },
+      "panel_funding_dataset_manifest_ref": {
+        "ref": "pit_okx_pt1h_panel_funding_dataset_v1:pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1:extended_chronological_with_funding_v1",
+        "status": "BOUND"
+      },
+      "pit_universe_manifest_ref": {
+        "ref": "pit_futures_universe_manifest_v1:pit_okx_linear_usdt_non_bitcoin_perpetual_universe_manifest_v1",
+        "status": "BOUND"
+      },
+      "slippage_model_version": {
+        "status": "BOUND",
+        "value": "backtest_slippage_symmetric_v0"
+      },
+      "spread_model_version": {
+        "status": "BOUND",
+        "value": "research_conservative_bps_v1"
+      }
+    },
+    "hypothesis_id": "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_NON_BITCOIN_PERPETUALS_V0",
+    "missing_bar_semantics": {
+      "carry_forward": false,
+      "missing_bar_policy": "exclude_non_selected_instrument_for_epoch",
+      "non_selected_missing": "exclude_for_epoch",
+      "selected_missing": "force_flat"
+    },
+    "numeric_bindings": {
+      "funding_delta_lookback_k": {
+        "status": "BOUND",
+        "value": 4
+      },
+      "max_bar_staleness_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "min_eligible_members_for_rank": {
+        "status": "BOUND",
+        "value": 5
+      },
+      "rebalance_interval_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "signal_lag_bars": {
+        "status": "BOUND",
+        "value": 1
+      },
+      "switch_entry_delay_epochs": {
+        "status": "BOUND",
+        "value": 1
+      }
+    },
+    "orchestrator": {
+      "owner": "cross_sectional_funding_rate_delta_momentum_single_slot_research_orchestrator_v0",
+      "scope": "RESEARCH_ONLY"
+    },
+    "panel_semantics": {
+      "eligibility_mode": "per_instrument_eligibility_mask",
+      "insufficient_panel_action": "flat",
+      "minimum_eligible_member_count_required": true
+    },
+    "policy_classes": {
+      "cooldown_policy": "no_cooldown",
+      "direction_policy": "symmetric_funding_delta_extremum_mean_reversion_single_leg_rotation_v0",
+      "minimum_hold_policy": "until_next_rebalance",
+      "missing_bar_policy": "exclude_non_selected_instrument_for_epoch",
+      "panel_completeness_policy": "per_instrument_eligibility_mask",
+      "rebalance_policy_class": "fixed_N_bar_cadence",
+      "score_family_policy": "cross_sectional_funding_rate_delta_rank_v0",
+      "signal_timing_policy": "finalized_bar_close_epoch",
+      "switch_policy": "flat_then_wait_one_epoch_then_enter",
+      "threshold_policy": "rank_extremes_only_no_continuous_threshold_tuning",
+      "tie_break_policy": "funding_delta_asc_then_instrument_id_asc_for_long_leg"
+    },
+    "schema_version": "cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding.v0",
+    "switch_semantics": {
+      "atomic_side_switch": false,
+      "flat_then_wait_one_epoch_then_enter": true,
+      "opposite_side_requires_reconciled_flat": true,
+      "switch_policy": "flat_then_wait_one_epoch_then_enter"
+    },
+    "system_constraints": {
+      "bitcoin_direction_allowed": false,
+      "futures_only": true,
+      "spot_allowed": false,
+      "synthetic_spot_allowed": false
+    },
+    "threshold_semantics": {
+      "numeric_strength_threshold_initial": false,
+      "threshold_policy": "rank_extremes_only_no_continuous_threshold_tuning"
+    },
+    "tie_break_semantics": {
+      "abs_delta_tie_leg_order": "instrument_id_asc",
+      "long_leg_order": "funding_delta_asc_then_instrument_id_asc",
+      "short_leg_order": "funding_delta_desc_then_instrument_id_asc",
+      "tie_break_policy": "funding_delta_asc_then_instrument_id_asc_for_long_leg"
+    },
+    "timing_semantics": {
+      "decision_input": "finalized_bars_only",
+      "finalized_bar_required": true,
+      "funding_observation_field": "funding_rate",
+      "minimum_signal_lag_bars": 1,
+      "pit_universe_at_score_epoch": true,
+      "same_bar_execution": false,
+      "score_epoch": "finalized_bar_close"
+    }
+  },
+  "binding_digest": "0e69aa7e94ac81cc20ef9a572701098ff0c009aef0512c51e4a97a4161d9b71c",
+  "config_digest": "b6f3890379bec953ef8930d64ea50fd262b80d8b9067628c90c3d2da59913f3b",
+  "cost_execution_binding": {
+    "binding_version": "v0",
+    "execution_model_binding": {
+      "effective_entry_cost_bps": 20.0,
+      "effective_exit_cost_bps": 20.0,
+      "execution_model_version": "backtest_execution_v0",
+      "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+      "roundtrip_cost_bps": 40.0
+    },
+    "fee_model_binding": {
+      "fee_bps_per_side": 10.0,
+      "fee_model_version": "backtest_fee_taker_symmetric_v0"
+    },
+    "funding_model_binding": {
+      "bind": true,
+      "funding_model_version": "backtest_funding_perpetual_interval_v1"
+    },
+    "implicit_zero_cost_forbidden": true,
+    "slippage_model_binding": {
+      "slippage_bps_per_side": 5.0,
+      "slippage_model_version": "backtest_slippage_symmetric_v0"
+    },
+    "spread_model_binding": {
+      "conservative_half_spread_bps": 5.0,
+      "spread_model_version": "research_conservative_bps_v1"
+    }
+  },
+  "data_digest": "fe2cb0975f73a4c115ce14d230e74869155afeaaff973c22dbb89175bfa5137f",
+  "economic_evaluation_executed": false,
+  "economic_policy_binding": {
+    "binding_version": "v1",
+    "economic_validity_policy_version": "economic_validity_policy_v1",
+    "minimum_trade_count": 50,
+    "policy_lowering_forbidden": true,
+    "promising_is_not_pass": true
+  },
+  "hypothesis_frozen": true,
+  "implementation_digest": "7103a4331436cd00ea0e1a7e77cdb6d468f33400c0d6ad7aba4387b0ba4804a2",
+  "instrument_binding": {
+    "binding_version": "v0",
+    "bitcoin_excluded": true,
+    "direction_policy": "symmetric_funding_delta_extremum_mean_reversion_single_leg_rotation_v0",
+    "instrument_id_canonicalization_version": "instrument_id_canonicalization.v1",
+    "pit_universe_manifest_ref": "pit_futures_universe_manifest_v1:pit_okx_linear_usdt_non_bitcoin_perpetual_universe_manifest_v1",
+    "selection_mode": "funding_delta_extremes_single_leg_rotation_v0",
+    "spot_excluded": true,
+    "synthetic_spot_excluded": true
+  },
+  "non_authorizing": true,
+  "orchestrator_owner": "cross_sectional_funding_rate_delta_momentum_single_slot_research_orchestrator_v0",
+  "order_effect": "NONE",
+  "panel_dataset_binding": {
+    "bar_interval": "PT1H",
+    "binding_version": "v0",
+    "credential_access_forbidden": true,
+    "dataset_extension": "extended_chronological_with_funding_v1",
+    "dataset_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+    "dataset_version": "v1",
+    "duplicate_bars_policy": "fail_closed",
+    "funding_fields": [
+      "funding_rate"
+    ],
+    "funding_usage": "funding_rate_for_score_computation",
+    "instrument_key": "instrument_id",
+    "missing_bars_policy": "exclude_non_selected_for_epoch",
+    "narrow_adapter": "pit_okx_pt1h_panel_funding_field_materialization.v0",
+    "network_access_forbidden": true,
+    "ohlcv_fields": [
+      "open",
+      "high",
+      "low",
+      "close",
+      "volume"
+    ],
+    "out_of_order_bars_policy": "fail_closed",
+    "panel_calendar_end_utc": "2024-09-01T00:00:00Z",
+    "panel_calendar_start_utc": "2024-05-01T00:00:00Z",
+    "panel_funding_dataset_manifest_ref": "pit_okx_pt1h_panel_funding_dataset_v1:pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1:extended_chronological_with_funding_v1",
+    "panel_schema": "pit_okx_pt1h_panel_funding_dataset_manifest_v1",
+    "price_usage": "close_for_execution_reference_only",
+    "timestamp_key": "timestamp_utc",
+    "timezone": "UTC",
+    "warmup_bars": 5
+  },
+  "parameter_binding": {
+    "binding_version": "v0",
+    "funding_delta_lookback_k": 4,
+    "funding_observation_field": "funding_rate",
+    "funding_signal_lag": 1,
+    "operator_decision_digest": "da52a9956189c2d10263b715240ecbca2ff0cf26188c7bee2fedb6699ce88597",
+    "parameter_search_forbidden": true,
+    "parameters": {
+      "funding_delta_lookback_k": 4,
+      "max_bar_staleness_bars": 1,
+      "min_eligible_members_for_rank": 5,
+      "rebalance_interval_bars": 1,
+      "signal_lag_bars": 1,
+      "switch_entry_delay_epochs": 1
+    },
+    "score_formula_expression": "delta_i(t) = funding_rate_i[t-lag] - funding_rate_i[t-lag-K]; long_leg = instrument with minimum delta; short_leg = instrument with maximum delta; single_slot selects leg with larger absolute delta",
+    "score_formula_version": "cross_sectional_funding_rate_delta_rank_v0"
+  },
+  "period_binding": {
+    "binding_version": "v1",
+    "boundary_semantics": "utc_bar_close_inclusive_end",
+    "embargo_duration": "PT2H",
+    "holdout_isolation_enforced": true,
+    "no_overlap_enforced": true,
+    "out_of_sample_end": "2024-08-31T23:00:00Z",
+    "out_of_sample_start": "2024-07-26T12:00:00Z",
+    "period_binding_id": "pit_cross_sectional_research_chronological_holdout_v1",
+    "periods_frozen_before_evaluation": true,
+    "purge_duration": "PT2H",
+    "split_policy_id": "pit_cross_sectional_research_chronological_holdout_v1",
+    "split_timezone": "UTC",
+    "training_end": "2024-06-19T16:00:00Z",
+    "training_start": "2024-05-01T21:00:00Z",
+    "validation_end": "2024-07-26T09:00:00Z",
+    "validation_start": "2024-06-19T19:00:00Z",
+    "warmup_end": "2024-05-01T20:00:00Z",
+    "warmup_start": "2024-05-01T00:00:00Z"
+  },
+  "pit_universe_binding": {
+    "binding_version": "v0",
+    "bitcoin_excluded": true,
+    "futures_only": true,
+    "instrument_identity_normalization": "instrument_id_canonicalization.v1",
+    "instrument_type": "LINEAR_PERPETUAL",
+    "minimum_eligible_member_count": 5,
+    "pit_universe_manifest_ref": "pit_futures_universe_manifest_v1:pit_okx_linear_usdt_non_bitcoin_perpetual_universe_manifest_v1",
+    "settlement_asset": "USDT",
+    "spot_excluded": true,
+    "survivorship_bias_forbidden": true,
+    "synthetic_spot_excluded": true,
+    "universe_lifecycle_registry_ref": "pit_futures_lifecycle_registry_v1:okx_production_lifecycle_v1",
+    "universe_policy_id": "pit_okx_linear_usdt_non_bitcoin_perpetual_cross_sectional_universe",
+    "universe_policy_version": "v1",
+    "venue": "OKX"
+  },
+  "ranking_semantics_binding_ref": "config/research/cross_sectional_funding_rate_delta_momentum_v0_ranking_semantics_binding_v0.json",
+  "ranking_semantics_schema_version": "cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding.v0",
+  "research_binding_only": true,
+  "research_hypothesis_id": "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_NON_BITCOIN_PERPETUALS_V0",
+  "runtime_effect": "NONE",
+  "schema_version": "cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding.v0",
+  "strategy_id": "cross_sectional_funding_rate_delta_momentum",
+  "strategy_version": "v0",
+  "system_constraints": {
+    "bitcoin_direction_allowed": false,
+    "futures_only": true,
+    "spot_allowed": false,
+    "synthetic_spot_allowed": false
+  },
+  "validation_verdict": "ACCEPTED_COMPLETE"
+}

--- a/scripts/ops/fetch_cross_sectional_funding_rate_delta_momentum_v0_extended_chronological_panel_v0.py
+++ b/scripts/ops/fetch_cross_sectional_funding_rate_delta_momentum_v0_extended_chronological_panel_v0.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Fetch extended chronological panel for cross-sectional funding-rate delta momentum v0.
+
+Public OKX PT1H fetch only. No credentials. Operator GO required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops import fetch_cross_sectional_bound_period_historical_pt1h_sources_v0 as fetch_mod  # noqa: E402
+from src.research.cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0 import (  # noqa: E402
+    PANEL_CALENDAR_END_UTC,
+    PANEL_CALENDAR_START_UTC,
+)
+
+CONFIRM_GO = "GO_BOUNDED_PRE_EVALUATION_PANEL_EXTENSION_AND_IMPLEMENTATION_SCOPE_RATIFICATION_V0"
+fetch_mod.CONFIRM_TOKEN = CONFIRM_GO
+DEFAULT_STAGING_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/"
+    "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/extended_chronological_v1"
+)
+DEFAULT_DURABLE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm", required=True)
+    parser.add_argument("--target-staging-root", type=Path, default=DEFAULT_STAGING_ROOT)
+    parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_ROOT)
+    parser.add_argument("--period-start-utc", default=PANEL_CALENDAR_START_UTC)
+    parser.add_argument("--period-end-utc", default=PANEL_CALENDAR_END_UTC)
+    args = parser.parse_args()
+    if args.confirm != CONFIRM_GO:
+        print(f"ERR: confirm_go_token_required:{CONFIRM_GO}", file=sys.stderr)
+        raise SystemExit(2)
+    result = fetch_mod.run_historical_fetch(
+        confirm=CONFIRM_GO,
+        target_staging_root=args.target_staging_root,
+        durable_evidence_root=args.durable_evidence_root,
+        period_start_utc=args.period_start_utc,
+        period_end_utc=args.period_end_utc,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ops/materialize_cross_sectional_funding_rate_delta_momentum_v0_bound_panel_funding_dataset_v0.py
+++ b/scripts/ops/materialize_cross_sectional_funding_rate_delta_momentum_v0_bound_panel_funding_dataset_v0.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Materialize bound funding panel for funding-rate delta momentum v0 extended calendar."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops import (
+    materialize_cross_sectional_funding_rate_carry_v0_bound_panel_funding_dataset_v0 as funding_mod,
+)  # noqa: E402
+from src.research.cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0 import (  # noqa: E402
+    INFRASTRUCTURE_GO_TOKEN,
+)
+
+CONFIRM_GO = INFRASTRUCTURE_GO_TOKEN
+funding_mod.CONFIRM_GO = CONFIRM_GO
+DEFAULT_STAGING_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/"
+    "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/extended_chronological_v1"
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm", required=True)
+    parser.add_argument("--staging-root", type=Path, default=DEFAULT_STAGING_ROOT)
+    parser.add_argument("--skip-fetch", action="store_true")
+    args = parser.parse_args()
+    result = funding_mod.materialize_bound_panel_funding_dataset_v0(
+        confirm=args.confirm,
+        staging_root=args.staging_root,
+        skip_fetch=args.skip_fetch,
+    )
+    manifest_path = args.staging_root / "panel" / "panel_funding_dataset_manifest.json"
+    if manifest_path.is_file():
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["dataset_extension"] = "extended_chronological_with_funding_v1"
+        manifest["panel_id"] = "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1"
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ops/run_cross_sectional_bounded_panel_fetch_preflight_v0.py
+++ b/scripts/ops/run_cross_sectional_bounded_panel_fetch_preflight_v0.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Run bounded cross-sectional panel fetch preflight (2 instruments max).
+
+Research-only technical preflight. No economic evaluation, no promotion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.research.cross_sectional_bounded_panel_fetch_v0 import (  # noqa: E402
+    GO_TOKEN,
+    run_bounded_panel_preflight_v0,
+)
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--confirm", required=True, help=f"Required GO token: {GO_TOKEN}")
+    parser.add_argument(
+        "--staging-root",
+        type=Path,
+        help="Fresh preflight staging root (must not exist)",
+    )
+    parser.add_argument(
+        "--durable-evidence-root",
+        type=Path,
+        default=Path(
+            "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+        ),
+        help="Archive root for default preflight staging location",
+    )
+    parser.add_argument("--max-instruments", type=int, default=2)
+    parser.add_argument("--preflight-only", action="store_true", default=True)
+    args = parser.parse_args()
+
+    if args.confirm != GO_TOKEN:
+        _die(f"ERR: confirm_go_token_required:{GO_TOKEN}")
+
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    staging_root = args.staging_root
+    if staging_root is None:
+        staging_root = (
+            args.durable_evidence_root
+            / "datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1"
+            / f"extended_chronological_preflight_v0_{ts_slug}"
+        )
+
+    result = run_bounded_panel_preflight_v0(
+        confirm=args.confirm,
+        staging_root=staging_root,
+        max_instruments=args.max_instruments,
+        preflight_only=args.preflight_only,
+    )
+    print(json.dumps({"preflight_result": result.__dict__}, indent=2, sort_keys=True))
+    if result.fail_reason or result.status.value != "PREFLIGHT_COMPLETE":
+        _die(f"ERR: preflight_failed:{result.status.value}:{result.fail_reason}", 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ops/run_cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Infrastructure-only runner for funding-rate delta momentum v0 (no economic evaluation)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.research.cross_sectional_funding_rate_delta_momentum_v0_bound_panel_dataset_materialization_v0 import (  # noqa: E402
+    MaterializationTerminalStatus,
+    materialization_result_to_dict,
+    materialize_bound_funding_panel_dataset_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0 import (  # noqa: E402
+    INFRASTRUCTURE_GO_TOKEN,
+    InfrastructureReadinessResultV0,
+    InfrastructureTerminalStatus,
+    entrypoint_result_to_dict,
+    load_versioned_research_binding_v0,
+    materialize_infrastructure_summary_v0,
+    run_full_evaluation_entrypoint_dry_run_v0,
+    verify_execution_start_state_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_scope_ratification_v0 import (  # noqa: E402
+    materialize_funding_delta_momentum_offline_evaluation_scope_ratification_v0,
+)
+
+CONFIRM_GO = INFRASTRUCTURE_GO_TOKEN
+DEFAULT_STAGING_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/"
+    "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/extended_chronological_v1"
+)
+DEFAULT_DURABLE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+
+
+def _resolve_origin_main(repo_root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "origin/main"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm", required=True)
+    parser.add_argument("--staging-root", type=Path, default=DEFAULT_STAGING_ROOT)
+    parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_ROOT)
+    parser.add_argument("--primary-worktree", type=Path, default=Path("/Users/frnkhrz/Peak_Trade"))
+    args = parser.parse_args()
+    if args.confirm != CONFIRM_GO:
+        print(f"ERR: confirm_go_token_required:{CONFIRM_GO}", file=sys.stderr)
+        raise SystemExit(2)
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    versioned_binding = load_versioned_research_binding_v0(_REPO_ROOT)
+    ratification = materialize_funding_delta_momentum_offline_evaluation_scope_ratification_v0(
+        repo_root=_REPO_ROOT,
+        versioned_binding=versioned_binding,
+    )
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        ratification=ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+    materialization = materialize_bound_funding_panel_dataset_v0(
+        args.staging_root,
+        period_binding=versioned_binding["period_binding"],
+        expected_data_digest=versioned_binding["data_digest"],
+    )
+    entrypoint = run_full_evaluation_entrypoint_dry_run_v0(
+        repo_root=_REPO_ROOT,
+        ratification=ratification,
+        staging_root=args.staging_root,
+        versioned_binding=versioned_binding,
+        go_token=args.confirm,
+    )
+    readiness = InfrastructureReadinessResultV0(
+        status=(
+            InfrastructureTerminalStatus.EXECUTION_INFRASTRUCTURE_COMPLETE
+            if materialization.status
+            is MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE
+            and entrypoint.precheck_passed
+            else InfrastructureTerminalStatus.FAIL_CLOSED_BOUND_DATA_UNAVAILABLE
+        ),
+        execution_infrastructure_complete=entrypoint.stage_wiring_complete,
+        panel_wiring_complete=entrypoint.stage_wiring_complete,
+        bound_dataset_materialized=(
+            materialization.status is MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE
+        ),
+        dataset_period_match=(
+            materialization.status is MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE
+        ),
+        panel_data_digest=materialization.panel_data_digest,
+        reason_codes=materialization.reason_codes + entrypoint.fail_reasons,
+        authority_effect="NONE",
+        runtime_effect="NONE",
+        economic_evaluation_executed=False,
+    )
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        args.durable_evidence_root
+        / "implementation"
+        / f"bounded_cross_sectional_funding_rate_delta_momentum_v0_panel_and_implementation_v0_{ts_slug}"
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+    summary = materialize_infrastructure_summary_v0(
+        ratification=ratification,
+        readiness=readiness,
+        origin_main_sha=origin_main,
+        execution_bundle_dir=str(bundle_dir),
+    )
+    (bundle_dir / "START_STATE.json").write_text(
+        json.dumps(
+            {
+                "valid": start_state.valid,
+                "fail_reasons": list(start_state.fail_reasons),
+                "origin_main_sha": start_state.origin_main_sha,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "DATASET_MATERIALIZATION_RESULT.json").write_text(
+        json.dumps(materialization_result_to_dict(materialization), indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "ENTRYPOINT_DRY_RUN_RESULT.json").write_text(
+        json.dumps(entrypoint_result_to_dict(entrypoint), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "INFRASTRUCTURE_SUMMARY.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        json.dumps(
+            {
+                "verdict": readiness.status.value,
+                "economic_evaluation_executed": False,
+                "bundle_dir": str(bundle_dir),
+                "start_state_valid": start_state.valid,
+                "entrypoint_status": entrypoint.status,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/research/cross_sectional_bounded_panel_fetch_v0.py
+++ b/src/research/cross_sectional_bounded_panel_fetch_v0.py
@@ -1,0 +1,919 @@
+"""Bounded cross-sectional panel OHLCV and funding fetch v0.
+
+Anchors pagination at END_EXCLUSIVE, retains only window-overlapping raw pages,
+enforces budget guards, and performs PIT backward-asof funding join.
+Research-only; no runtime, orders, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from src.research.cross_sectional_funding_rate_delta_momentum_scoring_v0 import (
+    FUNDING_DELTA_LOOKBACK_K,
+    FUNDING_SIGNAL_LAG,
+    funding_cashflow_provenance_marker_v0,
+    score_input_provenance_marker_v0,
+)
+from src.research.okx_production_instrument_lifecycle_source_v1 import (
+    evaluate_okx_instrument_eligibility_v1,
+)
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_BOUNDED_PANEL_FETCH_V0=true"
+MODULE_VERSION = "cross_sectional_bounded_panel_fetch.v0"
+
+START_INCLUSIVE_UTC = "2024-05-01T00:00:00Z"
+END_EXCLUSIVE_UTC = "2024-09-01T00:00:00Z"
+BAR_INTERVAL = "PT1H"
+PAGE_LIMIT = 300
+
+PHASE_A_BOUND_OHLCV_PANEL = "BOUND_OHLCV_PANEL"
+PHASE_B_BOUND_FUNDING_HISTORY = "BOUND_FUNDING_HISTORY"
+
+GO_TOKEN = (
+    "GO_BOUNDED_CROSS_SECTIONAL_FUNDING_PANEL_FETCH_PAGINATION_RETENTION_AND_BUDGET_RECOVERY_V0"
+)
+
+PublicGetFetcher = Callable[..., tuple[int, bytes, dict[str, str]]]
+
+
+class FetchTerminalStatus(str, Enum):
+    PREFLIGHT_COMPLETE = "PREFLIGHT_COMPLETE"
+    BUDGET_EXCEEDED_FAIL_CLOSED = "BUDGET_EXCEEDED_FAIL_CLOSED"
+    INCOMPLETE_NOT_PROMOTED = "INCOMPLETE_NOT_PROMOTED"
+    VALIDATION_FAILED = "VALIDATION_FAILED"
+
+
+class BudgetGuardReason(str, Enum):
+    MAX_INSTRUMENTS = "MAX_INSTRUMENTS"
+    MAX_PAGES_PER_INSTRUMENT = "MAX_PAGES_PER_INSTRUMENT"
+    MAX_TOTAL_REQUESTS = "MAX_TOTAL_REQUESTS"
+    MAX_TOTAL_RAW_BYTES = "MAX_TOTAL_RAW_BYTES"
+    MAX_RUNTIME_SECONDS = "MAX_RUNTIME_SECONDS"
+    MAX_CONSECUTIVE_EMPTY_PAGES = "MAX_CONSECUTIVE_EMPTY_PAGES"
+
+
+@dataclass(frozen=True)
+class BoundedWindowV0:
+    start_inclusive_utc: str
+    end_exclusive_utc: str
+    start_ms: int
+    end_exclusive_ms: int
+    window_hours: int
+    required_pre_window_hours: int
+    funding_fetch_start_utc: str
+    funding_fetch_start_ms: int
+
+    @property
+    def fetch_end_exclusive_utc(self) -> str:
+        return self.end_exclusive_utc
+
+    @property
+    def fetch_end_exclusive_ms(self) -> int:
+        return self.end_exclusive_ms
+
+
+def _parse_utc_ms(value: str) -> int:
+    dt = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _format_utc_ms(ms: int) -> str:
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def compute_bounded_window_v0(
+    *,
+    start_inclusive_utc: str = START_INCLUSIVE_UTC,
+    end_exclusive_utc: str = END_EXCLUSIVE_UTC,
+    funding_delta_lookback_k: int = FUNDING_DELTA_LOOKBACK_K,
+    funding_signal_lag: int = FUNDING_SIGNAL_LAG,
+) -> BoundedWindowV0:
+    start_ms = _parse_utc_ms(start_inclusive_utc)
+    end_ms = _parse_utc_ms(end_exclusive_utc)
+    window_hours = (end_ms - start_ms) // 3_600_000
+    pre_hours = funding_delta_lookback_k + funding_signal_lag
+    funding_start_ms = start_ms - pre_hours * 3_600_000
+    return BoundedWindowV0(
+        start_inclusive_utc=start_inclusive_utc,
+        end_exclusive_utc=end_exclusive_utc,
+        start_ms=start_ms,
+        end_exclusive_ms=end_ms,
+        window_hours=window_hours,
+        required_pre_window_hours=pre_hours,
+        funding_fetch_start_utc=_format_utc_ms(funding_start_ms),
+        funding_fetch_start_ms=funding_start_ms,
+    )
+
+
+def derive_production_budget_v0(window: BoundedWindowV0) -> dict[str, int]:
+    ohlcv_pages = (window.window_hours + PAGE_LIMIT - 1) // PAGE_LIMIT + 2
+    funding_span_hours = window.window_hours + window.required_pre_window_hours
+    funding_pages = (funding_span_hours + PAGE_LIMIT - 1) // PAGE_LIMIT + 2
+    max_pages_per_instrument = ohlcv_pages + funding_pages
+    return {
+        "max_pages_per_instrument_ohlcv": ohlcv_pages,
+        "max_pages_per_instrument_funding": funding_pages,
+        "max_pages_per_instrument": max_pages_per_instrument,
+        "max_total_requests_per_instrument": max_pages_per_instrument,
+    }
+
+
+@dataclass
+class FetchBudgetGuardV0:
+    max_instruments: int
+    max_pages_per_instrument: int
+    max_total_requests: int
+    max_total_raw_bytes: int
+    max_runtime_seconds: int
+    max_consecutive_empty_pages: int = 3
+    max_retries: int = 5
+    instruments_completed: int = 0
+    current_instrument_pages: int = 0
+    total_requests: int = 0
+    total_raw_bytes: int = 0
+    retained_pages: int = 0
+    discarded_pages: int = 0
+    start_monotonic: float = field(default_factory=time.monotonic)
+
+    def check_runtime(self) -> str | None:
+        if time.monotonic() - self.start_monotonic > self.max_runtime_seconds:
+            return BudgetGuardReason.MAX_RUNTIME_SECONDS.value
+        return None
+
+    def check_request(self) -> str | None:
+        if self.total_requests >= self.max_total_requests:
+            return BudgetGuardReason.MAX_TOTAL_REQUESTS.value
+        return None
+
+    def check_raw_bytes(self, additional: int) -> str | None:
+        if self.total_raw_bytes + additional > self.max_total_raw_bytes:
+            return BudgetGuardReason.MAX_TOTAL_RAW_BYTES.value
+        return None
+
+    def check_instrument_pages(self, pages: int | None = None) -> str | None:
+        count = self.current_instrument_pages if pages is None else pages
+        if count > self.max_pages_per_instrument:
+            return BudgetGuardReason.MAX_PAGES_PER_INSTRUMENT.value
+        return None
+
+    def begin_instrument(self) -> None:
+        self.current_instrument_pages = 0
+
+    def complete_instrument(self) -> None:
+        self.instruments_completed += 1
+        self.current_instrument_pages = 0
+
+    def check_instruments(self) -> str | None:
+        if self.instruments_completed >= self.max_instruments:
+            return BudgetGuardReason.MAX_INSTRUMENTS.value
+        return None
+
+
+@dataclass(frozen=True)
+class PaginationPageRecordV0:
+    phase: str
+    instrument_id: str
+    page_sequence: int
+    query_params: dict[str, str]
+    min_timestamp_ms: int | None
+    max_timestamp_ms: int | None
+    overlap_with_window: bool
+    retained: bool
+    raw_path: str
+    content_digest: str
+    row_count_in_window: int
+    http_status: int
+    discarded_reason: str = ""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _candle_is_final(row: Sequence[Any]) -> bool:
+    if len(row) >= 9:
+        return str(row[8]) == "1"
+    if len(row) >= 6:
+        return str(row[5]) == "1"
+    return False
+
+
+def _row_in_window(ts_ms: int, window: BoundedWindowV0) -> bool:
+    return window.start_ms <= ts_ms < window.end_exclusive_ms
+
+
+def _page_overlaps_window(
+    timestamps_ms: Sequence[int],
+    window: BoundedWindowV0,
+) -> bool:
+    if not timestamps_ms:
+        return False
+    page_min = min(timestamps_ms)
+    page_max = max(timestamps_ms)
+    return page_max >= window.start_ms and page_min < window.end_exclusive_ms
+
+
+def _safe_instrument_token(instrument_id: str) -> str:
+    return instrument_id.replace(":", "_").replace("/", "_")
+
+
+def _raw_filename_v0(
+    *,
+    instrument_id: str,
+    data_type: str,
+    page_sequence: int,
+    min_ts_ms: int | None,
+    max_ts_ms: int | None,
+    digest: str,
+) -> str:
+    min_part = str(min_ts_ms) if min_ts_ms is not None else "none"
+    max_part = str(max_ts_ms) if max_ts_ms is not None else "none"
+    return (
+        f"{_safe_instrument_token(instrument_id)}_{data_type}_p{page_sequence:04d}_"
+        f"{min_part}_{max_part}_{digest[:16]}.json"
+    )
+
+
+def paginate_bounded_ohlcv_v0(
+    *,
+    instrument_id: str,
+    native_instrument_id: str,
+    window: BoundedWindowV0,
+    fetcher: PublicGetFetcher,
+    rate_limiter: Any,
+    fetch_with_retry: Callable[..., tuple[int, bytes, dict[str, str]]],
+    build_url: Callable[[str, Mapping[str, str]], str],
+    parse_json: Callable[[bytes], dict[str, Any]],
+    raw_dir: Path,
+    request_log: list[PaginationPageRecordV0],
+    budget: FetchBudgetGuardV0,
+    okx_bar_param: str = "1H",
+) -> tuple[list[list[Any]], str | None]:
+    path = "/api/v5/market/history-candles"
+    params_base = {"instId": native_instrument_id, "bar": okx_bar_param}
+    all_rows: list[list[Any]] = []
+    after_cursor: str | None = str(window.end_exclusive_ms)
+    page = 0
+    consecutive_empty = 0
+    fail_reason: str | None = None
+
+    while True:
+        runtime_reason = budget.check_runtime()
+        if runtime_reason:
+            fail_reason = runtime_reason
+            break
+        req_reason = budget.check_request()
+        if req_reason:
+            fail_reason = req_reason
+            break
+        page_reason = budget.check_instrument_pages(budget.current_instrument_pages + 1)
+        if page_reason:
+            fail_reason = page_reason
+            break
+
+        params = dict(params_base)
+        params["limit"] = str(PAGE_LIMIT)
+        params["after"] = after_cursor
+        url = build_url(path, params)
+        budget.total_requests += 1
+        budget.current_instrument_pages += 1
+        status, body, _ = fetch_with_retry(
+            url,
+            timeout_seconds=30.0,
+            max_response_bytes=50_000_000,
+            rate_limiter=rate_limiter,
+            fetcher=fetcher,
+        )
+        digest = _sha256_bytes(body)
+        bytes_reason = budget.check_raw_bytes(len(body))
+        if bytes_reason:
+            fail_reason = bytes_reason
+            break
+
+        payload = parse_json(body)
+        rows = payload.get("data") or []
+        if not isinstance(rows, list):
+            rows = []
+        finalized = [r for r in rows if isinstance(r, list) and _candle_is_final(r)]
+        ts_values = [int(str(r[0])) for r in finalized] if finalized else []
+        overlap = _page_overlaps_window(ts_values, window)
+        in_window_count = sum(1 for ts in ts_values if _row_in_window(ts, window))
+        min_ts = min(ts_values) if ts_values else None
+        max_ts = max(ts_values) if ts_values else None
+
+        raw_path = ""
+        retained = False
+        discarded_reason = ""
+        if overlap:
+            raw_name = _raw_filename_v0(
+                instrument_id=instrument_id,
+                data_type="ohlcv",
+                page_sequence=page,
+                min_ts_ms=min_ts,
+                max_ts_ms=max_ts,
+                digest=digest,
+            )
+            raw_path = str(raw_dir / raw_name)
+            raw_dir.mkdir(parents=True, exist_ok=True)
+            Path(raw_path).write_bytes(body)
+            budget.total_raw_bytes += len(body)
+            budget.retained_pages += 1
+            retained = True
+        else:
+            budget.discarded_pages += 1
+            discarded_reason = "PAGE_FULLY_OUTSIDE_BOUND_WINDOW"
+
+        request_log.append(
+            PaginationPageRecordV0(
+                phase=PHASE_A_BOUND_OHLCV_PANEL,
+                instrument_id=instrument_id,
+                page_sequence=page,
+                query_params=dict(params),
+                min_timestamp_ms=min_ts,
+                max_timestamp_ms=max_ts,
+                overlap_with_window=overlap,
+                retained=retained,
+                raw_path=raw_path,
+                content_digest=digest,
+                row_count_in_window=in_window_count,
+                http_status=status,
+                discarded_reason=discarded_reason,
+            )
+        )
+
+        if status < 200 or status >= 300 or str(payload.get("code", "")) != "0":
+            fail_reason = f"OHLCV_HTTP_OR_OKX_ERROR:{status}"
+            break
+        if not rows:
+            consecutive_empty += 1
+            if consecutive_empty >= budget.max_consecutive_empty_pages:
+                fail_reason = BudgetGuardReason.MAX_CONSECUTIVE_EMPTY_PAGES.value
+                break
+            break
+
+        consecutive_empty = 0
+        for row in finalized:
+            ts = int(str(row[0]))
+            if _row_in_window(ts, window):
+                all_rows.append(row)
+
+        if not ts_values:
+            break
+        oldest = min(ts_values)
+        if oldest <= window.start_ms:
+            break
+        if len(rows) < PAGE_LIMIT:
+            break
+        before_cursor = str(oldest)
+        after_cursor = before_cursor
+        page += 1
+
+    dedup: dict[int, list[Any]] = {}
+    for row in all_rows:
+        dedup[int(str(row[0]))] = row
+    return [dedup[k] for k in sorted(dedup)], fail_reason
+
+
+def paginate_bounded_funding_v0(
+    *,
+    instrument_id: str,
+    native_instrument_id: str,
+    window: BoundedWindowV0,
+    fetcher: PublicGetFetcher,
+    rate_limiter: Any,
+    fetch_with_retry: Callable[..., tuple[int, bytes, dict[str, str]]],
+    build_url: Callable[[str, Mapping[str, str]], str],
+    parse_json: Callable[[bytes], dict[str, Any]],
+    raw_dir: Path,
+    request_log: list[PaginationPageRecordV0],
+    budget: FetchBudgetGuardV0,
+) -> tuple[list[dict[str, Any]], str | None]:
+    path = "/api/v5/public/funding-rate-history"
+    params_base = {"instId": native_instrument_id}
+    all_rows: list[dict[str, Any]] = []
+    after_cursor: str | None = str(window.end_exclusive_ms)
+    use_head_fallback = False
+    page = 0
+    consecutive_empty = 0
+    fail_reason: str | None = None
+    fetch_start = window.funding_fetch_start_ms
+    fetch_end = window.end_exclusive_ms
+
+    while True:
+        runtime_reason = budget.check_runtime()
+        if runtime_reason:
+            fail_reason = runtime_reason
+            break
+        req_reason = budget.check_request()
+        if req_reason:
+            fail_reason = req_reason
+            break
+        page_reason = budget.check_instrument_pages(budget.current_instrument_pages + 1)
+        if page_reason:
+            fail_reason = page_reason
+            break
+
+        params = dict(params_base)
+        params["limit"] = str(PAGE_LIMIT)
+        if after_cursor is not None:
+            params["after"] = after_cursor
+        url = build_url(path, params)
+        budget.total_requests += 1
+        budget.current_instrument_pages += 1
+        status, body, _ = fetch_with_retry(
+            url,
+            timeout_seconds=30.0,
+            max_response_bytes=50_000_000,
+            rate_limiter=rate_limiter,
+            fetcher=fetcher,
+        )
+        digest = _sha256_bytes(body)
+        bytes_reason = budget.check_raw_bytes(len(body))
+        if bytes_reason:
+            fail_reason = bytes_reason
+            break
+
+        payload = parse_json(body)
+        rows = payload.get("data") or []
+        if not isinstance(rows, list):
+            rows = []
+        dict_rows = [dict(r) for r in rows if isinstance(r, Mapping)]
+        ts_values = [int(str(r.get("fundingTime", "0"))) for r in dict_rows] if dict_rows else []
+        overlap = _page_overlaps_window(ts_values, window) if ts_values else False
+        if ts_values:
+            overlap = max(ts_values) >= fetch_start and min(ts_values) < fetch_end
+        in_window_count = sum(1 for ts in ts_values if fetch_start <= ts < fetch_end)
+        min_ts = min(ts_values) if ts_values else None
+        max_ts = max(ts_values) if ts_values else None
+
+        raw_path = ""
+        retained = False
+        discarded_reason = ""
+        if overlap:
+            raw_name = _raw_filename_v0(
+                instrument_id=instrument_id,
+                data_type="funding",
+                page_sequence=page,
+                min_ts_ms=min_ts,
+                max_ts_ms=max_ts,
+                digest=digest,
+            )
+            raw_path = str(raw_dir / raw_name)
+            raw_dir.mkdir(parents=True, exist_ok=True)
+            Path(raw_path).write_bytes(body)
+            budget.total_raw_bytes += len(body)
+            budget.retained_pages += 1
+            retained = True
+        else:
+            budget.discarded_pages += 1
+            discarded_reason = "PAGE_FULLY_OUTSIDE_FETCH_BOUNDS"
+
+        request_log.append(
+            PaginationPageRecordV0(
+                phase=PHASE_B_BOUND_FUNDING_HISTORY,
+                instrument_id=instrument_id,
+                page_sequence=page,
+                query_params=dict(params),
+                min_timestamp_ms=min_ts,
+                max_timestamp_ms=max_ts,
+                overlap_with_window=overlap,
+                retained=retained,
+                raw_path=raw_path,
+                content_digest=digest,
+                row_count_in_window=in_window_count,
+                http_status=status,
+                discarded_reason=discarded_reason,
+            )
+        )
+
+        if status < 200 or status >= 300 or str(payload.get("code", "")) != "0":
+            fail_reason = f"FUNDING_HTTP_OR_OKX_ERROR:{status}"
+            break
+        if not rows:
+            if after_cursor is not None and not use_head_fallback:
+                use_head_fallback = True
+                after_cursor = None
+                continue
+            consecutive_empty += 1
+            if consecutive_empty >= budget.max_consecutive_empty_pages:
+                fail_reason = BudgetGuardReason.MAX_CONSECUTIVE_EMPTY_PAGES.value
+                break
+            break
+
+        consecutive_empty = 0
+        for row in dict_rows:
+            ts = int(str(row.get("fundingTime", "0")))
+            if fetch_start <= ts < fetch_end:
+                all_rows.append(row)
+
+        if not ts_values:
+            break
+        oldest = min(ts_values)
+        if oldest <= fetch_start:
+            break
+        if len(rows) < PAGE_LIMIT:
+            break
+        after_cursor = str(oldest)
+        page += 1
+
+    dedup: dict[int, dict[str, Any]] = {}
+    for row in all_rows:
+        dedup[int(str(row["fundingTime"]))] = row
+    return [dedup[k] for k in sorted(dedup)], fail_reason
+
+
+def backward_asof_funding_lookup_v0(
+    funding_rows: Sequence[Mapping[str, Any]],
+    bar_timestamp_ms: int,
+) -> str | None:
+    """Return latest funding rate with fundingTime <= bar_timestamp_ms, else None."""
+    chosen: Mapping[str, Any] | None = None
+    chosen_ts = -1
+    for row in funding_rows:
+        ts = int(str(row.get("fundingTime", "0")))
+        if ts <= bar_timestamp_ms and ts >= chosen_ts:
+            chosen = row
+            chosen_ts = ts
+    if chosen is None:
+        return None
+    return str(chosen.get("fundingRate", ""))
+
+
+def attach_funding_to_ohlcv_bars_v0(
+    *,
+    instrument_id: str,
+    ohlcv_rows: Sequence[Sequence[Any]],
+    funding_rows: Sequence[Mapping[str, Any]],
+    window: BoundedWindowV0,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """PIT backward-asof join; missing funding stays explicit None."""
+    missing_reasons: list[str] = []
+    output: list[dict[str, Any]] = []
+    for row in ohlcv_rows:
+        ts = int(str(row[0]))
+        if not _row_in_window(ts, window):
+            continue
+        funding_rate = backward_asof_funding_lookup_v0(funding_rows, ts)
+        if funding_rate is None:
+            missing_reasons.append(f"missing_funding_at:{_format_utc_ms(ts)}")
+        output.append(
+            {
+                "instrument_id": instrument_id,
+                "timestamp_utc": _format_utc_ms(ts),
+                "open": str(row[1]),
+                "high": str(row[2]),
+                "low": str(row[3]),
+                "close": str(row[4]),
+                "volume": str(row[5]),
+                "funding_rate": funding_rate,
+                "score_input_provenance": score_input_provenance_marker_v0(),
+                "funding_cashflow_provenance": funding_cashflow_provenance_marker_v0(),
+                "is_final": _candle_is_final(row),
+            }
+        )
+    return output, missing_reasons
+
+
+def select_eligible_instruments_v0(
+    instruments: Sequence[Mapping[str, Any]],
+    *,
+    max_instruments: int | None = None,
+    listed_before_ms: int | None = None,
+) -> list[tuple[str, str]]:
+    eligible: list[tuple[str, str]] = []
+    for inst in instruments:
+        result = evaluate_okx_instrument_eligibility_v1(inst)
+        if not result.eligible or result.instrument_id is None or result.metadata is None:
+            continue
+        if listed_before_ms is not None:
+            list_ms = _parse_utc_ms(result.metadata.list_time_utc)
+            if list_ms > listed_before_ms:
+                continue
+        eligible.append((result.instrument_id, result.metadata.inst_id))
+    eligible.sort(key=lambda item: item[0])
+    if max_instruments is not None:
+        eligible = eligible[:max_instruments]
+    return eligible
+
+
+def first_ohlcv_request_anchored_at_end_exclusive(
+    request_log: Sequence[PaginationPageRecordV0],
+    window: BoundedWindowV0,
+) -> bool:
+    ohlcv_pages = [r for r in request_log if r.phase == PHASE_A_BOUND_OHLCV_PANEL]
+    if not ohlcv_pages:
+        return False
+    first = min(ohlcv_pages, key=lambda r: (r.instrument_id, r.page_sequence))
+    before_val = first.query_params.get("after")
+    return before_val == str(window.end_exclusive_ms)
+
+
+def out_of_window_retained_raw_count(raw_dir: Path) -> int:
+    count = 0
+    if not raw_dir.is_dir():
+        return 0
+    for path in raw_dir.glob("*.json"):
+        parts = path.stem.split("_")
+        if len(parts) < 6:
+            continue
+        try:
+            min_ts = int(parts[-3])
+            max_ts = int(parts[-2])
+        except ValueError:
+            continue
+        window = compute_bounded_window_v0()
+        if max_ts < window.start_ms or min_ts >= window.end_exclusive_ms:
+            count += 1
+    return count
+
+
+def _load_okx_ingest_helpers() -> tuple[Any, Any, Any, Any, Any]:
+    import importlib.util
+    import sys
+    from pathlib import Path as _Path
+
+    repo_root = _Path(__file__).resolve().parents[2]
+    mat_script = repo_root / "scripts/ops/materialize_okx_production_lifecycle_and_pt1h_panel_v1.py"
+    mat_spec = importlib.util.spec_from_file_location("mat_okx_bounded_fetch", mat_script)
+    assert mat_spec is not None and mat_spec.loader is not None
+    mat_mod = importlib.util.module_from_spec(mat_spec)
+    sys.modules[mat_spec.name] = mat_mod
+    mat_spec.loader.exec_module(mat_mod)
+    ingest_mod = mat_mod._load_okx_ingest_module()
+    return (
+        ingest_mod,
+        mat_mod,
+        ingest_mod.okx_public_fetch_v1,
+        ingest_mod.RateLimiter,
+        ingest_mod.fetch_with_retry,
+    )
+
+
+def _progress_log(payload: Mapping[str, Any]) -> None:
+    print(json.dumps({"progress": dict(payload)}, sort_keys=True), flush=True)
+
+
+@dataclass(frozen=True)
+class BoundedPreflightResultV0:
+    status: FetchTerminalStatus
+    staging_root: str
+    instrument_count: int
+    ohlcv_raw_files: int
+    funding_raw_files: int
+    out_of_window_raw_files: int
+    total_requests: int
+    total_raw_bytes: int
+    runtime_seconds: float
+    fail_reason: str
+    request_log_count: int
+    manifest_verify_rc: int
+    promoted: bool
+
+
+def run_bounded_panel_preflight_v0(
+    *,
+    confirm: str,
+    staging_root: Path,
+    max_instruments: int = 2,
+    preflight_only: bool = True,
+) -> BoundedPreflightResultV0:
+    if confirm != GO_TOKEN:
+        raise ValueError(f"GO_TOKEN_REQUIRED:{GO_TOKEN}")
+
+    if staging_root.exists():
+        raise ValueError(f"STAGING_ROOT_EXISTS:{staging_root}")
+
+    window = compute_bounded_window_v0()
+    derived = derive_production_budget_v0(window)
+    budget = FetchBudgetGuardV0(
+        max_instruments=max_instruments,
+        max_pages_per_instrument=derived["max_pages_per_instrument"],
+        max_total_requests=max(
+            derived["max_total_requests_per_instrument"] * max_instruments + 10, 20
+        ),
+        max_total_raw_bytes=50_000_000,
+        max_runtime_seconds=300,
+    )
+
+    ingest_mod, mat_mod, fetcher, rate_limiter_cls, fetch_with_retry = _load_okx_ingest_helpers()
+    rate_limiter = rate_limiter_cls()
+
+    staging_root.mkdir(parents=True, exist_ok=False)
+    raw_ohlcv_dir = staging_root / "raw" / "ohlcv"
+    raw_funding_dir = staging_root / "raw" / "funding"
+    panel_dir = staging_root / "panel"
+    reports_dir = staging_root / "reports"
+    for path in (raw_ohlcv_dir, raw_funding_dir, panel_dir, reports_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    request_log: list[PaginationPageRecordV0] = []
+    all_panel_bars: list[dict[str, Any]] = []
+    missing_report: dict[str, list[str]] = {}
+    fail_reason = ""
+    status = FetchTerminalStatus.PREFLIGHT_COMPLETE
+
+    raw_dir_tmp = staging_root / "raw"
+    instruments_payload = mat_mod.fetch_all_swap_instruments(
+        ingest_mod,
+        fetcher=fetcher,
+        rate_limiter=rate_limiter,
+        timeout_seconds=30.0,
+        max_response_bytes=50_000_000,
+        raw_dir=raw_dir_tmp,
+    )
+    eligible = select_eligible_instruments_v0(
+        instruments_payload,
+        max_instruments=max_instruments,
+        listed_before_ms=window.start_ms,
+    )
+    if len(eligible) < max_instruments:
+        fail_reason = "INSUFFICIENT_ELIGIBLE_INSTRUMENTS"
+        status = FetchTerminalStatus.VALIDATION_FAILED
+
+    for instrument_id, native_id in eligible:
+        inst_reason = budget.check_instruments()
+        if inst_reason:
+            fail_reason = inst_reason
+            status = FetchTerminalStatus.BUDGET_EXCEEDED_FAIL_CLOSED
+            break
+        budget.begin_instrument()
+        _progress_log(
+            {
+                "elapsed_seconds": round(time.monotonic() - budget.start_monotonic, 2),
+                "instruments_completed": budget.instruments_completed,
+                "instruments_total": max_instruments,
+                "current_instrument": instrument_id,
+                "phase": PHASE_A_BOUND_OHLCV_PANEL,
+            }
+        )
+        ohlcv_rows, ohlcv_fail = paginate_bounded_ohlcv_v0(
+            instrument_id=instrument_id,
+            native_instrument_id=native_id,
+            window=window,
+            fetcher=fetcher,
+            rate_limiter=rate_limiter,
+            fetch_with_retry=fetch_with_retry,
+            build_url=ingest_mod._build_url,
+            parse_json=ingest_mod._parse_okx_json,
+            raw_dir=raw_ohlcv_dir,
+            request_log=request_log,
+            budget=budget,
+        )
+        if ohlcv_fail:
+            fail_reason = ohlcv_fail
+            status = FetchTerminalStatus.BUDGET_EXCEEDED_FAIL_CLOSED
+            break
+
+        _progress_log(
+            {
+                "elapsed_seconds": round(time.monotonic() - budget.start_monotonic, 2),
+                "instruments_completed": budget.instruments_completed,
+                "instruments_total": max_instruments,
+                "current_instrument": instrument_id,
+                "phase": PHASE_B_BOUND_FUNDING_HISTORY,
+                "ohlcv_rows": len(ohlcv_rows),
+            }
+        )
+        funding_rows, funding_fail = paginate_bounded_funding_v0(
+            instrument_id=instrument_id,
+            native_instrument_id=native_id,
+            window=window,
+            fetcher=fetcher,
+            rate_limiter=rate_limiter,
+            fetch_with_retry=fetch_with_retry,
+            build_url=ingest_mod._build_url,
+            parse_json=ingest_mod._parse_okx_json,
+            raw_dir=raw_funding_dir,
+            request_log=request_log,
+            budget=budget,
+        )
+        if funding_fail:
+            fail_reason = funding_fail
+            status = FetchTerminalStatus.BUDGET_EXCEEDED_FAIL_CLOSED
+            break
+
+        joined, missing = attach_funding_to_ohlcv_bars_v0(
+            instrument_id=instrument_id,
+            ohlcv_rows=ohlcv_rows,
+            funding_rows=funding_rows,
+            window=window,
+        )
+        all_panel_bars.extend(joined)
+        if missing:
+            missing_report[instrument_id] = missing
+        budget.complete_instrument()
+        _progress_log(
+            {
+                "elapsed_seconds": round(time.monotonic() - budget.start_monotonic, 2),
+                "instruments_completed": budget.instruments_completed,
+                "instruments_total": max_instruments,
+                "current_instrument": instrument_id,
+                "ohlcv_pages": sum(
+                    1
+                    for r in request_log
+                    if r.instrument_id == instrument_id and r.phase == PHASE_A_BOUND_OHLCV_PANEL
+                ),
+                "funding_pages": sum(
+                    1
+                    for r in request_log
+                    if r.instrument_id == instrument_id and r.phase == PHASE_B_BOUND_FUNDING_HISTORY
+                ),
+                "retained_pages": budget.retained_pages,
+                "discarded_pages": budget.discarded_pages,
+                "total_requests": budget.total_requests,
+                "raw_bytes": budget.total_raw_bytes,
+            }
+        )
+
+    if status is FetchTerminalStatus.PREFLIGHT_COMPLETE:
+        if not first_ohlcv_request_anchored_at_end_exclusive(request_log, window):
+            fail_reason = "FIRST_REQUEST_NOT_ANCHORED_AT_END_EXCLUSIVE"
+            status = FetchTerminalStatus.VALIDATION_FAILED
+        if not all_panel_bars:
+            fail_reason = fail_reason or "PANEL_EMPTY_AFTER_PREFLIGHT"
+            status = FetchTerminalStatus.VALIDATION_FAILED
+        for bar in all_panel_bars:
+            ts = _parse_utc_ms(str(bar["timestamp_utc"]))
+            if ts >= window.end_exclusive_ms or ts < window.start_ms:
+                fail_reason = "PANEL_BAR_OUTSIDE_WINDOW"
+                status = FetchTerminalStatus.VALIDATION_FAILED
+                break
+
+    all_panel_bars.sort(key=lambda row: (row["instrument_id"], row["timestamp_utc"]))
+    (panel_dir / "normalized_panel_bars_with_funding.json").write_text(
+        json.dumps({"bars": all_panel_bars}, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    manifest = {
+        "schema_version": "pit_okx_pt1h_panel_funding_dataset_manifest_v1",
+        "panel_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+        "dataset_extension": "extended_chronological_with_funding_v1",
+        "preflight_only": preflight_only,
+        "window": {
+            "start_inclusive_utc": window.start_inclusive_utc,
+            "end_exclusive_utc": window.end_exclusive_utc,
+            "funding_fetch_start_utc": window.funding_fetch_start_utc,
+            "required_pre_window_hours": window.required_pre_window_hours,
+        },
+        "row_count_total": len(all_panel_bars),
+        "instrument_ids": sorted({bar["instrument_id"] for bar in all_panel_bars}),
+        "score_cashflow_separation": {
+            "score_input": score_input_provenance_marker_v0(),
+            "funding_cashflow": funding_cashflow_provenance_marker_v0(),
+        },
+    }
+    (panel_dir / "panel_funding_dataset_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (reports_dir / "PAGINATION_REQUEST_LOG.jsonl").write_text(
+        "\n".join(json.dumps(record.__dict__, sort_keys=True) for record in request_log) + "\n",
+        encoding="utf-8",
+    )
+    (reports_dir / "MISSING_DATA_REPORT.json").write_text(
+        json.dumps(missing_report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    from scripts.ops.primary_evidence_retention_v0 import (
+        verify_manifest_sha256,
+        write_manifest_sha256,
+    )
+
+    write_manifest_sha256(staging_root)
+    manifest_ok, manifest_msg = verify_manifest_sha256(staging_root)
+    manifest_verify_rc = 0 if manifest_ok else 1
+
+    ohlcv_raw_count = len(list(raw_ohlcv_dir.glob("*.json")))
+    funding_raw_count = len(list(raw_funding_dir.glob("*.json")))
+    oow_count = out_of_window_retained_raw_count(raw_ohlcv_dir) + out_of_window_retained_raw_count(
+        raw_funding_dir
+    )
+
+    promoted = False
+    if status is not FetchTerminalStatus.PREFLIGHT_COMPLETE or fail_reason:
+        status = status if fail_reason else FetchTerminalStatus.INCOMPLETE_NOT_PROMOTED
+
+    return BoundedPreflightResultV0(
+        status=status,
+        staging_root=str(staging_root),
+        instrument_count=len(eligible),
+        ohlcv_raw_files=ohlcv_raw_count,
+        funding_raw_files=funding_raw_count,
+        out_of_window_raw_files=oow_count,
+        total_requests=budget.total_requests,
+        total_raw_bytes=budget.total_raw_bytes,
+        runtime_seconds=round(time.monotonic() - budget.start_monotonic, 2),
+        fail_reason=fail_reason,
+        request_log_count=len(request_log),
+        manifest_verify_rc=manifest_verify_rc,
+        promoted=promoted,
+    )

--- a/src/research/cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_v0.py
+++ b/src/research/cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_v0.py
@@ -1,0 +1,275 @@
+"""Funding-rate delta-momentum cross-sectional ranking semantics declarative binding schema (v0)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from enum import Enum
+from typing import Any, Mapping
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_RANKING_SEMANTICS_BINDING_V0=true"
+SCHEMA_VERSION = "cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding.v0"
+HYPOTHESIS_ID = "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_NON_BITCOIN_PERPETUALS_V0"
+
+SCORE_FAMILY_POLICY = "cross_sectional_funding_rate_delta_rank_v0"
+DIRECTION_POLICY = "symmetric_funding_delta_extremum_mean_reversion_single_leg_rotation_v0"
+SELECTION_MODE = "funding_delta_extremes_single_leg_rotation_v0"
+LONG_LEG_MEANS = "LONG_MINIMUM_FUNDING_DELTA"
+SHORT_LEG_MEANS = "SHORT_MAXIMUM_FUNDING_DELTA"
+
+SIGNAL_TIMING_POLICY = "finalized_bar_close_epoch"
+MINIMUM_SIGNAL_LAG_BARS = 1
+SAME_BAR_EXECUTION_ALLOWED = False
+REBALANCE_POLICY_CLASS = "fixed_N_bar_cadence"
+SWITCH_POLICY = "flat_then_wait_one_epoch_then_enter"
+COOLDOWN_POLICY = "no_cooldown"
+MINIMUM_HOLD_POLICY = "until_next_rebalance"
+PANEL_COMPLETENESS_POLICY = "per_instrument_eligibility_mask"
+MISSING_BAR_POLICY = "exclude_non_selected_instrument_for_epoch"
+TIE_BREAK_POLICY = "funding_delta_asc_then_instrument_id_asc_for_long_leg"
+THRESHOLD_POLICY = "rank_extremes_only_no_continuous_threshold_tuning"
+
+ORCHESTRATOR_OWNER = (
+    "cross_sectional_funding_rate_delta_momentum_single_slot_research_orchestrator_v0"
+)
+ORCHESTRATOR_SCOPE = "RESEARCH_ONLY"
+
+NUMERIC_BINDING_KEYS = (
+    "funding_delta_lookback_k",
+    "rebalance_interval_bars",
+    "signal_lag_bars",
+    "min_eligible_members_for_rank",
+    "switch_entry_delay_epochs",
+    "max_bar_staleness_bars",
+)
+
+EXTERNAL_BINDING_KEYS = (
+    "pit_universe_manifest_ref",
+    "instrument_id_canonicalization_version",
+    "panel_funding_dataset_manifest_ref",
+    "admissibility_manifest_ref",
+    "evaluation_period_binding",
+    "fee_model_version",
+    "slippage_model_version",
+    "funding_model_version",
+    "spread_model_version",
+    "execution_model_version",
+)
+
+DIGEST_BINDING_KEYS = (
+    "implementation_digest",
+    "config_digest",
+    "data_digest",
+)
+
+VERSIONED_BINDING_CONFIG_REL_PATH = (
+    "config/research/"
+    "cross_sectional_funding_rate_delta_momentum_v0_ranking_semantics_binding_v0.json"
+)
+
+RATIFIED_OPERATOR_BINDING_VALUES: dict[str, int | float | str] = {
+    "funding_delta_lookback_k": 4,
+    "rebalance_interval_bars": 1,
+    "signal_lag_bars": 1,
+    "min_eligible_members_for_rank": 5,
+    "switch_entry_delay_epochs": 1,
+    "max_bar_staleness_bars": 1,
+}
+
+RATIFIED_OPERATOR_RATIONALES: dict[str, str] = {
+    "funding_delta_lookback_k": (
+        "Frozen K=4 PT1H bars for funding delta lookback; no post-hoc tuning permitted."
+    ),
+    "rebalance_interval_bars": (
+        "Ranking recomputed every finalized epoch; research-only, no runtime effect."
+    ),
+    "signal_lag_bars": ("One full bar lag prevents look-ahead on funding observations."),
+    "min_eligible_members_for_rank": (
+        "At least five simultaneously eligible panel members for cross-sectional ranking."
+    ),
+    "switch_entry_delay_epochs": (
+        "After leg change wait one epoch before entry per switch policy."
+    ),
+    "max_bar_staleness_bars": ("At most one bar staleness tolerance; older members excluded."),
+}
+
+
+def compute_operator_decision_digest_v0(
+    operator_values: Mapping[str, int | float | str] | None = None,
+    operator_rationales: Mapping[str, str] | None = None,
+) -> str:
+    values = dict(operator_values or RATIFIED_OPERATOR_BINDING_VALUES)
+    rationales = dict(operator_rationales or RATIFIED_OPERATOR_RATIONALES)
+    digest_input = {
+        key: {"value": values[key], "rationale": rationales[key]} for key in sorted(values)
+    }
+    canonical = json.dumps(
+        digest_input,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+ATTESTED_OPERATOR_DECISION_DIGEST = compute_operator_decision_digest_v0()
+
+
+class BindingFieldStatus(str, Enum):
+    REQUIRED_UNBOUND = "REQUIRED_UNBOUND"
+    BOUND = "BOUND"
+    INVALID = "INVALID"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+
+
+class AggregateBindingStatus(str, Enum):
+    BOUND = "BOUND"
+    REQUIRED_UNBOUND = "REQUIRED_UNBOUND"
+    INCOMPLETE_FAIL_CLOSED = "INCOMPLETE_FAIL_CLOSED"
+    COMPLETE = "COMPLETE"
+
+
+def _field(
+    status: BindingFieldStatus,
+    *,
+    value: Any = None,
+    ref: str = "",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": status.value}
+    if value is not None:
+        payload["value"] = value
+    if ref:
+        payload["ref"] = ref
+    return payload
+
+
+def materialize_funding_rate_delta_momentum_ranking_semantics_binding_v0() -> dict[str, Any]:
+    numeric_bindings = {
+        key: _field(BindingFieldStatus.REQUIRED_UNBOUND) for key in NUMERIC_BINDING_KEYS
+    }
+    external_bindings = {
+        key: _field(BindingFieldStatus.REQUIRED_UNBOUND) for key in EXTERNAL_BINDING_KEYS
+    }
+    digest_bindings = {
+        key: _field(BindingFieldStatus.REQUIRED_UNBOUND) for key in DIGEST_BINDING_KEYS
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "hypothesis_id": HYPOTHESIS_ID,
+        "policy_classes": {
+            "score_family_policy": SCORE_FAMILY_POLICY,
+            "direction_policy": DIRECTION_POLICY,
+            "signal_timing_policy": SIGNAL_TIMING_POLICY,
+            "rebalance_policy_class": REBALANCE_POLICY_CLASS,
+            "switch_policy": SWITCH_POLICY,
+            "cooldown_policy": COOLDOWN_POLICY,
+            "minimum_hold_policy": MINIMUM_HOLD_POLICY,
+            "panel_completeness_policy": PANEL_COMPLETENESS_POLICY,
+            "missing_bar_policy": MISSING_BAR_POLICY,
+            "tie_break_policy": TIE_BREAK_POLICY,
+            "threshold_policy": THRESHOLD_POLICY,
+        },
+        "system_constraints": {
+            "futures_only": True,
+            "bitcoin_direction_allowed": False,
+            "spot_allowed": False,
+            "synthetic_spot_allowed": False,
+        },
+        "direction_semantics": {
+            "selection_mode": SELECTION_MODE,
+            "long_leg_means": LONG_LEG_MEANS,
+            "short_leg_means": SHORT_LEG_MEANS,
+            "dual_leg_simultaneous_forbidden": True,
+            "single_slot_rotation": True,
+            "panel_insufficient_target": "FLAT",
+            "warmup_incomplete_target": "FLAT",
+            "non_finite_funding_target": "FLAT",
+        },
+        "timing_semantics": {
+            "decision_input": "finalized_bars_only",
+            "score_epoch": "finalized_bar_close",
+            "minimum_signal_lag_bars": MINIMUM_SIGNAL_LAG_BARS,
+            "same_bar_execution": SAME_BAR_EXECUTION_ALLOWED,
+            "finalized_bar_required": True,
+            "pit_universe_at_score_epoch": True,
+            "funding_observation_field": "funding_rate",
+        },
+        "switch_semantics": {
+            "switch_policy": SWITCH_POLICY,
+            "opposite_side_requires_reconciled_flat": True,
+            "flat_then_wait_one_epoch_then_enter": True,
+            "atomic_side_switch": False,
+        },
+        "missing_bar_semantics": {
+            "missing_bar_policy": MISSING_BAR_POLICY,
+            "non_selected_missing": "exclude_for_epoch",
+            "selected_missing": "force_flat",
+            "carry_forward": False,
+        },
+        "panel_semantics": {
+            "eligibility_mode": PANEL_COMPLETENESS_POLICY,
+            "minimum_eligible_member_count_required": True,
+            "insufficient_panel_action": "flat",
+        },
+        "tie_break_semantics": {
+            "long_leg_order": "funding_delta_asc_then_instrument_id_asc",
+            "short_leg_order": "funding_delta_desc_then_instrument_id_asc",
+            "tie_break_policy": TIE_BREAK_POLICY,
+            "abs_delta_tie_leg_order": "instrument_id_asc",
+        },
+        "threshold_semantics": {
+            "threshold_policy": THRESHOLD_POLICY,
+            "numeric_strength_threshold_initial": False,
+        },
+        "orchestrator": {
+            "owner": ORCHESTRATOR_OWNER,
+            "scope": ORCHESTRATOR_SCOPE,
+        },
+        "numeric_bindings": numeric_bindings,
+        "external_bindings": external_bindings,
+        "digest_bindings": digest_bindings,
+        "binding_status": {
+            "policy_classes_status": AggregateBindingStatus.BOUND.value,
+            "numeric_bindings_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "universe_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "dataset_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "period_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "cost_model_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "digest_binding_status": AggregateBindingStatus.REQUIRED_UNBOUND.value,
+            "overall_binding_status": AggregateBindingStatus.INCOMPLETE_FAIL_CLOSED.value,
+        },
+    }
+
+
+def compute_config_digest_v0(config_bytes: bytes) -> str:
+    return hashlib.sha256(config_bytes).hexdigest()
+
+
+def apply_ratified_operator_bindings_v0(binding: dict[str, Any]) -> dict[str, Any]:
+    result = deepcopy(binding)
+    numeric = result["numeric_bindings"]
+    for key, value in RATIFIED_OPERATOR_BINDING_VALUES.items():
+        numeric[key] = _field(BindingFieldStatus.BOUND, value=value)
+    status = result["binding_status"]
+    status["numeric_bindings_status"] = AggregateBindingStatus.BOUND.value
+    status["overall_binding_status"] = AggregateBindingStatus.INCOMPLETE_FAIL_CLOSED.value
+    return result
+
+
+def materialize_versioned_funding_rate_delta_momentum_ranking_semantics_binding_v0() -> dict[
+    str, Any
+]:
+    binding = apply_ratified_operator_bindings_v0(
+        materialize_funding_rate_delta_momentum_ranking_semantics_binding_v0()
+    )
+    return {
+        "artifact_kind": "cross_sectional_funding_rate_delta_momentum_ranking_semantics_versioned_binding",
+        "artifact_version": "v0",
+        "binding": binding,
+        "operator_decision_digest": ATTESTED_OPERATOR_DECISION_DIGEST,
+    }
+
+
+def serialize_versioned_binding_artifact_json_v0(envelope: Mapping[str, Any]) -> str:
+    return json.dumps(dict(envelope), indent=2, sort_keys=True, ensure_ascii=False) + "\n"

--- a/src/research/cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_validator_v0.py
+++ b/src/research/cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_validator_v0.py
@@ -1,0 +1,101 @@
+"""Fail-closed validator for cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding.v0."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+from src.research.cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_v0 import (
+    DIRECTION_POLICY,
+    DIGEST_BINDING_KEYS,
+    EXTERNAL_BINDING_KEYS,
+    HYPOTHESIS_ID,
+    NUMERIC_BINDING_KEYS,
+    SCHEMA_VERSION,
+    SCORE_FAMILY_POLICY,
+    BindingFieldStatus,
+)
+
+PACKAGE_MARKER = (
+    "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_RANKING_SEMANTICS_BINDING_VALIDATOR_V0=true"
+)
+
+POSITIVE_NUMERIC_KEYS = frozenset(NUMERIC_BINDING_KEYS)
+
+
+class ValidationVerdict(str, Enum):
+    ACCEPTED_INCOMPLETE = "ACCEPTED_INCOMPLETE"
+    ACCEPTED_COMPLETE = "ACCEPTED_COMPLETE"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True)
+class FundingDeltaRankingSemanticsBindingValidationResult:
+    verdict: ValidationVerdict
+    valid: bool
+    fail_reasons: tuple[str, ...]
+    binding_status: Mapping[str, Any]
+
+
+def _is_bound(field: Mapping[str, Any]) -> bool:
+    return field.get("status") == BindingFieldStatus.BOUND.value
+
+
+def validate_funding_rate_delta_momentum_ranking_semantics_binding_v0(
+    binding: Mapping[str, Any],
+) -> FundingDeltaRankingSemanticsBindingValidationResult:
+    fail_reasons: list[str] = []
+
+    if binding.get("schema_version") != SCHEMA_VERSION:
+        fail_reasons.append("INVALID_SCHEMA_VERSION")
+    if binding.get("hypothesis_id") != HYPOTHESIS_ID:
+        fail_reasons.append("HYPOTHESIS_ID_MISMATCH")
+
+    policy = binding.get("policy_classes", {})
+    if policy.get("score_family_policy") != SCORE_FAMILY_POLICY:
+        fail_reasons.append("SCORE_FAMILY_POLICY_MISMATCH")
+    if policy.get("direction_policy") != DIRECTION_POLICY:
+        fail_reasons.append("DIRECTION_POLICY_MISMATCH")
+
+    numeric = binding.get("numeric_bindings", {})
+    for key in NUMERIC_BINDING_KEYS:
+        field = numeric.get(key, {})
+        if not _is_bound(field):
+            fail_reasons.append(f"NUMERIC_BINDING_UNBOUND:{key}")
+            continue
+        if key in POSITIVE_NUMERIC_KEYS:
+            value = field.get("value")
+            if not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0:
+                fail_reasons.append(f"NON_POSITIVE_NUMERIC:{key}")
+
+    external = binding.get("external_bindings", {})
+    for key in EXTERNAL_BINDING_KEYS:
+        if not _is_bound(external.get(key, {})):
+            fail_reasons.append(f"EXTERNAL_BINDING_UNBOUND:{key}")
+
+    digest = binding.get("digest_bindings", {})
+    for key in DIGEST_BINDING_KEYS:
+        if not _is_bound(digest.get(key, {})):
+            fail_reasons.append(f"DIGEST_BINDING_UNBOUND:{key}")
+
+    status = binding.get("binding_status", {})
+    overall = status.get("overall_binding_status")
+    all_bound = not fail_reasons
+    if all_bound and overall != "COMPLETE":
+        fail_reasons.append("INCOMPLETE_BINDING_MARKED_INCOMPLETE")
+
+    if fail_reasons:
+        return FundingDeltaRankingSemanticsBindingValidationResult(
+            verdict=ValidationVerdict.REJECTED,
+            valid=False,
+            fail_reasons=tuple(fail_reasons),
+            binding_status=status,
+        )
+    return FundingDeltaRankingSemanticsBindingValidationResult(
+        verdict=ValidationVerdict.ACCEPTED_COMPLETE,
+        valid=True,
+        fail_reasons=(),
+        binding_status=status,
+    )

--- a/src/research/cross_sectional_funding_rate_delta_momentum_scoring_v0.py
+++ b/src/research/cross_sectional_funding_rate_delta_momentum_scoring_v0.py
@@ -1,0 +1,140 @@
+"""Cross-sectional funding-rate delta momentum v0 score and single-leg selection primitives.
+
+Pure offline, deterministic funding-delta ranking for long-min-delta / short-max-delta
+mean-reversion rotation. Research-only; no runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Sequence
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_SCORING_V0=true"
+
+SCORE_FORMULA_VERSION = "cross_sectional_funding_rate_delta_rank_v0"
+SCORE_FORMULA_EXPRESSION = (
+    "delta_i(t) = funding_rate_i[t-lag] - funding_rate_i[t-lag-K]; "
+    "long_leg = instrument with minimum delta; "
+    "short_leg = instrument with maximum delta; "
+    "single_slot selects leg with larger absolute delta"
+)
+FUNDING_DELTA_LOOKBACK_K = 4
+FUNDING_SIGNAL_LAG = 1
+
+
+class FundingDeltaLeg(str, Enum):
+    FLAT = "FLAT"
+    LONG_MIN_DELTA = "LONG_MIN_DELTA"
+    SHORT_MAX_DELTA = "SHORT_MAX_DELTA"
+
+
+@dataclass(frozen=True)
+class FundingDeltaScoreResultV0:
+    instrument_id: str
+    funding_rate_lag: float
+    funding_rate_lookback: float
+    funding_delta: float
+    warmup_complete: bool
+
+
+@dataclass(frozen=True)
+class FundingDeltaExtremeSelectionV0:
+    leg: FundingDeltaLeg
+    instrument_id: str | None
+    min_delta_instrument_id: str | None
+    max_delta_instrument_id: str | None
+    min_funding_delta: float | None
+    max_funding_delta: float | None
+
+
+def _is_bitcoin_instrument(instrument_id: str) -> bool:
+    lowered = instrument_id.lower()
+    return any(token in lowered for token in ("btc", "xbt", "bitcoin"))
+
+
+def compute_instrument_funding_delta_score_v0(
+    instrument_id: str,
+    funding_rates: Sequence[float],
+    *,
+    funding_delta_lookback_k: int = FUNDING_DELTA_LOOKBACK_K,
+    signal_lag_bars: int = FUNDING_SIGNAL_LAG,
+    epoch_index: int,
+) -> FundingDeltaScoreResultV0 | None:
+    if _is_bitcoin_instrument(instrument_id):
+        return None
+    lag_idx = epoch_index - signal_lag_bars
+    lookback_idx = lag_idx - funding_delta_lookback_k
+    if lag_idx < 0 or lookback_idx < 0:
+        return None
+    raw_lag = funding_rates[lag_idx]
+    raw_lookback = funding_rates[lookback_idx]
+    if not math.isfinite(raw_lag) or not math.isfinite(raw_lookback):
+        return None
+    delta = raw_lag - raw_lookback
+    if not math.isfinite(delta):
+        return None
+    return FundingDeltaScoreResultV0(
+        instrument_id=instrument_id,
+        funding_rate_lag=raw_lag,
+        funding_rate_lookback=raw_lookback,
+        funding_delta=delta,
+        warmup_complete=True,
+    )
+
+
+def rank_funding_deltas_for_long_min_v0(
+    scores: Sequence[FundingDeltaScoreResultV0],
+) -> tuple[FundingDeltaScoreResultV0, ...]:
+    return tuple(sorted(scores, key=lambda item: (item.funding_delta, item.instrument_id)))
+
+
+def rank_funding_deltas_for_short_max_v0(
+    scores: Sequence[FundingDeltaScoreResultV0],
+) -> tuple[FundingDeltaScoreResultV0, ...]:
+    return tuple(sorted(scores, key=lambda item: (-item.funding_delta, item.instrument_id)))
+
+
+def select_funding_delta_extreme_single_leg_v0(
+    scores: Sequence[FundingDeltaScoreResultV0],
+) -> FundingDeltaExtremeSelectionV0:
+    if not scores:
+        return FundingDeltaExtremeSelectionV0(
+            leg=FundingDeltaLeg.FLAT,
+            instrument_id=None,
+            min_delta_instrument_id=None,
+            max_delta_instrument_id=None,
+            min_funding_delta=None,
+            max_funding_delta=None,
+        )
+    long_ranked = rank_funding_deltas_for_long_min_v0(scores)
+    short_ranked = rank_funding_deltas_for_short_max_v0(scores)
+    min_item = long_ranked[0]
+    max_item = short_ranked[0]
+    min_abs = abs(min_item.funding_delta)
+    max_abs = abs(max_item.funding_delta)
+    if min_abs > max_abs or (
+        min_abs == max_abs and min_item.instrument_id <= max_item.instrument_id
+    ):
+        leg = FundingDeltaLeg.LONG_MIN_DELTA
+        selected_id = min_item.instrument_id
+    else:
+        leg = FundingDeltaLeg.SHORT_MAX_DELTA
+        selected_id = max_item.instrument_id
+    return FundingDeltaExtremeSelectionV0(
+        leg=leg,
+        instrument_id=selected_id,
+        min_delta_instrument_id=min_item.instrument_id,
+        max_delta_instrument_id=max_item.instrument_id,
+        min_funding_delta=min_item.funding_delta,
+        max_funding_delta=max_item.funding_delta,
+    )
+
+
+def score_input_provenance_marker_v0() -> str:
+    return "funding_delta_score_input_lagged_observation_v0"
+
+
+def funding_cashflow_provenance_marker_v0() -> str:
+    return "funding_cashflow_interval_settlement_v1"

--- a/src/research/cross_sectional_funding_rate_delta_momentum_single_slot_research_orchestrator_v0.py
+++ b/src/research/cross_sectional_funding_rate_delta_momentum_single_slot_research_orchestrator_v0.py
@@ -1,0 +1,224 @@
+"""Funding-rate delta momentum single-slot research orchestrator v0."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from src.research.cross_sectional_funding_rate_delta_momentum_scoring_v0 import (
+    SCORE_FORMULA_VERSION,
+    FundingDeltaLeg,
+    FundingDeltaScoreResultV0,
+    compute_instrument_funding_delta_score_v0,
+    select_funding_delta_extreme_single_leg_v0,
+)
+from src.research.cross_sectional_single_slot_research_orchestrator_v0 import (
+    OrchestratorEpochResultV0,
+    OrchestratorRunResultV0,
+    SingleSlotSelectionEventV0,
+    SlotSide,
+    _SlotState,
+    _apply_rotation_state_machine,
+    _extract_numeric_binding,
+    _is_stale,
+)
+from src.research.pit_okx_pt1h_panel_funding_dataset_v1 import InstrumentFundingPanelSeriesV1
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import (
+    PanelValidationErrorCode,
+    validate_panel_series_v1,
+)
+
+PACKAGE_MARKER = (
+    "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_SINGLE_SLOT_RESEARCH_ORCHESTRATOR_V0=true"
+)
+ORCHESTRATOR_VERSION = (
+    "cross_sectional_funding_rate_delta_momentum_single_slot_research_orchestrator.v0"
+)
+
+FORBIDDEN_INSTRUMENT_TOKENS = frozenset({"btc", "xbt", "bitcoin"})
+
+
+class FundingDeltaOrchestratorErrorCode(str, Enum):
+    BINDING_INCOMPLETE = "BINDING_INCOMPLETE"
+    PANEL_VALIDATION_FAILED = "PANEL_VALIDATION_FAILED"
+    INSUFFICIENT_ELIGIBLE_MEMBERS = "INSUFFICIENT_ELIGIBLE_MEMBERS"
+    MISSING_FUNDING_RATE = "MISSING_FUNDING_RATE"
+    INVALID_FUNDING_RATE = "INVALID_FUNDING_RATE"
+
+
+def _leg_to_slot_side(leg: FundingDeltaLeg) -> SlotSide:
+    if leg is FundingDeltaLeg.LONG_MIN_DELTA:
+        return SlotSide.LONG
+    if leg is FundingDeltaLeg.SHORT_MAX_DELTA:
+        return SlotSide.SHORT
+    return SlotSide.FLAT
+
+
+def _funding_rates_from_series(series: InstrumentFundingPanelSeriesV1) -> tuple[float, ...]:
+    return tuple(float(bar.funding_rate) for bar in series.bars)
+
+
+def run_cross_sectional_funding_rate_delta_momentum_orchestrator_v0(
+    *,
+    binding: Mapping[str, Any],
+    funding_panel_series: Sequence[InstrumentFundingPanelSeriesV1],
+    eligible_instrument_ids: Sequence[str] | None = None,
+) -> OrchestratorRunResultV0:
+    lookback_k = int(_extract_numeric_binding(binding, "funding_delta_lookback_k"))
+    signal_lag_bars = int(_extract_numeric_binding(binding, "signal_lag_bars"))
+    min_eligible = int(_extract_numeric_binding(binding, "min_eligible_members_for_rank"))
+    switch_delay = int(_extract_numeric_binding(binding, "switch_entry_delay_epochs"))
+    max_staleness = int(_extract_numeric_binding(binding, "max_bar_staleness_bars"))
+
+    ohlcv_series = [
+        type(
+            "OhlcvProxy",
+            (),
+            {
+                "instrument_id": item.instrument_id,
+                "native_instrument_id": item.native_instrument_id,
+                "bars": item.bars,
+                "series_digest": item.series_digest,
+            },
+        )()
+        for item in funding_panel_series
+    ]
+    panel_validation = validate_panel_series_v1(
+        ohlcv_series,
+        min_instruments=min_eligible,
+        forbidden_instrument_substrings=FORBIDDEN_INSTRUMENT_TOKENS,
+    )
+    if (
+        PanelValidationErrorCode.BITCOIN_INSTRUMENT_PRESENT.value in panel_validation.error_codes
+        or PanelValidationErrorCode.INSUFFICIENT_INSTRUMENTS.value in panel_validation.error_codes
+        or panel_validation.panel_alignment_check == "FAIL"
+    ):
+        return OrchestratorRunResultV0(
+            orchestrator_version=ORCHESTRATOR_VERSION,
+            score_formula_version=SCORE_FORMULA_VERSION,
+            epochs=(),
+            final_slot_side=SlotSide.FLAT,
+            final_instrument_id=None,
+            authority_effect="NONE",
+            runtime_effect="NONE",
+            order_effect="NONE",
+        )
+
+    series_by_id = {series.instrument_id: series for series in funding_panel_series}
+    if eligible_instrument_ids is not None:
+        allowed = set(eligible_instrument_ids)
+        series_by_id = {iid: series for iid, series in series_by_id.items() if iid in allowed}
+
+    if not series_by_id:
+        raise ValueError(FundingDeltaOrchestratorErrorCode.PANEL_VALIDATION_FAILED.value)
+
+    reference_series = max(series_by_id.values(), key=lambda s: len(s.bars))
+    bar_count = len(reference_series.bars)
+    rates_by_id = {iid: _funding_rates_from_series(series) for iid, series in series_by_id.items()}
+
+    state = _SlotState()
+    epoch_results: list[OrchestratorEpochResultV0] = []
+
+    for epoch_index in range(bar_count):
+        timestamp_utc = reference_series.bars[epoch_index].timestamp_utc
+        error_codes: list[str] = []
+        epoch_scores: list[FundingDeltaScoreResultV0] = []
+
+        for instrument_id, rates in rates_by_id.items():
+            series = series_by_id[instrument_id]
+            if _is_stale(
+                series.bars,
+                epoch_index=epoch_index,
+                reference_timestamp=timestamp_utc,
+                max_bar_staleness_bars=max_staleness,
+            ):
+                continue
+            score_result = compute_instrument_funding_delta_score_v0(
+                instrument_id,
+                rates,
+                funding_delta_lookback_k=lookback_k,
+                signal_lag_bars=signal_lag_bars,
+                epoch_index=epoch_index,
+            )
+            if score_result is not None:
+                epoch_scores.append(score_result)
+
+        selection_extreme = select_funding_delta_extreme_single_leg_v0(epoch_scores)
+        ranked_ids = tuple(
+            sorted(
+                (item.instrument_id for item in epoch_scores),
+                key=lambda iid: (
+                    rates_by_id[iid][epoch_index - signal_lag_bars]
+                    - rates_by_id[iid][epoch_index - signal_lag_bars - lookback_k]
+                    if epoch_index >= signal_lag_bars + lookback_k
+                    else float("inf"),
+                    iid,
+                ),
+            )
+        )
+
+        if len(epoch_scores) < min_eligible or selection_extreme.leg is FundingDeltaLeg.FLAT:
+            target_side = SlotSide.FLAT
+            target_instrument_id = None
+            top_score = None
+            error_codes.append(
+                FundingDeltaOrchestratorErrorCode.INSUFFICIENT_ELIGIBLE_MEMBERS.value
+            )
+        else:
+            target_side = _leg_to_slot_side(selection_extreme.leg)
+            target_instrument_id = selection_extreme.instrument_id
+            top_score = (
+                selection_extreme.min_funding_delta
+                if selection_extreme.leg is FundingDeltaLeg.LONG_MIN_DELTA
+                else selection_extreme.max_funding_delta
+            )
+
+        slot_side, selected_id, pending = _apply_rotation_state_machine(
+            state,
+            target_side=target_side,
+            target_instrument_id=target_instrument_id,
+            switch_entry_delay_epochs=switch_delay,
+        )
+
+        selection = SingleSlotSelectionEventV0(
+            epoch_index=epoch_index,
+            timestamp_utc=timestamp_utc,
+            ranked_instrument_ids=ranked_ids,
+            top_score=top_score,
+            selected_instrument_id=selected_id,
+            slot_side=slot_side,
+            pending_switch=pending,
+            eligible_member_count=len(epoch_scores),
+        )
+        epoch_results.append(
+            OrchestratorEpochResultV0(
+                epoch_index=epoch_index,
+                timestamp_utc=timestamp_utc,
+                scores=tuple(),
+                selection=selection,
+                error_codes=tuple(sorted(set(error_codes))),
+            )
+        )
+
+    return OrchestratorRunResultV0(
+        orchestrator_version=ORCHESTRATOR_VERSION,
+        score_formula_version=SCORE_FORMULA_VERSION,
+        epochs=tuple(epoch_results),
+        final_slot_side=state.current_side,
+        final_instrument_id=state.current_instrument_id,
+        authority_effect="NONE",
+        runtime_effect="NONE",
+        order_effect="NONE",
+    )
+
+
+def default_funding_delta_momentum_operator_binding_v0() -> Mapping[str, Any]:
+    from src.research.cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_v0 import (
+        apply_ratified_operator_bindings_v0,
+        materialize_funding_rate_delta_momentum_ranking_semantics_binding_v0,
+    )
+
+    return apply_ratified_operator_bindings_v0(
+        materialize_funding_rate_delta_momentum_ranking_semantics_binding_v0()
+    )

--- a/src/research/cross_sectional_funding_rate_delta_momentum_v0_bound_panel_dataset_materialization_v0.py
+++ b/src/research/cross_sectional_funding_rate_delta_momentum_v0_bound_panel_dataset_materialization_v0.py
@@ -1,0 +1,353 @@
+"""Bound funding panel dataset materialization for cross-sectional funding-rate delta momentum v0."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.research.cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0 import (
+    PANEL_CALENDAR_END_UTC,
+    PANEL_CALENDAR_START_UTC,
+    PANEL_DATASET_EXTENSION,
+    PANEL_DATASET_ID,
+    PANEL_FUNDING_DATASET_MANIFEST_REF,
+    PIT_UNIVERSE_MANIFEST_REF,
+    build_period_binding_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (
+    reject_foreign_panel_dataset_v0,
+    verify_panel_covers_period_binding_v0,
+)
+from src.research.pit_futures_cross_sectional_research_data_digest_period_split_materialization_v0 import (
+    load_panel_series_from_staging,
+)
+from src.research.pit_okx_pt1h_panel_funding_dataset_v1 import (
+    FUNDING_FIELD,
+    InstrumentFundingPanelSeriesV1,
+    validate_funding_panel_series_v1,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+
+PACKAGE_MARKER = (
+    "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_V0_BOUND_PANEL_DATASET_MATERIALIZATION_V0=true"
+)
+MATERIALIZATION_VERSION = (
+    "cross_sectional_funding_rate_delta_momentum_v0_bound_panel_dataset_materialization.v0"
+)
+
+REASON_PERIOD_MISMATCH = "PERIOD_BINDING_MISMATCH"
+REASON_FOREIGN_DATASET_REJECTED = "FOREIGN_DATASET_PERIOD_REJECTED"
+REASON_MISSING_STAGING = "MISSING_PANEL_STAGING"
+REASON_MISSING_FUNDING_MANIFEST = "MISSING_FUNDING_PANEL_MANIFEST"
+REASON_FUNDING_VALIDATION_FAILED = "FUNDING_PANEL_VALIDATION_FAILED"
+REASON_DATA_DIGEST_MISMATCH = "DATA_DIGEST_MISMATCH"
+REASON_INSUFFICIENT_COVERAGE = "INSUFFICIENT_PERIOD_COVERAGE"
+
+
+class MaterializationTerminalStatus(str, Enum):
+    DATASET_MATERIALIZATION_COMPLETE = "DATASET_MATERIALIZATION_COMPLETE"
+    BOUND_DATA_UNAVAILABLE_FAIL_CLOSED = "BOUND_DATA_UNAVAILABLE_FAIL_CLOSED"
+
+
+@dataclass(frozen=True)
+class BoundFundingPanelMaterializationResultV0:
+    status: MaterializationTerminalStatus
+    panel_data_digest: str
+    bound_data_digest: str
+    data_digest_match: bool
+    data_start_time: str
+    data_end_time: str
+    instrument_count: int
+    row_count_total: int
+    period_binding_id: str
+    dataset_id: str
+    dataset_extension: str
+    staging_root: str
+    panel_ref: str
+    funding_manifest_path: str
+    reason_codes: tuple[str, ...]
+    idempotent_digest_stable: bool
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_bound_funding_data_digest_v0() -> str:
+    return _stable_digest(
+        {
+            "dataset_id": PANEL_DATASET_ID,
+            "dataset_extension": PANEL_DATASET_EXTENSION,
+            "panel_funding_manifest_ref": PANEL_FUNDING_DATASET_MANIFEST_REF,
+            "pit_universe_manifest_ref": PIT_UNIVERSE_MANIFEST_REF,
+            "funding_field": FUNDING_FIELD,
+            "panel_calendar_start_utc": PANEL_CALENDAR_START_UTC,
+            "panel_calendar_end_utc": PANEL_CALENDAR_END_UTC,
+        }
+    )
+
+
+def _panel_time_bounds_from_funding(
+    panel_series: Sequence[InstrumentFundingPanelSeriesV1],
+) -> tuple[str, str]:
+    timestamps: list[str] = []
+    for series in panel_series:
+        for bar in series.bars:
+            timestamps.append(bar.timestamp_utc)
+    if not timestamps:
+        return "", ""
+    return min(timestamps), max(timestamps)
+
+
+def load_funding_panel_from_staging(
+    staging_root: Path,
+) -> tuple[tuple[InstrumentFundingPanelSeriesV1, ...], str, Path]:
+    manifest_path = staging_root / "panel" / "panel_funding_dataset_manifest.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"missing_funding_manifest:{manifest_path}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    panel_ref = (
+        f"pit_okx_pt1h_panel_funding_dataset_v1:{manifest.get('panel_id', PANEL_DATASET_ID)}:"
+        f"{manifest.get('dataset_extension', PANEL_DATASET_EXTENSION)}"
+    )
+    bars_path = staging_root / "panel" / "normalized_panel_bars_with_funding.json"
+    if not bars_path.is_file():
+        raise FileNotFoundError(f"missing_funding_bars:{bars_path}")
+    payload = json.loads(bars_path.read_text(encoding="utf-8"))
+    from src.research.pit_okx_pt1h_panel_funding_dataset_v1 import PanelBarWithFundingV1
+
+    grouped: dict[str, list[PanelBarWithFundingV1]] = {}
+    native: dict[str, str] = {}
+    for row in payload.get("bars", []):
+        instrument_id = str(row["instrument_id"])
+        native[instrument_id] = str(row.get("native_instrument_id", instrument_id))
+        grouped.setdefault(instrument_id, []).append(
+            PanelBarWithFundingV1(
+                instrument_id=instrument_id,
+                timestamp_utc=str(row["timestamp_utc"]),
+                open=str(row["open"]),
+                high=str(row["high"]),
+                low=str(row["low"]),
+                close=str(row["close"]),
+                volume=str(row["volume"]),
+                funding_rate=str(row["funding_rate"]),
+                is_final=bool(row.get("is_final", True)),
+            )
+        )
+    series_list: list[InstrumentFundingPanelSeriesV1] = []
+    for instrument_id in sorted(grouped):
+        bars = tuple(sorted(grouped[instrument_id], key=lambda b: b.timestamp_utc))
+        series_list.append(
+            InstrumentFundingPanelSeriesV1(
+                instrument_id=instrument_id,
+                native_instrument_id=native[instrument_id],
+                bars=bars,
+                series_digest=_stable_digest(
+                    [{"instrument_id": b.instrument_id, "ts": b.timestamp_utc} for b in bars]
+                ),
+            )
+        )
+    return tuple(series_list), panel_ref, manifest_path
+
+
+def materialize_bound_funding_panel_dataset_v0(
+    staging_root: Path,
+    *,
+    period_binding: Mapping[str, Any] | None = None,
+    expected_data_digest: str | None = None,
+) -> BoundFundingPanelMaterializationResultV0:
+    period = dict(period_binding or build_period_binding_v0())
+    staging_root = staging_root.resolve()
+    bound_digest = compute_bound_funding_data_digest_v0()
+    expected = expected_data_digest or bound_digest
+
+    if not staging_root.is_dir():
+        return BoundFundingPanelMaterializationResultV0(
+            status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            panel_data_digest="0" * 64,
+            bound_data_digest=bound_digest,
+            data_digest_match=False,
+            data_start_time="",
+            data_end_time="",
+            instrument_count=0,
+            row_count_total=0,
+            period_binding_id=str(period["period_binding_id"]),
+            dataset_id=PANEL_DATASET_ID,
+            dataset_extension=PANEL_DATASET_EXTENSION,
+            staging_root=str(staging_root),
+            panel_ref="",
+            funding_manifest_path="",
+            reason_codes=(REASON_MISSING_STAGING,),
+            idempotent_digest_stable=False,
+        )
+
+    try:
+        funding_series, panel_ref, manifest_path = load_funding_panel_from_staging(staging_root)
+    except FileNotFoundError as exc:
+        return BoundFundingPanelMaterializationResultV0(
+            status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            panel_data_digest="0" * 64,
+            bound_data_digest=bound_digest,
+            data_digest_match=False,
+            data_start_time="",
+            data_end_time="",
+            instrument_count=0,
+            row_count_total=0,
+            period_binding_id=str(period["period_binding_id"]),
+            dataset_id=PANEL_DATASET_ID,
+            dataset_extension=PANEL_DATASET_EXTENSION,
+            staging_root=str(staging_root),
+            panel_ref="",
+            funding_manifest_path="",
+            reason_codes=(str(exc), REASON_MISSING_FUNDING_MANIFEST),
+            idempotent_digest_stable=False,
+        )
+
+    for series in funding_series:
+        validation = validate_funding_panel_series_v1(series)
+        if not validation.valid:
+            return BoundFundingPanelMaterializationResultV0(
+                status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+                panel_data_digest="0" * 64,
+                bound_data_digest=bound_digest,
+                data_digest_match=False,
+                data_start_time="",
+                data_end_time="",
+                instrument_count=len(funding_series),
+                row_count_total=sum(len(s.bars) for s in funding_series),
+                period_binding_id=str(period["period_binding_id"]),
+                dataset_id=PANEL_DATASET_ID,
+                dataset_extension=PANEL_DATASET_EXTENSION,
+                staging_root=str(staging_root),
+                panel_ref=panel_ref,
+                funding_manifest_path=str(manifest_path),
+                reason_codes=(REASON_FUNDING_VALIDATION_FAILED, *validation.error_codes),
+                idempotent_digest_stable=False,
+            )
+
+    data_start, data_end = _panel_time_bounds_from_funding(funding_series)
+    foreign_rejected, foreign_reasons = reject_foreign_panel_dataset_v0(
+        data_first_timestamp=data_start,
+        data_last_timestamp=data_end,
+        period_binding=period,
+    )
+    if foreign_rejected:
+        return BoundFundingPanelMaterializationResultV0(
+            status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            panel_data_digest="0" * 64,
+            bound_data_digest=bound_digest,
+            data_digest_match=False,
+            data_start_time=data_start,
+            data_end_time=data_end,
+            instrument_count=len(funding_series),
+            row_count_total=sum(len(s.bars) for s in funding_series),
+            period_binding_id=str(period["period_binding_id"]),
+            dataset_id=PANEL_DATASET_ID,
+            dataset_extension=PANEL_DATASET_EXTENSION,
+            staging_root=str(staging_root),
+            panel_ref=panel_ref,
+            funding_manifest_path=str(manifest_path),
+            reason_codes=foreign_reasons,
+            idempotent_digest_stable=False,
+        )
+
+    ohlcv_proxy: list[InstrumentPanelSeriesV1] = []
+    try:
+        ohlcv_proxy, _ = load_panel_series_from_staging(staging_root)
+    except FileNotFoundError:
+        pass
+    if ohlcv_proxy:
+        covers, cover_reasons = verify_panel_covers_period_binding_v0(
+            ohlcv_proxy, period_binding=period
+        )
+        if not covers:
+            return BoundFundingPanelMaterializationResultV0(
+                status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+                panel_data_digest="0" * 64,
+                bound_data_digest=bound_digest,
+                data_digest_match=False,
+                data_start_time=data_start,
+                data_end_time=data_end,
+                instrument_count=len(funding_series),
+                row_count_total=sum(len(s.bars) for s in funding_series),
+                period_binding_id=str(period["period_binding_id"]),
+                dataset_id=PANEL_DATASET_ID,
+                dataset_extension=PANEL_DATASET_EXTENSION,
+                staging_root=str(staging_root),
+                panel_ref=panel_ref,
+                funding_manifest_path=str(manifest_path),
+                reason_codes=cover_reasons,
+                idempotent_digest_stable=False,
+            )
+
+    digest_match = bound_digest == expected
+    if not digest_match:
+        return BoundFundingPanelMaterializationResultV0(
+            status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            panel_data_digest=bound_digest,
+            bound_data_digest=bound_digest,
+            data_digest_match=False,
+            data_start_time=data_start,
+            data_end_time=data_end,
+            instrument_count=len(funding_series),
+            row_count_total=sum(len(s.bars) for s in funding_series),
+            period_binding_id=str(period["period_binding_id"]),
+            dataset_id=PANEL_DATASET_ID,
+            dataset_extension=PANEL_DATASET_EXTENSION,
+            staging_root=str(staging_root),
+            panel_ref=panel_ref,
+            funding_manifest_path=str(manifest_path),
+            reason_codes=(REASON_DATA_DIGEST_MISMATCH,),
+            idempotent_digest_stable=False,
+        )
+
+    digest_a = bound_digest
+    digest_b = compute_bound_funding_data_digest_v0()
+
+    return BoundFundingPanelMaterializationResultV0(
+        status=MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE,
+        panel_data_digest=digest_a,
+        bound_data_digest=bound_digest,
+        data_digest_match=True,
+        data_start_time=data_start,
+        data_end_time=data_end,
+        instrument_count=len(funding_series),
+        row_count_total=sum(len(s.bars) for s in funding_series),
+        period_binding_id=str(period["period_binding_id"]),
+        dataset_id=PANEL_DATASET_ID,
+        dataset_extension=PANEL_DATASET_EXTENSION,
+        staging_root=str(staging_root),
+        panel_ref=panel_ref,
+        funding_manifest_path=str(manifest_path),
+        reason_codes=(),
+        idempotent_digest_stable=digest_a == digest_b,
+    )
+
+
+def materialization_result_to_dict(
+    result: BoundFundingPanelMaterializationResultV0,
+) -> dict[str, Any]:
+    return {
+        "materialization_version": MATERIALIZATION_VERSION,
+        "status": result.status.value,
+        "panel_data_digest": result.panel_data_digest,
+        "bound_data_digest": result.bound_data_digest,
+        "data_digest_match": result.data_digest_match,
+        "data_start_time": result.data_start_time,
+        "data_end_time": result.data_end_time,
+        "instrument_count": result.instrument_count,
+        "row_count_total": result.row_count_total,
+        "period_binding_id": result.period_binding_id,
+        "dataset_id": result.dataset_id,
+        "dataset_extension": result.dataset_extension,
+        "staging_root": result.staging_root,
+        "panel_ref": result.panel_ref,
+        "funding_manifest_path": result.funding_manifest_path,
+        "reason_codes": list(result.reason_codes),
+        "idempotent_digest_stable": result.idempotent_digest_stable,
+    }

--- a/src/research/cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0.py
@@ -1,0 +1,240 @@
+"""Cross-sectional funding-rate delta momentum v0 offline evaluation infrastructure execution v0.
+
+Infrastructure-only runner surface. Does not execute economic evaluation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.research.cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_validator_v0 import (
+    ValidationVerdict,
+    validate_funding_rate_delta_momentum_ranking_semantics_binding_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_v0_bound_panel_dataset_materialization_v0 import (
+    MaterializationTerminalStatus,
+    materialization_result_to_dict,
+    materialize_bound_funding_panel_dataset_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_scope_ratification_v0 import (
+    ValidationVerdictEnum,
+    validate_funding_delta_momentum_offline_evaluation_scope_ratification_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0 import (
+    AUTHORITY_EFFECT,
+    CONFIG_REL_PATH,
+    ORDER_EFFECT,
+    RUNTIME_EFFECT,
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+    materialize_versioned_research_binding_v0,
+)
+
+PACKAGE_MARKER = (
+    "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0=true"
+)
+SCHEMA_VERSION = (
+    "cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution.v0"
+)
+EXECUTION_ID = (
+    "cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0"
+)
+EXECUTION_VERSION = "v0"
+CONFIG_REL_PATH_OPS = (
+    "config/ops/cross_sectional_funding_rate_delta_momentum_v0_economic_evaluation_v1.json"
+)
+INFRASTRUCTURE_GO_TOKEN = (
+    "GO_BOUNDED_PRE_EVALUATION_PANEL_EXTENSION_AND_IMPLEMENTATION_SCOPE_RATIFICATION_V0"
+)
+RUNNER_OWNER = "scripts.ops.run_cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0"
+
+
+class InfrastructureTerminalStatus(str, Enum):
+    EXECUTION_INFRASTRUCTURE_COMPLETE = "EXECUTION_INFRASTRUCTURE_COMPLETE"
+    FAIL_CLOSED_BOUND_DATA_UNAVAILABLE = "FAIL_CLOSED_BOUND_DATA_UNAVAILABLE"
+    FAIL_CLOSED = "FAIL_CLOSED"
+
+
+@dataclass(frozen=True)
+class StartStateVerificationResultV0:
+    valid: bool
+    fail_reasons: tuple[str, ...]
+    origin_main_sha: str
+    binding_digest: str
+    ratification_digest: str
+
+
+@dataclass(frozen=True)
+class InfrastructureReadinessResultV0:
+    status: InfrastructureTerminalStatus
+    execution_infrastructure_complete: bool
+    panel_wiring_complete: bool
+    bound_dataset_materialized: bool
+    dataset_period_match: bool
+    panel_data_digest: str
+    reason_codes: tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+    economic_evaluation_executed: bool
+
+
+@dataclass(frozen=True)
+class EvaluationEntrypointDryRunResultV0:
+    status: str
+    precheck_passed: bool
+    economic_evaluation_executed: bool
+    stage_wiring_complete: bool
+    fail_reasons: tuple[str, ...]
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def load_versioned_research_binding_v0(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / CONFIG_REL_PATH
+    if not path.is_file():
+        return materialize_versioned_research_binding_v0()
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def verify_execution_start_state_v0(
+    *,
+    repo_root: Path,
+    ratification: Mapping[str, Any],
+    versioned_binding: Mapping[str, Any] | None = None,
+    origin_main_sha: str = "",
+) -> StartStateVerificationResultV0:
+    reasons: list[str] = []
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    validation = validate_funding_rate_delta_momentum_ranking_semantics_binding_v0(
+        envelope["binding"]
+    )
+    if not validation.valid or validation.verdict != ValidationVerdict.ACCEPTED_COMPLETE:
+        reasons.extend(validation.fail_reasons or ("BINDING_INCOMPLETE",))
+
+    ratification_validation = (
+        validate_funding_delta_momentum_offline_evaluation_scope_ratification_v0(
+            ratification, expected_binding=envelope
+        )
+    )
+    if ratification_validation.verdict != ValidationVerdictEnum.ACCEPTED:
+        reasons.extend(ratification_validation.fail_reasons)
+
+    config_path = repo_root / CONFIG_REL_PATH_OPS
+    if not config_path.is_file():
+        reasons.append("MISSING_OPS_EVALUATION_CONFIG")
+
+    return StartStateVerificationResultV0(
+        valid=not reasons,
+        fail_reasons=tuple(reasons),
+        origin_main_sha=origin_main_sha,
+        binding_digest=str(envelope.get("binding_digest", "")),
+        ratification_digest=str(ratification.get("ratification_digest", "")),
+    )
+
+
+def run_full_evaluation_entrypoint_dry_run_v0(
+    *,
+    repo_root: Path,
+    ratification: Mapping[str, Any],
+    staging_root: Path,
+    versioned_binding: Mapping[str, Any],
+    go_token: str,
+) -> EvaluationEntrypointDryRunResultV0:
+    if go_token != INFRASTRUCTURE_GO_TOKEN:
+        return EvaluationEntrypointDryRunResultV0(
+            status="FAIL_CLOSED_PRECHECK",
+            precheck_passed=False,
+            economic_evaluation_executed=False,
+            stage_wiring_complete=False,
+            fail_reasons=("GO_TOKEN_INVALID",),
+        )
+    start = verify_execution_start_state_v0(
+        repo_root=repo_root,
+        ratification=ratification,
+        versioned_binding=versioned_binding,
+    )
+    if not start.valid:
+        return EvaluationEntrypointDryRunResultV0(
+            status="FAIL_CLOSED_PRECHECK",
+            precheck_passed=False,
+            economic_evaluation_executed=False,
+            stage_wiring_complete=False,
+            fail_reasons=start.fail_reasons,
+        )
+    materialization = materialize_bound_funding_panel_dataset_v0(
+        staging_root,
+        period_binding=versioned_binding["period_binding"],
+        expected_data_digest=versioned_binding["data_digest"],
+    )
+    if materialization.status is not MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE:
+        return EvaluationEntrypointDryRunResultV0(
+            status="FAIL_CLOSED_PRECHECK",
+            precheck_passed=False,
+            economic_evaluation_executed=False,
+            stage_wiring_complete=False,
+            fail_reasons=materialization.reason_codes,
+        )
+    return EvaluationEntrypointDryRunResultV0(
+        status="ENTRYPOINT_READY_DRY_RUN_STOPPED",
+        precheck_passed=True,
+        economic_evaluation_executed=False,
+        stage_wiring_complete=True,
+        fail_reasons=(),
+    )
+
+
+def materialize_infrastructure_summary_v0(
+    *,
+    ratification: Mapping[str, Any],
+    readiness: InfrastructureReadinessResultV0,
+    origin_main_sha: str,
+    execution_bundle_dir: str,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "execution_id": EXECUTION_ID,
+        "execution_version": EXECUTION_VERSION,
+        "strategy_id": STRATEGY_ID,
+        "strategy_version": STRATEGY_VERSION,
+        "ratification_digest": ratification.get("ratification_digest"),
+        "origin_main_sha": origin_main_sha,
+        "execution_bundle_dir": execution_bundle_dir,
+        "execution_infrastructure_complete": readiness.execution_infrastructure_complete,
+        "panel_wiring_complete": readiness.panel_wiring_complete,
+        "bound_dataset_materialized": readiness.bound_dataset_materialized,
+        "dataset_period_match": readiness.dataset_period_match,
+        "panel_data_digest": readiness.panel_data_digest,
+        "infrastructure_status": readiness.status.value,
+        "reason_codes": list(readiness.reason_codes),
+        "economic_evaluation_executed": False,
+        "economic_classification": "NONE",
+        "ready_for_separately_authorized_offline_economic_evaluation": (
+            readiness.status is InfrastructureTerminalStatus.EXECUTION_INFRASTRUCTURE_COMPLETE
+            and readiness.bound_dataset_materialized
+        ),
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "config_rel_path": CONFIG_REL_PATH_OPS,
+        "candidate_binding_ref": CONFIG_REL_PATH,
+    }
+    body["manifest_digest"] = _stable_digest(body)
+    return body
+
+
+def entrypoint_result_to_dict(result: EvaluationEntrypointDryRunResultV0) -> dict[str, Any]:
+    return {
+        "status": result.status,
+        "precheck_passed": result.precheck_passed,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "stage_wiring_complete": result.stage_wiring_complete,
+        "fail_reasons": list(result.fail_reasons),
+    }

--- a/src/research/cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_scope_ratification_v0.py
+++ b/src/research/cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_scope_ratification_v0.py
@@ -1,0 +1,123 @@
+"""Cross-sectional funding-rate delta momentum v0 offline evaluation scope ratification v0."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.backtest.economic_validity_policy_v1 import ECONOMIC_VALIDITY_POLICY_VERSION
+from src.research.cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_validator_v0 import (
+    ValidationVerdict,
+    validate_funding_rate_delta_momentum_ranking_semantics_binding_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0 import (
+    AUTHORITY_EFFECT,
+    CONFIG_REL_PATH,
+    ORDER_EFFECT,
+    RUNTIME_EFFECT,
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+    compute_implementation_digest_v0,
+    materialize_versioned_research_binding_v0,
+)
+
+PACKAGE_MARKER = (
+    "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_V0_OFFLINE_ECONOMIC_EVALUATION_"
+    "SCOPE_RATIFICATION_V0=true"
+)
+SCHEMA_VERSION = "cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_scope_ratification.v0"
+RATIFICATION_ID = (
+    "cross_sectional_funding_rate_delta_momentum_v0_offline_evaluation_infrastructure_scope_v0"
+)
+RATIFICATION_VERSION = "v0"
+
+OFFLINE_EVALUATION_INFRASTRUCTURE_SCOPE_RATIFIED = True
+ECONOMIC_EVALUATION_AUTHORIZED = False
+ECONOMIC_EVALUATION_EXECUTED = False
+
+
+class ValidationVerdictEnum(str, Enum):
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+
+
+@dataclass(frozen=True)
+class RatificationValidationResultV0:
+    verdict: ValidationVerdictEnum
+    fail_reasons: tuple[str, ...]
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def materialize_funding_delta_momentum_offline_evaluation_scope_ratification_v0(
+    *,
+    repo_root: Path,
+    versioned_binding: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    envelope = dict(versioned_binding or materialize_versioned_research_binding_v0())
+    binding = envelope["binding"]
+    validation = validate_funding_rate_delta_momentum_ranking_semantics_binding_v0(binding)
+    if not validation.valid or validation.verdict != ValidationVerdict.ACCEPTED_COMPLETE:
+        raise ValueError("versioned_binding_not_accepted_complete")
+
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "ratification_id": RATIFICATION_ID,
+        "ratification_version": RATIFICATION_VERSION,
+        "strategy_id": STRATEGY_ID,
+        "strategy_version": STRATEGY_VERSION,
+        "candidate_id": f"{STRATEGY_ID}/{STRATEGY_VERSION}",
+        "candidate_binding_ref": CONFIG_REL_PATH,
+        "binding_digest": envelope["binding_digest"],
+        "config_digest": envelope["config_digest"],
+        "data_digest": envelope["data_digest"],
+        "implementation_digest": compute_implementation_digest_v0(),
+        "parameter_binding": envelope["parameter_binding"],
+        "panel_dataset_binding": envelope["panel_dataset_binding"],
+        "period_binding": envelope["period_binding"],
+        "instrument_binding": envelope["instrument_binding"],
+        "cost_execution_binding": envelope["cost_execution_binding"],
+        "economic_policy_binding": envelope["economic_policy_binding"],
+        "offline_evaluation_infrastructure_scope_ratified": True,
+        "economic_evaluation_authorized": False,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "futures_only": True,
+        "bitcoin_direction_allowed": False,
+    }
+    body["ratification_digest"] = _stable_digest(body)
+    return body
+
+
+def validate_funding_delta_momentum_offline_evaluation_scope_ratification_v0(
+    ratification: Mapping[str, Any],
+    *,
+    expected_binding: Mapping[str, Any] | None = None,
+) -> RatificationValidationResultV0:
+    reasons: list[str] = []
+    envelope = dict(expected_binding or {})
+    if ratification.get("economic_evaluation_authorized") is not False:
+        reasons.append("ECONOMIC_EVALUATION_AUTHORIZED_MUST_BE_FALSE")
+    if ratification.get("economic_evaluation_executed") is not False:
+        reasons.append("ECONOMIC_EVALUATION_EXECUTED_MUST_BE_FALSE")
+    if envelope and ratification.get("binding_digest") != envelope.get("binding_digest"):
+        reasons.append("BINDING_DIGEST_MISMATCH")
+    if ratification.get("economic_policy_binding", {}).get(
+        "economic_validity_policy_version"
+    ) not in (None, ECONOMIC_VALIDITY_POLICY_VERSION):
+        reasons.append("ECONOMIC_POLICY_VERSION_MISMATCH")
+    if reasons:
+        return RatificationValidationResultV0(
+            verdict=ValidationVerdictEnum.REJECTED,
+            fail_reasons=tuple(reasons),
+        )
+    return RatificationValidationResultV0(verdict=ValidationVerdictEnum.ACCEPTED, fail_reasons=())

--- a/src/research/cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0.py
+++ b/src/research/cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0.py
@@ -1,0 +1,460 @@
+"""Cross-sectional funding-rate delta momentum v0 versioned research binding materializer."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.backtest.economic_validity_policy_v1 import ECONOMIC_VALIDITY_POLICY_VERSION
+from src.research.cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_v0 import (
+    ATTESTED_OPERATOR_DECISION_DIGEST,
+    HYPOTHESIS_ID,
+    ORCHESTRATOR_OWNER,
+    SCHEMA_VERSION,
+    VERSIONED_BINDING_CONFIG_REL_PATH,
+    apply_ratified_operator_bindings_v0,
+    compute_config_digest_v0,
+    materialize_funding_rate_delta_momentum_ranking_semantics_binding_v0,
+    materialize_versioned_funding_rate_delta_momentum_ranking_semantics_binding_v0,
+    serialize_versioned_binding_artifact_json_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_validator_v0 import (
+    ValidationVerdict,
+    validate_funding_rate_delta_momentum_ranking_semantics_binding_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_scoring_v0 import (
+    FUNDING_DELTA_LOOKBACK_K,
+    FUNDING_SIGNAL_LAG,
+    SCORE_FORMULA_EXPRESSION,
+    SCORE_FORMULA_VERSION,
+)
+from src.research.instrument_id_canonicalization_v1 import (
+    INSTRUMENT_ID_CANONICALIZATION_VERSION,
+)
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_V0_VERSIONED_RESEARCH_BINDING_V0=true"
+BINDING_ARTIFACT_VERSION = "v0"
+BINDING_SCHEMA_VERSION = (
+    "cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding.v0"
+)
+CONFIG_REL_PATH = (
+    "config/research/"
+    "cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0.json"
+)
+
+STRATEGY_ID = "cross_sectional_funding_rate_delta_momentum"
+STRATEGY_VERSION = "v0"
+RESEARCH_HYPOTHESIS_ID = HYPOTHESIS_ID
+
+PANEL_CALENDAR_START_UTC = "2024-05-01T00:00:00Z"
+PANEL_CALENDAR_END_UTC = "2024-09-01T00:00:00Z"
+PANEL_WARMUP_BARS = 21
+PANEL_DATASET_ID = "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1"
+PANEL_DATASET_EXTENSION = "extended_chronological_with_funding_v1"
+PANEL_FUNDING_DATASET_MANIFEST_REF = (
+    f"pit_okx_pt1h_panel_funding_dataset_v1:{PANEL_DATASET_ID}:{PANEL_DATASET_EXTENSION}"
+)
+PIT_UNIVERSE_MANIFEST_REF = "pit_futures_universe_manifest_v1:pit_okx_linear_usdt_non_bitcoin_perpetual_universe_manifest_v1"
+UNIVERSE_LIFECYCLE_REGISTRY_REF = "pit_futures_lifecycle_registry_v1:okx_production_lifecycle_v1"
+ADMISSIBILITY_MANIFEST_REF = (
+    f"pit_cross_sectional_research_dataset_envelope.v0:{PANEL_DATASET_ID}:{PANEL_DATASET_EXTENSION}"
+)
+PERIOD_BINDING_ID = "pit_cross_sectional_research_chronological_holdout_v1"
+PERIOD_BINDING_REF = f"{PERIOD_BINDING_ID}:v1"
+
+FEE_MODEL_VERSION = "backtest_fee_taker_symmetric_v0"
+FEE_BPS_PER_SIDE = 10.0
+SLIPPAGE_MODEL_VERSION = "backtest_slippage_symmetric_v0"
+SLIPPAGE_BPS_PER_SIDE = 5.0
+FUNDING_MODEL_VERSION = "backtest_funding_perpetual_interval_v1"
+SPREAD_MODEL_VERSION = "research_conservative_bps_v1"
+CONSERVATIVE_HALF_SPREAD_BPS = 5.0
+EXECUTION_MODEL_VERSION = "backtest_execution_v0"
+EFFECTIVE_ENTRY_COST_BPS = FEE_BPS_PER_SIDE + SLIPPAGE_BPS_PER_SIDE + CONSERVATIVE_HALF_SPREAD_BPS
+EFFECTIVE_EXIT_COST_BPS = EFFECTIVE_ENTRY_COST_BPS
+ROUNDTRIP_COST_BPS = EFFECTIVE_ENTRY_COST_BPS + EFFECTIVE_EXIT_COST_BPS
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+ORDER_EFFECT = "NONE"
+
+
+class BindingMaterializationVerdict(str, Enum):
+    COMPLETE = "COMPLETE"
+    INCOMPLETE = "INCOMPLETE"
+    REJECTED = "REJECTED"
+
+
+class BindingRatificationStatus(str, Enum):
+    BINDINGS_RATIFIED = "BINDINGS_RATIFIED"
+    FAIL_CLOSED_NOT_RATIFIED = "FAIL_CLOSED_NOT_RATIFIED"
+
+
+@dataclass(frozen=True)
+class VersionedResearchBindingResultV0:
+    verdict: BindingMaterializationVerdict
+    ratification_status: BindingRatificationStatus
+    binding: dict[str, Any]
+    ranking_semantics_binding: dict[str, Any]
+    validation_verdict: ValidationVerdict
+    fail_reasons: tuple[str, ...]
+
+
+def _field_bound(*, value: Any = None, ref: str = "") -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": "BOUND"}
+    if value is not None:
+        payload["value"] = value
+    if ref:
+        payload["ref"] = ref
+    return payload
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _parse_utc(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+
+def _format_utc(value: datetime) -> str:
+    return value.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def compute_implementation_digest_v0() -> str:
+    return _stable_digest(
+        {
+            "module": "cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0",
+            "orchestrator": ORCHESTRATOR_OWNER,
+            "score_formula_version": SCORE_FORMULA_VERSION,
+            "schema_version": BINDING_SCHEMA_VERSION,
+            "narrow_adapter": "pit_okx_pt1h_panel_funding_field_materialization.v0",
+        }
+    )
+
+
+def build_parameter_binding_v0() -> dict[str, Any]:
+    from src.research.cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_v0 import (
+        RATIFIED_OPERATOR_BINDING_VALUES,
+    )
+
+    return {
+        "binding_version": "v0",
+        "operator_decision_digest": ATTESTED_OPERATOR_DECISION_DIGEST,
+        "parameters": dict(RATIFIED_OPERATOR_BINDING_VALUES),
+        "score_formula_version": SCORE_FORMULA_VERSION,
+        "score_formula_expression": SCORE_FORMULA_EXPRESSION,
+        "funding_delta_lookback_k": FUNDING_DELTA_LOOKBACK_K,
+        "funding_signal_lag": FUNDING_SIGNAL_LAG,
+        "funding_observation_field": "funding_rate",
+        "parameter_search_forbidden": True,
+    }
+
+
+def build_pit_universe_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v0",
+        "venue": "OKX",
+        "instrument_type": "LINEAR_PERPETUAL",
+        "settlement_asset": "USDT",
+        "bitcoin_excluded": True,
+        "spot_excluded": True,
+        "synthetic_spot_excluded": True,
+        "futures_only": True,
+        "universe_policy_id": "pit_okx_linear_usdt_non_bitcoin_perpetual_cross_sectional_universe",
+        "universe_policy_version": "v1",
+        "pit_universe_manifest_ref": PIT_UNIVERSE_MANIFEST_REF,
+        "universe_lifecycle_registry_ref": UNIVERSE_LIFECYCLE_REGISTRY_REF,
+        "minimum_eligible_member_count": 5,
+        "instrument_identity_normalization": INSTRUMENT_ID_CANONICALIZATION_VERSION,
+        "survivorship_bias_forbidden": True,
+    }
+
+
+def build_panel_dataset_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v0",
+        "dataset_id": PANEL_DATASET_ID,
+        "dataset_extension": PANEL_DATASET_EXTENSION,
+        "dataset_version": "v1",
+        "bar_interval": "PT1H",
+        "panel_schema": "pit_okx_pt1h_panel_funding_dataset_manifest_v1",
+        "instrument_key": "instrument_id",
+        "timestamp_key": "timestamp_utc",
+        "timezone": "UTC",
+        "ohlcv_fields": ("open", "high", "low", "close", "volume"),
+        "funding_fields": ("funding_rate",),
+        "price_usage": "close_for_execution_reference_only",
+        "funding_usage": "funding_rate_for_score_computation",
+        "narrow_adapter": "pit_okx_pt1h_panel_funding_field_materialization.v0",
+        "missing_bars_policy": "exclude_non_selected_for_epoch",
+        "duplicate_bars_policy": "fail_closed",
+        "out_of_order_bars_policy": "fail_closed",
+        "warmup_bars": FUNDING_DELTA_LOOKBACK_K + FUNDING_SIGNAL_LAG,
+        "network_access_forbidden": True,
+        "credential_access_forbidden": True,
+        "panel_funding_dataset_manifest_ref": PANEL_FUNDING_DATASET_MANIFEST_REF,
+        "panel_calendar_start_utc": PANEL_CALENDAR_START_UTC,
+        "panel_calendar_end_utc": PANEL_CALENDAR_END_UTC,
+    }
+
+
+def build_period_binding_v0() -> dict[str, Any]:
+    start = _parse_utc(PANEL_CALENDAR_START_UTC)
+    end = _parse_utc(PANEL_CALENDAR_END_UTC)
+    total_bars = int((end - start).total_seconds() // 3600)
+    warmup_end = start + timedelta(hours=PANEL_WARMUP_BARS - 1)
+    post_warmup_bars = total_bars - PANEL_WARMUP_BARS
+    training_bars = int(post_warmup_bars * 0.40)
+    validation_bars = int(post_warmup_bars * 0.30)
+    training_start = warmup_end + timedelta(hours=1)
+    training_end = training_start + timedelta(hours=training_bars - 1)
+    validation_start = training_end + timedelta(hours=3)
+    validation_end = validation_start + timedelta(hours=validation_bars - 1)
+    oos_start = validation_end + timedelta(hours=3)
+    oos_end = end - timedelta(hours=1)
+    return {
+        "binding_version": "v1",
+        "period_binding_id": PERIOD_BINDING_ID,
+        "split_policy_id": PERIOD_BINDING_ID,
+        "split_timezone": "UTC",
+        "boundary_semantics": "utc_bar_close_inclusive_end",
+        "warmup_start": _format_utc(start),
+        "warmup_end": _format_utc(warmup_end),
+        "training_start": _format_utc(training_start),
+        "training_end": _format_utc(training_end),
+        "validation_start": _format_utc(validation_start),
+        "validation_end": _format_utc(validation_end),
+        "out_of_sample_start": _format_utc(oos_start),
+        "out_of_sample_end": _format_utc(oos_end),
+        "embargo_duration": "PT2H",
+        "purge_duration": "PT2H",
+        "periods_frozen_before_evaluation": True,
+        "no_overlap_enforced": True,
+        "holdout_isolation_enforced": True,
+    }
+
+
+def build_instrument_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v0",
+        "selection_mode": "funding_delta_extremes_single_leg_rotation_v0",
+        "direction_policy": "symmetric_funding_delta_extremum_mean_reversion_single_leg_rotation_v0",
+        "bitcoin_excluded": True,
+        "spot_excluded": True,
+        "synthetic_spot_excluded": True,
+        "pit_universe_manifest_ref": PIT_UNIVERSE_MANIFEST_REF,
+        "instrument_id_canonicalization_version": INSTRUMENT_ID_CANONICALIZATION_VERSION,
+    }
+
+
+def build_cost_execution_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v0",
+        "fee_model_binding": {
+            "fee_model_version": FEE_MODEL_VERSION,
+            "fee_bps_per_side": FEE_BPS_PER_SIDE,
+        },
+        "slippage_model_binding": {
+            "slippage_model_version": SLIPPAGE_MODEL_VERSION,
+            "slippage_bps_per_side": SLIPPAGE_BPS_PER_SIDE,
+        },
+        "funding_model_binding": {
+            "funding_model_version": FUNDING_MODEL_VERSION,
+            "bind": True,
+        },
+        "spread_model_binding": {
+            "spread_model_version": SPREAD_MODEL_VERSION,
+            "conservative_half_spread_bps": CONSERVATIVE_HALF_SPREAD_BPS,
+        },
+        "execution_model_binding": {
+            "execution_model_version": EXECUTION_MODEL_VERSION,
+            "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+            "effective_entry_cost_bps": EFFECTIVE_ENTRY_COST_BPS,
+            "effective_exit_cost_bps": EFFECTIVE_EXIT_COST_BPS,
+            "roundtrip_cost_bps": ROUNDTRIP_COST_BPS,
+        },
+        "implicit_zero_cost_forbidden": True,
+    }
+
+
+def build_economic_policy_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v1",
+        "economic_validity_policy_version": ECONOMIC_VALIDITY_POLICY_VERSION,
+        "policy_lowering_forbidden": True,
+        "promising_is_not_pass": True,
+        "minimum_trade_count": 50,
+    }
+
+
+def apply_complete_external_bindings_v0(binding: dict[str, Any]) -> dict[str, Any]:
+    result = deepcopy(binding)
+    external = result["external_bindings"]
+    external["pit_universe_manifest_ref"] = _field_bound(ref=PIT_UNIVERSE_MANIFEST_REF)
+    external["instrument_id_canonicalization_version"] = _field_bound(
+        value=INSTRUMENT_ID_CANONICALIZATION_VERSION
+    )
+    external["panel_funding_dataset_manifest_ref"] = _field_bound(
+        ref=PANEL_FUNDING_DATASET_MANIFEST_REF
+    )
+    external["admissibility_manifest_ref"] = _field_bound(ref=ADMISSIBILITY_MANIFEST_REF)
+    external["evaluation_period_binding"] = _field_bound(ref=PERIOD_BINDING_REF)
+    external["fee_model_version"] = _field_bound(value=FEE_MODEL_VERSION)
+    external["slippage_model_version"] = _field_bound(value=SLIPPAGE_MODEL_VERSION)
+    external["funding_model_version"] = _field_bound(value=FUNDING_MODEL_VERSION)
+    external["spread_model_version"] = _field_bound(value=SPREAD_MODEL_VERSION)
+    external["execution_model_version"] = _field_bound(value=EXECUTION_MODEL_VERSION)
+
+    impl_digest = compute_implementation_digest_v0()
+    config_bytes = json.dumps(
+        {
+            "strategy_id": STRATEGY_ID,
+            "strategy_version": STRATEGY_VERSION,
+            "parameter_binding": build_parameter_binding_v0(),
+            "pit_universe_binding": build_pit_universe_binding_v0(),
+            "panel_dataset_binding": build_panel_dataset_binding_v0(),
+            "period_binding": build_period_binding_v0(),
+            "cost_execution_binding": build_cost_execution_binding_v0(),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    config_digest = compute_config_digest_v0(config_bytes)
+    data_digest = _stable_digest(
+        {
+            "dataset_id": PANEL_DATASET_ID,
+            "dataset_extension": PANEL_DATASET_EXTENSION,
+            "panel_funding_manifest_ref": PANEL_FUNDING_DATASET_MANIFEST_REF,
+            "pit_universe_manifest_ref": PIT_UNIVERSE_MANIFEST_REF,
+            "funding_field": "funding_rate",
+            "panel_calendar_start_utc": PANEL_CALENDAR_START_UTC,
+            "panel_calendar_end_utc": PANEL_CALENDAR_END_UTC,
+        }
+    )
+    binding_digest = _stable_digest(
+        {
+            "config_digest": config_digest,
+            "data_digest": data_digest,
+            "implementation_digest": impl_digest,
+            "operator_decision_digest": ATTESTED_OPERATOR_DECISION_DIGEST,
+        }
+    )
+
+    digest = result["digest_bindings"]
+    digest["implementation_digest"] = _field_bound(value=impl_digest)
+    digest["config_digest"] = _field_bound(value=config_digest)
+    digest["data_digest"] = _field_bound(value=data_digest)
+
+    status = result["binding_status"]
+    status["universe_binding_status"] = "BOUND"
+    status["dataset_binding_status"] = "BOUND"
+    status["period_binding_status"] = "BOUND"
+    status["cost_model_binding_status"] = "BOUND"
+    status["digest_binding_status"] = "BOUND"
+    status["overall_binding_status"] = "COMPLETE"
+
+    result["_binding_digest"] = binding_digest
+    return result
+
+
+def materialize_versioned_research_binding_v0() -> dict[str, Any]:
+    base = materialize_funding_rate_delta_momentum_ranking_semantics_binding_v0()
+    with_numeric = apply_ratified_operator_bindings_v0(base)
+    complete_binding = apply_complete_external_bindings_v0(with_numeric)
+    binding_digest = complete_binding.pop("_binding_digest", "")
+    validation = validate_funding_rate_delta_momentum_ranking_semantics_binding_v0(complete_binding)
+    return {
+        "artifact_kind": "cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding",
+        "artifact_version": BINDING_ARTIFACT_VERSION,
+        "schema_version": BINDING_SCHEMA_VERSION,
+        "strategy_id": STRATEGY_ID,
+        "strategy_version": STRATEGY_VERSION,
+        "research_hypothesis_id": RESEARCH_HYPOTHESIS_ID,
+        "hypothesis_frozen": True,
+        "non_authorizing": True,
+        "research_binding_only": True,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "system_constraints": {
+            "futures_only": True,
+            "bitcoin_direction_allowed": False,
+            "spot_allowed": False,
+            "synthetic_spot_allowed": False,
+        },
+        "ranking_semantics_binding_ref": VERSIONED_BINDING_CONFIG_REL_PATH,
+        "ranking_semantics_schema_version": SCHEMA_VERSION,
+        "orchestrator_owner": ORCHESTRATOR_OWNER,
+        "parameter_binding": build_parameter_binding_v0(),
+        "pit_universe_binding": build_pit_universe_binding_v0(),
+        "panel_dataset_binding": build_panel_dataset_binding_v0(),
+        "period_binding": build_period_binding_v0(),
+        "instrument_binding": build_instrument_binding_v0(),
+        "cost_execution_binding": build_cost_execution_binding_v0(),
+        "economic_policy_binding": build_economic_policy_binding_v0(),
+        "implementation_digest": compute_implementation_digest_v0(),
+        "config_digest": complete_binding["digest_bindings"]["config_digest"]["value"],
+        "data_digest": complete_binding["digest_bindings"]["data_digest"]["value"],
+        "binding_digest": binding_digest,
+        "binding": complete_binding,
+        "validation_verdict": validation.verdict.value,
+    }
+
+
+def materialize_and_validate_versioned_research_binding_v0() -> VersionedResearchBindingResultV0:
+    envelope = materialize_versioned_research_binding_v0()
+    binding = envelope["binding"]
+    validation = validate_funding_rate_delta_momentum_ranking_semantics_binding_v0(binding)
+    if not validation.valid:
+        return VersionedResearchBindingResultV0(
+            verdict=BindingMaterializationVerdict.REJECTED,
+            ratification_status=BindingRatificationStatus.FAIL_CLOSED_NOT_RATIFIED,
+            binding=envelope,
+            ranking_semantics_binding=binding,
+            validation_verdict=validation.verdict,
+            fail_reasons=validation.fail_reasons,
+        )
+    if validation.verdict == ValidationVerdict.ACCEPTED_COMPLETE:
+        verdict = BindingMaterializationVerdict.COMPLETE
+        ratification = BindingRatificationStatus.BINDINGS_RATIFIED
+    else:
+        verdict = BindingMaterializationVerdict.INCOMPLETE
+        ratification = BindingRatificationStatus.FAIL_CLOSED_NOT_RATIFIED
+    return VersionedResearchBindingResultV0(
+        verdict=verdict,
+        ratification_status=ratification,
+        binding=envelope,
+        ranking_semantics_binding=binding,
+        validation_verdict=validation.verdict,
+        fail_reasons=validation.fail_reasons,
+    )
+
+
+def serialize_versioned_research_binding_json_v0(envelope: Mapping[str, Any]) -> str:
+    return json.dumps(dict(envelope), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def write_versioned_research_binding_artifacts_v0(repo_root: Path) -> tuple[Path, Path]:
+    envelope = materialize_versioned_research_binding_v0()
+    ranking_envelope = (
+        materialize_versioned_funding_rate_delta_momentum_ranking_semantics_binding_v0()
+    )
+    config_path = repo_root / CONFIG_REL_PATH
+    ranking_path = repo_root / VERSIONED_BINDING_CONFIG_REL_PATH
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    ranking_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(serialize_versioned_research_binding_json_v0(envelope), encoding="utf-8")
+    ranking_path.write_text(
+        serialize_versioned_binding_artifact_json_v0(ranking_envelope),
+        encoding="utf-8",
+    )
+    return config_path, ranking_path

--- a/tests/research/fixtures/cross_sectional_funding_rate_delta_momentum_v0/fixture_builder.py
+++ b/tests/research/fixtures/cross_sectional_funding_rate_delta_momentum_v0/fixture_builder.py
@@ -1,0 +1,67 @@
+"""Synthetic fixtures for cross-sectional funding-rate delta momentum v0 binding tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1, PanelBarV1
+
+
+def _bars(
+    instrument_id: str,
+    *,
+    base_close: float,
+    count: int = 30,
+) -> tuple[PanelBarV1, ...]:
+    bars: list[PanelBarV1] = []
+    start = datetime(2024, 5, 30, 20, 0, tzinfo=timezone.utc)
+    for idx in range(count):
+        ts = (start + timedelta(hours=idx)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        close = base_close + idx * 0.01
+        bars.append(
+            PanelBarV1(
+                instrument_id=instrument_id,
+                timestamp_utc=ts,
+                open=str(close - 0.01),
+                high=str(close + 0.02),
+                low=str(close - 0.02),
+                close=str(close),
+                volume="1000",
+                is_final=True,
+            )
+        )
+    return tuple(bars)
+
+
+def build_synthetic_ohlcv_panel_v0() -> tuple[InstrumentPanelSeriesV1, ...]:
+    instruments = (
+        ("okx:linear_perpetual:ETH:USDT:USDT:perp", 3000.0),
+        ("okx:linear_perpetual:SOL:USDT:USDT:perp", 150.0),
+        ("okx:linear_perpetual:AVAX:USDT:USDT:perp", 35.0),
+        ("okx:linear_perpetual:LINK:USDT:USDT:perp", 15.0),
+        ("okx:linear_perpetual:ADA:USDT:USDT:perp", 0.45),
+    )
+    series: list[InstrumentPanelSeriesV1] = []
+    for instrument_id, base_close in instruments:
+        bars = _bars(instrument_id, base_close=base_close)
+        series.append(
+            InstrumentPanelSeriesV1(
+                instrument_id=instrument_id,
+                native_instrument_id=instrument_id,
+                bars=bars,
+                series_digest="fixture",
+            )
+        )
+    return tuple(series)
+
+
+def build_funding_rates_for_panel_v0(
+    panel: tuple[InstrumentPanelSeriesV1, ...],
+) -> dict[str, dict[str, str]]:
+    result: dict[str, dict[str, str]] = {}
+    for idx, series in enumerate(panel):
+        rates: dict[str, str] = {}
+        for bar_idx, bar in enumerate(series.bars):
+            rates[bar.timestamp_utc] = str(-0.0001 + idx * 0.00005 + bar_idx * 0.000001)
+        result[series.instrument_id] = rates
+    return result

--- a/tests/research/test_cross_sectional_bounded_panel_fetch_v0.py
+++ b/tests/research/test_cross_sectional_bounded_panel_fetch_v0.py
@@ -1,0 +1,460 @@
+"""Contract tests for bounded cross-sectional panel OHLCV/funding fetch v0."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.research.cross_sectional_bounded_panel_fetch_v0 import (
+    PHASE_A_BOUND_OHLCV_PANEL,
+    PHASE_B_BOUND_FUNDING_HISTORY,
+    BudgetGuardReason,
+    FetchBudgetGuardV0,
+    PaginationPageRecordV0,
+    attach_funding_to_ohlcv_bars_v0,
+    backward_asof_funding_lookup_v0,
+    compute_bounded_window_v0,
+    derive_production_budget_v0,
+    first_ohlcv_request_anchored_at_end_exclusive,
+    out_of_window_retained_raw_count,
+    paginate_bounded_funding_v0,
+    paginate_bounded_ohlcv_v0,
+    select_eligible_instruments_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_scoring_v0 import (
+    FUNDING_DELTA_LOOKBACK_K,
+    FUNDING_SIGNAL_LAG,
+    funding_cashflow_provenance_marker_v0,
+    score_input_provenance_marker_v0,
+)
+from src.research.okx_production_instrument_lifecycle_source_v1 import (
+    evaluate_okx_instrument_eligibility_v1,
+)
+
+
+def _ms(utc: str) -> int:
+    from datetime import datetime, timezone
+
+    return int(
+        datetime.strptime(utc, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp() * 1000
+    )
+
+
+def _ohlcv_row(ts_utc: str, *, confirm: str = "1") -> list[str]:
+    return [str(_ms(ts_utc)), "1", "2", "0.5", "1.5", "100", "0", "0", confirm]
+
+
+def _funding_row(ts_utc: str, rate: str = "0.0001") -> dict[str, str]:
+    return {"fundingTime": str(_ms(ts_utc)), "fundingRate": rate, "instId": "ETH-USDT-SWAP"}
+
+
+class _SeqFetcher:
+    def __init__(self, responses: list[tuple[int, bytes]]) -> None:
+        self._responses = list(responses)
+        self._idx = 0
+        self.requested_urls: list[str] = []
+
+    def __call__(self, url: str, **_kwargs: Any) -> tuple[int, bytes, dict[str, str]]:
+        self.requested_urls.append(url)
+        if self._idx >= len(self._responses):
+            return 200, b'{"code":"0","data":[]}', {}
+        status, body = self._responses[self._idx]
+        self._idx += 1
+        return status, body, {}
+
+
+def _noop_rate_limiter() -> None:
+    return None
+
+
+def _build_url(path: str, params: dict[str, str]) -> str:
+    query = "&".join(f"{k}={v}" for k, v in sorted(params.items()))
+    return f"https://www.okx.com{path}?{query}"
+
+
+def _parse_json(body: bytes) -> dict[str, Any]:
+    return json.loads(body.decode())
+
+
+def _fetch_with_retry(
+    url: str, *, fetcher: Any, **_kwargs: Any
+) -> tuple[int, bytes, dict[str, str]]:
+    return fetcher(url)
+
+
+@pytest.fixture
+def window() -> Any:
+    return compute_bounded_window_v0()
+
+
+@pytest.fixture
+def budget(window: Any) -> FetchBudgetGuardV0:
+    derived = derive_production_budget_v0(window)
+    return FetchBudgetGuardV0(
+        max_instruments=10,
+        max_pages_per_instrument=derived["max_pages_per_instrument"],
+        max_total_requests=100,
+        max_total_raw_bytes=10_000_000,
+        max_runtime_seconds=60,
+    )
+
+
+def test_first_ohlcv_request_anchored_at_end_exclusive_not_now(
+    window: Any, budget: FetchBudgetGuardV0, tmp_path: Path
+) -> None:
+    now_ms = _ms("2026-07-03T12:00:00Z")
+    outside_page = [_ohlcv_row("2026-07-03T11:00:00Z"), _ohlcv_row("2026-06-01T00:00:00Z")]
+    inside_page = [_ohlcv_row("2024-08-31T23:00:00Z"), _ohlcv_row("2024-05-01T00:00:00Z")]
+    responses = [
+        (200, json.dumps({"code": "0", "data": outside_page}).encode()),
+        (200, json.dumps({"code": "0", "data": inside_page}).encode()),
+    ]
+    fetcher = _SeqFetcher(responses)
+    request_log: list[PaginationPageRecordV0] = []
+    paginate_bounded_ohlcv_v0(
+        instrument_id="ETH-USDT-SWAP",
+        native_instrument_id="ETH-USDT-SWAP",
+        window=window,
+        fetcher=fetcher,
+        rate_limiter=_noop_rate_limiter,
+        fetch_with_retry=_fetch_with_retry,
+        build_url=_build_url,
+        parse_json=_parse_json,
+        raw_dir=tmp_path / "ohlcv",
+        request_log=request_log,
+        budget=budget,
+    )
+    assert first_ohlcv_request_anchored_at_end_exclusive(request_log, window)
+    first_url = fetcher.requested_urls[0]
+    assert f"after={window.end_exclusive_ms}" in first_url
+    assert str(now_ms) not in first_url
+
+
+def test_window_boundaries_start_inclusive_end_exclusive(
+    window: Any, budget: FetchBudgetGuardV0, tmp_path: Path
+) -> None:
+    page = [
+        _ohlcv_row("2024-04-30T23:00:00Z"),
+        _ohlcv_row("2024-05-01T00:00:00Z"),
+        _ohlcv_row("2024-08-31T23:00:00Z"),
+        _ohlcv_row("2024-09-01T00:00:00Z"),
+    ]
+    fetcher = _SeqFetcher([(200, json.dumps({"code": "0", "data": page}).encode())])
+    rows, _ = paginate_bounded_ohlcv_v0(
+        instrument_id="ETH-USDT-SWAP",
+        native_instrument_id="ETH-USDT-SWAP",
+        window=window,
+        fetcher=fetcher,
+        rate_limiter=_noop_rate_limiter,
+        fetch_with_retry=_fetch_with_retry,
+        build_url=_build_url,
+        parse_json=_parse_json,
+        raw_dir=tmp_path / "ohlcv",
+        request_log=[],
+        budget=budget,
+    )
+    ts_set = {int(r[0]) for r in rows}
+    assert _ms("2024-05-01T00:00:00Z") in ts_set
+    assert _ms("2024-08-31T23:00:00Z") in ts_set
+    assert _ms("2024-04-30T23:00:00Z") not in ts_set
+    assert _ms("2024-09-01T00:00:00Z") not in ts_set
+
+
+def test_out_of_window_page_not_persisted_as_raw(
+    window: Any, budget: FetchBudgetGuardV0, tmp_path: Path
+) -> None:
+    outside = [_ohlcv_row("2026-01-01T00:00:00Z"), _ohlcv_row("2025-12-31T23:00:00Z")]
+    fetcher = _SeqFetcher([(200, json.dumps({"code": "0", "data": outside}).encode())])
+    request_log: list[PaginationPageRecordV0] = []
+    raw_dir = tmp_path / "ohlcv"
+    paginate_bounded_ohlcv_v0(
+        instrument_id="ETH-USDT-SWAP",
+        native_instrument_id="ETH-USDT-SWAP",
+        window=window,
+        fetcher=fetcher,
+        rate_limiter=_noop_rate_limiter,
+        fetch_with_retry=_fetch_with_retry,
+        build_url=_build_url,
+        parse_json=_parse_json,
+        raw_dir=raw_dir,
+        request_log=request_log,
+        budget=budget,
+    )
+    assert list(raw_dir.glob("*.json")) == []
+    assert request_log[0].retained is False
+    assert request_log[0].discarded_reason == "PAGE_FULLY_OUTSIDE_BOUND_WINDOW"
+
+
+def test_partial_overlap_page_filtered_and_retained(
+    window: Any, budget: FetchBudgetGuardV0, tmp_path: Path
+) -> None:
+    mixed = [
+        _ohlcv_row("2024-04-30T23:00:00Z"),
+        _ohlcv_row("2024-05-01T01:00:00Z"),
+        _ohlcv_row("2024-05-01T02:00:00Z"),
+    ]
+    fetcher = _SeqFetcher([(200, json.dumps({"code": "0", "data": mixed}).encode())])
+    request_log: list[PaginationPageRecordV0] = []
+    raw_dir = tmp_path / "ohlcv"
+    rows, _ = paginate_bounded_ohlcv_v0(
+        instrument_id="ETH-USDT-SWAP",
+        native_instrument_id="ETH-USDT-SWAP",
+        window=window,
+        fetcher=fetcher,
+        rate_limiter=_noop_rate_limiter,
+        fetch_with_retry=_fetch_with_retry,
+        build_url=_build_url,
+        parse_json=_parse_json,
+        raw_dir=raw_dir,
+        request_log=request_log,
+        budget=budget,
+    )
+    assert len(list(raw_dir.glob("*.json"))) == 1
+    assert request_log[0].retained is True
+    assert _ms("2024-04-30T23:00:00Z") not in {int(r[0]) for r in rows}
+    assert _ms("2024-05-01T01:00:00Z") in {int(r[0]) for r in rows}
+
+
+def test_pagination_stops_at_start_bound(
+    window: Any, budget: FetchBudgetGuardV0, tmp_path: Path
+) -> None:
+    from src.research.cross_sectional_bounded_panel_fetch_v0 import PAGE_LIMIT
+
+    start_bound = _ms("2024-05-01T00:00:00Z")
+    page1 = []
+    for i in range(PAGE_LIMIT):
+        ts = start_bound + (i + 48) * 3_600_000
+        page1.append(
+            _ohlcv_row(
+                datetime.fromtimestamp(ts / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            )
+        )
+    page2 = [_ohlcv_row("2024-05-01T00:00:00Z"), _ohlcv_row("2024-04-30T23:00:00Z")]
+    fetcher = _SeqFetcher(
+        [
+            (200, json.dumps({"code": "0", "data": page1}).encode()),
+            (200, json.dumps({"code": "0", "data": page2}).encode()),
+        ]
+    )
+    rows, _ = paginate_bounded_ohlcv_v0(
+        instrument_id="ETH-USDT-SWAP",
+        native_instrument_id="ETH-USDT-SWAP",
+        window=window,
+        fetcher=fetcher,
+        rate_limiter=_noop_rate_limiter,
+        fetch_with_retry=_fetch_with_retry,
+        build_url=_build_url,
+        parse_json=_parse_json,
+        raw_dir=tmp_path / "ohlcv",
+        request_log=[],
+        budget=budget,
+    )
+    assert len(fetcher.requested_urls) == 2
+    ts_set = {int(r[0]) for r in rows}
+    assert _ms("2024-05-01T00:00:00Z") in ts_set
+    assert _ms("2024-04-30T23:00:00Z") not in ts_set
+
+
+def test_ohlcv_and_funding_use_separate_paths(
+    window: Any, budget: FetchBudgetGuardV0, tmp_path: Path
+) -> None:
+    ohlcv_fetcher = _SeqFetcher(
+        [(200, json.dumps({"code": "0", "data": [_ohlcv_row("2024-05-01T00:00:00Z")]}).encode())]
+    )
+    funding_fetcher = _SeqFetcher(
+        [(200, json.dumps({"code": "0", "data": [_funding_row("2024-05-01T00:00:00Z")]}).encode())]
+    )
+    ohlcv_dir = tmp_path / "ohlcv"
+    funding_dir = tmp_path / "funding"
+    request_log: list[PaginationPageRecordV0] = []
+    paginate_bounded_ohlcv_v0(
+        instrument_id="ETH-USDT-SWAP",
+        native_instrument_id="ETH-USDT-SWAP",
+        window=window,
+        fetcher=ohlcv_fetcher,
+        rate_limiter=_noop_rate_limiter,
+        fetch_with_retry=_fetch_with_retry,
+        build_url=_build_url,
+        parse_json=_parse_json,
+        raw_dir=ohlcv_dir,
+        request_log=request_log,
+        budget=budget,
+    )
+    paginate_bounded_funding_v0(
+        instrument_id="ETH-USDT-SWAP",
+        native_instrument_id="ETH-USDT-SWAP",
+        window=window,
+        fetcher=funding_fetcher,
+        rate_limiter=_noop_rate_limiter,
+        fetch_with_retry=_fetch_with_retry,
+        build_url=_build_url,
+        parse_json=_parse_json,
+        raw_dir=funding_dir,
+        request_log=request_log,
+        budget=budget,
+    )
+    assert list(ohlcv_dir.glob("*.json"))
+    assert list(funding_dir.glob("*.json"))
+    phases = {r.phase for r in request_log}
+    assert PHASE_A_BOUND_OHLCV_PANEL in phases
+    assert PHASE_B_BOUND_FUNDING_HISTORY in phases
+    assert "history-candles" in ohlcv_fetcher.requested_urls[0]
+    assert "funding-rate-history" in funding_fetcher.requested_urls[0]
+
+
+def test_funding_pre_window_minimal_and_bounded(window: Any) -> None:
+    pre_hours = FUNDING_DELTA_LOOKBACK_K + FUNDING_SIGNAL_LAG
+    assert window.required_pre_window_hours == pre_hours
+    assert window.funding_fetch_start_ms == window.start_ms - pre_hours * 3_600_000
+
+
+def test_backward_asof_uses_no_future_funding(window: Any) -> None:
+    bar_ts = _ms("2024-05-10T12:00:00Z")
+    funding_rows = [
+        _funding_row("2024-05-10T11:00:00Z", "0.0001"),
+        _funding_row("2024-05-10T13:00:00Z", "0.0009"),
+    ]
+    rate = backward_asof_funding_lookup_v0(funding_rows, bar_ts)
+    assert rate == "0.0001"
+
+
+def test_missing_funding_stays_explicit_none(window: Any) -> None:
+    ohlcv = [_ohlcv_row("2024-05-10T12:00:00Z")]
+    joined, missing = attach_funding_to_ohlcv_bars_v0(
+        instrument_id="ETH-USDT-SWAP",
+        ohlcv_rows=ohlcv,
+        funding_rows=[],
+        window=window,
+    )
+    assert joined[0]["funding_rate"] is None
+    assert missing
+
+
+def test_score_and_cashflow_provenance_separated(window: Any) -> None:
+    ohlcv = [_ohlcv_row("2024-05-10T12:00:00Z")]
+    funding = [_funding_row("2024-05-10T11:00:00Z")]
+    joined, _ = attach_funding_to_ohlcv_bars_v0(
+        instrument_id="ETH-USDT-SWAP",
+        ohlcv_rows=ohlcv,
+        funding_rows=funding,
+        window=window,
+    )
+    assert joined[0]["score_input_provenance"] == score_input_provenance_marker_v0()
+    assert joined[0]["funding_cashflow_provenance"] == funding_cashflow_provenance_marker_v0()
+    assert joined[0]["score_input_provenance"] != joined[0]["funding_cashflow_provenance"]
+
+
+def test_budget_guard_fail_closed_on_max_requests(window: Any, tmp_path: Path) -> None:
+    from datetime import datetime, timezone
+
+    from src.research.cross_sectional_bounded_panel_fetch_v0 import PAGE_LIMIT
+
+    budget = FetchBudgetGuardV0(
+        max_instruments=2,
+        max_pages_per_instrument=50,
+        max_total_requests=1,
+        max_total_raw_bytes=10_000_000,
+        max_runtime_seconds=60,
+    )
+    base_ms = _ms("2024-05-10T00:00:00Z")
+    page = []
+    for i in range(PAGE_LIMIT):
+        ts = base_ms + i * 3_600_000
+        page.append(
+            _ohlcv_row(
+                datetime.fromtimestamp(ts / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            )
+        )
+    fetcher = _SeqFetcher(
+        [
+            (200, json.dumps({"code": "0", "data": page}).encode()),
+            (200, json.dumps({"code": "0", "data": page}).encode()),
+        ]
+    )
+    _, fail = paginate_bounded_ohlcv_v0(
+        instrument_id="ETH-USDT-SWAP",
+        native_instrument_id="ETH-USDT-SWAP",
+        window=window,
+        fetcher=fetcher,
+        rate_limiter=_noop_rate_limiter,
+        fetch_with_retry=_fetch_with_retry,
+        build_url=_build_url,
+        parse_json=_parse_json,
+        raw_dir=tmp_path / "ohlcv",
+        request_log=[],
+        budget=budget,
+    )
+    assert fail == BudgetGuardReason.MAX_TOTAL_REQUESTS.value
+
+
+def test_bitcoin_and_xbt_instruments_excluded() -> None:
+    list_time = str(_ms("2023-01-01T00:00:00Z"))
+    base = {
+        "instType": "SWAP",
+        "state": "live",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "listTime": list_time,
+        "expTime": "",
+    }
+    samples = [
+        {**base, "instId": "BTC-USDT-SWAP"},
+        {**base, "instId": "XBT-USDT-SWAP"},
+        {**base, "instId": "ETH-USDT-SWAP"},
+    ]
+    eligible = select_eligible_instruments_v0(samples)
+    canonical_ids = [item[0] for item in eligible]
+    native_ids = [item[1] for item in eligible]
+    assert "ETH-USDT-SWAP" in native_ids
+    assert "BTC-USDT-SWAP" not in native_ids
+    assert "XBT-USDT-SWAP" not in native_ids
+    assert any("ETH" in cid for cid in canonical_ids)
+    for inst in samples[:2]:
+        assert not evaluate_okx_instrument_eligibility_v1(inst).eligible
+
+
+def test_out_of_window_retained_raw_count_detects_bad_files(window: Any, tmp_path: Path) -> None:
+    bad_name = f"ETH-USDT-SWAP_ohlcv_p0000_{_ms('2026-01-01T00:00:00Z')}_{_ms('2026-01-02T00:00:00Z')}_abc123.json"
+    good_name = f"ETH-USDT-SWAP_ohlcv_p0001_{window.start_ms}_{window.end_exclusive_ms - 3_600_000}_def456.json"
+    raw_dir = tmp_path / "ohlcv"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / bad_name).write_text("{}", encoding="utf-8")
+    (raw_dir / good_name).write_text("{}", encoding="utf-8")
+    assert out_of_window_retained_raw_count(raw_dir) == 1
+
+
+def test_aborted_preflight_does_not_promote(tmp_path: Path) -> None:
+    from src.research.cross_sectional_bounded_panel_fetch_v0 import (
+        BoundedPreflightResultV0,
+        FetchTerminalStatus,
+    )
+
+    result = BoundedPreflightResultV0(
+        status=FetchTerminalStatus.BUDGET_EXCEEDED_FAIL_CLOSED,
+        staging_root=str(tmp_path),
+        instrument_count=1,
+        ohlcv_raw_files=1,
+        funding_raw_files=0,
+        out_of_window_raw_files=0,
+        total_requests=2,
+        total_raw_bytes=100,
+        runtime_seconds=1.0,
+        fail_reason=BudgetGuardReason.MAX_TOTAL_REQUESTS.value,
+        request_log_count=2,
+        manifest_verify_rc=0,
+        promoted=False,
+    )
+    assert result.promoted is False
+    assert result.status != FetchTerminalStatus.PREFLIGHT_COMPLETE
+
+
+def test_quarantine_path_not_used_by_bounded_preflight_runner() -> None:
+    from src.research import cross_sectional_bounded_panel_fetch_v0 as mod
+
+    source = Path(mod.__file__).read_text(encoding="utf-8")
+    quarantine = ".tmp_historical_20260703T134626Z"
+    assert quarantine not in source

--- a/tests/research/test_cross_sectional_funding_rate_delta_momentum_v0_binding_completion_v0.py
+++ b/tests/research/test_cross_sectional_funding_rate_delta_momentum_v0_binding_completion_v0.py
@@ -1,0 +1,169 @@
+"""Contract tests for cross-sectional funding-rate delta momentum v0 binding completion."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.backtest.economic_validity_policy_v1 import ECONOMIC_VALIDITY_POLICY_VERSION
+from src.research.cross_sectional_funding_rate_delta_momentum_scoring_v0 import (
+    FUNDING_DELTA_LOOKBACK_K,
+    FUNDING_SIGNAL_LAG,
+    FundingDeltaLeg,
+    compute_instrument_funding_delta_score_v0,
+    funding_cashflow_provenance_marker_v0,
+    score_input_provenance_marker_v0,
+    select_funding_delta_extreme_single_leg_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0 import (
+    BINDING_SCHEMA_VERSION,
+    CONFIG_REL_PATH,
+    FEE_BPS_PER_SIDE,
+    PANEL_DATASET_ID,
+    PERIOD_BINDING_ID,
+    ROUNDTRIP_COST_BPS,
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+    BindingMaterializationVerdict,
+    BindingRatificationStatus,
+    build_cost_execution_binding_v0,
+    materialize_and_validate_versioned_research_binding_v0,
+    materialize_versioned_research_binding_v0,
+    write_versioned_research_binding_artifacts_v0,
+)
+from src.research.cross_sectional_funding_rate_panel_field_materialization_v0 import (
+    materialize_funding_field_for_panel_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_ranking_semantics_binding_validator_v0 import (
+    ValidationVerdict,
+)
+from tests.research.fixtures.cross_sectional_funding_rate_delta_momentum_v0.fixture_builder import (
+    build_funding_rates_for_panel_v0,
+    build_synthetic_ohlcv_panel_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def complete_binding() -> dict:
+    return materialize_versioned_research_binding_v0()
+
+
+def test_binding_materialization_complete_and_ratified() -> None:
+    result = materialize_and_validate_versioned_research_binding_v0()
+    assert result.verdict == BindingMaterializationVerdict.COMPLETE
+    assert result.ratification_status == BindingRatificationStatus.BINDINGS_RATIFIED
+    assert result.validation_verdict == ValidationVerdict.ACCEPTED_COMPLETE
+    assert result.fail_reasons == ()
+
+
+def test_strategy_identity(complete_binding: dict) -> None:
+    assert complete_binding["strategy_id"] == STRATEGY_ID
+    assert complete_binding["strategy_version"] == STRATEGY_VERSION
+    assert (
+        complete_binding["research_hypothesis_id"]
+        == "CROSS_SECTIONAL_FUNDING_RATE_DELTA_MOMENTUM_NON_BITCOIN_PERPETUALS_V0"
+    )
+
+
+def test_frozen_score_parameters(complete_binding: dict) -> None:
+    params = complete_binding["parameter_binding"]["parameters"]
+    assert params["funding_delta_lookback_k"] == FUNDING_DELTA_LOOKBACK_K == 4
+    assert params["signal_lag_bars"] == FUNDING_SIGNAL_LAG == 1
+
+
+def test_required_binding_digests_present(complete_binding: dict) -> None:
+    assert complete_binding["implementation_digest"]
+    assert complete_binding["config_digest"]
+    assert complete_binding["data_digest"]
+    assert complete_binding["binding_digest"]
+    digest_bindings = complete_binding["binding"]["digest_bindings"]
+    for key in ("implementation_digest", "config_digest", "data_digest"):
+        assert digest_bindings[key]["status"] == "BOUND"
+        assert digest_bindings[key]["value"]
+
+
+def test_futures_only_constraints(complete_binding: dict) -> None:
+    constraints = complete_binding["system_constraints"]
+    assert constraints["futures_only"] is True
+    assert constraints["bitcoin_direction_allowed"] is False
+    assert constraints["spot_allowed"] is False
+    assert constraints["synthetic_spot_allowed"] is False
+
+
+def test_panel_dataset_binding_extended_calendar(complete_binding: dict) -> None:
+    binding = complete_binding["panel_dataset_binding"]
+    assert binding["dataset_id"] == PANEL_DATASET_ID
+    assert binding["dataset_extension"] == "extended_chronological_with_funding_v1"
+    assert binding["panel_calendar_start_utc"] == "2024-05-01T00:00:00Z"
+    assert binding["panel_calendar_end_utc"] == "2024-09-01T00:00:00Z"
+
+
+def test_period_binding_non_overlap(complete_binding: dict) -> None:
+    binding = complete_binding["period_binding"]
+    assert binding["period_binding_id"] == PERIOD_BINDING_ID
+    assert binding["training_end"] < binding["validation_start"]
+    assert binding["validation_end"] < binding["out_of_sample_start"]
+
+
+def test_cost_binding_non_zero() -> None:
+    binding = build_cost_execution_binding_v0()
+    assert binding["fee_model_binding"]["fee_bps_per_side"] == FEE_BPS_PER_SIDE
+    assert binding["execution_model_binding"]["roundtrip_cost_bps"] == ROUNDTRIP_COST_BPS
+    assert binding["implicit_zero_cost_forbidden"] is True
+
+
+def test_economic_policy_minimum_trade_count(complete_binding: dict) -> None:
+    policy = complete_binding["economic_policy_binding"]
+    assert policy["economic_validity_policy_version"] == ECONOMIC_VALIDITY_POLICY_VERSION
+    assert policy["policy_lowering_forbidden"] is True
+    assert policy["minimum_trade_count"] == 50
+
+
+def test_score_cashflow_provenance_separation() -> None:
+    assert score_input_provenance_marker_v0() != funding_cashflow_provenance_marker_v0()
+    assert "delta" in score_input_provenance_marker_v0()
+    assert "cashflow" in funding_cashflow_provenance_marker_v0()
+
+
+def test_funding_delta_score_and_selection() -> None:
+    rates = [0.0001 * idx for idx in range(12)]
+    scores = []
+    for instrument_id in (
+        "okx:linear_perpetual:ETH:USDT:USDT:perp",
+        "okx:linear_perpetual:SOL:USDT:USDT:perp",
+        "okx:linear_perpetual:AVAX:USDT:USDT:perp",
+        "okx:linear_perpetual:LINK:USDT:USDT:perp",
+        "okx:linear_perpetual:ADA:USDT:USDT:perp",
+    ):
+        score = compute_instrument_funding_delta_score_v0(
+            instrument_id,
+            rates,
+            funding_delta_lookback_k=4,
+            signal_lag_bars=1,
+            epoch_index=10,
+        )
+        if score is not None:
+            scores.append(score)
+    selection = select_funding_delta_extreme_single_leg_v0(scores)
+    assert selection.leg in {FundingDeltaLeg.LONG_MIN_DELTA, FundingDeltaLeg.SHORT_MAX_DELTA}
+    assert selection.instrument_id is not None
+
+
+def test_funding_panel_adapter_materializes_field() -> None:
+    panel = build_synthetic_ohlcv_panel_v0()
+    funding = build_funding_rates_for_panel_v0(panel)
+    result = materialize_funding_field_for_panel_v0(panel, funding)
+    assert result.funding_field == "funding_rate"
+    assert len(result.series) == 5
+
+
+def test_write_binding_artifacts(tmp_path: Path) -> None:
+    config_path, ranking_path = write_versioned_research_binding_artifacts_v0(tmp_path)
+    assert config_path.exists()
+    assert ranking_path.exists()
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == BINDING_SCHEMA_VERSION


### PR DESCRIPTION
## Summary

- Implement bounded OKX OHLCV and funding panel fetch with `after=END_EXCLUSIVE` pagination, window-only raw retention, separate OHLCV/funding phases, PIT backward-asof join, and fail-closed budget guards.
- Add cross-sectional funding-rate delta momentum v0 research bindings, scoring, orchestration wrappers, and 28 focused contract tests.
- Run and document a two-instrument technical preflight (no economic evaluation, no full 410-instrument fetch, quarantine untouched).

## Test plan

- [x] `pytest tests/research/test_cross_sectional_bounded_panel_fetch_v0.py` (15 passed)
- [x] `pytest tests/research/test_cross_sectional_funding_rate_delta_momentum_v0_binding_completion_v0.py` (13 passed)
- [x] `ruff format --check` and `ruff check` on changed Python files
- [x] CI selector via `--files-file` → `PR_BOUNDED_FULL`
- [x] Two-instrument preflight: `PREFLIGHT_COMPLETE`, `MANIFEST_VERIFY_RC=0`, `out_of_window_raw_files=0`
- [x] Quarantine `.tmp_historical_20260703T134626Z` unchanged (9309 files)

## Notes

- OKX public `funding-rate-history` currently retains only ~3 months; 2024-05..2024-09 funding is explicitly missing (not proxied from OHLCV).
- Full panel extension remains **not started**; next canonical step: `BOUNDED_FULL_PANEL_EXTENSION_EXECUTION_AFTER_FETCH_RECOVERY_V0`.


Made with [Cursor](https://cursor.com)