### PR TITLE
Add OKX self-accumulated forward OI archive correction execution entry point v0

### DIFF
--- a/config/research/okx_self_accumulated_forward_open_interest_archive_correction_and_executable_binding_v0.json
+++ b/config/research/okx_self_accumulated_forward_open_interest_archive_correction_and_executable_binding_v0.json
@@ -12,6 +12,10 @@
   "overlap_validator_owner": "okx_self_accumulated_forward_open_interest_overlap_validation_v0",
   "permitted_collector_entry_point": "scripts/ops/collect_okx_self_accumulated_forward_open_interest_one_shot_v0.py",
   "permitted_overlap_entry_point": "scripts/ops/validate_okx_self_accumulated_forward_open_interest_overlap_v0.py",
+  "correction_execution_entry_point": "scripts/ops/execute_okx_self_accumulated_forward_open_interest_archive_correction_v0.py",
+  "correction_execution_go_token": "GO_OKX_SELF_ACCUMULATED_FORWARD_OPEN_INTEREST_ARCHIVE_CORRECTION_EXECUTION_V0_AGAINST_EXECUTABLE_BINDING",
+  "correction_execution_validate_only_default": true,
+  "explicit_mutation_flag_required": true,
   "append_only": true,
   "conflict_overwrite_allowed": false,
   "historical_evidence_preserved": true,
@@ -30,5 +34,5 @@
   "authority_effect": "NONE",
   "runtime_effect": "NONE",
   "reuse_decision": "NEW_IMPLEMENTATION_JUSTIFIED",
-  "status": "ARCHIVE_CORRECTION_AND_EXECUTABLE_BINDING_V0_IMPLEMENTED"
+  "status": "ARCHIVE_CORRECTION_EXECUTION_ENTRY_POINT_V0_IMPLEMENTED"
 }

