### PR TITLE
Serialize lead-lag v0 decision funnel in offline evaluation evidence

### DIFF
--- a/scripts/ops/run_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
@@ -476,6 +476,21 @@ def run_bounded_full_evaluation_dispatch_v0(
         json.dumps(evaluation_payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+    if evaluation.compact_decision_funnel:
+        (bundle_dir / "compact_decision_funnel.json").write_text(
+            json.dumps(evaluation.compact_decision_funnel, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if evaluation.canonical_decision_funnel:
+        (bundle_dir / "canonical_decision_funnel.json").write_text(
+            json.dumps(evaluation.canonical_decision_funnel, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if evaluation.block_reason_counts:
+        (bundle_dir / "block_reason_counts.json").write_text(
+            json.dumps(evaluation.block_reason_counts, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
     (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
         f"ECONOMIC_EVALUATION_EXECUTED={'true' if economic_executed else 'false'}\n",
         encoding="utf-8",

--- a/src/backtest/mv2_research_wiring_v1.py
+++ b/src/backtest/mv2_research_wiring_v1.py
@@ -64,6 +64,10 @@ from src.experiments.stress_tests import (
     run_stress_test_suite,
 )
 from src.risk.limits import RiskLimits, RiskLimitsConfig
+from src.research.cross_sectional_offline_economic_evaluation_decision_funnel_v0 import (
+    DecisionFunnelAccumulatorV0,
+    materialize_block_reason_counts_v0,
+)
 from src.strategies.registry import (
     REGISTRY_SCHEMA_VERSION,
     StrategyRegistrySnapshotV1,
@@ -411,6 +415,8 @@ class MV2ResearchWiringResultV1:
     sizing_provenance: Mapping[str, Any] = field(default_factory=dict)
     backtest_engine_signal_source: str = ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY
     backtest_engine_signal_digest: str = ""
+    decision_funnel_counts: Mapping[str, int] = field(default_factory=dict)
+    block_reason_counts: Mapping[str, int] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -1790,6 +1796,7 @@ def run_mv2_research_backtest_wiring_v1(
     replay_signals: list[int] = []
     signal_index: list[pd.Timestamp] = []
     sequence_state: MV2IntegratedReplayBarSequenceStateV1 | None = None
+    decision_funnel_accumulator = DecisionFunnelAccumulatorV0()
     for i, (_, row) in enumerate(bars.iterrows()):
         if sequence_state is None:
             sequence_state = build_initial_mv2_integrated_replay_bar_sequence_state_v1(
@@ -1836,6 +1843,10 @@ def run_mv2_research_backtest_wiring_v1(
             )
         )
         replay_result = run_integrated_offline_trading_logic_replay_v1(replay_input)
+        decision_funnel_accumulator.accumulate_from_replay(
+            intermediate=replay_result.intermediate,
+            evidence_reason_codes=replay_result.evidence.reason_codes,
+        )
         if replay_result.intermediate is not None:
             sequence_state = project_mv2_integrated_replay_bar_sequence_state_from_intermediate_v1(
                 intermediate=replay_result.intermediate,
@@ -2075,6 +2086,12 @@ def run_mv2_research_backtest_wiring_v1(
             mv2_replay_signal_digest=mv2_replay_digest,
         )
 
+    trades_df = backtest_result.trades
+    trade_count_fallback = len(trades_df) if trades_df is not None else 0
+    decision_funnel_accumulator.set_trades_opened_count(
+        int(backtest_result.stats.get("total_trades", trade_count_fallback))
+    )
+
     return MV2ResearchWiringResultV1(
         instrument_id=instrument_id,
         registry_snapshot=snapshot,
@@ -2087,6 +2104,8 @@ def run_mv2_research_backtest_wiring_v1(
         mv2_replay_signal_digest=mv2_replay_digest,
         mv2_replay_nonzero_signal_count=mv2_replay_nonzero,
         sizing_provenance=sizing_provenance,
+        decision_funnel_counts=decision_funnel_accumulator.counts_dict(),
+        block_reason_counts=materialize_block_reason_counts_v0(decision_funnel_accumulator),
         backtest_engine_signal_source=backtest_engine_signal_source,
         backtest_engine_signal_digest=backtest_engine_signal_digest,
     )

--- a/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
@@ -10,13 +10,17 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 import pandas as pd
 
+from src.research.cross_sectional_offline_economic_evaluation_decision_funnel_v0 import (
+    DecisionFunnelAccumulatorV0,
+    build_decision_funnel_bundle_v0,
+)
 from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_scope_ratification_v0 import (
     ValidationVerdictEnum,
     validate_lead_lag_offline_economic_evaluation_scope_ratification_v0,
@@ -1099,6 +1103,9 @@ class FullEconomicEvaluationResultV0:
     reason_codes: tuple[str, ...]
     authority_effect: str
     runtime_effect: str
+    compact_decision_funnel: Mapping[str, Any] = field(default_factory=dict)
+    canonical_decision_funnel: Mapping[str, Any] = field(default_factory=dict)
+    block_reason_counts: Mapping[str, int] = field(default_factory=dict)
 
 
 def load_ohlcv_panel_series_for_backtest(
@@ -1106,6 +1113,48 @@ def load_ohlcv_panel_series_for_backtest(
 ) -> tuple[InstrumentPanelSeriesV1, ...]:
     panel_series, _ = load_panel_series_from_staging(staging_root)
     return panel_series
+
+
+def _decision_funnel_accumulator_from_wiring_result_v0(
+    wiring_result: Any,
+    *,
+    orchestrator: Any | None = None,
+) -> DecisionFunnelAccumulatorV0:
+    from src.backtest.mv2_research_wiring_v1 import MV2ResearchWiringResultV1
+
+    accumulator = DecisionFunnelAccumulatorV0()
+    if isinstance(wiring_result, MV2ResearchWiringResultV1):
+        for field_name in accumulator.counts_dict():
+            setattr(
+                accumulator,
+                field_name,
+                int(wiring_result.decision_funnel_counts.get(field_name, 0)),
+            )
+        accumulator.block_reason_counts.update(dict(wiring_result.block_reason_counts))
+    accumulator.merge_orchestrator_block_reasons(orchestrator)
+    return accumulator
+
+
+def _materialize_evaluation_decision_funnel_v0(
+    *,
+    wiring_result: Any | None,
+    orchestrator: Any | None,
+    evaluation_status: str,
+    precheck_passed: bool,
+    economic_evaluation_executed: bool,
+    reason_codes: Sequence[str],
+) -> dict[str, Any]:
+    accumulator = _decision_funnel_accumulator_from_wiring_result_v0(
+        wiring_result,
+        orchestrator=orchestrator,
+    )
+    return build_decision_funnel_bundle_v0(
+        accumulator=accumulator,
+        evaluation_status=evaluation_status,
+        precheck_passed=precheck_passed,
+        economic_evaluation_executed=economic_evaluation_executed,
+        reason_codes=reason_codes,
+    )
 
 
 def _compute_walk_forward_pass_ratio(
@@ -1684,6 +1733,15 @@ def run_full_offline_economic_evaluation_v0(
         ops_config=ops_config,
     )
 
+    funnel_bundle = _materialize_evaluation_decision_funnel_v0(
+        wiring_result=adapter_result.wiring_result,
+        orchestrator=orchestrator,
+        evaluation_status=ExecutionTerminalStatus.ECONOMIC_EVALUATION_COMPLETE.value,
+        precheck_passed=True,
+        economic_evaluation_executed=True,
+        reason_codes=reason_codes,
+    )
+
     return FullEconomicEvaluationResultV0(
         status=ExecutionTerminalStatus.ECONOMIC_EVALUATION_COMPLETE,
         precheck_passed=True,
@@ -1703,6 +1761,9 @@ def run_full_offline_economic_evaluation_v0(
         reason_codes=tuple(reason_codes),
         authority_effect=AUTHORITY_EFFECT,
         runtime_effect=RUNTIME_EFFECT,
+        compact_decision_funnel=funnel_bundle["compact_decision_funnel"],
+        canonical_decision_funnel=funnel_bundle["canonical_decision_funnel"],
+        block_reason_counts=funnel_bundle["block_reason_counts"],
     )
 
 
@@ -2033,6 +2094,9 @@ def execution_result_to_dict(result: FullEconomicEvaluationResultV0) -> dict[str
         ),
         "economic_viability_evidence": result.economic_viability_evidence,
         "reason_codes": list(result.reason_codes),
+        "compact_decision_funnel": dict(result.compact_decision_funnel),
+        "canonical_decision_funnel": dict(result.canonical_decision_funnel),
+        "block_reason_counts": dict(result.block_reason_counts),
         "authority_effect": result.authority_effect,
         "runtime_effect": result.runtime_effect,
         "execution_version": EXECUTION_VERSION,

--- a/src/research/cross_sectional_offline_economic_evaluation_decision_funnel_v0.py
+++ b/src/research/cross_sectional_offline_economic_evaluation_decision_funnel_v0.py
@@ -1,0 +1,211 @@
+"""Compact decision funnel serialization for offline economic evaluation v0.
+
+Aggregates runbook §18A.5 funnel counters from productive MV2 replay intermediates
+and orchestrator block reasons. Research-only; no runtime or authority effect.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from src.governance.capital_risk_sizing_v1 import CapitalRiskSizingOutcome
+from src.research.cross_sectional_single_slot_research_orchestrator_v0 import (
+    OrchestratorRunResultV0,
+)
+from src.trading.master_v2.directional_assessment_v1 import DirectionalAssessmentStatus
+from src.trading.master_v2.double_play_composition_matrix_v1 import CompositionStatus
+from src.trading.master_v2.double_play_entry_exit_policy_v0 import EntryEligibility
+from src.trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
+    IntegratedOfflineReplayIntermediateV1,
+)
+from src.trading.master_v2.suitability_binding_v1 import SuitabilityBindingStatus
+from src.trading.master_v2.survival_assessment_v1 import SurvivalAssessmentStatus
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_OFFLINE_ECONOMIC_EVALUATION_DECISION_FUNNEL_V0=true"
+FUNNEL_OWNER = "research.cross_sectional_offline_economic_evaluation_decision_funnel_v0"
+COMPACT_FUNNEL_SCHEMA_VERSION = "compact_decision_funnel.v0"
+CANONICAL_FUNNEL_SCHEMA_VERSION = "canonical_decision_funnel.v0"
+
+RUNBOOK_FUNNEL_FIELDS: tuple[str, ...] = (
+    "market_epochs_total",
+    "directional_candidate_count",
+    "directional_confirmed_count",
+    "survival_pass_count",
+    "suitability_pass_count",
+    "double_play_entry_eligible_count",
+    "entry_preconditions_pass_count",
+    "risk_sizing_admissible_count",
+    "portfolio_admissible_count",
+    "trades_opened_count",
+)
+
+_DOUBLE_PLAY_ENTRY_ELIGIBLE_STATUSES = frozenset(
+    {
+        CompositionStatus.LONG_SELECTED,
+        CompositionStatus.SHORT_SELECTED,
+    }
+)
+
+
+@dataclass
+class DecisionFunnelAccumulatorV0:
+    market_epochs_total: int = 0
+    directional_candidate_count: int = 0
+    directional_confirmed_count: int = 0
+    survival_pass_count: int = 0
+    suitability_pass_count: int = 0
+    double_play_entry_eligible_count: int = 0
+    entry_preconditions_pass_count: int = 0
+    risk_sizing_admissible_count: int = 0
+    portfolio_admissible_count: int = 0
+    trades_opened_count: int = 0
+    block_reason_counts: Counter[str] = field(default_factory=Counter)
+
+    def accumulate_from_replay(
+        self,
+        *,
+        intermediate: IntegratedOfflineReplayIntermediateV1 | None,
+        evidence_reason_codes: Sequence[str],
+    ) -> None:
+        self.market_epochs_total += 1
+        for code in evidence_reason_codes:
+            if code:
+                self.block_reason_counts[str(code)] += 1
+        if intermediate is None:
+            return
+
+        bull = intermediate.bull_assessment
+        bear = intermediate.bear_assessment
+        candidate_statuses = {
+            DirectionalAssessmentStatus.CANDIDATE,
+            DirectionalAssessmentStatus.CONFIRMED,
+        }
+        if bull.status in candidate_statuses or bear.status in candidate_statuses:
+            self.directional_candidate_count += 1
+        if (
+            bull.status is DirectionalAssessmentStatus.CONFIRMED
+            or bear.status is DirectionalAssessmentStatus.CONFIRMED
+        ):
+            self.directional_confirmed_count += 1
+
+        if (
+            intermediate.bull_survival.status is SurvivalAssessmentStatus.PASS
+            or intermediate.bear_survival.status is SurvivalAssessmentStatus.PASS
+        ):
+            self.survival_pass_count += 1
+        if (
+            intermediate.bull_suitability.status is SuitabilityBindingStatus.PASS
+            or intermediate.bear_suitability.status is SuitabilityBindingStatus.PASS
+        ):
+            self.suitability_pass_count += 1
+        if (
+            intermediate.composition_result.composition_status
+            in _DOUBLE_PLAY_ENTRY_ELIGIBLE_STATUSES
+        ):
+            self.double_play_entry_eligible_count += 1
+        if intermediate.entry_exit_decision.entry_eligibility is EntryEligibility.ELIGIBLE:
+            self.entry_preconditions_pass_count += 1
+
+        sizing = intermediate.capital_risk_sizing_decision
+        if sizing is not None and sizing.outcome is CapitalRiskSizingOutcome.PASS:
+            self.risk_sizing_admissible_count += 1
+        if intermediate.canonical_order_intent is not None:
+            self.portfolio_admissible_count += 1
+
+    def merge_orchestrator_block_reasons(
+        self,
+        orchestrator: OrchestratorRunResultV0 | None,
+    ) -> None:
+        if orchestrator is None:
+            return
+        for epoch in orchestrator.epochs:
+            for code in epoch.error_codes:
+                if code:
+                    self.block_reason_counts[str(code)] += 1
+
+    def set_trades_opened_count(self, trade_count: int) -> None:
+        self.trades_opened_count = int(trade_count)
+
+    def counts_dict(self) -> dict[str, int]:
+        return {field_name: int(getattr(self, field_name)) for field_name in RUNBOOK_FUNNEL_FIELDS}
+
+    def top_block_reasons(self, *, limit: int = 10) -> list[tuple[str, int]]:
+        return sorted(self.block_reason_counts.items(), key=lambda item: (-item[1], item[0]))[
+            :limit
+        ]
+
+
+def materialize_compact_decision_funnel_v0(
+    accumulator: DecisionFunnelAccumulatorV0,
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": COMPACT_FUNNEL_SCHEMA_VERSION,
+        **accumulator.counts_dict(),
+        "top_block_reasons": accumulator.top_block_reasons(),
+    }
+    return payload
+
+
+def materialize_canonical_decision_funnel_v0(
+    *,
+    accumulator: DecisionFunnelAccumulatorV0,
+    evaluation_status: str,
+    precheck_passed: bool,
+    economic_evaluation_executed: bool,
+    reason_codes: Sequence[str] = (),
+) -> dict[str, Any]:
+    return {
+        "schema_version": CANONICAL_FUNNEL_SCHEMA_VERSION,
+        "status": evaluation_status,
+        "precheck_passed": precheck_passed,
+        "economic_evaluation_executed": economic_evaluation_executed,
+        "reason_codes": list(reason_codes),
+        **accumulator.counts_dict(),
+        "top_block_reasons": accumulator.top_block_reasons(),
+    }
+
+
+def materialize_block_reason_counts_v0(
+    accumulator: DecisionFunnelAccumulatorV0,
+) -> dict[str, int]:
+    return dict(sorted(accumulator.block_reason_counts.items()))
+
+
+def aggregate_decision_funnel_from_mv2_bar_outcomes_v0(
+    bar_outcomes: Sequence[Any],
+) -> DecisionFunnelAccumulatorV0:
+    """Fallback aggregation from serialized bar outcomes when no live accumulator exists."""
+    from src.backtest.mv2_research_wiring_v1 import MV2ReplayBarOutcomeV1
+
+    accumulator = DecisionFunnelAccumulatorV0()
+    for outcome in bar_outcomes:
+        if not isinstance(outcome, MV2ReplayBarOutcomeV1):
+            continue
+        accumulator.accumulate_from_replay(
+            intermediate=None,
+            evidence_reason_codes=outcome.evidence.reason_codes,
+        )
+    return accumulator
+
+
+def build_decision_funnel_bundle_v0(
+    *,
+    accumulator: DecisionFunnelAccumulatorV0,
+    evaluation_status: str,
+    precheck_passed: bool,
+    economic_evaluation_executed: bool,
+    reason_codes: Sequence[str] = (),
+) -> dict[str, Any]:
+    return {
+        "compact_decision_funnel": materialize_compact_decision_funnel_v0(accumulator),
+        "canonical_decision_funnel": materialize_canonical_decision_funnel_v0(
+            accumulator=accumulator,
+            evaluation_status=evaluation_status,
+            precheck_passed=precheck_passed,
+            economic_evaluation_executed=economic_evaluation_executed,
+            reason_codes=reason_codes,
+        ),
+        "block_reason_counts": materialize_block_reason_counts_v0(accumulator),
+    }

--- a/tests/research/test_cross_sectional_futures_lead_lag_v0_funnel_evidence_serialization_repair_v0.py
+++ b/tests/research/test_cross_sectional_futures_lead_lag_v0_funnel_evidence_serialization_repair_v0.py
@@ -1,0 +1,298 @@
+"""Contract tests for lead-lag v0 decision funnel evidence serialization repair v0."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from scripts.ops import (
+    run_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 as runner_module,
+)
+from src.governance.capital_risk_sizing_v1 import CapitalRiskSizingOutcome
+from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 import (
+    EconomicClassification,
+    ExecutionTerminalStatus,
+    FullEconomicEvaluationResultV0,
+    REEVALUATION_GO_TOKEN,
+    execution_result_to_dict,
+)
+from src.research.cross_sectional_offline_economic_evaluation_decision_funnel_v0 import (
+    RUNBOOK_FUNNEL_FIELDS,
+    DecisionFunnelAccumulatorV0,
+    build_decision_funnel_bundle_v0,
+    materialize_block_reason_counts_v0,
+    materialize_compact_decision_funnel_v0,
+)
+from src.trading.master_v2.directional_assessment_v1 import DirectionalAssessmentStatus
+from src.trading.master_v2.double_play_composition_matrix_v1 import CompositionStatus
+from src.trading.master_v2.double_play_entry_exit_policy_v0 import EntryEligibility
+from src.trading.master_v2.suitability_binding_v1 import SuitabilityBindingStatus
+from src.trading.master_v2.survival_assessment_v1 import SurvivalAssessmentStatus
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _intermediate(
+    *,
+    bull_status: DirectionalAssessmentStatus,
+    bear_status: DirectionalAssessmentStatus,
+    survival_pass: bool,
+    suitability_pass: bool,
+    composition_status: CompositionStatus,
+    entry_eligible: bool,
+    sizing_pass: bool,
+    portfolio_bound: bool,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        bull_assessment=SimpleNamespace(status=bull_status),
+        bear_assessment=SimpleNamespace(status=bear_status),
+        bull_survival=SimpleNamespace(
+            status=SurvivalAssessmentStatus.PASS if survival_pass else SurvivalAssessmentStatus.FAIL
+        ),
+        bear_survival=SimpleNamespace(status=SurvivalAssessmentStatus.FAIL),
+        bull_suitability=SimpleNamespace(
+            status=SuitabilityBindingStatus.PASS
+            if suitability_pass
+            else SuitabilityBindingStatus.FAIL
+        ),
+        bear_suitability=SimpleNamespace(status=SuitabilityBindingStatus.FAIL),
+        composition_result=SimpleNamespace(composition_status=composition_status),
+        entry_exit_decision=SimpleNamespace(
+            entry_eligibility=(
+                EntryEligibility.ELIGIBLE if entry_eligible else EntryEligibility.BLOCKED
+            )
+        ),
+        capital_risk_sizing_decision=SimpleNamespace(
+            outcome=CapitalRiskSizingOutcome.PASS
+            if sizing_pass
+            else CapitalRiskSizingOutcome.BLOCKED
+        ),
+        canonical_order_intent=object() if portfolio_bound else None,
+    )
+
+
+def test_decision_funnel_accumulator_nontrivial_value_propagation() -> None:
+    accumulator = DecisionFunnelAccumulatorV0()
+    accumulator.accumulate_from_replay(
+        intermediate=_intermediate(
+            bull_status=DirectionalAssessmentStatus.CANDIDATE,
+            bear_status=DirectionalAssessmentStatus.OBSERVE,
+            survival_pass=False,
+            suitability_pass=False,
+            composition_status=CompositionStatus.OBSERVE,
+            entry_eligible=False,
+            sizing_pass=False,
+            portfolio_bound=False,
+        ),
+        evidence_reason_codes=("scope_warmup",),
+    )
+    accumulator.accumulate_from_replay(
+        intermediate=_intermediate(
+            bull_status=DirectionalAssessmentStatus.CONFIRMED,
+            bear_status=DirectionalAssessmentStatus.OBSERVE,
+            survival_pass=True,
+            suitability_pass=True,
+            composition_status=CompositionStatus.LONG_SELECTED,
+            entry_eligible=True,
+            sizing_pass=True,
+            portfolio_bound=True,
+        ),
+        evidence_reason_codes=("enter_long",),
+    )
+    accumulator.set_trades_opened_count(2)
+
+    counts = accumulator.counts_dict()
+    assert counts["market_epochs_total"] == 2
+    assert counts["directional_candidate_count"] == 2
+    assert counts["directional_confirmed_count"] == 1
+    assert counts["survival_pass_count"] == 1
+    assert counts["suitability_pass_count"] == 1
+    assert counts["double_play_entry_eligible_count"] == 1
+    assert counts["entry_preconditions_pass_count"] == 1
+    assert counts["risk_sizing_admissible_count"] == 1
+    assert counts["portfolio_admissible_count"] == 1
+    assert counts["trades_opened_count"] == 2
+    assert counts["directional_candidate_count"] != counts["directional_confirmed_count"]
+
+
+def test_compact_decision_funnel_serializes_all_runbook_fields_and_block_reasons() -> None:
+    accumulator = DecisionFunnelAccumulatorV0()
+    accumulator.accumulate_from_replay(
+        intermediate=None,
+        evidence_reason_codes=("INSUFFICIENT_ELIGIBLE_MEMBERS", "INSUFFICIENT_ELIGIBLE_MEMBERS"),
+    )
+    compact = materialize_compact_decision_funnel_v0(accumulator)
+    assert compact["schema_version"] == "compact_decision_funnel.v0"
+    for field_name in RUNBOOK_FUNNEL_FIELDS:
+        assert field_name in compact
+    assert compact["top_block_reasons"] == [("INSUFFICIENT_ELIGIBLE_MEMBERS", 2)]
+
+
+def test_build_decision_funnel_bundle_is_deterministic() -> None:
+    accumulator = DecisionFunnelAccumulatorV0()
+    accumulator.accumulate_from_replay(
+        intermediate=_intermediate(
+            bull_status=DirectionalAssessmentStatus.CONFIRMED,
+            bear_status=DirectionalAssessmentStatus.OBSERVE,
+            survival_pass=True,
+            suitability_pass=False,
+            composition_status=CompositionStatus.SHORT_SELECTED,
+            entry_eligible=True,
+            sizing_pass=False,
+            portfolio_bound=False,
+        ),
+        evidence_reason_codes=("survival_pass",),
+    )
+    accumulator.set_trades_opened_count(1)
+    first = json.dumps(
+        build_decision_funnel_bundle_v0(
+            accumulator=accumulator,
+            evaluation_status="ECONOMIC_EVALUATION_COMPLETE",
+            precheck_passed=True,
+            economic_evaluation_executed=True,
+            reason_codes=(),
+        ),
+        sort_keys=True,
+    )
+    second = json.dumps(
+        build_decision_funnel_bundle_v0(
+            accumulator=accumulator,
+            evaluation_status="ECONOMIC_EVALUATION_COMPLETE",
+            precheck_passed=True,
+            economic_evaluation_executed=True,
+            reason_codes=(),
+        ),
+        sort_keys=True,
+    )
+    assert first == second
+
+
+def test_execution_result_to_dict_includes_funnel_serialization_fields() -> None:
+    funnel_bundle = build_decision_funnel_bundle_v0(
+        accumulator=DecisionFunnelAccumulatorV0(
+            market_epochs_total=3,
+            directional_candidate_count=2,
+            directional_confirmed_count=1,
+            survival_pass_count=1,
+            suitability_pass_count=1,
+            double_play_entry_eligible_count=1,
+            entry_preconditions_pass_count=1,
+            risk_sizing_admissible_count=1,
+            portfolio_admissible_count=1,
+            trades_opened_count=1,
+        ),
+        evaluation_status="ECONOMIC_EVALUATION_COMPLETE",
+        precheck_passed=True,
+        economic_evaluation_executed=True,
+    )
+    result = FullEconomicEvaluationResultV0(
+        status=ExecutionTerminalStatus.ECONOMIC_EVALUATION_COMPLETE,
+        precheck_passed=True,
+        bound_dataset_materialized=True,
+        dataset_period_match=True,
+        panel_data_digest="a" * 64,
+        data_digest_is_fixture=False,
+        stage_wiring=(),
+        backtest=None,
+        robustness=None,
+        robustness_metrics=None,
+        economic_viability_evidence={},
+        economic_classification=EconomicClassification.FAIL,
+        economic_validity_offline_gate_pass=False,
+        promotion_candidate_eligible=False,
+        economic_evaluation_executed=True,
+        reason_codes=(),
+        authority_effect="NONE",
+        runtime_effect="NONE",
+        compact_decision_funnel=funnel_bundle["compact_decision_funnel"],
+        canonical_decision_funnel=funnel_bundle["canonical_decision_funnel"],
+        block_reason_counts=funnel_bundle["block_reason_counts"],
+    )
+    payload = execution_result_to_dict(result)
+    for field_name in RUNBOOK_FUNNEL_FIELDS:
+        assert field_name in payload["compact_decision_funnel"]
+    assert payload["block_reason_counts"] == {}
+    assert payload["canonical_decision_funnel"]["schema_version"] == "canonical_decision_funnel.v0"
+
+
+def test_runner_writes_productive_funnel_evidence_files(tmp_path: Path) -> None:
+    funnel_accumulator = DecisionFunnelAccumulatorV0(
+        market_epochs_total=5,
+        directional_candidate_count=4,
+        directional_confirmed_count=3,
+        survival_pass_count=2,
+        suitability_pass_count=2,
+        double_play_entry_eligible_count=2,
+        entry_preconditions_pass_count=2,
+        risk_sizing_admissible_count=2,
+        portfolio_admissible_count=2,
+        trades_opened_count=2,
+        block_reason_counts=Counter({"INSUFFICIENT_ELIGIBLE_MEMBERS": 1}),
+    )
+    funnel_bundle = build_decision_funnel_bundle_v0(
+        accumulator=funnel_accumulator,
+        evaluation_status="ECONOMIC_EVALUATION_COMPLETE",
+        precheck_passed=True,
+        economic_evaluation_executed=True,
+    )
+    evaluation = FullEconomicEvaluationResultV0(
+        status=ExecutionTerminalStatus.ECONOMIC_EVALUATION_COMPLETE,
+        precheck_passed=True,
+        bound_dataset_materialized=True,
+        dataset_period_match=True,
+        panel_data_digest="b" * 64,
+        data_digest_is_fixture=False,
+        stage_wiring=(),
+        backtest=None,
+        robustness=None,
+        robustness_metrics=None,
+        economic_viability_evidence={},
+        economic_classification=EconomicClassification.FAIL,
+        economic_validity_offline_gate_pass=False,
+        promotion_candidate_eligible=False,
+        economic_evaluation_executed=True,
+        reason_codes=(),
+        authority_effect="NONE",
+        runtime_effect="NONE",
+        compact_decision_funnel=funnel_bundle["compact_decision_funnel"],
+        canonical_decision_funnel=funnel_bundle["canonical_decision_funnel"],
+        block_reason_counts=materialize_block_reason_counts_v0(funnel_accumulator),
+    )
+
+    with patch.object(
+        runner_module,
+        "load_evaluation_path_parity_status_v0",
+        return_value=(True, True),
+    ):
+        with patch.object(
+            runner_module,
+            "verify_full_evaluation_precheck_v1",
+            return_value=(True, (), SimpleNamespace(panel_data_digest="c" * 64)),
+        ):
+            with patch.object(
+                runner_module,
+                "run_full_offline_economic_evaluation_v0",
+                return_value=evaluation,
+            ):
+                with patch.object(
+                    runner_module,
+                    "load_ohlcv_panel_series_for_backtest",
+                    return_value=(),
+                ):
+                    payload = runner_module.run_bounded_full_evaluation_dispatch_v0(
+                        confirm=REEVALUATION_GO_TOKEN,
+                        durable_evidence_root=tmp_path,
+                        primary_worktree=REPO_ROOT,
+                        staging_root=REPO_ROOT,
+                    )
+
+    bundle_dir = Path(payload["durable_evidence_path"])
+    compact = json.loads((bundle_dir / "compact_decision_funnel.json").read_text(encoding="utf-8"))
+    assert compact["market_epochs_total"] == 5
+    assert compact["trades_opened_count"] == 2
+    assert compact["directional_candidate_count"] != compact["survival_pass_count"]
+    assert (bundle_dir / "canonical_decision_funnel.json").is_file()
+    assert (bundle_dir / "block_reason_counts.json").is_file()


### PR DESCRIPTION
## Summary
- Add canonical decision-funnel aggregation owner that materializes all 10 runbook §18A.5 counters from existing MV2 replay intermediates (no trading-semantics changes).
- Persist `compact_decision_funnel.json`, `canonical_decision_funnel.json`, and `block_reason_counts.json` through the lead-lag offline evaluation execution runner and embed them in `FULL_EVALUATION_RESULT.json`.
- Add focused regression contracts for nontrivial value propagation, block-reason serialization, deterministic output, and productive runner evidence writes.

## Test plan
- [x] `pytest tests/research/test_cross_sectional_futures_lead_lag_v0_funnel_evidence_serialization_repair_v0.py -q`
- [x] `ruff format` / `ruff check` on touched files
- [x] CI selector: `PR_BOUNDED_FULL` (central `src/` touch)
- [ ] Await GitHub PR checks (terminal snapshot only; no polling)

## Risk / scope
- Serialization-only repair; `RUNTIME_EFFECT=NONE`, `AUTHORITY_EFFECT=NONE`, `ECONOMIC_EVALUATION_EXECUTED=false` for this implementation slice.
- Durable evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/implementation/cross_sectional_futures_lead_lag_v0_funnel_evidence_serialization_repair_v0_20260713T033243Z`


Made with [Cursor](https://cursor.com)