### PR TITLE
feat(research): productive factor exposure input join materializer v0

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -179,13 +179,15 @@
     "TARGET_BINDING_REPAIR": {
       "path_prefixes": [
         "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
+        "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
         "src/research/linear_evidence/feature_matrix.py",
         "src/research/linear_evidence/sensitivity.py",
         "src/research/linear_evidence/factor_exposure_productive_contract_v0.py"
       ],
       "path_globs": [
         "tests/research/test_offline_linear_cost_diagnostic_row_materializer_*",
-        "tests/research/test_offline_factor_exposure_productive_contract_v0.py"
+        "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
+        "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*"
       ]
     },
     "COST_MODEL_DIAGNOSTICS": {
@@ -194,15 +196,18 @@
         "src/research/linear_evidence/diagnostics.py",
         "src/research/linear_evidence/fitters.py",
         "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
+        "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
         "scripts/research/offline_linear_cost_model_diagnostics_v0.py",
         "scripts/research/offline_signal_orthogonality_diagnostics_v0.py",
-        "scripts/research/offline_factor_exposure_diagnostics_v0.py"
+        "scripts/research/offline_factor_exposure_diagnostics_v0.py",
+        "scripts/research/offline_factor_exposure_productive_input_join_materializer_v0.py"
       ],
       "path_globs": [
         "tests/research/test_offline_linear_cost_model_diagnostics_*",
         "tests/research/test_offline_signal_orthogonality_diagnostics_*",
         "tests/research/test_offline_factor_exposure_diagnostics_*",
         "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
+        "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
         "tests/research/test_linear_evidence_*"
       ]
     },
@@ -238,7 +243,8 @@
     },
     "DETERMINISTIC_MATERIALIZATION_REPAIR": {
       "path_prefixes": [
-        "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py"
+        "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
+        "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py"
       ]
     },
     "EXPLICITLY_CALIBRATABLE_RESEARCH_PARAMETERS_WITHIN_PREDECLARED_RANGES": {

--- a/scripts/research/offline_factor_exposure_diagnostics_v0.py
+++ b/scripts/research/offline_factor_exposure_diagnostics_v0.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 _SCRIPT_PATH = Path(__file__).resolve()
@@ -47,6 +48,10 @@ from src.research.linear_evidence.factor_exposure import (  # noqa: E402
     FactorExposureInputV1,
     fit_factor_exposure,
     make_deterministic_factor_exposure_fixture,
+)
+from src.research.offline_factor_exposure_productive_input_join_materializer_v0 import (  # noqa: E402
+    MaterializationStatus,
+    materialize_from_manifest_paths_v0,
 )
 
 AUTHORITY_EFFECT = "NONE"
@@ -139,6 +144,8 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Offline factor exposure diagnostics v0")
     parser.add_argument("--out", required=True)
     parser.add_argument("--input-jsonl", type=Path, default=None)
+    parser.add_argument("--trade-ledger", type=Path, default=None)
+    parser.add_argument("--factor-snapshots", type=Path, default=None)
     parser.add_argument("--fixture-scaffold", action="store_true")
     parser.add_argument("--repo-root", type=Path, default=None)
     parser.add_argument("--correlation-threshold", type=float, default=0.85)
@@ -151,12 +158,34 @@ def main() -> int:
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)
 
-    productive_binding_requested = args.input_jsonl is not None
+    productive_binding_requested = (
+        args.input_jsonl is not None
+        or args.trade_ledger is not None
+        or args.factor_snapshots is not None
+    )
     productive_binding_resolved = False
     fixture_scaffold_used = False
     input_mode = "UNBOUND"
+    materialization_status: str | None = None
+    materialization_digest: str | None = None
+    productive_provenance = None
 
-    if args.input_jsonl is not None:
+    if args.trade_ledger is not None or args.factor_snapshots is not None:
+        if args.trade_ledger is None or args.factor_snapshots is None:
+            raise SystemExit(
+                "PRODUCTIVE_JOIN_BINDING_INCOMPLETE: both --trade-ledger and --factor-snapshots required"
+            )
+        materialization = materialize_from_manifest_paths_v0(
+            trade_ledger_path=args.trade_ledger,
+            factor_snapshot_path=args.factor_snapshots,
+        )
+        records = list(materialization.records)
+        productive_binding_resolved = bool(records)
+        input_mode = "PRODUCTIVE_JOIN_MATERIALIZED"
+        materialization_status = materialization.status.value
+        materialization_digest = materialization.materialization_digest
+        productive_provenance = materialization.provenance
+    elif args.input_jsonl is not None:
         records = _load_jsonl(args.input_jsonl)
         productive_binding_resolved = bool(records)
         input_mode = "PRODUCTIVE_BINDING"
@@ -180,6 +209,8 @@ def main() -> int:
         productive_binding_gap=productive_binding_requested and not productive_binding_resolved,
         fixture_scaffold=fixture_scaffold_used,
     )
