### PR TITLE
post-pr4920 new versioned research scope definition

### DIFF
--- a/config/research/post_pr4920_new_versioned_research_scope_definition_v0.json
+++ b/config/research/post_pr4920_new_versioned_research_scope_definition_v0.json
@@ -1,0 +1,410 @@
+{
+  "admissible_next_go_tokens": [
+    "GO_POST_PR4920_VERSIONED_FLEET_BINDING_RATIFICATION_V0",
+    "GO_POST_PR4920_OFFLINE_ECONOMIC_EVALUATION_V0"
+  ],
+  "admissible_scope_class": "D_NEW_VERSIONED_RESEARCH_SCOPE_WITH_FULL_BINDINGS",
+  "allowed_actions": [
+    "DOCS_ONLY_SCOPE_DEFINITION",
+    "OFFLINE_DETERMINISTIC_SCOPE_BUNDLE_MATERIALIZATION",
+    "CONTRACT_TESTS_FOR_AUTHORITY_BOUNDARIES",
+    "CANDIDATE_ADMISSIBILITY_FILTER_DOCUMENTATION",
+    "REJECTION_CRITERIA_DOCUMENTATION"
+  ],
+  "artifact_kind": "post_pr4920_new_versioned_research_scope_definition",
+  "artifact_version": "v0",
+  "authority_effect": "NONE",
+  "base_head": "aa53ee580257b8d937a19c5172e98b7d16544221",
+  "baseline_pr": 4920,
+  "blocked_actions": [
+    "ECONOMIC_EVALUATION_EXECUTION",
+    "BACKTEST_RERUN",
+    "WALK_FORWARD_EXECUTION",
+    "MONTE_CARLO_EXECUTION",
+    "STRESS_EXECUTION",
+    "SAME_BINDING_RETRY",
+    "UNCHANGED_BINDING_RETRY",
+    "FAILED_BINDING_RETRY",
+    "PARAMETER_OPTIMIZATION",
+    "PARAMETER_RESCUE",
+    "THRESHOLD_LOWERING",
+    "RESULT_RESCUE",
+    "CANDIDATE_PROMOTION",
+    "PROMOTION",
+    "NEW_CANDIDATE_RATIFICATION",
+    "NEW_STRATEGY_IMPLEMENTATION",
+    "NEAR_DUPLICATE_BREAKOUT_MEAN_REVERSION_RETRY",
+    "RUNTIME",
+    "RUNTIME_REWIRE",
+    "SHADOW",
+    "PAPER",
+    "TESTNET",
+    "SCHEDULER",
+    "ADAPTER_SUBMISSION",
+    "ORDERS",
+    "CREDENTIALS",
+    "ARMING",
+    "CANARY",
+    "LIVE",
+    "CORE_SYSTEM_CHANGE",
+    "CANONICAL_TRADING_LOGIC_CHANGE",
+    "MASTER_V2_CHANGE",
+    "DOUBLE_PLAY_CHANGE",
+    "RISK_SIZING_CHANGE",
+    "SAFETY_RUNTIME_CHANGE",
+    "EVALUATION_EXECUTION_IN_THIS_SCOPE",
+    "BINDING_RATIFICATION_IN_THIS_SCOPE"
+  ],
+  "blocked_scope_classes": [
+    "A_UNMODIFIED_V1_BINDING_REEXECUTION",
+    "B_SAME_BINDINGS_NEW_SHA_ONLY",
+    "C_GOVERNANCE_REWORDING_ONLY",
+    "E_NEW_VERSIONED_EVIDENCE_CLASS_WITH_FULL_CONTRACT",
+    "F_EVALUATION_WITHOUT_RATIFICATION",
+    "G_RUNTIME_REWIRE",
+    "H_NEAR_DUPLICATE_ARCHETYPE_RETRY"
+  ],
+  "candidate_admissibility_filters": [
+    {
+      "filter_id": "EXCLUDE_UNCHANGED_V1_FAILED_BINDING",
+      "required": true,
+      "rule": "strategy_id/strategy_version must not equal any excluded_failed_binding"
+    },
+    {
+      "filter_id": "REQUIRE_NEW_VERSIONED_BINDING",
+      "required": true,
+      "rule": "strategy_version must be > v1 or a newly ratified versioned alias with full binding digest set"
+    },
+    {
+      "filter_id": "REQUIRE_MIN_TRADE_COUNT_EVIDENCE_PLAN",
+      "required": true,
+      "rule": "binding must declare minimum trade-count evidence plan to avoid zero-trade degeneration"
+    },
+    {
+      "filter_id": "REQUIRE_ROBUSTNESS_EVIDENCE_PLAN",
+      "required": true,
+      "rule": "binding must declare walk-forward, monte-carlo, and stress evidence plan before offline evaluation"
+    },
+    {
+      "filter_id": "REQUIRE_FLEET_PARITY",
+      "required": true,
+      "rule": "fleet-wide identical economic policy, fee, slippage, funding, execution, dataset, and period bindings"
+    },
+    {
+      "filter_id": "NO_NEAR_DUPLICATE_ARCHETYPE",
+      "required": true,
+      "rule": "candidate must not be near-duplicate breakout/mean-reversion workaround of failed v1 archetypes"
+    }
+  ],
+  "candidate_archetype_requirements": [
+    {
+      "archetype_id": "TREND_CONTINUATION_V2",
+      "derived_from_failure_class": "MONTE_CARLO_STRESS_WEAKNESS_CLASS",
+      "parent_strategy_id": "trend_following",
+      "replaces_binding": "trend_following/v1",
+      "required_evidence_axes": [
+        "signal_edge",
+        "walk_forward_oos_stability",
+        "monte_carlo_return_distribution",
+        "stress_tail_risk",
+        "turnover_cost_drag"
+      ]
+    },
+    {
+      "archetype_id": "MEAN_REVERSION_BANDS_V2",
+      "derived_from_failure_class": "FEATURE_EDGE_FAILURE_CLASS",
+      "parent_strategy_id": "bollinger_bands",
+      "replaces_binding": "bollinger_bands/v1",
+      "required_evidence_axes": [
+        "signal_edge",
+        "trade_count_adequacy",
+        "zero_trade_degeneration_guard",
+        "regime_bucket_stability"
+      ]
+    },
+    {
+      "archetype_id": "MOMENTUM_HORIZON_V2",
+      "derived_from_failure_class": "SPARSE_SIGNAL_UNDERPOWERING",
+      "parent_strategy_id": "momentum_1h",
+      "replaces_binding": "momentum_1h/v1",
+      "required_evidence_axes": [
+        "signal_edge",
+        "single_trade_dominance_guard",
+        "sparse_signal_underpowering",
+        "long_short_contribution",
+        "portfolio_contribution"
+      ]
+    }
+  ],
+  "canonical_trading_logic_mutation_allowed": false,
+  "core_system_mutation_allowed": false,
+  "data_period_model_binding_requirements": {
+    "dataset_binding": "required",
+    "data_digest": "required",
+    "economic_policy_binding": "required",
+    "execution_model_binding": "required",
+    "fee_model_binding": "required",
+    "funding_model_binding": "required",
+    "instrument_binding": "required",
+    "period_binding": "required",
+    "slippage_model_binding": "required"
+  },
+  "double_play_mutation_allowed": false,
+  "economic_evaluation_authorized": false,
+  "economic_evaluation_executed": false,
+  "economic_validity_offline_gate_pass": false,
+  "evidence_class_id": "POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0",
+  "excluded_failed_bindings": [
+    "trend_following/v1",
+    "bollinger_bands/v1",
+    "momentum_1h/v1"
+  ],
+  "explicit_rejection_criteria": [
+    "UNCHANGED_V1_BINDING_REEXECUTION",
+    "ZERO_TRADE_DEGENERATION_WITHOUT_NEW_VERSIONED_BINDING",
+    "SINGLE_TRADE_DOMINANCE_WITHOUT_MITIGATION_PLAN",
+    "THRESHOLD_LOWERING_TO_GENERATE_TRADES",
+    "PARAMETER_RESCUE_AFTER_KNOWN_NEGATIVE_EVIDENCE",
+    "NEAR_DUPLICATE_BREAKOUT_MEAN_REVERSION_WORKAROUND",
+    "POLICY_THRESHOLD_RESCUE",
+    "PROMOTION_WITHOUT_OFFLINE_ECONOMIC_GATE_PASS",
+    "RUNTIME_REWIRE_FROM_NEGATIVE_FLEET",
+    "PROFITABILITY_CLAIM_WITHOUT_OPERATOR_GO"
+  ],
+  "failed_bindings": [
+    {
+      "canonical_candidate_identifier": "trend_following/v1",
+      "classified_verdict": "ROBUSTNESS_FAILED",
+      "failure_reason_codes": [
+        "MONTE_CARLO_FAILED",
+        "NET_EXPECTANCY_BELOW_THRESHOLD",
+        "PROFIT_FACTOR_BELOW_THRESHOLD",
+        "STRESS_FAILED"
+      ],
+      "failure_summary": "terminal negative edge, MC/Stress failed",
+      "max_drawdown": -0.009945,
+      "net_return": -0.002398,
+      "profit_factor": 0.951,
+      "promotion_admissible": false,
+      "retry_unchanged_binding_allowed": false,
+      "strategy_id": "trend_following",
+      "strategy_version": "v1"
+    },
+    {
+      "canonical_candidate_identifier": "bollinger_bands/v1",
+      "classified_verdict": "ROBUSTNESS_FAILED",
+      "failure_reason_codes": [
+        "PROFIT_FACTOR_BELOW_THRESHOLD",
+        "STRESS_FAILED",
+        "TRADE_COUNT_BELOW_THRESHOLD",
+        "ZERO_TRADE_DEGENERATION"
+      ],
+      "failure_summary": "zero-trade degeneration, no edge",
+      "max_drawdown": 0.0,
+      "net_return": 0.0,
+      "profit_factor": 0.0,
+      "promotion_admissible": false,
+      "retry_unchanged_binding_allowed": false,
+      "strategy_id": "bollinger_bands",
+      "strategy_version": "v1"
+    },
+    {
+      "canonical_candidate_identifier": "momentum_1h/v1",
+      "classified_verdict": "ROBUSTNESS_FAILED",
+      "failure_reason_codes": [
+        "MONTE_CARLO_FAILED",
+        "NET_EXPECTANCY_BELOW_THRESHOLD",
+        "PROFIT_FACTOR_BELOW_THRESHOLD",
+        "SINGLE_TRADE_DOMINANCE_EXCEEDED",
+        "STRESS_FAILED",
+        "TRADE_COUNT_BELOW_THRESHOLD"
+      ],
+      "failure_summary": "sparse signal, single-trade dominance, terminal negative",
+      "max_drawdown": -0.002638,
+      "net_return": -0.001889,
+      "profit_factor": 0.285,
+      "promotion_admissible": false,
+      "retry_unchanged_binding_allowed": false,
+      "strategy_id": "momentum_1h",
+      "strategy_version": "v1"
+    }
+  ],
+  "failed_bindings_excluded": true,
+  "failed_bindings_retry_allowed": false,
+  "failed_evidence_is_terminal": true,
+  "final_research_fleet": [
+    "trend_following",
+    "bollinger_bands",
+    "momentum_1h"
+  ],
+  "final_research_fleet_status": "NEW_VERSIONED_BINDINGS_REQUIRED_BEFORE_ANY_OFFLINE_EVALUATION",
+  "fleet_status": "FAIL",
+  "fleet_verdict": "FLEET_ECONOMIC_VALIDITY_FAIL",
+  "followup_taxonomy": [
+    {
+      "admissible_followup_question": "Welche fehlenden Evidence-Achsen sind für eine spätere, separat autorisierte versionierte Binding-Ratifikation minimal hinreichend?",
+      "class_id": "EVIDENCE_ADEQUACY_GAPS",
+      "explicitly_non_admissible_automatic_action": "Automatische Evidence-Execution oder Gap-Fill ohne Operator GO",
+      "fleet_level_diagnosis": "long_short_contribution, fee_slippage_funding_drag, dominance_concentration teils MISSING_EVIDENCE oder INCONCLUSIVE"
+    },
+    {
+      "admissible_followup_question": "Welche Feature-/Edge-Hypothesen sind durch terminal negative v1-Evidence refutiert?",
+      "class_id": "FEATURE_EDGE_FAILURE_CLASS",
+      "explicitly_non_admissible_automatic_action": "Unveränderte v1-Binding-Reexecution",
+      "fleet_level_diagnosis": "Alle drei Kandidaten ROBUSTNESS_FAILED; bollinger_bands/v1 ZERO_TRADE_DEGENERATION"
+    },
+    {
+      "admissible_followup_question": "Ist Cost-Drag der dominante Failure-Mechanismus vs. Signal-Qualität für v2-Bindings?",
+      "class_id": "TURNOVER_COST_DRAG_CLASS",
+      "explicitly_non_admissible_automatic_action": "Parameter-Optimierung oder Threshold-Lowering zur Rettung",
+      "fleet_level_diagnosis": "trend_following/v1 und momentum_1h/v1 negative net edge bei moderatem Trade count"
+    },
+    {
+      "admissible_followup_question": "Welche Tail-Risk-Achsen dominieren das Fleet-Fail ohne Rescue?",
+      "class_id": "DRAWDOWN_TAIL_RISK_CLASS",
+      "explicitly_non_admissible_automatic_action": "Policy-Threshold-Rescue oder Negative-Evidence-Reclassification",
+      "fleet_level_diagnosis": "trend_following/v1 max drawdown -0.009945; Stress/Monte Carlo failed"
+    },
+    {
+      "admissible_followup_question": "Welche Regime-Buckets sind instabil ohne neues versioned binding?",
+      "class_id": "REGIME_INSTABILITY_CLASS",
+      "explicitly_non_admissible_automatic_action": "Same-binding retry unter anderem Regime-Label",
+      "fleet_level_diagnosis": "Regime breakdown MIXED_TERMINAL_NEGATIVE in Parent-Decomposition"
+    },
+    {
+      "admissible_followup_question": "Ist OOS-Instabilität strukturell oder binding-spezifisch terminal?",
+      "class_id": "WALK_FORWARD_OOS_INSTABILITY_CLASS",
+      "explicitly_non_admissible_automatic_action": "Walk-forward rerun unveränderter v1 bindings",
+      "fleet_level_diagnosis": "Walk-forward stability TERMINAL_NEGATIVE fleet-wide"
+    },
+    {
+      "admissible_followup_question": "Welche Robustness-Achsen sind terminal vs. inconclusive?",
+      "class_id": "MONTE_CARLO_STRESS_WEAKNESS_CLASS",
+      "explicitly_non_admissible_automatic_action": "Monte Carlo/Stress execution in diesem Scope",
+      "fleet_level_diagnosis": "Monte Carlo MIXED_TERMINAL_NEGATIVE; Stress TERMINAL_NEGATIVE"
+    },
+    {
+      "admissible_followup_question": "Welche Portfolio-Contribution-Schwächen schließen Fleet-Promotion aus?",
+      "class_id": "PORTFOLIO_CONTRIBUTION_WEAKNESS_CLASS",
+      "explicitly_non_admissible_automatic_action": "Promotion oder Runtime-Rewire aus negativem Fleet",
+      "fleet_level_diagnosis": "Fleet contribution failure TERMINAL_NEGATIVE; keine Kandidaten promotion-eligible"
+    }
+  ],
+  "forbidden_actions": [
+    "ECONOMIC_EVALUATION_EXECUTION",
+    "BACKTEST_RERUN",
+    "WALK_FORWARD_EXECUTION",
+    "MONTE_CARLO_EXECUTION",
+    "STRESS_EXECUTION",
+    "PARAMETER_SENSITIVITY_EXECUTION",
+    "SAME_BINDING_RETRY",
+    "UNCHANGED_BINDING_RETRY",
+    "FAILED_BINDING_RETRY",
+    "PARAMETER_OPTIMIZATION",
+    "PARAMETER_RESCUE",
+    "THRESHOLD_LOWERING",
+    "POLICY_THRESHOLD_RESCUE",
+    "NEW_CANDIDATE_RATIFICATION",
+    "NEW_STRATEGY_IMPLEMENTATION",
+    "RUNTIME",
+    "RUNTIME_REWIRE",
+    "SHADOW",
+    "PAPER",
+    "TESTNET",
+    "SCHEDULER",
+    "ADAPTER_SUBMISSION",
+    "ORDERS",
+    "CREDENTIALS",
+    "ARMING",
+    "CANARY",
+    "LIVE",
+    "CORE_SYSTEM_CHANGE",
+    "CANONICAL_TRADING_LOGIC_CHANGE",
+    "MASTER_V2_CHANGE",
+    "DOUBLE_PLAY_CHANGE",
+    "RISK_SIZING_CHANGE",
+    "SAFETY_RUNTIME_CHANGE",
+    "EVIDENCE_EXECUTION_IN_THIS_SCOPE",
+    "EVALUATION_EXECUTION_IN_THIS_SCOPE",
+    "POLICY_CHANGE_TO_RECLASSIFY_NEGATIVE_EVIDENCE"
+  ],
+  "futures_only": true,
+  "go_token": "GO_DEFINE_POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_FROM_FAILURE_DECOMPOSITION_V0",
+  "go_token_consumed": true,
+  "go_token_consumption": "CONSUMED_ONCE_FOR_SCOPE_DEFINITION_ONLY",
+  "governance_ref": "docs/governance/POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0.md",
+  "live_authorized": false,
+  "master_v2_mutation_allowed": false,
+  "new_candidate_ratified": false,
+  "new_candidates_ratified": false,
+  "next_step": "SEPARATE_OPERATOR_GO_REQUIRED_FOR_VERSIONED_BINDINGS_OR_OFFLINE_EVALUATION",
+  "no_evaluation_authority": true,
+  "no_order_authority": true,
+  "no_promotion_authority": true,
+  "no_runtime_authority": true,
+  "non_authorizing": true,
+  "offline_only": true,
+  "operator_go_required_for_next_scope": true,
+  "orders_allowed": false,
+  "paper_authorized": false,
+  "parameter_rescue_allowed": false,
+  "parent_decomposition_evidence_class_id": "POST_PR4920_FAILURE_DECOMPOSITION_FOLLOWUP_EXECUTION_OFFLINE_ONLY_V0",
+  "parent_decomposition_evidence_ref": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/post_pr4920_failure_decomposition_followup_execution_offline_only_20260706T080836Z",
+  "parent_decomposition_manifest_verify_rc": 0,
+  "parent_closeout_dir": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/pr4920_post_pr4919_terminal_final_fleet_failure_decomposition_followup_scope_merge_closeout_20260706T080500Z",
+  "parent_closeout_manifest_verify_rc": 0,
+  "process_classification": "POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_ONLY_V0",
+  "promotion_admissible": false,
+  "promotion_authority": false,
+  "promotion_eligible": false,
+  "repo_mutation_scope": "GOVERNANCE_ONLY",
+  "required_binding_fields": [
+    "strategy_id",
+    "strategy_version",
+    "parameter_binding",
+    "dataset_binding",
+    "period_binding",
+    "instrument_binding",
+    "fee_model_binding",
+    "slippage_model_binding",
+    "funding_model_binding",
+    "execution_model_binding",
+    "economic_policy_binding",
+    "implementation_digest",
+    "config_digest",
+    "data_digest"
+  ],
+  "required_future_operator_go": true,
+  "required_next_go_for_binding_ratification": "GO_POST_PR4920_VERSIONED_FLEET_BINDING_RATIFICATION_V0",
+  "required_next_go_for_offline_evaluation": "GO_POST_PR4920_OFFLINE_ECONOMIC_EVALUATION_V0",
+  "research_hypothesis": "POST_PR4920_FAILURE_DECOMPOSITION_REQUIRES_NEW_VERSIONED_BINDINGS_NOT_UNCHANGED_V1_RETRY_OR_NEAR_DUPLICATE_ARCHETYPE",
+  "retry_authorized": false,
+  "retry_unchanged_binding_allowed": false,
+  "risk_sizing_mutation_allowed": false,
+  "runtime_authority": "NONE",
+  "runtime_effect": "NONE",
+  "runtime_rewire_admissible": false,
+  "safety_runtime_mutation_allowed": false,
+  "same_binding_retry_allowed": false,
+  "schema_version": "post_pr4920_new_versioned_research_scope_definition.v0",
+  "scope_classification": "POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_FROM_FAILURE_DECOMPOSITION_DEFINITION_ONLY_V0",
+  "scope_definition_only": true,
+  "scope_id": "POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0",
+  "scope_version": "v0",
+  "selected_class": "D",
+  "shadow_authorized": false,
+  "source_evidence_refs": [
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/post_pr4920_failure_decomposition_followup_execution_offline_only_20260706T080836Z",
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/pr4920_post_pr4919_terminal_final_fleet_failure_decomposition_followup_scope_merge_closeout_20260706T080500Z",
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/pr4919_terminal_final_fleet_failure_decomposition_next_scope_merge_closeout_20260706T075014Z"
+  ],
+  "source_prs": [
+    4920
+  ],
+  "status": "SCOPE_DEFINED_NOT_EXECUTED",
+  "strategy_version": "v2_required",
+  "terminal_negative_evidence_unchanged": true,
+  "testnet_authorized": false,
+  "threshold_lowering_allowed": false,
+  "trading_effect": "NONE"
+}

