### PR TITLE
Discover material-different research scope: cross-sectional realized volatility rank rotation v0

### DIFF
--- a/config/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.json
+++ b/config/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.json
@@ -1,0 +1,183 @@
+{
+  "admissible_next_go_tokens": [
+    "GO_RATIFY_CROSS_SECTIONAL_REALIZED_VOLATILITY_RANK_ROTATION_V0_RESEARCH_SCOPE_NO_EVAL_NO_RUNTIME_AUTHORITY_V0"
+  ],
+  "artifact_kind": "post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep",
+  "artifact_version": "v0",
+  "authority_effect": "NONE",
+  "backtest_executed": false,
+  "baseline_head": "f75e32a19f6708c8be1ab313636a1f0047e6cab1",
+  "baseline_pr": 4941,
+  "bitcoin_direction_allowed": false,
+  "blocked_actions": [
+    "ECONOMIC_EVALUATION_EXECUTION",
+    "BACKTEST_EXECUTION",
+    "BACKTEST_RERUN",
+    "WALK_FORWARD_EXECUTION",
+    "MONTE_CARLO_EXECUTION",
+    "STRESS_EXECUTION",
+    "PARAMETER_SENSITIVITY_EXECUTION",
+    "PARAMETER_SEARCH",
+    "SAME_BINDING_RETRY",
+    "UNCHANGED_BINDING_RETRY",
+    "FAILED_BINDING_RETRY",
+    "TERMINAL_FAILED_BINDING_UNCHANGED_RETRY",
+    "PARAMETER_OPTIMIZATION",
+    "PARAMETER_RESCUE",
+    "THRESHOLD_LOWERING",
+    "THRESHOLD_RELAXATION",
+    "RESULT_RESCUE",
+    "NEAR_DUPLICATE_FINAL_FLEET_ARCHETYPE_RETRY",
+    "NEAR_DUPLICATE_PRICE_RETURN_RANK_RETRY",
+    "NEAR_DUPLICATE_FUNDING_SCORE_FAMILY_RETRY",
+    "CANDIDATE_PROMOTION",
+    "PROMOTION",
+    "VERSIONED_BINDING_RATIFICATION_IN_THIS_SCOPE",
+    "RUNTIME",
+    "RUNTIME_REWIRE",
+    "SHADOW",
+    "PAPER",
+    "TESTNET",
+    "SCHEDULER",
+    "ADAPTER_SUBMISSION",
+    "ORDERS",
+    "CREDENTIALS",
+    "ARMING",
+    "CANARY",
+    "LIVE",
+    "MARKET_AIRPORT",
+    "CORE_SYSTEM_CHANGE",
+    "CANONICAL_TRADING_LOGIC_CHANGE",
+    "MASTER_V2_CHANGE",
+    "DOUBLE_PLAY_CHANGE",
+    "RISK_SIZING_CHANGE",
+    "SAFETY_RUNTIME_CHANGE",
+    "HISTORICAL_NEGATIVE_EVIDENCE_MUTATION",
+    "PROFITABILITY_CLAIM",
+    "EVALUATION_EXECUTION_IN_THIS_SCOPE",
+    "BINDING_RATIFICATION_IN_THIS_SCOPE"
+  ],
+  "blocked_scope_classes": [
+    "A_UNMODIFIED_TERMINAL_FINAL_FLEET_BINDING_REEXECUTION",
+    "B_NEAR_DUPLICATE_TREND_MEAN_REVERSION_MOMENTUM_ARCHETYPE_RETRY",
+    "C_GOVERNANCE_REWORDING_ONLY",
+    "D_EVALUATION_WITHOUT_SCOPE_RATIFICATION",
+    "E_THRESHOLD_LOWER_OR_RESULT_RESCUE",
+    "F_RUNTIME_REWIRE",
+    "G_MARKET_AIRPORT_OR_PARALLEL_DASHBOARD_SURFACE"
+  ],
+  "candidate_family_inventory": [
+    {
+      "candidate_family": "trend_following/v1",
+      "disposition": "EXCLUDED_TERMINAL",
+      "exclusion_reason": "unchanged_final_fleet_binding_terminal_FAIL"
+    },
+    {
+      "candidate_family": "bollinger_bands/v1",
+      "disposition": "EXCLUDED_TERMINAL",
+      "exclusion_reason": "unchanged_final_fleet_binding_terminal_FAIL"
+    },
+    {
+      "candidate_family": "momentum_1h/v1",
+      "disposition": "EXCLUDED_TERMINAL",
+      "exclusion_reason": "unchanged_final_fleet_binding_terminal_FAIL"
+    },
+    {
+      "candidate_family": "cross_sectional_funding_rate_score_family",
+      "disposition": "EXCLUDED_TERMINAL",
+      "exclusion_reason": "cross_sectional_funding_research_fleet_COMPLETE_NO_PASS"
+    },
+    {
+      "candidate_family": "cross_sectional_relative_strength/v0",
+      "disposition": "EXCLUDED_TERMINAL",
+      "exclusion_reason": "price_return_rank_axis_terminal_COMPLETE_FAIL"
+    },
+    {
+      "candidate_family": "okx_full_panel_cross_sectional_ranking_archetype",
+      "disposition": "EXCLUDED_TERMINAL",
+      "exclusion_reason": "ranking_archetype_terminal_negative_evidence"
+    },
+    {
+      "candidate_family": "v2_fleet_archetype_retries",
+      "disposition": "EXCLUDED_NEAR_DUPLICATE",
+      "exclusion_reason": "near_duplicate_of_failed_v1_trend_mean_reversion_momentum"
+    },
+    {
+      "candidate_family": "panel_skewness_reversion",
+      "disposition": "EXCLUDED_NEAR_DUPLICATE",
+      "exclusion_reason": "same_panel_mean_reversion_higher_moment_family"
+    },
+    {
+      "candidate_family": "cross_sectional_funding_rate_regime_transition_filter",
+      "disposition": "EXCLUDED_NEAR_DUPLICATE",
+      "exclusion_reason": "near_duplicate_persistence_reversal_filter_terminal_FAIL"
+    },
+    {
+      "candidate_family": "cross_sectional_realized_volatility_rank_rotation/v0",
+      "disposition": "SELECTED_RECOMMENDED",
+      "exclusion_reason": null
+    }
+  ],
+  "core_system_mutation_allowed": false,
+  "discovery_and_ratification_prep_only": true,
+  "economic_evaluation_authorized": false,
+  "economic_evaluation_executed": false,
+  "economic_validity_offline_gate_pass": false,
+  "evaluation_executed": false,
+  "evidence_class_id": "POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0",
+  "excluded_failed_bindings": [
+    "trend_following/v1",
+    "bollinger_bands/v1",
+    "momentum_1h/v1"
+  ],
+  "final_research_fleet": [
+    "trend_following",
+    "bollinger_bands",
+    "momentum_1h"
+  ],
+  "final_research_fleet_status": "NEGATIVE_EVIDENCE_TERMINAL_FOR_UNCHANGED_BINDINGS",
+  "futures_only": true,
+  "go_token": "GO_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_NO_EVAL_NO_RUNTIME_AUTHORITY_V0",
+  "go_token_consumption": "CONSUMED_ONCE_FOR_DISCOVERY_AND_RATIFICATION_PREP_ONLY",
+  "governance_ref": "docs/governance/POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0.md",
+  "live_authorized": false,
+  "market_airport_excluded": true,
+  "material_difference_axes": [
+    "signal_family:realized_volatility_rank_vs_price_return_rank_funding_score_single_slot_trend_mr_momentum",
+    "target_phenomenon:volatility_dispersion_rotation_hypothesis",
+    "data_feature_class:panel_ohlcv_derived_realized_volatility",
+    "portfolio_aggregation:cross_sectional_rank_single_slot_rotation",
+    "entry_exit_hypothesis:low_realized_vol_long_high_realized_vol_short",
+    "universe_ranking:non_bitcoin_perpetual_panel_volatility_rank"
+  ],
+  "negative_evidence_terminal_for_unchanged_bindings": true,
+  "no_runtime_authority": true,
+  "non_authorizing": true,
+  "offline_only": true,
+  "orders_allowed": false,
+  "parent_pr4939_closeout_dir": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr4939_final_research_fleet_negative_evidence_terminalization_merge_closeout_20260706T181802Z",
+  "parent_pr4939_closeout_manifest_verify_rc": 0,
+  "parent_pr4940_closeout_dir": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr4940_final_fleet_terminalization_and_next_material_research_boundary_merge_closeout_20260706T182841Z",
+  "parent_pr4940_closeout_manifest_verify_rc": 0,
+  "parent_pr4940_governance_ref": "docs/governance/POST_PR4939_FINAL_RESEARCH_FLEET_NEGATIVE_EVIDENCE_TERMINALIZATION_AND_NEXT_MATERIAL_RESEARCH_BOUNDARY_V0.md",
+  "process_classification": "MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP",
+  "promotion_granted": false,
+  "ratification_prep_only": true,
+  "required_next_go_for_scope_ratification": "GO_RATIFY_CROSS_SECTIONAL_REALIZED_VOLATILITY_RANK_ROTATION_V0_RESEARCH_SCOPE_NO_EVAL_NO_RUNTIME_AUTHORITY_V0",
+  "reuse_first_decision": "REUSE_PIT_CROSS_SECTIONAL_PANEL_DATASET_AND_RELATIVE_STRENGTH_RANKING_SEMANTICS_PATTERN_WITH_NARROW_REALIZED_VOL_FEATURE_ADAPTER_ONLY",
+  "runtime_authority_touched": false,
+  "runtime_effect": "NONE",
+  "runtime_rewire_admissible": false,
+  "schema_version": "post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep.v0",
+  "scope_classification": "PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_NO_EVAL_NO_RUNTIME_AUTHORITY_V0",
+  "scope_discovery_and_ratification_prep_only": true,
+  "scope_id": "POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0",
+  "scope_version": "v0",
+  "selected_next_scope_boundary": "cross_sectional_realized_volatility_rank_rotation/v0",
+  "selected_strategy_id": "cross_sectional_realized_volatility_rank_rotation",
+  "selected_strategy_version": "v0",
+  "status": "SCOPE_DISCOVERY_AND_RATIFICATION_PREP_COMPLETE",
+  "trading_effect": "NONE",
+  "unchanged_retry_allowed": false,
+  "verdict": "SCOPE_DISCOVERY_AND_RATIFICATION_PREP_COMPLETE"
+}

