### PR TITLE
fix(backtest): gate MV2 economic wiring until warmup complete

### DIFF
--- a/src/backtest/mv2_research_wiring_v1.py
+++ b/src/backtest/mv2_research_wiring_v1.py
@@ -99,6 +99,8 @@ from src.trading.master_v2.canonical_scope_initialization_v1 import (
 from src.trading.master_v2.canonical_trading_decision_evidence_v1 import (
     CANONICAL_TRADING_DECISION_EVIDENCE_LAYER_VERSION,
     CanonicalTradingDecisionEvidenceV1,
+    derive_decision_id,
+    with_computed_evidence_semantic_digest,
 )
 from src.trading.master_v2.deterministic_scope_event_generator_v1 import (
     DETERMINISTIC_SCOPE_EVENT_GENERATOR_LAYER_VERSION,
@@ -226,6 +228,9 @@ from src.backtest.backtest_engine_position_feedback_adapter_v1 import (
 
 MV2_RESEARCH_WIRING_LAYER_VERSION = "v1"
 MV2_RESEARCH_WIRING_OWNER = "backtest.mv2_research_wiring_v1"
+ECONOMIC_RESEARCH_WARMUP_REQUIRED_SKIP_REASON = "warmup_required"
+ECONOMIC_RESEARCH_WARMUP_INVALID_BLOCK_REASON = "warmup_invalid_blocked"
+ECONOMIC_RESEARCH_NO_WARMUP_COMPLETE_BAR_REASON = "no_warmup_complete_bar"
 MV2_REQUIRED_INSTRUMENT_ID = "inst-eth-usdt-perp"
 
 _REPLAY_IMPLEMENTATION_DIGEST = hashlib.sha256(
@@ -609,6 +614,150 @@ def _resolve_volatility_estimate_for_economic_research_wiring_v1(
     return value
 
 
+def _validate_economic_research_bar_structural_contract_v1(bar: pd.Series) -> None:
+    """Structural finalized-bar contract for economic_research_v1 observation-only bars."""
+    is_final = bool(bar.get("is_final", True))
+    _fail_closed(not is_final, "bar_unfinalized")
+    ts = pd.Timestamp(bar.name)
+    decision_ts = pd.Timestamp(bar.get("decision_time", ts + timedelta(seconds=1)))
+    _fail_closed(decision_ts < ts, "decision_time_before_market_event")
+    _price(bar, "mark_price")
+
+
+def _bind_economic_research_l1_fields_v1(
+    *,
+    bar: pd.Series,
+    mark_price: float,
+    research_execution_cost: Optional[EconomicResearchExecutionCostBindingV0],
+) -> tuple[float, float, float, L1ObservationStatusV1, bool]:
+    if _has_observed_l1(bar):
+        best_bid = float(bar["best_bid"])
+        best_ask = float(bar["best_ask"])
+        spread = float(bar.get("spread", best_ask - best_bid))
+        return (
+            best_bid,
+            best_ask,
+            spread,
+            L1ObservationStatusV1.OBSERVED_HISTORICAL_L1,
+            True,
+        )
+    if research_execution_cost is None:
+        raise ValueError("research_execution_cost_binding_missing")
+    best_bid, best_ask, spread = _model_bound_l1_from_mark_price(
+        mark_price,
+        half_spread_bps=research_execution_cost.conservative_half_spread_bps,
+    )
+    return (
+        best_bid,
+        best_ask,
+        spread,
+        L1ObservationStatusV1.EXECUTION_MODEL_BOUND_NOT_OBSERVED,
+        False,
+    )
+
+
+def _bind_economic_research_warmup_observation_bar_v1(
+    *,
+    bar: pd.Series,
+    instrument_id: str,
+    trading_epoch: int,
+    research_execution_cost: Optional[EconomicResearchExecutionCostBindingV0],
+) -> tuple[CanonicalMarketContextV1, L1ObservationStatusV1, bool]:
+    """Observation-only economic_research_v1 binding for WARMUP_REQUIRED bars."""
+    _ensure_supported_instrument(instrument_id)
+    _validate_economic_research_bar_structural_contract_v1(bar)
+    ts = pd.Timestamp(bar.name)
+    market_event_time = ts.isoformat()
+    decision_ts = pd.Timestamp(bar.get("decision_time", ts + timedelta(seconds=1)))
+    mark_price = _price(bar, "mark_price")
+    best_bid, best_ask, spread, l1_status, observed_l1_used = _bind_economic_research_l1_fields_v1(
+        bar=bar,
+        mark_price=mark_price,
+        research_execution_cost=research_execution_cost,
+    )
+    context = CanonicalMarketContextV1(
+        context_id=f"mv2-ctx-{instrument_id}-{trading_epoch}",
+        instrument_id=instrument_id,
+        market_type=FuturesMarketType.PERPETUAL,
+        trading_epoch=trading_epoch,
+        market_event_time=market_event_time,
+        decision_time=decision_ts.isoformat(),
+        bar_interval=str(bar.get("bar_interval", "1m")),
+        bar_finality_status=BarFinalityStatus.FINALIZED,
+        mark_price=mark_price,
+        index_price=_price(bar, "index_price"),
+        best_bid=best_bid,
+        best_ask=best_ask,
+        spread=spread,
+        volume=float(bar.get("volume", 0.0)),
+        open_interest=float(bar.get("open_interest", 0.0)),
+        funding_rate=float(bar.get("funding_rate", 0.0)),
+        volatility_estimate=float("nan"),
+        trend_feature_set={"trend_slope": float(bar.get("trend_slope", 0.01))},
+        momentum_feature_set={"momentum": float(bar.get("momentum", 0.01))},
+        liquidity_feature_set={"liq_score": float(bar.get("liq_score", 0.9))},
+        market_structure_feature_set={"range_ratio": float(bar.get("range_ratio", 0.4))},
+        data_integrity_status=DataIntegrityStatus.TRUSTED,
+        clock_trust_status=ClockTrustStatus.TRUSTED,
+        warmup_status=WarmupStatus.WARMUP_REQUIRED,
+        feature_contract_version=FEATURE_CONTRACT_VERSION,
+    )
+    return with_computed_input_digest(context), l1_status, observed_l1_used
+
+
+def _build_economic_research_warmup_required_skip_evidence_v1(
+    *,
+    replay_id: str,
+    instrument_id: str,
+    trading_epoch: int,
+    config_digest: str,
+    implementation_digest: str,
+    input_digest: str,
+    direction_state: EntryExitDirectionState,
+) -> CanonicalTradingDecisionEvidenceV1:
+    decision_id = derive_decision_id(
+        replay_id=replay_id,
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        input_digest=input_digest,
+    )
+    evidence = CanonicalTradingDecisionEvidenceV1(
+        decision_id=decision_id,
+        replay_id=replay_id,
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        market_context_ref="",
+        scope_initialization_ref="",
+        scope_event_ref="",
+        bull_assessment_ref="",
+        bear_assessment_ref="",
+        state_switch_ref="",
+        bull_survival_ref="",
+        bear_survival_ref="",
+        bull_suitability_ref="",
+        bear_suitability_ref="",
+        composition_result_ref="",
+        entry_exit_policy_ref="",
+        current_scope_ref="",
+        next_scope_ref="",
+        previous_direction_state=direction_state.value,
+        next_direction_state=direction_state.value,
+        selected_side=CompositionSelectedSide.NONE.value,
+        selected_strategy_ref="",
+        decision_outcome="observe",
+        entry_or_exit_policy_ref="",
+        reason_codes=(ECONOMIC_RESEARCH_WARMUP_REQUIRED_SKIP_REASON,),
+        decision_precedence_trace=(),
+        component_versions=_default_component_versions(),
+        policy_versions=_default_policy_versions(),
+        config_digest=config_digest,
+        implementation_digest=implementation_digest,
+        input_digest=input_digest,
+        semantic_digest="",
+    )
+    return with_computed_evidence_semantic_digest(evidence)
+
+
 def _period_digest(bars: pd.DataFrame) -> str:
     if bars.empty:
         return _stable_digest({"empty": True})
@@ -681,22 +830,13 @@ def bind_bar_for_mv2_wiring_v1(
     _fail_closed(decision_ts < ts, "decision_time_before_market_event")
 
     mark_price = _price(bar, "mark_price")
-    observed_l1_used = False
-    outcome_l1_status = L1ObservationStatusV1.EXECUTION_MODEL_BOUND_NOT_OBSERVED
-
-    if _has_observed_l1(bar):
-        best_bid = float(bar["best_bid"])
-        best_ask = float(bar["best_ask"])
-        spread = float(bar.get("spread", best_ask - best_bid))
-        observed_l1_used = True
-        outcome_l1_status = L1ObservationStatusV1.OBSERVED_HISTORICAL_L1
-    else:
-        if research_execution_cost is None:
-            raise ValueError("research_execution_cost_binding_missing")
-        best_bid, best_ask, spread = _model_bound_l1_from_mark_price(
-            mark_price,
-            half_spread_bps=research_execution_cost.conservative_half_spread_bps,
+    best_bid, best_ask, spread, outcome_l1_status, observed_l1_used = (
+        _bind_economic_research_l1_fields_v1(
+            bar=bar,
+            mark_price=mark_price,
+            research_execution_cost=research_execution_cost,
         )
+    )
 
     warmup_status = _resolve_warmup_status(bar)
     volatility_estimate = _resolve_volatility_estimate_for_economic_research_wiring_v1(
@@ -1829,6 +1969,17 @@ def run_mv2_research_backtest_wiring_v1(
     signal_index: list[pd.Timestamp] = []
     sequence_state: MV2IntegratedReplayBarSequenceStateV1 | None = None
     decision_funnel_accumulator = DecisionFunnelAccumulatorV0()
+    economic_research_profile = (
+        effective_profile.dataset_profile is DatasetProfileV1.ECONOMIC_RESEARCH_V1
+    )
+    if economic_research_profile:
+        _fail_closed(
+            not any(
+                _resolve_warmup_status(row) is WarmupStatus.WARMUP_COMPLETE
+                for _, row in bars.iterrows()
+            ),
+            ECONOMIC_RESEARCH_NO_WARMUP_COMPLETE_BAR_REASON,
+        )
     for i, (_, row) in enumerate(bars.iterrows()):
         if sequence_state is None:
             sequence_state = build_initial_mv2_integrated_replay_bar_sequence_state_v1(
@@ -1843,6 +1994,75 @@ def run_mv2_research_backtest_wiring_v1(
                 sequence_state,
                 feedback,
             )
+        bar_warmup_status = _resolve_warmup_status(row)
+        if economic_research_profile:
+            if bar_warmup_status is WarmupStatus.WARMUP_INVALID:
+                _fail_closed(True, ECONOMIC_RESEARCH_WARMUP_INVALID_BLOCK_REASON)
+            if bar_warmup_status is WarmupStatus.WARMUP_REQUIRED:
+                context, l1_status, observed_l1_used = (
+                    _bind_economic_research_warmup_observation_bar_v1(
+                        bar=row,
+                        instrument_id=instrument_id,
+                        trading_epoch=i,
+                        research_execution_cost=research_execution_cost,
+                    )
+                )
+                input_digest = _stable_digest(
+                    {
+                        "context_digest": context.input_digest,
+                        "epoch": i,
+                        "registry_input_digest": snapshot.input_digest,
+                        "cost_digest": effective_cost.config_digest,
+                        "profile_binding": effective_profile.to_dict(),
+                        "l1_observation_status": l1_status.value,
+                        "observed_l1_used": observed_l1_used,
+                        "warmup_skip_reason": ECONOMIC_RESEARCH_WARMUP_REQUIRED_SKIP_REASON,
+                    }
+                )
+                skip_evidence = _build_economic_research_warmup_required_skip_evidence_v1(
+                    replay_id=replay_id,
+                    instrument_id=instrument_id,
+                    trading_epoch=i,
+                    config_digest=config_digest,
+                    implementation_digest=implementation_digest,
+                    input_digest=input_digest,
+                    direction_state=sequence_state.direction_state,
+                )
+                decision_funnel_accumulator.block_reason_counts[
+                    ECONOMIC_RESEARCH_WARMUP_REQUIRED_SKIP_REASON
+                ] += 1
+                signal = 0
+                if position_feedback_bound:
+                    if backtest_engine is None:
+                        raise ValueError("backtest_engine_position_feedback_engine_missing")
+                    if bar_loop_state is None:
+                        bar_loop_state = init_legacy_realistic_bar_loop_state_v1(
+                            backtest_engine,
+                            strategy_params=strategy_params,
+                        )
+                    bar_loop_state = step_legacy_realistic_bar_v1(
+                        backtest_engine,
+                        bar_loop_state,
+                        bar=row,
+                        signal=signal,
+                        symbol=instrument_id,
+                        effective_cost=effective_cost,
+                    )
+                outcomes.append(
+                    MV2ReplayBarOutcomeV1(
+                        trading_epoch=i,
+                        context=context,
+                        evidence=skip_evidence,
+                        position_signal=signal,
+                        replay_pass=False,
+                        fail_reasons=(ECONOMIC_RESEARCH_WARMUP_REQUIRED_SKIP_REASON,),
+                        l1_observation_status=l1_status,
+                        observed_l1_used=observed_l1_used,
+                    )
+                )
+                replay_signals.append(signal)
+                signal_index.append(pd.Timestamp(row.name))
+                continue
         context, l1_status, observed_l1_used = bind_bar_for_mv2_wiring_v1(
             bar=row,
             instrument_id=instrument_id,

--- a/tests/backtest/test_mv2_research_wiring_v1.py
+++ b/tests/backtest/test_mv2_research_wiring_v1.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import replace
 from typing import Any, Mapping
 
@@ -9,6 +10,7 @@ import pytest
 from src.backtest import admissible_versioned_futures_dataset_v1 as ds
 from src.backtest import cost_config_v0 as cost
 from src.backtest import mv2_research_wiring_v1 as wiring
+from src.backtest.strategy_signal_binding_v1 import ENGINE_SIGNAL_SOURCE_MV2_REPLAY
 from src.experiments.stress_tests import StressScenarioResult
 from src.trading.master_v2.canonical_market_context_v1 import WarmupStatus
 from src.trading.master_v2.canonical_trading_decision_evidence_v1 import (
@@ -850,3 +852,120 @@ class TestVolatilityEstimateFailClosedWiringRepairV0:
     def test_no_runtime_or_authority_effect_constants_unchanged(self) -> None:
         assert wiring.MV2_RESEARCH_WIRING_OWNER == "backtest.mv2_research_wiring_v1"
         assert wiring.MV2_RESEARCH_WIRING_LAYER_VERSION == "v1"
+
+
+def _research_warmup_bars(*, warmup_count: int = 2, complete_count: int = 3) -> pd.DataFrame:
+    n = warmup_count + complete_count
+    idx = pd.date_range("2026-06-01", periods=n, freq="1h", tz="UTC")
+    close = [100.0 + float(i) for i in range(n)]
+    warmup_status = ["WARMUP_REQUIRED"] * warmup_count + ["WARMUP_COMPLETE"] * complete_count
+    volatility = [None] * warmup_count + [0.15] * complete_count
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [v + 0.5 for v in close],
+            "low": [v - 0.5 for v in close],
+            "close": close,
+            "mark_price": close,
+            "index_price": [v - 0.1 for v in close],
+            "volume": [1000.0 for _ in close],
+            "open_interest": [10000.0 for _ in close],
+            "funding_rate": [0.0001 for _ in close],
+            "volatility_estimate": volatility,
+            "warmup_status": warmup_status,
+            "is_final": [True for _ in close],
+            "bar_interval": ["1m" for _ in close],
+        },
+        index=idx,
+    )
+
+
+def _run_research_warmup(**kwargs: Any) -> wiring.MV2ResearchWiringResultV1:
+    return wiring.run_mv2_research_backtest_wiring_v1(
+        bars=kwargs.pop("bars", _research_warmup_bars()),
+        strategy_id=kwargs.pop("strategy_id", "ma_crossover"),
+        cfg=kwargs.pop("cfg", _research_cfg()),
+        profile_binding=kwargs.pop("profile_binding", _research_profile_binding()),
+        backtest_engine_signal_source=kwargs.pop(
+            "backtest_engine_signal_source",
+            ENGINE_SIGNAL_SOURCE_MV2_REPLAY,
+        ),
+        **kwargs,
+    )
+
+
+class TestEconomicResearchWarmupGatingRepairV0:
+    def test_warmup_required_bars_skip_decision_chain_without_crash(self) -> None:
+        bars = _research_warmup_bars(warmup_count=2, complete_count=3)
+        result = _run_research_warmup(bars=bars)
+        assert len(result.bar_outcomes) == len(bars)
+        assert result.bar_outcomes[0].context.warmup_status == WarmupStatus.WARMUP_REQUIRED
+        assert result.bar_outcomes[1].context.warmup_status == WarmupStatus.WARMUP_REQUIRED
+        assert result.bar_outcomes[2].context.warmup_status == WarmupStatus.WARMUP_COMPLETE
+        assert all(outcome.position_signal == 0 for outcome in result.bar_outcomes[:2])
+        assert math.isnan(result.bar_outcomes[0].context.volatility_estimate)
+        assert result.bar_outcomes[2].context.volatility_estimate == pytest.approx(0.15)
+
+    def test_warmup_required_bars_do_not_run_integrated_replay(self) -> None:
+        result = _run_research_warmup()
+        for outcome in result.bar_outcomes[:2]:
+            assert outcome.replay_pass is False
+            assert wiring.ECONOMIC_RESEARCH_WARMUP_REQUIRED_SKIP_REASON in outcome.fail_reasons
+            assert outcome.evidence.decision_outcome == "observe"
+            assert (
+                wiring.ECONOMIC_RESEARCH_WARMUP_REQUIRED_SKIP_REASON
+                in outcome.evidence.reason_codes
+            )
+            assert outcome.evidence.scope_event_ref == ""
+            assert outcome.evidence.bull_assessment_ref == ""
+            assert outcome.evidence.bear_assessment_ref == ""
+
+    def test_warmup_required_bars_produce_no_engine_signals_or_trades(self) -> None:
+        result = _run_research_warmup()
+        assert list(result.mv2_replay_signals[:2]) == [0, 0]
+        assert list(result.signals[:2]) == [0, 0]
+        trades = result.backtest_result.trades
+        trade_count = 0 if trades is None else len(trades)
+        assert trade_count == 0
+
+    def test_first_warmup_complete_bar_processed_once(self) -> None:
+        bars = _research_warmup_bars(warmup_count=2, complete_count=2)
+        result = _run_research_warmup(bars=bars)
+        complete_outcomes = [
+            outcome
+            for outcome in result.bar_outcomes
+            if outcome.context.warmup_status is WarmupStatus.WARMUP_COMPLETE
+        ]
+        assert len(complete_outcomes) == 2
+        assert complete_outcomes[0].trading_epoch == 2
+        assert complete_outcomes[0].replay_pass is True
+        assert complete_outcomes[0].evidence.trading_epoch == 2
+
+    def test_epochs_and_provenance_remain_contiguous(self) -> None:
+        result = _run_research_warmup()
+        for i, outcome in enumerate(result.bar_outcomes):
+            assert outcome.trading_epoch == i
+            assert outcome.evidence.trading_epoch == i
+            assert outcome.evidence.decision_id
+
+    def test_warmup_invalid_fail_closed(self) -> None:
+        bars = _research_warmup_bars(warmup_count=1, complete_count=2)
+        bars.loc[bars.index[0], "warmup_status"] = "WARMUP_INVALID"
+        with pytest.raises(ValueError, match="warmup_invalid_blocked"):
+            _run_research_warmup(bars=bars)
+
+    def test_no_warmup_complete_bar_fail_closed(self) -> None:
+        bars = _research_warmup_bars(warmup_count=3, complete_count=0)
+        bars["warmup_status"] = "WARMUP_REQUIRED"
+        bars["volatility_estimate"] = None
+        with pytest.raises(ValueError, match="no_warmup_complete_bar"):
+            _run_research_warmup(bars=bars)
+
+    def test_bind_bar_still_rejects_warmup_required_volatility_resolution(self) -> None:
+        bar = _research_bind_bar(volatility_estimate=0.15, warmup_status="WARMUP_REQUIRED")
+        with pytest.raises(ValueError, match="warmup_status_not_complete"):
+            _bind_research_bar(bar)
+
+    def test_block_reason_counts_include_warmup_required_skips(self) -> None:
+        result = _run_research_warmup(bars=_research_warmup_bars(warmup_count=2, complete_count=1))
+        assert result.block_reason_counts[wiring.ECONOMIC_RESEARCH_WARMUP_REQUIRED_SKIP_REASON] == 2


### PR DESCRIPTION
## Summary

- Behebt den bestätigten Warmup-Gating-/Binding-Defekt in `src/backtest/mv2_research_wiring_v1.py`: `economic_research_v1`-Bars mit `warmup_status=WARMUP_REQUIRED` werden vor Volatility-Bindung und Integrated Replay deterministisch als Observation-only übersprungen.
- Erste fachlich verarbeitete Bar ist die erste `WARMUP_COMPLETE`-Bar; `WARMUP_INVALID` und Datensätze ohne `WARMUP_COMPLETE` bleiben fail-closed.
- Technischer Repair-Slice only — **kein Economic FAIL**, sondern Implementation/Binding-Defect.

## Root cause

`run_mv2_research_backtest_wiring_v1` iterierte ab Bar 0 und rief `bind_bar_for_mv2_wiring_v1` → `_resolve_volatility_estimate_for_economic_research_wiring_v1` auf, obwohl Bars 0–59 `warmup_status=WARMUP_REQUIRED` und `volatility_estimate=null` hatten. Ergebnis: `ValueError: warmup_status_not_complete`.

## Warmup-Semantik

**Vorher:** economic_research_v1-Warmup-Bars erreichten Volatility-Resolver und brachen fail-closed ab.

**Nachher:** Warmup-Bars validieren nur den strukturellen Bar-Contract, erzeugen Observation-only-Evidence (`decision_outcome=observe`, reason `warmup_required`), Signal=0, kein Integrated Replay, keine Trades. Erst `WARMUP_COMPLETE` tritt in die kanonische Decision Chain ein.

## Changed files

- `src/backtest/mv2_research_wiring_v1.py`
- `tests/backtest/test_mv2_research_wiring_v1.py`

## Tests

- `TestEconomicResearchWarmupGatingRepairV0` (9 neue Regressionstests)
- `tests/backtest/test_mv2_research_wiring_v1.py`
- `tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py`

## Evidence

- Source: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/canonical_full_system_economic_reevaluation_v0_20260714T172605Z`
- Repair bundle: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/canonical_full_system_economic_reevaluation_warmup_gating_defect_repair_scope_v0_20260714T173510Z`
- `SOURCE_MANIFEST_VERIFY_RC=0`
- `MANIFEST_VERIFY_RC=0`
- `ECONOMIC_EVALUATION_EXECUTED=false`
- `RUNTIME_EFFECT=NONE`
- `AUTHORITY_EFFECT=NONE`
- `REPAIR_GO_DOES_NOT_AUTHORIZE_REEVALUATION=true`

## Test plan

- [x] Fokussierte Warmup-Gating-Regressionstests
- [x] MV2 wiring + engine-signal-source Contract-Tests
- [x] Dataset-Smoke-Proof (60 Warmup-Bars, erste COMPLETE bei Index 60, kein `warmup_status_not_complete`)
- [ ] CI PR-bounded checks (Snapshot nach Merge-Freigabe)


Made with [Cursor](https://cursor.com)