### PR TITLE
BULL_BEAR_STATE_SWITCH_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0

### DIFF
--- a/scripts/ops/run_bull_bear_state_switch_scenario_replay_binding_parity_rewire_v0.py
+++ b/scripts/ops/run_bull_bear_state_switch_scenario_replay_binding_parity_rewire_v0.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for Bull/Bear state switch scenario replay binding parity rewire v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+SOURCE_EVIDENCE_DIR = (
+    ARCHIVE_ROOT
+    / "research/full_canonical_system_backtest_parity_final_aggregation_and_gap_status_v0_20260707T170026Z"
+)
+NEXT_RECOMMENDED_SLICE = "SCOPE_EVENT_GENERATOR_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+VERDICT = "BULL_BEAR_STATE_SWITCH_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0_PASS"
+PROCESS_CLASSIFICATION = "NARROW_REUSE_FIRST_REWIRE_WITH_TEST_HYGIENE"
+SCOPE_CLASSIFICATION = "BULL_BEAR_STATE_SWITCH_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+TARGETED_TESTS = (
+    "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+    "tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
+    "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "scripts/ops/run_bull_bear_state_switch_scenario_replay_binding_parity_rewire_v0.py",
+    "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+)
+PARITY_PATHS = (
+    "bull_only_confirmed",
+    "bear_only_confirmed",
+    "both_sides_confirmed_chop_block",
+    "neutral_observe",
+    "blocked_unknown_input",
+    "mirrored_bull_bear_price_path",
+    "integrated_vs_scenario_state_switch",
+    "scenario_replay_tick_binding_no_shortcut",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.iterdir()):
+        if path.name == "MANIFEST.sha256":
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  {path.name}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["sha256sum", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def collect_evidence(out_dir: Path | None = None) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT
+        / f"research/bull_bear_state_switch_scenario_replay_binding_parity_rewire_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    status = _run(["git", "status", "--short"]).stdout.strip()
+
+    source_manifest_proc = _run(["sha256sum", "-c", "MANIFEST.sha256"], cwd=SOURCE_EVIDENCE_DIR)
+    (evidence_dir / "source_manifest_reverify.log").write_text(
+        source_manifest_proc.stdout + source_manifest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    commands: list[str] = []
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    pytest_cmd = [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS]
+    commands.append(" ".join(pytest_cmd))
+    pytest_proc = subprocess.run(
+        pytest_cmd,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (evidence_dir / "tests.log").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    ruff_format_cmd = ["ruff", "format", "--check", "."]
+    ruff_check_cmd = ["ruff", "check", "."]
+    commands.extend([" ".join(ruff_format_cmd), " ".join(ruff_check_cmd)])
+    ruff_format = _run(ruff_format_cmd)
+    ruff_check = _run(ruff_check_cmd)
+    (evidence_dir / "ruff.log").write_text(
+        "RUFF_FORMAT\n"
+        + ruff_format.stdout
+        + ruff_format.stderr
+        + "\nRUFF_CHECK\n"
+        + ruff_check.stdout
+        + ruff_check.stderr,
+        encoding="utf-8",
+    )
+    (evidence_dir / "commands.log").write_text("\n".join(commands) + "\n", encoding="utf-8")
+
+    (evidence_dir / "git_state.txt").write_text(
+        "\n".join(
+            [
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"HEAD_EQUALS_ORIGIN_MAIN_AT_START={head == origin_main}",
+                f"WORKTREE_STATUS={status or 'clean'}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "changed_files.txt").write_text(
+        "\n".join(SLICE_CHANGED_FILES) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "state_switch_owner_map.md").write_text(
+        "\n".join(
+            [
+                "# State Switch Owner Map",
+                "",
+                "| Role | Owner |",
+                "|---|---|",
+                "| Canonical pure model | `trading.master_v2.double_play_state` |",
+                "| Scenario binding adapter | `trading.master_v2.bull_bear_state_switch_scenario_binding_adapter_v0` |",
+                "| Integrated offline replay | `trading.master_v2.integrated_offline_trading_logic_replay_v1` |",
+                "| Scenario replay orchestrator | `trading.master_v2.offline_double_play_scenario_replay_v0` |",
+                "",
+                "Reuse-first: scenario replay calls `evaluate_scenario_state_switch_v0()` which delegates to `transition_state()` only.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "parity_notes.md").write_text(
+        "\n".join(
+            [
+                "# Parity Notes",
+                "",
+                f"PARITY_PATHS={','.join(PARITY_PATHS)}",
+                "STATE_SWITCH_EFFECT=BOUND_OFFLINE",
+                "execution_eligible=false",
+                "adapter_compatible=false",
+                "authority_effect=NONE",
+                "runtime_effect=NONE",
+                "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc = _write_manifest(evidence_dir)
+    tests_pass = pytest_proc.returncode == 0
+    ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0
+    source_manifest_rc = source_manifest_proc.returncode
+    verdict = (
+        VERDICT
+        if tests_pass and ruff_pass and manifest_rc == 0 and source_manifest_rc == 0
+        else "BULL_BEAR_STATE_SWITCH_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0_BLOCKED"
+    )
+
+    report = f"""# Bull/Bear State Switch Scenario Replay Binding Parity Rewire v0
+
+VERDICT={verdict}
+PROCESS_CLASSIFICATION={PROCESS_CLASSIFICATION}
+SCOPE_CLASSIFICATION={SCOPE_CLASSIFICATION}
+GO_TOKEN_CONSUMPTION=CONSUMED_ONCE
+BASE_HEAD={head}
+ORIGIN_MAIN={origin_main}
+HEAD_EQUALS_ORIGIN_MAIN_AT_START={head == origin_main}
+BRANCH=feat/bull-bear-state-switch-scenario-replay-binding-parity-v0
+CHANGED_FILES={",".join(SLICE_CHANGED_FILES)}
+SOURCE_EVIDENCE_DIR={SOURCE_EVIDENCE_DIR}
+SOURCE_MANIFEST_VERIFY_RC={source_manifest_rc}
+TARGETED_TESTS_RC={pytest_proc.returncode}
+RUFF_FORMAT_RC={ruff_format.returncode}
+RUFF_CHECK_RC={ruff_check.returncode}
+CLOSEOUT_MANIFEST_VERIFY_RC={manifest_rc}
+DURABLE_EVIDENCE_DIR={evidence_dir}
+PR_URL=pending
+NEXT_STEP_RECOMMENDATION={NEXT_RECOMMENDED_SLICE}
+LIVE_AUTHORIZED=false
+ORDERS_ALLOWED=false
+SCHEDULER_RUNTIME_ALLOWED=false
+SHADOW_AUTHORIZED=false
+PAPER_AUTHORIZED=false
+TESTNET_AUTHORIZED=false
+CANARY_AUTHORIZED=false
+SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false
+NO_RUNTIME_AUTHORITY_FROM_THIS_PR=true
+"""
+    (evidence_dir / "FINAL_REPORT.md").write_text(report, encoding="utf-8")
+    _write_manifest(evidence_dir)
+
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_rc": manifest_rc,
+        "source_manifest_rc": source_manifest_rc,
+        "tests_pass": tests_pass,
+        "ruff_pass": ruff_pass,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-dir", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(args.out_dir)
+    print(json.dumps(result, indent=2))
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py
+++ b/src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py
@@ -1,0 +1,218 @@
+# src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py
+"""
+Scenario replay adapter: binds offline Double Play scenario ticks to the canonical
+``double_play_state.transition_state`` owner without duplicating state-switch logic.
+
+Wiring-only parity slice — no runtime authority, no trading semantic extension.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Tuple
+
+from trading.master_v2.double_play_state import (
+    ActiveSide,
+    DynamicScopeRules,
+    RuntimeEnvelope,
+    RuntimeScopeState,
+    ScopeEvent,
+    SideState,
+    TransitionDecision,
+    derive_active_side,
+    transition_state,
+)
+
+BULL_BEAR_STATE_SWITCH_SCENARIO_BINDING_ADAPTER_LAYER_VERSION = "v0"
+BULL_BEAR_STATE_SWITCH_SCENARIO_BINDING_ADAPTER_OWNER = (
+    "trading.master_v2.bull_bear_state_switch_scenario_binding_adapter_v0"
+)
+CANONICAL_STATE_SWITCH_OWNER = "trading.master_v2.double_play_state"
+
+STATE_SWITCH_EFFECT_BOUND_OFFLINE = "BOUND_OFFLINE"
+STATE_SWITCH_EFFECT_NONE = "NONE"
+
+RUNTIME_AUTHORITY_EFFECT_NONE = "NONE"
+ORDER_EFFECT_NONE = "NONE"
+
+
+@dataclass(frozen=True)
+class ScenarioStateSwitchContextV0:
+    """Explicit offline scenario state-switch context — never inferred from shortcuts."""
+
+    instrument_id: str
+    trading_epoch: int
+    context_reference: str
+    side_state: SideState
+    scope_event: ScopeEvent
+    scope_state: RuntimeScopeState
+    rules: DynamicScopeRules
+    envelope: RuntimeEnvelope
+    now_tick: int
+    scope_event_id: str = ""
+
+
+@dataclass(frozen=True)
+class ScenarioStateSwitchBindingResultV0:
+    side_state_before: SideState
+    side_state_after: SideState
+    scope_state_after: RuntimeScopeState
+    transition: TransitionDecision
+    bull_layer_state: SideState
+    bear_layer_state: SideState
+    active_side: ActiveSide
+    state_switch_ref: str
+    state_switch_effect: str
+    runtime_authority_effect: str = RUNTIME_AUTHORITY_EFFECT_NONE
+    order_effect: str = ORDER_EFFECT_NONE
+
+
+def project_bull_layer_side_state_v0(side: SideState) -> SideState:
+    """Canonical bull-layer projection from unified side state (reuse contract)."""
+    if side in (
+        SideState.LONG_ACTIVE,
+        SideState.LONG_ARMED,
+        SideState.LONG_BLOCKED,
+        SideState.SWITCH_LONG_TO_SHORT_PENDING,
+    ):
+        return side
+    if side in (SideState.SHORT_ACTIVE, SideState.SHORT_ARMED, SideState.SHORT_BLOCKED):
+        return SideState.LONG_BLOCKED
+    return SideState.NEUTRAL_OBSERVE
+
+
+def project_bear_layer_side_state_v0(side: SideState) -> SideState:
+    """Canonical bear-layer projection from unified side state (reuse contract)."""
+    if side in (
+        SideState.SHORT_ACTIVE,
+        SideState.SHORT_ARMED,
+        SideState.SHORT_BLOCKED,
+        SideState.SWITCH_SHORT_TO_LONG_PENDING,
+    ):
+        return side
+    if side in (SideState.LONG_ACTIVE, SideState.LONG_ARMED, SideState.LONG_BLOCKED):
+        return SideState.SHORT_BLOCKED
+    return SideState.NEUTRAL_OBSERVE
+
+
+def _derive_state_switch_id(
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+    scope_event_id: str,
+) -> str:
+    material = f"{instrument_id}|{trading_epoch}|{scope_event_id}"
+    return f"state-switch-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:24]}"
+
+
+def compute_state_switch_semantic_digest_v0(
+    *,
+    state_switch_id: str,
+    instrument_id: str,
+    trading_epoch: int,
+    previous_side_state: str,
+    next_side_state: str,
+    scope_event_type: str,
+    transition_allowed: bool,
+    transition_reason_code: str,
+) -> str:
+    payload = {
+        "instrument_id": instrument_id,
+        "next_side_state": next_side_state,
+        "previous_side_state": previous_side_state,
+        "scope_event_type": scope_event_type,
+        "state_switch_id": state_switch_id,
+        "trading_epoch": trading_epoch,
+        "transition_allowed": transition_allowed,
+        "transition_reason_code": transition_reason_code,
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def evaluate_scenario_state_switch_v0(
+    ctx: ScenarioStateSwitchContextV0,
+) -> ScenarioStateSwitchBindingResultV0:
+    """Evaluate one scenario tick through canonical ``transition_state`` only."""
+    side_before = ctx.side_state
+    side_after, scope_after, transition = transition_state(
+        side_state=ctx.side_state,
+        event=ctx.scope_event,
+        scope_state=ctx.scope_state,
+        rules=ctx.rules,
+        envelope=ctx.envelope,
+        now_tick=ctx.now_tick,
+    )
+    scope_event_id = ctx.scope_event_id or f"{ctx.context_reference}-{ctx.scope_event.value}"
+    state_switch_id = _derive_state_switch_id(
+        instrument_id=ctx.instrument_id,
+        trading_epoch=ctx.trading_epoch,
+        scope_event_id=scope_event_id,
+    )
+    return ScenarioStateSwitchBindingResultV0(
+        side_state_before=side_before,
+        side_state_after=side_after,
+        scope_state_after=scope_after,
+        transition=transition,
+        bull_layer_state=project_bull_layer_side_state_v0(side_after),
+        bear_layer_state=project_bear_layer_side_state_v0(side_after),
+        active_side=derive_active_side(side_after),
+        state_switch_ref=state_switch_id,
+        state_switch_effect=STATE_SWITCH_EFFECT_BOUND_OFFLINE,
+    )
+
+
+def state_switch_binding_non_authority_boundary_ok_v0(
+    binding: ScenarioStateSwitchBindingResultV0,
+) -> bool:
+    if binding.runtime_authority_effect != RUNTIME_AUTHORITY_EFFECT_NONE:
+        return False
+    if binding.order_effect != ORDER_EFFECT_NONE:
+        return False
+    if binding.transition.live_authorization_granted:
+        return False
+    if binding.state_switch_effect not in {
+        STATE_SWITCH_EFFECT_NONE,
+        STATE_SWITCH_EFFECT_BOUND_OFFLINE,
+    }:
+        return False
+    if (
+        binding.state_switch_effect == STATE_SWITCH_EFFECT_BOUND_OFFLINE
+        and not binding.state_switch_ref
+    ):
+        return False
+    return True
+
+
+def system_economic_evidence_admissible_v0(
+    binding: ScenarioStateSwitchBindingResultV0,
+) -> bool:
+    return False
+
+
+def state_switch_parity_aligned_v0(
+    *,
+    integrated_previous: str,
+    integrated_next: str,
+    integrated_transition_allowed: bool,
+    integrated_transition_reason: str,
+    scenario_binding: ScenarioStateSwitchBindingResultV0,
+) -> bool:
+    return (
+        integrated_previous == scenario_binding.side_state_before.value
+        and integrated_next == scenario_binding.side_state_after.value
+        and integrated_transition_allowed == scenario_binding.transition.allowed
+        and integrated_transition_reason == scenario_binding.transition.reason_code
+    )
+
+
+def mirrored_side_states_parity_ok_v0(
+    long_side: SideState,
+    short_side: SideState,
+) -> bool:
+    """Long-path vs mirrored short-path must remain mutually exclusive at active states."""
+    long_active = long_side == SideState.LONG_ACTIVE
+    short_active = short_side == SideState.SHORT_ACTIVE
+    return not (long_active and short_active)

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -75,6 +75,9 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "tests/trading/master_v2/test_feedback_learning_boundary_backtest_state_file_binding_contract_v0.py",
     "tests/trading/master_v2/test_feedback_learning_boundary_offline_replay_binding_parity_rewire_contract_v0.py",
     "tests/test_backtest_ai_observability_feedback_boundary_wiring_v0.py",
+    "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
+    "scripts/ops/run_bull_bear_state_switch_scenario_replay_binding_parity_rewire_v0.py",
+    "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
     "docs/research/FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_V0.md",
 )
 
@@ -121,7 +124,7 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
             ),
             current_scenario_replay_binding=(
                 "offline_double_play_scenario_replay_v0.run_offline_double_play_scenario_replay_v0"
-                " -> injected ScopeEvent ticks -> transition_state()"
+                " -> evaluate_scenario_state_switch_v0() per tick"
             ),
             current_backtest_binding=(
                 "backtest/mv2_research_wiring_v1.run_mv2_research_backtest_wiring_v1"
@@ -131,16 +134,14 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
                 "canonical_core_runtime_integration_bridge_v0 (BOUND_NOT_ACTIVATED);"
                 " legacy_runtime_entrypoint_guard_v0"
             ),
-            parity_status="PARTIAL",
+            parity_status="PASS",
             evidence_refs=(
                 "tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py",
                 "tests/trading/master_v2/test_integrated_offline_trading_logic_replay_v1.py",
                 "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+                "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
             ),
-            missing_binding_if_any=(
-                "End-to-end state-switch parity Integrated tick vs Scenario tick"
-                " (not only composition matrix alignment)"
-            ),
+            missing_binding_if_any="",
             recommended_next_slice=NEXT_RECOMMENDED_SLICE,
         ),
         ParitySurfaceAssessmentV0(

--- a/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
+++ b/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
@@ -66,13 +66,30 @@ from trading.master_v2.double_play_composition_scenario_matrix_adapter_v0 import
     evaluate_scenario_matrix_composition_v0,
 )
 from trading.master_v2.double_play_entry_exit_policy_v0 import EntryExitPolicyDecisionV0
+from trading.master_v2.bull_bear_state_switch_scenario_binding_adapter_v0 import (
+    BULL_BEAR_STATE_SWITCH_SCENARIO_BINDING_ADAPTER_OWNER,
+    CANONICAL_STATE_SWITCH_OWNER,
+    STATE_SWITCH_EFFECT_BOUND_OFFLINE,
+    STATE_SWITCH_EFFECT_NONE,
+    ScenarioStateSwitchBindingResultV0,
+    ScenarioStateSwitchContextV0,
+    evaluate_scenario_state_switch_v0,
+    state_switch_binding_non_authority_boundary_ok_v0,
+)
 from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
     CANONICAL_ENTRY_EXIT_POLICY_OWNER,
     DOUBLE_PLAY_ENTRY_EXIT_SCENARIO_BINDING_ADAPTER_OWNER,
     ScenarioEntryExitPolicyContextV0,
     evaluate_scenario_entry_exit_policy_v0,
 )
-from trading.master_v2.double_play_state import SideState
+from trading.master_v2.double_play_state import (
+    DynamicScopeRules,
+    RuntimeEnvelope,
+    RuntimeScopeState,
+    ScopeEvent,
+    SideState,
+    StaticHardLimits,
+)
 from trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
     INTEGRATED_OFFLINE_TRADING_LOGIC_REPLAY_OWNER,
     IntegratedOfflineReplayResultV1,
@@ -132,6 +149,9 @@ class ParityDecisionEnvelopeV0:
     reconciliation_unknown_outcome_effect: str = RECONCILIATION_UNKNOWN_OUTCOME_EFFECT_NONE
     killswitch_boundary_ref: str = ""
     killswitch_boundary_effect: str = KILLSWITCH_BOUNDARY_EFFECT_NONE
+    state_switch_ref: str = ""
+    state_switch_effect: str = STATE_SWITCH_EFFECT_NONE
+    transition_reason_code: str = ""
     conflict_status: Optional[str] = None
     selected_side: Optional[str] = None
 
@@ -224,6 +244,17 @@ def extract_integrated_parity_envelope_v0(
         reconciliation_unknown_outcome_effect=evidence.reconciliation_unknown_outcome_effect,
         killswitch_boundary_ref=evidence.killswitch_boundary_ref,
         killswitch_boundary_effect=evidence.killswitch_boundary_effect,
+        state_switch_ref=(
+            intermediate.state_switch.state_switch_id if intermediate is not None else ""
+        ),
+        state_switch_effect=(
+            STATE_SWITCH_EFFECT_BOUND_OFFLINE
+            if intermediate is not None
+            else STATE_SWITCH_EFFECT_NONE
+        ),
+        transition_reason_code=(
+            intermediate.state_switch.transition_reason_code if intermediate is not None else ""
+        ),
         authority_effect=evidence.authority_effect,
         runtime_effect=evidence.runtime_effect,
         conflict_status=conflict_status,
@@ -349,6 +380,113 @@ def extract_scenario_replay_tick_parity_envelope_v0(
         quantity_status="NOT_BOUND",
         authority_effect="NONE",
         runtime_effect="NONE",
+    )
+
+
+def extract_state_switch_parity_envelope_v0(
+    binding: ScenarioStateSwitchBindingResultV0,
+) -> ParityDecisionEnvelopeV0:
+    return ParityDecisionEnvelopeV0(
+        decision_outcome="not_bound_offline_state_switch_only",
+        previous_side_state=binding.side_state_before.value,
+        next_side_state=binding.side_state_after.value,
+        composition_status="not_bound_offline_state_switch_only",
+        composition_result_id="",
+        entry_or_exit_policy_ref="",
+        reason_codes=(binding.transition.reason_code,),
+        decision_precedence_trace=(),
+        execution_eligible=False,
+        adapter_compatible=False,
+        quantity_status="NOT_BOUND",
+        state_switch_ref=binding.state_switch_ref,
+        state_switch_effect=binding.state_switch_effect,
+        transition_reason_code=binding.transition.reason_code,
+        authority_effect="NONE",
+        runtime_effect="NONE",
+    )
+
+
+def extract_scenario_replay_tick_state_switch_envelope_v0(
+    tick: OfflineDoublePlayScenarioReplayTickRecordV0,
+) -> ParityDecisionEnvelopeV0:
+    return ParityDecisionEnvelopeV0(
+        decision_outcome="not_bound_offline_state_switch_only",
+        previous_side_state=tick.prior_side_state.value,
+        next_side_state=tick.side_state.value,
+        composition_status=tick.composition_status,
+        composition_result_id=tick.composition_result_id,
+        entry_or_exit_policy_ref=tick.entry_exit_policy_ref,
+        reason_codes=(tick.transition_reason_code,),
+        decision_precedence_trace=(),
+        execution_eligible=False,
+        adapter_compatible=False,
+        quantity_status="NOT_BOUND",
+        state_switch_ref=tick.state_switch_ref,
+        state_switch_effect=tick.state_switch_effect,
+        transition_reason_code=tick.transition_reason_code,
+        authority_effect="NONE",
+        runtime_effect="NONE",
+    )
+
+
+def assert_state_switch_non_authority_boundary_v0(envelope: ParityDecisionEnvelopeV0) -> None:
+    assert not envelope.execution_eligible
+    assert not envelope.adapter_compatible
+    assert envelope.authority_effect == "NONE"
+    assert envelope.runtime_effect == "NONE"
+    if envelope.state_switch_effect == STATE_SWITCH_EFFECT_BOUND_OFFLINE:
+        assert envelope.state_switch_ref
+
+
+_DEFAULT_SCENARIO_STATE_SWITCH_ENVELOPE = RuntimeEnvelope(
+    static=StaticHardLimits(min_band_width=1.0, max_band_width=100.0),
+    live_authorization=False,
+)
+_DEFAULT_SCENARIO_STATE_SWITCH_RULES = DynamicScopeRules(
+    min_band_width=1.0,
+    max_band_width=50.0,
+    min_switch_cooldown_ticks=0,
+    max_switches_per_window=1_000_000,
+    volatility_estimate=0.02,
+)
+_EMPTY_SCENARIO_SCOPE_STATE = RuntimeScopeState(
+    anchor_price=0.0,
+    current_downscope_boundary=0.0,
+    current_upscope_boundary=0.0,
+    current_hysteresis_band=0.0,
+    last_switch_tick=-1,
+    switches_in_window=0,
+    window_start_tick=0,
+    chop_latched=False,
+    now_tick=0,
+)
+
+
+def evaluate_scenario_state_switch_for_fixture_v0(
+    *,
+    side_state: SideState,
+    scope_event: ScopeEvent,
+    instrument_id: str,
+    trading_epoch: int,
+    context_reference: str,
+    scope_state: RuntimeScopeState | None = None,
+    rules: DynamicScopeRules | None = None,
+    now_tick: int | None = None,
+) -> ScenarioStateSwitchBindingResultV0:
+    tick = now_tick if now_tick is not None else trading_epoch
+    return evaluate_scenario_state_switch_v0(
+        ScenarioStateSwitchContextV0(
+            instrument_id=instrument_id,
+            trading_epoch=trading_epoch,
+            context_reference=context_reference,
+            side_state=side_state,
+            scope_event=scope_event,
+            scope_state=scope_state or _EMPTY_SCENARIO_SCOPE_STATE,
+            rules=rules or _DEFAULT_SCENARIO_STATE_SWITCH_RULES,
+            envelope=_DEFAULT_SCENARIO_STATE_SWITCH_ENVELOPE,
+            now_tick=tick,
+            scope_event_id=f"{context_reference}-scope-{scope_event.value}",
+        )
     )
 
 
@@ -804,6 +942,10 @@ def canonical_owner_refs_v0() -> Mapping[str, str]:
         ),
         "killswitch_boundary_offline_replay_binding_adapter": (
             KILLSWITCH_BOUNDARY_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER
+        ),
+        "state_switch": CANONICAL_STATE_SWITCH_OWNER,
+        "bull_bear_state_switch_scenario_binding_adapter": (
+            BULL_BEAR_STATE_SWITCH_SCENARIO_BINDING_ADAPTER_OWNER
         ),
         "runtime_state_reconciliation": RUNTIME_STATE_RECONCILIATION_OWNER,
         "reconciliation_entry_exit_policy": RECONCILIATION_ENTRY_EXIT_POLICY_OWNER,

--- a/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
+++ b/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
@@ -81,6 +81,10 @@ from trading.master_v2.double_play_composition_scenario_matrix_adapter_v0 import
     compose_double_play_scenario_via_canonical_matrix_v0,
     evaluate_scenario_matrix_composition_v0,
 )
+from trading.master_v2.bull_bear_state_switch_scenario_binding_adapter_v0 import (
+    ScenarioStateSwitchContextV0,
+    evaluate_scenario_state_switch_v0,
+)
 from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
     default_scenario_entry_exit_policy_context_v0,
     evaluate_scenario_entry_exit_policy_v0,
@@ -231,6 +235,8 @@ class OfflineDoublePlayScenarioReplayTickRecordV0:
     dynamic_scope_rules: DynamicScopeRules
     transition_allowed: bool
     transition_reason_code: str
+    state_switch_ref: str
+    state_switch_effect: str
     composition_status: str
     composition_result_id: str
     entry_exit_policy_ref: str
@@ -367,32 +373,6 @@ def _default_capital_state(
         opportunity_score=0.80,
         survival_allows_slot=True,
     )
-
-
-def _bull_layer_state(side: SideState) -> SideState:
-    if side in (
-        SideState.LONG_ACTIVE,
-        SideState.LONG_ARMED,
-        SideState.LONG_BLOCKED,
-        SideState.SWITCH_LONG_TO_SHORT_PENDING,
-    ):
-        return side
-    if side in (SideState.SHORT_ACTIVE, SideState.SHORT_ARMED, SideState.SHORT_BLOCKED):
-        return SideState.LONG_BLOCKED
-    return SideState.NEUTRAL_OBSERVE
-
-
-def _bear_layer_state(side: SideState) -> SideState:
-    if side in (
-        SideState.SHORT_ACTIVE,
-        SideState.SHORT_ARMED,
-        SideState.SHORT_BLOCKED,
-        SideState.SWITCH_SHORT_TO_LONG_PENDING,
-    ):
-        return side
-    if side in (SideState.LONG_ACTIVE, SideState.LONG_ARMED, SideState.LONG_BLOCKED):
-        return SideState.SHORT_BLOCKED
-    return SideState.NEUTRAL_OBSERVE
 
 
 def _requested_side(side: SideState) -> RequestedSide:
@@ -779,17 +759,24 @@ def run_offline_double_play_scenario_replay_v0(
         if not tick.safety_decision_allowed and event != ScopeEvent.KILL_ALL_REQUIRED:
             event = ScopeEvent.NOOP
 
-        side_after, scope_after, transition = transition_state(
-            side_state=side,
-            event=event,
-            scope_state=scope_state,
-            rules=rules,
-            envelope=_RUNTIME_ENVELOPE,
-            now_tick=tick.tick_index,
+        state_switch_binding = evaluate_scenario_state_switch_v0(
+            ScenarioStateSwitchContextV0(
+                instrument_id=inp.selected_future_id,
+                trading_epoch=tick.tick_index,
+                context_reference=f"{inp.correlation_id_prefix}-tick-{tick.tick_index}",
+                side_state=side,
+                scope_event=event,
+                scope_state=scope_state,
+                rules=rules,
+                envelope=_RUNTIME_ENVELOPE,
+                now_tick=tick.tick_index,
+                scope_event_id=f"{inp.correlation_id_prefix}-scope-{tick.tick_index}",
+            )
         )
-        side = side_after
-        scope_state = scope_after
-        active = derive_active_side(side)
+        side = state_switch_binding.side_state_after
+        scope_state = state_switch_binding.scope_state_after
+        transition = state_switch_binding.transition
+        active = state_switch_binding.active_side
         scope_state = update_dynamic_boundaries(
             mark_price=tick.price,
             side=active,
@@ -903,9 +890,9 @@ def run_offline_double_play_scenario_replay_v0(
             if snapshot is not None
             else None
         )
-        bull_state = _bull_layer_state(side)
-        bear_state = _bear_layer_state(side)
-        active_side = derive_active_side(side)
+        bull_state = state_switch_binding.bull_layer_state
+        bear_state = state_switch_binding.bear_layer_state
+        active_side = state_switch_binding.active_side
         release_reason = (
             release.release_reason.value if release.release_reason is not None else "none"
         )
@@ -1021,6 +1008,8 @@ def run_offline_double_play_scenario_replay_v0(
             dynamic_scope_rules=rules,
             transition_allowed=transition.allowed,
             transition_reason_code=transition.reason_code,
+            state_switch_ref=state_switch_binding.state_switch_ref,
+            state_switch_effect=state_switch_binding.state_switch_effect,
             composition_status=composition.status.value,
             composition_result_id=composition_result.composition_id,
             entry_exit_policy_ref=entry_exit_decision.policy_decision_id,

--- a/tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py
@@ -1,0 +1,330 @@
+"""Bull/Bear state switch binding parity: integrated offline replay vs scenario replay (offline only)."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+from trading.master_v2.bull_bear_state_switch_scenario_binding_adapter_v0 import (
+    BULL_BEAR_STATE_SWITCH_SCENARIO_BINDING_ADAPTER_OWNER,
+    CANONICAL_STATE_SWITCH_OWNER,
+    STATE_SWITCH_EFFECT_BOUND_OFFLINE,
+    mirrored_side_states_parity_ok_v0,
+    state_switch_binding_non_authority_boundary_ok_v0,
+    state_switch_parity_aligned_v0,
+)
+from trading.master_v2.deterministic_scope_event_generator_v1 import ScopeDirectionState
+from trading.master_v2.double_play_composition_matrix_v1 import CompositionStatus
+from trading.master_v2.double_play_state import ScopeEvent, SideState
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    assert_scenario_replay_zero_order_boundary_v0,
+    assert_state_switch_non_authority_boundary_v0,
+    canonical_owner_refs_v0,
+    evaluate_scenario_matrix_for_side_state_v0,
+    evaluate_scenario_state_switch_for_fixture_v0,
+    extract_integrated_parity_envelope_v0,
+    extract_scenario_replay_tick_state_switch_envelope_v0,
+    extract_state_switch_parity_envelope_v0,
+    scan_changed_paths_for_forbidden_runtime_v0,
+)
+from trading.master_v2.offline_double_play_scenario_replay_v0 import (
+    OFFLINE_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER,
+    OfflineDoublePlayScenarioReplayInputV0,
+    SYNTHETIC_FUTURES_INSTRUMENT,
+    build_default_bull_bear_bull_scenario_ticks,
+    run_offline_double_play_scenario_replay_v0,
+)
+from trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
+    _canonical_scope_event_to_scope_event,
+)
+from tests.trading.master_v2.test_integrated_offline_trading_logic_replay_v1 import _run
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_INSTRUMENT = SYNTHETIC_FUTURES_INSTRUMENT
+_EPOCH = 48
+_CONTEXT = "bull-bear-state-switch-binding-parity-v0"
+
+_SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
+    "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "scripts/ops/run_bull_bear_state_switch_scenario_replay_binding_parity_rewire_v0.py",
+    "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+)
+
+_FORBIDDEN_IMPORT_SCAN_PATHS = (
+    REPO_ROOT / "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
+    REPO_ROOT
+    / "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    REPO_ROOT
+    / "scripts/ops/run_bull_bear_state_switch_scenario_replay_binding_parity_rewire_v0.py",
+    REPO_ROOT
+    / "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
+)
+
+ALLOWED_SLICE_CHANGED_PATH_PREFIXES = _SLICE_CHANGED_FILES
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def test_owner_constants_and_canonical_reuse_v0() -> None:
+    refs = canonical_owner_refs_v0()
+    assert refs["state_switch"] == CANONICAL_STATE_SWITCH_OWNER
+    assert (
+        refs["bull_bear_state_switch_scenario_binding_adapter"]
+        == BULL_BEAR_STATE_SWITCH_SCENARIO_BINDING_ADAPTER_OWNER
+    )
+    assert refs["scenario_replay"] == OFFLINE_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER
+
+
+def test_forbidden_runtime_paths_guard_v0() -> None:
+    ok, violations = scan_changed_paths_for_forbidden_runtime_v0(
+        ALLOWED_SLICE_CHANGED_PATH_PREFIXES
+    )
+    assert ok is True
+    assert violations == ()
+
+
+def test_slice_sources_exclude_execution_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "execution",
+            "scheduler",
+            "credentials",
+            "live_runtime",
+            "testnet",
+            "shadow",
+            "paper_lane",
+        }
+    )
+    for path in _FORBIDDEN_IMPORT_SCAN_PATHS:
+        assert path.is_file(), f"missing slice source: {path}"
+        hits = _scan_forbidden_imports(path, forbidden)
+        assert hits == [], f"forbidden imports in {path}: {hits}"
+
+
+def test_1_bull_only_confirmed_path_bound_v0() -> None:
+    binding = evaluate_scenario_state_switch_for_fixture_v0(
+        side_state=SideState.NEUTRAL_OBSERVE,
+        scope_event=ScopeEvent.UPSCOPE_CONFIRMED,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    assert binding.side_state_after == SideState.LONG_ARMED
+    env = extract_state_switch_parity_envelope_v0(binding)
+    assert_state_switch_non_authority_boundary_v0(env)
+    assert state_switch_binding_non_authority_boundary_ok_v0(binding)
+
+    integrated = _run(side_state=SideState.LONG_ARMED)
+    integrated_env = extract_integrated_parity_envelope_v0(integrated)
+    assert integrated_env.state_switch_ref
+    assert integrated_env.state_switch_effect == STATE_SWITCH_EFFECT_BOUND_OFFLINE
+
+
+def test_2_bear_only_confirmed_path_bound_v0() -> None:
+    binding = evaluate_scenario_state_switch_for_fixture_v0(
+        side_state=SideState.NEUTRAL_OBSERVE,
+        scope_event=ScopeEvent.DOWNSCOPE_CONFIRMED,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    assert binding.side_state_after == SideState.SHORT_ARMED
+    env = extract_state_switch_parity_envelope_v0(binding)
+    assert_state_switch_non_authority_boundary_v0(env)
+
+    integrated = _run(
+        side_state=SideState.SHORT_ARMED,
+        scope_direction_state=ScopeDirectionState.SHORT,
+        price_path=(3500.0, 3400.0),
+    )
+    integrated_env = extract_integrated_parity_envelope_v0(integrated)
+    assert integrated_env.state_switch_ref
+    assert integrated_env.state_switch_effect == STATE_SWITCH_EFFECT_BOUND_OFFLINE
+
+
+def test_3_both_sides_confirmed_conflict_chop_block_v0() -> None:
+    binding = evaluate_scenario_state_switch_for_fixture_v0(
+        side_state=SideState.LONG_ARMED,
+        scope_event=ScopeEvent.CHOP_DETECTED,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    assert binding.side_state_after == SideState.CHOP_GUARD_BLOCK
+    matrix = evaluate_scenario_matrix_for_side_state_v0(
+        side_state=SideState.CHOP_GUARD_BLOCK,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    assert matrix.composition_status is CompositionStatus.CHOP_GUARD_BLOCK
+    env = extract_state_switch_parity_envelope_v0(binding)
+    assert_state_switch_non_authority_boundary_v0(env)
+
+
+def test_4_neutral_observe_path_bound_v0() -> None:
+    binding = evaluate_scenario_state_switch_for_fixture_v0(
+        side_state=SideState.NEUTRAL_OBSERVE,
+        scope_event=ScopeEvent.NOOP,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    assert binding.side_state_after == SideState.NEUTRAL_OBSERVE
+    assert binding.transition.reason_code == "NOOP"
+    env = extract_state_switch_parity_envelope_v0(binding)
+    assert_state_switch_non_authority_boundary_v0(env)
+
+
+def test_5_blocked_unknown_required_input_path_v0() -> None:
+    binding = evaluate_scenario_state_switch_for_fixture_v0(
+        side_state=SideState.LONG_ACTIVE,
+        scope_event=ScopeEvent.SCOPE_UNKNOWN,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    assert binding.side_state_after == SideState.LONG_ACTIVE
+    assert binding.transition.allowed is False
+    assert binding.transition.reason_code == "SCOPE_UNKNOWN_FAIL_CLOSED"
+    env = extract_state_switch_parity_envelope_v0(binding)
+    assert_state_switch_non_authority_boundary_v0(env)
+
+
+def test_6_mirrored_bull_bear_price_path_parity_v0() -> None:
+    long_binding = evaluate_scenario_state_switch_for_fixture_v0(
+        side_state=SideState.LONG_ACTIVE,
+        scope_event=ScopeEvent.DOWNSCOPE_CONFIRMED,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=f"{_CONTEXT}-long",
+    )
+    short_binding = evaluate_scenario_state_switch_for_fixture_v0(
+        side_state=SideState.SHORT_ACTIVE,
+        scope_event=ScopeEvent.UPSCOPE_CONFIRMED,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=f"{_CONTEXT}-short",
+    )
+    assert long_binding.side_state_after == SideState.SWITCH_LONG_TO_SHORT_PENDING
+    assert short_binding.side_state_after == SideState.SWITCH_SHORT_TO_LONG_PENDING
+    assert mirrored_side_states_parity_ok_v0(
+        long_binding.side_state_after,
+        short_binding.side_state_after,
+    )
+
+
+def test_7_integrated_vs_scenario_state_switch_parity_v0() -> None:
+    integrated = _run(
+        side_state=SideState.LONG_ACTIVE,
+        price_path=(3500.0, 3400.0),
+        scope_direction_state=ScopeDirectionState.SHORT,
+    )
+    assert integrated.intermediate is not None
+    mapped_event = _canonical_scope_event_to_scope_event(
+        integrated.intermediate.scope_event.event_type
+    )
+    scenario_binding = evaluate_scenario_state_switch_for_fixture_v0(
+        side_state=SideState(integrated.intermediate.state_switch.previous_side_state),
+        scope_event=mapped_event,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    assert state_switch_parity_aligned_v0(
+        integrated_previous=integrated.intermediate.state_switch.previous_side_state,
+        integrated_next=integrated.intermediate.state_switch.next_side_state,
+        integrated_transition_allowed=integrated.intermediate.state_switch.transition_allowed,
+        integrated_transition_reason=integrated.intermediate.state_switch.transition_reason_code,
+        scenario_binding=scenario_binding,
+    )
+
+
+def test_scenario_replay_tick_state_switch_binding_no_shortcut_v0() -> None:
+    result = run_offline_double_play_scenario_replay_v0(
+        OfflineDoublePlayScenarioReplayInputV0(
+            selected_future_id=_INSTRUMENT,
+            ticks=build_default_bull_bear_bull_scenario_ticks(),
+            source_revision="bull-bear-state-switch-binding-parity-v0",
+        )
+    )
+    assert result.replay_pass, result.fail_reasons
+    assert_scenario_replay_zero_order_boundary_v0(result)
+
+    bound_ticks = 0
+    for tick in result.tick_records:
+        env = extract_scenario_replay_tick_state_switch_envelope_v0(tick)
+        assert_state_switch_non_authority_boundary_v0(env)
+        if tick.state_switch_effect == STATE_SWITCH_EFFECT_BOUND_OFFLINE:
+            bound_ticks += 1
+            assert tick.state_switch_ref
+    assert bound_ticks == len(result.tick_records)
+
+
+def test_scenario_replay_no_duplicate_state_switch_logic_v0() -> None:
+    adapter_src = (
+        REPO_ROOT / "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py"
+    )
+    replay_src = REPO_ROOT / "src/trading/master_v2/offline_double_play_scenario_replay_v0.py"
+    adapter_text = adapter_src.read_text(encoding="utf-8")
+    replay_text = replay_src.read_text(encoding="utf-8")
+    assert "transition_state" in adapter_text
+    assert "def _bull_layer_state" not in replay_text
+    assert "def _bear_layer_state" not in replay_text
+    assert "evaluate_scenario_state_switch_v0" in replay_text
+
+
+def test_pr4946_parity_suite_still_passes_v0() -> None:
+    from tests.trading.master_v2 import (
+        test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0 as pr4946,
+    )
+
+    pr4946.test_harness_and_replay_owner_constants_v0()
+    pr4946.test_1_long_bull_path_parity_v0()
+    pr4946.test_3_both_confirmed_chop_guard_parity_v0()
+
+
+def test_entry_exit_binding_suite_still_passes_v0() -> None:
+    from tests.trading.master_v2 import (
+        test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0 as pr4948,
+    )
+
+    pr4948.test_owner_constants_and_canonical_reuse_v0()
+    pr4948.test_scenario_replay_tick_entry_exit_binding_no_shortcut_v0()
+
+
+def test_prometheus_client_importable_v0() -> None:
+    assert importlib.util.find_spec("prometheus_client") is not None
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import prometheus_client; print('PROMETHEUS_CLIENT_IMPORTABLE=true')",
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "PROMETHEUS_CLIENT_IMPORTABLE=true" in proc.stdout

--- a/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
+++ b/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
@@ -58,11 +58,18 @@ def test_gap_assessment_owner_and_surface_count_v0() -> None:
 
 def test_gap_assessment_status_distribution_v0() -> None:
     counts = parity_status_counts_v0()
-    assert counts["PASS"] == 10
+    assert counts["PASS"] == 11
     assert counts["PARTIAL"] >= 3
     assert counts["GAP"] == 0
     assert counts["NOT_APPLICABLE"] == 0
     assert sum(counts.values()) == 16
+
+
+def test_bull_bear_state_switch_surface_pass_v0() -> None:
+    state_switch = next(item for item in parity_surface_assessments_v0() if item.surface_id == "A")
+    assert state_switch.parity_status == "PASS"
+    assert state_switch.missing_binding_if_any == ""
+    assert "evaluate_scenario_state_switch_v0" in state_switch.current_scenario_replay_binding
 
 
 def test_composition_surface_pass_v0() -> None:

--- a/tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py
@@ -351,7 +351,7 @@ def test_pr4947_gap_assessment_suite_still_passes_v0() -> None:
         test_full_canonical_system_backtest_parity_gap_assessment_contract_v0 as pr4947,
     )
 
-    pr4947.test_capital_risk_sizing_surface_partial_v0()
+    pr4947.test_capital_risk_sizing_surface_pass_v0()
     pr4947.test_entry_exit_surface_pass_after_pr4948_v0()
     pr4947.test_pr4946_parity_suite_still_passes_v0()
 


### PR DESCRIPTION
## Summary

- Bind scenario replay Bull/Bear state transitions to the canonical `double_play_state.transition_state` owner via a narrow adapter (`evaluate_scenario_state_switch_v0`), removing local `_bull_layer_state` / `_bear_layer_state` shortcuts from the orchestrator.
- Add contract tests for bull-only, bear-only, chop conflict, neutral/observe, unknown-input fail-closed, mirrored price-path, and integrated-vs-scenario state-switch parity.
- Update gap assessment surface A (Bull/Bear State Switch) to PASS; fix stale `test_capital_risk_sizing_surface_partial_v0` reference to `_pass_v0` in entry-exit parity ratification test.

## Scope

`BULL_BEAR_STATE_SWITCH_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0` — wiring-only, offline-only, no trading semantic change.

## Reuse-first Owner

- Canonical: `trading.master_v2.double_play_state` (`transition_state`, `derive_active_side`)
- Adapter: `trading.master_v2.bull_bear_state_switch_scenario_binding_adapter_v0`

## Changed files

- `src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py`
- `src/trading/master_v2/offline_double_play_scenario_replay_v0.py`
- `src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py`
- `src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py`
- `scripts/ops/run_bull_bear_state_switch_scenario_replay_binding_parity_rewire_v0.py`
- `tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py`
- `tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py`
- `tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py`

## Tests

- `test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py` (15 tests)
- `test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py` (14 tests, previously failing ratification fixed)
- `test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py`
- `test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py`
- `test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py`
- **113 targeted tests passed** (2.47s wallclock)

## Evidence dir

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/bull_bear_state_switch_scenario_replay_binding_parity_rewire_v0_20260707T170440Z`

## Manifest verification

- `SOURCE_MANIFEST_VERIFY_RC=0`
- `CLOSEOUT_MANIFEST_VERIFY_RC=0`

## Authority flags

```
LIVE_AUTHORIZED=false
ORDERS_ALLOWED=false
SCHEDULER_RUNTIME_ALLOWED=false
SHADOW_AUTHORIZED=false
PAPER_AUTHORIZED=false
TESTNET_AUTHORIZED=false
CANARY_AUTHORIZED=false
SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false
NO_RUNTIME_AUTHORITY_FROM_THIS_PR=true
```


Made with [Cursor](https://cursor.com)