### PR TITLE
Add OKX historical funding archive ingest and fail-closed missing policy

### DIFF
--- a/scripts/ops/materialize_cross_sectional_funding_rate_carry_v0_bound_panel_funding_dataset_v0.py
+++ b/scripts/ops/materialize_cross_sectional_funding_rate_carry_v0_bound_panel_funding_dataset_v0.py
@@ -28,6 +28,14 @@ from scripts.ops.ingest_okx_futures_public_market_data_canonical_dataset_staging
 from src.research.cross_sectional_funding_rate_carry_v0_offline_economic_evaluation_execution_v0 import (  # noqa: E402
     INFRASTRUCTURE_GO_TOKEN,
 )
+from src.research.cross_sectional_bounded_panel_fetch_v0 import (  # noqa: E402
+    backward_asof_funding_lookup_v0,
+)
+from src.research.missing_funding_policy_v0 import (  # noqa: E402
+    MISSING_REASON_NO_PRIOR_FUNDING,
+    is_missing_funding_value_v0,
+    resolve_funding_rate_or_missing_v0,
+)
 from src.research.pit_futures_cross_sectional_research_data_digest_period_split_materialization_v0 import (  # noqa: E402
     load_panel_series_from_staging,
 )
@@ -86,17 +94,12 @@ def _funding_asof_lookup(
     *,
     funding_rows: list[dict[str, Any]],
     bar_timestamp_ms: int,
-) -> str:
-    chosen: dict[str, Any] | None = None
-    for row in funding_rows:
-        ts = int(str(row.get("fundingTime", "0")))
-        if ts <= bar_timestamp_ms:
-            chosen = row
-        else:
-            break
-    if chosen is None:
-        return "0.0"
-    return str(chosen.get("fundingRate", "0.0"))
+) -> tuple[str | None, str | None]:
+    """PIT backward-asof join; missing stays None (no synthetic zero fallback)."""
+    rate = backward_asof_funding_lookup_v0(funding_rows, bar_timestamp_ms)
+    if is_missing_funding_value_v0(rate):
+        return resolve_funding_rate_or_missing_v0(raw_value=None), MISSING_REASON_NO_PRIOR_FUNDING
+    return resolve_funding_rate_or_missing_v0(raw_value=rate), None
 
 
 def _fetch_funding_for_instrument(
@@ -172,11 +175,19 @@ def materialize_bound_panel_funding_dataset_v0(
             )
 
     funding_rows_out: list[dict[str, Any]] = []
+    missing_reasons: list[str] = []
     for series in panel_series:
         source_rows = funding_by_native.get(series.native_instrument_id, [])
         for bar in series.bars:
             ts_ms = _utc_ts_to_ms(bar.timestamp_utc)
-            funding_rate = _funding_asof_lookup(funding_rows=source_rows, bar_timestamp_ms=ts_ms)
+            funding_rate, missing_reason = _funding_asof_lookup(
+                funding_rows=source_rows,
+                bar_timestamp_ms=ts_ms,
+            )
+            if missing_reason is not None:
+                missing_reasons.append(
+                    f"{series.instrument_id}@{bar.timestamp_utc}:{missing_reason}"
+                )
             funding_rows_out.append(
                 {
                     "instrument_id": series.instrument_id,
@@ -188,6 +199,7 @@ def materialize_bound_panel_funding_dataset_v0(
                     "close": bar.close,
                     "volume": bar.volume,
                     "funding_rate": funding_rate,
+                    "missing_funding_reason": missing_reason,
                     "is_final": bar.is_final,
                 }
             )
@@ -210,6 +222,8 @@ def materialize_bound_panel_funding_dataset_v0(
         "row_count_total": len(funding_rows_out),
         "funding_panel_digest": funding_digest,
         "backward_asof_policy": "funding_time_lte_bar_timestamp_no_lookahead",
+        "missing_funding_policy": "fail_closed_none_no_zero_fallback",
+        "missing_funding_count": len(missing_reasons),
         "source_ohlcv_staging": str(staging_root),
         "fetched_from_okx_public": not skip_fetch,
     }

--- a/src/research/cross_sectional_funding_rate_delta_momentum_scoring_v0.py
+++ b/src/research/cross_sectional_funding_rate_delta_momentum_scoring_v0.py
@@ -24,6 +24,13 @@ FUNDING_DELTA_LOOKBACK_K = 4
 FUNDING_SIGNAL_LAG = 1
 
 
+class FundingDeltaScoreStatusV0(str, Enum):
+    COMPUTE_OK = "COMPUTE_OK"
+    WARMUP_INCOMPLETE = "WARMUP_INCOMPLETE"
+    MISSING_REQUIRED_FUNDING_HISTORY = "MISSING_REQUIRED_FUNDING_HISTORY"
+    NON_FINITE_INPUT = "NON_FINITE_INPUT"
+
+
 class FundingDeltaLeg(str, Enum):
     FLAT = "FLAT"
     LONG_MIN_DELTA = "LONG_MIN_DELTA"
@@ -37,6 +44,8 @@ class FundingDeltaScoreResultV0:
     funding_rate_lookback: float
     funding_delta: float
     warmup_complete: bool
+    score_status: FundingDeltaScoreStatusV0 = FundingDeltaScoreStatusV0.COMPUTE_OK
+    signal_eligible: bool = True
 
 
 @dataclass(frozen=True)
@@ -56,7 +65,7 @@ def _is_bitcoin_instrument(instrument_id: str) -> bool:
 
 def compute_instrument_funding_delta_score_v0(
     instrument_id: str,
-    funding_rates: Sequence[float],
+    funding_rates: Sequence[float | None],
     *,
     funding_delta_lookback_k: int = FUNDING_DELTA_LOOKBACK_K,
     signal_lag_bars: int = FUNDING_SIGNAL_LAG,
@@ -70,17 +79,45 @@ def compute_instrument_funding_delta_score_v0(
         return None
     raw_lag = funding_rates[lag_idx]
     raw_lookback = funding_rates[lookback_idx]
+    if raw_lag is None or raw_lookback is None:
+        return FundingDeltaScoreResultV0(
+            instrument_id=instrument_id,
+            funding_rate_lag=float("nan"),
+            funding_rate_lookback=float("nan"),
+            funding_delta=float("nan"),
+            warmup_complete=False,
+            score_status=FundingDeltaScoreStatusV0.MISSING_REQUIRED_FUNDING_HISTORY,
+            signal_eligible=False,
+        )
     if not math.isfinite(raw_lag) or not math.isfinite(raw_lookback):
-        return None
+        return FundingDeltaScoreResultV0(
+            instrument_id=instrument_id,
+            funding_rate_lag=raw_lag,
+            funding_rate_lookback=raw_lookback,
+            funding_delta=float("nan"),
+            warmup_complete=False,
+            score_status=FundingDeltaScoreStatusV0.NON_FINITE_INPUT,
+            signal_eligible=False,
+        )
     delta = raw_lag - raw_lookback
     if not math.isfinite(delta):
-        return None
+        return FundingDeltaScoreResultV0(
+            instrument_id=instrument_id,
+            funding_rate_lag=raw_lag,
+            funding_rate_lookback=raw_lookback,
+            funding_delta=delta,
+            warmup_complete=False,
+            score_status=FundingDeltaScoreStatusV0.NON_FINITE_INPUT,
+            signal_eligible=False,
+        )
     return FundingDeltaScoreResultV0(
         instrument_id=instrument_id,
         funding_rate_lag=raw_lag,
         funding_rate_lookback=raw_lookback,
         funding_delta=delta,
         warmup_complete=True,
+        score_status=FundingDeltaScoreStatusV0.COMPUTE_OK,
+        signal_eligible=True,
     )
 
 

--- a/src/research/cross_sectional_funding_rate_delta_momentum_single_slot_research_orchestrator_v0.py
+++ b/src/research/cross_sectional_funding_rate_delta_momentum_single_slot_research_orchestrator_v0.py
@@ -141,8 +141,10 @@ def run_cross_sectional_funding_rate_delta_momentum_orchestrator_v0(
                 signal_lag_bars=signal_lag_bars,
                 epoch_index=epoch_index,
             )
-            if score_result is not None:
+            if score_result is not None and score_result.signal_eligible:
                 epoch_scores.append(score_result)
+            elif score_result is not None:
+                error_codes.append(FundingDeltaOrchestratorErrorCode.MISSING_FUNDING_RATE.value)
 
         selection_extreme = select_funding_delta_extreme_single_leg_v0(epoch_scores)
         ranked_ids = tuple(

--- a/src/research/missing_funding_policy_v0.py
+++ b/src/research/missing_funding_policy_v0.py
@@ -1,0 +1,70 @@
+"""Canonical missing-funding semantics for cross-sectional research v0.
+
+Fail-closed: missing funding stays explicit None; synthetic zero is forbidden.
+Research-only; no runtime or authority effect.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+PACKAGE_MARKER = "MISSING_FUNDING_POLICY_V0=true"
+POLICY_VERSION = "missing_funding_policy.v0"
+
+MISSING_FUNDING_VALUE: None = None
+MISSING_FUNDING_IS_ZERO = False
+MISSING_FUNDING_FAIL_CLOSED = True
+
+FORBIDDEN_MISSING_FALLBACKS = frozenset({"0", "0.0", 0, 0.0, Decimal("0"), Decimal("0.0")})
+
+MISSING_REASON_NO_PRIOR_FUNDING = "MISSING_FUNDING_NO_PRIOR_SETTLEMENT"
+MISSING_REASON_FIELD_ABSENT = "MISSING_FUNDING_FIELD_ABSENT"
+MISSING_REASON_SYNTHETIC_ZERO_BLOCKED = "MISSING_FUNDING_SYNTHETIC_ZERO_BLOCKED"
+
+
+def is_missing_funding_value_v0(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str) and value.strip() == "":
+        return True
+    return False
+
+
+def reject_synthetic_zero_funding_fallback_v0(value: Any) -> None:
+    """Raise when a caller attempts to treat zero as a missing-funding substitute."""
+    if value in FORBIDDEN_MISSING_FALLBACKS:
+        raise ValueError(MISSING_REASON_SYNTHETIC_ZERO_BLOCKED)
+    if isinstance(value, str) and value.strip() in {"0", "0.0"}:
+        raise ValueError(MISSING_REASON_SYNTHETIC_ZERO_BLOCKED)
+
+
+def resolve_funding_rate_or_missing_v0(
+    *,
+    raw_value: Any,
+    allow_explicit_zero: bool = True,
+) -> str | None:
+    """Return normalized rate string or None; never synthesize zero for missing."""
+    if is_missing_funding_value_v0(raw_value):
+        return MISSING_FUNDING_VALUE
+    text = str(raw_value).strip()
+    if not text:
+        return MISSING_FUNDING_VALUE
+    if not allow_explicit_zero:
+        reject_synthetic_zero_funding_fallback_v0(text)
+    return text
+
+
+def backward_asof_funding_rate_fail_closed_v0(
+    funding_rows: list[dict[str, Any]],
+    bar_timestamp_ms: int,
+) -> tuple[str | None, str | None]:
+    """PIT lookup returning (rate_or_none, missing_reason_or_none)."""
+    from src.research.cross_sectional_bounded_panel_fetch_v0 import (
+        backward_asof_funding_lookup_v0,
+    )
+
+    rate = backward_asof_funding_lookup_v0(funding_rows, bar_timestamp_ms)
+    if rate is None or str(rate).strip() == "":
+        return MISSING_FUNDING_VALUE, MISSING_REASON_NO_PRIOR_FUNDING
+    return str(rate), None

--- a/src/research/okx_historical_funding_archive_ingest_v0.py
+++ b/src/research/okx_historical_funding_archive_ingest_v0.py
@@ -1,0 +1,607 @@
+"""OKX Historical Funding Archive ingest adapter v0.
+
+Consumes public OKX Historical Data Portal monthly settlement archives,
+normalizes schema, enforces fail-closed guards, and emits PIT-safe funding
+events for cross-sectional panel owners. Research-only; no network in tests.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import time
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from src.research.cross_sectional_funding_rate_delta_momentum_scoring_v0 import (
+    funding_cashflow_provenance_marker_v0,
+    score_input_provenance_marker_v0,
+)
+from src.research.missing_funding_policy_v0 import (
+    MISSING_FUNDING_FAIL_CLOSED,
+    MISSING_FUNDING_IS_ZERO,
+    MISSING_FUNDING_VALUE,
+    is_missing_funding_value_v0,
+    reject_synthetic_zero_funding_fallback_v0,
+)
+
+PACKAGE_MARKER = "OKX_HISTORICAL_FUNDING_ARCHIVE_INGEST_V0=true"
+MODULE_VERSION = "okx_historical_funding_archive_ingest.v0"
+SOURCE_ID = "OKX_HISTORICAL_FUNDING_ARCHIVE"
+SOURCE_VENUE = "OKX"
+SOURCE_ACCESS_METHOD = "HISTORICAL_DATA_PORTAL_ARCHIVE"
+SCHEMA_VERSION = "okx_historical_funding_archive_normalized_event.v0"
+
+FUNDING_RATE_FIELD = "funding_rate"
+FUNDING_TIMESTAMP_FIELD = "funding_time"
+INSTRUMENT_FIELD = "instrument_name"
+SETTLEMENT_CLASS = "SETTLEMENT"
+RATE_UNIT = "decimal_fraction_per_8h_interval"
+RATE_SIGN_CONVENTION = "signed_decimal_long_pays_positive"
+FUNDING_INTERVAL_MS = 28800000
+TIMEZONE = "UTC"
+
+REQUIRED_CSV_COLUMNS = frozenset({FUNDING_RATE_FIELD, FUNDING_TIMESTAMP_FIELD, INSTRUMENT_FIELD})
+FORECAST_COLUMN_NAMES = frozenset(
+    {
+        "nextFundingRate",
+        "predictedFundingRate",
+        "fundingRateForecast",
+        "forecast_funding_rate",
+        "realizedRate",
+    }
+)
+FORBIDDEN_INSTRUMENT_TOKENS = frozenset({"btc", "xbt", "bitcoin"})
+SPOT_DELIVERY_SUFFIXES = ("-SPOT", "-FUTURES", "-FUTURE", "-DELIVERY")
+
+CDN_BASE = "https://static.okx.com/cdn/okex/traderecords/swaprates/monthly"
+
+HISTORICAL_UNIVERSE_LIFECYCLE_PASS = False
+FULL_PANEL_PROMOTION_REQUIRES_HISTORICAL_UNIVERSE_LIFECYCLE_PASS = (
+    "FULL_PANEL_PROMOTION_REQUIRES_HISTORICAL_UNIVERSE_LIFECYCLE_PASS"
+)
+
+
+class ArchiveValidationErrorCode(str, Enum):
+    MISSING_FUNDING_RATE = "MISSING_FUNDING_RATE"
+    MISSING_FUNDING_TIME = "MISSING_FUNDING_TIME"
+    MISSING_INSTRUMENT = "MISSING_INSTRUMENT"
+    FORECAST_COLUMN_PRESENT = "FORECAST_COLUMN_PRESENT"
+    WRONG_INSTRUMENT = "WRONG_INSTRUMENT"
+    BITCOIN_INSTRUMENT = "BITCOIN_INSTRUMENT"
+    SPOT_OR_DELIVERY_INSTRUMENT = "SPOT_OR_DELIVERY_INSTRUMENT"
+    INVALID_RATE_UNIT = "INVALID_RATE_UNIT"
+    INVALID_TIMESTAMP_TYPE = "INVALID_TIMESTAMP_TYPE"
+    INVALID_INTERVAL = "INVALID_INTERVAL"
+    DUPLICATE_KEY = "DUPLICATE_KEY"
+    NON_MONOTONIC_TIMESTAMPS = "NON_MONOTONIC_TIMESTAMPS"
+    EMPTY_ARCHIVE = "EMPTY_ARCHIVE"
+    MULTIPLE_CSV_IN_ZIP = "MULTIPLE_CSV_IN_ZIP"
+    NO_CSV_IN_ZIP = "NO_CSV_IN_ZIP"
+
+
+class ArchiveAccessGuardReason(str, Enum):
+    MAX_INSTRUMENTS = "MAX_INSTRUMENTS"
+    MAX_MONTHS = "MAX_MONTHS"
+    MAX_HTTP_REQUESTS = "MAX_HTTP_REQUESTS"
+    MAX_TOTAL_BYTES = "MAX_TOTAL_BYTES"
+    MAX_RUNTIME_SECONDS = "MAX_RUNTIME_SECONDS"
+
+
+class ArchiveIngestTerminalStatus(str, Enum):
+    COMPLETE = "COMPLETE"
+    INCOMPLETE_NOT_PROMOTED = "INCOMPLETE_NOT_PROMOTED"
+    GUARD_EXCEEDED_FAIL_CLOSED = "GUARD_EXCEEDED_FAIL_CLOSED"
+    VALIDATION_FAILED = "VALIDATION_FAILED"
+
+
+@dataclass(frozen=True)
+class NormalizedFundingEventV0:
+    instrument_id: str
+    funding_rate: str
+    funding_time: int
+    source_id: str
+    source_file_digest: str
+    source_row_number: int
+    settlement_class: str
+    rate_unit: str
+    interval_ms: int
+    retrieval_time: str
+    schema_version: str
+
+
+@dataclass(frozen=True)
+class ArchiveRetrievalRecordV0:
+    portal_reference: str
+    instrument_id: str
+    month: str
+    expected_data_type: str
+    http_status: int
+    content_type: str
+    content_length: int
+    sha256: str
+    retrieval_time: str
+    raw_provenance: str
+
+
+@dataclass
+class ArchiveAccessGuardV0:
+    max_instruments: int
+    max_months: int
+    max_http_requests: int
+    max_total_bytes: int
+    max_runtime_seconds: int
+    instruments_used: int = 0
+    months_used: int = 0
+    http_requests: int = 0
+    total_bytes: int = 0
+    start_monotonic: float = field(default_factory=time.monotonic)
+    fail_reason: str = ""
+
+    def check_runtime(self) -> str | None:
+        if time.monotonic() - self.start_monotonic > self.max_runtime_seconds:
+            return ArchiveAccessGuardReason.MAX_RUNTIME_SECONDS.value
+        return None
+
+    def check_request(self) -> str | None:
+        if self.http_requests >= self.max_http_requests:
+            return ArchiveAccessGuardReason.MAX_HTTP_REQUESTS.value
+        return None
+
+    def check_bytes(self, additional: int) -> str | None:
+        if self.total_bytes + additional > self.max_total_bytes:
+            return ArchiveAccessGuardReason.MAX_TOTAL_BYTES.value
+        return None
+
+    def check_instruments(self) -> str | None:
+        if self.instruments_used >= self.max_instruments:
+            return ArchiveAccessGuardReason.MAX_INSTRUMENTS.value
+        return None
+
+    def check_months(self) -> str | None:
+        if self.months_used >= self.max_months:
+            return ArchiveAccessGuardReason.MAX_MONTHS.value
+        return None
+
+    def record_request(self, byte_count: int) -> str | None:
+        self.http_requests += 1
+        self.total_bytes += byte_count
+        for checker in (self.check_runtime, self.check_request, lambda: self.check_bytes(0)):
+            reason = checker()
+            if reason:
+                self.fail_reason = reason
+                return reason
+        return None
+
+
+@dataclass(frozen=True)
+class ArchiveParseResultV0:
+    events: tuple[NormalizedFundingEventV0, ...]
+    instrument_metadata: tuple[dict[str, str], ...]
+    validation_errors: tuple[str, ...]
+    duplicate_keys_removed: int
+    out_of_period_rows: int
+    status: ArchiveIngestTerminalStatus
+
+
+@dataclass(frozen=True)
+class ConsumerProvenanceRecordV0:
+    consumer_domain: str
+    provenance_marker: str
+    instrument_id: str
+    funding_time: int
+    funding_rate: str
+    source_file_digest: str
+    source_row_number: int
+    join_reason: str
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _parse_utc_ms(value: str) -> int:
+    dt = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _format_utc_ms(ms: int) -> str:
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def build_archive_cdn_url_v0(*, instrument_id: str, year: int, month: int) -> str:
+    yyyymm = f"{year}{month:02d}"
+    month_label = f"{year}-{month:02d}"
+    return f"{CDN_BASE}/{yyyymm}/{instrument_id}-fundingrates-{month_label}.zip"
+
+
+def _is_bitcoin_instrument(instrument_id: str) -> bool:
+    lowered = instrument_id.lower()
+    return any(token in lowered for token in FORBIDDEN_INSTRUMENT_TOKENS)
+
+
+def _is_spot_or_delivery(instrument_id: str) -> bool:
+    upper = instrument_id.upper()
+    return any(token in upper for token in SPOT_DELIVERY_SUFFIXES)
+
+
+def validate_archive_csv_headers_v0(headers: Sequence[str]) -> list[str]:
+    errors: list[str] = []
+    header_set = {h.strip() for h in headers if h}
+    missing = REQUIRED_CSV_COLUMNS - header_set
+    if FUNDING_RATE_FIELD in missing:
+        errors.append(ArchiveValidationErrorCode.MISSING_FUNDING_RATE.value)
+    if FUNDING_TIMESTAMP_FIELD in missing:
+        errors.append(ArchiveValidationErrorCode.MISSING_FUNDING_TIME.value)
+    if INSTRUMENT_FIELD in missing:
+        errors.append(ArchiveValidationErrorCode.MISSING_INSTRUMENT.value)
+    forecast_present = header_set & FORECAST_COLUMN_NAMES
+    if forecast_present:
+        errors.append(ArchiveValidationErrorCode.FORECAST_COLUMN_PRESENT.value)
+    return errors
+
+
+def validate_archive_row_v0(
+    row: Mapping[str, str],
+    *,
+    expected_instrument_id: str | None,
+    row_number: int,
+) -> list[str]:
+    errors: list[str] = []
+    instrument = str(row.get(INSTRUMENT_FIELD, "")).strip()
+    if not instrument:
+        errors.append(f"{ArchiveValidationErrorCode.MISSING_INSTRUMENT.value}:row={row_number}")
+        return errors
+    if expected_instrument_id is not None and instrument != expected_instrument_id:
+        errors.append(f"{ArchiveValidationErrorCode.WRONG_INSTRUMENT.value}:row={row_number}")
+    if _is_bitcoin_instrument(instrument):
+        errors.append(f"{ArchiveValidationErrorCode.BITCOIN_INSTRUMENT.value}:row={row_number}")
+    if _is_spot_or_delivery(instrument):
+        errors.append(
+            f"{ArchiveValidationErrorCode.SPOT_OR_DELIVERY_INSTRUMENT.value}:row={row_number}"
+        )
+    rate_raw = str(row.get(FUNDING_RATE_FIELD, "")).strip()
+    if not rate_raw:
+        errors.append(f"{ArchiveValidationErrorCode.MISSING_FUNDING_RATE.value}:row={row_number}")
+    else:
+        try:
+            rate_val = float(rate_raw)
+            if not (-1.0 <= rate_val <= 1.0):
+                errors.append(
+                    f"{ArchiveValidationErrorCode.INVALID_RATE_UNIT.value}:row={row_number}"
+                )
+        except ValueError:
+            errors.append(f"{ArchiveValidationErrorCode.INVALID_RATE_UNIT.value}:row={row_number}")
+    ts_raw = str(row.get(FUNDING_TIMESTAMP_FIELD, "")).strip()
+    if not ts_raw:
+        errors.append(f"{ArchiveValidationErrorCode.MISSING_FUNDING_TIME.value}:row={row_number}")
+    else:
+        try:
+            ts_val = int(ts_raw)
+            if ts_val <= 0:
+                errors.append(
+                    f"{ArchiveValidationErrorCode.INVALID_TIMESTAMP_TYPE.value}:row={row_number}"
+                )
+        except ValueError:
+            errors.append(
+                f"{ArchiveValidationErrorCode.INVALID_TIMESTAMP_TYPE.value}:row={row_number}"
+            )
+    return errors
+
+
+def _stable_event_key(instrument_id: str, funding_time: int) -> tuple[str, int]:
+    return (instrument_id, funding_time)
+
+
+def deduplicate_archive_events_v0(
+    events: Sequence[NormalizedFundingEventV0],
+) -> tuple[tuple[NormalizedFundingEventV0, ...], int]:
+    seen: dict[tuple[str, int], NormalizedFundingEventV0] = {}
+    duplicates = 0
+    for event in sorted(events, key=lambda item: (item.instrument_id, item.funding_time)):
+        key = _stable_event_key(event.instrument_id, event.funding_time)
+        if key in seen:
+            duplicates += 1
+            continue
+        seen[key] = event
+    ordered = tuple(seen[k] for k in sorted(seen))
+    return ordered, duplicates
+
+
+def compute_required_month_buckets_v0(
+    *,
+    period_start_utc: str,
+    period_end_exclusive_utc: str,
+    pre_window_hours: int = 5,
+) -> tuple[str, ...]:
+    """Return YYYY-MM month labels including adjacent months for warmup/end coverage."""
+    start_ms = _parse_utc_ms(period_start_utc) - pre_window_hours * 3_600_000
+    end_ms = _parse_utc_ms(period_end_exclusive_utc) + FUNDING_INTERVAL_MS
+
+    def _month_label(ms: int) -> str:
+        dt = datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+        return f"{dt.year}-{dt.month:02d}"
+
+    months: set[str] = set()
+    cursor = start_ms
+    while cursor < end_ms:
+        months.add(_month_label(cursor))
+        dt = datetime.fromtimestamp(cursor / 1000, tz=timezone.utc)
+        if dt.month == 12:
+            cursor = int(datetime(dt.year + 1, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+        else:
+            cursor = int(datetime(dt.year, dt.month + 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+    return tuple(sorted(months))
+
+
+def filter_events_for_period_v0(
+    events: Sequence[NormalizedFundingEventV0],
+    *,
+    period_start_utc: str,
+    period_end_exclusive_utc: str,
+    include_pre_warmup: bool = True,
+) -> tuple[tuple[NormalizedFundingEventV0, ...], int]:
+    start_ms = _parse_utc_ms(period_start_utc)
+    end_ms = _parse_utc_ms(period_end_exclusive_utc)
+    if include_pre_warmup:
+        start_ms -= FUNDING_INTERVAL_MS
+    kept: list[NormalizedFundingEventV0] = []
+    out_of_period = 0
+    for event in events:
+        if event.funding_time < start_ms or event.funding_time >= end_ms:
+            out_of_period += 1
+            continue
+        kept.append(event)
+    return tuple(kept), out_of_period
+
+
+def validate_funding_intervals_v0(events: Sequence[NormalizedFundingEventV0]) -> list[str]:
+    errors: list[str] = []
+    by_inst: dict[str, list[int]] = {}
+    for event in events:
+        by_inst.setdefault(event.instrument_id, []).append(event.funding_time)
+    for instrument_id, timestamps in by_inst.items():
+        ordered = sorted(timestamps)
+        for prev, curr in zip(ordered, ordered[1:]):
+            delta = curr - prev
+            if delta != FUNDING_INTERVAL_MS:
+                errors.append(
+                    f"{ArchiveValidationErrorCode.INVALID_INTERVAL.value}:"
+                    f"{instrument_id}:{_format_utc_ms(prev)}->{_format_utc_ms(curr)}"
+                )
+                break
+    return errors
+
+
+def parse_archive_csv_text_v0(
+    csv_text: str,
+    *,
+    source_file_digest: str,
+    expected_instrument_id: str | None = None,
+    retrieval_time: str | None = None,
+) -> ArchiveParseResultV0:
+    retrieval = retrieval_time or _utc_now_iso()
+    reader = csv.DictReader(io.StringIO(csv_text))
+    if reader.fieldnames is None:
+        return ArchiveParseResultV0(
+            events=(),
+            instrument_metadata=(),
+            validation_errors=(ArchiveValidationErrorCode.EMPTY_ARCHIVE.value,),
+            duplicate_keys_removed=0,
+            out_of_period_rows=0,
+            status=ArchiveIngestTerminalStatus.VALIDATION_FAILED,
+        )
+    header_errors = validate_archive_csv_headers_v0(reader.fieldnames)
+    if header_errors:
+        return ArchiveParseResultV0(
+            events=(),
+            instrument_metadata=(),
+            validation_errors=tuple(header_errors),
+            duplicate_keys_removed=0,
+            out_of_period_rows=0,
+            status=ArchiveIngestTerminalStatus.VALIDATION_FAILED,
+        )
+
+    raw_events: list[NormalizedFundingEventV0] = []
+    row_errors: list[str] = []
+    instruments_seen: set[str] = set()
+    for row_number, row in enumerate(reader, start=2):
+        row_errors.extend(
+            validate_archive_row_v0(
+                row, expected_instrument_id=expected_instrument_id, row_number=row_number
+            )
+        )
+        if row_errors:
+            continue
+        instrument = str(row[INSTRUMENT_FIELD]).strip()
+        instruments_seen.add(instrument)
+        raw_events.append(
+            NormalizedFundingEventV0(
+                instrument_id=instrument,
+                funding_rate=str(row[FUNDING_RATE_FIELD]).strip(),
+                funding_time=int(str(row[FUNDING_TIMESTAMP_FIELD]).strip()),
+                source_id=SOURCE_ID,
+                source_file_digest=source_file_digest,
+                source_row_number=row_number,
+                settlement_class=SETTLEMENT_CLASS,
+                rate_unit=RATE_UNIT,
+                interval_ms=FUNDING_INTERVAL_MS,
+                retrieval_time=retrieval,
+                schema_version=SCHEMA_VERSION,
+            )
+        )
+
+    if row_errors:
+        return ArchiveParseResultV0(
+            events=(),
+            instrument_metadata=(),
+            validation_errors=tuple(row_errors),
+            duplicate_keys_removed=0,
+            out_of_period_rows=0,
+            status=ArchiveIngestTerminalStatus.VALIDATION_FAILED,
+        )
+    if not raw_events:
+        return ArchiveParseResultV0(
+            events=(),
+            instrument_metadata=(),
+            validation_errors=(ArchiveValidationErrorCode.EMPTY_ARCHIVE.value,),
+            duplicate_keys_removed=0,
+            out_of_period_rows=0,
+            status=ArchiveIngestTerminalStatus.VALIDATION_FAILED,
+        )
+
+    deduped, dup_count = deduplicate_archive_events_v0(raw_events)
+    interval_errors = validate_funding_intervals_v0(deduped)
+    if interval_errors:
+        return ArchiveParseResultV0(
+            events=(),
+            instrument_metadata=(),
+            validation_errors=tuple(interval_errors),
+            duplicate_keys_removed=dup_count,
+            out_of_period_rows=0,
+            status=ArchiveIngestTerminalStatus.VALIDATION_FAILED,
+        )
+
+    metadata = tuple(
+        {"instrument_id": inst, "source_id": SOURCE_ID, "venue": SOURCE_VENUE}
+        for inst in sorted(instruments_seen)
+    )
+    return ArchiveParseResultV0(
+        events=deduped,
+        instrument_metadata=metadata,
+        validation_errors=(),
+        duplicate_keys_removed=dup_count,
+        out_of_period_rows=0,
+        status=ArchiveIngestTerminalStatus.COMPLETE,
+    )
+
+
+def parse_archive_zip_bytes_v0(
+    zip_bytes: bytes,
+    *,
+    expected_instrument_id: str | None = None,
+    retrieval_time: str | None = None,
+) -> ArchiveParseResultV0:
+    digest = _sha256_bytes(zip_bytes)
+    try:
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            csv_names = [n for n in zf.namelist() if n.lower().endswith(".csv")]
+            if not csv_names:
+                return ArchiveParseResultV0(
+                    events=(),
+                    instrument_metadata=(),
+                    validation_errors=(ArchiveValidationErrorCode.NO_CSV_IN_ZIP.value,),
+                    duplicate_keys_removed=0,
+                    out_of_period_rows=0,
+                    status=ArchiveIngestTerminalStatus.VALIDATION_FAILED,
+                )
+            if len(csv_names) > 1:
+                return ArchiveParseResultV0(
+                    events=(),
+                    instrument_metadata=(),
+                    validation_errors=(ArchiveValidationErrorCode.MULTIPLE_CSV_IN_ZIP.value,),
+                    duplicate_keys_removed=0,
+                    out_of_period_rows=0,
+                    status=ArchiveIngestTerminalStatus.VALIDATION_FAILED,
+                )
+            csv_text = zf.read(csv_names[0]).decode("utf-8")
+    except zipfile.BadZipFile:
+        return ArchiveParseResultV0(
+            events=(),
+            instrument_metadata=(),
+            validation_errors=("BAD_ZIP",),
+            duplicate_keys_removed=0,
+            out_of_period_rows=0,
+            status=ArchiveIngestTerminalStatus.VALIDATION_FAILED,
+        )
+    return parse_archive_csv_text_v0(
+        csv_text,
+        source_file_digest=digest,
+        expected_instrument_id=expected_instrument_id,
+        retrieval_time=retrieval_time,
+    )
+
+
+def archive_events_to_rest_compatible_rows_v0(
+    events: Sequence[NormalizedFundingEventV0],
+) -> list[dict[str, str]]:
+    return [
+        {
+            "instId": event.instrument_id,
+            "fundingTime": str(event.funding_time),
+            "fundingRate": event.funding_rate,
+        }
+        for event in events
+    ]
+
+
+def pit_join_funding_rate_v0(
+    events: Sequence[NormalizedFundingEventV0],
+    decision_bar_time_ms: int,
+) -> tuple[str | None, str | None]:
+    """Backward-asof join: funding_time <= decision_bar_time; no future values."""
+    from src.research.cross_sectional_bounded_panel_fetch_v0 import (
+        backward_asof_funding_lookup_v0,
+    )
+
+    rows = archive_events_to_rest_compatible_rows_v0(events)
+    rate = backward_asof_funding_lookup_v0(rows, decision_bar_time_ms)
+    if is_missing_funding_value_v0(rate):
+        return MISSING_FUNDING_VALUE, "MISSING_FUNDING_NO_PRIOR_SETTLEMENT"
+    return str(rate), None
+
+
+def build_score_input_provenance_record_v0(
+    event: NormalizedFundingEventV0,
+    *,
+    decision_bar_time_ms: int,
+) -> ConsumerProvenanceRecordV0:
+    return ConsumerProvenanceRecordV0(
+        consumer_domain="FUNDING_SCORE_INPUT",
+        provenance_marker=score_input_provenance_marker_v0(),
+        instrument_id=event.instrument_id,
+        funding_time=event.funding_time,
+        funding_rate=event.funding_rate,
+        source_file_digest=event.source_file_digest,
+        source_row_number=event.source_row_number,
+        join_reason=f"score_lag_observation:funding_time_lte_{decision_bar_time_ms}",
+    )
+
+
+def build_cashflow_provenance_record_v0(
+    event: NormalizedFundingEventV0,
+    *,
+    settlement_consumption_time_ms: int,
+) -> ConsumerProvenanceRecordV0:
+    return ConsumerProvenanceRecordV0(
+        consumer_domain="FUNDING_CASHFLOW",
+        provenance_marker=funding_cashflow_provenance_marker_v0(),
+        instrument_id=event.instrument_id,
+        funding_time=event.funding_time,
+        funding_rate=event.funding_rate,
+        source_file_digest=event.source_file_digest,
+        source_row_number=event.source_row_number,
+        join_reason=f"cashflow_settlement:{settlement_consumption_time_ms}",
+    )
+
+
+def check_full_panel_promotion_allowed_v0() -> tuple[bool, str]:
+    if HISTORICAL_UNIVERSE_LIFECYCLE_PASS:
+        return True, ""
+    return False, FULL_PANEL_PROMOTION_REQUIRES_HISTORICAL_UNIVERSE_LIFECYCLE_PASS
+
+
+def missing_funding_policy_contract_v0() -> dict[str, Any]:
+    return {
+        "missing_funding_value": MISSING_FUNDING_VALUE,
+        "missing_funding_is_zero": MISSING_FUNDING_IS_ZERO,
+        "missing_funding_fail_closed": MISSING_FUNDING_FAIL_CLOSED,
+    }

--- a/tests/fixtures/okx_historical_funding_archive_v0/PROVENANCE.txt
+++ b/tests/fixtures/okx_historical_funding_archive_v0/PROVENANCE.txt
@@ -1,0 +1,4 @@
+# Provenance-bound minimal OKX Historical Funding Archive fixtures.
+# Source: okx_historical_funding_archive_probe_v0_20260703T160811Z (read-only)
+# Inline CSV payloads live in tests/research/test_okx_historical_funding_archive_ingest_v0.py
+# (ETH_CSV_MINIMAL, SOL_CSV_MINIMAL) because repo-wide *.csv is gitignored.

--- a/tests/research/test_okx_historical_funding_archive_ingest_v0.py
+++ b/tests/research/test_okx_historical_funding_archive_ingest_v0.py
@@ -1,0 +1,394 @@
+"""Contract tests for OKX Historical Funding Archive ingest and missing policy v0."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts.ops.materialize_cross_sectional_funding_rate_carry_v0_bound_panel_funding_dataset_v0 import (
+    _funding_asof_lookup,
+)
+from src.research.cross_sectional_bounded_panel_fetch_v0 import (
+    compute_bounded_window_v0,
+)
+from src.research.cross_sectional_funding_rate_delta_momentum_scoring_v0 import (
+    FUNDING_DELTA_LOOKBACK_K,
+    FUNDING_SIGNAL_LAG,
+    FundingDeltaScoreStatusV0,
+    compute_instrument_funding_delta_score_v0,
+    funding_cashflow_provenance_marker_v0,
+    score_input_provenance_marker_v0,
+)
+from src.research.missing_funding_policy_v0 import (
+    MISSING_FUNDING_FAIL_CLOSED,
+    MISSING_FUNDING_IS_ZERO,
+    MISSING_FUNDING_VALUE,
+    reject_synthetic_zero_funding_fallback_v0,
+    resolve_funding_rate_or_missing_v0,
+)
+from src.research.okx_historical_funding_archive_ingest_v0 import (
+    FULL_PANEL_PROMOTION_REQUIRES_HISTORICAL_UNIVERSE_LIFECYCLE_PASS,
+    HISTORICAL_UNIVERSE_LIFECYCLE_PASS,
+    SOURCE_ACCESS_METHOD,
+    SOURCE_ID,
+    ArchiveAccessGuardReason,
+    ArchiveAccessGuardV0,
+    ArchiveIngestTerminalStatus,
+    ArchiveValidationErrorCode,
+    build_archive_cdn_url_v0,
+    build_cashflow_provenance_record_v0,
+    build_score_input_provenance_record_v0,
+    check_full_panel_promotion_allowed_v0,
+    compute_required_month_buckets_v0,
+    deduplicate_archive_events_v0,
+    filter_events_for_period_v0,
+    parse_archive_csv_text_v0,
+    parse_archive_zip_bytes_v0,
+    pit_join_funding_rate_v0,
+)
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "okx_historical_funding_archive_v0"
+
+ETH_CSV_MINIMAL = """\
+instrument_name,funding_rate,funding_time
+ETH-USDT-SWAP,0.000004880388991,1714492800000
+ETH-USDT-SWAP,0.0000017236956739,1714521600000
+ETH-USDT-SWAP,0.0000563153976033,1714550400000
+ETH-USDT-SWAP,-0.0000550400994381,1714579200000
+ETH-USDT-SWAP,0.0001388957663224,1714608000000
+ETH-USDT-SWAP,0.000100000136433,1714636800000
+"""
+
+SOL_CSV_MINIMAL = """\
+instrument_name,funding_rate,funding_time
+SOL-USDT-SWAP,0.0000647942365645,1714492800000
+SOL-USDT-SWAP,-0.0000340383839361,1714521600000
+SOL-USDT-SWAP,0.0000123456789012,1714550400000
+SOL-USDT-SWAP,0.0000234567890123,1714579200000
+SOL-USDT-SWAP,0.0000456789012345,1714608000000
+SOL-USDT-SWAP,0.0000567890123456,1714636800000
+"""
+PROBE_ETH_ZIP = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "probes/okx_historical_funding_archive_probe_v0_20260703T160811Z/"
+    "raw/ETH-USDT_ETH-USDT-SWAP-fundingrates-2024-05.zip"
+)
+PROBE_SOL_ZIP = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "probes/okx_historical_funding_archive_probe_v0_20260703T160811Z/"
+    "raw/SOL-USDT_SOL-USDT-SWAP-fundingrates-2024-05.zip"
+)
+
+
+def _ms(utc: str) -> int:
+    return int(
+        datetime.strptime(utc, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp() * 1000
+    )
+
+
+def _csv_to_zip(csv_text: str, inner_name: str = "TEST-SWAP-fundingrates-2024-05.csv") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(inner_name, csv_text)
+    return buf.getvalue()
+
+
+def _digest_placeholder() -> str:
+    return "0" * 64
+
+
+@pytest.fixture
+def eth_csv() -> str:
+    return ETH_CSV_MINIMAL
+
+
+@pytest.fixture
+def sol_csv() -> str:
+    return SOL_CSV_MINIMAL
+
+
+def test_missing_funding_policy_contract() -> None:
+    assert MISSING_FUNDING_VALUE is None
+    assert MISSING_FUNDING_IS_ZERO is False
+    assert MISSING_FUNDING_FAIL_CLOSED is True
+    assert resolve_funding_rate_or_missing_v0(raw_value=None) is None
+    with pytest.raises(ValueError):
+        reject_synthetic_zero_funding_fallback_v0("0.0")
+
+
+def test_source_binding_constants() -> None:
+    assert SOURCE_ID == "OKX_HISTORICAL_FUNDING_ARCHIVE"
+    assert SOURCE_ACCESS_METHOD == "HISTORICAL_DATA_PORTAL_ARCHIVE"
+
+
+def test_valid_eth_archive_accepted(eth_csv: str) -> None:
+    result = parse_archive_csv_text_v0(
+        eth_csv,
+        source_file_digest=_digest_placeholder(),
+        expected_instrument_id="ETH-USDT-SWAP",
+    )
+    assert result.status is ArchiveIngestTerminalStatus.COMPLETE
+    assert len(result.events) == 6
+    assert result.events[0].instrument_id == "ETH-USDT-SWAP"
+    assert result.events[0].settlement_class == "SETTLEMENT"
+
+
+def test_valid_sol_archive_accepted(sol_csv: str) -> None:
+    result = parse_archive_csv_text_v0(
+        sol_csv,
+        source_file_digest=_digest_placeholder(),
+        expected_instrument_id="SOL-USDT-SWAP",
+    )
+    assert result.status is ArchiveIngestTerminalStatus.COMPLETE
+    assert all(event.instrument_id == "SOL-USDT-SWAP" for event in result.events)
+
+
+@pytest.mark.parametrize(
+    ("csv_text", "expected_code"),
+    [
+        (
+            "instrument_name,funding_time\nETH-USDT-SWAP,1714492800000\n",
+            ArchiveValidationErrorCode.MISSING_FUNDING_RATE,
+        ),
+        (
+            "instrument_name,funding_rate\nETH-USDT-SWAP,0.0001\n",
+            ArchiveValidationErrorCode.MISSING_FUNDING_TIME,
+        ),
+        (
+            "instrument_name,funding_rate,funding_time,nextFundingRate\n"
+            "ETH-USDT-SWAP,0.0001,1714492800000,0.0002\n",
+            ArchiveValidationErrorCode.FORECAST_COLUMN_PRESENT,
+        ),
+        (
+            "instrument_name,funding_rate,funding_time\nSOL-USDT-SWAP,0.0001,1714492800000\n",
+            ArchiveValidationErrorCode.WRONG_INSTRUMENT,
+        ),
+        (
+            "instrument_name,funding_rate,funding_time\nBTC-USDT-SWAP,0.0001,1714492800000\n",
+            ArchiveValidationErrorCode.BITCOIN_INSTRUMENT,
+        ),
+        (
+            "instrument_name,funding_rate,funding_time\nETH-USDT-SPOT,0.0001,1714492800000\n",
+            ArchiveValidationErrorCode.SPOT_OR_DELIVERY_INSTRUMENT,
+        ),
+        (
+            "instrument_name,funding_rate,funding_time\nETH-USDT-SWAP,not_a_rate,1714492800000\n",
+            ArchiveValidationErrorCode.INVALID_RATE_UNIT,
+        ),
+        (
+            "instrument_name,funding_rate,funding_time\nETH-USDT-SWAP,0.0001,not_ms\n",
+            ArchiveValidationErrorCode.INVALID_TIMESTAMP_TYPE,
+        ),
+    ],
+)
+def test_archive_schema_rejections(
+    csv_text: str, expected_code: ArchiveValidationErrorCode
+) -> None:
+    result = parse_archive_csv_text_v0(
+        csv_text,
+        source_file_digest=_digest_placeholder(),
+        expected_instrument_id="ETH-USDT-SWAP",
+    )
+    assert result.status is ArchiveIngestTerminalStatus.VALIDATION_FAILED
+    assert any(expected_code.value in err for err in result.validation_errors)
+
+
+def test_probe_eth_zip_roundtrip_when_available() -> None:
+    if not PROBE_ETH_ZIP.is_file():
+        pytest.skip("probe bundle not available on this machine")
+    result = parse_archive_zip_bytes_v0(
+        PROBE_ETH_ZIP.read_bytes(),
+        expected_instrument_id="ETH-USDT-SWAP",
+    )
+    assert result.status is ArchiveIngestTerminalStatus.COMPLETE
+    assert len(result.events) >= 90
+
+
+def test_probe_sol_zip_roundtrip_when_available() -> None:
+    if not PROBE_SOL_ZIP.is_file():
+        pytest.skip("probe bundle not available on this machine")
+    result = parse_archive_zip_bytes_v0(
+        PROBE_SOL_ZIP.read_bytes(),
+        expected_instrument_id="SOL-USDT-SWAP",
+    )
+    assert result.status is ArchiveIngestTerminalStatus.COMPLETE
+
+
+def test_pre_warmup_row_allowed_and_end_exclusive_filter(eth_csv: str) -> None:
+    parsed = parse_archive_csv_text_v0(eth_csv, source_file_digest=_digest_placeholder())
+    filtered, out_of_period = filter_events_for_period_v0(
+        parsed.events,
+        period_start_utc="2024-05-01T00:00:00Z",
+        period_end_exclusive_utc="2024-09-01T00:00:00Z",
+        include_pre_warmup=True,
+    )
+    assert any(event.funding_time == _ms("2024-04-30T16:00:00Z") for event in filtered)
+    assert all(event.funding_time < _ms("2024-09-01T00:00:00Z") for event in filtered)
+    assert out_of_period >= 0
+
+
+def test_month_buckets_include_adjacent_months() -> None:
+    months = compute_required_month_buckets_v0(
+        period_start_utc="2024-05-01T00:00:00Z",
+        period_end_exclusive_utc="2024-09-01T00:00:00Z",
+        pre_window_hours=5,
+    )
+    assert "2024-04" in months
+    assert "2024-05" in months
+    assert "2024-08" in months
+
+
+def test_deduplicate_month_boundary_events(eth_csv: str) -> None:
+    parsed = parse_archive_csv_text_v0(eth_csv, source_file_digest=_digest_placeholder())
+    duplicate = parsed.events[0]
+    merged = parsed.events + (duplicate,)
+    deduped, removed = deduplicate_archive_events_v0(merged)
+    assert removed == 1
+    assert len(deduped) == len(parsed.events)
+
+
+def test_pit_join_no_future_funding(eth_csv: str) -> None:
+    parsed = parse_archive_csv_text_v0(eth_csv, source_file_digest=_digest_placeholder())
+    bar_ts = _ms("2024-05-01T00:00:00Z")
+    rate, reason = pit_join_funding_rate_v0(parsed.events, bar_ts)
+    assert rate is not None
+    assert reason is None
+    chosen_times = [event.funding_time for event in parsed.events if event.funding_time <= bar_ts]
+    assert chosen_times
+    assert max(chosen_times) <= bar_ts
+
+
+def test_pit_join_missing_when_no_prior_settlement(eth_csv: str) -> None:
+    parsed = parse_archive_csv_text_v0(eth_csv, source_file_digest=_digest_placeholder())
+    bar_ts = _ms("2024-04-01T00:00:00Z")
+    rate, reason = pit_join_funding_rate_v0(parsed.events, bar_ts)
+    assert rate is None
+    assert reason == "MISSING_FUNDING_NO_PRIOR_SETTLEMENT"
+
+
+def test_carry_materializer_has_no_zero_fallback_in_source() -> None:
+    from scripts.ops import (
+        materialize_cross_sectional_funding_rate_carry_v0_bound_panel_funding_dataset_v0 as mod,
+    )
+
+    source = Path(mod.__file__).read_text(encoding="utf-8")
+    assert 'return "0.0"' not in source
+    assert '"0.0"' not in source
+
+
+def test_carry_materializer_lookup_blocks_zero_fallback() -> None:
+    rate, reason = _funding_asof_lookup(
+        funding_rows=[], bar_timestamp_ms=_ms("2024-05-01T00:00:00Z")
+    )
+    assert rate is None
+    assert reason is not None
+
+
+def test_score_missing_t_minus_1_blocks() -> None:
+    rates: list[float | None] = [0.0001, None, 0.0002, 0.0003, 0.0004, 0.0005, 0.0006]
+    result = compute_instrument_funding_delta_score_v0(
+        "ETH-USDT-SWAP",
+        rates,
+        epoch_index=6,
+    )
+    assert result is not None
+    assert result.score_status is FundingDeltaScoreStatusV0.MISSING_REQUIRED_FUNDING_HISTORY
+    assert result.signal_eligible is False
+
+
+def test_score_missing_t_minus_1_minus_k_blocks() -> None:
+    rates: list[float | None] = [None, 0.0001, 0.0002, 0.0003, 0.0004, 0.0005, 0.0006]
+    result = compute_instrument_funding_delta_score_v0(
+        "ETH-USDT-SWAP",
+        rates,
+        epoch_index=5,
+    )
+    assert result is not None
+    assert result.score_status is FundingDeltaScoreStatusV0.MISSING_REQUIRED_FUNDING_HISTORY
+    assert result.signal_eligible is False
+
+
+def test_score_ok_uses_t_minus_1_and_t_minus_1_minus_k_indices() -> None:
+    rates = [float(i) * 0.0001 for i in range(10)]
+    epoch_index = 6
+    result = compute_instrument_funding_delta_score_v0(
+        "ETH-USDT-SWAP",
+        rates,
+        epoch_index=epoch_index,
+    )
+    assert result is not None
+    assert result.signal_eligible is True
+    assert result.funding_rate_lag == rates[epoch_index - FUNDING_SIGNAL_LAG]
+    assert (
+        result.funding_rate_lookback
+        == rates[epoch_index - FUNDING_SIGNAL_LAG - FUNDING_DELTA_LOOKBACK_K]
+    )
+
+
+def test_score_cashflow_provenance_separation(eth_csv: str) -> None:
+    parsed = parse_archive_csv_text_v0(eth_csv, source_file_digest=_digest_placeholder())
+    event = parsed.events[1]
+    bar_ts = event.funding_time + 3_600_000
+    score_record = build_score_input_provenance_record_v0(event, decision_bar_time_ms=bar_ts)
+    cashflow_record = build_cashflow_provenance_record_v0(
+        event,
+        settlement_consumption_time_ms=event.funding_time,
+    )
+    assert score_record.consumer_domain != cashflow_record.consumer_domain
+    assert score_record.provenance_marker == score_input_provenance_marker_v0()
+    assert cashflow_record.provenance_marker == funding_cashflow_provenance_marker_v0()
+    assert score_record.provenance_marker != cashflow_record.provenance_marker
+    assert score_record.source_file_digest == cashflow_record.source_file_digest
+    assert score_record.join_reason != cashflow_record.join_reason
+
+
+def test_archive_access_guards_fail_closed() -> None:
+    guard = ArchiveAccessGuardV0(
+        max_instruments=1,
+        max_months=1,
+        max_http_requests=1,
+        max_total_bytes=10,
+        max_runtime_seconds=60,
+    )
+    guard.instruments_used = 1
+    assert guard.check_instruments() == ArchiveAccessGuardReason.MAX_INSTRUMENTS.value
+    guard = ArchiveAccessGuardV0(
+        max_instruments=5,
+        max_months=1,
+        max_http_requests=5,
+        max_total_bytes=10,
+        max_runtime_seconds=60,
+    )
+    guard.months_used = 1
+    assert guard.check_months() == ArchiveAccessGuardReason.MAX_MONTHS.value
+    reason = guard.record_request(20)
+    assert reason == ArchiveAccessGuardReason.MAX_TOTAL_BYTES.value
+
+
+def test_lifecycle_blocker_prevents_full_panel_promotion() -> None:
+    assert HISTORICAL_UNIVERSE_LIFECYCLE_PASS is False
+    allowed, blocker = check_full_panel_promotion_allowed_v0()
+    assert allowed is False
+    assert blocker == FULL_PANEL_PROMOTION_REQUIRES_HISTORICAL_UNIVERSE_LIFECYCLE_PASS
+
+
+def test_cdn_url_contract() -> None:
+    url = build_archive_cdn_url_v0(instrument_id="ETH-USDT-SWAP", year=2024, month=5)
+    assert "202405" in url
+    assert url.endswith("ETH-USDT-SWAP-fundingrates-2024-05.zip")
+
+
+def test_zip_parse_from_minimal_fixture(eth_csv: str) -> None:
+    result = parse_archive_zip_bytes_v0(
+        _csv_to_zip(eth_csv), expected_instrument_id="ETH-USDT-SWAP"
+    )
+    assert result.status is ArchiveIngestTerminalStatus.COMPLETE
+
+
+def test_bounded_window_pre_window_matches_scoring_requirements() -> None:
+    window = compute_bounded_window_v0()
+    assert window.required_pre_window_hours == FUNDING_DELTA_LOOKBACK_K + FUNDING_SIGNAL_LAG


### PR DESCRIPTION
## Summary
- Implements bounded OKX Historical Funding Archive ingest adapter (`okx_historical_funding_archive_ingest_v0`) with schema validation, month-boundary contracts, download guards, and normalized settlement events.
- Consolidates missing-funding semantics (`missing_funding_policy_v0`) and removes the carry materializer `"0.0"` fallback in favor of explicit `None` + reason codes.
- Adds fail-closed delta-momentum score status (`MISSING_REQUIRED_FUNDING_HISTORY`) and focused contract tests; no full panel fetch or economic evaluation.

## Test plan
- [x] `pytest tests/research/test_okx_historical_funding_archive_ingest_v0.py` (30 passed)
- [x] Regression: bounded panel fetch, delta momentum binding, carry binding
- [x] `ruff format --check` / `ruff check` on changed Python files
- [x] CI selector: PR_BOUNDED_FULL (central src path)
- [ ] GitHub CI confirmation


Made with [Cursor](https://cursor.com)