### PR TITLE
feat(research): productive point-in-time factor snapshot rematerializer v0

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -180,6 +180,7 @@
       "path_prefixes": [
         "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
         "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+        "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
         "src/research/linear_evidence/feature_matrix.py",
         "src/research/linear_evidence/sensitivity.py",
         "src/research/linear_evidence/factor_exposure_productive_contract_v0.py"
@@ -187,7 +188,8 @@
       "path_globs": [
         "tests/research/test_offline_linear_cost_diagnostic_row_materializer_*",
         "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
-        "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*"
+        "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
+        "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*"
       ]
     },
     "COST_MODEL_DIAGNOSTICS": {
@@ -197,10 +199,12 @@
         "src/research/linear_evidence/fitters.py",
         "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
         "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+        "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
         "scripts/research/offline_linear_cost_model_diagnostics_v0.py",
         "scripts/research/offline_signal_orthogonality_diagnostics_v0.py",
         "scripts/research/offline_factor_exposure_diagnostics_v0.py",
-        "scripts/research/offline_factor_exposure_productive_input_join_materializer_v0.py"
+        "scripts/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+        "scripts/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py"
       ],
       "path_globs": [
         "tests/research/test_offline_linear_cost_model_diagnostics_*",
@@ -208,6 +212,7 @@
         "tests/research/test_offline_factor_exposure_diagnostics_*",
         "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
         "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
+        "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*",
         "tests/research/test_linear_evidence_*"
       ]
     },
