### PR TITLE
test(research): align surface P parity assertion with promoted registry state

### DIFF
--- a/tests/research/test_full_canonical_parity_proof_bundle_assembler_v0.py
+++ b/tests/research/test_full_canonical_parity_proof_bundle_assembler_v0.py
@@ -159,7 +159,7 @@ def test_required_proof_inputs_matrix_accounts_for_all_sixteen_surfaces() -> Non
     assert surface_p["status"] == "VERIFIED"
     assert surface_p["binding_status"] == "VERIFIED"
     assert surface_p["parity_status"] == "PASS"
-    assert surface_p["registry_parity_status"] == "PARTIAL"
+    assert surface_p["registry_parity_status"] == "PASS"
     assert surface_p["satisfied"] is True
 
 


### PR DESCRIPTION
## Summary

- Aligns the Surface P `registry_parity_status` test assertion from `PARTIAL` to `PASS` in `test_full_canonical_parity_proof_bundle_assembler_v0.py`.
- Root cause: stale assertion expected `PARTIAL` while canonical Surface P is promoted and satisfied when offline proof input binding is verified.

## Context

- **Production logic changed:** false
- **Source proof:** 16/16 satisfied, `PROVEN_MANIFEST_VERIFIED`
- **Targeted tests:** 11 passed
- **Source evidence:** `planning/full_canonical_parity_proof_bundle_regenerated_and_verified_v0_20260712T184545Z` (MANIFEST RC=0)
- **Runtime effect:** NONE
- **Authority effect:** NONE
- **Economic evaluation executed:** false

## Test plan

- [x] `python -m pytest -q tests/research/test_full_canonical_parity_proof_bundle_assembler_v0.py` (11 passed locally)
- [x] `git diff --check`
- [x] `ruff format --check` / `ruff check` on changed file

## Next step after merge-closeout

`FULL_CANONICAL_PARITY_PASS_ELIGIBILITY_GATE_V0`


Made with [Cursor](https://cursor.com)