### PR TITLE
Fix lead-lag v0 offline economic evaluation invocation-bound authorization

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -425,9 +425,10 @@
         "src/research/*offline_economic_evaluation_scope_ratification_v0.py",
         "tests/research/test_*offline_economic_evaluation_execution_infrastructure_v0.py",
         "tests/research/test_*offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",
+        "tests/research/test_*offline_economic_evaluation_execution_authorization_ratification_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_full_runner_v0.py"
       ],
-      "note": "Offline economic evaluation execution infrastructure, preexecution guards, and contract tests without trading semantic mutation or runtime authority."
+      "note": "Offline economic evaluation execution infrastructure, preexecution guards, invocation-bound authorization repair, and contract tests without trading semantic mutation or runtime authority."
     }
   }
 }

--- a/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
@@ -23,6 +23,7 @@ from src.research.cross_sectional_offline_economic_evaluation_decision_funnel_v0
 )
 from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_scope_ratification_v0 import (
     ValidationVerdictEnum,
+    evaluate_invocation_bound_economic_evaluation_authorization_v0,
     validate_lead_lag_offline_economic_evaluation_scope_ratification_v0,
 )
 from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_score_v0 import (
@@ -817,8 +818,6 @@ def verify_full_evaluation_precheck_v1(
         reasons.append(REASON_PARAMETER_SEARCH_FORBIDDEN_VIOLATION)
 
     if require_execution_go:
-        if ratification.get("economic_evaluation_authorized") is not True:
-            reasons.append(REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED)
         if go_token not in ALLOWED_FULL_EVALUATION_GO_TOKENS:
             reasons.append(REASON_GO_TOKEN_INVALID)
         entry_ok, _ = validate_entry_point_go_token_v0(str(go_token or ""))
@@ -858,6 +857,17 @@ def verify_full_evaluation_precheck_v1(
             reasons.append(REASON_FULL_CANONICAL_PARITY_NOT_PROVEN)
         if not parity_pass:
             reasons.append(REASON_BACKTEST_RUNTIME_DECISION_PARITY_FAIL)
+        auth_result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+            ratification=ratification,
+            versioned_binding=envelope,
+            go_token=go_token,
+            allowed_execution_go_tokens=ALLOWED_FULL_EVALUATION_GO_TOKENS,
+            ops_config=ops_cfg,
+            full_chain_wired=full_chain_wired,
+            parity_pass=parity_pass,
+        )
+        if not auth_result.authorized:
+            reasons.extend(auth_result.reason_codes)
 
     if reasons:
         return False, tuple(dict.fromkeys(reasons)), None

--- a/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_scope_ratification_v0.py
+++ b/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_scope_ratification_v0.py
@@ -75,6 +75,20 @@ ECONOMIC_EVALUATION_EXECUTED = False
 FUTURES_ONLY = True
 BITCOIN_DIRECTION_ALLOWED = False
 
+REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED = "ECONOMIC_EVALUATION_NOT_AUTHORIZED"
+REASON_OFFLINE_BOUNDARY_VIOLATION = "OFFLINE_BOUNDARY_VIOLATION"
+REASON_STORED_ECONOMIC_EVALUATION_AUTHORIZED_VIOLATION = (
+    "STORED_ECONOMIC_EVALUATION_AUTHORIZED_VIOLATION"
+)
+REASON_SCOPE_RATIFICATION_MISMATCH = "SCOPE_RATIFICATION_MISMATCH"
+REASON_BINDING_DIGEST_MISMATCH = "BINDING_DIGEST_MISMATCH"
+REASON_DATASET_DIGEST_MISMATCH = "DATASET_DIGEST_MISMATCH"
+REASON_UNIVERSE_DIGEST_MISMATCH = "UNIVERSE_DIGEST_MISMATCH"
+REASON_IMPLEMENTATION_DIGEST_MISMATCH = "IMPLEMENTATION_DIGEST_MISMATCH"
+REASON_CONFIG_DIGEST_MISMATCH = "CONFIG_DIGEST_MISMATCH"
+REASON_FULL_CANONICAL_PARITY_NOT_PROVEN = "FULL_CANONICAL_PARITY_NOT_PROVEN"
+REASON_BACKTEST_RUNTIME_DECISION_PARITY_FAIL = "BACKTEST_RUNTIME_DECISION_PARITY_FAIL"
+
 ALLOWED_EVALUATION_STAGES: tuple[str, ...] = (
     "OFFLINE_BACKTEST",
     "WALK_FORWARD",
@@ -126,6 +140,13 @@ class RatificationValidationResultV0:
     fail_reasons: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class InvocationBoundAuthorizationResultV0:
+    authorized: bool
+    economic_evaluation_authorized: bool
+    reason_codes: tuple[str, ...]
+
+
 def _stable_digest(payload: Mapping[str, Any]) -> str:
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
@@ -166,6 +187,137 @@ def validate_lead_lag_offline_economic_evaluation_scope_ratification_v0(
             fail_reasons=unique,
         )
     return RatificationValidationResultV0(verdict=ValidationVerdictEnum.ACCEPTED, fail_reasons=())
+
+
+def evaluate_invocation_bound_economic_evaluation_authorization_v0(
+    *,
+    ratification: Mapping[str, Any],
+    versioned_binding: Mapping[str, Any],
+    go_token: str | None,
+    allowed_execution_go_tokens: frozenset[str],
+    ops_config: Mapping[str, Any],
+    full_chain_wired: bool,
+    parity_pass: bool,
+) -> InvocationBoundAuthorizationResultV0:
+    """Derive fail-closed invocation-bound execution authorization.
+
+    Persisted scope ratification remains ``economic_evaluation_authorized=false`` by default.
+    A separately confirmed execution GO elevates authorization only when all canonical
+    co-requisites are satisfied for this invocation. No runtime or authority effect.
+    """
+    reasons: list[str] = []
+
+    if ratification.get("economic_evaluation_authorized") is not False:
+        reasons.append(REASON_STORED_ECONOMIC_EVALUATION_AUTHORIZED_VIOLATION)
+
+    if not go_token or go_token not in allowed_execution_go_tokens:
+        reasons.append(REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED)
+
+    for field_name in ("strategy_id", "strategy_version", "hypothesis_id"):
+        if ratification.get(field_name) != versioned_binding.get(field_name):
+            reasons.append(REASON_SCOPE_RATIFICATION_MISMATCH)
+
+    if ratification.get("binding_digest") != versioned_binding.get("binding_digest"):
+        reasons.append(REASON_BINDING_DIGEST_MISMATCH)
+
+    expected_dataset_digest = str(
+        ops_config.get("cross_sectional_evaluation_binding_v1", {})
+        .get("dataset_binding", {})
+        .get("dataset_digest", versioned_binding.get("dataset_digest", ""))
+    )
+    if str(versioned_binding.get("dataset_digest", "")) != expected_dataset_digest:
+        reasons.append(REASON_DATASET_DIGEST_MISMATCH)
+
+    universe_digest = str(
+        versioned_binding.get("binding", {})
+        .get("pit_universe_binding", {})
+        .get("universe_digest", "")
+    )
+    expected_universe_digest = str(
+        ops_config.get("cross_sectional_evaluation_binding_v1", {})
+        .get("instrument_universe_binding", {})
+        .get("universe_digest", ratification.get("universe_digest", ""))
+    )
+    if universe_digest != expected_universe_digest:
+        reasons.append(REASON_UNIVERSE_DIGEST_MISMATCH)
+
+    expected_implementation_digest = str(ops_config.get("implementation_digest", ""))
+    binding_implementation_digest = str(
+        versioned_binding.get("binding", {})
+        .get("digest_bindings", {})
+        .get("implementation_digest", {})
+        .get("value", versioned_binding.get("implementation_digest", ""))
+    )
+    ratification_implementation_digest = str(ratification.get("implementation_digest", ""))
+    if expected_implementation_digest and (
+        binding_implementation_digest != expected_implementation_digest
+        or ratification_implementation_digest != expected_implementation_digest
+    ):
+        reasons.append(REASON_IMPLEMENTATION_DIGEST_MISMATCH)
+
+    expected_config_digest = str(ops_config.get("config_digest", ""))
+    binding_config_digest = str(versioned_binding.get("config_digest", ""))
+    if expected_config_digest and binding_config_digest != expected_config_digest:
+        reasons.append(REASON_CONFIG_DIGEST_MISMATCH)
+
+    constraints = versioned_binding.get("system_constraints", {})
+    if constraints.get("futures_only") is not True or ratification.get("futures_only") is not True:
+        reasons.append("FUTURES_ONLY_VIOLATION")
+    if (
+        constraints.get("bitcoin_direction_allowed") is not False
+        or ratification.get("bitcoin_direction_allowed") is not False
+    ):
+        reasons.append("BITCOIN_DIRECTION_VIOLATION")
+
+    for effect_field, expected in (
+        ("runtime_effect", RUNTIME_EFFECT),
+        ("authority_effect", AUTHORITY_EFFECT),
+        ("order_effect", ORDER_EFFECT),
+    ):
+        if (
+            ratification.get(effect_field) != expected
+            or versioned_binding.get(effect_field) != expected
+        ):
+            reasons.append(REASON_OFFLINE_BOUNDARY_VIOLATION)
+
+    if not full_chain_wired:
+        reasons.append(REASON_FULL_CANONICAL_PARITY_NOT_PROVEN)
+    if not parity_pass:
+        reasons.append(REASON_BACKTEST_RUNTIME_DECISION_PARITY_FAIL)
+
+    unique = tuple(dict.fromkeys(reasons))
+    authorized = not unique
+    return InvocationBoundAuthorizationResultV0(
+        authorized=authorized,
+        economic_evaluation_authorized=authorized,
+        reason_codes=unique,
+    )
+
+
+def materialize_invocation_bound_authorization_contract_v0() -> dict[str, Any]:
+    return {
+        "schema_version": (
+            "cross_sectional_futures_lead_lag_information_diffusion_v0_invocation_bound_"
+            "economic_evaluation_authorization.v0"
+        ),
+        "authorization_model": "INVOCATION_BOUND_FAIL_CLOSED",
+        "persisted_economic_evaluation_authorized_default": ECONOMIC_EVALUATION_AUTHORIZED,
+        "invocation_elevates_authorization": True,
+        "runtime_effect": RUNTIME_EFFECT,
+        "authority_effect": AUTHORITY_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "required_co_requisites": [
+            "ALLOWED_EXECUTION_GO_TOKEN",
+            "PERSISTED_ECONOMIC_EVALUATION_AUTHORIZED_FALSE",
+            "SCOPE_RATIFICATION_BINDING_IDENTITY",
+            "RATIFIED_DIGEST_BINDINGS",
+            "FUTURES_ONLY",
+            "BITCOIN_EXCLUDED",
+            "OFFLINE_BOUNDARY_ENFORCED",
+            "FULL_CANONICAL_CHAIN_WIRED",
+            "BACKTEST_RUNTIME_DECISION_PARITY_PASS",
+        ],
+    }
 
 
 def materialize_lead_lag_offline_economic_evaluation_scope_ratification_v0(

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -119,6 +119,12 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
                 "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_infrastructure_v0.py",
                 "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",
             ],
+            [
+                "src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py",
+                "src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_scope_ratification_v0.py",
+                "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_authorization_ratification_repair_v0.py",
+                "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_full_runner_v0.py",
+            ],
         ],
     )
     def test_positive_cases_admissible(self, changed_files: list[str]) -> None:

--- a/tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py
+++ b/tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py
@@ -58,6 +58,37 @@ PY310_STAGING = pytest.mark.skipif(
 )
 
 
+def _dispatch_boundary_evaluation_result():
+    from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 import (
+        AUTHORITY_EFFECT,
+        EconomicClassification,
+        ExecutionTerminalStatus,
+        FullEconomicEvaluationResultV0,
+        RUNTIME_EFFECT,
+    )
+
+    return FullEconomicEvaluationResultV0(
+        status=ExecutionTerminalStatus.FAIL_CLOSED_PRECHECK,
+        precheck_passed=True,
+        bound_dataset_materialized=False,
+        dataset_period_match=False,
+        panel_data_digest="0" * 64,
+        data_digest_is_fixture=False,
+        stage_wiring=(),
+        backtest=None,
+        robustness=None,
+        robustness_metrics=None,
+        economic_viability_evidence={},
+        economic_classification=EconomicClassification.FAIL_CLOSED,
+        economic_validity_offline_gate_pass=False,
+        promotion_candidate_eligible=False,
+        economic_evaluation_executed=False,
+        reason_codes=(),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
 @pytest.fixture(name="complete_binding")
 def fixture_complete_binding() -> dict:
     return materialize_versioned_hypothesis_binding_v0()
@@ -205,8 +236,8 @@ def test_parity_true_and_valid_go_passes_precheck_without_evaluation(
             runner_envelope=envelope,
             materialize_dataset=False,
         )
-    assert ok is False
-    assert REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED in reasons
+    assert ok is True
+    assert REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED not in reasons
     assert materialization is None
 
 
@@ -258,20 +289,33 @@ def test_direct_runner_call_without_dispatch_success_blocked(
 
 
 @PY310_STAGING
-def test_ops_runner_execution_go_dispatch_blocks_before_evaluation(tmp_path: Path) -> None:
-    with pytest.raises(SystemExit) as exc:
+def test_ops_runner_execution_go_dispatch_blocks_before_evaluation(
+    tmp_path: Path, bound_staging: Path
+) -> None:
+    with (
+        patch.object(
+            runner_module,
+            "run_full_offline_economic_evaluation_v0",
+            return_value=_dispatch_boundary_evaluation_result(),
+        ) as full_eval,
+        patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+            "economic_evaluation_execution_v0.verify_panel_staging_source_manifests_v1",
+            return_value=(True, 0, ()),
+        ),
+        patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+            "economic_evaluation_execution_v0.load_ohlcv_panel_series_for_backtest",
+            return_value=(),
+        ),
+    ):
         runner_module.run_bounded_full_evaluation_dispatch_v0(
             confirm=GO_TOKEN,
             durable_evidence_root=tmp_path,
             primary_worktree=REPO_ROOT,
-            staging_root=REPO_ROOT,
+            staging_root=bound_staging,
         )
-    assert exc.value.code == 1
-    bundles = list(tmp_path.glob("research/*execution_v0_*"))
-    assert bundles
-    block_text = (bundles[0] / "PREEXECUTION_BLOCK.txt").read_text(encoding="utf-8")
-    assert "EVALUATION_EXECUTED=False" in block_text
-    assert "BLOCK_REASON=ECONOMIC_EVALUATION_NOT_AUTHORIZED" in block_text
+        full_eval.assert_called_once()
 
 
 @PY310_STAGING
@@ -286,13 +330,15 @@ def test_ops_runner_cli_execution_go_blocks_without_reevaluation_rewrite() -> No
             str(REPO_ROOT),
             "--durable-evidence-root",
             tempfile.mkdtemp(prefix="cs_lead_lag_cli_guard_"),
+            "--staging-root",
+            tempfile.mkdtemp(prefix="cs_lead_lag_cli_invalid_staging_"),
         ],
         capture_output=True,
         text=True,
         cwd=str(REPO_ROOT),
     )
     assert proc.returncode == 1
