### PR TITLE
docs: mark kraken references as legacy guarded infrastructure

### DIFF
--- a/INSTALLATION_UND_ROADMAP_BIS_FINISH_2026-01-12.md
+++ b/INSTALLATION_UND_ROADMAP_BIS_FINISH_2026-01-12.md
@@ -213,7 +213,7 @@ Dieses Dokument beschreibt:
 
 **Optional:**
 - **Docker** (für containerisierte Deployment)
-- **API-Keys** für Testnet-Exchange (Kraken Testnet)
+- **API-Keys** für legacy/decommissioned Testnet-Exchange (Kraken Testnet — nicht kanonischer Ziel-Venue)
 - **Slack Webhook** (für Alerts)
 
 **Unterstützte Betriebssysteme:**

--- a/WORKFLOW_RUNBOOK_OVERVIEW_2026-01-12.md
+++ b/WORKFLOW_RUNBOOK_OVERVIEW_2026-01-12.md
@@ -482,7 +482,9 @@ python scripts/live_web_server.py \
 
 #### Aktueller technischer Stand:
 
-**Data-Layer:** ✅ Loader, Normalizer, Cache, Kraken-Integration  
+> **Venue clarification:** Kraken is not the current canonical target venue (`default_exchange=okx_europe_eea`).
+
+**Data-Layer:** ✅ Loader, Normalizer, Cache, legacy Kraken public-OHLCV (nicht kanonischer Ziel-Venue; default_exchange=okx_europe_eea)  
 **Strategy-Layer:** ✅ BaseStrategy, MACrossover, RsiReversion, DonchianBreakout  
 **Core-Layer:** ✅ Config, PositionSizing, RiskManagement  
 **Backtest-Layer:** ✅ BacktestEngine, Stats  

--- a/docs/audit/VENUE_KRAKEN_LEGACY_CLARIFICATION_V0.md
+++ b/docs/audit/VENUE_KRAKEN_LEGACY_CLARIFICATION_V0.md
@@ -1,0 +1,37 @@
+# Venue Kraken Legacy Clarification v0
+
+**Status:** audit note (doc-only)  
+**Date:** 2026-07-08  
+**Scope:** documentation and legacy-script wording only — no runtime rewire
+
+## Machine-readable summary
+
+```
+KRAKEN_CURRENT_TARGET_VENUE=false
+KRAKEN_REFERENCES_ARE_LEGACY_OR_GUARDED_INFRASTRUCTURE=true
+NO_RUNTIME_AUTHORITY_FROM_VENUE_REFERENCES=true
+CURRENT_CANONICAL_VENUE_SSOT=okx_europe_eea
+```
+
+## Operator read
+
+- Production config default venue is **OKX EEA** (`config/config.toml`: `default_exchange = "okx_europe_eea"`).
+- Kraken profiles in config are **DORMANT/DECOMMISSIONED** unless separately ratified.
+- Kraken references in docs, comments, legacy scripts, guarded ops tooling, and negative test fixtures denote **historical/legacy** or **guarded infrastructure** only.
+- No Kraken mention grants runtime, order, credential, scheduler, shadow, paper, testnet, canary, or live authority.
+
+## Evidence chain
+
+- Legacy audit: `venue_kraken_legacy_audit_v0_20260708T002338Z`
+- Blocker refinement: `venue_kraken_blocker_refinement_v0_20260708T002605Z`
+- Cleanup PR scope: doc/comments/legacy-script text only (`DOC_AND_LEGACY_SCRIPT_CLEANUP_ONLY_NO_RUNTIME_REWIRE`)
+
+## Forbidden misreadings
+
+Do **not** treat any of the following as current canonical venue SSOT:
+
+- `CURRENT_TARGET_VENUE`
+- `CURRENT_CANONICAL_VENUE_SSOT`
+- stale project-docs Kraken pipeline summaries
+- legacy demo scripts (`scripts/demo_kraken_simple.py`, registry backtest helpers)
+- dormant Kraken config profile blocks

--- a/docs/project_docs/CONFIG_IMPORT_GUIDE.md
+++ b/docs/project_docs/CONFIG_IMPORT_GUIDE.md
@@ -35,7 +35,9 @@ Vertiefung Registry: [CONFIG_REGISTRY_USAGE.md](../CONFIG_REGISTRY_USAGE.md).
 
 ## 3. Empfohlene Imports nach Anwendungsfall
 
