### PR TITLE
feat(research): offline signal orthogonality diagnostics v0

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -191,23 +191,28 @@
         "src/research/linear_evidence/cost_model.py",
         "src/research/linear_evidence/diagnostics.py",
         "src/research/linear_evidence/fitters.py",
-        "scripts/research/offline_linear_cost_model_diagnostics_v0.py"
+        "scripts/research/offline_linear_cost_model_diagnostics_v0.py",
+        "scripts/research/offline_signal_orthogonality_diagnostics_v0.py"
       ],
       "path_globs": [
         "tests/research/test_offline_linear_cost_model_diagnostics_*",
+        "tests/research/test_offline_signal_orthogonality_diagnostics_*",
         "tests/research/test_linear_evidence_*"
       ]
     },
     "FEATURE_SCALING_OR_NUMERICAL_CONDITIONING_WITHOUT_TRADING_SEMANTIC_EFFECT": {
       "path_prefixes": [
         "src/research/linear_evidence/feature_matrix.py",
-        "src/research/linear_evidence/contracts.py"
+        "src/research/linear_evidence/contracts.py",
+        "src/research/linear_evidence/signal_orthogonality.py"
       ]
     },
     "REPORTING_AND_EVIDENCE_REPAIR": {
       "path_prefixes": [
         "scripts/ops/primary_evidence_retention_v0.py",
-        "scripts/ops/verify_pre_pr_validation_result_v0.py"
+        "scripts/ops/verify_pre_pr_validation_result_v0.py",
+        "scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py",
+        "tests/research/test_step29l2_import_boundary_classification_v0.py"
       ],
       "path_globs": [
         "scripts/ops/*evidence*",

--- a/scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py
+++ b/scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py
@@ -30,12 +30,14 @@ RESEARCH_SCRIPT_NAMES = (
     "offline_linear_cost_model_diagnostics_v0.py",
     "offline_parameter_sensitivity_surface_v0.py",
     "offline_rolling_linear_drift_diagnostics_v0.py",
+    "offline_signal_orthogonality_diagnostics_v0.py",
 )
 RESEARCH_TEST_NAMES = (
     "test_offline_factor_exposure_diagnostics_v0.py",
     "test_offline_linear_cost_model_diagnostics_v0.py",
     "test_offline_parameter_sensitivity_surface_v0.py",
     "test_offline_rolling_linear_drift_diagnostics_v0.py",
+    "test_offline_signal_orthogonality_diagnostics_v0.py",
 )
 
 
@@ -123,7 +125,9 @@ def _write_context(output_dir: Path, *, head: str, origin_main: str) -> None:
 
 
 def _write_surface_classification(output_dir: Path) -> None:
-    orthogonality_module = (REPO_ROOT / "src/research/linear_evidence/orthogonality.py").is_file()
+    orthogonality_module = (
+        REPO_ROOT / "src/research/linear_evidence/signal_orthogonality.py"
+    ).is_file()
     orthogonality_cli = (
         REPO_ROOT / "scripts/research/offline_signal_orthogonality_diagnostics_v0.py"
     ).is_file()
@@ -134,11 +138,12 @@ def _write_surface_classification(output_dir: Path) -> None:
     missing_clis: list[str] = []
     missing_tests: list[str] = []
     if not orthogonality_module:
-        missing_modules.extend(["orthogonality_module", "diagnostics"])
+        missing_modules.append("signal_orthogonality_module")
     if not orthogonality_cli:
         missing_clis.append("orthogonality_cli")
     if not orthogonality_tests:
         missing_tests.append("orthogonality_tests")
+    surface_complete = not missing_modules and not missing_clis and not missing_tests
     (output_dir / "classification.txt").write_text(
         "\n".join(
             [
@@ -148,9 +153,13 @@ def _write_surface_classification(output_dir: Path) -> None:
                 f"MISSING_REQUIRED_MODULES={','.join(missing_modules) if missing_modules else 'NONE'}",
                 f"MISSING_REQUIRED_CLIS={','.join(missing_clis) if missing_clis else 'NONE'}",
                 f"MISSING_REQUIRED_TESTS={','.join(missing_tests) if missing_tests else 'NONE'}",
-                "STEP29L2_SURFACE_STATUS=PARTIAL",
-                "NEXT_GAP_CLASS=MISSING_REQUIRED_DIAGNOSTIC_SURFACE",
-                f"MISSING_SURFACE={MISSING_SURFACE}",
+                f"STEP29L2_SURFACE_STATUS={'COMPLETE' if surface_complete else 'PARTIAL'}",
+                (
+                    "NEXT_GAP_CLASS=NONE"
+                    if surface_complete
+                    else "NEXT_GAP_CLASS=MISSING_REQUIRED_DIAGNOSTIC_SURFACE"
+                ),
+                f"MISSING_SURFACE={'NONE' if surface_complete else MISSING_SURFACE}",
             ]
         )
         + "\n",
@@ -200,6 +209,7 @@ def _write_final_report(
     origin_main: str,
     classification: dict[str, str | int | bool],
     manifest_verify_rc: int,
+    surface_complete: bool,
 ) -> None:
     (output_dir / "final_report.txt").write_text(
         "\n".join(
@@ -216,9 +226,13 @@ def _write_final_report(
                     "false_positive_docstring_ignored="
                     f"{str(classification['false_positive_docstring_ignored']).lower()}"
                 ),
-                "STEP29L2_SURFACE_STATUS=PARTIAL",
-                "NEXT_GAP_CLASS=MISSING_REQUIRED_DIAGNOSTIC_SURFACE",
-                f"MISSING_SURFACE={MISSING_SURFACE}",
+                f"STEP29L2_SURFACE_STATUS={'COMPLETE' if surface_complete else 'PARTIAL'}",
+                (
+                    "NEXT_GAP_CLASS=NONE"
+                    if surface_complete
+                    else "NEXT_GAP_CLASS=MISSING_REQUIRED_DIAGNOSTIC_SURFACE"
+                ),
+                f"MISSING_SURFACE={'NONE' if surface_complete else MISSING_SURFACE}",
                 f"MANIFEST_VERIFY_RC={manifest_verify_rc}",
             ]
         )
@@ -237,6 +251,9 @@ def run_classification(*, output_dir: Path, repo_root: Path | None = None) -> in
     _write_inventory(root, output_dir)
     _write_context(output_dir, head=head, origin_main=origin_main)
     _write_surface_classification(output_dir)
+    surface_complete = "STEP29L2_SURFACE_STATUS=COMPLETE" in (
+        output_dir / "classification.txt"
+    ).read_text(encoding="utf-8")
 
     scan_paths = _collect_scan_paths(root)
     hits, docstring_comment_probes = scan_paths_import_boundary(
@@ -260,6 +277,7 @@ def run_classification(*, output_dir: Path, repo_root: Path | None = None) -> in
         origin_main=origin_main,
         classification=boundary_classification,
         manifest_verify_rc=0,
+        surface_complete=surface_complete,
     )
 
     write_manifest_sha256(output_dir)
@@ -284,9 +302,13 @@ def run_classification(*, output_dir: Path, repo_root: Path | None = None) -> in
                     "false_positive_docstring_ignored="
                     f"{str(boundary_classification['false_positive_docstring_ignored']).lower()}"
                 ),
-                "STEP29L2_SURFACE_STATUS=PARTIAL",
-                "NEXT_GAP_CLASS=MISSING_REQUIRED_DIAGNOSTIC_SURFACE",
-                f"MISSING_SURFACE={MISSING_SURFACE}",
+                f"STEP29L2_SURFACE_STATUS={'COMPLETE' if surface_complete else 'PARTIAL'}",
+                (
+                    "NEXT_GAP_CLASS=NONE"
+                    if surface_complete
+                    else "NEXT_GAP_CLASS=MISSING_REQUIRED_DIAGNOSTIC_SURFACE"
+                ),
+                f"MISSING_SURFACE={'NONE' if surface_complete else MISSING_SURFACE}",
                 f"MANIFEST_VERIFY_RC={manifest_verify_rc}",
             ]
         )

