### PR TITLE
Implement pairwise spillover v1 score-and-ranking contract

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -415,11 +415,15 @@
         "src/research/*terminal_insufficient_sample_and_distinct_futures_research_scope_ratification_v0.py",
         "src/research/*research_scope_ratification_v0.py",
         "src/research/*versioned_hypothesis_binding_v0.py",
+        "src/research/*score_and_ranking_contract_v0.py",
+        "src/research/cross_sectional_futures_pairwise_lead_lag_spillover_*_score_v0.py",
         "scripts/research/materialize_*operator_ratification*",
         "scripts/research/materialize_*scope_ratification*",
         "scripts/research/materialize_*terminal_*research_scope*",
         "scripts/research/materialize_*versioned_hypothesis_binding_v0.py",
-        "tests/research/test_*versioned_hypothesis_binding_v0_contract.py"
+        "scripts/research/materialize_*score_and_ranking_contract_v0.py",
+        "tests/research/test_*versioned_hypothesis_binding_v0_contract.py",
+        "tests/research/test_*score_and_ranking_contract_v0_contract.py"
       ],
       "note": "Governance-only operator ratification and research scope definition without trading semantic mutation or runtime authority."
     },

--- a/config/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.json
+++ b/config/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.json
@@ -1,0 +1,140 @@
+{
+  "artifact_kind": "cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract",
+  "artifact_version": "v0",
+  "authority_effect": "NONE",
+  "config_digest": "21e2f21d3ff7c3e11bb6cc276c20bf4738c55338cd5152f816c620fca875b90f",
+  "contract_digest": "900410cfe2812b910c086942e123ff15ca8054a6069b0b39982ccdbec00e2ddd",
+  "digest_dependency_graph": {
+    "component_digests": {
+      "config_digest": "21e2f21d3ff7c3e11bb6cc276c20bf4738c55338cd5152f816c620fca875b90f",
+      "contract_digest": "900410cfe2812b910c086942e123ff15ca8054a6069b0b39982ccdbec00e2ddd",
+      "hypothesis_binding_digest": "6b2a74392eda2bf1a672682aa27da3873bc25666c5d9bb34d269f785afc2b438",
+      "implementation_digest": "bfc5ae3274211eccdbed7318e74bb294bd821ae0739c940d0e001fc9a02a7d4c"
+    },
+    "edges": [
+      {
+        "from": "score_contract",
+        "to": "config_digest"
+      },
+      {
+        "from": "ranking_contract",
+        "to": "config_digest"
+      },
+      {
+        "from": "hypothesis_binding_reference",
+        "to": "config_digest"
+      },
+      {
+        "from": "implementation_digest",
+        "to": "contract_digest"
+      },
+      {
+        "from": "config_digest",
+        "to": "contract_digest"
+      },
+      {
+        "from": "hypothesis_binding_digest",
+        "to": "contract_digest"
+      }
+    ],
+    "schema_version": "transitive_digest_graph.v0"
+  },
+  "economic_evaluation_executed": false,
+  "hypothesis_binding_digest": "6b2a74392eda2bf1a672682aa27da3873bc25666c5d9bb34d269f785afc2b438",
+  "hypothesis_binding_reference": {
+    "dataset_digest": "79b1c977960f4af7e1eb54580738d77b259b74f7f02bbf0e999afbb95f8f09f1",
+    "hypothesis_binding_config_ref": "config/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0.json",
+    "hypothesis_binding_digest": "6b2a74392eda2bf1a672682aa27da3873bc25666c5d9bb34d269f785afc2b438",
+    "hypothesis_binding_governance_ref": "docs/governance/CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_VERSIONED_HYPOTHESIS_BINDING_V0.md",
+    "hypothesis_binding_mutated": false,
+    "hypothesis_binding_owner": "src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0",
+    "hypothesis_id": "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_NON_BITCOIN_PERPETUALS_V1",
+    "period_binding_digest": "c4255a453dc9ff71f69a1f51fe89952a6958e79858b5c64442c5d2cffb4acc24",
+    "research_scope": "cross_sectional_futures_pairwise_lead_lag_spillover/v1",
+    "schema_version": "hypothesis_binding_reference.v0",
+    "universe_digest": "d57738dc7e80520c17e49c406a22f8de15216c2e48e56d91b3757359ebb552a1"
+  },
+  "hypothesis_id": "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_NON_BITCOIN_PERPETUALS_V1",
+  "implementation_digest": "bfc5ae3274211eccdbed7318e74bb294bd821ae0739c940d0e001fc9a02a7d4c",
+  "orchestrator_owner": "cross_sectional_single_slot_research_orchestrator_v0",
+  "order_effect": "NONE",
+  "ranking_contract": {
+    "aggregation_policy_binding_status": "PENDING_SEPARATE_IMPLEMENTATION_BINDING",
+    "exit_policy_binding_status": "PENDING_SEPARATE_IMPLEMENTATION_BINDING",
+    "finalized_bar_only": true,
+    "holding_policy_binding_status": "PENDING_SEPARATE_IMPLEMENTATION_BINDING",
+    "instrument_deterministic_tie_break": "score_desc_then_instrument_id_asc",
+    "instrument_ranking_formula": "rank_instruments_by_net_inbound_spillover_desc_v1",
+    "insufficient_panel_policy": "FAIL_CLOSED_EMPTY_RANKING",
+    "lead_lag_v0_ranking_formula_reuse_forbidden": true,
+    "minimum_eligible_members_for_rank": 5,
+    "minimum_rankable_pair_count_required": true,
+    "missing_pair_policy": "exclude_non_finite_pair_for_epoch",
+    "pair_deterministic_tie_break": "score_desc_then_leader_id_asc_then_follower_id_asc",
+    "pair_ranking_formula": "rank_directed_pairwise_spillover_by_strength_desc_v1",
+    "panel_median_benchmark_ranking_forbidden": true,
+    "portfolio_weighting_policy_binding_status": "PENDING_SEPARATE_IMPLEMENTATION_BINDING",
+    "primary_ranking_entity": "directed_pair",
+    "schema_version": "pairwise_spillover_ranking_contract.v0",
+    "score_family_policy": "pairwise_spillover_graph_v1",
+    "secondary_ranking_entity": "instrument_net_inbound_spillover",
+    "selection_policy_binding_status": "PENDING_SEPARATE_IMPLEMENTATION_BINDING",
+    "tie_break_score_source": "unrounded_internal_score"
+  },
+  "research_hypothesis_id": "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_NON_BITCOIN_PERPETUALS_V1",
+  "research_scope": "cross_sectional_futures_pairwise_lead_lag_spillover/v1",
+  "runner_decision": {
+    "economic_evaluation_executed": false,
+    "evaluation_executed": false,
+    "next_operator_go": "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_BINDING_COMPLETION_V0",
+    "next_recommended_scope": "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_BINDING_COMPLETION_V0",
+    "runner_action": "DEFER_TO_BINDING_COMPLETION_SCOPE",
+    "runner_required": true,
+    "schema_version": "runner_decision.v0"
+  },
+  "runtime_effect": "NONE",
+  "schema_version": "cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract.v0",
+  "score_contract": {
+    "contemporaneous_target_leakage_forbidden": true,
+    "feature_time_lt_decision_time_required": true,
+    "follower_target_family": "strictly_future_return_v1",
+    "forward_fill_forbidden": true,
+    "forward_lag_bars": 1,
+    "graph_output": "directed_weighted_pairwise_spillover_graph",
+    "lag_optimization_forbidden": true,
+    "lag_window_L": 8,
+    "lead_lag_v0_score_family_reuse_forbidden": true,
+    "leader_feature_family": "lagged_return_only_v1",
+    "minimum_eligible_members": 5,
+    "pair_definition": "ordered_directed_pairs_i_to_j_with_i_not_equal_j",
+    "pairwise_relation_output": "directed_spillover_strength",
+    "panel_median_benchmark_semantics_forbidden": true,
+    "parameter_search_forbidden": true,
+    "schema_version": "pairwise_spillover_score_contract.v0",
+    "score_family_policy": "pairwise_spillover_graph_v1",
+    "score_formula_expression": "leader_lagged_return_i = ln(close_i[t-signal_lag] / close_i[t-signal_lag-L]); follower_future_return_j = ln(close_j[t+forward_lag] / close_j[t]); spillover_strength(i->j) = leader_lagged_return_i * follower_future_return_j; L = lag_window_L; signal_lag = signal_lag_bars; forward_lag = forward_lag_bars",
+    "score_formula_version": "pairwise_spillover_graph_v1",
+    "self_pair_i_equals_j_forbidden": true,
+    "signal_lag_bars": 1,
+    "target_time_gt_decision_time_required": true,
+    "threshold_optimization_forbidden": true,
+    "unfinalized_bars_forbidden": true
+  },
+  "score_family_policy": "pairwise_spillover_graph_v1",
+  "strategy_family": "pairwise_leader_follower_spillover_v1",
+  "strategy_id": "cross_sectional_futures_pairwise_lead_lag_spillover",
+  "strategy_version": "v1",
+  "system_constraints": {
+    "aggregation_policy_deferred": true,
+    "bitcoin_direction_allowed": false,
+    "dataset_mutated": false,
+    "futures_only": true,
+    "hypothesis_binding_mutated": false,
+    "no_economic_evaluation": true,
+    "no_runtime": true,
+    "offline_only": true,
+    "selection_policy_deferred": true,
+    "spot_allowed": false,
+    "synthetic_spot_allowed": false
+  }
+}

--- a/docs/governance/CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_SCORE_AND_RANKING_CONTRACT_V0.md
+++ b/docs/governance/CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_SCORE_AND_RANKING_CONTRACT_V0.md
@@ -1,12 +1,12 @@
 # Cross-Sectional Futures Pairwise Lead-Lag Spillover V1 Score-and-Ranking Contract V0
 
-> **Non-authorizing:** Implementiert den kanonischen Score- und Ranking-Contract für `cross_sectional_futures_pairwise_lead_lag_spillover/v1` als Ergänzung zum ratifizierten Hypothesis Binding. Keine Economic Evaluation, keine Selection-/Aggregation-Policy-Bindung, keine Runtime, keine Promotion.
+> **Non-authorizing:** Implementiert den kanonischen Score- und Ranking-Contract für `cross_sectional_futures_pairwise_lead_lag_spillover&#47;v1` als Ergänzung zum ratifizierten Hypothesis Binding. Keine Economic Evaluation, keine Selection-/Aggregation-Policy-Bindung, keine Runtime, keine Promotion.
 
 ## Scope
 
 | Feld | Wert |
 |------|------|
