### PR TITLE
Fix factor-exposure materializer contract roundtrip

### DIFF
--- a/tests/research/test_offline_factor_exposure_productive_input_join_materializer_v0.py
+++ b/tests/research/test_offline_factor_exposure_productive_input_join_materializer_v0.py
@@ -297,6 +297,7 @@ def test_materializer_to_contract_roundtrip_pass() -> None:
             trade_id=f"t-{i}",
             entry_time=f"2026-01-01T{i:02d}:00:00+00:00",
             exit_time=f"2026-01-01T{i + 1:02d}:00:00+00:00",
+            net_pnl=float(i),
         )
         for i in range(1, 12)
     ]
@@ -306,6 +307,9 @@ def test_materializer_to_contract_roundtrip_pass() -> None:
             entry_time=f"2026-01-01T{i:02d}:00:00+00:00",
             bar_timestamp=f"2026-01-01T{i:02d}:00:00+00:00",
             feature_timestamp=f"2026-01-01T{i - 1:02d}:00:00+00:00",
+            spread_bps=float(i % 3) + 1.0,
+            funding_rate=-0.0001 * float(i),
+            volatility_estimate=0.01 + float(i % 5) * 0.001,
         )
         for i in range(1, 12)
     ]
@@ -314,6 +318,10 @@ def test_materializer_to_contract_roundtrip_pass() -> None:
     assert len(result.records) == 11
     evidence = fit_factor_exposure(result.records)
     assert evidence.status in {"DIAGNOSTIC_ONLY", "INSUFFICIENT_DATA", "RANK_DEFICIENT_BLOCKED"}
+    assert evidence.original_feature_names == EXPECTED_PRODUCTIVE_FACTOR_ORDER
+    assert evidence.effective_feature_names == EXPECTED_PRODUCTIVE_FACTOR_ORDER
+    assert evidence.excluded_factor_names == ()
+    assert evidence.excluded_factor_count == 0
     assert evidence.feature_names == EXPECTED_PRODUCTIVE_FACTOR_ORDER
 
 


### PR DESCRIPTION
## Summary

- **Root cause:** `test_materializer_to_contract_roundtrip_pass` used constant productive factor snapshot values. After PR #5162 strict zero-variance exclusion, `fit_factor_exposure` correctly excluded `funding_rate_abs` and `spread_bps` (`np.var == 0.0`), leaving only `volatility_estimate` (float-noise variance). Production materializer and factor-exposure owners behaved correctly; the test fixture was stale.
- **Repair:** Update the roundtrip test fixture to use row-varying `spread_bps`, `funding_rate`, `volatility_estimate`, and `net_pnl`, and assert PR5162 metadata (`original_feature_names`, `effective_feature_names`, `excluded_factor_names`, `excluded_factor_count`) alongside `feature_names`.
- **Canonical owners (unchanged):** `src/research/offline_factor_exposure_productive_input_join_materializer_v0.py`, `src/research/linear_evidence/factor_exposure.py`, `src/research/linear_evidence/factor_exposure_productive_contract_v0.py`.

## PR5162 semantics

Zero-variance factor exclusion semantics are **unchanged**. No production owner mutation.

## Test plan

- [x] Single failing test:
  `python3 -m pytest tests/research/test_offline_factor_exposure_productive_input_join_materializer_v0.py::test_materializer_to_contract_roundtrip_pass -v`
- [x] Focused suite (82 tests, same command as failure evidence):
  `python3 -m pytest -q tests/research/test_offline_factor_exposure_diagnostics_v0.py tests/research/test_offline_factor_exposure_productive_input_join_materializer_v0.py tests/research/test_offline_factor_exposure_productive_contract_v0.py tests/governance/test_verify_transitive_evidence_manifests_v0.py`
- [x] Production roundtrip: materialize → `fit_factor_exposure` → PASS
- [x] Deterministic double materialization: byte-identical serialized outputs

## Safety / scope

- SAME_DATASET=true, SAME_UNIVERSE=true, SAME_FEATURE_BINDING=true, SAME_TARGET_BINDING=true, SAME_VALIDATION_POLICY=true
- Economic evaluation **not** executed
- Factor-exposure reevaluation **not** executed
- RUNTIME_EFFECT=NONE, AUTHORITY_EFFECT=NONE

## Durable evidence

- Dir: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/pr5162_factor_exposure_materializer_contract_roundtrip_repair_v0_20260714T123105Z`
- MANIFEST_VERIFY_RC=0

**Note:** Factor-exposure reevaluation remains separately gated and requires explicit operator GO after merge closeout.

Made with [Cursor](https://cursor.com)