### PR TITLE
Bind canonical MV2 replay as the single backtest signal truth

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -322,7 +322,13 @@
     },
     "SIMULATED_FILL_BINDING_USING_EXISTING_CANONICAL_EXECUTION_OWNER": {
       "path_prefixes": [
-        "src/backtest/mv2_research_wiring_v1.py"
+        "src/backtest/mv2_research_wiring_v1.py",
+        "src/backtest/strategy_signal_binding_v1.py"
+      ],
+      "path_globs": [
+        "tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py",
+        "tests/research/test_cross_sectional_lead_lag_v0_backtest_engine_mv2_replay_signal_parity_v0.py",
+        "tests/research/test_cross_sectional_lead_lag_v0_research_eval_decision_parity_contract_suite_v0.py"
       ],
       "note": "Simulated fill binding must reuse existing canonical execution owners; no new runtime authority."
     },

--- a/config/ops/composite_breakout_confirmation_vol_gated_donchian_v1_architecture_binding_v1.json
+++ b/config/ops/composite_breakout_confirmation_vol_gated_donchian_v1_architecture_binding_v1.json
@@ -40,7 +40,7 @@
   "config_schema_version": "composite_breakout_confirmation_vol_gated_donchian_v1_architecture_binding_v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "strategy_id": "composite",
     "strategy_params": {
       "aggregation": "weighted",

--- a/config/ops/composite_vol_gated_breakout_donchian_v1_economic_evaluation_v1.json
+++ b/config/ops/composite_vol_gated_breakout_donchian_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_schema_version": "composite_vol_gated_breakout_donchian_v1_economic_evaluation_admissibility_v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step29m_okx_inst_eth_usdt_perp_armstrong_cycle_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_armstrong_cycle_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step29m_okx_inst_eth_usdt_perp_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step29m_okx_inst_eth_usdt_perp_breakout_donchian_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_breakout_donchian_v1_economic_evaluation_v1.json
@@ -74,7 +74,7 @@
   "config_schema_version": "step29m_breakout_donchian_v1_economic_evaluation_admissibility_v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step29m_okx_inst_eth_usdt_perp_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_schema_version": "step29m_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_admissibility_v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step29m_okx_inst_eth_usdt_perp_ehlers_cycle_filter_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_ehlers_cycle_filter_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step29m_okx_inst_eth_usdt_perp_el_karoui_vol_model_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_el_karoui_vol_model_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_ma_crossover_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v1.json
@@ -73,7 +73,7 @@
   },
   "config_schema_version": "step29m_macd_v1_economic_evaluation_admissibility_v1",
   "economic_evaluation_v1": {
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v2.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v2.json
@@ -74,7 +74,7 @@
   "config_schema_version": "step29m_macd_v1_economic_evaluation_admissibility_v2",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v3.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_macd_v1_economic_evaluation_v3.json
@@ -74,7 +74,7 @@
   "config_schema_version": "step29m_macd_v1_economic_evaluation_admissibility_v3",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step29m_okx_inst_eth_usdt_perp_vol_breakout_v1_economic_evaluation_v1.json
+++ b/config/ops/step29m_okx_inst_eth_usdt_perp_vol_breakout_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json
+++ b/config/ops/step30a_okx_inst_eth_usdt_perp_rsi_reversion_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step31f_okx_full_panel_eth_usdt_perp_bollinger_bands_v1_economic_evaluation_v1.json
+++ b/config/ops/step31f_okx_full_panel_eth_usdt_perp_bollinger_bands_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step31f_okx_full_panel_eth_usdt_perp_momentum_1h_v1_economic_evaluation_v1.json
+++ b/config/ops/step31f_okx_full_panel_eth_usdt_perp_momentum_1h_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step31f_okx_full_panel_eth_usdt_perp_trend_following_v1_economic_evaluation_v1.json
+++ b/config/ops/step31f_okx_full_panel_eth_usdt_perp_trend_following_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step31f_okx_inst_eth_usdt_perp_bollinger_bands_v1_economic_evaluation_v1.json
+++ b/config/ops/step31f_okx_inst_eth_usdt_perp_bollinger_bands_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step31f_okx_inst_eth_usdt_perp_momentum_1h_v1_economic_evaluation_v1.json
+++ b/config/ops/step31f_okx_inst_eth_usdt_perp_momentum_1h_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/config/ops/step31f_okx_inst_eth_usdt_perp_trend_following_v1_economic_evaluation_v1.json
+++ b/config/ops/step31f_okx_inst_eth_usdt_perp_trend_following_v1_economic_evaluation_v1.json
@@ -75,7 +75,7 @@
   "config_version": "v1",
   "economic_evaluation_v1": {
     "economic_validity_policy_version": "economic_validity_policy_v1",
-    "engine_signal_source": "configured_strategy_signal",
+    "engine_signal_source": "mv2_decision_replay_series",
     "monte_carlo": {
       "bind": true,
       "policy_version": "monte_carlo_v1",

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 """
-Peak_Trade – Zentrales Backtest-Script
-======================================
-Einziger Standard-Einstiegspunkt für Backtests.
+Peak_Trade – Legacy Raw-Signal Research Backtest Entry
+======================================================
+Bewusst separater Legacy-/Raw-Signal-Research-Einstiegspunkt — **nicht** der
+kanonische Full-System-/MV2-Replay-Entry und **kein** System-Economic-Evidence-Pfad.
+
+Path classification: ``RAW_SIGNAL_RESEARCH`` (``configured_strategy_signal``).
+Kanonischer Systempfad: ``run_mv2_research_backtest_wiring_v1`` mit
+``mv2_decision_replay_series`` (``CANONICAL_SYSTEM_REPLAY``).
 
 NO-LIVE: nur Backtest / Evidence-Artefakte — keine Order-Ausführung, kein Live- oder
 Execution-Scope. Das Handelssymbol für Metadaten kommt aus der Config über

--- a/src/backtest/mv2_research_wiring_v1.py
+++ b/src/backtest/mv2_research_wiring_v1.py
@@ -36,15 +36,18 @@ from src.backtest.engine import BacktestEngine
 from src.backtest.result import BacktestResult
 from src.backtest.stats import compute_backtest_stats
 from src.backtest.strategy_signal_binding_v1 import (
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
     ENGINE_SIGNAL_SOURCE_MV2_REPLAY,
     MV2_REPLAY_SIGNAL_SOURCE,
     StrategySignalBindingError,
     StrategySignalProvenanceV1,
+    assert_decision_funnel_trade_alignment_v1,
     assert_engine_signal_provenance_consistency_v1,
     assert_backtest_engine_mv2_replay_signal_parity_v1,
     compute_strategy_signal_digest_v1,
     execute_configured_strategy_signal_series_v1,
+    resolve_mv2_research_engine_signal_source_v1,
     validate_mv2_replay_engine_signal_contract_v1,
 )
 from src.backtest.offline_evaluation_sizing_contract_v1 import (
@@ -413,7 +416,7 @@ class MV2ResearchWiringResultV1:
     mv2_replay_signal_digest: str
     mv2_replay_nonzero_signal_count: int
     sizing_provenance: Mapping[str, Any] = field(default_factory=dict)
-    backtest_engine_signal_source: str = ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY
+    backtest_engine_signal_source: str = CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE
     backtest_engine_signal_digest: str = ""
     decision_funnel_counts: Mapping[str, int] = field(default_factory=dict)
     block_reason_counts: Mapping[str, int] = field(default_factory=dict)
@@ -1660,12 +1663,17 @@ def run_mv2_research_backtest_wiring_v1(
     | None = None,
     feedback_learning_state_file_binding: FeedbackLearningBacktestStateFileBindingConfigV1
     | None = None,
-    backtest_engine_signal_source: str = ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    backtest_engine_signal_source: str | None = None,
     expected_mv2_replay_signal_digest: Optional[str] = None,
 ) -> MV2ResearchWiringResultV1:
     _fail_closed(bars.empty, "bars_empty")
     _ensure_supported_instrument(instrument_id)
     _ensure_no_lookahead(bars)
+
+    resolved_engine_signal_source = resolve_mv2_research_engine_signal_source_v1(
+        explicit_source=backtest_engine_signal_source,
+        cfg=cfg,
+    )
 
     effective_profile = profile_binding or default_runtime_profile_binding_v1()
     if effective_profile.dataset_profile is DatasetProfileV1.RUNTIME_MARKET_CONTEXT_V1:
@@ -1783,7 +1791,7 @@ def run_mv2_research_backtest_wiring_v1(
     assert_engine_signal_provenance_consistency_v1(strategy_binding.provenance)
     engine_signal_series = strategy_binding.signals
 
-    position_feedback_bound = backtest_engine_signal_source == ENGINE_SIGNAL_SOURCE_MV2_REPLAY
+    position_feedback_bound = resolved_engine_signal_source == ENGINE_SIGNAL_SOURCE_MV2_REPLAY
     engine_cfg = dict(cfg)
     sizing_provenance: dict[str, Any] = {}
     strategy_params = {
@@ -2037,7 +2045,7 @@ def run_mv2_research_backtest_wiring_v1(
     )
     mv2_replay_nonzero = int((mv2_replay_series != 0).sum())
 
-    if backtest_engine_signal_source == ENGINE_SIGNAL_SOURCE_MV2_REPLAY:
+    if resolved_engine_signal_source == ENGINE_SIGNAL_SOURCE_MV2_REPLAY:
         try:
             engine_signal_series, engine_provenance = validate_mv2_replay_engine_signal_contract_v1(
                 mv2_replay_series,
@@ -2049,12 +2057,12 @@ def run_mv2_research_backtest_wiring_v1(
         except StrategySignalBindingError as exc:
             raise ValueError(f"mv2_replay_engine_signal_binding_failed:{exc}") from exc
         backtest_engine_signal_digest = mv2_replay_digest
-    elif backtest_engine_signal_source == ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+    elif resolved_engine_signal_source == ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
         engine_provenance = strategy_binding.provenance
         backtest_engine_signal_digest = engine_provenance.engine_signal_digest
     else:
         raise ValueError(
-            f"backtest_engine_signal_source_unsupported:{backtest_engine_signal_source}"
+            f"backtest_engine_signal_source_unsupported:{resolved_engine_signal_source}"
         )
 
     def _signal_fn(df: pd.DataFrame, params: Mapping[str, Any]) -> pd.Series:  # noqa: ARG001
@@ -2101,13 +2109,19 @@ def run_mv2_research_backtest_wiring_v1(
             raise ValueError("offline_sizing_accounting_missing")
         sizing_provenance = serialize_sizing_provenance_v1(contract, accounting)
 
-    if backtest_engine_signal_source == ENGINE_SIGNAL_SOURCE_MV2_REPLAY:
+    if resolved_engine_signal_source == ENGINE_SIGNAL_SOURCE_MV2_REPLAY:
         assert_backtest_engine_mv2_replay_signal_parity_v1(
             mv2_replay_signals=mv2_replay_series,
             bar_outcomes=tuple(outcomes),
-            backtest_engine_signal_source=backtest_engine_signal_source,
+            backtest_engine_signal_source=resolved_engine_signal_source,
             backtest_engine_signal_digest=backtest_engine_signal_digest,
             mv2_replay_signal_digest=mv2_replay_digest,
+        )
+        assert_decision_funnel_trade_alignment_v1(
+            bar_outcomes=tuple(outcomes),
+            engine_signals=engine_signal_series,
+            backtest_engine_signal_source=resolved_engine_signal_source,
+            backtest_result=backtest_result,
         )
 
     trades_df = backtest_result.trades
@@ -2130,7 +2144,7 @@ def run_mv2_research_backtest_wiring_v1(
         sizing_provenance=sizing_provenance,
         decision_funnel_counts=decision_funnel_accumulator.counts_dict(),
         block_reason_counts=materialize_block_reason_counts_v0(decision_funnel_accumulator),
-        backtest_engine_signal_source=backtest_engine_signal_source,
+        backtest_engine_signal_source=resolved_engine_signal_source,
         backtest_engine_signal_digest=backtest_engine_signal_digest,
     )
 

--- a/src/backtest/step29m_armstrong_cycle_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_armstrong_cycle_v1_economic_evaluation_admissibility_contract_v1.py
@@ -20,6 +20,7 @@ from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 
 )
 from src.backtest.strategy_signal_binding_v1 import (
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
     StrategySignalBindingError,
     collect_configured_strategy_params_v1,
     compute_required_warmup_rows_v1,
@@ -340,7 +341,7 @@ def verify_armstrong_cycle_v1_config_schema_v1(cfg: Mapping[str, Any]) -> tuple[
         reasons.append("config_strategy_id_mismatch")
     if eval_section.get("strategy_version") != ARMSTRONG_CYCLE_V1_STRATEGY_VERSION:
         reasons.append("config_strategy_version_mismatch")
-    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+    if eval_section.get("engine_signal_source") != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE:
         reasons.append("engine_signal_source_not_bound")
 
     strategy_params = eval_section.get("strategy_params")

--- a/src/backtest/step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_bouchaud_microstructure_ohlcv_proxy_v1_economic_evaluation_admissibility_contract_v1.py
@@ -25,6 +25,7 @@ from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 
 )
 from src.backtest.strategy_signal_binding_v1 import (
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
     StrategySignalBindingError,
     collect_configured_strategy_params_v1,
     compute_required_warmup_rows_v1,
@@ -541,7 +542,7 @@ def verify_bouchaud_microstructure_ohlcv_proxy_v1_config_schema_v1(
         reasons.append("config_strategy_version_mismatch")
     if eval_section.get("research_scope") != RESEARCH_SCOPE:
         reasons.append("config_research_scope_mismatch")
-    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+    if eval_section.get("engine_signal_source") != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE:
         reasons.append("engine_signal_source_not_bound")
     if eval_section.get("economic_validity_policy_version") != "economic_validity_policy_v1":
         reasons.append("economic_validity_policy_version_mismatch")

--- a/src/backtest/step29m_breakout_donchian_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_breakout_donchian_v1_economic_evaluation_admissibility_contract_v1.py
@@ -20,6 +20,7 @@ from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 
 )
 from src.backtest.strategy_signal_binding_v1 import (
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
     StrategySignalBindingError,
     collect_configured_strategy_params_v1,
     compute_required_warmup_rows_v1,
@@ -247,7 +248,7 @@ def verify_breakout_donchian_v1_config_schema_v1(cfg: Mapping[str, Any]) -> tupl
         reasons.append("config_strategy_id_mismatch")
     if eval_section.get("strategy_version") != BREAKOUT_DONCHIAN_V1_STRATEGY_VERSION:
         reasons.append("config_strategy_version_mismatch")
-    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+    if eval_section.get("engine_signal_source") != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE:
         reasons.append("engine_signal_source_not_bound")
 
     strategy_params = eval_section.get("strategy_params")

--- a/src/backtest/step29m_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_composite_breakout_confirmation_vol_gated_donchian_v1_economic_evaluation_admissibility_contract_v1.py
@@ -24,6 +24,7 @@ from src.backtest.strategy_signal_binding_v1 import (
     COMPOSITE_STRATEGY_ID,
     COMPOSITION_RULE_CONFIRMED_SIGNAL_TIMES_FILTER_MASK,
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
     StrategySignalBindingError,
     collect_configured_strategy_params_v1,
     compute_composite_required_warmup_rows_v1,
@@ -251,7 +252,7 @@ def verify_composite_breakout_confirmation_vol_gated_donchian_v1_config_schema_v
         reasons.append("config_strategy_id_mismatch")
     if eval_section.get("strategy_version") != COMPOSITE_V1_STRATEGY_VERSION:
         reasons.append("config_strategy_version_mismatch")
-    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+    if eval_section.get("engine_signal_source") != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE:
         reasons.append("engine_signal_source_not_bound")
 
     for required_section in ("walk_forward", "monte_carlo", "stress"):

--- a/src/backtest/step29m_ehlers_cycle_filter_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_ehlers_cycle_filter_v1_economic_evaluation_admissibility_contract_v1.py
@@ -20,6 +20,7 @@ from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 
 )
 from src.backtest.strategy_signal_binding_v1 import (
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
     StrategySignalBindingError,
     collect_configured_strategy_params_v1,
     compute_required_warmup_rows_v1,
@@ -336,7 +337,7 @@ def verify_ehlers_cycle_filter_v1_config_schema_v1(cfg: Mapping[str, Any]) -> tu
         reasons.append("config_strategy_id_mismatch")
     if eval_section.get("strategy_version") != EHLERS_CYCLE_FILTER_V1_STRATEGY_VERSION:
         reasons.append("config_strategy_version_mismatch")
-    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+    if eval_section.get("engine_signal_source") != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE:
         reasons.append("engine_signal_source_not_bound")
     if eval_section.get("economic_validity_policy_version") != "economic_validity_policy_v1":
         reasons.append("economic_validity_policy_version_mismatch")

--- a/src/backtest/step29m_el_karoui_vol_model_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_el_karoui_vol_model_v1_economic_evaluation_admissibility_contract_v1.py
@@ -20,6 +20,7 @@ from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 
 )
 from src.backtest.strategy_signal_binding_v1 import (
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
     StrategySignalBindingError,
     collect_configured_strategy_params_v1,
     compute_required_warmup_rows_v1,
@@ -370,7 +371,7 @@ def verify_el_karoui_vol_model_v1_config_schema_v1(cfg: Mapping[str, Any]) -> tu
         reasons.append("config_strategy_id_mismatch")
     if eval_section.get("strategy_version") != EL_KAROUI_VOL_MODEL_V1_STRATEGY_VERSION:
         reasons.append("config_strategy_version_mismatch")
-    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+    if eval_section.get("engine_signal_source") != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE:
         reasons.append("engine_signal_source_not_bound")
 
     strategy_params = eval_section.get("strategy_params")

--- a/src/backtest/step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_ma_crossover_v1_economic_evaluation_admissibility_contract_v1.py
@@ -20,6 +20,7 @@ from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 
 )
 from src.backtest.strategy_signal_binding_v1 import (
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
     StrategySignalBindingError,
     collect_configured_strategy_params_v1,
     compute_required_warmup_rows_v1,
@@ -325,7 +326,7 @@ def verify_ma_crossover_v1_config_schema_v1(cfg: Mapping[str, Any]) -> tuple[str
         reasons.append("config_strategy_id_mismatch")
     if eval_section.get("strategy_version") != MA_CROSSOVER_V1_STRATEGY_VERSION:
         reasons.append("config_strategy_version_mismatch")
-    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+    if eval_section.get("engine_signal_source") != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE:
         reasons.append("engine_signal_source_not_bound")
     if eval_section.get("economic_validity_policy_version") != "economic_validity_policy_v1":
         reasons.append("economic_validity_policy_version_mismatch")

--- a/src/backtest/step29m_macd_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_macd_v1_economic_evaluation_admissibility_contract_v1.py
@@ -25,6 +25,7 @@ from src.backtest.offline_evaluation_sizing_contract_v1 import (
 )
 from src.backtest.strategy_signal_binding_v1 import (
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
     MV2_REPLAY_SIGNAL_SOURCE,
     SignalAlignmentStatus,
     SignalContractStatus,
@@ -567,7 +568,7 @@ def evaluate_macd_v1_admissibility_contract_v1(
             blocking.append("config_strategy_id_mismatch")
         if eval_section.get("strategy_version") != MACD_V1_STRATEGY_VERSION:
             blocking.append("config_strategy_version_mismatch")
-        if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+        if eval_section.get("engine_signal_source") != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE:
             blocking.append("engine_signal_source_not_bound")
 
     if offline_evaluation_sizing_contract_requested(cfg):

--- a/src/backtest/step29m_vol_breakout_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step29m_vol_breakout_v1_economic_evaluation_admissibility_contract_v1.py
@@ -20,6 +20,7 @@ from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 
 )
 from src.backtest.strategy_signal_binding_v1 import (
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
     StrategySignalBindingError,
     collect_configured_strategy_params_v1,
     compute_required_warmup_rows_v1,
@@ -347,7 +348,7 @@ def verify_vol_breakout_v1_config_schema_v1(cfg: Mapping[str, Any]) -> tuple[str
         reasons.append("config_strategy_id_mismatch")
     if eval_section.get("strategy_version") != VOL_BREAKOUT_V1_STRATEGY_VERSION:
         reasons.append("config_strategy_version_mismatch")
-    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+    if eval_section.get("engine_signal_source") != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE:
         reasons.append("engine_signal_source_not_bound")
     if eval_section.get("economic_validity_policy_version") != "economic_validity_policy_v1":
         reasons.append("economic_validity_policy_version_mismatch")

--- a/src/backtest/step30a_rsi_reversion_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/src/backtest/step30a_rsi_reversion_v1_economic_evaluation_admissibility_contract_v1.py
@@ -22,6 +22,7 @@ from src.backtest.step29m_macd_v1_economic_evaluation_admissibility_contract_v1 
 )
 from src.backtest.strategy_signal_binding_v1 import (
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
     StrategySignalBindingError,
     collect_configured_strategy_params_v1,
     compute_required_warmup_rows_v1,
@@ -405,7 +406,7 @@ def verify_rsi_reversion_v1_config_schema_v1(cfg: Mapping[str, Any]) -> tuple[st
         reasons.append("config_strategy_id_mismatch")
     if eval_section.get("strategy_version") != RSI_REVERSION_V1_STRATEGY_VERSION:
         reasons.append("config_strategy_version_mismatch")
-    if eval_section.get("engine_signal_source") != ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY:
+    if eval_section.get("engine_signal_source") != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE:
         reasons.append("engine_signal_source_not_bound")
     if eval_section.get("economic_validity_policy_version") != "economic_validity_policy_v1":
         reasons.append("economic_validity_policy_version_mismatch")

--- a/src/backtest/strategy_signal_binding_v1.py
+++ b/src/backtest/strategy_signal_binding_v1.py
@@ -35,6 +35,16 @@ ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY = "configured_strategy_signal"
 ENGINE_SIGNAL_SOURCE_MV2_REPLAY = "mv2_decision_replay_series"
 STRATEGY_SIGNAL_SOURCE_CANONICAL = "canonical_strategy_signal_series"
 MV2_REPLAY_SIGNAL_SOURCE = ENGINE_SIGNAL_SOURCE_MV2_REPLAY
+CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE = ENGINE_SIGNAL_SOURCE_MV2_REPLAY
+LEGACY_RAW_SIGNAL_RESEARCH_ENGINE_SIGNAL_SOURCE = ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY
+RUN_BACKTEST_PATH_CLASSIFICATION = "RAW_SIGNAL_RESEARCH"
+CANONICAL_MV2_SYSTEM_PATH_CLASSIFICATION = "CANONICAL_SYSTEM_REPLAY"
+_ALLOWED_ENGINE_SIGNAL_SOURCES = frozenset(
+    {
+        ENGINE_SIGNAL_SOURCE_MV2_REPLAY,
+        ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    }
+)
 
 _ALLOWED_SIGNAL_VALUES = frozenset({-1, 0, 1})
 
@@ -999,6 +1009,118 @@ def validate_mv2_replay_engine_signal_contract_v1(
         all_flat_signal_reason=all_flat_reason,
     )
     return int_signals, provenance
+
+
+def resolve_engine_signal_source_from_cfg_v1(cfg: Mapping[str, Any]) -> str | None:
+    """Read optional engine_signal_source from economic_evaluation_v1 config section."""
+    eval_section = cfg.get("economic_evaluation_v1")
+    if not isinstance(eval_section, Mapping):
+        return None
+    raw = eval_section.get("engine_signal_source")
+    if raw is None:
+        return None
+    return str(raw).strip()
+
+
+def validate_engine_signal_source_v1(engine_signal_source: str) -> str:
+    """Fail-closed validation for known engine signal sources."""
+    normalized = str(engine_signal_source).strip()
+    _fail_closed(
+        normalized not in _ALLOWED_ENGINE_SIGNAL_SOURCES,
+        f"engine_signal_source_unsupported:{normalized or 'missing'}",
+    )
+    return normalized
+
+
+def resolve_mv2_research_engine_signal_source_v1(
+    *,
+    explicit_source: str | None = None,
+    cfg: Mapping[str, Any] | None = None,
+) -> str:
+    """Resolve canonical MV2 research engine signal source without silent fallback."""
+    if cfg is not None:
+        configured = resolve_engine_signal_source_from_cfg_v1(cfg)
+        if configured is not None:
+            return validate_engine_signal_source_v1(configured)
+    if explicit_source is not None:
+        return validate_engine_signal_source_v1(explicit_source)
+    return CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE
+
+
+def assert_canonical_mv2_config_engine_signal_source_bound_v1(
+    eval_section: Mapping[str, Any],
+) -> None:
+    """Require canonical MV2 configs to bind mv2_decision_replay_series."""
+    bound = eval_section.get("engine_signal_source")
+    _fail_closed(
+        bound != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
+        "canonical_mv2_engine_signal_source_not_bound",
+    )
+
+
+def assert_decision_funnel_trade_alignment_v1(
+    *,
+    bar_outcomes: Sequence[Any],
+    engine_signals: pd.Series,
+    backtest_engine_signal_source: str,
+    backtest_result: Any,
+) -> None:
+    """Fail-closed alignment between funnel evidence, mapped replay signals, and engine input."""
+    _fail_closed(
+        backtest_engine_signal_source != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
+        "decision_funnel_trade_alignment_requires_mv2_replay_source",
+    )
+    _fail_closed(
+        len(bar_outcomes) != len(engine_signals), "decision_funnel_engine_signal_length_mismatch"
+    )
+    replay_values = [int(outcome.position_signal) for outcome in bar_outcomes]
+    engine_values = [int(v) for v in engine_signals.astype(int).tolist()]
+    _fail_closed(replay_values != engine_values, "decision_funnel_engine_signal_value_mismatch")
+    for i, outcome in enumerate(bar_outcomes):
+        _fail_closed(
+            int(outcome.trading_epoch) != i,
+            f"decision_funnel_epoch_order_mismatch:{i}",
+        )
+        _fail_closed(
+            outcome.evidence.trading_epoch != outcome.trading_epoch,
+            f"decision_funnel_evidence_epoch_mismatch:{i}",
+        )
+        _fail_closed(
+            not getattr(outcome.evidence, "decision_id", ""),
+            f"decision_funnel_missing_decision_id:{i}",
+        )
+    trades_df = getattr(backtest_result, "trades", None)
+    trade_count = len(trades_df) if trades_df is not None else 0
+    if trade_count == 0:
+        return
+    _fail_closed(
+        not any(value != 0 for value in engine_values),
+        "decision_funnel_nonzero_engine_signal_missing_for_trades",
+    )
+
+
+def assert_parallel_strategy_signal_does_not_control_engine_v1(
+    *,
+    strategy_signals: pd.Series,
+    engine_signals: pd.Series,
+    mv2_replay_signals: pd.Series,
+    backtest_engine_signal_source: str,
+) -> None:
+    """Configured strategy diagnostics must not override canonical MV2 engine consumption."""
+    _fail_closed(
+        backtest_engine_signal_source != CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
+        "parallel_truth_prevention_requires_mv2_replay_source",
+    )
+    replay_values = [int(v) for v in mv2_replay_signals.astype(int).tolist()]
+    engine_values = [int(v) for v in engine_signals.astype(int).tolist()]
+    _fail_closed(replay_values != engine_values, "parallel_truth_engine_not_replay_aligned")
+    strategy_values = [int(v) for v in strategy_signals.astype(int).tolist()]
+    if strategy_values == replay_values:
+        return
+    _fail_closed(
+        engine_values == strategy_values,
+        "parallel_strategy_signal_controls_engine_output",
+    )
 
 
 def assert_backtest_engine_mv2_replay_signal_parity_v1(

--- a/tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py
+++ b/tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pandas as pd
+import pytest
+
+from src.backtest import mv2_research_wiring_v1 as wiring
+from src.backtest.strategy_signal_binding_v1 import (
+    CANONICAL_MV2_SYSTEM_PATH_CLASSIFICATION,
+    CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE,
+    ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+    ENGINE_SIGNAL_SOURCE_MV2_REPLAY,
+    LEGACY_RAW_SIGNAL_RESEARCH_ENGINE_SIGNAL_SOURCE,
+    RUN_BACKTEST_PATH_CLASSIFICATION,
+    StrategySignalBindingError,
+    assert_backtest_engine_mv2_replay_signal_parity_v1,
+    assert_decision_funnel_trade_alignment_v1,
+    assert_parallel_strategy_signal_does_not_control_engine_v1,
+    resolve_mv2_research_engine_signal_source_v1,
+    validate_engine_signal_source_v1,
+)
+
+
+def _cfg(*, engine_signal_source: str | None = None) -> Mapping[str, Any]:
+    payload: dict[str, Any] = {
+        "backtest": {
+            "initial_cash": 10_000.0,
+            "cost_model_version": "backtest_cost_v0",
+            "fee_bps": 10.0,
+            "slippage_bps": 5.0,
+        },
+        "risk": {
+            "risk_per_trade": 0.02,
+            "max_position_size": 0.25,
+            "min_position_value": 10.0,
+            "min_stop_distance": 0.0001,
+        },
+        "economic_evaluation_v1": {
+            "strategy_params": {"fast_window": 2, "slow_window": 3},
+        },
+    }
+    if engine_signal_source is not None:
+        payload["economic_evaluation_v1"]["engine_signal_source"] = engine_signal_source
+    return payload
+
+
+def _bars(n: int = 12) -> pd.DataFrame:
+    idx = pd.date_range("2026-06-01", periods=n, freq="1h", tz="UTC")
+    close = [100.0 + float(i) for i in range(n)]
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [v + 0.5 for v in close],
+            "low": [v - 0.5 for v in close],
+            "close": close,
+            "mark_price": close,
+            "index_price": [v - 0.1 for v in close],
+            "best_bid": [v - 0.05 for v in close],
+            "best_ask": [v + 0.05 for v in close],
+            "spread": [0.1 for _ in close],
+            "volume": [1000.0 for _ in close],
+            "open_interest": [10000.0 for _ in close],
+            "funding_rate": [0.0001 for _ in close],
+            "volatility_estimate": [0.2 for _ in close],
+            "is_final": [True for _ in close],
+            "bar_interval": ["1m" for _ in close],
+        },
+        index=idx,
+    )
+
+
+def _run(**kwargs: Any) -> wiring.MV2ResearchWiringResultV1:
+    return wiring.run_mv2_research_backtest_wiring_v1(
+        bars=kwargs.pop("bars", _bars()),
+        strategy_id=kwargs.pop("strategy_id", "ma_crossover"),
+        cfg=kwargs.pop("cfg", _cfg()),
+        **kwargs,
+    )
+
+
+def test_resolver_defaults_to_canonical_mv2_replay() -> None:
+    assert resolve_mv2_research_engine_signal_source_v1() == CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE
+
+
+def test_resolver_prefers_cfg_binding_over_explicit() -> None:
+    resolved = resolve_mv2_research_engine_signal_source_v1(
+        explicit_source=ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
+        cfg=_cfg(engine_signal_source=ENGINE_SIGNAL_SOURCE_MV2_REPLAY),
+    )
+    assert resolved == ENGINE_SIGNAL_SOURCE_MV2_REPLAY
+
+
+def test_resolver_rejects_unknown_source() -> None:
+    with pytest.raises(StrategySignalBindingError, match="engine_signal_source_unsupported"):
+        validate_engine_signal_source_v1("parallel_mixed_signal_truth")
+
+
+def test_mv2_default_wiring_uses_mv2_replay_engine_source() -> None:
+    result = _run()
+    assert result.backtest_engine_signal_source == ENGINE_SIGNAL_SOURCE_MV2_REPLAY
+
+
+def test_mv2_engine_signals_match_replay_series() -> None:
+    result = _run()
+    assert result.signals.astype(int).tolist() == result.mv2_replay_signals.astype(int).tolist()
+
+
+def test_mv2_replay_parity_assertion_passes_on_default_path() -> None:
+    result = _run()
+    assert_backtest_engine_mv2_replay_signal_parity_v1(
+        mv2_replay_signals=result.mv2_replay_signals,
+        bar_outcomes=result.bar_outcomes,
+        backtest_engine_signal_source=result.backtest_engine_signal_source,
+        backtest_engine_signal_digest=result.backtest_engine_signal_digest,
+        mv2_replay_signal_digest=result.mv2_replay_signal_digest,
+    )
+
+
+def test_decision_funnel_trade_alignment_passes_on_default_path() -> None:
+    result = _run()
+    assert_decision_funnel_trade_alignment_v1(
+        bar_outcomes=result.bar_outcomes,
+        engine_signals=result.signals,
+        backtest_engine_signal_source=result.backtest_engine_signal_source,
+        backtest_result=result.backtest_result,
+    )
+
+
+def test_parallel_strategy_signal_does_not_control_engine_when_divergent() -> None:
+    result = _run()
+    divergent_strategy = pd.Series(1, index=result.signals.index, dtype=int)
+    assert divergent_strategy.astype(int).tolist() != result.mv2_replay_signals.astype(int).tolist()
+    assert_parallel_strategy_signal_does_not_control_engine_v1(
+        strategy_signals=divergent_strategy,
+        engine_signals=result.signals,
+        mv2_replay_signals=result.mv2_replay_signals,
+        backtest_engine_signal_source=result.backtest_engine_signal_source,
+    )
+
+
+def test_legacy_configured_strategy_source_still_available_explicitly() -> None:
+    result = _run(
+        cfg=_cfg(engine_signal_source=ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY),
+    )
+    assert result.backtest_engine_signal_source == ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY
+    assert (
+        result.strategy_signal_provenance.engine_signal_source
+        == ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY
+    )
+
+
+def test_artificial_strategy_signal_mutation_does_not_change_engine_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bars = _bars()
+    baseline = _run(bars=bars)
+    mutated = pd.Series(1, index=bars.index, dtype=int)
+
+    def _mutated_strategy(*_args: Any, **_kwargs: Any):
+        from src.backtest.strategy_signal_binding_v1 import StrategySignalBindingResultV1
+
+        return StrategySignalBindingResultV1(
+            signals=mutated,
+            provenance=baseline.strategy_signal_provenance,
+        )
+
+    monkeypatch.setattr(
+        wiring,
+        "execute_configured_strategy_signal_series_v1",
+        _mutated_strategy,
+    )
+    result = _run(bars=bars)
+    assert result.backtest_engine_signal_source == ENGINE_SIGNAL_SOURCE_MV2_REPLAY
+    assert result.signals.astype(int).tolist() == result.mv2_replay_signals.astype(int).tolist()
+    assert mutated.astype(int).tolist() != result.signals.astype(int).tolist()
+
+
+def test_path_classification_constants() -> None:
+    assert CANONICAL_SYSTEM_ENGINE_SIGNAL_SOURCE == ENGINE_SIGNAL_SOURCE_MV2_REPLAY
+    assert (
+        LEGACY_RAW_SIGNAL_RESEARCH_ENGINE_SIGNAL_SOURCE == ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY
+    )
+    assert CANONICAL_MV2_SYSTEM_PATH_CLASSIFICATION == "CANONICAL_SYSTEM_REPLAY"
+    assert RUN_BACKTEST_PATH_CLASSIFICATION == "RAW_SIGNAL_RESEARCH"
+
+
+def test_run_backtest_script_documents_legacy_classification() -> None:
+    text = (wiring.__file__).replace(
+        "src/backtest/mv2_research_wiring_v1.py",
+        "scripts/run_backtest.py",
+    )
+    from pathlib import Path
+
+    content = Path(text).read_text(encoding="utf-8")
+    assert "RAW_SIGNAL_RESEARCH" in content
+    assert "CANONICAL_SYSTEM_REPLAY" in content

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -251,6 +251,24 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
             "WALK_FORWARD_MONTE_CARLO_STRESS_AND_PARAMETER_SENSITIVITY",
         }
 
+    def test_mv2_engine_signal_source_binding_surfaces_classified(self) -> None:
+        changed_files = [
+            "src/backtest/mv2_research_wiring_v1.py",
+            "src/backtest/strategy_signal_binding_v1.py",
+            "tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py",
+            "tests/research/test_cross_sectional_lead_lag_v0_backtest_engine_mv2_replay_signal_parity_v0.py",
+            "tests/research/test_cross_sectional_lead_lag_v0_research_eval_decision_parity_contract_suite_v0.py",
+            "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+        ]
+        report = build_boundary_report(changed_files, repo_root=REPO_ROOT)
+        assert report.admissible is True
+        assert report.impact_unknown is False
+        assert "ALLOWED_OPTIMIZATION_SURFACE_ONLY" in report.reason_codes
+        assert forbidden_surface_changed_count(report) == 0
+        assert set(report.allowed_surface_classification) == {
+            "SIMULATED_FILL_BINDING_USING_EXISTING_CANONICAL_EXECUTION_OWNER",
+        }
+
 
 class TestEconomicDiagnosticOptimizationBoundaryGuardNegativeV0:
     @pytest.mark.parametrize(

--- a/tests/ops/test_step29m_macd_v1_economic_evaluation_admissibility_contract_v1.py
+++ b/tests/ops/test_step29m_macd_v1_economic_evaluation_admissibility_contract_v1.py
@@ -93,7 +93,7 @@ def test_macd_warmup_contract() -> None:
 
 def test_config_schema_and_engine_signal_source(cfg: dict) -> None:
     assert cfg["config_schema_version"] == "step29m_macd_v1_economic_evaluation_admissibility_v1"
-    assert cfg["economic_evaluation_v1"]["engine_signal_source"] == "configured_strategy_signal"
+    assert cfg["economic_evaluation_v1"]["engine_signal_source"] == "mv2_decision_replay_series"
 
 
 def test_config_digest_stable(cfg: dict) -> None:

--- a/tests/research/test_cross_sectional_lead_lag_v0_backtest_engine_mv2_replay_signal_parity_v0.py
+++ b/tests/research/test_cross_sectional_lead_lag_v0_backtest_engine_mv2_replay_signal_parity_v0.py
@@ -265,7 +265,7 @@ def test_unrelated_mv2_wiring_path_unchanged() -> None:
         strategy_id="ma_crossover",
         cfg=cfg,
     )
-    assert result.backtest_engine_signal_source == ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY
+    assert result.backtest_engine_signal_source == ENGINE_SIGNAL_SOURCE_MV2_REPLAY
     assert (
         result.strategy_signal_provenance.engine_signal_source
         == ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY

--- a/tests/research/test_cross_sectional_lead_lag_v0_research_eval_decision_parity_contract_suite_v0.py
+++ b/tests/research/test_cross_sectional_lead_lag_v0_research_eval_decision_parity_contract_suite_v0.py
@@ -282,7 +282,7 @@ def test_unrelated_mv2_wiring_path_unchanged() -> None:
         strategy_id="ma_crossover",
         cfg=cfg,
     )
-    assert result.backtest_engine_signal_source == ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY
+    assert result.backtest_engine_signal_source == ENGINE_SIGNAL_SOURCE_MV2_REPLAY
 
 
 def test_contract_module_has_no_forbidden_runtime_imports() -> None:


### PR DESCRIPTION
## Summary
- Closes the proven P0 output-consumption gap: canonical MV2 integrated replay now drives BacktestEngine trades by default via `mv2_decision_replay_series`.
- Adds a central resolver (`resolve_mv2_research_engine_signal_source_v1`) plus funnel-trade alignment and parallel-truth prevention contracts; Step29m/30a/31f ops configs now bind the canonical source.
- Classifies `scripts/run_backtest.py` explicitly as `RAW_SIGNAL_RESEARCH` (legacy configured-strategy path), not canonical system economic evidence.

## Source evidence
- Bundle: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/full_chain_offline_replay_proof_v0_20260714T164500Z`
- Manifest verification: `SOURCE_MANIFEST_VERIFY_RC=0`
- Verdict: `FAIL_CANONICAL_REPLAY_EXECUTED_BUT_OUTPUT_NOT_CONSUMED_V0`

## Root cause
`run_mv2_research_backtest_wiring_v1` executed full integrated replay per bar and mapped decision evidence, but default `backtest_engine_signal_source` remained `configured_strategy_signal`, so trades followed a parallel strategy-signal path.

## Architecture after rewire
- Canonical system path: integrated replay → `map_decision_evidence_to_position_signal_v1` → BacktestEngine → funnel/trades
- `configured_strategy_signal` remains for strategy diagnostics/assessment and explicit legacy raw-signal research only
- No strategy/core/risk/sizing/safety semantic changes; no economic reevaluation in this slice

## Test plan
- [x] `tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py`
- [x] MV2 wiring + integrated replay focused tests
- [x] Lead-lag MV2 replay parity tests
- [x] Step29m MACD config contract (engine_signal_source binding)
- [x] Ruff format/check on touched Python surfaces

## Evidence (this slice)
- `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/engine_signal_source_binding_and_funnel_trade_alignment_v0_20260714T170707Z`
- `MANIFEST_VERIFY_RC=0`

## Operator note
Separate Operator-GO required for any later canonical full-system economic reevaluation.

Made with [Cursor](https://cursor.com)