### PR TITLE
fix: make offline evaluation re-execute runner import repo src

### DIFF
--- a/scripts/research/execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
+++ b/scripts/research/execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
@@ -82,6 +82,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     old_argv = sys.argv[:]
     try:
         sys.argv = [str(delegate), *passthrough_args]
+        repo_root_str = str(repo_root)
+        if repo_root_str not in sys.path:
+            sys.path.insert(0, repo_root_str)
         runpy.run_path(str(delegate), run_name="__main__")
     finally:
         sys.argv = old_argv

--- a/tests/research/test_execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
+++ b/tests/research/test_execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
@@ -59,3 +59,9 @@ def test_runner_fail_closed_verdict_for_resolution_error() -> None:
     assert "BLOCKED_RUNNER_RESOLUTION_NOT_EXACTLY_ONE" in text
     assert "resolved_count" in text
     assert "runpy.run_path" in text
+
+
+def test_runner_inserts_repo_root_on_sys_path_before_delegation() -> None:
+    text = RUNNER.read_text(encoding="utf-8")
+    assert "repo_root_str = str(repo_root)" in text
+    assert "sys.path.insert(0, repo_root_str)" in text


### PR DESCRIPTION
Fixes the blocked re-execute path by ensuring the delegated offline evaluation owner can import repo-local src modules before runpy.run_path delegation.

Changes:
- insert repo root on sys.path before runpy.run_path delegation
- add contract test for sys.path insertion

Evidence: /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/fix_re_execute_offline_eval_runner_src_path_and_source_lineage_v0_20260708T153221Z

Boundaries:
- no runtime authority
- no orders
- no scheduler
- no credentials
- no core trading logic mutation
- no economic claim
- offline runner/tooling fix only

Made with [Cursor](https://cursor.com)