### PR TITLE
Fail close zero-trade economic evidence status

### DIFF
--- a/src/backtest/economic_viability_evidence_v1.py
+++ b/src/backtest/economic_viability_evidence_v1.py
@@ -572,6 +572,30 @@ def _evaluate_robustness_failures(
     return failures
 
 
+_PROMISING_BLOCKING_GATE_REASON_CODES = frozenset(
+    {
+        "MONTE_CARLO_FAILED",
+        "STRESS_FAILED",
+        "WALK_FORWARD_FAILED",
+        "OUT_OF_SAMPLE_FAILED",
+        "PARAMETER_ROBUSTNESS_FAILED",
+        "NET_EXPECTANCY_BELOW_THRESHOLD",
+        "PROFIT_FACTOR_BELOW_THRESHOLD",
+        "TRADE_COUNT_BELOW_THRESHOLD",
+    }
+)
+
+
+def _reason_codes_block_promising_status(reason_codes: Sequence[str]) -> bool:
+    reason_code_set = frozenset(reason_codes)
+    if reason_code_set & _PROMISING_BLOCKING_GATE_REASON_CODES:
+        return True
+    return any(
+        code.startswith(("monte_carlo_", "stress_severe_loss:", "walk_forward_all_oos"))
+        for code in reason_codes
+    )
+
+
 def _resolve_status(
     *,
     reason_codes: Sequence[str],
@@ -581,9 +605,19 @@ def _resolve_status(
     funding_bound: bool,
     parameter_sensitivity_bound: bool,
     gates_pass: bool,
+    trade_count: int,
+    minimum_trade_count: int,
 ) -> EconomicViabilityStatus:
     if robustness_failures:
         return EconomicViabilityStatus.ROBUSTNESS_FAILED
+
+    if trade_count == 0:
+        return EconomicViabilityStatus.RESEARCH_ONLY
+    if trade_count < minimum_trade_count:
+        if not gates_pass or _reason_codes_block_promising_status(reason_codes):
+            return EconomicViabilityStatus.ROBUSTNESS_FAILED
+        return EconomicViabilityStatus.RESEARCH_ONLY
+
     if (
         gates_pass
         and data_admissible
@@ -594,6 +628,10 @@ def _resolve_status(
         return EconomicViabilityStatus.ECONOMICALLY_VIABLE_OFFLINE
     if not data_admissible or not policy_version_bound or not funding_bound:
         return EconomicViabilityStatus.RESEARCH_ONLY
+
+    if not gates_pass or _reason_codes_block_promising_status(reason_codes):
+        return EconomicViabilityStatus.ROBUSTNESS_FAILED
+
     return EconomicViabilityStatus.PROMISING
 
 
@@ -878,6 +916,14 @@ def build_economic_viability_evidence_v1(
     )
     gates_pass = gate_eval.gates_pass
     reason_codes.extend(gate_eval.reason_codes)
+    if trade_count_value == 0:
+        reason_codes.append("ZERO_TRADE_DEGENERATION")
+
+    minimum_trade_count = (
+        int(policy.minimum_trade_count.value)
+        if policy.thresholds_configured() and policy.minimum_trade_count.value is not None
+        else 0
+    )
 
     status = _resolve_status(
         reason_codes=reason_codes,
@@ -887,6 +933,8 @@ def build_economic_viability_evidence_v1(
         funding_bound=funding_bound,
         parameter_sensitivity_bound=parameter_sensitivity_bound,
         gates_pass=gates_pass,
+        trade_count=trade_count_value,
+        minimum_trade_count=minimum_trade_count,
     )
     _fail_closed(status.value not in _STEP29M_ALLOWED_STATUSES, "status_not_allowed_for_step29m")
 

--- a/tests/backtest/test_economic_viability_evidence_v1.py
+++ b/tests/backtest/test_economic_viability_evidence_v1.py
@@ -402,3 +402,79 @@ def test_reproducibility_mismatch_detected() -> None:
     repro = ev.verify_economic_viability_evidence_reproducibility_v1(persisted=a, rebuilt=b)
     assert repro.reproducible is False
     assert "manifest_digest_mismatch" in repro.reason_codes
+
+
+def _promising_eligible_bindings() -> dict[str, bool]:
+    return {
+        "data_admissible": True,
+        "policy_version_bound": True,
+        "funding_bound": True,
+        "parameter_sensitivity_bound": True,
+    }
+
+
+def test_resolve_status_zero_trade_gate_fail_never_promising() -> None:
+    status = ev._resolve_status(
+        reason_codes=["TRADE_COUNT_BELOW_THRESHOLD", "ZERO_TRADE_DEGENERATION"],
+        robustness_failures=[],
+        gates_pass=False,
+        trade_count=0,
+        minimum_trade_count=50,
+        **_promising_eligible_bindings(),
+    )
+    assert status is not ev.EconomicViabilityStatus.PROMISING
+    assert status is ev.EconomicViabilityStatus.RESEARCH_ONLY
+
+
+def test_resolve_status_zero_trade_trivial_mc_wf_pass_never_promising() -> None:
+    status = ev._resolve_status(
+        reason_codes=["ZERO_TRADE_DEGENERATION"],
+        robustness_failures=[],
+        gates_pass=True,
+        trade_count=0,
+        minimum_trade_count=50,
+        **_promising_eligible_bindings(),
+    )
+    assert status is not ev.EconomicViabilityStatus.PROMISING
+    assert status is ev.EconomicViabilityStatus.RESEARCH_ONLY
+
+
+def test_resolve_status_below_min_trade_count_never_promising() -> None:
+    status = ev._resolve_status(
+        reason_codes=["TRADE_COUNT_BELOW_THRESHOLD"],
+        robustness_failures=[],
+        gates_pass=False,
+        trade_count=2,
+        minimum_trade_count=50,
+        **_promising_eligible_bindings(),
+    )
+    assert status is not ev.EconomicViabilityStatus.PROMISING
+    assert status is ev.EconomicViabilityStatus.ROBUSTNESS_FAILED
+
+
+def test_resolve_status_terminal_gate_fail_dominates_promising_fallback() -> None:
+    status = ev._resolve_status(
+        reason_codes=["MONTE_CARLO_FAILED", "STRESS_FAILED", "PROFIT_FACTOR_BELOW_THRESHOLD"],
+        robustness_failures=[],
+        gates_pass=False,
+        trade_count=219,
+        minimum_trade_count=50,
+        **_promising_eligible_bindings(),
+    )
+    assert status is not ev.EconomicViabilityStatus.PROMISING
+    assert status is ev.EconomicViabilityStatus.ROBUSTNESS_FAILED
+
+
+def test_resolve_status_promising_fallback_unchanged_when_eligible() -> None:
+    status = ev._resolve_status(
+        reason_codes=[],
+        robustness_failures=[],
+        gates_pass=True,
+        trade_count=100,
+        minimum_trade_count=50,
+        data_admissible=True,
+        policy_version_bound=True,
+        funding_bound=True,
+        parameter_sensitivity_bound=False,
+    )
+    assert status is ev.EconomicViabilityStatus.PROMISING


### PR DESCRIPTION
## Summary
- **Problem:** `EconomicViabilityEvidenceV1.status` could resolve to `PROMISING` for zero-trade candidates even when the terminal economic validity gate failed (observed in Class-D forensics for `bollinger_bands/v1`: 0 trades, gate FAIL, status PROMISING).
- **Fix:** Fail-closed status resolution in `_resolve_status`: zero trades, below-minimum trade count, terminal gate FAIL, and MC/stress failure reason codes can no longer yield `PROMISING`. Zero-trade cases emit `ZERO_TRADE_DEGENERATION` reason code.
- **Tests:** Five targeted contract tests covering zero-trade gate fail, trivial MC/WF pass, below-min trade count, gate-fail dominance, and unchanged eligible PROMISING fallback.

## Test plan
- [x] `uv run ruff format --check` on changed Python files
- [x] `uv run ruff check` on changed Python files
- [x] `git diff --check`
- [x] `uv run pytest tests/backtest/test_economic_viability_evidence_v1.py -q` (39 passed)

## Safety
- No runtime rewire, no orders, no credentials, no live path
- No policy threshold lowering, no result rescue, no strategy/trading-logic changes
- No new evaluation started; durable archive evidence unchanged

## Evidence (diagnosis only)
Forensics source bundle (read-only, not modified):
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/bounded_class_d_final_research_fleet_offline_economic_evaluation_v0_20260704T221146Z`


Made with [Cursor](https://cursor.com)