### PR TITLE
Fix El Karoui v1 offline evaluation sizing config digest

### DIFF
--- a/config/ops/step29m_okx_inst_eth_usdt_perp_el_karoui_vol_model_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_el_karoui_vol_model_v1_economic_evaluation_v1.json
@@ -85,10 +85,10 @@
     "parameter_sensitivity_policy_version": "parameter_sensitivity_v1",
     "strategy_id": "el_karoui_vol_model",
     "strategy_params": {
-      "high_threshold": 0.7,
+      "vol_window": 20,
       "lookback_window": 252,
       "low_threshold": 0.3,
-      "vol_window": 20
+      "high_threshold": 0.7
     },
     "strategy_version": "v1",
     "stress": {
@@ -104,7 +104,7 @@
     }
   },
   "offline_evaluation_sizing_contract_v1": {
-    "config_digest": "d49d85ede512dda6d3200dbf9a50d306a423de4279767d228d20d28d88975dd8",
+    "config_digest": "dd9152621c58c1ed283c7b42601d66cf4fdcd1bb009f439d8583ebef64dc4516",
     "dataset_digest": "b4cbe7fff81a137da055588231757937406d8cb30d531ee0aab41d95ee9b6c78",
     "initial_equity": 10000.0,
     "instrument_metadata_source": "versioned_dataset_manifest_v1",

--- a/config/research/el_karoui_vol_model_v1_offline_economic_evaluation_scope_ratification_v0.json
+++ b/config/research/el_karoui_vol_model_v1_offline_economic_evaluation_scope_ratification_v0.json
@@ -1,14 +1,14 @@
 {
   "all_required_bindings_ratified": true,
   "authority_effect": "NONE",
-  "binding_digest": "223845f2047779218390fc245c3f2ebb04631bb068139e3d40731781906d099b",
+  "binding_digest": "2ba82dd901c940a5d41d2aabd3ddeb693dbbf7cdd1f0308275d11b6df4d988b3",
   "binding_ratified": true,
   "binding_version": "v0",
   "bitcoin_direction_allowed": false,
   "bitcoin_present": false,
   "candidate_binding_ref": "config/research/el_karoui_vol_model_v1_versioned_research_binding_v0.json",
   "candidate_id": "el_karoui_vol_model/v1",
-  "config_digest": "1b45ed11abdc5310f14a160200a63bb488c55d9677cd6caec0aa4bb202969d61",
+  "config_digest": "5d0afaed79c84a34bc0e92fc04c150dca1c0b828af4ee44b37384d0cd5943afc",
   "cost_execution_binding": {
     "binding_version": "v0",
     "execution_model_version": "backtest_execution_v0",
@@ -40,8 +40,8 @@
   "economic_evaluation_authorized": false,
   "economic_evaluation_executed": false,
   "economic_policy_binding": {
-    "baseline_adjudication_policy": "PASS_FAIL_INCONCLUSIVE",
     "binding_version": "v1",
+    "baseline_adjudication_policy": "PASS_FAIL_INCONCLUSIVE",
     "economic_validity_policy_version": "economic_validity_policy_v1",
     "minimum_trade_count_policy_bound": true,
     "promising_is_not_pass_bound": true,
@@ -89,10 +89,10 @@
     ],
     "parameter_search_forbidden": true,
     "parameters": {
-      "high_threshold": 0.7,
+      "vol_window": 20,
       "lookback_window": 252,
       "low_threshold": 0.3,
-      "vol_window": 20
+      "high_threshold": 0.7
     }
   },
   "parameter_search_forbidden": true,

--- a/config/research/el_karoui_vol_model_v1_versioned_research_binding_v0.json
+++ b/config/research/el_karoui_vol_model_v1_versioned_research_binding_v0.json
@@ -71,7 +71,7 @@
     "digest_bindings": {
       "config_digest": {
         "status": "BOUND",
-        "value": "1b45ed11abdc5310f14a160200a63bb488c55d9677cd6caec0aa4bb202969d61"
+        "value": "5d0afaed79c84a34bc0e92fc04c150dca1c0b828af4ee44b37384d0cd5943afc"
       },
       "data_digest": {
         "status": "BOUND",
@@ -99,8 +99,8 @@
       }
     },
     "economic_policy_binding": {
-      "baseline_adjudication_policy": "PASS_FAIL_INCONCLUSIVE",
       "binding_version": "v1",
+      "baseline_adjudication_policy": "PASS_FAIL_INCONCLUSIVE",
       "economic_validity_policy_version": "economic_validity_policy_v1",
       "minimum_trade_count_policy_bound": true,
       "promising_is_not_pass_bound": true,
@@ -192,10 +192,10 @@
       ],
       "parameter_search_forbidden": true,
       "parameters": {
-        "high_threshold": 0.7,
+        "vol_window": 20,
         "lookback_window": 252,
         "low_threshold": 0.3,
-        "vol_window": 20
+        "high_threshold": 0.7
       }
     },
     "period_binding": {
@@ -257,7 +257,7 @@
     }
   },
   "binding_changed": false,
