### PR TITLE
Bind canonical order intent boundary to backtest parity

### DIFF
--- a/scripts/ops/run_backtest_canonical_order_intent_wiring_v0.py
+++ b/scripts/ops/run_backtest_canonical_order_intent_wiring_v0.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for backtest canonical order intent state-file wiring v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARCHIVE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+DEFAULT_BASE_HEAD = "0e41339bf78d8ef65c1afd125f84bcf303a4d843"
+DEFAULT_SOURCE_EVIDENCE = (
+    DEFAULT_ARCHIVE_ROOT
+    / "research/pr_merge_closeout_backtest_capital_risk_sizing_wiring_v0_20260706T230540Z"
+)
+DEFAULT_RUNBOOK = (
+    "/mnt/data/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.4_full_canonical_system_"
+    "completion_post_merge_evidence_sync_guard_clarification.md"
+)
+NEXT_RECOMMENDED_SLICE = "BACKTEST_SAFETY_KERNEL_WIRING_V0"
+VERDICT = "BACKTEST_CANONICAL_ORDER_INTENT_WIRING_V0_PASS"
+PROCESS_CLASSIFICATION = "FULL_CANONICAL_BACKTEST_PARITY_NARROW_REWIRE"
+SCOPE_CLASSIFICATION = (
+    "BACKTEST_CANONICAL_ORDER_INTENT_WIRING_V0_NO_RUNTIME_NO_ORDERS_NO_ECONOMIC_EVALUATION_V0"
+)
+TARGETED_TESTS = (
+    "tests/test_backtest_canonical_order_intent_wiring_v0.py",
+    "tests/test_full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "tests/test_mv2_research_wiring_v1.py",
+    "tests/trading/master_v2/test_canonical_order_intent_offline_replay_binding_parity_rewire_contract_v0.py",
+    "tests/governance/test_canonical_order_intent_v1.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0.py",
+    "src/backtest/mv2_research_wiring_v1.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "scripts/ops/run_backtest_canonical_order_intent_wiring_v0.py",
+    "tests/test_backtest_canonical_order_intent_wiring_v0.py",
+    "tests/test_full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "tests/test_mv2_research_wiring_v1.py",
+)
+REUSED_OWNERS = (
+    "src.governance.canonical_order_intent_v1",
+    "trading.master_v2.canonical_order_intent_offline_replay_binding_adapter_v0",
+    "trading.master_v2.capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0",
+    "backtest.mv2_research_wiring_v1",
+)
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    repo_root: Path
+    durable_root: Path
+    runbook_path: str
+    scope: str
+    base_head: str
+    operator: str
+    reuse_first: bool
+    no_runtime_authority: bool
+    no_orders: bool
+    no_credentials: bool
+    forbid_live: bool
+    forbid_scheduler: bool
+    require_source_manifest_verify: bool
+    require_closeout_manifest: bool
+    source_evidence: Path
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.rglob("*")):
+        if path.is_dir() or path.name == "MANIFEST.sha256":
+            continue
+        rel = path.relative_to(evidence_dir).as_posix()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  ./{rel}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def _parse_bool(raw: str) -> bool:
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def collect_evidence(config: RunConfig, out_dir: Path | None = None) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        config.durable_root / f"research/backtest_canonical_order_intent_wiring_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"], cwd=config.repo_root).stdout.strip()
+    branch = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=config.repo_root).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"], cwd=config.repo_root).stdout.strip()
+    status = _run(["git", "status", "--short"], cwd=config.repo_root).stdout.strip()
+    diff_stat = _run(
+        ["git", "diff", "--stat", f"{config.base_head}...HEAD"],
+        cwd=config.repo_root,
+    )
+
+    source_manifest_rc = 0
+    source_manifest_log = "SOURCE_EVIDENCE_ABSENT=true\n"
+    if config.source_evidence.is_dir():
+        source_manifest = _run(
+            ["shasum", "-a", "256", "-c", "MANIFEST.sha256"],
+            cwd=config.source_evidence,
+        )
+        source_manifest_rc = source_manifest.returncode
+        source_manifest_log = (
+            source_manifest.stdout
+            + source_manifest.stderr
+            + f"\nSOURCE_MANIFEST_VERIFY_RC={source_manifest.returncode}\n"
+        )
+    elif config.require_source_manifest_verify:
+        source_manifest_rc = 1
+        source_manifest_log = "SOURCE_EVIDENCE_PATH_MISSING=true\nSOURCE_MANIFEST_VERIFY_RC=1\n"
+
+    (evidence_dir / "source_manifest_verify_pre_merge.log").write_text(
+        source_manifest_log,
+        encoding="utf-8",
+    )
+
+    (evidence_dir / "git_context.txt").write_text(
+        "\n".join(
+            [
+                f"HEAD={head}",
+                f"BRANCH={branch}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"BASE_HEAD={config.base_head}",
+                f"WORKTREE_STATUS={status or 'clean'}",
+                f"SOURCE_EVIDENCE={config.source_evidence}",
+                f"RUNBOOK={config.runbook_path}",
+                f"SCOPE={config.scope}",
+                f"OPERATOR={config.operator}",
+                f"REUSE_FIRST={config.reuse_first}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "changed_files.txt").write_text(
+        "\n".join(SLICE_CHANGED_FILES) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "reused_owners.txt").write_text(
+        "\n".join(REUSED_OWNERS) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "implementation_summary.txt").write_text(
+        "\n".join(
+            [
+                "CANONICAL_ORDER_INTENT_BOUND_TO_BACKTEST=true",
+                "ORDER_INTENT_PROVENANCE_REPRESENTED_IN_BACKTEST=true",
+                "ADAPTER_COMPATIBLE_REMAINS_FALSE_UNLESS_EXPLICITLY_TRANSFORMED=true",
+                "FULL_CANONICAL_CHAIN_WIRED=false",
+                "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false",
+                f"NO_RUNTIME_AUTHORITY={config.no_runtime_authority}",
+                f"NO_ORDERS={config.no_orders}",
+                f"NO_CREDENTIALS={config.no_credentials}",
+                f"FORBID_LIVE={config.forbid_live}",
+                f"FORBID_SCHEDULER={config.forbid_scheduler}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "semantic_flags.txt").write_text(
+        (evidence_dir / "implementation_summary.txt").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (evidence_dir / "diff_stat.txt").write_text(
+        diff_stat.stdout + diff_stat.stderr, encoding="utf-8"
+    )
+
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(config.repo_root / "src")}
+    pytest_cmd = [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS]
+    pytest_proc = subprocess.run(
+        pytest_cmd,
+        cwd=str(config.repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (evidence_dir / "pytest_targeted_post_merge.log").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    ruff_format = _run(
+        ["python3", "-m", "ruff", "format", "--check", *SLICE_CHANGED_FILES],
+        cwd=config.repo_root,
+    )
+    ruff_check = _run(
+        ["python3", "-m", "ruff", "check", *SLICE_CHANGED_FILES],
+        cwd=config.repo_root,
+    )
+    (evidence_dir / "ruff_post_merge.log").write_text(
+        "RUFF_FORMAT\n"
+        + ruff_format.stdout
+        + ruff_format.stderr
+        + "\nRUFF_CHECK\n"
+        + ruff_check.stdout
+        + ruff_check.stderr,
+        encoding="utf-8",
+    )
+
+    manifest_rc = _write_manifest(evidence_dir)
+    verify_proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    (evidence_dir / "MANIFEST_VERIFY.log").write_text(
+        verify_proc.stdout
+        + verify_proc.stderr
+        + f"\nMANIFEST_VERIFY_RC={verify_proc.returncode}\n",
+        encoding="utf-8",
+    )
+
+    tests_pass = pytest_proc.returncode == 0
+    ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0
+    closeout_ok = manifest_rc == 0
+    if config.require_closeout_manifest and manifest_rc != 0:
+        closeout_ok = False
+    source_ok = source_manifest_rc == 0 or not config.require_source_manifest_verify
+    verdict = (
+        VERDICT
+        if tests_pass and ruff_pass and closeout_ok and source_ok
+        else "BACKTEST_CANONICAL_ORDER_INTENT_WIRING_V0_BLOCKED"
+    )
+
+    report = "\n".join(
+        [
+            f"VERDICT={verdict}",
+            f"PROCESS_CLASSIFICATION={PROCESS_CLASSIFICATION}",
+            f"SCOPE_CLASSIFICATION={SCOPE_CLASSIFICATION}",
+            "GO_TOKEN_CONSUMPTION=CONSUMED_ONCE",
+            f"BASE_HEAD={config.base_head}",
+            f"ORIGIN_MAIN={origin_main}",
+            f"BRANCH={branch}",
+            f"COMMIT={head}",
+            f"SOURCE_EVIDENCE={config.source_evidence}",
+            f"SOURCE_MANIFEST_VERIFY_RC={source_manifest_rc}",
+            "CANONICAL_ORDER_INTENT_BOUND_TO_BACKTEST=true",
+            "ORDER_INTENT_PROVENANCE_REPRESENTED_IN_BACKTEST=true",
+            "ADAPTER_COMPATIBLE_REMAINS_FALSE_UNLESS_EXPLICITLY_TRANSFORMED=true",
+            "FULL_CANONICAL_CHAIN_WIRED=false",
+            "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false",
+            f"NO_RUNTIME_AUTHORITY={config.no_runtime_authority}",
+            f"NO_ORDERS={config.no_orders}",
+            f"TESTS={'pass' if tests_pass else 'fail'}",
+            f"RUFF={'pass' if ruff_pass else 'fail'}",
+            f"DURABLE_EVIDENCE_DIR={evidence_dir}",
+            f"MANIFEST_VERIFY_RC={manifest_rc}",
+            f"NEXT_STEP={NEXT_RECOMMENDED_SLICE}",
+        ]
+    )
+    (evidence_dir / "FINAL_REPORT.txt").write_text(report + "\n", encoding="utf-8")
+    manifest_rc = _write_manifest(evidence_dir)
+
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_rc": manifest_rc,
+        "tests_pass": tests_pass,
+        "ruff_pass": ruff_pass,
+        "source_manifest_rc": source_manifest_rc,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT)
+    parser.add_argument("--durable-root", type=Path, default=DEFAULT_ARCHIVE_ROOT)
+    parser.add_argument("--runbook", type=str, default=DEFAULT_RUNBOOK)
+    parser.add_argument("--scope", type=str, default="BACKTEST_CANONICAL_ORDER_INTENT_WIRING_V0")
+    parser.add_argument("--base-head", type=str, default=DEFAULT_BASE_HEAD)
+    parser.add_argument("--operator", type=str, default="")
+    parser.add_argument("--source-evidence", type=Path, default=DEFAULT_SOURCE_EVIDENCE)
+    parser.add_argument("--reuse-first", type=str, default="true")
+    parser.add_argument("--no-runtime-authority", type=str, default="true")
+    parser.add_argument("--no-orders", type=str, default="true")
+    parser.add_argument("--no-credentials", type=str, default="true")
+    parser.add_argument("--forbid-live", type=str, default="true")
+    parser.add_argument("--forbid-scheduler", type=str, default="true")
+    parser.add_argument(
+        "--require-source-manifest-verify",
+        type=str,
+        default="true",
+    )
+    parser.add_argument("--require-closeout-manifest", type=str, default="true")
+    parser.add_argument("--out-dir", type=Path, default=None)
+    args = parser.parse_args()
+
+    config = RunConfig(
+        repo_root=args.repo_root,
+        durable_root=args.durable_root,
+        runbook_path=args.runbook,
+        scope=args.scope,
+        base_head=args.base_head,
+        operator=args.operator,
+        reuse_first=_parse_bool(args.reuse_first),
+        no_runtime_authority=_parse_bool(args.no_runtime_authority),
+        no_orders=_parse_bool(args.no_orders),
+        no_credentials=_parse_bool(args.no_credentials),
+        forbid_live=_parse_bool(args.forbid_live),
+        forbid_scheduler=_parse_bool(args.forbid_scheduler),
+        require_source_manifest_verify=_parse_bool(args.require_source_manifest_verify),
+        require_closeout_manifest=_parse_bool(args.require_closeout_manifest),
+        source_evidence=args.source_evidence,
+    )
+    result = collect_evidence(config, args.out_dir)
+    print(json.dumps(result, indent=2))
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backtest/mv2_research_wiring_v1.py
+++ b/src/backtest/mv2_research_wiring_v1.py
@@ -159,6 +159,13 @@ from src.trading.master_v2.capital_risk_sizing_boundary_backtest_state_file_bind
     bind_capital_risk_sizing_boundary_backtest_state_file_evidence_v0,
     load_capital_risk_sizing_backtest_state_file_record_v0,
 )
+from src.trading.master_v2.canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0 import (
+    CanonicalOrderIntentBacktestStateFileRecordV0,
+    CanonicalOrderIntentBoundaryBacktestStateFileEvidenceV0,
+    apply_backtest_canonical_order_intent_exposure_gate_v0,
+    bind_canonical_order_intent_boundary_backtest_state_file_evidence_v0,
+    load_canonical_order_intent_backtest_state_file_record_v0,
+)
 
 MV2_RESEARCH_WIRING_LAYER_VERSION = "v1"
 MV2_RESEARCH_WIRING_OWNER = "backtest.mv2_research_wiring_v1"
@@ -224,6 +231,16 @@ class CapitalRiskSizingBacktestStateFileBindingConfigV1:
 
 
 @dataclass(frozen=True)
+class CanonicalOrderIntentBacktestStateFileBindingConfigV1:
+    """Optional backtest canonical order intent state-file binding — offline evidence only."""
+
+    state_file_path: Path | None = None
+    state_file_record: CanonicalOrderIntentBacktestStateFileRecordV0 | None = None
+    expected_state_file_digest_ref: str = ""
+    require_state_file: bool = False
+
+
+@dataclass(frozen=True)
 class MV2ReplayBarOutcomeV1:
     trading_epoch: int
     context: CanonicalMarketContextV1
@@ -241,6 +258,9 @@ class MV2ReplayBarOutcomeV1:
     ) = None
     capital_risk_sizing_backtest_state_file_evidence: (
         CapitalRiskSizingBoundaryBacktestStateFileEvidenceV0 | None
+    ) = None
+    canonical_order_intent_backtest_state_file_evidence: (
+        CanonicalOrderIntentBoundaryBacktestStateFileEvidenceV0 | None
     ) = None
 
 
@@ -885,6 +905,33 @@ def _resolve_capital_risk_sizing_backtest_state_file_record_v1(
     return None
 
 
+def _resolve_canonical_order_intent_backtest_state_file_record_v1(
+    binding: CanonicalOrderIntentBacktestStateFileBindingConfigV1 | None,
+) -> CanonicalOrderIntentBacktestStateFileRecordV0 | None:
+    if binding is None:
+        return None
+    if binding.state_file_record is not None:
+        record = binding.state_file_record
+        if binding.expected_state_file_digest_ref:
+            from src.trading.master_v2.canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0 import (
+                verify_canonical_order_intent_backtest_state_file_digest_v0,
+            )
+
+            verify_canonical_order_intent_backtest_state_file_digest_v0(
+                record,
+                expected_digest_ref=binding.expected_state_file_digest_ref,
+            )
+        return record
+    if binding.state_file_path is not None:
+        return load_canonical_order_intent_backtest_state_file_record_v0(
+            binding.state_file_path,
+            expected_digest_ref=binding.expected_state_file_digest_ref,
+        )
+    if binding.require_state_file:
+        raise ValueError("canonical_order_intent_backtest_state_file_missing")
+    return None
+
+
 def _resolve_killswitch_backtest_state_file_record_v1(
     binding: KillSwitchBacktestStateFileBindingConfigV1 | None,
 ) -> KillSwitchBacktestStateFileRecordV0 | None:
@@ -931,6 +978,9 @@ def run_mv2_research_backtest_wiring_v1(
     reconciliation_state_file_binding: ReconciliationBacktestStateFileBindingConfigV1 | None = None,
     capital_risk_sizing_state_file_binding: (
         CapitalRiskSizingBacktestStateFileBindingConfigV1 | None
+    ) = None,
+    canonical_order_intent_state_file_binding: (
+        CanonicalOrderIntentBacktestStateFileBindingConfigV1 | None
     ) = None,
 ) -> MV2ResearchWiringResultV1:
     _fail_closed(bars.empty, "bars_empty")
@@ -1015,6 +1065,15 @@ def run_mv2_research_backtest_wiring_v1(
             capital_risk_sizing_state_file_binding
         )
     )
+    canonical_order_intent_state_file_record = (
+        _resolve_canonical_order_intent_backtest_state_file_record_v1(
+            canonical_order_intent_state_file_binding
+        )
+    )
+    if canonical_order_intent_state_file_record is not None and (
+        capital_risk_sizing_state_file_record is None
+    ):
+        raise ValueError("canonical_order_intent_backtest_state_file_requires_sizing_state_file")
     killswitch_has_existing_position = (
         killswitch_state_file_binding.has_existing_position
         if killswitch_state_file_binding is not None
@@ -1101,6 +1160,25 @@ def run_mv2_research_backtest_wiring_v1(
                 signal,
                 evidence=capital_risk_sizing_evidence,
             )
+        canonical_order_intent_evidence: (
+            CanonicalOrderIntentBoundaryBacktestStateFileEvidenceV0 | None
+        ) = None
+        if canonical_order_intent_state_file_record is not None:
+            if capital_risk_sizing_evidence is None:
+                raise ValueError(
+                    "canonical_order_intent_backtest_state_file_sizing_evidence_missing"
+                )
+            canonical_order_intent_evidence = (
+                bind_canonical_order_intent_boundary_backtest_state_file_evidence_v0(
+                    replay_result.evidence,
+                    state_file=canonical_order_intent_state_file_record,
+                    sizing_evidence=capital_risk_sizing_evidence,
+                )
+            )
+            signal = apply_backtest_canonical_order_intent_exposure_gate_v0(
+                signal,
+                evidence=canonical_order_intent_evidence,
+            )
         if context.warmup_status is not WarmupStatus.WARMUP_COMPLETE:
             signal = 0
         outcomes.append(
@@ -1116,6 +1194,7 @@ def run_mv2_research_backtest_wiring_v1(
                 killswitch_backtest_state_file_evidence=killswitch_evidence,
                 reconciliation_backtest_state_file_evidence=reconciliation_evidence,
                 capital_risk_sizing_backtest_state_file_evidence=capital_risk_sizing_evidence,
+                canonical_order_intent_backtest_state_file_evidence=canonical_order_intent_evidence,
             )
         )
         replay_signals.append(signal)

--- a/src/trading/master_v2/canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0.py
+++ b/src/trading/master_v2/canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0.py
@@ -1,0 +1,412 @@
+# src/trading/master_v2/canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0.py
+"""
+Backtest state-file adapter: binds MV2 research backtest wiring to canonical
+order intent semantics via the Surface I offline replay adapter.
+
+Wiring-only parity slice — no runtime authority, no order effects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.governance.canonical_order_intent_v1 import (
+    CONTRACT_VERSION as CANONICAL_ORDER_INTENT_CONTRACT_VERSION,
+)
+from src.governance.capital_risk_sizing_v1 import InstrumentQuantityConstraintsV1
+from trading.master_v2.canonical_order_intent_offline_replay_binding_adapter_v0 import (
+    CANONICAL_ORDER_INTENT_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER,
+    ORDER_INTENT_EFFECT_BOUND_OFFLINE,
+    CanonicalOrderIntentOfflineReplayBindingResultV0,
+    bind_canonical_order_intent_offline_replay_evidence_v0,
+    canonical_order_intent_binding_non_authority_boundary_ok_v0,
+)
+from trading.master_v2.capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0 import (
+    CapitalRiskSizingBoundaryBacktestStateFileEvidenceV0,
+)
+
+CANONICAL_ORDER_INTENT_BOUNDARY_BACKTEST_STATE_FILE_BINDING_ADAPTER_LAYER_VERSION = "v0"
+CANONICAL_ORDER_INTENT_BOUNDARY_BACKTEST_STATE_FILE_BINDING_ADAPTER_OWNER = (
+    "trading.master_v2.canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0"
+)
+CANONICAL_ORDER_INTENT_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION = (
+    "canonical_order_intent_boundary_backtest_state_file_v0"
+)
+
+_BLOCKING_INTENT_OUTCOMES = frozenset({"BLOCKED"})
+
+
+@dataclass(frozen=True)
+class CanonicalOrderIntentBacktestStateFileRecordV0:
+    """Parsed canonical order intent backtest state-file payload."""
+
+    instrument_id: str
+    reference_price: str
+    protective_stop_price: str
+    account_equity: str
+    scope_capital_limit: str
+    per_trade_risk_limit: str
+    total_capital_limit: str
+    daily_loss_remaining_budget: str
+    current_reconciled_exposure: str
+    lot_size: str
+    minimum_quantity: str
+    maximum_quantity: str
+    minimum_notional: str
+    tick_size: str
+    maximum_positions: int
+    current_open_positions_count: int
+    reconciliation_status: str
+    canonical_order_intent_owner_digest_ref: str
+    state_file_digest_ref: str
+    raw_payload: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class CanonicalOrderIntentBoundaryBacktestStateFileEvidenceV0:
+    canonical_order_intent_boundary_backtest_state_file_bound: bool
+    order_intent_provenance_represented: bool
+    order_intent_ref: str
+    order_intent_effect: str
+    intent_outcome: str
+    adapter_compatible: bool
+    canonical_order_intent_owner_digest_ref: str
+    state_file_digest_ref: str
+    runtime_authority: bool
+    orders_allowed: bool
+    credentials_used: bool
+    economic_evaluation: bool
+    offline_binding: CanonicalOrderIntentOfflineReplayBindingResultV0
+    surface_i_adapter_owner_ref: str
+
+
+def _canonical_payload_bytes(payload: Mapping[str, Any]) -> bytes:
+    stripped = {k: v for k, v in payload.items() if k != "state_file_digest_ref"}
+    return json.dumps(stripped, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def compute_backtest_state_file_digest_v0(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def compute_backtest_state_file_digest_from_payload_v0(payload: Mapping[str, Any]) -> str:
+    return compute_backtest_state_file_digest_v0(_canonical_payload_bytes(payload))
+
+
+def _parse_positive_decimal(raw: object, *, field_name: str) -> Decimal:
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        raise ValueError(f"{field_name}_missing")
+    try:
+        value = Decimal(str(raw))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"{field_name}_invalid") from exc
+    if value <= 0:
+        raise ValueError(f"{field_name}_invalid")
+    return value
+
+
+def _parse_non_negative_decimal(raw: object, *, field_name: str) -> Decimal:
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        raise ValueError(f"{field_name}_missing")
+    try:
+        value = Decimal(str(raw))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"{field_name}_invalid") from exc
+    if value < 0:
+        raise ValueError(f"{field_name}_invalid")
+    return value
+
+
+def _parse_required_str(raw: object, *, field_name: str) -> str:
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(f"{field_name}_missing")
+    return raw.strip()
+
+
+def parse_canonical_order_intent_backtest_state_file_v0(
+    *,
+    path: Path | None = None,
+    payload: Mapping[str, Any] | None = None,
+    raw_bytes: bytes | None = None,
+) -> CanonicalOrderIntentBacktestStateFileRecordV0:
+    """Parse backtest canonical order intent state file. Fail-closed on invalid input."""
+    if path is None and payload is None and raw_bytes is None:
+        raise ValueError("canonical_order_intent_backtest_state_file_input_missing")
+
+    if raw_bytes is None:
+        if path is not None:
+            if not path.is_file():
+                raise ValueError("canonical_order_intent_backtest_state_file_missing")
+            raw_bytes = path.read_bytes()
+        elif payload is not None:
+            raw_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        else:
+            raise ValueError("canonical_order_intent_backtest_state_file_input_missing")
+
+    if not raw_bytes.strip():
+        raise ValueError("canonical_order_intent_backtest_state_file_empty")
+
+    try:
+        decoded = json.loads(raw_bytes.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError("canonical_order_intent_backtest_state_file_corrupt") from exc
+
+    if not isinstance(decoded, Mapping):
+        raise ValueError("canonical_order_intent_backtest_state_file_invalid_shape")
+
+    state_file_digest_ref = compute_backtest_state_file_digest_from_payload_v0(decoded)
+
+    schema_version = decoded.get("schema_version", "")
+    if (
+        schema_version
+        and schema_version != CANONICAL_ORDER_INTENT_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION
+    ):
+        raise ValueError("canonical_order_intent_backtest_state_file_schema_version_mismatch")
+
+    instrument_id = _parse_required_str(decoded.get("instrument_id"), field_name="instrument_id")
+    _parse_positive_decimal(decoded.get("reference_price"), field_name="reference_price")
+    _parse_positive_decimal(decoded.get("account_equity"), field_name="account_equity")
+    _parse_positive_decimal(decoded.get("scope_capital_limit"), field_name="scope_capital_limit")
+    _parse_positive_decimal(decoded.get("per_trade_risk_limit"), field_name="per_trade_risk_limit")
+    _parse_positive_decimal(decoded.get("total_capital_limit"), field_name="total_capital_limit")
+    _parse_non_negative_decimal(
+        decoded.get("daily_loss_remaining_budget"),
+        field_name="daily_loss_remaining_budget",
+    )
+    _parse_non_negative_decimal(
+        decoded.get("current_reconciled_exposure"),
+        field_name="current_reconciled_exposure",
+    )
+    _parse_positive_decimal(decoded.get("lot_size"), field_name="lot_size")
+    _parse_positive_decimal(decoded.get("minimum_quantity"), field_name="minimum_quantity")
+    _parse_positive_decimal(decoded.get("maximum_quantity"), field_name="maximum_quantity")
+    _parse_positive_decimal(decoded.get("minimum_notional"), field_name="minimum_notional")
+    _parse_positive_decimal(decoded.get("tick_size"), field_name="tick_size")
+
+    owner_ref = str(decoded.get("canonical_order_intent_owner_digest_ref", "")).strip()
+    if not owner_ref:
+        raise ValueError("canonical_order_intent_owner_digest_ref_missing")
+    if owner_ref != CANONICAL_ORDER_INTENT_CONTRACT_VERSION:
+        raise ValueError("canonical_order_intent_owner_digest_ref_mismatch")
+
+    expected_digest = str(decoded.get("state_file_digest_ref", "")).strip()
+    if expected_digest and expected_digest != state_file_digest_ref:
+        raise ValueError("canonical_order_intent_backtest_state_file_digest_mismatch")
+
+    protective_stop = decoded.get("protective_stop_price")
+    if protective_stop is None or (
+        isinstance(protective_stop, str) and not protective_stop.strip()
+    ):
+        raise ValueError("protective_stop_price_missing")
+
+    maximum_positions = int(decoded.get("maximum_positions", 1))
+    if maximum_positions <= 0:
+        raise ValueError("maximum_positions_invalid")
+    current_open_positions_count = int(decoded.get("current_open_positions_count", 0))
+    if current_open_positions_count < 0:
+        raise ValueError("current_open_positions_count_invalid")
+
+    return CanonicalOrderIntentBacktestStateFileRecordV0(
+        instrument_id=instrument_id,
+        reference_price=str(decoded["reference_price"]),
+        protective_stop_price=str(protective_stop),
+        account_equity=str(decoded["account_equity"]),
+        scope_capital_limit=str(decoded["scope_capital_limit"]),
+        per_trade_risk_limit=str(decoded["per_trade_risk_limit"]),
+        total_capital_limit=str(decoded["total_capital_limit"]),
+        daily_loss_remaining_budget=str(decoded["daily_loss_remaining_budget"]),
+        current_reconciled_exposure=str(decoded["current_reconciled_exposure"]),
+        lot_size=str(decoded["lot_size"]),
+        minimum_quantity=str(decoded["minimum_quantity"]),
+        maximum_quantity=str(decoded["maximum_quantity"]),
+        minimum_notional=str(decoded["minimum_notional"]),
+        tick_size=str(decoded["tick_size"]),
+        maximum_positions=maximum_positions,
+        current_open_positions_count=current_open_positions_count,
+        reconciliation_status=str(decoded.get("reconciliation_status", "RECONCILED")).strip()
+        or "RECONCILED",
+        canonical_order_intent_owner_digest_ref=owner_ref,
+        state_file_digest_ref=state_file_digest_ref,
+        raw_payload=dict(decoded),
+    )
+
+
+def verify_canonical_order_intent_backtest_state_file_digest_v0(
+    record: CanonicalOrderIntentBacktestStateFileRecordV0,
+    *,
+    expected_digest_ref: str,
+) -> None:
+    """Fail-closed when an expected digest does not match the parsed state file."""
+    if not expected_digest_ref.strip():
+        raise ValueError("expected_state_file_digest_ref_missing")
+    if record.state_file_digest_ref != expected_digest_ref.strip():
+        raise ValueError("canonical_order_intent_backtest_state_file_digest_mismatch")
+
+
+def _capital_context_from_state_file(
+    state_file: CanonicalOrderIntentBacktestStateFileRecordV0,
+):
+    from trading.master_v2.canonical_core_runtime_integration_intent_pipeline_bridge_v0 import (
+        CanonicalCoreRuntimeCapitalContextV0,
+    )
+
+    instrument = InstrumentQuantityConstraintsV1(
+        instrument_id=state_file.instrument_id,
+        market_type="futures",
+        contract_kind="LINEAR",
+        contract_multiplier=Decimal("1"),
+        lot_size=Decimal(state_file.lot_size),
+        minimum_quantity=Decimal(state_file.minimum_quantity),
+        maximum_quantity=Decimal(state_file.maximum_quantity),
+        minimum_notional=Decimal(state_file.minimum_notional),
+        tick_size=Decimal(state_file.tick_size),
+        instrument_metadata_version="backtest_state_file_futures_metadata_v0",
+    )
+    return CanonicalCoreRuntimeCapitalContextV0(
+        reference_price=Decimal(state_file.reference_price),
+        protective_stop_price=Decimal(state_file.protective_stop_price),
+        account_equity=Decimal(state_file.account_equity),
+        scope_capital_limit=Decimal(state_file.scope_capital_limit),
+        per_trade_risk_limit=Decimal(state_file.per_trade_risk_limit),
+        total_capital_limit=Decimal(state_file.total_capital_limit),
+        daily_loss_remaining_budget=Decimal(state_file.daily_loss_remaining_budget),
+        current_reconciled_exposure=Decimal(state_file.current_reconciled_exposure),
+        instrument=instrument,
+        maximum_positions=state_file.maximum_positions,
+        current_open_positions_count=state_file.current_open_positions_count,
+        reconciliation_status=state_file.reconciliation_status,
+        config_digest=state_file.state_file_digest_ref,
+    )
+
+
+def bind_canonical_order_intent_boundary_backtest_state_file_evidence_v0(
+    evidence: "CanonicalTradingDecisionEvidenceV1",
+    *,
+    state_file: CanonicalOrderIntentBacktestStateFileRecordV0,
+    sizing_evidence: CapitalRiskSizingBoundaryBacktestStateFileEvidenceV0,
+) -> CanonicalOrderIntentBoundaryBacktestStateFileEvidenceV0:
+    """Bind backtest state-file order intent through the Surface I offline adapter."""
+    if not sizing_evidence.capital_risk_sizing_boundary_backtest_state_file_bound:
+        raise ValueError("canonical_order_intent_backtest_state_file_sizing_evidence_missing")
+
+    sized_evidence = sizing_evidence.offline_binding.evidence
+    sizing_decision = sizing_evidence.offline_binding.sizing_decision
+    offline_binding = bind_canonical_order_intent_offline_replay_evidence_v0(
+        sized_evidence,
+        sizing_decision=sizing_decision,
+        capital_context=_capital_context_from_state_file(state_file),
+    )
+    if not canonical_order_intent_binding_non_authority_boundary_ok_v0(offline_binding):
+        raise ValueError("canonical_order_intent_backtest_state_file_non_authority_boundary_failed")
+
+    intent = offline_binding.canonical_intent
+    adapter_compatible = bool(intent.adapter_compatible) if intent is not None else False
+    order_intent_provenance_represented = bool(offline_binding.order_intent_ref)
+    return CanonicalOrderIntentBoundaryBacktestStateFileEvidenceV0(
+        canonical_order_intent_boundary_backtest_state_file_bound=True,
+        order_intent_provenance_represented=order_intent_provenance_represented,
+        order_intent_ref=offline_binding.order_intent_ref,
+        order_intent_effect=offline_binding.order_intent_effect,
+        intent_outcome=offline_binding.intent_outcome,
+        adapter_compatible=adapter_compatible,
+        canonical_order_intent_owner_digest_ref=state_file.canonical_order_intent_owner_digest_ref,
+        state_file_digest_ref=state_file.state_file_digest_ref,
+        runtime_authority=False,
+        orders_allowed=False,
+        credentials_used=False,
+        economic_evaluation=False,
+        offline_binding=offline_binding,
+        surface_i_adapter_owner_ref=CANONICAL_ORDER_INTENT_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER,
+    )
+
+
+def evaluate_backtest_canonical_order_intent_state_file_boundary_only_v0(
+    state_file: CanonicalOrderIntentBacktestStateFileRecordV0,
+    *,
+    sizing_evidence: CapitalRiskSizingBoundaryBacktestStateFileEvidenceV0,
+    decision_outcome: str = "enter_long",
+) -> CanonicalOrderIntentBoundaryBacktestStateFileEvidenceV0:
+    """Evaluate boundary evidence fields without mutating decision evidence."""
+    from trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0 import (
+        build_scenario_tick_decision_evidence_v0,
+    )
+
+    stub = build_scenario_tick_decision_evidence_v0(
+        decision_id="backtest-canonical-order-intent-state-file-stub",
+        replay_id="backtest-canonical-order-intent-state-file-stub",
+        instrument_id=state_file.instrument_id,
+        trading_epoch=0,
+        composition_result_id="stub",
+        entry_exit_policy_ref="stub",
+        selected_side="long",
+        decision_outcome=decision_outcome,
+        reason_codes=("stub",),
+        decision_precedence_trace=("stub",),
+        config_digest="stub",
+        implementation_digest="stub",
+    )
+    _ = stub
+    return bind_canonical_order_intent_boundary_backtest_state_file_evidence_v0(
+        sizing_evidence.offline_binding.evidence,
+        state_file=state_file,
+        sizing_evidence=sizing_evidence,
+    )
+
+
+def apply_backtest_canonical_order_intent_exposure_gate_v0(
+    position_signal: int,
+    *,
+    evidence: CanonicalOrderIntentBoundaryBacktestStateFileEvidenceV0,
+) -> int:
+    """Fail-closed backtest exposure representation — no runtime orders."""
+    if position_signal == 0:
+        return 0
+    if not evidence.canonical_order_intent_boundary_backtest_state_file_bound:
+        return 0
+    if evidence.intent_outcome in _BLOCKING_INTENT_OUTCOMES:
+        return 0
+    if not evidence.order_intent_ref:
+        return 0
+    if evidence.adapter_compatible:
+        return 0
+    if evidence.order_intent_effect != ORDER_INTENT_EFFECT_BOUND_OFFLINE:
+        return 0
+    return position_signal
+
+
+def backtest_canonical_order_intent_state_file_binding_non_authority_ok_v0(
+    evidence: CanonicalOrderIntentBoundaryBacktestStateFileEvidenceV0,
+) -> bool:
+    if not evidence.canonical_order_intent_boundary_backtest_state_file_bound:
+        return False
+    if evidence.runtime_authority or evidence.orders_allowed:
+        return False
+    if evidence.credentials_used or evidence.economic_evaluation:
+        return False
+    if evidence.adapter_compatible:
+        return False
+    return canonical_order_intent_binding_non_authority_boundary_ok_v0(evidence.offline_binding)
+
+
+def load_canonical_order_intent_backtest_state_file_record_v0(
+    path: Path,
+    *,
+    expected_digest_ref: str = "",
+) -> CanonicalOrderIntentBacktestStateFileRecordV0:
+    record = parse_canonical_order_intent_backtest_state_file_v0(path=path)
+    if expected_digest_ref:
+        verify_canonical_order_intent_backtest_state_file_digest_v0(
+            record,
+            expected_digest_ref=expected_digest_ref,
+        )
+    return record
+
+
+from trading.master_v2.canonical_trading_decision_evidence_v1 import (  # noqa: E402
+    CanonicalTradingDecisionEvidenceV1,
+)

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -25,7 +25,7 @@ MatrixStatus = Literal[
     "UNKNOWN",
 ]
 
-NEXT_RECOMMENDED_SLICE = "BACKTEST_CANONICAL_ORDER_INTENT_WIRING_V0"
+NEXT_RECOMMENDED_SLICE = "BACKTEST_SAFETY_KERNEL_WIRING_V0"
 
 ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
@@ -49,6 +49,9 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0.py",
     "scripts/ops/run_backtest_capital_risk_sizing_wiring_v0.py",
     "tests/trading/master_v2/test_capital_risk_sizing_boundary_backtest_state_file_binding_contract_v0.py",
+    "src/trading/master_v2/canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0.py",
+    "scripts/ops/run_backtest_canonical_order_intent_wiring_v0.py",
+    "tests/test_backtest_canonical_order_intent_wiring_v0.py",
     "docs/research/FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_V0.md",
 )
 
@@ -346,20 +349,23 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
                 "offline_double_play_scenario_replay_v0 ->"
                 " evaluate_scenario_canonical_order_intent_v0() per tick"
             ),
-            current_backtest_binding="NOT_BOUND",
+            current_backtest_binding=(
+                "backtest/mv2_research_wiring_v1.run_mv2_research_backtest_wiring_v1 ->"
+                " bind_canonical_order_intent_boundary_backtest_state_file_evidence_v0()"
+                " via canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0"
+            ),
             current_runtime_semantics_reference=(
                 "canonical_core_runtime_integration_intent_pipeline_bridge_v0"
                 " build_canonical_order_intent_v1 BOUND_NOT_ACTIVATED"
             ),
-            parity_status="PARTIAL",
+            parity_status="PASS",
             evidence_refs=(
                 "tests/governance/test_canonical_order_intent_v1.py",
                 "tests/governance/test_intent_compatibility_firewall_v1.py",
                 "tests/trading/master_v2/test_canonical_order_intent_offline_replay_binding_parity_rewire_contract_v0.py",
+                "tests/test_backtest_canonical_order_intent_wiring_v0.py",
             ),
-            missing_binding_if_any=(
-                "Runtime bridge Slice B activation (out of offline assessment scope)"
-            ),
+            missing_binding_if_any="",
             recommended_next_slice=NEXT_RECOMMENDED_SLICE,
         ),
         ParitySurfaceAssessmentV0(

--- a/tests/test_backtest_canonical_order_intent_wiring_v0.py
+++ b/tests/test_backtest_canonical_order_intent_wiring_v0.py
@@ -1,0 +1,355 @@
+"""Contract: canonical order intent boundary backtest state-file binding v0 (offline only)."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from src.backtest.mv2_research_wiring_v1 import (
+    CanonicalOrderIntentBacktestStateFileBindingConfigV1,
+    CapitalRiskSizingBacktestStateFileBindingConfigV1,
+    run_mv2_research_backtest_wiring_v1,
+)
+from src.governance.canonical_order_intent_v1 import (
+    CONTRACT_VERSION as CANONICAL_ORDER_INTENT_CONTRACT_VERSION,
+)
+from src.governance.capital_risk_sizing_v1 import (
+    CONTRACT_VERSION as CAPITAL_RISK_SIZING_CONTRACT_VERSION,
+)
+from trading.master_v2.canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0 import (
+    CANONICAL_ORDER_INTENT_BOUNDARY_BACKTEST_STATE_FILE_BINDING_ADAPTER_OWNER,
+    CANONICAL_ORDER_INTENT_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION,
+    ORDER_INTENT_EFFECT_BOUND_OFFLINE,
+    apply_backtest_canonical_order_intent_exposure_gate_v0,
+    backtest_canonical_order_intent_state_file_binding_non_authority_ok_v0,
+    bind_canonical_order_intent_boundary_backtest_state_file_evidence_v0,
+    compute_backtest_state_file_digest_from_payload_v0,
+    evaluate_backtest_canonical_order_intent_state_file_boundary_only_v0,
+    parse_canonical_order_intent_backtest_state_file_v0,
+    verify_canonical_order_intent_backtest_state_file_digest_v0,
+)
+from trading.master_v2.canonical_order_intent_offline_replay_binding_adapter_v0 import (
+    CANONICAL_ORDER_INTENT_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER,
+)
+from trading.master_v2.capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0 import (
+    CAPITAL_RISK_SIZING_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION,
+    compute_backtest_state_file_digest_from_payload_v0 as sizing_digest,
+    evaluate_backtest_capital_risk_sizing_state_file_boundary_only_v0,
+    parse_capital_risk_sizing_backtest_state_file_v0,
+)
+from trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0 import (
+    build_scenario_tick_decision_evidence_v0,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import DecisionOutcome
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    NEXT_RECOMMENDED_SLICE,
+    parity_surface_assessments_v0,
+)
+from tests.backtest.test_mv2_research_wiring_v1 import _bars, _cfg
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_FORBIDDEN_IMPORT_SCAN_PATHS = (
+    REPO_ROOT
+    / "src/trading/master_v2/canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0.py",
+    REPO_ROOT / "scripts/ops/run_backtest_canonical_order_intent_wiring_v0.py",
+    REPO_ROOT / "tests/test_backtest_canonical_order_intent_wiring_v0.py",
+)
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def _sizing_state_file_payload(**kwargs: object) -> dict[str, object]:
+    base = {
+        "schema_version": CAPITAL_RISK_SIZING_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION,
+        "instrument_id": "inst-eth-usdt-perp",
+        "reference_price": "3500",
+        "protective_stop_price": "3400",
+        "account_equity": "10000",
+        "scope_capital_limit": "500",
+        "per_trade_risk_limit": "25",
+        "total_capital_limit": "500",
+        "daily_loss_remaining_budget": "25",
+        "current_reconciled_exposure": "0",
+        "lot_size": "0.01",
+        "minimum_quantity": "0.01",
+        "maximum_quantity": "100",
+        "minimum_notional": "5",
+        "tick_size": "0.01",
+        "capital_risk_sizing_owner_digest_ref": CAPITAL_RISK_SIZING_CONTRACT_VERSION,
+        **kwargs,
+    }
+    digest = sizing_digest(base)
+    return {**base, "state_file_digest_ref": digest}
+
+
+def _order_intent_state_file_payload(**kwargs: object) -> dict[str, object]:
+    base = {
+        "schema_version": CANONICAL_ORDER_INTENT_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION,
+        "instrument_id": "inst-eth-usdt-perp",
+        "reference_price": "3500",
+        "protective_stop_price": "3400",
+        "account_equity": "10000",
+        "scope_capital_limit": "500",
+        "per_trade_risk_limit": "25",
+        "total_capital_limit": "500",
+        "daily_loss_remaining_budget": "25",
+        "current_reconciled_exposure": "0",
+        "lot_size": "0.01",
+        "minimum_quantity": "0.01",
+        "maximum_quantity": "100",
+        "minimum_notional": "5",
+        "tick_size": "0.01",
+        "canonical_order_intent_owner_digest_ref": CANONICAL_ORDER_INTENT_CONTRACT_VERSION,
+        **kwargs,
+    }
+    digest = compute_backtest_state_file_digest_from_payload_v0(base)
+    return {**base, "state_file_digest_ref": digest}
+
+
+def _sizing_record(**kwargs: object):
+    return parse_capital_risk_sizing_backtest_state_file_v0(
+        payload=_sizing_state_file_payload(**kwargs)
+    )
+
+
+def _order_intent_record(**kwargs: object):
+    return parse_canonical_order_intent_backtest_state_file_v0(
+        payload=_order_intent_state_file_payload(**kwargs)
+    )
+
+
+def _base_evidence(*, decision_outcome: str = DecisionOutcome.ENTER_LONG.value):
+    return build_scenario_tick_decision_evidence_v0(
+        decision_id="backtest-canonical-order-intent-state-file-decision",
+        replay_id="backtest-canonical-order-intent-state-file-replay",
+        instrument_id="inst-eth-usdt-perp",
+        trading_epoch=1,
+        composition_result_id="composition",
+        entry_exit_policy_ref="policy",
+        selected_side="long",
+        decision_outcome=decision_outcome,
+        reason_codes=("PASS",),
+        decision_precedence_trace=("enter_long",),
+        config_digest="config",
+        implementation_digest="impl",
+    )
+
+
+def test_owner_constants_reuse_surface_i_adapter_v0() -> None:
+    assert CANONICAL_ORDER_INTENT_BOUNDARY_BACKTEST_STATE_FILE_BINDING_ADAPTER_OWNER.endswith(
+        "canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0"
+    )
+
+
+def test_slice_sources_exclude_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "execution",
+            "scheduler",
+            "credentials",
+            "live_runtime",
+            "testnet",
+            "shadow",
+            "paper_lane",
+            "risk_layer.kill_switch.core",
+        }
+    )
+    for path in _FORBIDDEN_IMPORT_SCAN_PATHS:
+        assert path.is_file(), f"missing slice source: {path}"
+        hits = _scan_forbidden_imports(path, forbidden)
+        assert hits == [], f"forbidden imports in {path}: {hits}"
+
+
+def test_valid_caps_bind_order_intent_provenance_v0() -> None:
+    sizing_evidence = evaluate_backtest_capital_risk_sizing_state_file_boundary_only_v0(
+        _sizing_record()
+    )
+    evidence = evaluate_backtest_canonical_order_intent_state_file_boundary_only_v0(
+        _order_intent_record(),
+        sizing_evidence=sizing_evidence,
+    )
+    assert evidence.order_intent_provenance_represented is True
+    assert evidence.order_intent_ref
+    assert evidence.order_intent_effect == ORDER_INTENT_EFFECT_BOUND_OFFLINE
+    assert evidence.adapter_compatible is False
+    assert apply_backtest_canonical_order_intent_exposure_gate_v0(1, evidence=evidence) == 1
+
+
+def test_observe_decision_without_provenance_remains_non_executable_v0() -> None:
+    sizing_evidence = evaluate_backtest_capital_risk_sizing_state_file_boundary_only_v0(
+        _sizing_record(),
+        decision_outcome=DecisionOutcome.OBSERVE.value,
+    )
+    evidence = evaluate_backtest_canonical_order_intent_state_file_boundary_only_v0(
+        _order_intent_record(),
+        sizing_evidence=sizing_evidence,
+        decision_outcome=DecisionOutcome.OBSERVE.value,
+    )
+    assert evidence.order_intent_provenance_represented is False
+    assert evidence.offline_binding.binding_applied is False
+    assert apply_backtest_canonical_order_intent_exposure_gate_v0(1, evidence=evidence) == 0
+
+
+def test_blocked_sizing_blocks_order_intent_exposure_v0() -> None:
+    sizing_evidence = evaluate_backtest_capital_risk_sizing_state_file_boundary_only_v0(
+        _sizing_record(daily_loss_remaining_budget="0")
+    )
+    evidence = evaluate_backtest_canonical_order_intent_state_file_boundary_only_v0(
+        _order_intent_record(),
+        sizing_evidence=sizing_evidence,
+    )
+    assert evidence.intent_outcome == "BLOCKED"
+    assert apply_backtest_canonical_order_intent_exposure_gate_v0(1, evidence=evidence) == 0
+
+
+def test_missing_owner_digest_fails_closed_v0() -> None:
+    payload = _order_intent_state_file_payload()
+    del payload["canonical_order_intent_owner_digest_ref"]
+    with pytest.raises(ValueError, match="canonical_order_intent_owner_digest_ref_missing"):
+        parse_canonical_order_intent_backtest_state_file_v0(payload=payload)
+
+
+def test_corrupted_state_file_digest_fails_closed_v0() -> None:
+    payload = _order_intent_state_file_payload()
+    payload["state_file_digest_ref"] = "0" * 64
+    with pytest.raises(
+        ValueError, match="canonical_order_intent_backtest_state_file_digest_mismatch"
+    ):
+        parse_canonical_order_intent_backtest_state_file_v0(payload=payload)
+
+
+def test_backtest_binding_uses_surface_i_adapter_not_duplicate_semantics_v0() -> None:
+    sizing_evidence = evaluate_backtest_capital_risk_sizing_state_file_boundary_only_v0(
+        _sizing_record(daily_loss_remaining_budget="0")
+    )
+    bound = bind_canonical_order_intent_boundary_backtest_state_file_evidence_v0(
+        _base_evidence(decision_outcome=DecisionOutcome.ENTER_LONG.value),
+        state_file=_order_intent_record(),
+        sizing_evidence=sizing_evidence,
+    )
+    assert (
+        bound.surface_i_adapter_owner_ref
+        == CANONICAL_ORDER_INTENT_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER
+    )
+
+
+def test_non_authority_invariants_v0() -> None:
+    sizing_evidence = evaluate_backtest_capital_risk_sizing_state_file_boundary_only_v0(
+        _sizing_record()
+    )
+    evidence = evaluate_backtest_canonical_order_intent_state_file_boundary_only_v0(
+        _order_intent_record(),
+        sizing_evidence=sizing_evidence,
+    )
+    assert evidence.runtime_authority is False
+    assert evidence.orders_allowed is False
+    assert evidence.credentials_used is False
+    assert evidence.economic_evaluation is False
+    assert evidence.adapter_compatible is False
+    assert backtest_canonical_order_intent_state_file_binding_non_authority_ok_v0(evidence)
+
+
+def test_parity_gap_assessment_surface_i_backtest_state_file_pass_v0() -> None:
+    order_intent = next(item for item in parity_surface_assessments_v0() if item.surface_id == "I")
+    assert order_intent.parity_status == "PASS"
+    assert order_intent.missing_binding_if_any == ""
+    assert "bind_canonical_order_intent_boundary_backtest_state_file_evidence_v0" in (
+        order_intent.current_backtest_binding
+    )
+    assert NEXT_RECOMMENDED_SLICE == "BACKTEST_SAFETY_KERNEL_WIRING_V0"
+
+
+def test_mv2_research_wiring_binds_state_file_and_represents_order_intent_v0(
+    tmp_path: Path,
+) -> None:
+    sizing_payload = _sizing_state_file_payload()
+    sizing_path = tmp_path / "capital_risk_sizing_backtest_state.json"
+    sizing_path.write_text(json.dumps(sizing_payload, indent=2), encoding="utf-8")
+
+    intent_payload = _order_intent_state_file_payload()
+    intent_path = tmp_path / "canonical_order_intent_backtest_state.json"
+    intent_path.write_text(json.dumps(intent_payload, indent=2), encoding="utf-8")
+
+    result = run_mv2_research_backtest_wiring_v1(
+        _bars(n=6),
+        strategy_id="ma_crossover",
+        cfg=_cfg(),
+        explicit_zero_cost_non_economic=True,
+        capital_risk_sizing_state_file_binding=CapitalRiskSizingBacktestStateFileBindingConfigV1(
+            state_file_path=sizing_path,
+            expected_state_file_digest_ref=str(sizing_payload["state_file_digest_ref"]),
+        ),
+        canonical_order_intent_state_file_binding=CanonicalOrderIntentBacktestStateFileBindingConfigV1(
+            state_file_path=intent_path,
+            expected_state_file_digest_ref=str(intent_payload["state_file_digest_ref"]),
+        ),
+    )
+    assert result.bar_outcomes
+    bound = [
+        o for o in result.bar_outcomes if o.canonical_order_intent_backtest_state_file_evidence
+    ]
+    assert len(bound) == len(result.bar_outcomes)
+    sample = bound[0].canonical_order_intent_backtest_state_file_evidence
+    assert sample is not None
+    assert sample.canonical_order_intent_boundary_backtest_state_file_bound is True
+
+
+def test_mv2_research_wiring_legacy_without_state_file_unchanged_v0() -> None:
+    result = run_mv2_research_backtest_wiring_v1(
+        _bars(n=6),
+        strategy_id="ma_crossover",
+        cfg=_cfg(),
+        explicit_zero_cost_non_economic=True,
+    )
+    assert all(
+        o.canonical_order_intent_backtest_state_file_evidence is None for o in result.bar_outcomes
+    )
+
+
+def test_order_intent_without_sizing_state_file_fails_closed_v0(tmp_path: Path) -> None:
+    intent_payload = _order_intent_state_file_payload()
+    intent_path = tmp_path / "canonical_order_intent_backtest_state.json"
+    intent_path.write_text(json.dumps(intent_payload, indent=2), encoding="utf-8")
+    with pytest.raises(
+        ValueError, match="canonical_order_intent_backtest_state_file_requires_sizing_state_file"
+    ):
+        run_mv2_research_backtest_wiring_v1(
+            _bars(n=4),
+            strategy_id="ma_crossover",
+            cfg=_cfg(),
+            explicit_zero_cost_non_economic=True,
+            canonical_order_intent_state_file_binding=CanonicalOrderIntentBacktestStateFileBindingConfigV1(
+                state_file_path=intent_path,
+                expected_state_file_digest_ref=str(intent_payload["state_file_digest_ref"]),
+            ),
+        )
+
+
+def test_verify_state_file_digest_ref_v0() -> None:
+    record = _order_intent_record()
+    verify_canonical_order_intent_backtest_state_file_digest_v0(
+        record,
+        expected_digest_ref=record.state_file_digest_ref,
+    )
+    with pytest.raises(
+        ValueError, match="canonical_order_intent_backtest_state_file_digest_mismatch"
+    ):
+        verify_canonical_order_intent_backtest_state_file_digest_v0(
+            record, expected_digest_ref="0" * 64
+        )

--- a/tests/test_full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/tests/test_full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -1,0 +1,68 @@
+"""Contract: full canonical system backtest parity gap assessment v0 (offline only)."""
+
+from __future__ import annotations
+
+import json
+
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_OWNER,
+    NEXT_RECOMMENDED_SLICE,
+    parity_status_counts_v0,
+    parity_surface_assessments_v0,
+    render_parity_gap_matrix_json_v0,
+    render_parity_gap_matrix_markdown_v0,
+)
+
+
+def test_gap_assessment_owner_and_surface_count_v0() -> None:
+    assessments = parity_surface_assessments_v0()
+    assert len(assessments) == 16
+    ids = [item.surface_id for item in assessments]
+    assert ids == [chr(ord("A") + i) for i in range(16)]
+    assert all(item.forbidden_runtime_authority_confirmed for item in assessments)
+    assert FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_OWNER.endswith(
+        "full_canonical_system_backtest_parity_gap_assessment_v0"
+    )
+
+
+def test_gap_assessment_status_distribution_v0() -> None:
+    counts = parity_status_counts_v0()
+    assert counts["PASS"] == 6
+    assert counts["PARTIAL"] >= 4
+    assert counts["GAP"] == 0
+    assert counts["NOT_APPLICABLE"] >= 2
+    assert sum(counts.values()) == 16
+
+
+def test_canonical_order_intent_surface_pass_v0() -> None:
+    order_intent = next(item for item in parity_surface_assessments_v0() if item.surface_id == "I")
+    assert order_intent.parity_status == "PASS"
+    assert order_intent.missing_binding_if_any == ""
+    assert "bind_canonical_order_intent_boundary_backtest_state_file_evidence_v0" in (
+        order_intent.current_backtest_binding
+    )
+    assert order_intent.recommended_next_slice == NEXT_RECOMMENDED_SLICE
+
+
+def test_capital_risk_sizing_surface_pass_v0() -> None:
+    sizing = next(item for item in parity_surface_assessments_v0() if item.surface_id == "H")
+    assert sizing.parity_status == "PASS"
+    assert "bind_capital_risk_sizing_boundary_backtest_state_file_evidence_v0" in (
+        sizing.current_backtest_binding
+    )
+
+
+def test_gap_matrix_markdown_renders_v0() -> None:
+    md = render_parity_gap_matrix_markdown_v0()
+    assert "FULL_CANONICAL_CHAIN_WIRED=false" in md
+    assert NEXT_RECOMMENDED_SLICE in md
+
+
+def test_gap_matrix_json_machine_readable_v0() -> None:
+    payload = json.loads(render_parity_gap_matrix_json_v0())
+    assert payload["assessment_owner"] == FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_OWNER
+    assert payload["next_recommended_slice"] == NEXT_RECOMMENDED_SLICE
+    assert len(payload["surfaces"]) == 16
+    assert payload["summary"]["full_canonical_chain_wired"] is False
+    surface_i = next(item for item in payload["surfaces"] if item["surface_id"] == "I")
+    assert surface_i["parity_status"] == "PASS"

