### PR TITLE
Bind trend_following v2 execution GO to canonical offline dispatch owner

### DIFF
--- a/scripts/ops/materialize_trend_following_v2_offline_economic_evaluation_execution_dispatch_implementation_v0.py
+++ b/scripts/ops/materialize_trend_following_v2_offline_economic_evaluation_execution_dispatch_implementation_v0.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Materialize trend_following v2 offline economic evaluation execution dispatch implementation v0."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops import (  # noqa: E402
+    run_trend_following_v2_offline_economic_evaluation_execution_v0 as runner_module,
+)
+from src.research.trend_following_v2_offline_economic_evaluation_execution_v0 import (  # noqa: E402
+    DISPATCH_IMPLEMENTATION_GO_TOKEN,
+    verify_source_evidence_manifests_v0,
+)
+
+CONFIRM_GO = DISPATCH_IMPLEMENTATION_GO_TOKEN
+DEFAULT_DURABLE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+FOCUSED_TEST = (
+    "tests/research/"
+    "test_trend_following_v2_offline_economic_evaluation_execution_dispatch_implementation_v0.py"
+)
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def run_materialization(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+    run_tests: bool = True,
+) -> dict[str, Any]:
+    if confirm != CONFIRM_GO:
+        _die(f"ERR:confirm_go_token_required:{CONFIRM_GO}")
+
+    source_ok, source_reasons = verify_source_evidence_manifests_v0()
+    source_manifest_rc = 0 if source_ok else 1
+    if source_manifest_rc != 0:
+        _die(f"ERR:source_manifest_verify_failed:{source_reasons}")
+
+    if run_tests:
+        proc = subprocess.run(
+            [sys.executable, "-m", "pytest", FOCUSED_TEST, "-q", "--tb=short"],
+            cwd=_REPO_ROOT,
+            check=False,
+        )
+        if proc.returncode != 0:
+            _die(f"ERR:focused_tests_failed:{proc.returncode}")
+
+    result = runner_module.run_execution_dispatch_implementation_v0(
+        confirm=confirm,
+        durable_evidence_root=durable_evidence_root,
+        primary_worktree=primary_worktree,
+    )
+    final_report = (
+        "\n".join(
+            [
+                "STATUS=PASS",
+                "VERDICT=EXECUTION_DISPATCH_IMPLEMENTATION_COMPLETE",
+                "ROOT_CAUSE=AUTHORIZED_EXECUTION_GO_DISPATCH_NOT_BOUND_TO_CANONICAL_OWNER",
+                "REPAIR_SCOPE=BOUNDED_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_DISPATCH_IMPLEMENTATION_V0",
+                f"SOURCE_MANIFEST_VERIFY_RC={source_manifest_rc}",
+                f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}",
+                f"DURABLE_EVIDENCE_DIR={result['durable_evidence_path']}",
+                "NEXT_ADMISSIBLE_SCOPE=GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0",
+            ]
+        )
+        + "\n"
+    )
+    bundle_dir = Path(result["durable_evidence_path"])
+    (bundle_dir / "final_report.txt").write_text(final_report, encoding="utf-8")
+    print(final_report)
+    result["source_manifest_verify_rc"] = source_manifest_rc
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm", required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_ROOT)
+    parser.add_argument("--primary-worktree", type=Path, default=_REPO_ROOT)
+    parser.add_argument("--no-tests", action="store_true")
+    args = parser.parse_args()
+    payload = run_materialization(
+        confirm=args.confirm,
+        durable_evidence_root=args.durable_evidence_root,
+        primary_worktree=args.primary_worktree,
+        run_tests=not args.no_tests,
+    )
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ops/run_trend_following_v2_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_trend_following_v2_offline_economic_evaluation_execution_v0.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""Ops runner for trend_following v2 offline economic evaluation execution infrastructure.
+"""Ops runner for trend_following v2 offline economic evaluation execution.
 
-Bounded infrastructure mode only:
-- GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_V0
+Bounded modes:
+- Infrastructure/dry-run: GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_V0
+- Dispatch implementation: GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_DISPATCH_IMPLEMENTATION_V0
+- Execution dispatch: GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0
 
-No runtime, order, or authority effect. No economic evaluation execution in this scope.
+No runtime, order, or authority effect.
 """
 
 from __future__ import annotations
@@ -25,21 +27,36 @@ if str(_REPO_ROOT) not in sys.path:
 from scripts.ops import primary_evidence_retention_v0 as retention  # noqa: E402
 from src.research.trend_following_v2_offline_economic_evaluation_execution_v0 import (  # noqa: E402
     AUTHORITY_EFFECT,
+    DISPATCH_IMPLEMENTATION_GO_TOKEN,
+    EXECUTION_GO_TOKEN,
     EXECUTION_VERSION,
     INFRASTRUCTURE_GO_TOKEN,
     RUNTIME_EFFECT,
+    dispatch_result_to_dict,
     entrypoint_result_to_dict,
     load_authorization_ratification_v0,
     load_versioned_research_binding_v0,
+    materialize_dispatch_contract_v0,
+    materialize_execution_contract_v0,
     materialize_infrastructure_summary_v0,
     run_contract_smoke_evaluation_v0,
     run_full_evaluation_entrypoint_dry_run_v1,
+    run_full_offline_economic_evaluation_v0,
+    run_offline_economic_evaluation_execution_dispatch_v0,
     verify_execution_start_state_v0,
 )
 
 INFRASTRUCTURE_GO = INFRASTRUCTURE_GO_TOKEN
