### PR TITLE
test(trading): rewire surface p full system parity harness

### DIFF
--- a/scripts/ops/run_integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0.py
+++ b/scripts/ops/run_integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for Surface P full-system 4-way parity rewire v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+BASE_HEAD = "e2c345863c0f8fdaee215e32a4c6d4459b439061"
+BOUNDED_SELECTOR_EVIDENCE = (
+    ARCHIVE_ROOT
+    / "research/bounded_selector_retry_surface_p_after_pr4974_hang_recovery_v0_20260707T201702Z"
+)
+VERDICT = "INTEGRATED_VS_SCENARIO_REPLAY_FULL_SYSTEM_4_WAY_PARITY_REWIRE_V0_PASS"
+PROCESS_CLASSIFICATION = "NARROW_REUSE_FIRST_4_WAY_PARITY_REWIRE_OFFLINE_ONLY"
+SCOPE_CLASSIFICATION = (
+    "SURFACE_P_INTEGRATED_SCENARIO_BACKTEST_RUNTIME_REFERENCE_4_WAY_PARITY_"
+    "NO_RUNTIME_AUTHORITY_NO_ORDERS_V0"
+)
+TARGETED_TESTS = (
+    "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    "scripts/ops/run_integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+)
+REUSED_OWNERS = (
+    "trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0",
+    "trading.master_v2.integrated_offline_trading_logic_replay_v1",
+    "trading.master_v2.offline_double_play_scenario_replay_v0",
+    "backtest.mv2_research_wiring_v1",
+    "trading.master_v2.canonical_core_runtime_integration_bridge_v0",
+    "trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.rglob("*")):
+        if path.is_dir() or path.name == "MANIFEST.sha256":
+            continue
+        rel = path.relative_to(evidence_dir).as_posix()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  ./{rel}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def _verify_source_manifest(path: Path, label: str) -> tuple[int, str]:
+    if not path.is_dir():
+        return 1, f"{label}_ABSENT=true\n{label}_MANIFEST_VERIFY_RC=1\n"
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=path)
+    log = (
+        proc.stdout
+        + proc.stderr
+        + f"\n{label}_PATH={path}\n{label}_MANIFEST_VERIFY_RC={proc.returncode}\n"
+    )
+    return proc.returncode, log
+
+
+def collect_evidence(out_dir: Path | None = None) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT
+        / f"research/integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    status = _run(["git", "status", "--short"]).stdout.strip()
+
+    selector_rc, selector_log = _verify_source_manifest(
+        BOUNDED_SELECTOR_EVIDENCE,
+        "BOUNDED_SELECTOR",
+    )
+    (evidence_dir / "source_manifest_reverify.log").write_text(selector_log, encoding="utf-8")
+
+    (evidence_dir / "PREFLIGHT.env").write_text(
+        "\n".join(
+            [
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"BASE_HEAD={BASE_HEAD}",
+                f"WORKTREE_STATUS={status or 'clean'}",
+                f"BOUNDED_SELECTOR_EVIDENCE={BOUNDED_SELECTOR_EVIDENCE}",
+                f"BOUNDED_SELECTOR_MANIFEST_VERIFY_RC={selector_rc}",
+                "OFFLINE_ONLY=true",
+                "NO_RUNTIME_AUTHORITY=true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "reused_owners.txt").write_text(
+        "\n".join(REUSED_OWNERS) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "changed_files.txt").write_text(
+        "\n".join(SLICE_CHANGED_FILES) + "\n",
+        encoding="utf-8",
+    )
+
+    collect_proc = _run(
+        ["pytest", "--collect-only", "-q", *TARGETED_TESTS],
+    )
+    (evidence_dir / "bounded_collect_only.log").write_text(
+        collect_proc.stdout + collect_proc.stderr,
+        encoding="utf-8",
+    )
+
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    pytest_proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (evidence_dir / "targeted_pytest.log").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    touched = [REPO_ROOT / rel for rel in SLICE_CHANGED_FILES if rel.endswith(".py")]
+    ruff_format = _run(["ruff", "format", "--check", *[str(p) for p in touched]])
+    ruff_check = _run(["ruff", "check", *[str(p) for p in touched]])
+    (evidence_dir / "ruff_format_check.log").write_text(
+        ruff_format.stdout + ruff_format.stderr,
+        encoding="utf-8",
+    )
+    (evidence_dir / "ruff_check.log").write_text(
+        ruff_check.stdout + ruff_check.stderr,
+        encoding="utf-8",
+    )
+
+    diff_proc = _run(["git", "diff", f"{BASE_HEAD}...HEAD"])
+    (evidence_dir / "git_diff.patch").write_text(diff_proc.stdout, encoding="utf-8")
+
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+        parity_surface_assessments_v0,
+        render_parity_gap_matrix_json_v0,
+    )
+
+    surface_p = next(item for item in parity_surface_assessments_v0() if item.surface_id == "P")
+    (evidence_dir / "surface_p_assessment.json").write_text(
+        json.dumps(
+            {
+                "surface_id": surface_p.surface_id,
+                "parity_status": surface_p.parity_status,
+                "missing_binding": surface_p.missing_binding_if_any,
+                "recommended_next_slice": surface_p.recommended_next_slice,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "gap_matrix.json").write_text(
+        render_parity_gap_matrix_json_v0(),
+        encoding="utf-8",
+    )
+
+    manifest_rc = _write_manifest(evidence_dir)
+    tests_pass = pytest_proc.returncode == 0 and collect_proc.returncode == 0
+    ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0
+    verdict = (
+        VERDICT
+        if tests_pass and ruff_pass and manifest_rc == 0 and selector_rc == 0
+        else ("INTEGRATED_VS_SCENARIO_REPLAY_FULL_SYSTEM_4_WAY_PARITY_REWIRE_V0_BLOCKED")
+    )
+
+    (evidence_dir / "FINAL_REPORT.env").write_text(
+        "\n".join(
+            [
+                f"VERDICT={verdict}",
+                f"PROCESS_CLASSIFICATION={PROCESS_CLASSIFICATION}",
+                f"SCOPE_CLASSIFICATION={SCOPE_CLASSIFICATION}",
+                f"BASE_HEAD={BASE_HEAD}",
+                f"HEAD={head}",
+                f"TARGETED_PYTEST_RC={pytest_proc.returncode}",
+                f"RUFF_CHECK_RC={ruff_check.returncode}",
+                f"RUFF_FORMAT_CHECK_RC={ruff_format.returncode}",
+                f"BOUNDED_SELECTOR_MANIFEST_VERIFY_RC={selector_rc}",
+                f"SURFACE_P_STATUS={surface_p.parity_status}",
+                "FULL_CANONICAL_CHAIN_WIRED=false",
+                "BACKTEST_RUNTIME_DECISION_PARITY_PASS=false",
+                f"DURABLE_EVIDENCE_DIR={evidence_dir}",
+                f"MANIFEST_VERIFY_RC={manifest_rc}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_rc = _write_manifest(evidence_dir)
+
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_verify_rc": manifest_rc,
+        "tests_pass": tests_pass,
+        "ruff_pass": ruff_pass,
+        "selector_rc": selector_rc,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(args.out)
+    print(f"VERDICT={result['verdict']}")
+    print(f"DURABLE_EVIDENCE_DIR={result['evidence_dir']}")
+    print(f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}")
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -25,7 +25,7 @@ MatrixStatus = Literal[
     "UNKNOWN",
 ]
 
-NEXT_RECOMMENDED_SLICE = "INTEGRATED_VS_SCENARIO_REPLAY_FULL_SYSTEM_4_WAY_PARITY_REWIRE_V0"
+NEXT_RECOMMENDED_SLICE = "FULL_CANONICAL_BACKTEST_BOUNDARY_CHAIN_REASSESSMENT_V0"
 
 ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
@@ -88,6 +88,9 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "scripts/ops/run_flat_before_opposite_side_scenario_replay_binding_parity_rewire_v0.py",
     "tests/trading/master_v2/test_flat_before_opposite_side_scenario_replay_binding_parity_rewire_contract_v0.py",
     "docs/research/FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_V0.md",
+    "scripts/ops/run_integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0.py",
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
 )
 
 FORBIDDEN_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
@@ -625,21 +628,27 @@ def parity_surface_assessments_v0() -> Tuple[ParitySurfaceAssessmentV0, ...]:
             current_scenario_replay_binding=(
                 "run_offline_double_play_scenario_replay_v0() + matrix adapter"
             ),
-            current_backtest_binding=("run_mv2_research_backtest_wiring_v1() -> integrated only"),
+            current_backtest_binding=(
+                "evaluate_surface_p_four_way_parity_v0() ->"
+                " bind_backtest_bar_four_way_parity_lane_v0() via"
+                " integrated_vs_scenario_replay_full_system_parity_harness_v0"
+            ),
             current_runtime_semantics_reference=(
                 "canonical_core_runtime_integration_bridge_v0 +"
                 " canonical_core_runtime_integration_intent_pipeline_bridge_v0"
-                " both BOUND_NOT_ACTIVATED"
+                " both BOUND_NOT_ACTIVATED; runtime reference lane bound offline"
             ),
             parity_status="PARTIAL",
             evidence_refs=(
                 "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
                 "scripts/ops/run_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+                "scripts/ops/run_integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0.py",
                 "docs/governance/authority_conflict_matrix_v1.md",
             ),
             missing_binding_if_any=(
-                "Full 4-way parity suite including backtest bar wiring,"
-                " runtime bridge activation, entry-exit/capital/intent surfaces"
+                "Runtime bridge activation remains BOUND_NOT_ACTIVATED by policy;"
+                " full bar-sequence 4-way parity across all entry-exit/capital/intent"
+                " fixture cases not yet complete"
             ),
             recommended_next_slice=NEXT_RECOMMENDED_SLICE,
         ),

--- a/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
+++ b/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
@@ -127,10 +127,18 @@ INTEGRATED_VS_SCENARIO_REPLAY_FULL_SYSTEM_PARITY_HARNESS_OWNER = (
     "trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0"
 )
 
+FOUR_WAY_PARITY_REWIRE_SLICE_ID = "INTEGRATED_VS_SCENARIO_REPLAY_FULL_SYSTEM_4_WAY_PARITY_REWIRE_V0"
+RUNTIME_REFERENCE_INTEGRATION_STATUS_V0 = "BOUND_NOT_ACTIVATED"
+BACKTEST_PARITY_WIRING_OWNER = "backtest.mv2_research_wiring_v1"
+RUNTIME_BRIDGE_REFERENCE_OWNER = "trading.master_v2.canonical_core_runtime_integration_bridge_v0"
+
 ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
     "scripts/ops/run_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+    "scripts/ops/run_integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
     "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
 )
 
 FORBIDDEN_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
@@ -184,6 +192,19 @@ class ParityCaseV0:
     side_state: SideState
     expected_composition_status: CompositionStatus
     requested_side: RequestedSide = RequestedSide.NEUTRAL_OBSERVE
+
+
+@dataclass(frozen=True)
+class FullSystemFourWayParityAssessmentV0:
+    integrated_lane_bound: bool
+    scenario_lane_bound: bool
+    backtest_lane_bound: bool
+    runtime_reference_lane_bound: bool
+    integrated_scenario_composition_aligned: bool
+    backtest_non_authority_confirmed: bool
+    runtime_reference_non_authority_confirmed: bool
+    four_way_parity_rewire_bound: bool
+    fail_closed_reasons: Tuple[str, ...] = ()
 
 
 def evaluate_scenario_matrix_for_side_state_v0(
@@ -970,6 +991,8 @@ def canonical_owner_refs_v0() -> Mapping[str, str]:
         ),
         "runtime_state_reconciliation": RUNTIME_STATE_RECONCILIATION_OWNER,
         "reconciliation_entry_exit_policy": RECONCILIATION_ENTRY_EXIT_POLICY_OWNER,
+        "backtest_parity_wiring": BACKTEST_PARITY_WIRING_OWNER,
+        "runtime_bridge_reference": RUNTIME_BRIDGE_REFERENCE_OWNER,
         "parity_harness": INTEGRATED_VS_SCENARIO_REPLAY_FULL_SYSTEM_PARITY_HARNESS_OWNER,
     }
 
@@ -1036,6 +1059,226 @@ def evaluate_reversal_preparation_matrix_v0(
         input_digest=compute_composition_input_digest(matrix_input),
     )
     return evaluate_scenario_matrix_composition_v0(matrix_input)
+
+
+def extract_backtest_evidence_parity_envelope_v0(
+    evidence: "CanonicalTradingDecisionEvidenceV1",
+) -> ParityDecisionEnvelopeV0:
+    from trading.master_v2.canonical_trading_decision_evidence_v1 import (
+        CanonicalTradingDecisionEvidenceV1,
+    )
+
+    if not isinstance(evidence, CanonicalTradingDecisionEvidenceV1):
+        raise TypeError("evidence must be CanonicalTradingDecisionEvidenceV1")
+    return ParityDecisionEnvelopeV0(
+        decision_outcome=evidence.decision_outcome,
+        previous_side_state=evidence.previous_direction_state or None,
+        next_side_state=evidence.next_direction_state or None,
+        composition_status="",
+        composition_result_id=evidence.composition_result_ref,
+        entry_or_exit_policy_ref=evidence.entry_or_exit_policy_ref,
+        reason_codes=tuple(evidence.reason_codes),
+        decision_precedence_trace=tuple(evidence.decision_precedence_trace),
+        execution_eligible=evidence.execution_eligible,
+        adapter_compatible=evidence.adapter_compatible,
+        quantity_status=evidence.quantity_status,
+        quantity_provenance_ref=evidence.quantity_provenance_ref,
+        risk_sizing_ref=evidence.risk_sizing_ref,
+        risk_sizing_effect=evidence.risk_sizing_effect,
+        order_intent_ref=evidence.order_intent_ref,
+        order_intent_effect=evidence.order_intent_effect,
+        safety_boundary_ref=evidence.safety_boundary_ref,
+        safety_boundary_effect=evidence.safety_boundary_effect,
+        reconciliation_unknown_outcome_ref=evidence.reconciliation_unknown_outcome_ref,
+        reconciliation_unknown_outcome_effect=evidence.reconciliation_unknown_outcome_effect,
+        killswitch_boundary_ref=evidence.killswitch_boundary_ref,
+        killswitch_boundary_effect=evidence.killswitch_boundary_effect,
+        authority_effect=evidence.authority_effect,
+        runtime_effect=evidence.runtime_effect,
+        selected_side=evidence.selected_side or None,
+    )
+
+
+def extract_runtime_reference_parity_envelope_v0() -> ParityDecisionEnvelopeV0:
+    return ParityDecisionEnvelopeV0(
+        decision_outcome="runtime_reference_not_activated",
+        previous_side_state=None,
+        next_side_state=None,
+        composition_status="runtime_reference_only",
+        composition_result_id="runtime_bridge_reference_v0",
+        entry_or_exit_policy_ref=RUNTIME_BRIDGE_REFERENCE_OWNER,
+        reason_codes=("BOUND_NOT_ACTIVATED", "NO_RUNTIME_AUTHORITY"),
+        decision_precedence_trace=("runtime_reference_lane_v0",),
+        execution_eligible=False,
+        adapter_compatible=False,
+        quantity_status="NOT_BOUND",
+        authority_effect="NONE",
+        runtime_effect="NONE",
+        transition_reason_code=RUNTIME_REFERENCE_INTEGRATION_STATUS_V0,
+    )
+
+
+def assert_runtime_reference_lane_v0(envelope: ParityDecisionEnvelopeV0) -> None:
+    assert envelope.transition_reason_code == RUNTIME_REFERENCE_INTEGRATION_STATUS_V0
+    assert envelope.decision_outcome == "runtime_reference_not_activated"
+    assert not envelope.execution_eligible
+    assert not envelope.adapter_compatible
+    assert envelope.authority_effect == "NONE"
+    assert envelope.runtime_effect == "NONE"
+
+
+def assert_backtest_lane_non_authority_boundary_v0(envelope: ParityDecisionEnvelopeV0) -> None:
+    assert not envelope.execution_eligible
+    assert not envelope.adapter_compatible
+    assert envelope.authority_effect == "NONE"
+    assert envelope.runtime_effect == "NONE"
+
+
+def _default_mv2_research_cfg_v0() -> Mapping[str, object]:
+    return {
+        "backtest": {
+            "initial_cash": 10_000.0,
+            "cost_model_version": "backtest_cost_v0",
+            "fee_bps": 10.0,
+            "slippage_bps": 5.0,
+        },
+        "risk": {
+            "risk_per_trade": 0.02,
+            "max_position_size": 0.25,
+            "min_position_value": 10.0,
+            "min_stop_distance": 0.0001,
+        },
+        "economic_evaluation_v1": {
+            "strategy_params": {
+                "fast_window": 2,
+                "slow_window": 3,
+            },
+        },
+    }
+
+
+def _synthetic_mv2_research_bars_v0(*, bar_count: int = 12) -> "pd.DataFrame":
+    import pandas as pd
+
+    idx = pd.date_range("2026-06-01", periods=bar_count, freq="1h", tz="UTC")
+    close = [100.0 + float(i) for i in range(bar_count)]
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [v + 0.5 for v in close],
+            "low": [v - 0.5 for v in close],
+            "close": close,
+            "mark_price": close,
+            "index_price": [v - 0.1 for v in close],
+            "best_bid": [v - 0.05 for v in close],
+            "best_ask": [v + 0.05 for v in close],
+            "spread": [0.1 for _ in close],
+            "volume": [1000.0 for _ in close],
+            "open_interest": [10000.0 for _ in close],
+            "funding_rate": [0.0001 for _ in close],
+            "volatility_estimate": [0.2 for _ in close],
+            "is_final": [True for _ in close],
+            "bar_interval": ["1m" for _ in close],
+        },
+        index=idx,
+    )
+
+
+def bind_backtest_bar_four_way_parity_lane_v0() -> ParityDecisionEnvelopeV0 | None:
+    from src.backtest.mv2_research_wiring_v1 import (
+        MV2_REQUIRED_INSTRUMENT_ID,
+        run_mv2_research_backtest_wiring_v1,
+    )
+
+    result = run_mv2_research_backtest_wiring_v1(
+        bars=_synthetic_mv2_research_bars_v0(),
+        strategy_id="ma_crossover",
+        cfg=_default_mv2_research_cfg_v0(),
+        instrument_id=MV2_REQUIRED_INSTRUMENT_ID,
+    )
+    if not result.bar_outcomes:
+        return None
+    for bar_outcome in result.bar_outcomes:
+        envelope = extract_backtest_evidence_parity_envelope_v0(bar_outcome.evidence)
+        assert_backtest_lane_non_authority_boundary_v0(envelope)
+        return envelope
+    return None
+
+
+def evaluate_surface_p_four_way_parity_v0(
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+    context_reference: str,
+    integrated_envelope: ParityDecisionEnvelopeV0 | None = None,
+) -> FullSystemFourWayParityAssessmentV0:
+    fail_reasons: list[str] = []
+
+    matrix = evaluate_scenario_matrix_for_side_state_v0(
+        side_state=SideState.CHOP_GUARD_BLOCK,
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+    )
+    scenario_env = extract_scenario_matrix_parity_envelope_v0(matrix)
+    scenario_lane_bound = matrix.composition_status is CompositionStatus.CHOP_GUARD_BLOCK
+    if scenario_lane_bound:
+        assert_non_authority_boundary_v0(scenario_env)
+    else:
+        fail_reasons.append("scenario_lane_unbound")
+
+    integrated_lane_bound = integrated_envelope is not None
+    integrated_scenario_aligned = False
+    if integrated_envelope is not None:
+        try:
+            assert_non_authority_boundary_v0(integrated_envelope)
+            integrated_scenario_aligned = (
+                integrated_envelope.composition_status == scenario_env.composition_status
+            )
+        except AssertionError:
+            integrated_lane_bound = False
+            fail_reasons.append("integrated_lane_invalid")
+    else:
+        fail_reasons.append("integrated_lane_unbound")
+    if integrated_lane_bound and not integrated_scenario_aligned:
+        fail_reasons.append("integrated_scenario_composition_not_aligned")
+
+    backtest_env = bind_backtest_bar_four_way_parity_lane_v0()
+    backtest_lane_bound = backtest_env is not None
+    backtest_non_authority = backtest_lane_bound
+    if not backtest_lane_bound:
+        fail_reasons.append("backtest_lane_unbound")
+
+    runtime_env = extract_runtime_reference_parity_envelope_v0()
+    runtime_reference_lane_bound = True
+    runtime_reference_non_authority = True
+    try:
+        assert_runtime_reference_lane_v0(runtime_env)
+    except AssertionError:
+        runtime_reference_lane_bound = False
+        runtime_reference_non_authority = False
+        fail_reasons.append("runtime_reference_lane_invalid")
+
+    four_way_bound = (
+        integrated_lane_bound
+        and scenario_lane_bound
+        and backtest_lane_bound
+        and runtime_reference_lane_bound
+        and integrated_scenario_aligned
+        and backtest_non_authority
+        and runtime_reference_non_authority
+    )
+    return FullSystemFourWayParityAssessmentV0(
+        integrated_lane_bound=integrated_lane_bound,
+        scenario_lane_bound=scenario_lane_bound,
+        backtest_lane_bound=backtest_lane_bound,
+        runtime_reference_lane_bound=runtime_reference_lane_bound,
+        integrated_scenario_composition_aligned=integrated_scenario_aligned,
+        backtest_non_authority_confirmed=backtest_non_authority,
+        runtime_reference_non_authority_confirmed=runtime_reference_non_authority,
+        four_way_parity_rewire_bound=four_way_bound,
+        fail_closed_reasons=tuple(fail_reasons),
+    )
 
 
 def scan_changed_paths_for_forbidden_runtime_v0(

--- a/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
+++ b/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
@@ -175,6 +175,19 @@ def test_killswitch_boundary_surface_pass_v0() -> None:
     assert "evaluate_scenario_killswitch_boundary_v0" in killswitch.current_scenario_replay_binding
 
 
+def test_surface_p_four_way_parity_binding_partial_v0() -> None:
+    surface_p = next(item for item in parity_surface_assessments_v0() if item.surface_id == "P")
+    assert surface_p.parity_status == "PARTIAL"
+    assert "bind_backtest_bar_four_way_parity_lane_v0" in surface_p.current_backtest_binding
+    assert "runtime reference lane bound offline" in surface_p.current_runtime_semantics_reference
+    assert "BOUND_NOT_ACTIVATED by policy" in surface_p.missing_binding_if_any
+    assert (
+        "scripts/ops/run_integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0.py"
+        in surface_p.evidence_refs
+    )
+    assert surface_p.recommended_next_slice == NEXT_RECOMMENDED_SLICE
+
+
 def test_gap_matrix_markdown_renders_v0() -> None:
     md = render_parity_gap_matrix_markdown_v0()
     assert "FULL_CANONICAL_CHAIN_WIRED=false" in md

--- a/tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py
+++ b/tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py
@@ -39,14 +39,22 @@ from trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
 )
 from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
     ALLOWED_SLICE_CHANGED_PATH_PREFIXES,
