### PR TITLE
fix: split Surface P offline parity from runtime bridge activation

### DIFF
--- a/scripts/ops/run_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py
+++ b/scripts/ops/run_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for Surface P offline-complete runtime-bridge contract v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+SOURCE_EVIDENCE = (
+    ARCHIVE_ROOT
+    / "research/runtime_bridge_pre_activation_gate_readiness_assessment_v0_20260707T231500Z"
+)
+VERDICT = "SURFACE_P_OFFLINE_COMPLETE_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED_CONTRACT_V0_PASS"
+TARGETED_TESTS = (
+    "tests/trading/master_v2/test_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+    "tests/trading/master_v2/test_surface_p_full_bar_sequence_4_way_parity_completion_contract_v0.py",
+    "tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "scripts/ops/run_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
+    "tests/trading/master_v2/test_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.iterdir()):
+        if path.name == "MANIFEST.sha256":
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  {path.name}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def collect_evidence(out_dir: Path | None = None) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT
+        / f"research/surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    worktree = _run(["git", "status", "--short"]).stdout.strip()
+
+    source_proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=SOURCE_EVIDENCE)
+    (evidence_dir / "source_manifest_verify.log").write_text(
+        source_proc.stdout
+        + source_proc.stderr
+        + f"\nSOURCE_EVIDENCE_DIR={SOURCE_EVIDENCE}\nSOURCE_MANIFEST_VERIFY_RC={source_proc.returncode}\n",
+        encoding="utf-8",
+    )
+
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+        render_parity_gap_matrix_json_v0,
+    )
+    from trading.master_v2.surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0 import (
+        evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0,
+        surface_p_semantic_status_to_dict_v0,
+    )
+
+    semantic = evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0()
+    (evidence_dir / "SURFACE_P_SEMANTIC.json").write_text(
+        json.dumps(surface_p_semantic_status_to_dict_v0(semantic), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "FULL_CANONICAL_PARITY_GAP_MATRIX.json").write_text(
+        render_parity_gap_matrix_json_v0(),
+        encoding="utf-8",
+    )
+
+    env = {**dict(__import__("os").environ), "PYTHONPATH": str(REPO_ROOT / "src")}
+    pytest_proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (evidence_dir / "targeted_pytest.log").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    ruff_targets = [str(REPO_ROOT / p) for p in SLICE_CHANGED_FILES if p.endswith(".py")]
+    ruff_format = _run([sys.executable, "-m", "ruff", "format", *ruff_targets])
+    ruff_check = _run([sys.executable, "-m", "ruff", "check", *ruff_targets])
+    (evidence_dir / "ruff_format.log").write_text(
+        ruff_format.stdout + ruff_format.stderr,
+        encoding="utf-8",
+    )
+    (evidence_dir / "ruff_check.log").write_text(
+        ruff_check.stdout + ruff_check.stderr,
+        encoding="utf-8",
+    )
+
+    blocked = (
+        pytest_proc.returncode != 0
+        or ruff_format.returncode != 0
+        or ruff_check.returncode != 0
+        or source_proc.returncode != 0
+        or semantic.surface_p_offline_parity_status != "COMPLETE"
+        or semantic.surface_p_overall_status != "PARTIAL_RUNTIME_ACTIVATION_PENDING"
+        or semantic.runtime_bridge_activated
+    )
+    verdict = (
+        VERDICT
+        if not blocked
+        else "SURFACE_P_OFFLINE_COMPLETE_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED_CONTRACT_V0_BLOCKED"
+    )
+
+    (evidence_dir / "FINAL_REPORT.md").write_text(
+        "\n".join(
+            [
+                f"VERDICT={verdict}",
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"HEAD_EQUALS_ORIGIN_MAIN={str(head == origin_main).lower()}",
+                f"WORKTREE_STATUS={worktree or 'clean'}",
+                f"SOURCE_EVIDENCE_DIR={SOURCE_EVIDENCE}",
+                f"SOURCE_MANIFEST_VERIFY_RC={source_proc.returncode}",
+                "SURFACE_P_OFFLINE_PARITY_STATUS=COMPLETE",
+                "SURFACE_P_RUNTIME_BRIDGE_BINDING_STATUS=BOUND_NOT_ACTIVATED",
+                "SURFACE_P_RUNTIME_ACTIVATION_STATUS=NOT_ACTIVATED_POLICY_BLOCKED",
+                "SURFACE_P_OVERALL_STATUS=PARTIAL_RUNTIME_ACTIVATION_PENDING",
+                "RUNTIME_BRIDGE_ACTIVATED=false",
+                "RUNTIME_AUTHORITY_GRANTED=false",
+                "ORDER_AUTHORITY_GRANTED=false",
+                "SCHEDULER_AUTHORITY_GRANTED=false",
+                "SHADOW_PAPER_TESTNET_LIVE_AUTHORITY_GRANTED=false",
+                "AI_LAYER_AUTHORITY_EFFECT=NONE",
+                "AI_LAYER_ORDER_EFFECT=NONE",
+                "AI_LAYER_RUNTIME_EFFECT=NONE",
+                f"TARGETED_PYTEST_RC={pytest_proc.returncode}",
+                f"RUFF_FORMAT_RC={ruff_format.returncode}",
+                f"RUFF_CHECK_RC={ruff_check.returncode}",
+                f"DURABLE_EVIDENCE_DIR={evidence_dir}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_rc = _write_manifest(evidence_dir)
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_verify_rc": manifest_rc,
+        "pytest_rc": pytest_proc.returncode,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(args.out)
+    print(result["verdict"])
+    print(f"EVIDENCE_DIR={result['evidence_dir']}")
+    print(f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}")
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -93,6 +93,9 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
     "tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py",
     "tests/trading/master_v2/test_surface_p_full_bar_sequence_4_way_parity_completion_contract_v0.py",
+    "src/trading/master_v2/surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
+    "scripts/ops/run_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
+    "tests/trading/master_v2/test_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
 )
 
 FORBIDDEN_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
@@ -671,8 +674,17 @@ def normalize_matrix_status_v0(parity_status: ParityStatus) -> MatrixStatus:
 
 
 def parity_gap_records_v0() -> Tuple[Mapping[str, Any], ...]:
+    from trading.master_v2.surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0 import (
+        surface_p_offline_parity_complete_runtime_activation_pending_v0,
+    )
+
     records: list[Mapping[str, Any]] = []
     for item in parity_surface_assessments_v0():
+        if (
+            item.surface_id == "P"
+            and surface_p_offline_parity_complete_runtime_activation_pending_v0()
+        ):
+            continue
         matrix_status = normalize_matrix_status_v0(item.parity_status)
         if matrix_status != "GAP":
             continue
@@ -706,20 +718,33 @@ def parity_gap_records_v0() -> Tuple[Mapping[str, Any], ...]:
 
 
 def render_parity_gap_matrix_json_v0() -> str:
+    from trading.master_v2.surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0 import (
+        evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0,
+        surface_p_semantic_status_to_dict_v0,
+    )
+
+    surface_p_semantic = (
+        evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0()
+    )
     surfaces = []
     for item in parity_surface_assessments_v0():
-        surfaces.append(
-            {
-                "surface_id": item.surface_id,
-                "surface_name": item.surface_name,
-                "parity_status": item.parity_status,
-                "matrix_status": normalize_matrix_status_v0(item.parity_status),
-                "canonical_owner_files": list(item.canonical_owner_files),
-                "missing_binding": item.missing_binding_if_any or None,
-                "recommended_next_slice": item.recommended_next_slice,
-                "forbidden_runtime_authority_confirmed": item.forbidden_runtime_authority_confirmed,
-            }
-        )
+        surface_entry: dict[str, Any] = {
+            "surface_id": item.surface_id,
+            "surface_name": item.surface_name,
+            "parity_status": item.parity_status,
+            "matrix_status": normalize_matrix_status_v0(item.parity_status),
+            "canonical_owner_files": list(item.canonical_owner_files),
+            "missing_binding": item.missing_binding_if_any or None,
+            "recommended_next_slice": item.recommended_next_slice,
+            "forbidden_runtime_authority_confirmed": item.forbidden_runtime_authority_confirmed,
+        }
+        if item.surface_id == "P":
+            surface_entry["surface_p_semantic"] = dict(
+                surface_p_semantic_status_to_dict_v0(surface_p_semantic)
+            )
+            if surface_p_semantic.surface_p_overall_status == "PARTIAL_RUNTIME_ACTIVATION_PENDING":
+                surface_entry["matrix_status"] = "PARTIAL_RUNTIME_ACTIVATION_PENDING"
+        surfaces.append(surface_entry)
     counts = parity_status_counts_v0()
     gap_records = parity_gap_records_v0()
     payload = {
@@ -739,6 +764,7 @@ def render_parity_gap_matrix_json_v0() -> str:
         },
         "surfaces": surfaces,
         "gap_records": list(gap_records),
+        "surface_p_semantic": dict(surface_p_semantic_status_to_dict_v0(surface_p_semantic)),
     }
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"
 

--- a/src/trading/master_v2/surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py
+++ b/src/trading/master_v2/surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py
@@ -1,0 +1,172 @@
+"""
+Surface P offline-complete vs runtime-bridge-bound-not-activated contract v0.
+
+Fail-closed semantic split: offline/backtest/scenario 4-way parity may be COMPLETE
+while runtime bridge remains BOUND_NOT_ACTIVATED by policy. Does not grant runtime,
+order, scheduler, or AI trade authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Mapping, Tuple
+
+from trading.master_v2.ai_observability_boundary_offline_replay_binding_adapter_v0 import (
+    AI_LAYER_OBSERVABILITY_BOUNDARY_DOCUMENTED,
+    ORDER_EFFECT_NONE as AI_ORDER_EFFECT_NONE,
+    RUNTIME_AUTHORITY_EFFECT_NONE as AI_RUNTIME_AUTHORITY_EFFECT_NONE,
+)
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    RUNTIME_REFERENCE_INTEGRATION_STATUS_V0,
+    evaluate_surface_p_full_bar_sequence_four_way_parity_v0,
+)
+from trading.master_v2.legacy_runtime_entrypoint_guard_v0 import (
+    CANONICAL_RUNTIME_ENTRYPOINT_STATUS,
+)
+
+SURFACE_P_OFFLINE_COMPLETE_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED_CONTRACT_LAYER_VERSION = "v0"
+SURFACE_P_OFFLINE_COMPLETE_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED_CONTRACT_OWNER = (
+    "trading.master_v2.surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0"
+)
+CONTRACT_SLICE_ID = (
+    "SURFACE_P_OFFLINE_COMPLETE_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED_FAIL_CLOSED_CONTRACT_V0"
+)
+PACKAGE_MARKER = (
+    "SURFACE_P_OFFLINE_COMPLETE_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED_FAIL_CLOSED_CONTRACT_V0=true"
+)
+
+SurfacePOfflineParityStatus = Literal["COMPLETE", "INCOMPLETE"]
+SurfacePRuntimeBridgeBindingStatus = Literal["BOUND_NOT_ACTIVATED", "ACTIVATED", "UNBOUND"]
+SurfacePRuntimeActivationStatus = Literal["NOT_ACTIVATED_POLICY_BLOCKED", "ACTIVATED"]
+SurfacePOverallStatus = Literal[
+    "PARTIAL_RUNTIME_ACTIVATION_PENDING",
+    "PASS",
+    "GAP_OFFLINE_INCOMPLETE",
+]
+
+_AUTHORITY_EFFECT_NONE = "NONE"
+_ORDER_EFFECT_NONE = "NONE"
+_RUNTIME_EFFECT_NONE = "NONE"
+
+
+@dataclass(frozen=True)
+class SurfacePSemanticStatusV0:
+    surface_p_offline_parity_status: SurfacePOfflineParityStatus
+    surface_p_runtime_bridge_binding_status: SurfacePRuntimeBridgeBindingStatus
+    surface_p_runtime_activation_status: SurfacePRuntimeActivationStatus
+    surface_p_overall_status: SurfacePOverallStatus
+    offline_economic_evidence_blocked_by_runtime_activation: bool
+    runtime_authority_blocked_by_runtime_activation: bool
+    ai_observability_boundary_documented: bool
+    ai_layer_authority_effect: str
+    ai_layer_order_effect: str
+    ai_layer_runtime_effect: str
+    runtime_authority_granted: bool
+    order_authority_granted: bool
+    scheduler_authority_granted: bool
+    shadow_paper_testnet_live_authority_granted: bool
+    offline_four_way_fixtures_complete: bool
+    runtime_bridge_activated: bool
+    fail_closed_reasons: Tuple[str, ...]
+
+
+def _runtime_bridge_binding_status_v0() -> SurfacePRuntimeBridgeBindingStatus:
+    if CANONICAL_RUNTIME_ENTRYPOINT_STATUS == "BOUND_NOT_ACTIVATED":
+        return "BOUND_NOT_ACTIVATED"
+    if CANONICAL_RUNTIME_ENTRYPOINT_STATUS == "ACTIVATED":
+        return "ACTIVATED"
+    return "UNBOUND"
+
+
+def evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0(
+    *,
+    offline_four_way_fixtures_complete: bool | None = None,
+) -> SurfacePSemanticStatusV0:
+    """Evaluate fail-closed Surface P semantic split; never activates runtime bridge."""
+    bar_assessment = evaluate_surface_p_full_bar_sequence_four_way_parity_v0()
+    offline_complete = (
+        offline_four_way_fixtures_complete
+        if offline_four_way_fixtures_complete is not None
+        else bar_assessment.fixtures_complete
+    )
+    runtime_bridge_binding = _runtime_bridge_binding_status_v0()
+    runtime_bridge_activated = runtime_bridge_binding == "ACTIVATED"
+    runtime_activation_status: SurfacePRuntimeActivationStatus = (
+        "ACTIVATED" if runtime_bridge_activated else "NOT_ACTIVATED_POLICY_BLOCKED"
+    )
+
+    fail_reasons: list[str] = []
+    if not offline_complete:
+        fail_reasons.extend(bar_assessment.fail_closed_reasons or ("OFFLINE_FOUR_WAY_INCOMPLETE",))
+
+    if offline_complete and runtime_bridge_binding == "BOUND_NOT_ACTIVATED":
+        overall: SurfacePOverallStatus = "PARTIAL_RUNTIME_ACTIVATION_PENDING"
+    elif offline_complete and runtime_bridge_activated:
+        overall = "PASS"
+    else:
+        overall = "GAP_OFFLINE_INCOMPLETE"
+
+    return SurfacePSemanticStatusV0(
+        surface_p_offline_parity_status="COMPLETE" if offline_complete else "INCOMPLETE",
+        surface_p_runtime_bridge_binding_status=runtime_bridge_binding,
+        surface_p_runtime_activation_status=runtime_activation_status,
+        surface_p_overall_status=overall,
+        offline_economic_evidence_blocked_by_runtime_activation=False,
+        runtime_authority_blocked_by_runtime_activation=not runtime_bridge_activated,
+        ai_observability_boundary_documented=AI_LAYER_OBSERVABILITY_BOUNDARY_DOCUMENTED,
+        ai_layer_authority_effect=_AUTHORITY_EFFECT_NONE,
+        ai_layer_order_effect=AI_ORDER_EFFECT_NONE,
+        ai_layer_runtime_effect=AI_RUNTIME_AUTHORITY_EFFECT_NONE,
+        runtime_authority_granted=False,
+        order_authority_granted=False,
+        scheduler_authority_granted=False,
+        shadow_paper_testnet_live_authority_granted=False,
+        offline_four_way_fixtures_complete=offline_complete,
+        runtime_bridge_activated=runtime_bridge_activated,
+        fail_closed_reasons=tuple(fail_reasons),
+    )
+
+
+def surface_p_offline_parity_complete_runtime_activation_pending_v0(
+    semantic: SurfacePSemanticStatusV0 | None = None,
+) -> bool:
+    """True when offline parity is complete and only runtime activation remains policy-blocked."""
+    status = (
+        semantic
+        or evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0()
+    )
+    return (
+        status.surface_p_offline_parity_status == "COMPLETE"
+        and status.surface_p_runtime_bridge_binding_status == "BOUND_NOT_ACTIVATED"
+        and status.surface_p_runtime_activation_status == "NOT_ACTIVATED_POLICY_BLOCKED"
+        and status.surface_p_overall_status == "PARTIAL_RUNTIME_ACTIVATION_PENDING"
+    )
+
+
+def surface_p_semantic_status_to_dict_v0(
+    semantic: SurfacePSemanticStatusV0,
+) -> Mapping[str, object]:
+    return {
+        "surface_p_offline_parity_status": semantic.surface_p_offline_parity_status,
+        "surface_p_runtime_bridge_binding_status": semantic.surface_p_runtime_bridge_binding_status,
+        "surface_p_runtime_activation_status": semantic.surface_p_runtime_activation_status,
+        "surface_p_overall_status": semantic.surface_p_overall_status,
+        "offline_economic_evidence_blocked_by_runtime_activation": (
+            semantic.offline_economic_evidence_blocked_by_runtime_activation
+        ),
+        "runtime_authority_blocked_by_runtime_activation": (
+            semantic.runtime_authority_blocked_by_runtime_activation
+        ),
+        "ai_observability_boundary_documented": semantic.ai_observability_boundary_documented,
+        "ai_layer_authority_effect": semantic.ai_layer_authority_effect,
+        "ai_layer_order_effect": semantic.ai_layer_order_effect,
+        "ai_layer_runtime_effect": semantic.ai_layer_runtime_effect,
+        "runtime_authority_granted": semantic.runtime_authority_granted,
+        "order_authority_granted": semantic.order_authority_granted,
+        "scheduler_authority_granted": semantic.scheduler_authority_granted,
+        "shadow_paper_testnet_live_authority_granted": semantic.shadow_paper_testnet_live_authority_granted,
+        "offline_four_way_fixtures_complete": semantic.offline_four_way_fixtures_complete,
+        "runtime_bridge_activated": semantic.runtime_bridge_activated,
+        "runtime_reference_integration_status": RUNTIME_REFERENCE_INTEGRATION_STATUS_V0,
+        "fail_closed_reasons": list(semantic.fail_closed_reasons),
+    }

--- a/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
+++ b/tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py
@@ -215,7 +215,9 @@ def test_gap_matrix_json_machine_readable_v0() -> None:
         "NOT_APPLICABLE_BOUNDARY_ONLY",
         "BLOCKED",
         "UNKNOWN",
+        "PARTIAL_RUNTIME_ACTIVATION_PENDING",
     }
+    assert payload["surface_p_semantic"]["surface_p_offline_parity_status"] == "COMPLETE"
     for record in payload["gap_records"]:
         assert record["matrix_status"] == "GAP"
         assert record["missing_binding"]
@@ -230,7 +232,9 @@ def test_parity_gap_records_align_with_partial_surfaces_v0() -> None:
         if item.parity_status == "PARTIAL"
     }
     gap_record_ids = {record["surface_id"] for record in parity_gap_records_v0()}
-    assert partial_ids == gap_record_ids
+    assert "P" in partial_ids
+    assert "P" not in gap_record_ids
+    assert gap_record_ids <= partial_ids
     assert normalize_matrix_status_v0("NOT_APPLICABLE") == "NOT_APPLICABLE_BOUNDARY_ONLY"
     assert normalize_matrix_status_v0("PASS") == "PASS"
 

--- a/tests/trading/master_v2/test_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py
+++ b/tests/trading/master_v2/test_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py
@@ -1,0 +1,148 @@
+"""Surface P offline-complete vs runtime-bridge-bound-not-activated contract tests."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from trading.master_v2.ai_observability_boundary_offline_replay_binding_adapter_v0 import (
+    AI_LAYER_OBSERVABILITY_BOUNDARY_DOCUMENTED,
+    ORDER_EFFECT_NONE,
+    RUNTIME_AUTHORITY_EFFECT_NONE,
+)
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    ALLOWED_SLICE_CHANGED_PATH_PREFIXES,
+    parity_gap_records_v0,
+    parity_surface_assessments_v0,
+    render_parity_gap_matrix_json_v0,
+    scan_changed_paths_for_forbidden_runtime_v0,
+)
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    RUNTIME_REFERENCE_INTEGRATION_STATUS_V0,
+    evaluate_surface_p_full_bar_sequence_four_way_parity_v0,
+)
+from trading.master_v2.legacy_runtime_entrypoint_guard_v0 import (
+    CANONICAL_RUNTIME_ENTRYPOINT_STATUS,
+)
+from trading.master_v2.surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0 import (
+    CONTRACT_SLICE_ID,
+    PACKAGE_MARKER,
+    evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0,
+    surface_p_offline_parity_complete_runtime_activation_pending_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_SLICE_SOURCE_PATHS = tuple(
+    REPO_ROOT / p
+    for p in ALLOWED_SLICE_CHANGED_PATH_PREFIXES
+    if p.endswith(".py") and "surface_p_offline_complete_runtime_bridge" in p
+)
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def test_contract_constants_v0() -> None:
+    assert (
+        CONTRACT_SLICE_ID
+        == "SURFACE_P_OFFLINE_COMPLETE_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED_FAIL_CLOSED_CONTRACT_V0"
+    )
+    assert PACKAGE_MARKER.endswith("=true")
+
+
+def test_offline_four_way_parity_complete_runtime_bridge_bound_not_activated_v0() -> None:
+    bar = evaluate_surface_p_full_bar_sequence_four_way_parity_v0()
+    assert bar.fixtures_complete is True
+    assert bar.runtime_bridge_status == "BOUND_NOT_ACTIVATED"
+    assert CANONICAL_RUNTIME_ENTRYPOINT_STATUS == "BOUND_NOT_ACTIVATED"
+    assert RUNTIME_REFERENCE_INTEGRATION_STATUS_V0 == "BOUND_NOT_ACTIVATED"
+
+
+def test_surface_p_semantic_split_v0() -> None:
+    semantic = evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0()
+    assert semantic.surface_p_offline_parity_status == "COMPLETE"
+    assert semantic.surface_p_runtime_bridge_binding_status == "BOUND_NOT_ACTIVATED"
+    assert semantic.surface_p_runtime_activation_status == "NOT_ACTIVATED_POLICY_BLOCKED"
+    assert semantic.surface_p_overall_status == "PARTIAL_RUNTIME_ACTIVATION_PENDING"
+    assert semantic.offline_economic_evidence_blocked_by_runtime_activation is False
+    assert semantic.runtime_authority_blocked_by_runtime_activation is True
+    assert surface_p_offline_parity_complete_runtime_activation_pending_v0(semantic) is True
+
+
+def test_runtime_and_order_authority_remain_false_v0() -> None:
+    semantic = evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0()
+    assert semantic.runtime_authority_granted is False
+    assert semantic.order_authority_granted is False
+    assert semantic.scheduler_authority_granted is False
+    assert semantic.shadow_paper_testnet_live_authority_granted is False
+    assert semantic.runtime_bridge_activated is False
+
+
+def test_ai_observability_no_authority_boundary_v0() -> None:
+    semantic = evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0()
+    assert semantic.ai_observability_boundary_documented is True
+    assert (
+        semantic.ai_observability_boundary_documented == AI_LAYER_OBSERVABILITY_BOUNDARY_DOCUMENTED
+    )
+    assert semantic.ai_layer_authority_effect == "NONE"
+    assert semantic.ai_layer_order_effect == ORDER_EFFECT_NONE
+    assert semantic.ai_layer_runtime_effect == RUNTIME_AUTHORITY_EFFECT_NONE
+
+
+def test_surface_p_not_counted_as_offline_parity_gap_when_activation_pending_v0() -> None:
+    surface_p = next(item for item in parity_surface_assessments_v0() if item.surface_id == "P")
+    assert surface_p.parity_status == "PARTIAL"
+    gap_record_ids = {record["surface_id"] for record in parity_gap_records_v0()}
+    assert "P" not in gap_record_ids
+
+
+def test_parity_matrix_json_includes_surface_p_semantic_v0() -> None:
+    import json
+
+    payload = json.loads(render_parity_gap_matrix_json_v0())
+    assert payload["surface_p_semantic"]["surface_p_offline_parity_status"] == "COMPLETE"
+    assert (
+        payload["surface_p_semantic"]["surface_p_overall_status"]
+        == "PARTIAL_RUNTIME_ACTIVATION_PENDING"
+    )
+    surface_p = next(item for item in payload["surfaces"] if item["surface_id"] == "P")
+    assert surface_p["matrix_status"] == "PARTIAL_RUNTIME_ACTIVATION_PENDING"
+    assert surface_p["surface_p_semantic"]["runtime_bridge_activated"] is False
+
+
+def test_forbidden_runtime_paths_guard_v0() -> None:
+    ok, violations = scan_changed_paths_for_forbidden_runtime_v0(
+        ALLOWED_SLICE_CHANGED_PATH_PREFIXES
+    )
+    assert ok is True
+    assert violations == ()
+
+
+def test_slice_sources_exclude_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "execution",
+            "scheduler",
+            "credentials",
+            "live_runtime",
+            "testnet",
+            "shadow",
+            "paper_lane",
+        }
+    )
+    for path in _SLICE_SOURCE_PATHS:
+        assert path.is_file(), f"missing slice source: {path}"
+        hits = _scan_forbidden_imports(path, forbidden)
+        assert hits == [], f"forbidden imports in {path}: {hits}"


