### PR TITLE
post-pr4921 versioned research bindings no eval

### DIFF
--- a/config/research/post_pr4921_versioned_research_bindings_no_eval_v0.json
+++ b/config/research/post_pr4921_versioned_research_bindings_no_eval_v0.json
@@ -1,0 +1,302 @@
+{
+  "artifact_kind": "post_pr4921_versioned_research_bindings_no_eval",
+  "artifact_version": "v0",
+  "authority_effect": "NONE",
+  "backtest_execution_authorized": false,
+  "base_head": "dc6229ed32a57af4b9f3cd1f3d969cf499b6ebc5",
+  "baseline_pr": 4921,
+  "binding_materialization_only": true,
+  "binding_materialization_status": "BINDINGS_MATERIALIZED_NOT_EVALUATED",
+  "blocked_execution_classes": [
+    "ADAPTER_SUBMISSION",
+    "ARMING",
+    "BACKTEST",
+    "CANARY",
+    "CREDENTIALS",
+    "ECONOMIC_EVALUATION",
+    "LIVE",
+    "MONTE_CARLO",
+    "ORDERS",
+    "PAPER",
+    "PARAMETER_OPTIMIZATION",
+    "PARAMETER_SENSITIVITY",
+    "PROMOTION",
+    "RUNTIME_REWIRE",
+    "SCHEDULER",
+    "SHADOW",
+    "STRESS",
+    "TESTNET",
+    "THRESHOLD_LOWERING",
+    "WALK_FORWARD"
+  ],
+  "canonical_trading_logic_mutation_allowed": false,
+  "core_system_mutation_allowed": false,
+  "double_play_mutation_allowed": false,
+  "economic_evaluation_authorized": false,
+  "evidence_class_id": "POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0",
+  "excluded_failed_v1_bindings": [
+    "trend_following/v1",
+    "bollinger_bands/v1",
+    "momentum_1h/v1"
+  ],
+  "failed_v1_bindings_excluded": true,
+  "fleet_verdict_context": "FLEET_ECONOMIC_VALIDITY_FAIL",
+  "go_token": "GO_MATERIALIZE_POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0",
+  "go_token_consumed": true,
+  "go_token_consumption": "CONSUMED_ONCE_FOR_BINDING_MATERIALIZATION_ONLY",
+  "governance_ref": "docs/governance/POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0.md",
+  "live_authorized": false,
+  "master_v2_mutation_allowed": false,
+  "monte_carlo_execution_authorized": false,
+  "next_step": "SEPARATE_OPERATOR_GO_REQUIRED_FOR_OFFLINE_ECONOMIC_EVALUATION_EXECUTION",
+  "offline_only": true,
+  "orders_allowed": false,
+  "parameter_optimization_authorized": false,
+  "parent_closeout_dir": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/post_pr4920_new_versioned_research_scope_definition_merge_closeout_20260706T081927Z",
+  "parent_closeout_manifest_verify_rc": 0,
+  "parent_scope_config": "config/research/post_pr4920_new_versioned_research_scope_definition_v0.json",
+  "parent_scope_doc": "docs/governance/POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0.md",
+  "parent_scope_id": "POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0",
+  "process_classification": "POST_PR4921_VERSIONED_RESEARCH_BINDINGS_MATERIALIZATION_NO_EVAL_V0",
+  "promotion_admissible": false,
+  "repo_mutation_scope": "GOVERNANCE_ONLY",
+  "retry_authorized": false,
+  "risk_sizing_mutation_allowed": false,
+  "runtime_authority": "NONE",
+  "runtime_effect": "NONE",
+  "runtime_rewire_admissible": false,
+  "safety_runtime_mutation_allowed": false,
+  "schema_version": "post_pr4921_versioned_research_bindings_no_eval.v0",
+  "scope_classification": "BINDING_MATERIALIZATION_ONLY_NO_EVAL_NO_RUNTIME_AUTHORITY_V0",
+  "scope_id": "POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0",
+  "shared_model_bindings": {
+    "canonical_trading_logic_version": "canonical_mv2_decision_path_reuse_first",
+    "dataset_binding": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1_extended_chronological_v1",
+    "economic_policy_binding": "economic_validity_policy_v1_unchanged_no_threshold_lowering",
+    "execution_model_binding": "backtest_execution_v0_offline_simulation_only",
+    "fee_model_binding": "backtest_fee_taker_symmetric_v0_realistic_costs",
+    "funding_model_binding": "backtest_funding_perpetual_interval_v1",
+    "instrument_binding": "futures_only_okx_linear_usdt_non_bitcoin_panel_v1",
+    "period_binding": "panel_calendar_2024-05-01_to_2024-09-01_utc_pt1h",
+    "slippage_model_binding": "backtest_slippage_conservative_half_spread_v0"
+  },
+  "source_evidence_refs": [
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/post_pr4920_new_versioned_research_scope_definition_merge_closeout_20260706T081927Z",
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/post_pr4920_failure_decomposition_followup_execution_offline_only_20260706T080836Z"
+  ],
+  "status": "BINDINGS_MATERIALIZED_NOT_EVALUATED",
+  "stress_execution_authorized": false,
+  "threshold_lowering_authorized": false,
+  "trading_effect": "NONE",
+  "verdict": "BINDINGS_MATERIALIZED_NOT_EVALUATED",
+  "versioned_bindings": [
+    {
+      "candidate_id": "trend_following",
+      "candidate_version": "v2",
+      "strategy_archetype": "TREND_CONTINUATION_V2",
+      "replaces_failed_binding": "trend_following/v1",
+      "parameter_binding": {
+        "binding_id": "trend_following_v2_post_pr4921_parameters_bound_no_optimization",
+        "source": "config/config.toml:[strategies.trend_following.defaults]",
+        "values": {
+          "adx_period": 14,
+          "adx_threshold": 25.0,
+          "exit_threshold": 20.0,
+          "ma_period": 50,
+          "use_ma_filter": true
+        }
+      },
+      "dataset_binding": {
+        "binding_id": "trend_following_v2_futures_dataset_bound",
+        "dataset_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+        "dataset_extension": "extended_chronological_v1",
+        "panel_staging_root": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/extended_chronological_v1"
+      },
+      "period_binding": {
+        "binding_id": "trend_following_v2_periods_bound",
+        "panel_calendar_start_utc": "2024-05-01T00:00:00Z",
+        "panel_calendar_end_utc": "2024-09-01T00:00:00Z",
+        "timeframe": "1h"
+      },
+      "instrument_binding": {
+        "binding_id": "trend_following_v2_futures_instruments_bound",
+        "binding_mode": "extended_chronological_v1_panel_member_binding",
+        "bitcoin_direction_allowed": false,
+        "futures_only": true
+      },
+      "fee_model_binding": {
+        "binding_id": "trend_following_v2_fee_model_bound",
+        "fee_bps": 10.0,
+        "fee_model_version": "backtest_fee_taker_symmetric_v0"
+      },
+      "slippage_model_binding": {
+        "binding_id": "trend_following_v2_slippage_model_bound",
+        "conservative_half_spread_bps": 5.0,
+        "roundtrip_cost_bps": 40.0,
+        "slippage_model_version": "backtest_slippage_conservative_half_spread_v0"
+      },
+      "funding_model_binding": {
+        "binding_id": "trend_following_v2_funding_model_bound",
+        "bind": true,
+        "model_version": "backtest_funding_perpetual_interval_v1"
+      },
+      "execution_model_binding": {
+        "binding_id": "trend_following_v2_execution_model_bound",
+        "execution_model_version": "backtest_execution_v0",
+        "offline_simulation_only": true
+      },
+      "economic_policy_binding": {
+        "binding_id": "trend_following_v2_economic_policy_bound",
+        "policy_version": "economic_validity_policy_v1",
+        "threshold_lowering_allowed": false
+      },
+      "implementation_digest_source": "src/strategies/trend_following.py",
+      "config_digest_source": "config/config.toml:[strategies.trend_following]",
+      "data_digest_source": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/extended_chronological_v1/panel/panel_dataset_manifest.json",
+      "excluded_failed_v1_binding": "trend_following/v1",
+      "evaluation_authorized": false,
+      "retry_authorized": false,
+      "promotion_admissible": false,
+      "runtime_rewire_admissible": false,
+      "binding_status": "MATERIALIZED_NOT_EVALUATED"
+    },
+    {
+      "candidate_id": "bollinger_bands",
+      "candidate_version": "v2",
+      "strategy_archetype": "MEAN_REVERSION_BANDS_V2",
+      "replaces_failed_binding": "bollinger_bands/v1",
+      "parameter_binding": {
+        "binding_id": "bollinger_bands_v2_post_pr4921_parameters_bound_no_optimization",
+        "source": "config/config.toml:[strategy.bollinger_bands]",
+        "values": {
+          "bb_period": 20,
+          "bb_std": 2.0,
+          "stop_pct": 0.02
+        }
+      },
+      "dataset_binding": {
+        "binding_id": "bollinger_bands_v2_futures_dataset_bound",
+        "dataset_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+        "dataset_extension": "extended_chronological_v1",
+        "panel_staging_root": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/extended_chronological_v1"
+      },
+      "period_binding": {
+        "binding_id": "bollinger_bands_v2_periods_bound",
+        "panel_calendar_start_utc": "2024-05-01T00:00:00Z",
+        "panel_calendar_end_utc": "2024-09-01T00:00:00Z",
+        "timeframe": "1h"
+      },
+      "instrument_binding": {
+        "binding_id": "bollinger_bands_v2_futures_instruments_bound",
+        "binding_mode": "extended_chronological_v1_panel_member_binding",
+        "bitcoin_direction_allowed": false,
+        "futures_only": true
+      },
+      "fee_model_binding": {
+        "binding_id": "bollinger_bands_v2_fee_model_bound",
+        "fee_bps": 10.0,
+        "fee_model_version": "backtest_fee_taker_symmetric_v0"
+      },
+      "slippage_model_binding": {
+        "binding_id": "bollinger_bands_v2_slippage_model_bound",
+        "conservative_half_spread_bps": 5.0,
+        "roundtrip_cost_bps": 40.0,
+        "slippage_model_version": "backtest_slippage_conservative_half_spread_v0"
+      },
+      "funding_model_binding": {
+        "binding_id": "bollinger_bands_v2_funding_model_bound",
+        "bind": true,
+        "model_version": "backtest_funding_perpetual_interval_v1"
+      },
+      "execution_model_binding": {
+        "binding_id": "bollinger_bands_v2_execution_model_bound",
+        "execution_model_version": "backtest_execution_v0",
+        "offline_simulation_only": true
+      },
+      "economic_policy_binding": {
+        "binding_id": "bollinger_bands_v2_economic_policy_bound",
+        "policy_version": "economic_validity_policy_v1",
+        "threshold_lowering_allowed": false
+      },
+      "implementation_digest_source": "src/strategies/bollinger.py",
+      "config_digest_source": "config/config.toml:[strategy.bollinger_bands]",
+      "data_digest_source": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/extended_chronological_v1/panel/panel_dataset_manifest.json",
+      "excluded_failed_v1_binding": "bollinger_bands/v1",
+      "evaluation_authorized": false,
+      "retry_authorized": false,
+      "promotion_admissible": false,
+      "runtime_rewire_admissible": false,
+      "binding_status": "MATERIALIZED_NOT_EVALUATED"
+    },
+    {
+      "candidate_id": "momentum_1h",
+      "candidate_version": "v2",
+      "strategy_archetype": "MOMENTUM_HORIZON_V2",
+      "replaces_failed_binding": "momentum_1h/v1",
+      "parameter_binding": {
+        "binding_id": "momentum_1h_v2_post_pr4921_parameters_bound_no_optimization",
+        "source": "config/config.toml:[strategy.momentum_1h]",
+        "values": {
+          "lookback_period": 20,
+          "entry_threshold": 0.02,
+          "exit_threshold": -0.01,
+          "stop_pct": 0.025
+        }
+      },
+      "dataset_binding": {
+        "binding_id": "momentum_1h_v2_futures_dataset_bound",
+        "dataset_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+        "dataset_extension": "extended_chronological_v1",
+        "panel_staging_root": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/extended_chronological_v1"
+      },
+      "period_binding": {
+        "binding_id": "momentum_1h_v2_periods_bound",
+        "panel_calendar_start_utc": "2024-05-01T00:00:00Z",
+        "panel_calendar_end_utc": "2024-09-01T00:00:00Z",
+        "timeframe": "1h"
+      },
+      "instrument_binding": {
+        "binding_id": "momentum_1h_v2_futures_instruments_bound",
+        "binding_mode": "extended_chronological_v1_panel_member_binding",
+        "bitcoin_direction_allowed": false,
+        "futures_only": true
+      },
+      "fee_model_binding": {
+        "binding_id": "momentum_1h_v2_fee_model_bound",
+        "fee_bps": 10.0,
+        "fee_model_version": "backtest_fee_taker_symmetric_v0"
+      },
+      "slippage_model_binding": {
+        "binding_id": "momentum_1h_v2_slippage_model_bound",
+        "conservative_half_spread_bps": 5.0,
+        "roundtrip_cost_bps": 40.0,
+        "slippage_model_version": "backtest_slippage_conservative_half_spread_v0"
+      },
+      "funding_model_binding": {
+        "binding_id": "momentum_1h_v2_funding_model_bound",
+        "bind": true,
+        "model_version": "backtest_funding_perpetual_interval_v1"
+      },
+      "execution_model_binding": {
+        "binding_id": "momentum_1h_v2_execution_model_bound",
+        "execution_model_version": "backtest_execution_v0",
+        "offline_simulation_only": true
+      },
+      "economic_policy_binding": {
+        "binding_id": "momentum_1h_v2_economic_policy_bound",
+        "policy_version": "economic_validity_policy_v1",
+        "threshold_lowering_allowed": false
+      },
+      "implementation_digest_source": "src/strategies/momentum.py",
+      "config_digest_source": "config/config.toml:[strategy.momentum_1h]",
+      "data_digest_source": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/extended_chronological_v1/panel/panel_dataset_manifest.json",
+      "excluded_failed_v1_binding": "momentum_1h/v1",
+      "evaluation_authorized": false,
+      "retry_authorized": false,
+      "promotion_admissible": false,
+      "runtime_rewire_admissible": false,
+      "binding_status": "MATERIALIZED_NOT_EVALUATED"
+    }
+  ],
+  "walk_forward_execution_authorized": false
+}

