### PR TITLE
Add offline factor exposure diagnostics scaffold

### DIFF
--- a/scripts/research/offline_factor_exposure_diagnostics_v0.py
+++ b/scripts/research/offline_factor_exposure_diagnostics_v0.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from research.linear_evidence.factor_exposure import FactorExposureInputV1, fit_factor_exposure
+
+
+def _fixture_records():
+    return [
+        FactorExposureInputV1(
+            "PF_ETHUSD",
+            1,
+            0.010,
+            {"market_beta": 0.10, "liquidity_beta": 0.05, "volatility_beta": 0.20},
+        ),
+        FactorExposureInputV1(
+            "PF_ETHUSD",
+            2,
+            0.012,
+            {"market_beta": 0.11, "liquidity_beta": 0.04, "volatility_beta": 0.19},
+        ),
+        FactorExposureInputV1(
+            "PF_ETHUSD",
+            3,
+            0.009,
+            {"market_beta": 0.09, "liquidity_beta": 0.06, "volatility_beta": 0.21},
+        ),
+        FactorExposureInputV1(
+            "PF_SOLUSD",
+            4,
+            -0.004,
+            {"market_beta": -0.02, "liquidity_beta": 0.03, "volatility_beta": 0.25},
+        ),
+        FactorExposureInputV1(
+            "PF_SOLUSD",
+            5,
+            -0.006,
+            {"market_beta": -0.03, "liquidity_beta": 0.02, "volatility_beta": 0.26},
+        ),
+        FactorExposureInputV1(
+            "PF_SOLUSD",
+            6,
+            0.003,
+            {"market_beta": 0.04, "liquidity_beta": 0.08, "volatility_beta": 0.18},
+        ),
+        FactorExposureInputV1(
+            "PF_AVAXUSD",
+            7,
+            0.007,
+            {"market_beta": 0.08, "liquidity_beta": 0.07, "volatility_beta": 0.17},
+        ),
+        FactorExposureInputV1(
+            "PF_AVAXUSD",
+            8,
+            0.006,
+            {"market_beta": 0.07, "liquidity_beta": 0.07, "volatility_beta": 0.16},
+        ),
+        FactorExposureInputV1(
+            "PF_DOTUSD",
+            9,
+            -0.002,
+            {"market_beta": 0.01, "liquidity_beta": 0.01, "volatility_beta": 0.22},
+        ),
+        FactorExposureInputV1(
+            "PF_DOTUSD",
+            10,
+            0.001,
+            {"market_beta": 0.03, "liquidity_beta": 0.02, "volatility_beta": 0.20},
+        ),
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    evidence = fit_factor_exposure(_fixture_records())
+    report = evidence.to_dict()
+    report.update(
+        {
+            "offline_only": True,
+            "system_economic_evidence_admissible": False,
+            "runtime_rewire_admissible": False,
+            "promotion_pass_authority": False,
+        }
+    )
+
+    (out / "factor_exposure_evidence_v1.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+    print(f"STATUS={evidence.status}")
+    print("AUTHORITY_EFFECT=NONE")
+    print("RUNTIME_EFFECT=NONE")
+    print(f"REPORT={out / 'factor_exposure_evidence_v1.json'}")
+    return (
+        0
+        if evidence.status in {"DIAGNOSTIC_ONLY", "ROBUSTNESS_FAILED", "RANK_DEFICIENT_BLOCKED"}
+        else 1
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/linear_evidence/factor_exposure.py
+++ b/src/research/linear_evidence/factor_exposure.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
+import json
+import math
+import hashlib
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class FactorExposureInputV1:
+    instrument_id: str
+    timestamp: int
+    target_return: float
+    factor_values: Mapping[str, float]
+
+
+@dataclass(frozen=True)
+class FactorExposureEvidenceV1:
+    evidence_type: str
+    model_family: str
+    target_name: str
+    feature_names: Tuple[str, ...]
+    n_samples: int
+    n_features: int
+    solver: str
+    fit_intercept: bool
+    coefficients: Dict[str, float]
+    diagnostics: Dict[str, float]
+    feature_matrix_digest: str
+    target_digest: str
+    validation_policy: str
+    status: str
+    reason_codes: Tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "evidence_type": self.evidence_type,
+            "model_family": self.model_family,
+            "target_name": self.target_name,
+            "feature_names": list(self.feature_names),
+            "n_samples": self.n_samples,
+            "n_features": self.n_features,
+            "solver": self.solver,
+            "fit_intercept": self.fit_intercept,
+            "coefficients": dict(self.coefficients),
+            "diagnostics": dict(self.diagnostics),
+            "feature_matrix_digest": self.feature_matrix_digest,
+            "target_digest": self.target_digest,
+            "validation_policy": self.validation_policy,
+            "status": self.status,
+            "reason_codes": list(self.reason_codes),
+            "authority_effect": self.authority_effect,
+            "runtime_effect": self.runtime_effect,
+        }
+
+
+def _stable_digest(payload: object) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def build_factor_matrix(
+    records: Sequence[FactorExposureInputV1],
+) -> Tuple[np.ndarray, np.ndarray, Tuple[str, ...], str, str]:
+    if not records:
+        raise ValueError("INSUFFICIENT_DATA")
+
+    timestamps = [r.timestamp for r in records]
+    if timestamps != sorted(timestamps):
+        raise ValueError("RANDOM_VALIDATION_SPLIT_BLOCKED")
+
+    feature_names = tuple(sorted(records[0].factor_values.keys()))
+    if not feature_names:
+        raise ValueError("TARGET_BINDING_MISSING")
+
+    rows: List[List[float]] = []
+    targets: List[float] = []
+    for record in records:
+        if tuple(sorted(record.factor_values.keys())) != feature_names:
+            raise ValueError("FEATURE_SCHEMA_DRIFT")
+        row = [float(record.factor_values[name]) for name in feature_names]
+        if any(not math.isfinite(v) for v in row) or not math.isfinite(float(record.target_return)):
+            raise ValueError("INSUFFICIENT_DATA")
+        rows.append(row)
+        targets.append(float(record.target_return))
+
+    x = np.asarray(rows, dtype=float)
+    y = np.asarray(targets, dtype=float)
+    return x, y, feature_names, _stable_digest(rows), _stable_digest(targets)
+
+
+def fit_factor_exposure(
+    records: Sequence[FactorExposureInputV1],
+    *,
+    min_samples: int = 8,
+    max_condition_number: float = 1_000_000.0,
+) -> FactorExposureEvidenceV1:
+    x, y, feature_names, x_digest, y_digest = build_factor_matrix(records)
+    n_samples, n_features = x.shape
+
+    reason_codes: List[str] = []
+    if n_samples < min_samples:
+        return FactorExposureEvidenceV1(
+            evidence_type="factor_exposure",
+            model_family="ordinary_least_squares",
+            target_name="target_return",
+            feature_names=feature_names,
+            n_samples=n_samples,
+            n_features=n_features,
+            solver="numpy.linalg.lstsq",
+            fit_intercept=True,
+            coefficients={},
+            diagnostics={},
+            feature_matrix_digest=x_digest,
+            target_digest=y_digest,
+            validation_policy="time_ordered",
+            status="INSUFFICIENT_DATA",
+            reason_codes=("INSUFFICIENT_SAMPLE_COUNT",),
+            authority_effect="NONE",
+            runtime_effect="NONE",
+        )
+
+    design = np.column_stack([np.ones(n_samples), x])
+    rank = int(np.linalg.matrix_rank(design))
+    condition_number = float(np.linalg.cond(design))
+
+    if rank < design.shape[1]:
+        status = "RANK_DEFICIENT_BLOCKED"
+        reason_codes.append("HIGH_CONDITION_NUMBER")
+    elif condition_number > max_condition_number:
+        status = "ROBUSTNESS_FAILED"
+        reason_codes.append("HIGH_CONDITION_NUMBER")
+    else:
+        status = "DIAGNOSTIC_ONLY"
+
+    beta, residuals, _, _ = np.linalg.lstsq(design, y, rcond=None)
+    predictions = design @ beta
+    errors = y - predictions
+
+    ss_res = float(np.sum(errors**2))
+    ss_tot = float(np.sum((y - float(np.mean(y))) ** 2))
+    r2 = 0.0 if ss_tot == 0.0 else float(1.0 - ss_res / ss_tot)
+
+    coefficients = {"intercept": float(beta[0])}
+    coefficients.update({name: float(value) for name, value in zip(feature_names, beta[1:])})
+
+    diagnostics = {
+        "rank": float(rank),
+        "condition_number": condition_number,
+        "rmse": float(np.sqrt(np.mean(errors**2))),
+        "mae": float(np.mean(np.abs(errors))),
+        "r2": r2,
+        "max_abs_error": float(np.max(np.abs(errors))),
+    }
+
+    return FactorExposureEvidenceV1(
+        evidence_type="factor_exposure",
+        model_family="ordinary_least_squares",
+        target_name="target_return",
+        feature_names=feature_names,
+        n_samples=n_samples,
+        n_features=n_features,
+        solver="numpy.linalg.lstsq",
+        fit_intercept=True,
+        coefficients=coefficients,
+        diagnostics=diagnostics,
+        feature_matrix_digest=x_digest,
+        target_digest=y_digest,
+        validation_policy="time_ordered",
+        status=status,
+        reason_codes=tuple(reason_codes),
+        authority_effect="NONE",
+        runtime_effect="NONE",
+    )

--- a/tests/research/test_offline_factor_exposure_diagnostics_v0.py
+++ b/tests/research/test_offline_factor_exposure_diagnostics_v0.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from research.linear_evidence.factor_exposure import FactorExposureInputV1, fit_factor_exposure
+
+
+def test_factor_exposure_is_authority_neutral() -> None:
+    records = [
+        FactorExposureInputV1(
+            "PF_ETHUSD",
+            i,
+            float(i) * 0.001,
+            {
+                "market_beta": float(i),
+                "liquidity_beta": float(i % 3),
+                "volatility_beta": float(i % 5),
+            },
+        )
+        for i in range(1, 12)
+    ]
+
+    evidence = fit_factor_exposure(records)
+
+    assert evidence.evidence_type == "factor_exposure"
+    assert evidence.authority_effect == "NONE"
+    assert evidence.runtime_effect == "NONE"
+    assert evidence.solver == "numpy.linalg.lstsq"
+    assert evidence.validation_policy == "time_ordered"
+    assert evidence.status in {"DIAGNOSTIC_ONLY", "ROBUSTNESS_FAILED", "RANK_DEFICIENT_BLOCKED"}
+
+
+def test_factor_exposure_blocks_non_time_ordered_records() -> None:
+    records = [
+        FactorExposureInputV1("PF_ETHUSD", 2, 0.002, {"market_beta": 1.0}),
+        FactorExposureInputV1("PF_ETHUSD", 1, 0.001, {"market_beta": 2.0}),
+    ]
+
+    try:
+        fit_factor_exposure(records, min_samples=2)
+    except ValueError as exc:
+        assert str(exc) == "RANDOM_VALIDATION_SPLIT_BLOCKED"
+    else:
+        raise AssertionError("expected non-time-ordered records to fail closed")
+
+
+def test_factor_exposure_cli_writes_manifestable_report(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/research/offline_factor_exposure_diagnostics_v0.py",
+            "--out",
+            str(tmp_path),
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report_path = tmp_path / "factor_exposure_evidence_v1.json"
+    assert report_path.exists()
+    report = json.loads(report_path.read_text())
+    assert report["evidence_type"] == "factor_exposure"
+    assert report["authority_effect"] == "NONE"
+    assert report["runtime_effect"] == "NONE"
+    assert report["offline_only"] is True
+    assert report["system_economic_evidence_admissible"] is False
+    assert report["runtime_rewire_admissible"] is False


### PR DESCRIPTION
## Summary
- adds offline Factor Exposure Diagnostics v0 under linear evidence
- binds FactorExposureEvidenceV1 diagnostic output
- adds deterministic offline CLI writing factor_exposure_evidence_v1.json
- adds tests for authority neutrality, time-order fail-closed behavior, and CLI report generation

## Evidence
/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/offline_factor_exposure_diagnostics_v0_implementation_20260709T210659Z

## Verification
- py_compile: OK
- pytest: OK (tests/research/test_offline_factor_exposure_diagnostics_v0.py)
- diagnostics CLI: STATUS=DIAGNOSTIC_ONLY
- ruff check: OK
- ruff format --check: OK
- MANIFEST_VERIFY_RC=0
- SOURCE_MANIFEST_REVERIFY_BEFORE_COMMIT=0

## Authority
- OFFLINE_ONLY=true
- Authority/Runtime: NONE / NONE
- No runtime imports
- No order imports
- No scheduler imports
- No credentials
- No arming
- No economic pass claim

## Risk
Low: diagnostic-only offline scaffold, fail-closed on non-time-ordered records.

Made with [Cursor](https://cursor.com)