-    assert "EVALUATION_EXECUTED=false" in proc.stderr
+    assert "BLOCK_REASON=ECONOMIC_EVALUATION_NOT_AUTHORIZED" not in proc.stderr
     assert REEVALUATION_GO_TOKEN not in proc.stderr
 
 
@@ -387,15 +433,27 @@ def test_productive_entry_point_dispatch_to_guard_path(
     tmp_path: Path,
     bound_staging: Path,
 ) -> None:
-    with patch.object(
-        runner_module,
-        "run_full_offline_economic_evaluation_v0",
-    ) as full_eval:
-        with pytest.raises(SystemExit):
-            runner_module.run_bounded_full_evaluation_dispatch_v0(
-                confirm=GO_TOKEN,
-                durable_evidence_root=tmp_path,
-                primary_worktree=REPO_ROOT,
-                staging_root=bound_staging,
-            )
-        full_eval.assert_not_called()
+    with (
+        patch.object(
+            runner_module,
+            "run_full_offline_economic_evaluation_v0",
+            return_value=_dispatch_boundary_evaluation_result(),
+        ) as full_eval,
+        patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+            "economic_evaluation_execution_v0.verify_panel_staging_source_manifests_v1",
+            return_value=(True, 0, ()),
+        ),
+        patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+            "economic_evaluation_execution_v0.load_ohlcv_panel_series_for_backtest",
+            return_value=(),
+        ),
+    ):
+        runner_module.run_bounded_full_evaluation_dispatch_v0(
+            confirm=GO_TOKEN,
+            durable_evidence_root=tmp_path,
+            primary_worktree=REPO_ROOT,
+            staging_root=bound_staging,
+        )
+        full_eval.assert_called_once()

