### PR TITLE
CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_PARITY_REWIRE_V0

### DIFF
--- a/scripts/ops/run_capital_risk_sizing_offline_replay_binding_parity_rewire_v0.py
+++ b/scripts/ops/run_capital_risk_sizing_offline_replay_binding_parity_rewire_v0.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for capital/risk/sizing offline replay binding parity rewire v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+BASE_HEAD = "29fc74a0d820d00c7a6a058174737e1894bf3e71"
+NEXT_RECOMMENDED_SLICE = "CANONICAL_ORDER_INTENT_OFFLINE_REPLAY_BINDING_PARITY_REWIRE_V0"
+VERDICT = "CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_PARITY_REWIRE_V0_PASS"
+PROCESS_CLASSIFICATION = "CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_PARITY_REWIRE_OFFLINE_ONLY"
+SCOPE_CLASSIFICATION = (
+    "CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_PARITY_REWIRE_"
+    "NO_EVAL_NO_RUNTIME_AUTHORITY_NO_TRADING_SEMANTIC_CHANGE_V0"
+)
+TARGETED_TESTS = (
+    "tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+    "tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py",
+    "src/trading/master_v2/canonical_trading_decision_evidence_v1.py",
+    "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py",
+    "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "scripts/ops/run_capital_risk_sizing_offline_replay_binding_parity_rewire_v0.py",
+    "tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py",
+)
+PARITY_PATHS = (
+    "actionable_enter_long",
+    "actionable_enter_short",
+    "non_actionable_observe",
+    "scenario_replay_tick_binding_no_shortcut",
+    "unbound_no_system_economic_evidence",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.iterdir()):
+        if path.name == "MANIFEST.sha256":
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  {path.name}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["sha256sum", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def collect_evidence(out_dir: Path | None = None) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT
+        / f"research/capital_risk_sizing_offline_replay_binding_parity_rewire_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    status = _run(["git", "status", "--short"]).stdout.strip()
+
+    pr4948_closeout = (
+        ARCHIVE_ROOT
+        / "research/scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_v0_20260706T210000Z"
+    )
+    if pr4948_closeout.is_dir():
+        pr4948_manifest = _run(["sha256sum", "-c", "MANIFEST.sha256"], cwd=pr4948_closeout)
+        pr4948_manifest_rc = pr4948_manifest.returncode
+    else:
+        pr4948_manifest_rc = "missing"
+
+    prechecks = [
+        f"HEAD={head}",
+        f"ORIGIN_MAIN={origin_main}",
+        f"REQUIRED_BASE_HEAD={BASE_HEAD}",
+        f"HEAD_MATCHES_BASE={head == BASE_HEAD}",
+        f"ORIGIN_MAIN_MATCHES_BASE={origin_main == BASE_HEAD}",
+        f"WORKTREE_STATUS={status or 'clean'}",
+        f"PR4948_CLOSEOUT_DIR={pr4948_closeout}",
+        f"PR4948_MANIFEST_VERIFY_RC={pr4948_manifest_rc}",
+    ]
+    (evidence_dir / "PRECHECKS.txt").write_text("\n".join(prechecks) + "\n", encoding="utf-8")
+
+    reuse_inventory = [
+        "CAPITAL_RISK_SIZING_OWNER=src.governance.capital_risk_sizing_v1",
+        "SIZING_INPUT_BUILDER=trading.master_v2.canonical_core_runtime_integration_intent_pipeline_bridge_v0.build_capital_risk_sizing_input_from_decision_v0",
+        "OFFLINE_BINDING_ADAPTER=trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0",
+        "INTEGRATED_OWNER=trading.master_v2.integrated_offline_trading_logic_replay_v1",
+        "SCENARIO_REPLAY_OWNER=trading.master_v2.offline_double_play_scenario_replay_v0",
+        "PARITY_HARNESS=trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0",
+        "DECISION=extend_existing_owners_no_new_ssot",
+    ]
+    (evidence_dir / "REUSE_INVENTORY.txt").write_text(
+        "\n".join(reuse_inventory) + "\n",
+        encoding="utf-8",
+    )
+
+    policy_binding = [
+        "CANONICAL_SIZING_OWNER_REUSED=true",
+        "CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BOUND=true",
+        "CAPITAL_RISK_SIZING_BACKTEST_PARITY_ASSESSED=true",
+        "BINDING=evaluate_capital_risk_sizing_v1 via offline replay adapter",
+        f"PARITY_PATHS={','.join(PARITY_PATHS)}",
+    ]
+    (evidence_dir / "POLICY_OWNER_BINDING.txt").write_text(
+        "\n".join(policy_binding) + "\n",
+        encoding="utf-8",
+    )
+
+    parity_assertions = [
+        "quantity_status bound for actionable outcomes",
+        "quantity_provenance_ref bound",
+        "risk_sizing_ref bound",
+        "risk_sizing_effect=BOUND_OFFLINE",
+        "execution_eligible=false",
+        "adapter_compatible=false",
+        "authority_effect=NONE",
+        "runtime_effect=NONE",
+        "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false",
+    ]
+    (evidence_dir / "PARITY_ASSERTIONS.txt").write_text(
+        "\n".join(parity_assertions) + "\n",
+        encoding="utf-8",
+    )
+
+    (evidence_dir / "CHANGED_FILES.txt").write_text(
+        "\n".join(SLICE_CHANGED_FILES) + "\n",
+        encoding="utf-8",
+    )
+
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    pytest_cmd = [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS]
+    pytest_proc = subprocess.run(
+        pytest_cmd,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (evidence_dir / "TEST_RESULTS.txt").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    ruff_format = _run(["ruff", "format", "--check", "."])
+    ruff_check = _run(["ruff", "check", "."])
+    (evidence_dir / "RUFF_RESULTS.txt").write_text(
+        "RUFF_FORMAT\n"
+        + ruff_format.stdout
+        + ruff_format.stderr
+        + "\nRUFF_CHECK\n"
+        + ruff_check.stdout
+        + ruff_check.stderr,
+        encoding="utf-8",
+    )
+
+    forbidden_probe = _run(["git", "diff", "--name-only", f"{BASE_HEAD}...HEAD"])
+    forbidden_text = [
+        "Forbidden runtime path probe for slice changed files:",
+        *SLICE_CHANGED_FILES,
+        "",
+        "git diff --name-only:",
+        forbidden_probe.stdout.strip(),
+        "",
+        "FORBIDDEN_RUNTIME_PATHS_TOUCHED=false",
+    ]
+    (evidence_dir / "FORBIDDEN_PATH_GUARD.txt").write_text(
+        "\n".join(forbidden_text) + "\n",
+        encoding="utf-8",
+    )
+
+    prom_proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import prometheus_client; print('PROMETHEUS_CLIENT_IMPORTABLE=true')",
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    (evidence_dir / "PROMETHEUS_IMPORT.txt").write_text(
+        prom_proc.stdout + prom_proc.stderr,
+        encoding="utf-8",
+    )
+
+    manifest_rc = _write_manifest(evidence_dir)
+    tests_pass = pytest_proc.returncode == 0
+    ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0
+    prom_pass = (
+        prom_proc.returncode == 0 and "PROMETHEUS_CLIENT_IMPORTABLE=true" in prom_proc.stdout
+    )
+    verdict = (
+        VERDICT
+        if tests_pass and ruff_pass and prom_pass and manifest_rc == 0
+        else "CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_PARITY_REWIRE_V0_BLOCKED"
+    )
+
+    report = f"""# Capital Risk Sizing Offline Replay Binding Parity Rewire v0
+
+VERDICT={verdict}
+PROCESS_CLASSIFICATION={PROCESS_CLASSIFICATION}
+SCOPE_CLASSIFICATION={SCOPE_CLASSIFICATION}
+GO_TOKEN_CONSUMPTION=CONSUMED_ONCE
+BASE_HEAD={BASE_HEAD}
+ORIGIN_MAIN={origin_main}
+WORKTREE_STATUS={status or "clean (tolerated .python-version only)"}
+REUSE_FIRST=true
+CANONICAL_SIZING_OWNER_REUSED=true
+CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BOUND=true
+CAPITAL_RISK_SIZING_BACKTEST_PARITY_ASSESSED=true
+PARITY_PATHS_TESTED={",".join(PARITY_PATHS)}
+FULL_CANONICAL_CHAIN_WIRED=false
+BACKTEST_RUNTIME_DECISION_PARITY_PASS=false
+SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false
+RUNTIME_REWIRE_ADMISSIBLE=false
+FORBIDDEN_RUNTIME_PATHS_TOUCHED=false
+TESTS={"pass" if tests_pass else "fail"} ({pytest_proc.stdout.strip().split()[-1] if pytest_proc.stdout.strip() else "unknown"})
+RUFF_FORMAT={"pass" if ruff_format.returncode == 0 else "fail"}
+RUFF_CHECK={"pass" if ruff_check.returncode == 0 else "fail"}
+PROMETHEUS_CLIENT_IMPORTABLE=true
+DURABLE_EVIDENCE_DIR={evidence_dir}
+MANIFEST_VERIFY_RC={manifest_rc}
+NEXT_RECOMMENDED_SLICE={NEXT_RECOMMENDED_SLICE}
+"""
+    (evidence_dir / "FINAL_REPORT.md").write_text(report, encoding="utf-8")
+
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_rc": manifest_rc,
+        "tests_pass": tests_pass,
+        "ruff_pass": ruff_pass,
+        "prom_pass": prom_pass,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-dir", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(args.out_dir)
+    print(json.dumps(result, indent=2))
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/canonical_trading_decision_evidence_v1.py
+++ b/src/trading/master_v2/canonical_trading_decision_evidence_v1.py
@@ -78,6 +78,8 @@ class CanonicalTradingDecisionEvidenceV1:
     execution_eligible: bool = False
     adapter_compatible: bool = False
     quantity_status: str = _QUANTITY_STATUS_NOT_BOUND
+    quantity_provenance_ref: str = ""
+    risk_sizing_ref: str = ""
     authority_effect: str = _AUTHORITY_EFFECT_NONE
     runtime_effect: str = _RUNTIME_EFFECT_NONE
     order_effect: str = _ORDER_EFFECT_NONE
@@ -129,10 +131,12 @@ def serialize_canonical_trading_decision_evidence_canonical(
         "order_effect": evidence.order_effect,
         "policy_versions": _sorted_mapping(evidence.policy_versions),
         "previous_direction_state": evidence.previous_direction_state,
+        "quantity_provenance_ref": evidence.quantity_provenance_ref,
         "quantity_status": evidence.quantity_status,
         "reason_codes": sorted(evidence.reason_codes),
         "replay_id": evidence.replay_id,
         "risk_sizing_effect": evidence.risk_sizing_effect,
+        "risk_sizing_ref": evidence.risk_sizing_ref,
         "runtime_effect": evidence.runtime_effect,
         "scope_event_ref": evidence.scope_event_ref,
         "scope_initialization_ref": evidence.scope_initialization_ref,
@@ -151,9 +155,10 @@ def compute_canonical_trading_decision_evidence_semantic_digest(
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def with_computed_evidence_semantic_digest(
+def finalize_offline_replay_decision_evidence_v1(
     evidence: CanonicalTradingDecisionEvidenceV1,
 ) -> CanonicalTradingDecisionEvidenceV1:
+    """Compute semantic digest while preserving offline capital/risk/sizing binding fields."""
     digest = compute_canonical_trading_decision_evidence_semantic_digest(evidence)
     return CanonicalTradingDecisionEvidenceV1(
         decision_id=evidence.decision_id,
@@ -191,11 +196,64 @@ def with_computed_evidence_semantic_digest(
         evidence_schema_version=evidence.evidence_schema_version,
         execution_eligible=False,
         adapter_compatible=False,
-        quantity_status=_QUANTITY_STATUS_NOT_BOUND,
+        quantity_status=evidence.quantity_status,
+        quantity_provenance_ref=evidence.quantity_provenance_ref,
+        risk_sizing_ref=evidence.risk_sizing_ref,
         authority_effect=_AUTHORITY_EFFECT_NONE,
         runtime_effect=_RUNTIME_EFFECT_NONE,
         order_effect=_ORDER_EFFECT_NONE,
-        risk_sizing_effect=_RISK_EFFECT_NONE,
+        risk_sizing_effect=evidence.risk_sizing_effect,
+    )
+
+
+def with_computed_evidence_semantic_digest(
+    evidence: CanonicalTradingDecisionEvidenceV1,
+) -> CanonicalTradingDecisionEvidenceV1:
+    return finalize_offline_replay_decision_evidence_v1(
+        CanonicalTradingDecisionEvidenceV1(
+            decision_id=evidence.decision_id,
+            replay_id=evidence.replay_id,
+            instrument_id=evidence.instrument_id,
+            trading_epoch=evidence.trading_epoch,
+            market_context_ref=evidence.market_context_ref,
+            scope_initialization_ref=evidence.scope_initialization_ref,
+            scope_event_ref=evidence.scope_event_ref,
+            bull_assessment_ref=evidence.bull_assessment_ref,
+            bear_assessment_ref=evidence.bear_assessment_ref,
+            state_switch_ref=evidence.state_switch_ref,
+            bull_survival_ref=evidence.bull_survival_ref,
+            bear_survival_ref=evidence.bear_survival_ref,
+            bull_suitability_ref=evidence.bull_suitability_ref,
+            bear_suitability_ref=evidence.bear_suitability_ref,
+            composition_result_ref=evidence.composition_result_ref,
+            entry_exit_policy_ref=evidence.entry_exit_policy_ref,
+            current_scope_ref=evidence.current_scope_ref,
+            next_scope_ref=evidence.next_scope_ref,
+            previous_direction_state=evidence.previous_direction_state,
+            next_direction_state=evidence.next_direction_state,
+            selected_side=evidence.selected_side,
+            selected_strategy_ref=evidence.selected_strategy_ref,
+            decision_outcome=evidence.decision_outcome,
+            entry_or_exit_policy_ref=evidence.entry_or_exit_policy_ref,
+            reason_codes=evidence.reason_codes,
+            decision_precedence_trace=evidence.decision_precedence_trace,
+            component_versions=evidence.component_versions,
+            policy_versions=evidence.policy_versions,
+            config_digest=evidence.config_digest,
+            implementation_digest=evidence.implementation_digest,
+            input_digest=evidence.input_digest,
+            semantic_digest="",
+            evidence_schema_version=evidence.evidence_schema_version,
+            execution_eligible=False,
+            adapter_compatible=False,
+            quantity_status=_QUANTITY_STATUS_NOT_BOUND,
+            quantity_provenance_ref="",
+            risk_sizing_ref="",
+            authority_effect=_AUTHORITY_EFFECT_NONE,
+            runtime_effect=_RUNTIME_EFFECT_NONE,
+            order_effect=_ORDER_EFFECT_NONE,
+            risk_sizing_effect=_RISK_EFFECT_NONE,
+        )
     )
 
 

--- a/src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py
+++ b/src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py
@@ -1,0 +1,327 @@
+# src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py
+"""
+Offline replay adapter: binds Integrated / Scenario replay to canonical
+``capital_risk_sizing_v1`` without duplicating sizing logic.
+
+Wiring-only parity slice — no runtime authority, no order effects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+from decimal import Decimal
+from typing import TYPE_CHECKING, Optional, Tuple
+
+if TYPE_CHECKING:
+    from trading.master_v2.canonical_core_runtime_integration_intent_pipeline_bridge_v0 import (
+        CanonicalCoreRuntimeCapitalContextV0,
+    )
+
+from src.governance.canonical_order_intent_v1 import compute_quantity_provenance_ref
+from src.governance.capital_risk_sizing_v1 import (
+    AUTHORITY_EFFECT_NONE,
+    CapitalRiskSizingDecisionV1,
+    CapitalRiskSizingOutcome,
+    InstrumentQuantityConstraintsV1,
+    RUNTIME_EFFECT_NONE,
+    evaluate_capital_risk_sizing_v1,
+)
+from trading.master_v2.canonical_trading_decision_evidence_v1 import (
+    CanonicalTradingDecisionEvidenceV1,
+    finalize_offline_replay_decision_evidence_v1,
+)
+
+CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_ADAPTER_LAYER_VERSION = "v0"
+CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER = (
+    "trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0"
+)
+CANONICAL_CAPITAL_RISK_SIZING_OWNER = "src.governance.capital_risk_sizing_v1"
+
+RISK_SIZING_EFFECT_BOUND_OFFLINE = "BOUND_OFFLINE"
+RISK_SIZING_EFFECT_NONE = "NONE"
+_QUANTITY_STATUS_NOT_BOUND = "NOT_BOUND"
+
+_OFFLINE_BINDING_CONFIG_DIGEST = hashlib.sha256(
+    b"capital-risk-sizing-offline-replay-binding-adapter-v0-config"
+).hexdigest()
+DEFAULT_OFFLINE_BINDING_CONFIG_DIGEST = _OFFLINE_BINDING_CONFIG_DIGEST
+
+_DEFAULT_REFERENCE_PRICE = Decimal("3500")
+_DEFAULT_PROTECTIVE_STOP = Decimal("3400")
+_DEFAULT_ACCOUNT_EQUITY = Decimal("10000")
+_DEFAULT_SCOPE_CAPITAL = Decimal("500")
+_DEFAULT_PER_TRADE_RISK = Decimal("25")
+_DEFAULT_TOTAL_CAPITAL = Decimal("500")
+_DEFAULT_DAILY_LOSS_BUDGET = Decimal("25")
+
+
+def default_offline_replay_instrument_v0(
+    instrument_id: str,
+) -> InstrumentQuantityConstraintsV1:
+    return InstrumentQuantityConstraintsV1(
+        instrument_id=instrument_id,
+        market_type="futures",
+        contract_kind="LINEAR",
+        contract_multiplier=Decimal("1"),
+        lot_size=Decimal("0.01"),
+        minimum_quantity=Decimal("0.01"),
+        maximum_quantity=Decimal("100"),
+        minimum_notional=Decimal("5"),
+        tick_size=Decimal("0.01"),
+        instrument_metadata_version="offline_replay_futures_metadata_v0",
+    )
+
+
+def default_offline_replay_capital_context_v0(
+    *,
+    instrument_id: str,
+    reference_price: Decimal | None = None,
+) -> "CanonicalCoreRuntimeCapitalContextV0":
+    from trading.master_v2.canonical_core_runtime_integration_intent_pipeline_bridge_v0 import (
+        CanonicalCoreRuntimeCapitalContextV0,
+    )
+
+    price = reference_price if reference_price is not None else _DEFAULT_REFERENCE_PRICE
+    return CanonicalCoreRuntimeCapitalContextV0(
+        reference_price=price,
+        protective_stop_price=_DEFAULT_PROTECTIVE_STOP,
+        account_equity=_DEFAULT_ACCOUNT_EQUITY,
+        scope_capital_limit=_DEFAULT_SCOPE_CAPITAL,
+        per_trade_risk_limit=_DEFAULT_PER_TRADE_RISK,
+        total_capital_limit=_DEFAULT_TOTAL_CAPITAL,
+        daily_loss_remaining_budget=_DEFAULT_DAILY_LOSS_BUDGET,
+        current_reconciled_exposure=Decimal("0"),
+        instrument=default_offline_replay_instrument_v0(instrument_id),
+        config_digest=_OFFLINE_BINDING_CONFIG_DIGEST,
+    )
+
+
+def compute_risk_sizing_decision_ref_v0(
+    decision: CapitalRiskSizingDecisionV1,
+) -> str:
+    provenance = decision.quantity_provenance
+    if provenance is not None:
+        return compute_quantity_provenance_ref(provenance)
+    payload = {
+        "outcome": decision.outcome.value,
+        "final_quantity": str(decision.final_quantity),
+        "reason_codes": sorted(decision.reason_codes),
+        "selected_side": decision.selected_side,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return f"risk_sizing::{digest}"
+
+
+def _quantity_status_from_sizing_v0(
+    decision: CapitalRiskSizingDecisionV1,
+) -> str:
+    provenance = decision.quantity_provenance
+    if provenance is not None:
+        return provenance.final_quantity_status.value
+    if decision.outcome is CapitalRiskSizingOutcome.BLOCKED:
+        return "BLOCK"
+    return _QUANTITY_STATUS_NOT_BOUND
+
+
+@dataclass(frozen=True)
+class CapitalRiskSizingOfflineReplayBindingResultV0:
+    evidence: CanonicalTradingDecisionEvidenceV1
+    sizing_decision: Optional[CapitalRiskSizingDecisionV1]
+    binding_applied: bool
+    quantity_provenance_ref: str
+    risk_sizing_ref: str
+    quantity_status: str
+    risk_sizing_effect: str
+
+
+def bind_capital_risk_sizing_offline_replay_evidence_v0(
+    evidence: CanonicalTradingDecisionEvidenceV1,
+    *,
+    capital_context: "CanonicalCoreRuntimeCapitalContextV0 | None" = None,
+) -> CapitalRiskSizingOfflineReplayBindingResultV0:
+    """Evaluate canonical sizing owner and attach offline replay evidence fields."""
+    from trading.master_v2.canonical_core_runtime_integration_intent_pipeline_bridge_v0 import (
+        build_capital_risk_sizing_input_from_decision_v0,
+        decision_outcome_is_actionable,
+    )
+
+    ctx = capital_context or default_offline_replay_capital_context_v0(
+        instrument_id=evidence.instrument_id,
+    )
+    if not decision_outcome_is_actionable(evidence.decision_outcome):
+        finalized = finalize_offline_replay_decision_evidence_v1(evidence)
+        return CapitalRiskSizingOfflineReplayBindingResultV0(
+            evidence=finalized,
+            sizing_decision=None,
+            binding_applied=False,
+            quantity_provenance_ref="",
+            risk_sizing_ref="",
+            quantity_status=_QUANTITY_STATUS_NOT_BOUND,
+            risk_sizing_effect=RISK_SIZING_EFFECT_NONE,
+        )
+
+    sizing_input, build_errors = build_capital_risk_sizing_input_from_decision_v0(
+        decision=evidence,
+        capital_context=ctx,
+    )
+    if sizing_input is None:
+        finalized = finalize_offline_replay_decision_evidence_v1(
+            replace(
+                evidence,
+                reason_codes=tuple(dict.fromkeys((*evidence.reason_codes, *build_errors))),
+            )
+        )
+        return CapitalRiskSizingOfflineReplayBindingResultV0(
+            evidence=finalized,
+            sizing_decision=None,
+            binding_applied=False,
+            quantity_provenance_ref="",
+            risk_sizing_ref="",
+            quantity_status=_QUANTITY_STATUS_NOT_BOUND,
+            risk_sizing_effect=RISK_SIZING_EFFECT_NONE,
+        )
+
+    sizing_decision = evaluate_capital_risk_sizing_v1(sizing_input)
+    quantity_provenance_ref = ""
+    provenance = sizing_decision.quantity_provenance
+    if provenance is not None:
+        quantity_provenance_ref = compute_quantity_provenance_ref(provenance)
+    risk_sizing_ref = compute_risk_sizing_decision_ref_v0(sizing_decision)
+    quantity_status = _quantity_status_from_sizing_v0(sizing_decision)
+
+    bound_evidence = replace(
+        evidence,
+        quantity_status=quantity_status,
+        quantity_provenance_ref=quantity_provenance_ref,
+        risk_sizing_ref=risk_sizing_ref,
+        risk_sizing_effect=RISK_SIZING_EFFECT_BOUND_OFFLINE,
+    )
+    finalized = finalize_offline_replay_decision_evidence_v1(bound_evidence)
+    return CapitalRiskSizingOfflineReplayBindingResultV0(
+        evidence=finalized,
+        sizing_decision=sizing_decision,
+        binding_applied=True,
+        quantity_provenance_ref=quantity_provenance_ref,
+        risk_sizing_ref=risk_sizing_ref,
+        quantity_status=quantity_status,
+        risk_sizing_effect=RISK_SIZING_EFFECT_BOUND_OFFLINE,
+    )
+
+
+def build_scenario_tick_decision_evidence_v0(
+    *,
+    decision_id: str,
+    replay_id: str,
+    instrument_id: str,
+    trading_epoch: int,
+    composition_result_id: str,
+    entry_exit_policy_ref: str,
+    selected_side: str,
+    decision_outcome: str,
+    reason_codes: tuple[str, ...],
+    decision_precedence_trace: tuple[str, ...],
+    config_digest: str,
+    implementation_digest: str,
+) -> CanonicalTradingDecisionEvidenceV1:
+    input_material = json.dumps(
+        {
+            "decision_id": decision_id,
+            "instrument_id": instrument_id,
+            "trading_epoch": trading_epoch,
+            "composition_result_id": composition_result_id,
+        },
+        sort_keys=True,
+    )
+    input_digest = hashlib.sha256(input_material.encode("utf-8")).hexdigest()
+    return CanonicalTradingDecisionEvidenceV1(
+        decision_id=decision_id,
+        replay_id=replay_id,
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        market_context_ref=f"scenario-market-context::{decision_id}",
+        scope_initialization_ref=f"scenario-scope-init::{decision_id}",
+        scope_event_ref=f"scenario-scope-event::{decision_id}",
+        bull_assessment_ref=f"scenario-bull::{decision_id}",
+        bear_assessment_ref=f"scenario-bear::{decision_id}",
+        state_switch_ref=f"scenario-state-switch::{decision_id}",
+        bull_survival_ref=f"scenario-bull-survival::{decision_id}",
+        bear_survival_ref=f"scenario-bear-survival::{decision_id}",
+        bull_suitability_ref=f"scenario-bull-suitability::{decision_id}",
+        bear_suitability_ref=f"scenario-bear-suitability::{decision_id}",
+        composition_result_ref=composition_result_id,
+        entry_exit_policy_ref=entry_exit_policy_ref,
+        current_scope_ref=f"scenario-current-scope::{decision_id}",
+        next_scope_ref=f"scenario-next-scope::{decision_id}",
+        previous_direction_state="neutral",
+        next_direction_state=selected_side,
+        selected_side=selected_side,
+        selected_strategy_ref="",
+        decision_outcome=decision_outcome,
+        entry_or_exit_policy_ref=entry_exit_policy_ref,
+        reason_codes=reason_codes,
+        decision_precedence_trace=decision_precedence_trace,
+        component_versions={},
+        policy_versions={},
+        config_digest=config_digest,
+        implementation_digest=implementation_digest,
+        input_digest=input_digest,
+        semantic_digest="",
+    )
+
+
+def evaluate_scenario_capital_risk_sizing_v0(
+    evidence: CanonicalTradingDecisionEvidenceV1,
+    *,
+    reference_price: Decimal | None = None,
+) -> CapitalRiskSizingOfflineReplayBindingResultV0:
+    ctx = default_offline_replay_capital_context_v0(
+        instrument_id=evidence.instrument_id,
+        reference_price=reference_price,
+    )
+    return bind_capital_risk_sizing_offline_replay_evidence_v0(
+        evidence,
+        capital_context=ctx,
+    )
+
+
+def capital_risk_sizing_binding_non_authority_boundary_ok_v0(
+    binding: CapitalRiskSizingOfflineReplayBindingResultV0,
+) -> bool:
+    ev = binding.evidence
+    decision = binding.sizing_decision
+    if not ev.execution_eligible and ev.adapter_compatible:
+        return False
+    if ev.authority_effect != AUTHORITY_EFFECT_NONE:
+        return False
+    if ev.runtime_effect != RUNTIME_EFFECT_NONE:
+        return False
+    if ev.order_effect != "NONE":
+        return False
+    if binding.binding_applied and binding.risk_sizing_effect != RISK_SIZING_EFFECT_BOUND_OFFLINE:
+        return False
+    if decision is not None:
+        if decision.adapter_compatible or decision.authority_effect != AUTHORITY_EFFECT_NONE:
+            return False
+        if decision.runtime_effect != RUNTIME_EFFECT_NONE:
+            return False
+    return True
+
+
+def system_economic_evidence_admissible_v0(
+    binding: CapitalRiskSizingOfflineReplayBindingResultV0,
+) -> bool:
+    """Offline replay must not admit system-economic evidence without full chain proof."""
+    ev = binding.evidence
+    if not binding.binding_applied:
+        return False
+    if not binding.quantity_provenance_ref:
+        return False
+    if ev.execution_eligible or ev.adapter_compatible:
+        return False
+    if ev.risk_sizing_effect != RISK_SIZING_EFFECT_BOUND_OFFLINE:
+        return False
+    return False

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -17,7 +17,7 @@ FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_OWNER = (
 
 ParityStatus = Literal["PASS", "PARTIAL", "GAP", "NOT_APPLICABLE"]
 
-NEXT_RECOMMENDED_SLICE = "SCENARIO_REPLAY_DOUBLE_PLAY_ENTRY_EXIT_POLICY_BINDING_PARITY_REWIRE_V0"
+NEXT_RECOMMENDED_SLICE = "CANONICAL_ORDER_INTENT_OFFLINE_REPLAY_BINDING_PARITY_REWIRE_V0"
 
 ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
@@ -255,23 +255,20 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
                 " evaluate_double_play_entry_exit_policy_v0()"
             ),
             current_scenario_replay_binding=(
-                "offline_double_play_scenario_replay_v0: composition +"
-                " evaluate_master_v2_local_flow_v1() packet handoff only;"
-                " no entry-exit policy evaluation"
+                "offline_double_play_scenario_replay_v0 ->"
+                " evaluate_scenario_entry_exit_policy_v0() per tick"
             ),
             current_backtest_binding="Integrated replay",
             current_runtime_semantics_reference=(
                 "canonical_core_runtime_integration_bridge_v0 -> integrated replay evidence"
             ),
-            parity_status="GAP",
+            parity_status="PASS",
             evidence_refs=(
                 "tests/trading/master_v2/test_double_play_entry_exit_policy_v0.py",
                 "tests/trading/master_v2/test_integrated_offline_trading_logic_replay_v1.py",
+                "tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py",
             ),
-            missing_binding_if_any=(
-                "offline_double_play_scenario_replay_v0 ->"
-                " evaluate_double_play_entry_exit_policy_v0() per tick"
-            ),
+            missing_binding_if_any="",
             recommended_next_slice=NEXT_RECOMMENDED_SLICE,
         ),
         ParitySurfaceAssessmentV0(
@@ -282,11 +279,12 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
                 "src/trading/master_v2/double_play_capital_slot.py",
             ),
             current_integrated_offline_replay_binding=(
-                "NOT_BOUND: quantity_status=NOT_BOUND, risk_sizing_effect=NONE"
+                "integrated_offline_trading_logic_replay_v1 ->"
+                " bind_capital_risk_sizing_offline_replay_evidence_v0()"
             ),
             current_scenario_replay_binding=(
-                "offline_double_play_scenario_replay_v0 -> evaluate_capital_slot_ratchet/release;"
-                " not capital_risk_sizing_v1"
+                "offline_double_play_scenario_replay_v0 ->"
+                " evaluate_scenario_capital_risk_sizing_v0() per tick"
             ),
             current_backtest_binding=(
                 "No evaluate_capital_risk_sizing_v1 wiring in mv2_research_wiring_v1"
@@ -295,16 +293,14 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
                 "canonical_core_runtime_integration_intent_pipeline_bridge_v0"
                 " Slice B BOUND_NOT_ACTIVATED"
             ),
-            parity_status="GAP",
+            parity_status="PARTIAL",
             evidence_refs=(
                 "tests/governance/test_capital_risk_sizing_v1.py",
                 "tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py",
+                "tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py",
             ),
-            missing_binding_if_any=(
-                "Unified evaluate_capital_risk_sizing_v1 chain across"
-                " Integrated / Backtest / Scenario replay surfaces"
-            ),
-            recommended_next_slice=("CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_PARITY_REWIRE_V0"),
+            missing_binding_if_any=("Backtest mv2_research_wiring_v1 unified sizing chain parity"),
+            recommended_next_slice=NEXT_RECOMMENDED_SLICE,
         ),
         ParitySurfaceAssessmentV0(
             surface_id="I",

--- a/src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py
+++ b/src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py
@@ -9,9 +9,11 @@ No I/O, runtime, orders, adapter, quantity, or authority effects.
 from __future__ import annotations
 
 import hashlib
+import importlib
 import json
 import re
 from dataclasses import dataclass, replace
+from decimal import Decimal
 from typing import Mapping, Optional, Tuple
 
 from trading.master_v2.canonical_market_context_v1 import (
@@ -31,6 +33,7 @@ from trading.master_v2.canonical_scope_initialization_v1 import (
     ScopeReinitializationGuardV1,
     initialize_canonical_scope,
 )
+from src.governance.capital_risk_sizing_v1 import CapitalRiskSizingDecisionV1
 from trading.master_v2.canonical_trading_decision_evidence_v1 import (
     CANONICAL_TRADING_DECISION_EVIDENCE_LAYER_VERSION,
     CanonicalTradingDecisionEvidenceV1,
@@ -240,6 +243,7 @@ class IntegratedOfflineReplayIntermediateV1:
     bear_suitability: SuitabilityResultV1
     composition_result: DoublePlayCompositionResultV1
     entry_exit_decision: EntryExitPolicyDecisionV0
+    capital_risk_sizing_decision: Optional[CapitalRiskSizingDecisionV1]
     state_switch: StateSwitchEvidenceV1
     current_scope: CanonicalScopeSnapshotV1
     next_scope_ref: str
@@ -810,7 +814,19 @@ def run_integrated_offline_trading_logic_replay_v1(
         input_digest=input_digest,
         semantic_digest="",
     )
-    evidence = with_computed_evidence_semantic_digest(evidence)
+    _crs_binding = importlib.import_module(
+        "trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0"
+    )
+    capital_context = _crs_binding.default_offline_replay_capital_context_v0(
+        instrument_id=inp.instrument_id,
+        reference_price=Decimal(str(bound_context.mark_price)),
+    )
+    sizing_binding = _crs_binding.bind_capital_risk_sizing_offline_replay_evidence_v0(
+        evidence,
+        capital_context=capital_context,
+    )
+    evidence = sizing_binding.evidence
+    capital_risk_sizing_decision = sizing_binding.sizing_decision
 
     intermediate = IntegratedOfflineReplayIntermediateV1(
         market_context=bound_context,
@@ -824,6 +840,7 @@ def run_integrated_offline_trading_logic_replay_v1(
         bear_suitability=bear_suitability,
         composition_result=composition_result,
         entry_exit_decision=entry_exit_decision,
+        capital_risk_sizing_decision=capital_risk_sizing_decision,
         state_switch=state_switch,
         current_scope=current_scope,
         next_scope_ref=next_scope_ref,
@@ -839,6 +856,9 @@ def run_integrated_offline_trading_logic_replay_v1(
         and entry_exit_decision.risk_sizing_effect == "NONE"
         and not evidence.execution_eligible
         and not evidence.adapter_compatible
+        and evidence.authority_effect == "NONE"
+        and evidence.runtime_effect == "NONE"
+        and evidence.order_effect == "NONE"
     )
     replay_pass = boundary_ok
     if not boundary_ok:

--- a/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
+++ b/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
@@ -17,6 +17,14 @@ from trading.master_v2.double_play_composition_matrix_v1 import (
     CompositionStatus,
     DoublePlayCompositionResultV1,
 )
+from trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0 import (
+    CANONICAL_CAPITAL_RISK_SIZING_OWNER,
+    CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER,
+    RISK_SIZING_EFFECT_BOUND_OFFLINE,
+    RISK_SIZING_EFFECT_NONE,
+    CapitalRiskSizingOfflineReplayBindingResultV0,
+    capital_risk_sizing_binding_non_authority_boundary_ok_v0,
+)
 from trading.master_v2.double_play_composition_scenario_matrix_adapter_v0 import (
     CANONICAL_DOUBLE_PLAY_COMPOSITION_OWNER,
     DOUBLE_PLAY_COMPOSITION_SCENARIO_MATRIX_ADAPTER_OWNER,
@@ -80,6 +88,9 @@ class ParityDecisionEnvelopeV0:
     quantity_status: str
     authority_effect: str
     runtime_effect: str
+    quantity_provenance_ref: str = ""
+    risk_sizing_ref: str = ""
+    risk_sizing_effect: str = RISK_SIZING_EFFECT_NONE
     conflict_status: Optional[str] = None
     selected_side: Optional[str] = None
 
@@ -161,6 +172,9 @@ def extract_integrated_parity_envelope_v0(
         execution_eligible=evidence.execution_eligible,
         adapter_compatible=evidence.adapter_compatible,
         quantity_status=evidence.quantity_status,
+        quantity_provenance_ref=evidence.quantity_provenance_ref,
+        risk_sizing_ref=evidence.risk_sizing_ref,
+        risk_sizing_effect=evidence.risk_sizing_effect,
         authority_effect=evidence.authority_effect,
         runtime_effect=evidence.runtime_effect,
         conflict_status=conflict_status,
@@ -215,6 +229,56 @@ def extract_entry_exit_policy_parity_envelope_v0(
     )
 
 
+def extract_capital_risk_sizing_parity_envelope_v0(
+    binding: CapitalRiskSizingOfflineReplayBindingResultV0,
+    *,
+    decision_outcome: str = "",
+    composition_result_id: str = "",
+) -> ParityDecisionEnvelopeV0:
+    ev = binding.evidence
+    return ParityDecisionEnvelopeV0(
+        decision_outcome=decision_outcome or ev.decision_outcome,
+        previous_side_state=None,
+        next_side_state=None,
+        composition_status="",
+        composition_result_id=composition_result_id,
+        entry_or_exit_policy_ref=ev.entry_or_exit_policy_ref,
+        reason_codes=tuple(ev.reason_codes),
+        decision_precedence_trace=tuple(ev.decision_precedence_trace),
+        execution_eligible=ev.execution_eligible,
+        adapter_compatible=ev.adapter_compatible,
+        quantity_status=binding.quantity_status,
+        quantity_provenance_ref=binding.quantity_provenance_ref,
+        risk_sizing_ref=binding.risk_sizing_ref,
+        risk_sizing_effect=binding.risk_sizing_effect,
+        authority_effect=ev.authority_effect,
+        runtime_effect=ev.runtime_effect,
+    )
+
+
+def extract_scenario_replay_tick_capital_risk_sizing_envelope_v0(
+    tick: OfflineDoublePlayScenarioReplayTickRecordV0,
+) -> ParityDecisionEnvelopeV0:
+    return ParityDecisionEnvelopeV0(
+        decision_outcome=tick.entry_exit_decision_outcome,
+        previous_side_state=tick.prior_side_state.value,
+        next_side_state=tick.side_state.value,
+        composition_status=tick.composition_status,
+        composition_result_id=tick.composition_result_id,
+        entry_or_exit_policy_ref=tick.entry_exit_policy_ref,
+        reason_codes=tuple(tick.sizing_reason_codes),
+        decision_precedence_trace=tuple(tick.entry_exit_decision_precedence_trace),
+        execution_eligible=False,
+        adapter_compatible=False,
+        quantity_status=tick.quantity_status,
+        quantity_provenance_ref=tick.quantity_provenance_ref,
+        risk_sizing_ref=tick.capital_risk_sizing_ref,
+        risk_sizing_effect=tick.risk_sizing_effect,
+        authority_effect="NONE",
+        runtime_effect="NONE",
+    )
+
+
 def extract_scenario_replay_tick_parity_envelope_v0(
     tick: OfflineDoublePlayScenarioReplayTickRecordV0,
 ) -> ParityDecisionEnvelopeV0:
@@ -261,8 +325,24 @@ def assert_non_authority_boundary_v0(envelope: ParityDecisionEnvelopeV0) -> None
     assert not envelope.execution_eligible
     assert not envelope.adapter_compatible
     assert envelope.quantity_status == "NOT_BOUND"
+    assert envelope.risk_sizing_effect == RISK_SIZING_EFFECT_NONE
     assert envelope.authority_effect == "NONE"
     assert envelope.runtime_effect == "NONE"
+
+
+def assert_capital_risk_sizing_non_authority_boundary_v0(
+    envelope: ParityDecisionEnvelopeV0,
+) -> None:
+    assert not envelope.execution_eligible
+    assert not envelope.adapter_compatible
+    assert envelope.authority_effect == "NONE"
+    assert envelope.runtime_effect == "NONE"
+    if envelope.risk_sizing_effect == RISK_SIZING_EFFECT_BOUND_OFFLINE:
+        assert envelope.risk_sizing_ref
+    assert envelope.risk_sizing_effect in {
+        RISK_SIZING_EFFECT_NONE,
+        RISK_SIZING_EFFECT_BOUND_OFFLINE,
+    }
 
 
 def assert_scenario_replay_zero_order_boundary_v0(
@@ -343,6 +423,10 @@ def canonical_owner_refs_v0() -> Mapping[str, str]:
         "entry_exit_policy": CANONICAL_ENTRY_EXIT_POLICY_OWNER,
         "entry_exit_scenario_binding_adapter": (
             DOUBLE_PLAY_ENTRY_EXIT_SCENARIO_BINDING_ADAPTER_OWNER
+        ),
+        "capital_risk_sizing": CANONICAL_CAPITAL_RISK_SIZING_OWNER,
+        "capital_risk_sizing_offline_replay_binding_adapter": (
+            CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER
         ),
         "parity_harness": INTEGRATED_VS_SCENARIO_REPLAY_FULL_SYSTEM_PARITY_HARNESS_OWNER,
     }

--- a/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
+++ b/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
@@ -53,6 +53,13 @@ from trading.master_v2.double_play_composition import (
     DoublePlayCompositionInput,
     RequestedSide,
 )
+from decimal import Decimal
+
+from trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0 import (
+    DEFAULT_OFFLINE_BINDING_CONFIG_DIGEST,
+    build_scenario_tick_decision_evidence_v0,
+    evaluate_scenario_capital_risk_sizing_v0,
+)
 from trading.master_v2.double_play_composition_scenario_matrix_adapter_v0 import (
     build_scenario_matrix_composition_input_v0,
     compose_double_play_scenario_via_canonical_matrix_v0,
@@ -213,6 +220,12 @@ class OfflineDoublePlayScenarioReplayTickRecordV0:
     entry_exit_decision_outcome: str
     entry_exit_reason_codes: tuple[str, ...]
     entry_exit_decision_precedence_trace: tuple[str, ...]
+    capital_risk_sizing_ref: str
+    quantity_status: str
+    quantity_provenance_ref: str
+    risk_sizing_effect: str
+    sizing_outcome: str
+    sizing_reason_codes: tuple[str, ...]
     decision_id: str
     decision_snapshot: dict[str, Any] | None
     master_v2_decision_digest: str | None
@@ -891,6 +904,30 @@ def run_offline_double_play_scenario_replay_v0(
         )
         all_proof.extend(tick_proof)
 
+        tick_evidence = build_scenario_tick_decision_evidence_v0(
+            decision_id=decision_id,
+            replay_id=f"{inp.correlation_id_prefix}-replay",
+            instrument_id=inp.selected_future_id,
+            trading_epoch=tick.tick_index,
+            composition_result_id=composition_result.composition_id,
+            entry_exit_policy_ref=entry_exit_decision.policy_decision_id,
+            selected_side=composition_result.selected_side.value,
+            decision_outcome=entry_exit_decision.decision_outcome.value,
+            reason_codes=entry_exit_decision.reason_codes,
+            decision_precedence_trace=entry_exit_decision.decision_precedence_trace,
+            config_digest=DEFAULT_OFFLINE_BINDING_CONFIG_DIGEST,
+            implementation_digest="offline-double-play-scenario-replay-v0",
+        )
+        sizing_binding = evaluate_scenario_capital_risk_sizing_v0(
+            tick_evidence,
+            reference_price=Decimal(str(tick.price)),
+        )
+        sizing_decision = sizing_binding.sizing_decision
+        sizing_outcome = (
+            sizing_decision.outcome.value if sizing_decision is not None else "NOT_APPLICABLE"
+        )
+        sizing_reason_codes = sizing_decision.reason_codes if sizing_decision is not None else ()
+
         record = OfflineDoublePlayScenarioReplayTickRecordV0(
             tick_index=tick.tick_index,
             timestamp_ms=tick.timestamp_ms,
@@ -912,6 +949,12 @@ def run_offline_double_play_scenario_replay_v0(
             entry_exit_decision_outcome=entry_exit_decision.decision_outcome.value,
             entry_exit_reason_codes=entry_exit_decision.reason_codes,
             entry_exit_decision_precedence_trace=entry_exit_decision.decision_precedence_trace,
+            capital_risk_sizing_ref=sizing_binding.risk_sizing_ref,
+            quantity_status=sizing_binding.quantity_status,
+            quantity_provenance_ref=sizing_binding.quantity_provenance_ref,
+            risk_sizing_effect=sizing_binding.risk_sizing_effect,
+            sizing_outcome=sizing_outcome,
+            sizing_reason_codes=sizing_reason_codes,
             decision_id=decision_id,
             decision_snapshot=snapshot,
             master_v2_decision_digest=decision_digest,

--- a/tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py
@@ -1,0 +1,301 @@
+"""Capital/Risk/Sizing binding parity: integrated offline replay vs scenario replay (offline only)."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import subprocess
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+from trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0 import (
+    CANONICAL_CAPITAL_RISK_SIZING_OWNER,
+    CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER,
+    RISK_SIZING_EFFECT_BOUND_OFFLINE,
+    RISK_SIZING_EFFECT_NONE,
+    bind_capital_risk_sizing_offline_replay_evidence_v0,
+    build_scenario_tick_decision_evidence_v0,
+    capital_risk_sizing_binding_non_authority_boundary_ok_v0,
+    default_offline_replay_capital_context_v0,
+    evaluate_scenario_capital_risk_sizing_v0,
+    system_economic_evidence_admissible_v0,
+)
+from trading.master_v2.double_play_composition_matrix_v1 import CompositionStatus
+from trading.master_v2.double_play_entry_exit_policy_v0 import (
+    DecisionOutcome,
+    EntryExitDirectionState,
+)
+from trading.master_v2.double_play_state import SideState
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    assert_capital_risk_sizing_non_authority_boundary_v0,
+    assert_scenario_replay_zero_order_boundary_v0,
+    canonical_owner_refs_v0,
+    extract_capital_risk_sizing_parity_envelope_v0,
+    extract_integrated_parity_envelope_v0,
+    extract_scenario_replay_tick_capital_risk_sizing_envelope_v0,
+    scan_changed_paths_for_forbidden_runtime_v0,
+)
+from trading.master_v2.offline_double_play_scenario_replay_v0 import (
+    OFFLINE_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER,
+    OfflineDoublePlayScenarioReplayInputV0,
+    SYNTHETIC_FUTURES_INSTRUMENT,
+    build_default_bull_bear_bull_scenario_ticks,
+    run_offline_double_play_scenario_replay_v0,
+)
+from tests.trading.master_v2.test_integrated_offline_trading_logic_replay_v1 import _run
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_INSTRUMENT = SYNTHETIC_FUTURES_INSTRUMENT
+_EPOCH = 48
+_CONTEXT = "capital-risk-sizing-offline-replay-binding-parity-v0"
+
+_SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py",
+    "src/trading/master_v2/canonical_trading_decision_evidence_v1.py",
+    "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py",
+    "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "scripts/ops/run_capital_risk_sizing_offline_replay_binding_parity_rewire_v0.py",
+    "tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py",
+)
+
+_FORBIDDEN_IMPORT_SCAN_PATHS = (
+    REPO_ROOT / "src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py",
+    REPO_ROOT
+    / "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    REPO_ROOT / "scripts/ops/run_capital_risk_sizing_offline_replay_binding_parity_rewire_v0.py",
+    REPO_ROOT
+    / "tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py",
+)
+
+ALLOWED_SLICE_CHANGED_PATH_PREFIXES = _SLICE_CHANGED_FILES
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def test_owner_constants_and_canonical_reuse_v0() -> None:
+    refs = canonical_owner_refs_v0()
+    assert refs["capital_risk_sizing"] == CANONICAL_CAPITAL_RISK_SIZING_OWNER
+    assert (
+        refs["capital_risk_sizing_offline_replay_binding_adapter"]
+        == CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER
+    )
+    assert refs["scenario_replay"] == OFFLINE_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER
+
+
+def test_forbidden_runtime_paths_guard_v0() -> None:
+    ok, violations = scan_changed_paths_for_forbidden_runtime_v0(
+        ALLOWED_SLICE_CHANGED_PATH_PREFIXES
+    )
+    assert ok is True
+    assert violations == ()
+
+
+def test_slice_sources_exclude_execution_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "execution",
+            "scheduler",
+            "credentials",
+            "live_runtime",
+            "testnet",
+            "shadow",
+            "paper_lane",
+        }
+    )
+    for path in _FORBIDDEN_IMPORT_SCAN_PATHS:
+        assert path.is_file(), f"missing slice source: {path}"
+        hits = _scan_forbidden_imports(path, forbidden)
+        assert hits == [], f"forbidden imports in {path}: {hits}"
+
+
+def test_unbound_replay_cannot_admit_system_economic_evidence_v0() -> None:
+    evidence = build_scenario_tick_decision_evidence_v0(
+        decision_id="decision-unbound",
+        replay_id="replay-unbound",
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        composition_result_id="composition-unbound",
+        entry_exit_policy_ref="policy-unbound",
+        selected_side="long",
+        decision_outcome=DecisionOutcome.OBSERVE.value,
+        reason_codes=("OBSERVE",),
+        decision_precedence_trace=("observe",),
+        config_digest="config",
+        implementation_digest="impl",
+    )
+    binding = bind_capital_risk_sizing_offline_replay_evidence_v0(evidence)
+    assert binding.binding_applied is False
+    assert binding.risk_sizing_effect == RISK_SIZING_EFFECT_NONE
+    assert binding.quantity_provenance_ref == ""
+    assert not system_economic_evidence_admissible_v0(binding)
+
+
+def test_1_actionable_enter_long_sizing_bound_v0() -> None:
+    integrated = _run(
+        side_state=SideState.LONG_ARMED,
+        direction_state=EntryExitDirectionState.LONG_ARMED,
+    )
+    if integrated.intermediate is None:
+        return
+    if (
+        integrated.intermediate.composition_result.composition_status
+        is not CompositionStatus.LONG_SELECTED
+    ):
+        return
+    assert integrated.evidence.risk_sizing_effect == RISK_SIZING_EFFECT_BOUND_OFFLINE
+    assert integrated.evidence.risk_sizing_ref
+    assert integrated.evidence.quantity_provenance_ref
+    assert integrated.evidence.quantity_status in {"PASS", "REDUCE", "BLOCK", "ROUNDED_DOWN"}
+    assert integrated.intermediate.capital_risk_sizing_decision is not None
+    env = extract_integrated_parity_envelope_v0(integrated)
+    assert_capital_risk_sizing_non_authority_boundary_v0(env)
+    assert capital_risk_sizing_binding_non_authority_boundary_ok_v0(
+        bind_capital_risk_sizing_offline_replay_evidence_v0(integrated.evidence)
+    )
+
+
+def test_2_actionable_enter_short_sizing_bound_v0() -> None:
+    integrated = _run(
+        side_state=SideState.SHORT_ARMED,
+        direction_state=EntryExitDirectionState.SHORT_ARMED,
+        price_path=(3500.0, 3430.0),
+    )
+    if integrated.intermediate is None:
+        return
+    if (
+        integrated.intermediate.composition_result.composition_status
+        is not CompositionStatus.SHORT_SELECTED
+    ):
+        return
+    assert integrated.evidence.risk_sizing_effect == RISK_SIZING_EFFECT_BOUND_OFFLINE
+    assert integrated.evidence.quantity_provenance_ref
+
+
+def test_3_non_actionable_observe_remains_unbound_v0() -> None:
+    integrated = _run(price_path=(3500.0, 3600.0))
+    if (
+        integrated.intermediate
+        and integrated.intermediate.composition_result.composition_status
+        is CompositionStatus.CHOP_GUARD_BLOCK
+    ):
+        assert integrated.evidence.risk_sizing_effect == RISK_SIZING_EFFECT_NONE
+        assert integrated.evidence.quantity_status == "NOT_BOUND"
+        assert integrated.evidence.quantity_provenance_ref == ""
+
+
+def test_scenario_replay_tick_capital_risk_sizing_binding_no_shortcut_v0() -> None:
+    result = run_offline_double_play_scenario_replay_v0(
+        OfflineDoublePlayScenarioReplayInputV0(
+            selected_future_id=_INSTRUMENT,
+            ticks=build_default_bull_bear_bull_scenario_ticks(),
+            source_revision="capital-risk-sizing-binding-parity-v0",
+        )
+    )
+    assert result.replay_pass, result.fail_reasons
+    assert_scenario_replay_zero_order_boundary_v0(result)
+
+    bound_ticks = 0
+    for tick in result.tick_records:
+        env = extract_scenario_replay_tick_capital_risk_sizing_envelope_v0(tick)
+        assert_capital_risk_sizing_non_authority_boundary_v0(env)
+        if tick.risk_sizing_effect == RISK_SIZING_EFFECT_BOUND_OFFLINE:
+            bound_ticks += 1
+            assert tick.capital_risk_sizing_ref
+        if tick.quantity_provenance_ref:
+            assert tick.risk_sizing_effect == RISK_SIZING_EFFECT_BOUND_OFFLINE
+            assert tick.quantity_status in {"PASS", "REDUCE", "BLOCK", "ROUNDED_DOWN"}
+    assert bound_ticks >= 1
+
+
+def test_scenario_adapter_reuses_canonical_sizing_owner_v0() -> None:
+    adapter_src = (
+        REPO_ROOT / "src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py"
+    )
+    text = adapter_src.read_text(encoding="utf-8")
+    assert "evaluate_capital_risk_sizing_v1" in text
+    assert "build_capital_risk_sizing_input_from_decision_v0" in text
+    assert "def _build_scope_capital_envelope_v1" not in text
+
+
+def test_scenario_fixture_parity_envelope_v0() -> None:
+    evidence = build_scenario_tick_decision_evidence_v0(
+        decision_id=f"{_CONTEXT}-decision",
+        replay_id=f"{_CONTEXT}-replay",
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        composition_result_id=f"{_CONTEXT}-composition",
+        entry_exit_policy_ref=f"{_CONTEXT}-policy",
+        selected_side="long",
+        decision_outcome=DecisionOutcome.ENTER_LONG.value,
+        reason_codes=("PASS",),
+        decision_precedence_trace=("enter_long",),
+        config_digest="config",
+        implementation_digest="impl",
+    )
+    binding = evaluate_scenario_capital_risk_sizing_v0(
+        evidence,
+        reference_price=Decimal("3500"),
+    )
+    env = extract_capital_risk_sizing_parity_envelope_v0(
+        binding,
+        decision_outcome=DecisionOutcome.ENTER_LONG.value,
+        composition_result_id=f"{_CONTEXT}-composition",
+    )
+    assert binding.binding_applied is True
+    assert env.quantity_provenance_ref
+    assert env.risk_sizing_ref
+    assert_capital_risk_sizing_non_authority_boundary_v0(env)
+    assert not system_economic_evidence_admissible_v0(binding)
+
+
+def test_pr4946_parity_suite_still_passes_v0() -> None:
+    from tests.trading.master_v2 import (
+        test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0 as pr4946,
+    )
+
+    pr4946.test_harness_and_replay_owner_constants_v0()
+    pr4946.test_1_long_bull_path_parity_v0()
+    pr4946.test_3_both_confirmed_chop_guard_parity_v0()
+    pr4946.test_5_reversal_preparation_boundary_parity_v0()
+    pr4946.test_scenario_replay_e2e_composition_and_zero_order_boundary_v0()
+
+
+def test_pr4948_entry_exit_binding_suite_still_passes_v0() -> None:
+    from tests.trading.master_v2 import (
+        test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0 as pr4948,
+    )
+
+    pr4948.test_owner_constants_and_canonical_reuse_v0()
+    pr4948.test_scenario_replay_tick_entry_exit_binding_no_shortcut_v0()
+
+
+def test_prometheus_client_importable_v0() -> None:
+    assert importlib.util.find_spec("prometheus_client") is not None
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import prometheus_client; print('PROMETHEUS_CLIENT_IMPORTABLE=true')",
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "PROMETHEUS_CLIENT_IMPORTABLE=true" in proc.stdout

--- a/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
+++ b/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
@@ -52,8 +52,9 @@ def test_gap_assessment_owner_and_surface_count_v0() -> None:
 
 def test_gap_assessment_status_distribution_v0() -> None:
     counts = parity_status_counts_v0()
-    assert counts["PASS"] == 1
-    assert counts["GAP"] >= 2
+    assert counts["PASS"] == 2
+    assert counts["PARTIAL"] >= 8
+    assert counts["GAP"] == 0
     assert counts["NOT_APPLICABLE"] >= 3
     assert sum(counts.values()) == 16
 
@@ -64,13 +65,19 @@ def test_composition_surface_pass_v0() -> None:
     assert composition.missing_binding_if_any == ""
 
 
-def test_entry_exit_is_earliest_gap_recommended_slice_v0() -> None:
-    entry_exit = next(item for item in parity_surface_assessments_v0() if item.surface_id == "G")
-    assert entry_exit.parity_status == "GAP"
-    assert NEXT_RECOMMENDED_SLICE == (
-        "SCENARIO_REPLAY_DOUBLE_PLAY_ENTRY_EXIT_POLICY_BINDING_PARITY_REWIRE_V0"
+def test_capital_risk_sizing_surface_partial_v0() -> None:
+    sizing = next(item for item in parity_surface_assessments_v0() if item.surface_id == "H")
+    assert sizing.parity_status == "PARTIAL"
+    assert (
+        NEXT_RECOMMENDED_SLICE == "CANONICAL_ORDER_INTENT_OFFLINE_REPLAY_BINDING_PARITY_REWIRE_V0"
     )
-    assert entry_exit.recommended_next_slice == NEXT_RECOMMENDED_SLICE
+    assert sizing.recommended_next_slice == NEXT_RECOMMENDED_SLICE
+
+
+def test_entry_exit_surface_pass_after_pr4948_v0() -> None:
+    entry_exit = next(item for item in parity_surface_assessments_v0() if item.surface_id == "G")
+    assert entry_exit.parity_status == "PASS"
+    assert entry_exit.missing_binding_if_any == ""
 
 
 def test_gap_matrix_markdown_renders_v0() -> None:

--- a/tests/trading/master_v2/test_integrated_offline_trading_logic_replay_v1.py
+++ b/tests/trading/master_v2/test_integrated_offline_trading_logic_replay_v1.py
@@ -605,15 +605,15 @@ def test_boundary_fields_always_negative() -> None:
     dec = result.intermediate.entry_exit_decision if result.intermediate else None
     assert not ev.execution_eligible
     assert not ev.adapter_compatible
-    assert ev.quantity_status == "NOT_BOUND"
     assert ev.authority_effect == "NONE"
     assert ev.runtime_effect == "NONE"
     assert ev.order_effect == "NONE"
-    assert ev.risk_sizing_effect == "NONE"
+    assert ev.risk_sizing_effect in {"NONE", "BOUND_OFFLINE"}
     if dec:
         assert not dec.execution_eligible
         assert not dec.adapter_compatible
         assert dec.quantity_status == "NOT_BOUND"
+        assert dec.risk_sizing_effect == "NONE"
 
 
 def test_provenance_chain_refs_populated() -> None:

--- a/tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py
@@ -351,7 +351,8 @@ def test_pr4947_gap_assessment_suite_still_passes_v0() -> None:
         test_full_canonical_system_backtest_parity_gap_assessment_contract_v0 as pr4947,
     )
 
-    pr4947.test_entry_exit_is_earliest_gap_recommended_slice_v0()
+    pr4947.test_capital_risk_sizing_surface_partial_v0()
+    pr4947.test_entry_exit_surface_pass_after_pr4948_v0()
     pr4947.test_pr4946_parity_suite_still_passes_v0()
 
 


### PR DESCRIPTION
## Summary
- Bind `evaluate_capital_risk_sizing_v1` into integrated offline replay and scenario replay via a reuse-first offline adapter (`capital_risk_sizing_offline_replay_binding_adapter_v0`).
- Extend `CanonicalTradingDecisionEvidenceV1` with `quantity_provenance_ref` / `risk_sizing_ref` and populate `quantity_status` + `risk_sizing_effect=BOUND_OFFLINE` for actionable offline paths while preserving `execution_eligible=false`, `adapter_compatible=false`, and `authority_effect=NONE`.
- Add contract tests, parity harness helpers, gap-assessment updates (surface H → PARTIAL, surface G → PASS), and durable evidence script with `MANIFEST_VERIFY_RC=0`.

## Target flags
- `CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BOUND=true`
- `CAPITAL_RISK_SIZING_BACKTEST_PARITY_ASSESSED=true`
- `LIVE_AUTHORIZED=false`
- `ORDERS_ALLOWED=false`
- `SCHEDULER_RUNTIME_ALLOWED=false`
- `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`
- `RUNTIME_REWIRE_ADMISSIBLE=false`
- `FULL_CANONICAL_CHAIN_WIRED=false`

## Test plan
- [x] `tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py`
- [x] `tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py`
- [x] `tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py`
- [x] `tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py`
- [x] `tests/trading/master_v2/test_integrated_offline_trading_logic_replay_v1.py`
- [x] `ruff format --check .` / `ruff check .`
- [x] Evidence: `MANIFEST_VERIFY_RC=0` at `Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/capital_risk_sizing_offline_replay_binding_parity_rewire_v0_20260706T202629Z`