### PR TITLE
fix: align economic evidence runner with fail-closed persist directory lifecycle

### DIFF
--- a/scripts/ops/run_economic_viability_evidence_evaluation_v1.py
+++ b/scripts/ops/run_economic_viability_evidence_evaluation_v1.py
@@ -571,12 +571,27 @@ def _resolve_policy(cfg: Mapping[str, Any]) -> policy_mod.EconomicValidityPolicy
     return policy
 
 
-def _validate_output_dir(path: Path, *, allow_existing: bool) -> None:
+def _validate_output_dir(path: Path, *, allow_existing_parent: bool) -> None:
+    """Fail-closed output directory contract aligned with persist owner.
+
+    The final bundle directory (``path``) must not exist so
+    ``persist_economic_viability_evidence_bundle_v1`` can create it atomically.
+    ``allow_existing_parent`` (CLI: ``--allow-existing-output``) only documents
+    that an existing parent workspace directory is acceptable; it does not permit
+    a pre-created final persist target and does not authorize overwrite.
+    """
     if path.exists():
-        if not allow_existing:
-            raise RunnerError(f"output_dir_exists:{path}")
-        if any(path.iterdir()):
-            raise RunnerError(f"output_dir_nonempty:{path}")
+        raise RunnerError(f"output_dir_exists:{path}")
+    if not allow_existing_parent:
+        return
+    parent = path.parent
+    if parent.exists() and not parent.is_dir():
+        raise RunnerError(f"output_parent_not_directory:{parent}")
+
+
+def _resolve_persist_output_dir(path: Path, *, allow_existing_parent: bool) -> Path:
+    _validate_output_dir(path, allow_existing_parent=allow_existing_parent)
+    return path
 
 
 def _map_validity_result(status: EconomicValidityEvaluationStatus) -> str:
@@ -713,7 +728,10 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--allow-existing-output",
         action="store_true",
-        help="Allow writing to an existing empty output directory.",
+        help=(
+            "Allow an existing parent workspace directory for --output-dir. "
+            "The final output directory itself must not already exist."
+        ),
     )
     parser.add_argument(
         "--json", action="store_true", help="Emit machine-readable plan/result JSON."
@@ -773,7 +791,10 @@ def build_validation_plan(args: argparse.Namespace) -> ValidationPlanV1:
         config_digest=config_digest,
         policy_digest=policy.policy_digest(),
     )
