### PR TITLE
Rewire lead-lag productive research-eval backtest lane through canonical MV2 v0

### DIFF
--- a/scripts/ops/run_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
@@ -30,6 +30,7 @@ from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offl
     EXECUTION_VERSION,
     GO_TOKEN,
     INFRASTRUCTURE_GO_TOKEN,
+    PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN,
     REASON_FULL_CANONICAL_PARITY_NOT_PROVEN,
     REEVALUATION_GO_TOKEN,
     RUNTIME_EFFECT,
@@ -42,12 +43,14 @@ from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offl
     load_versioned_hypothesis_binding_v0,
     materialize_infrastructure_summary_v0,
     materialize_preexecution_fail_closed_block_v0,
+    materialize_productive_research_eval_backtest_lane_mv2_rewire_contract_v0,
     materialize_runner_envelope_v0,
     materialize_system_evidence_mv2_offline_economic_evaluation_binding_v0,
     resolve_identity_operator_go_v0,
     run_full_evaluation_entrypoint_dry_run_v1,
     run_full_offline_economic_evaluation_v0,
     run_mv2_system_evidence_wiring_dispatch_v0,
+    run_productive_research_eval_backtest_lane_mv2_rewire_dispatch_v0,
     validate_entry_point_go_token_v0,
     verify_execution_start_state_v0,
     verify_full_evaluation_precheck_v1,
