### PR TITLE
fix: execute core completion diagnostic owner path

### DIFF
--- a/scripts/research/run_full_canonical_core_completion_plausibility_diagnostic_v0.py
+++ b/scripts/research/run_full_canonical_core_completion_plausibility_diagnostic_v0.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED_CONFIRM = "GO_FULL_CANONICAL_CORE_COMPLETION_AND_PLAUSIBILITY_EVALUATION_DIAGNOSTIC_V0"
+EVIDENCE_CLASS = "FULL_CANONICAL_CORE_COMPLETION_AND_PLAUSIBILITY_EVALUATION_V0"
+
+AUTHORITY_FALSE_FIELDS = (
+    "promotion_admissible",
+    "runtime_admissible",
+    "live_authorized",
+    "orders_allowed",
+    "economic_validity_claim_allowed",
+    "scheduler_runtime_allowed",
+    "shadow_authorized",
+    "paper_authorized",
+    "testnet_authorized",
+    "canary_authorized",
+    "credential_access_allowed",
+)
+
+
+def _repo_root_from_file() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_policy(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise SystemExit(f"POLICY_MISSING: {path}")
+    data = json.loads(path.read_text())
+    digest_keys = (
+        "policy_digest",
+        "config_digest",
+        "implementation_digest",
+        "semantic_digest",
+        "source_policy_digest",
+        "owner_policy_decision_digest",
+    )
+    if not any(data.get(k) for k in digest_keys):
+        raise SystemExit("POLICY_DIGEST_MISSING")
+    return data
+
+
+def _as_mapping(result: Any) -> dict[str, Any]:
+    if hasattr(result, "to_dict"):
+        value = result.to_dict()
+    elif hasattr(result, "__dict__"):
+        value = dict(result.__dict__)
+    elif isinstance(result, dict):
+        value = result
+    else:
+        value = {"result_repr": repr(result)}
+    return dict(value)
+
+
+def _authority_false_or_block(result: dict[str, Any]) -> None:
+    violations = []
+    for key in AUTHORITY_FALSE_FIELDS:
+        if result.get(key) is True:
+            violations.append(key)
+    if violations:
+        raise SystemExit("AUTHORITY_FLAG_TRUE_BLOCKED: " + ",".join(sorted(violations)))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm", required=True)
+    parser.add_argument("--repo-root", type=Path, default=_repo_root_from_file())
+    parser.add_argument("--durable-evidence-root", type=Path, required=True)
+    parser.add_argument(
+        "--policy",
+        type=Path,
+        default=Path(
+            "config/research/full_canonical_core_completion_plausibility_evaluation_policy_v0.json"
+        ),
+    )
+    parser.add_argument(
+        "--binding-completion",
+        type=Path,
+        default=Path("config/research/final_research_fleet_versioned_binding_completion_v0.json"),
+    )
+    parser.add_argument("--evidence-class", default=EVIDENCE_CLASS)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    if args.confirm != REQUIRED_CONFIRM:
+        raise SystemExit("INVALID_CONFIRM_TOKEN")
+    if args.evidence_class != EVIDENCE_CLASS:
+        raise SystemExit("INVALID_EVIDENCE_CLASS")
+
+    policy_path = args.policy if args.policy.is_absolute() else repo_root / args.policy
+    binding_path = (
+        args.binding_completion
+        if args.binding_completion.is_absolute()
+        else repo_root / args.binding_completion
+    )
+    _load_policy(policy_path)
+    if not binding_path.exists():
+        raise SystemExit(f"BINDING_COMPLETION_MISSING: {binding_path}")
+
+    from src.research.full_canonical_core_completion_plausibility_evaluation_v0 import (
+        run_diagnostic_evaluation_v0,
+    )
+
+    result = run_diagnostic_evaluation_v0(
+        confirm=args.confirm,
+        repo_root=repo_root,
+        durable_evidence_root=args.durable_evidence_root.resolve(),
+    )
+
+    payload = _as_mapping(result)
+    payload.setdefault("status", "SYSTEM_DIAGNOSTIC_ONLY")
+    payload["evidence_class"] = EVIDENCE_CLASS
+    payload["promotion_admissible"] = False
+    payload["runtime_admissible"] = False
+    payload["live_authorized"] = False
+    payload["orders_allowed"] = False
+    payload["economic_validity_claim_allowed"] = False
+    payload["scheduler_runtime_allowed"] = False
+    payload["shadow_authorized"] = False
+    payload["paper_authorized"] = False
+    payload["testnet_authorized"] = False
+    payload["canary_authorized"] = False
+    payload["credential_access_allowed"] = False
+    _authority_false_or_block(payload)
+
+    text = json.dumps(payload, indent=2, sort_keys=True, default=str)
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(text + "\n")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/research/test_full_canonical_core_completion_plausibility_diagnostic_cli_v0.py
+++ b/tests/research/test_full_canonical_core_completion_plausibility_diagnostic_cli_v0.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path("scripts/research/run_full_canonical_core_completion_plausibility_diagnostic_v0.py")
+CONFIRM = "GO_FULL_CANONICAL_CORE_COMPLETION_AND_PLAUSIBILITY_EVALUATION_DIAGNOSTIC_V0"
+
+
+def test_cli_rejects_invalid_confirm_token(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--confirm",
+            "WRONG",
+            "--repo-root",
+            str(Path.cwd()),
+            "--durable-evidence-root",
+            str(tmp_path),
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode != 0
+    assert "INVALID_CONFIRM_TOKEN" in result.stderr or "INVALID_CONFIRM_TOKEN" in result.stdout
+
+
+def test_cli_rejects_policy_without_digest(tmp_path: Path) -> None:
+    policy = tmp_path / "policy.json"
+    policy.write_text(json.dumps({"diagnostic_only": True}))
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--confirm",
+            CONFIRM,
+            "--repo-root",
+            str(Path.cwd()),
+            "--durable-evidence-root",
+            str(tmp_path / "evidence"),
+            "--policy",
+            str(policy),
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode != 0
+    assert "POLICY_DIGEST_MISSING" in result.stderr or "POLICY_DIGEST_MISSING" in result.stdout
+
+
+def test_cli_source_contains_exact_owner_signature_kwargs() -> None:
+    source = SCRIPT.read_text()
+    assert "confirm=args.confirm" in source
+    assert "repo_root=repo_root" in source
+    assert "durable_evidence_root=args.durable_evidence_root.resolve()" in source
+    assert "confirm_token" not in source
+    assert "value_by_name" not in source
+
+
+def test_cli_source_forces_required_authority_fields_false() -> None:
+    source = SCRIPT.read_text()
+    for field in (
+        "promotion_admissible",
+        "runtime_admissible",
+        "live_authorized",
+        "orders_allowed",
+        "economic_validity_claim_allowed",
+    ):
+        assert f'payload["{field}"] = False' in source


### PR DESCRIPTION
## Summary
- Adds a stable CLI wrapper (`scripts/research/run_full_canonical_core_completion_plausibility_diagnostic_v0.py`) that calls `run_diagnostic_evaluation_v0` with the exact owner signature: `confirm`, `repo_root`, `durable_evidence_root`.
- Adds contract tests ensuring invalid confirm tokens, missing policy digests, exact owner kwargs, and forced authority-false payload fields are enforced.

## Safety / authority boundaries
- diagnostic-only
- no live / orders / runtime / shadow / paper / testnet / canary / credential authority
- no promotion admissibility
- no economic validity claim
- old unmodified retry guard remains active

## Test plan
- [x] owner contract pytest (`tests/research/test_full_canonical_core_completion_plausibility_evaluation_v0.py`)
- [x] policy contract pytest (`tests/ops/test_full_canonical_core_completion_plausibility_evaluation_policy_v0_contract.py`)
- [x] diagnostic CLI contract pytest (`tests/research/test_full_canonical_core_completion_plausibility_diagnostic_cli_v0.py`)
- [x] changed-file compileall / ruff gates
- [x] repaired diagnostic-only owner path executed and evidence written

## Durable evidence
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/fix_core_completion_diagnostic_owner_execute_after_pr5000_v0_20260708T163041Z`

Made with [Cursor](https://cursor.com)