### PR TITLE
fix: accept post-pr4990 origin main for non class d offline eval

### DIFF
--- a/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
+++ b/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
@@ -63,10 +63,14 @@ PR4826_MERGE_COMMIT = "208ab96562f7750fb4dff43936b345a040d1cea4"
 PR4832_MERGE_COMMIT = "ddce9c508158b89fa225c381436e2d1efced7328"
 PR4833_MERGE_COMMIT = "4828168cd91c57aa72dcb3b40b47188eeb82fd32"
 PR4834_MERGE_COMMIT = "0d23e662c4a0b8e0638a919ac879490e82e2ef41"
-# Non-Class-D offline evaluation allowlist admission for current origin/main after full
+# Non-Class-D offline evaluation allowlist admission for origin/main after full
 # canonical system backtest parity closeout and final research fleet binding ratification.
 ORIGIN_MAIN_AFTER_FULL_CANONICAL_BACKTEST_PARITY_CLOSEOUT_SHA = (
     "01186e8d7657b107651ec00a6bb68a70e45a5c87"
+)
+# Post-PR4990 origin/main after the Non-Class-D offline-eval origin-main policy merge.
+ORIGIN_MAIN_AFTER_NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_PR4990_SHA = (
+    "90d9b538bf1c23580a13ffb97d1c8d016ee95581"
 )
 SQUASH_MERGE_IDENTITY_CONTRACT_INTRODUCED_AT = PR4834_MERGE_COMMIT
 MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA = PR4832_MERGE_COMMIT
@@ -82,6 +86,7 @@ ACCEPTED_ORIGIN_MAIN_SHAS: frozenset[str] = frozenset(
         PR4833_MERGE_COMMIT,
         PR4834_MERGE_COMMIT,
         ORIGIN_MAIN_AFTER_FULL_CANONICAL_BACKTEST_PARITY_CLOSEOUT_SHA,
+        ORIGIN_MAIN_AFTER_NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_PR4990_SHA,
     }
 )
 REQUIRED_MERGED_PR_NUMBER = 4826

--- a/tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py
+++ b/tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
     ORIGIN_MAIN_AFTER_FULL_CANONICAL_BACKTEST_PARITY_CLOSEOUT_SHA,
+    ORIGIN_MAIN_AFTER_NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_PR4990_SHA,
     PR4826_MERGE_COMMIT,
     PR4833_MERGE_COMMIT,
     PR4834_MERGE_COMMIT,
@@ -30,6 +31,7 @@ def test_legacy_non_class_d_origin_main_shas_remain_accepted() -> None:
         MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
         PR4833_MERGE_COMMIT,
         PR4834_MERGE_COMMIT,
+        ORIGIN_MAIN_AFTER_FULL_CANONICAL_BACKTEST_PARITY_CLOSEOUT_SHA,
     ):
         assert is_accepted_origin_main_sha(sha)
 
@@ -42,7 +44,10 @@ def test_current_origin_main_accepted_for_non_class_d_policy() -> None:
         check=True,
     ).stdout.strip()
     assert live_origin_main == resolve_current_execution_origin_main_sha(REPO_ROOT)
-    assert live_origin_main == ORIGIN_MAIN_AFTER_FULL_CANONICAL_BACKTEST_PARITY_CLOSEOUT_SHA
+    assert (
+        live_origin_main
+        == ORIGIN_MAIN_AFTER_NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_PR4990_SHA
+    )
     assert is_accepted_origin_main_sha(live_origin_main)
 
 

--- a/tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py
+++ b/tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py
@@ -45,8 +45,7 @@ def test_current_origin_main_accepted_for_non_class_d_policy() -> None:
     ).stdout.strip()
     assert live_origin_main == resolve_current_execution_origin_main_sha(REPO_ROOT)
     assert (
-        live_origin_main
-        == ORIGIN_MAIN_AFTER_NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_PR4990_SHA
+        live_origin_main == ORIGIN_MAIN_AFTER_NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_PR4990_SHA
     )
     assert is_accepted_origin_main_sha(live_origin_main)
 


### PR DESCRIPTION
Fail-closed follow-up for the Non-Class-D offline evaluation policy after PR #4990 merge.

- Adds current post-merge origin/main SHA 90d9b538bf1c23580a13ffb97d1c8d016ee95581 to the accepted Non-Class-D offline-evaluation origin-main policy surface
- Preserves previous accepted SHA 01186e8d7657b107651ec00a6bb68a70e45a5c87
- Keeps evaluation offline-only
- No runtime, promotion, shadow, paper, testnet, scheduler, order, credential, arming, canary, or live authority

Evidence:
/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/fix_non_class_d_offline_eval_origin_main_allowlist_after_pr4990_v0_20260708T070645Z

Made with [Cursor](https://cursor.com)