### PR TITLE
fix: live post-merge origin/main policy for non-class-d offline eval

### DIFF
--- a/scripts/ops/squash_merge_post_merge_closeout_guard_v0.sh
+++ b/scripts/ops/squash_merge_post_merge_closeout_guard_v0.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 PACKAGE_MARKER="SQUASH_MERGE_POST_MERGE_CLOSEOUT_GUARD_V0=true"
 DEFAULT_PYTEST_K='evidence or manifest or docs or governance'
+NON_CLASS_D_ORIGIN_MAIN_POLICY_TEST_REL="tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py"
 REMOTE="${REMOTE:-origin}"
 MAIN_BRANCH="${MAIN_BRANCH:-main}"
 
@@ -21,6 +22,9 @@ Commands:
 Options:
   --evidence-dir <dir>     Required. Durable evidence output directory
   --pytest-k <expr>        Pytest -k expression (default: evidence or manifest or docs or governance)
+  --pytest-target <path>   Run pytest against an explicit test file path
+  --non-class-d-origin-main-policy-test
+                           Run canonical Non-Class-D origin-main policy contract test
   --skip-ruff              Skip ruff format/check gates
   --skip-pytest            Skip targeted pytest gate
   --verify-source-manifest Verify SOURCE_MANIFEST path when set in env
@@ -107,10 +111,27 @@ verify_source_manifest_if_referenced() {
   return 0
 }
 
