### PR TITLE
Offline parameter sensitivity: bind productive fleet inputs

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -181,17 +181,21 @@
         "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
         "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
         "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
+        "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
         "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
         "src/research/linear_evidence/feature_matrix.py",
         "src/research/linear_evidence/sensitivity.py",
         "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
-        "src/research/linear_evidence/signal_matrix_productive_contract_v0.py"
+        "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
+        "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py"
       ],
       "path_globs": [
         "tests/research/test_offline_linear_cost_diagnostic_row_materializer_*",
         "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
         "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
         "tests/research/test_offline_final_research_fleet_signal_matrix_productive_input_join_materializer_*",
+        "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
+        "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_*",
         "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*"
       ]
     },
@@ -210,6 +214,7 @@
         "scripts/research/offline_factor_exposure_diagnostics_v0.py",
         "scripts/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
         "scripts/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
+        "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
         "scripts/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py"
       ],
       "path_globs": [
@@ -219,6 +224,9 @@
         "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
         "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
         "tests/research/test_offline_final_research_fleet_signal_matrix_productive_input_join_materializer_*",
+        "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
+        "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_*",
+        "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
         "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*",
         "tests/research/test_linear_evidence_*"
       ]
@@ -230,7 +238,8 @@
         "src/research/linear_evidence/signal_orthogonality.py",
         "src/research/linear_evidence/factor_exposure.py",
         "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
-        "src/research/linear_evidence/signal_matrix_productive_contract_v0.py"
+        "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
+        "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py"
       ]
     },
     "REPORTING_AND_EVIDENCE_REPAIR": {
@@ -283,6 +292,9 @@
         "src/experiments/stress_tests.py",
         "src/experiments/portfolio_robustness.py",
         "scripts/research/offline_parameter_sensitivity_surface_v0.py"
+      ],
+      "path_globs": [
+        "tests/research/test_offline_parameter_sensitivity_surface_v0.py"
       ]
     },
     "PORTFOLIO_RESEARCH_AND_ECONOMIC_ATTRIBUTION_WITHOUT_RUNTIME_AUTHORITY": {

--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -259,13 +259,16 @@
         "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
         "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
         "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
+        "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
         "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py"
       ]
     },
     "EXPLICITLY_CALIBRATABLE_RESEARCH_PARAMETERS_WITHIN_PREDECLARED_RANGES": {
       "path_prefixes": [
         "src/research/linear_evidence/sensitivity.py",
-        "scripts/research/offline_parameter_sensitivity_surface_v0.py"
+        "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
+        "scripts/research/offline_parameter_sensitivity_surface_v0.py",
+        "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py"
       ]
     },
     "TIME_ORDERED_VALIDATION": {

--- a/scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py
+++ b/scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve()
+
+
+def discover_repo_root_from_script() -> Path | None:
+    for parent in [_SCRIPT_PATH, *_SCRIPT_PATH.parents]:
+        if (parent / "src").is_dir() and (parent / ".git").exists():
+            return parent.resolve()
+    return None
+
+
+def validate_peak_trade_repo_root(repo_root: Path) -> Path:
+    resolved = repo_root.expanduser().resolve()
+    if not resolved.is_dir():
+        raise SystemExit(f"REPO_ROOT_INVALID_NOT_DIRECTORY: {resolved}")
+    if not (resolved / "src").is_dir():
+        raise SystemExit(f"REPO_ROOT_INVALID_MISSING_SRC: {resolved}")
+    if not (resolved / ".git").exists():
+        raise SystemExit(f"REPO_ROOT_INVALID_MISSING_GIT: {resolved}")
+    return resolved
+
+
+def resolve_repo_root(explicit: Path | None) -> Path:
+    if explicit is not None:
+        return validate_peak_trade_repo_root(explicit)
+    discovered = discover_repo_root_from_script()
+    if discovered is None:
+        raise SystemExit("REPO_ROOT_DISCOVERY_FAILED: not inside Peak_Trade repo")
+    return discovered
+
+
+_discovered_repo_root = discover_repo_root_from_script()
+if _discovered_repo_root is not None:
+    repo_s = str(_discovered_repo_root)
+    src_s = str(_discovered_repo_root / "src")
+    if src_s not in sys.path:
+        sys.path.insert(0, src_s)
+    if repo_s not in sys.path:
+        sys.path.insert(0, repo_s)
+
+from src.research.offline_parameter_sensitivity_productive_input_join_materializer_v0 import (  # noqa: E402
+    materialize_from_manifest_paths_v0,
+    serialize_materialized_productive_inputs_v0,
+)
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Offline parameter sensitivity productive input join materializer v0"
+    )
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--signal-matrix", type=Path, required=True)
+    parser.add_argument("--productive-binding", type=Path, default=None)
+    parser.add_argument("--strategy-id", default="trend_following")
+    parser.add_argument("--repo-root", type=Path, default=None)
+    args = parser.parse_args()
+
+    repo_root = resolve_repo_root(args.repo_root)
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    result = materialize_from_manifest_paths_v0(
+        repo_root=repo_root,
+        signal_matrix_path=args.signal_matrix,
+        binding_completion_path=args.productive_binding,
+        strategy_id=args.strategy_id,
+    )
+
+    inputs_path = out / "productive_parameter_sensitivity_inputs.jsonl"
+    inputs_path.write_text(
+        serialize_materialized_productive_inputs_v0(result.records),
+        encoding="utf-8",
+    )
+    report = {
+        "status": result.status.value,
+        "materialization_digest": result.materialization_digest,
+        "output_digest": result.output_digest,
+        "productive_input_digest": result.productive_input_digest,
+        "grid_digest": result.grid_digest,
+        "source_binding_digest": result.source_binding_digest,
+        "source_signal_matrix_digest": result.source_signal_matrix_digest,
+        "binding": result.join_result.binding.to_dict(),
+        "grid": result.join_result.grid.to_dict(),
+        "grid_specs": [
+            {
+                "parameter_name": spec.parameter_name,
+                "scaled_feature_name": spec.scaled_feature_name,
+                "parameter_values": list(spec.parameter_values),
+            }
+            for spec in result.join_result.grid_specs
+        ],
+        "provenance": result.provenance.to_dict(),
+        "row_count_before_filter": result.join_result.row_count_before_filter,
+        "row_count_after_filter": result.join_result.row_count_after_filter,
+        "dropped_rows_by_reason": dict(result.join_result.dropped_rows_by_reason),
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "offline_only": True,
+        "economic_evaluation_executed": False,
+    }
+    report_path = out / "materialization_report.json"
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    final_report = "\n".join(
+        [
+            f"STATUS={result.status.value}",
+            f"VERDICT={'PASS' if result.status.value == 'PASS' else 'FAIL_CLOSED'}",
+            f"PRODUCTIVE_BINDING_FOUND={bool(result.records)}",
+            f"OUTPUT_DIGEST={result.output_digest}",
+            f"PRODUCTIVE_INPUT_DIGEST={result.productive_input_digest}",
+            f"GRID_DIGEST={result.grid_digest}",
+            f"MATERIALIZATION_DIGEST={result.materialization_digest}",
+            "AUTHORITY_EFFECT=NONE",
+            "RUNTIME_EFFECT=NONE",
+            f"REPORT={report_path}",
+        ]
+    )
+    (out / "final_report.txt").write_text(final_report + "\n", encoding="utf-8")
+
+    print(final_report)
+    return 0 if result.status.value == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/offline_parameter_sensitivity_surface_v0.py
+++ b/scripts/research/offline_parameter_sensitivity_surface_v0.py
@@ -10,11 +10,23 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 sys.path.insert(0, str(REPO_ROOT))
 