-    _validate_output_dir(output_dir, allow_existing=bool(args.allow_existing_output))
+    _resolve_persist_output_dir(
+        output_dir,
+        allow_existing_parent=bool(args.allow_existing_output),
+    )
 
     return ValidationPlanV1(
         run_id=run_id,
@@ -823,7 +844,10 @@ def execute_evaluation(args: argparse.Namespace) -> RunOutcomeV1:
     dataset_path = Path(plan.dataset_path)
     manifest_path = Path(plan.dataset_manifest_path)
     config_path = Path(plan.config_path)
-    output_dir = Path(plan.output_dir)
+    output_dir = _resolve_persist_output_dir(
+        Path(plan.output_dir),
+        allow_existing_parent=bool(args.allow_existing_output),
+    )
     policy_path = Path(plan.policy_path) if plan.policy_path else None
 
     manifest = _load_dataset_manifest(manifest_path)

--- a/tests/backtest/test_economic_viability_evidence_v1.py
+++ b/tests/backtest/test_economic_viability_evidence_v1.py
@@ -254,6 +254,20 @@ def test_persist_bundle_manifest_verify(tmp_path) -> None:
     assert loaded["status"] == "RESEARCH_ONLY"
 
 
+def test_persist_existing_output_dir_fail_closed(tmp_path) -> None:
+    result = _build()
+    out = tmp_path / "evidence"
+    out.mkdir()
+    with pytest.raises(ev.EconomicViabilityEvidenceError, match="output directory already exists"):
+        ev.persist_economic_viability_evidence_bundle_v1(
+            out,
+            result,
+            config_snapshot={"cfg": dict(_cfg())},
+            metrics={"total_return": result.gross_return.value},
+            input_provenance={"source": "synthetic_fixture"},
+        )
+
+
 def test_inadmissible_data_source_reason_code() -> None:
     bars = _bars()
     adm = ev.DataAdmissibilityV1(

--- a/tests/ops/test_economic_evidence_persist_output_directory_lifecycle_v0.py
+++ b/tests/ops/test_economic_evidence_persist_output_directory_lifecycle_v0.py
@@ -1,0 +1,133 @@
+"""Focused regression tests for economic evidence output directory lifecycle v0."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.backtest import economic_viability_evidence_v1 as ev
+from tests.ops.test_run_economic_viability_evidence_evaluation_v1 import (
+    RUNNER_SCRIPT,
+    _argv,
+    _load_runner,
+    _stage_run_inputs,
+)
+
+
+@pytest.fixture
+def runner():
+    return _load_runner()
+
+
+def test_persist_fresh_parent_final_target_absent(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    rc = runner.main(_argv(paths))
+    assert rc == 0
+    assert paths["output_dir"].is_dir()
+    assert (paths["output_dir"] / ev.ARTIFACT_FILENAME).is_file()
+    ok, _msg = verify_manifest_sha256(paths["output_dir"])
+    assert ok is True
+
+
+def test_persist_existing_parent_final_target_absent(runner, tmp_path: Path) -> None:
+    workspace = tmp_path / "evidence_workspace"
+    workspace.mkdir()
+    (workspace / "preflight.txt").write_text("parent workspace marker\n", encoding="utf-8")
+    paths = _stage_run_inputs(tmp_path)
+    paths["output_dir"] = workspace / "runner_output"
+    rc = runner.main(_argv(paths, allow_existing_output=True))
+    assert rc == 0
+    assert paths["output_dir"].is_dir()
+    assert (paths["output_dir"] / ev.ARTIFACT_FILENAME).is_file()
+
+
+def test_precreated_empty_final_target_fail_closed(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    paths["output_dir"].mkdir()
+    rc = runner.main(_argv(paths, allow_existing_output=True))
+    assert rc != 0
+    assert not (paths["output_dir"] / ev.ARTIFACT_FILENAME).exists()
+
+
+def test_precreated_nonempty_final_target_fail_closed(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    paths["output_dir"].mkdir()
+    (paths["output_dir"] / "stale.txt").write_text("stale", encoding="utf-8")
+    rc = runner.main(_argv(paths, allow_existing_output=True))
+    assert rc != 0
+    assert (paths["output_dir"] / "stale.txt").read_text(encoding="utf-8") == "stale"
+
+
+def test_allow_existing_output_does_not_authorize_final_target_reuse(
+    runner, tmp_path: Path
+) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    paths["output_dir"].mkdir()
+    existing = paths["output_dir"] / ev.ARTIFACT_FILENAME
+    existing.write_text('{"status":"STALE"}\n', encoding="utf-8")
+    rc = runner.main(_argv(paths, allow_existing_output=True))
+    assert rc != 0
+    assert json.loads(existing.read_text(encoding="utf-8"))["status"] == "STALE"
+
+
+def test_runner_persist_integration_real_path_no_mock(runner, tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    paths = _stage_run_inputs(tmp_path)
+    paths["output_dir"] = workspace / "economic_bundle"
+    rc = runner.main(_argv(paths, allow_existing_output=True))
+    assert rc == 0
+    assert (paths["output_dir"] / "run_summary.env").is_file()
+    assert (paths["output_dir"] / "MANIFEST.sha256").is_file()
+
+
+def test_partial_persist_failure_does_not_report_complete(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+
+    def _fail_persist(output_dir, **kwargs):
+        raise ev.EconomicViabilityEvidenceError("persist_failed:simulated")
+
+    with patch.object(
+        ev,
+        "build_and_persist_economic_viability_evidence_bundle_v1",
+        _fail_persist,
+    ):
+        rc = runner.main(_argv(paths))
+    assert rc != 0
+    assert not paths["output_dir"].exists()
+
+
+def test_deterministic_fixture_two_fresh_targets(runner, tmp_path: Path) -> None:
+    paths_a = _stage_run_inputs(tmp_path / "a")
+    paths_b = _stage_run_inputs(tmp_path / "b")
+    assert runner.main(_argv(paths_a)) == 0
+    assert runner.main(_argv(paths_b)) == 0
+    for name in (
+        "economic_viability_evidence_v1.json",
+        "dataset_admissibility_result_v1.json",
+        "economic_validity_evaluation_v1.json",
+    ):
+        a = json.loads((paths_a["output_dir"] / name).read_text(encoding="utf-8"))
+        b = json.loads((paths_b["output_dir"] / name).read_text(encoding="utf-8"))
+        assert a == b
+
+
+def test_validate_output_dir_contract_helper(runner, tmp_path: Path) -> None:
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    final_target = parent / "bundle"
+    runner._resolve_persist_output_dir(final_target, allow_existing_parent=True)
+    with pytest.raises(runner.RunnerError, match="output_dir_exists"):
+        final_target.mkdir()
+        runner._resolve_persist_output_dir(final_target, allow_existing_parent=True)
+
+
+def test_runner_source_documents_persist_alignment() -> None:
+    source = RUNNER_SCRIPT.read_text(encoding="utf-8")
+    assert "persist_economic_viability_evidence_bundle_v1" in source
+    assert "allow_existing_parent" in source
+    assert "must not already exist" in source

--- a/tests/ops/test_run_economic_viability_evidence_evaluation_v1.py
+++ b/tests/ops/test_run_economic_viability_evidence_evaluation_v1.py
@@ -476,6 +476,14 @@ def test_existing_output_fail_closed(runner, tmp_path: Path) -> None:
     assert rc != 0
 
 
+def test_empty_existing_output_fail_closed_even_with_allow_existing(runner, tmp_path: Path) -> None:
+    paths = _stage_run_inputs(tmp_path)
+    paths["output_dir"].mkdir()
+    rc = runner.main(_argv(paths, allow_existing_output=True))
+    assert rc != 0
+    assert not (paths["output_dir"] / "run_summary.env").exists()
+
+
 def test_runner_uses_existing_library_owners(runner, tmp_path: Path) -> None:
     paths = _stage_run_inputs(tmp_path)
     parser = runner.build_arg_parser()


### PR DESCRIPTION
## Summary

- **Root cause**: `OUTPUT_DIRECTORY_OWNERSHIP_CONTRACT_MISMATCH` — runner `_validate_output_dir` allowed an existing empty `--output-dir` with `--allow-existing-output`, but `persist_economic_viability_evidence_bundle_v1` requires the final target to be absent.
- **Canonical owner repaired**: `scripts/ops/run_economic_viability_evidence_evaluation_v1.py` (`_validate_output_dir` / `_resolve_persist_output_dir`).
- **Persist owner unchanged**: `src/backtest/economic_viability_evidence_v1.py::persist_economic_viability_evidence_bundle_v1` fail-closed contract preserved.

## Directory lifecycle

**Before**
- Runner accepted existing empty final `--output-dir` when `--allow-existing-output` was set.
- Persist owner rejected the same path (`output directory already exists (fail-closed)`).
- Blocked baseline run: parent evidence dir existed, `runner_output` was pre-created empty, compute completed, persist blocked.

**After**
- Final `--output-dir` must never exist at validation/persist time.
- `--allow-existing-output` documents that an existing parent workspace is acceptable; it does not authorize reusing or overwriting a final bundle directory.
- Parent directories may exist; only the atomic persist target is created by the persist owner.

## Safety

- Existing evidence bundles cannot be overwritten (final-target collision remains fail-closed).
- No directory auto-delete or silent cleanup.
- No trading, risk, sizing, cost, or economic-policy semantic changes.

## Tests

- `tests/ops/test_economic_evidence_persist_output_directory_lifecycle_v0.py` (new focused lifecycle matrix)
- `tests/ops/test_run_economic_viability_evidence_evaluation_v1.py`
- `tests/backtest/test_economic_viability_evidence_v1.py`
- Regression: `tests/backtest/test_mv2_research_wiring_v1.py`, `tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py`

## Evidence

- Source blocked evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/canonical_full_system_economic_reevaluation_v0_20260714T174553Z`
- Implementation evidence: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/narrow_evidence_persist_output_directory_lifecycle_defect_repair_v0_20260714T175730Z`
- `MANIFEST_VERIFY_RC=0`
- `ECONOMIC_EVALUATION_EXECUTED=false`
- `CORE_TRADING_SEMANTICS_CHANGED=false`
- `RISK_SIZING_SEMANTICS_CHANGED=false`
- `RUNTIME_EFFECT=NONE`
- `AUTHORITY_EFFECT=NONE`

Canonical full-system economic reevaluation remains separately gated after merge closeout.

## Test plan

- [x] Fresh parent, absent final target persists successfully
- [x] Existing parent, absent final target persists successfully (blocked-run shape)
- [x] Existing final target fail-closed without overwrite
- [x] `--allow-existing-output` does not authorize final-target reuse
- [x] Real runner/persist integration path (no lifecycle-masking mock)
- [x] Partial persist failure does not report completion
- [x] Deterministic fixture repeatability across fresh targets
- [x] MV2 wiring regression tests remain green

Made with [Cursor](https://cursor.com)