### PR TITLE
Bind lead-lag v0 MV2 system economic evaluation

### DIFF
--- a/scripts/ops/run_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
@@ -31,11 +31,14 @@ from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offl
     INFRASTRUCTURE_GO_TOKEN,
     REEVALUATION_GO_TOKEN,
     RUNTIME_EFFECT,
+    SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+    SYSTEM_EVIDENCE_MV2_PATH_MODE,
     entrypoint_result_to_dict,
     execution_result_to_dict,
     load_ohlcv_panel_series_for_backtest,
     load_versioned_hypothesis_binding_v0,
     materialize_infrastructure_summary_v0,
+    materialize_system_evidence_mv2_offline_economic_evaluation_binding_v0,
     run_full_evaluation_entrypoint_dry_run_v1,
     run_full_offline_economic_evaluation_v0,
     run_mv2_system_evidence_wiring_dispatch_v0,
@@ -73,6 +76,10 @@ MV2_WIRING_ADAPTER_GO_TOKEN = (
 MV2_WIRING_ADAPTER_SCOPE_CLASSIFICATION = (
     "BOUNDED_CROSS_SECTIONAL_FUTURES_LEAD_LAG_V0_MV2_RESEARCH_BACKTEST_WIRING_"
     "BOUNDARY_ADAPTER_IMPLEMENTATION_V0"
+)
+MV2_BINDING_SCOPE_CLASSIFICATION = (
+    "BOUNDED_CROSS_SECTIONAL_FUTURES_LEAD_LAG_V0_SYSTEM_EVIDENCE_MV2_OFFLINE_"
+    "ECONOMIC_EVALUATION_BINDING_V0"
 )
 
 
@@ -435,6 +442,109 @@ def run_mv2_wiring_adapter_dispatch_v0(
     return payload
 
 
+def run_system_evidence_mv2_binding_dispatch_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+    staging_root: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN:
+        _die(f"ERR:confirm_go_token_required:{SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN}")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "research"
+        / (
+            "cross_sectional_futures_lead_lag_v0_system_evidence_mv2_offline_economic_"
+            f"evaluation_binding_v0_{ts_slug}"
+        )
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    versioned_binding = load_versioned_hypothesis_binding_v0(_REPO_ROOT)
+    ratification = materialize_lead_lag_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=_REPO_ROOT,
+        versioned_binding=versioned_binding,
+    )
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        ratification=ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+    binding_contract = materialize_system_evidence_mv2_offline_economic_evaluation_binding_v0()
+    panel_series = load_ohlcv_panel_series_for_backtest(staging_root)
+    evaluation = run_full_offline_economic_evaluation_v0(
+        repo_root=_REPO_ROOT,
+        ratification=ratification,
+        staging_root=staging_root,
+        panel_series=panel_series,
+        versioned_binding=versioned_binding,
+        go_token=confirm,
+    )
+    evaluation_payload = execution_result_to_dict(evaluation)
+    economic_executed = evaluation.economic_evaluation_executed
+
+    (bundle_dir / "PREFLIGHT.txt").write_text(
+        "\n".join(
+            [
+                f"ORIGIN_MAIN={origin_main}",
+                f"PRIMARY_HEAD_BEFORE={primary_before['head']}",
+                f"START_STATE_VALID={start_state.valid}",
+                f"GO_TOKEN={confirm}",
+                f"SCOPE_CLASSIFICATION={MV2_BINDING_SCOPE_CLASSIFICATION}",
+                f"EVALUATION_PATH_MODE={SYSTEM_EVIDENCE_MV2_PATH_MODE}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "BINDING_CONTRACT.json").write_text(
+        json.dumps(binding_contract, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "MV2_BINDING_EVALUATION_RESULT.json").write_text(
+        json.dumps(evaluation_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
+        f"ECONOMIC_EVALUATION_EXECUTED={'true' if economic_executed else 'false'}\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    payload: dict[str, Any] = {
+        "verdict": evaluation_payload["status"],
+        "process_classification": MV2_BINDING_SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "start_state_valid": start_state.valid,
+        "evaluation_path_mode": SYSTEM_EVIDENCE_MV2_PATH_MODE,
+        "binding_contract": binding_contract,
+        "evaluation": evaluation_payload,
+        "economic_evaluation_executed": economic_executed,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree": str(primary_worktree),
+        "staging_root": str(staging_root),
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _guard_timeout(start_monotonic)
+    return payload
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--confirm", required=True)
@@ -464,9 +574,18 @@ def main() -> None:
             primary_worktree=args.primary_worktree,
             staging_root=args.staging_root,
         )
+    elif args.confirm == SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN:
+        result = run_system_evidence_mv2_binding_dispatch_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+            staging_root=args.staging_root,
+        )
     else:
         _die(
-            f"ERR:confirm_go_token_required:{INFRASTRUCTURE_GO}|{REEVALUATION_GO}|{MV2_WIRING_ADAPTER_GO_TOKEN}"
+            "ERR:confirm_go_token_required:"
+            f"{INFRASTRUCTURE_GO}|{REEVALUATION_GO}|{MV2_WIRING_ADAPTER_GO_TOKEN}|"
+            f"{SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN}"
         )
     print(json.dumps(result, indent=2, sort_keys=True))
 

--- a/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
@@ -15,6 +15,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+import pandas as pd
+
 from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_scope_ratification_v0 import (
     ValidationVerdictEnum,
     validate_lead_lag_offline_economic_evaluation_scope_ratification_v0,
@@ -102,7 +104,13 @@ REEVALUATION_GO_TOKEN = (
     "GO_CROSS_SECTIONAL_FUTURES_LEAD_LAG_INFORMATION_DIFFUSION_V0_OFFLINE_ECONOMIC_"
     "EVALUATION_REEVALUATION_V0"
 )
-ALLOWED_FULL_EVALUATION_GO_TOKENS: frozenset[str] = frozenset({REEVALUATION_GO_TOKEN})
+SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_FUTURES_LEAD_LAG_V0_SYSTEM_EVIDENCE_MV2_OFFLINE_ECONOMIC_"
+    "EVALUATION_BINDING_V0"
+)
+ALLOWED_FULL_EVALUATION_GO_TOKENS: frozenset[str] = frozenset(
+    {REEVALUATION_GO_TOKEN, SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN}
+)
 FIXTURE_DATA_DIGEST = "3b4d025422898fcbdb15390864ab17cd0d921e839b1a6bd09c42fa235024b769"
 REASON_FIXTURE_LEAKAGE = "FIXTURE_DATA_DIGEST_IN_ECONOMIC_EVALUATION"
 CONFIG_REL_PATH_OPS = (
@@ -136,6 +144,10 @@ MV2_WIRING_ADAPTER_GO_TOKEN = (
     "GO_CROSS_SECTIONAL_FUTURES_LEAD_LAG_V0_MV2_RESEARCH_BACKTEST_WIRING_BOUNDARY_ADAPTER_"
     "IMPLEMENTATION_V0"
 )
+MV2_WIRING_ADAPTER_OWNER = (
+    "research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0"
+)
+MV2_CANONICAL_BACKTEST_OWNER = "backtest.mv2_research_wiring_v1"
 
 REASON_BINDING_INCOMPLETE = "BINDING_INCOMPLETE"
 REASON_RATIFICATION_INVALID = "RATIFICATION_INVALID"
@@ -451,6 +463,10 @@ def materialize_execution_contract_v0() -> dict[str, Any]:
         "infrastructure_go_token": INFRASTRUCTURE_GO_TOKEN,
         "execution_go_token": GO_TOKEN,
         "reevaluation_go_token": REEVALUATION_GO_TOKEN,
+        "system_evidence_mv2_binding_go_token": SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+        "evaluation_path_modes": [LEGACY_RESEARCH_PATH_MODE, SYSTEM_EVIDENCE_MV2_PATH_MODE],
+        "mv2_wiring_adapter_owner": MV2_WIRING_ADAPTER_OWNER,
+        "mv2_canonical_backtest_owner": MV2_CANONICAL_BACKTEST_OWNER,
         "versioned_binding_config": CONFIG_REL_PATH,
         "orchestrator_owner": "cross_sectional_single_slot_research_orchestrator_v0",
         "score_owner": ("cross_sectional_futures_lead_lag_information_diffusion_v0_score_v0"),
@@ -533,18 +549,44 @@ def verify_full_evaluation_precheck_v1(
     return not reasons, tuple(dict.fromkeys(reasons)), materialization
 
 
+def materialize_system_evidence_mv2_offline_economic_evaluation_binding_v0() -> dict[str, Any]:
+    return {
+        "binding_version": "v0",
+        "binding_owner": EXECUTION_ID,
+        "system_evidence_mv2_binding_go_token": SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+        "evaluation_path_mode": SYSTEM_EVIDENCE_MV2_PATH_MODE,
+        "legacy_research_path_mode": LEGACY_RESEARCH_PATH_MODE,
+        "mv2_wiring_adapter_owner": MV2_WIRING_ADAPTER_OWNER,
+        "mv2_canonical_backtest_owner": MV2_CANONICAL_BACKTEST_OWNER,
+        "canonical_full_evaluation_callable": CANONICAL_FULL_EVALUATION_CALLABLE,
+        "score_to_final_side_shortcut_allowed": False,
+        "binding_digest_unchanged_required": True,
+        "dataset_digest_unchanged_required": True,
+        "universe_digest_unchanged_required": True,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+    }
+
+
 def build_stage_wiring_status_v1(
     *,
     orchestrator_result: Any,
     economic_policy_binding: Mapping[str, Any],
+    evaluation_path_mode: str = LEGACY_RESEARCH_PATH_MODE,
 ) -> tuple[StageWiringStatusV1, ...]:
     _ = orchestrator_result
     _ = economic_policy_binding
+    backtest_owner = (
+        MV2_WIRING_ADAPTER_OWNER
+        if evaluation_path_mode == SYSTEM_EVIDENCE_MV2_PATH_MODE
+        else "cross_sectional_single_slot_backtest_wiring_v0"
+    )
     return (
         StageWiringStatusV1(
             stage_name="OFFLINE_BACKTEST",
             wired=True,
-            owner="cross_sectional_single_slot_backtest_wiring_v0",
+            owner=backtest_owner,
         ),
         StageWiringStatusV1(
             stage_name="WALK_FORWARD",
@@ -971,6 +1013,46 @@ def materialize_economic_viability_evidence(
     return body
 
 
+def single_slot_backtest_from_mv2_wiring_v0(
+    *,
+    wiring_result: Any,
+    initial_cash: float,
+    roundtrip_cost_bps: float,
+) -> SingleSlotBacktestResultV0:
+    """Adapt canonical MV2 backtest output to panel economic evaluation wiring."""
+    from src.backtest.mv2_research_wiring_v1 import MV2ResearchWiringResultV1
+
+    if not isinstance(wiring_result, MV2ResearchWiringResultV1):
+        raise TypeError("mv2_wiring_result_type_invalid")
+    bt = wiring_result.backtest_result
+    equity_curve = bt.equity_curve
+    final_equity = float(equity_curve.iloc[-1]) if len(equity_curve) else initial_cash
+    stats = dict(bt.stats)
+    gross_return = float(stats.get("total_return", 0.0))
+    net_return = (final_equity / initial_cash) - 1.0 if initial_cash else 0.0
+    trades_df = bt.trades if bt.trades is not None else pd.DataFrame()
+    trade_count = int(stats.get("total_trades", len(trades_df)))
+    turnover = float(stats.get("turnover", trade_count))
+    fee_drag = float(stats.get("fee_drag", 0.0))
+    slippage_impact = float(stats.get("slippage_impact", 0.0))
+    return SingleSlotBacktestResultV0(
+        wiring_version="cross_sectional_mv2_system_evidence_backtest_adapter.v0",
+        initial_cash=initial_cash,
+        final_equity=final_equity,
+        gross_return=gross_return,
+        net_return=net_return,
+        trade_count=trade_count,
+        turnover=turnover,
+        fee_drag=fee_drag,
+        slippage_impact=slippage_impact,
+        roundtrip_cost_bps=roundtrip_cost_bps,
+        equity_curve=equity_curve,
+        trades=trades_df,
+        stats=stats,
+        authority_effect=AUTHORITY_EFFECT,
+    )
+
+
 def run_full_offline_economic_evaluation_v0(
     *,
     repo_root: Path,
@@ -1070,16 +1152,91 @@ def run_full_offline_economic_evaluation_v0(
         envelope["cost_execution_binding"]
     )
     economic_policy = _resolve_economic_policy_binding_v0(envelope)
-    orchestrator = run_cross_sectional_single_slot_orchestrator_v0(
-        binding=binding,
-        panel_series=active_panel,
-        score_formula_version=SCORE_FORMULA_VERSION,
+    initial_cash = float(ops_config.get("backtest", {}).get("initial_cash", 10_000.0))
+    roundtrip_cost_bps = float(
+        cost_binding.get("execution_model_binding", {}).get("roundtrip_cost_bps", 0.0)
     )
-    backtest = run_single_slot_panel_backtest_v0(
-        orchestrator,
-        active_panel,
-        cost_execution_binding=cost_binding,
+    evaluation_path_mode = (
+        SYSTEM_EVIDENCE_MV2_PATH_MODE
+        if go_token == SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN
+        else LEGACY_RESEARCH_PATH_MODE
     )
+
+    if evaluation_path_mode == SYSTEM_EVIDENCE_MV2_PATH_MODE:
+        from src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0 import (
+            AdapterTerminalStatus,
+            run_lead_lag_mv2_research_backtest_wiring_boundary_v0,
+        )
+
+        adapter_result = run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
+            repo_root=repo_root,
+            panel_series=active_panel,
+            versioned_binding=envelope,
+            ops_config=ops_config,
+            go_token=go_token,
+            evaluation_path_mode=evaluation_path_mode,
+        )
+        if adapter_result.status is not AdapterTerminalStatus.MV2_WIRING_BOUNDARY_COMPLETE:
+            reason_codes.extend(adapter_result.reason_codes)
+            return FullEconomicEvaluationResultV0(
+                status=ExecutionTerminalStatus.FAIL_CLOSED_PRECHECK,
+                precheck_passed=True,
+                bound_dataset_materialized=True,
+                dataset_period_match=True,
+                panel_data_digest=panel_digest,
+                data_digest_is_fixture=False,
+                stage_wiring=(),
+                backtest=None,
+                robustness=None,
+                robustness_metrics=None,
+                economic_viability_evidence={},
+                economic_classification=EconomicClassification.FAIL_CLOSED,
+                economic_validity_offline_gate_pass=False,
+                promotion_candidate_eligible=False,
+                economic_evaluation_executed=False,
+                reason_codes=tuple(reason_codes),
+                authority_effect=AUTHORITY_EFFECT,
+                runtime_effect=RUNTIME_EFFECT,
+            )
+        orchestrator = adapter_result.orchestrator_result
+        if orchestrator is None or adapter_result.wiring_result is None:
+            reason_codes.append("MV2_WIRING_RESULT_MISSING")
+            return FullEconomicEvaluationResultV0(
+                status=ExecutionTerminalStatus.FAIL_CLOSED_PRECHECK,
+                precheck_passed=True,
+                bound_dataset_materialized=True,
+                dataset_period_match=True,
+                panel_data_digest=panel_digest,
+                data_digest_is_fixture=False,
+                stage_wiring=(),
+                backtest=None,
+                robustness=None,
+                robustness_metrics=None,
+                economic_viability_evidence={},
+                economic_classification=EconomicClassification.FAIL_CLOSED,
+                economic_validity_offline_gate_pass=False,
+                promotion_candidate_eligible=False,
+                economic_evaluation_executed=False,
+                reason_codes=tuple(reason_codes),
+                authority_effect=AUTHORITY_EFFECT,
+                runtime_effect=RUNTIME_EFFECT,
+            )
+        backtest = single_slot_backtest_from_mv2_wiring_v0(
+            wiring_result=adapter_result.wiring_result,
+            initial_cash=initial_cash,
+            roundtrip_cost_bps=roundtrip_cost_bps,
+        )
+    else:
+        orchestrator = run_cross_sectional_single_slot_orchestrator_v0(
+            binding=binding,
+            panel_series=active_panel,
+            score_formula_version=SCORE_FORMULA_VERSION,
+        )
+        backtest = run_single_slot_panel_backtest_v0(
+            orchestrator,
+            active_panel,
+            cost_execution_binding=cost_binding,
+        )
     robustness = wire_robustness_stages_v0(
         backtest,
         period_binding=envelope["period_binding"],
@@ -1088,6 +1245,7 @@ def run_full_offline_economic_evaluation_v0(
     stage_wiring = build_stage_wiring_status_v1(
         orchestrator_result=orchestrator,
         economic_policy_binding=economic_policy,
+        evaluation_path_mode=evaluation_path_mode,
     )
 
     robustness_metrics = CrossSectionalRobustnessMetricsV0(

--- a/src/research/cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.py
+++ b/src/research/cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.py
@@ -48,6 +48,13 @@ GO_TOKEN = (
     "GO_CROSS_SECTIONAL_FUTURES_LEAD_LAG_V0_MV2_RESEARCH_BACKTEST_WIRING_BOUNDARY_ADAPTER_"
     "IMPLEMENTATION_V0"
 )
+SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_FUTURES_LEAD_LAG_V0_SYSTEM_EVIDENCE_MV2_OFFLINE_ECONOMIC_"
+    "EVALUATION_BINDING_V0"
+)
+ALLOWED_ADAPTER_GO_TOKENS: frozenset[str] = frozenset(
+    {GO_TOKEN, SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN}
+)
 
 LEGACY_RESEARCH_PATH_MODE = "LEGACY_RESEARCH"
 SYSTEM_EVIDENCE_MV2_PATH_MODE = "SYSTEM_EVIDENCE_MV2"
@@ -115,6 +122,8 @@ def materialize_adapter_contract_v0() -> dict[str, Any]:
         "adapter_owner": ADAPTER_OWNER,
         "adapter_module": ADAPTER_MODULE,
         "go_token": GO_TOKEN,
+        "system_evidence_mv2_binding_go_token": SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+        "allowed_adapter_go_tokens": sorted(ALLOWED_ADAPTER_GO_TOKENS),
         "canonical_mv2_owner": MV2_CANONICAL_OWNER,
         "canonical_mv2_callable": MV2_CANONICAL_CALLABLE,
         "legacy_research_path_mode": LEGACY_RESEARCH_PATH_MODE,
@@ -130,7 +139,7 @@ def materialize_adapter_contract_v0() -> dict[str, Any]:
 
 
 def verify_adapter_go_token_v0(go_token: str) -> tuple[bool, tuple[str, ...]]:
-    if go_token != GO_TOKEN:
+    if go_token not in ALLOWED_ADAPTER_GO_TOKENS:
         return False, (REASON_GO_TOKEN_INVALID,)
     return True, ()
 

--- a/tests/research/test_cross_sectional_futures_lead_lag_v0_system_evidence_mv2_offline_economic_evaluation_binding_v0.py
+++ b/tests/research/test_cross_sectional_futures_lead_lag_v0_system_evidence_mv2_offline_economic_evaluation_binding_v0.py
@@ -1,0 +1,233 @@
+"""Contract tests for lead-lag v0 SYSTEM_EVIDENCE_MV2 offline economic evaluation binding v0."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.backtest.mv2_research_wiring_v1 import MV2ResearchWiringResultV1
+from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 import (
+    ALLOWED_FULL_EVALUATION_GO_TOKENS,
+    LEGACY_RESEARCH_PATH_MODE,
+    SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+    SYSTEM_EVIDENCE_MV2_PATH_MODE,
+    load_ops_evaluation_config_v0,
+    load_versioned_hypothesis_binding_v0,
+    materialize_system_evidence_mv2_offline_economic_evaluation_binding_v0,
+    run_full_offline_economic_evaluation_v0,
+    single_slot_backtest_from_mv2_wiring_v0,
+    build_stage_wiring_status_v1,
+)
+from src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0 import (
+    ALLOWED_ADAPTER_GO_TOKENS,
+    GO_TOKEN as ADAPTER_IMPLEMENTATION_GO_TOKEN,
+    verify_adapter_go_token_v0,
+)
+from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_scope_ratification_v0 import (
+    materialize_lead_lag_offline_economic_evaluation_scope_ratification_v0,
+)
+from src.research.cross_sectional_panel_economic_evaluation_wiring_v0 import (
+    RobustnessStageResultsV0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.fixture_builder import (
+    build_synthetic_panel_series_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXECUTION_MODULE = (
+    REPO_ROOT
+    / "src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_"
+    "evaluation_execution_v0.py"
+)
+FORBIDDEN_RUNTIME_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+)
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return load_versioned_hypothesis_binding_v0(REPO_ROOT)
+
+
+@pytest.fixture(name="ops_config")
+def fixture_ops_config() -> dict:
+    return load_ops_evaluation_config_v0(REPO_ROOT)
+
+
+def test_binding_contract_declares_mv2_path_mode() -> None:
+    contract = materialize_system_evidence_mv2_offline_economic_evaluation_binding_v0()
+    assert contract["evaluation_path_mode"] == SYSTEM_EVIDENCE_MV2_PATH_MODE
+    assert contract["legacy_research_path_mode"] == LEGACY_RESEARCH_PATH_MODE
+    assert contract["score_to_final_side_shortcut_allowed"] is False
+    assert contract["system_evidence_mv2_binding_go_token"] == SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN
+
+
+def test_binding_go_token_in_allowed_full_evaluation_tokens() -> None:
+    assert SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN in ALLOWED_FULL_EVALUATION_GO_TOKENS
+
+
+def test_adapter_accepts_binding_go_token() -> None:
+    ok, reasons = verify_adapter_go_token_v0(SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN)
+    assert ok is True
+    assert reasons == ()
+    assert SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN in ALLOWED_ADAPTER_GO_TOKENS
+    assert ADAPTER_IMPLEMENTATION_GO_TOKEN in ALLOWED_ADAPTER_GO_TOKENS
+
+
+def test_stage_wiring_uses_mv2_owner_in_system_evidence_mode() -> None:
+    wiring = build_stage_wiring_status_v1(
+        orchestrator_result=None,
+        economic_policy_binding={},
+        evaluation_path_mode=SYSTEM_EVIDENCE_MV2_PATH_MODE,
+    )
+    backtest_stage = next(item for item in wiring if item.stage_name == "OFFLINE_BACKTEST")
+    assert "mv2_research_backtest_wiring_boundary_adapter_v0" in backtest_stage.owner
+
+
+def test_single_slot_backtest_from_mv2_wiring_maps_stats() -> None:
+    wiring = MV2ResearchWiringResultV1(
+        instrument_id="inst-eth-usdt-perp",
+        registry_snapshot=type("Snap", (), {"semantic_digest": "a" * 64})(),
+        effective_cost_config=type("Cost", (), {"config_digest": "b" * 64})(),
+        bar_outcomes=(),
+        signals=type("S", (), {"empty": True})(),
+        backtest_result=type(
+            "BT",
+            (),
+            {
+                "equity_curve": __import__("pandas").Series([10_000.0, 9_500.0]),
+                "trades": None,
+                "stats": {
+                    "total_return": -0.05,
+                    "total_trades": 2,
+                    "turnover": 2.0,
+                    "fee_drag": 10.0,
+                    "slippage_impact": 5.0,
+                },
+            },
+        )(),
+        mv2_replay_signals=type("S2", (), {"empty": True})(),
+        strategy_signal_provenance=type("P", (), {})(),
+        mv2_replay_signal_digest="c" * 64,
+        mv2_replay_nonzero_signal_count=0,
+    )
+    result = single_slot_backtest_from_mv2_wiring_v0(
+        wiring_result=wiring,
+        initial_cash=10_000.0,
+        roundtrip_cost_bps=30.0,
+    )
+    assert result.net_return == pytest.approx(-0.05)
+    assert result.trade_count == 2
+    assert result.roundtrip_cost_bps == 30.0
+
+
+def test_mv2_binding_evaluation_executes_on_synthetic_panel(
+    complete_binding: dict,
+) -> None:
+    ratification = materialize_lead_lag_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=REPO_ROOT,
+        versioned_binding=complete_binding,
+    )
+    panel = build_synthetic_panel_series_v0(bar_count=12)
+    materialization = type(
+        "MaterializationProxy",
+        (),
+        {
+            "status": __import__(
+                "src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0",
+                fromlist=["MaterializationTerminalStatus"],
+            ).MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE,
+            "panel_data_digest": "b" * 64,
+            "reason_codes": (),
+        },
+    )()
+    with patch(
+        "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.verify_full_evaluation_precheck_v1",
+        return_value=(True, (), materialization),
+    ):
+        with patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.load_panel_series_from_staging",
+            return_value=((), {}),
+        ):
+            with patch(
+                "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.wire_robustness_stages_v0",
+            ) as robustness_patch:
+                robustness_patch.return_value = RobustnessStageResultsV0(
+                    wiring_version="test.v0",
+                    walk_forward_results=(),
+                    monte_carlo_summary={"metric_quantiles": {"total_return": {"p50": -0.02}}},
+                    stress_results={"scenarios": []},
+                    parameter_sensitivity_status="BOUND",
+                    authority_effect="NONE",
+                )
+                with patch(
+                    "src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.run_mv2_research_backtest_wiring_v1",
+                ) as mv2_call:
+                    mv2_call.return_value = MV2ResearchWiringResultV1(
+                        instrument_id="inst-eth-usdt-perp",
+                        registry_snapshot=type("Snap", (), {"semantic_digest": "a" * 64})(),
+                        effective_cost_config=type("Cost", (), {"config_digest": "b" * 64})(),
+                        bar_outcomes=(),
+                        signals=type("S", (), {"empty": True})(),
+                        backtest_result=type(
+                            "BT",
+                            (),
+                            {
+                                "equity_curve": __import__("pandas").Series(
+                                    [10_000.0, 9_800.0],
+                                    index=__import__("pandas").to_datetime(
+                                        ["2024-01-01T00:00:00Z", "2024-06-01T00:00:00Z"],
+                                        utc=True,
+                                    ),
+                                ),
+                                "trades": None,
+                                "stats": {
+                                    "total_return": -0.02,
+                                    "total_trades": 1,
+                                    "turnover": 1.0,
+                                },
+                            },
+                        )(),
+                        mv2_replay_signals=type("S2", (), {"empty": True})(),
+                        strategy_signal_provenance=type("P", (), {})(),
+                        mv2_replay_signal_digest="c" * 64,
+                        mv2_replay_nonzero_signal_count=0,
+                    )
+                    result = run_full_offline_economic_evaluation_v0(
+                        repo_root=REPO_ROOT,
+                        ratification=ratification,
+                        staging_root=REPO_ROOT,
+                        panel_series=panel,
+                        versioned_binding=complete_binding,
+                        go_token=SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+                    )
+    assert result.economic_evaluation_executed is True
+    assert result.backtest is not None
+    assert any(
+        "mv2_research_backtest_wiring_boundary_adapter_v0" in item.owner
+        for item in result.stage_wiring
+        if item.stage_name == "OFFLINE_BACKTEST"
+    )
+
+
+def _collect_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.add(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+    return imports
+
+
+def test_execution_module_still_has_no_runtime_imports() -> None:
+    imports = _collect_imports(EXECUTION_MODULE)
+    for forbidden in FORBIDDEN_RUNTIME_IMPORT_PREFIXES:
+        assert not any(item == forbidden or item.startswith(forbidden + ".") for item in imports)


### PR DESCRIPTION
## Scope

Bind the cross-sectional futures lead-lag v0 offline economic evaluation to the canonical SYSTEM_EVIDENCE_MV2 research-backtest path.

## Implementation

- route the binding GO through run_full_offline_economic_evaluation_v0
- reuse the canonical MV2 research-backtest wiring boundary adapter
- add the fourth offline-only ops-runner dispatch branch
- add focused binding and regression tests

## Economic evidence

- evaluation path: SYSTEM_EVIDENCE_MV2
- evaluation executed: true
- classification: FAIL
- trade count: 0
- net return: 0.0
- terminal negative evidence preserved
- no unchanged retry authorized

## Safety boundaries

- runtime effect: NONE
- authority effect: NONE
- no trading, scheduler, credentials, orders, arming, testnet or live effect
- canonical trading semantics unchanged
- Master V2 and Double Play semantics unchanged

## Validation

- targeted tests: 20 passed
- Ruff format/check: PASS
- source evidence manifest: RC=0

## Durable evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/cross_sectional_futures_lead_lag_v0_system_evidence_mv2_offline_economic_evaluation_binding_v0_20260712T211610Z`

OPERATOR_GO=`GO_CROSS_SECTIONAL_FUTURES_LEAD_LAG_V0_SYSTEM_EVIDENCE_MV2_OFFLINE_ECONOMIC_EVALUATION_BINDING_V0_PR_CREATION`
COMMIT_HEAD=`51a471033eebd88ea90485ea2ac8f2d34b146c9d`

Made with [Cursor](https://cursor.com)