### PR TITLE
feat: bind Surface P required proof input for full parity bundle v0

### DIFF
--- a/scripts/research/full_canonical_parity_proof_bundle_assembler_v0.py
+++ b/scripts/research/full_canonical_parity_proof_bundle_assembler_v0.py
@@ -73,7 +73,10 @@ CONTEXT_PROTECTED_MARKERS = (
 )
 
 SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/surface_p_required_proof_input_binding_v0.py",
     "scripts/research/full_canonical_parity_proof_bundle_assembler_v0.py",
+    "scripts/research/full_canonical_surface_p_required_proof_input_v0.py",
+    "tests/trading/master_v2/test_surface_p_required_proof_input_binding_contract_v0.py",
     "tests/research/test_full_canonical_parity_proof_bundle_assembler_v0.py",
 )
 
@@ -83,6 +86,7 @@ TARGETED_TESTS = (
     "tests/research/test_full_canonical_parity_closure_assessment_v0.py",
     "tests/research/test_full_canonical_backtest_boundary_chain_reassessment_v0.py",
     "tests/research/test_backtest_runtime_decision_parity_trace_matrix_v0.py",
+    "tests/trading/master_v2/test_surface_p_required_proof_input_binding_contract_v0.py",
 )
 
 
@@ -180,6 +184,7 @@ REASON_FORBIDDEN_POSITIVE_CLAIMS = "FORBIDDEN_POSITIVE_CLAIMS_DETECTED"
 REASON_ECONOMIC_EVIDENCE_NOT_PROVEN = "SYSTEM_ECONOMIC_EVIDENCE_NOT_PROVEN"
 REASON_RUNTIME_REWIRE_NOT_PROVEN = "RUNTIME_REWIRE_PREREQUISITES_NOT_PROVEN"
 REASON_MISSING_REQUIRED_PROOF_INPUT = "MISSING_REQUIRED_PROOF_INPUT"
+REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P = "MISSING_REQUIRED_PROOF_INPUT_SURFACE_P"
 
 STRONGER_TRACE_STATES = frozenset({TRACE_REWIRE_BOUND_STATE})
 
@@ -299,6 +304,39 @@ def _count_present_evidence_refs(
     return len(present), missing
 
 
+def _surface_p_proof_input_entry(
+    repo_root: Path,
+    *,
+    spec: RequiredProofInputSpec,
+    assessment: Any,
+) -> dict[str, Any]:
+    from trading.master_v2.surface_p_required_proof_input_binding_v0 import (
+        evaluate_surface_p_required_proof_input_binding_v0,
+    )
+
+    binding = evaluate_surface_p_required_proof_input_binding_v0(repo_root)
+    return {
+        "proof_input_id": spec.proof_input_id,
+        "surface_id": spec.surface_id,
+        "label": spec.label,
+        "present": True,
+        "parity_status": assessment.parity_status,
+        "registry_parity_status": binding.registry_parity_status,
+        "binding_owner": binding.owner,
+        "binding_status": binding.binding_status,
+        "offline_four_way_fixtures_complete": binding.offline_four_way_fixtures_complete,
+        "semantic_binding_confirmations_complete": binding.semantic_binding_confirmations_complete,
+        "surface_p_offline_parity_complete": binding.surface_p_offline_parity_complete,
+        "runtime_bridge_bound_not_activated": binding.runtime_bridge_bound_not_activated,
+        "evidence_ref_count": binding.evidence_ref_count,
+        "present_evidence_ref_count": binding.present_evidence_ref_count,
+        "missing_evidence_refs": list(binding.missing_evidence_refs),
+        "status": binding.binding_status,
+        "satisfied": binding.satisfied,
+        "detail": binding.detail,
+    }
+
+
 def build_required_proof_inputs_matrix(repo_root: Path) -> dict[str, Any]:
     sys.path.insert(0, str(_REPO_ROOT / "src"))
     from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
@@ -329,6 +367,15 @@ def build_required_proof_inputs_matrix(repo_root: Path) -> dict[str, Any]:
                 }
             )
             missing_proof_input_ids.append(spec.proof_input_id)
