### PR TITLE
fix: STEP29L.2 import boundary AST classification (docstring false positive)

### DIFF
--- a/scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py
+++ b/scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Classify STEP29L.2 offline linear evidence surface status after PR5044 (offline only)."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from research.linear_evidence.import_boundary import (  # noqa: E402
+    classify_import_boundary_scan,
+    scan_paths_import_boundary,
+)
+from scripts.ops.primary_evidence_retention_v0 import (  # noqa: E402
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+
+CLASSIFICATION = "STEP29L2_OFFLINE_LINEAR_EVIDENCE_STATUS_AFTER_PR5044"
+MISSING_SURFACE = "offline_signal_orthogonality_diagnostics_v0"
+
+LINEAR_EVIDENCE_REL = Path("src/research/linear_evidence")
+RESEARCH_SCRIPT_NAMES = (
+    "offline_factor_exposure_diagnostics_v0.py",
+    "offline_linear_cost_model_diagnostics_v0.py",
+    "offline_parameter_sensitivity_surface_v0.py",
+    "offline_rolling_linear_drift_diagnostics_v0.py",
+)
+RESEARCH_TEST_NAMES = (
+    "test_offline_factor_exposure_diagnostics_v0.py",
+    "test_offline_linear_cost_model_diagnostics_v0.py",
+    "test_offline_parameter_sensitivity_surface_v0.py",
+    "test_offline_rolling_linear_drift_diagnostics_v0.py",
+)
+
+
+def _git_rev_parse(ref: str) -> str:
+    proc = subprocess.run(
+        ["git", "rev-parse", ref],
+        cwd=str(REPO_ROOT),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return "UNKNOWN"
+    return proc.stdout.strip()
+
+
+def _git_status_short() -> str:
+    proc = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=str(REPO_ROOT),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return proc.stdout.strip()
+
+
+def _collect_scan_paths(repo_root: Path) -> list[Path]:
+    paths: list[Path] = []
+    linear_dir = repo_root / LINEAR_EVIDENCE_REL
+    if linear_dir.is_dir():
+        paths.extend(sorted(p for p in linear_dir.rglob("*.py") if p.is_file()))
+    for name in RESEARCH_SCRIPT_NAMES:
+        candidate = repo_root / "scripts/research" / name
+        if candidate.is_file():
+            paths.append(candidate)
+    for name in RESEARCH_TEST_NAMES:
+        candidate = repo_root / "tests/research" / name
+        if candidate.is_file():
+            paths.append(candidate)
+    return paths
+
+
+def _write_inventory(repo_root: Path, output_dir: Path) -> None:
+    lines = ["=== linear_evidence tree ==="]
+    linear_dir = repo_root / LINEAR_EVIDENCE_REL
+    if linear_dir.is_dir():
+        for path in sorted(linear_dir.rglob("*")):
+            if path.is_file():
+                lines.append(path.relative_to(repo_root).as_posix())
+    lines.extend(["", "=== research scripts ==="])
+    for name in RESEARCH_SCRIPT_NAMES:
+        rel = f"scripts/research/{name}"
+        if (repo_root / rel).is_file():
+            lines.append(rel)
+    lines.extend(["", "=== research tests ==="])
+    for name in RESEARCH_TEST_NAMES:
+        rel = f"tests/research/{name}"
+        if (repo_root / rel).is_file():
+            lines.append(rel)
+    (output_dir / "inventory.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_context(output_dir: Path, *, head: str, origin_main: str) -> None:
+    worktree_clean = _git_status_short() == ""
+    (output_dir / "context.txt").write_text(
+        "\n".join(
+            [
+                f"CLASSIFICATION={CLASSIFICATION}",
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"HEAD_EQUALS_ORIGIN_MAIN={str(head == origin_main).lower()}",
+                f"WORKTREE_CLEAN={str(worktree_clean).lower()}",
+                "AUTHORITY_EFFECT=NONE",
+                "RUNTIME_EFFECT=NONE",
+                "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false",
+                "RUNTIME_REWIRE_ADMISSIBLE=false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_surface_classification(output_dir: Path) -> None:
+    orthogonality_module = (REPO_ROOT / "src/research/linear_evidence/orthogonality.py").is_file()
+    orthogonality_cli = (
+        REPO_ROOT / "scripts/research/offline_signal_orthogonality_diagnostics_v0.py"
+    ).is_file()
+    orthogonality_tests = (
+        REPO_ROOT / "tests/research/test_offline_signal_orthogonality_diagnostics_v0.py"
+    ).is_file()
+    missing_modules: list[str] = []
+    missing_clis: list[str] = []
+    missing_tests: list[str] = []
+    if not orthogonality_module:
+        missing_modules.extend(["orthogonality_module", "diagnostics"])
+    if not orthogonality_cli:
+        missing_clis.append("orthogonality_cli")
+    if not orthogonality_tests:
+        missing_tests.append("orthogonality_tests")
+    (output_dir / "classification.txt").write_text(
+        "\n".join(
+            [
+                f"REQUIRED_MODULES_PRESENT={str(not missing_modules).lower()}",
+                f"REQUIRED_CLIS_PRESENT={str(not missing_clis).lower()}",
+                f"REQUIRED_TESTS_PRESENT={str(not missing_tests).lower()}",
+                f"MISSING_REQUIRED_MODULES={','.join(missing_modules) if missing_modules else 'NONE'}",
+                f"MISSING_REQUIRED_CLIS={','.join(missing_clis) if missing_clis else 'NONE'}",
+                f"MISSING_REQUIRED_TESTS={','.join(missing_tests) if missing_tests else 'NONE'}",
+                "STEP29L2_SURFACE_STATUS=PARTIAL",
+                "NEXT_GAP_CLASS=MISSING_REQUIRED_DIAGNOSTIC_SURFACE",
+                f"MISSING_SURFACE={MISSING_SURFACE}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_import_boundary_artifacts(
+    output_dir: Path,
+    *,
+    hits,
+    docstring_comment_probes: list[str],
+    classification: dict[str, str | int | bool],
+) -> None:
+    scan_lines = ["=== authority/runtime import scan ==="]
+    if hits:
+        scan_lines.extend(hit.format_scan_line() for hit in hits)
+    (output_dir / "import_boundary_scan.txt").write_text(
+        "\n".join(scan_lines) + "\n",
+        encoding="utf-8",
+    )
+
+    class_lines = [
+        f"IMPORT_BOUNDARY_HITS={classification['IMPORT_BOUNDARY_HITS']}",
+        f"BAD_IMPORT_BOUNDARY_HITS={classification['BAD_IMPORT_BOUNDARY_HITS']}",
+        f"IMPORT_BOUNDARY_STATUS={classification['IMPORT_BOUNDARY_STATUS']}",
+        (
+            "false_positive_docstring_ignored="
+            f"{str(classification['false_positive_docstring_ignored']).lower()}"
+        ),
+        f"DOCSTRING_COMMENT_PROBE_HITS={classification['DOCSTRING_COMMENT_PROBE_HITS']}",
+    ]
+    if hits:
+        class_lines.append(f"BAD_HIT={hits[0].format_scan_line()}")
+    elif docstring_comment_probes:
+        class_lines.append(f"IGNORED_PROBE_HIT={docstring_comment_probes[0]}")
+    (output_dir / "import_boundary_classification.txt").write_text(
+        "\n".join(class_lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_final_report(
+    output_dir: Path,
+    *,
+    head: str,
+    origin_main: str,
+    classification: dict[str, str | int | bool],
+    manifest_verify_rc: int,
+) -> None:
+    (output_dir / "final_report.txt").write_text(
+        "\n".join(
+            [
+                f"CLASSIFICATION={CLASSIFICATION}",
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                "OFFLINE_ONLY=true",
+                "NO_RUNTIME_REWIRE=true",
+                "AUTHORITY_EFFECT=NONE",
+                "RUNTIME_EFFECT=NONE",
+                f"IMPORT_BOUNDARY_STATUS={classification['IMPORT_BOUNDARY_STATUS']}",
+                (
+                    "false_positive_docstring_ignored="
+                    f"{str(classification['false_positive_docstring_ignored']).lower()}"
+                ),
+                "STEP29L2_SURFACE_STATUS=PARTIAL",
+                "NEXT_GAP_CLASS=MISSING_REQUIRED_DIAGNOSTIC_SURFACE",
+                f"MISSING_SURFACE={MISSING_SURFACE}",
+                f"MANIFEST_VERIFY_RC={manifest_verify_rc}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def run_classification(*, output_dir: Path, repo_root: Path | None = None) -> int:
+    root = repo_root or REPO_ROOT
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _git_rev_parse("HEAD")
+    origin_main = _git_rev_parse("origin/main")
+
+    _write_inventory(root, output_dir)
+    _write_context(output_dir, head=head, origin_main=origin_main)
+    _write_surface_classification(output_dir)
+
+    scan_paths = _collect_scan_paths(root)
+    hits, docstring_comment_probes = scan_paths_import_boundary(
+        scan_paths,
+        repo_root=root,
+    )
+    boundary_classification = classify_import_boundary_scan(
+        hits,
+        docstring_comment_probes=docstring_comment_probes,
+    )
+    _write_import_boundary_artifacts(
+        output_dir,
+        hits=hits,
+        docstring_comment_probes=docstring_comment_probes,
+        classification=boundary_classification,
+    )
+
+    _write_final_report(
+        output_dir,
+        head=head,
+        origin_main=origin_main,
+        classification=boundary_classification,
+        manifest_verify_rc=0,
+    )
+
+    write_manifest_sha256(output_dir)
+    ok, _msg = verify_manifest_sha256(output_dir)
+    manifest_verify_rc = 0 if ok else 1
+    (output_dir / "MANIFEST.verify.rc").write_text(
+        f"{manifest_verify_rc}\n",
+        encoding="utf-8",
+    )
+    (output_dir / "final_report.txt").write_text(
+        "\n".join(
+            [
+                f"CLASSIFICATION={CLASSIFICATION}",
+                f"HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                "OFFLINE_ONLY=true",
+                "NO_RUNTIME_REWIRE=true",
+                "AUTHORITY_EFFECT=NONE",
+                "RUNTIME_EFFECT=NONE",
+                f"IMPORT_BOUNDARY_STATUS={boundary_classification['IMPORT_BOUNDARY_STATUS']}",
+                (
+                    "false_positive_docstring_ignored="
+                    f"{str(boundary_classification['false_positive_docstring_ignored']).lower()}"
+                ),
+                "STEP29L2_SURFACE_STATUS=PARTIAL",
+                "NEXT_GAP_CLASS=MISSING_REQUIRED_DIAGNOSTIC_SURFACE",
+                f"MISSING_SURFACE={MISSING_SURFACE}",
+                f"MANIFEST_VERIFY_RC={manifest_verify_rc}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    write_manifest_sha256(output_dir)
+    ok, _msg = verify_manifest_sha256(output_dir)
+    manifest_verify_rc = 0 if ok else 1
+    return (
+        0
+        if manifest_verify_rc == 0
+        and boundary_classification["IMPORT_BOUNDARY_STATUS"] != "REVIEW_REQUIRED"
+        else 1
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--repo-root", default=str(REPO_ROOT))
+    args = parser.parse_args()
+    return run_classification(
+        output_dir=Path(args.output_dir).resolve(),
+        repo_root=Path(args.repo_root).resolve(),
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/linear_evidence/import_boundary.py
+++ b/src/research/linear_evidence/import_boundary.py
@@ -1,0 +1,151 @@
+"""AST-based import boundary scanner for offline linear evidence surfaces."""
+
+from __future__ import annotations
+
+import ast
+import tokenize
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+
+FORBIDDEN_IMPORT_SEGMENTS = frozenset(
+    {
+        "runtime",
+        "scheduler",
+        "live",
+        "order_adapter",
+    }
+)
+
+# Grep-style false-positive probe tokens (docstrings/comments only; not import hits).
+_DOCSTRING_COMMENT_PROBE_TOKENS = frozenset(
+    {
+        "runtime",
+        "scheduler",
+        "live",
+        "order adapter",
+        "order_adapter",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ImportBoundaryHit:
+    path: str
+    line: int
+    module: str
+
+    def format_scan_line(self) -> str:
+        return f"{self.path}:{self.line}:{self.module}"
+
+
+def _module_segments(module: str) -> tuple[str, ...]:
+    return tuple(part for part in module.split(".") if part)
+
+
+def module_violates_forbidden_boundary(module: str) -> bool:
+    """Return True when an import module path crosses a forbidden offline boundary."""
+    normalized = module.replace("-", "_")
+    segments = _module_segments(normalized)
+    if any(segment in FORBIDDEN_IMPORT_SEGMENTS for segment in segments):
+        return True
+    if "order" in normalized and "adapter" in normalized:
+        return True
+    return False
+
+
+def _collect_import_hits(tree: ast.AST) -> list[tuple[int, str]]:
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if module_violates_forbidden_boundary(alias.name):
+                    hits.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if module_violates_forbidden_boundary(node.module):
+                hits.append((node.lineno, node.module))
+    return hits
+
+
+def _docstring_chunks(tree: ast.AST) -> list[tuple[int, str]]:
+    chunks: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Module)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                chunks.append((getattr(node, "lineno", 1), doc))
+    return chunks
+
+
+def _comment_and_docstring_probe_hits(source: str, *, rel_path: str) -> list[str]:
+    """Detect forbidden tokens appearing only in comments/docstrings (grep false positives)."""
+    probe_hits: list[str] = []
+    tree = ast.parse(source)
+    searchable_chunks: list[tuple[int, str]] = []
+
+    searchable_chunks.extend(_docstring_chunks(tree))
+
+    reader = BytesIO(source.encode("utf-8"))
+    for token in tokenize.tokenize(reader.readline):
+        if token.type == tokenize.COMMENT:
+            searchable_chunks.append((token.start[0], token.string))
+
+    for line_no, text in searchable_chunks:
+        lowered = text.lower()
+        for token in _DOCSTRING_COMMENT_PROBE_TOKENS:
+            if token in lowered:
+                probe_hits.append(f"{rel_path}:{line_no}:{token}")
+    return probe_hits
+
+
+def scan_file_import_boundary(
+    path: Path, *, repo_root: Path | None = None
+) -> list[ImportBoundaryHit]:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    rel = path.relative_to(repo_root).as_posix() if repo_root is not None else path.as_posix()
+    return [
+        ImportBoundaryHit(path=rel, line=line_no, module=module)
+        for line_no, module in _collect_import_hits(tree)
+    ]
+
+
+def scan_paths_import_boundary(
+    paths: list[Path],
+    *,
+    repo_root: Path,
+) -> tuple[list[ImportBoundaryHit], list[str]]:
+    hits: list[ImportBoundaryHit] = []
+    docstring_comment_probes: list[str] = []
+    for path in sorted(paths):
+        if not path.is_file() or path.suffix != ".py":
+            continue
+        rel = path.relative_to(repo_root).as_posix()
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        hits.extend(
+            ImportBoundaryHit(path=rel, line=line_no, module=module)
+            for line_no, module in _collect_import_hits(tree)
+        )
+        docstring_comment_probes.extend(_comment_and_docstring_probe_hits(source, rel_path=rel))
+    return hits, docstring_comment_probes
+
+
+def classify_import_boundary_scan(
+    hits: list[ImportBoundaryHit],
+    *,
+    docstring_comment_probes: list[str] | None = None,
+) -> dict[str, str | int | bool]:
+    probes = docstring_comment_probes or []
+    bad_hits = len(hits)
+    status = "PASS" if bad_hits == 0 else "REVIEW_REQUIRED"
+    false_positive_docstring_ignored = bad_hits == 0 and bool(probes)
+    if false_positive_docstring_ignored:
+        status = "PASS_DOCSTRING_FALSE_POSITIVE_IGNORED"
+    return {
+        "IMPORT_BOUNDARY_HITS": len(hits),
+        "BAD_IMPORT_BOUNDARY_HITS": bad_hits,
+        "IMPORT_BOUNDARY_STATUS": status,
+        "false_positive_docstring_ignored": false_positive_docstring_ignored,
+        "DOCSTRING_COMMENT_PROBE_HITS": len(probes),
+    }

--- a/tests/research/test_step29l2_import_boundary_classification_v0.py
+++ b/tests/research/test_step29l2_import_boundary_classification_v0.py
@@ -1,0 +1,138 @@
+"""Contract tests for STEP29L.2 import boundary classification (AST/tokenize owner)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from research.linear_evidence.import_boundary import (
+    classify_import_boundary_scan,
+    module_violates_forbidden_boundary,
+    scan_file_import_boundary,
+    scan_paths_import_boundary,
+)
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from scripts.research.classify_step29l2_offline_linear_evidence_status_after_pr5044_v0 import (
+    run_classification,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLASSIFY_SCRIPT = (
+    REPO_ROOT
+    / "scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py"
+)
+INIT_PATH = REPO_ROOT / "src/research/linear_evidence/__init__.py"
+
+
+def _write_probe_file(tmp_path: Path, name: str, source: str) -> Path:
+    path = tmp_path / name
+    path.write_text(textwrap.dedent(source).strip() + "\n", encoding="utf-8")
+    return path
+
+
+def test_module_violates_forbidden_boundary_segments() -> None:
+    assert module_violates_forbidden_boundary("src.scheduler.jobs")
+    assert module_violates_forbidden_boundary("src.live.execution")
+    assert module_violates_forbidden_boundary("src.runtime.bridge")
+    assert module_violates_forbidden_boundary("src.order_adapter.submit")
+    assert not module_violates_forbidden_boundary("research.linear_evidence.contracts")
+
+
+def test_docstring_with_scheduler_is_ignored(tmp_path: Path) -> None:
+    path = _write_probe_file(
+        tmp_path,
+        "docstring_probe.py",
+        '''
+        """Offline only; must not import scheduler paths."""
+        x = 1
+        ''',
+    )
+    hits = scan_file_import_boundary(path)
+    assert hits == []
+    _, probes = scan_paths_import_boundary([path], repo_root=tmp_path)
+    classification = classify_import_boundary_scan(hits, docstring_comment_probes=probes)
+    assert classification["IMPORT_BOUNDARY_STATUS"] == "PASS_DOCSTRING_FALSE_POSITIVE_IGNORED"
+    assert classification["false_positive_docstring_ignored"] is True
+
+
+def test_comment_with_runtime_order_adapter_is_ignored(tmp_path: Path) -> None:
+    path = _write_probe_file(
+        tmp_path,
+        "comment_probe.py",
+        """
+        # runtime/order adapter imports are forbidden here
+        value = 42
+        """,
+    )
+    hits = scan_file_import_boundary(path)
+    assert hits == []
+    _, probes = scan_paths_import_boundary([path], repo_root=tmp_path)
+    classification = classify_import_boundary_scan(hits, docstring_comment_probes=probes)
+    assert classification["IMPORT_BOUNDARY_STATUS"] == "PASS_DOCSTRING_FALSE_POSITIVE_IGNORED"
+    assert classification["false_positive_docstring_ignored"] is True
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_module"),
+    [
+        ("import src.scheduler.jobs", "src.scheduler.jobs"),
+        ("from src.live.execution import lane", "src.live.execution"),
+    ],
+)
+def test_real_imports_are_blocked(
+    tmp_path: Path,
+    source: str,
+    expected_module: str,
+) -> None:
+    path = _write_probe_file(tmp_path, "bad_import.py", source)
+    hits = scan_file_import_boundary(path)
+    assert len(hits) == 1
+    assert hits[0].module == expected_module
+    classification = classify_import_boundary_scan(hits)
+    assert classification["IMPORT_BOUNDARY_STATUS"] == "REVIEW_REQUIRED"
+    assert classification["BAD_IMPORT_BOUNDARY_HITS"] == 1
+
+
+def test_linear_evidence_init_docstring_is_not_import_hit() -> None:
+    hits = scan_file_import_boundary(INIT_PATH, repo_root=REPO_ROOT)
+    assert hits == []
+
+
+def test_classification_runner_emits_expected_artifacts(tmp_path: Path) -> None:
+    rc = run_classification(output_dir=tmp_path, repo_root=REPO_ROOT)
+    assert rc == 0
+
+    boundary_text = (tmp_path / "import_boundary_classification.txt").read_text(encoding="utf-8")
+    assert "IMPORT_BOUNDARY_STATUS=PASS_DOCSTRING_FALSE_POSITIVE_IGNORED" in boundary_text
+    assert "false_positive_docstring_ignored=true" in boundary_text
+    assert "STEP29L2_SURFACE_STATUS=PARTIAL" in (tmp_path / "classification.txt").read_text(
+        encoding="utf-8"
+    )
+    assert "MISSING_SURFACE=offline_signal_orthogonality_diagnostics_v0" in (
+        tmp_path / "classification.txt"
+    ).read_text(encoding="utf-8")
+    assert "NEXT_GAP_CLASS=MISSING_REQUIRED_DIAGNOSTIC_SURFACE" in (
+        tmp_path / "final_report.txt"
+    ).read_text(encoding="utf-8")
+
+    ok, _msg = verify_manifest_sha256(tmp_path)
+    assert ok
+    assert (tmp_path / "final_report.txt").is_file()
+    assert (tmp_path / "MANIFEST.sha256").is_file()
+
+
+def test_classify_script_uses_ast_not_raw_grep() -> None:
+    source = CLASSIFY_SCRIPT.read_text(encoding="utf-8")
+    assert "grep" not in source
+    assert "scan_paths_import_boundary" in source
+    assert "import_boundary" in source
+
+
+def test_import_boundary_module_uses_ast_walk_for_imports_only() -> None:
+    module_path = REPO_ROOT / "src/research/linear_evidence/import_boundary.py"
+    source = module_path.read_text(encoding="utf-8")
+    assert "isinstance(node, ast.Import)" in source
+    assert "isinstance(node, ast.ImportFrom)" in source
+    assert "tokenize.tokenize" in source


### PR DESCRIPTION
## Summary
- Add AST/tokenize-based import boundary owner for STEP29L.2 offline linear evidence classification.
- Replace grep-style forbidden-token matching so docstrings/comments (e.g. `__init__.py` scheduler warning) no longer trigger `REVIEW_REQUIRED`.
- Add classification runner emitting `import_boundary_scan.txt`, `import_boundary_classification.txt`, `final_report.txt`, and verified `MANIFEST.sha256`.

## Test plan
- [x] `pytest tests/research/test_step29l2_import_boundary_classification_v0.py -q`
- [x] `pytest tests/ci/test_ci_diff_aware_test_selection_v1.py -q`
- [x] `ruff format --check` / `ruff check` on touched files
- [x] Full classification run: `IMPORT_BOUNDARY_STATUS=PASS_DOCSTRING_FALSE_POSITIVE_IGNORED`, `MANIFEST_VERIFY_RC=0`

## Evidence
- `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0_20260709T214731Z`


Made with [Cursor](https://cursor.com)