### PR TITLE
Lead-lag v0 MV2 mandatory boundary state-file wiring v0

### DIFF
--- a/config/ops/cross_sectional_futures_lead_lag_information_diffusion_v0_economic_evaluation_v1.json
+++ b/config/ops/cross_sectional_futures_lead_lag_information_diffusion_v0_economic_evaluation_v1.json
@@ -83,6 +83,29 @@
     "parity_proof_ref": "planning/cross_sectional_futures_lead_lag_information_diffusion_v0_full_canonical_evaluation_path_parity_proof_read_only_v0_20260712T205902Z",
     "ratified_read_only": true
   },
+  "mv2_research_backtest_mandatory_boundary_state_file_binding_v0": {
+    "capital_risk_sizing": {
+      "expected_state_file_digest_ref": "82a8b8ae2f38a90c93915c97c912243b3fca64b68e1e1490e062049cdff728a7",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/capital_risk_sizing.json"
+    },
+    "canonical_order_intent": {
+      "expected_state_file_digest_ref": "3fc5a99ca38101b3017b00260b2bdbbd7a0fb96e7f2c600333e40876c98e06b5",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/canonical_order_intent.json"
+    },
+    "killswitch": {
+      "expected_state_file_digest_ref": "e8acdea6f07b3e5e232aef82ad9e6ce0e2dbf1bf09f7c1395a13e5cb176f9aeb",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/killswitch.json"
+    },
+    "reconciliation": {
+      "expected_state_file_digest_ref": "3475daedda9ec7d490f395972fd82356ac81288379fa708b43fc0a6c4870dcaf",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/reconciliation.json"
+    },
+    "safety_kernel": {
+      "expected_state_file_digest_ref": "21e11676f47a579032cfb594cc003271483e342f6edd49dd5e573c06da7bd30b",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/safety_kernel.json"
+    },
+    "schema_version": "mv2_research_backtest_mandatory_boundary_state_file_binding_v0"
+  },
   "evidence_schema_version": "economic_viability_evidence_schema_v1.json",
   "implementation_digest": "612b431acc3833ed364b66de58b06ce15268edb30e1c5d82db50258cedd6c949",
   "offline_evaluation_sizing_contract_v1": {

--- a/config/research/mv2_backtest_mandatory_boundary_state_files_v0/MANIFEST.json
+++ b/config/research/mv2_backtest_mandatory_boundary_state_files_v0/MANIFEST.json
@@ -1,0 +1,26 @@
+{
+  "files": {
+    "canonical_order_intent": {
+      "expected_state_file_digest_ref": "3fc5a99ca38101b3017b00260b2bdbbd7a0fb96e7f2c600333e40876c98e06b5",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/canonical_order_intent.json"
+    },
+    "capital_risk_sizing": {
+      "expected_state_file_digest_ref": "82a8b8ae2f38a90c93915c97c912243b3fca64b68e1e1490e062049cdff728a7",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/capital_risk_sizing.json"
+    },
+    "killswitch": {
+      "expected_state_file_digest_ref": "e8acdea6f07b3e5e232aef82ad9e6ce0e2dbf1bf09f7c1395a13e5cb176f9aeb",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/killswitch.json"
+    },
+    "reconciliation": {
+      "expected_state_file_digest_ref": "3475daedda9ec7d490f395972fd82356ac81288379fa708b43fc0a6c4870dcaf",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/reconciliation.json"
+    },
+    "safety_kernel": {
+      "expected_state_file_digest_ref": "21e11676f47a579032cfb594cc003271483e342f6edd49dd5e573c06da7bd30b",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/safety_kernel.json"
+    }
+  },
+  "instrument_id": "inst-eth-usdt-perp",
+  "schema_version": "mv2_backtest_mandatory_boundary_state_files_manifest_v0"
+}

--- a/config/research/mv2_backtest_mandatory_boundary_state_files_v0/canonical_order_intent.json
+++ b/config/research/mv2_backtest_mandatory_boundary_state_files_v0/canonical_order_intent.json
@@ -1,0 +1,19 @@
+{
+  "account_equity": "10000",
+  "canonical_order_intent_owner_digest_ref": "v1",
+  "current_reconciled_exposure": "0",
+  "daily_loss_remaining_budget": "25",
+  "instrument_id": "inst-eth-usdt-perp",
+  "lot_size": "0.01",
+  "maximum_quantity": "100",
+  "minimum_notional": "5",
+  "minimum_quantity": "0.01",
+  "per_trade_risk_limit": "25",
+  "protective_stop_price": "3400",
+  "reference_price": "3500",
+  "schema_version": "canonical_order_intent_boundary_backtest_state_file_v0",
+  "scope_capital_limit": "500",
+  "state_file_digest_ref": "3fc5a99ca38101b3017b00260b2bdbbd7a0fb96e7f2c600333e40876c98e06b5",
+  "tick_size": "0.01",
+  "total_capital_limit": "500"
+}

--- a/config/research/mv2_backtest_mandatory_boundary_state_files_v0/capital_risk_sizing.json
+++ b/config/research/mv2_backtest_mandatory_boundary_state_files_v0/capital_risk_sizing.json
@@ -1,0 +1,19 @@
+{
+  "account_equity": "10000",
+  "capital_risk_sizing_owner_digest_ref": "v1",
+  "current_reconciled_exposure": "0",
+  "daily_loss_remaining_budget": "25",
+  "instrument_id": "inst-eth-usdt-perp",
+  "lot_size": "0.01",
+  "maximum_quantity": "100",
+  "minimum_notional": "5",
+  "minimum_quantity": "0.01",
+  "per_trade_risk_limit": "25",
+  "protective_stop_price": "3400",
+  "reference_price": "3500",
+  "schema_version": "capital_risk_sizing_boundary_backtest_state_file_v0",
+  "scope_capital_limit": "500",
+  "state_file_digest_ref": "82a8b8ae2f38a90c93915c97c912243b3fca64b68e1e1490e062049cdff728a7",
+  "tick_size": "0.01",
+  "total_capital_limit": "500"
+}

--- a/config/research/mv2_backtest_mandatory_boundary_state_files_v0/killswitch.json
+++ b/config/research/mv2_backtest_mandatory_boundary_state_files_v0/killswitch.json
@@ -1,0 +1,7 @@
+{
+  "fencing_digest_ref": "killswitch_owner_contract_digest_v1_7f3c9a2e1b4d6f8051a9c3e7d2b4f6089a1c3e5d7b9f0123456789abcdef0123",
+  "killswitch_boundary_mode": "block_new",
+  "prior_killswitch_active": false,
+  "schema_version": "killswitch_boundary_backtest_state_file_v0",
+  "state_file_digest_ref": "e8acdea6f07b3e5e232aef82ad9e6ce0e2dbf1bf09f7c1395a13e5cb176f9aeb"
+}

--- a/config/research/mv2_backtest_mandatory_boundary_state_files_v0/reconciliation.json
+++ b/config/research/mv2_backtest_mandatory_boundary_state_files_v0/reconciliation.json
@@ -1,0 +1,12 @@
+{
+  "existing_position_side": "none",
+  "fill_snapshot_unresolved": false,
+  "intent_snapshot_unresolved": false,
+  "order_snapshot_unresolved": false,
+  "position_state": "flat_reconciled",
+  "reconciliation_owner_digest_ref": "runtime_state_reconciliation_contract_v1",
+  "reconciliation_state": "reconciled",
+  "schema_version": "reconciliation_boundary_backtest_state_file_v0",
+  "state_file_digest_ref": "3475daedda9ec7d490f395972fd82356ac81288379fa708b43fc0a6c4870dcaf",
+  "venue_flat": true
+}

--- a/config/research/mv2_backtest_mandatory_boundary_state_files_v0/safety_kernel.json
+++ b/config/research/mv2_backtest_mandatory_boundary_state_files_v0/safety_kernel.json
@@ -1,0 +1,14 @@
+{
+  "killswitch_blocked": false,
+  "killswitch_fencing_digest_ref": "killswitch_owner_contract_digest_v1_7f3c9a2e1b4d6f8051a9c3e7d2b4f6089a1c3e5d7b9f0123456789abcdef0123",
+  "position_state": "flat_reconciled",
+  "reconciliation_state": "reconciled",
+  "safety_decision_allowed": true,
+  "safety_exit_signal_reason_code": "",
+  "safety_exit_signal_triggered": false,
+  "safety_kernel_owner_digest_ref": "runtime_eligibility_evidence_v1",
+  "safety_mode": "normal",
+  "schema_version": "safety_kernel_boundary_backtest_state_file_v0",
+  "state_file_digest_ref": "21e11676f47a579032cfb594cc003271483e342f6edd49dd5e573c06da7bd30b",
+  "trading_gate": "entry_allowed"
+}

--- a/src/research/cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.py
+++ b/src/research/cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.py
@@ -22,6 +22,11 @@ from src.backtest import admissible_versioned_futures_dataset_v1 as ds
 from src.backtest.mv2_research_wiring_v1 import (
     MV2_REQUIRED_INSTRUMENT_ID,
     MV2ResearchWiringResultV1,
+    CanonicalOrderIntentBacktestStateFileBindingConfigV1,
+    CapitalRiskSizingBacktestStateFileBindingConfigV1,
+    KillSwitchBacktestStateFileBindingConfigV1,
+    ReconciliationBacktestStateFileBindingConfigV1,
+    SafetyKernelBacktestStateFileBindingConfigV1,
     run_mv2_research_backtest_wiring_v1,
 )
 from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_score_v0 import (
@@ -75,6 +80,28 @@ REASON_SCORE_SIDE_SHORTCUT_FORBIDDEN = (
 REASON_ORCHESTRATOR_EMPTY = "ORCHESTRATOR_EMPTY"
 REASON_PANEL_MEMBER_MISSING = "PANEL_MEMBER_MISSING"
 REASON_MV2_BARS_EMPTY = "MV2_BARS_EMPTY"
+REASON_MANDATORY_STATE_FILE_BINDING_SECTION_MISSING = "MANDATORY_STATE_FILE_BINDING_SECTION_MISSING"
+REASON_MANDATORY_STATE_FILE_BINDING_MISSING = "MANDATORY_STATE_FILE_BINDING_MISSING"
+REASON_MANDATORY_STATE_FILE_PATH_UNREADABLE = "MANDATORY_STATE_FILE_PATH_UNREADABLE"
+REASON_MANDATORY_STATE_FILE_VALIDATION_FAILED = "MANDATORY_STATE_FILE_VALIDATION_FAILED"
+
+MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION = (
+    "mv2_research_backtest_mandatory_boundary_state_file_binding_v0"
+)
+MANDATORY_BOUNDARY_STATE_FILE_BINDING_KEYS: tuple[str, ...] = (
+    "capital_risk_sizing",
+    "canonical_order_intent",
+    "safety_kernel",
+    "killswitch",
+    "reconciliation",
+)
+_MANDATORY_BINDING_KEY_TO_MV2_KWARG: dict[str, str] = {
+    "capital_risk_sizing": "capital_risk_sizing_state_file_binding",
+    "canonical_order_intent": "canonical_order_intent_state_file_binding",
+    "safety_kernel": "safety_kernel_state_file_binding",
+    "killswitch": "killswitch_state_file_binding",
+    "reconciliation": "reconciliation_state_file_binding",
+}
 
 
 class AdapterTerminalStatus(str, Enum):
@@ -89,6 +116,15 @@ class LeadLagScoreFeatureRowV0:
     diffusion_score: float
     panel_median_return: float
     lagged_return: float
+
+
+@dataclass(frozen=True)
+class MandatoryMv2BacktestBoundaryStateFileBindingsV0:
+    capital_risk_sizing: CapitalRiskSizingBacktestStateFileBindingConfigV1
+    canonical_order_intent: CanonicalOrderIntentBacktestStateFileBindingConfigV1
+    safety_kernel: SafetyKernelBacktestStateFileBindingConfigV1
+    killswitch: KillSwitchBacktestStateFileBindingConfigV1
+    reconciliation: ReconciliationBacktestStateFileBindingConfigV1
 
 
 @dataclass(frozen=True)
@@ -132,9 +168,155 @@ def materialize_adapter_contract_v0() -> dict[str, Any]:
         "mv2_required_instrument_id": MV2_REQUIRED_INSTRUMENT_ID,
         "score_family_policy": SCORE_FORMULA_VERSION,
         "score_to_final_side_shortcut_allowed": False,
+        "mandatory_boundary_state_file_binding_section": (
+            MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION
+        ),
+        "mandatory_boundary_state_file_binding_keys": list(
+            MANDATORY_BOUNDARY_STATE_FILE_BINDING_KEYS
+        ),
+        "mandatory_boundary_state_file_binding_count": len(
+            MANDATORY_BOUNDARY_STATE_FILE_BINDING_KEYS
+        ),
+        "synthetic_defaults_allowed": False,
         "economic_evaluation_executed": False,
         "authority_effect": "NONE",
         "runtime_effect": "NONE",
+    }
+
+
+def _resolve_single_mandatory_state_file_binding_v0(
+    repo_root: Path,
+    binding_section: Mapping[str, Any],
+    binding_key: str,
+) -> tuple[Path, str]:
+    entry = binding_section.get(binding_key)
+    if not isinstance(entry, Mapping):
+        raise ValueError(f"{REASON_MANDATORY_STATE_FILE_BINDING_MISSING}:{binding_key}")
+    rel_path = entry.get("state_file_path")
+    digest_ref = entry.get("expected_state_file_digest_ref")
+    if not isinstance(rel_path, str) or not rel_path.strip():
+        raise ValueError(f"{REASON_MANDATORY_STATE_FILE_BINDING_MISSING}:{binding_key}")
+    if not isinstance(digest_ref, str) or not digest_ref.strip():
+        raise ValueError(f"{REASON_MANDATORY_STATE_FILE_BINDING_MISSING}:{binding_key}")
+    resolved = (repo_root / rel_path).resolve()
+    if not resolved.is_file():
+        raise ValueError(f"{REASON_MANDATORY_STATE_FILE_PATH_UNREADABLE}:{binding_key}")
+    return resolved, digest_ref
+
+
+def resolve_mandatory_mv2_backtest_boundary_state_file_bindings_v0(
+    repo_root: Path,
+    ops_config: Mapping[str, Any],
+) -> tuple[MandatoryMv2BacktestBoundaryStateFileBindingsV0 | None, tuple[str, ...]]:
+    """Resolve and canonically validate mandatory MV2 backtest boundary state-file bindings."""
+    section = ops_config.get(MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION)
+    if not isinstance(section, Mapping):
+        return None, (REASON_MANDATORY_STATE_FILE_BINDING_SECTION_MISSING,)
+
+    reasons: list[str] = []
+    resolved_paths: dict[str, tuple[Path, str]] = {}
+    for binding_key in MANDATORY_BOUNDARY_STATE_FILE_BINDING_KEYS:
+        try:
+            resolved_paths[binding_key] = _resolve_single_mandatory_state_file_binding_v0(
+                repo_root,
+                section,
+                binding_key,
+            )
+        except ValueError as exc:
+            reasons.append(str(exc.args[0]))
+
+    if reasons:
+        return None, tuple(reasons)
+
+    try:
+        from src.trading.master_v2.capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0 import (
+            load_capital_risk_sizing_backtest_state_file_record_v0,
+        )
+        from src.trading.master_v2.canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0 import (
+            load_canonical_order_intent_backtest_state_file_record_v0,
+        )
+        from src.trading.master_v2.killswitch_boundary_backtest_state_file_binding_adapter_v0 import (
+            load_killswitch_backtest_state_file_record_v0,
+        )
+        from src.trading.master_v2.reconciliation_boundary_backtest_state_file_binding_adapter_v0 import (
+            load_reconciliation_backtest_state_file_record_v0,
+        )
+        from src.trading.master_v2.safety_kernel_boundary_backtest_state_file_binding_adapter_v0 import (
+            load_safety_kernel_backtest_state_file_record_v0,
+        )
+
+        crs_path, crs_digest = resolved_paths["capital_risk_sizing"]
+        coi_path, coi_digest = resolved_paths["canonical_order_intent"]
+        sk_path, sk_digest = resolved_paths["safety_kernel"]
+        ks_path, ks_digest = resolved_paths["killswitch"]
+        rec_path, rec_digest = resolved_paths["reconciliation"]
+
+        load_capital_risk_sizing_backtest_state_file_record_v0(
+            crs_path,
+            expected_digest_ref=crs_digest,
+        )
+        load_canonical_order_intent_backtest_state_file_record_v0(
+            coi_path,
+            expected_digest_ref=coi_digest,
+        )
+        load_safety_kernel_backtest_state_file_record_v0(
+            sk_path,
+            expected_digest_ref=sk_digest,
+        )
+        load_killswitch_backtest_state_file_record_v0(
+            ks_path,
+            expected_digest_ref=ks_digest,
+        )
+        load_reconciliation_backtest_state_file_record_v0(
+            rec_path,
+            expected_digest_ref=rec_digest,
+        )
+    except ValueError as exc:
+        return None, (f"{REASON_MANDATORY_STATE_FILE_VALIDATION_FAILED}:{exc.args[0]}",)
+
+    return (
+        MandatoryMv2BacktestBoundaryStateFileBindingsV0(
+            capital_risk_sizing=CapitalRiskSizingBacktestStateFileBindingConfigV1(
+                state_file_path=crs_path,
+                expected_state_file_digest_ref=crs_digest,
+                require_state_file=True,
+            ),
+            canonical_order_intent=CanonicalOrderIntentBacktestStateFileBindingConfigV1(
+                state_file_path=coi_path,
+                expected_state_file_digest_ref=coi_digest,
+                require_state_file=True,
+            ),
+            safety_kernel=SafetyKernelBacktestStateFileBindingConfigV1(
+                state_file_path=sk_path,
+                expected_state_file_digest_ref=sk_digest,
+                require_state_file=True,
+            ),
+            killswitch=KillSwitchBacktestStateFileBindingConfigV1(
+                state_file_path=ks_path,
+                expected_state_file_digest_ref=ks_digest,
+                require_state_file=True,
+            ),
+            reconciliation=ReconciliationBacktestStateFileBindingConfigV1(
+                state_file_path=rec_path,
+                expected_state_file_digest_ref=rec_digest,
+                require_state_file=True,
+            ),
+        ),
+        (),
+    )
+
+
+def mandatory_bindings_to_mv2_wiring_kwargs_v0(
+    bindings: MandatoryMv2BacktestBoundaryStateFileBindingsV0,
+) -> dict[str, Any]:
+    return {
+        _MANDATORY_BINDING_KEY_TO_MV2_KWARG["capital_risk_sizing"]: bindings.capital_risk_sizing,
+        _MANDATORY_BINDING_KEY_TO_MV2_KWARG["canonical_order_intent"]: (
+            bindings.canonical_order_intent
+        ),
+        _MANDATORY_BINDING_KEY_TO_MV2_KWARG["safety_kernel"]: bindings.safety_kernel,
+        _MANDATORY_BINDING_KEY_TO_MV2_KWARG["killswitch"]: bindings.killswitch,
+        _MANDATORY_BINDING_KEY_TO_MV2_KWARG["reconciliation"]: bindings.reconciliation,
     }
 
 
@@ -301,7 +483,6 @@ def run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
     evaluation_path_mode: str = SYSTEM_EVIDENCE_MV2_PATH_MODE,
 ) -> LeadLagMv2WiringAdapterResultV0:
     """Bind lead-lag research scores to canonical MV2 research backtest wiring."""
-    _ = repo_root
     authority = "NONE"
     runtime = "NONE"
     research_strategy_id = str(
@@ -495,12 +676,39 @@ def run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
         l1_observation_status=ds.L1ObservationStatusV1.EXECUTION_MODEL_BOUND_NOT_OBSERVED,
     )
 
+    mandatory_bindings, binding_reasons = (
+        resolve_mandatory_mv2_backtest_boundary_state_file_bindings_v0(
+            repo_root,
+            ops_config,
+        )
+    )
+    if mandatory_bindings is None:
+        return LeadLagMv2WiringAdapterResultV0(
+            status=AdapterTerminalStatus.FAIL_CLOSED,
+            evaluation_path_mode=evaluation_path_mode,
+            wiring_result=None,
+            orchestrator_result=orchestrator,
+            score_feature_rows=score_rows,
+            selected_panel_member_id=selected_member,
+            mv2_bars_row_count=len(bars),
+            binding_digest=binding_digest,
+            dataset_digest=dataset_digest,
+            universe_digest=universe_digest,
+            research_binding_strategy_id=research_strategy_id,
+            mv2_engine_signal_strategy_id=MV2_ENGINE_SIGNAL_STRATEGY_ID,
+            reason_codes=binding_reasons,
+            authority_effect=authority,
+            runtime_effect=runtime,
+            economic_evaluation_executed=False,
+        )
+
     wiring = run_mv2_research_backtest_wiring_v1(
         bars,
         strategy_id=MV2_ENGINE_SIGNAL_STRATEGY_ID,
         cfg=cfg,
         instrument_id=MV2_REQUIRED_INSTRUMENT_ID,
         profile_binding=profile_binding,
+        **mandatory_bindings_to_mv2_wiring_kwargs_v0(mandatory_bindings),
     )
 
     return LeadLagMv2WiringAdapterResultV0(

--- a/tests/research/test_cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.py
+++ b/tests/research/test_cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.py
@@ -23,13 +23,21 @@ from src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiri
     MV2_CANONICAL_OWNER,
     MV2_ENGINE_SIGNAL_STRATEGY_ID,
     REASON_GO_TOKEN_INVALID,
+    REASON_MANDATORY_STATE_FILE_BINDING_MISSING,
+    REASON_MANDATORY_STATE_FILE_BINDING_SECTION_MISSING,
+    REASON_MANDATORY_STATE_FILE_PATH_UNREADABLE,
+    REASON_MANDATORY_STATE_FILE_VALIDATION_FAILED,
     REASON_SCORE_SIDE_SHORTCUT_FORBIDDEN,
     AdapterTerminalStatus,
+    MANDATORY_BOUNDARY_STATE_FILE_BINDING_KEYS,
+    MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION,
     adapter_result_to_dict,
     extract_lead_lag_score_feature_rows_v0,
+    mandatory_bindings_to_mv2_wiring_kwargs_v0,
     materialize_adapter_contract_v0,
     materialize_mv2_bars_with_score_features_v0,
     reject_score_to_final_side_shortcut_v0,
+    resolve_mandatory_mv2_backtest_boundary_state_file_bindings_v0,
     run_lead_lag_mv2_research_backtest_wiring_boundary_v0,
     verify_adapter_go_token_v0,
     verify_binding_digests_unchanged_v0,
@@ -71,13 +79,6 @@ def fixture_complete_binding() -> dict:
 @pytest.fixture(name="ops_config")
 def fixture_ops_config() -> dict:
     return load_ops_evaluation_config_v0(REPO_ROOT)
-
-
-def test_adapter_contract_declares_mv2_owner() -> None:
-    contract = materialize_adapter_contract_v0()
-    assert contract["canonical_mv2_owner"] == MV2_CANONICAL_OWNER
-    assert contract["canonical_mv2_callable"] == MV2_CANONICAL_CALLABLE
-    assert contract["score_to_final_side_shortcut_allowed"] is False
 
 
 def test_go_token_validation() -> None:
@@ -151,6 +152,138 @@ def test_mv2_bars_carry_score_features_not_final_side(complete_binding: dict) ->
     assert "slot_side" not in bars.columns
 
 
+def test_adapter_contract_declares_mv2_owner() -> None:
+    contract = materialize_adapter_contract_v0()
+    assert contract["canonical_mv2_owner"] == MV2_CANONICAL_OWNER
+    assert contract["canonical_mv2_callable"] == MV2_CANONICAL_CALLABLE
+    assert contract["score_to_final_side_shortcut_allowed"] is False
+    assert contract["mandatory_boundary_state_file_binding_count"] == len(
+        MANDATORY_BOUNDARY_STATE_FILE_BINDING_KEYS
+    )
+    assert contract["synthetic_defaults_allowed"] is False
+    assert (
+        MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION
+        in contract["mandatory_boundary_state_file_binding_section"]
+    )
+
+
+def _ops_config_without_binding_key(ops_config: dict, key: str) -> dict:
+    cfg = json.loads(json.dumps(ops_config))
+    section = dict(cfg[MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION])
+    section.pop(key, None)
+    cfg[MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION] = section
+    return cfg
+
+
+def test_resolve_mandatory_bindings_from_ops_config(ops_config: dict) -> None:
+    bindings, reasons = resolve_mandatory_mv2_backtest_boundary_state_file_bindings_v0(
+        REPO_ROOT,
+        ops_config,
+    )
+    assert reasons == ()
+    assert bindings is not None
+    kwargs = mandatory_bindings_to_mv2_wiring_kwargs_v0(bindings)
+    assert set(kwargs) == {
+        "capital_risk_sizing_state_file_binding",
+        "canonical_order_intent_state_file_binding",
+        "safety_kernel_state_file_binding",
+        "killswitch_state_file_binding",
+        "reconciliation_state_file_binding",
+    }
+
+
+@pytest.mark.parametrize("binding_key", MANDATORY_BOUNDARY_STATE_FILE_BINDING_KEYS)
+def test_adapter_fail_closed_on_each_missing_mandatory_binding(
+    complete_binding: dict,
+    ops_config: dict,
+    binding_key: str,
+) -> None:
+    panel = build_synthetic_panel_series_v0()
+    cfg = _ops_config_without_binding_key(ops_config, binding_key)
+    result = run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
+        repo_root=REPO_ROOT,
+        panel_series=panel,
+        versioned_binding=complete_binding,
+        ops_config=cfg,
+        go_token=GO_TOKEN,
+    )
+    assert result.status is AdapterTerminalStatus.FAIL_CLOSED
+    assert result.wiring_result is None
+    assert any(
+        code == f"{REASON_MANDATORY_STATE_FILE_BINDING_MISSING}:{binding_key}"
+        for code in result.reason_codes
+    )
+
+
+def test_adapter_fail_closed_on_missing_binding_section(
+    complete_binding: dict,
+    ops_config: dict,
+) -> None:
+    panel = build_synthetic_panel_series_v0()
+    cfg = json.loads(json.dumps(ops_config))
+    cfg.pop(MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION, None)
+    result = run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
+        repo_root=REPO_ROOT,
+        panel_series=panel,
+        versioned_binding=complete_binding,
+        ops_config=cfg,
+        go_token=GO_TOKEN,
+    )
+    assert result.status is AdapterTerminalStatus.FAIL_CLOSED
+    assert REASON_MANDATORY_STATE_FILE_BINDING_SECTION_MISSING in result.reason_codes
+
+
+def test_adapter_fail_closed_on_unreadable_state_file_path(
+    complete_binding: dict,
+    ops_config: dict,
+) -> None:
+    panel = build_synthetic_panel_series_v0()
+    cfg = json.loads(json.dumps(ops_config))
+    section = dict(cfg[MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION])
+    section["capital_risk_sizing"] = {
+        "state_file_path": "config/research/does_not_exist/capital_risk_sizing.json",
+        "expected_state_file_digest_ref": "0" * 64,
+    }
+    cfg[MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION] = section
+    result = run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
+        repo_root=REPO_ROOT,
+        panel_series=panel,
+        versioned_binding=complete_binding,
+        ops_config=cfg,
+        go_token=GO_TOKEN,
+    )
+    assert result.status is AdapterTerminalStatus.FAIL_CLOSED
+    assert any(
+        code.startswith(f"{REASON_MANDATORY_STATE_FILE_PATH_UNREADABLE}:capital_risk_sizing")
+        for code in result.reason_codes
+    )
+
+
+def test_adapter_fail_closed_on_malformed_state_file_digest(
+    complete_binding: dict,
+    ops_config: dict,
+) -> None:
+    panel = build_synthetic_panel_series_v0()
+    cfg = json.loads(json.dumps(ops_config))
+    section = dict(cfg[MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION])
+    crs_entry = dict(section["capital_risk_sizing"])
+    crs_entry["expected_state_file_digest_ref"] = "0" * 64
+    section["capital_risk_sizing"] = crs_entry
+    cfg[MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION] = section
+    result = run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
+        repo_root=REPO_ROOT,
+        panel_series=panel,
+        versioned_binding=complete_binding,
+        ops_config=cfg,
+        go_token=GO_TOKEN,
+    )
+    assert result.status is AdapterTerminalStatus.FAIL_CLOSED
+    assert any(
+        code.startswith(REASON_MANDATORY_STATE_FILE_VALIDATION_FAILED)
+        for code in result.reason_codes
+    )
+
+
 def test_canonical_mv2_owner_invoked(complete_binding: dict, ops_config: dict) -> None:
     panel = build_synthetic_panel_series_v0()
     with patch(
@@ -182,6 +315,11 @@ def test_canonical_mv2_owner_invoked(complete_binding: dict, ops_config: dict) -
     mv2_call.assert_called_once()
     _, kwargs = mv2_call.call_args
     assert kwargs["strategy_id"] == MV2_ENGINE_SIGNAL_STRATEGY_ID
+    assert kwargs["capital_risk_sizing_state_file_binding"] is not None
+    assert kwargs["canonical_order_intent_state_file_binding"] is not None
+    assert kwargs["safety_kernel_state_file_binding"] is not None
+    assert kwargs["killswitch_state_file_binding"] is not None
+    assert kwargs["reconciliation_state_file_binding"] is not None
     assert result.status is AdapterTerminalStatus.MV2_WIRING_BOUNDARY_COMPLETE
 
 
@@ -204,6 +342,11 @@ def test_mv2_wiring_reaches_canonical_chain_components(
     assert outcome.context.instrument_id == "inst-eth-usdt-perp"
     assert outcome.evidence.decision_outcome is not None
     assert isinstance(outcome.replay_pass, bool)
+    assert outcome.capital_risk_sizing_backtest_state_file_evidence is not None
+    assert outcome.canonical_order_intent_backtest_state_file_evidence is not None
+    assert outcome.safety_kernel_backtest_state_file_evidence is not None
+    assert outcome.killswitch_backtest_state_file_evidence is not None
+    assert outcome.reconciliation_backtest_state_file_evidence is not None
 
 
 def test_dispatch_wrapper_preserves_no_runtime_effect(


### PR DESCRIPTION
## Summary
- Extend `run_lead_lag_mv2_research_backtest_wiring_boundary_v0` to require, validate, and forward five canonical offline backtest state-file bindings (capital/risk/sizing, canonical order intent, safety kernel, KillSwitch, reconciliation) into `run_mv2_research_backtest_wiring_v1`.
- Add committed canonical boundary state-file fixtures under `config/research/mv2_backtest_mandatory_boundary_state_files_v0/` and wire references in lead-lag ops evaluation config.
- Add fail-closed contract tests for missing, unreadable, and digest-mismatched bindings; preserve GO-token enforcement and LEGACY_RESEARCH default dispatch unchanged.

## Test plan
- [x] `pytest tests/research/test_cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.py` (22 passed)
- [x] `ruff format --check` and `ruff check` on touched Python surfaces
- [ ] CI PR-bounded full gate (selector: `PR_BOUNDED_FULL`)

## Hard boundaries preserved
- No economic evaluation, no runtime/authority effect, no trading semantic changes
- `FULL_CANONICAL_CHAIN_WIRED=false`, `BACKTEST_RUNTIME_DECISION_PARITY_PASS=false`, `SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE=false`


Made with [Cursor](https://cursor.com)