### PR TITLE
Double Play composition parity and Prometheus dependency guard v0

### DIFF
--- a/src/trading/master_v2/double_play_composition_scenario_matrix_adapter_v0.py
+++ b/src/trading/master_v2/double_play_composition_scenario_matrix_adapter_v0.py
@@ -1,0 +1,594 @@
+# src/trading/master_v2/double_play_composition_scenario_matrix_adapter_v0.py
+"""
+Scenario replay adapter: routes Double Play composition through the canonical
+``double_play_composition_matrix_v1`` owner while preserving the legacy
+``DoublePlayCompositionDecision`` envelope for scenario replay consumers.
+
+No runtime authority, no semantic extension — wiring-only parity slice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Optional, Tuple
+
+from trading.master_v2.directional_assessment_v1 import (
+    DirectionalAssessmentSide,
+    DirectionalAssessmentStatus,
+    DirectionalAssessmentV1,
+    ScopeEventRefV1,
+)
+from trading.master_v2.double_play_composition import (
+    DoublePlayCompositionBlockReason,
+    DoublePlayCompositionDecision,
+    DoublePlayCompositionInput,
+    DoublePlayCompositionStatus,
+    RequestedSide,
+)
+from trading.master_v2.double_play_composition_matrix_v1 import (
+    DOUBLE_PLAY_COMPOSITION_MATRIX_POLICY_VERSION,
+    BothCandidateOutcome,
+    BothInvalidOutcome,
+    CompositionStatus,
+    CompositionDirectionState,
+    DoublePlayCompositionInputV1,
+    DoublePlayCompositionPolicyV1,
+    DoublePlayCompositionResultV1,
+    PositionManagementContext,
+    compute_composition_input_digest,
+    evaluate_double_play_composition_matrix_v1,
+)
+from trading.master_v2.double_play_state import SideState
+from trading.master_v2.double_play_suitability import (
+    SuitabilityClass,
+    SuitabilityProjectionDecision,
+)
+from trading.master_v2.double_play_survival import (
+    SurvivalEnvelopeDecision,
+    SurvivalEnvelopeStatus,
+)
+from trading.master_v2.suitability_binding_v1 import (
+    SUITABILITY_RANKING_POLICY_VERSION,
+    SuitabilityBindingInputV1,
+    SuitabilityBindingStatus,
+    SuitabilityRankingPolicyV1,
+    SuitabilityRegimeStatus,
+    SuitabilityResultV1,
+    SuitabilityStrategyEntryV1,
+    SuitabilityStrategyRegistryV1,
+    evaluate_suitability_binding_v1,
+    mirror_suitability_strategy_entry_for_short,
+)
+from trading.master_v2.survival_assessment_v1 import (
+    SURVIVAL_ASSESSMENT_POLICY_VERSION,
+    SurvivalAssessmentInputV1,
+    SurvivalAssessmentPolicyV1,
+    SurvivalAssessmentStatus,
+    SurvivalCostInputsV1,
+    SurvivalMetricInputsV1,
+    SurvivalResultV1,
+    evaluate_survival_assessment_v1,
+)
+
+DOUBLE_PLAY_COMPOSITION_SCENARIO_MATRIX_ADAPTER_LAYER_VERSION = "v0"
+DOUBLE_PLAY_COMPOSITION_SCENARIO_MATRIX_ADAPTER_OWNER = (
+    "trading.master_v2.double_play_composition_scenario_matrix_adapter_v0"
+)
+CANONICAL_DOUBLE_PLAY_COMPOSITION_OWNER = "trading.master_v2.double_play_composition_matrix_v1"
+
+_STUB_DIGEST = "a" * 64
+_DEFAULT_POLICY = DoublePlayCompositionPolicyV1(
+    validity_epochs=3,
+    both_candidate_outcome=BothCandidateOutcome.OBSERVE,
+    both_invalid_outcome=BothInvalidOutcome.BLOCKED,
+    policy_version=DOUBLE_PLAY_COMPOSITION_MATRIX_POLICY_VERSION,
+)
+
+
+def _apply_legacy_pre_matrix_gates(
+    inp: DoublePlayCompositionInput,
+) -> Optional[DoublePlayCompositionDecision]:
+    tr = inp.transition
+    side_st = inp.resulting_side_state
+    surv = inp.survival
+    suit = inp.suitability
+    proj = suit.projection
+    req = inp.requested_side
+    rat = inp.capital_slot_ratchet_decision
+    rel = inp.capital_slot_release_decision
+
+    if (
+        tr.live_authorization_granted
+        or suit.live_authorization
+        or proj.live_authorization
+        or surv.live_authorization
+        or (rat is not None and rat.live_authorization)
+        or (rel is not None and rel.live_authorization)
+    ):
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.BLOCKED,
+            block_reasons=(DoublePlayCompositionBlockReason.LIVE_NOT_AUTHORIZED,),
+            reason="Live authorization must not be asserted on sub-decisions; fail closed.",
+            live_authorization=False,
+        )
+
+    if side_st == SideState.KILL_ALL:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.KILL_ALL,
+            block_reasons=(DoublePlayCompositionBlockReason.STATE_KILL_ALL,),
+            reason="State is KILL_ALL; no new activation.",
+            live_authorization=False,
+        )
+
+    if side_st == SideState.CHOP_GUARD_BLOCK:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.CHOP_GUARD,
+            block_reasons=(DoublePlayCompositionBlockReason.STATE_CHOP_GUARD,),
+            reason="Chop guard blocks new activation.",
+            live_authorization=False,
+        )
+
+    if surv.status == SurvivalEnvelopeStatus.BLOCKED or not surv.pre_authorization_eligible:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.BLOCKED,
+            block_reasons=(DoublePlayCompositionBlockReason.SURVIVAL_BLOCKED,),
+            reason="Survival envelope blocks composition.",
+            live_authorization=False,
+        )
+
+    sc = proj.suitability_class
+    if sc == SuitabilityClass.UNKNOWN_SUITABILITY:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.BLOCKED,
+            block_reasons=(DoublePlayCompositionBlockReason.SUITABILITY_UNKNOWN,),
+            reason="Suitability unknown; fail closed.",
+            live_authorization=False,
+        )
+
+    if sc == SuitabilityClass.DISABLED_FOR_CANDIDATE:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.BLOCKED,
+            block_reasons=(DoublePlayCompositionBlockReason.SUITABILITY_DISABLED,),
+            reason="Suitability disabled for candidate.",
+            live_authorization=False,
+        )
+
+    if req == RequestedSide.LONG_BULL and not suit.can_enter_long_bull_pool:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.BLOCKED,
+            block_reasons=(DoublePlayCompositionBlockReason.REQUESTED_SIDE_NOT_ELIGIBLE,),
+            reason="Requested Long/Bull but suitability does not allow long/bull pool.",
+            live_authorization=False,
+        )
+
+    if req == RequestedSide.SHORT_BEAR and not suit.can_enter_short_bear_pool:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.BLOCKED,
+            block_reasons=(DoublePlayCompositionBlockReason.REQUESTED_SIDE_NOT_ELIGIBLE,),
+            reason="Requested Short/Bear but suitability does not allow short/bear pool.",
+            live_authorization=False,
+        )
+
+    if req == RequestedSide.NEUTRAL_OBSERVE and not suit.can_enter_neutral_pool:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.BLOCKED,
+            block_reasons=(DoublePlayCompositionBlockReason.REQUESTED_SIDE_NOT_ELIGIBLE,),
+            reason="Requested neutral observe but suitability does not allow neutral pool.",
+            live_authorization=False,
+        )
+
+    if (
+        req in (RequestedSide.LONG_BULL, RequestedSide.SHORT_BEAR)
+        and side_st == SideState.NEUTRAL_OBSERVE
+    ):
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.BLOCKED,
+            block_reasons=(DoublePlayCompositionBlockReason.STATE_NOT_ACTIVE_OR_ARMED,),
+            reason="Directional request while state is neutral observe; not active/armed.",
+            live_authorization=False,
+        )
+
+    if req == RequestedSide.NEUTRAL_OBSERVE and side_st == SideState.NEUTRAL_OBSERVE:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.OBSERVE_ONLY,
+            block_reasons=(),
+            reason="Neutral observe path; model-level observe only.",
+            live_authorization=False,
+        )
+
+    return None
+
+
+def _apply_legacy_capital_slot_overlay(
+    inp: DoublePlayCompositionInput,
+    *,
+    matrix_status: CompositionStatus,
+) -> DoublePlayCompositionDecision:
+    req = inp.requested_side
+    rat = inp.capital_slot_ratchet_decision
+    rel = inp.capital_slot_release_decision
+
+    if rel is not None and rel.released:
+        if req in (RequestedSide.LONG_BULL, RequestedSide.SHORT_BEAR):
+            return DoublePlayCompositionDecision(
+                status=DoublePlayCompositionStatus.BLOCKED,
+                block_reasons=(DoublePlayCompositionBlockReason.CAPITAL_SLOT_RELEASED,),
+                reason=(
+                    "Capital slot released (inactivity or opportunity cost); "
+                    "no directional model eligibility."
+                ),
+                live_authorization=False,
+            )
+        if req == RequestedSide.NEUTRAL_OBSERVE:
+            return DoublePlayCompositionDecision(
+                status=DoublePlayCompositionStatus.OBSERVE_ONLY,
+                block_reasons=(),
+                reason="Capital slot released; neutral observe only (model-level).",
+                live_authorization=False,
+            )
+
+    if rat is not None and rat.block_reasons:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.BLOCKED,
+            block_reasons=(DoublePlayCompositionBlockReason.CAPITAL_SLOT_RATCHET_BLOCKED,),
+            reason="Capital slot ratchet pre-authorization blocked.",
+            live_authorization=False,
+        )
+
+    if matrix_status is CompositionStatus.CHOP_GUARD_BLOCK:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.CHOP_GUARD,
+            block_reasons=(DoublePlayCompositionBlockReason.STATE_CHOP_GUARD,),
+            reason="Canonical matrix chop guard blocks new activation.",
+            live_authorization=False,
+        )
+
+    if matrix_status in (CompositionStatus.OBSERVE, CompositionStatus.NO_ACTION):
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.OBSERVE_ONLY,
+            block_reasons=(),
+            reason="Canonical matrix observe-only coordination.",
+            live_authorization=False,
+        )
+
+    if matrix_status is CompositionStatus.BLOCKED:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.BLOCKED,
+            block_reasons=(DoublePlayCompositionBlockReason.REQUESTED_SIDE_NOT_ELIGIBLE,),
+            reason="Canonical matrix blocked coordination.",
+            live_authorization=False,
+        )
+
+    if matrix_status in (CompositionStatus.LONG_SELECTED, CompositionStatus.SHORT_SELECTED):
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY,
+            block_reasons=(),
+            reason="All pure gates pass; model-only eligibility (not trading permission).",
+            live_authorization=False,
+        )
+
+    if matrix_status is CompositionStatus.REVERSAL_PREPARATION:
+        return DoublePlayCompositionDecision(
+            status=DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY,
+            block_reasons=(),
+            reason="Reversal preparation; model-only eligibility (not trading permission).",
+            live_authorization=False,
+        )
+
+    return DoublePlayCompositionDecision(
+        status=DoublePlayCompositionStatus.BLOCKED,
+        block_reasons=(DoublePlayCompositionBlockReason.REQUESTED_SIDE_NOT_ELIGIBLE,),
+        reason=f"Unhandled canonical matrix status: {matrix_status.value}",
+        live_authorization=False,
+    )
+
+
+def _legacy_side_to_assessment_statuses(
+    side_st: SideState,
+) -> Tuple[DirectionalAssessmentStatus, DirectionalAssessmentStatus]:
+    if side_st == SideState.CHOP_GUARD_BLOCK:
+        return (
+            DirectionalAssessmentStatus.CONFIRMED,
+            DirectionalAssessmentStatus.CONFIRMED,
+        )
+    if side_st in (SideState.LONG_ACTIVE, SideState.LONG_ARMED):
+        return (
+            DirectionalAssessmentStatus.CONFIRMED,
+            DirectionalAssessmentStatus.OBSERVE,
+        )
+    if side_st in (SideState.SHORT_ACTIVE, SideState.SHORT_ARMED):
+        return (
+            DirectionalAssessmentStatus.OBSERVE,
+            DirectionalAssessmentStatus.CONFIRMED,
+        )
+    if side_st == SideState.LONG_BLOCKED:
+        return (
+            DirectionalAssessmentStatus.BLOCKED,
+            DirectionalAssessmentStatus.OBSERVE,
+        )
+    if side_st == SideState.SHORT_BLOCKED:
+        return (
+            DirectionalAssessmentStatus.OBSERVE,
+            DirectionalAssessmentStatus.BLOCKED,
+        )
+    if side_st == SideState.SWITCH_LONG_TO_SHORT_PENDING:
+        return (
+            DirectionalAssessmentStatus.OBSERVE,
+            DirectionalAssessmentStatus.CANDIDATE,
+        )
+    if side_st == SideState.SWITCH_SHORT_TO_LONG_PENDING:
+        return (
+            DirectionalAssessmentStatus.CANDIDATE,
+            DirectionalAssessmentStatus.OBSERVE,
+        )
+    return (
+        DirectionalAssessmentStatus.OBSERVE,
+        DirectionalAssessmentStatus.OBSERVE,
+    )
+
+
+def _position_management_context(side_st: SideState) -> PositionManagementContext:
+    if side_st in (SideState.LONG_ACTIVE, SideState.LONG_ARMED, SideState.LONG_BLOCKED):
+        return PositionManagementContext.LONG_POSITION
+    if side_st in (SideState.SHORT_ACTIVE, SideState.SHORT_ARMED, SideState.SHORT_BLOCKED):
+        return PositionManagementContext.SHORT_POSITION
+    return PositionManagementContext.FLAT
+
+
+def _previous_direction_state(side_st: SideState) -> CompositionDirectionState:
+    if side_st in (SideState.LONG_ACTIVE, SideState.LONG_ARMED, SideState.LONG_BLOCKED):
+        return CompositionDirectionState.LONG
+    if side_st in (SideState.SHORT_ACTIVE, SideState.SHORT_ARMED, SideState.SHORT_BLOCKED):
+        return CompositionDirectionState.SHORT
+    return CompositionDirectionState.NEUTRAL
+
+
+def _stub_directional_assessment(
+    *,
+    side: DirectionalAssessmentSide,
+    status: DirectionalAssessmentStatus,
+    instrument_id: str,
+    trading_epoch: int,
+) -> DirectionalAssessmentV1:
+    side_label = "long" if side is DirectionalAssessmentSide.LONG else "short"
+    return DirectionalAssessmentV1(
+        assessment_id=f"scenario-{side_label}-{trading_epoch}",
+        side=side,
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        status=status,
+        signal_strength=0.02 if status is DirectionalAssessmentStatus.CONFIRMED else 0.0,
+        confidence=0.9 if status is DirectionalAssessmentStatus.CONFIRMED else 0.1,
+        feature_refs=("scenario-replay-v0",),
+        scope_event_ref=ScopeEventRefV1(
+            scope_event_id=f"scope-{instrument_id}-{trading_epoch}",
+            semantic_digest=_STUB_DIGEST,
+            event_type="noop",
+            trading_epoch=trading_epoch - 1,
+        ),
+        survival_preconditions=("scenario_replay_ref_only",),
+        hard_block_reasons=(),
+        reason_codes=(f"scenario_{side_label}_{status.value}",),
+        valid_until_epoch=trading_epoch + 3,
+        semantic_digest=_STUB_DIGEST,
+    )
+
+
+def _survival_policy() -> SurvivalAssessmentPolicyV1:
+    return SurvivalAssessmentPolicyV1(
+        min_net_edge=0.001,
+        min_volatility_survival_ratio=0.5,
+        min_sequence_survival_ratio=0.5,
+        min_drawdown_survival_ratio=0.5,
+        min_liquidation_buffer_ratio=0.1,
+        validity_epochs=3,
+        policy_version=SURVIVAL_ASSESSMENT_POLICY_VERSION,
+    )
+
+
+def _scenario_survival_for(
+    assessment: DirectionalAssessmentV1,
+    *,
+    status: SurvivalAssessmentStatus = SurvivalAssessmentStatus.PASS,
+) -> SurvivalResultV1:
+    inp = SurvivalAssessmentInputV1(
+        instrument_id=assessment.instrument_id,
+        trading_epoch=assessment.trading_epoch,
+        side=assessment.side,
+        directional_assessment=assessment,
+        cost_inputs=SurvivalCostInputsV1(
+            entry_fee=0.0005,
+            expected_entry_slippage=0.0002,
+            exit_fee=0.0005,
+            expected_exit_slippage=0.0002,
+            expected_funding_cost=0.0001,
+            expected_gross_edge=0.02,
+            funding_cost_required=True,
+        ),
+        metric_inputs=SurvivalMetricInputsV1(
+            data_completeness_complete=True,
+            volatility_survival_ratio=0.8,
+            sequence_survival_ratio=0.8,
+            drawdown_survival_ratio=0.8,
+            liquidation_buffer_ratio=0.2,
+        ),
+        last_evaluated_trading_epoch=assessment.trading_epoch - 1,
+        input_complete=True,
+        explicit_hard_fail_reasons=(),
+        explicit_blocked_reasons=(),
+        policy_version=SURVIVAL_ASSESSMENT_POLICY_VERSION,
+    )
+    result = evaluate_survival_assessment_v1(inp, _survival_policy())
+    if status is not SurvivalAssessmentStatus.PASS:
+        return replace(result, status=status)
+    return result
+
+
+def _strategy_entry(side: DirectionalAssessmentSide) -> SuitabilityStrategyEntryV1:
+    return SuitabilityStrategyEntryV1(
+        strategy_id="scenario-replay-v0",
+        supported_regime_ids=("trending",),
+        supported_sides=(side,),
+        priority_rank=10,
+        disabled=False,
+        confidence_score=0.75,
+    )
+
+
+def _scenario_suitability_for(
+    assessment: DirectionalAssessmentV1,
+    survival: SurvivalResultV1,
+    *,
+    status: SuitabilityBindingStatus = SuitabilityBindingStatus.PASS,
+) -> SuitabilityResultV1:
+    entry = _strategy_entry(assessment.side)
+    if assessment.side is DirectionalAssessmentSide.SHORT:
+        entry = mirror_suitability_strategy_entry_for_short(
+            _strategy_entry(DirectionalAssessmentSide.LONG)
+        )
+    inp = SuitabilityBindingInputV1(
+        instrument_id=assessment.instrument_id,
+        trading_epoch=assessment.trading_epoch,
+        side=assessment.side,
+        directional_assessment=assessment,
+        survival_result=survival,
+        regime_id="trending",
+        regime_status=SuitabilityRegimeStatus.KNOWN,
+        strategy_registry=SuitabilityStrategyRegistryV1(entries=(entry,)),
+        last_evaluated_trading_epoch=assessment.trading_epoch - 1,
+        input_complete=True,
+        explicit_hard_block_reasons=(),
+        explicit_blocked_reasons=(),
+        ranking_policy_version=SUITABILITY_RANKING_POLICY_VERSION,
+    )
+    policy = SuitabilityRankingPolicyV1(
+        validity_epochs=3,
+        no_match_status=SuitabilityBindingStatus.FAIL,
+        policy_version=SUITABILITY_RANKING_POLICY_VERSION,
+    )
+    result = evaluate_suitability_binding_v1(inp, policy)
+    if status is not SuitabilityBindingStatus.PASS:
+        return replace(result, status=status, selected_strategy_id=None)
+    return result
+
+
+def build_scenario_matrix_composition_input_v0(
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+    context_reference: str,
+    side_st: SideState,
+    survival: SurvivalEnvelopeDecision,
+    suitability: SuitabilityProjectionDecision,
+) -> DoublePlayCompositionInputV1:
+    bull_status, bear_status = _legacy_side_to_assessment_statuses(side_st)
+    bull = _stub_directional_assessment(
+        side=DirectionalAssessmentSide.LONG,
+        status=bull_status,
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+    )
+    bear = _stub_directional_assessment(
+        side=DirectionalAssessmentSide.SHORT,
+        status=bear_status,
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+    )
+
+    survival_status = (
+        SurvivalAssessmentStatus.PASS
+        if survival.status is SurvivalEnvelopeStatus.OK and survival.pre_authorization_eligible
+        else SurvivalAssessmentStatus.FAIL
+    )
+    bull_survival = _scenario_survival_for(bull, status=survival_status)
+    bear_survival = _scenario_survival_for(bear, status=survival_status)
+
+    bull_suit_status = (
+        SuitabilityBindingStatus.PASS
+        if suitability.can_enter_long_bull_pool
+        else SuitabilityBindingStatus.BLOCKED
+    )
+    bear_suit_status = (
+        SuitabilityBindingStatus.PASS
+        if suitability.can_enter_short_bear_pool
+        else SuitabilityBindingStatus.BLOCKED
+    )
+    bull_suit = _scenario_suitability_for(bull, bull_survival, status=bull_suit_status)
+    bear_suit = _scenario_suitability_for(bear, bear_survival, status=bear_suit_status)
+
+    raw = DoublePlayCompositionInputV1(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+        bull_directional_assessment=bull,
+        bear_directional_assessment=bear,
+        bull_survival_result=bull_survival,
+        bear_survival_result=bear_survival,
+        bull_suitability_result=bull_suit,
+        bear_suitability_result=bear_suit,
+        previous_direction_state=_previous_direction_state(side_st),
+        position_management_context=_position_management_context(side_st),
+        last_evaluated_trading_epoch=trading_epoch - 1,
+        input_complete=True,
+        input_digest="",
+        explicit_blocked_reasons=(),
+        policy_version=DOUBLE_PLAY_COMPOSITION_MATRIX_POLICY_VERSION,
+    )
+    return replace(raw, input_digest=compute_composition_input_digest(raw))
+
+
+def evaluate_scenario_matrix_composition_v0(
+    matrix_input: DoublePlayCompositionInputV1,
+    *,
+    policy: DoublePlayCompositionPolicyV1 | None = None,
+) -> DoublePlayCompositionResultV1:
+    return evaluate_double_play_composition_matrix_v1(
+        matrix_input,
+        policy or _DEFAULT_POLICY,
+    )
+
+
+def compose_double_play_scenario_via_canonical_matrix_v0(
+    inp: DoublePlayCompositionInput,
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+    context_reference: str,
+    policy: DoublePlayCompositionPolicyV1 | None = None,
+) -> DoublePlayCompositionDecision:
+    pre = _apply_legacy_pre_matrix_gates(inp)
+    if pre is not None:
+        return pre
+
+    matrix_input = build_scenario_matrix_composition_input_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+        side_st=inp.resulting_side_state,
+        survival=inp.survival,
+        suitability=inp.suitability,
+    )
+    matrix_result = evaluate_scenario_matrix_composition_v0(matrix_input, policy=policy)
+    return _apply_legacy_capital_slot_overlay(
+        inp,
+        matrix_status=matrix_result.composition_status,
+    )
+
+
+def legacy_and_matrix_composition_parity_aligned_v0(
+    legacy: DoublePlayCompositionDecision,
+    matrix_result: DoublePlayCompositionResultV1,
+) -> bool:
+    status_map = {
+        CompositionStatus.LONG_SELECTED: DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY,
+        CompositionStatus.SHORT_SELECTED: DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY,
+        CompositionStatus.CHOP_GUARD_BLOCK: DoublePlayCompositionStatus.CHOP_GUARD,
+        CompositionStatus.OBSERVE: DoublePlayCompositionStatus.OBSERVE_ONLY,
+        CompositionStatus.NO_ACTION: DoublePlayCompositionStatus.OBSERVE_ONLY,
+        CompositionStatus.BLOCKED: DoublePlayCompositionStatus.BLOCKED,
+        CompositionStatus.REVERSAL_PREPARATION: DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY,
+    }
+    expected = status_map.get(matrix_result.composition_status)
+    if expected is None:
+        return False
+    return legacy.status is expected

--- a/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
+++ b/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
@@ -52,7 +52,9 @@ from trading.master_v2.double_play_capital_slot import (
 from trading.master_v2.double_play_composition import (
     DoublePlayCompositionInput,
     RequestedSide,
-    compose_double_play_decision,
+)
+from trading.master_v2.double_play_composition_scenario_matrix_adapter_v0 import (
+    compose_double_play_scenario_via_canonical_matrix_v0,
 )
 from trading.master_v2.double_play_dashboard_display import (
     DoublePlayDashboardDisplaySnapshot,
@@ -766,7 +768,7 @@ def run_offline_double_play_scenario_replay_v0(
             capital_state = replace(capital_state, active_slot_base=ratchet.new_active_slot_base)
         release = evaluate_capital_slot_release(_capital_config(), capital_state)
 
-        composition = compose_double_play_decision(
+        composition = compose_double_play_scenario_via_canonical_matrix_v0(
             DoublePlayCompositionInput(
                 transition=transition,
                 resulting_side_state=side,
@@ -775,7 +777,10 @@ def run_offline_double_play_scenario_replay_v0(
                 requested_side=_requested_side(side),
                 capital_slot_ratchet_decision=ratchet,
                 capital_slot_release_decision=release,
-            )
+            ),
+            instrument_id=inp.selected_future_id,
+            trading_epoch=tick.tick_index,
+            context_reference=f"{inp.correlation_id_prefix}-tick-{tick.tick_index}",
         )
 
         final_dashboard_display_snapshot = build_dashboard_display_snapshot(

--- a/tests/core/test_prometheus_client_dependency_bound_metrics_contract_v0.py
+++ b/tests/core/test_prometheus_client_dependency_bound_metrics_contract_v0.py
@@ -1,0 +1,44 @@
+"""Dependency-bound contract: prometheus-client declared and usable by src/core/metrics.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from src.core.metrics import PROMETHEUS_AVAILABLE, MetricsCollector
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_NS = "peak_trade_prometheus_dependency_bound_contract_v0"
+
+
+def _normalize_dependency_name(requirement: str) -> str:
+    match = re.match(r"\s*([A-Za-z0-9_.-]+)", requirement)
+    assert match is not None, f"Could not parse dependency requirement: {requirement!r}"
+    return match.group(1).replace("_", "-").lower()
+
+
+def test_prometheus_client_dependency_bound_in_pyproject_v0() -> None:
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    deps = pyproject["project"]["dependencies"]
+    prometheus = [d for d in deps if _normalize_dependency_name(d) == "prometheus-client"]
+    assert prometheus, "prometheus-client must be declared in pyproject.toml"
+    assert any(">=" in req for req in prometheus)
+
+
+def test_prometheus_client_importable_in_project_environment_v0() -> None:
+    assert importlib.util.find_spec("prometheus_client") is not None
+
+
+def test_metrics_collector_uses_bound_prometheus_client_without_drift_v0() -> None:
+    assert PROMETHEUS_AVAILABLE is True
+    body, content_type = MetricsCollector(namespace=_NS).export_prometheus()
+    assert isinstance(content_type, str)
+    raw = body.decode("utf-8") if isinstance(body, (bytes, bytearray)) else body
+    assert _NS in raw
+    assert len(raw) > 0