+    BACKTEST_PARITY_WIRING_OWNER,
+    FOUR_WAY_PARITY_REWIRE_SLICE_ID,
     INTEGRATED_VS_SCENARIO_REPLAY_FULL_SYSTEM_PARITY_HARNESS_OWNER,
+    RUNTIME_BRIDGE_REFERENCE_OWNER,
+    RUNTIME_REFERENCE_INTEGRATION_STATUS_V0,
     assert_non_authority_boundary_v0,
+    assert_runtime_reference_lane_v0,
     assert_scenario_replay_zero_order_boundary_v0,
+    bind_backtest_bar_four_way_parity_lane_v0,
     canonical_owner_refs_v0,
     composition_matrix_results_aligned_v0,
     evaluate_reversal_preparation_matrix_v0,
     evaluate_scenario_matrix_for_side_state_v0,
+    evaluate_surface_p_four_way_parity_v0,
     extract_integrated_parity_envelope_v0,
+    extract_runtime_reference_parity_envelope_v0,
     extract_scenario_matrix_parity_envelope_v0,
     extract_scenario_replay_tick_parity_envelope_v0,
     integrated_assessments_match_scenario_side_state_v0,
@@ -74,6 +82,8 @@ _SLICE_SOURCE_PATHS = (
     / "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
     REPO_ROOT
     / "scripts/ops/run_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
+    REPO_ROOT
+    / "scripts/ops/run_integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0.py",
     REPO_ROOT
     / "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
 )
