### PR TITLE
feat: Surface P final flags fail-closed contract v0

### DIFF
--- a/scripts/ops/run_surface_p_final_flags_fail_closed_contract_v0.py
+++ b/scripts/ops/run_surface_p_final_flags_fail_closed_contract_v0.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for Surface P final flags fail-closed contract v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPT_ROOT = Path(__file__).resolve()
+REPO_ROOT = _SCRIPT_ROOT.parents[2]
+for parent in [_SCRIPT_ROOT, *_SCRIPT_ROOT.parents]:
+    if (parent / "src").is_dir() and (parent / ".git").exists():
+        REPO_ROOT = parent
+        repo_s = str(parent)
+        src_s = str(parent / "src")
+        if repo_s not in sys.path:
+            sys.path.insert(0, repo_s)
+        if src_s not in sys.path:
+            sys.path.insert(0, src_s)
+        break
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+SOURCE_EVIDENCE_DIRS = (
+    ARCHIVE_ROOT / "research/pr4984_runbook_compliant_merge_closeout_v0_20260707T235544Z",
+    ARCHIVE_ROOT
+    / "research/full_canonical_system_backtest_parity_gap_assessment_after_pr4984_v0_20260707T235724Z",
+    ARCHIVE_ROOT
+    / "research/surface_p_semantic_parity_gap_verification_after_pr4984_v0_20260707T235857Z",
+    ARCHIVE_ROOT
+    / "research/final_flags_fail_closed_contract_proposal_after_pr4984_v0_20260708T000035Z",
+)
+VERDICT = "SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_V0_PASS"
+TARGETED_TESTS = (
+    "tests/trading/master_v2/test_surface_p_final_flags_fail_closed_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+    "tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py",
+    "tests/trading/master_v2/test_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/surface_p_final_flags_fail_closed_contract_v0.py",
+    "src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py",
+    "src/trading/master_v2/runtime_bridge_pre_activation_gate_v0.py",
+    "scripts/ops/run_surface_p_final_flags_fail_closed_contract_v0.py",
+    "tests/trading/master_v2/test_surface_p_final_flags_fail_closed_contract_v0.py",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.iterdir()):
+        if path.name == "MANIFEST.sha256":
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  {path.name}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def collect_evidence(out_dir: Path | None = None) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT / f"research/surface_p_final_flags_fail_closed_contract_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    worktree = _run(["git", "status", "--short"]).stdout.strip()
+    changed = _run(["git", "diff", "--name-only", "origin/main...HEAD"]).stdout.strip()
+
+    preflight_lines = [
+        f"HEAD={head}",
+        f"ORIGIN_MAIN={origin_main}",
+        f"WORKTREE_STATUS={worktree or 'clean'}",
+        f"CONTRACT_SLICE_ID=SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_V0",
+        f"DIRECT_TRUE_FLAG_ASSIGNMENT=false",
+        f"RUNTIME_ACTIVATION=false",
+    ]
+    (evidence_dir / "preflight.txt").write_text("\n".join(preflight_lines) + "\n", encoding="utf-8")
+    (evidence_dir / "changed_files.txt").write_text(
+        (changed + "\n") if changed else "(no committed diff vs origin/main yet)\n",
+        encoding="utf-8",
+    )
+
+    source_lines: list[str] = []
+    source_rc = 0
+    for source_dir in SOURCE_EVIDENCE_DIRS:
+        proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=source_dir)
+        source_lines.append(f"=== {source_dir} RC={proc.returncode} ===")
+        source_lines.append(proc.stdout)
+        source_lines.append(proc.stderr)
+        if proc.returncode != 0:
+            source_rc = proc.returncode
+    (evidence_dir / "source_manifest_reverify.txt").write_text(
+        "\n".join(source_lines) + f"\nSOURCE_MANIFEST_VERIFY_RC={source_rc}\n",
+        encoding="utf-8",
+    )
+
+    from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+        render_parity_gap_matrix_json_v0,
+    )
+    from trading.master_v2.surface_p_final_flags_fail_closed_contract_v0 import (
+        DIRECT_TRUE_FLAG_ASSIGNMENT,
+        evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0,
+        surface_p_final_flags_result_to_dict_v0,
+    )
+
+    final_flags = evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0()
+    (evidence_dir / "FINAL_FLAGS.json").write_text(
+        json.dumps(surface_p_final_flags_result_to_dict_v0(final_flags), indent=2, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "FULL_CANONICAL_PARITY_GAP_MATRIX.json").write_text(
+        render_parity_gap_matrix_json_v0(),
+        encoding="utf-8",
+    )
+    (evidence_dir / "contract_summary.md").write_text(
+        "\n".join(
+            [
+                "# Surface P Final Flags Fail-Closed Contract v0",
+                "",
+                f"CONTRACT=SurfacePFinalFlagsFailClosedContractV0",
+                f"CONFIRMED_GAP=full_canonical_chain_final_flags",
+                f"DIRECT_TRUE_FLAG_ASSIGNMENT={str(DIRECT_TRUE_FLAG_ASSIGNMENT).lower()}",
+                f"FULL_CANONICAL_CHAIN_WIRED={str(final_flags.full_canonical_chain_wired).lower()}",
+                (
+                    "BACKTEST_RUNTIME_DECISION_PARITY_PASS="
+                    f"{str(final_flags.backtest_runtime_decision_parity_pass).lower()}"
+                ),
+                (
+                    "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE="
+                    f"{str(final_flags.system_economic_evidence_admissible).lower()}"
+                ),
+                f"RUNTIME_BRIDGE_BINDING_STATUS=BOUND_NOT_ACTIVATED",
+                "",
+                "## Fail-closed reasons",
+                "",
+                *[f"- {reason}" for reason in final_flags.fail_closed_reasons],
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {
+        **dict(__import__("os").environ),
+        "PYTHONPATH": f"{REPO_ROOT / 'src'}:{REPO_ROOT}",
+    }
+    pytest_proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (evidence_dir / "test_results.txt").write_text(
+        pytest_proc.stdout + pytest_proc.stderr + f"\nTARGETED_TESTS_RC={pytest_proc.returncode}\n",
+        encoding="utf-8",
+    )
+
+    ruff_targets = [str(REPO_ROOT / p) for p in SLICE_CHANGED_FILES if p.endswith(".py")]
+    ruff_format = _run([sys.executable, "-m", "ruff", "format", "--check", *ruff_targets])
+    ruff_check = _run([sys.executable, "-m", "ruff", "check", *ruff_targets])
+    (evidence_dir / "ruff_format.log").write_text(
+        ruff_format.stdout + ruff_format.stderr + f"\nRUFF_FORMAT_RC={ruff_format.returncode}\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "ruff_check.log").write_text(
+        ruff_check.stdout + ruff_check.stderr + f"\nRUFF_CHECK_RC={ruff_check.returncode}\n",
+        encoding="utf-8",
+    )
+
+    blocked = (
+        pytest_proc.returncode != 0
+        or ruff_format.returncode != 0
+        or ruff_check.returncode != 0
+        or source_rc != 0
+        or final_flags.full_canonical_chain_wired
+        or final_flags.backtest_runtime_decision_parity_pass
+        or final_flags.system_economic_evidence_admissible
+        or final_flags.direct_true_flag_assignment
+    )
+    verdict = VERDICT if not blocked else "SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_V0_BLOCKED"
+
+    (evidence_dir / "final_operator_report.txt").write_text(
+        "\n".join(
+            [
+                f"VERDICT={verdict}",
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"SOURCE_MANIFEST_VERIFY_RC={source_rc}",
+                f"TARGETED_TESTS_RC={pytest_proc.returncode}",
+                f"LINT_RC={max(ruff_format.returncode, ruff_check.returncode)}",
+                f"DURABLE_EVIDENCE_DIR={evidence_dir}",
+                f"DIRECT_TRUE_FLAG_ASSIGNMENT=false",
+                f"RUNTIME_ACTIVATION=false",
+                (
+                    "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE="
+                    f"{str(final_flags.system_economic_evidence_admissible).lower()}"
+                ),
+                f"FULL_CANONICAL_CHAIN_WIRED={str(final_flags.full_canonical_chain_wired).lower()}",
+                (
+                    "BACKTEST_RUNTIME_DECISION_PARITY_PASS="
+                    f"{str(final_flags.backtest_runtime_decision_parity_pass).lower()}"
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_rc = _write_manifest(evidence_dir)
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_verify_rc": manifest_rc,
+        "pytest_rc": pytest_proc.returncode,
+        "source_manifest_verify_rc": source_rc,
+        "lint_rc": max(ruff_format.returncode, ruff_check.returncode),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(args.out)
+    print(result["verdict"])
+    print(f"EVIDENCE_DIR={result['evidence_dir']}")
+    print(f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}")
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -96,6 +96,9 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
     "scripts/ops/run_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
     "tests/trading/master_v2/test_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
+    "src/trading/master_v2/surface_p_final_flags_fail_closed_contract_v0.py",
+    "scripts/ops/run_surface_p_final_flags_fail_closed_contract_v0.py",
+    "tests/trading/master_v2/test_surface_p_final_flags_fail_closed_contract_v0.py",
 )
 
 FORBIDDEN_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
@@ -718,6 +721,10 @@ def parity_gap_records_v0() -> Tuple[Mapping[str, Any], ...]:
 
 
 def render_parity_gap_matrix_json_v0() -> str:
+    from trading.master_v2.surface_p_final_flags_fail_closed_contract_v0 import (
+        evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0,
+        surface_p_final_flags_result_to_dict_v0,
+    )
     from trading.master_v2.surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0 import (
         evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0,
         surface_p_semantic_status_to_dict_v0,
@@ -726,6 +733,7 @@ def render_parity_gap_matrix_json_v0() -> str:
     surface_p_semantic = (
         evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0()
     )
+    final_flags = evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0()
     surfaces = []
     for item in parity_surface_assessments_v0():
         surface_entry: dict[str, Any] = {
@@ -758,13 +766,18 @@ def render_parity_gap_matrix_json_v0() -> str:
             "gap_surfaces": counts["GAP"],
             "not_applicable_surfaces": counts["NOT_APPLICABLE"],
             "matrix_gap_count": len(gap_records),
-            "full_canonical_chain_wired": False,
-            "backtest_runtime_decision_parity_pass": False,
-            "system_economic_evidence_admissible": False,
+            "full_canonical_chain_wired": final_flags.full_canonical_chain_wired,
+            "backtest_runtime_decision_parity_pass": (
+                final_flags.backtest_runtime_decision_parity_pass
+            ),
+            "system_economic_evidence_admissible": (
+                final_flags.system_economic_evidence_admissible
+            ),
         },
         "surfaces": surfaces,
         "gap_records": list(gap_records),
         "surface_p_semantic": dict(surface_p_semantic_status_to_dict_v0(surface_p_semantic)),
+        "final_flags": dict(surface_p_final_flags_result_to_dict_v0(final_flags)),
     }
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"
 
@@ -778,6 +791,11 @@ def parity_status_counts_v0() -> Mapping[str, int]:
 
 
 def render_parity_gap_matrix_markdown_v0() -> str:
+    from trading.master_v2.surface_p_final_flags_fail_closed_contract_v0 import (
+        evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0,
+    )
+
+    final_flags = evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0()
     lines = [
         "# Full Canonical System Backtest Parity Gap Matrix v0",
         "",
@@ -809,9 +827,15 @@ def render_parity_gap_matrix_markdown_v0() -> str:
             f"GAP_SURFACES={counts['GAP']}",
             f"NOT_APPLICABLE_SURFACES={counts['NOT_APPLICABLE']}",
             "",
-            "FULL_CANONICAL_CHAIN_WIRED=false",
-            "BACKTEST_RUNTIME_DECISION_PARITY_PASS=false",
-            "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false",
+            f"FULL_CANONICAL_CHAIN_WIRED={str(final_flags.full_canonical_chain_wired).lower()}",
+            (
+                "BACKTEST_RUNTIME_DECISION_PARITY_PASS="
+                f"{str(final_flags.backtest_runtime_decision_parity_pass).lower()}"
+            ),
+            (
+                "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE="
+                f"{str(final_flags.system_economic_evidence_admissible).lower()}"
+            ),
         ]
     )
     return "\n".join(lines) + "\n"

--- a/src/trading/master_v2/runtime_bridge_pre_activation_gate_v0.py
+++ b/src/trading/master_v2/runtime_bridge_pre_activation_gate_v0.py
@@ -136,19 +136,18 @@ def _bool_to_gate_status(value: bool) -> GateStatus:
 
 def current_head_default_gate_input_v0() -> RuntimeBridgePreActivationGateInputV0:
     """Reuse-first static snapshot aligned with gap assessment @ current main."""
-    import json
-
     from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
         parity_surface_assessments_v0,
-        render_parity_gap_matrix_json_v0,
     )
     from trading.master_v2.legacy_runtime_entrypoint_guard_v0 import (
         CANONICAL_RUNTIME_ENTRYPOINT_STATUS,
         SLICE_D_STATUS,
     )
+    from trading.master_v2.surface_p_final_flags_fail_closed_contract_v0 import (
+        evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0,
+    )
 
-    payload = json.loads(render_parity_gap_matrix_json_v0())
-    summary = payload["summary"]
+    final_flags = evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0()
     surface_p = next(item for item in parity_surface_assessments_v0() if item.surface_id == "P")
 
     legacy_ok = (
@@ -159,13 +158,13 @@ def current_head_default_gate_input_v0() -> RuntimeBridgePreActivationGateInputV
     return RuntimeBridgePreActivationGateInputV0(
         operator_go_token_status="FAIL",
         full_canonical_chain_wired_status=_bool_to_gate_status(
-            summary["full_canonical_chain_wired"]
+            final_flags.full_canonical_chain_wired
         ),
         backtest_runtime_decision_parity_status=_bool_to_gate_status(
-            summary["backtest_runtime_decision_parity_pass"]
+            final_flags.backtest_runtime_decision_parity_pass
         ),
         system_economic_evidence_admissible_status=_bool_to_gate_status(
-            summary["system_economic_evidence_admissible"]
+            final_flags.system_economic_evidence_admissible
         ),
         economic_validity_offline_gate_status="FAIL",
         surface_p_status="PASS" if surface_p.parity_status == "PASS" else "FAIL",

--- a/src/trading/master_v2/surface_p_final_flags_fail_closed_contract_v0.py
+++ b/src/trading/master_v2/surface_p_final_flags_fail_closed_contract_v0.py
@@ -1,0 +1,219 @@
+"""
+Surface P final flags fail-closed contract v0.
+
+Derives FULL_CANONICAL_CHAIN_WIRED, BACKTEST_RUNTIME_DECISION_PARITY_PASS, and
+SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE fail-closed from manifest-verified evidence
+and targeted parity confirmation. No runtime activation, no direct true assignment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Literal, Mapping, Tuple
+
+SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_LAYER_VERSION = "v0"
+SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_OWNER = (
+    "trading.master_v2.surface_p_final_flags_fail_closed_contract_v0"
+)
+CONTRACT_NAME = "SurfacePFinalFlagsFailClosedContractV0"
+CONTRACT_SLICE_ID = "SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_V0"
+PACKAGE_MARKER = "SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_V0=true"
+DIRECT_TRUE_FLAG_ASSIGNMENT = False
+
+REQUIRED_SEMANTIC_BINDING_CONFIRMATIONS_V0: Tuple[str, ...] = (
+    "bull_bear_state_switch_backtest_parity",
+    "scope_exit_reversal_backtest_parity",
+    "capital_risk_sizing_backtest_parity",
+    "safety_killswitch_backtest_boundary",
+    "reconciliation_unknown_outcome_backtest_boundary",
+    "promotion_gate_boundary",
+    "ai_observability_feedback_boundary",
+)
+
+_SURFACE_IDS_BY_SEMANTIC_BINDING_V0: dict[str, Tuple[str, ...]] = {
+    "bull_bear_state_switch_backtest_parity": ("A",),
+    "scope_exit_reversal_backtest_parity": ("B", "C"),
+    "capital_risk_sizing_backtest_parity": ("H",),
+    "safety_killswitch_backtest_boundary": ("J", "K"),
+    "reconciliation_unknown_outcome_backtest_boundary": ("L",),
+    "promotion_gate_boundary": ("M",),
+    "ai_observability_feedback_boundary": ("N", "O"),
+}
+
+_FINAL_FLAG_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        "full_canonical_chain_wired",
+        "backtest_runtime_decision_parity_pass",
+        "system_economic_evidence_admissible",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SurfacePFinalFlagsEvidenceInputV0:
+    source_manifest_verify_rc: int
+    targeted_semantic_binding_confirmations: Mapping[str, bool]
+    surface_p_parity_suite_confirmed: bool
+    runtime_bridge_binding_status: Literal["BOUND_NOT_ACTIVATED", "ACTIVATED", "UNBOUND"]
+
+
+@dataclass(frozen=True)
+class SurfacePFinalFlagsResultV0:
+    full_canonical_chain_wired: bool
+    backtest_runtime_decision_parity_pass: bool
+    system_economic_evidence_admissible: bool
+    direct_true_flag_assignment: bool
+    fail_closed_reasons: Tuple[str, ...]
+
+
+def reject_direct_true_flag_assignment_v0(**kwargs: object) -> Tuple[bool, Tuple[str, ...]]:
+    """Reject any attempt to inject final success flags directly into evaluation."""
+    violations = tuple(
+        f"direct_true_flag_assignment:{name}={kwargs[name]!r}"
+        for name in _FINAL_FLAG_FIELD_NAMES
+        if name in kwargs and kwargs[name] is True
+    )
+    return (not violations, violations)
+
+
+def _manifest_verified_v0(source_manifest_verify_rc: int) -> bool:
+    return source_manifest_verify_rc == 0
+
+
+def _semantic_bindings_confirmed_v0(
+    confirmations: Mapping[str, bool],
+) -> Tuple[bool, Tuple[str, ...]]:
+    missing = tuple(
+        key
+        for key in REQUIRED_SEMANTIC_BINDING_CONFIRMATIONS_V0
+        if not confirmations.get(key, False)
+    )
+    return (not missing, missing)
+
+
+def evaluate_surface_p_final_flags_fail_closed_contract_v0(
+    evidence: SurfacePFinalFlagsEvidenceInputV0,
+    *,
+    attempted_direct_true_flags: Mapping[str, bool] | None = None,
+) -> SurfacePFinalFlagsResultV0:
+    """Derive final Surface-P flags fail-closed; never grants runtime authority."""
+    fail_reasons: list[str] = []
+
+    if attempted_direct_true_flags:
+        rejected, violations = reject_direct_true_flag_assignment_v0(**attempted_direct_true_flags)
+        if not rejected:
+            fail_reasons.extend(violations)
+
+    if not _manifest_verified_v0(evidence.source_manifest_verify_rc):
+        fail_reasons.append(f"source_manifest_verify_rc!={evidence.source_manifest_verify_rc}")
+
+    semantic_ok, missing_bindings = _semantic_bindings_confirmed_v0(
+        evidence.targeted_semantic_binding_confirmations
+    )
+    if not semantic_ok:
+        for binding in missing_bindings:
+            fail_reasons.append(f"missing_semantic_binding_confirmation:{binding}")
+
+    if not evidence.surface_p_parity_suite_confirmed:
+        fail_reasons.append("surface_p_parity_suite_not_targeted_test_confirmed")
+
+    if evidence.runtime_bridge_binding_status == "BOUND_NOT_ACTIVATED":
+        fail_reasons.append("runtime_bridge_bound_not_activated")
+    elif evidence.runtime_bridge_binding_status == "UNBOUND":
+        fail_reasons.append("runtime_bridge_unbound")
+
+    manifest_ok = _manifest_verified_v0(evidence.source_manifest_verify_rc)
+    full_canonical_chain_wired = manifest_ok and semantic_ok
+    backtest_runtime_decision_parity_pass = (
+        manifest_ok and evidence.surface_p_parity_suite_confirmed
+    )
+    system_economic_evidence_admissible = (
+        full_canonical_chain_wired
+        and backtest_runtime_decision_parity_pass
+        and evidence.runtime_bridge_binding_status == "ACTIVATED"
+    )
+
+    if fail_reasons:
+        full_canonical_chain_wired = False
+        backtest_runtime_decision_parity_pass = False
+        system_economic_evidence_admissible = False
+
+    return SurfacePFinalFlagsResultV0(
+        full_canonical_chain_wired=full_canonical_chain_wired,
+        backtest_runtime_decision_parity_pass=backtest_runtime_decision_parity_pass,
+        system_economic_evidence_admissible=system_economic_evidence_admissible,
+        direct_true_flag_assignment=False,
+        fail_closed_reasons=tuple(fail_reasons),
+    )
+
+
+def derive_targeted_semantic_binding_confirmations_from_gap_assessment_v0() -> dict[str, bool]:
+    from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+        parity_surface_assessments_v0,
+    )
+
+    status_by_surface = {
+        item.surface_id: item.parity_status == "PASS" for item in parity_surface_assessments_v0()
+    }
+    return {
+        binding: all(status_by_surface.get(surface_id, False) for surface_id in surface_ids)
+        for binding, surface_ids in _SURFACE_IDS_BY_SEMANTIC_BINDING_V0.items()
+    }
+
+
+def derive_surface_p_parity_suite_confirmed_from_targeted_tests_v0() -> bool:
+    from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+        evaluate_surface_p_full_bar_sequence_four_way_parity_v0,
+    )
+    from trading.master_v2.surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0 import (
+        evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0,
+    )
+
+    bar_assessment = evaluate_surface_p_full_bar_sequence_four_way_parity_v0()
+    semantic = evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0(
+        offline_four_way_fixtures_complete=bar_assessment.fixtures_complete,
+    )
+    return (
+        bar_assessment.fixtures_complete
+        and semantic.surface_p_offline_parity_status == "COMPLETE"
+        and semantic.surface_p_overall_status == "PASS"
+    )
+
+
+def current_head_default_final_flags_evidence_input_v0() -> SurfacePFinalFlagsEvidenceInputV0:
+    """Reuse-first snapshot: manifest unverified and runtime bridge policy-blocked."""
+    from trading.master_v2.surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0 import (
+        evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0,
+    )
+
+    semantic = evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0()
+    return SurfacePFinalFlagsEvidenceInputV0(
+        source_manifest_verify_rc=-1,
+        targeted_semantic_binding_confirmations=derive_targeted_semantic_binding_confirmations_from_gap_assessment_v0(),
+        surface_p_parity_suite_confirmed=derive_surface_p_parity_suite_confirmed_from_targeted_tests_v0(),
+        runtime_bridge_binding_status=semantic.surface_p_runtime_bridge_binding_status,
+    )
+
+
+def evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0() -> (
+    SurfacePFinalFlagsResultV0
+):
+    return evaluate_surface_p_final_flags_fail_closed_contract_v0(
+        current_head_default_final_flags_evidence_input_v0()
+    )
+
+
+def surface_p_final_flags_result_to_dict_v0(
+    result: SurfacePFinalFlagsResultV0,
+) -> Mapping[str, object]:
+    return {
+        "full_canonical_chain_wired": result.full_canonical_chain_wired,
+        "backtest_runtime_decision_parity_pass": result.backtest_runtime_decision_parity_pass,
+        "system_economic_evidence_admissible": result.system_economic_evidence_admissible,
+        "direct_true_flag_assignment": result.direct_true_flag_assignment,
+        "fail_closed_reasons": list(result.fail_closed_reasons),
+    }
+
+
+def surface_p_final_flags_evidence_input_field_names_v0() -> Tuple[str, ...]:
+    return tuple(field.name for field in fields(SurfacePFinalFlagsEvidenceInputV0))

--- a/tests/trading/master_v2/test_surface_p_final_flags_fail_closed_contract_v0.py
+++ b/tests/trading/master_v2/test_surface_p_final_flags_fail_closed_contract_v0.py
@@ -1,0 +1,240 @@
+"""Surface P final flags fail-closed contract tests (offline only)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    ALLOWED_SLICE_CHANGED_PATH_PREFIXES,
+    render_parity_gap_matrix_json_v0,
+    scan_changed_paths_for_forbidden_runtime_v0,
+)
+from trading.master_v2.legacy_runtime_entrypoint_guard_v0 import (
+    CANONICAL_RUNTIME_ENTRYPOINT_STATUS,
+)
+from trading.master_v2.surface_p_final_flags_fail_closed_contract_v0 import (
+    CONTRACT_NAME,
+    CONTRACT_SLICE_ID,
+    DIRECT_TRUE_FLAG_ASSIGNMENT,
+    PACKAGE_MARKER,
+    REQUIRED_SEMANTIC_BINDING_CONFIRMATIONS_V0,
+    SurfacePFinalFlagsEvidenceInputV0,
+    current_head_default_final_flags_evidence_input_v0,
+    derive_targeted_semantic_binding_confirmations_from_gap_assessment_v0,
+    evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0,
+    evaluate_surface_p_final_flags_fail_closed_contract_v0,
+    reject_direct_true_flag_assignment_v0,
+    surface_p_final_flags_evidence_input_field_names_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_FINAL_FLAG_FIELD_NAMES = frozenset(
+    {
+        "full_canonical_chain_wired",
+        "backtest_runtime_decision_parity_pass",
+        "system_economic_evidence_admissible",
+    }
+)
+
+_SLICE_SOURCE_PATHS = tuple(
+    REPO_ROOT / p
+    for p in ALLOWED_SLICE_CHANGED_PATH_PREFIXES
+    if p.endswith(".py") and "surface_p_final_flags_fail_closed_contract" in p
+)
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def _all_confirmed_evidence(
+    *,
+    manifest_rc: int = 0,
+    runtime_bridge_binding_status: str = "ACTIVATED",
+) -> SurfacePFinalFlagsEvidenceInputV0:
+    return SurfacePFinalFlagsEvidenceInputV0(
+        source_manifest_verify_rc=manifest_rc,
+        targeted_semantic_binding_confirmations={
+            key: True for key in REQUIRED_SEMANTIC_BINDING_CONFIRMATIONS_V0
+        },
+        surface_p_parity_suite_confirmed=True,
+        runtime_bridge_binding_status=runtime_bridge_binding_status,  # type: ignore[arg-type]
+    )
+
+
+def test_contract_constants_v0() -> None:
+    assert CONTRACT_NAME == "SurfacePFinalFlagsFailClosedContractV0"
+    assert CONTRACT_SLICE_ID == "SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_V0"
+    assert PACKAGE_MARKER == "SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_V0=true"
+    assert DIRECT_TRUE_FLAG_ASSIGNMENT is False
+
+
+def test_evidence_input_has_no_direct_final_flag_fields_v0() -> None:
+    assert _FINAL_FLAG_FIELD_NAMES.isdisjoint(surface_p_final_flags_evidence_input_field_names_v0())
+
+
+def test_missing_evidence_all_final_success_flags_false_v0() -> None:
+    result = evaluate_surface_p_final_flags_fail_closed_contract_v0(
+        SurfacePFinalFlagsEvidenceInputV0(
+            source_manifest_verify_rc=-1,
+            targeted_semantic_binding_confirmations={},
+            surface_p_parity_suite_confirmed=False,
+            runtime_bridge_binding_status="BOUND_NOT_ACTIVATED",
+        )
+    )
+    assert result.full_canonical_chain_wired is False
+    assert result.backtest_runtime_decision_parity_pass is False
+    assert result.system_economic_evidence_admissible is False
+    assert result.direct_true_flag_assignment is False
+
+
+def test_manifest_verify_nonzero_all_final_success_flags_false_v0() -> None:
+    result = evaluate_surface_p_final_flags_fail_closed_contract_v0(
+        _all_confirmed_evidence(manifest_rc=1)
+    )
+    assert result.full_canonical_chain_wired is False
+    assert result.backtest_runtime_decision_parity_pass is False
+    assert result.system_economic_evidence_admissible is False
+    assert any("source_manifest_verify_rc" in reason for reason in result.fail_closed_reasons)
+
+
+def test_incomplete_semantic_binding_full_canonical_chain_wired_false_v0() -> None:
+    confirmations = {key: True for key in REQUIRED_SEMANTIC_BINDING_CONFIRMATIONS_V0}
+    confirmations["promotion_gate_boundary"] = False
+    result = evaluate_surface_p_final_flags_fail_closed_contract_v0(
+        SurfacePFinalFlagsEvidenceInputV0(
+            source_manifest_verify_rc=0,
+            targeted_semantic_binding_confirmations=confirmations,
+            surface_p_parity_suite_confirmed=True,
+            runtime_bridge_binding_status="ACTIVATED",
+        )
+    )
+    assert result.full_canonical_chain_wired is False
+    assert result.system_economic_evidence_admissible is False
+    assert any(
+        reason.startswith("missing_semantic_binding_confirmation:")
+        for reason in result.fail_closed_reasons
+    )
+
+
+def test_missing_surface_p_parity_confirmation_backtest_parity_false_v0() -> None:
+    result = evaluate_surface_p_final_flags_fail_closed_contract_v0(
+        SurfacePFinalFlagsEvidenceInputV0(
+            source_manifest_verify_rc=0,
+            targeted_semantic_binding_confirmations={
+                key: True for key in REQUIRED_SEMANTIC_BINDING_CONFIRMATIONS_V0
+            },
+            surface_p_parity_suite_confirmed=False,
+            runtime_bridge_binding_status="ACTIVATED",
+        )
+    )
+    assert result.backtest_runtime_decision_parity_pass is False
+    assert result.system_economic_evidence_admissible is False
+    assert "surface_p_parity_suite_not_targeted_test_confirmed" in result.fail_closed_reasons
+
+
+def test_runtime_bridge_bound_not_activated_system_economic_false_v0() -> None:
+    result = evaluate_surface_p_final_flags_fail_closed_contract_v0(
+        _all_confirmed_evidence(runtime_bridge_binding_status="BOUND_NOT_ACTIVATED")
+    )
+    assert result.system_economic_evidence_admissible is False
+    assert "runtime_bridge_bound_not_activated" in result.fail_closed_reasons
+
+
+def test_direct_true_flag_assignment_rejected_fail_closed_v0() -> None:
+    rejected, violations = reject_direct_true_flag_assignment_v0(
+        full_canonical_chain_wired=True,
+        backtest_runtime_decision_parity_pass=True,
+    )
+    assert rejected is False
+    assert violations
+
+    result = evaluate_surface_p_final_flags_fail_closed_contract_v0(
+        _all_confirmed_evidence(),
+        attempted_direct_true_flags={"full_canonical_chain_wired": True},
+    )
+    assert result.full_canonical_chain_wired is False
+    assert result.direct_true_flag_assignment is False
+    assert any("direct_true_flag_assignment:" in reason for reason in result.fail_closed_reasons)
+
+
+def test_only_complete_manifest_verified_evidence_can_derive_true_flags_v0() -> None:
+    result = evaluate_surface_p_final_flags_fail_closed_contract_v0(_all_confirmed_evidence())
+    assert result.full_canonical_chain_wired is True
+    assert result.backtest_runtime_decision_parity_pass is True
+    assert result.system_economic_evidence_admissible is True
+    assert result.direct_true_flag_assignment is False
+    assert result.fail_closed_reasons == ()
+
+
+def test_current_head_default_all_final_flags_false_v0() -> None:
+    result = evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0()
+    assert result.full_canonical_chain_wired is False
+    assert result.backtest_runtime_decision_parity_pass is False
+    assert result.system_economic_evidence_admissible is False
+    assert result.direct_true_flag_assignment is False
+    assert CANONICAL_RUNTIME_ENTRYPOINT_STATUS == "BOUND_NOT_ACTIVATED"
+
+
+def test_current_head_default_manifest_unverified_v0() -> None:
+    evidence = current_head_default_final_flags_evidence_input_v0()
+    assert evidence.source_manifest_verify_rc != 0
+    assert evidence.runtime_bridge_binding_status == "BOUND_NOT_ACTIVATED"
+
+
+def test_gap_assessment_semantic_bindings_derived_from_targeted_pass_surfaces_v0() -> None:
+    confirmations = derive_targeted_semantic_binding_confirmations_from_gap_assessment_v0()
+    assert all(confirmations[key] for key in REQUIRED_SEMANTIC_BINDING_CONFIRMATIONS_V0)
+
+
+def test_parity_gap_matrix_json_uses_derived_final_flags_v0() -> None:
+    import json
+
+    payload = json.loads(render_parity_gap_matrix_json_v0())
+    final_flags = payload["final_flags"]
+    summary = payload["summary"]
+    assert summary["full_canonical_chain_wired"] == final_flags["full_canonical_chain_wired"]
+    assert (
+        summary["backtest_runtime_decision_parity_pass"]
+        == final_flags["backtest_runtime_decision_parity_pass"]
+    )
+    assert (
+        summary["system_economic_evidence_admissible"]
+        == final_flags["system_economic_evidence_admissible"]
+    )
+    assert final_flags["direct_true_flag_assignment"] is False
+    assert summary["full_canonical_chain_wired"] is False
+
+
+def test_slice_sources_have_no_forbidden_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "src.execution",
+            "src.live",
+            "src.runtime",
+            "src.scheduler",
+            "credentials",
+            "secrets",
+        }
+    )
+    for path in _SLICE_SOURCE_PATHS:
+        assert _scan_forbidden_imports(path, forbidden) == []
+
+
+def test_slice_changed_paths_allowed_v0() -> None:
+    ok, violations = scan_changed_paths_for_forbidden_runtime_v0(
+        [p.replace(REPO_ROOT.as_posix() + "/", "") for p in map(str, _SLICE_SOURCE_PATHS)]
+    )
+    assert ok, violations


### PR DESCRIPTION
## Summary
- Adds `SurfacePFinalFlagsFailClosedContractV0` to derive `FULL_CANONICAL_CHAIN_WIRED`, `BACKTEST_RUNTIME_DECISION_PARITY_PASS`, and `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE` fail-closed from manifest-verified evidence and targeted parity confirmation.
- Wires the contract into the existing gap-assessment JSON/markdown renderer and runtime-bridge pre-activation gate default snapshot (reuse-first; no runtime activation).
- Adds targeted contract tests and a durable evidence runner under the runtime evidence archive.

## Test plan
- [x] `pytest -q tests/trading/master_v2/test_surface_p_final_flags_fail_closed_contract_v0.py`
- [x] `pytest -q tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py`
- [x] `pytest -q tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py`
- [x] `pytest -q tests/trading/master_v2/test_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py`
- [x] `ruff format --check` + `ruff check` on touched files
- [x] Source manifest reverify RC=0 for PR4984 closeout, assessment, semantic reverify, and proposal bundles
- [x] Durable evidence bundle MANIFEST.sha256 verify RC=0


Made with [Cursor](https://cursor.com)