### PR TITLE
Add offline linear cost diagnostics scaffold

### DIFF
--- a/scripts/research/offline_linear_cost_model_diagnostics_v0.py
+++ b/scripts/research/offline_linear_cost_model_diagnostics_v0.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_SCRIPT_ROOT = Path(__file__).resolve()
+for parent in [_SCRIPT_ROOT, *_SCRIPT_ROOT.parents]:
+    if (parent / "src").is_dir() and (parent / ".git").exists():
+        repo_s = str(parent)
+        if repo_s not in sys.path:
+            sys.path.insert(0, repo_s)
+        break
+
+import numpy as np
+
+from src.research.linear_evidence.contracts import to_jsonable
+from src.research.linear_evidence.cost_model import build_cost_model_calibration_evidence
+from src.research.linear_evidence.feature_matrix import build_feature_matrix_binding
+from src.research.linear_evidence.fitters import fit_ols_lstsq
+
+
+FIXTURE_ROWS = [
+    {
+        "decision_time": "2026-01-01T00:00:00Z",
+        "spread_bps": 4.0,
+        "volatility_estimate": 0.010,
+        "order_notional_to_depth": 0.10,
+        "funding_rate_abs": 0.0001,
+        "liquidity_score": 0.90,
+        "realized_slippage_bps": 5.2,
+    },
+    {
+        "decision_time": "2026-01-01T01:00:00Z",
+        "spread_bps": 4.5,
+        "volatility_estimate": 0.011,
+        "order_notional_to_depth": 0.12,
+        "funding_rate_abs": 0.0001,
+        "liquidity_score": 0.88,
+        "realized_slippage_bps": 5.8,
+    },
+    {
+        "decision_time": "2026-01-01T02:00:00Z",
+        "spread_bps": 5.0,
+        "volatility_estimate": 0.014,
+        "order_notional_to_depth": 0.16,
+        "funding_rate_abs": 0.0002,
+        "liquidity_score": 0.80,
+        "realized_slippage_bps": 7.0,
+    },
+    {
+        "decision_time": "2026-01-01T03:00:00Z",
+        "spread_bps": 5.5,
+        "volatility_estimate": 0.015,
+        "order_notional_to_depth": 0.20,
+        "funding_rate_abs": 0.0002,
+        "liquidity_score": 0.76,
+        "realized_slippage_bps": 7.8,
+    },
+    {
+        "decision_time": "2026-01-01T04:00:00Z",
+        "spread_bps": 6.0,
+        "volatility_estimate": 0.018,
+        "order_notional_to_depth": 0.22,
+        "funding_rate_abs": 0.0003,
+        "liquidity_score": 0.70,
+        "realized_slippage_bps": 9.1,
+    },
+    {
+        "decision_time": "2026-01-01T05:00:00Z",
+        "spread_bps": 6.5,
+        "volatility_estimate": 0.020,
+        "order_notional_to_depth": 0.24,
+        "funding_rate_abs": 0.0003,
+        "liquidity_score": 0.66,
+        "realized_slippage_bps": 10.0,
+    },
+    {
+        "decision_time": "2026-01-01T06:00:00Z",
+        "spread_bps": 7.2,
+        "volatility_estimate": 0.023,
+        "order_notional_to_depth": 0.27,
+        "funding_rate_abs": 0.0004,
+        "liquidity_score": 0.60,
+        "realized_slippage_bps": 11.8,
+    },
+    {
+        "decision_time": "2026-01-01T07:00:00Z",
+        "spread_bps": 8.0,
+        "volatility_estimate": 0.026,
+        "order_notional_to_depth": 0.30,
+        "funding_rate_abs": 0.0005,
+        "liquidity_score": 0.55,
+        "realized_slippage_bps": 13.0,
+    },
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    feature_names = (
+        "spread_bps",
+        "volatility_estimate",
+        "order_notional_to_depth",
+        "funding_rate_abs",
+        "liquidity_score",
+    )
+    x, y, binding = build_feature_matrix_binding(
+        FIXTURE_ROWS,
+        feature_names=feature_names,
+        target_name="realized_slippage_bps",
+    )
+    model = fit_ols_lstsq(x, y, binding)
+    design_all = np.column_stack([np.ones(x.shape[0]), x])
+    coeff_values = np.asarray(list(model.coefficients.values()), dtype=float)
+    predicted = design_all @ coeff_values
+    calibration = build_cost_model_calibration_evidence(
+        model, observed_target_bps=y, predicted_target_bps=predicted
+    )
+
+    report = {
+        "verdict": "OFFLINE_LINEAR_COST_MODEL_DIAGNOSTICS_V0_PASS_OR_FAIL_CLOSED",
+        "offline_only": True,
+        "runtime_authority": False,
+        "order_authority": False,
+        "promotion_pass_authority": False,
+        "backtest_cost_default_change": False,
+        "calibration": to_jsonable(calibration),
+    }
+    (out / "offline_linear_cost_model_diagnostics_v0.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print("VERDICT=OFFLINE_LINEAR_COST_MODEL_DIAGNOSTICS_V0_PASS_OR_FAIL_CLOSED")
+    print(f"REPORT={out / 'offline_linear_cost_model_diagnostics_v0.json'}")
+    print(f"STATUS={calibration.status}")
+    print("OFFLINE_ONLY=true")
+    print("RUNTIME_AUTHORITY=false")
+    print("ORDER_AUTHORITY=false")
+    print("PROMOTION_PASS_AUTHORITY=false")
+    print("BACKTEST_COST_DEFAULT_CHANGE=false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/linear_evidence/__init__.py
+++ b/src/research/linear_evidence/__init__.py
@@ -1,0 +1,25 @@
+"""Offline linear evidence diagnostics.
+
+This package is offline-only and authority-neutral. It must not import runtime,
+scheduler, live execution, or order adapter paths.
+"""
+
+from .contracts import (
+    CostModelCalibrationEvidenceV1,
+    FeatureMatrixBindingV1,
+    LinearModelDiagnosticsV1,
+    LinearModelEvidenceV1,
+)
+from .cost_model import build_cost_model_calibration_evidence
+from .feature_matrix import build_feature_matrix_binding
+from .fitters import fit_ols_lstsq
+
+__all__ = [
+    "CostModelCalibrationEvidenceV1",
+    "FeatureMatrixBindingV1",
+    "LinearModelDiagnosticsV1",
+    "LinearModelEvidenceV1",
+    "build_cost_model_calibration_evidence",
+    "build_feature_matrix_binding",
+    "fit_ols_lstsq",
+]

--- a/src/research/linear_evidence/contracts.py
+++ b/src/research/linear_evidence/contracts.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+
+_ALLOWED_LINEAR_STATUSES = {
+    "DIAGNOSTIC_ONLY",
+    "CALIBRATION_CANDIDATE",
+    "CALIBRATION_VALIDATION_FAILED",
+    "CALIBRATION_VALIDATED_OFFLINE",
+    "ROBUSTNESS_FAILED",
+    "INSUFFICIENT_DATA",
+    "LEAKAGE_BLOCKED",
+    "RANK_DEFICIENT_BLOCKED",
+}
+
+
+@dataclass(frozen=True)
+class FeatureMatrixBindingV1:
+    target_name: str
+    feature_names: tuple[str, ...]
+    n_samples: int
+    n_features: int
+    feature_matrix_digest: str
+    target_digest: str
+    validation_policy: str
+    time_range: Mapping[str, str]
+    row_count_before_filter: int
+    row_count_after_filter: int
+    dropped_rows_by_reason: Mapping[str, int] = field(default_factory=dict)
+    status: str = "DIAGNOSTIC_ONLY"
+    reason_codes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.validation_policy != "TIME_ORDERED":
+            raise ValueError("RANDOM_VALIDATION_SPLIT_BLOCKED")
+        if self.n_samples < 1 or self.n_features < 1:
+            raise ValueError("INSUFFICIENT_DATA")
+        if self.n_features != len(self.feature_names):
+            raise ValueError("FEATURE_COUNT_MISMATCH")
+        if self.status not in _ALLOWED_LINEAR_STATUSES:
+            raise ValueError(f"unsupported linear evidence status: {self.status}")
+
+
+@dataclass(frozen=True)
+class LinearModelDiagnosticsV1:
+    rank: int
+    condition_number: float
+    rmse: float
+    mae: float
+    max_abs_error: float
+    r2_train: float
+    r2_validation: float | None
+    residual_mean: float
+    residual_std: float
+    outlier_count: int
+
+
+@dataclass(frozen=True)
+class LinearModelEvidenceV1:
+    evidence_type: str
+    model_family: str
+    target_name: str
+    feature_names: tuple[str, ...]
+    n_samples: int
+    n_features: int
+    solver: str
+    fit_intercept: bool
+    coefficients: Mapping[str, float]
+    diagnostics: LinearModelDiagnosticsV1
+    feature_matrix_digest: str
+    target_digest: str
+    config_digest: str
+    time_range: Mapping[str, str]
+    instrument_universe_digest: str
+    row_count_before_filter: int
+    row_count_after_filter: int
+    dropped_rows_by_reason: Mapping[str, int]
+    validation_policy: str
+    cost_policy_output: str
+    status: str
+    reason_codes: tuple[str, ...]
+    authority_effect: str = "NONE"
+    runtime_effect: str = "NONE"
+
+    def __post_init__(self) -> None:
+        if self.solver != "numpy.linalg.lstsq":
+            raise ValueError("unsupported solver for v0")
+        if self.validation_policy != "TIME_ORDERED":
+            raise ValueError("RANDOM_VALIDATION_SPLIT_BLOCKED")
+        if self.authority_effect != "NONE" or self.runtime_effect != "NONE":
+            raise ValueError("linear evidence must be authority-neutral")
+        if self.cost_policy_output not in {"diagnostic_only", "conservative_review_candidate"}:
+            raise ValueError("COST_POLICY_BELOW_FLOOR_BLOCKED")
+        if self.status not in _ALLOWED_LINEAR_STATUSES:
+            raise ValueError(f"unsupported linear evidence status: {self.status}")
+
+
+@dataclass(frozen=True)
+class CostModelCalibrationEvidenceV1:
+    linear_model_evidence: LinearModelEvidenceV1
+    rmse_bps: float
+    mae_bps: float
+    max_abs_error_bps: float
+    p75_abs_error_bps: float
+    p90_abs_error_bps: float
+    stress_cost_bps: float
+    calibrated_cost_policy: str
+    status: str
+    reason_codes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.calibrated_cost_policy != "CONSERVATIVE_NOT_MEAN":
+            raise ValueError("CALIBRATED_COST_POLICY_MUST_BE_CONSERVATIVE_NOT_MEAN")
+        if self.linear_model_evidence.authority_effect != "NONE":
+            raise ValueError("OLS_COST_DIAGNOSTICS_CAN_NOT_SET_AUTHORITY")
+        if self.status not in _ALLOWED_LINEAR_STATUSES:
+            raise ValueError(f"unsupported calibration evidence status: {self.status}")
+
+
+def to_jsonable(value: Any) -> Any:
+    if hasattr(value, "__dataclass_fields__"):
+        return {k: to_jsonable(getattr(value, k)) for k in value.__dataclass_fields__}
+    if isinstance(value, Mapping):
+        return {str(k): to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [to_jsonable(v) for v in value]
+    return value

--- a/src/research/linear_evidence/cost_model.py
+++ b/src/research/linear_evidence/cost_model.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .contracts import CostModelCalibrationEvidenceV1, LinearModelEvidenceV1
+
+
+def build_cost_model_calibration_evidence(
+    model_evidence: LinearModelEvidenceV1,
+    *,
+    observed_target_bps: np.ndarray,
+    predicted_target_bps: np.ndarray,
+) -> CostModelCalibrationEvidenceV1:
+    if observed_target_bps.shape != predicted_target_bps.shape:
+        raise ValueError("FEATURE_TARGET_SHAPE_MISMATCH")
+    residual_abs = np.abs(observed_target_bps - predicted_target_bps)
+    if residual_abs.size == 0:
+        raise ValueError("INSUFFICIENT_DATA")
+
+    p75 = float(np.percentile(residual_abs, 75))
+    p90 = float(np.percentile(residual_abs, 90))
+    stress = float(max(p90, np.max(residual_abs)))
+
+    status = model_evidence.status
+    reason_codes = tuple(model_evidence.reason_codes)
+    if model_evidence.status == "CALIBRATION_CANDIDATE" and p90 >= 0:
+        status = "CALIBRATION_VALIDATED_OFFLINE"
+
+    return CostModelCalibrationEvidenceV1(
+        linear_model_evidence=model_evidence,
+        rmse_bps=float(np.sqrt(np.mean((observed_target_bps - predicted_target_bps) ** 2))),
+        mae_bps=float(np.mean(residual_abs)),
+        max_abs_error_bps=float(np.max(residual_abs)),
+        p75_abs_error_bps=p75,
+        p90_abs_error_bps=p90,
+        stress_cost_bps=stress,
+        calibrated_cost_policy="CONSERVATIVE_NOT_MEAN",
+        status=status,
+        reason_codes=reason_codes,
+    )

--- a/src/research/linear_evidence/feature_matrix.py
+++ b/src/research/linear_evidence/feature_matrix.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from .contracts import FeatureMatrixBindingV1
+
+
+def _stable_digest(payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _as_float(value: object, *, field_name: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"NON_NUMERIC_FIELD:{field_name}") from exc
+    if not np.isfinite(result):
+        raise ValueError(f"NON_FINITE_FIELD:{field_name}")
+    return result
+
+
+def build_feature_matrix_binding(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    feature_names: Sequence[str],
+    target_name: str,
+    time_name: str = "decision_time",
+    validation_policy: str = "TIME_ORDERED",
+) -> tuple[np.ndarray, np.ndarray, FeatureMatrixBindingV1]:
+    if validation_policy != "TIME_ORDERED":
+        raise ValueError("RANDOM_VALIDATION_SPLIT_BLOCKED")
+    if not rows:
+        raise ValueError("INSUFFICIENT_DATA")
+    if not feature_names:
+        raise ValueError("INSUFFICIENT_DATA")
+
+    ordered = sorted(rows, key=lambda row: str(row.get(time_name, "")))
+    times = [str(row.get(time_name, "")) for row in ordered]
+    if any(not t for t in times):
+        raise ValueError("TARGET_BINDING_MISSING")
+    if times != sorted(times):
+        raise ValueError("TIME_ORDERING_FAILED")
+
+    dropped: dict[str, int] = {}
+    xs: list[list[float]] = []
+    ys: list[float] = []
+    kept_rows: list[Mapping[str, object]] = []
+
+    for row in ordered:
+        try:
+            xs.append([_as_float(row.get(name), field_name=name) for name in feature_names])
+            ys.append(_as_float(row.get(target_name), field_name=target_name))
+            kept_rows.append(row)
+        except ValueError as exc:
+            dropped[str(exc)] = dropped.get(str(exc), 0) + 1
+
+    if not xs:
+        raise ValueError("INSUFFICIENT_DATA")
+
+    x = np.asarray(xs, dtype=float)
+    y = np.asarray(ys, dtype=float)
+    binding = FeatureMatrixBindingV1(
+        target_name=target_name,
+        feature_names=tuple(feature_names),
+        n_samples=int(x.shape[0]),
+        n_features=int(x.shape[1]),
+        feature_matrix_digest=_stable_digest(
+            {"feature_names": list(feature_names), "x": x.tolist()}
+        ),
+        target_digest=_stable_digest({"target_name": target_name, "y": y.tolist()}),
+        validation_policy=validation_policy,
+        time_range={"start": str(kept_rows[0][time_name]), "end": str(kept_rows[-1][time_name])},
+        row_count_before_filter=len(rows),
+        row_count_after_filter=int(x.shape[0]),
+        dropped_rows_by_reason=dropped,
+    )
+    return x, y, binding

--- a/src/research/linear_evidence/fitters.py
+++ b/src/research/linear_evidence/fitters.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+
+import numpy as np
+
+from .contracts import FeatureMatrixBindingV1, LinearModelDiagnosticsV1, LinearModelEvidenceV1
+
+
+def _digest(payload: object) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode()
+    ).hexdigest()
+
+
+def _r2(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    denom = float(np.sum((y_true - float(np.mean(y_true))) ** 2))
+    if denom == 0.0:
+        return 0.0
+    return 1.0 - float(np.sum((y_true - y_pred) ** 2)) / denom
+
+
+def fit_ols_lstsq(
+    x: np.ndarray,
+    y: np.ndarray,
+    binding: FeatureMatrixBindingV1,
+    *,
+    fit_intercept: bool = True,
+    validation_fraction: float = 0.25,
+    evidence_type: str = "CostModelCalibrationEvidenceV1",
+    instrument_universe_digest: str = "fixture_universe",
+) -> LinearModelEvidenceV1:
+    if x.ndim != 2 or y.ndim != 1:
+        raise ValueError("FEATURE_TARGET_SHAPE_MISMATCH")
+    if x.shape[0] != y.shape[0]:
+        raise ValueError("FEATURE_TARGET_ROW_MISMATCH")
+    if x.shape[0] < max(4, x.shape[1] + 2):
+        raise ValueError("INSUFFICIENT_DATA")
+
+    n = x.shape[0]
+    split = max(1, min(n - 1, int(round(n * (1.0 - validation_fraction)))))
+    x_train = x[:split]
+    y_train = y[:split]
+    x_validation = x[split:]
+    y_validation = y[split:]
+
+    design_train = (
+        np.column_stack([np.ones(x_train.shape[0]), x_train]) if fit_intercept else x_train
+    )
+    design_all = np.column_stack([np.ones(x.shape[0]), x]) if fit_intercept else x
+
+    coeffs, _, rank, _ = np.linalg.lstsq(design_train, y_train, rcond=None)
+    y_pred_all = design_all @ coeffs
+    residuals = y - y_pred_all
+
+    validation_pred = (
+        (
+            np.column_stack([np.ones(x_validation.shape[0]), x_validation])
+            if fit_intercept
+            else x_validation
+        )
+        @ coeffs
+        if len(x_validation)
+        else np.asarray([], dtype=float)
+    )
+
+    mae = float(np.mean(np.abs(residuals)))
+    rmse = float(np.sqrt(np.mean(residuals**2)))
+    max_abs_error = float(np.max(np.abs(residuals)))
+    condition_number = float(np.linalg.cond(design_train))
+    residual_std = float(np.std(residuals))
+    outlier_cutoff = 3.0 * residual_std if residual_std > 0 else float("inf")
+
+    names = (("intercept",) if fit_intercept else ()) + tuple(binding.feature_names)
+    if len(names) != len(coeffs):
+        raise ValueError("COEFFICIENT_NAME_COUNT_MISMATCH")
+    coefficients: Mapping[str, float] = {name: float(value) for name, value in zip(names, coeffs)}
+    validation_r2 = _r2(y_validation, validation_pred) if len(y_validation) else None
+
+    status = "CALIBRATION_CANDIDATE"
+    reasons: list[str] = []
+    if rank < design_train.shape[1]:
+        status = "RANK_DEFICIENT_BLOCKED"
+        reasons.append("HIGH_CONDITION_NUMBER")
+    elif condition_number > 1_000_000:
+        status = "ROBUSTNESS_FAILED"
+        reasons.append("HIGH_CONDITION_NUMBER")
+
+    diagnostics = LinearModelDiagnosticsV1(
+        rank=int(rank),
+        condition_number=condition_number,
+        rmse=rmse,
+        mae=mae,
+        max_abs_error=max_abs_error,
+        r2_train=_r2(y_train, design_train @ coeffs),
+        r2_validation=validation_r2,
+        residual_mean=float(np.mean(residuals)),
+        residual_std=residual_std,
+        outlier_count=int(np.sum(np.abs(residuals) > outlier_cutoff)),
+    )
+
+    return LinearModelEvidenceV1(
+        evidence_type=evidence_type,
+        model_family="OLS",
+        target_name=binding.target_name,
+        feature_names=binding.feature_names,
+        n_samples=binding.n_samples,
+        n_features=binding.n_features,
+        solver="numpy.linalg.lstsq",
+        fit_intercept=fit_intercept,
+        coefficients=coefficients,
+        diagnostics=diagnostics,
+        feature_matrix_digest=binding.feature_matrix_digest,
+        target_digest=binding.target_digest,
+        config_digest=_digest(
+            {"fit_intercept": fit_intercept, "validation_fraction": validation_fraction}
+        ),
+        time_range=binding.time_range,
+        instrument_universe_digest=instrument_universe_digest,
+        row_count_before_filter=binding.row_count_before_filter,
+        row_count_after_filter=binding.row_count_after_filter,
+        dropped_rows_by_reason=binding.dropped_rows_by_reason,
+        validation_policy=binding.validation_policy,
+        cost_policy_output="diagnostic_only",
+        status=status,
+        reason_codes=tuple(reasons),
+    )

--- a/tests/research/test_offline_linear_cost_model_diagnostics_v0.py
+++ b/tests/research/test_offline_linear_cost_model_diagnostics_v0.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.research.linear_evidence.feature_matrix import build_feature_matrix_binding
+from src.research.linear_evidence.fitters import fit_ols_lstsq
+
+
+def test_feature_matrix_blocks_random_validation_split() -> None:
+    with pytest.raises(ValueError, match="RANDOM_VALIDATION_SPLIT_BLOCKED"):
+        build_feature_matrix_binding(
+            [{"decision_time": "2026-01-01T00:00:00Z", "x": 1.0, "y": 2.0}],
+            feature_names=("x",),
+            target_name="y",
+            validation_policy="RANDOM",
+        )
+
+
+def test_ols_evidence_is_authority_neutral() -> None:
+    rows = [
+        {
+            "decision_time": f"2026-01-01T0{i}:00:00Z",
+            "x": float(i),
+            "z": float(i + 1),
+            "y": float(2 * i + 1),
+        }
+        for i in range(8)
+    ]
+    x, y, binding = build_feature_matrix_binding(rows, feature_names=("x", "z"), target_name="y")
+    evidence = fit_ols_lstsq(x, y, binding)
+
+    assert evidence.solver == "numpy.linalg.lstsq"
+    assert evidence.authority_effect == "NONE"
+    assert evidence.runtime_effect == "NONE"
+    assert evidence.cost_policy_output == "diagnostic_only"
+    assert evidence.validation_policy == "TIME_ORDERED"
+
+
+def test_offline_linear_cost_model_diagnostics_cli(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/research/offline_linear_cost_model_diagnostics_v0.py",
+            "--out",
+            str(tmp_path),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads((tmp_path / "offline_linear_cost_model_diagnostics_v0.json").read_text())
+    assert report["offline_only"] is True
+    assert report["runtime_authority"] is False
+    assert report["order_authority"] is False
+    assert report["promotion_pass_authority"] is False
+    assert report["backtest_cost_default_change"] is False
+    assert report["calibration"]["calibrated_cost_policy"] == "CONSERVATIVE_NOT_MEAN"


### PR DESCRIPTION
## Summary
- adds offline-only LinearModelEvidenceV1 / CostModelCalibrationEvidenceV1 scaffolding
- adds deterministic feature-matrix binding and numpy.linalg.lstsq baseline fitter
- adds authority-neutral cost diagnostics CLI and targeted tests

## Safety / authority
- OFFLINE_ONLY=true
- RUNTIME_AUTHORITY=false
- ORDER_AUTHORITY=false
- PROMOTION_PASS_AUTHORITY=false
- BACKTEST_COST_DEFAULT_CHANGE=false

## Evidence
/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/offline_linear_cost_model_diagnostics_v0_implementation_20260709T205317Z

## Gates
- py_compile: PASS
- targeted pytest: PASS
- diagnostics CLI: PASS
- ruff: PASS

Made with [Cursor](https://cursor.com)