### PR TITLE
Wire bull bear state switch into parity path

### DIFF
--- a/scripts/research/backtest_runtime_decision_parity_inventory_v0.py
+++ b/scripts/research/backtest_runtime_decision_parity_inventory_v0.py
@@ -42,6 +42,11 @@ SURFACES = [
         "canonical_roots": ("src/trading", "src/strategies", "src/core"),
         "backtest_roots": ("src/backtest", "scripts", "tests"),
         "runtime_roots": ("src/live", "src/execution", "src/runtime", "src/ops"),
+        "backtest_binding_pins": (
+            "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py",
+            "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+            "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
+        ),
     },
     {
         "surface_id": "scope_adverse_exit_and_reversal_preparation",
@@ -184,6 +189,28 @@ def in_any_root(rel: str, roots: Iterable[str]) -> bool:
     return any(rel == root or rel.startswith(root.rstrip("/") + "/") for root in roots)
 
 
+def merge_backtest_binding_pins(
+    repo_root: Path,
+    backtest_hits: list[PathHit],
+    pins: Iterable[str],
+) -> list[PathHit]:
+    pinned_hits: list[PathHit] = []
+    for rel in pins:
+        path = repo_root / rel
+        if not path.is_file():
+            continue
+        text = read_text(path)
+        pinned_hits.append(
+            PathHit(
+                path=rel,
+                digest=digest_text(text),
+                matched_terms=["rewire_binding_pin"],
+            )
+        )
+    seen = {hit.path for hit in pinned_hits}
+    return pinned_hits + [hit for hit in backtest_hits if hit.path not in seen]
+
+
 def collect_hits(
     files: list[Path], repo_root: Path, roots: Iterable[str], keywords: Iterable[str]
 ) -> list[PathHit]:
@@ -275,6 +302,11 @@ def build_inventory(repo_root: Path) -> dict[str, object]:
             repo_root,
             surface["backtest_roots"],
             surface["keywords"],
+        )
+        backtest_hits = merge_backtest_binding_pins(
+            repo_root,
+            backtest_hits,
+            surface.get("backtest_binding_pins", ()),
         )
         runtime_hits = collect_hits(
             files,

--- a/scripts/research/bull_bear_state_switch_narrow_reuse_first_rewire_v0.py
+++ b/scripts/research/bull_bear_state_switch_narrow_reuse_first_rewire_v0.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import NO_AUTHORITY_FLAGS
+from trading.master_v2.bull_bear_state_switch_scenario_binding_adapter_v0 import (
+    BULL_BEAR_STATE_SWITCH_SCENARIO_BINDING_ADAPTER_OWNER,
+    CANONICAL_STATE_SWITCH_OWNER,
+    STATE_SWITCH_EFFECT_BOUND_OFFLINE,
+    mirrored_side_states_parity_ok_v0,
+    state_switch_binding_non_authority_boundary_ok_v0,
+)
+from trading.master_v2.double_play_state import ScopeEvent, SideState
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    assert_state_switch_non_authority_boundary_v0,
+    canonical_owner_refs_v0,
+    evaluate_scenario_state_switch_for_fixture_v0,
+    extract_state_switch_parity_envelope_v0,
+)
+from trading.master_v2.offline_double_play_scenario_replay_v0 import SYNTHETIC_FUTURES_INSTRUMENT
+
+SURFACE_ID = "bull_bear_state_switch"
+PLAN_TYPE = "NARROW_REUSE_FIRST_REWIRE"
+TRACE_ASSERTION_SOURCE_PR = 5006
+REWIRE_STATE = "REWIRE_BOUND_OFFLINE_PARITY_PATH"
+
+REUSED_CANONICAL_OWNER = CANONICAL_STATE_SWITCH_OWNER
+REUSED_ADAPTER_OWNER = BULL_BEAR_STATE_SWITCH_SCENARIO_BINDING_ADAPTER_OWNER
+CANONICAL_OWNER_PATH = "src/trading/master_v2/double_play_state.py"
+ADAPTER_PATH = "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py"
+HARNESS_PATH = (
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py"
+)
+OFFLINE_REPLAY_PATH = "src/trading/master_v2/offline_double_play_scenario_replay_v0.py"
+CONTRACT_TEST_PATH = "tests/trading/master_v2/test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py"
+OWNER_BOUND_PATHS = (
+    CANONICAL_OWNER_PATH,
+    ADAPTER_PATH,
+    HARNESS_PATH,
+    OFFLINE_REPLAY_PATH,
+    CONTRACT_TEST_PATH,
+)
+
+
+@dataclass(frozen=True)
+class RewireBinding:
+    surface_id: str
+    reused_canonical_owner: str
+    reused_adapter_owner: str
+    canonical_owner_path: str
+    adapter_path: str
+    harness_path: str
+    offline_replay_path: str
+    contract_test_path: str
+    bull_confirmed_side_state_after: str
+    bear_confirmed_side_state_after: str
+    mirrored_side_states_symmetric: bool
+    rewire_state: str
+    functional_rewire_performed: bool
+    new_parallel_owner_created: bool
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _assert_owner_bound_paths_exist(repo_root: Path) -> None:
+    for rel in OWNER_BOUND_PATHS:
+        if not (repo_root / rel).is_file():
+            raise ValueError(f"owner-bound path missing: {rel}")
+
+
+def _assert_canonical_owner_reuse() -> None:
+    refs = canonical_owner_refs_v0()
+    if refs["state_switch"] != REUSED_CANONICAL_OWNER:
+        raise ValueError("canonical state_switch owner drift")
+    if refs["bull_bear_state_switch_scenario_binding_adapter"] != REUSED_ADAPTER_OWNER:
+        raise ValueError("bull/bear adapter owner drift")
+
+
+def evaluate_bull_bear_parity_fixtures_v0(
+    *,
+    instrument_id: str = SYNTHETIC_FUTURES_INSTRUMENT,
+    trading_epoch: int = 48,
+    context_reference: str = "bull-bear-narrow-rewire-v0",
+) -> tuple[Any, Any]:
+    bull_binding = evaluate_scenario_state_switch_for_fixture_v0(
+        side_state=SideState.NEUTRAL_OBSERVE,
+        scope_event=ScopeEvent.UPSCOPE_CONFIRMED,
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=f"{context_reference}-bull",
+    )
+    bear_binding = evaluate_scenario_state_switch_for_fixture_v0(
+        side_state=SideState.NEUTRAL_OBSERVE,
+        scope_event=ScopeEvent.DOWNSCOPE_CONFIRMED,
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=f"{context_reference}-bear",
+    )
+    for binding in (bull_binding, bear_binding):
+        env = extract_state_switch_parity_envelope_v0(binding)
+        assert_state_switch_non_authority_boundary_v0(env)
+        if not state_switch_binding_non_authority_boundary_ok_v0(binding):
+            raise ValueError("state switch binding violated non-authority boundary")
+        if binding.state_switch_effect != STATE_SWITCH_EFFECT_BOUND_OFFLINE:
+            raise ValueError("state switch effect must remain offline-bound")
+    return bull_binding, bear_binding
+
+
+def build_rewire_binding(repo_root: Path) -> dict[str, Any]:
+    _assert_owner_bound_paths_exist(repo_root)
+    _assert_canonical_owner_reuse()
+    bull_binding, bear_binding = evaluate_bull_bear_parity_fixtures_v0()
+    mirrored = mirrored_side_states_parity_ok_v0(
+        SideState.LONG_ARMED,
+        SideState.SHORT_ARMED,
+    )
+    binding = RewireBinding(
+        surface_id=SURFACE_ID,
+        reused_canonical_owner=REUSED_CANONICAL_OWNER,
+        reused_adapter_owner=REUSED_ADAPTER_OWNER,
+        canonical_owner_path=CANONICAL_OWNER_PATH,
+        adapter_path=ADAPTER_PATH,
+        harness_path=HARNESS_PATH,
+        offline_replay_path=OFFLINE_REPLAY_PATH,
+        contract_test_path=CONTRACT_TEST_PATH,
+        bull_confirmed_side_state_after=bull_binding.side_state_after.value,
+        bear_confirmed_side_state_after=bear_binding.side_state_after.value,
+        mirrored_side_states_symmetric=mirrored,
+        rewire_state=REWIRE_STATE,
+        functional_rewire_performed=True,
+        new_parallel_owner_created=False,
+    )
+    return {
+        "schema": "BullBearStateSwitchNarrowReuseFirstRewireV1",
+        "surface_id": SURFACE_ID,
+        "plan_type": PLAN_TYPE,
+        "trace_assertion_source_pr": TRACE_ASSERTION_SOURCE_PR,
+        "rewire_scope": "bull_bear_state_switch_only",
+        "rewire_binding": asdict(binding),
+        "forbidden_claims_remain_false": {
+            "FULL_CANONICAL_CHAIN_WIRED": False,
+            "BACKTEST_RUNTIME_DECISION_PARITY_PASS": False,
+            "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE": False,
+            "RUNTIME_AUTHORITY": False,
+            "ORDERS_ALLOWED": False,
+            "ECONOMIC_CLAIM": False,
+        },
+        **NO_AUTHORITY_FLAGS,
+    }
+
+
+def render_markdown(rewire: dict[str, Any]) -> str:
+    binding = rewire["rewire_binding"]
+    lines = [
+        "# Bull Bear State Switch Narrow Reuse-First Rewire V1",
+        "",
+        "```text",
+        "NARROW_REUSE_FIRST_REWIRE=true",
+        "FUNCTIONAL_REWIRE_PERFORMED=true",
+        "NEW_PARALLEL_OWNER_CREATED=false",
+        "NO_RUNTIME_AUTHORITY=true",
+        "NO_ORDERS=true",
+        "NO_ECONOMIC_CLAIM=true",
+        "FULL_CANONICAL_CHAIN_WIRED=false",
+        "BACKTEST_RUNTIME_DECISION_PARITY_PASS=false",
+        "```",
+        "",
+        f"- reused_canonical_owner: `{binding['reused_canonical_owner']}`",
+        f"- reused_adapter_owner: `{binding['reused_adapter_owner']}`",
+        f"- harness_path: `{binding['harness_path']}`",
+        f"- contract_test_path: `{binding['contract_test_path']}`",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_manifest(output_dir: Path) -> int:
+    rows: list[str] = []
+    for path in sorted(output_dir.rglob("*")):
+        if path.is_file() and path.name != "MANIFEST.sha256":
+            rows.append(f"{_sha256(path)}  {path.relative_to(output_dir).as_posix()}")
+    (output_dir / "MANIFEST.sha256").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    for row in rows:
+        digest, rel = row.split("  ", 1)
+        if _sha256(output_dir / rel) != digest:
+            return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    rewire = build_rewire_binding(repo_root)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "bull_bear_state_switch_narrow_reuse_first_rewire_v0.json").write_text(
+        json.dumps(rewire, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "bull_bear_state_switch_narrow_reuse_first_rewire_v0.md").write_text(
+        render_markdown(rewire) + "\n",
+        encoding="utf-8",
+    )
+    verdict = "PASS_BULL_BEAR_STATE_SWITCH_NARROW_REUSE_FIRST_REWIRE_BOUND"
+    (output_dir / "verdict.txt").write_text(verdict + "\n", encoding="utf-8")
+    manifest_rc = write_manifest(output_dir)
+    (output_dir / "manifest_verify_rc.txt").write_text(f"{manifest_rc}\n", encoding="utf-8")
+    manifest_rc = write_manifest(output_dir)
+    print(verdict)
+    print(f"REUSED_CANONICAL_OWNER={REUSED_CANONICAL_OWNER}")
+    print(f"FUNCTIONAL_REWIRE_PERFORMED=true")
+    print(f"MANIFEST_VERIFY_RC={manifest_rc}")
+    print(f"EVIDENCE_DIR={output_dir}")
+    return 0 if manifest_rc == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/research/test_bull_bear_state_switch_narrow_reuse_first_rewire_v0.py
+++ b/tests/research/test_bull_bear_state_switch_narrow_reuse_first_rewire_v0.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.research.backtest_runtime_decision_parity_inventory_v0 import build_inventory
+from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import build_trace_matrix
+from scripts.research.bull_bear_state_switch_narrow_reuse_first_rewire_v0 import (
+    CONTRACT_TEST_PATH,
+    PLAN_TYPE,
+    REUSED_CANONICAL_OWNER,
+    SURFACE_ID,
+    build_rewire_binding,
+    evaluate_bull_bear_parity_fixtures_v0,
+)
+from trading.master_v2.double_play_state import SideState
+
+
+def _bull_bear_surface(inventory: dict) -> dict:
+    return next(s for s in inventory["surfaces"] if s["surface_id"] == SURFACE_ID)
+
+
+def test_inventory_pins_bull_bear_backtest_binding_to_parity_contract() -> None:
+    inventory = build_inventory(Path.cwd())
+    surface = _bull_bear_surface(inventory)
+    assert surface["backtest_binding_candidates"][0]["path"] == CONTRACT_TEST_PATH
+    assert surface["backtest_binding_candidates"][0]["matched_terms"] == ["rewire_binding_pin"]
+
+
+def test_rewire_binding_reuses_canonical_owner_without_parallel_owner() -> None:
+    rewire = build_rewire_binding(Path.cwd())
+    binding = rewire["rewire_binding"]
+
+    assert rewire["schema"] == "BullBearStateSwitchNarrowReuseFirstRewireV1"
+    assert rewire["plan_type"] == PLAN_TYPE
+    assert rewire["trace_assertion_source_pr"] == 5006
+    assert binding["reused_canonical_owner"] == REUSED_CANONICAL_OWNER
+    assert binding["functional_rewire_performed"] is True
+    assert binding["new_parallel_owner_created"] is False
+    assert binding["rewire_state"] == "REWIRE_BOUND_OFFLINE_PARITY_PATH"
+
+
+def test_bull_bear_parity_fixtures_reach_canonical_owner_symmetrically() -> None:
+    bull_binding, bear_binding = evaluate_bull_bear_parity_fixtures_v0()
+    assert bull_binding.side_state_after == SideState.LONG_ARMED
+    assert bear_binding.side_state_after == SideState.SHORT_ARMED
+    assert bull_binding.state_switch_ref
+    assert bear_binding.state_switch_ref
+
+
+def test_rewire_makes_no_forbidden_claims() -> None:
+    rewire = build_rewire_binding(Path.cwd())
+    assert rewire["runtime_authority"] is False
+    assert rewire["orders_allowed"] is False
+    assert rewire["economic_claim"] is False
+    assert rewire["full_canonical_chain_wired_claimed"] is False
+    assert rewire["backtest_runtime_decision_parity_pass_claimed"] is False
+    assert rewire["system_economic_evidence_admissible"] is False
+
+    forbidden = rewire["forbidden_claims_remain_false"]
+    assert all(value is False for value in forbidden.values())
+
+
+def test_trace_matrix_still_selects_bull_bear_after_inventory_pin() -> None:
+    inventory = build_inventory(Path.cwd())
+    matrix = build_trace_matrix(inventory)
+    assert matrix["selected_next_rewire_plan"]["selected_surface_id"] == SURFACE_ID
+    edge = matrix["trace_edges"][0]
+    assert edge["surface_id"] == SURFACE_ID
+    assert edge["backtest_candidate"] == CONTRACT_TEST_PATH


### PR DESCRIPTION
## Summary

Narrow reuse-first rewire for `bull_bear_state_switch` after PR #5006 trace assertion.

- Pins inventory backtest binding to the existing Master V2 offline parity contract (no parallel owner).
- Adds research rewire artifact that delegates bull/bear fixtures through `evaluate_scenario_state_switch_for_fixture_v0` on the canonical `double_play_state` owner via the existing scenario binding adapter.
- Keeps all parity-pass / full-chain / runtime / orders / economic claims false.

## Reused owner

- Canonical state switch: `trading.master_v2.double_play_state`
- Scenario binding adapter: `trading.master_v2.bull_bear_state_switch_scenario_binding_adapter_v0`
- Parity harness: `integrated_vs_scenario_replay_full_system_parity_harness_v0.py`
- Contract test: `test_bull_bear_state_switch_scenario_replay_binding_parity_rewire_contract_v0.py`

## Scope

- `scripts/research/backtest_runtime_decision_parity_inventory_v0.py` (bull/bear backtest binding pins only)
- `scripts/research/bull_bear_state_switch_narrow_reuse_first_rewire_v0.py` (new)
- `tests/research/test_bull_bear_state_switch_narrow_reuse_first_rewire_v0.py` (new)

## Non-claims

- `FULL_CANONICAL_CHAIN_WIRED=false`
- `BACKTEST_RUNTIME_DECISION_PARITY_PASS=false`
- `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`
- `RUNTIME_AUTHORITY=false`
- `ORDERS_ALLOWED=false`
- `ECONOMIC_EVALUATION_EXECUTED=false`
- `FUNCTIONAL_REWIRE_PERFORMED=true` (narrow offline parity binding only; no trading semantic extension)

## Evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/bull_bear_state_switch_narrow_reuse_first_rewire_v0_20260708T174916Z`

Source closeout (PR #5006):
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/merge_closeout_bull_bear_state_switch_narrow_trace_assertion_first_v0_20260708T174434Z`

## Validation

- [x] `pytest` research parity/trace/rewire suite (15 passed)
- [x] `ruff check` / `ruff format --check` on changed files
- [x] `compileall` on changed research sources
- [x] Evidence manifest `RC=0`
- [ ] CI fast-lane + tests matrix

Made with [Cursor](https://cursor.com)