### PR TITLE
Add offline parameter sensitivity surface diagnostics v0

### DIFF
--- a/scripts/research/offline_parameter_sensitivity_surface_v0.py
+++ b/scripts/research/offline_parameter_sensitivity_surface_v0.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from research.linear_evidence.sensitivity import (
+    ParameterGridSpecV1,
+    ParameterSensitivityInputV1,
+    fit_parameter_sensitivity_surface,
+)
+
+
+def _record(
+    index: int,
+    *,
+    target: float,
+    signal: float,
+    aux: float,
+) -> ParameterSensitivityInputV1:
+    decision_time = f"2026-01-01T{index:02d}:00:00Z"
+    return ParameterSensitivityInputV1(
+        instrument_id="PF_ETHUSD",
+        decision_time=decision_time,
+        feature_availability_time=decision_time,
+        target=target,
+        features={"signal": signal, "aux": aux},
+    )
+
+
+def fixture_robust_plateau_records() -> list[ParameterSensitivityInputV1]:
+    records: list[ParameterSensitivityInputV1] = []
+    for index in range(16):
+        signal = float(index + 1)
+        aux = 0.05 * float(index % 4)
+        records.append(_record(index, target=signal + aux, signal=signal, aux=aux))
+    return records
+
+
+def fixture_fragile_spike_records() -> list[ParameterSensitivityInputV1]:
+    records: list[ParameterSensitivityInputV1] = []
+    for index in range(12):
+        signal = float(index + 1)
+        aux = 0.2 * signal
+        records.append(_record(index, target=signal + aux, signal=signal, aux=aux))
+    for index in range(12, 16):
+        signal = float(index + 1)
+        aux = float((index % 3) + 1) * 2.0
+        records.append(_record(index, target=signal + aux, signal=signal, aux=aux))
+    return records
+
+
+def fixture_insufficient_grid_records() -> list[ParameterSensitivityInputV1]:
+    return fixture_robust_plateau_records()[:6]
+
+
+def fixture_unstable_validation_records() -> list[ParameterSensitivityInputV1]:
+    records: list[ParameterSensitivityInputV1] = []
+    for index in range(16):
+        signal = float(index + 1)
+        aux = float(index % 3)
+        target = 5.0 + float(index % 7) * 0.9
+        records.append(_record(index, target=target, signal=signal, aux=aux))
+    return records
+
+
+def _fixture_truth_pack() -> dict[str, object]:
+    robust_grid = ParameterGridSpecV1(
+        parameter_name="signal_scale",
+        scaled_feature_name="signal",
+        parameter_values=(0.85, 0.95, 1.0, 1.05, 1.15),
+    )
+    fragile_grid = ParameterGridSpecV1(
+        parameter_name="signal_scale",
+        scaled_feature_name="signal",
+        parameter_values=(0.25, 0.5, 0.75, 1.0, 1.25),
+    )
+    insufficient_grid = ParameterGridSpecV1(
+        parameter_name="signal_scale",
+        scaled_feature_name="signal",
+        parameter_values=(0.9, 1.1),
+    )
+    unstable_grid = fragile_grid
+
+    robust = fit_parameter_sensitivity_surface(fixture_robust_plateau_records(), grid=robust_grid)
+    fragile = fit_parameter_sensitivity_surface(fixture_fragile_spike_records(), grid=fragile_grid)
+    insufficient = fit_parameter_sensitivity_surface(
+        fixture_insufficient_grid_records(),
+        grid=insufficient_grid,
+        min_samples=4,
+    )
+    unstable = fit_parameter_sensitivity_surface(
+        fixture_unstable_validation_records(),
+        grid=unstable_grid,
+        max_validation_rmse=0.05,
+    )
+
+    return {
+        "robust_plateau_case": robust.to_dict(),
+        "fragile_spike_case": fragile.to_dict(),
+        "insufficient_grid_case": insufficient.to_dict(),
+        "unstable_validation_case": unstable.to_dict(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    grid = ParameterGridSpecV1(
+        parameter_name="signal_scale",
+        scaled_feature_name="signal",
+        parameter_values=(0.85, 0.95, 1.0, 1.05, 1.15),
+    )
+    evidence = fit_parameter_sensitivity_surface(fixture_robust_plateau_records(), grid=grid)
+    truth_pack = _fixture_truth_pack()
+
+    report = evidence.to_dict()
+    report.update(
+        {
+            "offline_only": True,
+            "system_economic_evidence_admissible": False,
+            "runtime_rewire_admissible": False,
+            "promotion_pass_authority": False,
+            "no_parameter_auto_optimization": True,
+            "no_parameter_default_change_in_v0": True,
+            "fixture_truth_pack": truth_pack,
+        }
+    )
+
+    report_path = out / "parameter_sensitivity_surface_evidence_v1.json"
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(f"STATUS={evidence.status}")
+    print("AUTHORITY_EFFECT=NONE")
+    print("RUNTIME_EFFECT=NONE")
+    print(f"PLATEAU_DETECTED={evidence.plateau_detected}")
+    print(f"FRAGILE_SPIKE_DETECTED={evidence.fragile_spike_detected}")
+    print(f"REASON_CODES={','.join(evidence.reason_codes) or 'NONE'}")
+    print(f"REPORT={report_path}")
+    return (
+        0
+        if evidence.status
+        in {
+            "DIAGNOSTIC_ONLY",
+            "ROBUSTNESS_FAILED",
+            "RANK_DEFICIENT_BLOCKED",
+            "INSUFFICIENT_DATA",
+        }
+        else 1
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/linear_evidence/sensitivity.py
+++ b/src/research/linear_evidence/sensitivity.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Sequence, Tuple
+import hashlib
+import json
+import math
+
+import numpy as np
+
+from .contracts import LinearModelEvidenceV1
+from .feature_matrix import build_feature_matrix_binding
+from .fitters import fit_ols_lstsq
+
+
+@dataclass(frozen=True)
+class ParameterSensitivityInputV1:
+    instrument_id: str
+    decision_time: str
+    feature_availability_time: str
+    target: float
+    features: Mapping[str, float]
+
+
+@dataclass(frozen=True)
+class ParameterGridSpecV1:
+    parameter_name: str
+    scaled_feature_name: str
+    parameter_values: Tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class ParameterSensitivitySurfaceEvidenceV1:
+    evidence_type: str
+    model_family: str
+    target_name: str
+    feature_names: Tuple[str, ...]
+    parameter_name: str
+    parameter_values: Tuple[float, ...]
+    n_samples: int
+    n_features: int
+    n_grid_points: int
+    solver: str
+    fit_intercept: bool
+    grid_evidence: Tuple[LinearModelEvidenceV1, ...]
+    surface_diagnostics: Dict[str, float]
+    plateau_detected: bool
+    fragile_spike_detected: bool
+    robust_region_bounds: Tuple[float, float] | None
+    feature_matrix_digest: str
+    target_digest: str
+    validation_policy: str
+    status: str
+    reason_codes: Tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "evidence_type": self.evidence_type,
+            "model_family": self.model_family,
+            "target_name": self.target_name,
+            "feature_names": list(self.feature_names),
+            "parameter_name": self.parameter_name,
+            "parameter_values": list(self.parameter_values),
+            "n_samples": self.n_samples,
+            "n_features": self.n_features,
+            "n_grid_points": self.n_grid_points,
+            "solver": self.solver,
+            "fit_intercept": self.fit_intercept,
+            "grid_evidence": [
+                {
+                    "parameter_value": parameter_value,
+                    "status": evidence.status,
+                    "reason_codes": list(evidence.reason_codes),
+                    "diagnostics": {
+                        "rmse": evidence.diagnostics.rmse,
+                        "r2_train": evidence.diagnostics.r2_train,
+                        "r2_validation": evidence.diagnostics.r2_validation,
+                    },
+                }
+                for parameter_value, evidence in zip(self.parameter_values, self.grid_evidence)
+            ],
+            "surface_diagnostics": dict(self.surface_diagnostics),
+            "plateau_detected": self.plateau_detected,
+            "fragile_spike_detected": self.fragile_spike_detected,
+            "robust_region_bounds": (
+                list(self.robust_region_bounds) if self.robust_region_bounds is not None else None
+            ),
+            "feature_matrix_digest": self.feature_matrix_digest,
+            "target_digest": self.target_digest,
+            "validation_policy": self.validation_policy,
+            "status": self.status,
+            "reason_codes": list(self.reason_codes),
+            "authority_effect": self.authority_effect,
+            "runtime_effect": self.runtime_effect,
+        }
+
+
+def _stable_digest(payload: object) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _validate_records(
+    records: Sequence[ParameterSensitivityInputV1],
+) -> Tuple[List[ParameterSensitivityInputV1], Tuple[str, ...], str, str]:
+    if not records:
+        raise ValueError("INSUFFICIENT_DATA")
+
+    decision_times = [record.decision_time for record in records]
+    if decision_times != sorted(decision_times):
+        raise ValueError("RANDOM_VALIDATION_SPLIT_BLOCKED")
+
+    for record in records:
+        if record.feature_availability_time > record.decision_time:
+            raise ValueError("LOOKAHEAD_BLOCKED")
+
+    feature_names = tuple(sorted(records[0].features.keys()))
+    if not feature_names:
+        raise ValueError("TARGET_BINDING_MISSING")
+
+    for record in records:
+        if tuple(sorted(record.features.keys())) != feature_names:
+            raise ValueError("FEATURE_SCHEMA_DRIFT")
+        row = [float(record.features[name]) for name in feature_names]
+        if any(not math.isfinite(value) for value in row) or not math.isfinite(
+            float(record.target)
+        ):
+            raise ValueError("INSUFFICIENT_DATA")
+
+    rows = [
+        {
+            "decision_time": record.decision_time,
+            "target": float(record.target),
+            **{name: float(record.features[name]) for name in feature_names},
+        }
+        for record in records
+    ]
+    return (
+        rows,
+        feature_names,
+        _stable_digest(rows),
+        _stable_digest([row["target"] for row in rows]),
+    )
+
+
+def _scale_rows(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    scaled_feature_name: str,
+    parameter_value: float,
+) -> List[Dict[str, object]]:
+    scaled_rows: List[Dict[str, object]] = []
+    for row in rows:
+        scaled = dict(row)
+        scaled[scaled_feature_name] = float(row[scaled_feature_name]) * float(parameter_value)
+        scaled_rows.append(scaled)
+    return scaled_rows
+
+
+def _validation_rmse(evidence: LinearModelEvidenceV1) -> float:
+    diagnostics = evidence.diagnostics
+    if diagnostics.r2_validation is None:
+        return float("inf")
+    train_r2 = diagnostics.r2_train
+    validation_r2 = diagnostics.r2_validation
+    if not math.isfinite(validation_r2):
+        return float("inf")
+    gap = max(0.0, float(train_r2) - float(validation_r2))
+    return float(diagnostics.rmse * (1.0 + gap))
+
+
+def _analyze_surface(
+    parameter_values: Sequence[float],
+    validation_errors: Sequence[float],
+    *,
+    plateau_relative_tolerance: float,
+    fragile_spike_ratio: float,
+    min_plateau_points: int,
+    max_validation_rmse: float,
+) -> Tuple[Dict[str, float], bool, bool, Tuple[float, float] | None, List[str]]:
+    reason_codes: List[str] = []
+    diagnostics: Dict[str, float] = {}
+
+    finite_errors = [value for value in validation_errors if math.isfinite(value)]
+    if not finite_errors:
+        reason_codes.append("VALIDATION_ERROR_TOO_HIGH")
+        diagnostics["validation_rmse_median"] = float("inf")
+        diagnostics["local_sensitivity_max"] = 0.0
+        diagnostics["plateau_width_fraction"] = 0.0
+        diagnostics["fragility_score"] = 0.0
+        return diagnostics, False, False, None, reason_codes
+
+    median_error = float(np.median(finite_errors))
+    min_error = float(min(finite_errors))
+    max_error = float(max(finite_errors))
+    diagnostics["validation_rmse_median"] = median_error
+    diagnostics["validation_rmse_min"] = min_error
+    diagnostics["validation_rmse_max"] = max_error
+    diagnostics["validation_rmse_range"] = max_error - min_error
+
+    local_sensitivities: List[float] = []
+    for left, right in zip(validation_errors, validation_errors[1:]):
+        if math.isfinite(left) and math.isfinite(right):
+            local_sensitivities.append(abs(float(right) - float(left)))
+    local_sensitivity_max = float(max(local_sensitivities, default=0.0))
+    diagnostics["local_sensitivity_max"] = local_sensitivity_max
+    diagnostics["fragility_score"] = local_sensitivity_max / max(median_error, 1e-9)
+
+    if median_error > max_validation_rmse:
+        reason_codes.append("VALIDATION_ERROR_TOO_HIGH")
+
+    tolerance = max(min_error * plateau_relative_tolerance, 1e-9)
+    plateau_mask = [
+        math.isfinite(error) and (error - min_error) <= tolerance for error in validation_errors
+    ]
+    plateau_runs: List[Tuple[int, int]] = []
+    start: int | None = None
+    for index, in_plateau in enumerate(plateau_mask):
+        if in_plateau and start is None:
+            start = index
+        elif not in_plateau and start is not None:
+            plateau_runs.append((start, index - 1))
+            start = None
+    if start is not None:
+        plateau_runs.append((start, len(plateau_mask) - 1))
+
+    plateau_detected = any((end - start + 1) >= min_plateau_points for start, end in plateau_runs)
+    plateau_width = max((end - start + 1 for start, end in plateau_runs), default=0)
+    diagnostics["plateau_width_points"] = float(plateau_width)
+    diagnostics["plateau_width_fraction"] = plateau_width / max(len(parameter_values), 1)
+
+    robust_region_bounds: Tuple[float, float] | None = None
+    if plateau_detected:
+        best_run = max(plateau_runs, key=lambda bounds: bounds[1] - bounds[0])
+        robust_region_bounds = (
+            float(parameter_values[best_run[0]]),
+            float(parameter_values[best_run[1]]),
+        )
+        reason_codes.append("ROBUST_PLATEAU_DETECTED")
+
+    fragile_spike_detected = False
+    if len(validation_errors) >= 3:
+        for index in range(1, len(validation_errors) - 1):
+            center = validation_errors[index]
+            left = validation_errors[index - 1]
+            right = validation_errors[index + 1]
+            if not all(math.isfinite(value) for value in (center, left, right)):
+                continue
+            neighbor_mean = 0.5 * (float(left) + float(right))
+            if neighbor_mean <= 0.0:
+                continue
+            if float(center) * fragile_spike_ratio <= neighbor_mean:
+                fragile_spike_detected = True
+                break
+    if fragile_spike_detected:
+        reason_codes.append("FRAGILE_PARAMETER_SPIKE")
+
+    return diagnostics, plateau_detected, fragile_spike_detected, robust_region_bounds, reason_codes
+
+
+def fit_parameter_sensitivity_surface(
+    records: Sequence[ParameterSensitivityInputV1],
+    *,
+    grid: ParameterGridSpecV1,
+    target_name: str = "target",
+    min_samples: int = 8,
+    min_grid_points: int = 3,
+    validation_fraction: float = 0.25,
+    plateau_relative_tolerance: float = 0.15,
+    fragile_spike_ratio: float = 3.0,
+    min_plateau_points: int = 3,
+    max_validation_rmse: float = 0.75,
+) -> ParameterSensitivitySurfaceEvidenceV1:
+    try:
+        rows, feature_names, x_digest, y_digest = _validate_records(records)
+    except ValueError as exc:
+        message = str(exc)
+        if message == "LOOKAHEAD_BLOCKED":
+            return ParameterSensitivitySurfaceEvidenceV1(
+                evidence_type="parameter_sensitivity_surface",
+                model_family="OLS",
+                target_name=target_name,
+                feature_names=(),
+                parameter_name=grid.parameter_name,
+                parameter_values=grid.parameter_values,
+                n_samples=len(records),
+                n_features=0,
+                n_grid_points=len(grid.parameter_values),
+                solver="numpy.linalg.lstsq",
+                fit_intercept=True,
+                grid_evidence=(),
+                surface_diagnostics={},
+                plateau_detected=False,
+                fragile_spike_detected=False,
+                robust_region_bounds=None,
+                feature_matrix_digest="",
+                target_digest="",
+                validation_policy="TIME_ORDERED",
+                status="LEAKAGE_BLOCKED",
+                reason_codes=("FEATURE_LEAKAGE_RISK",),
+                authority_effect="NONE",
+                runtime_effect="NONE",
+            )
+        raise
+
+    n_samples = len(rows)
+    if n_samples < min_samples:
+        return ParameterSensitivitySurfaceEvidenceV1(
+            evidence_type="parameter_sensitivity_surface",
+            model_family="OLS",
+            target_name=target_name,
+            feature_names=feature_names,
+            parameter_name=grid.parameter_name,
+            parameter_values=grid.parameter_values,
+            n_samples=n_samples,
+            n_features=len(feature_names),
+            n_grid_points=len(grid.parameter_values),
+            solver="numpy.linalg.lstsq",
+            fit_intercept=True,
+            grid_evidence=(),
+            surface_diagnostics={},
+            plateau_detected=False,
+            fragile_spike_detected=False,
+            robust_region_bounds=None,
+            feature_matrix_digest=x_digest,
+            target_digest=y_digest,
+            validation_policy="TIME_ORDERED",
+            status="INSUFFICIENT_DATA",
+            reason_codes=("INSUFFICIENT_SAMPLE_COUNT",),
+            authority_effect="NONE",
+            runtime_effect="NONE",
+        )
+
+    if grid.scaled_feature_name not in feature_names:
+        raise ValueError("TARGET_BINDING_MISSING")
+
+    if len(grid.parameter_values) < min_grid_points:
+        return ParameterSensitivitySurfaceEvidenceV1(
+            evidence_type="parameter_sensitivity_surface",
+            model_family="OLS",
+            target_name=target_name,
+            feature_names=feature_names,
+            parameter_name=grid.parameter_name,
+            parameter_values=grid.parameter_values,
+            n_samples=n_samples,
+            n_features=len(feature_names),
+            n_grid_points=len(grid.parameter_values),
+            solver="numpy.linalg.lstsq",
+            fit_intercept=True,
+            grid_evidence=(),
+            surface_diagnostics={"grid_point_count": float(len(grid.parameter_values))},
+            plateau_detected=False,
+            fragile_spike_detected=False,
+            robust_region_bounds=None,
+            feature_matrix_digest=x_digest,
+            target_digest=y_digest,
+            validation_policy="TIME_ORDERED",
+            status="INSUFFICIENT_DATA",
+            reason_codes=("PARAMETER_GRID_TOO_SMALL",),
+            authority_effect="NONE",
+            runtime_effect="NONE",
+        )
+
+    grid_evidence: List[LinearModelEvidenceV1] = []
+    validation_errors: List[float] = []
+
+    for parameter_value in grid.parameter_values:
+        scaled_rows = _scale_rows(
+            rows,
+            scaled_feature_name=grid.scaled_feature_name,
+            parameter_value=parameter_value,
+        )
+        x, y, binding = build_feature_matrix_binding(
+            scaled_rows,
+            feature_names=feature_names,
+            target_name=target_name,
+            time_name="decision_time",
+            validation_policy="TIME_ORDERED",
+        )
+        evidence = fit_ols_lstsq(
+            x,
+            y,
+            binding,
+            fit_intercept=True,
+            validation_fraction=validation_fraction,
+            evidence_type="parameter_sensitivity_surface_point",
+        )
+        grid_evidence.append(evidence)
+        validation_errors.append(_validation_rmse(evidence))
+
+    (
+        surface_diagnostics,
+        plateau_detected,
+        fragile_spike_detected,
+        robust_region_bounds,
+        surface_reasons,
+    ) = _analyze_surface(
+        grid.parameter_values,
+        validation_errors,
+        plateau_relative_tolerance=plateau_relative_tolerance,
+        fragile_spike_ratio=fragile_spike_ratio,
+        min_plateau_points=min_plateau_points,
+        max_validation_rmse=max_validation_rmse,
+    )
+
+    aggregate_reasons: List[str] = list(surface_reasons)
+    aggregate_status = "DIAGNOSTIC_ONLY"
+
+    for evidence in grid_evidence:
+        if evidence.status == "INSUFFICIENT_DATA":
+            aggregate_status = "INSUFFICIENT_DATA"
+            if "INSUFFICIENT_SAMPLE_COUNT" not in aggregate_reasons:
+                aggregate_reasons.append("INSUFFICIENT_SAMPLE_COUNT")
+        elif evidence.status == "RANK_DEFICIENT_BLOCKED":
+            aggregate_status = "RANK_DEFICIENT_BLOCKED"
+        elif evidence.status == "ROBUSTNESS_FAILED" and aggregate_status == "DIAGNOSTIC_ONLY":
+            aggregate_status = "ROBUSTNESS_FAILED"
+
+    surface_diagnostics["grid_point_count"] = float(len(grid.parameter_values))
+
+    return ParameterSensitivitySurfaceEvidenceV1(
+        evidence_type="parameter_sensitivity_surface",
+        model_family="OLS",
+        target_name=target_name,
+        feature_names=feature_names,
+        parameter_name=grid.parameter_name,
+        parameter_values=grid.parameter_values,
+        n_samples=n_samples,
+        n_features=len(feature_names),
+        n_grid_points=len(grid.parameter_values),
+        solver="numpy.linalg.lstsq",
+        fit_intercept=True,
+        grid_evidence=tuple(grid_evidence),
+        surface_diagnostics=surface_diagnostics,
+        plateau_detected=plateau_detected,
+        fragile_spike_detected=fragile_spike_detected,
+        robust_region_bounds=robust_region_bounds,
+        feature_matrix_digest=x_digest,
+        target_digest=y_digest,
+        validation_policy="TIME_ORDERED",
+        status=aggregate_status,
+        reason_codes=tuple(dict.fromkeys(aggregate_reasons)),
+        authority_effect="NONE",
+        runtime_effect="NONE",
+    )

--- a/tests/research/test_offline_parameter_sensitivity_surface_v0.py
+++ b/tests/research/test_offline_parameter_sensitivity_surface_v0.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from research.linear_evidence.sensitivity import (
+    ParameterGridSpecV1,
+    ParameterSensitivityInputV1,
+    fit_parameter_sensitivity_surface,
+)
+
+
+def _record(
+    index: int,
+    *,
+    target: float,
+    signal: float,
+    aux: float,
+    feature_time: str | None = None,
+) -> ParameterSensitivityInputV1:
+    decision_time = f"2026-01-01T{index:02d}:00:00Z"
+    return ParameterSensitivityInputV1(
+        instrument_id="PF_ETHUSD",
+        decision_time=decision_time,
+        feature_availability_time=feature_time or decision_time,
+        target=target,
+        features={"signal": signal, "aux": aux},
+    )
+
+
+def _robust_plateau_records(count: int = 16) -> list[ParameterSensitivityInputV1]:
+    return [
+        _record(
+            index,
+            target=float(index + 1) + 0.05 * float(index % 4),
+            signal=float(index + 1),
+            aux=0.05 * float(index % 4),
+        )
+        for index in range(count)
+    ]
+
+
+def _fragile_spike_records() -> list[ParameterSensitivityInputV1]:
+    records: list[ParameterSensitivityInputV1] = []
+    for index in range(12):
+        signal = float(index + 1)
+        aux = 0.2 * signal
+        records.append(
+            _record(index, target=signal + aux, signal=signal, aux=aux),
+        )
+    for index in range(12, 16):
+        signal = float(index + 1)
+        aux = float((index % 3) + 1) * 2.0
+        records.append(
+            _record(index, target=signal + aux, signal=signal, aux=aux),
+        )
+    return records
+
+
+def _default_grid() -> ParameterGridSpecV1:
+    return ParameterGridSpecV1(
+        parameter_name="signal_scale",
+        scaled_feature_name="signal",
+        parameter_values=(0.85, 0.95, 1.0, 1.05, 1.15),
+    )
+
+
+def test_parameter_sensitivity_surface_is_authority_neutral() -> None:
+    evidence = fit_parameter_sensitivity_surface(_robust_plateau_records(), grid=_default_grid())
+
+    assert evidence.evidence_type == "parameter_sensitivity_surface"
+    assert evidence.authority_effect == "NONE"
+    assert evidence.runtime_effect == "NONE"
+    assert evidence.solver == "numpy.linalg.lstsq"
+    assert evidence.validation_policy == "TIME_ORDERED"
+    assert evidence.n_grid_points == len(_default_grid().parameter_values)
+    assert all(point.solver == "numpy.linalg.lstsq" for point in evidence.grid_evidence)
+
+
+def test_parameter_sensitivity_surface_blocks_non_time_ordered_records() -> None:
+    records = [
+        _record(2, target=0.2, signal=2.0, aux=0.1),
+        _record(1, target=0.1, signal=1.0, aux=0.2),
+    ]
+
+    with pytest.raises(ValueError, match="RANDOM_VALIDATION_SPLIT_BLOCKED"):
+        fit_parameter_sensitivity_surface(records, grid=_default_grid(), min_samples=2)
+
+
+def test_parameter_sensitivity_surface_blocks_lookahead() -> None:
+    records = [
+        _record(
+            index,
+            target=float(index) * 0.1,
+            signal=float(index),
+            aux=float(index % 2),
+            feature_time=f"2026-01-01T{index + 1:02d}:00:00Z" if index == 0 else None,
+        )
+        for index in range(8)
+    ]
+
+    evidence = fit_parameter_sensitivity_surface(records, grid=_default_grid(), min_samples=4)
+
+    assert evidence.status == "LEAKAGE_BLOCKED"
+    assert evidence.reason_codes == ("FEATURE_LEAKAGE_RISK",)
+
+
+def test_parameter_sensitivity_surface_robust_plateau_case() -> None:
+    evidence = fit_parameter_sensitivity_surface(_robust_plateau_records(), grid=_default_grid())
+
+    assert evidence.plateau_detected is True
+    assert "ROBUST_PLATEAU_DETECTED" in evidence.reason_codes
+    assert evidence.robust_region_bounds is not None
+    assert evidence.robust_region_bounds[0] <= evidence.robust_region_bounds[1]
+
+
+def test_parameter_sensitivity_surface_fragile_spike_case() -> None:
+    grid = ParameterGridSpecV1(
+        parameter_name="signal_scale",
+        scaled_feature_name="signal",
+        parameter_values=(0.25, 0.5, 0.75, 1.0, 1.25),
+    )
+    evidence = fit_parameter_sensitivity_surface(_fragile_spike_records(), grid=grid)
+
+    assert evidence.fragile_spike_detected is True
+    assert "FRAGILE_PARAMETER_SPIKE" in evidence.reason_codes
+
+
+def test_parameter_sensitivity_surface_insufficient_grid_case() -> None:
+    grid = ParameterGridSpecV1(
+        parameter_name="signal_scale",
+        scaled_feature_name="signal",
+        parameter_values=(0.9, 1.1),
+    )
+    evidence = fit_parameter_sensitivity_surface(
+        _robust_plateau_records(count=8),
+        grid=grid,
+        min_samples=4,
+        min_grid_points=3,
+    )
+
+    assert evidence.status == "INSUFFICIENT_DATA"
+    assert evidence.reason_codes == ("PARAMETER_GRID_TOO_SMALL",)
+
+
+def test_parameter_sensitivity_surface_insufficient_sample_count() -> None:
+    evidence = fit_parameter_sensitivity_surface(
+        _robust_plateau_records(count=3),
+        grid=_default_grid(),
+        min_samples=8,
+    )
+
+    assert evidence.status == "INSUFFICIENT_DATA"
+    assert evidence.reason_codes == ("INSUFFICIENT_SAMPLE_COUNT",)
+
+
+def test_parameter_sensitivity_surface_unstable_validation_case() -> None:
+    records = [
+        _record(
+            index,
+            target=5.0 + float(index % 7) * 0.9,
+            signal=float(index + 1),
+            aux=float(index % 3),
+        )
+        for index in range(16)
+    ]
+    grid = ParameterGridSpecV1(
+        parameter_name="signal_scale",
+        scaled_feature_name="signal",
+        parameter_values=(0.5, 0.75, 1.0, 1.25, 1.5),
+    )
+
+    evidence = fit_parameter_sensitivity_surface(records, grid=grid, max_validation_rmse=0.05)
+
+    assert "VALIDATION_ERROR_TOO_HIGH" in evidence.reason_codes
+
+
+def test_parameter_sensitivity_surface_does_not_emit_best_parameter_point() -> None:
+    evidence = fit_parameter_sensitivity_surface(_robust_plateau_records(), grid=_default_grid())
+    payload = evidence.to_dict()
+
+    assert "best_parameter_value" not in payload
+    assert "best_parameter_point" not in payload
+    assert "optimal_parameter" not in payload
+
+
+def test_parameter_sensitivity_surface_cli_writes_manifestable_report(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/research/offline_parameter_sensitivity_surface_v0.py",
+            "--out",
+            str(tmp_path),
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report_path = tmp_path / "parameter_sensitivity_surface_evidence_v1.json"
+    assert report_path.exists()
+    report = json.loads(report_path.read_text())
+    assert report["evidence_type"] == "parameter_sensitivity_surface"
+    assert report["authority_effect"] == "NONE"
+    assert report["runtime_effect"] == "NONE"
+    assert report["offline_only"] is True
+    assert report["system_economic_evidence_admissible"] is False
+    assert report["runtime_rewire_admissible"] is False
+    assert report["no_parameter_auto_optimization"] is True
+    assert report["no_parameter_default_change_in_v0"] is True
+    truth_pack = report["fixture_truth_pack"]
+    assert "ROBUST_PLATEAU_DETECTED" in truth_pack["robust_plateau_case"]["reason_codes"]
+    assert "FRAGILE_PARAMETER_SPIKE" in truth_pack["fragile_spike_case"]["reason_codes"]
+    assert truth_pack["insufficient_grid_case"]["reason_codes"] == ["PARAMETER_GRID_TOO_SMALL"]
+    assert "VALIDATION_ERROR_TOO_HIGH" in truth_pack["unstable_validation_case"]["reason_codes"]


### PR DESCRIPTION
## Summary
- Adds `src/research/linear_evidence/sensitivity.py` for authority-neutral, diagnostic-only parameter sensitivity surface evaluation over a bounded grid.
- Reports plateau stability, fragile spikes, validation error, and leakage risk via deterministic reason codes without emitting a best-parameter recommendation.
- Adds offline CLI `scripts/research/offline_parameter_sensitivity_surface_v0.py` and fixture truth-pack tests covering robust plateau, fragile spike, insufficient grid, and unstable validation cases.

## Test plan
- [x] `python3 -m py_compile src/research/linear_evidence/*.py scripts/research/offline_parameter_sensitivity_surface_v0.py`
- [x] `python3 -m pytest -q tests/research/test_offline_parameter_sensitivity_surface_v0.py`
- [x] `python3 scripts/research/offline_parameter_sensitivity_surface_v0.py --out <archive>/diagnostics`
- [x] `python3 -m ruff check` / `python3 -m ruff format --check` on touched paths
- [x] PR-bounded CI contract batch (730 tests, ~46s local)

## Governance
- `AUTHORITY_EFFECT=NONE`
- `RUNTIME_EFFECT=NONE`
- `NO_PARAMETER_AUTO_OPTIMIZATION=true`
- `NO_PARAMETER_DEFAULT_CHANGE_IN_V0=true`
- `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`
- `RUNTIME_REWIRE_ADMISSIBLE=false`


Made with [Cursor](https://cursor.com)