### PR TITLE
fix(governance): restore SelectedSide contract export

### DIFF
--- a/src/governance/capital_risk_sizing_v1.py
+++ b/src/governance/capital_risk_sizing_v1.py
@@ -121,6 +121,18 @@ class FinalQuantityStatus(str, Enum):
     BLOCK = "BLOCK"
 
 
+class SelectedSide(str, Enum):
+    """Canonical selected-side contract for governance/runtime boundary binding.
+
+    Offline-only compatibility enum for capital risk sizing and runtime integration
+    bridge contracts. No execution, scheduling, order submission, arming, live
+    trading, shadow, paper, or testnet behavior.
+    """
+
+    LONG = "LONG"
+    SHORT = "SHORT"
+
+
 class CapitalRiskSizingOutcome(str, Enum):
     PASS = "PASS"
     BLOCKED = "BLOCKED"


### PR DESCRIPTION
## Summary
- Restore `SelectedSide` enum export in `capital_risk_sizing_v1` with canonical `LONG`/`SHORT` values.
- Fixes ops bridge test collection/import failure (`ImportError: cannot import name 'SelectedSide'`).
- Offline-only compatibility contract; no execution or runtime authority changes.

## Test plan
- [x] `pytest tests/ops/test_canonical_core_runtime_integration_bridge_slice_b_v0.py::test_package_marker_and_owner_present`
- [x] `pytest tests/ops/test_canonical_core_runtime_integration_bridge_slice_b_v0.py::test_no_execution_or_adapter_imports_in_bridge`
- [x] `pytest tests/ops/test_canonical_core_runtime_integration_bridge_slice_d_v0.py::test_package_marker_and_owner_present`
- [x] `pytest tests/governance/test_capital_risk_sizing_v1.py`
- [x] `pytest tests/ops/test_pr_closure_canonical_checklist_v1_contract.py`
- [x] PR-bounded selector targets (720 tests, 47s)

## Notes
- Full slice B/D ops suites still have pre-existing fixture/registry drift failures on `main` unrelated to this import fix.

Made with [Cursor](https://cursor.com)