### PR TITLE
fix(research): hard-block constant OLS targets before solver

### DIFF
--- a/scripts/research/offline_linear_cost_model_diagnostics_v0.py
+++ b/scripts/research/offline_linear_cost_model_diagnostics_v0.py
@@ -217,15 +217,16 @@ def main() -> int:
             target_name=TARGET_NAME,
         )
         model = fit_ols_lstsq(x, y, binding)
-        design_all = np.column_stack([np.ones(x.shape[0]), x])
-        coeff_values = np.asarray(list(model.coefficients.values()), dtype=float)
-        predicted = design_all @ coeff_values
-        calibration_payload = to_jsonable(
-            build_cost_model_calibration_evidence(
-                model, observed_target_bps=y, predicted_target_bps=predicted
+        if model.coefficients:
+            design_all = np.column_stack([np.ones(x.shape[0]), x])
+            coeff_values = np.asarray(list(model.coefficients.values()), dtype=float)
+            predicted = design_all @ coeff_values
+            calibration_payload = to_jsonable(
+                build_cost_model_calibration_evidence(
+                    model, observed_target_bps=y, predicted_target_bps=predicted
+                )
             )
-        )
-        ols_executed = True
+            ols_executed = True
     elif fixture_scaffold_only:
         x, y, binding = build_feature_matrix_binding(
             FIXTURE_ROWS,
@@ -239,15 +240,16 @@ def main() -> int:
             target_name="realized_slippage_bps",
         )
         model = fit_ols_lstsq(x, y, binding)
-        design_all = np.column_stack([np.ones(x.shape[0]), x])
-        coeff_values = np.asarray(list(model.coefficients.values()), dtype=float)
-        predicted = design_all @ coeff_values
-        calibration_payload = to_jsonable(
-            build_cost_model_calibration_evidence(
-                model, observed_target_bps=y, predicted_target_bps=predicted
+        if model.coefficients:
+            design_all = np.column_stack([np.ones(x.shape[0]), x])
+            coeff_values = np.asarray(list(model.coefficients.values()), dtype=float)
+            predicted = design_all @ coeff_values
+            calibration_payload = to_jsonable(
+                build_cost_model_calibration_evidence(
+                    model, observed_target_bps=y, predicted_target_bps=predicted
+                )
             )
-        )
-        ols_executed = True
+            ols_executed = True
 
     if n_productive_samples == 0 and not fixture_scaffold_only:
         verdict = "OFFLINE_LINEAR_COST_MODEL_DIAGNOSTICS_V0_FAIL_CLOSED"

--- a/src/research/linear_evidence/fitters.py
+++ b/src/research/linear_evidence/fitters.py
@@ -136,6 +136,63 @@ def compute_ols_fit_precheck_v0(
     )
 
 
+def _blocked_constant_target_evidence_v0(
+    precheck: OlsFitPrecheckDiagnosticsV0,
+    binding: FeatureMatrixBindingV1,
+    *,
+    fit_intercept: bool,
+    validation_fraction: float,
+    evidence_type: str,
+    instrument_universe_digest: str,
+) -> LinearModelEvidenceV1:
+    has_co_degeneracy = bool(
+        precheck.zero_variance_feature_names or precheck.intercept_collinear_feature_names
+    )
+    status = "RANK_DEFICIENT_BLOCKED" if has_co_degeneracy else "INSUFFICIENT_DATA"
+    reasons = list(precheck.reason_codes)
+    if has_co_degeneracy and REASON_RANK_DEFICIENT_FEATURE_MATRIX not in reasons:
+        reasons.append(REASON_RANK_DEFICIENT_FEATURE_MATRIX)
+
+    diagnostics = LinearModelDiagnosticsV1(
+        rank=0,
+        condition_number=0.0,
+        rmse=0.0,
+        mae=0.0,
+        max_abs_error=0.0,
+        r2_train=0.0,
+        r2_validation=None,
+        residual_mean=0.0,
+        residual_std=0.0,
+        outlier_count=0,
+    )
+    return LinearModelEvidenceV1(
+        evidence_type=evidence_type,
+        model_family="OLS",
+        target_name=binding.target_name,
+        feature_names=binding.feature_names,
+        n_samples=binding.n_samples,
+        n_features=binding.n_features,
+        solver="numpy.linalg.lstsq",
+        fit_intercept=fit_intercept,
+        coefficients={},
+        diagnostics=diagnostics,
+        feature_matrix_digest=binding.feature_matrix_digest,
+        target_digest=binding.target_digest,
+        config_digest=_digest(
+            {"fit_intercept": fit_intercept, "validation_fraction": validation_fraction}
+        ),
+        time_range=binding.time_range,
+        instrument_universe_digest=instrument_universe_digest,
+        row_count_before_filter=binding.row_count_before_filter,
+        row_count_after_filter=binding.row_count_after_filter,
+        dropped_rows_by_reason=binding.dropped_rows_by_reason,
+        validation_policy=binding.validation_policy,
+        cost_policy_output="diagnostic_only",
+        status=status,
+        reason_codes=tuple(reasons),
+    )
+
+
 def fit_ols_lstsq(
     x: np.ndarray,
     y: np.ndarray,
@@ -159,6 +216,16 @@ def fit_ols_lstsq(
         binding.feature_names,
         fit_intercept=fit_intercept,
     )
+
+    if precheck.target_is_constant:
+        return _blocked_constant_target_evidence_v0(
+            precheck,
+            binding,
+            fit_intercept=fit_intercept,
+            validation_fraction=validation_fraction,
+            evidence_type=evidence_type,
+            instrument_universe_digest=instrument_universe_digest,
+        )
 
     n = x.shape[0]
     split = max(1, min(n - 1, int(round(n * (1.0 - validation_fraction)))))

--- a/tests/research/test_offline_linear_cost_model_diagnostics_fitter_zero_variance_constant_target_precheck_v0.py
+++ b/tests/research/test_offline_linear_cost_model_diagnostics_fitter_zero_variance_constant_target_precheck_v0.py
@@ -120,6 +120,53 @@ def _archive_inputs_available() -> bool:
     return LEDGER_PATH.is_file() and SNAPSHOT_PATH.is_file()
 
 
+def _fit_with_lstsq_spy(
+    x: np.ndarray,
+    y: np.ndarray,
+    binding: object,
+    **kwargs: object,
+) -> tuple[object, bool]:
+    import numpy.linalg as npla
+
+    called = False
+    original_lstsq = npla.lstsq
+
+    def _spy_lstsq(*args, **kwargs_inner):  # type: ignore[no-untyped-def]
+        nonlocal called
+        called = True
+        return original_lstsq(*args, **kwargs_inner)
+
+    npla.lstsq = _spy_lstsq
+    try:
+        evidence = fit_ols_lstsq(x, y, binding, **kwargs)
+    finally:
+        npla.lstsq = original_lstsq
+    return evidence, called
+
+
+def test_constant_target_blocks_before_solver_with_fail_closed_evidence() -> None:
+    x, y, binding = _binding(_rows(constant_target=True), ("spread_bps", "volatility_estimate"))
+    precheck = compute_ols_fit_precheck_v0(x, y, binding.feature_names)
+    evidence, lstsq_called = _fit_with_lstsq_spy(x, y, binding)
+
+    assert precheck.target_is_constant is True
+    assert lstsq_called is False
+    assert evidence.reason_codes[0] == REASON_CONSTANT_TARGET
+    assert evidence.status == "INSUFFICIENT_DATA"
+    assert evidence.coefficients == {}
+    assert evidence.diagnostics.rank == 0
+    assert evidence.diagnostics.condition_number == 0.0
+    assert evidence.authority_effect == "NONE"
+    assert evidence.runtime_effect == "NONE"
+
+
+def test_non_constant_target_still_calls_solver() -> None:
+    x, y, binding = _binding(_rows(), ("spread_bps", "volatility_estimate", "order_notional"))
+    _, lstsq_called = _fit_with_lstsq_spy(x, y, binding)
+
+    assert lstsq_called is True
+
+
 def test_constant_target_only_emits_constant_target_reason_code() -> None:
     x, y, binding = _binding(_rows(constant_target=True), ("spread_bps", "volatility_estimate"))
     precheck = compute_ols_fit_precheck_v0(x, y, binding.feature_names)
@@ -127,7 +174,8 @@ def test_constant_target_only_emits_constant_target_reason_code() -> None:
 
     assert precheck.target_is_constant is True
     assert evidence.reason_codes[0] == REASON_CONSTANT_TARGET
-    assert evidence.status == "CALIBRATION_CANDIDATE"
+    assert evidence.status == "INSUFFICIENT_DATA"
+    assert evidence.coefficients == {}
 
 
 def test_zero_variance_feature_without_intercept_emits_feature_reason_only() -> None:
@@ -266,6 +314,8 @@ def test_archive_fixture_digests_unchanged_and_precheck_reason_codes_present(
     report = json.loads((tmp_path / "offline_linear_cost_model_diagnostics_v0.json").read_text())
     assert report["materialization_digest"] == EXPECTED_MATERIALIZATION_DIGEST
     assert report["n_productive_samples"] == 219
+    assert report["ols_executed"] is False
+    assert report["calibration"] is None
 
     trade_rows = [
         json.loads(line)
@@ -301,11 +351,33 @@ def test_archive_fixture_digests_unchanged_and_precheck_reason_codes_present(
 
     assert binding.target_digest == EXPECTED_TARGET_DIGEST
     assert binding.feature_matrix_digest == EXPECTED_FEATURE_MATRIX_DIGEST
+    assert evidence.status == "RANK_DEFICIENT_BLOCKED"
+    assert evidence.coefficients == {}
     assert evidence.reason_codes == (
         REASON_CONSTANT_TARGET,
         f"{REASON_ZERO_VARIANCE_FEATURE}:spread_bps",
         f"{REASON_CONSTANT_FEATURE_COLLINEAR_WITH_INTERCEPT}:spread_bps",
         REASON_RANK_DEFICIENT_FEATURE_MATRIX,
     )
-    calibration = report["calibration"]
-    assert calibration["linear_model_evidence"]["reason_codes"] == list(evidence.reason_codes)
+
+
+@pytest.mark.skipif(not _archive_inputs_available(), reason="archive evidence unavailable")
+def test_archive_fixture_entry_point_skips_calibration_when_constant_target_blocked(
+    tmp_path: Path,
+) -> None:
+    result = _run_cli(
+        tmp_path,
+        extra_args=[
+            "--trade-ledger",
+            str(LEDGER_PATH),
+            "--entry-bar-snapshots",
+            str(SNAPSHOT_PATH),
+            "--repo-root",
+            str(REPO_ROOT),
+        ],
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads((tmp_path / "offline_linear_cost_model_diagnostics_v0.json").read_text())
+    assert report["ols_executed"] is False
+    assert report["calibration"] is None
+    assert "OLS_EXECUTED=false" in result.stdout


### PR DESCRIPTION
## Summary
- Add a pre-solver hard block in `fit_ols_lstsq` when `precheck.target_is_constant` is true, returning fail-closed evidence with existing statuses (`INSUFFICIENT_DATA` for constant-target-only, `RANK_DEFICIENT_BLOCKED` when co-degeneracy is present).
- Prevent `numpy.linalg.lstsq` from running on constant targets; blocked paths emit empty coefficients and zero diagnostics per drift precedent.
- Gate `offline_linear_cost_model_diagnostics_v0` so `ols_executed` and calibration only occur when the solver actually ran.

## Test plan
- [x] `pytest tests/research/test_offline_linear_cost_model_diagnostics_fitter_zero_variance_constant_target_precheck_v0.py`
- [x] `pytest tests/research/test_offline_linear_cost_model_diagnostics_v0.py`
- [x] lstsq spy proves no solver call for constant target
- [x] Archive fixture proves `ols_executed=false` and no calibration payload
- [ ] CI PR_BOUNDED_FULL checks (awaiting terminal snapshot)


Made with [Cursor](https://cursor.com)