--- a/docs/governance/POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0.md
+++ b/docs/governance/POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0.md
@@ -1,0 +1,202 @@
+# Post-PR4920 New Versioned Research Scope Definition v0
+
+---
+docs_token: DOCS_TOKEN_POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0
+STATUS: SCOPE_DEFINED_NOT_EXECUTED
+scope: governance, documentation-only, non-authorizing
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+SCHEDULER_RUNTIME_ALLOWED: false
+---
+
+> **Non-authorizing:** Definiert ausschließlich den nächsten admissiblen versionierten Research-Scope nach manifest-verifizierter PR4920 Failure-Decomposition (`FLEET_ECONOMIC_VALIDITY_FAIL`, alle v1-Bindings terminal `ROBUSTNESS_FAILED`). Keine Economic Evaluation. Keine Binding-Ratifikation in diesem Scope. Kein Same-Binding-Retry, keine Parameterrettung, keine Runtime-Authority. Scope-Definition ≠ Binding-Ratifikation ≠ Evaluation-Autorisierung.
+
+## A. Verdict
+
+| Feld | Wert |
+|---|---|
+| `VERDICT` | `SCOPE_DEFINED_NOT_EXECUTED` |
+| `PROCESS_CLASSIFICATION` | `POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_ONLY_V0` |
+| `SCOPE_CLASSIFICATION` | `POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_FROM_FAILURE_DECOMPOSITION_DEFINITION_ONLY_V0` |
+| `SELECTED_CLASS` | `D` |
+| `ADMISSIBLE_SCOPE_CLASS` | `D_NEW_VERSIONED_RESEARCH_SCOPE_WITH_FULL_BINDINGS` |
+| `OPERATOR_GO` | `GO_DEFINE_POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_FROM_FAILURE_DECOMPOSITION_V0` |
+| `GO_TOKEN_CONSUMPTION` | `CONSUMED_ONCE_FOR_SCOPE_DEFINITION_ONLY` |
+| `CURRENT_BASELINE_PR` | `4920` |
+| `CURRENT_BASELINE_HEAD` | `aa53ee580257b8d937a19c5172e98b7d16544221` |
+| `PARENT_DECOMPOSITION_EVIDENCE_CLASS_ID` | `POST_PR4920_FAILURE_DECOMPOSITION_FOLLOWUP_EXECUTION_OFFLINE_ONLY_V0` |
+| `PARENT_DECOMPOSITION_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/post_pr4920_failure_decomposition_followup_execution_offline_only_20260706T080836Z` |
+| `PARENT_DECOMPOSITION_MANIFEST_VERIFY_RC` | `0` |
+| `PARENT_CLOSEOUT_DIR` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/pr4920_post_pr4919_terminal_final_fleet_failure_decomposition_followup_scope_merge_closeout_20260706T080500Z` |
+| `PARENT_CLOSEOUT_MANIFEST_VERIFY_RC` | `0` |
+| `EVIDENCE_CLASS_ID` | `POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0` |
+| `SCOPE_ID` | `POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0` |
+| `SCOPE_DEFINITION_ONLY` | `true` |
+| `RESEARCH_HYPOTHESIS` | `POST_PR4920_FAILURE_DECOMPOSITION_REQUIRES_NEW_VERSIONED_BINDINGS_NOT_UNCHANGED_V1_RETRY_OR_NEAR_DUPLICATE_ARCHETYPE` |
+| `FINAL_RESEARCH_FLEET` | `trend_following,bollinger_bands,momentum_1h` |
+| `FINAL_RESEARCH_FLEET_STATUS` | `NEW_VERSIONED_BINDINGS_REQUIRED_BEFORE_ANY_OFFLINE_EVALUATION` |
+| `STRATEGY_VERSION` | `v2_required` |
+| `FLEET_VERDICT` | `FLEET_ECONOMIC_VALIDITY_FAIL` |
+| `FLEET_STATUS` | `FAIL` |
+| `ECONOMIC_VALIDITY_OFFLINE_GATE_PASS` | `false` |
+| `PROMOTION_ADMISSIBLE` | `false` |
+| `RUNTIME_REWIRE_ADMISSIBLE` | `false` |
+| `RETRY_AUTHORIZED` | `false` |
+| `FAILED_BINDINGS_EXCLUDED` | `true` |
+| `TERMINAL_NEGATIVE_EVIDENCE_UNCHANGED` | `true` |
+| `FAILED_EVIDENCE_IS_TERMINAL` | `true` |
+| `NEW_CANDIDATE_RATIFIED` | `false` |
+| `NEW_CANDIDATES_RATIFIED` | `false` |
+| `PROMOTION_AUTHORITY` | `false` |
+| `PROMOTION_ELIGIBLE` | `false` |
+| `ECONOMIC_EVALUATION_AUTHORIZED` | `false` |
+| `ECONOMIC_EVALUATION_EXECUTED` | `false` |
+| `BACKTEST_EXECUTED` | `false` |
+| `EVALUATION_EXECUTION_IN_THIS_SCOPE` | `false` |
+| `RUNTIME_AUTHORITY` | `NONE` |
+| `SHADOW_AUTHORIZED` | `false` |
+| `PAPER_AUTHORIZED` | `false` |
+| `TESTNET_AUTHORIZED` | `false` |
+| `LIVE_AUTHORIZED` | `false` |
+| `NO_ORDER_AUTHORITY` | `true` |
+| `ORDERS_ALLOWED` | `false` |
+| `FUTURES_ONLY` | `true` |
+| `FAILED_BINDINGS_RETRY_ALLOWED` | `false` |
+| `UNCHANGED_RETRY_ALLOWED` | `false` |
+| `SAME_BINDING_RETRY_ALLOWED` | `false` |
+| `PARAMETER_RESCUE_ALLOWED` | `false` |
+| `PARAMETER_OPTIMIZATION_ALLOWED` | `false` |
+| `THRESHOLD_LOWERING_ALLOWED` | `false` |
+| `NEAR_DUPLICATE_BREAKOUT_MEAN_REVERSION_RETRY_ALLOWED` | `false` |
+| `CORE_SYSTEM_MUTATION_ALLOWED` | `false` |
+| `CANONICAL_TRADING_LOGIC_MUTATION_ALLOWED` | `false` |
+| `MASTER_V2_MUTATION_ALLOWED` | `false` |
+| `DOUBLE_PLAY_MUTATION_ALLOWED` | `false` |
+| `RISK_SIZING_MUTATION_ALLOWED` | `false` |
+| `SAFETY_RUNTIME_MUTATION_ALLOWED` | `false` |
+| `REQUIRED_FUTURE_OPERATOR_GO` | `true` |
+| `REQUIRED_NEXT_GO_FOR_BINDING_RATIFICATION` | `GO_POST_PR4920_VERSIONED_FLEET_BINDING_RATIFICATION_V0` |
+| `REQUIRED_NEXT_GO_FOR_OFFLINE_EVALUATION` | `GO_POST_PR4920_OFFLINE_ECONOMIC_EVALUATION_V0` |
+| `NEXT_STEP` | `SEPARATE_OPERATOR_GO_REQUIRED_FOR_VERSIONED_BINDINGS_OR_OFFLINE_EVALUATION` |
+| `runtime_effect` | `NONE` |
+| `authority_effect` | `NONE` |
+| `economic_evaluation_effect` | `NONE` |
+| `trading_effect` | `NONE` |
+
+**Authoritative owners (reuse, nicht ersetzen):**
+
+- Scope config: `config/research/post_pr4920_new_versioned_research_scope_definition_v0.json`
+- Parent decomposition bundle: `post_pr4920_failure_decomposition_followup_execution_offline_only_20260706T080836Z`
+- Parent scope config (PR4919): `config/research/post_pr4919_terminal_final_fleet_failure_decomposition_followup_scope_v0.json`
+- Parent scope doc (PR4919): `docs/governance/POST_PR4919_TERMINAL_FINAL_FLEET_FAILURE_DECOMPOSITION_FOLLOWUP_SCOPE_V0.md`
+- Progress registry: `docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md`
+
+## B. Excluded Failed v1 Bindings (bindend, nicht retry-fähig)
+
+| Binding | Failure Summary | Classified Verdict | Retry Allowed |
+|---|---|---|---|
+| `trend_following&#47;v1` | terminal negative edge, MC/Stress failed | `ROBUSTNESS_FAILED` | `false` |
+| `bollinger_bands&#47;v1` | zero-trade degeneration, no edge | `ROBUSTNESS_FAILED` | `false` |
+| `momentum_1h&#47;v1` | sparse signal, single-trade dominance, terminal negative | `ROBUSTNESS_FAILED` | `false` |
+
+Keine unveränderten v1-Binding-Reexecutions. Keine Threshold-Lowering zur Trade-Generierung. Keine Near-Duplicate-Breakout-/Mean-Reversion-Umgehung.
+
+## C. Candidate Archetype Requirements (v2, nicht autorisiert)
+
+| Archetype | Parent Strategy | Replaces Binding | Derived Failure Class |
+|---|---|---|---|
+| `TREND_CONTINUATION_V2` | `trend_following` | `trend_following&#47;v1` | `MONTE_CARLO_STRESS_WEAKNESS_CLASS` |
+| `MEAN_REVERSION_BANDS_V2` | `bollinger_bands` | `bollinger_bands&#47;v1` | `FEATURE_EDGE_FAILURE_CLASS` |
+| `MOMENTUM_HORIZON_V2` | `momentum_1h` | `momentum_1h&#47;v1` | `SPARSE_SIGNAL_UNDERPOWERING` |
+
+Diese Archetypen definieren Anforderungen für spätere versionierte Bindings — **keine** Economic Viability-Behauptung, **keine** Runtime-Eligibility.
+
+## D. Required Bindings Before Any Evaluation
+
+Bevor irgendeine spätere offline Economic Evaluation zulässig ist, müssen pro Kandidat versioniert und dauerhaft gebunden werden:
+
+| Binding-Feld | Pflicht pro Kandidat |
+|---|---|
+| `strategy_id` | `true` |
+| `strategy_version` | `true` |
+| `parameter_binding` | `true` |
+| `dataset_binding` | `true` |
+| `period_binding` | `true` |
+| `instrument_binding` | `true` |
+| `fee_model_binding` | `true` |
+| `slippage_model_binding` | `true` |
+| `funding_model_binding` | `true` |
+| `execution_model_binding` | `true` |
+| `economic_policy_binding` | `true` |
+| `implementation_digest` | `true` |
+| `config_digest` | `true` |
+| `data_digest` | `true` |
+
+Fleet-weite Paritätsregeln: identische Economic Policies und vergleichbare Kosten-, Execution-, Dataset- und Periodenbindungen über alle drei Kandidaten.
+
+## E. Admissibility Filters and Rejection Criteria
+
+**Admissibility filters (bindend):**
+
+- `EXCLUDE_UNCHANGED_V1_FAILED_BINDING` — strategy_id/strategy_version darf keinem excluded_failed_binding entsprechen
+- `REQUIRE_NEW_VERSIONED_BINDING` — strategy_version > v1 oder neu ratifizierter versionierter Alias mit vollem Binding-Digest-Set
+- `REQUIRE_MIN_TRADE_COUNT_EVIDENCE_PLAN` — Binding muss Minimum-Trade-Count-Evidence-Plan deklarieren
+- `REQUIRE_ROBUSTNESS_EVIDENCE_PLAN` — Binding muss Walk-Forward-, Monte-Carlo- und Stress-Evidence-Plan deklarieren
+- `REQUIRE_FLEET_PARITY` — fleet-weite identische Economic Policy und Kostenbindungen
+- `NO_NEAR_DUPLICATE_ARCHETYPE` — kein Near-Duplicate-Breakout-/Mean-Reversion-Workaround
+
+**Explicit rejection criteria (automatisch abgelehnt):**
+
+- `UNCHANGED_V1_BINDING_REEXECUTION`
+- `ZERO_TRADE_DEGENERATION_WITHOUT_NEW_VERSIONED_BINDING`
+- `SINGLE_TRADE_DOMINANCE_WITHOUT_MITIGATION_PLAN`
+- `THRESHOLD_LOWERING_TO_GENERATE_TRADES`
+- `PARAMETER_RESCUE_AFTER_KNOWN_NEGATIVE_EVIDENCE`
+- `NEAR_DUPLICATE_BREAKOUT_MEAN_REVERSION_WORKAROUND`
+- `PROMOTION_WITHOUT_OFFLINE_ECONOMIC_GATE_PASS`
+- `RUNTIME_REWIRE_FROM_NEGATIVE_FLEET`
+
+## F. Failure Taxonomy (from PR4920 Decomposition, read-only)
+
+| Follow-up class | Fleet-level diagnosis | Non-admissible automatic action |
+|---|---|---|
+| Evidence adequacy gaps | `long_short_contribution`, `fee_slippage_funding_drag`, `dominance_concentration` teils `MISSING_EVIDENCE` oder `INCONCLUSIVE` | Automatische Evidence-Execution ohne Operator GO |
+| Feature/edge failure class | Alle drei Kandidaten `ROBUSTNESS_FAILED`; `bollinger_bands&#47;v1` `ZERO_TRADE_DEGENERATION` | Unveränderte v1-Binding-Reexecution |
+| Turnover/cost drag class | `trend_following&#47;v1` und `momentum_1h&#47;v1` negative net edge | Parameter-Optimierung oder Threshold-Lowering |
+| Drawdown/tail-risk class | `trend_following&#47;v1` max drawdown -0.009945; Stress/MC failed | Policy-Threshold-Rescue |
+| Regime instability class | Regime breakdown `MIXED_TERMINAL_NEGATIVE` | Same-binding retry |
+| Walk-forward OOS instability | Walk-forward stability `TERMINAL_NEGATIVE` fleet-wide | Walk-forward rerun unveränderter v1 bindings |
+| Monte Carlo/stress weakness | MC `MIXED_TERMINAL_NEGATIVE`; Stress `TERMINAL_NEGATIVE` | Monte Carlo/Stress execution in diesem Scope |
+| Portfolio contribution weakness | Fleet contribution failure `TERMINAL_NEGATIVE` | Promotion oder Runtime-Rewire |
+
+## G. Authority Boundary
+
+Scope-Definition ≠ Binding-Ratifikation. Keine Economic Evaluation. Kein Same-Binding-Retry.
+
+| Boundary | Value |
+|---|---|
+| `SCOPE_DEFINITION_ONLY` | `true` |
+| `FAILED_BINDINGS_EXCLUDED` | `true` |
+| `FAILED_BINDINGS_RETRY_ALLOWED` | `false` |
+| `retry_unchanged_binding_allowed` | `false` |
+| `NO_ORDER_AUTHORITY` | `true` |
+| `RUNTIME` | `FORBIDDEN` |
+| `SHADOW` | `FORBIDDEN` |
+| `PAPER` | `FORBIDDEN` |
+| `TESTNET` | `FORBIDDEN` |
+| `SCHEDULER` | `FORBIDDEN` |
+| `ORDERS` | `FORBIDDEN` |
+| `CREDENTIALS` | `FORBIDDEN` |
+| `ARMING` | `FORBIDDEN` |
+| `LIVE` | `FORBIDDEN` |
+
+## H. Next Step
+
+`SEPARATE_OPERATOR_GO_REQUIRED_FOR_VERSIONED_BINDINGS_OR_OFFLINE_EVALUATION`
+
+Ein separater Operator GO ist erforderlich für:
+
+1. `GO_POST_PR4920_VERSIONED_FLEET_BINDING_RATIFICATION_V0` — Ratifikation neuer versionierter Bindings
+2. `GO_POST_PR4920_OFFLINE_ECONOMIC_EVALUATION_V0` — offline Economic Evaluation nach Binding-Ratifikation
+
+Dieser Scope autorisiert weder Evaluation noch Runtime noch Promotion.

