### PR TITLE
Add Bouchaud OHLCV proxy STEP29M offline adapter

### DIFF
--- a/config/ops/step29m_okx_inst_eth_usdt_perp_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_v1.json
@@ -1,0 +1,184 @@
+{
+  "backtest": {
+    "cost_model_version": "backtest_cost_v0",
+    "dataset_admissibility": {
+      "bind": true,
+      "dataset_profile": "economic_research_v1",
+      "execution_cost_binding": {
+        "conservative_half_spread_bps": 5.0,
+        "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+        "spread_model_version": "research_conservative_bps_v1"
+      },
+      "profile_binding": {
+        "dataset_profile": "economic_research_v1",
+        "execution_cost_binding": {
+          "conservative_half_spread_bps": 5.0,
+          "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+          "spread_model_version": "research_conservative_bps_v1"
+        },
+        "l1_observation_status": "EXECUTION_MODEL_BOUND_NOT_OBSERVED"
+      }
+    },
+    "economic_research_execution_cost": {
+      "conservative_half_spread_bps": 5.0,
+      "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+      "fee_bps": 10.0,
+      "slippage_bps": 5.0,
+      "spread_model_version": "research_conservative_bps_v1"
+    },
+    "fee_bps": 10.0,
+    "fee_model_version": "backtest_fee_taker_symmetric_v0",
+    "funding": {
+      "bind": true,
+      "model_version": "backtest_funding_perpetual_interval_v1"
+    },
+    "initial_cash": 10000.0,
+    "parameter_sensitivity": {
+      "bind": true,
+      "grid": {
+        "grid_id": "okx_eth_perp_research_cost_grid_v1",
+        "parameter_names": [
+          "fee_bps",
+          "slippage_bps"
+        ],
+        "parameter_values": [
+          [
+            8.0,
+            10.0,
+            12.0
+          ],
+          [
+            4.0,
+            5.0,
+            6.0
+          ]
+        ],
+        "search_space_bounds": {
+          "fee_bps": {
+            "max": 12.0,
+            "min": 8.0
+          },
+          "slippage_bps": {
+            "max": 6.0,
+            "min": 4.0
+          }
+        },
+        "seed": 42
+      },
+      "grid_version": "v1",
+      "policy_version": "parameter_sensitivity_v1"
+    },
+    "slippage_bps": 5.0,
+    "slippage_model_version": "backtest_slippage_symmetric_v0"
+  },
+  "config_schema_version": "step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_v1",
+  "config_version": "v1",
+  "economic_evaluation_v1": {
+    "economic_validity_policy_version": "economic_validity_policy_v1",
+    "engine_signal_source": "configured_strategy_signal",
+    "monte_carlo": {
+      "bind": true,
+      "policy_version": "monte_carlo_v1",
+      "runs": 64,
+      "seed": 42
+    },
+    "parameter_sensitivity_policy_version": "parameter_sensitivity_v1",
+    "research_scope": "bouchaud_microstructure_ohlcv_proxy/v1",
+    "strategy_id": "bouchaud_microstructure",
+    "strategy_params": {
+      "imbalance_threshold": 0.3,
+      "lookback_ticks": 100,
+      "min_liquidity_filter": 1000.0,
+      "propagator_decay": 0.5,
+      "use_orderbook_imbalance": true,
+      "use_trade_signs": true
+    },
+    "strategy_version": "v1",
+    "stress": {
+      "bind": true,
+      "policy_version": "stress_class_suite_v1"
+    },
+    "walk_forward": {
+      "bind": true,
+      "policy_version": "walk_forward_v1",
+      "step_bars": 1440,
+      "test_bars": 1440,
+      "train_bars": 4320
+    }
+  },
+  "offline_evaluation_sizing_contract_v1": {
+    "config_digest": "c0b377c523ccc6ed8c69e0976c36f19ba6d1f5f01080aecd36004f9d87bcddee",
+    "dataset_digest": "b4cbe7fff81a137da055588231757937406d8cb30d531ee0aab41d95ee9b6c78",
+    "initial_equity": 10000.0,
+    "instrument_metadata_source": "versioned_dataset_manifest_v1",
+    "max_position_pct": 0.25,
+    "minimum_notional_policy": "USE_RISK_MIN_POSITION_VALUE_v1",
+    "minimum_quantity_policy": "REJECT_BELOW_MIN_NOTIONAL_v1",
+    "oversize_policy": "REJECT_OVERSIZE",
+    "price_source": "bar_close_v1",
+    "quantity_rounding_policy": "NONE_v1",
+    "risk_per_trade": 0.005,
+    "sizing_contract_version": "offline_evaluation_sizing_contract_v1",
+    "sizing_mode": "fixed_fractional_risk_per_trade_v1",
+    "sizing_owner": "backtest.offline_evaluation_sizing_contract_v1",
+    "stop_distance_policy": "FIXED_PCT_FROM_ENTRY_v1",
+    "stop_pct": 0.025,
+    "stop_pct_derivation_ref": "fleet_precedent:macd_v3_post_risk_limits_rewire",
+    "strategy_params_digest": "bda8f9eb343ce818a1c56e69377c3c10c0c014bcb1f16053b0c897bd0a304b3f"
+  },
+  "real_admissible_futures_evaluation_binding_v1": {
+    "canonical_instrument_id": "inst-eth-usdt-perp",
+    "canonical_trading_logic_version": "integrated_offline_trading_logic_replay_v1",
+    "dataset_path": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/inst-eth-usdt-perp/v1/bars.parquet",
+    "dataset_profile": "economic_research_v1",
+    "effective_entry_cost_bps": 20.0,
+    "effective_exit_cost_bps": 20.0,
+    "execution_model_version": "backtest_execution_v0",
+    "expected_dataset_digest": "b4cbe7fff81a137da055588231757937406d8cb30d531ee0aab41d95ee9b6c78",
+    "expected_l1_observation_status": "EXECUTION_MODEL_BOUND_NOT_OBSERVED",
+    "expected_manifest_digest": "317105798c749943074911b1e9ea91ac9b94fab3b115fb7a64b692339426651a",
+    "native_instrument_id": "ETH-USDT-SWAP",
+    "out_of_sample_period": "2026-06-27 23:36:00+00:00..2026-07-01 10:07:00+00:00",
+    "require_dataset_admissible": true,
+    "require_integrity_pass": true,
+    "require_observed_l1_used_false": true,
+    "roundtrip_cost_bps": 40.0,
+    "source_venue": "OKX",
+    "training_period": "2026-06-17 16:00:00+00:00..2026-06-24 13:03:00+00:00",
+    "validation_period": "2026-06-24 13:04:00+00:00..2026-06-27 23:35:00+00:00"
+  },
+  "research_scope_binding_v1": {
+    "data_class": "FINALIZED_OHLCV_BARS",
+    "depth_data_required": false,
+    "hypothesis_id": "BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1",
+    "l2_data_required": false,
+    "orderbook_data_required": false,
+    "proxy_description": "BAR_LEVEL_PRESSURE_AND_IMPACT_PROXY_USING_FINALIZED_OHLCV_FEATURES",
+    "proxy_semantics": true,
+    "registry_strategy_id": "bouchaud_microstructure",
+    "research_scope": "bouchaud_microstructure_ohlcv_proxy/v1",
+    "tick_data_required": false,
+    "true_tick_l2_microstructure": false
+  },
+  "risk": {
+    "max_position_size": 0.25,
+    "min_position_value": 10.0,
+    "min_stop_distance": 0.0001,
+    "risk_per_trade": 0.005
+  },
+  "step29m_policy_ratification_v1": {
+    "dataset_replacement_allowed": false,
+    "evaluation_authorized": false,
+    "instrument_id": "inst-eth-usdt-perp",
+    "operator_policy_derivation_ref": "operator_policy_decision:STEP29M_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1",
+    "parameter_tuning_allowed": false,
+    "promotion_authorized": false,
+    "research_scope": "bouchaud_microstructure_ohlcv_proxy/v1",
+    "runtime_authorized": false,
+    "sizing_precedent_ref": "fleet_precedent:macd_v3_post_risk_limits_rewire",
+    "strategy_id": "bouchaud_microstructure",
+    "strategy_version": "v1",
+    "threshold_tuning_allowed": false,
+    "venue_id": "okx"
+  }
+}

--- a/config/research/bouchaud_microstructure_ohlcv_proxy_v1_material_difference_and_non_claim_contract_v0.json
+++ b/config/research/bouchaud_microstructure_ohlcv_proxy_v1_material_difference_and_non_claim_contract_v0.json
@@ -1,0 +1,32 @@
+{
+  "artifact_kind": "bouchaud_microstructure_ohlcv_proxy_v1_material_difference_and_non_claim_contract",
+  "artifact_version": "v0",
+  "explicit_non_claims": [
+    "TRUE_TICK_L2_MICROSTRUCTURE=false",
+    "ORDERBOOK_IMBALANCE=false",
+    "DEPTH_IMBALANCE=false",
+    "TICK_LEVEL_IMPACT=false",
+    "ORDER_FLOW_RECONSTRUCTION=false",
+    "REALIZED_EXECUTION_IMPACT_FROM_VENUE_FILLS=false",
+    "PROXY_SEMANTICS=true",
+    "NEW_SIGNAL_FAMILY=true",
+    "TERMINAL_SINGLE_INSTRUMENT_EVIDENCE_SUPERSEDED=false"
+  ],
+  "material_difference_axes": [
+    "SIGNAL_FAMILY=BAR_LEVEL_MICROSTRUCTURE_PRESSURE_PROXY_NOT_DSP_CYCLE_STOCH_VOL_OR_CALENDAR",
+    "DATA_SOURCE=FINALIZED_OHLCV_BARS_SINGLE_INSTRUMENT_NOT_TICK_L2_ORDERBOOK",
+    "RANKING_GEOMETRY=NONE_SINGLE_INSTRUMENT_NOT_CROSS_SECTIONAL_TOP1_ROTATION",
+    "EVALUATION_WIRING=STEP29M_SINGLE_INSTRUMENT_NOT_PANEL_ORCHESTRATOR",
+    "PORTFOLIO_AGGREGATION=DIRECT_SINGLE_SLOT_NOT_MULTI_INSTRUMENT_ROTATION"
+  ],
+  "material_difference_basis": "BAR_LEVEL_OHLCV_MICROSTRUCTURE_PRESSURE_PROXY_SINGLE_INSTRUMENT_NOT_CYCLE_VOL_CALENDAR_OR_TICK_L2",
+  "material_difference_confirmed": true,
+  "material_difference_digest": "34599aa261c9ce32ced00e8000e09e152031ba59d5402d89558488c177a378a2",
+  "near_duplicate_risk": "LOW_WITH_EXPLICIT_PROXY_VERSIONING",
+  "prior_evidence_exclusion_pass": true,
+  "proxy_semantics": true,
+  "schema_version": "bouchaud_microstructure_ohlcv_proxy_v1_material_difference_and_non_claim_contract.v0",
+  "signal_family": "BAR_LEVEL_MICROSTRUCTURE_PRESSURE_PROXY",
+  "signal_family_material_difference": true,
+  "source_discovery_evidence_ref": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/post_armstrong_registry_primary_signal_exhaustion_new_hypothesis_generation_and_capability_gap_classification_read_only_v0_20260710T170020Z"
+}

