### PR TITLE
test: bind diagnostic promotion boundary status

### DIFF
--- a/scripts/research/run_full_canonical_core_completion_plausibility_diagnostic_v0.py
+++ b/scripts/research/run_full_canonical_core_completion_plausibility_diagnostic_v0.py
@@ -125,6 +125,12 @@ def main(argv: list[str] | None = None) -> int:
     payload["live_authorized"] = False
     payload["orders_allowed"] = False
     payload["economic_validity_claim_allowed"] = False
+    payload["system_economic_evidence_admissible"] = False
+    payload.setdefault(
+        "promotion_boundary_status",
+        "DIAGNOSTIC_ONLY_NOT_PROMOTION_EVIDENCE",
+    )
+    payload.setdefault("promotion_boundary_reason_codes", [])
     payload["scheduler_runtime_allowed"] = False
     payload["shadow_authorized"] = False
     payload["paper_authorized"] = False

--- a/src/research/full_canonical_core_completion_plausibility_evaluation_v0.py
+++ b/src/research/full_canonical_core_completion_plausibility_evaluation_v0.py
@@ -75,6 +75,14 @@ DEFAULT_DURABLE_ARCHIVE_ROOT = Path(
 DURABLE_EVIDENCE_SUBDIR = "research"
 DURABLE_EVIDENCE_BUNDLE_PREFIX = "full_canonical_core_completion_plausibility_evaluation_v0"
 
+PROMOTION_BOUNDARY_STATUS = "DIAGNOSTIC_ONLY_NOT_PROMOTION_EVIDENCE"
+PROMOTION_BOUNDARY_REASON_CODES: tuple[str, ...] = (
+    "FULL_CANONICAL_CHAIN_PARITY_REQUIRED_BEFORE_SYSTEM_ECONOMIC_EVIDENCE",
+    "ECONOMIC_VIABILITY_EVIDENCE_V1_PASS_REQUIRED_BEFORE_PROMOTION_ADMISSIBILITY",
+    "DIAGNOSTIC_RESULT_IS_NOT_PROMOTION_EVIDENCE",
+    "RAW_RESEARCH_EVIDENCE_IS_NOT_SYSTEM_ECONOMIC_EVIDENCE",
+)
+
 
 @dataclass(frozen=True)
 class StartStateVerificationResultV0:
@@ -94,6 +102,15 @@ class DiagnosticExecutionResultV0:
     live_authorized: bool
     orders_allowed: bool
     economic_validity_claim_allowed: bool
+    system_economic_evidence_admissible: bool
+    scheduler_runtime_allowed: bool
+    shadow_authorized: bool
+    paper_authorized: bool
+    testnet_authorized: bool
+    canary_authorized: bool
+    credential_access_allowed: bool
+    promotion_boundary_status: str
+    promotion_boundary_reason_codes: tuple[str, ...]
     owner_policy_decision_digest: str
     evidence_class_id: str
     parity_status_counts: dict[str, int]
@@ -315,6 +332,9 @@ def build_diagnostic_output_v0(
         "live_authorized": False,
         "orders_allowed": False,
         "economic_validity_claim_allowed": False,
+        "system_economic_evidence_admissible": False,
+        "promotion_boundary_status": PROMOTION_BOUNDARY_STATUS,
+        "promotion_boundary_reason_codes": list(PROMOTION_BOUNDARY_REASON_CODES),
         "evidence_class_id": EVIDENCE_CLASS_ID,
         "purpose": PURPOSE,
         "owner_policy_decision_digest": str(owner_policy.get("owner_policy_decision_digest", "")),
@@ -408,6 +428,15 @@ def run_diagnostic_evaluation_v0(
         live_authorized=False,
         orders_allowed=False,
         economic_validity_claim_allowed=False,
+        system_economic_evidence_admissible=False,
+        scheduler_runtime_allowed=False,
+        shadow_authorized=False,
+        paper_authorized=False,
+        testnet_authorized=False,
+        canary_authorized=False,
+        credential_access_allowed=False,
+        promotion_boundary_status=PROMOTION_BOUNDARY_STATUS,
+        promotion_boundary_reason_codes=PROMOTION_BOUNDARY_REASON_CODES,
         owner_policy_decision_digest=str(
             start_state.owner_policy.get("owner_policy_decision_digest", "")
         ),

--- a/tests/research/test_full_canonical_core_completion_plausibility_promotion_boundary_v0.py
+++ b/tests/research/test_full_canonical_core_completion_plausibility_promotion_boundary_v0.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.research.full_canonical_core_completion_plausibility_evaluation_v0 import (
+    run_diagnostic_evaluation_v0,
+)
+
+CONFIRM = "GO_FULL_CANONICAL_CORE_COMPLETION_AND_PLAUSIBILITY_EVALUATION_DIAGNOSTIC_V0"
+
+
+def _as_dict(result: object) -> dict[str, object]:
+    if hasattr(result, "to_dict"):
+        value = result.to_dict()
+    elif hasattr(result, "__dict__"):
+        value = dict(result.__dict__)
+    else:
+        pytest.fail(f"Unsupported diagnostic result type: {type(result)!r}")
+    assert isinstance(value, dict)
+    return value
+
+
+def test_diagnostic_result_is_explicitly_not_promotion_evidence(tmp_path: Path) -> None:
+    result = run_diagnostic_evaluation_v0(
+        confirm=CONFIRM,
+        repo_root=Path.cwd(),
+        durable_evidence_root=tmp_path,
+    )
+    payload = _as_dict(result)
+
+    assert payload["status"] == "SYSTEM_DIAGNOSTIC_ONLY"
+    assert payload["promotion_admissible"] is False
+    assert payload["system_economic_evidence_admissible"] is False
+    assert payload["economic_validity_claim_allowed"] is False
+    assert payload["promotion_boundary_status"] == "DIAGNOSTIC_ONLY_NOT_PROMOTION_EVIDENCE"
+
+    reason_codes = set(payload["promotion_boundary_reason_codes"])
+    assert "FULL_CANONICAL_CHAIN_PARITY_REQUIRED_BEFORE_SYSTEM_ECONOMIC_EVIDENCE" in reason_codes
+    assert (
+        "ECONOMIC_VIABILITY_EVIDENCE_V1_PASS_REQUIRED_BEFORE_PROMOTION_ADMISSIBILITY"
+        in reason_codes
+    )
+    assert "DIAGNOSTIC_RESULT_IS_NOT_PROMOTION_EVIDENCE" in reason_codes
+    assert "RAW_RESEARCH_EVIDENCE_IS_NOT_SYSTEM_ECONOMIC_EVIDENCE" in reason_codes
+
+
+def test_diagnostic_result_grants_no_runtime_or_order_authority(tmp_path: Path) -> None:
+    result = run_diagnostic_evaluation_v0(
+        confirm=CONFIRM,
+        repo_root=Path.cwd(),
+        durable_evidence_root=tmp_path,
+    )
+    payload = _as_dict(result)
+
+    for key in (
+        "runtime_admissible",
+        "live_authorized",
+        "orders_allowed",
+        "scheduler_runtime_allowed",
+        "shadow_authorized",
+        "paper_authorized",
+        "testnet_authorized",
+        "canary_authorized",
+        "credential_access_allowed",
+    ):
+        assert payload[key] is False


### PR DESCRIPTION
## Summary
- Makes core-completion diagnostic output explicitly non-promotion evidence via `promotion_boundary_status=DIAGNOSTIC_ONLY_NOT_PROMOTION_EVIDENCE` and reason codes.
- Adds `system_economic_evidence_admissible=false` to diagnostic output and execution result.
- Adds promotion-boundary contract tests; extends CLI payload passthrough.

## Safety / authority boundaries
- no promotion enablement
- no runtime rewire
- no live/orders/shadow/paper/testnet/canary/credential authority
- no economic-validity claim
- old unmodified retry guard remains active

## Test plan
- [x] owner contract pytest (16/16)
- [x] policy contract pytest (3/3)
- [x] CLI contract pytest (4/4)
- [x] promotion-boundary contract pytest (2/2)
- [x] diagnostic CLI execution after fix
- [x] changed-file compileall / ruff gates

## Durable evidence
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/fix_promotion_boundary_diagnostic_status_contract_v0_20260708T163938Z`

Made with [Cursor](https://cursor.com)