@@ -244,7 +249,8 @@
     "DETERMINISTIC_MATERIALIZATION_REPAIR": {
       "path_prefixes": [
         "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
-        "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py"
+        "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+        "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py"
       ]
     },
     "EXPLICITLY_CALIBRATABLE_RESEARCH_PARAMETERS_WITHIN_PREDECLARED_RANGES": {

--- a/scripts/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py
+++ b/scripts/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve()
+
+
+def discover_repo_root_from_script() -> Path | None:
+    for parent in [_SCRIPT_PATH, *_SCRIPT_PATH.parents]:
+        if (parent / "src").is_dir() and (parent / ".git").exists():
+            return parent.resolve()
+    return None
+
+
+def validate_peak_trade_repo_root(repo_root: Path) -> Path:
+    resolved = repo_root.expanduser().resolve()
+    if not resolved.is_dir():
+        raise SystemExit(f"REPO_ROOT_INVALID_NOT_DIRECTORY: {resolved}")
+    if not (resolved / "src").is_dir():
+        raise SystemExit(f"REPO_ROOT_INVALID_MISSING_SRC: {resolved}")
+    if not (resolved / ".git").exists():
+        raise SystemExit(f"REPO_ROOT_INVALID_MISSING_GIT: {resolved}")
+    return resolved
+
+
+def resolve_repo_root(explicit: Path | None) -> Path:
+    if explicit is not None:
+        return validate_peak_trade_repo_root(explicit)
+    discovered = discover_repo_root_from_script()
+    if discovered is None:
+        raise SystemExit("REPO_ROOT_DISCOVERY_FAILED: not inside Peak_Trade repo")
+    return discovered
+
+
+_discovered_repo_root = discover_repo_root_from_script()
+if _discovered_repo_root is not None:
+    repo_s = str(_discovered_repo_root)
+    if repo_s not in sys.path:
+        sys.path.insert(0, repo_s)
+
+from scripts.ops.run_economic_viability_evidence_evaluation_v1 import (  # noqa: E402
+    _load_bars_from_dataset_path,
+)
+from src.research.offline_productive_point_in_time_factor_snapshot_rematerializer_v0 import (  # noqa: E402
+    AUTHORITY_EFFECT,
+    RUNTIME_EFFECT,
+    load_jsonl_rows,
+    materialize_productive_point_in_time_factor_snapshots_v0,
+    productive_factor_field_provenance_v0,
+    serialize_productive_point_in_time_factor_snapshots_v0,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Offline productive point-in-time factor snapshot rematerializer v0"
+    )
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--trade-ledger", required=True, type=Path)
+    parser.add_argument("--bars-dataset", required=True, type=Path)
+    parser.add_argument("--spread-half-bps", required=True, type=float)
+    parser.add_argument("--instrument-id", default=None)
+    parser.add_argument("--repo-root", type=Path, default=None)
+    args = parser.parse_args()
+
+    repo_root = resolve_repo_root(args.repo_root)
+    out = args.out
+    out.mkdir(parents=True, exist_ok=True)
+
+    trade_rows = load_jsonl_rows(args.trade_ledger)
+    bars = _load_bars_from_dataset_path(args.bars_dataset)
+    result = materialize_productive_point_in_time_factor_snapshots_v0(
+        trade_ledger_rows=trade_rows,
+        bars=bars,
+        spread_half_bps=args.spread_half_bps,
+        source_dataset_ref=str(args.bars_dataset.resolve()),
+        expected_instrument_id=args.instrument_id,
+    )
+    serialized = serialize_productive_point_in_time_factor_snapshots_v0(result.snapshots)
+    (out / "productive_point_in_time_factor_snapshots_v0.jsonl").write_text(
+        serialized, encoding="utf-8"
+    )
+    report = {
+        "status": result.status.value,
+        "admissible_count": result.admissible_count,
+        "rejected_count": len(result.rejected),
+        "dropped_rows_by_reason": dict(result.dropped_rows_by_reason),
+        "materialization_digest": result.materialization_digest,
+        "source_trade_ledger_digest": result.source_trade_ledger_digest,
+        "source_bars_digest": result.source_bars_digest,
+        "source_dataset_ref": result.source_dataset_ref,
+        "spread_bps_binding": result.spread_bps_binding,
+        "feature_provenance": productive_factor_field_provenance_v0(),
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "offline_only": True,
+        "repo_root": str(repo_root),
+    }
+    (out / "rematerialization_report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    final_report = "\n".join(
+        [
+            "VERDICT=OFFLINE_PRODUCTIVE_POINT_IN_TIME_FACTOR_SNAPSHOT_REMATERIALIZATION_V0_COLLECTED",
+            f"STATUS={result.status.value}",
+            f"ADMISSIBLE_COUNT={result.admissible_count}",
+            f"REJECTED_COUNT={len(result.rejected)}",
+            f"DROPPED_ROWS_BY_REASON={json.dumps(result.dropped_rows_by_reason, sort_keys=True)}",
+            f"MATERIALIZATION_DIGEST={result.materialization_digest}",
+            f"AUTHORITY_EFFECT={AUTHORITY_EFFECT}",
+            f"RUNTIME_EFFECT={RUNTIME_EFFECT}",
+            "OFFLINE_ONLY=true",
+            "",
+        ]
+    )
+    (out / "final_report.txt").write_text(final_report, encoding="utf-8")
+    print(final_report, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py
+++ b/src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py
@@ -1,0 +1,414 @@
+"""Offline productive point-in-time factor snapshot rematerializer v0.
+
+Deterministic as-of rematerialization of productive factor snapshots from
+manifest-verified trade ledger rows and admissible futures bar history. Selects
+the latest finalized bar strictly before each trade entry_time for
+funding_rate and volatility_estimate while preserving trade join keys.
+No factor exposure diagnostic execution, runtime, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+from src.research.linear_evidence.factor_exposure_productive_contract_v0 import (
+    AUTHORITY_EFFECT,
+    PRODUCTIVE_FACTOR_SPECS,
+    RUNTIME_EFFECT,
+    stable_digest_v0,
+)
+
+PACKAGE_MARKER = "OFFLINE_PRODUCTIVE_POINT_IN_TIME_FACTOR_SNAPSHOT_REMATERIALIZER_V0=true"
+SCHEMA_VERSION = "offline_productive_point_in_time_factor_snapshot_rematerializer.v0"
+CANONICAL_BARS_LOADER_OWNER = (
+    "scripts/ops/run_economic_viability_evidence_evaluation_v1.py::_load_bars_from_dataset_path"
+)
+CANONICAL_SPREAD_BINDING_OWNER = (
+    "src/research/trade_ledger_equity_curve_persistence_offline_evaluation_execution_v0.py"
+)
+ASOF_POLICY = "latest_finalized_bar_strictly_before_entry_time"
+
+
+class DropReason(str, Enum):
+    MISSING_TRADE_ID = "MISSING_TRADE_ID"
+    DUPLICATE_TRADE_ID = "DUPLICATE_TRADE_ID"
+    MISSING_INSTRUMENT_ID = "MISSING_INSTRUMENT_ID"
+    MISSING_ENTRY_TIME = "MISSING_ENTRY_TIME"
+    MISSING_PRIOR_BAR = "MISSING_PRIOR_BAR"
+    DUPLICATE_PRIOR_BAR_CANDIDATE = "DUPLICATE_PRIOR_BAR_CANDIDATE"
+    UNFINALIZED_PRIOR_BAR = "UNFINALIZED_PRIOR_BAR"
+    MISSING_FUNDING_RATE = "MISSING_FUNDING_RATE"
+    MISSING_VOLATILITY_ESTIMATE = "MISSING_VOLATILITY_ESTIMATE"
+    MISSING_SPREAD_BPS_BINDING = "MISSING_SPREAD_BPS_BINDING"
+    FEATURE_TIME_NOT_STRICTLY_BEFORE_ENTRY = "FEATURE_TIME_NOT_STRICTLY_BEFORE_ENTRY"
+    INSTRUMENT_ID_MISMATCH = "INSTRUMENT_ID_MISMATCH"
+
+
+class RematerializationStatus(str, Enum):
+    PASS = "PASS"
+    INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
+    TARGET_BINDING_MISSING = "TARGET_BINDING_MISSING"
+
+
+@dataclass(frozen=True)
+class RejectedSnapshotRowV0:
+    trade_id: str
+    reason: DropReason
+
+
+@dataclass(frozen=True)
+class RematerializationResultV0:
+    status: RematerializationStatus
+    snapshots: tuple[dict[str, Any], ...]
+    admissible_count: int
+    rejected: tuple[RejectedSnapshotRowV0, ...]
+    dropped_rows_by_reason: dict[str, int]
+    materialization_digest: str
+    source_trade_ledger_digest: str
+    source_bars_digest: str
+    source_dataset_ref: str
+    spread_bps_binding: float
+    authority_effect: str = AUTHORITY_EFFECT
+    runtime_effect: str = RUNTIME_EFFECT
+
+
+def load_jsonl_rows(path: Path) -> tuple[dict[str, Any], ...]:
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        payload = json.loads(stripped)
+        if not isinstance(payload, dict):
+            raise ValueError("JSONL_ROW_NOT_OBJECT")
+        rows.append(payload)
+    return tuple(rows)
+
+
+def compute_source_rows_digest(rows: Sequence[Mapping[str, Any]]) -> str:
+    ordered = sorted(
+        rows,
+        key=lambda row: json.dumps(row, sort_keys=True, separators=(",", ":"), default=str),
+    )
+    return stable_digest_v0({"rows": list(ordered), "schema": "offline_evidence_jsonl_v0"})
+
+
+def compute_bars_source_digest(*, bars: pd.DataFrame, source_dataset_ref: str) -> str:
+    index_values = [ts.isoformat() for ts in bars.index]
+    return stable_digest_v0(
+        {
+            "schema": "admissible_futures_bars_v0",
+            "source_dataset_ref": source_dataset_ref,
+            "row_count": len(bars),
+            "index_min": index_values[0] if index_values else "",
+            "index_max": index_values[-1] if index_values else "",
+            "columns": sorted(str(col) for col in bars.columns),
+        }
+    )
+
+
+def _is_finalized_bar(row: Mapping[str, Any]) -> bool:
+    if "is_finalized" in row:
+        return row.get("is_finalized") is True
+    if "is_final" in row:
+        return row.get("is_final") is True
+    return False
+
+
+def _row_mapping(row: Any) -> Mapping[str, Any]:
+    if hasattr(row, "to_dict"):
+        return row.to_dict()
+    if isinstance(row, Mapping):
+        return row
+    raise TypeError("bar_row_not_mapping")
+
+
+def lookup_prior_bar_asof_v0(
+    *,
+    bars: pd.DataFrame,
+    entry_time: Any,
+) -> tuple[pd.Timestamp, Mapping[str, Any]] | tuple[None, DropReason]:
+    if bars.empty or entry_time is None:
+        return None, DropReason.MISSING_PRIOR_BAR
+    try:
+        stamp = pd.Timestamp(entry_time)
+        if stamp.tzinfo is None:
+            stamp = stamp.tz_localize("UTC")
+    except (TypeError, ValueError):
+        return None, DropReason.MISSING_ENTRY_TIME
+
+    prior_index = bars.index[bars.index < stamp]
+    if len(prior_index) == 0:
+        return None, DropReason.MISSING_PRIOR_BAR
+    if len(prior_index) != len(set(prior_index)):
+        return None, DropReason.DUPLICATE_PRIOR_BAR_CANDIDATE
+
+    feature_ts = prior_index[-1]
+    matched = bars.loc[feature_ts]
+    if isinstance(matched, pd.DataFrame):
+        return None, DropReason.DUPLICATE_PRIOR_BAR_CANDIDATE
+
+    row = _row_mapping(matched)
+    if not _is_finalized_bar(row):
+        return None, DropReason.UNFINALIZED_PRIOR_BAR
+    if feature_ts >= stamp:
+        return None, DropReason.FEATURE_TIME_NOT_STRICTLY_BEFORE_ENTRY
+    return feature_ts, row
+
+
+def resolve_spread_bps_from_half_binding_v0(
+    spread_half_bps: float | None,
+) -> tuple[float | None, DropReason | None]:
+    if spread_half_bps is None:
+        return None, DropReason.MISSING_SPREAD_BPS_BINDING
+    return 2.0 * float(spread_half_bps), None
+
+
+def materialize_single_productive_point_in_time_factor_snapshot_v0(
+    *,
+    trade: Mapping[str, Any],
+    bars: pd.DataFrame,
+    spread_bps: float,
+    source_dataset_ref: str,
+    expected_instrument_id: str | None = None,
+) -> tuple[dict[str, Any] | None, DropReason | None]:
+    trade_id = str(trade.get("trade_id", ""))
+    if not trade_id:
+        return None, DropReason.MISSING_TRADE_ID
+
+    instrument_id = str(trade.get("instrument_id", ""))
+    if not instrument_id:
+        return None, DropReason.MISSING_INSTRUMENT_ID
+    if expected_instrument_id and instrument_id != expected_instrument_id:
+        return None, DropReason.INSTRUMENT_ID_MISMATCH
+
+    entry_time = str(trade.get("entry_time", ""))
+    if not entry_time:
+        return None, DropReason.MISSING_ENTRY_TIME
+
+    feature_ts, prior_or_reason = lookup_prior_bar_asof_v0(bars=bars, entry_time=entry_time)
+    if isinstance(prior_or_reason, DropReason):
+        return None, prior_or_reason
+    assert feature_ts is not None
+    prior = prior_or_reason
+
+    funding_raw = prior.get("funding_rate")
+    if funding_raw is None or (isinstance(funding_raw, float) and pd.isna(funding_raw)):
+        return None, DropReason.MISSING_FUNDING_RATE
+    try:
+        funding_rate = float(funding_raw)
+    except (TypeError, ValueError):
+        return None, DropReason.MISSING_FUNDING_RATE
+
+    vol_raw = prior.get("volatility_estimate")
+    if vol_raw is None or (isinstance(vol_raw, float) and pd.isna(vol_raw)):
+        return None, DropReason.MISSING_VOLATILITY_ESTIMATE
+    try:
+        volatility_estimate = float(vol_raw)
+    except (TypeError, ValueError):
+        return None, DropReason.MISSING_VOLATILITY_ESTIMATE
+
+    feature_timestamp = feature_ts.isoformat()
+    if feature_timestamp >= entry_time:
+        return None, DropReason.FEATURE_TIME_NOT_STRICTLY_BEFORE_ENTRY
+
+    snapshot: dict[str, Any] = {
+        "trade_id": trade_id,
+        "instrument_id": instrument_id,
+        "entry_time": entry_time,
+        "bar_timestamp": entry_time,
+        "feature_timestamp": feature_timestamp,
+        "funding_rate": funding_rate,
+        "spread_bps": spread_bps,
+        "volatility_estimate": volatility_estimate,
+        "is_finalized": True,
+        "source_dataset_ref": source_dataset_ref,
+        "source_row_identity": f"{instrument_id}@{feature_timestamp}",
+        "asof_policy": ASOF_POLICY,
+        "schema_version": SCHEMA_VERSION,
+    }
+    if prior.get("mark_price") is not None and not pd.isna(prior.get("mark_price")):
+        snapshot["mark_price"] = float(prior["mark_price"])
+    if prior.get("volume") is not None and not pd.isna(prior.get("volume")):
+        snapshot["volume"] = float(prior["volume"])
+    return snapshot, None
+
+
+def materialize_productive_point_in_time_factor_snapshots_v0(
+    *,
+    trade_ledger_rows: Sequence[Mapping[str, Any]],
+    bars: pd.DataFrame,
+    spread_half_bps: float | None,
+    source_dataset_ref: str,
+    expected_instrument_id: str | None = None,
+    source_trade_ledger_digest: str | None = None,
+    source_bars_digest: str | None = None,
+) -> RematerializationResultV0:
+    spread_bps, spread_reason = resolve_spread_bps_from_half_binding_v0(spread_half_bps)
+    if spread_reason is not None or spread_bps is None:
+        spread_bps = float("nan")
+
+    ledger_digest = source_trade_ledger_digest or compute_source_rows_digest(trade_ledger_rows)
+    bars_digest = source_bars_digest or compute_bars_source_digest(
+        bars=bars,
+        source_dataset_ref=source_dataset_ref,
+    )
+
+    rejected: list[RejectedSnapshotRowV0] = []
+    dropped: dict[str, int] = {}
+    admissible: list[dict[str, Any]] = []
+    seen_trade_ids: set[str] = set()
+
+    ordered_trades = sorted(
+        trade_ledger_rows,
+        key=lambda row: (
+            str(row.get("trade_id", "")),
+            str(row.get("entry_time", "")),
+            str(row.get("instrument_id", "")),
+        ),
+    )
+
+    for trade in ordered_trades:
+        trade_id = str(trade.get("trade_id", ""))
+        if not trade_id:
+            reason = DropReason.MISSING_TRADE_ID
+            rejected.append(RejectedSnapshotRowV0(trade_id="", reason=reason))
+            dropped[reason.value] = dropped.get(reason.value, 0) + 1
+            continue
+        if trade_id in seen_trade_ids:
+            reason = DropReason.DUPLICATE_TRADE_ID
+            rejected.append(RejectedSnapshotRowV0(trade_id=trade_id, reason=reason))
+            dropped[reason.value] = dropped.get(reason.value, 0) + 1
+            continue
+        seen_trade_ids.add(trade_id)
+
+        if spread_reason is not None:
+            rejected.append(RejectedSnapshotRowV0(trade_id=trade_id, reason=spread_reason))
+            dropped[spread_reason.value] = dropped.get(spread_reason.value, 0) + 1
+            continue
+
+        snapshot, row_reason = materialize_single_productive_point_in_time_factor_snapshot_v0(
+            trade=trade,
+            bars=bars,
+            spread_bps=spread_bps,
+            source_dataset_ref=source_dataset_ref,
+            expected_instrument_id=expected_instrument_id,
+        )
+        if row_reason is not None or snapshot is None:
+            reason = row_reason or DropReason.MISSING_PRIOR_BAR
+            rejected.append(RejectedSnapshotRowV0(trade_id=trade_id, reason=reason))
+            dropped[reason.value] = dropped.get(reason.value, 0) + 1
+            continue
+        admissible.append(snapshot)
+
+    admissible_sorted = sorted(
+        admissible,
+        key=lambda row: (
+            str(row.get("trade_id", "")),
+            str(row.get("entry_time", "")),
+            str(row.get("instrument_id", "")),
+        ),
+    )
+
+    if not admissible_sorted:
+        status = (
+            RematerializationStatus.TARGET_BINDING_MISSING
+            if trade_ledger_rows
+            else RematerializationStatus.INSUFFICIENT_DATA
+        )
+    else:
+        status = RematerializationStatus.PASS
+
+    materialization_digest = stable_digest_v0(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "snapshots": admissible_sorted,
+            "source_trade_ledger_digest": ledger_digest,
+            "source_bars_digest": bars_digest,
+            "spread_half_bps": spread_half_bps,
+            "dropped_rows_by_reason": dropped,
+        }
+    )
+
+    return RematerializationResultV0(
+        status=status,
+        snapshots=tuple(admissible_sorted),
+        admissible_count=len(admissible_sorted),
+        rejected=tuple(rejected),
+        dropped_rows_by_reason=dropped,
+        materialization_digest=materialization_digest,
+        source_trade_ledger_digest=ledger_digest,
+        source_bars_digest=bars_digest,
+        source_dataset_ref=source_dataset_ref,
+        spread_bps_binding=spread_bps if spread_reason is None else float("nan"),
+    )
+
+
+def serialize_productive_point_in_time_factor_snapshots_v0(
+    snapshots: Sequence[Mapping[str, Any]],
+) -> str:
+    ordered = sorted(
+        snapshots,
+        key=lambda row: (
+            str(row.get("trade_id", "")),
+            str(row.get("entry_time", "")),
+            str(row.get("instrument_id", "")),
+        ),
+    )
+    lines = [json.dumps(row, sort_keys=True, separators=(",", ":"), default=str) for row in ordered]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def productive_factor_field_provenance_v0() -> dict[str, Any]:
+    return {
+        "features": [
+            {
+                "canonical_name": spec.canonical_name,
+                "source_field": spec.source_field,
+                "source_artifact": "admissible_futures_bars.parquet",
+                "observed_event_timestamp_field": "feature_timestamp",
+                "availability_timestamp_field": "feature_timestamp",
+                "finalized_bar_field": "is_final",
+                "instrument_identity_field": "instrument_id",
+                "asof_policy": ASOF_POLICY,
+            }
+            for spec in PRODUCTIVE_FACTOR_SPECS
+        ],
+        "spread_bps": {
+            "source_artifact": "spread_half_bps_binding",
+            "observed_event_timestamp_field": "N/A_STATIC_BINDING",
+            "availability_timestamp_field": "evaluation_binding_time",
+            "transformation": "2.0 * spread_half_bps",
+        },
+    }
+
+
+__all__ = [
+    "ASOF_POLICY",
+    "AUTHORITY_EFFECT",
+    "CANONICAL_BARS_LOADER_OWNER",
+    "CANONICAL_SPREAD_BINDING_OWNER",
+    "DropReason",
+    "PACKAGE_MARKER",
+    "RematerializationResultV0",
+    "RematerializationStatus",
+    "RejectedSnapshotRowV0",
+    "RUNTIME_EFFECT",
+    "SCHEMA_VERSION",
+    "compute_bars_source_digest",
+    "compute_source_rows_digest",
+    "load_jsonl_rows",
+    "lookup_prior_bar_asof_v0",
+    "materialize_productive_point_in_time_factor_snapshots_v0",
+    "materialize_single_productive_point_in_time_factor_snapshot_v0",
+    "productive_factor_field_provenance_v0",
+    "resolve_spread_bps_from_half_binding_v0",
+    "serialize_productive_point_in_time_factor_snapshots_v0",
+]

--- a/tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py
+++ b/tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py
@@ -1,0 +1,303 @@
+"""Contract tests for offline productive point-in-time factor snapshot rematerializer v0."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from research.linear_evidence.factor_exposure_productive_contract_v0 import (
+    EXPECTED_PRODUCTIVE_FACTOR_ORDER,
+    ProductiveJoinRejectionReason,
+    validate_productive_join_batch_v0,
+)
+from research.linear_evidence.import_boundary import scan_file_import_boundary
+from scripts.ops.run_economic_viability_evidence_evaluation_v1 import _load_bars_from_dataset_path
+from src.research.offline_productive_point_in_time_factor_snapshot_rematerializer_v0 import (
+    AUTHORITY_EFFECT,
+    ASOF_POLICY,
+    RUNTIME_EFFECT,
+    DropReason,
+    RematerializationStatus,
+    lookup_prior_bar_asof_v0,
+    materialize_productive_point_in_time_factor_snapshots_v0,
+    serialize_productive_point_in_time_factor_snapshots_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MATERIALIZER_MODULE = (
+    REPO_ROOT / "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py"
+)
+RUNNER_MODULE = (
+    REPO_ROOT
+    / "scripts/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py"
+)
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+LEDGER = (
+    ARCHIVE_ROOT
+    / "trade_ledger_equity_curve_persistence_offline_evaluation_execution_v0_20260705T083113Z"
+    / "TRADE_LEDGER_V1.jsonl"
+)
+BARS = ARCHIVE_ROOT / "datasets/admissible_futures/inst-eth-usdt-perp/v1/bars.parquet"
+SPREAD_HALF_BPS = 5.0
+FORBIDDEN_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+    "requests",
+    "httpx",
+    "urllib.request",
+)
+
+
+def _trade(
+    *,
+    trade_id: str = "t-1",
+    instrument_id: str = "inst-eth-usdt-perp",
+    entry_time: str = "2026-06-17T17:55:00+00:00",
+) -> dict[str, object]:
+    return {
+        "trade_id": trade_id,
+        "instrument_id": instrument_id,
+        "entry_time": entry_time,
+        "exit_time": "2026-06-17T18:00:00+00:00",
+        "net_pnl": 10.0,
+        "notional": 1000.0,
+    }
+
+
+def _bars_frame() -> pd.DataFrame:
+    if not BARS.is_file():
+        pytest.skip("archive bars unavailable")
+    return _load_bars_from_dataset_path(BARS)
+
+
+def _ledger_rows() -> list[dict[str, object]]:
+    if not LEDGER.is_file():
+        pytest.skip("archive ledger unavailable")
+    return [
+        json.loads(line) for line in LEDGER.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+def _materialize(
+    trades: list[dict[str, object]],
+    bars: pd.DataFrame | None = None,
+    *,
+    spread_half_bps: float = SPREAD_HALF_BPS,
+):
+    frame = bars if bars is not None else _bars_frame()
+    return materialize_productive_point_in_time_factor_snapshots_v0(
+        trade_ledger_rows=trades,
+        bars=frame,
+        spread_half_bps=spread_half_bps,
+        source_dataset_ref=str(BARS),
+        expected_instrument_id="inst-eth-usdt-perp",
+    )
+
+
+def test_strict_less_than_boundary_accepted() -> None:
+    result = _materialize([_trade()])
+    assert result.admissible_count == 1
+    snap = result.snapshots[0]
+    assert snap["feature_timestamp"] < snap["entry_time"]
+
+
+def test_same_time_rejected() -> None:
+    bars = _bars_frame()
+    entry_time = "2026-06-17T17:55:00+00:00"
+    result = _materialize([_trade(entry_time=entry_time)], bars)
+    assert result.admissible_count == 1
+    assert result.snapshots[0]["feature_timestamp"] != entry_time
+
+
+def test_future_record_rejected_when_no_prior_bar() -> None:
+    bars = _bars_frame()
+    early = bars.index.min()
+    result = _materialize([_trade(entry_time=early.isoformat())], bars)
+    assert result.admissible_count == 0
+    assert DropReason.MISSING_PRIOR_BAR.value in result.dropped_rows_by_reason
+
+
+def test_missing_source_fail_closed() -> None:
+    bars = _bars_frame().copy()
+    idx = bars.index[bars.index < pd.Timestamp("2026-06-17T17:55:00+00:00")][-1]
+    bars.at[idx, "volatility_estimate"] = float("nan")
+    result = _materialize([_trade()], bars)
+    assert result.admissible_count == 0
+    assert DropReason.MISSING_VOLATILITY_ESTIMATE.value in result.dropped_rows_by_reason
+
+
+def test_deterministic_asof_selection() -> None:
+    bars = _bars_frame()
+    ts, row = lookup_prior_bar_asof_v0(
+        bars=bars,
+        entry_time="2026-06-17T17:55:00+00:00",
+    )
+    assert isinstance(ts, pd.Timestamp)
+    assert ts.isoformat() == "2026-06-17T17:54:00+00:00"
+    assert row["volatility_estimate"] == pytest.approx(0.0008222710610081796)
+
+
+def test_duplicate_trade_id_rejected() -> None:
+    result = _materialize([_trade(), _trade()])
+    assert DropReason.DUPLICATE_TRADE_ID.value in result.dropped_rows_by_reason
+
+
+def test_missing_spread_binding_rejected() -> None:
+    frame = _bars_frame()
+    result = materialize_productive_point_in_time_factor_snapshots_v0(
+        trade_ledger_rows=[_trade()],
+        bars=frame,
+        spread_half_bps=None,
+        source_dataset_ref=str(BARS),
+    )
+    assert result.admissible_count == 0
+    assert DropReason.MISSING_SPREAD_BPS_BINDING.value in result.dropped_rows_by_reason
+
+
+def test_repeated_materialization_byte_identical() -> None:
+    trades = _ledger_rows()[:5]
+    first = _materialize(trades)
+    second = _materialize(trades)
+    assert serialize_productive_point_in_time_factor_snapshots_v0(
+        first.snapshots
+    ) == serialize_productive_point_in_time_factor_snapshots_v0(second.snapshots)
+    assert first.materialization_digest == second.materialization_digest
+
+
+def test_second_materialization_diff_empty() -> None:
+    trades = _ledger_rows()[:3]
+    first = serialize_productive_point_in_time_factor_snapshots_v0(_materialize(trades).snapshots)
+    second = serialize_productive_point_in_time_factor_snapshots_v0(_materialize(trades).snapshots)
+    assert first == second
+
+
+def test_archive_219_trades_all_admissible_point_in_time() -> None:
+    result = _materialize(_ledger_rows())
+    assert result.admissible_count == 219
+    assert result.status == RematerializationStatus.PASS
+    assert all(s["feature_timestamp"] < s["entry_time"] for s in result.snapshots)
+    assert result.dropped_rows_by_reason == {}
+
+
+def test_productive_join_materializer_path_accepts_rematerialized_snapshots() -> None:
+    result = _materialize(_ledger_rows())
+    join = validate_productive_join_batch_v0(
+        trade_ledger_rows=_ledger_rows(),
+        factor_snapshots=list(result.snapshots),
+    )
+    assert join.row_count_after_filter == 219
+    assert join.dropped_rows_by_reason == {}
+    assert (
+        ProductiveJoinRejectionReason.FEATURE_LEAKAGE_DETECTED.value
+        not in join.dropped_rows_by_reason
+    )
+
+
+def test_stable_feature_order_in_productive_contract() -> None:
+    result = _materialize([_trade()])
+    snap = result.snapshots[0]
+    assert tuple(sorted(snap.keys()))  # snapshot keys stable serialization
+    assert "funding_rate" in snap
+    assert "spread_bps" in snap
+    assert "volatility_estimate" in snap
+    assert EXPECTED_PRODUCTIVE_FACTOR_ORDER == (
+        "funding_rate_abs",
+        "spread_bps",
+        "volatility_estimate",
+    )
+
+
+def test_no_runtime_import_boundary() -> None:
+    for path in (MATERIALIZER_MODULE, RUNNER_MODULE):
+        source = path.read_text(encoding="utf-8")
+        for token in FORBIDDEN_IMPORT_PREFIXES:
+            assert token not in source
+        hits = scan_file_import_boundary(path, repo_root=REPO_ROOT)
+        assert hits == []
+
+
+def test_no_runtime_or_authority_effect() -> None:
+    assert RUNTIME_EFFECT == "NONE"
+    assert AUTHORITY_EFFECT == "NONE"
+
+
+def test_asof_policy_documented() -> None:
+    assert ASOF_POLICY == "latest_finalized_bar_strictly_before_entry_time"
+
+
+def test_cli_materializes_manifestable_output(tmp_path: Path) -> None:
+    if not LEDGER.is_file() or not BARS.is_file():
+        pytest.skip("archive unavailable")
+    out = tmp_path / "out"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER_MODULE),
+            "--out",
+            str(out),
+            "--trade-ledger",
+            str(LEDGER),
+            "--bars-dataset",
+            str(BARS),
+            "--spread-half-bps",
+            str(SPREAD_HALF_BPS),
+            "--instrument-id",
+            "inst-eth-usdt-perp",
+            "--repo-root",
+            str(REPO_ROOT),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads((out / "rematerialization_report.json").read_text(encoding="utf-8"))
+    assert payload["admissible_count"] == 219
+    lines = (out / "productive_point_in_time_factor_snapshots_v0.jsonl").read_text().splitlines()
+    assert len(lines) == 219
+
+
+def test_temp_dir_deterministic_outputs_match() -> None:
+    if not LEDGER.is_file() or not BARS.is_file():
+        pytest.skip("archive unavailable")
+    outputs: list[str] = []
+    for _ in range(2):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(RUNNER_MODULE),
+                    "--out",
+                    str(out),
+                    "--trade-ledger",
+                    str(LEDGER),
+                    "--bars-dataset",
+                    str(BARS),
+                    "--spread-half-bps",
+                    str(SPREAD_HALF_BPS),
+                    "--instrument-id",
+                    "inst-eth-usdt-perp",
+                    "--repo-root",
+                    str(REPO_ROOT),
+                ],
+                capture_output=True,
+                text=True,
+                cwd=str(REPO_ROOT),
+                check=False,
+            )
+            assert proc.returncode == 0, proc.stderr
+            outputs.append(
+                (out / "productive_point_in_time_factor_snapshots_v0.jsonl").read_text(
+                    encoding="utf-8"
+                )
+            )
+    assert outputs[0] == outputs[1]


### PR DESCRIPTION
## Summary
- Add `offline_productive_point_in_time_factor_snapshot_rematerializer_v0` to rematerialize productive factor snapshots using the latest finalized bar strictly before each trade `entry_time`.
- Reuse canonical bars loader and spread-half-bps binding; preserve fail-closed drop reasons for missing prior bars, unfinalized bars, or missing feature values.
- Archive binding proves 219/219 admissible snapshots with `feature_timestamp < entry_time` and productive join acceptance.

## Test plan
- [x] `pytest tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py`
- [x] `pytest tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py`
- [x] Durable evidence at `.../productive_point_in_time_factor_snapshot_rematerialization_v0_20260713T164200Z`


Made with [Cursor](https://cursor.com)