### PR TITLE
Defer prometheus_client init for offline evaluation import chain

### DIFF
--- a/src/core/metrics.py
+++ b/src/core/metrics.py
@@ -23,42 +23,86 @@ Usage:
         fetch_data()
 """
 
+from __future__ import annotations
+
+import importlib.util
 import logging
 import time
-from typing import Dict, Optional, Any
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from threading import Lock
 from datetime import datetime
+from threading import Lock
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-# Try to import prometheus_client, but make it optional
-try:
-    from prometheus_client import (
-        Counter,
-        Gauge,
-        Histogram,
-        CollectorRegistry,
-        generate_latest,
-        CONTENT_TYPE_LATEST,
-    )
-
-    PROMETHEUS_AVAILABLE = True
-except ImportError:
-    PROMETHEUS_AVAILABLE = False
-    logger.warning(
-        "prometheus_client not installed. Metrics will be collected in-memory only. "
-        "Install with: pip install prometheus-client"
-    )
+_PROMETHEUS_INIT_LOCK = Lock()
+_PROMETHEUS_IMPORT_CACHE: Optional[Dict[str, Any]] = None
+_PROMETHEUS_IMPORT_FAILED = object()
 
 
 def get_utc_now() -> datetime:
     """Get current UTC time."""
     if hasattr(datetime, "UTC"):
         return datetime.now(datetime.UTC)
-    else:
-        return datetime.utcnow()
+    return datetime.utcnow()
+
+
+def _prometheus_spec_available() -> bool:
+    """Check install surface without importing prometheus_client."""
+    return importlib.util.find_spec("prometheus_client") is not None
+
+
+def _load_prometheus_client_module() -> Optional[Dict[str, Any]]:
+    """Import prometheus_client at most once per process; ImportError activates fallback."""
+    global _PROMETHEUS_IMPORT_CACHE
+
+    if _PROMETHEUS_IMPORT_CACHE is _PROMETHEUS_IMPORT_FAILED:
+        return None
+    if _PROMETHEUS_IMPORT_CACHE is not None:
+        return _PROMETHEUS_IMPORT_CACHE
+
+    with _PROMETHEUS_INIT_LOCK:
+        if _PROMETHEUS_IMPORT_CACHE is _PROMETHEUS_IMPORT_FAILED:
+            return None
+        if _PROMETHEUS_IMPORT_CACHE is not None:
+            return _PROMETHEUS_IMPORT_CACHE
+
+        try:
+            from prometheus_client import (
+                CONTENT_TYPE_LATEST,
+                CollectorRegistry,
+                Counter,
+                Gauge,
+                Histogram,
+                generate_latest,
+            )
+        except ImportError:
+            _PROMETHEUS_IMPORT_CACHE = _PROMETHEUS_IMPORT_FAILED
+            return None
+
+        _PROMETHEUS_IMPORT_CACHE = {
+            "Counter": Counter,
+            "Gauge": Gauge,
+            "Histogram": Histogram,
+            "CollectorRegistry": CollectorRegistry,
+            "generate_latest": generate_latest,
+            "CONTENT_TYPE_LATEST": CONTENT_TYPE_LATEST,
+        }
+        return _PROMETHEUS_IMPORT_CACHE
+
+
+def is_prometheus_available() -> bool:
+    """Return True when prometheus_client is installed and importable."""
+    if not _prometheus_spec_available():
+        return False
+    return _load_prometheus_client_module() is not None
+
+
+def __getattr__(name: str) -> Any:
+    if name == "PROMETHEUS_AVAILABLE":
+        return is_prometheus_available()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 @dataclass
@@ -90,8 +134,8 @@ class MetricsCollector:
     - Request latencies
     - Failure rates
 
-    If prometheus_client is available, exposes metrics for Prometheus scraping.
-    Otherwise, stores metrics in-memory for manual inspection.
+    Prometheus initialization is deferred until a Prometheus-backed operation
+    is requested on this collector instance. In-memory collection always works.
     """
 
     def __init__(self, namespace: str = "peak_trade"):
