### PR TITLE
fix(research): bind class-d offline evaluation execution owner v0

### DIFF
--- a/scripts/ops/run_final_research_fleet_offline_economic_evaluation_v0.py
+++ b/scripts/ops/run_final_research_fleet_offline_economic_evaluation_v0.py
@@ -2,7 +2,8 @@
 """Run final research fleet offline economic evaluation v0.
 
 Deterministic offline economic evaluation for trend_following/v1,
-bollinger_bands/v1, and momentum_1h/v1 against ratified PR #4826 bindings.
+bollinger_bands/v1, and momentum_1h/v1 against ratified Class-D bindings
+from PR #4832 (or legacy PR #4826 bindings when explicitly supplied).
 No runtime, order, or authority effect.
 Operator GO (canonical): GO_EXECUTE_BOUNDED_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_V0
 Operator GO (alias): GO_BOUNDED_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_FOR_VERSIONED_FINAL_RESEARCH_FLEET_V0
@@ -36,28 +37,33 @@ from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 
     AUTHORITY_EFFECT,
     EXPECTED_ORIGIN_MAIN_SHA,
     GO_TOKEN,
+    LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX,
+    LEGACY_DURABLE_EVIDENCE_SUBDIR,
+    MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
     ORDER_EFFECT,
     PR4826_MERGE_COMMIT,
+    PR4832_MERGE_COMMIT,
     REQUIRED_MERGED_PR_NUMBER,
     RUNTIME_EFFECT,
     CandidateTerminalStatus,
     dumps_execution_canonical_v1,
     is_accepted_go_token,
+    load_scope_ratification_for_execution_v0,
     materialize_fleet_evaluation_summary_v0,
+    resolve_durable_evidence_bundle_dir_v0,
+    resolve_legacy_durable_evidence_bundle_dir_v0,
     run_candidate_economic_evaluation_v0,
+    validate_binding_completion_for_execution_v0,
+    validate_scope_ratification_for_execution_v0,
     verify_execution_start_state_v0,
+    verify_origin_main_sha_for_binding_v0,
 )
 from src.research.final_research_fleet_offline_economic_evaluation_scope_ratification_v0 import (  # noqa: E402
-    materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0,
     serialize_ratification_canonical_v0,
-    validate_final_research_fleet_offline_economic_evaluation_scope_ratification_v0,
 )
 from src.research.final_research_fleet_v0_versioned_binding_manifest_contract_v0 import (  # noqa: E402
     FLEET_CANDIDATES,
     STEP31F_CONFIG_PATHS,
-)
-from src.research.final_research_fleet_versioned_binding_completion_v0 import (  # noqa: E402
-    validate_final_research_fleet_versioned_binding_completion_v0,
 )
 
 CONFIRM_GO = GO_TOKEN
@@ -65,7 +71,9 @@ DEFAULT_DURABLE_ROOT = Path(
     "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
 )
 DEFAULT_PRIMARY_WORKTREE = Path("/Users/frnkhrz/Peak_Trade")
-BINDING_COMPLETION_REL = "config/research/final_research_fleet_versioned_binding_completion_v0.json"
+BINDING_COMPLETION_REL = (
+    "config/research/final_research_fleet_class_d_versioned_binding_completion_v0.json"
+)
 
 _GATE_FAIL_CODES = {
     "walk_forward": "WALK_FORWARD_FAILED",
@@ -190,27 +198,22 @@ def _build_binding_digest_verification(
     fleet_binding_completion: Mapping[str, Any],
     ratification: Mapping[str, Any],
 ) -> dict[str, Any]:
-    binding_validation = validate_final_research_fleet_versioned_binding_completion_v0(
+    binding_ok, binding_fail_reasons = validate_binding_completion_for_execution_v0(
         fleet_binding_completion,
         repo_root=repo_root,
         require_ready_for_eval=True,
     )
-    ratification_validation = (
-        validate_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
-            ratification,
-            repo_root=repo_root,
-            expected_fleet_binding_completion=fleet_binding_completion,
-        )
+    scope_ok, scope_fail_reasons = validate_scope_ratification_for_execution_v0(
+        ratification,
+        repo_root=repo_root,
+        fleet_binding_completion=fleet_binding_completion,
     )
     return {
-        "binding_digest_verification_pass": (
-            binding_validation.verdict.value == "ACCEPTED"
-            and ratification_validation.verdict.value == "ACCEPTED"
-        ),
-        "binding_validation_verdict": binding_validation.verdict.value,
-        "binding_validation_fail_reasons": list(binding_validation.fail_reasons),
-        "ratification_validation_verdict": ratification_validation.verdict.value,
-        "ratification_validation_fail_reasons": list(ratification_validation.fail_reasons),
+        "binding_digest_verification_pass": binding_ok and scope_ok,
+        "binding_validation_verdict": "ACCEPTED" if binding_ok else "REJECTED",
+        "binding_validation_fail_reasons": list(binding_fail_reasons),
+        "ratification_validation_verdict": "ACCEPTED" if scope_ok else "REJECTED",
+        "ratification_validation_fail_reasons": list(scope_fail_reasons),
         "fleet_binding_digest": ratification.get("fleet_binding_digest"),
         "ratification_digest": ratification.get("ratification_digest"),
         "candidate_binding_digests": ratification.get("candidate_binding_digests"),
@@ -275,19 +278,22 @@ def run_evaluation(
 
     primary_before = _primary_worktree_snapshot(primary_worktree)
     origin_main = _resolve_origin_main(_REPO_ROOT)
-    if origin_main != EXPECTED_ORIGIN_MAIN_SHA:
-        _die(f"ERR: origin_main_mismatch:{origin_main}!={EXPECTED_ORIGIN_MAIN_SHA}")
 
     binding_path = binding_completion_path or (_REPO_ROOT / BINDING_COMPLETION_REL)
     if not binding_path.is_file():
         _die(f"ERR: missing_binding_completion:{binding_path}")
 
     fleet_binding_completion = _load_json(binding_path)
-    ratification = (
-        materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
-            repo_root=_REPO_ROOT,
-            fleet_binding_completion=fleet_binding_completion,
-        )
+    origin_ok, origin_reasons = verify_origin_main_sha_for_binding_v0(
+        origin_main_sha=origin_main,
+        fleet_binding_completion=fleet_binding_completion,
+    )
+    if not origin_ok:
+        _die(f"ERR: origin_main_mismatch:{origin_reasons}")
+
+    ratification = load_scope_ratification_for_execution_v0(
+        repo_root=_REPO_ROOT,
+        fleet_binding_completion=fleet_binding_completion,
     )
     start_state = verify_execution_start_state_v0(
         repo_root=_REPO_ROOT,
@@ -311,18 +317,26 @@ def run_evaluation(
         _die("ERR: common_policy_comparability_failed")
 
     ts_slug = _utc_slug()
-    evidence_dir = (
-        durable_evidence_root
-        / "implementation"
-        / f"bounded_final_research_fleet_offline_economic_evaluation_v0_{ts_slug}"
+    evidence_dir = resolve_durable_evidence_bundle_dir_v0(
+        durable_evidence_root=durable_evidence_root,
+        timestamp_slug=ts_slug,
     )
     evidence_dir.mkdir(parents=True, exist_ok=False)
+    legacy_evidence_dir = resolve_legacy_durable_evidence_bundle_dir_v0(
+        durable_evidence_root=durable_evidence_root,
+        timestamp_slug=ts_slug,
+    )
 
     preflight_lines = [
         f"ORIGIN_MAIN={origin_main}",
         f"PR4826_MERGE_COMMIT={PR4826_MERGE_COMMIT}",
+        f"PR4832_MERGE_COMMIT={PR4832_MERGE_COMMIT}",
         f"EXPECTED_ORIGIN_MAIN={EXPECTED_ORIGIN_MAIN_SHA}",
+        f"MATERIALIZED_CLASS_D_ORIGIN_MAIN={MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA}",
         f"REQUIRED_MERGED_PR_NUMBER={REQUIRED_MERGED_PR_NUMBER}",
+        f"DURABLE_EVIDENCE_SUBDIR={evidence_dir.parent.name}",
+        f"DURABLE_EVIDENCE_BUNDLE={evidence_dir.name}",
+        f"LEGACY_DURABLE_EVIDENCE_ALIAS={legacy_evidence_dir.parent.name}/{legacy_evidence_dir.name}",
         "FINAL_RESEARCH_FLEET_BINDING_READY=true",
         "NEW_CANDIDATES_RATIFIED=true",
         "ECONOMIC_EVALUATION_SCOPE_RATIFIED=true",
@@ -359,6 +373,20 @@ def run_evaluation(
     )
     (evidence_dir / "common_policy_comparability_matrix.json").write_text(
         json.dumps(comparability, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "durable_evidence_path_alias.json").write_text(
+        json.dumps(
+            {
+                "canonical_path": str(evidence_dir),
+                "legacy_alias_path": str(legacy_evidence_dir),
+                "legacy_subdir": LEGACY_DURABLE_EVIDENCE_SUBDIR,
+                "legacy_prefix": LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
         encoding="utf-8",
     )
     (

--- a/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
+++ b/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
@@ -31,6 +31,7 @@ from src.research.final_research_fleet_v0_versioned_binding_manifest_contract_v0
 from src.research.final_research_fleet_offline_economic_evaluation_scope_ratification_v0 import (
     OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFIED,
     ValidationVerdict,
+    materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0,
     validate_final_research_fleet_offline_economic_evaluation_scope_ratification_v0,
 )
 from src.research.final_research_fleet_versioned_binding_completion_v0 import (
@@ -51,9 +52,31 @@ GO_TOKEN_OPERATOR_ALIAS = (
     "GO_BOUNDED_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_FOR_VERSIONED_FINAL_RESEARCH_FLEET_V0"
 )
 ACCEPTED_GO_TOKENS: frozenset[str] = frozenset({GO_TOKEN, GO_TOKEN_OPERATOR_ALIAS})
-EXPECTED_ORIGIN_MAIN_SHA = "208ab96562f7750fb4dff43936b345a040d1cea4"
-REQUIRED_MERGED_PR_NUMBER = 4826
 PR4826_MERGE_COMMIT = "208ab96562f7750fb4dff43936b345a040d1cea4"
+PR4832_MERGE_COMMIT = "ddce9c508158b89fa225c381436e2d1efced7328"
+MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA = PR4832_MERGE_COMMIT
+EXPECTED_ORIGIN_MAIN_SHA = MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA
+ACCEPTED_ORIGIN_MAIN_SHAS: frozenset[str] = frozenset(
+    {PR4826_MERGE_COMMIT, MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA}
+)
+REQUIRED_MERGED_PR_NUMBER = 4826
+CLASS_D_BINDING_COMPLETION_ID = "final_research_fleet_class_d_versioned_binding_completion_v0"
+CLASS_D_BINDING_COMPLETION_SCHEMA_VERSION = (
+    "final_research_fleet_class_d_versioned_bindings_and_offline_economic_evaluation_scope.v0"
+)
+CLASS_D_BINDING_COMPLETION_DIGEST = (
+    "0610afa34b347abde08768fb2fbfb30fd4bb19ae010f3b2042c67155fb6c0fc4"
+)
+CLASS_D_SCOPE_RATIFICATION_CONFIG_REL = "config/research/final_research_fleet_class_d_offline_economic_evaluation_scope_ratification_v0.json"
+CLASS_D_RATIFIED_SCOPE_ID = (
+    "FINAL_RESEARCH_FLEET_VERSIONED_BINDINGS_AND_OFFLINE_ECONOMIC_EVALUATION_SCOPE_V0"
+)
+DURABLE_EVIDENCE_SUBDIR = "research"
+DURABLE_EVIDENCE_BUNDLE_PREFIX = "bounded_offline_economic_evaluation_final_research_fleet_v0"
+LEGACY_DURABLE_EVIDENCE_SUBDIR = "implementation"
+LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX = (
+    "bounded_final_research_fleet_offline_economic_evaluation_v0"
+)
 HISTORICAL_STEP31F_BINDING_COMPLETION_DIGEST = (
     "161d834e5153df78a0013b6e55c4c8bd4788c775811e3678f025104a307d78f1"
 )
@@ -185,6 +208,182 @@ def is_accepted_go_token(token: str) -> bool:
     return token in ACCEPTED_GO_TOKENS
 
 
+def is_accepted_origin_main_sha(origin_main_sha: str) -> bool:
+    return origin_main_sha in ACCEPTED_ORIGIN_MAIN_SHAS
+
+
+def is_class_d_binding_completion_v0(fleet_binding_completion: Mapping[str, Any]) -> bool:
+    return (
+        fleet_binding_completion.get("schema_version") == CLASS_D_BINDING_COMPLETION_SCHEMA_VERSION
+        or fleet_binding_completion.get("completion_id") == CLASS_D_BINDING_COMPLETION_ID
+        or fleet_binding_completion.get("ratification_class") == "D"
+    )
+
+
+def resolve_durable_evidence_bundle_dir_v0(
+    *,
+    durable_evidence_root: Path,
+    timestamp_slug: str,
+) -> Path:
+    return (
+        durable_evidence_root
+        / DURABLE_EVIDENCE_SUBDIR
+        / f"{DURABLE_EVIDENCE_BUNDLE_PREFIX}_{timestamp_slug}"
+    )
+
+
+def resolve_legacy_durable_evidence_bundle_dir_v0(
+    *,
+    durable_evidence_root: Path,
+    timestamp_slug: str,
+) -> Path:
+    return (
+        durable_evidence_root
+        / LEGACY_DURABLE_EVIDENCE_SUBDIR
+        / f"{LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX}_{timestamp_slug}"
+    )
+
+
+def verify_origin_main_sha_for_binding_v0(
+    *,
+    origin_main_sha: str,
+    fleet_binding_completion: Mapping[str, Any],
+) -> tuple[bool, tuple[str, ...]]:
+    if is_class_d_binding_completion_v0(fleet_binding_completion):
+        if origin_main_sha != MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA:
+            return False, (
+                f"{REASON_ORIGIN_MAIN_MISMATCH}:{origin_main_sha}!={MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA}",
+            )
+        return True, ()
+    if not is_accepted_origin_main_sha(origin_main_sha):
+        return False, (f"{REASON_ORIGIN_MAIN_MISMATCH}:{origin_main_sha}",)
+    return True, ()
+
+
+def load_scope_ratification_for_execution_v0(
+    *,
+    repo_root: Path,
+    fleet_binding_completion: Mapping[str, Any],
+) -> dict[str, Any]:
+    if is_class_d_binding_completion_v0(fleet_binding_completion):
+        scope_path = repo_root / CLASS_D_SCOPE_RATIFICATION_CONFIG_REL
+        if not scope_path.is_file():
+            raise ValueError(f"missing_class_d_scope_ratification:{scope_path}")
+        payload = json.loads(scope_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("class_d_scope_ratification_not_object")
+        return payload
+    return materialize_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=repo_root,
+        fleet_binding_completion=fleet_binding_completion,
+    )
+
+
+def validate_binding_completion_for_execution_v0(
+    fleet_binding_completion: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    require_ready_for_eval: bool = True,
+) -> tuple[bool, tuple[str, ...]]:
+    if is_class_d_binding_completion_v0(fleet_binding_completion):
+        from src.research.final_research_fleet_class_d_versioned_bindings_and_offline_economic_evaluation_scope_v0 import (  # noqa: PLC0415,E501
+            validate_class_d_binding_completion_v0,
+        )
+
+        verdict, fail_reasons = validate_class_d_binding_completion_v0(
+            fleet_binding_completion,
+            repo_root=repo_root,
+        )
+        if verdict.value != "ACCEPTED":
+            return False, fail_reasons
+        return True, ()
+    binding_validation = validate_final_research_fleet_versioned_binding_completion_v0(
+        fleet_binding_completion,
+        repo_root=repo_root,
+        require_ready_for_eval=require_ready_for_eval,
+    )
+    if binding_validation.verdict != BindingValidationVerdict.ACCEPTED:
+        return False, binding_validation.fail_reasons
+    return True, ()
+
+
+def validate_class_d_scope_ratification_for_execution_v0(
+    ratification: Mapping[str, Any],
+    *,
+    fleet_binding_completion: Mapping[str, Any],
+) -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    if ratification.get("schema_version") != CLASS_D_BINDING_COMPLETION_SCHEMA_VERSION:
+        reasons.append("UNKNOWN_SCHEMA_VERSION")
+    if ratification.get("ratified_scope_id") != CLASS_D_RATIFIED_SCOPE_ID:
+        reasons.append("RATIFIED_SCOPE_ID_MISMATCH")
+    if ratification.get("fleet_binding_digest") != fleet_binding_completion.get(
+        "completion_digest"
+    ):
+        reasons.append(REASON_BINDING_DIGEST_MISMATCH)
+    if ratification.get("offline_economic_evaluation_scope_ratified") is not True:
+        reasons.append(REASON_SCOPE_NOT_RATIFIED)
+    if ratification.get("economic_evaluation_executed") is not False:
+        reasons.append(REASON_EVALUATION_ALREADY_EXECUTED)
+    if ratification.get("economic_evaluation_authorized") is not False:
+        reasons.append("ECONOMIC_EVALUATION_AUTHORIZED_MUST_BE_FALSE")
+    for effect_field, expected in (
+        ("authority_effect", AUTHORITY_EFFECT),
+        ("runtime_effect", RUNTIME_EFFECT),
+        ("order_effect", ORDER_EFFECT),
+    ):
+        if ratification.get(effect_field) != expected:
+            reasons.append(f"EFFECT_NOT_NONE:{effect_field}")
+    if ratification.get("runtime_rewire_admissible") is not False:
+        reasons.append("RUNTIME_REWIRE_MUST_BE_FALSE")
+    if ratification.get("futures_only") is not True:
+        reasons.append("FUTURES_ONLY_VIOLATION")
+    if ratification.get("bitcoin_direction_allowed") is not False:
+        reasons.append("BITCOIN_DIRECTION_BINDING_REJECTED")
+    expected_refs = [
+        canonical_candidate_identifier(strategy_id, version)
+        for strategy_id, version in FLEET_CANDIDATES
+    ]
+    if sorted(ratification.get("candidate_refs") or []) != sorted(expected_refs):
+        reasons.append("CANDIDATE_SET_MISMATCH")
+    binding_digests = ratification.get("candidate_binding_digests")
+    if isinstance(binding_digests, Mapping):
+        for candidate in fleet_binding_completion.get("candidates", ()):
+            if not isinstance(candidate, Mapping):
+                continue
+            ref = canonical_candidate_identifier(
+                str(candidate["strategy_id"]), str(candidate["strategy_version"])
+            )
+            expected = str(candidate.get("binding_semantic_digest", ""))
+            actual = binding_digests.get(ref)
+            if actual != expected:
+                reasons.append(f"{REASON_BINDING_DIGEST_MISMATCH}:{ref}")
+    return not reasons, tuple(reasons)
+
+
+def validate_scope_ratification_for_execution_v0(
+    ratification: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    fleet_binding_completion: Mapping[str, Any],
+) -> tuple[bool, tuple[str, ...]]:
+    if is_class_d_binding_completion_v0(fleet_binding_completion):
+        return validate_class_d_scope_ratification_for_execution_v0(
+            ratification,
+            fleet_binding_completion=fleet_binding_completion,
+        )
+    ratification_validation = (
+        validate_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
+            ratification,
+            repo_root=repo_root,
+            expected_fleet_binding_completion=fleet_binding_completion,
+        )
+    )
+    if ratification_validation.verdict != ValidationVerdict.ACCEPTED:
+        return False, ratification_validation.fail_reasons
+    return True, ()
+
+
 def canonical_go_token(token: str) -> str:
     if is_accepted_go_token(token):
         return GO_TOKEN
@@ -218,35 +417,38 @@ def verify_execution_start_state_v0(
 ) -> StartStateVerificationResultV0:
     reasons: list[str] = []
     resolved_origin = origin_main_sha or _resolve_origin_main_sha(repo_root)
-    if resolved_origin != EXPECTED_ORIGIN_MAIN_SHA:
-        reasons.append(f"{REASON_ORIGIN_MAIN_MISMATCH}:{resolved_origin}")
+    origin_ok, origin_reasons = verify_origin_main_sha_for_binding_v0(
+        origin_main_sha=resolved_origin,
+        fleet_binding_completion=fleet_binding_completion,
+    )
+    if not origin_ok:
+        reasons.extend(origin_reasons)
 
-    binding_validation = validate_final_research_fleet_versioned_binding_completion_v0(
+    binding_ok, binding_reasons = validate_binding_completion_for_execution_v0(
         fleet_binding_completion,
         repo_root=repo_root,
         require_ready_for_eval=True,
     )
-    if binding_validation.verdict != BindingValidationVerdict.ACCEPTED:
-        reasons.extend(binding_validation.fail_reasons)
+    if not binding_ok:
+        reasons.extend(binding_reasons)
 
-    ratification_validation = (
-        validate_final_research_fleet_offline_economic_evaluation_scope_ratification_v0(
-            ratification,
-            repo_root=repo_root,
-            expected_fleet_binding_completion=fleet_binding_completion,
-        )
+    scope_ok, scope_reasons = validate_scope_ratification_for_execution_v0(
+        ratification,
+        repo_root=repo_root,
+        fleet_binding_completion=fleet_binding_completion,
     )
-    if ratification_validation.verdict != ValidationVerdict.ACCEPTED:
-        reasons.extend(ratification_validation.fail_reasons)
+    if not scope_ok:
+        reasons.extend(scope_reasons)
 
     if ratification.get("offline_economic_evaluation_scope_ratified") is not True:
         reasons.append(REASON_SCOPE_NOT_RATIFIED)
     if ratification.get("economic_evaluation_executed") is not False:
         reasons.append(REASON_EVALUATION_ALREADY_EXECUTED)
-    if ratification.get("offline_economic_evaluation_scope_ratified") != (
-        OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFIED
-    ):
-        reasons.append(REASON_SCOPE_NOT_RATIFIED)
+    if not is_class_d_binding_completion_v0(fleet_binding_completion):
+        if ratification.get("offline_economic_evaluation_scope_ratified") != (
+            OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFIED
+        ):
+            reasons.append(REASON_SCOPE_NOT_RATIFIED)
 
     expected_refs = [
         canonical_candidate_identifier(strategy_id, version)

--- a/tests/ops/test_post_pr4827_operator_decision_readiness_unmodified_binding_reexecution_blocked_progress_registry_contract_v0.py
+++ b/tests/ops/test_post_pr4827_operator_decision_readiness_unmodified_binding_reexecution_blocked_progress_registry_contract_v0.py
@@ -20,6 +20,7 @@ from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 
     REASON_NEW_EVIDENCE_CLASS_REQUIRED,
     REASON_UNMODIFIED_BINDING_RETRY_BLOCKED,
     is_accepted_go_token,
+    is_accepted_origin_main_sha,
     verify_unmodified_retry_admissibility_v0,
 )
 from tests.ops.runbook_progress_registry_contract_helpers_v1 import (
@@ -122,8 +123,13 @@ class TestPostPr4827ExecutionOwnerAdmissibility:
         assert is_accepted_go_token(GO_TOKEN_OPERATOR_ALIAS)
         assert is_accepted_go_token(GO_TOKEN)
 
-    def test_sha_rebind_to_pr4826_does_not_create_new_evidence_class(self) -> None:
-        assert EXPECTED_ORIGIN_MAIN_SHA == PR4826_MERGE_COMMIT
+    def test_sha_rebind_accepts_class_d_materialized_main_without_new_evidence_class(self) -> None:
+        from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
+            MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
+        )
+
+        assert EXPECTED_ORIGIN_MAIN_SHA == MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA
+        assert is_accepted_origin_main_sha(PR4826_MERGE_COMMIT)
         assert PR4826_CREATES_NEW_EXECUTION_EVIDENCE_CLASS is False
 
     def test_unmodified_step31f_retry_blocked_despite_go_alias_and_sha_rebind(self) -> None:

--- a/tests/research/test_final_research_fleet_class_d_offline_evaluation_execution_owner_rebind_v0.py
+++ b/tests/research/test_final_research_fleet_class_d_offline_evaluation_execution_owner_rebind_v0.py
@@ -1,0 +1,130 @@
+"""Contract tests for Class-D offline evaluation execution owner rebind v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    CLASS_D_BINDING_COMPLETION_DIGEST,
+    DURABLE_EVIDENCE_BUNDLE_PREFIX,
+    DURABLE_EVIDENCE_SUBDIR,
+    EXPECTED_ORIGIN_MAIN_SHA,
+    GO_TOKEN_OPERATOR_ALIAS,
+    LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX,
+    LEGACY_DURABLE_EVIDENCE_SUBDIR,
+    MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
+    ORDER_EFFECT,
+    PR4826_MERGE_COMMIT,
+    RUNTIME_EFFECT,
+    is_accepted_go_token,
+    is_accepted_origin_main_sha,
+    is_class_d_binding_completion_v0,
+    load_scope_ratification_for_execution_v0,
+    resolve_durable_evidence_bundle_dir_v0,
+    resolve_legacy_durable_evidence_bundle_dir_v0,
+    validate_binding_completion_for_execution_v0,
+    verify_execution_start_state_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLASS_D_BINDING_PATH = (
+    REPO_ROOT / "config/research/final_research_fleet_class_d_versioned_binding_completion_v0.json"
+)
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+
+
+@pytest.fixture(name="class_d_binding_completion")
+def fixture_class_d_binding_completion() -> dict:
+    assert CLASS_D_BINDING_PATH.is_file(), f"missing: {CLASS_D_BINDING_PATH}"
+    return json.loads(CLASS_D_BINDING_PATH.read_text(encoding="utf-8"))
+
+
+def test_expected_origin_main_sha_points_to_class_d_materialized_main() -> None:
+    assert EXPECTED_ORIGIN_MAIN_SHA == MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA
+    assert EXPECTED_ORIGIN_MAIN_SHA == "ddce9c508158b89fa225c381436e2d1efced7328"
+
+
+def test_legacy_pr4826_sha_still_accepted_but_not_exclusive() -> None:
+    assert is_accepted_origin_main_sha(PR4826_MERGE_COMMIT)
+    assert is_accepted_origin_main_sha(MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA)
+    assert EXPECTED_ORIGIN_MAIN_SHA != PR4826_MERGE_COMMIT
+
+
+def test_class_d_completion_digest_accepted(class_d_binding_completion: dict) -> None:
+    assert is_class_d_binding_completion_v0(class_d_binding_completion)
+    assert class_d_binding_completion["completion_digest"] == CLASS_D_BINDING_COMPLETION_DIGEST
+    ok, reasons = validate_binding_completion_for_execution_v0(
+        class_d_binding_completion,
+        repo_root=REPO_ROOT,
+        require_ready_for_eval=True,
+    )
+    assert ok is True
+    assert reasons == ()
+
+
+def test_class_d_start_state_accepts_materialized_origin_main(
+    class_d_binding_completion: dict,
+) -> None:
+    ratification = load_scope_ratification_for_execution_v0(
+        repo_root=REPO_ROOT,
+        fleet_binding_completion=class_d_binding_completion,
+    )
+    result = verify_execution_start_state_v0(
+        repo_root=REPO_ROOT,
+        ratification=ratification,
+        fleet_binding_completion=class_d_binding_completion,
+        origin_main_sha=MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
+    )
+    assert result.valid is True
+    assert result.fail_reasons == ()
+
+
+def test_class_d_start_state_rejects_stale_pr4826_origin_only(
+    class_d_binding_completion: dict,
+) -> None:
+    ratification = load_scope_ratification_for_execution_v0(
+        repo_root=REPO_ROOT,
+        fleet_binding_completion=class_d_binding_completion,
+    )
+    result = verify_execution_start_state_v0(
+        repo_root=REPO_ROOT,
+        ratification=ratification,
+        fleet_binding_completion=class_d_binding_completion,
+        origin_main_sha=PR4826_MERGE_COMMIT,
+    )
+    assert result.valid is False
+    assert any("ORIGIN_MAIN_SHA_MISMATCH" in reason for reason in result.fail_reasons)
+
+
+def test_durable_evidence_path_owner_contract() -> None:
+    bundle = resolve_durable_evidence_bundle_dir_v0(
+        durable_evidence_root=ARCHIVE_ROOT,
+        timestamp_slug="20260704T231500Z",
+    )
+    legacy = resolve_legacy_durable_evidence_bundle_dir_v0(
+        durable_evidence_root=ARCHIVE_ROOT,
+        timestamp_slug="20260704T231500Z",
+    )
+    assert bundle.parts[-2:] == (
+        DURABLE_EVIDENCE_SUBDIR,
+        f"{DURABLE_EVIDENCE_BUNDLE_PREFIX}_20260704T231500Z",
+    )
+    assert legacy.parts[-2:] == (
+        LEGACY_DURABLE_EVIDENCE_SUBDIR,
+        f"{LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX}_20260704T231500Z",
+    )
+
+
+def test_evaluation_not_started_without_go_token() -> None:
+    assert is_accepted_go_token(GO_TOKEN_OPERATOR_ALIAS) is True
+    assert is_accepted_go_token("GO_UNKNOWN") is False
+
+
+def test_runtime_authority_flags_remain_false() -> None:
+    assert AUTHORITY_EFFECT == "NONE"
+    assert RUNTIME_EFFECT == "NONE"
+    assert ORDER_EFFECT == "NONE"

