### PR TITLE
fix: add dedicated bounded offline economic eval execute runner

### DIFF
--- a/scripts/research/execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
+++ b/scripts/research/execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import runpy
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+PREFERRED_OWNER_RELATIVE_PATH = (
+    "src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py"
+)
+
+VERDICT_BLOCKED_RUNNER_RESOLUTION_NOT_EXACTLY_ONE = (
+    "EXECUTE_BOUNDED_OFFLINE_ECONOMIC_EVALUATION_FROM_RATIFIED_SCOPE_NO_RETRY_V0_"
+    "BLOCKED_RUNNER_RESOLUTION_NOT_EXACTLY_ONE"
+)
+
+LIVE_AUTHORIZED = False
+READY_FOR_OPERATOR_ARMING = False
+ORDERS_ALLOWED = False
+SCHEDULER_RUNTIME_ALLOWED = False
+SHADOW_AUTHORIZED = False
+PAPER_AUTHORIZED = False
+TESTNET_AUTHORIZED = False
+CANARY_AUTHORIZED = False
+RETRY_MODE = "NO_RETRY"
+UNMODIFIED_BINDING_RETRY_ALLOWED = False
+
+
+class RunnerResolutionError(RuntimeError):
+    pass
+
+
+def repo_root_from_runner() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_preferred_runner(repo_root: Path) -> Path:
+    preferred = repo_root / PREFERRED_OWNER_RELATIVE_PATH
+    resolved = [preferred] if preferred.is_file() else []
+    if len(resolved) != 1:
+        raise RunnerResolutionError(
+            f"{VERDICT_BLOCKED_RUNNER_RESOLUTION_NOT_EXACTLY_ONE}: "
+            f"preferred_runner={PREFERRED_OWNER_RELATIVE_PATH!r} "
+            f"resolved_count={len(resolved)}"
+        )
+    return resolved[0]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0",
+        description=(
+            "Dedicated fail-closed no-retry entry point for the ratified bounded "
+            "offline economic evaluation scope. This script resolves exactly one "
+            "canonical existing offline evaluation owner and delegates execution "
+            "without granting runtime, order, scheduler, shadow, paper, testnet, "
+            "canary, or live authority."
+        ),
+    )
+    parser.add_argument(
+        "--print-delegate-only",
+        action="store_true",
+        help="Print the resolved delegate path and exit without executing it.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    known_args, passthrough_args = parser.parse_known_args(argv)
+
+    repo_root = repo_root_from_runner()
+    delegate = resolve_preferred_runner(repo_root)
+
+    if known_args.print_delegate_only:
+        print(delegate)
+        return 0
+
+    old_argv = sys.argv[:]
+    try:
+        sys.argv = [str(delegate), *passthrough_args]
+        runpy.run_path(str(delegate), run_name="__main__")
+    finally:
+        sys.argv = old_argv
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/research/test_execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
+++ b/tests/research/test_execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+RUNNER = Path(
+    "scripts/research/"
+    "execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py"
+)
+PREFERRED_OWNER = Path(
+    "src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py"
+)
+
+
+def test_dedicated_execute_runner_exists() -> None:
+    assert RUNNER.is_file()
+
+
+def test_preferred_existing_owner_exists() -> None:
+    assert PREFERRED_OWNER.is_file()
+
+
+def test_runner_is_parseable_and_binds_single_preferred_owner() -> None:
+    tree = ast.parse(RUNNER.read_text(encoding="utf-8"))
+    assignments = {
+        node.targets[0].id: ast.literal_eval(node.value)
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "PREFERRED_OWNER_RELATIVE_PATH"
+    }
+    assert assignments == {
+        "PREFERRED_OWNER_RELATIVE_PATH": str(PREFERRED_OWNER),
+    }
+
+
+def test_runner_preserves_no_runtime_authority_boundary() -> None:
+    text = RUNNER.read_text(encoding="utf-8")
+    required_false_bindings = [
+        "LIVE_AUTHORIZED = False",
+        "READY_FOR_OPERATOR_ARMING = False",
+        "ORDERS_ALLOWED = False",
+        "SCHEDULER_RUNTIME_ALLOWED = False",
+        "SHADOW_AUTHORIZED = False",
+        "PAPER_AUTHORIZED = False",
+        "TESTNET_AUTHORIZED = False",
+        "CANARY_AUTHORIZED = False",
+        "UNMODIFIED_BINDING_RETRY_ALLOWED = False",
+    ]
+    for binding in required_false_bindings:
+        assert binding in text
+    assert 'RETRY_MODE = "NO_RETRY"' in text
+
+
+def test_runner_fail_closed_verdict_for_resolution_error() -> None:
+    text = RUNNER.read_text(encoding="utf-8")
+    assert "BLOCKED_RUNNER_RESOLUTION_NOT_EXACTLY_ONE" in text
+    assert "resolved_count" in text
+    assert "runpy.run_path" in text


### PR DESCRIPTION
Adds a dedicated fail-closed no-retry execute entry point for the ratified bounded offline economic evaluation scope.

Governance:
- Reuses existing offline evaluation owner
- No new Economic Validation stack
- No retry of unchanged bindings
- No runtime/order/live/scheduler/shadow/paper/testnet/canary authority
- Execution remains offline-only and delegated

Evidence:
/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/implement_dedicated_bounded_offline_economic_eval_execute_runner_no_retry_v0_20260708T101855Z

Made with [Cursor](https://cursor.com)