--- a/scripts/research/offline_signal_orthogonality_diagnostics_v0.py
+++ b/scripts/research/offline_signal_orthogonality_diagnostics_v0.py
@@ -5,24 +5,56 @@ import csv
 import json
 import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-SRC_ROOT = REPO_ROOT / "src"
-if str(SRC_ROOT) not in sys.path:
-    sys.path.insert(0, str(SRC_ROOT))
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+_SCRIPT_PATH = Path(__file__).resolve()
 
-from research.linear_evidence.signal_orthogonality import (
+
+def discover_repo_root_from_script() -> Path | None:
+    for parent in [_SCRIPT_PATH, *_SCRIPT_PATH.parents]:
+        if (parent / "src").is_dir() and (parent / ".git").exists():
+            return parent.resolve()
+    return None
+
+
+def validate_peak_trade_repo_root(repo_root: Path) -> Path:
+    resolved = repo_root.expanduser().resolve()
+    if not resolved.is_dir():
+        raise SystemExit(f"REPO_ROOT_INVALID_NOT_DIRECTORY: {resolved}")
+    if not (resolved / "src").is_dir():
+        raise SystemExit(f"REPO_ROOT_INVALID_MISSING_SRC: {resolved}")
+    if not (resolved / ".git").exists():
+        raise SystemExit(f"REPO_ROOT_INVALID_MISSING_GIT: {resolved}")
+    return resolved
+
+
+def resolve_repo_root(explicit: Path | None) -> Path:
+    if explicit is not None:
+        return validate_peak_trade_repo_root(explicit)
+    discovered = discover_repo_root_from_script()
+    if discovered is None:
+        raise SystemExit("REPO_ROOT_DISCOVERY_FAILED: not inside Peak_Trade repo")
+    return discovered
+
+
+_discovered_repo_root = discover_repo_root_from_script()
+if _discovered_repo_root is not None:
+    repo_s = str(_discovered_repo_root)
+    if repo_s not in sys.path:
+        sys.path.insert(0, repo_s)
+
+from src.research.linear_evidence.signal_orthogonality import (  # noqa: E402
     SignalOrthogonalityConfigV1,
     analyze_signal_orthogonality,
     evidence_to_dict,
     make_deterministic_signal_fixture,
 )
 
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+DEFAULT_FEATURES = "trend_following,momentum_1h,bollinger_bands,liquidity_context"
 
-def _read_csv(path: Path, features: Tuple[str, ...]) -> List[Dict[str, object]]:
+
+def _read_csv(path: Path, features: tuple[str, ...]) -> list[dict[str, object]]:
     with path.open("r", encoding="utf-8", newline="") as handle:
         reader = csv.DictReader(handle)
         missing = [name for name in features if name not in (reader.fieldnames or [])]
@@ -34,54 +66,100 @@ def _read_csv(path: Path, features: Tuple[str, ...]) -> List[Dict[str, object]]:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Offline signal orthogonality diagnostics v0")
     parser.add_argument("--out", required=True)
-    parser.add_argument("--input-csv", default="")
-    parser.add_argument(
-        "--features", default="trend_following,momentum_1h,bollinger_bands,liquidity_context"
-    )
+    parser.add_argument("--input-csv", type=Path, default=None)
+    parser.add_argument("--features", default=DEFAULT_FEATURES)
     parser.add_argument("--correlation-threshold", type=float, default=0.85)
     parser.add_argument("--condition-number-threshold", type=float, default=1000.0)
     parser.add_argument("--min-samples", type=int, default=8)
+    parser.add_argument(
+        "--fixture-scaffold",
+        action="store_true",
+        help="Use deterministic fixture truth-pack when no productive binding is supplied.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Peak_Trade repo root; defaults to script discovery.",
+    )
     args = parser.parse_args()
 
+    repo_root = resolve_repo_root(args.repo_root)
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)
 
     features = tuple(name.strip() for name in args.features.split(",") if name.strip())
-    if args.input_csv:
-        rows = _read_csv(Path(args.input_csv), features)
-    else:
+    productive_binding_found = False
+    fixture_truth_pack_used = False
+
+    if args.input_csv is not None:
+        rows = _read_csv(args.input_csv, features)
+        productive_binding_found = True
+    elif args.fixture_scaffold or args.features == DEFAULT_FEATURES:
         rows, fixture_features = make_deterministic_signal_fixture()
-        if args.features == "trend_following,momentum_1h,bollinger_bands,liquidity_context":
+        if args.features == DEFAULT_FEATURES:
             features = fixture_features
+        fixture_truth_pack_used = True
+    else:
+        rows = []
+        fixture_truth_pack_used = False
 
     config = SignalOrthogonalityConfigV1(
         correlation_threshold=args.correlation_threshold,
         condition_number_threshold=args.condition_number_threshold,
         min_samples=args.min_samples,
     )