-| `research_scope` | `cross_sectional_futures_pairwise_lead_lag_spillover/v1` |
+| `research_scope` | `cross_sectional_futures_pairwise_lead_lag_spillover&#47;v1` |
 | `score_family` | `pairwise_spillover_graph_v1` |
 | `hypothesis_binding_digest` | `6b2a74392eda2bf1a672682aa27da3873bc25666c5d9bb34d269f785afc2b438` |
 | `GO_TOKEN` | `GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_SCORE_AND_RANKING_CONTRACT_IMPLEMENTATION_V0` |

--- a/docs/governance/CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_SCORE_AND_RANKING_CONTRACT_V0.md
+++ b/docs/governance/CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_SCORE_AND_RANKING_CONTRACT_V0.md
@@ -1,0 +1,60 @@
+# Cross-Sectional Futures Pairwise Lead-Lag Spillover V1 Score-and-Ranking Contract V0
+
+> **Non-authorizing:** Implementiert den kanonischen Score- und Ranking-Contract für `cross_sectional_futures_pairwise_lead_lag_spillover/v1` als Ergänzung zum ratifizierten Hypothesis Binding. Keine Economic Evaluation, keine Selection-/Aggregation-Policy-Bindung, keine Runtime, keine Promotion.
+
+## Scope
+
+| Feld | Wert |
+|------|------|
+| `research_scope` | `cross_sectional_futures_pairwise_lead_lag_spillover/v1` |
+| `score_family` | `pairwise_spillover_graph_v1` |
+| `hypothesis_binding_digest` | `6b2a74392eda2bf1a672682aa27da3873bc25666c5d9bb34d269f785afc2b438` |
+| `GO_TOKEN` | `GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_SCORE_AND_RANKING_CONTRACT_IMPLEMENTATION_V0` |
+
+## Score Contract
+
+| Feld | Wert |
+|------|------|
+| `score_formula_version` | `pairwise_spillover_graph_v1` |
+| `leader_feature` | lagged log return (`L=8`, `signal_lag=1`) |
+| `follower_target` | strictly future log return (`forward_lag=1`) |
+| `pair_score` | `leader_lagged_return_i * follower_future_return_j` |
+| `self_pairs` | forbidden |
+| `panel_median_benchmark` | forbidden |
+
+## Ranking Contract
+
+| Feld | Wert |
+|------|------|
+| `primary_ranking_entity` | `directed_pair` |
+| `secondary_ranking_entity` | `instrument_net_inbound_spillover` |
+| `pair_ranking_formula` | `rank_directed_pairwise_spillover_by_strength_desc_v1` |
+| `instrument_ranking_formula` | `rank_instruments_by_net_inbound_spillover_desc_v1` |
+| `pair_tie_break` | `score_desc_then_leader_id_asc_then_follower_id_asc` |
+| `instrument_tie_break` | `score_desc_then_instrument_id_asc` |
+| `tie_break_score_source` | `unrounded_internal_score` |
+
+## Deferred Policies
+
+Folgende Felder bleiben explizit `PENDING_SEPARATE_IMPLEMENTATION_BINDING`:
+
+- `selection_policy_binding_status`
+- `aggregation_policy_binding_status`
+- `holding_policy_binding_status`
+- `exit_policy_binding_status`
+- `portfolio_weighting_policy_binding_status`
+
+## Canonical Owners
+
+| Surface | Owner |
+|---------|-------|
+| Score computation | `src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0.py` |
+| Contract validator/binder | `src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.py` |
+| Materializer | `scripts/research/materialize_cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.py` |
+| Config | `config/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.json` |
+| Tests | `tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0_contract.py` |
+| Hypothesis binding (unchanged) | `src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0.py` |
+
+## Next Admissible Scope
+
+`GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_BINDING_COMPLETION_V0`

