### PR TITLE
fix(offline-eval): repair pairwise baseline cost-binding adapter wiring

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -436,6 +436,7 @@
     "OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_WITHOUT_TRADING_SEMANTIC_EFFECT": {
       "path_globs": [
         "src/research/*offline_economic_evaluation_execution_v0.py",
+        "src/research/cross_sectional_cost_execution_binding_normalization_v0.py",
         "src/research/*offline_economic_evaluation_scope_ratification_v0.py",
         "tests/research/test_*offline_economic_evaluation_execution_infrastructure_v0.py",
         "tests/research/test_*offline_economic_evaluation_execution_dispatch_implementation_v0.py",
@@ -446,6 +447,7 @@
         "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py",
         "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_actual_execution_owner_implementation_v0.py",
         "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_dataset_digest_reconciliation_repair_v0.py",
+        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_data_unavailable_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_execution_authorization_ratification_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_full_runner_v0.py"

--- a/src/research/cross_sectional_cost_execution_binding_normalization_v0.py
+++ b/src/research/cross_sectional_cost_execution_binding_normalization_v0.py
@@ -1,0 +1,33 @@
+"""Canonical cost-execution-binding normalization for single-slot backtest wiring v0.
+
+Maps ratified fee_binding/slippage_binding aliases to fee_model_binding/slippage_model_binding
+expected by run_single_slot_panel_backtest_v0. Research-only; no runtime or authority effect.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+PACKAGE_MARKER = "CROSS_SECTIONAL_COST_EXECUTION_BINDING_NORMALIZATION_V0=true"
+NORMALIZATION_VERSION = "cross_sectional_cost_execution_binding_normalization.v0"
+
+
+def normalize_cost_execution_binding_for_backtest_v0(
+    cost_execution_binding: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return backtest-ready cost binding without mutating ratified cost values."""
+    if "fee_model_binding" in cost_execution_binding:
+        return dict(cost_execution_binding)
+    return {
+        **dict(cost_execution_binding),
+        "fee_model_binding": cost_execution_binding.get("fee_binding", {}),
+        "slippage_model_binding": cost_execution_binding.get("slippage_binding", {}),
+        "funding_model_binding": cost_execution_binding.get("funding_binding", {}),
+    }
+
+
+__all__ = [
+    "NORMALIZATION_VERSION",
+    "PACKAGE_MARKER",
+    "normalize_cost_execution_binding_for_backtest_v0",
+]

--- a/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py
@@ -336,14 +336,11 @@ def load_ops_evaluation_config_v0(repo_root: Path) -> dict[str, Any]:
 def _normalize_cost_execution_binding_for_backtest_v0(
     cost_execution_binding: Mapping[str, Any],
 ) -> dict[str, Any]:
-    if "fee_model_binding" in cost_execution_binding:
-        return dict(cost_execution_binding)
-    return {
-        **dict(cost_execution_binding),
-        "fee_model_binding": cost_execution_binding.get("fee_binding", {}),
-        "slippage_model_binding": cost_execution_binding.get("slippage_binding", {}),
-        "funding_model_binding": cost_execution_binding.get("funding_binding", {}),
-    }
+    from src.research.cross_sectional_cost_execution_binding_normalization_v0 import (
+        normalize_cost_execution_binding_for_backtest_v0,
+    )
+
+    return normalize_cost_execution_binding_for_backtest_v0(cost_execution_binding)
 
 
 def _resolve_economic_policy_binding_v0(envelope: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
+++ b/src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py
@@ -79,6 +79,9 @@ from src.research.cross_sectional_panel_robustness_adapter_v0 import (
     build_stress_adapter_input_v0,
     build_walk_forward_adapter_input_v0,
 )
+from src.research.cross_sectional_cost_execution_binding_normalization_v0 import (
+    normalize_cost_execution_binding_for_backtest_v0,
+)
 from src.research.cross_sectional_single_slot_backtest_wiring_v0 import (
     run_single_slot_panel_backtest_v0,
 )
@@ -346,6 +349,9 @@ REASON_REEVALUATION_EXECUTION_WIRING_VERIFIED = (
 REASON_BASELINE_WIRING_VERIFIED = "BASELINE_WIRING_VERIFIED_STOPPED_BEFORE_EXECUTION"
 REASON_BASELINE_BACKTEST_OWNER_INVOKED = "BASELINE_BACKTEST_OWNER_INVOKED_STOPPED_BEFORE_EVIDENCE"
 REASON_BASELINE_EXECUTION_DATA_UNAVAILABLE = "BASELINE_EXECUTION_DATA_UNAVAILABLE_FAIL_CLOSED"
+REASON_BASELINE_COST_BINDING_CONTRACT_MISMATCH = (
+    "BASELINE_COST_BINDING_CONTRACT_MISMATCH_FAIL_CLOSED"
+)
 REASON_BASELINE_BACKTEST_ALREADY_INVOKED = "BASELINE_BACKTEST_ALREADY_INVOKED_FAIL_CLOSED"
 REASON_DOWNSTREAM_WIRING_VERIFIED = "DOWNSTREAM_WIRING_VERIFIED_STOPPED_BEFORE_EXECUTION"
 REASON_BASELINE_ADJUDICATION_BLOCKS_DOWNSTREAM = (
@@ -2040,13 +2046,33 @@ def run_baseline_offline_economic_evaluation_v0(
         versioned_binding=envelope,
     )
     backtest_invoked = False
+    normalized_cost_binding = normalize_cost_execution_binding_for_backtest_v0(
+        envelope["cost_execution_binding"]
+    )
     try:
         _ = run_single_slot_panel_backtest_v0(
             orchestrator,
             panel_series,
-            cost_execution_binding=envelope["cost_execution_binding"],
+            cost_execution_binding=normalized_cost_binding,
         )
         backtest_invoked = True
+    except ValueError as exc:
+        if str(exc) == "implicit_zero_cost_forbidden":
+            reason_codes = (REASON_BASELINE_COST_BINDING_CONTRACT_MISMATCH,)
+        else:
+            reason_codes = (REASON_BASELINE_EXECUTION_DATA_UNAVAILABLE,)
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=True,
+            wiring_verified=True,
+            canonical_owner=owner_ref,
+            actual_baseline_backtest_call_present=backtest_invoked,
+            baseline_backtest_owner_call_count=1 if backtest_invoked else 0,
+            reason_codes=reason_codes,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
     except Exception:
         return PhaseExecutionBlockedResultV0(
             phase="BASELINE",

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -154,6 +154,13 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
                 "tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_actual_execution_owner_implementation_v0.py",
             ],
             [
+                "src/research/cross_sectional_cost_execution_binding_normalization_v0.py",
+                "src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py",
+                "src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py",
+                "tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_data_unavailable_repair_v0.py",
+                "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+            ],
+            [
                 "src/research/cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py",
                 "scripts/ops/run_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0.py",
                 "config/ops/cross_sectional_futures_pairwise_lead_lag_spillover_v1_economic_evaluation_v1.json",

--- a/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_actual_execution_owner_implementation_v0.py
+++ b/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_actual_execution_owner_implementation_v0.py
@@ -108,7 +108,13 @@ class TestHappyPathCanonicalBacktestOwnerInvocation:
         assert REASON_BASELINE_BACKTEST_OWNER_INVOKED in result.reason_codes
         backtest_spy.assert_called_once()
         _, kwargs = backtest_spy.call_args
-        assert kwargs["cost_execution_binding"] == complete_binding["cost_execution_binding"]
+        from src.research.cross_sectional_cost_execution_binding_normalization_v0 import (
+            normalize_cost_execution_binding_for_backtest_v0,
+        )
+
+        assert kwargs["cost_execution_binding"] == normalize_cost_execution_binding_for_backtest_v0(
+            complete_binding["cost_execution_binding"]
+        )
         orchestrator_arg, panel_arg = backtest_spy.call_args[0]
         assert orchestrator_arg.score_formula_version == complete_binding["score_family_policy"]
         assert panel_arg == panel_series

--- a/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_data_unavailable_repair_v0.py
+++ b/tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_data_unavailable_repair_v0.py
@@ -1,0 +1,123 @@
+"""Repair contract tests for pairwise spillover baseline cost-binding normalization v0."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.research.cross_sectional_cost_execution_binding_normalization_v0 import (
+    normalize_cost_execution_binding_for_backtest_v0,
+)
+from src.research.cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0 import (
+    _normalize_cost_execution_binding_for_backtest_v0 as lead_lag_normalize_cost_binding_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_authorization_ratification_v0 import (
+    materialize_offline_economic_evaluation_authorization_ratification_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+    REASON_BASELINE_BACKTEST_OWNER_INVOKED,
+    REEVALUATION_BASELINE_EXECUTION_GO_TOKEN,
+    run_baseline_offline_economic_evaluation_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_versioned_hypothesis_binding_v0 import (
+    materialize_versioned_hypothesis_binding_v0,
+)
+from src.research.cross_sectional_single_slot_backtest_wiring_v0 import (
+    run_single_slot_panel_backtest_v0,
+)
+from src.research.cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_execution_v0 import (
+    _run_pairwise_spillover_single_slot_orchestrator_v0,
+)
+from tests.research.fixtures.cross_sectional_relative_strength_v0.fixture_builder import (
+    build_synthetic_panel_series_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_BASELINE_EXEC_GO = REEVALUATION_BASELINE_EXECUTION_GO_TOKEN
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_hypothesis_binding_v0()
+
+
+@pytest.fixture(name="authorization_ratification")
+def fixture_authorization_ratification() -> dict:
+    return materialize_offline_economic_evaluation_authorization_ratification_v0()
+
+
+@pytest.fixture(name="panel_series")
+def fixture_panel_series():
+    return build_synthetic_panel_series_v0(bar_count=40, end="2024-06-01T02:00:00Z")
+
+
+class TestSharedNormalizerReuse:
+    def test_pairwise_binding_normalizes_fee_and_slippage_aliases(
+        self, complete_binding: dict
+    ) -> None:
+        raw = complete_binding["cost_execution_binding"]
+        normalized = normalize_cost_execution_binding_for_backtest_v0(raw)
+        assert normalized["fee_model_binding"] == raw["fee_binding"]
+        assert normalized["slippage_model_binding"] == raw["slippage_binding"]
+        assert normalized["funding_model_binding"] == raw["funding_binding"]
+        assert normalized["fee_model_binding"]["fee_bps_per_side"] > 0
+        assert normalized["slippage_model_binding"]["slippage_bps_per_side"] > 0
+
+    def test_fee_model_binding_passthrough_unchanged(self, complete_binding: dict) -> None:
+        raw = dict(complete_binding["cost_execution_binding"])
+        raw["fee_model_binding"] = {"fee_bps_per_side": 10.0, "fee_model_version": "x"}
+        raw["slippage_model_binding"] = {
+            "slippage_bps_per_side": 5.0,
+            "slippage_model_version": "y",
+        }
+        assert normalize_cost_execution_binding_for_backtest_v0(raw) == raw
+
+    def test_lead_lag_wrapper_matches_shared_normalizer(self, complete_binding: dict) -> None:
+        raw = complete_binding["cost_execution_binding"]
+        assert lead_lag_normalize_cost_binding_v0(
+            raw
+        ) == normalize_cost_execution_binding_for_backtest_v0(raw)
+
+
+class TestBacktestOwnerContract:
+    def test_pairwise_binding_does_not_trigger_implicit_zero_cost_forbidden(
+        self,
+        complete_binding: dict,
+        panel_series,
+    ) -> None:
+        orchestrator = _run_pairwise_spillover_single_slot_orchestrator_v0(
+            panel_series=panel_series,
+            versioned_binding=complete_binding,
+        )
+        backtest = run_single_slot_panel_backtest_v0(
+            orchestrator,
+            panel_series,
+            cost_execution_binding=normalize_cost_execution_binding_for_backtest_v0(
+                complete_binding["cost_execution_binding"]
+            ),
+        )
+        assert backtest.roundtrip_cost_bps > 0
+        assert backtest.trade_count >= 0
+
+
+class TestBaselineExecutionRepair:
+    def test_baseline_path_invokes_backtest_with_normalized_cost_binding(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+        panel_series,
+    ) -> None:
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token=_BASELINE_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            panel_series=panel_series,
+            verify_source_manifests=False,
+            materialize_dataset=False,
+        )
+        assert result.blocked is False
+        assert result.actual_baseline_backtest_call_present is True
+        assert result.baseline_backtest_owner_call_count == 1
+        assert REASON_BASELINE_BACKTEST_OWNER_INVOKED in result.reason_codes


### PR DESCRIPTION
## Summary
- Extract canonical `normalize_cost_execution_binding_for_backtest_v0` helper and reuse it from lead-lag and pairwise spillover execution owners.
- Normalize pairwise `fee_binding`/`slippage_binding` aliases before `run_single_slot_panel_backtest_v0` to fix the confirmed `ADAPTER_WIRING_DEFECT` (`implicit_zero_cost_forbidden`).
- Add focused regression tests and boundary-guard owner-map coverage; map `implicit_zero_cost_forbidden` to a precise fail-closed reason.

## Test plan
- [x] `pytest tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_execution_data_unavailable_repair_v0.py`
- [x] `pytest tests/research/test_cross_sectional_futures_pairwise_lead_lag_spillover_v1_offline_economic_evaluation_reevaluation_baseline_actual_execution_owner_implementation_v0.py`
- [x] `pytest tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py::TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0`
- [x] `ruff format --check` / `ruff check` on changed files


Made with [Cursor](https://cursor.com)