### PR TITLE
Backtest KillSwitch state-file wiring v0 (Surface K backtest parity)

### DIFF
--- a/scripts/ops/run_backtest_killswitch_state_file_wiring_v0.py
+++ b/scripts/ops/run_backtest_killswitch_state_file_wiring_v0.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for backtest KillSwitch state-file wiring v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+BASE_HEAD = "bac655e6b459fbd23c0b6b652b8fd63e673b700a"
+SOURCE_EVIDENCE = (
+    ARCHIVE_ROOT
+    / "research/pr4956_surface_k_killswitch_boundary_offline_replay_binding_parity_rewire_merge_closeout_20260706T223758Z"
+)
+NEXT_RECOMMENDED_SLICE = "BACKTEST_RECONCILIATION_STATE_FILE_WIRING_V0"
+VERDICT = "BACKTEST_KILLSWITCH_STATE_FILE_WIRING_V0_PASS"
+PROCESS_CLASSIFICATION = "BOUNDED_REUSE_FIRST_BACKTEST_PARITY_REWIRE"
+SCOPE_CLASSIFICATION = (
+    "BACKTEST_KILLSWITCH_STATE_FILE_WIRING_NO_RUNTIME_NO_ORDERS_NO_ECONOMIC_EVALUATION_V0"
+)
+TARGETED_TESTS = (
+    "tests/trading/master_v2/test_killswitch_boundary_backtest_state_file_binding_contract_v0.py",
+    "tests/trading/master_v2/test_killswitch_boundary_offline_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/killswitch_boundary_backtest_state_file_binding_adapter_v0.py",
+    "src/backtest/mv2_research_wiring_v1.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "scripts/ops/run_backtest_killswitch_state_file_wiring_v0.py",
+    "tests/trading/master_v2/test_killswitch_boundary_backtest_state_file_binding_contract_v0.py",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.rglob("*")):
+        if path.is_dir() or path.name == "MANIFEST.sha256":
+            continue
+        rel = path.relative_to(evidence_dir).as_posix()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  ./{rel}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def collect_evidence(out_dir: Path | None = None) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT / f"research/backtest_killswitch_state_file_wiring_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    branch = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    status = _run(["git", "status", "--short"]).stdout.strip()
+    diff_stat = _run(["git", "diff", "--stat", f"{BASE_HEAD}...HEAD"])
+
+    source_manifest = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=SOURCE_EVIDENCE)
+    (evidence_dir / "source_closeout_manifest_verify.log").write_text(
+        source_manifest.stdout
+        + source_manifest.stderr
+        + f"\nSOURCE_MANIFEST_VERIFY_RC={source_manifest.returncode}\n",
+        encoding="utf-8",
+    )
+
+    (evidence_dir / "git_context.txt").write_text(
+        "\n".join(
+            [
+                f"HEAD={head}",
+                f"BRANCH={branch}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"BASE_HEAD={BASE_HEAD}",
+                f"WORKTREE_STATUS={status or 'clean'}",
+                f"SOURCE_CLOSEOUT_EVIDENCE={SOURCE_EVIDENCE}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "changed_files.txt").write_text(
+        "\n".join(SLICE_CHANGED_FILES) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "diff_stat.txt").write_text(
+        diff_stat.stdout + diff_stat.stderr, encoding="utf-8"
+    )
+
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    pytest_cmd = [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS]
+    pytest_proc = subprocess.run(
+        pytest_cmd, cwd=str(REPO_ROOT), capture_output=True, text=True, check=False, env=env
+    )
+    (evidence_dir / "test_killswitch_backtest_state_file.log").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    ruff_format = _run(["python3", "-m", "ruff", "format", "--check", "."])
+    ruff_check = _run(["python3", "-m", "ruff", "check", "."])
+    (evidence_dir / "ruff.log").write_text(
+        "RUFF_FORMAT\n"
+        + ruff_format.stdout
+        + ruff_format.stderr
+        + "\nRUFF_CHECK\n"
+        + ruff_check.stdout
+        + ruff_check.stderr,
+        encoding="utf-8",
+    )
+
+    manifest_rc = _write_manifest(evidence_dir)
+    verify_proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    (evidence_dir / "MANIFEST_VERIFY.log").write_text(
+        verify_proc.stdout
+        + verify_proc.stderr
+        + f"\nMANIFEST_VERIFY_RC={verify_proc.returncode}\n",
+        encoding="utf-8",
+    )
+
+    tests_pass = pytest_proc.returncode == 0
+    ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0
+    verdict = (
+        VERDICT
+        if tests_pass and ruff_pass and manifest_rc == 0
+        else "BACKTEST_KILLSWITCH_STATE_FILE_WIRING_V0_BLOCKED"
+    )
+
+    report = "\n".join(
+        [
+            f"VERDICT={verdict}",
+            f"PROCESS_CLASSIFICATION={PROCESS_CLASSIFICATION}",
+            f"SCOPE_CLASSIFICATION={SCOPE_CLASSIFICATION}",
+            "GO_TOKEN_CONSUMPTION=CONSUMED_ONCE",
+            f"BASE_HEAD={BASE_HEAD}",
+            f"ORIGIN_MAIN={origin_main}",
+            f"BRANCH={branch}",
+            f"COMMIT={head}",
+            f"SOURCE_CLOSEOUT_EVIDENCE={SOURCE_EVIDENCE}",
+            f"SOURCE_MANIFEST_VERIFY_RC={source_manifest.returncode}",
+            "KILLSWITCH_BOUNDARY_BACKTEST_STATE_FILE_BOUND_STATUS=true",
+            "FULL_CANONICAL_CHAIN_WIRED=false",
+            "RUNTIME_AUTHORITY=false",
+            "ORDERS_ALLOWED=false",
+            "CREDENTIALS_USED=false",
+            "ECONOMIC_EVALUATION=false",
+            f"TESTS={'pass' if tests_pass else 'fail'}",
+            f"RUFF={'pass' if ruff_pass else 'fail'}",
+            f"DURABLE_EVIDENCE_DIR={evidence_dir}",
+            f"MANIFEST_VERIFY_RC={manifest_rc}",
+            f"NEXT_STEP={NEXT_RECOMMENDED_SLICE}",
+        ]
+    )
+    (evidence_dir / "FINAL_REPORT.txt").write_text(report + "\n", encoding="utf-8")
+    manifest_rc = _write_manifest(evidence_dir)
+
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_rc": manifest_rc,
+        "tests_pass": tests_pass,
+        "ruff_pass": ruff_pass,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-dir", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(args.out_dir)
+    print(json.dumps(result, indent=2))
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backtest/mv2_research_wiring_v1.py
+++ b/src/backtest/mv2_research_wiring_v1.py
@@ -15,6 +15,7 @@ import math
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
+from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence
 
 import pandas as pd
@@ -137,6 +138,13 @@ from src.trading.master_v2.survival_assessment_v1 import (
     SURVIVAL_ASSESSMENT_POLICY_VERSION,
     SurvivalAssessmentPolicyV1,
 )
+from src.trading.master_v2.killswitch_boundary_backtest_state_file_binding_adapter_v0 import (
+    KillSwitchBacktestStateFileRecordV0,
+    KillSwitchBoundaryBacktestStateFileEvidenceV0,
+    apply_backtest_killswitch_exposure_gate_v0,
+    bind_killswitch_boundary_backtest_state_file_evidence_v0,
+    load_killswitch_backtest_state_file_record_v0,
+)
 
 MV2_RESEARCH_WIRING_LAYER_VERSION = "v1"
 MV2_RESEARCH_WIRING_OWNER = "backtest.mv2_research_wiring_v1"
@@ -171,6 +179,17 @@ class StressClassBindingStatus(str, Enum):
 
 
 @dataclass(frozen=True)
+class KillSwitchBacktestStateFileBindingConfigV1:
+    """Optional backtest KillSwitch state-file binding — offline evidence only."""
+
+    state_file_path: Path | None = None
+    state_file_record: KillSwitchBacktestStateFileRecordV0 | None = None
+    expected_state_file_digest_ref: str = ""
+    require_state_file: bool = False
+    has_existing_position: bool = False
+
+
+@dataclass(frozen=True)
 class MV2ReplayBarOutcomeV1:
     trading_epoch: int
     context: CanonicalMarketContextV1
@@ -180,6 +199,9 @@ class MV2ReplayBarOutcomeV1:
     fail_reasons: tuple[str, ...]
     l1_observation_status: L1ObservationStatusV1
     observed_l1_used: bool
+    killswitch_backtest_state_file_evidence: (
+        KillSwitchBoundaryBacktestStateFileEvidenceV0 | None
+    ) = None
 
 
 @dataclass(frozen=True)
@@ -769,6 +791,33 @@ def _build_replay_input(
     )
 
 
+def _resolve_killswitch_backtest_state_file_record_v1(
+    binding: KillSwitchBacktestStateFileBindingConfigV1 | None,
+) -> KillSwitchBacktestStateFileRecordV0 | None:
+    if binding is None:
+        return None
+    if binding.state_file_record is not None:
+        record = binding.state_file_record
+        if binding.expected_state_file_digest_ref:
+            from src.trading.master_v2.killswitch_boundary_backtest_state_file_binding_adapter_v0 import (
+                verify_killswitch_backtest_state_file_digest_v0,
+            )
+
+            verify_killswitch_backtest_state_file_digest_v0(
+                record,
+                expected_digest_ref=binding.expected_state_file_digest_ref,
+            )
+        return record
+    if binding.state_file_path is not None:
+        return load_killswitch_backtest_state_file_record_v0(
+            binding.state_file_path,
+            expected_digest_ref=binding.expected_state_file_digest_ref,
+        )
+    if binding.require_state_file:
+        raise ValueError("killswitch_backtest_state_file_missing")
+    return None
+
+
 def run_mv2_research_backtest_wiring_v1(
     bars: pd.DataFrame,
     *,
@@ -784,6 +833,7 @@ def run_mv2_research_backtest_wiring_v1(
     expected_implementation_digest: Optional[str] = None,
     explicit_zero_cost_non_economic: bool = False,
     profile_binding: Optional[DatasetProfileBindingV1] = None,
+    killswitch_state_file_binding: KillSwitchBacktestStateFileBindingConfigV1 | None = None,
 ) -> MV2ResearchWiringResultV1:
     _fail_closed(bars.empty, "bars_empty")
     _ensure_supported_instrument(instrument_id)
@@ -856,6 +906,14 @@ def run_mv2_research_backtest_wiring_v1(
 
     replay_id = f"mv2-research-{len(bars)}"
     config_digest = _stable_digest({"cfg": dict(cfg), "owner": MV2_RESEARCH_WIRING_OWNER})
+    killswitch_state_file_record = _resolve_killswitch_backtest_state_file_record_v1(
+        killswitch_state_file_binding
+    )
+    killswitch_has_existing_position = (
+        killswitch_state_file_binding.has_existing_position
+        if killswitch_state_file_binding is not None
+        else False
+    )
 
     try:
         strategy_binding = execute_configured_strategy_signal_series_v1(
@@ -902,6 +960,17 @@ def run_mv2_research_backtest_wiring_v1(
         )
         replay_result = run_integrated_offline_trading_logic_replay_v1(replay_input)
         signal = map_decision_evidence_to_position_signal_v1(replay_result.evidence)
+        killswitch_evidence: KillSwitchBoundaryBacktestStateFileEvidenceV0 | None = None
+        if killswitch_state_file_record is not None:
+            killswitch_evidence = bind_killswitch_boundary_backtest_state_file_evidence_v0(
+                replay_result.evidence,
+                state_file=killswitch_state_file_record,
+            )
+            signal = apply_backtest_killswitch_exposure_gate_v0(
+                signal,
+                evidence=killswitch_evidence,
+                has_existing_position=killswitch_has_existing_position,
+            )
         if context.warmup_status is not WarmupStatus.WARMUP_COMPLETE:
             signal = 0
         outcomes.append(
@@ -914,6 +983,7 @@ def run_mv2_research_backtest_wiring_v1(
                 fail_reasons=replay_result.fail_reasons,
                 l1_observation_status=l1_status,
                 observed_l1_used=observed_l1_used,
+                killswitch_backtest_state_file_evidence=killswitch_evidence,
             )
         )
         replay_signals.append(signal)

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -25,7 +25,7 @@ MatrixStatus = Literal[
     "UNKNOWN",
 ]
 
-NEXT_RECOMMENDED_SLICE = "BACKTEST_KILLSWITCH_STATE_FILE_WIRING_V0"
+NEXT_RECOMMENDED_SLICE = "BACKTEST_RECONCILIATION_STATE_FILE_WIRING_V0"
 
 ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
@@ -39,6 +39,10 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "tests/trading/master_v2/test_killswitch_boundary_offline_replay_binding_parity_rewire_contract_v0.py",
     "src/trading/master_v2/reconciliation_unknown_outcome_offline_replay_binding_adapter_v0.py",
     "src/trading/master_v2/killswitch_boundary_offline_replay_binding_adapter_v0.py",
+    "src/trading/master_v2/killswitch_boundary_backtest_state_file_binding_adapter_v0.py",
+    "src/backtest/mv2_research_wiring_v1.py",
+    "scripts/ops/run_backtest_killswitch_state_file_wiring_v0.py",
+    "tests/trading/master_v2/test_killswitch_boundary_backtest_state_file_binding_contract_v0.py",
     "docs/research/FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_V0.md",
 )
 
@@ -397,7 +401,9 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
                 " evaluate_scenario_killswitch_boundary_v0() per tick"
             ),
             current_backtest_binding=(
-                "Default SafetyMode.NORMAL via integrated input; killswitch boundary bound offline"
+                "backtest/mv2_research_wiring_v1.run_mv2_research_backtest_wiring_v1"
+                " -> bind_killswitch_boundary_backtest_state_file_evidence_v0()"
+                " via killswitch_boundary_backtest_state_file_binding_adapter_v0"
             ),
             current_runtime_semantics_reference=(
                 "src/ops/gates/risk_gate.py; FUTURES_RISK_SAFETY_KILLSWITCH_CONTRACT_V0"
@@ -406,10 +412,9 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
             evidence_refs=(
                 "tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py::test_killswitch_blocks_activation",
                 "tests/trading/master_v2/test_killswitch_boundary_offline_replay_binding_parity_rewire_contract_v0.py",
+                "tests/trading/master_v2/test_killswitch_boundary_backtest_state_file_binding_contract_v0.py",
             ),
-            missing_binding_if_any=(
-                "Backtest wiring explicit KillSwitch state file (out of offline scope)"
-            ),
+            missing_binding_if_any="",
             recommended_next_slice=NEXT_RECOMMENDED_SLICE,
         ),
         ParitySurfaceAssessmentV0(

--- a/src/trading/master_v2/killswitch_boundary_backtest_state_file_binding_adapter_v0.py
+++ b/src/trading/master_v2/killswitch_boundary_backtest_state_file_binding_adapter_v0.py
@@ -1,0 +1,308 @@
+# src/trading/master_v2/killswitch_boundary_backtest_state_file_binding_adapter_v0.py
+"""
+Backtest state-file adapter: binds MV2 research backtest wiring to canonical
+KillSwitch boundary semantics via the Surface K offline replay adapter.
+
+Wiring-only parity slice — no runtime authority, no order effects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from trading.master_v2.double_play_entry_exit_policy_v0 import (
+    PositionState,
+    ReconciliationState,
+)
+from trading.master_v2.killswitch_boundary_offline_replay_binding_adapter_v0 import (
+    KILLSWITCH_BOUNDARY_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER,
+    KILLSWITCH_FENCING_OWNER,
+    KillSwitchBoundaryMode,
+    KillSwitchBoundaryOfflineReplayBindingResultV0,
+    KillSwitchBoundaryOfflineReplayContextV0,
+    bind_killswitch_boundary_offline_replay_evidence_v0,
+    killswitch_boundary_binding_non_authority_boundary_ok_v0,
+)
+
+KILLSWITCH_BOUNDARY_BACKTEST_STATE_FILE_BINDING_ADAPTER_LAYER_VERSION = "v0"
+KILLSWITCH_BOUNDARY_BACKTEST_STATE_FILE_BINDING_ADAPTER_OWNER = (
+    "trading.master_v2.killswitch_boundary_backtest_state_file_binding_adapter_v0"
+)
+KILLSWITCH_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION = (
+    "killswitch_boundary_backtest_state_file_v0"
+)
+
+_VALID_BOUNDARY_MODES = frozenset(mode.value for mode in KillSwitchBoundaryMode)
+
+
+@dataclass(frozen=True)
+class KillSwitchBacktestStateFileRecordV0:
+    """Parsed KillSwitch backtest state-file payload."""
+
+    killswitch_boundary_mode: str
+    fencing_digest_ref: str
+    state_file_digest_ref: str
+    prior_killswitch_active: bool = False
+    raw_payload: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class KillSwitchBoundaryBacktestStateFileEvidenceV0:
+    killswitch_boundary_backtest_state_file_bound: bool
+    killswitch_boundary_mode: str
+    no_new_positions: bool
+    no_position_increase: bool
+    cancel_pending_required: bool
+    reduce_to_flat_required: bool
+    emergency_flatten_required: bool
+    reconciliation_required: bool
+    fencing_digest_ref: str
+    state_file_digest_ref: str
+    runtime_authority: bool
+    orders_allowed: bool
+    credentials_used: bool
+    economic_evaluation: bool
+    offline_binding: KillSwitchBoundaryOfflineReplayBindingResultV0
+    surface_k_adapter_owner_ref: str
+    killswitch_fencing_owner_ref: str
+
+
+def _canonical_payload_bytes(payload: Mapping[str, Any]) -> bytes:
+    stripped = {k: v for k, v in payload.items() if k != "state_file_digest_ref"}
+    return json.dumps(stripped, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def compute_backtest_state_file_digest_v0(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def compute_backtest_state_file_digest_from_payload_v0(payload: Mapping[str, Any]) -> str:
+    return compute_backtest_state_file_digest_v0(_canonical_payload_bytes(payload))
+
+
+def _parse_boundary_mode(raw: object) -> KillSwitchBoundaryMode:
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError("killswitch_boundary_mode_missing")
+    normalized = raw.strip().lower()
+    if normalized not in _VALID_BOUNDARY_MODES:
+        raise ValueError(f"killswitch_boundary_mode_invalid:{normalized}")
+    return KillSwitchBoundaryMode(normalized)
+
+
+def parse_killswitch_backtest_state_file_v0(
+    *,
+    path: Path | None = None,
+    payload: Mapping[str, Any] | None = None,
+    raw_bytes: bytes | None = None,
+) -> KillSwitchBacktestStateFileRecordV0:
+    """Parse backtest KillSwitch state file. Fail-closed on missing or invalid input."""
+    if path is None and payload is None and raw_bytes is None:
+        raise ValueError("killswitch_backtest_state_file_input_missing")
+
+    if raw_bytes is None:
+        if path is not None:
+            if not path.is_file():
+                raise ValueError("killswitch_backtest_state_file_missing")
+            raw_bytes = path.read_bytes()
+        elif payload is not None:
+            raw_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        else:
+            raise ValueError("killswitch_backtest_state_file_input_missing")
+
+    if not raw_bytes.strip():
+        raise ValueError("killswitch_backtest_state_file_empty")
+
+    try:
+        decoded = json.loads(raw_bytes.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError("killswitch_backtest_state_file_corrupt") from exc
+
+    if not isinstance(decoded, Mapping):
+        raise ValueError("killswitch_backtest_state_file_invalid_shape")
+
+    state_file_digest_ref = compute_backtest_state_file_digest_from_payload_v0(decoded)
+
+    schema_version = decoded.get("schema_version", "")
+    if schema_version and schema_version != KILLSWITCH_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION:
+        raise ValueError("killswitch_backtest_state_file_schema_version_mismatch")
+
+    mode = _parse_boundary_mode(decoded.get("killswitch_boundary_mode"))
+    fencing_digest_ref = str(decoded.get("fencing_digest_ref", "")).strip()
+    if not fencing_digest_ref:
+        raise ValueError("fencing_digest_ref_missing")
+
+    expected_digest = str(decoded.get("state_file_digest_ref", "")).strip()
+    if expected_digest and expected_digest != state_file_digest_ref:
+        raise ValueError("killswitch_backtest_state_file_digest_mismatch")
+
+    prior_active = bool(decoded.get("prior_killswitch_active", False))
+    return KillSwitchBacktestStateFileRecordV0(
+        killswitch_boundary_mode=mode.value,
+        fencing_digest_ref=fencing_digest_ref,
+        state_file_digest_ref=state_file_digest_ref,
+        prior_killswitch_active=prior_active,
+        raw_payload=dict(decoded),
+    )
+
+
+def verify_killswitch_backtest_state_file_digest_v0(
+    record: KillSwitchBacktestStateFileRecordV0,
+    *,
+    expected_digest_ref: str,
+) -> None:
+    """Fail-closed when an expected digest does not match the parsed state file."""
+    if not expected_digest_ref.strip():
+        raise ValueError("expected_state_file_digest_ref_missing")
+    if record.state_file_digest_ref != expected_digest_ref.strip():
+        raise ValueError("killswitch_backtest_state_file_digest_mismatch")
+
+
+def _derive_reconciliation_required(
+    boundary: KillSwitchBoundaryOfflineReplayBindingResultV0,
+) -> bool:
+    return boundary.boundary.reconciliation_precedence_blocks_new_exposure or any(
+        code in boundary.boundary.reason_codes
+        for code in ("reconciliation_required", "position_reconciliation_required")
+    )
+
+
+def _derive_no_new_positions(mode: KillSwitchBoundaryMode, *, active: bool) -> bool:
+    return active and mode in (
+        KillSwitchBoundaryMode.BLOCK_NEW,
+        KillSwitchBoundaryMode.NO_NEW_POSITIONS,
+        KillSwitchBoundaryMode.EMERGENCY_FLATTEN,
+    )
+
+
+def bind_killswitch_boundary_backtest_state_file_evidence_v0(
+    evidence: "CanonicalTradingDecisionEvidenceV1",
+    *,
+    state_file: KillSwitchBacktestStateFileRecordV0,
+    reconciliation_state: ReconciliationState = ReconciliationState.RECONCILED,
+    position_state: PositionState | None = None,
+) -> KillSwitchBoundaryBacktestStateFileEvidenceV0:
+    """Bind backtest state-file KillSwitch mode through the Surface K offline adapter."""
+    pos_state = position_state if position_state is not None else PositionState.FLAT_RECONCILED
+    mode = KillSwitchBoundaryMode(state_file.killswitch_boundary_mode)
+    active = mode is not KillSwitchBoundaryMode.NORMAL
+    offline_binding = bind_killswitch_boundary_offline_replay_evidence_v0(
+        evidence,
+        context=KillSwitchBoundaryOfflineReplayContextV0(
+            boundary_mode=mode,
+            killswitch_active=active,
+            prior_killswitch_active=state_file.prior_killswitch_active,
+            reconciliation_state=reconciliation_state,
+            position_state=pos_state,
+        ),
+    )
+    if not killswitch_boundary_binding_non_authority_boundary_ok_v0(offline_binding):
+        raise ValueError("killswitch_backtest_state_file_non_authority_boundary_failed")
+
+    boundary = offline_binding.boundary
+    return KillSwitchBoundaryBacktestStateFileEvidenceV0(
+        killswitch_boundary_backtest_state_file_bound=True,
+        killswitch_boundary_mode=mode.value,
+        no_new_positions=_derive_no_new_positions(mode, active=active),
+        no_position_increase=boundary.no_position_increase,
+        cancel_pending_required=boundary.cancel_pending_boundary_only,
+        reduce_to_flat_required=boundary.reduce_to_flat_boundary_only,
+        emergency_flatten_required=boundary.emergency_flatten_boundary_only,
+        reconciliation_required=_derive_reconciliation_required(offline_binding),
+        fencing_digest_ref=state_file.fencing_digest_ref,
+        state_file_digest_ref=state_file.state_file_digest_ref,
+        runtime_authority=False,
+        orders_allowed=False,
+        credentials_used=False,
+        economic_evaluation=False,
+        offline_binding=offline_binding,
+        surface_k_adapter_owner_ref=KILLSWITCH_BOUNDARY_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER,
+        killswitch_fencing_owner_ref=KILLSWITCH_FENCING_OWNER,
+    )
+
+
+def evaluate_backtest_state_file_boundary_only_v0(
+    state_file: KillSwitchBacktestStateFileRecordV0,
+) -> KillSwitchBoundaryBacktestStateFileEvidenceV0:
+    """Evaluate boundary evidence fields without mutating decision evidence."""
+    from trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0 import (
+        build_scenario_tick_decision_evidence_v0,
+    )
+
+    stub = build_scenario_tick_decision_evidence_v0(
+        decision_id="backtest-killswitch-state-file-stub",
+        replay_id="backtest-killswitch-state-file-stub",
+        instrument_id="backtest-stub",
+        trading_epoch=0,
+        composition_result_id="stub",
+        entry_exit_policy_ref="stub",
+        selected_side="none",
+        decision_outcome="observe",
+        reason_codes=("stub",),
+        decision_precedence_trace=("stub",),
+        config_digest="stub",
+        implementation_digest="stub",
+    )
+    return bind_killswitch_boundary_backtest_state_file_evidence_v0(
+        stub,
+        state_file=state_file,
+    )
+
+
+def apply_backtest_killswitch_exposure_gate_v0(
+    position_signal: int,
+    *,
+    evidence: KillSwitchBoundaryBacktestStateFileEvidenceV0,
+    has_existing_position: bool = False,
+) -> int:
+    """Fail-closed backtest exposure representation — no runtime orders."""
+    if position_signal == 0:
+        return 0
+    mode = KillSwitchBoundaryMode(evidence.killswitch_boundary_mode)
+    if mode is KillSwitchBoundaryMode.BLOCK_NEW:
+        return 0
+    if mode is KillSwitchBoundaryMode.NO_NEW_POSITIONS:
+        return position_signal if has_existing_position else 0
+    if evidence.no_position_increase and position_signal != 0:
+        return 0
+    if evidence.emergency_flatten_required and position_signal != 0:
+        return 0
+    if evidence.reconciliation_required and position_signal != 0:
+        return 0
+    if evidence.no_new_positions and position_signal != 0:
+        return 0
+    return position_signal
+
+
+def backtest_state_file_binding_non_authority_ok_v0(
+    evidence: KillSwitchBoundaryBacktestStateFileEvidenceV0,
+) -> bool:
+    if not evidence.killswitch_boundary_backtest_state_file_bound:
+        return False
+    if evidence.runtime_authority or evidence.orders_allowed:
+        return False
+    if evidence.credentials_used or evidence.economic_evaluation:
+        return False
+    return killswitch_boundary_binding_non_authority_boundary_ok_v0(evidence.offline_binding)
+
+
+def load_killswitch_backtest_state_file_record_v0(
+    path: Path,
+    *,
+    expected_digest_ref: str = "",
+) -> KillSwitchBacktestStateFileRecordV0:
+    record = parse_killswitch_backtest_state_file_v0(path=path)
+    if expected_digest_ref:
+        verify_killswitch_backtest_state_file_digest_v0(
+            record,
+            expected_digest_ref=expected_digest_ref,
+        )
+    return record
+
+
+from trading.master_v2.canonical_trading_decision_evidence_v1 import (  # noqa: E402
+    CanonicalTradingDecisionEvidenceV1,
+)

--- a/tests/trading/master_v2/test_killswitch_boundary_backtest_state_file_binding_contract_v0.py
+++ b/tests/trading/master_v2/test_killswitch_boundary_backtest_state_file_binding_contract_v0.py
@@ -1,0 +1,291 @@
+"""Contract: KillSwitch boundary backtest state-file binding v0 (offline only)."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from src.backtest.mv2_research_wiring_v1 import (
+    KillSwitchBacktestStateFileBindingConfigV1,
+    run_mv2_research_backtest_wiring_v1,
+)
+from src.meta.learning_loop.killswitch_writer_fencing_and_independent_read_paths_v1 import (
+    KILL_SWITCH_CONTRACT_DIGEST,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import DecisionOutcome
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    NEXT_RECOMMENDED_SLICE,
+    parity_surface_assessments_v0,
+)
+from trading.master_v2.killswitch_boundary_backtest_state_file_binding_adapter_v0 import (
+    KILLSWITCH_BOUNDARY_BACKTEST_STATE_FILE_BINDING_ADAPTER_OWNER,
+    KILLSWITCH_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION,
+    apply_backtest_killswitch_exposure_gate_v0,
+    backtest_state_file_binding_non_authority_ok_v0,
+    bind_killswitch_boundary_backtest_state_file_evidence_v0,
+    compute_backtest_state_file_digest_from_payload_v0,
+    evaluate_backtest_state_file_boundary_only_v0,
+    parse_killswitch_backtest_state_file_v0,
+    verify_killswitch_backtest_state_file_digest_v0,
+)
+from trading.master_v2.killswitch_boundary_offline_replay_binding_adapter_v0 import (
+    KILLSWITCH_BOUNDARY_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER,
+    KillSwitchBoundaryMode,
+)
+from trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0 import (
+    build_scenario_tick_decision_evidence_v0,
+)
+from tests.backtest.test_mv2_research_wiring_v1 import _bars, _cfg
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_FORBIDDEN_IMPORT_SCAN_PATHS = (
+    REPO_ROOT
+    / "src/trading/master_v2/killswitch_boundary_backtest_state_file_binding_adapter_v0.py",
+    REPO_ROOT / "scripts/ops/run_backtest_killswitch_state_file_wiring_v0.py",
+    REPO_ROOT
+    / "tests/trading/master_v2/test_killswitch_boundary_backtest_state_file_binding_contract_v0.py",
+)
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def _state_file_payload(*, mode: str, prior: bool = False) -> dict[str, object]:
+    base = {
+        "schema_version": KILLSWITCH_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION,
+        "killswitch_boundary_mode": mode,
+        "fencing_digest_ref": KILL_SWITCH_CONTRACT_DIGEST,
+        "prior_killswitch_active": prior,
+    }
+    digest = compute_backtest_state_file_digest_from_payload_v0(base)
+    return {**base, "state_file_digest_ref": digest}
+
+
+def _base_evidence(*, decision_outcome: str = DecisionOutcome.OBSERVE.value):
+    return build_scenario_tick_decision_evidence_v0(
+        decision_id="backtest-killswitch-state-file-decision",
+        replay_id="backtest-killswitch-state-file-replay",
+        instrument_id="inst-eth-usdt-perp",
+        trading_epoch=1,
+        composition_result_id="composition",
+        entry_exit_policy_ref="policy",
+        selected_side="long",
+        decision_outcome=decision_outcome,
+        reason_codes=("PASS",),
+        decision_precedence_trace=("observe",),
+        config_digest="config",
+        implementation_digest="impl",
+    )
+
+
+def _record(*, mode: str, prior: bool = False):
+    return parse_killswitch_backtest_state_file_v0(
+        payload=_state_file_payload(mode=mode, prior=prior)
+    )
+
+
+def test_owner_constants_reuse_surface_k_adapter_v0() -> None:
+    assert KILLSWITCH_BOUNDARY_BACKTEST_STATE_FILE_BINDING_ADAPTER_OWNER.endswith(
+        "killswitch_boundary_backtest_state_file_binding_adapter_v0"
+    )
+
+
+def test_slice_sources_exclude_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "execution",
+            "scheduler",
+            "credentials",
+            "live_runtime",
+            "testnet",
+            "shadow",
+            "paper_lane",
+            "risk_layer.kill_switch.core",
+        }
+    )
+    for path in _FORBIDDEN_IMPORT_SCAN_PATHS:
+        assert path.is_file(), f"missing slice source: {path}"
+        hits = _scan_forbidden_imports(path, forbidden)
+        assert hits == [], f"forbidden imports in {path}: {hits}"
+
+
+@pytest.mark.parametrize(
+    ("mode", "signal", "expected"),
+    [
+        (KillSwitchBoundaryMode.BLOCK_NEW.value, 1, 0),
+        (KillSwitchBoundaryMode.NO_NEW_POSITIONS.value, 1, 0),
+        (KillSwitchBoundaryMode.NO_POSITION_INCREASE.value, 1, 0),
+        (KillSwitchBoundaryMode.CANCEL_PENDING.value, 1, 1),
+        (KillSwitchBoundaryMode.REDUCE_TO_FLAT.value, 1, 1),
+        (KillSwitchBoundaryMode.EMERGENCY_FLATTEN.value, 1, 0),
+    ],
+)
+def test_backtest_exposure_gate_by_mode_v0(mode: str, signal: int, expected: int) -> None:
+    evidence = evaluate_backtest_state_file_boundary_only_v0(_record(mode=mode))
+    gated = apply_backtest_killswitch_exposure_gate_v0(signal, evidence=evidence)
+    assert gated == expected
+
+
+def test_no_new_positions_permits_existing_position_management_v0() -> None:
+    evidence = evaluate_backtest_state_file_boundary_only_v0(
+        _record(mode=KillSwitchBoundaryMode.NO_NEW_POSITIONS.value)
+    )
+    assert evidence.no_new_positions is True
+    assert apply_backtest_killswitch_exposure_gate_v0(1, evidence=evidence) == 0
+    assert (
+        apply_backtest_killswitch_exposure_gate_v0(
+            1,
+            evidence=evidence,
+            has_existing_position=True,
+        )
+        == 1
+    )
+
+
+def test_cancel_pending_maps_to_cancel_pending_required_only_v0() -> None:
+    evidence = evaluate_backtest_state_file_boundary_only_v0(
+        _record(mode=KillSwitchBoundaryMode.CANCEL_PENDING.value)
+    )
+    assert evidence.cancel_pending_required is True
+    assert evidence.reduce_to_flat_required is False
+    assert evidence.emergency_flatten_required is False
+
+
+def test_reduce_to_flat_maps_to_reduce_required_only_v0() -> None:
+    evidence = evaluate_backtest_state_file_boundary_only_v0(
+        _record(mode=KillSwitchBoundaryMode.REDUCE_TO_FLAT.value)
+    )
+    assert evidence.reduce_to_flat_required is True
+    assert evidence.emergency_flatten_required is False
+
+
+def test_emergency_flatten_maps_to_emergency_required_only_v0() -> None:
+    evidence = evaluate_backtest_state_file_boundary_only_v0(
+        _record(mode=KillSwitchBoundaryMode.EMERGENCY_FLATTEN.value)
+    )
+    assert evidence.emergency_flatten_required is True
+
+
+def test_missing_state_file_input_fails_closed_v0() -> None:
+    with pytest.raises(ValueError, match="killswitch_backtest_state_file_input_missing"):
+        parse_killswitch_backtest_state_file_v0()
+
+
+def test_corrupted_state_file_digest_fails_closed_v0() -> None:
+    payload = _state_file_payload(mode=KillSwitchBoundaryMode.BLOCK_NEW.value)
+    payload["state_file_digest_ref"] = "0" * 64
+    with pytest.raises(ValueError, match="killswitch_backtest_state_file_digest_mismatch"):
+        parse_killswitch_backtest_state_file_v0(payload=payload)
+
+
+def test_invalid_mode_fails_closed_v0() -> None:
+    payload = _state_file_payload(mode=KillSwitchBoundaryMode.BLOCK_NEW.value)
+    payload["killswitch_boundary_mode"] = "not_a_mode"
+    with pytest.raises(ValueError, match="killswitch_boundary_mode_invalid"):
+        parse_killswitch_backtest_state_file_v0(payload=payload)
+
+
+def test_backtest_binding_uses_surface_k_adapter_not_duplicate_semantics_v0() -> None:
+    evidence = _base_evidence(decision_outcome=DecisionOutcome.ENTER_LONG.value)
+    bound = bind_killswitch_boundary_backtest_state_file_evidence_v0(
+        evidence,
+        state_file=_record(mode=KillSwitchBoundaryMode.BLOCK_NEW.value),
+    )
+    assert (
+        bound.surface_k_adapter_owner_ref
+        == KILLSWITCH_BOUNDARY_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER
+    )
+    assert bound.offline_binding.binding_applied is True
+
+
+def test_non_authority_invariants_v0() -> None:
+    evidence = evaluate_backtest_state_file_boundary_only_v0(
+        _record(mode=KillSwitchBoundaryMode.EMERGENCY_FLATTEN.value)
+    )
+    assert evidence.runtime_authority is False
+    assert evidence.orders_allowed is False
+    assert evidence.credentials_used is False
+    assert evidence.economic_evaluation is False
+    assert backtest_state_file_binding_non_authority_ok_v0(evidence)
+
+
+def test_parity_gap_assessment_surface_k_backtest_state_file_pass_v0() -> None:
+    killswitch = next(item for item in parity_surface_assessments_v0() if item.surface_id == "K")
+    assert killswitch.parity_status == "PASS"
+    assert killswitch.missing_binding_if_any == ""
+    assert "bind_killswitch_boundary_backtest_state_file_evidence_v0" in (
+        killswitch.current_backtest_binding
+    )
+    assert NEXT_RECOMMENDED_SLICE == "BACKTEST_RECONCILIATION_STATE_FILE_WIRING_V0"
+
+
+def test_mv2_research_wiring_binds_state_file_and_blocks_new_exposure_v0(tmp_path: Path) -> None:
+    payload = _state_file_payload(mode=KillSwitchBoundaryMode.BLOCK_NEW.value)
+    state_path = tmp_path / "killswitch_backtest_state.json"
+    state_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    result = run_mv2_research_backtest_wiring_v1(
+        _bars(n=6),
+        strategy_id="ma_crossover",
+        cfg=_cfg(),
+        explicit_zero_cost_non_economic=True,
+        killswitch_state_file_binding=KillSwitchBacktestStateFileBindingConfigV1(
+            state_file_path=state_path,
+            expected_state_file_digest_ref=str(payload["state_file_digest_ref"]),
+        ),
+    )
+    assert result.bar_outcomes
+    bound = [o for o in result.bar_outcomes if o.killswitch_backtest_state_file_evidence]
+    assert len(bound) == len(result.bar_outcomes)
+    sample = bound[0].killswitch_backtest_state_file_evidence
+    assert sample is not None
+    assert sample.killswitch_boundary_backtest_state_file_bound is True
+    assert sample.killswitch_boundary_mode == KillSwitchBoundaryMode.BLOCK_NEW.value
+    assert all(o.position_signal == 0 for o in result.bar_outcomes)
+
+
+def test_mv2_research_wiring_legacy_without_state_file_unchanged_v0() -> None:
+    result = run_mv2_research_backtest_wiring_v1(
+        _bars(n=6),
+        strategy_id="ma_crossover",
+        cfg=_cfg(),
+        explicit_zero_cost_non_economic=True,
+    )
+    assert all(o.killswitch_backtest_state_file_evidence is None for o in result.bar_outcomes)
+
+
+def test_required_state_file_missing_fails_closed_v0() -> None:
+    with pytest.raises(ValueError, match="killswitch_backtest_state_file_missing"):
+        run_mv2_research_backtest_wiring_v1(
+            _bars(n=4),
+            strategy_id="ma_crossover",
+            cfg=_cfg(),
+            explicit_zero_cost_non_economic=True,
+            killswitch_state_file_binding=KillSwitchBacktestStateFileBindingConfigV1(
+                require_state_file=True,
+            ),
+        )
+
+
+def test_verify_state_file_digest_ref_v0() -> None:
+    record = _record(mode=KillSwitchBoundaryMode.NORMAL.value)
+    verify_killswitch_backtest_state_file_digest_v0(
+        record,
+        expected_digest_ref=record.state_file_digest_ref,
+    )
+    with pytest.raises(ValueError, match="killswitch_backtest_state_file_digest_mismatch"):
+        verify_killswitch_backtest_state_file_digest_v0(record, expected_digest_ref="0" * 64)


### PR DESCRIPTION
## Summary

- Adds `killswitch_boundary_backtest_state_file_binding_adapter_v0` as a narrow reuse-first adapter that binds backtest KillSwitch state-file input to canonical Surface K semantics (`killswitch_boundary_offline_replay_binding_adapter_v0`) without runtime authority, orders, credentials, or economic evaluation.
- Wires optional KillSwitch state-file binding into `mv2_research_wiring_v1` with fail-closed digest/mode validation and exposure gating for backtest position signals.
- Updates full canonical parity gap assessment: Surface K backtest state-file binding PASS; `NEXT_RECOMMENDED_SLICE=BACKTEST_RECONCILIATION_STATE_FILE_WIRING_V0`; `FULL_CANONICAL_CHAIN_WIRED=false`.

## Evidence

Durable evidence archive:
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/backtest_killswitch_state_file_wiring_v0_20260706T224125Z`

Source closeout (PR4956):
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr4956_surface_k_killswitch_boundary_offline_replay_binding_parity_rewire_merge_closeout_20260706T223758Z`

## Final Report (excerpt)

```
VERDICT=BACKTEST_KILLSWITCH_STATE_FILE_WIRING_V0_PASS
PROCESS_CLASSIFICATION=BOUNDED_REUSE_FIRST_BACKTEST_PARITY_REWIRE
SCOPE_CLASSIFICATION=BACKTEST_KILLSWITCH_STATE_FILE_WIRING_NO_RUNTIME_NO_ORDERS_NO_ECONOMIC_EVALUATION_V0
GO_TOKEN_CONSUMPTION=CONSUMED_ONCE
BASE_HEAD=bac655e6b459fbd23c0b6b652b8fd63e673b700a
KILLSWITCH_BOUNDARY_BACKTEST_STATE_FILE_BOUND_STATUS=true
FULL_CANONICAL_CHAIN_WIRED=false
RUNTIME_AUTHORITY=false
ORDERS_ALLOWED=false
CREDENTIALS_USED=false
ECONOMIC_EVALUATION=false
NEXT_STEP=BACKTEST_RECONCILIATION_STATE_FILE_WIRING_V0
```

## Test plan

- [x] `pytest tests/trading/master_v2/test_killswitch_boundary_backtest_state_file_binding_contract_v0.py -q`
- [x] `pytest tests/trading/master_v2/test_killswitch_boundary_offline_replay_binding_parity_rewire_contract_v0.py -q`
- [x] `pytest tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py -q`
- [x] `ruff format --check .` / `ruff check .`


Made with [Cursor](https://cursor.com)