### PR TITLE
fix(csf-rdm-v0): runtime origin/main SHA binding for ops runner

### DIFF
--- a/scripts/ops/run_cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import time
@@ -33,7 +34,8 @@ from src.research.cross_sectional_funding_rate_delta_momentum_v0_bound_panel_dat
 from src.research.cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0 import (  # noqa: E402
     AUTHORITY_EFFECT,
     EXECUTION_VERSION,
-    EXPECTED_ORIGIN_MAIN_SHA,
+    FAIL_CLOSED_EXPECTED_ORIGIN_MAIN_SHA_BINDING_MISSING,
+    FAIL_CLOSED_ORIGIN_MAIN_SHA_MISMATCH,
     FIXTURE_DATA_DIGEST,
     INFRASTRUCTURE_GO_TOKEN,
     GO_TOKEN,
@@ -41,8 +43,10 @@ from src.research.cross_sectional_funding_rate_delta_momentum_v0_offline_economi
     execution_result_to_dict,
     load_ohlcv_panel_series_for_backtest,
     load_versioned_research_binding_v0,
+    origin_main_sha_guard_to_dict,
     run_full_offline_economic_evaluation_v0,
     verify_execution_start_state_v0,
+    verify_origin_main_sha_guard_v0,
 )
 from src.research.cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_scope_ratification_v0 import (  # noqa: E402
     materialize_funding_delta_momentum_offline_economic_evaluation_scope_ratification_v0,
@@ -72,16 +76,6 @@ SCOPE_CLASSIFICATION = (
 def _die(msg: str, code: int = 2) -> None:
     print(msg, file=sys.stderr)
     raise SystemExit(code)
-
-
-def _resolve_origin_main(repo_root: Path) -> str:
-    result = subprocess.run(
-        ["git", "-C", str(repo_root), "rev-parse", "origin/main"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    return result.stdout.strip() if result.returncode == 0 else ""
 
 
 def _primary_worktree_snapshot(primary_worktree: Path) -> dict[str, Any]:
@@ -117,12 +111,18 @@ def run_offline_economic_evaluation_scope_v0(
     primary_worktree: Path,
     staging_root: Path,
     skip_fetch: bool = False,
+    expected_origin_main_sha: str | None = None,
 ) -> dict[str, Any]:
     start_monotonic = time.monotonic()
     if confirm != CONFIRM_GO:
         _die(f"ERR: confirm_go_token_required:{CONFIRM_GO}")
 
-    origin_main = _resolve_origin_main(_REPO_ROOT)
+    sha_guard = verify_origin_main_sha_guard_v0(
+        repo_root=_REPO_ROOT,
+        expected_origin_main_sha=expected_origin_main_sha,
+        env=os.environ,
+    )
+    origin_main = sha_guard.actual_origin_main_sha
     primary_before = _primary_worktree_snapshot(primary_worktree)
     ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     bundle_dir = (
@@ -134,8 +134,13 @@ def run_offline_economic_evaluation_scope_v0(
 
     prechecks = {
         "origin_main": origin_main,
-        "expected_origin_main": EXPECTED_ORIGIN_MAIN_SHA,
-        "origin_main_match": origin_main == EXPECTED_ORIGIN_MAIN_SHA,
+        "origin_main_sha_guard": origin_main_sha_guard_to_dict(sha_guard),
+        "expected_origin_main_sha": sha_guard.expected_origin_main_sha,
+        "actual_head_sha": sha_guard.actual_head_sha,
+        "actual_origin_main_sha": sha_guard.actual_origin_main_sha,
+        "binding_source": sha_guard.binding_source,
+        "sha_guard_status": sha_guard.sha_guard_status,
+        "origin_main_match": sha_guard.passed,
         "primary_worktree_head": primary_before["head"],
         "primary_worktree_dirty_count": primary_before["dirty_count"],
         "primary_worktree_dirty_files": primary_before["dirty_files"],
@@ -148,8 +153,12 @@ def run_offline_economic_evaluation_scope_v0(
         json.dumps(prechecks, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-    if not prechecks["origin_main_match"]:
-        _die("ERR: origin_main_mismatch_fail_closed")
+    if not sha_guard.passed:
+        if sha_guard.sha_guard_status == FAIL_CLOSED_EXPECTED_ORIGIN_MAIN_SHA_BINDING_MISSING:
+            _die(f"ERR:{FAIL_CLOSED_EXPECTED_ORIGIN_MAIN_SHA_BINDING_MISSING}")
+        if sha_guard.sha_guard_status == FAIL_CLOSED_ORIGIN_MAIN_SHA_MISMATCH:
+            _die(f"ERR:{FAIL_CLOSED_ORIGIN_MAIN_SHA_MISMATCH}")
+        _die(f"ERR:origin_main_sha_guard_failed:{sha_guard.fail_reasons}")
 
     versioned_binding = load_versioned_research_binding_v0(_REPO_ROOT)
     ratification = (
@@ -382,6 +391,7 @@ def main() -> None:
     parser.add_argument("--primary-worktree", type=Path, required=True)
     parser.add_argument("--staging-root", type=Path, default=DEFAULT_STAGING_ROOT)
     parser.add_argument("--skip-fetch", action="store_true")
+    parser.add_argument("--expected-origin-main-sha", default=None)
     args = parser.parse_args()
     result = run_offline_economic_evaluation_scope_v0(
         confirm=args.confirm,
@@ -389,6 +399,7 @@ def main() -> None:
         primary_worktree=args.primary_worktree,
         staging_root=args.staging_root,
         skip_fetch=args.skip_fetch,
+        expected_origin_main_sha=args.expected_origin_main_sha,
     )
     print(json.dumps(result, indent=2, sort_keys=True))
 

--- a/src/research/cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import subprocess
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -95,7 +97,12 @@ INFRASTRUCTURE_GO_TOKEN = (
 )
 _DEFAULT_INFRASTRUCTURE_GO = INFRASTRUCTURE_GO_TOKEN
 ALLOWED_EXECUTION_GO_TOKENS: frozenset[str] = frozenset({GO_TOKEN})
-EXPECTED_ORIGIN_MAIN_SHA = "525cd82535cd7c65f4cdbca282094e4fc174b0fe"
+ORIGIN_MAIN_SHA_BINDING_ENV_VAR = "EXPECTED_ORIGIN_MAIN_SHA"
+FAIL_CLOSED_EXPECTED_ORIGIN_MAIN_SHA_BINDING_MISSING = (
+    "FAIL_CLOSED_EXPECTED_ORIGIN_MAIN_SHA_BINDING_MISSING"
+)
+FAIL_CLOSED_ORIGIN_MAIN_SHA_MISMATCH = "FAIL_CLOSED_ORIGIN_MAIN_SHA_MISMATCH"
+SHA_GUARD_STATUS_PASS = "PASS"
 FIXTURE_DATA_DIGEST = "0000000000000000000000000000000000000000000000000000000000000000"
 REASON_FIXTURE_LEAKAGE = "FIXTURE_DATA_DIGEST_IN_ECONOMIC_EVALUATION"
 CONFIG_REL_PATH_OPS = (
@@ -144,6 +151,17 @@ class StartStateVerificationResultV0:
 
 
 @dataclass(frozen=True)
+class OriginMainShaGuardResultV0:
+    passed: bool
+    sha_guard_status: str
+    expected_origin_main_sha: str
+    actual_head_sha: str
+    actual_origin_main_sha: str
+    binding_source: str
+    fail_reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class InfrastructureReadinessResultV0:
     status: InfrastructureTerminalStatus
     execution_infrastructure_complete: bool
@@ -182,12 +200,110 @@ def load_ops_evaluation_config_v0(repo_root: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def resolve_expected_origin_main_sha_binding_v0(
+    *,
+    explicit_sha: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> tuple[str, str]:
+    """Resolve expected origin/main SHA from explicit CLI binding or environment."""
+    if explicit_sha and explicit_sha.strip():
+        return explicit_sha.strip(), "cli_argument"
+    env_map = env if env is not None else os.environ
+    env_sha = str(env_map.get(ORIGIN_MAIN_SHA_BINDING_ENV_VAR, "")).strip()
+    if env_sha:
+        return env_sha, "environment_variable"
+    return "", ""
+
+
+def resolve_actual_repo_shas_v0(repo_root: Path) -> tuple[str, str]:
+    head_result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    origin_result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "origin/main"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    actual_head = head_result.stdout.strip() if head_result.returncode == 0 else ""
+    actual_origin_main = origin_result.stdout.strip() if origin_result.returncode == 0 else ""
+    return actual_head, actual_origin_main
+
+
+def verify_origin_main_sha_guard_v0(
+    *,
+    repo_root: Path,
+    expected_origin_main_sha: str | None = None,
+    binding_source: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> OriginMainShaGuardResultV0:
+    """Fail-closed guard: runtime binding must match actual origin/main."""
+    resolved_expected, resolved_binding_source = resolve_expected_origin_main_sha_binding_v0(
+        explicit_sha=expected_origin_main_sha,
+        env=env,
+    )
+    if binding_source:
+        resolved_binding_source = binding_source
+    actual_head, actual_origin_main = resolve_actual_repo_shas_v0(repo_root)
+
+    if not resolved_expected:
+        return OriginMainShaGuardResultV0(
+            passed=False,
+            sha_guard_status=FAIL_CLOSED_EXPECTED_ORIGIN_MAIN_SHA_BINDING_MISSING,
+            expected_origin_main_sha="",
+            actual_head_sha=actual_head,
+            actual_origin_main_sha=actual_origin_main,
+            binding_source=resolved_binding_source,
+            fail_reasons=(FAIL_CLOSED_EXPECTED_ORIGIN_MAIN_SHA_BINDING_MISSING,),
+        )
+
+    if resolved_expected != actual_origin_main:
+        return OriginMainShaGuardResultV0(
+            passed=False,
+            sha_guard_status=FAIL_CLOSED_ORIGIN_MAIN_SHA_MISMATCH,
+            expected_origin_main_sha=resolved_expected,
+            actual_head_sha=actual_head,
+            actual_origin_main_sha=actual_origin_main,
+            binding_source=resolved_binding_source,
+            fail_reasons=(
+                FAIL_CLOSED_ORIGIN_MAIN_SHA_MISMATCH,
+                f"expected={resolved_expected}",
+                f"actual_origin_main={actual_origin_main}",
+            ),
+        )
+
+    return OriginMainShaGuardResultV0(
+        passed=True,
+        sha_guard_status=SHA_GUARD_STATUS_PASS,
+        expected_origin_main_sha=resolved_expected,
+        actual_head_sha=actual_head,
+        actual_origin_main_sha=actual_origin_main,
+        binding_source=resolved_binding_source,
+        fail_reasons=(),
+    )
+
+
+def origin_main_sha_guard_to_dict(guard: OriginMainShaGuardResultV0) -> dict[str, Any]:
+    return {
+        "sha_guard_status": guard.sha_guard_status,
+        "expected_origin_main_sha": guard.expected_origin_main_sha,
+        "actual_head_sha": guard.actual_head_sha,
+        "actual_origin_main_sha": guard.actual_origin_main_sha,
+        "binding_source": guard.binding_source,
+        "passed": guard.passed,
+        "fail_reasons": list(guard.fail_reasons),
+    }
+
+
 def verify_execution_start_state_v0(
     *,
     repo_root: Path,
     ratification: Mapping[str, Any],
     versioned_binding: Mapping[str, Any] | None = None,
-    origin_main_sha: str = EXPECTED_ORIGIN_MAIN_SHA,
+    origin_main_sha: str = "",
 ) -> StartStateVerificationResultV0:
     reasons: list[str] = []
     envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
@@ -1082,6 +1198,8 @@ __all__ = [
     "CrossSectionalRobustnessMetricsV0",
     "EconomicClassification",
     "ExecutionTerminalStatus",
+    "FAIL_CLOSED_EXPECTED_ORIGIN_MAIN_SHA_BINDING_MISSING",
+    "FAIL_CLOSED_ORIGIN_MAIN_SHA_MISMATCH",
     "FIXTURE_DATA_DIGEST",
     "FullEconomicEvaluationResultV0",
     "GO_TOKEN",
@@ -1089,8 +1207,11 @@ __all__ = [
     "InfrastructureReadinessResultV0",
     "InfrastructureTerminalStatus",
     "MaterializationTerminalStatus",
+    "ORIGIN_MAIN_SHA_BINDING_ENV_VAR",
+    "OriginMainShaGuardResultV0",
     "RUNTIME_EFFECT",
     "RUNNER_SCRIPT",
+    "SHA_GUARD_STATUS_PASS",
     "entrypoint_result_to_dict",
     "execution_result_to_dict",
     "load_ops_evaluation_config_v0",
@@ -1098,9 +1219,13 @@ __all__ = [
     "materialization_result_to_dict",
     "materialize_economic_viability_evidence",
     "materialize_infrastructure_summary_v0",
+    "origin_main_sha_guard_to_dict",
+    "resolve_actual_repo_shas_v0",
+    "resolve_expected_origin_main_sha_binding_v0",
     "run_contract_smoke_evaluation_v0",
     "run_full_evaluation_entrypoint_dry_run_v1",
     "run_full_offline_economic_evaluation_v0",
     "verify_execution_start_state_v0",
     "verify_full_evaluation_precheck_v1",
+    "verify_origin_main_sha_guard_v0",
 ]

--- a/tests/research/test_cross_sectional_funding_rate_delta_momentum_v0_ops_runner_pre_eval_blocker_fix_v0.py
+++ b/tests/research/test_cross_sectional_funding_rate_delta_momentum_v0_ops_runner_pre_eval_blocker_fix_v0.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 from pathlib import Path
 
 from src.research.cross_sectional_funding_rate_delta_momentum_v0_bound_panel_dataset_materialization_v0 import (
@@ -10,13 +11,20 @@ from src.research.cross_sectional_funding_rate_delta_momentum_v0_bound_panel_dat
     materialize_bound_funding_panel_dataset_v0,
 )
 from src.research.cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0 import (
-    EXPECTED_ORIGIN_MAIN_SHA,
+    FAIL_CLOSED_EXPECTED_ORIGIN_MAIN_SHA_BINDING_MISSING,
+    FAIL_CLOSED_ORIGIN_MAIN_SHA_MISMATCH,
+    ORIGIN_MAIN_SHA_BINDING_ENV_VAR,
+    SHA_GUARD_STATUS_PASS,
+    resolve_actual_repo_shas_v0,
+    verify_origin_main_sha_guard_v0,
 )
 from src.research.cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0 import (
     materialize_versioned_research_binding_v0,
 )
 
-EXPECTED_ORIGIN_MAIN = "525cd82535cd7c65f4cdbca282094e4fc174b0fe"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+STALE_SHA_0179009507 = "0179009507d0841e155adc60fa347a3208329670"
+STALE_SHA_525CD825 = "525cd82535cd7c65f4cdbca282094e4fc174b0fe"
 MISSING_STAGING_ROOT = Path(
     "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
     "datasets/admissible_futures/"
@@ -24,8 +32,66 @@ MISSING_STAGING_ROOT = Path(
 )
 
 
-def test_expected_origin_main_sha_matches_post_pr4809_merge_head() -> None:
-    assert EXPECTED_ORIGIN_MAIN_SHA == EXPECTED_ORIGIN_MAIN
+def test_missing_origin_main_sha_binding_fails_closed() -> None:
+    guard = verify_origin_main_sha_guard_v0(
+        repo_root=_REPO_ROOT,
+        expected_origin_main_sha=None,
+        env={},
+    )
+    assert guard.passed is False
+    assert guard.sha_guard_status == FAIL_CLOSED_EXPECTED_ORIGIN_MAIN_SHA_BINDING_MISSING
+    assert FAIL_CLOSED_EXPECTED_ORIGIN_MAIN_SHA_BINDING_MISSING in guard.fail_reasons
+
+
+def test_wrong_origin_main_sha_binding_fails_closed() -> None:
+    guard = verify_origin_main_sha_guard_v0(
+        repo_root=_REPO_ROOT,
+        expected_origin_main_sha=STALE_SHA_525CD825,
+        binding_source="test_fixture",
+    )
+    assert guard.passed is False
+    assert guard.sha_guard_status == FAIL_CLOSED_ORIGIN_MAIN_SHA_MISMATCH
+    assert FAIL_CLOSED_ORIGIN_MAIN_SHA_MISMATCH in guard.fail_reasons
+    assert guard.expected_origin_main_sha == STALE_SHA_525CD825
+    assert guard.actual_origin_main_sha != STALE_SHA_525CD825
+
+
+def test_matching_origin_main_sha_binding_reaches_dataset_gate() -> None:
+    _, actual_origin_main = resolve_actual_repo_shas_v0(_REPO_ROOT)
+    guard = verify_origin_main_sha_guard_v0(
+        repo_root=_REPO_ROOT,
+        expected_origin_main_sha=actual_origin_main,
+        binding_source="test_fixture",
+    )
+    assert guard.passed is True
+    assert guard.sha_guard_status == SHA_GUARD_STATUS_PASS
+
+    binding = materialize_versioned_research_binding_v0()
+    result = materialize_bound_funding_panel_dataset_v0(
+        MISSING_STAGING_ROOT,
+        period_binding=binding["period_binding"],
+        expected_data_digest=binding["data_digest"],
+    )
+    assert result.status is MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED
+    assert "MISSING_PANEL_STAGING" in result.reason_codes
+
+
+def test_runner_context_has_no_hardcoded_stale_origin_main_sha() -> None:
+    execution_mod = importlib.import_module(
+        "src.research.cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0"
+    )
+    runner_mod = importlib.import_module(
+        "scripts.ops.run_cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0"
+    )
+    execution_source = inspect.getsource(execution_mod)
+    runner_source = inspect.getsource(runner_mod)
+
+    assert STALE_SHA_0179009507 not in execution_source
+    assert STALE_SHA_525CD825 not in execution_source
+    assert STALE_SHA_0179009507 not in runner_source
+    assert STALE_SHA_525CD825 not in runner_source
+    assert not hasattr(execution_mod, "EXPECTED_ORIGIN_MAIN_SHA")
+    assert ORIGIN_MAIN_SHA_BINDING_ENV_VAR == "EXPECTED_ORIGIN_MAIN_SHA"
 
 
 def test_ops_runner_materialize_import_contract() -> None:


### PR DESCRIPTION
## Summary
- Entfernt die hardcodierte `EXPECTED_ORIGIN_MAIN_SHA`-Konstante (`525cd825…`) aus dem cross-sectional-funding-rate-delta-momentum-v0 Ops-Runner-Kontext.
- Führt einen fail-closed Runtime-Binding-Mechanismus ein: erwarteter SHA via `--expected-origin-main-sha` oder Env `EXPECTED_ORIGIN_MAIN_SHA`.
- Persistiert `expected_origin_main_sha`, `actual_head_sha`, `actual_origin_main_sha`, `binding_source` und `sha_guard_status` in Preflight-Evidence.
- Dataset-Gate und `materialize_bound_panel_funding_dataset_v0`-Import-Contract bleiben unverändert fail-closed.

## Test plan
- [x] `test_missing_origin_main_sha_binding_fails_closed`
- [x] `test_wrong_origin_main_sha_binding_fails_closed`
- [x] `test_matching_origin_main_sha_binding_reaches_dataset_gate`
- [x] `test_runner_context_has_no_hardcoded_stale_origin_main_sha`
- [x] `test_ops_runner_materialize_import_contract`
- [x] `test_missing_extended_chronological_staging_remains_fail_closed`
- [x] `ruff format --check` / `ruff check` auf geänderten Dateien
- [x] Keine Dataset-Materialization, kein Funding-Fetch, keine Evaluation


Made with [Cursor](https://cursor.com)