### PR TITLE
test: bind full canonical chain diagnostic status

### DIFF
--- a/src/research/full_canonical_core_completion_plausibility_evaluation_v0.py
+++ b/src/research/full_canonical_core_completion_plausibility_evaluation_v0.py
@@ -83,6 +83,14 @@ PROMOTION_BOUNDARY_REASON_CODES: tuple[str, ...] = (
     "RAW_RESEARCH_EVIDENCE_IS_NOT_SYSTEM_ECONOMIC_EVIDENCE",
 )
 
+FULL_CANONICAL_CHAIN_WIRED_STATUS = "DIAGNOSTIC_ONLY_NOT_FULLY_WIRED"
+FULL_CANONICAL_CHAIN_WIRED_REASON_CODES: tuple[str, ...] = (
+    "FULL_CANONICAL_CHAIN_WIRED_STATUS_NOT_YET_PROVEN",
+    "BACKTEST_RUNTIME_DECISION_PARITY_NOT_YET_PROVEN",
+    "SYSTEM_ECONOMIC_EVIDENCE_REQUIRES_FULL_CANONICAL_CHAIN_PARITY",
+    "DIAGNOSTIC_RESULT_DOES_NOT_WIRE_CANONICAL_CHAIN",
+)
+
 
 @dataclass(frozen=True)
 class StartStateVerificationResultV0:
@@ -111,6 +119,10 @@ class DiagnosticExecutionResultV0:
     credential_access_allowed: bool
     promotion_boundary_status: str
     promotion_boundary_reason_codes: tuple[str, ...]
+    full_canonical_chain_wired: bool
+    backtest_runtime_decision_parity_pass: bool
+    full_canonical_chain_wired_status: str
+    full_canonical_chain_wired_reason_codes: tuple[str, ...]
     owner_policy_decision_digest: str
     evidence_class_id: str
     parity_status_counts: dict[str, int]
@@ -333,6 +345,10 @@ def build_diagnostic_output_v0(
         "orders_allowed": False,
         "economic_validity_claim_allowed": False,
         "system_economic_evidence_admissible": False,
+        "full_canonical_chain_wired": False,
+        "backtest_runtime_decision_parity_pass": False,
+        "full_canonical_chain_wired_status": FULL_CANONICAL_CHAIN_WIRED_STATUS,
+        "full_canonical_chain_wired_reason_codes": list(FULL_CANONICAL_CHAIN_WIRED_REASON_CODES),
         "promotion_boundary_status": PROMOTION_BOUNDARY_STATUS,
         "promotion_boundary_reason_codes": list(PROMOTION_BOUNDARY_REASON_CODES),
         "evidence_class_id": EVIDENCE_CLASS_ID,
@@ -437,6 +453,10 @@ def run_diagnostic_evaluation_v0(
         credential_access_allowed=False,
         promotion_boundary_status=PROMOTION_BOUNDARY_STATUS,
         promotion_boundary_reason_codes=PROMOTION_BOUNDARY_REASON_CODES,
+        full_canonical_chain_wired=False,
+        backtest_runtime_decision_parity_pass=False,
+        full_canonical_chain_wired_status=FULL_CANONICAL_CHAIN_WIRED_STATUS,
+        full_canonical_chain_wired_reason_codes=FULL_CANONICAL_CHAIN_WIRED_REASON_CODES,
         owner_policy_decision_digest=str(
             start_state.owner_policy.get("owner_policy_decision_digest", "")
         ),

--- a/tests/research/test_full_canonical_core_completion_plausibility_full_chain_status_v0.py
+++ b/tests/research/test_full_canonical_core_completion_plausibility_full_chain_status_v0.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.research.full_canonical_core_completion_plausibility_evaluation_v0 import (
+    run_diagnostic_evaluation_v0,
+)
+
+CONFIRM = "GO_FULL_CANONICAL_CORE_COMPLETION_AND_PLAUSIBILITY_EVALUATION_DIAGNOSTIC_V0"
+
+
+def _as_dict(result: object) -> dict[str, object]:
+    if hasattr(result, "to_dict"):
+        value = result.to_dict()
+    elif hasattr(result, "__dict__"):
+        value = dict(result.__dict__)
+    else:
+        pytest.fail(f"Unsupported diagnostic result type: {type(result)!r}")
+    assert isinstance(value, dict)
+    return value
+
+
+def test_diagnostic_result_explicitly_blocks_full_system_economic_evidence_until_full_chain_parity(
+    tmp_path: Path,
+) -> None:
+    result = run_diagnostic_evaluation_v0(
+        confirm=CONFIRM,
+        repo_root=Path.cwd(),
+        durable_evidence_root=tmp_path,
+    )
+    payload = _as_dict(result)
+
+    assert payload["status"] == "SYSTEM_DIAGNOSTIC_ONLY"
+    assert payload["full_canonical_chain_wired"] is False
+    assert payload["backtest_runtime_decision_parity_pass"] is False
+    assert payload["system_economic_evidence_admissible"] is False
+    assert payload["economic_validity_claim_allowed"] is False
+    assert payload["full_canonical_chain_wired_status"] == "DIAGNOSTIC_ONLY_NOT_FULLY_WIRED"
+
+    reason_codes = set(payload["full_canonical_chain_wired_reason_codes"])
+    assert "FULL_CANONICAL_CHAIN_WIRED_STATUS_NOT_YET_PROVEN" in reason_codes
+    assert "BACKTEST_RUNTIME_DECISION_PARITY_NOT_YET_PROVEN" in reason_codes
+    assert "SYSTEM_ECONOMIC_EVIDENCE_REQUIRES_FULL_CANONICAL_CHAIN_PARITY" in reason_codes
+    assert "DIAGNOSTIC_RESULT_DOES_NOT_WIRE_CANONICAL_CHAIN" in reason_codes
+
+
+def test_full_chain_status_contract_grants_no_promotion_runtime_or_order_authority(
+    tmp_path: Path,
+) -> None:
+    result = run_diagnostic_evaluation_v0(
+        confirm=CONFIRM,
+        repo_root=Path.cwd(),
+        durable_evidence_root=tmp_path,
+    )
+    payload = _as_dict(result)
+
+    assert payload["promotion_admissible"] is False
+    assert payload["runtime_admissible"] is False
+    assert payload["live_authorized"] is False
+    assert payload["orders_allowed"] is False
+    assert payload["scheduler_runtime_allowed"] is False
+    assert payload["shadow_authorized"] is False
+    assert payload["paper_authorized"] is False
+    assert payload["testnet_authorized"] is False
+    assert payload["canary_authorized"] is False
+    assert payload["credential_access_allowed"] is False


### PR DESCRIPTION
Diagnostic-only full-canonical-chain status contract after PR #5002.

This PR makes the core-completion diagnostic result explicit that full-system economic evidence is still blocked:
- full_canonical_chain_wired=false
- backtest_runtime_decision_parity_pass=false
- system_economic_evidence_admissible=false
- economic_validity_claim_allowed=false
- full_canonical_chain_wired_status=DIAGNOSTIC_ONLY_NOT_FULLY_WIRED

Authority boundaries:
- no full-chain rewire
- no promotion enablement
- no runtime rewire
- no live/orders/shadow/paper/testnet/canary/credential authority
- no economic-validity claim
- old unmodified retry guard remains active

Validation:
- owner contract pytest
- policy contract pytest
- CLI contract pytest
- promotion-boundary contract pytest
- new full-chain-status contract pytest
- diagnostic CLI execution after fix
- changed-file compileall/ruff gates

Durable evidence:
/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/fix_full_canonical_chain_wired_status_contract_v0_20260708T165208Z