### PR TITLE
Surface D: flat-before-opposite-side scenario replay binding parity rewire v0

### DIFF
--- a/scripts/ops/run_flat_before_opposite_side_scenario_replay_binding_parity_rewire_v0.py
+++ b/scripts/ops/run_flat_before_opposite_side_scenario_replay_binding_parity_rewire_v0.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for flat-before-opposite-side scenario replay binding parity rewire v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+SOURCE_EVIDENCE_DIR = (
+    ARCHIVE_ROOT
+    / "research/full_canonical_backtest_boundary_chain_reassessment_after_reversal_preparation_rewire_v0_20260707T173859Z"
+)
+CLOSEOUT_EVIDENCE_DIR = (
+    ARCHIVE_ROOT
+    / "research/pr_merge_closeout_reversal_preparation_scenario_replay_binding_parity_rewire_v0_20260707T173729Z"
+)
+NEXT_RECOMMENDED_SLICE = "SURVIVAL_SUITABILITY_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+VERDICT = "FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0_PASS"
+PROCESS_CLASSIFICATION = "NARROW_REUSE_FIRST_REWIRE_NO_RUNTIME_AUTHORITY"
+SCOPE_CLASSIFICATION = "FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+TARGETED_TESTS = (
+    "tests/trading/master_v2/test_flat_before_opposite_side_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_scenario_replay_double_play_entry_exit_policy_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+    "tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py",
+    "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "scripts/ops/run_flat_before_opposite_side_scenario_replay_binding_parity_rewire_v0.py",
+    "tests/trading/master_v2/test_flat_before_opposite_side_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+    "tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.iterdir()):
+        if path.name == "MANIFEST.sha256":
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  {path.name}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def collect_evidence(out_dir: Path | None = None) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT
+        / f"research/flat_before_opposite_side_scenario_replay_binding_parity_rewire_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    status = _run(["git", "status", "--short"]).stdout.strip()
+
+    source_manifest_proc = _run(
+        ["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=SOURCE_EVIDENCE_DIR
+    )
+    closeout_manifest_proc = _run(
+        ["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=CLOSEOUT_EVIDENCE_DIR
+    )
+    (evidence_dir / "source_manifest_verification.txt").write_text(
+        "\n".join(
+            [
+                f"SOURCE_EVIDENCE_DIR={SOURCE_EVIDENCE_DIR}",
+                f"SOURCE_MANIFEST_VERIFY_RC={source_manifest_proc.returncode}",
+                f"CLOSEOUT_EVIDENCE_DIR={CLOSEOUT_EVIDENCE_DIR}",
+                f"CLOSEOUT_MANIFEST_VERIFY_RC={closeout_manifest_proc.returncode}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    pytest_cmd = [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS]
+    pytest_proc = subprocess.run(
+        pytest_cmd,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (evidence_dir / "targeted_pytest.txt").write_text(
+        " ".join(pytest_cmd)
+        + f"\nRC={pytest_proc.returncode}\n\n"
+        + pytest_proc.stdout
+        + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    ruff_targets = [
+        str(REPO_ROOT / p)
+        for p in SLICE_CHANGED_FILES
+        if p.endswith(".py") and (REPO_ROOT / p).is_file()
+    ]
+    ruff_format_cmd = ["ruff", "format", "--check", *ruff_targets]
+    ruff_check_cmd = ["ruff", "check", *ruff_targets]
+    ruff_format = _run(ruff_format_cmd)
+    ruff_check = _run(ruff_check_cmd)
+    (evidence_dir / "ruff_format_check.txt").write_text(
+        ruff_format.stdout + ruff_format.stderr + f"\nRC={ruff_format.returncode}\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "ruff_check.txt").write_text(
+        ruff_check.stdout + ruff_check.stderr + f"\nRC={ruff_check.returncode}\n",
+        encoding="utf-8",
+    )
+
+    (evidence_dir / "preflight.txt").write_text(
+        "\n".join(
+            [
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"HEAD_EQUALS_ORIGIN_MAIN={head == origin_main}",
+                f"WORKTREE_STATUS={status or 'clean'}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "changed_files.txt").write_text(
+        "\n".join(SLICE_CHANGED_FILES) + "\n", encoding="utf-8"
+    )
+    (evidence_dir / "implementation_summary.txt").write_text(
+        "\n".join(
+            [
+                "Surface D only: scenario replay calls evaluate_scenario_flat_before_opposite_side_entry_exit_v0().",
+                "Side-state pipeline maps to canonical entry-exit position context for flat/flip gates.",
+                "Chains through reversal-preparation adapter to evaluate_double_play_entry_exit_policy_v0().",
+                "Surfaces C PASS unchanged; E/P remain PARTIAL.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "surface_d_binding_evidence.txt").write_text(
+        "\n".join(
+            [
+                "SURFACE_D_STATUS=PASS",
+                "CANONICAL_OWNER=trading.master_v2.double_play_entry_exit_policy_v0",
+                "ADAPTER=trading.master_v2.flat_before_opposite_side_scenario_binding_adapter_v0",
+                "SCENARIO_BINDING=evaluate_scenario_flat_before_opposite_side_entry_exit_v0",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "residual_gap_status.txt").write_text(
+        "\n".join(
+            [
+                "SURFACE_C_STATUS=PASS",
+                "SURFACE_D_STATUS=PASS",
+                "SURFACE_E_STATUS=UNCHANGED_PARTIAL",
+                "SURFACE_P_STATUS=UNCHANGED_PARTIAL",
+                "FINAL_GAP_STATUS=PARTIAL",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "authority_flags.txt").write_text(
+        "\n".join(
+            [
+                "NO_RUNTIME_AUTHORITY=true",
+                "NO_ORDER_SUBMISSION=true",
+                "NO_ADAPTER_SUBMISSION=true",
+                "LIVE_AUTHORIZED=false",
+                "FULL_CANONICAL_CHAIN_WIRED=false",
+                "BACKTEST_RUNTIME_DECISION_PARITY_PASS=false",
+                "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc = _write_manifest(evidence_dir)
+    tests_pass = pytest_proc.returncode == 0
+    ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0
+    source_manifest_rc = source_manifest_proc.returncode
+    closeout_manifest_rc = closeout_manifest_proc.returncode
+    verdict = (
+        VERDICT
+        if tests_pass
+        and ruff_pass
+        and manifest_rc == 0
+        and source_manifest_rc == 0
+        and closeout_manifest_rc == 0
+        else "FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0_BLOCKED"
+    )
+
+    report = f"""# Flat Before Opposite Side Scenario Replay Binding Parity Rewire v0
+
+VERDICT={verdict}
+PROCESS_CLASSIFICATION={PROCESS_CLASSIFICATION}
+SCOPE_CLASSIFICATION={SCOPE_CLASSIFICATION}
+HEAD={head}
+ORIGIN_MAIN={origin_main}
+HEAD_EQUALS_ORIGIN_MAIN={head == origin_main}
+CHANGED_FILES={",".join(SLICE_CHANGED_FILES)}
+SOURCE_EVIDENCE_DIR={SOURCE_EVIDENCE_DIR}
+SOURCE_MANIFEST_VERIFY_RC={source_manifest_rc}
+CLOSEOUT_EVIDENCE_DIR={CLOSEOUT_EVIDENCE_DIR}
+CLOSEOUT_MANIFEST_VERIFY_RC={closeout_manifest_rc}
+SURFACE_C_STATUS=PASS
+SURFACE_D_STATUS=PASS
+SURFACE_E_STATUS=UNCHANGED_PARTIAL
+SURFACE_P_STATUS=UNCHANGED_PARTIAL
+FULL_CANONICAL_CHAIN_WIRED=false
+BACKTEST_RUNTIME_DECISION_PARITY_PASS=false
+SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false
+NO_RUNTIME_AUTHORITY=true
+NO_ORDER_AUTHORITY=true
+TEST_COMMANDS_AND_RC={" ".join(pytest_cmd)}={pytest_proc.returncode}
+RUFF_FORMAT_RC={ruff_format.returncode}
+RUFF_CHECK_RC={ruff_check.returncode}
+MANIFEST_VERIFY_RC={manifest_rc}
+DURABLE_EVIDENCE_DIR={evidence_dir}
+NEXT_STEP={NEXT_RECOMMENDED_SLICE}
+"""
+    (evidence_dir / "FINAL_REPORT.md").write_text(report, encoding="utf-8")
+    _write_manifest(evidence_dir)
+
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_rc": manifest_rc,
+        "source_manifest_rc": source_manifest_rc,
+        "closeout_manifest_rc": closeout_manifest_rc,
+        "tests_pass": tests_pass,
+        "ruff_pass": ruff_pass,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-dir", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(args.out_dir)
+    print(json.dumps(result, indent=2))
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py
+++ b/src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py
@@ -1,0 +1,173 @@
+# src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py
+"""
+Scenario replay adapter: binds offline Double Play scenario ticks to the canonical
+``double_play_entry_exit_policy_v0`` flat-before-opposite-side path without duplicating policy logic.
+
+Wiring-only parity slice (Surface D) — no runtime authority, no trading semantic extension.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from trading.master_v2.double_play_composition_matrix_v1 import DoublePlayCompositionResultV1
+from trading.master_v2.double_play_entry_exit_policy_v0 import (
+    DecisionOutcome,
+    EntryExitPolicyDecisionV0,
+    ExistingPositionSide,
+    PositionState,
+)
+from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
+    CANONICAL_ENTRY_EXIT_POLICY_OWNER,
+    ScenarioEntryExitPolicyContextV0,
+)
+from trading.master_v2.double_play_state import SideState
+from trading.master_v2.reversal_preparation_scenario_binding_adapter_v0 import (
+    evaluate_scenario_reversal_preparation_entry_exit_v0,
+)
+
+FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_BINDING_ADAPTER_LAYER_VERSION = "v0"
+FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_BINDING_ADAPTER_OWNER = (
+    "trading.master_v2.flat_before_opposite_side_scenario_binding_adapter_v0"
+)
+
+FLAT_BEFORE_OPPOSITE_SIDE_EFFECT_BOUND_OFFLINE = "BOUND_OFFLINE"
+FLAT_BEFORE_OPPOSITE_SIDE_EFFECT_NONE = "NONE"
+
+RUNTIME_AUTHORITY_EFFECT_NONE = "NONE"
+ORDER_EFFECT_NONE = "NONE"
+
+_EXPLICIT_POSITION_OVERRIDE_STATES = frozenset(
+    {
+        PositionState.RECONCILIATION_REQUIRED,
+        PositionState.SUBMISSION_UNKNOWN,
+        PositionState.REDUCING_PARTIAL,
+        PositionState.EXIT_PENDING,
+    }
+)
+
+
+def derive_flat_before_opposite_side_position_context_v0(
+    side_state: SideState,
+) -> ScenarioEntryExitPolicyContextV0 | None:
+    """Map side-state pipeline evidence to open-position policy context for flat/flip gates."""
+    if side_state is SideState.LONG_ACTIVE:
+        return ScenarioEntryExitPolicyContextV0(
+            position_state=PositionState.OPEN_FULL,
+            existing_position_side=ExistingPositionSide.LONG,
+            venue_flat=False,
+        )
+    if side_state is SideState.SHORT_ACTIVE:
+        return ScenarioEntryExitPolicyContextV0(
+            position_state=PositionState.OPEN_FULL,
+            existing_position_side=ExistingPositionSide.SHORT,
+            venue_flat=False,
+        )
+    if side_state is SideState.SWITCH_LONG_TO_SHORT_PENDING:
+        return ScenarioEntryExitPolicyContextV0(
+            position_state=PositionState.OPEN_FULL,
+            existing_position_side=ExistingPositionSide.LONG,
+            venue_flat=False,
+        )
+    if side_state is SideState.SWITCH_SHORT_TO_LONG_PENDING:
+        return ScenarioEntryExitPolicyContextV0(
+            position_state=PositionState.OPEN_FULL,
+            existing_position_side=ExistingPositionSide.SHORT,
+            venue_flat=False,
+        )
+    if side_state is SideState.LONG_BLOCKED:
+        return ScenarioEntryExitPolicyContextV0(
+            position_state=PositionState.EXIT_PENDING,
+            existing_position_side=ExistingPositionSide.LONG,
+            venue_flat=False,
+        )
+    if side_state is SideState.SHORT_BLOCKED:
+        return ScenarioEntryExitPolicyContextV0(
+            position_state=PositionState.EXIT_PENDING,
+            existing_position_side=ExistingPositionSide.SHORT,
+            venue_flat=False,
+        )
+    return None
+
+
+def merge_flat_before_opposite_side_policy_context_v0(
+    *,
+    side_state: SideState,
+    policy_context: ScenarioEntryExitPolicyContextV0,
+) -> ScenarioEntryExitPolicyContextV0:
+    """Merge side-state position evidence into scenario policy context; preserve explicit overrides."""
+    if policy_context.position_state in _EXPLICIT_POSITION_OVERRIDE_STATES:
+        return policy_context
+    derived = derive_flat_before_opposite_side_position_context_v0(side_state)
+    if derived is None:
+        return policy_context
+    return replace(
+        policy_context,
+        position_state=derived.position_state,
+        existing_position_side=derived.existing_position_side,
+        venue_flat=derived.venue_flat,
+        reconciliation_state=policy_context.reconciliation_state,
+        safety_decision_allowed=policy_context.safety_decision_allowed,
+        scope_adverse_exit_signal=policy_context.scope_adverse_exit_signal,
+        profit_protection_signal=policy_context.profit_protection_signal,
+        time_exit_signal=policy_context.time_exit_signal,
+        strategy_invalidation_signal=policy_context.strategy_invalidation_signal,
+        hard_risk_reduction_signal=policy_context.hard_risk_reduction_signal,
+        safety_exit_signal=policy_context.safety_exit_signal,
+    )
+
+
+def evaluate_scenario_flat_before_opposite_side_entry_exit_v0(
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+    context_reference: str,
+    composition_result: DoublePlayCompositionResultV1,
+    side_state: SideState,
+    policy_context: ScenarioEntryExitPolicyContextV0,
+) -> EntryExitPolicyDecisionV0:
+    """Evaluate entry-exit with flat-before-opposite-side binding through canonical policy."""
+    merged_ctx = merge_flat_before_opposite_side_policy_context_v0(
+        side_state=side_state,
+        policy_context=policy_context,
+    )
+    return evaluate_scenario_reversal_preparation_entry_exit_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+        composition_result=composition_result,
+        side_state=side_state,
+        policy_context=merged_ctx,
+    )
+
+
+def flat_before_opposite_side_blocks_opposite_entry_v0(
+    decision: EntryExitPolicyDecisionV0,
+) -> bool:
+    if decision.position_flip_allowed:
+        return False
+    if decision.decision_outcome in (DecisionOutcome.ENTER_LONG, DecisionOutcome.ENTER_SHORT):
+        return False
+    return True
+
+
+def flat_before_opposite_side_binding_non_authority_boundary_ok_v0(
+    decision: EntryExitPolicyDecisionV0,
+) -> bool:
+    if decision.runtime_effect != RUNTIME_AUTHORITY_EFFECT_NONE:
+        return False
+    if decision.authority_effect != RUNTIME_AUTHORITY_EFFECT_NONE:
+        return False
+    if decision.execution_eligible:
+        return False
+    if decision.adapter_compatible:
+        return False
+    return True
+
+
+def system_economic_evidence_admissible_v0() -> bool:
+    return False
+
+
+def canonical_entry_exit_owner_ref_v0() -> str:
+    return CANONICAL_ENTRY_EXIT_POLICY_OWNER

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -25,7 +25,7 @@ MatrixStatus = Literal[
     "UNKNOWN",
 ]
 
-NEXT_RECOMMENDED_SLICE = "FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+NEXT_RECOMMENDED_SLICE = "SURVIVAL_SUITABILITY_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
 
 ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
@@ -84,6 +84,9 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
     "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
     "tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py",
+    "src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py",
+    "scripts/ops/run_flat_before_opposite_side_scenario_replay_binding_parity_rewire_v0.py",
+    "tests/trading/master_v2/test_flat_before_opposite_side_scenario_replay_binding_parity_rewire_contract_v0.py",
     "docs/research/FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_V0.md",
 )
 
@@ -224,8 +227,10 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
                 " + evaluate_double_play_entry_exit_policy_v0() flat/flip gates"
             ),
             current_scenario_replay_binding=(
-                "offline_double_play_scenario_replay_v0 -> transition_state() only;"
-                " entry-exit policy not per tick"
+                "offline_double_play_scenario_replay_v0"
+                " -> evaluate_scenario_flat_before_opposite_side_entry_exit_v0()"
+                " -> evaluate_double_play_entry_exit_policy_v0()"
+                " flat/flip gates per tick"
             ),
             current_backtest_binding=(
                 "Integrated replay defaults venue_flat=True, ExistingPositionSide.NONE"
@@ -233,15 +238,13 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
             current_runtime_semantics_reference=(
                 "double_play_state.transition_state (DOUBLE_PLAY_BULL_BEAR_REFERENCE_V0)"
             ),
-            parity_status="PARTIAL",
+            parity_status="PASS",
             evidence_refs=(
                 "tests/trading/master_v2/test_double_play_entry_exit_policy_v0.py",
                 "tests/trading/master_v2/test_offline_master_v2_double_play_scenario_replay_binding_contract_v0.py",
+                "tests/trading/master_v2/test_flat_before_opposite_side_scenario_replay_binding_parity_rewire_contract_v0.py",
             ),
-            missing_binding_if_any=(
-                "Scenario replay -> evaluate_double_play_entry_exit_policy_v0()"
-                " for flat-before-opposite-side invariant"
-            ),
+            missing_binding_if_any="",
             recommended_next_slice=NEXT_RECOMMENDED_SLICE,
         ),
         ParitySurfaceAssessmentV0(

--- a/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
+++ b/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
@@ -91,6 +91,9 @@ from trading.master_v2.reversal_preparation_scenario_binding_adapter_v0 import (
     evaluate_scenario_reversal_preparation_entry_exit_v0,
     reversal_preparation_binding_non_authority_boundary_ok_v0,
 )
+from trading.master_v2.flat_before_opposite_side_scenario_binding_adapter_v0 import (
+    FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_BINDING_ADAPTER_OWNER,
+)
 from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
     CANONICAL_ENTRY_EXIT_POLICY_OWNER,
     DOUBLE_PLAY_ENTRY_EXIT_SCENARIO_BINDING_ADAPTER_OWNER,
@@ -968,6 +971,9 @@ def canonical_owner_refs_v0() -> Mapping[str, str]:
         ),
         "reversal_preparation_scenario_binding_adapter": (
             REVERSAL_PREPARATION_SCENARIO_BINDING_ADAPTER_OWNER
+        ),
+        "flat_before_opposite_side_scenario_binding_adapter": (
+            FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_BINDING_ADAPTER_OWNER
         ),
         "runtime_state_reconciliation": RUNTIME_STATE_RECONCILIATION_OWNER,
         "reconciliation_entry_exit_policy": RECONCILIATION_ENTRY_EXIT_POLICY_OWNER,

--- a/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
+++ b/src/trading/master_v2/offline_double_play_scenario_replay_v0.py
@@ -90,8 +90,8 @@ from trading.master_v2.scope_event_generator_scenario_binding_adapter_v0 import 
     ScenarioScopeEventContextV0,
     evaluate_scenario_scope_event_v0,
 )
-from trading.master_v2.reversal_preparation_scenario_binding_adapter_v0 import (
-    evaluate_scenario_reversal_preparation_entry_exit_v0,
+from trading.master_v2.flat_before_opposite_side_scenario_binding_adapter_v0 import (
+    evaluate_scenario_flat_before_opposite_side_entry_exit_v0,
 )
 from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
     default_scenario_entry_exit_policy_context_v0,
@@ -863,7 +863,7 @@ def run_offline_double_play_scenario_replay_v0(
             ),
             scope_adverse_exit_signal=scope_event_binding.scope_adverse_exit_signal,
         )
-        entry_exit_decision = evaluate_scenario_reversal_preparation_entry_exit_v0(
+        entry_exit_decision = evaluate_scenario_flat_before_opposite_side_entry_exit_v0(
             instrument_id=inp.selected_future_id,
             trading_epoch=tick.tick_index,
             context_reference=f"{inp.correlation_id_prefix}-tick-{tick.tick_index}",

--- a/tests/trading/master_v2/test_flat_before_opposite_side_scenario_replay_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_flat_before_opposite_side_scenario_replay_binding_parity_rewire_contract_v0.py
@@ -1,0 +1,324 @@
+"""Flat-before-opposite-side binding parity: scenario replay entry-exit path (offline only)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from trading.master_v2.double_play_composition_matrix_v1 import (
+    CompositionSelectedSide,
+    CompositionStatus,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import (
+    DecisionOutcome,
+    ExistingPositionSide,
+    PositionState,
+    ReconciliationState,
+)
+from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
+    CANONICAL_ENTRY_EXIT_POLICY_OWNER,
+    ScenarioEntryExitPolicyContextV0,
+    default_scenario_entry_exit_policy_context_v0,
+)
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    ALLOWED_SLICE_CHANGED_PATH_PREFIXES,
+    NEXT_RECOMMENDED_SLICE,
+    parity_surface_assessments_v0,
+    parity_status_counts_v0,
+    scan_changed_paths_for_forbidden_runtime_v0,
+)
+from trading.master_v2.flat_before_opposite_side_scenario_binding_adapter_v0 import (
+    FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_BINDING_ADAPTER_OWNER,
+    derive_flat_before_opposite_side_position_context_v0,
+    evaluate_scenario_flat_before_opposite_side_entry_exit_v0,
+    flat_before_opposite_side_binding_non_authority_boundary_ok_v0,
+    flat_before_opposite_side_blocks_opposite_entry_v0,
+    merge_flat_before_opposite_side_policy_context_v0,
+)
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    canonical_owner_refs_v0,
+    evaluate_scenario_matrix_for_side_state_v0,
+)
+from trading.master_v2.offline_double_play_scenario_replay_v0 import (
+    OFFLINE_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER,
+    OfflineDoublePlayScenarioReplayInputV0,
+    SYNTHETIC_FUTURES_INSTRUMENT,
+    build_default_bull_bear_bull_scenario_ticks,
+    run_offline_double_play_scenario_replay_v0,
+)
+from trading.master_v2.double_play_state import SideState
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_INSTRUMENT = SYNTHETIC_FUTURES_INSTRUMENT
+_EPOCH = 54
+_CONTEXT = "flat-before-opposite-side-binding-parity-v0"
+
+_SLICE_CHANGED_FILES = ALLOWED_SLICE_CHANGED_PATH_PREFIXES
+
+_FORBIDDEN_IMPORT_SCAN_PATHS = (
+    REPO_ROOT / "src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py",
+    REPO_ROOT
+    / "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    REPO_ROOT
+    / "scripts/ops/run_flat_before_opposite_side_scenario_replay_binding_parity_rewire_v0.py",
+    REPO_ROOT
+    / "tests/trading/master_v2/test_flat_before_opposite_side_scenario_replay_binding_parity_rewire_contract_v0.py",
+)
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def _short_selected_matrix():
+    return evaluate_scenario_matrix_for_side_state_v0(
+        side_state=SideState.SHORT_ARMED,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+
+
+def _long_selected_matrix():
+    return evaluate_scenario_matrix_for_side_state_v0(
+        side_state=SideState.LONG_ARMED,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+
+
+def test_owner_constants_and_canonical_reuse_v0() -> None:
+    refs = canonical_owner_refs_v0()
+    assert refs["entry_exit_policy"] == CANONICAL_ENTRY_EXIT_POLICY_OWNER
+    assert (
+        refs["flat_before_opposite_side_scenario_binding_adapter"]
+        == FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_BINDING_ADAPTER_OWNER
+    )
+    assert refs["scenario_replay"] == OFFLINE_DOUBLE_PLAY_SCENARIO_REPLAY_OWNER
+
+
+def test_forbidden_runtime_paths_guard_v0() -> None:
+    ok, violations = scan_changed_paths_for_forbidden_runtime_v0(_SLICE_CHANGED_FILES)
+    assert ok is True
+    assert violations == ()
+
+
+def test_slice_sources_exclude_execution_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "execution",
+            "scheduler",
+            "credentials",
+            "live_runtime",
+            "testnet",
+            "shadow",
+            "paper_lane",
+        }
+    )
+    for path in _FORBIDDEN_IMPORT_SCAN_PATHS:
+        assert path.is_file(), f"missing slice source: {path}"
+        hits = _scan_forbidden_imports(path, forbidden)
+        assert hits == [], f"forbidden imports in {path}: {hits}"
+
+
+def test_derive_long_active_open_position_context_v0() -> None:
+    derived = derive_flat_before_opposite_side_position_context_v0(SideState.LONG_ACTIVE)
+    assert derived is not None
+    assert derived.position_state is PositionState.OPEN_FULL
+    assert derived.existing_position_side is ExistingPositionSide.LONG
+    assert derived.venue_flat is False
+
+
+def test_derive_switch_pending_preserves_open_position_v0() -> None:
+    derived = derive_flat_before_opposite_side_position_context_v0(
+        SideState.SWITCH_LONG_TO_SHORT_PENDING
+    )
+    assert derived is not None
+    assert derived.existing_position_side is ExistingPositionSide.LONG
+
+
+def test_1_opposite_side_candidate_while_position_not_flat_blocked_v0() -> None:
+    matrix = _short_selected_matrix()
+    ctx = default_scenario_entry_exit_policy_context_v0()
+    decision = evaluate_scenario_flat_before_opposite_side_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=ctx,
+    )
+    assert decision.decision_outcome is not DecisionOutcome.ENTER_SHORT
+    assert flat_before_opposite_side_blocks_opposite_entry_v0(decision)
+    assert decision.position_flip_allowed is False
+
+
+def test_2_opposite_side_candidate_reconciliation_unresolved_blocked_v0() -> None:
+    matrix = _short_selected_matrix()
+    ctx = ScenarioEntryExitPolicyContextV0(
+        position_state=PositionState.RECONCILIATION_REQUIRED,
+        reconciliation_state=ReconciliationState.RECONCILIATION_REQUIRED,
+        existing_position_side=ExistingPositionSide.NONE,
+        venue_flat=True,
+    )
+    decision = evaluate_scenario_flat_before_opposite_side_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.SHORT_ARMED,
+        policy_context=ctx,
+    )
+    assert decision.decision_outcome is DecisionOutcome.RECONCILE_ONLY
+    assert decision.decision_outcome is not DecisionOutcome.ENTER_SHORT
+    assert flat_before_opposite_side_blocks_opposite_entry_v0(decision)
+
+
+def test_3_venue_flat_without_reconciled_state_blocked_v0() -> None:
+    matrix = _long_selected_matrix()
+    ctx = ScenarioEntryExitPolicyContextV0(
+        position_state=PositionState.RECONCILIATION_REQUIRED,
+        reconciliation_state=ReconciliationState.RECONCILED,
+        existing_position_side=ExistingPositionSide.NONE,
+        venue_flat=True,
+    )
+    decision = evaluate_scenario_flat_before_opposite_side_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.LONG_ARMED,
+        policy_context=ctx,
+    )
+    assert decision.decision_outcome is DecisionOutcome.RECONCILE_ONLY
+    assert decision.decision_outcome is not DecisionOutcome.ENTER_LONG
+
+
+def test_4_reconciled_flat_opposite_entry_via_canonical_policy_only_v0() -> None:
+    matrix = _long_selected_matrix()
+    ctx = default_scenario_entry_exit_policy_context_v0()
+    decision = evaluate_scenario_flat_before_opposite_side_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.LONG_ARMED,
+        policy_context=ctx,
+    )
+    assert decision.decision_outcome is DecisionOutcome.ENTER_LONG
+    assert decision.position_flip_allowed is False
+    assert flat_before_opposite_side_binding_non_authority_boundary_ok_v0(decision)
+
+
+def test_no_direct_long_to_short_shortcut_v0() -> None:
+    matrix = evaluate_scenario_matrix_for_side_state_v0(
+        side_state=SideState.SHORT_ACTIVE,
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+    )
+    if matrix.composition_status is not CompositionStatus.SHORT_SELECTED:
+        matrix = _short_selected_matrix()
+    ctx = merge_flat_before_opposite_side_policy_context_v0(
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=default_scenario_entry_exit_policy_context_v0(),
+    )
+    decision = evaluate_scenario_flat_before_opposite_side_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=ctx,
+    )
+    assert decision.decision_outcome is not DecisionOutcome.ENTER_SHORT
+    assert matrix.selected_side is not CompositionSelectedSide.LONG
+
+
+def test_adapter_no_runtime_order_authority_v0() -> None:
+    matrix = _long_selected_matrix()
+    decision = evaluate_scenario_flat_before_opposite_side_entry_exit_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        composition_result=matrix,
+        side_state=SideState.LONG_ARMED,
+        policy_context=default_scenario_entry_exit_policy_context_v0(),
+    )
+    assert decision.runtime_effect == "NONE"
+    assert decision.authority_effect == "NONE"
+    assert decision.execution_eligible is False
+
+
+def test_scenario_replay_e2e_flat_before_opposite_side_binding_v0() -> None:
+    result = run_offline_double_play_scenario_replay_v0(
+        OfflineDoublePlayScenarioReplayInputV0(
+            selected_future_id=_INSTRUMENT,
+            ticks=build_default_bull_bear_bull_scenario_ticks(),
+            source_revision="flat-before-opposite-side-binding-parity-v0",
+        )
+    )
+    assert result.replay_pass, result.fail_reasons
+    assert result.summary.orders_total == 0
+
+
+def test_gap_assessment_surface_d_pass_v0() -> None:
+    surface_d = next(item for item in parity_surface_assessments_v0() if item.surface_id == "D")
+    assert surface_d.parity_status == "PASS"
+    assert surface_d.missing_binding_if_any == ""
+    assert "evaluate_scenario_flat_before_opposite_side_entry_exit_v0" in (
+        surface_d.current_scenario_replay_binding
+    )
+
+
+def test_gap_assessment_surface_c_still_pass_v0() -> None:
+    surface_c = next(item for item in parity_surface_assessments_v0() if item.surface_id == "C")
+    assert surface_c.parity_status == "PASS"
+
+
+def test_gap_assessment_e_p_unchanged_partial_v0() -> None:
+    surface_e = next(item for item in parity_surface_assessments_v0() if item.surface_id == "E")
+    surface_p = next(item for item in parity_surface_assessments_v0() if item.surface_id == "P")
+    assert surface_e.parity_status == "PARTIAL"
+    assert surface_p.parity_status == "PARTIAL"
+
+
+def test_gap_assessment_status_distribution_v0() -> None:
+    counts = parity_status_counts_v0()
+    assert counts["PASS"] == 14
+    assert counts["PARTIAL"] == 2
+    assert counts["GAP"] == 0
+
+
+def test_next_recommended_slice_points_to_surface_e_v0() -> None:
+    assert NEXT_RECOMMENDED_SLICE == "SURVIVAL_SUITABILITY_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
+
+
+def test_reversal_preparation_contracts_still_pass_v0() -> None:
+    from tests.trading.master_v2 import (
+        test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0 as pr4969,
+    )
+
+    pr4969.test_scenario_reversal_preparation_exit_via_canonical_policy_v0()
+    pr4969.test_reversal_preparation_no_enter_opposite_side_v0()
+    pr4969.test_reversal_preparation_reduce_only_preparation_bound_v0()
+
+
+def test_pr4946_parity_suite_still_passes_v0() -> None:
+    from tests.trading.master_v2 import (
+        test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0 as pr4946,
+    )
+
+    pr4946.test_5_reversal_preparation_boundary_parity_v0()
+    pr4946.test_scenario_replay_e2e_composition_and_zero_order_boundary_v0()

--- a/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
+++ b/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
@@ -58,8 +58,8 @@ def test_gap_assessment_owner_and_surface_count_v0() -> None:
 
 def test_gap_assessment_status_distribution_v0() -> None:
     counts = parity_status_counts_v0()
-    assert counts["PASS"] == 13
-    assert counts["PARTIAL"] >= 3
+    assert counts["PASS"] == 14
+    assert counts["PARTIAL"] >= 2
     assert counts["GAP"] == 0
     assert counts["NOT_APPLICABLE"] == 0
     assert sum(counts.values()) == 16
@@ -86,6 +86,17 @@ def test_reversal_preparation_surface_pass_v0() -> None:
     assert reversal.missing_binding_if_any == ""
     assert "evaluate_scenario_reversal_preparation_entry_exit_v0" in (
         reversal.current_scenario_replay_binding
+    )
+
+
+def test_flat_before_opposite_side_surface_pass_v0() -> None:
+    flat_invariant = next(
+        item for item in parity_surface_assessments_v0() if item.surface_id == "D"
+    )
+    assert flat_invariant.parity_status == "PASS"
+    assert flat_invariant.missing_binding_if_any == ""
+    assert "evaluate_scenario_flat_before_opposite_side_entry_exit_v0" in (
+        flat_invariant.current_scenario_replay_binding
     )
 
 

--- a/tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py
@@ -227,18 +227,17 @@ def test_project_composition_sets_opposite_selected_side_v0() -> None:
 
 def test_surface_c_pass_dep_unchanged_partial_v0() -> None:
     counts = parity_status_counts_v0()
-    assert counts["PASS"] == 13
-    assert counts["PARTIAL"] == 3
+    assert counts["PASS"] == 14
+    assert counts["PARTIAL"] == 2
     surface_c = next(item for item in parity_surface_assessments_v0() if item.surface_id == "C")
     assert surface_c.parity_status == "PASS"
     assert surface_c.missing_binding_if_any == ""
-    for surface_id in ("D", "E", "P"):
+    surface_d = next(item for item in parity_surface_assessments_v0() if item.surface_id == "D")
+    assert surface_d.parity_status == "PASS"
+    for surface_id in ("E", "P"):
         item = next(s for s in parity_surface_assessments_v0() if s.surface_id == surface_id)
         assert item.parity_status == "PARTIAL"
-    assert (
-        NEXT_RECOMMENDED_SLICE
-        == "FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
-    )
+    assert NEXT_RECOMMENDED_SLICE == "SURVIVAL_SUITABILITY_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
 
 
 def test_default_scenario_replay_still_passes_v0() -> None:

--- a/tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py
@@ -252,21 +252,20 @@ def test_adapter_output_decision_bound_no_runtime_order_authority_v0() -> None:
 
 def test_surface_b_pass_cde_remain_partial_v0() -> None:
     counts = parity_status_counts_v0()
-    assert counts["PASS"] == 13
-    assert counts["PARTIAL"] == 3
+    assert counts["PASS"] == 14
+    assert counts["PARTIAL"] == 2
     surface_b = next(item for item in parity_surface_assessments_v0() if item.surface_id == "B")
     assert surface_b.parity_status == "PASS"
     assert surface_b.missing_binding_if_any == ""
     surface_c = next(item for item in parity_surface_assessments_v0() if item.surface_id == "C")
     assert surface_c.parity_status == "PASS"
     assert surface_c.missing_binding_if_any == ""
-    for surface_id in ("D", "E"):
+    surface_d = next(item for item in parity_surface_assessments_v0() if item.surface_id == "D")
+    assert surface_d.parity_status == "PASS"
+    for surface_id in ("E", "P"):
         item = next(s for s in parity_surface_assessments_v0() if s.surface_id == surface_id)
         assert item.parity_status == "PARTIAL"
-    assert (
-        NEXT_RECOMMENDED_SLICE
-        == "FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
-    )
+    assert NEXT_RECOMMENDED_SLICE == "SURVIVAL_SUITABILITY_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0"
 
 
 def test_scenario_replay_e2e_wires_generator_per_tick_v0() -> None:


### PR DESCRIPTION
## Summary
- Wire Surface D (flat-before-opposite-side invariant) in scenario replay through the canonical `evaluate_double_play_entry_exit_policy_v0()` owner via a reuse-first adapter.
- Derive position/reconciliation context from side-state pipeline evidence (`LONG_ACTIVE`, `SWITCH_*_PENDING`, `*_BLOCKED`, etc.) per tick; chain through existing reversal-preparation adapter without new policy owners.
- Update gap registry: Surface D **PASS** (14 PASS / 2 PARTIAL). Surface C remains **PASS**; E/P remain **UNCHANGED_PARTIAL**.

## Reuse-First Owner
- Canonical: `trading.master_v2.double_play_entry_exit_policy_v0`
- Adapter: `trading.master_v2.flat_before_opposite_side_scenario_binding_adapter_v0`
- Scenario binding: `evaluate_scenario_flat_before_opposite_side_entry_exit_v0()`

## Tests
- `tests/trading/master_v2/test_flat_before_opposite_side_scenario_replay_binding_parity_rewire_contract_v0.py` (negative cases: non-flat, unresolved reconciliation, venue-flat-only, reconciled-flat canonical entry)
- Regression: PR4969 reversal-preparation, scope-event, entry-exit, bull/bear switch, parity suite, offline scenario replay, gap assessment (159 passed)

## Evidence Bundle
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/flat_before_opposite_side_scenario_replay_binding_parity_rewire_v0_20260707T174228Z`
- MANIFEST_VERIFY_RC=0
- VERDICT=FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0_PASS

## Authority Flags (all false / no authority)
- NO_RUNTIME_AUTHORITY=true
- NO_ORDER_SUBMISSION=true
- NO_ADAPTER_SUBMISSION=true
- LIVE/SHADOW/PAPER/TESTNET/SCHEDULER/ARMING: false

## Residual Gaps
- Surface E: UNCHANGED_PARTIAL (survival/suitability direct binding)
- Surface P: UNCHANGED_PARTIAL (full 4-way parity suite)
- NEXT_RECOMMENDED_SLICE=SURVIVAL_SUITABILITY_SCENARIO_REPLAY_BINDING_PARITY_REWIRE_V0

## Test plan
- [x] Targeted pytest (159 tests)
- [x] ruff format --check
- [x] ruff check
- [x] Evidence manifest RC=0

Made with [Cursor](https://cursor.com)