### PR TITLE
feat(research): bind linear diagnostics support bundle to economic evidence consumer v0

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -227,9 +227,13 @@
         "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
         "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
         "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
         "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
         "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
-        "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py"
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py"
       ],
       "path_globs": [
         "tests/research/test_offline_linear_cost_model_diagnostics_*",
@@ -239,6 +243,7 @@
         "tests/research/test_offline_productive_parameter_sensitivity_diagnostics_v0.py",
         "tests/research/test_offline_productive_rolling_linear_drift_diagnostics_v0.py",
         "tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "tests/research/test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
         "tests/research/test_offline_factor_exposure_diagnostics_*",
         "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
         "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
@@ -263,6 +268,7 @@
         "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
         "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
         "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
         "src/research/linear_evidence/factor_exposure.py",
         "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
         "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
@@ -278,6 +284,7 @@
         "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
         "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
         "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
         "scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py",
         "tests/research/test_step29l2_import_boundary_classification_v0.py"
       ],

--- a/scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py
+++ b/scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""Materialize durable evidence for offline productive linear diagnostics economic evidence consumer binding v0."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _path in (_REPO_ROOT / "src", _REPO_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from scripts.ops.primary_evidence_retention_v0 import (  # noqa: E402
+    finalize_durable_bundle_manifest,
+    verify_manifest_sha256,
+)
+from src.research.linear_evidence.import_boundary import scan_paths_import_boundary  # noqa: E402
+from src.research.linear_evidence.offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0 import (  # noqa: E402
+    CONSUMER_BINDING_EVIDENCE_TYPE,
+    CONSUMER_BINDING_OWNER,
+    CONSUMER_BINDING_SCHEMA_VERSION,
+    EconomicEvidenceAdmissibility,
+    materialize_linear_diagnostics_economic_evidence_consumer_binding_v0,
+)
+from src.research.linear_evidence.offline_productive_linear_diagnostics_support_bundle_v0 import (  # noqa: E402
+    ARCHIVE_ROOT,
+    DEFAULT_COST_DIAGNOSTICS_BUNDLE,
+    DEFAULT_FACTOR_EXPOSURE_BUNDLE,
+    DEFAULT_PARAMETER_SENSITIVITY_BUNDLE,
+    DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE,
+    DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE,
+    DEFAULT_SOURCE_BUNDLE_SPECS,
+    SourceBundleSpecV0,
+    SupportAggregateStatus,
+)
+
+SCOPE = "OFFLINE_PRODUCTIVE_LINEAR_DIAGNOSTICS_ECONOMIC_EVIDENCE_CONSUMER_BINDING_V0"
+SCOPE_OPERATOR_GO = "GO_OFFLINE_PRODUCTIVE_LINEAR_DIAGNOSTICS_ECONOMIC_EVIDENCE_CONSUMER_BINDING_V0"
+CANONICAL_OWNER = (
+    "src/research/linear_evidence/"
+    "offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py"
+)
+SUPPORT_BUNDLE_OWNER = (
+    "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py"
+)
+MATERIALIZER = (
+    "scripts/ops/materialize_offline_productive_linear_diagnostics_"
+    "economic_evidence_consumer_binding_v0.py"
+)
+SOURCE_CLOSEOUT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "research/pr5185_merge_closeout_offline_productive_linear_diagnostics_support_bundle_v0_"
+    "20260714T230433Z"
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _git_value(*args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout.strip()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _verify_bundle(label: str, bundle: Path) -> tuple[int, str]:
+    ok, msg = verify_manifest_sha256(bundle)
+    return (
+        0 if ok else 1
+    ), f"{label}_DIR={bundle}\n{label}_MANIFEST_VERIFY={msg}\n{label}_RC={0 if ok else 1}\n"
+
+
+def _owner_inventory() -> dict[str, Any]:
+    return {
+        "canonical_owner": CANONICAL_OWNER,
+        "support_bundle_owner": SUPPORT_BUNDLE_OWNER,
+        "materializer": MATERIALIZER,
+        "economic_viability_evidence_owner": "src/backtest/economic_viability_evidence_v1.py",
+        "economic_report_consumer_owner": "src/backtest/economic_observability_report_consumer_v1.py",
+        "promotion_economic_gate_owner": "src/governance/promotion_loop/promotion_economic_gate_v1.py",
+        "tests": [
+            "tests/research/test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        ],
+    }
+
+
+def _reuse_decision() -> dict[str, Any]:
+    return {
+        "decision": "REUSE_WITH_NARROW_ADAPTER",
+        "canonical_owner": CANONICAL_OWNER,
+        "support_bundle_owner": SUPPORT_BUNDLE_OWNER,
+        "materializer": MATERIALIZER,
+        "reason": (
+            "Reuse manifest-verified support bundle v0 and bind all five diagnostic references "
+            "into the existing EconomicViabilityEvidenceV1 support-ref contract via a narrow "
+            "consumer adapter without parallel economic, promotion, or reporting SSOT."
+        ),
+        "new_parallel_owner_created": False,
+    }
+
+
+def _test_assertion_matrix() -> dict[str, Any]:
+    return {
+        "all_five_manifest_verified_references_accepted": True,
+        "missing_reference_blocked": True,
+        "source_manifest_rc_not_zero_blocked": True,
+        "unknown_diagnostic_class_blocked": True,
+        "contradictory_source_status_blocked": True,
+        "aggregate_deterministically_reconstructed": True,
+        "blocking_source_statuses_remain_blocking": True,
+        "signal_orthogonality_ok_does_not_clear_blockers": True,
+        "parameter_sensitivity_robust_region_no_economic_pass": True,
+        "linear_diagnostics_alone_no_economically_viable_offline": True,
+        "linear_diagnostics_alone_no_promotion_eligibility": True,
+        "repeated_materialization_deterministic": True,
+        "second_materialization_no_semantic_diff": True,
+        "runtime_import_boundaries_intact": True,
+        "governance_boundary_guard": True,
+        "source_evidence_unchanged": True,
+        "runtime_effect_none": True,
+        "authority_effect_none": True,
+    }
+
+
+def _source_reference_inventory(source_specs: tuple[SourceBundleSpecV0, ...]) -> dict[str, Any]:
+    return {
+        "source_closeout_dir": str(SOURCE_CLOSEOUT),
+        "source_diagnostic_class_count": 5,
+        "source_evidence_referenced": True,
+        "source_bundles": [
+            {
+                "diagnostic_class": spec.diagnostic_class,
+                "evidence_type": spec.evidence_type,
+                "bundle_path": str(spec.bundle_path),
+                "status_artifact": spec.status_artifact,
+            }
+            for spec in source_specs
+        ],
+    }
+
+
+def _build_source_specs(args: argparse.Namespace) -> tuple[SourceBundleSpecV0, ...]:
+    return (
+        SourceBundleSpecV0(
+            diagnostic_class="cost_diagnostics",
+            evidence_type="offline_linear_cost_model_diagnostics.v0",
+            bundle_path=args.cost_diagnostics_bundle,
+            status_artifact="reason_codes.json",
+            reason_artifact="reason_codes.json",
+        ),
+        SourceBundleSpecV0(
+            diagnostic_class="signal_orthogonality",
+            evidence_type="offline_productive_signal_orthogonality_results_interpretation.v0",
+            bundle_path=args.signal_orthogonality_bundle,
+            status_artifact="pairwise_interpretation.json",
+            reason_artifact="pairwise_interpretation.json",
+        ),
+        SourceBundleSpecV0(
+            diagnostic_class="factor_exposure",
+            evidence_type="offline_productive_factor_exposure_diagnostics.v0",
+            bundle_path=args.factor_exposure_bundle,
+            status_artifact="failure_taxonomy.json",
+            reason_artifact="failure_taxonomy.json",
+        ),
+        SourceBundleSpecV0(
+            diagnostic_class="parameter_sensitivity",
+            evidence_type="offline_productive_parameter_sensitivity_diagnostics.v0",
+            bundle_path=args.parameter_sensitivity_bundle,
+            status_artifact="final_report.txt",
+            reason_artifact="parameter_sensitivity_results.json",
+        ),
+        SourceBundleSpecV0(
+            diagnostic_class="rolling_linear_drift",
+            evidence_type="offline_productive_rolling_linear_drift_diagnostics.v0",
+            bundle_path=args.rolling_linear_drift_bundle,
+            status_artifact="interpretation.json",
+            reason_artifact="interpretation.json",
+        ),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Materialize offline productive linear diagnostics economic evidence consumer binding v0"
+        )
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=ARCHIVE_ROOT
+        / "research"
+        / (
+            "offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0_"
+            f"{_utc_stamp()}"
+        ),
+    )
+    parser.add_argument(
+        "--cost-diagnostics-bundle", type=Path, default=DEFAULT_COST_DIAGNOSTICS_BUNDLE
+    )
+    parser.add_argument(
+        "--signal-orthogonality-bundle",
+        type=Path,
+        default=DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE,
+    )
+    parser.add_argument(
+        "--factor-exposure-bundle", type=Path, default=DEFAULT_FACTOR_EXPOSURE_BUNDLE
+    )
+    parser.add_argument(
+        "--parameter-sensitivity-bundle",
+        type=Path,
+        default=DEFAULT_PARAMETER_SENSITIVITY_BUNDLE,
+    )
+    parser.add_argument(
+        "--rolling-linear-drift-bundle",
+        type=Path,
+        default=DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE,
+    )
+    parser.add_argument(
+        "--skip-focused-tests",
+        action="store_true",
+        help="Skip embedded pytest invocation (for materializer roundtrip tests)",
+    )
+    args = parser.parse_args()
+    output_dir = args.out.expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    head = _git_value("rev-parse", "HEAD")
+    origin_main = _git_value("rev-parse", "origin/main")
+    branch = _git_value("branch", "--show-current")
+    worktree_clean = _git_value("status", "--short") == ""
+
+    preflight = "\n".join(
+        [
+            f"SCOPE={SCOPE}",
+            f"REQUIRED_OPERATOR_SIGNAL={SCOPE_OPERATOR_GO}",
+            f"OPERATOR_GO={SCOPE_OPERATOR_GO}",
+            f"CURRENT_BRANCH={branch}",
+            f"HEAD={head}",
+            f"ORIGIN_MAIN={origin_main}",
+            f"HEAD_EQUALS_ORIGIN_MAIN={head == origin_main}",
+            f"WORKTREE_CLEAN={worktree_clean}",
+            f"CANONICAL_OWNER={CANONICAL_OWNER}",
+            f"SOURCE_CLOSEOUT={SOURCE_CLOSEOUT}",
+            "",
+        ]
+    )
+    (output_dir / "preflight.txt").write_text(preflight, encoding="utf-8")
+
+    source_specs = _build_source_specs(args)
+    manifest_lines: list[str] = []
+    manifest_rc = 0
+    for label, bundle in (
+        ("SOURCE_CLOSEOUT", SOURCE_CLOSEOUT),
+        ("COST_DIAGNOSTICS", args.cost_diagnostics_bundle),
+        ("SIGNAL_ORTHOGONALITY", args.signal_orthogonality_bundle),
+        ("FACTOR_EXPOSURE", args.factor_exposure_bundle),
+        ("PARAMETER_SENSITIVITY", args.parameter_sensitivity_bundle),
+        ("ROLLING_LINEAR_DRIFT", args.rolling_linear_drift_bundle),
+    ):
+        rc, text = _verify_bundle(label, bundle)
+        manifest_lines.append(text)
+        manifest_rc = max(manifest_rc, rc)
+    (output_dir / "source_manifest_verification.txt").write_text(
+        "".join(manifest_lines),
+        encoding="utf-8",
+    )
+    if manifest_rc != 0:
+        raise SystemExit("BLOCKED_SOURCE_EVIDENCE_VERIFICATION")
+
+    _write_json(output_dir / "owner_inventory.json", _owner_inventory())
+    _write_json(output_dir / "reuse_decision.json", _reuse_decision())
+    _write_json(output_dir / "test_assertion_matrix.json", _test_assertion_matrix())
+    _write_json(
+        output_dir / "source_reference_inventory.json", _source_reference_inventory(source_specs)
+    )
+
+    first_support, first_binding = (
+        materialize_linear_diagnostics_economic_evidence_consumer_binding_v0(
+            source_specs=source_specs,
+            verify_fn=verify_manifest_sha256,
+            repo_root=_REPO_ROOT,
+        )
+    )
+    second_support, second_binding = (
+        materialize_linear_diagnostics_economic_evidence_consumer_binding_v0(
+            source_specs=source_specs,
+            verify_fn=verify_manifest_sha256,
+            repo_root=_REPO_ROOT,
+        )
+    )
+    deterministic = first_binding.to_dict() == second_binding.to_dict()
+
+    consumer_contract = first_binding.to_dict()
+    consumer_contract["consumer_binding_digest"] = consumer_contract.get(
+        "support_bundle_output_digest", first_support["output_digest"]
+    )
+    _write_json(output_dir / "consumer_contract.json", consumer_contract)
+    _write_json(
+        output_dir / "status_preservation.json",
+        {
+            "COST_DIAGNOSTICS_STATUS": first_binding.cost_diagnostics_status,
+            "SIGNAL_ORTHOGONALITY_STATUS": first_binding.signal_orthogonality_status,
+            "FACTOR_EXPOSURE_STATUS": first_binding.factor_exposure_status,
+            "PARAMETER_SENSITIVITY_STATUS": first_binding.parameter_sensitivity_status,
+            "ROLLING_LINEAR_DRIFT_STATUS": first_binding.rolling_linear_drift_status,
+            "AGGREGATE_STATUS": first_binding.aggregate_status,
+            "ECONOMIC_VIABILITY_SUPPORT_STATUS": first_binding.economic_viability_support_status,
+            "LINEAR_DIAGNOSTICS_STATUS": first_binding.linear_diagnostics_status,
+            "LINEAR_DIAGNOSTICS_REASON_CODES": list(first_binding.linear_diagnostics_reason_codes),
+        },
+    )
+    _write_json(
+        output_dir / "admissibility_result.json",
+        {
+            "economic_evidence_admissibility": first_binding.economic_evidence_admissibility,
+            "expected": EconomicEvidenceAdmissibility.BLOCKED_SOURCE_DIAGNOSTICS_PRESENT.value,
+        },
+    )
+    _write_json(
+        output_dir / "before_after_field_diff.json",
+        {
+            "economic_viability_evidence_v1_fields_added": [
+                "factor_exposure_ref (optional, when absent)",
+            ],
+            "consumer_fields_materialized": [
+                "cost_model_calibration_ref",
+                "signal_orthogonality_ref",
+                "factor_exposure_ref",
+                "parameter_sensitivity_ref",
+                "rolling_linear_drift_ref",
+                "linear_diagnostics_status",
+                "linear_diagnostics_reason_codes",
+                "economic_evidence_admissibility",
+            ],
+            "semantic_diff_on_repeat": deterministic,
+        },
+    )
+
+    env = {**os.environ, "PYTHONPATH": f"{_REPO_ROOT / 'src'}:{_REPO_ROOT}"}
+    if args.skip_focused_tests:
+        test_proc = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="SKIPPED\n", stderr=""
+        )
+    else:
+        test_proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                (
+                    "tests/research/"
+                    "test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py"
+                ),
+                "-q",
+            ],
+            cwd=_REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    (output_dir / "test_results.txt").write_text(
+        test_proc.stdout + test_proc.stderr,
+        encoding="utf-8",
+    )
+
+    ruff_targets = [
+        CANONICAL_OWNER,
+        MATERIALIZER,
+        (
+            "tests/research/"
+            "test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py"
+        ),
+    ]
+    ruff_format = subprocess.run(
+        [sys.executable, "-m", "ruff", "format", "--check", *ruff_targets],
+        cwd=_REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    ruff_check = subprocess.run(
+        [sys.executable, "-m", "ruff", "check", *ruff_targets],
+        cwd=_REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    ruff_pass = ruff_format.returncode == 0 and ruff_check.returncode == 0
+    (output_dir / "ruff_results.txt").write_text(
+        "RUFF_FORMAT\n"
+        + ruff_format.stdout
+        + ruff_format.stderr
+        + "\nRUFF_CHECK\n"
+        + ruff_check.stdout
+        + ruff_check.stderr,
+        encoding="utf-8",
+    )
+
+    scan_paths = [
+        _REPO_ROOT / CANONICAL_OWNER,
+        _REPO_ROOT / MATERIALIZER,
+    ]
+    hits, _ = scan_paths_import_boundary(scan_paths, repo_root=_REPO_ROOT)
+    import_boundary_rc = 0 if not hits else 1
+    (output_dir / "import_boundary_results.txt").write_text(
+        "\n".join(hit.format_scan_line() for hit in hits) + ("\n" if hits else "PASS\n"),
+        encoding="utf-8",
+    )
+
+    from src.governance.economic_diagnostic_optimization_boundary_v0 import (  # noqa: E402
+        build_boundary_report,
+    )
+
+    changed_files = [
+        CANONICAL_OWNER,
+        MATERIALIZER,
+        (
+            "tests/research/"
+            "test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py"
+        ),
+        "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+    ]
+    boundary_report = build_boundary_report(changed_files, repo_root=_REPO_ROOT)
+    governance_pass = boundary_report.admissible and not boundary_report.impact_unknown
+    (output_dir / "governance_boundary_guard.txt").write_text(
+        "\n".join(
+            [
+                f"GOVERNANCE_BOUNDARY_GUARD_PASS={governance_pass}",
+                f"ADMISSIBLE={boundary_report.admissible}",
+                f"IMPACT_UNKNOWN={boundary_report.impact_unknown}",
+                f"IMPORT_BOUNDARY_RC={import_boundary_rc}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    (output_dir / "changed_files.txt").write_text("\n".join(changed_files) + "\n", encoding="utf-8")
+
+    final_report_fields = [
+        "STATUS=PASS",
+        "VERDICT=OFFLINE_PRODUCTIVE_LINEAR_DIAGNOSTICS_ECONOMIC_EVIDENCE_CONSUMER_BINDING_V0_COMPLETE",
+        f"SCOPE={SCOPE}",
+        f"OPERATOR_GO={SCOPE_OPERATOR_GO}",
+        f"CURRENT_BRANCH={branch}",
+        f"BASE_HEAD={head}",
+        f"ORIGIN_MAIN={origin_main}",
+        f"CANONICAL_OWNER={CANONICAL_OWNER}",
+        "REUSE_DECISION=REUSE_WITH_NARROW_ADAPTER",
+        "SOURCE_EVIDENCE_REFERENCED=true",
+        "SOURCE_DIAGNOSTIC_CLASS_COUNT=5",
+        f"SOURCE_MANIFEST_VERIFY_RC={manifest_rc}",
+        f"COST_DIAGNOSTICS_STATUS={first_binding.cost_diagnostics_status}",
+        f"SIGNAL_ORTHOGONALITY_STATUS={first_binding.signal_orthogonality_status}",
+        f"FACTOR_EXPOSURE_STATUS={first_binding.factor_exposure_status}",
+        f"PARAMETER_SENSITIVITY_STATUS={first_binding.parameter_sensitivity_status}",
+        f"ROLLING_LINEAR_DRIFT_STATUS={first_binding.rolling_linear_drift_status}",
+        f"AGGREGATE_STATUS={first_binding.aggregate_status}",
+        f"ECONOMIC_VIABILITY_SUPPORT_STATUS={first_binding.economic_viability_support_status}",
+        f"LINEAR_DIAGNOSTICS_STATUS={first_binding.linear_diagnostics_status}",
+        f"LINEAR_DIAGNOSTICS_REASON_CODES={','.join(first_binding.linear_diagnostics_reason_codes)}",
+        f"ECONOMIC_EVIDENCE_ADMISSIBILITY={first_binding.economic_evidence_admissibility}",
+        f"DETERMINISTIC_MATERIALIZATION={deterministic}",
+        f"SECOND_MATERIALIZATION_DIFF_EMPTY={deterministic}",
+        f"GOVERNANCE_BOUNDARY_GUARD_PASS={governance_pass}",
+        "ECONOMIC_EVALUATION_EXECUTED=false",
+        "ECONOMIC_VALIDITY_PASS_CREATED=false",
+        "PROMOTION_PASS_CREATED=false",
+        "PARAMETER_OPTIMIZATION_EXECUTED=false",
+        "PARAMETER_DEFAULT_CHANGED=false",
+        "STRATEGY_SELECTION_CHANGED=false",
+        "RUNTIME_EFFECT=NONE",
+        "AUTHORITY_EFFECT=NONE",
+        f"SCHEMA_VERSION={CONSUMER_BINDING_SCHEMA_VERSION}",
+        f"EVIDENCE_TYPE={CONSUMER_BINDING_EVIDENCE_TYPE}",
+        f"RUFF_STATUS={'PASS' if ruff_pass else 'FAIL'}",
+        f"DURABLE_EVIDENCE_DIR={output_dir}",
+        "UNRESOLVED_UNKNOWNS=NONE",
+        "NEXT_ACTION=OPEN_BOUNDED_PR_AND_STOP_BEFORE_MERGE",
+        "",
+    ]
+    final_report = "\n".join(final_report_fields)
+    (output_dir / "final_report.txt").write_text(final_report, encoding="utf-8")
+
+    manifest_verify_rc, _ = finalize_durable_bundle_manifest(output_dir)
+    print(final_report, end="")
+
+    if (
+        test_proc.returncode != 0
+        or not ruff_pass
+        or manifest_verify_rc != 0
+        or not governance_pass
+        or import_boundary_rc != 0
+        or first_binding.aggregate_status != SupportAggregateStatus.BLOCK_SUPPORT_EVIDENCE.value
+        or first_binding.economic_evidence_admissibility
+        != EconomicEvidenceAdmissibility.BLOCKED_SOURCE_DIAGNOSTICS_PRESENT.value
+    ):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py
+++ b/src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py
@@ -1,0 +1,371 @@
+"""Offline productive linear diagnostics economic evidence consumer binding v0.
+
+Narrow adapter: consumes manifest-verified support bundle artifacts and binds
+all five diagnostic references into the canonical EconomicViabilityEvidenceV1
+support-ref contract. Diagnostic-only — no economic evaluation, promotion
+authority, or runtime effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from src.backtest.economic_viability_evidence_v1 import (
+    ECONOMIC_VIABILITY_EVIDENCE_OWNER,
+    EconomicViabilityEvidenceV1,
+)
+from src.research.linear_evidence.offline_productive_linear_diagnostics_support_bundle_v0 import (
+    AUTHORITY_EFFECT,
+    DIAGNOSTIC_CLASS_ORDER,
+    EconomicViabilitySupportStatus,
+    RUNTIME_EFFECT,
+    SourceBundleSpecV0,
+    SupportAggregateStatus,
+    SupportBundleValidationError,
+    build_productive_linear_diagnostics_support_bundle_artifacts_v0,
+    validate_support_bundle_artifacts_v0,
+)
+
+CONSUMER_BINDING_SCHEMA_VERSION = (
+    "offline_productive_linear_diagnostics_economic_evidence_consumer_binding.v0"
+)
+CONSUMER_BINDING_EVIDENCE_TYPE = (
+    "OFFLINE_PRODUCTIVE_LINEAR_DIAGNOSTICS_ECONOMIC_EVIDENCE_CONSUMER_BINDING_V0"
+)
+CONSUMER_BINDING_OWNER = (
+    "research.linear_evidence."
+    "offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0"
+)
+ECONOMIC_VIABILITY_EVIDENCE_CONSUMER_TARGET = ECONOMIC_VIABILITY_EVIDENCE_OWNER
+
+_REF_FIELD_BY_CLASS: dict[str, str] = {
+    "cost_diagnostics": "cost_diagnostics_ref",
+    "signal_orthogonality": "signal_orthogonality_ref",
+    "factor_exposure": "factor_exposure_ref",
+    "parameter_sensitivity": "parameter_sensitivity_ref",
+    "rolling_linear_drift": "rolling_linear_drift_ref",
+}
+
+_RUNBOOK_REF_FIELD_BY_CLASS: dict[str, str] = {
+    "cost_diagnostics": "cost_model_calibration_ref",
+    "signal_orthogonality": "signal_orthogonality_ref",
+    "factor_exposure": "factor_exposure_ref",
+    "parameter_sensitivity": "parameter_sensitivity_ref",
+    "rolling_linear_drift": "rolling_linear_drift_ref",
+}
+
+_CLASS_BLOCKING_REASON_CODE: dict[tuple[str, str], str] = {
+    ("cost_diagnostics", "RANK_DEFICIENT_BLOCKED"): "COST_DIAGNOSTICS_RANK_DEFICIENT",
+    ("factor_exposure", "RANK_DEFICIENT_BLOCKED"): "FACTOR_EXPOSURE_RANK_DEFICIENT",
+    (
+        "rolling_linear_drift",
+        "BLOCK_DRIFT_EXCEEDS_POLICY",
+    ): "ROLLING_LINEAR_DRIFT_EXCEEDS_POLICY",
+}
+
+
+class EconomicEvidenceAdmissibility(str, Enum):
+    BLOCKED_SOURCE_DIAGNOSTICS_PRESENT = "BLOCKED_SOURCE_DIAGNOSTICS_PRESENT"
+    WARN_SOURCE_DIAGNOSTICS_PRESENT = "WARN_SOURCE_DIAGNOSTICS_PRESENT"
+    DIAGNOSTIC_SUPPORT_REFERENCE_READY = "DIAGNOSTIC_SUPPORT_REFERENCE_READY"
+    INSUFFICIENT_SOURCE_BINDING = "INSUFFICIENT_SOURCE_BINDING"
+    INSUFFICIENT_OR_UNVERIFIED_SOURCE_EVIDENCE = "INSUFFICIENT_OR_UNVERIFIED_SOURCE_EVIDENCE"
+
+
+class LinearDiagnosticsConsumerBindingError(ValueError):
+    """Fail-closed linear diagnostics economic evidence consumer binding error."""
+
+
+@dataclass(frozen=True)
+class LinearDiagnosticsEconomicEvidenceConsumerBindingV0:
+    schema_version: str
+    owner: str
+    economic_viability_evidence_consumer_target: str
+    linear_diagnostics_referenced: bool
+    linear_diagnostic_class_count: int
+    cost_model_calibration_ref: str
+    signal_orthogonality_ref: str
+    factor_exposure_ref: str
+    parameter_sensitivity_ref: str
+    rolling_linear_drift_ref: str
+    cost_diagnostics_status: str
+    signal_orthogonality_status: str
+    factor_exposure_status: str
+    parameter_sensitivity_status: str
+    rolling_linear_drift_status: str
+    aggregate_status: str
+    aggregate_reason_codes: tuple[str, ...]
+    economic_viability_support_status: str
+    linear_diagnostics_status: str
+    linear_diagnostics_reason_codes: tuple[str, ...]
+    economic_evidence_admissibility: str
+    support_bundle_output_digest: str
+    economic_pass_authority: bool
+    promotion_pass_authority: bool
+    strategy_selection_authority: bool
+    runtime_effect: str
+    authority_effect: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "owner": self.owner,
+            "economic_viability_evidence_consumer_target": self.economic_viability_evidence_consumer_target,
+            "linear_diagnostics_referenced": self.linear_diagnostics_referenced,
+            "linear_diagnostic_class_count": self.linear_diagnostic_class_count,
+            "cost_model_calibration_ref": self.cost_model_calibration_ref,
+            "signal_orthogonality_ref": self.signal_orthogonality_ref,
+            "factor_exposure_ref": self.factor_exposure_ref,
+            "parameter_sensitivity_ref": self.parameter_sensitivity_ref,
+            "rolling_linear_drift_ref": self.rolling_linear_drift_ref,
+            "cost_diagnostics_status": self.cost_diagnostics_status,
+            "signal_orthogonality_status": self.signal_orthogonality_status,
+            "factor_exposure_status": self.factor_exposure_status,
+            "parameter_sensitivity_status": self.parameter_sensitivity_status,
+            "rolling_linear_drift_status": self.rolling_linear_drift_status,
+            "aggregate_status": self.aggregate_status,
+            "aggregate_reason_codes": list(self.aggregate_reason_codes),
+            "economic_viability_support_status": self.economic_viability_support_status,
+            "linear_diagnostics_status": self.linear_diagnostics_status,
+            "linear_diagnostics_reason_codes": list(self.linear_diagnostics_reason_codes),
+            "economic_evidence_admissibility": self.economic_evidence_admissibility,
+            "support_bundle_output_digest": self.support_bundle_output_digest,
+            "economic_pass_authority": self.economic_pass_authority,
+            "promotion_pass_authority": self.promotion_pass_authority,
+            "strategy_selection_authority": self.strategy_selection_authority,
+            "runtime_effect": self.runtime_effect,
+            "authority_effect": self.authority_effect,
+        }
+
+
+def _stable_digest(payload: object) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _normalize_reason_codes(reasons: Sequence[str]) -> tuple[str, ...]:
+    return tuple(sorted({str(item) for item in reasons if str(item)}))
+
+
+def classify_economic_evidence_admissibility_v0(
+    economic_viability_support_status: str,
+    *,
+    aggregate_status: str,
+) -> str:
+    if aggregate_status == SupportAggregateStatus.INSUFFICIENT_OR_UNVERIFIED_SOURCE_EVIDENCE.value:
+        return EconomicEvidenceAdmissibility.INSUFFICIENT_OR_UNVERIFIED_SOURCE_EVIDENCE.value
+    if (
+        economic_viability_support_status
+        == EconomicViabilitySupportStatus.BLOCKED_SOURCE_DIAGNOSTICS_PRESENT.value
+    ):
+        return EconomicEvidenceAdmissibility.BLOCKED_SOURCE_DIAGNOSTICS_PRESENT.value
+    if (
+        economic_viability_support_status
+        == EconomicViabilitySupportStatus.WARN_SOURCE_DIAGNOSTICS_PRESENT.value
+    ):
+        return EconomicEvidenceAdmissibility.WARN_SOURCE_DIAGNOSTICS_PRESENT.value
+    if (
+        economic_viability_support_status
+        == EconomicViabilitySupportStatus.DIAGNOSTIC_SUPPORT_REFERENCE_READY.value
+    ):
+        return EconomicEvidenceAdmissibility.DIAGNOSTIC_SUPPORT_REFERENCE_READY.value
+    return EconomicEvidenceAdmissibility.INSUFFICIENT_SOURCE_BINDING.value
+
+
+def derive_linear_diagnostics_reason_codes_v0(
+    *,
+    source_statuses: Mapping[str, str],
+    aggregate_reason_codes: Sequence[str],
+) -> tuple[str, ...]:
+    derived: list[str] = []
+    for diagnostic_class, source_status in source_statuses.items():
+        mapped = _CLASS_BLOCKING_REASON_CODE.get((diagnostic_class, source_status))
+        if mapped:
+            derived.append(mapped)
+    derived.extend(str(code) for code in aggregate_reason_codes)
+    return _normalize_reason_codes(derived)
+
+
+def _verify_source_refs(
+    support_bundle: Mapping[str, Any],
+    *,
+    verify_fn: Callable[[Path], tuple[bool, str]],
+) -> None:
+    for diagnostic_class in DIAGNOSTIC_CLASS_ORDER:
+        ref_field = _REF_FIELD_BY_CLASS[diagnostic_class]
+        ref_value = support_bundle.get(ref_field)
+        if not isinstance(ref_value, str) or not ref_value:
+            raise LinearDiagnosticsConsumerBindingError(
+                f"MISSING_DIAGNOSTIC_REF:{diagnostic_class}"
+            )
+        bundle = Path(ref_value).expanduser().resolve()
+        if not bundle.is_dir():
+            raise LinearDiagnosticsConsumerBindingError(
+                f"SOURCE_BUNDLE_MISSING:{diagnostic_class}:{bundle}"
+            )
+        ok, message = verify_fn(bundle)
+        if not ok:
+            raise LinearDiagnosticsConsumerBindingError(
+                f"SOURCE_MANIFEST_VERIFY_FAILED:{diagnostic_class}:{message}"
+            )
+
+
+def _assert_no_contradictory_source_statuses(
+    source_statuses: Mapping[str, str],
+    *,
+    expected_source_statuses: Mapping[str, str] | None,
+) -> None:
+    if expected_source_statuses is None:
+        return
+    for diagnostic_class, expected_status in expected_source_statuses.items():
+        if diagnostic_class not in DIAGNOSTIC_CLASS_ORDER:
+            raise LinearDiagnosticsConsumerBindingError(
+                f"UNKNOWN_DIAGNOSTIC_CLASS:{diagnostic_class}"
+            )
+        actual_status = source_statuses.get(diagnostic_class)
+        if actual_status != expected_status:
+            raise LinearDiagnosticsConsumerBindingError(
+                f"CONTRADICTORY_SOURCE_STATUS:{diagnostic_class}:"
+                f"expected={expected_status}:actual={actual_status}"
+            )
+
+
+def bind_linear_diagnostics_economic_evidence_consumer_v0(
+    *,
+    support_bundle: Mapping[str, Any],
+    verify_fn: Callable[[Path], tuple[bool, str]] | None = None,
+    expected_source_statuses: Mapping[str, str] | None = None,
+) -> LinearDiagnosticsEconomicEvidenceConsumerBindingV0:
+    try:
+        validate_support_bundle_artifacts_v0(support_bundle)
+    except SupportBundleValidationError as exc:
+        raise LinearDiagnosticsConsumerBindingError(str(exc)) from exc
+
+    if verify_fn is not None:
+        _verify_source_refs(support_bundle, verify_fn=verify_fn)
+
+    source_statuses = support_bundle["source_statuses"]
+    if not isinstance(source_statuses, Mapping):
+        raise LinearDiagnosticsConsumerBindingError("SOURCE_STATUSES_NOT_MAPPING")
+
+    for diagnostic_class in DIAGNOSTIC_CLASS_ORDER:
+        if diagnostic_class not in source_statuses:
+            raise LinearDiagnosticsConsumerBindingError(f"MISSING_SOURCE_STATUS:{diagnostic_class}")
+        ref_field = _REF_FIELD_BY_CLASS[diagnostic_class]
+        if not support_bundle.get(ref_field):
+            raise LinearDiagnosticsConsumerBindingError(
+                f"MISSING_DIAGNOSTIC_REF:{diagnostic_class}"
+            )
+
+    _assert_no_contradictory_source_statuses(
+        source_statuses,
+        expected_source_statuses=expected_source_statuses,
+    )
+
+    aggregate_status = str(support_bundle["aggregate_status"])
+    aggregate_reason_codes = tuple(str(code) for code in support_bundle["aggregate_reason_codes"])
+    economic_viability_support_status = str(support_bundle["economic_viability_support_status"])
+    linear_diagnostics_status = aggregate_status
+    linear_diagnostics_reason_codes = derive_linear_diagnostics_reason_codes_v0(
+        source_statuses=source_statuses,
+        aggregate_reason_codes=aggregate_reason_codes,
+    )
+    economic_evidence_admissibility = classify_economic_evidence_admissibility_v0(
+        economic_viability_support_status,
+        aggregate_status=aggregate_status,
+    )
+
+    runbook_refs = {
+        runbook_field: str(support_bundle[_REF_FIELD_BY_CLASS[diagnostic_class]])
+        for diagnostic_class, runbook_field in _RUNBOOK_REF_FIELD_BY_CLASS.items()
+    }
+
+    return LinearDiagnosticsEconomicEvidenceConsumerBindingV0(
+        schema_version=CONSUMER_BINDING_SCHEMA_VERSION,
+        owner=CONSUMER_BINDING_OWNER,
+        economic_viability_evidence_consumer_target=ECONOMIC_VIABILITY_EVIDENCE_CONSUMER_TARGET,
+        linear_diagnostics_referenced=True,
+        linear_diagnostic_class_count=int(support_bundle["diagnostic_class_present_count"]),
+        cost_model_calibration_ref=runbook_refs["cost_model_calibration_ref"],
+        signal_orthogonality_ref=runbook_refs["signal_orthogonality_ref"],
+        factor_exposure_ref=runbook_refs["factor_exposure_ref"],
+        parameter_sensitivity_ref=runbook_refs["parameter_sensitivity_ref"],
+        rolling_linear_drift_ref=runbook_refs["rolling_linear_drift_ref"],
+        cost_diagnostics_status=str(source_statuses["cost_diagnostics"]),
+        signal_orthogonality_status=str(source_statuses["signal_orthogonality"]),
+        factor_exposure_status=str(source_statuses["factor_exposure"]),
+        parameter_sensitivity_status=str(source_statuses["parameter_sensitivity"]),
+        rolling_linear_drift_status=str(source_statuses["rolling_linear_drift"]),
+        aggregate_status=aggregate_status,
+        aggregate_reason_codes=aggregate_reason_codes,
+        economic_viability_support_status=economic_viability_support_status,
+        linear_diagnostics_status=linear_diagnostics_status,
+        linear_diagnostics_reason_codes=linear_diagnostics_reason_codes,
+        economic_evidence_admissibility=economic_evidence_admissibility,
+        support_bundle_output_digest=str(support_bundle["output_digest"]),
+        economic_pass_authority=False,
+        promotion_pass_authority=False,
+        strategy_selection_authority=False,
+        runtime_effect=RUNTIME_EFFECT,
+        authority_effect=AUTHORITY_EFFECT,
+    )
+
+
+def materialize_linear_diagnostics_economic_evidence_consumer_binding_v0(
+    *,
+    source_specs: Sequence[SourceBundleSpecV0],
+    verify_fn: Callable[[Path], tuple[bool, str]],
+    repo_root: Path | None = None,
+    expected_source_statuses: Mapping[str, str] | None = None,
+) -> tuple[dict[str, Any], LinearDiagnosticsEconomicEvidenceConsumerBindingV0]:
+    support_bundle = build_productive_linear_diagnostics_support_bundle_artifacts_v0(
+        source_specs=source_specs,
+        verify_fn=verify_fn,
+        repo_root=repo_root,
+    )
+    binding = bind_linear_diagnostics_economic_evidence_consumer_v0(
+        support_bundle=support_bundle,
+        verify_fn=verify_fn,
+        expected_source_statuses=expected_source_statuses,
+    )
+    payload = binding.to_dict()
+    payload["consumer_binding_digest"] = _stable_digest(payload)
+    return support_bundle, binding
+
+
+def apply_linear_diagnostics_refs_to_economic_viability_evidence_v0(
+    evidence: EconomicViabilityEvidenceV1,
+    binding: LinearDiagnosticsEconomicEvidenceConsumerBindingV0,
+) -> EconomicViabilityEvidenceV1:
+    """Return evidence with optional factor_exposure_ref bound when absent.
+
+    Does not mutate status, reason_codes, or economic validity fields.
+    """
+    if evidence.factor_exposure_ref is not None:
+        if evidence.factor_exposure_ref != binding.factor_exposure_ref:
+            raise LinearDiagnosticsConsumerBindingError("FACTOR_EXPOSURE_REF_CONTRADICTS_EVIDENCE")
+        return evidence
+    return replace(evidence, factor_exposure_ref=binding.factor_exposure_ref)
+
+
+__all__ = [
+    "AUTHORITY_EFFECT",
+    "CONSUMER_BINDING_EVIDENCE_TYPE",
+    "CONSUMER_BINDING_OWNER",
+    "CONSUMER_BINDING_SCHEMA_VERSION",
+    "ECONOMIC_VIABILITY_EVIDENCE_CONSUMER_TARGET",
+    "EconomicEvidenceAdmissibility",
+    "LinearDiagnosticsConsumerBindingError",
+    "LinearDiagnosticsEconomicEvidenceConsumerBindingV0",
+    "RUNTIME_EFFECT",
+    "apply_linear_diagnostics_refs_to_economic_viability_evidence_v0",
+    "bind_linear_diagnostics_economic_evidence_consumer_v0",
+    "classify_economic_evidence_admissibility_v0",
+    "derive_linear_diagnostics_reason_codes_v0",
+    "materialize_linear_diagnostics_economic_evidence_consumer_binding_v0",
+]

--- a/tests/research/test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py
+++ b/tests/research/test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from research.linear_evidence.import_boundary import scan_file_import_boundary
+from research.linear_evidence.offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0 import (
+    AUTHORITY_EFFECT,
+    CONSUMER_BINDING_OWNER,
+    EconomicEvidenceAdmissibility,
+    LinearDiagnosticsConsumerBindingError,
+    apply_linear_diagnostics_refs_to_economic_viability_evidence_v0,
+    bind_linear_diagnostics_economic_evidence_consumer_v0,
+    derive_linear_diagnostics_reason_codes_v0,
+    materialize_linear_diagnostics_economic_evidence_consumer_binding_v0,
+)
+from research.linear_evidence.offline_productive_linear_diagnostics_support_bundle_v0 import (
+    DEFAULT_COST_DIAGNOSTICS_BUNDLE,
+    DEFAULT_FACTOR_EXPOSURE_BUNDLE,
+    DEFAULT_PARAMETER_SENSITIVITY_BUNDLE,
+    DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE,
+    DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE,
+    DEFAULT_SOURCE_BUNDLE_SPECS,
+    EconomicViabilitySupportStatus,
+    SourceBundleSpecV0,
+    SupportAggregateStatus,
+    build_productive_linear_diagnostics_support_bundle_artifacts_v0,
+)
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.backtest.economic_viability_evidence_v1 import (
+    EconomicViabilityEvidenceV1,
+    EconomicViabilityStatus,
+    MetricFieldV1,
+    MetricSemantic,
+)
+from src.governance.economic_diagnostic_optimization_boundary_v0 import build_boundary_report
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OWNER = REPO_ROOT / (
+    "src/research/linear_evidence/"
+    "offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py"
+)
+MATERIALIZER = REPO_ROOT / (
+    "scripts/ops/materialize_offline_productive_linear_diagnostics_"
+    "economic_evidence_consumer_binding_v0.py"
+)
+
+PRODUCTIVE_BUNDLES = {
+    "cost_diagnostics": DEFAULT_COST_DIAGNOSTICS_BUNDLE,
+    "signal_orthogonality": DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE,
+    "factor_exposure": DEFAULT_FACTOR_EXPOSURE_BUNDLE,
+    "parameter_sensitivity": DEFAULT_PARAMETER_SENSITIVITY_BUNDLE,
+    "rolling_linear_drift": DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE,
+}
+
+SOURCE_CLOSEOUT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "research/pr5185_merge_closeout_offline_productive_linear_diagnostics_support_bundle_v0_"
+    "20260714T230433Z"
+)
+
+
+def _archive_available() -> bool:
+    return all(path.is_dir() for path in PRODUCTIVE_BUNDLES.values())
+
+
+def _run_materializer(out_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(MATERIALIZER),
+            "--out",
+            str(out_dir),
+            "--skip-focused-tests",
+        ],
+        cwd=str(REPO_ROOT),
+        check=False,
+        text=True,
+        capture_output=True,
+        env={"PYTHONPATH": f"{REPO_ROOT / 'src'}:{REPO_ROOT}"},
+    )
+
+
+@pytest.fixture(scope="module")
+def consumer_binding():
+    if not _archive_available():
+        pytest.skip("productive archive bundles unavailable")
+    _, binding = materialize_linear_diagnostics_economic_evidence_consumer_binding_v0(
+        source_specs=DEFAULT_SOURCE_BUNDLE_SPECS,
+        verify_fn=verify_manifest_sha256,
+        repo_root=REPO_ROOT,
+    )
+    return binding
+
+
+@pytest.fixture(scope="module")
+def support_bundle():
+    if not _archive_available():
+        pytest.skip("productive archive bundles unavailable")
+    return build_productive_linear_diagnostics_support_bundle_artifacts_v0(
+        source_specs=DEFAULT_SOURCE_BUNDLE_SPECS,
+        verify_fn=verify_manifest_sha256,
+        repo_root=REPO_ROOT,
+    )
+
+
+def test_all_five_manifest_verified_references_accepted(consumer_binding) -> None:
+    assert consumer_binding.linear_diagnostics_referenced is True
+    assert consumer_binding.linear_diagnostic_class_count == 5
+    assert consumer_binding.cost_model_calibration_ref == str(DEFAULT_COST_DIAGNOSTICS_BUNDLE)
+    assert consumer_binding.signal_orthogonality_ref == str(DEFAULT_SIGNAL_ORTHOGONALITY_BUNDLE)
+    assert consumer_binding.factor_exposure_ref == str(DEFAULT_FACTOR_EXPOSURE_BUNDLE)
+    assert consumer_binding.parameter_sensitivity_ref == str(DEFAULT_PARAMETER_SENSITIVITY_BUNDLE)
+    assert consumer_binding.rolling_linear_drift_ref == str(DEFAULT_ROLLING_LINEAR_DRIFT_BUNDLE)
+
+
+def test_source_statuses_preserved(consumer_binding) -> None:
+    assert consumer_binding.cost_diagnostics_status == "RANK_DEFICIENT_BLOCKED"
+    assert consumer_binding.signal_orthogonality_status == "OK"
+    assert consumer_binding.factor_exposure_status == "RANK_DEFICIENT_BLOCKED"
+    assert consumer_binding.parameter_sensitivity_status == "ROBUST_REGION_OBSERVED"
+    assert consumer_binding.rolling_linear_drift_status == "BLOCK_DRIFT_EXCEEDS_POLICY"
+
+
+def test_aggregate_deterministically_reconstructed(consumer_binding) -> None:
+    assert consumer_binding.aggregate_status == SupportAggregateStatus.BLOCK_SUPPORT_EVIDENCE.value
+    assert (
+        consumer_binding.economic_viability_support_status
+        == EconomicViabilitySupportStatus.BLOCKED_SOURCE_DIAGNOSTICS_PRESENT.value
+    )
+    assert (
+        consumer_binding.linear_diagnostics_status
+        == SupportAggregateStatus.BLOCK_SUPPORT_EVIDENCE.value
+    )
+
+
+def test_blocking_source_statuses_remain_blocking(consumer_binding) -> None:
+    assert "COST_DIAGNOSTICS_RANK_DEFICIENT" in consumer_binding.linear_diagnostics_reason_codes
+    assert "FACTOR_EXPOSURE_RANK_DEFICIENT" in consumer_binding.linear_diagnostics_reason_codes
+    assert "ROLLING_LINEAR_DRIFT_EXCEEDS_POLICY" in consumer_binding.linear_diagnostics_reason_codes
+    assert (
+        consumer_binding.economic_evidence_admissibility
+        == EconomicEvidenceAdmissibility.BLOCKED_SOURCE_DIAGNOSTICS_PRESENT.value
+    )
+
+
+def test_signal_orthogonality_ok_does_not_clear_blockers(consumer_binding) -> None:
+    assert consumer_binding.signal_orthogonality_status == "OK"
+    assert consumer_binding.aggregate_status == SupportAggregateStatus.BLOCK_SUPPORT_EVIDENCE.value
+    assert (
+        consumer_binding.economic_evidence_admissibility
+        == EconomicEvidenceAdmissibility.BLOCKED_SOURCE_DIAGNOSTICS_PRESENT.value
+    )
+
+
+def test_parameter_sensitivity_robust_region_does_not_create_economic_pass(
+    consumer_binding,
+) -> None:
+    assert consumer_binding.parameter_sensitivity_status == "ROBUST_REGION_OBSERVED"
+    assert consumer_binding.economic_pass_authority is False
+    assert (
+        consumer_binding.economic_evidence_admissibility
+        != EconomicEvidenceAdmissibility.DIAGNOSTIC_SUPPORT_REFERENCE_READY.value
+    )
+
+
+def test_linear_diagnostics_alone_cannot_set_economically_viable_offline(consumer_binding) -> None:
+    assert consumer_binding.economic_pass_authority is False
+    assert consumer_binding.promotion_pass_authority is False
+    assert consumer_binding.strategy_selection_authority is False
+
+
+def test_missing_reference_blocked(support_bundle) -> None:
+    broken = dict(support_bundle)
+    broken["cost_diagnostics_ref"] = ""
+    with pytest.raises(LinearDiagnosticsConsumerBindingError, match="MISSING_DIAGNOSTIC_REF"):
+        bind_linear_diagnostics_economic_evidence_consumer_v0(
+            support_bundle=broken,
+            verify_fn=verify_manifest_sha256,
+        )
+
+
+def test_source_manifest_rc_not_zero_blocked(support_bundle) -> None:
+    def _fail_verify(_: Path) -> tuple[bool, str]:
+        return False, "MANIFEST_MISMATCH"
+
+    with pytest.raises(
+        LinearDiagnosticsConsumerBindingError, match="SOURCE_MANIFEST_VERIFY_FAILED"
+    ):
+        bind_linear_diagnostics_economic_evidence_consumer_v0(
+            support_bundle=support_bundle,
+            verify_fn=_fail_verify,
+        )
+
+
+def test_unknown_diagnostic_class_blocked(support_bundle) -> None:
+    with pytest.raises(LinearDiagnosticsConsumerBindingError, match="UNKNOWN_DIAGNOSTIC_CLASS"):
+        bind_linear_diagnostics_economic_evidence_consumer_v0(
+            support_bundle=support_bundle,
+            verify_fn=verify_manifest_sha256,
+            expected_source_statuses={"unknown_class": "OK"},
+        )
+
+
+def test_contradictory_source_status_blocked(support_bundle) -> None:
+    with pytest.raises(LinearDiagnosticsConsumerBindingError, match="CONTRADICTORY_SOURCE_STATUS"):
+        bind_linear_diagnostics_economic_evidence_consumer_v0(
+            support_bundle=support_bundle,
+            verify_fn=verify_manifest_sha256,
+            expected_source_statuses={"cost_diagnostics": "OK"},
+        )
+
+
+def test_repeated_materialization_deterministic(consumer_binding) -> None:
+    _, second = materialize_linear_diagnostics_economic_evidence_consumer_binding_v0(
+        source_specs=DEFAULT_SOURCE_BUNDLE_SPECS,
+        verify_fn=verify_manifest_sha256,
+        repo_root=REPO_ROOT,
+    )
+    assert second.to_dict() == consumer_binding.to_dict()
+    assert second.support_bundle_output_digest == consumer_binding.support_bundle_output_digest
+
+
+def test_second_materialization_no_semantic_diff(consumer_binding) -> None:
+    first_payload = json.dumps(consumer_binding.to_dict(), sort_keys=True, separators=(",", ":"))
+    _, second = materialize_linear_diagnostics_economic_evidence_consumer_binding_v0(
+        source_specs=DEFAULT_SOURCE_BUNDLE_SPECS,
+        verify_fn=verify_manifest_sha256,
+        repo_root=REPO_ROOT,
+    )
+    second_payload = json.dumps(second.to_dict(), sort_keys=True, separators=(",", ":"))
+    assert first_payload == second_payload
+
+
+def test_runtime_and_authority_effects_none(consumer_binding) -> None:
+    assert consumer_binding.runtime_effect == AUTHORITY_EFFECT == "NONE"
+    assert consumer_binding.authority_effect == "NONE"
+
+
+def test_import_boundary_owner_and_materializer() -> None:
+    assert scan_file_import_boundary(OWNER, repo_root=REPO_ROOT) == []
+    assert scan_file_import_boundary(MATERIALIZER, repo_root=REPO_ROOT) == []
+
+
+def test_governance_boundary_guard_accepts_new_owner() -> None:
+    changed_files = [
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "tests/research/test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+    ]
+    report = build_boundary_report(changed_files, repo_root=REPO_ROOT)
+    assert report.admissible is True
+    assert report.impact_unknown is False
+
+
+def test_apply_refs_to_economic_viability_evidence_preserves_status(consumer_binding) -> None:
+    evidence = EconomicViabilityEvidenceV1(
+        contract_version="v1",
+        owner="backtest.economic_viability_evidence_v1",
+        strategy_id="test",
+        strategy_version="v0",
+        instrument_id_or_universe="ETH-USDT-SWAP",
+        canonical_trading_logic_version="v1",
+        data_period="p",
+        training_period="p",
+        validation_period="p",
+        out_of_sample_period="p",
+        fee_model_version="v0",
+        slippage_model_version="v0",
+        funding_model_version="v0",
+        execution_model_version="v0",
+        config_digest="c",
+        implementation_digest="i",
+        data_digest="d",
+        gross_return=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        net_return=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        net_expectancy=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        profit_factor=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        sharpe=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        sortino=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        max_drawdown=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        calmar=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        trade_count=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        turnover=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        fee_drag=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        funding_drag=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        slippage_impact=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        tail_loss=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        time_in_market=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        long_contribution=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        short_contribution=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        regime_breakdown={},
+        portfolio_contribution={},
+        walk_forward_results={},
+        monte_carlo_results={},
+        stress_results={},
+        parameter_sensitivity_results={},
+        parameter_neighbor_degradation=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        single_trade_profit_contribution=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        single_regime_profit_contribution=MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED),
+        status=EconomicViabilityStatus.RESEARCH_ONLY,
+        reason_codes=("configured_strategy_signal_bound",),
+        manifest_digest="m",
+        wiring_chain_digest="w",
+        randomness_seed=0,
+        data_admissibility={},
+        cost_binding={},
+    )
+    bound = apply_linear_diagnostics_refs_to_economic_viability_evidence_v0(
+        evidence, consumer_binding
+    )
+    assert bound.status is EconomicViabilityStatus.RESEARCH_ONLY
+    assert bound.factor_exposure_ref == consumer_binding.factor_exposure_ref
+    assert "factor_exposure_ref" in bound.to_semantic_dict()
+
+
+def test_derive_reason_codes_includes_blocking_classes() -> None:
+    reason_codes = derive_linear_diagnostics_reason_codes_v0(
+        source_statuses={
+            "cost_diagnostics": "RANK_DEFICIENT_BLOCKED",
+            "factor_exposure": "RANK_DEFICIENT_BLOCKED",
+            "rolling_linear_drift": "BLOCK_DRIFT_EXCEEDS_POLICY",
+        },
+        aggregate_reason_codes=("BLOCKED_SOURCE:cost_diagnostics:RANK_DEFICIENT_BLOCKED",),
+    )
+    assert "COST_DIAGNOSTICS_RANK_DEFICIENT" in reason_codes
+    assert "FACTOR_EXPOSURE_RANK_DEFICIENT" in reason_codes
+    assert "ROLLING_LINEAR_DRIFT_EXCEEDS_POLICY" in reason_codes
+
+
+def test_missing_source_evidence_fail_closed(tmp_path: Path) -> None:
+    missing_spec = SourceBundleSpecV0(
+        diagnostic_class="cost_diagnostics",
+        evidence_type="offline_linear_cost_model_diagnostics.v0",
+        bundle_path=tmp_path / "missing_bundle",
+        status_artifact="reason_codes.json",
+    )
+    specs = (missing_spec, *DEFAULT_SOURCE_BUNDLE_SPECS[1:])
+    with pytest.raises(Exception, match="SOURCE_BUNDLE_MISSING"):
+        materialize_linear_diagnostics_economic_evidence_consumer_binding_v0(
+            source_specs=specs,
+            verify_fn=verify_manifest_sha256,
+            repo_root=REPO_ROOT,
+        )
+
+
+def test_source_closeout_manifest_verified() -> None:
+    if not SOURCE_CLOSEOUT.is_dir():
+        pytest.skip("source closeout unavailable")
+    ok, _ = verify_manifest_sha256(SOURCE_CLOSEOUT)
+    assert ok
+
+
+def test_materializer_roundtrip(tmp_path: Path) -> None:
+    if not _archive_available():
+        pytest.skip("productive archive bundles unavailable")
+
+    first_dir = tmp_path / "evidence_a"
+    second_dir = tmp_path / "evidence_b"
+    first = _run_materializer(first_dir)
+    second = _run_materializer(second_dir)
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+
+    for bundle in (first_dir, second_dir):
+        ok, _ = verify_manifest_sha256(bundle)
+        assert ok
+
+    binding_a = json.loads((first_dir / "consumer_contract.json").read_text(encoding="utf-8"))
+    binding_b = json.loads((second_dir / "consumer_contract.json").read_text(encoding="utf-8"))
+    assert binding_a == binding_b
+    assert (
+        binding_a["linear_diagnostics_status"]
+        == SupportAggregateStatus.BLOCK_SUPPORT_EVIDENCE.value
+    )


### PR DESCRIPTION
## Summary
- Adds a narrow consumer adapter (`offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0`) that reuses the manifest-verified PR5185 support bundle and binds all five productive linear diagnostic references into the canonical `EconomicViabilityEvidenceV1` support-ref contract.
- Preserves source statuses fail-closed (`BLOCK_SUPPORT_EVIDENCE`, `BLOCKED_SOURCE_DIAGNOSTICS_PRESENT`, `ECONOMIC_EVIDENCE_ADMISSIBILITY=BLOCKED_SOURCE_DIAGNOSTICS_PRESENT`) and materializes deterministic `linear_diagnostics_status` / `linear_diagnostics_reason_codes` without economic pass or promotion authority.
- **Reuse decision:** `REUSE_WITH_NARROW_ADAPTER` on existing support-bundle owner + `EconomicViabilityEvidenceV1`; no parallel economic/promotion/registry owner created.
- **Source evidence:** PR5185 merge closeout + five manifest-verified productive diagnostic bundles (`SOURCE_MANIFEST_VERIFY_RC=0`).

## Hard boundaries (unchanged)
- `OFFLINE_ONLY=true`, `ECONOMIC_EVALUATION_EXECUTED=false`, `WALK_FORWARD/MONTE_CARLO/STRESS=false`
- `ECONOMIC_VALIDITY_PASS_CREATED=false`, `PROMOTION_PASS_CREATED=false`, `PROMOTION_ELIGIBILITY_CHANGED=false`
- `PARAMETER_OPTIMIZATION_EXECUTED=false`, `PARAMETER_DEFAULT_CHANGED=false`, `STRATEGY_SELECTION_CHANGED=false`
- `RUNTIME_EFFECT=NONE`, `AUTHORITY_EFFECT=NONE`

## Test plan
- [x] Focused contract tests: `tests/research/test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py` (21 tests)
- [x] Support bundle regression: `tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py` (19 tests)
- [x] Governance boundary guard + import boundary scan green
- [x] Durable evidence bundle manifest-verified outside repo (`MANIFEST_VERIFY_RC=0`)
- [ ] CI required checks (no merge until green)


Made with [Cursor](https://cursor.com)