### PR TITLE
docs(governance): supersede stale Class-D v1 fleet runbook snapshot

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -33,6 +33,12 @@ SCHEDULER_RUNTIME_ALLOWED: false
 | `CURRENT_ADMISSIBLE_IMPLEMENTATION_SCOPE` | `NONE` |
 | `CURRENT_BLOCKING_POLICY` | `ECONOMIC_VALIDITY_OFFLINE_GATE_FAIL` |
 | `RUNBOOK_V4_4_CANONICAL_SOURCE` | `docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4_current_state_multi_candidate_research_fleet.md` |
+| `RUNBOOK_V4_4_STALE_GOVERNANCE_SUPERSESSION_STATUS` | `DOCS_HYGIENE_APPLIED_V0` |
+| `RUNBOOK_V4_4_STALE_GOVERNANCE_SUPERSESSION_NOTE` | Runbook-v4.4 enthält historische Pre-Fail-Snapshots (`NO_NEW_CANDIDATE_HOLD=REVOKED`, `MULTI_CANDIDATE_RESEARCH_FLEET_ALLOWED=true`); operative Authority = diese Registry-Metadaten, nicht stale v4.4-Abschnitte 19.2/45. |
+| `CLASS_D_V1_FLEET` | `TERMINAL_PARKED` |
+| `CLASS_D_V1_FLEET_TERMINAL_PARK_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/bounded_class_d_v1_fleet_terminal_park_ratification_v0_20260704T224245Z (MANIFEST_VERIFY_RC=0)` |
+| `CLASS_D_V1_FLEET_OPERATOR_DECISION_DOSSIER_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/bounded_class_d_v1_fleet_operator_decision_dossier_and_governance_disposition_read_only_v0_20260704T224019Z (MANIFEST_VERIFY_RC=0)` |
+| `CLASS_D_V1_FLEET_ARCHITECTURE_REVIEW_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/bounded_class_d_v1_fleet_architecture_review_read_only_v0_20260704T224444Z (MANIFEST_VERIFY_RC=0)` |
 | `RUNBOOK_V4_4_RESEARCH_GOVERNANCE_RECONCILIATION_STATUS` | `COMPLETE` |
 | `OPERATOR_POLICY_DECISION` | `NO_NEW_CANDIDATE_HOLD_REINSTATE` |
 | `NO_NEW_CANDIDATE_HOLD` | `ACTIVE` |

--- a/docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4_current_state_multi_candidate_research_fleet.md
+++ b/docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4_current_state_multi_candidate_research_fleet.md
@@ -8,6 +8,28 @@
 **Systemziel:** Vollautonomes, futures-only Peak-Trade-System mit deterministischer, konsistenter und auditierbarer Handelslogik; realistischer Profitabilitätsvalidierung; unabhängiger Safety Authority; gefenceter Single-Writer-Runtime; vollständiger Reconciliation; sicherer Restart-/Recovery-Semantik und einer durchgängigen Research→Validation→Promotion→Runtime→Feedback-Kette.
 **Keine Anlageberatung.**
 
+> **STALE GOVERNANCE SUPERSESSION NOTICE (2026-07-04)**
+>
+> Abschnitte mit `NO_NEW_CANDIDATE_HOLD=REVOKED`, `MULTI_CANDIDATE_RESEARCH_FLEET_ALLOWED=true` und frühen `NEXT_STEP=RATIFY_VERSIONED_FINAL_FLEET_BINDINGS…`-Werten sind **historische Pre-Fail-Snapshots** (Stand vor PR4819 Hold-Reinstatement, Fleet-FAIL 0/3, Terminal Park).
+>
+> **Operative Authority:** [`PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md`](PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md) → `## Registry-Metadaten` (aufgelöst via `src/governance/runbook_progress_registry_v1.py`).
+>
+> **Authoritativer Current State:**
+>
+> ```text
+> NO_NEW_CANDIDATE_HOLD=ACTIVE
+> MULTI_CANDIDATE_RESEARCH_FLEET_ALLOWED=false
+> CLASS_D_V1_FLEET=TERMINAL_PARKED
+> CURRENT_ADMISSIBLE_NEXT_SCOPE=NONE
+> PASS_COUNT=0 / FAIL_COUNT=3
+> ECONOMIC_EVALUATION_AUTHORIZED=false
+> v2 successor research=BLOCKED
+> ```
+>
+> **Evidence Bundles (MANIFEST_VERIFY_RC=0):** `bounded_class_d_v1_fleet_operator_decision_dossier_and_governance_disposition_read_only_v0_20260704T224019Z`, `bounded_class_d_v1_fleet_terminal_park_ratification_v0_20260704T224245Z`, `bounded_class_d_v1_fleet_architecture_review_read_only_v0_20260704T224444Z` unter `$DURABLE_ARCHIVE_ROOT/implementation/`.
+>
+> Stale Governance-Werte in diesem Dokument sind **nicht** für operative Entscheidungen zu verwenden.
+
 ---
 
 # 0. Zweck dieser Version