+DISPATCH_IMPLEMENTATION_GO = DISPATCH_IMPLEMENTATION_GO_TOKEN
+EXECUTION_GO = EXECUTION_GO_TOKEN
 SCOPE_CLASSIFICATION = (
     "BOUNDED_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_V0"
+)
+DISPATCH_IMPLEMENTATION_SCOPE_CLASSIFICATION = (
+    "BOUNDED_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_DISPATCH_IMPLEMENTATION_V0"
+)
+EXECUTION_DISPATCH_SCOPE_CLASSIFICATION = (
+    "BOUNDED_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0"
 )
 DEFAULT_DURABLE_ROOT = Path(
     "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
@@ -197,17 +214,245 @@ def run_execution_infrastructure_v0(
     return payload
 
 
+def run_execution_dispatch_implementation_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != DISPATCH_IMPLEMENTATION_GO:
+        _die(f"ERR:confirm_go_token_required:{DISPATCH_IMPLEMENTATION_GO}")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "implementation"
+        / (
+            "trend_following_v2_offline_economic_evaluation_execution_dispatch_"
+            f"implementation_v0_{ts_slug}"
+        )
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    versioned_binding = load_versioned_research_binding_v0(_REPO_ROOT)
+    authorization_ratification = load_authorization_ratification_v0(_REPO_ROOT)
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+    dispatch = run_offline_economic_evaluation_execution_dispatch_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        go_token=EXECUTION_GO,
+        versioned_binding=versioned_binding,
+        verify_source_manifests=True,
+    )
+    dispatch_payload = dispatch_result_to_dict(dispatch)
+    execution_contract = materialize_execution_contract_v0()
+    dispatch_contract = materialize_dispatch_contract_v0()
+
+    (bundle_dir / "PREFLIGHT.txt").write_text(
+        "\n".join(
+            [
+                f"ORIGIN_MAIN={origin_main}",
+                f"PRIMARY_HEAD_BEFORE={primary_before['head']}",
+                f"PRIMARY_DIRTY_COUNT_BEFORE={primary_before['dirty_count']}",
+                f"START_STATE_VALID={start_state.valid}",
+                f"START_STATE_FAIL_REASONS={list(start_state.fail_reasons)}",
+                "ROOT_CAUSE=AUTHORIZED_EXECUTION_GO_DISPATCH_NOT_BOUND_TO_CANONICAL_OWNER",
+                f"REPAIR_SCOPE={DISPATCH_IMPLEMENTATION_SCOPE_CLASSIFICATION}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "EXECUTION_LOG.txt").write_text(
+        "\n".join(
+            [
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                "EXECUTION_SCOPE=DISPATCH_IMPLEMENTATION_V0",
+                f"GO_TOKEN={confirm}",
+                "GO_TOKEN_CONSUMPTION=CONSUMED_ONCE",
+                f"SCOPE_CLASSIFICATION={DISPATCH_IMPLEMENTATION_SCOPE_CLASSIFICATION}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "DISPATCH_RESULT.json").write_text(
+        json.dumps(dispatch_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "EXECUTION_CONTRACT.json").write_text(
+        json.dumps(execution_contract, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "DISPATCH_CONTRACT.json").write_text(
+        json.dumps(dispatch_contract, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
+        "ECONOMIC_EVALUATION_EXECUTED=false\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    payload: dict[str, Any] = {
+        "verdict": "EXECUTION_DISPATCH_IMPLEMENTATION_COMPLETE",
+        "process_classification": DISPATCH_IMPLEMENTATION_SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "start_state_valid": start_state.valid,
+        "dispatch": dispatch_payload,
+        "execution_go_dispatch_bound": dispatch.dispatch_accepted,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree_head_before": primary_before["head"],
+        "primary_worktree_dirty_count_before": primary_before["dirty_count"],
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_DISPATCH_IMPLEMENTATION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if time.monotonic() - start_monotonic > MAX_RUNTIME_SECONDS:
+        _die(f"ERR:timeout_guard_exceeded:{MAX_RUNTIME_SECONDS}s")
+    return payload
+
+
+def run_execution_dispatch_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != EXECUTION_GO:
+        _die(f"ERR:confirm_go_token_required:{EXECUTION_GO}")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "implementation"
+        / (f"trend_following_v2_offline_economic_evaluation_execution_v0_{ts_slug}")
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    versioned_binding = load_versioned_research_binding_v0(_REPO_ROOT)
+    authorization_ratification = load_authorization_ratification_v0(_REPO_ROOT)
+    evaluation = run_full_offline_economic_evaluation_v0(
+        go_token=EXECUTION_GO,
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        verify_source_manifests=True,
+    )
+    (bundle_dir / "EXECUTION_LOG.txt").write_text(
+        "\n".join(
+            [
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                f"EXECUTION_SCOPE={EXECUTION_DISPATCH_SCOPE_CLASSIFICATION}",
+                f"GO_TOKEN={confirm}",
+                "GO_TOKEN_CONSUMPTION=CONSUMED_ONCE",
+                f"BLOCKED={str(evaluation.blocked).lower()}",
+                f"WIRING_VERIFIED={str(evaluation.wiring_verified).lower()}",
+                f"REASON_CODES={list(evaluation.reason_codes)}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "FULL_EVALUATION_DISPATCH_RESULT.json").write_text(
+        json.dumps(
+            {
+                "executed": evaluation.executed,
+                "blocked": evaluation.blocked,
+                "wiring_verified": evaluation.wiring_verified,
+                "reason_codes": list(evaluation.reason_codes),
+                "authority_effect": evaluation.authority_effect,
+                "runtime_effect": evaluation.runtime_effect,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
+        "ECONOMIC_EVALUATION_EXECUTED=false\n",
+        encoding="utf-8",
+    )
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    payload: dict[str, Any] = {
+        "verdict": "EXECUTION_DISPATCH_COMPLETE",
+        "process_classification": EXECUTION_DISPATCH_SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "evaluation": {
+            "executed": evaluation.executed,
+            "blocked": evaluation.blocked,
+            "wiring_verified": evaluation.wiring_verified,
+            "reason_codes": list(evaluation.reason_codes),
+        },
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree_head_before": primary_before["head"],
+        "primary_worktree_dirty_count_before": primary_before["dirty_count"],
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if time.monotonic() - start_monotonic > MAX_RUNTIME_SECONDS:
+        _die(f"ERR:timeout_guard_exceeded:{MAX_RUNTIME_SECONDS}s")
+    return payload
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--confirm", required=True)
     parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_ROOT)
     parser.add_argument("--primary-worktree", type=Path, default=_REPO_ROOT)
     args = parser.parse_args()
-    result = run_execution_infrastructure_v0(
-        confirm=args.confirm,
-        durable_evidence_root=args.durable_evidence_root,
-        primary_worktree=args.primary_worktree,
-    )
+    if args.confirm == INFRASTRUCTURE_GO:
+        result = run_execution_infrastructure_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+        )
+    elif args.confirm == DISPATCH_IMPLEMENTATION_GO:
+        result = run_execution_dispatch_implementation_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+        )
+    elif args.confirm == EXECUTION_GO:
+        result = run_execution_dispatch_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+        )
+    else:
+        _die(
+            "ERR:confirm_go_token_required:"
+            f"{INFRASTRUCTURE_GO}|{DISPATCH_IMPLEMENTATION_GO}|{EXECUTION_GO}"
+        )
     print(json.dumps(result, indent=2, sort_keys=True))
 
 

--- a/src/research/trend_following_v2_offline_economic_evaluation_execution_v0.py
+++ b/src/research/trend_following_v2_offline_economic_evaluation_execution_v0.py
@@ -57,6 +57,9 @@ CANONICAL_SERIALIZATION_VERSION = "sparse_signal_execution_canonical_json_v1"
 INFRASTRUCTURE_GO_TOKEN = (
     "GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_V0"
 )
+DISPATCH_IMPLEMENTATION_GO_TOKEN = (
+    "GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_DISPATCH_IMPLEMENTATION_V0"
+)
 EXECUTION_GO_TOKEN = "GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0"
 GO_TOKEN = EXECUTION_GO_TOKEN
 
@@ -67,13 +70,25 @@ CONFIG_REL_PATH_OPS = "config/ops/trend_following_v2_economic_evaluation_v1.json
 RUNNER_SCRIPT = "scripts/ops/run_trend_following_v2_offline_economic_evaluation_execution_v0.py"
 CANONICAL_EVALUATION_CALLABLE = "run_contract_smoke_evaluation_v0"
 CANONICAL_FULL_EVALUATION_CALLABLE = "run_full_offline_economic_evaluation_v0"
-ENTRY_POINT_STATUS = "EXECUTION_INFRASTRUCTURE_WIRING_V0"
+CANONICAL_DISPATCH_CALLABLE = "run_offline_economic_evaluation_execution_dispatch_v0"
+HARNESS_OWNER = "src.research.trend_following_v2_offline_economic_evaluation_execution_v0"
+BASELINE_EVALUATOR_OWNER = (
+    "versioned_final_fleet_bindings_offline_economic_evaluation_v0."
+    "_run_candidate_with_runtime_config_v0"
+)
+ENTRY_POINT_STATUS = "EXECUTION_DISPATCH_WIRING_V0"
 
 _BRANCH_INFRASTRUCTURE_V0 = "INFRASTRUCTURE_V0"
 _BRANCH_EXECUTION_V0 = "EXECUTION_V0"
+_BRANCH_DISPATCH_IMPLEMENTATION_V0 = "DISPATCH_IMPLEMENTATION_V0"
+ALLOWED_EVALUATION_DISPATCH_GO_TOKENS: frozenset[str] = frozenset({EXECUTION_GO_TOKEN})
+ALLOWED_DISPATCH_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset(
+    {DISPATCH_IMPLEMENTATION_GO_TOKEN}
+)
 ENTRY_POINT_DISPATCH_REGISTRY: dict[str, str] = {
     INFRASTRUCTURE_GO_TOKEN: _BRANCH_INFRASTRUCTURE_V0,
     EXECUTION_GO_TOKEN: _BRANCH_EXECUTION_V0,
+    DISPATCH_IMPLEMENTATION_GO_TOKEN: _BRANCH_DISPATCH_IMPLEMENTATION_V0,
 }
 
 REASON_BINDING_DIGEST_MISMATCH = "BINDING_DIGEST_MISMATCH"
@@ -82,6 +97,10 @@ REASON_BINDING_INCOMPLETE = "BINDING_INCOMPLETE"
 REASON_RATIFICATION_INVALID = "RATIFICATION_INVALID"
 REASON_GO_TOKEN_INVALID = "GO_TOKEN_INVALID"
 REASON_ECONOMIC_EXECUTION_FORBIDDEN = "ECONOMIC_EXECUTION_FORBIDDEN_IN_INFRASTRUCTURE_SCOPE"
+REASON_OFFLINE_ONLY_VIOLATION = "OFFLINE_ONLY_VIOLATION"
+REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION = (
+    "DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION"
+)
 REASON_MISSING_OPS_EVALUATION_CONFIG = "MISSING_OPS_EVALUATION_CONFIG"
 REASON_PANEL_STAGING_MISSING = "PANEL_STAGING_MISSING"
 REASON_SOURCE_MANIFEST_VERIFY_FAILED = "SOURCE_MANIFEST_VERIFY_FAILED"
@@ -97,6 +116,13 @@ class InfrastructureTerminalStatus(str, Enum):
 class EvaluationEntrypointTerminalStatus(str, Enum):
     ENTRYPOINT_READY_DRY_RUN_STOPPED = "ENTRYPOINT_READY_DRY_RUN_STOPPED"
     FAIL_CLOSED_PRECHECK = "FAIL_CLOSED_PRECHECK"
+
+
+class ExecutionDispatchTerminalStatus(str, Enum):
+    DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION = (
+        "DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION"
+    )
+    DISPATCH_FAIL_CLOSED = "DISPATCH_FAIL_CLOSED"
 
 
 @dataclass(frozen=True)
@@ -155,6 +181,26 @@ class FullEvaluationDispatchResultV0:
     reason_codes: tuple[str, ...]
     authority_effect: str
     runtime_effect: str
+
+
+@dataclass(frozen=True)
+class OfflineEconomicEvaluationDispatchResultV0:
+    status: ExecutionDispatchTerminalStatus
+    dispatch_accepted: bool
+    precheck_passed: bool
+    source_manifests_verified: bool
+    bound_dataset_materialized: bool
+    dataset_period_match: bool
+    panel_data_digest: str
+    panel_wiring_complete: bool
+    reason_codes: tuple[str, ...]
+    baseline_executed: bool
+    robustness_executed: bool
+    economic_evaluation_executed: bool
+    authority_effect: str
+    runtime_effect: str
+    dispatcher_owner: str
+    baseline_phase_owner: str
 
 
 def _stable_digest(payload: Mapping[str, Any]) -> str:
@@ -289,6 +335,22 @@ def validate_infrastructure_go_token_v0(go_token: str | None) -> tuple[bool, tup
 
 def validate_execution_go_token_v0(go_token: str | None) -> tuple[bool, tuple[str, ...]]:
     if go_token != EXECUTION_GO_TOKEN:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_dispatch_implementation_go_token_v0(
+    go_token: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    if go_token not in ALLOWED_DISPATCH_IMPLEMENTATION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_evaluation_dispatch_go_token_v0(
+    go_token: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    if go_token not in ALLOWED_EVALUATION_DISPATCH_GO_TOKENS:
         return False, (REASON_GO_TOKEN_INVALID,)
     return True, ()
 
@@ -446,6 +508,8 @@ def verify_full_evaluation_precheck_v1(
         ok, token_reasons = validate_infrastructure_go_token_v0(go_token)
         if not ok:
             reasons.extend(token_reasons)
+        if go_token in ALLOWED_EVALUATION_DISPATCH_GO_TOKENS:
+            reasons.append(REASON_ECONOMIC_EXECUTION_FORBIDDEN)
 
     staging_root = _resolve_panel_staging_root(envelope)
     if not staging_root.is_dir():
@@ -461,6 +525,22 @@ def run_full_evaluation_entrypoint_dry_run_v1(
     versioned_binding: Mapping[str, Any] | None = None,
     go_token: str = INFRASTRUCTURE_GO_TOKEN,
 ) -> FullEvaluationEntrypointResultV1:
+    if go_token in ALLOWED_EVALUATION_DISPATCH_GO_TOKENS:
+        return FullEvaluationEntrypointResultV1(
+            status=EvaluationEntrypointTerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=False,
+            source_manifests_verified=False,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest=RATIFIED_DATASET_DIGEST,
+            stage_wiring=(),
+            dry_run_stopped_before_execution=True,
+            economic_evaluation_executed=False,
+            reason_codes=(REASON_ECONOMIC_EXECUTION_FORBIDDEN,),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
     envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
     precheck_ok, precheck_reasons = verify_full_evaluation_precheck_v1(
         repo_root=repo_root,
@@ -525,12 +605,108 @@ def run_full_evaluation_entrypoint_dry_run_v1(
     )
 
 
+def run_offline_economic_evaluation_execution_dispatch_v0(
+    *,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any],
+    go_token: str,
+    versioned_binding: Mapping[str, Any] | None = None,
+    verify_source_manifests: bool = True,
+) -> OfflineEconomicEvaluationDispatchResultV0:
+    """Fail-closed offline economic evaluation dispatch without baseline or robustness."""
+    reasons: list[str] = []
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+
+    token_ok, token_reasons = validate_evaluation_dispatch_go_token_v0(go_token)
+    if not token_ok:
+        reasons.extend(token_reasons)
+
+    if authorization_ratification.get("offline_only") is not True:
+        reasons.append(REASON_OFFLINE_ONLY_VIOLATION)
+    ops_cfg = load_ops_evaluation_config_v0(repo_root)
+    if ops_cfg.get("offline_only") is not True:
+        reasons.append(REASON_OFFLINE_ONLY_VIOLATION)
+
+    start_state = verify_execution_start_state_v0(
+        repo_root=repo_root,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=envelope,
+    )
+    if not start_state.valid:
+        reasons.extend(start_state.fail_reasons)
+
+    digest_ok, digest_reasons = verify_ratified_digests_v0(
+        envelope,
+        expected_binding_digest=str(ops_cfg.get("binding_digest", RATIFIED_BINDING_DIGEST)),
+        expected_dataset_digest=str(
+            ops_cfg.get("sparse_signal_evaluation_binding_v0", {}).get(
+                "dataset_digest",
+                RATIFIED_DATASET_DIGEST,
+            )
+        ),
+    )
+    if not digest_ok:
+        reasons.extend(digest_reasons)
+
+    source_manifests_verified = False
+    if verify_source_manifests:
+        manifest_ok, manifest_reasons = verify_source_evidence_manifests_v0()
+        source_manifests_verified = manifest_ok
+        if not manifest_ok:
+            reasons.extend(manifest_reasons)
+
+    panel_data_digest = str(envelope.get("dataset_digest", RATIFIED_DATASET_DIGEST))
+    bound_dataset_materialized = False
+    dataset_period_match = False
+    panel_wiring_complete = False
+    if not reasons:
+        smoke = run_contract_smoke_evaluation_v0(
+            repo_root=repo_root,
+            versioned_binding=envelope,
+            authorization_ratification=authorization_ratification,
+        )
+        panel_data_digest = smoke.panel_data_digest
+        bound_dataset_materialized = smoke.bound_dataset_materialized
+        dataset_period_match = smoke.dataset_period_match
+        panel_wiring_complete = smoke.panel_wiring_complete
+        if smoke.status is not InfrastructureTerminalStatus.EXECUTION_INFRASTRUCTURE_COMPLETE:
+            reasons.extend(smoke.reason_codes)
+
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    precheck_passed = not unique_reasons
+    dispatch_accepted = token_ok and precheck_passed
+    status = (
+        ExecutionDispatchTerminalStatus.DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION
+        if dispatch_accepted
+        else ExecutionDispatchTerminalStatus.DISPATCH_FAIL_CLOSED
+    )
+    return OfflineEconomicEvaluationDispatchResultV0(
+        status=status,
+        dispatch_accepted=dispatch_accepted,
+        precheck_passed=precheck_passed,
+        source_manifests_verified=source_manifests_verified,
+        bound_dataset_materialized=bound_dataset_materialized,
+        dataset_period_match=dataset_period_match,
+        panel_data_digest=panel_data_digest,
+        panel_wiring_complete=panel_wiring_complete,
+        reason_codes=unique_reasons,
+        baseline_executed=False,
+        robustness_executed=False,
+        economic_evaluation_executed=False,
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+        dispatcher_owner=f"{HARNESS_OWNER}.{CANONICAL_DISPATCH_CALLABLE}",
+        baseline_phase_owner=BASELINE_EVALUATOR_OWNER,
+    )
+
+
 def run_full_offline_economic_evaluation_v0(
     *,
     go_token: str,
     repo_root: Path,
     authorization_ratification: Mapping[str, Any] | None = None,
     versioned_binding: Mapping[str, Any] | None = None,
+    verify_source_manifests: bool = True,
 ) -> FullEvaluationDispatchResultV0:
     envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
     ratification = dict(authorization_ratification or load_authorization_ratification_v0(repo_root))
@@ -571,11 +747,28 @@ def run_full_offline_economic_evaluation_v0(
             runtime_effect=RUNTIME_EFFECT,
         )
 
+    dispatch = run_offline_economic_evaluation_execution_dispatch_v0(
+        repo_root=repo_root,
+        authorization_ratification=ratification,
+        go_token=go_token,
+        versioned_binding=envelope,
+        verify_source_manifests=verify_source_manifests,
+    )
+    if not dispatch.dispatch_accepted:
+        return FullEvaluationDispatchResultV0(
+            executed=False,
+            blocked=True,
+            wiring_verified=dispatch.precheck_passed,
+            reason_codes=dispatch.reason_codes,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
     return FullEvaluationDispatchResultV0(
         executed=False,
-        blocked=True,
+        blocked=False,
         wiring_verified=True,
-        reason_codes=(REASON_ECONOMIC_EXECUTION_FORBIDDEN,),
+        reason_codes=(REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION,),
         authority_effect=AUTHORITY_EFFECT,
         runtime_effect=RUNTIME_EFFECT,
     )
@@ -594,7 +787,9 @@ def materialize_execution_contract_v0() -> dict[str, Any]:
         "dataset_digest": RATIFIED_DATASET_DIGEST,
         "canonical_evaluation_callable": CANONICAL_EVALUATION_CALLABLE,
         "canonical_full_evaluation_callable": CANONICAL_FULL_EVALUATION_CALLABLE,
+        "canonical_dispatch_callable": CANONICAL_DISPATCH_CALLABLE,
         "infrastructure_go_token": INFRASTRUCTURE_GO_TOKEN,
+        "dispatch_implementation_go_token": DISPATCH_IMPLEMENTATION_GO_TOKEN,
         "execution_go_token": EXECUTION_GO_TOKEN,
         "entry_point_status": ENTRY_POINT_STATUS,
         "harness_binding_ref": HARNESS_BINDING_REF,
@@ -608,6 +803,47 @@ def materialize_execution_contract_v0() -> dict[str, Any]:
         "authority_effect": AUTHORITY_EFFECT,
         "runtime_effect": RUNTIME_EFFECT,
         "order_effect": ORDER_EFFECT,
+    }
+
+
+def materialize_dispatch_contract_v0() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "execution_id": EXECUTION_ID,
+        "canonical_dispatch_callable": CANONICAL_DISPATCH_CALLABLE,
+        "dispatcher_owner": f"{HARNESS_OWNER}.{CANONICAL_DISPATCH_CALLABLE}",
+        "baseline_phase_owner": BASELINE_EVALUATOR_OWNER,
+        "dispatch_implementation_go_token": DISPATCH_IMPLEMENTATION_GO_TOKEN,
+        "execution_go_token": EXECUTION_GO_TOKEN,
+        "entry_point_status": ENTRY_POINT_STATUS,
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "robustness_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+    }
+
+
+def dispatch_result_to_dict(
+    result: OfflineEconomicEvaluationDispatchResultV0,
+) -> dict[str, Any]:
+    return {
+        "status": result.status.value,
+        "dispatch_accepted": result.dispatch_accepted,
+        "precheck_passed": result.precheck_passed,
+        "source_manifests_verified": result.source_manifests_verified,
+        "bound_dataset_materialized": result.bound_dataset_materialized,
+        "dataset_period_match": result.dataset_period_match,
+        "panel_data_digest": result.panel_data_digest,
+        "panel_wiring_complete": result.panel_wiring_complete,
+        "reason_codes": list(result.reason_codes),
+        "baseline_executed": result.baseline_executed,
+        "robustness_executed": result.robustness_executed,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+        "dispatcher_owner": result.dispatcher_owner,
+        "baseline_phase_owner": result.baseline_phase_owner,
     }
 
 
@@ -677,34 +913,44 @@ def entrypoint_result_to_dict(result: FullEvaluationEntrypointResultV1) -> dict[
 
 __all__ = [
     "AUTHORITY_EFFECT",
+    "BASELINE_EVALUATOR_OWNER",
+    "CANONICAL_DISPATCH_CALLABLE",
     "CANONICAL_EVALUATION_CALLABLE",
     "CANONICAL_FULL_EVALUATION_CALLABLE",
     "CONFIG_REL_PATH_OPS",
+    "DISPATCH_IMPLEMENTATION_GO_TOKEN",
     "ENTRY_POINT_STATUS",
     "EXECUTION_GO_TOKEN",
     "EXECUTION_VERSION",
     "GO_TOKEN",
     "HARNESS_BINDING_REF",
+    "HARNESS_OWNER",
     "INFRASTRUCTURE_GO_TOKEN",
     "ORDER_EFFECT",
     "RATIFIED_BINDING_DIGEST",
     "RATIFIED_DATASET_DIGEST",
     "REASON_BINDING_DIGEST_MISMATCH",
     "REASON_DATASET_DIGEST_MISMATCH",
+    "REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION",
     "REASON_ECONOMIC_EXECUTION_FORBIDDEN",
     "REASON_GO_TOKEN_INVALID",
     "RUNNER_SCRIPT",
     "RUNTIME_EFFECT",
+    "dispatch_result_to_dict",
     "entrypoint_result_to_dict",
     "load_authorization_ratification_v0",
     "load_ops_evaluation_config_v0",
     "load_versioned_research_binding_v0",
+    "materialize_dispatch_contract_v0",
     "materialize_execution_contract_v0",
     "materialize_infrastructure_summary_v0",
     "run_contract_smoke_evaluation_v0",
     "run_full_evaluation_entrypoint_dry_run_v1",
     "run_full_offline_economic_evaluation_v0",
+    "run_offline_economic_evaluation_execution_dispatch_v0",
+    "validate_dispatch_implementation_go_token_v0",
     "validate_entry_point_go_token_v0",
+    "validate_evaluation_dispatch_go_token_v0",
     "validate_execution_go_token_v0",
     "validate_infrastructure_go_token_v0",
     "verify_execution_start_state_v0",

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -153,6 +153,13 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
                 "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
             ],
             [
+                "src/research/trend_following_v2_offline_economic_evaluation_execution_v0.py",
+                "scripts/ops/run_trend_following_v2_offline_economic_evaluation_execution_v0.py",
+                "scripts/ops/materialize_trend_following_v2_offline_economic_evaluation_execution_dispatch_implementation_v0.py",
+                "tests/research/test_trend_following_v2_offline_economic_evaluation_execution_dispatch_implementation_v0.py",
+                "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+            ],
+            [
                 "src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py",
                 "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_infrastructure_v0.py",
                 "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",

--- a/tests/research/test_trend_following_v2_offline_economic_evaluation_execution_dispatch_implementation_v0.py
+++ b/tests/research/test_trend_following_v2_offline_economic_evaluation_execution_dispatch_implementation_v0.py
@@ -1,0 +1,257 @@
+"""Dispatch implementation contract tests for trend_following v2 execution v0."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.research.trend_following_v2_offline_economic_evaluation_authorization_ratification_v0 import (
+    materialize_offline_economic_evaluation_authorization_ratification_v0,
+)
+from src.research.trend_following_v2_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    DISPATCH_IMPLEMENTATION_GO_TOKEN,
+    EXECUTION_GO_TOKEN,
+    INFRASTRUCTURE_GO_TOKEN,
+    RATIFIED_BINDING_DIGEST,
+    RATIFIED_DATASET_DIGEST,
+    REASON_BINDING_DIGEST_MISMATCH,
+    REASON_DATASET_DIGEST_MISMATCH,
+    REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION,
+    REASON_ECONOMIC_EXECUTION_FORBIDDEN,
+    REASON_GO_TOKEN_INVALID,
+    RUNNER_SCRIPT,
+    RUNTIME_EFFECT,
+    dispatch_result_to_dict,
+    materialize_dispatch_contract_v0,
+    run_full_evaluation_entrypoint_dry_run_v1,
+    run_full_offline_economic_evaluation_v0,
+    run_offline_economic_evaluation_execution_dispatch_v0,
+    validate_entry_point_go_token_v0,
+    verify_ratified_digests_v0,
+)
+from src.research.trend_following_v2_versioned_research_binding_v0 import (
+    materialize_versioned_research_binding_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_MODULE = REPO_ROOT / RUNNER_SCRIPT
+MATERIALIZER_MODULE = (
+    REPO_ROOT / "scripts/ops/materialize_trend_following_v2_offline_economic_evaluation_execution_"
+    "dispatch_implementation_v0.py"
+)
+_EXEC_GO = EXECUTION_GO_TOKEN
+_INFRA_GO = INFRASTRUCTURE_GO_TOKEN
+_DISPATCH_IMPL_GO = DISPATCH_IMPLEMENTATION_GO_TOKEN
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_research_binding_v0(repo_root=REPO_ROOT)
+
+
+@pytest.fixture(name="authorization_ratification")
+def fixture_authorization_ratification(complete_binding: dict) -> dict:
+    return materialize_offline_economic_evaluation_authorization_ratification_v0(
+        repo_root=REPO_ROOT,
+        versioned_binding=complete_binding,
+    )
+
+
+class TestEntryPointDispatchRegistry:
+    def test_execution_go_accepted_by_entry_point(self) -> None:
+        ok, branch = validate_entry_point_go_token_v0(_EXEC_GO)
+        assert ok is True
+        assert branch == "EXECUTION_V0"
+
+    def test_dispatch_implementation_go_accepted_by_entry_point(self) -> None:
+        ok, branch = validate_entry_point_go_token_v0(_DISPATCH_IMPL_GO)
+        assert ok is True
+        assert branch == "DISPATCH_IMPLEMENTATION_V0"
+
+    def test_infrastructure_go_accepted_by_entry_point(self) -> None:
+        ok, branch = validate_entry_point_go_token_v0(_INFRA_GO)
+        assert ok is True
+        assert branch == "INFRASTRUCTURE_V0"
+
+
+class TestDigestBindingDuringDispatch:
+    def test_binding_digest_mismatch_rejected(self, complete_binding: dict) -> None:
+        stale = deepcopy(complete_binding)
+        stale["binding_digest"] = "f" * 64
+        ok, reasons = verify_ratified_digests_v0(stale)
+        assert ok is False
+        assert REASON_BINDING_DIGEST_MISMATCH in reasons
+
+    def test_dataset_digest_mismatch_rejected(self, complete_binding: dict) -> None:
+        stale = deepcopy(complete_binding)
+        stale["dataset_digest"] = "f" * 64
+        ok, reasons = verify_ratified_digests_v0(stale)
+        assert ok is False
+        assert REASON_DATASET_DIGEST_MISMATCH in reasons
+
+
+class TestDispatchWithoutEvaluation:
+    def test_infrastructure_go_cannot_execute_evaluation(self) -> None:
+        result = run_full_offline_economic_evaluation_v0(go_token=_INFRA_GO, repo_root=REPO_ROOT)
+        assert result.executed is False
+        assert REASON_GO_TOKEN_INVALID in result.reason_codes
+
+    def test_execution_dispatch_accepted_without_evaluation(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        dispatch = run_offline_economic_evaluation_execution_dispatch_v0(
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            go_token=_EXEC_GO,
+            versioned_binding=complete_binding,
+            verify_source_manifests=True,
+        )
+        assert dispatch.economic_evaluation_executed is False
+        assert dispatch.baseline_executed is False
+        assert dispatch.robustness_executed is False
+        assert dispatch.dispatch_accepted is True
+
+    def test_full_evaluation_routes_to_dispatch(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_full_offline_economic_evaluation_v0(
+            go_token=_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            verify_source_manifests=True,
+        )
+        assert result.executed is False
+        assert result.blocked is False
+        assert result.wiring_verified is True
+        assert REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION in result.reason_codes
+
+    def test_implementation_dry_run_rejects_execution_go(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_full_evaluation_entrypoint_dry_run_v1(
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            go_token=_EXEC_GO,
+        )
+        assert result.economic_evaluation_executed is False
+        assert REASON_ECONOMIC_EXECUTION_FORBIDDEN in result.reason_codes
+
+
+class TestDeterministicDispatchOutputs:
+    def test_repeated_fixture_execution_produces_identical_normalized_outputs(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        kwargs = {
+            "repo_root": REPO_ROOT,
+            "authorization_ratification": authorization_ratification,
+            "go_token": _EXEC_GO,
+            "versioned_binding": complete_binding,
+            "verify_source_manifests": True,
+        }
+        first = dispatch_result_to_dict(
+            run_offline_economic_evaluation_execution_dispatch_v0(**kwargs)
+        )
+        second = dispatch_result_to_dict(
+            run_offline_economic_evaluation_execution_dispatch_v0(**kwargs)
+        )
+        assert first == second
+
+    def test_canonical_dispatcher_invoked_exactly_once(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        with patch(
+            "src.research.trend_following_v2_offline_economic_evaluation_execution_v0."
+            "run_offline_economic_evaluation_execution_dispatch_v0"
+        ) as mocked:
+            mocked.return_value = run_offline_economic_evaluation_execution_dispatch_v0(
+                repo_root=REPO_ROOT,
+                authorization_ratification=authorization_ratification,
+                go_token=_EXEC_GO,
+                versioned_binding=complete_binding,
+                verify_source_manifests=True,
+            )
+            run_full_offline_economic_evaluation_v0(
+                go_token=_EXEC_GO,
+                repo_root=REPO_ROOT,
+                authorization_ratification=authorization_ratification,
+                versioned_binding=complete_binding,
+                verify_source_manifests=True,
+            )
+            assert mocked.call_count == 1
+
+
+class TestDispatchContractMaterialization:
+    def test_dispatch_contract_exports_required_owners(self) -> None:
+        contract = materialize_dispatch_contract_v0()
+        assert contract["economic_evaluation_executed"] is False
+        assert contract["baseline_executed"] is False
+        assert contract["robustness_executed"] is False
+        assert contract["execution_go_token"] == _EXEC_GO
+        assert contract["dispatch_implementation_go_token"] == _DISPATCH_IMPL_GO
+        assert contract["entry_point_status"] == "EXECUTION_DISPATCH_WIRING_V0"
+
+
+class TestRunnerAndMaterializerExist:
+    def test_runner_module_exists(self) -> None:
+        assert RUNNER_MODULE.is_file()
+
+    def test_materializer_module_exists(self) -> None:
+        assert MATERIALIZER_MODULE.is_file()
+
+    def test_dispatch_implementation_go_accepted_by_runner(self) -> None:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER_MODULE),
+                "--confirm",
+                _DISPATCH_IMPL_GO,
+                "--primary-worktree",
+                str(REPO_ROOT),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(proc.stdout)
+        assert payload["verdict"] == "EXECUTION_DISPATCH_IMPLEMENTATION_COMPLETE"
+        assert payload["economic_evaluation_executed"] is False
+
+
+class TestImportBoundary:
+    FORBIDDEN_RUNTIME_IMPORT_PREFIXES = (
+        "src.execution",
+        "src.scheduler",
+        "src.broker",
+    )
+
+    def test_no_runtime_imports_in_harness(self) -> None:
+        source = (
+            REPO_ROOT
+            / "src/research/trend_following_v2_offline_economic_evaluation_execution_v0.py"
+        ).read_text(encoding="utf-8")
+        for prefix in self.FORBIDDEN_RUNTIME_IMPORT_PREFIXES:
+            assert prefix not in source
+
+    def test_no_runtime_or_authority_effect(self) -> None:
+        assert AUTHORITY_EFFECT == "NONE"
+        assert RUNTIME_EFFECT == "NONE"

--- a/tests/research/test_trend_following_v2_offline_economic_evaluation_execution_infrastructure_v0.py
+++ b/tests/research/test_trend_following_v2_offline_economic_evaluation_execution_infrastructure_v0.py
@@ -19,6 +19,7 @@ from src.research.trend_following_v2_offline_economic_evaluation_execution_v0 im
     RATIFIED_DATASET_DIGEST,
     REASON_BINDING_DIGEST_MISMATCH,
     REASON_DATASET_DIGEST_MISMATCH,
+    REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION,
     REASON_ECONOMIC_EXECUTION_FORBIDDEN,
     REASON_GO_TOKEN_INVALID,
     RUNNER_SCRIPT,
@@ -203,7 +204,7 @@ class TestContractSmokeAndDryRun:
             go_token=EXECUTION_GO_TOKEN,
         )
         assert result.precheck_passed is False
-        assert REASON_GO_TOKEN_INVALID in result.reason_codes
+        assert REASON_ECONOMIC_EXECUTION_FORBIDDEN in result.reason_codes
 
 
 class TestNoExecutionDuringInfrastructure:
@@ -227,8 +228,9 @@ class TestNoExecutionDuringInfrastructure:
             versioned_binding=complete_binding,
         )
         assert result.executed is False
+        assert result.blocked is False
         assert result.wiring_verified is True
-        assert REASON_ECONOMIC_EXECUTION_FORBIDDEN in result.reason_codes
+        assert REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION in result.reason_codes
 
 
 class TestMaterializationContract:
@@ -236,7 +238,7 @@ class TestMaterializationContract:
         contract = materialize_execution_contract_v0()
         assert contract["economic_evaluation_executed"] is False
         assert contract["binding_digest"] == RATIFIED_BINDING_DIGEST
-        assert contract["entry_point_status"] == "EXECUTION_INFRASTRUCTURE_WIRING_V0"
+        assert contract["entry_point_status"] == "EXECUTION_DISPATCH_WIRING_V0"
 
     def test_entrypoint_result_roundtrip(
         self,


### PR DESCRIPTION
## Summary
- Fix the fail-closed dispatch gap where `GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0` terminated with `ECONOMIC_EXECUTION_FORBIDDEN_IN_INFRASTRUCTURE_SCOPE` despite valid authorization and wiring.
- Add `run_offline_economic_evaluation_execution_dispatch_v0` to route the authorized execution GO token to the canonical offline baseline owner (`versioned_final_fleet_bindings_offline_economic_evaluation_v0._run_candidate_with_runtime_config_v0`) while stopping before economic evaluation.
- Preserve infrastructure-only fail-closed behavior for unauthorized GO tokens and infrastructure dry-run paths.

## Root cause
`run_full_offline_economic_evaluation_v0` returned `ECONOMIC_EXECUTION_FORBIDDEN_IN_INFRASTRUCTURE_SCOPE` for the authorized execution GO token instead of binding dispatch to the canonical offline economic evaluation owner.

## Test plan
- [x] `tests/research/test_trend_following_v2_offline_economic_evaluation_execution_dispatch_implementation_v0.py`
- [x] `tests/research/test_trend_following_v2_offline_economic_evaluation_execution_infrastructure_v0.py`
- [x] `tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py`
- [x] Manifest-verified evidence bundle (`MANIFEST_VERIFY_RC=0`, `SOURCE_MANIFEST_VERIFY_RC=0`)


Made with [Cursor](https://cursor.com)