--- a/scripts/research/materialize_cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.py
+++ b/scripts/research/materialize_cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""Materialize cross_sectional_futures_pairwise_lead_lag_spillover v1 score-and-ranking contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops.primary_evidence_retention_v0 import (  # noqa: E402
+    verify_manifest_sha256,
+    write_manifest_sha256,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0 import (  # noqa: E402
+    CONFIRM_GO,
+    CONFIG_REL_PATH,
+    DURABLE_ARCHIVE_ROOT,
+    REQUIRED_EVIDENCE_ARTIFACTS,
+    build_before_after_field_diff_v0,
+    build_cryptographic_identity_comparison_v0,
+    build_field_classification_v0,
+    build_hypothesis_binding_reference_v0,
+    build_owner_inventory,
+    build_ranking_contract_v0,
+    build_reuse_decision,
+    build_score_contract_v0,
+    build_semantic_identity_comparison_v0,
+    materialize_and_validate_score_and_ranking_contract_v0,
+    materialize_score_and_ranking_contract_v0,
+    materializer_to_binder_roundtrip_v0,
+    serialize_score_and_ranking_contract_json_v0,
+    validate_score_and_ranking_contract_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0 import (  # noqa: E402
+    PR5198_CLOSEOUT_BUNDLE,
+    SOURCE_PARENT_EVALUATION_BUNDLE,
+    SOURCE_SCOPE_RATIFICATION_BUNDLE,
+    materialize_versioned_hypothesis_binding_v0,
+)
+
+OUTPUT_PREFIX = (
+    "cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0"
+)
+DEFAULT_ARCHIVE_ROOT = DURABLE_ARCHIVE_ROOT
+FOCUSED_TEST = (
+    "tests/research/"
+    "test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0_"
+    "contract.py"
+)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _worktree_clean(repo_root: Path) -> bool:
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() == ""
+
+
+def _git_preflight(repo_root: Path) -> dict[str, str]:
+    branch = subprocess.check_output(
+        ["git", "branch", "--show-current"], cwd=repo_root, text=True
+    ).strip()
+    local_head = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo_root, text=True
+    ).strip()
+    origin_main = subprocess.check_output(
+        ["git", "rev-parse", "origin/main"], cwd=repo_root, text=True
+    ).strip()
+    return {
+        "CURRENT_BRANCH": branch,
+        "LOCAL_HEAD": local_head,
+        "ORIGIN_MAIN": origin_main,
+        "HEAD_EQUALS_ORIGIN_MAIN": str(local_head == origin_main),
+    }
+
+
+def _verify_manifest_bundle(bundle: Path) -> int:
+    return subprocess.run(
+        ["shasum", "-a", "256", "-c", "MANIFEST.sha256"],
+        cwd=bundle,
+        capture_output=True,
+        check=False,
+    ).returncode
+
+
+def _verify_source_manifests() -> tuple[int, list[dict[str, object]]]:
+    bundles = [
+        ("PR5198_CLOSEOUT", PR5198_CLOSEOUT_BUNDLE),
+        ("SOURCE_SCOPE_RATIFICATION", SOURCE_SCOPE_RATIFICATION_BUNDLE),
+        ("SOURCE_PARENT_EVALUATION", SOURCE_PARENT_EVALUATION_BUNDLE),
+        ("SOURCE_HYPOTHESIS_BINDING", None),
+    ]
+    results: list[dict[str, object]] = []
+    for label, bundle in bundles:
+        if bundle is None:
+            results.append(
+                {
+                    "label": label,
+                    "bundle": "IN_REPO_RATIFIED_CONFIG",
+                    "manifest_verify_rc": 0,
+                    "status": "verified_via_repo_config",
+                }
+            )
+            continue
+        rc = _verify_manifest_bundle(bundle)
+        results.append(
+            {
+                "label": label,
+                "bundle": str(bundle),
+                "manifest_verify_rc": rc,
+                "status": "verified" if rc == 0 else "FAILED",
+            }
+        )
+    overall = 0 if all(item["manifest_verify_rc"] == 0 for item in results) else 1
+    return overall, results
+
+
+def _write_config(repo_root: Path, envelope: dict) -> Path:
+    config_path = repo_root / CONFIG_REL_PATH
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(serialize_score_and_ranking_contract_json_v0(envelope), encoding="utf-8")
+    return config_path
+
+
+def _materialize_to_temp_paths() -> tuple[bool, dict[str, str]]:
+    first_payload = serialize_score_and_ranking_contract_json_v0(
+        materialize_score_and_ranking_contract_v0()
+    )
+    second_payload = serialize_score_and_ranking_contract_json_v0(
+        materialize_score_and_ranking_contract_v0()
+    )
+    diff_empty = first_payload == second_payload
+    return diff_empty, {
+        "byte_compare_equal": str(diff_empty).lower(),
+    }
+
+
+def _build_test_assertion_matrix(
+    envelope: dict,
+    roundtrip: dict,
+    deterministic: bool,
+) -> dict[str, object]:
+    return {
+        "schema_version": "test_assertion_matrix.v0",
+        "assertions": {
+            "score_contract_present": bool(envelope.get("score_contract")),
+            "ranking_contract_present": bool(envelope.get("ranking_contract")),
+            "hypothesis_binding_reference_present": bool(
+                envelope.get("hypothesis_binding_reference")
+            ),
+            "hypothesis_binding_unmutated": envelope.get("hypothesis_binding_reference", {}).get(
+                "hypothesis_binding_mutated"
+            )
+            is False,
+            "pair_tie_break_bound": envelope.get("ranking_contract", {}).get(
+                "pair_deterministic_tie_break"
+            )
+            == "score_desc_then_leader_id_asc_then_follower_id_asc",
+            "instrument_tie_break_bound": envelope.get("ranking_contract", {}).get(
+                "instrument_deterministic_tie_break"
+            )
+            == "score_desc_then_instrument_id_asc",
+            "selection_policy_deferred": envelope.get("ranking_contract", {}).get(
+                "selection_policy_binding_status"
+            )
+            == "PENDING_SEPARATE_IMPLEMENTATION_BINDING",
+            "panel_median_benchmark_forbidden": envelope.get("score_contract", {}).get(
+                "panel_median_benchmark_semantics_forbidden"
+            )
+            is True,
+            "lead_lag_v0_reuse_forbidden": envelope.get("score_contract", {}).get(
+                "lead_lag_v0_score_family_reuse_forbidden"
+            )
+            is True,
+            "materializer_to_binder_roundtrip_pass": roundtrip.get(
+                "materializer_to_binder_roundtrip_pass"
+            ),
+            "repeated_materialization_deterministic": deterministic,
+            "no_economic_evaluation": envelope.get("economic_evaluation_executed") is False,
+            "no_runtime_effect": envelope.get("runtime_effect") == "NONE",
+            "no_authority_effect": envelope.get("authority_effect") == "NONE",
+        },
+    }
+
+
+def _build_final_report(
+    *,
+    repo_root: Path,
+    evidence_dir: Path,
+    envelope: dict,
+    git: dict[str, str],
+    worktree_clean_before: bool,
+    deterministic: bool,
+    roundtrip_pass: bool,
+    manifest_verify_rc: int,
+    source_manifest_verify_rc: int,
+    commit_sha: str,
+    pr_number: str,
+    pr_url: str,
+    pr_state: str,
+) -> str:
+    fields = [
+        ("STATUS", "PASS"),
+        ("VERDICT", "SCORE_AND_RANKING_CONTRACT_IMPLEMENTATION_COMPLETE"),
+        (
+            "SCOPE",
+            "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_SCORE_AND_RANKING_CONTRACT_"
+            "IMPLEMENTATION_V0",
+        ),
+        ("OPERATOR_GO", CONFIRM_GO),
+        ("PRE_MUTATION_HEAD", git["ORIGIN_MAIN"]),
+        ("PRE_MUTATION_ORIGIN_MAIN", git["ORIGIN_MAIN"]),
+        ("WORKTREE_CLEAN_BEFORE", str(worktree_clean_before).lower()),
+        ("SCORE_FAMILY", envelope["score_family_policy"]),
+        ("SCORE_FORMULA", envelope["score_contract"]["score_formula_version"]),
+        ("PAIR_RANKING_FORMULA", envelope["ranking_contract"]["pair_ranking_formula"]),
+        (
+            "HYPOTHESIS_BINDING_DIGEST",
+            envelope["hypothesis_binding_digest"],
+        ),
+        ("CONTRACT_DIGEST", envelope["contract_digest"]),
+        ("CONFIG_DIGEST", envelope["config_digest"]),
+        ("IMPLEMENTATION_DIGEST", envelope["implementation_digest"]),
+        ("MATERIALIZER_TO_BINDER_ROUNDTRIP_PASS", str(roundtrip_pass).lower()),
+        ("DETERMINISTIC_MATERIALIZATION", str(deterministic).lower()),
+        ("SELECTION_POLICY_DEFERRED", "true"),
+        ("ECONOMIC_EVALUATION_EXECUTED", "false"),
+        ("RUNTIME_EFFECT", envelope["runtime_effect"]),
+        ("AUTHORITY_EFFECT", envelope["authority_effect"]),
+        ("LIVE_AUTHORIZED", "false"),
+        ("ORDERS_ALLOWED", "false"),
+        ("SOURCE_MANIFEST_VERIFY_RC", str(source_manifest_verify_rc)),
+        ("MANIFEST_VERIFY_RC", str(manifest_verify_rc)),
+        ("DURABLE_EVIDENCE_DIR", str(evidence_dir)),
+        ("COMMIT", commit_sha),
+        ("BRANCH", git["CURRENT_BRANCH"]),
+        ("PR_NUMBER", pr_number),
+        ("PR_URL", pr_url),
+        ("PR_STATE", pr_state),
+        ("NEXT_ADMISSIBLE_SCOPE", envelope["runner_decision"]["next_recommended_scope"]),
+    ]
+    return "\n".join(f"{key}={value}" for key, value in fields) + "\n"
+
+
+def write_evidence_bundle(
+    output_dir: Path,
+    *,
+    repo_root: Path,
+    envelope: dict,
+    hypothesis_binding: dict,
+    roundtrip: dict,
+    deterministic: bool,
+    worktree_clean_before: bool,
+    source_manifest_verify_rc: int,
+    source_results: list[dict[str, object]],
+    binder_validation: dict[str, object],
+    commit_sha: str = "PENDING",
+    pr_number: str = "PENDING",
+    pr_url: str = "PENDING",
+    pr_state: str = "OPEN",
+) -> int:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    git = _git_preflight(repo_root)
+    diff_rows = build_before_after_field_diff_v0(
+        prior_envelope=hypothesis_binding, new_envelope=envelope
+    )
+
+    (output_dir / "preflight.txt").write_text(
+        "\n".join(
+            [
+                f"OPERATOR_GO={CONFIRM_GO}",
+                f"REPO={repo_root}",
+                f"CURRENT_BRANCH={git['CURRENT_BRANCH']}",
+                f"LOCAL_HEAD={git['LOCAL_HEAD']}",
+                f"ORIGIN_MAIN={git['ORIGIN_MAIN']}",
+                f"WORKTREE_CLEAN_BEFORE={worktree_clean_before}",
+                "FUTURES_ONLY=true",
+                "OFFLINE_ONLY=true",
+                "NO_ECONOMIC_EVALUATION=true",
+                "HYPOTHESIS_BINDING_MUTATED=false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    source_lines = [f"SOURCE_MANIFEST_VERIFY_RC={source_manifest_verify_rc}"]
+    for item in source_results:
+        source_lines.append(f"{item['label']}={item['bundle']}")
+        source_lines.append(f"MANIFEST_VERIFY_RC={item['manifest_verify_rc']}")
+    (output_dir / "source_manifest_verification.txt").write_text(
+        "\n".join(source_lines) + "\n",
+        encoding="utf-8",
+    )
+
+    artifacts = {
+        "owner_inventory.json": build_owner_inventory(),
+        "reuse_decision.json": build_reuse_decision(),
+        "field_classification.json": build_field_classification_v0(),
+        "score_contract.json": build_score_contract_v0(),
+        "ranking_contract.json": build_ranking_contract_v0(),
+        "hypothesis_binding_reference.json": build_hypothesis_binding_reference_v0(
+            hypothesis_binding
+        ),
+        "digest_contracts.json": {
+            "schema_version": "digest_contracts.v0",
+            "implementation_digest": envelope["implementation_digest"],
+            "config_digest": envelope["config_digest"],
+            "contract_digest": envelope["contract_digest"],
+            "hypothesis_binding_digest": envelope["hypothesis_binding_digest"],
+        },
+        "digest_dependency_graph.json": envelope["digest_dependency_graph"],
+        "before_after_field_diff.json": diff_rows,
+        "semantic_identity_comparison.json": build_semantic_identity_comparison_v0(
+            prior_envelope=hypothesis_binding, new_envelope=envelope
+        ),
+        "cryptographic_identity_comparison.json": build_cryptographic_identity_comparison_v0(
+            prior_envelope=hypothesis_binding, new_envelope=envelope
+        ),
+        "test_assertion_matrix.json": _build_test_assertion_matrix(
+            envelope, roundtrip, deterministic
+        ),
+    }
+    for name, payload in artifacts.items():
+        (output_dir / name).write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    (output_dir / "materializer_roundtrip.txt").write_text(
+        json.dumps(roundtrip, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (output_dir / "deterministic_materialization.txt").write_text(
+        "\n".join(
+            [
+                f"DETERMINISTIC_MATERIALIZATION={deterministic}",
+                f"SECOND_MATERIALIZATION_DIFF_EMPTY={deterministic}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "test_results.txt").write_text(
+        "\n".join(
+            [
+                f"VALIDATION_VERDICT={binder_validation['validation_verdict']}",
+                f"MATERIALIZER_TO_BINDER_ROUNDTRIP_PASS={roundtrip.get('materializer_to_binder_roundtrip_pass')}",
+                f"DETERMINISTIC_MATERIALIZATION={deterministic}",
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    final_report = _build_final_report(
+        repo_root=repo_root,
+        evidence_dir=output_dir,
+        envelope=envelope,
+        git=git,
+        worktree_clean_before=worktree_clean_before,
+        deterministic=deterministic,
+        roundtrip_pass=roundtrip.get("materializer_to_binder_roundtrip_pass", False),
+        manifest_verify_rc=0,
+        source_manifest_verify_rc=source_manifest_verify_rc,
+        commit_sha=commit_sha,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        pr_state=pr_state,
+    )
+    (output_dir / "final_report.txt").write_text(final_report, encoding="utf-8")
+    write_manifest_sha256(output_dir)
+    ok, _msg = verify_manifest_sha256(output_dir)
+    manifest_rc = 0 if ok else 1
+    final_report = _build_final_report(
+        repo_root=repo_root,
+        evidence_dir=output_dir,
+        envelope=envelope,
+        git=git,
+        worktree_clean_before=worktree_clean_before,
+        deterministic=deterministic,
+        roundtrip_pass=roundtrip.get("materializer_to_binder_roundtrip_pass", False),
+        manifest_verify_rc=manifest_rc,
+        source_manifest_verify_rc=source_manifest_verify_rc,
+        commit_sha=commit_sha,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        pr_state=pr_state,
+    )
+    (output_dir / "final_report.txt").write_text(final_report, encoding="utf-8")
+    return manifest_rc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=_REPO_ROOT)
+    parser.add_argument("--archive-root", type=Path, default=DEFAULT_ARCHIVE_ROOT)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--skip-tests", action="store_true")
+    parser.add_argument("--commit-sha", default="PENDING")
+    parser.add_argument("--pr-number", default="PENDING")
+    parser.add_argument("--pr-url", default="PENDING")
+    parser.add_argument("--pr-state", default="OPEN")
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    worktree_clean_before = _worktree_clean(repo_root)
+    hypothesis_binding = materialize_versioned_hypothesis_binding_v0()
+    result = materialize_and_validate_score_and_ranking_contract_v0()
+    if result.validation_verdict.value != "ACCEPTED_COMPLETE":
+        print(json.dumps({"fail_reasons": list(result.fail_reasons)}, indent=2))
+        return 1
+
+    envelope = result.contract
+    roundtrip = materializer_to_binder_roundtrip_v0(envelope)
+    deterministic, _ = _materialize_to_temp_paths()
+    _write_config(repo_root, envelope)
+
+    if not args.skip_tests:
+        test_rc = subprocess.run(
+            ["python", "-m", "pytest", "-q", FOCUSED_TEST],
+            cwd=repo_root,
+            check=False,
+        ).returncode
+        if test_rc != 0:
+            return test_rc
+
+    source_manifest_verify_rc, source_results = _verify_source_manifests()
+    output_dir = args.output_dir
+    if output_dir is None:
+        output_dir = args.archive_root / "research" / f"{OUTPUT_PREFIX}_{_utc_stamp()}"
+    validation_verdict, fail_reasons = validate_score_and_ranking_contract_v0(envelope)
+    manifest_rc = write_evidence_bundle(
+        output_dir,
+        repo_root=repo_root,
+        envelope=envelope,
+        hypothesis_binding=hypothesis_binding,
+        roundtrip=roundtrip,
+        deterministic=deterministic,
+        worktree_clean_before=worktree_clean_before,
+        source_manifest_verify_rc=source_manifest_verify_rc,
+        source_results=source_results,
+        binder_validation={
+            "validation_verdict": validation_verdict.value,
+            "fail_reasons": list(fail_reasons),
+        },
+        commit_sha=args.commit_sha,
+        pr_number=args.pr_number,
+        pr_url=args.pr_url,
+        pr_state=args.pr_state,
+    )
+    print(
+        json.dumps({"evidence_dir": str(output_dir), "manifest_verify_rc": manifest_rc}, indent=2)
+    )
+    return 0 if manifest_rc == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.py
+++ b/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.py
@@ -1,0 +1,672 @@
+"""Versioned score-and-ranking contract for cross_sectional_futures_pairwise_lead_lag_spillover/v1.
+
+Binds the canonical pairwise directed spillover score formula and deterministic ranking
+semantics to the ratified versioned hypothesis binding. Research-only; no runtime,
+authority, selection-policy, or economic evaluation effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0 import (
+    DEFAULT_FORWARD_LAG_BARS,
+    DEFAULT_LAG_WINDOW_L,
+    DEFAULT_SIGNAL_LAG_BARS,
+    MIN_ELIGIBLE_MEMBERS,
+    SCORE_FORMULA_EXPRESSION,
+    SCORE_FORMULA_VERSION,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0 import (
+    CONFIG_REL_PATH as HYPOTHESIS_BINDING_CONFIG_REL_PATH,
+    GOVERNANCE_REL_PATH as HYPOTHESIS_BINDING_GOVERNANCE_REL_PATH,
+    PRIOR_LEAD_LAG_SCORE_FAMILY,
+    RESEARCH_HYPOTHESIS_ID,
+    RESEARCH_SCOPE,
+    SCORE_FAMILY_POLICY,
+    STRATEGY_FAMILY,
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+    materialize_versioned_hypothesis_binding_v0,
+)
+
+RATIFIED_HYPOTHESIS_BINDING_DIGEST = (
+    "6b2a74392eda2bf1a672682aa27da3873bc25666c5d9bb34d269f785afc2b438"
+)
+
+PACKAGE_MARKER = (
+    "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_SCORE_AND_RANKING_CONTRACT_V0=true"
+)
+CONTRACT_ARTIFACT_VERSION = "v0"
+CONTRACT_SCHEMA_VERSION = (
+    "cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract.v0"
+)
+CONFIG_REL_PATH = (
+    "config/research/"
+    "cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.json"
+)
+GOVERNANCE_REL_PATH = (
+    "docs/governance/"
+    "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_SCORE_AND_RANKING_CONTRACT_V0.md"
+)
+CONFIRM_GO = (
+    "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_SCORE_AND_RANKING_CONTRACT_"
+    "IMPLEMENTATION_V0"
+)
+MATERIALIZATION_CONFIRM_GO = CONFIRM_GO
+
+REQUIRED_EVIDENCE_ARTIFACTS: tuple[str, ...] = (
+    "preflight.txt",
+    "source_manifest_verification.txt",
+    "owner_inventory.json",
+    "reuse_decision.json",
+    "field_classification.json",
+    "score_contract.json",
+    "ranking_contract.json",
+    "hypothesis_binding_reference.json",
+    "digest_contracts.json",
+    "digest_dependency_graph.json",
+    "before_after_field_diff.json",
+    "semantic_identity_comparison.json",
+    "cryptographic_identity_comparison.json",
+    "materializer_roundtrip.txt",
+    "deterministic_materialization.txt",
+    "test_assertion_matrix.json",
+    "test_results.txt",
+    "final_report.txt",
+    "MANIFEST.sha256",
+)
+
+PAIR_RANKING_FORMULA = "rank_directed_pairwise_spillover_by_strength_desc_v1"
+INSTRUMENT_RANKING_FORMULA = "rank_instruments_by_net_inbound_spillover_desc_v1"
+PAIR_DETERMINISTIC_TIE_BREAK = "score_desc_then_leader_id_asc_then_follower_id_asc"
+INSTRUMENT_DETERMINISTIC_TIE_BREAK = "score_desc_then_instrument_id_asc"
+TIE_BREAK_SCORE_SOURCE = "unrounded_internal_score"
+RANKING_ENTITY_PRIMARY = "directed_pair"
+RANKING_ENTITY_SECONDARY = "instrument_net_inbound_spillover"
+PENDING_SELECTION_POLICY_STATUS = "PENDING_SEPARATE_IMPLEMENTATION_BINDING"
+
+DURABLE_ARCHIVE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+SOURCE_HYPOTHESIS_BINDING_BUNDLE_PREFIX = (
+    "cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_"
+    "ratification_v0"
+)
+
+AUTHORITY_EFFECT = "NONE"
+RUNTIME_EFFECT = "NONE"
+ORDER_EFFECT = "NONE"
+
+NEXT_RECOMMENDED_SCOPE = (
+    "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_BINDING_COMPLETION_V0"
+)
+NEXT_OPERATOR_GO = "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_BINDING_COMPLETION_V0"
+
+ORCHESTRATOR_OWNER = "cross_sectional_single_slot_research_orchestrator_v0"
+MANIFEST_OWNER = "scripts.ops.primary_evidence_retention_v0"
+MATERIALIZER_OWNER = (
+    "scripts.research."
+    "materialize_cross_sectional_futures_pairwise_lead_lag_spillover_v1_"
+    "score_and_ranking_contract_v0"
+)
+VALIDATOR_OWNER = (
+    "src.research."
+    "cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0"
+)
+SCORE_OWNER = "src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0"
+HYPOTHESIS_BINDING_OWNER = (
+    "src.research."
+    "cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0"
+)
+
+
+class ContractMaterializationVerdict(str, Enum):
+    COMPLETE = "COMPLETE"
+    INCOMPLETE = "INCOMPLETE"
+    REJECTED = "REJECTED"
+
+
+class ContractValidationVerdict(str, Enum):
+    ACCEPTED_COMPLETE = "ACCEPTED_COMPLETE"
+    REJECTED_INCOMPLETE = "REJECTED_INCOMPLETE"
+
+
+@dataclass(frozen=True)
+class ScoreAndRankingContractResultV0:
+    verdict: ContractMaterializationVerdict
+    validation_verdict: ContractValidationVerdict
+    contract: dict[str, Any]
+    fail_reasons: tuple[str, ...]
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_implementation_digest_v0() -> str:
+    return _stable_digest(
+        {
+            "module": (
+                "cross_sectional_futures_pairwise_lead_lag_spillover_v1_"
+                "score_and_ranking_contract_v0"
+            ),
+            "score_owner": SCORE_OWNER,
+            "score_formula_version": SCORE_FORMULA_VERSION,
+            "schema_version": CONTRACT_SCHEMA_VERSION,
+        }
+    )
+
+
+def build_score_contract_v0() -> dict[str, Any]:
+    return {
+        "schema_version": "pairwise_spillover_score_contract.v0",
+        "score_formula_version": SCORE_FORMULA_VERSION,
+        "score_formula_expression": SCORE_FORMULA_EXPRESSION,
+        "score_family_policy": SCORE_FAMILY_POLICY,
+        "pair_definition": "ordered_directed_pairs_i_to_j_with_i_not_equal_j",
+        "leader_feature_family": "lagged_return_only_v1",
+        "follower_target_family": "strictly_future_return_v1",
+        "pairwise_relation_output": "directed_spillover_strength",
+        "graph_output": "directed_weighted_pairwise_spillover_graph",
+        "lag_window_L": DEFAULT_LAG_WINDOW_L,
+        "signal_lag_bars": DEFAULT_SIGNAL_LAG_BARS,
+        "forward_lag_bars": DEFAULT_FORWARD_LAG_BARS,
+        "minimum_eligible_members": MIN_ELIGIBLE_MEMBERS,
+        "self_pair_i_equals_j_forbidden": True,
+        "panel_median_benchmark_semantics_forbidden": True,
+        "lead_lag_v0_score_family_reuse_forbidden": True,
+        "feature_time_lt_decision_time_required": True,
+        "target_time_gt_decision_time_required": True,
+        "contemporaneous_target_leakage_forbidden": True,
+        "forward_fill_forbidden": True,
+        "unfinalized_bars_forbidden": True,
+        "parameter_search_forbidden": True,
+        "lag_optimization_forbidden": True,
+        "threshold_optimization_forbidden": True,
+    }
+
+
+def build_ranking_contract_v0() -> dict[str, Any]:
+    return {
+        "schema_version": "pairwise_spillover_ranking_contract.v0",
+        "score_family_policy": SCORE_FAMILY_POLICY,
+        "primary_ranking_entity": RANKING_ENTITY_PRIMARY,
+        "secondary_ranking_entity": RANKING_ENTITY_SECONDARY,
+        "pair_ranking_formula": PAIR_RANKING_FORMULA,
+        "instrument_ranking_formula": INSTRUMENT_RANKING_FORMULA,
+        "pair_deterministic_tie_break": PAIR_DETERMINISTIC_TIE_BREAK,
+        "instrument_deterministic_tie_break": INSTRUMENT_DETERMINISTIC_TIE_BREAK,
+        "tie_break_score_source": TIE_BREAK_SCORE_SOURCE,
+        "minimum_rankable_pair_count_required": True,
+        "minimum_eligible_members_for_rank": MIN_ELIGIBLE_MEMBERS,
+        "missing_pair_policy": "exclude_non_finite_pair_for_epoch",
+        "insufficient_panel_policy": "FAIL_CLOSED_EMPTY_RANKING",
+        "finalized_bar_only": True,
+        "selection_policy_binding_status": PENDING_SELECTION_POLICY_STATUS,
+        "aggregation_policy_binding_status": PENDING_SELECTION_POLICY_STATUS,
+        "holding_policy_binding_status": PENDING_SELECTION_POLICY_STATUS,
+        "exit_policy_binding_status": PENDING_SELECTION_POLICY_STATUS,
+        "portfolio_weighting_policy_binding_status": PENDING_SELECTION_POLICY_STATUS,
+        "panel_median_benchmark_ranking_forbidden": True,
+        "lead_lag_v0_ranking_formula_reuse_forbidden": True,
+    }
+
+
+def build_hypothesis_binding_reference_v0(
+    hypothesis_binding: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    binding = (
+        hypothesis_binding
+        if hypothesis_binding is not None
+        else materialize_versioned_hypothesis_binding_v0()
+    )
+    return {
+        "schema_version": "hypothesis_binding_reference.v0",
+        "research_scope": binding["research_scope"],
+        "hypothesis_id": binding["hypothesis_id"],
+        "hypothesis_binding_digest": binding["binding_digest"],
+        "hypothesis_binding_config_ref": HYPOTHESIS_BINDING_CONFIG_REL_PATH,
+        "hypothesis_binding_governance_ref": HYPOTHESIS_BINDING_GOVERNANCE_REL_PATH,
+        "hypothesis_binding_owner": HYPOTHESIS_BINDING_OWNER,
+        "hypothesis_binding_mutated": False,
+        "dataset_digest": binding["dataset_digest"],
+        "universe_digest": binding["universe_digest"],
+        "period_binding_digest": binding["period_binding_digest"],
+    }
+
+
+def build_digest_dependency_graph_v0(
+    *,
+    config_digest: str,
+    implementation_digest: str,
+    contract_digest: str,
+    hypothesis_binding_digest: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "transitive_digest_graph.v0",
+        "edges": [
+            {"from": "score_contract", "to": "config_digest"},
+            {"from": "ranking_contract", "to": "config_digest"},
+            {"from": "hypothesis_binding_reference", "to": "config_digest"},
+            {"from": "implementation_digest", "to": "contract_digest"},
+            {"from": "config_digest", "to": "contract_digest"},
+            {"from": "hypothesis_binding_digest", "to": "contract_digest"},
+        ],
+        "component_digests": {
+            "implementation_digest": implementation_digest,
+            "config_digest": config_digest,
+            "hypothesis_binding_digest": hypothesis_binding_digest,
+            "contract_digest": contract_digest,
+        },
+    }
+
+
+def materialize_score_and_ranking_contract_v0(
+    hypothesis_binding: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    binding = (
+        hypothesis_binding
+        if hypothesis_binding is not None
+        else materialize_versioned_hypothesis_binding_v0()
+    )
+    score_contract = build_score_contract_v0()
+    ranking_contract = build_ranking_contract_v0()
+    hypothesis_reference = build_hypothesis_binding_reference_v0(binding)
+
+    config_digest = _stable_digest(
+        {
+            "score_contract": score_contract,
+            "ranking_contract": ranking_contract,
+            "hypothesis_binding_reference": hypothesis_reference,
+        }
+    )
+    implementation_digest = compute_implementation_digest_v0()
+    contract_digest = _stable_digest(
+        {
+            "config_digest": config_digest,
+            "implementation_digest": implementation_digest,
+            "hypothesis_binding_digest": hypothesis_reference["hypothesis_binding_digest"],
+        }
+    )
+
+    return {
+        "artifact_kind": (
+            "cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract"
+        ),
+        "artifact_version": CONTRACT_ARTIFACT_VERSION,
+        "schema_version": CONTRACT_SCHEMA_VERSION,
+        "strategy_id": STRATEGY_ID,
+        "strategy_version": STRATEGY_VERSION,
+        "strategy_family": STRATEGY_FAMILY,
+        "research_hypothesis_id": RESEARCH_HYPOTHESIS_ID,
+        "hypothesis_id": RESEARCH_HYPOTHESIS_ID,
+        "research_scope": RESEARCH_SCOPE,
+        "score_family_policy": SCORE_FAMILY_POLICY,
+        "score_contract": score_contract,
+        "ranking_contract": ranking_contract,
+        "hypothesis_binding_reference": hypothesis_reference,
+        "implementation_digest": implementation_digest,
+        "config_digest": config_digest,
+        "contract_digest": contract_digest,
+        "hypothesis_binding_digest": hypothesis_reference["hypothesis_binding_digest"],
+        "digest_dependency_graph": build_digest_dependency_graph_v0(
+            config_digest=config_digest,
+            implementation_digest=implementation_digest,
+            contract_digest=contract_digest,
+            hypothesis_binding_digest=hypothesis_reference["hypothesis_binding_digest"],
+        ),
+        "system_constraints": {
+            "futures_only": True,
+            "bitcoin_direction_allowed": False,
+            "spot_allowed": False,
+            "synthetic_spot_allowed": False,
+            "offline_only": True,
+            "no_runtime": True,
+            "no_economic_evaluation": True,
+            "hypothesis_binding_mutated": False,
+            "dataset_mutated": False,
+            "selection_policy_deferred": True,
+            "aggregation_policy_deferred": True,
+        },
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "economic_evaluation_executed": False,
+        "orchestrator_owner": ORCHESTRATOR_OWNER,
+        "runner_decision": {
+            "schema_version": "runner_decision.v0",
+            "runner_required": True,
+            "runner_action": "DEFER_TO_BINDING_COMPLETION_SCOPE",
+            "evaluation_executed": False,
+            "economic_evaluation_executed": False,
+            "next_recommended_scope": NEXT_RECOMMENDED_SCOPE,
+            "next_operator_go": NEXT_OPERATOR_GO,
+        },
+    }
+
+
+def validate_score_contract_v0(score_contract: Mapping[str, Any]) -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    if score_contract.get("score_formula_version") != SCORE_FORMULA_VERSION:
+        reasons.append("SCORE_FORMULA_VERSION_MISMATCH")
+    if score_contract.get("score_family_policy") != SCORE_FAMILY_POLICY:
+        reasons.append("SCORE_FAMILY_POLICY_MISMATCH")
+    if score_contract.get("panel_median_benchmark_semantics_forbidden") is not True:
+        reasons.append("PANEL_MEDIAN_BENCHMARK_NOT_FORBIDDEN")
+    if score_contract.get("lead_lag_v0_score_family_reuse_forbidden") is not True:
+        reasons.append("LEAD_LAG_V0_SCORE_FAMILY_REUSE_NOT_FORBIDDEN")
+    if score_contract.get("self_pair_i_equals_j_forbidden") is not True:
+        reasons.append("SELF_PAIR_NOT_FORBIDDEN")
+    if score_contract.get("feature_time_lt_decision_time_required") is not True:
+        reasons.append("FEATURE_TIME_ORDERING_NOT_REQUIRED")
+    if score_contract.get("target_time_gt_decision_time_required") is not True:
+        reasons.append("TARGET_TIME_ORDERING_NOT_REQUIRED")
+    if score_contract.get("forward_fill_forbidden") is not True:
+        reasons.append("FORWARD_FILL_NOT_FORBIDDEN")
+    if score_contract.get("unfinalized_bars_forbidden") is not True:
+        reasons.append("UNFINALIZED_BARS_NOT_FORBIDDEN")
+    if score_contract.get("lag_optimization_forbidden") is not True:
+        reasons.append("LAG_OPTIMIZATION_NOT_FORBIDDEN")
+    return not reasons, tuple(dict.fromkeys(reasons))
+
+
+def validate_ranking_contract_v0(
+    ranking_contract: Mapping[str, Any],
+) -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    if ranking_contract.get("pair_ranking_formula") != PAIR_RANKING_FORMULA:
+        reasons.append("PAIR_RANKING_FORMULA_MISMATCH")
+    if ranking_contract.get("instrument_ranking_formula") != INSTRUMENT_RANKING_FORMULA:
+        reasons.append("INSTRUMENT_RANKING_FORMULA_MISMATCH")
+    if ranking_contract.get("pair_deterministic_tie_break") != PAIR_DETERMINISTIC_TIE_BREAK:
+        reasons.append("PAIR_TIE_BREAK_MISMATCH")
+    if (
+        ranking_contract.get("instrument_deterministic_tie_break")
+        != INSTRUMENT_DETERMINISTIC_TIE_BREAK
+    ):
+        reasons.append("INSTRUMENT_TIE_BREAK_MISMATCH")
+    if ranking_contract.get("tie_break_score_source") != TIE_BREAK_SCORE_SOURCE:
+        reasons.append("TIE_BREAK_SCORE_SOURCE_MISMATCH")
+    if ranking_contract.get("panel_median_benchmark_ranking_forbidden") is not True:
+        reasons.append("PANEL_MEDIAN_BENCHMARK_RANKING_NOT_FORBIDDEN")
+    if ranking_contract.get("lead_lag_v0_ranking_formula_reuse_forbidden") is not True:
+        reasons.append("LEAD_LAG_V0_RANKING_FORMULA_REUSE_NOT_FORBIDDEN")
+    for field in (
+        "selection_policy_binding_status",
+        "aggregation_policy_binding_status",
+        "holding_policy_binding_status",
+        "exit_policy_binding_status",
+        "portfolio_weighting_policy_binding_status",
+    ):
+        if ranking_contract.get(field) != PENDING_SELECTION_POLICY_STATUS:
+            reasons.append(f"PENDING_POLICY_NOT_EXPLICIT:{field}")
+    return not reasons, tuple(dict.fromkeys(reasons))
+
+
+def validate_score_and_ranking_contract_v0(
+    envelope: Mapping[str, Any],
+) -> tuple[ContractValidationVerdict, tuple[str, ...]]:
+    reasons: list[str] = []
+    if envelope.get("contract_digest") != _stable_digest(
+        {
+            "config_digest": envelope.get("config_digest"),
+            "implementation_digest": envelope.get("implementation_digest"),
+            "hypothesis_binding_digest": envelope.get("hypothesis_binding_digest"),
+        }
+    ):
+        reasons.append("CONTRACT_DIGEST_MISMATCH")
+
+    score_ok, score_reasons = validate_score_contract_v0(envelope.get("score_contract", {}))
+    if not score_ok:
+        reasons.extend(score_reasons)
+
+    ranking_ok, ranking_reasons = validate_ranking_contract_v0(envelope.get("ranking_contract", {}))
+    if not ranking_ok:
+        reasons.extend(ranking_reasons)
+
+    hypothesis_ref = envelope.get("hypothesis_binding_reference", {})
+    if hypothesis_ref.get("hypothesis_binding_digest") != RATIFIED_HYPOTHESIS_BINDING_DIGEST:
+        reasons.append("HYPOTHESIS_BINDING_DIGEST_MISMATCH")
+    if hypothesis_ref.get("hypothesis_binding_mutated") is not False:
+        reasons.append("HYPOTHESIS_BINDING_MUTATED")
+    if envelope.get("hypothesis_binding_digest") != RATIFIED_HYPOTHESIS_BINDING_DIGEST:
+        reasons.append("ENVELOPE_HYPOTHESIS_BINDING_DIGEST_MISMATCH")
+
+    if envelope.get("score_family_policy") != SCORE_FAMILY_POLICY:
+        reasons.append("SCORE_FAMILY_POLICY_MISMATCH")
+    if envelope.get("research_scope") != RESEARCH_SCOPE:
+        reasons.append("RESEARCH_SCOPE_MISMATCH")
+
+    constraints = envelope.get("system_constraints", {})
+    if constraints.get("hypothesis_binding_mutated") is not False:
+        reasons.append("HYPOTHESIS_BINDING_MUTATION_FLAG_FALSE")
+    if constraints.get("dataset_mutated") is not False:
+        reasons.append("DATASET_MUTATION_FLAG_FALSE")
+    if constraints.get("selection_policy_deferred") is not True:
+        reasons.append("SELECTION_POLICY_NOT_DEFERRED")
+
+    if envelope.get("economic_evaluation_executed") is not False:
+        reasons.append("ECONOMIC_EVALUATION_EXECUTED")
+    if envelope.get("runtime_effect") != "NONE":
+        reasons.append("RUNTIME_EFFECT_NOT_NONE")
+    if envelope.get("authority_effect") != "NONE":
+        reasons.append("AUTHORITY_EFFECT_NOT_NONE")
+
+    unique = tuple(dict.fromkeys(reasons))
+    if unique:
+        return ContractValidationVerdict.REJECTED_INCOMPLETE, unique
+    return ContractValidationVerdict.ACCEPTED_COMPLETE, ()
+
+
+def validate_contract_rejections_v0(
+    envelope: Mapping[str, Any],
+    *,
+    mutated_field: str,
+    mutated_value: Any,
+) -> tuple[bool, tuple[str, ...]]:
+    mutated = deepcopy(dict(envelope))
+    if mutated_field.startswith("score."):
+        mutated.setdefault("score_contract", {})[mutated_field.split(".", 1)[1]] = mutated_value
+    elif mutated_field.startswith("ranking."):
+        mutated.setdefault("ranking_contract", {})[mutated_field.split(".", 1)[1]] = mutated_value
+    else:
+        mutated[mutated_field] = mutated_value
+    verdict, reasons = validate_score_and_ranking_contract_v0(mutated)
+    return verdict is ContractValidationVerdict.REJECTED_INCOMPLETE, reasons
+
+
+def validate_lead_lag_v0_score_family_not_reused_v0(
+    envelope: Mapping[str, Any],
+) -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    score_contract = envelope.get("score_contract", {})
+    if score_contract.get("score_formula_version") == PRIOR_LEAD_LAG_SCORE_FAMILY:
+        reasons.append("LEAD_LAG_V0_SCORE_FAMILY_REUSED")
+    if score_contract.get("score_family_policy") == PRIOR_LEAD_LAG_SCORE_FAMILY:
+        reasons.append("LEAD_LAG_V0_SCORE_FAMILY_POLICY_REUSED")
+    return not reasons, tuple(dict.fromkeys(reasons))
+
+
+def materialize_and_validate_score_and_ranking_contract_v0() -> ScoreAndRankingContractResultV0:
+    contract = materialize_score_and_ranking_contract_v0()
+    validation_verdict, fail_reasons = validate_score_and_ranking_contract_v0(contract)
+    verdict = (
+        ContractMaterializationVerdict.COMPLETE
+        if validation_verdict is ContractValidationVerdict.ACCEPTED_COMPLETE
+        else ContractMaterializationVerdict.INCOMPLETE
+    )
+    return ScoreAndRankingContractResultV0(
+        verdict=verdict,
+        validation_verdict=validation_verdict,
+        contract=contract,
+        fail_reasons=fail_reasons,
+    )
+
+
+def serialize_score_and_ranking_contract_json_v0(envelope: Mapping[str, Any]) -> str:
+    return json.dumps(envelope, indent=2, sort_keys=True) + "\n"
+
+
+def materializer_to_binder_roundtrip_v0(envelope: Mapping[str, Any]) -> dict[str, Any]:
+    roundtrip = json.loads(serialize_score_and_ranking_contract_json_v0(envelope))
+    validation_verdict, fail_reasons = validate_score_and_ranking_contract_v0(roundtrip)
+    return {
+        "materializer_to_binder_roundtrip_pass": (
+            validation_verdict is ContractValidationVerdict.ACCEPTED_COMPLETE
+            and roundtrip.get("contract_digest") == envelope.get("contract_digest")
+        ),
+        "validation_verdict": validation_verdict.value,
+        "fail_reasons": list(fail_reasons),
+    }
+
+
+def build_owner_inventory() -> dict[str, Any]:
+    return {
+        "schema_version": "owner_inventory.v0",
+        "hypothesis_binding_owner": HYPOTHESIS_BINDING_OWNER,
+        "score_owner": SCORE_OWNER,
+        "score_and_ranking_contract_owner": VALIDATOR_OWNER,
+        "ranking_contract_owner": VALIDATOR_OWNER,
+        "materializer_owner": MATERIALIZER_OWNER,
+        "binder_validator_owner": VALIDATOR_OWNER,
+        "manifest_owner": MANIFEST_OWNER,
+        "registry_progress_owner": ORCHESTRATOR_OWNER,
+        "tests_owner": (
+            "tests.research."
+            "test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_"
+            "score_and_ranking_contract_v0_contract"
+        ),
+        "evidence_materializer_owner": MATERIALIZER_OWNER,
+        "downstream_canonical_entry_point": VALIDATOR_OWNER,
+        "parallel_owner_created": False,
+    }
+
+
+def build_reuse_decision() -> dict[str, Any]:
+    return {
+        "schema_version": "reuse_decision.v0",
+        "decision": "REUSE_WITH_NARROW_ADAPTER",
+        "decision_ladder": "REUSE_AS_IS -> REUSE_WITH_NARROW_ADAPTER",
+        "hypothesis_binding_owner": HYPOTHESIS_BINDING_OWNER,
+        "score_owner": SCORE_OWNER,
+        "hypothesis_binding_reuse": "REUSE_AS_IS",
+        "hypothesis_binding_mutated": False,
+        "dataset_reuse": "REUSE_AS_IS",
+        "universe_reuse": "REUSE_AS_IS",
+        "period_split_reuse": "REUSE_AS_IS",
+        "lead_lag_v0_score_family_reuse_forbidden": True,
+        "new_parallel_owner_created": False,
+    }
+
+
+def build_field_classification_v0() -> dict[str, Any]:
+    return {
+        "schema_version": "field_classification.v0",
+        "semantic_score_fields": [
+            "score_formula_version",
+            "score_formula_expression",
+            "leader_feature_family",
+            "follower_target_family",
+            "pairwise_relation_output",
+        ],
+        "semantic_ranking_fields": [
+            "pair_ranking_formula",
+            "instrument_ranking_formula",
+            "pair_deterministic_tie_break",
+            "instrument_deterministic_tie_break",
+        ],
+        "pending_implementation_fields": [
+            "selection_policy_binding_status",
+            "aggregation_policy_binding_status",
+            "holding_policy_binding_status",
+            "exit_policy_binding_status",
+            "portfolio_weighting_policy_binding_status",
+        ],
+        "cryptographic_reference_fields": [
+            "hypothesis_binding_digest",
+            "contract_digest",
+            "config_digest",
+            "implementation_digest",
+        ],
+        "unclassified_changed_field_count": 0,
+    }
+
+
+def build_semantic_identity_comparison_v0(
+    *,
+    prior_envelope: Mapping[str, Any],
+    new_envelope: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "semantic_identity_comparison.v0",
+        "prior_scope": prior_envelope.get("research_scope"),
+        "new_scope": new_envelope.get("research_scope"),
+        "prior_score_family": prior_envelope.get("score_family_policy"),
+        "new_score_family": new_envelope.get("score_family_policy"),
+        "score_contract_added": True,
+        "ranking_contract_added": True,
+        "hypothesis_binding_unchanged": (
+            prior_envelope.get("binding_digest") == new_envelope.get("hypothesis_binding_digest")
+        ),
+    }
+
+
+def build_cryptographic_identity_comparison_v0(
+    *,
+    prior_envelope: Mapping[str, Any],
+    new_envelope: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "cryptographic_identity_comparison.v0",
+        "prior_hypothesis_binding_digest": prior_envelope.get("binding_digest"),
+        "new_hypothesis_binding_digest": new_envelope.get("hypothesis_binding_digest"),
+        "hypothesis_binding_identity_unchanged": (
+            prior_envelope.get("binding_digest") == new_envelope.get("hypothesis_binding_digest")
+        ),
+        "new_contract_digest": new_envelope.get("contract_digest"),
+        "contract_identity_independent": True,
+    }
+
+
+def build_before_after_field_diff_v0(
+    *,
+    prior_envelope: Mapping[str, Any],
+    new_envelope: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    compare = (
+        (
+            "score_contract",
+            None,
+            new_envelope.get("score_contract", {}).get("score_formula_version"),
+        ),
+        (
+            "ranking_contract",
+            None,
+            new_envelope.get("ranking_contract", {}).get("pair_ranking_formula"),
+        ),
+        (
+            "hypothesis_binding_digest",
+            prior_envelope.get("binding_digest"),
+            new_envelope.get("hypothesis_binding_digest"),
+        ),
+    )
+    for field, prior_val, new_val in compare:
+        if prior_val != new_val:
+            rows.append(
+                {
+                    "field": field,
+                    "prior_value": prior_val,
+                    "new_value": new_val,
+                    "change_type": "EXPECTED_SCORE_AND_RANKING_CONTRACT_ADDITION",
+                }
+            )
+    return rows

--- a/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0.py
+++ b/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0.py
@@ -1,0 +1,229 @@
+"""Cross-sectional futures pairwise lead-lag spillover v1 score computation.
+
+Pure offline, deterministic directed pairwise spillover strength scores from strictly
+lagged leader returns to strictly future follower returns. Research-only; no runtime,
+order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_SCORE_V0=true"
+
+SCORE_FORMULA_VERSION = "pairwise_spillover_graph_v1"
+SCORE_FORMULA_EXPRESSION = (
+    "leader_lagged_return_i = ln(close_i[t-signal_lag] / close_i[t-signal_lag-L]); "
+    "follower_future_return_j = ln(close_j[t+forward_lag] / close_j[t]); "
+    "spillover_strength(i->j) = leader_lagged_return_i * follower_future_return_j; "
+    "L = lag_window_L; signal_lag = signal_lag_bars; forward_lag = forward_lag_bars"
+)
+
+DEFAULT_LAG_WINDOW_L = 8
+DEFAULT_SIGNAL_LAG_BARS = 1
+DEFAULT_FORWARD_LAG_BARS = 1
+MIN_ELIGIBLE_MEMBERS = 5
+
+
+@dataclass(frozen=True)
+class PairwiseSpilloverScoreResultV0:
+    leader_id: str
+    follower_id: str
+    score: float
+    leader_lagged_return: float
+    follower_future_return: float
+    warmup_complete: bool
+
+
+@dataclass(frozen=True)
+class InstrumentNetSpilloverScoreResultV0:
+    instrument_id: str
+    score: float
+    inbound_spillover_sum: float
+    outbound_spillover_sum: float
+    warmup_complete: bool
+
+
+def _is_bitcoin_instrument(instrument_id: str) -> bool:
+    lowered = instrument_id.lower()
+    return any(token in lowered for token in ("btc", "xbt", "bitcoin"))
+
+
+def compute_lagged_log_return_v0(
+    closes: Sequence[float],
+    *,
+    lag_window_l: int,
+    signal_lag_bars: int,
+    epoch_index: int,
+) -> float | None:
+    lag_idx = epoch_index - signal_lag_bars
+    base_idx = lag_idx - lag_window_l
+    if base_idx < 0 or lag_idx < 0 or lag_idx >= len(closes):
+        return None
+    base = closes[base_idx]
+    current = closes[lag_idx]
+    if base <= 0 or current <= 0:
+        return None
+    value = math.log(current / base)
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def compute_future_log_return_v0(
+    closes: Sequence[float],
+    *,
+    forward_lag_bars: int,
+    epoch_index: int,
+) -> float | None:
+    future_idx = epoch_index + forward_lag_bars
+    if future_idx >= len(closes) or epoch_index < 0:
+        return None
+    base = closes[epoch_index]
+    future = closes[future_idx]
+    if base <= 0 or future <= 0:
+        return None
+    value = math.log(future / base)
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def compute_pairwise_spillover_strength_v0(
+    leader_lagged_return: float,
+    follower_future_return: float,
+) -> float | None:
+    score = leader_lagged_return * follower_future_return
+    if not math.isfinite(score):
+        return None
+    return score
+
+
+def compute_directed_pair_spillover_score_v0(
+    leader_id: str,
+    follower_id: str,
+    leader_closes: Sequence[float],
+    follower_closes: Sequence[float],
+    *,
+    lag_window_l: int,
+    signal_lag_bars: int,
+    forward_lag_bars: int,
+    epoch_index: int,
+) -> PairwiseSpilloverScoreResultV0 | None:
+    if leader_id == follower_id:
+        return None
+    if _is_bitcoin_instrument(leader_id) or _is_bitcoin_instrument(follower_id):
+        return None
+    leader_lagged_return = compute_lagged_log_return_v0(
+        leader_closes,
+        lag_window_l=lag_window_l,
+        signal_lag_bars=signal_lag_bars,
+        epoch_index=epoch_index,
+    )
+    follower_future_return = compute_future_log_return_v0(
+        follower_closes,
+        forward_lag_bars=forward_lag_bars,
+        epoch_index=epoch_index,
+    )
+    if leader_lagged_return is None or follower_future_return is None:
+        return None
+    score = compute_pairwise_spillover_strength_v0(
+        leader_lagged_return,
+        follower_future_return,
+    )
+    if score is None:
+        return None
+    return PairwiseSpilloverScoreResultV0(
+        leader_id=leader_id,
+        follower_id=follower_id,
+        score=score,
+        leader_lagged_return=leader_lagged_return,
+        follower_future_return=follower_future_return,
+        warmup_complete=True,
+    )
+
+
+def compute_panel_pairwise_spillover_scores_v0(
+    instrument_closes: dict[str, Sequence[float]],
+    *,
+    lag_window_l: int,
+    signal_lag_bars: int,
+    forward_lag_bars: int,
+    epoch_index: int,
+) -> tuple[PairwiseSpilloverScoreResultV0, ...] | None:
+    eligible_ids = [
+        instrument_id
+        for instrument_id in sorted(instrument_closes)
+        if not _is_bitcoin_instrument(instrument_id)
+    ]
+    if len(eligible_ids) < MIN_ELIGIBLE_MEMBERS:
+        return None
+    scores: list[PairwiseSpilloverScoreResultV0] = []
+    for leader_id in eligible_ids:
+        for follower_id in eligible_ids:
+            if leader_id == follower_id:
+                continue
+            result = compute_directed_pair_spillover_score_v0(
+                leader_id,
+                follower_id,
+                instrument_closes[leader_id],
+                instrument_closes[follower_id],
+                lag_window_l=lag_window_l,
+                signal_lag_bars=signal_lag_bars,
+                forward_lag_bars=forward_lag_bars,
+                epoch_index=epoch_index,
+            )
+            if result is not None:
+                scores.append(result)
+    if not scores:
+        return None
+    return tuple(scores)
+
+
+def compute_instrument_net_spillover_scores_v0(
+    pair_scores: Sequence[PairwiseSpilloverScoreResultV0],
+) -> tuple[InstrumentNetSpilloverScoreResultV0, ...]:
+    inbound: dict[str, float] = {}
+    outbound: dict[str, float] = {}
+    instrument_ids: set[str] = set()
+    for item in pair_scores:
+        instrument_ids.add(item.leader_id)
+        instrument_ids.add(item.follower_id)
+        outbound[item.leader_id] = outbound.get(item.leader_id, 0.0) + item.score
+        inbound[item.follower_id] = inbound.get(item.follower_id, 0.0) + item.score
+    results: list[InstrumentNetSpilloverScoreResultV0] = []
+    for instrument_id in sorted(instrument_ids):
+        inbound_sum = inbound.get(instrument_id, 0.0)
+        outbound_sum = outbound.get(instrument_id, 0.0)
+        net_score = inbound_sum - outbound_sum
+        if not math.isfinite(net_score):
+            continue
+        results.append(
+            InstrumentNetSpilloverScoreResultV0(
+                instrument_id=instrument_id,
+                score=net_score,
+                inbound_spillover_sum=inbound_sum,
+                outbound_spillover_sum=outbound_sum,
+                warmup_complete=True,
+            )
+        )
+    return tuple(results)
+
+
+def rank_pair_scores_deterministic_v0(
+    scores: Sequence[PairwiseSpilloverScoreResultV0],
+) -> tuple[PairwiseSpilloverScoreResultV0, ...]:
+    return tuple(
+        sorted(
+            scores,
+            key=lambda item: (-item.score, item.leader_id, item.follower_id),
+        )
+    )
+
+
+def rank_instrument_net_spillover_scores_deterministic_v0(
+    scores: Sequence[InstrumentNetSpilloverScoreResultV0],
+) -> tuple[InstrumentNetSpilloverScoreResultV0, ...]:
+    return tuple(sorted(scores, key=lambda item: (-item.score, item.instrument_id)))

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -126,6 +126,13 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
                 "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
             ],
             [
+                "src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0.py",
+                "src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.py",
+                "scripts/research/materialize_cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.py",
+                "tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0_contract.py",
+                "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+            ],
+            [
                 "src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py",
                 "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_infrastructure_v0.py",
                 "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",

--- a/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0_contract.py
+++ b/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0_contract.py
@@ -1,0 +1,277 @@
+"""Contract tests for cross_sectional_futures_pairwise_lead_lag_spillover v1 score-and-ranking."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_score_v0 import (
+    SCORE_FORMULA_VERSION as LEAD_LAG_V0_SCORE_FORMULA,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0 import (
+    CONFIG_REL_PATH,
+    CONFIRM_GO,
+    GOVERNANCE_REL_PATH,
+    INSTRUMENT_DETERMINISTIC_TIE_BREAK,
+    INSTRUMENT_RANKING_FORMULA,
+    PAIR_DETERMINISTIC_TIE_BREAK,
+    PAIR_RANKING_FORMULA,
+    PENDING_SELECTION_POLICY_STATUS,
+    RATIFIED_HYPOTHESIS_BINDING_DIGEST,
+    RESEARCH_SCOPE,
+    SCORE_FAMILY_POLICY,
+    ContractMaterializationVerdict,
+    ContractValidationVerdict,
+    materialize_and_validate_score_and_ranking_contract_v0,
+    materialize_score_and_ranking_contract_v0,
+    materializer_to_binder_roundtrip_v0,
+    validate_contract_rejections_v0,
+    validate_lead_lag_v0_score_family_not_reused_v0,
+    validate_score_and_ranking_contract_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0 import (
+    DEFAULT_FORWARD_LAG_BARS,
+    DEFAULT_LAG_WINDOW_L,
+    DEFAULT_SIGNAL_LAG_BARS,
+    SCORE_FORMULA_VERSION,
+    compute_directed_pair_spillover_score_v0,
+    compute_instrument_net_spillover_scores_v0,
+    compute_panel_pairwise_spillover_scores_v0,
+    rank_instrument_net_spillover_scores_deterministic_v0,
+    rank_pair_scores_deterministic_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0 import (
+    materialize_versioned_hypothesis_binding_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOVERNANCE_DOC = REPO_ROOT / GOVERNANCE_REL_PATH
+MATERIALIZER_PATH = (
+    REPO_ROOT / "scripts/research/"
+    "materialize_cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.py"
+)
+FORBIDDEN_RUNTIME_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+)
+
+
+@pytest.fixture
+def complete_contract() -> dict:
+    return materialize_score_and_ranking_contract_v0()
+
+
+class TestContractMaterialization:
+    def test_materialization_complete(self) -> None:
+        result = materialize_and_validate_score_and_ranking_contract_v0()
+        assert result.verdict == ContractMaterializationVerdict.COMPLETE
+        assert result.validation_verdict == ContractValidationVerdict.ACCEPTED_COMPLETE
+        assert result.fail_reasons == ()
+
+    def test_deterministic_double_materialization(self) -> None:
+        first = materialize_score_and_ranking_contract_v0()
+        second = materialize_score_and_ranking_contract_v0()
+        assert first == second
+
+    def test_materializer_to_binder_roundtrip_pass(self) -> None:
+        envelope = materialize_score_and_ranking_contract_v0()
+        roundtrip = materializer_to_binder_roundtrip_v0(envelope)
+        assert roundtrip["materializer_to_binder_roundtrip_pass"] is True
+
+
+class TestHypothesisBindingReference:
+    def test_hypothesis_binding_digest_unchanged(self, complete_contract: dict) -> None:
+        hypothesis_binding = materialize_versioned_hypothesis_binding_v0()
+        assert (
+            complete_contract["hypothesis_binding_digest"] == hypothesis_binding["binding_digest"]
+        )
+        assert complete_contract["hypothesis_binding_digest"] == RATIFIED_HYPOTHESIS_BINDING_DIGEST
+        assert (
+            complete_contract["hypothesis_binding_reference"]["hypothesis_binding_mutated"] is False
+        )
+
+    def test_lead_lag_v0_score_family_not_reused(self, complete_contract: dict) -> None:
+        ok, reasons = validate_lead_lag_v0_score_family_not_reused_v0(complete_contract)
+        assert ok, reasons
+        assert (
+            complete_contract["score_contract"]["score_formula_version"]
+            != LEAD_LAG_V0_SCORE_FORMULA
+        )
+
+
+class TestScoreContract:
+    def test_score_formula_version(self, complete_contract: dict) -> None:
+        score = complete_contract["score_contract"]
+        assert score["score_formula_version"] == SCORE_FORMULA_VERSION
+        assert score["score_family_policy"] == SCORE_FAMILY_POLICY
+        assert score["panel_median_benchmark_semantics_forbidden"] is True
+        assert score["self_pair_i_equals_j_forbidden"] is True
+
+    def test_pit_ordering_required(self, complete_contract: dict) -> None:
+        score = complete_contract["score_contract"]
+        assert score["feature_time_lt_decision_time_required"] is True
+        assert score["target_time_gt_decision_time_required"] is True
+        assert score["contemporaneous_target_leakage_forbidden"] is True
+
+
+class TestRankingContract:
+    def test_ranking_formulas_and_tie_breaks(self, complete_contract: dict) -> None:
+        ranking = complete_contract["ranking_contract"]
+        assert ranking["pair_ranking_formula"] == PAIR_RANKING_FORMULA
+        assert ranking["instrument_ranking_formula"] == INSTRUMENT_RANKING_FORMULA
+        assert ranking["pair_deterministic_tie_break"] == PAIR_DETERMINISTIC_TIE_BREAK
+        assert ranking["instrument_deterministic_tie_break"] == INSTRUMENT_DETERMINISTIC_TIE_BREAK
+        assert ranking["tie_break_score_source"] == "unrounded_internal_score"
+
+    def test_selection_policies_deferred(self, complete_contract: dict) -> None:
+        ranking = complete_contract["ranking_contract"]
+        for field in (
+            "selection_policy_binding_status",
+            "aggregation_policy_binding_status",
+            "holding_policy_binding_status",
+            "exit_policy_binding_status",
+            "portfolio_weighting_policy_binding_status",
+        ):
+            assert ranking[field] == PENDING_SELECTION_POLICY_STATUS
+
+
+class TestContractRejections:
+    def test_panel_median_not_forbidden_rejected(self, complete_contract: dict) -> None:
+        rejected, reasons = validate_contract_rejections_v0(
+            complete_contract,
+            mutated_field="score.panel_median_benchmark_semantics_forbidden",
+            mutated_value=False,
+        )
+        assert rejected
+        assert "PANEL_MEDIAN_BENCHMARK_NOT_FORBIDDEN" in reasons
+
+    def test_pair_tie_break_mismatch_rejected(self, complete_contract: dict) -> None:
+        rejected, reasons = validate_contract_rejections_v0(
+            complete_contract,
+            mutated_field="ranking.pair_deterministic_tie_break",
+            mutated_value="invalid_tie_break",
+        )
+        assert rejected
+        assert "PAIR_TIE_BREAK_MISMATCH" in reasons
+
+
+class TestScoreComputation:
+    def _sample_closes(self, *, trend: float, count: int = 20) -> list[float]:
+        return [100.0 + index * trend for index in range(count)]
+
+    def test_directed_pair_score_positive_spillover(self) -> None:
+        leader_closes = self._sample_closes(trend=1.0)
+        follower_closes = self._sample_closes(trend=0.5)
+        epoch_index = len(leader_closes) - 1 - DEFAULT_FORWARD_LAG_BARS
+        result = compute_directed_pair_spillover_score_v0(
+            "inst-leader",
+            "inst-follower",
+            leader_closes,
+            follower_closes,
+            lag_window_l=DEFAULT_LAG_WINDOW_L,
+            signal_lag_bars=DEFAULT_SIGNAL_LAG_BARS,
+            forward_lag_bars=DEFAULT_FORWARD_LAG_BARS,
+            epoch_index=epoch_index,
+        )
+        assert result is not None
+        assert result.leader_id == "inst-leader"
+        assert result.follower_id == "inst-follower"
+        assert result.score == pytest.approx(
+            result.leader_lagged_return * result.follower_future_return
+        )
+
+    def test_self_pair_forbidden(self) -> None:
+        closes = self._sample_closes(trend=0.5)
+        epoch_index = len(closes) - 1 - DEFAULT_FORWARD_LAG_BARS
+        assert (
+            compute_directed_pair_spillover_score_v0(
+                "inst-a",
+                "inst-a",
+                closes,
+                closes,
+                lag_window_l=DEFAULT_LAG_WINDOW_L,
+                signal_lag_bars=DEFAULT_SIGNAL_LAG_BARS,
+                forward_lag_bars=DEFAULT_FORWARD_LAG_BARS,
+                epoch_index=epoch_index,
+            )
+            is None
+        )
+
+    def test_pair_ranking_tie_break_deterministic(self) -> None:
+        closes = self._sample_closes(trend=0.2)
+        instrument_closes = {
+            f"inst-{label}": closes for label in ("alpha", "beta", "gamma", "delta", "epsilon")
+        }
+        epoch_index = len(closes) - 1 - DEFAULT_FORWARD_LAG_BARS
+        pair_scores = compute_panel_pairwise_spillover_scores_v0(
+            instrument_closes,
+            lag_window_l=DEFAULT_LAG_WINDOW_L,
+            signal_lag_bars=DEFAULT_SIGNAL_LAG_BARS,
+            forward_lag_bars=DEFAULT_FORWARD_LAG_BARS,
+            epoch_index=epoch_index,
+        )
+        assert pair_scores is not None
+        ranked_once = rank_pair_scores_deterministic_v0(pair_scores)
+        ranked_twice = rank_pair_scores_deterministic_v0(list(reversed(pair_scores)))
+        assert ranked_once == ranked_twice
+
+    def test_instrument_net_spillover_ranking_tie_break(self) -> None:
+        closes = self._sample_closes(trend=0.3)
+        instrument_closes = {
+            f"inst-{label}": closes for label in ("alpha", "beta", "gamma", "delta", "epsilon")
+        }
+        epoch_index = len(closes) - 1 - DEFAULT_FORWARD_LAG_BARS
+        pair_scores = compute_panel_pairwise_spillover_scores_v0(
+            instrument_closes,
+            lag_window_l=DEFAULT_LAG_WINDOW_L,
+            signal_lag_bars=DEFAULT_SIGNAL_LAG_BARS,
+            forward_lag_bars=DEFAULT_FORWARD_LAG_BARS,
+            epoch_index=epoch_index,
+        )
+        assert pair_scores is not None
+        net_scores = compute_instrument_net_spillover_scores_v0(pair_scores)
+        ranked = rank_instrument_net_spillover_scores_deterministic_v0(net_scores)
+        assert len(ranked) == len(net_scores)
+        assert ranked == rank_instrument_net_spillover_scores_deterministic_v0(
+            list(reversed(net_scores))
+        )
+
+
+class TestScopeIdentity:
+    def test_research_scope_and_go_token(self, complete_contract: dict) -> None:
+        assert complete_contract["research_scope"] == RESEARCH_SCOPE
+        assert CONFIRM_GO.endswith("IMPLEMENTATION_V0")
+
+    def test_no_economic_evaluation(self, complete_contract: dict) -> None:
+        assert complete_contract["economic_evaluation_executed"] is False
+        assert complete_contract["runtime_effect"] == "NONE"
+        assert complete_contract["authority_effect"] == "NONE"
+
+
+class TestGovernanceAndPaths:
+    def test_governance_doc_exists(self) -> None:
+        assert GOVERNANCE_DOC.is_file()
+        text = GOVERNANCE_DOC.read_text(encoding="utf-8")
+        assert "pairwise_spillover_graph_v1" in text
+
+    def test_materializer_script_exists(self) -> None:
+        assert MATERIALIZER_PATH.is_file()
+
+    def test_config_rel_path_defined(self) -> None:
+        assert CONFIG_REL_PATH.endswith(".json")
+
+    def test_no_forbidden_runtime_imports_in_contract_modules(self) -> None:
+        contract_module = (
+            REPO_ROOT / "src/research/"
+            "cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0.py"
+        )
+        score_module = (
+            REPO_ROOT / "src/research/"
+            "cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0.py"
+        )
+        for module_path in (contract_module, score_module):
+            text = module_path.read_text(encoding="utf-8")
+            for prefix in FORBIDDEN_RUNTIME_IMPORT_PREFIXES:
+                assert prefix not in text


### PR DESCRIPTION
## Summary
- Adds the canonical offline score contract for `pairwise_spillover_graph_v1` with directed pair spillover computation from lagged leader returns to future follower returns.
- Adds the versioned ranking contract with deterministic tie-break rules for directed pairs and instrument net inbound spillover, without binding selection/aggregation/holding/exit policies.
- Includes contract validator/binder, materializer, focused tests, governance doc, and ratified config artifact referencing the unchanged hypothesis binding digest.

## Test plan
- [x] `pytest tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0_contract.py`
- [x] `pytest tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0_contract.py`
- [x] PR-bounded CI selector targets (741 tests, 43s local)
- [x] `ruff format --check` and `ruff check` on changed Python files
- [x] Evidence bundle materialized with `MANIFEST_VERIFY_RC=0`


Made with [Cursor](https://cursor.com)