### PR TITLE
fix: wire capital risk sizing into parity path

### DIFF
--- a/scripts/research/backtest_runtime_decision_parity_inventory_v0.py
+++ b/scripts/research/backtest_runtime_decision_parity_inventory_v0.py
@@ -115,9 +115,17 @@ SURFACES = [
         "surface_id": "capital_risk_sizing",
         "required_status": "CAPITAL_RISK_SIZING_WIRED_TO_BACKTEST",
         "keywords": ("risk", "sizing", "quantity", "capital", "notional"),
-        "canonical_roots": ("src/risk", "src/trading", "src/core", "src/ops"),
+        "canonical_roots": ("src/governance", "src/risk", "src/trading", "src/core", "src/ops"),
         "backtest_roots": ("src/backtest", "scripts", "tests"),
         "runtime_roots": ("src/live", "src/execution", "src/runtime", "src/ops"),
+        "backtest_binding_pins": (
+            "tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py",
+            "tests/trading/master_v2/test_capital_risk_sizing_boundary_backtest_state_file_binding_contract_v0.py",
+            "tests/research/test_capital_risk_sizing_narrow_reuse_first_rewire_v0.py",
+            "src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py",
+            "src/trading/master_v2/capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0.py",
+        ),
+        "trace_rewire_bound": True,
     },
     {
         "surface_id": "canonical_order_intent_boundary",

--- a/scripts/research/backtest_runtime_decision_parity_trace_matrix_v0.py
+++ b/scripts/research/backtest_runtime_decision_parity_trace_matrix_v0.py
@@ -130,11 +130,7 @@ def build_trace_matrix(inventory: dict[str, Any]) -> dict[str, Any]:
     selected = next(
         edge for edge in edges if edge.trace_state == "TRACE_CANDIDATE_READY_NOT_ASSERTED"
     )
-    plan_type = (
-        "NARROW_REUSE_FIRST_REWIRE"
-        if selected.surface_id == "capital_risk_sizing"
-        else "NARROW_TRACE_ASSERTION_FIRST"
-    )
+    plan_type = "NARROW_TRACE_ASSERTION_FIRST"
     plan = RewirePlan(
         selected_surface_id=selected.surface_id,
         plan_type=plan_type,

--- a/scripts/research/capital_risk_sizing_narrow_reuse_first_rewire_v0.py
+++ b/scripts/research/capital_risk_sizing_narrow_reuse_first_rewire_v0.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import NO_AUTHORITY_FLAGS
+from trading.master_v2.capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0 import (
+    CAPITAL_RISK_SIZING_BOUNDARY_BACKTEST_STATE_FILE_BINDING_ADAPTER_OWNER,
+)
+from trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0 import (
+    CANONICAL_CAPITAL_RISK_SIZING_OWNER,
+    CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER,
+    RISK_SIZING_EFFECT_BOUND_OFFLINE,
+    build_scenario_tick_decision_evidence_v0,
+    capital_risk_sizing_binding_non_authority_boundary_ok_v0,
+    evaluate_scenario_capital_risk_sizing_v0,
+    system_economic_evidence_admissible_v0,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import DecisionOutcome
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    assert_capital_risk_sizing_non_authority_boundary_v0,
+    canonical_owner_refs_v0,
+    extract_capital_risk_sizing_parity_envelope_v0,
+)
+from trading.master_v2.offline_double_play_scenario_replay_v0 import SYNTHETIC_FUTURES_INSTRUMENT
+
+SURFACE_ID = "capital_risk_sizing"
+PLAN_TYPE = "NARROW_REUSE_FIRST_REWIRE"
+TRACE_ASSERTION_SOURCE_PR = 5011
+REWIRE_STATE = "REWIRE_BOUND_OFFLINE_PARITY_PATH"
+
+REUSED_CANONICAL_OWNER = CANONICAL_CAPITAL_RISK_SIZING_OWNER
+REUSED_OFFLINE_REPLAY_ADAPTER_OWNER = CAPITAL_RISK_SIZING_OFFLINE_REPLAY_BINDING_ADAPTER_OWNER
+REUSED_BOUNDARY_BACKTEST_ADAPTER_OWNER = (
+    CAPITAL_RISK_SIZING_BOUNDARY_BACKTEST_STATE_FILE_BINDING_ADAPTER_OWNER
+)
+CANONICAL_OWNER_PATH = "src/governance/capital_risk_sizing_v1.py"
+OFFLINE_REPLAY_ADAPTER_PATH = (
+    "src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py"
+)
+BOUNDARY_BACKTEST_ADAPTER_PATH = (
+    "src/trading/master_v2/capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0.py"
+)
+HARNESS_PATH = (
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py"
+)
+OFFLINE_REPLAY_PATH = "src/trading/master_v2/offline_double_play_scenario_replay_v0.py"
+OFFLINE_REPLAY_CONTRACT_TEST_PATH = "tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py"
+BOUNDARY_BACKTEST_CONTRACT_TEST_PATH = "tests/trading/master_v2/test_capital_risk_sizing_boundary_backtest_state_file_binding_contract_v0.py"
+CHAINED_CONTRACT_TEST_PATH = (
+    "tests/research/test_capital_risk_sizing_narrow_reuse_first_rewire_v0.py"
+)
+OWNER_BOUND_PATHS = (
+    CANONICAL_OWNER_PATH,
+    OFFLINE_REPLAY_ADAPTER_PATH,
+    BOUNDARY_BACKTEST_ADAPTER_PATH,
+    HARNESS_PATH,
+    OFFLINE_REPLAY_PATH,
+    OFFLINE_REPLAY_CONTRACT_TEST_PATH,
+    BOUNDARY_BACKTEST_CONTRACT_TEST_PATH,
+    CHAINED_CONTRACT_TEST_PATH,
+)
+
+
+@dataclass(frozen=True)
+class RewireBinding:
+    surface_id: str
+    reused_canonical_owner: str
+    reused_offline_replay_adapter_owner: str
+    reused_boundary_backtest_adapter_owner: str
+    canonical_owner_path: str
+    offline_replay_adapter_path: str
+    boundary_backtest_adapter_path: str
+    harness_path: str
+    offline_replay_path: str
+    offline_replay_contract_test_path: str
+    boundary_backtest_contract_test_path: str
+    chained_contract_test_path: str
+    entry_exit_policy_chain_preserved: bool
+    sizing_bound_for_actionable_enter: bool
+    risk_sizing_effect: str
+    quantity_provenance_ref_present: bool
+    rewire_state: str
+    functional_rewire_performed: bool
+    new_parallel_owner_created: bool
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _assert_owner_bound_paths_exist(repo_root: Path) -> None:
+    for rel in OWNER_BOUND_PATHS:
+        if not (repo_root / rel).is_file():
+            raise ValueError(f"owner-bound path missing: {rel}")
+
+
+def _assert_canonical_owner_reuse() -> None:
+    refs = canonical_owner_refs_v0()
+    if refs["capital_risk_sizing"] != REUSED_CANONICAL_OWNER:
+        raise ValueError("capital risk sizing owner drift")
+    if (
+        refs["capital_risk_sizing_offline_replay_binding_adapter"]
+        != REUSED_OFFLINE_REPLAY_ADAPTER_OWNER
+    ):
+        raise ValueError("capital risk sizing offline replay adapter owner drift")
+
+
+def evaluate_capital_risk_sizing_parity_fixtures_v0(
+    *,
+    instrument_id: str = SYNTHETIC_FUTURES_INSTRUMENT,
+    trading_epoch: int = 48,
+    context_reference: str = "capital-risk-sizing-narrow-rewire-v0",
+) -> Any:
+    evidence = build_scenario_tick_decision_evidence_v0(
+        decision_id=f"{context_reference}-decision",
+        replay_id=f"{context_reference}-replay",
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        composition_result_id=f"{context_reference}-composition",
+        entry_exit_policy_ref=f"{context_reference}-policy",
+        selected_side="long",
+        decision_outcome=DecisionOutcome.ENTER_LONG.value,
+        reason_codes=("PASS",),
+        decision_precedence_trace=("enter_long",),
+        config_digest="config",
+        implementation_digest="impl",
+    )
+    binding = evaluate_scenario_capital_risk_sizing_v0(
+        evidence,
+        reference_price=Decimal("3500"),
+    )
+    envelope = extract_capital_risk_sizing_parity_envelope_v0(
+        binding,
+        decision_outcome=DecisionOutcome.ENTER_LONG.value,
+        composition_result_id=f"{context_reference}-composition",
+    )
+    assert_capital_risk_sizing_non_authority_boundary_v0(envelope)
+    if not capital_risk_sizing_binding_non_authority_boundary_ok_v0(binding):
+        raise ValueError("capital risk sizing binding violated non-authority boundary")
+    if not binding.binding_applied:
+        raise ValueError("fixture must bind sizing for actionable enter")
+    if binding.risk_sizing_effect != RISK_SIZING_EFFECT_BOUND_OFFLINE:
+        raise ValueError("fixture must remain offline-bound only")
+    if system_economic_evidence_admissible_v0(binding):
+        raise ValueError("system economic evidence must remain inadmissible")
+    return binding
+
+
+def build_rewire_binding(repo_root: Path) -> dict[str, Any]:
+    _assert_owner_bound_paths_exist(repo_root)
+    _assert_canonical_owner_reuse()
+    binding_result = evaluate_capital_risk_sizing_parity_fixtures_v0()
+    binding = RewireBinding(
+        surface_id=SURFACE_ID,
+        reused_canonical_owner=REUSED_CANONICAL_OWNER,
+        reused_offline_replay_adapter_owner=REUSED_OFFLINE_REPLAY_ADAPTER_OWNER,
+        reused_boundary_backtest_adapter_owner=REUSED_BOUNDARY_BACKTEST_ADAPTER_OWNER,
+        canonical_owner_path=CANONICAL_OWNER_PATH,
+        offline_replay_adapter_path=OFFLINE_REPLAY_ADAPTER_PATH,
+        boundary_backtest_adapter_path=BOUNDARY_BACKTEST_ADAPTER_PATH,
+        harness_path=HARNESS_PATH,
+        offline_replay_path=OFFLINE_REPLAY_PATH,
+        offline_replay_contract_test_path=OFFLINE_REPLAY_CONTRACT_TEST_PATH,
+        boundary_backtest_contract_test_path=BOUNDARY_BACKTEST_CONTRACT_TEST_PATH,
+        chained_contract_test_path=CHAINED_CONTRACT_TEST_PATH,
+        entry_exit_policy_chain_preserved=True,
+        sizing_bound_for_actionable_enter=True,
+        risk_sizing_effect=binding_result.risk_sizing_effect,
+        quantity_provenance_ref_present=bool(binding_result.quantity_provenance_ref),
+        rewire_state=REWIRE_STATE,
+        functional_rewire_performed=True,
+        new_parallel_owner_created=False,
+    )
+    return {
+        "schema": "CapitalRiskSizingNarrowReuseFirstRewireV1",
+        "surface_id": SURFACE_ID,
+        "plan_type": PLAN_TYPE,
+        "trace_assertion_source_pr": TRACE_ASSERTION_SOURCE_PR,
+        "rewire_scope": "capital_risk_sizing_only",
+        "rewire_binding": asdict(binding),
+        "forbidden_claims_remain_false": {
+            "FULL_CANONICAL_CHAIN_WIRED": False,
+            "BACKTEST_RUNTIME_DECISION_PARITY_PASS": False,
+            "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE": False,
+            "RUNTIME_REWIRE_ADMISSIBLE": False,
+            "RUNTIME_AUTHORITY": False,
+            "ORDERS_ALLOWED": False,
+            "ECONOMIC_CLAIM": False,
+        },
+        **NO_AUTHORITY_FLAGS,
+    }
+
+
+def render_markdown(rewire: dict[str, Any]) -> str:
+    binding = rewire["rewire_binding"]
+    lines = [
+        "# Capital Risk Sizing Narrow Reuse-First Rewire V1",
+        "",
+        "```text",
+        "NARROW_REUSE_FIRST_REWIRE=true",
+        "FUNCTIONAL_REWIRE_PERFORMED=true",
+        "NEW_PARALLEL_OWNER_CREATED=false",
+        "NO_RUNTIME_AUTHORITY=true",
+        "NO_ORDERS=true",
+        "NO_ECONOMIC_CLAIM=true",
+        "FULL_CANONICAL_CHAIN_WIRED=false",
+        "BACKTEST_RUNTIME_DECISION_PARITY_PASS=false",
+        "RUNTIME_REWIRE_ADMISSIBLE=false",
+        "```",
+        "",
+        f"- reused_canonical_owner: `{binding['reused_canonical_owner']}`",
+        f"- reused_offline_replay_adapter_owner: `{binding['reused_offline_replay_adapter_owner']}`",
+        f"- reused_boundary_backtest_adapter_owner: `{binding['reused_boundary_backtest_adapter_owner']}`",
+        f"- harness_path: `{binding['harness_path']}`",
+        f"- chained_contract_test_path: `{binding['chained_contract_test_path']}`",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_manifest(output_dir: Path) -> int:
+    rows: list[str] = []
+    for path in sorted(output_dir.rglob("*")):
+        if path.is_file() and path.name != "MANIFEST.sha256":
+            rows.append(f"{_sha256(path)}  {path.relative_to(output_dir).as_posix()}")
+    (output_dir / "MANIFEST.sha256").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    for row in rows:
+        digest, rel = row.split("  ", 1)
+        if _sha256(output_dir / rel) != digest:
+            return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    rewire = build_rewire_binding(repo_root)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "capital_risk_sizing_narrow_reuse_first_rewire_v0.json").write_text(
+        json.dumps(rewire, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "capital_risk_sizing_narrow_reuse_first_rewire_v0.md").write_text(
+        render_markdown(rewire) + "\n",
+        encoding="utf-8",
+    )
+    verdict = "PASS_CAPITAL_RISK_SIZING_NARROW_REUSE_FIRST_REWIRE_BOUND"
+    (output_dir / "verdict.txt").write_text(verdict + "\n", encoding="utf-8")
+    manifest_rc = write_manifest(output_dir)
+    (output_dir / "manifest_verify_rc.txt").write_text(f"{manifest_rc}\n", encoding="utf-8")
+    manifest_rc = write_manifest(output_dir)
+    print(verdict)
+    print(f"REUSED_CANONICAL_OWNER={REUSED_CANONICAL_OWNER}")
+    print("FUNCTIONAL_REWIRE_PERFORMED=true")
+    print(f"MANIFEST_VERIFY_RC={manifest_rc}")
+    print(f"EVIDENCE_DIR={output_dir}")
+    return 0 if manifest_rc == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/research/test_capital_risk_sizing_narrow_reuse_first_rewire_v0.py
+++ b/tests/research/test_capital_risk_sizing_narrow_reuse_first_rewire_v0.py
@@ -4,27 +4,27 @@ from pathlib import Path
 
 from scripts.research.backtest_runtime_decision_parity_inventory_v0 import build_inventory
 from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import build_trace_matrix
-from scripts.research.entry_position_exit_policy_narrow_reuse_first_rewire_v0 import (
+from scripts.research.capital_risk_sizing_narrow_reuse_first_rewire_v0 import (
+    BOUNDARY_BACKTEST_CONTRACT_TEST_PATH,
     CHAINED_CONTRACT_TEST_PATH,
-    ENTRY_EXIT_CONTRACT_TEST_PATH,
-    FLAT_BEFORE_CONTRACT_TEST_PATH,
+    OFFLINE_REPLAY_CONTRACT_TEST_PATH,
     PLAN_TYPE,
     REUSED_CANONICAL_OWNER,
     SURFACE_ID,
     build_rewire_binding,
-    evaluate_entry_position_exit_policy_parity_fixtures_v0,
+    evaluate_capital_risk_sizing_parity_fixtures_v0,
 )
-from trading.master_v2.double_play_entry_exit_policy_v0 import DecisionOutcome
+from trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0 import (
+    RISK_SIZING_EFFECT_BOUND_OFFLINE,
+)
 
 
-def test_inventory_pins_chained_entry_position_exit_backtest_binding_to_parity_contracts() -> None:
+def test_inventory_pins_chained_capital_risk_sizing_backtest_binding_to_parity_contracts() -> None:
     inventory = build_inventory(Path.cwd())
-    surface = next(
-        s for s in inventory["surfaces"] if s["surface_id"] == "entry_position_exit_policy"
-    )
+    surface = next(s for s in inventory["surfaces"] if s["surface_id"] == SURFACE_ID)
     pinned_paths = {hit["path"] for hit in surface["backtest_binding_candidates"][:3]}
-    assert ENTRY_EXIT_CONTRACT_TEST_PATH in pinned_paths
-    assert FLAT_BEFORE_CONTRACT_TEST_PATH in pinned_paths
+    assert OFFLINE_REPLAY_CONTRACT_TEST_PATH in pinned_paths
+    assert BOUNDARY_BACKTEST_CONTRACT_TEST_PATH in pinned_paths
     assert CHAINED_CONTRACT_TEST_PATH in pinned_paths
     assert surface["backtest_binding_candidates"][0]["matched_terms"] == ["rewire_binding_pin"]
 
@@ -33,27 +33,23 @@ def test_rewire_binding_reuses_canonical_owners_without_parallel_owner() -> None
     rewire = build_rewire_binding(Path.cwd())
     binding = rewire["rewire_binding"]
 
-    assert rewire["schema"] == "EntryPositionExitPolicyNarrowReuseFirstRewireV1"
+    assert rewire["schema"] == "CapitalRiskSizingNarrowReuseFirstRewireV1"
     assert rewire["surface_id"] == SURFACE_ID
     assert rewire["plan_type"] == PLAN_TYPE
-    assert rewire["trace_assertion_source_pr"] == 5010
+    assert rewire["trace_assertion_source_pr"] == 5011
     assert binding["reused_canonical_owner"] == REUSED_CANONICAL_OWNER
     assert binding["functional_rewire_performed"] is True
     assert binding["new_parallel_owner_created"] is False
-    assert binding["flat_before_context_merged_into_entry_exit_policy"] is True
-    assert binding["adverse_scope_signal_wired_into_entry_exit_policy"] is True
+    assert binding["entry_exit_policy_chain_preserved"] is True
     assert binding["rewire_state"] == "REWIRE_BOUND_OFFLINE_PARITY_PATH"
 
 
-def test_chained_entry_position_exit_parity_fixture_blocks_opposite_entry() -> None:
-    decision = evaluate_entry_position_exit_policy_parity_fixtures_v0()
-    assert decision.decision_outcome not in (
-        DecisionOutcome.ENTER_LONG,
-        DecisionOutcome.ENTER_SHORT,
-    )
-    assert decision.position_flip_allowed is False
-    assert decision.policy_decision_id
-    assert decision.decision_precedence_trace
+def test_chained_capital_risk_sizing_parity_fixture_binds_offline_only() -> None:
+    binding = evaluate_capital_risk_sizing_parity_fixtures_v0()
+    assert binding.binding_applied is True
+    assert binding.risk_sizing_effect == RISK_SIZING_EFFECT_BOUND_OFFLINE
+    assert binding.quantity_provenance_ref
+    assert binding.risk_sizing_ref
 
 
 def test_rewire_makes_no_forbidden_claims() -> None:
@@ -69,12 +65,17 @@ def test_rewire_makes_no_forbidden_claims() -> None:
     assert all(value is False for value in forbidden.values())
 
 
-def test_trace_matrix_keeps_entry_position_exit_rewire_bound_in_chain() -> None:
+def test_trace_matrix_selects_safety_kernel_after_capital_risk_sizing_rewire_bound() -> None:
     inventory = build_inventory(Path.cwd())
     matrix = build_trace_matrix(inventory)
-    entry_edge = matrix["trace_edges"][3]
-    assert entry_edge["surface_id"] == SURFACE_ID
+    assert (
+        matrix["selected_next_rewire_plan"]["selected_surface_id"]
+        == "safety_kernel_and_killswitch_boundary"
+    )
+    assert matrix["selected_next_rewire_plan"]["plan_type"] == "NARROW_TRACE_ASSERTION_FIRST"
+    sizing_edge = next(edge for edge in matrix["trace_edges"] if edge["surface_id"] == SURFACE_ID)
+    assert sizing_edge["trace_state"] == "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"
+    entry_edge = next(
+        edge for edge in matrix["trace_edges"] if edge["surface_id"] == "entry_position_exit_policy"
+    )
     assert entry_edge["trace_state"] == "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"
-    flat_edge = matrix["trace_edges"][2]
-    assert flat_edge["surface_id"] == "flat_before_opposite_side"
-    assert flat_edge["trace_state"] == "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"


### PR DESCRIPTION
## Summary

- **Selected surface:** `capital_risk_sizing`
- **Rewire status:** `REWIRE_BOUND_OFFLINE_PARITY_PATH`
- **Reuse-first owner path(s):**
  - `src/governance/capital_risk_sizing_v1.py` (canonical sizing owner)
  - `src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py`
  - `src/trading/master_v2/capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0.py`
  - `src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py`
- Binds `capital_risk_sizing` into the existing offline/backtest parity trace matrix after PR #5011 (`entry_position_exit_policy`), with narrow contract tests proving trace representation, canonical owner reuse, and offline-only path.
- **No runtime authority**, **no order/adapter submission**, **no economic evidence admissibility**, **no full canonical chain claim**, **no backtest/runtime parity pass claim**.
- **Next trace node** after this (`safety_kernel_and_killswitch_boundary`) remains unresolved and must be separately assessed.

## Forbidden claims (explicitly remain false)

- `FULL_CANONICAL_CHAIN_WIRED=false`
- `BACKTEST_RUNTIME_DECISION_PARITY_PASS=false`
- `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`
- `RUNTIME_REWIRE_ADMISSIBLE=false`

## Test plan

- [x] `tests/research/test_capital_risk_sizing_narrow_reuse_first_rewire_v0.py`
- [x] `tests/research/test_entry_position_exit_policy_narrow_reuse_first_rewire_v0.py`
- [x] `tests/research/test_backtest_runtime_decision_parity_trace_matrix_v0.py`
- [x] `tests/research/test_backtest_runtime_decision_parity_inventory_v0.py`
- [x] `ruff check` / `ruff format --check` / `py_compile`


Made with [Cursor](https://cursor.com)