### PR TITLE
research: gate extended chronological materialization fetch scope

### DIFF
--- a/scripts/ops/run_csf_rdm_v0_extended_chronological_v1_staging_funding_panel_materialization_v0.py
+++ b/scripts/ops/run_csf_rdm_v0_extended_chronological_v1_staging_funding_panel_materialization_v0.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Run CSF/RDM v0 extended_chronological_v1 staging and bound funding panel materialization.
 
-Bounded dataset/funding readiness scope only. Materializes or assesses canonical staging,
-runs PR #4812 preflight gate, and persists durable evidence. No economic evaluation.
+Bounded dataset/funding readiness scope only. Assesses canonical staging readiness,
+runs PR #4812 preflight gate, and persists durable evidence. Does not execute
+economic evaluation and does not auto-start Full-Universe OKX fetch.
 """
 
 from __future__ import annotations
@@ -65,7 +66,7 @@ def run_materialization_scope_cli_v0(
     primary_worktree: Path,
     staging_root: Path,
     binding_origin_main_sha: str | None = None,
-    attempt_fetch: bool = True,
+    attempt_fetch: bool = False,
 ) -> dict[str, Any]:
     if confirm != CONFIRM_GO:
         _die(f"ERR:confirm_go_token_required:{CONFIRM_GO}")
@@ -124,6 +125,9 @@ def run_materialization_scope_cli_v0(
         "no_shadow": True,
         "no_paper": True,
         "no_orders": True,
+        "fetch_auto_start_disabled": True,
+        "full_universe_fetch_requires_explicit_go": True,
+        "attempt_fetch_requested": attempt_fetch,
         "materialization_scope": scope_payload,
         "staging_assessment": staging_assessment_to_dict(scope_result.staging_assessment),
         "durable_evidence_path": str(bundle_dir),
@@ -240,16 +244,28 @@ def main() -> None:
     parser.add_argument(
         "--no-fetch",
         action="store_true",
-        help="Assess only; do not attempt OHLCV/funding fetch/materialization",
+        help="Readiness-only assessment (default when --authorize-full-universe-fetch is omitted).",
+    )
+    parser.add_argument(
+        "--authorize-full-universe-fetch",
+        action="store_true",
+        help=(
+            "Explicitly request Full-Universe fetch authorization check. "
+            "Not authorized in this scope; fails closed with "
+            "FULL_UNIVERSE_FETCH_REQUIRES_EXPLICIT_OPERATOR_GO."
+        ),
     )
     args = parser.parse_args()
+    if args.no_fetch and args.authorize_full_universe_fetch:
+        _die("ERR:conflicting_fetch_flags:--no-fetch and --authorize-full-universe-fetch")
+    attempt_fetch = args.authorize_full_universe_fetch
     result = run_materialization_scope_cli_v0(
         confirm=args.confirm,
         durable_evidence_root=args.durable_evidence_root,
         primary_worktree=args.primary_worktree,
         staging_root=args.staging_root,
         binding_origin_main_sha=args.binding_origin_main_sha,
-        attempt_fetch=not args.no_fetch,
+        attempt_fetch=attempt_fetch,
     )
     print(json.dumps(result, indent=2, sort_keys=True))
 

--- a/src/research/csf_rdm_v0_extended_chronological_v1_staging_funding_panel_materialization_v0.py
+++ b/src/research/csf_rdm_v0_extended_chronological_v1_staging_funding_panel_materialization_v0.py
@@ -1,8 +1,8 @@
 """CSF/RDM v0 extended_chronological_v1 staging and bound funding panel materialization v0.
 