--- a/tests/test_mv2_research_wiring_v1.py
+++ b/tests/test_mv2_research_wiring_v1.py
@@ -1,0 +1,112 @@
+"""MV2 research wiring v1: canonical order intent backtest state-file integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.backtest.mv2_research_wiring_v1 import (
+    CanonicalOrderIntentBacktestStateFileBindingConfigV1,
+    CapitalRiskSizingBacktestStateFileBindingConfigV1,
+    run_mv2_research_backtest_wiring_v1,
+)
+from src.governance.canonical_order_intent_v1 import (
+    CONTRACT_VERSION as CANONICAL_ORDER_INTENT_CONTRACT_VERSION,
+)
+from src.governance.capital_risk_sizing_v1 import (
+    CONTRACT_VERSION as CAPITAL_RISK_SIZING_CONTRACT_VERSION,
+)
+from trading.master_v2.canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0 import (
+    CANONICAL_ORDER_INTENT_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION,
+    compute_backtest_state_file_digest_from_payload_v0,
+)
+from trading.master_v2.capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0 import (
+    CAPITAL_RISK_SIZING_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION,
+    compute_backtest_state_file_digest_from_payload_v0 as sizing_digest,
+)
+from tests.backtest.test_mv2_research_wiring_v1 import _bars, _cfg
+
+
+def _sizing_payload() -> dict[str, object]:
+    base = {
+        "schema_version": CAPITAL_RISK_SIZING_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION,
+        "instrument_id": "inst-eth-usdt-perp",
+        "reference_price": "3500",
+        "protective_stop_price": "3400",
+        "account_equity": "10000",
+        "scope_capital_limit": "500",
+        "per_trade_risk_limit": "25",
+        "total_capital_limit": "500",
+        "daily_loss_remaining_budget": "25",
+        "current_reconciled_exposure": "0",
+        "lot_size": "0.01",
+        "minimum_quantity": "0.01",
+        "maximum_quantity": "100",
+        "minimum_notional": "5",
+        "tick_size": "0.01",
+        "capital_risk_sizing_owner_digest_ref": CAPITAL_RISK_SIZING_CONTRACT_VERSION,
+    }
+    return {**base, "state_file_digest_ref": sizing_digest(base)}
+
+
+def _order_intent_payload() -> dict[str, object]:
+    base = {
+        "schema_version": CANONICAL_ORDER_INTENT_BOUNDARY_BACKTEST_STATE_FILE_SCHEMA_VERSION,
+        "instrument_id": "inst-eth-usdt-perp",
+        "reference_price": "3500",
+        "protective_stop_price": "3400",
+        "account_equity": "10000",
+        "scope_capital_limit": "500",
+        "per_trade_risk_limit": "25",
+        "total_capital_limit": "500",
+        "daily_loss_remaining_budget": "25",
+        "current_reconciled_exposure": "0",
+        "lot_size": "0.01",
+        "minimum_quantity": "0.01",
+        "maximum_quantity": "100",
+        "minimum_notional": "5",
+        "tick_size": "0.01",
+        "canonical_order_intent_owner_digest_ref": CANONICAL_ORDER_INTENT_CONTRACT_VERSION,
+    }
+    return {
+        **base,
+        "state_file_digest_ref": compute_backtest_state_file_digest_from_payload_v0(base),
+    }
+
+
+def test_mv2_wiring_reuses_existing_backtest_matrix_v0() -> None:
+    from tests.backtest import test_mv2_research_wiring_v1 as core
+
+    core.test_matrix_23_end_to_end_returns_signal_series()
+
+
+def test_mv2_wiring_canonical_order_intent_chain_v0(tmp_path: Path) -> None:
+    sizing_payload = _sizing_payload()
+    sizing_path = tmp_path / "capital_risk_sizing_backtest_state.json"
+    sizing_path.write_text(json.dumps(sizing_payload, indent=2), encoding="utf-8")
+
+    intent_payload = _order_intent_payload()
+    intent_path = tmp_path / "canonical_order_intent_backtest_state.json"
+    intent_path.write_text(json.dumps(intent_payload, indent=2), encoding="utf-8")
+
+    result = run_mv2_research_backtest_wiring_v1(
+        _bars(n=6),
+        strategy_id="ma_crossover",
+        cfg=_cfg(),
+        explicit_zero_cost_non_economic=True,
+        capital_risk_sizing_state_file_binding=CapitalRiskSizingBacktestStateFileBindingConfigV1(
+            state_file_path=sizing_path,
+            expected_state_file_digest_ref=str(sizing_payload["state_file_digest_ref"]),
+        ),
+        canonical_order_intent_state_file_binding=CanonicalOrderIntentBacktestStateFileBindingConfigV1(
+            state_file_path=intent_path,
+            expected_state_file_digest_ref=str(intent_payload["state_file_digest_ref"]),
+        ),
+    )
+    assert all(
+        o.capital_risk_sizing_backtest_state_file_evidence is not None for o in result.bar_outcomes
+    )
+    assert all(
+        o.canonical_order_intent_backtest_state_file_evidence is not None
+        for o in result.bar_outcomes
+    )

--- a/tests/trading/master_v2/test_capital_risk_sizing_boundary_backtest_state_file_binding_contract_v0.py
+++ b/tests/trading/master_v2/test_capital_risk_sizing_boundary_backtest_state_file_binding_contract_v0.py
@@ -251,7 +251,7 @@ def test_parity_gap_assessment_surface_h_backtest_state_file_pass_v0() -> None:
     assert "bind_capital_risk_sizing_boundary_backtest_state_file_evidence_v0" in (
         sizing.current_backtest_binding
     )
-    assert NEXT_RECOMMENDED_SLICE == "BACKTEST_CANONICAL_ORDER_INTENT_WIRING_V0"
+    assert NEXT_RECOMMENDED_SLICE == "BACKTEST_SAFETY_KERNEL_WIRING_V0"
 
 
 def test_mv2_research_wiring_binds_state_file_and_represents_sizing_v0(tmp_path: Path) -> None:

--- a/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
+++ b/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
@@ -58,8 +58,8 @@ def test_gap_assessment_owner_and_surface_count_v0() -> None:
 
 def test_gap_assessment_status_distribution_v0() -> None:
     counts = parity_status_counts_v0()
-    assert counts["PASS"] == 5
-    assert counts["PARTIAL"] >= 5
+    assert counts["PASS"] == 6
+    assert counts["PARTIAL"] >= 4
     assert counts["GAP"] == 0
     assert counts["NOT_APPLICABLE"] >= 2
     assert sum(counts.values()) == 16
@@ -80,11 +80,12 @@ def test_capital_risk_sizing_surface_pass_v0() -> None:
     )
 
 
-def test_canonical_order_intent_surface_partial_v0() -> None:
+def test_canonical_order_intent_surface_pass_v0() -> None:
     order_intent = next(item for item in parity_surface_assessments_v0() if item.surface_id == "I")
-    assert order_intent.parity_status == "PARTIAL"
-    assert "bind_canonical_order_intent_offline_replay_evidence_v0" in (
-        order_intent.current_integrated_offline_replay_binding
+    assert order_intent.parity_status == "PASS"
+    assert order_intent.missing_binding_if_any == ""
+    assert "bind_canonical_order_intent_boundary_backtest_state_file_evidence_v0" in (
+        order_intent.current_backtest_binding
     )
     assert order_intent.recommended_next_slice == NEXT_RECOMMENDED_SLICE
 


### PR DESCRIPTION
VERDICT=BACKTEST_CANONICAL_ORDER_INTENT_WIRING_V0_READY_FOR_REVIEW

SCOPE=BACKTEST_CANONICAL_ORDER_INTENT_WIRING_V0
BASE_HEAD=0e41339bf78d8ef65c1afd125f84bcf303a4d843
ORIGIN_MAIN=0e41339bf78d8ef65c1afd125f84bcf303a4d843
REUSE_FIRST=true

Goal:
Bind the canonical order intent boundary into the backtest parity path without runtime authority, adapter submission, orders, credentials, scheduler, shadow, paper, testnet, canary, or live scope.

Expected outcomes:
CANONICAL_ORDER_INTENT_BOUND_TO_BACKTEST=true
ORDER_INTENT_PROVENANCE_REPRESENTED_IN_BACKTEST=true
ADAPTER_COMPATIBLE_REMAINS_FALSE_UNLESS_EXPLICITLY_TRANSFORMED=true
FULL_CANONICAL_CHAIN_WIRED=false
SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false
NO_RUNTIME_AUTHORITY=true
NO_ORDERS=true

Closeout requirements:
POST_MERGE_HEAD_EQUALS_ORIGIN_MAIN_REQUIRED=true
SOURCE_EVIDENCE_MANIFEST_REVERIFY_REQUIRED_WHEN_REFERENCED=true
SOURCE_EVIDENCE_ABSENCE_MUST_BE_EXPLICITLY_REPORTED=true
CLOSEOUT_MANIFEST_VERIFY_RC_REQUIRED=0

Made with [Cursor](https://cursor.com)