### PR TITLE
fix(backtest): preserve parameter sensitivity pipeline status contract

### DIFF
--- a/src/backtest/parameter_sensitivity_v1.py
+++ b/src/backtest/parameter_sensitivity_v1.py
@@ -777,8 +777,6 @@ def run_parameter_sensitivity_v1(
     if failed_count:
         reason_codes.append("parameter_points_failed")
     pipeline_status = PipelineStatus.PIPELINE_PASS
-    if failed_count == len(points) and points:
-        pipeline_status = PipelineStatus.PIPELINE_FAILED
 
     result_payload = {
         "grid_digest": grid.grid_digest,


### PR DESCRIPTION
## Summary
- Stop mapping all failed parameter points to `PIPELINE_FAILED` when the sensitivity pipeline still executed and persisted the full grid.
- Keep policy and point-level outcomes on `parameter_robustness_policy_*`, `failed_point_count`, and per-point `evaluation_status`.

## Test plan
- [x] `python -m pytest -q tests/backtest/test_parameter_sensitivity_v1.py --tb=short --durations=20`
- [x] `python -m pytest -q tests/backtest/test_parameter_sensitivity_v1.py tests/ci/test_cursor_auto_pr_pre_pr_validation_enforcement_contract_v0.py::test_pre_pr_result_file_not_on_main_after_cleanup --tb=short --durations=20`
- [x] `ruff format --check .`
- [x] `ruff check .`

Evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/parameter_sensitivity_pipeline_status_contract_fix_v0_20260707T192933Z`