--- a/docs/governance/POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0.md
+++ b/docs/governance/POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0.md
@@ -1,0 +1,107 @@
+# Post-PR4921 Versioned Research Bindings (No Eval) v0
+
+---
+docs_token: DOCS_TOKEN_POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0
+STATUS: BINDINGS_MATERIALIZED_NOT_EVALUATED
+scope: research, offline-only, non-authorizing
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+SCHEDULER_RUNTIME_ALLOWED: false
+---
+
+> **Non-authorizing:** Materialisiert ausschließlich versionierte Research-Bindings nach PR4921 Scope-Definition (PR4920 Failure-Decomposition Follow-up). Keine Offline-Economic-Evaluation, kein Backtest/WF/MC/Stress, kein v1 Same-Binding-Retry, keine Runtime-Authority. Binding-Materialisierung ≠ Evaluation-Autorisierung.
+
+## A. Verdict
+
+| Feld | Wert |
+|---|---|
+| `VERDICT` | `BINDINGS_MATERIALIZED_NOT_EVALUATED` |
+| `PROCESS_CLASSIFICATION` | `POST_PR4921_VERSIONED_RESEARCH_BINDINGS_MATERIALIZATION_NO_EVAL_V0` |
+| `SCOPE_CLASSIFICATION` | `BINDING_MATERIALIZATION_ONLY_NO_EVAL_NO_RUNTIME_AUTHORITY_V0` |
+| `GO_TOKEN` | `GO_MATERIALIZE_POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0` |
+| `GO_TOKEN_CONSUMPTION` | `CONSUMED_ONCE_FOR_BINDING_MATERIALIZATION_ONLY` |
+| `BASE_HEAD` | `dc6229ed32a57af4b9f3cd1f3d969cf499b6ebc5` |
+| `PARENT_PR` | `4921` |
+| `PARENT_SCOPE_ID` | `POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0` |
+| `PARENT_CLOSEOUT_DIR` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/post_pr4920_new_versioned_research_scope_definition_merge_closeout_20260706T081927Z` |
+| `PARENT_CLOSEOUT_MANIFEST_VERIFY_RC` | `0` |
+| `BINDING_MATERIALIZATION_ONLY` | `true` |
+| `BINDING_MATERIALIZATION_STATUS` | `BINDINGS_MATERIALIZED_NOT_EVALUATED` |
+| `FAILED_V1_BINDINGS_EXCLUDED` | `true` |
+| `EXCLUDED_FAILED_V1_BINDINGS` | `trend_following&#47;v1,bollinger_bands&#47;v1,momentum_1h&#47;v1` |
+| `STRATEGY_VERSION_MATERIALIZED` | `v2` |
+| `EVALUATION_AUTHORIZED` | `false` |
+| `ECONOMIC_EVALUATION_AUTHORIZED` | `false` |
+| `BACKTEST_EXECUTION_AUTHORIZED` | `false` |
+| `WALK_FORWARD_EXECUTION_AUTHORIZED` | `false` |
+| `MONTE_CARLO_EXECUTION_AUTHORIZED` | `false` |
+| `STRESS_EXECUTION_AUTHORIZED` | `false` |
+| `PARAMETER_OPTIMIZATION_AUTHORIZED` | `false` |
+| `THRESHOLD_LOWERING_AUTHORIZED` | `false` |
+| `RETRY_AUTHORIZED` | `false` |
+| `PROMOTION_ADMISSIBLE` | `false` |
+| `RUNTIME_REWIRE_ADMISSIBLE` | `false` |
+| `RUNTIME_AUTHORITY` | `NONE` |
+| `ORDERS_ALLOWED` | `false` |
+| `LIVE_AUTHORIZED` | `false` |
+| `SHADOW_AUTHORIZED` | `false` |
+| `PAPER_AUTHORIZED` | `false` |
+| `TESTNET_AUTHORIZED` | `false` |
+| `NEXT_STEP` | `SEPARATE_OPERATOR_GO_REQUIRED_FOR_OFFLINE_ECONOMIC_EVALUATION_EXECUTION` |
+| `runtime_effect` | `NONE` |
+| `authority_effect` | `NONE` |
+| `trading_effect` | `NONE` |
+
+**Authoritative owners (reuse, nicht ersetzen):**
+
+- Binding config: `config/research/post_pr4921_versioned_research_bindings_no_eval_v0.json`
+- Parent scope config: `config/research/post_pr4920_new_versioned_research_scope_definition_v0.json`
+- Parent scope doc: `docs/governance/POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0.md`
+- Collector: `scripts/research/post_pr4921_versioned_research_bindings_no_eval_v0.py`
+
+## B. Materialized Versioned Bindings
+
+| Kandidat | Version | Archetype | Ersetzt | Status |
+|---|---|---|---|---|
+| `trend_following` | `v2` | `TREND_CONTINUATION_V2` | `trend_following&#47;v1` | `MATERIALIZED_NOT_EVALUATED` |
+| `bollinger_bands` | `v2` | `MEAN_REVERSION_BANDS_V2` | `bollinger_bands&#47;v1` | `MATERIALIZED_NOT_EVALUATED` |
+| `momentum_1h` | `v2` | `MOMENTUM_HORIZON_V2` | `momentum_1h&#47;v1` | `MATERIALIZED_NOT_EVALUATED` |
+
+Jede Binding enthält: `parameter_binding`, `dataset_binding`, `period_binding`, `instrument_binding`, `fee_model_binding`, `slippage_model_binding`, `funding_model_binding`, `execution_model_binding`, `economic_policy_binding`, `implementation_digest_source`, `config_digest_source`, `data_digest_source`, sowie explizite Exclusion-Beziehung zu failed v1 Bindings.
+
+## C. Shared Model Bindings (Fleet Parity)
+
+| Binding | Wert |
+|---|---|
+| `dataset_binding` | `pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1_extended_chronological_v1` |
+| `period_binding` | `panel_calendar_2024-05-01_to_2024-09-01_utc_pt1h` |
+| `instrument_binding` | `futures_only_okx_linear_usdt_non_bitcoin_panel_v1` |
+| `fee_model_binding` | `backtest_fee_taker_symmetric_v0_realistic_costs` |
+| `slippage_model_binding` | `backtest_slippage_conservative_half_spread_v0` |
+| `funding_model_binding` | `backtest_funding_perpetual_interval_v1` |
+| `execution_model_binding` | `backtest_execution_v0_offline_simulation_only` |
+| `economic_policy_binding` | `economic_validity_policy_v1_unchanged_no_threshold_lowering` |
+
+Fleet-weite Parität: identische Economic Policy und vergleichbare Kosten-, Execution-, Dataset- und Periodenbindungen über alle drei Kandidaten.
+
+## D. Authority Boundary
+
+Binding-Materialisierung ≠ Evaluation-Autorisierung. Keine Economic Evaluation. Kein v1 Same-Binding-Retry.
+
+| Pfad | Status |
+|---|---|
+| Binding materialization | `ALLOWED` (this scope only) |
+| Economic evaluation / Backtest | `BLOCKED` |
+| Walk-Forward / Monte-Carlo / Stress | `BLOCKED` |
+| v1 unmodified binding retry | `BLOCKED` |
+| Parameter optimization / Threshold lowering | `BLOCKED` |
+| Runtime / Shadow / Paper / Testnet / Live | `BLOCKED` |
+| Orders / Adapter / Credentials / Arming | `BLOCKED` |
+| `CREDENTIALS` | `FORBIDDEN` |
+| `ARMING` | `FORBIDDEN` |
+
+## E. Next Step
+
+`SEPARATE_OPERATOR_GO_REQUIRED_FOR_OFFLINE_ECONOMIC_EVALUATION_EXECUTION`
+
+Separater Operator GO erforderlich für offline Economic Evaluation Execution nach Binding-Materialisierung. Dieser Scope autorisiert weder Evaluation noch Runtime noch Promotion.