--- a/tests/research/test_final_research_fleet_offline_economic_evaluation_execution_v0.py
+++ b/tests/research/test_final_research_fleet_offline_economic_evaluation_execution_v0.py
@@ -71,8 +71,8 @@ def test_go_token_operator_alias_is_accepted_without_second_authority() -> None:
     assert not is_accepted_go_token("GO_UNKNOWN_TOKEN")
 
 
-def test_expected_origin_main_sha_rebound_to_pr4826_merge() -> None:
-    assert EXPECTED_ORIGIN_MAIN_SHA == "208ab96562f7750fb4dff43936b345a040d1cea4"
+def test_expected_origin_main_sha_rebound_to_class_d_materialized_main() -> None:
+    assert EXPECTED_ORIGIN_MAIN_SHA == "ddce9c508158b89fa225c381436e2d1efced7328"
 
 
 def test_pr4826_scope_does_not_create_new_execution_evidence_class() -> None:


### PR DESCRIPTION
## Summary
- Rebind the canonical offline economic evaluation execution owner to accept Class-D binding completion (`completion_digest=0610afa3…`) and materialized `origin/main=ddce9c5…`.
- Route Class-D preflight through dedicated binding/scope validators and load ratified scope from repo config.
- Canonicalize durable evaluation evidence path to `research/bounded_offline_economic_evaluation_final_research_fleet_v0_*` with documented legacy alias under `implementation/…`.
- No offline evaluation execution in this slice.

## Test plan
- [x] `pytest tests/research/test_final_research_fleet_class_d_bitcoin_drift_guard_v0.py`
- [x] `pytest tests/research/test_final_research_fleet_class_d_offline_evaluation_execution_owner_rebind_v0.py`
- [x] `pytest tests/research/test_final_research_fleet_offline_economic_evaluation_execution_v0.py`
- [x] `pytest tests/ops/test_post_pr4827_operator_decision_readiness_unmodified_binding_reexecution_blocked_progress_registry_contract_v0.py`
- [x] `ruff format --check` / `ruff check` on changed Python files
- [x] Durable evidence bundle with `MANIFEST_VERIFY_RC=0`


Made with [Cursor](https://cursor.com)