### PR TITLE
Add offline rolling linear drift diagnostics v0

### DIFF
--- a/scripts/research/offline_rolling_linear_drift_diagnostics_v0.py
+++ b/scripts/research/offline_rolling_linear_drift_diagnostics_v0.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from research.linear_evidence.drift import RollingLinearDriftInputV1, fit_rolling_linear_drift
+
+
+def _fixture_records() -> list[RollingLinearDriftInputV1]:
+    records: list[RollingLinearDriftInputV1] = []
+    for index in range(1, 19):
+        hour = index - 1
+        decision_time = f"2026-01-01T{hour:02d}:00:00Z"
+        feature_time = decision_time
+        signal = float(index)
+        if index <= 9:
+            target = 0.5 * signal + 0.1
+        else:
+            target = 2.5 * signal - 1.0
+        records.append(
+            RollingLinearDriftInputV1(
+                instrument_id="PF_ETHUSD",
+                decision_time=decision_time,
+                feature_availability_time=feature_time,
+                target=target,
+                features={"signal": signal, "aux": float(index % 3)},
+            )
+        )
+    return records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    evidence = fit_rolling_linear_drift(_fixture_records(), window_size=6, min_samples=4)
+    report = evidence.to_dict()
+    report.update(
+        {
+            "offline_only": True,
+            "system_economic_evidence_admissible": False,
+            "runtime_rewire_admissible": False,
+            "promotion_pass_authority": False,
+        }
+    )
+
+    report_path = out / "rolling_linear_drift_evidence_v1.json"
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(f"STATUS={evidence.status}")
+    print("AUTHORITY_EFFECT=NONE")
+    print("RUNTIME_EFFECT=NONE")
+    print(f"DRIFT_SCORE={evidence.drift_score}")
+    print(f"REASON_CODES={','.join(evidence.reason_codes) or 'NONE'}")
+    print(f"REPORT={report_path}")
+    return (
+        0
+        if evidence.status
+        in {
+            "DIAGNOSTIC_ONLY",
+            "ROBUSTNESS_FAILED",
+            "RANK_DEFICIENT_BLOCKED",
+            "INSUFFICIENT_DATA",
+        }
+        else 1
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/linear_evidence/drift.py
+++ b/src/research/linear_evidence/drift.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Sequence, Tuple
+import hashlib
+import json
+import math
+
+import numpy as np
+
+from .contracts import LinearModelDiagnosticsV1, LinearModelEvidenceV1
+
+
+@dataclass(frozen=True)
+class RollingLinearDriftInputV1:
+    instrument_id: str
+    decision_time: str
+    feature_availability_time: str
+    target: float
+    features: Mapping[str, float]
+
+
+@dataclass(frozen=True)
+class RollingLinearDriftEvidenceV1:
+    evidence_type: str
+    model_family: str
+    target_name: str
+    feature_names: Tuple[str, ...]
+    n_samples: int
+    n_features: int
+    window_size: int
+    n_windows: int
+    solver: str
+    fit_intercept: bool
+    window_evidence: Tuple[LinearModelEvidenceV1, ...]
+    coefficient_drift: Dict[str, float]
+    drift_score: float
+    diagnostics: Dict[str, float]
+    feature_matrix_digest: str
+    target_digest: str
+    validation_policy: str
+    status: str
+    reason_codes: Tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "evidence_type": self.evidence_type,
+            "model_family": self.model_family,
+            "target_name": self.target_name,
+            "feature_names": list(self.feature_names),
+            "n_samples": self.n_samples,
+            "n_features": self.n_features,
+            "window_size": self.window_size,
+            "n_windows": self.n_windows,
+            "solver": self.solver,
+            "fit_intercept": self.fit_intercept,
+            "window_evidence": [
+                {
+                    "time_range": dict(evidence.time_range),
+                    "status": evidence.status,
+                    "reason_codes": list(evidence.reason_codes),
+                    "coefficients": dict(evidence.coefficients),
+                    "diagnostics": {
+                        "rank": evidence.diagnostics.rank,
+                        "condition_number": evidence.diagnostics.condition_number,
+                        "rmse": evidence.diagnostics.rmse,
+                        "r2_train": evidence.diagnostics.r2_train,
+                    },
+                }
+                for evidence in self.window_evidence
+            ],
+            "coefficient_drift": dict(self.coefficient_drift),
+            "drift_score": self.drift_score,
+            "diagnostics": dict(self.diagnostics),
+            "feature_matrix_digest": self.feature_matrix_digest,
+            "target_digest": self.target_digest,
+            "validation_policy": self.validation_policy,
+            "status": self.status,
+            "reason_codes": list(self.reason_codes),
+            "authority_effect": self.authority_effect,
+            "runtime_effect": self.runtime_effect,
+        }
+
+
+def _stable_digest(payload: object) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _r2(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    denom = float(np.sum((y_true - float(np.mean(y_true))) ** 2))
+    if denom == 0.0:
+        return 0.0
+    return 1.0 - float(np.sum((y_true - y_pred) ** 2)) / denom
+
+
+def _build_drift_matrix(
+    records: Sequence[RollingLinearDriftInputV1],
+) -> Tuple[np.ndarray, np.ndarray, Tuple[str, ...], List[str], str, str]:
+    if not records:
+        raise ValueError("INSUFFICIENT_DATA")
+
+    decision_times = [r.decision_time for r in records]
+    if decision_times != sorted(decision_times):
+        raise ValueError("RANDOM_VALIDATION_SPLIT_BLOCKED")
+
+    for record in records:
+        if record.feature_availability_time > record.decision_time:
+            raise ValueError("LOOKAHEAD_BLOCKED")
+
+    feature_names = tuple(sorted(records[0].features.keys()))
+    if not feature_names:
+        raise ValueError("TARGET_BINDING_MISSING")
+
+    rows: List[List[float]] = []
+    targets: List[float] = []
+    for record in records:
+        if tuple(sorted(record.features.keys())) != feature_names:
+            raise ValueError("FEATURE_SCHEMA_DRIFT")
+        row = [float(record.features[name]) for name in feature_names]
+        if any(not math.isfinite(v) for v in row) or not math.isfinite(float(record.target)):
+            raise ValueError("INSUFFICIENT_DATA")
+        rows.append(row)
+        targets.append(float(record.target))
+
+    x = np.asarray(rows, dtype=float)
+    y = np.asarray(targets, dtype=float)
+    return x, y, feature_names, decision_times, _stable_digest(rows), _stable_digest(targets)
+
+
+def _fit_window_linear_evidence(
+    x: np.ndarray,
+    y: np.ndarray,
+    *,
+    feature_names: Tuple[str, ...],
+    target_name: str,
+    time_range: Mapping[str, str],
+    feature_matrix_digest: str,
+    target_digest: str,
+    max_condition_number: float,
+    min_samples: int,
+) -> LinearModelEvidenceV1:
+    n_samples, n_features = x.shape
+    reason_codes: List[str] = []
+
+    if n_samples < min_samples:
+        return LinearModelEvidenceV1(
+            evidence_type="rolling_linear_drift_window",
+            model_family="OLS",
+            target_name=target_name,
+            feature_names=feature_names,
+            n_samples=n_samples,
+            n_features=n_features,
+            solver="numpy.linalg.lstsq",
+            fit_intercept=True,
+            coefficients={},
+            diagnostics=LinearModelDiagnosticsV1(
+                rank=0,
+                condition_number=0.0,
+                rmse=0.0,
+                mae=0.0,
+                max_abs_error=0.0,
+                r2_train=0.0,
+                r2_validation=None,
+                residual_mean=0.0,
+                residual_std=0.0,
+                outlier_count=0,
+            ),
+            feature_matrix_digest=feature_matrix_digest,
+            target_digest=target_digest,
+            config_digest=_stable_digest({"window_size": n_samples}),
+            time_range=dict(time_range),
+            instrument_universe_digest="rolling_window",
+            row_count_before_filter=n_samples,
+            row_count_after_filter=n_samples,
+            dropped_rows_by_reason={},
+            validation_policy="TIME_ORDERED",
+            cost_policy_output="diagnostic_only",
+            status="INSUFFICIENT_DATA",
+            reason_codes=("INSUFFICIENT_SAMPLE_COUNT",),
+        )
+
+    design = np.column_stack([np.ones(n_samples), x])
+    rank = int(np.linalg.matrix_rank(design))
+    condition_number = float(np.linalg.cond(design))
+
+    if rank < design.shape[1]:
+        status = "RANK_DEFICIENT_BLOCKED"
+        reason_codes.append("HIGH_CONDITION_NUMBER")
+    elif condition_number > max_condition_number:
+        status = "ROBUSTNESS_FAILED"
+        reason_codes.append("HIGH_CONDITION_NUMBER")
+    else:
+        status = "DIAGNOSTIC_ONLY"
+
+    coeffs, _, _, _ = np.linalg.lstsq(design, y, rcond=None)
+    predictions = design @ coeffs
+    residuals = y - predictions
+    residual_std = float(np.std(residuals))
+    outlier_cutoff = 3.0 * residual_std if residual_std > 0 else float("inf")
+
+    coeff_names = ("intercept",) + feature_names
+    coefficients = {name: float(value) for name, value in zip(coeff_names, coeffs)}
+
+    diagnostics = LinearModelDiagnosticsV1(
+        rank=rank,
+        condition_number=condition_number,
+        rmse=float(np.sqrt(np.mean(residuals**2))),
+        mae=float(np.mean(np.abs(residuals))),
+        max_abs_error=float(np.max(np.abs(residuals))),
+        r2_train=_r2(y, predictions),
+        r2_validation=None,
+        residual_mean=float(np.mean(residuals)),
+        residual_std=residual_std,
+        outlier_count=int(np.sum(np.abs(residuals) > outlier_cutoff)),
+    )
+
+    return LinearModelEvidenceV1(
+        evidence_type="rolling_linear_drift_window",
+        model_family="OLS",
+        target_name=target_name,
+        feature_names=feature_names,
+        n_samples=n_samples,
+        n_features=n_features,
+        solver="numpy.linalg.lstsq",
+        fit_intercept=True,
+        coefficients=coefficients,
+        diagnostics=diagnostics,
+        feature_matrix_digest=feature_matrix_digest,
+        target_digest=target_digest,
+        config_digest=_stable_digest({"window_size": n_samples}),
+        time_range=dict(time_range),
+        instrument_universe_digest="rolling_window",
+        row_count_before_filter=n_samples,
+        row_count_after_filter=n_samples,
+        dropped_rows_by_reason={},
+        validation_policy="TIME_ORDERED",
+        cost_policy_output="diagnostic_only",
+        status=status,
+        reason_codes=tuple(reason_codes),
+    )
+
+
+def fit_rolling_linear_drift(
+    records: Sequence[RollingLinearDriftInputV1],
+    *,
+    target_name: str = "target",
+    window_size: int = 6,
+    min_samples: int = 4,
+    max_condition_number: float = 1_000_000.0,
+    unstable_coefficient_threshold: float = 0.75,
+    drift_detection_threshold: float = 0.5,
+) -> RollingLinearDriftEvidenceV1:
+    try:
+        x, y, feature_names, decision_times, x_digest, y_digest = _build_drift_matrix(records)
+    except ValueError as exc:
+        message = str(exc)
+        if message == "LOOKAHEAD_BLOCKED":
+            return RollingLinearDriftEvidenceV1(
+                evidence_type="rolling_linear_drift",
+                model_family="OLS",
+                target_name=target_name,
+                feature_names=(),
+                n_samples=len(records),
+                n_features=0,
+                window_size=window_size,
+                n_windows=0,
+                solver="numpy.linalg.lstsq",
+                fit_intercept=True,
+                window_evidence=(),
+                coefficient_drift={},
+                drift_score=0.0,
+                diagnostics={},
+                feature_matrix_digest="",
+                target_digest="",
+                validation_policy="TIME_ORDERED",
+                status="LEAKAGE_BLOCKED",
+                reason_codes=("LOOKAHEAD_BLOCKED",),
+                authority_effect="NONE",
+                runtime_effect="NONE",
+            )
+        raise
+
+    n_samples = x.shape[0]
+    if n_samples < window_size:
+        return RollingLinearDriftEvidenceV1(
+            evidence_type="rolling_linear_drift",
+            model_family="OLS",
+            target_name=target_name,
+            feature_names=feature_names,
+            n_samples=n_samples,
+            n_features=len(feature_names),
+            window_size=window_size,
+            n_windows=0,
+            solver="numpy.linalg.lstsq",
+            fit_intercept=True,
+            window_evidence=(),
+            coefficient_drift={},
+            drift_score=0.0,
+            diagnostics={},
+            feature_matrix_digest=x_digest,
+            target_digest=y_digest,
+            validation_policy="TIME_ORDERED",
+            status="INSUFFICIENT_DATA",
+            reason_codes=("INSUFFICIENT_SAMPLE_COUNT",),
+            authority_effect="NONE",
+            runtime_effect="NONE",
+        )
+
+    window_evidence: List[LinearModelEvidenceV1] = []
+    coeff_series: Dict[str, List[float]] = {}
+
+    for start in range(0, n_samples - window_size + 1):
+        end = start + window_size
+        x_window = x[start:end]
+        y_window = y[start:end]
+        window_digest = _stable_digest(x_window.tolist())
+        target_window_digest = _stable_digest(y_window.tolist())
+        evidence = _fit_window_linear_evidence(
+            x_window,
+            y_window,
+            feature_names=feature_names,
+            target_name=target_name,
+            time_range={
+                "start": decision_times[start],
+                "end": decision_times[end - 1],
+            },
+            feature_matrix_digest=window_digest,
+            target_digest=target_window_digest,
+            max_condition_number=max_condition_number,
+            min_samples=min_samples,
+        )
+        window_evidence.append(evidence)
+        for name, value in evidence.coefficients.items():
+            coeff_series.setdefault(name, []).append(value)
+
+    aggregate_reasons: List[str] = []
+    aggregate_status = "DIAGNOSTIC_ONLY"
+
+    for evidence in window_evidence:
+        if evidence.status == "INSUFFICIENT_DATA":
+            aggregate_status = "INSUFFICIENT_DATA"
+            aggregate_reasons.append("INSUFFICIENT_SAMPLE_COUNT")
+        elif evidence.status == "RANK_DEFICIENT_BLOCKED":
+            aggregate_status = "RANK_DEFICIENT_BLOCKED"
+            aggregate_reasons.append("HIGH_CONDITION_NUMBER")
+        elif evidence.status == "ROBUSTNESS_FAILED" and aggregate_status == "DIAGNOSTIC_ONLY":
+            aggregate_status = "ROBUSTNESS_FAILED"
+            aggregate_reasons.append("HIGH_CONDITION_NUMBER")
+
+    coefficient_drift: Dict[str, float] = {}
+    for name, values in coeff_series.items():
+        if len(values) < 2:
+            coefficient_drift[name] = 0.0
+            continue
+        spread = float(max(values) - min(values))
+        scale = max(abs(float(np.mean(values))), 1e-9)
+        coefficient_drift[name] = spread / scale
+
+    drift_score = float(max(coefficient_drift.values(), default=0.0))
+    unstable = [
+        name for name, score in coefficient_drift.items() if score >= unstable_coefficient_threshold
+    ]
+    if unstable and aggregate_status == "DIAGNOSTIC_ONLY":
+        aggregate_reasons.append("UNSTABLE_COEFFICIENTS")
+
+    if (
+        drift_score >= drift_detection_threshold
+        and "COEFFICIENT_DRIFT_DETECTED" not in aggregate_reasons
+    ):
+        aggregate_reasons.append("COEFFICIENT_DRIFT_DETECTED")
+
+    diagnostics = {
+        "drift_score": drift_score,
+        "max_coefficient_drift": drift_score,
+        "window_count": float(len(window_evidence)),
+        "unstable_coefficient_count": float(len(unstable)),
+    }
+
+    return RollingLinearDriftEvidenceV1(
+        evidence_type="rolling_linear_drift",
+        model_family="OLS",
+        target_name=target_name,
+        feature_names=feature_names,
+        n_samples=n_samples,
+        n_features=len(feature_names),
+        window_size=window_size,
+        n_windows=len(window_evidence),
+        solver="numpy.linalg.lstsq",
+        fit_intercept=True,
+        window_evidence=tuple(window_evidence),
+        coefficient_drift=coefficient_drift,
+        drift_score=drift_score,
+        diagnostics=diagnostics,
+        feature_matrix_digest=x_digest,
+        target_digest=y_digest,
+        validation_policy="TIME_ORDERED",
+        status=aggregate_status,
+        reason_codes=tuple(dict.fromkeys(aggregate_reasons)),
+        authority_effect="NONE",
+        runtime_effect="NONE",
+    )

--- a/tests/research/test_offline_rolling_linear_drift_diagnostics_v0.py
+++ b/tests/research/test_offline_rolling_linear_drift_diagnostics_v0.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from research.linear_evidence.drift import RollingLinearDriftInputV1, fit_rolling_linear_drift
+
+
+def _stable_records(count: int = 14) -> list[RollingLinearDriftInputV1]:
+    return [
+        RollingLinearDriftInputV1(
+            instrument_id="PF_ETHUSD",
+            decision_time=f"2026-01-01T{index:02d}:00:00Z",
+            feature_availability_time=f"2026-01-01T{index:02d}:00:00Z",
+            target=float(index) * 0.2,
+            features={"signal": float(index), "aux": float(index % 2)},
+        )
+        for index in range(count)
+    ]
+
+
+def test_rolling_linear_drift_is_authority_neutral() -> None:
+    evidence = fit_rolling_linear_drift(_stable_records(), window_size=6, min_samples=4)
+
+    assert evidence.evidence_type == "rolling_linear_drift"
+    assert evidence.authority_effect == "NONE"
+    assert evidence.runtime_effect == "NONE"
+    assert evidence.solver == "numpy.linalg.lstsq"
+    assert evidence.validation_policy == "TIME_ORDERED"
+    assert evidence.n_windows >= 1
+    assert all(window.solver == "numpy.linalg.lstsq" for window in evidence.window_evidence)
+
+
+def test_rolling_linear_drift_blocks_non_time_ordered_records() -> None:
+    records = [
+        RollingLinearDriftInputV1(
+            "PF_ETHUSD",
+            "2026-01-01T02:00:00Z",
+            "2026-01-01T02:00:00Z",
+            0.2,
+            {"signal": 2.0},
+        ),
+        RollingLinearDriftInputV1(
+            "PF_ETHUSD",
+            "2026-01-01T01:00:00Z",
+            "2026-01-01T01:00:00Z",
+            0.1,
+            {"signal": 1.0},
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="RANDOM_VALIDATION_SPLIT_BLOCKED"):
+        fit_rolling_linear_drift(records, window_size=2, min_samples=2)
+
+
+def test_rolling_linear_drift_blocks_lookahead() -> None:
+    records = [
+        RollingLinearDriftInputV1(
+            "PF_ETHUSD",
+            "2026-01-01T01:00:00Z",
+            "2026-01-01T02:00:00Z",
+            0.1,
+            {"signal": 1.0},
+        ),
+        RollingLinearDriftInputV1(
+            "PF_ETHUSD",
+            "2026-01-01T02:00:00Z",
+            "2026-01-01T02:00:00Z",
+            0.2,
+            {"signal": 2.0},
+        ),
+        RollingLinearDriftInputV1(
+            "PF_ETHUSD",
+            "2026-01-01T03:00:00Z",
+            "2026-01-01T03:00:00Z",
+            0.3,
+            {"signal": 3.0},
+        ),
+        RollingLinearDriftInputV1(
+            "PF_ETHUSD",
+            "2026-01-01T04:00:00Z",
+            "2026-01-01T04:00:00Z",
+            0.4,
+            {"signal": 4.0},
+        ),
+        RollingLinearDriftInputV1(
+            "PF_ETHUSD",
+            "2026-01-01T05:00:00Z",
+            "2026-01-01T05:00:00Z",
+            0.5,
+            {"signal": 5.0},
+        ),
+        RollingLinearDriftInputV1(
+            "PF_ETHUSD",
+            "2026-01-01T06:00:00Z",
+            "2026-01-01T06:00:00Z",
+            0.6,
+            {"signal": 6.0},
+        ),
+    ]
+
+    evidence = fit_rolling_linear_drift(records, window_size=4, min_samples=4)
+
+    assert evidence.status == "LEAKAGE_BLOCKED"
+    assert evidence.reason_codes == ("LOOKAHEAD_BLOCKED",)
+
+
+def test_rolling_linear_drift_detects_coefficient_shift() -> None:
+    records: list[RollingLinearDriftInputV1] = []
+    for index in range(1, 19):
+        signal = float(index)
+        target = 0.4 * signal if index <= 9 else 2.0 * signal
+        records.append(
+            RollingLinearDriftInputV1(
+                instrument_id="PF_ETHUSD",
+                decision_time=f"2026-01-01T{index - 1:02d}:00:00Z",
+                feature_availability_time=f"2026-01-01T{index - 1:02d}:00:00Z",
+                target=target,
+                features={"signal": signal},
+            )
+        )
+
+    evidence = fit_rolling_linear_drift(records, window_size=6, min_samples=4)
+
+    assert evidence.drift_score > 0.5
+    assert "COEFFICIENT_DRIFT_DETECTED" in evidence.reason_codes
+    assert evidence.coefficient_drift["signal"] > 0.5
+
+
+def test_rolling_linear_drift_insufficient_data_reason_code() -> None:
+    evidence = fit_rolling_linear_drift(_stable_records(count=3), window_size=6, min_samples=4)
+
+    assert evidence.status == "INSUFFICIENT_DATA"
+    assert evidence.reason_codes == ("INSUFFICIENT_SAMPLE_COUNT",)
+
+
+def test_rolling_linear_drift_rank_deficient_reason_code() -> None:
+    records = [
+        RollingLinearDriftInputV1(
+            "PF_ETHUSD",
+            f"2026-01-01T{index:02d}:00:00Z",
+            f"2026-01-01T{index:02d}:00:00Z",
+            float(index),
+            {"signal": 1.0, "duplicate": 2.0, "copy": 2.0},
+        )
+        for index in range(6)
+    ]
+
+    evidence = fit_rolling_linear_drift(records, window_size=6, min_samples=4)
+
+    assert evidence.status == "RANK_DEFICIENT_BLOCKED"
+    assert "HIGH_CONDITION_NUMBER" in evidence.reason_codes
+
+
+def test_rolling_linear_drift_cli_writes_manifestable_report(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/research/offline_rolling_linear_drift_diagnostics_v0.py",
+            "--out",
+            str(tmp_path),
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report_path = tmp_path / "rolling_linear_drift_evidence_v1.json"
+    assert report_path.exists()
+    report = json.loads(report_path.read_text())
+    assert report["evidence_type"] == "rolling_linear_drift"
+    assert report["authority_effect"] == "NONE"
+    assert report["runtime_effect"] == "NONE"
+    assert report["offline_only"] is True
+    assert report["system_economic_evidence_admissible"] is False
+    assert report["runtime_rewire_admissible"] is False
+    assert report["drift_score"] > 0.5
+    assert "COEFFICIENT_DRIFT_DETECTED" in report["reason_codes"]


### PR DESCRIPTION
## Summary
- Add `src/research/linear_evidence/drift.py` with time-ordered rolling-window OLS drift detection, fail-closed lookahead blocking, and LinearModelEvidenceV1-compatible window evidence.
- Add offline CLI `scripts/research/offline_rolling_linear_drift_diagnostics_v0.py` producing manifestable `rolling_linear_drift_evidence_v1.json`.
- Add targeted tests covering authority neutrality, time-ordering, lookahead, coefficient drift, insufficient data, rank deficiency, and CLI report output.

## Test plan
- [x] `python3 -m py_compile src/research/linear_evidence/*.py scripts/research/offline_rolling_linear_drift_diagnostics_v0.py`
- [x] `python3 -m pytest -q tests/research/test_offline_rolling_linear_drift_diagnostics_v0.py` (7 passed)
- [x] `python3 scripts/research/offline_rolling_linear_drift_diagnostics_v0.py --out <archive>/diagnostics`
- [x] `python3 -m ruff check` / `python3 -m ruff format --check` on touched paths
- [x] PR-bounded gate batch (720 tests, ~46s)

## Authority / runtime
- `AUTHORITY_EFFECT=NONE`
- `RUNTIME_EFFECT=NONE`
- `OFFLINE_ONLY=true`
- `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`


Made with [Cursor](https://cursor.com)