--- a/scripts/research/post_pr4921_versioned_research_bindings_no_eval_v0.py
+++ b/scripts/research/post_pr4921_versioned_research_bindings_no_eval_v0.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Materialize post-PR4921 versioned research bindings (no eval) v0.
+
+Offline-only binding materialization. No economic evaluation, no backtest,
+no walk-forward, Monte Carlo, stress, or runtime authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.primary_evidence_retention_v0 import (  # noqa: E402
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+
+CONFIRM_GO = "GO_MATERIALIZE_POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0"
+SCOPE_ID = "POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0"
+PROCESS_CLASSIFICATION = "POST_PR4921_VERSIONED_RESEARCH_BINDINGS_MATERIALIZATION_NO_EVAL_V0"
+SCOPE_CLASSIFICATION = "BINDING_MATERIALIZATION_ONLY_NO_EVAL_NO_RUNTIME_AUTHORITY_V0"
+VERDICT = "BINDINGS_MATERIALIZED_NOT_EVALUATED"
+NEXT_STEP = "SEPARATE_OPERATOR_GO_REQUIRED_FOR_OFFLINE_ECONOMIC_EVALUATION_EXECUTION"
+DEFAULT_CONFIG = (
+    _REPO_ROOT / "config/research/post_pr4921_versioned_research_bindings_no_eval_v0.json"
+)
+DEFAULT_DOC = _REPO_ROOT / "docs/governance/POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0.md"
+DEFAULT_ARCHIVE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+OUTPUT_PREFIX = "post_pr4921_versioned_research_bindings_no_eval"
+PARENT_CLOSEOUT_SUFFIX = (
+    "post_pr4920_new_versioned_research_scope_definition_merge_closeout_20260706T081927Z"
+)
+
+REQUIRED_BINDING_FIELDS = (
+    "candidate_id",
+    "candidate_version",
+    "strategy_archetype",
+    "parameter_binding",
+    "dataset_binding",
+    "period_binding",
+    "instrument_binding",
+    "fee_model_binding",
+    "slippage_model_binding",
+    "funding_model_binding",
+    "execution_model_binding",
+    "economic_policy_binding",
+    "implementation_digest_source",
+    "config_digest_source",
+    "data_digest_source",
+    "excluded_failed_v1_binding",
+    "evaluation_authorized",
+    "retry_authorized",
+    "promotion_admissible",
+    "runtime_rewire_admissible",
+)
+
+REQUIRED_CONTRACT_FLAGS = (
+    ("binding_materialization_only", True),
+    ("economic_evaluation_authorized", False),
+    ("backtest_execution_authorized", False),
+    ("walk_forward_execution_authorized", False),
+    ("monte_carlo_execution_authorized", False),
+    ("stress_execution_authorized", False),
+    ("retry_authorized", False),
+    ("parameter_optimization_authorized", False),
+    ("threshold_lowering_authorized", False),
+    ("promotion_admissible", False),
+    ("runtime_rewire_admissible", False),
+    ("orders_allowed", False),
+    ("live_authorized", False),
+    ("failed_v1_bindings_excluded", True),
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _die(message: str, code: int = 2) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"not_object:{path}")
+    return payload
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _git_snapshot() -> dict[str, str]:
+    def _run(args: list[str]) -> str:
+        return subprocess.check_output(["git", *args], cwd=_REPO_ROOT, text=True).strip()
+
+    return {
+        "head": _run(["rev-parse", "HEAD"]),
+        "origin_main": _run(["rev-parse", "origin/main"]),
+        "branch": _run(["branch", "--show-current"]),
+        "status_short": _run(["status", "--short"]) or "(clean)",
+    }
+
+
+def validate_config(config: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    if config.get("scope_id") != SCOPE_ID:
+        errors.append("unexpected scope_id")
+    if config.get("go_token") != CONFIRM_GO:
+        errors.append("unexpected go_token")
+    if config.get("next_step") != NEXT_STEP:
+        errors.append("unexpected next_step")
+    if config.get("verdict") != VERDICT:
+        errors.append("unexpected verdict")
+
+    for field, expected in REQUIRED_CONTRACT_FLAGS:
+        if config.get(field) is not expected:
+            errors.append(f"contract flag mismatch: {field} expected {expected}")
+
+    bindings = config.get("versioned_bindings", [])
+    if not isinstance(bindings, list) or len(bindings) != 3:
+        errors.append("versioned_bindings must contain exactly 3 entries")
+
+    for binding in bindings:
+        for key in REQUIRED_BINDING_FIELDS:
+            if key not in binding:
+                errors.append(f"missing binding field {key} in {binding.get('candidate_id')}")
+        if binding.get("evaluation_authorized") is not False:
+            errors.append(f"evaluation_authorized must be false for {binding.get('candidate_id')}")
+
+    excluded = {b.get("excluded_failed_v1_binding") for b in bindings}
+    required_excluded = {"trend_following/v1", "bollinger_bands/v1", "momentum_1h/v1"}
+    if excluded != required_excluded:
+        errors.append("excluded_failed_v1_binding set mismatch")
+
+    return errors
+
+
+def _verify_source_manifest(source_dir: Path) -> tuple[int, str]:
+    if not source_dir.is_dir():
+        return -1, "missing"
+    ok, msg = verify_manifest_sha256(source_dir)
+    return (0 if ok else 1), msg or "ok"
+
+
+def _build_authority_boundary(config: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "backtest_execution_authorized": False,
+        "binding_materialization_only": True,
+        "economic_evaluation_authorized": False,
+        "failed_v1_bindings_excluded": True,
+        "live_authorized": False,
+        "monte_carlo_execution_authorized": False,
+        "next_step": NEXT_STEP,
+        "orders_allowed": False,
+        "parameter_optimization_authorized": False,
+        "promotion_admissible": False,
+        "retry_authorized": False,
+        "runtime_authority": "NONE",
+        "runtime_rewire_admissible": False,
+        "scheduler_runtime_allowed": False,
+        "shadow_authorized": False,
+        "stress_execution_authorized": False,
+        "testnet_authorized": False,
+        "threshold_lowering_authorized": False,
+        "walk_forward_execution_authorized": False,
+    }
+
+
+def _build_source_evidence_index(
+    config: dict[str, Any],
+    *,
+    parent_closeout_dir: Path,
+    parent_closeout_rc: int,
+    output_dir: Path,
+) -> dict[str, Any]:
+    return {
+        "git_snapshot": _git_snapshot(),
+        "parent_closeout_dir": str(parent_closeout_dir),
+        "parent_closeout_manifest_verify_rc": parent_closeout_rc,
+        "parent_scope_config": str(_REPO_ROOT / config["parent_scope_config"]),
+        "parent_scope_doc": str(_REPO_ROOT / config["parent_scope_doc"]),
+        "repo_binding_config": str(DEFAULT_CONFIG),
+        "repo_binding_doc": str(DEFAULT_DOC),
+        "source_evidence_refs": config.get("source_evidence_refs", []),
+        "versioned_binding_count": len(config.get("versioned_bindings", [])),
+        "durable_bundle_dir": str(output_dir),
+    }
+
+
+def run_post_pr4921_versioned_research_bindings_no_eval_v0(
+    *,
+    config_path: Path = DEFAULT_CONFIG,
+    archive_root: Path = DEFAULT_ARCHIVE_ROOT,
+    output_dir: Path | None = None,
+) -> dict[str, Any]:
+    if not config_path.is_file():
+        _die(f"ERR:missing config: {config_path}")
+
+    config = _load_json(config_path)
+    errors = validate_config(config)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        _die("ERR:config validation failed", code=1)
+
+    parent_closeout_dir = Path(config["parent_closeout_dir"])
+    parent_closeout_rc, parent_closeout_msg = _verify_source_manifest(parent_closeout_dir)
+    required_rc = int(config.get("parent_closeout_manifest_verify_rc", 0))
+    if parent_closeout_rc >= 0 and parent_closeout_rc != required_rc:
+        _die(f"ERR:parent closeout manifest verify rc mismatch: {parent_closeout_dir}")
+
+    if output_dir is None:
+        output_dir = archive_root / "implementation" / f"{OUTPUT_PREFIX}_{_utc_stamp()}"
+    output_dir = output_dir.resolve()
+    if output_dir.exists() and any(output_dir.iterdir()):
+        _die(f"ERR:output dir not empty: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    versioned_bindings = {
+        "binding_count": len(config["versioned_bindings"]),
+        "excluded_failed_v1_bindings": config["excluded_failed_v1_bindings"],
+        "shared_model_bindings": config["shared_model_bindings"],
+        "versioned_bindings": config["versioned_bindings"],
+    }
+    authority_boundary = _build_authority_boundary(config)
+    source_index = _build_source_evidence_index(
+        config,
+        parent_closeout_dir=parent_closeout_dir,
+        parent_closeout_rc=parent_closeout_rc,
+        output_dir=output_dir,
+    )
+
+    binding_summary_lines = [
+        "# Binding Summary",
+        "",
+        f"- scope_id: `{SCOPE_ID}`",
+        f"- verdict: `{VERDICT}`",
+        f"- process_classification: `{PROCESS_CLASSIFICATION}`",
+        f"- binding_materialization_only: `true`",
+        f"- failed_v1_bindings_excluded: `true`",
+        f"- next_step: `{NEXT_STEP}`",
+        "",
+        "## Versioned Bindings",
+        "",
+    ]
+    for binding in config["versioned_bindings"]:
+        binding_summary_lines.extend(
+            [
+                f"### `{binding['candidate_id']}` / `{binding['candidate_version']}`",
+                "",
+                f"- strategy_archetype: `{binding['strategy_archetype']}`",
+                f"- replaces_failed_binding: `{binding['replaces_failed_binding']}`",
+                f"- excluded_failed_v1_binding: `{binding['excluded_failed_v1_binding']}`",
+                f"- binding_status: `{binding['binding_status']}`",
+                f"- evaluation_authorized: `{binding['evaluation_authorized']}`",
+                "",
+            ]
+        )
+    (output_dir / "BINDING_SUMMARY.md").write_text(
+        "\n".join(binding_summary_lines) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "VERSIONED_BINDINGS.json").write_text(
+        json.dumps(versioned_bindings, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "AUTHORITY_BOUNDARY.json").write_text(
+        json.dumps(authority_boundary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "SOURCE_EVIDENCE_INDEX.json").write_text(
+        json.dumps(source_index, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "parent_closeout_manifest_verify.log").write_text(
+        "\n".join(
+            [
+                f"PARENT_CLOSEOUT_DIR={parent_closeout_dir}",
+                f"MANIFEST_VERIFY_RC={parent_closeout_rc}",
+                f"MANIFEST_VERIFY_MSG={parent_closeout_msg}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    write_manifest_sha256(output_dir)
+    ok, msg = verify_manifest_sha256(output_dir)
+    manifest_rc = 0 if ok else 1
+    (output_dir / "MANIFEST.verify.txt").write_text(
+        f"MANIFEST_VERIFY_RC={manifest_rc}\nMANIFEST_VERIFY_MSG={msg or 'ok'}\n",
+        encoding="utf-8",
+    )
+    if manifest_rc != 0:
+        _die(f"ERR:manifest verify failed: {output_dir}")
+
+    return {
+        "durable_evidence_path": str(output_dir),
+        "manifest_verify_rc": manifest_rc,
+        "next_step": NEXT_STEP,
+        "process_classification": PROCESS_CLASSIFICATION,
+        "scope_classification": SCOPE_CLASSIFICATION,
+        "scope_id": SCOPE_ID,
+        "verdict": VERDICT,
+        "versioned_binding_count": len(config["versioned_bindings"]),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Materialize post-PR4921 versioned research bindings (no eval) v0"
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_ARCHIVE_ROOT)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    result = run_post_pr4921_versioned_research_bindings_no_eval_v0(
+        config_path=args.config,
+        archive_root=args.durable_evidence_root,
+        output_dir=args.out,
+    )
+    print(f"VERDICT={result['verdict']}")
+    print(f"SCOPE_ID={result['scope_id']}")
+    print(f"DURABLE_BUNDLE_DIR={result['durable_evidence_path']}")
+    print(f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}")
+    print(f"NEXT_STEP={result['next_step']}")
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ops/test_post_pr4921_versioned_research_bindings_no_eval_v0_contract.py
+++ b/tests/ops/test_post_pr4921_versioned_research_bindings_no_eval_v0_contract.py
@@ -1,0 +1,288 @@
+"""Contract tests for post-PR4921 versioned research bindings no eval v0."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from scripts.ops.validate_docs_token_policy import DocsTokenPolicyValidator
+from scripts.research.post_pr4921_versioned_research_bindings_no_eval_v0 import (
+    CONFIRM_GO,
+    NEXT_STEP,
+    PROCESS_CLASSIFICATION,
+    SCOPE_CLASSIFICATION,
+    SCOPE_ID,
+    VERDICT,
+    run_post_pr4921_versioned_research_bindings_no_eval_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BINDING_CONFIG = (
+    REPO_ROOT / "config/research/post_pr4921_versioned_research_bindings_no_eval_v0.json"
+)
+GOVERNANCE_DOC = REPO_ROOT / "docs/governance/POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0.md"
+BINDING_SCRIPT = (
+    REPO_ROOT / "scripts/research/post_pr4921_versioned_research_bindings_no_eval_v0.py"
+)
+PARENT_SCOPE_CONFIG = (
+    REPO_ROOT / "config/research/post_pr4920_new_versioned_research_scope_definition_v0.json"
+)
+BASE_HEAD = "dc6229ed32a57af4b9f3cd1f3d969cf499b6ebc5"
+PARENT_CLOSEOUT_SUFFIX = (
+    "post_pr4920_new_versioned_research_scope_definition_merge_closeout_20260706T081927Z"
+)
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+PARENT_CLOSEOUT_DIR = ARCHIVE_ROOT / "implementation" / PARENT_CLOSEOUT_SUFFIX
+EXCLUDED_V1 = ("trend_following/v1", "bollinger_bands/v1", "momentum_1h/v1")
+FLEET_CANDIDATES = ("trend_following", "bollinger_bands", "momentum_1h")
+ARCHETYPES = (
+    "TREND_CONTINUATION_V2",
+    "MEAN_REVERSION_BANDS_V2",
+    "MOMENTUM_HORIZON_V2",
+)
+PROVENANCE_FIELDS = (
+    "parameter_binding",
+    "dataset_binding",
+    "period_binding",
+    "instrument_binding",
+    "fee_model_binding",
+    "slippage_model_binding",
+    "funding_model_binding",
+    "execution_model_binding",
+    "economic_policy_binding",
+    "implementation_digest_source",
+    "config_digest_source",
+    "data_digest_source",
+)
+REQUIRED_CONTRACT_ASSERTIONS = (
+    ("binding_materialization_only", True),
+    ("economic_evaluation_authorized", False),
+    ("backtest_execution_authorized", False),
+    ("walk_forward_execution_authorized", False),
+    ("monte_carlo_execution_authorized", False),
+    ("stress_execution_authorized", False),
+    ("retry_authorized", False),
+    ("parameter_optimization_authorized", False),
+    ("threshold_lowering_authorized", False),
+    ("promotion_admissible", False),
+    ("runtime_rewire_admissible", False),
+    ("orders_allowed", False),
+    ("live_authorized", False),
+    ("failed_v1_bindings_excluded", True),
+)
+REQUIRED_BUNDLE_ARTIFACTS = (
+    "BINDING_SUMMARY.md",
+    "VERSIONED_BINDINGS.json",
+    "AUTHORITY_BOUNDARY.json",
+    "SOURCE_EVIDENCE_INDEX.json",
+    "MANIFEST.sha256",
+    "MANIFEST.verify.txt",
+)
+FORBIDDEN_RUNTIME_ACTIONS = (
+    "RUNTIME",
+    "SHADOW",
+    "PAPER",
+    "TESTNET",
+    "SCHEDULER",
+    "ORDERS",
+    "CREDENTIALS",
+    "ARMING",
+    "LIVE",
+)
+BOUNDARY_PHRASES = (
+    "Binding-Materialisierung ≠ Evaluation-Autorisierung",
+    "FAILED_V1_BINDINGS_EXCLUDED",
+    "Keine Offline-Economic-Evaluation",
+    "SEPARATE_OPERATOR_GO_REQUIRED_FOR_OFFLINE_ECONOMIC_EVALUATION_EXECUTION",
+    "MATERIALIZED_NOT_EVALUATED",
+)
+
+
+def _docs_token_marker(token_name: str) -> str:
+    return "docs_" + "token: " + token_name
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(rf"\| `{re.escape(field)}` \| `([^`]*)` \|", text)
+    assert match, f"missing governance field: {field}"
+    return match.group(1)
+
+
+class TestPostPr4921VersionedResearchBindingsNoEvalV0Contract:
+    def test_binding_config_exists_and_parses(self) -> None:
+        assert BINDING_CONFIG.is_file()
+        config = json.loads(BINDING_CONFIG.read_text(encoding="utf-8"))
+        assert config["schema_version"] == "post_pr4921_versioned_research_bindings_no_eval.v0"
+
+    def test_required_contract_assertions(self) -> None:
+        config = json.loads(BINDING_CONFIG.read_text(encoding="utf-8"))
+        for field, expected in REQUIRED_CONTRACT_ASSERTIONS:
+            assert config[field] is expected, f"contract assertion failed: {field}"
+        assert config["next_step"] == NEXT_STEP
+
+    def test_binding_config_core_fields(self) -> None:
+        config = json.loads(BINDING_CONFIG.read_text(encoding="utf-8"))
+        assert config["verdict"] == VERDICT
+        assert config["scope_id"] == SCOPE_ID
+        assert config["process_classification"] == PROCESS_CLASSIFICATION
+        assert config["scope_classification"] == SCOPE_CLASSIFICATION
+        assert config["go_token"] == CONFIRM_GO
+        assert config["base_head"] == BASE_HEAD
+        assert config["baseline_pr"] == 4921
+        assert config["parent_scope_id"] == "POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0"
+
+    def test_versioned_bindings_structure(self) -> None:
+        config = json.loads(BINDING_CONFIG.read_text(encoding="utf-8"))
+        bindings = config["versioned_bindings"]
+        assert len(bindings) == 3
+        by_id = {b["candidate_id"]: b for b in bindings}
+        for sid in FLEET_CANDIDATES:
+            assert sid in by_id
+        archetypes = [b["strategy_archetype"] for b in bindings]
+        assert archetypes == list(ARCHETYPES)
+        for binding in bindings:
+            assert binding["candidate_version"] == "v2"
+            assert binding["binding_status"] == "MATERIALIZED_NOT_EVALUATED"
+            for field in PROVENANCE_FIELDS:
+                assert field in binding, f"missing {field} in {binding['candidate_id']}"
+            assert binding["evaluation_authorized"] is False
+            assert binding["retry_authorized"] is False
+            assert binding["promotion_admissible"] is False
+            assert binding["runtime_rewire_admissible"] is False
+
+    def test_failed_v1_bindings_excluded(self) -> None:
+        config = json.loads(BINDING_CONFIG.read_text(encoding="utf-8"))
+        assert set(config["excluded_failed_v1_bindings"]) == set(EXCLUDED_V1)
+        for binding in config["versioned_bindings"]:
+            assert binding["excluded_failed_v1_binding"] in EXCLUDED_V1
+            assert binding["replaces_failed_binding"] == binding["excluded_failed_v1_binding"]
+
+    def test_blocked_execution_classes(self) -> None:
+        config = json.loads(BINDING_CONFIG.read_text(encoding="utf-8"))
+        blocked = set(config["blocked_execution_classes"])
+        for action in (
+            "BACKTEST",
+            "WALK_FORWARD",
+            "MONTE_CARLO",
+            "STRESS",
+            "ECONOMIC_EVALUATION",
+            "PROMOTION",
+            "LIVE",
+        ):
+            assert action in blocked
+
+    def test_parent_closeout_ref_present(self) -> None:
+        config = json.loads(BINDING_CONFIG.read_text(encoding="utf-8"))
+        assert PARENT_CLOSEOUT_SUFFIX in config["parent_closeout_dir"]
+        assert config["parent_closeout_manifest_verify_rc"] == 0
+
+    def test_governance_doc_exists_with_docs_token(self) -> None:
+        assert GOVERNANCE_DOC.is_file()
+        body = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        assert (
+            _docs_token_marker("DOCS_TOKEN_POST_PR4921_VERSIONED_RESEARCH_BINDINGS_NO_EVAL_V0")
+            in body
+        )
+        assert "`BINDING_MATERIALIZATION_ONLY` | `true`" in body
+        assert "`FAILED_V1_BINDINGS_EXCLUDED` | `true`" in body
+        assert "`ECONOMIC_EVALUATION_AUTHORIZED` | `false`" in body
+        assert "`RETRY_AUTHORIZED` | `false`" in body
+        assert "`ORDERS_ALLOWED` | `false`" in body
+        assert "`LIVE_AUTHORIZED` | `false`" in body
+
+    def test_governance_doc_boundary_phrases(self) -> None:
+        body = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        for phrase in BOUNDARY_PHRASES:
+            assert phrase in body
+
+    def test_governance_doc_forbidden_runtime_actions(self) -> None:
+        body = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        for action in FORBIDDEN_RUNTIME_ACTIONS:
+            assert action in body
+
+    def test_governance_doc_next_step(self) -> None:
+        body = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        assert _field_value(body, "NEXT_STEP") == NEXT_STEP
+
+    def test_implementation_digest_sources_exist(self) -> None:
+        config = json.loads(BINDING_CONFIG.read_text(encoding="utf-8"))
+        for binding in config["versioned_bindings"]:
+            impl_path = REPO_ROOT / binding["implementation_digest_source"]
+            assert impl_path.is_file(), binding["implementation_digest_source"]
+
+    def test_script_has_no_forbidden_imports(self) -> None:
+        body = BINDING_SCRIPT.read_text(encoding="utf-8")
+        forbidden_import_re = re.compile(
+            r"^\s*(from|import)\s+"
+            r"src\.(execution|live|scheduler|adapters|broker|exchange|order|shadow|paper|testnet|credentials)"
+        )
+        for line in body.splitlines():
+            assert not forbidden_import_re.match(line), line
+
+    def test_docs_token_policy_passes_for_governance_doc(self) -> None:
+        validator = DocsTokenPolicyValidator(REPO_ROOT)
+        result = validator.scan_file(GOVERNANCE_DOC)
+        assert result.passed, [(v.line, v.token, v.message) for v in result.violations]
+
+    def test_docs_reference_targets_for_governance_doc(self) -> None:
+        body = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        for match in re.finditer(r"`((?:config|docs)/[^`]+)`", body):
+            target = REPO_ROOT / match.group(1)
+            assert target.is_file(), match.group(1)
+
+    @pytest.mark.parametrize("parent_path", [PARENT_CLOSEOUT_DIR])
+    def test_parent_closeout_manifest_verifies(self, parent_path: Path) -> None:
+        if not parent_path.is_dir():
+            pytest.skip(f"parent closeout unavailable: {parent_path}")
+        ok, _msg = verify_manifest_sha256(parent_path)
+        assert ok, f"parent manifest invalid: {parent_path}"
+
+    def test_runner_materializes_required_artifacts(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "bundle"
+        result = run_post_pr4921_versioned_research_bindings_no_eval_v0(output_dir=output_dir)
+        assert result["verdict"] == VERDICT
+        assert result["manifest_verify_rc"] == 0
+        for artifact_name in REQUIRED_BUNDLE_ARTIFACTS:
+            assert (output_dir / artifact_name).is_file(), artifact_name
+        ok, _msg = verify_manifest_sha256(output_dir)
+        assert ok
+
+        authority = json.loads((output_dir / "AUTHORITY_BOUNDARY.json").read_text(encoding="utf-8"))
+        assert authority["binding_materialization_only"] is True
+        assert authority["economic_evaluation_authorized"] is False
+        assert authority["failed_v1_bindings_excluded"] is True
+        assert authority["next_step"] == NEXT_STEP
+
+        bindings = json.loads((output_dir / "VERSIONED_BINDINGS.json").read_text(encoding="utf-8"))
+        assert bindings["binding_count"] == 3
+        assert set(bindings["excluded_failed_v1_bindings"]) == set(EXCLUDED_V1)
+
+    def test_cli_entrypoint(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "cli_bundle"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(BINDING_SCRIPT),
+                "--out",
+                str(output_dir),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert f"VERDICT={VERDICT}" in proc.stdout
+        assert (output_dir / "MANIFEST.sha256").is_file()
+
+    def test_parent_scope_config_referenced(self) -> None:
+        assert PARENT_SCOPE_CONFIG.is_file()
+        parent = json.loads(PARENT_SCOPE_CONFIG.read_text(encoding="utf-8"))
+        assert parent["scope_id"] == "POST_PR4920_NEW_VERSIONED_RESEARCH_SCOPE_DEFINITION_V0"
+        assert parent["failed_bindings_excluded"] is True


### PR DESCRIPTION
## Summary
- Materialize v2 versioned research bindings after PR4921 scope definition (PR4920 failure decomposition follow-up).
- Three fleet bindings: `trend_following/v2`, `bollinger_bands/v2`, `momentum_1h/v2` with full provenance fields.
- Excludes failed v1 bindings; binding materialization only, no evaluation authority.

## Boundaries
- Binding materialization only.
- No economic evaluation.
- No retry.
- No optimization.
- No promotion.
- No runtime/shadow/paper/testnet/live authority.
- Separate Operator GO required for offline economic evaluation execution.

## Test plan
- [x] `python3 -m pytest tests/ops/test_post_pr4921_versioned_research_bindings_no_eval_v0_contract.py -q`
- [x] `python3 scripts/research/post_pr4921_versioned_research_bindings_no_eval_v0.py`
- [x] Generated bundle `MANIFEST_VERIFY_RC=0`
- [x] `bash scripts/ops/preflight_docs_token_policy_changed.sh`
- [x] `bash scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`


Made with [Cursor](https://cursor.com)