### PR TITLE
fix: assess next full canonical parity surface after surface p

### DIFF
--- a/scripts/ops/run_next_full_canonical_parity_surface_after_surface_p_assessment_v0.py
+++ b/scripts/ops/run_next_full_canonical_parity_surface_after_surface_p_assessment_v0.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for next full canonical parity surface after Surface P v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPT_ROOT = Path(__file__).resolve()
+REPO_ROOT = _SCRIPT_ROOT.parents[2]
+for parent in [_SCRIPT_ROOT, *_SCRIPT_ROOT.parents]:
+    if (parent / "src").is_dir() and (parent / ".git").exists():
+        REPO_ROOT = parent
+        repo_s = str(parent)
+        src_s = str(parent / "src")
+        if repo_s not in sys.path:
+            sys.path.insert(0, repo_s)
+        if src_s not in sys.path:
+            sys.path.insert(0, src_s)
+        break
+
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+DEFAULT_PR5023_CLOSEOUT = (
+    ARCHIVE_ROOT
+    / "research/merge_closeout_pr5023_surface_p_semantic_parity_gap_assessment_targeted_v0_20260708T231817Z"
+)
+DEFAULT_PR5022_PROOF_BUNDLE = (
+    ARCHIVE_ROOT / "research/full_canonical_parity_proof_bundle_v0_20260708T224152Z"
+)
+
+VERDICT = "NEXT_FULL_CANONICAL_PARITY_SURFACE_AFTER_SURFACE_P_ASSESSMENT_V0_PASS"
+TARGETED_TESTS = (
+    "tests/trading/master_v2/test_next_full_canonical_parity_surface_after_surface_p_assessment_contract_v0.py",
+    "tests/trading/master_v2/test_surface_p_semantic_parity_gap_assessment_contract_v0.py",
+    "tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py",
+    "tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/next_full_canonical_parity_surface_after_surface_p_assessment_v0.py",
+    "scripts/ops/run_next_full_canonical_parity_surface_after_surface_p_assessment_v0.py",
+    "tests/trading/master_v2/test_next_full_canonical_parity_surface_after_surface_p_assessment_contract_v0.py",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.iterdir()):
+        if path.name == "MANIFEST.sha256":
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  {path.name}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def _scan_forbidden_claims(changed_files: list[str]) -> tuple[int, list[str]]:
+    from trading.master_v2.next_full_canonical_parity_surface_after_surface_p_assessment_v0 import (
+        scan_forbidden_positive_claims,
+    )
+
+    violations = scan_forbidden_positive_claims(REPO_ROOT, changed_files)
+    return (0 if not violations else 1, violations)
+
+
+def collect_evidence(
+    out_dir: Path | None = None,
+    *,
+    pr5023_closeout_dir: Path | None = None,
+    pr5022_proof_bundle_dir: Path | None = None,
+) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT / f"research/pr5024_next_full_canonical_parity_surface_after_pr5023_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    closeout_dir = pr5023_closeout_dir or DEFAULT_PR5023_CLOSEOUT
+    proof_bundle_dir = pr5022_proof_bundle_dir or DEFAULT_PR5022_PROOF_BUNDLE
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    worktree = _run(["git", "status", "--short"]).stdout.strip()
+    changed = _run(["git", "diff", "--name-only", "origin/main...HEAD"]).stdout.strip()
+
+    (evidence_dir / "git_context.txt").write_text(
+        "\n".join(
+            [
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"WORKTREE_STATUS={worktree or 'clean'}",
+                "ASSESSMENT_SLICE_ID=NEXT_FULL_CANONICAL_PARITY_SURFACE_AFTER_SURFACE_P_ASSESSMENT_V0",
+                f"PR5023_CLOSEOUT_PATH={closeout_dir}",
+                f"PR5022_PROOF_BUNDLE_PATH={proof_bundle_dir}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "changed_files.txt").write_text(
+        (changed + "\n") if changed else "(no committed diff vs origin/main yet)\n",
+        encoding="utf-8",
+    )
+
+    source_lines: list[str] = []
+    source_rc = 0
+    for source_dir in (closeout_dir, proof_bundle_dir):
+        proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=source_dir)
+        source_lines.append(f"=== {source_dir} RC={proc.returncode} ===")
+        source_lines.append(proc.stdout)
+        source_lines.append(proc.stderr)
+        if proc.returncode != 0:
+            source_rc = proc.returncode
+    (evidence_dir / "source_manifest_verify.txt").write_text(
+        "\n".join(source_lines) + f"\nSOURCE_MANIFEST_VERIFY_RC={source_rc}\n",
+        encoding="utf-8",
+    )
+
+    from trading.master_v2.next_full_canonical_parity_surface_after_surface_p_assessment_v0 import (
+        evaluate_next_full_canonical_parity_surface_after_surface_p_assessment_v0,
+        next_full_canonical_parity_surface_assessment_to_dict_v0,
+        render_next_full_canonical_parity_surface_matrix_json_v0,
+        render_next_full_canonical_parity_surface_report_markdown_v0,
+    )
+
+    assessment = evaluate_next_full_canonical_parity_surface_after_surface_p_assessment_v0(
+        repo_root=REPO_ROOT,
+        pr5023_closeout_dir=closeout_dir,
+        pr5022_proof_bundle_dir=proof_bundle_dir,
+        source_manifest_verify_rc=source_rc,
+    )
+    (evidence_dir / "next_full_canonical_parity_surface_matrix.json").write_text(
+        render_next_full_canonical_parity_surface_matrix_json_v0(
+            repo_root=REPO_ROOT,
+            pr5023_closeout_dir=closeout_dir,
+            pr5022_proof_bundle_dir=proof_bundle_dir,
+        ),
+        encoding="utf-8",
+    )
+    (evidence_dir / "next_full_canonical_parity_surface_report.md").write_text(
+        render_next_full_canonical_parity_surface_report_markdown_v0(
+            repo_root=REPO_ROOT,
+            pr5023_closeout_dir=closeout_dir,
+            pr5022_proof_bundle_dir=proof_bundle_dir,
+        ),
+        encoding="utf-8",
+    )
+    (evidence_dir / "assessment_result.json").write_text(
+        json.dumps(
+            next_full_canonical_parity_surface_assessment_to_dict_v0(assessment),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {
+        **dict(__import__("os").environ),
+        "PYTHONPATH": f"{REPO_ROOT / 'src'}:{REPO_ROOT}",
+    }
+    pytest_proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (evidence_dir / "targeted_pytest.txt").write_text(
+        pytest_proc.stdout + pytest_proc.stderr + f"\nTARGETED_TESTS_RC={pytest_proc.returncode}\n",
+        encoding="utf-8",
+    )
+
+    ruff_targets = [str(REPO_ROOT / p) for p in SLICE_CHANGED_FILES if p.endswith(".py")]
+    ruff_format = _run([sys.executable, "-m", "ruff", "format", "--check", *ruff_targets])
+    ruff_check = _run([sys.executable, "-m", "ruff", "check", *ruff_targets])
+    (evidence_dir / "ruff_format_check.txt").write_text(
+        ruff_format.stdout + ruff_format.stderr + f"\nRUFF_FORMAT_RC={ruff_format.returncode}\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "ruff_check.txt").write_text(
+        ruff_check.stdout + ruff_check.stderr + f"\nRUFF_CHECK_RC={ruff_check.returncode}\n",
+        encoding="utf-8",
+    )
+
+    compile_lines: list[str] = []
+    compile_rc = 0
+    for rel in SLICE_CHANGED_FILES:
+        if not rel.endswith(".py"):
+            continue
+        proc = _run([sys.executable, "-m", "py_compile", str(REPO_ROOT / rel)])
+        compile_lines.append(f"=== {rel} RC={proc.returncode} ===")
+        compile_lines.append(proc.stdout)
+        compile_lines.append(proc.stderr)
+        if proc.returncode != 0:
+            compile_rc = proc.returncode
+    (evidence_dir / "py_compile.txt").write_text(
+        "\n".join(compile_lines) + f"\nPY_COMPILE_RC={compile_rc}\n",
+        encoding="utf-8",
+    )
+
+    forbidden_rc, forbidden_violations = _scan_forbidden_claims(list(SLICE_CHANGED_FILES))
+    (evidence_dir / "forbidden_claims_scan.txt").write_text(
+        "\n".join(
+            [
+                f"FORBIDDEN_CLAIMS_SCAN_RC={forbidden_rc}",
+                *forbidden_violations,
+                "NO_RUNTIME_AUTHORITY_CONFIRMED=true",
+                "NO_ECONOMIC_CLAIM_CONFIRMED=true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    blocked = (
+        pytest_proc.returncode != 0
+        or ruff_format.returncode != 0
+        or ruff_check.returncode != 0
+        or compile_rc != 0
+        or forbidden_rc != 0
+        or source_rc != 0
+        or assessment.assessment_verdict != "PASS"
+        or assessment.full_canonical_chain_wired
+        or assessment.backtest_runtime_decision_parity_pass
+        or assessment.system_economic_evidence_admissible
+        or assessment.runtime_rewire_admissible
+        or assessment.claim_promotion_allowed
+    )
+    verdict = (
+        VERDICT
+        if not blocked
+        else "NEXT_FULL_CANONICAL_PARITY_SURFACE_AFTER_SURFACE_P_ASSESSMENT_V0_BLOCKED"
+    )
+
+    (evidence_dir / "final_report.txt").write_text(
+        "\n".join(
+            [
+                f"VERDICT={verdict}",
+                f"BASE_HEAD={head}",
+                f"POST_BRANCH_HEAD={head}",
+                "BRANCH_NAME=core-system-completion-next-full-canonical-parity-surface-after-pr5023-v0",
+                f"NEXT_UNBOUND_NODE_BEFORE={assessment.trace_next_unbound_node_before}",
+                f"SELECTED_SURFACE={assessment.selected_surface}",
+                f"PLAN_TYPE={assessment.plan_type}",
+                f"SOURCE_MANIFEST_VERIFY_RC={source_rc}",
+                f"SURFACE_P_REGISTRY_STATUS={assessment.surface_p_registry_status}",
+                f"SURFACE_P_SEMANTIC_POST_STATUS={assessment.surface_p_semantic_post_status}",
+                f"NEXT_UNBOUND_NODE={assessment.next_unbound_node}",
+                f"BLOCKED_REASON={assessment.blocked_reason}",
+                f"FULL_CANONICAL_CHAIN_WIRED={str(assessment.full_canonical_chain_wired).lower()}",
+                (
+                    "BACKTEST_RUNTIME_DECISION_PARITY_PASS="
+                    f"{str(assessment.backtest_runtime_decision_parity_pass).lower()}"
+                ),
+                (
+                    "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE="
+                    f"{str(assessment.system_economic_evidence_admissible).lower()}"
+                ),
+                f"RUNTIME_REWIRE_ADMISSIBLE={str(assessment.runtime_rewire_admissible).lower()}",
+                f"CLAIM_PROMOTION_ALLOWED={str(assessment.claim_promotion_allowed).lower()}",
+                "NO_RUNTIME_AUTHORITY_CONFIRMED=true",
+                "NO_ECONOMIC_CLAIM_CONFIRMED=true",
+                f"DURABLE_EVIDENCE_DIR={evidence_dir}",
+                f"NEXT_STEP_AFTER_PR={assessment.next_step_after_pr}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc = _write_manifest(evidence_dir)
+    (evidence_dir / "final_report.txt").write_text(
+        (evidence_dir / "final_report.txt").read_text(encoding="utf-8")
+        + f"MANIFEST_VERIFY_RC={manifest_rc}\n",
+        encoding="utf-8",
+    )
+    manifest_rc = _write_manifest(evidence_dir)
+
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_verify_rc": manifest_rc,
+        "pytest_rc": pytest_proc.returncode,
+        "source_manifest_verify_rc": source_rc,
+        "ruff_rc": ruff_check.returncode,
+        "ruff_format_rc": ruff_format.returncode,
+        "py_compile_rc": compile_rc,
+        "lint_rc": max(ruff_format.returncode, ruff_check.returncode),
+        "forbidden_rc": forbidden_rc,
+        "assessment": assessment,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, default=None)
+    parser.add_argument("--pr5023-closeout", type=Path, default=None)
+    parser.add_argument("--pr5022-proof-bundle", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(
+        args.out,
+        pr5023_closeout_dir=args.pr5023_closeout,
+        pr5022_proof_bundle_dir=args.pr5022_proof_bundle,
+    )
+    print(result["verdict"])
+    print(f"EVIDENCE_DIR={result['evidence_dir']}")
+    print(f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}")
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -99,6 +99,12 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/surface_p_final_flags_fail_closed_contract_v0.py",
     "scripts/ops/run_surface_p_final_flags_fail_closed_contract_v0.py",
     "tests/trading/master_v2/test_surface_p_final_flags_fail_closed_contract_v0.py",
+    "src/trading/master_v2/surface_p_semantic_parity_gap_assessment_v0.py",
+    "scripts/ops/run_surface_p_semantic_parity_gap_assessment_v0.py",
+    "tests/trading/master_v2/test_surface_p_semantic_parity_gap_assessment_contract_v0.py",
+    "src/trading/master_v2/next_full_canonical_parity_surface_after_surface_p_assessment_v0.py",
+    "scripts/ops/run_next_full_canonical_parity_surface_after_surface_p_assessment_v0.py",
+    "tests/trading/master_v2/test_next_full_canonical_parity_surface_after_surface_p_assessment_contract_v0.py",
 )
 
 FORBIDDEN_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (

--- a/src/trading/master_v2/next_full_canonical_parity_surface_after_surface_p_assessment_v0.py
+++ b/src/trading/master_v2/next_full_canonical_parity_surface_after_surface_p_assessment_v0.py
@@ -1,0 +1,463 @@
+"""
+Next full canonical parity surface assessment after Surface P semantic parity v0.
+
+Read-only / offline-only assessment that consumes trace-matrix NEXT_UNBOUND_NODE,
+gap-assessment NEXT_RECOMMENDED_SLICE, and PR5023 Surface P semantic parity
+evidence to make the next canonical parity work slice explicit. Does not activate
+runtime, grant order authority, or promote final success flags.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Literal, Mapping, Tuple
+
+NEXT_FULL_CANONICAL_PARITY_SURFACE_ASSESSMENT_LAYER_VERSION = "v0"
+NEXT_FULL_CANONICAL_PARITY_SURFACE_ASSESSMENT_OWNER = (
+    "trading.master_v2.next_full_canonical_parity_surface_after_surface_p_assessment_v0"
+)
+ASSESSMENT_SLICE_ID = "NEXT_FULL_CANONICAL_PARITY_SURFACE_AFTER_SURFACE_P_ASSESSMENT_V0"
+PACKAGE_MARKER = "NEXT_FULL_CANONICAL_PARITY_SURFACE_AFTER_SURFACE_P_ASSESSMENT_V0=true"
+
+SELECTED_SURFACE = "FULL_CANONICAL_BACKTEST_BOUNDARY_CHAIN_REASSESSMENT_V0"
+PLAN_TYPE = "ASSESSMENT_ONLY"
+
+DEFAULT_PR5023_CLOSEOUT_EVIDENCE = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "research/merge_closeout_pr5023_surface_p_semantic_parity_gap_assessment_targeted_v0_20260708T231817Z"
+)
+DEFAULT_PR5022_PROOF_BUNDLE_EVIDENCE = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "research/full_canonical_parity_proof_bundle_v0_20260708T224152Z"
+)
+
+AssessmentVerdict = Literal["PASS", "FAIL_CLOSED"]
+TraceNextUnboundNode = str
+
+REASON_TRACE_NODES_ALL_BOUND = "TRACE_MATRIX_NEXT_UNBOUND_NODE_NONE"
+REASON_SURFACE_P_SEMANTIC_PASS_REGISTRY_PARTIAL = (
+    "SURFACE_P_SEMANTIC_PASS_REGISTRY_PARTIAL_RUNTIME_BRIDGE_BLOCKED"
+)
+REASON_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED = "RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED_BY_POLICY"
+REASON_SOURCE_MANIFEST_UNVERIFIED = "SOURCE_EVIDENCE_MANIFEST_NOT_VERIFIED"
+REASON_PR5023_CLOSEOUT_MISSING = "PR5023_SURFACE_P_SEMANTIC_CLOSEOUT_EVIDENCE_MISSING"
+REASON_SURFACE_P_SEMANTIC_NOT_PASS = "SURFACE_P_SEMANTIC_PARITY_NOT_PASS"
+REASON_FINAL_FLAGS_STILL_FALSE = "FINAL_SUCCESS_FLAGS_REMAIN_FAIL_CLOSED"
+
+FORBIDDEN_POSITIVE_CLAIM_LITERALS = (
+    "FULL_CANONICAL_CHAIN_WIRED=true",
+    "BACKTEST_RUNTIME_DECISION_PARITY_PASS=true",
+    "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=true",
+    "RUNTIME_REWIRE_ADMISSIBLE=true",
+    "CLAIM_PROMOTION_ALLOWED=true",
+)
+
+FORBIDDEN_POSITIVE_ASSIGNMENT_RES = (
+    re.compile(r"FULL_CANONICAL_CHAIN_WIRED\s*=\s*True\b"),
+    re.compile(r"BACKTEST_RUNTIME_DECISION_PARITY_PASS\s*=\s*True\b"),
+    re.compile(r"SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE\s*=\s*True\b"),
+    re.compile(r"RUNTIME_REWIRE_ADMISSIBLE\s*=\s*True\b"),
+    re.compile(r"CLAIM_PROMOTION_ALLOWED\s*=\s*True\b"),
+    re.compile(r'"full_canonical_chain_wired"\s*:\s*true\b'),
+    re.compile(r'"backtest_runtime_decision_parity_pass"\s*:\s*true\b'),
+    re.compile(r'"system_economic_evidence_admissible"\s*:\s*true\b'),
+    re.compile(r'"runtime_rewire_admissible"\s*:\s*true\b'),
+    re.compile(r'"claim_promotion_allowed"\s*:\s*true\b'),
+)
+
+_CONTEXT_PROTECTED_MARKERS = (
+    "forbidden_claims",
+    "FORBIDDEN_POSITIVE_CLAIM",
+    "FORBIDDEN_POSITIVE_ASSIGNMENT",
+    '_claimed": False',
+    "is False",
+    "== False",
+    "!= True",
+    "assert ",
+    "# ",
+    '"""',
+    "'''",
+    "unless fully proven",
+    "denylist",
+    "needle",
+)
+
+
+@dataclass(frozen=True)
+class SourceEvidenceRefV0:
+    evidence_id: str
+    path: str
+    present: bool
+    manifest_present: bool
+    manifest_verified: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class NextFullCanonicalParitySurfaceAssessmentResultV0:
+    assessment_verdict: AssessmentVerdict
+    trace_next_unbound_node_before: TraceNextUnboundNode
+    next_unbound_node: str
+    selected_surface: str
+    plan_type: str
+    surface_p_registry_status: str
+    surface_p_semantic_post_status: str
+    chain_surface_binding_complete: bool
+    gap_assessment_next_recommended_slice: str
+    blocked_reason: str
+    next_step_after_pr: str
+    source_evidence_referenced: bool
+    source_manifest_verify_rc: int
+    full_canonical_chain_wired: bool
+    backtest_runtime_decision_parity_pass: bool
+    system_economic_evidence_admissible: bool
+    runtime_rewire_admissible: bool
+    claim_promotion_allowed: bool
+    no_runtime_authority_confirmed: bool
+    no_economic_claim_confirmed: bool
+    fail_closed_reasons: Tuple[str, ...]
+
+
+def _line_context_protected(line: str) -> bool:
+    lowered = line.lower()
+    for marker in _CONTEXT_PROTECTED_MARKERS:
+        if marker in line or marker in lowered:
+            return True
+    for literal in FORBIDDEN_POSITIVE_CLAIM_LITERALS:
+        if literal in line and ("forbidden" in lowered or "deny" in lowered or "needle" in lowered):
+            return True
+    return False
+
+
+def scan_forbidden_positive_claims(repo_root: Path, changed_files: list[str]) -> list[str]:
+    violations: list[str] = []
+    for rel in changed_files:
+        path = repo_root / rel
+        if not path.is_file() or path.suffix != ".py":
+            continue
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if _line_context_protected(line):
+                continue
+            for pattern in FORBIDDEN_POSITIVE_ASSIGNMENT_RES:
+                if pattern.search(line):
+                    violations.append(f"{rel}:{line_no}: {line.strip()}")
+    return violations
+
+
+def verify_source_manifest(evidence_dir: Path) -> tuple[bool, int, str]:
+    manifest = evidence_dir / "MANIFEST.sha256"
+    if not evidence_dir.is_dir():
+        return False, -1, "directory_missing"
+    if not manifest.is_file():
+        return False, -1, "manifest_missing"
+    rows = manifest.read_text(encoding="utf-8").splitlines()
+    for row in rows:
+        if not row.strip():
+            continue
+        digest, rel = row.split("  ", 1)
+        target = evidence_dir / rel
+        if not target.is_file():
+            return False, 1, f"missing_file:{rel}"
+        import hashlib
+
+        actual = hashlib.sha256(target.read_bytes()).hexdigest()
+        if actual != digest:
+            return False, 1, f"digest_mismatch:{rel}"
+    return True, 0, "verified"
+
+
+def collect_source_evidence_refs(
+    *,
+    pr5023_closeout_dir: Path | None = None,
+    pr5022_proof_bundle_dir: Path | None = None,
+) -> Tuple[SourceEvidenceRefV0, ...]:
+    closeout = pr5023_closeout_dir or Path(DEFAULT_PR5023_CLOSEOUT_EVIDENCE)
+    proof_bundle = pr5022_proof_bundle_dir or Path(DEFAULT_PR5022_PROOF_BUNDLE_EVIDENCE)
+    refs: list[SourceEvidenceRefV0] = []
+    for evidence_id, path in (
+        ("pr5023_closeout", closeout),
+        ("pr5022_proof_bundle", proof_bundle),
+    ):
+        present = path.is_dir()
+        manifest_present = present and (path / "MANIFEST.sha256").is_file()
+        if manifest_present:
+            verified, rc, detail = verify_source_manifest(path)
+            refs.append(
+                SourceEvidenceRefV0(
+                    evidence_id=evidence_id,
+                    path=str(path),
+                    present=True,
+                    manifest_present=True,
+                    manifest_verified=verified,
+                    detail=detail if verified else f"rc={rc}:{detail}",
+                )
+            )
+        else:
+            refs.append(
+                SourceEvidenceRefV0(
+                    evidence_id=evidence_id,
+                    path=str(path),
+                    present=present,
+                    manifest_present=False,
+                    manifest_verified=False,
+                    detail="missing" if not present else "manifest_missing",
+                )
+            )
+    return tuple(refs)
+
+
+def _trace_matrix_snapshot_v0(repo_root: Path) -> tuple[str, bool]:
+    from scripts.research.backtest_runtime_decision_parity_inventory_v0 import build_inventory
+    from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import (
+        build_trace_matrix,
+        compute_chain_surface_binding_complete,
+        compute_next_unbound_node,
+    )
+
+    inventory = build_inventory(repo_root)
+    matrix = build_trace_matrix(inventory)
+    edges = matrix["trace_edges"]
+    return (
+        compute_next_unbound_node(edges),
+        compute_chain_surface_binding_complete(edges),
+    )
+
+
+def resolve_next_unbound_canonical_parity_node_v0(
+    *,
+    trace_next_unbound_node: str,
+    gap_assessment_next_recommended_slice: str,
+    surface_p_semantic_post_status: str,
+) -> str:
+    """Make the next canonical parity node explicit when trace surfaces are all bound."""
+    if trace_next_unbound_node != "NONE":
+        return trace_next_unbound_node
+    if surface_p_semantic_post_status == "PASS":
+        return gap_assessment_next_recommended_slice
+    return gap_assessment_next_recommended_slice
+
+
+def evaluate_next_full_canonical_parity_surface_after_surface_p_assessment_v0(
+    *,
+    repo_root: Path | None = None,
+    pr5023_closeout_dir: Path | None = None,
+    pr5022_proof_bundle_dir: Path | None = None,
+    source_manifest_verify_rc: int | None = None,
+) -> NextFullCanonicalParitySurfaceAssessmentResultV0:
+    """Evaluate next full canonical parity surface after Surface P; never grants authority."""
+    from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+        NEXT_RECOMMENDED_SLICE,
+        parity_surface_assessments_v0,
+    )
+    from trading.master_v2.surface_p_semantic_parity_gap_assessment_v0 import (
+        evaluate_surface_p_semantic_parity_gap_assessment_v0,
+    )
+
+    root = repo_root or Path(__file__).resolve().parents[3]
+    fail_reasons: list[str] = []
+    source_refs = collect_source_evidence_refs(
+        pr5023_closeout_dir=pr5023_closeout_dir,
+        pr5022_proof_bundle_dir=pr5022_proof_bundle_dir,
+    )
+    closeout_ref = next(ref for ref in source_refs if ref.evidence_id == "pr5023_closeout")
+    source_evidence_referenced = closeout_ref.present
+    manifest_rc = (
+        source_manifest_verify_rc
+        if source_manifest_verify_rc is not None
+        else (0 if closeout_ref.manifest_verified else -1)
+    )
+    if not closeout_ref.present:
+        fail_reasons.append(REASON_PR5023_CLOSEOUT_MISSING)
+    elif manifest_rc != 0:
+        fail_reasons.append(REASON_SOURCE_MANIFEST_UNVERIFIED)
+
+    trace_next_unbound, chain_binding_complete = _trace_matrix_snapshot_v0(root)
+
+    surface_p = next(item for item in parity_surface_assessments_v0() if item.surface_id == "P")
+    surface_p_registry_status = surface_p.parity_status
+
+    semantic = evaluate_surface_p_semantic_parity_gap_assessment_v0(
+        pr5022_proof_bundle_dir=pr5022_proof_bundle_dir,
+        source_manifest_verify_rc=manifest_rc if manifest_rc != -1 else None,
+    )
+    surface_p_semantic_post_status = semantic.surface_p_post_status
+    if surface_p_semantic_post_status != "PASS":
+        fail_reasons.append(REASON_SURFACE_P_SEMANTIC_NOT_PASS)
+
+    next_unbound_node = resolve_next_unbound_canonical_parity_node_v0(
+        trace_next_unbound_node=trace_next_unbound,
+        gap_assessment_next_recommended_slice=NEXT_RECOMMENDED_SLICE,
+        surface_p_semantic_post_status=surface_p_semantic_post_status,
+    )
+
+    blocked_reason = semantic.next_blocker
+    if blocked_reason == REASON_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED:
+        fail_reasons.append(REASON_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED)
+
+    next_step_after_pr = (
+        "RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_ASSESSMENT_V0"
+        if blocked_reason == REASON_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED
+        else SELECTED_SURFACE
+    )
+
+    assessment_verdict: AssessmentVerdict = (
+        "PASS"
+        if (
+            next_unbound_node == SELECTED_SURFACE
+            and surface_p_semantic_post_status == "PASS"
+            and manifest_rc == 0
+            and chain_binding_complete
+        )
+        else "FAIL_CLOSED"
+    )
+
+    return NextFullCanonicalParitySurfaceAssessmentResultV0(
+        assessment_verdict=assessment_verdict,
+        trace_next_unbound_node_before=trace_next_unbound,
+        next_unbound_node=next_unbound_node,
+        selected_surface=SELECTED_SURFACE,
+        plan_type=PLAN_TYPE,
+        surface_p_registry_status=surface_p_registry_status,
+        surface_p_semantic_post_status=surface_p_semantic_post_status,
+        chain_surface_binding_complete=chain_binding_complete,
+        gap_assessment_next_recommended_slice=NEXT_RECOMMENDED_SLICE,
+        blocked_reason=blocked_reason,
+        next_step_after_pr=next_step_after_pr,
+        source_evidence_referenced=source_evidence_referenced,
+        source_manifest_verify_rc=manifest_rc,
+        full_canonical_chain_wired=False,
+        backtest_runtime_decision_parity_pass=False,
+        system_economic_evidence_admissible=False,
+        runtime_rewire_admissible=False,
+        claim_promotion_allowed=False,
+        no_runtime_authority_confirmed=True,
+        no_economic_claim_confirmed=True,
+        fail_closed_reasons=tuple(dict.fromkeys(fail_reasons)),
+    )
+
+
+def next_full_canonical_parity_surface_assessment_to_dict_v0(
+    result: NextFullCanonicalParitySurfaceAssessmentResultV0,
+) -> Mapping[str, object]:
+    return {
+        "assessment_version": NEXT_FULL_CANONICAL_PARITY_SURFACE_ASSESSMENT_LAYER_VERSION,
+        "assessment_owner": NEXT_FULL_CANONICAL_PARITY_SURFACE_ASSESSMENT_OWNER,
+        "assessment_slice_id": ASSESSMENT_SLICE_ID,
+        "assessment_verdict": result.assessment_verdict,
+        "trace_next_unbound_node_before": result.trace_next_unbound_node_before,
+        "next_unbound_node": result.next_unbound_node,
+        "selected_surface": result.selected_surface,
+        "plan_type": result.plan_type,
+        "surface_p_registry_status": result.surface_p_registry_status,
+        "surface_p_semantic_post_status": result.surface_p_semantic_post_status,
+        "chain_surface_binding_complete": result.chain_surface_binding_complete,
+        "gap_assessment_next_recommended_slice": result.gap_assessment_next_recommended_slice,
+        "blocked_reason": result.blocked_reason,
+        "next_step_after_pr": result.next_step_after_pr,
+        "source_evidence_referenced": result.source_evidence_referenced,
+        "source_manifest_verify_rc": result.source_manifest_verify_rc,
+        "full_canonical_chain_wired": result.full_canonical_chain_wired,
+        "backtest_runtime_decision_parity_pass": result.backtest_runtime_decision_parity_pass,
+        "system_economic_evidence_admissible": result.system_economic_evidence_admissible,
+        "runtime_rewire_admissible": result.runtime_rewire_admissible,
+        "claim_promotion_allowed": result.claim_promotion_allowed,
+        "no_runtime_authority_confirmed": result.no_runtime_authority_confirmed,
+        "no_economic_claim_confirmed": result.no_economic_claim_confirmed,
+        "fail_closed_reasons": list(result.fail_closed_reasons),
+    }
+
+
+def render_next_full_canonical_parity_surface_matrix_json_v0(
+    *,
+    repo_root: Path | None = None,
+    pr5023_closeout_dir: Path | None = None,
+    pr5022_proof_bundle_dir: Path | None = None,
+) -> str:
+    result = evaluate_next_full_canonical_parity_surface_after_surface_p_assessment_v0(
+        repo_root=repo_root,
+        pr5023_closeout_dir=pr5023_closeout_dir,
+        pr5022_proof_bundle_dir=pr5022_proof_bundle_dir,
+    )
+    source_refs = collect_source_evidence_refs(
+        pr5023_closeout_dir=pr5023_closeout_dir,
+        pr5022_proof_bundle_dir=pr5022_proof_bundle_dir,
+    )
+    payload = {
+        **dict(next_full_canonical_parity_surface_assessment_to_dict_v0(result)),
+        "source_evidence_refs": [
+            {
+                "evidence_id": ref.evidence_id,
+                "path": ref.path,
+                "present": ref.present,
+                "manifest_present": ref.manifest_present,
+                "manifest_verified": ref.manifest_verified,
+                "detail": ref.detail,
+            }
+            for ref in source_refs
+        ],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def render_next_full_canonical_parity_surface_report_markdown_v0(
+    *,
+    repo_root: Path | None = None,
+    pr5023_closeout_dir: Path | None = None,
+    pr5022_proof_bundle_dir: Path | None = None,
+) -> str:
+    result = evaluate_next_full_canonical_parity_surface_after_surface_p_assessment_v0(
+        repo_root=repo_root,
+        pr5023_closeout_dir=pr5023_closeout_dir,
+        pr5022_proof_bundle_dir=pr5022_proof_bundle_dir,
+    )
+    lines = [
+        "# Next Full Canonical Parity Surface After Surface P Assessment v0",
+        "",
+        "MODE=READ_ONLY_NO_RUNTIME_NO_REWIRE",
+        "",
+        "## Selection",
+        "",
+        f"- trace_next_unbound_node_before: {result.trace_next_unbound_node_before}",
+        f"- next_unbound_node: {result.next_unbound_node}",
+        f"- selected_surface: {result.selected_surface}",
+        f"- plan_type: {result.plan_type}",
+        "",
+        "## Surface P State After PR5023",
+        "",
+        f"- surface_p_registry_status: {result.surface_p_registry_status}",
+        f"- surface_p_semantic_post_status: {result.surface_p_semantic_post_status}",
+        f"- blocked_reason: {result.blocked_reason}",
+        "",
+        "## Chain Status",
+        "",
+        (f"- chain_surface_binding_complete: {str(result.chain_surface_binding_complete).lower()}"),
+        (
+            "- gap_assessment_next_recommended_slice: "
+            f"{result.gap_assessment_next_recommended_slice}"
+        ),
+        "",
+        "## Final Status (fail-closed)",
+        "",
+        f"FULL_CANONICAL_CHAIN_WIRED={str(result.full_canonical_chain_wired).lower()}",
+        (
+            "BACKTEST_RUNTIME_DECISION_PARITY_PASS="
+            f"{str(result.backtest_runtime_decision_parity_pass).lower()}"
+        ),
+        (
+            "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE="
+            f"{str(result.system_economic_evidence_admissible).lower()}"
+        ),
+        f"RUNTIME_REWIRE_ADMISSIBLE={str(result.runtime_rewire_admissible).lower()}",
+        f"CLAIM_PROMOTION_ALLOWED={str(result.claim_promotion_allowed).lower()}",
+        f"NEXT_STEP_AFTER_PR={result.next_step_after_pr}",
+        "NO_RUNTIME_AUTHORITY_CONFIRMED=true",
+        "NO_ECONOMIC_CLAIM_CONFIRMED=true",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def assessment_result_field_names_v0() -> Tuple[str, ...]:
+    return tuple(field.name for field in fields(NextFullCanonicalParitySurfaceAssessmentResultV0))

--- a/tests/trading/master_v2/test_next_full_canonical_parity_surface_after_surface_p_assessment_contract_v0.py
+++ b/tests/trading/master_v2/test_next_full_canonical_parity_surface_after_surface_p_assessment_contract_v0.py
@@ -1,0 +1,206 @@
+"""Next full canonical parity surface after Surface P assessment contract tests."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    NEXT_RECOMMENDED_SLICE,
+    parity_surface_assessments_v0,
+)
+from trading.master_v2.next_full_canonical_parity_surface_after_surface_p_assessment_v0 import (
+    ASSESSMENT_SLICE_ID,
+    DEFAULT_PR5022_PROOF_BUNDLE_EVIDENCE,
+    DEFAULT_PR5023_CLOSEOUT_EVIDENCE,
+    PACKAGE_MARKER,
+    PLAN_TYPE,
+    REASON_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED,
+    SELECTED_SURFACE,
+    assessment_result_field_names_v0,
+    collect_source_evidence_refs,
+    evaluate_next_full_canonical_parity_surface_after_surface_p_assessment_v0,
+    render_next_full_canonical_parity_surface_matrix_json_v0,
+    render_next_full_canonical_parity_surface_report_markdown_v0,
+    resolve_next_unbound_canonical_parity_node_v0,
+    scan_forbidden_positive_claims,
+    verify_source_manifest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/next_full_canonical_parity_surface_after_surface_p_assessment_v0.py",
+    "scripts/ops/run_next_full_canonical_parity_surface_after_surface_p_assessment_v0.py",
+    "tests/trading/master_v2/test_next_full_canonical_parity_surface_after_surface_p_assessment_contract_v0.py",
+)
+
+_SLICE_SOURCE_PATHS = tuple(REPO_ROOT / p for p in _SLICE_CHANGED_FILES if p.endswith(".py"))
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def test_assessment_constants_v0() -> None:
+    assert ASSESSMENT_SLICE_ID == "NEXT_FULL_CANONICAL_PARITY_SURFACE_AFTER_SURFACE_P_ASSESSMENT_V0"
+    assert PACKAGE_MARKER == "NEXT_FULL_CANONICAL_PARITY_SURFACE_AFTER_SURFACE_P_ASSESSMENT_V0=true"
+    assert SELECTED_SURFACE == "FULL_CANONICAL_BACKTEST_BOUNDARY_CHAIN_REASSESSMENT_V0"
+    assert PLAN_TYPE == "ASSESSMENT_ONLY"
+    assert NEXT_RECOMMENDED_SLICE == SELECTED_SURFACE
+
+
+def test_surface_p_registry_partial_semantic_pass_v0() -> None:
+    surface_p = next(item for item in parity_surface_assessments_v0() if item.surface_id == "P")
+    assert surface_p.parity_status == "PARTIAL"
+
+
+def test_resolve_next_unbound_node_when_trace_none_v0() -> None:
+    resolved = resolve_next_unbound_canonical_parity_node_v0(
+        trace_next_unbound_node="NONE",
+        gap_assessment_next_recommended_slice=SELECTED_SURFACE,
+        surface_p_semantic_post_status="PASS",
+    )
+    assert resolved == SELECTED_SURFACE
+
+
+def test_pr5023_source_evidence_manifest_verified_when_available_v0() -> None:
+    closeout = Path(DEFAULT_PR5023_CLOSEOUT_EVIDENCE)
+    proof_bundle = Path(DEFAULT_PR5022_PROOF_BUNDLE_EVIDENCE)
+    if not closeout.is_dir() or not proof_bundle.is_dir():
+        return
+    ok, rc, detail = verify_source_manifest(closeout)
+    assert ok is True
+    assert rc == 0
+    assert detail == "verified"
+    refs = collect_source_evidence_refs(
+        pr5023_closeout_dir=closeout,
+        pr5022_proof_bundle_dir=proof_bundle,
+    )
+    assert all(ref.manifest_verified for ref in refs if ref.present)
+
+
+def test_current_head_assessment_selects_boundary_chain_reassessment_v0() -> None:
+    closeout = Path(DEFAULT_PR5023_CLOSEOUT_EVIDENCE)
+    proof_bundle = Path(DEFAULT_PR5022_PROOF_BUNDLE_EVIDENCE)
+    if not closeout.is_dir():
+        return
+    result = evaluate_next_full_canonical_parity_surface_after_surface_p_assessment_v0(
+        repo_root=REPO_ROOT,
+        pr5023_closeout_dir=closeout,
+        pr5022_proof_bundle_dir=proof_bundle if proof_bundle.is_dir() else None,
+        source_manifest_verify_rc=0,
+    )
+    assert result.assessment_verdict == "PASS"
+    assert result.trace_next_unbound_node_before == "NONE"
+    assert result.next_unbound_node == SELECTED_SURFACE
+    assert result.selected_surface == SELECTED_SURFACE
+    assert result.plan_type == PLAN_TYPE
+    assert result.surface_p_registry_status == "PARTIAL"
+    assert result.surface_p_semantic_post_status == "PASS"
+    assert result.chain_surface_binding_complete is True
+    assert result.blocked_reason == REASON_RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED
+    assert result.next_step_after_pr == "RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_ASSESSMENT_V0"
+
+
+def test_final_success_flags_remain_false_v0() -> None:
+    closeout = Path(DEFAULT_PR5023_CLOSEOUT_EVIDENCE)
+    if not closeout.is_dir():
+        return
+    result = evaluate_next_full_canonical_parity_surface_after_surface_p_assessment_v0(
+        repo_root=REPO_ROOT,
+        pr5023_closeout_dir=closeout,
+        source_manifest_verify_rc=0,
+    )
+    assert result.full_canonical_chain_wired is False
+    assert result.backtest_runtime_decision_parity_pass is False
+    assert result.system_economic_evidence_admissible is False
+    assert result.runtime_rewire_admissible is False
+    assert result.claim_promotion_allowed is False
+    assert result.no_runtime_authority_confirmed is True
+    assert result.no_economic_claim_confirmed is True
+
+
+def test_missing_source_evidence_fails_closed_v0(tmp_path: Path) -> None:
+    result = evaluate_next_full_canonical_parity_surface_after_surface_p_assessment_v0(
+        repo_root=REPO_ROOT,
+        pr5023_closeout_dir=tmp_path / "missing",
+        source_manifest_verify_rc=-1,
+    )
+    assert result.assessment_verdict == "FAIL_CLOSED"
+    assert result.source_evidence_referenced is False
+
+
+def test_matrix_json_schema_v0() -> None:
+    closeout = Path(DEFAULT_PR5023_CLOSEOUT_EVIDENCE)
+    if not closeout.is_dir():
+        return
+    payload = json.loads(
+        render_next_full_canonical_parity_surface_matrix_json_v0(
+            repo_root=REPO_ROOT,
+            pr5023_closeout_dir=closeout,
+        )
+    )
+    assert payload["assessment_slice_id"] == ASSESSMENT_SLICE_ID
+    assert payload["next_unbound_node"] == SELECTED_SURFACE
+    assert payload["selected_surface"] == SELECTED_SURFACE
+    assert payload["plan_type"] == PLAN_TYPE
+    assert payload["full_canonical_chain_wired"] is False
+    assert payload["source_evidence_refs"]
+
+
+def test_report_markdown_documents_selection_v0() -> None:
+    closeout = Path(DEFAULT_PR5023_CLOSEOUT_EVIDENCE)
+    if not closeout.is_dir():
+        return
+    report = render_next_full_canonical_parity_surface_report_markdown_v0(
+        repo_root=REPO_ROOT,
+        pr5023_closeout_dir=closeout,
+    )
+    assert "MODE=READ_ONLY_NO_RUNTIME_NO_REWIRE" in report
+    assert SELECTED_SURFACE in report
+    assert "NO_RUNTIME_AUTHORITY_CONFIRMED=true" in report
+    assert "FULL_CANONICAL_CHAIN_WIRED=false" in report
+
+
+def test_forbidden_positive_claims_scan_clean_v0() -> None:
+    violations = scan_forbidden_positive_claims(REPO_ROOT, list(_SLICE_CHANGED_FILES))
+    assert violations == []
+
+
+def test_slice_sources_exclude_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "execution",
+            "scheduler",
+            "credentials",
+            "live_runtime",
+            "testnet",
+            "shadow",
+            "paper_lane",
+        }
+    )
+    for path in _SLICE_SOURCE_PATHS:
+        assert path.is_file(), f"missing slice source: {path}"
+        hits = _scan_forbidden_imports(path, forbidden)
+        assert hits == [], f"forbidden imports in {path}: {hits}"
+
+
+def test_assessment_result_has_required_fields_v0() -> None:
+    names = assessment_result_field_names_v0()
+    assert "trace_next_unbound_node_before" in names
+    assert "next_unbound_node" in names
+    assert "selected_surface" in names
+    assert "blocked_reason" in names
+    assert "next_step_after_pr" in names


### PR DESCRIPTION
## Summary

- This is no-runtime, no-order, no-credential, no-economic-claim work.
- It continues Full Canonical System Backtest Parity after PR #5023.
- Adds a read-only assessment that consumes trace-matrix `NEXT_UNBOUND_NODE`, gap-assessment `NEXT_RECOMMENDED_SLICE`, and PR5023 Surface P semantic parity evidence to make `FULL_CANONICAL_BACKTEST_BOUNDARY_CHAIN_REASSESSMENT_V0` the explicit next canonical parity work slice.
- Full canonical chain and backtest/runtime parity remain false unless this PR explicitly proves otherwise.
- Runtime evidence remains disallowed before full core completion.

## Assessment outcome

- `NEXT_UNBOUND_NODE_BEFORE=NONE` (all 12 trace surfaces bound)
- `SELECTED_SURFACE=FULL_CANONICAL_BACKTEST_BOUNDARY_CHAIN_REASSESSMENT_V0`
- `PLAN_TYPE=ASSESSMENT_ONLY`
- `BLOCKED_REASON=RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED_BY_POLICY`
- `NEXT_STEP_AFTER_PR=RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_ASSESSMENT_V0`

## Invariants (unchanged)

- `FULL_CANONICAL_CHAIN_WIRED=false`
- `BACKTEST_RUNTIME_DECISION_PARITY_PASS=false`
- `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`
- `RUNTIME_REWIRE_ADMISSIBLE=false`
- `CLAIM_PROMOTION_ALLOWED=false`
- `NO_RUNTIME_AUTHORITY_CONFIRMED=true`
- `NO_ECONOMIC_CLAIM_CONFIRMED=true`

## Test plan

- [x] `pytest -q tests/trading/master_v2/test_next_full_canonical_parity_surface_after_surface_p_assessment_contract_v0.py`
- [x] `pytest -q tests/trading/master_v2/test_surface_p_semantic_parity_gap_assessment_contract_v0.py`
- [x] `pytest -q tests/trading/master_v2/test_full_canonical_system_backtest_parity_gap_assessment_contract_v0.py`
- [x] `pytest -q tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py`
- [x] `ruff check` / `ruff format --check` / `py_compile` on changed Python files
- [x] Durable evidence MANIFEST.sha256 verify RC=0


Made with [Cursor](https://cursor.com)