### PR DESCRIPTION
## Summary
- Adds fail-closed Surface P semantic contract splitting offline/backtest/scenario 4-way parity (`COMPLETE`) from runtime bridge binding (`BOUND_NOT_ACTIVATED`) and runtime activation (`NOT_ACTIVATED_POLICY_BLOCKED`).
- Extends canonical parity gap assessment JSON so Surface P uses `PARTIAL_RUNTIME_ACTIVATION_PENDING` instead of counting offline parity as a GAP when only runtime activation is policy-blocked.
- Documents AI/Observability as read-only/no-authority (`AI_LAYER_*_EFFECT=NONE`).

## Safety / scope
- **No runtime activation**
- **No order authority**
- **No scheduler authority**
- **No shadow/paper/testnet/live**
- **No AI autonomy / no AI trade authority**
- Source evidence manifest RC=0: `runtime_bridge_pre_activation_gate_readiness_assessment_v0_20260707T231500Z`

## Expected final state
- `SURFACE_P_OFFLINE_PARITY_STATUS=COMPLETE`
- `SURFACE_P_RUNTIME_BRIDGE_BINDING_STATUS=BOUND_NOT_ACTIVATED`
- `SURFACE_P_OVERALL_STATUS=PARTIAL_RUNTIME_ACTIVATION_PENDING`

## Test plan
- [x] `tests/trading/master_v2/test_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py`
- [x] `tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py`
- [x] `tests/trading/master_v2/test_surface_p_full_bar_sequence_4_way_parity_completion_contract_v0.py`
- [x] `tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py`
- [x] ruff format/check on changed Python files

Made with [Cursor](https://cursor.com)