--- a/tests/trading/master_v2/test_double_play_composition_scenario_matrix_parity_contract_v0.py
+++ b/tests/trading/master_v2/test_double_play_composition_scenario_matrix_parity_contract_v0.py
@@ -1,0 +1,242 @@
+"""Parity contract: scenario adapter vs canonical double_play_composition_matrix_v1."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from trading.master_v2.directional_assessment_v1 import DirectionalAssessmentStatus
+from trading.master_v2.double_play_composition import (
+    DoublePlayCompositionInput,
+    DoublePlayCompositionStatus,
+    RequestedSide,
+)
+from trading.master_v2.double_play_composition_matrix_v1 import (
+    CompositionConflictStatus,
+    CompositionSelectedSide,
+    CompositionStatus,
+    PositionManagementContext,
+    compute_composition_input_digest,
+)
+from trading.master_v2.double_play_composition_scenario_matrix_adapter_v0 import (
+    CANONICAL_DOUBLE_PLAY_COMPOSITION_OWNER,
+    DOUBLE_PLAY_COMPOSITION_SCENARIO_MATRIX_ADAPTER_OWNER,
+    build_scenario_matrix_composition_input_v0,
+    compose_double_play_scenario_via_canonical_matrix_v0,
+    evaluate_scenario_matrix_composition_v0,
+    legacy_and_matrix_composition_parity_aligned_v0,
+)
+from trading.master_v2.double_play_state import SideState, TransitionDecision
+from trading.master_v2.double_play_suitability import (
+    SuitabilityProjectionDecision,
+    project_strategy_suitability,
+)
+from trading.master_v2.double_play_survival import evaluate_survival_envelope
+from trading.master_v2.offline_double_play_scenario_replay_v0 import (
+    SYNTHETIC_FUTURES_INSTRUMENT,
+    _survival_envelope,
+    _suitability_input,
+)
+
+_INSTRUMENT = SYNTHETIC_FUTURES_INSTRUMENT
+_EPOCH = 44
+_CONTEXT = "scenario-matrix-parity-v0"
+
+
+def _transition() -> TransitionDecision:
+    return TransitionDecision(
+        allowed=True,
+        reason_code="TEST",
+        live_authorization_granted=False,
+    )
+
+
+def _survival_ok():
+    return evaluate_survival_envelope(_survival_envelope())
+
+
+def _suitability_both_pools() -> SuitabilityProjectionDecision:
+    return project_strategy_suitability(_suitability_input())
+
+
+def _suitability_neutral_observe() -> SuitabilityProjectionDecision:
+    base = _suitability_both_pools()
+    proj = replace(base.projection, eligible_for_neutral_pool=True)
+    return replace(
+        base,
+        projection=proj,
+        can_enter_neutral_pool=True,
+    )
+
+
+def _legacy_input(
+    *,
+    side: SideState,
+    requested: RequestedSide,
+    suitability: SuitabilityProjectionDecision | None = None,
+) -> DoublePlayCompositionInput:
+    return DoublePlayCompositionInput(
+        transition=_transition(),
+        resulting_side_state=side,
+        survival=_survival_ok(),
+        suitability=suitability or _suitability_both_pools(),
+        requested_side=requested,
+    )
+
+
+def _adapter_decision(
+    *,
+    side: SideState,
+    requested: RequestedSide,
+    suitability: SuitabilityProjectionDecision | None = None,
+):
+    return compose_double_play_scenario_via_canonical_matrix_v0(
+        _legacy_input(side=side, requested=requested, suitability=suitability),
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+
+
+def test_adapter_owner_points_at_canonical_matrix_v0() -> None:
+    assert CANONICAL_DOUBLE_PLAY_COMPOSITION_OWNER.endswith("double_play_composition_matrix_v1")
+    assert DOUBLE_PLAY_COMPOSITION_SCENARIO_MATRIX_ADAPTER_OWNER.endswith(
+        "double_play_composition_scenario_matrix_adapter_v0"
+    )
+
+
+def test_1_bull_confirmed_bear_blocked_long_selected_v0() -> None:
+    matrix_input = build_scenario_matrix_composition_input_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        side_st=SideState.LONG_ACTIVE,
+        survival=_survival_ok(),
+        suitability=_suitability_both_pools(),
+    )
+    matrix_result = evaluate_scenario_matrix_composition_v0(matrix_input)
+    adapter = _adapter_decision(
+        side=SideState.LONG_ACTIVE,
+        requested=RequestedSide.LONG_BULL,
+    )
+
+    assert matrix_result.composition_status is CompositionStatus.LONG_SELECTED
+    assert adapter.status is DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY
+    assert legacy_and_matrix_composition_parity_aligned_v0(adapter, matrix_result)
+
+
+def test_2_bear_confirmed_bull_blocked_short_selected_v0() -> None:
+    matrix_input = build_scenario_matrix_composition_input_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        side_st=SideState.SHORT_ACTIVE,
+        survival=_survival_ok(),
+        suitability=_suitability_both_pools(),
+    )
+    matrix_result = evaluate_scenario_matrix_composition_v0(matrix_input)
+    adapter = _adapter_decision(
+        side=SideState.SHORT_ACTIVE,
+        requested=RequestedSide.SHORT_BEAR,
+    )
+
+    assert matrix_result.composition_status is CompositionStatus.SHORT_SELECTED
+    assert adapter.status is DoublePlayCompositionStatus.ELIGIBLE_MODEL_ONLY
+    assert legacy_and_matrix_composition_parity_aligned_v0(adapter, matrix_result)
+
+
+def test_3_both_confirmed_chop_guard_block_v0() -> None:
+    matrix_input = build_scenario_matrix_composition_input_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        side_st=SideState.CHOP_GUARD_BLOCK,
+        survival=_survival_ok(),
+        suitability=_suitability_both_pools(),
+    )
+    matrix_result = evaluate_scenario_matrix_composition_v0(matrix_input)
+    adapter = _adapter_decision(
+        side=SideState.CHOP_GUARD_BLOCK,
+        requested=RequestedSide.NEUTRAL_OBSERVE,
+    )
+
+    assert matrix_result.composition_status is CompositionStatus.CHOP_GUARD_BLOCK
+    assert matrix_result.conflict_status is CompositionConflictStatus.BOTH_SIDES_CONFIRMED
+    assert "no_new_entry" in matrix_result.reason_codes
+    assert adapter.status is DoublePlayCompositionStatus.CHOP_GUARD
+
+
+def test_4_both_blocked_observe_no_action_v0() -> None:
+    suitability = _suitability_neutral_observe()
+    matrix_input = build_scenario_matrix_composition_input_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        side_st=SideState.NEUTRAL_OBSERVE,
+        survival=_survival_ok(),
+        suitability=suitability,
+    )
+    matrix_result = evaluate_scenario_matrix_composition_v0(matrix_input)
+    adapter = _adapter_decision(
+        side=SideState.NEUTRAL_OBSERVE,
+        requested=RequestedSide.NEUTRAL_OBSERVE,
+        suitability=suitability,
+    )
+
+    assert matrix_result.composition_status in (
+        CompositionStatus.OBSERVE,
+        CompositionStatus.NO_ACTION,
+    )
+    assert matrix_result.selected_side is CompositionSelectedSide.NONE
+    assert adapter.status is DoublePlayCompositionStatus.OBSERVE_ONLY
+
+
+def test_5_existing_position_reversal_preparation_not_overridden_v0() -> None:
+    matrix_input = build_scenario_matrix_composition_input_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        side_st=SideState.LONG_ACTIVE,
+        survival=_survival_ok(),
+        suitability=_suitability_both_pools(),
+    )
+    bull_observe = replace(
+        matrix_input.bull_directional_assessment,
+        status=DirectionalAssessmentStatus.OBSERVE,
+    )
+    bear_confirmed = replace(
+        matrix_input.bear_directional_assessment,
+        status=DirectionalAssessmentStatus.CONFIRMED,
+    )
+
+    matrix_input = replace(
+        matrix_input,
+        bull_directional_assessment=bull_observe,
+        bear_directional_assessment=bear_confirmed,
+        position_management_context=PositionManagementContext.LONG_POSITION,
+    )
+    matrix_input = replace(
+        matrix_input,
+        input_digest=compute_composition_input_digest(matrix_input),
+    )
+    matrix_result = evaluate_scenario_matrix_composition_v0(matrix_input)
+
+    assert matrix_result.composition_status is CompositionStatus.REVERSAL_PREPARATION
+    assert "existing_long_position" in matrix_result.reason_codes
+    assert "reversal_preparation" in matrix_result.reason_codes
+
+
+def test_scenario_replay_default_still_passes_v0() -> None:
+    from trading.master_v2.offline_double_play_scenario_replay_v0 import (
+        OfflineDoublePlayScenarioReplayInputV0,
+        build_default_bull_bear_bull_scenario_ticks,
+        run_offline_double_play_scenario_replay_v0,
+    )
+
+    result = run_offline_double_play_scenario_replay_v0(
+        OfflineDoublePlayScenarioReplayInputV0(
+            selected_future_id=SYNTHETIC_FUTURES_INSTRUMENT,
+            ticks=build_default_bull_bear_bull_scenario_ticks(),
+            source_revision="parity-contract-v0",
+        )
+    )
+    assert result.replay_pass, result.fail_reasons


### PR DESCRIPTION
## Summary
- Rewires `offline_double_play_scenario_replay_v0` to compose via canonical `double_play_composition_matrix_v1` through a narrow scenario adapter while preserving the legacy `DoublePlayCompositionDecision` envelope.
- Adds parity contract tests for representative bull/bear/chop/observe/reversal-preparation cases plus default scenario replay regression coverage.
- Adds a prometheus-client dependency-bound contract test; dependency was already declared in `pyproject.toml` / `requirements.txt` — no duplicate dependency added.

## Boundaries
- No runtime authority
- No economic evaluation
- No semantic change to Double Play, Master V2, risk, sizing, or safety
- No Prometheus runtime activation / no new metrics SSOT

## Prometheus client
- Before/after: importable=true, dependency-bound=true
- Action: `NO_DUPLICATE_ADD_CONTRACT_GUARD_ONLY`

## Evidence
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/double_play_composition_parity_prometheus_guard_after_pr4944_20260706T193650Z/` (MANIFEST_VERIFY_RC=0)

## Tests
- 65 targeted tests PASS (parity + scenario replay binding + prometheus contracts)
- `ruff format --check .` PASS
- `ruff check .` PASS

## Test plan
- [x] Parity contract cases 1–5
- [x] Default offline scenario replay still passes
- [x] Existing scenario replay binding contract suite (53 tests)
- [x] Prometheus dependency-bound metrics contract


Made with [Cursor](https://cursor.com)