### PR TITLE
fix: bind surface p proof input into gap assessment

### DIFF
--- a/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/src/trading/master_v2/full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Literal, Mapping, Sequence, Tuple
 
 FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_LAYER_VERSION = "v0"
@@ -108,6 +109,8 @@ ALLOWED_SLICE_CHANGED_PATH_PREFIXES: Tuple[str, ...] = (
     "src/trading/master_v2/runtime_bridge_pre_activation_gate_assessment_v0.py",
     "scripts/ops/run_runtime_bridge_pre_activation_gate_assessment_v0.py",
     "tests/trading/master_v2/test_runtime_bridge_pre_activation_gate_assessment_contract_v0.py",
+    "src/trading/master_v2/surface_p_required_proof_input_binding_v0.py",
+    "tests/research/test_surface_p_proof_input_gap_assessment_binding_v0.py",
     "src/trading/master_v2/runtime_bridge_boundary_gap_assessment_v0.py",
     "scripts/ops/run_runtime_bridge_boundary_gap_assessment_v0.py",
     "tests/trading/master_v2/test_runtime_bridge_boundary_gap_assessment_contract_v0.py",
@@ -688,6 +691,55 @@ def normalize_matrix_status_v0(parity_status: ParityStatus) -> MatrixStatus:
     return "UNKNOWN"
 
 
+def get_surface_p_required_proof_input_binding_v0(
+    repo_root: Path | None = None,
+) -> Mapping[str, Any]:
+    """Expose Surface P required proof-input binding in gap assessment; fail-closed only."""
+    from trading.master_v2.surface_p_required_proof_input_binding_v0 import (
+        BINDING_SLICE_ID,
+        SURFACE_P_PROOF_INPUT_ID,
+        SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_OWNER,
+        SURFACE_P_SURFACE_ID,
+        evaluate_surface_p_required_proof_input_binding_v0,
+    )
+
+    root = repo_root or Path(__file__).resolve().parents[3]
+    binding = evaluate_surface_p_required_proof_input_binding_v0(root)
+    binding_status = (
+        "BOUND_FROM_REPAIRED_SOURCE_EVIDENCE"
+        if binding.satisfied and binding.binding_status == "VERIFIED"
+        else "MISSING_REQUIRED_PROOF_INPUT_SURFACE_P"
+    )
+    return {
+        "surface_id": SURFACE_P_SURFACE_ID,
+        "required_proof_input_id": SURFACE_P_PROOF_INPUT_ID,
+        "required_proof_input_binding_status": binding_status,
+        "binding_owner": SURFACE_P_REQUIRED_PROOF_INPUT_BINDING_OWNER,
+        "binding_slice_id": BINDING_SLICE_ID,
+        "accepted_source_status": binding.registry_parity_status,
+        "partial_reason_required": "RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED",
+        "proof_input_satisfied": binding.satisfied,
+        "owner_evidence_refs_present": binding.owner_evidence_refs_present,
+        "offline_four_way_fixtures_complete": binding.offline_four_way_fixtures_complete,
+        "semantic_binding_confirmations_complete": binding.semantic_binding_confirmations_complete,
+        "surface_p_offline_parity_complete": binding.surface_p_offline_parity_complete,
+        "runtime_bridge_bound_not_activated": binding.runtime_bridge_bound_not_activated,
+        "full_canonical_chain_wired": False,
+        "backtest_runtime_decision_parity_pass": False,
+        "system_economic_evidence_admissible": False,
+        "runtime_rewire_admissible": False,
+        "claim_promotion_allowed": False,
+        "runtime_authority_effect": "NONE",
+        "order_authority_effect": "NONE",
+        "safety_semantics_changed": False,
+        "economic_claim_changed": False,
+        "no_runtime_authority_confirmed": True,
+        "no_economic_claim_confirmed": True,
+        "detail": binding.detail,
+        "fail_closed_reasons": list(binding.fail_closed_reasons),
+    }
+
+
 def parity_gap_records_v0() -> Tuple[Mapping[str, Any], ...]:
     from trading.master_v2.surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0 import (
         surface_p_offline_parity_complete_runtime_activation_pending_v0,
@@ -745,6 +797,7 @@ def render_parity_gap_matrix_json_v0() -> str:
     surface_p_semantic = (
         evaluate_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0()
     )
+    surface_p_proof_input_binding = get_surface_p_required_proof_input_binding_v0()
     final_flags = evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0()
     surfaces = []
     for item in parity_surface_assessments_v0():
@@ -761,6 +814,9 @@ def render_parity_gap_matrix_json_v0() -> str:
         if item.surface_id == "P":
             surface_entry["surface_p_semantic"] = dict(
                 surface_p_semantic_status_to_dict_v0(surface_p_semantic)
+            )
+            surface_entry["surface_p_required_proof_input_binding"] = dict(
+                surface_p_proof_input_binding
             )
             if surface_p_semantic.surface_p_overall_status == "PARTIAL_RUNTIME_ACTIVATION_PENDING":
                 surface_entry["matrix_status"] = "PARTIAL_RUNTIME_ACTIVATION_PENDING"
@@ -789,6 +845,7 @@ def render_parity_gap_matrix_json_v0() -> str:
         "surfaces": surfaces,
         "gap_records": list(gap_records),
         "surface_p_semantic": dict(surface_p_semantic_status_to_dict_v0(surface_p_semantic)),
+        "surface_p_required_proof_input_binding": dict(surface_p_proof_input_binding),
         "final_flags": dict(surface_p_final_flags_result_to_dict_v0(final_flags)),
     }
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"

--- a/tests/research/test_surface_p_proof_input_gap_assessment_binding_v0.py
+++ b/tests/research/test_surface_p_proof_input_gap_assessment_binding_v0.py
@@ -1,0 +1,50 @@
+"""Surface P required proof-input gap assessment binding contract (offline only)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
+    get_surface_p_required_proof_input_binding_v0,
+    render_parity_gap_matrix_json_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_surface_p_required_proof_input_binding_is_fail_closed() -> None:
+    binding = get_surface_p_required_proof_input_binding_v0(REPO_ROOT)
+
+    assert binding["surface_id"] == "P"
+    assert binding["required_proof_input_id"] == "backtest_offline_replay_runtime_decision_parity"
+    assert binding["required_proof_input_binding_status"] == "BOUND_FROM_REPAIRED_SOURCE_EVIDENCE"
+    assert binding["accepted_source_status"] == "PARTIAL"
+    assert binding["partial_reason_required"] == "RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED"
+    assert binding["proof_input_satisfied"] is True
+
+    assert binding["full_canonical_chain_wired"] is False
+    assert binding["backtest_runtime_decision_parity_pass"] is False
+    assert binding["system_economic_evidence_admissible"] is False
+    assert binding["runtime_rewire_admissible"] is False
+    assert binding["claim_promotion_allowed"] is False
+
+    assert binding["runtime_authority_effect"] == "NONE"
+    assert binding["order_authority_effect"] == "NONE"
+    assert binding["safety_semantics_changed"] is False
+    assert binding["economic_claim_changed"] is False
+    assert binding["no_runtime_authority_confirmed"] is True
+    assert binding["no_economic_claim_confirmed"] is True
+
+
+def test_parity_gap_matrix_json_includes_surface_p_proof_input_binding() -> None:
+    payload = json.loads(render_parity_gap_matrix_json_v0())
+    top_binding = payload["surface_p_required_proof_input_binding"]
+    surface_p = next(item for item in payload["surfaces"] if item["surface_id"] == "P")
+
+    assert (
+        top_binding["required_proof_input_binding_status"] == "BOUND_FROM_REPAIRED_SOURCE_EVIDENCE"
+    )
+    assert surface_p["surface_p_required_proof_input_binding"]["proof_input_satisfied"] is True
+    assert payload["summary"]["full_canonical_chain_wired"] is False
+    assert payload["summary"]["backtest_runtime_decision_parity_pass"] is False


### PR DESCRIPTION
## Summary
Replaces stuck PR #5031 with a fresh branch from current origin/main.

Functional change preserved from commit 8b38ea98:
- binds Surface-P required proof-input into the full canonical gap assessment registry reuse-first
- delegates to existing owner evaluate_surface_p_required_proof_input_binding_v0()
- exposes surface_p_required_proof_input_binding at top-level and per Surface-P entry
- keeps fail-closed canonical flags unchanged

## Replaced PR
- Closed PR #5031 due repeated GitHub required-check liveness deadlock after hard retrigger.
- CI retrigger-only commits are intentionally excluded from this fresh PR.

## Evidence
/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr5031_replaced_by_fresh_pr_surface_p_gap_binding_v1_20260709T090659Z

## Source Evidence Reverify
/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/surface_p_proof_input_gap_assessment_binding_v0_20260709T085023Z
MANIFEST reverify: see source_manifest_reverify.txt

## Fail-closed unchanged
FULL_CANONICAL_CHAIN_WIRED=false
BACKTEST_RUNTIME_DECISION_PARITY_PASS=false
SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false
RUNTIME_REWIRE_ADMISSIBLE=false

## Safety / Authority
No runtime authority.
No order authority.
No credential authority.
No shadow/paper/testnet/canary/live authority.
No runtime evidence.

Made with [Cursor](https://cursor.com)