--- a/config/research/bouchaud_microstructure_ohlcv_proxy_v1_scope_separation_contract_v0.json
+++ b/config/research/bouchaud_microstructure_ohlcv_proxy_v1_scope_separation_contract_v0.json
@@ -1,0 +1,30 @@
+{
+  "artifact_kind": "bouchaud_microstructure_ohlcv_proxy_v1_scope_separation_contract",
+  "artifact_version": "v0",
+  "authority_effect": "NONE",
+  "data_class": "FINALIZED_OHLCV_BARS",
+  "depth_data_required": false,
+  "futures_only": true,
+  "hypothesis_id": "BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1",
+  "l2_data_required": false,
+  "orderbook_data_required": false,
+  "proxy_description": "BAR_LEVEL_PRESSURE_AND_IMPACT_PROXY_USING_FINALIZED_OHLCV_FEATURES",
+  "proxy_semantics": true,
+  "research_scope": "bouchaud_microstructure_ohlcv_proxy/v1",
+  "reserved_non_implemented_scopes": [
+    {
+      "research_scope": "bouchaud_microstructure_tick_l2/v1",
+      "status": "NOT_IMPLEMENTED_DATA_CAPABILITY_MISSING",
+      "tick_data_required": true,
+      "orderbook_data_required": true,
+      "l2_data_required": true,
+      "evaluation_admissible": false,
+      "ratification_allowed": false,
+      "registration_allowed": false
+    }
+  ],
+  "runtime_effect": "NONE",
+  "schema_version": "bouchaud_microstructure_ohlcv_proxy_v1_scope_separation_contract.v0",
+  "tick_data_required": false,
+  "true_tick_l2_microstructure": false
+}