@@ -103,24 +147,45 @@ class MetricsCollector:
         """
         self.namespace = namespace
         self.lock = Lock()
+        self._prometheus_init_lock = Lock()
+        self._prometheus_initialized = False
+        self.registry = None
 
         # In-memory storage for metrics (fallback when Prometheus not available)
         self.snapshots: Dict[str, list] = {}
 
-        if PROMETHEUS_AVAILABLE:
-            self.registry = CollectorRegistry()
-            self._init_prometheus_metrics()
-            logger.info(
-                f"MetricsCollector initialized with Prometheus support (namespace: {namespace})"
-            )
-        else:
-            self.registry = None
-            logger.info(f"MetricsCollector initialized in-memory mode (namespace: {namespace})")
+    def _ensure_prometheus_backend(self) -> bool:
+        """Initialize Prometheus metrics once per collector when client is available."""
+        if self._prometheus_initialized:
+            return self.registry is not None
 
-    def _init_prometheus_metrics(self) -> None:
-        """Initialize Prometheus metrics."""
-        if not PROMETHEUS_AVAILABLE:
-            return
+        if not _prometheus_spec_available():
+            self._prometheus_initialized = True
+            return False
+
+        with self._prometheus_init_lock:
+            if self._prometheus_initialized:
+                return self.registry is not None
+
+            prom = _load_prometheus_client_module()
+            if prom is None:
+                self._prometheus_initialized = True
+                return False
+
+            self.registry = prom["CollectorRegistry"]()
+            self._init_prometheus_metrics(prom)
+            self._prometheus_initialized = True
+            logger.info(
+                "MetricsCollector initialized Prometheus backend (namespace: %s)",
+                self.namespace,
+            )
+            return True
+
+    def _init_prometheus_metrics(self, prom: Dict[str, Any]) -> None:
+        """Initialize Prometheus metrics using a loaded prometheus_client module."""
+        Counter = prom["Counter"]
+        Gauge = prom["Gauge"]
+        Histogram = prom["Histogram"]
 
         # Circuit Breaker Metrics
         self.circuit_breaker_state = Gauge(
@@ -209,7 +274,7 @@ class MetricsCollector:
             from_state: Previous state
             to_state: New state
         """
-        if PROMETHEUS_AVAILABLE:
+        if self._ensure_prometheus_backend():
             self.circuit_breaker_state_changes.labels(
                 name=name, from_state=from_state, to_state=to_state
             ).inc()
@@ -233,7 +298,7 @@ class MetricsCollector:
         Args:
             name: Circuit breaker name
         """
-        if PROMETHEUS_AVAILABLE:
+        if self._ensure_prometheus_backend():
             self.circuit_breaker_failures.labels(name=name).inc()
 
         self._store_snapshot("circuit_breaker_failure", 1.0, {"name": name})
@@ -246,7 +311,7 @@ class MetricsCollector:
             limiter: Rate limiter name
             endpoint: Optional endpoint name
         """
-        if PROMETHEUS_AVAILABLE:
+        if self._ensure_prometheus_backend():
             self.rate_limit_hits.labels(limiter=limiter, endpoint=endpoint).inc()
 
         self._store_snapshot("rate_limit_hit", 1.0, {"limiter": limiter, "endpoint": endpoint})
@@ -259,7 +324,7 @@ class MetricsCollector:
             limiter: Rate limiter name
             endpoint: Optional endpoint name
         """
-        if PROMETHEUS_AVAILABLE:
+        if self._ensure_prometheus_backend():
             self.rate_limit_rejections.labels(limiter=limiter, endpoint=endpoint).inc()
 
         self._store_snapshot(
@@ -276,7 +341,7 @@ class MetricsCollector:
             limiter: Rate limiter name
             tokens: Current token count
         """
-        if PROMETHEUS_AVAILABLE:
+        if self._ensure_prometheus_backend():
             self.rate_limit_tokens.labels(limiter=limiter).set(tokens)
 
         self._store_snapshot("rate_limit_tokens", tokens, {"limiter": limiter})
@@ -299,7 +364,7 @@ class MetricsCollector:
         finally:
             duration = time.time() - start
 
-            if PROMETHEUS_AVAILABLE:
+            if self._ensure_prometheus_backend():
                 self.request_latency.labels(operation=operation).observe(duration)
 
             self._store_snapshot("request_latency", duration, {"operation": operation})
@@ -312,7 +377,7 @@ class MetricsCollector:
             operation: Operation name
             error_type: Type of error
         """
-        if PROMETHEUS_AVAILABLE:
+        if self._ensure_prometheus_backend():
             self.operation_failures.labels(operation=operation, error_type=error_type).inc()
 
         self._store_snapshot(
@@ -326,7 +391,7 @@ class MetricsCollector:
         Args:
             operation: Operation name
         """
-        if PROMETHEUS_AVAILABLE:
+        if self._ensure_prometheus_backend():
             self.operation_successes.labels(operation=operation).inc()
 
         self._store_snapshot("operation_success", 1.0, {"operation": operation})
@@ -339,7 +404,7 @@ class MetricsCollector:
             check_name: Health check name
             healthy: Whether check passed
         """
-        if PROMETHEUS_AVAILABLE:
+        if self._ensure_prometheus_backend():
             self.health_check_status.labels(check_name=check_name).set(1.0 if healthy else 0.0)
 
         self._store_snapshot("health_check", 1.0 if healthy else 0.0, {"check_name": check_name})
@@ -388,10 +453,12 @@ class MetricsCollector:
         Returns:
             Tuple of (content, content_type) for HTTP response
         """