--- a/scripts/ops/execute_okx_self_accumulated_forward_open_interest_archive_correction_v0.py
+++ b/scripts/ops/execute_okx_self_accumulated_forward_open_interest_archive_correction_v0.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Execute one bounded OKX self-accumulated forward OI archive correction v0.
+
+Thin canonical entry point for append-only archive correction against a bound
+execution plan. Default-off validate-only; explicit flags required for mutation.
+Operator GO: GO_OKX_SELF_ACCUMULATED_FORWARD_OPEN_INTEREST_ARCHIVE_CORRECTION_EXECUTION_V0_AGAINST_EXECUTABLE_BINDING
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.research.okx_self_accumulated_forward_open_interest_archive_correction_and_executable_binding_v0 import (  # noqa: E402
+    CONFIRM_GO_EXECUTION,
+    correction_execution_result_to_dict_v0,
+    execute_archive_correction_v0,
+    exit_code_for_correction_execution_result_v0,
+)
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bounded default-off OKX self-accumulated forward OI archive correction "
+            "execution entry point v0."
+        )
+    )
+    parser.add_argument(
+        "--confirm-go-token",
+        required=True,
+        help=f"Required operator GO token ({CONFIRM_GO_EXECUTION})",
+    )
+    parser.add_argument(
+        "--bound-plan",
+        type=Path,
+        required=True,
+        help="Bound archive correction execution plan JSON",
+    )
+    parser.add_argument(
+        "--target-archive",
+        type=Path,
+        required=True,
+        help="Target self-accumulated archive snapshot directory",
+    )
+    parser.add_argument(
+        "--source-manifest-dir",
+        type=Path,
+        action="append",
+        default=[],
+        help="Optional source evidence directory with MANIFEST.sha256 to verify",
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        default=True,
+        help="Validate plan and mutation set without mutating archive (default)",
+    )
+    parser.add_argument(
+        "--execute-mutation",
+        action="store_true",
+        default=False,
+        help="Explicitly authorize one append-only archive correction mutation",
+    )
+    parser.add_argument(
+        "--enabled",
+        action="store_true",
+        default=False,
+        help="Explicit enable flag required together with --execute-mutation",
+    )
+    parser.add_argument(
+        "--output-file",
+        type=Path,
+        default=None,
+        help="Optional JSON result output path",
+    )
+    args = parser.parse_args(argv)
+
+    validate_only = not args.execute_mutation
+    if args.execute_mutation and not args.enabled:
+        _die("ERR: EXECUTE_MUTATION_REQUIRES_ENABLED_FLAG")
+
+    result = execute_archive_correction_v0(
+        confirm=args.confirm_go_token,
+        validate_only=validate_only,
+        execute_mutation=args.execute_mutation,
+        enabled=args.enabled,
+        bound_plan_path=args.bound_plan,
+        target_archive_path=args.target_archive,
+        source_manifest_dirs=tuple(args.source_manifest_dir),
+    )
+    report = correction_execution_result_to_dict_v0(result)
+    serialized = json.dumps(report, sort_keys=True, indent=2)
+    print(serialized)
+    if args.output_file is not None:
+        args.output_file.parent.mkdir(parents=True, exist_ok=True)
+        args.output_file.write_text(serialized + "\n", encoding="utf-8")
+    return exit_code_for_correction_execution_result_v0(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/okx_self_accumulated_forward_open_interest_archive_correction_and_executable_binding_v0.py
+++ b/src/research/okx_self_accumulated_forward_open_interest_archive_correction_and_executable_binding_v0.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import shutil
+import tempfile
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -22,11 +25,14 @@ from src.research.cross_sectional_open_interest_delta_rank_v0_pit_semantics_cont
 from src.research.okx_self_accumulated_forward_open_interest_archive_v0 import (
     ARCHIVE_MANIFEST_FILENAME,
     ARCHIVE_SCHEMA_VERSION,
+    MANIFEST_SHA256_FILENAME,
     OBSERVATIONS_JSONL_FILENAME,
     OPEN_INTEREST_UNIT,
     VENUE,
     compute_observation_digest_v0,
+    observation_from_row_dict_v0,
     serialize_canonical_json,
+    write_manifest_sha256_v0,
 )
 from src.research.okx_self_accumulated_forward_open_interest_one_shot_collector_harness_v0 import (
     MODULE_VERSION as COLLECTOR_MODULE_VERSION,
@@ -87,6 +93,19 @@ NEXT_CANONICAL_STEP = (
     "OKX_SELF_ACCUMULATED_FORWARD_OPEN_INTEREST_ARCHIVE_CORRECTION_EXECUTION_V0_"
     "AGAINST_EXECUTABLE_BINDING"
 )
+CONFIRM_GO_EXECUTION = (
+    "GO_OKX_SELF_ACCUMULATED_FORWARD_OPEN_INTEREST_ARCHIVE_CORRECTION_EXECUTION_V0_"
+    "AGAINST_EXECUTABLE_BINDING"
+)
+CORRECTION_ENTRY_POINT = (
+    "scripts/ops/execute_okx_self_accumulated_forward_open_interest_archive_correction_v0.py"
+)
+BOUND_EXECUTION_PLAN_SCHEMA_VERSION = (
+    "okx_self_accumulated_forward_open_interest_archive_correction_execution_plan.v0"
+)
+CORRECTED_OBSERVATIONS_JSONL_FILENAME = "corrected_observations.jsonl"
+SUPERSESSION_RECORDS_JSONL_FILENAME = "supersession_records.jsonl"
+CORRECTION_GENERATION_BINDING_FILENAME = "correction_generation_binding.json"
 
 
 class SourceModeV0(str, Enum):
@@ -922,5 +941,769 @@ def materialization_result_to_dict_v0(result: ContractMaterializationResultV0) -
 
 def exit_code_for_materialization_result_v0(result: ContractMaterializationResultV0) -> int:
     if result.status == MaterializationTerminalStatus.COMPLETE:
+        return 0
+    return 2
+
+
+class CorrectionExecutionTerminalStatus(str, Enum):
+    VALIDATE_ONLY_PASS = "VALIDATE_ONLY_PASS"
+    EXECUTION_COMPLETE = "EXECUTION_COMPLETE"
+    ALREADY_APPLIED_NOOP = "ALREADY_APPLIED_NOOP"
+    FAIL_CLOSED_OPERATOR_GO = "FAIL_CLOSED_OPERATOR_GO"
+    FAIL_CLOSED_DEFAULT_OFF = "FAIL_CLOSED_DEFAULT_OFF"
+    FAIL_CLOSED_PLAN_BINDING = "FAIL_CLOSED_PLAN_BINDING"
+    FAIL_CLOSED_INVALID_INPUT = "FAIL_CLOSED_INVALID_INPUT"
+    FAIL_CLOSED_MUTATION_SET = "FAIL_CLOSED_MUTATION_SET"
+    FAIL_CLOSED_POST_VALIDATION = "FAIL_CLOSED_POST_VALIDATION"
+
+
+@dataclass(frozen=True)
+class ArchiveCorrectionExecutionResultV0:
+    status: CorrectionExecutionTerminalStatus
+    validate_only: bool
+    target_archive_path: str
+    before_archive_digest: str | None
+    after_archive_digest: str | None
+    expected_mutation_set: dict[str, Any]
+    actual_mutation_set: dict[str, Any]
+    unexpected_change_count: int
+    supersession_records: tuple[ArchiveSupersessionRecordV0, ...] = ()
+    corrected_observation_digests: tuple[str, ...] = ()
+    post_validation: dict[str, Any] = field(default_factory=dict)
+    reason_codes: tuple[str, ...] = ()
+    authority_effect: str = AUTHORITY_EFFECT
+    runtime_effect: str = RUNTIME_EFFECT
+    economic_evaluation_executed: bool = False
+
+
+def _load_json_object_required(path: Path, label: str) -> dict[str, Any]:
+    if not path.is_file():
+        raise ValueError(f"missing_{label}:{path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"not_object:{path}")
+    return data
+
+
+def _read_jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if not isinstance(row, dict):
+            raise ValueError(f"invalid_jsonl_row:{path}")
+        rows.append(row)
+    return rows
+
+
+def _write_jsonl_rows(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(serialize_canonical_json(dict(row)) + "\n")
+
+
+def _archive_tree_snapshot(archive_dir: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for path in sorted(archive_dir.rglob("*")):
+        if path.is_file():
+            rel = path.relative_to(archive_dir).as_posix()
+            snapshot[rel] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return snapshot
+
+
+def _load_archive_manifest_digest(archive_dir: Path) -> str:
+    manifest = archive_dir / ARCHIVE_MANIFEST_FILENAME
+    if not manifest.is_file():
+        rows = _load_observation_rows(archive_dir)
+        return hashlib.sha256(
+            serialize_canonical_json([row["observation_digest"] for row in rows]).encode("utf-8")
+        ).hexdigest()
+    data = _load_json_object(manifest)
+    digest = data.get("archive_digest")
+    if not isinstance(digest, str) or not digest:
+        raise ValueError(f"missing_archive_digest:{archive_dir}")
+    return digest
+
+
+def _load_supersession_records_from_archive(archive_dir: Path) -> list[dict[str, Any]]:
+    return _read_jsonl_rows(archive_dir / SUPERSESSION_RECORDS_JSONL_FILENAME)
+
+
+def _load_corrected_observations_from_archive(archive_dir: Path) -> list[dict[str, Any]]:
+    return _read_jsonl_rows(archive_dir / CORRECTED_OBSERVATIONS_JSONL_FILENAME)
+
+
+def validate_bound_execution_plan_v0(
+    bound_plan: Mapping[str, Any],
+    *,
+    target_archive_path: Path,
+    cli_go_token: str,
+) -> tuple[tuple[str, ...], dict[str, Any]]:
+    reasons: list[str] = []
+    if bound_plan.get("schema_version") != BOUND_EXECUTION_PLAN_SCHEMA_VERSION:
+        reasons.append("BOUND_PLAN_SCHEMA_VERSION_MISMATCH")
+    plan_go = bound_plan.get("operator_go")
+    if plan_go != CONFIRM_GO_EXECUTION:
+        reasons.append("PLAN_OPERATOR_GO_MISMATCH")
+    if cli_go_token != CONFIRM_GO_EXECUTION:
+        reasons.append("CLI_OPERATOR_GO_MISMATCH")
+    if cli_go_token != plan_go:
+        reasons.append("CLI_PLAN_OPERATOR_GO_MISMATCH")
+    if bound_plan.get("execution_authorized") is not True:
+        reasons.append("PLAN_EXECUTION_NOT_AUTHORIZED")
+    plan_target = bound_plan.get("target_archive_path")
+    if str(target_archive_path) != str(plan_target):
+        reasons.append("TARGET_ARCHIVE_PATH_MISMATCH")
+    before_digest = bound_plan.get("before_archive_digest")
+    actual_before = _load_archive_manifest_digest(target_archive_path)
+    if before_digest != actual_before:
+        reasons.append("BEFORE_ARCHIVE_DIGEST_MISMATCH")
+    executable_binding = bound_plan.get("executable_binding")
+    if not isinstance(executable_binding, dict):
+        reasons.append("MISSING_EXECUTABLE_BINDING")
+        executable_binding = {}
+    if executable_binding.get("overwrite_allowed") is True:
+        reasons.append("OVERWRITE_NOT_ALLOWED")
+    if (
+        executable_binding.get("external_reference_usage")
+        != ExternalReferenceUsageV0.VALIDATION_ONLY.value
+    ):
+        reasons.append("EXTERNAL_REFERENCE_MUST_BE_VALIDATION_ONLY")
+    if bound_plan.get("external_reference_as_self_source_allowed") is True:
+        reasons.append("EXTERNAL_REFERENCE_AS_SELF_SOURCE_BLOCKED")
+    corrected = bound_plan.get("corrected_observations")
+    if not isinstance(corrected, list) or not corrected:
+        reasons.append("MISSING_CORRECTED_OBSERVATIONS")
+        corrected = []
+    collection_binding = bound_plan.get("collection_binding")
+    if not isinstance(collection_binding, dict):
+        reasons.append("MISSING_COLLECTION_BINDING")
+        collection_binding = {}
+    collection_execution_id = bound_plan.get("collection_execution_id")
+    if not isinstance(collection_execution_id, str) or not collection_execution_id:
+        reasons.append("MISSING_COLLECTION_EXECUTION_ID")
+        collection_execution_id = ""
+    fixture_refs = bound_plan.get("fixture_observations_to_preserve")
+    if not isinstance(fixture_refs, list):
+        reasons.append("MISSING_FIXTURE_OBSERVATIONS_TO_PRESERVE")
+        fixture_refs = []
+    external_ref = bound_plan.get("external_reference_input")
+    self_source = bound_plan.get("self_observation_source")
+    if self_source and external_ref and str(self_source) == str(external_ref):
+        reasons.append("EXTERNAL_REFERENCE_AS_SELF_SOURCE_BLOCKED")
+    normalized = {
+        "executable_binding": executable_binding,
+        "corrected_observations": corrected,
+        "collection_binding": collection_binding,
+        "collection_execution_id": collection_execution_id,
+        "fixture_observations_to_preserve": fixture_refs,
+        "actual_before_archive_digest": actual_before,
+    }
+    return tuple(reasons), normalized
+
+
+def build_expected_mutation_set_v0(
+    bound_plan: Mapping[str, Any],
+    *,
+    archive_dir: Path,
+) -> dict[str, Any]:
+    fixture_refs = list(bound_plan.get("fixture_observations_to_preserve", []))
+    corrected = bound_plan.get("corrected_observations", [])
+    supersession_plan = bound_plan.get("supersession_records", [])
+    return {
+        "append_only": True,
+        "conflict_overwrite_allowed": False,
+        "historical_evidence_preserved": True,
+        "observations_jsonl_unchanged": True,
+        "fixture_observations_preserved": fixture_refs,
+        "corrected_observations_to_append": [
+            row["observation_digest"] for row in corrected if isinstance(row, dict)
+        ],
+        "supersession_records_to_register": supersession_plan,
+        "files_to_create_or_update": sorted(
+            {
+                CORRECTED_OBSERVATIONS_JSONL_FILENAME,
+                SUPERSESSION_RECORDS_JSONL_FILENAME,
+                CORRECTION_GENERATION_BINDING_FILENAME,
+                ARCHIVE_MANIFEST_FILENAME,
+                MANIFEST_SHA256_FILENAME,
+            }
+        ),
+        "files_must_remain_unchanged": [OBSERVATIONS_JSONL_FILENAME],
+        "before_archive_digest": _load_archive_manifest_digest(archive_dir),
+        "expected_after_archive_digest": bound_plan.get("expected_after_archive_digest"),
+    }
+
+
+def _validate_corrected_observations_admissibility_v0(
+    corrected_rows: Sequence[Mapping[str, Any]],
+    *,
+    collection_binding: Mapping[str, Any],
+    collection_execution_id: str,
+    evidence_ref: str | None,
+) -> tuple[tuple[str, ...], tuple[ObservationAdmissibilityAssessmentV0, ...]]:
+    reasons: list[str] = []
+    assessments: list[ObservationAdmissibilityAssessmentV0] = []
+    for row in corrected_rows:
+        obs, obs_reason = observation_from_row_dict_v0(row)
+        if obs is None:
+            reasons.append(obs_reason or "INVALID_CORRECTED_OBSERVATION")
+            continue
+        assessment = assess_observation_admissibility_v0(
+            serialize_observation_for_assessment_v0(obs),
+            collection_binding=collection_binding,
+            evidence_ref=evidence_ref,
+            collection_execution_id=collection_execution_id,
+            snapshot_path=None,
+        )
+        assessments.append(assessment)
+        if (
+            assessment.admissibility
+            != ArchiveObservationAdmissibilityV0.PRODUCTION_ADMISSIBLE.value
+        ):
+            reasons.append("CORRECTED_OBSERVATION_NOT_PRODUCTION_ADMISSIBLE")
+        if not assessment.executable_binding_eligible:
+            reasons.append("CORRECTED_OBSERVATION_NOT_EXECUTABLE_BINDING_ELIGIBLE")
+    return tuple(reasons), tuple(assessments)
+
+
+def serialize_observation_for_assessment_v0(obs: Any) -> dict[str, Any]:
+    from src.research.okx_self_accumulated_forward_open_interest_archive_v0 import (
+        serialize_observation_v0,
+    )
+
+    return serialize_observation_v0(obs)
+
+
+def _fixture_digest_to_venue_ms(
+    fixture_observations: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    return {
+        str(row["observation_digest"]): int(row["venue_timestamp_ms"])
+        for row in fixture_observations
+        if isinstance(row, dict) and "observation_digest" in row and "venue_timestamp_ms" in row
+    }
+
+
+def _resolve_supersession_records_v0(
+    planned_records: Sequence[Mapping[str, Any]],
+    corrected_rows: Sequence[Mapping[str, Any]],
+    *,
+    fixture_observations: Sequence[Mapping[str, Any]],
+) -> tuple[tuple[ArchiveSupersessionRecordV0, ...], tuple[str, ...]]:
+    digest_to_venue = _fixture_digest_to_venue_ms(fixture_observations)
+    corrected_by_venue = {
+        int(row["venue_timestamp_ms"]): str(row["observation_digest"])
+        for row in corrected_rows
+        if isinstance(row, dict) and "venue_timestamp_ms" in row and "observation_digest" in row
+    }
+    records: list[ArchiveSupersessionRecordV0] = []
+    corrected_digests: list[str] = []
+    for planned in planned_records:
+        superseded = str(planned["superseded_observation_ref"])
+        replacement = planned.get("replacement_observation_ref")
+        if replacement is None:
+            venue_ms = digest_to_venue.get(superseded)
+            if venue_ms is None:
+                raise ValueError(f"missing_fixture_venue_for_superseded:{superseded}")
+            replacement = corrected_by_venue.get(venue_ms)
+        if replacement is None:
+            raise ValueError(f"missing_replacement_for_superseded:{superseded}")
+        records.append(
+            build_supersession_record_v0(
+                superseded_observation_ref=superseded,
+                replacement_observation_ref=str(replacement),
+                supersession_reason=str(
+                    planned.get(
+                        "supersession_reason",
+                        "FIXTURE_NON_PRODUCTION_REQUIRES_CORRECTED_GENERATION",
+                    )
+                ),
+            )
+        )
+        if str(replacement) not in corrected_digests:
+            corrected_digests.append(str(replacement))
+    return tuple(records), tuple(corrected_digests)
+
+
+def _supersession_already_applied_v0(
+    archive_dir: Path,
+    *,
+    planned_records: Sequence[Mapping[str, Any]],
+    corrected_rows: Sequence[Mapping[str, Any]],
+    fixture_observations: Sequence[Mapping[str, Any]],
+) -> bool:
+    existing = _load_supersession_records_from_archive(archive_dir)
+    if not existing or not planned_records:
+        return False
+    try:
+        planned_records_resolved, _ = _resolve_supersession_records_v0(
+            planned_records,
+            corrected_rows,
+            fixture_observations=fixture_observations,
+        )
+    except ValueError:
+        return False
+    existing_map = {
+        str(row["superseded_observation_ref"]): str(row.get("replacement_observation_ref"))
+        for row in existing
+    }
+    for record in planned_records_resolved:
+        if (
+            existing_map.get(record.superseded_observation_ref)
+            != record.replacement_observation_ref
+        ):
+            return False
+    return True
+
+
+def _apply_correction_to_staging_v0(
+    staging_dir: Path,
+    *,
+    bound_plan: Mapping[str, Any],
+    supersession_records: Sequence[ArchiveSupersessionRecordV0],
+    corrected_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    before_tree = _archive_tree_snapshot(staging_dir)
+    observations_path = staging_dir / OBSERVATIONS_JSONL_FILENAME
+    before_observations = observations_path.read_bytes() if observations_path.is_file() else b""
+
+    existing_corrected = _load_corrected_observations_from_archive(staging_dir)
+    existing_keys = {
+        str(row["observation_digest"]) for row in existing_corrected if "observation_digest" in row
+    }
+    merged_corrected = list(existing_corrected)
+    for row in corrected_rows:
+        digest = str(row["observation_digest"])
+        if digest not in existing_keys:
+            merged_corrected.append(dict(row))
+            existing_keys.add(digest)
+    _write_jsonl_rows(staging_dir / CORRECTED_OBSERVATIONS_JSONL_FILENAME, merged_corrected)
+
+    existing_supersession = _load_supersession_records_from_archive(staging_dir)
+    existing_sup_keys = {
+        str(row["superseded_observation_ref"])
+        for row in existing_supersession
+        if "superseded_observation_ref" in row
+    }
+    merged_supersession = list(existing_supersession)
+    for record in supersession_records:
+        if record.superseded_observation_ref in existing_sup_keys:
+            continue
+        merged_supersession.append(
+            {
+                "superseded_observation_ref": record.superseded_observation_ref,
+                "replacement_observation_ref": record.replacement_observation_ref,
+                "supersession_reason": record.supersession_reason,
+                "historical_record_preserved": record.historical_record_preserved,
+                "in_place_mutation": record.in_place_mutation,
+                "authority_effect": record.authority_effect,
+                "runtime_effect": record.runtime_effect,
+                "supersession_digest": record.supersession_digest,
+            }
+        )
+        existing_sup_keys.add(record.superseded_observation_ref)
+    _write_jsonl_rows(staging_dir / SUPERSESSION_RECORDS_JSONL_FILENAME, merged_supersession)
+
+    generation_binding = bound_plan.get("generation_binding")
+    if isinstance(generation_binding, dict):
+        (staging_dir / CORRECTION_GENERATION_BINDING_FILENAME).write_text(
+            json.dumps(generation_binding, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    manifest_path = staging_dir / ARCHIVE_MANIFEST_FILENAME
+    manifest = _load_json_object(manifest_path) if manifest_path.is_file() else {}
+    observations_digest = manifest.get("archive_digest")
+    if not isinstance(observations_digest, str) or not observations_digest:
+        observation_rows = _load_observation_rows(staging_dir)
+        observations_digest = hashlib.sha256(
+            serialize_canonical_json(
+                [row["observation_digest"] for row in observation_rows]
+            ).encode("utf-8")
+        ).hexdigest()
+    manifest["archive_digest"] = observations_digest
+    manifest["correction_applied"] = True
+    manifest["correction_generation_id"] = bound_plan.get("expected_after_archive_digest")
+    manifest["input_archive_generation_id"] = bound_plan.get("before_archive_digest")
+    manifest["corrected_observation_count"] = len(merged_corrected)
+    manifest["supersession_record_count"] = len(merged_supersession)
+    manifest["append_only"] = True
+    manifest["historical_evidence_preserved"] = True
+    manifest_path.write_text(
+        json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+    write_manifest_sha256_v0(staging_dir)
+
+    after_observations = observations_path.read_bytes() if observations_path.is_file() else b""
+    if before_observations != after_observations:
+        raise ValueError("OBSERVATIONS_JSONL_MUTATED")
+
+    after_tree = _archive_tree_snapshot(staging_dir)
+    changed_files = sorted(
+        rel
+        for rel in set(before_tree) | set(after_tree)
+        if before_tree.get(rel) != after_tree.get(rel)
+    )
+    return {
+        "changed_files": changed_files,
+        "observations_jsonl_unchanged": before_observations == after_observations,
+        "corrected_observation_count": len(merged_corrected),
+        "supersession_record_count": len(merged_supersession),
+    }
+
+
+def _promote_staging_to_target_v0(
+    staging_dir: Path, target_dir: Path, changed_files: Sequence[str]
+) -> None:
+    for rel in changed_files:
+        src = staging_dir / rel
+        dst = target_dir / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if src.is_file():
+            os.replace(src, dst)
+        elif dst.is_file():
+            dst.unlink()
+
+
+def _run_post_validators_v0(
+    archive_dir: Path,
+    *,
+    bound_plan: Mapping[str, Any],
+    supersession_records: Sequence[ArchiveSupersessionRecordV0],
+) -> tuple[tuple[str, ...], dict[str, Any]]:
+    from src.research.okx_self_accumulated_forward_open_interest_archive_integrity_audit_v0 import (
+        ArchiveIntegrityAuditStatus,
+        audit_archive_snapshot_v0,
+        audit_result_to_dict_v0,
+    )
+    from src.research.okx_self_accumulated_forward_open_interest_overlap_validation_v0 import (
+        OverlapValidationVerdict,
+        validate_overlap_v0,
+    )
+
+    reasons: list[str] = []
+    audit = audit_archive_snapshot_v0(snapshot_dir=archive_dir)
+    audit_report = audit_result_to_dict_v0(audit)
+    if audit.status not in {
+        ArchiveIntegrityAuditStatus.PASS,
+        ArchiveIntegrityAuditStatus.VALID_EMPTY,
+    }:
+        reasons.append("ARCHIVE_INTEGRITY_AUDIT_FAIL")
+
+    overlap_report: dict[str, Any] = {"verdict": OverlapValidationVerdict.NOT_EXECUTABLE.value}
+    external_ref = bound_plan.get("external_reference_input")
+    if external_ref:
+        validation_dir = Path(tempfile.mkdtemp(prefix="peak_trade_okx_oi_correction_validate_"))
+        try:
+            shutil.copytree(archive_dir, validation_dir / "archive", dirs_exist_ok=True)
+            corrected_src = archive_dir / CORRECTED_OBSERVATIONS_JSONL_FILENAME
+            if corrected_src.is_file():
+                shutil.copy2(
+                    corrected_src,
+                    validation_dir / "archive" / OBSERVATIONS_JSONL_FILENAME,
+                )
+            overlap = validate_overlap_v0(
+                self_accumulated_source=validation_dir / "archive",
+                external_reference_source=Path(str(external_ref)),
+            )
+            overlap_report = {
+                "verdict": overlap.verdict,
+                "status": overlap.status,
+                "matched_pair_count": overlap.matched_pair_count,
+                "mismatched_pair_count": overlap.mismatched_pair_count,
+            }
+            if overlap.verdict != OverlapValidationVerdict.PASS.value:
+                reasons.append("OVERLAP_VALIDATION_FAIL")
+        finally:
+            shutil.rmtree(validation_dir, ignore_errors=True)
+
+    for record in supersession_records:
+        if not record.historical_record_preserved:
+            reasons.append("HISTORICAL_EVIDENCE_NOT_PRESERVED")
+        if record.in_place_mutation:
+            reasons.append("IN_PLACE_MUTATION_NOT_ALLOWED")
+
+    return tuple(reasons), {
+        "archive_integrity_audit": audit_report,
+        "overlap_validation": overlap_report,
+        "supersession_relation_valid": not reasons,
+    }
+
+
+def execute_archive_correction_v0(
+    *,
+    confirm: str,
+    validate_only: bool,
+    execute_mutation: bool,
+    enabled: bool,
+    bound_plan_path: Path,
+    target_archive_path: Path,
+    source_manifest_dirs: Sequence[Path] | None = None,
+) -> ArchiveCorrectionExecutionResultV0:
+    empty_mutation: dict[str, Any] = {}
+    if not enabled and execute_mutation:
+        return ArchiveCorrectionExecutionResultV0(
+            status=CorrectionExecutionTerminalStatus.FAIL_CLOSED_DEFAULT_OFF,
+            validate_only=validate_only,
+            target_archive_path=str(target_archive_path),
+            before_archive_digest=None,
+            after_archive_digest=None,
+            expected_mutation_set=empty_mutation,
+            actual_mutation_set=empty_mutation,
+            unexpected_change_count=0,
+            reason_codes=("DEFAULT_OFF_ENABLED_FLAG_REQUIRED",),
+        )
+    if confirm != CONFIRM_GO_EXECUTION:
+        return ArchiveCorrectionExecutionResultV0(
+            status=CorrectionExecutionTerminalStatus.FAIL_CLOSED_OPERATOR_GO,
+            validate_only=validate_only,
+            target_archive_path=str(target_archive_path),
+            before_archive_digest=None,
+            after_archive_digest=None,
+            expected_mutation_set=empty_mutation,
+            actual_mutation_set=empty_mutation,
+            unexpected_change_count=0,
+            reason_codes=("CLI_OPERATOR_GO_MISMATCH",),
+        )
+    try:
+        bound_plan = _load_json_object_required(bound_plan_path, "bound_plan")
+    except ValueError as exc:
+        return ArchiveCorrectionExecutionResultV0(
+            status=CorrectionExecutionTerminalStatus.FAIL_CLOSED_INVALID_INPUT,
+            validate_only=validate_only,
+            target_archive_path=str(target_archive_path),
+            before_archive_digest=None,
+            after_archive_digest=None,
+            expected_mutation_set=empty_mutation,
+            actual_mutation_set=empty_mutation,
+            unexpected_change_count=0,
+            reason_codes=(str(exc),),
+        )
+
+    if source_manifest_dirs:
+        from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+
+        for manifest_dir in source_manifest_dirs:
+            ok, msg = verify_manifest_sha256(manifest_dir)
+            if not ok:
+                return ArchiveCorrectionExecutionResultV0(
+                    status=CorrectionExecutionTerminalStatus.FAIL_CLOSED_PLAN_BINDING,
+                    validate_only=validate_only,
+                    target_archive_path=str(target_archive_path),
+                    before_archive_digest=None,
+                    after_archive_digest=None,
+                    expected_mutation_set=empty_mutation,
+                    actual_mutation_set=empty_mutation,
+                    unexpected_change_count=0,
+                    reason_codes=(f"SOURCE_MANIFEST_VERIFY_FAIL:{manifest_dir}:{msg}",),
+                )
+
+    plan_reasons, normalized = validate_bound_execution_plan_v0(
+        bound_plan,
+        target_archive_path=target_archive_path,
+        cli_go_token=confirm,
+    )
+    if plan_reasons:
+        return ArchiveCorrectionExecutionResultV0(
+            status=CorrectionExecutionTerminalStatus.FAIL_CLOSED_PLAN_BINDING,
+            validate_only=validate_only,
+            target_archive_path=str(target_archive_path),
+            before_archive_digest=normalized.get("actual_before_archive_digest"),
+            after_archive_digest=None,
+            expected_mutation_set=empty_mutation,
+            actual_mutation_set=empty_mutation,
+            unexpected_change_count=0,
+            reason_codes=plan_reasons,
+        )
+
+    corrected_rows = [row for row in normalized["corrected_observations"] if isinstance(row, dict)]
+    admissibility_reasons, _ = _validate_corrected_observations_admissibility_v0(
+        corrected_rows,
+        collection_binding=normalized["collection_binding"],
+        collection_execution_id=normalized["collection_execution_id"],
+        evidence_ref=bound_plan.get("evidence_ref"),
+    )
+    if admissibility_reasons:
+        return ArchiveCorrectionExecutionResultV0(
+            status=CorrectionExecutionTerminalStatus.FAIL_CLOSED_PLAN_BINDING,
+            validate_only=validate_only,
+            target_archive_path=str(target_archive_path),
+            before_archive_digest=normalized.get("actual_before_archive_digest"),
+            after_archive_digest=None,
+            expected_mutation_set=empty_mutation,
+            actual_mutation_set=empty_mutation,
+            unexpected_change_count=0,
+            reason_codes=admissibility_reasons,
+        )
+
+    expected_mutation_set = build_expected_mutation_set_v0(
+        bound_plan, archive_dir=target_archive_path
+    )
+    planned_supersession = bound_plan.get("supersession_records", [])
+    if not isinstance(planned_supersession, list):
+        planned_supersession = []
+    fixture_observations = _load_observation_rows(target_archive_path)
+
+    if _supersession_already_applied_v0(
+        target_archive_path,
+        planned_records=planned_supersession,
+        corrected_rows=corrected_rows,
+        fixture_observations=fixture_observations,
+    ):
+        return ArchiveCorrectionExecutionResultV0(
+            status=CorrectionExecutionTerminalStatus.ALREADY_APPLIED_NOOP,
+            validate_only=validate_only,
+            target_archive_path=str(target_archive_path),
+            before_archive_digest=normalized.get("actual_before_archive_digest"),
+            after_archive_digest=bound_plan.get("expected_after_archive_digest"),
+            expected_mutation_set=expected_mutation_set,
+            actual_mutation_set={"mutation_applied": False, "reason": "ALREADY_APPLIED_NOOP"},
+            unexpected_change_count=0,
+            reason_codes=("ALREADY_APPLIED_NOOP",),
+        )
+
+    try:
+        supersession_records, corrected_digests = _resolve_supersession_records_v0(
+            planned_supersession,
+            corrected_rows,
+            fixture_observations=fixture_observations,
+        )
+    except ValueError as exc:
+        return ArchiveCorrectionExecutionResultV0(
+            status=CorrectionExecutionTerminalStatus.FAIL_CLOSED_PLAN_BINDING,
+            validate_only=validate_only,
+            target_archive_path=str(target_archive_path),
+            before_archive_digest=normalized.get("actual_before_archive_digest"),
+            after_archive_digest=None,
+            expected_mutation_set=expected_mutation_set,
+            actual_mutation_set=empty_mutation,
+            unexpected_change_count=0,
+            reason_codes=(str(exc),),
+        )
+
+    if validate_only or not execute_mutation:
+        return ArchiveCorrectionExecutionResultV0(
+            status=CorrectionExecutionTerminalStatus.VALIDATE_ONLY_PASS,
+            validate_only=True,
+            target_archive_path=str(target_archive_path),
+            before_archive_digest=normalized.get("actual_before_archive_digest"),
+            after_archive_digest=bound_plan.get("expected_after_archive_digest"),
+            expected_mutation_set=expected_mutation_set,
+            actual_mutation_set={"mutation_applied": False, "validate_only": True},
+            unexpected_change_count=0,
+            supersession_records=supersession_records,
+            corrected_observation_digests=corrected_digests,
+        )
+
+    staging_dir = Path(tempfile.mkdtemp(prefix="peak_trade_okx_oi_correction_stage_"))
+    try:
+        shutil.copytree(target_archive_path, staging_dir, dirs_exist_ok=True)
+        actual_mutation = _apply_correction_to_staging_v0(
+            staging_dir,
+            bound_plan=bound_plan,
+            supersession_records=supersession_records,
+            corrected_rows=corrected_rows,
+        )
+        unexpected = [
+            rel
+            for rel in actual_mutation["changed_files"]
+            if rel not in expected_mutation_set["files_to_create_or_update"]
+            and rel not in expected_mutation_set["files_must_remain_unchanged"]
+        ]
+        if unexpected:
+            return ArchiveCorrectionExecutionResultV0(
+                status=CorrectionExecutionTerminalStatus.FAIL_CLOSED_MUTATION_SET,
+                validate_only=False,
+                target_archive_path=str(target_archive_path),
+                before_archive_digest=normalized.get("actual_before_archive_digest"),
+                after_archive_digest=None,
+                expected_mutation_set=expected_mutation_set,
+                actual_mutation_set=actual_mutation,
+                unexpected_change_count=len(unexpected),
+                reason_codes=tuple(f"UNEXPECTED_CHANGE:{rel}" for rel in unexpected),
+            )
+        post_reasons, post_validation = _run_post_validators_v0(
+            staging_dir,
+            bound_plan=bound_plan,
+            supersession_records=supersession_records,
+        )
+        if post_reasons:
+            return ArchiveCorrectionExecutionResultV0(
+                status=CorrectionExecutionTerminalStatus.FAIL_CLOSED_POST_VALIDATION,
+                validate_only=False,
+                target_archive_path=str(target_archive_path),
+                before_archive_digest=normalized.get("actual_before_archive_digest"),
+                after_archive_digest=None,
+                expected_mutation_set=expected_mutation_set,
+                actual_mutation_set=actual_mutation,
+                unexpected_change_count=0,
+                post_validation=post_validation,
+                reason_codes=post_reasons,
+            )
+        _promote_staging_to_target_v0(
+            staging_dir, target_archive_path, actual_mutation["changed_files"]
+        )
+    finally:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+    return ArchiveCorrectionExecutionResultV0(
+        status=CorrectionExecutionTerminalStatus.EXECUTION_COMPLETE,
+        validate_only=False,
+        target_archive_path=str(target_archive_path),
+        before_archive_digest=normalized.get("actual_before_archive_digest"),
+        after_archive_digest=bound_plan.get("expected_after_archive_digest"),
+        expected_mutation_set=expected_mutation_set,
+        actual_mutation_set=actual_mutation,
+        unexpected_change_count=0,
+        supersession_records=supersession_records,
+        corrected_observation_digests=corrected_digests,
+        post_validation=post_validation,
+    )
+
+
+def correction_execution_result_to_dict_v0(
+    result: ArchiveCorrectionExecutionResultV0,
+) -> dict[str, Any]:
+    return {
+        "status": result.status.value,
+        "validate_only": result.validate_only,
+        "target_archive_path": result.target_archive_path,
+        "before_archive_digest": result.before_archive_digest,
+        "after_archive_digest": result.after_archive_digest,
+        "expected_mutation_set": result.expected_mutation_set,
+        "actual_mutation_set": result.actual_mutation_set,
+        "unexpected_change_count": result.unexpected_change_count,
+        "supersession_records": [
+            {
+                "superseded_observation_ref": r.superseded_observation_ref,
+                "replacement_observation_ref": r.replacement_observation_ref,
+                "supersession_reason": r.supersession_reason,
+                "historical_record_preserved": r.historical_record_preserved,
+                "in_place_mutation": r.in_place_mutation,
+                "supersession_digest": r.supersession_digest,
+            }
+            for r in result.supersession_records
+        ],
+        "corrected_observation_digests": list(result.corrected_observation_digests),
+        "post_validation": result.post_validation,
+        "reason_codes": list(result.reason_codes),
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+    }
+
+
+def exit_code_for_correction_execution_result_v0(
+    result: ArchiveCorrectionExecutionResultV0,
+) -> int:
+    if result.status in {
+        CorrectionExecutionTerminalStatus.VALIDATE_ONLY_PASS,
+        CorrectionExecutionTerminalStatus.EXECUTION_COMPLETE,
+        CorrectionExecutionTerminalStatus.ALREADY_APPLIED_NOOP,
+    }:
         return 0
     return 2

--- a/tests/research/test_okx_self_accumulated_forward_open_interest_archive_correction_execution_v0_contract.py
+++ b/tests/research/test_okx_self_accumulated_forward_open_interest_archive_correction_execution_v0_contract.py
@@ -1,0 +1,522 @@
+"""Contract tests for OKX self-accumulated forward OI archive correction execution v0."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.research.okx_self_accumulated_forward_open_interest_archive_correction_and_executable_binding_v0 import (
+    BOUND_EXECUTION_PLAN_SCHEMA_VERSION,
+    CONFIRM_GO_EXECUTION,
+    CORRECTED_OBSERVATIONS_JSONL_FILENAME,
+    CORRECTION_ENTRY_POINT,
+    SUPERSESSION_RECORDS_JSONL_FILENAME,
+    CorrectionExecutionTerminalStatus,
+    execute_archive_correction_v0,
+)
+from src.research.okx_self_accumulated_forward_open_interest_archive_v0 import (
+    COLLECTION_MODE_FORWARD_ONLY,
+    InstrumentArchiveStateV0,
+    append_forward_observation_v0,
+    compute_observation_digest_v0,
+    normalize_forward_open_interest_observation_v0,
+    persist_archive_snapshot_v0,
+    write_manifest_sha256_v0,
+)
+from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_PATH = REPO_ROOT / CORRECTION_ENTRY_POINT
+CONFIG_PATH = (
+    REPO_ROOT
+    / "config/research/okx_self_accumulated_forward_open_interest_archive_correction_and_executable_binding_v0.json"
+)
+FORBIDDEN_RUNTIME_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+)
+
+
+def _ms(utc: str) -> int:
+    return int(
+        datetime.strptime(utc, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp() * 1000
+    )
+
+
+def _observation_row(ts_utc: str, oi: str, collected_at_utc: str = "2026-07-11T19:30:00Z") -> dict:
+    payload = {
+        "instrument_id": "okx:linear_perpetual:ETH:USDT:USDT:perp",
+        "native_instrument_id": "ETH-USDT-SWAP",
+        "venue_timestamp_ms": _ms(ts_utc),
+        "venue_timestamp_utc": ts_utc,
+        "collected_at_ms": _ms(collected_at_utc),
+        "collected_at_utc": collected_at_utc,
+        "open_interest_raw": oi,
+        "open_interest_unit": "okx_native_contract_count",
+        "bar_interval": "PT1H",
+        "source_schema_version": "okx_rubik_open_interest_history.v0",
+        "source_endpoint": "/api/v5/rubik/stat/contracts/open-interest-history",
+        "source_record_key": f"ETH-USDT-SWAP:{_ms(ts_utc)}",
+        "collection_mode": COLLECTION_MODE_FORWARD_ONLY,
+    }
+    payload["observation_digest"] = compute_observation_digest_v0(payload)
+    return payload
+
+
+def _write_fixture_archive(tmp_path: Path) -> tuple[Path, list[dict]]:
+    snapshot_dir = tmp_path / "archive"
+    state = InstrumentArchiveStateV0(
+        instrument_id="okx:linear_perpetual:ETH:USDT:USDT:perp",
+        native_instrument_id="ETH-USDT-SWAP",
+    )
+    rows: list[dict] = []
+    for ts, oi in (
+        ("2026-07-11T11:00:00Z", "1234.5"),
+        ("2026-07-11T12:00:00Z", "1350.0"),
+    ):
+        row = [str(_ms(ts)), oi, "100.0", "2000000.0"]
+        obs = normalize_forward_open_interest_observation_v0(
+            row,
+            instrument_id=state.instrument_id,
+            native_instrument_id=state.native_instrument_id,
+            collected_at_utc="2026-07-11T18:10:07Z",
+        )
+        assert obs is not None
+        append_forward_observation_v0(state, obs, preconditions_checked=True)
+        rows.append(
+            {
+                "instrument_id": obs.instrument_id,
+                "native_instrument_id": obs.native_instrument_id,
+                "venue_timestamp_ms": obs.venue_timestamp_ms,
+                "venue_timestamp_utc": obs.venue_timestamp_utc,
+                "collected_at_ms": obs.collected_at_ms,
+                "collected_at_utc": obs.collected_at_utc,
+                "open_interest_raw": obs.open_interest_raw,
+                "open_interest_unit": obs.open_interest_unit,
+                "bar_interval": obs.bar_interval,
+                "source_schema_version": obs.source_schema_version,
+                "source_endpoint": obs.source_endpoint,
+                "source_record_key": obs.source_record_key,
+                "collection_mode": obs.collection_mode,
+                "observation_digest": obs.observation_digest,
+            }
+        )
+    persist_archive_snapshot_v0([state], output_dir=snapshot_dir)
+    write_manifest_sha256_v0(snapshot_dir)
+    return snapshot_dir, rows
+
+
+def _write_external_reference(tmp_path: Path) -> Path:
+    ref_dir = tmp_path / "external_ref"
+    ref_dir.mkdir(parents=True)
+    rows = [
+        _observation_row("2026-07-11T11:00:00Z", "7193416.080000025"),
+        _observation_row("2026-07-11T12:00:00Z", "7211803.7800000251"),
+    ]
+    (ref_dir / "observations.jsonl").write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+    return ref_dir
+
+
+def _bound_plan(
+    tmp_path: Path,
+    archive_dir: Path,
+    fixture_rows: list[dict],
+    *,
+    execution_authorized: bool = True,
+    operator_go: str = CONFIRM_GO_EXECUTION,
+    before_digest: str | None = None,
+    external_ref: Path | None = None,
+    self_source: str | None = None,
+) -> Path:
+    if before_digest is None:
+        manifest = json.loads((archive_dir / "archive_manifest.json").read_text(encoding="utf-8"))
+        before_digest = manifest["archive_digest"]
+    corrected = [
+        _observation_row("2026-07-11T11:00:00Z", "7193416.080000025"),
+        _observation_row("2026-07-11T12:00:00Z", "7211803.7800000251"),
+    ]
+    if external_ref is None:
+        external_ref = _write_external_reference(tmp_path)
+    plan = {
+        "schema_version": BOUND_EXECUTION_PLAN_SCHEMA_VERSION,
+        "operator_go": operator_go,
+        "execution_authorized": execution_authorized,
+        "target_archive_path": str(archive_dir),
+        "before_archive_digest": before_digest,
+        "expected_after_archive_digest": f"{before_digest}:corrected_v0",
+        "external_reference_input": str(external_ref),
+        "external_reference_as_self_source_allowed": False,
+        "self_observation_source": self_source,
+        "fixture_observations_to_preserve": [row["observation_digest"] for row in fixture_rows],
+        "corrected_observations": corrected,
+        "collection_binding": {
+            "enable_live_fetch": True,
+            "fixture_source_used": False,
+            "network_allowed": True,
+        },
+        "collection_execution_id": "exec-live-correction-1",
+        "evidence_ref": str(tmp_path / "evidence"),
+        "executable_binding": {
+            "overwrite_allowed": False,
+            "external_reference_usage": "VALIDATION_ONLY",
+            "historical_evidence_preserved": True,
+        },
+        "supersession_records": [
+            {
+                "superseded_observation_ref": fixture_rows[0]["observation_digest"],
+                "replacement_observation_ref": None,
+                "supersession_reason": "FIXTURE_NON_PRODUCTION_REQUIRES_CORRECTED_GENERATION",
+            },
+            {
+                "superseded_observation_ref": fixture_rows[1]["observation_digest"],
+                "replacement_observation_ref": None,
+                "supersession_reason": "FIXTURE_NON_PRODUCTION_REQUIRES_CORRECTED_GENERATION",
+            },
+        ],
+        "generation_binding": {
+            "generation_id": f"{before_digest}:corrected_v0",
+            "parent_generation_id": before_digest,
+            "generation_mode": "CORRECTION",
+        },
+    }
+    plan_path = tmp_path / "bound_plan.json"
+    plan_path.write_text(json.dumps(plan, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    return plan_path
+
+
+def _run_cli(
+    tmp_path: Path, archive_dir: Path, plan_path: Path, *extra: str
+) -> subprocess.CompletedProcess:
+    cmd = [
+        sys.executable,
+        str(CLI_PATH),
+        "--confirm-go-token",
+        CONFIRM_GO_EXECUTION,
+        "--bound-plan",
+        str(plan_path),
+        "--target-archive",
+        str(archive_dir),
+        *extra,
+    ]
+    return subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+
+
+class TestConfigAndImports:
+    def test_config_binds_entry_point_and_go_token(self) -> None:
+        config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        assert config["correction_execution_entry_point"] == CORRECTION_ENTRY_POINT
+        assert config["correction_execution_go_token"] == CONFIRM_GO_EXECUTION
+        assert config["correction_execution_validate_only_default"] is True
+        assert config["explicit_mutation_flag_required"] is True
+        assert config["no_archive_correction_execution"] is True
+        assert config["correction_execution_authorized"] is False
+
+    def test_no_runtime_imports(self) -> None:
+        module_path = REPO_ROOT / (
+            "src/research/okx_self_accumulated_forward_open_interest_archive_correction_and_executable_binding_v0.py"
+        )
+        cli_source = CLI_PATH.read_text(encoding="utf-8")
+        for prefix in FORBIDDEN_RUNTIME_IMPORT_PREFIXES:
+            assert prefix not in module_path.read_text(encoding="utf-8")
+            assert prefix not in cli_source
+
+
+class TestAuthorityAndRejection:
+    def test_missing_go_token_rejected(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(tmp_path, archive_dir, fixture_rows)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(CLI_PATH),
+                "--bound-plan",
+                str(plan_path),
+                "--target-archive",
+                str(archive_dir),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode != 0
+
+    def test_wrong_go_token_rejected(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(tmp_path, archive_dir, fixture_rows)
+        result = _run_cli(tmp_path, archive_dir, plan_path, "--confirm-go-token", "GO_WRONG")
+        assert result.returncode == 2
+
+    def test_unbound_go_token_rejected(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(
+            tmp_path,
+            archive_dir,
+            fixture_rows,
+            operator_go="GO_UNBOUND_TOKEN",
+        )
+        result = execute_archive_correction_v0(
+            confirm=CONFIRM_GO_EXECUTION,
+            validate_only=True,
+            execute_mutation=False,
+            enabled=False,
+            bound_plan_path=plan_path,
+            target_archive_path=archive_dir,
+        )
+        assert result.status == CorrectionExecutionTerminalStatus.FAIL_CLOSED_PLAN_BINDING
+        assert "PLAN_OPERATOR_GO_MISMATCH" in result.reason_codes
+
+    def test_plan_execution_authorized_false_rejected(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(
+            tmp_path,
+            archive_dir,
+            fixture_rows,
+            execution_authorized=False,
+        )
+        result = execute_archive_correction_v0(
+            confirm=CONFIRM_GO_EXECUTION,
+            validate_only=True,
+            execute_mutation=False,
+            enabled=False,
+            bound_plan_path=plan_path,
+            target_archive_path=archive_dir,
+        )
+        assert result.status == CorrectionExecutionTerminalStatus.FAIL_CLOSED_PLAN_BINDING
+        assert "PLAN_EXECUTION_NOT_AUTHORIZED" in result.reason_codes
+
+    def test_validate_only_default_no_mutation(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(tmp_path, archive_dir, fixture_rows)
+        before = (archive_dir / "observations.jsonl").read_bytes()
+        result = _run_cli(tmp_path, archive_dir, plan_path)
+        after = (archive_dir / "observations.jsonl").read_bytes()
+        assert result.returncode == 0
+        assert before == after
+        assert not (archive_dir / CORRECTED_OBSERVATIONS_JSONL_FILENAME).exists()
+
+    def test_explicit_mutation_flag_required(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(tmp_path, archive_dir, fixture_rows)
+        result = _run_cli(
+            tmp_path,
+            archive_dir,
+            plan_path,
+            "--execute-mutation",
+        )
+        assert result.returncode != 0
+        assert "EXECUTE_MUTATION_REQUIRES_ENABLED_FLAG" in result.stderr
+
+    def test_source_manifest_failure_rejected(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(tmp_path, archive_dir, fixture_rows)
+        bad_manifest_dir = tmp_path / "bad_manifest"
+        bad_manifest_dir.mkdir()
+        (bad_manifest_dir / "MANIFEST.sha256").write_text(
+            "deadbeef  missing.txt\n", encoding="utf-8"
+        )
+        result = execute_archive_correction_v0(
+            confirm=CONFIRM_GO_EXECUTION,
+            validate_only=True,
+            execute_mutation=False,
+            enabled=False,
+            bound_plan_path=plan_path,
+            target_archive_path=archive_dir,
+            source_manifest_dirs=(bad_manifest_dir,),
+        )
+        assert result.status == CorrectionExecutionTerminalStatus.FAIL_CLOSED_PLAN_BINDING
+        assert any("SOURCE_MANIFEST_VERIFY_FAIL" in code for code in result.reason_codes)
+
+    def test_wrong_target_archive_rejected(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        other_dir, _ = _write_fixture_archive(tmp_path / "other")
+        plan_path = _bound_plan(tmp_path, archive_dir, fixture_rows)
+        result = execute_archive_correction_v0(
+            confirm=CONFIRM_GO_EXECUTION,
+            validate_only=True,
+            execute_mutation=False,
+            enabled=False,
+            bound_plan_path=plan_path,
+            target_archive_path=other_dir,
+        )
+        assert result.status == CorrectionExecutionTerminalStatus.FAIL_CLOSED_PLAN_BINDING
+        assert "TARGET_ARCHIVE_PATH_MISMATCH" in result.reason_codes
+
+    def test_before_digest_mismatch_rejected(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(
+            tmp_path,
+            archive_dir,
+            fixture_rows,
+            before_digest="deadbeef",
+        )
+        result = execute_archive_correction_v0(
+            confirm=CONFIRM_GO_EXECUTION,
+            validate_only=True,
+            execute_mutation=False,
+            enabled=False,
+            bound_plan_path=plan_path,
+            target_archive_path=archive_dir,
+        )
+        assert "BEFORE_ARCHIVE_DIGEST_MISMATCH" in result.reason_codes
+
+    def test_external_reference_as_self_source_rejected(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        external_ref = _write_external_reference(tmp_path)
+        plan_path = _bound_plan(
+            tmp_path,
+            archive_dir,
+            fixture_rows,
+            external_ref=external_ref,
+            self_source=str(external_ref),
+        )
+        result = execute_archive_correction_v0(
+            confirm=CONFIRM_GO_EXECUTION,
+            validate_only=True,
+            execute_mutation=False,
+            enabled=False,
+            bound_plan_path=plan_path,
+            target_archive_path=archive_dir,
+        )
+        assert "EXTERNAL_REFERENCE_AS_SELF_SOURCE_BLOCKED" in result.reason_codes
+
+
+class TestIntegrationExecution:
+    def test_real_entry_point_append_only_supersession_and_idempotency(
+        self, tmp_path: Path
+    ) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(tmp_path, archive_dir, fixture_rows)
+        before_obs = (archive_dir / "observations.jsonl").read_text(encoding="utf-8")
+
+        result = _run_cli(
+            tmp_path,
+            archive_dir,
+            plan_path,
+            "--execute-mutation",
+            "--enabled",
+        )
+        assert result.returncode == 0, result.stderr + result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["status"] == CorrectionExecutionTerminalStatus.EXECUTION_COMPLETE.value
+        assert payload["authority_effect"] == "NONE"
+        assert payload["runtime_effect"] == "NONE"
+        assert payload["economic_evaluation_executed"] is False
+        assert (archive_dir / "observations.jsonl").read_text(encoding="utf-8") == before_obs
+        assert (archive_dir / CORRECTED_OBSERVATIONS_JSONL_FILENAME).is_file()
+        assert (archive_dir / SUPERSESSION_RECORDS_JSONL_FILENAME).is_file()
+        supersession_rows = [
+            json.loads(line)
+            for line in (archive_dir / SUPERSESSION_RECORDS_JSONL_FILENAME)
+            .read_text(encoding="utf-8")
+            .splitlines()
+            if line.strip()
+        ]
+        assert len(supersession_rows) == 2
+        assert all(row["historical_record_preserved"] for row in supersession_rows)
+        assert all(row["replacement_observation_ref"] for row in supersession_rows)
+
+        repeat = _run_cli(
+            tmp_path,
+            archive_dir,
+            plan_path,
+            "--execute-mutation",
+            "--enabled",
+        )
+        assert repeat.returncode == 0
+        repeat_payload = json.loads(repeat.stdout)
+        assert (
+            repeat_payload["status"] == CorrectionExecutionTerminalStatus.ALREADY_APPLIED_NOOP.value
+        )
+
+    def test_deterministic_second_validate_only_diff_empty(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(tmp_path, archive_dir, fixture_rows)
+        first = execute_archive_correction_v0(
+            confirm=CONFIRM_GO_EXECUTION,
+            validate_only=True,
+            execute_mutation=False,
+            enabled=False,
+            bound_plan_path=plan_path,
+            target_archive_path=archive_dir,
+        )
+        second = execute_archive_correction_v0(
+            confirm=CONFIRM_GO_EXECUTION,
+            validate_only=True,
+            execute_mutation=False,
+            enabled=False,
+            bound_plan_path=plan_path,
+            target_archive_path=archive_dir,
+        )
+        assert json.dumps(
+            {
+                "status": first.status.value,
+                "reason_codes": list(first.reason_codes),
+                "expected": first.expected_mutation_set,
+            },
+            sort_keys=True,
+        ) == json.dumps(
+            {
+                "status": second.status.value,
+                "reason_codes": list(second.reason_codes),
+                "expected": second.expected_mutation_set,
+            },
+            sort_keys=True,
+        )
+
+    def test_conflict_overwrite_rejected(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(tmp_path, archive_dir, fixture_rows)
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        plan["executable_binding"]["overwrite_allowed"] = True
+        plan_path.write_text(json.dumps(plan, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+        result = execute_archive_correction_v0(
+            confirm=CONFIRM_GO_EXECUTION,
+            validate_only=True,
+            execute_mutation=False,
+            enabled=False,
+            bound_plan_path=plan_path,
+            target_archive_path=archive_dir,
+        )
+        assert "OVERWRITE_NOT_ALLOWED" in result.reason_codes
+
+    def test_production_path_not_derived_from_fixture(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        plan_path = _bound_plan(tmp_path, archive_dir, fixture_rows)
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        assert "production_snapshot" not in plan["target_archive_path"]
+        result = execute_archive_correction_v0(
+            confirm=CONFIRM_GO_EXECUTION,
+            validate_only=True,
+            execute_mutation=False,
+            enabled=False,
+            bound_plan_path=plan_path,
+            target_archive_path=archive_dir,
+        )
+        assert result.status == CorrectionExecutionTerminalStatus.VALIDATE_ONLY_PASS
+
+    def test_plan_manifest_failure_rejected(self, tmp_path: Path) -> None:
+        archive_dir, fixture_rows = _write_fixture_archive(tmp_path)
+        manifest_dir = tmp_path / "source_manifest"
+        manifest_dir.mkdir()
+        (manifest_dir / "proof.txt").write_text("proof\n", encoding="utf-8")
+        write_manifest_sha256(manifest_dir)
+        (manifest_dir / "proof.txt").write_text("mutated\n", encoding="utf-8")
+        plan_path = _bound_plan(tmp_path, archive_dir, fixture_rows)
+        result = execute_archive_correction_v0(
+            confirm=CONFIRM_GO_EXECUTION,
+            validate_only=True,
+            execute_mutation=False,
+            enabled=False,
+            bound_plan_path=plan_path,
+            target_archive_path=archive_dir,
+            source_manifest_dirs=(manifest_dir,),
+        )
+        assert result.status == CorrectionExecutionTerminalStatus.FAIL_CLOSED_PLAN_BINDING


### PR DESCRIPTION
## Summary
- Adds a thin canonical execution entry point (`execute_okx_self_accumulated_forward_open_interest_archive_correction_v0.py`) for one bounded append-only archive correction against a bound execution plan.
- Extends the existing correction/binding owner with validate-only-by-default execution semantics, atomic staging promotion, supersession persistence, and post-mutation integrity/overlap validation.
- Binds GO token and entry-point metadata in the existing correction config without globally enabling archive correction execution.

## Test plan
- [x] `pytest tests/research/test_okx_self_accumulated_forward_open_interest_archive_correction_execution_v0_contract.py`
- [x] `pytest tests/research/test_okx_self_accumulated_forward_open_interest_archive_correction_and_executable_binding_v0_contract.py`
- [x] `ruff format --check` and `ruff check` on changed Python files
- [ ] Wait for CI checks on PR (PR_BOUNDED_FULL per selector)


Made with [Cursor](https://cursor.com)