### PR TITLE
test(research): fail closed class-d final fleet selector v0

### DIFF
--- a/scripts/ops/run_final_research_fleet_offline_economic_evaluation_v0.py
+++ b/scripts/ops/run_final_research_fleet_offline_economic_evaluation_v0.py
@@ -7,6 +7,7 @@ from PR #4832 (or legacy PR #4826 bindings when explicitly supplied).
 No runtime, order, or authority effect.
 Operator GO (canonical): GO_EXECUTE_BOUNDED_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_V0
 Operator GO (alias): GO_BOUNDED_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_FOR_VERSIONED_FINAL_RESEARCH_FLEET_V0
+Operator GO (Class-D final): GO_BOUNDED_CLASS_D_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_V0
 """
 
 from __future__ import annotations
@@ -19,7 +20,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SRC_ROOT = _REPO_ROOT / "src"
@@ -35,19 +36,25 @@ from src.backtest.economic_viability_evidence_v1 import (  # noqa: E402
 from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (  # noqa: E402
     ACCEPTED_GO_TOKENS,
     AUTHORITY_EFFECT,
+    CLASS_D_FINAL_DURABLE_EVIDENCE_BUNDLE_PREFIX,
     GO_TOKEN,
+    GO_TOKEN_CLASS_D_FINAL,
     LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX,
     LEGACY_DURABLE_EVIDENCE_SUBDIR,
     MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
     ORDER_EFFECT,
+    PR4826_MERGE_COMMIT,
     PR4832_MERGE_COMMIT,
     PR4833_MERGE_COMMIT,
     PR4834_MERGE_COMMIT,
     REQUIRED_MERGED_PR_NUMBER,
     RUNTIME_EFFECT,
     CandidateTerminalStatus,
+    is_class_d_binding_completion_v0,
     resolve_current_execution_origin_main_sha,
+    resolve_durable_evidence_bundle_dir_for_binding_v0,
     resolve_expected_origin_main_sha,
+    resolve_authorized_fleet_candidates_for_execution_v0,
     dumps_execution_canonical_v1,
     is_accepted_go_token,
     load_scope_ratification_for_execution_v0,
@@ -223,6 +230,275 @@ def _build_binding_digest_verification(
     }
 
 
+def _write_evaluation_plan_md(
+    *,
+    evidence_dir: Path,
+    origin_main: str,
+    fleet_binding_completion: Mapping[str, Any],
+    ratification: Mapping[str, Any],
+    go_token: str,
+    authorized_candidates: Sequence[tuple[str, str]],
+) -> None:
+    candidates = fleet_binding_completion.get("candidates", [])
+    lines = [
+        "# EVALUATION_PLAN",
+        "",
+        "## Scope",
+        "",
+        "- Classification: `BOUNDED_CLASS_D_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_V0`",
+        "- Mode: offline-only, non-authorizing",
+        f"- GO token consumed: `{go_token}`",
+        f"- Origin/main: `{origin_main}`",
+        f"- Fleet binding digest: `{fleet_binding_completion.get('completion_digest', '')}`",
+        f"- Ratification digest: `{ratification.get('ratification_digest', '')}`",
+        "",
+        "## Final Fleet",
+        "",
+        "| strategy_id | strategy_version |",
+        "|---|---|",
+    ]
+    for strategy_id, strategy_version in authorized_candidates:
+        lines.append(f"| `{strategy_id}` | `{strategy_version}` |")
+    lines.extend(
+        [
+            "",
+            "## Stages (all candidates, identical economic policy)",
+            "",
+            "- OFFLINE_BACKTEST",
+            "- WALK_FORWARD",
+            "- MONTE_CARLO",
+            "- STRESS",
+            "- PARAMETER_SENSITIVITY",
+            "- ECONOMIC_VIABILITY_EVIDENCE_MATERIALIZATION",
+            "",
+            "## Safety",
+            "",
+            "- NO_LIVE / NO_PAPER / NO_TESTNET / NO_SHADOW",
+            "- NO_RUNTIME_REWIRE / NO_ORDERS / NO_CREDENTIALS",
+            "- RUNTIME_REWIRE_ADMISSIBLE=false",
+            "- LIVE_AUTHORIZED=false",
+            "",
+            "## Binding owners (reuse-first)",
+            "",
+            "- `scripts/run_backtest.py`",
+            "- `src/backtest/engine.py`",
+            "- `src/backtest/walkforward.py`",
+            "- `src/experiments/monte_carlo.py`",
+            "- `src/experiments/stress_tests.py`",
+            "- `src/backtest/stats.py`",
+            "- `src/backtest/economic_viability_evidence_v1.py`",
+            "- `scripts/ops/run_economic_viability_evidence_evaluation_v1.py`",
+            "",
+            "## Candidate bindings",
+            "",
+        ]
+    )
+    for candidate in candidates:
+        if not isinstance(candidate, Mapping):
+            continue
+        sid = str(candidate.get("strategy_id", ""))
+        lines.append(f"### {sid}/v1")
+        for key in (
+            "parameter_binding",
+            "dataset_binding",
+            "period_binding",
+            "instrument_binding",
+            "fee_model_binding",
+            "slippage_model_binding",
+            "funding_model_binding",
+            "execution_model_binding",
+            "economic_policy_binding",
+            "implementation_digest",
+            "config_digest",
+            "data_digest",
+        ):
+            value = candidate.get(key)
+            if value is not None:
+                lines.append(f"- `{key}`: present")
+            else:
+                lines.append(f"- `{key}`: **MISSING**")
+        lines.append("")
+    evidence_dir.joinpath("EVALUATION_PLAN.md").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+
+def _write_binding_admissibility_matrix_md(
+    *,
+    evidence_dir: Path,
+    fleet_binding_completion: Mapping[str, Any],
+    binding_digest_verification: Mapping[str, Any],
+    comparability: Mapping[str, Any],
+) -> None:
+    lines = [
+        "# BINDING_ADMISSIBILITY_MATRIX",
+        "",
+        f"- binding_digest_verification_pass: `{binding_digest_verification.get('binding_digest_verification_pass')}`",
+        f"- common_economic_policy_pass: `{comparability.get('common_economic_policy_pass')}`",
+        "",
+        "## Per-candidate binding fields",
+        "",
+    ]
+    for candidate in fleet_binding_completion.get("candidates", ()):
+        if not isinstance(candidate, Mapping):
+            continue
+        sid = str(candidate.get("strategy_id", ""))
+        lines.append(f"### {sid}/v1")
+        required = (
+            "strategy_id",
+            "strategy_version",
+            "parameter_binding",
+            "dataset_binding",
+            "period_binding",
+            "instrument_binding",
+            "fee_model_binding",
+            "slippage_model_binding",
+            "funding_model_binding",
+            "execution_model_binding",
+            "economic_policy_binding",
+            "implementation_digest",
+            "config_digest",
+            "data_digest",
+        )
+        for key in required:
+            present = candidate.get(key) is not None
+            lines.append(f"- `{key}`: {'PRESENT' if present else 'MISSING'}")
+        lines.append("")
+    evidence_dir.joinpath("BINDING_ADMISSIBILITY_MATRIX.md").write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_candidate_results_summary_md(
+    *,
+    evidence_dir: Path,
+    candidate_reports: Mapping[str, Mapping[str, Any]],
+    fleet_summary: Mapping[str, Any],
+) -> None:
+    lines = [
+        "# CANDIDATE_RESULTS_SUMMARY",
+        "",
+        f"- fleet_status: `{fleet_summary.get('fleet_status')}`",
+        f"- economic_validity_offline_gate_pass: `{fleet_summary.get('economic_validity_offline_gate_pass')}`",
+        f"- pass_count: `{fleet_summary.get('pass_count')}`",
+        f"- fail_count: `{fleet_summary.get('fail_count')}`",
+        f"- inconclusive_count: `{fleet_summary.get('inconclusive_count')}`",
+        "- runtime_rewire_admissible: `false`",
+        "- live_authorized: `false`",
+        "",
+        "| candidate | terminal_verdict | net_return | sharpe | max_drawdown | trade_count |",
+        "|---|---|---:|---:|---:|---:|",
+    ]
+    for strategy_id, report in sorted(candidate_reports.items()):
+        lines.append(
+            "| `{sid}` | `{verdict}` | `{net}` | `{sharpe}` | `{mdd}` | `{tc}` |".format(
+                sid=strategy_id,
+                verdict=report.get("terminal_verdict"),
+                net=report.get("net_return"),
+                sharpe=report.get("sharpe"),
+                mdd=report.get("max_drawdown"),
+                tc=report.get("trade_count"),
+            )
+        )
+    evidence_dir.joinpath("CANDIDATE_RESULTS_SUMMARY.md").write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_failure_or_inconclusive_reason_codes_md(
+    *,
+    evidence_dir: Path,
+    candidate_reports: Mapping[str, Mapping[str, Any]],
+    fleet_summary: Mapping[str, Any],
+) -> None:
+    lines = [
+        "# FAILURE_OR_INCONCLUSIVE_REASON_CODES",
+        "",
+        f"- fleet_status: `{fleet_summary.get('fleet_status')}`",
+        "",
+    ]
+    any_codes = False
+    for strategy_id, report in sorted(candidate_reports.items()):
+        verdict = report.get("terminal_verdict")
+        codes = report.get("reason_codes") or []
+        if verdict in {"FAIL", "INCONCLUSIVE"} or codes:
+            any_codes = True
+            lines.append(f"## {strategy_id}")
+            lines.append(f"- terminal_verdict: `{verdict}`")
+            lines.append(f"- reason_codes: `{codes}`")
+            lines.append("")
+    if not any_codes:
+        lines.append("No FAIL/INCONCLUSIVE reason codes recorded.")
+        lines.append("")
+    evidence_dir.joinpath("FAILURE_OR_INCONCLUSIVE_REASON_CODES.md").write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_blocking_evidence_bundle(
+    *,
+    evidence_dir: Path,
+    origin_main: str,
+    fleet_binding_completion: Mapping[str, Any],
+    ratification: Mapping[str, Any],
+    fail_reasons: tuple[str, ...],
+    go_token: str,
+) -> dict[str, Any]:
+    evidence_dir.mkdir(parents=True, exist_ok=False)
+    _write_evaluation_plan_md(
+        evidence_dir=evidence_dir,
+        origin_main=origin_main,
+        fleet_binding_completion=fleet_binding_completion,
+        ratification=ratification,
+        go_token=go_token,
+        authorized_candidates=resolve_authorized_fleet_candidates_for_execution_v0(
+            fleet_binding_completion=fleet_binding_completion,
+            ratification=ratification,
+        ),
+    )
+    blocking = {
+        "status": "CLASS_D_EVALUATION_BLOCKED_MISSING_VERSIONED_BINDING",
+        "fail_reasons": list(fail_reasons),
+        "evaluation_executed": False,
+        "origin_main_sha": origin_main,
+        "generated_at_utc": _utc_now_z(),
+    }
+    (evidence_dir / "BLOCKING_EVIDENCE.json").write_text(
+        json.dumps(blocking, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "BINDING_ADMISSIBILITY_MATRIX.md").write_text(
+        "# BINDING_ADMISSIBILITY_MATRIX\n\n"
+        f"- verdict: `CLASS_D_EVALUATION_BLOCKED_MISSING_VERSIONED_BINDING`\n"
+        f"- fail_reasons: `{list(fail_reasons)}`\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "CANDIDATE_RESULTS_SUMMARY.md").write_text(
+        "# CANDIDATE_RESULTS_SUMMARY\n\n"
+        "- evaluation_executed: `false`\n"
+        "- fleet_status: `INCONCLUSIVE`\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "FAILURE_OR_INCONCLUSIVE_REASON_CODES.md").write_text(
+        "# FAILURE_OR_INCONCLUSIVE_REASON_CODES\n\n"
+        + "\n".join(f"- `{reason}`" for reason in fail_reasons)
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(evidence_dir)
+    return {
+        "verdict": "CLASS_D_EVALUATION_BLOCKED_MISSING_VERSIONED_BINDING",
+        "evaluation_executed": False,
+        "durable_evidence_path": str(evidence_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "fail_reasons": list(fail_reasons),
+    }
+
+
 def _build_common_policy_comparability_matrix(
     fleet_binding_completion: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -308,6 +584,14 @@ def run_evaluation(
     if not start_state.valid:
         _die(f"ERR: start_state_verification_failed:{start_state.fail_reasons}")
 
+    try:
+        authorized_candidates = resolve_authorized_fleet_candidates_for_execution_v0(
+            fleet_binding_completion=fleet_binding_completion,
+            ratification=ratification,
+        )
+    except ValueError as exc:
+        _die(f"ERR: {exc}")
+
     binding_digest_verification = _build_binding_digest_verification(
         repo_root=_REPO_ROOT,
         fleet_binding_completion=fleet_binding_completion,
@@ -321,14 +605,29 @@ def run_evaluation(
         _die("ERR: common_policy_comparability_failed")
 
     ts_slug = _utc_slug()
-    evidence_dir = resolve_durable_evidence_bundle_dir_v0(
+    evidence_dir = resolve_durable_evidence_bundle_dir_for_binding_v0(
         durable_evidence_root=durable_evidence_root,
         timestamp_slug=ts_slug,
+        fleet_binding_completion=fleet_binding_completion,
     )
     evidence_dir.mkdir(parents=True, exist_ok=False)
     legacy_evidence_dir = resolve_legacy_durable_evidence_bundle_dir_v0(
         durable_evidence_root=durable_evidence_root,
         timestamp_slug=ts_slug,
+    )
+    _write_evaluation_plan_md(
+        evidence_dir=evidence_dir,
+        origin_main=origin_main,
+        fleet_binding_completion=fleet_binding_completion,
+        ratification=ratification,
+        go_token=confirm,
+        authorized_candidates=authorized_candidates,
+    )
+    _write_binding_admissibility_matrix_md(
+        evidence_dir=evidence_dir,
+        fleet_binding_completion=fleet_binding_completion,
+        binding_digest_verification=binding_digest_verification,
+        comparability=comparability,
     )
 
     expected_origin_main = resolve_expected_origin_main_sha(_REPO_ROOT)
@@ -349,7 +648,8 @@ def run_evaluation(
         "FINAL_RESEARCH_FLEET_BINDING_READY=true",
         "NEW_CANDIDATES_RATIFIED=true",
         "ECONOMIC_EVALUATION_SCOPE_RATIFIED=true",
-        f"GO_TOKEN={GO_TOKEN}",
+        f"AUTHORIZED_CANDIDATES={','.join(f'{sid}/{ver}' for sid, ver in authorized_candidates)}",
+        f"GO_TOKEN={confirm}",
         f"VERIFIED_AT_UTC={_utc_now_z()}",
     ]
     (evidence_dir / "preflight.txt").write_text("\n".join(preflight_lines) + "\n", encoding="utf-8")
@@ -391,6 +691,8 @@ def run_evaluation(
                 "legacy_alias_path": str(legacy_evidence_dir),
                 "legacy_subdir": LEGACY_DURABLE_EVIDENCE_SUBDIR,
                 "legacy_prefix": LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX,
+                "class_d_final_prefix": CLASS_D_FINAL_DURABLE_EVIDENCE_BUNDLE_PREFIX,
+                "class_d_binding": is_class_d_binding_completion_v0(fleet_binding_completion),
             },
             indent=2,
             sort_keys=True,
@@ -405,7 +707,7 @@ def run_evaluation(
     candidate_results = []
     candidate_reports: dict[str, dict[str, Any]] = {}
     execution_plan = {"candidates": []}
-    for strategy_id, strategy_version in FLEET_CANDIDATES:
+    for strategy_id, strategy_version in authorized_candidates:
         candidate_dir = evidence_dir / f"candidate_{strategy_id}"
         config_path = _REPO_ROOT / STEP31F_CONFIG_PATHS[strategy_id]
         execution_plan["candidates"].append(
@@ -428,6 +730,10 @@ def run_evaluation(
             strategy_id=strategy_id,
             candidate_dir=candidate_dir,
             terminal_status=result.terminal_status,
+        )
+        shutil.copy2(
+            candidate_dir / ARTIFACT_FILENAME,
+            evidence_dir / f"ECONOMIC_VIABILITY_EVIDENCE_{strategy_id}.json",
         )
         shutil.copy2(
             candidate_dir / ARTIFACT_FILENAME,
@@ -490,6 +796,17 @@ def run_evaluation(
         encoding="utf-8",
     )
 
+    _write_candidate_results_summary_md(
+        evidence_dir=evidence_dir,
+        candidate_reports=candidate_reports,
+        fleet_summary=fleet_summary,
+    )
+    _write_failure_or_inconclusive_reason_codes_md(
+        evidence_dir=evidence_dir,
+        candidate_reports=candidate_reports,
+        fleet_summary=fleet_summary,
+    )
+
     env_snapshot = [
         f"PYTHON={sys.executable}",
         f"PLATFORM={platform.platform()}",
@@ -520,8 +837,9 @@ def run_evaluation(
 
     payload = {
         "verdict": "FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_COMPLETE",
-        "go_token": GO_TOKEN,
+        "go_token": confirm,
         "go_token_consumed": True,
+        "evaluation_executed": True,
         "origin_main_sha": origin_main,
         "fleet_status": fleet_summary["fleet_status"],
         "economic_validity_offline_gate_pass": fleet_summary["economic_validity_offline_gate_pass"],

--- a/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
+++ b/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
@@ -51,7 +51,10 @@ GO_TOKEN = "GO_EXECUTE_BOUNDED_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_
 GO_TOKEN_OPERATOR_ALIAS = (
     "GO_BOUNDED_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_FOR_VERSIONED_FINAL_RESEARCH_FLEET_V0"
 )
-ACCEPTED_GO_TOKENS: frozenset[str] = frozenset({GO_TOKEN, GO_TOKEN_OPERATOR_ALIAS})
+GO_TOKEN_CLASS_D_FINAL = "GO_BOUNDED_CLASS_D_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_V0"
+ACCEPTED_GO_TOKENS: frozenset[str] = frozenset(
+    {GO_TOKEN, GO_TOKEN_OPERATOR_ALIAS, GO_TOKEN_CLASS_D_FINAL}
+)
 PR4826_MERGE_COMMIT = "208ab96562f7750fb4dff43936b345a040d1cea4"
 PR4832_MERGE_COMMIT = "ddce9c508158b89fa225c381436e2d1efced7328"
 PR4833_MERGE_COMMIT = "4828168cd91c57aa72dcb3b40b47188eeb82fd32"
@@ -88,6 +91,9 @@ DURABLE_EVIDENCE_BUNDLE_PREFIX = "bounded_offline_economic_evaluation_final_rese
 LEGACY_DURABLE_EVIDENCE_SUBDIR = "implementation"
 LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX = (
     "bounded_final_research_fleet_offline_economic_evaluation_v0"
+)
+CLASS_D_FINAL_DURABLE_EVIDENCE_BUNDLE_PREFIX = (
+    "bounded_class_d_final_research_fleet_offline_economic_evaluation_v0"
 )
 HISTORICAL_STEP31F_BINDING_COMPLETION_DIGEST = (
     "161d834e5153df78a0013b6e55c4c8bd4788c775811e3678f025104a307d78f1"
@@ -133,6 +139,19 @@ REASON_CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE = "CURRENT_MAIN_SHA_DRIFT_AFTER
 REASON_ORIGIN_MAIN_RESOLVE_FAILED = "ORIGIN_MAIN_RESOLVE_FAILED"
 REASON_UNMODIFIED_BINDING_RETRY_BLOCKED = "UNMODIFIED_BINDING_RETRY_BLOCKED"
 REASON_NEW_EVIDENCE_CLASS_REQUIRED = "NEW_EVIDENCE_CLASS_REQUIRED_FOR_REEXECUTION"
+REASON_UNAUTHORIZED_CANDIDATE = "UNAUTHORIZED_CANDIDATE_NOT_IN_CLASS_D_FINAL_FLEET"
+REASON_BITCOIN_LABELLED_CANDIDATE = "BITCOIN_LABELLED_CANDIDATE_REJECTED_FOR_CLASS_D_FINAL_FLEET"
+REASON_CLASS_D_FINAL_FLEET_CANDIDATE_SET_MISMATCH = "CLASS_D_FINAL_FLEET_CANDIDATE_SET_MISMATCH"
+
+AUTHORIZED_CLASS_D_FINAL_FLEET_STRATEGY_IDS: frozenset[str] = frozenset(
+    {"trend_following", "bollinger_bands", "momentum_1h"}
+)
+AUTHORIZED_CLASS_D_FINAL_FLEET_CANDIDATES: tuple[tuple[str, str], ...] = (
+    ("trend_following", "v1"),
+    ("bollinger_bands", "v1"),
+    ("momentum_1h", "v1"),
+)
+_BITCOIN_CANDIDATE_SUBSTRINGS: frozenset[str] = frozenset({"btc", "xbt", "bitcoin"})
 
 
 class CandidateTerminalStatus(str, Enum):
@@ -273,6 +292,88 @@ def is_class_d_binding_completion_v0(fleet_binding_completion: Mapping[str, Any]
     )
 
 
+def _candidate_identifier_contains_bitcoin_label(strategy_id: str) -> bool:
+    lowered = strategy_id.lower()
+    return any(token in lowered for token in _BITCOIN_CANDIDATE_SUBSTRINGS)
+
+
+def resolve_class_d_final_fleet_candidates_v0(
+    *,
+    fleet_binding_completion: Mapping[str, Any] | None = None,
+    ratification: Mapping[str, Any] | None = None,
+) -> tuple[tuple[str, str], ...]:
+    """Resolve the exact authorized Class-D final fleet candidate list (fail-closed source)."""
+    if fleet_binding_completion is not None:
+        resolved: list[tuple[str, str]] = []
+        for candidate in fleet_binding_completion.get("candidates", ()):
+            if not isinstance(candidate, Mapping):
+                continue
+            resolved.append((str(candidate["strategy_id"]), str(candidate["strategy_version"])))
+        if resolved:
+            return tuple(resolved)
+    if ratification is not None:
+        refs = ratification.get("candidate_refs")
+        if isinstance(refs, list):
+            parsed: list[tuple[str, str]] = []
+            for ref in refs:
+                if not isinstance(ref, str) or "/" not in ref:
+                    continue
+                strategy_id, strategy_version = ref.split("/", 1)
+                parsed.append((strategy_id, strategy_version))
+            if parsed:
+                return tuple(parsed)
+    return AUTHORIZED_CLASS_D_FINAL_FLEET_CANDIDATES
+
+
+def validate_class_d_final_fleet_candidate_scope_v0(
+    *,
+    candidates: Sequence[tuple[str, str]] | None = None,
+    fleet_binding_completion: Mapping[str, Any] | None = None,
+    ratification: Mapping[str, Any] | None = None,
+) -> tuple[bool, tuple[str, ...], tuple[tuple[str, str], ...]]:
+    """Fail closed unless candidates match the authorized Class-D final fleet exactly."""
+    resolved = candidates or resolve_class_d_final_fleet_candidates_v0(
+        fleet_binding_completion=fleet_binding_completion,
+        ratification=ratification,
+    )
+    reasons: list[str] = []
+    resolved_ids = {strategy_id for strategy_id, _ in resolved}
+    authorized_ids = set(AUTHORIZED_CLASS_D_FINAL_FLEET_STRATEGY_IDS)
+    if resolved_ids != authorized_ids:
+        extra = sorted(resolved_ids - authorized_ids)
+        missing = sorted(authorized_ids - resolved_ids)
+        if extra:
+            reasons.append(f"{REASON_UNAUTHORIZED_CANDIDATE}:{','.join(extra)}")
+        if missing:
+            reasons.append(
+                f"{REASON_CLASS_D_FINAL_FLEET_CANDIDATE_SET_MISMATCH}:missing={','.join(missing)}"
+            )
+    if tuple(resolved) != AUTHORIZED_CLASS_D_FINAL_FLEET_CANDIDATES:
+        reasons.append(
+            f"{REASON_CLASS_D_FINAL_FLEET_CANDIDATE_SET_MISMATCH}:resolved={tuple(resolved)}"
+        )
+    for strategy_id, _ in resolved:
+        if _candidate_identifier_contains_bitcoin_label(strategy_id):
+            reasons.append(f"{REASON_BITCOIN_LABELLED_CANDIDATE}:{strategy_id}")
+    return not reasons, tuple(reasons), tuple(resolved)
+
+
+def resolve_authorized_fleet_candidates_for_execution_v0(
+    *,
+    fleet_binding_completion: Mapping[str, Any],
+    ratification: Mapping[str, Any] | None = None,
+) -> tuple[tuple[str, str], ...]:
+    if is_class_d_binding_completion_v0(fleet_binding_completion):
+        ok, reasons, resolved = validate_class_d_final_fleet_candidate_scope_v0(
+            fleet_binding_completion=fleet_binding_completion,
+            ratification=ratification,
+        )
+        if not ok:
+            raise ValueError(f"class_d_final_fleet_candidate_scope_invalid:{reasons}")
+        return resolved
+    return FLEET_CANDIDATES
+
+
 def resolve_durable_evidence_bundle_dir_v0(
     *,
     durable_evidence_root: Path,
@@ -294,6 +395,35 @@ def resolve_legacy_durable_evidence_bundle_dir_v0(
         durable_evidence_root
         / LEGACY_DURABLE_EVIDENCE_SUBDIR
         / f"{LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX}_{timestamp_slug}"
+    )
+
+
+def resolve_class_d_final_durable_evidence_bundle_dir_v0(
+    *,
+    durable_evidence_root: Path,
+    timestamp_slug: str,
+) -> Path:
+    return (
+        durable_evidence_root
+        / LEGACY_DURABLE_EVIDENCE_SUBDIR
+        / f"{CLASS_D_FINAL_DURABLE_EVIDENCE_BUNDLE_PREFIX}_{timestamp_slug}"
+    )
+
+
+def resolve_durable_evidence_bundle_dir_for_binding_v0(
+    *,
+    durable_evidence_root: Path,
+    timestamp_slug: str,
+    fleet_binding_completion: Mapping[str, Any],
+) -> Path:
+    if is_class_d_binding_completion_v0(fleet_binding_completion):
+        return resolve_class_d_final_durable_evidence_bundle_dir_v0(
+            durable_evidence_root=durable_evidence_root,
+            timestamp_slug=timestamp_slug,
+        )
+    return resolve_durable_evidence_bundle_dir_v0(
+        durable_evidence_root=durable_evidence_root,
+        timestamp_slug=timestamp_slug,
     )
 
 
@@ -539,6 +669,14 @@ def verify_execution_start_state_v0(
     )
     if not retry_ok:
         reasons.extend(retry_reasons)
+
+    if is_class_d_binding_completion_v0(fleet_binding_completion):
+        scope_ok, scope_reasons, _ = validate_class_d_final_fleet_candidate_scope_v0(
+            fleet_binding_completion=fleet_binding_completion,
+            ratification=ratification,
+        )
+        if not scope_ok:
+            reasons.extend(scope_reasons)
 
     return StartStateVerificationResultV0(
         valid=not reasons,

--- a/tests/research/test_final_research_fleet_class_d_offline_evaluation_execution_owner_rebind_v0.py
+++ b/tests/research/test_final_research_fleet_class_d_offline_evaluation_execution_owner_rebind_v0.py
@@ -10,9 +10,13 @@ import pytest
 
 from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
     AUTHORITY_EFFECT,
+    AUTHORIZED_CLASS_D_FINAL_FLEET_CANDIDATES,
+    AUTHORIZED_CLASS_D_FINAL_FLEET_STRATEGY_IDS,
     CLASS_D_BINDING_COMPLETION_DIGEST,
+    CLASS_D_FINAL_DURABLE_EVIDENCE_BUNDLE_PREFIX,
     DURABLE_EVIDENCE_BUNDLE_PREFIX,
     DURABLE_EVIDENCE_SUBDIR,
+    GO_TOKEN_CLASS_D_FINAL,
     GO_TOKEN_OPERATOR_ALIAS,
     LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX,
     LEGACY_DURABLE_EVIDENCE_SUBDIR,
@@ -21,16 +25,23 @@ from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 
     ORDER_EFFECT,
     PR4826_MERGE_COMMIT,
     PR4832_MERGE_COMMIT,
+    REASON_BITCOIN_LABELLED_CANDIDATE,
+    REASON_UNAUTHORIZED_CANDIDATE,
     RUNTIME_EFFECT,
     is_accepted_go_token,
     is_accepted_origin_main_sha,
     is_class_d_binding_completion_v0,
     load_scope_ratification_for_execution_v0,
+    resolve_authorized_fleet_candidates_for_execution_v0,
+    resolve_class_d_final_fleet_candidates_v0,
+    resolve_class_d_final_durable_evidence_bundle_dir_v0,
     resolve_current_execution_origin_main_sha,
+    resolve_durable_evidence_bundle_dir_for_binding_v0,
     resolve_expected_origin_main_sha,
     resolve_durable_evidence_bundle_dir_v0,
     resolve_legacy_durable_evidence_bundle_dir_v0,
     validate_binding_completion_for_execution_v0,
+    validate_class_d_final_fleet_candidate_scope_v0,
     verify_execution_start_state_v0,
     verify_origin_main_sha_for_binding_v0,
 )
@@ -171,7 +182,7 @@ def test_live_origin_main_sha_accepted_for_class_d_execution(
     assert result.fail_reasons == ()
 
 
-def test_durable_evidence_path_owner_contract() -> None:
+def test_durable_evidence_path_owner_contract(class_d_binding_completion: dict) -> None:
     bundle = resolve_durable_evidence_bundle_dir_v0(
         durable_evidence_root=ARCHIVE_ROOT,
         timestamp_slug="20260704T231500Z",
@@ -179,6 +190,15 @@ def test_durable_evidence_path_owner_contract() -> None:
     legacy = resolve_legacy_durable_evidence_bundle_dir_v0(
         durable_evidence_root=ARCHIVE_ROOT,
         timestamp_slug="20260704T231500Z",
+    )
+    class_d_final = resolve_class_d_final_durable_evidence_bundle_dir_v0(
+        durable_evidence_root=ARCHIVE_ROOT,
+        timestamp_slug="20260704T231500Z",
+    )
+    class_d_resolved = resolve_durable_evidence_bundle_dir_for_binding_v0(
+        durable_evidence_root=ARCHIVE_ROOT,
+        timestamp_slug="20260704T231500Z",
+        fleet_binding_completion=class_d_binding_completion,
     )
     assert bundle.parts[-2:] == (
         DURABLE_EVIDENCE_SUBDIR,
@@ -188,11 +208,78 @@ def test_durable_evidence_path_owner_contract() -> None:
         LEGACY_DURABLE_EVIDENCE_SUBDIR,
         f"{LEGACY_DURABLE_EVIDENCE_BUNDLE_PREFIX}_20260704T231500Z",
     )
+    assert class_d_final.parts[-2:] == (
+        LEGACY_DURABLE_EVIDENCE_SUBDIR,
+        f"{CLASS_D_FINAL_DURABLE_EVIDENCE_BUNDLE_PREFIX}_20260704T231500Z",
+    )
+    assert class_d_resolved == class_d_final
 
 
-def test_evaluation_not_started_without_go_token() -> None:
+def test_class_d_final_go_token_accepted_without_second_authority() -> None:
+    assert is_accepted_go_token(GO_TOKEN_CLASS_D_FINAL) is True
     assert is_accepted_go_token(GO_TOKEN_OPERATOR_ALIAS) is True
     assert is_accepted_go_token("GO_UNKNOWN") is False
+
+
+def test_class_d_final_fleet_candidate_scope_exact(class_d_binding_completion: dict) -> None:
+    ratification = load_scope_ratification_for_execution_v0(
+        repo_root=REPO_ROOT,
+        fleet_binding_completion=class_d_binding_completion,
+    )
+    ok, reasons, resolved = validate_class_d_final_fleet_candidate_scope_v0(
+        fleet_binding_completion=class_d_binding_completion,
+        ratification=ratification,
+    )
+    assert ok is True
+    assert reasons == ()
+    assert resolved == AUTHORIZED_CLASS_D_FINAL_FLEET_CANDIDATES
+    assert (
+        resolve_class_d_final_fleet_candidates_v0(
+            fleet_binding_completion=class_d_binding_completion,
+            ratification=ratification,
+        )
+        == AUTHORIZED_CLASS_D_FINAL_FLEET_CANDIDATES
+    )
+    assert (
+        resolve_authorized_fleet_candidates_for_execution_v0(
+            fleet_binding_completion=class_d_binding_completion,
+            ratification=ratification,
+        )
+        == AUTHORIZED_CLASS_D_FINAL_FLEET_CANDIDATES
+    )
+
+
+def test_class_d_final_fleet_rejects_unauthorized_candidates_fail_closed() -> None:
+    unauthorized = (
+        ("rsi_reversion_eth_aggressive", "v1"),
+        ("ma_trend_btc_conservative", "v1"),
+        ("trend_following_eth_moderate", "v1"),
+        ("armstrong_cycle", "v1"),
+    )
+    ok, reasons, resolved = validate_class_d_final_fleet_candidate_scope_v0(
+        candidates=unauthorized,
+    )
+    assert ok is False
+    assert resolved == unauthorized
+    assert any(REASON_UNAUTHORIZED_CANDIDATE in reason for reason in reasons)
+
+
+def test_class_d_final_fleet_rejects_bitcoin_labelled_candidates_fail_closed() -> None:
+    ok, reasons, _ = validate_class_d_final_fleet_candidate_scope_v0(
+        candidates=(
+            ("trend_following", "v1"),
+            ("bollinger_bands", "v1"),
+            ("ma_trend_btc_moderate", "v1"),
+        ),
+    )
+    assert ok is False
+    assert any(REASON_BITCOIN_LABELLED_CANDIDATE in reason for reason in reasons)
+
+
+def test_class_d_final_fleet_strategy_id_set_is_exact() -> None:
+    assert AUTHORIZED_CLASS_D_FINAL_FLEET_STRATEGY_IDS == frozenset(
+        {"trend_following", "bollinger_bands", "momentum_1h"}
+    )
 
 
 def test_runtime_authority_flags_remain_false() -> None:


### PR DESCRIPTION
## Summary

- Fail-closed Class-D Final Fleet selector: exact authorized fleet only (`trend_following/v1`, `bollinger_bands/v1`, `momentum_1h/v1`)
- Rejects unauthorized candidates, BTC/XBT/Bitcoin-labelled strategy IDs, and candidate set/order mismatches
- Runner loop uses `resolve_authorized_fleet_candidates_for_execution_v0()` and writes `AUTHORIZED_CANDIDATES=` to preflight output to distinguish from ConfigRegistry warnings

## STOP report context

- `PROCESS_NOT_RUNNING` on kill attempt (aborted/hung partial run)
- Wrong-looking names (`rsi_reversion_*`, `ma_trend_btc_*`, `trend_following_eth_*`, etc.) were **ConfigRegistry warnings** from legacy `config.toml` `[strategy.*]` blocks, **not** evaluated candidates
- Actual partial run before abort: `trend_following` completed, `bollinger_bands` partial, `momentum_1h` not started

## Quarantine (not admissible)

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/WRONG_SCOPE_ABORTED_DO_NOT_USE/bounded_class_d_final_research_fleet_offline_economic_evaluation_v0_20260704T215856Z/`

## Selector fix

- Exact authorized fleet only
- BTC/XBT/Bitcoin label rejection
- Candidate set/order mismatch rejection
- Runner loop uses `resolve_authorized_fleet_candidates_for_execution_v0()`

## Validation

- py_compile PASS
- ruff format --check PASS
- ruff check PASS
- git diff --check PASS
- contract tests: 15 passed (`test_final_research_fleet_class_d_offline_evaluation_execution_owner_rebind_v0.py`)

## Safety

- NO_LIVE
- NO_RUNTIME_REWIRE
- NO_PAPER
- NO_TESTNET
- NO_SHADOW
- NO_ORDERS
- NO_CREDENTIALS
- NO_ARMING
- No production trading logic change
- No policy lowering
- No result rescue

## Explicit

- **Full Offline Evaluation not restarted in this PR.**
- **NEXT_ACTION** after merge and green CI: fresh Class-D Final Fleet Offline Evaluation run with exact resolved candidate list (`trend_following/v1`, `bollinger_bands/v1`, `momentum_1h/v1`).


Made with [Cursor](https://cursor.com)