### PR TITLE
fix(mv2): fail-closed volatility_estimate binding in economic research wiring

### DIFF
--- a/src/backtest/mv2_research_wiring_v1.py
+++ b/src/backtest/mv2_research_wiring_v1.py
@@ -588,6 +588,24 @@ def _resolve_warmup_status(bar: pd.Series) -> WarmupStatus:
     return WarmupStatus.WARMUP_COMPLETE
 
 
+def _resolve_volatility_estimate_for_economic_research_wiring_v1(
+    bar: pd.Series,
+    *,
+    warmup_status: WarmupStatus,
+) -> float:
+    """Fail-closed volatility binding for economic_research_v1 MV2 wiring."""
+    _fail_closed(warmup_status is not WarmupStatus.WARMUP_COMPLETE, "warmup_status_not_complete")
+    if "volatility_estimate" not in bar.index:
+        _fail_closed(True, "volatility_estimate_missing")
+    raw = bar["volatility_estimate"]
+    if raw is None or pd.isna(raw):
+        _fail_closed(True, "volatility_estimate_null")
+    value = float(raw)
+    _fail_closed(not math.isfinite(value), "volatility_estimate_non_finite")
+    _fail_closed(value <= 0.0, "volatility_estimate_non_positive")
+    return value
+
+
 def _period_digest(bars: pd.DataFrame) -> str:
     if bars.empty:
         return _stable_digest({"empty": True})
@@ -677,6 +695,12 @@ def bind_bar_for_mv2_wiring_v1(
             half_spread_bps=research_execution_cost.conservative_half_spread_bps,
         )
 
