### PR TITLE
ops: pre-economics notion/market/security operational sync v0

### DIFF
--- a/src/webui/market_dashboard_current_state_snapshot_v0.py
+++ b/src/webui/market_dashboard_current_state_snapshot_v0.py
@@ -1,9 +1,9 @@
-"""Versioned STEP29M current-state snapshot for GET /market (display-only SSOT).
+"""Versioned current-state snapshot for GET /market (display-only SSOT).
 
 Provenance:
-- docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md (RUNBOOK_STEP_29M)
-- documentation/bounded_notion_current_state_synchronization_after_step29m_ma_crossover_policy_ratification_v0_20260702T002000Z
-- config/ops/step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json
+- docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+- research/merge_closeout_pr5033_surface_p_semantic_parity_status_binding_fix_v0_20260709T135256Z
+- research/system_economic_evidence_admissibility_gap_scan_after_full_parity_v0_20260709T141726Z
 
 No trading authority. No runtime effect. Single dashboard owner — no parallel SSOT.
 """
@@ -18,6 +18,14 @@ RUNBOOK_PROGRESS_OWNER: Final[str] = "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOO
 MA_CROSSOVER_CONFIG_OWNER: Final[str] = (
     "config/ops/step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json"
 )
+FULL_PARITY_CLOSEOUT_EVIDENCE_REF: Final[str] = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "research/merge_closeout_pr5033_surface_p_semantic_parity_status_binding_fix_v0_20260709T135256Z"
+)
+ECONOMIC_GAP_SCAN_EVIDENCE_REF: Final[str] = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "research/system_economic_evidence_admissibility_gap_scan_after_full_parity_v0_20260709T141726Z"
+)
 NOTION_SYNC_EVIDENCE_REF: Final[str] = (
     "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
     "documentation/bounded_notion_current_state_synchronization_after_step29m_ma_crossover_policy_ratification_v0_20260702T002000Z"
@@ -28,14 +36,15 @@ RATIFICATION_EVIDENCE_REF: Final[str] = (
 )
 
 NEXT_CANONICAL_STEP: Final[str] = (
-    "BOUNDED_STEP29M_MA_CROSSOVER_V1_REAL_ADMISSIBLE_FUTURES_ECONOMIC_EVALUATION_PREFLIGHT_READ_ONLY_V0"
+    "OFFLINE_ONLY_ECONOMIC_VIABILITY_EVIDENCE_GAP_ASSESSMENT_AND_REUSE_FIRST_BINDING"
 )
+NEXT_BLOCKER: Final[str] = "SYSTEM_ECONOMIC_EVIDENCE_NOT_PROVEN"
 
-CURRENT_ORIGIN_MAIN: Final[str] = "f37f20008bfaee613f8d7e5005acd80da62db78e"
+CURRENT_ORIGIN_MAIN: Final[str] = "720b59bed1c012e873c8e1207b057ebd5fa8f21a"
 
-PR4740_MERGE_COMMIT: Final[str] = CURRENT_ORIGIN_MAIN
-PR4740_HEAD: Final[str] = "0386199d957001287814ad15f5477920bacdbe5b"
-PR4740_BASE: Final[str] = "b30e001738bc829cba58ee5db7191e05d01ae638"
+PR5033_MERGE_COMMIT: Final[str] = CURRENT_ORIGIN_MAIN
+PR5033_HEAD: Final[str] = "bf6778ef9815b197a8d0e7a649c96dda8cb61546"
+PR5033_BASE: Final[str] = "50c714baee959e0bbea8c1f79cf1ebdfdadb46d4"
 
 RATIFICATION_BUNDLE_MANIFEST_VERIFY_RC: Final[int] = 1
 RATIFICATION_BUNDLE_MANIFEST_DRIFT_NOTE: Final[str] = (
@@ -58,11 +67,18 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
         "provenance": {
             "runbook_progress_owner": RUNBOOK_PROGRESS_OWNER,
             "ma_crossover_config_owner": MA_CROSSOVER_CONFIG_OWNER,
+            "full_parity_closeout_evidence_ref": FULL_PARITY_CLOSEOUT_EVIDENCE_REF,
+            "economic_gap_scan_evidence_ref": ECONOMIC_GAP_SCAN_EVIDENCE_REF,
             "notion_sync_evidence_ref": NOTION_SYNC_EVIDENCE_REF,
             "ratification_evidence_ref": RATIFICATION_EVIDENCE_REF,
         },
         "current_system_state": {
             "CURRENT_ORIGIN_MAIN": CURRENT_ORIGIN_MAIN,
+            "FULL_CANONICAL_CHAIN_WIRED": True,
+            "BACKTEST_RUNTIME_DECISION_PARITY_PASS": True,
+            "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE": False,
+            "RUNTIME_REWIRE_ADMISSIBLE": False,
+            "NEXT_BLOCKER": NEXT_BLOCKER,
             "STEP29M_EXECUTION_COMPLETE": True,
             "ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED": False,
             "CURRENT_FLEET_ECONOMIC_VALIDITY_PASS": False,
@@ -146,6 +162,7 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
             "STEP29N_AUTHORIZED": False,
             "STEP29R_AUTHORIZED": False,
             "RUNTIME_AUTHORIZED": False,
+            "RUNTIME_REWIRE_ADMISSIBLE": False,
         },
         "governance_and_safety": {
             "FUTURES_ONLY": True,
@@ -158,19 +175,33 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
             "RUNTIME_AUTHORIZED": False,
             "ORDERS_ALLOWED": False,
             "LIVE_AUTHORIZED": False,
+            "RUNTIME_REWIRE_ADMISSIBLE": False,
         },
         "pr_and_evidence_status": {
-            "PR4740": {
-                "pr_number": 4740,
+            "PR5033": {
+                "pr_number": 5033,
                 "state": "MERGED",
-                "merge_commit": PR4740_MERGE_COMMIT,
-                "head": PR4740_HEAD,
-                "base": PR4740_BASE,
+                "merge_commit": PR5033_MERGE_COMMIT,
+                "head": PR5033_HEAD,
+                "base": PR5033_BASE,
+            },
+            "full_parity_proof": {
+                "FULL_CANONICAL_CHAIN_WIRED": True,
+                "BACKTEST_RUNTIME_DECISION_PARITY_PASS": True,
+                "MANIFEST_VERIFY_RC": 0,
+                "evidence_ref": FULL_PARITY_CLOSEOUT_EVIDENCE_REF,
+            },
+            "economic_evidence_gap": {
+                "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE": False,
+                "NEXT_BLOCKER": NEXT_BLOCKER,
+                "MANIFEST_VERIFY_RC": 0,
+                "evidence_ref": ECONOMIC_GAP_SCAN_EVIDENCE_REF,
             },
             "notion_current_state_sync": {
-                "NOTION_CURRENT": True,
+                "NOTION_CURRENT": False,
+                "stale_reason": "Last verified Notion mirror is STEP29M/PR4740 (20260702); post-PR5033 full-parity mirror pending operator write GO.",
+                "last_verified_evidence_ref": NOTION_SYNC_EVIDENCE_REF,
                 "MANIFEST_VERIFY_RC": 0,
-                "evidence_ref": NOTION_SYNC_EVIDENCE_REF,
             },
             "ratification_evidence": {
                 "pr_merge_verified": True,
@@ -187,6 +218,9 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
             "next_step_is_policy_selection",
             "economic_validity_pass_achieved",
             "step29n_or_runtime_authorized",
+            "runtime_rewire_admissible",
+            "system_economic_evidence_admissible",
+            "notion_current_after_pr5033",
         ],
         "view_only": True,
         "controls_allowed": False,

--- a/templates/peak_trade_dashboard/partials/market_current_state_compact_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_current_state_compact_v1.html
@@ -1,8 +1,8 @@
-{# STEP29M current-state panel — compact, view-only, no controls #}
+{# Full-parity current-state panel — compact, view-only, no controls #}
 <section
   class="rounded-lg border border-slate-800/70 bg-slate-950/55 px-2.5 py-2 mt-2"
   role="region"
-  aria-label="STEP29M current system state"
+  aria-label="Full parity current system state"
   data-market-current-state-compact-v1="true"
   data-market-current-state-owner-v1="{{ current_state.snapshot_owner|e }}"
   data-market-current-state-version-v1="{{ current_state.snapshot_version|e }}"
@@ -11,17 +11,26 @@
   data-market-controls-allowed-v1="false"
 >
   <div class="flex flex-wrap items-center justify-between gap-2 mb-1.5">
-    <h2 class="m-0 text-[10px] font-semibold uppercase tracking-wide text-slate-300">STEP29M · Current state</h2>
+    <h2 class="m-0 text-[10px] font-semibold uppercase tracking-wide text-slate-300">Full parity · Current state</h2>
     <span class="text-[9px] font-mono text-slate-500" data-market-current-origin-main-v1="true">origin/main · {{ current_state.system.CURRENT_ORIGIN_MAIN|e }}</span>
   </div>
 
   <dl class="m-0 grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-x-2 gap-y-1 text-[9px] font-mono mb-2" data-market-current-state-flags-v1="true">
+    <div><dt class="text-slate-500 uppercase">Chain wired</dt><dd class="m-0 text-emerald-200/90" data-market-full-canonical-chain-wired-v1="true">true</dd></div>
+    <div><dt class="text-slate-500 uppercase">Parity pass</dt><dd class="m-0 text-emerald-200/90" data-market-backtest-runtime-parity-pass-v1="true">true</dd></div>
+    <div><dt class="text-slate-500 uppercase">Econ evidence</dt><dd class="m-0 text-rose-200/90" data-market-economic-evidence-admissible-v1="true">false</dd></div>
+    <div><dt class="text-slate-500 uppercase">Runtime rewire</dt><dd class="m-0 text-rose-200/90" data-market-runtime-rewire-admissible-v1="true">false</dd></div>
+    <div><dt class="text-slate-500 uppercase">Next blocker</dt><dd class="m-0 text-amber-200/90" data-market-next-blocker-v1="true">{{ current_state.system.NEXT_BLOCKER|e }}</dd></div>
+    <div><dt class="text-slate-500 uppercase">Runtime</dt><dd class="m-0 text-slate-300" data-market-runtime-authorized-v1="true">false</dd></div>
+  </dl>
+
+  <dl class="m-0 grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-x-2 gap-y-1 text-[9px] font-mono mb-2" data-market-current-state-fleet-flags-v1="true">
     <div><dt class="text-slate-500 uppercase">Pending eval</dt><dd class="m-0 text-sky-200/90" data-market-authorized-pending-count-v1="true">{{ current_state.system.AUTHORIZED_PENDING_EVALUATION_COUNT|e }}</dd></div>
     <div><dt class="text-slate-500 uppercase">Next strategy</dt><dd class="m-0 text-sky-200/90" data-market-next-evaluation-strategy-v1="true">{{ current_state.system.NEXT_EVALUATION_STRATEGY_ID|e }}</dd></div>
     <div><dt class="text-slate-500 uppercase">Next status</dt><dd class="m-0 text-sky-200/90" data-market-next-evaluation-status-v1="true">{{ current_state.system.NEXT_EVALUATION_CONFIG_STATUS|e }}</dd></div>
     <div><dt class="text-slate-500 uppercase">Econ pass</dt><dd class="m-0 text-rose-200/90" data-market-economic-validity-pass-v1="true">false</dd></div>
     <div><dt class="text-slate-500 uppercase">Promotion</dt><dd class="m-0 text-slate-300" data-market-promotion-allowed-v1="true">false</dd></div>
-    <div><dt class="text-slate-500 uppercase">Runtime</dt><dd class="m-0 text-slate-300" data-market-runtime-authorized-v1="true">false</dd></div>
+    <div><dt class="text-slate-500 uppercase">Live</dt><dd class="m-0 text-slate-300" data-market-live-authorized-v1="true">false</dd></div>
   </dl>
 
   <div class="mb-2" data-market-strategy-fleet-compact-v1="true">
@@ -65,7 +74,7 @@
   <div class="rounded border border-sky-900/40 bg-sky-950/20 px-2 py-1.5 mb-2" data-market-next-canonical-step-v1="true">
     <p class="m-0 text-[9px] uppercase text-sky-300/90">Next canonical step</p>
     <p class="m-0 mt-0.5 font-mono text-[9px] text-sky-100/90 break-all">{{ current_state.next_canonical_step.step_id|e }}</p>
-    <p class="m-0 mt-1 text-[8px] text-slate-400">PREFLIGHT_ONLY=true · ECONOMIC_EVALUATION_AUTHORIZED=false · PRODUCTIVE_RUNNER_INVOCATIONS=0 · BACKTEST_ALLOWED=false</p>
+    <p class="m-0 mt-1 text-[8px] text-slate-400">PREFLIGHT_ONLY=true · ECONOMIC_EVALUATION_AUTHORIZED=false · PRODUCTIVE_RUNNER_INVOCATIONS=0 · BACKTEST_ALLOWED=false · RUNTIME_REWIRE_ADMISSIBLE=false</p>
   </div>
 
   <div class="flex flex-wrap gap-1 text-[8px] uppercase mb-1" data-market-governance-safety-compact-v1="true">
@@ -80,6 +89,6 @@
   </div>
 
   <p class="m-0 text-[8px] text-slate-500" data-market-evidence-primary-v1="true">
-    PR #4740 MERGED · Notion sync MANIFEST_VERIFY_RC=0 · view-only · no controls
+    PR #5033 MERGED · FULL_CANONICAL_CHAIN_WIRED=true · RUNTIME_REWIRE_ADMISSIBLE=false · view-only · no controls
   </p>
 </section>

--- a/templates/peak_trade_dashboard/partials/market_diagnostics_drawer_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_diagnostics_drawer_v1.html
@@ -20,11 +20,11 @@
       <dl class="m-0 grid grid-cols-1 sm:grid-cols-2 gap-2 text-[10px] font-mono text-slate-300">
         <div>
           <dt class="text-slate-500 uppercase">Notion current-state sync</dt>
-          <dd class="m-0 mt-0.5">NOTION_CURRENT=true · MANIFEST_VERIFY_RC=0</dd>
+          <dd class="m-0 mt-0.5">NOTION_CURRENT={{ current_state.pr_and_evidence_status.notion_current_state_sync.NOTION_CURRENT|lower }} · last verified MANIFEST_VERIFY_RC={{ current_state.pr_and_evidence_status.notion_current_state_sync.MANIFEST_VERIFY_RC|e }}</dd>
         </div>
         <div>
-          <dt class="text-slate-500 uppercase">PR #4740</dt>
-          <dd class="m-0 mt-0.5">MERGED · {{ current_state.pr_and_evidence_status.PR4740.merge_commit|e }}</dd>
+          <dt class="text-slate-500 uppercase">PR #5033</dt>
+          <dd class="m-0 mt-0.5">MERGED · {{ current_state.pr_and_evidence_status.PR5033.merge_commit|e }}</dd>
         </div>
         <div class="sm:col-span-2">
           <dt class="text-slate-500 uppercase">Ratification bundle (historical)</dt>

--- a/tests/webui/test_market_dashboard_current_state_sync_v0.py
+++ b/tests/webui/test_market_dashboard_current_state_sync_v0.py
@@ -1,4 +1,4 @@
-"""Market dashboard STEP29M current-state sync contract (view-only, SSR)."""
+"""Market dashboard full-parity current-state sync contract (view-only, SSR)."""
 
 from __future__ import annotations
 
@@ -20,6 +20,8 @@ pytestmark = pytest.mark.web
 
 from src.webui.app import create_app
 from src.webui.market_dashboard_current_state_snapshot_v0 import (
+    CURRENT_ORIGIN_MAIN,
+    NEXT_BLOCKER,
     NEXT_CANONICAL_STEP,
     SNAPSHOT_OWNER,
     market_dashboard_current_state_snapshot_v0,
@@ -92,7 +94,12 @@ def test_single_current_state_ssot_owner() -> None:
 
 def test_current_system_state_snapshot_values() -> None:
     system = market_dashboard_current_state_snapshot_v0()["current_system_state"]
-    assert system["CURRENT_ORIGIN_MAIN"] == "f37f20008bfaee613f8d7e5005acd80da62db78e"
+    assert system["CURRENT_ORIGIN_MAIN"] == CURRENT_ORIGIN_MAIN
+    assert system["FULL_CANONICAL_CHAIN_WIRED"] is True
+    assert system["BACKTEST_RUNTIME_DECISION_PARITY_PASS"] is True
+    assert system["SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE"] is False
+    assert system["RUNTIME_REWIRE_ADMISSIBLE"] is False
+    assert system["NEXT_BLOCKER"] == NEXT_BLOCKER
     assert system["STEP29M_EXECUTION_COMPLETE"] is True
     assert system["ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED"] is False
     assert system["CURRENT_FLEET_ECONOMIC_VALIDITY_PASS"] is False
@@ -105,6 +112,16 @@ def test_current_system_state_snapshot_values() -> None:
     assert system["RUNTIME_AUTHORIZED"] is False
     assert system["PROFITABILITY_CLAIM_ALLOWED"] is False
     assert system["NEXT_CANONICAL_STEP"] == NEXT_CANONICAL_STEP
+
+
+def test_full_parity_flags_visible(client: TestClient) -> None:
+    html = _html(client)
+    assert 'data-market-full-canonical-chain-wired-v1="true">true' in html
+    assert 'data-market-backtest-runtime-parity-pass-v1="true">true' in html
+    assert 'data-market-economic-evidence-admissible-v1="true">false' in html
+    assert 'data-market-runtime-rewire-admissible-v1="true">false' in html
+    assert f'data-market-next-blocker-v1="true">{NEXT_BLOCKER}' in html
+    assert CURRENT_ORIGIN_MAIN in html
 
 
 def test_strategy_fleet_snapshot(client: TestClient) -> None:
@@ -140,6 +157,7 @@ def test_next_canonical_step_exact(client: TestClient) -> None:
     assert "PREFLIGHT_ONLY=true" in html
     assert "ECONOMIC_EVALUATION_AUTHORIZED=false" in html
     assert "PRODUCTIVE_RUNNER_INVOCATIONS=0" in html
+    assert "RUNTIME_REWIRE_ADMISSIBLE=false" in html
 
 
 def test_governance_safety_flags_visible(client: TestClient) -> None:
@@ -177,7 +195,9 @@ def test_no_post_or_order_controls(client: TestClient) -> None:
 def test_evidence_integrity_secondary_not_dominant_alarm(client: TestClient) -> None:
     html = _html(client)
     assert 'data-market-evidence-primary-v1="true"' in html
-    assert "Notion sync MANIFEST_VERIFY_RC=0" in html
+    assert "PR #5033 MERGED" in html
+    assert "FULL_CANONICAL_CHAIN_WIRED=true" in html
+    assert "RUNTIME_REWIRE_ADMISSIBLE=false" in html
     assert 'data-market-diagnostics-evidence-integrity-v1="true"' in html
     assert 'data-market-ratification-manifest-drift-v1="true"' in html
     assert "REPORT.md hash drift" in html


### PR DESCRIPTION
## Summary
- Aktualisiert die view-only Market-Dashboard-Current-State-Oberfläche auf den Stand nach PR #5033 (Full-Parity PASS): `FULL_CANONICAL_CHAIN_WIRED=true`, `BACKTEST_RUNTIME_DECISION_PARITY_PASS=true`, `RUNTIME_REWIRE_ADMISSIBLE=false`, `NEXT_BLOCKER=SYSTEM_ECONOMIC_EVIDENCE_NOT_PROVEN`.
- Notion-Mirror bleibt bewusst **nicht** live geschrieben (`NOTION_CURRENT=false`); apply-ready Mirror-Artefakt liegt im Durable-Evidence-Bundle.
- Cybersecurity-Visibility-Surfaces reviewed — konsistent mit NO_RUNTIME/NO_CREDENTIALS/NO_LIVE; keine Repo-Mutation nötig.

## Test plan
- [x] `ruff format --check` / `ruff check` auf geänderte Python-Dateien
- [x] `tests/webui/test_market_dashboard_current_state_sync_v0.py` (13/13)
- [x] Selector-FOCUSED Market-Dashboard-Paket (754/754, ~55s)
- [x] Evidence-Bundle `pre_economics_notion_market_security_sync_v0_20260709T143714Z` mit `MANIFEST_VERIFY_RC=0`

## Evidence
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pre_economics_notion_market_security_sync_v0_20260709T143714Z`

## Next step after merge
`OFFLINE_ONLY_ECONOMIC_VIABILITY_EVIDENCE_GAP_ASSESSMENT_AND_REUSE_FIRST_BINDING`


Made with [Cursor](https://cursor.com)