-    evidence = analyze_signal_orthogonality(rows, features, config=config)
+    evidence = analyze_signal_orthogonality(
+        rows,
+        features,
+        config=config,
+        productive_binding_gap=not productive_binding_found and not fixture_truth_pack_used,
+    )
     payload = evidence_to_dict(evidence)
+    payload.update(
+        {
+            "offline_only": True,
+            "runtime_authority": False,
+            "order_authority": False,
+            "promotion_pass_authority": False,
+            "strategy_selection_changed": False,
+            "economic_evaluation_executed": False,
+            "system_economic_evidence_admissible": False,
+            "runtime_rewire_admissible": False,
+            "productive_binding_found": productive_binding_found,
+            "fixture_truth_pack_used": fixture_truth_pack_used,
+            "repo_root": str(repo_root),
+            "signal_orthogonality_diagnostic_only": True,
+            "signal_orthogonality_does_not_prove_profitability": True,
+            "redundancy_does_not_delete_signal_automatically": True,
+            "redundancy_can_downweight_evidence_only": True,
+            "do_not_bind_signal_orthogonality_into_strategy_selection": True,
+        }
+    )
 
     report_json = out / "signal_orthogonality_evidence_v1.json"
     report_txt = out / "signal_orthogonality_report.txt"
     final_report = out / "final_report.txt"
 
