### PR TITLE
fix: include repo root in canonical gap assessment runner path

### DIFF
--- a/scripts/ops/run_full_canonical_system_backtest_parity_gap_assessment_v0.py
+++ b/scripts/ops/run_full_canonical_system_backtest_parity_gap_assessment_v0.py
@@ -111,6 +111,7 @@ def _verify_post_merge_guard_preflight(evidence_dir: Path) -> tuple[int, list[st
 
 def collect_evidence(out_dir: Path | None = None) -> dict[str, object]:
     sys.path.insert(0, str(REPO_ROOT / "src"))
+    sys.path.insert(0, str(REPO_ROOT))
     from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
         parity_gap_records_v0,
         parity_status_counts_v0,


### PR DESCRIPTION
Fixes the full canonical system backtest parity gap assessment ops runner import path so src-prefixed imports resolve during offline assessment collection.

Evidence:
/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/commit_full_canonical_gap_assessment_ops_runner_src_import_path_v0_20260709T203932Z

Validated:
- py_compile RC=0
- runner --out RC=0
- targeted pytest RC=0
- python -m ruff check RC=0
- python -m ruff format --check RC=0
- manifest verify RC=0

Scope:
- only scripts/ops/run_full_canonical_system_backtest_parity_gap_assessment_v0.py
- docs side effect reset before commit
- no runtime
- no shadow
- no paper
- no testnet
- no orders
- no credentials
- no arming

Made with [Cursor](https://cursor.com)