+            continue
+
+        if spec.surface_id == "P":
+            entry = _surface_p_proof_input_entry(repo_root, spec=spec, assessment=assessment)
+            proof_inputs.append(entry)
+            if entry["satisfied"]:
+                satisfied_count += 1
+            else:
+                missing_proof_input_ids.append(spec.proof_input_id)
             continue
 
         present_ref_count, missing_refs = _count_present_evidence_refs(
@@ -610,6 +657,10 @@ def evaluate_proof_bundle(
     if not coverage["surface_coverage_complete"]:
         reason_codes.append(REASON_SURFACE_COVERAGE_INCOMPLETE)
     if not proof_inputs["required_proof_inputs_complete"]:
+        if proof_inputs["missing_proof_input_ids"] == [
+            "backtest_offline_replay_runtime_decision_parity"
+        ]:
+            reason_codes.append(REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P)
         reason_codes.append(REASON_MISSING_REQUIRED_PROOF_INPUT)
     if not gap_all_pass:
         reason_codes.append(REASON_GAP_ASSESSMENT_NOT_ALL_PASS)
@@ -624,6 +675,7 @@ def evaluate_proof_bundle(
         REASON_TRACE_REWIRE_BINDING_INCOMPLETE,
         REASON_SURFACE_COVERAGE_INCOMPLETE,
         REASON_MISSING_REQUIRED_PROOF_INPUT,
+        REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P,
     }.intersection(reason_codes)
 
     semantic_ok = structural_ok and gap_all_pass
@@ -941,10 +993,11 @@ def collect_evidence(
         and bundle["next_unbound_node"] == "NONE"
         and bundle["surface_coverage_complete"] is True
         and bundle["required_proof_input_count"] == 16
-        and bundle["required_proof_inputs_complete"] is False
+        and bundle["required_proof_inputs_complete"] is True
+        and bundle["satisfied_proof_input_count"] == 16
         and bundle["source_evidence_all_manifests_verified"] is True
         and not bundle["stale_source_evidence_detected"]
-        and bundle["next_blocker"] == REASON_MISSING_REQUIRED_PROOF_INPUT
+        and bundle["next_blocker"] == REASON_GAP_ASSESSMENT_NOT_ALL_PASS
     )
     tests_pass = pytest_proc.returncode == 0
     ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0

--- a/scripts/research/full_canonical_surface_p_required_proof_input_v0.py
+++ b/scripts/research/full_canonical_surface_p_required_proof_input_v0.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for Surface P required proof-input binding v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from scripts.research.full_canonical_parity_proof_bundle_assembler_v0 import (
+    REASON_GAP_ASSESSMENT_NOT_ALL_PASS,
+    SLICE_CHANGED_FILES,
+    TARGETED_TESTS,
+    evaluate_proof_bundle,
+    scan_assembler_forbidden_positive_claims,
+    write_manifest,
+)
+from trading.master_v2.surface_p_required_proof_input_binding_v0 import (
+    BINDING_SLICE_ID,
+    REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P,
+    SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_OWNER,
+    evaluate_surface_p_required_proof_input_binding_v0,
+    surface_p_required_proof_input_binding_to_dict_v0,
+)
+
+VERDICT_PASS = "SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_V0_PASS"
+VERDICT_BLOCKED = "SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_V0_BLOCKED"
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _run(
+    cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False, env=env)
+
+
+def collect_evidence(
+    repo_root: Path,
+    *,
+    output_dir: Path | None = None,
+    durable_archive_root: Path | None = None,
+) -> dict[str, object]:
+    repo_root = repo_root.resolve()
+    archive_root = Path(
+        durable_archive_root
+        or os.environ.get(
+            "PEAK_TRADE_DURABLE_ARCHIVE_ROOT",
+            "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z",
+        )
+    )
+    evidence_dir = output_dir or (
+        archive_root / f"research/full_canonical_surface_p_required_proof_input_v0_{_utc_stamp()}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"], cwd=repo_root).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"], cwd=repo_root).stdout.strip()
+    branch = _run(["git", "branch", "--show-current"], cwd=repo_root).stdout.strip()
+    status = _run(["git", "status", "--short"], cwd=repo_root).stdout.strip()
+
+    binding = evaluate_surface_p_required_proof_input_binding_v0(repo_root)
+    bundle = evaluate_proof_bundle(repo_root, current_origin_main=origin_main)
+    forbidden_violations = scan_assembler_forbidden_positive_claims(
+        repo_root, list(SLICE_CHANGED_FILES)
+    )
+
+    (evidence_dir / "git_context.txt").write_text(
+        "\n".join(
+            [
+                f"REPO={repo_root}",
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"BRANCH={branch}",
+                f"WORKTREE_STATUS={status or 'clean'}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "surface_p_required_proof_input_binding.json").write_text(
+        json.dumps(
+            surface_p_required_proof_input_binding_to_dict_v0(binding), indent=2, sort_keys=True
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "proof_bundle_snapshot.json").write_text(
+        json.dumps(
+            {
+                "required_proof_input_count": bundle["required_proof_input_count"],
+                "satisfied_proof_input_count": bundle["satisfied_proof_input_count"],
+                "required_proof_inputs_complete": bundle["required_proof_inputs_complete"],
+                "missing_proof_input_ids": bundle["missing_proof_input_ids"],
+                "next_blocker": bundle["next_blocker"],
+                "full_canonical_chain_wired": bundle["full_canonical_chain_wired"],
+                "backtest_runtime_decision_parity_pass": bundle[
+                    "backtest_runtime_decision_parity_pass"
+                ],
+                "system_economic_evidence_admissible": bundle[
+                    "system_economic_evidence_admissible"
+                ],
+                "runtime_rewire_admissible": bundle["runtime_rewire_admissible"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "changed_files.txt").write_text(
+        "\n".join(SLICE_CHANGED_FILES) + "\n", encoding="utf-8"
+    )
+
+    env = {**dict(os.environ), "PYTHONPATH": f"{repo_root / 'src'}:{repo_root}"}
+    pytest_proc = _run(
+        [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS], cwd=repo_root, env=env
+    )
+    (evidence_dir / "targeted_pytest.txt").write_text(
+        pytest_proc.stdout + pytest_proc.stderr,
+        encoding="utf-8",
+    )
+
+    changed_py = [repo_root / rel for rel in SLICE_CHANGED_FILES if rel.endswith(".py")]
+    ruff_targets = [str(path) for path in changed_py if path.is_file()]
+    ruff_format = _run(
+        [sys.executable, "-m", "ruff", "format", "--check", *ruff_targets], cwd=repo_root
+    )
+    ruff_check = _run([sys.executable, "-m", "ruff", "check", *ruff_targets], cwd=repo_root)
+    (evidence_dir / "ruff_format_check.txt").write_text(
+        (ruff_format.stdout + ruff_format.stderr) or f"RC={ruff_format.returncode}\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "ruff_check.txt").write_text(
+        (ruff_check.stdout + ruff_check.stderr) or f"RC={ruff_check.returncode}\n",
+        encoding="utf-8",
+    )
+
+    py_compile_lines: list[str] = []
+    py_compile_rc = 0
+    for path in changed_py:
+        if not path.is_file():
+            continue
+        proc = _run([sys.executable, "-m", "py_compile", str(path)], cwd=repo_root)
+        py_compile_lines.append(f"{path.relative_to(repo_root)} RC={proc.returncode}")
+        if proc.returncode != 0:
+            py_compile_rc = proc.returncode
+            py_compile_lines.extend([proc.stdout, proc.stderr])
+    (evidence_dir / "py_compile.txt").write_text(
+        "\n".join(py_compile_lines) + "\n", encoding="utf-8"
+    )
+
+    forbidden_ok = not forbidden_violations
+    (evidence_dir / "forbidden_claims_scan.txt").write_text(
+        "\n".join(
+            [
+                f"FORBIDDEN_POSITIVE_CLAIMS_RC={0 if forbidden_ok else 1}",
+                f"FORBIDDEN_POSITIVE_CLAIMS_SCAN={'PASS' if forbidden_ok else 'BLOCKED'}",
+                *forbidden_violations,
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    binding_pass = (
+        binding.satisfied
+        and binding.binding_status == "VERIFIED"
+        and bundle["required_proof_inputs_complete"] is True
+        and bundle["satisfied_proof_input_count"] == 16
+        and bundle["full_canonical_chain_wired"] is False
+        and bundle["backtest_runtime_decision_parity_pass"] is False
+        and bundle["next_blocker"] == REASON_GAP_ASSESSMENT_NOT_ALL_PASS
+    )
+    tests_pass = pytest_proc.returncode == 0
+    ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0
+    verdict = (
+        VERDICT_PASS
+        if binding_pass and tests_pass and ruff_pass and py_compile_rc == 0 and forbidden_ok
+        else VERDICT_BLOCKED
+    )
+
+    manifest_rc = write_manifest(evidence_dir)
+    (evidence_dir / "final_report.txt").write_text(
+        "\n".join(
+            [
+                f"VERDICT={verdict}",
+                f"BINDING_SLICE_ID={BINDING_SLICE_ID}",
+                f"SURFACE_P_BINDING_OWNER={SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_OWNER}",
+                f"SURFACE_P_PROOF_INPUT_BINDING_STATUS={binding.binding_status}",
+                f"SURFACE_P_PROOF_INPUT_SATISFIED={str(binding.satisfied).lower()}",
+                f"REQUIRED_PROOF_INPUT_COUNT={bundle['required_proof_input_count']}",
+                f"SATISFIED_PROOF_INPUT_COUNT={bundle['satisfied_proof_input_count']}",
+                (
+                    "REQUIRED_PROOF_INPUTS_COMPLETE="
+                    f"{str(bundle['required_proof_inputs_complete']).lower()}"
+                ),
+                f"MISSING_PROOF_INPUT_IDS={','.join(bundle['missing_proof_input_ids']) or 'NONE'}",
+                f"NEXT_BLOCKER={bundle['next_blocker']}",
+                f"FULL_CANONICAL_CHAIN_WIRED={str(bundle['full_canonical_chain_wired']).lower()}",
+                (
+                    "BACKTEST_RUNTIME_DECISION_PARITY_PASS="
+                    f"{str(bundle['backtest_runtime_decision_parity_pass']).lower()}"
+                ),
+                (
+                    "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE="
+                    f"{str(bundle['system_economic_evidence_admissible']).lower()}"
+                ),
+                f"RUNTIME_REWIRE_ADMISSIBLE={str(bundle['runtime_rewire_admissible']).lower()}",
+                f"MISSING_REASON_WHEN_UNBOUND={REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P}",
+                "NO_RUNTIME_AUTHORITY_CONFIRMED=true",
+                "NO_ECONOMIC_CLAIM_CONFIRMED=true",
+                f"MANIFEST_VERIFY_RC={manifest_rc}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_rc = write_manifest(evidence_dir)
+
+    return {
+        "verdict": verdict,
+        "binding": binding,
+        "bundle": bundle,
+        "evidence_dir": str(evidence_dir),
+        "manifest_verify_rc": manifest_rc,
+        "tests_pass": tests_pass,
+        "ruff_pass": ruff_pass,
+        "forbidden_ok": forbidden_ok,
+        "py_compile_rc": py_compile_rc,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--durable-archive-root", default=None)
+    args = parser.parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    output_dir = Path(args.output_dir).resolve() if args.output_dir else None
+    archive_root = Path(args.durable_archive_root).resolve() if args.durable_archive_root else None
+    result = collect_evidence(repo_root, output_dir=output_dir, durable_archive_root=archive_root)
+    binding = result["binding"]
+    bundle = result["bundle"]
+    print(f"VERDICT={result['verdict']}")
+    print(f"SURFACE_P_PROOF_INPUT_BINDING_STATUS={binding.binding_status}")
+    print(f"SURFACE_P_PROOF_INPUT_SATISFIED={str(binding.satisfied).lower()}")
+    print(f"SATISFIED_PROOF_INPUT_COUNT={bundle['satisfied_proof_input_count']}")
+    print(f"NEXT_BLOCKER={bundle['next_blocker']}")
+    print(f"DURABLE_EVIDENCE_DIR={result['evidence_dir']}")
+    print(f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}")
+    return 0 if result["verdict"] == VERDICT_PASS else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/surface_p_required_proof_input_binding_v0.py
+++ b/src/trading/master_v2/surface_p_required_proof_input_binding_v0.py
@@ -1,0 +1,236 @@
+"""
+Surface P required proof-input binding v0.
+
+Owner-bound evaluation for the Full Canonical Parity Proof Bundle Assembler
+required proof input on surface P. Offline/backtest/scenario 4-way parity may be
+COMPLETE while registry parity_status remains PARTIAL because runtime bridge
+activation is policy-blocked. Does not activate runtime, grant order authority,
+or promote final success flags.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Literal, Mapping, Tuple
+
+SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_LAYER_VERSION = "v0"
+SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_OWNER = (
+    "trading.master_v2.surface_p_required_proof_input_binding_v0"
+)
+BINDING_SLICE_ID = "SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_V0"
+PACKAGE_MARKER = "SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_V0=true"
+
+SURFACE_P_PROOF_INPUT_ID = "backtest_offline_replay_runtime_decision_parity"
+SURFACE_P_SURFACE_ID = "P"
+SURFACE_P_PROOF_INPUT_LABEL = (
+    "Backtest / Offline Replay / Runtime decision parity proof eligibility evidence"
+)
+
+REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P = "MISSING_REQUIRED_PROOF_INPUT_SURFACE_P"
+REASON_OFFLINE_FOUR_WAY_INCOMPLETE = "OFFLINE_FOUR_WAY_PARITY_INCOMPLETE"
+REASON_SEMANTIC_BINDING_INCOMPLETE = "SEMANTIC_BINDING_CONFIRMATION_INCOMPLETE"
+REASON_OFFLINE_PARITY_NOT_COMPLETE = "SURFACE_P_OFFLINE_PARITY_NOT_COMPLETE"
+REASON_RUNTIME_BRIDGE_NOT_BOUND_NOT_ACTIVATED = "RUNTIME_BRIDGE_NOT_BOUND_NOT_ACTIVATED"
+REASON_OWNER_EVIDENCE_REFS_MISSING = "OWNER_EVIDENCE_REFS_MISSING"
+
+SurfacePProofInputBindingStatus = Literal["VERIFIED", "MISSING_REQUIRED_PROOF_INPUT_SURFACE_P"]
+
+CANONICAL_OWNER_FILES: Tuple[str, ...] = (
+    "src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py",
+    "src/trading/master_v2/surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
+    "src/trading/master_v2/surface_p_semantic_parity_gap_assessment_v0.py",
+    "src/trading/master_v2/surface_p_required_proof_input_binding_v0.py",
+)
+
+
+@dataclass(frozen=True)
+class SurfacePRequiredProofInputBindingResultV0:
+    proof_input_id: str
+    surface_id: str
+    label: str
+    owner: str
+    binding_status: SurfacePProofInputBindingStatus
+    satisfied: bool
+    registry_parity_status: str
+    offline_four_way_fixtures_complete: bool
+    semantic_binding_confirmations_complete: bool
+    surface_p_offline_parity_complete: bool
+    runtime_bridge_bound_not_activated: bool
+    owner_evidence_refs_present: bool
+    evidence_ref_count: int
+    present_evidence_ref_count: int
+    missing_evidence_refs: Tuple[str, ...]
+    detail: str
+    fail_closed_reasons: Tuple[str, ...]
+    full_canonical_chain_wired: bool
+    backtest_runtime_decision_parity_pass: bool
+    system_economic_evidence_admissible: bool
+    runtime_rewire_admissible: bool
+    claim_promotion_allowed: bool
+    no_runtime_authority_confirmed: bool
+    no_economic_claim_confirmed: bool
+
+
+def _count_present_evidence_refs(
+    repo_root: Path, evidence_refs: Tuple[str, ...]
+) -> tuple[int, tuple[str, ...]]:
+    present_count = 0
+    missing: list[str] = []
+    for ref in evidence_refs:
+        if (repo_root / ref).is_file():
+            present_count += 1
+        else:
+            missing.append(ref)
+    return present_count, tuple(missing)
+
+
+def evaluate_surface_p_required_proof_input_binding_v0(
+    repo_root: Path,
+) -> SurfacePRequiredProofInputBindingResultV0:
+    """Evaluate Surface P required proof-input binding; never grants runtime authority."""
+    from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+        parity_surface_assessments_v0,
+    )
+    from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_v0 import (
+        evaluate_surface_p_full_bar_sequence_four_way_parity_v0,
+    )
+    from trading.master_v2.surface_p_final_flags_fail_closed_contract_v0 import (
+        REQUIRED_SEMANTIC_BINDING_CONFIRMATIONS_V0,
+        derive_targeted_semantic_binding_confirmations_from_gap_assessment_v0,
+    )
+    from trading.master_v2.surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0 import (
+        evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0,
+        surface_p_offline_parity_complete_runtime_activation_pending_v0,
+    )
+
+    fail_reasons: list[str] = []
+    surface_p = next(item for item in parity_surface_assessments_v0() if item.surface_id == "P")
+    bar_assessment = evaluate_surface_p_full_bar_sequence_four_way_parity_v0()
+    semantic = evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0(
+        offline_four_way_fixtures_complete=bar_assessment.fixtures_complete,
+    )
+    confirmations = derive_targeted_semantic_binding_confirmations_from_gap_assessment_v0()
+    missing_bindings = tuple(
+        key
+        for key in REQUIRED_SEMANTIC_BINDING_CONFIRMATIONS_V0
+        if not confirmations.get(key, False)
+    )
+    present_ref_count, missing_refs = _count_present_evidence_refs(
+        repo_root, surface_p.evidence_refs
+    )
+
+    offline_complete = bar_assessment.fixtures_complete
+    if not offline_complete:
+        fail_reasons.append(REASON_OFFLINE_FOUR_WAY_INCOMPLETE)
+
+    semantic_bindings_complete = not missing_bindings
+    if missing_bindings:
+        fail_reasons.append(REASON_SEMANTIC_BINDING_INCOMPLETE)
+
+    offline_parity_complete = semantic.surface_p_offline_parity_status == "COMPLETE"
+    if not offline_parity_complete:
+        fail_reasons.append(REASON_OFFLINE_PARITY_NOT_COMPLETE)
+
+    runtime_bridge_bound_not_activated = (
+        semantic.surface_p_runtime_bridge_binding_status == "BOUND_NOT_ACTIVATED"
+        and semantic.surface_p_runtime_activation_status == "NOT_ACTIVATED_POLICY_BLOCKED"
+    )
+    if not runtime_bridge_bound_not_activated:
+        fail_reasons.append(REASON_RUNTIME_BRIDGE_NOT_BOUND_NOT_ACTIVATED)
+
+    owner_evidence_refs_present = present_ref_count > 0 and not missing_refs
+    if not owner_evidence_refs_present:
+        fail_reasons.append(REASON_OWNER_EVIDENCE_REFS_MISSING)
+
+    activation_pending = surface_p_offline_parity_complete_runtime_activation_pending_v0(semantic)
+    satisfied = (
+        offline_complete
+        and semantic_bindings_complete
+        and offline_parity_complete
+        and runtime_bridge_bound_not_activated
+        and activation_pending
+        and owner_evidence_refs_present
+    )
+    if not satisfied:
+        fail_reasons.append(REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P)
+
+    detail_parts: list[str] = []
+    if not offline_complete:
+        detail_parts.append("offline_four_way_fixtures_incomplete")
+    if not semantic_bindings_complete:
+        detail_parts.append("semantic_binding_confirmations_incomplete")
+    if not offline_parity_complete:
+        detail_parts.append("surface_p_offline_parity_incomplete")
+    if not runtime_bridge_bound_not_activated:
+        detail_parts.append("runtime_bridge_not_bound_not_activated")
+    if not activation_pending:
+        detail_parts.append("offline_complete_runtime_activation_not_pending")
+    if not owner_evidence_refs_present:
+        detail_parts.append("owner_evidence_refs_missing")
+
+    return SurfacePRequiredProofInputBindingResultV0(
+        proof_input_id=SURFACE_P_PROOF_INPUT_ID,
+        surface_id=SURFACE_P_SURFACE_ID,
+        label=SURFACE_P_PROOF_INPUT_LABEL,
+        owner=SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_OWNER,
+        binding_status="VERIFIED" if satisfied else "MISSING_REQUIRED_PROOF_INPUT_SURFACE_P",
+        satisfied=satisfied,
+        registry_parity_status=surface_p.parity_status,
+        offline_four_way_fixtures_complete=offline_complete,
+        semantic_binding_confirmations_complete=semantic_bindings_complete,
+        surface_p_offline_parity_complete=offline_parity_complete,
+        runtime_bridge_bound_not_activated=runtime_bridge_bound_not_activated,
+        owner_evidence_refs_present=owner_evidence_refs_present,
+        evidence_ref_count=len(surface_p.evidence_refs),
+        present_evidence_ref_count=present_ref_count,
+        missing_evidence_refs=missing_refs,
+        detail="verified" if satisfied else "; ".join(detail_parts),
+        fail_closed_reasons=tuple(dict.fromkeys(fail_reasons)),
+        full_canonical_chain_wired=False,
+        backtest_runtime_decision_parity_pass=False,
+        system_economic_evidence_admissible=False,
+        runtime_rewire_admissible=False,
+        claim_promotion_allowed=False,
+        no_runtime_authority_confirmed=True,
+        no_economic_claim_confirmed=True,
+    )
+
+
+def surface_p_required_proof_input_binding_to_dict_v0(
+    result: SurfacePRequiredProofInputBindingResultV0,
+) -> Mapping[str, object]:
+    return {
+        "binding_version": SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_LAYER_VERSION,
+        "binding_owner": SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_OWNER,
+        "binding_slice_id": BINDING_SLICE_ID,
+        "proof_input_id": result.proof_input_id,
+        "surface_id": result.surface_id,
+        "label": result.label,
+        "owner": result.owner,
+        "binding_status": result.binding_status,
+        "satisfied": result.satisfied,
+        "registry_parity_status": result.registry_parity_status,
+        "offline_four_way_fixtures_complete": result.offline_four_way_fixtures_complete,
+        "semantic_binding_confirmations_complete": result.semantic_binding_confirmations_complete,
+        "surface_p_offline_parity_complete": result.surface_p_offline_parity_complete,
+        "runtime_bridge_bound_not_activated": result.runtime_bridge_bound_not_activated,
+        "owner_evidence_refs_present": result.owner_evidence_refs_present,
+        "evidence_ref_count": result.evidence_ref_count,
+        "present_evidence_ref_count": result.present_evidence_ref_count,
+        "missing_evidence_refs": list(result.missing_evidence_refs),
+        "detail": result.detail,
+        "fail_closed_reasons": list(result.fail_closed_reasons),
+        "full_canonical_chain_wired": result.full_canonical_chain_wired,
+        "backtest_runtime_decision_parity_pass": result.backtest_runtime_decision_parity_pass,
+        "system_economic_evidence_admissible": result.system_economic_evidence_admissible,
+        "runtime_rewire_admissible": result.runtime_rewire_admissible,
+        "claim_promotion_allowed": result.claim_promotion_allowed,
+        "no_runtime_authority_confirmed": result.no_runtime_authority_confirmed,
+        "no_economic_claim_confirmed": result.no_economic_claim_confirmed,
+        "canonical_owner_files": list(CANONICAL_OWNER_FILES),
+    }
+
+
+def binding_result_field_names_v0() -> Tuple[str, ...]:
+    return tuple(field.name for field in fields(SurfacePRequiredProofInputBindingResultV0))

--- a/tests/research/test_full_canonical_parity_proof_bundle_assembler_v0.py
+++ b/tests/research/test_full_canonical_parity_proof_bundle_assembler_v0.py
@@ -21,7 +21,8 @@ from scripts.research.full_canonical_parity_proof_bundle_assembler_v0 import (
     DEFAULT_PR5027_CLOSEOUT_EVIDENCE,
     DEFAULT_PR5028_CLOSEOUT_EVIDENCE,
     DEFAULT_PR5028_ELIGIBILITY_EVIDENCE,
-    REASON_MISSING_REQUIRED_PROOF_INPUT,
+    REASON_GAP_ASSESSMENT_NOT_ALL_PASS,
+    REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P,
     REASON_SOURCE_EVIDENCE_MISSING,
     REQUIRED_PROOF_INPUT_SPECS,
     SLICE_CHANGED_FILES,
@@ -130,9 +131,9 @@ def test_proof_bundle_schema_and_fail_closed_status(module_proof_bundle: dict[st
     assert bundle["covered_surface_count"] == 12
     assert bundle["missing_surfaces"] == []
     assert bundle["required_proof_input_count"] == 16
-    assert bundle["satisfied_proof_input_count"] == 15
-    assert bundle["required_proof_inputs_complete"] is False
-    assert bundle["missing_proof_input_ids"] == ["backtest_offline_replay_runtime_decision_parity"]
+    assert bundle["satisfied_proof_input_count"] == 16
+    assert bundle["required_proof_inputs_complete"] is True
+    assert bundle["missing_proof_input_ids"] == []
     assert bundle["no_runtime_authority_confirmed"] is True
     assert bundle["no_economic_claim_confirmed"] is True
 
@@ -145,12 +146,16 @@ def test_required_proof_inputs_matrix_accounts_for_all_sixteen_surfaces() -> Non
         item["proof_input_id"] for item in matrix["proof_inputs"]
     ]
     surface_p = next(item for item in matrix["proof_inputs"] if item["surface_id"] == "P")
-    assert surface_p["status"] == "MISSING_REQUIRED_PROOF_INPUT"
+    assert surface_p["status"] == "VERIFIED"
+    assert surface_p["binding_status"] == "VERIFIED"
     assert surface_p["parity_status"] == "PARTIAL"
-    assert surface_p["satisfied"] is False
+    assert surface_p["registry_parity_status"] == "PARTIAL"
+    assert surface_p["satisfied"] is True
 
 
-def test_proof_bundle_reports_missing_required_proof_input_as_next_blocker(tmp_path: Path) -> None:
+def test_proof_bundle_reports_gap_assessment_blocker_when_proof_inputs_complete(
+    tmp_path: Path,
+) -> None:
     repo_root = Path.cwd()
     pr5020, pr5027, pr5028, eligibility, origin_main = _build_verified_source_evidence_fixture(
         tmp_path,
@@ -165,12 +170,72 @@ def test_proof_bundle_reports_missing_required_proof_input_as_next_blocker(tmp_p
         pr5028_eligibility_dir=eligibility,
         current_origin_main=origin_main,
     )
-    assert bundle["next_blocker"] == REASON_MISSING_REQUIRED_PROOF_INPUT
-    assert REASON_MISSING_REQUIRED_PROOF_INPUT in bundle["reason_codes"]
+    assert bundle["required_proof_inputs_complete"] is True
+    assert bundle["satisfied_proof_input_count"] == 16
+    assert bundle["next_blocker"] == REASON_GAP_ASSESSMENT_NOT_ALL_PASS
     assert REASON_GAP_ASSESSMENT_NOT_ALL_PASS in bundle["reason_codes"]
     assert bundle["gap_assessment_all_pass"] is False
     assert bundle["source_evidence_all_manifests_verified"] is True
     assert bundle["source_evidence_missing"] == []
+
+
+def test_proof_bundle_reports_missing_surface_p_proof_input_when_binding_unsatisfied(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = Path.cwd()
+    pr5020, pr5027, pr5028, eligibility, origin_main = _build_verified_source_evidence_fixture(
+        tmp_path,
+        repo_root,
+        origin_main="1fecc0566ccc5d0b9ffd7e0cc9d485f88a63729b",
+    )
+
+    def _unsatisfied_binding(_repo_root: Path):
+        from trading.master_v2.surface_p_required_proof_input_binding_v0 import (
+            SurfacePRequiredProofInputBindingResultV0,
+        )
+
+        return SurfacePRequiredProofInputBindingResultV0(
+            proof_input_id="backtest_offline_replay_runtime_decision_parity",
+            surface_id="P",
+            label="Backtest / Offline Replay / Runtime decision parity proof eligibility evidence",
+            owner="trading.master_v2.surface_p_required_proof_input_binding_v0",
+            binding_status="MISSING_REQUIRED_PROOF_INPUT_SURFACE_P",
+            satisfied=False,
+            registry_parity_status="PARTIAL",
+            offline_four_way_fixtures_complete=False,
+            semantic_binding_confirmations_complete=False,
+            surface_p_offline_parity_complete=False,
+            runtime_bridge_bound_not_activated=False,
+            owner_evidence_refs_present=False,
+            evidence_ref_count=0,
+            present_evidence_ref_count=0,
+            missing_evidence_refs=("missing/evidence.py",),
+            detail="offline_four_way_fixtures_incomplete",
+            fail_closed_reasons=(REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P,),
+            full_canonical_chain_wired=False,
+            backtest_runtime_decision_parity_pass=False,
+            system_economic_evidence_admissible=False,
+            runtime_rewire_admissible=False,
+            claim_promotion_allowed=False,
+            no_runtime_authority_confirmed=True,
+            no_economic_claim_confirmed=True,
+        )
+
+    monkeypatch.setattr(
+        "trading.master_v2.surface_p_required_proof_input_binding_v0.evaluate_surface_p_required_proof_input_binding_v0",
+        _unsatisfied_binding,
+    )
+    bundle = evaluate_proof_bundle(
+        repo_root,
+        pr5020_closeout_dir=pr5020,
+        pr5027_closeout_dir=pr5027,
+        pr5028_closeout_dir=pr5028,
+        pr5028_eligibility_dir=eligibility,
+        current_origin_main=origin_main,
+    )
+    assert bundle["required_proof_inputs_complete"] is False
+    assert bundle["next_blocker"] == REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P
+    assert REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P in bundle["reason_codes"]
 
 
 def test_proof_bundle_reports_missing_source_evidence_without_local_archive(

--- a/tests/trading/master_v2/test_surface_p_required_proof_input_binding_contract_v0.py
+++ b/tests/trading/master_v2/test_surface_p_required_proof_input_binding_contract_v0.py
@@ -1,0 +1,147 @@
+"""Surface P required proof-input binding contract tests (offline only)."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    parity_surface_assessments_v0,
+)
+from trading.master_v2.legacy_runtime_entrypoint_guard_v0 import (
+    CANONICAL_RUNTIME_ENTRYPOINT_STATUS,
+)
+from trading.master_v2.surface_p_required_proof_input_binding_v0 import (
+    BINDING_SLICE_ID,
+    PACKAGE_MARKER,
+    REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P,
+    SURFACE_P_PROOF_INPUT_ID,
+    SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_OWNER,
+    SURFACE_P_SURFACE_ID,
+    binding_result_field_names_v0,
+    evaluate_surface_p_required_proof_input_binding_v0,
+    surface_p_required_proof_input_binding_to_dict_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_SLICE_CHANGED_FILES = (
+    "src/trading/master_v2/surface_p_required_proof_input_binding_v0.py",
+    "scripts/research/full_canonical_parity_proof_bundle_assembler_v0.py",
+    "scripts/research/full_canonical_surface_p_required_proof_input_v0.py",
+    "tests/trading/master_v2/test_surface_p_required_proof_input_binding_contract_v0.py",
+)
+
+_SLICE_SOURCE_PATHS = tuple(REPO_ROOT / p for p in _SLICE_CHANGED_FILES if p.endswith(".py"))
+
+
+def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(token in alias.name for token in forbidden_tokens):
+                    hits.append(alias.name)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if any(token in node.module for token in forbidden_tokens):
+                hits.append(node.module)
+    return hits
+
+
+def test_binding_constants_v0() -> None:
+    assert BINDING_SLICE_ID == "SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_V0"
+    assert PACKAGE_MARKER == "SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_V0=true"
+    assert SURFACE_P_PROOF_INPUT_ID == "backtest_offline_replay_runtime_decision_parity"
+    assert SURFACE_P_SURFACE_ID == "P"
+    assert SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_OWNER.endswith(
+        "surface_p_required_proof_input_binding_v0"
+    )
+
+
+def test_surface_p_registry_parity_status_remains_partial_v0() -> None:
+    surface_p = next(item for item in parity_surface_assessments_v0() if item.surface_id == "P")
+    assert surface_p.parity_status == "PARTIAL"
+    assert "BOUND_NOT_ACTIVATED" in surface_p.missing_binding_if_any
+
+
+def test_current_head_surface_p_required_proof_input_binding_verified_v0() -> None:
+    result = evaluate_surface_p_required_proof_input_binding_v0(REPO_ROOT)
+    assert result.satisfied is True
+    assert result.binding_status == "VERIFIED"
+    assert result.registry_parity_status == "PARTIAL"
+    assert result.offline_four_way_fixtures_complete is True
+    assert result.semantic_binding_confirmations_complete is True
+    assert result.surface_p_offline_parity_complete is True
+    assert result.runtime_bridge_bound_not_activated is True
+    assert result.owner_evidence_refs_present is True
+    assert result.present_evidence_ref_count == result.evidence_ref_count
+    assert result.missing_evidence_refs == ()
+    assert CANONICAL_RUNTIME_ENTRYPOINT_STATUS == "BOUND_NOT_ACTIVATED"
+
+
+def test_missing_owner_evidence_refs_fail_closed_with_surface_p_reason_v0(
+    tmp_path: Path,
+) -> None:
+    with patch(
+        "trading.master_v2.surface_p_required_proof_input_binding_v0._count_present_evidence_refs",
+        return_value=(0, ("missing/evidence.py",)),
+    ):
+        result = evaluate_surface_p_required_proof_input_binding_v0(tmp_path)
+    assert result.satisfied is False
+    assert result.binding_status == "MISSING_REQUIRED_PROOF_INPUT_SURFACE_P"
+    assert REASON_MISSING_REQUIRED_PROOF_INPUT_SURFACE_P in result.fail_closed_reasons
+
+
+def test_binding_json_schema_deterministic_v0() -> None:
+    result = evaluate_surface_p_required_proof_input_binding_v0(REPO_ROOT)
+    payload = surface_p_required_proof_input_binding_to_dict_v0(result)
+    assert payload["binding_slice_id"] == BINDING_SLICE_ID
+    assert payload["proof_input_id"] == SURFACE_P_PROOF_INPUT_ID
+    assert payload["surface_id"] == SURFACE_P_SURFACE_ID
+    assert payload["binding_status"] == "VERIFIED"
+    assert payload["full_canonical_chain_wired"] is False
+    assert payload["backtest_runtime_decision_parity_pass"] is False
+    assert payload["system_economic_evidence_admissible"] is False
+    assert payload["runtime_rewire_admissible"] is False
+    assert payload["claim_promotion_allowed"] is False
+    assert payload["no_runtime_authority_confirmed"] is True
+    assert payload["no_economic_claim_confirmed"] is True
+    encoded = json.dumps(payload, indent=2, sort_keys=True)
+    assert '"binding_status": "VERIFIED"' in encoded
+
+
+def test_final_success_flags_remain_false_v0() -> None:
+    result = evaluate_surface_p_required_proof_input_binding_v0(REPO_ROOT)
+    assert result.full_canonical_chain_wired is False
+    assert result.backtest_runtime_decision_parity_pass is False
+    assert result.system_economic_evidence_admissible is False
+    assert result.runtime_rewire_admissible is False
+    assert result.claim_promotion_allowed is False
+
+
+def test_slice_sources_exclude_runtime_imports_v0() -> None:
+    forbidden = frozenset(
+        {
+            "execution",
+            "scheduler",
+            "credentials",
+            "live_runtime",
+            "testnet",
+            "shadow",
+            "paper_lane",
+        }
+    )
+    for path in _SLICE_SOURCE_PATHS:
+        assert path.is_file(), f"missing slice source: {path}"
+        hits = _scan_forbidden_imports(path, forbidden)
+        assert hits == [], f"forbidden imports in {path}: {hits}"
+
+
+def test_binding_result_has_required_fields_v0() -> None:
+    names = binding_result_field_names_v0()
+    assert "binding_status" in names
+    assert "satisfied" in names
+    assert "missing_evidence_refs" in names


### PR DESCRIPTION
## Summary
- Add owner-bound Surface P required proof-input binding (`surface_p_required_proof_input_binding_v0`) that treats offline-complete + runtime-bridge-bound-not-activated as a verified proof input without promoting final parity flags.
- Integrate Surface P binding into the Full Canonical Parity Proof Bundle Assembler so required proof inputs reach 16/16 while `FULL_CANONICAL_CHAIN_WIRED` and `BACKTEST_RUNTIME_DECISION_PARITY_PASS` remain fail-closed until gap-assessment all-PASS is proven.
- Add durable evidence runner and contract tests covering `MISSING_REQUIRED_PROOF_INPUT_SURFACE_P` fail-closed behavior and deterministic manifest/report fields.

## Test plan
- [x] `pytest -q tests/research/test_full_canonical_parity_proof_bundle_assembler_v0.py tests/trading/master_v2/test_surface_p_required_proof_input_binding_contract_v0.py`
- [x] PR-bounded CI selector targets (720 tests)
- [x] `ruff check` / `ruff format --check` on changed Python files
- [x] `python -m py_compile` on changed Python files
- [x] `git diff --check`
- [x] Evidence: `full_canonical_surface_p_required_proof_input_v0_20260709T080223Z` (`MANIFEST_VERIFY_RC=0`)
- [x] Proof bundle assembler rerun (`MANIFEST_VERIFY_RC=0`, `SATISFIED_PROOF_INPUT_COUNT=16`)

Made with [Cursor](https://cursor.com)