### PR TITLE
Bind STEP29M execution result fail-closed preconditions classification v0

### DIFF
--- a/docs/research/STEP29M_EXECUTION_RESULT_FAIL_CLOSED_PRECONDITIONS_NOT_ADMISSIBLE_V0.md
+++ b/docs/research/STEP29M_EXECUTION_RESULT_FAIL_CLOSED_PRECONDITIONS_NOT_ADMISSIBLE_V0.md
@@ -1,0 +1,78 @@
+# STEP29M Execution Result — Fail-Closed Preconditions Not Admissible v0
+
+## Verdict
+
+`PASS_STEP29M_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0`
+
+The STEP29M versioned offline execution runner completed successfully as an evidence-materialization pipeline.
+
+It does not execute economic evaluation.
+
+## Economic Result
+
+`FAIL_CLOSED_STEP29M_EXECUTION_PRECONDITIONS_NOT_ADMISSIBLE`
+
+## Boundary
+
+```text
+AUTHORITY_EFFECT=NONE
+RUNTIME_EFFECT=NONE
+SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false
+ECONOMIC_EVALUATION_EXECUTED=false
+RUNTIME_REWIRE_ADMISSIBLE=false
+LIVE_AUTHORIZED=false
+ORDERS_ALLOWED=false
+SHADOW_AUTHORIZED=false
+PAPER_AUTHORIZED=false
+TESTNET_AUTHORIZED=false
+```
+
+## Failed Preconditions
+
+```text
+FULL_CANONICAL_CHAIN_WIRED=false
+BACKTEST_RUNTIME_DECISION_PARITY_PASS=false
+REALISTIC_COSTS_BOUND=false
+ROBUSTNESS_EVIDENCE_PASS=false
+```
+
+## Reason Codes
+
+- `SYSTEM_ECONOMIC_EVIDENCE_NOT_ADMISSIBLE_FROM_PLAN_PRECONDITIONS`
+
+## Classification
+
+```text
+pipeline_materialization_pass=true
+economic_execution_blocked_fail_closed=true
+negative_or_positive_profitability_claim_created=false
+promotion_candidate_created=false
+runtime_authority_created=false
+```
+
+## Allowed Next Scope
+
+- `CORE_SYSTEM_COMPLETION`
+- `OFFLINE_PARITY_ASSESSMENT`
+- `NARROW_REUSE_FIRST_REWIRE`
+
+## Disallowed Next Scope
+
+- runtime, shadow, paper, testnet, canary, or live evidence
+- order submission, credential use, or arming
+
+## Source Evidence
+
+- STEP29M offline execution evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/step29m_offline_economic_evaluation_execution_v0_20260709T230849Z`
+- Source manifest verify required: `true`
+- Source manifest verify RC: `0`
+
+## Authoritative Owners
+
+- Classification JSON: `docs/research/step29m_execution_result_fail_closed_preconditions_not_admissible_v0.json`
+- Classification doc: `docs/research/STEP29M_EXECUTION_RESULT_FAIL_CLOSED_PRECONDITIONS_NOT_ADMISSIBLE_V0.md`
+- Classification tests: `tests/research/test_step29m_execution_result_fail_closed_preconditions_not_admissible_v0.py`
+
+## Next Step
+
+`FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_AND_REWIRE_SCOPE`

--- a/docs/research/step29m_execution_result_fail_closed_preconditions_not_admissible_v0.json
+++ b/docs/research/step29m_execution_result_fail_closed_preconditions_not_admissible_v0.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "step29m_execution_result_fail_closed_preconditions_not_admissible_v0",
+  "status": "binding_classification",
+  "authority_effect": "NONE",
+  "runtime_effect": "NONE",
+  "step": "STEP29M",
+  "execution_pipeline_verdict": "PASS_STEP29M_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0",
+  "execution_runner_rc": 0,
+  "economic_evaluation_result_verdict": "FAIL_CLOSED_STEP29M_EXECUTION_PRECONDITIONS_NOT_ADMISSIBLE",
+  "economic_evaluation_executed": false,
+  "system_economic_evidence_admissible": false,
+  "runtime_rewire_admissible": false,
+  "live_authorized": false,
+  "orders_allowed": false,
+  "shadow_authorized": false,
+  "paper_authorized": false,
+  "testnet_authorized": false,
+  "reason_codes": [
+    "SYSTEM_ECONOMIC_EVIDENCE_NOT_ADMISSIBLE_FROM_PLAN_PRECONDITIONS"
+  ],
+  "failed_preconditions": {
+    "FULL_CANONICAL_CHAIN_WIRED": false,
+    "BACKTEST_RUNTIME_DECISION_PARITY_PASS": false,
+    "REALISTIC_COSTS_BOUND": false,
+    "ROBUSTNESS_EVIDENCE_PASS": false
+  },
+  "classification": {
+    "pipeline_materialization_pass": true,
+    "economic_execution_blocked_fail_closed": true,
+    "negative_or_positive_profitability_claim_created": false,
+    "promotion_candidate_created": false,
+    "runtime_authority_created": false
+  },
+  "next_step": "FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_AND_REWIRE_SCOPE",
+  "allowed_next_scope": [
+    "CORE_SYSTEM_COMPLETION",
+    "OFFLINE_PARITY_ASSESSMENT",
+    "NARROW_REUSE_FIRST_REWIRE"
+  ],
+  "disallowed_next_scope": [
+    "RUNTIME_EVIDENCE",
+    "SHADOW_EVIDENCE",
+    "PAPER_EVIDENCE",
+    "TESTNET_EVIDENCE",
+    "CANARY_EVIDENCE",
+    "LIVE_EVIDENCE",
+    "ORDER_SUBMISSION",
+    "CREDENTIAL_USE",
+    "ARMING"
+  ],
+  "source_evidence": {
+    "durable_evidence_dir": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/step29m_offline_economic_evaluation_execution_v0_20260709T230849Z",
+    "manifest_verify_required": true,
+    "manifest_verify_rc": 0
+  }
+}

--- a/tests/research/test_step29m_execution_result_fail_closed_preconditions_not_admissible_v0.py
+++ b/tests/research/test_step29m_execution_result_fail_closed_preconditions_not_admissible_v0.py
@@ -77,7 +77,4 @@ def test_step29m_execution_result_fail_closed_classification_doc_states_no_eval_
     assert "does not execute economic evaluation" in text.lower()
     assert "AUTHORITY_EFFECT=NONE" in text
     assert "RUNTIME_EFFECT=NONE" in text
-    assert (
-        "FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_AND_REWIRE_SCOPE"
-        in text
-    )
+    assert "FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_AND_REWIRE_SCOPE" in text

--- a/tests/research/test_step29m_execution_result_fail_closed_preconditions_not_admissible_v0.py
+++ b/tests/research/test_step29m_execution_result_fail_closed_preconditions_not_admissible_v0.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+CLASSIFICATION_PATH = Path(
+    "docs/research/step29m_execution_result_fail_closed_preconditions_not_admissible_v0.json"
+)
+MD_PATH = Path(
+    "docs/research/STEP29M_EXECUTION_RESULT_FAIL_CLOSED_PRECONDITIONS_NOT_ADMISSIBLE_V0.md"
+)
+
+
+def test_step29m_execution_result_fail_closed_classification_is_bound_v0():
+    payload = json.loads(CLASSIFICATION_PATH.read_text(encoding="utf-8"))
+
+    assert (
+        payload["schema_version"]
+        == "step29m_execution_result_fail_closed_preconditions_not_admissible_v0"
+    )
+    assert payload["status"] == "binding_classification"
+    assert payload["authority_effect"] == "NONE"
+    assert payload["runtime_effect"] == "NONE"
+    assert (
+        payload["execution_pipeline_verdict"]
+        == "PASS_STEP29M_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0"
+    )
+    assert payload["execution_runner_rc"] == 0
+    assert (
+        payload["economic_evaluation_result_verdict"]
+        == "FAIL_CLOSED_STEP29M_EXECUTION_PRECONDITIONS_NOT_ADMISSIBLE"
+    )
+    assert payload["economic_evaluation_executed"] is False
+    assert payload["system_economic_evidence_admissible"] is False
+    assert payload["runtime_rewire_admissible"] is False
+    assert payload["live_authorized"] is False
+    assert payload["orders_allowed"] is False
+
+    classification = payload["classification"]
+    assert classification["pipeline_materialization_pass"] is True
+    assert classification["economic_execution_blocked_fail_closed"] is True
+    assert classification["negative_or_positive_profitability_claim_created"] is False
+    assert classification["promotion_candidate_created"] is False
+    assert classification["runtime_authority_created"] is False
+
+    failed = payload["failed_preconditions"]
+    assert failed["FULL_CANONICAL_CHAIN_WIRED"] is False
+    assert failed["BACKTEST_RUNTIME_DECISION_PARITY_PASS"] is False
+    assert failed["REALISTIC_COSTS_BOUND"] is False
+    assert failed["ROBUSTNESS_EVIDENCE_PASS"] is False
+
+    assert payload["reason_codes"] == [
+        "SYSTEM_ECONOMIC_EVIDENCE_NOT_ADMISSIBLE_FROM_PLAN_PRECONDITIONS"
+    ]
+    assert (
+        payload["next_step"]
+        == "FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_AND_REWIRE_SCOPE"
+    )
+
+    allowed = payload["allowed_next_scope"]
+    assert "CORE_SYSTEM_COMPLETION" in allowed
+    assert "OFFLINE_PARITY_ASSESSMENT" in allowed
+    assert "NARROW_REUSE_FIRST_REWIRE" in allowed
+
+    disallowed = payload["disallowed_next_scope"]
+    assert "LIVE_EVIDENCE" in disallowed
+    assert "ORDER_SUBMISSION" in disallowed
+    assert "CREDENTIAL_USE" in disallowed
+
+    source = payload["source_evidence"]
+    assert source["manifest_verify_required"] is True
+    assert source["manifest_verify_rc"] == 0
+
+
+def test_step29m_execution_result_fail_closed_classification_doc_states_no_eval_v0():
+    text = MD_PATH.read_text(encoding="utf-8")
+    assert "PASS_STEP29M_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0" in text
+    assert "FAIL_CLOSED_STEP29M_EXECUTION_PRECONDITIONS_NOT_ADMISSIBLE" in text
+    assert "does not execute economic evaluation" in text.lower()
+    assert "AUTHORITY_EFFECT=NONE" in text
+    assert "RUNTIME_EFFECT=NONE" in text
+    assert (
+        "FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_AND_REWIRE_SCOPE"
+        in text
+    )


### PR DESCRIPTION
## Summary

Materializes STEP29M execution-result classification after the offline economic evaluation runner completed but failed closed on inadmissible preconditions.

Verdict:

```text
PASS_STEP29M_EXECUTION_RESULT_FAIL_CLOSED_PRECONDITIONS_NOT_ADMISSIBLE_CLASSIFICATION_V0
```

## Materialized artifacts

- `docs/research/step29m_execution_result_fail_closed_preconditions_not_admissible_v0.json`
- `docs/research/STEP29M_EXECUTION_RESULT_FAIL_CLOSED_PRECONDITIONS_NOT_ADMISSIBLE_V0.md`
- `tests/research/test_step29m_execution_result_fail_closed_preconditions_not_admissible_v0.py`

## Scope

- Pipeline verdict: `PASS_STEP29M_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0`
- Economic result: `FAIL_CLOSED_STEP29M_EXECUTION_PRECONDITIONS_NOT_ADMISSIBLE`
- Classifies fail-closed precondition block without creating profitability, promotion, or runtime authority.
- Next step: `FULL_CANONICAL_SYSTEM_BACKTEST_PARITY_GAP_ASSESSMENT_AND_REWIRE_SCOPE`

## Authority / Runtime

- `AUTHORITY_EFFECT=NONE`
- `RUNTIME_EFFECT=NONE`
- `ECONOMIC_EVALUATION_EXECUTED=false`
- `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`
- `RUNTIME_REWIRE_ADMISSIBLE=false`
- `ORDERS_ALLOWED=false`
- `LIVE_AUTHORIZED=false`
- `PAPER_AUTHORIZED=false`
- `TESTNET_AUTHORIZED=false`
- `SHADOW_AUTHORIZED=false`

## Validation

- `python3 -m pytest tests/research/test_step29m_execution_result_fail_closed_preconditions_not_admissible_v0.py -q`
- `python3 -m ruff check tests/research/test_step29m_execution_result_fail_closed_preconditions_not_admissible_v0.py`
- Contract sanity check confirms no evaluation/runtime/order authority.

## Durable Evidence

- Classification evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/classify_step29m_execution_result_fail_closed_preconditions_not_admissible_v0_20260709T231850Z`
- Source execution evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/step29m_offline_economic_evaluation_execution_v0_20260709T230849Z`

Create-PR evidence is stored under the generated `pr_step29m_execution_result_fail_closed_classification_v0_create_*` directory.