-### 3.1 Live-Session, Kraken, bounded Live-Limits
+### 3.1 Live-Session, legacy Kraken profiles, bounded Live-Limits
+
+> **Venue clarification:** Kraken is not the current canonical target venue (`default_exchange=okx_europe_eea`). Kraken config profiles are dormant/decommissioned legacy unless separately ratified.
 
 ```python
 from src.core.peak_config import (

--- a/docs/project_docs/FINAL_SUMMARY.md
+++ b/docs/project_docs/FINAL_SUMMARY.md
@@ -1,5 +1,7 @@
 # Peak_Trade - Finale Implementierungs-Zusammenfassung
 
+> **Venue clarification (2026-07-08):** Kraken is **not** the current canonical target venue (`default_exchange=okx_europe_eea`). Kraken references below are **historical/legacy** or **guarded infrastructure** only unless separately ratified. No venue reference grants runtime, order, credential, scheduler, shadow, paper, testnet, canary, or live authority.
+
 **Datum:** 2024-12-02
 **Status:** ✅ Vollständig implementiert und getestet
 
@@ -46,7 +48,7 @@ max_total_exposure = 0.75
 
 ---
 
-### 3. ✅ Kraken Data Pipeline
+### 3. ✅ Kraken Data Pipeline (legacy / guarded infrastructure)
 
 **Implementiert:**
 - ✅ `src/data/kraken_pipeline.py` - Vollständige Pipeline-Integration

--- a/docs/project_docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/project_docs/IMPLEMENTATION_SUMMARY.md
@@ -1,5 +1,7 @@
 # Peak_Trade - Implementierungs-Zusammenfassung
 
+> **Venue clarification (2026-07-08):** Kraken is **not** the current canonical target venue (`default_exchange=okx_europe_eea`). Kraken references below are **historical/legacy** or **guarded infrastructure** only unless separately ratified.
+
 **Datum:** 2024-12-02
 **Status:** ✅ Erfolgreich implementiert
 
@@ -67,7 +69,7 @@ print(config.risk.max_daily_loss)  # 0.03
 
 ---
 
-### 3. ✅ Kraken Data Pipeline
+### 3. ✅ Kraken Data Pipeline (legacy / guarded infrastructure)
 
 **Neu implementierte Dateien:**
 - `src/data/kraken_pipeline.py` - Vollständige Pipeline-Integration

--- a/docs/project_docs/NEXT_STEPS.md
+++ b/docs/project_docs/NEXT_STEPS.md
@@ -1,10 +1,12 @@
 # Peak_Trade - Nächste Schritte
 
+> **Venue clarification (2026-07-08):** Kraken is **not** the current canonical target venue (`default_exchange=okx_europe_eea`). Kraken references below are **historical/legacy** infrastructure only unless separately ratified.
+
 ## ✅ Fertig Implementiert
 
 1. ✅ Risk-Layer (Position Sizing + Limits)
 2. ✅ Config-System mit TOML
-3. ✅ Kraken Data Pipeline
+3. ✅ Kraken Data Pipeline (legacy / guarded infrastructure)
 4. ✅ Demo-Scripts
 5. ✅ Dokumentation
 

--- a/scripts/_shared_forward_args.py
+++ b/scripts/_shared_forward_args.py
@@ -3,9 +3,14 @@
 Gemeinsame CLI-Defaults und Argument-Gruppe für Forward-/Portfolio-OHLCV (J1).
 
 Drei Skripte teilen denselben Parametervertrag für ``--n-bars``/``--bars``,
-``--ohlcv-source`` und ``--timeframe`` (Kraken; Dummy ignoriert ``timeframe`` intern 1h).
+``--ohlcv-source`` und ``--timeframe`` (optional legacy Kraken; Dummy ignoriert
+``timeframe`` intern 1h).
 
-Gemeinsame CLI-Normalisierung inkl. lokaler CSV (``--ohlcv-csv``); Kraken-Pagination für große ``n-bars`` liegt im Loader.
+Gemeinsame CLI-Normalisierung inkl. lokaler CSV (``--ohlcv-csv``); legacy Kraken-Pagination
+für große ``n-bars`` liegt im Loader.
+
+Legacy note: Kraken is not the current canonical target venue. ``--ohlcv-source=kraken`` is
+historical/guarded public OHLCV infrastructure only unless separately ratified.
 
 NO-LIVE: keine Order-Ausführung; Kraken-Pfad nur öffentliche OHLCV (Stub), siehe Epilog-Helfer unten.
 """

--- a/scripts/_shared_ohlcv_loader.py
+++ b/scripts/_shared_ohlcv_loader.py
@@ -2,8 +2,11 @@
 """
 Gemeinsamer OHLCV-Loader für Forward-/Paper-Skripte (J1).
 
+Legacy note: Kraken is not the current canonical target venue. ``source="kraken"`` below is
+historical/guarded public OHLCV infrastructure only unless separately ratified.
+
 Gleicher DataFrame-Vertrag für ``generate_forward_signals``, ``evaluate_forward_signals``,
-``run_portfolio_backtest_v2`` (Slice 1–3: Dummy; Slice 4: optional Kraken über ``load_ohlcv``).
+``run_portfolio_backtest_v2`` (Slice 1–3: Dummy; Slice 4: optional legacy Kraken über ``load_ohlcv``).
 
 - ``DatetimeIndex`` (1h, **UTC**), Spalten open/high/low/close/volume (vgl. ``src.data.REQUIRED_OHLCV_COLUMNS``).
 - Dummy: OHLC-Nachkorrektur zentral; vor Rückgabe ``validate_ohlcv(..., strict=True, require_tz=True)``.

--- a/scripts/demo_kraken_simple.py
+++ b/scripts/demo_kraken_simple.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 """
-Peak_Trade Kraken Integration Demo
-====================================
+Peak_Trade Kraken Integration Demo (legacy, non-canonical)
+==========================================================
 Einfaches Demo für Kraken → Normalizer → Cache → Backtest Pipeline.
+
+Legacy note: Kraken is not the current canonical target venue (production default:
+okx_europe_eea). This standalone demo uses historical/guarded Kraken public-data paths
+only. No venue reference grants runtime, order, credential, scheduler, shadow, paper,
+testnet, canary, or live authority.
 
 Usage:
     python scripts/demo_kraken_simple.py

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -10,7 +10,7 @@ Execution-Scope. Das Handelssymbol für Metadaten kommt aus der Config über
 
 Workflow:
 1. Config laden (TOML)
-2. Daten-Pipeline aufbauen (CSV oder Kraken API)
+2. Daten-Pipeline aufbauen (CSV oder optional legacy Kraken public OHLCV — nicht kanonisch)
 3. Strategie instanziieren
 4. Backtest ausführen (run_realistic)
 5. Stats berechnen

--- a/scripts/run_portfolio_backtest.py
+++ b/scripts/run_portfolio_backtest.py
@@ -117,7 +117,8 @@ def load_data_for_symbol(
     Lädt Daten für ein bestimmtes Symbol.
 
     Aktuell: Dummy-Daten mit symbol-spezifischem Seed.
-    NOTE: Siehe docs/TECH_DEBT_BACKLOG.md (Eintrag "Echte Kraken-Daten: run_portfolio_backtest.py")
+    NOTE: Legacy Kraken OHLCV ist nicht der kanonische Ziel-Venue-Pfad (default_exchange=okx_europe_eea).
+    Siehe docs/TECH_DEBT_BACKLOG.md (Eintrag "Echte Kraken-Daten: run_portfolio_backtest.py")
 
     Args:
         symbol: Trading-Pair (z.B. "BTC/EUR")

--- a/scripts/run_registry_portfolio_backtest.py
+++ b/scripts/run_registry_portfolio_backtest.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 """
-Peak_Trade - End-to-End Registry Portfolio Backtest
-=====================================================
+Peak_Trade - End-to-End Registry Portfolio Backtest (legacy script)
+====================================================================
 Vollständiger Backtest mit echten Marktdaten über Registry + Portfolio + Engine.
 
+Legacy note: Kraken is not the current canonical target venue (production default:
+okx_europe_eea). Optional Kraken OHLCV below is historical/legacy data infrastructure
+only unless separately ratified. No venue reference grants runtime authority.
+
 Features:
-- Lädt echte Kraken-Daten über Data-Layer (mit Caching)
+- Optional legacy Kraken public OHLCV über Data-Layer (mit Caching; nicht kanonisch)
 - Nutzt Portfolio-Config aus config.toml
 - Multi-Strategie-Backtest mit Registry-Integration
 - Export von Ergebnissen (CSV/JSON)

--- a/src/ops/okx_europe_adapter_lifecycle_contract_v0.py
+++ b/src/ops/okx_europe_adapter_lifecycle_contract_v0.py
@@ -4,8 +4,9 @@ Pure offline, fixture-evaluable contracts for auth capabilities, order/cancel/fi
 normalization, client-order-id semantics, reconciliation FSM, and durable evidence.
 
 Does not authorize network, credentials, private API, orders, runtime, or promotion.
-PE-12 and PE-9 remain Kraken-scoped — this module is the OKX-Europe Success-SSOT for
-adapter lifecycle semantics only.
+Kraken is not the current canonical target venue; historical PE-12/PE-9 Kraken scope notes
+are legacy only. This module is the OKX-Europe Success-SSOT for adapter lifecycle semantics
+only unless separately ratified.
 """
 
 from __future__ import annotations

--- a/tests/ops/test_venue_kraken_legacy_doc_clarification_v0.py
+++ b/tests/ops/test_venue_kraken_legacy_doc_clarification_v0.py
@@ -1,0 +1,57 @@
+"""Docs-contract guard: stale Kraken docs must not claim current target venue SSOT."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+POSITIVE_CLAIM_PHRASES = (
+    "Kraken is the current canonical target venue",
+    "Kraken is the current target venue",
+    "CURRENT_CANONICAL_VENUE_SSOT=kraken",
+    'default_exchange = "kraken"',
+    'default_exchange="kraken"',
+)
+
+CLARIFIED_DOC_PATHS = (
+    REPO_ROOT / "docs" / "project_docs" / "FINAL_SUMMARY.md",
+    REPO_ROOT / "docs" / "project_docs" / "IMPLEMENTATION_SUMMARY.md",
+    REPO_ROOT / "docs" / "project_docs" / "NEXT_STEPS.md",
+    REPO_ROOT / "docs" / "project_docs" / "CONFIG_IMPORT_GUIDE.md",
+    REPO_ROOT / "WORKFLOW_RUNBOOK_OVERVIEW_2026-01-12.md",
+)
+
+
+def test_venue_kraken_legacy_clarification_audit_note_present_v0() -> None:
+    text = (REPO_ROOT / "docs" / "audit" / "VENUE_KRAKEN_LEGACY_CLARIFICATION_V0.md").read_text(
+        encoding="utf-8"
+    )
+    assert "KRAKEN_CURRENT_TARGET_VENUE=false" in text
+    assert "KRAKEN_REFERENCES_ARE_LEGACY_OR_GUARDED_INFRASTRUCTURE=true" in text
+    assert "NO_RUNTIME_AUTHORITY_FROM_VENUE_REFERENCES=true" in text
+    assert "okx_europe_eea" in text
+
+
+def _normalized_doc_text(text: str) -> str:
+    return text.lower().replace("*", "")
+
+
+def test_clarified_kraken_docs_do_not_claim_current_target_venue_ssot_v0() -> None:
+    for path in CLARIFIED_DOC_PATHS:
+        text = path.read_text(encoding="utf-8")
+        for phrase in POSITIVE_CLAIM_PHRASES:
+            assert phrase not in text, (
+                f"{path.relative_to(REPO_ROOT)} contains forbidden phrase: {phrase!r}"
+            )
+        normalized = _normalized_doc_text(text)
+        assert "not the current canonical target venue" in normalized
+        assert "okx_europe_eea" in normalized
+
+
+def test_legacy_kraken_demo_script_docstring_marks_non_canonical_v0() -> None:
+    text = (REPO_ROOT / "scripts" / "demo_kraken_simple.py").read_text(encoding="utf-8")
+    assert "legacy" in text.lower()
+    assert "not the current canonical target venue" in text.lower()
+    for phrase in POSITIVE_CLAIM_PHRASES:
+        assert phrase not in text


### PR DESCRIPTION
## Summary
- Mark stale Kraken references as historical/legacy or guarded infrastructure in project docs, legacy script docstrings, and a narrow audit note.
- Add docs-contract regression tests asserting clarified docs do not claim Kraken as current canonical target venue.
- Canonical production venue remains OKX EEA (`default_exchange=okx_europe_eea`).

## Scope
This PR changes only documentation, comments/docstrings, legacy wording, and optional narrow docs-contract tests. It does not change venue selection, config defaults, execution behavior, safety behavior, runtime authority, orders, credentials, scheduler, shadow, paper, testnet, canary, or live authority.

## Test plan
- [x] `pytest tests/ops/test_venue_kraken_legacy_doc_clarification_v0.py`
- [x] `ruff format --check` and `ruff check` on changed Python files
- [x] Post-cleanup venue refinement metrics remain non-material (0 canonical Kraken SSOT / 0 authority paths)

Made with [Cursor](https://cursor.com)