### PR TITLE
feat(research): factor exposure precheck and boundary parity v0

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -192,11 +192,13 @@
         "src/research/linear_evidence/diagnostics.py",
         "src/research/linear_evidence/fitters.py",
         "scripts/research/offline_linear_cost_model_diagnostics_v0.py",
-        "scripts/research/offline_signal_orthogonality_diagnostics_v0.py"
+        "scripts/research/offline_signal_orthogonality_diagnostics_v0.py",
+        "scripts/research/offline_factor_exposure_diagnostics_v0.py"
       ],
       "path_globs": [
         "tests/research/test_offline_linear_cost_model_diagnostics_*",
         "tests/research/test_offline_signal_orthogonality_diagnostics_*",
+        "tests/research/test_offline_factor_exposure_diagnostics_*",
         "tests/research/test_linear_evidence_*"
       ]
     },
@@ -204,7 +206,8 @@
       "path_prefixes": [
         "src/research/linear_evidence/feature_matrix.py",
         "src/research/linear_evidence/contracts.py",
-        "src/research/linear_evidence/signal_orthogonality.py"
+        "src/research/linear_evidence/signal_orthogonality.py",
+        "src/research/linear_evidence/factor_exposure.py"
       ]
     },
     "REPORTING_AND_EVIDENCE_REPAIR": {

--- a/scripts/research/offline_factor_exposure_diagnostics_v0.py
+++ b/scripts/research/offline_factor_exposure_diagnostics_v0.py
@@ -3,110 +3,219 @@ from __future__ import annotations
 
 import argparse
 import json
-from pathlib import Path
 import sys
+from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(REPO_ROOT / "src"))
-sys.path.insert(0, str(REPO_ROOT))
-
-from research.linear_evidence.factor_exposure import FactorExposureInputV1, fit_factor_exposure
+_SCRIPT_PATH = Path(__file__).resolve()
 
 
-def _fixture_records():
-    return [
-        FactorExposureInputV1(
-            "PF_ETHUSD",
-            1,
-            0.010,
-            {"market_beta": 0.10, "liquidity_beta": 0.05, "volatility_beta": 0.20},
-        ),
-        FactorExposureInputV1(
-            "PF_ETHUSD",
-            2,
-            0.012,
-            {"market_beta": 0.11, "liquidity_beta": 0.04, "volatility_beta": 0.19},
-        ),
-        FactorExposureInputV1(
-            "PF_ETHUSD",
-            3,
-            0.009,
-            {"market_beta": 0.09, "liquidity_beta": 0.06, "volatility_beta": 0.21},
-        ),
-        FactorExposureInputV1(
-            "PF_SOLUSD",
-            4,
-            -0.004,
-            {"market_beta": -0.02, "liquidity_beta": 0.03, "volatility_beta": 0.25},
-        ),
-        FactorExposureInputV1(
-            "PF_SOLUSD",
-            5,
-            -0.006,
-            {"market_beta": -0.03, "liquidity_beta": 0.02, "volatility_beta": 0.26},
-        ),
-        FactorExposureInputV1(
-            "PF_SOLUSD",
-            6,
-            0.003,
-            {"market_beta": 0.04, "liquidity_beta": 0.08, "volatility_beta": 0.18},
-        ),
-        FactorExposureInputV1(
-            "PF_AVAXUSD",
-            7,
-            0.007,
-            {"market_beta": 0.08, "liquidity_beta": 0.07, "volatility_beta": 0.17},
-        ),
-        FactorExposureInputV1(
-            "PF_AVAXUSD",
-            8,
-            0.006,
-            {"market_beta": 0.07, "liquidity_beta": 0.07, "volatility_beta": 0.16},
-        ),
-        FactorExposureInputV1(
-            "PF_DOTUSD",
-            9,
-            -0.002,
-            {"market_beta": 0.01, "liquidity_beta": 0.01, "volatility_beta": 0.22},
-        ),
-        FactorExposureInputV1(
-            "PF_DOTUSD",
-            10,
-            0.001,
-            {"market_beta": 0.03, "liquidity_beta": 0.02, "volatility_beta": 0.20},
-        ),
+def discover_repo_root_from_script() -> Path | None:
+    for parent in [_SCRIPT_PATH, *_SCRIPT_PATH.parents]:
+        if (parent / "src").is_dir() and (parent / ".git").exists():
+            return parent.resolve()
+    return None
+
+
+def validate_peak_trade_repo_root(repo_root: Path) -> Path:
+    resolved = repo_root.expanduser().resolve()
+    if not resolved.is_dir():
+        raise SystemExit(f"REPO_ROOT_INVALID_NOT_DIRECTORY: {resolved}")
+    if not (resolved / "src").is_dir():
+        raise SystemExit(f"REPO_ROOT_INVALID_MISSING_SRC: {resolved}")
+    if not (resolved / ".git").exists():
+        raise SystemExit(f"REPO_ROOT_INVALID_MISSING_GIT: {resolved}")
+    return resolved
+
+
+def resolve_repo_root(explicit: Path | None) -> Path:
+    if explicit is not None:
+        return validate_peak_trade_repo_root(explicit)
+    discovered = discover_repo_root_from_script()
+    if discovered is None:
+        raise SystemExit("REPO_ROOT_DISCOVERY_FAILED: not inside Peak_Trade repo")
+    return discovered
+
+
+_discovered_repo_root = discover_repo_root_from_script()
+if _discovered_repo_root is not None:
+    repo_s = str(_discovered_repo_root)
+    if repo_s not in sys.path:
+        sys.path.insert(0, repo_s)
+
+from src.research.linear_evidence.factor_exposure import (  # noqa: E402
+    FactorExposureConfigV1,
+    FactorExposureInputV1,
+    fit_factor_exposure,
+    make_deterministic_factor_exposure_fixture,
+)
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+
+
+def _load_jsonl(path: Path) -> list[FactorExposureInputV1]:
+    records: list[FactorExposureInputV1] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        records.append(
+            FactorExposureInputV1(
+                instrument_id=str(payload["instrument_id"]),
+                timestamp=int(payload["timestamp"]),
+                target_return=float(payload["target_return"]),
+                factor_values=dict(payload["factor_values"]),
+                factor_time=payload.get("factor_time"),
+                decision_time=payload.get("decision_time"),
+            )
+        )
+    return records
+
+
+def _report_fields(
+    *,
+    evidence_dict: dict[str, object],
+    input_mode: str,
+    productive_binding_requested: bool,
+    productive_binding_resolved: bool,
+    fixture_scaffold_used: bool,
+) -> dict[str, object]:
+    diagnostics = dict(evidence_dict.get("diagnostics", {}))
+    corr = diagnostics.get("pairwise_correlation", {})
+    vif = diagnostics.get("vif_scores", {})
+    max_abs_corr = 0.0
+    if isinstance(corr, dict):
+        for left, row in corr.items():
+            if isinstance(row, dict):
+                for right, value in row.items():
+                    if left != right:
+                        max_abs_corr = max(max_abs_corr, abs(float(value)))
+    finite_vifs = [
+        float(value)
+        for value in vif.values()
+        if isinstance(value, (int, float)) and value != float("inf")
     ]
+    max_vif = max(finite_vifs) if finite_vifs else None
+    sample_sufficiency = diagnostics.get("sample_sufficiency", {})
+    return {
+        **evidence_dict,
+        "INPUT_MODE": input_mode,
+        "PRODUCTIVE_BINDING_REQUESTED": productive_binding_requested,
+        "PRODUCTIVE_BINDING_RESOLVED": productive_binding_resolved,
+        "FIXTURE_SCAFFOLD_USED": fixture_scaffold_used,
+        "FACTOR_TIME_LESS_THAN_DECISION_TIME": True,
+        "NO_LOOKAHEAD_PASS": "FACTOR_LOOKAHEAD_DETECTED"
+        not in evidence_dict.get("reason_codes", []),
+        "SAMPLE_SUFFICIENCY_PASS": bool(sample_sufficiency.get("sufficient", False))
+        if isinstance(sample_sufficiency, dict)
+        else False,
+        "ZERO_VARIANCE_FACTOR_COUNT": sum(
+            1
+            for code in evidence_dict.get("reason_codes", [])
+            if str(code).startswith("ZERO_VARIANCE_FACTOR")
+        ),
+        "PERFECT_COLLINEARITY_COUNT": diagnostics.get("perfect_collinearity_count", 0),
+        "MAX_ABS_PAIRWISE_CORRELATION": max_abs_corr,
+        "MAX_VIF": max_vif,
+        "CONDITION_NUMBER": diagnostics.get("condition_number"),
+        "FEATURE_ORDER_STABLE": True,
+        "FEATURE_MATRIX_DIGEST": evidence_dict.get("feature_matrix_digest"),
+        "TARGET_DIGEST": evidence_dict.get("target_digest"),
+        "CONFIG_DIGEST": evidence_dict.get("config_digest"),
+        "STATUS": evidence_dict.get("status"),
+        "REASON_CODES": evidence_dict.get("reason_codes"),
+        "offline_only": True,
+        "system_economic_evidence_admissible": False,
+        "runtime_rewire_admissible": False,
+        "promotion_pass_authority": False,
+        "strategy_selection_changed": False,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+    }
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="Offline factor exposure diagnostics v0")
     parser.add_argument("--out", required=True)
