### PR TITLE
Offline linear cost diagnostic row materialization v0

### DIFF
--- a/scripts/research/offline_linear_cost_model_diagnostics_v0.py
+++ b/scripts/research/offline_linear_cost_model_diagnostics_v0.py
@@ -19,7 +19,14 @@ from src.research.linear_evidence.contracts import to_jsonable
 from src.research.linear_evidence.cost_model import build_cost_model_calibration_evidence
 from src.research.linear_evidence.feature_matrix import build_feature_matrix_binding
 from src.research.linear_evidence.fitters import fit_ols_lstsq
+from src.research.offline_linear_cost_diagnostic_row_materializer_v0 import (
+    MaterializationStatus,
+    TARGET_NAME,
+    materialize_offline_linear_cost_diagnostic_rows_v0,
+)
 
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
 
 FIXTURE_ROWS = [
     {
@@ -97,50 +104,152 @@ FIXTURE_ROWS = [
 ]
 
 
+def _load_jsonl(path: Path) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        payload = json.loads(stripped)
+        if isinstance(payload, dict):
+            rows.append(payload)
+    return rows
+
+
+def _materializer_rows_to_feature_rows(
+    materialized_rows: tuple[dict[str, object], ...],
+) -> list[dict[str, object]]:
+    feature_rows: list[dict[str, object]] = []
+    for row in materialized_rows:
+        feature_rows.append(
+            {
+                "decision_time": row["decision_time"],
+                "spread_bps": row["spread_bps"],
+                "volatility_estimate": row["volatility_estimate"],
+                "order_notional": row["order_notional"],
+                "funding_rate_abs": row.get("funding_rate_abs"),
+                "liquidity_score": row.get("liquidity_score"),
+                TARGET_NAME: row[TARGET_NAME],
+            }
+        )
+    return feature_rows
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--out", required=True)
+    parser.add_argument("--trade-ledger", type=Path, default=None)
+    parser.add_argument("--entry-bar-snapshots", type=Path, default=None)
+    parser.add_argument(
+        "--fixture-scaffold",
+        action="store_true",
+        help="Scaffolding-only fixture rows; never counted as productive samples.",
+    )
     args = parser.parse_args()
 
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)
 
-    feature_names = (
-        "spread_bps",
-        "volatility_estimate",
-        "order_notional_to_depth",
-        "funding_rate_abs",
-        "liquidity_score",
+    fixture_scaffold_only = bool(args.fixture_scaffold)
+    trade_ledger_rows: list[dict[str, object]] = []
+    entry_bar_snapshots: list[dict[str, object]] = []
+    if args.trade_ledger is not None:
+        trade_ledger_rows = _load_jsonl(args.trade_ledger)
+    if args.entry_bar_snapshots is not None:
+        entry_bar_snapshots = _load_jsonl(args.entry_bar_snapshots)
+
+    materialization = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=trade_ledger_rows,
+        entry_bar_reference_snapshots=entry_bar_snapshots,
     )
-    x, y, binding = build_feature_matrix_binding(
-        FIXTURE_ROWS,
-        feature_names=feature_names,
-        target_name="realized_slippage_bps",
-    )
-    model = fit_ols_lstsq(x, y, binding)
-    design_all = np.column_stack([np.ones(x.shape[0]), x])
-    coeff_values = np.asarray(list(model.coefficients.values()), dtype=float)
-    predicted = design_all @ coeff_values
-    calibration = build_cost_model_calibration_evidence(
-        model, observed_target_bps=y, predicted_target_bps=predicted
-    )
+    productive_rows = _materializer_rows_to_feature_rows(materialization.rows)
+    n_productive_samples = len(productive_rows)
+    ols_executed = False
+    calibration_payload: dict[str, object] | None = None
+    min_ols_samples = 5
+
+    if n_productive_samples >= min_ols_samples:
+        feature_names = (
+            "spread_bps",
+            "volatility_estimate",
+            "order_notional",
+        )
+        x, y, binding = build_feature_matrix_binding(
+            productive_rows,
+            feature_names=feature_names,
+            target_name=TARGET_NAME,
+        )
+        model = fit_ols_lstsq(x, y, binding)
+        design_all = np.column_stack([np.ones(x.shape[0]), x])
+        coeff_values = np.asarray(list(model.coefficients.values()), dtype=float)
+        predicted = design_all @ coeff_values
+        calibration_payload = to_jsonable(
+            build_cost_model_calibration_evidence(
+                model, observed_target_bps=y, predicted_target_bps=predicted
+            )
+        )
+        ols_executed = True
+    elif fixture_scaffold_only:
+        x, y, binding = build_feature_matrix_binding(
+            FIXTURE_ROWS,
+            feature_names=(
+                "spread_bps",
+                "volatility_estimate",
+                "order_notional_to_depth",
+                "funding_rate_abs",
+                "liquidity_score",
+            ),
+            target_name="realized_slippage_bps",
+        )
+        model = fit_ols_lstsq(x, y, binding)
+        design_all = np.column_stack([np.ones(x.shape[0]), x])
+        coeff_values = np.asarray(list(model.coefficients.values()), dtype=float)
+        predicted = design_all @ coeff_values
+        calibration_payload = to_jsonable(
+            build_cost_model_calibration_evidence(
+                model, observed_target_bps=y, predicted_target_bps=predicted
+            )
+        )
+        ols_executed = True
+
+    if n_productive_samples == 0 and not fixture_scaffold_only:
+        verdict = "OFFLINE_LINEAR_COST_MODEL_DIAGNOSTICS_V0_FAIL_CLOSED"
+        status = materialization.status.value
+    else:
+        verdict = "OFFLINE_LINEAR_COST_MODEL_DIAGNOSTICS_V0_PASS_OR_FAIL_CLOSED"
+        status = (
+            materialization.status.value
+            if n_productive_samples > 0
+            else MaterializationStatus.INSUFFICIENT_DATA.value
+        )
 
     report = {
-        "verdict": "OFFLINE_LINEAR_COST_MODEL_DIAGNOSTICS_V0_PASS_OR_FAIL_CLOSED",
+        "verdict": verdict,
         "offline_only": True,
         "runtime_authority": False,
         "order_authority": False,
         "promotion_pass_authority": False,
         "backtest_cost_default_change": False,
-        "calibration": to_jsonable(calibration),
+        "fixture_scaffold_only": fixture_scaffold_only,
+        "n_productive_samples": n_productive_samples,
+        "n_fixture_scaffold_rows": len(FIXTURE_ROWS) if fixture_scaffold_only else 0,
+        "ols_executed": ols_executed,
+        "materialization_status": status,
+        "materialization_digest": materialization.materialization_digest,
+        "admissible_sample_count": materialization.admissible_count,
+        "rejected_row_count": len(materialization.rejected),
+        "target_name": TARGET_NAME,
+        "calibration": calibration_payload,
     }
     (out / "offline_linear_cost_model_diagnostics_v0.json").write_text(
         json.dumps(report, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-    print("VERDICT=OFFLINE_LINEAR_COST_MODEL_DIAGNOSTICS_V0_PASS_OR_FAIL_CLOSED")
+    print(f"VERDICT={verdict}")
     print(f"REPORT={out / 'offline_linear_cost_model_diagnostics_v0.json'}")
-    print(f"STATUS={calibration.status}")
+    print(f"MATERIALIZATION_STATUS={status}")
+    print(f"N_PRODUCTIVE_SAMPLES={n_productive_samples}")
+    print(f"OLS_EXECUTED={'true' if ols_executed else 'false'}")
     print("OFFLINE_ONLY=true")
     print("RUNTIME_AUTHORITY=false")
     print("ORDER_AUTHORITY=false")
@@ -151,7 +260,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-
-
-AUTHORITY_EFFECT = "NONE"
-RUNTIME_EFFECT = "NONE"

--- a/src/research/offline_linear_cost_diagnostic_row_materializer_v0.py
+++ b/src/research/offline_linear_cost_diagnostic_row_materializer_v0.py
@@ -1,0 +1,420 @@
+"""Offline linear cost diagnostic row materializer v0.
+
+Deterministic, offline-only join of manifest-verified TRADE_LEDGER_V1 rows to
+entry-time bar reference snapshots. Computes SIMULATED_BACKTEST_SLIPPAGE target
+via the canonical execution_reports side-adjusted formula. No OLS, calibration,
+economic evaluation, runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+
+SCHEMA_VERSION = "offline_linear_cost_diagnostic_row_materializer.v0"
+TARGET_NAME = "simulated_backtest_slippage_bps"
+TARGET_PROVENANCE_CLASS = "SIMULATED_BACKTEST_SLIPPAGE"
+CANONICAL_REFERENCE_PRICE_OWNER = "close_for_execution_reference_only"
+CANONICAL_JOIN_KEY = "trade_id + instrument_id + entry_time"
+
+INCONCLUSIVE_SENTINEL = "INCONCLUSIVE"
+
+REQUIRED_DIAGNOSTIC_FIELDS = (
+    "instrument_id",
+    "side",
+    "decision_time",
+    "spread_bps",
+    "volatility_estimate",
+    "order_notional",
+    "simulated_or_realized_fill_price",
+    "execution_reference_price",
+    TARGET_NAME,
+)
+
+OPTIONAL_DIAGNOSTIC_FIELDS = (
+    "funding_rate_abs",
+    "liquidity_score",
+    "regime",
+    "best_bid",
+    "best_ask",
+    "depth_near_touch",
+)
+
+
+class RejectionReason(str, Enum):
+    MISSING_TRADE_ID = "MISSING_TRADE_ID"
+    DUPLICATE_TRADE_ID = "DUPLICATE_TRADE_ID"
+    MISSING_INSTRUMENT_ID = "MISSING_INSTRUMENT_ID"
+    MISSING_ENTRY_TIME = "MISSING_ENTRY_TIME"
+    MISSING_REFERENCE_SNAPSHOT = "MISSING_REFERENCE_SNAPSHOT"
+    DUPLICATE_JOIN_CANDIDATE = "DUPLICATE_JOIN_CANDIDATE"
+    NONPOSITIVE_REFERENCE_PRICE = "NONPOSITIVE_REFERENCE_PRICE"
+    FEATURE_AFTER_TARGET_TIME = "FEATURE_AFTER_TARGET_TIME"
+    UNFINALIZED_BAR = "UNFINALIZED_BAR"
+    INCONCLUSIVE_FIELD = "INCONCLUSIVE_FIELD"
+    INVALID_SIDE = "INVALID_SIDE"
+    MISSING_FILL_PRICE = "MISSING_FILL_PRICE"
+    MISSING_ORDER_NOTIONAL = "MISSING_ORDER_NOTIONAL"
+    MISSING_SPREAD_BPS = "MISSING_SPREAD_BPS"
+    MISSING_VOLATILITY_ESTIMATE = "MISSING_VOLATILITY_ESTIMATE"
+
+
+class MaterializationStatus(str, Enum):
+    PASS = "PASS"
+    INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
+    TARGET_BINDING_MISSING = "TARGET_BINDING_MISSING"
+
+
+@dataclass(frozen=True)
+class RejectedRowV0:
+    trade_id: str
+    reason: RejectionReason
+
+
+@dataclass(frozen=True)
+class MaterializationResultV0:
+    status: MaterializationStatus
+    rows: tuple[dict[str, Any], ...]
+    admissible_count: int
+    rejected: tuple[RejectedRowV0, ...]
+    materialization_digest: str
+    target_provenance_class: str = TARGET_PROVENANCE_CLASS
+    target_name: str = TARGET_NAME
+    authority_effect: str = AUTHORITY_EFFECT
+    runtime_effect: str = RUNTIME_EFFECT
+
+
+def _stable_digest(payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _is_inconclusive(value: Any) -> bool:
+    return value is None or value == INCONCLUSIVE_SENTINEL
+
+
+def _side_to_execution_side(side: str) -> str:
+    normalized = str(side).strip().lower()
+    if normalized == "long":
+        return "buy"
+    if normalized == "short":
+        return "sell"
+    raise ValueError(RejectionReason.INVALID_SIDE.value)
+
+
+def compute_simulated_backtest_slippage_bps(
+    *,
+    side: str,
+    fill_price: float,
+    execution_reference_price: float,
+) -> float:
+    """Canonical side-adjusted slippage formula from execution_reports."""
+    if execution_reference_price <= 0:
+        raise ValueError(RejectionReason.NONPOSITIVE_REFERENCE_PRICE.value)
+    execution_side = _side_to_execution_side(side)
+    if execution_side == "buy":
+        return (fill_price - execution_reference_price) / execution_reference_price * 10000.0
+    return (execution_reference_price - fill_price) / execution_reference_price * 10000.0
+
+
+def _snapshot_join_key(snapshot: Mapping[str, Any]) -> tuple[str, str]:
+    return (str(snapshot.get("instrument_id", "")), str(snapshot.get("bar_timestamp", "")))
+
+
+def _build_snapshot_index(
+    snapshots: Sequence[Mapping[str, Any]],
+) -> tuple[dict[tuple[str, str], Mapping[str, Any]], dict[tuple[str, str], int]]:
+    index: dict[tuple[str, str], Mapping[str, Any]] = {}
+    counts: dict[tuple[str, str], int] = {}
+    for snapshot in snapshots:
+        key = _snapshot_join_key(snapshot)
+        counts[key] = counts.get(key, 0) + 1
+        if counts[key] == 1:
+            index[key] = snapshot
+    return index, counts
+
+
+def _resolve_snapshot_for_trade(
+    *,
+    trade: Mapping[str, Any],
+    snapshot_index: Mapping[tuple[str, str], Mapping[str, Any]],
+    snapshot_counts: Mapping[tuple[str, str], int],
+) -> tuple[Mapping[str, Any] | None, RejectionReason | None]:
+    inline = trade.get("entry_bar_reference_snapshot")
+    if isinstance(inline, Mapping):
+        return inline, None
+
+    instrument_id = str(trade.get("instrument_id", ""))
+    entry_time = str(trade.get("entry_time", ""))
+    if not instrument_id or not entry_time:
+        return None, RejectionReason.MISSING_REFERENCE_SNAPSHOT
+
+    key = (instrument_id, entry_time)
+    if snapshot_counts.get(key, 0) > 1:
+        return None, RejectionReason.DUPLICATE_JOIN_CANDIDATE
+    snapshot = snapshot_index.get(key)
+    if snapshot is None:
+        return None, RejectionReason.MISSING_REFERENCE_SNAPSHOT
+    return snapshot, None
+
+
+def _validate_snapshot_point_in_time(
+    *,
+    snapshot: Mapping[str, Any],
+    entry_time: str,
+) -> RejectionReason | None:
+    if snapshot.get("is_finalized") is False:
+        return RejectionReason.UNFINALIZED_BAR
+
+    feature_time = str(
+        snapshot.get("feature_timestamp") or snapshot.get("bar_timestamp") or entry_time
+    )
+    if feature_time > entry_time:
+        return RejectionReason.FEATURE_AFTER_TARGET_TIME
+    return None
+
+
+def _as_positive_float(
+    value: Any, *, reason: RejectionReason
+) -> tuple[float | None, RejectionReason | None]:
+    if _is_inconclusive(value):
+        return None, reason
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None, reason
+    if parsed <= 0:
+        return None, RejectionReason.NONPOSITIVE_REFERENCE_PRICE
+    return parsed, None
+
+
+def _as_required_float(
+    value: Any, *, reason: RejectionReason
+) -> tuple[float | None, RejectionReason | None]:
+    if _is_inconclusive(value):
+        return None, reason
+    try:
+        return float(value), None
+    except (TypeError, ValueError):
+        return None, reason
+
+
+def _materialize_single_row(
+    *,
+    trade: Mapping[str, Any],
+    snapshot: Mapping[str, Any],
+) -> tuple[dict[str, Any] | None, RejectionReason | None]:
+    trade_id = str(trade.get("trade_id", ""))
+    if not trade_id:
+        return None, RejectionReason.MISSING_TRADE_ID
+
+    instrument_id = str(trade.get("instrument_id", ""))
+    if not instrument_id:
+        return None, RejectionReason.MISSING_INSTRUMENT_ID
+
+    entry_time = str(trade.get("entry_time", ""))
+    if not entry_time:
+        return None, RejectionReason.MISSING_ENTRY_TIME
+
+    pit_reason = _validate_snapshot_point_in_time(snapshot=snapshot, entry_time=entry_time)
+    if pit_reason is not None:
+        return None, pit_reason
+
+    execution_reference_price, ref_reason = _as_positive_float(
+        snapshot.get("close"),
+        reason=RejectionReason.NONPOSITIVE_REFERENCE_PRICE,
+    )
+    if ref_reason is not None or execution_reference_price is None:
+        return None, ref_reason or RejectionReason.NONPOSITIVE_REFERENCE_PRICE
+
+    fill_price, fill_reason = _as_positive_float(
+        trade.get("entry_price"),
+        reason=RejectionReason.MISSING_FILL_PRICE,
+    )
+    if fill_reason is not None or fill_price is None:
+        return None, fill_reason or RejectionReason.MISSING_FILL_PRICE
+
+    order_notional, notional_reason = _as_positive_float(
+        trade.get("notional"),
+        reason=RejectionReason.MISSING_ORDER_NOTIONAL,
+    )
+    if notional_reason is not None or order_notional is None:
+        return None, notional_reason or RejectionReason.MISSING_ORDER_NOTIONAL
+
+    side = str(trade.get("side", ""))
+    if side in ("", INCONCLUSIVE_SENTINEL):
+        return None, RejectionReason.INVALID_SIDE
+
+    spread_bps, spread_reason = _as_required_float(
+        snapshot.get("spread_bps"),
+        reason=RejectionReason.MISSING_SPREAD_BPS,
+    )
+    if spread_reason is not None or spread_bps is None:
+        return None, spread_reason or RejectionReason.MISSING_SPREAD_BPS
+
+    volatility_estimate, vol_reason = _as_required_float(
+        snapshot.get("volatility_estimate"),
+        reason=RejectionReason.MISSING_VOLATILITY_ESTIMATE,
+    )
+    if vol_reason is not None or volatility_estimate is None:
+        return None, vol_reason or RejectionReason.MISSING_VOLATILITY_ESTIMATE
+
+    try:
+        slippage_bps = compute_simulated_backtest_slippage_bps(
+            side=side,
+            fill_price=fill_price,
+            execution_reference_price=execution_reference_price,
+        )
+    except ValueError as exc:
+        reason_name = str(exc)
+        if reason_name in RejectionReason.__members__:
+            return None, RejectionReason(reason_name)
+        return None, RejectionReason.INVALID_SIDE
+
+    row: dict[str, Any] = {
+        "trade_id": trade_id,
+        "instrument_id": instrument_id,
+        "side": side,
+        "decision_time": entry_time,
+        "spread_bps": spread_bps,
+        "volatility_estimate": volatility_estimate,
+        "order_notional": order_notional,
+        "simulated_or_realized_fill_price": fill_price,
+        "execution_reference_price": execution_reference_price,
+        TARGET_NAME: slippage_bps,
+        "target_provenance_class": TARGET_PROVENANCE_CLASS,
+        "target_name": TARGET_NAME,
+        "reference_price_owner": CANONICAL_REFERENCE_PRICE_OWNER,
+    }
+
+    for optional in OPTIONAL_DIAGNOSTIC_FIELDS:
+        value = snapshot.get(optional)
+        if value is not None and not _is_inconclusive(value):
+            row[optional] = value
+
+    return row, None
+
+
+def materialize_offline_linear_cost_diagnostic_rows_v0(
+    *,
+    trade_ledger_rows: Sequence[Mapping[str, Any]],
+    entry_bar_reference_snapshots: Sequence[Mapping[str, Any]] | None = None,
+) -> MaterializationResultV0:
+    """Materialize admissible diagnostic rows from ledger rows and bar snapshots."""
+    snapshots = list(entry_bar_reference_snapshots or ())
+    snapshot_index, snapshot_counts = _build_snapshot_index(snapshots)
+
+    seen_trade_ids: set[str] = set()
+    admissible: list[dict[str, Any]] = []
+    rejected: list[RejectedRowV0] = []
+
+    ordered_trades = sorted(
+        trade_ledger_rows,
+        key=lambda row: (
+            str(row.get("trade_id", "")),
+            str(row.get("entry_time", "")),
+            str(row.get("instrument_id", "")),
+        ),
+    )
+
+    for trade in ordered_trades:
+        trade_id = str(trade.get("trade_id", ""))
+        if not trade_id:
+            rejected.append(RejectedRowV0(trade_id="", reason=RejectionReason.MISSING_TRADE_ID))
+            continue
+        if trade_id in seen_trade_ids:
+            rejected.append(
+                RejectedRowV0(trade_id=trade_id, reason=RejectionReason.DUPLICATE_TRADE_ID)
+            )
+            continue
+        seen_trade_ids.add(trade_id)
+
+        snapshot, snap_reason = _resolve_snapshot_for_trade(
+            trade=trade,
+            snapshot_index=snapshot_index,
+            snapshot_counts=snapshot_counts,
+        )
+        if snap_reason is not None or snapshot is None:
+            rejected.append(
+                RejectedRowV0(
+                    trade_id=trade_id,
+                    reason=snap_reason or RejectionReason.MISSING_REFERENCE_SNAPSHOT,
+                )
+            )
+            continue
+
+        row, row_reason = _materialize_single_row(trade=trade, snapshot=snapshot)
+        if row_reason is not None or row is None:
+            rejected.append(
+                RejectedRowV0(
+                    trade_id=trade_id,
+                    reason=row_reason or RejectionReason.TARGET_BINDING_MISSING,
+                )
+            )
+            continue
+        admissible.append(row)
+
+    admissible_sorted = sorted(
+        admissible,
+        key=lambda row: (
+            str(row.get("trade_id", "")),
+            str(row.get("decision_time", "")),
+            str(row.get("instrument_id", "")),
+        ),
+    )
+
+    if not admissible_sorted:
+        status = (
+            MaterializationStatus.TARGET_BINDING_MISSING
+            if trade_ledger_rows
+            else MaterializationStatus.INSUFFICIENT_DATA
+        )
+    else:
+        status = MaterializationStatus.PASS
+
+    digest = _stable_digest({"rows": admissible_sorted, "schema_version": SCHEMA_VERSION})
+    return MaterializationResultV0(
+        status=status,
+        rows=tuple(admissible_sorted),
+        admissible_count=len(admissible_sorted),
+        rejected=tuple(rejected),
+        materialization_digest=digest,
+    )
+
+
+def serialize_materialized_rows_v0(rows: Sequence[Mapping[str, Any]]) -> str:
+    """Deterministic JSONL serialization for repeated materialization checks."""
+    ordered = sorted(
+        rows,
+        key=lambda row: (
+            str(row.get("trade_id", "")),
+            str(row.get("decision_time", "")),
+            str(row.get("instrument_id", "")),
+        ),
+    )
+    lines = [json.dumps(row, sort_keys=True, default=str) for row in ordered]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+__all__ = [
+    "AUTHORITY_EFFECT",
+    "RUNTIME_EFFECT",
+    "SCHEMA_VERSION",
+    "TARGET_NAME",
+    "TARGET_PROVENANCE_CLASS",
+    "CANONICAL_REFERENCE_PRICE_OWNER",
+    "CANONICAL_JOIN_KEY",
+    "MaterializationResultV0",
+    "MaterializationStatus",
+    "RejectionReason",
+    "RejectedRowV0",
+    "compute_simulated_backtest_slippage_bps",
+    "materialize_offline_linear_cost_diagnostic_rows_v0",
+    "serialize_materialized_rows_v0",
+]

--- a/src/research/trade_ledger_equity_curve_persistence_offline_evaluation_execution_v0.py
+++ b/src/research/trade_ledger_equity_curve_persistence_offline_evaluation_execution_v0.py
@@ -311,6 +311,47 @@ def _iso_ts(value: Any) -> str:
     return str(value)
 
 
+def _lookup_entry_bar_reference_snapshot_v0(
+    *,
+    instrument_id: str,
+    entry_time: Any,
+    bars: pd.DataFrame | None,
+    spread_half_bps: float | None,
+) -> dict[str, Any] | None:
+    """Deterministic entry-time bar snapshot for offline cost diagnostic materializer v0."""
+    if bars is None or bars.empty or entry_time is None:
+        return None
+    try:
+        stamp = pd.Timestamp(entry_time)
+    except (TypeError, ValueError):
+        return None
+    if stamp not in bars.index:
+        return None
+    matched = bars.loc[stamp]
+    if isinstance(matched, pd.DataFrame):
+        return None
+    close_raw = matched.get("close")
+    if close_raw is None or pd.isna(close_raw):
+        return None
+    close = float(close_raw)
+    if close <= 0:
+        return None
+    vol_raw = matched.get("volatility_estimate")
+    volatility_estimate = float(vol_raw) if vol_raw is not None and not pd.isna(vol_raw) else None
+    spread_bps = (2.0 * float(spread_half_bps)) if spread_half_bps is not None else None
+    if spread_bps is None or volatility_estimate is None:
+        return None
+    return {
+        "instrument_id": instrument_id,
+        "bar_timestamp": stamp.isoformat(),
+        "close": close,
+        "spread_bps": spread_bps,
+        "volatility_estimate": volatility_estimate,
+        "is_finalized": True,
+        "feature_timestamp": stamp.isoformat(),
+    }
+
+
 def _equity_at_time(equity_curve: pd.Series, ts: Any) -> Any:
     if ts is None or equity_curve.empty:
         return INCONCLUSIVE_SENTINEL
@@ -338,6 +379,8 @@ def materialize_trade_ledger_v1_records_v0(
     config_digest: str,
     implementation_digest: str,
     required_fields: Sequence[str],
+    bars: pd.DataFrame | None = None,
+    spread_half_bps: float | None = None,
 ) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     if trades_df is None or trades_df.empty:
@@ -433,6 +476,14 @@ def materialize_trade_ledger_v1_records_v0(
             "config_digest": config_digest,
             "implementation_digest": implementation_digest,
         }
+        entry_snapshot = _lookup_entry_bar_reference_snapshot_v0(
+            instrument_id=instrument_id,
+            entry_time=entry_time,
+            bars=bars,
+            spread_half_bps=spread_half_bps,
+        )
+        if entry_snapshot is not None:
+            record["entry_bar_reference_snapshot"] = entry_snapshot
         for field in required_fields:
             record.setdefault(field, INCONCLUSIVE_SENTINEL)
         records.append(record)
@@ -633,6 +684,12 @@ def run_execution_v0(
     input_digest = str(binding_set.get("data_digest", ""))
     config_digest = str(binding_set.get("config_digest", ""))
     implementation_digest = str(binding_set.get("implementation_digest", ""))
+    spread_half_bps_raw = (
+        cfg.get("backtest", {})
+        .get("economic_research_execution_cost", {})
+        .get("conservative_half_spread_bps")
+    )
+    spread_half_bps = float(spread_half_bps_raw) if spread_half_bps_raw is not None else None
 
     trade_records = materialize_trade_ledger_v1_records_v0(
         trades_df=trades_df,
@@ -648,6 +705,8 @@ def run_execution_v0(
         config_digest=config_digest,
         implementation_digest=implementation_digest,
         required_fields=trade_ledger_fields,
+        bars=bars,
+        spread_half_bps=spread_half_bps,
     )
     equity_records = materialize_equity_curve_v1_records_v0(
         equity_curve=equity_curve,

--- a/tests/research/test_offline_linear_cost_diagnostic_row_materializer_v0.py
+++ b/tests/research/test_offline_linear_cost_diagnostic_row_materializer_v0.py
@@ -1,0 +1,407 @@
+"""Contract tests for offline linear cost diagnostic row materializer v0."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.research.linear_evidence.import_boundary import scan_file_import_boundary
+from src.research.offline_linear_cost_diagnostic_row_materializer_v0 import (
+    AUTHORITY_EFFECT,
+    RUNTIME_EFFECT,
+    MaterializationStatus,
+    RejectionReason,
+    TARGET_NAME,
+    TARGET_PROVENANCE_CLASS,
+    compute_simulated_backtest_slippage_bps,
+    materialize_offline_linear_cost_diagnostic_rows_v0,
+    serialize_materialized_rows_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MATERIALIZER_MODULE = (
+    REPO_ROOT / "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py"
+)
+RUNNER_MODULE = REPO_ROOT / "scripts/research/offline_linear_cost_model_diagnostics_v0.py"
+FORBIDDEN_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+    "requests",
+    "httpx",
+    "urllib.request",
+)
+
+
+def _trade(
+    *,
+    trade_id: str = "t-1",
+    instrument_id: str = "inst-eth-usdt-perp",
+    entry_time: str = "2026-01-01T00:00:00+00:00",
+    side: str = "long",
+    entry_price: float = 100.5,
+    notional: float = 1000.0,
+) -> dict[str, object]:
+    return {
+        "trade_id": trade_id,
+        "instrument_id": instrument_id,
+        "entry_time": entry_time,
+        "side": side,
+        "entry_price": entry_price,
+        "notional": notional,
+    }
+
+
+def _snapshot(
+    *,
+    instrument_id: str = "inst-eth-usdt-perp",
+    bar_timestamp: str = "2026-01-01T00:00:00+00:00",
+    close: float = 100.0,
+    spread_bps: float = 10.0,
+    volatility_estimate: float = 0.02,
+    is_finalized: bool = True,
+    feature_timestamp: str | None = None,
+    **extra: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "instrument_id": instrument_id,
+        "bar_timestamp": bar_timestamp,
+        "close": close,
+        "spread_bps": spread_bps,
+        "volatility_estimate": volatility_estimate,
+        "is_finalized": is_finalized,
+        "feature_timestamp": feature_timestamp or bar_timestamp,
+    }
+    payload.update(extra)
+    return payload
+
+
+def test_buy_slippage_formula_exact() -> None:
+    result = compute_simulated_backtest_slippage_bps(
+        side="long",
+        fill_price=100.5,
+        execution_reference_price=100.0,
+    )
+    assert result == pytest.approx(50.0)
+
+
+def test_sell_slippage_formula_exact() -> None:
+    result = compute_simulated_backtest_slippage_bps(
+        side="short",
+        fill_price=99.5,
+        execution_reference_price=100.0,
+    )
+    assert result == pytest.approx(50.0)
+
+
+def test_long_short_symmetry() -> None:
+    ref = 200.0
+    fill = 201.0
+    buy = compute_simulated_backtest_slippage_bps(
+        side="long", fill_price=fill, execution_reference_price=ref
+    )
+    sell = compute_simulated_backtest_slippage_bps(
+        side="short", fill_price=199.0, execution_reference_price=ref
+    )
+    assert buy == pytest.approx(sell)
+
+
+def test_zero_slippage_at_reference_price() -> None:
+    assert (
+        compute_simulated_backtest_slippage_bps(
+            side="long", fill_price=100.0, execution_reference_price=100.0
+        )
+        == 0.0
+    )
+    assert (
+        compute_simulated_backtest_slippage_bps(
+            side="short", fill_price=100.0, execution_reference_price=100.0
+        )
+        == 0.0
+    )
+
+
+def test_deterministic_trade_id_join() -> None:
+    trade = _trade()
+    snapshot = _snapshot()
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[trade],
+        entry_bar_reference_snapshots=[snapshot],
+    )
+    assert result.admissible_count == 1
+    assert result.rows[0]["trade_id"] == "t-1"
+
+
+def test_instrument_id_entry_time_snapshot_join() -> None:
+    trade = _trade(entry_time="2026-01-01T01:00:00+00:00")
+    snapshots = [
+        _snapshot(bar_timestamp="2026-01-01T00:00:00+00:00"),
+        _snapshot(bar_timestamp="2026-01-01T01:00:00+00:00", close=101.0),
+    ]
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[trade],
+        entry_bar_reference_snapshots=snapshots,
+    )
+    assert result.admissible_count == 1
+    assert result.rows[0]["execution_reference_price"] == 101.0
+
+
+def test_duplicate_join_candidate_rejected() -> None:
+    trade = _trade()
+    snapshots = [_snapshot(), _snapshot()]
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[trade],
+        entry_bar_reference_snapshots=snapshots,
+    )
+    assert result.admissible_count == 0
+    assert result.rejected[0].reason == RejectionReason.DUPLICATE_JOIN_CANDIDATE
+
+
+def test_missing_reference_snapshot_rejected() -> None:
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[_trade()],
+        entry_bar_reference_snapshots=[],
+    )
+    assert result.admissible_count == 0
+    assert result.rejected[0].reason == RejectionReason.MISSING_REFERENCE_SNAPSHOT
+
+
+def test_nonpositive_reference_price_rejected() -> None:
+    trade = _trade()
+    snapshot = _snapshot(close=0.0)
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[trade],
+        entry_bar_reference_snapshots=[snapshot],
+    )
+    assert result.admissible_count == 0
+    assert result.rejected[0].reason == RejectionReason.NONPOSITIVE_REFERENCE_PRICE
+
+
+def test_feature_after_target_time_rejected() -> None:
+    trade = _trade(entry_time="2026-01-01T00:00:00+00:00")
+    snapshot = _snapshot(feature_timestamp="2026-01-01T01:00:00+00:00")
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[trade],
+        entry_bar_reference_snapshots=[snapshot],
+    )
+    assert result.admissible_count == 0
+    assert result.rejected[0].reason == RejectionReason.FEATURE_AFTER_TARGET_TIME
+
+
+def test_unfinalized_bar_rejected() -> None:
+    trade = _trade()
+    snapshot = _snapshot(is_finalized=False)
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[trade],
+        entry_bar_reference_snapshots=[snapshot],
+    )
+    assert result.admissible_count == 0
+    assert result.rejected[0].reason == RejectionReason.UNFINALIZED_BAR
+
+
+def test_optional_depth_absent_admissible() -> None:
+    trade = _trade()
+    snapshot = _snapshot()
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[trade],
+        entry_bar_reference_snapshots=[snapshot],
+    )
+    assert result.admissible_count == 1
+    assert "depth_near_touch" not in result.rows[0]
+
+
+def test_order_notional_used_without_synthetic_depth_ratio() -> None:
+    trade = _trade(notional=1234.5)
+    snapshot = _snapshot()
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[trade],
+        entry_bar_reference_snapshots=[snapshot],
+    )
+    row = result.rows[0]
+    assert row["order_notional"] == pytest.approx(1234.5)
+    assert "order_notional_to_depth" not in row
+
+
+def test_stable_row_order() -> None:
+    trades = [
+        _trade(trade_id="t-2", entry_time="2026-01-01T02:00:00+00:00"),
+        _trade(trade_id="t-1", entry_time="2026-01-01T01:00:00+00:00"),
+    ]
+    snapshots = [
+        _snapshot(bar_timestamp="2026-01-01T01:00:00+00:00"),
+        _snapshot(bar_timestamp="2026-01-01T02:00:00+00:00"),
+    ]
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=trades,
+        entry_bar_reference_snapshots=snapshots,
+    )
+    assert [row["trade_id"] for row in result.rows] == ["t-1", "t-2"]
+
+
+def test_repeated_materialization_byte_identical() -> None:
+    trades = [
+        _trade(trade_id="t-1"),
+        _trade(trade_id="t-2", entry_time="2026-01-01T01:00:00+00:00"),
+    ]
+    snapshots = [
+        _snapshot(bar_timestamp="2026-01-01T00:00:00+00:00"),
+        _snapshot(bar_timestamp="2026-01-01T01:00:00+00:00"),
+    ]
+    first = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=trades,
+        entry_bar_reference_snapshots=snapshots,
+    )
+    second = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=trades,
+        entry_bar_reference_snapshots=snapshots,
+    )
+    assert serialize_materialized_rows_v0(first.rows) == serialize_materialized_rows_v0(second.rows)
+
+
+def test_second_materialization_diff_empty() -> None:
+    trades = [_trade()]
+    snapshots = [_snapshot()]
+    first = serialize_materialized_rows_v0(
+        materialize_offline_linear_cost_diagnostic_rows_v0(
+            trade_ledger_rows=trades,
+            entry_bar_reference_snapshots=snapshots,
+        ).rows
+    )
+    second = serialize_materialized_rows_v0(
+        materialize_offline_linear_cost_diagnostic_rows_v0(
+            trade_ledger_rows=trades,
+            entry_bar_reference_snapshots=snapshots,
+        ).rows
+    )
+    assert first == second
+
+
+def test_diagnostics_runner_consumes_materializer_output(tmp_path: Path) -> None:
+    trade = _trade()
+    snapshot = _snapshot()
+    ledger_path = tmp_path / "ledger.jsonl"
+    snapshot_path = tmp_path / "snapshots.jsonl"
+    ledger_path.write_text(json.dumps(trade, sort_keys=True) + "\n", encoding="utf-8")
+    snapshot_path.write_text(json.dumps(snapshot, sort_keys=True) + "\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER_MODULE),
+            "--out",
+            str(tmp_path / "out"),
+            "--trade-ledger",
+            str(ledger_path),
+            "--entry-bar-snapshots",
+            str(snapshot_path),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads(
+        (tmp_path / "out" / "offline_linear_cost_model_diagnostics_v0.json").read_text()
+    )
+    assert report["n_productive_samples"] == 1
+    assert report["target_name"] == TARGET_NAME
+    assert report["ols_executed"] is False
+    assert report["materialization_status"] == "PASS"
+
+
+def test_fixture_rows_not_counted_as_productive_samples(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER_MODULE),
+            "--out",
+            str(tmp_path),
+            "--fixture-scaffold",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads((tmp_path / "offline_linear_cost_model_diagnostics_v0.json").read_text())
+    assert report["fixture_scaffold_only"] is True
+    assert report["n_productive_samples"] == 0
+
+
+def test_zero_admissible_rows_fail_closed(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(RUNNER_MODULE), "--out", str(tmp_path)],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads((tmp_path / "offline_linear_cost_model_diagnostics_v0.json").read_text())
+    assert report["n_productive_samples"] == 0
+    assert report["ols_executed"] is False
+    assert report["verdict"] == "OFFLINE_LINEAR_COST_MODEL_DIAGNOSTICS_V0_FAIL_CLOSED"
+
+
+def test_no_runtime_import_boundary() -> None:
+    for path in (MATERIALIZER_MODULE, RUNNER_MODULE):
+        source = path.read_text(encoding="utf-8")
+        for token in FORBIDDEN_IMPORT_PREFIXES:
+            assert token not in source
+        hits = scan_file_import_boundary(path, repo_root=REPO_ROOT)
+        assert hits == []
+
+
+def test_no_order_adapter_import_boundary() -> None:
+    source = MATERIALIZER_MODULE.read_text(encoding="utf-8")
+    for token in ("order_adapter", "src.orders", "src.trading.orders"):
+        assert token not in source
+
+
+def test_no_scheduler_import_boundary() -> None:
+    source = MATERIALIZER_MODULE.read_text(encoding="utf-8")
+    assert "src.scheduler" not in source
+
+
+def test_no_runtime_effect() -> None:
+    assert RUNTIME_EFFECT == "NONE"
+
+
+def test_no_authority_effect() -> None:
+    assert AUTHORITY_EFFECT == "NONE"
+
+
+def test_target_provenance_class() -> None:
+    trade = _trade()
+    snapshot = _snapshot()
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[trade],
+        entry_bar_reference_snapshots=[snapshot],
+    )
+    assert result.rows[0]["target_provenance_class"] == TARGET_PROVENANCE_CLASS
+    assert result.rows[0]["target_name"] == TARGET_NAME
+
+
+def test_inline_snapshot_join() -> None:
+    trade = _trade()
+    trade["entry_bar_reference_snapshot"] = _snapshot()
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[trade],
+        entry_bar_reference_snapshots=[],
+    )
+    assert result.admissible_count == 1
+
+
+def test_zero_admissible_rows_status() -> None:
+    result = materialize_offline_linear_cost_diagnostic_rows_v0(
+        trade_ledger_rows=[],
+        entry_bar_reference_snapshots=[],
+    )
+    assert result.status == MaterializationStatus.INSUFFICIENT_DATA
+    assert result.admissible_count == 0

