### PR TITLE
fix: fail closed promotion eligibility live flag

### DIFF
--- a/scripts/run_promotion_proposal_cycle.py
+++ b/scripts/run_promotion_proposal_cycle.py
@@ -237,7 +237,7 @@ def main() -> None:
     for candidate in candidates:
         confidence = candidate.patch.confidence_score
         if confidence and confidence >= 0.75:
-            candidate.eligible_for_live = True
+            candidate.eligible_for_live = False
             print(
                 f"[promotion_loop] Marked {candidate.patch.id} as eligible_for_live (confidence: {confidence:.2f})"
             )


### PR DESCRIPTION
## Summary

This PR fixes the executable promotion-cycle true-authority surface by changing the promotion candidate live eligibility assignment from fail-open to fail-closed:

```python
candidate.eligible_for_live = False
```

## Scope

- Narrow one-line fix in `scripts/run_promotion_proposal_cycle.py`
- No Runtime, Order, Scheduler, Shadow, Paper, Testnet, Canary, or Live authority granted
- No promotion authority granted
- No core trading logic, Master V2, Double Play, risk/sizing, safety, runtime, adapter, or credential changes

## Validation

Promotion fix evidence:

```text
VERDICT=PROMOTION_ELIGIBILITY_TRUE_FLAG_FAIL_CLOSED_FIX_V0_PASS
COMMIT=f6f90f29
AST_TRUE_ASSIGNMENT_HITS=0
AST_FALSE_ASSIGNMENT_HITS=1
NARROW_PYTEST=211 passed
COMPILE_RC=0
RUFF_RC=0
MANIFEST_VERIFY_RC=0
DURABLE_EVIDENCE_DIR=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/promotion_eligibility_true_flag_fail_closed_fix_v0_20260708T005443Z
```

Post-fix true-authority surface rescan:

```text
VERDICT=TRUE_AUTHORITY_SURFACE_RESCAN_AFTER_PROMOTION_FIX_V0_PASS
HEAD=f6f90f29
SOURCE_MANIFEST_VERIFY_RC=0
MANIFEST_VERIFY_RC=0
PROMOTION_TARGET_AST_TRUE_HITS=0
PROMOTION_TARGET_AST_FALSE_HITS=1
EXECUTABLE_TRUE_AUTHORITY_ASSIGNMENT_BLOCKER_COUNT=0
RAW_TRUE_AUTHORITY_GREP_BLOCKER_COUNT=0
TARGETED_PYTEST_RC=0
COMPILE_RC=0
RUFF_RC=0
PR_CREATION_ADMISSIBLE=true
DURABLE_EVIDENCE_DIR=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/true_authority_surface_rescan_after_promotion_fix_v0_20260708T005713Z
```

## Authority boundary

```text
RUNTIME_AUTHORITY_GRANTED=false
PROMOTION_AUTHORITY_GRANTED=false
ORDER_AUTHORITY_GRANTED=false
LIVE_AUTHORIZED=false
READY_FOR_OPERATOR_ARMING=false
SCHEDULER_RUNTIME_ALLOWED=false
```

## Next after green checks

```text
MERGE_CLOSEOUT_AFTER_GREEN_CHECKS_WITH_POST_MERGE_MAIN_SYNC_AND_MANIFEST_VERIFY_V0
```