### PR TITLE
Repair offline linear evidence layer gaps

### DIFF
--- a/scripts/research/offline_linear_cost_model_diagnostics_v0.py
+++ b/scripts/research/offline_linear_cost_model_diagnostics_v0.py
@@ -151,3 +151,7 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"

--- a/src/research/linear_evidence/cost_model.py
+++ b/src/research/linear_evidence/cost_model.py
@@ -38,3 +38,14 @@ def build_cost_model_calibration_evidence(
         status=status,
         reason_codes=reason_codes,
     )
+
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+
+
+def with_authority_neutral_effects(payload):
+    enriched = dict(payload)
+    enriched["authority_effect"] = AUTHORITY_EFFECT
+    enriched["runtime_effect"] = RUNTIME_EFFECT
+    return enriched

--- a/src/research/linear_evidence/diagnostics.py
+++ b/src/research/linear_evidence/diagnostics.py
@@ -1,0 +1,69 @@
+"""Offline linear evidence diagnostics.
+
+This module is intentionally offline-only and authority-neutral.
+It provides small deterministic helpers shared by the linear evidence
+surfaces without importing any runtime execution paths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import sqrt
+from typing import Dict, Iterable, Mapping, Sequence
+
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+
+
+@dataclass(frozen=True)
+class ResidualDiagnosticsV1:
+    """Basic residual diagnostics for offline linear evidence."""
+
+    n_samples: int
+    mae: float
+    rmse: float
+    max_abs_error: float
+    mean_error: float
+    authority_effect: str = AUTHORITY_EFFECT
+    runtime_effect: str = RUNTIME_EFFECT
+
+
+def compute_residual_diagnostics(
+    residuals: Sequence[float] | Iterable[float],
+) -> ResidualDiagnosticsV1:
+    values = [float(v) for v in residuals]
+    if not values:
+        return ResidualDiagnosticsV1(
+            n_samples=0,
+            mae=0.0,
+            rmse=0.0,
+            max_abs_error=0.0,
+            mean_error=0.0,
+        )
+
+    abs_values = [abs(v) for v in values]
+    n = len(values)
+    return ResidualDiagnosticsV1(
+        n_samples=n,
+        mae=sum(abs_values) / n,
+        rmse=sqrt(sum(v * v for v in values) / n),
+        max_abs_error=max(abs_values),
+        mean_error=sum(values) / n,
+    )
+
+
+def attach_authority_neutral_fields(payload: Mapping[str, object]) -> Dict[str, object]:
+    enriched = dict(payload)
+    enriched["authority_effect"] = AUTHORITY_EFFECT
+    enriched["runtime_effect"] = RUNTIME_EFFECT
+    return enriched
+
+
+__all__ = [
+    "AUTHORITY_EFFECT",
+    "RUNTIME_EFFECT",
+    "ResidualDiagnosticsV1",
+    "attach_authority_neutral_fields",
+    "compute_residual_diagnostics",
+]

--- a/src/research/linear_evidence/report.py
+++ b/src/research/linear_evidence/report.py
@@ -1,0 +1,55 @@
+"""Offline linear evidence reporting helpers.
+
+Reports produced here are diagnostic-only. They do not create trading,
+runtime, sizing, promotion, or economic-pass authority.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping, MutableMapping
+
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+
+
+def normalize_linear_evidence_report(
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    report = dict(payload)
+    report["authority_effect"] = AUTHORITY_EFFECT
+    report["runtime_effect"] = RUNTIME_EFFECT
+    report.setdefault("status", "DIAGNOSTIC_ONLY")
+    report.setdefault("cost_policy_output", "diagnostic_only")
+    return report
+
+
+def write_linear_evidence_report(
+    payload: Mapping[str, object],
+    output_path: str | Path,
+) -> dict[str, object]:
+    normalized = normalize_linear_evidence_report(payload)
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(normalized, sort_keys=True, indent=2) + "\n")
+    return normalized
+
+
+def merge_report_fields(
+    base: Mapping[str, object],
+    updates: Mapping[str, object],
+) -> dict[str, object]:
+    merged: MutableMapping[str, object] = dict(base)
+    merged.update(updates)
+    return normalize_linear_evidence_report(merged)
+
+
+__all__ = [
+    "AUTHORITY_EFFECT",
+    "RUNTIME_EFFECT",
+    "merge_report_fields",
+    "normalize_linear_evidence_report",
+    "write_linear_evidence_report",
+]

--- a/tests/research/test_step29l2_linear_evidence_base_modules_v0.py
+++ b/tests/research/test_step29l2_linear_evidence_base_modules_v0.py
@@ -1,0 +1,31 @@
+from src.research.linear_evidence.diagnostics import (
+    AUTHORITY_EFFECT as DIAG_AUTHORITY_EFFECT,
+    RUNTIME_EFFECT as DIAG_RUNTIME_EFFECT,
+    attach_authority_neutral_fields,
+    compute_residual_diagnostics,
+)
+from src.research.linear_evidence.report import normalize_linear_evidence_report
+
+
+def test_linear_evidence_base_modules_are_authority_neutral():
+    payload = attach_authority_neutral_fields({"status": "DIAGNOSTIC_ONLY"})
+    assert payload["authority_effect"] == "NONE"
+    assert payload["runtime_effect"] == "NONE"
+    assert DIAG_AUTHORITY_EFFECT == "NONE"
+    assert DIAG_RUNTIME_EFFECT == "NONE"
+
+
+def test_residual_diagnostics_are_deterministic_and_authority_neutral():
+    result = compute_residual_diagnostics([1.0, -1.0, 2.0])
+    assert result.n_samples == 3
+    assert result.mae == 4.0 / 3.0
+    assert result.max_abs_error == 2.0
+    assert result.authority_effect == "NONE"
+    assert result.runtime_effect == "NONE"
+
+
+def test_report_normalization_injects_required_effect_tokens():
+    report = normalize_linear_evidence_report({"evidence_type": "cost_model"})
+    assert report["authority_effect"] == "NONE"
+    assert report["runtime_effect"] == "NONE"
+    assert report["cost_policy_output"] == "diagnostic_only"


### PR DESCRIPTION
## Summary
Repairs the Step29L.2 offline linear evidence layer gaps identified by the latest classification.

## Scope
- Add missing base module: `src/research/linear_evidence/diagnostics.py`
- Add missing base module: `src/research/linear_evidence/report.py`
- Add authority-neutral tokens to the cost-model surface
- Add targeted contract tests for base module behavior and authority-neutral output

## Evidence
Durable evidence:
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/repair_step29l2_offline_linear_evidence_layer_gaps_v0_20260709T220658Z`

Gate results:
- py_compile: PASS
- targeted pytest: PASS
- token_scan: PASS
- import_boundary: PASS
- manifest_verify: PASS
- ruff local: unavailable, RC=127

## Boundaries
- OFFLINE_ONLY=true
- AUTHORITY_EFFECT=NONE
- RUNTIME_EFFECT=NONE
- NO_RUNTIME=true
- NO_TRADING_LOGIC_CHANGE=true
- NO_ORDER_AUTHORITY=true
- NO_PROMOTION_AUTHORITY=true

## Notes
Local ruff is unavailable in the current shell environment. CI lint/format remains authoritative for that gate.

Made with [Cursor](https://cursor.com)