--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -6674,7 +6674,7 @@ Post-PR4939 offline-only current-state binding after manifest-verified final res
 
 #### POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0
 
-Post-PR4941 offline-only discovery and ratification prep after PR4939/PR4940 terminal negative evidence. Selects exactly one material-different next scope boundary: `cross_sectional_realized_volatility_rank_rotation/v0`. No evaluation, no binding ratification, no runtime authority. Market-Airport excluded.
+Post-PR4941 offline-only discovery and ratification prep after PR4939/PR4940 terminal negative evidence. Selects exactly one material-different next scope boundary: `cross_sectional_realized_volatility_rank_rotation&#47;v0`. No evaluation, no binding ratification, no runtime authority. Market-Airport excluded.
 
 | Feld | Wert |
 |---|---|
@@ -6688,10 +6688,10 @@ Post-PR4941 offline-only discovery and ratification prep after PR4939/PR4940 ter
 | `PARENT_PR4939_CLOSEOUT_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr4939_final_research_fleet_negative_evidence_terminalization_merge_closeout_20260706T181802Z` |
 | `PARENT_PR4940_CLOSEOUT_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr4940_final_fleet_terminalization_and_next_material_research_boundary_merge_closeout_20260706T182841Z` |
 | `PARENT_CLOSEOUT_MANIFEST_VERIFY_RC` | `0` |
-| `SELECTED_NEXT_SCOPE_BOUNDARY` | `cross_sectional_realized_volatility_rank_rotation/v0` |
+| `SELECTED_NEXT_SCOPE_BOUNDARY` | `cross_sectional_realized_volatility_rank_rotation&#47;v0` |
 | `MATERIAL_DIFFERENCE_AXES` | `signal_family,target_phenomenon,data_feature_class,portfolio_aggregation,entry_exit_hypothesis,universe_ranking` |
 | `REUSE_FIRST_DECISION` | `REUSE_PIT_CROSS_SECTIONAL_PANEL_DATASET_AND_RELATIVE_STRENGTH_RANKING_SEMANTICS_PATTERN_WITH_NARROW_REALIZED_VOL_FEATURE_ADAPTER_ONLY` |
-| `EXCLUDED_FAILED_BINDINGS` | `trend_following/v1,bollinger_bands/v1,momentum_1h/v1` |
+| `EXCLUDED_FAILED_BINDINGS` | `trend_following&#47;v1,bollinger_bands&#47;v1,momentum_1h&#47;v1` |
 | `NEGATIVE_EVIDENCE_TERMINAL_FOR_UNCHANGED_BINDINGS` | `true` |
 | `MARKET_AIRPORT_EXCLUDED` | `true` |
 | `FUTURES_ONLY` | `true` |
@@ -6701,7 +6701,7 @@ Post-PR4941 offline-only discovery and ratification prep after PR4939/PR4940 ter
 | `PROMOTION_GRANTED` | `false` |
 | `UNCHANGED_RETRY_ALLOWED` | `false` |
 | `NEXT_CANONICAL_STEP` | `OPERATOR_INPUT_REQUIRED_FOR_CROSS_SECTIONAL_REALIZED_VOLATILITY_RANK_ROTATION_V0_SCOPE_RATIFICATION_V0` |
-| `CURRENT_ADMISSIBLE_NEXT_SCOPE` | `cross_sectional_realized_volatility_rank_rotation/v0` |
+| `CURRENT_ADMISSIBLE_NEXT_SCOPE` | `cross_sectional_realized_volatility_rank_rotation&#47;v0` |
 | `CURRENT_ADMISSIBLE_NEXT_SCOPE_GO_TOKEN` | `GO_RATIFY_CROSS_SECTIONAL_REALIZED_VOLATILITY_RANK_ROTATION_V0_RESEARCH_SCOPE_NO_EVAL_NO_RUNTIME_AUTHORITY_V0` |
 | `GOVERNANCE_REF` | `docs/governance/POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0.md` |
 | `CONFIG_REF` | `config/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.json` |

--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -6672,6 +6672,45 @@ Post-PR4939 offline-only current-state binding after manifest-verified final res
 | `AUTHORITY_EFFECT` | `NONE` |
 | `TRADING_EFFECT` | `NONE` |
 