--- a/tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_authorization_ratification_repair_v0.py
+++ b/tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_authorization_ratification_repair_v0.py
@@ -1,0 +1,531 @@
+"""Repair contract tests for lead-lag v0 invocation-bound execution authorization."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.ops import (
+    run_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 as runner_module,
+)
+from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    GO_TOKEN,
+    REASON_BACKTEST_RUNTIME_DECISION_PARITY_FAIL,
+    REASON_BINDING_DIGEST_MISMATCH,
+    REASON_DATASET_DIGEST_MISMATCH,
+    REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED,
+    REASON_FULL_CANONICAL_PARITY_NOT_PROVEN,
+    REASON_GO_TOKEN_INVALID,
+    REASON_UNIVERSE_DIGEST_MISMATCH,
+    RUNTIME_EFFECT,
+    materialize_runner_envelope_v0,
+    resolve_identity_operator_go_v0,
+    verify_full_evaluation_precheck_v1,
+)
+from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_scope_ratification_v0 import (
+    ECONOMIC_EVALUATION_AUTHORIZED,
+    REASON_CONFIG_DIGEST_MISMATCH,
+    REASON_IMPLEMENTATION_DIGEST_MISMATCH,
+    REASON_OFFLINE_BOUNDARY_VIOLATION,
+    REASON_SCOPE_RATIFICATION_MISMATCH,
+    evaluate_invocation_bound_economic_evaluation_authorization_v0,
+    materialize_invocation_bound_authorization_contract_v0,
+    materialize_lead_lag_offline_economic_evaluation_scope_ratification_v0,
+)
+from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_versioned_hypothesis_binding_v0 import (
+    materialize_versioned_hypothesis_binding_v0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.staging_builder import (
+    write_bound_period_staging_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_MODULE = (
+    REPO_ROOT / "scripts/ops/"
+    "run_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_"
+    "evaluation_execution_v0.py"
+)
+PY310_STAGING = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="panel staging loader requires Python 3.10+ zip(strict=True)",
+)
+
+
+def _dispatch_boundary_evaluation_result():
+    from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 import (
+        AUTHORITY_EFFECT,
+        EconomicClassification,
+        ExecutionTerminalStatus,
+        FullEconomicEvaluationResultV0,
+        RUNTIME_EFFECT,
+    )
+
+    return FullEconomicEvaluationResultV0(
+        status=ExecutionTerminalStatus.FAIL_CLOSED_PRECHECK,
+        precheck_passed=True,
+        bound_dataset_materialized=False,
+        dataset_period_match=False,
+        panel_data_digest="0" * 64,
+        data_digest_is_fixture=False,
+        stage_wiring=(),
+        backtest=None,
+        robustness=None,
+        robustness_metrics=None,
+        economic_viability_evidence={},
+        economic_classification=EconomicClassification.FAIL_CLOSED,
+        economic_validity_offline_gate_pass=False,
+        promotion_candidate_eligible=False,
+        economic_evaluation_executed=False,
+        reason_codes=(),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_hypothesis_binding_v0()
+
+
+@pytest.fixture(name="scope_ratification")
+def fixture_scope_ratification(complete_binding: dict) -> dict:
+    return materialize_lead_lag_offline_economic_evaluation_scope_ratification_v0(
+        repo_root=REPO_ROOT,
+        versioned_binding=complete_binding,
+    )
+
+
+@pytest.fixture(name="bound_staging")
+def fixture_bound_staging() -> Path:
+    tmp = Path(tempfile.mkdtemp(prefix="cs_lead_lag_auth_repair_v0_"))
+    staging = write_bound_period_staging_v0(tmp)
+    lifecycle = staging / "lifecycle"
+    lifecycle.mkdir(parents=True, exist_ok=True)
+    lifecycle.joinpath("SOURCE_REGISTRATION.json").write_text(
+        '{"source_snapshot_ref":"test:fixture","source_snapshot_digest":"'
+        + "a" * 64
+        + '","registered":true}\n',
+        encoding="utf-8",
+    )
+    return staging
+
+
+def _load_ops_config() -> dict:
+    from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 import (
+        load_ops_evaluation_config_v0,
+    )
+
+    return load_ops_evaluation_config_v0(REPO_ROOT)
+
+
+def _allowed_tokens() -> frozenset[str]:
+    from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 import (
+        ALLOWED_FULL_EVALUATION_GO_TOKENS,
+    )
+
+    return ALLOWED_FULL_EVALUATION_GO_TOKENS
+
+
+def _make_envelope(*, go_token: str, parity: bool) -> object:
+    return materialize_runner_envelope_v0(
+        requested_operator_go=go_token,
+        dispatched_operator_go=resolve_identity_operator_go_v0(go_token),
+        dispatch_rc=0,
+        preexecution_parity_guard_pass=parity,
+        full_canonical_chain_wired=parity,
+        backtest_runtime_decision_parity_pass=parity,
+    )
+
+
+def test_persisted_authorization_default_remains_false(scope_ratification: dict) -> None:
+    assert ECONOMIC_EVALUATION_AUTHORIZED is False
+    assert scope_ratification["economic_evaluation_authorized"] is False
+
+
+def test_invocation_contract_declares_invocation_bound_model() -> None:
+    contract = materialize_invocation_bound_authorization_contract_v0()
+    assert contract["authorization_model"] == "INVOCATION_BOUND_FAIL_CLOSED"
+    assert contract["persisted_economic_evaluation_authorized_default"] is False
+    assert contract["invocation_elevates_authorization"] is True
+
+
+def test_valid_execution_go_authorizes_invocation(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=complete_binding,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is True
+    assert result.economic_evaluation_authorized is True
+    assert result.reason_codes == ()
+
+
+def test_missing_execution_go_blocks(scope_ratification: dict, complete_binding: dict) -> None:
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=complete_binding,
+        go_token=None,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED in result.reason_codes
+
+
+def test_wrong_execution_go_blocks(scope_ratification: dict, complete_binding: dict) -> None:
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=complete_binding,
+        go_token="GO_WRONG_TOKEN",
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED in result.reason_codes
+
+
+def test_scope_ratification_mismatch_blocks(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    stale = deepcopy(scope_ratification)
+    stale["hypothesis_id"] = "WRONG_HYPOTHESIS"
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=stale,
+        versioned_binding=complete_binding,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert REASON_SCOPE_RATIFICATION_MISMATCH in result.reason_codes
+
+
+def test_binding_digest_mismatch_blocks(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    stale = deepcopy(complete_binding)
+    stale["binding_digest"] = "f" * 64
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=stale,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert REASON_BINDING_DIGEST_MISMATCH in result.reason_codes
+
+
+def test_dataset_digest_mismatch_blocks(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    stale = deepcopy(complete_binding)
+    stale["dataset_digest"] = "f" * 64
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=stale,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert REASON_DATASET_DIGEST_MISMATCH in result.reason_codes
+
+
+def test_universe_digest_mismatch_blocks(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    stale = deepcopy(complete_binding)
+    stale["binding"]["pit_universe_binding"]["universe_digest"] = "f" * 64
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=stale,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert REASON_UNIVERSE_DIGEST_MISMATCH in result.reason_codes
+
+
+def test_implementation_digest_mismatch_blocks(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    ops = deepcopy(_load_ops_config())
+    ops["implementation_digest"] = "f" * 64
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=complete_binding,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=ops,
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert REASON_IMPLEMENTATION_DIGEST_MISMATCH in result.reason_codes
+
+
+def test_config_digest_mismatch_blocks(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    ops = deepcopy(_load_ops_config())
+    ops["config_digest"] = "f" * 64
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=complete_binding,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=ops,
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert REASON_CONFIG_DIGEST_MISMATCH in result.reason_codes
+
+
+def test_bitcoin_presence_blocks(scope_ratification: dict, complete_binding: dict) -> None:
+    stale = deepcopy(complete_binding)
+    stale["system_constraints"]["bitcoin_direction_allowed"] = True
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=stale,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert "BITCOIN_DIRECTION_VIOLATION" in result.reason_codes
+
+
+def test_non_futures_scope_blocks(scope_ratification: dict, complete_binding: dict) -> None:
+    stale = deepcopy(complete_binding)
+    stale["system_constraints"]["futures_only"] = False
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=stale,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert "FUTURES_ONLY_VIOLATION" in result.reason_codes
+
+
+def test_offline_boundary_violation_blocks(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    stale = deepcopy(scope_ratification)
+    stale["runtime_effect"] = "LIVE"
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=stale,
+        versioned_binding=complete_binding,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=True,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert REASON_OFFLINE_BOUNDARY_VIOLATION in result.reason_codes
+
+
+def test_full_canonical_chain_required(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=complete_binding,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=False,
+        parity_pass=True,
+    )
+    assert result.authorized is False
+    assert REASON_FULL_CANONICAL_PARITY_NOT_PROVEN in result.reason_codes
+
+
+def test_backtest_runtime_parity_required(
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    result = evaluate_invocation_bound_economic_evaluation_authorization_v0(
+        ratification=scope_ratification,
+        versioned_binding=complete_binding,
+        go_token=GO_TOKEN,
+        allowed_execution_go_tokens=_allowed_tokens(),
+        ops_config=_load_ops_config(),
+        full_chain_wired=True,
+        parity_pass=False,
+    )
+    assert result.authorized is False
+    assert REASON_BACKTEST_RUNTIME_DECISION_PARITY_FAIL in result.reason_codes
+
+
+@PY310_STAGING
+def test_production_precheck_authorizes_valid_execution_go_without_evaluation(
+    bound_staging: Path,
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    envelope = _make_envelope(go_token=GO_TOKEN, parity=True)
+    with (
+        patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+            "economic_evaluation_execution_v0.load_evaluation_path_parity_status_v0",
+            return_value=(True, True),
+        ),
+        patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+            "economic_evaluation_execution_v0.verify_panel_staging_source_manifests_v1",
+            return_value=(True, 0, ()),
+        ),
+    ):
+        ok, reasons, _ = verify_full_evaluation_precheck_v1(
+            repo_root=REPO_ROOT,
+            ratification=scope_ratification,
+            staging_root=bound_staging,
+            versioned_binding=complete_binding,
+            go_token=GO_TOKEN,
+            require_execution_go=True,
+            runner_envelope=envelope,
+            materialize_dataset=False,
+        )
+    assert ok is True
+    assert REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED not in reasons
+
+
+@PY310_STAGING
+def test_production_precheck_blocks_missing_go(
+    bound_staging: Path,
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    envelope = _make_envelope(go_token=GO_TOKEN, parity=True)
+    ok, reasons, _ = verify_full_evaluation_precheck_v1(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        staging_root=bound_staging,
+        versioned_binding=complete_binding,
+        go_token=None,
+        require_execution_go=True,
+        runner_envelope=envelope,
+        materialize_dataset=False,
+    )
+    assert ok is False
+    assert REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED in reasons
+
+
+@PY310_STAGING
+def test_production_precheck_blocks_wrong_go(
+    bound_staging: Path,
+    scope_ratification: dict,
+    complete_binding: dict,
+) -> None:
+    envelope = _make_envelope(go_token=GO_TOKEN, parity=True)
+    ok, reasons, _ = verify_full_evaluation_precheck_v1(
+        repo_root=REPO_ROOT,
+        ratification=scope_ratification,
+        staging_root=bound_staging,
+        versioned_binding=complete_binding,
+        go_token="GO_WRONG_TOKEN",
+        require_execution_go=True,
+        runner_envelope=envelope,
+        materialize_dataset=False,
+    )
+    assert ok is False
+    assert REASON_GO_TOKEN_INVALID in reasons
+    assert REASON_ECONOMIC_EVALUATION_NOT_AUTHORIZED in reasons
+
+
+@PY310_STAGING
+def test_production_runner_reaches_dispatch_boundary_without_economic_execution(
+    bound_staging: Path,
+) -> None:
+    with (
+        patch.object(
+            runner_module,
+            "run_full_offline_economic_evaluation_v0",
+            return_value=_dispatch_boundary_evaluation_result(),
+        ) as full_eval,
+        patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+            "economic_evaluation_execution_v0.verify_panel_staging_source_manifests_v1",
+            return_value=(True, 0, ()),
+        ),
+        patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+            "economic_evaluation_execution_v0.load_ohlcv_panel_series_for_backtest",
+            return_value=(),
+        ),
+    ):
+        runner_module.run_bounded_full_evaluation_dispatch_v0(
+            confirm=GO_TOKEN,
+            durable_evidence_root=Path(tempfile.mkdtemp(prefix="cs_lead_lag_auth_dispatch_")),
+            primary_worktree=REPO_ROOT,
+            staging_root=bound_staging,
+        )
+        full_eval.assert_called_once()
+        assert full_eval.call_args.kwargs["go_token"] == GO_TOKEN
+
+
+def test_repair_preserves_no_runtime_or_authority_effect() -> None:
+    assert RUNTIME_EFFECT == "NONE"
+    assert AUTHORITY_EFFECT == "NONE"
+
+
+def test_runner_cli_wrong_go_still_fail_closed() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER_MODULE),
+            "--confirm",
+            "GO_WRONG_TOKEN",
+            "--primary-worktree",
+            str(REPO_ROOT),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode == 2
+    assert "ERR:confirm_go_token_required" in proc.stderr

--- a/tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_full_runner_v0.py
+++ b/tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_full_runner_v0.py
@@ -391,23 +391,65 @@ def test_implementation_scope_runner_infrastructure_mode_does_not_execute_evalua
         full_eval.assert_not_called()
 
 
+def _dispatch_boundary_evaluation_result():
+    from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 import (
+        AUTHORITY_EFFECT,
+        EconomicClassification,
+        ExecutionTerminalStatus,
+        FullEconomicEvaluationResultV0,
+        RUNTIME_EFFECT,
+    )
+
+    return FullEconomicEvaluationResultV0(
+        status=ExecutionTerminalStatus.FAIL_CLOSED_PRECHECK,
+        precheck_passed=True,
+        bound_dataset_materialized=False,
+        dataset_period_match=False,
+        panel_data_digest="0" * 64,
+        data_digest_is_fixture=False,
+        stage_wiring=(),
+        backtest=None,
+        robustness=None,
+        robustness_metrics=None,
+        economic_viability_evidence={},
+        economic_classification=EconomicClassification.FAIL_CLOSED,
+        economic_validity_offline_gate_pass=False,
+        promotion_candidate_eligible=False,
+        economic_evaluation_executed=False,
+        reason_codes=(),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
 def test_execution_go_reaches_guarded_dispatch_without_reevaluation_rewrite(
     tmp_path: Path,
     bound_staging: Path,
 ) -> None:
-    with patch.object(
-        runner_module,
-        "run_full_offline_economic_evaluation_v0",
-    ) as full_eval:
-        with pytest.raises(SystemExit) as exc:
-            runner_module.run_bounded_full_evaluation_dispatch_v0(
-                confirm=GO_TOKEN,
-                durable_evidence_root=tmp_path,
-                primary_worktree=REPO_ROOT,
-                staging_root=bound_staging,
-            )
-        assert exc.value.code == 1
-        full_eval.assert_not_called()
+    with (
+        patch.object(
+            runner_module,
+            "run_full_offline_economic_evaluation_v0",
+            return_value=_dispatch_boundary_evaluation_result(),
+        ) as full_eval,
+        patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+            "economic_evaluation_execution_v0.verify_panel_staging_source_manifests_v1",
+            return_value=(True, 0, ()),
+        ),
+        patch(
+            "src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_"
+            "economic_evaluation_execution_v0.load_ohlcv_panel_series_for_backtest",
+            return_value=(),
+        ),
+    ):
+        runner_module.run_bounded_full_evaluation_dispatch_v0(
+            confirm=GO_TOKEN,
+            durable_evidence_root=tmp_path,
+            primary_worktree=REPO_ROOT,
+            staging_root=bound_staging,
+        )
+        full_eval.assert_called_once()
 
 
 def test_ops_runner_rejects_wrong_go_token() -> None:
@@ -439,13 +481,15 @@ def test_ops_runner_execution_go_routes_to_guarded_dispatch_not_infrastructure_m
             str(REPO_ROOT),
             "--durable-evidence-root",
             tempfile.mkdtemp(prefix="cs_lead_lag_exec_go_cli_"),
+            "--staging-root",
+            tempfile.mkdtemp(prefix="cs_lead_lag_cli_invalid_staging_"),
         ],
         capture_output=True,
         text=True,
         cwd=str(REPO_ROOT),
     )
     assert proc.returncode == 1
-    assert "BLOCK_REASON=FULL_CANONICAL_PARITY_NOT_PROVEN" in proc.stderr
+    assert "BLOCK_REASON=ECONOMIC_EVALUATION_NOT_AUTHORIZED" not in proc.stderr
     assert "ERR:confirm_go_token_required" not in proc.stderr
 
 


### PR DESCRIPTION
## Summary

- Behebt den Ratification-Execution-Authorization-Gap für `cross_sectional_futures_lead_lag_information_diffusion/v0`: der kanonische Execution-GO-Token wird jetzt invocation-bound und fail-closed in `evaluate_invocation_bound_economic_evaluation_authorization_v0()` abgeleitet, statt ein persistiertes `economic_evaluation_authorized=true` zu verlangen.
- Persistierte Scope-Ratification bleibt `economic_evaluation_authorized=false` (Default-unauthorized); Autorisierung gilt nur bei gleichzeitig erfüllten Co-Requisites (Execution-GO, Digest-Bindings, Futures-only/Bitcoin-Ausschluss, Offline-Boundary, Full-Canonical-Chain, Runtime-Parity).
- Keine Hypothesen-, Parameter-, Dataset-, Kosten-, Risk-/Sizing-, Runtime- oder Promotion-Änderung.

## Root cause

PR #5196 akzeptierte den Execution-GO am Entry Point, aber `verify_full_evaluation_precheck_v1(require_execution_go=True)` blockierte mit `ECONOMIC_EVALUATION_NOT_AUTHORIZED`, weil `materialize_lead_lag_offline_economic_evaluation_scope_ratification_v0()` immer `economic_evaluation_authorized=false` lieferte.

## Invarianten

- `ECONOMIC_EVALUATION_EXECUTED=false` in diesem Repair-Slice
- `RUNTIME_EFFECT=NONE`, `AUTHORITY_EFFECT=NONE`, `LIVE_AUTHORIZED=false`, `ORDERS_ALLOWED=false`
- Binding-/Config-/Implementation-Digests unverändert
- Keine parallele Authorization-SSOT

## Tests

- `tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_authorization_ratification_repair_v0.py` (neu, 22 Fälle)
- Aktualisierte Guard/Full-Runner/Infrastructure-Contract-Tests
- Lokal: 87 passed, 1 skipped

## Evidence

`/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_authorization_ratification_repair_v0_20260715T025347Z` (MANIFEST_VERIFY_RC=0)

## Test plan

- [x] Fokussierte Lead-Lag-Authorization/Precheck/Runner-Contract-Tests grün
- [x] Ruff format/check auf geänderten Dateien grün
- [ ] CI PR_BOUNDED_FULL (central `src/` change)
- [ ] Nach Merge: separater GO für Baseline-Offline-Economic-Evaluation


Made with [Cursor](https://cursor.com)