--- a/tests/research/test_offline_linear_cost_model_diagnostics_v0.py
+++ b/tests/research/test_offline_linear_cost_model_diagnostics_v0.py
@@ -41,7 +41,9 @@ def test_ols_evidence_is_authority_neutral() -> None:
     assert evidence.validation_policy == "TIME_ORDERED"
 
 
-def test_offline_linear_cost_model_diagnostics_cli(tmp_path: Path) -> None:
+def test_offline_linear_cost_model_diagnostics_cli_fail_closed_without_materialized_rows(
+    tmp_path: Path,
+) -> None:
     result = subprocess.run(
         [
             sys.executable,
@@ -61,4 +63,28 @@ def test_offline_linear_cost_model_diagnostics_cli(tmp_path: Path) -> None:
     assert report["order_authority"] is False
     assert report["promotion_pass_authority"] is False
     assert report["backtest_cost_default_change"] is False
+    assert report["n_productive_samples"] == 0
+    assert report["ols_executed"] is False
+    assert report["verdict"] == "OFFLINE_LINEAR_COST_MODEL_DIAGNOSTICS_V0_FAIL_CLOSED"
+
+
+def test_offline_linear_cost_model_diagnostics_fixture_scaffold_cli(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/research/offline_linear_cost_model_diagnostics_v0.py",
+            "--out",
+            str(tmp_path),
+            "--fixture-scaffold",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads((tmp_path / "offline_linear_cost_model_diagnostics_v0.json").read_text())
+    assert report["offline_only"] is True
+    assert report["fixture_scaffold_only"] is True
+    assert report["n_productive_samples"] == 0
     assert report["calibration"]["calibrated_cost_policy"] == "CONSERVATIVE_NOT_MEAN"


### PR DESCRIPTION
## Summary
- Adds `offline_linear_cost_diagnostic_row_materializer_v0` to deterministically join manifest-verified TRADE_LEDGER_V1 rows with entry-time bar reference snapshots and compute `SIMULATED_BACKTEST_SLIPPAGE` via the canonical execution_reports formula.
- Persists optional `entry_bar_reference_snapshot` on trade ledger rows when bars and spread binding are available from the existing offline evaluation path.
- Rewires `offline_linear_cost_model_diagnostics_v0` to consume materializer output only; fixture rows remain scaffolding-only via `--fixture-scaffold`; zero productive samples fail closed without OLS.

## Test plan
- [x] `tests/research/test_offline_linear_cost_diagnostic_row_materializer_v0.py` (formula, join, PIT, determinism, import boundaries)
- [x] `tests/research/test_offline_linear_cost_model_diagnostics_v0.py` (fail-closed default + fixture scaffold)
- [x] ruff format/check on touched files


Made with [Cursor](https://cursor.com)