-        if not PROMETHEUS_AVAILABLE:
+        if not self._ensure_prometheus_backend():
             return ("# Prometheus client not installed\n", "text/plain; charset=utf-8")
 
-        return generate_latest(self.registry), CONTENT_TYPE_LATEST
+        prom = _load_prometheus_client_module()
+        assert prom is not None
+        return prom["generate_latest"](self.registry), prom["CONTENT_TYPE_LATEST"]
 
     def get_summary(self) -> Dict[str, Any]:
         """
@@ -402,7 +469,7 @@ class MetricsCollector:
         """
         summary = {
             "namespace": self.namespace,
-            "prometheus_available": PROMETHEUS_AVAILABLE,
+            "prometheus_available": is_prometheus_available(),
             "timestamp": get_utc_now().isoformat(),
             "metrics": {},
         }
@@ -426,5 +493,6 @@ __all__ = [
     "MetricsCollector",
     "MetricSnapshot",
     "metrics",
-    "PROMETHEUS_AVAILABLE",
+    "is_prometheus_available",
 ]
+# PROMETHEUS_AVAILABLE is exported lazily via __getattr__ for deferred probing.

--- a/tests/core/test_metrics_lazy_prometheus_init_offline_import_chain_v0.py
+++ b/tests/core/test_metrics_lazy_prometheus_init_offline_import_chain_v0.py
@@ -1,0 +1,198 @@
+"""Focused contract tests for lazy Prometheus initialization in src/core/metrics.py (v0)."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import subprocess
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_NS = "peak_trade_lazy_prometheus_init_offline_import_chain_v0"
+
+
+def _import_with_blocked_prometheus(module_name: str):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "prometheus_client" or name.startswith("prometheus_client."):
+            raise ImportError("blocked for contract test")
+        return real_import(name, globals, locals, fromlist, level)
+
+    builtins.__import__ = blocked_import
+    sys.modules.pop("prometheus_client", None)
+    for key in list(sys.modules):
+        if key == "src.core.metrics" or key.startswith("src.core.metrics."):
+            sys.modules.pop(key, None)
+        if key == "src.core.resilience_helpers":
+            sys.modules.pop(key, None)
+        if key == "src.risk.limits":
+            sys.modules.pop(key, None)
+        if key == "src.backtest.mv2_research_wiring_v1":
+            sys.modules.pop(key, None)
+    try:
+        return importlib.import_module(module_name)
+    finally:
+        builtins.__import__ = real_import
+
+
+def test_offline_transitive_import_emits_no_prometheus_warning_v0(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _import_with_blocked_prometheus("src.backtest.mv2_research_wiring_v1")
+
+    assert "prometheus_client" not in sys.modules
+    assert not any("prometheus_client not installed" in record.message for record in caplog.records)
+    assert not any("prometheus_client not installed" in str(w.message) for w in caught)
+
+
+def test_metrics_module_import_does_not_import_prometheus_client_v0() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import importlib.util, sys\n"
+                "import builtins\n"
+                "real=builtins.__import__\n"
+                "def blocked(name,*a,**k):\n"
+                "  if name=='prometheus_client' or name.startswith('prometheus_client.'):\n"
+                "    raise ImportError('blocked')\n"
+                "  return real(name,*a,**k)\n"
+                "builtins.__import__=blocked\n"
+                "import src.core.metrics as m\n"
+                "assert 'prometheus_client' not in sys.modules\n"
+                "print('OK')"
+            ),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "OK" in proc.stdout
+
+
+def test_in_memory_metrics_work_without_prometheus_import_v0(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics_mod = importlib.import_module("src.core.metrics")
+    monkeypatch.setattr(metrics_mod, "_prometheus_spec_available", lambda: False)
+    collector = metrics_mod.MetricsCollector(namespace=_NS)
+
+    with collector.track_latency("offline.op"):
+        pass
+    collector.record_operation_success("offline.op")
+
+    snapshots = collector.get_snapshots("request_latency", limit=1)
+    assert snapshots["request_latency"]
+    assert collector.export_prometheus()[0] in (
+        b"# Prometheus client not installed\n",
+        "# Prometheus client not installed\n",
+    )
+
+
+def test_export_prometheus_uses_fallback_without_client_v0(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics_mod = importlib.import_module("src.core.metrics")
+    monkeypatch.setattr(metrics_mod, "_prometheus_spec_available", lambda: False)
+    collector = metrics_mod.MetricsCollector(namespace=_NS)
+    body, content_type = collector.export_prometheus()
+    raw = body.decode("utf-8") if isinstance(body, (bytes, bytearray)) else body
+    assert raw == "# Prometheus client not installed\n"
+    assert content_type == "text/plain; charset=utf-8"
+
+
+def test_prometheus_import_attempted_at_most_once_per_process_v0() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import importlib.util\n"
+                "if importlib.util.find_spec('prometheus_client') is None:\n"
+                "    print('SKIP_NO_PROMETHEUS')\n"
+                "    raise SystemExit(0)\n"
+                "from src.core.metrics import MetricsCollector\n"
+                "import prometheus_client\n"
+                "calls = {'n': 0}\n"
+                "real_import = __builtins__.__import__\n"
+                "def counting(name, *a, **k):\n"
+                "    if name == 'prometheus_client':\n"
+                "        calls['n'] += 1\n"
+                "    return real_import(name, *a, **k)\n"
+                "__builtins__.__import__ = counting\n"
+                "c = MetricsCollector(namespace='once_test')\n"
+                "c.export_prometheus()\n"
+                "c.export_prometheus()\n"
+                "c.record_operation_success('x')\n"
+                "assert calls['n'] == 1\n"
+                "print('OK_ONCE')"
+            ),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if "SKIP_NO_PROMETHEUS" in proc.stdout:
+        pytest.skip("prometheus_client not installed in test interpreter")
+    assert proc.returncode == 0, proc.stderr
+    assert "OK_ONCE" in proc.stdout
+
+
+def test_unrelated_initialization_errors_are_not_swallowed_v0(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics_mod = importlib.import_module("src.core.metrics")
+    collector = metrics_mod.MetricsCollector(namespace=_NS)
+
+    monkeypatch.setattr(metrics_mod, "_prometheus_spec_available", lambda: True)
+    monkeypatch.setattr(metrics_mod, "_PROMETHEUS_IMPORT_CACHE", None)
+
+    def broken_loader():
+        raise RuntimeError("unrelated init defect")
+
+    monkeypatch.setattr(metrics_mod, "_load_prometheus_client_module", broken_loader)
+
+    with pytest.raises(RuntimeError, match="unrelated init defect"):
+        collector.export_prometheus()
+
+
+def test_public_api_compatibility_preserved_v0() -> None:
+    metrics_mod = importlib.import_module("src.core.metrics")
+    assert hasattr(metrics_mod, "MetricsCollector")
+    assert hasattr(metrics_mod, "MetricSnapshot")
+    assert hasattr(metrics_mod, "metrics")
+    assert hasattr(metrics_mod, "PROMETHEUS_AVAILABLE")
+    assert hasattr(metrics_mod, "is_prometheus_available")
+    assert callable(metrics_mod.MetricsCollector().track_latency)
+    assert callable(metrics_mod.MetricsCollector().record_operation_success)
+    assert callable(metrics_mod.MetricsCollector().export_prometheus)
+    assert callable(metrics_mod.MetricsCollector().get_summary)
+
+
+def test_repeated_in_memory_calls_do_not_repeat_import_or_warnings_v0(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    metrics_mod = importlib.import_module("src.core.metrics")
+    monkeypatch.setattr(metrics_mod, "_prometheus_spec_available", lambda: False)
+    collector = metrics_mod.MetricsCollector(namespace=_NS)
+
+    for _ in range(5):
+        collector.record_operation_success("repeat.op")
+
+    assert not any("prometheus_client not installed" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

- Defers `prometheus_client` initialization in the existing canonical owner `src/core/metrics.py` behind a lazy, thread-safe singleton probe.
- Preserves in-memory `MetricsCollector` behavior for `track_latency`, `record_operation_success`, and the offline Ehlers evaluation transitive import chain (`mv2_research_wiring_v1` → `risk.limits` → `resilience_helpers` → `metrics`).
- Removes import-time missing-client warnings when `prometheus_client` is not installed in the operator Python environment; Prometheus export still initializes on first Prometheus-backed use with the existing no-op fallback.

## Source evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/classify_prometheus_client_usage_and_optional_dependency_boundary_read_only_v0_20260710T112832Z`

## Defect scope / non-effects

This repair has **no trading, accounting, economic, runtime, or authority effect**. It is observability import-path hygiene only. Ehlers same-binding reevaluation regression confirms unchanged accounting reconciliation (`PASS`), baseline verdict (`INCONCLUSIVE`), binding digests, trade count, and exit code.

## Test plan

- [x] `tests/core/test_metrics_lazy_prometheus_init_offline_import_chain_v0.py`
- [x] `tests/core/test_prometheus_client_dependency_bound_metrics_contract_v0.py`
- [x] `tests/test_metrics_collector_export_prometheus_contract_v0.py`
- [x] `tests/test_metrics_collector_summary_shape_contract_v0.py`
- [x] Ehlers same-binding reevaluation runner regression (accounting PASS, verdict INCONCLUSIVE unchanged)


Made with [Cursor](https://cursor.com)