### PR TITLE
Add runtime bridge pre-activation gate contract

### DIFF
--- a/scripts/ops/run_runtime_bridge_pre_activation_gate_contract_v0.py
+++ b/scripts/ops/run_runtime_bridge_pre_activation_gate_contract_v0.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for RuntimeBridgePreActivationGateContractV0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+BASE_HEAD = "8ab416a3c46f38b798853c306acaa21372c788b6"
+OPERATOR_GO_TOKEN = (
+    "GO_IMPLEMENT_RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_CONTRACT_V0_NO_ACTIVATION_NO_RUNTIME_AUTHORITY"
+)
+REVIEW_EVIDENCE = (
+    ARCHIVE_ROOT
+    / "research/operator_review_runtime_bridge_pre_activation_gate_contract_v0_20260707T204930Z"
+)
+PROPOSAL_EVIDENCE = (
+    ARCHIVE_ROOT
+    / "research/runtime_bridge_pre_activation_gate_contract_proposal_v0_20260707T204830Z"
+)
+VERDICT = "RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_CONTRACT_IMPLEMENTATION_V0_PASS"
+TARGETED_TESTS = ("tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py",)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/runtime_bridge_pre_activation_gate_v0.py",
+    "scripts/ops/run_runtime_bridge_pre_activation_gate_contract_v0.py",
+    "tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.iterdir()):
+        if path.name == "MANIFEST.sha256":
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  {path.name}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def _verify_manifest(path: Path, label: str) -> tuple[int, str]:
+    if not path.is_dir():
+        return 1, f"{label}_ABSENT=true\n{label}_MANIFEST_VERIFY_RC=1\n"
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=path)
+    return proc.returncode, (
+        proc.stdout
+        + proc.stderr
+        + f"\n{label}_PATH={path}\n{label}_MANIFEST_VERIFY_RC={proc.returncode}\n"
+    )
+
+
+def collect_evidence(out_dir: Path | None = None) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT / f"research/runtime_bridge_pre_activation_gate_contract_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    worktree = _run(["git", "status", "--short"]).stdout.strip()
+
+    review_rc, review_log = _verify_manifest(REVIEW_EVIDENCE, "REVIEW")
+    proposal_rc, proposal_log = _verify_manifest(PROPOSAL_EVIDENCE, "PROPOSAL")
+    (evidence_dir / "review_manifest_reverify.log").write_text(review_log, encoding="utf-8")
+    (evidence_dir / "proposal_manifest_reverify.log").write_text(proposal_log, encoding="utf-8")
+
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from trading.master_v2.runtime_bridge_pre_activation_gate_v0 import (
+        CONTRACT_NAME,
+        current_head_default_gate_input_v0,
+        evaluate_runtime_bridge_pre_activation_gate_v0,
+    )
+
+    gate_input = current_head_default_gate_input_v0()
+    gate_result = evaluate_runtime_bridge_pre_activation_gate_v0(gate_input)
+    (evidence_dir / "gate_evaluation.log").write_text(
+        "\n".join(
+            [
+                f"CONTRACT_NAME={CONTRACT_NAME}",
+                f"runtime_bridge_pre_activation_gate_status={gate_result.runtime_bridge_pre_activation_gate_status}",
+                f"runtime_bridge_activation_admissible={str(gate_result.runtime_bridge_activation_admissible).lower()}",
+                f"blocking_reasons={','.join(gate_result.blocking_reasons)}",
+                f"required_next_gates={','.join(gate_result.required_next_gates)}",
+                f"authority_effect={gate_result.authority_effect}",
+                f"runtime_effect={gate_result.runtime_effect}",
+                f"order_effect={gate_result.order_effect}",
+                f"execution_eligible={str(gate_result.execution_eligible).lower()}",
+                f"adapter_compatible={str(gate_result.adapter_compatible).lower()}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    pytest_proc = _run(
+        [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS],
+        cwd=REPO_ROOT,
+    )
+    (evidence_dir / "targeted_pytest.log").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+    pytest_summary = ""
+    for line in pytest_proc.stdout.splitlines():
+        if "passed" in line or "failed" in line or "error" in line:
+            pytest_summary = line.strip()
+            break
+
+    ruff_targets = list(SLICE_CHANGED_FILES)
+    ruff_format = _run([sys.executable, "-m", "ruff", "format", *ruff_targets])
+    ruff_check = _run([sys.executable, "-m", "ruff", "check", *ruff_targets])
+    (evidence_dir / "ruff_format.log").write_text(
+        ruff_format.stdout + ruff_format.stderr,
+        encoding="utf-8",
+    )
+    (evidence_dir / "ruff_check.log").write_text(
+        ruff_check.stdout + ruff_check.stderr,
+        encoding="utf-8",
+    )
+
+    blocked = (
+        gate_result.runtime_bridge_pre_activation_gate_status != "FAIL"
+        or gate_result.authority_effect != "NONE"
+        or gate_result.runtime_effect != "NONE"
+        or gate_result.order_effect != "NONE"
+        or gate_result.execution_eligible
+        or gate_result.adapter_compatible
+        or pytest_proc.returncode != 0
+        or ruff_format.returncode != 0
+        or ruff_check.returncode != 0
+    )
+    verdict = (
+        VERDICT
+        if not blocked
+        else "RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_CONTRACT_IMPLEMENTATION_V0_BLOCKED"
+    )
+
+    (evidence_dir / "FINAL_REPORT.env").write_text(
+        "\n".join(
+            [
+                f"VERDICT={verdict}",
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"BASE_HEAD={BASE_HEAD}",
+                f"HEAD_EQUALS_ORIGIN_MAIN={str(head == origin_main).lower()}",
+                f"WORKTREE_STATUS={worktree or 'clean'}",
+                f"OPERATOR_GO_TOKEN={OPERATOR_GO_TOKEN}",
+                f"REVIEW_MANIFEST_VERIFY_RC={review_rc}",
+                f"PROPOSAL_MANIFEST_VERIFY_RC={proposal_rc}",
+                f"CONTRACT_NAME={CONTRACT_NAME}",
+                f"runtime_bridge_pre_activation_gate_status={gate_result.runtime_bridge_pre_activation_gate_status}",
+                "RUNTIME_BRIDGE_ACTIVATION_ADMISSIBLE=false",
+                "RUNTIME_AUTHORITY_ACTIVATED=false",
+                "ORDERS_ALLOWED=false",
+                "SCHEDULER_RUNTIME_ALLOWED=false",
+                "SHADOW_AUTHORIZED=false",
+                "PAPER_AUTHORIZED=false",
+                "TESTNET_AUTHORIZED=false",
+                "LIVE_AUTHORIZED=false",
+                f"TARGETED_PYTEST_RC={pytest_proc.returncode}",
+                f"TARGETED_PYTEST_SUMMARY={pytest_summary}",
+                f"RUFF_FORMAT_RC={ruff_format.returncode}",
+                f"RUFF_CHECK_RC={ruff_check.returncode}",
+                f"CHANGED_FILES={','.join(SLICE_CHANGED_FILES)}",
+                f"DURABLE_EVIDENCE_DIR={evidence_dir}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_rc = _write_manifest(evidence_dir)
+
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_verify_rc": manifest_rc,
+        "pytest_rc": pytest_proc.returncode,
+        "gate_status": gate_result.runtime_bridge_pre_activation_gate_status,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(args.out)
+    print(result["verdict"])
+    print(f"EVIDENCE_DIR={result['evidence_dir']}")
+    print(f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}")
+    print(f"GATE_STATUS={result['gate_status']}")
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/runtime_bridge_pre_activation_gate_v0.py
+++ b/src/trading/master_v2/runtime_bridge_pre_activation_gate_v0.py
@@ -1,0 +1,180 @@
+"""
+Runtime Bridge Pre-Activation Gate Contract v0.
+
+Fail-closed evaluator-only contract determining whether a later Runtime-Bridge
+activation slice may be considered for separate Operator-GO review.
+
+No runtime authority, no bridge activation, no orders, no IO, no side effects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Tuple
+
+RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_LAYER_VERSION = "v0"
+RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_OWNER = "trading.master_v2.runtime_bridge_pre_activation_gate_v0"
+CONTRACT_NAME = "RuntimeBridgePreActivationGateContractV0"
+PACKAGE_MARKER = "RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_CONTRACT_V0=true"
+
+GateStatus = Literal["PASS", "FAIL"]
+LegacyEntrypointGuardStatus = Literal["PASS_DEAUTHORIZED_UNTIL_CANONICAL_PATH", "FAIL"]
+ShadowPaperTestnetCanaryGateStatus = Literal["SEPARATELY_GATED", "FAIL"]
+PreActivationGateStatus = Literal["PASS", "FAIL"]
+
+_AUTHORITY_EFFECT_NONE = "NONE"
+_RUNTIME_EFFECT_NONE = "NONE"
+_ORDER_EFFECT_NONE = "NONE"
+
+_GATE_FIELD_ORDER: Tuple[str, ...] = (
+    "operator_go_token_status",
+    "full_canonical_chain_wired_status",
+    "backtest_runtime_decision_parity_status",
+    "system_economic_evidence_admissible_status",
+    "economic_validity_offline_gate_status",
+    "surface_p_status",
+    "canonical_order_intent_adapter_compatibility_status",
+    "runtime_rewire_eligibility_status",
+    "runtime_rewire_activation_contract_status",
+    "zero_order_pre_activation_evidence_status",
+    "legacy_entrypoint_guard_status",
+    "shadow_paper_testnet_canary_gate_status",
+)
+
+_REQUIRED_NEXT_GATE_BY_FIELD: dict[str, str] = {
+    "operator_go_token_status": "OPERATOR_GO_SEPARATE_RUNTIME_BRIDGE_ACTIVATION",
+    "full_canonical_chain_wired_status": "FULL_CANONICAL_CHAIN_WIRED_PASS",
+    "backtest_runtime_decision_parity_status": "BACKTEST_RUNTIME_DECISION_PARITY_PASS",
+    "system_economic_evidence_admissible_status": "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE",
+    "economic_validity_offline_gate_status": "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS",
+    "surface_p_status": "SURFACE_P_STATUS_PASS",
+    "canonical_order_intent_adapter_compatibility_status": (
+        "CANONICAL_ORDER_INTENT_ADAPTER_COMPATIBILITY_PROVEN"
+    ),
+    "runtime_rewire_eligibility_status": "RUNTIME_REWIRE_ELIGIBILITY_PROVEN",
+    "runtime_rewire_activation_contract_status": "RUNTIME_REWIRE_ACTIVATION_BOUND_CONTRACT",
+    "zero_order_pre_activation_evidence_status": "ZERO_ORDER_PRE_ACTIVATION_EVIDENCE",
+    "legacy_entrypoint_guard_status": (
+        "LEGACY_ENTRYPOINTS_REMAIN_DEAUTHORIZED_UNTIL_CANONICAL_PATH"
+    ),
+    "shadow_paper_testnet_canary_gate_status": "SHADOW_PAPER_TESTNET_CANARY_OPERATOR_GATES",
+}
+
+
+@dataclass(frozen=True)
+class RuntimeBridgePreActivationGateInputV0:
+    operator_go_token_status: GateStatus
+    full_canonical_chain_wired_status: GateStatus
+    backtest_runtime_decision_parity_status: GateStatus
+    system_economic_evidence_admissible_status: GateStatus
+    economic_validity_offline_gate_status: GateStatus
+    surface_p_status: GateStatus
+    canonical_order_intent_adapter_compatibility_status: GateStatus
+    runtime_rewire_eligibility_status: GateStatus
+    runtime_rewire_activation_contract_status: GateStatus
+    zero_order_pre_activation_evidence_status: GateStatus
+    legacy_entrypoint_guard_status: LegacyEntrypointGuardStatus
+    shadow_paper_testnet_canary_gate_status: ShadowPaperTestnetCanaryGateStatus
+
+
+@dataclass(frozen=True)
+class RuntimeBridgePreActivationGateResultV0:
+    runtime_bridge_pre_activation_gate_status: PreActivationGateStatus
+    runtime_bridge_activation_admissible: bool
+    blocking_reasons: Tuple[str, ...]
+    required_next_gates: Tuple[str, ...]
+    authority_effect: Literal["NONE"]
+    runtime_effect: Literal["NONE"]
+    order_effect: Literal["NONE"]
+    execution_eligible: bool
+    adapter_compatible: bool
+
+
+def _gate_values(inp: RuntimeBridgePreActivationGateInputV0) -> dict[str, str]:
+    return {field: getattr(inp, field) for field in _GATE_FIELD_ORDER}
+
+
+def _is_gate_pass(field: str, value: str) -> bool:
+    if field == "legacy_entrypoint_guard_status":
+        return value == "PASS_DEAUTHORIZED_UNTIL_CANONICAL_PATH"
+    if field == "shadow_paper_testnet_canary_gate_status":
+        return value == "SEPARATELY_GATED"
+    return value == "PASS"
+
+
+def evaluate_runtime_bridge_pre_activation_gate_v0(
+    inp: RuntimeBridgePreActivationGateInputV0,
+) -> RuntimeBridgePreActivationGateResultV0:
+    """Evaluate pre-activation gate inputs fail-closed; never grants runtime authority."""
+    values = _gate_values(inp)
+    blocking_reasons: list[str] = []
+    required_next_gates: list[str] = []
+
+    for field in _GATE_FIELD_ORDER:
+        value = values[field]
+        if not _is_gate_pass(field, value):
+            blocking_reasons.append(f"{field}!={value}")
+            required_next_gates.append(_REQUIRED_NEXT_GATE_BY_FIELD[field])
+
+    gate_pass = not blocking_reasons
+    return RuntimeBridgePreActivationGateResultV0(
+        runtime_bridge_pre_activation_gate_status="PASS" if gate_pass else "FAIL",
+        runtime_bridge_activation_admissible=gate_pass,
+        blocking_reasons=tuple(blocking_reasons),
+        required_next_gates=tuple(dict.fromkeys(required_next_gates)),
+        authority_effect=_AUTHORITY_EFFECT_NONE,
+        runtime_effect=_RUNTIME_EFFECT_NONE,
+        order_effect=_ORDER_EFFECT_NONE,
+        execution_eligible=False,
+        adapter_compatible=False,
+    )
+
+
+def _bool_to_gate_status(value: bool) -> GateStatus:
+    return "PASS" if value else "FAIL"
+
+
+def current_head_default_gate_input_v0() -> RuntimeBridgePreActivationGateInputV0:
+    """Reuse-first static snapshot aligned with gap assessment @ current main."""
+    import json
+
+    from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+        parity_surface_assessments_v0,
+        render_parity_gap_matrix_json_v0,
+    )
+    from trading.master_v2.legacy_runtime_entrypoint_guard_v0 import (
+        CANONICAL_RUNTIME_ENTRYPOINT_STATUS,
+        SLICE_D_STATUS,
+    )
+
+    payload = json.loads(render_parity_gap_matrix_json_v0())
+    summary = payload["summary"]
+    surface_p = next(item for item in parity_surface_assessments_v0() if item.surface_id == "P")
+
+    legacy_ok = (
+        SLICE_D_STATUS == "LEGACY_RUNTIME_ENTRYPOINTS_DEAUTHORIZED"
+        and CANONICAL_RUNTIME_ENTRYPOINT_STATUS == "BOUND_NOT_ACTIVATED"
+    )
+
+    return RuntimeBridgePreActivationGateInputV0(
+        operator_go_token_status="FAIL",
+        full_canonical_chain_wired_status=_bool_to_gate_status(
+            summary["full_canonical_chain_wired"]
+        ),
+        backtest_runtime_decision_parity_status=_bool_to_gate_status(
+            summary["backtest_runtime_decision_parity_pass"]
+        ),
+        system_economic_evidence_admissible_status=_bool_to_gate_status(
+            summary["system_economic_evidence_admissible"]
+        ),
+        economic_validity_offline_gate_status="FAIL",
+        surface_p_status="PASS" if surface_p.parity_status == "PASS" else "FAIL",
+        canonical_order_intent_adapter_compatibility_status="FAIL",
+        runtime_rewire_eligibility_status="FAIL",
+        runtime_rewire_activation_contract_status="PASS",
+        zero_order_pre_activation_evidence_status="FAIL",
+        legacy_entrypoint_guard_status=(
+            "PASS_DEAUTHORIZED_UNTIL_CANONICAL_PATH" if legacy_ok else "FAIL"
+        ),
+        shadow_paper_testnet_canary_gate_status="SEPARATELY_GATED",
+    )

--- a/tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py
+++ b/tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py
@@ -1,0 +1,119 @@
+"""Runtime bridge pre-activation gate contract tests (offline only)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from trading.master_v2.runtime_bridge_pre_activation_gate_v0 import (
+    CONTRACT_NAME,
+    PACKAGE_MARKER,
+    RuntimeBridgePreActivationGateInputV0,
+    current_head_default_gate_input_v0,
+    evaluate_runtime_bridge_pre_activation_gate_v0,
+)
+
+
+def _all_pass_input() -> RuntimeBridgePreActivationGateInputV0:
+    return RuntimeBridgePreActivationGateInputV0(
+        operator_go_token_status="PASS",
+        full_canonical_chain_wired_status="PASS",
+        backtest_runtime_decision_parity_status="PASS",
+        system_economic_evidence_admissible_status="PASS",
+        economic_validity_offline_gate_status="PASS",
+        surface_p_status="PASS",
+        canonical_order_intent_adapter_compatibility_status="PASS",
+        runtime_rewire_eligibility_status="PASS",
+        runtime_rewire_activation_contract_status="PASS",
+        zero_order_pre_activation_evidence_status="PASS",
+        legacy_entrypoint_guard_status="PASS_DEAUTHORIZED_UNTIL_CANONICAL_PATH",
+        shadow_paper_testnet_canary_gate_status="SEPARATELY_GATED",
+    )
+
+
+def test_contract_constants_v0() -> None:
+    assert CONTRACT_NAME == "RuntimeBridgePreActivationGateContractV0"
+    assert PACKAGE_MARKER == "RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_CONTRACT_V0=true"
+
+
+def test_current_head_default_snapshot_evaluates_fail_v0() -> None:
+    result = evaluate_runtime_bridge_pre_activation_gate_v0(current_head_default_gate_input_v0())
+    assert result.runtime_bridge_pre_activation_gate_status == "FAIL"
+    assert result.runtime_bridge_activation_admissible is False
+
+
+def test_any_single_non_pass_gate_evaluates_fail_v0() -> None:
+    base = _all_pass_input()
+    for field in (
+        "operator_go_token_status",
+        "full_canonical_chain_wired_status",
+        "backtest_runtime_decision_parity_status",
+        "system_economic_evidence_admissible_status",
+        "economic_validity_offline_gate_status",
+        "surface_p_status",
+        "canonical_order_intent_adapter_compatibility_status",
+        "runtime_rewire_eligibility_status",
+        "runtime_rewire_activation_contract_status",
+        "zero_order_pre_activation_evidence_status",
+    ):
+        result = evaluate_runtime_bridge_pre_activation_gate_v0(replace(base, **{field: "FAIL"}))
+        assert result.runtime_bridge_pre_activation_gate_status == "FAIL"
+        assert result.runtime_bridge_activation_admissible is False
+
+
+def test_all_gates_pass_evaluates_pre_activation_readiness_pass_v0() -> None:
+    result = evaluate_runtime_bridge_pre_activation_gate_v0(_all_pass_input())
+    assert result.runtime_bridge_pre_activation_gate_status == "PASS"
+    assert result.runtime_bridge_activation_admissible is True
+
+
+def test_pass_output_keeps_authority_effect_none_v0() -> None:
+    result = evaluate_runtime_bridge_pre_activation_gate_v0(_all_pass_input())
+    assert result.authority_effect == "NONE"
+
+
+def test_pass_output_keeps_runtime_effect_none_v0() -> None:
+    result = evaluate_runtime_bridge_pre_activation_gate_v0(_all_pass_input())
+    assert result.runtime_effect == "NONE"
+
+
+def test_pass_output_keeps_order_effect_none_v0() -> None:
+    result = evaluate_runtime_bridge_pre_activation_gate_v0(_all_pass_input())
+    assert result.order_effect == "NONE"
+
+
+def test_pass_output_keeps_execution_eligible_false_v0() -> None:
+    result = evaluate_runtime_bridge_pre_activation_gate_v0(_all_pass_input())
+    assert result.execution_eligible is False
+
+
+def test_pass_output_keeps_adapter_compatible_false_v0() -> None:
+    result = evaluate_runtime_bridge_pre_activation_gate_v0(_all_pass_input())
+    assert result.adapter_compatible is False
+
+
+def test_wrong_legacy_entrypoint_guard_status_fails_v0() -> None:
+    result = evaluate_runtime_bridge_pre_activation_gate_v0(
+        replace(_all_pass_input(), legacy_entrypoint_guard_status="FAIL")
+    )
+    assert result.runtime_bridge_pre_activation_gate_status == "FAIL"
+    assert "legacy_entrypoint_guard_status!=FAIL" in result.blocking_reasons
+
+
+def test_wrong_shadow_paper_testnet_canary_gate_status_fails_v0() -> None:
+    result = evaluate_runtime_bridge_pre_activation_gate_v0(
+        replace(_all_pass_input(), shadow_paper_testnet_canary_gate_status="FAIL")
+    )
+    assert result.runtime_bridge_pre_activation_gate_status == "FAIL"
+    assert "shadow_paper_testnet_canary_gate_status!=FAIL" in result.blocking_reasons
+
+
+def test_fail_populates_blocking_reasons_v0() -> None:
+    result = evaluate_runtime_bridge_pre_activation_gate_v0(current_head_default_gate_input_v0())
+    assert result.runtime_bridge_pre_activation_gate_status == "FAIL"
+    assert len(result.blocking_reasons) > 0
+
+
+def test_fail_populates_required_next_gates_v0() -> None:
+    result = evaluate_runtime_bridge_pre_activation_gate_v0(current_head_default_gate_input_v0())
+    assert result.runtime_bridge_pre_activation_gate_status == "FAIL"
+    assert len(result.required_next_gates) > 0


### PR DESCRIPTION
## Summary

- Add `RuntimeBridgePreActivationGateContractV0` as a fail-closed, evaluator-only pre-activation gate contract.
- Add contract tests proving mandatory fail-closed rules and non-authority guarantees.
- Add read-only evidence collector writing durable archive bundle with `MANIFEST_VERIFY_RC=0`.

## Operator GO

`GO_IMPLEMENT_RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_CONTRACT_V0_NO_ACTIVATION_NO_RUNTIME_AUTHORITY`

## VERDICT target

`RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_CONTRACT_IMPLEMENTATION_V0_PR_OPENED`

## Evidence refs

- Review: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/operator_review_runtime_bridge_pre_activation_gate_contract_v0_20260707T204930Z` (MANIFEST_VERIFY_RC=0)
- Proposal: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/runtime_bridge_pre_activation_gate_contract_proposal_v0_20260707T204830Z` (MANIFEST_VERIFY_RC=0)
- Implementation: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/runtime_bridge_pre_activation_gate_contract_v0_20260707T205208Z` (MANIFEST_VERIFY_RC=0)

## Strict no-activation / no-authority boundary

- NO runtime bridge activation
- NO runtime authority
- NO orders, scheduler, shadow, paper, testnet, canary, or live authorization
- NO Slice A/B lift
- NO registry or runbook mutation
- Evaluator returns FAIL at current HEAD (blocking gates active)
- Even PASS output keeps `authority_effect=NONE`, `runtime_effect=NONE`, `order_effect=NONE`, `execution_eligible=false`, `adapter_compatible=false`

## Changed files

- `src/trading/master_v2/runtime_bridge_pre_activation_gate_v0.py`
- `tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py`
- `scripts/ops/run_runtime_bridge_pre_activation_gate_contract_v0.py`

## Tests executed

- `python -m pytest tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py -q` — 13 passed
- `python scripts/ops/run_runtime_bridge_pre_activation_gate_contract_v0.py` — PASS, GATE_STATUS=FAIL
- `ruff format` / `ruff check` on changed files — RC=0

## Status remains blocked

- `RUNTIME_BRIDGE_ACTIVATION_ADMISSIBLE=false`
- `RUNTIME_AUTHORITY_ACTIVATED=false`
- `ORDERS_ALLOWED=false`
- Scheduler/Shadow/Paper/Testnet/Canary/Live remain false

## Test plan

- [x] Contract tests pass locally
- [x] Evidence collector produces manifest-verified bundle
- [x] Current-head default snapshot evaluates FAIL
- [ ] CI green on PR
