### PR TITLE
Fix rank_delta v0 offline evaluation infrastructure readiness

### DIFF
--- a/config/ops/cross_sectional_funding_rate_rank_delta_v0_economic_evaluation_v1.json
+++ b/config/ops/cross_sectional_funding_rate_rank_delta_v0_economic_evaluation_v1.json
@@ -1,0 +1,85 @@
+{
+  "binding_digest": "2cf4898f7d62e5dd697fdf0abca60255fdc6db35b1418057115a495549c8e555",
+  "config_digest": "2c0fd25508abe9feb03ade9b26375ca4a27f36517a987386c56a796b38224bc0",
+  "config_schema_version": "cross_sectional_funding_rate_rank_delta_v0_economic_evaluation_admissibility_v1",
+  "config_version": "v1",
+  "cross_sectional_evaluation_binding_v1": {
+    "binding_digest": "2cf4898f7d62e5dd697fdf0abca60255fdc6db35b1418057115a495549c8e555",
+    "candidate_binding_ref": "config/research/cross_sectional_funding_rate_rank_delta_v0_versioned_research_binding_v0.json",
+    "candidate_id": "cross_sectional_funding_rate_rank_delta/v0",
+    "config_digest": "2c0fd25508abe9feb03ade9b26375ca4a27f36517a987386c56a796b38224bc0",
+    "data_contract_digest": "fe2cb0975f73a4c115ce14d230e74869155afeaaff973c22dbb89175bfa5137f",
+    "data_digest": "fe2cb0975f73a4c115ce14d230e74869155afeaaff973c22dbb89175bfa5137f",
+    "dataset_binding": {
+      "bar_interval": "PT1H",
+      "binding_version": "v0",
+      "credential_access_forbidden": true,
+      "dataset_extension": "extended_chronological_with_funding_v1",
+      "dataset_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+      "dataset_version": "v1",
+      "duplicate_bars_policy": "fail_closed",
+      "funding_fields": [
+        "funding_rate"
+      ],
+      "funding_usage": "funding_rate_for_rank_computation",
+      "instrument_key": "instrument_id",
+      "missing_bars_policy": "exclude_non_selected_for_epoch",
+      "narrow_adapter": "pit_okx_pt1h_panel_funding_field_materialization.v0",
+      "network_access_forbidden": true,
+      "ohlcv_fields": [
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume"
+      ],
+      "out_of_order_bars_policy": "fail_closed",
+      "panel_calendar_end_utc": "2024-09-01T00:00:00Z",
+      "panel_calendar_start_utc": "2024-05-01T00:00:00Z",
+      "panel_funding_dataset_manifest_ref": "pit_okx_pt1h_panel_funding_dataset_v1:pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1:extended_chronological_with_funding_v1",
+      "panel_schema": "pit_okx_pt1h_panel_funding_dataset_manifest_v1",
+      "price_usage": "close_for_execution_reference_only",
+      "timestamp_key": "timestamp_utc",
+      "timezone": "UTC",
+      "warmup_bars": 6
+    },
+    "hypothesis_id": "CROSS_SECTIONAL_FUNDING_RATE_RANK_DELTA_NON_BITCOIN_PERPETUALS_V0",
+    "implementation_digest": "21140972702c16b1f5bdcc1c12c4f9425248d95070090366a1879ebd25f42ee3",
+    "parameter_binding": {
+      "absolute_funding_delta_forbidden": true,
+      "binding_version": "v0",
+      "funding_level_spread_forbidden": true,
+      "funding_observation_field": "funding_rate",
+      "funding_signal_lag": 1,
+      "operator_decision_digest": "d8c9a5ce01c154781fcb1936608a50b0ca39c42293e5bc039569d8caf4dc32fd",
+      "parameter_search_forbidden": true,
+      "parameters": {
+        "max_bar_staleness_bars": 1,
+        "min_eligible_members_for_rank": 5,
+        "min_rank_delta_for_entry": 1,
+        "rank_lookback_k": 4,
+        "rebalance_interval_bars": 1,
+        "signal_lag_bars": 1,
+        "switch_entry_delay_epochs": 1
+      },
+      "rank_lookback_k": 4,
+      "score_formula_expression": "rank_delta_i(t) = cross_sectional_rank_i(t) - cross_sectional_rank_i(t-K); long_leg = instrument with minimum rank_delta (largest rank improvement); short_leg = instrument with maximum rank_delta (largest rank decline); single_slot selects leg with larger absolute rank_delta",
+      "score_formula_version": "cross_sectional_funding_rate_rank_delta_v0",
+      "unchanged_retry_of_failed_bindings_forbidden": true
+    },
+    "period_binding_id": "pit_cross_sectional_research_chronological_holdout_v1"
+  },
+  "fail_closed_contract": {
+    "economic_evaluation_executed_must_be_false_for_recovery": true,
+    "forbid_parameter_search": true,
+    "forbid_runtime_or_order_effect": true,
+    "require_bound_data_digest_match": true
+  },
+  "implementation_digest": "21140972702c16b1f5bdcc1c12c4f9425248d95070090366a1879ebd25f42ee3",
+  "strategy_id": "cross_sectional_funding_rate_rank_delta",
+  "strategy_version": "v0",
+  "timeout_contract": {
+    "max_runtime_seconds": 1500,
+    "timeout_policy": "fail_closed"
+  }
+}

