### PR TITLE
feat(research): align offline parameter sensitivity model specification v0

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -227,6 +227,7 @@
         "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
         "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_*",
         "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
+        "tests/research/test_offline_parameter_sensitivity_model_spec_alignment_*",
         "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*",
         "tests/research/test_linear_evidence_*"
       ]
@@ -294,7 +295,8 @@
         "scripts/research/offline_parameter_sensitivity_surface_v0.py"
       ],
       "path_globs": [
-        "tests/research/test_offline_parameter_sensitivity_surface_v0.py"
+        "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
+        "tests/research/test_offline_parameter_sensitivity_model_spec_alignment_*"
       ]
     },
     "PORTFOLIO_RESEARCH_AND_ECONOMIC_ATTRIBUTION_WITHOUT_RUNTIME_AUTHORITY": {

--- a/src/research/linear_evidence/fitters.py
+++ b/src/research/linear_evidence/fitters.py
@@ -14,6 +14,7 @@ REASON_CONSTANT_TARGET = "CONSTANT_TARGET"
 REASON_ZERO_VARIANCE_FEATURE = "ZERO_VARIANCE_FEATURE"
 REASON_CONSTANT_FEATURE_COLLINEAR_WITH_INTERCEPT = "CONSTANT_FEATURE_COLLINEAR_WITH_INTERCEPT"
 REASON_RANK_DEFICIENT_FEATURE_MATRIX = "RANK_DEFICIENT_FEATURE_MATRIX"
+REASON_STRICT_ZERO_VARIANCE_FEATURE_EXCLUDED = "STRICT_ZERO_VARIANCE_FEATURE_EXCLUDED"
 
 
 @dataclass(frozen=True)
@@ -53,6 +54,41 @@ def _target_is_constant(y: np.ndarray) -> bool:
 
 def _feature_unique_value_count(column: np.ndarray) -> int:
     return int(len(np.unique(np.round(column, _UNIQUE_ROUND_DECIMALS))))
+
+
+def exclude_strict_zero_variance_features_v0(
+    x: np.ndarray,
+    feature_names: Sequence[str],
+) -> tuple[np.ndarray, tuple[str, ...], tuple[str, ...]]:
+    """Deterministically exclude strictly zero-variance feature columns.
+
+    Predicate: exact float(np.var(column)) == 0.0 on the canonical float matrix.
+    Exclusion order is stable w.r.t. feature_names.
+    """
+    if x.size == 0 or not feature_names:
+        return x, tuple(feature_names), ()
+    excluded: list[str] = []
+    keep_indices: list[int] = []
+    for index, name in enumerate(feature_names):
+        if float(np.var(x[:, index])) == 0.0:
+            excluded.append(str(name))
+        else:
+            keep_indices.append(index)
+    if not excluded:
+        return x, tuple(feature_names), ()
+    if not keep_indices:
+        return np.empty((x.shape[0], 0), dtype=float), (), tuple(excluded)
+    kept = x[:, keep_indices]
+    kept_names = tuple(feature_names[index] for index in keep_indices)
+    return kept, kept_names, tuple(excluded)
+
+
+def strict_zero_variance_feature_exclusion_reason_codes_v0(
+    excluded_feature_names: Sequence[str],
+) -> tuple[str, ...]:
+    return tuple(
+        f"{REASON_STRICT_ZERO_VARIANCE_FEATURE_EXCLUDED}:{name}" for name in excluded_feature_names
+    )
 
 
 def _zero_variance_feature_names(x: np.ndarray, feature_names: Sequence[str]) -> tuple[str, ...]:

--- a/src/research/linear_evidence/sensitivity.py
+++ b/src/research/linear_evidence/sensitivity.py
@@ -8,9 +8,54 @@ import math
 
 import numpy as np
 
-from .contracts import LinearModelEvidenceV1
+from .contracts import FeatureMatrixBindingV1, LinearModelDiagnosticsV1, LinearModelEvidenceV1
 from .feature_matrix import build_feature_matrix_binding
-from .fitters import fit_ols_lstsq
+from .fitters import (
+    REASON_RANK_DEFICIENT_FEATURE_MATRIX,
+    REASON_STRICT_ZERO_VARIANCE_FEATURE_EXCLUDED,
+    exclude_strict_zero_variance_features_v0,
+    fit_ols_lstsq,
+    strict_zero_variance_feature_exclusion_reason_codes_v0,
+)
+
+MODEL_SPEC_VERSION = "parameter_sensitivity_active_feature_subset_v0"
+EXCLUSION_REASON_ZERO_VARIANCE = "ZERO_VARIANCE_WITHIN_1D_SURFACE_FIT"
+
+
+@dataclass(frozen=True)
+class ParameterSensitivityGridPointModelSpecV1:
+    parameter_value: float
+    requested_feature_names: Tuple[str, ...]
+    active_feature_names: Tuple[str, ...]
+    excluded_feature_names: Tuple[str, ...]
+    exclusion_reason_codes: Tuple[str, ...]
+    design_matrix_rows: int
+    requested_design_matrix_columns: int
+    active_design_matrix_columns: int
+    requested_rank: int
+    active_rank: int
+    required_active_rank: int
+    condition_number: float
+    fit_status: str
+    fit_reason_codes: Tuple[str, ...]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "parameter_value": self.parameter_value,
+            "requested_feature_names": list(self.requested_feature_names),
+            "active_feature_names": list(self.active_feature_names),
+            "excluded_feature_names": list(self.excluded_feature_names),
+            "exclusion_reason_codes": list(self.exclusion_reason_codes),
+            "design_matrix_rows": self.design_matrix_rows,
+            "requested_design_matrix_columns": self.requested_design_matrix_columns,
+            "active_design_matrix_columns": self.active_design_matrix_columns,
+            "requested_rank": self.requested_rank,
+            "active_rank": self.active_rank,
+            "required_active_rank": self.required_active_rank,
+            "condition_number": self.condition_number,
+            "fit_status": self.fit_status,
+            "fit_reason_codes": list(self.fit_reason_codes),
+        }
 
 
 @dataclass(frozen=True)