+    if productive_provenance is not None:
+        evidence = replace(evidence, productive_provenance=productive_provenance)
     payload = _report_fields(
         evidence_dict=evidence.to_dict(),
         input_mode=input_mode,
@@ -188,6 +219,12 @@ def main() -> int:
         fixture_scaffold_used=fixture_scaffold_used,
     )
     payload["repo_root"] = str(repo_root)
+    if materialization_status is not None:
+        payload["MATERIALIZATION_STATUS"] = materialization_status
+        payload["MATERIALIZATION_DIGEST"] = materialization_digest
+        payload["PRODUCTIVE_JOIN_MATERIALIZER_PASS"] = (
+            materialization_status == MaterializationStatus.PASS.value
+        )
 
     report_json = out / "factor_exposure_evidence_v1.json"
     report_txt = out / "factor_exposure_report.txt"

--- a/scripts/research/offline_factor_exposure_productive_input_join_materializer_v0.py
+++ b/scripts/research/offline_factor_exposure_productive_input_join_materializer_v0.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve()
+
+
+def discover_repo_root_from_script() -> Path | None:
+    for parent in [_SCRIPT_PATH, *_SCRIPT_PATH.parents]:
+        if (parent / "src").is_dir() and (parent / ".git").exists():
+            return parent.resolve()
+    return None
+
+
+def validate_peak_trade_repo_root(repo_root: Path) -> Path:
+    resolved = repo_root.expanduser().resolve()
+    if not resolved.is_dir():
+        raise SystemExit(f"REPO_ROOT_INVALID_NOT_DIRECTORY: {resolved}")
+    if not (resolved / "src").is_dir():
+        raise SystemExit(f"REPO_ROOT_INVALID_MISSING_SRC: {resolved}")
+    if not (resolved / ".git").exists():
+        raise SystemExit(f"REPO_ROOT_INVALID_MISSING_GIT: {resolved}")
+    return resolved
+
+
+def resolve_repo_root(explicit: Path | None) -> Path:
+    if explicit is not None:
+        return validate_peak_trade_repo_root(explicit)
+    discovered = discover_repo_root_from_script()
+    if discovered is None:
+        raise SystemExit("REPO_ROOT_DISCOVERY_FAILED: not inside Peak_Trade repo")
+    return discovered
+
+
+_discovered_repo_root = discover_repo_root_from_script()
+if _discovered_repo_root is not None:
+    repo_s = str(_discovered_repo_root)
+    if repo_s not in sys.path:
+        sys.path.insert(0, repo_s)
+
+from src.research.offline_factor_exposure_productive_input_join_materializer_v0 import (  # noqa: E402
+    AUTHORITY_EFFECT,
+    CANONICAL_JOIN_KEY,
+    RUNTIME_EFFECT,
+    SECONDARY_INTEGRITY_KEY,
+    materialize_from_manifest_paths_v0,
+    serialize_materialized_productive_inputs_v0,
+)
+
+AUTHORITY_EFFECT = AUTHORITY_EFFECT
+RUNTIME_EFFECT = RUNTIME_EFFECT
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Offline factor exposure productive input join materializer v0"
+    )
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--trade-ledger", required=True, type=Path)
+    parser.add_argument("--factor-snapshots", required=True, type=Path)
+    parser.add_argument("--repo-root", type=Path, default=None)
+    args = parser.parse_args()
+
+    repo_root = resolve_repo_root(args.repo_root)
+    out = args.out
+    out.mkdir(parents=True, exist_ok=True)
+
+    result = materialize_from_manifest_paths_v0(
+        trade_ledger_path=args.trade_ledger,
+        factor_snapshot_path=args.factor_snapshots,
+    )
+    serialized = serialize_materialized_productive_inputs_v0(result.records)
+    (out / "productive_factor_exposure_inputs.jsonl").write_text(serialized, encoding="utf-8")
+    (out / "materialization_report.json").write_text(
+        json.dumps(
+            {
+                "status": result.status.value,
+                "materialization_digest": result.materialization_digest,
+                "output_digest": result.output_digest,
+                "source_trade_ledger_digest": result.source_trade_ledger_digest,
+                "source_factor_snapshot_digest": result.source_factor_snapshot_digest,
+                "row_count_before_filter": result.join_result.row_count_before_filter,
+                "row_count_after_filter": result.join_result.row_count_after_filter,
+                "dropped_rows_by_reason": dict(result.join_result.dropped_rows_by_reason),
+                "join_keys": {
+                    "primary": CANONICAL_JOIN_KEY,
+                    "secondary_integrity": SECONDARY_INTEGRITY_KEY,
+                },
+                "provenance": result.provenance.to_dict(),
+                "authority_effect": AUTHORITY_EFFECT,
+                "runtime_effect": RUNTIME_EFFECT,
+                "offline_only": True,
+                "repo_root": str(repo_root),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    final_report = "\n".join(
+        [
+            "VERDICT=OFFLINE_FACTOR_EXPOSURE_PRODUCTIVE_INPUT_JOIN_MATERIALIZATION_V0_COLLECTED",
+            f"STATUS={result.status.value}",
+            f"ROW_COUNT_BEFORE_JOIN={result.join_result.row_count_before_filter}",
+            f"ROW_COUNT_AFTER_JOIN={result.join_result.row_count_after_filter}",
+            f"DROPPED_ROWS_BY_REASON={json.dumps(result.join_result.dropped_rows_by_reason, sort_keys=True)}",
+            f"OUTPUT_DIGEST={result.output_digest}",
+            f"MATERIALIZATION_DIGEST={result.materialization_digest}",
+            f"PRIMARY_JOIN_KEY={CANONICAL_JOIN_KEY}",
+            f"SECONDARY_INTEGRITY_KEY={SECONDARY_INTEGRITY_KEY}",
+            f"AUTHORITY_EFFECT={AUTHORITY_EFFECT}",
+            f"RUNTIME_EFFECT={RUNTIME_EFFECT}",
+            "OFFLINE_ONLY=true",
+            "",
+        ]
+    )
+    (out / "final_report.txt").write_text(final_report, encoding="utf-8")
+    print(final_report, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/offline_factor_exposure_productive_input_join_materializer_v0.py
+++ b/src/research/offline_factor_exposure_productive_input_join_materializer_v0.py
@@ -1,0 +1,273 @@
+"""Offline factor exposure productive input join materializer v0.
+
+Deterministic, offline-only join of manifest-verified TRADE_LEDGER_V1 rows to
+factor snapshot rows via the operator-ratified productive contract v0. Reuses
+``validate_productive_join_batch_v0`` as the sole join owner. No OLS, economic
+evaluation, runtime, order, scheduler, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.research.linear_evidence.factor_exposure import FactorExposureInputV1
+from src.research.linear_evidence.factor_exposure_productive_contract_v0 import (
+    AUTHORITY_EFFECT,
+    EXPECTED_DATASET_DIGEST,
+    EXPECTED_PRODUCTIVE_FACTOR_ORDER,
+    FactorExposureJoinContractV0,
+    FactorExposureProductiveProvenanceV0,
+    ProductiveInputRowV0,
+    ProductiveJoinValidationResultV0,
+    RUNTIME_EFFECT,
+    TARGET_NAME,
+    stable_digest_v0,
+    validate_dataset_digest_v0,
+    validate_productive_join_batch_v0,
+)
+
+PACKAGE_MARKER = "OFFLINE_FACTOR_EXPOSURE_PRODUCTIVE_INPUT_JOIN_MATERIALIZER_V0=true"
+SCHEMA_VERSION = "offline_factor_exposure_productive_input_join_materializer.v0"
+CANONICAL_CONTRACT_OWNER = "src/research/linear_evidence/factor_exposure_productive_contract_v0.py"
+CANONICAL_JOIN_KEY = FactorExposureJoinContractV0().primary_join_key
+SECONDARY_INTEGRITY_KEY = FactorExposureJoinContractV0().secondary_integrity_key
+IMPLEMENTATION_DIGEST = stable_digest_v0(
+    {
+        "contract": SCHEMA_VERSION,
+        "join_owner": CANONICAL_CONTRACT_OWNER,
+        "join_key": CANONICAL_JOIN_KEY,
+        "secondary_integrity_key": SECONDARY_INTEGRITY_KEY,
+    }
+)
+
+
+class MaterializationStatus(str, Enum):
+    PASS = "PASS"
+    INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
+    TARGET_BINDING_MISSING = "TARGET_BINDING_MISSING"
+
+
+@dataclass(frozen=True)
+class MaterializationResultV0:
+    status: MaterializationStatus
+    records: tuple[FactorExposureInputV1, ...]
+    join_result: ProductiveJoinValidationResultV0
+    provenance: FactorExposureProductiveProvenanceV0
+    materialization_digest: str
+    output_digest: str
+    source_trade_ledger_digest: str
+    source_factor_snapshot_digest: str
+    authority_effect: str = AUTHORITY_EFFECT
+    runtime_effect: str = RUNTIME_EFFECT
+
+
+def load_jsonl_rows(path: Path) -> tuple[dict[str, Any], ...]:
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        payload = json.loads(stripped)
+        if not isinstance(payload, dict):
+            raise ValueError("JSONL_ROW_NOT_OBJECT")
+        rows.append(payload)
+    return tuple(rows)
+
+
+def compute_source_rows_digest(rows: Sequence[Mapping[str, Any]]) -> str:
+    ordered = sorted(
+        rows,
+        key=lambda row: json.dumps(row, sort_keys=True, separators=(",", ":"), default=str),
+    )
+    return stable_digest_v0({"rows": list(ordered), "schema": "offline_evidence_jsonl_v0"})
+
+
+def productive_input_row_to_factor_exposure_input_v0(
+    row: ProductiveInputRowV0,
+    *,
+    timestamp: int,
+) -> FactorExposureInputV1:
+    ordered_factor_values = {
+        name: float(row.factor_values[name]) for name in EXPECTED_PRODUCTIVE_FACTOR_ORDER
+    }
+    return FactorExposureInputV1(
+        instrument_id=row.instrument_id,
+        timestamp=timestamp,
+        target_return=float(row.target_return),
+        factor_values=ordered_factor_values,
+        factor_time=row.factor_time,
+        decision_time=row.decision_time,
+    )
+
+
+def _records_from_join_result(
+    join_result: ProductiveJoinValidationResultV0,
+) -> tuple[FactorExposureInputV1, ...]:
+    ordered_rows = sorted(
+        join_result.admissible_rows,
+        key=lambda row: (row.decision_time, row.trade_id, row.instrument_id),
+    )
+    records: list[FactorExposureInputV1] = []
+    for index, row in enumerate(ordered_rows, start=1):
+        records.append(productive_input_row_to_factor_exposure_input_v0(row, timestamp=index))
+    return tuple(records)
+
+
+def _serialize_records(records: Sequence[FactorExposureInputV1]) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    for record in records:
+        payload.append(
+            {
+                "instrument_id": record.instrument_id,
+                "timestamp": record.timestamp,
+                "target_return": record.target_return,
+                "factor_values": {
+                    name: record.factor_values[name] for name in EXPECTED_PRODUCTIVE_FACTOR_ORDER
+                },
+                "factor_time": record.factor_time,
+                "decision_time": record.decision_time,
+            }
+        )
+    return payload
+
+
+def build_productive_provenance_v0(
+    *,
+    join_result: ProductiveJoinValidationResultV0,
+    source_trade_ledger_digest: str,
+    source_factor_snapshot_digest: str,
+) -> FactorExposureProductiveProvenanceV0:
+    validate_dataset_digest_v0(EXPECTED_DATASET_DIGEST)
+    return FactorExposureProductiveProvenanceV0(
+        implementation_digest=IMPLEMENTATION_DIGEST,
+        dataset_digest=EXPECTED_DATASET_DIGEST,
+        instrument_universe=join_result.instrument_universe,
+        instrument_universe_digest=join_result.instrument_universe_digest,
+        time_range=dict(join_result.time_range),
+        row_count_before_filter=join_result.row_count_before_filter,
+        row_count_after_filter=join_result.row_count_after_filter,
+        dropped_rows_by_reason=dict(join_result.dropped_rows_by_reason),
+        source_trade_ledger_digest=source_trade_ledger_digest,
+        source_factor_snapshot_digest=source_factor_snapshot_digest,
+    )
+
+
+def materialize_offline_factor_exposure_productive_inputs_v0(
+    *,
+    trade_ledger_rows: Sequence[Mapping[str, Any]],
+    factor_snapshot_rows: Sequence[Mapping[str, Any]],
+    source_trade_ledger_digest: str | None = None,
+    source_factor_snapshot_digest: str | None = None,
+) -> MaterializationResultV0:
+    """Materialize productive FactorExposureInputV1 records from ledger + snapshots."""
+    ledger_digest = source_trade_ledger_digest or compute_source_rows_digest(trade_ledger_rows)
+    snapshot_digest = source_factor_snapshot_digest or compute_source_rows_digest(
+        factor_snapshot_rows
+    )
+
+    join_result = validate_productive_join_batch_v0(
+        trade_ledger_rows=trade_ledger_rows,
+        factor_snapshots=factor_snapshot_rows,
+    )
+    records = _records_from_join_result(join_result)
+    serialized = _serialize_records(records)
+    output_digest = stable_digest_v0(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "target_name": TARGET_NAME,
+            "records": serialized,
+        }
+    )
+    materialization_digest = stable_digest_v0(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "output_digest": output_digest,
+            "source_trade_ledger_digest": ledger_digest,
+            "source_factor_snapshot_digest": snapshot_digest,
+            "row_count_after_filter": join_result.row_count_after_filter,
+            "dropped_rows_by_reason": dict(join_result.dropped_rows_by_reason),
+        }
+    )
+    provenance = build_productive_provenance_v0(
+        join_result=join_result,
+        source_trade_ledger_digest=ledger_digest,
+        source_factor_snapshot_digest=snapshot_digest,
+    )
+
+    if not records:
+        status = (
+            MaterializationStatus.TARGET_BINDING_MISSING
+            if trade_ledger_rows
+            else MaterializationStatus.INSUFFICIENT_DATA
+        )
+    else:
+        status = MaterializationStatus.PASS
+
+    return MaterializationResultV0(
+        status=status,
+        records=records,
+        join_result=join_result,
+        provenance=provenance,
+        materialization_digest=materialization_digest,
+        output_digest=output_digest,
+        source_trade_ledger_digest=ledger_digest,
+        source_factor_snapshot_digest=snapshot_digest,
+    )
+
+
+def serialize_materialized_productive_inputs_v0(
+    records: Sequence[FactorExposureInputV1],
+) -> str:
+    """Deterministic JSONL serialization for repeated materialization checks."""
+    serialized = _serialize_records(records)
+    ordered = sorted(
+        serialized,
+        key=lambda row: (
+            str(row.get("decision_time", "")),
+            str(row.get("instrument_id", "")),
+            int(row.get("timestamp", 0)),
+        ),
+    )
+    lines = [json.dumps(row, sort_keys=True, separators=(",", ":"), default=str) for row in ordered]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def materialize_from_manifest_paths_v0(
+    *,
+    trade_ledger_path: Path,
+    factor_snapshot_path: Path,
+) -> MaterializationResultV0:
+    ledger_rows = load_jsonl_rows(trade_ledger_path)
+    snapshot_rows = load_jsonl_rows(factor_snapshot_path)
+    return materialize_offline_factor_exposure_productive_inputs_v0(
+        trade_ledger_rows=ledger_rows,
+        factor_snapshot_rows=snapshot_rows,
+        source_trade_ledger_digest=compute_source_rows_digest(ledger_rows),
+        source_factor_snapshot_digest=compute_source_rows_digest(snapshot_rows),
+    )
+
+
+__all__ = [
+    "AUTHORITY_EFFECT",
+    "RUNTIME_EFFECT",
+    "PACKAGE_MARKER",
+    "SCHEMA_VERSION",
+    "CANONICAL_CONTRACT_OWNER",
+    "CANONICAL_JOIN_KEY",
+    "SECONDARY_INTEGRITY_KEY",
+    "IMPLEMENTATION_DIGEST",
+    "MaterializationResultV0",
+    "MaterializationStatus",
+    "build_productive_provenance_v0",
+    "compute_source_rows_digest",
+    "load_jsonl_rows",
+    "materialize_from_manifest_paths_v0",
+    "materialize_offline_factor_exposure_productive_inputs_v0",
+    "productive_input_row_to_factor_exposure_input_v0",
+    "serialize_materialized_productive_inputs_v0",
+]

--- a/tests/research/test_offline_factor_exposure_productive_input_join_materializer_v0.py
+++ b/tests/research/test_offline_factor_exposure_productive_input_join_materializer_v0.py
@@ -1,0 +1,446 @@
+"""Contract tests for offline factor exposure productive input join materializer v0."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from research.linear_evidence.factor_exposure import (
+    REASON_FACTOR_LOOKAHEAD_DETECTED,
+    build_factor_matrix,
+    fit_factor_exposure,
+)
+from research.linear_evidence.factor_exposure_productive_contract_v0 import (
+    EXPECTED_PRODUCTIVE_FACTOR_ORDER,
+    ProductiveJoinRejectionReason,
+)
+from research.linear_evidence.import_boundary import scan_file_import_boundary
+from src.research.offline_factor_exposure_productive_input_join_materializer_v0 import (
+    AUTHORITY_EFFECT,
+    CANONICAL_JOIN_KEY,
+    RUNTIME_EFFECT,
+    MaterializationStatus,
+    compute_source_rows_digest,
+    materialize_offline_factor_exposure_productive_inputs_v0,
+    serialize_materialized_productive_inputs_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MATERIALIZER_MODULE = (
+    REPO_ROOT / "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py"
+)
+RUNNER_MODULE = (
+    REPO_ROOT / "scripts/research/offline_factor_exposure_productive_input_join_materializer_v0.py"
+)
+DIAGNOSTICS_RUNNER = REPO_ROOT / "scripts/research/offline_factor_exposure_diagnostics_v0.py"
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+FORBIDDEN_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+    "requests",
+    "httpx",
+    "urllib.request",
+)
+
+
+def _trade(
+    *,
+    trade_id: str = "t-1",
+    instrument_id: str = "inst-eth-usdt-perp",
+    entry_time: str = "2026-01-01T00:00:00+00:00",
+    exit_time: str = "2026-01-01T01:00:00+00:00",
+    net_pnl: float = 10.0,
+    notional: float = 1000.0,
+) -> dict[str, object]:
+    return {
+        "trade_id": trade_id,
+        "instrument_id": instrument_id,
+        "entry_time": entry_time,
+        "exit_time": exit_time,
+        "net_pnl": net_pnl,
+        "notional": notional,
+    }
+
+
+def _snapshot(
+    *,
+    trade_id: str = "t-1",
+    instrument_id: str = "inst-eth-usdt-perp",
+    entry_time: str = "2026-01-01T00:00:00+00:00",
+    bar_timestamp: str = "2026-01-01T00:00:00+00:00",
+    feature_timestamp: str = "2025-12-31T23:00:00+00:00",
+    spread_bps: float = 10.0,
+    volatility_estimate: float = 0.02,
+    funding_rate: float = -0.0001,
+    is_finalized: bool = True,
+) -> dict[str, object]:
+    return {
+        "trade_id": trade_id,
+        "instrument_id": instrument_id,
+        "entry_time": entry_time,
+        "bar_timestamp": bar_timestamp,
+        "feature_timestamp": feature_timestamp,
+        "spread_bps": spread_bps,
+        "volatility_estimate": volatility_estimate,
+        "funding_rate": funding_rate,
+        "is_finalized": is_finalized,
+    }
+
+
+def _materialize(
+    trades: list[dict[str, object]],
+    snapshots: list[dict[str, object]],
+):
+    return materialize_offline_factor_exposure_productive_inputs_v0(
+        trade_ledger_rows=trades,
+        factor_snapshot_rows=snapshots,
+    )
+
+
+def test_productive_contract_accepted() -> None:
+    result = _materialize([_trade()], [_snapshot()])
+    assert result.status == MaterializationStatus.PASS
+    assert len(result.records) == 1
+    assert result.records[0].factor_time < result.records[0].decision_time
+
+
+def test_missing_required_input_rejected() -> None:
+    trade = _trade()
+    trade.pop("trade_id")
+    result = _materialize([trade], [_snapshot()])
+    assert result.status == MaterializationStatus.TARGET_BINDING_MISSING
+    assert (
+        ProductiveJoinRejectionReason.MISSING_TRADE_ID.value
+        in result.join_result.dropped_rows_by_reason
+    )
+
+
+def test_duplicate_join_partner_rejected() -> None:
+    result = _materialize(
+        [_trade(trade_id="t-1"), _trade(trade_id="t-1")],
+        [_snapshot(trade_id="t-1")],
+    )
+    assert (
+        ProductiveJoinRejectionReason.DUPLICATE_TRADE_ID.value
+        in result.join_result.dropped_rows_by_reason
+    )
+
+
+def test_ambiguous_join_partner_rejected() -> None:
+    trade = _trade()
+    trade["notional"] = 1000.0
+    trade["entry_notional"] = 2000.0
+    result = _materialize([trade], [_snapshot()])
+    assert (
+        ProductiveJoinRejectionReason.TARGET_NOTIONAL_OWNER_AMBIGUOUS.value
+        in result.join_result.dropped_rows_by_reason
+    )
+
+
+def test_conflicting_partner_rejected() -> None:
+    result = _materialize(
+        [_trade(trade_id="t-1", instrument_id="inst-a")],
+        [_snapshot(trade_id="t-1", instrument_id="inst-b")],
+    )
+    assert (
+        ProductiveJoinRejectionReason.INSTRUMENT_ID_MISMATCH.value
+        in result.join_result.dropped_rows_by_reason
+    )
+
+
+def test_many_to_many_join_rejected() -> None:
+    result = _materialize(
+        [_trade(trade_id="t-1")],
+        [_snapshot(trade_id="t-1"), _snapshot(trade_id="t-1")],
+    )
+    assert (
+        ProductiveJoinRejectionReason.DUPLICATE_FACTOR_SNAPSHOT.value
+        in result.join_result.dropped_rows_by_reason
+    )
+
+
+def test_stale_or_future_dated_input_rejected() -> None:
+    result = _materialize(
+        [_trade(entry_time="2026-01-01T00:00:00+00:00", exit_time="2026-01-01T01:00:00+00:00")],
+        [
+            _snapshot(
+                entry_time="2026-01-01T01:00:00+00:00",
+                bar_timestamp="2026-01-01T01:00:00+00:00",
+                feature_timestamp="2025-12-31T23:00:00+00:00",
+            )
+        ],
+    )
+    assert (
+        ProductiveJoinRejectionReason.ENTRY_TIME_MISMATCH.value
+        in result.join_result.dropped_rows_by_reason
+    )
+
+
+def test_lookahead_rejected() -> None:
+    result = _materialize(
+        [_trade()],
+        [_snapshot(feature_timestamp="2026-01-01T01:00:00+00:00")],
+    )
+    assert (
+        ProductiveJoinRejectionReason.FEATURE_LEAKAGE_DETECTED.value
+        in result.join_result.dropped_rows_by_reason
+    )
+
+
+def test_deterministic_row_order() -> None:
+    trades = [
+        _trade(
+            trade_id="t-2",
+            entry_time="2026-01-01T02:00:00+00:00",
+            exit_time="2026-01-01T03:00:00+00:00",
+        ),
+        _trade(
+            trade_id="t-1",
+            entry_time="2026-01-01T00:00:00+00:00",
+            exit_time="2026-01-01T01:00:00+00:00",
+        ),
+    ]
+    snapshots = [
+        _snapshot(
+            trade_id="t-2",
+            entry_time="2026-01-01T02:00:00+00:00",
+            bar_timestamp="2026-01-01T02:00:00+00:00",
+            feature_timestamp="2026-01-01T01:00:00+00:00",
+        ),
+        _snapshot(trade_id="t-1"),
+    ]
+    result = _materialize(trades, snapshots)
+    decision_times = [record.decision_time for record in result.records]
+    assert decision_times == sorted(decision_times)
+
+
+def test_deterministic_feature_order() -> None:
+    result = _materialize([_trade()], [_snapshot()])
+    assert tuple(sorted(result.records[0].factor_values.keys())) == EXPECTED_PRODUCTIVE_FACTOR_ORDER
+    _, _, names, _, _ = build_factor_matrix(result.records)
+    assert names == EXPECTED_PRODUCTIVE_FACTOR_ORDER
+
+
+def test_repeated_materialization_identical() -> None:
+    trades = [
+        _trade(trade_id="t-1"),
+        _trade(
+            trade_id="t-2",
+            entry_time="2026-01-01T02:00:00+00:00",
+            exit_time="2026-01-01T03:00:00+00:00",
+        ),
+    ]
+    snapshots = [
+        _snapshot(trade_id="t-1"),
+        _snapshot(
+            trade_id="t-2",
+            entry_time="2026-01-01T02:00:00+00:00",
+            bar_timestamp="2026-01-01T02:00:00+00:00",
+            feature_timestamp="2026-01-01T01:00:00+00:00",
+        ),
+    ]
+    first = _materialize(trades, snapshots)
+    second = _materialize(trades, snapshots)
+    assert first.output_digest == second.output_digest
+    assert first.materialization_digest == second.materialization_digest
+
+
+def test_second_materialization_diff_empty() -> None:
+    trades = [_trade()]
+    snapshots = [_snapshot()]
+    first = serialize_materialized_productive_inputs_v0(_materialize(trades, snapshots).records)
+    second = serialize_materialized_productive_inputs_v0(_materialize(trades, snapshots).records)
+    assert first == second
+
+
+def test_dropped_row_accounting_complete() -> None:
+    trades = [
+        _trade(trade_id="t-1"),
+        _trade(trade_id="t-2"),
+        _trade(trade_id="t-3", instrument_id="inst-a"),
+    ]
+    snapshots = [
+        _snapshot(trade_id="t-1"),
+        _snapshot(trade_id="t-3", instrument_id="inst-b"),
+        _snapshot(trade_id="orphan"),
+    ]
+    result = _materialize(trades, snapshots)
+    dropped = result.join_result.dropped_rows_by_reason
+    assert dropped.get(ProductiveJoinRejectionReason.MISSING_FACTOR_SNAPSHOT.value, 0) >= 1
+    assert dropped.get(ProductiveJoinRejectionReason.INSTRUMENT_ID_MISMATCH.value, 0) >= 1
+    assert dropped.get(ProductiveJoinRejectionReason.ORPHAN_FACTOR_ROW.value, 0) >= 1
+    assert sum(dropped.values()) == len(result.join_result.rejected)
+
+
+def test_input_digests_stable() -> None:
+    trades = [_trade()]
+    snapshots = [_snapshot()]
+    first = compute_source_rows_digest(trades)
+    second = compute_source_rows_digest(trades)
+    assert first == second
+
+
+def test_output_digest_stable() -> None:
+    result = _materialize([_trade()], [_snapshot()])
+    assert result.output_digest
+    assert len(result.output_digest) == 64
+
+
+def test_materializer_to_contract_roundtrip_pass() -> None:
+    trades = [
+        _trade(
+            trade_id=f"t-{i}",
+            entry_time=f"2026-01-01T{i:02d}:00:00+00:00",
+            exit_time=f"2026-01-01T{i + 1:02d}:00:00+00:00",
+        )
+        for i in range(1, 12)
+    ]
+    snapshots = [
+        _snapshot(
+            trade_id=f"t-{i}",
+            entry_time=f"2026-01-01T{i:02d}:00:00+00:00",
+            bar_timestamp=f"2026-01-01T{i:02d}:00:00+00:00",
+            feature_timestamp=f"2026-01-01T{i - 1:02d}:00:00+00:00",
+        )
+        for i in range(1, 12)
+    ]
+    result = _materialize(trades, snapshots)
+    assert result.status == MaterializationStatus.PASS
+    assert len(result.records) == 11
+    evidence = fit_factor_exposure(result.records)
+    assert evidence.status in {"DIAGNOSTIC_ONLY", "INSUFFICIENT_DATA", "RANK_DEFICIENT_BLOCKED"}
+    assert evidence.feature_names == EXPECTED_PRODUCTIVE_FACTOR_ORDER
+
+
+def test_diagnostics_runner_consumes_materializer_output(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "ledger.jsonl"
+    snapshot_path = tmp_path / "snapshots.jsonl"
+    ledger_path.write_text(json.dumps(_trade(), sort_keys=True) + "\n", encoding="utf-8")
+    snapshot_path.write_text(json.dumps(_snapshot(), sort_keys=True) + "\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(DIAGNOSTICS_RUNNER),
+            "--out",
+            str(out_dir),
+            "--trade-ledger",
+            str(ledger_path),
+            "--factor-snapshots",
+            str(snapshot_path),
+            "--repo-root",
+            str(REPO_ROOT),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads((out_dir / "factor_exposure_evidence_v1.json").read_text(encoding="utf-8"))
+    assert payload["INPUT_MODE"] == "PRODUCTIVE_JOIN_MATERIALIZED"
+    assert payload["PRODUCTIVE_BINDING_RESOLVED"] is True
+    assert payload["dataset_digest"]
+
+
+def test_cli_materializer_writes_manifestable_report(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "ledger.jsonl"
+    snapshot_path = tmp_path / "snapshots.jsonl"
+    ledger_path.write_text(json.dumps(_trade(), sort_keys=True) + "\n", encoding="utf-8")
+    snapshot_path.write_text(json.dumps(_snapshot(), sort_keys=True) + "\n", encoding="utf-8")
+    out_dir = tmp_path / "materialized"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER_MODULE),
+            "--out",
+            str(out_dir),
+            "--trade-ledger",
+            str(ledger_path),
+            "--factor-snapshots",
+            str(snapshot_path),
+            "--repo-root",
+            str(REPO_ROOT),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads((out_dir / "materialization_report.json").read_text(encoding="utf-8"))
+    assert report["status"] == "PASS"
+    assert report["join_keys"]["primary"] == CANONICAL_JOIN_KEY
+
+
+def test_archive_binding_fail_closed_on_equal_feature_and_entry_time() -> None:
+    ledger_path = (
+        ARCHIVE_ROOT
+        / "trade_ledger_equity_curve_persistence_offline_evaluation_execution_v0_20260705T083113Z"
+        / "TRADE_LEDGER_V1.jsonl"
+    )
+    snapshot_path = (
+        ARCHIVE_ROOT
+        / "research/offline_linear_cost_entry_bar_reference_snapshot_materialization_v0_for_trend_following_v1_trade_ledger_binding_20260713T055132Z"
+        / "entry_bar_snapshots.jsonl"
+    )
+    if not ledger_path.is_file() or not snapshot_path.is_file():
+        pytest.skip("archive evidence unavailable in this environment")
+
+    ledger_rows = [
+        json.loads(line)
+        for line in ledger_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    snapshot_rows = [
+        json.loads(line)
+        for line in snapshot_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    result = _materialize(ledger_rows, snapshot_rows)
+    assert result.join_result.row_count_before_filter == 219
+    assert result.join_result.row_count_after_filter == 0
+    assert result.join_result.dropped_rows_by_reason == {
+        ProductiveJoinRejectionReason.FEATURE_LEAKAGE_DETECTED.value: 219
+    }
+
+
+def test_no_runtime_order_or_scheduler_imports_in_owner() -> None:
+    for path in (MATERIALIZER_MODULE, RUNNER_MODULE, DIAGNOSTICS_RUNNER):
+        source = path.read_text(encoding="utf-8")
+        for token in FORBIDDEN_IMPORT_PREFIXES:
+            assert token not in source
+        hits = scan_file_import_boundary(path, repo_root=REPO_ROOT)
+        assert hits == []
+
+
+def test_no_trading_semantics_mutation_constants() -> None:
+    assert AUTHORITY_EFFECT == "NONE"
+    assert RUNTIME_EFFECT == "NONE"
+
+
+def test_lookahead_blocks_build_factor_matrix() -> None:
+    result = _materialize(
+        [_trade()],
+        [_snapshot(feature_timestamp="2026-01-01T01:00:00+00:00")],
+    )
+    assert not result.records
+    good = _materialize([_trade()], [_snapshot()])
+    with pytest.raises(ValueError, match=REASON_FACTOR_LOOKAHEAD_DETECTED):
+        build_factor_matrix(
+            [
+                type(good.records[0])(
+                    good.records[0].instrument_id,
+                    good.records[0].timestamp,
+                    good.records[0].target_return,
+                    good.records[0].factor_values,
+                    factor_time="2026-01-01T01:00:00+00:00",
+                    decision_time="2026-01-01T00:00:00+00:00",
+                )
+            ]
+        )


### PR DESCRIPTION
## Summary
- Add `offline_factor_exposure_productive_input_join_materializer_v0` that reuses the ratified productive contract join owner (`validate_productive_join_batch_v0`) to emit deterministic `FactorExposureInputV1` rows with provenance and digest binding.
- Wire `offline_factor_exposure_diagnostics_v0.py` with `--trade-ledger` and `--factor-snapshots` for manifest-verified productive binding.
- Register the new materializer in the economic diagnostic boundary owner map and add focused contract tests (join rejection, lookahead, determinism, archive fail-closed).

## Test plan
- [x] `pytest tests/research/test_offline_factor_exposure_productive_input_join_materializer_v0.py`
- [x] `pytest tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py`
- [x] `pytest tests/research/test_offline_factor_exposure_diagnostics_v0.py`
- [x] Durable evidence at `.../offline_factor_exposure_diagnostics_v0_productive_factor_exposure_input_join_materialization_v0_20260713T182500Z`


Made with [Cursor](https://cursor.com)