### PR TITLE
fix: wire flat before opposite side into parity path

### DIFF
--- a/scripts/research/backtest_runtime_decision_parity_inventory_v0.py
+++ b/scripts/research/backtest_runtime_decision_parity_inventory_v0.py
@@ -62,6 +62,7 @@ SURFACES = [
             "src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py",
             "src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py",
         ),
+        "trace_rewire_bound": True,
     },
     {
         "surface_id": "flat_before_opposite_side",
@@ -70,6 +71,11 @@ SURFACES = [
         "canonical_roots": ("src/trading", "src/execution", "src/live", "src/core"),
         "backtest_roots": ("src/backtest", "scripts", "tests"),
         "runtime_roots": ("src/live", "src/execution", "src/runtime", "src/ops"),
+        "backtest_binding_pins": (
+            "tests/trading/master_v2/test_flat_before_opposite_side_scenario_replay_binding_parity_rewire_contract_v0.py",
+            "src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py",
+            "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+        ),
     },
     {
         "surface_id": "survival_and_suitability",

--- a/scripts/research/backtest_runtime_decision_parity_trace_matrix_v0.py
+++ b/scripts/research/backtest_runtime_decision_parity_trace_matrix_v0.py
@@ -132,7 +132,7 @@ def build_trace_matrix(inventory: dict[str, Any]) -> dict[str, Any]:
     )
     plan_type = (
         "NARROW_REUSE_FIRST_REWIRE"
-        if selected.surface_id == "scope_adverse_exit_and_reversal_preparation"
+        if selected.surface_id == "flat_before_opposite_side"
         else "NARROW_TRACE_ASSERTION_FIRST"
     )
     plan = RewirePlan(

--- a/scripts/research/flat_before_opposite_side_narrow_reuse_first_rewire_v0.py
+++ b/scripts/research/flat_before_opposite_side_narrow_reuse_first_rewire_v0.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import NO_AUTHORITY_FLAGS
+from trading.master_v2.double_play_entry_exit_policy_v0 import DecisionOutcome
+from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
+    CANONICAL_ENTRY_EXIT_POLICY_OWNER,
+)
+from trading.master_v2.flat_before_opposite_side_scenario_binding_adapter_v0 import (
+    FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_BINDING_ADAPTER_OWNER,
+    flat_before_opposite_side_binding_non_authority_boundary_ok_v0,
+    flat_before_opposite_side_blocks_opposite_entry_v0,
+)
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    assert_flat_before_opposite_side_non_authority_boundary_v0,
+    canonical_owner_refs_v0,
+    evaluate_scenario_flat_before_opposite_side_for_fixture_v0,
+    extract_flat_before_opposite_side_parity_envelope_v0,
+)
+from trading.master_v2.offline_double_play_scenario_replay_v0 import SYNTHETIC_FUTURES_INSTRUMENT
+
+SURFACE_ID = "flat_before_opposite_side"
+PLAN_TYPE = "NARROW_REUSE_FIRST_REWIRE"
+TRACE_ASSERTION_SOURCE_PR = 5008
+REWIRE_STATE = "REWIRE_BOUND_OFFLINE_PARITY_PATH"
+
+REUSED_CANONICAL_OWNER = CANONICAL_ENTRY_EXIT_POLICY_OWNER
+REUSED_ADAPTER_OWNER = FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_BINDING_ADAPTER_OWNER
+CANONICAL_OWNER_PATH = "src/trading/master_v2/double_play_entry_exit_policy_v0.py"
+ADAPTER_PATH = "src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py"
+HARNESS_PATH = (
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py"
+)
+OFFLINE_REPLAY_PATH = "src/trading/master_v2/offline_double_play_scenario_replay_v0.py"
+CONTRACT_TEST_PATH = "tests/trading/master_v2/test_flat_before_opposite_side_scenario_replay_binding_parity_rewire_contract_v0.py"
+OWNER_BOUND_PATHS = (
+    CANONICAL_OWNER_PATH,
+    ADAPTER_PATH,
+    HARNESS_PATH,
+    OFFLINE_REPLAY_PATH,
+    CONTRACT_TEST_PATH,
+)
+
+
+@dataclass(frozen=True)
+class RewireBinding:
+    surface_id: str
+    reused_canonical_owner: str
+    reused_adapter_owner: str
+    canonical_owner_path: str
+    adapter_path: str
+    harness_path: str
+    offline_replay_path: str
+    contract_test_path: str
+    blocked_opposite_entry: bool
+    decision_outcome: str
+    position_flip_allowed: bool
+    rewire_state: str
+    functional_rewire_performed: bool
+    new_parallel_owner_created: bool
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _assert_owner_bound_paths_exist(repo_root: Path) -> None:
+    for rel in OWNER_BOUND_PATHS:
+        if not (repo_root / rel).is_file():
+            raise ValueError(f"owner-bound path missing: {rel}")
+
+
+def _assert_canonical_owner_reuse() -> None:
+    refs = canonical_owner_refs_v0()
+    if refs["entry_exit_policy"] != REUSED_CANONICAL_OWNER:
+        raise ValueError("entry-exit policy owner drift")
+    if refs["flat_before_opposite_side_scenario_binding_adapter"] != REUSED_ADAPTER_OWNER:
+        raise ValueError("flat-before-opposite-side adapter owner drift")
+
+
+def evaluate_flat_before_opposite_side_parity_fixtures_v0(
+    *,
+    instrument_id: str = SYNTHETIC_FUTURES_INSTRUMENT,
+    trading_epoch: int = 54,
+    context_reference: str = "flat-before-opposite-narrow-rewire-v0",
+) -> Any:
+    decision = evaluate_scenario_flat_before_opposite_side_for_fixture_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+    )
+    envelope = extract_flat_before_opposite_side_parity_envelope_v0(
+        decision,
+        composition_status="SHORT_SELECTED",
+    )
+    assert_flat_before_opposite_side_non_authority_boundary_v0(envelope)
+    if not flat_before_opposite_side_blocks_opposite_entry_v0(decision):
+        raise ValueError("fixture must block opposite entry while position not flat")
+    if not flat_before_opposite_side_binding_non_authority_boundary_ok_v0(decision):
+        raise ValueError("flat-before-opposite-side binding violated non-authority boundary")
+    if decision.decision_outcome is DecisionOutcome.ENTER_SHORT:
+        raise ValueError("fixture must not allow direct opposite entry")
+    return decision
+
+
+def build_rewire_binding(repo_root: Path) -> dict[str, Any]:
+    _assert_owner_bound_paths_exist(repo_root)
+    _assert_canonical_owner_reuse()
+    decision = evaluate_flat_before_opposite_side_parity_fixtures_v0()
+    binding = RewireBinding(
+        surface_id=SURFACE_ID,
+        reused_canonical_owner=REUSED_CANONICAL_OWNER,
+        reused_adapter_owner=REUSED_ADAPTER_OWNER,
+        canonical_owner_path=CANONICAL_OWNER_PATH,
+        adapter_path=ADAPTER_PATH,
+        harness_path=HARNESS_PATH,
+        offline_replay_path=OFFLINE_REPLAY_PATH,
+        contract_test_path=CONTRACT_TEST_PATH,
+        blocked_opposite_entry=flat_before_opposite_side_blocks_opposite_entry_v0(decision),
+        decision_outcome=decision.decision_outcome.value,
+        position_flip_allowed=decision.position_flip_allowed,
+        rewire_state=REWIRE_STATE,
+        functional_rewire_performed=True,
+        new_parallel_owner_created=False,
+    )
+    return {
+        "schema": "FlatBeforeOppositeSideNarrowReuseFirstRewireV1",
+        "surface_id": SURFACE_ID,
+        "plan_type": PLAN_TYPE,
+        "trace_assertion_source_pr": TRACE_ASSERTION_SOURCE_PR,
+        "rewire_scope": "flat_before_opposite_side_only",
+        "rewire_binding": asdict(binding),
+        "forbidden_claims_remain_false": {
+            "FULL_CANONICAL_CHAIN_WIRED": False,
+            "BACKTEST_RUNTIME_DECISION_PARITY_PASS": False,
+            "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE": False,
+            "RUNTIME_REWIRE_ADMISSIBLE": False,
+            "RUNTIME_AUTHORITY": False,
+            "ORDERS_ALLOWED": False,
+            "ECONOMIC_CLAIM": False,
+        },
+        **NO_AUTHORITY_FLAGS,
+    }
+
+
+def render_markdown(rewire: dict[str, Any]) -> str:
+    binding = rewire["rewire_binding"]
+    lines = [
+        "# Flat Before Opposite Side Narrow Reuse-First Rewire V1",
+        "",
+        "```text",
+        "NARROW_REUSE_FIRST_REWIRE=true",
+        "FUNCTIONAL_REWIRE_PERFORMED=true",
+        "NEW_PARALLEL_OWNER_CREATED=false",
+        "NO_RUNTIME_AUTHORITY=true",
+        "NO_ORDERS=true",
+        "NO_ECONOMIC_CLAIM=true",
+        "FULL_CANONICAL_CHAIN_WIRED=false",
+        "BACKTEST_RUNTIME_DECISION_PARITY_PASS=false",
+        "```",
+        "",
+        f"- reused_canonical_owner: `{binding['reused_canonical_owner']}`",
+        f"- reused_adapter_owner: `{binding['reused_adapter_owner']}`",
+        f"- harness_path: `{binding['harness_path']}`",
+        f"- contract_test_path: `{binding['contract_test_path']}`",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_manifest(output_dir: Path) -> int:
+    rows: list[str] = []
+    for path in sorted(output_dir.rglob("*")):
+        if path.is_file() and path.name != "MANIFEST.sha256":
+            rows.append(f"{_sha256(path)}  {path.relative_to(output_dir).as_posix()}")
+    (output_dir / "MANIFEST.sha256").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    for row in rows:
+        digest, rel = row.split("  ", 1)
+        if _sha256(output_dir / rel) != digest:
+            return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    rewire = build_rewire_binding(repo_root)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "flat_before_opposite_side_narrow_reuse_first_rewire_v0.json").write_text(
+        json.dumps(rewire, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "flat_before_opposite_side_narrow_reuse_first_rewire_v0.md").write_text(
+        render_markdown(rewire) + "\n",
+        encoding="utf-8",
+    )
+    verdict = "PASS_FLAT_BEFORE_OPPOSITE_SIDE_NARROW_REUSE_FIRST_REWIRE_BOUND"
+    (output_dir / "verdict.txt").write_text(verdict + "\n", encoding="utf-8")
+    manifest_rc = write_manifest(output_dir)
+    (output_dir / "manifest_verify_rc.txt").write_text(f"{manifest_rc}\n", encoding="utf-8")
+    manifest_rc = write_manifest(output_dir)
+    print(verdict)
+    print(f"REUSED_CANONICAL_OWNER={REUSED_CANONICAL_OWNER}")
+    print(f"FUNCTIONAL_REWIRE_PERFORMED=true")
+    print(f"MANIFEST_VERIFY_RC={manifest_rc}")
+    print(f"EVIDENCE_DIR={output_dir}")
+    return 0 if manifest_rc == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
+++ b/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
@@ -136,6 +136,9 @@ from trading.master_v2.reversal_preparation_scenario_binding_adapter_v0 import (
 )
 from trading.master_v2.flat_before_opposite_side_scenario_binding_adapter_v0 import (
     FLAT_BEFORE_OPPOSITE_SIDE_SCENARIO_BINDING_ADAPTER_OWNER,
+    evaluate_scenario_flat_before_opposite_side_entry_exit_v0,
+    flat_before_opposite_side_binding_non_authority_boundary_ok_v0,
+    flat_before_opposite_side_blocks_opposite_entry_v0,
 )
 from trading.master_v2.double_play_entry_exit_scenario_binding_adapter_v0 import (
     CANONICAL_ENTRY_EXIT_POLICY_OWNER,
@@ -778,6 +781,67 @@ def evaluate_scenario_reversal_preparation_for_fixture_v0(
         side_state=SideState.LONG_ACTIVE,
         policy_context=default_scenario_entry_exit_policy_context_v0(),
     )
+
+
+def extract_flat_before_opposite_side_parity_envelope_v0(
+    decision: EntryExitPolicyDecisionV0,
+    *,
+    composition_status: str,
+) -> ParityDecisionEnvelopeV0:
+    return ParityDecisionEnvelopeV0(
+        decision_outcome=decision.decision_outcome.value,
+        previous_side_state=None,
+        next_side_state=None,
+        composition_status=composition_status,
+        composition_result_id="",
+        entry_or_exit_policy_ref=decision.policy_decision_id or "",
+        reason_codes=tuple(decision.reason_codes),
+        decision_precedence_trace=tuple(decision.decision_precedence_trace),
+        execution_eligible=False,
+        adapter_compatible=False,
+        quantity_status="NOT_BOUND",
+        authority_effect="NONE",
+        runtime_effect="NONE",
+    )
+
+
+def assert_flat_before_opposite_side_non_authority_boundary_v0(
+    envelope: ParityDecisionEnvelopeV0,
+) -> None:
+    assert not envelope.execution_eligible
+    assert not envelope.adapter_compatible
+    assert envelope.authority_effect == "NONE"
+    assert envelope.runtime_effect == "NONE"
+    assert envelope.entry_or_exit_policy_ref
+
+
+def evaluate_scenario_flat_before_opposite_side_for_fixture_v0(
+    *,
+    instrument_id: str = SYNTHETIC_FUTURES_INSTRUMENT,
+    trading_epoch: int = 54,
+    context_reference: str = "flat-before-opposite-narrow-rewire-v0",
+) -> EntryExitPolicyDecisionV0:
+    matrix = evaluate_scenario_matrix_for_side_state_v0(
+        side_state=SideState.SHORT_ARMED,
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+    )
+    if matrix.composition_status is not CompositionStatus.SHORT_SELECTED:
+        raise ValueError("fixture matrix must be SHORT_SELECTED for opposite-side block")
+    decision = evaluate_scenario_flat_before_opposite_side_entry_exit_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+        composition_result=matrix,
+        side_state=SideState.LONG_ACTIVE,
+        policy_context=default_scenario_entry_exit_policy_context_v0(),
+    )
+    if not flat_before_opposite_side_blocks_opposite_entry_v0(decision):
+        raise ValueError("fixture must block opposite entry while position not flat")
+    if not flat_before_opposite_side_binding_non_authority_boundary_ok_v0(decision):
+        raise ValueError("flat-before-opposite-side binding violated non-authority boundary")
+    return decision
 
 
 def integrated_assessments_match_scenario_side_state_v0(

--- a/tests/research/test_flat_before_opposite_side_narrow_reuse_first_rewire_v0.py
+++ b/tests/research/test_flat_before_opposite_side_narrow_reuse_first_rewire_v0.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.research.backtest_runtime_decision_parity_inventory_v0 import build_inventory
+from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import build_trace_matrix
+from scripts.research.flat_before_opposite_side_narrow_reuse_first_rewire_v0 import (
+    CONTRACT_TEST_PATH,
+    PLAN_TYPE,
+    REUSED_CANONICAL_OWNER,
+    SURFACE_ID,
+    build_rewire_binding,
+    evaluate_flat_before_opposite_side_parity_fixtures_v0,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import DecisionOutcome
+
+
+def _flat_surface(inventory: dict) -> dict:
+    return next(s for s in inventory["surfaces"] if s["surface_id"] == SURFACE_ID)
+
+
+def test_inventory_pins_flat_before_opposite_side_backtest_binding_to_parity_contract() -> None:
+    inventory = build_inventory(Path.cwd())
+    surface = _flat_surface(inventory)
+    pinned_paths = {hit["path"] for hit in surface["backtest_binding_candidates"][:2]}
+    assert CONTRACT_TEST_PATH in pinned_paths
+    assert surface["backtest_binding_candidates"][0]["matched_terms"] == ["rewire_binding_pin"]
+
+
+def test_rewire_binding_reuses_canonical_owners_without_parallel_owner() -> None:
+    rewire = build_rewire_binding(Path.cwd())
+    binding = rewire["rewire_binding"]
+
+    assert rewire["schema"] == "FlatBeforeOppositeSideNarrowReuseFirstRewireV1"
+    assert rewire["plan_type"] == PLAN_TYPE
+    assert rewire["trace_assertion_source_pr"] == 5008
+    assert binding["reused_canonical_owner"] == REUSED_CANONICAL_OWNER
+    assert binding["functional_rewire_performed"] is True
+    assert binding["new_parallel_owner_created"] is False
+    assert binding["rewire_state"] == "REWIRE_BOUND_OFFLINE_PARITY_PATH"
+
+
+def test_flat_before_opposite_side_parity_fixture_blocks_opposite_entry() -> None:
+    decision = evaluate_flat_before_opposite_side_parity_fixtures_v0()
+    assert decision.decision_outcome is not DecisionOutcome.ENTER_SHORT
+    assert decision.position_flip_allowed is False
+    assert decision.policy_decision_id
+
+
+def test_rewire_makes_no_forbidden_claims() -> None:
+    rewire = build_rewire_binding(Path.cwd())
+    assert rewire["runtime_authority"] is False
+    assert rewire["orders_allowed"] is False
+    assert rewire["economic_claim"] is False
+    assert rewire["full_canonical_chain_wired_claimed"] is False
+    assert rewire["backtest_runtime_decision_parity_pass_claimed"] is False
+    assert rewire["system_economic_evidence_admissible"] is False
+
+    forbidden = rewire["forbidden_claims_remain_false"]
+    assert all(value is False for value in forbidden.values())
+
+
+def test_trace_matrix_selects_flat_before_opposite_side_after_scope_rewire_bound() -> None:
+    inventory = build_inventory(Path.cwd())
+    matrix = build_trace_matrix(inventory)
+    assert matrix["selected_next_rewire_plan"]["selected_surface_id"] == SURFACE_ID
+    assert matrix["selected_next_rewire_plan"]["plan_type"] == PLAN_TYPE
+    scope_edge = matrix["trace_edges"][1]
+    assert scope_edge["surface_id"] == "scope_adverse_exit_and_reversal_preparation"
+    assert scope_edge["trace_state"] == "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"
+    flat_edge = matrix["trace_edges"][2]
+    assert flat_edge["surface_id"] == SURFACE_ID
+    assert flat_edge["backtest_candidate"] == CONTRACT_TEST_PATH

--- a/tests/research/test_scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py
+++ b/tests/research/test_scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py
@@ -71,11 +71,12 @@ def test_rewire_makes_no_forbidden_claims() -> None:
 def test_trace_matrix_selects_scope_after_bull_bear_rewire_bound() -> None:
     inventory = build_inventory(Path.cwd())
     matrix = build_trace_matrix(inventory)
-    assert matrix["selected_next_rewire_plan"]["selected_surface_id"] == SURFACE_ID
-    assert matrix["selected_next_rewire_plan"]["plan_type"] == PLAN_TYPE
+    assert matrix["selected_next_rewire_plan"]["selected_surface_id"] == "flat_before_opposite_side"
+    assert matrix["selected_next_rewire_plan"]["plan_type"] == "NARROW_REUSE_FIRST_REWIRE"
     bull_bear_edge = matrix["trace_edges"][0]
     assert bull_bear_edge["surface_id"] == "bull_bear_state_switch"
     assert bull_bear_edge["trace_state"] == "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"
     scope_edge = matrix["trace_edges"][1]
     assert scope_edge["surface_id"] == SURFACE_ID
+    assert scope_edge["trace_state"] == "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"
     assert scope_edge["backtest_candidate"] == SCOPE_CONTRACT_TEST_PATH


### PR DESCRIPTION
## Summary

- **surface=`flat_before_opposite_side`**
- Reuse-first owners: `trading.master_v2.double_play_entry_exit_policy_v0`, `trading.master_v2.flat_before_opposite_side_scenario_binding_adapter_v0`, `integrated_vs_scenario_replay_full_system_parity_harness_v0`
- Narrow harness fixture + trace/inventory pins wire flat-before-opposite-side into the backtest/runtime decision parity path after PR #5008 scope-adverse rewire completion
- No runtime, order, economic, or promotion authority created

## Tests run

- `pytest tests/research/test_flat_before_opposite_side_narrow_reuse_first_rewire_v0.py tests/research/test_scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py tests/research/test_bull_bear_state_switch_narrow_reuse_first_rewire_v0.py` — 15/15 passed (RC=0)
- `ruff check` on changed Python files — RC=0
- `ruff format --check` on changed Python files — RC=0
- `python -m py_compile` on changed Python files — RC=0

## Durable evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr5009_flat_before_opposite_side_parity_surface_reuse_first_narrow_rewire_v0_20260708T184523Z`

MANIFEST verify RC=0

## Explicit non-claims

- `FULL_CANONICAL_CHAIN_WIRED=false`
- `BACKTEST_RUNTIME_DECISION_PARITY_PASS=false`
- `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`
- `RUNTIME_REWIRE_ADMISSIBLE=false`


Made with [Cursor](https://cursor.com)