+    parser.add_argument("--input-jsonl", type=Path, default=None)
+    parser.add_argument("--fixture-scaffold", action="store_true")
+    parser.add_argument("--repo-root", type=Path, default=None)
+    parser.add_argument("--correlation-threshold", type=float, default=0.85)
+    parser.add_argument("--vif-threshold", type=float, default=10.0)
+    parser.add_argument("--condition-number-threshold", type=float, default=1000.0)
+    parser.add_argument("--min-samples", type=int, default=8)
     args = parser.parse_args()
 
+    repo_root = resolve_repo_root(args.repo_root)
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)
 
-    evidence = fit_factor_exposure(_fixture_records())
-    report = evidence.to_dict()
-    report.update(
-        {
-            "offline_only": True,
-            "system_economic_evidence_admissible": False,
-            "runtime_rewire_admissible": False,
-            "promotion_pass_authority": False,
-        }
-    )
+    productive_binding_requested = args.input_jsonl is not None
+    productive_binding_resolved = False
+    fixture_scaffold_used = False
+    input_mode = "UNBOUND"
 
-    (out / "factor_exposure_evidence_v1.json").write_text(
-        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.input_jsonl is not None:
+        records = _load_jsonl(args.input_jsonl)
+        productive_binding_resolved = bool(records)
+        input_mode = "PRODUCTIVE_BINDING"
+    elif args.fixture_scaffold:
+        records = make_deterministic_factor_exposure_fixture()
+        fixture_scaffold_used = True
+        input_mode = "FIXTURE_SCAFFOLD"
+    else:
+        records = []
+        input_mode = "UNBOUND"
+
+    config = FactorExposureConfigV1(
+        correlation_threshold=args.correlation_threshold,
+        vif_threshold=args.vif_threshold,
+        condition_number_threshold=args.condition_number_threshold,
+        min_samples=args.min_samples,
     )
-    print(f"STATUS={evidence.status}")
-    print("AUTHORITY_EFFECT=NONE")
-    print("RUNTIME_EFFECT=NONE")
-    print(f"REPORT={out / 'factor_exposure_evidence_v1.json'}")
+    evidence = fit_factor_exposure(
+        records,
+        config=config,
+        productive_binding_gap=productive_binding_requested and not productive_binding_resolved,
+        fixture_scaffold=fixture_scaffold_used,
+    )
+    payload = _report_fields(
+        evidence_dict=evidence.to_dict(),
+        input_mode=input_mode,
+        productive_binding_requested=productive_binding_requested,
+        productive_binding_resolved=productive_binding_resolved,
+        fixture_scaffold_used=fixture_scaffold_used,
+    )
+    payload["repo_root"] = str(repo_root)
+
+    report_json = out / "factor_exposure_evidence_v1.json"
+    report_txt = out / "factor_exposure_report.txt"
+    final_report = out / "final_report.txt"
+    report_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    report_txt.write_text(
+        "\n".join(
+            [
+                "VERDICT=OFFLINE_FACTOR_EXPOSURE_DIAGNOSTICS_V0_COLLECTED",
+                f"STATUS={payload['STATUS']}",
+                f"INPUT_MODE={payload['INPUT_MODE']}",
+                f"AUTHORITY_EFFECT={AUTHORITY_EFFECT}",
+                f"RUNTIME_EFFECT={RUNTIME_EFFECT}",
+                "OFFLINE_ONLY=true",
+                f"FIXTURE_SCAFFOLD_USED={str(fixture_scaffold_used).lower()}",
+                f"PRODUCTIVE_BINDING_RESOLVED={str(productive_binding_resolved).lower()}",
+                f"REASON_CODES={','.join(payload.get('REASON_CODES', []))}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    final_report.write_text(report_txt.read_text(encoding="utf-8"), encoding="utf-8")
+    print(final_report.read_text(encoding="utf-8"), end="")
     return (
         0
-        if evidence.status in {"DIAGNOSTIC_ONLY", "ROBUSTNESS_FAILED", "RANK_DEFICIENT_BLOCKED"}
+        if evidence.status
+        in {"DIAGNOSTIC_ONLY", "ROBUSTNESS_FAILED", "RANK_DEFICIENT_BLOCKED", "INSUFFICIENT_DATA"}
         else 1
     )
 

--- a/src/research/linear_evidence/factor_exposure.py
+++ b/src/research/linear_evidence/factor_exposure.py
@@ -1,12 +1,56 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
+import hashlib
 import json
 import math
-import hashlib
+from dataclasses import dataclass
+from math import isfinite
+from typing import Dict, List, Mapping, Sequence, Tuple
 
 import numpy as np
+
+from .fitters import REASON_ZERO_VARIANCE_FEATURE
+from .signal_orthogonality import (
+    _condition_number,
+    _pairwise_correlations,
+    _rank,
+    _redundant_pairs,
+    _vif_scores,
+)
+
+REASON_INSUFFICIENT_SAMPLE_COUNT = "INSUFFICIENT_SAMPLE_COUNT"
+REASON_FACTOR_TIME_BINDING_MISSING = "FACTOR_TIME_BINDING_MISSING"
+REASON_FACTOR_LOOKAHEAD_DETECTED = "FACTOR_LOOKAHEAD_DETECTED"
+REASON_NON_MONOTONIC_TIME_ORDER = "NON_MONOTONIC_TIME_ORDER"
+REASON_ZERO_VARIANCE_FACTOR = "ZERO_VARIANCE_FACTOR"
+REASON_PERFECT_COLLINEARITY_DETECTED = "PERFECT_COLLINEARITY_DETECTED"
+REASON_HIGH_PAIRWISE_CORRELATION = "HIGH_PAIRWISE_CORRELATION"
+REASON_HIGH_VIF = "HIGH_VIF"
+REASON_HIGH_CONDITION_NUMBER = "HIGH_CONDITION_NUMBER"
+REASON_PRODUCTIVE_BINDING_MISSING = "PRODUCTIVE_BINDING_MISSING"
+REASON_FIXTURE_SCAFFOLD_DIAGNOSTIC_ONLY = "FIXTURE_SCAFFOLD_DIAGNOSTIC_ONLY"
+REASON_RANK_DEFICIENT = "RANK_DEFICIENT_FEATURE_MATRIX"
+
+_AUTHORITY_EFFECT = "NONE"
+_RUNTIME_EFFECT = "NONE"
+
+
+@dataclass(frozen=True)
+class FactorExposureConfigV1:
+    correlation_threshold: float = 0.85
+    vif_threshold: float = 10.0
+    condition_number_threshold: float = 1000.0
+    min_samples: int = 8
+
+    def validate(self) -> None:
+        if not 0.0 < self.correlation_threshold < 1.0:
+            raise ValueError("correlation_threshold must be between 0 and 1")
+        if self.vif_threshold <= 0:
+            raise ValueError("vif_threshold must be positive")
+        if self.condition_number_threshold <= 0:
+            raise ValueError("condition_number_threshold must be positive")
+        if self.min_samples < 3:
+            raise ValueError("min_samples must be at least 3")
 
 
 @dataclass(frozen=True)
@@ -15,6 +59,25 @@ class FactorExposureInputV1:
     timestamp: int
     target_return: float
     factor_values: Mapping[str, float]
+    factor_time: str | None = None
+    decision_time: str | None = None
+
+    def resolved_factor_time(self) -> str:
+        if self.factor_time is not None:
+            return self.factor_time
+        return f"2026-01-01T{self.timestamp:02d}:00:00Z"
+
+    def resolved_decision_time(self) -> str:
+        if self.decision_time is not None:
+            return self.decision_time
+        return f"2026-01-01T{self.timestamp + 1:02d}:00:00Z"
+
+
+@dataclass(frozen=True)
+class FactorExposurePrecheckV0:
+    zero_variance_factor_names: tuple[str, ...]
+    reason_codes: tuple[str, ...]
+    blocking: bool
 
 
 @dataclass(frozen=True)
@@ -28,9 +91,10 @@ class FactorExposureEvidenceV1:
     solver: str
     fit_intercept: bool
     coefficients: Dict[str, float]
-    diagnostics: Dict[str, float]
+    diagnostics: Dict[str, object]
     feature_matrix_digest: str
     target_digest: str
+    config_digest: str
     validation_policy: str
     status: str
     reason_codes: Tuple[str, ...]
@@ -51,6 +115,7 @@ class FactorExposureEvidenceV1:
             "diagnostics": dict(self.diagnostics),
             "feature_matrix_digest": self.feature_matrix_digest,
             "target_digest": self.target_digest,
+            "config_digest": self.config_digest,
             "validation_policy": self.validation_policy,
             "status": self.status,
             "reason_codes": list(self.reason_codes),
@@ -64,23 +129,49 @@ def _stable_digest(payload: object) -> str:
     return hashlib.sha256(raw).hexdigest()
 
 
-def build_factor_matrix(
+def _sorted_unique_factor_names(factor_names: Sequence[str]) -> tuple[str, ...]:
+    names = tuple(sorted(str(name) for name in factor_names))
+    if not names:
+        raise ValueError("TARGET_BINDING_MISSING")
+    if len(set(names)) != len(names):
+        raise ValueError("FEATURE_SCHEMA_DRIFT")
+    return names
+
+
+def _validate_temporal_bindings(
     records: Sequence[FactorExposureInputV1],
-) -> Tuple[np.ndarray, np.ndarray, Tuple[str, ...], str, str]:
+) -> list[FactorExposureInputV1]:
     if not records:
         raise ValueError("INSUFFICIENT_DATA")
 
-    timestamps = [r.timestamp for r in records]
-    if timestamps != sorted(timestamps):
-        raise ValueError("RANDOM_VALIDATION_SPLIT_BLOCKED")
+    decision_times = [record.resolved_decision_time() for record in records]
+    if any(not value for value in decision_times):
+        raise ValueError(REASON_FACTOR_TIME_BINDING_MISSING)
+    if decision_times != sorted(decision_times):
+        raise ValueError(REASON_NON_MONOTONIC_TIME_ORDER)
 
-    feature_names = tuple(sorted(records[0].factor_values.keys()))
-    if not feature_names:
-        raise ValueError("TARGET_BINDING_MISSING")
+    ordered = sorted(records, key=lambda record: record.resolved_decision_time())
+
+    for record in ordered:
+        factor_time = record.resolved_factor_time()
+        decision_time = record.resolved_decision_time()
+        if not factor_time:
+            raise ValueError(REASON_FACTOR_TIME_BINDING_MISSING)
+        if factor_time >= decision_time:
+            raise ValueError(REASON_FACTOR_LOOKAHEAD_DETECTED)
+
+    return ordered
+
+
+def build_factor_matrix(
+    records: Sequence[FactorExposureInputV1],
+) -> Tuple[np.ndarray, np.ndarray, Tuple[str, ...], str, str]:
+    ordered = _validate_temporal_bindings(records)
+    feature_names = _sorted_unique_factor_names(ordered[0].factor_values.keys())
 
     rows: List[List[float]] = []
     targets: List[float] = []
-    for record in records:
+    for record in ordered:
         if tuple(sorted(record.factor_values.keys())) != feature_names:
             raise ValueError("FEATURE_SCHEMA_DRIFT")
         row = [float(record.factor_values[name]) for name in feature_names]
@@ -94,51 +185,198 @@ def build_factor_matrix(
     return x, y, feature_names, _stable_digest(rows), _stable_digest(targets)
 
 
+def compute_factor_exposure_precheck_v0(
+    matrix: np.ndarray,
+    factor_names: Sequence[str],
+    *,
+    min_samples: int,
+) -> FactorExposurePrecheckV0:
+    reason_codes: list[str] = []
+    if matrix.shape[0] < min_samples:
+        reason_codes.append(REASON_INSUFFICIENT_SAMPLE_COUNT)
+
+    zero_variance_factor_names: list[str] = []
+    if matrix.size:
+        for index, name in enumerate(factor_names):
+            if float(np.var(matrix[:, index])) == 0.0:
+                zero_variance_factor_names.append(str(name))
+                reason_codes.append(f"{REASON_ZERO_VARIANCE_FACTOR}:{name}")
+
+    blocking = bool(matrix.shape[0] < min_samples or zero_variance_factor_names)
+    return FactorExposurePrecheckV0(
+        zero_variance_factor_names=tuple(sorted(zero_variance_factor_names)),
+        reason_codes=tuple(dict.fromkeys(reason_codes)),
+        blocking=blocking,
+    )
+
+
+def _blocked_diagnostics(*, computed: bool = False) -> dict[str, object]:
+    return {
+        "computed": computed,
+        "rank": 0,
+        "condition_number": None,
+        "pairwise_correlation": {},
+        "redundant_pairs": [],
+        "vif_scores": {},
+        "perfect_collinearity_count": 0,
+        "sample_sufficiency": {"sufficient": False},
+    }
+
+
+def _blocked_evidence(
+    *,
+    factor_names: tuple[str, ...],
+    matrix: np.ndarray,
+    target_digest: str,
+    feature_matrix_digest: str,
+    cfg: FactorExposureConfigV1,
+    precheck: FactorExposurePrecheckV0,
+    extra_reasons: Sequence[str] = (),
+    productive_binding_gap: bool = False,
+    fixture_scaffold: bool = False,
+) -> FactorExposureEvidenceV1:
+    reasons = list(precheck.reason_codes)
+    reasons.extend(extra_reasons)
+    if productive_binding_gap and REASON_PRODUCTIVE_BINDING_MISSING not in reasons:
+        reasons.append(REASON_PRODUCTIVE_BINDING_MISSING)
+    if fixture_scaffold and REASON_FIXTURE_SCAFFOLD_DIAGNOSTIC_ONLY not in reasons:
+        reasons.append(REASON_FIXTURE_SCAFFOLD_DIAGNOSTIC_ONLY)
+    if precheck.zero_variance_factor_names and REASON_RANK_DEFICIENT not in reasons:
+        reasons.append(REASON_RANK_DEFICIENT)
+
+    status = "INSUFFICIENT_DATA"
+    if precheck.zero_variance_factor_names or REASON_PERFECT_COLLINEARITY_DETECTED in reasons:
+        status = "RANK_DEFICIENT_BLOCKED"
+    elif REASON_HIGH_CONDITION_NUMBER in reasons:
+        status = "RANK_DEFICIENT_BLOCKED"
+
+    return FactorExposureEvidenceV1(
+        evidence_type="factor_exposure",
+        model_family="ordinary_least_squares",
+        target_name="target_return",
+        feature_names=factor_names if factor_names else ("",),
+        n_samples=int(matrix.shape[0]),
+        n_features=len(factor_names) if factor_names else 0,
+        solver="numpy.linalg.lstsq",
+        fit_intercept=True,
+        coefficients={},
+        diagnostics=_blocked_diagnostics(computed=False),
+        feature_matrix_digest=feature_matrix_digest,
+        target_digest=target_digest,
+        config_digest=_stable_digest(
+            [
+                cfg.correlation_threshold,
+                cfg.vif_threshold,
+                cfg.condition_number_threshold,
+                cfg.min_samples,
+            ]
+        ),
+        validation_policy="time_ordered",
+        status=status,
+        reason_codes=tuple(dict.fromkeys(reasons)),
+        authority_effect=_AUTHORITY_EFFECT,
+        runtime_effect=_RUNTIME_EFFECT,
+    )
+
+
 def fit_factor_exposure(
     records: Sequence[FactorExposureInputV1],
     *,
-    min_samples: int = 8,
-    max_condition_number: float = 1_000_000.0,
+    config: FactorExposureConfigV1 | None = None,
+    productive_binding_gap: bool = False,
+    fixture_scaffold: bool = False,
+    min_samples: int | None = None,
+    max_condition_number: float | None = None,
 ) -> FactorExposureEvidenceV1:
-    x, y, feature_names, x_digest, y_digest = build_factor_matrix(records)
+    cfg = config or FactorExposureConfigV1()
+    if min_samples is not None:
+        cfg = FactorExposureConfigV1(
+            correlation_threshold=cfg.correlation_threshold,
+            vif_threshold=cfg.vif_threshold,
+            condition_number_threshold=max_condition_number or cfg.condition_number_threshold,
+            min_samples=min_samples,
+        )
+    elif max_condition_number is not None:
+        cfg = FactorExposureConfigV1(
+            correlation_threshold=cfg.correlation_threshold,
+            vif_threshold=cfg.vif_threshold,
+            condition_number_threshold=max_condition_number,
+            min_samples=cfg.min_samples,
+        )
+    cfg.validate()
+
+    if not records:
+        precheck = FactorExposurePrecheckV0(
+            zero_variance_factor_names=(),
+            reason_codes=(REASON_INSUFFICIENT_SAMPLE_COUNT,),
+            blocking=True,
+        )
+        return _blocked_evidence(
+            factor_names=(),
+            matrix=np.empty((0, 0), dtype=float),
+            target_digest=_stable_digest([]),
+            feature_matrix_digest=_stable_digest([]),
+            cfg=cfg,
+            precheck=precheck,
+            productive_binding_gap=productive_binding_gap,
+            fixture_scaffold=fixture_scaffold,
+        )
+
+    x, y, factor_names, x_digest, y_digest = build_factor_matrix(records)
     n_samples, n_features = x.shape
 
-    reason_codes: List[str] = []
-    if n_samples < min_samples:
-        return FactorExposureEvidenceV1(
-            evidence_type="factor_exposure",
-            model_family="ordinary_least_squares",
-            target_name="target_return",
-            feature_names=feature_names,
-            n_samples=n_samples,
-            n_features=n_features,
-            solver="numpy.linalg.lstsq",
-            fit_intercept=True,
-            coefficients={},
-            diagnostics={},
-            feature_matrix_digest=x_digest,
+    precheck = compute_factor_exposure_precheck_v0(x, factor_names, min_samples=cfg.min_samples)
+    if precheck.blocking or productive_binding_gap:
+        return _blocked_evidence(
+            factor_names=factor_names,
+            matrix=x,
             target_digest=y_digest,
-            validation_policy="time_ordered",
-            status="INSUFFICIENT_DATA",
-            reason_codes=("INSUFFICIENT_SAMPLE_COUNT",),
-            authority_effect="NONE",
-            runtime_effect="NONE",
+            feature_matrix_digest=x_digest,
+            cfg=cfg,
+            precheck=precheck,
+            productive_binding_gap=productive_binding_gap,
+            fixture_scaffold=fixture_scaffold,
+        )
+
+    rank = _rank(x)
+    condition_number = _condition_number(x)
+    corr = _pairwise_correlations(factor_names, x)
+    redundant = _redundant_pairs(factor_names, corr, cfg.correlation_threshold)
+    vif = _vif_scores(factor_names, x)
+
+    reason_codes: list[str] = []
+    perfect_collinearity_count = sum(1 for value in vif.values() if value == float("inf"))
+
+    if rank < len(factor_names):
+        reason_codes.append(REASON_PERFECT_COLLINEARITY_DETECTED)
+        reason_codes.append(REASON_RANK_DEFICIENT)
+    if perfect_collinearity_count:
+        reason_codes.append(REASON_PERFECT_COLLINEARITY_DETECTED)
+    if redundant:
+        reason_codes.append(REASON_HIGH_PAIRWISE_CORRELATION)
+    if any(value > cfg.vif_threshold for value in vif.values() if isfinite(value)):
+        reason_codes.append(REASON_HIGH_VIF)
+    if not isfinite(condition_number) or condition_number > cfg.condition_number_threshold:
+        reason_codes.append(REASON_HIGH_CONDITION_NUMBER)
+
+    if (
+        REASON_PERFECT_COLLINEARITY_DETECTED in reason_codes
+        or REASON_RANK_DEFICIENT in reason_codes
+        or REASON_HIGH_CONDITION_NUMBER in reason_codes
+    ):
+        return _blocked_evidence(
+            factor_names=factor_names,
+            matrix=x,
+            target_digest=y_digest,
+            feature_matrix_digest=x_digest,
+            cfg=cfg,
+            precheck=precheck,
+            extra_reasons=reason_codes,
+            fixture_scaffold=fixture_scaffold,
         )
 
     design = np.column_stack([np.ones(n_samples), x])
-    rank = int(np.linalg.matrix_rank(design))
-    condition_number = float(np.linalg.cond(design))
-
-    if rank < design.shape[1]:
-        status = "RANK_DEFICIENT_BLOCKED"
-        reason_codes.append("HIGH_CONDITION_NUMBER")
-    elif condition_number > max_condition_number:
-        status = "ROBUSTNESS_FAILED"
-        reason_codes.append("HIGH_CONDITION_NUMBER")
-    else:
-        status = "DIAGNOSTIC_ONLY"
-
-    beta, residuals, _, _ = np.linalg.lstsq(design, y, rcond=None)
+    beta, _, _, _ = np.linalg.lstsq(design, y, rcond=None)
     predictions = design @ beta
     errors = y - predictions
 
@@ -147,22 +385,36 @@ def fit_factor_exposure(
     r2 = 0.0 if ss_tot == 0.0 else float(1.0 - ss_res / ss_tot)
 
     coefficients = {"intercept": float(beta[0])}
-    coefficients.update({name: float(value) for name, value in zip(feature_names, beta[1:])})
+    coefficients.update({name: float(value) for name, value in zip(factor_names, beta[1:])})
 
-    diagnostics = {
-        "rank": float(rank),
+    diagnostics: dict[str, object] = {
+        "computed": True,
+        "rank": rank,
         "condition_number": condition_number,
+        "pairwise_correlation": corr,
+        "redundant_pairs": redundant,
+        "vif_scores": vif,
+        "perfect_collinearity_count": perfect_collinearity_count,
         "rmse": float(np.sqrt(np.mean(errors**2))),
         "mae": float(np.mean(np.abs(errors))),
         "r2": r2,
         "max_abs_error": float(np.max(np.abs(errors))),
+        "sample_sufficiency": {
+            "sufficient": n_samples >= cfg.min_samples,
+            "min_samples": cfg.min_samples,
+            "actual_samples": n_samples,
+        },
     }
+
+    final_reasons = list(reason_codes)
+    if fixture_scaffold:
+        final_reasons.append(REASON_FIXTURE_SCAFFOLD_DIAGNOSTIC_ONLY)
 
     return FactorExposureEvidenceV1(
         evidence_type="factor_exposure",
         model_family="ordinary_least_squares",
         target_name="target_return",
-        feature_names=feature_names,
+        feature_names=factor_names,
         n_samples=n_samples,
         n_features=n_features,
         solver="numpy.linalg.lstsq",
@@ -171,9 +423,95 @@ def fit_factor_exposure(
         diagnostics=diagnostics,
         feature_matrix_digest=x_digest,
         target_digest=y_digest,
+        config_digest=_stable_digest(
+            [
+                cfg.correlation_threshold,
+                cfg.vif_threshold,
+                cfg.condition_number_threshold,
+                cfg.min_samples,
+            ]
+        ),
         validation_policy="time_ordered",
-        status=status,
-        reason_codes=tuple(reason_codes),
-        authority_effect="NONE",
-        runtime_effect="NONE",
+        status="DIAGNOSTIC_ONLY",
+        reason_codes=tuple(dict.fromkeys(final_reasons)),
+        authority_effect=_AUTHORITY_EFFECT,
+        runtime_effect=_RUNTIME_EFFECT,
     )
+
+
+def make_deterministic_factor_exposure_fixture() -> list[FactorExposureInputV1]:
+    records: list[FactorExposureInputV1] = []
+    fixtures = [
+        (
+            "PF_ETHUSD",
+            1,
+            0.010,
+            {"market_beta": 0.10, "liquidity_beta": 0.05, "volatility_beta": 0.20},
+        ),
+        (
+            "PF_ETHUSD",
+            2,
+            0.012,
+            {"market_beta": 0.11, "liquidity_beta": 0.04, "volatility_beta": 0.19},
+        ),
+        (
+            "PF_ETHUSD",
+            3,
+            0.009,
+            {"market_beta": 0.09, "liquidity_beta": 0.06, "volatility_beta": 0.21},
+        ),
+        (
+            "PF_SOLUSD",
+            4,
+            -0.004,
+            {"market_beta": -0.02, "liquidity_beta": 0.03, "volatility_beta": 0.25},
+        ),
+        (
+            "PF_SOLUSD",
+            5,
+            -0.006,
+            {"market_beta": -0.03, "liquidity_beta": 0.02, "volatility_beta": 0.26},
+        ),
+        (
+            "PF_SOLUSD",
+            6,
+            0.003,
+            {"market_beta": 0.04, "liquidity_beta": 0.08, "volatility_beta": 0.18},
+        ),
+        (
+            "PF_AVAXUSD",
+            7,
+            0.007,
+            {"market_beta": 0.08, "liquidity_beta": 0.07, "volatility_beta": 0.17},
+        ),
+        (
+            "PF_AVAXUSD",
+            8,
+            0.006,
+            {"market_beta": 0.07, "liquidity_beta": 0.07, "volatility_beta": 0.16},
+        ),
+        (
+            "PF_DOTUSD",
+            9,
+            -0.002,
+            {"market_beta": 0.01, "liquidity_beta": 0.01, "volatility_beta": 0.22},
+        ),
+        (
+            "PF_DOTUSD",
+            10,
+            0.001,
+            {"market_beta": 0.03, "liquidity_beta": 0.02, "volatility_beta": 0.20},
+        ),
+    ]
+    for instrument_id, timestamp, target_return, factor_values in fixtures:
+        records.append(
+            FactorExposureInputV1(
+                instrument_id=instrument_id,
+                timestamp=timestamp,
+                target_return=target_return,
+                factor_values=factor_values,
+                factor_time=f"2026-01-01T{timestamp:02d}:00:00Z",
+                decision_time=f"2026-01-01T{timestamp + 1:02d}:00:00Z",
+            )
+        )
+    return records

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -143,6 +143,19 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
             "REPORTING_AND_EVIDENCE_REPAIR",
         }
 
+    def test_factor_exposure_parity_surfaces_classified(self) -> None:
+        changed_files = [
+            "src/research/linear_evidence/factor_exposure.py",
+            "scripts/research/offline_factor_exposure_diagnostics_v0.py",
+            "tests/research/test_offline_factor_exposure_diagnostics_v0.py",
+            "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+        ]
+        report = build_boundary_report(changed_files, repo_root=REPO_ROOT)
+        assert report.admissible is True
+        assert report.impact_unknown is False
+        assert "ALLOWED_OPTIMIZATION_SURFACE_ONLY" in report.reason_codes
+        assert forbidden_surface_changed_count(report) == 0
+
 
 class TestEconomicDiagnosticOptimizationBoundaryGuardNegativeV0:
     @pytest.mark.parametrize(

--- a/tests/research/test_offline_factor_exposure_diagnostics_v0.py
+++ b/tests/research/test_offline_factor_exposure_diagnostics_v0.py
@@ -5,69 +5,306 @@ import subprocess
 import sys
 from pathlib import Path
 
-from research.linear_evidence.factor_exposure import FactorExposureInputV1, fit_factor_exposure
+import numpy as np
+import pytest
+
+from research.linear_evidence.factor_exposure import (
+    REASON_FACTOR_LOOKAHEAD_DETECTED,
+    REASON_FACTOR_TIME_BINDING_MISSING,
+    REASON_FIXTURE_SCAFFOLD_DIAGNOSTIC_ONLY,
+    REASON_HIGH_CONDITION_NUMBER,
+    REASON_INSUFFICIENT_SAMPLE_COUNT,
+    REASON_NON_MONOTONIC_TIME_ORDER,
+    REASON_PERFECT_COLLINEARITY_DETECTED,
+    REASON_PRODUCTIVE_BINDING_MISSING,
+    REASON_ZERO_VARIANCE_FACTOR,
+    FactorExposureConfigV1,
+    FactorExposureInputV1,
+    build_factor_matrix,
+    fit_factor_exposure,
+    make_deterministic_factor_exposure_fixture,
+)
+from research.linear_evidence.import_boundary import scan_file_import_boundary
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER = REPO_ROOT / "scripts/research/offline_factor_exposure_diagnostics_v0.py"
+OWNER = REPO_ROOT / "src/research/linear_evidence/factor_exposure.py"
 
 
-def test_factor_exposure_is_authority_neutral() -> None:
-    records = [
+def _record(
+    *,
+    timestamp: int,
+    target_return: float | None = None,
+    factor_values: dict[str, float] | None = None,
+    factor_time: str | None = None,
+    decision_time: str | None = None,
+    instrument_id: str = "PF_ETHUSD",
+) -> FactorExposureInputV1:
+    return FactorExposureInputV1(
+        instrument_id=instrument_id,
+        timestamp=timestamp,
+        target_return=0.01 if target_return is None else target_return,
+        factor_values=factor_values
+        or {
+            "market_beta": float(timestamp) * 0.01,
+            "liquidity_beta": float(timestamp % 3) * 0.01,
+            "volatility_beta": float(timestamp % 5) * 0.01,
+        },
+        factor_time=factor_time,
+        decision_time=decision_time,
+    )
+
+
+def _records(count: int = 12) -> list[FactorExposureInputV1]:
+    return [_record(timestamp=i) for i in range(1, count + 1)]
+
+
+def test_fixture_truth_pack_runs_deterministically() -> None:
+    first = fit_factor_exposure(
+        make_deterministic_factor_exposure_fixture(),
+        fixture_scaffold=True,
+    )
+    second = fit_factor_exposure(
+        make_deterministic_factor_exposure_fixture(),
+        fixture_scaffold=True,
+    )
+    assert first.feature_matrix_digest == second.feature_matrix_digest
+    assert first.config_digest == second.config_digest
+    assert first.to_dict() == second.to_dict()
+
+
+def test_repeat_run_identical_digests() -> None:
+    records = _records()
+    first = fit_factor_exposure(records).to_dict()
+    second = fit_factor_exposure(records).to_dict()
+    assert first == second
+
+
+def test_stable_factor_ordering_independent_of_input_order() -> None:
+    records = _records()
+    shuffled_factors = [
         FactorExposureInputV1(
-            "PF_ETHUSD",
-            i,
-            float(i) * 0.001,
+            record.instrument_id,
+            record.timestamp,
+            record.target_return,
             {
-                "market_beta": float(i),
-                "liquidity_beta": float(i % 3),
-                "volatility_beta": float(i % 5),
+                "volatility_beta": record.factor_values["volatility_beta"],
+                "market_beta": record.factor_values["market_beta"],
+                "liquidity_beta": record.factor_values["liquidity_beta"],
+            },
+            factor_time=record.factor_time,
+            decision_time=record.decision_time,
+        )
+        for record in records
+    ]
+    first = fit_factor_exposure(records)
+    second = fit_factor_exposure(shuffled_factors)
+    assert (
+        first.feature_names
+        == second.feature_names
+        == (
+            "liquidity_beta",
+            "market_beta",
+            "volatility_beta",
+        )
+    )
+    assert first.feature_matrix_digest == second.feature_matrix_digest
+
+
+def test_factor_time_before_decision_time_accepted() -> None:
+    records = [
+        _record(
+            timestamp=1, factor_time="2026-01-01T01:00:00Z", decision_time="2026-01-01T02:00:00Z"
+        ),
+        _record(
+            timestamp=2, factor_time="2026-01-01T02:00:00Z", decision_time="2026-01-01T03:00:00Z"
+        ),
+        _record(
+            timestamp=3, factor_time="2026-01-01T03:00:00Z", decision_time="2026-01-01T04:00:00Z"
+        ),
+        _record(
+            timestamp=4, factor_time="2026-01-01T04:00:00Z", decision_time="2026-01-01T05:00:00Z"
+        ),
+        _record(
+            timestamp=5, factor_time="2026-01-01T05:00:00Z", decision_time="2026-01-01T06:00:00Z"
+        ),
+        _record(
+            timestamp=6, factor_time="2026-01-01T06:00:00Z", decision_time="2026-01-01T07:00:00Z"
+        ),
+        _record(
+            timestamp=7, factor_time="2026-01-01T07:00:00Z", decision_time="2026-01-01T08:00:00Z"
+        ),
+        _record(
+            timestamp=8, factor_time="2026-01-01T08:00:00Z", decision_time="2026-01-01T09:00:00Z"
+        ),
+    ]
+    evidence = fit_factor_exposure(records, config=FactorExposureConfigV1(min_samples=8))
+    assert evidence.status == "DIAGNOSTIC_ONLY"
+
+
+def test_equal_factor_and_decision_time_blocked() -> None:
+    records = _records(8)
+    records[3] = _record(
+        timestamp=4,
+        factor_time="2026-01-01T05:00:00Z",
+        decision_time="2026-01-01T05:00:00Z",
+    )
+    with pytest.raises(ValueError, match=REASON_FACTOR_LOOKAHEAD_DETECTED):
+        build_factor_matrix(records)
+
+
+def test_factor_time_after_decision_time_blocked() -> None:
+    records = _records(8)
+    records[3] = _record(
+        timestamp=4,
+        factor_time="2026-01-01T06:00:00Z",
+        decision_time="2026-01-01T05:00:00Z",
+    )
+    with pytest.raises(ValueError, match=REASON_FACTOR_LOOKAHEAD_DETECTED):
+        build_factor_matrix(records)
+
+
+def test_missing_factor_time_blocked() -> None:
+    record = _record(timestamp=1, factor_time="", decision_time="2026-01-01T02:00:00Z")
+    with pytest.raises(ValueError, match=REASON_FACTOR_TIME_BINDING_MISSING):
+        build_factor_matrix([record])
+
+
+def test_non_monotonic_time_order_blocked() -> None:
+    records = [
+        _record(
+            timestamp=2, factor_time="2026-01-01T02:00:00Z", decision_time="2026-01-01T03:00:00Z"
+        ),
+        _record(
+            timestamp=1, factor_time="2026-01-01T01:00:00Z", decision_time="2026-01-01T02:00:00Z"
+        ),
+    ]
+    with pytest.raises(ValueError, match=REASON_NON_MONOTONIC_TIME_ORDER):
+        build_factor_matrix(records)
+
+
+def test_zero_variance_blocked_before_fit() -> None:
+    records = [
+        _record(
+            timestamp=i,
+            factor_values={
+                "market_beta": 1.0,
+                "liquidity_beta": float(i),
+                "volatility_beta": float(i % 3),
             },
         )
         for i in range(1, 12)
     ]
-
     evidence = fit_factor_exposure(records)
+    assert any(str(code).startswith(REASON_ZERO_VARIANCE_FACTOR) for code in evidence.reason_codes)
+    assert evidence.coefficients == {}
+    assert evidence.diagnostics["computed"] is False
 
-    assert evidence.evidence_type == "factor_exposure"
+
+def test_perfect_collinearity_detected_deterministically() -> None:
+    records = [
+        _record(
+            timestamp=i,
+            factor_values={
+                "market_beta": float(i),
+                "liquidity_beta": float(i * 2),
+                "volatility_beta": float(i * 3),
+            },
+        )
+        for i in range(1, 12)
+    ]
+    evidence = fit_factor_exposure(records)
+    assert REASON_PERFECT_COLLINEARITY_DETECTED in evidence.reason_codes
+    assert evidence.coefficients == {}
+    assert evidence.diagnostics["computed"] is False
+
+
+def test_correlation_and_vif_computed_on_admissible_matrix() -> None:
+    records = _records()
+    evidence = fit_factor_exposure(records)
+    assert evidence.diagnostics["computed"] is True
+    assert evidence.diagnostics["pairwise_correlation"]
+    assert evidence.diagnostics["vif_scores"]
+
+
+def test_productive_binding_missing_fail_closed_without_fixture() -> None:
+    evidence = fit_factor_exposure([], productive_binding_gap=True)
+    assert REASON_PRODUCTIVE_BINDING_MISSING in evidence.reason_codes
+    assert evidence.diagnostics["computed"] is False
+
+
+def test_fixture_scaffold_explicit_diagnostic_only() -> None:
+    evidence = fit_factor_exposure(
+        make_deterministic_factor_exposure_fixture(),
+        fixture_scaffold=True,
+    )
+    assert REASON_FIXTURE_SCAFFOLD_DIAGNOSTIC_ONLY in evidence.reason_codes
+
+
+def test_authority_and_runtime_effects_none() -> None:
+    evidence = fit_factor_exposure(_records())
     assert evidence.authority_effect == "NONE"
     assert evidence.runtime_effect == "NONE"
-    assert evidence.solver == "numpy.linalg.lstsq"
-    assert evidence.validation_policy == "time_ordered"
-    assert evidence.status in {"DIAGNOSTIC_ONLY", "ROBUSTNESS_FAILED", "RANK_DEFICIENT_BLOCKED"}
 
 
-def test_factor_exposure_blocks_non_time_ordered_records() -> None:
-    records = [
-        FactorExposureInputV1("PF_ETHUSD", 2, 0.002, {"market_beta": 1.0}),
-        FactorExposureInputV1("PF_ETHUSD", 1, 0.001, {"market_beta": 2.0}),
-    ]
-
-    try:
-        fit_factor_exposure(records, min_samples=2)
-    except ValueError as exc:
-        assert str(exc) == "RANDOM_VALIDATION_SPLIT_BLOCKED"
-    else:
-        raise AssertionError("expected non-time-ordered records to fail closed")
+def test_insufficient_sample_count_blocks() -> None:
+    evidence = fit_factor_exposure(_records(4), config=FactorExposureConfigV1(min_samples=8))
+    assert REASON_INSUFFICIENT_SAMPLE_COUNT in evidence.reason_codes
 
 
-def test_factor_exposure_cli_writes_manifestable_report(tmp_path: Path) -> None:
+def test_no_runtime_order_or_scheduler_imports_in_owner() -> None:
+    hits = scan_file_import_boundary(OWNER, repo_root=REPO_ROOT)
+    assert hits == []
+
+
+def test_cli_fixture_scaffold_writes_manifestable_report(tmp_path: Path) -> None:
     result = subprocess.run(
         [
             sys.executable,
-            "scripts/research/offline_factor_exposure_diagnostics_v0.py",
+            str(RUNNER),
             "--out",
             str(tmp_path),
+            "--fixture-scaffold",
+            "--repo-root",
+            str(REPO_ROOT),
         ],
         check=False,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
+        cwd=str(REPO_ROOT),
     )
-
     assert result.returncode == 0, result.stderr
-    report_path = tmp_path / "factor_exposure_evidence_v1.json"
-    assert report_path.exists()
-    report = json.loads(report_path.read_text())
-    assert report["evidence_type"] == "factor_exposure"
-    assert report["authority_effect"] == "NONE"
-    assert report["runtime_effect"] == "NONE"
-    assert report["offline_only"] is True
-    assert report["system_economic_evidence_admissible"] is False
-    assert report["runtime_rewire_admissible"] is False
+    payload = json.loads(
+        (tmp_path / "factor_exposure_evidence_v1.json").read_text(encoding="utf-8")
+    )
+    assert payload["authority_effect"] == "NONE"
+    assert payload["runtime_effect"] == "NONE"
+    assert payload["FIXTURE_SCAFFOLD_USED"] is True
+    assert payload["INPUT_MODE"] == "FIXTURE_SCAFFOLD"
+
+
+def test_cli_productive_binding_requested_without_input_fail_closed(tmp_path: Path) -> None:
+    empty_input = tmp_path / "empty.jsonl"
+    empty_input.write_text("", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            "--out",
+            str(out_dir),
+            "--input-jsonl",
+            str(empty_input),
+            "--repo-root",
+            str(REPO_ROOT),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0
+    payload = json.loads((out_dir / "factor_exposure_evidence_v1.json").read_text(encoding="utf-8"))
+    assert payload["PRODUCTIVE_BINDING_REQUESTED"] is True
+    assert payload["PRODUCTIVE_BINDING_RESOLVED"] is False
+    assert "PRODUCTIVE_BINDING_MISSING" in payload["reason_codes"]


### PR DESCRIPTION
## Summary
- Extends `factor_exposure.py` with PR5157-parity temporal guards, fail-closed prechecks (sample sufficiency, zero-variance, collinearity, correlation, VIF, condition number), and deterministic digests.
- Extends `offline_factor_exposure_diagnostics_v0.py` with `--repo-root`, `--fixture-scaffold`, `--input-jsonl`, and explicit productive-vs-fixture reporting.
- Registers factor-exposure surfaces in the economic-diagnostic boundary owner map and adds focused regression tests.

## Test plan
- [x] `pytest tests/research/test_offline_factor_exposure_diagnostics_v0.py`
- [x] `pytest tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py`
- [x] `python scripts/ops/check_economic_diagnostic_optimization_boundary_guard_v0.py` on PR diff files
- [ ] CI terminal snapshot (read-only, no polling)


Made with [Cursor](https://cursor.com)