### PR TITLE
Add reference drift visibility report v1 (non-blocking)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-all audit audit-tools gc report-smoke report-smoke-open ops-validate-pr-reports
+.PHONY: clean clean-all audit audit-tools gc report-smoke report-smoke-open ops-validate-pr-reports drift-report
 
 # ============================================================================
 # Cleanup Targets
@@ -157,6 +157,10 @@ deps-sync-check:
 # Validate PR final report formatting
 ops-validate-pr-reports:
 	bash scripts/validate_pr_report_format.sh
+
+# Non-blocking global docs/reference drift visibility report
+drift-report:
+	python3 scripts/ops/reference_drift_report_v1.py
 
 # ============================================================================
 # Governance Gate (AI matrix vs registry)

--- a/scripts/ops/reference_drift_report_v1.py
+++ b/scripts/ops/reference_drift_report_v1.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+Reference Drift Visibility Report v1 — non-blocking analysis layer.
+
+Runs the canonical docs token policy validator in global (--all) mode, classifies
+violations for visibility, and writes a structured JSON report. Does not modify
+source files or fail CI-style on violations.
+
+Classification (review-input only):
+  LEGACY  — historical / low-risk illustrative drift (non-blocking)
+  BROKEN  — potentially critical missing or broken reference surface
+  UNKNOWN — unclassified violations
+
+NO-LIVE: local docs / git metadata only — not a trading or execution path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "peak_trade.reference_drift_report.v1"
+
+REPO_PATH_EXTENSIONS = (
+    ".py",
+    ".toml",
+    ".yml",
+    ".yaml",
+    ".md",
+    ".txt",
+    ".json",
+    ".sh",
+    ".sql",
+    ".js",
+    ".ts",
+    ".tsx",
+    ".jsx",
+    ".css",
+    ".html",
+    ".xml",
+    ".csv",
+    ".log",
+)
+
+CRITICAL_DOC_PREFIXES = (
+    "docs/ops/runbooks/",
+    "docs/ops/specs/",
+    "docs/governance/",
+)
+
+LEGACY_DOC_MARKERS = (
+    "IMPLEMENTATION_REPORT",
+    "MERGE_LOG",
+    "docs/ops/reviews/",
+    "docs/ops/planning/",
+    "docs/archive/",
+)
+
+GENERIC_PLACEHOLDER_PATTERN = re.compile(
+    r"^(some|your|path|example|foo|bar|test)/",
+    re.IGNORECASE,
+)
+
+
+def repo_root() -> Path:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit("Error: Not in a git repository") from exc
+    return Path(out)
+
+
+def git_head(root: Path) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return "unknown"
+
+
+def _looks_like_repo_path(token: str) -> bool:
+    return any(token.endswith(ext) for ext in REPO_PATH_EXTENSIONS)
+
+
+def classify_violation(violation: dict[str, Any], root: Path) -> str:
+    """Classify a single validator violation as LEGACY, BROKEN, or UNKNOWN."""
+    token_type = str(violation.get("token_type", ""))
+    file_path = str(violation.get("file", ""))
+    token = str(violation.get("token", ""))
+
+    if token_type == "ERROR":
+        return "BROKEN"
+
+    if any(marker in file_path for marker in LEGACY_DOC_MARKERS):
+        return "LEGACY"
+
+    if GENERIC_PLACEHOLDER_PATTERN.match(token):
+        return "LEGACY"
+
+    if _looks_like_repo_path(token):
+        candidate = root / token
+        if not candidate.exists():
+            if any(file_path.startswith(prefix) for prefix in CRITICAL_DOC_PREFIXES):
+                return "BROKEN"
+            parent = candidate.parent
+            if parent.exists() and str(parent) != str(root):
+                return "BROKEN"
+
+    if any(file_path.startswith(prefix) for prefix in CRITICAL_DOC_PREFIXES):
+        return "BROKEN"
+
+    return "UNKNOWN"
+
+
+def run_validator(root: Path, json_out: Path) -> dict[str, Any]:
+    validator = root / "scripts" / "ops" / "validate_docs_token_policy.py"
+    if not validator.is_file():
+        raise SystemExit(f"Error: validator not found: {validator}")
+
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        [sys.executable, str(validator), "--all", "--json", str(json_out)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode not in (0, 1):
+        raise SystemExit(f"Validator failed (exit {proc.returncode}): {proc.stderr or proc.stdout}")
+
+    if not json_out.is_file():
+        raise SystemExit("Validator did not produce JSON output")
+
+    return json.loads(json_out.read_text(encoding="utf-8"))
+
+
+def build_report(
+    validator_report: dict[str, Any],
+    *,
+    root: Path,
+    timestamp: str,
+    head: str,
+) -> dict[str, Any]:
+    legacy_list: list[dict[str, Any]] = []
+    broken_list: list[dict[str, Any]] = []
+    unknown_count = 0
+    affected_files: set[str] = set()
+
+    for result in validator_report.get("results", []):
+        for violation in result.get("violations", []):
+            if not isinstance(violation, dict):
+                continue
+            classification = classify_violation(violation, root)
+            entry = {
+                **violation,
+                "classification": classification,
+            }
+            file_path = str(violation.get("file", ""))
+            if file_path:
+                affected_files.add(file_path)
+
+            if classification == "LEGACY":
+                legacy_list.append(entry)
+            elif classification == "BROKEN":
+                broken_list.append(entry)
+            else:
+                unknown_count += 1
+
+    total_violations = len(legacy_list) + len(broken_list) + unknown_count
+
+    return {
+        "schema": SCHEMA,
+        "total_violations": total_violations,
+        "affected_files": sorted(affected_files),
+        "classification_counts": {
+            "LEGACY": len(legacy_list),
+            "BROKEN": len(broken_list),
+            "UNKNOWN": unknown_count,
+        },
+        "legacy_list": legacy_list,
+        "broken_list": broken_list,
+        "timestamp": timestamp,
+        "git_head": head,
+        "validator_summary": {
+            "mode": validator_report.get("mode"),
+            "files_scanned": validator_report.get("files_scanned"),
+            "files_with_violations": validator_report.get("files_with_violations"),
+        },
+        "non_blocking": True,
+    }
+
+
+def write_report(report: dict[str, Any], out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a non-blocking reference drift visibility report from "
+            "validate_docs_token_policy.py --all output."
+        ),
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output JSON path (default: reports/reference_drift_v1.json)",
+    )
+    args = parser.parse_args(argv)
+
+    root = repo_root()
+    out_path = args.out or (root / "reports" / "reference_drift_v1.json")
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    head = git_head(root)
+
+    temp_validator_json = out_path.parent / ".reference_drift_validator_scratch.json"
+    try:
+        validator_report = run_validator(root, temp_validator_json)
+        report = build_report(validator_report, root=root, timestamp=timestamp, head=head)
+        write_report(report, out_path)
+    finally:
+        if temp_validator_json.exists():
+            temp_validator_json.unlink()
+
+    print(f"Reference drift report written to: {out_path}")
+    print(
+        "Violations: "
+        f"total={report['total_violations']} "
+        f"legacy={report['classification_counts']['LEGACY']} "
+        f"broken={report['classification_counts']['BROKEN']} "
+        f"unknown={report['classification_counts']['UNKNOWN']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_reference_drift_report_v1.py
+++ b/tests/ops/test_reference_drift_report_v1.py
@@ -1,0 +1,89 @@
+"""Smoke tests for scripts/ops/reference_drift_report_v1.py (read-only visibility layer)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "ops" / "reference_drift_report_v1.py"
+
+REQUIRED_TOP_LEVEL_FIELDS = (
+    "total_violations",
+    "affected_files",
+    "classification_counts",
+    "legacy_list",
+    "broken_list",
+    "timestamp",
+    "git_head",
+)
+
+
+def _git_porcelain(root: Path) -> str:
+    proc = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+@pytest.fixture(scope="module")
+def repo_porcelain_before() -> str:
+    return _git_porcelain(ROOT)
+
+
+def test_script_runs_and_writes_json(tmp_path: Path, repo_porcelain_before: str) -> None:
+    out_path = tmp_path / "reference_drift_v1.json"
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--out", str(out_path)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    assert out_path.is_file(), "expected JSON report file"
+
+
+def test_report_has_required_fields(tmp_path: Path) -> None:
+    out_path = tmp_path / "reference_drift_v1.json"
+    subprocess.run(
+        [sys.executable, str(SCRIPT), "--out", str(out_path)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    for field in REQUIRED_TOP_LEVEL_FIELDS:
+        assert field in payload, f"missing field: {field}"
+
+    counts = payload["classification_counts"]
+    assert set(counts) >= {"LEGACY", "BROKEN", "UNKNOWN"}
+    assert payload["total_violations"] == sum(counts.values())
+    assert isinstance(payload["affected_files"], list)
+    assert isinstance(payload["legacy_list"], list)
+    assert isinstance(payload["broken_list"], list)
+    assert payload["git_head"]
+    assert payload["timestamp"].endswith("Z")
+
+
+def test_script_does_not_modify_repo(tmp_path: Path, repo_porcelain_before: str) -> None:
+    out_path = tmp_path / "reference_drift_v1.json"
+    subprocess.run(
+        [sys.executable, str(SCRIPT), "--out", str(out_path)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert _git_porcelain(ROOT) == repo_porcelain_before


### PR DESCRIPTION
## Summary
- Adds `scripts/ops/reference_drift_report_v1.py`, a read-only visibility layer that runs `validate_docs_token_policy.py --all`, classifies violations as LEGACY / BROKEN / UNKNOWN, and writes `reports/reference_drift_v1.json`.
- Adds `make drift-report` alias and smoke tests that verify the script runs, emits the required JSON schema, and does not modify the repo.

## Test plan
- [x] `python3 -m ruff format --check` on new Python files
- [x] `python3 -m ruff check` on new Python files
- [x] `python3 -m pytest tests/ops/test_reference_drift_report_v1.py -q`
- [x] `make drift-report` smoke (non-blocking, exit 0)

## Safety
- No CI/workflow changes
- No validator or policy changes
- No runtime or governance changes
- Report-only; always exits 0


Made with [Cursor](https://cursor.com)