-from research.linear_evidence.sensitivity import (
+from research.linear_evidence.sensitivity import (  # noqa: E402
     ParameterGridSpecV1,
     ParameterSensitivityInputV1,
     fit_parameter_sensitivity_surface,
 )
+from src.research.offline_parameter_sensitivity_productive_input_join_materializer_v0 import (  # noqa: E402
+    MaterializationStatus,
+    load_signal_matrix_rows,
+    materialize_offline_parameter_sensitivity_productive_inputs_v0,
+    serialize_materialized_productive_inputs_v0,
+)
+from src.research.offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0 import (  # noqa: E402
+    load_ratified_binding_completion_v0,
+)
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
 
 
 def _record(
@@ -109,14 +121,7 @@ def _fixture_truth_pack() -> dict[str, object]:
     }
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--out", required=True)
-    args = parser.parse_args()
-
-    out = Path(args.out)
-    out.mkdir(parents=True, exist_ok=True)
-
+def _run_fixture_mode(out: Path) -> int:
     grid = ParameterGridSpecV1(
         parameter_name="signal_scale",
         scaled_feature_name="signal",
@@ -128,12 +133,17 @@ def main() -> int:
     report = evidence.to_dict()
     report.update(
         {
+            "INPUT_MODE": "FIXTURE_SCAFFOLD",
+            "PRODUCTIVE_BINDING_REQUESTED": False,
+            "PRODUCTIVE_BINDING_RESOLVED": False,
+            "FIXTURE_SCAFFOLD_USED": True,
             "offline_only": True,
             "system_economic_evidence_admissible": False,
             "runtime_rewire_admissible": False,
             "promotion_pass_authority": False,
             "no_parameter_auto_optimization": True,
             "no_parameter_default_change_in_v0": True,
+            "economic_evaluation_executed": False,
             "fixture_truth_pack": truth_pack,
         }
     )
@@ -143,6 +153,7 @@ def main() -> int:
     print(f"STATUS={evidence.status}")
     print("AUTHORITY_EFFECT=NONE")
     print("RUNTIME_EFFECT=NONE")
+    print("INPUT_MODE=FIXTURE_SCAFFOLD")
     print(f"PLATEAU_DETECTED={evidence.plateau_detected}")
     print(f"FRAGILE_SPIKE_DETECTED={evidence.fragile_spike_detected}")
     print(f"REASON_CODES={','.join(evidence.reason_codes) or 'NONE'}")
@@ -157,6 +168,115 @@ def main() -> int:
             "INSUFFICIENT_DATA",
         }
         else 1
+    )
+
+
+def _run_productive_binding_mode(
+    out: Path,
+    *,
+    signal_matrix_path: Path,
+    productive_binding_path: Path | None,
+    strategy_id: str,
+) -> int:
+    signal_rows = load_signal_matrix_rows(signal_matrix_path)
+    binding_payload = None
+    if productive_binding_path is not None:
+        binding_payload = json.loads(productive_binding_path.read_text(encoding="utf-8"))
+    else:
+        binding_payload = load_ratified_binding_completion_v0(REPO_ROOT)
+
+    materialization = materialize_offline_parameter_sensitivity_productive_inputs_v0(
+        signal_matrix_rows=signal_rows,
+        repo_root=REPO_ROOT,
+        binding_completion=binding_payload,
+        strategy_id=strategy_id,
+    )
+
+    binding_report = {
+        "INPUT_MODE": "PRODUCTIVE_BINDING",
+        "PRODUCTIVE_BINDING_REQUESTED": True,
+        "PRODUCTIVE_BINDING_RESOLVED": materialization.status == MaterializationStatus.PASS,
+        "FIXTURE_SCAFFOLD_USED": False,
+        "status": materialization.status.value,
+        "materialization_digest": materialization.materialization_digest,
+        "output_digest": materialization.output_digest,
+        "productive_input_digest": materialization.productive_input_digest,
+        "grid_digest": materialization.grid_digest,
+        "source_binding_digest": materialization.source_binding_digest,
+        "source_signal_matrix_digest": materialization.source_signal_matrix_digest,
+        "binding": materialization.join_result.binding.to_dict(),
+        "grid": materialization.join_result.grid.to_dict(),
+        "grid_specs": [
+            {
+                "parameter_name": spec.parameter_name,
+                "scaled_feature_name": spec.scaled_feature_name,
+                "parameter_values": list(spec.parameter_values),
+            }
+            for spec in materialization.join_result.grid_specs
+        ],
+        "provenance": materialization.provenance.to_dict(),
+        "row_count_before_filter": materialization.join_result.row_count_before_filter,
+        "row_count_after_filter": materialization.join_result.row_count_after_filter,
+        "dropped_rows_by_reason": dict(materialization.join_result.dropped_rows_by_reason),
+        "offline_only": True,
+        "system_economic_evidence_admissible": False,
+        "runtime_rewire_admissible": False,
+        "promotion_pass_authority": False,
+        "no_parameter_auto_optimization": True,
+        "no_parameter_default_change_in_v0": True,
+        "economic_evaluation_executed": False,
+        "sensitivity_surface_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+    }
+    report_path = out / "parameter_sensitivity_productive_binding_v0.json"
+    report_path.write_text(
+        json.dumps(binding_report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    inputs_path = out / "productive_parameter_sensitivity_inputs.jsonl"
+    inputs_path.write_text(
+        serialize_materialized_productive_inputs_v0(materialization.records),
+        encoding="utf-8",
+    )
+
+    print(f"STATUS={materialization.status.value}")
+    print("AUTHORITY_EFFECT=NONE")
+    print("RUNTIME_EFFECT=NONE")
+    print("INPUT_MODE=PRODUCTIVE_BINDING")
+    print(f"PRODUCTIVE_BINDING_RESOLVED={materialization.status == MaterializationStatus.PASS}")
+    print(f"PRODUCTIVE_INPUT_DIGEST={materialization.productive_input_digest}")
+    print(f"GRID_DIGEST={materialization.grid_digest}")
+    print(f"REPORT={report_path}")
+    return 0 if materialization.status == MaterializationStatus.PASS else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--fixture", action="store_true")
+    parser.add_argument("--signal-matrix", type=Path, default=None)
+    parser.add_argument("--productive-binding", type=Path, default=None)
+    parser.add_argument("--parameter-grid", default="trend_following")
+    args = parser.parse_args()
+
+    productive_requested = args.signal_matrix is not None or args.productive_binding is not None
+    if args.fixture and productive_requested:
+        raise SystemExit("MIXED_MODE_BLOCKED: fixture and productive modes are mutually exclusive")
+    if not args.fixture and not productive_requested:
+        args.fixture = True
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    if args.fixture:
+        return _run_fixture_mode(out)
+    if args.signal_matrix is None:
+        raise SystemExit("TARGET_BINDING_MISSING: --signal-matrix required for productive mode")
+    return _run_productive_binding_mode(
+        out,
+        signal_matrix_path=args.signal_matrix,
+        productive_binding_path=args.productive_binding,
+        strategy_id=args.parameter_grid,
     )
 
 

--- a/src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py
+++ b/src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py
@@ -1,0 +1,482 @@
+"""Operator-ratified productive normative contract for offline parameter sensitivity v0.
+
+Offline-only, authority-neutral contract owner. No IO, runtime, trading logic, or solver
+duplication. Materializer execution remains a separate scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from math import isfinite
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+from src.backtest.parameter_sensitivity_v1 import (
+    PARAMETER_SENSITIVITY_OWNER,
+    ParameterSensitivityError,
+    ParameterSensitivityGridV1,
+    load_parameter_grid_v1,
+)
+from src.backtest.strategy_signal_binding_v1 import (
+    _EVALUATION_ONLY_STRATEGY_PARAMS_V1,
+    _EXTERNAL_PARAMETER_SCHEMA_V1,
+)
+from src.research.final_research_fleet_v0_versioned_binding_manifest_contract_v0 import (
+    FLEET_CANDIDATES,
+    load_step31f_evaluation_config_v0,
+)
+from src.research.linear_evidence.factor_exposure_productive_contract_v0 import (
+    AUTHORITY_EFFECT,
+    RUNTIME_EFFECT,
+    stable_digest_v0,
+)
+from src.research.linear_evidence.sensitivity import (
+    ParameterGridSpecV1,
+    ParameterSensitivityInputV1,
+)
+from src.research.linear_evidence.signal_matrix_productive_contract_v0 import (
+    DECISION_TIME_KEY,
+    EXPECTED_FLEET_SIGNAL_ORDER,
+    FEATURE_TIME_KEY,
+    INSTRUMENT_ID_KEY,
+    RATIFIED_BINDING_SOURCE,
+    RATIFIED_FLEET_SIGNAL_IDS,
+    compute_signal_matrix_digest_v0,
+)
+
+PACKAGE_MARKER = "OFFLINE_PARAMETER_SENSITIVITY_PRODUCTIVE_CONTRACT_V0=true"
+
+BINDING_CONTRACT_VERSION = "offline_parameter_sensitivity_binding_v0"
+GRID_CONTRACT_VERSION = "offline_parameter_sensitivity_grid_join_v0"
+PROVENANCE_CONTRACT_VERSION = "offline_parameter_sensitivity_provenance_v0"
+
+ALLOWED_CALIBRATABLE_PARAMETERS: tuple[str, ...] = ("fee_bps", "slippage_bps")
+DIAGNOSTIC_ONLY_PARAMETERS: frozenset[str] = frozenset({"signal_scale"})
+FLEET_STRATEGY_IDS: frozenset[str] = frozenset(sid for sid, _ in FLEET_CANDIDATES)
+
+PARAMETER_CLASS_CONSTITUTIONAL_CORE = "CONSTITUTIONAL_CORE"
+PARAMETER_CLASS_EXPLICITLY_CALIBRATABLE = "EXPLICITLY_CALIBRATABLE_RESEARCH_PARAMETER"
+PARAMETER_CLASS_DIAGNOSTIC_ONLY = "DIAGNOSTIC_ONLY"
+PARAMETER_CLASS_UNKNOWN = "UNKNOWN"
+
+
+class ProductiveBindingRejectionReason(str, Enum):
+    BINDING_DIGEST_MISMATCH = "BINDING_DIGEST_MISMATCH"
+    SIGNAL_MATRIX_DIGEST_MISMATCH = "SIGNAL_MATRIX_DIGEST_MISMATCH"
+    MISSING_FLEET_BINDING = "MISSING_FLEET_BINDING"
+    MISSING_SIGNAL_MATRIX = "MISSING_SIGNAL_MATRIX"
+    UNKNOWN_PARAMETER = "UNKNOWN_PARAMETER"
+    CONSTITUTIONAL_PARAMETER_VARIATION_REQUESTED = "CONSTITUTIONAL_PARAMETER_VARIATION_REQUESTED"
+    DIAGNOSTIC_ONLY_PARAMETER_VARIATION_REQUESTED = "DIAGNOSTIC_ONLY_PARAMETER_VARIATION_REQUESTED"
+    UNDECLARED_PARAMETER_RANGE = "UNDECLARED_PARAMETER_RANGE"
+    GRID_SPEC_INVALID = "GRID_SPEC_INVALID"
+    TARGET_BINDING_MISSING = "TARGET_BINDING_MISSING"
+    FEATURE_LEAKAGE_DETECTED = "FEATURE_LEAKAGE_DETECTED"
+    NON_FINITE_FEATURE_VALUE = "NON_FINITE_FEATURE_VALUE"
+    NON_FINITE_TARGET = "NON_FINITE_TARGET"
+    PARAMETER_NOT_IN_ALLOWED_SURFACE = "PARAMETER_NOT_IN_ALLOWED_SURFACE"
+
+
+@dataclass(frozen=True)
+class ParameterClassificationRowV0:
+    strategy_name: str
+    parameter_name: str
+    parameter_class: str
+    baseline_value: Any
+    mutation_allowed: bool
+    sensitivity_variation_allowed: bool
+
+
+@dataclass(frozen=True)
+class ParameterSensitivityProductiveBindingV0:
+    contract_version: str = BINDING_CONTRACT_VERSION
+    binding_source_path: str = RATIFIED_BINDING_SOURCE
+    binding_digest: str = ""
+    signal_matrix_digest: str = ""
+    strategy_id: str = ""
+    strategy_version: str = "v1"
+    baseline_fee_bps: float = 0.0
+    baseline_slippage_bps: float = 0.0
+    grid_id: str = ""
+    grid_digest: str = ""
+    authority_effect: str = AUTHORITY_EFFECT
+    runtime_effect: str = RUNTIME_EFFECT
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "binding_source_path": self.binding_source_path,
+            "binding_digest": self.binding_digest,
+            "signal_matrix_digest": self.signal_matrix_digest,
+            "strategy_id": self.strategy_id,
+            "strategy_version": self.strategy_version,
+            "baseline_fee_bps": self.baseline_fee_bps,
+            "baseline_slippage_bps": self.baseline_slippage_bps,
+            "grid_id": self.grid_id,
+            "grid_digest": self.grid_digest,
+            "authority_effect": self.authority_effect,
+            "runtime_effect": self.runtime_effect,
+        }
+
+
+@dataclass(frozen=True)
+class ProductiveBindingRejectedRowV0:
+    instrument_id: str
+    decision_time: str
+    reason: ProductiveBindingRejectionReason
+
+
+@dataclass(frozen=True)
+class ProductiveBindingValidationResultV0:
+    admissible_records: tuple[ParameterSensitivityInputV1, ...]
+    rejected: tuple[ProductiveBindingRejectedRowV0, ...]
+    row_count_before_filter: int
+    row_count_after_filter: int
+    dropped_rows_by_reason: dict[str, int]
+    binding: ParameterSensitivityProductiveBindingV0
+    grid: ParameterSensitivityGridV1
+    grid_specs: tuple[ParameterGridSpecV1, ...]
+    authority_effect: str = AUTHORITY_EFFECT
+    runtime_effect: str = RUNTIME_EFFECT
+
+
+@dataclass(frozen=True)
+class ParameterSensitivityProductiveProvenanceV0:
+    contract_version: str = PROVENANCE_CONTRACT_VERSION
+    binding_source_path: str = RATIFIED_BINDING_SOURCE
+    binding_digest: str = ""
+    signal_matrix_digest: str = ""
+    grid_digest: str = ""
+    strategy_id: str = ""
+    strategy_version: str = "v1"
+    parameter_names: tuple[str, ...] = ALLOWED_CALIBRATABLE_PARAMETERS
+    row_count_before_filter: int = 0
+    row_count_after_filter: int = 0
+    dropped_rows_by_reason: dict[str, int] = field(default_factory=dict)
+    implementation_digest: str = ""
+    grid_owner: str = PARAMETER_SENSITIVITY_OWNER
+    authority_effect: str = AUTHORITY_EFFECT
+    runtime_effect: str = RUNTIME_EFFECT
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "binding_source_path": self.binding_source_path,
+            "binding_digest": self.binding_digest,
+            "signal_matrix_digest": self.signal_matrix_digest,
+            "grid_digest": self.grid_digest,
+            "strategy_id": self.strategy_id,
+            "strategy_version": self.strategy_version,
+            "parameter_names": list(self.parameter_names),
+            "row_count_before_filter": self.row_count_before_filter,
+            "row_count_after_filter": self.row_count_after_filter,
+            "dropped_rows_by_reason": dict(self.dropped_rows_by_reason),
+            "implementation_digest": self.implementation_digest,
+            "grid_owner": self.grid_owner,
+            "authority_effect": self.authority_effect,
+            "runtime_effect": self.runtime_effect,
+        }
+
+
+def classify_fleet_parameters_v0() -> tuple[ParameterClassificationRowV0, ...]:
+    rows: list[ParameterClassificationRowV0] = []
+    calibratable_names = frozenset(ALLOWED_CALIBRATABLE_PARAMETERS)
+    for strategy_id in sorted(FLEET_STRATEGY_IDS):
+        schema = _EXTERNAL_PARAMETER_SCHEMA_V1.get(strategy_id, {})
+        eval_only = _EVALUATION_ONLY_STRATEGY_PARAMS_V1.get(strategy_id, frozenset())
+        for name, default in schema.items():
+            if name in eval_only:
+                pclass = PARAMETER_CLASS_DIAGNOSTIC_ONLY
+            else:
+                pclass = PARAMETER_CLASS_CONSTITUTIONAL_CORE
+            rows.append(
+                ParameterClassificationRowV0(
+                    strategy_name=strategy_id,
+                    parameter_name=name,
+                    parameter_class=pclass,
+                    baseline_value=default,
+                    mutation_allowed=False,
+                    sensitivity_variation_allowed=False,
+                )
+            )
+        for name in calibratable_names:
+            rows.append(
+                ParameterClassificationRowV0(
+                    strategy_name=strategy_id,
+                    parameter_name=name,
+                    parameter_class=PARAMETER_CLASS_EXPLICITLY_CALIBRATABLE,
+                    baseline_value=None,
+                    mutation_allowed=True,
+                    sensitivity_variation_allowed=True,
+                )
+            )
+    rows.append(
+        ParameterClassificationRowV0(
+            strategy_name="fleet_aggregate",
+            parameter_name="signal_scale",
+            parameter_class=PARAMETER_CLASS_DIAGNOSTIC_ONLY,
+            baseline_value=1.0,
+            mutation_allowed=False,
+            sensitivity_variation_allowed=False,
+        )
+    )
+    return tuple(rows)
+
+
+def validate_parameter_variation_allowed_v0(parameter_name: str) -> str | None:
+    if parameter_name in DIAGNOSTIC_ONLY_PARAMETERS:
+        return ProductiveBindingRejectionReason.DIAGNOSTIC_ONLY_PARAMETER_VARIATION_REQUESTED.value
+    if parameter_name not in ALLOWED_CALIBRATABLE_PARAMETERS:
+        for strategy_id in FLEET_STRATEGY_IDS:
+            schema = _EXTERNAL_PARAMETER_SCHEMA_V1.get(strategy_id, {})
+            if parameter_name in schema:
+                return ProductiveBindingRejectionReason.CONSTITUTIONAL_PARAMETER_VARIATION_REQUESTED.value
+        return ProductiveBindingRejectionReason.UNKNOWN_PARAMETER.value
+    return None
+
+
+def validate_binding_digest_v0(
+    *,
+    expected_digest: str,
+    actual_digest: str,
+) -> str | None:
+    if not expected_digest or not actual_digest:
+        return ProductiveBindingRejectionReason.MISSING_FLEET_BINDING.value
+    if expected_digest != actual_digest:
+        return ProductiveBindingRejectionReason.BINDING_DIGEST_MISMATCH.value
+    return None
+
+
+def validate_signal_matrix_digest_v0(
+    *,
+    expected_digest: str | None,
+    actual_digest: str,
+    rows: Sequence[Mapping[str, Any]],
+) -> str | None:
+    if not rows:
+        return ProductiveBindingRejectionReason.MISSING_SIGNAL_MATRIX.value
+    computed = compute_signal_matrix_digest_v0(rows)
+    if expected_digest is not None and expected_digest != computed:
+        return ProductiveBindingRejectionReason.SIGNAL_MATRIX_DIGEST_MISMATCH.value
+    if actual_digest != computed:
+        return ProductiveBindingRejectionReason.SIGNAL_MATRIX_DIGEST_MISMATCH.value
+    return None
+
+
+def resolve_baseline_cost_params_v0(cfg: Mapping[str, Any]) -> tuple[float, float]:
+    backtest = cfg.get("backtest", {})
+    if not isinstance(backtest, Mapping):
+        raise ValueError(ProductiveBindingRejectionReason.TARGET_BINDING_MISSING.value)
+    fee_bps = backtest.get("fee_bps")
+    slippage_bps = backtest.get("slippage_bps")
+    if fee_bps is None or slippage_bps is None:
+        raise ValueError(ProductiveBindingRejectionReason.TARGET_BINDING_MISSING.value)
+    return float(fee_bps), float(slippage_bps)
+
+
+def load_productive_parameter_grid_v0(
+    *,
+    repo_root: Path,
+    strategy_id: str,
+    strategy_version: str = "v1",
+    data_digest: str,
+    instrument_id: str = "okx:linear_perpetual:ETH:USDT:USDT:perp",
+) -> ParameterSensitivityGridV1:
+    cfg = load_step31f_evaluation_config_v0(repo_root, strategy_id)
+    timestamps = pd.date_range("2024-05-30T20:00:00Z", periods=32, freq="1h", tz="UTC")
+    bars = pd.DataFrame(
+        {
+            "open": [100.0] * len(timestamps),
+            "high": [101.0] * len(timestamps),
+            "low": [99.0] * len(timestamps),
+            "close": [100.0] * len(timestamps),
+            "volume": [1000.0] * len(timestamps),
+        },
+        index=timestamps,
+    )
+    try:
+        return load_parameter_grid_v1(
+            cfg,
+            strategy_id=strategy_id,
+            strategy_version=strategy_version,
+            bars=bars,
+            data_digest=data_digest,
+            instrument_id=instrument_id,
+        )
+    except ParameterSensitivityError as exc:
+        raise ValueError(
+            f"{ProductiveBindingRejectionReason.GRID_SPEC_INVALID.value}:{exc}"
+        ) from exc
+
+
+def build_parameter_grid_specs_v0(
+    grid: ParameterSensitivityGridV1,
+) -> tuple[ParameterGridSpecV1, ...]:
+    specs: list[ParameterGridSpecV1] = []
+    for index, name in enumerate(grid.parameter_names):
+        if name not in ALLOWED_CALIBRATABLE_PARAMETERS:
+            raise ValueError(
+                ProductiveBindingRejectionReason.PARAMETER_NOT_IN_ALLOWED_SURFACE.value
+            )
+        values = grid.parameter_values[index]
+        specs.append(
+            ParameterGridSpecV1(
+                parameter_name=name,
+                scaled_feature_name=name,
+                parameter_values=tuple(float(value) for value in values),
+            )
+        )
+    return tuple(specs)
+
+
+def _diagnostic_target_from_signals(row: Mapping[str, Any]) -> float:
+    values = [float(row[name]) for name in EXPECTED_FLEET_SIGNAL_ORDER]
+    return sum(values) / len(values)
+
+
+def materialize_productive_sensitivity_row_v0(
+    row: Mapping[str, Any],
+    *,
+    baseline_fee_bps: float,
+    baseline_slippage_bps: float,
+) -> tuple[ParameterSensitivityInputV1 | None, str | None]:
+    instrument_id = str(row.get(INSTRUMENT_ID_KEY, ""))
+    decision_time = str(row.get(DECISION_TIME_KEY, ""))
+    feature_time = str(row.get(FEATURE_TIME_KEY, ""))
+    if not instrument_id or not decision_time or not feature_time:
+        return None, ProductiveBindingRejectionReason.TARGET_BINDING_MISSING.value
+    if feature_time >= decision_time:
+        return None, ProductiveBindingRejectionReason.FEATURE_LEAKAGE_DETECTED.value
+    features: dict[str, float] = {
+        "fee_bps": float(baseline_fee_bps),
+        "slippage_bps": float(baseline_slippage_bps),
+    }
+    for name in EXPECTED_FLEET_SIGNAL_ORDER:
+        if name not in row:
+            return None, ProductiveBindingRejectionReason.TARGET_BINDING_MISSING.value
+        value = float(row[name])
+        if not isfinite(value):
+            return None, ProductiveBindingRejectionReason.NON_FINITE_FEATURE_VALUE.value
+        features[name] = value
+    target = _diagnostic_target_from_signals(row)
+    if not isfinite(target):
+        return None, ProductiveBindingRejectionReason.NON_FINITE_TARGET.value
+    return (
+        ParameterSensitivityInputV1(
+            instrument_id=instrument_id,
+            decision_time=decision_time,
+            feature_availability_time=feature_time,
+            target=target,
+            features=features,
+        ),
+        None,
+    )
+
+
+def validate_productive_binding_batch_v0(
+    *,
+    signal_matrix_rows: Sequence[Mapping[str, Any]],
+    binding_completion: Mapping[str, Any],
+    repo_root: Path,
+    strategy_id: str = "trend_following",
+    expected_binding_digest: str | None = None,
+    expected_signal_matrix_digest: str | None = None,
+) -> ProductiveBindingValidationResultV0:
+    binding_digest = str(binding_completion.get("completion_digest", ""))
+    digest_reason = validate_binding_digest_v0(
+        expected_digest=expected_binding_digest or binding_digest,
+        actual_digest=binding_digest,
+    )
+    if digest_reason is not None:
+        raise ValueError(digest_reason)
+
+    signal_matrix_digest = compute_signal_matrix_digest_v0(signal_matrix_rows)
+    matrix_reason = validate_signal_matrix_digest_v0(
+        expected_digest=expected_signal_matrix_digest,
+        actual_digest=signal_matrix_digest,
+        rows=signal_matrix_rows,
+    )
+    if matrix_reason is not None:
+        raise ValueError(matrix_reason)
+
+    shared = binding_completion.get("shared_bindings", {})
+    dataset_binding = shared.get("dataset_binding", {}) if isinstance(shared, Mapping) else {}
+    data_digest = str(dataset_binding.get("data_digest", ""))
+
+    cfg = load_step31f_evaluation_config_v0(repo_root, strategy_id)
+    baseline_fee_bps, baseline_slippage_bps = resolve_baseline_cost_params_v0(cfg)
+    grid = load_productive_parameter_grid_v0(
+        repo_root=repo_root,
+        strategy_id=strategy_id,
+        data_digest=data_digest,
+    )
+    grid_specs = build_parameter_grid_specs_v0(grid)
+
+    candidates = {
+        str(item.get("strategy_id", "")): item
+        for item in binding_completion.get("candidates", [])
+        if isinstance(item, Mapping)
+    }
+    if strategy_id not in candidates:
+        raise ValueError(ProductiveBindingRejectionReason.MISSING_FLEET_BINDING.value)
+    strategy_version = str(candidates[strategy_id].get("strategy_version", "v1"))
+
+    binding = ParameterSensitivityProductiveBindingV0(
+        binding_digest=binding_digest,
+        signal_matrix_digest=signal_matrix_digest,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        baseline_fee_bps=baseline_fee_bps,
+        baseline_slippage_bps=baseline_slippage_bps,
+        grid_id=grid.grid_id,
+        grid_digest=grid.grid_digest,
+    )
+
+    rejected: list[ProductiveBindingRejectedRowV0] = []
+    dropped: dict[str, int] = {}
+    admissible: list[ParameterSensitivityInputV1] = []
+    ordered_rows = sorted(
+        signal_matrix_rows,
+        key=lambda row: (
+            str(row.get(INSTRUMENT_ID_KEY, "")),
+            str(row.get(DECISION_TIME_KEY, "")),
+        ),
+    )
+    for row in ordered_rows:
+        record, reason = materialize_productive_sensitivity_row_v0(
+            row,
+            baseline_fee_bps=baseline_fee_bps,
+            baseline_slippage_bps=baseline_slippage_bps,
+        )
+        if record is None:
+            rejected.append(
+                ProductiveBindingRejectedRowV0(
+                    instrument_id=str(row.get(INSTRUMENT_ID_KEY, "")),
+                    decision_time=str(row.get(DECISION_TIME_KEY, "")),
+                    reason=ProductiveBindingRejectionReason(reason or "TARGET_BINDING_MISSING"),
+                )
+            )
+            key = reason or ProductiveBindingRejectionReason.TARGET_BINDING_MISSING.value
+            dropped[key] = dropped.get(key, 0) + 1
+            continue
+        admissible.append(record)
+
+    return ProductiveBindingValidationResultV0(
+        admissible_records=tuple(admissible),
+        rejected=tuple(rejected),
+        row_count_before_filter=len(signal_matrix_rows),
+        row_count_after_filter=len(admissible),
+        dropped_rows_by_reason=dropped,
+        binding=binding,
+        grid=grid,
+        grid_specs=grid_specs,
+    )
+
+
+def validate_fleet_candidate_set_v0(strategy_ids: Sequence[str]) -> None:
+    requested = set(strategy_ids)
+    if requested != set(RATIFIED_FLEET_SIGNAL_IDS):
+        raise ValueError(ProductiveBindingRejectionReason.MISSING_FLEET_BINDING.value)

--- a/src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py
+++ b/src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py
@@ -1,0 +1,315 @@
+"""Offline parameter sensitivity productive input join materializer v0.
+
+Deterministic, offline-only join of ratified final-research-fleet signal matrix rows
+to parameter sensitivity inputs via the operator-ratified productive contract v0.
+Reuses ``validate_productive_binding_batch_v0`` as the sole join owner. No OLS,
+economic evaluation, runtime, order, scheduler, or authority effect.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.research.linear_evidence.parameter_sensitivity_productive_contract_v0 import (
+    AUTHORITY_EFFECT,
+    ALLOWED_CALIBRATABLE_PARAMETERS,
+    ParameterSensitivityProductiveBindingV0,
+    ParameterSensitivityProductiveProvenanceV0,
+    ProductiveBindingValidationResultV0,
+    RUNTIME_EFFECT,
+    load_productive_parameter_grid_v0,
+    stable_digest_v0,
+    validate_productive_binding_batch_v0,
+)
+from src.research.linear_evidence.sensitivity import ParameterSensitivityInputV1
+from src.research.linear_evidence.signal_matrix_productive_contract_v0 import (
+    compute_signal_matrix_digest_v0,
+)
+from src.research.offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0 import (
+    load_ratified_binding_completion_v0,
+)
+
+PACKAGE_MARKER = "OFFLINE_PARAMETER_SENSITIVITY_PRODUCTIVE_INPUT_JOIN_MATERIALIZER_V0=true"
+SCHEMA_VERSION = "offline_parameter_sensitivity_productive_input_join_materializer.v0"
+CANONICAL_CONTRACT_OWNER = (
+    "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py"
+)
+CANONICAL_GRID_OWNER = "src/backtest/parameter_sensitivity_v1.py"
+IMPLEMENTATION_DIGEST = stable_digest_v0(
+    {
+        "contract": SCHEMA_VERSION,
+        "join_owner": CANONICAL_CONTRACT_OWNER,
+        "grid_owner": CANONICAL_GRID_OWNER,
+        "allowed_parameters": list(ALLOWED_CALIBRATABLE_PARAMETERS),
+    }
+)
+
+
+class MaterializationStatus(str, Enum):
+    PASS = "PASS"
+    INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
+    TARGET_BINDING_MISSING = "TARGET_BINDING_MISSING"
+
+
+@dataclass(frozen=True)
+class MaterializationResultV0:
+    status: MaterializationStatus
+    records: tuple[ParameterSensitivityInputV1, ...]
+    join_result: ProductiveBindingValidationResultV0
+    provenance: ParameterSensitivityProductiveProvenanceV0
+    materialization_digest: str
+    output_digest: str
+    productive_input_digest: str
+    grid_digest: str
+    source_binding_digest: str
+    source_signal_matrix_digest: str
+    authority_effect: str = AUTHORITY_EFFECT
+    runtime_effect: str = RUNTIME_EFFECT
+
+
+def load_signal_matrix_rows(path: Path) -> tuple[dict[str, Any], ...]:
+    rows: list[dict[str, Any]] = []
+    if path.suffix.lower() == ".jsonl":
+        for line in path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            payload = json.loads(stripped)
+            if not isinstance(payload, dict):
+                raise ValueError("JSONL_ROW_NOT_OBJECT")
+            rows.append(payload)
+        return tuple(rows)
+    if path.suffix.lower() == ".csv":
+        import csv
+
+        with path.open(encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            for row in reader:
+                payload = {key: row[key] for key in row}
+                for signal_key in ("bollinger_bands", "momentum_1h", "trend_following"):
+                    if signal_key in payload:
+                        payload[signal_key] = float(payload[signal_key])
+                rows.append(payload)
+        return tuple(rows)
+    raise ValueError(f"UNSUPPORTED_SIGNAL_MATRIX_FORMAT:{path.suffix}")
+
+
+def compute_source_rows_digest(rows: Sequence[Mapping[str, Any]]) -> str:
+    ordered = sorted(
+        rows,
+        key=lambda row: json.dumps(row, sort_keys=True, separators=(",", ":"), default=str),
+    )
+    return stable_digest_v0({"rows": list(ordered), "schema": "offline_signal_matrix_rows_v0"})
+
+
+def _serialize_records(records: Sequence[ParameterSensitivityInputV1]) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    for record in records:
+        payload.append(
+            {
+                "instrument_id": record.instrument_id,
+                "decision_time": record.decision_time,
+                "feature_availability_time": record.feature_availability_time,
+                "target": record.target,
+                "features": dict(record.features),
+            }
+        )
+    return payload
+
+
+def build_productive_provenance_v0(
+    *,
+    join_result: ProductiveBindingValidationResultV0,
+    source_binding_digest: str,
+    source_signal_matrix_digest: str,
+) -> ParameterSensitivityProductiveProvenanceV0:
+    return ParameterSensitivityProductiveProvenanceV0(
+        binding_digest=source_binding_digest,
+        signal_matrix_digest=source_signal_matrix_digest,
+        grid_digest=join_result.grid.grid_digest,
+        strategy_id=join_result.binding.strategy_id,
+        strategy_version=join_result.binding.strategy_version,
+        row_count_before_filter=join_result.row_count_before_filter,
+        row_count_after_filter=join_result.row_count_after_filter,
+        dropped_rows_by_reason=dict(join_result.dropped_rows_by_reason),
+        implementation_digest=IMPLEMENTATION_DIGEST,
+    )
+
+
+def materialize_offline_parameter_sensitivity_productive_inputs_v0(
+    *,
+    signal_matrix_rows: Sequence[Mapping[str, Any]],
+    repo_root: Path,
+    binding_completion: Mapping[str, Any] | None = None,
+    strategy_id: str = "trend_following",
+    source_binding_digest: str | None = None,
+    source_signal_matrix_digest: str | None = None,
+) -> MaterializationResultV0:
+    binding_payload = binding_completion or load_ratified_binding_completion_v0(repo_root)
+    binding_digest = source_binding_digest or str(binding_payload.get("completion_digest", ""))
+
+    if not signal_matrix_rows:
+        provenance = ParameterSensitivityProductiveProvenanceV0(
+            binding_digest=binding_digest,
+            implementation_digest=IMPLEMENTATION_DIGEST,
+        )
+        return MaterializationResultV0(
+            status=MaterializationStatus.INSUFFICIENT_DATA,
+            records=(),
+            join_result=ProductiveBindingValidationResultV0(
+                admissible_records=(),
+                rejected=(),
+                row_count_before_filter=0,
+                row_count_after_filter=0,
+                dropped_rows_by_reason={},
+                binding=ParameterSensitivityProductiveBindingV0(binding_digest=binding_digest),
+                grid=load_productive_parameter_grid_v0(
+                    repo_root=repo_root,
+                    strategy_id=strategy_id,
+                    data_digest=str(
+                        binding_payload.get("shared_bindings", {})
+                        .get("dataset_binding", {})
+                        .get("data_digest", "")
+                    ),
+                ),
+                grid_specs=(),
+            ),
+            provenance=provenance,
+            materialization_digest=stable_digest_v0(
+                {"schema_version": SCHEMA_VERSION, "empty": True}
+            ),
+            output_digest=stable_digest_v0({"schema_version": SCHEMA_VERSION, "empty": True}),
+            productive_input_digest=stable_digest_v0(
+                {"schema_version": SCHEMA_VERSION, "empty": True}
+            ),
+            grid_digest="",
+            source_binding_digest=binding_digest,
+            source_signal_matrix_digest="",
+        )
+
+    signal_digest = source_signal_matrix_digest or compute_signal_matrix_digest_v0(
+        signal_matrix_rows
+    )
+
+    join_result = validate_productive_binding_batch_v0(
+        signal_matrix_rows=signal_matrix_rows,
+        binding_completion=binding_payload,
+        repo_root=repo_root,
+        strategy_id=strategy_id,
+        expected_binding_digest=binding_digest,
+        expected_signal_matrix_digest=signal_digest,
+    )
+    records = join_result.admissible_records
+    serialized = _serialize_records(records)
+    productive_input_digest = stable_digest_v0(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "records": serialized,
+        }
+    )
+    output_digest = stable_digest_v0(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "productive_input_digest": productive_input_digest,
+            "grid_digest": join_result.grid.grid_digest,
+            "row_count_after_filter": join_result.row_count_after_filter,
+        }
+    )
+    materialization_digest = stable_digest_v0(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "output_digest": output_digest,
+            "source_binding_digest": binding_digest,
+            "source_signal_matrix_digest": signal_digest,
+            "grid_digest": join_result.grid.grid_digest,
+            "dropped_rows_by_reason": dict(join_result.dropped_rows_by_reason),
+        }
+    )
+    provenance = build_productive_provenance_v0(
+        join_result=join_result,
+        source_binding_digest=binding_digest,
+        source_signal_matrix_digest=signal_digest,
+    )
+
+    if not signal_matrix_rows:
+        status = MaterializationStatus.INSUFFICIENT_DATA
+    elif not records:
+        status = MaterializationStatus.TARGET_BINDING_MISSING
+    else:
+        status = MaterializationStatus.PASS
+
+    return MaterializationResultV0(
+        status=status,
+        records=records,
+        join_result=join_result,
+        provenance=provenance,
+        materialization_digest=materialization_digest,
+        output_digest=output_digest,
+        productive_input_digest=productive_input_digest,
+        grid_digest=join_result.grid.grid_digest,
+        source_binding_digest=binding_digest,
+        source_signal_matrix_digest=signal_digest,
+    )
+
+
+def materialize_from_manifest_paths_v0(
+    *,
+    repo_root: Path,
+    signal_matrix_path: Path,
+    binding_completion_path: Path | None = None,
+    strategy_id: str = "trend_following",
+) -> MaterializationResultV0:
+    signal_rows = load_signal_matrix_rows(signal_matrix_path)
+    binding_payload: Mapping[str, Any] | None = None
+    if binding_completion_path is not None:
+        binding_payload = json.loads(binding_completion_path.read_text(encoding="utf-8"))
+    return materialize_offline_parameter_sensitivity_productive_inputs_v0(
+        signal_matrix_rows=signal_rows,
+        repo_root=repo_root,
+        binding_completion=binding_payload,
+        strategy_id=strategy_id,
+    )
+
+
+def serialize_materialized_productive_inputs_v0(
+    records: Sequence[ParameterSensitivityInputV1],
+) -> str:
+    ordered = sorted(
+        records,
+        key=lambda record: (record.decision_time, record.instrument_id),
+    )
+    lines = [
+        json.dumps(
+            {
+                "instrument_id": record.instrument_id,
+                "decision_time": record.decision_time,
+                "feature_availability_time": record.feature_availability_time,
+                "target": record.target,
+                "features": dict(record.features),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        for record in ordered
+    ]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def materializer_to_contract_roundtrip_pass_v0(
+    result: MaterializationResultV0,
+) -> bool:
+    if result.status != MaterializationStatus.PASS:
+        return False
+    if not result.records:
+        return False
+    for spec in result.join_result.grid_specs:
+        if spec.parameter_name not in ALLOWED_CALIBRATABLE_PARAMETERS:
+            return False
+        if spec.scaled_feature_name != spec.parameter_name:
+            return False
+    return bool(result.join_result.binding.binding_digest)

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -175,6 +175,29 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
             "TARGET_BINDING_REPAIR",
         }
 
+    def test_parameter_sensitivity_productive_binding_surfaces_classified(self) -> None:
+        changed_files = [
+            "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
+            "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
+            "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
+            "scripts/research/offline_parameter_sensitivity_surface_v0.py",
+            "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
+            "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
+            "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
+            "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+        ]
+        report = build_boundary_report(changed_files, repo_root=REPO_ROOT)
+        assert report.admissible is True
+        assert report.impact_unknown is False
+        assert "ALLOWED_OPTIMIZATION_SURFACE_ONLY" in report.reason_codes
+        assert forbidden_surface_changed_count(report) == 0
+        assert set(report.allowed_surface_classification) >= {
+            "DETERMINISTIC_MATERIALIZATION_REPAIR",
+            "EXPLICITLY_CALIBRATABLE_RESEARCH_PARAMETERS_WITHIN_PREDECLARED_RANGES",
+            "TARGET_BINDING_REPAIR",
+            "WALK_FORWARD_MONTE_CARLO_STRESS_AND_PARAMETER_SENSITIVITY",
+        }
+
 
 class TestEconomicDiagnosticOptimizationBoundaryGuardNegativeV0:
     @pytest.mark.parametrize(

--- a/tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py
+++ b/tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py
@@ -1,0 +1,231 @@
+"""Contract tests for operator-ratified productive parameter sensitivity normative contract v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from research.linear_evidence.import_boundary import scan_file_import_boundary
+from research.linear_evidence.parameter_sensitivity_productive_contract_v0 import (
+    ALLOWED_CALIBRATABLE_PARAMETERS,
+    AUTHORITY_EFFECT,
+    PARAMETER_CLASS_CONSTITUTIONAL_CORE,
+    PARAMETER_CLASS_DIAGNOSTIC_ONLY,
+    PARAMETER_CLASS_EXPLICITLY_CALIBRATABLE,
+    PARAMETER_CLASS_UNKNOWN,
+    ProductiveBindingRejectionReason,
+    build_parameter_grid_specs_v0,
+    classify_fleet_parameters_v0,
+    load_productive_parameter_grid_v0,
+    materialize_productive_sensitivity_row_v0,
+    validate_binding_digest_v0,
+    validate_fleet_candidate_set_v0,
+    validate_parameter_variation_allowed_v0,
+    validate_productive_binding_batch_v0,
+    validate_signal_matrix_digest_v0,
+)
+from research.linear_evidence.signal_matrix_productive_contract_v0 import (
+    DECISION_TIME_KEY,
+    EXPECTED_FLEET_SIGNAL_ORDER,
+    FEATURE_TIME_KEY,
+    INSTRUMENT_ID_KEY,
+    compute_signal_matrix_digest_v0,
+)
+from research.offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0 import (
+    load_ratified_binding_completion_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_MODULE = (
+    REPO_ROOT / "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py"
+)
+FORBIDDEN_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+    "requests",
+    "httpx",
+    "urllib.request",
+)
+
+
+def _signal_matrix_row(
+    *,
+    instrument_id: str = "okx:linear_perpetual:ETH:USDT:USDT:perp",
+    decision_time: str = "2024-05-31T10:00:00Z",
+    feature_time: str = "2024-05-31T09:00:00Z",
+    bollinger_bands: float = 1.0,
+    momentum_1h: float = 0.0,
+    trend_following: float = -1.0,
+) -> dict[str, object]:
+    return {
+        INSTRUMENT_ID_KEY: instrument_id,
+        DECISION_TIME_KEY: decision_time,
+        FEATURE_TIME_KEY: feature_time,
+        "bollinger_bands": bollinger_bands,
+        "momentum_1h": momentum_1h,
+        "trend_following": trend_following,
+    }
+
+
+def test_allowed_calibratable_parameters_are_fee_and_slippage_only() -> None:
+    assert ALLOWED_CALIBRATABLE_PARAMETERS == ("fee_bps", "slippage_bps")
+
+
+def test_parameter_classification_has_no_unknowns() -> None:
+    rows = classify_fleet_parameters_v0()
+    assert all(row.parameter_class != PARAMETER_CLASS_UNKNOWN for row in rows)
+
+
+def test_constitutional_core_variation_rejected() -> None:
+    assert (
+        validate_parameter_variation_allowed_v0("adx_period")
+        == ProductiveBindingRejectionReason.CONSTITUTIONAL_PARAMETER_VARIATION_REQUESTED.value
+    )
+
+
+def test_diagnostic_only_variation_rejected() -> None:
+    assert (
+        validate_parameter_variation_allowed_v0("signal_scale")
+        == ProductiveBindingRejectionReason.DIAGNOSTIC_ONLY_PARAMETER_VARIATION_REQUESTED.value
+    )
+
+
+def test_unknown_parameter_variation_rejected() -> None:
+    assert (
+        validate_parameter_variation_allowed_v0("not_a_real_parameter")
+        == ProductiveBindingRejectionReason.UNKNOWN_PARAMETER.value
+    )
+
+
+def test_calibratable_parameters_classified_correctly() -> None:
+    rows = classify_fleet_parameters_v0()
+    fee_rows = [row for row in rows if row.parameter_name == "fee_bps"]
+    assert fee_rows
+    assert all(row.parameter_class == PARAMETER_CLASS_EXPLICITLY_CALIBRATABLE for row in fee_rows)
+    assert all(row.sensitivity_variation_allowed is True for row in fee_rows)
+
+
+def test_constitutional_parameters_not_variation_allowed() -> None:
+    rows = classify_fleet_parameters_v0()
+    core_rows = [row for row in rows if row.parameter_class == PARAMETER_CLASS_CONSTITUTIONAL_CORE]
+    assert core_rows
+    assert all(row.sensitivity_variation_allowed is False for row in core_rows)
+
+
+def test_diagnostic_only_signal_scale_not_variation_allowed() -> None:
+    rows = classify_fleet_parameters_v0()
+    signal_scale = [row for row in rows if row.parameter_name == "signal_scale"]
+    assert len(signal_scale) == 1
+    assert signal_scale[0].parameter_class == PARAMETER_CLASS_DIAGNOSTIC_ONLY
+    assert signal_scale[0].sensitivity_variation_allowed is False
+
+
+def test_binding_digest_mismatch_rejected() -> None:
+    assert (
+        validate_binding_digest_v0(expected_digest="abc", actual_digest="def")
+        == ProductiveBindingRejectionReason.BINDING_DIGEST_MISMATCH.value
+    )
+
+
+def test_signal_matrix_digest_mismatch_rejected() -> None:
+    rows = (_signal_matrix_row(),)
+    digest = compute_signal_matrix_digest_v0(rows)
+    assert (
+        validate_signal_matrix_digest_v0(
+            expected_digest="stale",
+            actual_digest=digest,
+            rows=rows,
+        )
+        == ProductiveBindingRejectionReason.SIGNAL_MATRIX_DIGEST_MISMATCH.value
+    )
+
+
+def test_missing_signal_matrix_rejected() -> None:
+    assert (
+        validate_signal_matrix_digest_v0(expected_digest=None, actual_digest="", rows=())
+        == ProductiveBindingRejectionReason.MISSING_SIGNAL_MATRIX.value
+    )
+
+
+def test_materialize_row_rejects_lookahead() -> None:
+    record, reason = materialize_productive_sensitivity_row_v0(
+        _signal_matrix_row(feature_time="2024-05-31T11:00:00Z"),
+        baseline_fee_bps=10.0,
+        baseline_slippage_bps=5.0,
+    )
+    assert record is None
+    assert reason == ProductiveBindingRejectionReason.FEATURE_LEAKAGE_DETECTED.value
+
+
+def test_materialize_row_accepts_valid_row() -> None:
+    record, reason = materialize_productive_sensitivity_row_v0(
+        _signal_matrix_row(),
+        baseline_fee_bps=10.0,
+        baseline_slippage_bps=5.0,
+    )
+    assert reason is None
+    assert record is not None
+    assert record.features["fee_bps"] == pytest.approx(10.0)
+    assert record.features["slippage_bps"] == pytest.approx(5.0)
+    for name in EXPECTED_FLEET_SIGNAL_ORDER:
+        assert name in record.features
+
+
+def test_step31f_grid_loads_fee_and_slippage_only() -> None:
+    binding = load_ratified_binding_completion_v0(REPO_ROOT)
+    shared = binding.get("shared_bindings", {})
+    dataset_binding = shared.get("dataset_binding", {})
+    grid = load_productive_parameter_grid_v0(
+        repo_root=REPO_ROOT,
+        strategy_id="trend_following",
+        data_digest=str(dataset_binding.get("data_digest", "")),
+    )
+    assert grid.grid_id == "okx_eth_perp_research_cost_grid_v1"
+    assert grid.parameter_names == ("fee_bps", "slippage_bps")
+    specs = build_parameter_grid_specs_v0(grid)
+    assert [spec.parameter_name for spec in specs] == ["fee_bps", "slippage_bps"]
+
+
+def test_productive_binding_batch_accepts_valid_rows() -> None:
+    binding = load_ratified_binding_completion_v0(REPO_ROOT)
+    rows = tuple(
+        _signal_matrix_row(decision_time=f"2024-05-31T{hour:02d}:00:00Z") for hour in range(10, 18)
+    )
+    result = validate_productive_binding_batch_v0(
+        signal_matrix_rows=rows,
+        binding_completion=binding,
+        repo_root=REPO_ROOT,
+    )
+    assert result.row_count_after_filter == len(rows)
+    assert result.grid.grid_id == "okx_eth_perp_research_cost_grid_v1"
+    assert len(result.grid_specs) == 2
+
+
+def test_productive_binding_batch_rejects_binding_digest_mismatch() -> None:
+    binding = load_ratified_binding_completion_v0(REPO_ROOT)
+    rows = (_signal_matrix_row(),)
+    with pytest.raises(ValueError, match="BINDING_DIGEST_MISMATCH"):
+        validate_productive_binding_batch_v0(
+            signal_matrix_rows=rows,
+            binding_completion=binding,
+            repo_root=REPO_ROOT,
+            expected_binding_digest="stale-digest",
+        )
+
+
+def test_fleet_candidate_set_validation() -> None:
+    validate_fleet_candidate_set_v0(["trend_following", "momentum_1h", "bollinger_bands"])
+    with pytest.raises(ValueError, match="MISSING_FLEET_BINDING"):
+        validate_fleet_candidate_set_v0(["trend_following"])
+
+
+def test_contract_module_has_no_forbidden_imports() -> None:
+    violations = scan_file_import_boundary(CONTRACT_MODULE, repo_root=REPO_ROOT)
+    assert violations == []
+
+
+def test_contract_authority_effect_none() -> None:
+    assert AUTHORITY_EFFECT == "NONE"

--- a/tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_v0.py
+++ b/tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_v0.py
@@ -1,0 +1,278 @@
+"""Contract tests for offline parameter sensitivity productive input join materializer v0."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from research.linear_evidence.import_boundary import scan_file_import_boundary
+from research.linear_evidence.parameter_sensitivity_productive_contract_v0 import (
+    AUTHORITY_EFFECT,
+    ProductiveBindingRejectionReason,
+)
+from research.linear_evidence.signal_matrix_productive_contract_v0 import (
+    DECISION_TIME_KEY,
+    FEATURE_TIME_KEY,
+    INSTRUMENT_ID_KEY,
+)
+from src.research.offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0 import (
+    materialize_offline_final_research_fleet_signal_matrix_v0,
+    serialize_signal_matrix_rows_v0,
+)
+from src.research.offline_parameter_sensitivity_productive_input_join_materializer_v0 import (
+    RUNTIME_EFFECT,
+    MaterializationStatus,
+    materialize_offline_parameter_sensitivity_productive_inputs_v0,
+    materializer_to_contract_roundtrip_pass_v0,
+    serialize_materialized_productive_inputs_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MATERIALIZER_MODULE = (
+    REPO_ROOT
+    / "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py"
+)
+CONTRACT_MODULE = (
+    REPO_ROOT / "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py"
+)
+RUNNER_MODULE = (
+    REPO_ROOT
+    / "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py"
+)
+SURFACE_RUNNER_MODULE = REPO_ROOT / "scripts/research/offline_parameter_sensitivity_surface_v0.py"
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+STAGING_ROOT = (
+    ARCHIVE_ROOT / "datasets/admissible_futures/"
+    "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/"
+    "extended_chronological_v1"
+)
+FORBIDDEN_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+    "requests",
+    "httpx",
+    "urllib.request",
+)
+
+
+def _signal_matrix_row(
+    *,
+    instrument_id: str = "okx:linear_perpetual:ETH:USDT:USDT:perp",
+    decision_time: str = "2024-05-31T10:00:00Z",
+    feature_time: str = "2024-05-31T09:00:00Z",
+) -> dict[str, object]:
+    return {
+        INSTRUMENT_ID_KEY: instrument_id,
+        DECISION_TIME_KEY: decision_time,
+        FEATURE_TIME_KEY: feature_time,
+        "bollinger_bands": 1.0,
+        "momentum_1h": 0.0,
+        "trend_following": -1.0,
+    }
+
+
+def _materialize_productive_signal_matrix(
+    tmp_path: Path,
+) -> tuple[tuple[dict[str, object], ...], Path]:
+    if not STAGING_ROOT.is_dir():
+        pytest.skip("archive staging root unavailable")
+    result = materialize_offline_final_research_fleet_signal_matrix_v0(
+        repo_root=REPO_ROOT,
+        staging_root=STAGING_ROOT,
+    )
+    signal_matrix_path = tmp_path / "signal_matrix.jsonl"
+    signal_matrix_path.write_text(serialize_signal_matrix_rows_v0(result.rows), encoding="utf-8")
+    return result.rows, signal_matrix_path
+
+
+def test_productive_materialization_accepts_fleet_binding(tmp_path: Path) -> None:
+    rows, _ = _materialize_productive_signal_matrix(tmp_path)
+    result = materialize_offline_parameter_sensitivity_productive_inputs_v0(
+        signal_matrix_rows=rows,
+        repo_root=REPO_ROOT,
+    )
+    assert result.status == MaterializationStatus.PASS
+    assert result.records
+    assert result.grid_digest
+    assert result.join_result.grid.grid_id == "okx_eth_perp_research_cost_grid_v1"
+
+
+def test_missing_signal_matrix_fail_closed() -> None:
+    from src.research.offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0 import (
+        load_ratified_binding_completion_v0,
+    )
+
+    binding = load_ratified_binding_completion_v0(REPO_ROOT)
+    result = materialize_offline_parameter_sensitivity_productive_inputs_v0(
+        signal_matrix_rows=(),
+        repo_root=REPO_ROOT,
+        binding_completion=binding,
+    )
+    assert result.status == MaterializationStatus.INSUFFICIENT_DATA
+
+
+def test_stale_binding_digest_rejected(tmp_path: Path) -> None:
+    rows = tuple(
+        _signal_matrix_row(decision_time=f"2024-05-31T{hour:02d}:00:00Z") for hour in range(10, 18)
+    )
+    with pytest.raises(ValueError, match="BINDING_DIGEST_MISMATCH"):
+        materialize_offline_parameter_sensitivity_productive_inputs_v0(
+            signal_matrix_rows=rows,
+            repo_root=REPO_ROOT,
+            source_binding_digest="stale-binding-digest",
+        )
+
+
+def test_stale_signal_matrix_digest_rejected() -> None:
+    rows = (_signal_matrix_row(),)
+    with pytest.raises(ValueError, match="SIGNAL_MATRIX_DIGEST_MISMATCH"):
+        materialize_offline_parameter_sensitivity_productive_inputs_v0(
+            signal_matrix_rows=rows,
+            repo_root=REPO_ROOT,
+            source_signal_matrix_digest="stale-signal-matrix-digest",
+        )
+
+
+def test_fixture_and_productive_modes_mutually_exclusive(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SURFACE_RUNNER_MODULE),
+            "--out",
+            str(tmp_path / "mixed"),
+            "--fixture",
+            "--signal-matrix",
+            str(tmp_path / "missing.jsonl"),
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode != 0
+    assert "MIXED_MODE_BLOCKED" in result.stderr
+
+
+def test_productive_runner_does_not_fallback_to_fixture(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SURFACE_RUNNER_MODULE),
+            "--out",
+            str(tmp_path / "productive"),
+            "--signal-matrix",
+            str(tmp_path / "missing.jsonl"),
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode != 0
+    assert "UNSUPPORTED_SIGNAL_MATRIX_FORMAT" in result.stderr or result.returncode == 1
+
+
+def test_fixture_runner_still_works(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SURFACE_RUNNER_MODULE),
+            "--out",
+            str(tmp_path / "fixture"),
+            "--fixture",
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads(
+        (tmp_path / "fixture" / "parameter_sensitivity_surface_evidence_v1.json").read_text()
+    )
+    assert report["INPUT_MODE"] == "FIXTURE_SCAFFOLD"
+    assert report["FIXTURE_SCAFFOLD_USED"] is True
+
+
+def test_materializer_roundtrip_pass(tmp_path: Path) -> None:
+    rows, _ = _materialize_productive_signal_matrix(tmp_path)
+    result = materialize_offline_parameter_sensitivity_productive_inputs_v0(
+        signal_matrix_rows=rows,
+        repo_root=REPO_ROOT,
+    )
+    assert materializer_to_contract_roundtrip_pass_v0(result) is True
+
+
+def test_deterministic_materialization(tmp_path: Path) -> None:
+    rows, _ = _materialize_productive_signal_matrix(tmp_path)
+    first = materialize_offline_parameter_sensitivity_productive_inputs_v0(
+        signal_matrix_rows=rows,
+        repo_root=REPO_ROOT,
+    )
+    second = materialize_offline_parameter_sensitivity_productive_inputs_v0(
+        signal_matrix_rows=rows,
+        repo_root=REPO_ROOT,
+    )
+    assert serialize_materialized_productive_inputs_v0(
+        first.records
+    ) == serialize_materialized_productive_inputs_v0(second.records)
+    assert first.materialization_digest == second.materialization_digest
+    assert first.productive_input_digest == second.productive_input_digest
+    assert first.grid_digest == second.grid_digest
+
+
+def test_grid_specs_only_fee_and_slippage(tmp_path: Path) -> None:
+    rows, _ = _materialize_productive_signal_matrix(tmp_path)
+    result = materialize_offline_parameter_sensitivity_productive_inputs_v0(
+        signal_matrix_rows=rows,
+        repo_root=REPO_ROOT,
+    )
+    assert [spec.parameter_name for spec in result.join_result.grid_specs] == [
+        "fee_bps",
+        "slippage_bps",
+    ]
+
+
+def test_materializer_cli_smoke(tmp_path: Path) -> None:
+    rows, signal_matrix_path = _materialize_productive_signal_matrix(tmp_path)
+    assert rows
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER_MODULE),
+            "--out",
+            str(tmp_path / "cli"),
+            "--signal-matrix",
+            str(signal_matrix_path),
+            "--repo-root",
+            str(REPO_ROOT),
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads((tmp_path / "cli" / "materialization_report.json").read_text())
+    assert report["status"] == "PASS"
+    assert report["grid"]["grid_id"] == "okx_eth_perp_research_cost_grid_v1"
+
+
+def test_materializer_module_has_no_forbidden_imports() -> None:
+    violations = scan_file_import_boundary(MATERIALIZER_MODULE, repo_root=REPO_ROOT)
+    assert violations == []
+
+
+def test_contract_module_has_no_forbidden_imports() -> None:
+    violations = scan_file_import_boundary(CONTRACT_MODULE, repo_root=REPO_ROOT)
+    assert violations == []
+
+
+def test_authority_and_runtime_effect_none() -> None:
+    assert AUTHORITY_EFFECT == "NONE"
+    assert RUNTIME_EFFECT == "NONE"

--- a/tests/research/test_offline_parameter_sensitivity_surface_v0.py
+++ b/tests/research/test_offline_parameter_sensitivity_surface_v0.py
@@ -195,6 +195,7 @@ def test_parameter_sensitivity_surface_cli_writes_manifestable_report(tmp_path: 
             "scripts/research/offline_parameter_sensitivity_surface_v0.py",
             "--out",
             str(tmp_path),
+            "--fixture",
         ],
         check=False,
         text=True,


### PR DESCRIPTION
## Summary
- Closes the productive binding gap identified in `offline_parameter_sensitivity_surface_v0_20260714T133948Z` by adding a narrow productive contract and input-join materializer for the ratified Final Research Fleet.
- Extends `scripts/research/offline_parameter_sensitivity_surface_v0.py` with an explicit productive mode (`--signal-matrix`, `--productive-binding`, `--parameter-grid`) while preserving the existing fixture scaffold via `--fixture`.
- Reuses existing owners only: `src/research/linear_evidence/sensitivity.py` for sensitivity math, `src/backtest/parameter_sensitivity_v1.py` for step31f `fee_bps`/`slippage_bps` grids, and the ratified fleet binding plus signal-matrix materializer for productive inputs.

## Root cause
The canonical parameter-sensitivity runner was fixture-only and had no productive fleet input path, so productive diagnostics could not bind to ratified fleet artifacts.

## Productive binding path
1. Load ratified binding from `config/research/final_research_fleet_versioned_binding_completion_v0.json`
2. Consume productive signal-matrix rows
3. Validate binding/signal-matrix digests and parameter classification fail-closed
4. Bind predeclared step31f cost grids (`okx_eth_perp_research_cost_grid_v1`)
5. Materialize `ParameterSensitivityInputV1` records without executing sensitivity surface evaluation

## Contract and determinism evidence
- Materializer-to-contract roundtrip: PASS
- Second materialization diff: EMPTY
- Productive input digest stable: true
- Grid digest stable: true
- Focused tests: 43 passed locally

## Semantic boundaries
- `ECONOMIC_EVALUATION_EXECUTED=false`
- `RUNTIME_EFFECT=NONE`
- `AUTHORITY_EFFECT=NONE`
- No trading, signal, strategy-default, cost-policy, promotion, or runtime semantic changes
- Reevaluation of fleet parameter sensitivity is explicitly **not** authorized by this repair scope

## Source / durable evidence
- Source failure evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/offline_parameter_sensitivity_surface_v0_20260714T133948Z`
- Repair evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/offline_parameter_sensitivity_productive_binding_repair_v0_20260714T134911Z`
- `MANIFEST_VERIFY_RC=0`

## Test plan
- [x] `tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py`
- [x] `tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_v0.py`
- [x] `tests/research/test_offline_parameter_sensitivity_surface_v0.py`
- [x] `tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py`
- [x] Deterministic productive materialization probe on archive staging data

Made with [Cursor](https://cursor.com)