### PR TITLE
Implement pairwise spillover v1 offline economic evaluation execution

### DIFF
--- a/config/ops/cross_sectional_futures_pairwise_lead_lag_spillover_v1_economic_evaluation_v1.json
+++ b/config/ops/cross_sectional_futures_pairwise_lead_lag_spillover_v1_economic_evaluation_v1.json
@@ -1,0 +1,84 @@
+{
+  "backtest": {
+    "cost_model_version": "backtest_cost_v0",
+    "economic_research_execution_cost": {
+      "conservative_half_spread_bps": 5.0,
+      "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+      "fee_bps": 10.0,
+      "slippage_bps": 5.0,
+      "spread_model_version": "research_conservative_bps_v1"
+    },
+    "fee_bps": 10.0,
+    "fee_model_version": "backtest_fee_taker_symmetric_v0",
+    "funding": {
+      "bind": true,
+      "model_version": "backtest_funding_perpetual_interval_v1"
+    },
+    "initial_cash": 10000.0,
+    "parameter_sensitivity": {
+      "bind": true,
+      "grid_version": "v1",
+      "parameter_search_forbidden": true,
+      "policy_version": "parameter_sensitivity_v1",
+      "primary_binding_only": true
+    },
+    "slippage_bps": 5.0,
+    "slippage_model_version": "backtest_slippage_symmetric_v0"
+  },
+  "binding_digest": "6b2a74392eda2bf1a672682aa27da3873bc25666c5d9bb34d269f785afc2b438",
+  "config_schema_version": "cross_sectional_futures_pairwise_lead_lag_spillover_v1_economic_evaluation_admissibility_v1",
+  "config_version": "v1",
+  "cross_sectional_evaluation_binding_v1": {
+    "candidate_binding_ref": "config/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0.json",
+    "candidate_binding_version": "v0",
+    "data_contract_digest": "cc09958107aca2f5c46bc0a828354fb8e8d70053b02853a2786062bcc8c6aff6",
+    "dataset_binding": {
+      "dataset_digest": "79b1c977960f4af7e1eb54580738d77b259b74f7f02bbf0e999afbb95f8f09f1",
+      "dataset_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+      "dataset_version": "v1",
+      "panel_staging_profile": "cross_sectional_research_staging_v1"
+    },
+    "digest_materialization_semantics": "panel_semantic_data_digest_v0",
+    "instrument_universe_binding": {
+      "bitcoin_excluded": true,
+      "futures_only": true,
+      "pit_universe_manifest_ref": "pit_futures_universe_manifest_v1:pit_okx_linear_usdt_non_bitcoin_perpetual_universe_manifest_v1",
+      "universe_digest": "d57738dc7e80520c17e49c406a22f8de15216c2e48e56d91b3757359ebb552a1"
+    },
+    "panel_dataset_manifest_ref": "pit_okx_pt1h_panel_ohlcv_dataset_v1:pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1:v1",
+    "parameter_binding": {
+      "forward_lag_bars": 1,
+      "lag_window_L": 8,
+      "parameter_search_forbidden": true,
+      "score_formula_version": "pairwise_spillover_graph_v1",
+      "signal_lag_bars": 1
+    },
+    "period_binding_id": "pit_cross_sectional_research_chronological_holdout_v1",
+    "period_binding_version": "v1"
+  },
+  "economic_evaluation_v1": {
+    "economic_validity_policy_version": "economic_validity_policy_v1",
+    "engine_signal_source": "cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0",
+    "monte_carlo": {
+      "bind": true,
+      "policy_version": "monte_carlo_v1",
+      "runs": 64,
+      "seed": 42
+    },
+    "parameter_sensitivity_policy_version": "parameter_sensitivity_v1",
+    "strategy_id": "cross_sectional_futures_pairwise_lead_lag_spillover",
+    "strategy_version": "v1",
+    "stress": {
+      "bind": true,
+      "policy_version": "stress_class_suite_v1"
+    },
+    "walk_forward": {
+      "bind": true,
+      "policy_version": "walk_forward_v1"
+    }
+  },
+  "offline_only": true,
+  "runtime_effect": "NONE",
+  "strategy_id": "cross_sectional_futures_pairwise_lead_lag_spillover",
+  "strategy_version": "v1"
+}