-    report_json.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    report_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     report_txt.write_text(
         "\n".join(
             [
                 "VERDICT=OFFLINE_SIGNAL_ORTHOGONALITY_DIAGNOSTICS_V0_COLLECTED",
                 "STATUS=" + str(payload["status"]),
-                "AUTHORITY_EFFECT=" + str(payload["authority_effect"]),
-                "RUNTIME_EFFECT=" + str(payload["runtime_effect"]),
+                "AUTHORITY_EFFECT=" + AUTHORITY_EFFECT,
+                "RUNTIME_EFFECT=" + RUNTIME_EFFECT,
                 "OFFLINE_ONLY=true",
                 "NO_STRATEGY_SELECTION_EFFECT=true",
                 "NO_PROMOTION_PASS_AUTHORITY=true",
                 "NO_RUNTIME_REWIRE=true",
+                "PRODUCTIVE_BINDING_FOUND=" + str(productive_binding_found).lower(),
+                "FIXTURE_TRUTH_PACK_USED=" + str(fixture_truth_pack_used).lower(),
                 "REASON_CODES=" + ",".join(payload["reason_codes"]),
-                "REDUNDANT_PAIR_COUNT=" + str(len(payload["diagnostics"]["redundant_pairs"])),
-                "CONDITION_NUMBER=" + str(payload["diagnostics"]["condition_number"]),
-                "RANK=" + str(payload["diagnostics"]["rank"]),
+                "REDUNDANT_PAIR_COUNT="
+                + str(len(payload["diagnostics"].get("redundant_pairs", []))),
+                "DIAGNOSTICS_COMPUTED="
+                + str(payload["diagnostics"].get("computed", False)).lower(),
                 "",
             ]
         ),

--- a/src/research/linear_evidence/signal_orthogonality.py
+++ b/src/research/linear_evidence/signal_orthogonality.py
@@ -1,15 +1,37 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 from math import isfinite
 from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
 
 import numpy as np
 
+from .fitters import (
+    REASON_RANK_DEFICIENT_FEATURE_MATRIX,
+    REASON_ZERO_VARIANCE_FEATURE,
+)
 
-_ALLOWED_STATUS = "DIAGNOSTIC_ONLY"
+_ALLOWED_STATUSES = frozenset(
+    {
+        "DIAGNOSTIC_ONLY",
+        "INSUFFICIENT_DATA",
+        "RANK_DEFICIENT_BLOCKED",
+    }
+)
 _AUTHORITY_EFFECT = "NONE"
 _RUNTIME_EFFECT = "NONE"
+REASON_INSUFFICIENT_SAMPLE_COUNT = "INSUFFICIENT_SAMPLE_COUNT"
+REASON_SIGNAL_REDUNDANCY_REPORTED = "SIGNAL_REDUNDANCY_REPORTED"
+_REASON_INSUFFICIENT_SAMPLE_COUNT = REASON_INSUFFICIENT_SAMPLE_COUNT
+_REASON_SIGNAL_REDUNDANCY_REPORTED = REASON_SIGNAL_REDUNDANCY_REPORTED
+_REASON_HIGH_CONDITION_NUMBER = "HIGH_CONDITION_NUMBER"
+_REASON_TIME_ORDERING_FAILED = "TIME_ORDERING_FAILED"
+_REASON_LOOKAHEAD_BLOCKED = "LOOKAHEAD_BLOCKED"
+_REASON_PRODUCTIVE_BINDING_GAP = "PRODUCTIVE_BINDING_GAP"
+_DEFAULT_TIME_NAME = "decision_time"
+_DEFAULT_FEATURE_TIME_NAME = "feature_time"
 
 
 @dataclass(frozen=True)
@@ -25,6 +47,14 @@ class SignalOrthogonalityConfigV1:
             raise ValueError("condition_number_threshold must be positive")
         if self.min_samples < 3:
             raise ValueError("min_samples must be at least 3")
+
+
+@dataclass(frozen=True)
+class SignalOrthogonalityPrecheckV0:
+    target_is_constant: bool
+    zero_variance_feature_names: tuple[str, ...]
+    reason_codes: tuple[str, ...]
+    blocking: bool
 
 
 @dataclass(frozen=True)
@@ -55,12 +85,57 @@ class SignalOrthogonalityEvidenceV1:
     reason_codes: Tuple[str, ...]
 
 
+def _stable_digest(parts: Iterable[object]) -> str:
+    payload = json.dumps(list(parts), sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _sorted_unique_feature_names(feature_names: Sequence[str]) -> tuple[str, ...]:
+    names = tuple(sorted(str(name) for name in feature_names))
+    if not names:
+        raise ValueError("feature_names must not be empty")
+    if len(set(names)) != len(names):
+        raise ValueError("feature_names must be unique")
+    return names
+
+
+def _time_order_rows(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    time_name: str = _DEFAULT_TIME_NAME,
+) -> list[Mapping[str, object]]:
+    if not rows:
+        return []
+    ordered = sorted(rows, key=lambda row: str(row.get(time_name, "")))
+    times = [str(row.get(time_name, "")) for row in ordered]
+    if any(not value for value in times):
+        raise ValueError("TIME_BINDING_MISSING")
+    if times != sorted(times):
+        raise ValueError(_REASON_TIME_ORDERING_FAILED)
+    return list(ordered)
+
+
+def _assert_feature_time_before_target_time(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    feature_time_name: str = _DEFAULT_FEATURE_TIME_NAME,
+    target_time_name: str = _DEFAULT_TIME_NAME,
+) -> None:
+    for row in rows:
+        feature_time = row.get(feature_time_name)
+        target_time = row.get(target_time_name)
+        if feature_time is None or target_time is None:
+            continue
+        if str(feature_time) >= str(target_time):
+            raise ValueError(_REASON_LOOKAHEAD_BLOCKED)
+
+
 def _as_float_matrix(
     rows: Sequence[Mapping[str, object]], feature_names: Sequence[str]
-) -> Tuple[np.ndarray, List[int]]:
+) -> Tuple[np.ndarray, dict[str, int]]:
     matrix: List[List[float]] = []
-    dropped: List[int] = []
-    for idx, row in enumerate(rows):
+    dropped: dict[str, int] = {}
+    for row in rows:
         values: List[float] = []
         ok = True
         for name in feature_names:
@@ -68,26 +143,128 @@ def _as_float_matrix(
                 value = float(row[name])
             except (KeyError, TypeError, ValueError):
                 ok = False
+                dropped["missing_or_non_numeric_feature"] = (
+                    dropped.get("missing_or_non_numeric_feature", 0) + 1
+                )
                 break
             if not isfinite(value):
                 ok = False
+                dropped["non_finite_feature"] = dropped.get("non_finite_feature", 0) + 1
                 break
             values.append(value)
         if ok:
             matrix.append(values)
-        else:
-            dropped.append(idx)
     if not matrix:
         return np.empty((0, len(feature_names)), dtype=float), dropped
     return np.asarray(matrix, dtype=float), dropped
 
 
-def _stable_digest(parts: Iterable[object]) -> str:
-    import hashlib
-    import json
+def compute_signal_orthogonality_precheck_v0(
+    matrix: np.ndarray,
+    feature_names: Sequence[str],
+    *,
+    min_samples: int,
+) -> SignalOrthogonalityPrecheckV0:
+    reason_codes: list[str] = []
+    if matrix.shape[0] < min_samples:
+        reason_codes.append(_REASON_INSUFFICIENT_SAMPLE_COUNT)
 
-    payload = json.dumps(list(parts), sort_keys=True, separators=(",", ":"), default=str)
-    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    zero_variance_feature_names: list[str] = []
+    if matrix.size:
+        for index, name in enumerate(feature_names):
+            if float(np.var(matrix[:, index])) == 0.0:
+                zero_variance_feature_names.append(str(name))
+                reason_codes.append(f"{REASON_ZERO_VARIANCE_FEATURE}:{name}")
+
+    blocking = bool(matrix.shape[0] < min_samples or zero_variance_feature_names)
+    return SignalOrthogonalityPrecheckV0(
+        target_is_constant=False,
+        zero_variance_feature_names=tuple(sorted(zero_variance_feature_names)),
+        reason_codes=tuple(dict.fromkeys(reason_codes)),
+        blocking=blocking,
+    )
+
+
+def _validation_policy() -> dict[str, object]:
+    return {
+        "offline_only": True,
+        "validation_split": "not_applicable_for_unsupervised_orthogonality_diagnostic",
+        "random_split_allowed": False,
+        "lookahead_allowed": False,
+        "strategy_selection_effect": False,
+        "feature_time_less_than_target_time": True,
+        "time_ordered": True,
+    }
+
+
+def _blocked_diagnostics(*, computed: bool = False) -> dict[str, object]:
+    return {
+        "computed": computed,
+        "correlation_threshold": None,
+        "condition_number_threshold": None,
+        "rank": 0,
+        "condition_number": None,
+        "pairwise_correlation": {},
+        "redundant_pairs": [],
+        "vif_scores": {},
+        "sample_sufficiency": {"sufficient": False},
+        "interpretation": "diagnostic_only_redundancy_report_no_strategy_selection_effect",
+    }
+
+
+def _blocked_evidence(
+    *,
+    names: tuple[str, ...],
+    target_name: str,
+    matrix: np.ndarray,
+    rows: Sequence[Mapping[str, object]],
+    row_count_before: int,
+    dropped_rows: Mapping[str, int],
+    cfg: SignalOrthogonalityConfigV1,
+    precheck: SignalOrthogonalityPrecheckV0,
+    time_range: Mapping[str, object],
+    productive_binding_gap: bool,
+) -> SignalOrthogonalityEvidenceV1:
+    reasons = list(precheck.reason_codes)
+    if productive_binding_gap and _REASON_PRODUCTIVE_BINDING_GAP not in reasons:
+        reasons.append(_REASON_PRODUCTIVE_BINDING_GAP)
+    if precheck.zero_variance_feature_names and REASON_RANK_DEFICIENT_FEATURE_MATRIX not in reasons:
+        reasons.append(REASON_RANK_DEFICIENT_FEATURE_MATRIX)
+
+    status = "INSUFFICIENT_DATA"
+    if precheck.zero_variance_feature_names or REASON_RANK_DEFICIENT_FEATURE_MATRIX in reasons:
+        status = "RANK_DEFICIENT_BLOCKED"
+
+    return SignalOrthogonalityEvidenceV1(
+        evidence_type="SignalOrthogonalityEvidenceV1",
+        model_family="linear_diagnostics",
+        target_name=target_name,
+        feature_names=names,
+        n_samples=int(matrix.shape[0]),
+        n_features=len(names),
+        solver="numpy_correlation_lstsq_vif",
+        fit_intercept=True,
+        coefficients={},
+        diagnostics=_blocked_diagnostics(computed=False),
+        feature_matrix_digest=_stable_digest(
+            [{name: row.get(name) for name in names} for row in rows]
+        ),
+        target_digest=_stable_digest([target_name, "diagnostic_only"]),
+        config_digest=_stable_digest(
+            [cfg.correlation_threshold, cfg.condition_number_threshold, cfg.min_samples]
+        ),
+        time_range=time_range,
+        instrument_universe_digest=_stable_digest(["offline_signal_orthogonality", names]),
+        row_count_before_filter=row_count_before,
+        row_count_after_filter=int(matrix.shape[0]),
+        dropped_rows_by_reason=dict(dropped_rows),
+        validation_policy=_validation_policy(),
+        cost_policy_output="diagnostic_only",
+        status=status,
+        authority_effect=_AUTHORITY_EFFECT,
+        runtime_effect=_RUNTIME_EFFECT,
+        reason_codes=tuple(dict.fromkeys(reasons)),
+    )
 
 
 def _standardize(matrix: np.ndarray) -> np.ndarray:
@@ -180,40 +357,75 @@ def analyze_signal_orthogonality(
     feature_names: Sequence[str],
     target_name: str = "diagnostic_only_no_target",
     config: SignalOrthogonalityConfigV1 | None = None,
+    *,
+    time_name: str = _DEFAULT_TIME_NAME,
+    feature_time_name: str = _DEFAULT_FEATURE_TIME_NAME,
+    productive_binding_gap: bool = False,
 ) -> SignalOrthogonalityEvidenceV1:
     cfg = config or SignalOrthogonalityConfigV1()
     cfg.validate()
 
-    names = tuple(feature_names)
-    if not names:
-        raise ValueError("feature_names must not be empty")
-    if len(set(names)) != len(names):
-        raise ValueError("feature_names must be unique")
+    names = _sorted_unique_feature_names(feature_names)
+    ordered_rows = _time_order_rows(rows, time_name=time_name)
+    _assert_feature_time_before_target_time(
+        ordered_rows,
+        feature_time_name=feature_time_name,
+        target_time_name=time_name,
+    )
 
-    matrix, dropped = _as_float_matrix(rows, names)
     row_count_before = len(rows)
+    matrix, dropped = _as_float_matrix(ordered_rows, names)
     row_count_after = int(matrix.shape[0])
 
-    reason_codes: List[str] = []
-    if row_count_after < cfg.min_samples:
-        reason_codes.append("INSUFFICIENT_SAMPLE_COUNT")
+    time_range: Mapping[str, object]
+    if ordered_rows and time_name in ordered_rows[0]:
+        time_range = {
+            "start": str(ordered_rows[0][time_name]),
+            "end": str(ordered_rows[-1][time_name]),
+            "policy": "time_ordered_finalized_bar_bound",
+        }
+    else:
+        time_range = {"policy": "offline_fixture_or_input_rows", "target_shift": "not_applicable"}
+
+    precheck = compute_signal_orthogonality_precheck_v0(
+        matrix,
+        names,
+        min_samples=cfg.min_samples,
+    )
+    if precheck.blocking or productive_binding_gap:
+        return _blocked_evidence(
+            names=names,
+            target_name=target_name,
+            matrix=matrix,
+            rows=ordered_rows,
+            row_count_before=row_count_before,
+            dropped_rows=dropped,
+            cfg=cfg,
+            precheck=precheck,
+            time_range=time_range,
+            productive_binding_gap=productive_binding_gap,
+        )
 
     rank = _rank(matrix)
-    if rank < len(names):
-        reason_codes.append("RANK_DEFICIENT_FEATURE_MATRIX")
-
     condition_number = _condition_number(matrix)
-    if not isfinite(condition_number) or condition_number > cfg.condition_number_threshold:
-        reason_codes.append("HIGH_CONDITION_NUMBER")
-
     corr = _pairwise_correlations(names, matrix)
     redundant = _redundant_pairs(names, corr, cfg.correlation_threshold)
-    if redundant:
-        reason_codes.append("SIGNAL_REDUNDANCY_REPORTED")
-
     vif = _vif_scores(names, matrix)
 
+    reason_codes: list[str] = []
+    if rank < len(names):
+        reason_codes.append(REASON_RANK_DEFICIENT_FEATURE_MATRIX)
+    if not isfinite(condition_number) or condition_number > cfg.condition_number_threshold:
+        reason_codes.append(_REASON_HIGH_CONDITION_NUMBER)
+    if redundant:
+        reason_codes.append(_REASON_SIGNAL_REDUNDANCY_REPORTED)
+
+    status = "DIAGNOSTIC_ONLY"
+    if REASON_RANK_DEFICIENT_FEATURE_MATRIX in reason_codes:
+        status = "RANK_DEFICIENT_BLOCKED"
+
     diagnostics: Dict[str, object] = {
+        "computed": True,
         "correlation_threshold": cfg.correlation_threshold,
         "condition_number_threshold": cfg.condition_number_threshold,
         "rank": rank,
@@ -221,6 +433,11 @@ def analyze_signal_orthogonality(
         "pairwise_correlation": corr,
         "redundant_pairs": redundant,
         "vif_scores": vif,
+        "sample_sufficiency": {
+            "sufficient": row_count_after >= cfg.min_samples,
+            "min_samples": cfg.min_samples,
+            "actual_samples": row_count_after,
+        },
         "interpretation": "diagnostic_only_redundancy_report_no_strategy_selection_effect",
     }
 
@@ -233,29 +450,23 @@ def analyze_signal_orthogonality(
         n_features=len(names),
         solver="numpy_correlation_lstsq_vif",
         fit_intercept=True,
-        coefficients={name: 0.0 for name in names},
+        coefficients={},
         diagnostics=diagnostics,
         feature_matrix_digest=_stable_digest(
-            [{name: row.get(name) for name in names} for row in rows]
+            [{name: row.get(name) for name in names} for row in ordered_rows]
         ),
         target_digest=_stable_digest([target_name, "diagnostic_only"]),
         config_digest=_stable_digest(
             [cfg.correlation_threshold, cfg.condition_number_threshold, cfg.min_samples]
         ),
-        time_range={"policy": "offline_fixture_or_input_rows", "target_shift": "not_applicable"},
+        time_range=time_range,
         instrument_universe_digest=_stable_digest(["offline_signal_orthogonality", names]),
         row_count_before_filter=row_count_before,
         row_count_after_filter=row_count_after,
-        dropped_rows_by_reason={"non_finite_or_missing_feature": len(dropped)},
-        validation_policy={
-            "offline_only": True,
-            "validation_split": "not_applicable_for_unsupervised_orthogonality_diagnostic",
-            "random_split_allowed": False,
-            "lookahead_allowed": False,
-            "strategy_selection_effect": False,
-        },
+        dropped_rows_by_reason=dict(dropped),
+        validation_policy=_validation_policy(),
         cost_policy_output="diagnostic_only",
-        status=_ALLOWED_STATUS,
+        status=status,
         authority_effect=_AUTHORITY_EFFECT,
         runtime_effect=_RUNTIME_EFFECT,
         reason_codes=tuple(dict.fromkeys(reason_codes)),
@@ -271,13 +482,15 @@ def make_deterministic_signal_fixture() -> Tuple[List[Dict[str, float]], Tuple[s
         liquidity = float(10 + ((idx * 7) % 11))
         rows.append(
             {
+                "decision_time": f"2026-01-01T{idx + 1:02d}:00:00Z",
+                "feature_time": f"2026-01-01T{idx:02d}:00:00Z",
                 "trend_following": trend,
                 "momentum_1h": momentum,
                 "bollinger_bands": volatility,
                 "liquidity_context": liquidity,
             }
         )
-    return rows, ("trend_following", "momentum_1h", "bollinger_bands", "liquidity_context")
+    return rows, ("bollinger_bands", "liquidity_context", "momentum_1h", "trend_following")
 
 
 def evidence_to_dict(evidence: SignalOrthogonalityEvidenceV1) -> Dict[str, object]:

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -103,6 +103,13 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
                 "config/governance/economic_diagnostic_optimization_boundary_v0.json",
                 "tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py",
             ],
+            [
+                "src/research/linear_evidence/signal_orthogonality.py",
+                "scripts/research/offline_signal_orthogonality_diagnostics_v0.py",
+                "scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py",
+                "tests/research/test_offline_signal_orthogonality_diagnostics_v0.py",
+                "tests/research/test_step29l2_import_boundary_classification_v0.py",
+            ],
         ],
     )
     def test_positive_cases_admissible(self, changed_files: list[str]) -> None:
@@ -111,6 +118,30 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
         assert report.fail_closed is False
         assert forbidden_surface_changed_count(report) == 0
         assert report.canonical_trading_semantics_changed is False
+
+    def test_pr5157_offline_signal_orthogonality_surfaces_classified(self) -> None:
+        changed_files = [
+            "src/research/linear_evidence/signal_orthogonality.py",
+            "scripts/research/offline_signal_orthogonality_diagnostics_v0.py",
+            "scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py",
+            "tests/research/test_offline_signal_orthogonality_diagnostics_v0.py",
+            "tests/research/test_step29l2_import_boundary_classification_v0.py",
+        ]
+        report = build_boundary_report(changed_files, repo_root=REPO_ROOT)
+        assert report.admissible is True
+        assert report.economic_or_diagnostic_only is True
+        assert report.impact_unknown is False
+        assert "ALLOWED_OPTIMIZATION_SURFACE_ONLY" in report.reason_codes
+        assert forbidden_surface_changed_count(report) == 0
+        assert report.master_v2_changed is False
+        assert report.promotion_runtime_authority_changed is False
+        assert report.risk_sizing_changed is False
+        assert report.safety_killswitch_reconciliation_changed is False
+        assert set(report.allowed_surface_classification) >= {
+            "COST_MODEL_DIAGNOSTICS",
+            "FEATURE_SCALING_OR_NUMERICAL_CONDITIONING_WITHOUT_TRADING_SEMANTIC_EFFECT",
+            "REPORTING_AND_EVIDENCE_REPAIR",
+        }
 
 
 class TestEconomicDiagnosticOptimizationBoundaryGuardNegativeV0:
@@ -157,6 +188,15 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardNegativeV0:
         assert report.admissible is False
         assert report.impact_unknown is True
         assert "IMPACT_UNKNOWN_MUTATION_BLOCKED" in report.reason_codes
+
+    def test_no_directory_wide_research_exemption(self) -> None:
+        report = build_boundary_report(
+            ["src/research/unregistered_offline_diagnostic_owner_v0.py"],
+            repo_root=REPO_ROOT,
+        )
+        assert report.admissible is False
+        assert report.impact_unknown is True
+        assert forbidden_surface_changed_count(report) == 0
 
     def test_boundary_report_serializes_required_fields(self) -> None:
         report = build_boundary_report(

--- a/tests/research/test_offline_signal_orthogonality_diagnostics_v0.py
+++ b/tests/research/test_offline_signal_orthogonality_diagnostics_v0.py
@@ -5,72 +5,238 @@ import subprocess
 import sys
 from pathlib import Path
 
+import numpy as np
+import pytest
+
+from research.linear_evidence.fitters import (
+    REASON_CONSTANT_TARGET,
+    REASON_ZERO_VARIANCE_FEATURE,
+    fit_ols_lstsq,
+)
+from research.linear_evidence.feature_matrix import build_feature_matrix_binding
+from research.linear_evidence.import_boundary import scan_file_import_boundary
 from research.linear_evidence.signal_orthogonality import (
+    REASON_INSUFFICIENT_SAMPLE_COUNT,
+    REASON_SIGNAL_REDUNDANCY_REPORTED,
     SignalOrthogonalityConfigV1,
     analyze_signal_orthogonality,
+    compute_signal_orthogonality_precheck_v0,
     evidence_to_dict,
     make_deterministic_signal_fixture,
 )
+from research.offline_linear_cost_diagnostic_row_materializer_v0 import TARGET_NAME
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER = REPO_ROOT / "scripts/research/offline_signal_orthogonality_diagnostics_v0.py"
+OWNER = REPO_ROOT / "src/research/linear_evidence/signal_orthogonality.py"
 
 
-def test_signal_orthogonality_fixture_reports_redundancy_without_authority() -> None:
+def _rows(
+    *, constant_signal: str | None = None, zero_variance: str | None = None
+) -> list[dict[str, object]]:
+    out: list[dict[str, object]] = []
+    for idx in range(12):
+        row = {
+            "decision_time": f"2026-01-01T{idx + 1:02d}:00:00Z",
+            "feature_time": f"2026-01-01T{idx:02d}:00:00Z",
+            "alpha": float(idx + 1),
+            "beta": float((idx + 1) * 2),
+            "gamma": float((idx + 1) * 3 + (idx % 2)),
+        }
+        if constant_signal:
+            row[constant_signal] = 5.0
+        if zero_variance:
+            row[zero_variance] = 7.0
+        out.append(row)
+    return out
+
+
+def test_deterministic_feature_ordering_and_stable_digest() -> None:
+    rows, features = make_deterministic_signal_fixture()
+    shuffled = ("liquidity_context", "trend_following", "momentum_1h", "bollinger_bands")
+    first = analyze_signal_orthogonality(rows, shuffled)
+    second = analyze_signal_orthogonality(rows, features)
+
+    assert first.feature_names == second.feature_names == features
+    assert first.feature_matrix_digest == second.feature_matrix_digest
+    assert first.config_digest == second.config_digest
+
+
+def test_identical_repeated_output_and_second_run_diff_empty() -> None:
+    rows, features = make_deterministic_signal_fixture()
+    first = evidence_to_dict(analyze_signal_orthogonality(rows, features))
+    second = evidence_to_dict(analyze_signal_orthogonality(rows, features))
+    assert first == second
+
+
+def test_time_order_and_lookahead_guard() -> None:
+    rows = _rows()
+    rows[0] = {**rows[0], "decision_time": ""}
+    with pytest.raises(ValueError, match="TIME_BINDING_MISSING"):
+        analyze_signal_orthogonality(rows, ("alpha", "beta", "gamma"))
+
+    lookahead_rows = _rows()
+    lookahead_rows[3]["feature_time"] = lookahead_rows[3]["decision_time"]
+    with pytest.raises(ValueError, match="LOOKAHEAD_BLOCKED"):
+        analyze_signal_orthogonality(lookahead_rows, ("alpha", "beta", "gamma"))
+
+
+def test_constant_signal_pre_computation_block() -> None:
+    rows = _rows(constant_signal="alpha")
+    matrix = np.asarray(
+        [[float(row["alpha"]), float(row["beta"]), float(row["gamma"])] for row in rows]
+    )
+    precheck = compute_signal_orthogonality_precheck_v0(
+        matrix,
+        ("alpha", "beta", "gamma"),
+        min_samples=8,
+    )
+    evidence = analyze_signal_orthogonality(rows, ("gamma", "alpha", "beta"))
+
+    assert precheck.blocking is True
+    assert f"{REASON_ZERO_VARIANCE_FEATURE}:alpha" in evidence.reason_codes
+    assert evidence.coefficients == {}
+    assert evidence.diagnostics["computed"] is False
+    assert evidence.diagnostics["pairwise_correlation"] == {}
+
+
+def test_zero_variance_feature_block() -> None:
+    rows = _rows(zero_variance="beta")
+    evidence = analyze_signal_orthogonality(rows, ("alpha", "beta", "gamma"))
+
+    assert f"{REASON_ZERO_VARIANCE_FEATURE}:beta" in evidence.reason_codes
+    assert evidence.diagnostics["computed"] is False
+    assert evidence.diagnostics["vif_scores"] == {}
+
+
+def test_insufficient_sample_block() -> None:
+    rows = _rows()[:4]
+    evidence = analyze_signal_orthogonality(
+        rows,
+        ("alpha", "beta", "gamma"),
+        config=SignalOrthogonalityConfigV1(min_samples=8),
+    )
+
+    assert REASON_INSUFFICIENT_SAMPLE_COUNT in evidence.reason_codes
+    assert evidence.status == "INSUFFICIENT_DATA"
+    assert evidence.diagnostics["computed"] is False
+
+
+def test_pairwise_symmetry_and_diagonal_identity() -> None:
     rows, features = make_deterministic_signal_fixture()
     evidence = analyze_signal_orthogonality(
         rows,
         features,
         config=SignalOrthogonalityConfigV1(correlation_threshold=0.80),
     )
-    payload = evidence_to_dict(evidence)
-
-    assert payload["status"] == "DIAGNOSTIC_ONLY"
-    assert payload["authority_effect"] == "NONE"
-    assert payload["runtime_effect"] == "NONE"
-    assert payload["cost_policy_output"] == "diagnostic_only"
-    assert payload["validation_policy"]["strategy_selection_effect"] is False
-    assert "SIGNAL_REDUNDANCY_REPORTED" in payload["reason_codes"]
-    assert payload["diagnostics"]["redundant_pairs"]
+    corr = evidence.diagnostics["pairwise_correlation"]
+    assert isinstance(corr, dict)
+    for left, row in corr.items():
+        assert row[left] == pytest.approx(1.0)
+        for right, value in row.items():
+            assert corr[right][left] == pytest.approx(value)
 
 
-def test_signal_orthogonality_blocks_random_split_and_keeps_offline_policy() -> None:
+def test_finite_diagnostics_only_on_computed_path() -> None:
     rows, features = make_deterministic_signal_fixture()
     evidence = analyze_signal_orthogonality(rows, features)
-    payload = evidence_to_dict(evidence)
+    assert evidence.diagnostics["computed"] is True
+    assert np.isfinite(float(evidence.diagnostics["condition_number"]))
+    for row in evidence.diagnostics["pairwise_correlation"].values():
+        for value in row.values():
+            assert np.isfinite(value)
 
-    assert payload["validation_policy"]["offline_only"] is True
-    assert payload["validation_policy"]["random_split_allowed"] is False
-    assert payload["validation_policy"]["lookahead_allowed"] is False
+
+def test_stable_redundancy_classification() -> None:
+    rows, features = make_deterministic_signal_fixture()
+    evidence = analyze_signal_orthogonality(
+        rows,
+        features,
+        config=SignalOrthogonalityConfigV1(correlation_threshold=0.80),
+    )
+    assert REASON_SIGNAL_REDUNDANCY_REPORTED in evidence.reason_codes
+    assert evidence.diagnostics["redundant_pairs"]
 
 
-def test_signal_orthogonality_cli_writes_manifestable_report(tmp_path: Path) -> None:
-    script = Path("scripts/research/offline_signal_orthogonality_diagnostics_v0.py")
+def test_blocked_path_emits_no_fabricated_statistics() -> None:
+    rows = _rows(constant_signal="alpha")
+    evidence = analyze_signal_orthogonality(rows, ("alpha", "beta", "gamma"))
+    assert evidence.coefficients == {}
+    assert evidence.diagnostics["rank"] == 0
+    assert evidence.diagnostics["condition_number"] is None
+    assert evidence.diagnostics["redundant_pairs"] == []
+
+
+def test_authority_and_runtime_effects_none() -> None:
+    rows, features = make_deterministic_signal_fixture()
+    evidence = analyze_signal_orthogonality(rows, features)
+    assert evidence.authority_effect == "NONE"
+    assert evidence.runtime_effect == "NONE"
+    assert evidence.cost_policy_output == "diagnostic_only"
+    assert evidence.validation_policy["strategy_selection_effect"] is False
+
+
+def test_no_runtime_order_or_scheduler_imports_in_owner() -> None:
+    hits = scan_file_import_boundary(OWNER, repo_root=REPO_ROOT)
+    assert hits == []
+
+
+def test_real_production_owner_invoked_by_focused_test() -> None:
+    rows, features = make_deterministic_signal_fixture()
+    evidence = analyze_signal_orthogonality(rows, features)
+    assert evidence.evidence_type == "SignalOrthogonalityEvidenceV1"
+    assert evidence.status in {"DIAGNOSTIC_ONLY", "RANK_DEFICIENT_BLOCKED", "INSUFFICIENT_DATA"}
+
+
+def test_productive_binding_gap_fail_closed_without_fixture() -> None:
+    evidence = analyze_signal_orthogonality([], ("alpha", "beta"), productive_binding_gap=True)
+    assert "PRODUCTIVE_BINDING_GAP" in evidence.reason_codes
+    assert evidence.diagnostics["computed"] is False
+
+
+def test_cli_fixture_scaffold_writes_manifestable_report(tmp_path: Path) -> None:
     result = subprocess.run(
-        [sys.executable, str(script), "--out", str(tmp_path)],
-        check=True,
+        [
+            sys.executable,
+            str(RUNNER),
+            "--out",
+            str(tmp_path),
+            "--fixture-scaffold",
+            "--repo-root",
+            str(REPO_ROOT),
+        ],
+        check=False,
         text=True,
         capture_output=True,
+        cwd=str(REPO_ROOT),
     )
-
+    assert result.returncode == 0, result.stderr
     assert "VERDICT=OFFLINE_SIGNAL_ORTHOGONALITY_DIAGNOSTICS_V0_COLLECTED" in result.stdout
     payload = json.loads(
         (tmp_path / "signal_orthogonality_evidence_v1.json").read_text(encoding="utf-8")
     )
     assert payload["authority_effect"] == "NONE"
     assert payload["runtime_effect"] == "NONE"
+    assert payload["fixture_truth_pack_used"] is True
+    assert payload["productive_binding_found"] is False
 
 
-def test_signal_orthogonality_source_has_no_runtime_order_or_scheduler_imports() -> None:
-    source = Path("src/research/linear_evidence/signal_orthogonality.py").read_text(
-        encoding="utf-8"
-    )
-    forbidden = [
-        "src.live",
-        "src.execution",
-        "src.scheduler",
-        "live.",
-        "execution.",
-        "scheduler.",
-        "order_adapter",
-        "submit_order",
-        "cancel_order",
+def test_existing_cost_model_constant_target_behavior_remains_green() -> None:
+    rows = [
+        {
+            "decision_time": f"2026-01-01T{index:02d}:00:00Z",
+            "spread_bps": float(10 + index),
+            "volatility_estimate": float(0.01 + index * 0.001),
+            "order_notional": float(1000 + index * 10),
+            TARGET_NAME: 5.0,
+        }
+        for index in range(12)
     ]
-    assert not any(token in source for token in forbidden)
+    x, y, binding = build_feature_matrix_binding(
+        rows,
+        feature_names=("spread_bps", "volatility_estimate", "order_notional"),
+        target_name=TARGET_NAME,
+    )
+    evidence = fit_ols_lstsq(x, y, binding)
+    assert REASON_CONSTANT_TARGET in evidence.reason_codes
+    assert evidence.coefficients == {}

--- a/tests/research/test_step29l2_import_boundary_classification_v0.py
+++ b/tests/research/test_step29l2_import_boundary_classification_v0.py
@@ -107,15 +107,11 @@ def test_classification_runner_emits_expected_artifacts(tmp_path: Path) -> None:
     boundary_text = (tmp_path / "import_boundary_classification.txt").read_text(encoding="utf-8")
     assert "IMPORT_BOUNDARY_STATUS=PASS_DOCSTRING_FALSE_POSITIVE_IGNORED" in boundary_text
     assert "false_positive_docstring_ignored=true" in boundary_text
-    assert "STEP29L2_SURFACE_STATUS=PARTIAL" in (tmp_path / "classification.txt").read_text(
+    assert "STEP29L2_SURFACE_STATUS=COMPLETE" in (tmp_path / "classification.txt").read_text(
         encoding="utf-8"
     )
-    assert "MISSING_SURFACE=offline_signal_orthogonality_diagnostics_v0" in (
-        tmp_path / "classification.txt"
-    ).read_text(encoding="utf-8")
-    assert "NEXT_GAP_CLASS=MISSING_REQUIRED_DIAGNOSTIC_SURFACE" in (
-        tmp_path / "final_report.txt"
-    ).read_text(encoding="utf-8")
+    assert "MISSING_SURFACE=NONE" in (tmp_path / "classification.txt").read_text(encoding="utf-8")
+    assert "NEXT_GAP_CLASS=NONE" in (tmp_path / "final_report.txt").read_text(encoding="utf-8")
 
     ok, _msg = verify_manifest_sha256(tmp_path)
     assert ok


### PR DESCRIPTION
## Summary
- Vervollständigt den kanonischen Owner `src/research/linear_evidence/signal_orthogonality.py` mit fail-closed Prechecks (konstante/Zero-Variance-Signale, Sample-Sufficiency), Zeitordnung/Leakage-Guards und deterministischer Pairwise-/Rank-/Redundancy-Diagnostik ohne fabrizierte Statistiken auf geblockten Pfaden.
- Erweitert den dünnen Offline-Entry-Point `scripts/research/offline_signal_orthogonality_diagnostics_v0.py` um Repo-Root-Discovery, Fixture-Truth-Pack und produktiven Binding-Gap-Status.
- Ergänzt fokussierte Tests und markiert die STEP29L2-Oberfläche als COMPLETE in der bestehenden Classification.

## Test plan
- [x] `pytest tests/research/test_offline_signal_orthogonality_diagnostics_v0.py -q`
- [x] `pytest tests/research/test_step29l2_import_boundary_classification_v0.py -q`
- [x] `pytest tests/research/test_offline_linear_cost_model_diagnostics_fitter_zero_variance_constant_target_precheck_v0.py -q`
- [x] `ruff format --check` / `ruff check` auf geänderten Dateien
- [x] CI-Selector: `PR_BOUNDED_FULL` (central src)

## Scope / Safety
- Offline-only, `AUTHORITY_EFFECT=NONE`, `RUNTIME_EFFECT=NONE`
- Keine Trading-, Runtime-, Promotion- oder Economic-Evaluation-Mutation
- Evidence: `offline_signal_orthogonality_diagnostics_v0_implementation_20260713T143015Z`


Made with [Cursor](https://cursor.com)