### PR TITLE
fix: accept current main for non class d offline eval runner

### DIFF
--- a/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
+++ b/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
@@ -63,6 +63,11 @@ PR4826_MERGE_COMMIT = "208ab96562f7750fb4dff43936b345a040d1cea4"
 PR4832_MERGE_COMMIT = "ddce9c508158b89fa225c381436e2d1efced7328"
 PR4833_MERGE_COMMIT = "4828168cd91c57aa72dcb3b40b47188eeb82fd32"
 PR4834_MERGE_COMMIT = "0d23e662c4a0b8e0638a919ac879490e82e2ef41"
+# Non-Class-D offline evaluation allowlist admission for current origin/main after full
+# canonical system backtest parity closeout and final research fleet binding ratification.
+ORIGIN_MAIN_AFTER_FULL_CANONICAL_BACKTEST_PARITY_CLOSEOUT_SHA = (
+    "01186e8d7657b107651ec00a6bb68a70e45a5c87"
+)
 SQUASH_MERGE_IDENTITY_CONTRACT_INTRODUCED_AT = PR4834_MERGE_COMMIT
 MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA = PR4832_MERGE_COMMIT
 # Class-D execution origin is resolved live from origin/main (identity-gated, not statically pinned).
@@ -76,6 +81,7 @@ ACCEPTED_ORIGIN_MAIN_SHAS: frozenset[str] = frozenset(
         MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
         PR4833_MERGE_COMMIT,
         PR4834_MERGE_COMMIT,
+        ORIGIN_MAIN_AFTER_FULL_CANONICAL_BACKTEST_PARITY_CLOSEOUT_SHA,
     }
 )
 REQUIRED_MERGED_PR_NUMBER = 4826

--- a/tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py
+++ b/tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py
@@ -1,0 +1,58 @@
+"""Narrow contract tests for Non-Class-D offline evaluation origin-main allowlist."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
+    ORIGIN_MAIN_AFTER_FULL_CANONICAL_BACKTEST_PARITY_CLOSEOUT_SHA,
+    PR4826_MERGE_COMMIT,
+    PR4833_MERGE_COMMIT,
+    PR4834_MERGE_COMMIT,
+    MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
+    is_accepted_origin_main_sha,
+    is_class_d_binding_completion_v0,
+    resolve_current_execution_origin_main_sha,
+    verify_origin_main_sha_for_binding_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NON_CLASS_D_BINDING_PATH = (
+    REPO_ROOT / "config/research/final_research_fleet_versioned_binding_completion_v0.json"
+)
+
+
+def test_legacy_non_class_d_origin_main_shas_remain_accepted() -> None:
+    for sha in (
+        PR4826_MERGE_COMMIT,
+        MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
+        PR4833_MERGE_COMMIT,
+        PR4834_MERGE_COMMIT,
+    ):
+        assert is_accepted_origin_main_sha(sha)
+
+
+def test_current_origin_main_accepted_for_non_class_d_policy() -> None:
+    live_origin_main = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "origin/main"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert live_origin_main == resolve_current_execution_origin_main_sha(REPO_ROOT)
+    assert live_origin_main == ORIGIN_MAIN_AFTER_FULL_CANONICAL_BACKTEST_PARITY_CLOSEOUT_SHA
+    assert is_accepted_origin_main_sha(live_origin_main)
+
+
+def test_verify_origin_main_accepts_current_main_for_non_class_d_binding() -> None:
+    fleet_binding_completion = json.loads(NON_CLASS_D_BINDING_PATH.read_text(encoding="utf-8"))
+    assert is_class_d_binding_completion_v0(fleet_binding_completion) is False
+    live_origin_main = resolve_current_execution_origin_main_sha(REPO_ROOT)
+    ok, reasons = verify_origin_main_sha_for_binding_v0(
+        origin_main_sha=live_origin_main,
+        fleet_binding_completion=fleet_binding_completion,
+    )
+    assert ok is True
+    assert reasons == ()


### PR DESCRIPTION
## Summary

- Adds `01186e8d7657b107651ec00a6bb68a70e45a5c87` (current `origin/main`) to `ACCEPTED_ORIGIN_MAIN_SHAS` for Non-Class-D offline economic evaluation origin policy only.
- Unblocks `ORIGIN_MAIN_SHA_MISMATCH` observed when running the canonical ops runner with `final_research_fleet_versioned_binding_completion_v0.json` on current main.
- No evaluation logic, binding, dataset, cost, runtime, promotion, or safety changes.

## Test plan

- [x] `pytest tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py -q` (3 passed)
- [x] `ruff format --check` / `ruff check` on touched files
- [x] Source repair + blocked-run durable evidence manifests re-verified (RC=0)
- [ ] Offline economic evaluation rerun deferred to follow-up step after merge


Made with [Cursor](https://cursor.com)