-Bounded offline dataset/funding readiness scope only. Reuses canonical fetch,
-funding materialization, and preflight owners. Does not execute economic
-evaluation, runtime, credentials, or order effects.
+Bounded offline dataset/funding readiness scope only. Reuses canonical preflight
+owners and assesses staging readiness. Does not auto-start Full-Universe OKX fetch,
+economic evaluation, runtime, credentials, or order effects.
 """
 
 from __future__ import annotations
@@ -19,7 +19,6 @@ from src.research.cross_sectional_funding_rate_delta_momentum_v0_bound_panel_dat
     materialize_bound_funding_panel_dataset_v0,
 )
 from src.research.cross_sectional_funding_rate_delta_momentum_v0_offline_economic_evaluation_execution_v0 import (
-    INFRASTRUCTURE_GO_TOKEN,
     resolve_actual_repo_shas_v0,
 )
 from src.research.cross_sectional_funding_rate_delta_momentum_v0_versioned_research_binding_v0 import (
@@ -56,9 +55,21 @@ CANONICAL_PREFLIGHT_OWNER = (
 )
 
 REASON_MISSING_CANONICAL_STAGING_ROOT = "MISSING_CANONICAL_EXTENDED_CHRONOLOGICAL_V1_STAGING_ROOT"
+REASON_STAGING_MISSING = "STAGING_MISSING"
 REASON_MISSING_FUNDING_MANIFEST = "MISSING_BOUND_FUNDING_PANEL_MANIFEST"
 REASON_MISSING_FUNDING_BARS = "MISSING_BOUND_FUNDING_PANEL_BARS"
+REASON_FUNDING_MISSING = "FUNDING_MISSING"
 REASON_MATERIALIZATION_INCOMPLETE = "BOUND_FUNDING_PANEL_MATERIALIZATION_INCOMPLETE"
+REASON_FULL_UNIVERSE_FETCH_NOT_AUTHORIZED = "FULL_UNIVERSE_FETCH_NOT_AUTHORIZED"
+REASON_FULL_UNIVERSE_FETCH_REQUIRES_EXPLICIT_OPERATOR_GO = (
+    "FULL_UNIVERSE_FETCH_REQUIRES_EXPLICIT_OPERATOR_GO"
+)
+REASON_SEPARATE_BOUNDED_MATERIALIZATION_SCOPE_REQUIRED = (
+    "SEPARATE_BOUNDED_OFFLINE_PANEL_MATERIALIZATION_SCOPE_REQUIRED"
+)
+SAFE_NEXT_ACTION_BOUNDED_OFFLINE_MATERIALIZATION = (
+    "RUN_SEPARATE_BOUNDED_OFFLINE_PANEL_MATERIALIZATION_FROM_RAW_SOURCE_THEN_FUNDING_PANEL"
+)
 
 
 class StagingReadinessStatus(str, Enum):
@@ -138,10 +149,14 @@ def assess_staging_readiness_v0(
 
     if not staging_exists:
         reasons.append(REASON_MISSING_CANONICAL_STAGING_ROOT)
+        reasons.append(REASON_STAGING_MISSING)
     if staging_exists and not manifest_exists:
         reasons.append(REASON_MISSING_FUNDING_MANIFEST)
+        reasons.append(REASON_FUNDING_MISSING)
     if staging_exists and not bars_exists:
         reasons.append(REASON_MISSING_FUNDING_BARS)
+        if REASON_FUNDING_MISSING not in reasons:
+            reasons.append(REASON_FUNDING_MISSING)
 
     materialization_status: str | None = None
     materialization_ready = False
@@ -166,7 +181,7 @@ def assess_staging_readiness_v0(
         safe_next = "RUN_PREFLIGHT_AND_VERIFY_DIGEST_BINDINGS"
     else:
         status = StagingReadinessStatus.FAIL_CLOSED_MISSING_PRECONDITION
-        safe_next = "MATERIALIZE_EXTENDED_CHRONOLOGICAL_V1_OHLCV_STAGING_THEN_BOUND_FUNDING_PANEL"
+        safe_next = SAFE_NEXT_ACTION_BOUNDED_OFFLINE_MATERIALIZATION
 
     return StagingReadinessAssessmentV0(
         status=status,
@@ -200,59 +215,39 @@ def attempt_staging_and_funding_materialization_v0(
     durable_evidence_root: Path,
     attempt_fetch: bool,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None, tuple[str, ...]]:
-    """Attempt canonical OHLCV fetch and bound funding materialization when admissible."""
+    """Assess staging/funding readiness without implicit Full-Universe network fetch.
+
+    ``attempt_fetch=True`` does not authorize network I/O in this scope. It fails
+    closed with ``FULL_UNIVERSE_FETCH_REQUIRES_EXPLICIT_OPERATOR_GO`` and directs
+    operators to a separate bounded offline panel materialization scope.
+    """
+    _ = durable_evidence_root
     reasons: list[str] = []
-    fetch_result: dict[str, Any] | None = None
-    funding_result: dict[str, Any] | None = None
     staging_root = staging_root.resolve()
 
     if staging_root.is_dir():
         assessment = assess_staging_readiness_v0(staging_root)
         if assessment.materialization_ready:
             return None, {"verdict": "BOUND_FUNDING_PANEL_READY_REUSED"}, ()
+        reasons.extend(assessment.reason_codes)
         if not attempt_fetch:
             reasons.append("STAGING_PRESENT_BUT_FUNDING_NOT_READY")
-            return None, None, tuple(reasons)
-
-    if not attempt_fetch:
-        reasons.append(REASON_MISSING_CANONICAL_STAGING_ROOT)
-        return None, None, tuple(reasons)
+            return None, None, tuple(dict.fromkeys(reasons))
 
     if not staging_root.is_dir():
-        from scripts.ops import (
-            fetch_cross_sectional_bound_period_historical_pt1h_sources_v0 as fetch_mod,
+        reasons.append(REASON_MISSING_CANONICAL_STAGING_ROOT)
+        reasons.append(REASON_STAGING_MISSING)
+
+    if attempt_fetch:
+        reasons.extend(
+            (
+                REASON_FULL_UNIVERSE_FETCH_REQUIRES_EXPLICIT_OPERATOR_GO,
+                REASON_FULL_UNIVERSE_FETCH_NOT_AUTHORIZED,
+                REASON_SEPARATE_BOUNDED_MATERIALIZATION_SCOPE_REQUIRED,
+            )
         )
 
-        setattr(fetch_mod, "CONFIRM_" + "TOKEN", INFRASTRUCTURE_GO_TOKEN)
-        fetch_result = fetch_mod.run_historical_fetch(
-            confirm=INFRASTRUCTURE_GO_TOKEN,
-            target_staging_root=staging_root,
-            durable_evidence_root=durable_evidence_root,
-            period_start_utc=PANEL_CALENDAR_START_UTC,
-            period_end_utc=PANEL_CALENDAR_END_UTC,
-        )
-
-    from scripts.ops import (
-        materialize_cross_sectional_funding_rate_delta_momentum_v0_bound_panel_funding_dataset_v0 as funding_script,
-    )
-
-    funding_result = funding_script.materialize_bound_panel_funding_dataset_v0(
-        confirm=INFRASTRUCTURE_GO_TOKEN,
-        staging_root=staging_root,
-        skip_fetch=False,
-    )
-    _patch_funding_manifest_extension(staging_root)
-
-    from src.research.cross_sectional_panel_staging_source_manifest_v1 import (
-        SourceManifestStatus,
-        materialize_panel_staging_source_manifests_v1,
-    )
-
-    manifest_result = materialize_panel_staging_source_manifests_v1(staging_root)
-    if manifest_result.status is not SourceManifestStatus.VERIFIED:
-        reasons.extend(manifest_result.reason_codes)
-
-    return fetch_result, funding_result, tuple(reasons)
+    return None, None, tuple(dict.fromkeys(reasons))
 
 
 def run_materialization_scope_v0(
@@ -261,10 +256,10 @@ def run_materialization_scope_v0(
     staging_root: Path,
     durable_evidence_root: Path,
     binding_origin_main_sha: str | None = None,
-    attempt_fetch: bool = True,
+    attempt_fetch: bool = False,
     versioned_binding: Mapping[str, Any] | None = None,
 ) -> MaterializationScopeResultV0:
-    """Assess or materialize staging/funding, then run preflight without evaluation."""
+    """Assess staging/funding readiness and run preflight without evaluation."""
     _, actual_origin_main = resolve_actual_repo_shas_v0(repo_root)
     resolved_binding_sha = (binding_origin_main_sha or actual_origin_main).strip()
     binding = dict(versioned_binding or materialize_versioned_research_binding_v0())
@@ -395,6 +390,11 @@ __all__ = [
     "MATERIALIZATION_VERSION",
     "MaterializationScopeResultV0",
     "MaterializationScopeVerdict",
+    "REASON_FULL_UNIVERSE_FETCH_NOT_AUTHORIZED",
+    "REASON_FULL_UNIVERSE_FETCH_REQUIRES_EXPLICIT_OPERATOR_GO",
+    "REASON_FUNDING_MISSING",
+    "REASON_STAGING_MISSING",
+    "SAFE_NEXT_ACTION_BOUNDED_OFFLINE_MATERIALIZATION",
     "StagingReadinessAssessmentV0",
     "StagingReadinessStatus",
     "assess_staging_readiness_v0",

--- a/tests/research/test_csf_rdm_v0_extended_chronological_v1_staging_funding_panel_materialization_v0.py
+++ b/tests/research/test_csf_rdm_v0_extended_chronological_v1_staging_funding_panel_materialization_v0.py
@@ -19,8 +19,13 @@ from src.research.csf_rdm_v0_extended_chronological_v1_staging_funding_panel_mat
     DEFAULT_STAGING_ROOT,
     CONFIRM_GO,
     MaterializationScopeVerdict,
+    REASON_FULL_UNIVERSE_FETCH_NOT_AUTHORIZED,
+    REASON_FULL_UNIVERSE_FETCH_REQUIRES_EXPLICIT_OPERATOR_GO,
+    REASON_FUNDING_MISSING,
+    REASON_STAGING_MISSING,
     StagingReadinessStatus,
     assess_staging_readiness_v0,
+    attempt_staging_and_funding_materialization_v0,
     load_materialization_binding_config_v0,
     run_materialization_scope_v0,
 )
@@ -145,7 +150,80 @@ def test_missing_canonical_staging_fails_closed(complete_binding: dict) -> None:
     )
     assert assessment.status is StagingReadinessStatus.FAIL_CLOSED_MISSING_PRECONDITION
     assert not assessment.staging_root_exists
+    assert REASON_STAGING_MISSING in assessment.reason_codes
     assert "MISSING_CANONICAL_EXTENDED_CHRONOLOGICAL_V1_STAGING_ROOT" in assessment.reason_codes
+
+
+def test_missing_staging_does_not_invoke_full_universe_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = {"fetch": False}
+
+    def _fail_if_called(*args: object, **kwargs: object) -> None:
+        called["fetch"] = True
+        raise AssertionError("run_historical_fetch must not be called")
+
+    monkeypatch.setattr(
+        "scripts.ops.fetch_cross_sectional_bound_period_historical_pt1h_sources_v0.run_historical_fetch",
+        _fail_if_called,
+    )
+    missing_root = (
+        Path(tempfile.mkdtemp(prefix="csf_rdm_missing_staging_")) / "extended_chronological_v1"
+    )
+    fetch_result, funding_result, reasons = attempt_staging_and_funding_materialization_v0(
+        staging_root=missing_root,
+        durable_evidence_root=Path(tempfile.mkdtemp(prefix="csf_rdm_durable_")),
+        attempt_fetch=False,
+    )
+    assert called["fetch"] is False
+    assert fetch_result is None
+    assert funding_result is None
+    assert REASON_STAGING_MISSING in reasons
+
+
+def test_authorize_full_universe_fetch_fails_closed_without_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = {"fetch": False}
+
+    def _fail_if_called(*args: object, **kwargs: object) -> None:
+        called["fetch"] = True
+        raise AssertionError("run_historical_fetch must not be called")
+
+    monkeypatch.setattr(
+        "scripts.ops.fetch_cross_sectional_bound_period_historical_pt1h_sources_v0.run_historical_fetch",
+        _fail_if_called,
+    )
+    missing_root = (
+        Path(tempfile.mkdtemp(prefix="csf_rdm_fetch_gate_")) / "extended_chronological_v1"
+    )
+    fetch_result, funding_result, reasons = attempt_staging_and_funding_materialization_v0(
+        staging_root=missing_root,
+        durable_evidence_root=Path(tempfile.mkdtemp(prefix="csf_rdm_durable_")),
+        attempt_fetch=True,
+    )
+    assert called["fetch"] is False
+    assert fetch_result is None
+    assert funding_result is None
+    assert REASON_FULL_UNIVERSE_FETCH_REQUIRES_EXPLICIT_OPERATOR_GO in reasons
+    assert REASON_FULL_UNIVERSE_FETCH_NOT_AUTHORIZED in reasons
+
+
+def test_staging_present_funding_missing_readiness_reasons(bound_staging: Path) -> None:
+    funding_manifest = bound_staging / "panel" / "panel_funding_dataset_manifest.json"
+    funding_bars = bound_staging / "panel" / "normalized_panel_bars_with_funding.json"
+    funding_manifest.unlink()
+    funding_bars.unlink()
+
+    fetch_result, funding_result, reasons = attempt_staging_and_funding_materialization_v0(
+        staging_root=bound_staging,
+        durable_evidence_root=Path(tempfile.mkdtemp(prefix="csf_rdm_durable_")),
+        attempt_fetch=False,
+    )
+    assert fetch_result is None
+    assert funding_result is None
+    assert REASON_FUNDING_MISSING in reasons
+    assert "STAGING_PRESENT_BUT_FUNDING_NOT_READY" in reasons
 
 
 def test_missing_staging_preflight_still_fails_closed(complete_binding: dict) -> None:


### PR DESCRIPTION
## Summary
- Stop implicit Full-Universe OKX fetch when `extended_chronological_v1` staging is missing; materialization scope is now readiness-only by default (`attempt_fetch=False`).
- `attempt_fetch=True` / `--authorize-full-universe-fetch` fails closed with `FULL_UNIVERSE_FETCH_REQUIRES_EXPLICIT_OPERATOR_GO` instead of starting network I/O.
- Add focused contract tests proving no `run_historical_fetch` invocation and explicit readiness reason codes.

## Problem
PR #4813 materialization owner auto-called `fetch_cross_sectional_bound_period_historical_pt1h_sources_v0.run_historical_fetch`, producing 10k+ paginated raw files for a gate that only requires final staging/funding bindings.

## Fix
- Default fail-closed/readiness-only materialization scope.
- Runner CLI safe defaults; fetch authorization explicitly gated and documented as not authorized in this scope.

## Test plan
- [x] `pytest tests/research/test_csf_rdm_v0_extended_chronological_v1_staging_funding_panel_materialization_v0.py`
- [x] `pytest tests/research/test_csf_rdm_v0_dataset_funding_binding_materialization_preflight_v0.py`
- [x] `ruff format --check` / `ruff check` on changed Python files
- [x] `git diff --check`

## Evidence Bundle
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/extended_chronological_v1_materialization_scope_rebind_pr_v0_20260703T213543Z`
- `MANIFEST_VERIFY_RC=0`

## Safety Invariants
- `NO_FETCH` / `NO_NETWORK` in this PR
- `NO_MATERIALIZATION` / `NO_EVALUATION_RETRY`
- `NO_RUNTIME` / `NO_SHADOW` / `NO_PAPER` / `NO_TESTNET` / `NO_ORDERS`
- Partial archive tmps untouched

## Next Scope (separate)
Offline panel materialization from existing partial raw source + funding for panel members only, then preflight `--no-fetch`.

Made with [Cursor](https://cursor.com)