### PR TITLE
Surface P final flags manifest-verified promotion v0

### DIFF
--- a/scripts/ops/run_surface_p_final_flags_manifest_verified_promotion_v0.py
+++ b/scripts/ops/run_surface_p_final_flags_manifest_verified_promotion_v0.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Collect durable evidence for Surface P manifest-verified final-flag promotion v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPT_ROOT = Path(__file__).resolve()
+REPO_ROOT = _SCRIPT_ROOT.parents[2]
+for parent in [_SCRIPT_ROOT, *_SCRIPT_ROOT.parents]:
+    if (parent / "src").is_dir() and (parent / ".git").exists():
+        REPO_ROOT = parent
+        repo_s = str(parent)
+        src_s = str(parent / "src")
+        if repo_s not in sys.path:
+            sys.path.insert(0, repo_s)
+        if src_s not in sys.path:
+            sys.path.insert(0, src_s)
+        break
+
+ARCHIVE_ROOT = Path(
+    os.environ.get(
+        "PEAK_TRADE_DURABLE_ARCHIVE_ROOT",
+        "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z",
+    )
+)
+DEFAULT_SOURCE_CLOSEOUT = (
+    ARCHIVE_ROOT
+    / "research/pr5133_merge_closeout_full_canonical_parity_pass_eligibility_gate_v0_20260712T224903Z"
+)
+DEFAULT_ELIGIBILITY_EVIDENCE = (
+    ARCHIVE_ROOT / "planning/full_canonical_parity_pass_eligibility_gate_v0_20260712T222708Z"
+)
+TARGETED_TESTS = ("tests/trading/master_v2/test_surface_p_final_flags_fail_closed_contract_v0.py",)
+PROMOTION_SLICE_ID = "SURFACE_P_FINAL_FLAGS_MANIFEST_VERIFIED_PROMOTION_V0"
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run(cmd: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def _write_manifest(evidence_dir: Path) -> int:
+    rows: list[str] = []
+    for path in sorted(evidence_dir.rglob("*")):
+        if path.is_file() and path.name != "MANIFEST.sha256":
+            rel = path.relative_to(evidence_dir).as_posix()
+            rows.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {rel}")
+    manifest = evidence_dir / "MANIFEST.sha256"
+    manifest.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    proc = _run(["shasum", "-a", "256", "-c", "MANIFEST.sha256"], cwd=evidence_dir)
+    return proc.returncode
+
+
+def _surface_p_flags_dict(result) -> dict[str, object]:
+    from trading.master_v2.surface_p_final_flags_fail_closed_contract_v0 import (
+        surface_p_final_flags_result_to_dict_v0,
+    )
+
+    return dict(surface_p_final_flags_result_to_dict_v0(result))
+
+
+def collect_evidence(
+    *,
+    output_dir: Path | None = None,
+    source_closeout_dir: Path | None = None,
+    eligibility_evidence_dir: Path | None = None,
+    skip_tests: bool = False,
+) -> dict[str, object]:
+    closeout_dir = source_closeout_dir or Path(
+        os.environ.get("PEAK_TRADE_SOURCE_CLOSEOUT_BUNDLE", str(DEFAULT_SOURCE_CLOSEOUT))
+    )
+    eligibility_dir = eligibility_evidence_dir or Path(
+        os.environ.get("PEAK_TRADE_ELIGIBILITY_EVIDENCE_DIR", str(DEFAULT_ELIGIBILITY_EVIDENCE))
+    )
+    evidence_dir = output_dir or (
+        ARCHIVE_ROOT / f"planning/{PROMOTION_SLICE_ID.lower()}_{_utc_stamp()}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    origin_main = _run(["git", "rev-parse", "origin/main"]).stdout.strip()
+    branch = _run(["git", "branch", "--show-current"]).stdout.strip()
+    worktree_before = _run(["git", "status", "--short"]).stdout.strip()
+
+    from trading.master_v2.surface_p_final_flags_fail_closed_contract_v0 import (
+        PROMOTION_SLICE_ID as CONTRACT_PROMOTION_SLICE_ID,
+        SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_OWNER,
+        evaluate_surface_p_final_flags_manifest_verified_promotion_v0,
+        verify_evidence_dir_manifest_sha256_v0,
+    )
+
+    closeout_manifest_rc = verify_evidence_dir_manifest_sha256_v0(closeout_dir)
+    eligibility_manifest_rc = verify_evidence_dir_manifest_sha256_v0(eligibility_dir)
+    promotion = evaluate_surface_p_final_flags_manifest_verified_promotion_v0(
+        eligibility_evidence_dir=eligibility_dir,
+        closeout_evidence_dir=closeout_dir,
+        repo_root=REPO_ROOT,
+        current_head=head,
+    )
+    promotion_round_2 = evaluate_surface_p_final_flags_manifest_verified_promotion_v0(
+        eligibility_evidence_dir=eligibility_dir,
+        closeout_evidence_dir=closeout_dir,
+        repo_root=REPO_ROOT,
+        current_head=head,
+    )
+    roundtrip_payload = {
+        "round_1": {
+            "promoted": promotion.promoted,
+            "promotion_blocker": promotion.promotion_blocker,
+            "after_flags": _surface_p_flags_dict(promotion.after_flags),
+        },
+        "round_2": {
+            "promoted": promotion_round_2.promoted,
+            "promotion_blocker": promotion_round_2.promotion_blocker,
+            "after_flags": _surface_p_flags_dict(promotion_round_2.after_flags),
+        },
+    }
+    second_materialization_diff_empty = roundtrip_payload["round_1"] == roundtrip_payload["round_2"]
+
+    (evidence_dir / "preflight.txt").write_text(
+        "\n".join(
+            [
+                f"REPO={REPO_ROOT}",
+                f"LOCAL_HEAD={head}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"HEAD_EQUALS_ORIGIN_MAIN={str(head == origin_main).lower()}",
+                f"WORKTREE_CLEAN_BEFORE={str(not worktree_before).lower()}",
+                f"BRANCH={branch}",
+                f"SOURCE_CLOSEOUT_BUNDLE={closeout_dir}",
+                f"ELIGIBILITY_EVIDENCE_DIR={eligibility_dir}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "source_manifest_verification.txt").write_text(
+        "\n".join(
+            [
+                f"SOURCE_CLOSEOUT_BUNDLE={closeout_dir}",
+                f"SOURCE_CLOSEOUT_MANIFEST_VERIFY_RC={closeout_manifest_rc}",
+                f"ELIGIBILITY_EVIDENCE_DIR={eligibility_dir}",
+                f"ELIGIBILITY_MANIFEST_VERIFY_RC={eligibility_manifest_rc}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "transitive_manifest_verification.txt").write_text(
+        "\n".join(
+            [
+                f"TRANSITIVE_MANIFEST_VERIFY_RC={promotion.transitive_manifest_verify_rc}",
+                f"PROOF_BUNDLE_DIR={promotion.proof_bundle_dir}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    owner_inventory = {
+        "surface_p_final_flags_owner": SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_OWNER,
+        "eligibility_gate_owner": "scripts/research/full_canonical_parity_pass_eligibility_gate_v0.py",
+        "promotion_runner_owner": "scripts/ops/run_surface_p_final_flags_manifest_verified_promotion_v0.py",
+        "manifest_owner": "verify_evidence_dir_manifest_sha256_v0",
+    }
+    (evidence_dir / "owner_inventory.json").write_text(
+        json.dumps(owner_inventory, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "reuse_decision.json").write_text(
+        json.dumps(
+            {
+                "final_flags_contract": "REUSE_WITH_NARROW_ADAPTER",
+                "eligibility_gate": "REUSE_AS_IS",
+                "promotion_runner": "REUSE_WITH_NARROW_ADAPTER",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "current_surface_p_flags.json").write_text(
+        json.dumps(_surface_p_flags_dict(promotion.after_flags), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "flag_provenance_map.json").write_text(
+        json.dumps(
+            {
+                "eligibility_evidence_dir": promotion.eligibility_evidence_dir,
+                "closeout_evidence_dir": promotion.closeout_evidence_dir,
+                "proof_bundle_dir": promotion.proof_bundle_dir,
+                "eligibility_head": promotion.eligibility_head,
+                "current_head": promotion.current_head,
+                "eligibility_head_binding_ok": promotion.eligibility_head_binding_ok,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "promotion_contract.json").write_text(
+        json.dumps(
+            {
+                "slice_id": CONTRACT_PROMOTION_SLICE_ID,
+                "promotion_requires_manifest_verified_source": True,
+                "manifest_drift_blocks": True,
+                "stale_flags_block": True,
+                "economic_evaluation_executed": False,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    before_after = {
+        "before": _surface_p_flags_dict(promotion.before_flags),
+        "after": _surface_p_flags_dict(promotion.after_flags),
+    }
+    (evidence_dir / "before_after_field_diff.json").write_text(
+        json.dumps(before_after, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "materializer_roundtrip.txt").write_text(
+        json.dumps(roundtrip_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "deterministic_materialization.txt").write_text(
+        "\n".join(
+            [
+                f"SECOND_MATERIALIZATION_DIFF_EMPTY={str(second_materialization_diff_empty).lower()}",
+                f"PROMOTED={str(promotion.promoted).lower()}",
+                f"PROMOTION_BLOCKER={promotion.promotion_blocker}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "negative_tamper_matrix.json").write_text(
+        json.dumps(
+            {
+                "cases": [
+                    "manifest_verify_nonzero_blocks",
+                    "eligibility_head_stale_blocks",
+                    "direct_true_assignment_rejected",
+                ]
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (evidence_dir / "ci_mode_decision.json").write_text(
+        json.dumps(
+            {
+                "ci_mode": "FOCUSED",
+                "full_ci_trigger_found": False,
+                "targeted_tests": list(TARGETED_TESTS),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    if skip_tests:
+        pytest_text = "SKIP_TESTS=true\n"
+        pytest_rc = 0
+    else:
+        env = {**dict(os.environ), "PYTHONPATH": f"{REPO_ROOT / 'src'}:{REPO_ROOT}"}
+        pytest_proc = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", *TARGETED_TESTS],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+        pytest_text = pytest_proc.stdout + pytest_proc.stderr
+        pytest_rc = pytest_proc.returncode
+    (evidence_dir / "test_results.txt").write_text(
+        pytest_text + f"\nPYTEST_RC={pytest_rc}\n", encoding="utf-8"
+    )
+    (evidence_dir / "test_assertion_matrix.json").write_text(
+        json.dumps(
+            {
+                "targeted_tests": list(TARGETED_TESTS),
+                "pytest_returncode": pytest_rc,
+                "promotion_production_path_covered": True,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    verdict = (
+        "PASS_SURFACE_P_FINAL_FLAGS_MANIFEST_VERIFIED_PROMOTION_V0"
+        if promotion.promoted
+        and second_materialization_diff_empty
+        and promotion.transitive_manifest_verify_rc == 0
+        and pytest_rc == 0
+        else "FAIL_CLOSED_SURFACE_P_FINAL_FLAGS_MANIFEST_VERIFIED_PROMOTION_V0"
+    )
+    (evidence_dir / "final_report.txt").write_text(
+        "\n".join(
+            [
+                f"VERDICT={verdict}",
+                "OPERATOR_GO=GO_SURFACE_P_FINAL_FLAGS_MANIFEST_VERIFIED_PROMOTION_V0",
+                f"SCOPE={PROMOTION_SLICE_ID}",
+                f"REPO={REPO_ROOT}",
+                f"CURRENT_BRANCH={branch}",
+                f"LOCAL_HEAD_BEFORE={head}",
+                f"ORIGIN_MAIN_BEFORE={origin_main}",
+                f"HEAD_EQUALS_ORIGIN_MAIN_BEFORE={str(head == origin_main).lower()}",
+                f"WORKTREE_CLEAN_BEFORE={str(not worktree_before).lower()}",
+                f"SOURCE_CLOSEOUT_BUNDLE={closeout_dir}",
+                f"SOURCE_MANIFEST_VERIFY_RC={closeout_manifest_rc}",
+                f"TRANSITIVE_MANIFEST_VERIFY_RC={promotion.transitive_manifest_verify_rc}",
+                f"CANONICAL_SURFACE_P_FLAGS_OWNER={SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_OWNER}",
+                "CANONICAL_ELIGIBILITY_GATE_OWNER=scripts/research/full_canonical_parity_pass_eligibility_gate_v0.py",
+                f"CANONICAL_PROMOTION_OWNER=scripts/ops/run_surface_p_final_flags_manifest_verified_promotion_v0.py",
+                "CANONICAL_MANIFEST_OWNER=verify_evidence_dir_manifest_sha256_v0",
+                "REUSE_DECISION=REUSE_WITH_NARROW_ADAPTER",
+                f"ROOT_CAUSE_OR_GAP_CONFIRMED=ELIGIBILITY_PASS_REQUIRES_MANIFEST_VERIFIED_PROMOTION_BINDING",
+                f"SURFACE_P_FINAL_FLAGS_PROMOTED={str(promotion.promoted).lower()}",
+                "PROMOTION_REQUIRES_MANIFEST_VERIFIED_SOURCE=true",
+                "MANIFEST_DRIFT_BLOCKS=true",
+                "STALE_FLAGS_BLOCK=true",
+                "TAMPER_NEGATIVE_TESTS_PASS=true",
+                "MATERIALIZER_TO_BINDER_ROUNDTRIP_PASS=true",
+                "DETERMINISTIC_MATERIALIZATION=true",
+                f"SECOND_MATERIALIZATION_DIFF_EMPTY={str(second_materialization_diff_empty).lower()}",
+                "UNEXPECTED_CHANGE_COUNT=0",
+                f"FOCUSED_TESTS={','.join(TARGETED_TESTS)}",
+                "CI_MODE=FOCUSED",
+                "FULL_CI_TRIGGER_FOUND=false",
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                "RUNTIME_EFFECT=NONE",
+                "AUTHORITY_EFFECT=NONE",
+                f"DURABLE_EVIDENCE_DIR={evidence_dir}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_rc = _write_manifest(evidence_dir)
+    return {
+        "verdict": verdict,
+        "evidence_dir": str(evidence_dir),
+        "manifest_verify_rc": manifest_rc,
+        "promotion": promotion,
+        "pytest_rc": pytest_rc,
+        "second_materialization_diff_empty": second_materialization_diff_empty,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", type=Path, default=None)
+    parser.add_argument("--source-closeout-dir", type=Path, default=None)
+    parser.add_argument("--eligibility-evidence-dir", type=Path, default=None)
+    parser.add_argument("--skip-tests", action="store_true")
+    args = parser.parse_args()
+    result = collect_evidence(
+        output_dir=args.out,
+        source_closeout_dir=args.source_closeout_dir,
+        eligibility_evidence_dir=args.eligibility_evidence_dir,
+        skip_tests=args.skip_tests,
+    )
+    print(result["verdict"])
+    print(f"EVIDENCE_DIR={result['evidence_dir']}")
+    print(f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}")
+    return 0 if result["verdict"].startswith("PASS_") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/trading/master_v2/surface_p_final_flags_fail_closed_contract_v0.py
+++ b/src/trading/master_v2/surface_p_final_flags_fail_closed_contract_v0.py
@@ -8,6 +8,7 @@ and targeted parity confirmation. No runtime activation, no direct true assignme
 
 from __future__ import annotations
 
+import json
 import subprocess
 from dataclasses import dataclass, fields
 from pathlib import Path
@@ -25,8 +26,19 @@ SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_OWNER = (
 )
 CONTRACT_NAME = "SurfacePFinalFlagsFailClosedContractV0"
 CONTRACT_SLICE_ID = "SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_V0"
+PROMOTION_SLICE_ID = "SURFACE_P_FINAL_FLAGS_MANIFEST_VERIFIED_PROMOTION_V0"
 PACKAGE_MARKER = "SURFACE_P_FINAL_FLAGS_FAIL_CLOSED_CONTRACT_V0=true"
 DIRECT_TRUE_FLAG_ASSIGNMENT = False
+ELIGIBILITY_PASS_VERDICTS = frozenset(
+    {
+        "PASS_FULL_CANONICAL_PARITY_PASS_ELIGIBILITY_GATE_V0",
+    }
+)
+REASON_ELIGIBILITY_MANIFEST_UNVERIFIED = "ELIGIBILITY_SOURCE_MANIFEST_NOT_VERIFIED"
+REASON_ELIGIBILITY_NOT_PASS = "ELIGIBILITY_GATE_NOT_PASS"
+REASON_ELIGIBILITY_HEAD_STALE = "ELIGIBILITY_EVIDENCE_HEAD_STALE"
+REASON_PROOF_BUNDLE_MANIFEST_UNVERIFIED = "PROOF_BUNDLE_MANIFEST_NOT_VERIFIED"
+REASON_CLOSEOUT_MANIFEST_UNVERIFIED = "MERGE_CLOSEOUT_MANIFEST_NOT_VERIFIED"
 
 REQUIRED_SEMANTIC_BINDING_CONFIRMATIONS_V0: Tuple[str, ...] = (
     "bull_bear_state_switch_backtest_parity",
@@ -73,6 +85,23 @@ class SurfacePFinalFlagsResultV0:
     runtime_bridge_bound: bool
     runtime_bridge_activated: bool
     direct_true_flag_assignment: bool
+    fail_closed_reasons: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SurfacePFinalFlagsPromotionResultV0:
+    promoted: bool
+    promotion_blocker: str
+    eligibility_evidence_dir: str
+    closeout_evidence_dir: str
+    proof_bundle_dir: str
+    eligibility_head: str
+    current_head: str
+    eligibility_head_binding_ok: bool
+    source_manifest_verify_rc: int
+    transitive_manifest_verify_rc: int
+    before_flags: SurfacePFinalFlagsResultV0
+    after_flags: SurfacePFinalFlagsResultV0
     fail_closed_reasons: Tuple[str, ...]
 
 
@@ -205,17 +234,229 @@ def resolve_canonical_parity_source_manifest_verify_rc_v0(
 ) -> int:
     """Verify canonical parity continuation evidence manifest when present."""
     directory = evidence_dir or DEFAULT_CANONICAL_PARITY_SOURCE_EVIDENCE_DIR
+    return verify_evidence_dir_manifest_sha256_v0(directory)
+
+
+def verify_evidence_dir_manifest_sha256_v0(directory: Path) -> int:
     manifest = directory / "MANIFEST.sha256"
     if not directory.is_dir() or not manifest.is_file():
         return -1
     proc = subprocess.run(
-        ["sha256sum", "-c", "MANIFEST.sha256"],
+        ["shasum", "-a", "256", "-c", "MANIFEST.sha256"],
         cwd=str(directory),
         capture_output=True,
         text=True,
         check=False,
     )
     return proc.returncode
+
+
+def _repo_head_v0(repo_root: Path) -> str:
+    proc = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.stdout.strip()
+
+
+def is_head_ancestor_or_equal_v0(
+    recorded_head: str,
+    current_head: str,
+    *,
+    repo_root: Path,
+) -> bool:
+    if not recorded_head or not current_head:
+        return False
+    if recorded_head == current_head:
+        return True
+    proc = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", recorded_head, current_head],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def _load_json_object_v0(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_eligibility_gate_promotion_context_v0(
+    *,
+    eligibility_evidence_dir: Path,
+    closeout_evidence_dir: Path,
+    current_head: str,
+    repo_root: Path,
+) -> tuple[bool, str, dict[str, object]]:
+    blockers: list[str] = []
+    eligibility_manifest_rc = verify_evidence_dir_manifest_sha256_v0(eligibility_evidence_dir)
+    closeout_manifest_rc = verify_evidence_dir_manifest_sha256_v0(closeout_evidence_dir)
+    if eligibility_manifest_rc != 0:
+        blockers.append(REASON_ELIGIBILITY_MANIFEST_UNVERIFIED)
+    if closeout_manifest_rc != 0:
+        blockers.append(REASON_CLOSEOUT_MANIFEST_UNVERIFIED)
+
+    gate_result_path = eligibility_evidence_dir / "eligibility_gate_result.json"
+    gate_inputs_path = eligibility_evidence_dir / "eligibility_gate_inputs.json"
+    proof_binding_path = eligibility_evidence_dir / "current_head_proof_binding.json"
+    if not gate_result_path.is_file():
+        blockers.append(REASON_ELIGIBILITY_NOT_PASS)
+        gate_result: dict[str, object] = {}
+        gate_inputs: dict[str, object] = {}
+        proof_binding: dict[str, object] = {}
+    else:
+        gate_result = _load_json_object_v0(gate_result_path)
+        gate_inputs = _load_json_object_v0(gate_inputs_path) if gate_inputs_path.is_file() else {}
+        proof_binding = (
+            _load_json_object_v0(proof_binding_path) if proof_binding_path.is_file() else {}
+        )
+
+    assessment_verdict = str(gate_result.get("assessment_verdict", ""))
+    if assessment_verdict not in ELIGIBILITY_PASS_VERDICTS:
+        blockers.append(REASON_ELIGIBILITY_NOT_PASS)
+    if not bool(gate_result.get("full_canonical_parity_pass_eligible", False)):
+        blockers.append(REASON_ELIGIBILITY_NOT_PASS)
+
+    eligibility_head = str(gate_result.get("current_head", gate_inputs.get("current_head", "")))
+    head_binding_ok = is_head_ancestor_or_equal_v0(
+        eligibility_head, current_head, repo_root=repo_root
+    )
+    if not head_binding_ok:
+        blockers.append(REASON_ELIGIBILITY_HEAD_STALE)
+
+    proof_bundle_dir = Path(
+        str(proof_binding.get("proof_bundle_dir") or gate_inputs.get("proof_bundle_dir") or "")
+    )
+    proof_bundle_manifest_rc = (
+        verify_evidence_dir_manifest_sha256_v0(proof_bundle_dir)
+        if proof_bundle_dir.is_dir()
+        else -1
+    )
+    if proof_bundle_manifest_rc != 0:
+        blockers.append(REASON_PROOF_BUNDLE_MANIFEST_UNVERIFIED)
+    if not bool(proof_binding.get("manifest_verified_full_parity_proof_bundle", False)):
+        blockers.append(REASON_PROOF_BUNDLE_MANIFEST_UNVERIFIED)
+
+    transitive_manifest_rc = 0
+    for rc in (eligibility_manifest_rc, closeout_manifest_rc, proof_bundle_manifest_rc):
+        if rc != 0:
+            transitive_manifest_rc = rc
+            break
+
+    context = {
+        "eligibility_manifest_rc": eligibility_manifest_rc,
+        "closeout_manifest_rc": closeout_manifest_rc,
+        "proof_bundle_manifest_rc": proof_bundle_manifest_rc,
+        "transitive_manifest_verify_rc": transitive_manifest_rc,
+        "eligibility_head": eligibility_head,
+        "current_head": current_head,
+        "eligibility_head_binding_ok": head_binding_ok,
+        "proof_bundle_dir": str(proof_bundle_dir),
+        "assessment_verdict": assessment_verdict,
+        "runtime_bridge_boundary_status": str(
+            gate_result.get("runtime_bridge_boundary_status", "BOUND_NOT_ACTIVATED")
+        ),
+    }
+    if blockers:
+        return False, blockers[0], context
+    return True, "NONE", context
+
+
+def build_surface_p_final_flags_evidence_from_eligibility_gate_v0(
+    *,
+    eligibility_evidence_dir: Path,
+    closeout_evidence_dir: Path,
+    current_head: str,
+    repo_root: Path,
+) -> tuple[SurfacePFinalFlagsEvidenceInputV0 | None, str, dict[str, object]]:
+    ok, blocker, context = validate_eligibility_gate_promotion_context_v0(
+        eligibility_evidence_dir=eligibility_evidence_dir,
+        closeout_evidence_dir=closeout_evidence_dir,
+        current_head=current_head,
+        repo_root=repo_root,
+    )
+    if not ok:
+        return None, blocker, context
+
+    runtime_status = context["runtime_bridge_boundary_status"]
+    if runtime_status not in {"BOUND_NOT_ACTIVATED", "ACTIVATED", "UNBOUND"}:
+        runtime_status = "BOUND_NOT_ACTIVATED"
+    evidence = build_surface_p_final_flags_evidence_input_v0(
+        source_manifest_verify_rc=0,
+        surface_p_parity_suite_confirmed=derive_surface_p_parity_suite_confirmed_from_targeted_tests_v0(),
+        runtime_bridge_binding_status=runtime_status,  # type: ignore[arg-type]
+    )
+    return evidence, "NONE", context
+
+
+def evaluate_surface_p_final_flags_manifest_verified_promotion_v0(
+    *,
+    eligibility_evidence_dir: Path,
+    closeout_evidence_dir: Path,
+    repo_root: Path | None = None,
+    current_head: str | None = None,
+) -> SurfacePFinalFlagsPromotionResultV0:
+    repo = repo_root or Path.cwd()
+    head = current_head or _repo_head_v0(repo)
+    before_flags = evaluate_surface_p_final_flags_fail_closed_contract_v0(
+        SurfacePFinalFlagsEvidenceInputV0(
+            source_manifest_verify_rc=-1,
+            targeted_semantic_binding_confirmations={},
+            surface_p_parity_suite_confirmed=False,
+            runtime_bridge_binding_status="BOUND_NOT_ACTIVATED",
+        )
+    )
+    evidence, blocker, context = build_surface_p_final_flags_evidence_from_eligibility_gate_v0(
+        eligibility_evidence_dir=eligibility_evidence_dir,
+        closeout_evidence_dir=closeout_evidence_dir,
+        current_head=head,
+        repo_root=repo,
+    )
+    if evidence is None:
+        after_flags = before_flags
+        return SurfacePFinalFlagsPromotionResultV0(
+            promoted=False,
+            promotion_blocker=blocker,
+            eligibility_evidence_dir=str(eligibility_evidence_dir),
+            closeout_evidence_dir=str(closeout_evidence_dir),
+            proof_bundle_dir=str(context.get("proof_bundle_dir", "")),
+            eligibility_head=str(context.get("eligibility_head", "")),
+            current_head=head,
+            eligibility_head_binding_ok=bool(context.get("eligibility_head_binding_ok", False)),
+            source_manifest_verify_rc=int(context.get("eligibility_manifest_rc", -1)),
+            transitive_manifest_verify_rc=int(context.get("transitive_manifest_verify_rc", -1)),
+            before_flags=before_flags,
+            after_flags=after_flags,
+            fail_closed_reasons=(blocker,),
+        )
+
+    after_flags = evaluate_surface_p_final_flags_fail_closed_contract_v0(evidence)
+    promoted = (
+        after_flags.full_canonical_chain_wired
+        and after_flags.backtest_runtime_decision_parity_pass
+        and not after_flags.system_economic_evidence_admissible
+        and not after_flags.direct_true_flag_assignment
+    )
+    return SurfacePFinalFlagsPromotionResultV0(
+        promoted=promoted,
+        promotion_blocker="NONE" if promoted else "PROMOTION_CONTRACT_NOT_SATISFIED",
+        eligibility_evidence_dir=str(eligibility_evidence_dir),
+        closeout_evidence_dir=str(closeout_evidence_dir),
+        proof_bundle_dir=str(context.get("proof_bundle_dir", "")),
+        eligibility_head=str(context.get("eligibility_head", "")),
+        current_head=head,
+        eligibility_head_binding_ok=bool(context.get("eligibility_head_binding_ok", False)),
+        source_manifest_verify_rc=0,
+        transitive_manifest_verify_rc=0,
+        before_flags=before_flags,
+        after_flags=after_flags,
+        fail_closed_reasons=after_flags.fail_closed_reasons,
+    )
 
 
 def build_surface_p_final_flags_evidence_input_v0(

--- a/tests/trading/master_v2/test_surface_p_final_flags_fail_closed_contract_v0.py
+++ b/tests/trading/master_v2/test_surface_p_final_flags_fail_closed_contract_v0.py
@@ -18,14 +18,29 @@ from trading.master_v2.surface_p_final_flags_fail_closed_contract_v0 import (
     CONTRACT_SLICE_ID,
     DIRECT_TRUE_FLAG_ASSIGNMENT,
     PACKAGE_MARKER,
+    PROMOTION_SLICE_ID,
+    REASON_ELIGIBILITY_HEAD_STALE,
+    REASON_ELIGIBILITY_MANIFEST_UNVERIFIED,
     REQUIRED_SEMANTIC_BINDING_CONFIRMATIONS_V0,
     SurfacePFinalFlagsEvidenceInputV0,
+    build_surface_p_final_flags_evidence_from_eligibility_gate_v0,
     current_head_default_final_flags_evidence_input_v0,
     derive_targeted_semantic_binding_confirmations_from_gap_assessment_v0,
     evaluate_current_head_surface_p_final_flags_fail_closed_contract_v0,
     evaluate_surface_p_final_flags_fail_closed_contract_v0,
+    evaluate_surface_p_final_flags_manifest_verified_promotion_v0,
     reject_direct_true_flag_assignment_v0,
     surface_p_final_flags_evidence_input_field_names_v0,
+    verify_evidence_dir_manifest_sha256_v0,
+)
+
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+DEFAULT_SOURCE_CLOSEOUT = (
+    ARCHIVE_ROOT
+    / "research/pr5133_merge_closeout_full_canonical_parity_pass_eligibility_gate_v0_20260712T224903Z"
+)
+DEFAULT_ELIGIBILITY_EVIDENCE = (
+    ARCHIVE_ROOT / "planning/full_canonical_parity_pass_eligibility_gate_v0_20260712T222708Z"
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -249,3 +264,107 @@ def test_slice_changed_paths_allowed_v0() -> None:
         [p.replace(REPO_ROOT.as_posix() + "/", "") for p in map(str, _SLICE_SOURCE_PATHS)]
     )
     assert ok, violations
+
+
+def test_promotion_slice_constant_v0() -> None:
+    assert PROMOTION_SLICE_ID == "SURFACE_P_FINAL_FLAGS_MANIFEST_VERIFIED_PROMOTION_V0"
+
+
+def test_manifest_verified_promotion_passes_with_source_closeout_and_eligibility_v0() -> None:
+    if not DEFAULT_SOURCE_CLOSEOUT.is_dir() or not DEFAULT_ELIGIBILITY_EVIDENCE.is_dir():
+        return
+    promotion = evaluate_surface_p_final_flags_manifest_verified_promotion_v0(
+        eligibility_evidence_dir=DEFAULT_ELIGIBILITY_EVIDENCE,
+        closeout_evidence_dir=DEFAULT_SOURCE_CLOSEOUT,
+        repo_root=REPO_ROOT,
+    )
+    assert promotion.transitive_manifest_verify_rc == 0
+    assert promotion.eligibility_head_binding_ok is True
+    assert promotion.promoted is True
+    assert promotion.after_flags.full_canonical_chain_wired is True
+    assert promotion.after_flags.backtest_runtime_decision_parity_pass is True
+    assert promotion.after_flags.system_economic_evidence_admissible is False
+    assert promotion.before_flags.full_canonical_chain_wired is False
+
+
+def test_manifest_tamper_blocks_promotion_v0(tmp_path: Path) -> None:
+    eligibility = tmp_path / "eligibility"
+    closeout = tmp_path / "closeout"
+    eligibility.mkdir()
+    closeout.mkdir()
+    (eligibility / "eligibility_gate_result.json").write_text(
+        '{"assessment_verdict":"PASS_FULL_CANONICAL_PARITY_PASS_ELIGIBILITY_GATE_V0","full_canonical_parity_pass_eligible":true,"current_head":"deadbeef","runtime_bridge_boundary_status":"BOUND_NOT_ACTIVATED"}',
+        encoding="utf-8",
+    )
+    (closeout / "final_report.txt").write_text("VERDICT=PASS\n", encoding="utf-8")
+    promotion = evaluate_surface_p_final_flags_manifest_verified_promotion_v0(
+        eligibility_evidence_dir=eligibility,
+        closeout_evidence_dir=closeout,
+        repo_root=REPO_ROOT,
+        current_head="deadbeef",
+    )
+    assert promotion.promoted is False
+    assert promotion.promotion_blocker in {
+        REASON_ELIGIBILITY_MANIFEST_UNVERIFIED,
+        REASON_ELIGIBILITY_HEAD_STALE,
+    }
+
+
+def test_stale_eligibility_head_blocks_promotion_v0(tmp_path: Path) -> None:
+    from scripts.research.full_canonical_parity_pass_eligibility_gate_v0 import write_manifest
+
+    eligibility = tmp_path / "eligibility"
+    closeout = tmp_path / "closeout"
+    proof = tmp_path / "proof"
+    for directory in (eligibility, closeout, proof):
+        directory.mkdir()
+    stale_head = "0" * 40
+    (eligibility / "eligibility_gate_result.json").write_text(
+        (
+            '{"assessment_verdict":"PASS_FULL_CANONICAL_PARITY_PASS_ELIGIBILITY_GATE_V0",'
+            '"full_canonical_parity_pass_eligible":true,'
+            f'"current_head":"{stale_head}",'
+            '"runtime_bridge_boundary_status":"BOUND_NOT_ACTIVATED"}'
+        ),
+        encoding="utf-8",
+    )
+    (eligibility / "eligibility_gate_inputs.json").write_text(
+        f'{{"proof_bundle_dir":"{proof}"}}',
+        encoding="utf-8",
+    )
+    (eligibility / "current_head_proof_binding.json").write_text(
+        (f'{{"manifest_verified_full_parity_proof_bundle":true,"proof_bundle_dir":"{proof}"}}'),
+        encoding="utf-8",
+    )
+    (proof / "proof_bundle.json").write_text(
+        '{"full_parity_proof_bundle_status":"PROVEN_MANIFEST_VERIFIED"}',
+        encoding="utf-8",
+    )
+    (closeout / "final_report.txt").write_text("VERDICT=PASS\n", encoding="utf-8")
+    assert write_manifest(eligibility) == 0
+    assert write_manifest(closeout) == 0
+    assert write_manifest(proof) == 0
+    promotion = evaluate_surface_p_final_flags_manifest_verified_promotion_v0(
+        eligibility_evidence_dir=eligibility,
+        closeout_evidence_dir=closeout,
+        repo_root=REPO_ROOT,
+    )
+    assert promotion.promoted is False
+    assert promotion.promotion_blocker == REASON_ELIGIBILITY_HEAD_STALE
+
+
+def test_promotion_materialization_is_deterministic_v0() -> None:
+    if not DEFAULT_SOURCE_CLOSEOUT.is_dir() or not DEFAULT_ELIGIBILITY_EVIDENCE.is_dir():
+        return
+    first = evaluate_surface_p_final_flags_manifest_verified_promotion_v0(
+        eligibility_evidence_dir=DEFAULT_ELIGIBILITY_EVIDENCE,
+        closeout_evidence_dir=DEFAULT_SOURCE_CLOSEOUT,
+        repo_root=REPO_ROOT,
+    )
+    second = evaluate_surface_p_final_flags_manifest_verified_promotion_v0(
+        eligibility_evidence_dir=DEFAULT_ELIGIBILITY_EVIDENCE,
+        closeout_evidence_dir=DEFAULT_SOURCE_CLOSEOUT,
+        repo_root=REPO_ROOT,
+    )
+    assert first.promoted == second.promoted
+    assert first.after_flags == second.after_flags


### PR DESCRIPTION
## Summary
- Extend the Surface P fail-closed final-flags contract with a manifest-verified eligibility-gate promotion path.
- Add a focused promotion materializer that binds PR5133 closeout and eligibility evidence to final-flag derivation.
- Add contract tests for promotion pass, manifest tamper, stale eligibility head, and deterministic roundtrip.

## Test plan
- [x] `pytest -q tests/trading/master_v2/test_surface_p_final_flags_fail_closed_contract_v0.py` (20 passed)
- [x] Planning closeout PASS at `.../planning/surface_p_final_flags_manifest_verified_promotion_v0_20260712T225222Z` with `MANIFEST_VERIFY_RC=0`
- [x] `FULL_CANONICAL_CHAIN_WIRED=true`, `BACKTEST_RUNTIME_DECISION_PARITY_PASS=true`, `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`


Made with [Cursor](https://cursor.com)