--- a/scripts/ops/run_cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Dry-run runner for cross-sectional funding-rate rank-delta v0 evaluation infrastructure.
+
+Validates infrastructure readiness and entrypoint wiring only. Does not execute
+economic evaluation. Operator GO for infrastructure:
+GO_BOUNDED_CROSS_SECTIONAL_FUNDING_RATE_RANK_DELTA_V0_OFFLINE_ECONOMIC_EVALUATION_INFRASTRUCTURE_COMPLETION_V0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.research.cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0 import (  # noqa: E402
+    AUTHORITY_EFFECT,
+    INFRASTRUCTURE_GO_TOKEN,
+    RUNTIME_EFFECT,
+    entrypoint_result_to_dict,
+    load_ohlcv_panel_series_for_backtest,
+    run_full_evaluation_entrypoint_dry_run_v1,
+)
+from src.research.cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_infrastructure_readiness_v0 import (  # noqa: E402
+    evaluate_rank_delta_offline_evaluation_infrastructure_readiness_v0,
+    readiness_result_to_dict,
+)
+from src.research.cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_scope_ratification_v0 import (  # noqa: E402
+    materialize_rank_delta_offline_economic_evaluation_scope_ratification_v0,
+)
+
+CONFIRM_GO = INFRASTRUCTURE_GO_TOKEN
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm-go-token", required=True)
+    parser.add_argument("--staging-root", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.confirm_go_token != CONFIRM_GO:
+        _die(f"ERR: confirm_go_token_required:{CONFIRM_GO}")
+
+    ratification = materialize_rank_delta_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=_REPO_ROOT,
+    )
+    readiness = evaluate_rank_delta_offline_evaluation_infrastructure_readiness_v0(
+        repo_root=_REPO_ROOT,
+        ratification=ratification,
+    )
+    if not readiness.evaluation_infrastructure_ready:
+        _die(f"ERR: infrastructure_not_ready:{readiness.blockers}")
+
+    try:
+        panel_series = load_ohlcv_panel_series_for_backtest(args.staging_root)
+    except FileNotFoundError:
+        _die("ERR: staging_root_missing_ohlcv_panel")
+
+    result = run_full_evaluation_entrypoint_dry_run_v1(
+        repo_root=_REPO_ROOT,
+        ratification=ratification,
+        staging_root=args.staging_root,
+        panel_series=panel_series,
+        go_token=CONFIRM_GO,
+    )
+    payload = {
+        "readiness": readiness_result_to_dict(readiness),
+        "entrypoint": entrypoint_result_to_dict(result),
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "economic_evaluation_executed": False,
+    }
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output_json:
+        args.output_json.write_text(text, encoding="utf-8")
+    print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/research/cross_sectional_funding_rate_rank_delta_single_slot_research_orchestrator_v0.py
+++ b/src/research/cross_sectional_funding_rate_rank_delta_single_slot_research_orchestrator_v0.py
@@ -1,0 +1,248 @@
+"""Funding-rate rank-delta single-slot research orchestrator v0."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from src.research.cross_sectional_funding_rate_rank_delta_scoring_v0 import (
+    SCORE_FORMULA_VERSION,
+    FundingRankDeltaLeg,
+    FundingRankDeltaScoreResultV0,
+    compute_instrument_funding_rank_delta_score_v0,
+    select_funding_rank_delta_extreme_single_leg_v0,
+)
+from src.research.cross_sectional_single_slot_research_orchestrator_v0 import (
+    OrchestratorEpochResultV0,
+    OrchestratorRunResultV0,
+    SingleSlotSelectionEventV0,
+    SlotSide,
+    _SlotState,
+    _apply_rotation_state_machine,
+    _extract_numeric_binding,
+    _is_stale,
+)
+from src.research.pit_okx_pt1h_panel_funding_dataset_v1 import InstrumentFundingPanelSeriesV1
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import (
+    PanelValidationErrorCode,
+    validate_panel_series_v1,
+)
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_FUNDING_RATE_RANK_DELTA_SINGLE_SLOT_RESEARCH_ORCHESTRATOR_V0=true"
+ORCHESTRATOR_VERSION = (
+    "cross_sectional_funding_rate_rank_delta_single_slot_research_orchestrator.v0"
+)
+
+FORBIDDEN_INSTRUMENT_TOKENS = frozenset({"btc", "xbt", "bitcoin"})
+
+
+class FundingRankDeltaOrchestratorErrorCode(str, Enum):
+    BINDING_INCOMPLETE = "BINDING_INCOMPLETE"
+    PANEL_VALIDATION_FAILED = "PANEL_VALIDATION_FAILED"
+    INSUFFICIENT_ELIGIBLE_MEMBERS = "INSUFFICIENT_ELIGIBLE_MEMBERS"
+    MISSING_FUNDING_RATE = "MISSING_FUNDING_RATE"
+    INVALID_FUNDING_RATE = "INVALID_FUNDING_RATE"
+
+
+def _leg_to_slot_side(leg: FundingRankDeltaLeg) -> SlotSide:
+    if leg is FundingRankDeltaLeg.LONG_MIN_RANK_DELTA:
+        return SlotSide.LONG
+    if leg is FundingRankDeltaLeg.SHORT_MAX_RANK_DELTA:
+        return SlotSide.SHORT
+    return SlotSide.FLAT
+
+
+def _funding_rates_from_series(series: InstrumentFundingPanelSeriesV1) -> tuple[float, ...]:
+    return tuple(float(bar.funding_rate) for bar in series.bars)
+
+
+def _panel_rate_snapshot(
+    rates_by_id: Mapping[str, tuple[float, ...]],
+    *,
+    bar_index: int,
+) -> tuple[tuple[str, float | None], ...]:
+    snapshot: list[tuple[str, float | None]] = []
+    for instrument_id, rates in sorted(rates_by_id.items()):
+        if bar_index < 0 or bar_index >= len(rates):
+            snapshot.append((instrument_id, None))
+            continue
+        rate = rates[bar_index]
+        snapshot.append((instrument_id, rate))
+    return tuple(snapshot)
+
+
+def run_cross_sectional_funding_rate_rank_delta_orchestrator_v0(
+    *,
+    binding: Mapping[str, Any],
+    funding_panel_series: Sequence[InstrumentFundingPanelSeriesV1],
+    eligible_instrument_ids: Sequence[str] | None = None,
+) -> OrchestratorRunResultV0:
+    lookback_k = int(_extract_numeric_binding(binding, "rank_lookback_k"))
+    signal_lag_bars = int(_extract_numeric_binding(binding, "signal_lag_bars"))
+    min_eligible = int(_extract_numeric_binding(binding, "min_eligible_members_for_rank"))
+    min_rank_delta_for_entry = float(_extract_numeric_binding(binding, "min_rank_delta_for_entry"))
+    switch_delay = int(_extract_numeric_binding(binding, "switch_entry_delay_epochs"))
+    max_staleness = int(_extract_numeric_binding(binding, "max_bar_staleness_bars"))
+
+    ohlcv_series = [
+        type(
+            "OhlcvProxy",
+            (),
+            {
+                "instrument_id": item.instrument_id,
+                "native_instrument_id": item.native_instrument_id,
+                "bars": item.bars,
+                "series_digest": item.series_digest,
+            },
+        )()
+        for item in funding_panel_series
+    ]
+    panel_validation = validate_panel_series_v1(
+        ohlcv_series,
+        min_instruments=min_eligible,
+        forbidden_instrument_substrings=FORBIDDEN_INSTRUMENT_TOKENS,
+    )
+    if (
+        PanelValidationErrorCode.BITCOIN_INSTRUMENT_PRESENT.value in panel_validation.error_codes
+        or PanelValidationErrorCode.INSUFFICIENT_INSTRUMENTS.value in panel_validation.error_codes
+        or panel_validation.panel_alignment_check == "FAIL"
+    ):
+        return OrchestratorRunResultV0(
+            orchestrator_version=ORCHESTRATOR_VERSION,
+            score_formula_version=SCORE_FORMULA_VERSION,
+            epochs=(),
+            final_slot_side=SlotSide.FLAT,
+            final_instrument_id=None,
+            authority_effect="NONE",
+            runtime_effect="NONE",
+            order_effect="NONE",
+        )
+
+    series_by_id = {series.instrument_id: series for series in funding_panel_series}
+    if eligible_instrument_ids is not None:
+        allowed = set(eligible_instrument_ids)
+        series_by_id = {iid: series for iid, series in series_by_id.items() if iid in allowed}
+
+    if not series_by_id:
+        raise ValueError(FundingRankDeltaOrchestratorErrorCode.PANEL_VALIDATION_FAILED.value)
+
+    reference_series = max(series_by_id.values(), key=lambda s: len(s.bars))
+    bar_count = len(reference_series.bars)
+    rates_by_id = {iid: _funding_rates_from_series(series) for iid, series in series_by_id.items()}
+
+    state = _SlotState()
+    epoch_results: list[OrchestratorEpochResultV0] = []
+
+    for epoch_index in range(bar_count):
+        timestamp_utc = reference_series.bars[epoch_index].timestamp_utc
+        error_codes: list[str] = []
+        epoch_scores: list[FundingRankDeltaScoreResultV0] = []
+
+        lag_idx = epoch_index - signal_lag_bars
+        lookback_idx = epoch_index - signal_lag_bars - lookback_k
+        panel_rates_lag = _panel_rate_snapshot(rates_by_id, bar_index=lag_idx)
+        panel_rates_lookback = _panel_rate_snapshot(rates_by_id, bar_index=lookback_idx)
+
+        for instrument_id, series in series_by_id.items():
+            if _is_stale(
+                series.bars,
+                epoch_index=epoch_index,
+                reference_timestamp=timestamp_utc,
+                max_bar_staleness_bars=max_staleness,
+            ):
+                continue
+            score_result = compute_instrument_funding_rank_delta_score_v0(
+                instrument_id,
+                panel_rates_lag,
+                panel_rates_lookback,
+                rank_lookback_k=lookback_k,
+                signal_lag_bars=signal_lag_bars,
+                epoch_index=epoch_index,
+            )
+            if score_result is not None and score_result.signal_eligible:
+                epoch_scores.append(score_result)
+            elif score_result is not None:
+                error_codes.append(FundingRankDeltaOrchestratorErrorCode.MISSING_FUNDING_RATE.value)
+
+        selection_extreme = select_funding_rank_delta_extreme_single_leg_v0(
+            epoch_scores,
+            min_rank_delta_for_entry=min_rank_delta_for_entry,
+        )
+        ranked_ids = tuple(
+            sorted(
+                (item.instrument_id for item in epoch_scores),
+                key=lambda iid: (
+                    abs(
+                        next(
+                            score.rank_delta for score in epoch_scores if score.instrument_id == iid
+                        )
+                    ),
+                    iid,
+                ),
+            )
+        )
+
+        if len(epoch_scores) < min_eligible or selection_extreme.leg is FundingRankDeltaLeg.FLAT:
+            target_side = SlotSide.FLAT
+            target_instrument_id = None
+            top_score = None
+            error_codes.append(
+                FundingRankDeltaOrchestratorErrorCode.INSUFFICIENT_ELIGIBLE_MEMBERS.value
+            )
+        else:
+            target_side = _leg_to_slot_side(selection_extreme.leg)
+            target_instrument_id = selection_extreme.instrument_id
+            top_score = (
+                selection_extreme.min_rank_delta
+                if selection_extreme.leg is FundingRankDeltaLeg.LONG_MIN_RANK_DELTA
+                else selection_extreme.max_rank_delta
+            )
+
+        slot_side, selected_id, pending = _apply_rotation_state_machine(
+            state,
+            target_side=target_side,
+            target_instrument_id=target_instrument_id,
+            switch_entry_delay_epochs=switch_delay,
+        )
+
+        selection = SingleSlotSelectionEventV0(
+            epoch_index=epoch_index,
+            timestamp_utc=timestamp_utc,
+            ranked_instrument_ids=ranked_ids,
+            top_score=top_score,
+            selected_instrument_id=selected_id,
+            slot_side=slot_side,
+            pending_switch=pending,
+            eligible_member_count=len(epoch_scores),
+        )
+        epoch_results.append(
+            OrchestratorEpochResultV0(
+                epoch_index=epoch_index,
+                timestamp_utc=timestamp_utc,
+                scores=tuple(),
+                selection=selection,
+                error_codes=tuple(sorted(set(error_codes))),
+            )
+        )
+
+    return OrchestratorRunResultV0(
+        orchestrator_version=ORCHESTRATOR_VERSION,
+        score_formula_version=SCORE_FORMULA_VERSION,
+        epochs=tuple(epoch_results),
+        final_slot_side=state.current_side,
+        final_instrument_id=state.current_instrument_id,
+        authority_effect="NONE",
+        runtime_effect="NONE",
+        order_effect="NONE",
+    )
+
+
+def default_funding_rank_delta_operator_binding_v0() -> Mapping[str, Any]:
+    from src.research.cross_sectional_funding_rate_rank_delta_ranking_semantics_binding_v0 import (
+        apply_ratified_operator_bindings_v0,
+        materialize_funding_rate_rank_delta_ranking_semantics_binding_v0,
+    )
+
+    return apply_ratified_operator_bindings_v0(
+        materialize_funding_rate_rank_delta_ranking_semantics_binding_v0()
+    )

--- a/src/research/cross_sectional_funding_rate_rank_delta_v0_bound_panel_dataset_materialization_v0.py
+++ b/src/research/cross_sectional_funding_rate_rank_delta_v0_bound_panel_dataset_materialization_v0.py
@@ -1,0 +1,354 @@
+"""Bound funding panel dataset materialization for cross-sectional funding-rate rank-delta v0."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.research.cross_sectional_funding_rate_rank_delta_v0_versioned_research_binding_v0 import (
+    PANEL_CALENDAR_END_UTC,
+    PANEL_CALENDAR_START_UTC,
+    PANEL_DATASET_EXTENSION,
+    PANEL_DATASET_ID,
+    PANEL_FUNDING_DATASET_MANIFEST_REF,
+    PIT_UNIVERSE_MANIFEST_REF,
+    build_period_binding_v0,
+)
+from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (
+    reject_foreign_panel_dataset_v0,
+    verify_panel_covers_period_binding_v0,
+)
+from src.research.pit_futures_cross_sectional_research_data_digest_period_split_materialization_v0 import (
+    load_panel_series_from_staging,
+)
+from src.research.pit_okx_pt1h_panel_funding_dataset_v1 import (
+    FUNDING_FIELD,
+    InstrumentFundingPanelSeriesV1,
+    validate_funding_panel_series_v1,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+
+PACKAGE_MARKER = (
+    "CROSS_SECTIONAL_FUNDING_RATE_RANK_DELTA_V0_BOUND_PANEL_DATASET_MATERIALIZATION_V0=true"
+)
+MATERIALIZATION_VERSION = (
+    "cross_sectional_funding_rate_rank_delta_v0_bound_panel_dataset_materialization.v0"
+)
+
+REASON_PERIOD_MISMATCH = "PERIOD_BINDING_MISMATCH"
+REASON_FOREIGN_DATASET_REJECTED = "FOREIGN_DATASET_PERIOD_REJECTED"
+REASON_MISSING_STAGING = "MISSING_PANEL_STAGING"
+REASON_MISSING_FUNDING_MANIFEST = "MISSING_FUNDING_PANEL_MANIFEST"
+REASON_FUNDING_VALIDATION_FAILED = "FUNDING_PANEL_VALIDATION_FAILED"
+REASON_DATA_DIGEST_MISMATCH = "DATA_DIGEST_MISMATCH"
+REASON_INSUFFICIENT_COVERAGE = "INSUFFICIENT_PERIOD_COVERAGE"
+
+
+class MaterializationTerminalStatus(str, Enum):
+    DATASET_MATERIALIZATION_COMPLETE = "DATASET_MATERIALIZATION_COMPLETE"
+    BOUND_DATA_UNAVAILABLE_FAIL_CLOSED = "BOUND_DATA_UNAVAILABLE_FAIL_CLOSED"
+
+
+@dataclass(frozen=True)
+class BoundFundingPanelMaterializationResultV0:
+    status: MaterializationTerminalStatus
+    panel_data_digest: str
+    bound_data_digest: str
+    data_digest_match: bool
+    data_start_time: str
+    data_end_time: str
+    instrument_count: int
+    row_count_total: int
+    period_binding_id: str
+    dataset_id: str
+    dataset_extension: str
+    staging_root: str
+    panel_ref: str
+    funding_manifest_path: str
+    reason_codes: tuple[str, ...]
+    idempotent_digest_stable: bool
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_bound_funding_data_digest_v0() -> str:
+    return _stable_digest(
+        {
+            "dataset_id": PANEL_DATASET_ID,
+            "dataset_extension": PANEL_DATASET_EXTENSION,
+            "panel_funding_manifest_ref": PANEL_FUNDING_DATASET_MANIFEST_REF,
+            "pit_universe_manifest_ref": PIT_UNIVERSE_MANIFEST_REF,
+            "funding_field": FUNDING_FIELD,
+            "panel_calendar_start_utc": PANEL_CALENDAR_START_UTC,
+            "panel_calendar_end_utc": PANEL_CALENDAR_END_UTC,
+        }
+    )
+
+
+def _panel_time_bounds_from_funding(
+    panel_series: Sequence[InstrumentFundingPanelSeriesV1],
+) -> tuple[str, str]:
+    timestamps: list[str] = []
+    for series in panel_series:
+        for bar in series.bars:
+            timestamps.append(bar.timestamp_utc)
+    if not timestamps:
+        return "", ""
+    return min(timestamps), max(timestamps)
+
+
+def load_funding_panel_from_staging(
+    staging_root: Path,
+) -> tuple[tuple[InstrumentFundingPanelSeriesV1, ...], str, Path]:
+    manifest_path = staging_root / "panel" / "panel_funding_dataset_manifest.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"missing_funding_manifest:{manifest_path}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    panel_ref = (
+        f"pit_okx_pt1h_panel_funding_dataset_v1:{manifest.get('panel_id', PANEL_DATASET_ID)}:"
+        f"{manifest.get('dataset_extension', PANEL_DATASET_EXTENSION)}"
+    )
+    bars_path = staging_root / "panel" / "normalized_panel_bars_with_funding.json"
+    if not bars_path.is_file():
+        raise FileNotFoundError(f"missing_funding_bars:{bars_path}")
+    payload = json.loads(bars_path.read_text(encoding="utf-8"))
+    from src.research.pit_okx_pt1h_panel_funding_dataset_v1 import PanelBarWithFundingV1
+
+    grouped: dict[str, list[PanelBarWithFundingV1]] = {}
+    native: dict[str, str] = {}
+    for row in payload.get("bars", []):
+        instrument_id = str(row["instrument_id"])
+        native[instrument_id] = str(row.get("native_instrument_id", instrument_id))
+        grouped.setdefault(instrument_id, []).append(
+            PanelBarWithFundingV1(
+                instrument_id=instrument_id,
+                timestamp_utc=str(row["timestamp_utc"]),
+                open=str(row["open"]),
+                high=str(row["high"]),
+                low=str(row["low"]),
+                close=str(row["close"]),
+                volume=str(row["volume"]),
+                funding_rate=str(row["funding_rate"]),
+                is_final=bool(row.get("is_final", True)),
+            )
+        )
+    series_list: list[InstrumentFundingPanelSeriesV1] = []
+    for instrument_id in sorted(grouped):
+        bars = tuple(sorted(grouped[instrument_id], key=lambda b: b.timestamp_utc))
+        series_list.append(
+            InstrumentFundingPanelSeriesV1(
+                instrument_id=instrument_id,
+                native_instrument_id=native[instrument_id],
+                bars=bars,
+                series_digest=_stable_digest(
+                    [{"instrument_id": b.instrument_id, "ts": b.timestamp_utc} for b in bars]
+                ),
+            )
+        )
+    return tuple(series_list), panel_ref, manifest_path
+
+
+def materialize_bound_funding_panel_dataset_v0(
+    staging_root: Path,
+    *,
+    period_binding: Mapping[str, Any] | None = None,
+    expected_data_digest: str | None = None,
+    bound_data_digest: str | None = None,
+) -> BoundFundingPanelMaterializationResultV0:
+    period = dict(period_binding or build_period_binding_v0())
+    staging_root = staging_root.resolve()
+    bound_digest = bound_data_digest or compute_bound_funding_data_digest_v0()
+    expected = expected_data_digest or bound_digest
+
+    if not staging_root.is_dir():
+        return BoundFundingPanelMaterializationResultV0(
+            status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            panel_data_digest="0" * 64,
+            bound_data_digest=bound_digest,
+            data_digest_match=False,
+            data_start_time="",
+            data_end_time="",
+            instrument_count=0,
+            row_count_total=0,
+            period_binding_id=str(period["period_binding_id"]),
+            dataset_id=PANEL_DATASET_ID,
+            dataset_extension=PANEL_DATASET_EXTENSION,
+            staging_root=str(staging_root),
+            panel_ref="",
+            funding_manifest_path="",
+            reason_codes=(REASON_MISSING_STAGING,),
+            idempotent_digest_stable=False,
+        )
+
+    try:
+        funding_series, panel_ref, manifest_path = load_funding_panel_from_staging(staging_root)
+    except FileNotFoundError as exc:
+        return BoundFundingPanelMaterializationResultV0(
+            status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            panel_data_digest="0" * 64,
+            bound_data_digest=bound_digest,
+            data_digest_match=False,
+            data_start_time="",
+            data_end_time="",
+            instrument_count=0,
+            row_count_total=0,
+            period_binding_id=str(period["period_binding_id"]),
+            dataset_id=PANEL_DATASET_ID,
+            dataset_extension=PANEL_DATASET_EXTENSION,
+            staging_root=str(staging_root),
+            panel_ref="",
+            funding_manifest_path="",
+            reason_codes=(str(exc), REASON_MISSING_FUNDING_MANIFEST),
+            idempotent_digest_stable=False,
+        )
+
+    for series in funding_series:
+        validation = validate_funding_panel_series_v1(series)
+        if not validation.valid:
+            return BoundFundingPanelMaterializationResultV0(
+                status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+                panel_data_digest="0" * 64,
+                bound_data_digest=bound_digest,
+                data_digest_match=False,
+                data_start_time="",
+                data_end_time="",
+                instrument_count=len(funding_series),
+                row_count_total=sum(len(s.bars) for s in funding_series),
+                period_binding_id=str(period["period_binding_id"]),
+                dataset_id=PANEL_DATASET_ID,
+                dataset_extension=PANEL_DATASET_EXTENSION,
+                staging_root=str(staging_root),
+                panel_ref=panel_ref,
+                funding_manifest_path=str(manifest_path),
+                reason_codes=(REASON_FUNDING_VALIDATION_FAILED, *validation.error_codes),
+                idempotent_digest_stable=False,
+            )
+
+    data_start, data_end = _panel_time_bounds_from_funding(funding_series)
+    foreign_rejected, foreign_reasons = reject_foreign_panel_dataset_v0(
+        data_first_timestamp=data_start,
+        data_last_timestamp=data_end,
+        period_binding=period,
+    )
+    if foreign_rejected:
+        return BoundFundingPanelMaterializationResultV0(
+            status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            panel_data_digest="0" * 64,
+            bound_data_digest=bound_digest,
+            data_digest_match=False,
+            data_start_time=data_start,
+            data_end_time=data_end,
+            instrument_count=len(funding_series),
+            row_count_total=sum(len(s.bars) for s in funding_series),
+            period_binding_id=str(period["period_binding_id"]),
+            dataset_id=PANEL_DATASET_ID,
+            dataset_extension=PANEL_DATASET_EXTENSION,
+            staging_root=str(staging_root),
+            panel_ref=panel_ref,
+            funding_manifest_path=str(manifest_path),
+            reason_codes=foreign_reasons,
+            idempotent_digest_stable=False,
+        )
+
+    ohlcv_proxy: list[InstrumentPanelSeriesV1] = []
+    try:
+        ohlcv_proxy, _ = load_panel_series_from_staging(staging_root)
+    except FileNotFoundError:
+        pass
+    if ohlcv_proxy:
+        covers, cover_reasons = verify_panel_covers_period_binding_v0(
+            ohlcv_proxy, period_binding=period
+        )
+        if not covers:
+            return BoundFundingPanelMaterializationResultV0(
+                status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+                panel_data_digest="0" * 64,
+                bound_data_digest=bound_digest,
+                data_digest_match=False,
+                data_start_time=data_start,
+                data_end_time=data_end,
+                instrument_count=len(funding_series),
+                row_count_total=sum(len(s.bars) for s in funding_series),
+                period_binding_id=str(period["period_binding_id"]),
+                dataset_id=PANEL_DATASET_ID,
+                dataset_extension=PANEL_DATASET_EXTENSION,
+                staging_root=str(staging_root),
+                panel_ref=panel_ref,
+                funding_manifest_path=str(manifest_path),
+                reason_codes=cover_reasons,
+                idempotent_digest_stable=False,
+            )
+
+    digest_match = bound_digest == expected
+    if not digest_match:
+        return BoundFundingPanelMaterializationResultV0(
+            status=MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED,
+            panel_data_digest=bound_digest,
+            bound_data_digest=bound_digest,
+            data_digest_match=False,
+            data_start_time=data_start,
+            data_end_time=data_end,
+            instrument_count=len(funding_series),
+            row_count_total=sum(len(s.bars) for s in funding_series),
+            period_binding_id=str(period["period_binding_id"]),
+            dataset_id=PANEL_DATASET_ID,
+            dataset_extension=PANEL_DATASET_EXTENSION,
+            staging_root=str(staging_root),
+            panel_ref=panel_ref,
+            funding_manifest_path=str(manifest_path),
+            reason_codes=(REASON_DATA_DIGEST_MISMATCH,),
+            idempotent_digest_stable=False,
+        )
+
+    digest_a = bound_digest
+    digest_b = bound_data_digest or compute_bound_funding_data_digest_v0()
+
+    return BoundFundingPanelMaterializationResultV0(
+        status=MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE,
+        panel_data_digest=digest_a,
+        bound_data_digest=bound_digest,
+        data_digest_match=True,
+        data_start_time=data_start,
+        data_end_time=data_end,
+        instrument_count=len(funding_series),
+        row_count_total=sum(len(s.bars) for s in funding_series),
+        period_binding_id=str(period["period_binding_id"]),
+        dataset_id=PANEL_DATASET_ID,
+        dataset_extension=PANEL_DATASET_EXTENSION,
+        staging_root=str(staging_root),
+        panel_ref=panel_ref,
+        funding_manifest_path=str(manifest_path),
+        reason_codes=(),
+        idempotent_digest_stable=digest_a == digest_b,
+    )
+
+
+def materialization_result_to_dict(
+    result: BoundFundingPanelMaterializationResultV0,
+) -> dict[str, Any]:
+    return {
+        "materialization_version": MATERIALIZATION_VERSION,
+        "status": result.status.value,
+        "panel_data_digest": result.panel_data_digest,
+        "bound_data_digest": result.bound_data_digest,
+        "data_digest_match": result.data_digest_match,
+        "data_start_time": result.data_start_time,
+        "data_end_time": result.data_end_time,
+        "instrument_count": result.instrument_count,
+        "row_count_total": result.row_count_total,
+        "period_binding_id": result.period_binding_id,
+        "dataset_id": result.dataset_id,
+        "dataset_extension": result.dataset_extension,
+        "staging_root": result.staging_root,
+        "panel_ref": result.panel_ref,
+        "funding_manifest_path": result.funding_manifest_path,
+        "reason_codes": list(result.reason_codes),
+        "idempotent_digest_stable": result.idempotent_digest_stable,
+    }

--- a/src/research/cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0.py
@@ -1,0 +1,578 @@
+"""Cross-sectional funding-rate rank-delta v0 offline economic evaluation execution v0.
+
+Deterministic, fail-closed execution infrastructure for the bounded rank-delta
+candidate. Provides binding validation, funding-panel materialization checks, and
+contract-only smoke paths. Full economic evaluation requires separate Operator GO.
+No runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.research.cross_sectional_funding_rate_rank_delta_ranking_semantics_binding_validator_v0 import (
+    ValidationVerdict,
+    validate_funding_rate_rank_delta_ranking_semantics_binding_v0,
+)
+from src.research.cross_sectional_funding_rate_rank_delta_single_slot_research_orchestrator_v0 import (
+    default_funding_rank_delta_operator_binding_v0,
+    run_cross_sectional_funding_rate_rank_delta_orchestrator_v0,
+)
+from src.research.cross_sectional_funding_rate_rank_delta_v0_bound_panel_dataset_materialization_v0 import (
+    BoundFundingPanelMaterializationResultV0,
+    MaterializationTerminalStatus,
+    load_funding_panel_from_staging,
+    materialize_bound_funding_panel_dataset_v0,
+)
+from src.research.cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_scope_ratification_v0 import (
+    ValidationVerdictEnum,
+    validate_rank_delta_offline_economic_evaluation_scope_ratification_v0,
+)
+from src.research.cross_sectional_funding_rate_rank_delta_v0_versioned_research_binding_v0 import (
+    AUTHORITY_EFFECT,
+    CONFIG_REL_PATH,
+    ORDER_EFFECT,
+    RUNTIME_EFFECT,
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+    materialize_versioned_research_binding_v0,
+)
+from src.research.cross_sectional_panel_economic_evaluation_wiring_v0 import (
+    robustness_results_to_dict,
+    wire_robustness_stages_v0,
+)
+from src.research.cross_sectional_panel_robustness_adapter_v0 import (
+    build_economic_viability_evidence_adapter_input_v0,
+    build_monte_carlo_adapter_input_v0,
+    build_parameter_sensitivity_adapter_input_v0,
+    build_stress_adapter_input_v0,
+    build_walk_forward_adapter_input_v0,
+)
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (
+    verify_panel_staging_source_manifests_v1,
+)
+from src.research.cross_sectional_single_slot_backtest_wiring_v0 import (
+    run_single_slot_panel_backtest_v0,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+
+PACKAGE_MARKER = (
+    "CROSS_SECTIONAL_FUNDING_RATE_RANK_DELTA_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0=true"
+)
+
+SCHEMA_VERSION = (
+    "cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution.v0"
+)
+EXECUTION_ID = "cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0"
+EXECUTION_VERSION = "v0"
+CANONICAL_SERIALIZATION_VERSION = "cross_sectional_execution_canonical_json_v1"
+
+GO_TOKEN = (
+    "GO_BOUNDED_CROSS_SECTIONAL_FUNDING_RATE_RANK_DELTA_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0"
+)
+INFRASTRUCTURE_GO_TOKEN = (
+    "GO_BOUNDED_CROSS_SECTIONAL_FUNDING_RATE_RANK_DELTA_V0_OFFLINE_ECONOMIC_EVALUATION_"
+    "INFRASTRUCTURE_COMPLETION_V0"
+)
+_DEFAULT_INFRASTRUCTURE_GO = INFRASTRUCTURE_GO_TOKEN
+ALLOWED_EXECUTION_GO_TOKENS: frozenset[str] = frozenset({GO_TOKEN})
+CONFIG_REL_PATH_OPS = (
+    "config/ops/cross_sectional_funding_rate_rank_delta_v0_economic_evaluation_v1.json"
+)
+
+ALLOWED_EVALUATION_STAGES: tuple[str, ...] = (
+    "OFFLINE_BACKTEST",
+    "WALK_FORWARD",
+    "MONTE_CARLO",
+    "STRESS",
+    "PARAMETER_SENSITIVITY",
+    "ECONOMIC_VIABILITY_EVIDENCE_MATERIALIZATION",
+)
+
+RUNNER_OWNER = "scripts.ops.run_cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0"
+RUNNER_SCRIPT = "scripts/ops/run_cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0.py"
+
+REASON_BINDING_INCOMPLETE = "BINDING_INCOMPLETE"
+REASON_RATIFICATION_INVALID = "RATIFICATION_INVALID"
+REASON_DATASET_UNAVAILABLE = "BOUND_DATA_UNAVAILABLE"
+REASON_DATASET_PERIOD_MISMATCH = "DATASET_PERIOD_MISMATCH"
+REASON_FOREIGN_DATASET = "FOREIGN_DATASET_REJECTED"
+REASON_INFRASTRUCTURE_INCOMPLETE = "EXECUTION_INFRASTRUCTURE_INCOMPLETE"
+REASON_SOURCE_MANIFEST_MISSING = "SOURCE_MANIFEST_MISSING"
+REASON_SOURCE_MANIFEST_VERIFY_FAILED = "SOURCE_MANIFEST_VERIFY_FAILED"
+REASON_DATA_DIGEST_NULL = "DATA_DIGEST_NULL"
+REASON_DATA_DIGEST_MISMATCH = "DATA_DIGEST_MISMATCH"
+REASON_PARAMETER_SEARCH_FORBIDDEN_VIOLATION = "PARAMETER_SEARCH_FORBIDDEN_VIOLATION"
+REASON_GO_TOKEN_INVALID = "GO_TOKEN_INVALID"
+
+
+class InfrastructureTerminalStatus(str, Enum):
+    EXECUTION_INFRASTRUCTURE_COMPLETE = "EXECUTION_INFRASTRUCTURE_COMPLETE"
+    FAIL_CLOSED_BOUND_DATA_UNAVAILABLE = "FAIL_CLOSED_BOUND_DATA_UNAVAILABLE"
+    FAIL_CLOSED = "FAIL_CLOSED"
+
+
+@dataclass(frozen=True)
+class StartStateVerificationResultV0:
+    valid: bool
+    fail_reasons: tuple[str, ...]
+    origin_main_sha: str
+    binding_digest: str
+    ratification_digest: str
+
+
+@dataclass(frozen=True)
+class InfrastructureReadinessResultV0:
+    status: InfrastructureTerminalStatus
+    execution_infrastructure_complete: bool
+    panel_wiring_complete: bool
+    bound_dataset_materialized: bool
+    dataset_period_match: bool
+    panel_data_digest: str
+    reason_codes: tuple[str, ...]
+    smoke_backtest_net_return: float | None
+    smoke_trade_count: int | None
+    authority_effect: str
+    runtime_effect: str
+    economic_evaluation_executed: bool
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def dumps_execution_canonical_v1(obj: Mapping[str, Any]) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str, ensure_ascii=False)
+
+
+def load_versioned_research_binding_v0(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / CONFIG_REL_PATH
+    if not path.is_file():
+        return materialize_versioned_research_binding_v0()
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_ops_evaluation_config_v0(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / CONFIG_REL_PATH_OPS
+    if not path.is_file():
+        raise FileNotFoundError(f"missing_ops_config:{path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def verify_execution_start_state_v0(
+    *,
+    repo_root: Path,
+    ratification: Mapping[str, Any],
+    versioned_binding: Mapping[str, Any] | None = None,
+    origin_main_sha: str = "",
+) -> StartStateVerificationResultV0:
+    reasons: list[str] = []
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    validation = validate_funding_rate_rank_delta_ranking_semantics_binding_v0(envelope["binding"])
+    if not validation.valid or validation.verdict != ValidationVerdict.ACCEPTED_COMPLETE:
+        reasons.extend(validation.fail_reasons or (REASON_BINDING_INCOMPLETE,))
+
+    ratification_validation = validate_rank_delta_offline_economic_evaluation_scope_ratification_v0(
+        ratification, expected_binding=envelope
+    )
+    if ratification_validation.verdict != ValidationVerdictEnum.ACCEPTED:
+        reasons.extend(ratification_validation.fail_reasons)
+
+    constraints = envelope.get("system_constraints", {})
+    if constraints.get("futures_only") is not True:
+        reasons.append("FUTURES_ONLY_VIOLATION")
+    if constraints.get("bitcoin_direction_allowed") is not False:
+        reasons.append("BITCOIN_DIRECTION_VIOLATION")
+
+    config_path = repo_root / CONFIG_REL_PATH_OPS
+    if not config_path.is_file():
+        reasons.append("MISSING_OPS_EVALUATION_CONFIG")
+
+    harness_path = (
+        repo_root
+        / "src/research"
+        / ("cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0.py")
+    )
+    if not harness_path.is_file():
+        reasons.append(REASON_INFRASTRUCTURE_INCOMPLETE)
+
+    runner_path = repo_root / RUNNER_SCRIPT
+    if not runner_path.is_file():
+        reasons.append("MISSING_RUNNER_SCRIPT")
+
+    orchestrator_path = (
+        repo_root
+        / "src/research"
+        / ("cross_sectional_funding_rate_rank_delta_single_slot_research_orchestrator_v0.py")
+    )
+    if not orchestrator_path.is_file():
+        reasons.append("MISSING_ORCHESTRATOR_WIRING")
+
+    materialization_path = (
+        repo_root
+        / "src/research"
+        / ("cross_sectional_funding_rate_rank_delta_v0_bound_panel_dataset_materialization_v0.py")
+    )
+    if not materialization_path.is_file():
+        reasons.append("MISSING_DATASET_MATERIALIZATION_ADAPTER")
+
+    return StartStateVerificationResultV0(
+        valid=not reasons,
+        fail_reasons=tuple(reasons),
+        origin_main_sha=origin_main_sha,
+        binding_digest=str(envelope.get("binding_digest", "")),
+        ratification_digest=str(ratification.get("ratification_digest", "")),
+    )
+
+
+def run_contract_smoke_evaluation_v0(
+    *,
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    versioned_binding: Mapping[str, Any],
+    staging_root: Path | None = None,
+) -> InfrastructureReadinessResultV0:
+    """Contract-only smoke: funding orchestrator -> backtest -> robustness wiring."""
+    envelope = dict(versioned_binding)
+    binding = default_funding_rank_delta_operator_binding_v0()
+    cost_binding = envelope["cost_execution_binding"]
+    period_binding = envelope["period_binding"]
+    economic_policy = envelope["economic_policy_binding"]
+
+    materialization = materialize_bound_funding_panel_dataset_v0(
+        staging_root or Path("."),
+        period_binding=period_binding,
+        expected_data_digest=envelope["data_digest"],
+    )
+    if materialization.status is MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED:
+        return InfrastructureReadinessResultV0(
+            status=InfrastructureTerminalStatus.FAIL_CLOSED_BOUND_DATA_UNAVAILABLE,
+            execution_infrastructure_complete=True,
+            panel_wiring_complete=True,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest=materialization.panel_data_digest,
+            reason_codes=materialization.reason_codes,
+            smoke_backtest_net_return=None,
+            smoke_trade_count=None,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+            economic_evaluation_executed=False,
+        )
+
+    funding_panel_series, _, _ = load_funding_panel_from_staging(staging_root or Path("."))
+    orchestrator = run_cross_sectional_funding_rate_rank_delta_orchestrator_v0(
+        binding=binding,
+        funding_panel_series=funding_panel_series,
+    )
+    backtest = run_single_slot_panel_backtest_v0(
+        orchestrator,
+        panel_series,
+        cost_execution_binding=cost_binding,
+    )
+    robustness = wire_robustness_stages_v0(
+        backtest,
+        period_binding=period_binding,
+        economic_policy_binding=economic_policy,
+    )
+    _ = robustness_results_to_dict(robustness)
+
+    return InfrastructureReadinessResultV0(
+        status=InfrastructureTerminalStatus.EXECUTION_INFRASTRUCTURE_COMPLETE,
+        execution_infrastructure_complete=True,
+        panel_wiring_complete=True,
+        bound_dataset_materialized=True,
+        dataset_period_match=True,
+        panel_data_digest=materialization.panel_data_digest,
+        reason_codes=(),
+        smoke_backtest_net_return=backtest.net_return,
+        smoke_trade_count=backtest.trade_count,
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+        economic_evaluation_executed=False,
+    )
+
+
+def materialize_infrastructure_summary_v0(
+    *,
+    ratification: Mapping[str, Any],
+    readiness: InfrastructureReadinessResultV0,
+    origin_main_sha: str,
+    execution_bundle_dir: str,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "execution_id": EXECUTION_ID,
+        "execution_version": EXECUTION_VERSION,
+        "strategy_id": STRATEGY_ID,
+        "strategy_version": STRATEGY_VERSION,
+        "ratification_digest": ratification.get("ratification_digest"),
+        "origin_main_sha": origin_main_sha,
+        "execution_bundle_dir": execution_bundle_dir,
+        "execution_infrastructure_complete": readiness.execution_infrastructure_complete,
+        "panel_wiring_complete": readiness.panel_wiring_complete,
+        "bound_dataset_materialized": readiness.bound_dataset_materialized,
+        "dataset_period_match": readiness.dataset_period_match,
+        "panel_data_digest": readiness.panel_data_digest,
+        "infrastructure_status": readiness.status.value,
+        "reason_codes": list(readiness.reason_codes),
+        "economic_evaluation_executed": False,
+        "economic_classification": "NONE",
+        "ready_for_separately_authorized_offline_economic_evaluation": (
+            readiness.status is InfrastructureTerminalStatus.EXECUTION_INFRASTRUCTURE_COMPLETE
+            and readiness.bound_dataset_materialized
+        ),
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "config_rel_path": CONFIG_REL_PATH_OPS,
+        "candidate_binding_ref": CONFIG_REL_PATH,
+        "canonical_serialization_version": CANONICAL_SERIALIZATION_VERSION,
+    }
+    body["manifest_digest"] = _stable_digest(body)
+    return body
+
+
+class EvaluationEntrypointTerminalStatus(str, Enum):
+    ENTRYPOINT_READY_DRY_RUN_STOPPED = "ENTRYPOINT_READY_DRY_RUN_STOPPED"
+    FAIL_CLOSED_PRECHECK = "FAIL_CLOSED_PRECHECK"
+
+
+@dataclass(frozen=True)
+class StageWiringStatusV1:
+    stage_name: str
+    wired: bool
+    owner: str
+
+
+@dataclass(frozen=True)
+class FullEvaluationEntrypointResultV1:
+    status: EvaluationEntrypointTerminalStatus
+    precheck_passed: bool
+    source_manifests_verified: bool
+    bound_dataset_materialized: bool
+    dataset_period_match: bool
+    panel_data_digest: str
+    stage_wiring: tuple[StageWiringStatusV1, ...]
+    dry_run_stopped_before_execution: bool
+    economic_evaluation_executed: bool
+    reason_codes: tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+
+
+def verify_full_evaluation_precheck_v1(
+    *,
+    repo_root: Path,
+    ratification: Mapping[str, Any],
+    staging_root: Path,
+    versioned_binding: Mapping[str, Any] | None = None,
+    go_token: str | None = None,
+    require_execution_go: bool = False,
+) -> tuple[bool, tuple[str, ...], BoundFundingPanelMaterializationResultV0]:
+    """Fail-closed precheck before any economic evaluation stage."""
+    reasons: list[str] = []
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    ops_cfg = load_ops_evaluation_config_v0(repo_root)
+
+    start_state = verify_execution_start_state_v0(
+        repo_root=repo_root,
+        ratification=ratification,
+        versioned_binding=envelope,
+    )
+    if not start_state.valid:
+        reasons.extend(start_state.fail_reasons)
+
+    if envelope.get("parameter_binding", {}).get("parameter_search_forbidden") is not True:
+        reasons.append(REASON_PARAMETER_SEARCH_FORBIDDEN_VIOLATION)
+
+    if require_execution_go:
+        if go_token not in ALLOWED_EXECUTION_GO_TOKENS:
+            reasons.append(REASON_GO_TOKEN_INVALID)
+    elif go_token != INFRASTRUCTURE_GO_TOKEN:
+        reasons.append(REASON_GO_TOKEN_INVALID)
+
+    manifest_ok, manifest_rc, manifest_reasons = verify_panel_staging_source_manifests_v1(
+        staging_root
+    )
+    if not manifest_ok:
+        if any("missing" in item.lower() for item in manifest_reasons):
+            reasons.append(REASON_SOURCE_MANIFEST_MISSING)
+        else:
+            reasons.append(REASON_SOURCE_MANIFEST_VERIFY_FAILED)
+        reasons.extend(manifest_reasons)
+    if manifest_rc != 0:
+        reasons.append(REASON_SOURCE_MANIFEST_VERIFY_FAILED)
+
+    expected_data_digest = str(
+        ops_cfg.get("cross_sectional_evaluation_binding_v1", {}).get("data_contract_digest", "")
+    ) or str(envelope.get("data_digest", ""))
+    materialization = materialize_bound_funding_panel_dataset_v0(
+        staging_root,
+        period_binding=envelope["period_binding"],
+        expected_data_digest=expected_data_digest,
+    )
+    if materialization.status is not MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE:
+        reasons.extend(materialization.reason_codes)
+        reasons.append(REASON_DATASET_UNAVAILABLE)
+    elif materialization.panel_data_digest == "0" * 64:
+        reasons.append(REASON_DATA_DIGEST_NULL)
+    elif not materialization.idempotent_digest_stable:
+        reasons.append("DATA_DIGEST_NOT_IDEMPOTENT")
+    elif materialization.bound_data_digest != expected_data_digest:
+        reasons.append(REASON_DATA_DIGEST_MISMATCH)
+
+    return not reasons, tuple(reasons), materialization
+
+
+def build_stage_wiring_status_v1() -> tuple[StageWiringStatusV1, ...]:
+    return (
+        StageWiringStatusV1(
+            stage_name="OFFLINE_BACKTEST",
+            wired=True,
+            owner="cross_sectional_single_slot_backtest_wiring_v0",
+        ),
+        StageWiringStatusV1(
+            stage_name="WALK_FORWARD",
+            wired=True,
+            owner="cross_sectional_panel_economic_evaluation_wiring_v0",
+        ),
+        StageWiringStatusV1(
+            stage_name="MONTE_CARLO",
+            wired=True,
+            owner="src.experiments.monte_carlo",
+        ),
+        StageWiringStatusV1(
+            stage_name="STRESS",
+            wired=True,
+            owner="src.experiments.stress_tests",
+        ),
+        StageWiringStatusV1(
+            stage_name="PARAMETER_SENSITIVITY",
+            wired=True,
+            owner="cross_sectional_panel_robustness_adapter_v0",
+        ),
+        StageWiringStatusV1(
+            stage_name="ECONOMIC_VIABILITY_EVIDENCE_MATERIALIZATION",
+            wired=True,
+            owner="src.backtest.economic_viability_evidence_v1",
+        ),
+    )
+
+
+def run_full_evaluation_entrypoint_dry_run_v1(
+    *,
+    repo_root: Path,
+    ratification: Mapping[str, Any],
+    staging_root: Path,
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    versioned_binding: Mapping[str, Any] | None = None,
+    go_token: str = _DEFAULT_INFRASTRUCTURE_GO,
+) -> FullEvaluationEntrypointResultV1:
+    """Validate full evaluation entrypoint wiring; stop before economic classification."""
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    precheck_ok, precheck_reasons, materialization = verify_full_evaluation_precheck_v1(
+        repo_root=repo_root,
+        ratification=ratification,
+        staging_root=staging_root,
+        versioned_binding=envelope,
+        go_token=go_token,
+        require_execution_go=False,
+    )
+
+    manifest_ok, _, _ = verify_panel_staging_source_manifests_v1(staging_root)
+    if not precheck_ok:
+        return FullEvaluationEntrypointResultV1(
+            status=EvaluationEntrypointTerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=False,
+            source_manifests_verified=manifest_ok,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest=getattr(materialization, "panel_data_digest", "0" * 64),
+            stage_wiring=(),
+            dry_run_stopped_before_execution=True,
+            economic_evaluation_executed=False,
+            reason_codes=precheck_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    funding_panel_series, _, _ = load_funding_panel_from_staging(staging_root)
+    binding = default_funding_rank_delta_operator_binding_v0()
+    orchestrator = run_cross_sectional_funding_rate_rank_delta_orchestrator_v0(
+        binding=binding,
+        funding_panel_series=funding_panel_series,
+    )
+    _ = build_walk_forward_adapter_input_v0(
+        orchestrator, economic_policy_binding=envelope["economic_policy_binding"]
+    )
+    _ = build_monte_carlo_adapter_input_v0(
+        orchestrator, economic_policy_binding=envelope["economic_policy_binding"]
+    )
+    _ = build_stress_adapter_input_v0(
+        orchestrator, economic_policy_binding=envelope["economic_policy_binding"]
+    )
+    _ = build_parameter_sensitivity_adapter_input_v0(
+        economic_policy_binding=envelope["economic_policy_binding"],
+    )
+    _ = build_economic_viability_evidence_adapter_input_v0(
+        orchestrator,
+        economic_policy_binding=envelope["economic_policy_binding"],
+    )
+    _ = run_single_slot_panel_backtest_v0(
+        orchestrator,
+        panel_series,
+        cost_execution_binding=envelope["cost_execution_binding"],
+    )
+
+    return FullEvaluationEntrypointResultV1(
+        status=EvaluationEntrypointTerminalStatus.ENTRYPOINT_READY_DRY_RUN_STOPPED,
+        precheck_passed=True,
+        source_manifests_verified=manifest_ok,
+        bound_dataset_materialized=True,
+        dataset_period_match=True,
+        panel_data_digest=materialization.panel_data_digest,
+        stage_wiring=build_stage_wiring_status_v1(),
+        dry_run_stopped_before_execution=True,
+        economic_evaluation_executed=False,
+        reason_codes=(),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def load_ohlcv_panel_series_for_backtest(staging_root: Path) -> tuple[InstrumentPanelSeriesV1, ...]:
+    from src.research.pit_futures_cross_sectional_research_data_digest_period_split_materialization_v0 import (
+        load_panel_series_from_staging,
+    )
+
+    panel_series, _ = load_panel_series_from_staging(staging_root)
+    return panel_series
+
+
+def entrypoint_result_to_dict(result: FullEvaluationEntrypointResultV1) -> dict[str, Any]:
+    return {
+        "status": result.status.value,
+        "precheck_passed": result.precheck_passed,
+        "source_manifests_verified": result.source_manifests_verified,
+        "bound_dataset_materialized": result.bound_dataset_materialized,
+        "dataset_period_match": result.dataset_period_match,
+        "panel_data_digest": result.panel_data_digest,
+        "stage_wiring": [
+            {"stage_name": item.stage_name, "wired": item.wired, "owner": item.owner}
+            for item in result.stage_wiring
+        ],
+        "allowed_evaluation_stages": list(ALLOWED_EVALUATION_STAGES),
+        "dry_run_stopped_before_execution": result.dry_run_stopped_before_execution,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "reason_codes": list(result.reason_codes),
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+        "runner_owner": RUNNER_OWNER,
+        "runner_script": RUNNER_SCRIPT,
+    }

--- a/src/research/cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_infrastructure_readiness_v0.py
+++ b/src/research/cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_infrastructure_readiness_v0.py
@@ -1,0 +1,162 @@
+"""Cross-sectional funding-rate rank-delta v0 offline evaluation infrastructure readiness v0.
+
+Deterministic, fail-closed read-model for offline-only evaluation infrastructure
+preconditions. Does not execute economic evaluation or touch runtime authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.research.cross_sectional_funding_rate_rank_delta_ranking_semantics_binding_validator_v0 import (
+    ValidationVerdict,
+    validate_funding_rate_rank_delta_ranking_semantics_binding_v0,
+)
+from src.research.cross_sectional_funding_rate_rank_delta_v0_versioned_research_binding_v0 import (
+    AUTHORITY_EFFECT,
+    RUNTIME_EFFECT,
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+    materialize_versioned_research_binding_v0,
+)
+
+PACKAGE_MARKER = (
+    "CROSS_SECTIONAL_FUNDING_RATE_RANK_DELTA_V0_OFFLINE_ECONOMIC_EVALUATION_"
+    "INFRASTRUCTURE_READINESS_V0=true"
+)
+
+READINESS_SCHEMA_VERSION = (
+    "cross_sectional_funding_rate_rank_delta_v0_offline_evaluation_infrastructure_readiness.v0"
+)
+READINESS_ID = (
+    "cross_sectional_funding_rate_rank_delta_v0_offline_evaluation_infrastructure_readiness_v0"
+)
+
+HARNESS_REL_PATH = (
+    "src/research/"
+    "cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0.py"
+)
+RUNNER_REL_PATH = (
+    "scripts/ops/"
+    "run_cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0.py"
+)
+CONFIG_REL_PATH_OPS = (
+    "config/ops/cross_sectional_funding_rate_rank_delta_v0_economic_evaluation_v1.json"
+)
+ORCHESTRATOR_REL_PATH = (
+    "src/research/cross_sectional_funding_rate_rank_delta_single_slot_research_orchestrator_v0.py"
+)
+MATERIALIZATION_REL_PATH = (
+    "src/research/"
+    "cross_sectional_funding_rate_rank_delta_v0_bound_panel_dataset_materialization_v0.py"
+)
+READINESS_REL_PATH = (
+    "src/research/"
+    "cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_infrastructure_readiness_v0.py"
+)
+
+REQUIRED_WIRING_REFS: tuple[str, ...] = (
+    HARNESS_REL_PATH,
+    RUNNER_REL_PATH,
+    CONFIG_REL_PATH_OPS,
+    ORCHESTRATOR_REL_PATH,
+    MATERIALIZATION_REL_PATH,
+    READINESS_REL_PATH,
+)
+
+SEPARATE_EVALUATION_GO_TOKEN = (
+    "GO_BOUNDED_CROSS_SECTIONAL_FUNDING_RATE_RANK_DELTA_V0_OFFLINE_ECONOMIC_EVALUATION_"
+    "EXECUTION_NO_RUNTIME_AUTHORITY_V0"
+)
+
+
+@dataclass(frozen=True)
+class OfflineEvaluationInfrastructureReadinessResultV0:
+    strategy_id: str
+    strategy_version: str
+    binding_ratified: bool
+    evaluation_execution_authorized: bool
+    runtime_authority: bool
+    evaluation_infrastructure_ready: bool
+    blockers: tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+    economic_evaluation_executed: bool
+
+
+def _missing_wiring_blockers(repo_root: Path) -> tuple[str, ...]:
+    blockers: list[str] = []
+    for rel_path in REQUIRED_WIRING_REFS:
+        if not (repo_root / rel_path).is_file():
+            blockers.append(f"MISSING_WIRING:{rel_path}")
+    return tuple(blockers)
+
+
+def _binding_blockers(envelope: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    validation = validate_funding_rate_rank_delta_ranking_semantics_binding_v0(envelope["binding"])
+    if not validation.valid or validation.verdict != ValidationVerdict.ACCEPTED_COMPLETE:
+        reasons.extend(validation.fail_reasons or ("BINDING_INCOMPLETE",))
+
+    constraints = envelope.get("system_constraints", {})
+    if constraints.get("futures_only") is not True:
+        reasons.append("FUTURES_ONLY_VIOLATION")
+    if constraints.get("bitcoin_direction_allowed") is not False:
+        reasons.append("BITCOIN_DIRECTION_VIOLATION")
+
+    return tuple(dict.fromkeys(reasons))
+
+
+def evaluate_rank_delta_offline_evaluation_infrastructure_readiness_v0(
+    *,
+    repo_root: Path,
+    versioned_binding: Mapping[str, Any] | None = None,
+    ratification: Mapping[str, Any] | None = None,
+) -> OfflineEvaluationInfrastructureReadinessResultV0:
+    """Fail-closed readiness surface without economic evaluation execution."""
+    envelope = dict(versioned_binding or materialize_versioned_research_binding_v0())
+    binding_ratified = envelope.get("binding", {}).get("binding_status", {}).get(
+        "overall_binding_status"
+    ) in {"COMPLETE", "BOUND"}
+
+    blockers = list(_missing_wiring_blockers(repo_root))
+    blockers.extend(_binding_blockers(envelope))
+
+    unique_blockers = tuple(dict.fromkeys(blockers))
+    ready = binding_ratified and not unique_blockers
+
+    return OfflineEvaluationInfrastructureReadinessResultV0(
+        strategy_id=STRATEGY_ID,
+        strategy_version=STRATEGY_VERSION,
+        binding_ratified=binding_ratified,
+        evaluation_execution_authorized=False,
+        runtime_authority=False,
+        evaluation_infrastructure_ready=ready,
+        blockers=unique_blockers,
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+        economic_evaluation_executed=False,
+    )
+
+
+def readiness_result_to_dict(
+    result: OfflineEvaluationInfrastructureReadinessResultV0,
+) -> dict[str, Any]:
+    return {
+        "schema_version": READINESS_SCHEMA_VERSION,
+        "readiness_id": READINESS_ID,
+        "strategy_id": result.strategy_id,
+        "strategy_version": result.strategy_version,
+        "binding_ratified": result.binding_ratified,
+        "evaluation_execution_authorized": result.evaluation_execution_authorized,
+        "runtime_authority": result.runtime_authority,
+        "evaluation_infrastructure_ready": result.evaluation_infrastructure_ready,
+        "blockers": list(result.blockers),
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "separate_evaluation_go_required": SEPARATE_EVALUATION_GO_TOKEN,
+        "required_wiring_refs": list(REQUIRED_WIRING_REFS),
+    }

--- a/src/research/cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_scope_ratification_v0.py
+++ b/src/research/cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_scope_ratification_v0.py
@@ -18,6 +18,9 @@ from src.research.cross_sectional_funding_rate_rank_delta_ranking_semantics_bind
     ValidationVerdict,
     validate_funding_rate_rank_delta_ranking_semantics_binding_v0,
 )
+from src.research.cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_infrastructure_readiness_v0 import (
+    evaluate_rank_delta_offline_evaluation_infrastructure_readiness_v0,
+)
 from src.research.cross_sectional_funding_rate_rank_delta_v0_versioned_research_binding_v0 import (
     AUTHORITY_EFFECT,
     CONFIG_REL_PATH as VERSIONED_BINDING_CONFIG_REL_PATH,
@@ -66,6 +69,12 @@ FUTURE_HARNESS_BINDING_REF = (
     "src/research/"
     "cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0.py"
 )
+RUNNER_BINDING_REF = FUTURE_RUNNER_BINDING_REF
+HARNESS_BINDING_REF = FUTURE_HARNESS_BINDING_REF
+READINESS_BINDING_REF = (
+    "src/research/"
+    "cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_infrastructure_readiness_v0.py"
+)
 PARENT_TERMINAL_SCOPE_BUNDLE = (
     "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/"
     "dual_leg_spread_v1_terminal_negative_evidence_and_next_material_scope_20260706T145350Z"
@@ -78,7 +87,6 @@ PARENT_DUAL_LEG_SPREAD_V1_EVALUATION_BUNDLE = (
 OFFLINE_ECONOMIC_EVALUATION_SCOPE_RATIFIED = True
 ECONOMIC_EVALUATION_AUTHORIZED = False
 ECONOMIC_EVALUATION_EXECUTED = False
-EVALUATION_INFRASTRUCTURE_READY = False
 FUTURES_ONLY = True
 BITCOIN_DIRECTION_ALLOWED = False
 
@@ -259,7 +267,7 @@ def materialize_rank_delta_offline_economic_evaluation_scope_ratification_v0(
     required_bindings_matrix = _required_bindings_matrix_v0(envelope)
     all_required_bindings_ratified = _all_required_bindings_ratified_v0(required_bindings_matrix)
 
-    body: dict[str, Any] = {
+    body_without_readiness: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "ratification_id": RATIFICATION_ID,
         "ratification_version": RATIFICATION_VERSION,
@@ -292,7 +300,9 @@ def materialize_rank_delta_offline_economic_evaluation_scope_ratification_v0(
         "execution_model_binding": envelope["cost_execution_binding"]["execution_model_binding"],
         "future_runner_binding": FUTURE_RUNNER_BINDING_REF,
         "future_harness_binding": FUTURE_HARNESS_BINDING_REF,
-        "evaluation_infrastructure_ready": EVALUATION_INFRASTRUCTURE_READY,
+        "runner_binding": RUNNER_BINDING_REF,
+        "harness_binding": HARNESS_BINDING_REF,
+        "readiness_binding": READINESS_BINDING_REF,
         "material_difference_basis": (
             "cross_sectional_rank_migration_not_level_spread_or_absolute_funding_delta"
         ),
@@ -339,9 +349,20 @@ def materialize_rank_delta_offline_economic_evaluation_scope_ratification_v0(
         "reason_codes": [],
         "canonical_serialization_version": CANONICAL_SERIALIZATION_VERSION,
     }
-    body["ratification_digest"] = _stable_digest(
-        {k: v for k, v in body.items() if k != "ratification_digest"}
+    body_without_readiness["ratification_digest"] = _stable_digest(
+        {k: v for k, v in body_without_readiness.items() if k != "ratification_digest"}
     )
+
+    readiness = evaluate_rank_delta_offline_evaluation_infrastructure_readiness_v0(
+        repo_root=repo_root or Path("."),
+        versioned_binding=envelope,
+        ratification=body_without_readiness,
+    )
+    body = dict(body_without_readiness)
+    body["evaluation_infrastructure_ready"] = readiness.evaluation_infrastructure_ready
+    body["evaluation_infrastructure_blockers"] = list(readiness.blockers)
+    body["runtime_authority"] = readiness.runtime_authority
+    body["evaluation_execution_authorized"] = readiness.evaluation_execution_authorized
     return body
 
 

--- a/tests/research/fixtures/cross_sectional_funding_rate_rank_delta_v0/fixture_builder.py
+++ b/tests/research/fixtures/cross_sectional_funding_rate_rank_delta_v0/fixture_builder.py
@@ -1,0 +1,63 @@
+"""Synthetic fixtures for cross-sectional funding-rate rank-delta v0 infrastructure tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1, PanelBarV1
+
+PANEL_CALENDAR_START_UTC = datetime(2024, 5, 1, 0, 0, tzinfo=timezone.utc)
+PANEL_CALENDAR_END_UTC = datetime(2024, 9, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def _bars(
+    instrument_id: str,
+    *,
+    base_close: float,
+    start: datetime | None = None,
+    end: datetime | None = None,
+) -> tuple[PanelBarV1, ...]:
+    bars: list[PanelBarV1] = []
+    cursor = start or PANEL_CALENDAR_START_UTC
+    stop = end or PANEL_CALENDAR_END_UTC
+    idx = 0
+    while cursor < stop:
+        ts = cursor.strftime("%Y-%m-%dT%H:%M:%SZ")
+        close = base_close + idx * 0.01
+        bars.append(
+            PanelBarV1(
+                instrument_id=instrument_id,
+                timestamp_utc=ts,
+                open=str(close - 0.01),
+                high=str(close + 0.02),
+                low=str(close - 0.02),
+                close=str(close),
+                volume="1000",
+                is_final=True,
+            )
+        )
+        cursor += timedelta(hours=1)
+        idx += 1
+    return tuple(bars)
+
+
+def build_synthetic_ohlcv_panel_v0() -> tuple[InstrumentPanelSeriesV1, ...]:
+    instruments = (
+        ("okx:linear_perpetual:ETH:USDT:USDT:perp", 3000.0),
+        ("okx:linear_perpetual:SOL:USDT:USDT:perp", 150.0),
+        ("okx:linear_perpetual:AVAX:USDT:USDT:perp", 35.0),
+        ("okx:linear_perpetual:LINK:USDT:USDT:perp", 15.0),
+        ("okx:linear_perpetual:ADA:USDT:USDT:perp", 0.45),
+    )
+    series: list[InstrumentPanelSeriesV1] = []
+    for instrument_id, base_close in instruments:
+        bars = _bars(instrument_id, base_close=base_close)
+        series.append(
+            InstrumentPanelSeriesV1(
+                instrument_id=instrument_id,
+                native_instrument_id=instrument_id,
+                bars=bars,
+                series_digest="fixture",
+            )
+        )
+    return tuple(series)

--- a/tests/research/test_cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_infrastructure_v0.py
+++ b/tests/research/test_cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_infrastructure_v0.py
@@ -1,0 +1,323 @@
+"""Contract tests for funding-rate rank-delta execution infrastructure v0."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.research.cross_sectional_funding_rate_rank_delta_v0_bound_panel_dataset_materialization_v0 import (
+    MaterializationTerminalStatus,
+    materialize_bound_funding_panel_dataset_v0,
+)
+from src.research.cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    GO_TOKEN,
+    INFRASTRUCTURE_GO_TOKEN,
+    RUNTIME_EFFECT,
+    entrypoint_result_to_dict,
+    load_ops_evaluation_config_v0,
+    materialize_infrastructure_summary_v0,
+    run_contract_smoke_evaluation_v0,
+    run_full_evaluation_entrypoint_dry_run_v1,
+    verify_execution_start_state_v0,
+    verify_full_evaluation_precheck_v1,
+)
+from src.research.cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_infrastructure_readiness_v0 import (
+    evaluate_rank_delta_offline_evaluation_infrastructure_readiness_v0,
+    readiness_result_to_dict,
+)
+from src.research.cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_scope_ratification_v0 import (
+    materialize_rank_delta_offline_economic_evaluation_scope_ratification_v0,
+)
+from src.research.cross_sectional_funding_rate_rank_delta_v0_versioned_research_binding_v0 import (
+    materialize_and_validate_versioned_research_binding_v0,
+    materialize_versioned_research_binding_v0,
+)
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (
+    SourceManifestStatus,
+    materialize_panel_staging_source_manifests_v1,
+)
+from tests.research.fixtures.cross_sectional_funding_rate_rank_delta_v0.fixture_builder import (
+    build_synthetic_ohlcv_panel_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFRA_GO = INFRASTRUCTURE_GO_TOKEN
+
+
+def _write_staging_with_funding(
+    root: Path,
+    *,
+    with_manifests: bool = True,
+) -> Path:
+    panel = build_synthetic_ohlcv_panel_v0()
+    panel_dir = root / "panel"
+    lifecycle = root / "lifecycle"
+    panel_dir.mkdir(parents=True, exist_ok=True)
+    lifecycle.mkdir(parents=True, exist_ok=True)
+
+    funding_rows: list[dict[str, object]] = []
+    for series_idx, series in enumerate(panel):
+        for bar_idx, bar in enumerate(series.bars):
+            funding_rows.append(
+                {
+                    "instrument_id": bar.instrument_id,
+                    "native_instrument_id": series.native_instrument_id,
+                    "timestamp_utc": bar.timestamp_utc,
+                    "open": bar.open,
+                    "high": bar.high,
+                    "low": bar.low,
+                    "close": bar.close,
+                    "volume": bar.volume,
+                    "funding_rate": str(-0.0002 + series_idx * 0.00003 + bar_idx * 0.000001),
+                    "is_final": bar.is_final,
+                }
+            )
+
+    funding_rows.sort(key=lambda row: (str(row["instrument_id"]), str(row["timestamp_utc"])))
+    funding_digest = (
+        __import__("hashlib")
+        .sha256(
+            json.dumps(
+                funding_rows, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+            ).encode("utf-8")
+        )
+        .hexdigest()
+    )
+
+    (panel_dir / "normalized_panel_bars_with_funding.json").write_text(
+        json.dumps({"bars": funding_rows}, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (panel_dir / "panel_funding_dataset_manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "pit_okx_pt1h_panel_funding_dataset_manifest_v1",
+                "panel_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+                "dataset_extension": "extended_chronological_with_funding_v1",
+                "row_count_total": len(funding_rows),
+                "funding_panel_digest": funding_digest,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (lifecycle / "SOURCE_REGISTRATION.json").write_text(
+        json.dumps(
+            {
+                "source_snapshot_ref": "test:fixture",
+                "source_snapshot_digest": "a" * 64,
+                "registered": True,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    if with_manifests:
+        manifest = materialize_panel_staging_source_manifests_v1(root)
+        assert manifest.status is SourceManifestStatus.VERIFIED
+    return root
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_research_binding_v0()
+
+
+@pytest.fixture(name="scope_ratification")
+def fixture_scope_ratification(complete_binding: dict) -> dict:
+    return materialize_rank_delta_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=REPO_ROOT,
+        versioned_binding=complete_binding,
+    )
+
+
+@pytest.fixture(name="bound_staging")
+def fixture_bound_staging() -> Path:
+    tmp = Path(tempfile.mkdtemp(prefix="cs_rank_delta_exec_v0_"))
+    return _write_staging_with_funding(tmp)
+
+
+def test_go_token_constants() -> None:
+    assert GO_TOKEN == (
+        "GO_BOUNDED_CROSS_SECTIONAL_FUNDING_RATE_RANK_DELTA_V0_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0"
+    )
+    assert INFRASTRUCTURE_GO_TOKEN == (
+        "GO_BOUNDED_CROSS_SECTIONAL_FUNDING_RATE_RANK_DELTA_V0_OFFLINE_ECONOMIC_EVALUATION_"
+        "INFRASTRUCTURE_COMPLETION_V0"
+    )
+
+
+def test_no_runtime_authority_effect_constants() -> None:
+    assert AUTHORITY_EFFECT == "NONE"
+    assert RUNTIME_EFFECT == "NONE"
+
+
+def test_binding_materialization_complete_accepted() -> None:
+    result = materialize_and_validate_versioned_research_binding_v0()
+    assert result.validation_verdict.value == "ACCEPTED_COMPLETE"
+
+
+def test_readiness_fail_closed_before_wiring_removed(complete_binding: dict) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        incomplete_repo = Path(tmp)
+        readiness = evaluate_rank_delta_offline_evaluation_infrastructure_readiness_v0(
+            repo_root=incomplete_repo,
+            versioned_binding=complete_binding,
+        )
+        assert readiness.evaluation_infrastructure_ready is False
+        assert readiness.blockers
+
+
+def test_readiness_true_when_wiring_complete(
+    complete_binding: dict,
+    scope_ratification: dict,
+) -> None:
+    readiness = evaluate_rank_delta_offline_evaluation_infrastructure_readiness_v0(
+        repo_root=REPO_ROOT,
+        versioned_binding=complete_binding,
+        ratification=scope_ratification,
+    )
+    assert readiness.evaluation_infrastructure_ready is True
+    assert readiness.blockers == ()
+    assert readiness.evaluation_execution_authorized is False
+    assert readiness.runtime_authority is False
+    assert readiness.economic_evaluation_executed is False
+
+
+def test_readiness_dict_contains_no_economic_metrics(
+    scope_ratification: dict,
+) -> None:
+    readiness = evaluate_rank_delta_offline_evaluation_infrastructure_readiness_v0(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+    )
+    payload = readiness_result_to_dict(readiness)
+    forbidden = ("net_return", "profit_factor", "sharpe", "max_drawdown", "calmar")
+    serialized = json.dumps(payload)
+    for key in forbidden:
+        assert key not in serialized
+
+
+def test_scope_ratification_reports_infrastructure_ready(
+    scope_ratification: dict,
+) -> None:
+    assert scope_ratification["evaluation_infrastructure_ready"] is True
+    assert scope_ratification["evaluation_infrastructure_blockers"] == []
+    assert scope_ratification["runtime_authority"] is False
+    assert scope_ratification["evaluation_execution_authorized"] is False
+
+
+def test_start_state_verification_accepts_ratified_binding(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    result = verify_execution_start_state_v0(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        versioned_binding=complete_binding,
+    )
+    assert result.valid is True
+    assert result.fail_reasons == ()
+
+
+def test_bound_funding_materialization_is_complete(
+    bound_staging: Path,
+    complete_binding: dict,
+) -> None:
+    result = materialize_bound_funding_panel_dataset_v0(
+        bound_staging,
+        period_binding=complete_binding["period_binding"],
+        expected_data_digest=complete_binding["data_digest"],
+    )
+    assert result.status is MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE
+    assert result.data_digest_match is True
+
+
+def test_precheck_rejects_invalid_go_token(
+    bound_staging: Path,
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    ok, reasons, _ = verify_full_evaluation_precheck_v1(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        staging_root=bound_staging,
+        versioned_binding=complete_binding,
+        go_token="INVALID_TOKEN",
+    )
+    assert ok is False
+    assert "GO_TOKEN_INVALID" in reasons
+
+
+def test_contract_smoke_evaluation_produces_wiring_outputs(
+    bound_staging: Path,
+    complete_binding: dict,
+) -> None:
+    readiness = run_contract_smoke_evaluation_v0(
+        panel_series=build_synthetic_ohlcv_panel_v0(),
+        versioned_binding=complete_binding,
+        staging_root=bound_staging,
+    )
+    assert readiness.execution_infrastructure_complete is True
+    assert readiness.panel_wiring_complete is True
+    assert readiness.bound_dataset_materialized is True
+    assert readiness.economic_evaluation_executed is False
+    assert readiness.smoke_trade_count is not None
+
+
+def test_dry_run_entrypoint_stops_before_economic_execution(
+    bound_staging: Path,
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    result = run_full_evaluation_entrypoint_dry_run_v1(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        staging_root=bound_staging,
+        panel_series=build_synthetic_ohlcv_panel_v0(),
+        versioned_binding=complete_binding,
+        go_token=_INFRA_GO,
+    )
+    assert result.dry_run_stopped_before_execution is True
+    assert result.economic_evaluation_executed is False
+    assert len(result.stage_wiring) == 6
+    assert all(item.wired for item in result.stage_wiring)
+
+
+def test_infrastructure_summary_flags_no_economic_evaluation(
+    scope_ratification: dict,
+    complete_binding: dict,
+    bound_staging: Path,
+) -> None:
+    readiness = run_contract_smoke_evaluation_v0(
+        panel_series=build_synthetic_ohlcv_panel_v0(),
+        versioned_binding=complete_binding,
+        staging_root=bound_staging,
+    )
+    summary = materialize_infrastructure_summary_v0(
+        ratification=scope_ratification,
+        readiness=readiness,
+        origin_main_sha="test",
+        execution_bundle_dir="/tmp/test",
+    )
+    assert summary["economic_evaluation_executed"] is False
+    assert summary["economic_classification"] == "NONE"
+    assert "net_return" not in summary
+    assert summary["authority_effect"] == "NONE"
+
+
+def test_ops_config_loads(complete_binding: dict) -> None:
+    cfg = load_ops_evaluation_config_v0(REPO_ROOT)
+    assert cfg["strategy_id"] == complete_binding["strategy_id"]
+    assert (
+        cfg["cross_sectional_evaluation_binding_v1"]["data_digest"]
+        == complete_binding["data_digest"]
+    )

--- a/tests/research/test_cross_sectional_funding_rate_rank_delta_v0_scope_binding_ratification_prep_v0.py
+++ b/tests/research/test_cross_sectional_funding_rate_rank_delta_v0_scope_binding_ratification_prep_v0.py
@@ -55,7 +55,8 @@ class TestCrossSectionalFundingRateRankDeltaV0ScopeBindingRatificationPrep:
             "cross_sectional_funding_rate_dual_leg_spread/v1"
             in ratification["terminal_failed_binding_exclusions"]
         )
-        assert ratification["evaluation_infrastructure_ready"] is False
+        assert ratification["evaluation_infrastructure_ready"] is True
+        assert ratification["evaluation_infrastructure_blockers"] == []
 
     def test_governance_doc_exists_and_states_no_eval(self) -> None:
         text = GOVERNANCE_DOC.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Adds fail-closed offline evaluation infrastructure readiness for `cross_sectional_funding_rate_rank_delta/v0`: orchestrator, bound funding panel materialization, execution harness (dry-run/contract smoke only), ops config, and readiness read-model.
- Updates scope ratification to compute `evaluation_infrastructure_ready` and `evaluation_infrastructure_blockers` dynamically from wired prerequisites.
- Adds focused contract tests proving readiness fail-closed/ready semantics without economic evaluation execution.

## Authority boundary
- No economic evaluation executed
- No runtime authority touched
- Readiness only
- Separate Operator-GO still required for actual offline economic evaluation execution

## Evidence
- Durable evidence dir: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/pr4930_rank_delta_v0_eval_infra_readiness_fix_20260706T151050Z`
- MANIFEST_VERIFY_RC=0

## Test plan
- [x] `pytest tests/research/test_cross_sectional_funding_rate_rank_delta_v0_offline_economic_evaluation_execution_infrastructure_v0.py`
- [x] `pytest tests/research/test_cross_sectional_funding_rate_rank_delta_v0_scope_binding_ratification_prep_v0.py`
- [x] `pytest tests/research/test_cross_sectional_funding_rate_rank_delta_v0_binding_completion_v0.py`
- [x] `ruff format --check` and `ruff check` on changed Python files


Made with [Cursor](https://cursor.com)