@@ -54,6 +99,23 @@ class ParameterSensitivitySurfaceEvidenceV1:
     reason_codes: Tuple[str, ...]
     authority_effect: str
     runtime_effect: str
+    model_spec_version: str = MODEL_SPEC_VERSION
+    requested_feature_names: Tuple[str, ...] = ()
+    active_feature_names: Tuple[str, ...] = ()
+    excluded_feature_names: Tuple[str, ...] = ()
+    exclusion_reason_codes: Tuple[str, ...] = ()
+    requested_design_matrix_columns: int = 0
+    active_design_matrix_columns: int = 0
+    requested_rank: int = 0
+    active_rank: int = 0
+    required_active_rank: int = 0
+    condition_number: float = float("inf")
+    fit_status: str = "DIAGNOSTIC_ONLY"
+    fit_reason_codes: Tuple[str, ...] = ()
+    grid_point_model_specs: Tuple[ParameterSensitivityGridPointModelSpecV1, ...] = ()
+    plateau_detection_admissible: bool = False
+    fragility_detection_admissible: bool = False
+    economic_interpretation_admissible: bool = False
 
     def to_dict(self) -> Dict[str, object]:
         return {
@@ -78,8 +140,15 @@ class ParameterSensitivitySurfaceEvidenceV1:
                         "r2_train": evidence.diagnostics.r2_train,
                         "r2_validation": evidence.diagnostics.r2_validation,
                     },
+                    "model_spec": (
+                        self.grid_point_model_specs[index].to_dict()
+                        if index < len(self.grid_point_model_specs)
+                        else {}
+                    ),
                 }
-                for parameter_value, evidence in zip(self.parameter_values, self.grid_evidence)
+                for index, (parameter_value, evidence) in enumerate(
+                    zip(self.parameter_values, self.grid_evidence)
+                )
             ],
             "surface_diagnostics": dict(self.surface_diagnostics),
             "plateau_detected": self.plateau_detected,
@@ -94,6 +163,23 @@ class ParameterSensitivitySurfaceEvidenceV1:
             "reason_codes": list(self.reason_codes),
             "authority_effect": self.authority_effect,
             "runtime_effect": self.runtime_effect,
+            "model_spec_version": self.model_spec_version,
+            "requested_feature_names": list(self.requested_feature_names),
+            "active_feature_names": list(self.active_feature_names),
+            "excluded_feature_names": list(self.excluded_feature_names),
+            "exclusion_reason_codes": list(self.exclusion_reason_codes),
+            "design_matrix_rows": self.n_samples,
+            "requested_design_matrix_columns": self.requested_design_matrix_columns,
+            "active_design_matrix_columns": self.active_design_matrix_columns,
+            "requested_rank": self.requested_rank,
+            "active_rank": self.active_rank,
+            "required_active_rank": self.required_active_rank,
+            "condition_number": self.condition_number,
+            "fit_status": self.fit_status,
+            "fit_reason_codes": list(self.fit_reason_codes),
+            "plateau_detection_admissible": self.plateau_detection_admissible,
+            "fragility_detection_admissible": self.fragility_detection_admissible,
+            "economic_interpretation_admissible": self.economic_interpretation_admissible,
         }
 
 