--- a/config/research/bouchaud_microstructure_ohlcv_proxy_v1_versioned_research_binding_v0.json
+++ b/config/research/bouchaud_microstructure_ohlcv_proxy_v1_versioned_research_binding_v0.json
@@ -81,7 +81,7 @@
       },
       "implementation_digest": {
         "status": "BOUND",
-        "value": "bb4ecee4b88a715e9b8e340abb56b4a43668512bd1f060ee4eaa9996c19aeffb"
+        "value": "c36c717694d66e7a147fdccd2a8a7ffeb62c948be47746b335fc8ad5cb4467a9"
       },
       "material_difference_digest": {
         "status": "BOUND",
@@ -150,10 +150,10 @@
   "economic_evaluation_authorized": false,
   "economic_evaluation_executed": false,
   "evaluation_authorized": false,
-  "go_token": "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STEP29M_SINGLE_INSTRUMENT_OFFLINE_EVALUATION_ADAPTER_IMPLEMENTATION_V0",
+  "operator_go_literal": "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STEP29M_SINGLE_INSTRUMENT_OFFLINE_EVALUATION_ADAPTER_IMPLEMENTATION_V0",
   "hypothesis_id": "BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1",
-  "implementation_go_token": "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STEP29M_SINGLE_INSTRUMENT_OFFLINE_EVALUATION_ADAPTER_IMPLEMENTATION_V0",
-  "next_evaluation_go_token": "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_BOUND_OFFLINE_ECONOMIC_BASELINE_EVALUATION_V0",
+  "implementation_operator_go": "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STEP29M_SINGLE_INSTRUMENT_OFFLINE_EVALUATION_ADAPTER_IMPLEMENTATION_V0",
+  "next_evaluation_operator_go": "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_BOUND_OFFLINE_ECONOMIC_BASELINE_EVALUATION_V0",
   "proxy_semantics": true,
   "research_scope": "bouchaud_microstructure_ohlcv_proxy/v1",
   "runtime_effect": "NONE",

--- a/config/research/bouchaud_microstructure_ohlcv_proxy_v1_versioned_research_binding_v0.json
+++ b/config/research/bouchaud_microstructure_ohlcv_proxy_v1_versioned_research_binding_v0.json
@@ -1,0 +1,164 @@
+{
+  "adapter_implementation_status": "COMPLETE",
+  "artifact_kind": "bouchaud_microstructure_ohlcv_proxy_v1_versioned_research_binding",
+  "artifact_version": "v0",
+  "authority_effect": "NONE",
+  "binding": {
+    "baseline_evaluation_contract": {
+      "baseline_count": 1,
+      "baseline_type": "FULL_CANONICAL_OFFLINE_BASELINE_SINGLE_INSTRUMENT",
+      "economic_evaluation_executed_in_this_slice": false,
+      "evidence_class_id": "BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_FULL_CANONICAL_OFFLINE_BASELINE_ECONOMIC_EVALUATION_V0",
+      "parameter_tuning_after_baseline_forbidden": true,
+      "parameter_tuning_during_baseline_forbidden": true
+    },
+    "binding_status": {
+      "baseline_binding_status": "STAGED",
+      "candidate_binding_status": "BOUND",
+      "cost_model_binding_status": "BOUND",
+      "dataset_binding_status": "BOUND",
+      "digest_binding_status": "STAGED",
+      "instrument_binding_status": "BOUND",
+      "numeric_bindings_status": "BOUND",
+      "overall_binding_status": "ADAPTER_IMPLEMENTATION_STAGED",
+      "parameter_binding_status": "BOUND",
+      "period_binding_status": "BOUND",
+      "policy_classes_status": "BOUND",
+      "warmup_binding_status": "BOUND"
+    },
+    "candidate_binding": {
+      "canonical_candidate_identifier": "bouchaud_microstructure_ohlcv_proxy/v1",
+      "canonical_owner": "src/strategies/bouchaud/bouchaud_microstructure_strategy.py",
+      "engine_signal_source": "configured_strategy_signal",
+      "hypothesis_id": "BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1",
+      "implementation_ref": "src.strategies.bouchaud.bouchaud_microstructure_strategy.BouchaudMicrostructureStrategy",
+      "proxy_semantics": true,
+      "registry_class": "oop_strategy_spec",
+      "registry_key": "bouchaud_microstructure",
+      "research_scope": "bouchaud_microstructure_ohlcv_proxy/v1",
+      "signal_family": "BAR_LEVEL_MICROSTRUCTURE_PRESSURE_PROXY",
+      "strategy_id": "bouchaud_microstructure",
+      "strategy_version": "v1",
+      "true_tick_l2_microstructure": false
+    },
+    "cost_execution_binding": {
+      "binding_version": "v0",
+      "execution_model_version": "backtest_execution_v0",
+      "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+      "fee_model_version": "backtest_fee_taker_symmetric_v0",
+      "funding_bind": true,
+      "funding_model_version": "backtest_funding_perpetual_interval_v1",
+      "implicit_zero_cost_forbidden": true,
+      "roundtrip_cost_bps": 40.0,
+      "slippage_model_version": "backtest_slippage_symmetric_v0",
+      "spread_model_version": "research_conservative_bps_v1"
+    },
+    "dataset_binding": {
+      "binding_version": "v1",
+      "canonical_instrument_id": "inst-eth-usdt-perp",
+      "data_class": "FINALIZED_OHLCV_BARS",
+      "dataset_digest": "b4cbe7fff81a137da055588231757937406d8cb30d531ee0aab41d95ee9b6c78",
+      "dataset_id": "inst-eth-usdt-perp_v1",
+      "dataset_path": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/inst-eth-usdt-perp/v1/bars.parquet",
+      "dataset_profile": "economic_research_v1",
+      "dataset_version": "v1",
+      "expected_manifest_digest": "317105798c749943074911b1e9ea91ac9b94fab3b115fb7a64b692339426651a",
+      "native_instrument_id": "ETH-USDT-SWAP",
+      "no_lookahead_semantics": "point_in_time_bar_close_v1",
+      "point_in_time_binding": true,
+      "source_venue": "OKX",
+      "survivorship_bias_forbidden": true,
+      "tick_data_required": false
+    },
+    "digest_bindings": {
+      "config_digest": {
+        "status": "BOUND",
+        "value": "a9c0f1d859855ef406e3f7cdc31e4f71ddf86e18d7e97a0bea2b2d0d1fdd1472"
+      },
+      "data_digest": {
+        "status": "BOUND",
+        "value": "b4cbe7fff81a137da055588231757937406d8cb30d531ee0aab41d95ee9b6c78"
+      },
+      "implementation_digest": {
+        "status": "BOUND",
+        "value": "bb4ecee4b88a715e9b8e340abb56b4a43668512bd1f060ee4eaa9996c19aeffb"
+      },
+      "material_difference_digest": {
+        "status": "BOUND",
+        "value": "34599aa261c9ce32ced00e8000e09e152031ba59d5402d89558488c177a378a2"
+      },
+      "strategy_params_digest": {
+        "status": "BOUND",
+        "value": "bda8f9eb343ce818a1c56e69377c3c10c0c014bcb1f16053b0c897bd0a304b3f"
+      }
+    },
+    "economic_policy_binding": {
+      "binding_version": "v1",
+      "economic_validity_policy_version": "economic_validity_policy_v1",
+      "minimum_trade_count_policy_bound": true,
+      "promising_is_not_pass_bound": true
+    },
+    "external_bindings": {
+      "adapter_owner_ref": {
+        "ref": "src/research/bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py",
+        "status": "BOUND"
+      },
+      "admissibility_contract_ref": {
+        "ref": "src/backtest/step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1.py",
+        "status": "BOUND"
+      },
+      "evaluation_config_ref": {
+        "ref": "config/ops/step29m_okx_inst_eth_usdt_perp_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_v1.json",
+        "status": "BOUND"
+      },
+      "material_difference_contract_ref": {
+        "ref": "config/research/bouchaud_microstructure_ohlcv_proxy_v1_material_difference_and_non_claim_contract_v0.json",
+        "status": "BOUND"
+      },
+      "scope_separation_contract_ref": {
+        "ref": "config/research/bouchaud_microstructure_ohlcv_proxy_v1_scope_separation_contract_v0.json",
+        "status": "BOUND"
+      },
+      "strategy_signal_binding_owner": {
+        "status": "BOUND",
+        "value": "backtest.strategy_signal_binding_v1"
+      }
+    },
+    "instrument_binding": {
+      "binding_version": "v0",
+      "bitcoin_direction_allowed": false,
+      "canonical_instrument_id": "inst-eth-usdt-perp",
+      "futures_only": true,
+      "native_instrument_id": "ETH-USDT-SWAP",
+      "source_venue": "OKX",
+      "spot_allowed": false,
+      "synthetic_spot_allowed": false
+    },
+    "period_binding": {
+      "binding_version": "v0",
+      "data_period": "2026-06-17 16:00:00+00:00..2026-07-01 10:07:00+00:00",
+      "out_of_sample_period": "2026-06-27 23:36:00+00:00..2026-07-01 10:07:00+00:00",
+      "training_period": "2026-06-17 16:00:00+00:00..2026-06-24 13:03:00+00:00",
+      "validation_period": "2026-06-24 13:04:00+00:00..2026-06-27 23:35:00+00:00"
+    },
+    "warmup_binding": {
+      "binding_version": "v0",
+      "required_warmup_rows": 100
+    }
+  },
+  "candidate_id": "bouchaud_microstructure_ohlcv_proxy/v1",
+  "economic_evaluation_authorized": false,
+  "economic_evaluation_executed": false,
+  "evaluation_authorized": false,
+  "go_token": "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STEP29M_SINGLE_INSTRUMENT_OFFLINE_EVALUATION_ADAPTER_IMPLEMENTATION_V0",
+  "hypothesis_id": "BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1",
+  "implementation_go_token": "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STEP29M_SINGLE_INSTRUMENT_OFFLINE_EVALUATION_ADAPTER_IMPLEMENTATION_V0",
+  "next_evaluation_go_token": "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_BOUND_OFFLINE_ECONOMIC_BASELINE_EVALUATION_V0",
+  "proxy_semantics": true,
+  "research_scope": "bouchaud_microstructure_ohlcv_proxy/v1",
+  "runtime_effect": "NONE",
+  "schema_version": "bouchaud_microstructure_ohlcv_proxy_v1_versioned_research_binding.v0",
+  "selection_mode": "single_instrument_prebound",
+  "source_discovery_evidence_ref": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/post_armstrong_registry_primary_signal_exhaustion_new_hypothesis_generation_and_capability_gap_classification_read_only_v0_20260710T170020Z",
+  "true_tick_l2_microstructure": false
+}

--- a/scripts/ops/invoke_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py
+++ b/scripts/ops/invoke_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Canonical invocation adapter for bouchaud OHLCV proxy v1 STEP29M adapter runner.
+
+Offline-only. Forwards implementation GO token to adapter runner. No economic
+evaluation logic is owned here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.offline_evaluation_runner_invocation_contract_v0 import (  # noqa: E402
+    RUNNER_INVOCATION_CONTRACT_PASS,
+    emit_invocation_contract_failure_v0,
+    invoke_bound_offline_evaluation_runner_v0,
+    read_confirm_go_token_from_env_v0,
+)
+
+RUNNER_REL_PATH = (
+    "scripts/ops/run_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_"
+    "offline_evaluation_adapter_v0.py"
+)
+
+
+def main() -> None:
+    confirm_go_token, token_reason, token_exit = read_confirm_go_token_from_env_v0()
+    if token_reason != RUNNER_INVOCATION_CONTRACT_PASS:
+        emit_invocation_contract_failure_v0(token_reason)
+        raise SystemExit(token_exit)
+
+    exit_code, reason_code = invoke_bound_offline_evaluation_runner_v0(
+        repo_root=_REPO_ROOT,
+        runner_rel_path=RUNNER_REL_PATH,
+        confirm_go_token=confirm_go_token,
+    )
+    if reason_code != RUNNER_INVOCATION_CONTRACT_PASS:
+        emit_invocation_contract_failure_v0(reason_code)
+        raise SystemExit(exit_code)
+    raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ops/run_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py
+++ b/scripts/ops/run_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py
@@ -43,19 +43,20 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    go_result = classify_go_token_v0(args.confirm_go_token)
+    operator_go = args.confirm_go_token
+    go_result = classify_go_token_v0(operator_go)
     if go_result.classification.value == "REJECTED":
         raise SystemExit(f"ERR: {go_result.blocking_reasons[0]}")
 
-    if args.confirm_go_token == EVALUATION_GO_TOKEN:
+    if operator_go == EVALUATION_GO_TOKEN:
         raise SystemExit("ERR: evaluation_go_blocked_in_implementation_slice")
 
-    if args.confirm_go_token != IMPLEMENTATION_GO_TOKEN:
-        raise SystemExit(f"ERR: invalid_go_token:{args.confirm_go_token}")
+    if operator_go != IMPLEMENTATION_GO_TOKEN:
+        raise SystemExit(f"ERR: invalid_go_token:{operator_go}")
 
     result = run_adapter_implementation_v0(
         repo_root=args.repo_root,
-        confirm_go_token=args.confirm_go_token,
+        confirm_operator_go=operator_go,
     )
     print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
 

--- a/scripts/ops/run_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py
+++ b/scripts/ops/run_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""STEP29M single-instrument offline evaluation adapter runner for bouchaud OHLCV proxy v1.
+
+Implementation slice only: validates contracts and materializes adapter evidence.
+Blocks economic evaluation unless separate evaluation GO is provided (also blocked here).
+No runtime, credentials, orders, or authority effect.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.research.bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0 import (  # noqa: E402
+    EVALUATION_GO_TOKEN,
+    IMPLEMENTATION_GO_TOKEN,
+    classify_go_token_v0,
+    run_adapter_implementation_v0,
+)
+
+RUNNER_OWNER = (
+    "scripts.ops.run_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_"
+    "offline_evaluation_adapter_v0"
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm-go-token", required=True)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument(
+        "--durable-evidence-root",
+        type=Path,
+        default=Path(
+            "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+        ),
+    )
+    args = parser.parse_args()
+
+    go_result = classify_go_token_v0(args.confirm_go_token)
+    if go_result.classification.value == "REJECTED":
+        raise SystemExit(f"ERR: {go_result.blocking_reasons[0]}")
+
+    if args.confirm_go_token == EVALUATION_GO_TOKEN:
+        raise SystemExit("ERR: evaluation_go_blocked_in_implementation_slice")
+
+    if args.confirm_go_token != IMPLEMENTATION_GO_TOKEN:
+        raise SystemExit(f"ERR: invalid_go_token:{args.confirm_go_token}")
+
+    result = run_adapter_implementation_v0(
+        repo_root=args.repo_root,
+        confirm_go_token=args.confirm_go_token,
+    )
+    print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backtest/step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1.py
@@ -1,0 +1,543 @@
+"""
+STEP 29M bouchaud_microstructure_ohlcv_proxy v1 economic evaluation admissibility contract v1.
+
+Read-only contract diagnostics for operator-ratified fixed-config policy,
+parameter binding, sizing invariants, signal-binding provenance, proxy scope
+separation, and staged config readiness. No economic evaluation execution.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 import (
+    compute_evaluation_config_digest_v1,
+    verify_cost_binding_v1,
+)
+from src.backtest.strategy_signal_binding_v1 import (
+    ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    StrategySignalBindingError,
+    collect_configured_strategy_params_v1,
+    compute_required_warmup_rows_v1,
+    project_strategy_params_for_binding_v1,
+    resolve_effective_strategy_params_v1,
+)
+from src.strategies.registry import get_strategy_registry_entry, resolve_strategy_id
+
+CONTRACT_LAYER_VERSION = "v1"
+CONTRACT_OWNER = "backtest.step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1"
+
+RESEARCH_SCOPE = "bouchaud_microstructure_ohlcv_proxy/v1"
+HYPOTHESIS_ID = "BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1"
+REGISTRY_STRATEGY_ID = "bouchaud_microstructure"
+BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STRATEGY_VERSION = "v1"
+BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STRATEGY_OWNER = (
+    "src.strategies.bouchaud.bouchaud_microstructure_strategy.BouchaudMicrostructureStrategy"
+)
+
+BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_CANONICAL_PARAMS = {
+    "lookback_ticks": 100,
+    "imbalance_threshold": 0.3,
+    "use_orderbook_imbalance": True,
+    "use_trade_signs": True,
+    "min_liquidity_filter": 1000.0,
+    "propagator_decay": 0.5,
+}
+BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_REQUIRED_WARMUP_ROWS = 100
+
+LOOKBACK_TICKS_MIN = 1
+LOOKBACK_TICKS_MAX = 500
+IMBALANCE_THRESHOLD_MIN = -1.0
+IMBALANCE_THRESHOLD_MAX = 1.0
+
+EXCLUDED_BINDING_PARAMS = frozenset()
+
+OPERATOR_RATIFIED_RISK_PER_TRADE = 0.005
+OPERATOR_RATIFIED_STOP_PCT = 0.025
+OPERATOR_RATIFIED_MAX_POSITION_PCT = 0.25
+OFFLINE_BOUND_OVERSIZE_POLICY = "REJECT_OVERSIZE"
+POLICY_INVARIANT = "risk_per_trade <= max_position_pct * stop_pct"
+POLICY_INVARIANT_RESULT = "0.005 <= 0.25 * 0.025 = 0.00625"
+OPERATOR_POLICY_DERIVATION_REF = (
+    "operator_policy_decision:STEP29M_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1"
+)
+FLEET_SIZING_PRECEDENT_REF = "fleet_precedent:macd_v3_post_risk_limits_rewire"
+
+DEFAULT_EVALUATION_CONFIG_PATH = (
+    "config/ops/step29m_okx_inst_eth_usdt_perp_bouchaud_microstructure_ohlcv_proxy_v1_"
+    "economic_evaluation_v1.json"
+)
+CONFIG_SCHEMA_VERSION = (
+    "step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_v1"
+)
+
+IMPLEMENTATION_GO_TOKEN = (
+    "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STEP29M_SINGLE_INSTRUMENT_"
+    "OFFLINE_EVALUATION_ADAPTER_IMPLEMENTATION_V0"
+)
+EVALUATION_GO_TOKEN = (
+    "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_BOUND_OFFLINE_ECONOMIC_BASELINE_EVALUATION_V0"
+)
+
+STEP29M_REGISTERED_ECONOMIC_EVALUATION_CONFIGS_V1: tuple[str, ...] = (
+    DEFAULT_EVALUATION_CONFIG_PATH,
+)
+
+_FORBIDDEN_INSTRUMENT_SUBSTRINGS = frozenset({"btc", "xbt", "bitcoin", "spot", "synthetic_spot"})
+
+RATIFICATION_SLICE_SAFETY_FLAGS: dict[str, Any] = {
+    "futures_only": True,
+    "bitcoin_direction_allowed": False,
+    "spot_allowed": False,
+    "synthetic_spot_allowed": False,
+    "fixed_config_required": True,
+    "parameter_tuning_allowed": False,
+    "parameter_search_allowed": False,
+    "dataset_change_allowed": False,
+    "policy_threshold_change_allowed": False,
+    "productive_runner_invocations_allowed": 0,
+    "economic_evaluation_allowed": False,
+    "promotion_allowed": False,
+    "runtime_effect": False,
+    "order_effect": False,
+    "profitability_claim_allowed": False,
+    "proxy_semantics": True,
+    "true_tick_l2_microstructure": False,
+}
+
+
+class AdmissibilityResult(str, Enum):
+    PASS = "PASS"
+    BLOCKED = "BLOCKED"
+
+
+@dataclass(frozen=True)
+class BouchaudMicrostructureOhlcvProxyV1AdmissibilityContractResultV1:
+    admissibility_result: AdmissibilityResult
+    blocking_reasons: tuple[str, ...]
+    research_scope: str
+    hypothesis_id: str
+    strategy_id: str
+    strategy_version: str
+    strategy_owner: str
+    configured_strategy_params: dict[str, Any]
+    effective_strategy_params: dict[str, Any]
+    strategy_params_digest: str
+    evaluation_config_path: str
+    config_digest: str
+    config_schema_version: str
+    cost_binding_status: str
+    policy_invariant_result: str
+    signal_semantics: str
+    required_warmup_rows: int
+    proxy_semantics: bool
+    true_tick_l2_microstructure: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "admissibility_result": self.admissibility_result.value,
+            "blocking_reasons": list(self.blocking_reasons),
+            "research_scope": self.research_scope,
+            "hypothesis_id": self.hypothesis_id,
+            "strategy_id": self.strategy_id,
+            "strategy_version": self.strategy_version,
+            "strategy_owner": self.strategy_owner,
+            "configured_strategy_params": self.configured_strategy_params,
+            "effective_strategy_params": self.effective_strategy_params,
+            "strategy_params_digest": self.strategy_params_digest,
+            "evaluation_config_path": self.evaluation_config_path,
+            "config_digest": self.config_digest,
+            "config_schema_version": self.config_schema_version,
+            "cost_binding_status": self.cost_binding_status,
+            "policy_invariant_result": self.policy_invariant_result,
+            "signal_semantics": self.signal_semantics,
+            "required_warmup_rows": self.required_warmup_rows,
+            "proxy_semantics": self.proxy_semantics,
+            "true_tick_l2_microstructure": self.true_tick_l2_microstructure,
+        }
+
+
+def list_step29m_registered_economic_evaluation_configs_v1() -> tuple[str, ...]:
+    return STEP29M_REGISTERED_ECONOMIC_EVALUATION_CONFIGS_V1
+
+
+def load_bouchaud_microstructure_ohlcv_proxy_v1_evaluation_config_v1(
+    repo_root: Path,
+    config_path: Optional[str] = None,
+) -> dict[str, Any]:
+    rel = config_path or DEFAULT_EVALUATION_CONFIG_PATH
+    path = repo_root / rel
+    if not path.is_file():
+        raise FileNotFoundError(f"evaluation_config_not_found:{path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("evaluation_config_not_object")
+    return payload
+
+
+def verify_bouchaud_microstructure_ohlcv_proxy_v1_strategy_identity_v1() -> tuple[str, ...]:
+    reasons: list[str] = []
+    resolution = resolve_strategy_id(REGISTRY_STRATEGY_ID)
+    if resolution.canonical_strategy_id != REGISTRY_STRATEGY_ID:
+        reasons.append("strategy_id_not_canonical")
+    entry = get_strategy_registry_entry(REGISTRY_STRATEGY_ID)
+    if entry.strategy_version != BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STRATEGY_VERSION:
+        reasons.append("strategy_version_mismatch")
+    if entry.implementation_ref != BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STRATEGY_OWNER:
+        reasons.append("strategy_owner_mismatch")
+    if not entry.futures_compatible:
+        reasons.append("strategy_not_futures_compatible")
+    if entry.spot_compatible:
+        reasons.append("strategy_spot_compatible_true")
+    lowered = entry.strategy_id.lower()
+    if "btc" in lowered or "xbt" in lowered:
+        reasons.append("strategy_btc_specialization")
+    return tuple(reasons)
+
+
+def verify_bouchaud_microstructure_ohlcv_proxy_v1_scope_binding_v1(
+    cfg: Mapping[str, Any],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    scope_binding = cfg.get("research_scope_binding_v1")
+    if not isinstance(scope_binding, Mapping):
+        return ("research_scope_binding_v1_missing",)
+
+    if scope_binding.get("research_scope") != RESEARCH_SCOPE:
+        reasons.append("research_scope_mismatch")
+    if scope_binding.get("hypothesis_id") != HYPOTHESIS_ID:
+        reasons.append("hypothesis_id_mismatch")
+    if scope_binding.get("data_class") != "FINALIZED_OHLCV_BARS":
+        reasons.append("data_class_mismatch")
+    if scope_binding.get("proxy_semantics") is not True:
+        reasons.append("proxy_semantics_not_true")
+    if scope_binding.get("true_tick_l2_microstructure") is not False:
+        reasons.append("true_tick_l2_microstructure_not_false")
+    for flag in (
+        "tick_data_required",
+        "orderbook_data_required",
+        "depth_data_required",
+        "l2_data_required",
+    ):
+        if scope_binding.get(flag) is not False:
+            reasons.append(f"{flag}_not_false")
+    if scope_binding.get("registry_strategy_id") != REGISTRY_STRATEGY_ID:
+        reasons.append("registry_strategy_id_mismatch")
+    return tuple(reasons)
+
+
+def verify_bouchaud_microstructure_ohlcv_proxy_v1_go_token_policy_v1(
+    go_token: Optional[str],
+) -> tuple[str, ...]:
+    if go_token is None:
+        return ()
+    if go_token == IMPLEMENTATION_GO_TOKEN:
+        return ("implementation_go_cannot_authorize_evaluation",)
+    if go_token == EVALUATION_GO_TOKEN:
+        return ()
+    return (f"invalid_go_token:{go_token}",)
+
+
+def verify_evaluation_go_token_accepted_for_validation_only_v1(go_token: str) -> bool:
+    return go_token == EVALUATION_GO_TOKEN
+
+
+def _validate_integer_window_v1(
+    name: str,
+    value: Any,
+    *,
+    minimum: int,
+    maximum: int,
+) -> tuple[Optional[int], tuple[str, ...]]:
+    if value is None:
+        return None, (f"{name}_missing",)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, (f"{name}_not_integer",)
+    if value < minimum or value > maximum:
+        return None, (f"{name}_out_of_range",)
+    return value, ()
+
+
+def _validate_float_window_v1(
+    name: str,
+    value: Any,
+    *,
+    minimum: float,
+    maximum: float,
+) -> tuple[Optional[float], tuple[str, ...]]:
+    if value is None:
+        return None, (f"{name}_missing",)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None, (f"{name}_not_numeric",)
+    if float(value) < minimum or float(value) > maximum:
+        return None, (f"{name}_out_of_range",)
+    return float(value), ()
+
+
+def verify_bouchaud_microstructure_ohlcv_proxy_v1_strategy_params_v1(
+    configured: Mapping[str, Any],
+    effective: Mapping[str, Any],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if set(configured.keys()) - set(BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_CANONICAL_PARAMS):
+        reasons.append("unknown_configured_strategy_param")
+    if EXCLUDED_BINDING_PARAMS & set(configured.keys()):
+        reasons.append("excluded_binding_param_present")
+    if set(effective.keys()) != set(BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_CANONICAL_PARAMS):
+        reasons.append("unknown_effective_strategy_param")
+    for key, expected in BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_CANONICAL_PARAMS.items():
+        if effective.get(key) != expected:
+            reasons.append(f"{key}_not_canonical")
+
+    _, lookback_reasons = _validate_integer_window_v1(
+        "lookback_ticks",
+        effective.get("lookback_ticks"),
+        minimum=LOOKBACK_TICKS_MIN,
+        maximum=LOOKBACK_TICKS_MAX,
+    )
+    reasons.extend(lookback_reasons)
+    _, threshold_reasons = _validate_float_window_v1(
+        "imbalance_threshold",
+        effective.get("imbalance_threshold"),
+        minimum=IMBALANCE_THRESHOLD_MIN,
+        maximum=IMBALANCE_THRESHOLD_MAX,
+    )
+    reasons.extend(threshold_reasons)
+    return tuple(reasons)
+
+
+def verify_bouchaud_microstructure_ohlcv_proxy_v1_sizing_policy_v1(
+    cfg: Mapping[str, Any],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    sizing = cfg.get("offline_evaluation_sizing_contract_v1")
+    if not isinstance(sizing, Mapping):
+        return ("offline_evaluation_sizing_contract_v1_missing",)
+
+    risk = sizing.get("risk_per_trade")
+    stop_pct = sizing.get("stop_pct")
+    max_position_pct = sizing.get("max_position_pct")
+    oversize_policy = sizing.get("oversize_policy")
+
+    if risk != OPERATOR_RATIFIED_RISK_PER_TRADE:
+        reasons.append("risk_per_trade_not_ratified")
+    if stop_pct != OPERATOR_RATIFIED_STOP_PCT:
+        reasons.append("stop_pct_not_ratified")
+    if max_position_pct != OPERATOR_RATIFIED_MAX_POSITION_PCT:
+        reasons.append("max_position_pct_not_ratified")
+    if oversize_policy != OFFLINE_BOUND_OVERSIZE_POLICY:
+        reasons.append("oversize_policy_not_reject")
+    if not isinstance(risk, (int, float)) or float(risk) <= 0:
+        reasons.append("risk_per_trade_non_positive")
+    if not isinstance(stop_pct, (int, float)) or float(stop_pct) <= 0:
+        reasons.append("stop_pct_non_positive")
+    if not isinstance(max_position_pct, (int, float)) or float(max_position_pct) <= 0:
+        reasons.append("max_position_pct_non_positive")
+    if isinstance(risk, (int, float)) and isinstance(stop_pct, (int, float)):
+        if isinstance(max_position_pct, (int, float)):
+            if float(risk) > float(max_position_pct) * float(stop_pct):
+                reasons.append("policy_invariant_violation")
+    if sizing.get("stop_pct_derivation_ref") != FLEET_SIZING_PRECEDENT_REF:
+        reasons.append("stop_pct_derivation_ref_not_fleet_precedent")
+    return tuple(reasons)
+
+
+def verify_bouchaud_microstructure_ohlcv_proxy_v1_instrument_binding_v1(
+    cfg: Mapping[str, Any],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    binding = cfg.get("real_admissible_futures_evaluation_binding_v1")
+    if not isinstance(binding, Mapping):
+        return ("real_admissible_futures_evaluation_binding_v1_missing",)
+
+    instrument_id = str(binding.get("canonical_instrument_id", ""))
+    if instrument_id != "inst-eth-usdt-perp":
+        reasons.append("instrument_id_mismatch")
+    venue = str(binding.get("source_venue", ""))
+    if venue != "OKX":
+        reasons.append("source_venue_mismatch")
+    native = str(binding.get("native_instrument_id", ""))
+    lowered = f"{instrument_id} {native} {venue}".lower()
+    for forbidden in _FORBIDDEN_INSTRUMENT_SUBSTRINGS:
+        if forbidden in lowered:
+            reasons.append(f"forbidden_instrument_binding:{forbidden}")
+    if binding.get("roundtrip_cost_bps") != 40.0:
+        reasons.append("roundtrip_cost_bps_not_ratified")
+    return tuple(reasons)
+
+
+def verify_bouchaud_microstructure_ohlcv_proxy_v1_ratification_authority_v1(
+    cfg: Mapping[str, Any],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    ratification = cfg.get("step29m_policy_ratification_v1")
+    if not isinstance(ratification, Mapping):
+        return ("step29m_policy_ratification_v1_missing",)
+
+    expected_false = (
+        "evaluation_authorized",
+        "promotion_authorized",
+        "runtime_authorized",
+        "parameter_tuning_allowed",
+        "threshold_tuning_allowed",
+        "dataset_replacement_allowed",
+    )
+    for field in expected_false:
+        if ratification.get(field) is not False:
+            reasons.append(f"{field}_not_false")
+
+    if ratification.get("instrument_id") != "inst-eth-usdt-perp":
+        reasons.append("ratification_instrument_id_mismatch")
+    if ratification.get("strategy_id") != REGISTRY_STRATEGY_ID:
+        reasons.append("ratification_strategy_id_mismatch")
+    if (
+        ratification.get("strategy_version")
+        != BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STRATEGY_VERSION
+    ):
+        reasons.append("ratification_strategy_version_mismatch")
+    if ratification.get("research_scope") != RESEARCH_SCOPE:
+        reasons.append("ratification_research_scope_mismatch")
+    if ratification.get("venue_id") != "okx":
+        reasons.append("ratification_venue_id_mismatch")
+    if ratification.get("operator_policy_derivation_ref") != OPERATOR_POLICY_DERIVATION_REF:
+        reasons.append("operator_policy_derivation_ref_mismatch")
+    if ratification.get("sizing_precedent_ref") != FLEET_SIZING_PRECEDENT_REF:
+        reasons.append("sizing_precedent_ref_mismatch")
+    return tuple(reasons)
+
+
+def verify_bouchaud_microstructure_ohlcv_proxy_v1_config_schema_v1(
+    cfg: Mapping[str, Any],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if cfg.get("config_schema_version") != CONFIG_SCHEMA_VERSION:
+        reasons.append("config_schema_version_mismatch")
+
+    eval_section = cfg.get("economic_evaluation_v1")
+    if not isinstance(eval_section, Mapping):
+        return ("economic_evaluation_v1_missing",)
+    if eval_section.get("strategy_id") != REGISTRY_STRATEGY_ID:
+        reasons.append("config_strategy_id_mismatch")
+    if (
+        eval_section.get("strategy_version")
+        != BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STRATEGY_VERSION
+    ):
+        reasons.append("config_strategy_version_mismatch")
+    if eval_section.get("research_scope") != RESEARCH_SCOPE:
+        reasons.append("config_research_scope_mismatch")
+    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+        reasons.append("engine_signal_source_not_bound")
+    if eval_section.get("economic_validity_policy_version") != "economic_validity_policy_v1":
+        reasons.append("economic_validity_policy_version_mismatch")
+
+    strategy_params = eval_section.get("strategy_params")
+    if not isinstance(strategy_params, Mapping):
+        reasons.append("strategy_params_missing")
+    else:
+        if EXCLUDED_BINDING_PARAMS & set(strategy_params.keys()):
+            reasons.append("excluded_binding_param_in_config")
+        _, lookback_reasons = _validate_integer_window_v1(
+            "lookback_ticks",
+            strategy_params.get("lookback_ticks"),
+            minimum=LOOKBACK_TICKS_MIN,
+            maximum=LOOKBACK_TICKS_MAX,
+        )
+        reasons.extend(lookback_reasons)
+        if set(strategy_params.keys()) != set(
+            BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_CANONICAL_PARAMS
+        ):
+            reasons.append("unknown_strategy_params_in_config")
+
+    return tuple(reasons)
+
+
+def verify_bouchaud_microstructure_ohlcv_proxy_v1_signal_binding_v1(
+    cfg: Mapping[str, Any],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    configured = collect_configured_strategy_params_v1(cfg, REGISTRY_STRATEGY_ID)
+    try:
+        effective, _ = resolve_effective_strategy_params_v1(
+            REGISTRY_STRATEGY_ID,
+            project_strategy_params_for_binding_v1(
+                REGISTRY_STRATEGY_ID,
+                configured,
+            ),
+        )
+        warmup = compute_required_warmup_rows_v1(REGISTRY_STRATEGY_ID, effective)
+        if warmup != BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_REQUIRED_WARMUP_ROWS:
+            reasons.append("warmup_not_equal_to_required_rows")
+    except StrategySignalBindingError as exc:
+        reasons.append(str(exc))
+    return tuple(reasons)
+
+
+def evaluate_bouchaud_microstructure_ohlcv_proxy_v1_admissibility_contract_v1(
+    *,
+    repo_root: Path,
+    config_path: Optional[str] = None,
+    go_token: Optional[str] = None,
+) -> BouchaudMicrostructureOhlcvProxyV1AdmissibilityContractResultV1:
+    blocking: list[str] = []
+    rel_path = config_path or DEFAULT_EVALUATION_CONFIG_PATH
+    cfg = load_bouchaud_microstructure_ohlcv_proxy_v1_evaluation_config_v1(repo_root, rel_path)
+    config_digest = compute_evaluation_config_digest_v1(cfg)
+
+    blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_strategy_identity_v1())
+    blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_scope_binding_v1(cfg))
+    blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_config_schema_v1(cfg))
+    blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_sizing_policy_v1(cfg))
+    blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_instrument_binding_v1(cfg))
+    blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_ratification_authority_v1(cfg))
+    blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_signal_binding_v1(cfg))
+    blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_go_token_policy_v1(go_token))
+
+    cost_status, cost_reasons = verify_cost_binding_v1(cfg)
+    blocking.extend(cost_reasons)
+
+    configured = collect_configured_strategy_params_v1(cfg, REGISTRY_STRATEGY_ID)
+    try:
+        effective, params_digest = resolve_effective_strategy_params_v1(
+            REGISTRY_STRATEGY_ID,
+            project_strategy_params_for_binding_v1(
+                REGISTRY_STRATEGY_ID,
+                configured,
+            ),
+        )
+        warmup = compute_required_warmup_rows_v1(REGISTRY_STRATEGY_ID, effective)
+    except StrategySignalBindingError as exc:
+        blocking.append(str(exc))
+        effective = dict(BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_CANONICAL_PARAMS)
+        params_digest = ""
+        warmup = BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_REQUIRED_WARMUP_ROWS
+
+    blocking.extend(
+        verify_bouchaud_microstructure_ohlcv_proxy_v1_strategy_params_v1(configured, effective)
+    )
+
+    admissibility = AdmissibilityResult.PASS if not blocking else AdmissibilityResult.BLOCKED
+    return BouchaudMicrostructureOhlcvProxyV1AdmissibilityContractResultV1(
+        admissibility_result=admissibility,
+        blocking_reasons=tuple(sorted(set(blocking))),
+        research_scope=RESEARCH_SCOPE,
+        hypothesis_id=HYPOTHESIS_ID,
+        strategy_id=REGISTRY_STRATEGY_ID,
+        strategy_version=BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STRATEGY_VERSION,
+        strategy_owner=BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STRATEGY_OWNER,
+        configured_strategy_params=dict(configured),
+        effective_strategy_params=dict(effective),
+        strategy_params_digest=params_digest,
+        evaluation_config_path=rel_path,
+        config_digest=config_digest,
+        config_schema_version=str(cfg.get("config_schema_version", "")),
+        cost_binding_status=cost_status,
+        policy_invariant_result=POLICY_INVARIANT_RESULT,
+        signal_semantics="LONG_FLAT_0_1",
+        required_warmup_rows=warmup,
+        proxy_semantics=True,
+        true_tick_l2_microstructure=False,
+    )

--- a/src/backtest/step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1.py
@@ -231,19 +231,19 @@ def verify_bouchaud_microstructure_ohlcv_proxy_v1_scope_binding_v1(
 
 
 def verify_bouchaud_microstructure_ohlcv_proxy_v1_go_token_policy_v1(
-    go_token: Optional[str],
+    operator_go: Optional[str],
 ) -> tuple[str, ...]:
-    if go_token is None:
+    if operator_go is None:
         return ()
-    if go_token == IMPLEMENTATION_GO_TOKEN:
+    if operator_go == IMPLEMENTATION_GO_TOKEN:
         return ("implementation_go_cannot_authorize_evaluation",)
-    if go_token == EVALUATION_GO_TOKEN:
+    if operator_go == EVALUATION_GO_TOKEN:
         return ()
-    return (f"invalid_go_token:{go_token}",)
+    return (f"invalid_go_token:{operator_go}",)
 
 
-def verify_evaluation_go_token_accepted_for_validation_only_v1(go_token: str) -> bool:
-    return go_token == EVALUATION_GO_TOKEN
+def verify_evaluation_go_token_accepted_for_validation_only_v1(operator_go: str) -> bool:
+    return operator_go == EVALUATION_GO_TOKEN
 
 
 def _validate_integer_window_v1(
@@ -480,7 +480,7 @@ def evaluate_bouchaud_microstructure_ohlcv_proxy_v1_admissibility_contract_v1(
     *,
     repo_root: Path,
     config_path: Optional[str] = None,
-    go_token: Optional[str] = None,
+    operator_go: Optional[str] = None,
 ) -> BouchaudMicrostructureOhlcvProxyV1AdmissibilityContractResultV1:
     blocking: list[str] = []
     rel_path = config_path or DEFAULT_EVALUATION_CONFIG_PATH
@@ -494,7 +494,7 @@ def evaluate_bouchaud_microstructure_ohlcv_proxy_v1_admissibility_contract_v1(
     blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_instrument_binding_v1(cfg))
     blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_ratification_authority_v1(cfg))
     blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_signal_binding_v1(cfg))
-    blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_go_token_policy_v1(go_token))
+    blocking.extend(verify_bouchaud_microstructure_ohlcv_proxy_v1_go_token_policy_v1(operator_go))
 
     cost_status, cost_reasons = verify_cost_binding_v1(cfg)
     blocking.extend(cost_reasons)

--- a/src/backtest/strategy_signal_binding_v1.py
+++ b/src/backtest/strategy_signal_binding_v1.py
@@ -107,6 +107,14 @@ _EXTERNAL_PARAMETER_SCHEMA_V1: dict[str, dict[str, Any]] = {
         "reference_date": "2015-10-01",
         "phase_position_map": "default",
     },
+    "bouchaud_microstructure": {
+        "lookback_ticks": 100,
+        "imbalance_threshold": 0.3,
+        "use_orderbook_imbalance": True,
+        "use_trade_signs": True,
+        "min_liquidity_filter": 1000.0,
+        "propagator_decay": 0.5,
+    },
 }
 
 COMPOSITE_STRATEGY_ID = "composite"
@@ -775,6 +783,17 @@ def compute_required_warmup_rows_v1(
         if event_window_raw < 1 or event_window_raw >= cycle_length_raw // 2:
             raise StrategySignalBindingError("armstrong_cycle_warmup_param_invariant_failed")
         return 0
+    if strategy_id == "bouchaud_microstructure":
+        lookback_raw = effective_params.get("lookback_ticks")
+        if lookback_raw is None:
+            raise StrategySignalBindingError("bouchaud_microstructure_lookback_ticks_missing")
+        if isinstance(lookback_raw, bool) or not isinstance(lookback_raw, int):
+            raise StrategySignalBindingError("bouchaud_microstructure_lookback_ticks_not_integer")
+        if lookback_raw < 1:
+            raise StrategySignalBindingError(
+                "bouchaud_microstructure_warmup_param_invariant_failed"
+            )
+        return lookback_raw
     if strategy_id == COMPOSITE_STRATEGY_ID:
         raise StrategySignalBindingError("composite_warmup_requires_binding_context")
     raise StrategySignalBindingError(f"required_warmup_rows_unbound:{strategy_id}")

--- a/src/research/bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py
+++ b/src/research/bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py
@@ -141,15 +141,15 @@ class AdapterMaterializationResultV0:
         }
 
 
-def classify_go_token_v0(go_token: str) -> GoTokenValidationResultV0:
-    if go_token in ALLOWED_IMPLEMENTATION_GO_TOKENS:
+def classify_go_token_v0(operator_go: str) -> GoTokenValidationResultV0:
+    if operator_go in ALLOWED_IMPLEMENTATION_GO_TOKENS:
         return GoTokenValidationResultV0(
             classification=GoTokenClassification.IMPLEMENTATION,
             accepted_for_validation_only=True,
             execution_mode=AdapterExecutionMode.IMPLEMENTATION_ONLY,
             blocking_reasons=(),
         )
-    if go_token in ALLOWED_EVALUATION_GO_TOKENS:
+    if operator_go in ALLOWED_EVALUATION_GO_TOKENS:
         return GoTokenValidationResultV0(
             classification=GoTokenClassification.EVALUATION,
             accepted_for_validation_only=True,
@@ -160,7 +160,7 @@ def classify_go_token_v0(go_token: str) -> GoTokenValidationResultV0:
         classification=GoTokenClassification.REJECTED,
         accepted_for_validation_only=False,
         execution_mode=AdapterExecutionMode.EVALUATION_BLOCKED,
-        blocking_reasons=(f"invalid_go_token:{go_token}",),
+        blocking_reasons=(f"invalid_go_token:{operator_go}",),
     )
 
 
@@ -220,7 +220,7 @@ def verify_tick_l2_scope_rejected_v0(research_scope: str) -> tuple[str, ...]:
 def run_adapter_implementation_v0(
     *,
     repo_root: Path,
-    confirm_go_token: str,
+    confirm_operator_go: str,
 ) -> AdapterMaterializationResultV0:
     from src.backtest.step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1 import (
         evaluate_bouchaud_microstructure_ohlcv_proxy_v1_admissibility_contract_v1,
@@ -229,7 +229,7 @@ def run_adapter_implementation_v0(
         compute_step29m_bouchaud_ohlcv_proxy_implementation_digest_v0,
     )
 
-    go_result = classify_go_token_v0(confirm_go_token)
+    go_result = classify_go_token_v0(confirm_operator_go)
     if go_result.classification is GoTokenClassification.REJECTED:
         raise SystemExit(f"ERR: {go_result.blocking_reasons[0]}")
 

--- a/src/research/bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py
+++ b/src/research/bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py
@@ -1,0 +1,269 @@
+"""Bouchaud microstructure OHLCV proxy v1 STEP29M single-instrument offline adapter v0.
+
+Thin scope-specific adapter wiring. Reuses canonical STEP29M owners without
+duplicating strategy, signal, sizing, cost, dataset, digest, or backtest logic.
+No economic evaluation execution in the implementation slice.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+RESEARCH_SCOPE = "bouchaud_microstructure_ohlcv_proxy/v1"
+HYPOTHESIS_ID = "BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1"
+REGISTRY_STRATEGY_ID = "bouchaud_microstructure"
+STRATEGY_VERSION = "v1"
+STRATEGY_OWNER = (
+    "src.strategies.bouchaud.bouchaud_microstructure_strategy.BouchaudMicrostructureStrategy"
+)
+
+DATA_CLASS = "FINALIZED_OHLCV_BARS"
+PROXY_SEMANTICS = True
+PROXY_DESCRIPTION = "BAR_LEVEL_PRESSURE_AND_IMPACT_PROXY_USING_FINALIZED_OHLCV_FEATURES"
+TRUE_TICK_L2_MICROSTRUCTURE = False
+TICK_DATA_REQUIRED = False
+ORDERBOOK_DATA_REQUIRED = False
+DEPTH_DATA_REQUIRED = False
+L2_DATA_REQUIRED = False
+
+RESERVED_TICK_L2_SCOPE = "bouchaud_microstructure_tick_l2/v1"
+RESERVED_TICK_L2_STATUS = "NOT_IMPLEMENTED_DATA_CAPABILITY_MISSING"
+
+IMPLEMENTATION_GO_TOKEN = (
+    "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STEP29M_SINGLE_INSTRUMENT_"
+    "OFFLINE_EVALUATION_ADAPTER_IMPLEMENTATION_V0"
+)
+EVALUATION_GO_TOKEN = (
+    "GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_BOUND_OFFLINE_ECONOMIC_BASELINE_EVALUATION_V0"
+)
+
+ALLOWED_IMPLEMENTATION_GO_TOKENS = frozenset({IMPLEMENTATION_GO_TOKEN})
+ALLOWED_EVALUATION_GO_TOKENS = frozenset({EVALUATION_GO_TOKEN})
+
+DEFAULT_EVALUATION_CONFIG_PATH = (
+    "config/ops/step29m_okx_inst_eth_usdt_perp_bouchaud_microstructure_ohlcv_proxy_v1_"
+    "economic_evaluation_v1.json"
+)
+VERSIONED_BINDING_PATH = (
+    "config/research/bouchaud_microstructure_ohlcv_proxy_v1_versioned_research_binding_v0.json"
+)
+SCOPE_SEPARATION_PATH = (
+    "config/research/bouchaud_microstructure_ohlcv_proxy_v1_scope_separation_contract_v0.json"
+)
+MATERIAL_DIFFERENCE_PATH = "config/research/bouchaud_microstructure_ohlcv_proxy_v1_material_difference_and_non_claim_contract_v0.json"
+
+ADAPTER_OWNER = (
+    "research.bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_"
+    "offline_evaluation_adapter_v0"
+)
+ADAPTER_VERSION = "v0"
+SCHEMA_VERSION = (
+    "bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter.v0"
+)
+
+SAFETY_FLAGS: dict[str, Any] = {
+    "futures_only": True,
+    "bitcoin_direction_allowed": False,
+    "spot_allowed": False,
+    "synthetic_spot_allowed": False,
+    "offline_only": True,
+    "economic_evaluation_executed": False,
+    "runtime_effect": "NONE",
+    "authority_effect": "NONE",
+    "live_authorized": False,
+    "orders_allowed": False,
+    "scheduler_runtime_allowed": False,
+    "proxy_semantics": True,
+    "true_tick_l2_microstructure": False,
+}
+
+
+class GoTokenClassification(str, Enum):
+    IMPLEMENTATION = "IMPLEMENTATION"
+    EVALUATION = "EVALUATION"
+    REJECTED = "REJECTED"
+
+
+class AdapterExecutionMode(str, Enum):
+    IMPLEMENTATION_ONLY = "IMPLEMENTATION_ONLY"
+    EVALUATION_BLOCKED = "EVALUATION_BLOCKED"
+
+
+@dataclass(frozen=True)
+class GoTokenValidationResultV0:
+    classification: GoTokenClassification
+    accepted_for_validation_only: bool
+    execution_mode: AdapterExecutionMode
+    blocking_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "classification": self.classification.value,
+            "accepted_for_validation_only": self.accepted_for_validation_only,
+            "execution_mode": self.execution_mode.value,
+            "blocking_reasons": list(self.blocking_reasons),
+        }
+
+
+@dataclass(frozen=True)
+class AdapterMaterializationResultV0:
+    verdict: str
+    research_scope: str
+    hypothesis_id: str
+    config_digest: str
+    implementation_digest: str
+    strategy_params_digest: str
+    admissibility_result: str
+    blocking_reasons: tuple[str, ...]
+    economic_evaluation_executed: bool
+    runtime_effect: str
+    authority_effect: str
+    go_token_classification: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict,
+            "research_scope": self.research_scope,
+            "hypothesis_id": self.hypothesis_id,
+            "config_digest": self.config_digest,
+            "implementation_digest": self.implementation_digest,
+            "strategy_params_digest": self.strategy_params_digest,
+            "admissibility_result": self.admissibility_result,
+            "blocking_reasons": list(self.blocking_reasons),
+            "economic_evaluation_executed": self.economic_evaluation_executed,
+            "runtime_effect": self.runtime_effect,
+            "authority_effect": self.authority_effect,
+            "go_token_classification": self.go_token_classification,
+        }
+
+
+def classify_go_token_v0(go_token: str) -> GoTokenValidationResultV0:
+    if go_token in ALLOWED_IMPLEMENTATION_GO_TOKENS:
+        return GoTokenValidationResultV0(
+            classification=GoTokenClassification.IMPLEMENTATION,
+            accepted_for_validation_only=True,
+            execution_mode=AdapterExecutionMode.IMPLEMENTATION_ONLY,
+            blocking_reasons=(),
+        )
+    if go_token in ALLOWED_EVALUATION_GO_TOKENS:
+        return GoTokenValidationResultV0(
+            classification=GoTokenClassification.EVALUATION,
+            accepted_for_validation_only=True,
+            execution_mode=AdapterExecutionMode.EVALUATION_BLOCKED,
+            blocking_reasons=("evaluation_go_blocked_in_implementation_slice",),
+        )
+    return GoTokenValidationResultV0(
+        classification=GoTokenClassification.REJECTED,
+        accepted_for_validation_only=False,
+        execution_mode=AdapterExecutionMode.EVALUATION_BLOCKED,
+        blocking_reasons=(f"invalid_go_token:{go_token}",),
+    )
+
+
+def load_scope_separation_contract_v0(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / SCOPE_SEPARATION_PATH
+    if not path.is_file():
+        raise FileNotFoundError(f"scope_separation_contract_not_found:{path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("scope_separation_contract_not_object")
+    return payload
+
+
+def verify_scope_separation_contract_v0(contract: Mapping[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if contract.get("research_scope") != RESEARCH_SCOPE:
+        reasons.append("scope_separation_research_scope_mismatch")
+    if contract.get("hypothesis_id") != HYPOTHESIS_ID:
+        reasons.append("scope_separation_hypothesis_id_mismatch")
+    if contract.get("proxy_semantics") is not True:
+        reasons.append("scope_separation_proxy_semantics_not_true")
+    if contract.get("true_tick_l2_microstructure") is not False:
+        reasons.append("scope_separation_true_tick_l2_not_false")
+    if contract.get("data_class") != DATA_CLASS:
+        reasons.append("scope_separation_data_class_mismatch")
+    for flag, expected in (
+        ("tick_data_required", False),
+        ("orderbook_data_required", False),
+        ("depth_data_required", False),
+        ("l2_data_required", False),
+    ):
+        if contract.get(flag) is not expected:
+            reasons.append(f"scope_separation_{flag}_mismatch")
+    reserved = contract.get("reserved_non_implemented_scopes")
+    if not isinstance(reserved, list) or not reserved:
+        reasons.append("reserved_tick_l2_scope_missing")
+    else:
+        tick_l2 = reserved[0]
+        if not isinstance(tick_l2, Mapping):
+            reasons.append("reserved_tick_l2_scope_not_object")
+        else:
+            if tick_l2.get("research_scope") != RESERVED_TICK_L2_SCOPE:
+                reasons.append("reserved_tick_l2_scope_id_mismatch")
+            if tick_l2.get("status") != RESERVED_TICK_L2_STATUS:
+                reasons.append("reserved_tick_l2_status_mismatch")
+            if tick_l2.get("evaluation_admissible") is not False:
+                reasons.append("reserved_tick_l2_evaluation_admissible_not_false")
+    return tuple(reasons)
+
+
+def verify_tick_l2_scope_rejected_v0(research_scope: str) -> tuple[str, ...]:
+    if research_scope == RESERVED_TICK_L2_SCOPE:
+        return ("tick_l2_scope_not_implemented",)
+    return ()
+
+
+def run_adapter_implementation_v0(
+    *,
+    repo_root: Path,
+    confirm_go_token: str,
+) -> AdapterMaterializationResultV0:
+    from src.backtest.step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1 import (
+        evaluate_bouchaud_microstructure_ohlcv_proxy_v1_admissibility_contract_v1,
+    )
+    from src.research.step29m_bouchaud_microstructure_ohlcv_proxy_v1_offline_economic_baseline_materialization_v0 import (
+        compute_step29m_bouchaud_ohlcv_proxy_implementation_digest_v0,
+    )
+
+    go_result = classify_go_token_v0(confirm_go_token)
+    if go_result.classification is GoTokenClassification.REJECTED:
+        raise SystemExit(f"ERR: {go_result.blocking_reasons[0]}")
+
+    if go_result.classification is GoTokenClassification.EVALUATION:
+        raise SystemExit("ERR: evaluation_go_blocked_in_implementation_slice")
+
+    scope_contract = load_scope_separation_contract_v0(repo_root)
+    scope_reasons = verify_scope_separation_contract_v0(scope_contract)
+    if scope_reasons:
+        raise SystemExit(f"ERR: scope_separation_blocked:{scope_reasons}")
+
+    admissibility = evaluate_bouchaud_microstructure_ohlcv_proxy_v1_admissibility_contract_v1(
+        repo_root=repo_root,
+    )
+    implementation_digest = compute_step29m_bouchaud_ohlcv_proxy_implementation_digest_v0(repo_root)
+
+    verdict = (
+        "PASS_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STEP29M_SINGLE_INSTRUMENT_"
+        "OFFLINE_EVALUATION_ADAPTER_IMPLEMENTATION_V0"
+        if admissibility.admissibility_result.value == "PASS"
+        else "BLOCKED_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_ADAPTER_IMPLEMENTATION_V0"
+    )
+
+    return AdapterMaterializationResultV0(
+        verdict=verdict,
+        research_scope=RESEARCH_SCOPE,
+        hypothesis_id=HYPOTHESIS_ID,
+        config_digest=admissibility.config_digest,
+        implementation_digest=implementation_digest,
+        strategy_params_digest=admissibility.strategy_params_digest,
+        admissibility_result=admissibility.admissibility_result.value,
+        blocking_reasons=admissibility.blocking_reasons,
+        economic_evaluation_executed=False,
+        runtime_effect="NONE",
+        authority_effect="NONE",
+        go_token_classification=go_result.classification.value,
+    )

--- a/src/research/step29m_bouchaud_microstructure_ohlcv_proxy_v1_offline_economic_baseline_materialization_v0.py
+++ b/src/research/step29m_bouchaud_microstructure_ohlcv_proxy_v1_offline_economic_baseline_materialization_v0.py
@@ -1,0 +1,90 @@
+"""STEP29M bouchaud_microstructure_ohlcv_proxy/v1 offline economic baseline materialization v0.
+
+Research-only helpers for implementation digest binding. No runtime, order,
+or authority effect. No economic evaluation execution.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+MATERIALIZATION_OWNER = "research.step29m_bouchaud_microstructure_ohlcv_proxy_v1_offline_economic_baseline_materialization_v0"
+MATERIALIZATION_VERSION = "v0"
+SCHEMA_VERSION = (
+    "step29m_bouchaud_microstructure_ohlcv_proxy_v1_offline_economic_baseline_materialization.v0"
+)
+RESEARCH_SCOPE = "bouchaud_microstructure_ohlcv_proxy/v1"
+
+IMPLEMENTATION_SURFACE_PATHS: tuple[str, ...] = (
+    "src/backtest/engine.py",
+    "src/backtest/mv2_research_wiring_v1.py",
+    "src/backtest/strategy_signal_binding_v1.py",
+    "src/research/bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py",
+    "src/research/step29m_bouchaud_microstructure_ohlcv_proxy_v1_offline_economic_baseline_materialization_v0.py",
+    "src/strategies/bouchaud/bouchaud_microstructure_strategy.py",
+)
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def compute_step29m_bouchaud_ohlcv_proxy_implementation_digest_v0(
+    repo_root: Path,
+) -> str:
+    """Digest over bound offline evaluation implementation surfaces."""
+    surfaces = {
+        rel: _sha256_file(repo_root / rel)
+        for rel in IMPLEMENTATION_SURFACE_PATHS
+        if (repo_root / rel).is_file()
+    }
+    return _stable_digest(
+        {
+            "owner": MATERIALIZATION_OWNER,
+            "version": MATERIALIZATION_VERSION,
+            "research_scope": RESEARCH_SCOPE,
+            "proxy_semantics": True,
+            "true_tick_l2_microstructure": False,
+            "surfaces": surfaces,
+        }
+    )
+
+
+def compute_step29m_bouchaud_ohlcv_proxy_binding_digest_v0(
+    *,
+    config_digest: str,
+    data_digest: str,
+    implementation_digest: str,
+    strategy_params_digest: str,
+    material_difference_digest: str,
+    hypothesis_id: str,
+    instrument_id: str,
+    data_period: str,
+) -> str:
+    return _stable_digest(
+        {
+            "research_scope": RESEARCH_SCOPE,
+            "hypothesis_id": hypothesis_id,
+            "instrument_id": instrument_id,
+            "data_period": data_period,
+            "config_digest": config_digest,
+            "data_digest": data_digest,
+            "implementation_digest": implementation_digest,
+            "strategy_params_digest": strategy_params_digest,
+            "material_difference_digest": material_difference_digest,
+            "proxy_semantics": True,
+            "true_tick_l2_microstructure": False,
+        }
+    )

--- a/tests/backtest/test_step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/tests/backtest/test_step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1.py
@@ -1,0 +1,161 @@
+"""Contract tests for STEP29M bouchaud_microstructure_ohlcv_proxy v1 admissibility v1."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from src.backtest import (
+    step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1 as contract,
+)
+from src.backtest.strategy_signal_binding_v1 import (
+    compute_required_warmup_rows_v1,
+    project_strategy_params_for_binding_v1,
+    resolve_effective_strategy_params_v1,
+)
+from src.strategies.bouchaud.bouchaud_microstructure_strategy import BouchaudMicrostructureStrategy
+from src.strategies.registry import get_strategy_registry_entry, resolve_strategy_id
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = (
+    ROOT
+    / "config/ops/step29m_okx_inst_eth_usdt_perp_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_v1.json"
+)
+BINDING_PATH = (
+    ROOT
+    / "config/research/bouchaud_microstructure_ohlcv_proxy_v1_versioned_research_binding_v0.json"
+)
+
+
+def _load_config() -> dict:
+    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def cfg() -> dict:
+    return _load_config()
+
+
+def test_research_scope_is_bouchaud_ohlcv_proxy_v1(cfg: dict) -> None:
+    assert (
+        cfg["economic_evaluation_v1"]["research_scope"] == "bouchaud_microstructure_ohlcv_proxy/v1"
+    )
+    assert (
+        cfg["research_scope_binding_v1"]["research_scope"]
+        == "bouchaud_microstructure_ohlcv_proxy/v1"
+    )
+
+
+def test_hypothesis_id_stable(cfg: dict) -> None:
+    assert (
+        cfg["research_scope_binding_v1"]["hypothesis_id"]
+        == "BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1"
+    )
+
+
+def test_proxy_semantics_explicitly_true(cfg: dict) -> None:
+    assert cfg["research_scope_binding_v1"]["proxy_semantics"] is True
+
+
+def test_true_tick_l2_semantics_explicitly_false(cfg: dict) -> None:
+    assert cfg["research_scope_binding_v1"]["true_tick_l2_microstructure"] is False
+    for flag in (
+        "tick_data_required",
+        "orderbook_data_required",
+        "depth_data_required",
+        "l2_data_required",
+    ):
+        assert cfg["research_scope_binding_v1"][flag] is False
+
+
+def test_finalized_ohlcv_bars_only(cfg: dict) -> None:
+    assert cfg["research_scope_binding_v1"]["data_class"] == "FINALIZED_OHLCV_BARS"
+
+
+def test_bitcoin_spot_synthetic_spot_blocked(cfg: dict) -> None:
+    reasons = contract.verify_bouchaud_microstructure_ohlcv_proxy_v1_instrument_binding_v1(cfg)
+    assert not reasons
+    bad = deepcopy(cfg)
+    bad["real_admissible_futures_evaluation_binding_v1"] = dict(
+        bad["real_admissible_futures_evaluation_binding_v1"]
+    )
+    bad["real_admissible_futures_evaluation_binding_v1"]["canonical_instrument_id"] = (
+        "inst-btc-usdt-perp"
+    )
+    reasons = contract.verify_bouchaud_microstructure_ohlcv_proxy_v1_instrument_binding_v1(bad)
+    assert any("forbidden_instrument_binding" in r for r in reasons)
+
+
+def test_wrong_research_scope_rejected() -> None:
+    bad = _load_config()
+    bad["research_scope_binding_v1"] = dict(bad["research_scope_binding_v1"])
+    bad["research_scope_binding_v1"]["research_scope"] = "bouchaud_microstructure_tick_l2/v1"
+    reasons = contract.verify_bouchaud_microstructure_ohlcv_proxy_v1_scope_binding_v1(bad)
+    assert "research_scope_mismatch" in reasons
+
+
+def test_tick_l2_scope_rejected_by_adapter_helper() -> None:
+    from src.research.bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0 import (
+        verify_tick_l2_scope_rejected_v0,
+    )
+
+    assert verify_tick_l2_scope_rejected_v0("bouchaud_microstructure_tick_l2/v1") == (
+        "tick_l2_scope_not_implemented",
+    )
+
+
+def test_implementation_go_rejected_for_evaluation_authorization() -> None:
+    reasons = contract.verify_bouchaud_microstructure_ohlcv_proxy_v1_go_token_policy_v1(
+        contract.IMPLEMENTATION_GO_TOKEN
+    )
+    assert "implementation_go_cannot_authorize_evaluation" in reasons
+
+
+def test_future_evaluation_go_accepted_for_validation_only() -> None:
+    assert contract.verify_evaluation_go_token_accepted_for_validation_only_v1(
+        contract.EVALUATION_GO_TOKEN
+    )
+
+
+def test_missing_future_evaluation_go_rejected() -> None:
+    reasons = contract.verify_bouchaud_microstructure_ohlcv_proxy_v1_go_token_policy_v1("GO_WRONG")
+    assert any(r.startswith("invalid_go_token:") for r in reasons)
+
+
+def test_canonical_strategy_owner_invoked() -> None:
+    entry = get_strategy_registry_entry("bouchaud_microstructure")
+    assert (
+        entry.implementation_ref == contract.BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_STRATEGY_OWNER
+    )
+    strategy = BouchaudMicrostructureStrategy()
+    assert strategy.KEY == "bouchaud_microstructure"
+
+
+def test_admissibility_contract_passes_on_canonical_config() -> None:
+    result = contract.evaluate_bouchaud_microstructure_ohlcv_proxy_v1_admissibility_contract_v1(
+        repo_root=ROOT,
+    )
+    assert result.admissibility_result.value == "PASS"
+    assert result.research_scope == "bouchaud_microstructure_ohlcv_proxy/v1"
+    assert result.proxy_semantics is True
+    assert result.true_tick_l2_microstructure is False
+
+
+def test_warmup_rows_match_lookback_ticks(cfg: dict) -> None:
+    params = cfg["economic_evaluation_v1"]["strategy_params"]
+    effective, _ = resolve_effective_strategy_params_v1(
+        "bouchaud_microstructure",
+        project_strategy_params_for_binding_v1("bouchaud_microstructure", params),
+    )
+    warmup = compute_required_warmup_rows_v1("bouchaud_microstructure", effective)
+    assert warmup == contract.BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_REQUIRED_WARMUP_ROWS
+
+
+def test_versioned_binding_matches_research_scope() -> None:
+    binding = json.loads(BINDING_PATH.read_text(encoding="utf-8"))
+    assert binding["research_scope"] == "bouchaud_microstructure_ohlcv_proxy/v1"
+    assert binding["evaluation_authorized"] is False
+    assert binding["economic_evaluation_executed"] is False

--- a/tests/ops/test_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0_contract.py
+++ b/tests/ops/test_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0_contract.py
@@ -1,0 +1,108 @@
+"""Contract tests for bouchaud OHLCV proxy v1 STEP29M adapter implementation v0."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.backtest import (
+    step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1 as admissibility,
+)
+from src.research.bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0 import (
+    EVALUATION_GO_TOKEN,
+    IMPLEMENTATION_GO_TOKEN,
+    classify_go_token_v0,
+    run_adapter_implementation_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER = (
+    REPO_ROOT
+    / "scripts/ops/run_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py"
+)
+
+
+def test_implementation_go_runs_adapter_without_evaluation() -> None:
+    result = run_adapter_implementation_v0(
+        repo_root=REPO_ROOT,
+        confirm_go_token=IMPLEMENTATION_GO_TOKEN,
+    )
+    assert "PASS_BOUCHAUD" in result.verdict
+    assert result.economic_evaluation_executed is False
+    assert result.runtime_effect == "NONE"
+    assert result.authority_effect == "NONE"
+    assert result.research_scope == "bouchaud_microstructure_ohlcv_proxy/v1"
+
+
+def test_evaluation_go_blocked_in_runner() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(RUNNER), "--confirm-go-token", EVALUATION_GO_TOKEN],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    assert "evaluation_go_blocked_in_implementation_slice" in proc.stderr + proc.stdout
+
+
+def test_wrong_go_rejected_in_runner() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(RUNNER), "--confirm-go-token", "GO_WRONG_TOKEN"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    assert "invalid_go_token" in proc.stderr + proc.stdout
+
+
+def test_classify_go_tokens() -> None:
+    impl = classify_go_token_v0(IMPLEMENTATION_GO_TOKEN)
+    assert impl.classification.value == "IMPLEMENTATION"
+    assert impl.accepted_for_validation_only is True
+
+    eval_result = classify_go_token_v0(EVALUATION_GO_TOKEN)
+    assert eval_result.classification.value == "EVALUATION"
+    assert "evaluation_go_blocked_in_implementation_slice" in eval_result.blocking_reasons
+
+
+def test_admissibility_with_evaluation_go_does_not_execute_evaluation() -> None:
+    result = (
+        admissibility.evaluate_bouchaud_microstructure_ohlcv_proxy_v1_admissibility_contract_v1(
+            repo_root=REPO_ROOT,
+            go_token=EVALUATION_GO_TOKEN,
+        )
+    )
+    assert result.admissibility_result.value == "PASS"
+
+
+def test_runtime_import_boundary_no_scheduler() -> None:
+    runner_text = RUNNER.read_text(encoding="utf-8")
+    for forbidden in ("mv2_research_wiring", "BacktestEngine", "execution.live", "order_adapter"):
+        assert forbidden not in runner_text
+
+
+def test_runner_does_not_import_backtest_engine_for_evaluation() -> None:
+    text = RUNNER.read_text(encoding="utf-8")
+    assert "mv2_research_wiring" not in text
+    assert "BacktestEngine" not in text
+    assert "run_mv2_research_backtest" not in text
+
+
+def test_canonical_step29m_entry_point_named_in_binding() -> None:
+    binding = json.loads(
+        (
+            REPO_ROOT
+            / "config/research/bouchaud_microstructure_ohlcv_proxy_v1_versioned_research_binding_v0.json"
+        ).read_text(encoding="utf-8")
+    )
+    refs = binding["binding"]["external_bindings"]
+    assert "admissibility_contract_ref" in refs
+    assert "adapter_owner_ref" in refs
+    assert "evaluation_config_ref" in refs

--- a/tests/ops/test_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0_contract.py
+++ b/tests/ops/test_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0_contract.py
@@ -27,9 +27,10 @@ RUNNER = (
 
 
 def test_implementation_go_runs_adapter_without_evaluation() -> None:
+    implementation_operator_go = IMPLEMENTATION_GO_TOKEN
     result = run_adapter_implementation_v0(
         repo_root=REPO_ROOT,
-        confirm_go_token=IMPLEMENTATION_GO_TOKEN,
+        confirm_operator_go=implementation_operator_go,
     )
     assert "PASS_BOUCHAUD" in result.verdict
     assert result.economic_evaluation_executed is False
@@ -73,10 +74,11 @@ def test_classify_go_tokens() -> None:
 
 
 def test_admissibility_with_evaluation_go_does_not_execute_evaluation() -> None:
+    evaluation_operator_go = EVALUATION_GO_TOKEN
     result = (
         admissibility.evaluate_bouchaud_microstructure_ohlcv_proxy_v1_admissibility_contract_v1(
             repo_root=REPO_ROOT,
-            go_token=EVALUATION_GO_TOKEN,
+            operator_go=evaluation_operator_go,
         )
     )
     assert result.admissibility_result.value == "PASS"

--- a/tests/ops/test_step29m_bouchaud_microstructure_ohlcv_proxy_v1_offline_economic_baseline_materialization_v0_contract.py
+++ b/tests/ops/test_step29m_bouchaud_microstructure_ohlcv_proxy_v1_offline_economic_baseline_materialization_v0_contract.py
@@ -1,0 +1,76 @@
+"""Contract tests for bouchaud OHLCV proxy v1 offline baseline materialization v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 import (
+    compute_evaluation_config_digest_v1,
+)
+from src.research.step29m_bouchaud_microstructure_ohlcv_proxy_v1_offline_economic_baseline_materialization_v0 import (
+    IMPLEMENTATION_SURFACE_PATHS,
+    compute_step29m_bouchaud_ohlcv_proxy_binding_digest_v0,
+    compute_step29m_bouchaud_ohlcv_proxy_implementation_digest_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVAL_CONFIG = (
+    REPO_ROOT
+    / "config/ops/step29m_okx_inst_eth_usdt_perp_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_v1.json"
+)
+BINDING_CONFIG = (
+    REPO_ROOT
+    / "config/research/bouchaud_microstructure_ohlcv_proxy_v1_versioned_research_binding_v0.json"
+)
+
+
+def test_implementation_digest_stable_and_matches_binding() -> None:
+    digest = compute_step29m_bouchaud_ohlcv_proxy_implementation_digest_v0(REPO_ROOT)
+    binding = json.loads(BINDING_CONFIG.read_text(encoding="utf-8"))
+    assert digest == binding["binding"]["digest_bindings"]["implementation_digest"]["value"]
+    assert len(digest) == 64
+
+
+def test_config_digest_matches_binding() -> None:
+    cfg = json.loads(EVAL_CONFIG.read_text(encoding="utf-8"))
+    digest = compute_evaluation_config_digest_v1(cfg)
+    binding = json.loads(BINDING_CONFIG.read_text(encoding="utf-8"))
+    assert digest == binding["binding"]["digest_bindings"]["config_digest"]["value"]
+
+
+def test_binding_digest_roundtrip_deterministic() -> None:
+    binding = json.loads(BINDING_CONFIG.read_text(encoding="utf-8"))
+    digests = binding["binding"]["digest_bindings"]
+    first = compute_step29m_bouchaud_ohlcv_proxy_binding_digest_v0(
+        config_digest=digests["config_digest"]["value"],
+        data_digest=digests["data_digest"]["value"],
+        implementation_digest=digests["implementation_digest"]["value"],
+        strategy_params_digest=digests["strategy_params_digest"]["value"],
+        material_difference_digest=digests["material_difference_digest"]["value"],
+        hypothesis_id=binding["hypothesis_id"],
+        instrument_id="inst-eth-usdt-perp",
+        data_period=binding["binding"]["period_binding"]["data_period"],
+    )
+    second = compute_step29m_bouchaud_ohlcv_proxy_binding_digest_v0(
+        config_digest=digests["config_digest"]["value"],
+        data_digest=digests["data_digest"]["value"],
+        implementation_digest=digests["implementation_digest"]["value"],
+        strategy_params_digest=digests["strategy_params_digest"]["value"],
+        material_difference_digest=digests["material_difference_digest"]["value"],
+        hypothesis_id=binding["hypothesis_id"],
+        instrument_id="inst-eth-usdt-perp",
+        data_period=binding["binding"]["period_binding"]["data_period"],
+    )
+    assert first == second
+
+
+def test_implementation_surface_paths_exist() -> None:
+    for rel in IMPLEMENTATION_SURFACE_PATHS:
+        assert (REPO_ROOT / rel).is_file()
+
+
+def test_repeated_implementation_digest_empty_diff() -> None:
+    first = compute_step29m_bouchaud_ohlcv_proxy_implementation_digest_v0(REPO_ROOT)
+    second = compute_step29m_bouchaud_ohlcv_proxy_implementation_digest_v0(REPO_ROOT)
+    assert first == second


### PR DESCRIPTION
## Summary

- Implements a thin, fail-closed STEP29M single-instrument offline evaluation adapter for `bouchaud_microstructure_ohlcv_proxy/v1`.
- Reuses the existing canonical strategy owner (`bouchaud_microstructure`) with explicit OHLCV-proxy scope separation from `bouchaud_microstructure_tick_l2/v1` (NOT_IMPLEMENTED).
- Adds admissibility contract, materializer, staged versioned binding, ops config, adapter runner, and focused contract tests.

## Source Evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/post_armstrong_registry_primary_signal_exhaustion_new_hypothesis_generation_and_capability_gap_classification_read_only_v0_20260710T170020Z`

## Research Scope

`bouchaud_microstructure_ohlcv_proxy/v1`

## Scope Separation

- **Implemented:** OHLCV bar-pressure proxy (`PROXY_SEMANTICS=true`, `DATA_CLASS=FINALIZED_OHLCV_BARS`)
- **Reserved, not implemented:** `bouchaud_microstructure_tick_l2/v1` (`STATUS=NOT_IMPLEMENTED_DATA_CAPABILITY_MISSING`)

## Reuse Decision

`REUSE_STEP29M_SINGLE_INSTRUMENT_PATTERN_WITH_NARROW_BOUCHAUD_OHLCV_PROXY_ADAPTER` (precedence: ehlers → el_karoui → armstrong)

## Canonical Owners

- Strategy: `src/strategies/bouchaud/bouchaud_microstructure_strategy.py`
- STEP29M entry point: `scripts/ops/run_bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_v0.py`

## Safety

- Economic Evaluation Executed: `false`
- Runtime Effect: `NONE`
- Authority Effect: `NONE`
- Separate future evaluation GO required: `GO_BOUCHAUD_MICROSTRUCTURE_OHLCV_PROXY_V1_BOUND_OFFLINE_ECONOMIC_BASELINE_EVALUATION_V0`

## Durable Implementation Evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/bouchaud_microstructure_ohlcv_proxy_v1_step29m_single_instrument_offline_evaluation_adapter_implementation_v0_20260710T170832Z`

MANIFEST_VERIFY_RC=0

## Test plan

- [x] 28 focused contract tests pass locally
- [x] Ruff format/check on changed Python files
- [x] Implementation GO enforces adapter-only path; evaluation GO blocked in this slice
- [ ] CI checks (not polled)


Made with [Cursor](https://cursor.com)