### PR TITLE
fix: wire survival and suitability into backtest parity path

### DIFF
--- a/scripts/research/backtest_runtime_decision_parity_inventory_v0.py
+++ b/scripts/research/backtest_runtime_decision_parity_inventory_v0.py
@@ -86,6 +86,15 @@ SURFACES = [
         "canonical_roots": ("src/trading", "src/strategies", "src/experiments", "src/core"),
         "backtest_roots": ("src/backtest", "scripts", "tests"),
         "runtime_roots": ("src/live", "src/execution", "src/runtime", "src/ops"),
+        "backtest_binding_pins": (
+            "tests/trading/master_v2/test_survival_suitability_scenario_replay_binding_parity_rewire_contract_v0.py",
+            "tests/research/test_survival_suitability_narrow_reuse_first_rewire_v0.py",
+            "src/trading/master_v2/survival_suitability_scenario_binding_adapter_v0.py",
+            "src/trading/master_v2/survival_assessment_v1.py",
+            "src/trading/master_v2/suitability_binding_v1.py",
+            "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+        ),
+        "trace_rewire_bound": True,
     },
     {
         "surface_id": "double_play_composition",

--- a/scripts/research/survival_suitability_narrow_reuse_first_rewire_v0.py
+++ b/scripts/research/survival_suitability_narrow_reuse_first_rewire_v0.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import NO_AUTHORITY_FLAGS
+from trading.master_v2.directional_assessment_v1 import DirectionalAssessmentSide
+from trading.master_v2.double_play_composition import (
+    DoublePlayCompositionInput,
+    DoublePlayCompositionStatus,
+    RequestedSide,
+)
+from trading.master_v2.double_play_state import SideState, TransitionDecision
+from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+    assert_survival_suitability_non_authority_boundary_v0,
+    canonical_owner_refs_v0,
+    extract_survival_suitability_parity_envelope_v0,
+)
+from trading.master_v2.double_play_suitability import project_strategy_suitability
+from trading.master_v2.double_play_survival import evaluate_survival_envelope
+from trading.master_v2.offline_double_play_scenario_replay_v0 import (
+    SYNTHETIC_FUTURES_INSTRUMENT,
+    _survival_envelope,
+    _suitability_input,
+)
+from trading.master_v2.survival_assessment_v1 import (
+    SurvivalAssessmentStatus,
+    SurvivalHardFailReason,
+    SurvivalMetricInputsV1,
+)
+from trading.master_v2.survival_suitability_scenario_binding_adapter_v0 import (
+    CANONICAL_SUITABILITY_BINDING_OWNER,
+    CANONICAL_SURVIVAL_ASSESSMENT_OWNER,
+    SURVIVAL_SUITABILITY_SCENARIO_BINDING_ADAPTER_OWNER,
+    ScenarioSurvivalSuitabilityEvaluationV0,
+    ScenarioSurvivalSuitabilityOverridesV0,
+    apply_canonical_survival_suitability_pre_matrix_gates_v0,
+    canonical_survival_blocks_entry_v0,
+    evaluate_scenario_survival_suitability_v0,
+)
+from trading.master_v2.suitability_binding_v1 import (
+    SuitabilityBindingStatus,
+    SuitabilityRegimeStatus,
+    SuitabilityStrategyEntryV1,
+    SuitabilityStrategyRegistryV1,
+)
+
+SURFACE_ID = "survival_and_suitability"
+PLAN_TYPE = "NARROW_REUSE_FIRST_REWIRE"
+TRACE_ASSERTION_SOURCE_PR = 5017
+REWIRE_STATE = "REWIRE_BOUND_OFFLINE_PARITY_PATH"
+
+REUSED_SURVIVAL_ASSESSMENT_OWNER = CANONICAL_SURVIVAL_ASSESSMENT_OWNER
+REUSED_SUITABILITY_BINDING_OWNER = CANONICAL_SUITABILITY_BINDING_OWNER
+REUSED_SCENARIO_BINDING_ADAPTER_OWNER = SURVIVAL_SUITABILITY_SCENARIO_BINDING_ADAPTER_OWNER
+CANONICAL_SURVIVAL_OWNER_PATH = "src/trading/master_v2/survival_assessment_v1.py"
+CANONICAL_SUITABILITY_OWNER_PATH = "src/trading/master_v2/suitability_binding_v1.py"
+LEGACY_SURVIVAL_ENVELOPE_PATH = "src/trading/master_v2/double_play_survival.py"
+LEGACY_SUITABILITY_PROJECTION_PATH = "src/trading/master_v2/double_play_suitability.py"
+SCENARIO_BINDING_ADAPTER_PATH = (
+    "src/trading/master_v2/survival_suitability_scenario_binding_adapter_v0.py"
+)
+OFFLINE_REPLAY_PATH = "src/trading/master_v2/offline_double_play_scenario_replay_v0.py"
+HARNESS_PATH = (
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py"
+)
+SCENARIO_REPLAY_CONTRACT_TEST_PATH = "tests/trading/master_v2/test_survival_suitability_scenario_replay_binding_parity_rewire_contract_v0.py"
+CHAINED_CONTRACT_TEST_PATH = (
+    "tests/research/test_survival_suitability_narrow_reuse_first_rewire_v0.py"
+)
+OWNER_BOUND_PATHS = (
+    CANONICAL_SURVIVAL_OWNER_PATH,
+    CANONICAL_SUITABILITY_OWNER_PATH,
+    SCENARIO_BINDING_ADAPTER_PATH,
+    OFFLINE_REPLAY_PATH,
+    HARNESS_PATH,
+    SCENARIO_REPLAY_CONTRACT_TEST_PATH,
+    CHAINED_CONTRACT_TEST_PATH,
+)
+
+
+@dataclass(frozen=True)
+class RewireBinding:
+    surface_id: str
+    reused_survival_assessment_owner: str
+    reused_suitability_binding_owner: str
+    reused_scenario_binding_adapter_owner: str
+    canonical_survival_owner_path: str
+    canonical_suitability_owner_path: str
+    legacy_survival_envelope_path: str
+    legacy_suitability_projection_path: str
+    scenario_binding_adapter_path: str
+    offline_replay_path: str
+    harness_path: str
+    scenario_replay_contract_test_path: str
+    chained_contract_test_path: str
+    double_play_composition_chain_preserved: bool
+    survival_hard_fail_blocks_composition: bool
+    survival_required_unknown_fail_closed: bool
+    suitability_deterministic_strategy_selection: bool
+    no_list_order_strategy_override: bool
+    no_confidence_only_selection: bool
+    cost_model_boundary_bound: bool
+    regime_owner_boundary_bound: bool
+    survival_suitability_offline_only: bool
+    rewire_state: str
+    functional_rewire_performed: bool
+    new_parallel_owner_created: bool
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _assert_owner_bound_paths_exist(repo_root: Path) -> None:
+    for rel in OWNER_BOUND_PATHS:
+        if not (repo_root / rel).is_file():
+            raise ValueError(f"owner-bound path missing: {rel}")
+
+
+def _assert_canonical_owner_reuse() -> None:
+    refs = canonical_owner_refs_v0()
+    if refs["survival_assessment"] != REUSED_SURVIVAL_ASSESSMENT_OWNER:
+        raise ValueError("survival assessment owner drift")
+    if refs["suitability_binding"] != REUSED_SUITABILITY_BINDING_OWNER:
+        raise ValueError("suitability binding owner drift")
+    if refs["survival_suitability_scenario_binding_adapter"] != (
+        REUSED_SCENARIO_BINDING_ADAPTER_OWNER
+    ):
+        raise ValueError("survival suitability scenario binding adapter owner drift")
+
+
+def _composition_input(*, requested: RequestedSide) -> DoublePlayCompositionInput:
+    return DoublePlayCompositionInput(
+        transition=TransitionDecision(
+            allowed=True,
+            reason_code="TEST",
+            live_authorization_granted=False,
+        ),
+        resulting_side_state=SideState.LONG_ACTIVE,
+        survival=evaluate_survival_envelope(_survival_envelope()),
+        suitability=project_strategy_suitability(_suitability_input()),
+        requested_side=requested,
+    )
+
+
+def _assert_survival_hard_fail_blocks(evaluation: ScenarioSurvivalSuitabilityEvaluationV0) -> None:
+    if not canonical_survival_blocks_entry_v0(evaluation.bull_survival):
+        raise ValueError("survival hard fail must block entry")
+    decision = apply_canonical_survival_suitability_pre_matrix_gates_v0(
+        _composition_input(requested=RequestedSide.LONG_BULL),
+        evaluation,
+    )
+    if decision is None or decision.status is not DoublePlayCompositionStatus.BLOCKED:
+        raise ValueError("survival hard fail must block composition")
+
+
+def _assert_survival_required_unknown_blocks(
+    evaluation: ScenarioSurvivalSuitabilityEvaluationV0,
+) -> None:
+    if evaluation.bull_survival.status is not SurvivalAssessmentStatus.BLOCKED:
+        raise ValueError("required unknown survival inputs must yield BLOCKED")
+    decision = apply_canonical_survival_suitability_pre_matrix_gates_v0(
+        _composition_input(requested=RequestedSide.LONG_BULL),
+        evaluation,
+    )
+    if decision is None or decision.status is not DoublePlayCompositionStatus.BLOCKED:
+        raise ValueError("survival required unknown must block composition fail-closed")
+
+
+def _strategy_entry(
+    *,
+    strategy_id: str,
+    priority_rank: int,
+    confidence_score: float,
+) -> SuitabilityStrategyEntryV1:
+    return SuitabilityStrategyEntryV1(
+        strategy_id=strategy_id,
+        supported_regime_ids=("trending",),
+        supported_sides=(DirectionalAssessmentSide.LONG,),
+        priority_rank=priority_rank,
+        disabled=False,
+        confidence_score=confidence_score,
+    )
+
+
+def _assert_deterministic_strategy_selection(
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+) -> None:
+    registry_ab = SuitabilityStrategyRegistryV1(
+        entries=(
+            _strategy_entry(strategy_id="strat-a", priority_rank=10, confidence_score=0.99),
+            _strategy_entry(strategy_id="strat-b", priority_rank=10, confidence_score=0.01),
+        )
+    )
+    registry_ba = SuitabilityStrategyRegistryV1(
+        entries=(
+            _strategy_entry(strategy_id="strat-b", priority_rank=10, confidence_score=0.99),
+            _strategy_entry(strategy_id="strat-a", priority_rank=10, confidence_score=0.01),
+        )
+    )
+    eval_ab = evaluate_scenario_survival_suitability_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        side_st=SideState.LONG_ACTIVE,
+        overrides=ScenarioSurvivalSuitabilityOverridesV0(strategy_registry=registry_ab),
+    )
+    eval_ba = evaluate_scenario_survival_suitability_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        side_st=SideState.LONG_ACTIVE,
+        overrides=ScenarioSurvivalSuitabilityOverridesV0(strategy_registry=registry_ba),
+    )
+    if eval_ab.bull_suitability.selected_strategy_id != "strat-a":
+        raise ValueError("deterministic selection must prefer priority_rank then strategy_id")
+    if eval_ba.bull_suitability.selected_strategy_id != "strat-a":
+        raise ValueError("list order must not override deterministic strategy selection")
+    if (
+        eval_ab.bull_suitability.selected_strategy_id
+        != eval_ba.bull_suitability.selected_strategy_id
+    ):
+        raise ValueError("registry list order must not change selected strategy")
+
+
+def _assert_regime_unknown_blocks(
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+) -> None:
+    evaluation = evaluate_scenario_survival_suitability_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        side_st=SideState.LONG_ACTIVE,
+        overrides=ScenarioSurvivalSuitabilityOverridesV0(
+            regime_status=SuitabilityRegimeStatus.UNKNOWN,
+        ),
+    )
+    if evaluation.bull_suitability.status is not SuitabilityBindingStatus.BLOCKED:
+        raise ValueError("unknown regime must block suitability fail-closed")
+    decision = apply_canonical_survival_suitability_pre_matrix_gates_v0(
+        _composition_input(requested=RequestedSide.LONG_BULL),
+        evaluation,
+    )
+    if decision is None or decision.status is not DoublePlayCompositionStatus.BLOCKED:
+        raise ValueError("unknown regime must block composition")
+
+
+def _assert_cost_model_boundary_bound(evaluation: ScenarioSurvivalSuitabilityEvaluationV0) -> None:
+    if evaluation.bull_survival.cost_survival_result is None:
+        raise ValueError("cost model boundary must be represented in survival assessment")
+    if evaluation.bull_survival.expected_roundtrip_cost is None:
+        raise ValueError("cost model boundary must expose roundtrip cost evidence")
+
+
+def evaluate_survival_suitability_parity_fixtures_v0(
+    *,
+    instrument_id: str = SYNTHETIC_FUTURES_INSTRUMENT,
+    trading_epoch: int = 61,
+    context_reference: str = "survival-suitability-narrow-rewire-v0",
+) -> ScenarioSurvivalSuitabilityEvaluationV0:
+    del context_reference
+    hard_fail_overrides = ScenarioSurvivalSuitabilityOverridesV0(
+        bull_survival_status=SurvivalAssessmentStatus.FAIL,
+        bull_explicit_hard_fail_reasons=(SurvivalHardFailReason.EXPLICIT_HARD_FAIL,),
+    )
+    hard_fail_eval = evaluate_scenario_survival_suitability_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        side_st=SideState.LONG_ACTIVE,
+        overrides=hard_fail_overrides,
+    )
+    _assert_survival_hard_fail_blocks(hard_fail_eval)
+
+    unknown_metrics = SurvivalMetricInputsV1(
+        data_completeness_complete=None,
+        volatility_survival_ratio=0.8,
+        sequence_survival_ratio=0.8,
+        drawdown_survival_ratio=0.8,
+        liquidation_buffer_ratio=0.2,
+    )
+    unknown_eval = evaluate_scenario_survival_suitability_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        side_st=SideState.LONG_ACTIVE,
+        overrides=ScenarioSurvivalSuitabilityOverridesV0(
+            bull_metric_inputs=unknown_metrics,
+            bear_metric_inputs=unknown_metrics,
+        ),
+    )
+    _assert_survival_required_unknown_blocks(unknown_eval)
+
+    _assert_deterministic_strategy_selection(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+    )
+    _assert_regime_unknown_blocks(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+    )
+
+    baseline = evaluate_scenario_survival_suitability_v0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        side_st=SideState.LONG_ACTIVE,
+    )
+    _assert_cost_model_boundary_bound(baseline)
+
+    envelope = extract_survival_suitability_parity_envelope_v0(baseline)
+    assert_survival_suitability_non_authority_boundary_v0(envelope, evaluation=baseline)
+    return baseline
+
+
+def build_rewire_binding(repo_root: Path) -> dict[str, Any]:
+    _assert_owner_bound_paths_exist(repo_root)
+    _assert_canonical_owner_reuse()
+    result = evaluate_survival_suitability_parity_fixtures_v0()
+    binding = RewireBinding(
+        surface_id=SURFACE_ID,
+        reused_survival_assessment_owner=REUSED_SURVIVAL_ASSESSMENT_OWNER,
+        reused_suitability_binding_owner=REUSED_SUITABILITY_BINDING_OWNER,
+        reused_scenario_binding_adapter_owner=REUSED_SCENARIO_BINDING_ADAPTER_OWNER,
+        canonical_survival_owner_path=CANONICAL_SURVIVAL_OWNER_PATH,
+        canonical_suitability_owner_path=CANONICAL_SUITABILITY_OWNER_PATH,
+        legacy_survival_envelope_path=LEGACY_SURVIVAL_ENVELOPE_PATH,
+        legacy_suitability_projection_path=LEGACY_SUITABILITY_PROJECTION_PATH,
+        scenario_binding_adapter_path=SCENARIO_BINDING_ADAPTER_PATH,
+        offline_replay_path=OFFLINE_REPLAY_PATH,
+        harness_path=HARNESS_PATH,
+        scenario_replay_contract_test_path=SCENARIO_REPLAY_CONTRACT_TEST_PATH,
+        chained_contract_test_path=CHAINED_CONTRACT_TEST_PATH,
+        double_play_composition_chain_preserved=True,
+        survival_hard_fail_blocks_composition=True,
+        survival_required_unknown_fail_closed=True,
+        suitability_deterministic_strategy_selection=True,
+        no_list_order_strategy_override=True,
+        no_confidence_only_selection=True,
+        cost_model_boundary_bound=True,
+        regime_owner_boundary_bound=True,
+        survival_suitability_offline_only=True,
+        rewire_state=REWIRE_STATE,
+        functional_rewire_performed=True,
+        new_parallel_owner_created=False,
+    )
+    return {
+        "schema": "SurvivalSuitabilityNarrowReuseFirstRewireV1",
+        "surface_id": SURFACE_ID,
+        "plan_type": PLAN_TYPE,
+        "trace_assertion_source_pr": TRACE_ASSERTION_SOURCE_PR,
+        "rewire_scope": "survival_and_suitability_only",
+        "rewire_binding": asdict(binding),
+        "bull_survival_status": result.bull_survival.status.value,
+        "bull_suitability_status": result.bull_suitability.status.value,
+        "selected_strategy_id": result.bull_suitability.selected_strategy_id,
+        "forbidden_claims_remain_false": {
+            "FULL_CANONICAL_CHAIN_WIRED": False,
+            "BACKTEST_RUNTIME_DECISION_PARITY_PASS": False,
+            "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE": False,
+            "RUNTIME_REWIRE_ADMISSIBLE": False,
+            "RUNTIME_AUTHORITY": False,
+            "ORDERS_ALLOWED": False,
+            "ECONOMIC_CLAIM": False,
+        },
+        **NO_AUTHORITY_FLAGS,
+    }
+
+
+def render_markdown(rewire: dict[str, Any]) -> str:
+    binding = rewire["rewire_binding"]
+    lines = [
+        "# Survival and Suitability Narrow Reuse-First Rewire V1",
+        "",
+        "```text",
+        "NARROW_REUSE_FIRST_REWIRE=true",
+        "FUNCTIONAL_REWIRE_PERFORMED=true",
+        "NEW_PARALLEL_OWNER_CREATED=false",
+        "NO_RUNTIME_AUTHORITY=true",
+        "NO_ORDERS=true",
+        "NO_ECONOMIC_CLAIM=true",
+        "FULL_CANONICAL_CHAIN_WIRED=false",
+        "BACKTEST_RUNTIME_DECISION_PARITY_PASS=false",
+        "RUNTIME_REWIRE_ADMISSIBLE=false",
+        "SURVIVAL_HARD_FAIL_BLOCKS_COMPOSITION=true",
+        "SURVIVAL_REQUIRED_UNKNOWN_FAIL_CLOSED=true",
+        "SUITABILITY_DETERMINISTIC_STRATEGY_SELECTION=true",
+        "```",
+        "",
+        f"- reused_survival_assessment_owner: `{binding['reused_survival_assessment_owner']}`",
+        f"- reused_suitability_binding_owner: `{binding['reused_suitability_binding_owner']}`",
+        f"- reused_scenario_binding_adapter_owner: `{binding['reused_scenario_binding_adapter_owner']}`",
+        f"- harness_path: `{binding['harness_path']}`",
+        f"- chained_contract_test_path: `{binding['chained_contract_test_path']}`",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_manifest(output_dir: Path) -> int:
+    rows: list[str] = []
+    for path in sorted(output_dir.rglob("*")):
+        if path.is_file() and path.name != "MANIFEST.sha256":
+            rows.append(f"{_sha256(path)}  {path.relative_to(output_dir).as_posix()}")
+    (output_dir / "MANIFEST.sha256").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    for row in rows:
+        digest, rel = row.split("  ", 1)
+        if _sha256(output_dir / rel) != digest:
+            return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    rewire = build_rewire_binding(repo_root)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "survival_suitability_narrow_reuse_first_rewire_v0.json").write_text(
+        json.dumps(rewire, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "survival_suitability_narrow_reuse_first_rewire_v0.md").write_text(
+        render_markdown(rewire) + "\n",
+        encoding="utf-8",
+    )
+    verdict = "PASS_SURVIVAL_SUITABILITY_NARROW_REUSE_FIRST_REWIRE_BOUND"
+    (output_dir / "verdict.txt").write_text(verdict + "\n", encoding="utf-8")
+    manifest_rc = write_manifest(output_dir)
+    (output_dir / "manifest_verify_rc.txt").write_text(f"{manifest_rc}\n", encoding="utf-8")
+    manifest_rc = write_manifest(output_dir)
+    print(verdict)
+    print(f"REUSED_SURVIVAL_ASSESSMENT_OWNER={REUSED_SURVIVAL_ASSESSMENT_OWNER}")
+    print(f"REUSED_SUITABILITY_BINDING_OWNER={REUSED_SUITABILITY_BINDING_OWNER}")
+    print("FUNCTIONAL_REWIRE_PERFORMED=true")
+    print(f"MANIFEST_VERIFY_RC={manifest_rc}")
+    print(f"EVIDENCE_DIR={output_dir}")
+    return 0 if manifest_rc == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
+++ b/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
@@ -114,9 +114,13 @@ from trading.master_v2.double_play_composition_scenario_matrix_adapter_v0 import
     evaluate_scenario_matrix_composition_v0,
 )
 from trading.master_v2.survival_suitability_scenario_binding_adapter_v0 import (
+    CANONICAL_SUITABILITY_BINDING_OWNER,
+    CANONICAL_SURVIVAL_ASSESSMENT_OWNER,
+    ScenarioSurvivalSuitabilityEvaluationV0,
     ScenarioSurvivalSuitabilityOverridesV0,
     SURVIVAL_SUITABILITY_SCENARIO_BINDING_ADAPTER_OWNER,
     legacy_side_to_assessment_statuses_v0,
+    survival_suitability_binding_non_authority_boundary_ok_v0,
 )
 from trading.master_v2.double_play_entry_exit_policy_v0 import (
     DecisionOutcome,
@@ -1071,6 +1075,65 @@ def assert_double_play_composition_non_authority_boundary_v0(
         assert matrix_result.sizing_effect == "NONE"
 
 
+def extract_survival_suitability_parity_envelope_v0(
+    evaluation: ScenarioSurvivalSuitabilityEvaluationV0,
+) -> ParityDecisionEnvelopeV0:
+    bull_survival = evaluation.bull_survival.status.value
+    bear_survival = evaluation.bear_survival.status.value
+    bull_suitability = evaluation.bull_suitability.status.value
+    bear_suitability = evaluation.bear_suitability.status.value
+    return ParityDecisionEnvelopeV0(
+        decision_outcome="not_bound_offline_survival_suitability_only",
+        previous_side_state=None,
+        next_side_state=None,
+        composition_status=(
+            f"bull_survival={bull_survival};bear_survival={bear_survival};"
+            f"bull_suitability={bull_suitability};bear_suitability={bear_suitability}"
+        ),
+        composition_result_id=(
+            f"{evaluation.bull_survival.survival_id}:{evaluation.bear_survival.survival_id}"
+        ),
+        entry_or_exit_policy_ref="",
+        reason_codes=tuple(
+            evaluation.bull_survival.reason_codes + evaluation.bear_suitability.reason_codes
+        ),
+        decision_precedence_trace=(),
+        execution_eligible=False,
+        adapter_compatible=False,
+        quantity_status="NOT_BOUND",
+        authority_effect="NONE",
+        runtime_effect="NONE",
+    )
+
+
+def assert_survival_suitability_non_authority_boundary_v0(
+    envelope: ParityDecisionEnvelopeV0,
+    *,
+    evaluation: ScenarioSurvivalSuitabilityEvaluationV0 | None = None,
+) -> None:
+    assert_non_authority_boundary_v0(envelope)
+    assert envelope.order_intent_effect == ORDER_INTENT_EFFECT_NONE
+    assert envelope.safety_boundary_effect == SAFETY_BOUNDARY_EFFECT_NONE
+    assert envelope.reconciliation_unknown_outcome_effect == (
+        RECONCILIATION_UNKNOWN_OUTCOME_EFFECT_NONE
+    )
+    assert envelope.killswitch_boundary_effect == KILLSWITCH_BOUNDARY_EFFECT_NONE
+    assert envelope.promotion_gate_boundary_effect == PROMOTION_GATE_BOUNDARY_EFFECT_NONE
+    assert envelope.ai_observability_boundary_effect == AI_OBSERVABILITY_BOUNDARY_EFFECT_NONE
+    assert envelope.feedback_learning_boundary_effect == FEEDBACK_LEARNING_BOUNDARY_EFFECT_NONE
+    assert survival_suitability_binding_non_authority_boundary_ok_v0() is True
+    if evaluation is not None:
+        for survival in (evaluation.bull_survival, evaluation.bear_survival):
+            assert survival.authority_effect == "NONE"
+            assert survival.runtime_effect == "NONE"
+            assert survival.order_effect == "NONE"
+        for suitability in (evaluation.bull_suitability, evaluation.bear_suitability):
+            assert suitability.authority_effect == "NONE"
+            assert suitability.runtime_effect == "NONE"
+            assert suitability.order_effect == "NONE"
+            assert suitability.risk_effect == "NONE"
+
+
 def assert_capital_risk_sizing_non_authority_boundary_v0(
     envelope: ParityDecisionEnvelopeV0,
 ) -> None:
@@ -1675,6 +1738,8 @@ def canonical_owner_refs_v0() -> Mapping[str, str]:
         "survival_suitability_scenario_binding_adapter": (
             SURVIVAL_SUITABILITY_SCENARIO_BINDING_ADAPTER_OWNER
         ),
+        "survival_assessment": CANONICAL_SURVIVAL_ASSESSMENT_OWNER,
+        "suitability_binding": CANONICAL_SUITABILITY_BINDING_OWNER,
         "runtime_state_reconciliation": RUNTIME_STATE_RECONCILIATION_OWNER,
         "reconciliation_entry_exit_policy": RECONCILIATION_ENTRY_EXIT_POLICY_OWNER,
         "promotion_economic_gate": PROMOTION_GATE_CANONICAL_OWNER,

--- a/tests/research/test_ai_observability_feedback_boundary_narrow_reuse_first_rewire_v0.py
+++ b/tests/research/test_ai_observability_feedback_boundary_narrow_reuse_first_rewire_v0.py
@@ -108,12 +108,15 @@ def test_rewire_makes_no_forbidden_claims() -> None:
     assert all(value is False for value in forbidden.values())
 
 
-def test_trace_matrix_selects_survival_and_suitability_after_double_play_composition_rewire_bound() -> (
+def test_trace_matrix_selects_canonical_order_intent_after_survival_and_suitability_rewire_bound() -> (
     None
 ):
     inventory = build_inventory(Path.cwd())
     matrix = build_trace_matrix(inventory)
-    assert matrix["selected_next_rewire_plan"]["selected_surface_id"] == "survival_and_suitability"
+    assert (
+        matrix["selected_next_rewire_plan"]["selected_surface_id"]
+        == "canonical_order_intent_boundary"
+    )
     ai_feedback_edge = next(
         edge for edge in matrix["trace_edges"] if edge["surface_id"] == SURFACE_ID
     )

--- a/tests/research/test_promotion_gate_boundary_narrow_reuse_first_rewire_v0.py
+++ b/tests/research/test_promotion_gate_boundary_narrow_reuse_first_rewire_v0.py
@@ -71,12 +71,15 @@ def test_rewire_makes_no_forbidden_claims() -> None:
     assert all(value is False for value in forbidden.values())
 
 
-def test_trace_matrix_selects_survival_and_suitability_after_double_play_composition_rewire_bound() -> (
+def test_trace_matrix_selects_canonical_order_intent_after_survival_and_suitability_rewire_bound() -> (
     None
 ):
     inventory = build_inventory(Path.cwd())
     matrix = build_trace_matrix(inventory)
-    assert matrix["selected_next_rewire_plan"]["selected_surface_id"] == "survival_and_suitability"
+    assert (
+        matrix["selected_next_rewire_plan"]["selected_surface_id"]
+        == "canonical_order_intent_boundary"
+    )
     assert matrix["selected_next_rewire_plan"]["plan_type"] == "NARROW_TRACE_ASSERTION_FIRST"
     ai_feedback_edge = next(
         edge

--- a/tests/research/test_survival_suitability_narrow_reuse_first_rewire_v0.py
+++ b/tests/research/test_survival_suitability_narrow_reuse_first_rewire_v0.py
@@ -7,30 +7,26 @@ from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import (
     TRACE_PRIORITY,
     build_trace_matrix,
 )
-from scripts.research.double_play_composition_narrow_reuse_first_rewire_v0 import (
+from scripts.research.survival_suitability_narrow_reuse_first_rewire_v0 import (
     CHAINED_CONTRACT_TEST_PATH,
     PLAN_TYPE,
-    REUSED_CANONICAL_OWNER,
-    REUSED_SCENARIO_MATRIX_ADAPTER_OWNER,
-    SCENARIO_MATRIX_PARITY_CONTRACT_TEST_PATH,
+    REUSED_SCENARIO_BINDING_ADAPTER_OWNER,
+    REUSED_SUITABILITY_BINDING_OWNER,
+    REUSED_SURVIVAL_ASSESSMENT_OWNER,
+    SCENARIO_REPLAY_CONTRACT_TEST_PATH,
     SURFACE_ID,
     build_rewire_binding,
-    evaluate_double_play_composition_parity_fixtures_v0,
+    evaluate_survival_suitability_parity_fixtures_v0,
 )
-from trading.master_v2.double_play_composition_matrix_v1 import (
-    CompositionConflictStatus,
-    CompositionSelectedSide,
-    CompositionStatus,
-)
+from trading.master_v2.survival_assessment_v1 import SurvivalAssessmentStatus
+from trading.master_v2.suitability_binding_v1 import SuitabilityBindingStatus
 
 
-def test_inventory_pins_chained_double_play_composition_backtest_binding_to_parity_contracts() -> (
-    None
-):
+def test_inventory_pins_chained_survival_suitability_backtest_binding_to_parity_contracts() -> None:
     inventory = build_inventory(Path.cwd())
     surface = next(s for s in inventory["surfaces"] if s["surface_id"] == SURFACE_ID)
     pinned_paths = {hit["path"] for hit in surface["backtest_binding_candidates"][:5]}
-    assert SCENARIO_MATRIX_PARITY_CONTRACT_TEST_PATH in pinned_paths
+    assert SCENARIO_REPLAY_CONTRACT_TEST_PATH in pinned_paths
     assert CHAINED_CONTRACT_TEST_PATH in pinned_paths
     assert surface["backtest_binding_candidates"][0]["matched_terms"] == ["rewire_binding_pin"]
 
@@ -39,34 +35,37 @@ def test_rewire_binding_reuses_canonical_owners_without_parallel_owner() -> None
     rewire = build_rewire_binding(Path.cwd())
     binding = rewire["rewire_binding"]
 
-    assert rewire["schema"] == "DoublePlayCompositionNarrowReuseFirstRewireV1"
+    assert rewire["schema"] == "SurvivalSuitabilityNarrowReuseFirstRewireV1"
     assert rewire["surface_id"] == SURFACE_ID
     assert rewire["plan_type"] == PLAN_TYPE
-    assert rewire["trace_assertion_source_pr"] == 5016
-    assert binding["reused_canonical_owner"] == REUSED_CANONICAL_OWNER
-    assert binding["reused_scenario_matrix_adapter_owner"] == REUSED_SCENARIO_MATRIX_ADAPTER_OWNER
+    assert rewire["trace_assertion_source_pr"] == 5017
+    assert binding["reused_survival_assessment_owner"] == REUSED_SURVIVAL_ASSESSMENT_OWNER
+    assert binding["reused_suitability_binding_owner"] == REUSED_SUITABILITY_BINDING_OWNER
+    assert binding["reused_scenario_binding_adapter_owner"] == REUSED_SCENARIO_BINDING_ADAPTER_OWNER
     assert binding["functional_rewire_performed"] is True
     assert binding["new_parallel_owner_created"] is False
-    assert binding["ai_observability_feedback_boundary_chain_preserved"] is True
-    assert binding["both_sides_confirmed_resolves_to_chop_guard_block"] is True
-    assert binding["no_implicit_scoring_override"] is True
+    assert binding["double_play_composition_chain_preserved"] is True
+    assert binding["survival_hard_fail_blocks_composition"] is True
+    assert binding["survival_required_unknown_fail_closed"] is True
+    assert binding["suitability_deterministic_strategy_selection"] is True
     assert binding["no_list_order_strategy_override"] is True
-    assert binding["composition_matrix_complete"] is True
-    assert binding["composition_conflict_rule_represented"] is True
-    assert binding["composition_offline_only"] is True
+    assert binding["no_confidence_only_selection"] is True
+    assert binding["cost_model_boundary_bound"] is True
+    assert binding["regime_owner_boundary_bound"] is True
+    assert binding["survival_suitability_offline_only"] is True
     assert binding["rewire_state"] == "REWIRE_BOUND_OFFLINE_PARITY_PATH"
 
 
-def test_chained_double_play_composition_parity_fixture_binds_offline_only() -> None:
-    result = evaluate_double_play_composition_parity_fixtures_v0()
-    assert result.composition_status is CompositionStatus.CHOP_GUARD_BLOCK
-    assert result.conflict_status is CompositionConflictStatus.BOTH_SIDES_CONFIRMED
-    assert result.selected_side is CompositionSelectedSide.NONE
-    assert "no_new_entry" in result.reason_codes
-    assert "existing_position_management_continues" in result.reason_codes
-    assert result.authority_effect == "NONE"
-    assert result.runtime_effect == "NONE"
-    assert result.order_effect == "NONE"
+def test_chained_survival_suitability_parity_fixture_binds_offline_only() -> None:
+    result = evaluate_survival_suitability_parity_fixtures_v0()
+    assert result.bull_survival.status is SurvivalAssessmentStatus.PASS
+    assert result.bull_suitability.status is SuitabilityBindingStatus.PASS
+    assert result.bull_survival.authority_effect == "NONE"
+    assert result.bull_survival.runtime_effect == "NONE"
+    assert result.bull_survival.order_effect == "NONE"
+    assert result.bull_suitability.authority_effect == "NONE"
+    assert result.bull_suitability.runtime_effect == "NONE"
+    assert result.bull_suitability.order_effect == "NONE"
 
 
 def test_rewire_makes_no_forbidden_claims() -> None:
@@ -82,7 +81,7 @@ def test_rewire_makes_no_forbidden_claims() -> None:
     assert all(value is False for value in forbidden.values())
 
 
-def test_trace_matrix_selects_canonical_order_intent_after_survival_and_suitability_rewire_bound() -> (
+def test_trace_matrix_selects_canonical_order_intent_after_survival_suitability_rewire_bound() -> (
     None
 ):
     inventory = build_inventory(Path.cwd())
@@ -91,19 +90,15 @@ def test_trace_matrix_selects_canonical_order_intent_after_survival_and_suitabil
         matrix["selected_next_rewire_plan"]["selected_surface_id"]
         == "canonical_order_intent_boundary"
     )
+    survival_edge = next(edge for edge in matrix["trace_edges"] if edge["surface_id"] == SURFACE_ID)
+    assert survival_edge["trace_state"] == "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"
     double_play_edge = next(
-        edge for edge in matrix["trace_edges"] if edge["surface_id"] == SURFACE_ID
+        edge for edge in matrix["trace_edges"] if edge["surface_id"] == "double_play_composition"
     )
     assert double_play_edge["trace_state"] == "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"
-    ai_feedback_edge = next(
-        edge
-        for edge in matrix["trace_edges"]
-        if edge["surface_id"] == "ai_observability_feedback_boundary"
-    )
-    assert ai_feedback_edge["trace_state"] == "TRACE_REWIRE_BOUND_OFFLINE_PARITY_PATH"
 
 
-def test_trace_chain_preserves_prior_bound_surfaces_through_double_play_composition() -> None:
+def test_trace_chain_preserves_prior_bound_surfaces_through_survival_suitability() -> None:
     inventory = build_inventory(Path.cwd())
     matrix = build_trace_matrix(inventory)
     bound_prior = [
@@ -113,6 +108,7 @@ def test_trace_chain_preserves_prior_bound_surfaces_through_double_play_composit
         "promotion_gate_boundary",
         "ai_observability_feedback_boundary",
         "double_play_composition",
+        "survival_and_suitability",
     ]
     by_surface = {edge["surface_id"]: edge for edge in matrix["trace_edges"]}
     for surface_id in bound_prior:


### PR DESCRIPTION
## Summary

- Bind `survival_and_suitability` as the next narrow reuse-first offline parity surface after `double_play_composition`, reusing canonical `survival_assessment_v1` and `suitability_binding_v1` via the existing scenario binding adapter (no parallel SSOT).
- Extend inventory pins/trace rewire state, add chained rewire script + contract tests, and harness extract/assert helpers for offline non-authority boundary verification.
- Preserve prior bound surfaces; trace chain now ends at `survival_and_suitability`; next unbound node is `canonical_order_intent_boundary`.

## Base HEAD

`2a7e2c1630127b0bb5ecd1765a66c75ce3374d7f`

## Source evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/survival_suitability_parity_surface_reuse_first_narrow_rewire_v0_20260708T204928Z`

- MANIFEST verify RC=0

## Tests run (RCs)

| Test | RC |
|------|-----|
| `tests/research/test_survival_suitability_narrow_reuse_first_rewire_v0.py` | 0 |
| `tests/trading/master_v2/test_double_play_survival.py` | 0 |
| `tests/trading/master_v2/test_double_play_suitability.py` | 0 |
| `tests/trading/master_v2/test_double_play_pure_stack_contract.py` | 0 |
| `tests/research/test_double_play_composition_narrow_reuse_first_rewire_v0.py` | 0 |
| `tests/research/test_ai_observability_feedback_boundary_narrow_reuse_first_rewire_v0.py` | 0 |
| `tests/research/test_promotion_gate_boundary_narrow_reuse_first_rewire_v0.py` | 0 |
| ruff format --check (changed Python) | 0 |
| ruff check (changed Python) | 0 |
| py_compile (changed Python) | 0 |
| forbidden positive claims scan (scoped, NO_-guard) | 0 |

Note: two pre-existing failures on `main` in `test_survival_suitability_scenario_replay_binding_parity_rewire_contract_v0.py` (`NEXT_RECOMMENDED_SLICE` drift) were not introduced by this PR.

## Changed files

- `scripts/research/backtest_runtime_decision_parity_inventory_v0.py`
- `scripts/research/survival_suitability_narrow_reuse_first_rewire_v0.py` (new)
- `src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py`
- `tests/research/test_survival_suitability_narrow_reuse_first_rewire_v0.py` (new)
- `tests/research/test_double_play_composition_narrow_reuse_first_rewire_v0.py`
- `tests/research/test_ai_observability_feedback_boundary_narrow_reuse_first_rewire_v0.py`
- `tests/research/test_promotion_gate_boundary_narrow_reuse_first_rewire_v0.py`

## Forbidden claims remain false

- `FULL_CANONICAL_CHAIN_WIRED=false`
- `BACKTEST_RUNTIME_DECISION_PARITY_PASS=false`
- `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`
- `RUNTIME_REWIRE_ADMISSIBLE=false`
- `RUNTIME_AUTHORITY=false`
- `ORDERS_ALLOWED=false`
- `ECONOMIC_CLAIM=false`

## Trace chain after this PR

`capital_risk_sizing` → `safety_kernel_and_killswitch_boundary` → `reconciliation_unknown_outcome` → `promotion_gate_boundary` → `ai_observability_feedback_boundary` → `double_play_composition` → `survival_and_suitability`

Next unbound: `canonical_order_intent_boundary`

## Scope statement

No Runtime, Shadow, Paper, Testnet, Scheduler, Credential, Order, Live, Canary, or Economic evidence was created.

## Test plan

- [x] Chained survival/suitability narrow rewire contract tests
- [x] Existing survival/suitability/pure-stack/parity-chain preservation tests
- [x] ruff + py_compile + forbidden-claims scan on changed files
- [x] Source evidence MANIFEST verify RC=0

Made with [Cursor](https://cursor.com)