### PR TITLE
Surface C: reversal preparation scenario replay binding parity rewire v0

### DIFF
--- a/scripts/ops/run_reversal_preparation_scenario_replay_binding_parity_rewire_v0.py
+++ b/scripts/ops/run_reversal_preparation_scenario_replay_binding_parity_rewire_v0.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for reversal preparation scenario replay binding parity rewire v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+SOURCE_EVIDENCE_DIR = (
+    ARCHIVE_ROOT
+    / "research/full_canonical_backtest_boundary_chain_reassessment_after_scope_event_rewire_v0_20260707T172819Z"
+)
+NEXT_RECOMMENDED_SLICE = "FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+VERDICT = "REVERSAL_PREPARATION_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0_PASS"
+PROCESS_CLASSIFICATION = "NARROW_REUSE_FIRST_REWIRE_WITH_TEST_HYGIENE"
+SCOPE_CLASSIFICATION = "REVERSAL_PREPARATION_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+TARGETED_TESTS = (
+    "tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+    "tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py",
+    "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "scripts/ops/run_reversal_preparation_scenario_replay_binding_parity_rewire_v0.py",
+    "tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+    "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.iterdir()):
+        if path.name == "MANIFEST.sha256":
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  {path.name}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["sha256sum", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def collect_evidence(out_dir: Path | None = None) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT
+        / f"research/reversal_preparation_scenario_replay_binding_parity_rewire_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    status = _run(["git", "status", "--short"]).stdout.strip()
+
+    source_manifest_proc = _run(["sha256sum", "-c", "MANIFEST.sha256"], cwd=SOURCE_EVIDENCE_DIR)
+    (evidence_dir / "source_manifest_reverify.log").write_text(
+        source_manifest_proc.stdout + source_manifest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    commands: list[str] = []
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    pytest_cmd = [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS]
+    commands.append(" ".join(pytest_cmd))
+    pytest_proc = subprocess.run(
+        pytest_cmd,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (evidence_dir / "tests.log").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    ruff_targets = [
+        str(REPO_ROOT / p)
+        for p in SLICE_CHANGED_FILES
+        if p.endswith(".py") and (REPO_ROOT / p).is_file()
+    ]
+    ruff_format_cmd = ["ruff", "format", "--check", *ruff_targets]
+    ruff_check_cmd = ["ruff", "check", *ruff_targets]
+    commands.extend([" ".join(ruff_format_cmd), " ".join(ruff_check_cmd)])
+    ruff_format = _run(ruff_format_cmd)
+    ruff_check = _run(ruff_check_cmd)
+    (evidence_dir / "ruff.log").write_text(
+        "RUFF_FORMAT\n"
+        + ruff_format.stdout
+        + ruff_format.stderr
+        + "\nRUFF_CHECK\n"
+        + ruff_check.stdout
+        + ruff_check.stderr,
+        encoding="utf-8",
+    )
+    (evidence_dir / "commands.log").write_text("\n".join(commands) + "\n", encoding="utf-8")
+
+    (evidence_dir / "git_state.txt").write_text(
+        "\n".join(
+            [
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"HEAD_EQUALS_ORIGIN_MAIN_AT_START={head == origin_main}",
+                f"WORKTREE_STATUS={status or 'clean'}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "changed_files.txt").write_text(
+        "\n".join(SLICE_CHANGED_FILES) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "PRE_FLIGHT.md").write_text(
+        "\n".join(
+            [
+                "# Pre-Flight",
+                "",
+                "BASE_HEAD=61a0c33175a57819cfa708026014c967f332fa92",
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                "HEAD_EQUALS_ORIGIN_MAIN=false",
+                "BRANCH=feat/reversal-preparation-scenario-replay-binding-parity-v0",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "SOURCE_EVIDENCE_REVERIFY.md").write_text(
+        "\n".join(
+            [
+                "# Source Evidence Reverify",
+                "",
+                f"SOURCE_EVIDENCE_DIR={SOURCE_EVIDENCE_DIR}",
+                f"SOURCE_MANIFEST_VERIFY_RC={source_manifest_proc.returncode}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "REUSE_DISCOVERY.md").write_text(
+        "\n".join(
+            [
+                "# Reuse Discovery",
+                "",
+                "| Role | Owner |",
+                "|---|---|",
+                "| Canonical entry-exit policy | `trading.master_v2.double_play_entry_exit_policy_v0` |",
+                "| Composition matrix | `trading.master_v2.double_play_composition_matrix_v1` |",
+                "| Scenario entry-exit adapter | `trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0` |",
+                "| Reversal preparation scenario adapter | `trading.master_v2.reversal_preparation_scenario_binding_adapter_v0` |",
+                "| Scenario replay orchestrator | `trading.master_v2.offline_double_play_scenario_replay_v0` |",
+                "",
+                "Pattern reused from PR4967/PR4968 consumer-bridge adapters.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "IMPLEMENTATION_NOTES.md").write_text(
+        "\n".join(
+            [
+                "# Implementation Notes",
+                "",
+                "Surface C only: scenario replay calls `evaluate_scenario_reversal_preparation_entry_exit_v0()`.",
+                "REVERSAL_PREPARATION composition maps to open-position policy context and opposite selected_side projection.",
+                "Canonical policy emits REVERSAL_PREPARATION_EXIT (reduce-only, no opposite-side entry).",
+                "Surfaces D/E/P unchanged PARTIAL.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "BOUNDARY_MATRIX_DELTA.md").write_text(
+        "\n".join(
+            [
+                "# Boundary Matrix Delta",
+                "",
+                "Surface C: PARTIAL -> PASS",
+                "Surfaces D/E/P: unchanged PARTIAL",
+                "PASS count: 12 -> 13",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "AUTHORITY_FLAGS.md").write_text(
+        "\n".join(
+            [
+                "# Authority Flags",
+                "",
+                "NO_RUNTIME_AUTHORITY=true",
+                "NO_ORDER_AUTHORITY=true",
+                "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false",
+                "FULL_CANONICAL_CHAIN_WIRED=false",
+                "BACKTEST_RUNTIME_DECISION_PARITY_PASS=false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc = _write_manifest(evidence_dir)
+    tests_pass = pytest_proc.returncode == 0
+    ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0
+    source_manifest_rc = source_manifest_proc.returncode
+    verdict = (
+        VERDICT
+        if tests_pass and ruff_pass and manifest_rc == 0 and source_manifest_rc == 0
+        else "REVERSAL_PREPARATION_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0_BLOCKED"
+    )
+
+    report = f"""# Reversal Preparation Scenario Replay Binding Parity Rewire v0
+
+VERDICT={verdict}
+PROCESS_CLASSIFICATION={PROCESS_CLASSIFICATION}
+SCOPE_CLASSIFICATION={SCOPE_CLASSIFICATION}
+BASE_HEAD=61a0c33175a57819cfa708026014c967f332fa92
+HEAD={head}
+ORIGIN_MAIN={origin_main}
+HEAD_EQUALS_ORIGIN_MAIN=false
+BRANCH=feat/reversal-preparation-scenario-replay-binding-parity-v0
+CHANGED_FILES={",".join(SLICE_CHANGED_FILES)}
+SOURCE_REASSESSMENT_EVIDENCE_REFERENCED=true
+SOURCE_EVIDENCE_DIR={SOURCE_EVIDENCE_DIR}
+SOURCE_MANIFEST_VERIFY_RC={source_manifest_rc}
+SURFACE_C_STATUS=PASS
+SURFACE_D_STATUS=UNCHANGED_PARTIAL
+SURFACE_E_STATUS=UNCHANGED_PARTIAL
+SURFACE_P_STATUS=UNCHANGED_PARTIAL
+FULL_CANONICAL_CHAIN_WIRED=false
+BACKTEST_RUNTIME_DECISION_PARITY_PASS=false
+SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false
+NO_RUNTIME_AUTHORITY=true
+NO_ORDER_AUTHORITY=true
+TEST_COMMANDS_AND_RC={" ".join(pytest_cmd)}={pytest_proc.returncode}
+RUFF_FORMAT_RC={ruff_format.returncode}
+RUFF_CHECK_RC={ruff_check.returncode}
+MANIFEST_VERIFY_RC={manifest_rc}
+DURABLE_EVIDENCE_DIR={evidence_dir}
+NEXT_STEP={NEXT_RECOMMENDED_SLICE}
+"""
+    (evidence_dir / "FINAL_REPORT.md").write_text(report, encoding="utf-8")
+    (evidence_dir / "TEST_RESULTS.md").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+    _write_manifest(evidence_dir)
+
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_rc": manifest_rc,
+        "source_manifest_rc": source_manifest_rc,
+        "tests_pass": tests_pass,
+        "ruff_pass": ruff_pass,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-dir", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(args.out_dir)
+    print(json.dumps(result, indent=2))
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -25,7 +25,7 @@ MatrixStatus = Literal[
     "UNKNOWN",
 ]
 
-NEXT_RECOMMENDED_SLICE = "REVERSAL_PREPARATION_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+NEXT_RECOMMENDED_SLICE = "FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
 
 ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
@@ -77,10 +77,13 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "tests/test_backtest_ai_observability_feedback_boundary_wiring_v0.py",
     "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
     "src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py",
+    "src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py",
     "scripts/ops/run_bull_bear_state_switch_scenario_replay_binding_parity_rewire_v0.py",
     "scripts/ops/run_scope_event_generator_scenario_replay_binding_parity_rewire_v0.py",
+    "scripts/ops/run_reversal_preparation_scenario_replay_binding_parity_rewire_v0.py",
     "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
     "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py",
     "docs/research/FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_V0.md",
 )
 
@@ -190,22 +193,23 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
                 " + evaluate_double_play_entry_exit_policy_v0()"
             ),
             current_scenario_replay_binding=(
-                "double_play_composition_scenario_matrix_adapter_v0"
-                " -> evaluate_scenario_matrix_composition_v0()"
+                "offline_double_play_scenario_replay_v0"
+                " -> evaluate_scenario_reversal_preparation_entry_exit_v0()"
+                " -> evaluate_double_play_entry_exit_policy_v0()"
+                " (REVERSAL_PREPARATION_EXIT)"
             ),
             current_backtest_binding="Integrated replay (default PositionManagementContext.FLAT)",
             current_runtime_semantics_reference=(
                 "canonical_core_runtime_integration_bridge_v0 -> integrated replay"
             ),
-            parity_status="PARTIAL",
+            parity_status="PASS",
             evidence_refs=(
                 "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py::test_5_reversal_preparation_boundary_parity_v0",
                 "tests/trading/master_v2/test_double_play_composition_matrix_v1.py",
                 "tests/trading/master_v2/test_double_play_entry_exit_policy_v0.py",
+                "tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py",
             ),
-            missing_binding_if_any=(
-                "Scenario tick -> entry-exit REVERSAL_PREPARATION_EXIT policy evaluation"
-            ),
+            missing_binding_if_any="",
             recommended_next_slice=NEXT_RECOMMENDED_SLICE,
         ),
         ParitySurfaceAssessmentV0(

--- a/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
+++ b/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
@@ -85,6 +85,12 @@ from trading.master_v2.scope_event_generator_scenario_binding_adapter_v0 import 
     evaluate_scenario_scope_event_v0,
     scope_event_binding_non_authority_boundary_ok_v0,
 )
+from trading.master_v2.reversal_preparation_scenario_binding_adapter_v0 import (
+    REVERSAL_PREPARATION_SCENARIO_BINDING_ADAPTER_OWNER,
+    REVERSAL_PREPARATION_EFFECT_BOUND_OFFLINE,
+    evaluate_scenario_reversal_preparation_entry_exit_v0,
+    reversal_preparation_binding_non_authority_boundary_ok_v0,
+)
 from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
     CANONICAL_ENTRY_EXIT_POLICY_OWNER,
     DOUBLE_PLAY_ENTRY_EXIT_SCENARIO_BINDING_ADAPTER_OWNER,
@@ -959,6 +965,9 @@ def canonical_owner_refs_v0() -> Mapping[str, str]:
         "scope_event_generator": CANONICAL_SCOPE_EVENT_GENERATOR_OWNER,
         "scope_event_generator_scenario_binding_adapter": (
             SCOPE_EVENT_GENERATOR_SCENARIO_BINDING_ADAPTER_OWNER
+        ),
+        "reversal_preparation_scenario_binding_adapter": (
+            REVERSAL_PREPARATION_SCENARIO_BINDING_ADAPTER_OWNER
         ),
         "runtime_state_reconciliation": RUNTIME_STATE_RECONCILIATION_OWNER,
         "reconciliation_entry_exit_policy": RECONCILIATION_ENTRY_EXIT_POLICY_OWNER,

--- a/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
+++ b/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
@@ -90,9 +90,11 @@ from trading.master_v2.scope_event_generator_scenario_binding_adapter_v0 import 
     ScenarioScopeEventContextV0,
     evaluate_scenario_scope_event_v0,
 )
+from trading.master_v2.reversal_preparation_scenario_binding_adapter_v0 import (
+    evaluate_scenario_reversal_preparation_entry_exit_v0,
+)
 from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
     default_scenario_entry_exit_policy_context_v0,
-    evaluate_scenario_entry_exit_policy_v0,
 )
 from trading.master_v2.double_play_entry_exit_policy_v0 import SafetyMode
 from trading.master_v2.double_play_dashboard_display import (
@@ -861,7 +863,7 @@ def run_offline_double_play_scenario_replay_v0(
             ),
             scope_adverse_exit_signal=scope_event_binding.scope_adverse_exit_signal,
         )
-        entry_exit_decision = evaluate_scenario_entry_exit_policy_v0(
+        entry_exit_decision = evaluate_scenario_reversal_preparation_entry_exit_v0(
             instrument_id=inp.selected_future_id,
             trading_epoch=tick.tick_index,
             context_reference=f"{inp.correlation_id_prefix}-tick-{tick.tick_index}",

--- a/src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py
+++ b/src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py
@@ -1,0 +1,183 @@
+# src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py
+"""
+Scenario replay adapter: binds offline Double Play scenario ticks to the canonical
+``double_play_entry_exit_policy_v0`` reversal-preparation path without duplicating policy logic.
+
+Wiring-only parity slice (Surface C) — no runtime authority, no trading semantic extension.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from trading.master_v2.double_play_composition_matrix_v1 import (
+    CompositionSelectedSide,
+    CompositionStatus,
+    DoublePlayCompositionResultV1,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import (
+    DecisionOutcome,
+    EntryExitPolicyDecisionV0,
+    ExitClass,
+    ExistingPositionSide,
+    PositionState,
+)
+from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
+    CANONICAL_ENTRY_EXIT_POLICY_OWNER,
+    ScenarioEntryExitPolicyContextV0,
+    evaluate_scenario_entry_exit_policy_v0,
+)
+from trading.master_v2.double_play_state import SideState
+
+REVERSAL_PREPARATION_SCENARIO_BINDING_ADAPTER_LAYER_VERSION = "v0"
+REVERSAL_PREPARATION_SCENARIO_BINDING_ADAPTER_OWNER = (
+    "trading.master_v2.reversal_preparation_scenario_binding_adapter_v0"
+)
+
+REVERSAL_PREPARATION_EFFECT_BOUND_OFFLINE = "BOUND_OFFLINE"
+REVERSAL_PREPARATION_EFFECT_NONE = "NONE"
+
+RUNTIME_AUTHORITY_EFFECT_NONE = "NONE"
+ORDER_EFFECT_NONE = "NONE"
+
+
+def is_reversal_preparation_composition_v0(
+    composition_result: DoublePlayCompositionResultV1,
+) -> bool:
+    return composition_result.composition_status is CompositionStatus.REVERSAL_PREPARATION
+
+
+def derive_reversal_preparation_position_context_v0(
+    composition_result: DoublePlayCompositionResultV1,
+    *,
+    safety_decision_allowed: bool = True,
+) -> ScenarioEntryExitPolicyContextV0 | None:
+    """Map REVERSAL_PREPARATION composition evidence to open-position policy context."""
+    if not is_reversal_preparation_composition_v0(composition_result):
+        return None
+    codes = composition_result.reason_codes
+    if "existing_long_position" in codes:
+        return ScenarioEntryExitPolicyContextV0(
+            position_state=PositionState.OPEN_FULL,
+            existing_position_side=ExistingPositionSide.LONG,
+            venue_flat=False,
+            safety_decision_allowed=safety_decision_allowed,
+        )
+    if "existing_short_position" in codes:
+        return ScenarioEntryExitPolicyContextV0(
+            position_state=PositionState.OPEN_FULL,
+            existing_position_side=ExistingPositionSide.SHORT,
+            venue_flat=False,
+            safety_decision_allowed=safety_decision_allowed,
+        )
+    return None
+
+
+def project_composition_for_reversal_preparation_entry_exit_v0(
+    composition_result: DoublePlayCompositionResultV1,
+) -> DoublePlayCompositionResultV1:
+    """
+    Consumer-bridge projection: canonical entry-exit precedence 6 expects opposite
+    ``selected_side``, not ``REVERSAL_PREPARATION`` with ``selected_side=NONE``.
+    """
+    if not is_reversal_preparation_composition_v0(composition_result):
+        return composition_result
+    codes = composition_result.reason_codes
+    if "existing_long_position" in codes:
+        return replace(
+            composition_result,
+            selected_side=CompositionSelectedSide.SHORT,
+        )
+    if "existing_short_position" in codes:
+        return replace(
+            composition_result,
+            selected_side=CompositionSelectedSide.LONG,
+        )
+    return composition_result
+
+
+def evaluate_scenario_reversal_preparation_entry_exit_v0(
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+    context_reference: str,
+    composition_result: DoublePlayCompositionResultV1,
+    side_state: SideState,
+    policy_context: ScenarioEntryExitPolicyContextV0,
+) -> EntryExitPolicyDecisionV0:
+    """Evaluate entry-exit with reversal-preparation binding when composition requires it."""
+    if not policy_context.safety_decision_allowed:
+        return evaluate_scenario_entry_exit_policy_v0(
+            instrument_id=instrument_id,
+            trading_epoch=trading_epoch,
+            context_reference=context_reference,
+            composition_result=composition_result,
+            side_state=side_state,
+            policy_context=policy_context,
+        )
+
+    reversal_ctx = derive_reversal_preparation_position_context_v0(
+        composition_result,
+        safety_decision_allowed=policy_context.safety_decision_allowed,
+    )
+    if reversal_ctx is None:
+        return evaluate_scenario_entry_exit_policy_v0(
+            instrument_id=instrument_id,
+            trading_epoch=trading_epoch,
+            context_reference=context_reference,
+            composition_result=composition_result,
+            side_state=side_state,
+            policy_context=policy_context,
+        )
+
+    merged_ctx = replace(
+        policy_context,
+        position_state=reversal_ctx.position_state,
+        existing_position_side=reversal_ctx.existing_position_side,
+        venue_flat=reversal_ctx.venue_flat,
+    )
+    projected = project_composition_for_reversal_preparation_entry_exit_v0(composition_result)
+    return evaluate_scenario_entry_exit_policy_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+        composition_result=projected,
+        side_state=side_state,
+        policy_context=merged_ctx,
+    )
+
+
+def reversal_preparation_decision_is_reduce_only_preparation_v0(
+    decision: EntryExitPolicyDecisionV0,
+) -> bool:
+    if decision.exit_class is not ExitClass.REVERSAL_PREPARATION_EXIT:
+        return False
+    if decision.decision_outcome in (DecisionOutcome.ENTER_LONG, DecisionOutcome.ENTER_SHORT):
+        return False
+    if decision.position_flip_allowed:
+        return False
+    return decision.decision_outcome in (DecisionOutcome.REDUCE, DecisionOutcome.EXIT)
+
+
+def reversal_preparation_binding_non_authority_boundary_ok_v0(
+    decision: EntryExitPolicyDecisionV0,
+) -> bool:
+    if decision.runtime_effect != RUNTIME_AUTHORITY_EFFECT_NONE:
+        return False
+    if decision.authority_effect != RUNTIME_AUTHORITY_EFFECT_NONE:
+        return False
+    if decision.execution_eligible:
+        return False
+    if decision.adapter_compatible:
+        return False
+    if decision.decision_outcome in (DecisionOutcome.ENTER_LONG, DecisionOutcome.ENTER_SHORT):
+        return False
+    return True
+
+
+def system_economic_evidence_admissible_v0() -> bool:
+    return False
+
+
+def canonical_entry_exit_owner_ref_v0() -> str:
+    return CANONICAL_ENTRY_EXIT_POLICY_OWNER

--- a/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
+++ b/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
@@ -58,7 +58,7 @@ def test_gap_assessment_owner_and_surface_count_v0() -> None:
 
 def test_gap_assessment_status_distribution_v0() -> None:
     counts = parity_status_counts_v0()
-    assert counts["PASS"] == 12
+    assert counts["PASS"] == 13
     assert counts["PARTIAL"] >= 3
     assert counts["GAP"] == 0
     assert counts["NOT_APPLICABLE"] == 0
@@ -78,6 +78,15 @@ def test_scope_adverse_exit_surface_pass_v0() -> None:
     assert scope_adverse.missing_binding_if_any == ""
     assert "evaluate_scenario_scope_event_v0" in scope_adverse.current_scenario_replay_binding
     assert "generate_deterministic_scope_event" in scope_adverse.current_scenario_replay_binding
+
+
+def test_reversal_preparation_surface_pass_v0() -> None:
+    reversal = next(item for item in parity_surface_assessments_v0() if item.surface_id == "C")
+    assert reversal.parity_status == "PASS"
+    assert reversal.missing_binding_if_any == ""
+    assert "evaluate_scenario_reversal_preparation_entry_exit_v0" in (
+        reversal.current_scenario_replay_binding
+    )
 
 
 def test_composition_surface_pass_v0() -> None:

--- a/tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py
@@ -1,0 +1,275 @@
+"""Reversal preparation binding parity: scenario replay entry-exit path (offline only)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from trading.master_v2.double_play_composition_matrix_v1 import (
+    CompositionSelectedSide,
+    CompositionStatus,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import (
+    DecisionOutcome,
+    ExitClass,
+    ExistingPositionSide,
+    PositionState,
+    ReversalState,
+)
+from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
+    CANONICAL_ENTRY_EXIT_POLICY_OWNER,
+    default_scenario_entry_exit_policy_context_v0,
+)
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    ALLOWED_SLICE_CHANGED_PATH_PREFIXES,
+    NEXT_RECOMMENDED_SLICE,
+    parity_surface_assessments_v0,
+    parity_status_counts_v0,
+    scan_changed_paths_for_forbidden_runtime_v0,
+)
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    canonical_owner_refs_v0,
+    evaluate_reversal_preparation_matrix_v0,
+)
+from trading.master_v2.offline_double_play_scenario_replay_v0 import (
+    OFFLINE_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER,
+    SYNTHETIC_FUTURES_INSTRUMENT,
+    build_default_bull_bear_bull_scenario_ticks,
+    run_offline_double_play_scenario_replay_v0,
+    OfflineDoublePlayScenarioReplayInputV0,
+)
+from trading.master_v2.reversal_preparation_scenario_binding_adapter_v0 import (
+    REVERSAL_PREPARATION_SCENARIO_BINDING_ADAPTER_OWNER,
+    derive_reversal_preparation_position_context_v0,
+    evaluate_scenario_reversal_preparation_entry_exit_v0,
+    is_reversal_preparation_composition_v0,
+    project_composition_for_reversal_preparation_entry_exit_v0,
+    reversal_preparation_binding_non_authority_boundary_ok_v0,
+    reversal_preparation_decision_is_reduce_only_preparation_v0,
+)
+from trading.master_v2.double_play_state import SideState
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_INSTRUMENT = SYNTHETIC_FUTURES_INSTRUMENT
+_EPOCH = 52
+_CONTEXT = "reversal-preparation-binding-parity-v0"
+
+_SLICE_CHANGED_FILES = ALLOWED_SLICE_CHANGED_PATH_PREFIXES
+
+_FORBIDDEN_IMPORT_SCAN_PATHS = (
+    REPO_ROOT / "src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py",
+    REPO_ROOT
+    / "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    REPO_ROOT / "scripts/ops/run_reversal_preparation_scenario_replay_binding_parity_rewire_v0.py",
+    REPO_ROOT
+    / "tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py",
+)
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def test_owner_constants_and_canonical_reuse_v0() -> None:
+    refs = canonical_owner_refs_v0()
+    assert refs["entry_exit_policy"] == CANONICAL_ENTRY_EXIT_POLICY_OWNER
+    assert (
+        refs["reversal_preparation_scenario_binding_adapter"]
+        == REVERSAL_PREPARATION_SCENARIO_BINDING_ADAPTER_OWNER
+    )
+    assert refs["scenario_replay"] == OFFLINE_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER
+
+
+def test_forbidden_runtime_paths_guard_v0() -> None:
+    ok, violations = scan_changed_paths_for_forbidden_runtime_v0(_SLICE_CHANGED_FILES)
+    assert ok is True
+    assert violations == ()
+
+
+def test_slice_sources_exclude_execution_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "execution",
+            "scheduler",
+            "credentials",
+            "live_runtime",
+            "testnet",
+            "shadow",
+            "paper_lane",
+        }
+    )
+    for path in _FORBIDDEN_IMPORT_SCAN_PATHS:
+        assert path.is_file(), f"missing slice source: {path}"
+        hits = _scan_forbidden_imports(path, forbidden)
+        assert hits == [], f"forbidden imports in {path}: {hits}"
+
+
+def test_scenario_reversal_preparation_exit_via_canonical_policy_v0() -> None:
+    matrix = evaluate_reversal_preparation_matrix_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    assert is_reversal_preparation_composition_v0(matrix)
+    decision = evaluate_scenario_reversal_preparation_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=default_scenario_entry_exit_policy_context_v0(),
+    )
+    assert decision.exit_class is ExitClass.REVERSAL_PREPARATION_EXIT
+    assert decision.reversal_state is ReversalState.PREPARATION
+    assert reversal_preparation_decision_is_reduce_only_preparation_v0(decision)
+    assert reversal_preparation_binding_non_authority_boundary_ok_v0(decision)
+
+
+def test_reversal_preparation_no_enter_opposite_side_v0() -> None:
+    matrix = evaluate_reversal_preparation_matrix_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    decision = evaluate_scenario_reversal_preparation_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=default_scenario_entry_exit_policy_context_v0(),
+    )
+    assert decision.decision_outcome is not DecisionOutcome.ENTER_SHORT
+    assert decision.decision_outcome is not DecisionOutcome.ENTER_LONG
+    assert decision.position_flip_allowed is False
+
+
+def test_reversal_preparation_reduce_only_preparation_bound_v0() -> None:
+    matrix = evaluate_reversal_preparation_matrix_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    decision = evaluate_scenario_reversal_preparation_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=default_scenario_entry_exit_policy_context_v0(),
+    )
+    assert decision.decision_outcome in (DecisionOutcome.REDUCE, DecisionOutcome.EXIT)
+    assert "reversal_preparation" in decision.reason_codes
+
+
+def test_untrusted_input_blocks_reversal_authority_v0() -> None:
+    matrix = evaluate_reversal_preparation_matrix_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    decision = evaluate_scenario_reversal_preparation_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=default_scenario_entry_exit_policy_context_v0(
+            safety_decision_allowed=False,
+        ),
+    )
+    assert decision.exit_class is not ExitClass.REVERSAL_PREPARATION_EXIT
+    assert reversal_preparation_binding_non_authority_boundary_ok_v0(decision)
+
+
+def test_adapter_no_runtime_order_authority_v0() -> None:
+    matrix = evaluate_reversal_preparation_matrix_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    decision = evaluate_scenario_reversal_preparation_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=default_scenario_entry_exit_policy_context_v0(),
+    )
+    assert decision.runtime_effect == "NONE"
+    assert decision.authority_effect == "NONE"
+    assert decision.execution_eligible is False
+
+
+def test_project_composition_sets_opposite_selected_side_v0() -> None:
+    matrix = evaluate_reversal_preparation_matrix_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    projected = project_composition_for_reversal_preparation_entry_exit_v0(matrix)
+    assert projected.selected_side is CompositionSelectedSide.SHORT
+    ctx = derive_reversal_preparation_position_context_v0(matrix)
+    assert ctx is not None
+    assert ctx.existing_position_side is ExistingPositionSide.LONG
+    assert ctx.position_state is PositionState.OPEN_FULL
+
+
+def test_surface_c_pass_dep_unchanged_partial_v0() -> None:
+    counts = parity_status_counts_v0()
+    assert counts["PASS"] == 13
+    assert counts["PARTIAL"] == 3
+    surface_c = next(item for item in parity_surface_assessments_v0() if item.surface_id == "C")
+    assert surface_c.parity_status == "PASS"
+    assert surface_c.missing_binding_if_any == ""
+    for surface_id in ("D", "E", "P"):
+        item = next(s for s in parity_surface_assessments_v0() if s.surface_id == surface_id)
+        assert item.parity_status == "PARTIAL"
+    assert (
+        NEXT_RECOMMENDED_SLICE
+        == "FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+    )
+
+
+def test_default_scenario_replay_still_passes_v0() -> None:
+    result = run_offline_double_play_scenario_replay_v0(
+        OfflineDoublePlayScenarioReplayInputV0(
+            selected_future_id=_INSTRUMENT,
+            ticks=build_default_bull_bear_bull_scenario_ticks(),
+            correlation_id_prefix="reversal-prep-default-scenario-v0",
+        )
+    )
+    assert result.replay_pass is True
+
+
+def test_non_reversal_composition_passthrough_v0() -> None:
+    from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+        evaluate_scenario_matrix_for_side_state_v0,
+    )
+
+    matrix = evaluate_scenario_matrix_for_side_state_v0(
+        side_state=SideState.LONG_ACTIVE,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    assert matrix.composition_status is not CompositionStatus.REVERSAL_PREPARATION
+    decision = evaluate_scenario_reversal_preparation_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=default_scenario_entry_exit_policy_context_v0(),
+    )
+    assert decision.exit_class is not ExitClass.REVERSAL_PREPARATION_EXIT

--- a/tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py
@@ -252,15 +252,21 @@ def test_adapter_output_decision_bound_no_runtime_order_authority_v0() -> None:
 
 def test_surface_b_pass_cde_remain_partial_v0() -> None:
     counts = parity_status_counts_v0()
-    assert counts["PASS"] == 12
-    assert counts["PARTIAL"] == 4
+    assert counts["PASS"] == 13
+    assert counts["PARTIAL"] == 3
     surface_b = next(item for item in parity_surface_assessments_v0() if item.surface_id == "B")
     assert surface_b.parity_status == "PASS"
     assert surface_b.missing_binding_if_any == ""
-    for surface_id in ("C", "D", "E"):
+    surface_c = next(item for item in parity_surface_assessments_v0() if item.surface_id == "C")
+    assert surface_c.parity_status == "PASS"
+    assert surface_c.missing_binding_if_any == ""
+    for surface_id in ("D", "E"):
         item = next(s for s in parity_surface_assessments_v0() if s.surface_id == surface_id)
         assert item.parity_status == "PARTIAL"
-    assert NEXT_RECOMMENDED_SLICE == "REVERSAL_PREPARATION_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+    assert (
+        NEXT_RECOMMENDED_SLICE
+        == "FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+    )
 
 
 def test_scenario_replay_e2e_wires_generator_per_tick_v0() -> None:


### PR DESCRIPTION
## Summary

- Adds narrow consumer-bridge adapter `reversal_preparation_scenario_binding_adapter_v0` so offline scenario replay binds `REVERSAL_PREPARATION` composition through the canonical `double_play_entry_exit_policy_v0` chain.
- Scenario replay now calls `evaluate_scenario_reversal_preparation_entry_exit_v0()` per tick, producing `REVERSAL_PREPARATION_EXIT` (reduce-only exit preparation) without opposite-side entry or runtime/order authority.
- Registry delta: Surface **C** PARTIAL → PASS (13 PASS / 3 PARTIAL). Surfaces D/E/P unchanged PARTIAL.

## Evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/reversal_preparation_scenario_replay_binding_parity_rewire_v0_20260707T173152Z/`

Source reassessment: `full_canonical_backtest_boundary_chain_reassessment_after_scope_event_rewire_v0_20260707T172819Z/` (SOURCE_MANIFEST_VERIFY_RC=0)

## Boundary delta

| Surface | Before | After |
|---------|--------|-------|
| C (Reversal preparation) | PARTIAL | **PASS** |
| D (Flat before opposite side) | PARTIAL | UNCHANGED_PARTIAL |
| E | PARTIAL | UNCHANGED_PARTIAL |
| P | PARTIAL | UNCHANGED_PARTIAL |

## Authority flags

- `NO_RUNTIME_AUTHORITY=true`
- `NO_ORDER_AUTHORITY=true`
- `FULL_CANONICAL_CHAIN_WIRED=false`
- `BACKTEST_RUNTIME_DECISION_PARITY_PASS=false`
- `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`

## Test plan

- [x] `tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py` (contracts a–f)
- [x] PR4967 bull/bear state switch regression
- [x] PR4968 scope event generator regression
- [x] Scenario replay / double play composition / entry-exit policy regressions
- [x] `ruff format --check` / `ruff check` on changed files
- [x] 139 targeted pytest passed locally

**Next recommended slice:** `FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0` (Surface D)

No merge without separate operator instruction.

Made with [Cursor](https://cursor.com)