### PR TITLE
Add pairwise spillover v1 reevaluation baseline execution preflight infrastructure

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -442,6 +442,7 @@
         "tests/research/test_*offline_economic_evaluation_execution_implementation_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_reevaluation_execution_implementation_v0.py",
         "tests/research/test_*offline_economic_evaluation_reevaluation_execution_ops_runner_branch_v0.py",
+        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py",
         "tests/research/test_*offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_execution_authorization_ratification_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_full_runner_v0.py"

--- a/scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -17,6 +17,9 @@ Bounded modes:
 - Reevaluation execution dispatch (fail-closed before economic evaluation):
   GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_
   EVALUATION_REEVALUATION_EXECUTION_V0
+- Reevaluation baseline execution implementation:
+  GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_
+  EVALUATION_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0
 
 No economic evaluation execution, runtime, order, or authority effect.
 """
@@ -46,7 +49,17 @@ from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline
     IMPLEMENTATION_REPAIR_GO_TOKEN,
     REEVALUATION_EXECUTION_GO_TOKEN,
     REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+    REEVALUATION_BASELINE_EXECUTION_GO_TOKEN,
+    REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
     RUNTIME_EFFECT,
+    build_reevaluation_baseline_reuse_decision,
+    build_reevaluation_baseline_runner_decision,
+    build_reevaluation_baseline_test_assertion_matrix,
+    materialize_dataset_preflight_contract_v0,
+    materialize_go_token_and_dispatch_contract_v0,
+    materialize_python_version_contract_v0,
+    preflight_result_to_dict,
+    run_reevaluation_baseline_execution_preflight_v0,
     InfrastructureReadinessResultV0,
     InfrastructureTerminalStatus,
     build_before_after_field_diff,
@@ -78,6 +91,9 @@ from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline
 from tests.research.fixtures.cross_sectional_relative_strength_v0.fixture_builder import (  # noqa: E402
     build_synthetic_panel_series_v0,
 )
+from src.research.cross_sectional_panel_staging_source_manifest_v1 import (  # noqa: E402
+    verify_panel_staging_source_manifests_v1,
+)
 
 CONFIRM_GO = IMPLEMENTATION_GO_TOKEN
 DISPATCH_IMPLEMENTATION_CONFIRM_GO = DISPATCH_IMPLEMENTATION_GO_TOKEN
@@ -85,6 +101,10 @@ EXECUTION_CONFIRM_GO = GO_TOKEN
 IMPLEMENTATION_REPAIR_CONFIRM_GO = IMPLEMENTATION_REPAIR_GO_TOKEN
 REEVALUATION_EXECUTION_CONFIRM_GO = REEVALUATION_EXECUTION_GO_TOKEN
 REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO = REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN
+REEVALUATION_BASELINE_EXECUTION_CONFIRM_GO = REEVALUATION_BASELINE_EXECUTION_GO_TOKEN
+REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO = (
+    REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN
+)
 DEFAULT_DURABLE_ROOT = Path(
     "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
 )
@@ -116,6 +136,10 @@ REEVALUATION_EXECUTION_SCOPE_CLASSIFICATION = (
     "BOUNDED_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
     "EVALUATION_REEVALUATION_EXECUTION_V0"
 )
+REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION = (
+    "BOUNDED_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
+)
 MAX_RUNTIME_SECONDS = 1500
 ALLOWED_CONFIRM_GO_TOKENS = frozenset(
     {
@@ -125,7 +149,13 @@ ALLOWED_CONFIRM_GO_TOKENS = frozenset(
         IMPLEMENTATION_REPAIR_CONFIRM_GO,
         REEVALUATION_EXECUTION_CONFIRM_GO,
         REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO,
+        REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO,
     }
+)
+BASELINE_IMPLEMENTATION_TEST_MODULE = (
+    "tests/research/"
+    "test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_"
+    "evaluation_reevaluation_baseline_execution_implementation_v0.py"
 )
 
 
@@ -940,6 +970,212 @@ def run_reevaluation_execution_implementation_v0(
     return payload
 
 
+def run_reevaluation_baseline_execution_implementation_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+    staging_root: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO:
+        _die(
+            "ERR:confirm_go_token_required:"
+            f"{REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO}"
+        )
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "implementation"
+        / (
+            "cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_"
+            f"evaluation_reevaluation_baseline_execution_implementation_v0_{ts_slug}"
+        )
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    versioned_binding = load_versioned_hypothesis_binding_v0(_REPO_ROOT)
+    authorization_ratification = load_authorization_ratification_v0(_REPO_ROOT)
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+
+    preflight = run_reevaluation_baseline_execution_preflight_v0(
+        go_token=confirm,
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        staging_root=staging_root,
+        versioned_binding=versioned_binding,
+        verify_source_manifests=True,
+        materialize_dataset=True,
+    )
+    preflight_payload = preflight_result_to_dict(preflight)
+
+    manifest_ok, manifest_rc, manifest_reasons = verify_panel_staging_source_manifests_v1(
+        staging_root
+    )
+    source_manifest_text = (
+        "\n".join(
+            [
+                f"SOURCE_MANIFEST_VERIFY_RC={manifest_rc if preflight.python_version_ok else -1}",
+                f"SOURCE_MANIFESTS_VERIFIED={str(preflight.source_manifests_verified).lower()}",
+                f"MANIFEST_REASON_CODES={','.join(manifest_reasons) if manifest_reasons else 'NONE'}",
+            ]
+        )
+        + "\n"
+    )
+
+    test_proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            BASELINE_IMPLEMENTATION_TEST_MODULE,
+            "-q",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(_REPO_ROOT),
+    )
+    test_results_text = (
+        test_proc.stdout
+        + ("\n" + test_proc.stderr if test_proc.stderr else "")
+        + f"\nPYTEST_EXIT_CODE={test_proc.returncode}\n"
+    )
+
+    artifacts: dict[str, Any] = {
+        "preflight.txt": "\n".join(
+            [
+                f"PRE_IMPLEMENTATION_HEAD={origin_main}",
+                f"ORIGIN_MAIN={origin_main}",
+                "HEAD_EQUALS_ORIGIN_MAIN=true",
+                "WORKTREE_CLEAN=true",
+                f"OPERATOR_GO={confirm}",
+                f"PYTHON_VERSION={preflight.python_version}",
+                f"PYTHON_VERSION_OK={str(preflight.python_version_ok).lower()}",
+                f"BOUND_DATASET_MATERIALIZED={str(preflight.bound_dataset_materialized).lower()}",
+                f"SOURCE_MANIFESTS_VERIFIED={str(preflight.source_manifests_verified).lower()}",
+                f"DATASET_DIGEST_VERIFIED={str(preflight.dataset_digest_verified).lower()}",
+                f"PORTFOLIO_BINDINGS_VALID={str(preflight.portfolio_bindings_valid).lower()}",
+                f"BASELINE_EXECUTION_ADMISSIBLE={str(preflight.baseline_execution_admissible).lower()}",
+                f"IMPLEMENTATION_WIRING_VERIFIED={str(preflight.implementation_wiring_verified).lower()}",
+            ]
+        )
+        + "\n",
+        "source_manifest_verification.txt": source_manifest_text,
+        "owner_inventory.json": build_owner_inventory(),
+        "reuse_decision.json": build_reevaluation_baseline_reuse_decision(),
+        "runner_decision.json": build_reevaluation_baseline_runner_decision(),
+        "go_token_and_dispatch_contract.json": materialize_go_token_and_dispatch_contract_v0(),
+        "python_version_contract.json": materialize_python_version_contract_v0(),
+        "dataset_preflight_contract.json": materialize_dataset_preflight_contract_v0(preflight),
+        "test_assertion_matrix.json": build_reevaluation_baseline_test_assertion_matrix(),
+        "test_results.txt": test_results_text,
+        "PREFLIGHT_RESULT.json": preflight_payload,
+        "START_STATE.json": {
+            "valid": start_state.valid,
+            "fail_reasons": list(start_state.fail_reasons),
+            "binding_digest": start_state.binding_digest,
+            "authorization_ratification_digest": start_state.authorization_ratification_digest,
+        },
+    }
+    for name, payload in artifacts.items():
+        if name.endswith(".json"):
+            (bundle_dir / name).write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        else:
+            (bundle_dir / name).write_text(str(payload), encoding="utf-8")
+
+    manifest_verify_rc, manifest_verify_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    implementation_complete = (
+        preflight.implementation_wiring_verified and test_proc.returncode == 0 and start_state.valid
+    )
+    final_report = (
+        "\n".join(
+            [
+                f"STATUS={'PASS' if implementation_complete else 'FAIL_CLOSED'}",
+                (
+                    "VERDICT=REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_COMPLETE"
+                    if implementation_complete
+                    else "VERDICT=FAIL_CLOSED"
+                ),
+                f"SCOPE={REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION}",
+                f"OPERATOR_GO={confirm}",
+                f"PRE_IMPLEMENTATION_HEAD={origin_main}",
+                f"ORIGIN_MAIN={origin_main}",
+                "REEVALUATION_BASELINE_EXECUTION_GO_TOKEN_REGISTERED=true",
+                "IMPLEMENTATION_GO_AUTHORIZES_BASELINE_EXECUTION=false",
+                f"BASELINE_EXECUTION_ADMISSIBLE={str(preflight.baseline_execution_admissible).lower()}",
+                f"DATASET_DIGEST_VERIFIED={str(preflight.dataset_digest_verified).lower()}",
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                "BASELINE_EXECUTED=false",
+                "WALK_FORWARD_EXECUTED=false",
+                "MONTE_CARLO_EXECUTED=false",
+                "STRESS_EXECUTED=false",
+                "DATASET_DIGEST_REPAIRED=false",
+                "RUNTIME_EFFECT=NONE",
+                "AUTHORITY_EFFECT=NONE",
+                "ORDERS_ALLOWED=false",
+                "LIVE_AUTHORIZED=false",
+                f"PYTEST_EXIT_CODE={test_proc.returncode}",
+                f"MANIFEST_VERIFY_RC={manifest_verify_rc}",
+                f"DURABLE_EVIDENCE_DIR={bundle_dir}",
+                (
+                    "NEXT_ADMISSIBLE_SCOPE="
+                    "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+                    "EVALUATION_REEVALUATION_BASELINE_EXECUTION_V0"
+                ),
+                f"NEXT_OPERATOR_GO={REEVALUATION_BASELINE_EXECUTION_CONFIRM_GO}",
+                "NEXT_SCOPE_REQUIRES_SEPARATE_OPERATOR_GO=true",
+            ]
+        )
+        + "\n"
+    )
+    (bundle_dir / "final_report.txt").write_text(final_report, encoding="utf-8")
+
+    payload: dict[str, Any] = {
+        "verdict": (
+            "REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_COMPLETE"
+            if implementation_complete
+            else "FAIL_CLOSED"
+        ),
+        "process_classification": REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "staging_root": str(staging_root),
+        "start_state_valid": start_state.valid,
+        "preflight": preflight_payload,
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "robustness_executed": False,
+        "dataset_digest_repaired": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree_head_before": primary_before["head"],
+        "primary_worktree_dirty_count_before": primary_before["dirty_count"],
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_verify_rc,
+        "manifest_verify_msg": manifest_verify_msg,
+        "pytest_exit_code": test_proc.returncode,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _guard_timeout(start_monotonic)
+    return payload
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--confirm", required=True)
@@ -954,7 +1190,8 @@ def main() -> None:
             f"{CONFIRM_GO}|{DISPATCH_IMPLEMENTATION_CONFIRM_GO}|{EXECUTION_CONFIRM_GO}|"
             f"{IMPLEMENTATION_REPAIR_CONFIRM_GO}|"
             f"{REEVALUATION_EXECUTION_CONFIRM_GO}|"
-            f"{REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO}"
+            f"{REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO}|"
+            f"{REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO}"
         )
 
     if args.confirm == CONFIRM_GO:
@@ -973,6 +1210,13 @@ def main() -> None:
         )
     elif args.confirm == IMPLEMENTATION_REPAIR_CONFIRM_GO:
         result = run_execution_implementation_repair_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+            staging_root=args.staging_root,
+        )
+    elif args.confirm == REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO:
+        result = run_reevaluation_baseline_execution_implementation_v0(
             confirm=args.confirm,
             durable_evidence_root=args.durable_evidence_root,
             primary_worktree=args.primary_worktree,

--- a/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import importlib
 import json
+import sys
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -128,6 +129,18 @@ REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN = (
     "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
     "EVALUATION_REEVALUATION_EXECUTION_IMPLEMENTATION_V0"
 )
+REEVALUATION_BASELINE_EXECUTION_GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_REEVALUATION_BASELINE_EXECUTION_V0"
+)
+REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN = (
+    "GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
+)
+
+MINIMUM_PYTHON_VERSION_MAJOR = 3
+MINIMUM_PYTHON_VERSION_MINOR = 10
+PREFERRED_PYTHON_VERSION_MINOR = 11
 
 ALLOWED_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset({IMPLEMENTATION_GO_TOKEN})
 ALLOWED_IMPLEMENTATION_REPAIR_GO_TOKENS: frozenset[str] = frozenset(
@@ -143,8 +156,16 @@ ALLOWED_REEVALUATION_EXECUTION_GO_TOKENS: frozenset[str] = frozenset(
 ALLOWED_REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset(
     {REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN}
 )
+ALLOWED_REEVALUATION_BASELINE_EXECUTION_GO_TOKENS: frozenset[str] = frozenset(
+    {REEVALUATION_BASELINE_EXECUTION_GO_TOKEN}
+)
+ALLOWED_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset(
+    {REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN}
+)
 ALLOWED_EVALUATION_DISPATCH_GO_TOKENS: frozenset[str] = (
-    ALLOWED_EXECUTION_GO_TOKENS | ALLOWED_REEVALUATION_EXECUTION_GO_TOKENS
+    ALLOWED_EXECUTION_GO_TOKENS
+    | ALLOWED_REEVALUATION_EXECUTION_GO_TOKENS
+    | ALLOWED_REEVALUATION_BASELINE_EXECUTION_GO_TOKENS
 )
 
 _BRANCH_IMPLEMENTATION_V0 = "IMPLEMENTATION_V0"
@@ -153,6 +174,10 @@ _BRANCH_EXECUTION_V0 = "EXECUTION_V0"
 _BRANCH_IMPLEMENTATION_REPAIR_V0 = "IMPLEMENTATION_REPAIR_V0"
 _BRANCH_REEVALUATION_EXECUTION_V0 = "REEVALUATION_EXECUTION_V0"
 _BRANCH_REEVALUATION_EXECUTION_IMPLEMENTATION_V0 = "REEVALUATION_EXECUTION_IMPLEMENTATION_V0"
+_BRANCH_REEVALUATION_BASELINE_EXECUTION_V0 = "REEVALUATION_BASELINE_EXECUTION_V0"
+_BRANCH_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0 = (
+    "REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
+)
 ENTRY_POINT_DISPATCH_REGISTRY: dict[str, str] = {
     IMPLEMENTATION_GO_TOKEN: _BRANCH_IMPLEMENTATION_V0,
     DISPATCH_IMPLEMENTATION_GO_TOKEN: _BRANCH_DISPATCH_IMPLEMENTATION_V0,
@@ -161,6 +186,10 @@ ENTRY_POINT_DISPATCH_REGISTRY: dict[str, str] = {
     REEVALUATION_EXECUTION_GO_TOKEN: _BRANCH_REEVALUATION_EXECUTION_V0,
     REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN: (
         _BRANCH_REEVALUATION_EXECUTION_IMPLEMENTATION_V0
+    ),
+    REEVALUATION_BASELINE_EXECUTION_GO_TOKEN: _BRANCH_REEVALUATION_BASELINE_EXECUTION_V0,
+    REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN: (
+        _BRANCH_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0
     ),
 }
 
@@ -283,6 +312,17 @@ REASON_BASELINE_ADJUDICATION_BLOCKS_DOWNSTREAM = (
     "BASELINE_ADJUDICATION_BLOCKS_DOWNSTREAM_ROBUSTNESS"
 )
 REASON_CANONICAL_OWNER_UNREACHABLE = "CANONICAL_OWNER_UNREACHABLE"
+REASON_PYTHON_VERSION_TOO_LOW = "PYTHON_VERSION_TOO_LOW_BLOCKED_BASELINE_PREFLIGHT"
+REASON_DATASET_DIGEST_NOT_VERIFIED = "DATASET_DIGEST_NOT_VERIFIED_FAIL_CLOSED"
+REASON_BASELINE_CALLABLE_WIRING_ONLY_ACKNOWLEDGED = (
+    "BASELINE_CALLABLE_WIRING_ONLY_STOPPED_BEFORE_EXECUTION"
+)
+REASON_REEVALUATION_BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE = (
+    "REEVALUATION_BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE_STOPPED_BEFORE_EXECUTION"
+)
+REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION = (
+    "IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION"
+)
 
 
 class InfrastructureTerminalStatus(str, Enum):
@@ -362,6 +402,35 @@ class PhaseExecutionBlockedResultV0:
     wiring_verified: bool = False
     canonical_owner: str = ""
     downstream_sequence_allowed: bool | None = None
+
+
+@dataclass(frozen=True)
+class ReevaluationBaselineExecutionPreflightResultV0:
+    preflight_passed: bool
+    blocked: bool
+    baseline_execution_admissible: bool
+    implementation_wiring_verified: bool
+    reason_codes: tuple[str, ...]
+    python_version_ok: bool
+    python_version: str
+    bound_dataset_materialized: bool
+    source_manifests_verified: bool
+    dataset_digest_verified: bool
+    portfolio_bindings_valid: bool
+    same_dataset: bool
+    same_universe: bool
+    same_strategy_parameters: bool
+    same_cost_policy: bool
+    same_risk_sizing_semantics: bool
+    panel_data_digest: str
+    ratified_dataset_digest: str
+    baseline_wiring_verified: bool
+    baseline_executed: bool
+    baseline_callable_wiring_only: bool
+    economic_evaluation_executed: bool
+    dataset_digest_repaired: bool
+    authority_effect: str
+    runtime_effect: str
 
 
 @dataclass(frozen=True)
@@ -449,6 +518,246 @@ def validate_reevaluation_execution_implementation_go_token_v0(
     if go_token not in ALLOWED_REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKENS:
         return False, (REASON_GO_TOKEN_INVALID,)
     return True, ()
+
+
+def validate_reevaluation_baseline_execution_go_token_v0(
+    go_token: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    if not go_token:
+        return False, (REASON_GO_TOKEN_MISSING,)
+    if go_token not in ALLOWED_REEVALUATION_BASELINE_EXECUTION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_reevaluation_baseline_execution_implementation_go_token_v0(
+    go_token: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    if not go_token:
+        return False, (REASON_GO_TOKEN_MISSING,)
+    if go_token not in ALLOWED_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def verify_python_version_for_baseline_preflight_v0() -> tuple[bool, str]:
+    version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    ok = sys.version_info.major > MINIMUM_PYTHON_VERSION_MAJOR or (
+        sys.version_info.major == MINIMUM_PYTHON_VERSION_MAJOR
+        and sys.version_info.minor >= MINIMUM_PYTHON_VERSION_MINOR
+    )
+    return ok, version
+
+
+def build_identity_invariant_contract_v0(
+    authorization_ratification: Mapping[str, Any],
+    envelope: Mapping[str, Any],
+) -> dict[str, bool]:
+    return {
+        "same_dataset": str(authorization_ratification.get("dataset_digest", ""))
+        == RATIFIED_DATASET_DIGEST
+        and str(envelope.get("dataset_digest", "")) == RATIFIED_DATASET_DIGEST,
+        "same_universe": str(authorization_ratification.get("universe_digest", ""))
+        == RATIFIED_UNIVERSE_DIGEST,
+        "same_strategy_parameters": authorization_ratification.get("hypothesis_binding_unchanged")
+        is True,
+        "same_cost_policy": authorization_ratification.get("cost_policy_unchanged") is True,
+        "same_risk_sizing_semantics": authorization_ratification.get("portfolio_binding_unchanged")
+        is True,
+    }
+
+
+def preflight_result_to_dict(
+    result: ReevaluationBaselineExecutionPreflightResultV0,
+) -> dict[str, Any]:
+    return {
+        "preflight_passed": result.preflight_passed,
+        "blocked": result.blocked,
+        "baseline_execution_admissible": result.baseline_execution_admissible,
+        "implementation_wiring_verified": result.implementation_wiring_verified,
+        "reason_codes": list(result.reason_codes),
+        "python_version_ok": result.python_version_ok,
+        "python_version": result.python_version,
+        "bound_dataset_materialized": result.bound_dataset_materialized,
+        "source_manifests_verified": result.source_manifests_verified,
+        "dataset_digest_verified": result.dataset_digest_verified,
+        "portfolio_bindings_valid": result.portfolio_bindings_valid,
+        "same_dataset": result.same_dataset,
+        "same_universe": result.same_universe,
+        "same_strategy_parameters": result.same_strategy_parameters,
+        "same_cost_policy": result.same_cost_policy,
+        "same_risk_sizing_semantics": result.same_risk_sizing_semantics,
+        "panel_data_digest": result.panel_data_digest,
+        "ratified_dataset_digest": result.ratified_dataset_digest,
+        "baseline_wiring_verified": result.baseline_wiring_verified,
+        "baseline_executed": result.baseline_executed,
+        "baseline_callable_wiring_only": result.baseline_callable_wiring_only,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "dataset_digest_repaired": result.dataset_digest_repaired,
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+    }
+
+
+def run_reevaluation_baseline_execution_preflight_v0(
+    *,
+    go_token: str,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any] | None = None,
+    staging_root: Path | None = None,
+    versioned_binding: Mapping[str, Any] | None = None,
+    verify_source_manifests: bool = True,
+    materialize_dataset: bool = True,
+) -> ReevaluationBaselineExecutionPreflightResultV0:
+    """Fail-closed baseline-execution preflight for implementation and future execution GO."""
+    reasons: list[str] = []
+    impl_ok, impl_reasons = validate_reevaluation_baseline_execution_implementation_go_token_v0(
+        go_token
+    )
+    if not impl_ok:
+        reasons.extend(impl_reasons)
+
+    python_ok, python_version = verify_python_version_for_baseline_preflight_v0()
+    if not python_ok:
+        reasons.append(REASON_PYTHON_VERSION_TOO_LOW)
+
+    auth = authorization_ratification or load_authorization_ratification_v0(repo_root)
+    envelope = dict(versioned_binding or load_versioned_hypothesis_binding_v0(repo_root))
+    identity = build_identity_invariant_contract_v0(auth, envelope)
+    if not all(identity.values()):
+        reasons.append(REASON_SEMANTIC_BINDING_MUTATION)
+
+    start_state = verify_execution_start_state_v0(
+        repo_root=repo_root,
+        authorization_ratification=auth,
+        versioned_binding=envelope,
+    )
+    if not start_state.valid:
+        reasons.extend(start_state.fail_reasons)
+
+    portfolio_ok, portfolio_reasons = validate_portfolio_bindings_for_execution_dispatch_v0(
+        envelope,
+        materialize_score_and_ranking_contract_v0(envelope),
+    )
+    if not portfolio_ok:
+        reasons.extend(portfolio_reasons)
+
+    source_manifests_verified = False
+    if verify_source_manifests and staging_root is not None and python_ok:
+        manifest_ok, manifest_rc, manifest_reasons = verify_panel_staging_source_manifests_v1(
+            staging_root
+        )
+        source_manifests_verified = manifest_ok and manifest_rc == 0
+        if not source_manifests_verified:
+            reasons.append(REASON_SOURCE_MANIFEST_VERIFY_FAILED)
+            reasons.extend(manifest_reasons)
+
+    bound_dataset_materialized = False
+    panel_data_digest = "0" * 64
+    if materialize_dataset and staging_root is not None and python_ok and not reasons:
+        materialization = materialize_bound_panel_dataset_v0(
+            staging_root,
+            period_binding=envelope["period_binding"],
+        )
+        panel_data_digest = materialization.panel_data_digest
+        bound_dataset_materialized = (
+            materialization.status is MaterializationTerminalStatus.DATASET_MATERIALIZATION_COMPLETE
+        )
+        if not bound_dataset_materialized:
+            reasons.extend(materialization.reason_codes)
+
+    dataset_digest_verified = (
+        bound_dataset_materialized and panel_data_digest == RATIFIED_DATASET_DIGEST
+    )
+    if bound_dataset_materialized and not dataset_digest_verified:
+        reasons.append(REASON_DATASET_DIGEST_NOT_VERIFIED)
+
+    baseline_wiring_verified = False
+    baseline_callable_wiring_only = False
+    if impl_ok and python_ok and portfolio_ok and all(identity.values()):
+        baseline_probe = run_baseline_offline_economic_evaluation_v0(
+            go_token=REEVALUATION_BASELINE_EXECUTION_GO_TOKEN,
+            repo_root=repo_root,
+            authorization_ratification=auth,
+            versioned_binding=envelope,
+        )
+        baseline_wiring_verified = baseline_probe.wiring_verified and not baseline_probe.blocked
+        baseline_callable_wiring_only = (
+            baseline_probe.executed is False and baseline_wiring_verified
+        )
+        if baseline_callable_wiring_only:
+            reasons.append(REASON_BASELINE_CALLABLE_WIRING_ONLY_ACKNOWLEDGED)
+        if not baseline_wiring_verified:
+            reasons.extend(baseline_probe.reason_codes)
+
+    impl_exec_blocked = run_baseline_offline_economic_evaluation_v0(
+        go_token=go_token,
+        repo_root=repo_root,
+        authorization_ratification=auth,
+        versioned_binding=envelope,
+    )
+    if impl_exec_blocked.blocked and REASON_GO_TOKEN_INVALID in impl_exec_blocked.reason_codes:
+        reasons.append(REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION)
+
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    implementation_wiring_verified = (
+        impl_ok
+        and python_ok
+        and portfolio_ok
+        and all(identity.values())
+        and baseline_wiring_verified
+        and baseline_callable_wiring_only
+        and REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION in unique_reasons
+    )
+    baseline_execution_admissible = (
+        implementation_wiring_verified
+        and bound_dataset_materialized
+        and source_manifests_verified
+        and dataset_digest_verified
+    )
+    blocked = not baseline_execution_admissible and (
+        REASON_DATASET_DIGEST_NOT_VERIFIED in unique_reasons
+        or REASON_SOURCE_MANIFEST_VERIFY_FAILED in unique_reasons
+        or REASON_PYTHON_VERSION_TOO_LOW in unique_reasons
+        or not impl_ok
+        or not portfolio_ok
+    )
+    preflight_passed = implementation_wiring_verified
+    if preflight_passed:
+        terminal_reasons = (
+            *unique_reasons,
+            REASON_REEVALUATION_BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE,
+        )
+    else:
+        terminal_reasons = unique_reasons
+
+    return ReevaluationBaselineExecutionPreflightResultV0(
+        preflight_passed=preflight_passed,
+        blocked=blocked,
+        baseline_execution_admissible=baseline_execution_admissible,
+        implementation_wiring_verified=implementation_wiring_verified,
+        reason_codes=tuple(dict.fromkeys(terminal_reasons)),
+        python_version_ok=python_ok,
+        python_version=python_version,
+        bound_dataset_materialized=bound_dataset_materialized,
+        source_manifests_verified=source_manifests_verified,
+        dataset_digest_verified=dataset_digest_verified,
+        portfolio_bindings_valid=portfolio_ok,
+        same_dataset=identity["same_dataset"],
+        same_universe=identity["same_universe"],
+        same_strategy_parameters=identity["same_strategy_parameters"],
+        same_cost_policy=identity["same_cost_policy"],
+        same_risk_sizing_semantics=identity["same_risk_sizing_semantics"],
+        panel_data_digest=panel_data_digest,
+        ratified_dataset_digest=RATIFIED_DATASET_DIGEST,
+        baseline_wiring_verified=baseline_wiring_verified,
+        baseline_executed=False,
+        baseline_callable_wiring_only=baseline_callable_wiring_only,
+        economic_evaluation_executed=False,
+        dataset_digest_repaired=False,
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
 
 
 def validate_evaluation_dispatch_go_token_v0(
@@ -577,6 +886,10 @@ def materialize_dispatch_contract_v0() -> dict[str, Any]:
         "reevaluation_execution_go_token": REEVALUATION_EXECUTION_GO_TOKEN,
         "reevaluation_execution_implementation_go_token": (
             REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN
+        ),
+        "reevaluation_baseline_execution_go_token": REEVALUATION_BASELINE_EXECUTION_GO_TOKEN,
+        "reevaluation_baseline_execution_implementation_go_token": (
+            REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN
         ),
         "entry_point_dispatch_registry": dict(ENTRY_POINT_DISPATCH_REGISTRY),
         "baseline_executed": False,
@@ -1622,6 +1935,11 @@ def materialize_execution_contract_v0() -> dict[str, Any]:
         "reevaluation_execution_implementation_go_token": (
             REEVALUATION_EXECUTION_IMPLEMENTATION_GO_TOKEN
         ),
+        "reevaluation_baseline_execution_go_token": REEVALUATION_BASELINE_EXECUTION_GO_TOKEN,
+        "reevaluation_baseline_execution_implementation_go_token": (
+            REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN
+        ),
+        "baseline_execution_entry_point_status": "REEVALUATION_BASELINE_EXECUTION_PREFLIGHT_V0",
         "entry_point_status": ENTRY_POINT_STATUS,
         "entry_point_dispatch_registry": dict(ENTRY_POINT_DISPATCH_REGISTRY),
         "baseline_evaluator_owner": BASELINE_EVALUATOR_OWNER,
@@ -1992,6 +2310,131 @@ def build_test_assertion_matrix() -> dict[str, Any]:
     ]
     return {
         "schema_version": "test_assertion_matrix.v0",
+        "assertions": assertions,
+        "assertion_count": len(assertions),
+    }
+
+
+def materialize_python_version_contract_v0() -> dict[str, Any]:
+    python_ok, python_version = verify_python_version_for_baseline_preflight_v0()
+    return {
+        "schema_version": "python_version_contract.v0",
+        "minimum_python_version": f"{MINIMUM_PYTHON_VERSION_MAJOR}.{MINIMUM_PYTHON_VERSION_MINOR}",
+        "preferred_python_version": (
+            f"{MINIMUM_PYTHON_VERSION_MAJOR}.{PREFERRED_PYTHON_VERSION_MINOR}"
+        ),
+        "active_python_version": python_version,
+        "python_version_ok": python_ok,
+        "fail_closed_reason_code": REASON_PYTHON_VERSION_TOO_LOW,
+    }
+
+
+def materialize_dataset_preflight_contract_v0(
+    preflight: ReevaluationBaselineExecutionPreflightResultV0,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "dataset_preflight_contract.v0",
+        "ratified_dataset_digest": preflight.ratified_dataset_digest,
+        "panel_data_digest": preflight.panel_data_digest,
+        "bound_dataset_materialized": preflight.bound_dataset_materialized,
+        "source_manifests_verified": preflight.source_manifests_verified,
+        "dataset_digest_verified": preflight.dataset_digest_verified,
+        "dataset_digest_repaired": preflight.dataset_digest_repaired,
+        "dataset_materialization_owner": (
+            "cross_sectional_relative_strength_v0_bound_panel_dataset_materialization_v0"
+        ),
+        "panel_staging_manifest_owner": "cross_sectional_panel_staging_source_manifest_v1",
+        "fail_closed_reason_code": REASON_DATASET_DIGEST_NOT_VERIFIED,
+    }
+
+
+def materialize_go_token_and_dispatch_contract_v0() -> dict[str, Any]:
+    return {
+        "schema_version": "go_token_and_dispatch_contract.v0",
+        "entry_point_dispatch_registry": dict(ENTRY_POINT_DISPATCH_REGISTRY),
+        "reevaluation_baseline_execution_go_token": REEVALUATION_BASELINE_EXECUTION_GO_TOKEN,
+        "reevaluation_baseline_execution_implementation_go_token": (
+            REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN
+        ),
+        "baseline_execution_go_separately_gated": True,
+        "implementation_go_authorizes_baseline_execution": False,
+        "implementation_go_authorizes_economic_evaluation": False,
+        "baseline_evaluator_owner": BASELINE_EVALUATOR_OWNER,
+        "baseline_backtest_owner": CANONICAL_BASELINE_BACKTEST_OWNER,
+        "baseline_execution_branch": _BRANCH_REEVALUATION_BASELINE_EXECUTION_V0,
+        "baseline_implementation_branch": _BRANCH_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0,
+    }
+
+
+def build_reevaluation_baseline_reuse_decision() -> dict[str, Any]:
+    base = build_reuse_decision()
+    base["decisions"].extend(
+        [
+            {
+                "component": "reevaluation_baseline_execution_preflight",
+                "decision": "REWIRE_EXISTING_COMPONENT",
+                "owner": f"{HARNESS_OWNER}.run_reevaluation_baseline_execution_preflight_v0",
+                "justification": (
+                    "register_baseline_execution_go_tokens_and_fail_closed_preflight_on_existing_harness"
+                ),
+            },
+            {
+                "component": "baseline_evaluator_wiring_probe",
+                "decision": "REUSE_AS_IS",
+                "owner": BASELINE_EVALUATOR_OWNER,
+            },
+        ]
+    )
+    return base
+
+
+def build_reevaluation_baseline_runner_decision() -> dict[str, Any]:
+    return {
+        "schema_version": "runner_decision.v0",
+        "runner_required": True,
+        "runner_action": "THIN_OPS_DELEGATION_TO_BASELINE_PREFLIGHT_HARNESS",
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "robustness_executed": False,
+        "dataset_digest_repaired": False,
+        "implementation_go_token": REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+        "execution_go_token": REEVALUATION_BASELINE_EXECUTION_GO_TOKEN,
+        "implementation_go_authorizes_baseline_execution": False,
+        "baseline_execution_requires_separate_go": True,
+        "wiring_inspection_only": True,
+        "next_recommended_scope": (
+            "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+            "EVALUATION_REEVALUATION_BASELINE_EXECUTION_V0"
+        ),
+        "next_operator_go": REEVALUATION_BASELINE_EXECUTION_GO_TOKEN,
+    }
+
+
+def build_reevaluation_baseline_test_assertion_matrix() -> dict[str, Any]:
+    assertions = [
+        "reevaluation_baseline_execution_implementation_go_token_accepted",
+        "reevaluation_baseline_execution_go_token_registered_in_dispatch_registry",
+        "reevaluation_baseline_execution_go_token_separately_gated",
+        "implementation_go_does_not_authorize_baseline_execution",
+        "python_version_too_low_blocks",
+        "dataset_digest_mismatch_blocks_baseline_execution_admissible",
+        "baseline_callable_wiring_only_acknowledged",
+        "economic_evaluation_not_executed",
+        "baseline_not_executed",
+        "dataset_digest_not_repaired",
+        "unknown_go_token_rejected",
+        "missing_go_token_rejected",
+        "offline_boundary_preserved",
+        "no_runtime_import_boundary_violation",
+        "runtime_effect_none",
+        "authority_effect_none",
+    ]
+    return {
+        "schema_version": "test_assertion_matrix.v0",
+        "scope": (
+            "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+            "EVALUATION_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
+        ),
         "assertions": assertions,
         "assertion_count": len(assertions),
     }

--- a/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py
+++ b/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py
@@ -1,0 +1,280 @@
+"""Reevaluation baseline execution implementation contract tests for pairwise spillover v1."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.ops.run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+    ALLOWED_CONFIRM_GO_TOKENS,
+    REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_authorization_ratification_v0 import (
+    materialize_offline_economic_evaluation_authorization_ratification_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    CANONICAL_BASELINE_BACKTEST_OWNER,
+    ENTRY_POINT_DISPATCH_REGISTRY,
+    REASON_DATASET_DIGEST_NOT_VERIFIED,
+    REASON_GO_TOKEN_INVALID,
+    REASON_GO_TOKEN_MISSING,
+    REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION,
+    REASON_PYTHON_VERSION_TOO_LOW,
+    REASON_REEVALUATION_BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE,
+    REEVALUATION_BASELINE_EXECUTION_GO_TOKEN,
+    REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+    RUNNER_SCRIPT,
+    RUNTIME_EFFECT,
+    RATIFIED_BINDING_DIGEST,
+    build_cryptographic_identity_comparison,
+    materialize_go_token_and_dispatch_contract_v0,
+    run_baseline_offline_economic_evaluation_v0,
+    run_reevaluation_baseline_execution_preflight_v0,
+    validate_entry_point_go_token_v0,
+    validate_reevaluation_baseline_execution_go_token_v0,
+    validate_reevaluation_baseline_execution_implementation_go_token_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0 import (
+    materialize_versioned_hypothesis_binding_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_IMPL_GO = REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN
+_BASELINE_EXEC_GO = REEVALUATION_BASELINE_EXECUTION_GO_TOKEN
+RUNNER_MODULE = REPO_ROOT / RUNNER_SCRIPT
+STAGING_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/v1"
+)
+FORBIDDEN_RUNTIME_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+    "src.orders",
+)
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_hypothesis_binding_v0()
+
+
+@pytest.fixture(name="authorization_ratification")
+def fixture_authorization_ratification() -> dict:
+    return materialize_offline_economic_evaluation_authorization_ratification_v0()
+
+
+class TestBaselineGoTokenRegistration:
+    def test_implementation_go_token_accepted(self) -> None:
+        ok, reasons = validate_reevaluation_baseline_execution_implementation_go_token_v0(_IMPL_GO)
+        assert ok is True
+        assert reasons == ()
+
+    def test_baseline_execution_go_token_registered_in_dispatch_registry(self) -> None:
+        assert (
+            ENTRY_POINT_DISPATCH_REGISTRY[_BASELINE_EXEC_GO] == "REEVALUATION_BASELINE_EXECUTION_V0"
+        )
+        assert (
+            ENTRY_POINT_DISPATCH_REGISTRY[_IMPL_GO]
+            == "REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
+        )
+
+    def test_implementation_go_in_runner_allowed_confirm_tokens(self) -> None:
+        assert _IMPL_GO in ALLOWED_CONFIRM_GO_TOKENS
+
+    def test_baseline_execution_go_not_in_runner_allowed_confirm_tokens(self) -> None:
+        assert _BASELINE_EXEC_GO not in ALLOWED_CONFIRM_GO_TOKENS
+
+    def test_baseline_execution_go_separately_gated(self) -> None:
+        contract = materialize_go_token_and_dispatch_contract_v0()
+        assert contract["baseline_execution_go_separately_gated"] is True
+        assert contract["implementation_go_authorizes_baseline_execution"] is False
+
+
+class TestImplementationGoAuthorizationBoundary:
+    def test_implementation_go_does_not_authorize_baseline_execution(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token=_IMPL_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+        )
+        assert result.executed is False
+        assert result.blocked is True
+        assert REASON_GO_TOKEN_INVALID in result.reason_codes
+
+    def test_baseline_execution_go_reaches_wiring_only_stop(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token=_BASELINE_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+        )
+        assert result.executed is False
+        assert result.blocked is False
+        assert result.wiring_verified is True
+        assert result.canonical_owner == CANONICAL_BASELINE_BACKTEST_OWNER
+
+
+class TestBaselinePreflightBehavior:
+    def test_preflight_without_dataset_materialization_passes_wiring(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_reevaluation_baseline_execution_preflight_v0(
+            go_token=_IMPL_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            verify_source_manifests=False,
+            materialize_dataset=False,
+        )
+        assert result.implementation_wiring_verified is True
+        assert result.preflight_passed is True
+        assert result.baseline_executed is False
+        assert result.economic_evaluation_executed is False
+        assert result.dataset_digest_repaired is False
+        assert REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION in result.reason_codes
+        assert REASON_REEVALUATION_BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE in result.reason_codes
+
+    @pytest.mark.skipif(
+        not STAGING_ROOT.is_dir(),
+        reason="staging_root_unavailable",
+    )
+    def test_dataset_digest_mismatch_blocks_baseline_execution_admissible(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_reevaluation_baseline_execution_preflight_v0(
+            go_token=_IMPL_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            staging_root=STAGING_ROOT,
+            verify_source_manifests=True,
+            materialize_dataset=True,
+        )
+        assert result.bound_dataset_materialized is True
+        assert result.dataset_digest_verified is False
+        assert result.baseline_execution_admissible is False
+        assert REASON_DATASET_DIGEST_NOT_VERIFIED in result.reason_codes
+
+
+class TestPythonVersionGate:
+    def test_python_version_too_low_blocks(self) -> None:
+        with patch(
+            "src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.sys.version_info",
+            type("VI", (), {"major": 3, "minor": 9, "micro": 6})(),
+        ):
+            from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+                verify_python_version_for_baseline_preflight_v0,
+            )
+
+            ok, _version = verify_python_version_for_baseline_preflight_v0()
+            assert ok is False
+
+        result = run_reevaluation_baseline_execution_preflight_v0(
+            go_token=_IMPL_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=materialize_offline_economic_evaluation_authorization_ratification_v0(),
+            versioned_binding=materialize_versioned_hypothesis_binding_v0(),
+            verify_source_manifests=False,
+            materialize_dataset=False,
+        )
+        if sys.version_info < (3, 10):
+            assert REASON_PYTHON_VERSION_TOO_LOW in result.reason_codes
+
+
+class TestGoTokenRejection:
+    def test_unknown_go_token_rejected(self) -> None:
+        ok, reasons = validate_reevaluation_baseline_execution_implementation_go_token_v0(
+            "INVALID_GO_TOKEN"
+        )
+        assert ok is False
+        assert REASON_GO_TOKEN_INVALID in reasons
+
+        ok_baseline, baseline_reasons = validate_reevaluation_baseline_execution_go_token_v0(
+            "INVALID_GO_TOKEN"
+        )
+        assert ok_baseline is False
+        assert REASON_GO_TOKEN_INVALID in baseline_reasons
+
+    def test_missing_go_token_rejected(self) -> None:
+        ok, reasons = validate_reevaluation_baseline_execution_implementation_go_token_v0(None)
+        assert ok is False
+        assert REASON_GO_TOKEN_MISSING in reasons
+
+
+class TestOfflineBoundaryAndBindingInvariants:
+    def test_offline_boundary_preserved(
+        self,
+        authorization_ratification: dict,
+    ) -> None:
+        assert authorization_ratification.get("offline_only") is True
+
+    def test_no_binding_digest_change(self) -> None:
+        identity = build_cryptographic_identity_comparison(REPO_ROOT)
+        assert identity["CRYPTOGRAPHIC_BINDING_IDENTITY_CHANGED"] is False
+        assert identity["binding_digest"] == RATIFIED_BINDING_DIGEST
+
+    def test_runtime_effect_none(self) -> None:
+        assert RUNTIME_EFFECT == "NONE"
+
+    def test_authority_effect_none(self) -> None:
+        assert AUTHORITY_EFFECT == "NONE"
+
+
+class TestImportBoundary:
+    def test_no_runtime_import_boundary_violation(self) -> None:
+        source = (REPO_ROOT / RUNNER_SCRIPT).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imports = {
+            node.module
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        assert not any(
+            item.startswith(prefix)
+            for item in imports
+            for prefix in FORBIDDEN_RUNTIME_IMPORT_PREFIXES
+        )
+
+
+class TestRunnerBranch:
+    def test_runner_accepts_implementation_go_token(self) -> None:
+        ok, branch = validate_entry_point_go_token_v0(_IMPL_GO)
+        assert ok is True
+        assert branch == "REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
+
+    def test_unknown_token_rejected_by_subprocess(self) -> None:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER_MODULE),
+                "--confirm",
+                "INVALID_GO_TOKEN",
+                "--primary-worktree",
+                str(REPO_ROOT),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 2
+        assert "ERR:confirm_go_token_required" in proc.stderr


### PR DESCRIPTION
## Summary
- Registers `GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_EVALUATION_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0` and the separately gated future baseline execution GO token on the existing pairwise spillover harness and ops runner.
- Adds fail-closed baseline preflight (`Python >=3.10`, source-manifest verification, bound dataset materialization, ratified dataset digest check) without economic evaluation, baseline backtest execution, or dataset-digest repair.
- Adds focused contract/dispatch/boundary tests and durable implementation evidence generation via the canonical ops runner branch.

## Reuse decision
- Reuses canonical harness owners: `run_baseline_offline_economic_evaluation_v0`, `run_offline_economic_evaluation_execution_dispatch_v0`, bound panel dataset materialization, and panel staging manifest verification.
- Adds one thin ops-runner branch only; no parallel baseline runner or binding mutation.

## Test plan
- [x] `pytest tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py`
- [x] Regression: reevaluation execution implementation + ops-runner branch tests (62 passed)
- [x] `ruff check` / `ruff format --check` on changed files
- [x] Implementation evidence bundle: `MANIFEST_VERIFY_RC=0`, wiring verified, `baseline_execution_admissible=false` due to expected dataset digest mismatch (fail-closed, no repair)

## Boundary
- `ECONOMIC_EVALUATION_EXECUTED=false`
- `BASELINE_EXECUTED=false`
- `DATASET_DIGEST_REPAIRED=false`
- `RUNTIME_EFFECT=NONE` / `AUTHORITY_EFFECT=NONE`


Made with [Cursor](https://cursor.com)