### PR TITLE
Add bounded final fleet offline economic evaluation runner

### DIFF
--- a/scripts/research/bounded_final_research_fleet_offline_economic_evaluation_v0.py
+++ b/scripts/research/bounded_final_research_fleet_offline_economic_evaluation_v0.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+FINAL_FLEET = ("trend_following", "bollinger_bands", "momentum_1h")
+
+
+def _run_materializer(
+    repo_root: Path, output_dir: Path, operator: str, go_token: str
+) -> dict[str, Any]:
+    materializer = (
+        repo_root
+        / "scripts"
+        / "ops"
+        / "materialize_final_research_fleet_offline_economic_evaluation_execution_v0.py"
+    )
+    if not materializer.exists():
+        return {
+            "status": "FAIL_CLOSED",
+            "reason_codes": ["MATERIALIZER_SCRIPT_MISSING"],
+            "materializer_path": str(materializer),
+            "rc": 2,
+        }
+
+    cmd = [
+        sys.executable,
+        str(materializer),
+        "--repo-root",
+        str(repo_root),
+        "--output-dir",
+        str(output_dir),
+        "--operator",
+        operator,
+        "--go-token",
+        go_token,
+    ]
+
+    completed = subprocess.run(
+        cmd,
+        cwd=str(repo_root),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    (output_dir / "materializer_stdout.txt").write_text(completed.stdout, encoding="utf-8")
+    (output_dir / "materializer_stderr.txt").write_text(completed.stderr, encoding="utf-8")
+    (output_dir / "materializer.rc").write_text(f"{completed.returncode}\n", encoding="utf-8")
+
+    return {
+        "status": "PASS" if completed.returncode == 0 else "FAIL_CLOSED",
+        "reason_codes": [] if completed.returncode == 0 else ["MATERIALIZER_RC_NONZERO"],
+        "materializer_path": str(materializer),
+        "rc": completed.returncode,
+    }
+
+
+def _write_manifest(output_dir: Path) -> int:
+    manifest = output_dir / "MANIFEST.sha256"
+    files = sorted(
+        p
+        for p in output_dir.rglob("*")
+        if p.is_file()
+        and p.name not in {"MANIFEST.sha256", "MANIFEST.verify.txt", "MANIFEST.verify.rc"}
+    )
+
+    lines: list[str] = []
+    for file_path in files:
+        rel = file_path.relative_to(output_dir)
+        digest = subprocess.check_output(
+            ["shasum", "-a", "256", str(file_path)], text=True
+        ).split()[0]
+        lines.append(f"{digest}  {rel}\n")
+
+    manifest.write_text("".join(lines), encoding="utf-8")
+    verify = subprocess.run(
+        ["shasum", "-a", "256", "-c", "MANIFEST.sha256"],
+        cwd=str(output_dir),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    (output_dir / "MANIFEST.verify.txt").write_text(verify.stdout, encoding="utf-8")
+    (output_dir / "MANIFEST.verify.rc").write_text(f"{verify.returncode}\n", encoding="utf-8")
+    return verify.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--operator", required=True)
+    parser.add_argument("--go-token", required=True)
+    parser.add_argument("--fleet", required=True)
+    parser.add_argument("--futures-only", action="store_true")
+    parser.add_argument("--offline-only", action="store_true")
+    parser.add_argument("--no-runtime", action="store_true")
+    parser.add_argument("--no-orders", action="store_true")
+    parser.add_argument("--require-full-canonical-chain-wired", action="store_true")
+    parser.add_argument("--require-backtest-runtime-decision-parity-pass", action="store_true")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    requested_fleet = tuple(x.strip() for x in args.fleet.split(",") if x.strip())
+    reason_codes: list[str] = []
+
+    if requested_fleet != FINAL_FLEET:
+        reason_codes.append("FINAL_RESEARCH_FLEET_MISMATCH")
+    if not args.futures_only:
+        reason_codes.append("FUTURES_ONLY_NOT_ASSERTED")
+    if not args.offline_only:
+        reason_codes.append("OFFLINE_ONLY_NOT_ASSERTED")
+    if not args.no_runtime:
+        reason_codes.append("NO_RUNTIME_NOT_ASSERTED")
+    if not args.no_orders:
+        reason_codes.append("NO_ORDERS_NOT_ASSERTED")
+    if not args.require_full_canonical_chain_wired:
+        reason_codes.append("FULL_CANONICAL_CHAIN_WIRED_REQUIREMENT_MISSING")
+    if not args.require_backtest_runtime_decision_parity_pass:
+        reason_codes.append("BACKTEST_RUNTIME_DECISION_PARITY_REQUIREMENT_MISSING")
+
+    materializer_result = _run_materializer(repo_root, output_dir, args.operator, args.go_token)
+    reason_codes.extend(materializer_result["reason_codes"])
+
+    status = "PASS" if not reason_codes else "FAIL_CLOSED"
+
+    report = {
+        "verdict": (
+            "PASS_BOUNDED_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_V0"
+            if status == "PASS"
+            else "BLOCKED_BOUNDED_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_V0"
+        ),
+        "status": status,
+        "repo_root": str(repo_root),
+        "operator": args.operator,
+        "go_token": args.go_token,
+        "final_research_fleet": list(FINAL_FLEET),
+        "requested_fleet": list(requested_fleet),
+        "futures_only": args.futures_only,
+        "bitcoin_direction_allowed": False,
+        "offline_only": args.offline_only,
+        "no_runtime": args.no_runtime,
+        "no_orders": args.no_orders,
+        "no_credentials": True,
+        "system_economic_evidence_admissible": False,
+        "runtime_rewire_admissible": False,
+        "economic_validity_offline_gate_pass": False,
+        "materializer_result": materializer_result,
+        "reason_codes": reason_codes,
+        "authority_effect": "NONE",
+        "runtime_effect": "NONE",
+    }
+
+    (output_dir / "bounded_final_research_fleet_offline_economic_evaluation_v0.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    final_report_lines = [
+        f"VERDICT={report['verdict']}",
+        f"STATUS={status}",
+        f"REPO_ROOT={repo_root}",
+        f"OPERATOR={args.operator}",
+        f"GO_TOKEN={args.go_token}",
+        "FINAL_RESEARCH_FLEET=trend_following,bollinger_bands,momentum_1h",
+        f"REQUESTED_FLEET={','.join(requested_fleet)}",
+        f"FUTURES_ONLY={str(args.futures_only).lower()}",
+        "BITCOIN_DIRECTION_ALLOWED=false",
+        f"OFFLINE_ONLY={str(args.offline_only).lower()}",
+        f"NO_RUNTIME={str(args.no_runtime).lower()}",
+        f"NO_ORDERS={str(args.no_orders).lower()}",
+        "NO_CREDENTIALS=true",
+        "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false",
+        "RUNTIME_REWIRE_ADMISSIBLE=false",
+        "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS=false",
+        f"MATERIALIZER_RC={materializer_result['rc']}",
+        f"REASON_CODES={','.join(reason_codes) if reason_codes else 'NONE'}",
+        "AUTHORITY_EFFECT=NONE",
+        "RUNTIME_EFFECT=NONE",
+    ]
+    (output_dir / "final_report.txt").write_text(
+        "\n".join(final_report_lines) + "\n", encoding="utf-8"
+    )
+
+    manifest_rc = _write_manifest(output_dir)
+    return 0 if status == "PASS" and manifest_rc == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/research/test_bounded_final_research_fleet_offline_economic_evaluation_v0.py
+++ b/tests/research/test_bounded_final_research_fleet_offline_economic_evaluation_v0.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_bounded_final_research_fleet_runner_exists() -> None:
+    assert Path(
+        "scripts/research/bounded_final_research_fleet_offline_economic_evaluation_v0.py"
+    ).exists()
+
+
+def test_bounded_final_research_fleet_runner_help() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/research/bounded_final_research_fleet_offline_economic_evaluation_v0.py",
+            "--help",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "--fleet" in result.stdout
+    assert "--offline-only" in result.stdout
+    assert "--no-runtime" in result.stdout
+
+
+def test_bounded_final_research_fleet_runner_fail_closed_on_wrong_fleet(tmp_path: Path) -> None:
+    out = tmp_path / "evidence"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/research/bounded_final_research_fleet_offline_economic_evaluation_v0.py",
+            "--repo-root",
+            ".",
+            "--output-dir",
+            str(out),
+            "--operator",
+            "Frank Rauter",
+            "--go-token",
+            "GO_IMPLEMENT_BOUNDED_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_RUNNER_V0",
+            "--fleet",
+            "trend_following",
+            "--futures-only",
+            "--offline-only",
+            "--no-runtime",
+            "--no-orders",
+            "--require-full-canonical-chain-wired",
+            "--require-backtest-runtime-decision-parity-pass",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert result.returncode == 1
+    payload = json.loads(
+        (out / "bounded_final_research_fleet_offline_economic_evaluation_v0.json").read_text()
+    )
+    assert payload["status"] == "FAIL_CLOSED"
+    assert "FINAL_RESEARCH_FLEET_MISMATCH" in payload["reason_codes"]
+    assert payload["system_economic_evidence_admissible"] is False
+    assert payload["runtime_rewire_admissible"] is False
+    assert payload["authority_effect"] == "NONE"
+    assert payload["runtime_effect"] == "NONE"
+
+
+def test_bounded_final_research_fleet_runner_passes_or_fail_closed_with_manifest(
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "evidence"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/research/bounded_final_research_fleet_offline_economic_evaluation_v0.py",
+            "--repo-root",
+            ".",
+            "--output-dir",
+            str(out),
+            "--operator",
+            "Frank Rauter",
+            "--go-token",
+            "GO_IMPLEMENT_BOUNDED_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_RUNNER_V0",
+            "--fleet",
+            "trend_following,bollinger_bands,momentum_1h",
+            "--futures-only",
+            "--offline-only",
+            "--no-runtime",
+            "--no-orders",
+            "--require-full-canonical-chain-wired",
+            "--require-backtest-runtime-decision-parity-pass",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert result.returncode in {0, 1}
+    assert (out / "bounded_final_research_fleet_offline_economic_evaluation_v0.json").exists()
+    assert (out / "final_report.txt").exists()
+    assert (out / "MANIFEST.sha256").exists()
+    assert (out / "MANIFEST.verify.rc").read_text().strip() == "0"
+    payload = json.loads(
+        (out / "bounded_final_research_fleet_offline_economic_evaluation_v0.json").read_text()
+    )
+    assert payload["final_research_fleet"] == ["trend_following", "bollinger_bands", "momentum_1h"]
+    assert payload["futures_only"] is True
+    assert payload["bitcoin_direction_allowed"] is False
+    assert payload["offline_only"] is True
+    assert payload["no_runtime"] is True
+    assert payload["no_orders"] is True
+    assert payload["system_economic_evidence_admissible"] is False
+    assert payload["runtime_rewire_admissible"] is False


### PR DESCRIPTION
Implements the missing offline-only bounded final research fleet economic evaluation runner by reusing the existing final_research_fleet_offline_economic_evaluation_execution materializer path.

Scope:
- offline-only runner under scripts/research
- final fleet fixed to trend_following,bollinger_bands,momentum_1h
- futures-only and no-Bitcoin boundary
- no runtime, no orders, no credentials, no authority effects
- manifest-verified durable output
- fail-closed behavior for wrong fleet or missing materializer
- targeted contract tests

Non-goals:
- no runtime evidence
- no shadow/paper/testnet/canary/live
- no strategy mutation
- no safety/runtime mutation
- no EconomicValidity pass claim
- no RuntimeRewire admissibility

GO_TOKEN=GO_IMPLEMENT_BOUNDED_FINAL_RESEARCH_FLEET_OFFLINE_ECONOMIC_EVALUATION_RUNNER_V0
OPERATOR=Frank Rauter
DURABLE_ROOT=/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z

Made with [Cursor](https://cursor.com)