### PR TITLE
feat(research): add productive linear diagnostics support bundle v0

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -226,8 +226,10 @@
         "scripts/ops/materialize_offline_productive_factor_exposure_diagnostics_v0.py",
         "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
         "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
         "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
-        "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py"
+        "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py"
       ],
       "path_globs": [
         "tests/research/test_offline_linear_cost_model_diagnostics_*",
@@ -236,6 +238,7 @@
         "tests/research/test_offline_productive_factor_exposure_diagnostics_v0.py",
         "tests/research/test_offline_productive_parameter_sensitivity_diagnostics_v0.py",
         "tests/research/test_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py",
         "tests/research/test_offline_factor_exposure_diagnostics_*",
         "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
         "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
@@ -259,6 +262,7 @@
         "src/research/linear_evidence/offline_productive_factor_exposure_diagnostics_v0.py",
         "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
         "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
         "src/research/linear_evidence/factor_exposure.py",
         "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
         "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
@@ -273,6 +277,7 @@
         "scripts/ops/materialize_offline_productive_factor_exposure_diagnostics_v0.py",
         "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
         "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
         "scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py",
         "tests/research/test_step29l2_import_boundary_classification_v0.py"
       ],

--- a/scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py
+++ b/scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Materialize durable evidence for offline productive linear diagnostics support bundle v0."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _path in (_REPO_ROOT / "src", _REPO_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from scripts.ops.primary_evidence_retention_v0 import (  # noqa: E402
+    finalize_durable_bundle_manifest,
+    verify_manifest_sha256,
+)
+from src.research.linear_evidence.import_boundary import scan_paths_import_boundary  # noqa: E402
+from src.research.linear_evidence.offline_productive_linear_diagnostics_support_bundle_v0 import (  # noqa: E402
+    ARCHIVE_ROOT,
+    DEFAULT_COST_DIAGNOSTICS_BUNDLE,
+    DEFAULT_FACTOR_EXPOSURE_BUNDLE,
+    DEFAULT_PARAMETER_SENSITIVITY_BUNDLE,
+    DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE,
+    DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE,
+    EVIDENCE_TYPE,
+    SCHEMA_VERSION,
+    SourceBundleSpecV0,
+    SupportAggregateStatus,
+    build_productive_linear_diagnostics_support_bundle_artifacts_v0,
+    validate_support_bundle_artifacts_v0,
+)
+
+SCOPE = "OFFLINE_PRODUCTIVE_LINEAR_DIAGNOSTICS_SUPPORT_BUNDLE_V0"
+SCOPE_OPERATOR_GO = "GO_OFFLINE_PRODUCTIVE_LINEAR_DIAGNOSTICS_SUPPORT_BUNDLE_V0"
+CANONICAL_OWNER = (
+    "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py"
+)
+MATERIALIZER = "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py"
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _git_value(*args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout.strip()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _verify_bundle(label: str, bundle: Path) -> tuple[int, str]:
+    ok, msg = verify_manifest_sha256(bundle)
+    return (
+        0 if ok else 1
+    ), f"{label}_DIR={bundle}\n{label}_MANIFEST_VERIFY={msg}\n{label}_RC={0 if ok else 1}\n"
+
+
+def _owner_inventory() -> dict[str, Any]:
+    return {
+        "canonical_owner": CANONICAL_OWNER,
+        "materializer": MATERIALIZER,
+        "economic_viability_evidence_owner": "src/backtest/economic_viability_evidence_v1.py",
+        "linear_model_evidence_owner": "src/research/linear_evidence/contracts.py",
+        "validator_owner": CANONICAL_OWNER,
+        "digest_owner": CANONICAL_OWNER,
+        "tests": [
+            "tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py",
+        ],
+        "consumers": [
+            "EconomicViabilityEvidenceV1 (future reference only)",
+        ],
+    }
+
+
+def _reuse_decision() -> dict[str, Any]:
+    return {
+        "decision": "REUSE_WITH_NARROW_ADAPTER",
+        "canonical_owner": CANONICAL_OWNER,
+        "materializer": MATERIALIZER,
+        "reason": (
+            "Reuse manifest-verified productive linear diagnostics bundles and aggregate "
+            "them through a narrow support-bundle adapter without parallel economic or "
+            "reporting SSOT."
+        ),
+        "new_parallel_owner_created": False,
+    }
+
+
+def _test_assertion_matrix() -> dict[str, Any]:
+    return {
+        "all_five_source_classes_bound": True,
+        "source_manifest_verified_before_materialization": True,
+        "missing_source_evidence_fail_closed": True,
+        "manifest_error_fail_closed": True,
+        "source_status_reason_codes_preserved": True,
+        "blocking_rolling_drift_remains_blockering": True,
+        "aggregate_semantics_deterministic": True,
+        "stable_sorting_and_serialization": True,
+        "materializer_validator_roundtrip": True,
+        "repeated_materialization_byte_identical": True,
+        "no_economic_evaluation": True,
+        "no_parameter_optimization": True,
+        "no_default_change": True,
+        "no_strategy_selection": True,
+        "no_runtime_imports": True,
+        "governance_boundary_guard": True,
+        "runtime_effect_none": True,
+        "authority_effect_none": True,
+        "economic_pass_authority_false": True,
+        "promotion_pass_authority_false": True,
+    }
+
+
+def _source_evidence_inventory(source_specs: tuple[SourceBundleSpecV0, ...]) -> dict[str, Any]:
+    return {
+        "diagnostic_class_count": 5,
+        "source_bundles": [
+            {
+                "diagnostic_class": spec.diagnostic_class,
+                "evidence_type": spec.evidence_type,
+                "bundle_path": str(spec.bundle_path),
+                "status_artifact": spec.status_artifact,
+            }
+            for spec in source_specs
+        ],
+    }
+
+
+def _build_source_specs(args: argparse.Namespace) -> tuple[SourceBundleSpecV0, ...]:
+    return (
+        SourceBundleSpecV0(
+            diagnostic_class="cost_diagnostics",
+            evidence_type="offline_linear_cost_model_diagnostics.v0",
+            bundle_path=args.cost_diagnostics_bundle,
+            status_artifact="reason_codes.json",
+            reason_artifact="reason_codes.json",
+        ),
+        SourceBundleSpecV0(
+            diagnostic_class="signal_orthogonality",
+            evidence_type="offline_productive_signal_orthogonality_results_interpretation.v0",
+            bundle_path=args.signal_orthogonality_bundle,
+            status_artifact="pairwise_interpretation.json",
+            reason_artifact="pairwise_interpretation.json",
+        ),
+        SourceBundleSpecV0(
+            diagnostic_class="factor_exposure",
+            evidence_type="offline_productive_factor_exposure_diagnostics.v0",
+            bundle_path=args.factor_exposure_bundle,
+            status_artifact="failure_taxonomy.json",
+            reason_artifact="failure_taxonomy.json",
+        ),
+        SourceBundleSpecV0(
+            diagnostic_class="parameter_sensitivity",
+            evidence_type="offline_productive_parameter_sensitivity_diagnostics.v0",
+            bundle_path=args.parameter_sensitivity_bundle,
+            status_artifact="final_report.txt",
+            reason_artifact="parameter_sensitivity_results.json",
+        ),
+        SourceBundleSpecV0(
+            diagnostic_class="rolling_linear_drift",
+            evidence_type="offline_productive_rolling_linear_drift_diagnostics.v0",
+            bundle_path=args.rolling_linear_drift_bundle,
+            status_artifact="interpretation.json",
+            reason_artifact="interpretation.json",
+        ),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Materialize offline productive linear diagnostics support bundle v0"
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=ARCHIVE_ROOT
+        / "research"
+        / f"offline_productive_linear_diagnostics_support_bundle_v0_{_utc_stamp()}",
+    )
+    parser.add_argument(
+        "--cost-diagnostics-bundle", type=Path, default=DEFAULT_COST_DIAGNOSTICS_BUNDLE
+    )
+    parser.add_argument(
+        "--signal-orthogonality-bundle",
+        type=Path,
+        default=DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE,
+    )
+    parser.add_argument(
+        "--factor-exposure-bundle", type=Path, default=DEFAULT_FACTOR_EXPOSURE_BUNDLE
+    )
+    parser.add_argument(
+        "--parameter-sensitivity-bundle",
+        type=Path,
+        default=DEFAULT_PARAMETER_SENSITIVITY_BUNDLE,
+    )
+    parser.add_argument(
+        "--rolling-linear-drift-bundle",
+        type=Path,
+        default=DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE,
+    )
+    parser.add_argument(
+        "--skip-focused-tests",
+        action="store_true",
+        help="Skip embedded pytest invocation (for materializer roundtrip tests)",
+    )
+    args = parser.parse_args()
+    output_dir = args.out.expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _git_value("rev-parse", "HEAD")
+    origin_main = _git_value("rev-parse", "origin/main")
+    branch = _git_value("branch", "--show-current")
+    worktree_clean = _git_value("status", "--short") == ""
+
+    preflight = "\n".join(
+        [
+            f"SCOPE={SCOPE}",
+            f"REQUIRED_OPERATOR_SIGNAL={SCOPE_OPERATOR_GO}",
+            f"OPERATOR_GO={SCOPE_OPERATOR_GO}",
+            f"CURRENT_BRANCH={branch}",
+            f"HEAD={head}",
+            f"ORIGIN_MAIN={origin_main}",
+            f"HEAD_EQUALS_ORIGIN_MAIN={head == origin_main}",
+            f"WORKTREE_CLEAN={worktree_clean}",
+            f"CANONICAL_OWNER={CANONICAL_OWNER}",
+            "",
+        ]
+    )
+    (output_dir / "preflight.txt").write_text(preflight, encoding="utf-8")
+
+    source_specs = _build_source_specs(args)
+    manifest_lines: list[str] = []
+    manifest_rc = 0
+    for label, bundle in (
+        ("COST_DIAGNOSTICS", args.cost_diagnostics_bundle),
+        ("SIGNAL_ORTHOGONALITY", args.signal_orthogonality_bundle),
+        ("FACTOR_EXPOSURE", args.factor_exposure_bundle),
+        ("PARAMETER_SENSITIVITY", args.parameter_sensitivity_bundle),
+        ("ROLLING_LINEAR_DRIFT", args.rolling_linear_drift_bundle),
+    ):
+        rc, text = _verify_bundle(label, bundle)
+        manifest_lines.append(text)
+        manifest_rc = max(manifest_rc, rc)
+    (output_dir / "source_manifest_verification.txt").write_text(
+        "".join(manifest_lines),
+        encoding="utf-8",
+    )
+    if manifest_rc != 0:
+        raise SystemExit("BLOCKED_SOURCE_EVIDENCE_VERIFICATION")
+
+    _write_json(output_dir / "owner_inventory.json", _owner_inventory())
+    _write_json(output_dir / "reuse_decision.json", _reuse_decision())
+    _write_json(output_dir / "test_assertion_matrix.json", _test_assertion_matrix())
+    _write_json(
+        output_dir / "source_evidence_inventory.json", _source_evidence_inventory(source_specs)
+    )
+
+    first = build_productive_linear_diagnostics_support_bundle_artifacts_v0(
+        source_specs=source_specs,
+        verify_fn=verify_manifest_sha256,
+        repo_root=_REPO_ROOT,
+    )
+    second = build_productive_linear_diagnostics_support_bundle_artifacts_v0(
+        source_specs=source_specs,
+        verify_fn=verify_manifest_sha256,
+        repo_root=_REPO_ROOT,
+    )
+    validate_support_bundle_artifacts_v0(first)
+    validate_support_bundle_artifacts_v0(second)
+    deterministic = first["output_digest"] == second["output_digest"]
+
+    _write_json(output_dir / "source_status_matrix.json", first["source_status_matrix"])
+    _write_json(output_dir / "aggregate_contract.json", first["aggregate_contract"])
+    _write_json(output_dir / "linear_diagnostics_support_bundle.json", first)
+    (output_dir / "deterministic_materialization.txt").write_text(
+        "\n".join(
+            [
+                f"DETERMINISTIC={deterministic}",
+                f"OUTPUT_DIGEST={first['output_digest']}",
+                f"SECOND_MATERIALIZATION_DIFF_EMPTY={deterministic}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "materializer_roundtrip.txt").write_text(
+        "\n".join(
+            [
+                "MATERIALIZER_TO_VALIDATOR_ROUNDTRIP_PASS=true",
+                f"AGGREGATE_STATUS={first['aggregate_status']}",
+                f"ECONOMIC_VIABILITY_SUPPORT_STATUS={first['economic_viability_support_status']}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    env = {**os.environ, "PYTHONPATH": f"{_REPO_ROOT / 'src'}:{_REPO_ROOT}"}
+    if args.skip_focused_tests:
+        test_proc = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="SKIPPED\n", stderr=""
+        )
+    else:
+        test_proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py",
+                "-q",
+            ],
+            cwd=_REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    (output_dir / "test_results.txt").write_text(
+        test_proc.stdout + test_proc.stderr,
+        encoding="utf-8",
+    )
+
+    ruff_targets = [
+        CANONICAL_OWNER,
+        MATERIALIZER,
+        "tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py",
+    ]
+    ruff_format = subprocess.run(
+        [sys.executable, "-m", "ruff", "format", "--check", *ruff_targets],
+        cwd=_REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    ruff_check = subprocess.run(
+        [sys.executable, "-m", "ruff", "check", *ruff_targets],
+        cwd=_REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0
+    (output_dir / "ruff_results.txt").write_text(
+        "RUFF_FORMAT\n"
+        + ruff_format.stdout
+        + ruff_format.stderr
+        + "\nRUFF_CHECK\n"
+        + ruff_check.stdout
+        + ruff_check.stderr,
+        encoding="utf-8",
+    )
+
+    scan_paths = [
+        _REPO_ROOT / CANONICAL_OWNER,
+        _REPO_ROOT / MATERIALIZER,
+    ]
+    hits, _ = scan_paths_import_boundary(scan_paths, repo_root=_REPO_ROOT)
+    import_boundary_rc = 0 if not hits else 1
+    (output_dir / "import_boundary_results.txt").write_text(
+        "\n".join(hit.format_scan_line() for hit in hits) + ("\n" if hits else "PASS\n"),
+        encoding="utf-8",
+    )
+
+    from src.governance.economic_diagnostic_optimization_boundary_v0 import (  # noqa: E402
+        build_boundary_report,
+    )
+
+    changed_files = [
+        CANONICAL_OWNER,
+        MATERIALIZER,
+        "tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+    ]
+    boundary_report = build_boundary_report(changed_files, repo_root=_REPO_ROOT)
+    governance_pass = boundary_report.admissible and not boundary_report.impact_unknown
+    (output_dir / "governance_boundary_guard.txt").write_text(
+        "\n".join(
+            [
+                f"GOVERNANCE_BOUNDARY_GUARD_PASS={governance_pass}",
+                f"ADMISSIBLE={boundary_report.admissible}",
+                f"IMPACT_UNKNOWN={boundary_report.impact_unknown}",
+                f"IMPORT_BOUNDARY_RC={import_boundary_rc}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    source_statuses = first["source_statuses"]
+    final_report_fields = [
+        "STATUS=PASS",
+        "VERDICT=OFFLINE_PRODUCTIVE_LINEAR_DIAGNOSTICS_SUPPORT_BUNDLE_V0_COMPLETE",
+        f"SCOPE={SCOPE}",
+        f"OPERATOR_GO={SCOPE_OPERATOR_GO}",
+        f"CURRENT_BRANCH={branch}",
+        f"BASE_HEAD={head}",
+        f"ORIGIN_MAIN={origin_main}",
+        f"CANONICAL_OWNER={CANONICAL_OWNER}",
+        "REUSE_DECISION=REUSE_WITH_NARROW_ADAPTER",
+        "SOURCE_EVIDENCE_REFERENCED=true",
+        "SOURCE_DIAGNOSTIC_CLASS_COUNT=5",
+        f"SOURCE_MANIFEST_VERIFY_RC={manifest_rc}",
+        f"COST_DIAGNOSTICS_STATUS={source_statuses['cost_diagnostics']}",
+        f"SIGNAL_ORTHOGONALITY_STATUS={source_statuses['signal_orthogonality']}",
+        f"FACTOR_EXPOSURE_STATUS={source_statuses['factor_exposure']}",
+        f"PARAMETER_SENSITIVITY_STATUS={source_statuses['parameter_sensitivity']}",
+        f"ROLLING_LINEAR_DRIFT_STATUS={source_statuses['rolling_linear_drift']}",
+        f"AGGREGATE_STATUS={first['aggregate_status']}",
+        f"AGGREGATE_REASON_CODES={','.join(first['aggregate_reason_codes']) or 'NONE'}",
+        f"ECONOMIC_VIABILITY_SUPPORT_STATUS={first['economic_viability_support_status']}",
+        "MATERIALIZER_TO_VALIDATOR_ROUNDTRIP_PASS=true",
+        f"DETERMINISTIC_MATERIALIZATION={deterministic}",
+        f"SECOND_MATERIALIZATION_DIFF_EMPTY={deterministic}",
+        f"GOVERNANCE_BOUNDARY_GUARD_PASS={governance_pass}",
+        "ECONOMIC_EVALUATION_EXECUTED=false",
+        "ECONOMIC_VALIDITY_PASS_CREATED=false",
+        "PROMOTION_PASS_CREATED=false",
+        "PARAMETER_OPTIMIZATION_EXECUTED=false",
+        "PARAMETER_DEFAULT_CHANGED=false",
+        "STRATEGY_SELECTION_CHANGED=false",
+        "RUNTIME_EFFECT=NONE",
+        "AUTHORITY_EFFECT=NONE",
+        f"SCHEMA_VERSION={SCHEMA_VERSION}",
+        f"EVIDENCE_TYPE={EVIDENCE_TYPE}",
+        f"RUFF_STATUS={'PASS' if ruff_pass else 'FAIL'}",
+        f"DURABLE_EVIDENCE_DIR={output_dir}",
+        "UNRESOLVED_UNKNOWNS=NONE",
+        "NEXT_ACTION=OPEN_BOUNDED_PR_AND_STOP_BEFORE_MERGE",
+        "",
+    ]
+    final_report = "\n".join(final_report_fields)
+    (output_dir / "final_report.txt").write_text(final_report, encoding="utf-8")
+
+    manifest_verify_rc, _ = finalize_durable_bundle_manifest(output_dir)
+    print(final_report, end="")
+
+    if (
+        test_proc.returncode != 0
+        or not ruff_pass
+        or manifest_verify_rc != 0
+        or not governance_pass
+        or import_boundary_rc != 0
+        or first["aggregate_status"] != SupportAggregateStatus.BLOCK_SUPPORT_EVIDENCE.value
+    ):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py
+++ b/src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py
@@ -1,0 +1,799 @@
+"""Offline productive linear diagnostics support bundle v0.
+
+Deterministically aggregates manifest-verified productive linear diagnostics into
+support evidence for later EconomicViabilityEvidenceV1 reference. Diagnostic-only:
+no economic evaluation, promotion authority, strategy selection, or runtime effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+SCHEMA_VERSION = "offline_productive_linear_diagnostics_support_bundle.v0"
+EVIDENCE_TYPE = "OFFLINE_PRODUCTIVE_LINEAR_DIAGNOSTICS_SUPPORT_BUNDLE_V0"
+DIAGNOSTIC_EVIDENCE_ID = "offline_productive_linear_diagnostics_support_bundle_v0"
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+
+ARCHIVE_ROOT = Path("/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z")
+
+DEFAULT_COST_DIAGNOSTICS_BUNDLE = (
+    ARCHIVE_ROOT / "research/offline_linear_cost_model_diagnostics_v0_20260714T125628Z"
+)
+DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE = (
+    ARCHIVE_ROOT
+    / "research/offline_productive_signal_orthogonality_results_interpretation_v0_20260714T213029Z"
+)
+DEFAULT_FACTOR_EXPOSURE_BUNDLE = (
+    ARCHIVE_ROOT / "research/offline_productive_factor_exposure_diagnostics_v0_20260714T220739Z"
+)
+DEFAULT_PARAMETER_SENSITIVITY_BUNDLE = (
+    ARCHIVE_ROOT
+    / "research/offline_productive_parameter_sensitivity_diagnostics_v0_20260714T222747Z"
+)
+DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE = (
+    ARCHIVE_ROOT
+    / "research/offline_productive_rolling_linear_drift_diagnostics_v0_20260714T224214Z"
+)
+
+DIAGNOSTIC_CLASS_ORDER: tuple[str, ...] = (
+    "cost_diagnostics",
+    "signal_orthogonality",
+    "factor_exposure",
+    "parameter_sensitivity",
+    "rolling_linear_drift",
+)
+
+PAIR_STATUS_PRECEDENCE: dict[str, int] = {
+    "BLOCKED": 3,
+    "INDICATIVE": 2,
+    "OK": 1,
+}
+
+SOURCE_STATUS_PRECEDENCE: dict[str, int] = {
+    "BLOCK_DRIFT_EXCEEDS_POLICY": 100,
+    "RANK_DEFICIENT_BLOCKED": 90,
+    "LEAKAGE_BLOCKED": 90,
+    "FEATURE_LEAKAGE_BLOCKED": 90,
+    "BLOCKED": 85,
+    "ROBUSTNESS_FAILED": 70,
+    "WARN_DRIFT_DETECTED": 60,
+    "FRAGILE_PARAMETER_RESPONSE": 60,
+    "INDICATIVE": 55,
+    "INSUFFICIENT_DATA": 50,
+    "INCONCLUSIVE": 40,
+    "DIAGNOSTIC_ONLY": 10,
+    "ROBUST_REGION_OBSERVED": 10,
+    "PASS_STABLE": 10,
+    "OK": 5,
+}
+
+BLOCKING_SOURCE_STATUSES: frozenset[str] = frozenset(
+    {
+        "RANK_DEFICIENT_BLOCKED",
+        "BLOCK_DRIFT_EXCEEDS_POLICY",
+        "LEAKAGE_BLOCKED",
+        "FEATURE_LEAKAGE_BLOCKED",
+        "BLOCKED",
+        "TARGET_BINDING_MISSING",
+        "FEATURE_BINDING_MISMATCH",
+        "SOURCE_EVIDENCE_INVALID",
+    }
+)
+
+WARN_SOURCE_STATUSES: frozenset[str] = frozenset(
+    {
+        "WARN_DRIFT_DETECTED",
+        "FRAGILE_PARAMETER_RESPONSE",
+        "ROBUSTNESS_FAILED",
+        "INDICATIVE",
+        "INSUFFICIENT_DATA",
+        "INCONCLUSIVE",
+        "INSUFFICIENT_WINDOWS",
+        "WINDOW_SAMPLE_INSUFFICIENT",
+    }
+)
+
+PASS_OR_INFORMATIONAL_SOURCE_STATUSES: frozenset[str] = frozenset(
+    {
+        "DIAGNOSTIC_ONLY",
+        "ROBUST_REGION_OBSERVED",
+        "PASS_STABLE",
+        "OK",
+    }
+)
+
+
+class SupportAggregateStatus(str, Enum):
+    BLOCK_SUPPORT_EVIDENCE = "BLOCK_SUPPORT_EVIDENCE"
+    WARN_SUPPORT_EVIDENCE = "WARN_SUPPORT_EVIDENCE"
+    DIAGNOSTIC_SUPPORT_COMPLETE = "DIAGNOSTIC_SUPPORT_COMPLETE"
+    INSUFFICIENT_OR_UNVERIFIED_SOURCE_EVIDENCE = "INSUFFICIENT_OR_UNVERIFIED_SOURCE_EVIDENCE"
+
+
+class EconomicViabilitySupportStatus(str, Enum):
+    BLOCKED_SOURCE_DIAGNOSTICS_PRESENT = "BLOCKED_SOURCE_DIAGNOSTICS_PRESENT"
+    WARN_SOURCE_DIAGNOSTICS_PRESENT = "WARN_SOURCE_DIAGNOSTICS_PRESENT"
+    DIAGNOSTIC_SUPPORT_REFERENCE_READY = "DIAGNOSTIC_SUPPORT_REFERENCE_READY"
+    INSUFFICIENT_SOURCE_BINDING = "INSUFFICIENT_SOURCE_BINDING"
+
+
+class SupportBundleValidationError(ValueError):
+    """Fail-closed validation for productive linear diagnostics support bundle."""
+
+
+@dataclass(frozen=True)
+class SourceBundleSpecV0:
+    diagnostic_class: str
+    evidence_type: str
+    bundle_path: Path
+    status_artifact: str
+    reason_artifact: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceDiagnosticBindingV0:
+    diagnostic_class: str
+    evidence_type: str
+    bundle_path: str
+    manifest_digest: str
+    implementation_digest: str | None
+    source_status: str
+    source_reason_codes: tuple[str, ...]
+    manifest_verify_rc: int
+    evidence_ref: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "diagnostic_class": self.diagnostic_class,
+            "evidence_type": self.evidence_type,
+            "bundle_path": self.bundle_path,
+            "manifest_digest": self.manifest_digest,
+            "implementation_digest": self.implementation_digest,
+            "source_status": self.source_status,
+            "source_reason_codes": list(self.source_reason_codes),
+            "manifest_verify_rc": self.manifest_verify_rc,
+            "evidence_ref": self.evidence_ref,
+        }
+
+
+DEFAULT_SOURCE_BUNDLE_SPECS: tuple[SourceBundleSpecV0, ...] = (
+    SourceBundleSpecV0(
+        diagnostic_class="cost_diagnostics",
+        evidence_type="offline_linear_cost_model_diagnostics.v0",
+        bundle_path=DEFAULT_COST_DIAGNOSTICS_BUNDLE,
+        status_artifact="reason_codes.json",
+        reason_artifact="reason_codes.json",
+    ),
+    SourceBundleSpecV0(
+        diagnostic_class="signal_orthogonality",
+        evidence_type="offline_productive_signal_orthogonality_results_interpretation.v0",
+        bundle_path=DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE,
+        status_artifact="pairwise_interpretation.json",
+        reason_artifact="pairwise_interpretation.json",
+    ),
+    SourceBundleSpecV0(
+        diagnostic_class="factor_exposure",
+        evidence_type="offline_productive_factor_exposure_diagnostics.v0",
+        bundle_path=DEFAULT_FACTOR_EXPOSURE_BUNDLE,
+        status_artifact="failure_taxonomy.json",
+        reason_artifact="failure_taxonomy.json",
+    ),
+    SourceBundleSpecV0(
+        diagnostic_class="parameter_sensitivity",
+        evidence_type="offline_productive_parameter_sensitivity_diagnostics.v0",
+        bundle_path=DEFAULT_PARAMETER_SENSITIVITY_BUNDLE,
+        status_artifact="final_report.txt",
+        reason_artifact="parameter_sensitivity_results.json",
+    ),
+    SourceBundleSpecV0(
+        diagnostic_class="rolling_linear_drift",
+        evidence_type="offline_productive_rolling_linear_drift_diagnostics.v0",
+        bundle_path=DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE,
+        status_artifact="interpretation.json",
+        reason_artifact="interpretation.json",
+    ),
+)
+
+
+def _stable_digest(payload: object) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _manifest_file_digest(bundle: Path) -> str:
+    manifest_path = bundle / "MANIFEST.sha256"
+    if not manifest_path.is_file():
+        raise SupportBundleValidationError(f"MISSING_MANIFEST:{bundle}")
+    return hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+
+def _implementation_digest_from_owner_inventory(
+    bundle: Path,
+    *,
+    repo_root: Path | None = None,
+) -> str | None:
+    inventory_path = bundle / "owner_inventory.json"
+    if not inventory_path.is_file():
+        return None
+    inventory = _read_json(inventory_path)
+    owner_rel = inventory.get("canonical_owner")
+    if not isinstance(owner_rel, str) or not owner_rel:
+        return None
+    if repo_root is None:
+        return _stable_digest({"canonical_owner": owner_rel})
+    owner_path = repo_root / owner_rel
+    if not owner_path.is_file():
+        return _stable_digest({"canonical_owner": owner_rel, "owner_present": False})
+    return hashlib.sha256(owner_path.read_bytes()).hexdigest()
+
+
+def verify_bundle_manifest(path: Path, *, verify_fn: Callable[[Path], tuple[bool, str]]) -> int:
+    ok, _ = verify_fn(path)
+    return 0 if ok else 1
+
+
+def _worst_status(statuses: Sequence[str]) -> str:
+    if not statuses:
+        return "INCONCLUSIVE"
+    return max(statuses, key=lambda item: SOURCE_STATUS_PRECEDENCE.get(item, 0))
+
+
+def _normalize_reason_codes(reasons: Sequence[str]) -> tuple[str, ...]:
+    return tuple(sorted({str(item) for item in reasons if str(item)}))
+
+
+def _extract_cost_status(bundle: Path) -> tuple[str, tuple[str, ...]]:
+    reason_path = bundle / "reason_codes.json"
+    if reason_path.is_file():
+        payload = _read_json(reason_path)
+        status = str(payload.get("status", "INCONCLUSIVE"))
+        reasons = payload.get("reason_codes", [])
+        if isinstance(reasons, list):
+            return status, _normalize_reason_codes(reasons)
+    evidence_path = bundle / "diagnostic_model_evidence.json"
+    if evidence_path.is_file():
+        payload = _read_json(evidence_path)
+        status = str(payload.get("status", "INCONCLUSIVE"))
+        reasons = payload.get("reason_codes", [])
+        if isinstance(reasons, list):
+            return status, _normalize_reason_codes(reasons)
+    raise SupportBundleValidationError("MISSING_COST_STATUS_ARTIFACT")
+
+
+def _extract_signal_orthogonality_status(bundle: Path) -> tuple[str, tuple[str, ...]]:
+    pairwise_path = bundle / "pairwise_interpretation.json"
+    if not pairwise_path.is_file():
+        raise SupportBundleValidationError("MISSING_SIGNAL_ORTHOGONALITY_STATUS_ARTIFACT")
+    records = _read_json(pairwise_path)
+    if not isinstance(records, list) or not records:
+        raise SupportBundleValidationError("EMPTY_SIGNAL_ORTHOGONALITY_PAIRWISE")
+    pair_statuses = [str(item.get("status", "INCONCLUSIVE")) for item in records]
+    aggregate_pair_status = max(
+        pair_statuses,
+        key=lambda item: PAIR_STATUS_PRECEDENCE.get(item, 0),
+    )
+    reasons: list[str] = []
+    for record in records:
+        record_reasons = record.get("reason_codes", [])
+        if isinstance(record_reasons, list):
+            reasons.extend(str(item) for item in record_reasons)
+        interpretation_class = record.get("interpretation_class")
+        if isinstance(interpretation_class, str) and interpretation_class:
+            reasons.append(f"INTERPRETATION_CLASS:{interpretation_class}")
+    return aggregate_pair_status, _normalize_reason_codes(reasons)
+
+
+def _extract_factor_exposure_status(bundle: Path) -> tuple[str, tuple[str, ...]]:
+    taxonomy_path = bundle / "failure_taxonomy.json"
+    if not taxonomy_path.is_file():
+        raise SupportBundleValidationError("MISSING_FACTOR_EXPOSURE_STATUS_ARTIFACT")
+    payload = _read_json(taxonomy_path)
+    observed_statuses = payload.get("observed_statuses", [])
+    observed_reasons = payload.get("observed_reason_codes", [])
+    if not isinstance(observed_statuses, list) or not observed_statuses:
+        raise SupportBundleValidationError("EMPTY_FACTOR_EXPOSURE_OBSERVED_STATUSES")
+    status = _worst_status(str(item) for item in observed_statuses)
+    reasons = observed_reasons if isinstance(observed_reasons, list) else []
+    return status, _normalize_reason_codes(str(item) for item in reasons)
+
+
+def _parse_final_report_field(bundle: Path, field: str) -> str | None:
+    report_path = bundle / "final_report.txt"
+    if not report_path.is_file():
+        return None
+    prefix = f"{field}="
+    for line in report_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix) :]
+    return None
+
+
+def _extract_parameter_sensitivity_status(bundle: Path) -> tuple[str, tuple[str, ...]]:
+    aggregate_status = _parse_final_report_field(bundle, "AGGREGATE_STATUS")
+    if aggregate_status:
+        results_path = bundle / "parameter_sensitivity_results.json"
+        reasons: list[str] = []
+        if results_path.is_file():
+            payload = _read_json(results_path)
+            if isinstance(payload, dict):
+                for parameter_payload in payload.values():
+                    if not isinstance(parameter_payload, dict):
+                        continue
+                    point_results = parameter_payload.get("point_results", [])
+                    if isinstance(point_results, list):
+                        for point in point_results:
+                            point_reasons = point.get("reason_codes", [])
+                            if isinstance(point_reasons, list):
+                                reasons.extend(str(item) for item in point_reasons)
+        return aggregate_status, _normalize_reason_codes(reasons)
+    raise SupportBundleValidationError("MISSING_PARAMETER_SENSITIVITY_STATUS_ARTIFACT")
+
+
+def _extract_rolling_linear_drift_status(bundle: Path) -> tuple[str, tuple[str, ...]]:
+    interpretation_path = bundle / "interpretation.json"
+    if interpretation_path.is_file():
+        payload = _read_json(interpretation_path)
+        status = _parse_final_report_field(bundle, "ROLLING_DRIFT_STATUS")
+        if not status:
+            status = str(payload.get("productive_status", payload.get("status", "INCONCLUSIVE")))
+        reasons = payload.get("reason_codes", [])
+        if isinstance(reasons, list):
+            return status, _normalize_reason_codes(str(item) for item in reasons)
+    final_status = _parse_final_report_field(bundle, "ROLLING_DRIFT_STATUS")
+    if final_status:
+        reason_field = _parse_final_report_field(bundle, "ROLLING_DRIFT_REASON_CODES")
+        if reason_field:
+            return final_status, _normalize_reason_codes(
+                item.strip() for item in reason_field.split(",") if item.strip()
+            )
+        return final_status, ()
+    raise SupportBundleValidationError("MISSING_ROLLING_LINEAR_DRIFT_STATUS_ARTIFACT")
+
+
+_STATUS_EXTRACTORS: dict[str, Callable[[Path], tuple[str, tuple[str, ...]]]] = {
+    "cost_diagnostics": _extract_cost_status,
+    "signal_orthogonality": _extract_signal_orthogonality_status,
+    "factor_exposure": _extract_factor_exposure_status,
+    "parameter_sensitivity": _extract_parameter_sensitivity_status,
+    "rolling_linear_drift": _extract_rolling_linear_drift_status,
+}
+
+
+def _classify_source_bucket(status: str) -> str:
+    if status in BLOCKING_SOURCE_STATUSES:
+        return "blocked"
+    if status in WARN_SOURCE_STATUSES:
+        return "warn"
+    if status in PASS_OR_INFORMATIONAL_SOURCE_STATUSES:
+        return "pass_or_informational"
+    if status.startswith("BLOCK_"):
+        return "blocked"
+    if status.startswith("WARN_"):
+        return "warn"
+    if status.startswith("PASS_"):
+        return "pass_or_informational"
+    return "warn"
+
+
+def classify_support_aggregate_status(
+    bindings: Sequence[SourceDiagnosticBindingV0],
+) -> tuple[str, tuple[str, ...]]:
+    if not bindings:
+        return (
+            SupportAggregateStatus.INSUFFICIENT_OR_UNVERIFIED_SOURCE_EVIDENCE.value,
+            ("NO_SOURCE_BINDINGS",),
+        )
+    if any(item.manifest_verify_rc != 0 for item in bindings):
+        return (
+            SupportAggregateStatus.INSUFFICIENT_OR_UNVERIFIED_SOURCE_EVIDENCE.value,
+            ("SOURCE_MANIFEST_VERIFY_FAILED",),
+        )
+    if len(bindings) != len(DIAGNOSTIC_CLASS_ORDER):
+        return (
+            SupportAggregateStatus.INSUFFICIENT_OR_UNVERIFIED_SOURCE_EVIDENCE.value,
+            ("INCOMPLETE_DIAGNOSTIC_CLASS_BINDING",),
+        )
+
+    reason_codes: list[str] = []
+    blocked_count = 0
+    warn_count = 0
+    pass_count = 0
+    for binding in bindings:
+        bucket = _classify_source_bucket(binding.source_status)
+        if bucket == "blocked":
+            blocked_count += 1
+            reason_codes.append(
+                f"BLOCKED_SOURCE:{binding.diagnostic_class}:{binding.source_status}"
+            )
+        elif bucket == "warn":
+            warn_count += 1
+            reason_codes.append(f"WARN_SOURCE:{binding.diagnostic_class}:{binding.source_status}")
+        else:
+            pass_count += 1
+
+    if blocked_count > 0:
+        return (
+            SupportAggregateStatus.BLOCK_SUPPORT_EVIDENCE.value,
+            tuple(sorted(set(reason_codes))),
+        )
+    if warn_count > 0:
+        return (
+            SupportAggregateStatus.WARN_SUPPORT_EVIDENCE.value,
+            tuple(sorted(set(reason_codes))),
+        )
+    return (
+        SupportAggregateStatus.DIAGNOSTIC_SUPPORT_COMPLETE.value,
+        tuple(sorted(set(reason_codes))) if reason_codes else ("ALL_SOURCE_CLASSES_INFORMATIONAL",),
+    )
+
+
+def classify_economic_viability_support_status(aggregate_status: str) -> str:
+    if aggregate_status == SupportAggregateStatus.BLOCK_SUPPORT_EVIDENCE.value:
+        return EconomicViabilitySupportStatus.BLOCKED_SOURCE_DIAGNOSTICS_PRESENT.value
+    if aggregate_status == SupportAggregateStatus.WARN_SUPPORT_EVIDENCE.value:
+        return EconomicViabilitySupportStatus.WARN_SOURCE_DIAGNOSTICS_PRESENT.value
+    if aggregate_status == SupportAggregateStatus.DIAGNOSTIC_SUPPORT_COMPLETE.value:
+        return EconomicViabilitySupportStatus.DIAGNOSTIC_SUPPORT_REFERENCE_READY.value
+    return EconomicViabilitySupportStatus.INSUFFICIENT_SOURCE_BINDING.value
+
+
+def build_interpretation_v0(
+    *,
+    bindings: Sequence[SourceDiagnosticBindingV0],
+    aggregate_status: str,
+    aggregate_reason_codes: Sequence[str],
+) -> dict[str, Any]:
+    per_class = {
+        binding.diagnostic_class: {
+            "source_status": binding.source_status,
+            "source_reason_codes": list(binding.source_reason_codes),
+            "manifest_verify_rc": binding.manifest_verify_rc,
+        }
+        for binding in bindings
+    }
+    return {
+        "summary": (
+            "Manifest-verified productive linear diagnostics aggregated as offline support "
+            "evidence only. No economic evaluation, promotion authority, or strategy selection."
+        ),
+        "aggregate_status": aggregate_status,
+        "aggregate_reason_codes": list(aggregate_reason_codes),
+        "per_class_status": per_class,
+        "blocked_classes": sorted(
+            binding.diagnostic_class
+            for binding in bindings
+            if _classify_source_bucket(binding.source_status) == "blocked"
+        ),
+        "warn_classes": sorted(
+            binding.diagnostic_class
+            for binding in bindings
+            if _classify_source_bucket(binding.source_status) == "warn"
+        ),
+        "informational_classes": sorted(
+            binding.diagnostic_class
+            for binding in bindings
+            if _classify_source_bucket(binding.source_status) == "pass_or_informational"
+        ),
+        "economic_pass_claim_forbidden": True,
+        "promotion_pass_claim_forbidden": True,
+        "strategy_selection_claim_forbidden": True,
+    }
+
+
+def bind_source_diagnostic_v0(
+    spec: SourceBundleSpecV0,
+    *,
+    verify_fn: Callable[[Path], tuple[bool, str]],
+    repo_root: Path | None = None,
+) -> SourceDiagnosticBindingV0:
+    bundle = spec.bundle_path.expanduser().resolve()
+    if not bundle.is_dir():
+        raise SupportBundleValidationError(
+            f"SOURCE_BUNDLE_MISSING:{spec.diagnostic_class}:{bundle}"
+        )
+    manifest_verify_rc = verify_bundle_manifest(bundle, verify_fn=verify_fn)
+    if manifest_verify_rc != 0:
+        raise SupportBundleValidationError(f"SOURCE_MANIFEST_VERIFY_FAILED:{spec.diagnostic_class}")
+
+    extractor = _STATUS_EXTRACTORS[spec.diagnostic_class]
+    source_status, source_reason_codes = extractor(bundle)
+    return SourceDiagnosticBindingV0(
+        diagnostic_class=spec.diagnostic_class,
+        evidence_type=spec.evidence_type,
+        bundle_path=str(bundle),
+        manifest_digest=_manifest_file_digest(bundle),
+        implementation_digest=_implementation_digest_from_owner_inventory(
+            bundle,
+            repo_root=repo_root,
+        ),
+        source_status=source_status,
+        source_reason_codes=source_reason_codes,
+        manifest_verify_rc=manifest_verify_rc,
+        evidence_ref=spec.status_artifact,
+    )
+
+
+def build_source_status_matrix_v0(
+    bindings: Sequence[SourceDiagnosticBindingV0],
+) -> dict[str, Any]:
+    rows = [binding.to_dict() for binding in bindings]
+    blocked = sum(
+        1 for item in bindings if _classify_source_bucket(item.source_status) == "blocked"
+    )
+    warn = sum(1 for item in bindings if _classify_source_bucket(item.source_status) == "warn")
+    informational = sum(
+        1
+        for item in bindings
+        if _classify_source_bucket(item.source_status) == "pass_or_informational"
+    )
+    return {
+        "diagnostic_class_count": len(DIAGNOSTIC_CLASS_ORDER),
+        "diagnostic_class_present_count": len(bindings),
+        "diagnostic_class_blocked_count": blocked,
+        "diagnostic_class_warn_count": warn,
+        "diagnostic_class_pass_or_informational_count": informational,
+        "rows": rows,
+    }
+
+
+def build_authority_boundary_v0() -> dict[str, Any]:
+    return {
+        "offline_only": True,
+        "economic_evaluation_executed": False,
+        "economic_validity_pass_created": False,
+        "promotion_pass_created": False,
+        "strategy_selection_changed": False,
+        "parameter_optimization_executed": False,
+        "parameter_default_changed": False,
+        "cost_default_changed": False,
+        "core_trading_semantics_changed": False,
+        "economic_pass_authority": False,
+        "promotion_pass_authority": False,
+        "strategy_selection_authority": False,
+        "runtime_effect": RUNTIME_EFFECT,
+        "authority_effect": AUTHORITY_EFFECT,
+        "support_evidence_only": True,
+        "forbidden_claims": [
+            "economic_validity_pass",
+            "promotion_eligibility",
+            "strategy_selection_authority",
+            "profitability_proof",
+        ],
+    }
+
+
+def build_productive_linear_diagnostics_support_bundle_artifacts_v0(
+    *,
+    source_specs: Sequence[SourceBundleSpecV0] = DEFAULT_SOURCE_BUNDLE_SPECS,
+    verify_fn: Callable[[Path], tuple[bool, str]],
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    ordered_specs = sorted(
+        source_specs, key=lambda item: DIAGNOSTIC_CLASS_ORDER.index(item.diagnostic_class)
+    )
+    bindings = [
+        bind_source_diagnostic_v0(spec, verify_fn=verify_fn, repo_root=repo_root)
+        for spec in ordered_specs
+    ]
+    aggregate_status, aggregate_reason_codes = classify_support_aggregate_status(bindings)
+    economic_viability_support_status = classify_economic_viability_support_status(aggregate_status)
+    status_matrix = build_source_status_matrix_v0(bindings)
+    interpretation = build_interpretation_v0(
+        bindings=bindings,
+        aggregate_status=aggregate_status,
+        aggregate_reason_codes=aggregate_reason_codes,
+    )
+
+    source_evidence_refs = [binding.bundle_path for binding in bindings]
+    source_manifest_digests = {
+        binding.diagnostic_class: binding.manifest_digest for binding in bindings
+    }
+    source_implementation_digests = {
+        binding.diagnostic_class: binding.implementation_digest for binding in bindings
+    }
+    source_statuses = {binding.diagnostic_class: binding.source_status for binding in bindings}
+    source_reason_codes = {
+        binding.diagnostic_class: list(binding.source_reason_codes) for binding in bindings
+    }
+
+    config_payload = {
+        "schema_version": SCHEMA_VERSION,
+        "diagnostic_class_order": list(DIAGNOSTIC_CLASS_ORDER),
+        "source_specs": [
+            {
+                "diagnostic_class": spec.diagnostic_class,
+                "evidence_type": spec.evidence_type,
+                "bundle_path": str(spec.bundle_path),
+                "status_artifact": spec.status_artifact,
+            }
+            for spec in ordered_specs
+        ],
+    }
+    config_digest = _stable_digest(config_payload)
+    input_digest = _stable_digest(
+        {
+            "source_manifest_digests": source_manifest_digests,
+            "source_statuses": source_statuses,
+            "source_reason_codes": source_reason_codes,
+        }
+    )
+
+    aggregate_contract = {
+        "schema_version": SCHEMA_VERSION,
+        "evidence_type": EVIDENCE_TYPE,
+        "aggregate_status": aggregate_status,
+        "aggregate_reason_codes": list(aggregate_reason_codes),
+        "economic_viability_support_status": economic_viability_support_status,
+        "diagnostic_class_count": status_matrix["diagnostic_class_count"],
+        "diagnostic_class_present_count": status_matrix["diagnostic_class_present_count"],
+        "diagnostic_class_blocked_count": status_matrix["diagnostic_class_blocked_count"],
+        "diagnostic_class_warn_count": status_matrix["diagnostic_class_warn_count"],
+        "diagnostic_class_pass_or_informational_count": status_matrix[
+            "diagnostic_class_pass_or_informational_count"
+        ],
+    }
+    output_digest = _stable_digest(
+        {
+            "aggregate_contract": aggregate_contract,
+            "source_status_matrix": status_matrix,
+            "interpretation": interpretation,
+            "authority_boundary": build_authority_boundary_v0(),
+        }
+    )
+
+    ref_by_class = {binding.diagnostic_class: binding.bundle_path for binding in bindings}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "evidence_type": EVIDENCE_TYPE,
+        "diagnostic_evidence_id": DIAGNOSTIC_EVIDENCE_ID,
+        "source_evidence_refs": source_evidence_refs,
+        "source_manifest_digests": source_manifest_digests,
+        "source_implementation_digests": source_implementation_digests,
+        "source_statuses": source_statuses,
+        "source_reason_codes": source_reason_codes,
+        "cost_diagnostics_ref": ref_by_class["cost_diagnostics"],
+        "signal_orthogonality_ref": ref_by_class["signal_orthogonality"],
+        "factor_exposure_ref": ref_by_class["factor_exposure"],
+        "parameter_sensitivity_ref": ref_by_class["parameter_sensitivity"],
+        "rolling_linear_drift_ref": ref_by_class["rolling_linear_drift"],
+        "diagnostic_class_count": status_matrix["diagnostic_class_count"],
+        "diagnostic_class_present_count": status_matrix["diagnostic_class_present_count"],
+        "diagnostic_class_blocked_count": status_matrix["diagnostic_class_blocked_count"],
+        "diagnostic_class_warn_count": status_matrix["diagnostic_class_warn_count"],
+        "diagnostic_class_pass_or_informational_count": status_matrix[
+            "diagnostic_class_pass_or_informational_count"
+        ],
+        "aggregate_status": aggregate_status,
+        "aggregate_reason_codes": list(aggregate_reason_codes),
+        "economic_viability_support_status": economic_viability_support_status,
+        "economic_pass_authority": False,
+        "promotion_pass_authority": False,
+        "strategy_selection_authority": False,
+        "runtime_effect": RUNTIME_EFFECT,
+        "authority_effect": AUTHORITY_EFFECT,
+        "interpretation": interpretation,
+        "config_digest": config_digest,
+        "input_digest": input_digest,
+        "output_digest": output_digest,
+        "source_status_matrix": status_matrix,
+        "aggregate_contract": aggregate_contract,
+        "authority_boundary": build_authority_boundary_v0(),
+    }
+
+
+_REQUIRED_ARTIFACT_KEYS: tuple[str, ...] = (
+    "schema_version",
+    "evidence_type",
+    "source_evidence_refs",
+    "source_manifest_digests",
+    "source_implementation_digests",
+    "source_statuses",
+    "source_reason_codes",
+    "cost_diagnostics_ref",
+    "signal_orthogonality_ref",
+    "factor_exposure_ref",
+    "parameter_sensitivity_ref",
+    "rolling_linear_drift_ref",
+    "diagnostic_class_count",
+    "diagnostic_class_present_count",
+    "diagnostic_class_blocked_count",
+    "diagnostic_class_warn_count",
+    "diagnostic_class_pass_or_informational_count",
+    "aggregate_status",
+    "aggregate_reason_codes",
+    "economic_viability_support_status",
+    "economic_pass_authority",
+    "promotion_pass_authority",
+    "strategy_selection_authority",
+    "runtime_effect",
+    "authority_effect",
+    "interpretation",
+    "config_digest",
+    "input_digest",
+    "output_digest",
+)
+
+
+def validate_support_bundle_artifacts_v0(artifacts: Mapping[str, Any]) -> None:
+    missing = [key for key in _REQUIRED_ARTIFACT_KEYS if key not in artifacts]
+    if missing:
+        raise SupportBundleValidationError(f"MISSING_REQUIRED_KEYS:{','.join(missing)}")
+
+    if artifacts["schema_version"] != SCHEMA_VERSION:
+        raise SupportBundleValidationError("SCHEMA_VERSION_MISMATCH")
+    if artifacts["evidence_type"] != EVIDENCE_TYPE:
+        raise SupportBundleValidationError("EVIDENCE_TYPE_MISMATCH")
+    if artifacts["economic_pass_authority"] is not False:
+        raise SupportBundleValidationError("ECONOMIC_PASS_AUTHORITY_FORBIDDEN")
+    if artifacts["promotion_pass_authority"] is not False:
+        raise SupportBundleValidationError("PROMOTION_PASS_AUTHORITY_FORBIDDEN")
+    if artifacts["strategy_selection_authority"] is not False:
+        raise SupportBundleValidationError("STRATEGY_SELECTION_AUTHORITY_FORBIDDEN")
+    if artifacts["runtime_effect"] != RUNTIME_EFFECT:
+        raise SupportBundleValidationError("RUNTIME_EFFECT_MISMATCH")
+    if artifacts["authority_effect"] != AUTHORITY_EFFECT:
+        raise SupportBundleValidationError("AUTHORITY_EFFECT_MISMATCH")
+
+    expected_output_digest = _stable_digest(
+        {
+            "aggregate_contract": artifacts["aggregate_contract"],
+            "source_status_matrix": artifacts["source_status_matrix"],
+            "interpretation": artifacts["interpretation"],
+            "authority_boundary": artifacts["authority_boundary"],
+        }
+    )
+    if artifacts["output_digest"] != expected_output_digest:
+        raise SupportBundleValidationError("OUTPUT_DIGEST_MISMATCH")
+
+    aggregate_status = str(artifacts["aggregate_status"])
+    allowed_aggregate = {item.value for item in SupportAggregateStatus}
+    if aggregate_status not in allowed_aggregate:
+        raise SupportBundleValidationError(f"UNKNOWN_AGGREGATE_STATUS:{aggregate_status}")
+
+    rolling_status = artifacts["source_statuses"].get("rolling_linear_drift")
+    if (
+        rolling_status == "BLOCK_DRIFT_EXCEEDS_POLICY"
+        and aggregate_status != SupportAggregateStatus.BLOCK_SUPPORT_EVIDENCE.value
+    ):
+        raise SupportBundleValidationError("ROLLING_DRIFT_BLOCK_NIVELLED")
+
+
+__all__ = [
+    "ARCHIVE_ROOT",
+    "AUTHORITY_EFFECT",
+    "DEFAULT_COST_DIAGNOSTICS_BUNDLE",
+    "DEFAULT_FACTOR_EXPOSURE_BUNDLE",
+    "DEFAULT_PARAMETER_SENSITIVITY_BUNDLE",
+    "DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE",
+    "DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE",
+    "DEFAULT_SOURCE_BUNDLE_SPECS",
+    "DIAGNOSTIC_CLASS_ORDER",
+    "DIAGNOSTIC_EVIDENCE_ID",
+    "EVIDENCE_TYPE",
+    "EconomicViabilitySupportStatus",
+    "RUNTIME_EFFECT",
+    "SCHEMA_VERSION",
+    "SourceBundleSpecV0",
+    "SourceDiagnosticBindingV0",
+    "SupportAggregateStatus",
+    "SupportBundleValidationError",
+    "bind_source_diagnostic_v0",
+    "build_authority_boundary_v0",
+    "build_interpretation_v0",
+    "build_productive_linear_diagnostics_support_bundle_artifacts_v0",
+    "build_source_status_matrix_v0",
+    "classify_economic_viability_support_status",
+    "classify_support_aggregate_status",
+    "validate_support_bundle_artifacts_v0",
+    "verify_bundle_manifest",
+]

--- a/tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py
+++ b/tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from research.linear_evidence.import_boundary import scan_file_import_boundary
+from research.linear_evidence.offline_productive_linear_diagnostics_support_bundle_v0 import (
+    AUTHORITY_EFFECT,
+    DEFAULT_COST_DIAGNOSTICS_BUNDLE,
+    DEFAULT_FACTOR_EXPOSURE_BUNDLE,
+    DEFAULT_PARAMETER_SENSITIVITY_BUNDLE,
+    DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE,
+    DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE,
+    DEFAULT_SOURCE_BUNDLE_SPECS,
+    DIAGNOSTIC_CLASS_ORDER,
+    EVIDENCE_TYPE,
+    SCHEMA_VERSION,
+    EconomicViabilitySupportStatus,
+    SourceBundleSpecV0,
+    SupportAggregateStatus,
+    SupportBundleValidationError,
+    bind_source_diagnostic_v0,
+    build_authority_boundary_v0,
+    build_productive_linear_diagnostics_support_bundle_artifacts_v0,
+    classify_support_aggregate_status,
+    validate_support_bundle_artifacts_v0,
+    verify_bundle_manifest,
+)
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.governance.economic_diagnostic_optimization_boundary_v0 import build_boundary_report
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OWNER = REPO_ROOT / (
+    "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py"
+)
+MATERIALIZER = (
+    REPO_ROOT / "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py"
+)
+
+PRODUCTIVE_BUNDLES = {
+    "cost_diagnostics": DEFAULT_COST_DIAGNOSTICS_BUNDLE,
+    "signal_orthogonality": DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE,
+    "factor_exposure": DEFAULT_FACTOR_EXPOSURE_BUNDLE,
+    "parameter_sensitivity": DEFAULT_PARAMETER_SENSITIVITY_BUNDLE,
+    "rolling_linear_drift": DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE,
+}
+
+
+def _archive_available() -> bool:
+    return all(path.is_dir() for path in PRODUCTIVE_BUNDLES.values())
+
+
+def _run_materializer(out_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(MATERIALIZER),
+            "--out",
+            str(out_dir),
+            "--skip-focused-tests",
+        ],
+        cwd=str(REPO_ROOT),
+        check=False,
+        text=True,
+        capture_output=True,
+        env={"PYTHONPATH": f"{REPO_ROOT / 'src'}:{REPO_ROOT}"},
+    )
+
+
+@pytest.fixture(scope="module")
+def productive_artifacts():
+    if not _archive_available():
+        pytest.skip("productive archive bundles unavailable")
+    artifacts = build_productive_linear_diagnostics_support_bundle_artifacts_v0(
+        source_specs=DEFAULT_SOURCE_BUNDLE_SPECS,
+        verify_fn=verify_manifest_sha256,
+        repo_root=REPO_ROOT,
+    )
+    validate_support_bundle_artifacts_v0(artifacts)
+    return artifacts
+
+
+def test_all_five_source_classes_canonically_bound(productive_artifacts) -> None:
+    assert productive_artifacts["diagnostic_class_present_count"] == 5
+    assert productive_artifacts["diagnostic_class_count"] == 5
+    ref_fields = {
+        "cost_diagnostics": "cost_diagnostics_ref",
+        "signal_orthogonality": "signal_orthogonality_ref",
+        "factor_exposure": "factor_exposure_ref",
+        "parameter_sensitivity": "parameter_sensitivity_ref",
+        "rolling_linear_drift": "rolling_linear_drift_ref",
+    }
+    for diagnostic_class in DIAGNOSTIC_CLASS_ORDER:
+        assert diagnostic_class in productive_artifacts["source_statuses"]
+        assert diagnostic_class in productive_artifacts["source_reason_codes"]
+        assert productive_artifacts["source_manifest_digests"][diagnostic_class]
+        assert productive_artifacts[ref_fields[diagnostic_class]]
+
+
+def test_productive_bundle_refs_present(productive_artifacts) -> None:
+    assert productive_artifacts["cost_diagnostics_ref"] == str(DEFAULT_COST_DIAGNOSTICS_BUNDLE)
+    assert productive_artifacts["signal_orthogonality_ref"] == str(
+        DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE
+    )
+    assert productive_artifacts["factor_exposure_ref"] == str(DEFAULT_FACTOR_EXPOSURE_BUNDLE)
+    assert productive_artifacts["parameter_sensitivity_ref"] == str(
+        DEFAULT_PARAMETER_SENSITIVITY_BUNDLE
+    )
+    assert productive_artifacts["rolling_linear_drift_ref"] == str(
+        DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE
+    )
+
+
+def test_source_manifests_verified_before_materialization() -> None:
+    if not _archive_available():
+        pytest.skip("productive archive bundles unavailable")
+    for bundle in PRODUCTIVE_BUNDLES.values():
+        assert verify_bundle_manifest(bundle, verify_fn=verify_manifest_sha256) == 0
+
+
+def test_missing_source_evidence_fail_closed(tmp_path: Path) -> None:
+    missing_spec = SourceBundleSpecV0(
+        diagnostic_class="cost_diagnostics",
+        evidence_type="offline_linear_cost_model_diagnostics.v0",
+        bundle_path=tmp_path / "missing_bundle",
+        status_artifact="reason_codes.json",
+    )
+    with pytest.raises(SupportBundleValidationError, match="SOURCE_BUNDLE_MISSING"):
+        bind_source_diagnostic_v0(missing_spec, verify_fn=verify_manifest_sha256)
+
+
+def test_manifest_error_fail_closed(tmp_path: Path) -> None:
+    bundle = tmp_path / "bad_bundle"
+    bundle.mkdir()
+    (bundle / "MANIFEST.sha256").write_text("deadbeef  missing.txt\n", encoding="utf-8")
+    spec = SourceBundleSpecV0(
+        diagnostic_class="cost_diagnostics",
+        evidence_type="offline_linear_cost_model_diagnostics.v0",
+        bundle_path=bundle,
+        status_artifact="reason_codes.json",
+    )
+
+    def _fail_verify(_: Path) -> tuple[bool, str]:
+        return False, "MANIFEST_MISMATCH"
+
+    with pytest.raises(SupportBundleValidationError, match="SOURCE_MANIFEST_VERIFY_FAILED"):
+        bind_source_diagnostic_v0(spec, verify_fn=_fail_verify)
+
+
+def test_source_status_and_reason_codes_preserved(productive_artifacts) -> None:
+    assert productive_artifacts["source_statuses"]["cost_diagnostics"] == "RANK_DEFICIENT_BLOCKED"
+    assert (
+        "RANK_DEFICIENT_FEATURE_MATRIX"
+        in productive_artifacts["source_reason_codes"]["cost_diagnostics"]
+    )
+    assert productive_artifacts["source_statuses"]["signal_orthogonality"] == "OK"
+    assert productive_artifacts["source_statuses"]["factor_exposure"] == "RANK_DEFICIENT_BLOCKED"
+    assert (
+        productive_artifacts["source_statuses"]["parameter_sensitivity"] == "ROBUST_REGION_OBSERVED"
+    )
+    assert (
+        productive_artifacts["source_statuses"]["rolling_linear_drift"]
+        == "BLOCK_DRIFT_EXCEEDS_POLICY"
+    )
+    assert (
+        "COEFFICIENT_MAGNITUDE_DRIFT"
+        in productive_artifacts["source_reason_codes"]["rolling_linear_drift"]
+    )
+
+
+def test_blocking_rolling_drift_remains_blockering_in_aggregate(productive_artifacts) -> None:
+    assert (
+        productive_artifacts["aggregate_status"]
+        == SupportAggregateStatus.BLOCK_SUPPORT_EVIDENCE.value
+    )
+    assert any(
+        code.startswith("BLOCKED_SOURCE:rolling_linear_drift:")
+        for code in productive_artifacts["aggregate_reason_codes"]
+    )
+    assert (
+        productive_artifacts["economic_viability_support_status"]
+        == EconomicViabilitySupportStatus.BLOCKED_SOURCE_DIAGNOSTICS_PRESENT.value
+    )
+
+
+def test_aggregate_semantics_deterministic(productive_artifacts) -> None:
+    second = build_productive_linear_diagnostics_support_bundle_artifacts_v0(
+        source_specs=DEFAULT_SOURCE_BUNDLE_SPECS,
+        verify_fn=verify_manifest_sha256,
+        repo_root=REPO_ROOT,
+    )
+    assert second["aggregate_status"] == productive_artifacts["aggregate_status"]
+    assert second["aggregate_reason_codes"] == productive_artifacts["aggregate_reason_codes"]
+
+
+def test_stable_sorting_and_serialization(productive_artifacts) -> None:
+    serialized = json.dumps(productive_artifacts, sort_keys=True, separators=(",", ":"))
+    roundtrip = json.loads(serialized)
+    assert roundtrip["source_evidence_refs"] == productive_artifacts["source_evidence_refs"]
+    assert roundtrip["aggregate_reason_codes"] == productive_artifacts["aggregate_reason_codes"]
+
+
+def test_materializer_to_validator_roundtrip(productive_artifacts) -> None:
+    validate_support_bundle_artifacts_v0(productive_artifacts)
+
+
+def test_repeated_materialization_byte_identical(productive_artifacts) -> None:
+    second = build_productive_linear_diagnostics_support_bundle_artifacts_v0(
+        source_specs=DEFAULT_SOURCE_BUNDLE_SPECS,
+        verify_fn=verify_manifest_sha256,
+        repo_root=REPO_ROOT,
+    )
+    assert second["output_digest"] == productive_artifacts["output_digest"]
+
+
+def test_no_economic_evaluation_or_authority(productive_artifacts) -> None:
+    boundary = productive_artifacts["authority_boundary"]
+    assert boundary["economic_evaluation_executed"] is False
+    assert boundary["economic_validity_pass_created"] is False
+    assert boundary["promotion_pass_created"] is False
+    assert boundary["parameter_optimization_executed"] is False
+    assert boundary["parameter_default_changed"] is False
+    assert boundary["strategy_selection_changed"] is False
+    assert productive_artifacts["economic_pass_authority"] is False
+    assert productive_artifacts["promotion_pass_authority"] is False
+    assert productive_artifacts["strategy_selection_authority"] is False
+
+
+def test_runtime_and_authority_effects_none() -> None:
+    boundary = build_authority_boundary_v0()
+    assert boundary["runtime_effect"] == AUTHORITY_EFFECT == "NONE"
+    assert boundary["authority_effect"] == "NONE"
+
+
+def test_import_boundary_owner_and_materializer() -> None:
+    assert scan_file_import_boundary(OWNER, repo_root=REPO_ROOT) == []
+    assert scan_file_import_boundary(MATERIALIZER, repo_root=REPO_ROOT) == []
+
+
+def test_governance_boundary_guard_accepts_new_owner() -> None:
+    changed_files = [
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+    ]
+    report = build_boundary_report(changed_files, repo_root=REPO_ROOT)
+    assert report.admissible is True
+    assert report.impact_unknown is False
+
+
+def test_unknown_path_still_blocked() -> None:
+    report = build_boundary_report(
+        ["src/research/unregistered_offline_diagnostic_owner_v0.py"],
+        repo_root=REPO_ROOT,
+    )
+    assert report.admissible is False
+    assert report.impact_unknown is True
+
+
+def test_contract_metadata_bound(productive_artifacts) -> None:
+    assert productive_artifacts["schema_version"] == SCHEMA_VERSION
+    assert productive_artifacts["evidence_type"] == EVIDENCE_TYPE
+    assert productive_artifacts["runtime_effect"] == "NONE"
+    assert productive_artifacts["authority_effect"] == "NONE"
+
+
+def test_materializer_roundtrip(tmp_path: Path) -> None:
+    if not _archive_available():
+        pytest.skip("productive archive bundles unavailable")
+
+    first_dir = tmp_path / "evidence_a"
+    second_dir = tmp_path / "evidence_b"
+    first = _run_materializer(first_dir)
+    second = _run_materializer(second_dir)
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+
+    for bundle in (first_dir, second_dir):
+        ok, _ = verify_manifest_sha256(bundle)
+        assert ok
+
+    digest_a = (first_dir / "deterministic_materialization.txt").read_text(encoding="utf-8")
+    digest_b = (second_dir / "deterministic_materialization.txt").read_text(encoding="utf-8")
+    assert "SECOND_MATERIALIZATION_DIFF_EMPTY=True" in digest_a
+    assert digest_a == digest_b
+
+    payload_a = json.loads(
+        (first_dir / "linear_diagnostics_support_bundle.json").read_text(encoding="utf-8")
+    )
+    payload_b = json.loads(
+        (second_dir / "linear_diagnostics_support_bundle.json").read_text(encoding="utf-8")
+    )
+    assert payload_a["output_digest"] == payload_b["output_digest"]
+    assert payload_a["aggregate_status"] == SupportAggregateStatus.BLOCK_SUPPORT_EVIDENCE.value
+
+
+def test_insufficient_binding_aggregate_fail_closed() -> None:
+    aggregate_status, reason_codes = classify_support_aggregate_status([])
+    assert (
+        aggregate_status == SupportAggregateStatus.INSUFFICIENT_OR_UNVERIFIED_SOURCE_EVIDENCE.value
+    )
+    assert "NO_SOURCE_BINDINGS" in reason_codes


### PR DESCRIPTION
## Summary

- Adds a narrow offline-only support-bundle adapter that deterministically aggregates five manifest-verified productive linear diagnostics classes into one canonical support-evidence contract for later `EconomicViabilityEvidenceV1` reference.
- Reuses existing productive bundles (cost/slippage, signal orthogonality interpretation, factor exposure, parameter sensitivity, rolling linear drift from PR #5184) without mutating source evidence, economic thresholds, or trading semantics.
- Introduces focused contract, determinism, boundary, governance, and materializer roundtrip tests plus durable manifest-verified evidence.

## Reuse decision

`REUSE_WITH_NARROW_ADAPTER` on `src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py` with materializer `scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py`.

## Source evidence (productive, manifest-verified)

| Class | Bundle |
|---|---|
| Cost/Slippage | `.../research/offline_linear_cost_model_diagnostics_v0_20260714T125628Z` |
| Signal Orthogonality | `.../research/offline_productive_signal_orthogonality_results_interpretation_v0_20260714T213029Z` |
| Factor Exposure | `.../research/offline_productive_factor_exposure_diagnostics_v0_20260714T220739Z` |
| Parameter Sensitivity | `.../research/offline_productive_parameter_sensitivity_diagnostics_v0_20260714T222747Z` |
| Rolling Linear Drift (PR #5184) | `.../research/offline_productive_rolling_linear_drift_diagnostics_v0_20260714T224214Z` |

Productive aggregate result with current sources: `AGGREGATE_STATUS=BLOCK_SUPPORT_EVIDENCE` (blocking statuses from cost, factor exposure, and rolling drift are preserved fail-closed).

## Durable evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/offline_productive_linear_diagnostics_support_bundle_v0_20260714T225556Z`

`MANIFEST_VERIFY_RC=0`, `SECOND_MATERIALIZATION_DIFF_EMPTY=true`, `MATERIALIZER_TO_VALIDATOR_ROUNDTRIP_PASS=true`.

## Authority boundaries (explicit)

- `OFFLINE_ONLY=true`
- `ECONOMIC_EVALUATION_EXECUTED=false`
- `ECONOMIC_VALIDITY_PASS_CREATED=false`
- `PROMOTION_PASS_CREATED=false`
- `STRATEGY_SELECTION_CHANGED=false`
- `PARAMETER_OPTIMIZATION_EXECUTED=false`
- `PARAMETER_DEFAULT_CHANGED=false`
- `RUNTIME_EFFECT=NONE`
- `AUTHORITY_EFFECT=NONE`
- `economic_pass_authority=false`
- `promotion_pass_authority=false`

## Test plan

- [x] `tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py` (19 tests, productive archive paths)
- [x] `tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py`
- [x] `tests/ci/test_ci_diff_aware_test_selection_v1.py`
- [x] `ruff format --check` / `ruff check` on new surfaces
- [x] Durable evidence materializer PASS with manifest verification


Made with [Cursor](https://cursor.com)