@@ -157,6 +243,198 @@ def _scale_rows(
         scaled[scaled_feature_name] = float(row[scaled_feature_name]) * float(parameter_value)
         scaled_rows.append(scaled)
     return scaled_rows
+
+
+def _active_feature_binding_v0(
+    binding: FeatureMatrixBindingV1,
+    *,
+    active_feature_names: Sequence[str],
+) -> FeatureMatrixBindingV1:
+    return FeatureMatrixBindingV1(
+        target_name=binding.target_name,
+        feature_names=tuple(active_feature_names),
+        n_samples=binding.n_samples,
+        n_features=len(active_feature_names),
+        feature_matrix_digest=binding.feature_matrix_digest,
+        target_digest=binding.target_digest,
+        validation_policy=binding.validation_policy,
+        time_range=binding.time_range,
+        row_count_before_filter=binding.row_count_before_filter,
+        row_count_after_filter=binding.row_count_after_filter,
+        dropped_rows_by_reason=binding.dropped_rows_by_reason,
+        status=binding.status,
+        reason_codes=binding.reason_codes,
+    )
+
+
+def _blocked_grid_point_model_spec_v0(
+    *,
+    parameter_value: float,
+    requested_feature_names: Sequence[str],
+    excluded_feature_names: Sequence[str],
+    exclusion_reason_codes: Sequence[str],
+    design_matrix_rows: int,
+    binding: FeatureMatrixBindingV1,
+) -> tuple[LinearModelEvidenceV1, ParameterSensitivityGridPointModelSpecV1]:
+    requested_columns = len(requested_feature_names) + 1
+    reasons = tuple(dict.fromkeys([*exclusion_reason_codes, REASON_RANK_DEFICIENT_FEATURE_MATRIX]))
+    blocked = LinearModelEvidenceV1(
+        evidence_type="parameter_sensitivity_surface_point",
+        model_family="OLS",
+        target_name=binding.target_name,
+        feature_names=tuple(requested_feature_names),
+        n_samples=design_matrix_rows,
+        n_features=len(requested_feature_names),
+        solver="numpy.linalg.lstsq",
+        fit_intercept=True,
+        coefficients={},
+        diagnostics=LinearModelDiagnosticsV1(
+            rank=0,
+            condition_number=0.0,
+            rmse=0.0,
+            mae=0.0,
+            max_abs_error=0.0,
+            r2_train=0.0,
+            r2_validation=None,
+            residual_mean=0.0,
+            residual_std=0.0,
+            outlier_count=0,
+        ),
+        feature_matrix_digest=binding.feature_matrix_digest,
+        target_digest=binding.target_digest,
+        config_digest="",
+        time_range=binding.time_range,
+        instrument_universe_digest="fixture_universe",
+        row_count_before_filter=binding.row_count_before_filter,
+        row_count_after_filter=binding.row_count_after_filter,
+        dropped_rows_by_reason=binding.dropped_rows_by_reason,
+        validation_policy=binding.validation_policy,
+        cost_policy_output="diagnostic_only",
+        status="RANK_DEFICIENT_BLOCKED",
+        reason_codes=reasons,
+    )
+    model_spec = ParameterSensitivityGridPointModelSpecV1(
+        parameter_value=float(parameter_value),
+        requested_feature_names=tuple(requested_feature_names),
+        active_feature_names=(),
+        excluded_feature_names=tuple(excluded_feature_names),
+        exclusion_reason_codes=tuple(exclusion_reason_codes),
+        design_matrix_rows=design_matrix_rows,
+        requested_design_matrix_columns=requested_columns,
+        active_design_matrix_columns=0,
+        requested_rank=requested_columns,
+        active_rank=0,
+        required_active_rank=0,
+        condition_number=0.0,
+        fit_status="RANK_DEFICIENT_BLOCKED",
+        fit_reason_codes=reasons,
+    )
+    return blocked, model_spec
+
+
+def _compose_exclusion_reason_codes_v0(
+    excluded_feature_names: Sequence[str],
+) -> tuple[str, ...]:
+    return tuple(
+        dict.fromkeys(
+            [
+                *strict_zero_variance_feature_exclusion_reason_codes_v0(excluded_feature_names),
+                *(f"{EXCLUSION_REASON_ZERO_VARIANCE}:{name}" for name in excluded_feature_names),
+            ]
+        )
+    )
+
+
+def _fit_grid_point_with_active_feature_subset_v0(
+    *,
+    parameter_value: float,
+    scaled_rows: Sequence[Mapping[str, object]],
+    feature_names: Sequence[str],
+    target_name: str,
+    validation_fraction: float,
+) -> tuple[LinearModelEvidenceV1, ParameterSensitivityGridPointModelSpecV1]:
+    x, y, binding = build_feature_matrix_binding(
+        scaled_rows,
+        feature_names=feature_names,
+        target_name=target_name,
+        time_name="decision_time",
+        validation_policy="TIME_ORDERED",
+    )
+    requested_feature_names = binding.feature_names
+    requested_columns = len(requested_feature_names) + 1
+    x_active, active_feature_names, excluded_feature_names = (
+        exclude_strict_zero_variance_features_v0(x, requested_feature_names)
+    )
+    exclusion_reason_codes = _compose_exclusion_reason_codes_v0(excluded_feature_names)
+
+    if not active_feature_names:
+        return _blocked_grid_point_model_spec_v0(
+            parameter_value=parameter_value,
+            requested_feature_names=requested_feature_names,
+            excluded_feature_names=excluded_feature_names,
+            exclusion_reason_codes=exclusion_reason_codes,
+            design_matrix_rows=int(x.shape[0]),
+            binding=binding,
+        )
+
+    active_binding = _active_feature_binding_v0(
+        binding,
+        active_feature_names=active_feature_names,
+    )
+    evidence = fit_ols_lstsq(
+        x_active,
+        y,
+        active_binding,
+        fit_intercept=True,
+        validation_fraction=validation_fraction,
+        evidence_type="parameter_sensitivity_surface_point",
+    )
+    active_columns = len(active_feature_names) + 1
+    required_active_rank = active_columns
+    merged_reasons = tuple(dict.fromkeys([*exclusion_reason_codes, *evidence.reason_codes]))
+    evidence = LinearModelEvidenceV1(
+        evidence_type=evidence.evidence_type,
+        model_family=evidence.model_family,
+        target_name=evidence.target_name,
+        feature_names=requested_feature_names,
+        n_samples=evidence.n_samples,
+        n_features=len(requested_feature_names),
+        solver=evidence.solver,
+        fit_intercept=evidence.fit_intercept,
+        coefficients=evidence.coefficients,
+        diagnostics=evidence.diagnostics,
+        feature_matrix_digest=binding.feature_matrix_digest,
+        target_digest=evidence.target_digest,
+        config_digest=evidence.config_digest,
+        time_range=evidence.time_range,
+        instrument_universe_digest=evidence.instrument_universe_digest,
+        row_count_before_filter=evidence.row_count_before_filter,
+        row_count_after_filter=evidence.row_count_after_filter,
+        dropped_rows_by_reason=evidence.dropped_rows_by_reason,
+        validation_policy=evidence.validation_policy,
+        cost_policy_output=evidence.cost_policy_output,
+        status=evidence.status,
+        reason_codes=merged_reasons,
+        authority_effect=evidence.authority_effect,
+        runtime_effect=evidence.runtime_effect,
+    )
+    model_spec = ParameterSensitivityGridPointModelSpecV1(
+        parameter_value=float(parameter_value),
+        requested_feature_names=requested_feature_names,
+        active_feature_names=active_feature_names,
+        excluded_feature_names=excluded_feature_names,
+        exclusion_reason_codes=exclusion_reason_codes,
+        design_matrix_rows=int(x.shape[0]),
+        requested_design_matrix_columns=requested_columns,
+        active_design_matrix_columns=active_columns,
+        requested_rank=requested_columns,
+        active_rank=int(evidence.diagnostics.rank),
+        required_active_rank=required_active_rank,
+        condition_number=float(evidence.diagnostics.condition_number),
+        fit_status=evidence.status,
+        fit_reason_codes=merged_reasons,
+    )
+    return evidence, model_spec
 
 
 def _validation_rmse(evidence: LinearModelEvidenceV1) -> float:
@@ -364,6 +642,7 @@ def fit_parameter_sensitivity_surface(
         )
 
     grid_evidence: List[LinearModelEvidenceV1] = []
+    grid_point_model_specs: List[ParameterSensitivityGridPointModelSpecV1] = []
     validation_errors: List[float] = []
 
     for parameter_value in grid.parameter_values:
@@ -372,22 +651,15 @@ def fit_parameter_sensitivity_surface(
             scaled_feature_name=grid.scaled_feature_name,
             parameter_value=parameter_value,
         )
-        x, y, binding = build_feature_matrix_binding(
-            scaled_rows,
+        evidence, model_spec = _fit_grid_point_with_active_feature_subset_v0(
+            parameter_value=float(parameter_value),
+            scaled_rows=scaled_rows,
             feature_names=feature_names,
             target_name=target_name,
-            time_name="decision_time",
-            validation_policy="TIME_ORDERED",
-        )
-        evidence = fit_ols_lstsq(
-            x,
-            y,
-            binding,
-            fit_intercept=True,
             validation_fraction=validation_fraction,
-            evidence_type="parameter_sensitivity_surface_point",
         )
         grid_evidence.append(evidence)
+        grid_point_model_specs.append(model_spec)
         validation_errors.append(_validation_rmse(evidence))
 
     (
@@ -418,7 +690,43 @@ def fit_parameter_sensitivity_surface(
         elif evidence.status == "ROBUSTNESS_FAILED" and aggregate_status == "DIAGNOSTIC_ONLY":
             aggregate_status = "ROBUSTNESS_FAILED"
 
+    for model_spec in grid_point_model_specs:
+        for reason in model_spec.exclusion_reason_codes:
+            if reason not in aggregate_reasons:
+                aggregate_reasons.append(reason)
+
     surface_diagnostics["grid_point_count"] = float(len(grid.parameter_values))
+
+    requested_columns = len(feature_names) + 1
+    active_feature_names = (
+        grid_point_model_specs[0].active_feature_names if grid_point_model_specs else ()
+    )
+    excluded_feature_names = (
+        grid_point_model_specs[0].excluded_feature_names if grid_point_model_specs else ()
+    )
+    exclusion_reason_codes = (
+        grid_point_model_specs[0].exclusion_reason_codes if grid_point_model_specs else ()
+    )
+    active_columns = len(active_feature_names) + 1 if active_feature_names else 0
+    active_ranks = [spec.active_rank for spec in grid_point_model_specs]
+    active_rank = min(active_ranks) if active_ranks else 0
+    condition_numbers = [
+        spec.condition_number
+        for spec in grid_point_model_specs
+        if math.isfinite(spec.condition_number)
+    ]
+    condition_number = float(max(condition_numbers, default=float("inf")))
+    active_design_full_rank = bool(
+        grid_point_model_specs
+        and all(
+            spec.active_rank == spec.required_active_rank and spec.active_rank > 0
+            for spec in grid_point_model_specs
+        )
+    )
+    plateau_detection_admissible = (
+        active_design_full_rank and aggregate_status != "RANK_DEFICIENT_BLOCKED"
+    )
+    fragility_detection_admissible = plateau_detection_admissible
 
     return ParameterSensitivitySurfaceEvidenceV1(
         evidence_type="parameter_sensitivity_surface",
@@ -444,4 +752,21 @@ def fit_parameter_sensitivity_surface(
         reason_codes=tuple(dict.fromkeys(aggregate_reasons)),
         authority_effect="NONE",
         runtime_effect="NONE",
+        model_spec_version=MODEL_SPEC_VERSION,
+        requested_feature_names=feature_names,
+        active_feature_names=active_feature_names,
+        excluded_feature_names=excluded_feature_names,
+        exclusion_reason_codes=exclusion_reason_codes,
+        requested_design_matrix_columns=requested_columns,
+        active_design_matrix_columns=active_columns,
+        requested_rank=requested_columns,
+        active_rank=active_rank,
+        required_active_rank=active_columns,
+        condition_number=condition_number,
+        fit_status=aggregate_status,
+        fit_reason_codes=tuple(dict.fromkeys(aggregate_reasons)),
+        grid_point_model_specs=tuple(grid_point_model_specs),
+        plateau_detection_admissible=plateau_detection_admissible,
+        fragility_detection_admissible=fragility_detection_admissible,
+        economic_interpretation_admissible=False,
     )

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -198,6 +198,25 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
             "WALK_FORWARD_MONTE_CARLO_STRESS_AND_PARAMETER_SENSITIVITY",
         }
 
+    def test_parameter_sensitivity_model_spec_alignment_surfaces_classified(self) -> None:
+        changed_files = [
+            "src/research/linear_evidence/fitters.py",
+            "src/research/linear_evidence/sensitivity.py",
+            "tests/research/test_offline_parameter_sensitivity_model_spec_alignment_v0.py",
+            "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+        ]
+        report = build_boundary_report(changed_files, repo_root=REPO_ROOT)
+        assert report.admissible is True
+        assert report.impact_unknown is False
+        assert "ALLOWED_OPTIMIZATION_SURFACE_ONLY" in report.reason_codes
+        assert forbidden_surface_changed_count(report) == 0
+        assert set(report.allowed_surface_classification) >= {
+            "COST_MODEL_DIAGNOSTICS",
+            "EXPLICITLY_CALIBRATABLE_RESEARCH_PARAMETERS_WITHIN_PREDECLARED_RANGES",
+            "TARGET_BINDING_REPAIR",
+            "WALK_FORWARD_MONTE_CARLO_STRESS_AND_PARAMETER_SENSITIVITY",
+        }
+
 
 class TestEconomicDiagnosticOptimizationBoundaryGuardNegativeV0:
     @pytest.mark.parametrize(

--- a/tests/research/test_offline_parameter_sensitivity_model_spec_alignment_v0.py
+++ b/tests/research/test_offline_parameter_sensitivity_model_spec_alignment_v0.py
@@ -1,0 +1,302 @@
+"""Regression tests for offline parameter sensitivity model spec alignment v0."""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from research.linear_evidence.import_boundary import scan_file_import_boundary
+from research.linear_evidence.sensitivity import (
+    EXCLUSION_REASON_ZERO_VARIANCE,
+    MODEL_SPEC_VERSION,
+    ParameterGridSpecV1,
+    ParameterSensitivityInputV1,
+    fit_parameter_sensitivity_surface,
+)
+from src.research.linear_evidence.fitters import (
+    REASON_CONSTANT_TARGET,
+    REASON_RANK_DEFICIENT_FEATURE_MATRIX,
+)
+from src.research.linear_evidence.parameter_sensitivity_productive_contract_v0 import (
+    materialize_productive_sensitivity_row_v0,
+)
+from research.linear_evidence.signal_matrix_productive_contract_v0 import (
+    DECISION_TIME_KEY,
+    FEATURE_TIME_KEY,
+    INSTRUMENT_ID_KEY,
+)
+from src.research.offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0 import (
+    materialize_offline_final_research_fleet_signal_matrix_v0,
+    serialize_signal_matrix_rows_v0,
+)
+from src.research.offline_parameter_sensitivity_productive_input_join_materializer_v0 import (
+    materialize_offline_parameter_sensitivity_productive_inputs_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SENSITIVITY_MODULE = REPO_ROOT / "src/research/linear_evidence/sensitivity.py"
+FITTER_MODULE = REPO_ROOT / "src/research/linear_evidence/fitters.py"
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+STAGING_ROOT = (
+    ARCHIVE_ROOT / "datasets/admissible_futures/"
+    "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/"
+    "extended_chronological_v1"
+)
+FORBIDDEN_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+    "src.trading.master_v2",
+    "src.risk",
+    "src.governance",
+)
+
+
+def _record(
+    index: int,
+    *,
+    target: float,
+    signal: float,
+    aux: float,
+    fee_bps: float = 10.0,
+    slippage_bps: float = 5.0,
+) -> ParameterSensitivityInputV1:
+    decision_time = f"2026-01-01T{index:02d}:00:00Z"
+    return ParameterSensitivityInputV1(
+        instrument_id="PF_ETHUSD",
+        decision_time=decision_time,
+        feature_availability_time=decision_time,
+        target=target,
+        features={
+            "signal": signal,
+            "aux": aux,
+            "fee_bps": fee_bps,
+            "slippage_bps": slippage_bps,
+        },
+    )
+
+
+def _productive_like_records(count: int = 16) -> list[ParameterSensitivityInputV1]:
+    records: list[ParameterSensitivityInputV1] = []
+    for index in range(count):
+        signal = float(index + 1)
+        aux = 0.05 * float(index % 4)
+        records.append(
+            _record(
+                index,
+                target=signal + aux,
+                signal=signal,
+                aux=aux,
+                fee_bps=10.0,
+                slippage_bps=5.0,
+            )
+        )
+    return records
+
+
+def _default_grid() -> ParameterGridSpecV1:
+    return ParameterGridSpecV1(
+        parameter_name="signal_scale",
+        scaled_feature_name="signal",
+        parameter_values=(0.85, 0.95, 1.0, 1.05, 1.15),
+    )
+
+
+def _fee_bps_grid() -> ParameterGridSpecV1:
+    return ParameterGridSpecV1(
+        parameter_name="fee_bps_scale",
+        scaled_feature_name="fee_bps",
+        parameter_values=(0.8, 1.0, 1.2),
+    )
+
+
+def test_constant_cost_features_excluded_transparently_for_1d_surface() -> None:
+    evidence = fit_parameter_sensitivity_surface(
+        _productive_like_records(),
+        grid=_fee_bps_grid(),
+    )
+
+    assert evidence.model_spec_version == MODEL_SPEC_VERSION
+    assert set(evidence.excluded_feature_names) == {"fee_bps", "slippage_bps"}
+    strict_codes = [
+        code
+        for code in evidence.exclusion_reason_codes
+        if code.startswith("STRICT_ZERO_VARIANCE_FEATURE_EXCLUDED:")
+    ]
+    surface_codes = [
+        code
+        for code in evidence.exclusion_reason_codes
+        if code.startswith(f"{EXCLUSION_REASON_ZERO_VARIANCE}:")
+    ]
+    assert len(strict_codes) == 2
+    assert len(surface_codes) == 2
+    assert {code.split(":", 1)[1] for code in strict_codes} == {"fee_bps", "slippage_bps"}
+
+
+def test_active_design_matrix_reaches_full_rank_for_productive_like_surface() -> None:
+    evidence = fit_parameter_sensitivity_surface(
+        _productive_like_records(),
+        grid=_fee_bps_grid(),
+    )
+
+    assert evidence.active_rank == evidence.required_active_rank == 3
+    assert evidence.requested_rank == 5
+    assert evidence.status != "RANK_DEFICIENT_BLOCKED"
+    assert math.isfinite(evidence.condition_number)
+    assert evidence.plateau_detection_admissible is True
+    assert evidence.fragility_detection_admissible is True
+
+
+def test_non_constant_features_are_not_excluded() -> None:
+    evidence = fit_parameter_sensitivity_surface(
+        _productive_like_records(),
+        grid=_fee_bps_grid(),
+    )
+
+    assert evidence.active_feature_names == ("aux", "signal")
+    assert "signal" not in evidence.excluded_feature_names
+    assert "aux" not in evidence.excluded_feature_names
+
+
+def test_constant_target_still_blocked() -> None:
+    records = [
+        _record(index, target=3.0, signal=float(index + 1), aux=0.1 * float(index))
+        for index in range(12)
+    ]
+    evidence = fit_parameter_sensitivity_surface(records, grid=_default_grid(), min_samples=4)
+
+    assert any(REASON_CONSTANT_TARGET in point.reason_codes for point in evidence.grid_evidence)
+    assert evidence.status in {"INSUFFICIENT_DATA", "RANK_DEFICIENT_BLOCKED"}
+
+
+def test_varying_feature_collinearity_still_blocked() -> None:
+    records = [
+        _record(index, target=float(index + 1), signal=float(index + 1), aux=2.0 * float(index + 1))
+        for index in range(12)
+    ]
+    evidence = fit_parameter_sensitivity_surface(records, grid=_default_grid(), min_samples=4)
+
+    assert evidence.status == "RANK_DEFICIENT_BLOCKED"
+    assert any(
+        REASON_RANK_DEFICIENT_FEATURE_MATRIX in point.reason_codes
+        for point in evidence.grid_evidence
+    )
+
+
+def test_deterministic_feature_order_and_exclusion_reason_codes() -> None:
+    first = fit_parameter_sensitivity_surface(_productive_like_records(), grid=_fee_bps_grid())
+    second = fit_parameter_sensitivity_surface(_productive_like_records(), grid=_fee_bps_grid())
+
+    assert (
+        first.excluded_feature_names
+        == second.excluded_feature_names
+        == (
+            "fee_bps",
+            "slippage_bps",
+        )
+    )
+    assert first.exclusion_reason_codes == second.exclusion_reason_codes
+    assert first.active_feature_names == second.active_feature_names == ("aux", "signal")
+
+
+def test_repeated_run_produces_byte_identical_diagnostic_payload(tmp_path: Path) -> None:
+    evidence = fit_parameter_sensitivity_surface(_productive_like_records(), grid=_default_grid())
+    payload = json.dumps(evidence.to_dict(), sort_keys=True, separators=(",", ":"))
+    path_a = tmp_path / "a.json"
+    path_b = tmp_path / "b.json"
+    path_a.write_text(payload, encoding="utf-8")
+    second = fit_parameter_sensitivity_surface(_productive_like_records(), grid=_default_grid())
+    path_b.write_text(
+        json.dumps(second.to_dict(), sort_keys=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    assert path_a.read_bytes() == path_b.read_bytes()
+
+
+def test_binding_semantics_unchanged_in_productive_contract() -> None:
+    row = {
+        INSTRUMENT_ID_KEY: "okx:linear_perpetual:ETH:USDT:USDT:perp",
+        DECISION_TIME_KEY: "2024-05-31T10:00:00Z",
+        FEATURE_TIME_KEY: "2024-05-31T09:00:00Z",
+        "bollinger_bands": 1.0,
+        "momentum_1h": 0.0,
+        "trend_following": -1.0,
+    }
+    record, reason = materialize_productive_sensitivity_row_v0(
+        row,
+        baseline_fee_bps=10.0,
+        baseline_slippage_bps=5.0,
+    )
+    assert reason is None
+    assert record is not None
+    assert record.features["fee_bps"] == 10.0
+    assert record.features["slippage_bps"] == 5.0
+
+
+def test_sensitivity_module_import_boundary() -> None:
+    violations = scan_file_import_boundary(SENSITIVITY_MODULE, repo_root=REPO_ROOT)
+    assert violations == []
+
+
+def test_fitter_module_import_boundary() -> None:
+    violations = scan_file_import_boundary(FITTER_MODULE, repo_root=REPO_ROOT)
+    assert violations == []
+
+
+def test_no_forbidden_trading_core_imports_in_sensitivity_module() -> None:
+    source = SENSITIVITY_MODULE.read_text(encoding="utf-8")
+    for prefix in FORBIDDEN_IMPORT_PREFIXES:
+        assert prefix not in source
+
+
+@pytest.mark.skipif(not STAGING_ROOT.is_dir(), reason="archive staging root unavailable")
+def test_productive_diagnostic_smoke_full_rank(tmp_path: Path) -> None:
+    result = materialize_offline_final_research_fleet_signal_matrix_v0(
+        repo_root=REPO_ROOT,
+        staging_root=STAGING_ROOT,
+    )
+    materialization = materialize_offline_parameter_sensitivity_productive_inputs_v0(
+        signal_matrix_rows=result.rows,
+        repo_root=REPO_ROOT,
+    )
+    assert materialization.status.value == "PASS"
+    sorted_records = tuple(
+        sorted(
+            materialization.records,
+            key=lambda record: (record.decision_time, record.instrument_id),
+        )
+    )
+    fee_spec = materialization.join_result.grid_specs[0]
+    evidence = fit_parameter_sensitivity_surface(
+        sorted_records,
+        grid=fee_spec,
+    )
+    assert evidence.excluded_feature_names == ("fee_bps", "slippage_bps")
+    assert evidence.active_rank == evidence.required_active_rank == 4
+    assert evidence.status != "RANK_DEFICIENT_BLOCKED"
+    assert evidence.economic_interpretation_admissible is False
+
+
+def test_fixture_runner_still_emits_model_spec_fields(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts/research/offline_parameter_sensitivity_surface_v0.py"),
+            "--out",
+            str(tmp_path),
+            "--fixture",
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads((tmp_path / "parameter_sensitivity_surface_evidence_v1.json").read_text())
+    assert report["model_spec_version"] == MODEL_SPEC_VERSION
+    assert report["economic_interpretation_admissible"] is False


### PR DESCRIPTION
## Summary
- Align productive 1D parameter sensitivity OLS fits with an active-feature-subset model spec that excludes strictly zero-variance cost columns (`fee_bps`, `slippage_bps`) per grid point while preserving full requested row provenance.
- Reuse canonical `fit_ols_lstsq` via a narrow preprocessing adapter in `sensitivity.py`; add shared strict zero-variance exclusion helpers in `fitters.py`.
- Add regression/contract tests and offline diagnostic evidence showing active design full rank without binding or trading-core semantic changes.

## Test plan
- [x] `tests/research/test_offline_parameter_sensitivity_model_spec_alignment_v0.py`
- [x] `tests/research/test_offline_parameter_sensitivity_surface_v0.py`
- [x] `tests/research/test_offline_parameter_sensitivity_productive_*`
- [x] `tests/research/test_offline_linear_cost_model_diagnostics_fitter_zero_variance_constant_target_precheck_v0.py`
- [x] Productive diagnostic smoke (1020 rows, active rank 4/4)


Made with [Cursor](https://cursor.com)