### PR TITLE
Fix ehlers v1 legacy end_of_data equity curve accounting defect

### DIFF
--- a/scripts/ops/run_ehlers_cycle_filter_v1_bound_offline_economic_baseline_evaluation_v0.py
+++ b/scripts/ops/run_ehlers_cycle_filter_v1_bound_offline_economic_baseline_evaluation_v0.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Bound offline economic baseline evaluation runner for ehlers_cycle_filter/v1 (STEP29M).
+
+Offline-only. Uses MV2 research wiring and canonical legacy accounting reconciliation.
+No runtime, credentials, orders, or authority effect.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+for path in (REPO_ROOT / "src", REPO_ROOT):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from scripts.ops import primary_evidence_retention_v0 as retention  # noqa: E402
+from src.backtest import admissible_versioned_futures_dataset_v1 as ds  # noqa: E402
+from src.backtest import mv2_research_wiring_v1 as mv2_wiring  # noqa: E402
+from src.backtest.admissible_versioned_futures_dataset_v1 import (  # noqa: E402
+    load_profile_binding_from_manifest,
+)
+from src.backtest.economic_validity_policy_v1 import (  # noqa: E402
+    EconomicValidityEvidenceMetricsV1,
+    default_economic_validity_policy_v1,
+    evaluate_economic_validity_against_policy_v1,
+)
+from src.backtest.step29m_ehlers_cycle_filter_v1_economic_evaluation_admissibility_contract_v1 import (  # noqa: E402
+    evaluate_ehlers_cycle_filter_v1_admissibility_contract_v1,
+    load_ehlers_cycle_filter_v1_evaluation_config_v1,
+)
+from src.research.step29m_ehlers_cycle_filter_v1_offline_economic_baseline_materialization_v0 import (  # noqa: E402
+    compute_step29m_ehlers_binding_digest_v0,
+    compute_step29m_ehlers_implementation_digest_v0,
+    materialize_legacy_backtest_accounting_reconciliation_v0,
+)
+
+ALLOWED_GO_TOKENS = frozenset(
+    {
+        "GO_EHLERS_CYCLE_FILTER_V1_BOUND_OFFLINE_ECONOMIC_BASELINE_EVALUATION_V0",
+        "GO_EHLERS_CYCLE_FILTER_V1_DEFECT_REPAIR_SAME_BINDING_REEVALUATION_V0",
+    }
+)
+STRATEGY_ID = "ehlers_cycle_filter"
+EVAL_CONFIG_PATH = (
+    "config/ops/step29m_okx_inst_eth_usdt_perp_ehlers_cycle_filter_v1_economic_evaluation_v1.json"
+)
+BINDING_CONFIG_PATH = "config/research/ehlers_cycle_filter_v1_versioned_research_binding_v0.json"
+MATERIAL_DIFFERENCE_PATH = (
+    "config/research/ehlers_cycle_filter_v1_material_difference_and_non_claim_contract_v0.json"
+)
+
+
+class EconomicClassification(str, Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    INCONCLUSIVE = "INCONCLUSIVE"
+
+
+def _utc_slug() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run_git(args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], cwd=REPO_ROOT, text=True).strip()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _classify_sample(trade_count: int, minimum: int) -> str:
+    return "INSUFFICIENT_TRADE_SAMPLE" if trade_count < minimum else "SUFFICIENT_TRADE_SAMPLE"
+
+
+def _classify_baseline(
+    *,
+    trade_count: int,
+    net_return: float,
+    accounting_pass: bool,
+    sample_status: str,
+) -> tuple[EconomicClassification, str]:
+    if not accounting_pass:
+        return EconomicClassification.INCONCLUSIVE, "BASELINE_INCONCLUSIVE_OR_INSUFFICIENT_SAMPLE"
+    if sample_status != "SUFFICIENT_TRADE_SAMPLE":
+        return EconomicClassification.INCONCLUSIVE, "BASELINE_INCONCLUSIVE_OR_INSUFFICIENT_SAMPLE"
+    if trade_count == 0:
+        return EconomicClassification.INCONCLUSIVE, "BASELINE_INCONCLUSIVE_OR_INSUFFICIENT_SAMPLE"
+    if net_return < 0.0:
+        return EconomicClassification.FAIL, "BASELINE_TERMINAL_NEGATIVE"
+    if net_return > 0.0:
+        return EconomicClassification.INCONCLUSIVE, "BASELINE_INCONCLUSIVE_POSITIVE_UNROBUST"
+    return EconomicClassification.INCONCLUSIVE, "BASELINE_INCONCLUSIVE_OR_INSUFFICIENT_SAMPLE"
+
+
+def run_baseline_evaluation(
+    *,
+    confirm_go_token: str,
+    repo_root: Path,
+    durable_evidence_root: Path,
+    source_closeout_bundle: Path | None = None,
+    prior_implementation_digest: str | None = None,
+) -> dict[str, Any]:
+    if confirm_go_token not in ALLOWED_GO_TOKENS:
+        raise SystemExit(f"ERR: invalid_go_token:{confirm_go_token}")
+
+    head = _run_git(["rev-parse", "HEAD"])
+    origin_main = _run_git(["rev-parse", "origin/main"])
+    worktree_clean = (
+        subprocess.check_output(["git", "status", "--porcelain"], cwd=repo_root, text=True).strip()
+        == ""
+    )
+
+    admissibility = evaluate_ehlers_cycle_filter_v1_admissibility_contract_v1(repo_root=repo_root)
+    if admissibility.admissibility_result.value != "PASS":
+        raise SystemExit(f"ERR: admissibility_blocked:{admissibility.blocking_reasons}")
+
+    cfg = load_ehlers_cycle_filter_v1_evaluation_config_v1(repo_root, EVAL_CONFIG_PATH)
+    binding_cfg = _load_json(repo_root / BINDING_CONFIG_PATH)
+    material_diff = _load_json(repo_root / MATERIAL_DIFFERENCE_PATH)
+    binding_section = binding_cfg["binding"]
+    digest_bindings = binding_section["digest_bindings"]
+
+    eval_binding = cfg["real_admissible_futures_evaluation_binding_v1"]
+    dataset_path = Path(str(eval_binding["dataset_path"]))
+    manifest_path = dataset_path.parent / "dataset_manifest.json"
+    manifest = _load_json(manifest_path)
+    descriptor, provenance = ds.load_dataset_admissibility_from_flat_economic_research_manifest_v1(
+        manifest,
+        manifest_path=str(manifest_path),
+    )
+    if descriptor.dataset_digest != digest_bindings["data_digest"]["value"]:
+        raise SystemExit("ERR: data_digest_mismatch")
+
+    bars = pd.read_parquet(dataset_path)
+    if not isinstance(bars.index, pd.DatetimeIndex):
+        if "timestamp" in bars.columns:
+            bars = bars.copy()
+            bars.index = pd.to_datetime(bars["timestamp"], utc=True)
+        elif "time" in bars.columns:
+            bars = bars.copy()
+            bars.index = pd.to_datetime(bars["time"], utc=True)
+        else:
+            bars = bars.set_index("timestamp")
+    if not isinstance(bars.index, pd.DatetimeIndex):
+        raise SystemExit("ERR: bars_index_not_datetime")
+    if bars.index.tz is None:
+        bars.index = bars.index.tz_localize("UTC")
+    bars = bars.sort_index()
+
+    profile_binding = load_profile_binding_from_manifest(manifest)
+    wiring = mv2_wiring.run_mv2_research_backtest_wiring_v1(
+        bars,
+        strategy_id=STRATEGY_ID,
+        cfg=cfg,
+        instrument_id=str(eval_binding["canonical_instrument_id"]),
+        profile_binding=profile_binding,
+    )
+    backtest = wiring.backtest_result
+    initial_cash = float(cfg["backtest"]["initial_cash"])
+    stats = backtest.stats
+    trade_count = int(stats.get("total_trades", 0))
+    net_return = float(stats.get("total_return", 0.0))
+
+    accounting = materialize_legacy_backtest_accounting_reconciliation_v0(
+        backtest,
+        initial_cash=initial_cash,
+    )
+    accounting_pass = bool(accounting.get("accounting_reconciliation_pass"))
+
+    policy = default_economic_validity_policy_v1()
+    gate = evaluate_economic_validity_against_policy_v1(
+        policy=policy,
+        metrics=EconomicValidityEvidenceMetricsV1(
+            net_expectancy=float(stats.get("expectancy", 0.0)),
+            profit_factor=float(stats.get("profit_factor", 0.0)),
+            trade_count=trade_count,
+            max_drawdown=float(stats.get("max_drawdown", 0.0)),
+        ),
+        expected_policy_digest=policy.policy_digest(),
+    )
+
+    minimum_trade_count = int(policy.minimum_trade_count.value or 50)
+    sample_status = _classify_sample(trade_count, minimum_trade_count)
+    baseline_class, failure_class = _classify_baseline(
+        trade_count=trade_count,
+        net_return=net_return,
+        accounting_pass=accounting_pass,
+        sample_status=sample_status,
+    )
+
+    implementation_digest = compute_step29m_ehlers_implementation_digest_v0(repo_root)
+    if prior_implementation_digest and prior_implementation_digest == implementation_digest:
+        raise SystemExit("ERR: defect_repair_requires_implementation_digest_change")
+
+    config_digest = admissibility.config_digest
+    strategy_params_digest = admissibility.strategy_params_digest
+    data_period = f"{descriptor.start_time}..{descriptor.end_time}"
+    binding_digest = compute_step29m_ehlers_binding_digest_v0(
+        config_digest=config_digest,
+        data_digest=descriptor.dataset_digest,
+        implementation_digest=implementation_digest,
+        strategy_params_digest=strategy_params_digest,
+        material_difference_digest=str(material_diff["material_difference_digest"]),
+        hypothesis_id=str(binding_cfg["hypothesis_id"]),
+        instrument_id=str(eval_binding["canonical_instrument_id"]),
+        data_period=data_period,
+    )
+
+    ts = _utc_slug()
+    evidence_dir = (
+        durable_evidence_root
+        / "research"
+        / f"ehlers_cycle_filter_v1_bound_offline_economic_baseline_evaluation_v0_{ts}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=False)
+
+    trades_path = evidence_dir / "trade_ledger.jsonl"
+    if backtest.trades is not None and not backtest.trades.empty:
+        with trades_path.open("w", encoding="utf-8") as handle:
+            for row in backtest.trades.to_dict(orient="records"):
+                handle.write(json.dumps(row, default=str) + "\n")
+
+    (evidence_dir / "accounting_reconciliation.json").write_text(
+        json.dumps(accounting, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "sample_sufficiency.json").write_text(
+        json.dumps(
+            {
+                "minimum_trade_count_policy": minimum_trade_count,
+                "policy_version": "economic_validity_policy_v1",
+                "status": sample_status,
+                "trade_count": trade_count,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "immutable_binding_snapshot.json").write_text(
+        json.dumps(
+            {
+                "bar_interval": "1m",
+                "binding_digest": binding_digest,
+                "binding_immutable": True,
+                "config_digest": config_digest,
+                "data_digest": descriptor.dataset_digest,
+                "data_period": data_period,
+                "hypothesis_id": binding_cfg["hypothesis_id"],
+                "implementation_digest": implementation_digest,
+                "instrument_id": eval_binding["canonical_instrument_id"],
+                "material_difference_digest": material_diff["material_difference_digest"],
+                "research_scope": "ehlers_cycle_filter/v1",
+                "strategy_params_digest": strategy_params_digest,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "performance_metrics.json").write_text(
+        json.dumps(
+            {
+                "net_return": net_return,
+                "net_expectancy": float(stats.get("expectancy", 0.0)),
+                "profit_factor": float(stats.get("profit_factor", 0.0)),
+                "sharpe": float(stats.get("sharpe", 0.0)),
+                "max_drawdown": float(stats.get("max_drawdown", 0.0)),
+                "trade_count": trade_count,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "evaluation_context.json").write_text(
+        json.dumps(
+            {
+                "accounting_owner": (
+                    "src/research/cross_sectional_single_slot_accounting_reconciliation_v0.py"
+                ),
+                "baseline_runner": str(Path(__file__).relative_to(repo_root)),
+                "go_token": confirm_go_token,
+                "head": head,
+                "head_equals_origin_main": head == origin_main,
+                "materialization_owner": (
+                    "src/research/step29m_ehlers_cycle_filter_v1_offline_economic_baseline_materialization_v0.py"
+                ),
+                "origin_main": origin_main,
+                "reevaluation_class": (
+                    "DEFECT_REPAIR_REEVALUATION"
+                    if confirm_go_token.endswith("REEVALUATION_V0")
+                    else "INITIAL_BASELINE"
+                ),
+                "source_closeout_bundle": str(source_closeout_bundle or ""),
+                "worktree_clean": worktree_clean,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    final_report = "\n".join(
+        [
+            f"VERDICT={baseline_class.value}_EHLERS_CYCLE_FILTER_V1_BOUND_OFFLINE_ECONOMIC_BASELINE_EVALUATION_V0",
+            f"REPO={repo_root}",
+            f"HEAD={head}",
+            f"ORIGIN_MAIN={origin_main}",
+            f"BINDING_DIGEST={binding_digest}",
+            f"IMPLEMENTATION_DIGEST={implementation_digest}",
+            f"CONFIG_DIGEST={config_digest}",
+            f"DATA_DIGEST={descriptor.dataset_digest}",
+            f"STRATEGY_PARAMS_DIGEST={strategy_params_digest}",
+            f"TRADE_COUNT={trade_count}",
+            f"SAMPLE_SUFFICIENCY_STATUS={sample_status}",
+            f"ACCOUNTING_RECONCILIATION_PASS={accounting_pass}",
+            f"BASELINE_STATUS={baseline_class.value}",
+            f"FAILURE_CLASS={failure_class}",
+            f"ECONOMIC_VALIDITY_OFFLINE_GATE_PASS={gate.gates_pass}",
+            f"DURABLE_EVIDENCE_DIR={evidence_dir}",
+            "WALK_FORWARD_EXECUTED=false",
+            "MONTE_CARLO_EXECUTED=false",
+            "STRESS_EXECUTED=false",
+            "RUNTIME_EFFECT=NONE",
+            "AUTHORITY_EFFECT=NONE",
+            "REPO_MUTATION=false",
+        ]
+    )
+    (evidence_dir / "final_report.txt").write_text(final_report + "\n", encoding="utf-8")
+
+    manifest_rc, _ = retention.finalize_durable_bundle_manifest(evidence_dir)
+    return {
+        "verdict": baseline_class.value,
+        "accounting_reconciliation_pass": accounting_pass,
+        "sample_sufficiency_status": sample_status,
+        "implementation_digest": implementation_digest,
+        "config_digest": config_digest,
+        "data_digest": descriptor.dataset_digest,
+        "strategy_params_digest": strategy_params_digest,
+        "binding_digest": binding_digest,
+        "manifest_verify_rc": manifest_rc,
+        "evidence_dir": str(evidence_dir),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm-go-token", required=True)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument(
+        "--durable-evidence-root",
+        type=Path,
+        default=Path(
+            "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+        ),
+    )
+    parser.add_argument("--source-closeout-bundle", type=Path, default=None)
+    parser.add_argument("--prior-implementation-digest", default=None)
+    args = parser.parse_args()
+    result = run_baseline_evaluation(
+        confirm_go_token=args.confirm_go_token,
+        repo_root=args.repo_root,
+        durable_evidence_root=args.durable_evidence_root,
+        source_closeout_bundle=args.source_closeout_bundle,
+        prior_implementation_digest=args.prior_implementation_digest,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -759,6 +759,10 @@ class BacktestEngine:
             # Daily Returns registrieren
             self._register_trade_pnl(last_bar.name, current_trade.pnl_pct)
 
+            # Materialize realized post-close equity on the final bar point.
+            if self.equity_curve:
+                self.equity_curve[-1] = equity
+
         # Stats berechnen
         equity_series = pd.Series(self.equity_curve, index=[df.index[0]] + list(df.index))
 
@@ -1185,6 +1189,9 @@ class BacktestEngine:
                     }
                 )
                 equity += pnl
+
+            if self.equity_curve:
+                self.equity_curve[-1] = equity
 
         # Stats berechnen
         equity_series = pd.Series(self.equity_curve, index=[df.index[0]] + list(df.index))

--- a/src/research/cross_sectional_single_slot_accounting_reconciliation_v0.py
+++ b/src/research/cross_sectional_single_slot_accounting_reconciliation_v0.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
+import pandas as pd
+
 from src.research.cross_sectional_single_slot_backtest_wiring_v0 import (
     END_OF_WINDOW_POLICY,
 )
@@ -34,6 +36,16 @@ class OpenPositionStateV0:
     entry_time: str | None
     entry_price: float | None
     entry_cost: float | None
+
+
+@dataclass(frozen=True)
+class LegacyBacktestAccountingViewV0:
+    """Adapter view for legacy BacktestEngine results (single-slot, closed-trade ledger)."""
+
+    initial_cash: float
+    final_equity: float
+    trades: pd.DataFrame
+    slippage_impact: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -76,6 +88,52 @@ def detect_open_position_at_window_end(
         entry_time=None,
         entry_price=None,
         entry_cost=None,
+    )
+
+
+def legacy_backtest_result_accounting_view_v0(
+    backtest_result: Any,
+    *,
+    initial_cash: float,
+    slippage_impact: float = 0.0,
+) -> LegacyBacktestAccountingViewV0:
+    """Project BacktestResult equity curve and trade ledger for canonical reconciliation."""
+    equity_curve = getattr(backtest_result, "equity_curve", None)
+    if equity_curve is None or len(equity_curve) == 0:
+        raise ValueError("backtest_result_missing_equity_curve")
+    trades = getattr(backtest_result, "trades", None)
+    if trades is None:
+        trades_df = pd.DataFrame()
+    elif isinstance(trades, pd.DataFrame):
+        trades_df = trades
+    else:
+        trades_df = pd.DataFrame(trades)
+    return LegacyBacktestAccountingViewV0(
+        initial_cash=float(initial_cash),
+        final_equity=float(equity_curve.iloc[-1]),
+        trades=trades_df,
+        slippage_impact=float(slippage_impact),
+    )
+
+
+def reconcile_legacy_backtest_result_accounting_v0(
+    backtest_result: Any,
+    *,
+    initial_cash: float,
+    funding_drag: float = 0.0,
+    spread_drag: float = 0.0,
+    slippage_impact: float = 0.0,
+) -> AccountingReconciliationResultV0:
+    """Reconcile legacy BacktestEngine output via the canonical single-slot owner."""
+    view = legacy_backtest_result_accounting_view_v0(
+        backtest_result,
+        initial_cash=initial_cash,
+        slippage_impact=slippage_impact,
+    )
+    return reconcile_single_slot_backtest_accounting_v0(
+        view,
+        funding_drag=funding_drag,
+        spread_drag=spread_drag,
     )
 
 

--- a/src/research/step29m_ehlers_cycle_filter_v1_offline_economic_baseline_materialization_v0.py
+++ b/src/research/step29m_ehlers_cycle_filter_v1_offline_economic_baseline_materialization_v0.py
@@ -1,0 +1,114 @@
+"""STEP29M ehlers_cycle_filter/v1 offline economic baseline materialization v0.
+
+Research-only helpers for canonical accounting reconciliation and implementation
+digest binding. No runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.research.cross_sectional_single_slot_accounting_reconciliation_v0 import (
+    accounting_reconciliation_to_dict,
+    reconcile_legacy_backtest_result_accounting_v0,
+)
+
+MATERIALIZATION_OWNER = (
+    "research.step29m_ehlers_cycle_filter_v1_offline_economic_baseline_materialization_v0"
+)
+MATERIALIZATION_VERSION = "v0"
+SCHEMA_VERSION = "step29m_ehlers_cycle_filter_v1_offline_economic_baseline_materialization.v0"
+
+IMPLEMENTATION_SURFACE_PATHS: tuple[str, ...] = (
+    "src/backtest/engine.py",
+    "src/backtest/mv2_research_wiring_v1.py",
+    "src/research/cross_sectional_single_slot_accounting_reconciliation_v0.py",
+    "src/research/step29m_ehlers_cycle_filter_v1_offline_economic_baseline_materialization_v0.py",
+)
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def compute_step29m_ehlers_implementation_digest_v0(
+    repo_root: Path,
+) -> str:
+    """Digest over bound offline evaluation implementation surfaces."""
+    surfaces = {
+        rel: _sha256_file(repo_root / rel)
+        for rel in IMPLEMENTATION_SURFACE_PATHS
+        if (repo_root / rel).is_file()
+    }
+    return _stable_digest(
+        {
+            "owner": MATERIALIZATION_OWNER,
+            "version": MATERIALIZATION_VERSION,
+            "research_scope": "ehlers_cycle_filter/v1",
+            "surfaces": surfaces,
+        }
+    )
+
+
+def compute_step29m_ehlers_binding_digest_v0(
+    *,
+    config_digest: str,
+    data_digest: str,
+    implementation_digest: str,
+    strategy_params_digest: str,
+    material_difference_digest: str,
+    hypothesis_id: str,
+    instrument_id: str,
+    data_period: str,
+) -> str:
+    return _stable_digest(
+        {
+            "research_scope": "ehlers_cycle_filter/v1",
+            "hypothesis_id": hypothesis_id,
+            "instrument_id": instrument_id,
+            "data_period": data_period,
+            "config_digest": config_digest,
+            "data_digest": data_digest,
+            "implementation_digest": implementation_digest,
+            "strategy_params_digest": strategy_params_digest,
+            "material_difference_digest": material_difference_digest,
+        }
+    )
+
+
+def materialize_legacy_backtest_accounting_reconciliation_v0(
+    backtest_result: Any,
+    *,
+    initial_cash: float,
+    funding_drag: float = 0.0,
+    spread_drag: float = 0.0,
+    slippage_impact: float = 0.0,
+) -> dict[str, Any]:
+    """Materialize accounting_reconciliation.json via the canonical reconciliation owner."""
+    result = reconcile_legacy_backtest_result_accounting_v0(
+        backtest_result,
+        initial_cash=initial_cash,
+        funding_drag=funding_drag,
+        spread_drag=spread_drag,
+        slippage_impact=slippage_impact,
+    )
+    payload = accounting_reconciliation_to_dict(result)
+    payload["accounting_reconciliation_pass"] = result.reconciled
+    payload["failure_class"] = (
+        None
+        if result.reconciled
+        else (result.failure_class or "ACCOUNTING_RECONCILIATION_MISMATCH")
+    )
+    return payload

--- a/tests/backtest/test_engine_legacy_end_of_data_equity_curve_v0.py
+++ b/tests/backtest/test_engine_legacy_end_of_data_equity_curve_v0.py
@@ -1,0 +1,191 @@
+"""Regression tests for legacy BacktestEngine end_of_data equity_curve materialization."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.backtest.engine import BacktestEngine
+from src.research.cross_sectional_single_slot_accounting_reconciliation_v0 import (
+    reconcile_legacy_backtest_result_accounting_v0,
+)
+
+
+def _bars(closes: list[float]) -> pd.DataFrame:
+    index = pd.date_range("2024-01-01", periods=len(closes), freq="1h", tz="UTC")
+    return pd.DataFrame(
+        {
+            "open": closes,
+            "high": [c + 1.0 for c in closes],
+            "low": [c - 1.0 for c in closes],
+            "close": closes,
+            "volume": [1000.0] * len(closes),
+        },
+        index=index,
+    )
+
+
+def _long_entry_hold_to_end_strategy() -> callable:
+    def strategy_fn(df: pd.DataFrame, params: dict) -> pd.Series:
+        signals = pd.Series(0, index=df.index, dtype=int)
+        signals.iloc[1] = 1
+        return signals
+
+    return strategy_fn
+
+
+def _flat_strategy() -> callable:
+    def strategy_fn(df: pd.DataFrame, params: dict) -> pd.Series:
+        return pd.Series(0, index=df.index, dtype=int)
+
+    return strategy_fn
+
+
+def _engine_config(initial_cash: float = 10_000.0) -> dict:
+    return {
+        "backtest": {
+            "initial_cash": initial_cash,
+            "fee_bps": 0.0,
+            "slippage_bps": 0.0,
+        },
+        "risk": {
+            "risk_per_trade": 0.01,
+            "max_position_size": 0.25,
+            "min_position_value": 50.0,
+            "min_stop_distance": 0.001,
+        },
+    }
+
+
+def _run_legacy(engine: BacktestEngine, **kwargs):
+    return engine.run_realistic(
+        fee_bps=0.0,
+        slippage_bps=0.0,
+        explicit_zero_cost_non_economic=True,
+        **kwargs,
+    )
+
+
+class TestLegacyEndOfDataEquityCurve:
+    def test_open_position_at_period_end_updates_final_equity_curve_point(self) -> None:
+        df = _bars([100.0, 101.0, 105.0])
+        engine = BacktestEngine(use_execution_pipeline=False)
+        engine.config = _engine_config()
+        result = _run_legacy(
+            engine,
+            df=df,
+            strategy_signal_fn=_long_entry_hold_to_end_strategy(),
+            strategy_params={"stop_pct": 0.5},
+        )
+        assert result.trades is not None
+        assert len(result.trades) == 1
+        assert result.trades.iloc[0]["exit_reason"] == "end_of_data"
+
+        initial_cash = float(engine.config["backtest"]["initial_cash"])
+        trade_pnl_sum = float(result.trades["pnl"].sum())
+        final_equity = float(result.equity_curve.iloc[-1])
+        assert final_equity == pytest.approx(initial_cash + trade_pnl_sum)
+        assert final_equity != pytest.approx(initial_cash)
+
+    def test_no_open_position_at_period_end_unchanged(self) -> None:
+        df = _bars([100.0, 101.0, 102.0])
+        engine = BacktestEngine(use_execution_pipeline=False)
+        engine.config = _engine_config()
+        result = _run_legacy(
+            engine,
+            df=df,
+            strategy_signal_fn=_flat_strategy(),
+            strategy_params={"stop_pct": 0.02},
+        )
+        assert result.trades is None or len(result.trades) == 0
+        initial_cash = float(engine.config["backtest"]["initial_cash"])
+        assert float(result.equity_curve.iloc[-1]) == pytest.approx(initial_cash)
+
+    def test_ledger_equity_reconciliation_passes_after_end_of_data_close(self) -> None:
+        df = _bars([100.0, 101.0, 105.0])
+        engine = BacktestEngine(use_execution_pipeline=False)
+        engine.config = _engine_config()
+        result = _run_legacy(
+            engine,
+            df=df,
+            strategy_signal_fn=_long_entry_hold_to_end_strategy(),
+            strategy_params={"stop_pct": 0.5},
+        )
+        reconciliation = reconcile_legacy_backtest_result_accounting_v0(
+            result,
+            initial_cash=float(engine.config["backtest"]["initial_cash"]),
+        )
+        assert reconciliation.reconciled is True
+        assert abs(reconciliation.accounting_delta) <= reconciliation.tolerance_abs
+
+    def test_no_double_equity_booking_on_forced_close(self) -> None:
+        df = _bars([100.0, 101.0, 105.0])
+        engine = BacktestEngine(use_execution_pipeline=False)
+        engine.config = _engine_config()
+        result = _run_legacy(
+            engine,
+            df=df,
+            strategy_signal_fn=_long_entry_hold_to_end_strategy(),
+            strategy_params={"stop_pct": 0.5},
+        )
+        trade_pnl = float(result.trades.iloc[0]["pnl"])
+        penultimate_equity = float(result.equity_curve.iloc[-2])
+        final_equity = float(result.equity_curve.iloc[-1])
+        assert final_equity == pytest.approx(penultimate_equity + trade_pnl)
+
+
+class TestExecutionPipelineEndOfDataEquityCurve:
+    def test_long_open_position_at_period_end_materializes_realized_equity(self) -> None:
+        df = _bars([100.0, 101.0, 105.0])
+
+        def long_entry_hold_strategy(_df: pd.DataFrame, _params: dict) -> pd.Series:
+            return pd.Series(1, index=_df.index, dtype=int)
+
+        engine = BacktestEngine(use_execution_pipeline=True)
+        engine.config = _engine_config()
+        result = engine.run_realistic(
+            df=df,
+            strategy_signal_fn=long_entry_hold_strategy,
+            strategy_params={},
+            symbol="ETH/USDT",
+            fee_bps=0.0,
+            slippage_bps=0.0,
+            explicit_zero_cost_non_economic=True,
+        )
+        assert result.trades is not None
+        end_of_data = result.trades[result.trades["exit_reason"] == "end_of_data"]
+        assert len(end_of_data) == 1
+        assert end_of_data.iloc[0]["side"] == "long"
+
+        initial_cash = float(engine.config["backtest"]["initial_cash"])
+        trade_pnl_sum = float(result.trades["pnl"].sum())
+        final_equity = float(result.equity_curve.iloc[-1])
+        assert final_equity == pytest.approx(initial_cash + trade_pnl_sum)
+
+    def test_short_open_position_at_period_end_materializes_realized_equity(self) -> None:
+        df = _bars([100.0, 99.0, 98.0])
+
+        def short_entry_hold_strategy(_df: pd.DataFrame, _params: dict) -> pd.Series:
+            signals = pd.Series(-1, index=_df.index, dtype=int)
+            return signals
+
+        engine = BacktestEngine(use_execution_pipeline=True)
+        engine.config = _engine_config()
+        result = engine.run_realistic(
+            df=df,
+            strategy_signal_fn=short_entry_hold_strategy,
+            strategy_params={},
+            symbol="ETH/USDT",
+            fee_bps=0.0,
+            slippage_bps=0.0,
+            explicit_zero_cost_non_economic=True,
+        )
+        assert result.trades is not None
+        end_of_data = result.trades[result.trades["exit_reason"] == "end_of_data"]
+        assert len(end_of_data) == 1
+        assert end_of_data.iloc[0]["side"] == "short"
+
+        initial_cash = float(engine.config["backtest"]["initial_cash"])
+        trade_pnl_sum = float(result.trades["pnl"].sum())
+        final_equity = float(result.equity_curve.iloc[-1])
+        assert final_equity == pytest.approx(initial_cash + trade_pnl_sum)

--- a/tests/ops/test_step29m_ehlers_cycle_filter_v1_offline_economic_baseline_materialization_v0_contract.py
+++ b/tests/ops/test_step29m_ehlers_cycle_filter_v1_offline_economic_baseline_materialization_v0_contract.py
@@ -1,0 +1,94 @@
+"""Contract tests for ehlers_cycle_filter/v1 offline baseline materialization v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.backtest.engine import BacktestEngine
+from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 import (
+    compute_evaluation_config_digest_v1,
+)
+from src.research.step29m_ehlers_cycle_filter_v1_offline_economic_baseline_materialization_v0 import (
+    IMPLEMENTATION_SURFACE_PATHS,
+    compute_step29m_ehlers_implementation_digest_v0,
+    materialize_legacy_backtest_accounting_reconciliation_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVAL_CONFIG = (
+    REPO_ROOT
+    / "config/ops/step29m_okx_inst_eth_usdt_perp_ehlers_cycle_filter_v1_economic_evaluation_v1.json"
+)
+PRIOR_IMPLEMENTATION_DIGEST = "a153ea4fc624ed3e00fbcd38006c361b05ddeab473344c5181efa79372962702"
+
+
+def test_implementation_digest_changes_after_defect_repair_surfaces() -> None:
+    digest = compute_step29m_ehlers_implementation_digest_v0(REPO_ROOT)
+    assert digest != PRIOR_IMPLEMENTATION_DIGEST
+    assert len(digest) == 64
+
+
+def test_config_and_strategy_params_digests_unchanged_on_main_config() -> None:
+    cfg = json.loads(EVAL_CONFIG.read_text(encoding="utf-8"))
+    assert (
+        compute_evaluation_config_digest_v1(cfg)
+        == "c4db0a42b95156192d8c1fcf486aa3d616ae2f0b5dafa26b9e0d7d9a29c204a6"
+    )
+    assert cfg["offline_evaluation_sizing_contract_v1"]["strategy_params_digest"] == (
+        "49f8b07e7de872e66f74dd27b5e97a3ae3aaee414e25d3b08cba2674c40cc5b9"
+    )
+
+
+def test_materializer_uses_canonical_accounting_owner_fields() -> None:
+    index = pd.date_range("2024-01-01", periods=3, freq="1h", tz="UTC")
+    closes = [100.0, 101.0, 105.0]
+    df = pd.DataFrame(
+        {
+            "open": closes,
+            "high": [c + 1.0 for c in closes],
+            "low": [c - 1.0 for c in closes],
+            "close": closes,
+            "volume": [1000.0] * len(closes),
+        },
+        index=index,
+    )
+
+    def strategy_fn(_df: pd.DataFrame, _params: dict) -> pd.Series:
+        signals = pd.Series(0, index=_df.index, dtype=int)
+        signals.iloc[1] = 1
+        return signals
+
+    engine = BacktestEngine(use_execution_pipeline=False)
+    engine.config = {
+        "backtest": {"initial_cash": 10_000.0, "fee_bps": 0.0, "slippage_bps": 0.0},
+        "risk": {
+            "risk_per_trade": 0.01,
+            "max_position_size": 0.25,
+            "min_position_value": 50.0,
+            "min_stop_distance": 0.001,
+        },
+    }
+    result = engine.run_realistic(
+        df=df,
+        strategy_signal_fn=strategy_fn,
+        strategy_params={"stop_pct": 0.5},
+        fee_bps=0.0,
+        slippage_bps=0.0,
+        explicit_zero_cost_non_economic=True,
+    )
+    payload = materialize_legacy_backtest_accounting_reconciliation_v0(
+        result,
+        initial_cash=10_000.0,
+    )
+    assert payload["schema_version"] == "cross_sectional_single_slot_accounting_reconciliation.v0"
+    assert payload["accounting_reconciliation_pass"] is True
+    assert payload["failure_class"] is None
+
+
+def test_implementation_surface_paths_exist() -> None:
+    for rel in IMPLEMENTATION_SURFACE_PATHS:
+        assert (REPO_ROOT / rel).is_file()

--- a/tests/research/test_cross_sectional_single_slot_accounting_reconciliation_v0.py
+++ b/tests/research/test_cross_sectional_single_slot_accounting_reconciliation_v0.py
@@ -16,6 +16,7 @@ from src.research.cross_sectional_relative_strength_v0_versioned_research_bindin
 )
 from src.research.cross_sectional_single_slot_accounting_reconciliation_v0 import (
     FAILURE_FORCED_END_OF_WINDOW_LIQUIDATION_MISSING,
+    reconcile_legacy_backtest_result_accounting_v0,
     reconcile_single_slot_backtest_accounting_v0,
 )
 from src.research.cross_sectional_single_slot_backtest_wiring_v0 import (


### PR DESCRIPTION
## Summary
- Repariert den Legacy-`BacktestEngine`-Pfad (`run_realistic`): nach `end_of_data`-Close wird der finale `equity_curve`-Punkt mit dem realisierten Equity-Stand materialisiert (keine Doppelbuchung, Long/Short-Symmetrie im Execution-Pipeline-Pfad).
- Erweitert den kanonischen Owner `cross_sectional_single_slot_accounting_reconciliation_v0` um einen `BacktestResult`-Adapter; die ehlers-Baseline-Materialisierung nutzt diesen Owner statt einer naiven Stale-Equity-Reconciliation.
- Fügt kanonischen Baseline-Runner `scripts/ops/run_ehlers_cycle_filter_v1_bound_offline_economic_baseline_evaluation_v0.py` plus Regressionstests hinzu.

## Defect context
- Classification: `COMBINED_ACCOUNTING_DEFECT_AND_SAMPLE_INSUFFICIENCY`
- Primary defect: `LEGACY_END_OF_DATA_CLOSE_MISSING_FINAL_EQUITY_CURVE_POINT`
- Secondary defect: `BASELINE_MATERIALIZER_USES_NAIVE_STALE_EQUITY_RECONCILIATION`

## Digest invariants (local reevaluation pre-merge)
| Digest | Status |
|---|---|
| `config_digest` | unchanged (`c4db0a42…`) |
| `data_digest` | unchanged (`b4cbe7ff…`) |
| `strategy_params_digest` | unchanged (`49f8b07e…`) |
| `implementation_digest` | changed (`a153ea4…` → `409e42f4…`) |

Local same-binding reevaluation: `ACCOUNTING_RECONCILIATION_PASS=true`, sample still `INSUFFICIENT_TRADE_SAMPLE` (6 ≪ 50), baseline `INCONCLUSIVE`.

## Implementation evidence
`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr_ehlers_cycle_filter_v1_legacy_end_of_data_equity_curve_defect_repair_implementation_v0_20260710T111437Z` (MANIFEST_VERIFY_RC=0)

## Test plan
- [x] `tests/backtest/test_engine_legacy_end_of_data_equity_curve_v0.py`
- [x] `tests/ops/test_step29m_ehlers_cycle_filter_v1_offline_economic_baseline_materialization_v0_contract.py`
- [x] `tests/research/test_cross_sectional_single_slot_accounting_reconciliation_v0.py`
- [x] Local reevaluation via `GO_EHLERS_CYCLE_FILTER_V1_DEFECT_REPAIR_SAME_BINDING_REEVALUATION_V0`

## Prohibited (confirmed unchanged)
No parameter, threshold, policy, signal, sizing, dataset, instrument, period, or runtime changes.


Made with [Cursor](https://cursor.com)