### PR TITLE
Fix OI level-rank v0 economic evidence materializer binding compatibility

### DIFF
--- a/src/research/cross_sectional_open_interest_level_rank_v0_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_open_interest_level_rank_v0_offline_economic_evaluation_execution_v0.py
@@ -165,6 +165,22 @@ REASON_NON_ALIGNED_PANEL = "NON_ALIGNED_PANEL_REJECTED"
 REASON_PANEL_MANIFEST_MISSING = "PANEL_MANIFEST_MISSING"
 REASON_PANEL_BARS_MISSING = "PANEL_BARS_MISSING"
 REASON_ECONOMIC_EXECUTION_FORBIDDEN = "ECONOMIC_EXECUTION_FORBIDDEN_IN_ADAPTER_SCOPE"
+REASON_INSTRUMENT_BINDING_MISSING = "INSTRUMENT_BINDING_MISSING"
+REASON_FEE_BINDING_MISSING = "FEE_BINDING_MISSING"
+REASON_SLIPPAGE_BINDING_MISSING = "SLIPPAGE_BINDING_MISSING"
+REASON_FUNDING_BINDING_MISSING = "FUNDING_BINDING_MISSING"
+REASON_CONFLICTING_INSTRUMENT_BINDINGS = "CONFLICTING_INSTRUMENT_BINDINGS"
+REASON_CONFLICTING_FEE_BINDINGS = "CONFLICTING_FEE_BINDINGS"
+REASON_CONFLICTING_SLIPPAGE_BINDINGS = "CONFLICTING_SLIPPAGE_BINDINGS"
+REASON_CONFLICTING_FUNDING_BINDINGS = "CONFLICTING_FUNDING_BINDINGS"
+
+
+class EconomicViabilityEvidenceBindingResolutionError(ValueError):
+    def __init__(self, reason_code: str, *, detail: str = "") -> None:
+        self.reason_code = reason_code
+        self.detail = detail
+        message = reason_code if not detail else f"{reason_code}:{detail}"
+        super().__init__(message)
 
 
 class PrecheckTerminalStatus(str, Enum):
@@ -545,6 +561,91 @@ def _normalize_cost_execution_binding_for_backtest_v0(
         "slippage_model_binding": cost_execution_binding.get("slippage_binding", {}),
         "funding_model_binding": cost_execution_binding.get("funding_binding", {}),
     }