--- a/scripts/research/post_pr4920_new_versioned_research_scope_definition_v0.py
+++ b/scripts/research/post_pr4920_new_versioned_research_scope_definition_v0.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Materialize post-PR4920 new versioned research scope definition v0.
+
+Offline-only scope-definition evidence bundle. No economic evaluation, no binding ratification,
+no runtime authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.primary_evidence_retention_v0 import (  # noqa: E402
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+
+SCOPE_ID = "POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0"
+PROCESS_CLASSIFICATION = "POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_ONLY_V0"
+SCOPE_CLASSIFICATION = (
+    "POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_FROM_FAILURE_DECOMPOSITION_DEFINITION_ONLY_V0"
+)
+CONFIRM_GO = "GO_DEFINE_POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_FROM_FAILURE_DECOMPOSITION_V0"
+NEXT_STEP = "SEPARATE_OPERATOR_GO_REQUIRED_FOR_VERSIONED_BINDINGS_OR_OFFLINE_EVALUATION"
+DEFAULT_CONFIG = (
+    _REPO_ROOT / "config/research/post_pr4920_new_versioned_research_scope_definition_v0.json"
+)
+DEFAULT_DOC = (
+    _REPO_ROOT / "docs/governance/POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0.md"
+)
+DEFAULT_ARCHIVE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+PARENT_DECOMPOSITION_BUNDLE_SUFFIX = (
+    "post_pr4920_failure_decomposition_followup_execution_offline_only_20260706T080836Z"
+)
+OUTPUT_PREFIX = "post_pr4920_new_versioned_research_scope_definition_v0"
+
+REQUIRED_CONFIG_KEYS = (
+    "scope_id",
+    "scope_version",
+    "base_head",
+    "parent_decomposition_evidence_ref",
+    "parent_closeout_dir",
+    "fleet_verdict",
+    "economic_validity_offline_gate_pass",
+    "promotion_admissible",
+    "runtime_rewire_admissible",
+    "retry_authorized",
+    "scope_definition_only",
+    "failed_bindings_excluded",
+    "no_order_authority",
+    "excluded_failed_bindings",
+    "allowed_actions",
+    "forbidden_actions",
+    "followup_taxonomy",
+    "candidate_archetype_requirements",
+    "candidate_admissibility_filters",
+    "explicit_rejection_criteria",
+    "next_step",
+    "governance_ref",
+)
+
+REQUIRED_CONTRACT_FLAGS = (
+    ("scope_definition_only", True),
+    ("economic_evaluation_authorized", False),
+    ("retry_authorized", False),
+    ("runtime_rewire_admissible", False),
+    ("promotion_admissible", False),
+    ("failed_bindings_excluded", True),
+    ("core_system_mutation_allowed", False),
+    ("canonical_trading_logic_mutation_allowed", False),
+    ("master_v2_mutation_allowed", False),
+    ("double_play_mutation_allowed", False),
+    ("safety_runtime_mutation_allowed", False),
+    ("no_order_authority", True),
+)
+
+
+def _die(message: str, code: int = 2) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"not_object:{path}")
+    return payload
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _sha256_path(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def validate_config(config: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    for key in REQUIRED_CONFIG_KEYS:
+        if key not in config:
+            errors.append(f"missing required config key: {key}")
+
+    if config.get("scope_id") != SCOPE_ID:
+        errors.append("unexpected scope_id")
+    if config.get("process_classification") != PROCESS_CLASSIFICATION:
+        errors.append("unexpected process_classification")
+    if config.get("scope_classification") != SCOPE_CLASSIFICATION:
+        errors.append("unexpected scope_classification")
+    if config.get("go_token") != CONFIRM_GO:
+        errors.append("unexpected go_token")
+    if config.get("next_step") != NEXT_STEP:
+        errors.append("unexpected next_step")
+    if config.get("fleet_verdict") != "FLEET_ECONOMIC_VALIDITY_FAIL":
+        errors.append("unexpected fleet_verdict")
+
+    for field, expected in REQUIRED_CONTRACT_FLAGS:
+        if config.get(field) is not expected:
+            errors.append(f"contract flag mismatch: {field} expected {expected}")
+
+    excluded = set(config.get("excluded_failed_bindings", []))
+    required_excluded = {"trend_following/v1", "bollinger_bands/v1", "momentum_1h/v1"}
+    if not required_excluded.issubset(excluded):
+        errors.append("excluded_failed_bindings must include all failed v1 bindings")
+
+    taxonomy = config.get("followup_taxonomy", [])
+    if not isinstance(taxonomy, list) or len(taxonomy) < 8:
+        errors.append("followup_taxonomy must contain at least 8 entries")
+
+    return errors
+
+
+def _verify_optional_manifest(source_dir: Path) -> tuple[int, str]:
+    manifest_path = source_dir / "MANIFEST.sha256"
+    if not manifest_path.is_file():
+        return -1, "manifest_missing"
+    ok, msg = verify_manifest_sha256(source_dir)
+    return (0 if ok else 1), msg or "ok"
+
+
+def _build_scope_summary(config: dict[str, Any], doc_sha256: str) -> dict[str, Any]:
+    return {
+        "authority_effect": config.get("authority_effect", "NONE"),
+        "base_head": config["base_head"],
+        "config_sha256": _sha256_text(json.dumps(config, indent=2, sort_keys=True) + "\n"),
+        "doc_sha256": doc_sha256,
+        "economic_validity_offline_gate_pass": False,
+        "excluded_failed_bindings": config["excluded_failed_bindings"],
+        "failed_bindings_excluded": True,
+        "fleet_verdict": config["fleet_verdict"],
+        "followup_class_count": len(config["followup_taxonomy"]),
+        "go_token": CONFIRM_GO,
+        "go_token_consumption": "CONSUMED_ONCE_FOR_SCOPE_DEFINITION_ONLY",
+        "next_step": config["next_step"],
+        "no_order_authority": True,
+        "non_authorizing": True,
+        "offline_only": True,
+        "parent_closeout_dir": config["parent_closeout_dir"],
+        "parent_decomposition_evidence_ref": config["parent_decomposition_evidence_ref"],
+        "process_classification": PROCESS_CLASSIFICATION,
+        "promotion_admissible": False,
+        "retry_authorized": False,
+        "runtime_rewire_admissible": False,
+        "scope_classification": SCOPE_CLASSIFICATION,
+        "scope_definition_only": True,
+        "scope_id": SCOPE_ID,
+        "scope_version": config["scope_version"],
+        "status": "SCOPE_DEFINED_NOT_EXECUTED",
+        "verdict": "SCOPE_DEFINED_NOT_EXECUTED",
+    }
+
+
+def _build_authority_boundary(config: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "canonical_trading_logic_mutation_allowed": False,
+        "core_system_mutation_allowed": False,
+        "double_play_mutation_allowed": False,
+        "economic_evaluation_authorized": False,
+        "economic_evaluation_executed": False,
+        "evaluation_execution_in_this_scope": False,
+        "failed_bindings_excluded": True,
+        "failed_bindings_retry_allowed": False,
+        "forbidden_actions": sorted(config["forbidden_actions"]),
+        "live_authorized": False,
+        "master_v2_mutation_allowed": False,
+        "new_candidate_ratified": False,
+        "no_order_authority": True,
+        "no_runtime_authority": True,
+        "offline_only": True,
+        "orders_allowed": False,
+        "paper_authorized": False,
+        "promotion_admissible": False,
+        "retry_authorized": False,
+        "runtime_authority": "NONE",
+        "runtime_rewire_admissible": False,
+        "safety_runtime_mutation_allowed": False,
+        "scope_definition_only": True,
+        "shadow_authorized": False,
+        "testnet_authorized": False,
+    }
+
+
+def _build_failure_taxonomy(config: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "candidate_admissibility_filters": config["candidate_admissibility_filters"],
+        "candidate_archetype_requirements": config["candidate_archetype_requirements"],
+        "excluded_failed_bindings": config["excluded_failed_bindings"],
+        "explicit_rejection_criteria": config["explicit_rejection_criteria"],
+        "failed_evidence_is_terminal": config.get("failed_evidence_is_terminal", True),
+        "fleet_verdict": config["fleet_verdict"],
+        "followup_taxonomy": config["followup_taxonomy"],
+        "next_step": config["next_step"],
+        "not_a_new_candidate": True,
+        "not_a_rerun": True,
+        "scope_id": SCOPE_ID,
+    }
+
+
+def run_post_pr4920_new_versioned_research_scope_definition_v0(
+    *,
+    config_path: Path = DEFAULT_CONFIG,
+    governance_doc_path: Path = DEFAULT_DOC,
+    output_dir: Path,
+    archive_root: Path = DEFAULT_ARCHIVE_ROOT,
+) -> dict[str, Any]:
+    if not config_path.is_file():
+        _die(f"ERR:missing config: {config_path}")
+    if not governance_doc_path.is_file():
+        _die(f"ERR:missing governance doc: {governance_doc_path}")
+
+    config = _load_json(config_path)
+    errors = validate_config(config)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        _die("ERR:config validation failed", code=1)
+
+    output_dir = output_dir.resolve()
+    if output_dir.exists() and any(output_dir.iterdir()):
+        _die(f"ERR:output dir not empty: {output_dir}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    parent_decomposition_dir = Path(config["parent_decomposition_evidence_ref"])
+    parent_closeout_dir = Path(config["parent_closeout_dir"])
+
+    parent_decomposition_rc, parent_decomposition_msg = _verify_optional_manifest(
+        parent_decomposition_dir
+    )
+    parent_closeout_rc, parent_closeout_msg = _verify_optional_manifest(parent_closeout_dir)
+
+    required_decomposition_rc = int(config.get("parent_decomposition_manifest_verify_rc", 0))
+    required_closeout_rc = int(config.get("parent_closeout_manifest_verify_rc", 0))
+
+    if parent_decomposition_rc >= 0 and parent_decomposition_rc != required_decomposition_rc:
+        _die(f"ERR:parent decomposition manifest verify rc mismatch: {parent_decomposition_dir}")
+    if parent_closeout_rc >= 0 and parent_closeout_rc != required_closeout_rc:
+        _die(f"ERR:parent closeout manifest verify rc mismatch: {parent_closeout_dir}")
+
+    doc_sha256 = _sha256_path(governance_doc_path)
+    scope_summary = _build_scope_summary(config, doc_sha256)
+    authority_boundary = _build_authority_boundary(config)
+    failure_taxonomy = _build_failure_taxonomy(config)
+
+    (output_dir / "SCOPE_DEFINITION_SUMMARY.json").write_text(
+        json.dumps(scope_summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "AUTHORITY_BOUNDARY.json").write_text(
+        json.dumps(authority_boundary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "FAILURE_TAXONOMY.json").write_text(
+        json.dumps(failure_taxonomy, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "parent_decomposition_manifest_verify.log").write_text(
+        "\n".join(
+            [
+                f"PARENT_DECOMPOSITION_DIR={parent_decomposition_dir}",
+                f"MANIFEST_VERIFY_RC={parent_decomposition_rc}",
+                f"MANIFEST_VERIFY_MSG={parent_decomposition_msg}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "parent_closeout_manifest_verify.log").write_text(
+        "\n".join(
+            [
+                f"PARENT_CLOSEOUT_DIR={parent_closeout_dir}",
+                f"MANIFEST_VERIFY_RC={parent_closeout_rc}",
+                f"MANIFEST_VERIFY_MSG={parent_closeout_msg}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    write_manifest_sha256(output_dir)
+    manifest_ok, manifest_msg = verify_manifest_sha256(output_dir)
+    manifest_rc = 0 if manifest_ok else 1
+    if manifest_rc != 0:
+        _die(f"ERR:manifest verify failed: {output_dir} ({manifest_msg})")
+
+    return {
+        "authority_boundary_path": str(output_dir / "AUTHORITY_BOUNDARY.json"),
+        "durable_evidence_path": str(output_dir),
+        "failure_taxonomy_path": str(output_dir / "FAILURE_TAXONOMY.json"),
+        "fleet_verdict": config["fleet_verdict"],
+        "manifest_verify_rc": manifest_rc,
+        "next_step": config["next_step"],
+        "parent_closeout_manifest_verify_rc": parent_closeout_rc,
+        "parent_decomposition_manifest_verify_rc": parent_decomposition_rc,
+        "process_classification": PROCESS_CLASSIFICATION,
+        "scope_classification": SCOPE_CLASSIFICATION,
+        "scope_definition_summary_path": str(output_dir / "SCOPE_DEFINITION_SUMMARY.json"),
+        "scope_id": SCOPE_ID,
+        "verdict": "SCOPE_DEFINED_NOT_EXECUTED",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Materialize post-PR4920 new versioned research scope definition v0"
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--governance-doc", type=Path, default=DEFAULT_DOC)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_ARCHIVE_ROOT)
+    args = parser.parse_args()
+
+    result = run_post_pr4920_new_versioned_research_scope_definition_v0(
+        config_path=args.config,
+        governance_doc_path=args.governance_doc,
+        output_dir=args.out,
+        archive_root=args.durable_evidence_root,
+    )
+    print("VERDICT=SCOPE_DEFINED_NOT_EXECUTED")
+    print(f"SCOPE_ID={result['scope_id']}")
+    print(f"DURABLE_EVIDENCE_BUNDLE={result['durable_evidence_path']}")
+    print(f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}")
+    print(f"NEXT_STEP={result['next_step']}")
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ops/test_post_pr4920_new_versioned_research_scope_definition_v0_contract.py
+++ b/tests/ops/test_post_pr4920_new_versioned_research_scope_definition_v0_contract.py
@@ -1,0 +1,289 @@
+"""Contract tests for post-PR4920 new versioned research scope definition v0."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from scripts.ops.validate_docs_token_policy import DocsTokenPolicyValidator
+from scripts.research.post_pr4920_new_versioned_research_scope_definition_v0 import (
+    CONFIRM_GO,
+    NEXT_STEP,
+    PROCESS_CLASSIFICATION,
+    SCOPE_CLASSIFICATION,
+    SCOPE_ID,
+    run_post_pr4920_new_versioned_research_scope_definition_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCOPE_CONFIG = (
+    REPO_ROOT / "config/research/post_pr4920_new_versioned_research_scope_definition_v0.json"
+)
+GOVERNANCE_DOC = (
+    REPO_ROOT / "docs/governance/POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0.md"
+)
+SCOPE_SCRIPT = (
+    REPO_ROOT / "scripts/research/post_pr4920_new_versioned_research_scope_definition_v0.py"
+)
+EVIDENCE_CLASS_ID = "POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0"
+SCOPE_STATUS = "SCOPE_DEFINED_NOT_EXECUTED"
+BASE_HEAD = "aa53ee580257b8d937a19c5172e98b7d16544221"
+PARENT_DECOMPOSITION_SUFFIX = (
+    "post_pr4920_failure_decomposition_followup_execution_offline_only_20260706T080836Z"
+)
+PARENT_CLOSEOUT_SUFFIX = "pr4920_post_pr4919_terminal_final_fleet_failure_decomposition_followup_scope_merge_closeout_20260706T080500Z"
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+PARENT_DECOMPOSITION_DIR = ARCHIVE_ROOT / "implementation" / PARENT_DECOMPOSITION_SUFFIX
+PARENT_CLOSEOUT_DIR = ARCHIVE_ROOT / "implementation" / PARENT_CLOSEOUT_SUFFIX
+EXCLUDED_BINDINGS = ("trend_following/v1", "bollinger_bands/v1", "momentum_1h/v1")
+FOLLOWUP_TAXONOMY_CLASS_IDS = (
+    "EVIDENCE_ADEQUACY_GAPS",
+    "FEATURE_EDGE_FAILURE_CLASS",
+    "TURNOVER_COST_DRAG_CLASS",
+    "DRAWDOWN_TAIL_RISK_CLASS",
+    "REGIME_INSTABILITY_CLASS",
+    "WALK_FORWARD_OOS_INSTABILITY_CLASS",
+    "MONTE_CARLO_STRESS_WEAKNESS_CLASS",
+    "PORTFOLIO_CONTRIBUTION_WEAKNESS_CLASS",
+)
+FORBIDDEN_RUNTIME_ACTIONS = (
+    "RUNTIME",
+    "SHADOW",
+    "PAPER",
+    "TESTNET",
+    "SCHEDULER",
+    "ORDERS",
+    "CREDENTIALS",
+    "ARMING",
+    "LIVE",
+)
+BOUNDARY_PHRASES = (
+    "Scope-Definition ≠ Binding-Ratifikation",
+    "Keine Economic Evaluation",
+    "FLEET_ECONOMIC_VALIDITY_FAIL",
+    "FAILED_BINDINGS_EXCLUDED",
+    "NO_ORDER_AUTHORITY",
+    "retry_unchanged_binding_allowed",
+    "SEPARATE_OPERATOR_GO_REQUIRED_FOR_VERSIONED_BINDINGS_OR_OFFLINE_EVALUATION",
+    "nicht retry-fähig",
+)
+REQUIRED_BUNDLE_ARTIFACTS = (
+    "SCOPE_DEFINITION_SUMMARY.json",
+    "AUTHORITY_BOUNDARY.json",
+    "FAILURE_TAXONOMY.json",
+    "MANIFEST.sha256",
+)
+REQUIRED_CONTRACT_ASSERTIONS = (
+    ("scope_definition_only", True),
+    ("economic_evaluation_authorized", False),
+    ("retry_authorized", False),
+    ("runtime_rewire_admissible", False),
+    ("promotion_admissible", False),
+    ("failed_bindings_excluded", True),
+    ("core_system_mutation_allowed", False),
+    ("canonical_trading_logic_mutation_allowed", False),
+    ("master_v2_mutation_allowed", False),
+    ("double_play_mutation_allowed", False),
+    ("safety_runtime_mutation_allowed", False),
+    ("no_order_authority", True),
+)
+
+
+def _docs_token_marker(token_name: str) -> str:
+    return "docs_" + "token: " + token_name
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(rf"\| `{re.escape(field)}` \| `([^`]*)` \|", text)
+    assert match, f"missing governance field: {field}"
+    return match.group(1)
+
+
+class TestPostPr4920NewVersionedResearchScopeDefinitionV0Contract:
+    def test_scope_config_exists_and_parses(self) -> None:
+        assert SCOPE_CONFIG.is_file()
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        assert isinstance(config, dict)
+        assert config["schema_version"] == "post_pr4920_new_versioned_research_scope_definition.v0"
+
+    def test_required_contract_assertions(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        for field, expected in REQUIRED_CONTRACT_ASSERTIONS:
+            assert config[field] is expected, f"contract assertion failed: {field}"
+        assert config["next_step"] == NEXT_STEP
+
+    def test_scope_config_core_fields(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        assert config["status"] == SCOPE_STATUS
+        assert config["evidence_class_id"] == EVIDENCE_CLASS_ID
+        assert config["scope_id"] == SCOPE_ID
+        assert config["scope_version"] == "v0"
+        assert config["process_classification"] == PROCESS_CLASSIFICATION
+        assert config["scope_classification"] == SCOPE_CLASSIFICATION
+        assert config["go_token"] == CONFIRM_GO
+        assert config["base_head"] == BASE_HEAD
+        assert config["baseline_pr"] == 4920
+        assert config["fleet_verdict"] == "FLEET_ECONOMIC_VALIDITY_FAIL"
+        assert config["economic_validity_offline_gate_pass"] is False
+        assert config["operator_go_required_for_next_scope"] is True
+
+    def test_excluded_failed_bindings(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        assert config["failed_bindings_excluded"] is True
+        assert set(config["excluded_failed_bindings"]) == set(EXCLUDED_BINDINGS)
+        for binding in config["failed_bindings"]:
+            identifier = binding["canonical_candidate_identifier"]
+            assert identifier in EXCLUDED_BINDINGS
+            assert binding["retry_unchanged_binding_allowed"] is False
+
+    def test_followup_taxonomy_classes(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        class_ids = [entry["class_id"] for entry in config["followup_taxonomy"]]
+        assert class_ids == list(FOLLOWUP_TAXONOMY_CLASS_IDS)
+
+    def test_candidate_archetype_requirements(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        archetypes = config["candidate_archetype_requirements"]
+        assert len(archetypes) == 3
+        replaces = {entry["replaces_binding"] for entry in archetypes}
+        assert replaces == set(EXCLUDED_BINDINGS)
+
+    def test_forbidden_actions_present(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        forbidden = set(config["forbidden_actions"])
+        for action in (
+            "ECONOMIC_EVALUATION_EXECUTION",
+            "SAME_BINDING_RETRY",
+            "PARAMETER_OPTIMIZATION",
+            "THRESHOLD_LOWERING",
+            "RUNTIME_REWIRE",
+            *FORBIDDEN_RUNTIME_ACTIONS,
+        ):
+            assert action in forbidden
+
+    def test_blocked_scope_classes(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        blocked = set(config["blocked_scope_classes"])
+        assert "A_UNMODIFIED_V1_BINDING_REEXECUTION" in blocked
+        assert "G_RUNTIME_REWIRE" in blocked
+
+    def test_parent_evidence_refs_present(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        assert PARENT_DECOMPOSITION_SUFFIX in config["parent_decomposition_evidence_ref"]
+        assert PARENT_CLOSEOUT_SUFFIX in config["parent_closeout_dir"]
+        assert config["parent_decomposition_manifest_verify_rc"] == 0
+        assert config["parent_closeout_manifest_verify_rc"] == 0
+
+    def test_governance_doc_exists_with_docs_token(self) -> None:
+        assert GOVERNANCE_DOC.is_file()
+        body = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        assert (
+            _docs_token_marker("DOCS_TOKEN_POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0")
+            in body
+        )
+        assert "LIVE_AUTHORIZED: false" in body
+        assert "`FLEET_VERDICT` | `FLEET_ECONOMIC_VALIDITY_FAIL`" in body
+        assert "`SCOPE_DEFINITION_ONLY` | `true`" in body
+        assert "`FAILED_BINDINGS_EXCLUDED` | `true`" in body
+        assert "`NO_ORDER_AUTHORITY` | `true`" in body
+        assert "`ECONOMIC_EVALUATION_AUTHORIZED` | `false`" in body
+        assert "`RETRY_AUTHORIZED` | `false`" in body
+
+    def test_governance_doc_boundary_phrases(self) -> None:
+        body = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        for phrase in BOUNDARY_PHRASES:
+            assert phrase in body
+
+    def test_governance_doc_forbidden_runtime_actions(self) -> None:
+        body = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        for action in FORBIDDEN_RUNTIME_ACTIONS:
+            assert action in body
+
+    def test_governance_doc_next_step(self) -> None:
+        body = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        assert _field_value(body, "NEXT_STEP") == NEXT_STEP
+
+    def test_scope_is_definition_only_not_execution(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        assert config["non_authorizing"] is True
+        assert config["offline_only"] is True
+        assert config["repo_mutation_scope"] == "GOVERNANCE_ONLY"
+        assert config["economic_evaluation_executed"] is False
+
+    def test_script_has_no_forbidden_imports(self) -> None:
+        body = SCOPE_SCRIPT.read_text(encoding="utf-8")
+        forbidden_import_re = re.compile(
+            r"^\s*(from|import)\s+"
+            r"src\.(execution|live|scheduler|adapters|broker|exchange|order|shadow|paper|testnet|credentials)"
+        )
+        for line in body.splitlines():
+            assert not forbidden_import_re.match(line), line
+
+    def test_docs_token_policy_passes_for_governance_doc(self) -> None:
+        validator = DocsTokenPolicyValidator(REPO_ROOT)
+        result = validator.scan_file(GOVERNANCE_DOC)
+        assert result.passed, [(v.line, v.token, v.message) for v in result.violations]
+
+    def test_docs_reference_targets_for_governance_doc(self) -> None:
+        body = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        for match in re.finditer(r"`((?:config|docs)/[^`]+)`", body):
+            target = REPO_ROOT / match.group(1)
+            assert target.is_file(), match.group(1)
+
+    @pytest.mark.parametrize("parent_path", [PARENT_DECOMPOSITION_DIR, PARENT_CLOSEOUT_DIR])
+    def test_parent_manifest_verifies(self, parent_path: Path) -> None:
+        if not parent_path.is_dir():
+            pytest.skip(f"parent bundle unavailable: {parent_path}")
+        ok, _msg = verify_manifest_sha256(parent_path)
+        assert ok, f"parent manifest invalid: {parent_path}"
+
+    def test_runner_materializes_required_artifacts(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "bundle_a"
+        result = run_post_pr4920_new_versioned_research_scope_definition_v0(
+            output_dir=output_dir,
+        )
+        assert result["verdict"] == SCOPE_STATUS
+        assert result["manifest_verify_rc"] == 0
+        for artifact_name in REQUIRED_BUNDLE_ARTIFACTS:
+            assert (output_dir / artifact_name).is_file(), artifact_name
+        ok, _msg = verify_manifest_sha256(output_dir)
+        assert ok
+
+        authority = json.loads((output_dir / "AUTHORITY_BOUNDARY.json").read_text(encoding="utf-8"))
+        assert authority["scope_definition_only"] is True
+        assert authority["failed_bindings_excluded"] is True
+        assert authority["no_order_authority"] is True
+        assert authority["retry_authorized"] is False
+        assert authority["promotion_admissible"] is False
+
+        taxonomy = json.loads((output_dir / "FAILURE_TAXONOMY.json").read_text(encoding="utf-8"))
+        assert taxonomy["not_a_new_candidate"] is True
+        assert taxonomy["not_a_rerun"] is True
+        assert taxonomy["next_step"] == NEXT_STEP
+        assert set(taxonomy["excluded_failed_bindings"]) == set(EXCLUDED_BINDINGS)
+
+    def test_cli_entrypoint(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "cli_bundle"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCOPE_SCRIPT),
+                "--config",
+                str(SCOPE_CONFIG),
+                "--out",
+                str(output_dir),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "VERDICT=SCOPE_DEFINED_NOT_EXECUTED" in proc.stdout
+        assert (output_dir / "MANIFEST.sha256").is_file()


### PR DESCRIPTION
## Summary
- Scope-definition only after PR4920 failure decomposition (`FLEET_ECONOMIC_VALIDITY_FAIL`).
- Defines bounded next versioned research scope excluding failed v1 bindings (`trend_following/v1`, `bollinger_bands/v1`, `momentum_1h/v1`).
- No economic evaluation, no retry, no promotion, no runtime/shadow/paper/testnet/live authority.

## Boundaries
- Scope-definition only.
- No economic evaluation.
- No retry.
- No promotion.
- No runtime/shadow/paper/testnet/live authority.
- Separate Operator GO required for any execution.

## Test plan
- [x] `python3 -m pytest tests/ops/test_post_pr4920_new_versioned_research_scope_definition_v0_contract.py -q`
- [x] `bash scripts/ops/preflight_docs_token_policy_changed.sh`
- [x] `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`
- [x] `python3 -m ruff format --check` and `python3 -m ruff check` on changed Python files


Made with [Cursor](https://cursor.com)