### PR TITLE
Wire REEVALUATION_BASELINE_EXECUTION_V0 ops-runner branch (pairwise spillover v1)

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -442,6 +442,7 @@
         "tests/research/test_*offline_economic_evaluation_execution_implementation_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_reevaluation_execution_implementation_v0.py",
         "tests/research/test_*offline_economic_evaluation_reevaluation_execution_ops_runner_branch_v0.py",
+        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_ops_runner_branch_v0.py",
         "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py",
         "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_dataset_digest_reconciliation_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",

--- a/scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -20,6 +20,9 @@ Bounded modes:
 - Reevaluation baseline execution implementation:
   GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_
   EVALUATION_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0
+- Reevaluation baseline execution dispatch (fail-closed before economic evaluation):
+  GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_
+  EVALUATION_REEVALUATION_BASELINE_EXECUTION_V0
 
 No economic evaluation execution, runtime, order, or authority effect.
 """
@@ -84,6 +87,7 @@ from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline
     materialize_portfolio_binding_contract_v0,
     phase_result_to_dict,
     run_full_offline_economic_evaluation_v0,
+    run_baseline_offline_economic_evaluation_v0,
     run_full_evaluation_entrypoint_dry_run_v1,
     run_offline_economic_evaluation_execution_dispatch_v0,
     verify_execution_start_state_v0,
@@ -140,6 +144,10 @@ REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION = (
     "BOUNDED_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
     "EVALUATION_REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
 )
+REEVALUATION_BASELINE_EXECUTION_SCOPE_CLASSIFICATION = (
+    "BOUNDED_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+    "EVALUATION_REEVALUATION_BASELINE_EXECUTION_OPS_RUNNER_BRANCH_IMPLEMENTATION_V0"
+)
 MAX_RUNTIME_SECONDS = 1500
 ALLOWED_CONFIRM_GO_TOKENS = frozenset(
     {
@@ -150,6 +158,7 @@ ALLOWED_CONFIRM_GO_TOKENS = frozenset(
         REEVALUATION_EXECUTION_CONFIRM_GO,
         REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO,
         REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO,
+        REEVALUATION_BASELINE_EXECUTION_CONFIRM_GO,
     }
 )
 BASELINE_IMPLEMENTATION_TEST_MODULE = (
@@ -1176,6 +1185,201 @@ def run_reevaluation_baseline_execution_implementation_v0(
     return payload
 
 
+def run_reevaluation_baseline_execution_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+    staging_root: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != REEVALUATION_BASELINE_EXECUTION_CONFIRM_GO:
+        _die(f"ERR:confirm_go_token_required:{REEVALUATION_BASELINE_EXECUTION_CONFIRM_GO}")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "implementation"
+        / (
+            "cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_"
+            f"evaluation_reevaluation_baseline_execution_ops_runner_branch_v0_{ts_slug}"
+        )
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    versioned_binding = load_versioned_hypothesis_binding_v0(_REPO_ROOT)
+    authorization_ratification = load_authorization_ratification_v0(_REPO_ROOT)
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+
+    preflight = run_reevaluation_baseline_execution_preflight_v0(
+        go_token=confirm,
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        staging_root=staging_root,
+        versioned_binding=versioned_binding,
+        verify_source_manifests=True,
+        materialize_dataset=True,
+    )
+    preflight_payload = preflight_result_to_dict(preflight)
+
+    baseline = run_baseline_offline_economic_evaluation_v0(
+        go_token=confirm,
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+    )
+    baseline_payload = phase_result_to_dict(baseline)
+
+    manifest_ok, manifest_rc, manifest_reasons = verify_panel_staging_source_manifests_v1(
+        staging_root
+    )
+    source_manifest_text = (
+        "\n".join(
+            [
+                f"SOURCE_MANIFEST_VERIFY_RC={manifest_rc if preflight.python_version_ok else -1}",
+                f"SOURCE_MANIFESTS_VERIFIED={str(preflight.source_manifests_verified).lower()}",
+                f"MANIFEST_REASON_CODES={','.join(manifest_reasons) if manifest_reasons else 'NONE'}",
+            ]
+        )
+        + "\n"
+    )
+
+    artifacts: dict[str, Any] = {
+        "preflight.txt": "\n".join(
+            [
+                f"PRE_IMPLEMENTATION_HEAD={origin_main}",
+                f"ORIGIN_MAIN={origin_main}",
+                "HEAD_EQUALS_ORIGIN_MAIN=true",
+                "WORKTREE_CLEAN=true",
+                f"OPERATOR_GO={confirm}",
+                f"PYTHON_VERSION={preflight.python_version}",
+                f"PYTHON_VERSION_OK={str(preflight.python_version_ok).lower()}",
+                f"BOUND_DATASET_MATERIALIZED={str(preflight.bound_dataset_materialized).lower()}",
+                f"SOURCE_MANIFESTS_VERIFIED={str(preflight.source_manifests_verified).lower()}",
+                f"DATASET_DIGEST_VERIFIED={str(preflight.dataset_digest_verified).lower()}",
+                f"BINDING_DIGEST_VERIFIED={str(start_state.valid).lower()}",
+                f"PORTFOLIO_BINDINGS_VALID={str(preflight.portfolio_bindings_valid).lower()}",
+                f"BASELINE_EXECUTION_ADMISSIBLE={str(preflight.baseline_execution_admissible).lower()}",
+                f"BASELINE_WIRING_VERIFIED={str(preflight.baseline_wiring_verified).lower()}",
+            ]
+        )
+        + "\n",
+        "source_manifest_verification.txt": source_manifest_text,
+        "owner_inventory.json": build_owner_inventory(),
+        "reuse_decision.json": build_reevaluation_baseline_reuse_decision(),
+        "runner_decision.json": build_reevaluation_baseline_runner_decision(),
+        "go_token_and_dispatch_contract.json": materialize_go_token_and_dispatch_contract_v0(),
+        "before_after_field_diff.json": build_before_after_field_diff(),
+        "test_assertion_matrix.json": build_reevaluation_baseline_test_assertion_matrix(),
+        "PREFLIGHT_RESULT.json": preflight_payload,
+        "BASELINE_WIRING_RESULT.json": baseline_payload,
+        "START_STATE.json": {
+            "valid": start_state.valid,
+            "fail_reasons": list(start_state.fail_reasons),
+            "binding_digest": start_state.binding_digest,
+            "authorization_ratification_digest": start_state.authorization_ratification_digest,
+        },
+    }
+    for name, payload in artifacts.items():
+        if name.endswith(".json"):
+            (bundle_dir / name).write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        else:
+            (bundle_dir / name).write_text(str(payload), encoding="utf-8")
+
+    manifest_verify_rc, manifest_verify_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    wiring_complete = (
+        preflight.baseline_wiring_verified
+        and baseline.wiring_verified
+        and not baseline.blocked
+        and start_state.valid
+    )
+    final_report = (
+        "\n".join(
+            [
+                f"STATUS={'PASS' if wiring_complete else 'FAIL_CLOSED'}",
+                (
+                    "VERDICT=IMPLEMENTATION_COMPLETE_OPS_RUNNER_BRANCH_WIRED"
+                    if wiring_complete
+                    else "VERDICT=FAIL_CLOSED"
+                ),
+                f"SCOPE={REEVALUATION_BASELINE_EXECUTION_SCOPE_CLASSIFICATION}",
+                f"OPERATOR_GO={confirm}",
+                f"PRE_IMPLEMENTATION_HEAD={origin_main}",
+                f"ORIGIN_MAIN={origin_main}",
+                "OPS_RUNNER_GO_TOKEN_REGISTERED=true",
+                "OPS_RUNNER_BRANCH_REGISTERED=true",
+                "REAL_OFFLINE_EVALUATION_PATH_WIRED=true",
+                f"DATASET_DIGEST_VERIFIED={str(preflight.dataset_digest_verified).lower()}",
+                f"BINDING_DIGEST_VERIFIED={str(start_state.valid).lower()}",
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                "BASELINE_EXECUTION_EXECUTED=false",
+                "WALK_FORWARD_EXECUTED=false",
+                "MONTE_CARLO_EXECUTED=false",
+                "STRESS_EXECUTED=false",
+                "RUNTIME_EFFECT=NONE",
+                "AUTHORITY_EFFECT=NONE",
+                "ORDERS_ALLOWED=false",
+                "LIVE_AUTHORIZED=false",
+                f"MANIFEST_VERIFY_RC={manifest_verify_rc}",
+                f"DURABLE_EVIDENCE_DIR={bundle_dir}",
+                (
+                    "NEXT_ADMISSIBLE_SCOPE="
+                    "CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_"
+                    "EVALUATION_REEVALUATION_BASELINE_EXECUTION_V0"
+                ),
+                f"NEXT_OPERATOR_GO={REEVALUATION_BASELINE_EXECUTION_CONFIRM_GO}",
+                "NEXT_SCOPE_REQUIRES_SEPARATE_OPERATOR_GO=true",
+            ]
+        )
+        + "\n"
+    )
+    (bundle_dir / "final_report.txt").write_text(final_report, encoding="utf-8")
+
+    payload: dict[str, Any] = {
+        "verdict": (
+            "REEVALUATION_BASELINE_EXECUTION_OPS_RUNNER_BRANCH_WIRED"
+            if wiring_complete
+            else "FAIL_CLOSED"
+        ),
+        "process_classification": REEVALUATION_BASELINE_EXECUTION_SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "staging_root": str(staging_root),
+        "start_state_valid": start_state.valid,
+        "go_token_forwarded": confirm,
+        "harness_dispatch_branch": "REEVALUATION_BASELINE_EXECUTION_V0",
+        "preflight": preflight_payload,
+        "baseline_wiring": baseline_payload,
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "robustness_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree_head_before": primary_before["head"],
+        "primary_worktree_dirty_count_before": primary_before["dirty_count"],
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_verify_rc,
+        "manifest_verify_msg": manifest_verify_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _guard_timeout(start_monotonic)
+    return payload
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--confirm", required=True)
@@ -1191,7 +1395,8 @@ def main() -> None:
             f"{IMPLEMENTATION_REPAIR_CONFIRM_GO}|"
             f"{REEVALUATION_EXECUTION_CONFIRM_GO}|"
             f"{REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO}|"
-            f"{REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO}"
+            f"{REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO}|"
+            f"{REEVALUATION_BASELINE_EXECUTION_CONFIRM_GO}"
         )
 
     if args.confirm == CONFIRM_GO:
@@ -1217,6 +1422,13 @@ def main() -> None:
         )
     elif args.confirm == REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO:
         result = run_reevaluation_baseline_execution_implementation_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+            staging_root=args.staging_root,
+        )
+    elif args.confirm == REEVALUATION_BASELINE_EXECUTION_CONFIRM_GO:
+        result = run_reevaluation_baseline_execution_v0(
             confirm=args.confirm,
             durable_evidence_root=args.durable_evidence_root,
             primary_worktree=args.primary_worktree,

--- a/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -635,13 +635,16 @@ def run_reevaluation_baseline_execution_preflight_v0(
     verify_source_manifests: bool = True,
     materialize_dataset: bool = True,
 ) -> ReevaluationBaselineExecutionPreflightResultV0:
-    """Fail-closed baseline-execution preflight for implementation and future execution GO."""
+    """Fail-closed baseline-execution preflight for implementation and execution GO."""
     reasons: list[str] = []
+    baseline_exec_ok, baseline_exec_reasons = validate_reevaluation_baseline_execution_go_token_v0(
+        go_token
+    )
     impl_ok, impl_reasons = validate_reevaluation_baseline_execution_implementation_go_token_v0(
         go_token
     )
-    if not impl_ok:
-        reasons.extend(impl_reasons)
+    if not baseline_exec_ok and not impl_ok:
+        reasons.extend(baseline_exec_reasons)
 
     python_ok, python_version = verify_python_version_for_baseline_preflight_v0()
     if not python_ok:
@@ -705,7 +708,8 @@ def run_reevaluation_baseline_execution_preflight_v0(
 
     baseline_wiring_verified = False
     baseline_callable_wiring_only = False
-    if impl_ok and python_ok and portfolio_ok and all(identity.values()):
+    token_ok_for_wiring_probe = baseline_exec_ok or impl_ok
+    if token_ok_for_wiring_probe and python_ok and portfolio_ok and all(identity.values()):
         baseline_probe = run_baseline_offline_economic_evaluation_v0(
             go_token=REEVALUATION_BASELINE_EXECUTION_GO_TOKEN,
             repo_root=repo_root,
@@ -721,14 +725,15 @@ def run_reevaluation_baseline_execution_preflight_v0(
         if not baseline_wiring_verified:
             reasons.extend(baseline_probe.reason_codes)
 
-    impl_exec_blocked = run_baseline_offline_economic_evaluation_v0(
-        go_token=go_token,
-        repo_root=repo_root,
-        authorization_ratification=auth,
-        versioned_binding=envelope,
-    )
-    if impl_exec_blocked.blocked and REASON_GO_TOKEN_INVALID in impl_exec_blocked.reason_codes:
-        reasons.append(REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION)
+    if impl_ok:
+        impl_exec_blocked = run_baseline_offline_economic_evaluation_v0(
+            go_token=go_token,
+            repo_root=repo_root,
+            authorization_ratification=auth,
+            versioned_binding=envelope,
+        )
+        if impl_exec_blocked.blocked and REASON_GO_TOKEN_INVALID in impl_exec_blocked.reason_codes:
+            reasons.append(REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION)
 
     unique_reasons = tuple(dict.fromkeys(reasons))
     implementation_wiring_verified = (
@@ -740,8 +745,16 @@ def run_reevaluation_baseline_execution_preflight_v0(
         and baseline_callable_wiring_only
         and REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION in unique_reasons
     )
+    execution_preflight_passed = (
+        baseline_exec_ok
+        and python_ok
+        and portfolio_ok
+        and all(identity.values())
+        and baseline_wiring_verified
+        and baseline_callable_wiring_only
+    )
     baseline_execution_admissible = (
-        implementation_wiring_verified
+        (implementation_wiring_verified or execution_preflight_passed)
         and bound_dataset_materialized
         and source_manifests_verified
         and dataset_digest_verified
@@ -750,15 +763,17 @@ def run_reevaluation_baseline_execution_preflight_v0(
         REASON_DATASET_DIGEST_NOT_VERIFIED in unique_reasons
         or REASON_SOURCE_MANIFEST_VERIFY_FAILED in unique_reasons
         or REASON_PYTHON_VERSION_TOO_LOW in unique_reasons
-        or not impl_ok
+        or (not baseline_exec_ok and not impl_ok)
         or not portfolio_ok
     )
-    preflight_passed = implementation_wiring_verified
-    if preflight_passed:
+    preflight_passed = implementation_wiring_verified or execution_preflight_passed
+    if implementation_wiring_verified:
         terminal_reasons = (
             *unique_reasons,
             REASON_REEVALUATION_BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE,
         )
+    elif execution_preflight_passed:
+        terminal_reasons = unique_reasons
     else:
         terminal_reasons = unique_reasons
 

--- a/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py
+++ b/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py
@@ -88,8 +88,8 @@ class TestBaselineGoTokenRegistration:
     def test_implementation_go_in_runner_allowed_confirm_tokens(self) -> None:
         assert _IMPL_GO in ALLOWED_CONFIRM_GO_TOKENS
 
-    def test_baseline_execution_go_not_in_runner_allowed_confirm_tokens(self) -> None:
-        assert _BASELINE_EXEC_GO not in ALLOWED_CONFIRM_GO_TOKENS
+    def test_baseline_execution_go_in_runner_allowed_confirm_tokens(self) -> None:
+        assert _BASELINE_EXEC_GO in ALLOWED_CONFIRM_GO_TOKENS
 
     def test_baseline_execution_go_separately_gated(self) -> None:
         contract = materialize_go_token_and_dispatch_contract_v0()

--- a/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_ops_runner_branch_v0.py
+++ b/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_ops_runner_branch_v0.py
@@ -1,0 +1,450 @@
+"""Ops-runner branch contract tests for pairwise spillover reevaluation baseline execution v0."""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.ops.run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+    ALLOWED_CONFIRM_GO_TOKENS,
+    IMPLEMENTATION_REPAIR_CONFIRM_GO,
+    REEVALUATION_BASELINE_EXECUTION_CONFIRM_GO,
+    REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO,
+    REEVALUATION_EXECUTION_CONFIRM_GO,
+    REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO,
+    run_reevaluation_baseline_execution_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_authorization_ratification_v0 import (
+    materialize_offline_economic_evaluation_authorization_ratification_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    CANONICAL_BASELINE_BACKTEST_OWNER,
+    DISPATCH_IMPLEMENTATION_GO_TOKEN,
+    ENTRY_POINT_DISPATCH_REGISTRY,
+    EXECUTION_GO_TOKEN,
+    IMPLEMENTATION_GO_TOKEN,
+    IMPLEMENTATION_REPAIR_GO_TOKEN,
+    REASON_DATASET_DIGEST_NOT_VERIFIED,
+    REASON_GO_TOKEN_INVALID,
+    REASON_GO_TOKEN_MISSING,
+    REEVALUATION_BASELINE_EXECUTION_GO_TOKEN,
+    REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+    RUNNER_SCRIPT,
+    RUNTIME_EFFECT,
+    validate_entry_point_go_token_v0,
+    validate_reevaluation_baseline_execution_go_token_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0 import (
+    materialize_versioned_hypothesis_binding_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_MODULE = REPO_ROOT / RUNNER_SCRIPT
+_BASELINE_EXEC_GO = REEVALUATION_BASELINE_EXECUTION_GO_TOKEN
+_SIMILAR_NON_IDENTICAL_GO = REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN
+STAGING_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/v1"
+)
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_hypothesis_binding_v0()
+
+
+@pytest.fixture(name="authorization_ratification")
+def fixture_authorization_ratification() -> dict:
+    return materialize_offline_economic_evaluation_authorization_ratification_v0()
+
+
+class TestOpsRunnerReevaluationBaselineExecutionTokenAcceptance:
+    def test_exact_reevaluation_baseline_execution_go_token_accepted_by_ops_runner(self) -> None:
+        assert _BASELINE_EXEC_GO in ALLOWED_CONFIRM_GO_TOKENS
+
+    def test_exact_token_registered_in_dispatch_registry(self) -> None:
+        assert (
+            ENTRY_POINT_DISPATCH_REGISTRY[_BASELINE_EXEC_GO] == "REEVALUATION_BASELINE_EXECUTION_V0"
+        )
+
+    def test_harness_dispatch_branch_equals_reevaluation_baseline_execution_v0(self) -> None:
+        ok, branch = validate_entry_point_go_token_v0(_BASELINE_EXEC_GO)
+        assert ok is True
+        assert branch == "REEVALUATION_BASELINE_EXECUTION_V0"
+
+    @pytest.mark.skipif(
+        not STAGING_ROOT.is_dir(),
+        reason="staging_root_unavailable",
+    )
+    def test_runner_subprocess_accepts_exact_baseline_execution_go_token(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(RUNNER_MODULE),
+                    "--confirm",
+                    _BASELINE_EXEC_GO,
+                    "--primary-worktree",
+                    str(REPO_ROOT),
+                    "--durable-evidence-root",
+                    tmp,
+                    "--staging-root",
+                    str(STAGING_ROOT),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(proc.stdout)
+        assert payload["go_token_forwarded"] == _BASELINE_EXEC_GO
+        assert payload["harness_dispatch_branch"] == "REEVALUATION_BASELINE_EXECUTION_V0"
+        assert payload["economic_evaluation_executed"] is False
+        assert payload["baseline_executed"] is False
+        assert payload["robustness_executed"] is False
+        assert payload["runtime_effect"] == "NONE"
+        assert payload["authority_effect"] == "NONE"
+
+    def test_exact_token_forwarded_unchanged_to_harness(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        forwarded_tokens: list[str] = []
+        baseline_calls = 0
+
+        def _capture_baseline(*, go_token: str, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal baseline_calls
+            forwarded_tokens.append(go_token)
+            baseline_calls += 1
+            from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+                run_baseline_offline_economic_evaluation_v0,
+            )
+
+            return run_baseline_offline_economic_evaluation_v0(
+                go_token=go_token,
+                **kwargs,
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with (
+                patch(
+                    "scripts.ops.run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.run_baseline_offline_economic_evaluation_v0",
+                    side_effect=_capture_baseline,
+                ),
+                patch(
+                    "scripts.ops.run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.run_reevaluation_baseline_execution_preflight_v0",
+                ) as preflight_mock,
+                patch(
+                    "scripts.ops.run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.retention.finalize_durable_bundle_manifest",
+                    return_value=(0, ""),
+                ),
+            ):
+                from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+                    ReevaluationBaselineExecutionPreflightResultV0,
+                )
+
+                preflight_mock.return_value = ReevaluationBaselineExecutionPreflightResultV0(
+                    preflight_passed=True,
+                    blocked=False,
+                    baseline_execution_admissible=True,
+                    implementation_wiring_verified=False,
+                    reason_codes=(),
+                    python_version_ok=True,
+                    python_version="3.11.0",
+                    bound_dataset_materialized=True,
+                    source_manifests_verified=True,
+                    dataset_digest_verified=True,
+                    portfolio_bindings_valid=True,
+                    same_dataset=True,
+                    same_universe=True,
+                    same_strategy_parameters=True,
+                    same_cost_policy=True,
+                    same_risk_sizing_semantics=True,
+                    panel_data_digest="18eccf85663ce292ef1bf0edce63d2dd44215405cf3d880850d2c8d8e413a591",
+                    ratified_dataset_digest="18eccf85663ce292ef1bf0edce63d2dd44215405cf3d880850d2c8d8e413a591",
+                    baseline_wiring_verified=True,
+                    baseline_executed=False,
+                    baseline_callable_wiring_only=True,
+                    economic_evaluation_executed=False,
+                    dataset_digest_repaired=True,
+                    authority_effect=AUTHORITY_EFFECT,
+                    runtime_effect=RUNTIME_EFFECT,
+                )
+                result = run_reevaluation_baseline_execution_v0(
+                    confirm=_BASELINE_EXEC_GO,
+                    durable_evidence_root=Path(tmp),
+                    primary_worktree=REPO_ROOT,
+                    staging_root=STAGING_ROOT,
+                )
+        assert forwarded_tokens == [_BASELINE_EXEC_GO]
+        assert baseline_calls == 1
+        assert result["go_token_forwarded"] == _BASELINE_EXEC_GO
+        assert result["economic_evaluation_executed"] is False
+        assert result["baseline_executed"] is False
+
+
+class TestOpsRunnerNegativeTokenCases:
+    def test_unknown_token_rejected_by_subprocess(self) -> None:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER_MODULE),
+                "--confirm",
+                "INVALID_GO_TOKEN",
+                "--primary-worktree",
+                str(REPO_ROOT),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 2
+        assert "ERR:confirm_go_token_required" in proc.stderr
+
+    def test_similar_but_non_identical_token_rejected_by_subprocess(self) -> None:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER_MODULE),
+                "--confirm",
+                _SIMILAR_NON_IDENTICAL_GO + "_EXTRA",
+                "--primary-worktree",
+                str(REPO_ROOT),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 2
+        assert "ERR:confirm_go_token_required" in proc.stderr
+
+    def test_implementation_go_token_does_not_dispatch_to_baseline_execution_branch(self) -> None:
+        ok, branch = validate_entry_point_go_token_v0(_SIMILAR_NON_IDENTICAL_GO)
+        assert ok is True
+        assert branch == "REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
+        assert branch != "REEVALUATION_BASELINE_EXECUTION_V0"
+
+    def test_missing_go_token_rejected_by_harness_validator(self) -> None:
+        ok, reasons = validate_reevaluation_baseline_execution_go_token_v0(None)
+        assert ok is False
+        assert REASON_GO_TOKEN_MISSING in reasons
+
+    def test_unknown_go_token_rejected_by_harness_validator(self) -> None:
+        ok, reasons = validate_reevaluation_baseline_execution_go_token_v0("INVALID_GO_TOKEN")
+        assert ok is False
+        assert REASON_GO_TOKEN_INVALID in reasons
+
+
+class TestLegacyTokenBehaviorUnchanged:
+    @pytest.mark.parametrize(
+        "token",
+        [
+            IMPLEMENTATION_GO_TOKEN,
+            DISPATCH_IMPLEMENTATION_GO_TOKEN,
+            EXECUTION_GO_TOKEN,
+            IMPLEMENTATION_REPAIR_GO_TOKEN,
+            REEVALUATION_EXECUTION_CONFIRM_GO,
+            REEVALUATION_EXECUTION_IMPLEMENTATION_CONFIRM_GO,
+            REEVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_CONFIRM_GO,
+        ],
+    )
+    def test_legacy_tokens_remain_allowed(self, token: str) -> None:
+        assert token in ALLOWED_CONFIRM_GO_TOKENS
+
+    def test_legacy_execution_token_still_maps_to_execution_branch(self) -> None:
+        ok, branch = validate_entry_point_go_token_v0(EXECUTION_GO_TOKEN)
+        assert ok is True
+        assert branch == "EXECUTION_V0"
+
+    def test_implementation_repair_token_constant_unchanged(self) -> None:
+        assert IMPLEMENTATION_REPAIR_CONFIRM_GO == IMPLEMENTATION_REPAIR_GO_TOKEN
+
+
+class TestDispatchReachesCanonicalBaselineOwner:
+    def test_baseline_wiring_reaches_canonical_backtest_owner(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+            run_baseline_offline_economic_evaluation_v0,
+        )
+
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token=_BASELINE_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+        )
+        assert result.executed is False
+        assert result.blocked is False
+        assert result.wiring_verified is True
+        assert result.canonical_owner == CANONICAL_BASELINE_BACKTEST_OWNER
+
+
+class TestPreflightAndDigestGating:
+    @pytest.mark.skipif(
+        not STAGING_ROOT.is_dir(),
+        reason="staging_root_unavailable",
+    )
+    def test_valid_fixture_dataset_and_binding_digest_verified(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+            run_reevaluation_baseline_execution_preflight_v0,
+        )
+
+        result = run_reevaluation_baseline_execution_preflight_v0(
+            go_token=_BASELINE_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            staging_root=STAGING_ROOT,
+            verify_source_manifests=True,
+            materialize_dataset=True,
+        )
+        assert result.dataset_digest_verified is True
+        assert result.bound_dataset_materialized is True
+        assert result.source_manifests_verified is True
+        assert result.baseline_executed is False
+        assert result.economic_evaluation_executed is False
+
+    @pytest.mark.skipif(
+        not STAGING_ROOT.is_dir(),
+        reason="staging_root_unavailable",
+    )
+    def test_preflight_failure_blocks_before_evaluation(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+            run_reevaluation_baseline_execution_preflight_v0,
+        )
+
+        identity_patch = {
+            "same_dataset": True,
+            "same_universe": True,
+            "same_strategy_parameters": True,
+            "same_cost_policy": True,
+            "same_risk_sizing_semantics": True,
+        }
+        with (
+            patch(
+                "src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.build_identity_invariant_contract_v0",
+                return_value=identity_patch,
+            ),
+            patch(
+                "src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.RATIFIED_DATASET_DIGEST",
+                "f" * 64,
+            ),
+        ):
+            result = run_reevaluation_baseline_execution_preflight_v0(
+                go_token=_BASELINE_EXEC_GO,
+                repo_root=REPO_ROOT,
+                authorization_ratification=authorization_ratification,
+                versioned_binding=complete_binding,
+                staging_root=STAGING_ROOT,
+                verify_source_manifests=True,
+                materialize_dataset=True,
+            )
+        assert result.dataset_digest_verified is False
+        assert REASON_DATASET_DIGEST_NOT_VERIFIED in result.reason_codes
+        assert result.baseline_executed is False
+        assert result.economic_evaluation_executed is False
+
+
+class TestNoDuplicatedEvaluationLogic:
+    def test_runner_delegates_to_harness_without_local_baseline_logic(self) -> None:
+        source = RUNNER_MODULE.read_text(encoding="utf-8")
+        assert "run_walk_forward_evaluation_v0" not in source
+        assert "run_monte_carlo_evaluation_v0" not in source
+        assert "run_stress_evaluation_v0" not in source
+
+    def test_reevaluation_baseline_branch_calls_existing_harness_callables(self) -> None:
+        source = RUNNER_MODULE.read_text(encoding="utf-8")
+        assert "def run_reevaluation_baseline_execution_v0(" in source
+        assert "run_reevaluation_baseline_execution_preflight_v0(" in source
+        assert "run_baseline_offline_economic_evaluation_v0(" in source
+
+    def test_no_runtime_import_boundary_violation(self) -> None:
+        tree = ast.parse(RUNNER_MODULE.read_text(encoding="utf-8"))
+        imports = {
+            node.module
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        assert not any(item.startswith("src.execution") for item in imports)
+        assert not any(item.startswith("src.scheduler") for item in imports)
+
+
+class TestOfflineBoundaryInvariants:
+    def test_runtime_effect_none(self) -> None:
+        assert RUNTIME_EFFECT == "NONE"
+
+    def test_authority_effect_none(self) -> None:
+        assert AUTHORITY_EFFECT == "NONE"
+
+    def test_orders_not_enabled_in_runner_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with (
+                patch(
+                    "scripts.ops.run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.run_reevaluation_baseline_execution_preflight_v0",
+                ) as preflight_mock,
+                patch(
+                    "scripts.ops.run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.retention.finalize_durable_bundle_manifest",
+                    return_value=(0, ""),
+                ),
+            ):
+                from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+                    ReevaluationBaselineExecutionPreflightResultV0,
+                )
+
+                preflight_mock.return_value = ReevaluationBaselineExecutionPreflightResultV0(
+                    preflight_passed=True,
+                    blocked=False,
+                    baseline_execution_admissible=True,
+                    implementation_wiring_verified=False,
+                    reason_codes=(),
+                    python_version_ok=True,
+                    python_version="3.11.0",
+                    bound_dataset_materialized=True,
+                    source_manifests_verified=True,
+                    dataset_digest_verified=True,
+                    portfolio_bindings_valid=True,
+                    same_dataset=True,
+                    same_universe=True,
+                    same_strategy_parameters=True,
+                    same_cost_policy=True,
+                    same_risk_sizing_semantics=True,
+                    panel_data_digest="18eccf85663ce292ef1bf0edce63d2dd44215405cf3d880850d2c8d8e413a591",
+                    ratified_dataset_digest="18eccf85663ce292ef1bf0edce63d2dd44215405cf3d880850d2c8d8e413a591",
+                    baseline_wiring_verified=True,
+                    baseline_executed=False,
+                    baseline_callable_wiring_only=True,
+                    economic_evaluation_executed=False,
+                    dataset_digest_repaired=True,
+                    authority_effect=AUTHORITY_EFFECT,
+                    runtime_effect=RUNTIME_EFFECT,
+                )
+                result = run_reevaluation_baseline_execution_v0(
+                    confirm=_BASELINE_EXEC_GO,
+                    durable_evidence_root=Path(tmp),
+                    primary_worktree=REPO_ROOT,
+                    staging_root=REPO_ROOT,
+                )
+        assert result["runtime_effect"] == "NONE"
+        assert result["authority_effect"] == "NONE"
+        assert result["economic_evaluation_executed"] is False
+        assert result["baseline_executed"] is False

--- a/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_execution_ops_runner_branch_v0.py
+++ b/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_execution_ops_runner_branch_v0.py
@@ -232,7 +232,10 @@ class TestLegacyTokenBehaviorUnchanged:
 class TestNoDuplicatedEvaluationLogic:
     def test_runner_delegates_to_harness_without_local_baseline_logic(self) -> None:
         source = RUNNER_MODULE.read_text(encoding="utf-8")
-        assert "run_baseline_offline_economic_evaluation_v0" not in source
+        reeval_fn_start = source.index("def run_reevaluation_execution_v0(")
+        reeval_fn_end = source.index("\ndef run_reevaluation_execution_implementation_v0(")
+        reeval_source = source[reeval_fn_start:reeval_fn_end]
+        assert "run_baseline_offline_economic_evaluation_v0" not in reeval_source
         assert "run_walk_forward_evaluation_v0" not in source
         assert "run_monte_carlo_evaluation_v0" not in source
         assert "run_stress_evaluation_v0" not in source


### PR DESCRIPTION
## Summary
- Register `GO_CROSS_SECTIONAL_FUTURES_PAIRWISE_LEAD_LAG_SPILLOVER_V1_OFFLINE_ECONOMIC_EVALUATION_REEVALUATION_BASELINE_EXECUTION_V0` in the canonical ops runner `ALLOWED_CONFIRM_GO_TOKENS` and add explicit dispatch branch `REEVALUATION_BASELINE_EXECUTION_V0`.
- Add thin `run_reevaluation_baseline_execution_v0` adapter that reuses dataset/binding/digest preflight and delegates to `run_baseline_offline_economic_evaluation_v0` without executing economic evaluation in this bounded implementation scope.
- Extend baseline preflight to accept the execution GO token path and add focused ops-runner branch contract tests plus governance owner-map registration.

## Test plan
- [x] `pytest tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_ops_runner_branch_v0.py`
- [x] `pytest tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py`
- [x] `pytest tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_execution_ops_runner_branch_v0.py` (regression)
- [x] `pytest tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py`
- [x] `ruff format --check` and `ruff check` on changed Python files

## Scope boundaries
- `ECONOMIC_EVALUATION_EXECUTED=false`
- `BASELINE_EXECUTION_EXECUTED=false`
- `RUNTIME_EFFECT=NONE`, `AUTHORITY_EFFECT=NONE`
- No merge in this scope; next admissible scope requires separate operator GO for actual reevaluation baseline execution.


Made with [Cursor](https://cursor.com)