+
+
+def _resolve_binding_reference_field_v0(
+    *,
+    container: Mapping[str, Any],
+    legacy_key: str,
+    level_rank_key: str,
+    missing_reason: str,
+    conflict_reason: str,
+) -> dict[str, Any]:
+    legacy_value = container.get(legacy_key)
+    level_rank_value = container.get(level_rank_key)
+    if legacy_value is not None and level_rank_value is not None:
+        if _stable_digest(legacy_value) != _stable_digest(level_rank_value):
+            raise EconomicViabilityEvidenceBindingResolutionError(
+                conflict_reason,
+                detail=f"{legacy_key}!={level_rank_key}",
+            )
+    if legacy_value is not None:
+        return dict(legacy_value)
+    if level_rank_value is not None:
+        return dict(level_rank_value)
+    raise EconomicViabilityEvidenceBindingResolutionError(missing_reason)
+
+
+def resolve_economic_viability_binding_references_v0(
+    envelope: Mapping[str, Any],
+) -> dict[str, Any]:
+    universe_binding = _resolve_binding_reference_field_v0(
+        container=envelope,
+        legacy_key="instrument_binding",
+        level_rank_key="pit_universe_binding",
+        missing_reason=REASON_INSTRUMENT_BINDING_MISSING,
+        conflict_reason=REASON_CONFLICTING_INSTRUMENT_BINDINGS,
+    )
+    cost_binding = envelope.get("cost_execution_binding")
+    if not isinstance(cost_binding, Mapping):
+        raise EconomicViabilityEvidenceBindingResolutionError(
+            REASON_BINDING_INCOMPLETE,
+            detail="cost_execution_binding_missing",
+        )
+    fee_model_binding = _resolve_binding_reference_field_v0(
+        container=cost_binding,
+        legacy_key="fee_model_binding",
+        level_rank_key="fee_binding",
+        missing_reason=REASON_FEE_BINDING_MISSING,
+        conflict_reason=REASON_CONFLICTING_FEE_BINDINGS,
+    )
+    slippage_model_binding = _resolve_binding_reference_field_v0(
+        container=cost_binding,
+        legacy_key="slippage_model_binding",
+        level_rank_key="slippage_binding",
+        missing_reason=REASON_SLIPPAGE_BINDING_MISSING,
+        conflict_reason=REASON_CONFLICTING_SLIPPAGE_BINDINGS,
+    )
+    funding_model_binding = _resolve_binding_reference_field_v0(
+        container=cost_binding,
+        legacy_key="funding_model_binding",
+        level_rank_key="funding_binding",
+        missing_reason=REASON_FUNDING_BINDING_MISSING,
+        conflict_reason=REASON_CONFLICTING_FUNDING_BINDINGS,
+    )
+    execution_model_binding = cost_binding.get("execution_model_binding")
+    if not isinstance(execution_model_binding, Mapping):
+        raise EconomicViabilityEvidenceBindingResolutionError(
+            REASON_BINDING_INCOMPLETE,
+            detail="execution_model_binding_missing",
+        )
+
+    references: dict[str, Any] = {
+        "instrument_binding": universe_binding,
+        "fee_model_binding": fee_model_binding,
+        "slippage_model_binding": slippage_model_binding,
+        "funding_model_binding": funding_model_binding,
+        "execution_model_binding": dict(execution_model_binding),
+    }
+    if "pit_universe_binding" in envelope and "instrument_binding" not in envelope:
+        references["pit_universe_binding"] = universe_binding
+    if "fee_binding" in cost_binding and "fee_model_binding" not in cost_binding:
+        references["fee_binding"] = fee_model_binding
+    if "slippage_binding" in cost_binding and "slippage_model_binding" not in cost_binding:
+        references["slippage_binding"] = slippage_model_binding
+    if "funding_binding" in cost_binding and "funding_model_binding" not in cost_binding:
+        references["funding_binding"] = funding_model_binding
+    return references
 
 
 def load_ops_evaluation_config_v0(repo_root: Path) -> dict[str, Any]:
@@ -1395,6 +1496,7 @@ def materialize_economic_viability_evidence(
     long_contrib, short_contrib = _compute_long_short_contribution(backtest)
     single_trade_val = _compute_single_trade_contribution(backtest)
     single_regime_val = _compute_single_regime_contribution(backtest)
+    resolved_bindings = resolve_economic_viability_binding_references_v0(envelope)
 
     body: dict[str, Any] = {
         "schema_version": "economic_viability_evidence_cross_sectional_open_interest_level_rank_v0",
@@ -1444,19 +1546,29 @@ def materialize_economic_viability_evidence(
             "parameter_binding": envelope["parameter_binding"],
             "dataset_binding": envelope["panel_dataset_binding"],
             "period_binding": envelope["period_binding"],
-            "instrument_binding": envelope["instrument_binding"],
-            "fee_model_binding": envelope["cost_execution_binding"]["fee_model_binding"],
-            "slippage_model_binding": envelope["cost_execution_binding"]["slippage_model_binding"],
-            "funding_model_binding": envelope["cost_execution_binding"]["funding_model_binding"],
-            "execution_model_binding": envelope["cost_execution_binding"][
-                "execution_model_binding"
-            ],
+            "instrument_binding": resolved_bindings["instrument_binding"],
+            "fee_model_binding": resolved_bindings["fee_model_binding"],
+            "slippage_model_binding": resolved_bindings["slippage_model_binding"],
+            "funding_model_binding": resolved_bindings["funding_model_binding"],
+            "execution_model_binding": resolved_bindings["execution_model_binding"],
             "economic_policy_binding": envelope["economic_policy_binding"],
             "implementation_digest": envelope.get("implementation_digest"),
             "config_digest": envelope["config_digest"],
             "data_digest": panel_data_digest,
             "ratification_digest": ratification.get("ratification_digest"),
             "ops_config_digest": ops_config.get("config_digest"),
+            **{
+                key: value
+                for key, value in resolved_bindings.items()
+                if key
+                not in {
+                    "instrument_binding",
+                    "fee_model_binding",
+                    "slippage_model_binding",
+                    "funding_model_binding",
+                    "execution_model_binding",
+                }
+            },
         },
         "materialization_root": str(materialization_root),
         "fixture_data_digest_excluded": FIXTURE_DATA_DIGEST,

--- a/tests/research/test_cross_sectional_open_interest_level_rank_v0_economic_viability_evidence_materializer_binding_compatibility_v0.py
+++ b/tests/research/test_cross_sectional_open_interest_level_rank_v0_economic_viability_evidence_materializer_binding_compatibility_v0.py
@@ -1,0 +1,211 @@
+"""Binding-compatibility contract tests for level-rank economic viability evidence materializer v0."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.backtest.economic_validity_policy_v1 import (
+    EconomicValidityEvaluationStatus,
+    EconomicValidityGateEvaluationV1,
+)
+from src.research.cross_sectional_open_interest_level_rank_v0_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    REASON_CONFLICTING_FEE_BINDINGS,
+    REASON_CONFLICTING_INSTRUMENT_BINDINGS,
+    REASON_FEE_BINDING_MISSING,
+    REASON_INSTRUMENT_BINDING_MISSING,
+    RUNTIME_EFFECT,
+    EconomicClassification,
+    EconomicViabilityEvidenceBindingResolutionError,
+    CrossSectionalRobustnessMetricsV0,
+    materialize_economic_viability_evidence,
+    resolve_economic_viability_binding_references_v0,
+)
+from src.research.cross_sectional_open_interest_level_rank_v0_versioned_hypothesis_binding_v0 import (
+    materialize_versioned_hypothesis_binding_v0,
+)
+from src.research.cross_sectional_open_interest_delta_rank_v0_versioned_research_binding_v0 import (
+    materialize_versioned_research_binding_v0,
+)
+from src.research.cross_sectional_panel_economic_evaluation_wiring_v0 import (
+    RobustnessStageResultsV0,
+)
+from src.research.cross_sectional_single_slot_backtest_wiring_v0 import (
+    SingleSlotBacktestResultV0,
+)
+
+EXPECTED_BINDING_DIGEST = "b7099d17af888dabebf14a63797729f807f866d265aeb5095c385541222fc2f2"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _minimal_backtest() -> SingleSlotBacktestResultV0:
+    equity = pd.Series(
+        [10000.0, 9990.0], index=pd.to_datetime(["2024-05-01", "2024-05-02"], utc=True)
+    )
+    return SingleSlotBacktestResultV0(
+        wiring_version="v0",
+        initial_cash=10000.0,
+        final_equity=9990.0,
+        gross_return=-0.001,
+        net_return=-0.001,
+        trade_count=1,
+        turnover=1.0,
+        fee_drag=1.0,
+        slippage_impact=0.5,
+        roundtrip_cost_bps=20.0,
+        equity_curve=equity,
+        trades=pd.DataFrame(),
+        stats={"expectancy": -10.0, "profit_factor": 0.0, "sharpe": -1.0, "sortino": -1.0},
+        authority_effect=AUTHORITY_EFFECT,
+    )
+
+
+def _minimal_robustness() -> RobustnessStageResultsV0:
+    return RobustnessStageResultsV0(
+        wiring_version="v0",
+        walk_forward_results=(),
+        monte_carlo_summary={"metric_quantiles": {"total_return": {"p50": -0.001}}},
+        stress_results={"scenarios": []},
+        parameter_sensitivity_status="NOT_EXECUTED",
+        authority_effect=AUTHORITY_EFFECT,
+    )
+
+
+def _minimal_robustness_metrics() -> CrossSectionalRobustnessMetricsV0:
+    return CrossSectionalRobustnessMetricsV0(
+        walk_forward_pass_ratio=0.0,
+        out_of_sample_pass_ratio=0.0,
+        monte_carlo_pass_ratio=0.0,
+        stress_failure_count=0,
+        parameter_robustness_pass=True,
+        parameter_neighbor_degradation=0.0,
+    )
+
+
+def _minimal_gate() -> EconomicValidityGateEvaluationV1:
+    return EconomicValidityGateEvaluationV1(
+        gates_pass=False,
+        reason_codes=("METRIC_MISSING_trade_count",),
+        policy_threshold_status="BLOCKED",
+        evaluation_status=EconomicValidityEvaluationStatus.BLOCKED,
+    )
+
+
+def _materialize_with_envelope(envelope: dict) -> dict:
+    return materialize_economic_viability_evidence(
+        ratification={"ratification_digest": "abc123"},
+        versioned_binding=envelope,
+        materialization_root=Path("/tmp/materialization"),
+        panel_data_digest=envelope.get("data_digest", "0" * 64),
+        backtest=_minimal_backtest(),
+        robustness=_minimal_robustness(),
+        robustness_metrics=_minimal_robustness_metrics(),
+        gate_evaluation=_minimal_gate(),
+        economic_classification=EconomicClassification.INCONCLUSIVE,
+        ops_config={"config_digest": envelope.get("config_digest", "0" * 64)},
+    )
+
+
+@pytest.fixture(name="level_rank_binding")
+def fixture_level_rank_binding() -> dict:
+    return materialize_versioned_hypothesis_binding_v0()
+
+
+@pytest.fixture(name="legacy_binding")
+def fixture_legacy_binding() -> dict:
+    envelope = copy.deepcopy(materialize_versioned_research_binding_v0())
+    envelope.pop("pit_universe_binding", None)
+    return envelope
+
+
+def test_level_rank_binding_digest_unchanged(level_rank_binding: dict) -> None:
+    assert level_rank_binding["binding_digest"] == EXPECTED_BINDING_DIGEST
+
+
+def test_level_rank_production_materializer_path_without_monkeypatch(
+    level_rank_binding: dict,
+) -> None:
+    evidence = _materialize_with_envelope(level_rank_binding)
+    assert evidence["schema_version"].startswith(
+        "economic_viability_evidence_cross_sectional_open_interest_level_rank_v0"
+    )
+    assert "manifest_digest" in evidence
+    assert evidence["binding_references"]["pit_universe_binding"] is not None
+
+
+def test_level_rank_pit_universe_and_fee_binding_pass(level_rank_binding: dict) -> None:
+    evidence = _materialize_with_envelope(level_rank_binding)
+    refs = evidence["binding_references"]
+    assert "pit_universe_binding" in refs
+    assert refs["pit_universe_binding"] == level_rank_binding["pit_universe_binding"]
+    assert refs["instrument_binding"] == level_rank_binding["pit_universe_binding"]
+    assert refs["fee_binding"] == level_rank_binding["cost_execution_binding"]["fee_binding"]
+    assert refs["fee_model_binding"] == level_rank_binding["cost_execution_binding"]["fee_binding"]
+    assert evidence["authority_effect"] == "NONE"
+    assert evidence["runtime_effect"] == "NONE"
+
+
+def test_legacy_instrument_and_fee_model_binding_pass(legacy_binding: dict) -> None:
+    evidence = _materialize_with_envelope(legacy_binding)
+    refs = evidence["binding_references"]
+    assert refs["instrument_binding"] == legacy_binding["instrument_binding"]
+    assert (
+        refs["fee_model_binding"] == legacy_binding["cost_execution_binding"]["fee_model_binding"]
+    )
+    assert "pit_universe_binding" not in refs
+    assert "fee_binding" not in refs
+
+
+def test_missing_instrument_and_universe_binding_fail_closed(level_rank_binding: dict) -> None:
+    envelope = copy.deepcopy(level_rank_binding)
+    envelope.pop("pit_universe_binding", None)
+    with pytest.raises(EconomicViabilityEvidenceBindingResolutionError) as exc_info:
+        resolve_economic_viability_binding_references_v0(envelope)
+    assert exc_info.value.reason_code == REASON_INSTRUMENT_BINDING_MISSING
+
+
+def test_missing_fee_binding_fail_closed(level_rank_binding: dict) -> None:
+    envelope = copy.deepcopy(level_rank_binding)
+    cost = dict(envelope["cost_execution_binding"])
+    cost.pop("fee_binding", None)
+    envelope["cost_execution_binding"] = cost
+    with pytest.raises(EconomicViabilityEvidenceBindingResolutionError) as exc_info:
+        resolve_economic_viability_binding_references_v0(envelope)
+    assert exc_info.value.reason_code == REASON_FEE_BINDING_MISSING
+
+
+def test_conflicting_instrument_bindings_fail_closed(level_rank_binding: dict) -> None:
+    envelope = copy.deepcopy(level_rank_binding)
+    envelope["instrument_binding"] = {"binding_version": "legacy-conflict"}
+    with pytest.raises(EconomicViabilityEvidenceBindingResolutionError) as exc_info:
+        resolve_economic_viability_binding_references_v0(envelope)
+    assert exc_info.value.reason_code == REASON_CONFLICTING_INSTRUMENT_BINDINGS
+
+
+def test_conflicting_fee_bindings_fail_closed(level_rank_binding: dict) -> None:
+    envelope = copy.deepcopy(level_rank_binding)
+    cost = dict(envelope["cost_execution_binding"])
+    cost["fee_model_binding"] = {"fee_model_version": "conflict", "fee_bps_per_side": 99}
+    envelope["cost_execution_binding"] = cost
+    with pytest.raises(EconomicViabilityEvidenceBindingResolutionError) as exc_info:
+        resolve_economic_viability_binding_references_v0(envelope)
+    assert exc_info.value.reason_code == REASON_CONFLICTING_FEE_BINDINGS
+
+
+def test_deterministic_repeated_materialization(level_rank_binding: dict) -> None:
+    first = _materialize_with_envelope(level_rank_binding)
+    second = _materialize_with_envelope(level_rank_binding)
+    assert first["manifest_digest"] == second["manifest_digest"]
+
+
+def test_materializer_to_binder_roundtrip_pass(level_rank_binding: dict) -> None:
+    resolved = resolve_economic_viability_binding_references_v0(level_rank_binding)
+    evidence = _materialize_with_envelope(level_rank_binding)
+    refs = evidence["binding_references"]
+    assert refs["instrument_binding"] == resolved["instrument_binding"]
+    assert refs["fee_model_binding"] == resolved["fee_model_binding"]
+    assert refs["pit_universe_binding"] == resolved["pit_universe_binding"]


### PR DESCRIPTION
## Summary
- Fix `materialize_economic_viability_evidence()` in the level-rank execution owner to resolve universe and cost bindings fail-closed across legacy (`instrument_binding` / `fee_model_binding`) and level-rank (`pit_universe_binding` / `fee_binding`) schemas.
- Add focused binding-compatibility contract tests covering legacy pass, level-rank pass, missing/conflicting bindings, deterministic materialization, and production-path materialization without monkeypatch.
- No economic evaluation execution, no binding digest change, no runtime/authority effect.

## Root cause
Level-rank envelopes use `pit_universe_binding` and `fee_binding`, but the materializer accessed legacy keys directly, causing `KeyError` on the production path (reevaluation previously required an archive monkeypatch).

## Test plan
- [x] `pytest tests/research/test_cross_sectional_open_interest_level_rank_v0_economic_viability_evidence_materializer_binding_compatibility_v0.py`
- [x] `pytest tests/research/test_cross_sectional_open_interest_level_rank_v0_offline_economic_evaluation_execution_infrastructure_v0.py`
- [x] `ruff format --check` and `ruff check` on touched files

## Follow-up (out of scope)
Ops runner CLI gap for reevaluation (`--go-token`, `--source-closeout-bundle`) remains a separate surface; assessed as `SEPARATE_FOLLOW_UP` in durable evidence.


Made with [Cursor](https://cursor.com)