### PR TITLE
fix: assess runtime bridge boundary gap after pr5025

### DIFF
--- a/scripts/ops/run_runtime_bridge_boundary_gap_assessment_v0.py
+++ b/scripts/ops/run_runtime_bridge_boundary_gap_assessment_v0.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for Runtime Bridge Boundary Gap Assessment v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPT_ROOT = Path(__file__).resolve()
+REPO_ROOT = _SCRIPT_ROOT.parents[2]
+for parent in [_SCRIPT_ROOT, *_SCRIPT_ROOT.parents]:
+    if (parent / "src").is_dir() and (parent / ".git").exists():
+        REPO_ROOT = parent
+        repo_s = str(parent)
+        src_s = str(parent / "src")
+        if repo_s not in sys.path:
+            sys.path.insert(0, repo_s)
+        if src_s not in sys.path:
+            sys.path.insert(0, src_s)
+        break
+
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+DEFAULT_PR5025_SOURCE = (
+    ARCHIVE_ROOT / "research/runtime_bridge_pre_activation_gate_assessment_v0_20260708T234554Z"
+)
+
+VERDICT = "RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_V0_PASS"
+TARGETED_TESTS = (
+    "tests/trading/master_v2/test_runtime_bridge_boundary_gap_assessment_contract_v0.py",
+    "tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_assessment_contract_v0.py",
+    "tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py",
+)
+SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/runtime_bridge_boundary_gap_assessment_v0.py",
+    "scripts/ops/run_runtime_bridge_boundary_gap_assessment_v0.py",
+    "tests/trading/master_v2/test_runtime_bridge_boundary_gap_assessment_contract_v0.py",
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    entries: list[str] = []
+    for path in sorted(evidence_dir.iterdir()):
+        if path.name == "MANIFEST.sha256":
+            continue
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        entries.append(f"{digest}  {path.name}\n")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("".join(entries), encoding="utf-8")
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def _scan_forbidden_claims(changed_files: list[str]) -> tuple[int, list[str]]:
+    from trading.master_v2.runtime_bridge_boundary_gap_assessment_v0 import (
+        scan_forbidden_positive_claims,
+    )
+
+    violations = scan_forbidden_positive_claims(REPO_ROOT, changed_files)
+    return (0 if not violations else 1, violations)
+
+
+def collect_evidence(
+    out_dir: Path | None = None,
+    *,
+    pr5025_source_dir: Path | None = None,
+) -> dict[str, object]:
+    stamp = _utc_stamp()
+    evidence_dir = out_dir or (
+        ARCHIVE_ROOT / f"research/runtime_bridge_boundary_gap_assessment_v0_{stamp}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    source_dir = pr5025_source_dir or DEFAULT_PR5025_SOURCE
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    worktree = _run(["git", "status", "--short"]).stdout.strip()
+    changed = _run(["git", "diff", "--name-only", "origin/main...HEAD"]).stdout.strip()
+
+    (evidence_dir / "operator_intent.env").write_text(
+        "\n".join(
+            [
+                "VERDICT_SCOPE=RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_V0",
+                f"BASE_HEAD={head}",
+                f"ORIGIN_MAIN_HEAD={origin_main}",
+                (
+                    "FEATURE_BRANCH="
+                    "core-system-completion-runtime-bridge-boundary-rewire-or-gap-assessment-v0"
+                ),
+                "MODE=READ_ONLY_ASSESSMENT_FIRST",
+                "NO_RUNTIME_AUTHORITY=true",
+                "NO_RUNTIME_EVIDENCE=true",
+                "NO_ZERO_ORDER_RUNTIME_EVIDENCE=true",
+                "NO_SHADOW=true",
+                "NO_PAPER=true",
+                "NO_TESTNET=true",
+                "NO_CANARY=true",
+                "NO_LIVE=true",
+                "NO_ORDERS=true",
+                "NO_CREDENTIALS=true",
+                "NO_ARMING=true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "git_context.txt").write_text(
+        "\n".join(
+            [
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"WORKTREE_STATUS={worktree or 'clean'}",
+                "ASSESSMENT_SLICE_ID=RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_V0",
+                f"PR5025_SOURCE_PATH={source_dir}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "changed_files.txt").write_text(
+        (changed + "\n") if changed else "(no committed diff vs origin/main yet)\n",
+        encoding="utf-8",
+    )
+
+    source_proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=source_dir)
+    source_rc = source_proc.returncode
+    (evidence_dir / "source_manifest_verify.txt").write_text(
+        source_proc.stdout + source_proc.stderr + f"\nSOURCE_MANIFEST_VERIFY_RC={source_rc}\n",
+        encoding="utf-8",
+    )
+
+    from trading.master_v2.runtime_bridge_boundary_gap_assessment_v0 import (
+        evaluate_runtime_bridge_boundary_gap_assessment_v0,
+        render_runtime_bridge_boundary_gap_matrix_json_v0,
+        render_runtime_bridge_boundary_gap_report_markdown_v0,
+        runtime_bridge_boundary_gap_assessment_to_dict_v0,
+    )
+
+    assessment = evaluate_runtime_bridge_boundary_gap_assessment_v0(
+        repo_root=REPO_ROOT,
+        pr5025_source_dir=source_dir,
+        source_manifest_verify_rc=source_rc,
+    )
+    (evidence_dir / "runtime_bridge_boundary_gap_matrix.json").write_text(
+        render_runtime_bridge_boundary_gap_matrix_json_v0(
+            repo_root=REPO_ROOT,
+            pr5025_source_dir=source_dir,
+        ),
+        encoding="utf-8",
+    )
+    (evidence_dir / "runtime_bridge_boundary_gap_assessment_v0.md").write_text(
+        render_runtime_bridge_boundary_gap_report_markdown_v0(
+            repo_root=REPO_ROOT,
+            pr5025_source_dir=source_dir,
+        ),
+        encoding="utf-8",
+    )
+    (evidence_dir / "assessment_result.json").write_text(
+        json.dumps(
+            runtime_bridge_boundary_gap_assessment_to_dict_v0(assessment),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = {
+        **dict(__import__("os").environ),
+        "PYTHONPATH": f"{REPO_ROOT / 'src'}:{REPO_ROOT}",
+    }
+    pytest_proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    (evidence_dir / "targeted_pytest.txt").write_text(
+        pytest_proc.stdout + pytest_proc.stderr + f"\nTARGETED_TESTS_RC={pytest_proc.returncode}\n",
+        encoding="utf-8",
+    )
+
+    ruff_targets = [str(REPO_ROOT / p) for p in SLICE_CHANGED_FILES if p.endswith(".py")]
+    ruff_format = _run([sys.executable, "-m", "ruff", "format", "--check", *ruff_targets])
+    ruff_check = _run([sys.executable, "-m", "ruff", "check", *ruff_targets])
+    (evidence_dir / "ruff_format_check.txt").write_text(
+        ruff_format.stdout + ruff_format.stderr + f"\nRUFF_FORMAT_RC={ruff_format.returncode}\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "ruff_check.txt").write_text(
+        ruff_check.stdout + ruff_check.stderr + f"\nRUFF_CHECK_RC={ruff_check.returncode}\n",
+        encoding="utf-8",
+    )
+
+    compile_lines: list[str] = []
+    compile_rc = 0
+    for rel in SLICE_CHANGED_FILES:
+        if not rel.endswith(".py"):
+            continue
+        proc = _run([sys.executable, "-m", "py_compile", str(REPO_ROOT / rel)])
+        compile_lines.append(f"=== {rel} RC={proc.returncode} ===")
+        compile_lines.append(proc.stdout)
+        compile_lines.append(proc.stderr)
+        if proc.returncode != 0:
+            compile_rc = proc.returncode
+    (evidence_dir / "py_compile.txt").write_text(
+        "\n".join(compile_lines) + f"\nPY_COMPILE_RC={compile_rc}\n",
+        encoding="utf-8",
+    )
+
+    forbidden_rc, forbidden_violations = _scan_forbidden_claims(list(SLICE_CHANGED_FILES))
+    (evidence_dir / "forbidden_claims_scan.txt").write_text(
+        "\n".join(
+            [
+                f"FORBIDDEN_CLAIMS_SCAN_RC={forbidden_rc}",
+                *forbidden_violations,
+                "NO_RUNTIME_AUTHORITY_CONFIRMED=true",
+                "NO_ECONOMIC_CLAIM_CONFIRMED=true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    blocked = (
+        pytest_proc.returncode != 0
+        or ruff_format.returncode != 0
+        or ruff_check.returncode != 0
+        or compile_rc != 0
+        or forbidden_rc != 0
+        or source_rc != 0
+        or assessment.assessment_verdict != "PASS"
+        or assessment.narrow_rewire_justified
+        or assessment.narrow_rewire_admissible
+        or assessment.runtime_bridge_activation_admissible
+        or assessment.runtime_bridge_pre_activation_gate_status != "FAIL"
+        or assessment.full_canonical_chain_wired
+        or assessment.backtest_runtime_decision_parity_pass
+        or assessment.system_economic_evidence_admissible
+        or assessment.runtime_rewire_admissible
+        or assessment.claim_promotion_allowed
+    )
+    verdict = VERDICT if not blocked else "RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_V0_BLOCKED"
+
+    (evidence_dir / "final_report.txt").write_text(
+        "\n".join(
+            [
+                f"VERDICT={verdict}",
+                f"BASE_HEAD={head}",
+                f"POST_BRANCH_HEAD={head}",
+                (
+                    "BRANCH_NAME="
+                    "core-system-completion-runtime-bridge-boundary-rewire-or-gap-assessment-v0"
+                ),
+                f"BOUNDARY_GAP_STATUS={assessment.boundary_gap_status}",
+                f"PLAN_TYPE={assessment.plan_type}",
+                f"NARROW_REWIRE_JUSTIFIED={str(assessment.narrow_rewire_justified).lower()}",
+                f"NARROW_REWIRE_ADMISSIBLE={str(assessment.narrow_rewire_admissible).lower()}",
+                f"TRACE_NEXT_UNBOUND_NODE={assessment.trace_next_unbound_node}",
+                (
+                    "CHAIN_SURFACE_BINDING_COMPLETE="
+                    f"{str(assessment.chain_surface_binding_complete).lower()}"
+                ),
+                f"RUNTIME_BRIDGE_BOUNDARY_STATUS={assessment.runtime_bridge_boundary_status}",
+                (
+                    "RUNTIME_BRIDGE_PRE_ACTIVATION_GATE_STATUS="
+                    f"{assessment.runtime_bridge_pre_activation_gate_status}"
+                ),
+                (
+                    "RUNTIME_BRIDGE_ACTIVATION_ADMISSIBLE="
+                    f"{str(assessment.runtime_bridge_activation_admissible).lower()}"
+                ),
+                f"PRIMARY_BLOCKER={assessment.primary_blocker}",
+                f"SURFACE_P_REGISTRY_STATUS={assessment.surface_p_registry_status}",
+                f"SURFACE_P_SEMANTIC_POST_STATUS={assessment.surface_p_semantic_post_status}",
+                f"SOURCE_MANIFEST_VERIFY_RC={source_rc}",
+                f"FULL_CANONICAL_CHAIN_WIRED={str(assessment.full_canonical_chain_wired).lower()}",
+                (
+                    "BACKTEST_RUNTIME_DECISION_PARITY_PASS="
+                    f"{str(assessment.backtest_runtime_decision_parity_pass).lower()}"
+                ),
+                (
+                    "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE="
+                    f"{str(assessment.system_economic_evidence_admissible).lower()}"
+                ),
+                f"RUNTIME_REWIRE_ADMISSIBLE={str(assessment.runtime_rewire_admissible).lower()}",
+                f"CLAIM_PROMOTION_ALLOWED={str(assessment.claim_promotion_allowed).lower()}",
+                "NO_RUNTIME_AUTHORITY_CONFIRMED=true",
+                "NO_ECONOMIC_CLAIM_CONFIRMED=true",
+                (
+                    "NO_RUNTIME_EVIDENCE_BEFORE_CORE_SYSTEM_COMPLETE="
+                    f"{str(assessment.no_runtime_evidence_before_core_system_complete).lower()}"
+                ),
+                f"DURABLE_EVIDENCE_DIR={evidence_dir}",
+                f"NEXT_STEP_AFTER_PR={assessment.next_step_after_pr}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc = _write_manifest(evidence_dir)
+    (evidence_dir / "final_report.txt").write_text(
+        (evidence_dir / "final_report.txt").read_text(encoding="utf-8")
+        + f"MANIFEST_VERIFY_RC={manifest_rc}\n",
+        encoding="utf-8",
+    )
+    manifest_rc = _write_manifest(evidence_dir)
+
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_verify_rc": manifest_rc,
+        "pytest_rc": pytest_proc.returncode,
+        "source_manifest_verify_rc": source_rc,
+        "ruff_rc": ruff_check.returncode,
+        "ruff_format_rc": ruff_format.returncode,
+        "py_compile_rc": compile_rc,
+        "forbidden_rc": forbidden_rc,
+        "assessment": assessment,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, default=None)
+    parser.add_argument("--pr5025-source", type=Path, default=None)
+    args = parser.parse_args()
+    result = collect_evidence(args.out, pr5025_source_dir=args.pr5025_source)
+    print(result["verdict"])
+    print(f"EVIDENCE_DIR={result['evidence_dir']}")
+    print(f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}")
+    return 0 if result["verdict"] == VERDICT else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -108,6 +108,9 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/runtime_bridge_pre_activation_gate_assessment_v0.py",
     "scripts/ops/run_runtime_bridge_pre_activation_gate_assessment_v0.py",
     "tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_assessment_contract_v0.py",
+    "src/trading/master_v2/runtime_bridge_boundary_gap_assessment_v0.py",
+    "scripts/ops/run_runtime_bridge_boundary_gap_assessment_v0.py",
+    "tests/trading/master_v2/test_runtime_bridge_boundary_gap_assessment_contract_v0.py",
 )
 
 FORBIDDEN_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (

--- a/src/trading/master_v2/runtime_bridge_boundary_gap_assessment_v0.py
+++ b/src/trading/master_v2/runtime_bridge_boundary_gap_assessment_v0.py
@@ -1,0 +1,572 @@
+"""
+Runtime Bridge Boundary Gap Assessment v0.
+
+Read-only assessment documenting the remaining runtime-bridge boundary gap after
+PR #5025 pre-activation gate assessment. Consumes manifest-verified PR5025 source
+evidence, evaluates trace-chain binding completeness, and determines whether a
+narrow reuse-first offline boundary rewire is justified without activating runtime,
+granting order authority, or promoting final success flags.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Literal, Mapping, Tuple
+
+RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_LAYER_VERSION = "v0"
+RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_OWNER = (
+    "trading.master_v2.runtime_bridge_boundary_gap_assessment_v0"
+)
+ASSESSMENT_SLICE_ID = "RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_V0"
+PACKAGE_MARKER = "RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_V0=true"
+
+DEFAULT_PR5025_SOURCE_EVIDENCE = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "research/runtime_bridge_pre_activation_gate_assessment_v0_20260708T234554Z"
+)
+
+AssessmentVerdict = Literal["PASS", "FAIL_CLOSED"]
+PlanType = Literal["ASSESSMENT_ONLY", "NARROW_REUSE_FIRST_REWIRE"]
+BoundaryGapStatus = Literal[
+    "FAIL_CLOSED_DOCUMENTED",
+    "UNEXPECTED_REWIRE_JUSTIFIED",
+    "EVALUATION_ERROR",
+]
+
+REASON_SOURCE_MANIFEST_UNVERIFIED = "SOURCE_EVIDENCE_MANIFEST_NOT_VERIFIED"
+REASON_PR5025_SOURCE_MISSING = "PR5025_PRE_ACTIVATION_GATE_ASSESSMENT_EVIDENCE_MISSING"
+REASON_PRE_ACTIVATION_GATE_NOT_DOCUMENTED = "PRE_ACTIVATION_GATE_NOT_FAIL_CLOSED_DOCUMENTED"
+REASON_TRACE_CHAIN_INCOMPLETE = "TRACE_CHAIN_SURFACE_BINDING_INCOMPLETE"
+REASON_RUNTIME_BRIDGE_NOT_BOUND = "RUNTIME_BRIDGE_NOT_BOUND_NOT_ACTIVATED"
+REASON_OFFLINE_PARITY_INCOMPLETE = "OFFLINE_PARITY_NOT_COMPLETE"
+REASON_NARROW_REWIRE_UNEXPECTEDLY_JUSTIFIED = "NARROW_REWIRE_JUSTIFIED_UNEXPECTED_AT_CURRENT_HEAD"
+
+FORBIDDEN_POSITIVE_CLAIM_LITERALS = (
+    "FULL_CANONICAL_CHAIN_WIRED=true",
+    "BACKTEST_RUNTIME_DECISION_PARITY_PASS=true",
+    "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=true",
+    "RUNTIME_REWIRE_ADMISSIBLE=true",
+    "CLAIM_PROMOTION_ALLOWED=true",
+    "RUNTIME_BRIDGE_ACTIVATION_ADMISSIBLE=true",
+    "NARROW_REWIRE_JUSTIFIED=true",
+)
+
+FORBIDDEN_POSITIVE_ASSIGNMENT_RES = (
+    re.compile(r"FULL_CANONICAL_CHAIN_WIRED\s*=\s*True\b"),
+    re.compile(r"BACKTEST_RUNTIME_DECISION_PARITY_PASS\s*=\s*True\b"),
+    re.compile(r"SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE\s*=\s*True\b"),
+    re.compile(r"RUNTIME_REWIRE_ADMISSIBLE\s*=\s*True\b"),
+    re.compile(r"CLAIM_PROMOTION_ALLOWED\s*=\s*True\b"),
+    re.compile(r"RUNTIME_BRIDGE_ACTIVATION_ADMISSIBLE\s*=\s*True\b"),
+    re.compile(r"NARROW_REWIRE_JUSTIFIED\s*=\s*True\b"),
+    re.compile(r'"full_canonical_chain_wired"\s*:\s*true\b'),
+    re.compile(r'"backtest_runtime_decision_parity_pass"\s*:\s*true\b'),
+    re.compile(r'"system_economic_evidence_admissible"\s*:\s*true\b'),
+    re.compile(r'"runtime_rewire_admissible"\s*:\s*true\b'),
+    re.compile(r'"claim_promotion_allowed"\s*:\s*true\b'),
+    re.compile(r'"runtime_bridge_activation_admissible"\s*:\s*true\b'),
+    re.compile(r'"narrow_rewire_justified"\s*:\s*true\b'),
+)
+
+_CONTEXT_PROTECTED_MARKERS = (
+    "forbidden_claims",
+    "FORBIDDEN_POSITIVE_CLAIM",
+    "FORBIDDEN_POSITIVE_ASSIGNMENT",
+    '_claimed": False',
+    "is False",
+    "== False",
+    "!= True",
+    "assert ",
+    "# ",
+    '"""',
+    "'''",
+    "unless fully proven",
+    "denylist",
+    "needle",
+)
+
+
+@dataclass(frozen=True)
+class SourceEvidenceRefV0:
+    evidence_id: str
+    path: str
+    present: bool
+    manifest_present: bool
+    manifest_verified: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class RuntimeBridgeBoundaryGapAssessmentResultV0:
+    assessment_verdict: AssessmentVerdict
+    boundary_gap_status: BoundaryGapStatus
+    plan_type: PlanType
+    narrow_rewire_justified: bool
+    narrow_rewire_admissible: bool
+    trace_next_unbound_node: str
+    chain_surface_binding_complete: bool
+    runtime_bridge_boundary_status: str
+    runtime_bridge_pre_activation_gate_status: str
+    runtime_bridge_activation_admissible: bool
+    offline_parity_complete_runtime_activation_pending: bool
+    surface_p_registry_status: str
+    surface_p_semantic_post_status: str
+    canonical_runtime_entrypoint_status: str
+    blocking_reasons: Tuple[str, ...]
+    required_next_gates: Tuple[str, ...]
+    primary_blocker: str
+    next_step_after_pr: str
+    source_evidence_referenced: bool
+    source_manifest_verify_rc: int
+    full_canonical_chain_wired: bool
+    backtest_runtime_decision_parity_pass: bool
+    system_economic_evidence_admissible: bool
+    runtime_rewire_admissible: bool
+    claim_promotion_allowed: bool
+    no_runtime_authority_confirmed: bool
+    no_economic_claim_confirmed: bool
+    no_runtime_evidence_before_core_system_complete: bool
+    fail_closed_reasons: Tuple[str, ...]
+
+
+def _line_context_protected(line: str) -> bool:
+    lowered = line.lower()
+    for marker in _CONTEXT_PROTECTED_MARKERS:
+        if marker in line or marker in lowered:
+            return True
+    for literal in FORBIDDEN_POSITIVE_CLAIM_LITERALS:
+        if literal in line and ("forbidden" in lowered or "deny" in lowered or "needle" in lowered):
+            return True
+    return False
+
+
+def scan_forbidden_positive_claims(repo_root: Path, changed_files: list[str]) -> list[str]:
+    violations: list[str] = []
+    for rel in changed_files:
+        path = repo_root / rel
+        if not path.is_file() or path.suffix != ".py":
+            continue
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if _line_context_protected(line):
+                continue
+            for pattern in FORBIDDEN_POSITIVE_ASSIGNMENT_RES:
+                if pattern.search(line):
+                    violations.append(f"{rel}:{line_no}: {line.strip()}")
+    return violations
+
+
+def verify_source_manifest(evidence_dir: Path) -> tuple[bool, int, str]:
+    manifest = evidence_dir / "MANIFEST.sha256"
+    if not evidence_dir.is_dir():
+        return False, -1, "directory_missing"
+    if not manifest.is_file():
+        return False, -1, "manifest_missing"
+    rows = manifest.read_text(encoding="utf-8").splitlines()
+    for row in rows:
+        if not row.strip():
+            continue
+        digest, rel = row.split("  ", 1)
+        target = evidence_dir / rel
+        if not target.is_file():
+            return False, 1, f"missing_file:{rel}"
+        import hashlib
+
+        actual = hashlib.sha256(target.read_bytes()).hexdigest()
+        if actual != digest:
+            return False, 1, f"digest_mismatch:{rel}"
+    return True, 0, "verified"
+
+
+def collect_source_evidence_refs(
+    *,
+    pr5025_source_dir: Path | None = None,
+) -> Tuple[SourceEvidenceRefV0, ...]:
+    source = pr5025_source_dir or Path(DEFAULT_PR5025_SOURCE_EVIDENCE)
+    present = source.is_dir()
+    manifest_present = present and (source / "MANIFEST.sha256").is_file()
+    if manifest_present:
+        verified, rc, detail = verify_source_manifest(source)
+        return (
+            SourceEvidenceRefV0(
+                evidence_id="pr5025_pre_activation_gate_assessment",
+                path=str(source),
+                present=True,
+                manifest_present=True,
+                manifest_verified=verified,
+                detail=detail if verified else f"rc={rc}:{detail}",
+            ),
+        )
+    return (
+        SourceEvidenceRefV0(
+            evidence_id="pr5025_pre_activation_gate_assessment",
+            path=str(source),
+            present=present,
+            manifest_present=False,
+            manifest_verified=False,
+            detail="missing" if not present else "manifest_missing",
+        ),
+    )
+
+
+def _trace_matrix_snapshot_v0(repo_root: Path) -> tuple[str, bool]:
+    from scripts.research.backtest_runtime_decision_parity_inventory_v0 import build_inventory
+    from scripts.research.backtest_runtime_decision_parity_trace_matrix_v0 import (
+        build_trace_matrix,
+        compute_chain_surface_binding_complete,
+        compute_next_unbound_node,
+    )
+
+    inventory = build_inventory(repo_root)
+    matrix = build_trace_matrix(inventory)
+    edges = matrix["trace_edges"]
+    return (
+        compute_next_unbound_node(edges),
+        compute_chain_surface_binding_complete(edges),
+    )
+
+
+def _narrow_rewire_justified_v0(
+    *,
+    trace_next_unbound_node: str,
+    chain_surface_binding_complete: bool,
+    offline_parity_complete_runtime_activation_pending: bool,
+    runtime_bridge_boundary_status: str,
+) -> bool:
+    """True only when a concrete offline trace/boundary node remains unbound."""
+    if trace_next_unbound_node != "NONE":
+        return True
+    if not chain_surface_binding_complete:
+        return True
+    if (
+        offline_parity_complete_runtime_activation_pending
+        and runtime_bridge_boundary_status == "BOUND_NOT_ACTIVATED"
+    ):
+        return False
+    return False
+
+
+def evaluate_runtime_bridge_boundary_gap_assessment_v0(
+    *,
+    repo_root: Path | None = None,
+    pr5025_source_dir: Path | None = None,
+    source_manifest_verify_rc: int | None = None,
+) -> RuntimeBridgeBoundaryGapAssessmentResultV0:
+    """Document runtime-bridge boundary gap; never grants runtime authority."""
+    from trading.master_v2.canonical_core_runtime_integration_bridge_v0 import (
+        INTEGRATION_STATUS_BOUND_NOT_ACTIVATED,
+    )
+    from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+        NEXT_RECOMMENDED_SLICE,
+        parity_surface_assessments_v0,
+    )
+    from trading.master_v2.legacy_runtime_entrypoint_guard_v0 import (
+        CANONICAL_RUNTIME_ENTRYPOINT_STATUS,
+    )
+    from trading.master_v2.runtime_bridge_pre_activation_gate_assessment_v0 import (
+        evaluate_runtime_bridge_pre_activation_gate_assessment_v0,
+    )
+    from trading.master_v2.surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0 import (
+        surface_p_offline_parity_complete_runtime_activation_pending_v0,
+    )
+    from trading.master_v2.surface_p_semantic_parity_gap_assessment_v0 import (
+        DEFAULT_PR5022_PROOF_BUNDLE_EVIDENCE,
+        evaluate_surface_p_semantic_parity_gap_assessment_v0,
+    )
+
+    root = repo_root or Path(__file__).resolve().parents[3]
+    fail_reasons: list[str] = []
+    source_refs = collect_source_evidence_refs(pr5025_source_dir=pr5025_source_dir)
+    source_ref = source_refs[0]
+    source_evidence_referenced = source_ref.present
+    manifest_rc = (
+        source_manifest_verify_rc
+        if source_manifest_verify_rc is not None
+        else (0 if source_ref.manifest_verified else -1)
+    )
+    if not source_ref.present:
+        fail_reasons.append(REASON_PR5025_SOURCE_MISSING)
+    elif manifest_rc != 0:
+        fail_reasons.append(REASON_SOURCE_MANIFEST_UNVERIFIED)
+
+    pre_activation = evaluate_runtime_bridge_pre_activation_gate_assessment_v0(
+        source_manifest_verify_rc=manifest_rc if manifest_rc != -1 else None,
+    )
+    if pre_activation.assessment_verdict != "PASS":
+        fail_reasons.append(REASON_PRE_ACTIVATION_GATE_NOT_DOCUMENTED)
+    if pre_activation.runtime_bridge_pre_activation_gate_status != "FAIL":
+        fail_reasons.append(REASON_PRE_ACTIVATION_GATE_NOT_DOCUMENTED)
+
+    trace_next_unbound, chain_binding_complete = _trace_matrix_snapshot_v0(root)
+    if not chain_binding_complete:
+        fail_reasons.append(REASON_TRACE_CHAIN_INCOMPLETE)
+
+    surface_p = next(item for item in parity_surface_assessments_v0() if item.surface_id == "P")
+    surface_p_registry_status = surface_p.parity_status
+
+    proof_bundle = Path(DEFAULT_PR5022_PROOF_BUNDLE_EVIDENCE)
+    semantic = evaluate_surface_p_semantic_parity_gap_assessment_v0(
+        pr5022_proof_bundle_dir=proof_bundle if proof_bundle.is_dir() else None,
+        source_manifest_verify_rc=manifest_rc if manifest_rc != -1 else None,
+    )
+    surface_p_semantic_post_status = semantic.surface_p_post_status
+    if not semantic.offline_four_way_fixtures_complete:
+        fail_reasons.append(REASON_OFFLINE_PARITY_INCOMPLETE)
+
+    offline_pending = surface_p_offline_parity_complete_runtime_activation_pending_v0()
+    runtime_bridge_boundary_status = CANONICAL_RUNTIME_ENTRYPOINT_STATUS
+    if runtime_bridge_boundary_status != INTEGRATION_STATUS_BOUND_NOT_ACTIVATED:
+        fail_reasons.append(REASON_RUNTIME_BRIDGE_NOT_BOUND)
+
+    narrow_rewire_justified = _narrow_rewire_justified_v0(
+        trace_next_unbound_node=trace_next_unbound,
+        chain_surface_binding_complete=chain_binding_complete,
+        offline_parity_complete_runtime_activation_pending=offline_pending,
+        runtime_bridge_boundary_status=runtime_bridge_boundary_status,
+    )
+    if narrow_rewire_justified:
+        fail_reasons.append(REASON_NARROW_REWIRE_UNEXPECTEDLY_JUSTIFIED)
+
+    plan_type: PlanType = (
+        "NARROW_REUSE_FIRST_REWIRE" if narrow_rewire_justified else "ASSESSMENT_ONLY"
+    )
+    if narrow_rewire_justified:
+        boundary_gap_status: BoundaryGapStatus = "UNEXPECTED_REWIRE_JUSTIFIED"
+    elif (
+        pre_activation.gate_assessment_status == "FAIL_CLOSED_DOCUMENTED"
+        and chain_binding_complete
+        and trace_next_unbound == "NONE"
+        and offline_pending
+        and runtime_bridge_boundary_status == INTEGRATION_STATUS_BOUND_NOT_ACTIVATED
+    ):
+        boundary_gap_status = "FAIL_CLOSED_DOCUMENTED"
+    else:
+        boundary_gap_status = "EVALUATION_ERROR"
+
+    primary_blocker = pre_activation.primary_blocker
+    next_step_after_pr = (
+        NEXT_RECOMMENDED_SLICE if not narrow_rewire_justified else trace_next_unbound
+    )
+
+    assessment_verdict: AssessmentVerdict = (
+        "PASS"
+        if (
+            boundary_gap_status == "FAIL_CLOSED_DOCUMENTED"
+            and plan_type == "ASSESSMENT_ONLY"
+            and not narrow_rewire_justified
+            and manifest_rc == 0
+            and pre_activation.runtime_bridge_pre_activation_gate_status == "FAIL"
+            and not pre_activation.runtime_bridge_activation_admissible
+            and pre_activation.no_runtime_authority_confirmed
+            and pre_activation.no_economic_claim_confirmed
+        )
+        else "FAIL_CLOSED"
+    )
+
+    return RuntimeBridgeBoundaryGapAssessmentResultV0(
+        assessment_verdict=assessment_verdict,
+        boundary_gap_status=boundary_gap_status,
+        plan_type=plan_type,
+        narrow_rewire_justified=narrow_rewire_justified,
+        narrow_rewire_admissible=False,
+        trace_next_unbound_node=trace_next_unbound,
+        chain_surface_binding_complete=chain_binding_complete,
+        runtime_bridge_boundary_status=runtime_bridge_boundary_status,
+        runtime_bridge_pre_activation_gate_status=(
+            pre_activation.runtime_bridge_pre_activation_gate_status
+        ),
+        runtime_bridge_activation_admissible=pre_activation.runtime_bridge_activation_admissible,
+        offline_parity_complete_runtime_activation_pending=offline_pending,
+        surface_p_registry_status=surface_p_registry_status,
+        surface_p_semantic_post_status=surface_p_semantic_post_status,
+        canonical_runtime_entrypoint_status=CANONICAL_RUNTIME_ENTRYPOINT_STATUS,
+        blocking_reasons=pre_activation.blocking_reasons,
+        required_next_gates=pre_activation.required_next_gates,
+        primary_blocker=primary_blocker,
+        next_step_after_pr=next_step_after_pr,
+        source_evidence_referenced=source_evidence_referenced,
+        source_manifest_verify_rc=manifest_rc,
+        full_canonical_chain_wired=False,
+        backtest_runtime_decision_parity_pass=False,
+        system_economic_evidence_admissible=False,
+        runtime_rewire_admissible=False,
+        claim_promotion_allowed=False,
+        no_runtime_authority_confirmed=True,
+        no_economic_claim_confirmed=True,
+        no_runtime_evidence_before_core_system_complete=True,
+        fail_closed_reasons=tuple(dict.fromkeys(fail_reasons)),
+    )
+
+
+def runtime_bridge_boundary_gap_assessment_to_dict_v0(
+    result: RuntimeBridgeBoundaryGapAssessmentResultV0,
+) -> Mapping[str, object]:
+    return {
+        "assessment_version": RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_LAYER_VERSION,
+        "assessment_owner": RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_OWNER,
+        "assessment_slice_id": ASSESSMENT_SLICE_ID,
+        "assessment_verdict": result.assessment_verdict,
+        "boundary_gap_status": result.boundary_gap_status,
+        "plan_type": result.plan_type,
+        "narrow_rewire_justified": result.narrow_rewire_justified,
+        "narrow_rewire_admissible": result.narrow_rewire_admissible,
+        "trace_next_unbound_node": result.trace_next_unbound_node,
+        "chain_surface_binding_complete": result.chain_surface_binding_complete,
+        "runtime_bridge_boundary_status": result.runtime_bridge_boundary_status,
+        "runtime_bridge_pre_activation_gate_status": (
+            result.runtime_bridge_pre_activation_gate_status
+        ),
+        "runtime_bridge_activation_admissible": result.runtime_bridge_activation_admissible,
+        "offline_parity_complete_runtime_activation_pending": (
+            result.offline_parity_complete_runtime_activation_pending
+        ),
+        "surface_p_registry_status": result.surface_p_registry_status,
+        "surface_p_semantic_post_status": result.surface_p_semantic_post_status,
+        "canonical_runtime_entrypoint_status": result.canonical_runtime_entrypoint_status,
+        "blocking_reasons": list(result.blocking_reasons),
+        "required_next_gates": list(result.required_next_gates),
+        "primary_blocker": result.primary_blocker,
+        "next_step_after_pr": result.next_step_after_pr,
+        "source_evidence_referenced": result.source_evidence_referenced,
+        "source_manifest_verify_rc": result.source_manifest_verify_rc,
+        "full_canonical_chain_wired": result.full_canonical_chain_wired,
+        "backtest_runtime_decision_parity_pass": result.backtest_runtime_decision_parity_pass,
+        "system_economic_evidence_admissible": result.system_economic_evidence_admissible,
+        "runtime_rewire_admissible": result.runtime_rewire_admissible,
+        "claim_promotion_allowed": result.claim_promotion_allowed,
+        "no_runtime_authority_confirmed": result.no_runtime_authority_confirmed,
+        "no_economic_claim_confirmed": result.no_economic_claim_confirmed,
+        "no_runtime_evidence_before_core_system_complete": (
+            result.no_runtime_evidence_before_core_system_complete
+        ),
+        "fail_closed_reasons": list(result.fail_closed_reasons),
+    }
+
+
+def render_runtime_bridge_boundary_gap_matrix_json_v0(
+    *,
+    repo_root: Path | None = None,
+    pr5025_source_dir: Path | None = None,
+) -> str:
+    result = evaluate_runtime_bridge_boundary_gap_assessment_v0(
+        repo_root=repo_root,
+        pr5025_source_dir=pr5025_source_dir,
+    )
+    source_refs = collect_source_evidence_refs(pr5025_source_dir=pr5025_source_dir)
+    payload = {
+        **dict(runtime_bridge_boundary_gap_assessment_to_dict_v0(result)),
+        "source_evidence_refs": [
+            {
+                "evidence_id": ref.evidence_id,
+                "path": ref.path,
+                "present": ref.present,
+                "manifest_present": ref.manifest_present,
+                "manifest_verified": ref.manifest_verified,
+                "detail": ref.detail,
+            }
+            for ref in source_refs
+        ],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def render_runtime_bridge_boundary_gap_report_markdown_v0(
+    *,
+    repo_root: Path | None = None,
+    pr5025_source_dir: Path | None = None,
+) -> str:
+    result = evaluate_runtime_bridge_boundary_gap_assessment_v0(
+        repo_root=repo_root,
+        pr5025_source_dir=pr5025_source_dir,
+    )
+    lines = [
+        "# Runtime Bridge Boundary Gap Assessment v0",
+        "",
+        "MODE=READ_ONLY_NO_RUNTIME_NO_REWIRE",
+        "",
+        "## Verdict",
+        "",
+        f"- assessment_verdict: {result.assessment_verdict}",
+        f"- boundary_gap_status: {result.boundary_gap_status}",
+        f"- plan_type: {result.plan_type}",
+        f"- narrow_rewire_justified: {str(result.narrow_rewire_justified).lower()}",
+        f"- narrow_rewire_admissible: {str(result.narrow_rewire_admissible).lower()}",
+        "",
+        "## Trace / Boundary Context",
+        "",
+        f"- trace_next_unbound_node: {result.trace_next_unbound_node}",
+        (f"- chain_surface_binding_complete: {str(result.chain_surface_binding_complete).lower()}"),
+        f"- runtime_bridge_boundary_status: {result.runtime_bridge_boundary_status}",
+        (
+            "- offline_parity_complete_runtime_activation_pending: "
+            f"{str(result.offline_parity_complete_runtime_activation_pending).lower()}"
+        ),
+        "",
+        "## Pre-Activation Gate Context",
+        "",
+        (
+            "- runtime_bridge_pre_activation_gate_status: "
+            f"{result.runtime_bridge_pre_activation_gate_status}"
+        ),
+        (
+            "- runtime_bridge_activation_admissible: "
+            f"{str(result.runtime_bridge_activation_admissible).lower()}"
+        ),
+        f"- primary_blocker: {result.primary_blocker}",
+        "",
+        "## Surface P Context",
+        "",
+        f"- surface_p_registry_status: {result.surface_p_registry_status}",
+        f"- surface_p_semantic_post_status: {result.surface_p_semantic_post_status}",
+        f"- canonical_runtime_entrypoint_status: {result.canonical_runtime_entrypoint_status}",
+        "",
+        "## Blocking Reasons",
+        "",
+    ]
+    if result.blocking_reasons:
+        lines.extend(f"- {item}" for item in result.blocking_reasons)
+    else:
+        lines.append("- NONE")
+    lines.extend(
+        [
+            "",
+            "## Required Next Gates",
+            "",
+        ]
+    )
+    if result.required_next_gates:
+        lines.extend(f"- {item}" for item in result.required_next_gates)
+    else:
+        lines.append("- NONE")
+    lines.extend(
+        [
+            "",
+            "## Final Status (fail-closed)",
+            "",
+            f"FULL_CANONICAL_CHAIN_WIRED={str(result.full_canonical_chain_wired).lower()}",
+            (
+                "BACKTEST_RUNTIME_DECISION_PARITY_PASS="
+                f"{str(result.backtest_runtime_decision_parity_pass).lower()}"
+            ),
+            (
+                "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE="
+                f"{str(result.system_economic_evidence_admissible).lower()}"
+            ),
+            f"RUNTIME_REWIRE_ADMISSIBLE={str(result.runtime_rewire_admissible).lower()}",
+            f"CLAIM_PROMOTION_ALLOWED={str(result.claim_promotion_allowed).lower()}",
+            (
+                "NO_RUNTIME_EVIDENCE_BEFORE_CORE_SYSTEM_COMPLETE="
+                f"{str(result.no_runtime_evidence_before_core_system_complete).lower()}"
+            ),
+            f"NEXT_STEP_AFTER_PR={result.next_step_after_pr}",
+            "NO_RUNTIME_AUTHORITY_CONFIRMED=true",
+            "NO_ECONOMIC_CLAIM_CONFIRMED=true",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def assessment_result_field_names_v0() -> Tuple[str, ...]:
+    return tuple(field.name for field in fields(RuntimeBridgeBoundaryGapAssessmentResultV0))

--- a/tests/trading/master_v2/test_runtime_bridge_boundary_gap_assessment_contract_v0.py
+++ b/tests/trading/master_v2/test_runtime_bridge_boundary_gap_assessment_contract_v0.py
@@ -1,0 +1,185 @@
+"""Runtime Bridge Boundary Gap Assessment contract tests (offline only)."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    NEXT_RECOMMENDED_SLICE,
+)
+from trading.master_v2.runtime_bridge_boundary_gap_assessment_v0 import (
+    ASSESSMENT_SLICE_ID,
+    DEFAULT_PR5025_SOURCE_EVIDENCE,
+    PACKAGE_MARKER,
+    assessment_result_field_names_v0,
+    collect_source_evidence_refs,
+    evaluate_runtime_bridge_boundary_gap_assessment_v0,
+    render_runtime_bridge_boundary_gap_matrix_json_v0,
+    render_runtime_bridge_boundary_gap_report_markdown_v0,
+    scan_forbidden_positive_claims,
+    verify_source_manifest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/runtime_bridge_boundary_gap_assessment_v0.py",
+    "scripts/ops/run_runtime_bridge_boundary_gap_assessment_v0.py",
+    "tests/trading/master_v2/test_runtime_bridge_boundary_gap_assessment_contract_v0.py",
+)
+
+_SLICE_SOURCE_PATHS = tuple(REPO_ROOT / p for p in _SLICE_CHANGED_FILES if p.endswith(".py"))
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def test_assessment_constants_v0() -> None:
+    assert ASSESSMENT_SLICE_ID == "RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_V0"
+    assert PACKAGE_MARKER == "RUNTIME_BRIDGE_BOUNDARY_GAP_ASSESSMENT_V0=true"
+
+
+def test_pr5025_source_evidence_manifest_verified_when_available_v0() -> None:
+    source = Path(DEFAULT_PR5025_SOURCE_EVIDENCE)
+    if not source.is_dir():
+        return
+    ok, rc, detail = verify_source_manifest(source)
+    assert ok is True
+    assert rc == 0
+    assert detail == "verified"
+    refs = collect_source_evidence_refs(pr5025_source_dir=source)
+    assert refs[0].manifest_verified is True
+
+
+def test_current_head_assessment_documents_boundary_gap_no_rewire_v0() -> None:
+    source = Path(DEFAULT_PR5025_SOURCE_EVIDENCE)
+    if not source.is_dir():
+        return
+    result = evaluate_runtime_bridge_boundary_gap_assessment_v0(
+        repo_root=REPO_ROOT,
+        pr5025_source_dir=source,
+        source_manifest_verify_rc=0,
+    )
+    assert result.assessment_verdict == "PASS"
+    assert result.boundary_gap_status == "FAIL_CLOSED_DOCUMENTED"
+    assert result.plan_type == "ASSESSMENT_ONLY"
+    assert result.narrow_rewire_justified is False
+    assert result.narrow_rewire_admissible is False
+    assert result.trace_next_unbound_node == "NONE"
+    assert result.chain_surface_binding_complete is True
+    assert result.runtime_bridge_boundary_status == "BOUND_NOT_ACTIVATED"
+    assert result.runtime_bridge_pre_activation_gate_status == "FAIL"
+    assert result.runtime_bridge_activation_admissible is False
+    assert result.offline_parity_complete_runtime_activation_pending is True
+    assert result.surface_p_registry_status == "PARTIAL"
+    assert result.surface_p_semantic_post_status == "PASS"
+    assert result.next_step_after_pr == NEXT_RECOMMENDED_SLICE
+
+
+def test_final_success_flags_remain_false_v0() -> None:
+    source = Path(DEFAULT_PR5025_SOURCE_EVIDENCE)
+    if not source.is_dir():
+        return
+    result = evaluate_runtime_bridge_boundary_gap_assessment_v0(
+        repo_root=REPO_ROOT,
+        pr5025_source_dir=source,
+        source_manifest_verify_rc=0,
+    )
+    assert result.full_canonical_chain_wired is False
+    assert result.backtest_runtime_decision_parity_pass is False
+    assert result.system_economic_evidence_admissible is False
+    assert result.runtime_rewire_admissible is False
+    assert result.claim_promotion_allowed is False
+    assert result.no_runtime_authority_confirmed is True
+    assert result.no_economic_claim_confirmed is True
+    assert result.no_runtime_evidence_before_core_system_complete is True
+
+
+def test_missing_source_evidence_fails_closed_v0(tmp_path: Path) -> None:
+    result = evaluate_runtime_bridge_boundary_gap_assessment_v0(
+        repo_root=REPO_ROOT,
+        pr5025_source_dir=tmp_path / "missing",
+        source_manifest_verify_rc=-1,
+    )
+    assert result.assessment_verdict == "FAIL_CLOSED"
+    assert result.source_evidence_referenced is False
+
+
+def test_matrix_json_schema_v0() -> None:
+    source = Path(DEFAULT_PR5025_SOURCE_EVIDENCE)
+    if not source.is_dir():
+        return
+    payload = json.loads(
+        render_runtime_bridge_boundary_gap_matrix_json_v0(
+            repo_root=REPO_ROOT,
+            pr5025_source_dir=source,
+        )
+    )
+    assert payload["assessment_slice_id"] == ASSESSMENT_SLICE_ID
+    assert payload["boundary_gap_status"] == "FAIL_CLOSED_DOCUMENTED"
+    assert payload["plan_type"] == "ASSESSMENT_ONLY"
+    assert payload["narrow_rewire_justified"] is False
+    assert payload["trace_next_unbound_node"] == "NONE"
+    assert payload["full_canonical_chain_wired"] is False
+    assert payload["source_evidence_refs"]
+
+
+def test_report_markdown_documents_boundary_gap_v0() -> None:
+    source = Path(DEFAULT_PR5025_SOURCE_EVIDENCE)
+    if not source.is_dir():
+        return
+    report = render_runtime_bridge_boundary_gap_report_markdown_v0(
+        repo_root=REPO_ROOT,
+        pr5025_source_dir=source,
+    )
+    assert "MODE=READ_ONLY_NO_RUNTIME_NO_REWIRE" in report
+    assert "plan_type: ASSESSMENT_ONLY" in report
+    assert "narrow_rewire_justified: false" in report
+    assert "trace_next_unbound_node: NONE" in report
+    assert "NO_RUNTIME_AUTHORITY_CONFIRMED=true" in report
+    assert "FULL_CANONICAL_CHAIN_WIRED=false" in report
+
+
+def test_forbidden_positive_claims_scan_clean_v0() -> None:
+    violations = scan_forbidden_positive_claims(REPO_ROOT, list(_SLICE_CHANGED_FILES))
+    assert violations == []
+
+
+def test_slice_sources_exclude_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "execution",
+            "scheduler",
+            "credentials",
+            "live_runtime",
+            "testnet",
+            "shadow",
+            "paper_lane",
+        }
+    )
+    for path in _SLICE_SOURCE_PATHS:
+        assert path.is_file(), f"missing slice source: {path}"
+        hits = _scan_forbidden_imports(path, forbidden)
+        assert hits == [], f"forbidden imports in {path}: {hits}"
+
+
+def test_assessment_result_has_required_fields_v0() -> None:
+    names = assessment_result_field_names_v0()
+    assert "boundary_gap_status" in names
+    assert "narrow_rewire_justified" in names
+    assert "trace_next_unbound_node" in names
+    assert "next_step_after_pr" in names
+    assert "no_runtime_evidence_before_core_system_complete" in names


### PR DESCRIPTION
## Summary
- Adds read-only `RuntimeBridgeBoundaryGapAssessmentV0` after PR #5025 pre-activation gate assessment.
- Confirms trace chain is fully bound (`next_unbound_node=NONE`), runtime bridge remains `BOUND_NOT_ACTIVATED`, and no narrow reuse-first rewire is justified at current head.
- Next deterministic offline step: `FULL_CANONICAL_BACKTEST_BOUNDARY_CHAIN_REASSESSMENT_V0`.

## Invariants (fail-closed, unchanged)
| Invariant | Value |
|---|---|
| FULL_CANONICAL_CHAIN_WIRED | false |
| BACKTEST_RUNTIME_DECISION_PARITY_PASS | false |
| SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE | false |
| RUNTIME_REWIRE_ADMISSIBLE | false |
| NO_RUNTIME_AUTHORITY_CONFIRMED | true |
| NO_ECONOMIC_CLAIM_CONFIRMED | true |

## Assessment verdict
- `boundary_gap_status=FAIL_CLOSED_DOCUMENTED`
- `plan_type=ASSESSMENT_ONLY`
- `narrow_rewire_justified=false`
- `primary_blocker=operator_go_token_status!=FAIL`

## Evidence
- `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/runtime_bridge_boundary_gap_assessment_v0_20260709T000322Z`
- `MANIFEST_VERIFY_RC=0`

## Test plan
- [x] `pytest -q tests/trading/master_v2/test_runtime_bridge_boundary_gap_assessment_contract_v0.py` (10 passed)
- [x] `pytest -q tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_assessment_contract_v0.py`
- [x] `pytest -q tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_contract_v0.py`
- [x] `ruff format --check` / `ruff check` on changed py files
- [x] `py_compile` on changed py files
- [x] forbidden positive-claim scan RC=0

Made with [Cursor](https://cursor.com)