-  "binding_digest": "223845f2047779218390fc245c3f2ebb04631bb068139e3d40731781906d099b",
+  "binding_digest": "2ba82dd901c940a5d41d2aabd3ddeb693dbbf7cdd1f0308275d11b6df4d988b3",
   "binding_ratified": true,
   "binding_version": "v0",
   "bitcoin_direction_allowed": false,

--- a/src/research/el_karoui_vol_model_v1_offline_economic_evaluation_scope_ratification_v0.py
+++ b/src/research/el_karoui_vol_model_v1_offline_economic_evaluation_scope_ratification_v0.py
@@ -26,6 +26,10 @@ from src.backtest.step29m_el_karoui_vol_model_v1_economic_evaluation_admissibili
     EXCLUDED_BINDING_PARAMS,
     evaluate_el_karoui_vol_model_v1_admissibility_contract_v1,
 )
+from src.backtest.offline_evaluation_sizing_contract_v1 import (
+    compute_sizing_contract_digest_v1,
+    load_offline_evaluation_sizing_contract_v1,
+)
 from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 import (
     compute_evaluation_config_digest_v1,
 )
@@ -338,10 +342,15 @@ def materialize_evaluation_config_v1(repo_root: Path) -> dict[str, Any]:
         strategy_params_digest=strategy_params_digest,
         config_digest="",
     )
-    config_digest = compute_evaluation_config_digest_v1(draft)
+    sizing_contract = load_offline_evaluation_sizing_contract_v1(
+        draft,
+        strategy_params_digest=strategy_params_digest,
+        dataset_digest=DATASET_DIGEST,
+    )
+    sizing_config_digest = compute_sizing_contract_digest_v1(sizing_contract)
     return build_evaluation_config_template_v1(
         strategy_params_digest=strategy_params_digest,
-        config_digest=config_digest,
+        config_digest=sizing_config_digest,
     )
 
 

