### PR TITLE
fix: bind final fleet economic runner to materializer cli

### DIFF
--- a/scripts/research/bounded_final_research_fleet_offline_economic_evaluation_v0.py
+++ b/scripts/research/bounded_final_research_fleet_offline_economic_evaluation_v0.py
@@ -9,6 +9,16 @@ from typing import Any
 
 
 FINAL_FLEET = ("trend_following", "bollinger_bands", "momentum_1h")
+DEFAULT_BINDING_COMPLETION_RELATIVE_PATH = (
+    "config/research/final_research_fleet_versioned_binding_completion_v0.json"
+)
+
+
+def _resolve_durable_evidence_root(output_dir: Path) -> Path:
+    for parent in output_dir.parents:
+        if parent.name == "research":
+            return parent.parent
+    return output_dir
 
 
 def _run_materializer(
@@ -28,17 +38,20 @@ def _run_materializer(
             "rc": 2,
         }
 
+    binding_completion_path = repo_root / DEFAULT_BINDING_COMPLETION_RELATIVE_PATH
+    durable_evidence_root = _resolve_durable_evidence_root(output_dir)
+
     cmd = [
         sys.executable,
         str(materializer),
-        "--repo-root",
-        str(repo_root),
-        "--output-dir",
-        str(output_dir),
-        "--operator",
-        operator,
-        "--go-token",
+        "--confirm-go-token",
         go_token,
+        "--binding-completion-path",
+        str(binding_completion_path),
+        "--durable-evidence-root",
+        str(durable_evidence_root),
+        "--primary-worktree",
+        str(repo_root),
     ]
 
     completed = subprocess.run(


### PR DESCRIPTION
## Summary
- binds bounded final fleet offline economic evaluation runner to the canonical materializer CLI signature
- replaces stale materializer args with confirm-go-token, binding-completion-path, durable-evidence-root
- preserves offline-only, no-runtime, no-orders, no-credentials boundaries

## Gates
- targeted pytest RC=0
- ruff check RC=0
- ruff format RC=0
- py_compile RC=0
- evaluation smoke RC=1 fail-closed allowed
- manifest verify RC=0

## Evidence
/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/fix_bounded_final_fleet_economic_runner_materializer_cli_binding_v0_20260709T160223Z

## Safety
OFFLINE_ONLY=true
NO_RUNTIME=true
NO_ORDERS=true
NO_CREDENTIALS=true
SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false
RUNTIME_REWIRE_ADMISSIBLE=false