### PR TITLE
fix(backtest): guard calmar ratio for negative equity

### DIFF
--- a/src/backtest/stats.py
+++ b/src/backtest/stats.py
@@ -21,6 +21,10 @@ class TradeRecordContractError(KeyError):
     """Raised when a trade dict lacks the canonical ``pnl`` field."""
 
 
+# Fail-closed finite sentinel when annualization base is non-positive (e.g. total_return <= -1.0).
+_CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL = -1.0e9
+
+
 @dataclass
 class TradeStats:
     """Trade-Statistiken."""
@@ -170,9 +174,19 @@ def compute_calmar_ratio(equity: pd.Series, periods_per_year: int = 252) -> floa
     if years <= 0:
         return 0.0
 
-    annual_return = (1 + total_return) ** (1 / years) - 1
+    annualization_base = 1.0 + total_return
+    if annualization_base <= 0.0:
+        return float(_CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL)
 
-    return float(annual_return / max_dd)
+    annual_return = annualization_base ** (1 / years) - 1
+    if not np.isfinite(annual_return):
+        return float(_CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL)
+
+    calmar = annual_return / max_dd
+    if not np.isfinite(calmar):
+        return float(_CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL)
+
+    return float(calmar)
 
 
 def compute_ulcer_index(equity: pd.Series) -> float:

--- a/tests/backtest/test_stats_calmar_negative_equity_v0.py
+++ b/tests/backtest/test_stats_calmar_negative_equity_v0.py
@@ -1,0 +1,80 @@
+"""Regression tests for compute_calmar_ratio catastrophic negative-equity guard.
+
+Covers the dual-leg spread v1 offline re-evaluation blocker where total_return <= -1.0
+produced a complex annual_return and raised TypeError during stats materialization.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+
+from src.backtest.stats import (
+    _CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL,
+    compute_backtest_stats,
+    compute_calmar_ratio,
+)
+
+
+def test_compute_calmar_ratio_dual_leg_spread_reeval_blocked_negative_equity_returns_finite_float():
+    """Blocked re-eval class: negative ending equity must not raise and must stay finite."""
+    # Mirrors blocked eval: 10000 -> -1468 (~-114.7% total return) with drawdown.
+    equity = pd.Series(
+        [10000.0, 9500.0, 8000.0, 5000.0, 1000.0, -500.0, -1468.17],
+        index=pd.date_range("2024-05-01", periods=7, freq="h", tz="UTC"),
+    )
+
+    calmar = compute_calmar_ratio(equity, periods_per_year=8760)
+
+    assert isinstance(calmar, float)
+    assert math.isfinite(calmar)
+    assert calmar <= 0.0
+    assert calmar == _CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL
+
+
+def test_compute_calmar_ratio_total_return_exactly_minus_one_returns_finite_negative_sentinel():
+    equity = pd.Series(
+        [100.0, 0.0, -10.0], index=pd.date_range("2024-05-01", periods=3, freq="h", tz="UTC")
+    )
+
+    calmar = compute_calmar_ratio(equity, periods_per_year=8760)
+
+    assert math.isfinite(calmar)
+    assert calmar == _CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL
+
+
+def test_compute_calmar_ratio_positive_return_unchanged():
+    equity = pd.Series([100.0, 110.0, 105.0, 120.0])
+
+    calmar = compute_calmar_ratio(equity, periods_per_year=252)
+
+    assert calmar == pytest.approx(98547872.25414029, rel=1e-9)
+
+
+def test_compute_calmar_ratio_zero_drawdown_returns_zero():
+    equity = pd.Series([100.0, 101.0, 102.0, 103.0])
+
+    assert compute_calmar_ratio(equity, periods_per_year=252) == 0.0
+
+
+def test_compute_calmar_ratio_zero_years_returns_zero():
+    equity = pd.Series([100.0])
+
+    assert compute_calmar_ratio(equity, periods_per_year=252) == 0.0
+
+
+def test_compute_backtest_stats_negative_equity_no_type_error():
+    equity = pd.Series(
+        [10000.0, 5000.0, -1000.0, -1468.17],
+        index=pd.date_range("2024-05-01", periods=4, freq="h", tz="UTC"),
+    )
+    trades = [{"pnl": -500.0}, {"pnl": -300.0}]
+
+    stats = compute_backtest_stats(trades, equity, periods_per_year=8760)
+
+    assert "calmar" in stats
+    assert isinstance(stats["calmar"], float)
+    assert math.isfinite(stats["calmar"])
+    assert stats["calmar"] <= 0.0


### PR DESCRIPTION
## Summary
- Infrastructure-only fix in `compute_calmar_ratio` for catastrophic negative equity (`total_return <= -1.0`).
- Returns a deterministic finite negative sentinel (`-1.0e9`) instead of raising `TypeError` from complex annualization.
- Adds focused regression tests documenting the blocked dual-leg spread v1 re-evaluation failure class.

## Scope boundaries
- No economic evaluation executed in this PR.
- No strategy logic change.
- No parameter rescue or threshold relaxation.
- No promotion or runtime authority effects.

## Parent context
- Blocked evaluation evidence: `dual_leg_spread_v1_full_offline_economic_reevaluation_after_pr4928_20260706T143554Z`
- Parent wiring fix: PR #4928

## Tests run
- `tests/backtest/test_stats_calmar_negative_equity_v0.py` (6 tests)
- `tests/backtest/test_stats_ulcer_recovery.py` (8 tests)
- `tests/research/test_cross_sectional_dual_leg_spread_backtest_wiring_v1_short_direction_v0.py` (3 tests)
- `tests/research/test_cross_sectional_funding_rate_dual_leg_spread_v1_prometheus_and_materialization_reuse_contract_v0.py` (9 tests)
- `tests/research/test_cross_sectional_funding_rate_dual_leg_spread_v1_offline_economic_evaluation_execution_infrastructure_v0.py` (15 tests)

**Total: 41 passed**

## Test plan
- [x] New calmar negative-equity regression tests
- [x] Existing stats/backtest tests unchanged
- [x] PR4928 regression subset green
- [ ] Wait for CI checks

Made with [Cursor](https://cursor.com)