### PR TITLE
fix: delegate offline evaluation runner to materializing owner

### DIFF
--- a/scripts/research/execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
+++ b/scripts/research/execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
@@ -9,7 +9,7 @@ from typing import Sequence
 
 
 PREFERRED_OWNER_RELATIVE_PATH = (
-    "src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py"
+    "scripts/ops/materialize_final_research_fleet_offline_economic_evaluation_execution_v0.py"
 )
 
 VERDICT_BLOCKED_RUNNER_RESOLUTION_NOT_EXACTLY_ONE = (

--- a/tests/research/test_execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
+++ b/tests/research/test_execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py
@@ -9,7 +9,7 @@ RUNNER = Path(
     "execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py"
 )
 PREFERRED_OWNER = Path(
-    "src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py"
+    "scripts/ops/materialize_final_research_fleet_offline_economic_evaluation_execution_v0.py"
 )
 
 

--- a/tests/research/test_execute_bounded_offline_evaluation_runner_materializing_owner_v0.py
+++ b/tests/research/test_execute_bounded_offline_evaluation_runner_materializing_owner_v0.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+RUNNER = Path(
+    "scripts/research/execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py"
+)
+MATERIALIZER = (
+    "scripts/ops/materialize_final_research_fleet_offline_economic_evaluation_execution_v0.py"
+)
+LIBRARY_DELEGATE = "src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py"
+
+
+def test_execute_runner_delegates_to_materializing_owner() -> None:
+    text = RUNNER.read_text()
+    assert MATERIALIZER in text
+    assert LIBRARY_DELEGATE not in text
+
+
+def test_execute_runner_preserves_repo_root_sys_path_guard() -> None:
+    text = RUNNER.read_text()
+    assert "repo_root_str = str(repo_root)" in text
+    assert "sys.path.insert(0, repo_root_str)" in text


### PR DESCRIPTION
## Summary
- Fixes the bounded offline economic evaluation execute runner to delegate to `scripts/ops/materialize_final_research_fleet_offline_economic_evaluation_execution_v0.py` instead of the library module (`src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py`), which had no `__main__` entry point and exited with empty output.
- Adds a focused materializing-owner contract test and updates the existing execute-runner contract test.

Evidence: /Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/fix_execute_offline_eval_runner_materializing_owner_v0_20260708T154119Z

Boundaries:
- offline runner/tooling fix only
- no runtime authority
- no orders
- no scheduler
- no credentials
- no shadow/paper/testnet
- no economic claim
- no core trading logic mutation

## Test plan
- [x] `pytest -q tests/research/test_execute_bounded_offline_evaluation_runner_materializing_owner_v0.py`
- [x] `pytest -q tests/research/test_execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py`
- [x] `ruff check` / `ruff format --check` on touched files
- [x] `python3 scripts/research/execute_bounded_offline_economic_evaluation_from_ratified_scope_no_retry_v0.py --print-delegate-only`

Made with [Cursor](https://cursor.com)