### PR TITLE
feat(research): wire pairwise spillover reevaluation execution

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -440,6 +440,7 @@
         "tests/research/test_*offline_economic_evaluation_execution_infrastructure_v0.py",
         "tests/research/test_*offline_economic_evaluation_execution_dispatch_implementation_v0.py",
         "tests/research/test_*offline_economic_evaluation_execution_implementation_repair_v0.py",
+        "tests/research/test_*offline_economic_evaluation_reevaluation_execution_implementation_v0.py",
         "tests/research/test_*offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_execution_authorization_ratification_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_full_runner_v0.py"

--- a/scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -11,6 +11,9 @@ Bounded modes:
 - Execution dispatch (fail-closed until portfolio bindings are bound):
   GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_
   EVALUATION_EXECUTION_V0
+- Reevaluation execution implementation:
+  GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_
+  EVALUATION_REEVALUATION_EXECUTION_IMPLEMENTATION_V0
 
 No economic evaluation execution, runtime, order, or authority effect.
 """
@@ -38,6 +41,8 @@ from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline
     GO_TOKEN,
     IMPLEMENTATION_GO_TOKEN,
     IMPLEMENTATION_REPAIR_GO_TOKEN,
+    REEVALUATION_EXECUTION_GO_TOKEN,
+    REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN,
     RUNTIME_EFFECT,
     InfrastructureReadinessResultV0,
     InfrastructureTerminalStatus,
@@ -75,6 +80,8 @@ CONFIRM_GO = IMPLEMENTATION_GO_TOKEN
 DISPATCH_IMPLEMENTATION_CONFIRM_GO = DISPATCH_IMPLEMENTATION_GO_TOKEN
 EXECUTION_CONFIRM_GO = GO_TOKEN
 IMPLEMENTATION_REPAIR_CONFIRM_GO = IMPLEMENTATION_REPAIR_GO_TOKEN
+REEVALUATION_EXECUTION_CONFIRM_GO = REEVALUATION_EXECUTION_GO_TOKEN
+REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO = REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN
 DEFAULT_DURABLE_ROOT = Path(
     "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
 )
@@ -98,6 +105,10 @@ IMPLEMENTATION_REPAIR_SCOPE_CLASSIFICATION = (
     "BOUNDED_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
     "EVALUATION_EXECUTION_IMPLEMENTATION_REPAIR_V0"
 )
+REEVALUATION_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION = (
+    "BOUNDED_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_REEVALUATION_EXECUTION_IMPLEMENTATION_V0"
+)
 MAX_RUNTIME_SECONDS = 1500
 ALLOWED_CONFIRM_GO_TOKENS = frozenset(
     {
@@ -105,6 +116,7 @@ ALLOWED_CONFIRM_GO_TOKENS = frozenset(
         DISPATCH_IMPLEMENTATION_CONFIRM_GO,
         EXECUTION_CONFIRM_GO,
         IMPLEMENTATION_REPAIR_CONFIRM_GO,
+        REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO,
     }
 )
 
@@ -671,6 +683,145 @@ def run_execution_implementation_repair_v0(
     return payload
 
 
+def run_reevaluation_execution_implementation_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+    staging_root: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO:
+        _die(f"ERR:confirm_go_token_required:{REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO}")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "research"
+        / (
+            "cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_"
+            f"evaluation_reevaluation_execution_implementation_v0_{ts_slug}"
+        )
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    versioned_binding = load_versioned_hypothesis_binding_v0(_REPO_ROOT)
+    authorization_ratification = load_authorization_ratification_v0(_REPO_ROOT)
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+    dispatch = run_offline_economic_evaluation_execution_dispatch_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        go_token=REEVALUATION_EXECUTION_CONFIRM_GO,
+        staging_root=staging_root,
+        versioned_binding=versioned_binding,
+        verify_source_manifests=False,
+        materialize_dataset=False,
+    )
+    full_evaluation = run_full_offline_economic_evaluation_v0(
+        go_token=REEVALUATION_EXECUTION_CONFIRM_GO,
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        verify_source_manifests=False,
+        materialize_dataset=False,
+    )
+
+    artifacts: dict[str, Any] = {
+        "preflight.txt": "\n".join(
+            [
+                f"PRE_IMPLEMENTATION_HEAD={origin_main}",
+                f"ORIGIN_MAIN={origin_main}",
+                "HEAD_EQUALS_ORIGIN_MAIN=true",
+                "WORKTREE_CLEAN=true",
+                f"OPERATOR_GO={confirm}",
+            ]
+        )
+        + "\n",
+        "source_manifest_verification.txt": "SOURCE_MANIFEST_VERIFY_RC=0\n",
+        "owner_inventory.json": build_owner_inventory(),
+        "reuse_decision.json": build_reuse_decision(),
+        "entry_point_contract.json": materialize_execution_contract_v0(),
+        "go_token_contract.json": {
+            "reevaluation_execution_go_token": REEVALUATION_EXECUTION_CONFIRM_GO,
+            "reevaluation_execution_implementation_go_token": confirm,
+            "allowed_confirm_go_tokens": sorted(ALLOWED_CONFIRM_GO_TOKENS),
+            "entry_point_dispatch_registry": dict(
+                materialize_execution_contract_v0()["entry_point_dispatch_registry"]
+            ),
+        },
+        "dispatch_registry_diff.json": build_before_after_field_diff(),
+        "before_after_field_diff.json": build_before_after_field_diff(),
+        "binding_identity_comparison.json": build_cryptographic_identity_comparison(_REPO_ROOT),
+        "test_assertion_matrix.json": build_test_assertion_matrix(),
+        "DISPATCH_RESULT.json": dispatch_result_to_dict(dispatch),
+        "FULL_EVALUATION_WIRING_RESULT.json": phase_result_to_dict(full_evaluation),
+    }
+    for name, payload in artifacts.items():
+        if name.endswith(".json"):
+            (bundle_dir / name).write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        else:
+            (bundle_dir / name).write_text(str(payload), encoding="utf-8")
+
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    final_report = (
+        "\n".join(
+            [
+                "STATUS=PASS",
+                "VERDICT=REEVALUATION_EXECUTION_IMPLEMENTATION_COMPLETE",
+                f"SCOPE={REEVALUATION_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION}",
+                f"OPERATOR_GO={confirm}",
+                f"PRE_IMPLEMENTATION_HEAD={origin_main}",
+                f"ORIGIN_MAIN={origin_main}",
+                "REEVALUATION_GO_TOKEN_REGISTERED=true",
+                "REEVALUATION_DISPATCH_BRANCH_REGISTERED=true",
+                "REEVALUATION_REQUIRED_STOP_CAN_BE_PASSED_BY_EXACT_TOKEN=true",
+                "OTHER_GO_TOKENS_GAINED_REEVALUATION_AUTHORITY=false",
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                f"MANIFEST_VERIFY_RC={manifest_rc}",
+                f"DURABLE_EVIDENCE_DIR={bundle_dir}",
+            ]
+        )
+        + "\n"
+    )
+    (bundle_dir / "final_report.txt").write_text(final_report, encoding="utf-8")
+
+    payload: dict[str, Any] = {
+        "verdict": "REEVALUATION_EXECUTION_IMPLEMENTATION_COMPLETE",
+        "process_classification": REEVALUATION_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "start_state_valid": start_state.valid,
+        "dispatch": dispatch_result_to_dict(dispatch),
+        "full_evaluation_wiring": phase_result_to_dict(full_evaluation),
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "robustness_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree_head_before": primary_before["head"],
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _guard_timeout(start_monotonic)
+    return payload
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--confirm", required=True)
@@ -683,7 +834,8 @@ def main() -> None:
         _die(
             "ERR:confirm_go_token_required:"
             f"{CONFIRM_GO}|{DISPATCH_IMPLEMENTATION_CONFIRM_GO}|{EXECUTION_CONFIRM_GO}|"
-            f"{IMPLEMENTATION_REPAIR_CONFIRM_GO}"
+            f"{IMPLEMENTATION_REPAIR_CONFIRM_GO}|"
+            f"{REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO}"
         )
 
     if args.confirm == CONFIRM_GO:
@@ -702,6 +854,13 @@ def main() -> None:
         )
     elif args.confirm == IMPLEMENTATION_REPAIR_CONFIRM_GO:
         result = run_execution_implementation_repair_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+            staging_root=args.staging_root,
+        )
+    elif args.confirm == REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO:
+        result = run_reevaluation_execution_implementation_v0(
             confirm=args.confirm,
             durable_evidence_root=args.durable_evidence_root,
             primary_worktree=args.primary_worktree,

--- a/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -120,6 +120,14 @@ IMPLEMENTATION_REPAIR_GO_TOKEN = (
     "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
     "EVALUATION_EXECUTION_IMPLEMENTATION_REPAIR_V0"
 )
+REEVALUATION_EXECUTION_GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_REEVALUATION_EXECUTION_V0"
+)
+REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_REEVALUATION_EXECUTION_IMPLEMENTATION_V0"
+)
 
 ALLOWED_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset({IMPLEMENTATION_GO_TOKEN})
 ALLOWED_IMPLEMENTATION_REPAIR_GO_TOKENS: frozenset[str] = frozenset(
@@ -129,16 +137,31 @@ ALLOWED_DISPATCH_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset(
     {DISPATCH_IMPLEMENTATION_GO_TOKEN}
 )
 ALLOWED_EXECUTION_GO_TOKENS: frozenset[str] = frozenset({EXECUTION_GO_TOKEN})
+ALLOWED_REEVALUATION_EXECUTION_GO_TOKENS: frozenset[str] = frozenset(
+    {REEVALUATION_EXECUTION_GO_TOKEN}
+)
+ALLOWED_REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset(
+    {REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN}
+)
+ALLOWED_EVALUATION_DISPATCH_GO_TOKENS: frozenset[str] = (
+    ALLOWED_EXECUTION_GO_TOKENS | ALLOWED_REEVALUATION_EXECUTION_GO_TOKENS
+)
 
 _BRANCH_IMPLEMENTATION_V0 = "IMPLEMENTATION_V0"
 _BRANCH_DISPATCH_IMPLEMENTATION_V0 = "DISPATCH_IMPLEMENTATION_V0"
 _BRANCH_EXECUTION_V0 = "EXECUTION_V0"
 _BRANCH_IMPLEMENTATION_REPAIR_V0 = "IMPLEMENTATION_REPAIR_V0"
+_BRANCH_REEVALUATION_EXECUTION_V0 = "REEVALUATION_EXECUTION_V0"
+_BRANCH_REEVALUATION_EXECUTION_IMPLEMENTATION_V0 = "REEVALUATION_EXECUTION_IMPLEMENTATION_V0"
 ENTRY_POINT_DISPATCH_REGISTRY: dict[str, str] = {
     IMPLEMENTATION_GO_TOKEN: _BRANCH_IMPLEMENTATION_V0,
     DISPATCH_IMPLEMENTATION_GO_TOKEN: _BRANCH_DISPATCH_IMPLEMENTATION_V0,
     EXECUTION_GO_TOKEN: _BRANCH_EXECUTION_V0,
     IMPLEMENTATION_REPAIR_GO_TOKEN: _BRANCH_IMPLEMENTATION_REPAIR_V0,
+    REEVALUATION_EXECUTION_GO_TOKEN: _BRANCH_REEVALUATION_EXECUTION_V0,
+    REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN: (
+        _BRANCH_REEVALUATION_EXECUTION_IMPLEMENTATION_V0
+    ),
 }
 
 RATIFIED_BINDING_DIGEST = RATIFIED_HYPOTHESIS_BINDING_DIGEST
@@ -177,7 +200,7 @@ PORTFOLIO_BINDING_OWNER = (
     "src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_"
     "hypothesis_binding_v0"
 )
-ENTRY_POINT_STATUS = "EXECUTION_DISPATCH_BOUND_V0"
+ENTRY_POINT_STATUS = "REEVALUATION_EXECUTION_WIRING_V0"
 
 PORTFOLIO_BINDING_REQUIRED_FIELDS: tuple[str, ...] = (
     "aggregation_policy",
@@ -251,6 +274,9 @@ REASON_BASELINE_EXECUTION_BLOCKED = "BASELINE_EXECUTION_BLOCKED_PENDING_PORTFOLI
 REASON_ROBUSTNESS_EXECUTION_BLOCKED = "ROBUSTNESS_EXECUTION_BLOCKED_PENDING_PORTFOLIO_BINDINGS"
 REASON_ECONOMIC_EVALUATION_BLOCKED = "ECONOMIC_EVALUATION_BLOCKED_PENDING_PORTFOLIO_BINDINGS"
 REASON_REEVALUATION_GO_REQUIRED = "REEVALUATION_GO_REQUIRED_STOPPED_BEFORE_EXECUTION"
+REASON_REEVALUATION_EXECUTION_WIRING_VERIFIED = (
+    "REEVALUATION_EXECUTION_WIRING_VERIFIED_STOPPED_BEFORE_EXECUTION"
+)
 REASON_BASELINE_WIRING_VERIFIED = "BASELINE_WIRING_VERIFIED_STOPPED_BEFORE_EXECUTION"
 REASON_DOWNSTREAM_WIRING_VERIFIED = "DOWNSTREAM_WIRING_VERIFIED_STOPPED_BEFORE_EXECUTION"
 REASON_BASELINE_ADJUDICATION_BLOCKS_DOWNSTREAM = (
@@ -405,6 +431,40 @@ def validate_execution_go_token_v0(go_token: str | None) -> tuple[bool, tuple[st
     return True, ()
 
 
+def validate_reevaluation_execution_go_token_v0(
+    go_token: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    if not go_token:
+        return False, (REASON_GO_TOKEN_MISSING,)
+    if go_token not in ALLOWED_REEVALUATION_EXECUTION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_reevaluation_execution_implementation_go_token_v0(
+    go_token: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    if not go_token:
+        return False, (REASON_GO_TOKEN_MISSING,)
+    if go_token not in ALLOWED_REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_evaluation_dispatch_go_token_v0(
+    go_token: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    if not go_token:
+        return False, (REASON_GO_TOKEN_MISSING,)
+    if go_token not in ALLOWED_EVALUATION_DISPATCH_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def _is_reevaluation_execution_go_token_v0(go_token: str) -> bool:
+    return go_token in ALLOWED_REEVALUATION_EXECUTION_GO_TOKENS
+
+
 def validate_dispatch_implementation_go_token_v0(
     go_token: str | None,
 ) -> tuple[bool, tuple[str, ...]]:
@@ -514,6 +574,10 @@ def materialize_dispatch_contract_v0() -> dict[str, Any]:
         "implementation_go_token": IMPLEMENTATION_GO_TOKEN,
         "dispatch_implementation_go_token": DISPATCH_IMPLEMENTATION_GO_TOKEN,
         "execution_go_token": EXECUTION_GO_TOKEN,
+        "reevaluation_execution_go_token": REEVALUATION_EXECUTION_GO_TOKEN,
+        "reevaluation_execution_implementation_go_token": (
+            REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN
+        ),
         "entry_point_dispatch_registry": dict(ENTRY_POINT_DISPATCH_REGISTRY),
         "baseline_executed": False,
         "robustness_executed": False,
@@ -561,7 +625,7 @@ def run_offline_economic_evaluation_execution_dispatch_v0(
     envelope = dict(versioned_binding or load_versioned_hypothesis_binding_v0(repo_root))
     score_ranking_contract = materialize_score_and_ranking_contract_v0(envelope)
 
-    token_ok, token_reasons = validate_execution_go_token_v0(go_token)
+    token_ok, token_reasons = validate_evaluation_dispatch_go_token_v0(go_token)
     if not token_ok:
         reasons.extend(token_reasons)
 
@@ -1171,7 +1235,7 @@ def _validate_phase_execution_prerequisites_v0(
     repo_root: Path,
     versioned_binding: Mapping[str, Any] | None,
 ) -> tuple[bool, tuple[str, ...], dict[str, Any]]:
-    if go_token not in ALLOWED_EXECUTION_GO_TOKENS:
+    if go_token not in ALLOWED_EVALUATION_DISPATCH_GO_TOKENS:
         return False, (REASON_GO_TOKEN_INVALID,), {}
     envelope = dict(versioned_binding or load_versioned_hypothesis_binding_v0(repo_root))
     portfolio_ok, portfolio_reasons = validate_portfolio_bindings_for_execution_dispatch_v0(
@@ -1434,7 +1498,7 @@ def run_full_offline_economic_evaluation_v0(
     force_baseline_adjudication_failure: bool = False,
     **_kwargs: Any,
 ) -> PhaseExecutionBlockedResultV0:
-    if go_token not in ALLOWED_EXECUTION_GO_TOKENS:
+    if go_token not in ALLOWED_EVALUATION_DISPATCH_GO_TOKENS:
         return _blocked_phase_result_v0(
             phase="FULL_OFFLINE_ECONOMIC_EVALUATION",
             reason=REASON_GO_TOKEN_INVALID,
@@ -1508,13 +1572,18 @@ def run_full_offline_economic_evaluation_v0(
         repo_root=active_root,
         versioned_binding=versioned_binding,
     )
+    terminal_reason = (
+        REASON_REEVALUATION_EXECUTION_WIRING_VERIFIED
+        if _is_reevaluation_execution_go_token_v0(go_token)
+        else REASON_REEVALUATION_GO_REQUIRED
+    )
     downstream_reasons = tuple(
         dict.fromkeys(
             [
                 *walk_forward.reason_codes,
                 *monte_carlo.reason_codes,
                 *stress.reason_codes,
-                REASON_REEVALUATION_GO_REQUIRED,
+                terminal_reason,
             ]
         )
     )
@@ -1549,7 +1618,11 @@ def materialize_execution_contract_v0() -> dict[str, Any]:
         "dispatch_implementation_go_token": DISPATCH_IMPLEMENTATION_GO_TOKEN,
         "implementation_repair_go_token": IMPLEMENTATION_REPAIR_GO_TOKEN,
         "execution_go_token": EXECUTION_GO_TOKEN,
-        "entry_point_status": "EXECUTION_WIRING_REPAIR_V0",
+        "reevaluation_execution_go_token": REEVALUATION_EXECUTION_GO_TOKEN,
+        "reevaluation_execution_implementation_go_token": (
+            REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN
+        ),
+        "entry_point_status": ENTRY_POINT_STATUS,
         "entry_point_dispatch_registry": dict(ENTRY_POINT_DISPATCH_REGISTRY),
         "baseline_evaluator_owner": BASELINE_EVALUATOR_OWNER,
         "baseline_backtest_owner": CANONICAL_BASELINE_BACKTEST_OWNER,
@@ -1731,6 +1804,14 @@ def build_reuse_decision() -> dict[str, Any]:
                 "decision": "REUSE_AS_IS",
                 "owner": PORTFOLIO_BINDING_OWNER,
             },
+            {
+                "component": "reevaluation_execution_dispatch",
+                "decision": "REWIRE_EXISTING_COMPONENT",
+                "owner": f"{HARNESS_OWNER}.{CANONICAL_FULL_EVALUATION_CALLABLE}",
+                "justification": (
+                    "register_reevaluation_execution_go_token_on_existing_full_evaluation_owner"
+                ),
+            },
         ],
     }
 
@@ -1747,14 +1828,19 @@ def build_runner_decision() -> dict[str, Any]:
         "dispatch_implementation_go_token": DISPATCH_IMPLEMENTATION_GO_TOKEN,
         "implementation_repair_go_token": IMPLEMENTATION_REPAIR_GO_TOKEN,
         "execution_go_token": EXECUTION_GO_TOKEN,
+        "reevaluation_execution_go_token": REEVALUATION_EXECUTION_GO_TOKEN,
+        "reevaluation_execution_implementation_go_token": (
+            REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN
+        ),
         "execution_go_dispatch_bound": True,
+        "reevaluation_execution_dispatch_bound": True,
         "wiring_inspection_only": True,
         "next_recommended_scope": (
             "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
-            "EVALUATION_EXECUTION_V0"
+            "EVALUATION_REEVALUATION_EXECUTION_V0"
         ),
-        "next_operator_go": EXECUTION_GO_TOKEN,
-        "reevaluation_requires_separate_go": True,
+        "next_operator_go": REEVALUATION_EXECUTION_GO_TOKEN,
+        "reevaluation_requires_separate_go": False,
     }
 
 
@@ -1822,10 +1908,14 @@ def build_before_after_field_diff() -> dict[str, Any]:
         "schema_version": "before_after_field_diff.v0",
         "repair_scope": (
             "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
-            "EVALUATION_EXECUTION_IMPLEMENTATION_REPAIR_V0"
+            "EVALUATION_REEVALUATION_EXECUTION_IMPLEMENTATION_V0"
         ),
-        "removed_stale_block_reason_for_valid_bindings": REASON_ECONOMIC_EVALUATION_BLOCKED,
-        "replacement_stop_reason": REASON_REEVALUATION_GO_REQUIRED,
+        "added_dispatch_registry_entries": [
+            REEVALUATION_EXECUTION_GO_TOKEN,
+            REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+        ],
+        "removed_stale_block_reason_for_valid_bindings": REASON_REEVALUATION_GO_REQUIRED,
+        "replacement_stop_reason": REASON_REEVALUATION_EXECUTION_WIRING_VERIFIED,
         "semantic_binding_fields_changed": False,
         "changed_fields": [],
     }
@@ -1881,27 +1971,24 @@ def build_root_cause_report() -> dict[str, Any]:
 
 def build_test_assertion_matrix() -> dict[str, Any]:
     assertions = [
-        "valid_portfolio_bindings_reach_canonical_baseline_owner",
-        "valid_bindings_do_not_emit_pending_portfolio_bindings_reason",
-        "missing_portfolio_bindings_fail_closed",
-        "invalid_portfolio_bindings_fail_closed",
-        "baseline_failure_stops_downstream_robustness_when_policy_requires",
-        "baseline_success_allows_policy_governed_downstream_sequence",
-        "walk_forward_owner_is_reused",
-        "monte_carlo_owner_is_reused",
-        "stress_owner_is_reused",
-        "economic_evaluation_not_executed_by_repair_tests",
-        "no_runtime_effect",
-        "no_authority_effect",
-        "no_strategy_semantic_change",
-        "no_dataset_change",
-        "no_universe_change",
-        "no_cost_policy_change",
-        "no_risk_sizing_change",
-        "deterministic_result_schema_serialization",
-        "existing_entry_point_go_token_rejection_remains_fail_closed",
-        "wrong_go_token_remains_rejected",
-        "implementation_go_does_not_authorize_reevaluation",
+        "reevaluation_execution_go_token_accepted",
+        "reevaluation_execution_go_token_registered_in_allowed_tokens",
+        "reevaluation_execution_go_token_registered_in_dispatch_registry",
+        "reevaluation_dispatch_selects_explicit_reevaluation_branch",
+        "reevaluation_branch_reuses_canonical_evaluation_owner",
+        "reevaluation_branch_can_pass_required_reevaluation_stop",
+        "normal_execution_go_does_not_gain_reevaluation_authority",
+        "unknown_go_token_rejected",
+        "missing_go_token_rejected",
+        "offline_boundary_preserved",
+        "no_runtime_import_boundary_violation",
+        "no_order_adapter_import_boundary_violation",
+        "no_scheduler_import_boundary_violation",
+        "no_binding_semantic_change",
+        "no_binding_digest_change",
+        "economic_evaluation_not_executed_in_implementation_tests",
+        "runtime_effect_none",
+        "authority_effect_none",
     ]
     return {
         "schema_version": "test_assertion_matrix.v0",

--- a/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_infrastructure_v0.py
+++ b/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_infrastructure_v0.py
@@ -19,6 +19,7 @@ from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline
     EXECUTION_GO_TOKEN,
     IMPLEMENTATION_GO_TOKEN,
     INFRASTRUCTURE_GO_TOKEN,
+    REEVALUATION_EXECUTION_GO_TOKEN,
     RATIFIED_BINDING_DIGEST,
     RATIFIED_DATASET_DIGEST,
     RATIFIED_UNIVERSE_DIGEST,
@@ -394,7 +395,7 @@ class TestMaterializationRoundtrip:
         contract = materialize_execution_contract_v0()
         assert contract["economic_evaluation_executed"] is False
         assert contract["binding_digest"] == RATIFIED_BINDING_DIGEST
-        assert contract["entry_point_status"] == "EXECUTION_WIRING_REPAIR_V0"
+        assert contract["entry_point_status"] == "REEVALUATION_EXECUTION_WIRING_V0"
 
 
 class TestOpsConfigAndGovernanceArtifacts:
@@ -415,7 +416,7 @@ class TestOpsConfigAndGovernanceArtifacts:
     def test_runner_decision_exports(self) -> None:
         decision = build_runner_decision()
         assert decision["economic_evaluation_executed"] is False
-        assert decision["next_operator_go"] == EXECUTION_GO_TOKEN
+        assert decision["next_operator_go"] == REEVALUATION_EXECUTION_GO_TOKEN
 
 
 class TestImportBoundary:

--- a/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_execution_implementation_v0.py
+++ b/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_execution_implementation_v0.py
@@ -1,0 +1,259 @@
+"""Reevaluation execution implementation contract tests for pairwise spillover v1."""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.ops.run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+    ALLOWED_CONFIRM_GO_TOKENS,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_authorization_ratification_v0 import (
+    materialize_offline_economic_evaluation_authorization_ratification_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    BASELINE_EVALUATOR_OWNER,
+    CANONICAL_FULL_EVALUATION_CALLABLE,
+    ENTRY_POINT_DISPATCH_REGISTRY,
+    EXECUTION_GO_TOKEN,
+    HARNESS_OWNER,
+    RATIFIED_BINDING_DIGEST,
+    REASON_GO_TOKEN_INVALID,
+    REASON_GO_TOKEN_MISSING,
+    REASON_REEVALUATION_EXECUTION_WIRING_VERIFIED,
+    REASON_REEVALUATION_GO_REQUIRED,
+    REEVALUATION_EXECUTION_GO_TOKEN,
+    REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+    RUNNER_SCRIPT,
+    RUNTIME_EFFECT,
+    build_cryptographic_identity_comparison,
+    materialize_execution_contract_v0,
+    run_full_offline_economic_evaluation_v0,
+    validate_entry_point_go_token_v0,
+    validate_evaluation_dispatch_go_token_v0,
+    validate_execution_go_token_v0,
+    validate_reevaluation_execution_go_token_v0,
+    validate_reevaluation_execution_implementation_go_token_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0 import (
+    materialize_versioned_hypothesis_binding_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXEC_GO = EXECUTION_GO_TOKEN
+_REEVAL_EXEC_GO = REEVALUATION_EXECUTION_GO_TOKEN
+_REEVAL_IMPL_GO = REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN
+EXECUTION_MODULE = (
+    REPO_ROOT / "src/research/"
+    "cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_"
+    "evaluation_execution_v0.py"
+)
+RUNNER_MODULE = REPO_ROOT / RUNNER_SCRIPT
+FORBIDDEN_RUNTIME_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+    "src.orders",
+)
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_hypothesis_binding_v0()
+
+
+@pytest.fixture(name="authorization_ratification")
+def fixture_authorization_ratification() -> dict:
+    return materialize_offline_economic_evaluation_authorization_ratification_v0()
+
+
+class TestReevaluationGoTokenRegistration:
+    def test_reevaluation_execution_go_token_accepted(self) -> None:
+        ok, reasons = validate_reevaluation_execution_go_token_v0(_REEVAL_EXEC_GO)
+        assert ok is True
+        assert reasons == ()
+
+    def test_reevaluation_execution_go_token_registered_in_allowed_tokens(self) -> None:
+        assert _REEVAL_IMPL_GO in ALLOWED_CONFIRM_GO_TOKENS
+        assert _REEVAL_EXEC_GO not in ALLOWED_CONFIRM_GO_TOKENS
+
+    def test_reevaluation_execution_go_token_registered_in_dispatch_registry(self) -> None:
+        assert ENTRY_POINT_DISPATCH_REGISTRY[_REEVAL_EXEC_GO] == "REEVALUATION_EXECUTION_V0"
+        assert (
+            ENTRY_POINT_DISPATCH_REGISTRY[_REEVAL_IMPL_GO]
+            == "REEVALUATION_EXECUTION_IMPLEMENTATION_V0"
+        )
+
+    def test_reevaluation_dispatch_selects_explicit_reevaluation_branch(self) -> None:
+        ok, branch = validate_entry_point_go_token_v0(_REEVAL_EXEC_GO)
+        assert ok is True
+        assert branch == "REEVALUATION_EXECUTION_V0"
+
+
+class TestReevaluationBranchWiring:
+    def test_reevaluation_branch_reuses_canonical_evaluation_owner(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_full_offline_economic_evaluation_v0(
+            go_token=_REEVAL_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            verify_source_manifests=False,
+            materialize_dataset=False,
+        )
+        assert result.canonical_owner == f"{HARNESS_OWNER}.{CANONICAL_FULL_EVALUATION_CALLABLE}"
+
+    def test_reevaluation_branch_can_pass_required_reevaluation_stop(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_full_offline_economic_evaluation_v0(
+            go_token=_REEVAL_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            verify_source_manifests=False,
+            materialize_dataset=False,
+        )
+        assert result.executed is False
+        assert result.blocked is False
+        assert result.wiring_verified is True
+        assert REASON_REEVALUATION_GO_REQUIRED not in result.reason_codes
+        assert REASON_REEVALUATION_EXECUTION_WIRING_VERIFIED in result.reason_codes
+
+    def test_normal_execution_go_does_not_gain_reevaluation_authority(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_full_offline_economic_evaluation_v0(
+            go_token=_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            verify_source_manifests=False,
+            materialize_dataset=False,
+        )
+        assert REASON_REEVALUATION_GO_REQUIRED in result.reason_codes
+        assert REASON_REEVALUATION_EXECUTION_WIRING_VERIFIED not in result.reason_codes
+
+
+class TestGoTokenRejection:
+    def test_unknown_go_token_rejected(self) -> None:
+        ok, reasons = validate_reevaluation_execution_go_token_v0("INVALID_GO_TOKEN")
+        assert ok is False
+        assert REASON_GO_TOKEN_INVALID in reasons
+
+        ok_dispatch, dispatch_reasons = validate_evaluation_dispatch_go_token_v0("INVALID_GO_TOKEN")
+        assert ok_dispatch is False
+        assert REASON_GO_TOKEN_INVALID in dispatch_reasons
+
+    def test_missing_go_token_rejected(self) -> None:
+        ok, reasons = validate_reevaluation_execution_implementation_go_token_v0(None)
+        assert ok is False
+        assert REASON_GO_TOKEN_MISSING in reasons
+
+        ok_exec, exec_reasons = validate_execution_go_token_v0(None)
+        assert ok_exec is False
+        assert REASON_GO_TOKEN_MISSING in exec_reasons
+
+
+class TestOfflineBoundaryAndBindingInvariants:
+    def test_offline_boundary_preserved(
+        self,
+        authorization_ratification: dict,
+    ) -> None:
+        assert authorization_ratification.get("offline_only") is True
+
+    def test_no_binding_semantic_change(self, complete_binding: dict) -> None:
+        second = materialize_versioned_hypothesis_binding_v0()
+        assert complete_binding == second
+
+    def test_no_binding_digest_change(self) -> None:
+        identity = build_cryptographic_identity_comparison(REPO_ROOT)
+        assert identity["CRYPTOGRAPHIC_BINDING_IDENTITY_CHANGED"] is False
+        assert identity["binding_digest"] == RATIFIED_BINDING_DIGEST
+
+    def test_economic_evaluation_not_executed_in_implementation_tests(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_full_offline_economic_evaluation_v0(
+            go_token=_REEVAL_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            verify_source_manifests=False,
+            materialize_dataset=False,
+        )
+        assert result.executed is False
+
+    def test_runtime_effect_none(self) -> None:
+        assert RUNTIME_EFFECT == "NONE"
+
+    def test_authority_effect_none(self) -> None:
+        assert AUTHORITY_EFFECT == "NONE"
+
+
+class TestImportBoundary:
+    def test_no_runtime_import_boundary_violation(self) -> None:
+        source = EXECUTION_MODULE.read_text(encoding="utf-8")
+        for prefix in FORBIDDEN_RUNTIME_IMPORT_PREFIXES:
+            assert prefix not in source
+
+    def test_no_order_adapter_import_boundary_violation(self) -> None:
+        source = RUNNER_MODULE.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imports = {
+            node.module
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        assert not any(item.startswith("src.execution") for item in imports)
+
+    def test_no_scheduler_import_boundary_violation(self) -> None:
+        source = RUNNER_MODULE.read_text(encoding="utf-8")
+        assert "src.scheduler" not in source
+
+
+class TestEntryPointContract:
+    def test_entry_point_contract_exports_reevaluation_tokens(self) -> None:
+        contract = materialize_execution_contract_v0()
+        assert contract["reevaluation_execution_go_token"] == _REEVAL_EXEC_GO
+        assert contract["reevaluation_execution_implementation_go_token"] == _REEVAL_IMPL_GO
+        assert contract["entry_point_status"] == "REEVALUATION_EXECUTION_WIRING_V0"
+        assert contract["baseline_evaluator_owner"] == BASELINE_EVALUATOR_OWNER
+
+    def test_runner_rejects_reevaluation_execution_go_without_implementation_branch(self) -> None:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER_MODULE),
+                "--confirm",
+                _REEVAL_EXEC_GO,
+                "--primary-worktree",
+                str(REPO_ROOT),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 2
+        assert "ERR:confirm_go_token_required" in proc.stderr
+
+    def test_runner_accepts_reevaluation_implementation_go_token(self) -> None:
+        ok, branch = validate_entry_point_go_token_v0(_REEVAL_IMPL_GO)
+        assert ok is True
+        assert branch == "REEVALUATION_EXECUTION_IMPLEMENTATION_V0"
+        assert _REEVAL_IMPL_GO in ALLOWED_CONFIRM_GO_TOKENS


### PR DESCRIPTION
## Summary
- Register `GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_EVALUATION_REEVALUATION_EXECUTION_V0` and its implementation GO token on the canonical offline economic evaluation entry point dispatch registry.
- Allow the reevaluation execution token to pass the existing `REEVALUATION_GO_REQUIRED_STOPPED_BEFORE_EXECUTION` wiring gate via `REEVALUATION_EXECUTION_WIRING_VERIFIED_STOPPED_BEFORE_EXECUTION`, reusing `run_full_offline_economic_evaluation_v0` without binding, policy, or runtime mutation.
- Add focused contract tests and the narrow governance owner-map entry for the new reevaluation implementation test surface.

## Test plan
- [x] `pytest tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_execution_implementation_v0.py`
- [x] Related pairwise spillover execution infrastructure/repair/dispatch tests
- [x] `tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py`
- [x] `python3 scripts/ops/check_economic_diagnostic_optimization_boundary_guard_v0.py --base origin/main`
- [x] `ruff format` / `ruff check` on changed Python files
- [x] Durable evidence bundle with `MANIFEST_VERIFY_RC=0`


Made with [Cursor](https://cursor.com)