+resolve_non_class_d_origin_main_policy_test_path() {
+  if [[ -f "$NON_CLASS_D_ORIGIN_MAIN_POLICY_TEST_REL" ]]; then
+    echo "$NON_CLASS_D_ORIGIN_MAIN_POLICY_TEST_REL"
+    return 0
+  fi
+  echo "BLOCKED_NON_CLASS_D_ORIGIN_MAIN_POLICY_TEST_MISSING=${NON_CLASS_D_ORIGIN_MAIN_POLICY_TEST_REL}" >&2
+  return 1
+}
+
 run_targeted_pytest() {
   local pytest_k="$1"
+  local pytest_target="${2:-}"
   local log_file="${EVIDENCE_DIR}/pytest_targeted_post_merge.log"
-  local python_cmd=(python3 -m pytest tests -q -k "$pytest_k")
+  local python_cmd
+  if [[ -n "$pytest_target" ]]; then
+    python_cmd=(python3 -m pytest "$pytest_target" -q)
+    printf '%s\n' "$pytest_target" >"${EVIDENCE_DIR}/pytest_target_path.txt"
+  else
+    python_cmd=(python3 -m pytest tests -q -k "$pytest_k")
+    printf '%s\n' "$pytest_k" >"${EVIDENCE_DIR}/pytest_target_k.txt"
+  fi
   if [[ -d src ]]; then
     PYTHONPATH="${PYTHONPATH:-src}" run_teed "$log_file" env PYTHONPATH="${PYTHONPATH:-src}" "${python_cmd[@]}"
   else
@@ -159,6 +180,8 @@ verify_closeout_manifest() {
 
 cmd_post_merge_validate() {
   local pytest_k="$DEFAULT_PYTEST_K"
+  local pytest_target=""
+  local non_class_d_origin_main_policy_test=0
   local skip_ruff=0
   local skip_pytest=0
   local verify_source=0
@@ -178,6 +201,16 @@ cmd_post_merge_validate() {
         pytest_k="$1"
         shift
         ;;
+      --pytest-target)
+        shift
+        [[ $# -gt 0 ]] || die_usage "Missing value for --pytest-target"
+        pytest_target="$1"
+        shift
+        ;;
+      --non-class-d-origin-main-policy-test)
+        non_class_d_origin_main_policy_test=1
+        shift
+        ;;
       --skip-ruff) skip_ruff=1; shift ;;
       --skip-pytest) skip_pytest=1; shift ;;
       --verify-source-manifest) verify_source=1; shift ;;
@@ -193,6 +226,12 @@ cmd_post_merge_validate() {
 
   [[ -n "$EVIDENCE_DIR" ]] || die_usage "--evidence-dir is required"
   mkdir -p "$EVIDENCE_DIR"
+
+  if [[ "$non_class_d_origin_main_policy_test" -eq 1 ]]; then
+    if ! pytest_target="$(resolve_non_class_d_origin_main_policy_test_path)"; then
+      die_usage "Canonical Non-Class-D origin-main policy test missing"
+    fi
+  fi
 
   local pytest_rc=0
   local ruff_rc=0
@@ -211,7 +250,7 @@ cmd_post_merge_validate() {
   fi
 
   if [[ "$skip_pytest" -eq 0 ]]; then
-    if ! run_targeted_pytest "$pytest_k"; then
+    if ! run_targeted_pytest "$pytest_k" "$pytest_target"; then
       pytest_rc=6
     fi
     printf '%s\n' "$pytest_rc" >"${EVIDENCE_DIR}/pytest_targeted_post_merge.rc"

--- a/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
+++ b/src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py
@@ -99,6 +99,10 @@ ACCEPTED_ORIGIN_MAIN_SHAS: frozenset[str] = frozenset(
         ORIGIN_MAIN_AFTER_PR4992_NON_CLASS_D_ORIGIN_MAIN_ALLOWLIST_FIX_SHA,
     }
 )
+HISTORICAL_NON_CLASS_D_ACCEPTED_ORIGIN_MAIN_SHAS = ACCEPTED_ORIGIN_MAIN_SHAS
+NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_TEST_REL = (
+    "tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py"
+)
 REQUIRED_MERGED_PR_NUMBER = 4826
 CLASS_D_BINDING_COMPLETION_ID = "final_research_fleet_class_d_versioned_binding_completion_v0"
 CLASS_D_BINDING_COMPLETION_SCHEMA_VERSION = (
@@ -161,6 +165,8 @@ REASON_MANIFEST_VERIFY_FAILED = "MANIFEST_VERIFY_FAILED"
 REASON_BINDING_DIGEST_MISMATCH = "CANDIDATE_BINDING_DIGEST_MISMATCH"
 REASON_BINDING_IDENTITY_MISMATCH = "BINDING_IDENTITY_MISMATCH"
 REASON_CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE = "CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE"
+REASON_LOCAL_HEAD_NOT_ORIGIN_MAIN = "LOCAL_HEAD_NOT_ORIGIN_MAIN"
+REASON_WORKTREE_NOT_CLEAN = "WORKTREE_NOT_CLEAN"
 REASON_ORIGIN_MAIN_RESOLVE_FAILED = "ORIGIN_MAIN_RESOLVE_FAILED"
 REASON_UNMODIFIED_BINDING_RETRY_BLOCKED = "UNMODIFIED_BINDING_RETRY_BLOCKED"
 REASON_NEW_EVIDENCE_CLASS_REQUIRED = "NEW_EVIDENCE_CLASS_REQUIRED_FOR_REEXECUTION"
@@ -268,6 +274,69 @@ def resolve_current_execution_origin_main_sha(repo_root: Path) -> str:
     return _resolve_origin_main_sha(repo_root)
 
 
+def resolve_local_head_sha(repo_root: Path) -> str:
+    """Resolve the local HEAD SHA for post-merge sync verification."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def is_worktree_clean(repo_root: Path) -> bool:
+    """Return True only when the worktree has no staged or unstaged changes."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "status", "--porcelain"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False
+    return result.stdout.strip() == ""
+
+
+def resolve_non_class_d_offline_eval_origin_main_policy_test_path_v0(
+    repo_root: Path,
+) -> Path:
+    """Canonical Non-Class-D origin-main policy contract test path."""
+    return repo_root / NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_TEST_REL
+
+
+def is_non_class_d_offline_eval_origin_main_policy_test_present_v0(repo_root: Path) -> bool:
+    return resolve_non_class_d_offline_eval_origin_main_policy_test_path_v0(repo_root).is_file()
+
+
+def validate_non_class_d_live_post_merge_origin_main_v0(
+    *,
+    origin_main_sha: str,
+    repo_root: Path | None,
+    live_origin_main_sha: str | None = None,
+) -> tuple[bool, tuple[str, ...]]:
+    """Accept Non-Class-D live origin/main only after synced post-merge HEAD proof."""
+    if repo_root is None:
+        return False, (REASON_ORIGIN_MAIN_RESOLVE_FAILED,)
+    live = live_origin_main_sha or resolve_current_execution_origin_main_sha(repo_root)
+    if not live:
+        return False, (REASON_ORIGIN_MAIN_RESOLVE_FAILED,)
+    local_head = resolve_local_head_sha(repo_root)
+    if not local_head:
+        return False, (REASON_ORIGIN_MAIN_RESOLVE_FAILED,)
+    if origin_main_sha != live:
+        return False, (
+            f"{REASON_CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE}:{origin_main_sha}!={live}",
+        )
+    if local_head != live:
+        return False, (f"{REASON_LOCAL_HEAD_NOT_ORIGIN_MAIN}:{local_head}!={live}",)
+    if not is_worktree_clean(repo_root):
+        return False, (REASON_WORKTREE_NOT_CLEAN,)
+    return True, ()
+
+
 def resolve_expected_origin_main_sha(repo_root: Path) -> str:
     """Legacy alias for resolve_current_execution_origin_main_sha."""
     return resolve_current_execution_origin_main_sha(repo_root)
@@ -306,7 +375,8 @@ def is_accepted_go_token(token: str) -> bool:
 
 
 def is_accepted_origin_main_sha(origin_main_sha: str) -> bool:
-    return origin_main_sha in ACCEPTED_ORIGIN_MAIN_SHAS
+    """Historical Non-Class-D allowlist membership (replay documentation only)."""
+    return origin_main_sha in HISTORICAL_NON_CLASS_D_ACCEPTED_ORIGIN_MAIN_SHAS
 
 
 def is_class_d_binding_completion_v0(fleet_binding_completion: Mapping[str, Any]) -> bool:
@@ -470,9 +540,11 @@ def verify_origin_main_sha_for_binding_v0(
             fleet_binding_completion=fleet_binding_completion,
             live_origin_main_sha=live,
         )
-    if not is_accepted_origin_main_sha(origin_main_sha):
-        return False, (f"{REASON_ORIGIN_MAIN_MISMATCH}:{origin_main_sha}",)
-    return True, ()
+    return validate_non_class_d_live_post_merge_origin_main_v0(
+        origin_main_sha=origin_main_sha,
+        repo_root=repo_root,
+        live_origin_main_sha=live_origin_main_sha,
+    )
 
 
 def load_scope_ratification_for_execution_v0(

--- a/tests/ops/test_squash_merge_post_merge_closeout_guard_v0_contract.py
+++ b/tests/ops/test_squash_merge_post_merge_closeout_guard_v0_contract.py
@@ -211,6 +211,13 @@ def test_post_merge_validate_passes_when_pytest_and_manifest_ok(tmp_path: Path) 
     assert (evidence / "pytest_targeted_post_merge.log").is_file()
 
 
+def test_guard_script_resolves_non_class_d_origin_main_policy_test_path() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py" in text
+    assert "resolve_non_class_d_origin_main_policy_test_path" in text
+    assert "--non-class-d-origin-main-policy-test" in text
+
+
 def test_meta_conftest_pytest_plugins_collection_no_longer_errors() -> None:
     proc = subprocess.run(
         [

--- a/tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py
+++ b/tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py
@@ -1,23 +1,30 @@
-"""Narrow contract tests for Non-Class-D offline evaluation origin-main allowlist."""
+"""Narrow contract tests for Non-Class-D offline evaluation live origin-main policy."""
 
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
+    NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_TEST_REL,
     ORIGIN_MAIN_AFTER_FULL_CANONICAL_BACKTEST_PARITY_CLOSEOUT_SHA,
     ORIGIN_MAIN_AFTER_NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_PR4990_SHA,
     ORIGIN_MAIN_AFTER_PR4991_NON_CLASS_D_ORIGIN_MAIN_ALLOWLIST_FIX_SHA,
     ORIGIN_MAIN_AFTER_PR4992_NON_CLASS_D_ORIGIN_MAIN_ALLOWLIST_FIX_SHA,
+    MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
     PR4826_MERGE_COMMIT,
     PR4833_MERGE_COMMIT,
     PR4834_MERGE_COMMIT,
-    MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
+    REASON_CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE,
+    REASON_LOCAL_HEAD_NOT_ORIGIN_MAIN,
+    REASON_WORKTREE_NOT_CLEAN,
     is_accepted_origin_main_sha,
     is_class_d_binding_completion_v0,
+    is_non_class_d_offline_eval_origin_main_policy_test_present_v0,
     resolve_current_execution_origin_main_sha,
+    resolve_non_class_d_offline_eval_origin_main_policy_test_path_v0,
+    validate_non_class_d_live_post_merge_origin_main_v0,
     verify_origin_main_sha_for_binding_v0,
 )
 
@@ -25,9 +32,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 NON_CLASS_D_BINDING_PATH = (
     REPO_ROOT / "config/research/final_research_fleet_versioned_binding_completion_v0.json"
 )
+STALE_PR4992_BASE_SHA = ORIGIN_MAIN_AFTER_PR4992_NON_CLASS_D_ORIGIN_MAIN_ALLOWLIST_FIX_SHA
 
 
-def test_legacy_non_class_d_origin_main_shas_remain_accepted() -> None:
+def test_legacy_non_class_d_origin_main_shas_remain_in_historical_set() -> None:
     for sha in (
         PR4826_MERGE_COMMIT,
         MATERIALIZED_CLASS_D_ORIGIN_MAIN_SHA,
@@ -36,29 +44,106 @@ def test_legacy_non_class_d_origin_main_shas_remain_accepted() -> None:
         ORIGIN_MAIN_AFTER_FULL_CANONICAL_BACKTEST_PARITY_CLOSEOUT_SHA,
         ORIGIN_MAIN_AFTER_NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_PR4990_SHA,
         ORIGIN_MAIN_AFTER_PR4991_NON_CLASS_D_ORIGIN_MAIN_ALLOWLIST_FIX_SHA,
+        STALE_PR4992_BASE_SHA,
     ):
         assert is_accepted_origin_main_sha(sha)
 
 
-def test_current_origin_main_accepted_for_non_class_d_policy() -> None:
-    live_origin_main = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "rev-parse", "origin/main"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
-    assert live_origin_main == resolve_current_execution_origin_main_sha(REPO_ROOT)
-    assert live_origin_main == ORIGIN_MAIN_AFTER_PR4992_NON_CLASS_D_ORIGIN_MAIN_ALLOWLIST_FIX_SHA
-    assert is_accepted_origin_main_sha(live_origin_main)
+def test_live_origin_main_accepted_after_post_merge_sync() -> None:
+    live_origin_main = resolve_current_execution_origin_main_sha(REPO_ROOT)
+    assert live_origin_main
+    with (
+        patch(
+            "src.research.final_research_fleet_offline_economic_evaluation_execution_v0.resolve_local_head_sha",
+            return_value=live_origin_main,
+        ),
+        patch(
+            "src.research.final_research_fleet_offline_economic_evaluation_execution_v0.is_worktree_clean",
+            return_value=True,
+        ),
+    ):
+        ok, reasons = validate_non_class_d_live_post_merge_origin_main_v0(
+            origin_main_sha=live_origin_main,
+            repo_root=REPO_ROOT,
+            live_origin_main_sha=live_origin_main,
+        )
+    assert ok is True
+    assert reasons == ()
 
 
-def test_verify_origin_main_accepts_current_main_for_non_class_d_binding() -> None:
+def test_stale_pr_base_sha_alone_not_live_post_merge_proof() -> None:
+    live_origin_main = resolve_current_execution_origin_main_sha(REPO_ROOT)
+    assert live_origin_main
+    assert is_accepted_origin_main_sha(STALE_PR4992_BASE_SHA)
+    if live_origin_main == STALE_PR4992_BASE_SHA:
+        return
+    ok, reasons = validate_non_class_d_live_post_merge_origin_main_v0(
+        origin_main_sha=STALE_PR4992_BASE_SHA,
+        repo_root=REPO_ROOT,
+        live_origin_main_sha=live_origin_main,
+    )
+    assert ok is False
+    assert any(REASON_CURRENT_MAIN_SHA_DRIFT_AFTER_SQUASH_MERGE in reason for reason in reasons)
+
+
+def test_head_not_origin_main_blocks_fail_closed() -> None:
+    live_origin_main = resolve_current_execution_origin_main_sha(REPO_ROOT)
+    assert live_origin_main
+    drifted_head = "deadbeef" * 5
+    with patch(
+        "src.research.final_research_fleet_offline_economic_evaluation_execution_v0.resolve_local_head_sha",
+        return_value=drifted_head,
+    ):
+        ok, reasons = validate_non_class_d_live_post_merge_origin_main_v0(
+            origin_main_sha=live_origin_main,
+            repo_root=REPO_ROOT,
+            live_origin_main_sha=live_origin_main,
+        )
+    assert ok is False
+    assert any(REASON_LOCAL_HEAD_NOT_ORIGIN_MAIN in reason for reason in reasons)
+
+
+def test_dirty_worktree_blocks_fail_closed() -> None:
+    live_origin_main = resolve_current_execution_origin_main_sha(REPO_ROOT)
+    assert live_origin_main
+    with patch(
+        "src.research.final_research_fleet_offline_economic_evaluation_execution_v0.is_worktree_clean",
+        return_value=False,
+    ):
+        ok, reasons = validate_non_class_d_live_post_merge_origin_main_v0(
+            origin_main_sha=live_origin_main,
+            repo_root=REPO_ROOT,
+            live_origin_main_sha=live_origin_main,
+        )
+    assert ok is False
+    assert REASON_WORKTREE_NOT_CLEAN in reasons
+
+
+def test_canonical_test_path_resolves_without_stub() -> None:
+    assert is_non_class_d_offline_eval_origin_main_policy_test_present_v0(REPO_ROOT)
+    path = resolve_non_class_d_offline_eval_origin_main_policy_test_path_v0(REPO_ROOT)
+    assert path == REPO_ROOT / NON_CLASS_D_OFFLINE_EVAL_ORIGIN_MAIN_POLICY_TEST_REL
+    assert path.is_file()
+
+
+def test_verify_origin_main_accepts_synced_main_for_non_class_d_binding() -> None:
     fleet_binding_completion = json.loads(NON_CLASS_D_BINDING_PATH.read_text(encoding="utf-8"))
     assert is_class_d_binding_completion_v0(fleet_binding_completion) is False
     live_origin_main = resolve_current_execution_origin_main_sha(REPO_ROOT)
-    ok, reasons = verify_origin_main_sha_for_binding_v0(
-        origin_main_sha=live_origin_main,
-        fleet_binding_completion=fleet_binding_completion,
-    )
+    with (
+        patch(
+            "src.research.final_research_fleet_offline_economic_evaluation_execution_v0.resolve_local_head_sha",
+            return_value=live_origin_main,
+        ),
+        patch(
+            "src.research.final_research_fleet_offline_economic_evaluation_execution_v0.is_worktree_clean",
+            return_value=True,
+        ),
+    ):
+        ok, reasons = verify_origin_main_sha_for_binding_v0(
+            origin_main_sha=live_origin_main,
+            fleet_binding_completion=fleet_binding_completion,
+            repo_root=REPO_ROOT,
+        )
     assert ok is True
     assert reasons == ()


### PR DESCRIPTION
## Summary
- Ersetzt die statische Non-Class-D-Origin-Main-Allowlist durch fail-closed Live-Sync-Proof: `origin_main_sha == origin/main`, `HEAD == origin/main`, saubere Worktree.
- Historische SHAs bleiben in `HISTORICAL_NON_CLASS_D_ACCEPTED_ORIGIN_MAIN_SHAS` dokumentiert, reichen aber allein nicht mehr als Post-Merge-Nachweis (behebt Squash-Merge-Drift nach PR #4993).
- Merge-Closeout-Guard findet die kanonische Testdatei `tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py` via `--non-class-d-origin-main-policy-test` / `resolve_non_class_d_origin_main_policy_test_path()`.

## Test plan
- [x] `python -m pytest tests/research/test_non_class_d_offline_eval_accepted_origin_main_policy_v0.py -q` (7 passed)
- [x] `python -m pytest tests/ops/test_squash_merge_post_merge_closeout_guard_v0_contract.py -q` (9 passed)
- [x] `ruff check` / `ruff format --check` auf geänderte Python-Dateien
- [x] `python -m compileall` auf geänderte src-Datei
- [ ] GitHub CI grün vor Merge

## Evidence
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/policy_redesign_non_class_d_origin_main_live_post_merge_sync_v0_20260708T074558Z`

Verdict: `POLICY_REDESIGN_NON_CLASS_D_ORIGIN_MAIN_LIVE_POST_MERGE_SYNC_V0_PASS_PR_READY`


Made with [Cursor](https://cursor.com)