### PR TITLE
SCOPE_EVENT_GENERATOR_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0

### DIFF
--- a/scripts/ops/run_scope_event_generator_scenario_replay_binding_parity_rewire_v0.py
+++ b/scripts/ops/run_scope_event_generator_scenario_replay_binding_parity_rewire_v0.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for scope event generator scenario replay binding parity rewire v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+SOURCE_EVIDENCE_DIR = (
+    ARCHIVE_ROOT
+    / "research/full_canonical_backtest_boundary_chain_reassessment_after_pr4967_v0_20260707T171627Z"
+)
+NEXT_RECOMMENDED_SLICE = "REVERSAL_PREPARATION_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+VERDICT = "SCOPE_EVENT_GENERATOR_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0_PASS"
+PROCESS_CLASSIFICATION = "NARROW_REUSE_FIRST_REWIRE_WITH_TEST_HYGIENE"
+SCOPE_CLASSIFICATION = "SCOPE_EVENT_GENERATOR_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+TARGETED_TESTS = (
+    "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+    "tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py",
+    "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "scripts/ops/run_scope_event_generator_scenario_replay_binding_parity_rewire_v0.py",
+    "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.iterdir()):
+        if path.name == "MANIFEST.sha256":
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  {path.name}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["sha256sum", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def collect_evidence(out_dir: Path | None = None) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT
+        / f"research/scope_event_generator_scenario_replay_binding_parity_rewire_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    status = _run(["git", "status", "--short"]).stdout.strip()
+
+    source_manifest_proc = _run(["sha256sum", "-c", "MANIFEST.sha256"], cwd=SOURCE_EVIDENCE_DIR)
+    (evidence_dir / "source_manifest_reverify.log").write_text(
+        source_manifest_proc.stdout + source_manifest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    commands: list[str] = []
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    pytest_cmd = [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS]
+    commands.append(" ".join(pytest_cmd))
+    pytest_proc = subprocess.run(
+        pytest_cmd,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (evidence_dir / "tests.log").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    ruff_targets = [
+        str(REPO_ROOT / p)
+        for p in SLICE_CHANGED_FILES
+        if p.endswith(".py") and (REPO_ROOT / p).is_file()
+    ]
+    ruff_format_cmd = ["ruff", "format", "--check", *ruff_targets]
+    ruff_check_cmd = ["ruff", "check", *ruff_targets]
+    commands.extend([" ".join(ruff_format_cmd), " ".join(ruff_check_cmd)])
+    ruff_format = _run(ruff_format_cmd)
+    ruff_check = _run(ruff_check_cmd)
+    (evidence_dir / "ruff.log").write_text(
+        "RUFF_FORMAT\n"
+        + ruff_format.stdout
+        + ruff_format.stderr
+        + "\nRUFF_CHECK\n"
+        + ruff_check.stdout
+        + ruff_check.stderr,
+        encoding="utf-8",
+    )
+    (evidence_dir / "commands.log").write_text("\n".join(commands) + "\n", encoding="utf-8")
+
+    (evidence_dir / "git_state.txt").write_text(
+        "\n".join(
+            [
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"HEAD_EQUALS_ORIGIN_MAIN_AT_START={head == origin_main}",
+                f"WORKTREE_STATUS={status or 'clean'}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "changed_files.txt").write_text(
+        "\n".join(SLICE_CHANGED_FILES) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "REUSE_DISCOVERY.md").write_text(
+        "\n".join(
+            [
+                "# Reuse Discovery",
+                "",
+                "| Role | Owner |",
+                "|---|---|",
+                "| Canonical scope event generator | `trading.master_v2.deterministic_scope_event_generator_v1` |",
+                "| Scenario binding adapter | `trading.master_v2.scope_event_generator_scenario_binding_adapter_v0` |",
+                "| Entry-exit policy | `trading.master_v2.double_play_entry_exit_policy_v0` |",
+                "| Scenario entry-exit adapter | `trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0` |",
+                "| Scenario replay orchestrator | `trading.master_v2.offline_double_play_scenario_replay_v0` |",
+                "",
+                "Pattern reused from PR4967 bull/bear state switch adapter slice.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "IMPLEMENTATION_NOTES.md").write_text(
+        "\n".join(
+            [
+                "# Implementation Notes",
+                "",
+                "Surface B only: scenario replay calls `evaluate_scenario_scope_event_v0()` per tick.",
+                "Adverse-exit signal derived exclusively from `generate_deterministic_scope_event` evidence.",
+                "Entry-exit policy receives `scope_adverse_exit_signal` via scenario policy context.",
+                "State-switch tick.scope_event path unchanged (Surfaces C/D out of scope).",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "BOUNDARY_MATRIX_DELTA.md").write_text(
+        "\n".join(
+            [
+                "# Boundary Matrix Delta",
+                "",
+                "Surface B: PARTIAL -> PASS",
+                "Surfaces C/D/E/P: unchanged PARTIAL",
+                "PASS count: 11 -> 12",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "AUTHORITY_FLAGS.md").write_text(
+        "\n".join(
+            [
+                "# Authority Flags",
+                "",
+                "NO_RUNTIME_AUTHORITY=true",
+                "NO_ORDER_AUTHORITY=true",
+                "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false",
+                "FULL_CANONICAL_CHAIN_WIRED=false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc = _write_manifest(evidence_dir)
+    tests_pass = pytest_proc.returncode == 0
+    ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0
+    source_manifest_rc = source_manifest_proc.returncode
+    verdict = (
+        VERDICT
+        if tests_pass and ruff_pass and manifest_rc == 0 and source_manifest_rc == 0
+        else "SCOPE_EVENT_GENERATOR_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0_BLOCKED"
+    )
+
+    report = f"""# Scope Event Generator Scenario Replay Binding Parity Rewire v0
+
+VERDICT={verdict}
+PROCESS_CLASSIFICATION={PROCESS_CLASSIFICATION}
+SCOPE_CLASSIFICATION={SCOPE_CLASSIFICATION}
+GO_TOKEN_CONSUMPTION=CONSUMED_ONCE
+BASE_HEAD=7a0e56aee45a19224ba4c46116e5e9628d43b5dc
+HEAD={head}
+ORIGIN_MAIN={origin_main}
+BRANCH=feat/scope-event-generator-scenario-replay-binding-parity-v0
+CHANGED_FILES={",".join(SLICE_CHANGED_FILES)}
+SOURCE_REASSESSMENT_EVIDENCE_REFERENCED=true
+SOURCE_EVIDENCE_DIR={SOURCE_EVIDENCE_DIR}
+SOURCE_MANIFEST_VERIFY_RC={source_manifest_rc}
+SURFACE_B_STATUS=PASS
+SURFACE_C_STATUS=UNCHANGED_PARTIAL
+SURFACE_D_STATUS=UNCHANGED_PARTIAL
+SURFACE_E_STATUS=UNCHANGED_PARTIAL
+FULL_CANONICAL_CHAIN_WIRED=false
+BACKTEST_RUNTIME_DECISION_PARITY_PASS=false
+SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false
+NO_RUNTIME_AUTHORITY=true
+NO_ORDER_AUTHORITY=true
+TARGETED_TESTS_RC={pytest_proc.returncode}
+RUFF_FORMAT_RC={ruff_format.returncode}
+RUFF_CHECK_RC={ruff_check.returncode}
+MANIFEST_VERIFY_RC={manifest_rc}
+DURABLE_EVIDENCE_DIR={evidence_dir}
+NEXT_STEP={NEXT_RECOMMENDED_SLICE}
+"""
+    (evidence_dir / "FINAL_REPORT.md").write_text(report, encoding="utf-8")
+    (evidence_dir / "PRE_FLIGHT.md").write_text(
+        f"BASE_HEAD=7a0e56aee45a19224ba4c46116e5e9628d43b5dc\nHEAD={head}\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "TEST_RESULTS.md").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+    _write_manifest(evidence_dir)
+
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_rc": manifest_rc,
+        "source_manifest_rc": source_manifest_rc,
+        "tests_pass": tests_pass,
+        "ruff_pass": ruff_pass,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-dir", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(args.out_dir)
+    print(json.dumps(result, indent=2))
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -25,7 +25,7 @@ MatrixStatus = Literal[
     "UNKNOWN",
 ]
 
-NEXT_RECOMMENDED_SLICE = "FULL_CANONICAL_BACKTEST_BOUNDARY_CHAIN_REASSESSMENT_V0"
+NEXT_RECOMMENDED_SLICE = "REVERSAL_PREPARATION_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
 
 ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
@@ -76,8 +76,11 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "tests/trading/master_v2/test_feedback_learning_boundary_offline_replay_binding_parity_rewire_contract_v0.py",
     "tests/test_backtest_ai_observability_feedback_boundary_wiring_v0.py",
     "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
+    "src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py",
     "scripts/ops/run_bull_bear_state_switch_scenario_replay_binding_parity_rewire_v0.py",
+    "scripts/ops/run_scope_event_generator_scenario_replay_binding_parity_rewire_v0.py",
     "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
     "docs/research/FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_V0.md",
 )
 
@@ -156,8 +159,9 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
                 " + scope_adverse_exit_signal -> evaluate_double_play_entry_exit_policy_v0()"
             ),
             current_scenario_replay_binding=(
-                "offline_double_play_scenario_replay_v0: ScopeEvent on ticks only;"
-                " no full generator + entry-exit chain per tick"
+                "offline_double_play_scenario_replay_v0 -> evaluate_scenario_scope_event_v0()"
+                " -> generate_deterministic_scope_event()"
+                " + scope_adverse_exit_signal -> evaluate_scenario_entry_exit_policy_v0()"
             ),
             current_backtest_binding=(
                 "mv2_research_wiring_v1 adverse_exit_distance=60.0 -> integrated replay"
@@ -165,15 +169,13 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
             current_runtime_semantics_reference=(
                 "canonical_core_runtime_integration_bridge_v0 passes scope params to integrated replay"
             ),
-            parity_status="PARTIAL",
+            parity_status="PASS",
             evidence_refs=(
                 "tests/trading/master_v2/test_deterministic_scope_event_generator_v1.py",
                 "tests/trading/master_v2/test_double_play_entry_exit_policy_v0.py",
+                "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
             ),
-            missing_binding_if_any=(
-                "Scenario replay binding to deterministic_scope_event_generator_v1"
-                " + entry-exit adverse-exit path"
-            ),
+            missing_binding_if_any="",
             recommended_next_slice=NEXT_RECOMMENDED_SLICE,
         ),
         ParitySurfaceAssessmentV0(

--- a/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
+++ b/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
@@ -76,6 +76,15 @@ from trading.master_v2.bull_bear_state_switch_scenario_binding_adapter_v0 import
     evaluate_scenario_state_switch_v0,
     state_switch_binding_non_authority_boundary_ok_v0,
 )
+from trading.master_v2.scope_event_generator_scenario_binding_adapter_v0 import (
+    CANONICAL_SCOPE_EVENT_GENERATOR_OWNER,
+    SCOPE_EVENT_GENERATOR_SCENARIO_BINDING_ADAPTER_OWNER,
+    SCOPE_EVENT_EFFECT_BOUND_OFFLINE,
+    ScenarioScopeEventBindingResultV0,
+    ScenarioScopeEventContextV0,
+    evaluate_scenario_scope_event_v0,
+    scope_event_binding_non_authority_boundary_ok_v0,
+)
 from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
     CANONICAL_ENTRY_EXIT_POLICY_OWNER,
     DOUBLE_PLAY_ENTRY_EXIT_SCENARIO_BINDING_ADAPTER_OWNER,
@@ -946,6 +955,10 @@ def canonical_owner_refs_v0() -> Mapping[str, str]:
         "state_switch": CANONICAL_STATE_SWITCH_OWNER,
         "bull_bear_state_switch_scenario_binding_adapter": (
             BULL_BEAR_STATE_SWITCH_SCENARIO_BINDING_ADAPTER_OWNER
+        ),
+        "scope_event_generator": CANONICAL_SCOPE_EVENT_GENERATOR_OWNER,
+        "scope_event_generator_scenario_binding_adapter": (
+            SCOPE_EVENT_GENERATOR_SCENARIO_BINDING_ADAPTER_OWNER
         ),
         "runtime_state_reconciliation": RUNTIME_STATE_RECONCILIATION_OWNER,
         "reconciliation_entry_exit_policy": RECONCILIATION_ENTRY_EXIT_POLICY_OWNER,

--- a/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
+++ b/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
@@ -85,6 +85,11 @@ from trading.master_v2.bull_bear_state_switch_scenario_binding_adapter_v0 import
     ScenarioStateSwitchContextV0,
     evaluate_scenario_state_switch_v0,
 )
+from trading.master_v2.deterministic_scope_event_generator_v1 import ScopeConfirmationStateV1
+from trading.master_v2.scope_event_generator_scenario_binding_adapter_v0 import (
+    ScenarioScopeEventContextV0,
+    evaluate_scenario_scope_event_v0,
+)
 from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
     default_scenario_entry_exit_policy_context_v0,
     evaluate_scenario_entry_exit_policy_v0,
@@ -739,6 +744,11 @@ def run_offline_double_play_scenario_replay_v0(
     fail_reasons: list[str] = []
     prior_volatility_estimate = rules.volatility_estimate
     final_dashboard_display_snapshot: DoublePlayDashboardDisplaySnapshot | None = None
+    scope_confirmation_state = ScopeConfirmationStateV1(
+        candidate_kind=None,
+        candidate_count=0,
+        last_evaluated_trading_epoch=-1,
+    )
 
     sorted_ticks = tuple(sorted(inp.ticks, key=lambda t: t.tick_index))
 
@@ -754,6 +764,21 @@ def run_offline_double_play_scenario_replay_v0(
             rules=rules,
             env=_RUNTIME_ENVELOPE,
         )
+
+        scope_event_binding = evaluate_scenario_scope_event_v0(
+            ScenarioScopeEventContextV0(
+                instrument_id=inp.selected_future_id,
+                trading_epoch=tick.tick_index,
+                context_reference=f"{inp.correlation_id_prefix}-tick-{tick.tick_index}",
+                current_price=tick.price,
+                scope_state=scope_state,
+                rules=rules,
+                active_side=active,
+                confirmation_state=scope_confirmation_state,
+                safety_decision_allowed=tick.safety_decision_allowed,
+            )
+        )
+        scope_confirmation_state = scope_event_binding.next_confirmation_state
 
         event = tick.scope_event
         if not tick.safety_decision_allowed and event != ScopeEvent.KILL_ALL_REQUIRED:
@@ -830,8 +855,11 @@ def run_offline_double_play_scenario_replay_v0(
             suitability=suitability,
         )
         composition_result = evaluate_scenario_matrix_composition_v0(matrix_input)
-        policy_ctx = default_scenario_entry_exit_policy_context_v0(
-            safety_decision_allowed=safety_allowed,
+        policy_ctx = replace(
+            default_scenario_entry_exit_policy_context_v0(
+                safety_decision_allowed=safety_allowed,
+            ),
+            scope_adverse_exit_signal=scope_event_binding.scope_adverse_exit_signal,
         )
         entry_exit_decision = evaluate_scenario_entry_exit_policy_v0(
             instrument_id=inp.selected_future_id,

--- a/src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py
+++ b/src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py
@@ -1,0 +1,323 @@
+# src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py
+"""
+Scenario replay adapter: binds offline Double Play scenario ticks to the canonical
+``deterministic_scope_event_generator_v1.generate_deterministic_scope_event`` owner
+and derives ``scope_adverse_exit_signal`` for the entry-exit policy chain.
+
+Wiring-only parity slice (Surface B) — no runtime authority, no trading semantic extension.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Tuple
+
+from trading.master_v2.canonical_market_context_v1 import (
+    BarFinalityStatus,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+)
+from trading.master_v2.canonical_scope_initialization_v1 import (
+    CanonicalScopeLifecycleState,
+    CanonicalScopeSnapshotV1,
+    SCOPE_INITIALIZATION_POLICY_VERSION,
+    with_computed_semantic_digest,
+)
+from trading.master_v2.deterministic_scope_event_generator_v1 import (
+    CanonicalScopeEventType,
+    DETERMINISTIC_SCOPE_EVENT_GENERATOR_LAYER_VERSION,
+    SCOPE_EVENT_GENERATOR_POLICY_VERSION,
+    ScopeCandidateKind,
+    ScopeConfirmationStateV1,
+    ScopeCooldownStateV1,
+    ScopeDirectionState,
+    ScopeEventEvidenceV1,
+    ScopeEventGeneratorInputV1,
+    ScopeEventGeneratorPolicyV1,
+    generate_deterministic_scope_event,
+    with_computed_scope_event_digest,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import PolicySignalV0
+from trading.master_v2.double_play_state import ActiveSide, DynamicScopeRules, RuntimeScopeState
+
+SCOPE_EVENT_GENERATOR_SCENARIO_BINDING_ADAPTER_LAYER_VERSION = "v0"
+SCOPE_EVENT_GENERATOR_SCENARIO_BINDING_ADAPTER_OWNER = (
+    "trading.master_v2.scope_event_generator_scenario_binding_adapter_v0"
+)
+CANONICAL_SCOPE_EVENT_GENERATOR_OWNER = "trading.master_v2.deterministic_scope_event_generator_v1"
+
+SCOPE_EVENT_EFFECT_BOUND_OFFLINE = "BOUND_OFFLINE"
+SCOPE_EVENT_EFFECT_NONE = "NONE"
+
+RUNTIME_AUTHORITY_EFFECT_NONE = "NONE"
+ORDER_EFFECT_NONE = "NONE"
+
+_DEFAULT_GENERATOR_POLICY = ScopeEventGeneratorPolicyV1(
+    hard_max_scope_distance=1000.0,
+    hard_max_adverse_distance=500.0,
+    hard_max_reversal_distance=800.0,
+    policy_version=SCOPE_EVENT_GENERATOR_POLICY_VERSION,
+)
+_DEFAULT_COOLDOWN = ScopeCooldownStateV1(
+    active=False,
+    remaining_epochs=0,
+    policy_version=SCOPE_EVENT_GENERATOR_POLICY_VERSION,
+)
+_CONTEXT_DIGEST_PLACEHOLDER = "c" * 64
+
+
+@dataclass(frozen=True)
+class ScenarioScopeEventContextV0:
+    """Explicit offline scenario scope-event context — never inferred from tick shortcuts."""
+
+    instrument_id: str
+    trading_epoch: int
+    context_reference: str
+    current_price: float
+    scope_state: RuntimeScopeState
+    rules: DynamicScopeRules
+    active_side: ActiveSide
+    confirmation_state: ScopeConfirmationStateV1
+    safety_decision_allowed: bool = True
+    data_integrity_status: DataIntegrityStatus | None = None
+    clock_trust_status: ClockTrustStatus | None = None
+    bar_finality_status: BarFinalityStatus | None = None
+    scope_lifecycle_state: CanonicalScopeLifecycleState | None = None
+    up_distance: float | None = None
+    adverse_exit_distance: float | None = None
+    reversal_distance: float | None = None
+    confirmation_epochs: int = 2
+
+
+@dataclass(frozen=True)
+class ScenarioScopeEventBindingResultV0:
+    scope_event_evidence: ScopeEventEvidenceV1
+    scope_adverse_exit_signal: PolicySignalV0
+    next_confirmation_state: ScopeConfirmationStateV1
+    scope_event_ref: str
+    scope_event_effect: str
+    runtime_authority_effect: str = RUNTIME_AUTHORITY_EFFECT_NONE
+    order_effect: str = ORDER_EFFECT_NONE
+
+
+def active_side_to_scope_direction_v0(active: ActiveSide) -> ScopeDirectionState:
+    if active is ActiveSide.SHORT:
+        return ScopeDirectionState.SHORT
+    return ScopeDirectionState.LONG
+
+
+def _resolve_trust_gates_v0(
+    ctx: ScenarioScopeEventContextV0,
+) -> tuple[DataIntegrityStatus, ClockTrustStatus, BarFinalityStatus, CanonicalScopeLifecycleState]:
+    if not ctx.safety_decision_allowed:
+        return (
+            DataIntegrityStatus.UNTRUSTED,
+            ClockTrustStatus.UNTRUSTED,
+            BarFinalityStatus.UNFINALIZED,
+            CanonicalScopeLifecycleState.SCOPE_INVALID,
+        )
+    return (
+        ctx.data_integrity_status or DataIntegrityStatus.TRUSTED,
+        ctx.clock_trust_status or ClockTrustStatus.TRUSTED,
+        ctx.bar_finality_status or BarFinalityStatus.FINALIZED,
+        ctx.scope_lifecycle_state or CanonicalScopeLifecycleState.SCOPE_VALID,
+    )
+
+
+def _distance_triplet_from_scope_v0(
+    *,
+    scope_state: RuntimeScopeState,
+    rules: DynamicScopeRules,
+    up_distance: float | None,
+    adverse_exit_distance: float | None,
+    reversal_distance: float | None,
+) -> tuple[float, float, float]:
+    if (
+        up_distance is not None
+        and adverse_exit_distance is not None
+        and reversal_distance is not None
+    ):
+        return float(up_distance), float(adverse_exit_distance), float(reversal_distance)
+    band = max(
+        float(scope_state.current_hysteresis_band),
+        float(rules.min_band_width),
+        1.0,
+    )
+    up = band
+    adverse = band * 0.8
+    reversal = band * 2.0
+    return up, adverse, reversal
+
+
+def build_scenario_canonical_scope_snapshot_v0(
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+    scope_state: RuntimeScopeState,
+    rules: DynamicScopeRules,
+    mark_price: float,
+    lifecycle_state: CanonicalScopeLifecycleState,
+) -> CanonicalScopeSnapshotV1:
+    anchor = float(scope_state.anchor_price) if scope_state.anchor_price > 0 else float(mark_price)
+    band = max(float(scope_state.current_hysteresis_band), float(rules.min_band_width), 1.0)
+    half = band / 2.0
+    raw = CanonicalScopeSnapshotV1(
+        scope_id=f"scope-{instrument_id}-epoch{trading_epoch}-scenario",
+        instrument_id=instrument_id,
+        initialized_at_trading_epoch=max(0, trading_epoch - 1),
+        source_market_context_id=f"ctx-{instrument_id}-epoch{trading_epoch}",
+        source_input_digest=_CONTEXT_DIGEST_PLACEHOLDER,
+        lifecycle_state=lifecycle_state,
+        reference_price=anchor,
+        volatility_estimate=float(rules.volatility_estimate),
+        initial_volatility_distance=band,
+        scope_band=band,
+        neutral_upper_boundary=anchor + half,
+        neutral_lower_boundary=max(anchor - half, 0.01),
+        trailing_anchor=anchor,
+        min_scope_band=float(rules.min_band_width),
+        max_scope_band=float(rules.max_band_width),
+        policy_version=SCOPE_INITIALIZATION_POLICY_VERSION,
+        semantic_digest="",
+        reason_codes=(),
+    )
+    return with_computed_semantic_digest(raw)
+
+
+def build_scenario_scope_generator_input_v0(
+    ctx: ScenarioScopeEventContextV0,
+    *,
+    policy: ScopeEventGeneratorPolicyV1 | None = None,
+) -> ScopeEventGeneratorInputV1:
+    data_integrity, clock_trust, bar_finality, lifecycle = _resolve_trust_gates_v0(ctx)
+    up_distance, adverse_exit_distance, reversal_distance = _distance_triplet_from_scope_v0(
+        scope_state=ctx.scope_state,
+        rules=ctx.rules,
+        up_distance=ctx.up_distance,
+        adverse_exit_distance=ctx.adverse_exit_distance,
+        reversal_distance=ctx.reversal_distance,
+    )
+    scope_snapshot = build_scenario_canonical_scope_snapshot_v0(
+        instrument_id=ctx.instrument_id,
+        trading_epoch=ctx.trading_epoch,
+        scope_state=ctx.scope_state,
+        rules=ctx.rules,
+        mark_price=ctx.current_price,
+        lifecycle_state=lifecycle,
+    )
+    anchor = float(scope_snapshot.trailing_anchor)
+    return ScopeEventGeneratorInputV1(
+        instrument_id=ctx.instrument_id,
+        trading_epoch=ctx.trading_epoch,
+        market_context_id=f"ctx-{ctx.instrument_id}-epoch{ctx.trading_epoch}",
+        market_context_digest=_CONTEXT_DIGEST_PLACEHOLDER,
+        current_scope=scope_snapshot,
+        current_direction_state=active_side_to_scope_direction_v0(ctx.active_side),
+        reference_price=anchor,
+        current_price=float(ctx.current_price),
+        trailing_anchor=anchor,
+        up_distance=up_distance,
+        adverse_exit_distance=adverse_exit_distance,
+        reversal_distance=reversal_distance,
+        confirmation_epochs=int(ctx.confirmation_epochs),
+        confirmation_state=ctx.confirmation_state,
+        cooldown_state=_DEFAULT_COOLDOWN,
+        cooldown_remaining_epochs=0,
+        data_integrity_status=data_integrity,
+        clock_trust_status=clock_trust,
+        bar_finality_status=bar_finality,
+        policy_version=(policy or _DEFAULT_GENERATOR_POLICY).policy_version,
+    )
+
+
+def derive_scope_adverse_exit_signal_v0(
+    evidence: ScopeEventEvidenceV1,
+) -> PolicySignalV0:
+    """Adverse-exit signal from canonical generator evidence only — no legacy shortcuts."""
+    if evidence.blocked_reasons:
+        return PolicySignalV0(triggered=False, reason_code="scope_event_blocked")
+    if evidence.event_type is CanonicalScopeEventType.ADVERSE_EXIT_CANDIDATE:
+        return PolicySignalV0(triggered=True, reason_code="adverse_scope_exit_candidate")
+    if ScopeCandidateKind.ADVERSE_EXIT.value in evidence.matched_conditions:
+        return PolicySignalV0(triggered=True, reason_code="adverse_scope_exit_matched")
+    return PolicySignalV0(triggered=False, reason_code="no_adverse_scope_exit")
+
+
+def _derive_scope_event_ref(
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+    scope_event_id: str,
+) -> str:
+    material = f"{instrument_id}|{trading_epoch}|{scope_event_id}"
+    return f"scope-event-binding-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:24]}"
+
+
+def evaluate_scenario_scope_event_v0(
+    ctx: ScenarioScopeEventContextV0,
+    *,
+    policy: ScopeEventGeneratorPolicyV1 | None = None,
+) -> ScenarioScopeEventBindingResultV0:
+    """Evaluate one scenario tick through canonical ``generate_deterministic_scope_event`` only."""
+    generator_policy = policy or _DEFAULT_GENERATOR_POLICY
+    generator_input = build_scenario_scope_generator_input_v0(ctx, policy=generator_policy)
+    evidence = with_computed_scope_event_digest(
+        generate_deterministic_scope_event(generator_input, generator_policy)
+    )
+    adverse_signal = derive_scope_adverse_exit_signal_v0(evidence)
+    scope_event_ref = _derive_scope_event_ref(
+        instrument_id=ctx.instrument_id,
+        trading_epoch=ctx.trading_epoch,
+        scope_event_id=evidence.scope_event_id,
+    )
+    return ScenarioScopeEventBindingResultV0(
+        scope_event_evidence=evidence,
+        scope_adverse_exit_signal=adverse_signal,
+        next_confirmation_state=evidence.next_confirmation_state,
+        scope_event_ref=scope_event_ref,
+        scope_event_effect=SCOPE_EVENT_EFFECT_BOUND_OFFLINE,
+    )
+
+
+def scope_event_binding_non_authority_boundary_ok_v0(
+    binding: ScenarioScopeEventBindingResultV0,
+) -> bool:
+    evidence = binding.scope_event_evidence
+    if binding.runtime_authority_effect != RUNTIME_AUTHORITY_EFFECT_NONE:
+        return False
+    if binding.order_effect != ORDER_EFFECT_NONE:
+        return False
+    if evidence.authority_effect != RUNTIME_AUTHORITY_EFFECT_NONE:
+        return False
+    if evidence.runtime_effect != RUNTIME_AUTHORITY_EFFECT_NONE:
+        return False
+    if evidence.order_effect != ORDER_EFFECT_NONE:
+        return False
+    if binding.scope_event_effect not in {
+        SCOPE_EVENT_EFFECT_NONE,
+        SCOPE_EVENT_EFFECT_BOUND_OFFLINE,
+    }:
+        return False
+    if (
+        binding.scope_event_effect == SCOPE_EVENT_EFFECT_BOUND_OFFLINE
+        and not binding.scope_event_ref
+    ):
+        return False
+    return True
+
+
+def system_economic_evidence_admissible_v0(
+    binding: ScenarioScopeEventBindingResultV0,
+) -> bool:
+    return False
+
+
+def scope_event_parity_adverse_signal_aligned_v0(
+    *,
+    integrated_triggered: bool,
+    integrated_reason: str,
+    scenario_binding: ScenarioScopeEventBindingResultV0,
+) -> bool:
+    scenario = scenario_binding.scope_adverse_exit_signal
+    return integrated_triggered == scenario.triggered and integrated_reason == scenario.reason_code

--- a/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
+++ b/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
@@ -58,7 +58,7 @@ def test_gap_assessment_owner_and_surface_count_v0() -> None:
 
 def test_gap_assessment_status_distribution_v0() -> None:
     counts = parity_status_counts_v0()
-    assert counts["PASS"] == 11
+    assert counts["PASS"] == 12
     assert counts["PARTIAL"] >= 3
     assert counts["GAP"] == 0
     assert counts["NOT_APPLICABLE"] == 0
@@ -70,6 +70,14 @@ def test_bull_bear_state_switch_surface_pass_v0() -> None:
     assert state_switch.parity_status == "PASS"
     assert state_switch.missing_binding_if_any == ""
     assert "evaluate_scenario_state_switch_v0" in state_switch.current_scenario_replay_binding
+
+
+def test_scope_adverse_exit_surface_pass_v0() -> None:
+    scope_adverse = next(item for item in parity_surface_assessments_v0() if item.surface_id == "B")
+    assert scope_adverse.parity_status == "PASS"
+    assert scope_adverse.missing_binding_if_any == ""
+    assert "evaluate_scenario_scope_event_v0" in scope_adverse.current_scenario_replay_binding
+    assert "generate_deterministic_scope_event" in scope_adverse.current_scenario_replay_binding
 
 
 def test_composition_surface_pass_v0() -> None:

--- a/tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py
@@ -1,0 +1,335 @@
+"""Scope event generator binding parity: scenario replay adverse-exit path (offline only)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from trading.master_v2.canonical_market_context_v1 import DataIntegrityStatus
+from trading.master_v2.deterministic_scope_event_generator_v1 import (
+    CanonicalScopeEventType,
+    ScopeCandidateKind,
+    ScopeConfirmationStateV1,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import (
+    DecisionOutcome,
+    ExitClass,
+    PolicySignalV0,
+)
+from trading.master_v2.double_play_state import (
+    ActiveSide,
+    DynamicScopeRules,
+    RuntimeScopeState,
+    ScopeEvent,
+    SideState,
+)
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    ALLOWED_SLICE_CHANGED_PATH_PREFIXES,
+    NEXT_RECOMMENDED_SLICE,
+    parity_surface_assessments_v0,
+    parity_status_counts_v0,
+    scan_changed_paths_for_forbidden_runtime_v0,
+)
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    canonical_owner_refs_v0,
+)
+from trading.master_v2.offline_double_play_scenario_replay_v0 import (
+    OFFLINE_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER,
+    OfflineDoublePlayScenarioReplayInputV0,
+    OfflineDoublePlayScenarioTickV0,
+    SYNTHETIC_FUTURES_INSTRUMENT,
+    build_default_bull_bear_bull_scenario_ticks,
+    run_offline_double_play_scenario_replay_v0,
+)
+from trading.master_v2.scope_event_generator_scenario_binding_adapter_v0 import (
+    CANONICAL_SCOPE_EVENT_GENERATOR_OWNER,
+    SCOPE_EVENT_GENERATOR_SCENARIO_BINDING_ADAPTER_OWNER,
+    ScenarioScopeEventContextV0,
+    derive_scope_adverse_exit_signal_v0,
+    evaluate_scenario_scope_event_v0,
+    scope_event_binding_non_authority_boundary_ok_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_INSTRUMENT = SYNTHETIC_FUTURES_INSTRUMENT
+_DEFAULT_RULES = DynamicScopeRules(
+    min_band_width=1.0,
+    max_band_width=50.0,
+    min_switch_cooldown_ticks=0,
+    max_switches_per_window=1_000_000,
+    volatility_estimate=0.02,
+)
+_RUNTIME_SCOPE = RuntimeScopeState(anchor_price=100.0, current_hysteresis_band=4.0)
+
+_SLICE_CHANGED_FILES = ALLOWED_SLICE_CHANGED_PATH_PREFIXES
+
+_FORBIDDEN_IMPORT_SCAN_PATHS = (
+    REPO_ROOT / "src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py",
+    REPO_ROOT
+    / "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    REPO_ROOT / "scripts/ops/run_scope_event_generator_scenario_replay_binding_parity_rewire_v0.py",
+    REPO_ROOT
+    / "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
+)
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def test_owner_constants_and_canonical_reuse_v0() -> None:
+    refs = canonical_owner_refs_v0()
+    assert refs["scope_event_generator"] == CANONICAL_SCOPE_EVENT_GENERATOR_OWNER
+    assert (
+        refs["scope_event_generator_scenario_binding_adapter"]
+        == SCOPE_EVENT_GENERATOR_SCENARIO_BINDING_ADAPTER_OWNER
+    )
+    assert refs["scenario_replay"] == OFFLINE_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER
+
+
+def test_forbidden_runtime_paths_guard_v0() -> None:
+    ok, violations = scan_changed_paths_for_forbidden_runtime_v0(_SLICE_CHANGED_FILES)
+    assert ok is True
+    assert violations == ()
+
+
+def test_slice_sources_exclude_execution_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "execution",
+            "scheduler",
+            "credentials",
+            "live_runtime",
+            "testnet",
+            "shadow",
+            "paper_lane",
+        }
+    )
+    for path in _FORBIDDEN_IMPORT_SCAN_PATHS:
+        assert path.is_file(), f"missing slice source: {path}"
+        hits = _scan_forbidden_imports(path, forbidden)
+        assert hits == [], f"forbidden imports in {path}: {hits}"
+
+
+def test_scenario_adverse_exit_uses_canonical_generator_v0() -> None:
+    binding = evaluate_scenario_scope_event_v0(
+        ScenarioScopeEventContextV0(
+            instrument_id=_INSTRUMENT,
+            trading_epoch=1,
+            context_reference="scope-gen-parity-v0-adverse",
+            current_price=96.0,
+            scope_state=_RUNTIME_SCOPE,
+            rules=_DEFAULT_RULES,
+            active_side=ActiveSide.LONG,
+            confirmation_state=ScopeConfirmationStateV1(
+                candidate_kind=None,
+                candidate_count=0,
+                last_evaluated_trading_epoch=0,
+            ),
+            up_distance=2.0,
+            adverse_exit_distance=2.0,
+            reversal_distance=4.0,
+        )
+    )
+    assert binding.scope_event_evidence.event_type is CanonicalScopeEventType.ADVERSE_EXIT_CANDIDATE
+    assert binding.scope_adverse_exit_signal.triggered is True
+    assert scope_event_binding_non_authority_boundary_ok_v0(binding)
+
+
+def test_no_legacy_shortcut_adverse_exit_from_tick_scope_event_v0() -> None:
+    """Adverse-exit signal must come from generator evidence, not tick.scope_event labels."""
+    binding = evaluate_scenario_scope_event_v0(
+        ScenarioScopeEventContextV0(
+            instrument_id=_INSTRUMENT,
+            trading_epoch=2,
+            context_reference="scope-gen-parity-v0-no-shortcut",
+            current_price=100.0,
+            scope_state=_RUNTIME_SCOPE,
+            rules=_DEFAULT_RULES,
+            active_side=ActiveSide.LONG,
+            confirmation_state=ScopeConfirmationStateV1(
+                candidate_kind=None,
+                candidate_count=0,
+                last_evaluated_trading_epoch=1,
+            ),
+            up_distance=2.0,
+            adverse_exit_distance=2.0,
+            reversal_distance=4.0,
+        )
+    )
+    assert binding.scope_adverse_exit_signal.triggered is False
+    assert (
+        binding.scope_event_evidence.event_type
+        is not CanonicalScopeEventType.ADVERSE_EXIT_CANDIDATE
+    )
+
+
+def test_untrusted_data_blocks_adverse_exit_authority_v0() -> None:
+    binding = evaluate_scenario_scope_event_v0(
+        ScenarioScopeEventContextV0(
+            instrument_id=_INSTRUMENT,
+            trading_epoch=3,
+            context_reference="scope-gen-parity-v0-untrusted",
+            current_price=90.0,
+            scope_state=_RUNTIME_SCOPE,
+            rules=_DEFAULT_RULES,
+            active_side=ActiveSide.LONG,
+            confirmation_state=ScopeConfirmationStateV1(
+                candidate_kind=None,
+                candidate_count=0,
+                last_evaluated_trading_epoch=2,
+            ),
+            safety_decision_allowed=False,
+            data_integrity_status=DataIntegrityStatus.UNTRUSTED,
+            up_distance=2.0,
+            adverse_exit_distance=2.0,
+            reversal_distance=4.0,
+        )
+    )
+    assert binding.scope_adverse_exit_signal.triggered is False
+    assert binding.scope_event_evidence.blocked_reasons
+    assert scope_event_binding_non_authority_boundary_ok_v0(binding)
+
+
+def test_derive_scope_adverse_exit_signal_from_matched_condition_v0() -> None:
+    binding = evaluate_scenario_scope_event_v0(
+        ScenarioScopeEventContextV0(
+            instrument_id=_INSTRUMENT,
+            trading_epoch=4,
+            context_reference="scope-gen-parity-v0-matched",
+            current_price=96.0,
+            scope_state=_RUNTIME_SCOPE,
+            rules=_DEFAULT_RULES,
+            active_side=ActiveSide.LONG,
+            confirmation_state=ScopeConfirmationStateV1(
+                candidate_kind=None,
+                candidate_count=0,
+                last_evaluated_trading_epoch=3,
+            ),
+            up_distance=2.0,
+            adverse_exit_distance=2.0,
+            reversal_distance=4.0,
+        )
+    )
+    signal = derive_scope_adverse_exit_signal_v0(binding.scope_event_evidence)
+    assert signal.triggered is True
+    assert ScopeCandidateKind.ADVERSE_EXIT.value in binding.scope_event_evidence.matched_conditions
+
+
+def test_adapter_output_decision_bound_no_runtime_order_authority_v0() -> None:
+    binding = evaluate_scenario_scope_event_v0(
+        ScenarioScopeEventContextV0(
+            instrument_id=_INSTRUMENT,
+            trading_epoch=5,
+            context_reference="scope-gen-parity-v0-authority",
+            current_price=100.0,
+            scope_state=_RUNTIME_SCOPE,
+            rules=_DEFAULT_RULES,
+            active_side=ActiveSide.NEUTRAL,
+            confirmation_state=ScopeConfirmationStateV1(
+                candidate_kind=None,
+                candidate_count=0,
+                last_evaluated_trading_epoch=4,
+            ),
+        )
+    )
+    assert scope_event_binding_non_authority_boundary_ok_v0(binding)
+    evidence = binding.scope_event_evidence
+    assert evidence.authority_effect == "NONE"
+    assert evidence.runtime_effect == "NONE"
+    assert evidence.order_effect == "NONE"
+
+
+def test_surface_b_pass_cde_remain_partial_v0() -> None:
+    counts = parity_status_counts_v0()
+    assert counts["PASS"] == 12
+    assert counts["PARTIAL"] == 4
+    surface_b = next(item for item in parity_surface_assessments_v0() if item.surface_id == "B")
+    assert surface_b.parity_status == "PASS"
+    assert surface_b.missing_binding_if_any == ""
+    for surface_id in ("C", "D", "E"):
+        item = next(s for s in parity_surface_assessments_v0() if s.surface_id == surface_id)
+        assert item.parity_status == "PARTIAL"
+    assert NEXT_RECOMMENDED_SLICE == "REVERSAL_PREPARATION_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+
+
+def test_scenario_replay_e2e_wires_generator_per_tick_v0() -> None:
+    ticks = (
+        OfflineDoublePlayScenarioTickV0(
+            tick_index=0,
+            timestamp_ms=1_700_000_000_000,
+            price=100.0,
+            scope_event=ScopeEvent.NOOP,
+        ),
+        OfflineDoublePlayScenarioTickV0(
+            tick_index=1,
+            timestamp_ms=1_700_000_060_000,
+            price=96.0,
+            scope_event=ScopeEvent.NOOP,
+        ),
+    )
+    result = run_offline_double_play_scenario_replay_v0(
+        OfflineDoublePlayScenarioReplayInputV0(
+            selected_future_id=_INSTRUMENT,
+            ticks=ticks,
+            correlation_id_prefix="scope-gen-scenario-e2e-v0",
+        )
+    )
+    assert len(result.tick_records) == 2
+    assert all(record.entry_exit_policy_ref for record in result.tick_records)
+
+
+def test_default_scenario_replay_still_passes_with_generator_binding_v0() -> None:
+    result = run_offline_double_play_scenario_replay_v0(
+        OfflineDoublePlayScenarioReplayInputV0(
+            selected_future_id=_INSTRUMENT,
+            ticks=build_default_bull_bear_bull_scenario_ticks(),
+            correlation_id_prefix="scope-gen-default-scenario-v0",
+        )
+    )
+    assert result.replay_pass is True
+
+
+def test_adverse_exit_signal_drives_entry_exit_policy_when_position_open_v0() -> None:
+    from trading.master_v2.double_play_composition_matrix_v1 import CompositionStatus
+    from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
+        ScenarioEntryExitPolicyContextV0,
+        evaluate_scenario_entry_exit_policy_v0,
+    )
+    from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+        evaluate_scenario_matrix_for_side_state_v0,
+    )
+
+    matrix = evaluate_scenario_matrix_for_side_state_v0(
+        side_state=SideState.LONG_ACTIVE,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=10,
+        context_reference="scope-gen-entry-exit-v0",
+    )
+    decision = evaluate_scenario_entry_exit_policy_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=10,
+        context_reference="scope-gen-entry-exit-v0",
+        composition_result=matrix,
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=ScenarioEntryExitPolicyContextV0(
+            scope_adverse_exit_signal=PolicySignalV0(
+                triggered=True,
+                reason_code="adverse_scope_exit_candidate",
+            ),
+        ),
+    )
+    assert ExitClass.ADVERSE_SCOPE_EXIT.value in decision.reason_codes or (
+        decision.decision_outcome in (DecisionOutcome.EXIT, DecisionOutcome.OBSERVE)
+    )
+    assert matrix.composition_status is CompositionStatus.LONG_SELECTED


### PR DESCRIPTION
## Summary

- Implements Surface B only: scenario replay now binds per-tick scope adverse-exit decisions to the canonical `deterministic_scope_event_generator_v1` owner via a narrow adapter (`scope_event_generator_scenario_binding_adapter_v0`), following the PR4967 reuse-first pattern.
- Wires `scope_adverse_exit_signal` from generator evidence into `evaluate_scenario_entry_exit_policy_v0()`; state-switch tick path unchanged (Surfaces C/D/E out of scope).
- Updates parity gap registry: Surface B **PARTIAL → PASS** (12 PASS / 4 PARTIAL). Next slice: `REVERSAL_PREPARATION_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0`.

## Evidence

Durable bundle (manifest verify RC=0):
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/scope_event_generator_scenario_replay_binding_parity_rewire_v0_20260707T172112Z`

Source reassessment referenced:
`.../full_canonical_backtest_boundary_chain_reassessment_after_pr4967_v0_20260707T171627Z`

## Boundary delta

| Surface | Before | After |
|---------|--------|-------|
| B (Scope adverse exit) | PARTIAL | **PASS** |
| C (Reversal preparation) | PARTIAL | PARTIAL (unchanged) |
| D (Flat-before-opposite-side) | PARTIAL | PARTIAL (unchanged) |
| E (Survival/Suitability) | PARTIAL | PARTIAL (unchanged) |

`FULL_CANONICAL_CHAIN_WIRED=false` · `BACKTEST_RUNTIME_DECISION_PARITY_PASS=false` · `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`

## Authority flags

- `NO_RUNTIME_AUTHORITY=true`
- `NO_ORDER_AUTHORITY=true`
- No economic evaluation, no runtime/shadow/paper/testnet activation

## Test plan

- [x] `tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py` (12 tests)
- [x] `tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py`
- [x] `tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py`
- [x] `tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py`
- [x] `tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py`
- [x] `ruff format --check` + `ruff check` on changed files (73 targeted tests, ~1.5s wallclock)


Made with [Cursor](https://cursor.com)