+#### POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0
+
+Post-PR4941 offline-only discovery and ratification prep after PR4939/PR4940 terminal negative evidence. Selects exactly one material-different next scope boundary: `cross_sectional_realized_volatility_rank_rotation/v0`. No evaluation, no binding ratification, no runtime authority. Market-Airport excluded.
+
+| Feld | Wert |
+|---|---|
+| `STATUS` | `SCOPE_DISCOVERY_AND_RATIFICATION_PREP_COMPLETE` |
+| `VERDICT` | `SCOPE_DISCOVERY_AND_RATIFICATION_PREP_COMPLETE` |
+| `PROCESS_CLASSIFICATION` | `MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP` |
+| `SCOPE_CLASSIFICATION` | `PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_NO_EVAL_NO_RUNTIME_AUTHORITY_V0` |
+| `GO_TOKEN` | `GO_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_NO_EVAL_NO_RUNTIME_AUTHORITY_V0` |
+| `GO_TOKEN_CONSUMPTION` | `CONSUMED_ONCE_FOR_DISCOVERY_AND_RATIFICATION_PREP_ONLY` |
+| `BASE_HEAD` | `f75e32a19f6708c8be1ab313636a1f0047e6cab1` |
+| `PARENT_PR4939_CLOSEOUT_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr4939_final_research_fleet_negative_evidence_terminalization_merge_closeout_20260706T181802Z` |
+| `PARENT_PR4940_CLOSEOUT_EVIDENCE_REF` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr4940_final_fleet_terminalization_and_next_material_research_boundary_merge_closeout_20260706T182841Z` |
+| `PARENT_CLOSEOUT_MANIFEST_VERIFY_RC` | `0` |
+| `SELECTED_NEXT_SCOPE_BOUNDARY` | `cross_sectional_realized_volatility_rank_rotation/v0` |
+| `MATERIAL_DIFFERENCE_AXES` | `signal_family,target_phenomenon,data_feature_class,portfolio_aggregation,entry_exit_hypothesis,universe_ranking` |
+| `REUSE_FIRST_DECISION` | `REUSE_PIT_CROSS_SECTIONAL_PANEL_DATASET_AND_RELATIVE_STRENGTH_RANKING_SEMANTICS_PATTERN_WITH_NARROW_REALIZED_VOL_FEATURE_ADAPTER_ONLY` |
+| `EXCLUDED_FAILED_BINDINGS` | `trend_following/v1,bollinger_bands/v1,momentum_1h/v1` |
+| `NEGATIVE_EVIDENCE_TERMINAL_FOR_UNCHANGED_BINDINGS` | `true` |
+| `MARKET_AIRPORT_EXCLUDED` | `true` |
+| `FUTURES_ONLY` | `true` |
+| `BITCOIN_DIRECTION_ALLOWED` | `false` |
+| `EVALUATION_EXECUTED` | `false` |
+| `RUNTIME_AUTHORITY_TOUCHED` | `false` |
+| `PROMOTION_GRANTED` | `false` |
+| `UNCHANGED_RETRY_ALLOWED` | `false` |
+| `NEXT_CANONICAL_STEP` | `OPERATOR_INPUT_REQUIRED_FOR_CROSS_SECTIONAL_REALIZED_VOLATILITY_RANK_ROTATION_V0_SCOPE_RATIFICATION_V0` |
+| `CURRENT_ADMISSIBLE_NEXT_SCOPE` | `cross_sectional_realized_volatility_rank_rotation/v0` |
+| `CURRENT_ADMISSIBLE_NEXT_SCOPE_GO_TOKEN` | `GO_RATIFY_CROSS_SECTIONAL_REALIZED_VOLATILITY_RANK_ROTATION_V0_RESEARCH_SCOPE_NO_EVAL_NO_RUNTIME_AUTHORITY_V0` |
+| `GOVERNANCE_REF` | `docs/governance/POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0.md` |
+| `CONFIG_REF` | `config/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.json` |
+| `offline_only` | `true` |
+| `non_authorizing` | `true` |
+| `RUNTIME_EFFECT` | `NONE` |
+| `AUTHORITY_EFFECT` | `NONE` |
+| `TRADING_EFFECT` | `NONE` |
+
 ---
 
 ## PR #4629 Evidence-Drift (historisch, transparent)

--- a/docs/governance/POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0.md
+++ b/docs/governance/POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0.md
@@ -1,0 +1,141 @@
+# Post-PR4941 Material-Different Offline-Only Research Scope Discovery and Ratification Prep v0
+
+---
+docs_token: DOCS_TOKEN_POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0
+STATUS: SCOPE_DISCOVERY_AND_RATIFICATION_PREP_COMPLETE
+scope: governance, documentation-only, non-authorizing
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+SCHEDULER_RUNTIME_ALLOWED: false
+---
+
+> **Non-authorizing:** Discovery und Ratifikation-Vorbereitung für genau einen material-differenten offline-only Research-Scope nach manifest-verifizierter PR4939/PR4940 Terminal-Negative-Evidence. Keine Economic Evaluation. Keine Binding-Ratifikation in diesem Scope. Kein Same-Binding-Retry, keine Parameterrettung, keine Runtime-Authority. Market-Airport ausgeschlossen.
+
+## A. Verdict
+
+| Feld | Wert |
+|---|---|
+| `VERDICT` | `SCOPE_DISCOVERY_AND_RATIFICATION_PREP_COMPLETE` |
+| `PROCESS_CLASSIFICATION` | `MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP` |
+| `SCOPE_CLASSIFICATION` | `PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_NO_EVAL_NO_RUNTIME_AUTHORITY_V0` |
+| `OPERATOR_GO` | `GO_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_NO_EVAL_NO_RUNTIME_AUTHORITY_V0` |
+| `GO_TOKEN_CONSUMPTION` | `CONSUMED_ONCE_FOR_DISCOVERY_AND_RATIFICATION_PREP_ONLY` |
+| `CURRENT_BASELINE_PR` | `4941` |
+| `BASE_HEAD` | `f75e32a19f6708c8be1ab313636a1f0047e6cab1` |
+| `PARENT_PR4939_CLOSEOUT_DIR` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr4939_final_research_fleet_negative_evidence_terminalization_merge_closeout_20260706T181802Z` |
+| `PARENT_PR4939_CLOSEOUT_MANIFEST_VERIFY_RC` | `0` |
+| `PARENT_PR4940_CLOSEOUT_DIR` | `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr4940_final_fleet_terminalization_and_next_material_research_boundary_merge_closeout_20260706T182841Z` |
+| `PARENT_PR4940_CLOSEOUT_MANIFEST_VERIFY_RC` | `0` |
+| `EVIDENCE_CLASS_ID` | `POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0` |
+| `SCOPE_ID` | `POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0` |
+| `FINAL_RESEARCH_FLEET` | `trend_following,bollinger_bands,momentum_1h` |
+| `FINAL_RESEARCH_FLEET_STATUS` | `NEGATIVE_EVIDENCE_TERMINAL_FOR_UNCHANGED_BINDINGS` |
+| `AGGREGATE_FLEET_VERDICT` | `FLEET_ECONOMIC_VALIDITY_FAIL` |
+| `ECONOMIC_VALIDITY_OFFLINE_GATE_PASS` | `false` |
+| `NEGATIVE_EVIDENCE_TERMINAL_FOR_UNCHANGED_BINDINGS` | `true` |
+| `SELECTED_NEXT_SCOPE_BOUNDARY` | `cross_sectional_realized_volatility_rank_rotation&#47;v0` |
+| `SELECTED_STRATEGY_ID` | `cross_sectional_realized_volatility_rank_rotation` |
+| `SELECTED_STRATEGY_VERSION` | `v0` |
+| `MATERIAL_DIFFERENCE_AXES` | `signal_family,target_phenomenon,data_feature_class,portfolio_aggregation,entry_exit_hypothesis,universe_ranking` |
+| `REUSE_FIRST_DECISION` | `REUSE_PIT_CROSS_SECTIONAL_PANEL_DATASET_AND_RELATIVE_STRENGTH_RANKING_SEMANTICS_PATTERN_WITH_NARROW_REALIZED_VOL_FEATURE_ADAPTER_ONLY` |
+| `FUTURES_ONLY` | `true` |
+| `BITCOIN_DIRECTION_ALLOWED` | `false` |
+| `MARKET_AIRPORT_EXCLUDED` | `true` |
+| `SCOPE_DISCOVERY_AND_RATIFICATION_PREP_ONLY` | `true` |
+| `RATIFICATION_PREP_ONLY` | `true` |
+| `EVALUATION_EXECUTED` | `false` |
+| `ECONOMIC_EVALUATION_AUTHORIZED` | `false` |
+| `RUNTIME_AUTHORITY_TOUCHED` | `false` |
+| `PROMOTION_GRANTED` | `false` |
+| `UNCHANGED_RETRY_ALLOWED` | `false` |
+| `REQUIRED_NEXT_GO_FOR_SCOPE_RATIFICATION` | `GO_RATIFY_CROSS_SECTIONAL_REALIZED_VOLATILITY_RANK_ROTATION_V0_RESEARCH_SCOPE_NO_EVAL_NO_RUNTIME_AUTHORITY_V0` |
+| `runtime_effect` | `NONE` |
+| `authority_effect` | `NONE` |
+| `economic_evaluation_effect` | `NONE` |
+| `trading_effect` | `NONE` |
+
+**Authoritative owners (reuse, nicht ersetzen):**
+
+- Scope config: `config/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.json`
+- Materialization owner: `scripts/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.py`
+- Validation owner: `src/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.py`
+- Parent PR4940 boundary: `docs/governance/POST_PR4939_FINAL_RESEARCH_FLEET_NEGATIVE_EVIDENCE_TERMINALIZATION_AND_NEXT_MATERIAL_RESEARCH_BOUNDARY_V0.md`
+- Progress registry: `docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md`
+
+## B. Excluded Failed Bindings (bindend)
+
+| Binding | Terminal Verdict | Retry Allowed |
+|---|---|---|
+| `trend_following&#47;v1` | `FAIL` | `false` |
+| `bollinger_bands&#47;v1` | `FAIL` | `false` |
+| `momentum_1h&#47;v1` | `FAIL` | `false` |
+
+Keine unveränderten Final-Fleet-Binding-Reexecutions. Keine Threshold-Lowering. Keine Parameter-Drift-Retries.
+
+## C. Candidate Family Inventory
+
+| Candidate Family | Disposition | Exclusion / Selection Rationale |
+|---|---|---|
+| `trend_following&#47;v1` | `EXCLUDED_TERMINAL` | unchanged final fleet binding terminal FAIL |
+| `bollinger_bands&#47;v1` | `EXCLUDED_TERMINAL` | unchanged final fleet binding terminal FAIL |
+| `momentum_1h&#47;v1` | `EXCLUDED_TERMINAL` | unchanged final fleet binding terminal FAIL |
+| `cross_sectional_funding_rate_score_family` | `EXCLUDED_TERMINAL` | fleet `COMPLETE_NO_PASS`, score family exhausted |
+| `cross_sectional_relative_strength&#47;v0` | `EXCLUDED_TERMINAL` | price-return rank axis terminal `COMPLETE_FAIL` |
+| `okx_full_panel_cross_sectional_ranking_archetype` | `EXCLUDED_TERMINAL` | ranking archetype terminal negative evidence |
+| `v2_fleet_archetype_retries` | `EXCLUDED_NEAR_DUPLICATE` | near-duplicate of failed v1 trend/mr/momentum |
+| `panel_skewness_reversion` | `EXCLUDED_NEAR_DUPLICATE` | same panel mean-reversion higher-moment family |
+| `cross_sectional_funding_rate_regime_transition_filter` | `EXCLUDED_NEAR_DUPLICATE` | near-duplicate persistence reversal filter |
+| `cross_sectional_realized_volatility_rank_rotation&#47;v0` | `SELECTED_RECOMMENDED` | material-different volatility-rank axis, reuse-first compatible |
+
+## D. Selected Next Scope Boundary (exactly one)
+
+| Feld | Wert |
+|---|---|
+| `SELECTED_NEXT_SCOPE_BOUNDARY` | `cross_sectional_realized_volatility_rank_rotation&#47;v0` |
+| `RESEARCH_HYPOTHESIS` | `NON_BITCOIN_PERPETUAL_PANEL_REALIZED_VOLATILITY_DISPERSION_SUPPORTS_CROSS_SECTIONAL_LOW_VOL_LONG_HIGH_VOL_SHORT_ROTATION_EDGE` |
+| `SIGNAL_FAMILY` | `realized_volatility_rank` |
+| `TARGET_PHENOMENON` | `volatility_dispersion_rotation` |
+| `DATA_FEATURE_CLASS` | `panel_ohlcv_derived_realized_volatility` |
+| `AGGREGATION_MECHANISM` | `cross_sectional_rank_single_slot_rotation` |
+| `ENTRY_EXIT_HYPOTHESIS` | `long_lowest_realized_vol_short_highest_realized_vol` |
+| `UNIVERSE_RANKING` | `pit_okx_linear_usdt_non_bitcoin_perpetual_panel` |
+
+## E. Material Difference Matrix
+
+| Axis | Failed Final Fleet / Prior Families | Selected Scope |
+|---|---|---|
+| Signal family | price trend, mean-reversion bands, price momentum, funding scores, price-return rank | realized volatility rank |
+| Target phenomenon | directional edge on single slot or funding score | volatility dispersion rotation |
+| Data feature class | OHLCV trend/band/momentum; funding panel scores | panel OHLCV-derived realized vol |
+| Aggregation | single-slot ETH narrow adapter or funding cross-section | cross-sectional vol rank rotation |
+| Entry/exit | trend/band/momentum thresholds; funding z-scores | low-vol long / high-vol short rank selection |
+| Regime filter | persistence/reversal filter (terminal) | none — not filter-overlay near-duplicate |
+
+Material difference confirmed. Economic gates and safety boundaries are not weakened.
+
+## F. Reuse-First Decision
+
+| Surface | Reuse Owner |
+|---|---|
+| Panel dataset | `pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1` |
+| Ranking semantics pattern | `config/research/cross_sectional_relative_strength_non_bitcoin_perpetuals_v0_ranking_semantics_binding_v0.json` |
+| Scope ratification pattern | `cross_sectional_funding_rate_*_research_scope_ratification_v0` family |
+| Offline evaluation infra pattern | `cross_sectional_relative_strength_v0_offline_economic_evaluation_execution_v0` |
+| Narrow adapter need | realized-vol feature computation from panel OHLCV only — no core/runtime mutation |
+| Manifest verify | `scripts/ops/primary_evidence_retention_v0.py` |
+
+Keine Core-System-, Master-V2-, Double-Play-, Risk-/Sizing-, Safety-Runtime- oder Market-Airport-Mutation.
+
+## G. Authority Boundary
+
+Scope-Discovery/Ratifikation-Prep ≠ Binding-Ratifikation ≠ Evaluation-Autorisierung.
+
+| Boundary | Value |
+|---|---|
+| `SCOPE_DISCOVERY_AND_RATIFICATION_PREP_ONLY` | `true` |
+| `OFFLINE_ONLY` | `true` |
+| `EVALUATION_EXECUTED` | `false` |
+| `RUNTIME_AUTHORITY_TOUCHED` | `false` |
+| `PROMOTION_GRANTED` | `false` |
+| `UNCHANGED_RETRY_ALLOWED` | `false` |
+| `MARKET_AIRPORT_EXCLUDED` | `true` |

