### PR TITLE
fix: wire next canonical parity surface into backtest parity path

### DIFF
--- a/scripts/research/backtest_runtime_decision_parity_inventory_v0.py
+++ b/scripts/research/backtest_runtime_decision_parity_inventory_v0.py
@@ -47,6 +47,7 @@ SURFACES = [
             "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
             "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
         ),
+        "trace_rewire_bound": True,
     },
     {
         "surface_id": "scope_adverse_exit_and_reversal_preparation",
@@ -55,6 +56,12 @@ SURFACES = [
         "canonical_roots": ("src/trading", "src/core", "src/strategies"),
         "backtest_roots": ("src/backtest", "scripts", "tests"),
         "runtime_roots": ("src/live", "src/execution", "src/runtime", "src/ops"),
+        "backtest_binding_pins": (
+            "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py",
+            "tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py",
+            "src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py",
+            "src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py",
+        ),
     },
     {
         "surface_id": "flat_before_opposite_side",

--- a/scripts/research/backtest_runtime_decision_parity_trace_matrix_v0.py
+++ b/scripts/research/backtest_runtime_decision_parity_trace_matrix_v0.py
@@ -7,6 +7,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from scripts.research.backtest_runtime_decision_parity_inventory_v0 import SURFACES
+
 INVENTORY_SCRIPT = Path("scripts/research/backtest_runtime_decision_parity_inventory_v0.py")
 
 TRACE_PRIORITY = [
@@ -71,6 +73,20 @@ def _first_path(surface: dict[str, Any], key: str) -> str:
     return hits[0]["path"]
 
 
+def _is_rewire_bound_surface(surface: dict[str, Any]) -> bool:
+    configured = next(
+        (item for item in SURFACES if item["surface_id"] == surface["surface_id"]),
+        None,
+    )
+    if configured is None or not configured.get("trace_rewire_bound"):
+        return False
+    backtest_hits = surface.get("backtest_binding_candidates", [])
+    if not backtest_hits:
+        return False
+    first = backtest_hits[0]
+    return first.get("matched_terms") == ["rewire_binding_pin"]
+
+
 def _load_inventory_from_file(path: Path) -> dict[str, Any]:
     data = json.loads(path.read_text(encoding="utf-8"))
     if data["schema"] != "BacktestRuntimeDecisionParityInventoryV1":
@@ -91,7 +107,10 @@ def build_trace_matrix(inventory: dict[str, Any]) -> dict[str, Any]:
         canonical = _first_path(surface, "canonical_owner_candidates")
         backtest = _first_path(surface, "backtest_binding_candidates")
         runtime = _first_path(surface, "runtime_boundary_candidates")
-        if "NONE_DISCOVERED" in {canonical, backtest, runtime}:
+        if _is_rewire_bound_surface(surface):
+            trace_state = "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"
+            next_action = "rewire_complete_advance_to_next_surface"
+        elif "NONE_DISCOVERED" in {canonical, backtest, runtime}:
             trace_state = "TRACE_INCOMPLETE"
             next_action = "owner_discovery_before_rewire"
         else:
@@ -111,9 +130,14 @@ def build_trace_matrix(inventory: dict[str, Any]) -> dict[str, Any]:
     selected = next(
         edge for edge in edges if edge.trace_state == "TRACE_CANDIDATE_READY_NOT_ASSERTED"
     )
+    plan_type = (
+        "NARROW_REUSE_FIRST_REWIRE"
+        if selected.surface_id == "scope_adverse_exit_and_reversal_preparation"
+        else "NARROW_TRACE_ASSERTION_FIRST"
+    )
     plan = RewirePlan(
         selected_surface_id=selected.surface_id,
-        plan_type="NARROW_TRACE_ASSERTION_FIRST",
+        plan_type=plan_type,
         rationale=(
             "Inventory found candidates on all three surfaces. The next safe move is not a new status contract; "
             "it is an executable trace assertion proving whether the selected canonical owner is actually consumed "

--- a/scripts/research/scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py
+++ b/scripts/research/scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import NO_AUTHORITY_FLAGS
+from trading.master_v2.deterministic_scope_event_generator_v1 import CanonicalScopeEventType
+from trading.master_v2.double_play_entry_exit_policy_v0 import ExitClass
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    assert_reversal_preparation_non_authority_boundary_v0,
+    assert_scope_event_non_authority_boundary_v0,
+    canonical_owner_refs_v0,
+    evaluate_scenario_reversal_preparation_for_fixture_v0,
+    evaluate_scenario_scope_event_for_fixture_v0,
+    extract_reversal_preparation_parity_envelope_v0,
+    extract_scope_event_parity_envelope_v0,
+)
+from trading.master_v2.offline_double_play_scenario_replay_v0 import SYNTHETIC_FUTURES_INSTRUMENT
+from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
+    CANONICAL_ENTRY_EXIT_POLICY_OWNER,
+)
+from trading.master_v2.reversal_preparation_scenario_binding_adapter_v0 import (
+    REVERSAL_PREPARATION_SCENARIO_BINDING_ADAPTER_OWNER,
+    reversal_preparation_binding_non_authority_boundary_ok_v0,
+    reversal_preparation_decision_is_reduce_only_preparation_v0,
+)
+from trading.master_v2.scope_event_generator_scenario_binding_adapter_v0 import (
+    CANONICAL_SCOPE_EVENT_GENERATOR_OWNER,
+    SCOPE_EVENT_EFFECT_BOUND_OFFLINE,
+    SCOPE_EVENT_GENERATOR_SCENARIO_BINDING_ADAPTER_OWNER,
+    scope_event_binding_non_authority_boundary_ok_v0,
+)
+
+SURFACE_ID = "scope_adverse_exit_and_reversal_preparation"
+PLAN_TYPE = "NARROW_REUSE_FIRST_REWIRE"
+TRACE_ASSERTION_SOURCE_PR = 5007
+REWIRE_STATE = "REWIRE_BOUND_OFFLINE_PARITY_PATH"
+
+REUSED_SCOPE_CANONICAL_OWNER = CANONICAL_SCOPE_EVENT_GENERATOR_OWNER
+REUSED_SCOPE_ADAPTER_OWNER = SCOPE_EVENT_GENERATOR_SCENARIO_BINDING_ADAPTER_OWNER
+REUSED_REVERSAL_CANONICAL_OWNER = CANONICAL_ENTRY_EXIT_POLICY_OWNER
+REUSED_REVERSAL_ADAPTER_OWNER = REVERSAL_PREPARATION_SCENARIO_BINDING_ADAPTER_OWNER
+SCOPE_CANONICAL_OWNER_PATH = "src/trading/master_v2/deterministic_scope_event_generator_v1.py"
+SCOPE_ADAPTER_PATH = "src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py"
+REVERSAL_ADAPTER_PATH = "src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py"
+HARNESS_PATH = (
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py"
+)
+OFFLINE_REPLAY_PATH = "src/trading/master_v2/offline_double_play_scenario_replay_v0.py"
+SCOPE_CONTRACT_TEST_PATH = "tests/trading/master_v2/test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py"
+REVERSAL_CONTRACT_TEST_PATH = "tests/trading/master_v2/test_reversal_preparation_scenario_replay_binding_parity_rewire_contract_v0.py"
+OWNER_BOUND_PATHS = (
+    SCOPE_CANONICAL_OWNER_PATH,
+    SCOPE_ADAPTER_PATH,
+    REVERSAL_ADAPTER_PATH,
+    HARNESS_PATH,
+    OFFLINE_REPLAY_PATH,
+    SCOPE_CONTRACT_TEST_PATH,
+    REVERSAL_CONTRACT_TEST_PATH,
+)
+
+
+@dataclass(frozen=True)
+class RewireBinding:
+    surface_id: str
+    reused_scope_canonical_owner: str
+    reused_scope_adapter_owner: str
+    reused_reversal_canonical_owner: str
+    reused_reversal_adapter_owner: str
+    scope_canonical_owner_path: str
+    scope_adapter_path: str
+    reversal_adapter_path: str
+    harness_path: str
+    offline_replay_path: str
+    scope_contract_test_path: str
+    reversal_contract_test_path: str
+    adverse_scope_event_type: str
+    adverse_exit_signal_triggered: bool
+    reversal_preparation_exit_class: str
+    reversal_preparation_reduce_only: bool
+    rewire_state: str
+    functional_rewire_performed: bool
+    new_parallel_owner_created: bool
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _assert_owner_bound_paths_exist(repo_root: Path) -> None:
+    for rel in OWNER_BOUND_PATHS:
+        if not (repo_root / rel).is_file():
+            raise ValueError(f"owner-bound path missing: {rel}")
+
+
+def _assert_canonical_owner_reuse() -> None:
+    refs = canonical_owner_refs_v0()
+    if refs["scope_event_generator"] != REUSED_SCOPE_CANONICAL_OWNER:
+        raise ValueError("scope event generator owner drift")
+    if refs["scope_event_generator_scenario_binding_adapter"] != REUSED_SCOPE_ADAPTER_OWNER:
+        raise ValueError("scope adapter owner drift")
+    if refs["reversal_preparation_scenario_binding_adapter"] != REUSED_REVERSAL_ADAPTER_OWNER:
+        raise ValueError("reversal preparation adapter owner drift")
+
+
+def evaluate_scope_adverse_exit_and_reversal_parity_fixtures_v0(
+    *,
+    instrument_id: str = SYNTHETIC_FUTURES_INSTRUMENT,
+    trading_epoch: int = 48,
+    context_reference: str = "scope-reversal-narrow-rewire-v0",
+) -> tuple[Any, Any]:
+    scope_binding = evaluate_scenario_scope_event_for_fixture_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=f"{context_reference}-scope",
+    )
+    scope_env = extract_scope_event_parity_envelope_v0(scope_binding)
+    assert_scope_event_non_authority_boundary_v0(scope_env)
+    if not scope_event_binding_non_authority_boundary_ok_v0(scope_binding):
+        raise ValueError("scope event binding violated non-authority boundary")
+    if scope_binding.scope_event_effect != SCOPE_EVENT_EFFECT_BOUND_OFFLINE:
+        raise ValueError("scope event effect must remain offline-bound")
+    if (
+        scope_binding.scope_event_evidence.event_type
+        is not CanonicalScopeEventType.ADVERSE_EXIT_CANDIDATE
+    ):
+        raise ValueError("adverse scope fixture must reach ADVERSE_EXIT_CANDIDATE")
+    if not scope_binding.scope_adverse_exit_signal.triggered:
+        raise ValueError("adverse exit signal must be triggered in fixture")
+
+    reversal_decision = evaluate_scenario_reversal_preparation_for_fixture_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=f"{context_reference}-reversal",
+    )
+    reversal_env = extract_reversal_preparation_parity_envelope_v0(reversal_decision)
+    assert_reversal_preparation_non_authority_boundary_v0(reversal_env)
+    if not reversal_preparation_binding_non_authority_boundary_ok_v0(reversal_decision):
+        raise ValueError("reversal preparation binding violated non-authority boundary")
+    if reversal_decision.exit_class is not ExitClass.REVERSAL_PREPARATION_EXIT:
+        raise ValueError("reversal fixture must reach REVERSAL_PREPARATION_EXIT")
+    if not reversal_preparation_decision_is_reduce_only_preparation_v0(reversal_decision):
+        raise ValueError("reversal preparation must remain reduce-only preparation")
+
+    return scope_binding, reversal_decision
+
+
+def build_rewire_binding(repo_root: Path) -> dict[str, Any]:
+    _assert_owner_bound_paths_exist(repo_root)
+    _assert_canonical_owner_reuse()
+    scope_binding, reversal_decision = evaluate_scope_adverse_exit_and_reversal_parity_fixtures_v0()
+    binding = RewireBinding(
+        surface_id=SURFACE_ID,
+        reused_scope_canonical_owner=REUSED_SCOPE_CANONICAL_OWNER,
+        reused_scope_adapter_owner=REUSED_SCOPE_ADAPTER_OWNER,
+        reused_reversal_canonical_owner=REUSED_REVERSAL_CANONICAL_OWNER,
+        reused_reversal_adapter_owner=REUSED_REVERSAL_ADAPTER_OWNER,
+        scope_canonical_owner_path=SCOPE_CANONICAL_OWNER_PATH,
+        scope_adapter_path=SCOPE_ADAPTER_PATH,
+        reversal_adapter_path=REVERSAL_ADAPTER_PATH,
+        harness_path=HARNESS_PATH,
+        offline_replay_path=OFFLINE_REPLAY_PATH,
+        scope_contract_test_path=SCOPE_CONTRACT_TEST_PATH,
+        reversal_contract_test_path=REVERSAL_CONTRACT_TEST_PATH,
+        adverse_scope_event_type=scope_binding.scope_event_evidence.event_type.value,
+        adverse_exit_signal_triggered=scope_binding.scope_adverse_exit_signal.triggered,
+        reversal_preparation_exit_class=reversal_decision.exit_class.value,
+        reversal_preparation_reduce_only=True,
+        rewire_state=REWIRE_STATE,
+        functional_rewire_performed=True,
+        new_parallel_owner_created=False,
+    )
+    return {
+        "schema": "ScopeAdverseExitAndReversalPreparationNarrowReuseFirstRewireV1",
+        "surface_id": SURFACE_ID,
+        "plan_type": PLAN_TYPE,
+        "trace_assertion_source_pr": TRACE_ASSERTION_SOURCE_PR,
+        "rewire_scope": "scope_adverse_exit_and_reversal_preparation_only",
+        "rewire_binding": asdict(binding),
+        "forbidden_claims_remain_false": {
+            "FULL_CANONICAL_CHAIN_WIRED": False,
+            "BACKTEST_RUNTIME_DECISION_PARITY_PASS": False,
+            "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE": False,
+            "RUNTIME_AUTHORITY": False,
+            "ORDERS_ALLOWED": False,
+            "ECONOMIC_CLAIM": False,
+        },
+        **NO_AUTHORITY_FLAGS,
+    }
+
+
+def render_markdown(rewire: dict[str, Any]) -> str:
+    binding = rewire["rewire_binding"]
+    lines = [
+        "# Scope Adverse Exit And Reversal Preparation Narrow Reuse-First Rewire V1",
+        "",
+        "```text",
+        "NARROW_REUSE_FIRST_REWIRE=true",
+        "FUNCTIONAL_REWIRE_PERFORMED=true",
+        "NEW_PARALLEL_OWNER_CREATED=false",
+        "NO_RUNTIME_AUTHORITY=true",
+        "NO_ORDERS=true",
+        "NO_ECONOMIC_CLAIM=true",
+        "FULL_CANONICAL_CHAIN_WIRED=false",
+        "BACKTEST_RUNTIME_DECISION_PARITY_PASS=false",
+        "```",
+        "",
+        f"- reused_scope_canonical_owner: `{binding['reused_scope_canonical_owner']}`",
+        f"- reused_scope_adapter_owner: `{binding['reused_scope_adapter_owner']}`",
+        f"- reused_reversal_adapter_owner: `{binding['reused_reversal_adapter_owner']}`",
+        f"- harness_path: `{binding['harness_path']}`",
+        f"- scope_contract_test_path: `{binding['scope_contract_test_path']}`",
+        f"- reversal_contract_test_path: `{binding['reversal_contract_test_path']}`",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_manifest(output_dir: Path) -> int:
+    rows: list[str] = []
+    for path in sorted(output_dir.rglob("*")):
+        if path.is_file() and path.name != "MANIFEST.sha256":
+            rows.append(f"{_sha256(path)}  {path.relative_to(output_dir).as_posix()}")
+    (output_dir / "MANIFEST.sha256").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    for row in rows:
+        digest, rel = row.split("  ", 1)
+        if _sha256(output_dir / rel) != digest:
+            return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    rewire = build_rewire_binding(repo_root)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (
+        output_dir / "scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.json"
+    ).write_text(
+        json.dumps(rewire, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (
+        output_dir / "scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.md"
+    ).write_text(
+        render_markdown(rewire) + "\n",
+        encoding="utf-8",
+    )
+    verdict = "PASS_SCOPE_ADVERSE_EXIT_AND_REVERSAL_PREPARATION_NARROW_REUSE_FIRST_REWIRE_BOUND"
+    (output_dir / "verdict.txt").write_text(verdict + "\n", encoding="utf-8")
+    manifest_rc = write_manifest(output_dir)
+    (output_dir / "manifest_verify_rc.txt").write_text(f"{manifest_rc}\n", encoding="utf-8")
+    manifest_rc = write_manifest(output_dir)
+    print(verdict)
+    print(f"REUSED_SCOPE_CANONICAL_OWNER={REUSED_SCOPE_CANONICAL_OWNER}")
+    print(f"FUNCTIONAL_REWIRE_PERFORMED=true")
+    print(f"MANIFEST_VERIFY_RC={manifest_rc}")
+    print(f"EVIDENCE_DIR={output_dir}")
+    return 0 if manifest_rc == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
+++ b/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
@@ -130,7 +130,9 @@ from trading.master_v2.reversal_preparation_scenario_binding_adapter_v0 import (
     REVERSAL_PREPARATION_SCENARIO_BINDING_ADAPTER_OWNER,
     REVERSAL_PREPARATION_EFFECT_BOUND_OFFLINE,
     evaluate_scenario_reversal_preparation_entry_exit_v0,
+    is_reversal_preparation_composition_v0,
     reversal_preparation_binding_non_authority_boundary_ok_v0,
+    reversal_preparation_decision_is_reduce_only_preparation_v0,
 )
 from trading.master_v2.flat_before_opposite_side_scenario_binding_adapter_v0 import (
     FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_BINDING_ADAPTER_OWNER,
@@ -142,6 +144,7 @@ from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import
     evaluate_scenario_entry_exit_policy_v0,
 )
 from trading.master_v2.double_play_state import (
+    ActiveSide,
     DynamicScopeRules,
     RuntimeEnvelope,
     RuntimeScopeState,
@@ -264,6 +267,8 @@ class ParityDecisionEnvelopeV0:
     ai_observability_boundary_effect: str = AI_OBSERVABILITY_BOUNDARY_EFFECT_NONE
     state_switch_ref: str = ""
     state_switch_effect: str = STATE_SWITCH_EFFECT_NONE
+    scope_event_ref: str = ""
+    scope_event_effect: str = ""
     transition_reason_code: str = ""
     conflict_status: Optional[str] = None
     selected_side: Optional[str] = None
@@ -636,6 +641,142 @@ def evaluate_scenario_state_switch_for_fixture_v0(
             now_tick=tick,
             scope_event_id=f"{context_reference}-scope-{scope_event.value}",
         )
+    )
+
+
+_DEFAULT_SCENARIO_SCOPE_EVENT_RULES = DynamicScopeRules(
+    min_band_width=1.0,
+    max_band_width=50.0,
+    min_switch_cooldown_ticks=0,
+    max_switches_per_window=1_000_000,
+    volatility_estimate=0.02,
+)
+_DEFAULT_SCENARIO_SCOPE_RUNTIME = RuntimeScopeState(
+    anchor_price=100.0,
+    current_hysteresis_band=4.0,
+)
+
+
+def _default_scenario_scope_confirmation_state_v0():
+    from trading.master_v2.deterministic_scope_event_generator_v1 import ScopeConfirmationStateV1
+
+    return ScopeConfirmationStateV1(
+        candidate_kind=None,
+        candidate_count=0,
+        last_evaluated_trading_epoch=0,
+    )
+
+
+def extract_scope_event_parity_envelope_v0(
+    binding: ScenarioScopeEventBindingResultV0,
+) -> ParityDecisionEnvelopeV0:
+    evidence = binding.scope_event_evidence
+    adverse = binding.scope_adverse_exit_signal
+    return ParityDecisionEnvelopeV0(
+        decision_outcome="not_bound_offline_scope_event_only",
+        previous_side_state=None,
+        next_side_state=None,
+        composition_status="not_bound_offline_scope_event_only",
+        composition_result_id="",
+        entry_or_exit_policy_ref="",
+        reason_codes=(evidence.event_type.value, adverse.reason_code),
+        decision_precedence_trace=(),
+        execution_eligible=False,
+        adapter_compatible=False,
+        quantity_status="NOT_BOUND",
+        scope_event_ref=binding.scope_event_ref,
+        scope_event_effect=binding.scope_event_effect,
+        authority_effect="NONE",
+        runtime_effect="NONE",
+    )
+
+
+def assert_scope_event_non_authority_boundary_v0(envelope: ParityDecisionEnvelopeV0) -> None:
+    assert not envelope.execution_eligible
+    assert not envelope.adapter_compatible
+    assert envelope.authority_effect == "NONE"
+    assert envelope.runtime_effect == "NONE"
+    if envelope.scope_event_effect == SCOPE_EVENT_EFFECT_BOUND_OFFLINE:
+        assert envelope.scope_event_ref
+
+
+def evaluate_scenario_scope_event_for_fixture_v0(
+    *,
+    instrument_id: str = SYNTHETIC_FUTURES_INSTRUMENT,
+    trading_epoch: int = 48,
+    context_reference: str = "scope-adverse-narrow-rewire-v0",
+    current_price: float = 96.0,
+    adverse_exit_distance: float = 2.0,
+) -> ScenarioScopeEventBindingResultV0:
+    return evaluate_scenario_scope_event_v0(
+        ScenarioScopeEventContextV0(
+            instrument_id=instrument_id,
+            trading_epoch=trading_epoch,
+            context_reference=context_reference,
+            current_price=current_price,
+            scope_state=_DEFAULT_SCENARIO_SCOPE_RUNTIME,
+            rules=_DEFAULT_SCENARIO_SCOPE_EVENT_RULES,
+            active_side=ActiveSide.LONG,
+            confirmation_state=_default_scenario_scope_confirmation_state_v0(),
+            up_distance=2.0,
+            adverse_exit_distance=adverse_exit_distance,
+            reversal_distance=4.0,
+        )
+    )
+
+
+def extract_reversal_preparation_parity_envelope_v0(
+    decision: EntryExitPolicyDecisionV0,
+    *,
+    reversal_preparation_ref: str = "",
+) -> ParityDecisionEnvelopeV0:
+    return ParityDecisionEnvelopeV0(
+        decision_outcome=decision.decision_outcome.value,
+        previous_side_state=None,
+        next_side_state=None,
+        composition_status=CompositionStatus.REVERSAL_PREPARATION.value,
+        composition_result_id=reversal_preparation_ref,
+        entry_or_exit_policy_ref=decision.policy_decision_id or "",
+        reason_codes=tuple(decision.reason_codes),
+        decision_precedence_trace=tuple(decision.decision_precedence_trace),
+        execution_eligible=False,
+        adapter_compatible=False,
+        quantity_status="NOT_BOUND",
+        authority_effect="NONE",
+        runtime_effect="NONE",
+    )
+
+
+def assert_reversal_preparation_non_authority_boundary_v0(
+    envelope: ParityDecisionEnvelopeV0,
+) -> None:
+    assert not envelope.execution_eligible
+    assert not envelope.adapter_compatible
+    assert envelope.authority_effect == "NONE"
+    assert envelope.runtime_effect == "NONE"
+    assert envelope.composition_status == CompositionStatus.REVERSAL_PREPARATION.value
+
+
+def evaluate_scenario_reversal_preparation_for_fixture_v0(
+    *,
+    instrument_id: str = SYNTHETIC_FUTURES_INSTRUMENT,
+    trading_epoch: int = 48,
+    context_reference: str = "reversal-prep-narrow-rewire-v0",
+) -> EntryExitPolicyDecisionV0:
+    matrix = evaluate_reversal_preparation_matrix_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+    )
+    if not is_reversal_preparation_composition_v0(matrix):
+        raise ValueError("fixture matrix must be reversal preparation composition")
+    return evaluate_scenario_reversal_preparation_entry_exit_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+        composition_result=matrix,
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=default_scenario_entry_exit_policy_context_v0(),
     )
 
 

--- a/tests/research/test_bull_bear_state_switch_narrow_reuse_first_rewire_v0.py
+++ b/tests/research/test_bull_bear_state_switch_narrow_reuse_first_rewire_v0.py
@@ -60,10 +60,10 @@ def test_rewire_makes_no_forbidden_claims() -> None:
     assert all(value is False for value in forbidden.values())
 
 
-def test_trace_matrix_still_selects_bull_bear_after_inventory_pin() -> None:
+def test_trace_matrix_bull_bear_marked_rewire_bound_after_inventory_pin() -> None:
     inventory = build_inventory(Path.cwd())
     matrix = build_trace_matrix(inventory)
-    assert matrix["selected_next_rewire_plan"]["selected_surface_id"] == SURFACE_ID
     edge = matrix["trace_edges"][0]
-    assert edge["surface_id"] == SURFACE_ID
+    assert edge["surface_id"] == "bull_bear_state_switch"
+    assert edge["trace_state"] == "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"
     assert edge["backtest_candidate"] == CONTRACT_TEST_PATH

--- a/tests/research/test_scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py
+++ b/tests/research/test_scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.research.backtest_runtime_decision_parity_inventory_v0 import build_inventory
+from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import build_trace_matrix
+from scripts.research.scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0 import (
+    PLAN_TYPE,
+    REUSED_SCOPE_CANONICAL_OWNER,
+    REVERSAL_CONTRACT_TEST_PATH,
+    SCOPE_CONTRACT_TEST_PATH,
+    SURFACE_ID,
+    build_rewire_binding,
+    evaluate_scope_adverse_exit_and_reversal_parity_fixtures_v0,
+)
+from trading.master_v2.deterministic_scope_event_generator_v1 import CanonicalScopeEventType
+from trading.master_v2.double_play_entry_exit_policy_v0 import ExitClass
+
+
+def _scope_surface(inventory: dict) -> dict:
+    return next(s for s in inventory["surfaces"] if s["surface_id"] == SURFACE_ID)
+
+
+def test_inventory_pins_scope_reversal_backtest_binding_to_parity_contracts() -> None:
+    inventory = build_inventory(Path.cwd())
+    surface = _scope_surface(inventory)
+    pinned_paths = {hit["path"] for hit in surface["backtest_binding_candidates"][:2]}
+    assert SCOPE_CONTRACT_TEST_PATH in pinned_paths
+    assert REVERSAL_CONTRACT_TEST_PATH in pinned_paths
+    assert surface["backtest_binding_candidates"][0]["matched_terms"] == ["rewire_binding_pin"]
+
+
+def test_rewire_binding_reuses_canonical_owners_without_parallel_owner() -> None:
+    rewire = build_rewire_binding(Path.cwd())
+    binding = rewire["rewire_binding"]
+
+    assert rewire["schema"] == "ScopeAdverseExitAndReversalPreparationNarrowReuseFirstRewireV1"
+    assert rewire["plan_type"] == PLAN_TYPE
+    assert rewire["trace_assertion_source_pr"] == 5007
+    assert binding["reused_scope_canonical_owner"] == REUSED_SCOPE_CANONICAL_OWNER
+    assert binding["functional_rewire_performed"] is True
+    assert binding["new_parallel_owner_created"] is False
+    assert binding["rewire_state"] == "REWIRE_BOUND_OFFLINE_PARITY_PATH"
+
+
+def test_scope_and_reversal_parity_fixtures_reach_canonical_owners() -> None:
+    scope_binding, reversal_decision = evaluate_scope_adverse_exit_and_reversal_parity_fixtures_v0()
+    assert (
+        scope_binding.scope_event_evidence.event_type
+        is CanonicalScopeEventType.ADVERSE_EXIT_CANDIDATE
+    )
+    assert scope_binding.scope_adverse_exit_signal.triggered is True
+    assert scope_binding.scope_event_ref
+    assert reversal_decision.exit_class is ExitClass.REVERSAL_PREPARATION_EXIT
+    assert reversal_decision.policy_decision_id
+
+
+def test_rewire_makes_no_forbidden_claims() -> None:
+    rewire = build_rewire_binding(Path.cwd())
+    assert rewire["runtime_authority"] is False
+    assert rewire["orders_allowed"] is False
+    assert rewire["economic_claim"] is False
+    assert rewire["full_canonical_chain_wired_claimed"] is False
+    assert rewire["backtest_runtime_decision_parity_pass_claimed"] is False
+    assert rewire["system_economic_evidence_admissible"] is False
+
+    forbidden = rewire["forbidden_claims_remain_false"]
+    assert all(value is False for value in forbidden.values())
+
+
+def test_trace_matrix_selects_scope_after_bull_bear_rewire_bound() -> None:
+    inventory = build_inventory(Path.cwd())
+    matrix = build_trace_matrix(inventory)
+    assert matrix["selected_next_rewire_plan"]["selected_surface_id"] == SURFACE_ID
+    assert matrix["selected_next_rewire_plan"]["plan_type"] == PLAN_TYPE
+    bull_bear_edge = matrix["trace_edges"][0]
+    assert bull_bear_edge["surface_id"] == "bull_bear_state_switch"
+    assert bull_bear_edge["trace_state"] == "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"
+    scope_edge = matrix["trace_edges"][1]
+    assert scope_edge["surface_id"] == SURFACE_ID
+    assert scope_edge["backtest_candidate"] == SCOPE_CONTRACT_TEST_PATH


### PR DESCRIPTION
## Summary
- Advance parity trace matrix past completed `bull_bear_state_switch` rewire (PR #5007) to `scope_adverse_exit_and_reversal_preparation`.
- Add narrow reuse-first rewire evidence script and harness fixture helpers wiring existing scope event generator + reversal preparation adapters into the offline/backtest parity path.
- Pin scope/reversal contract tests in parity inventory; add research trace tests proving adverse-exit and reversal-preparation surfaces are represented without forbidden claims.

## Selected surface
`scope_adverse_exit_and_reversal_preparation` (priority #1 after bull/bear)

## Reuse owners
- `trading.master_v2.deterministic_scope_event_generator_v1` (scope adverse exit)
- `trading.master_v2.scope_event_generator_scenario_binding_adapter_v0`
- `trading.master_v2.reversal_preparation_scenario_binding_adapter_v0` → `double_play_entry_exit_policy_v0`

## Claims unchanged (fail-closed)
- `FULL_CANONICAL_CHAIN_WIRED=false`
- `BACKTEST_RUNTIME_DECISION_PARITY_PASS=false`
- `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`
- `RUNTIME_REWIRE_ADMISSIBLE=false`

## Test plan
- [x] `tests/research/test_scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py`
- [x] `tests/research/test_bull_bear_state_switch_narrow_reuse_first_rewire_v0.py`
- [x] `tests/research/test_backtest_runtime_decision_parity_trace_matrix_v0.py`
- [x] `tests/research/test_backtest_runtime_decision_parity_inventory_v0.py`
- [x] ruff check / ruff format --check on changed Python files
- [x] durable evidence manifest verify RC=0

## Evidence
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0_20260708T180917Z`


Made with [Cursor](https://cursor.com)