@@ -95,6 +98,9 @@ MV2_WIRING_ADAPTER_SCOPE_CLASSIFICATION = (
 MV2_BINDING_SCOPE_CLASSIFICATION = (
     "BOUNDED_CROSS_SECTIONAL_FUTURES_LEAD_LAG_V0_SYSTEM_EVIDENCE_MV2_OFFLINE_"
     "ECONOMIC_EVALUATION_BINDING_V0"
+)
+PRODUCTIVE_MV2_REWIRE_SCOPE_CLASSIFICATION = (
+    "BOUNDED_CROSS_SECTIONAL_LEAD_LAG_V0_PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_V0"
 )
 
 
@@ -772,6 +778,107 @@ def run_system_evidence_mv2_binding_dispatch_v0(
     return payload
 
 
+def run_productive_research_eval_backtest_lane_mv2_rewire_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+    staging_root: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN:
+        _die(
+            "ERR:confirm_go_token_required:"
+            f"{PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN}"
+        )
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "research"
+        / (
+            "cross_sectional_lead_lag_v0_productive_research_eval_backtest_lane_mv2_"
+            f"rewire_v0_{ts_slug}"
+        )
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    versioned_binding = load_versioned_hypothesis_binding_v0(_REPO_ROOT)
+    ratification = materialize_lead_lag_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=_REPO_ROOT,
+        versioned_binding=versioned_binding,
+    )
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        ratification=ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+    rewire_contract = materialize_productive_research_eval_backtest_lane_mv2_rewire_contract_v0()
+    panel_series = load_ohlcv_panel_series_for_backtest(staging_root)
+    dispatch = run_productive_research_eval_backtest_lane_mv2_rewire_dispatch_v0(
+        repo_root=_REPO_ROOT,
+        panel_series=panel_series,
+        versioned_binding=versioned_binding,
+        go_token=confirm,
+    )
+
+    (bundle_dir / "PREFLIGHT.txt").write_text(
+        "\n".join(
+            [
+                f"ORIGIN_MAIN={origin_main}",
+                f"PRIMARY_HEAD_BEFORE={primary_before['head']}",
+                f"GO_TOKEN={confirm}",
+                f"SCOPE_CLASSIFICATION={PRODUCTIVE_MV2_REWIRE_SCOPE_CLASSIFICATION}",
+                f"EVALUATION_PATH_MODE={SYSTEM_EVIDENCE_MV2_PATH_MODE}",
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "REWIRE_CONTRACT.json").write_text(
+        json.dumps(rewire_contract, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "PRODUCTIVE_MV2_REWIRE_DISPATCH.json").write_text(
+        json.dumps(dispatch, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
+        "ECONOMIC_EVALUATION_EXECUTED=false\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    payload: dict[str, Any] = {
+        "verdict": dispatch["adapter"]["status"] if dispatch.get("adapter") else "FAIL_CLOSED",
+        "process_classification": PRODUCTIVE_MV2_REWIRE_SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "start_state_valid": start_state.valid,
+        "rewire_contract": rewire_contract,
+        "dispatch": dispatch,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree": str(primary_worktree),
+        "staging_root": str(staging_root),
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _guard_timeout(start_monotonic)
+    return payload
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--confirm", required=True)
@@ -808,11 +915,19 @@ def main() -> None:
             primary_worktree=args.primary_worktree,
             staging_root=args.staging_root,
         )
+    elif args.confirm == PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN:
+        result = run_productive_research_eval_backtest_lane_mv2_rewire_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+            staging_root=args.staging_root,
+        )
     else:
         _die(
             "ERR:confirm_go_token_required:"
             f"{INFRASTRUCTURE_GO}|{GO_TOKEN}|{REEVALUATION_GO}|{MV2_WIRING_ADAPTER_GO_TOKEN}|"
-            f"{SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN}"
+            f"{SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN}|"
+            f"{PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN}"
         )
     print(json.dumps(result, indent=2, sort_keys=True))
 

--- a/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
@@ -64,7 +64,6 @@ from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_mater
 )
 from src.research.cross_sectional_single_slot_backtest_wiring_v0 import (
     SingleSlotBacktestResultV0,
-    run_single_slot_panel_backtest_v0,
 )
 from src.research.cross_sectional_single_slot_research_orchestrator_v0 import (
     SlotSide,
@@ -108,6 +107,9 @@ SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN = (
     "GO_CROSS_SECTIONAL_FUTURES_LEAD_LAG_V0_SYSTEM_EVIDENCE_MV2_OFFLINE_ECONOMIC_"
     "EVALUATION_BINDING_V0"
 )
+PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_LEAD_LAG_V0_PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_V0"
+)
 ALLOWED_FULL_EVALUATION_GO_TOKENS: frozenset[str] = frozenset(
     {GO_TOKEN, REEVALUATION_GO_TOKEN, SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN}
 )
@@ -149,12 +151,23 @@ MV2_WIRING_ADAPTER_OWNER = (
     "research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0"
 )
 MV2_CANONICAL_BACKTEST_OWNER = "backtest.mv2_research_wiring_v1"
+CANONICAL_MV2_DECISION_CHAIN_OWNER = "trading.master_v2.integrated_offline_trading_logic_replay_v1"
+PRODUCTIVE_BACKTEST_LANE_GO_TOKENS: frozenset[str] = frozenset(
+    {
+        GO_TOKEN,
+        REEVALUATION_GO_TOKEN,
+        SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+        PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN,
+        INFRASTRUCTURE_GO_TOKEN,
+    }
+)
 
 _BRANCH_INFRASTRUCTURE_V0 = "INFRASTRUCTURE_V0"
 _BRANCH_EXECUTION_V0 = "EXECUTION_V0"
 _BRANCH_REEVALUATION_V0 = "REEVALUATION_V0"
 _BRANCH_MV2_WIRING_ADAPTER_V0 = "MV2_WIRING_ADAPTER_V0"
 _BRANCH_MV2_BINDING_V0 = "MV2_BINDING_V0"
+_BRANCH_PRODUCTIVE_MV2_REWIRE_V0 = "PRODUCTIVE_MV2_REWIRE_V0"
 
 _ENTRY_POINT_DISPATCH_PAIRS: tuple[tuple[str, str], ...] = (
     (INFRASTRUCTURE_GO_TOKEN, _BRANCH_INFRASTRUCTURE_V0),
@@ -162,6 +175,7 @@ _ENTRY_POINT_DISPATCH_PAIRS: tuple[tuple[str, str], ...] = (
     (REEVALUATION_GO_TOKEN, _BRANCH_REEVALUATION_V0),
     (MV2_WIRING_ADAPTER_GO_TOKEN, _BRANCH_MV2_WIRING_ADAPTER_V0),
     (SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN, _BRANCH_MV2_BINDING_V0),
+    (PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN, _BRANCH_PRODUCTIVE_MV2_REWIRE_V0),
 )
 ENTRY_POINT_DISPATCH_REGISTRY: dict[str, str] = dict(_ENTRY_POINT_DISPATCH_PAIRS)
 
@@ -184,6 +198,7 @@ REASON_RUNNER_ENVELOPE_INVALID = "RUNNER_ENVELOPE_INVALID"
 REASON_DISPATCH_GO_MISMATCH = "DISPATCH_GO_TOKEN_MISMATCH"
 REASON_DISPATCH_NOT_SUCCESSFUL = "DISPATCH_NOT_SUCCESSFUL"
 REASON_ENTRY_POINT_GO_TOKEN_UNKNOWN = "ENTRY_POINT_GO_TOKEN_UNKNOWN"
+REASON_LEGACY_RESEARCH_BACKTEST_BYPASS_BLOCKED = "LEGACY_RESEARCH_BACKTEST_BYPASS_BLOCKED"
 
 
 class InfrastructureTerminalStatus(str, Enum):
@@ -376,18 +391,39 @@ def verify_execution_start_state_v0(
 
 def run_contract_smoke_evaluation_v0(
     *,
+    repo_root: Path,
     panel_series: Sequence[InstrumentPanelSeriesV1],
     versioned_binding: Mapping[str, Any],
     staging_root: Path | None = None,
+    go_token: str = INFRASTRUCTURE_GO_TOKEN,
 ) -> InfrastructureReadinessResultV0:
-    """Contract-only smoke: lead-lag orchestrator -> backtest -> robustness wiring."""
+    """Contract-only smoke: lead-lag orchestrator -> MV2 backtest lane -> robustness wiring."""
     envelope = dict(versioned_binding)
-    binding = default_lead_lag_operator_binding_v0(envelope)
     cost_binding = _normalize_cost_execution_binding_for_backtest_v0(
         envelope["cost_execution_binding"]
     )
     period_binding = envelope["period_binding"]
     economic_policy = _resolve_economic_policy_binding_v0(envelope)
+    ops_config = load_ops_evaluation_config_v0(repo_root)
+    evaluation_path_mode = resolve_productive_evaluation_path_mode_v0(go_token=go_token)
+    legacy_ok, legacy_reasons = reject_legacy_research_backtest_bypass_v0(
+        evaluation_path_mode=evaluation_path_mode,
+    )
+    if not legacy_ok:
+        return InfrastructureReadinessResultV0(
+            status=InfrastructureTerminalStatus.FAIL_CLOSED,
+            execution_infrastructure_complete=False,
+            panel_wiring_complete=False,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest="0" * 64,
+            reason_codes=legacy_reasons,
+            smoke_backtest_net_return=None,
+            smoke_trade_count=None,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+            economic_evaluation_executed=False,
+        )
 
     materialization = materialize_bound_panel_dataset_v0(
         staging_root or Path("."),
@@ -409,15 +445,61 @@ def run_contract_smoke_evaluation_v0(
             economic_evaluation_executed=False,
         )
 
-    orchestrator = run_cross_sectional_single_slot_orchestrator_v0(
-        binding=binding,
-        panel_series=panel_series,
-        score_formula_version=SCORE_FORMULA_VERSION,
+    from src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0 import (
+        AdapterTerminalStatus,
+        run_lead_lag_mv2_research_backtest_wiring_boundary_v0,
     )
-    backtest = run_single_slot_panel_backtest_v0(
-        orchestrator,
-        panel_series,
-        cost_execution_binding=cost_binding,
+
+    adapter_go_token = resolve_adapter_go_token_for_productive_lane_v0(go_token=go_token)
+    adapter_result = run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
+        repo_root=repo_root,
+        panel_series=panel_series,
+        versioned_binding=envelope,
+        ops_config=ops_config,
+        go_token=adapter_go_token,
+        evaluation_path_mode=evaluation_path_mode,
+    )
+    if adapter_result.status is not AdapterTerminalStatus.MV2_WIRING_BOUNDARY_COMPLETE:
+        return InfrastructureReadinessResultV0(
+            status=InfrastructureTerminalStatus.FAIL_CLOSED,
+            execution_infrastructure_complete=False,
+            panel_wiring_complete=True,
+            bound_dataset_materialized=True,
+            dataset_period_match=True,
+            panel_data_digest=materialization.panel_data_digest,
+            reason_codes=adapter_result.reason_codes,
+            smoke_backtest_net_return=None,
+            smoke_trade_count=None,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+            economic_evaluation_executed=False,
+        )
+
+    orchestrator = adapter_result.orchestrator_result
+    if orchestrator is None or adapter_result.wiring_result is None:
+        return InfrastructureReadinessResultV0(
+            status=InfrastructureTerminalStatus.FAIL_CLOSED,
+            execution_infrastructure_complete=False,
+            panel_wiring_complete=True,
+            bound_dataset_materialized=True,
+            dataset_period_match=True,
+            panel_data_digest=materialization.panel_data_digest,
+            reason_codes=("MV2_WIRING_RESULT_MISSING",),
+            smoke_backtest_net_return=None,
+            smoke_trade_count=None,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+            economic_evaluation_executed=False,
+        )
+
+    initial_cash = float(ops_config.get("backtest", {}).get("initial_cash", 10_000.0))
+    roundtrip_cost_bps = float(
+        cost_binding.get("execution_model_binding", {}).get("roundtrip_cost_bps", 0.0)
+    )
+    backtest = single_slot_backtest_from_mv2_wiring_v0(
+        wiring_result=adapter_result.wiring_result,
+        initial_cash=initial_cash,
+        roundtrip_cost_bps=roundtrip_cost_bps,
     )
     robustness = wire_robustness_stages_v0(
         backtest,
@@ -500,9 +582,15 @@ def materialize_execution_contract_v0() -> dict[str, Any]:
         "execution_go_token": GO_TOKEN,
         "reevaluation_go_token": REEVALUATION_GO_TOKEN,
         "system_evidence_mv2_binding_go_token": SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+        "productive_research_eval_backtest_lane_mv2_rewire_go_token": (
+            PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN
+        ),
         "evaluation_path_modes": [LEGACY_RESEARCH_PATH_MODE, SYSTEM_EVIDENCE_MV2_PATH_MODE],
+        "productive_evaluation_path_mode": SYSTEM_EVIDENCE_MV2_PATH_MODE,
+        "legacy_research_backtest_bypass_blocked": True,
         "mv2_wiring_adapter_owner": MV2_WIRING_ADAPTER_OWNER,
         "mv2_canonical_backtest_owner": MV2_CANONICAL_BACKTEST_OWNER,
+        "canonical_mv2_decision_chain_owner": CANONICAL_MV2_DECISION_CHAIN_OWNER,
         "versioned_binding_config": CONFIG_REL_PATH,
         "orchestrator_owner": "cross_sectional_single_slot_research_orchestrator_v0",
         "score_owner": ("cross_sectional_futures_lead_lag_information_diffusion_v0_score_v0"),
@@ -548,6 +636,36 @@ def validate_entry_point_go_token_v0(go_token: str) -> tuple[bool, str | None]:
 
 def resolve_identity_operator_go_v0(requested_operator_go: str) -> str:
     return requested_operator_go
+
+
+def resolve_productive_evaluation_path_mode_v0(*, go_token: str) -> str:
+    """Productive lead-lag research-eval/backtest lane routes through SYSTEM_EVIDENCE_MV2."""
+    if go_token in PRODUCTIVE_BACKTEST_LANE_GO_TOKENS:
+        return SYSTEM_EVIDENCE_MV2_PATH_MODE
+    return LEGACY_RESEARCH_PATH_MODE
+
+
+def reject_legacy_research_backtest_bypass_v0(
+    *,
+    evaluation_path_mode: str,
+) -> tuple[bool, tuple[str, ...]]:
+    if evaluation_path_mode == LEGACY_RESEARCH_PATH_MODE:
+        return False, (REASON_LEGACY_RESEARCH_BACKTEST_BYPASS_BLOCKED,)
+    return True, ()
+
+
+def resolve_adapter_go_token_for_productive_lane_v0(*, go_token: str) -> str:
+    """Map productive lane GO tokens to adapter-accepted tokens."""
+    if go_token == INFRASTRUCTURE_GO_TOKEN:
+        return MV2_WIRING_ADAPTER_GO_TOKEN
+    if go_token in {
+        GO_TOKEN,
+        REEVALUATION_GO_TOKEN,
+        SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+        PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN,
+    }:
+        return go_token
+    return go_token
 
 
 def materialize_runner_envelope_v0(
@@ -847,6 +965,7 @@ def run_full_evaluation_entrypoint_dry_run_v1(
     stage_wiring = build_stage_wiring_status_v1(
         orchestrator_result=orchestrator,
         economic_policy_binding=_resolve_economic_policy_binding_v0(envelope),
+        evaluation_path_mode=SYSTEM_EVIDENCE_MV2_PATH_MODE,
     )
 
     return FullEvaluationEntrypointResultV1(
@@ -1349,7 +1468,6 @@ def run_full_offline_economic_evaluation_v0(
 
     loaded_panel, _ = load_panel_series_from_staging(staging_root)
     active_panel = loaded_panel if loaded_panel else tuple(panel_series)
-    binding = default_lead_lag_operator_binding_v0(envelope)
     cost_binding = _normalize_cost_execution_binding_for_backtest_v0(
         envelope["cost_execution_binding"]
     )
@@ -1358,87 +1476,97 @@ def run_full_offline_economic_evaluation_v0(
     roundtrip_cost_bps = float(
         cost_binding.get("execution_model_binding", {}).get("roundtrip_cost_bps", 0.0)
     )
-    evaluation_path_mode = (
-        SYSTEM_EVIDENCE_MV2_PATH_MODE
-        if go_token == SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN
-        else LEGACY_RESEARCH_PATH_MODE
+    evaluation_path_mode = resolve_productive_evaluation_path_mode_v0(go_token=go_token)
+    legacy_ok, legacy_reasons = reject_legacy_research_backtest_bypass_v0(
+        evaluation_path_mode=evaluation_path_mode,
+    )
+    if not legacy_ok:
+        reason_codes.extend(legacy_reasons)
+        return FullEconomicEvaluationResultV0(
+            status=ExecutionTerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=True,
+            bound_dataset_materialized=True,
+            dataset_period_match=True,
+            panel_data_digest=panel_digest,
+            data_digest_is_fixture=False,
+            stage_wiring=(),
+            backtest=None,
+            robustness=None,
+            robustness_metrics=None,
+            economic_viability_evidence={},
+            economic_classification=EconomicClassification.FAIL_CLOSED,
+            economic_validity_offline_gate_pass=False,
+            promotion_candidate_eligible=False,
+            economic_evaluation_executed=False,
+            reason_codes=tuple(reason_codes),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    from src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0 import (
+        AdapterTerminalStatus,
+        run_lead_lag_mv2_research_backtest_wiring_boundary_v0,
     )
 
-    if evaluation_path_mode == SYSTEM_EVIDENCE_MV2_PATH_MODE:
-        from src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0 import (
-            AdapterTerminalStatus,
-            run_lead_lag_mv2_research_backtest_wiring_boundary_v0,
+    adapter_go_token = resolve_adapter_go_token_for_productive_lane_v0(go_token=go_token)
+    adapter_result = run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
+        repo_root=repo_root,
+        panel_series=active_panel,
+        versioned_binding=envelope,
+        ops_config=ops_config,
+        go_token=adapter_go_token,
+        evaluation_path_mode=evaluation_path_mode,
+    )
+    if adapter_result.status is not AdapterTerminalStatus.MV2_WIRING_BOUNDARY_COMPLETE:
+        reason_codes.extend(adapter_result.reason_codes)
+        return FullEconomicEvaluationResultV0(
+            status=ExecutionTerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=True,
+            bound_dataset_materialized=True,
+            dataset_period_match=True,
+            panel_data_digest=panel_digest,
+            data_digest_is_fixture=False,
+            stage_wiring=(),
+            backtest=None,
+            robustness=None,
+            robustness_metrics=None,
+            economic_viability_evidence={},
+            economic_classification=EconomicClassification.FAIL_CLOSED,
+            economic_validity_offline_gate_pass=False,
+            promotion_candidate_eligible=False,
+            economic_evaluation_executed=False,
+            reason_codes=tuple(reason_codes),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
         )
-
-        adapter_result = run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
-            repo_root=repo_root,
-            panel_series=active_panel,
-            versioned_binding=envelope,
-            ops_config=ops_config,
-            go_token=go_token,
-            evaluation_path_mode=evaluation_path_mode,
+    orchestrator = adapter_result.orchestrator_result
+    if orchestrator is None or adapter_result.wiring_result is None:
+        reason_codes.append("MV2_WIRING_RESULT_MISSING")
+        return FullEconomicEvaluationResultV0(
+            status=ExecutionTerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=True,
+            bound_dataset_materialized=True,
+            dataset_period_match=True,
+            panel_data_digest=panel_digest,
+            data_digest_is_fixture=False,
+            stage_wiring=(),
+            backtest=None,
+            robustness=None,
+            robustness_metrics=None,
+            economic_viability_evidence={},
+            economic_classification=EconomicClassification.FAIL_CLOSED,
+            economic_validity_offline_gate_pass=False,
+            promotion_candidate_eligible=False,
+            economic_evaluation_executed=False,
+            reason_codes=tuple(reason_codes),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
         )
-        if adapter_result.status is not AdapterTerminalStatus.MV2_WIRING_BOUNDARY_COMPLETE:
-            reason_codes.extend(adapter_result.reason_codes)
-            return FullEconomicEvaluationResultV0(
-                status=ExecutionTerminalStatus.FAIL_CLOSED_PRECHECK,
-                precheck_passed=True,
-                bound_dataset_materialized=True,
-                dataset_period_match=True,
-                panel_data_digest=panel_digest,
-                data_digest_is_fixture=False,
-                stage_wiring=(),
-                backtest=None,
-                robustness=None,
-                robustness_metrics=None,
-                economic_viability_evidence={},
-                economic_classification=EconomicClassification.FAIL_CLOSED,
-                economic_validity_offline_gate_pass=False,
-                promotion_candidate_eligible=False,
-                economic_evaluation_executed=False,
-                reason_codes=tuple(reason_codes),
-                authority_effect=AUTHORITY_EFFECT,
-                runtime_effect=RUNTIME_EFFECT,
-            )
-        orchestrator = adapter_result.orchestrator_result
-        if orchestrator is None or adapter_result.wiring_result is None:
-            reason_codes.append("MV2_WIRING_RESULT_MISSING")
-            return FullEconomicEvaluationResultV0(
-                status=ExecutionTerminalStatus.FAIL_CLOSED_PRECHECK,
-                precheck_passed=True,
-                bound_dataset_materialized=True,
-                dataset_period_match=True,
-                panel_data_digest=panel_digest,
-                data_digest_is_fixture=False,
-                stage_wiring=(),
-                backtest=None,
-                robustness=None,
-                robustness_metrics=None,
-                economic_viability_evidence={},
-                economic_classification=EconomicClassification.FAIL_CLOSED,
-                economic_validity_offline_gate_pass=False,
-                promotion_candidate_eligible=False,
-                economic_evaluation_executed=False,
-                reason_codes=tuple(reason_codes),
-                authority_effect=AUTHORITY_EFFECT,
-                runtime_effect=RUNTIME_EFFECT,
-            )
-        backtest = single_slot_backtest_from_mv2_wiring_v0(
-            wiring_result=adapter_result.wiring_result,
-            initial_cash=initial_cash,
-            roundtrip_cost_bps=roundtrip_cost_bps,
-        )
-    else:
-        orchestrator = run_cross_sectional_single_slot_orchestrator_v0(
-            binding=binding,
-            panel_series=active_panel,
-            score_formula_version=SCORE_FORMULA_VERSION,
-        )
-        backtest = run_single_slot_panel_backtest_v0(
-            orchestrator,
-            active_panel,
-            cost_execution_binding=cost_binding,
-        )
+    backtest = single_slot_backtest_from_mv2_wiring_v0(
+        wiring_result=adapter_result.wiring_result,
+        initial_cash=initial_cash,
+        roundtrip_cost_bps=roundtrip_cost_bps,
+    )
     robustness = wire_robustness_stages_v0(
         backtest,
         period_binding=envelope["period_binding"],
@@ -1528,6 +1656,81 @@ def run_full_offline_economic_evaluation_v0(
         authority_effect=AUTHORITY_EFFECT,
         runtime_effect=RUNTIME_EFFECT,
     )
+
+
+def materialize_productive_research_eval_backtest_lane_mv2_rewire_contract_v0() -> dict[str, Any]:
+    return {
+        "rewire_version": "v0",
+        "rewire_owner": EXECUTION_ID,
+        "productive_research_eval_backtest_lane_mv2_rewire_go_token": (
+            PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN
+        ),
+        "productive_evaluation_path_mode": SYSTEM_EVIDENCE_MV2_PATH_MODE,
+        "legacy_research_path_mode": LEGACY_RESEARCH_PATH_MODE,
+        "legacy_research_backtest_bypass_blocked": True,
+        "mv2_wiring_adapter_owner": MV2_WIRING_ADAPTER_OWNER,
+        "mv2_canonical_backtest_owner": MV2_CANONICAL_BACKTEST_OWNER,
+        "canonical_mv2_decision_chain_owner": CANONICAL_MV2_DECISION_CHAIN_OWNER,
+        "boundary_state_adapter_owner": MV2_WIRING_ADAPTER_OWNER,
+        "productive_backtest_lane_go_tokens": sorted(PRODUCTIVE_BACKTEST_LANE_GO_TOKENS),
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+    }
+
+
+def run_productive_research_eval_backtest_lane_mv2_rewire_dispatch_v0(
+    *,
+    repo_root: Path,
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    versioned_binding: Mapping[str, Any] | None = None,
+    go_token: str,
+) -> dict[str, Any]:
+    """Dispatch productive backtest lane through canonical MV2 wiring (no economic evaluation)."""
+    from src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0 import (
+        adapter_result_to_dict,
+        run_lead_lag_mv2_research_backtest_wiring_boundary_v0,
+    )
+
+    envelope = dict(versioned_binding or load_versioned_hypothesis_binding_v0(repo_root))
+    ops_config = load_ops_evaluation_config_v0(repo_root)
+    evaluation_path_mode = resolve_productive_evaluation_path_mode_v0(go_token=go_token)
+    legacy_ok, legacy_reasons = reject_legacy_research_backtest_bypass_v0(
+        evaluation_path_mode=evaluation_path_mode,
+    )
+    if not legacy_ok:
+        return {
+            "evaluation_path_mode": evaluation_path_mode,
+            "legacy_research_path_mode": LEGACY_RESEARCH_PATH_MODE,
+            "productive_backtest_lane_mv2_rewired": False,
+            "legacy_research_bypass_blocked": True,
+            "reason_codes": list(legacy_reasons),
+            "adapter": None,
+            "economic_evaluation_executed": False,
+            "authority_effect": AUTHORITY_EFFECT,
+            "runtime_effect": RUNTIME_EFFECT,
+        }
+
+    adapter_go_token = resolve_adapter_go_token_for_productive_lane_v0(go_token=go_token)
+    adapter_result = run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
+        repo_root=repo_root,
+        panel_series=panel_series,
+        versioned_binding=envelope,
+        ops_config=ops_config,
+        go_token=adapter_go_token,
+        evaluation_path_mode=evaluation_path_mode,
+    )
+    return {
+        "evaluation_path_mode": evaluation_path_mode,
+        "legacy_research_path_mode": LEGACY_RESEARCH_PATH_MODE,
+        "productive_backtest_lane_mv2_rewired": True,
+        "legacy_research_bypass_blocked": True,
+        "mv2_wiring_adapter_go_token": MV2_WIRING_ADAPTER_GO_TOKEN,
+        "adapter": adapter_result_to_dict(adapter_result),
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+    }
 
 
 def run_mv2_system_evidence_wiring_dispatch_v0(

--- a/src/research/cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.py
+++ b/src/research/cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.py
@@ -57,8 +57,15 @@ SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN = (
     "GO_CROSS_SECTIONAL_FUTURES_LEAD_LAG_V0_SYSTEM_EVIDENCE_MV2_OFFLINE_ECONOMIC_"
     "EVALUATION_BINDING_V0"
 )
+PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_LEAD_LAG_V0_PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_V0"
+)
 ALLOWED_ADAPTER_GO_TOKENS: frozenset[str] = frozenset(
-    {GO_TOKEN, SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN}
+    {
+        GO_TOKEN,
+        SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+        PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN,
+    }
 )
 
 LEGACY_RESEARCH_PATH_MODE = "LEGACY_RESEARCH"
@@ -84,6 +91,7 @@ REASON_MANDATORY_STATE_FILE_BINDING_SECTION_MISSING = "MANDATORY_STATE_FILE_BIND
 REASON_MANDATORY_STATE_FILE_BINDING_MISSING = "MANDATORY_STATE_FILE_BINDING_MISSING"
 REASON_MANDATORY_STATE_FILE_PATH_UNREADABLE = "MANDATORY_STATE_FILE_PATH_UNREADABLE"
 REASON_MANDATORY_STATE_FILE_VALIDATION_FAILED = "MANDATORY_STATE_FILE_VALIDATION_FAILED"
+REASON_LEGACY_RESEARCH_BACKTEST_BYPASS_BLOCKED = "LEGACY_RESEARCH_BACKTEST_BYPASS_BLOCKED"
 
 MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION = (
     "mv2_research_backtest_mandatory_boundary_state_file_binding_v0"
@@ -350,6 +358,16 @@ def verify_binding_digests_unchanged_v0(
     return not reasons, tuple(reasons)
 
 
+def reject_legacy_research_evaluation_path_mode_v0(
+    *,
+    evaluation_path_mode: str,
+) -> tuple[bool, tuple[str, ...]]:
+    """Fail-closed guard: productive adapter path must not accept legacy research bypass."""
+    if evaluation_path_mode == LEGACY_RESEARCH_PATH_MODE:
+        return False, (REASON_LEGACY_RESEARCH_BACKTEST_BYPASS_BLOCKED,)
+    return True, ()
+
+
 def reject_score_to_final_side_shortcut_v0(
     *,
     evaluation_path_mode: str,
@@ -497,6 +515,29 @@ def run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
         .get("pit_universe_binding", {})
         .get("universe_digest", "")
     )
+
+    legacy_ok, legacy_reasons = reject_legacy_research_evaluation_path_mode_v0(
+        evaluation_path_mode=evaluation_path_mode,
+    )
+    if not legacy_ok:
+        return LeadLagMv2WiringAdapterResultV0(
+            status=AdapterTerminalStatus.FAIL_CLOSED,
+            evaluation_path_mode=evaluation_path_mode,
+            wiring_result=None,
+            orchestrator_result=None,
+            score_feature_rows=(),
+            selected_panel_member_id="",
+            mv2_bars_row_count=0,
+            binding_digest=binding_digest,
+            dataset_digest=dataset_digest,
+            universe_digest=universe_digest,
+            research_binding_strategy_id=research_strategy_id,
+            mv2_engine_signal_strategy_id=MV2_ENGINE_SIGNAL_STRATEGY_ID,
+            reason_codes=legacy_reasons,
+            authority_effect=authority,
+            runtime_effect=runtime,
+            economic_evaluation_executed=False,
+        )
 
     go_ok, go_reasons = verify_adapter_go_token_v0(go_token)
     if not go_ok:

--- a/tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_infrastructure_v0.py
+++ b/tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_infrastructure_v0.py
@@ -271,6 +271,7 @@ def test_precheck_rejects_invalid_go_token(
 def test_contract_smoke_evaluation_no_economic_execution(complete_binding: dict) -> None:
     panel = build_synthetic_panel_series_v0()
     result = run_contract_smoke_evaluation_v0(
+        repo_root=REPO_ROOT,
         panel_series=panel,
         versioned_binding=complete_binding,
         staging_root=Path("."),

--- a/tests/research/test_cross_sectional_futures_lead_lag_v0_system_evidence_mv2_offline_economic_evaluation_binding_v0.py
+++ b/tests/research/test_cross_sectional_futures_lead_lag_v0_system_evidence_mv2_offline_economic_evaluation_binding_v0.py
@@ -16,6 +16,7 @@ from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offl
     SYSTEM_EVIDENCE_MV2_PATH_MODE,
     load_ops_evaluation_config_v0,
     load_versioned_hypothesis_binding_v0,
+    materialize_runner_envelope_v0,
     materialize_system_evidence_mv2_offline_economic_evaluation_binding_v0,
     run_full_offline_economic_evaluation_v0,
     single_slot_backtest_from_mv2_wiring_v0,
@@ -205,6 +206,14 @@ def test_mv2_binding_evaluation_executes_on_synthetic_panel(
                         panel_series=panel,
                         versioned_binding=complete_binding,
                         go_token=SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+                        runner_envelope=materialize_runner_envelope_v0(
+                            requested_operator_go=SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+                            dispatched_operator_go=SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+                            dispatch_rc=0,
+                            preexecution_parity_guard_pass=True,
+                            full_canonical_chain_wired=True,
+                            backtest_runtime_decision_parity_pass=True,
+                        ),
                     )
     assert result.economic_evaluation_executed is True
     assert result.backtest is not None

--- a/tests/research/test_cross_sectional_lead_lag_v0_productive_research_eval_backtest_lane_mv2_rewire_v0.py
+++ b/tests/research/test_cross_sectional_lead_lag_v0_productive_research_eval_backtest_lane_mv2_rewire_v0.py
@@ -1,0 +1,290 @@
+"""Contract tests for lead-lag v0 productive research-eval/backtest lane MV2 rewire v0."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.backtest.mv2_research_wiring_v1 import MV2ResearchWiringResultV1
+from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 import (
+    CANONICAL_MV2_DECISION_CHAIN_OWNER,
+    GO_TOKEN,
+    INFRASTRUCTURE_GO_TOKEN,
+    LEGACY_RESEARCH_PATH_MODE,
+    MV2_CANONICAL_BACKTEST_OWNER,
+    MV2_WIRING_ADAPTER_OWNER,
+    PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN,
+    REASON_LEGACY_RESEARCH_BACKTEST_BYPASS_BLOCKED,
+    REEVALUATION_GO_TOKEN,
+    SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+    SYSTEM_EVIDENCE_MV2_PATH_MODE,
+    load_ops_evaluation_config_v0,
+    load_versioned_hypothesis_binding_v0,
+    materialize_execution_contract_v0,
+    materialize_productive_research_eval_backtest_lane_mv2_rewire_contract_v0,
+    reject_legacy_research_backtest_bypass_v0,
+    resolve_productive_evaluation_path_mode_v0,
+    run_contract_smoke_evaluation_v0,
+    run_productive_research_eval_backtest_lane_mv2_rewire_dispatch_v0,
+    validate_entry_point_go_token_v0,
+)
+from src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0 import (
+    AdapterTerminalStatus,
+    LEGACY_RESEARCH_PATH_MODE as ADAPTER_LEGACY_MODE,
+    REASON_LEGACY_RESEARCH_BACKTEST_BYPASS_BLOCKED as ADAPTER_LEGACY_REASON,
+    reject_legacy_research_evaluation_path_mode_v0,
+    run_lead_lag_mv2_research_backtest_wiring_boundary_v0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.fixture_builder import (
+    build_synthetic_panel_series_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXECUTION_MODULE = (
+    REPO_ROOT
+    / "src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_"
+    "evaluation_execution_v0.py"
+)
+FORBIDDEN_RUNTIME_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+)
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return load_versioned_hypothesis_binding_v0(REPO_ROOT)
+
+
+@pytest.fixture(name="ops_config")
+def fixture_ops_config() -> dict:
+    return load_ops_evaluation_config_v0(REPO_ROOT)
+
+
+@pytest.mark.parametrize(
+    "go_token",
+    [
+        GO_TOKEN,
+        REEVALUATION_GO_TOKEN,
+        SYSTEM_EVIDENCE_MV2_BINDING_GO_TOKEN,
+        INFRASTRUCTURE_GO_TOKEN,
+        PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN,
+    ],
+)
+def test_productive_go_tokens_resolve_to_system_evidence_mv2(go_token: str) -> None:
+    assert (
+        resolve_productive_evaluation_path_mode_v0(go_token=go_token)
+        == SYSTEM_EVIDENCE_MV2_PATH_MODE
+    )
+
+
+def test_legacy_research_bypass_rejected() -> None:
+    ok, reasons = reject_legacy_research_backtest_bypass_v0(
+        evaluation_path_mode=LEGACY_RESEARCH_PATH_MODE,
+    )
+    assert ok is False
+    assert REASON_LEGACY_RESEARCH_BACKTEST_BYPASS_BLOCKED in reasons
+
+
+def test_adapter_rejects_legacy_research_path_mode(
+    complete_binding: dict,
+    ops_config: dict,
+) -> None:
+    panel = build_synthetic_panel_series_v0()
+    result = run_lead_lag_mv2_research_backtest_wiring_boundary_v0(
+        repo_root=REPO_ROOT,
+        panel_series=panel,
+        versioned_binding=complete_binding,
+        ops_config=ops_config,
+        go_token=PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN,
+        evaluation_path_mode=ADAPTER_LEGACY_MODE,
+    )
+    assert result.status is AdapterTerminalStatus.FAIL_CLOSED
+    assert ADAPTER_LEGACY_REASON in result.reason_codes
+
+
+def test_rewire_go_token_registered_in_entry_point_dispatch() -> None:
+    ok, branch = validate_entry_point_go_token_v0(
+        PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN,
+    )
+    assert ok is True
+    assert branch == "PRODUCTIVE_MV2_REWIRE_V0"
+
+
+def test_rewire_contract_declares_mv2_owners_and_blocked_legacy_bypass() -> None:
+    contract = materialize_productive_research_eval_backtest_lane_mv2_rewire_contract_v0()
+    assert contract["productive_evaluation_path_mode"] == SYSTEM_EVIDENCE_MV2_PATH_MODE
+    assert contract["legacy_research_backtest_bypass_blocked"] is True
+    assert contract["mv2_canonical_backtest_owner"] == MV2_CANONICAL_BACKTEST_OWNER
+    assert contract["canonical_mv2_decision_chain_owner"] == CANONICAL_MV2_DECISION_CHAIN_OWNER
+    assert contract["boundary_state_adapter_owner"] == MV2_WIRING_ADAPTER_OWNER
+    assert contract["economic_evaluation_executed"] is False
+    assert contract["authority_effect"] == "NONE"
+    assert contract["runtime_effect"] == "NONE"
+
+
+def test_execution_contract_declares_productive_mv2_path() -> None:
+    contract = materialize_execution_contract_v0()
+    assert contract["productive_evaluation_path_mode"] == SYSTEM_EVIDENCE_MV2_PATH_MODE
+    assert contract["legacy_research_backtest_bypass_blocked"] is True
+    assert contract["canonical_mv2_decision_chain_owner"] == CANONICAL_MV2_DECISION_CHAIN_OWNER
+
+
+def test_productive_dispatch_routes_through_mv2_adapter(
+    complete_binding: dict,
+) -> None:
+    panel = build_synthetic_panel_series_v0(bar_count=12)
+    with patch(
+        "src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.run_mv2_research_backtest_wiring_v1",
+    ) as mv2_call:
+        mv2_call.return_value = MV2ResearchWiringResultV1(
+            instrument_id="inst-eth-usdt-perp",
+            registry_snapshot=type("Snap", (), {"semantic_digest": "a" * 64})(),
+            effective_cost_config=type("Cost", (), {"config_digest": "b" * 64})(),
+            bar_outcomes=(),
+            signals=type("S", (), {"empty": True})(),
+            backtest_result=type(
+                "BT",
+                (),
+                {"stats": {"total_trades": 0}, "trades": None, "equity_curve": None},
+            )(),
+            mv2_replay_signals=type("S2", (), {"empty": True})(),
+            strategy_signal_provenance=type("P", (), {})(),
+            mv2_replay_signal_digest="c" * 64,
+            mv2_replay_nonzero_signal_count=0,
+        )
+        payload = run_productive_research_eval_backtest_lane_mv2_rewire_dispatch_v0(
+            repo_root=REPO_ROOT,
+            panel_series=panel,
+            versioned_binding=complete_binding,
+            go_token=PRODUCTIVE_RESEARCH_EVAL_BACKTEST_LANE_MV2_REWIRE_GO_TOKEN,
+        )
+    mv2_call.assert_called_once()
+    assert payload["evaluation_path_mode"] == SYSTEM_EVIDENCE_MV2_PATH_MODE
+    assert payload["productive_backtest_lane_mv2_rewired"] is True
+    assert payload["legacy_research_bypass_blocked"] is True
+    assert payload["economic_evaluation_executed"] is False
+
+
+def test_contract_smoke_uses_mv2_lane_not_legacy_backtest(
+    complete_binding: dict,
+) -> None:
+    panel = build_synthetic_panel_series_v0(bar_count=12)
+    materialization = type(
+        "MaterializationProxy",
+        (),
+        {
+            "status": __import__(
+                "src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0",
+                fromlist=["MaterializationTerminalStatus"],
+            ).MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE,
+            "panel_data_digest": "b" * 64,
+            "reason_codes": (),
+        },
+    )()
+    with patch(
+        "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+        "economic_evaluation_execution_v0.materialize_bound_panel_dataset_v0",
+        return_value=materialization,
+    ):
+        with patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+            "economic_evaluation_execution_v0.wire_robustness_stages_v0",
+        ) as robustness_patch:
+            robustness_patch.return_value = type(
+                "RobustnessProxy",
+                (),
+                {
+                    "wiring_version": "test.v0",
+                    "walk_forward_results": (),
+                    "monte_carlo_summary": {},
+                    "stress_results": {},
+                    "parameter_sensitivity_status": "BOUND",
+                    "authority_effect": "NONE",
+                },
+            )()
+            with patch(
+                "src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.run_mv2_research_backtest_wiring_v1",
+            ) as mv2_call:
+                mv2_call.return_value = MV2ResearchWiringResultV1(
+                    instrument_id="inst-eth-usdt-perp",
+                    registry_snapshot=type("Snap", (), {"semantic_digest": "a" * 64})(),
+                    effective_cost_config=type("Cost", (), {"config_digest": "b" * 64})(),
+                    bar_outcomes=(),
+                    signals=type("S", (), {"empty": True})(),
+                    backtest_result=type(
+                        "BT",
+                        (),
+                        {
+                            "stats": {"total_trades": 1, "total_return": 0.01},
+                            "trades": None,
+                            "equity_curve": __import__("pandas").Series([10_000.0, 10_100.0]),
+                        },
+                    )(),
+                    mv2_replay_signals=type("S2", (), {"empty": True})(),
+                    strategy_signal_provenance=type("P", (), {})(),
+                    mv2_replay_signal_digest="c" * 64,
+                    mv2_replay_nonzero_signal_count=0,
+                )
+                result = run_contract_smoke_evaluation_v0(
+                    repo_root=REPO_ROOT,
+                    panel_series=panel,
+                    versioned_binding=complete_binding,
+                    staging_root=Path("."),
+                    go_token=INFRASTRUCTURE_GO_TOKEN,
+                )
+    mv2_call.assert_called_once()
+    assert result.economic_evaluation_executed is False
+    assert result.authority_effect == "NONE"
+
+
+def test_adapter_legacy_guard_helper() -> None:
+    ok, reasons = reject_legacy_research_evaluation_path_mode_v0(
+        evaluation_path_mode=SYSTEM_EVIDENCE_MV2_PATH_MODE,
+    )
+    assert ok is True
+    assert reasons == ()
+    bad, bad_reasons = reject_legacy_research_evaluation_path_mode_v0(
+        evaluation_path_mode=ADAPTER_LEGACY_MODE,
+    )
+    assert bad is False
+    assert ADAPTER_LEGACY_REASON in bad_reasons
+
+
+def _collect_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.add(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+    return imports
+
+
+def test_execution_module_still_has_no_runtime_imports() -> None:
+    imports = _collect_imports(EXECUTION_MODULE)
+    for forbidden in FORBIDDEN_RUNTIME_IMPORT_PREFIXES:
+        assert not any(item == forbidden or item.startswith(forbidden + ".") for item in imports)
+
+
+def test_before_after_productive_entry_point_inventory_shape() -> None:
+    before_after = {
+        "before": {
+            "default_evaluation_path_mode": LEGACY_RESEARCH_PATH_MODE,
+            "backtest_owner": "cross_sectional_single_slot_backtest_wiring_v0",
+        },
+        "after": {
+            "default_evaluation_path_mode": SYSTEM_EVIDENCE_MV2_PATH_MODE,
+            "backtest_owner": MV2_WIRING_ADAPTER_OWNER,
+            "decision_chain_owner": CANONICAL_MV2_DECISION_CHAIN_OWNER,
+        },
+    }
+    assert before_after["after"]["default_evaluation_path_mode"] == SYSTEM_EVIDENCE_MV2_PATH_MODE
+    assert json.dumps(before_after)


### PR DESCRIPTION
## Summary
- Rewires the productive cross-sectional lead-lag research-eval/backtest lane (`GO_TOKEN`, `REEVALUATION_GO_TOKEN`, infrastructure smoke, and new rewire GO) through the existing MV2 boundary adapter and `run_mv2_research_backtest_wiring_v1`.
- Blocks the legacy `LEGACY_RESEARCH` single-slot backtest bypass fail-closed (`LEGACY_RESEARCH_BACKTEST_BYPASS_BLOCKED`).
- Preserves existing hypothesis, dataset, universe, score, parameter, ranking, portfolio, cost and robustness bindings; consumes mandatory boundary state files via PR #5137 adapter.

## Test plan
- [x] `tests/research/test_cross_sectional_lead_lag_v0_productive_research_eval_backtest_lane_mv2_rewire_v0.py`
- [x] `tests/research/test_cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0.py`
- [x] `tests/research/test_cross_sectional_futures_lead_lag_v0_system_evidence_mv2_offline_economic_evaluation_binding_v0.py`
- [x] Entry-point guard and infrastructure contract suites (84 tests total, all pass locally)

## Notes
- `FULL_CANONICAL_CHAIN_WIRED=false` and `BACKTEST_RUNTIME_DECISION_PARITY_PASS=false` retained; next blocker is BacktestEngine vs mv2_replay_signals parity (implementation_sequence step 4).
- No economic evaluation executed; runtime/authority effects remain NONE.


Made with [Cursor](https://cursor.com)