### PR TITLE
fix: stabilize class d offline evaluation current main contract after squash merges

### DIFF
--- a/scripts/ops/materialize_final_research_fleet_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/materialize_final_research_fleet_offline_economic_evaluation_execution_v0.py
@@ -25,13 +25,13 @@ for _path in (_SRC_ROOT, _REPO_ROOT):
 
 from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (  # noqa: E402
     AUTHORITY_EFFECT,
-    EXPECTED_ORIGIN_MAIN_SHA,
     GO_TOKEN,
     ORDER_EFFECT,
     RUNTIME_EFFECT,
     SCHEMA_VERSION,
     dumps_execution_canonical_v1,
     materialize_fleet_evaluation_summary_v0,
+    resolve_expected_origin_main_sha,
     run_candidate_economic_evaluation_v0,
     verify_execution_start_state_v0,
 )
@@ -127,7 +127,7 @@ def run_execution(
 
     start_state_payload = {
         "origin_main_head": start_state.origin_main_sha,
-        "expected_origin_main_head": EXPECTED_ORIGIN_MAIN_SHA,
+        "expected_origin_main_head": resolve_expected_origin_main_sha(_REPO_ROOT),
         "pr_4800_merged": True,
         "offline_economic_evaluation_scope_ratified": True,
         "economic_evaluation_executed": False,

--- a/scripts/ops/run_final_research_fleet_offline_economic_evaluation_v0.py
+++ b/scripts/ops/run_final_research_fleet_offline_economic_evaluation_v0.py
@@ -35,7 +35,6 @@ from src.backtest.economic_viability_evidence_v1 import (  # noqa: E402
 from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (  # noqa: E402
     ACCEPTED_GO_TOKENS,
     AUTHORITY_EFFECT,
-    EXPECTED_ORIGIN_MAIN_SHA,
     GO_TOKEN,
     LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX,
     LEGACY_DURABLE_EVIDENCE_SUBDIR,
@@ -43,10 +42,12 @@ from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 
     ORDER_EFFECT,
     PR4832_MERGE_COMMIT,
     PR4833_MERGE_COMMIT,
+    PR4834_MERGE_COMMIT,
     REQUIRED_MERGED_PR_NUMBER,
     RUNTIME_EFFECT,
     CandidateTerminalStatus,
-    CURRENT_EXECUTION_ORIGIN_MAIN_SHA,
+    resolve_current_execution_origin_main_sha,
+    resolve_expected_origin_main_sha,
     dumps_execution_canonical_v1,
     is_accepted_go_token,
     load_scope_ratification_for_execution_v0,
@@ -288,6 +289,8 @@ def run_evaluation(
     origin_ok, origin_reasons = verify_origin_main_sha_for_binding_v0(
         origin_main_sha=origin_main,
         fleet_binding_completion=fleet_binding_completion,
+        repo_root=_REPO_ROOT,
+        live_origin_main_sha=origin_main,
     )
     if not origin_ok:
         _die(f"ERR: origin_main_mismatch:{origin_reasons}")
@@ -328,14 +331,17 @@ def run_evaluation(
         timestamp_slug=ts_slug,
     )
 
+    expected_origin_main = resolve_expected_origin_main_sha(_REPO_ROOT)
+    current_execution_origin_main = resolve_current_execution_origin_main_sha(_REPO_ROOT)
     preflight_lines = [
         f"ORIGIN_MAIN={origin_main}",
         f"PR4826_MERGE_COMMIT={PR4826_MERGE_COMMIT}",
         f"PR4832_MERGE_COMMIT={PR4832_MERGE_COMMIT}",
         f"PR4833_MERGE_COMMIT={PR4833_MERGE_COMMIT}",
-        f"EXPECTED_ORIGIN_MAIN={EXPECTED_ORIGIN_MAIN_SHA}",
+        f"PR4834_MERGE_COMMIT={PR4834_MERGE_COMMIT}",
+        f"EXPECTED_ORIGIN_MAIN={expected_origin_main}",
         f"MATERIALIZED_CLASS_D_ORIGIN_MAIN={MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA}",
-        f"CURRENT_EXECUTION_ORIGIN_MAIN={CURRENT_EXECUTION_ORIGIN_MAIN_SHA}",
+        f"CURRENT_EXECUTION_ORIGIN_MAIN={current_execution_origin_main}",
         f"REQUIRED_MERGED_PR_NUMBER={REQUIRED_MERGED_PR_NUMBER}",
         f"DURABLE_EVIDENCE_SUBDIR={evidence_dir.parent.name}",
         f"DURABLE_EVIDENCE_BUNDLE={evidence_dir.name}",

--- a/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
+++ b/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
@@ -55,14 +55,20 @@ ACCEPTED_GO_TOKENS: frozenset[str] = frozenset({GO_TOKEN, GO_TOKEN_OPERATOR_ALIA
 PR4826_MERGE_COMMIT = "208ab96562f7750fb4dff43936b345a040d1cea4"
 PR4832_MERGE_COMMIT = "ddce9c508158b89fa225c381436e2d1efced7328"
 PR4833_MERGE_COMMIT = "4828168cd91c57aa72dcb3b40b47188eeb82fd32"
+PR4834_MERGE_COMMIT = "0d23e662c4a0b8e0638a919ac879490e82e2ef41"
+SQUASH_MERGE_IDENTITY_CONTRACT_INTRODUCED_AT = PR4834_MERGE_COMMIT
 MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA = PR4832_MERGE_COMMIT
-CURRENT_EXECUTION_ORIGIN_MAIN_SHA = PR4833_MERGE_COMMIT
-EXPECTED_ORIGIN_MAIN_SHA = CURRENT_EXECUTION_ORIGIN_MAIN_SHA
+# Class-D execution origin is resolved live from origin/main (identity-gated, not statically pinned).
+LEGACY_STATIC_EXECUTION_ORIGIN_MAIN_SHA = PR4833_MERGE_COMMIT
+# Deprecated static exports for import compatibility; Class-D verification uses live resolution.
+CURRENT_EXECUTION_ORIGIN_MAIN_SHA = LEGACY_STATIC_EXECUTION_ORIGIN_MAIN_SHA
+EXPECTED_ORIGIN_MAIN_SHA = LEGACY_STATIC_EXECUTION_ORIGIN_MAIN_SHA
 ACCEPTED_ORIGIN_MAIN_SHAS: frozenset[str] = frozenset(
     {
         PR4826_MERGE_COMMIT,
         MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
-        CURRENT_EXECUTION_ORIGIN_MAIN_SHA,
+        PR4833_MERGE_COMMIT,
+        PR4834_MERGE_COMMIT,
     }
 )
 REQUIRED_MERGED_PR_NUMBER = 4826
@@ -122,6 +128,9 @@ REASON_CANDIDATE_RUN_TIMEOUT = "CANDIDATE_RUN_TIMEOUT"
 REASON_CANDIDATE_EVIDENCE_MISSING = "CANDIDATE_EVIDENCE_MISSING"
 REASON_MANIFEST_VERIFY_FAILED = "MANIFEST_VERIFY_FAILED"
 REASON_BINDING_DIGEST_MISMATCH = "CANDIDATE_BINDING_DIGEST_MISMATCH"
+REASON_BINDING_IDENTITY_MISMATCH = "BINDING_IDENTITY_MISMATCH"
+REASON_CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE = "CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE"
+REASON_ORIGIN_MAIN_RESOLVE_FAILED = "ORIGIN_MAIN_RESOLVE_FAILED"
 REASON_UNMODIFIED_BINDING_RETRY_BLOCKED = "UNMODIFIED_BINDING_RETRY_BLOCKED"
 REASON_NEW_EVIDENCE_CLASS_REQUIRED = "NEW_EVIDENCE_CLASS_REQUIRED_FOR_REEXECUTION"
 
@@ -210,6 +219,44 @@ def _resolve_origin_main_sha(repo_root: Path) -> str:
     return result.stdout.strip()
 
 
+def resolve_current_execution_origin_main_sha(repo_root: Path) -> str:
+    """Resolve live origin/main as the Class-D execution origin candidate."""
+    return _resolve_origin_main_sha(repo_root)
+
+
+def resolve_expected_origin_main_sha(repo_root: Path) -> str:
+    """Legacy alias for resolve_current_execution_origin_main_sha."""
+    return resolve_current_execution_origin_main_sha(repo_root)
+
+
+def validate_current_main_against_immutable_binding_identity(
+    *,
+    origin_main_sha: str,
+    fleet_binding_completion: Mapping[str, Any],
+    live_origin_main_sha: str,
+) -> tuple[bool, tuple[str, ...]]:
+    """Accept live origin/main only when immutable Class-D binding anchors are unchanged."""
+    if not origin_main_sha or not live_origin_main_sha:
+        return False, (REASON_ORIGIN_MAIN_RESOLVE_FAILED,)
+    if origin_main_sha != live_origin_main_sha:
+        return False, (
+            f"{REASON_CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE}:"
+            f"{origin_main_sha}!={live_origin_main_sha}",
+        )
+    if origin_main_sha == MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA:
+        return False, (
+            f"{REASON_ORIGIN_MAIN_MISMATCH}:{origin_main_sha}==MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA",
+        )
+    if (
+        str(fleet_binding_completion.get("completion_digest", ""))
+        != CLASS_D_BINDING_COMPLETION_DIGEST
+    ):
+        return False, (f"{REASON_BINDING_IDENTITY_MISMATCH}:completion_digest",)
+    if fleet_binding_completion.get("schema_version") != CLASS_D_BINDING_COMPLETION_SCHEMA_VERSION:
+        return False, (f"{REASON_BINDING_IDENTITY_MISMATCH}:schema_version",)
+    return True, ()
+
+
 def is_accepted_go_token(token: str) -> bool:
     return token in ACCEPTED_GO_TOKENS
 
@@ -254,13 +301,20 @@ def verify_origin_main_sha_for_binding_v0(
     *,
     origin_main_sha: str,
     fleet_binding_completion: Mapping[str, Any],
+    repo_root: Path | None = None,
+    live_origin_main_sha: str | None = None,
 ) -> tuple[bool, tuple[str, ...]]:
     if is_class_d_binding_completion_v0(fleet_binding_completion):
-        if origin_main_sha != CURRENT_EXECUTION_ORIGIN_MAIN_SHA:
-            return False, (
-                f"{REASON_ORIGIN_MAIN_MISMATCH}:{origin_main_sha}!={CURRENT_EXECUTION_ORIGIN_MAIN_SHA}",
-            )
-        return True, ()
+        live = live_origin_main_sha
+        if live is None and repo_root is not None:
+            live = resolve_current_execution_origin_main_sha(repo_root)
+        if live is None:
+            return False, (REASON_ORIGIN_MAIN_RESOLVE_FAILED,)
+        return validate_current_main_against_immutable_binding_identity(
+            origin_main_sha=origin_main_sha,
+            fleet_binding_completion=fleet_binding_completion,
+            live_origin_main_sha=live,
+        )
     if not is_accepted_origin_main_sha(origin_main_sha):
         return False, (f"{REASON_ORIGIN_MAIN_MISMATCH}:{origin_main_sha}",)
     return True, ()
@@ -423,9 +477,12 @@ def verify_execution_start_state_v0(
 ) -> StartStateVerificationResultV0:
     reasons: list[str] = []
     resolved_origin = origin_main_sha or _resolve_origin_main_sha(repo_root)
+    live_origin = _resolve_origin_main_sha(repo_root)
     origin_ok, origin_reasons = verify_origin_main_sha_for_binding_v0(
         origin_main_sha=resolved_origin,
         fleet_binding_completion=fleet_binding_completion,
+        repo_root=repo_root,
+        live_origin_main_sha=live_origin,
     )
     if not origin_ok:
         reasons.extend(origin_reasons)

--- a/tests/ops/test_post_pr4827_operator_decision_readiness_unmodified_binding_reexecution_blocked_progress_registry_contract_v0.py
+++ b/tests/ops/test_post_pr4827_operator_decision_readiness_unmodified_binding_reexecution_blocked_progress_registry_contract_v0.py
@@ -125,10 +125,13 @@ class TestPostPr4827ExecutionOwnerAdmissibility:
 
     def test_sha_rebind_accepts_current_execution_main_without_new_evidence_class(self) -> None:
         from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
-            CURRENT_EXECUTION_ORIGIN_MAIN_SHA,
+            resolve_current_execution_origin_main_sha,
+            resolve_expected_origin_main_sha,
         )
 
-        assert EXPECTED_ORIGIN_MAIN_SHA == CURRENT_EXECUTION_ORIGIN_MAIN_SHA
+        assert resolve_expected_origin_main_sha(
+            REPO_ROOT
+        ) == resolve_current_execution_origin_main_sha(REPO_ROOT)
         assert is_accepted_origin_main_sha(PR4826_MERGE_COMMIT)
         assert PR4826_CREATES_NEW_EXECUTION_EVIDENCE_CLASS is False
 

--- a/tests/research/test_final_research_fleet_class_d_offline_evaluation_execution_owner_rebind_v0.py
+++ b/tests/research/test_final_research_fleet_class_d_offline_evaluation_execution_owner_rebind_v0.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -10,22 +11,24 @@ import pytest
 from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
     AUTHORITY_EFFECT,
     CLASS_D_BINDING_COMPLETION_DIGEST,
-    CURRENT_EXECUTION_ORIGIN_MAIN_SHA,
     DURABLE_EVIDENCE_BUNDLE_PREFIX,
     DURABLE_EVIDENCE_SUBDIR,
-    EXPECTED_ORIGIN_MAIN_SHA,
     GO_TOKEN_OPERATOR_ALIAS,
     LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX,
     LEGACY_DURABLE_EVIDENCE_SUBDIR,
+    LEGACY_STATIC_EXECUTION_ORIGIN_MAIN_SHA,
     MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
     ORDER_EFFECT,
     PR4826_MERGE_COMMIT,
     PR4832_MERGE_COMMIT,
+    PR4834_MERGE_COMMIT,
     RUNTIME_EFFECT,
     is_accepted_go_token,
     is_accepted_origin_main_sha,
     is_class_d_binding_completion_v0,
     load_scope_ratification_for_execution_v0,
+    resolve_current_execution_origin_main_sha,
+    resolve_expected_origin_main_sha,
     resolve_durable_evidence_bundle_dir_v0,
     resolve_legacy_durable_evidence_bundle_dir_v0,
     validate_binding_completion_for_execution_v0,
@@ -46,22 +49,25 @@ def fixture_class_d_binding_completion() -> dict:
     return json.loads(CLASS_D_BINDING_PATH.read_text(encoding="utf-8"))
 
 
-def test_expected_origin_main_sha_points_to_current_execution_main() -> None:
-    assert EXPECTED_ORIGIN_MAIN_SHA == CURRENT_EXECUTION_ORIGIN_MAIN_SHA
-    assert EXPECTED_ORIGIN_MAIN_SHA == "4828168cd91c57aa72dcb3b40b47188eeb82fd32"
+def test_execution_origin_resolves_from_live_origin_main() -> None:
+    live = resolve_current_execution_origin_main_sha(REPO_ROOT)
+    assert live == resolve_expected_origin_main_sha(REPO_ROOT)
+    assert live == PR4834_MERGE_COMMIT
+    assert live != LEGACY_STATIC_EXECUTION_ORIGIN_MAIN_SHA
 
 
 def test_materialization_sha_retained_but_not_current_execution_pin() -> None:
     assert MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA == PR4832_MERGE_COMMIT
     assert MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA == "ddce9c508158b89fa225c381436e2d1efced7328"
     assert is_accepted_origin_main_sha(MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA)
-    assert EXPECTED_ORIGIN_MAIN_SHA != MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA
+    assert (
+        resolve_current_execution_origin_main_sha(REPO_ROOT) != MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA
+    )
 
 
-def test_legacy_pr4826_sha_still_accepted_but_not_exclusive() -> None:
+def test_legacy_pr4826_sha_still_accepted_for_non_class_d_set() -> None:
     assert is_accepted_origin_main_sha(PR4826_MERGE_COMMIT)
-    assert is_accepted_origin_main_sha(CURRENT_EXECUTION_ORIGIN_MAIN_SHA)
-    assert EXPECTED_ORIGIN_MAIN_SHA != PR4826_MERGE_COMMIT
+    assert resolve_current_execution_origin_main_sha(REPO_ROOT) != PR4826_MERGE_COMMIT
 
 
 def test_class_d_completion_digest_accepted(class_d_binding_completion: dict) -> None:
@@ -76,18 +82,17 @@ def test_class_d_completion_digest_accepted(class_d_binding_completion: dict) ->
     assert reasons == ()
 
 
-def test_class_d_start_state_accepts_current_execution_origin_main(
-    class_d_binding_completion: dict,
-) -> None:
+def test_class_d_start_state_accepts_live_origin_main(class_d_binding_completion: dict) -> None:
     ratification = load_scope_ratification_for_execution_v0(
         repo_root=REPO_ROOT,
         fleet_binding_completion=class_d_binding_completion,
     )
+    live = resolve_current_execution_origin_main_sha(REPO_ROOT)
     result = verify_execution_start_state_v0(
         repo_root=REPO_ROOT,
         ratification=ratification,
         fleet_binding_completion=class_d_binding_completion,
-        origin_main_sha=CURRENT_EXECUTION_ORIGIN_MAIN_SHA,
+        origin_main_sha=live,
     )
     assert result.valid is True
     assert result.fail_reasons == ()
@@ -103,6 +108,7 @@ def test_class_d_start_state_rejects_materialization_sha_as_current_execution_or
     ok, reasons = verify_origin_main_sha_for_binding_v0(
         origin_main_sha=MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
         fleet_binding_completion=class_d_binding_completion,
+        live_origin_main_sha=MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
     )
     assert ok is False
     assert any("ORIGIN_MAIN_SHA_MISMATCH" in reason for reason in reasons)
@@ -129,7 +135,35 @@ def test_class_d_start_state_rejects_stale_pr4826_origin_only(
         origin_main_sha=PR4826_MERGE_COMMIT,
     )
     assert result.valid is False
-    assert any("ORIGIN_MAIN_SHA_MISMATCH" in reason for reason in result.fail_reasons)
+    assert any(
+        token in reason
+        for reason in result.fail_reasons
+        for token in ("ORIGIN_MAIN_SHA_MISMATCH", "CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE")
+    )
+
+
+def test_live_origin_main_sha_accepted_for_class_d_execution(
+    class_d_binding_completion: dict,
+) -> None:
+    live_origin_main = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "origin/main"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert live_origin_main == resolve_current_execution_origin_main_sha(REPO_ROOT)
+    ratification = load_scope_ratification_for_execution_v0(
+        repo_root=REPO_ROOT,
+        fleet_binding_completion=class_d_binding_completion,
+    )
+    result = verify_execution_start_state_v0(
+        repo_root=REPO_ROOT,
+        ratification=ratification,
+        fleet_binding_completion=class_d_binding_completion,
+        origin_main_sha=live_origin_main,
+    )
+    assert result.valid is True
+    assert result.fail_reasons == ()
 
 
 def test_durable_evidence_path_owner_contract() -> None:

--- a/tests/research/test_final_research_fleet_class_d_offline_evaluation_squash_merge_current_main_contract_v0.py
+++ b/tests/research/test_final_research_fleet_class_d_offline_evaluation_squash_merge_current_main_contract_v0.py
@@ -1,0 +1,166 @@
+"""Contract tests for Class-D squash-merge identity-gated current-main acceptance v0."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    CLASS_D_BINDING_COMPLETION_DIGEST,
+    GO_TOKEN_OPERATOR_ALIAS,
+    LEGACY_STATIC_EXECUTION_ORIGIN_MAIN_SHA,
+    MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
+    ORDER_EFFECT,
+    PR4834_MERGE_COMMIT,
+    REASON_BINDING_IDENTITY_MISMATCH,
+    REASON_CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE,
+    REASON_EVALUATION_ALREADY_EXECUTED,
+    REASON_ORIGIN_MAIN_MISMATCH,
+    RUNTIME_EFFECT,
+    is_accepted_go_token,
+    load_scope_ratification_for_execution_v0,
+    resolve_current_execution_origin_main_sha,
+    validate_current_main_against_immutable_binding_identity,
+    verify_execution_start_state_v0,
+    verify_origin_main_sha_for_binding_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLASS_D_BINDING_PATH = (
+    REPO_ROOT / "config/research/final_research_fleet_class_d_versioned_binding_completion_v0.json"
+)
+HYPOTHETICAL_POST_SQUASH_MAIN_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+STALE_PR4833_SHA = LEGACY_STATIC_EXECUTION_ORIGIN_MAIN_SHA
+
+
+@pytest.fixture(name="class_d_binding_completion")
+def fixture_class_d_binding_completion() -> dict:
+    assert CLASS_D_BINDING_PATH.is_file(), f"missing: {CLASS_D_BINDING_PATH}"
+    return json.loads(CLASS_D_BINDING_PATH.read_text(encoding="utf-8"))
+
+
+def test_live_origin_main_resolves_to_current_execution_candidate() -> None:
+    live = resolve_current_execution_origin_main_sha(REPO_ROOT)
+    expected = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "origin/main"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert live == expected
+    assert live == PR4834_MERGE_COMMIT
+
+
+def test_new_squash_merge_sha_accepted_when_binding_identity_unchanged(
+    class_d_binding_completion: dict,
+) -> None:
+    ok, reasons = validate_current_main_against_immutable_binding_identity(
+        origin_main_sha=HYPOTHETICAL_POST_SQUASH_MAIN_SHA,
+        fleet_binding_completion=class_d_binding_completion,
+        live_origin_main_sha=HYPOTHETICAL_POST_SQUASH_MAIN_SHA,
+    )
+    assert ok is True
+    assert reasons == ()
+
+
+def test_stale_pinned_pr4833_sha_rejected_when_live_main_advanced(
+    class_d_binding_completion: dict,
+) -> None:
+    ok, reasons = validate_current_main_against_immutable_binding_identity(
+        origin_main_sha=STALE_PR4833_SHA,
+        fleet_binding_completion=class_d_binding_completion,
+        live_origin_main_sha=PR4834_MERGE_COMMIT,
+    )
+    assert ok is False
+    assert any(REASON_CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE in reason for reason in reasons)
+
+
+def test_exclusive_static_pin_regression_no_longer_accepts_stale_main(
+    class_d_binding_completion: dict,
+) -> None:
+    ok, reasons = verify_origin_main_sha_for_binding_v0(
+        origin_main_sha=STALE_PR4833_SHA,
+        fleet_binding_completion=class_d_binding_completion,
+        live_origin_main_sha=PR4834_MERGE_COMMIT,
+    )
+    assert ok is False
+    assert STALE_PR4833_SHA != PR4834_MERGE_COMMIT
+    assert any(REASON_CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE in reason for reason in reasons)
+
+
+def test_materialization_sha_rejected_as_execution_origin(
+    class_d_binding_completion: dict,
+) -> None:
+    ok, reasons = validate_current_main_against_immutable_binding_identity(
+        origin_main_sha=MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
+        fleet_binding_completion=class_d_binding_completion,
+        live_origin_main_sha=MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
+    )
+    assert ok is False
+    assert any(REASON_ORIGIN_MAIN_MISMATCH in reason for reason in reasons)
+
+
+def test_changed_completion_digest_rejected(
+    class_d_binding_completion: dict,
+) -> None:
+    tampered = copy.deepcopy(class_d_binding_completion)
+    tampered["completion_digest"] = "0" * 64
+    ok, reasons = validate_current_main_against_immutable_binding_identity(
+        origin_main_sha=PR4834_MERGE_COMMIT,
+        fleet_binding_completion=tampered,
+        live_origin_main_sha=PR4834_MERGE_COMMIT,
+    )
+    assert ok is False
+    assert any(REASON_BINDING_IDENTITY_MISMATCH in reason for reason in reasons)
+
+
+def test_live_origin_main_accepted_for_class_d_start_state(
+    class_d_binding_completion: dict,
+) -> None:
+    ratification = load_scope_ratification_for_execution_v0(
+        repo_root=REPO_ROOT,
+        fleet_binding_completion=class_d_binding_completion,
+    )
+    result = verify_execution_start_state_v0(
+        repo_root=REPO_ROOT,
+        ratification=ratification,
+        fleet_binding_completion=class_d_binding_completion,
+    )
+    assert result.valid is True
+    assert result.origin_main_sha == PR4834_MERGE_COMMIT
+    assert class_d_binding_completion["completion_digest"] == CLASS_D_BINDING_COMPLETION_DIGEST
+
+
+def test_evaluation_authorization_still_blocked_without_go_token() -> None:
+    assert is_accepted_go_token(GO_TOKEN_OPERATOR_ALIAS) is True
+    assert is_accepted_go_token("GO_UNKNOWN") is False
+
+
+def test_changed_scope_ratification_rejects_execution_without_go(
+    class_d_binding_completion: dict,
+) -> None:
+    ratification = load_scope_ratification_for_execution_v0(
+        repo_root=REPO_ROOT,
+        fleet_binding_completion=class_d_binding_completion,
+    )
+    tampered = copy.deepcopy(ratification)
+    tampered["economic_evaluation_executed"] = True
+    result = verify_execution_start_state_v0(
+        repo_root=REPO_ROOT,
+        ratification=tampered,
+        fleet_binding_completion=class_d_binding_completion,
+        origin_main_sha=PR4834_MERGE_COMMIT,
+    )
+    assert result.valid is False
+    assert any(REASON_EVALUATION_ALREADY_EXECUTED in reason for reason in result.fail_reasons)
+
+
+def test_runtime_authority_flags_remain_false() -> None:
+    assert AUTHORITY_EFFECT == "NONE"
+    assert RUNTIME_EFFECT == "NONE"
+    assert ORDER_EFFECT == "NONE"

--- a/tests/research/test_final_research_fleet_offline_economic_evaluation_execution_v0.py
+++ b/tests/research/test_final_research_fleet_offline_economic_evaluation_execution_v0.py
@@ -12,12 +12,12 @@ from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 
     AUTHORITY_EFFECT,
     CandidateExecutionResultV0,
     CandidateTerminalStatus,
-    EXPECTED_ORIGIN_MAIN_SHA,
     FleetTerminalStatus,
     GO_TOKEN,
     GO_TOKEN_OPERATOR_ALIAS,
     HISTORICAL_STEP31F_BINDING_COMPLETION_DIGEST,
     ORDER_EFFECT,
+    PR4834_MERGE_COMMIT,
     PR4826_CREATES_NEW_EXECUTION_EVIDENCE_CLASS,
     REASON_NEW_EVIDENCE_CLASS_REQUIRED,
     REASON_UNMODIFIED_BINDING_RETRY_BLOCKED,
@@ -25,6 +25,7 @@ from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 
     is_accepted_go_token,
     map_candidate_terminal_status_v0,
     materialize_fleet_evaluation_summary_v0,
+    resolve_current_execution_origin_main_sha,
     resolve_fleet_terminal_status_v0,
     verify_execution_start_state_v0,
     verify_unmodified_retry_admissibility_v0,
@@ -71,8 +72,9 @@ def test_go_token_operator_alias_is_accepted_without_second_authority() -> None:
     assert not is_accepted_go_token("GO_UNKNOWN_TOKEN")
 
 
-def test_expected_origin_main_sha_rebound_to_current_execution_main() -> None:
-    assert EXPECTED_ORIGIN_MAIN_SHA == "4828168cd91c57aa72dcb3b40b47188eeb82fd32"
+def test_expected_origin_main_sha_resolves_from_live_origin_main() -> None:
+    live = resolve_current_execution_origin_main_sha(REPO_ROOT)
+    assert live == PR4834_MERGE_COMMIT
 
 
 def test_pr4826_scope_does_not_create_new_execution_evidence_class() -> None:
@@ -232,7 +234,7 @@ def test_fleet_summary_preserves_individual_failures(
         ratification=scope_ratification,
         candidate_results=results,
         execution_bundle_dir="/tmp/fleet",
-        origin_main_sha=EXPECTED_ORIGIN_MAIN_SHA,
+        origin_main_sha=resolve_current_execution_origin_main_sha(REPO_ROOT),
     )
     assert summary["individual_failure_preservation"] is True
     assert summary["fail_count"] == 3
@@ -266,7 +268,7 @@ def test_start_state_verification_blocks_unmodified_step31f_retry() -> None:
         repo_root=REPO_ROOT,
         ratification=scope_ratification,
         fleet_binding_completion=fleet_binding_completion,
-        origin_main_sha=EXPECTED_ORIGIN_MAIN_SHA,
+        origin_main_sha=resolve_current_execution_origin_main_sha(REPO_ROOT),
     )
     assert result.valid is False
     assert REASON_UNMODIFIED_BINDING_RETRY_BLOCKED in result.fail_reasons


### PR DESCRIPTION
## Summary
- Replace static `CURRENT_EXECUTION_ORIGIN_MAIN_SHA` pin with identity-gated live `origin/main` acceptance for Class-D offline evaluation preflight.
- Accept current squash-merge main head when immutable anchors (`completion_digest`, schema) and repo binding identity remain unchanged.
- Reject stale pinned SHAs, materialization SHA as execution origin, and tampered completion digests without loosening safety gates.
- No evaluation, backtest, runtime, or live/paper/testnet/shadow actions in this slice.

## Test plan
- [x] `ruff format --check` / `ruff check` on changed Python files
- [x] `git diff --check`
- [x] New squash-merge identity contract tests (10 cases)
- [x] Updated Class-D rebind / execution / post-PR4827 contract tests
- [x] Bitcoin drift guard (52 passed total)


Made with [Cursor](https://cursor.com)