+    warmup_status = _resolve_warmup_status(bar)
+    volatility_estimate = _resolve_volatility_estimate_for_economic_research_wiring_v1(
+        bar,
+        warmup_status=warmup_status,
+    )
+
     context = CanonicalMarketContextV1(
         context_id=f"mv2-ctx-{instrument_id}-{trading_epoch}",
         instrument_id=instrument_id,
@@ -696,14 +720,14 @@ def bind_bar_for_mv2_wiring_v1(
         volume=float(bar.get("volume", 0.0)),
         open_interest=float(bar.get("open_interest", 0.0)),
         funding_rate=float(bar.get("funding_rate", 0.0)),
-        volatility_estimate=float(bar.get("volatility_estimate", 0.2)),
+        volatility_estimate=volatility_estimate,
         trend_feature_set={"trend_slope": float(bar.get("trend_slope", 0.01))},
         momentum_feature_set={"momentum": float(bar.get("momentum", 0.01))},
         liquidity_feature_set={"liq_score": float(bar.get("liq_score", 0.9))},
         market_structure_feature_set={"range_ratio": float(bar.get("range_ratio", 0.4))},
         data_integrity_status=DataIntegrityStatus.TRUSTED,
         clock_trust_status=ClockTrustStatus.TRUSTED,
-        warmup_status=_resolve_warmup_status(bar),
+        warmup_status=warmup_status,
         feature_contract_version=FEATURE_CONTRACT_VERSION,
     )
     return with_computed_input_digest(context), outcome_l1_status, observed_l1_used

--- a/tests/backtest/test_mv2_research_wiring_v1.py
+++ b/tests/backtest/test_mv2_research_wiring_v1.py
@@ -778,3 +778,75 @@ def test_bar_sequence_state_carrier_futures_only_and_no_bitcoin_boundaries_uncha
     with pytest.raises(ValueError, match="instrument_not_supported_for_step29l"):
         _run(instrument_id="inst-eth-usdt-spot")
     assert wiring.MV2_REQUIRED_INSTRUMENT_ID == "inst-eth-usdt-perp"
+
+
+def _bind_research_bar(
+    bar: pd.Series, *, trading_epoch: int = 0
+) -> wiring.CanonicalMarketContextV1:
+    context, _, _ = wiring.bind_bar_for_mv2_wiring_v1(
+        bar=bar,
+        instrument_id="inst-eth-usdt-perp",
+        trading_epoch=trading_epoch,
+        profile_binding=_research_profile_binding(),
+        research_execution_cost=cost.resolve_economic_research_execution_cost_binding(
+            _research_cfg()
+        ),
+    )
+    return context
+
+
+def _research_bind_bar(**overrides: Any) -> pd.Series:
+    frame = _research_bars(1)
+    row = frame.iloc[0].copy()
+    for key, value in overrides.items():
+        if value is ...:
+            row = row.drop(labels=[key])
+        else:
+            row[key] = value
+    row.name = frame.index[0]
+    return row
+
+
+class TestVolatilityEstimateFailClosedWiringRepairV0:
+    def test_missing_volatility_estimate_does_not_default_to_0_2(self) -> None:
+        bar = _research_bind_bar(volatility_estimate=...)
+        with pytest.raises(ValueError, match="volatility_estimate_missing"):
+            _bind_research_bar(bar)
+
+    def test_explicit_null_volatility_fail_closed(self) -> None:
+        bar = _research_bind_bar(volatility_estimate=None, warmup_status="WARMUP_COMPLETE")
+        with pytest.raises(ValueError, match="volatility_estimate_null"):
+            _bind_research_bar(bar)
+
+    @pytest.mark.parametrize("invalid", [float("inf"), float("-inf")])
+    def test_nonfinite_volatility_fail_closed(self, invalid: float) -> None:
+        bar = _research_bind_bar(volatility_estimate=invalid, warmup_status="WARMUP_COMPLETE")
+        with pytest.raises(ValueError, match="volatility_estimate_non_finite"):
+            _bind_research_bar(bar)
+
+    def test_nan_volatility_fail_closed(self) -> None:
+        bar = _research_bind_bar(volatility_estimate=float("nan"), warmup_status="WARMUP_COMPLETE")
+        with pytest.raises(ValueError, match="volatility_estimate_null"):
+            _bind_research_bar(bar)
+
+    def test_warmup_required_with_present_value_fail_closed(self) -> None:
+        bar = _research_bind_bar(volatility_estimate=0.15, warmup_status="WARMUP_REQUIRED")
+        with pytest.raises(ValueError, match="warmup_status_not_complete"):
+            _bind_research_bar(bar)
+
+    def test_warmup_complete_positive_value_bound_exactly(self) -> None:
+        bar = _research_bind_bar(volatility_estimate=0.123456, warmup_status="WARMUP_COMPLETE")
+        context = _bind_research_bar(bar)
+        assert context.volatility_estimate == pytest.approx(0.123456)
+        assert context.warmup_status is WarmupStatus.WARMUP_COMPLETE
+
+    def test_runtime_warmup_signal_path_remains_signal_zero(self) -> None:
+        bars = _bars()
+        bars["warmup_complete"] = [False] + [True] * (len(bars) - 1)
+        result = _run(bars=bars)
+        assert result.bar_outcomes[0].position_signal == 0
+        assert result.bar_outcomes[0].context.warmup_status == WarmupStatus.WARMUP_REQUIRED
+
+    def test_no_runtime_or_authority_effect_constants_unchanged(self) -> None:
+        assert wiring.MV2_RESEARCH_WIRING_OWNER == "backtest.mv2_research_wiring_v1"
+        assert wiring.MV2_RESEARCH_WIRING_LAYER_VERSION == "v1"


### PR DESCRIPTION
## Summary

- Remove the implicit `0.2` `volatility_estimate` fallback from `bind_bar_for_mv2_wiring_v1` on the `economic_research_v1` path.
- Add `_resolve_volatility_estimate_for_economic_research_wiring_v1` to fail closed on missing, null, non-finite, non-positive, or warmup-incomplete bars.
- Add focused regression tests in `TestVolatilityEstimateFailClosedWiringRepairV0`.

## Scope boundaries

- No dataset publication, digest rebind, config regeneration, economic evaluation, or OLS.
- Runtime profile path (`bind_historical_bar_to_canonical_market_context_v1`) unchanged.
- No runtime, authority, order, or live effects.

## Test plan

- [x] `pytest tests/backtest/test_mv2_research_wiring_v1.py -q` (89 passed)
- [x] Focused fail-closed assertions for missing/null/non-finite/warmup/valid-complete cases
- [x] Existing runtime warmup signal-0 path preserved (`test_matrix_49` semantics)

## CI mode

Selector reports `PR_BOUNDED_FULL` (`category_central_src_requires_full`) due to `src/backtest/` change. Local gate: `tests/backtest/test_mv2_research_wiring_v1.py`.

## Evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/mv2_volatility_estimate_fail_closed_wiring_repair_v0_20260713T045658Z`


Made with [Cursor](https://cursor.com)