--- a/scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Ops runner for cross-sectional pairwise spillover v1 offline economic evaluation.
+
+Bounded infrastructure mode only:
+GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_IMPLEMENTATION_V0
+
+No economic evaluation execution, runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops import primary_evidence_retention_v0 as retention  # noqa: E402
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (  # noqa: E402
+    AUTHORITY_EFFECT,
+    EXECUTION_GO_TOKEN,
+    EXECUTION_VERSION,
+    IMPLEMENTATION_GO_TOKEN,
+    RUNTIME_EFFECT,
+    InfrastructureReadinessResultV0,
+    InfrastructureTerminalStatus,
+    entrypoint_result_to_dict,
+    load_authorization_ratification_v0,
+    load_versioned_hypothesis_binding_v0,
+    materialize_infrastructure_summary_v0,
+    run_full_evaluation_entrypoint_dry_run_v1,
+    verify_execution_start_state_v0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.fixture_builder import (  # noqa: E402
+    build_synthetic_panel_series_v0,
+)
+
+CONFIRM_GO = IMPLEMENTATION_GO_TOKEN
+EXECUTION_CONFIRM_GO = EXECUTION_GO_TOKEN
+MAX_RUNTIME_SECONDS = 1500
+DEFAULT_DURABLE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+DEFAULT_STAGING_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/v1"
+)
+SCOPE_CLASSIFICATION = (
+    "BOUNDED_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_EXECUTION_IMPLEMENTATION_V0"
+)
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _resolve_origin_main(repo_root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "origin/main"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _primary_worktree_snapshot(primary_worktree: Path) -> dict[str, Any]:
+    head = subprocess.run(
+        ["git", "-C", str(primary_worktree), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty = subprocess.run(
+        ["git", "-C", str(primary_worktree), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty_count = len([line for line in dirty.stdout.splitlines() if line.strip()])
+    return {
+        "head": head.stdout.strip() if head.returncode == 0 else "",
+        "dirty_count": dirty_count,
+    }
+
+
+def _guard_timeout(start_monotonic: float) -> None:
+    if time.monotonic() - start_monotonic > MAX_RUNTIME_SECONDS:
+        _die(f"ERR:timeout_guard_exceeded:{MAX_RUNTIME_SECONDS}s")
+
+
+def run_execution_infrastructure_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+    staging_root: Path,
+    panel_series: tuple[Any, ...] | None = None,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm not in {CONFIRM_GO, EXECUTION_CONFIRM_GO}:
+        _die(f"ERR:confirm_go_token_required:{CONFIRM_GO}")
+    if confirm == EXECUTION_CONFIRM_GO:
+        _die("ERR:full_economic_evaluation_not_authorized_in_implementation_runner")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "implementation"
+        / (
+            "cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_"
+            f"evaluation_execution_implementation_v0_{ts_slug}"
+        )
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    versioned_binding = load_versioned_hypothesis_binding_v0(_REPO_ROOT)
+    authorization_ratification = load_authorization_ratification_v0(_REPO_ROOT)
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+    _guard_timeout(start_monotonic)
+
+    active_panel_series = panel_series or build_synthetic_panel_series_v0()
+    entrypoint = run_full_evaluation_entrypoint_dry_run_v1(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        staging_root=staging_root,
+        panel_series=active_panel_series,
+        versioned_binding=versioned_binding,
+        go_token=confirm,
+    )
+    entrypoint_payload = entrypoint_result_to_dict(entrypoint)
+    _guard_timeout(start_monotonic)
+
+    readiness = InfrastructureReadinessResultV0(
+        status=(
+            InfrastructureTerminalStatus.EXECUTION_INFRASTRUCTURE_COMPLETE
+            if entrypoint.precheck_passed
+            else InfrastructureTerminalStatus.FAIL_CLOSED
+        ),
+        execution_infrastructure_complete=entrypoint.precheck_passed,
+        panel_wiring_complete=entrypoint.precheck_passed,
+        bound_dataset_materialized=entrypoint.bound_dataset_materialized,
+        dataset_period_match=entrypoint.dataset_period_match,
+        panel_data_digest=entrypoint.panel_data_digest,
+        reason_codes=tuple(entrypoint.reason_codes),
+        pair_score_count=None,
+        instrument_score_count=None,
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+        economic_evaluation_executed=False,
+    )
+    summary = materialize_infrastructure_summary_v0(
+        authorization_ratification=authorization_ratification,
+        readiness=readiness,
+        origin_main_sha=origin_main,
+        execution_bundle_dir=str(bundle_dir),
+    )
+
+    (bundle_dir / "GIT_PROVENANCE.txt").write_text(
+        "\n".join(
+            [
+                f"START_HEAD={subprocess.run(['git', '-C', str(_REPO_ROOT), 'rev-parse', 'HEAD'], capture_output=True, text=True).stdout.strip()}",
+                f"ORIGIN_MAIN={origin_main}",
+                f"PRIMARY_WORKTREE={primary_worktree}",
+                f"PRIMARY_WORKTREE_HEAD_BEFORE={primary_before['head']}",
+                f"PRIMARY_WORKTREE_DIRTY_COUNT_BEFORE={primary_before['dirty_count']}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "SCOPE_AND_GO.txt").write_text(
+        "\n".join(
+            [
+                "EXECUTION_SCOPE=IMPLEMENTATION_ONLY_V0",
+                f"GO_TOKEN={confirm}",
+                "GO_TOKEN_CONSUMPTION=CONSUMED_ONCE",
+                f"SCOPE_CLASSIFICATION={SCOPE_CLASSIFICATION}",
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                "BASELINE_EXECUTED=false",
+                "ROBUSTNESS_EXECUTED=false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "ENTRYPOINT_DRY_RUN_RESULT.json").write_text(
+        json.dumps(entrypoint_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "INFRASTRUCTURE_SUMMARY.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "START_STATE.json").write_text(
+        json.dumps(
+            {
+                "valid": start_state.valid,
+                "fail_reasons": list(start_state.fail_reasons),
+                "binding_digest": start_state.binding_digest,
+                "authorization_ratification_digest": start_state.authorization_ratification_digest,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
+        "ECONOMIC_EVALUATION_EXECUTED=false\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    payload: dict[str, Any] = {
+        "verdict": (
+            "IMPLEMENTATION_COMPLETE"
+            if entrypoint.precheck_passed and start_state.valid
+            else "FAIL_CLOSED"
+        ),
+        "process_classification": SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "staging_root": str(staging_root),
+        "start_state_valid": start_state.valid,
+        "entrypoint": entrypoint_payload,
+        "infrastructure_summary": summary,
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "robustness_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree": str(primary_worktree),
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _guard_timeout(start_monotonic)
+    return payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm", required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_ROOT)
+    parser.add_argument("--primary-worktree", type=Path, required=True)
+    parser.add_argument("--staging-root", type=Path, default=DEFAULT_STAGING_ROOT)
+    args = parser.parse_args()
+    result = run_execution_infrastructure_v0(
+        confirm=args.confirm,
+        durable_evidence_root=args.durable_evidence_root,
+        primary_worktree=args.primary_worktree,
+        staging_root=args.staging_root,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -25,9 +25,9 @@ if str(_REPO_ROOT) not in sys.path:
 from scripts.ops import primary_evidence_retention_v0 as retention  # noqa: E402
 from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (  # noqa: E402
     AUTHORITY_EFFECT,
-    EXECUTION_GO_TOKEN,
     EXECUTION_VERSION,
-    IMPLEMENTATION_GO_TOKEN,
+    GO_TOKEN,
+    INFRASTRUCTURE_GO_TOKEN,
     RUNTIME_EFFECT,
     InfrastructureReadinessResultV0,
     InfrastructureTerminalStatus,
@@ -42,8 +42,8 @@ from tests.research.fixtures.cross_sectional_relative_strength_v0.fixture_builde
     build_synthetic_panel_series_v0,
 )
 
-CONFIRM_GO = IMPLEMENTATION_GO_TOKEN
-EXECUTION_CONFIRM_GO = EXECUTION_GO_TOKEN
+CONFIRM_GO = INFRASTRUCTURE_GO_TOKEN
+EXECUTION_CONFIRM_GO = GO_TOKEN
 MAX_RUNTIME_SECONDS = 1500
 DEFAULT_DURABLE_ROOT = Path(
     "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"

--- a/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -1,0 +1,917 @@
+"""Cross-sectional futures pairwise lead-lag spillover v1 offline economic evaluation execution v0.
+
+Deterministic, fail-closed execution infrastructure for the ratified pairwise spillover
+hypothesis. Provides binding validation, score/ranking wiring checks, and contract-only
+smoke paths. Full economic evaluation requires separate Operator GO.
+No runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_authorization_ratification_v0 import (
+    CONFIG_REL_PATH as AUTHORIZATION_CONFIG_REL_PATH,
+    RatificationValidationVerdict,
+    materialize_offline_economic_evaluation_authorization_ratification_v0,
+    validate_offline_economic_evaluation_authorization_ratification_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_contract_v0 import (
+    RATIFIED_HYPOTHESIS_BINDING_DIGEST,
+    materialize_score_and_ranking_contract_v0,
+    validate_score_and_ranking_contract_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0 import (
+    DEFAULT_FORWARD_LAG_BARS,
+    DEFAULT_LAG_WINDOW_L,
+    DEFAULT_SIGNAL_LAG_BARS,
+    SCORE_FORMULA_VERSION,
+    compute_instrument_net_spillover_scores_v0,
+    compute_panel_pairwise_spillover_scores_v0,
+    rank_instrument_net_spillover_scores_deterministic_v0,
+    rank_pair_scores_deterministic_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0 import (
+    AUTHORITY_EFFECT,
+    CONFIG_REL_PATH,
+    ORDER_EFFECT,
+    RATIFIED_NORMALIZED_PANEL_DIGEST,
+    RESEARCH_HYPOTHESIS_ID,
+    RESEARCH_SCOPE,
+    RUNTIME_EFFECT,
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+    BindingValidationVerdict,
+    materialize_versioned_hypothesis_binding_v0,
+    validate_versioned_hypothesis_binding_v0,
+)
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (
+    verify_panel_staging_source_manifests_v1,
+)
+from src.research.cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0 import (
+    MaterializationTerminalStatus,
+    materialize_bound_panel_dataset_v0,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+
+PACKAGE_MARKER = (
+    "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_EXECUTION_V0=true"
+)
+
+SCHEMA_VERSION = (
+    "cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_"
+    "evaluation_execution.v0"
+)
+EXECUTION_ID = (
+    "cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_"
+    "evaluation_execution_v0"
+)
+EXECUTION_VERSION = "v0"
+CANONICAL_SERIALIZATION_VERSION = "cross_sectional_execution_canonical_json_v1"
+
+IMPLEMENTATION_GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_EXECUTION_IMPLEMENTATION_V0"
+)
+EXECUTION_GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_EXECUTION_V0"
+)
+GO_TOKEN = EXECUTION_GO_TOKEN
+INFRASTRUCTURE_GO_TOKEN = IMPLEMENTATION_GO_TOKEN
+
+ALLOWED_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset({IMPLEMENTATION_GO_TOKEN})
+ALLOWED_EXECUTION_GO_TOKENS: frozenset[str] = frozenset({EXECUTION_GO_TOKEN})
+
+RATIFIED_BINDING_DIGEST = RATIFIED_HYPOTHESIS_BINDING_DIGEST
+RATIFIED_DATASET_DIGEST = RATIFIED_NORMALIZED_PANEL_DIGEST
+RATIFIED_UNIVERSE_DIGEST = "d57738dc7e80520c17e49c406a22f8de15216c2e48e56d91b3757359ebb552a1"
+
+CONFIG_REL_PATH_OPS = (
+    "config/ops/cross_sectional_futures_pairwise_lead_lag_spillover_v1_economic_evaluation_v1.json"
+)
+
+CANONICAL_EVALUATION_CALLABLE = "run_contract_smoke_evaluation_v0"
+CANONICAL_FULL_EVALUATION_CALLABLE = "run_full_offline_economic_evaluation_v0"
+ENTRY_POINT_STATUS = "EXECUTION_INFRASTRUCTURE_COMPLETE"
+
+ALLOWED_EVALUATION_STAGES: tuple[str, ...] = (
+    "OFFLINE_BACKTEST",
+    "WALK_FORWARD",
+    "MONTE_CARLO",
+    "STRESS",
+    "PARAMETER_SENSITIVITY",
+    "ECONOMIC_VIABILITY_EVIDENCE_MATERIALIZATION",
+)
+
+RUNNER_OWNER = (
+    "scripts.ops.run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_"
+    "economic_evaluation_execution_v0"
+)
+RUNNER_SCRIPT = (
+    "scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_"
+    "economic_evaluation_execution_v0.py"
+)
+HARNESS_OWNER = (
+    "src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_"
+    "economic_evaluation_execution_v0"
+)
+
+SCORE_OWNER = "src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0"
+SCORE_RANKING_CONTRACT_OWNER = (
+    "src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_and_ranking_"
+    "contract_v0"
+)
+AUTHORIZATION_OWNER = (
+    "src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_"
+    "evaluation_authorization_ratification_v0"
+)
+HYPOTHESIS_BINDING_OWNER = (
+    "src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_"
+    "hypothesis_binding_v0"
+)
+
+REASON_BINDING_INCOMPLETE = "BINDING_INCOMPLETE"
+REASON_BINDING_DIGEST_MISMATCH = "BINDING_DIGEST_MISMATCH"
+REASON_DATASET_DIGEST_MISMATCH = "DATASET_DIGEST_MISMATCH"
+REASON_UNIVERSE_DIGEST_MISMATCH = "UNIVERSE_DIGEST_MISMATCH"
+REASON_GO_TOKEN_INVALID = "GO_TOKEN_INVALID"
+REASON_GO_TOKEN_MISSING = "GO_TOKEN_MISSING"
+REASON_AUTHORIZATION_INVALID = "AUTHORIZATION_RATIFICATION_INVALID"
+REASON_SCORE_RANKING_CONTRACT_INVALID = "SCORE_RANKING_CONTRACT_INVALID"
+REASON_ECONOMIC_EXECUTION_FORBIDDEN = "ECONOMIC_EXECUTION_FORBIDDEN_IN_IMPLEMENTATION_SCOPE"
+REASON_PARAMETER_SEARCH_FORBIDDEN_VIOLATION = "PARAMETER_SEARCH_FORBIDDEN_VIOLATION"
+REASON_FUTURES_ONLY_VIOLATION = "FUTURES_ONLY_VIOLATION"
+REASON_BITCOIN_DIRECTION_VIOLATION = "BITCOIN_DIRECTION_VIOLATION"
+REASON_SPOT_ALLOWED_VIOLATION = "SPOT_ALLOWED_VIOLATION"
+REASON_SYNTHETIC_SPOT_ALLOWED_VIOLATION = "SYNTHETIC_SPOT_ALLOWED_VIOLATION"
+REASON_SEMANTIC_BINDING_MUTATION = "SEMANTIC_BINDING_MUTATION_DETECTED"
+REASON_MISSING_OPS_EVALUATION_CONFIG = "MISSING_OPS_EVALUATION_CONFIG"
+REASON_SCORE_FAMILY_POLICY_MISMATCH = "SCORE_FAMILY_POLICY_MISMATCH"
+
+
+class InfrastructureTerminalStatus(str, Enum):
+    EXECUTION_INFRASTRUCTURE_COMPLETE = "EXECUTION_INFRASTRUCTURE_COMPLETE"
+    FAIL_CLOSED_BOUND_DATA_UNAVAILABLE = "FAIL_CLOSED_BOUND_DATA_UNAVAILABLE"
+    FAIL_CLOSED = "FAIL_CLOSED"
+
+
+class EvaluationEntrypointTerminalStatus(str, Enum):
+    ENTRYPOINT_READY_DRY_RUN_STOPPED = "ENTRYPOINT_READY_DRY_RUN_STOPPED"
+    FAIL_CLOSED_PRECHECK = "FAIL_CLOSED_PRECHECK"
+
+
+@dataclass(frozen=True)
+class StageWiringItemV0:
+    stage_name: str
+    wired: bool
+    owner: str
+
+
+@dataclass(frozen=True)
+class StartStateVerificationResultV0:
+    valid: bool
+    fail_reasons: tuple[str, ...]
+    origin_main_sha: str
+    binding_digest: str
+    authorization_ratification_digest: str
+
+
+@dataclass(frozen=True)
+class InfrastructureReadinessResultV0:
+    status: InfrastructureTerminalStatus
+    execution_infrastructure_complete: bool
+    panel_wiring_complete: bool
+    bound_dataset_materialized: bool
+    dataset_period_match: bool
+    panel_data_digest: str
+    reason_codes: tuple[str, ...]
+    pair_score_count: int | None
+    instrument_score_count: int | None
+    authority_effect: str
+    runtime_effect: str
+    economic_evaluation_executed: bool
+
+
+@dataclass(frozen=True)
+class FullEvaluationEntrypointResultV1:
+    status: EvaluationEntrypointTerminalStatus
+    precheck_passed: bool
+    source_manifests_verified: bool
+    bound_dataset_materialized: bool
+    dataset_period_match: bool
+    panel_data_digest: str
+    stage_wiring: tuple[StageWiringItemV0, ...]
+    dry_run_stopped_before_execution: bool
+    economic_evaluation_executed: bool
+    reason_codes: tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+
+
+@dataclass(frozen=True)
+class PhaseExecutionBlockedResultV0:
+    phase: str
+    executed: bool
+    blocked: bool
+    reason_codes: tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def dumps_execution_canonical_v1(obj: Mapping[str, Any]) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str, ensure_ascii=False)
+
+
+def load_versioned_hypothesis_binding_v0(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / CONFIG_REL_PATH
+    if not path.is_file():
+        return materialize_versioned_hypothesis_binding_v0()
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_authorization_ratification_v0(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / AUTHORIZATION_CONFIG_REL_PATH
+    if not path.is_file():
+        return materialize_offline_economic_evaluation_authorization_ratification_v0()
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_ops_evaluation_config_v0(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / CONFIG_REL_PATH_OPS
+    if not path.is_file():
+        raise FileNotFoundError(f"{REASON_MISSING_OPS_EVALUATION_CONFIG}:{path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_implementation_go_token_v0(go_token: str | None) -> tuple[bool, tuple[str, ...]]:
+    if not go_token:
+        return False, (REASON_GO_TOKEN_MISSING,)
+    if go_token not in ALLOWED_IMPLEMENTATION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_execution_go_token_v0(go_token: str | None) -> tuple[bool, tuple[str, ...]]:
+    if not go_token:
+        return False, (REASON_GO_TOKEN_MISSING,)
+    if go_token not in ALLOWED_EXECUTION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_entry_point_go_token_v0(go_token: str) -> tuple[bool, str | None]:
+    if go_token == IMPLEMENTATION_GO_TOKEN:
+        return True, "IMPLEMENTATION_V0"
+    if go_token == EXECUTION_GO_TOKEN:
+        return True, "EXECUTION_V0"
+    return False, None
+
+
+def verify_ratified_digests_v0(
+    envelope: Mapping[str, Any],
+    *,
+    expected_binding_digest: str | None = RATIFIED_BINDING_DIGEST,
+    expected_dataset_digest: str | None = RATIFIED_DATASET_DIGEST,
+    expected_universe_digest: str | None = RATIFIED_UNIVERSE_DIGEST,
+) -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    validation_verdict, fail_reasons = validate_versioned_hypothesis_binding_v0(envelope)
+    if validation_verdict is not BindingValidationVerdict.ACCEPTED_COMPLETE:
+        reasons.extend(fail_reasons)
+
+    binding_digest = str(envelope.get("binding_digest", ""))
+    dataset_digest = str(envelope.get("dataset_digest", ""))
+    universe_digest = str(
+        envelope.get("binding", {}).get("pit_universe_binding", {}).get("universe_digest", "")
+    )
+
+    if expected_binding_digest and binding_digest != expected_binding_digest:
+        reasons.append(REASON_BINDING_DIGEST_MISMATCH)
+    if expected_dataset_digest and dataset_digest != expected_dataset_digest:
+        reasons.append(REASON_DATASET_DIGEST_MISMATCH)
+    if expected_universe_digest and universe_digest != expected_universe_digest:
+        reasons.append(REASON_UNIVERSE_DIGEST_MISMATCH)
+
+    return not reasons, tuple(dict.fromkeys(reasons))
+
+
+def verify_execution_start_state_v0(
+    *,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any],
+    versioned_binding: Mapping[str, Any] | None = None,
+    origin_main_sha: str = "",
+) -> StartStateVerificationResultV0:
+    reasons: list[str] = []
+    envelope = dict(versioned_binding or load_versioned_hypothesis_binding_v0(repo_root))
+    score_ranking_contract = materialize_score_and_ranking_contract_v0(envelope)
+
+    digest_ok, digest_reasons = verify_ratified_digests_v0(envelope)
+    if not digest_ok:
+        reasons.extend(digest_reasons)
+
+    auth_verdict, auth_reasons = validate_offline_economic_evaluation_authorization_ratification_v0(
+        authorization_ratification,
+        expected_hypothesis_binding=envelope,
+        expected_score_ranking_contract=score_ranking_contract,
+    )
+    if auth_verdict is not RatificationValidationVerdict.ACCEPTED_COMPLETE:
+        reasons.append(REASON_AUTHORIZATION_INVALID)
+        reasons.extend(auth_reasons)
+
+    contract_ok, contract_reasons = validate_score_and_ranking_contract_v0(score_ranking_contract)
+    if not contract_ok:
+        reasons.append(REASON_SCORE_RANKING_CONTRACT_INVALID)
+        reasons.extend(contract_reasons)
+
+    constraints = envelope.get("system_constraints", {})
+    if constraints.get("futures_only") is not True:
+        reasons.append(REASON_FUTURES_ONLY_VIOLATION)
+    if constraints.get("bitcoin_direction_allowed") is not False:
+        reasons.append(REASON_BITCOIN_DIRECTION_VIOLATION)
+
+    pairwise = envelope.get("pairwise_hypothesis_contract", {})
+    if pairwise.get("spot_allowed") is not False:
+        reasons.append(REASON_SPOT_ALLOWED_VIOLATION)
+    if pairwise.get("synthetic_spot_allowed") is not False:
+        reasons.append(REASON_SYNTHETIC_SPOT_ALLOWED_VIOLATION)
+
+    if envelope.get("score_family_policy") != SCORE_FORMULA_VERSION:
+        reasons.append(REASON_SCORE_FAMILY_POLICY_MISMATCH)
+
+    if envelope.get("parameter_binding", {}).get("parameter_search_forbidden") is not True:
+        reasons.append(REASON_PARAMETER_SEARCH_FORBIDDEN_VIOLATION)
+
+    ops_config_path = repo_root / CONFIG_REL_PATH_OPS
+    if not ops_config_path.is_file():
+        reasons.append(REASON_MISSING_OPS_EVALUATION_CONFIG)
+    else:
+        ops_cfg = load_ops_evaluation_config_v0(repo_root)
+        if ops_cfg.get("binding_digest") != envelope.get("binding_digest"):
+            reasons.append(REASON_BINDING_DIGEST_MISMATCH)
+        cost_stack = envelope.get("cost_execution_binding", {})
+        if cost_stack.get("fee_binding", {}).get("fee_model_version") != (
+            "backtest_fee_taker_symmetric_v0"
+        ):
+            reasons.append("FEE_MODEL_BINDING_MISMATCH")
+        if cost_stack.get("slippage_binding", {}).get("slippage_model_version") != (
+            "backtest_slippage_symmetric_v0"
+        ):
+            reasons.append("SLIPPAGE_MODEL_BINDING_MISMATCH")
+        if cost_stack.get("funding_binding", {}).get("funding_model_version") != (
+            "backtest_funding_perpetual_interval_v1"
+        ):
+            reasons.append("FUNDING_MODEL_BINDING_MISMATCH")
+
+    return StartStateVerificationResultV0(
+        valid=not reasons,
+        fail_reasons=tuple(dict.fromkeys(reasons)),
+        origin_main_sha=origin_main_sha,
+        binding_digest=str(envelope.get("binding_digest", "")),
+        authorization_ratification_digest=str(
+            authorization_ratification.get("ratification_digest", "")
+        ),
+    )
+
+
+def _panel_to_instrument_closes(
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+) -> dict[str, tuple[float, ...]]:
+    closes: dict[str, tuple[float, ...]] = {}
+    for series in panel_series:
+        closes[series.instrument_id] = tuple(float(bar.close) for bar in series.bars)
+    return closes
+
+
+def run_pairwise_spillover_score_ranking_pipeline_v0(
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    *,
+    epoch_index: int | None = None,
+    lag_window_l: int = DEFAULT_LAG_WINDOW_L,
+    signal_lag_bars: int = DEFAULT_SIGNAL_LAG_BARS,
+    forward_lag_bars: int = DEFAULT_FORWARD_LAG_BARS,
+) -> dict[str, Any]:
+    instrument_closes = _panel_to_instrument_closes(panel_series)
+    if not instrument_closes:
+        return {
+            "pair_scores": (),
+            "ranked_pairs": (),
+            "instrument_scores": (),
+            "ranked_instruments": (),
+            "epoch_index": epoch_index,
+            "score_owner": SCORE_OWNER,
+        }
+    max_len = min(len(values) for values in instrument_closes.values())
+    active_epoch = epoch_index if epoch_index is not None else max_len - forward_lag_bars - 1
+    pair_scores = compute_panel_pairwise_spillover_scores_v0(
+        instrument_closes,
+        lag_window_l=lag_window_l,
+        signal_lag_bars=signal_lag_bars,
+        forward_lag_bars=forward_lag_bars,
+        epoch_index=active_epoch,
+    )
+    if pair_scores is None:
+        return {
+            "pair_scores": None,
+            "ranked_pairs": (),
+            "instrument_scores": (),
+            "ranked_instruments": (),
+            "epoch_index": active_epoch,
+            "score_owner": SCORE_OWNER,
+        }
+    ranked_pairs = rank_pair_scores_deterministic_v0(pair_scores)
+    instrument_scores = compute_instrument_net_spillover_scores_v0(pair_scores)
+    ranked_instruments = rank_instrument_net_spillover_scores_deterministic_v0(instrument_scores)
+    return {
+        "pair_scores": pair_scores,
+        "ranked_pairs": ranked_pairs,
+        "instrument_scores": instrument_scores,
+        "ranked_instruments": ranked_instruments,
+        "epoch_index": active_epoch,
+        "score_owner": SCORE_OWNER,
+    }
+
+
+def build_stage_wiring_status_v0() -> tuple[StageWiringItemV0, ...]:
+    return (
+        StageWiringItemV0(
+            "OFFLINE_BACKTEST", True, "cross_sectional_single_slot_backtest_wiring_v0"
+        ),
+        StageWiringItemV0("WALK_FORWARD", True, "cross_sectional_panel_robustness_adapter_v0"),
+        StageWiringItemV0("MONTE_CARLO", True, "cross_sectional_panel_robustness_adapter_v0"),
+        StageWiringItemV0("STRESS", True, "cross_sectional_panel_robustness_adapter_v0"),
+        StageWiringItemV0(
+            "PARAMETER_SENSITIVITY",
+            True,
+            "cross_sectional_panel_robustness_adapter_v0",
+        ),
+        StageWiringItemV0(
+            "ECONOMIC_VIABILITY_EVIDENCE_MATERIALIZATION",
+            True,
+            "cross_sectional_panel_economic_evaluation_wiring_v0",
+        ),
+    )
+
+
+def run_contract_smoke_evaluation_v0(
+    *,
+    repo_root: Path,
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    versioned_binding: Mapping[str, Any],
+    staging_root: Path | None = None,
+    go_token: str = IMPLEMENTATION_GO_TOKEN,
+) -> InfrastructureReadinessResultV0:
+    """Contract-only smoke: score/ranking pipeline wiring without economic execution."""
+    token_ok, token_reasons = validate_implementation_go_token_v0(go_token)
+    if not token_ok:
+        return InfrastructureReadinessResultV0(
+            status=InfrastructureTerminalStatus.FAIL_CLOSED,
+            execution_infrastructure_complete=False,
+            panel_wiring_complete=False,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest="0" * 64,
+            reason_codes=token_reasons,
+            pair_score_count=None,
+            instrument_score_count=None,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+            economic_evaluation_executed=False,
+        )
+
+    envelope = dict(versioned_binding)
+    period_binding = envelope["period_binding"]
+    materialization = materialize_bound_panel_dataset_v0(
+        staging_root or Path("."),
+        period_binding=period_binding,
+    )
+    if materialization.status is MaterializationTerminalStatus.BOUND_DATA_UNAVAILABLE_FAIL_CLOSED:
+        pipeline = run_pairwise_spillover_score_ranking_pipeline_v0(panel_series)
+        pair_count = len(pipeline["ranked_pairs"]) if pipeline["pair_scores"] else 0
+        instrument_count = len(pipeline["ranked_instruments"])
+        return InfrastructureReadinessResultV0(
+            status=InfrastructureTerminalStatus.FAIL_CLOSED_BOUND_DATA_UNAVAILABLE,
+            execution_infrastructure_complete=True,
+            panel_wiring_complete=True,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest=materialization.panel_data_digest,
+            reason_codes=materialization.reason_codes,
+            pair_score_count=pair_count,
+            instrument_score_count=instrument_count,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+            economic_evaluation_executed=False,
+        )
+
+    pipeline = run_pairwise_spillover_score_ranking_pipeline_v0(panel_series)
+    pair_count = len(pipeline["ranked_pairs"]) if pipeline["pair_scores"] else 0
+    instrument_count = len(pipeline["ranked_instruments"])
+    _ = build_stage_wiring_status_v0()
+
+    return InfrastructureReadinessResultV0(
+        status=InfrastructureTerminalStatus.EXECUTION_INFRASTRUCTURE_COMPLETE,
+        execution_infrastructure_complete=True,
+        panel_wiring_complete=True,
+        bound_dataset_materialized=True,
+        dataset_period_match=True,
+        panel_data_digest=materialization.panel_data_digest,
+        reason_codes=(),
+        pair_score_count=pair_count,
+        instrument_score_count=instrument_count,
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+        economic_evaluation_executed=False,
+    )
+
+
+def verify_full_evaluation_precheck_v1(
+    *,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any],
+    staging_root: Path,
+    versioned_binding: Mapping[str, Any] | None = None,
+    go_token: str | None = None,
+    require_execution_go: bool = False,
+) -> tuple[bool, tuple[str, ...], Any]:
+    reasons: list[str] = []
+    envelope = dict(versioned_binding or load_versioned_hypothesis_binding_v0(repo_root))
+
+    start_state = verify_execution_start_state_v0(
+        repo_root=repo_root,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=envelope,
+    )
+    if not start_state.valid:
+        reasons.extend(start_state.fail_reasons)
+
+    if require_execution_go:
+        token_ok, token_reasons = validate_execution_go_token_v0(go_token)
+        if not token_ok:
+            reasons.extend(token_reasons)
+    else:
+        token_ok, token_reasons = validate_implementation_go_token_v0(go_token)
+        if not token_ok:
+            reasons.extend(token_reasons)
+
+    if go_token == EXECUTION_GO_TOKEN and not require_execution_go:
+        reasons.append(REASON_ECONOMIC_EXECUTION_FORBIDDEN)
+
+    ops_cfg = load_ops_evaluation_config_v0(repo_root)
+    digest_ok, digest_reasons = verify_ratified_digests_v0(
+        envelope,
+        expected_binding_digest=str(ops_cfg.get("binding_digest", "")),
+        expected_dataset_digest=str(
+            ops_cfg.get("cross_sectional_evaluation_binding_v1", {})
+            .get("dataset_binding", {})
+            .get("dataset_digest", RATIFIED_DATASET_DIGEST)
+        ),
+    )
+    if not digest_ok:
+        reasons.extend(digest_reasons)
+
+    if reasons:
+        return False, tuple(dict.fromkeys(reasons)), None
+
+    materialization = materialize_bound_panel_dataset_v0(
+        staging_root,
+        period_binding=envelope["period_binding"],
+    )
+    return True, (), materialization
+
+
+def run_full_evaluation_entrypoint_dry_run_v1(
+    *,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any],
+    staging_root: Path,
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    versioned_binding: Mapping[str, Any] | None = None,
+    go_token: str = IMPLEMENTATION_GO_TOKEN,
+) -> FullEvaluationEntrypointResultV1:
+    """Validate full evaluation entrypoint wiring; stop before economic classification."""
+    if go_token == EXECUTION_GO_TOKEN:
+        return FullEvaluationEntrypointResultV1(
+            status=EvaluationEntrypointTerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=False,
+            source_manifests_verified=False,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest="0" * 64,
+            stage_wiring=(),
+            dry_run_stopped_before_execution=True,
+            economic_evaluation_executed=False,
+            reason_codes=(REASON_ECONOMIC_EXECUTION_FORBIDDEN,),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    envelope = dict(versioned_binding or load_versioned_hypothesis_binding_v0(repo_root))
+    precheck_ok, precheck_reasons, materialization = verify_full_evaluation_precheck_v1(
+        repo_root=repo_root,
+        authorization_ratification=authorization_ratification,
+        staging_root=staging_root,
+        versioned_binding=envelope,
+        go_token=go_token,
+    )
+    manifest_ok, _, _ = verify_panel_staging_source_manifests_v1(staging_root)
+
+    if not precheck_ok:
+        return FullEvaluationEntrypointResultV1(
+            status=EvaluationEntrypointTerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=False,
+            source_manifests_verified=manifest_ok,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest=getattr(materialization, "panel_data_digest", "0" * 64),
+            stage_wiring=(),
+            dry_run_stopped_before_execution=True,
+            economic_evaluation_executed=False,
+            reason_codes=precheck_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    smoke = run_contract_smoke_evaluation_v0(
+        repo_root=repo_root,
+        panel_series=panel_series,
+        versioned_binding=envelope,
+        staging_root=staging_root,
+        go_token=go_token,
+    )
+    stage_wiring = build_stage_wiring_status_v0()
+
+    return FullEvaluationEntrypointResultV1(
+        status=EvaluationEntrypointTerminalStatus.ENTRYPOINT_READY_DRY_RUN_STOPPED,
+        precheck_passed=True,
+        source_manifests_verified=manifest_ok,
+        bound_dataset_materialized=smoke.bound_dataset_materialized,
+        dataset_period_match=smoke.dataset_period_match,
+        panel_data_digest=smoke.panel_data_digest,
+        stage_wiring=stage_wiring,
+        dry_run_stopped_before_execution=True,
+        economic_evaluation_executed=False,
+        reason_codes=(),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def _blocked_phase_result_v0(*, phase: str, reason: str) -> PhaseExecutionBlockedResultV0:
+    return PhaseExecutionBlockedResultV0(
+        phase=phase,
+        executed=False,
+        blocked=True,
+        reason_codes=(reason,),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def run_baseline_offline_economic_evaluation_v0(
+    *,
+    go_token: str,
+    **_kwargs: Any,
+) -> PhaseExecutionBlockedResultV0:
+    if go_token != EXECUTION_GO_TOKEN:
+        return _blocked_phase_result_v0(phase="BASELINE", reason=REASON_GO_TOKEN_INVALID)
+    return _blocked_phase_result_v0(
+        phase="BASELINE",
+        reason=REASON_ECONOMIC_EXECUTION_FORBIDDEN,
+    )
+
+
+def run_walk_forward_evaluation_v0(
+    *, go_token: str, **_kwargs: Any
+) -> PhaseExecutionBlockedResultV0:
+    if go_token != EXECUTION_GO_TOKEN:
+        return _blocked_phase_result_v0(phase="WALK_FORWARD", reason=REASON_GO_TOKEN_INVALID)
+    return _blocked_phase_result_v0(
+        phase="WALK_FORWARD",
+        reason=REASON_ECONOMIC_EXECUTION_FORBIDDEN,
+    )
+
+
+def run_monte_carlo_evaluation_v0(
+    *, go_token: str, **_kwargs: Any
+) -> PhaseExecutionBlockedResultV0:
+    if go_token != EXECUTION_GO_TOKEN:
+        return _blocked_phase_result_v0(phase="MONTE_CARLO", reason=REASON_GO_TOKEN_INVALID)
+    return _blocked_phase_result_v0(
+        phase="MONTE_CARLO",
+        reason=REASON_ECONOMIC_EXECUTION_FORBIDDEN,
+    )
+
+
+def run_stress_evaluation_v0(*, go_token: str, **_kwargs: Any) -> PhaseExecutionBlockedResultV0:
+    if go_token != EXECUTION_GO_TOKEN:
+        return _blocked_phase_result_v0(phase="STRESS", reason=REASON_GO_TOKEN_INVALID)
+    return _blocked_phase_result_v0(phase="STRESS", reason=REASON_ECONOMIC_EXECUTION_FORBIDDEN)
+
+
+def run_full_offline_economic_evaluation_v0(
+    *,
+    go_token: str,
+    **_kwargs: Any,
+) -> PhaseExecutionBlockedResultV0:
+    if go_token != EXECUTION_GO_TOKEN:
+        return _blocked_phase_result_v0(
+            phase="FULL_OFFLINE_ECONOMIC_EVALUATION",
+            reason=REASON_GO_TOKEN_INVALID,
+        )
+    return _blocked_phase_result_v0(
+        phase="FULL_OFFLINE_ECONOMIC_EVALUATION",
+        reason=REASON_ECONOMIC_EXECUTION_FORBIDDEN,
+    )
+
+
+def materialize_execution_contract_v0() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "execution_id": EXECUTION_ID,
+        "strategy_id": STRATEGY_ID,
+        "strategy_version": STRATEGY_VERSION,
+        "research_scope": RESEARCH_SCOPE,
+        "hypothesis_id": RESEARCH_HYPOTHESIS_ID,
+        "score_family_policy": SCORE_FORMULA_VERSION,
+        "canonical_evaluation_callable": CANONICAL_EVALUATION_CALLABLE,
+        "canonical_full_evaluation_callable": CANONICAL_FULL_EVALUATION_CALLABLE,
+        "implementation_go_token": IMPLEMENTATION_GO_TOKEN,
+        "execution_go_token": EXECUTION_GO_TOKEN,
+        "entry_point_status": ENTRY_POINT_STATUS,
+        "runner_binding_ref": RUNNER_SCRIPT,
+        "harness_binding_ref": f"{HARNESS_OWNER}.py",
+        "versioned_binding_config": CONFIG_REL_PATH,
+        "authorization_config": AUTHORIZATION_CONFIG_REL_PATH,
+        "ops_evaluation_config": CONFIG_REL_PATH_OPS,
+        "score_owner": SCORE_OWNER,
+        "score_ranking_contract_owner": SCORE_RANKING_CONTRACT_OWNER,
+        "authorization_owner": AUTHORIZATION_OWNER,
+        "hypothesis_binding_owner": HYPOTHESIS_BINDING_OWNER,
+        "binding_digest": RATIFIED_BINDING_DIGEST,
+        "dataset_digest": RATIFIED_DATASET_DIGEST,
+        "universe_digest": RATIFIED_UNIVERSE_DIGEST,
+        "fee_model_version": "backtest_fee_taker_symmetric_v0",
+        "slippage_model_version": "backtest_slippage_symmetric_v0",
+        "funding_model_version": "backtest_funding_perpetual_interval_v1",
+        "allowed_evaluation_stages": list(ALLOWED_EVALUATION_STAGES),
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "robustness_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+    }
+
+
+def materialize_infrastructure_summary_v0(
+    *,
+    authorization_ratification: Mapping[str, Any],
+    readiness: InfrastructureReadinessResultV0,
+    origin_main_sha: str,
+    execution_bundle_dir: str,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "execution_id": EXECUTION_ID,
+        "execution_version": EXECUTION_VERSION,
+        "strategy_id": STRATEGY_ID,
+        "strategy_version": STRATEGY_VERSION,
+        "hypothesis_id": RESEARCH_HYPOTHESIS_ID,
+        "research_scope": RESEARCH_SCOPE,
+        "score_family_policy": SCORE_FORMULA_VERSION,
+        "authorization_ratification_digest": authorization_ratification.get("ratification_digest"),
+        "origin_main_sha": origin_main_sha,
+        "execution_bundle_dir": execution_bundle_dir,
+        "execution_infrastructure_complete": readiness.execution_infrastructure_complete,
+        "panel_wiring_complete": readiness.panel_wiring_complete,
+        "bound_dataset_materialized": readiness.bound_dataset_materialized,
+        "dataset_period_match": readiness.dataset_period_match,
+        "panel_data_digest": readiness.panel_data_digest,
+        "infrastructure_status": readiness.status.value,
+        "reason_codes": list(readiness.reason_codes),
+        "pair_score_count": readiness.pair_score_count,
+        "instrument_score_count": readiness.instrument_score_count,
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "robustness_executed": False,
+        "economic_classification": "NONE",
+        "ready_for_separately_authorized_offline_economic_evaluation": (
+            readiness.status is InfrastructureTerminalStatus.EXECUTION_INFRASTRUCTURE_COMPLETE
+            and readiness.panel_wiring_complete
+        ),
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "config_rel_path": CONFIG_REL_PATH_OPS,
+        "candidate_binding_ref": CONFIG_REL_PATH,
+        "canonical_serialization_version": CANONICAL_SERIALIZATION_VERSION,
+    }
+    body["manifest_digest"] = _stable_digest(body)
+    return body
+
+
+def entrypoint_result_to_dict(result: FullEvaluationEntrypointResultV1) -> dict[str, Any]:
+    return {
+        "status": result.status.value,
+        "precheck_passed": result.precheck_passed,
+        "source_manifests_verified": result.source_manifests_verified,
+        "bound_dataset_materialized": result.bound_dataset_materialized,
+        "dataset_period_match": result.dataset_period_match,
+        "panel_data_digest": result.panel_data_digest,
+        "stage_wiring": [
+            {"stage_name": item.stage_name, "wired": item.wired, "owner": item.owner}
+            for item in result.stage_wiring
+        ],
+        "allowed_evaluation_stages": list(ALLOWED_EVALUATION_STAGES),
+        "dry_run_stopped_before_execution": result.dry_run_stopped_before_execution,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "reason_codes": list(result.reason_codes),
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+        "runner_owner": RUNNER_OWNER,
+        "runner_script": RUNNER_SCRIPT,
+    }
+
+
+def build_owner_inventory() -> dict[str, Any]:
+    return {
+        "schema_version": "owner_inventory.v0",
+        "harness_owner": HARNESS_OWNER,
+        "runner_owner": RUNNER_OWNER,
+        "score_owner": SCORE_OWNER,
+        "score_ranking_contract_owner": SCORE_RANKING_CONTRACT_OWNER,
+        "authorization_owner": AUTHORIZATION_OWNER,
+        "hypothesis_binding_owner": HYPOTHESIS_BINDING_OWNER,
+        "dataset_materialization_owner": (
+            "cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0"
+        ),
+        "panel_staging_manifest_owner": "cross_sectional_panel_staging_source_manifest_v1",
+        "robustness_wiring_owner": "cross_sectional_panel_economic_evaluation_wiring_v0",
+        "manifest_owner": "scripts.ops.primary_evidence_retention_v0",
+    }
+
+
+def build_reuse_decision() -> dict[str, Any]:
+    return {
+        "schema_version": "reuse_decision.v0",
+        "decisions": [
+            {
+                "component": "hypothesis_binding_loader",
+                "decision": "REUSE_AS_IS",
+                "owner": HYPOTHESIS_BINDING_OWNER,
+            },
+            {
+                "component": "authorization_ratification_loader",
+                "decision": "REUSE_AS_IS",
+                "owner": AUTHORIZATION_OWNER,
+            },
+            {
+                "component": "score_ranking_pipeline",
+                "decision": "REUSE_AS_IS",
+                "owner": SCORE_OWNER,
+            },
+            {
+                "component": "bound_panel_dataset_materialization",
+                "decision": "REUSE_AS_IS",
+                "owner": (
+                    "cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0"
+                ),
+            },
+            {
+                "component": "execution_harness",
+                "decision": "NEW_IMPLEMENTATION_JUSTIFIED",
+                "justification": "scope_specific_orchestration_adapter_without_semantic_duplication",
+            },
+        ],
+    }
+
+
+def build_runner_decision() -> dict[str, Any]:
+    return {
+        "schema_version": "runner_decision.v0",
+        "runner_required": True,
+        "runner_action": "THIN_OPS_DELEGATION_TO_HARNESS",
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "robustness_executed": False,
+        "implementation_go_token": IMPLEMENTATION_GO_TOKEN,
+        "execution_go_token": EXECUTION_GO_TOKEN,
+        "next_recommended_scope": (
+            "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+            "EVALUATION_EXECUTION_V0"
+        ),
+        "next_operator_go": EXECUTION_GO_TOKEN,
+    }

--- a/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -83,8 +83,14 @@ EXECUTION_GO_TOKEN = (
     "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
     "EVALUATION_EXECUTION_V0"
 )
-GO_TOKEN = EXECUTION_GO_TOKEN
-INFRASTRUCTURE_GO_TOKEN = IMPLEMENTATION_GO_TOKEN
+GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_EXECUTION_V0"
+)
+INFRASTRUCTURE_GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_EXECUTION_IMPLEMENTATION_V0"
+)
 
 ALLOWED_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset({IMPLEMENTATION_GO_TOKEN})
 ALLOWED_EXECUTION_GO_TOKENS: frozenset[str] = frozenset({EXECUTION_GO_TOKEN})
@@ -471,10 +477,11 @@ def run_contract_smoke_evaluation_v0(
     panel_series: Sequence[InstrumentPanelSeriesV1],
     versioned_binding: Mapping[str, Any],
     staging_root: Path | None = None,
-    go_token: str = IMPLEMENTATION_GO_TOKEN,
+    go_token: str | None = None,
 ) -> InfrastructureReadinessResultV0:
     """Contract-only smoke: score/ranking pipeline wiring without economic execution."""
-    token_ok, token_reasons = validate_implementation_go_token_v0(go_token)
+    active_go = go_token if go_token is not None else IMPLEMENTATION_GO_TOKEN
+    token_ok, token_reasons = validate_implementation_go_token_v0(active_go)
     if not token_ok:
         return InfrastructureReadinessResultV0(
             status=InfrastructureTerminalStatus.FAIL_CLOSED,
@@ -599,10 +606,11 @@ def run_full_evaluation_entrypoint_dry_run_v1(
     staging_root: Path,
     panel_series: Sequence[InstrumentPanelSeriesV1],
     versioned_binding: Mapping[str, Any] | None = None,
-    go_token: str = IMPLEMENTATION_GO_TOKEN,
+    go_token: str | None = None,
 ) -> FullEvaluationEntrypointResultV1:
     """Validate full evaluation entrypoint wiring; stop before economic classification."""
-    if go_token == EXECUTION_GO_TOKEN:
+    active_go = go_token if go_token is not None else IMPLEMENTATION_GO_TOKEN
+    if active_go == EXECUTION_GO_TOKEN:
         return FullEvaluationEntrypointResultV1(
             status=EvaluationEntrypointTerminalStatus.FAIL_CLOSED_PRECHECK,
             precheck_passed=False,
@@ -624,7 +632,7 @@ def run_full_evaluation_entrypoint_dry_run_v1(
         authorization_ratification=authorization_ratification,
         staging_root=staging_root,
         versioned_binding=envelope,
-        go_token=go_token,
+        go_token=active_go,
     )
     manifest_ok, _, _ = verify_panel_staging_source_manifests_v1(staging_root)
 
@@ -649,7 +657,7 @@ def run_full_evaluation_entrypoint_dry_run_v1(
         panel_series=panel_series,
         versioned_binding=envelope,
         staging_root=staging_root,
-        go_token=go_token,
+        go_token=active_go,
     )
     stage_wiring = build_stage_wiring_status_v0()
 

--- a/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -278,9 +278,9 @@ def validate_execution_go_token_v0(go_token: str | None) -> tuple[bool, tuple[st
 
 
 def validate_entry_point_go_token_v0(go_token: str) -> tuple[bool, str | None]:
-    if go_token == IMPLEMENTATION_GO_TOKEN:
+    if go_token in ALLOWED_IMPLEMENTATION_GO_TOKENS:
         return True, "IMPLEMENTATION_V0"
-    if go_token == EXECUTION_GO_TOKEN:
+    if go_token in ALLOWED_EXECUTION_GO_TOKENS:
         return True, "EXECUTION_V0"
     return False, None
 
@@ -573,7 +573,7 @@ def verify_full_evaluation_precheck_v1(
         if not token_ok:
             reasons.extend(token_reasons)
 
-    if go_token == EXECUTION_GO_TOKEN and not require_execution_go:
+    if go_token in ALLOWED_EXECUTION_GO_TOKENS and not require_execution_go:
         reasons.append(REASON_ECONOMIC_EXECUTION_FORBIDDEN)
 
     ops_cfg = load_ops_evaluation_config_v0(repo_root)
@@ -610,7 +610,7 @@ def run_full_evaluation_entrypoint_dry_run_v1(
 ) -> FullEvaluationEntrypointResultV1:
     """Validate full evaluation entrypoint wiring; stop before economic classification."""
     active_go = go_token if go_token is not None else IMPLEMENTATION_GO_TOKEN
-    if active_go == EXECUTION_GO_TOKEN:
+    if active_go in ALLOWED_EXECUTION_GO_TOKENS:
         return FullEvaluationEntrypointResultV1(
             status=EvaluationEntrypointTerminalStatus.FAIL_CLOSED_PRECHECK,
             precheck_passed=False,
@@ -693,7 +693,7 @@ def run_baseline_offline_economic_evaluation_v0(
     go_token: str,
     **_kwargs: Any,
 ) -> PhaseExecutionBlockedResultV0:
-    if go_token != EXECUTION_GO_TOKEN:
+    if go_token not in ALLOWED_EXECUTION_GO_TOKENS:
         return _blocked_phase_result_v0(phase="BASELINE", reason=REASON_GO_TOKEN_INVALID)
     return _blocked_phase_result_v0(
         phase="BASELINE",
@@ -704,7 +704,7 @@ def run_baseline_offline_economic_evaluation_v0(
 def run_walk_forward_evaluation_v0(
     *, go_token: str, **_kwargs: Any
 ) -> PhaseExecutionBlockedResultV0:
-    if go_token != EXECUTION_GO_TOKEN:
+    if go_token not in ALLOWED_EXECUTION_GO_TOKENS:
         return _blocked_phase_result_v0(phase="WALK_FORWARD", reason=REASON_GO_TOKEN_INVALID)
     return _blocked_phase_result_v0(
         phase="WALK_FORWARD",
@@ -715,7 +715,7 @@ def run_walk_forward_evaluation_v0(
 def run_monte_carlo_evaluation_v0(
     *, go_token: str, **_kwargs: Any
 ) -> PhaseExecutionBlockedResultV0:
-    if go_token != EXECUTION_GO_TOKEN:
+    if go_token not in ALLOWED_EXECUTION_GO_TOKENS:
         return _blocked_phase_result_v0(phase="MONTE_CARLO", reason=REASON_GO_TOKEN_INVALID)
     return _blocked_phase_result_v0(
         phase="MONTE_CARLO",
@@ -724,7 +724,7 @@ def run_monte_carlo_evaluation_v0(
 
 
 def run_stress_evaluation_v0(*, go_token: str, **_kwargs: Any) -> PhaseExecutionBlockedResultV0:
-    if go_token != EXECUTION_GO_TOKEN:
+    if go_token not in ALLOWED_EXECUTION_GO_TOKENS:
         return _blocked_phase_result_v0(phase="STRESS", reason=REASON_GO_TOKEN_INVALID)
     return _blocked_phase_result_v0(phase="STRESS", reason=REASON_ECONOMIC_EXECUTION_FORBIDDEN)
 
@@ -734,7 +734,7 @@ def run_full_offline_economic_evaluation_v0(
     go_token: str,
     **_kwargs: Any,
 ) -> PhaseExecutionBlockedResultV0:
-    if go_token != EXECUTION_GO_TOKEN:
+    if go_token not in ALLOWED_EXECUTION_GO_TOKENS:
         return _blocked_phase_result_v0(
             phase="FULL_OFFLINE_ECONOMIC_EVALUATION",
             reason=REASON_GO_TOKEN_INVALID,

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -149,6 +149,12 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
                 "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_authorization_ratification_repair_v0.py",
                 "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_full_runner_v0.py",
             ],
+            [
+                "src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py",
+                "scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py",
+                "config/ops/cross_sectional_futures_pairwise_lead_lag_spillover_v1_economic_evaluation_v1.json",
+                "tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_infrastructure_v0.py",
+            ],
         ],
     )
     def test_positive_cases_admissible(self, changed_files: list[str]) -> None:

--- a/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_infrastructure_v0.py
+++ b/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_infrastructure_v0.py
@@ -1,0 +1,424 @@
+"""Contract and integration tests for pairwise spillover v1 execution infrastructure v0."""
+
+from __future__ import annotations
+
+import ast
+import sys
+import tempfile
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_authorization_ratification_v0 import (
+    materialize_offline_economic_evaluation_authorization_ratification_v0,
+    materializer_to_binder_roundtrip_v0 as authorization_materializer_roundtrip_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    EXECUTION_GO_TOKEN,
+    IMPLEMENTATION_GO_TOKEN,
+    RATIFIED_BINDING_DIGEST,
+    RATIFIED_DATASET_DIGEST,
+    RATIFIED_UNIVERSE_DIGEST,
+    REASON_BINDING_DIGEST_MISMATCH,
+    REASON_DATASET_DIGEST_MISMATCH,
+    REASON_ECONOMIC_EXECUTION_FORBIDDEN,
+    REASON_GO_TOKEN_INVALID,
+    REASON_UNIVERSE_DIGEST_MISMATCH,
+    RUNNER_SCRIPT,
+    RUNTIME_EFFECT,
+    build_owner_inventory,
+    build_reuse_decision,
+    build_runner_decision,
+    load_ops_evaluation_config_v0,
+    materialize_execution_contract_v0,
+    run_baseline_offline_economic_evaluation_v0,
+    run_contract_smoke_evaluation_v0,
+    run_full_evaluation_entrypoint_dry_run_v1,
+    run_full_offline_economic_evaluation_v0,
+    run_pairwise_spillover_score_ranking_pipeline_v0,
+    validate_entry_point_go_token_v0,
+    validate_execution_go_token_v0,
+    validate_implementation_go_token_v0,
+    verify_execution_start_state_v0,
+    verify_ratified_digests_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_score_v0 import (
+    DEFAULT_FORWARD_LAG_BARS,
+    DEFAULT_LAG_WINDOW_L,
+    DEFAULT_SIGNAL_LAG_BARS,
+    SCORE_FORMULA_VERSION,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0 import (
+    materialize_and_validate_versioned_hypothesis_binding_v0,
+    materialize_versioned_hypothesis_binding_v0,
+    materializer_to_binder_roundtrip_v0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.fixture_builder import (
+    build_synthetic_panel_series_v0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.staging_builder import (
+    write_bound_period_staging_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXECUTION_MODULE = (
+    REPO_ROOT / "src/research/"
+    "cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_"
+    "evaluation_execution_v0.py"
+)
+RUNNER_MODULE = REPO_ROOT / RUNNER_SCRIPT
+FORBIDDEN_RUNTIME_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+)
+PY310_STAGING = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="panel staging loader requires Python 3.10+ zip(strict=True)",
+)
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_hypothesis_binding_v0()
+
+
+@pytest.fixture(name="authorization_ratification")
+def fixture_authorization_ratification() -> dict:
+    return materialize_offline_economic_evaluation_authorization_ratification_v0()
+
+
+@pytest.fixture(name="bound_staging")
+def fixture_bound_staging() -> Path:
+    tmp = Path(tempfile.mkdtemp(prefix="cs_pairwise_spillover_bound_staging_"))
+    staging = write_bound_period_staging_v0(tmp)
+    lifecycle = staging / "lifecycle"
+    lifecycle.mkdir(parents=True, exist_ok=True)
+    lifecycle.joinpath("SOURCE_REGISTRATION.json").write_text(
+        '{"source_snapshot_ref":"test:fixture","source_snapshot_digest":"'
+        + "a" * 64
+        + '","registered":true}\n',
+        encoding="utf-8",
+    )
+    return staging
+
+
+class TestCanonicalEntryPointExists:
+    def test_harness_module_exists(self) -> None:
+        assert EXECUTION_MODULE.is_file()
+
+    def test_runner_module_exists(self) -> None:
+        assert RUNNER_MODULE.is_file()
+
+    def test_import_is_side_effect_free(self) -> None:
+        tree = ast.parse(EXECUTION_MODULE.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+                pytest.fail("module import must not invoke call expressions at top level")
+
+
+class TestGoTokenEnforcement:
+    def test_implementation_go_token_accepted(self) -> None:
+        ok, reasons = validate_implementation_go_token_v0(IMPLEMENTATION_GO_TOKEN)
+        assert ok, reasons
+
+    def test_execution_go_token_accepted(self) -> None:
+        ok, reasons = validate_execution_go_token_v0(EXECUTION_GO_TOKEN)
+        assert ok, reasons
+
+    def test_missing_go_token_rejected(self) -> None:
+        ok, reasons = validate_implementation_go_token_v0(None)
+        assert not ok
+        assert REASON_GO_TOKEN_INVALID in reasons or "GO_TOKEN_MISSING" in reasons
+
+    def test_wrong_go_token_rejected(self) -> None:
+        ok, reasons = validate_implementation_go_token_v0("GO_WRONG_TOKEN")
+        assert not ok
+        assert REASON_GO_TOKEN_INVALID in reasons
+
+    def test_entry_point_dispatch(self) -> None:
+        ok, branch = validate_entry_point_go_token_v0(IMPLEMENTATION_GO_TOKEN)
+        assert ok and branch == "IMPLEMENTATION_V0"
+        ok, branch = validate_entry_point_go_token_v0(EXECUTION_GO_TOKEN)
+        assert ok and branch == "EXECUTION_V0"
+
+
+class TestOfflineBoundary:
+    def test_no_runtime_authority_effect_constants(self) -> None:
+        assert AUTHORITY_EFFECT == "NONE"
+        assert RUNTIME_EFFECT == "NONE"
+
+    def test_futures_only_and_bitcoin_excluded(self, complete_binding: dict) -> None:
+        assert complete_binding["system_constraints"]["futures_only"] is True
+        assert complete_binding["system_constraints"]["bitcoin_direction_allowed"] is False
+        pairwise = complete_binding["pairwise_hypothesis_contract"]
+        assert pairwise["spot_allowed"] is False
+        assert pairwise["synthetic_spot_allowed"] is False
+
+
+class TestDigestBinding:
+    def test_binding_digest_matches_ratified(self, complete_binding: dict) -> None:
+        assert complete_binding["binding_digest"] == RATIFIED_BINDING_DIGEST
+
+    def test_dataset_digest_matches_ratified(self, complete_binding: dict) -> None:
+        assert complete_binding["dataset_digest"] == RATIFIED_DATASET_DIGEST
+
+    def test_universe_digest_matches_ratified(self, complete_binding: dict) -> None:
+        universe_digest = complete_binding["binding"]["pit_universe_binding"]["universe_digest"]
+        assert universe_digest == RATIFIED_UNIVERSE_DIGEST
+
+    def test_binding_digest_mismatch_rejected(self, complete_binding: dict) -> None:
+        stale = deepcopy(complete_binding)
+        stale["binding_digest"] = "f" * 64
+        ok, reasons = verify_ratified_digests_v0(
+            stale,
+            expected_binding_digest=complete_binding["binding_digest"],
+        )
+        assert ok is False
+        assert REASON_BINDING_DIGEST_MISMATCH in reasons
+
+    def test_dataset_digest_mismatch_rejected(self, complete_binding: dict) -> None:
+        stale = deepcopy(complete_binding)
+        stale["dataset_digest"] = "f" * 64
+        ok, reasons = verify_ratified_digests_v0(
+            stale,
+            expected_dataset_digest=complete_binding["dataset_digest"],
+        )
+        assert ok is False
+        assert REASON_DATASET_DIGEST_MISMATCH in reasons
+
+    def test_universe_digest_mismatch_rejected(self, complete_binding: dict) -> None:
+        stale = deepcopy(complete_binding)
+        stale["binding"]["pit_universe_binding"]["universe_digest"] = "f" * 64
+        ok, reasons = verify_ratified_digests_v0(
+            stale,
+            expected_universe_digest=(
+                complete_binding["binding"]["pit_universe_binding"]["universe_digest"]
+            ),
+        )
+        assert ok is False
+        assert REASON_UNIVERSE_DIGEST_MISMATCH in reasons
+
+
+class TestAuthorizationAndBindingValidation:
+    def test_start_state_verification_accepts_ratified_bindings(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = verify_execution_start_state_v0(
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+        )
+        assert result.valid is True
+        assert result.fail_reasons == ()
+
+    def test_authorization_status_mismatch_rejected(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        stale = deepcopy(authorization_ratification)
+        stale["economic_evaluation_executed"] = True
+        result = verify_execution_start_state_v0(
+            repo_root=REPO_ROOT,
+            authorization_ratification=stale,
+            versioned_binding=complete_binding,
+        )
+        assert result.valid is False
+
+    def test_semantic_binding_mutation_rejected(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        stale = deepcopy(complete_binding)
+        stale["score_family_policy"] = "panel_median_benchmark_lagged_return_diffusion_v0"
+        result = verify_execution_start_state_v0(
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=stale,
+        )
+        assert result.valid is False
+
+
+class TestScoreRankingPipeline:
+    def test_canonical_score_owner_invoked(self) -> None:
+        panel = build_synthetic_panel_series_v0()
+        pipeline = run_pairwise_spillover_score_ranking_pipeline_v0(panel)
+        assert pipeline["score_owner"].endswith("score_v0")
+        assert pipeline["ranked_pairs"] is not None
+
+    def test_score_parameters_bound_from_defaults(self) -> None:
+        assert DEFAULT_LAG_WINDOW_L == 8
+        assert DEFAULT_SIGNAL_LAG_BARS == 1
+        assert DEFAULT_FORWARD_LAG_BARS == 1
+        assert SCORE_FORMULA_VERSION == "pairwise_spillover_graph_v1"
+
+    def test_deterministic_pipeline(self) -> None:
+        panel = build_synthetic_panel_series_v0()
+        first = run_pairwise_spillover_score_ranking_pipeline_v0(panel)
+        second = run_pairwise_spillover_score_ranking_pipeline_v0(panel)
+        assert first == second
+
+    def test_cost_bindings_preserved(self, complete_binding: dict) -> None:
+        cost = complete_binding["cost_execution_binding"]
+        assert cost["fee_binding"]["fee_model_version"] == "backtest_fee_taker_symmetric_v0"
+        assert (
+            cost["slippage_binding"]["slippage_model_version"] == "backtest_slippage_symmetric_v0"
+        )
+        assert (
+            cost["funding_binding"]["funding_model_version"]
+            == "backtest_funding_perpetual_interval_v1"
+        )
+
+
+class TestContractSmokeAndDryRun:
+    def test_contract_smoke_no_economic_execution(self, complete_binding: dict) -> None:
+        panel = build_synthetic_panel_series_v0()
+        result = run_contract_smoke_evaluation_v0(
+            repo_root=REPO_ROOT,
+            panel_series=panel,
+            versioned_binding=complete_binding,
+            staging_root=Path("."),
+        )
+        assert result.economic_evaluation_executed is False
+        assert result.authority_effect == "NONE"
+
+    def test_precheck_rejects_invalid_go_token(
+        self,
+        bound_staging: Path,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        panel = build_synthetic_panel_series_v0()
+        result = run_full_evaluation_entrypoint_dry_run_v1(
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            staging_root=bound_staging,
+            panel_series=panel,
+            versioned_binding=complete_binding,
+            go_token="INVALID_TOKEN",
+        )
+        assert result.precheck_passed is False
+        assert result.economic_evaluation_executed is False
+
+    def test_execution_go_token_rejected_in_implementation_dry_run(
+        self,
+        bound_staging: Path,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        panel = build_synthetic_panel_series_v0()
+        result = run_full_evaluation_entrypoint_dry_run_v1(
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            staging_root=bound_staging,
+            panel_series=panel,
+            versioned_binding=complete_binding,
+            go_token=EXECUTION_GO_TOKEN,
+        )
+        assert result.precheck_passed is False
+        assert REASON_ECONOMIC_EXECUTION_FORBIDDEN in result.reason_codes
+
+    @PY310_STAGING
+    def test_full_evaluation_entrypoint_dry_run_stops_before_execution(
+        self,
+        bound_staging: Path,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        panel = build_synthetic_panel_series_v0()
+        result = run_full_evaluation_entrypoint_dry_run_v1(
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            staging_root=bound_staging,
+            panel_series=panel,
+            versioned_binding=complete_binding,
+            go_token=IMPLEMENTATION_GO_TOKEN,
+        )
+        assert result.economic_evaluation_executed is False
+        assert result.dry_run_stopped_before_execution is True
+
+
+class TestNoExecutionDuringImplementation:
+    def test_baseline_phase_blocked_without_execution_go(self) -> None:
+        result = run_baseline_offline_economic_evaluation_v0(go_token=IMPLEMENTATION_GO_TOKEN)
+        assert result.executed is False
+        assert result.blocked is True
+
+    def test_full_evaluation_blocked_in_implementation_scope(self) -> None:
+        result = run_full_offline_economic_evaluation_v0(go_token=EXECUTION_GO_TOKEN)
+        assert result.executed is False
+        assert REASON_ECONOMIC_EXECUTION_FORBIDDEN in result.reason_codes
+
+
+class TestMaterializationRoundtrip:
+    def test_binding_materialization_complete(self) -> None:
+        result = materialize_and_validate_versioned_hypothesis_binding_v0()
+        assert result.validation_verdict.value == "ACCEPTED_COMPLETE"
+
+    def test_hypothesis_materializer_to_binder_roundtrip(self, complete_binding: dict) -> None:
+        roundtrip = materializer_to_binder_roundtrip_v0(complete_binding)
+        assert roundtrip["materializer_to_binder_roundtrip_pass"] is True
+
+    def test_authorization_materializer_to_binder_roundtrip(
+        self,
+        authorization_ratification: dict,
+    ) -> None:
+        roundtrip = authorization_materializer_roundtrip_v0(authorization_ratification)
+        assert roundtrip["materializer_to_binder_roundtrip_pass"] is True
+
+    def test_deterministic_double_materialization(self) -> None:
+        first = materialize_versioned_hypothesis_binding_v0()
+        second = materialize_versioned_hypothesis_binding_v0()
+        assert first == second
+
+    def test_execution_contract_materialization(self) -> None:
+        contract = materialize_execution_contract_v0()
+        assert contract["economic_evaluation_executed"] is False
+        assert contract["binding_digest"] == RATIFIED_BINDING_DIGEST
+        assert contract["entry_point_status"] == "EXECUTION_INFRASTRUCTURE_COMPLETE"
+
+
+class TestOpsConfigAndGovernanceArtifacts:
+    def test_ops_config_loads(self, complete_binding: dict) -> None:
+        cfg = load_ops_evaluation_config_v0(REPO_ROOT)
+        assert cfg["strategy_id"] == "cross_sectional_futures_pairwise_lead_lag_spillover"
+        assert cfg["binding_digest"] == complete_binding["binding_digest"]
+
+    def test_owner_inventory_exports(self) -> None:
+        inventory = build_owner_inventory()
+        assert inventory["harness_owner"].endswith("execution_v0")
+        assert inventory["score_owner"].endswith("score_v0")
+
+    def test_reuse_decision_exports(self) -> None:
+        reuse = build_reuse_decision()
+        assert any(item["decision"] == "REUSE_AS_IS" for item in reuse["decisions"])
+
+    def test_runner_decision_exports(self) -> None:
+        decision = build_runner_decision()
+        assert decision["economic_evaluation_executed"] is False
+        assert decision["next_operator_go"] == EXECUTION_GO_TOKEN
+
+
+class TestImportBoundary:
+    def test_no_forbidden_runtime_imports(self) -> None:
+        source = EXECUTION_MODULE.read_text(encoding="utf-8")
+        for prefix in FORBIDDEN_RUNTIME_IMPORT_PREFIXES:
+            assert prefix not in source
+
+    def test_runner_has_no_forbidden_runtime_imports(self) -> None:
+        source = RUNNER_MODULE.read_text(encoding="utf-8")
+        for prefix in FORBIDDEN_RUNTIME_IMPORT_PREFIXES:
+            assert prefix not in source
+
+
+class TestHarnessRunnerContractRoundtrip:
+    def test_runner_delegates_to_harness_constants(self) -> None:
+        contract = materialize_execution_contract_v0()
+        assert contract["runner_binding_ref"] == RUNNER_SCRIPT
+        assert contract["implementation_go_token"] == IMPLEMENTATION_GO_TOKEN

--- a/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_infrastructure_v0.py
+++ b/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_infrastructure_v0.py
@@ -18,6 +18,7 @@ from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline
     AUTHORITY_EFFECT,
     EXECUTION_GO_TOKEN,
     IMPLEMENTATION_GO_TOKEN,
+    INFRASTRUCTURE_GO_TOKEN,
     RATIFIED_BINDING_DIGEST,
     RATIFIED_DATASET_DIGEST,
     RATIFIED_UNIVERSE_DIGEST,
@@ -63,6 +64,8 @@ from tests.research.fixtures.cross_sectional_relative_strength_v0.staging_builde
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+_INFRA_GO = INFRASTRUCTURE_GO_TOKEN
+_EXEC_GO = EXECUTION_GO_TOKEN
 EXECUTION_MODULE = (
     REPO_ROOT / "src/research/"
     "cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_"
@@ -319,7 +322,7 @@ class TestContractSmokeAndDryRun:
             staging_root=bound_staging,
             panel_series=panel,
             versioned_binding=complete_binding,
-            go_token=EXECUTION_GO_TOKEN,
+            go_token=_EXEC_GO,
         )
         assert result.precheck_passed is False
         assert REASON_ECONOMIC_EXECUTION_FORBIDDEN in result.reason_codes
@@ -338,7 +341,7 @@ class TestContractSmokeAndDryRun:
             staging_root=bound_staging,
             panel_series=panel,
             versioned_binding=complete_binding,
-            go_token=IMPLEMENTATION_GO_TOKEN,
+            go_token=_INFRA_GO,
         )
         assert result.economic_evaluation_executed is False
         assert result.dry_run_stopped_before_execution is True
@@ -346,12 +349,12 @@ class TestContractSmokeAndDryRun:
 
 class TestNoExecutionDuringImplementation:
     def test_baseline_phase_blocked_without_execution_go(self) -> None:
-        result = run_baseline_offline_economic_evaluation_v0(go_token=IMPLEMENTATION_GO_TOKEN)
+        result = run_baseline_offline_economic_evaluation_v0(go_token=_INFRA_GO)
         assert result.executed is False
         assert result.blocked is True
 
     def test_full_evaluation_blocked_in_implementation_scope(self) -> None:
-        result = run_full_offline_economic_evaluation_v0(go_token=EXECUTION_GO_TOKEN)
+        result = run_full_offline_economic_evaluation_v0(go_token=_EXEC_GO)
         assert result.executed is False
         assert REASON_ECONOMIC_EXECUTION_FORBIDDEN in result.reason_codes
 


### PR DESCRIPTION
## Summary
- Add ops config and execution module for cross-sectional futures pairwise lead-lag spillover v1 offline economic evaluation.
- Wire CLI runner script and infrastructure tests for the execution path.
- Extend economic diagnostic optimization boundary guard coverage for the new surface.

## Test plan
- [x] `PYENV_VERSION=3.11.14 ruff format --check` and `ruff check` on changed Python files
- [x] `PYENV_VERSION=3.11.14 python -m pytest` on `tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_infrastructure_v0.py`
- [x] `PYENV_VERSION=3.11.14 python -m pytest` on `tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py`
- [ ] CI green on push


Made with [Cursor](https://cursor.com)