--- a/scripts/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.py
+++ b/scripts/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Materialize post-PR4941 material-different offline-only research scope discovery v0.
+
+Offline-only discovery/ratification-prep evidence bundle. No economic evaluation,
+no binding ratification, no runtime authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.primary_evidence_retention_v0 import (  # noqa: E402
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.research.post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0 import (  # noqa: E402
+    BASE_HEAD,
+    GO_TOKEN,
+    PROCESS_CLASSIFICATION,
+    REQUIRED_MATERIAL_DIFFERENCE_AXES,
+    SCOPE_CLASSIFICATION,
+    SCOPE_ID,
+    SELECTED_NEXT_SCOPE_BOUNDARY,
+    VERDICT,
+    validate_discovery_config_v0,
+)
+
+CONFIRM_GO = GO_TOKEN
+DEFAULT_CONFIG = (
+    _REPO_ROOT / "config/research/post_pr4941_material_different_offline_only_research_scope_"
+    "discovery_and_ratification_prep_v0.json"
+)
+DEFAULT_DOC = (
+    _REPO_ROOT / "docs/governance/POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_"
+    "DISCOVERY_AND_RATIFICATION_PREP_V0.md"
+)
+DEFAULT_ARCHIVE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+OUTPUT_PREFIX = (
+    "pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep"
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _die(message: str, code: int = 2) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"not_object:{path}")
+    return payload
+
+
+def _sha256_path(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _git_snapshot(*, fallback_head: str | None = None) -> dict[str, str]:
+    def _run(args: list[str]) -> str | None:
+        try:
+            return subprocess.check_output(["git", *args], cwd=_REPO_ROOT, text=True).strip()
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return None
+
+    head = _run(["rev-parse", "HEAD"]) or fallback_head or "unknown"
+    origin_main = _run(["rev-parse", "origin/main"]) or fallback_head or head
+    branch = _run(["branch", "--show-current"]) or "unknown"
+    status_short = _run(["status", "--short"]) or "(clean)"
+    return {
+        "head": head,
+        "origin_main": origin_main,
+        "branch": branch,
+        "status_short": status_short,
+    }
+
+
+def _verify_source_manifest(source_dir: Path) -> tuple[int, str]:
+    if not (source_dir / "MANIFEST.sha256").is_file():
+        return -1, "manifest_missing"
+    ok, msg = verify_manifest_sha256(source_dir)
+    return (0 if ok else 1), msg or "ok"
+
+
+def validate_config(config: dict[str, Any]) -> list[str]:
+    validation = validate_discovery_config_v0(config, repo_root=_REPO_ROOT)
+    return list(validation.reasons)
+
+
+def _build_failed_binding_exclusion_matrix(config: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "aggregate_fleet_verdict": "FLEET_ECONOMIC_VALIDITY_FAIL",
+        "economic_validity_offline_gate_pass": False,
+        "excluded_failed_bindings": config["excluded_failed_bindings"],
+        "final_research_fleet": config["final_research_fleet"],
+        "negative_evidence_terminal_for_unchanged_bindings": True,
+        "unchanged_retry_allowed": False,
+    }
+
+
+def _build_material_difference_matrix(config: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "material_difference_axes": config["material_difference_axes"],
+        "material_difference_confirmed": True,
+        "near_duplicate_archetype_blocked": True,
+        "selected_next_scope_boundary": config["selected_next_scope_boundary"],
+        "threshold_lowering_blocked": True,
+    }
+
+
+def _build_reuse_first_matrix(config: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "narrow_adapter_need": "realized_vol_feature_from_panel_ohlcv_only",
+        "panel_dataset_owner": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+        "ranking_semantics_pattern_owner": (
+            "config/research/cross_sectional_relative_strength_non_bitcoin_perpetuals_v0_"
+            "ranking_semantics_binding_v0.json"
+        ),
+        "reuse_first_decision": config["reuse_first_decision"],
+        "scope_ratification_pattern_owner": "cross_sectional_funding_rate_research_scope_ratification_v0_family",
+    }
+
+
+def run_post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0(
+    *,
+    confirm_go_token: str,
+    config_path: Path = DEFAULT_CONFIG,
+    governance_doc_path: Path = DEFAULT_DOC,
+    output_dir: Path,
+    archive_root: Path = DEFAULT_ARCHIVE_ROOT,
+) -> dict[str, Any]:
+    del archive_root
+    if confirm_go_token != CONFIRM_GO:
+        _die("ERR:invalid confirm go token")
+
+    if not config_path.is_file():
+        _die(f"ERR:missing config: {config_path}")
+    if not governance_doc_path.is_file():
+        _die(f"ERR:missing governance doc: {governance_doc_path}")
+
+    config = _load_json(config_path)
+    errors = validate_config(config)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        _die("ERR:config validation failed", code=1)
+
+    output_dir = output_dir.resolve()
+    if output_dir.exists() and any(output_dir.iterdir()):
+        _die(f"ERR:output dir not empty: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    pr4939_dir = Path(config["parent_pr4939_closeout_dir"])
+    pr4940_dir = Path(config["parent_pr4940_closeout_dir"])
+    pr4939_rc, pr4939_msg = _verify_source_manifest(pr4939_dir)
+    pr4940_rc, pr4940_msg = _verify_source_manifest(pr4940_dir)
+    if pr4939_rc != int(config.get("parent_pr4939_closeout_manifest_verify_rc", 0)):
+        _die(f"ERR:pr4939 closeout manifest verify rc mismatch: {pr4939_dir}")
+    if pr4940_rc != int(config.get("parent_pr4940_closeout_manifest_verify_rc", 0)):
+        _die(f"ERR:pr4940 closeout manifest verify rc mismatch: {pr4940_dir}")
+
+    git_snapshot = _git_snapshot(fallback_head=config.get("baseline_head"))
+    exclusion_matrix = _build_failed_binding_exclusion_matrix(config)
+    material_matrix = _build_material_difference_matrix(config)
+    reuse_matrix = _build_reuse_first_matrix(config)
+
+    (output_dir / "git_context.txt").write_text(
+        "\n".join(
+            [
+                f"HEAD={git_snapshot['head']}",
+                f"ORIGIN_MAIN={git_snapshot['origin_main']}",
+                f"BRANCH={git_snapshot['branch']}",
+                f"STATUS={git_snapshot['status_short']}",
+                f"BASE_HEAD={BASE_HEAD}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "pr4939_closeout_manifest_verify.log").write_text(
+        f"dir={pr4939_dir}\nrc={pr4939_rc}\nmsg={pr4939_msg}\n",
+        encoding="utf-8",
+    )
+    (output_dir / "pr4940_closeout_manifest_verify.log").write_text(
+        f"dir={pr4940_dir}\nrc={pr4940_rc}\nmsg={pr4940_msg}\n",
+        encoding="utf-8",
+    )
+    (output_dir / "FAILED_BINDING_EXCLUSION_MATRIX.json").write_text(
+        json.dumps(exclusion_matrix, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "MATERIAL_DIFFERENCE_MATRIX.json").write_text(
+        json.dumps(material_matrix, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "REUSE_FIRST_MATRIX.json").write_text(
+        json.dumps(reuse_matrix, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "CANDIDATE_FAMILY_INVENTORY.json").write_text(
+        json.dumps(config["candidate_family_inventory"], indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "SELECTED_NEXT_SCOPE_BOUNDARY.md").write_text(
+        "\n".join(
+            [
+                "# Selected Next Scope Boundary",
+                "",
+                f"- selected_next_scope_boundary: `{config['selected_next_scope_boundary']}`",
+                f"- selected_strategy_id: `{config['selected_strategy_id']}`",
+                f"- selected_strategy_version: `{config['selected_strategy_version']}`",
+                f"- reuse_first_decision: `{config['reuse_first_decision']}`",
+                f"- required_next_go_for_scope_ratification: `{config['required_next_go_for_scope_ratification']}`",
+                "",
+                "## Material Difference Axes",
+                "",
+            ]
+            + [f"- `{axis}`" for axis in REQUIRED_MATERIAL_DIFFERENCE_AXES]
+            + [""]
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "NO_EVAL_NO_RUNTIME_AUTHORITY_STATEMENT.md").write_text(
+        "\n".join(
+            [
+                "# No-Eval / No-Runtime Authority Statement",
+                "",
+                "- evaluation_executed: `false`",
+                "- economic_evaluation_authorized: `false`",
+                "- runtime_authority_touched: `false`",
+                "- promotion_granted: `false`",
+                "- unchanged_retry_allowed: `false`",
+                "- market_airport_excluded: `true`",
+                "- scope_discovery_and_ratification_prep_only: `true`",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "SCOPE_DISCOVERY_SUMMARY.json").write_text(
+        json.dumps(
+            {
+                "config_sha256": _sha256_path(config_path),
+                "doc_sha256": _sha256_path(governance_doc_path),
+                "go_token": CONFIRM_GO,
+                "go_token_consumption": config["go_token_consumption"],
+                "material_difference_axes": config["material_difference_axes"],
+                "process_classification": PROCESS_CLASSIFICATION,
+                "scope_classification": SCOPE_CLASSIFICATION,
+                "scope_id": SCOPE_ID,
+                "selected_next_scope_boundary": config["selected_next_scope_boundary"],
+                "status": VERDICT,
+                "verdict": VERDICT,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "FINAL_REPORT.md").write_text(
+        "\n".join(
+            [
+                f"VERDICT={VERDICT}",
+                f"PROCESS_CLASSIFICATION={PROCESS_CLASSIFICATION}",
+                f"SCOPE_CLASSIFICATION={SCOPE_CLASSIFICATION}",
+                "GO_TOKEN_CONSUMPTION=CONSUMED_ONCE_FOR_DISCOVERY_AND_RATIFICATION_PREP_ONLY",
+                f"BASE_HEAD={git_snapshot['head']}",
+                f"ORIGIN_MAIN={git_snapshot['origin_main']}",
+                f"WORKTREE_STATUS={git_snapshot['status_short']}",
+                "PR=not_created",
+                "PR_URL=none",
+                f"SELECTED_NEXT_SCOPE_BOUNDARY={SELECTED_NEXT_SCOPE_BOUNDARY}",
+                "EVALUATION_EXECUTED=false",
+                "RUNTIME_AUTHORITY_TOUCHED=false",
+                "PROMOTION_GRANTED=false",
+                f"PR4939_MANIFEST_VERIFY_RC={pr4939_rc}",
+                f"PR4940_MANIFEST_VERIFY_RC={pr4940_rc}",
+                f"DURABLE_EVIDENCE_DIR={output_dir}",
+                "MANIFEST_VERIFY_RC=pending",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    write_manifest_sha256(output_dir)
+    ok, msg = verify_manifest_sha256(output_dir)
+    manifest_rc = 0 if ok else 1
+    if manifest_rc != 0:
+        _die(f"ERR:manifest verify failed: {output_dir} ({msg})")
+
+    final_report = output_dir / "FINAL_REPORT.md"
+    final_report.write_text(
+        final_report.read_text(encoding="utf-8").replace(
+            "MANIFEST_VERIFY_RC=pending", f"MANIFEST_VERIFY_RC={manifest_rc}"
+        ),
+        encoding="utf-8",
+    )
+    write_manifest_sha256(output_dir)
+    ok, msg = verify_manifest_sha256(output_dir)
+    manifest_rc = 0 if ok else 1
+    if manifest_rc != 0:
+        _die(f"ERR:manifest verify failed after final report update: {output_dir} ({msg})")
+
+    return {
+        "durable_evidence_path": str(output_dir),
+        "manifest_verify_rc": manifest_rc,
+        "material_difference_axes": config["material_difference_axes"],
+        "pr4939_manifest_verify_rc": pr4939_rc,
+        "pr4940_manifest_verify_rc": pr4940_rc,
+        "process_classification": PROCESS_CLASSIFICATION,
+        "reuse_first_decision": config["reuse_first_decision"],
+        "scope_classification": SCOPE_CLASSIFICATION,
+        "scope_id": SCOPE_ID,
+        "selected_next_scope_boundary": config["selected_next_scope_boundary"],
+        "verdict": VERDICT,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Materialize post-PR4941 material-different offline-only research scope "
+            "discovery and ratification prep v0"
+        )
+    )
+    parser.add_argument("--confirm-go-token", required=True, choices=[CONFIRM_GO])
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--governance-doc", type=Path, default=DEFAULT_DOC)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_ARCHIVE_ROOT)
+    args = parser.parse_args()
+
+    result = run_post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0(
+        confirm_go_token=args.confirm_go_token,
+        config_path=args.config,
+        governance_doc_path=args.governance_doc,
+        output_dir=args.out,
+        archive_root=args.durable_evidence_root,
+    )
+    print(f"VERDICT={VERDICT}")
+    print(f"SCOPE_ID={result['scope_id']}")
+    print(f"SELECTED_NEXT_SCOPE_BOUNDARY={result['selected_next_scope_boundary']}")
+    print(f"DURABLE_EVIDENCE_BUNDLE={result['durable_evidence_path']}")
+    print(f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}")
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.py
+++ b/src/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.py
@@ -1,0 +1,171 @@
+"""Post-PR4941 material-different offline-only research scope discovery and ratification prep v0.
+
+Deterministic, fail-closed validation of scope discovery output after PR4939/PR4940
+terminal negative evidence. No economic evaluation, no binding ratification, no runtime
+or order effect.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+PACKAGE_MARKER = (
+    "POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_"
+    "RATIFICATION_PREP_V0=true"
+)
+
+SCHEMA_VERSION = (
+    "post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep.v0"
+)
+SCOPE_ID = (
+    "POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0"
+)
+CONFIG_REL_PATH = (
+    "config/research/post_pr4941_material_different_offline_only_research_scope_"
+    "discovery_and_ratification_prep_v0.json"
+)
+GO_TOKEN = (
+    "GO_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_"
+    "RATIFICATION_PREP_NO_EVAL_NO_RUNTIME_AUTHORITY_V0"
+)
+PROCESS_CLASSIFICATION = (
+    "MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP"
+)
+SCOPE_CLASSIFICATION = (
+    "PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_"
+    "PREP_NO_EVAL_NO_RUNTIME_AUTHORITY_V0"
+)
+VERDICT = "SCOPE_DISCOVERY_AND_RATIFICATION_PREP_COMPLETE"
+SELECTED_NEXT_SCOPE_BOUNDARY = "cross_sectional_realized_volatility_rank_rotation/v0"
+SELECTED_STRATEGY_ID = "cross_sectional_realized_volatility_rank_rotation"
+SELECTED_STRATEGY_VERSION = "v0"
+BASE_HEAD = "f75e32a19f6708c8be1ab313636a1f0047e6cab1"
+EXCLUDED_FAILED_BINDINGS = (
+    "trend_following/v1",
+    "bollinger_bands/v1",
+    "momentum_1h/v1",
+)
+REQUIRED_MATERIAL_DIFFERENCE_AXES = (
+    "signal_family:realized_volatility_rank_vs_price_return_rank_funding_score_single_slot_trend_mr_momentum",
+    "target_phenomenon:volatility_dispersion_rotation_hypothesis",
+    "data_feature_class:panel_ohlcv_derived_realized_volatility",
+    "portfolio_aggregation:cross_sectional_rank_single_slot_rotation",
+    "entry_exit_hypothesis:low_realized_vol_long_high_realized_vol_short",
+    "universe_ranking:non_bitcoin_perpetual_panel_volatility_rank",
+)
+
+REQUIRED_CONTRACT_FLAGS: tuple[tuple[str, Any], ...] = (
+    ("scope_discovery_and_ratification_prep_only", True),
+    ("ratification_prep_only", True),
+    ("discovery_and_ratification_prep_only", True),
+    ("offline_only", True),
+    ("economic_evaluation_authorized", False),
+    ("economic_evaluation_executed", False),
+    ("evaluation_executed", False),
+    ("runtime_authority_touched", False),
+    ("promotion_granted", False),
+    ("unchanged_retry_allowed", False),
+    ("negative_evidence_terminal_for_unchanged_bindings", True),
+    ("economic_validity_offline_gate_pass", False),
+    ("runtime_rewire_admissible", False),
+    ("live_authorized", False),
+    ("no_runtime_authority", True),
+    ("market_airport_excluded", True),
+    ("futures_only", True),
+    ("bitcoin_direction_allowed", False),
+)
+
+
+@dataclass(frozen=True)
+class DiscoveryValidationResultV0:
+    valid: bool
+    reasons: tuple[str, ...]
+
+
+def validate_discovery_config_v0(
+    config: Mapping[str, Any],
+    *,
+    repo_root: Path | None = None,
+) -> DiscoveryValidationResultV0:
+    reasons: list[str] = []
+
+    if config.get("scope_id") != SCOPE_ID:
+        reasons.append("UNEXPECTED_SCOPE_ID")
+    if config.get("go_token") != GO_TOKEN:
+        reasons.append("UNEXPECTED_GO_TOKEN")
+    if config.get("verdict") != VERDICT:
+        reasons.append("UNEXPECTED_VERDICT")
+    if config.get("process_classification") != PROCESS_CLASSIFICATION:
+        reasons.append("UNEXPECTED_PROCESS_CLASSIFICATION")
+    if config.get("scope_classification") != SCOPE_CLASSIFICATION:
+        reasons.append("UNEXPECTED_SCOPE_CLASSIFICATION")
+    if config.get("selected_next_scope_boundary") != SELECTED_NEXT_SCOPE_BOUNDARY:
+        reasons.append("UNEXPECTED_SELECTED_NEXT_SCOPE_BOUNDARY")
+    if config.get("selected_strategy_id") != SELECTED_STRATEGY_ID:
+        reasons.append("UNEXPECTED_SELECTED_STRATEGY_ID")
+    if config.get("selected_strategy_version") != SELECTED_STRATEGY_VERSION:
+        reasons.append("UNEXPECTED_SELECTED_STRATEGY_VERSION")
+    if list(config.get("excluded_failed_bindings", [])) != list(EXCLUDED_FAILED_BINDINGS):
+        reasons.append("EXCLUDED_FAILED_BINDINGS_MISMATCH")
+
+    axes = config.get("material_difference_axes", [])
+    if list(axes) != list(REQUIRED_MATERIAL_DIFFERENCE_AXES):
+        reasons.append("MATERIAL_DIFFERENCE_AXES_MISMATCH")
+
+    for field, expected in REQUIRED_CONTRACT_FLAGS:
+        if config.get(field) is not expected:
+            reasons.append(f"CONTRACT_FLAG_MISMATCH:{field}")
+
+    inventory = config.get("candidate_family_inventory", [])
+    selected = [entry for entry in inventory if entry.get("disposition") == "SELECTED_RECOMMENDED"]
+    if len(selected) != 1:
+        reasons.append("EXACTLY_ONE_SELECTED_CANDIDATE_FAMILY_REQUIRED")
+    elif selected[0].get("candidate_family") != SELECTED_NEXT_SCOPE_BOUNDARY:
+        reasons.append("SELECTED_INVENTORY_FAMILY_MISMATCH")
+
+    blocked = set(config.get("blocked_actions", []))
+    for forbidden in (
+        "THRESHOLD_LOWERING",
+        "UNCHANGED_BINDING_RETRY",
+        "EVALUATION_EXECUTION_IN_THIS_SCOPE",
+        "BINDING_RATIFICATION_IN_THIS_SCOPE",
+        "MARKET_AIRPORT",
+        "LIVE",
+        "ORDERS",
+    ):
+        if forbidden not in blocked:
+            reasons.append(f"MISSING_BLOCKED_ACTION:{forbidden}")
+
+    if repo_root is not None and not (repo_root / CONFIG_REL_PATH).is_file():
+        reasons.append("CONFIG_OWNER_MISSING")
+
+    return DiscoveryValidationResultV0(valid=not reasons, reasons=tuple(reasons))
+
+
+def load_discovery_config_v0(repo_root: Path) -> dict[str, Any]:
+    payload = json.loads((repo_root / CONFIG_REL_PATH).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"not_object:{CONFIG_REL_PATH}")
+    return payload
+
+
+__all__ = [
+    "BASE_HEAD",
+    "CONFIG_REL_PATH",
+    "EXCLUDED_FAILED_BINDINGS",
+    "GO_TOKEN",
+    "PROCESS_CLASSIFICATION",
+    "REQUIRED_MATERIAL_DIFFERENCE_AXES",
+    "SCOPE_CLASSIFICATION",
+    "SCOPE_ID",
+    "SELECTED_NEXT_SCOPE_BOUNDARY",
+    "SELECTED_STRATEGY_ID",
+    "SELECTED_STRATEGY_VERSION",
+    "VERDICT",
+    "DiscoveryValidationResultV0",
+    "load_discovery_config_v0",
+    "validate_discovery_config_v0",
+]

--- a/tests/ops/test_post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0_contract.py
+++ b/tests/ops/test_post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0_contract.py
@@ -1,0 +1,251 @@
+"""Contract tests for post-PR4941 material-different research scope discovery prep v0."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from scripts.ops.validate_docs_token_policy import DocsTokenPolicyValidator
+from scripts.research.post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0 import (
+    CONFIRM_GO,
+    PROCESS_CLASSIFICATION,
+    SCOPE_CLASSIFICATION,
+    run_post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0,
+    validate_config,
+)
+from src.research.post_pr4940_final_research_fleet_negative_evidence_terminalization_and_next_material_research_boundary_v0 import (
+    EXPECTED_CANDIDATE_RESULTS,
+    FINAL_RESEARCH_FLEET,
+)
+from src.research.post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0 import (
+    BASE_HEAD,
+    EXCLUDED_FAILED_BINDINGS,
+    REQUIRED_MATERIAL_DIFFERENCE_AXES,
+    SCOPE_ID,
+    SELECTED_NEXT_SCOPE_BOUNDARY,
+    VERDICT,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCOPE_CONFIG = (
+    REPO_ROOT / "config/research/post_pr4941_material_different_offline_only_research_scope_"
+    "discovery_and_ratification_prep_v0.json"
+)
+GOVERNANCE_DOC = (
+    REPO_ROOT / "docs/governance/POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_"
+    "DISCOVERY_AND_RATIFICATION_PREP_V0.md"
+)
+SCOPE_SCRIPT = (
+    REPO_ROOT / "scripts/research/post_pr4941_material_different_offline_only_research_scope_"
+    "discovery_and_ratification_prep_v0.py"
+)
+EVIDENCE_CLASS_ID = (
+    "POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0"
+)
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+PR4939_CLOSEOUT_DIR = (
+    ARCHIVE_ROOT
+    / "research/pr4939_final_research_fleet_negative_evidence_terminalization_merge_closeout_20260706T181802Z"
+)
+PR4940_CLOSEOUT_DIR = (
+    ARCHIVE_ROOT
+    / "research/pr4940_final_fleet_terminalization_and_next_material_research_boundary_merge_closeout_20260706T182841Z"
+)
+FORBIDDEN_RUNTIME_ACTIONS = (
+    "RUNTIME",
+    "SHADOW",
+    "PAPER",
+    "TESTNET",
+    "SCHEDULER",
+    "ORDERS",
+    "CREDENTIALS",
+    "ARMING",
+    "LIVE",
+    "MARKET_AIRPORT",
+)
+REQUIRED_CONTRACT_ASSERTIONS = (
+    ("scope_discovery_and_ratification_prep_only", True),
+    ("ratification_prep_only", True),
+    ("discovery_and_ratification_prep_only", True),
+    ("offline_only", True),
+    ("economic_evaluation_authorized", False),
+    ("economic_evaluation_executed", False),
+    ("evaluation_executed", False),
+    ("runtime_authority_touched", False),
+    ("promotion_granted", False),
+    ("unchanged_retry_allowed", False),
+    ("negative_evidence_terminal_for_unchanged_bindings", True),
+    ("economic_validity_offline_gate_pass", False),
+    ("runtime_rewire_admissible", False),
+    ("live_authorized", False),
+    ("no_runtime_authority", True),
+    ("market_airport_excluded", True),
+    ("futures_only", True),
+    ("bitcoin_direction_allowed", False),
+)
+
+
+def _field_value(text: str, field: str) -> str:
+    match = re.search(rf"\| `{re.escape(field)}` \| `([^`]*)` \|", text)
+    assert match, f"missing governance field: {field}"
+    return match.group(1)
+
+
+def _docs_token_marker(token_name: str) -> str:
+    return "docs_" + "token: " + token_name
+
+
+class TestPostPr4941MaterialDifferentOfflineOnlyResearchScopeDiscoveryAndRatificationPrepV0Contract:
+    def test_scope_config_exists_and_parses(self) -> None:
+        assert SCOPE_CONFIG.is_file()
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        assert isinstance(config, dict)
+        assert (
+            config["schema_version"]
+            == "post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep.v0"
+        )
+
+    def test_required_contract_assertions(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        for field, expected in REQUIRED_CONTRACT_ASSERTIONS:
+            assert config[field] is expected, f"contract assertion failed: {field}"
+
+    def test_scope_config_core_fields(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        assert config["status"] == VERDICT
+        assert config["evidence_class_id"] == EVIDENCE_CLASS_ID
+        assert config["scope_id"] == SCOPE_ID
+        assert config["process_classification"] == PROCESS_CLASSIFICATION
+        assert config["scope_classification"] == SCOPE_CLASSIFICATION
+        assert config["go_token"] == CONFIRM_GO
+        assert config["baseline_head"] == BASE_HEAD
+        assert config["selected_next_scope_boundary"] == SELECTED_NEXT_SCOPE_BOUNDARY
+        assert config["excluded_failed_bindings"] == list(EXCLUDED_FAILED_BINDINGS)
+        assert config["material_difference_axes"] == list(REQUIRED_MATERIAL_DIFFERENCE_AXES)
+        assert config["final_research_fleet"] == list(FINAL_RESEARCH_FLEET)
+
+    def test_final_fleet_terminal_fail_state_remains_bound(self) -> None:
+        pr4940_config = json.loads(
+            (
+                REPO_ROOT / "config/research/post_pr4940_final_research_fleet_negative_evidence_"
+                "terminalization_and_next_material_research_boundary_v0.json"
+            ).read_text(encoding="utf-8")
+        )
+        assert pr4940_config["candidate_results"] == EXPECTED_CANDIDATE_RESULTS
+        assert pr4940_config["negative_evidence_terminal_for_unchanged_bindings"] is True
+        assert pr4940_config["unchanged_retry_allowed"] is False
+
+    def test_exactly_one_selected_candidate_family(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        selected = [
+            entry
+            for entry in config["candidate_family_inventory"]
+            if entry["disposition"] == "SELECTED_RECOMMENDED"
+        ]
+        assert len(selected) == 1
+        assert selected[0]["candidate_family"] == SELECTED_NEXT_SCOPE_BOUNDARY
+
+    def test_blocked_actions_include_forbidden_runtime(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        blocked = set(config["blocked_actions"])
+        for action in FORBIDDEN_RUNTIME_ACTIONS:
+            assert action in blocked
+        assert "EVALUATION_EXECUTION_IN_THIS_SCOPE" in blocked
+        assert "UNCHANGED_BINDING_RETRY" in blocked
+        assert "BINDING_RATIFICATION_IN_THIS_SCOPE" in blocked
+
+    def test_validate_config_accepts_canonical_config(self) -> None:
+        config = json.loads(SCOPE_CONFIG.read_text(encoding="utf-8"))
+        assert validate_config(config) == []
+
+    def test_governance_doc_states_discovery_prep_and_selected_scope(self) -> None:
+        text = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        assert SCOPE_ID in text
+        assert _field_value(text, "VERDICT") == VERDICT
+        assert _field_value(text, "SELECTED_NEXT_SCOPE_BOUNDARY") == (
+            "cross_sectional_realized_volatility_rank_rotation&#47;v0"
+        )
+        assert _field_value(text, "EVALUATION_EXECUTED") == "false"
+        assert _field_value(text, "RUNTIME_AUTHORITY_TOUCHED") == "false"
+        assert _field_value(text, "PROMOTION_GRANTED") == "false"
+        assert _field_value(text, "UNCHANGED_RETRY_ALLOWED") == "false"
+        assert _field_value(text, "MARKET_AIRPORT_EXCLUDED") == "true"
+
+    def test_docs_token_policy(self) -> None:
+        validator = DocsTokenPolicyValidator(REPO_ROOT)
+        result = validator.scan_file(GOVERNANCE_DOC)
+        assert result.passed, [(v.line, v.token, v.message) for v in result.violations]
+
+    def test_parent_closeout_manifests_verify(self) -> None:
+        assert PR4939_CLOSEOUT_DIR.is_dir()
+        assert PR4940_CLOSEOUT_DIR.is_dir()
+        ok4939, _ = verify_manifest_sha256(PR4939_CLOSEOUT_DIR)
+        ok4940, _ = verify_manifest_sha256(PR4940_CLOSEOUT_DIR)
+        assert ok4939 is True
+        assert ok4940 is True
+
+    def test_materialization_produces_manifest_verified_bundle(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "bundle"
+        result = run_post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0(
+            confirm_go_token=CONFIRM_GO,
+            output_dir=output_dir,
+        )
+        assert result["verdict"] == VERDICT
+        assert result["selected_next_scope_boundary"] == SELECTED_NEXT_SCOPE_BOUNDARY
+        assert result["manifest_verify_rc"] == 0
+        assert result["pr4939_manifest_verify_rc"] == 0
+        assert result["pr4940_manifest_verify_rc"] == 0
+        for artifact in (
+            "FINAL_REPORT.md",
+            "FAILED_BINDING_EXCLUSION_MATRIX.json",
+            "MATERIAL_DIFFERENCE_MATRIX.json",
+            "REUSE_FIRST_MATRIX.json",
+            "SELECTED_NEXT_SCOPE_BOUNDARY.md",
+            "NO_EVAL_NO_RUNTIME_AUTHORITY_STATEMENT.md",
+            "MANIFEST.sha256",
+        ):
+            assert (output_dir / artifact).is_file()
+        ok, _msg = verify_manifest_sha256(output_dir)
+        assert ok is True
+
+    def test_script_cli_entrypoint(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "cli_bundle"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCOPE_SCRIPT),
+                "--confirm-go-token",
+                CONFIRM_GO,
+                "--out",
+                str(output_dir),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert f"VERDICT={VERDICT}" in proc.stdout
+        assert "MANIFEST_VERIFY_RC=0" in proc.stdout
+
+    def test_no_core_runtime_forbidden_paths_changed(self) -> None:
+        forbidden_prefixes = (
+            "src/execution/",
+            "src/governance/",
+            "src/risk/",
+            "src/trading/master_v2/",
+        )
+        changed_paths = (
+            "config/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.json",
+            "docs/governance/POST_PR4941_MATERIAL_DIFFERENT_OFFLINE_ONLY_RESEARCH_SCOPE_DISCOVERY_AND_RATIFICATION_PREP_V0.md",
+            "scripts/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.py",
+            "src/research/post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0.py",
+            "tests/ops/test_post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0_contract.py",
+            "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md",
+        )
+        for path in changed_paths:
+            assert not any(path.startswith(prefix) for prefix in forbidden_prefixes), path


### PR DESCRIPTION
## Summary
- Verifiziert PR4939/PR4940 Closeout-Evidence (`MANIFEST_VERIFY_RC=0`) und bindet terminal FAIL für unveränderte Final-Fleet-Bindings.
- Inventarisiert ausgeschlossene Kandidatenfamilien und wählt **genau eine** empfohlene Boundary: `cross_sectional_realized_volatility_rank_rotation/v0`.
- Dokumentiert Material-Difference-Achsen (Volatilitäts-Rank vs. Preis-/Funding-/Single-Slot-Archetypen) und Reuse-First-Entscheidung (PIT-Panel + Ranking-Semantik-Pattern, schmaler Realized-Vol-Adapter).

## Scope boundaries
- Discovery/Ratifikation-Prep only — keine Evaluation, keine Binding-Ratifikation, keine Runtime-Authority
- Market-Airport ausgeschlossen; futures-only, Bitcoin-direction disabled
- Kein Retry/Rescue/Threshold-Lowering für terminal FAIL Bindings

## Test plan
- [x] `pytest tests/ops/test_post_pr4941_material_different_offline_only_research_scope_discovery_and_ratification_prep_v0_contract.py`
- [x] `ruff format --check` und `ruff check` grün
- [x] Durable evidence bundle mit `MANIFEST_VERIFY_RC=0`
- [ ] CI required checks grün


Made with [Cursor](https://cursor.com)