@@ -906,6 +928,8 @@ PROMISING != PROMOTION_CANDIDATE
 ```
 
 ## 19.2 Aktive Research-Governance
+
+> **HISTORISCH — STALE PRE-FAIL SNAPSHOT.** Die folgenden Werte (`NO_NEW_CANDIDATE_HOLD=REVOKED`, `MULTI_CANDIDATE_RESEARCH_FLEET_ALLOWED=true`) sind **nicht** operative Authority. Siehe Supersession Notice am Dokumentanfang und `PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md` → `## Registry-Metadaten`.
 
 ```text
 OPERATOR_POLICY_DECISION=AUTHORIZE_BOUNDED_MULTI_CANDIDATE_FUTURES_RESEARCH_FLEET_V0
@@ -2078,6 +2102,8 @@ Ergänzt oder aktualisiert wurden:
 ---
 
 # 45. Kanonische Gesamtentscheidung
+
+> **HISTORISCH — STALE PRE-FAIL SNAPSHOT.** Die folgenden Governance-Werte (`NO_NEW_CANDIDATE_HOLD=REVOKED`, `MULTI_CANDIDATE_RESEARCH_FLEET_ALLOWED=true`) spiegeln den Stand vor Hold-Reinstatement und Terminal Park wider. Operative Authority: `NO_NEW_CANDIDATE_HOLD=ACTIVE`, `MULTI_CANDIDATE_RESEARCH_FLEET_ALLOWED=false`, `CLASS_D_V1_FLEET=TERMINAL_PARKED` — siehe Registry-Metadaten.
 
 ```text
 V4_4_IS_CANONICAL_TARGET=true

--- a/docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4_current_state_multi_candidate_research_fleet.md
+++ b/docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4_current_state_multi_candidate_research_fleet.md
@@ -26,7 +26,7 @@
 > v2 successor research=BLOCKED
 > ```
 >
-> **Evidence Bundles (MANIFEST_VERIFY_RC=0):** `bounded_class_d_v1_fleet_operator_decision_dossier_and_governance_disposition_read_only_v0_20260704T224019Z`, `bounded_class_d_v1_fleet_terminal_park_ratification_v0_20260704T224245Z`, `bounded_class_d_v1_fleet_architecture_review_read_only_v0_20260704T224444Z` unter `$DURABLE_ARCHIVE_ROOT/implementation/`.
+> **Evidence Bundles (MANIFEST_VERIFY_RC=0):** `bounded_class_d_v1_fleet_operator_decision_dossier_and_governance_disposition_read_only_v0_20260704T224019Z`, `bounded_class_d_v1_fleet_terminal_park_ratification_v0_20260704T224245Z`, `bounded_class_d_v1_fleet_architecture_review_read_only_v0_20260704T224444Z` unter `$DURABLE_ARCHIVE_ROOT&#47;implementation&#47;`.
 >
 > Stale Governance-Werte in diesem Dokument sind **nicht** für operative Entscheidungen zu verwenden.
 


### PR DESCRIPTION
## Summary
- Add supersession notice banner to Runbook v4.4 `current_state_multi_candidate_research_fleet` clarifying that `NO_NEW_CANDIDATE_HOLD=REVOKED` and `MULTI_CANDIDATE_RESEARCH_FLEET_ALLOWED=true` are historical pre-fail snapshots, not operative authority.
- Add historical snapshot warnings before v4.4 sections 19.2 and 45.
- Extend Progress Registry `Registry-Metadaten` with supersession status, `CLASS_D_V1_FLEET=TERMINAL_PARKED`, and evidence cross-refs to operator decision dossier, terminal park, and architecture review bundles.

## Governance / No-Authority Effect
- **No runtime effect**
- **No evaluation authorization**
- **No candidate ratification**
- **No v2 scope authorization**
- **No retry / promotion / runtime-rewire authority**
- Evidence-only / docs-only hygiene

## Authoritative current state (unchanged)
```text
NO_NEW_CANDIDATE_HOLD=ACTIVE
MULTI_CANDIDATE_RESEARCH_FLEET_ALLOWED=false
CLASS_D_V1_FLEET=TERMINAL_PARKED
CURRENT_ADMISSIBLE_NEXT_SCOPE=NONE
PASS_COUNT=0 / FAIL_COUNT=3
```

## Test plan
- [x] `git diff --check` — pass
- [x] Docs token policy preflight — pass (docs-only)
- [x] Docs reference targets verify — pass
- [x] CI selector — `NO_OP` (docs-only)
- [x] `test_runbook_v4_4_source_bound` contract — pass
- [ ] GitHub CI confirmation


Made with [Cursor](https://cursor.com)