@@ -137,6 +147,48 @@ def test_harness_and_replay_owner_constants_v0() -> None:
     assert refs["scenario_matrix_adapter"] == DOUBLE_PLAY_COMPOSITION_SCENARIO_MATRIX_ADAPTER_OWNER
     assert refs["double_play_composition_matrix"] == CANONICAL_DOUBLE_PLAY_COMPOSITION_OWNER
     assert refs["parity_harness"] == INTEGRATED_VS_SCENARIO_REPLAY_FULL_SYSTEM_PARITY_HARNESS_OWNER
+    assert refs["backtest_parity_wiring"] == BACKTEST_PARITY_WIRING_OWNER
+    assert refs["runtime_bridge_reference"] == RUNTIME_BRIDGE_REFERENCE_OWNER
+
+
+def test_four_way_parity_slice_constants_v0() -> None:
+    assert (
+        FOUR_WAY_PARITY_REWIRE_SLICE_ID
+        == "INTEGRATED_VS_SCENARIO_REPLAY_FULL_SYSTEM_4_WAY_PARITY_REWIRE_V0"
+    )
+    assert RUNTIME_REFERENCE_INTEGRATION_STATUS_V0 == "BOUND_NOT_ACTIVATED"
+
+
+def test_runtime_reference_lane_bound_not_activated_v0() -> None:
+    envelope = extract_runtime_reference_parity_envelope_v0()
+    assert_runtime_reference_lane_v0(envelope)
+
+
+def test_backtest_bar_lane_bound_offline_v0() -> None:
+    envelope = bind_backtest_bar_four_way_parity_lane_v0()
+    assert envelope is not None
+    assert envelope.decision_outcome
+    assert envelope.authority_effect == "NONE"
+    assert envelope.runtime_effect == "NONE"
+
+
+def test_surface_p_four_way_parity_smoke_assessment_v0() -> None:
+    integrated = _run(price_path=(3500.0, 3600.0))
+    integrated_env = extract_integrated_parity_envelope_v0(integrated)
+    assessment = evaluate_surface_p_four_way_parity_v0(
+        instrument_id=_INSTRUMENT,
+        trading_epoch=_EPOCH,
+        context_reference=_CONTEXT,
+        integrated_envelope=integrated_env,
+    )
+    assert assessment.scenario_lane_bound is True
+    assert assessment.backtest_lane_bound is True
+    assert assessment.runtime_reference_lane_bound is True
+    assert assessment.integrated_lane_bound is True
+    assert assessment.integrated_scenario_composition_aligned is True
+    assert assessment.backtest_non_authority_confirmed is True
+    assert assessment.runtime_reference_non_authority_confirmed is True
+    assert assessment.four_way_parity_rewire_bound is True
 
 
 def test_forbidden_runtime_paths_guard_v0() -> None:


### PR DESCRIPTION
## Summary

- Extends `integrated_vs_scenario_replay_full_system_parity_harness_v0` with offline Surface P 4-way parity binding: integrated envelope input, scenario matrix lane, backtest bar lane via `mv2_research_wiring_v1`, and runtime reference lane (`BOUND_NOT_ACTIVATED`).
- Updates gap assessment Surface P metadata and adds ops evidence runner `run_integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0.py`.
- Adds contract coverage for 4-way smoke assessment and Surface P partial binding state.

## Hard boundaries

NO_LIVE · NO_CANARY · NO_TESTNET · NO_PAPER · NO_SHADOW · NO_SCHEDULER · NO_RUNTIME_START · NO_ORDER_SUBMISSION · NO_EXECUTION · NO_CREDENTIALS · NO_ARMING · NO_ADAPTER_SUBMISSION · NO_CORE_TRADING_LOGIC_CHANGE · NO_DOUBLE_PLAY_CHANGE · NO_RISK_SIZING_CHANGE · NO_SAFETY_RUNTIME_CHANGE

`FULL_CANONICAL_CHAIN_WIRED=false` and `BACKTEST_RUNTIME_DECISION_PARITY_PASS=false` remain explicit; Surface P stays `PARTIAL`.

## Durable evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0_20260707T202113Z`

MANIFEST_VERIFY_RC=0

Bounded selector source:
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/bounded_selector_retry_surface_p_after_pr4974_hang_recovery_v0_20260707T201702Z`

## Test plan

- [x] `pytest -q tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py` (40 passed)
- [x] `ruff check` / `ruff format --check` on touched Python files
- [x] Offline evidence script `run_integrated_vs_scenario_replay_full_system_4_way_parity_rewire_v0.py`


Made with [Cursor](https://cursor.com)