--- a/tests/ops/test_step29m_el_karoui_vol_model_v1_economic_evaluation_registry_contract_v1.py
+++ b/tests/ops/test_step29m_el_karoui_vol_model_v1_economic_evaluation_registry_contract_v1.py
@@ -1,0 +1,162 @@
+"""Registry contract for STEP 29M el_karoui_vol_model v1 economic evaluation config."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from src.backtest import (
+    step29m_el_karoui_vol_model_v1_economic_evaluation_admissibility_contract_v1 as contract,
+)
+from src.backtest.offline_evaluation_sizing_contract_v1 import (
+    OfflineEvaluationSizingError,
+    bind_offline_evaluation_sizing_v1,
+    compute_sizing_contract_digest_v1,
+    load_offline_evaluation_sizing_contract_v1,
+)
+from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 import (
+    compute_evaluation_config_digest_v1,
+)
+from src.research.el_karoui_vol_model_v1_offline_economic_evaluation_scope_ratification_v0 import (
+    compute_universe_digest_v0,
+)
+from src.research.step29m_el_karoui_vol_model_v1_offline_economic_baseline_materialization_v0 import (
+    compute_step29m_el_karoui_binding_digest_v0,
+    compute_step29m_el_karoui_implementation_digest_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EL_KAROUI_CONFIG = REPO_ROOT / contract.DEFAULT_EVALUATION_CONFIG_PATH
+RATIFIED_BINDING_DIGEST = "2ba82dd901c940a5d41d2aabd3ddeb693dbbf7cdd1f0308275d11b6df4d988b3"
+STALE_RATIFIED_BINDING_DIGEST = "223845f2047779218390fc245c3f2ebb04631bb068139e3d40731781906d099b"
+STALE_SIZING_CONFIG_DIGEST = "d49d85ede512dda6d3200dbf9a50d306a423de4279767d228d20d28d88975dd8"
+RECOMPUTED_SIZING_CONFIG_DIGEST = "dd9152621c58c1ed283c7b42601d66cf4fdcd1bb009f439d8583ebef64dc4516"
+
+
+def _load_config() -> dict:
+    return json.loads(EL_KAROUI_CONFIG.read_text(encoding="utf-8"))
+
+
+def _admissibility() -> contract.ElKarouiVolModelV1AdmissibilityContractResultV1:
+    return contract.evaluate_el_karoui_vol_model_v1_admissibility_contract_v1(repo_root=REPO_ROOT)
+
+
+def _sizing_contract(cfg: dict):
+    sizing = cfg["offline_evaluation_sizing_contract_v1"]
+    return load_offline_evaluation_sizing_contract_v1(
+        cfg,
+        strategy_params_digest=sizing["strategy_params_digest"],
+        dataset_digest=sizing["dataset_digest"],
+    )
+
+
+def test_el_karoui_config_registered_in_canonical_registry() -> None:
+    registry = contract.list_step29m_registered_economic_evaluation_configs_v1()
+    assert contract.DEFAULT_EVALUATION_CONFIG_PATH in registry
+    assert EL_KAROUI_CONFIG.is_file()
+
+
+def test_el_karoui_config_digest_stable() -> None:
+    cfg = _load_config()
+    digest = compute_evaluation_config_digest_v1(cfg)
+    assert len(digest) == 64
+    assert digest == compute_evaluation_config_digest_v1(
+        json.loads(EL_KAROUI_CONFIG.read_text(encoding="utf-8"))
+    )
+
+
+def test_el_karoui_sizing_config_digest_matches_sizing_contract() -> None:
+    cfg = _load_config()
+    sizing = cfg["offline_evaluation_sizing_contract_v1"]
+    expected_sizing_digest = compute_sizing_contract_digest_v1(_sizing_contract(cfg))
+    assert sizing["config_digest"] == expected_sizing_digest
+    assert sizing["config_digest"] == RECOMPUTED_SIZING_CONFIG_DIGEST
+    assert sizing["config_digest"] != STALE_SIZING_CONFIG_DIGEST
+    assert sizing["config_digest"] != compute_evaluation_config_digest_v1(cfg)
+
+
+def test_el_karoui_stale_sizing_config_digest_rejected_by_binding() -> None:
+    cfg = _load_config()
+    bad = deepcopy(cfg)
+    bad["offline_evaluation_sizing_contract_v1"] = dict(
+        bad["offline_evaluation_sizing_contract_v1"]
+    )
+    bad["offline_evaluation_sizing_contract_v1"]["config_digest"] = STALE_SIZING_CONFIG_DIGEST
+    sizing = bad["offline_evaluation_sizing_contract_v1"]
+    adm = _admissibility()
+    with pytest.raises(OfflineEvaluationSizingError, match="sizing_config_digest_mismatch"):
+        bind_offline_evaluation_sizing_v1(
+            bad,
+            strategy_params_digest=adm.strategy_params_digest,
+            dataset_digest=sizing["dataset_digest"],
+        )
+
+
+def test_el_karoui_repaired_sizing_config_digest_accepted_by_binding() -> None:
+    cfg = _load_config()
+    sizing = cfg["offline_evaluation_sizing_contract_v1"]
+    adm = _admissibility()
+    contract_obj, _ = bind_offline_evaluation_sizing_v1(
+        deepcopy(cfg),
+        strategy_params_digest=adm.strategy_params_digest,
+        dataset_digest=sizing["dataset_digest"],
+    )
+    assert contract_obj.config_digest == RECOMPUTED_SIZING_CONFIG_DIGEST
+
+
+def test_el_karoui_evaluation_config_digest_rejected_in_sizing_binding() -> None:
+    cfg = _load_config()
+    bad = deepcopy(cfg)
+    bad["offline_evaluation_sizing_contract_v1"] = dict(
+        bad["offline_evaluation_sizing_contract_v1"]
+    )
+    bad["offline_evaluation_sizing_contract_v1"]["config_digest"] = (
+        compute_evaluation_config_digest_v1(cfg)
+    )
+    sizing = bad["offline_evaluation_sizing_contract_v1"]
+    sizing_contract = load_offline_evaluation_sizing_contract_v1(
+        bad,
+        strategy_params_digest=sizing["strategy_params_digest"],
+        dataset_digest=sizing["dataset_digest"],
+    )
+    assert sizing["config_digest"] != compute_sizing_contract_digest_v1(sizing_contract)
+
+
+def test_el_karoui_binding_digest_matches_canonical_materializer_after_repair() -> None:
+    cfg = _load_config()
+    adm = _admissibility()
+    binding_cfg = json.loads(
+        (
+            REPO_ROOT / "config/research/el_karoui_vol_model_v1_versioned_research_binding_v0.json"
+        ).read_text(encoding="utf-8")
+    )
+    material_diff = json.loads(
+        (
+            REPO_ROOT
+            / "config/research/el_karoui_vol_model_v1_material_difference_and_non_claim_contract_v0.json"
+        ).read_text(encoding="utf-8")
+    )
+    eval_binding = cfg["real_admissible_futures_evaluation_binding_v1"]
+    data_period = (
+        f"{eval_binding['training_period']}|"
+        f"{eval_binding['validation_period']}|"
+        f"{eval_binding['out_of_sample_period']}"
+    )
+    binding_digest = compute_step29m_el_karoui_binding_digest_v0(
+        config_digest=adm.config_digest,
+        data_digest=cfg["offline_evaluation_sizing_contract_v1"]["dataset_digest"],
+        implementation_digest=compute_step29m_el_karoui_implementation_digest_v0(REPO_ROOT),
+        strategy_params_digest=adm.strategy_params_digest,
+        material_difference_digest=material_diff["material_difference_digest"],
+        hypothesis_id=binding_cfg["hypothesis_id"],
+        instrument_id=eval_binding["canonical_instrument_id"],
+        data_period=data_period,
+        universe_digest=compute_universe_digest_v0(),
+    )
+    assert binding_digest == RATIFIED_BINDING_DIGEST
+    assert binding_cfg["binding_digest"] == RATIFIED_BINDING_DIGEST
+    assert binding_cfg["binding_digest"] != STALE_RATIFIED_BINDING_DIGEST
+    assert binding_cfg["binding"]["digest_bindings"]["config_digest"]["value"] == adm.config_digest


### PR DESCRIPTION
## Summary

- Repariert den stale `offline_evaluation_sizing_contract_v1.config_digest` in der gebundenen El-Karoui-v1-Offline-Evaluation-Config (`d49d85e…` → kanonisch `dd915262…`).
- Behebt die Ursache im Materializer `materialize_evaluation_config_v1`, der fälschlich `compute_evaluation_config_digest_v1(draft)` statt `compute_sizing_contract_digest_v1` in das Sizing-Feld geschrieben hat.
- Synchronisiert die abgeleiteten Eval-Config- und Binding-Metadaten (`config_digest`, `binding_digest`) ohne Änderung an Sizing-Semantik, Dataset, Universe, Strategieparametern oder Trading-Logik.

## Defect-Ursache

`bind_offline_evaluation_sizing_v1` fail-closed mit `sizing_config_digest_mismatch`, weil das gebundene Sizing-`config_digest`-Feld den Evaluation-Config-Digest eines Drafts enthielt statt des kanonischen Sizing-Contract-Digests.

## Kanonischer Digest-Owner

`src/backtest/offline_evaluation_sizing_contract_v1.py` → `compute_sizing_contract_digest_v1` / `bind_offline_evaluation_sizing_v1`

## Digest-Nachweis

| Feld | Alt | Neu |
|---|---|---|
| Sizing `config_digest` | `d49d85ede512dda6d3200dbf9a50d306a423de4279767d228d20d28d88975dd8` | `dd9152621c58c1ed283c7b42601d66cf4fdcd1bb009f439d8583ebef64dc4516` |
| Eval `config_digest` | `1b45ed11abdc5310f14a160200a63bb488c55d9677cd6caec0aa4bb202969d61` | `5d0afaed79c84a34bc0e92fc04c150dca1c0b828af4ee44b37384d0cd5943afc` |
| `binding_digest` | `223845f2047779218390fc245c3f2ebb04631bb068139e3d40731781906d099b` | `2ba82dd901c940a5d41d2aabd3ddeb693dbbf7cdd1f0308275d11b6df4d988b3` |

Semantische Sizing-Werte, Dataset-Digest, Universe-Digest und Strategieparameter sind unverändert; nur abgeleitete Digest-Metadaten wurden korrigiert.

## Runner-Reuse-Entscheidung

`RUNNER_REQUIRED=false`, `RUNNER_ACTION=NOT_APPLICABLE`. Es existiert kein generischer gebundener Offline-Runner für alle Scopes; der Ehlers-v1-Runner ist strategy-spezifisch. Dieser Repair-Slice führt keine Evaluation aus; ein dünner El-Karoui-Adapter kann im separaten Reevaluation-Slice ergänzt werden, falls dann verbindlich.

## Grenzen

- Keine Economic Evaluation, keine Baseline, keine Robustness
- Keine Runtime-/Authority-Wirkung
- Keine Trading-Logic-, Risk-Sizing- oder Policy-Änderung

## Test plan

- [x] `pytest tests/ops/test_step29m_el_karoui_vol_model_v1_economic_evaluation_registry_contract_v1.py -q`
- [x] `pytest tests/ops/test_el_karoui_vol_model_v1_offline_economic_evaluation_scope_ratification_v0_contract.py -q`
- [x] `ruff check` / `ruff format --check` auf geänderte Python-Dateien

## Durable Evidence

- Source bundle: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/el_karoui_vol_model_v1_bound_offline_economic_baseline_evaluation_v0_20260710T130747Z` (`MANIFEST_VERIFY_RC=0`)
- Repair bundle: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/el_karoui_vol_model_v1_defect_repair_sizing_config_digest_same_binding_no_runtime_authority_v0_20260710T131442Z` (`MANIFEST_VERIFY_RC=0`)


Made with [Cursor](https://cursor.com)