### PR TITLE
Fix Armstrong cycle v1 binding canonicalization for baseline runner

### DIFF
--- a/scripts/ops/run_armstrong_cycle_v1_bound_offline_economic_baseline_evaluation_v0.py
+++ b/scripts/ops/run_armstrong_cycle_v1_bound_offline_economic_baseline_evaluation_v0.py
@@ -39,6 +39,10 @@ from src.backtest.step29m_armstrong_cycle_v1_economic_evaluation_admissibility_c
     load_armstrong_cycle_v1_evaluation_config_v1,
 )
 from src.core.metrics import metrics as resilience_metrics  # noqa: E402
+from src.research.armstrong_cycle_v1_offline_economic_evaluation_scope_ratification_v0 import (  # noqa: E402
+    build_armstrong_cycle_v1_period_binding_data_period_v0,
+    reject_stale_runner_descriptor_range_data_period_v0,
+)
 from src.research.step29m_armstrong_cycle_v1_offline_economic_baseline_materialization_v0 import (  # noqa: E402
     METRICS_SUMMARY_FILENAME,
     compute_step29m_armstrong_binding_digest_v0,
@@ -60,6 +64,50 @@ BINDING_CONFIG_PATH = "config/research/armstrong_cycle_v1_versioned_research_bin
 MATERIAL_DIFFERENCE_PATH = (
     "config/research/armstrong_cycle_v1_material_difference_and_non_claim_contract_v0.json"
 )
+
+STALE_RUNNER_DESCRIPTOR_RANGE_DATA_PERIOD = "2026-06-17 10:07:00+00:00..2026-07-01 10:07:00+00:00"
+
+
+def resolve_armstrong_cycle_v1_binding_data_period_for_baseline_v0(
+    binding_cfg: Mapping[str, Any],
+) -> str:
+    """Resolve canonical ratified period_binding pipe payload for baseline binding digest."""
+    period_binding = binding_cfg["binding"]["period_binding"]
+    data_period = build_armstrong_cycle_v1_period_binding_data_period_v0(period_binding)
+    reject_stale_runner_descriptor_range_data_period_v0(data_period)
+    return data_period
+
+
+def compute_armstrong_cycle_v1_ratified_binding_digest_for_baseline_v0(
+    *,
+    binding_cfg: Mapping[str, Any],
+    material_diff: Mapping[str, Any],
+    config_digest: str,
+    strategy_params_digest: str,
+    data_digest: str,
+    implementation_digest: str,
+    instrument_id: str,
+) -> tuple[str, str]:
+    """Compute baseline binding digest using ratified period_binding canonicalization owner."""
+    data_period = resolve_armstrong_cycle_v1_binding_data_period_for_baseline_v0(binding_cfg)
+    universe_digest = str(binding_cfg.get("universe_digest", ""))
+    binding_digest = compute_step29m_armstrong_binding_digest_v0(
+        config_digest=config_digest,
+        data_digest=data_digest,
+        implementation_digest=implementation_digest,
+        strategy_params_digest=strategy_params_digest,
+        material_difference_digest=str(material_diff["material_difference_digest"]),
+        hypothesis_id=str(binding_cfg["hypothesis_id"]),
+        instrument_id=instrument_id,
+        data_period=data_period,
+        universe_digest=universe_digest,
+    )
+    ratified_binding_digest = str(binding_cfg.get("binding_digest", ""))
+    if ratified_binding_digest and binding_digest != ratified_binding_digest:
+        raise SystemExit(
+            f"ERR: binding_digest_mismatch:computed={binding_digest}:ratified={ratified_binding_digest}"
+        )
+    return data_period, binding_digest
 
 
 class EconomicClassification(str, Enum):
@@ -206,18 +254,16 @@ def run_baseline_evaluation(
 
     config_digest = admissibility.config_digest
     strategy_params_digest = admissibility.strategy_params_digest
-    data_period = f"{descriptor.start_time}..{descriptor.end_time}"
-    universe_digest = str(binding_cfg.get("universe_digest", ""))
-    binding_digest = compute_step29m_armstrong_binding_digest_v0(
-        config_digest=config_digest,
-        data_digest=descriptor.dataset_digest,
-        implementation_digest=implementation_digest,
-        strategy_params_digest=strategy_params_digest,
-        material_difference_digest=str(material_diff["material_difference_digest"]),
-        hypothesis_id=str(binding_cfg["hypothesis_id"]),
-        instrument_id=str(eval_binding["canonical_instrument_id"]),
-        data_period=data_period,
-        universe_digest=universe_digest,
+    data_period, binding_digest = (
+        compute_armstrong_cycle_v1_ratified_binding_digest_for_baseline_v0(
+            binding_cfg=binding_cfg,
+            material_diff=material_diff,
+            config_digest=config_digest,
+            strategy_params_digest=strategy_params_digest,
+            data_digest=descriptor.dataset_digest,
+            implementation_digest=implementation_digest,
+            instrument_id=str(eval_binding["canonical_instrument_id"]),
+        )
     )
 
     ts = _utc_slug()

--- a/src/research/armstrong_cycle_v1_offline_economic_evaluation_scope_ratification_v0.py
+++ b/src/research/armstrong_cycle_v1_offline_economic_evaluation_scope_ratification_v0.py
@@ -97,7 +97,58 @@ DATASET_PATH = (
 TRAINING_PERIOD = "2026-06-17 16:00:00+00:00..2026-06-24 13:03:00+00:00"
 VALIDATION_PERIOD = "2026-06-24 13:04:00+00:00..2026-06-27 23:35:00+00:00"
 OUT_OF_SAMPLE_PERIOD = "2026-06-27 23:36:00+00:00..2026-07-01 10:07:00+00:00"
-DATA_PERIOD = f"{TRAINING_PERIOD}|{VALIDATION_PERIOD}|{OUT_OF_SAMPLE_PERIOD}"
+
+PERIOD_BINDING_DATA_PERIOD_KEYS = (
+    "training_period",
+    "validation_period",
+    "out_of_sample_period",
+)
+
+
+class ArmstrongCycleV1BindingDataPeriodError(ValueError):
+    """Fail-closed when binding data_period payload is not ratified period_binding pipe format."""
+
+
+def build_armstrong_cycle_v1_period_binding_data_period_v0(
+    period_binding: Mapping[str, Any],
+) -> str:
+    """Canonical pipe-serialization owner for ratified period_binding → binding digest data_period."""
+    missing = [key for key in PERIOD_BINDING_DATA_PERIOD_KEYS if key not in period_binding]
+    if missing:
+        raise ArmstrongCycleV1BindingDataPeriodError(
+            f"period_binding_missing_keys:{','.join(missing)}"
+        )
+    return (
+        f"{period_binding['training_period']}|"
+        f"{period_binding['validation_period']}|"
+        f"{period_binding['out_of_sample_period']}"
+    )
+
+
+def is_stale_runner_descriptor_range_data_period_v0(data_period: str) -> bool:
+    """True when payload uses single dataset-descriptor range instead of ratified pipe format."""
+    return ".." in data_period and "|" not in data_period
+
+
+def reject_stale_runner_descriptor_range_data_period_v0(data_period: str) -> None:
+    if is_stale_runner_descriptor_range_data_period_v0(data_period):
+        raise ArmstrongCycleV1BindingDataPeriodError(
+            "stale_runner_descriptor_range_data_period_rejected"
+        )
+
+
+def build_period_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v1",
+        "out_of_sample_period": OUT_OF_SAMPLE_PERIOD,
+        "periods_frozen_before_execution": True,
+        "random_split_forbidden": True,
+        "training_period": TRAINING_PERIOD,
+        "validation_period": VALIDATION_PERIOD,
+    }
+
+
+DATA_PERIOD = build_armstrong_cycle_v1_period_binding_data_period_v0(build_period_binding_v0())
 
 NEXT_GO_TOKEN = (
     "GO_ARMSTRONG_CYCLE_V1_BOUNDED_OFFLINE_ECONOMIC_BASELINE_EVALUATION_NO_RUNTIME_AUTHORITY_V0"
@@ -641,14 +692,7 @@ def materialize_versioned_research_binding_v0(
                 "parameter_search_forbidden": True,
                 "parameters": dict(ARMSTRONG_CYCLE_V1_CANONICAL_PARAMS),
             },
-            "period_binding": {
-                "binding_version": "v1",
-                "out_of_sample_period": OUT_OF_SAMPLE_PERIOD,
-                "periods_frozen_before_execution": True,
-                "random_split_forbidden": True,
-                "training_period": TRAINING_PERIOD,
-                "validation_period": VALIDATION_PERIOD,
-            },
+            "period_binding": build_period_binding_v0(),
             "prior_evidence_exclusion": {
                 "excluded_terminal_inconclusive_bindings": [
                     "ehlers_cycle_filter/v1",

--- a/tests/ops/test_armstrong_cycle_v1_binding_canonicalization_repair_v0_contract.py
+++ b/tests/ops/test_armstrong_cycle_v1_binding_canonicalization_repair_v0_contract.py
@@ -1,0 +1,237 @@
+"""Contract tests for armstrong_cycle/v1 binding canonicalization repair v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ops.run_armstrong_cycle_v1_bound_offline_economic_baseline_evaluation_v0 import (
+    STALE_RUNNER_DESCRIPTOR_RANGE_DATA_PERIOD,
+    compute_armstrong_cycle_v1_ratified_binding_digest_for_baseline_v0,
+    resolve_armstrong_cycle_v1_binding_data_period_for_baseline_v0,
+)
+from src.backtest.step29m_armstrong_cycle_v1_economic_evaluation_admissibility_contract_v1 import (
+    evaluate_armstrong_cycle_v1_admissibility_contract_v1,
+    load_armstrong_cycle_v1_evaluation_config_v1,
+)
+from src.research.armstrong_cycle_v1_offline_economic_evaluation_scope_ratification_v0 import (
+    DATA_PERIOD,
+    ArmstrongCycleV1BindingDataPeriodError,
+    build_armstrong_cycle_v1_period_binding_data_period_v0,
+    build_period_binding_v0,
+    is_stale_runner_descriptor_range_data_period_v0,
+    materialize_evaluation_config_v1,
+    materialize_material_difference_contract_v0,
+    materialize_versioned_research_binding_v0,
+    reject_stale_runner_descriptor_range_data_period_v0,
+)
+from src.research.step29m_armstrong_cycle_v1_offline_economic_baseline_materialization_v0 import (
+    compute_step29m_armstrong_binding_digest_v0,
+    compute_step29m_armstrong_implementation_digest_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RATIFIED_BINDING_DIGEST = "d29de831f426eeca087518ab9ebe53c1e77895fc0f9f4550a0d804a69403d69c"
+DEFECTIVE_EVALUATION_SNAPSHOT_BINDING_DIGEST = (
+    "e01256994d1835f8f5b579a51ef618da77cbc1d6a4df5ed1e92deb3ebc1a7109"
+)
+DATASET_DIGEST = "b4cbe7fff81a137da055588231757937406d8cb30d531ee0aab41d95ee9b6c78"
+UNIVERSE_DIGEST = "be6ea12f6e883de596e8e7987be071bcb4ebc3d32bff15ec933643dcf74f9ee2"
+EVAL_CONFIG_PATH = (
+    "config/ops/step29m_okx_inst_eth_usdt_perp_armstrong_cycle_v1_economic_evaluation_v1.json"
+)
+BINDING_CONFIG_PATH = "config/research/armstrong_cycle_v1_versioned_research_binding_v0.json"
+MATERIAL_DIFFERENCE_PATH = (
+    "config/research/armstrong_cycle_v1_material_difference_and_non_claim_contract_v0.json"
+)
+SOURCE_EVALUATION_DIR = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "research/armstrong_cycle_v1_bound_offline_economic_baseline_evaluation_v0_20260710T153705Z"
+)
+
+
+def _load_binding_cfg() -> dict:
+    return json.loads((REPO_ROOT / BINDING_CONFIG_PATH).read_text(encoding="utf-8"))
+
+
+def _load_material_diff() -> dict:
+    return json.loads((REPO_ROOT / MATERIAL_DIFFERENCE_PATH).read_text(encoding="utf-8"))
+
+
+def _ratified_data_period() -> str:
+    return build_armstrong_cycle_v1_period_binding_data_period_v0(build_period_binding_v0())
+
+
+def _runner_ratified_digest() -> tuple[str, str]:
+    binding_cfg = _load_binding_cfg()
+    material_diff = _load_material_diff()
+    admissibility = evaluate_armstrong_cycle_v1_admissibility_contract_v1(repo_root=REPO_ROOT)
+    eval_cfg = load_armstrong_cycle_v1_evaluation_config_v1(REPO_ROOT, EVAL_CONFIG_PATH)
+    instrument_id = str(
+        eval_cfg["real_admissible_futures_evaluation_binding_v1"]["canonical_instrument_id"]
+    )
+    return compute_armstrong_cycle_v1_ratified_binding_digest_for_baseline_v0(
+        binding_cfg=binding_cfg,
+        material_diff=material_diff,
+        config_digest=admissibility.config_digest,
+        strategy_params_digest=admissibility.strategy_params_digest,
+        data_digest=DATASET_DIGEST,
+        implementation_digest=compute_step29m_armstrong_implementation_digest_v0(REPO_ROOT),
+        instrument_id=instrument_id,
+    )
+
+
+def test_stale_or_runner_specific_data_period_payload_rejected() -> None:
+    assert is_stale_runner_descriptor_range_data_period_v0(
+        STALE_RUNNER_DESCRIPTOR_RANGE_DATA_PERIOD
+    )
+    with pytest.raises(ArmstrongCycleV1BindingDataPeriodError):
+        reject_stale_runner_descriptor_range_data_period_v0(
+            STALE_RUNNER_DESCRIPTOR_RANGE_DATA_PERIOD
+        )
+
+
+def test_ratified_period_binding_payload_accepted() -> None:
+    payload = _ratified_data_period()
+    assert payload == DATA_PERIOD
+    reject_stale_runner_descriptor_range_data_period_v0(payload)
+
+
+def test_runner_uses_canonical_period_binding_owner() -> None:
+    binding_cfg = _load_binding_cfg()
+    data_period = resolve_armstrong_cycle_v1_binding_data_period_for_baseline_v0(binding_cfg)
+    assert data_period == DATA_PERIOD
+    assert "|" in data_period
+
+
+def test_ratification_and_runner_binding_payload_equal() -> None:
+    binding_cfg = _load_binding_cfg()
+    ratification_payload = build_armstrong_cycle_v1_period_binding_data_period_v0(
+        build_period_binding_v0()
+    )
+    runner_payload = resolve_armstrong_cycle_v1_binding_data_period_for_baseline_v0(binding_cfg)
+    assert ratification_payload == runner_payload
+
+
+def test_ratification_and_runner_binding_digest_equal() -> None:
+    evaluation_config = materialize_evaluation_config_v1(REPO_ROOT)
+    material_difference = materialize_material_difference_contract_v0()
+    versioned_binding = materialize_versioned_research_binding_v0(
+        REPO_ROOT,
+        material_difference=material_difference,
+        evaluation_config=evaluation_config,
+    )
+    _, runner_digest = _runner_ratified_digest()
+    assert runner_digest == versioned_binding["binding_digest"]
+    assert runner_digest == RATIFIED_BINDING_DIGEST
+    assert runner_digest != DEFECTIVE_EVALUATION_SNAPSHOT_BINDING_DIGEST
+
+
+def test_materializer_to_real_binder_roundtrip_pass() -> None:
+    evaluation_config = materialize_evaluation_config_v1(REPO_ROOT)
+    material_difference = materialize_material_difference_contract_v0()
+    versioned_binding = materialize_versioned_research_binding_v0(
+        REPO_ROOT,
+        material_difference=material_difference,
+        evaluation_config=evaluation_config,
+    )
+    binding = versioned_binding["binding"]
+    digest_bindings = binding["digest_bindings"]
+    recomputed = compute_step29m_armstrong_binding_digest_v0(
+        config_digest=digest_bindings["config_digest"]["value"],
+        data_digest=digest_bindings["data_digest"]["value"],
+        implementation_digest=digest_bindings["implementation_digest"]["value"],
+        strategy_params_digest=digest_bindings["strategy_params_digest"]["value"],
+        material_difference_digest=digest_bindings["material_difference_digest"]["value"],
+        hypothesis_id=versioned_binding["hypothesis_id"],
+        instrument_id="inst-eth-usdt-perp",
+        data_period=build_armstrong_cycle_v1_period_binding_data_period_v0(
+            binding["period_binding"]
+        ),
+        universe_digest=digest_bindings["universe_digest"]["value"],
+    )
+    assert recomputed == versioned_binding["binding_digest"]
+
+
+def test_repeated_materialization_deterministic() -> None:
+    first = materialize_versioned_research_binding_v0(
+        REPO_ROOT,
+        material_difference=materialize_material_difference_contract_v0(),
+        evaluation_config=materialize_evaluation_config_v1(REPO_ROOT),
+    )
+    second = materialize_versioned_research_binding_v0(
+        REPO_ROOT,
+        material_difference=materialize_material_difference_contract_v0(),
+        evaluation_config=materialize_evaluation_config_v1(REPO_ROOT),
+    )
+    assert first["binding_digest"] == second["binding_digest"]
+
+
+def test_second_materialization_diff_empty() -> None:
+    first = materialize_versioned_research_binding_v0(
+        REPO_ROOT,
+        material_difference=materialize_material_difference_contract_v0(),
+        evaluation_config=materialize_evaluation_config_v1(REPO_ROOT),
+    )
+    second = materialize_versioned_research_binding_v0(
+        REPO_ROOT,
+        material_difference=materialize_material_difference_contract_v0(),
+        evaluation_config=materialize_evaluation_config_v1(REPO_ROOT),
+    )
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def test_dataset_digest_unchanged() -> None:
+    binding_cfg = _load_binding_cfg()
+    assert binding_cfg["binding"]["digest_bindings"]["data_digest"]["value"] == DATASET_DIGEST
+
+
+def test_universe_digest_unchanged() -> None:
+    binding_cfg = _load_binding_cfg()
+    assert binding_cfg["universe_digest"] == UNIVERSE_DIGEST
+
+
+def test_strategy_parameters_unchanged() -> None:
+    eval_cfg = load_armstrong_cycle_v1_evaluation_config_v1(REPO_ROOT, EVAL_CONFIG_PATH)
+    expected = eval_cfg["economic_evaluation_v1"]["strategy_params"]
+    binding_cfg = _load_binding_cfg()
+    assert binding_cfg["binding"]["parameter_binding"]["parameters"] == expected
+
+
+def test_cost_policy_unchanged() -> None:
+    eval_cfg = load_armstrong_cycle_v1_evaluation_config_v1(REPO_ROOT, EVAL_CONFIG_PATH)
+    binding_cfg = _load_binding_cfg()
+    assert binding_cfg["binding"]["cost_execution_binding"]["roundtrip_cost_bps"] == 40.0
+    assert eval_cfg["backtest"]["fee_bps"] == 10.0
+    assert eval_cfg["backtest"]["slippage_bps"] == 5.0
+
+
+def test_risk_sizing_semantics_unchanged() -> None:
+    eval_cfg = load_armstrong_cycle_v1_evaluation_config_v1(REPO_ROOT, EVAL_CONFIG_PATH)
+    sizing = eval_cfg["offline_evaluation_sizing_contract_v1"]
+    assert sizing["risk_per_trade"] == 0.005
+    assert sizing["stop_pct"] == 0.025
+
+
+def test_historical_evaluation_evidence_preserved() -> None:
+    assert SOURCE_EVALUATION_DIR.is_dir()
+    snapshot = json.loads(
+        (SOURCE_EVALUATION_DIR / "immutable_binding_snapshot.json").read_text(encoding="utf-8")
+    )
+    assert snapshot["binding_digest"] == DEFECTIVE_EVALUATION_SNAPSHOT_BINDING_DIGEST
+
+
+def test_no_economic_evaluation_executed() -> None:
+    assert True
+
+
+def test_no_runtime_effect() -> None:
+    binding_cfg = _load_binding_cfg()
+    assert binding_cfg["runtime_effect"] == "NONE"
+
+
+def test_no_authority_effect() -> None:
+    binding_cfg = _load_binding_cfg()
+    assert binding_cfg["authority_effect"] == "NONE"

--- a/tests/ops/test_step29m_armstrong_cycle_v1_offline_economic_baseline_materialization_v0_contract.py
+++ b/tests/ops/test_step29m_armstrong_cycle_v1_offline_economic_baseline_materialization_v0_contract.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from src.research.armstrong_cycle_v1_offline_economic_evaluation_scope_ratification_v0 import (
+    build_armstrong_cycle_v1_period_binding_data_period_v0,
     materialize_evaluation_config_v1,
     materialize_material_difference_contract_v0,
     materialize_versioned_research_binding_v0,
@@ -43,10 +44,8 @@ def test_binding_digest_roundtrip() -> None:
         material_difference_digest=digest_bindings["material_difference_digest"]["value"],
         hypothesis_id=versioned_binding["hypothesis_id"],
         instrument_id="inst-eth-usdt-perp",
-        data_period=(
-            f"{binding['period_binding']['training_period']}|"
-            f"{binding['period_binding']['validation_period']}|"
-            f"{binding['period_binding']['out_of_sample_period']}"
+        data_period=build_armstrong_cycle_v1_period_binding_data_period_v0(
+            binding["period_binding"]
         ),
         universe_digest=digest_bindings["universe_digest"]["value"],
     )


### PR DESCRIPTION
## Summary
- Adds canonical `period_binding` pipe-format serialization to the ratified Armstrong cycle v1 research binding owner.
- Updates the baseline offline evaluation runner to consume ratified `period_binding` instead of dataset-descriptor `start..end` range when computing `binding_digest`.
- Adds contract tests proving ratification and runner binding payloads and digests match the ratified contract (`d29de831…`).

## Source evidence
- Classification: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/classify_armstrong_cycle_v1_baseline_inconclusive_cause_read_only_v0_20260710T154059Z`
- Ratification closeout: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr5092_merge_closeout_armstrong_cycle_v1_versioned_research_binding_and_offline_evaluation_scope_v0_20260710T153527Z`
- Defective evaluation (preserved): `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/armstrong_cycle_v1_bound_offline_economic_baseline_evaluation_v0_20260710T153705Z`
- Repair evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/armstrong_cycle_v1_binding_canonicalization_repair_v0_20260710T154425Z`

## Explicit non-claims
- ECONOMIC_EVALUATION_EXECUTED=false
- GROSS_PNL_REPORTING_DEFECT_REPAIRED=false
- EXPECTANCY_MATERIALIZATION_DEFECT_REPAIRED=false
- REEVALUATION_AUTHORIZED=false
- RUNTIME_EFFECT=NONE
- AUTHORITY_EFFECT=NONE

## Test plan
- [x] `pytest tests/ops/test_armstrong_cycle_v1_binding_canonicalization_repair_v0_contract.py`
- [x] `pytest tests/ops/test_step29m_armstrong_cycle_v1_offline_economic_baseline_materialization_v0_contract.py`
- [ ] Wait for CI checks (no merge without operator GO)


Made with [Cursor](https://cursor.com)