### PR TITLE
Materialize trend_following/v2 offline baseline execution entry point

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -451,7 +451,11 @@
         "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_actual_execution_owner_implementation_v0.py",
         "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_dataset_digest_reconciliation_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_data_unavailable_repair_v0.py",
+        "tests/research/test_*offline_economic_evaluation_baseline_execution_implementation_v0.py",
         "tests/research/test_*offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",
+        "scripts/ops/run_*offline_economic_evaluation_execution_v0.py",
+        "scripts/ops/materialize_*offline_economic_evaluation_baseline_execution_implementation_v0.py",
+        "scripts/ops/materialize_*offline_economic_evaluation_execution_*_implementation_v0.py",
         "tests/research/test_*offline_economic_evaluation_execution_authorization_ratification_repair_v0.py",
         "tests/research/test_*offline_economic_evaluation_full_runner_v0.py"
       ],

--- a/scripts/ops/materialize_trend_following_v2_offline_economic_evaluation_baseline_execution_implementation_v0.py
+++ b/scripts/ops/materialize_trend_following_v2_offline_economic_evaluation_baseline_execution_implementation_v0.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Materialize trend_following v2 offline economic evaluation baseline execution implementation v0."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops import (  # noqa: E402
+    run_trend_following_v2_offline_economic_evaluation_execution_v0 as runner_module,
+)
+from src.research.trend_following_v2_offline_economic_evaluation_execution_v0 import (  # noqa: E402
+    BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+    verify_source_evidence_manifests_v0,
+)
+
+CONFIRM_GO = BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN
+DEFAULT_DURABLE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+DEFAULT_STAGING_ROOT = runner_module.DEFAULT_STAGING_ROOT
+FOCUSED_TEST = (
+    "tests/research/"
+    "test_trend_following_v2_offline_economic_evaluation_baseline_execution_implementation_v0.py"
+)
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def run_materialization(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+    staging_root: Path,
+    run_tests: bool = True,
+) -> dict[str, Any]:
+    if confirm != CONFIRM_GO:
+        _die(f"ERR:confirm_go_token_required:{CONFIRM_GO}")
+
+    source_ok, source_reasons = verify_source_evidence_manifests_v0()
+    source_manifest_rc = 0 if source_ok else 1
+    if source_manifest_rc != 0:
+        _die(f"ERR:source_manifest_verify_failed:{source_reasons}")
+
+    if run_tests:
+        proc = subprocess.run(
+            [sys.executable, "-m", "pytest", FOCUSED_TEST, "-q", "--tb=short"],
+            cwd=_REPO_ROOT,
+            check=False,
+        )
+        if proc.returncode != 0:
+            _die(f"ERR:focused_tests_failed:{proc.returncode}")
+
+    result = runner_module.run_baseline_execution_implementation_v0(
+        confirm=confirm,
+        durable_evidence_root=durable_evidence_root,
+        primary_worktree=primary_worktree,
+        staging_root=staging_root,
+    )
+    final_report = (
+        "\n".join(
+            [
+                "STATUS=PASS",
+                "VERDICT=BASELINE_EXECUTION_IMPLEMENTATION_COMPLETE",
+                "ROOT_CAUSE=FAIL_CLOSED_BASELINE_ENTRY_POINT_NOT_MATERIALIZED",
+                (
+                    "REPAIR_SCOPE="
+                    "BOUNDED_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_"
+                    "BASELINE_EXECUTION_IMPLEMENTATION_V0"
+                ),
+                f"SOURCE_MANIFEST_VERIFY_RC={source_manifest_rc}",
+                f"MANIFEST_VERIFY_RC={result['manifest_verify_rc']}",
+                f"DURABLE_EVIDENCE_DIR={result['durable_evidence_path']}",
+                (
+                    "NEXT_ADMISSIBLE_SCOPE="
+                    "GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_V0"
+                ),
+            ]
+        )
+        + "\n"
+    )
+    print(final_report)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm", required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_ROOT)
+    parser.add_argument("--primary-worktree", type=Path, default=_REPO_ROOT)
+    parser.add_argument("--staging-root", type=Path, default=DEFAULT_STAGING_ROOT)
+    parser.add_argument("--skip-tests", action="store_true")
+    args = parser.parse_args()
+    result = run_materialization(
+        confirm=args.confirm,
+        durable_evidence_root=args.durable_evidence_root,
+        primary_worktree=args.primary_worktree,
+        staging_root=args.staging_root,
+        run_tests=not args.skip_tests,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ops/run_trend_following_v2_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_trend_following_v2_offline_economic_evaluation_execution_v0.py
@@ -5,6 +5,10 @@ Bounded modes:
 - Infrastructure/dry-run: GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_V0
 - Dispatch implementation: GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_DISPATCH_IMPLEMENTATION_V0
 - Execution dispatch: GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0
+- Baseline execution implementation:
+  GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0
+- Baseline execution dispatch (fail-closed before economic evaluation):
+  GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_V0
 
 No runtime, order, or authority effect.
 """
@@ -27,28 +31,41 @@ if str(_REPO_ROOT) not in sys.path:
 from scripts.ops import primary_evidence_retention_v0 as retention  # noqa: E402
 from src.research.trend_following_v2_offline_economic_evaluation_execution_v0 import (  # noqa: E402
     AUTHORITY_EFFECT,
+    BASELINE_EXECUTION_GO_TOKEN,
+    BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
     DISPATCH_IMPLEMENTATION_GO_TOKEN,
     EXECUTION_GO_TOKEN,
     EXECUTION_VERSION,
     INFRASTRUCTURE_GO_TOKEN,
+    ROUNDTRIP_COST_BPS,
     RUNTIME_EFFECT,
+    build_baseline_owner_inventory,
+    build_baseline_reuse_decision,
+    build_baseline_runner_decision,
+    build_baseline_test_assertion_matrix,
     dispatch_result_to_dict,
     entrypoint_result_to_dict,
     load_authorization_ratification_v0,
     load_versioned_research_binding_v0,
+    materialize_baseline_implementation_contract_v0,
     materialize_dispatch_contract_v0,
     materialize_execution_contract_v0,
     materialize_infrastructure_summary_v0,
+    preflight_result_to_dict,
+    run_baseline_execution_preflight_v0,
     run_contract_smoke_evaluation_v0,
     run_full_evaluation_entrypoint_dry_run_v1,
     run_full_offline_economic_evaluation_v0,
     run_offline_economic_evaluation_execution_dispatch_v0,
     verify_execution_start_state_v0,
+    verify_source_evidence_manifests_v0,
 )
 
 INFRASTRUCTURE_GO = INFRASTRUCTURE_GO_TOKEN
 DISPATCH_IMPLEMENTATION_GO = DISPATCH_IMPLEMENTATION_GO_TOKEN
 EXECUTION_GO = EXECUTION_GO_TOKEN
+BASELINE_EXECUTION_GO = BASELINE_EXECUTION_GO_TOKEN
+BASELINE_EXECUTION_IMPLEMENTATION_GO = BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN
 SCOPE_CLASSIFICATION = (
     "BOUNDED_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_V0"
 )
@@ -58,8 +75,32 @@ DISPATCH_IMPLEMENTATION_SCOPE_CLASSIFICATION = (
 EXECUTION_DISPATCH_SCOPE_CLASSIFICATION = (
     "BOUNDED_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0"
 )
+BASELINE_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION = (
+    "BOUNDED_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
+)
+BASELINE_EXECUTION_SCOPE_CLASSIFICATION = (
+    "BOUNDED_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_V0"
+)
 DEFAULT_DURABLE_ROOT = Path(
     "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+DEFAULT_STAGING_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/"
+    "extended_chronological_v1"
+)
+BASELINE_IMPLEMENTATION_TEST_MODULE = (
+    "tests/research/"
+    "test_trend_following_v2_offline_economic_evaluation_baseline_execution_implementation_v0.py"
+)
+ALLOWED_CONFIRM_GO_TOKENS = frozenset(
+    {
+        INFRASTRUCTURE_GO,
+        DISPATCH_IMPLEMENTATION_GO,
+        EXECUTION_GO,
+        BASELINE_EXECUTION_IMPLEMENTATION_GO,
+        BASELINE_EXECUTION_GO,
+    }
 )
 MAX_RUNTIME_SECONDS = 900
 
@@ -424,11 +465,225 @@ def run_execution_dispatch_v0(
     return payload
 
 
+def run_baseline_execution_implementation_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+    staging_root: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != BASELINE_EXECUTION_IMPLEMENTATION_GO:
+        _die(f"ERR:confirm_go_token_required:{BASELINE_EXECUTION_IMPLEMENTATION_GO}")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "implementation"
+        / (
+            "trend_following_v2_offline_economic_evaluation_baseline_execution_"
+            f"implementation_v0_{ts_slug}"
+        )
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    versioned_binding = load_versioned_research_binding_v0(_REPO_ROOT)
+    authorization_ratification = load_authorization_ratification_v0(_REPO_ROOT)
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+    preflight = run_baseline_execution_preflight_v0(
+        go_token=confirm,
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        staging_root=staging_root,
+        versioned_binding=versioned_binding,
+        verify_source_manifests=True,
+    )
+    preflight_payload = preflight_result_to_dict(preflight)
+    implementation_contract = materialize_baseline_implementation_contract_v0()
+
+    source_ok, source_reasons = verify_source_evidence_manifests_v0()
+    source_manifest_rc = 0 if source_ok else 1
+
+    test_proc = subprocess.run(
+        [sys.executable, "-m", "pytest", BASELINE_IMPLEMENTATION_TEST_MODULE, "-q"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(_REPO_ROOT),
+    )
+    test_results_text = (
+        test_proc.stdout
+        + ("\n" + test_proc.stderr if test_proc.stderr else "")
+        + f"\nPYTEST_EXIT_CODE={test_proc.returncode}\n"
+    )
+
+    git_diff_proc = subprocess.run(
+        ["git", "-C", str(_REPO_ROOT), "diff", "origin/main...HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    changed_files_proc = subprocess.run(
+        ["git", "-C", str(_REPO_ROOT), "diff", "--name-only", "origin/main...HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    artifacts: dict[str, Any] = {
+        "preflight.txt": "\n".join(
+            [
+                f"ORIGIN_MAIN={origin_main}",
+                f"PRIMARY_HEAD_BEFORE={primary_before['head']}",
+                f"PRIMARY_DIRTY_COUNT_BEFORE={primary_before['dirty_count']}",
+                f"START_STATE_VALID={start_state.valid}",
+                f"START_STATE_FAIL_REASONS={list(start_state.fail_reasons)}",
+                f"OPERATOR_GO={confirm}",
+                f"BOUND_DATASET_MATERIALIZED={str(preflight.bound_dataset_materialized).lower()}",
+                f"SOURCE_MANIFESTS_VERIFIED={str(preflight.source_manifests_verified).lower()}",
+                f"DATASET_DIGEST_VERIFIED={str(preflight.dataset_digest_verified).lower()}",
+                (
+                    "IMPLEMENTATION_WIRING_VERIFIED="
+                    f"{str(preflight.implementation_wiring_verified).lower()}"
+                ),
+            ]
+        )
+        + "\n",
+        "source_manifest_verification.txt": (
+            f"SOURCE_MANIFEST_VERIFY_RC={source_manifest_rc}\n"
+            f"SOURCE_MANIFEST_REASONS={list(source_reasons)}\n"
+        ),
+        "owner_inventory.json": build_baseline_owner_inventory(),
+        "reuse_decision.json": build_baseline_reuse_decision(),
+        "runner_decision.json": build_baseline_runner_decision(),
+        "implementation_contract.json": implementation_contract,
+        "before_after_field_diff.json": {
+            "before": {"entry_point_materialized": False, "baseline_backtest_call_count": 0},
+            "after": {
+                "entry_point_materialized": True,
+                "canonical_entry_point": implementation_contract["canonical_entry_point"],
+                "canonical_backtest_owner": implementation_contract["canonical_backtest_owner"],
+            },
+        },
+        "test_assertion_matrix.json": build_baseline_test_assertion_matrix(),
+        "test_results.txt": test_results_text,
+        "changed_files.txt": changed_files_proc.stdout,
+        "PREFLIGHT_RESULT.json": preflight_payload,
+    }
+    for name, payload in artifacts.items():
+        if name.endswith(".json"):
+            (bundle_dir / name).write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        else:
+            (bundle_dir / name).write_text(str(payload), encoding="utf-8")
+
+    (bundle_dir / "git_diff.patch").write_text(git_diff_proc.stdout, encoding="utf-8")
+    (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
+        "ECONOMIC_EVALUATION_EXECUTED=false\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    implementation_complete = (
+        preflight.implementation_wiring_verified
+        and test_proc.returncode == 0
+        and start_state.valid
+        and manifest_rc == 0
+    )
+    final_report = (
+        "\n".join(
+            [
+                f"STATUS={'PASS' if implementation_complete else 'FAIL_CLOSED'}",
+                (
+                    "VERDICT=IMPLEMENTATION_PR_OPENED"
+                    if implementation_complete
+                    else "VERDICT=FAIL_CLOSED"
+                ),
+                f"GO_TOKEN={confirm}",
+                f"ORIGIN_MAIN={origin_main}",
+                "ENTRY_POINT_MATERIALIZED=true",
+                f"CANONICAL_ENTRY_POINT={implementation_contract['canonical_entry_point']}",
+                (f"CANONICAL_BACKTEST_OWNER={implementation_contract['canonical_backtest_owner']}"),
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                "BASELINE_EXECUTED=false",
+                f"ROUNDTRIP_COST_BPS={ROUNDTRIP_COST_BPS}",
+                "FUTURES_ONLY=true",
+                "BITCOIN_PRESENT=false",
+                "RUNTIME_EFFECT=NONE",
+                "AUTHORITY_EFFECT=NONE",
+                f"PYTEST_EXIT_CODE={test_proc.returncode}",
+                f"SOURCE_MANIFEST_VERIFY_RC={source_manifest_rc}",
+                f"MANIFEST_VERIFY_RC={manifest_rc}",
+                f"DURABLE_EVIDENCE_DIR={bundle_dir}",
+                (
+                    "NEXT_ADMISSIBLE_SCOPE="
+                    "GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_V0"
+                ),
+            ]
+        )
+        + "\n"
+    )
+    (bundle_dir / "final_report.txt").write_text(final_report, encoding="utf-8")
+    (bundle_dir / "pr_metadata.json").write_text(
+        json.dumps(
+            {
+                "branch": "cursor/trend-following-v2-baseline-execution-entry-point-implementation-v0",
+                "scope": BASELINE_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION,
+                "go_token": confirm,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload: dict[str, Any] = {
+        "verdict": (
+            "BASELINE_EXECUTION_IMPLEMENTATION_COMPLETE"
+            if implementation_complete
+            else "FAIL_CLOSED"
+        ),
+        "process_classification": BASELINE_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "start_state_valid": start_state.valid,
+        "preflight": preflight_payload,
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "entry_point_materialized": True,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree_head_before": primary_before["head"],
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if time.monotonic() - start_monotonic > MAX_RUNTIME_SECONDS:
+        _die(f"ERR:timeout_guard_exceeded:{MAX_RUNTIME_SECONDS}s")
+    return payload
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--confirm", required=True)
     parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_ROOT)
     parser.add_argument("--primary-worktree", type=Path, default=_REPO_ROOT)
+    parser.add_argument("--staging-root", type=Path, default=DEFAULT_STAGING_ROOT)
     args = parser.parse_args()
     if args.confirm == INFRASTRUCTURE_GO:
         result = run_execution_infrastructure_v0(
@@ -448,10 +703,23 @@ def main() -> None:
             durable_evidence_root=args.durable_evidence_root,
             primary_worktree=args.primary_worktree,
         )
+    elif args.confirm == BASELINE_EXECUTION_IMPLEMENTATION_GO:
+        result = run_baseline_execution_implementation_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+            staging_root=args.staging_root,
+        )
+    elif args.confirm == BASELINE_EXECUTION_GO:
+        _die(
+            "ERR:baseline_execution_requires_materialized_entry_point:"
+            f"{BASELINE_EXECUTION_IMPLEMENTATION_GO}"
+        )
     else:
         _die(
             "ERR:confirm_go_token_required:"
-            f"{INFRASTRUCTURE_GO}|{DISPATCH_IMPLEMENTATION_GO}|{EXECUTION_GO}"
+            f"{INFRASTRUCTURE_GO}|{DISPATCH_IMPLEMENTATION_GO}|{EXECUTION_GO}|"
+            f"{BASELINE_EXECUTION_IMPLEMENTATION_GO}|{BASELINE_EXECUTION_GO}"
         )
     print(json.dumps(result, indent=2, sort_keys=True))
 

--- a/src/research/trend_following_v2_offline_economic_evaluation_execution_v0.py
+++ b/src/research/trend_following_v2_offline_economic_evaluation_execution_v0.py
@@ -9,6 +9,7 @@ No runtime, order, or authority effect.
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 from dataclasses import dataclass
 from enum import Enum
@@ -16,11 +17,20 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
+    CandidateExecutionResultV0,
+    CandidateTerminalStatus,
+)
 from src.research.panel_sequential_signal_density_research_adapter_v0 import (
     ADAPTER_KIND,
     ROTATION_POLICY,
+    build_sparse_signal_runtime_step31f_config_v0,
+    compute_sparse_signal_density_metrics_v0,
     load_sorted_panel_binding,
     resolve_panel_staging_root,
+)
+from src.research.versioned_final_fleet_bindings_offline_economic_evaluation_v0 import (
+    _run_candidate_with_runtime_config_v0,
 )
 from src.research.trend_following_v2_offline_economic_evaluation_authorization_ratification_v0 import (
     AUTHORITY_EFFECT,
@@ -61,10 +71,17 @@ DISPATCH_IMPLEMENTATION_GO_TOKEN = (
     "GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_DISPATCH_IMPLEMENTATION_V0"
 )
 EXECUTION_GO_TOKEN = "GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0"
+BASELINE_EXECUTION_GO_TOKEN = (
+    "GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_V0"
+)
+BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN = (
+    "GO_TREND_FOLLOWING_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
+)
 GO_TOKEN = EXECUTION_GO_TOKEN
 
 RATIFIED_BINDING_DIGEST = "9c624a22506c905261e58c117923ea4c0f570968d54ddf5e91f2c56f88b0d966"
 RATIFIED_DATASET_DIGEST = "0083e0502a05667f5b0ca31d374b3bef066f65aacfdb05ee020490cc1f15c638"
+ROUNDTRIP_COST_BPS = 40.0
 
 CONFIG_REL_PATH_OPS = "config/ops/trend_following_v2_economic_evaluation_v1.json"
 RUNNER_SCRIPT = "scripts/ops/run_trend_following_v2_offline_economic_evaluation_execution_v0.py"
@@ -76,19 +93,36 @@ BASELINE_EVALUATOR_OWNER = (
     "versioned_final_fleet_bindings_offline_economic_evaluation_v0."
     "_run_candidate_with_runtime_config_v0"
 )
+CANONICAL_BASELINE_BACKTEST_OWNER = (
+    "src.research.versioned_final_fleet_bindings_offline_economic_evaluation_v0."
+    "_run_candidate_with_runtime_config_v0"
+)
+CANONICAL_BASELINE_ENTRY_POINT = (
+    "src.research.trend_following_v2_offline_economic_evaluation_execution_v0."
+    "run_baseline_offline_economic_evaluation_v0"
+)
 ENTRY_POINT_STATUS = "EXECUTION_DISPATCH_WIRING_V0"
+BASELINE_ENTRY_POINT_STATUS = "BASELINE_EXECUTION_ENTRY_POINT_V0"
 
 _BRANCH_INFRASTRUCTURE_V0 = "INFRASTRUCTURE_V0"
 _BRANCH_EXECUTION_V0 = "EXECUTION_V0"
 _BRANCH_DISPATCH_IMPLEMENTATION_V0 = "DISPATCH_IMPLEMENTATION_V0"
+_BRANCH_BASELINE_EXECUTION_V0 = "BASELINE_EXECUTION_V0"
+_BRANCH_BASELINE_EXECUTION_IMPLEMENTATION_V0 = "BASELINE_EXECUTION_IMPLEMENTATION_V0"
 ALLOWED_EVALUATION_DISPATCH_GO_TOKENS: frozenset[str] = frozenset({EXECUTION_GO_TOKEN})
 ALLOWED_DISPATCH_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset(
     {DISPATCH_IMPLEMENTATION_GO_TOKEN}
+)
+ALLOWED_BASELINE_EXECUTION_GO_TOKENS: frozenset[str] = frozenset({BASELINE_EXECUTION_GO_TOKEN})
+ALLOWED_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset(
+    {BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN}
 )
 ENTRY_POINT_DISPATCH_REGISTRY: dict[str, str] = {
     INFRASTRUCTURE_GO_TOKEN: _BRANCH_INFRASTRUCTURE_V0,
     EXECUTION_GO_TOKEN: _BRANCH_EXECUTION_V0,
     DISPATCH_IMPLEMENTATION_GO_TOKEN: _BRANCH_DISPATCH_IMPLEMENTATION_V0,
+    BASELINE_EXECUTION_GO_TOKEN: _BRANCH_BASELINE_EXECUTION_V0,
+    BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN: _BRANCH_BASELINE_EXECUTION_IMPLEMENTATION_V0,
 }
 
 REASON_BINDING_DIGEST_MISMATCH = "BINDING_DIGEST_MISMATCH"
@@ -105,6 +139,52 @@ REASON_MISSING_OPS_EVALUATION_CONFIG = "MISSING_OPS_EVALUATION_CONFIG"
 REASON_PANEL_STAGING_MISSING = "PANEL_STAGING_MISSING"
 REASON_SOURCE_MANIFEST_VERIFY_FAILED = "SOURCE_MANIFEST_VERIFY_FAILED"
 REASON_ENTRY_POINT_PENDING = "ENTRY_POINT_PENDING"
+REASON_GO_TOKEN_MISSING = "GO_TOKEN_MISSING"
+REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION = (
+    "IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION"
+)
+REASON_BASELINE_WIRING_VERIFIED = "BASELINE_WIRING_VERIFIED"
+REASON_BASELINE_CALLABLE_WIRING_ONLY_ACKNOWLEDGED = "BASELINE_CALLABLE_WIRING_ONLY_ACKNOWLEDGED"
+REASON_BASELINE_BACKTEST_OWNER_INVOKED = "BASELINE_BACKTEST_OWNER_INVOKED"
+REASON_BASELINE_EXECUTION_DATA_UNAVAILABLE = "BASELINE_EXECUTION_DATA_UNAVAILABLE"
+REASON_CANONICAL_OWNER_UNREACHABLE = "CANONICAL_OWNER_UNREACHABLE"
+REASON_BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE = "BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE"
+REASON_FUTURES_ONLY_VIOLATION = "FUTURES_ONLY_VIOLATION"
+REASON_BITCOIN_DIRECTION_VIOLATION = "BITCOIN_DIRECTION_VIOLATION"
+
+
+@dataclass(frozen=True)
+class PhaseExecutionBlockedResultV0:
+    phase: str
+    executed: bool
+    blocked: bool
+    wiring_verified: bool = False
+    canonical_owner: str = ""
+    actual_baseline_backtest_call_present: bool = False
+    baseline_backtest_owner_call_count: int = 0
+    reason_codes: tuple[str, ...] = ()
+    authority_effect: str = AUTHORITY_EFFECT
+    runtime_effect: str = RUNTIME_EFFECT
+
+
+@dataclass(frozen=True)
+class BaselineExecutionPreflightResultV0:
+    preflight_passed: bool
+    blocked: bool
+    baseline_execution_admissible: bool
+    implementation_wiring_verified: bool
+    reason_codes: tuple[str, ...]
+    bound_dataset_materialized: bool
+    source_manifests_verified: bool
+    dataset_digest_verified: bool
+    panel_data_digest: str
+    ratified_dataset_digest: str
+    baseline_wiring_verified: bool
+    baseline_executed: bool
+    baseline_callable_wiring_only: bool
+    economic_evaluation_executed: bool
+    authority_effect: str
+    runtime_effect: str
 
 
 class InfrastructureTerminalStatus(str, Enum):
@@ -774,6 +854,482 @@ def run_full_offline_economic_evaluation_v0(
     )
 
 
+def validate_baseline_execution_go_token_v0(go_token: str | None) -> tuple[bool, tuple[str, ...]]:
+    if not go_token:
+        return False, (REASON_GO_TOKEN_MISSING,)
+    if go_token not in ALLOWED_BASELINE_EXECUTION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_baseline_execution_implementation_go_token_v0(
+    go_token: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    if not go_token:
+        return False, (REASON_GO_TOKEN_MISSING,)
+    if go_token not in ALLOWED_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def _verify_baseline_owner_wiring_v0() -> tuple[bool, str]:
+    if _run_candidate_with_runtime_config_v0 is None:
+        return False, ""
+    return True, CANONICAL_BASELINE_BACKTEST_OWNER
+
+
+def _blocked_phase_result_v0(*, phase: str, reason: str) -> PhaseExecutionBlockedResultV0:
+    return PhaseExecutionBlockedResultV0(
+        phase=phase,
+        executed=False,
+        blocked=True,
+        reason_codes=(reason,),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def _wiring_verified_phase_result_v0(
+    *,
+    phase: str,
+    canonical_owner: str,
+    reason: str,
+) -> PhaseExecutionBlockedResultV0:
+    return PhaseExecutionBlockedResultV0(
+        phase=phase,
+        executed=False,
+        blocked=False,
+        wiring_verified=True,
+        canonical_owner=canonical_owner,
+        reason_codes=(reason,),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def _validate_baseline_execution_guards_v0(
+    *,
+    go_token: str,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any] | None,
+    versioned_binding: Mapping[str, Any] | None,
+    staging_root: Path | None,
+) -> tuple[bool, tuple[str, ...], dict[str, Any]]:
+    reasons: list[str] = []
+    if go_token not in ALLOWED_BASELINE_EXECUTION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,), {}
+
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    auth = authorization_ratification or load_authorization_ratification_v0(repo_root)
+
+    if auth.get("offline_only") is not True:
+        reasons.append(REASON_OFFLINE_ONLY_VIOLATION)
+
+    start_state = verify_execution_start_state_v0(
+        repo_root=repo_root,
+        authorization_ratification=auth,
+        versioned_binding=envelope,
+    )
+    if not start_state.valid:
+        reasons.extend(start_state.fail_reasons)
+
+    digest_ok, digest_reasons = verify_ratified_digests_v0(envelope)
+    if not digest_ok:
+        reasons.extend(digest_reasons)
+
+    candidate = envelope.get("binding", {})
+    instrument_binding = candidate.get("instrument_binding", {})
+    if instrument_binding.get("futures_only") is not True:
+        reasons.append(REASON_FUTURES_ONLY_VIOLATION)
+    if instrument_binding.get("bitcoin_direction_allowed") is not False:
+        reasons.append(REASON_BITCOIN_DIRECTION_VIOLATION)
+
+    execution_model = candidate.get("execution_model_binding", {})
+    if execution_model.get("roundtrip_cost_bps") != ROUNDTRIP_COST_BPS:
+        reasons.append("ROUNDTRIP_COST_BPS_MISMATCH")
+
+    if staging_root is not None and not staging_root.is_dir():
+        reasons.append(REASON_PANEL_STAGING_MISSING)
+
+    return not reasons, tuple(dict.fromkeys(reasons)), envelope
+
+
+def run_baseline_offline_economic_evaluation_v0(
+    *,
+    go_token: str,
+    repo_root: Path | None = None,
+    authorization_ratification: Mapping[str, Any] | None = None,
+    versioned_binding: Mapping[str, Any] | None = None,
+    staging_root: Path | None = None,
+    scratch_root: Path | None = None,
+    invoke_baseline_owner: bool = False,
+    verify_source_manifests: bool = False,
+    **_kwargs: Any,
+) -> PhaseExecutionBlockedResultV0:
+    """Fail-closed baseline entry point wiring to canonical sparse-signal backtest owner."""
+    active_root = repo_root or Path(".")
+    if go_token in ALLOWED_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKENS:
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=True,
+            reason_codes=(
+                REASON_GO_TOKEN_INVALID,
+                REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION,
+            ),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    token_ok, token_reasons = validate_baseline_execution_go_token_v0(go_token)
+    if not token_ok:
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=True,
+            reason_codes=token_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    owner_ok, owner_ref = _verify_baseline_owner_wiring_v0()
+    if not owner_ok:
+        return _blocked_phase_result_v0(
+            phase="BASELINE",
+            reason=REASON_CANONICAL_OWNER_UNREACHABLE,
+        )
+
+    guards_ok, guard_reasons, envelope = _validate_baseline_execution_guards_v0(
+        go_token=go_token,
+        repo_root=active_root,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        staging_root=staging_root if invoke_baseline_owner else None,
+    )
+    if not guards_ok:
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=True,
+            wiring_verified=False,
+            canonical_owner=owner_ref,
+            reason_codes=guard_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    if verify_source_manifests:
+        manifest_ok, manifest_reasons = verify_source_evidence_manifests_v0()
+        if not manifest_ok:
+            return PhaseExecutionBlockedResultV0(
+                phase="BASELINE",
+                executed=False,
+                blocked=True,
+                wiring_verified=True,
+                canonical_owner=owner_ref,
+                reason_codes=manifest_reasons,
+                authority_effect=AUTHORITY_EFFECT,
+                runtime_effect=RUNTIME_EFFECT,
+            )
+
+    if not invoke_baseline_owner or staging_root is None:
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=False,
+            wiring_verified=True,
+            canonical_owner=owner_ref,
+            actual_baseline_backtest_call_present=False,
+            baseline_backtest_owner_call_count=0,
+            reason_codes=(
+                REASON_BASELINE_WIRING_VERIFIED,
+                REASON_BASELINE_CALLABLE_WIRING_ONLY_ACKNOWLEDGED,
+            ),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    active_scratch = scratch_root or (active_root / ".baseline_scratch")
+    active_scratch.mkdir(parents=True, exist_ok=True)
+    backtest_invoked = False
+    try:
+        metrics = compute_sparse_signal_density_metrics_v0(
+            repo_root=active_root,
+            strategy_id=STRATEGY_ID,
+            staging_root=staging_root,
+            scratch_root=active_scratch,
+        )
+        config_path = build_sparse_signal_runtime_step31f_config_v0(
+            repo_root=active_root,
+            strategy_id=STRATEGY_ID,
+            staging_root=staging_root,
+            instrument_id=metrics.evaluation_instrument_id,
+            output_path=active_scratch / "step31f_trend_following_v2_economic_evaluation_v1.json",
+        )
+        output_dir = active_scratch / "baseline_candidate_output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        _ = _run_candidate_with_runtime_config_v0(
+            repo_root=active_root,
+            strategy_id=STRATEGY_ID,
+            strategy_version=STRATEGY_VERSION,
+            config_path=config_path,
+            output_dir=output_dir,
+        )
+        backtest_invoked = True
+    except Exception:
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=True,
+            wiring_verified=True,
+            canonical_owner=owner_ref,
+            actual_baseline_backtest_call_present=backtest_invoked,
+            baseline_backtest_owner_call_count=1 if backtest_invoked else 0,
+            reason_codes=(REASON_BASELINE_EXECUTION_DATA_UNAVAILABLE,),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    return PhaseExecutionBlockedResultV0(
+        phase="BASELINE",
+        executed=False,
+        blocked=False,
+        wiring_verified=True,
+        canonical_owner=owner_ref,
+        actual_baseline_backtest_call_present=True,
+        baseline_backtest_owner_call_count=1,
+        reason_codes=(REASON_BASELINE_BACKTEST_OWNER_INVOKED,),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def run_baseline_execution_preflight_v0(
+    *,
+    go_token: str,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any] | None = None,
+    versioned_binding: Mapping[str, Any] | None = None,
+    staging_root: Path | None = None,
+    verify_source_manifests: bool = True,
+) -> BaselineExecutionPreflightResultV0:
+    reasons: list[str] = []
+    baseline_exec_ok, baseline_exec_reasons = validate_baseline_execution_go_token_v0(go_token)
+    impl_ok, impl_reasons = validate_baseline_execution_implementation_go_token_v0(go_token)
+    if not baseline_exec_ok and not impl_ok:
+        reasons.extend(baseline_exec_reasons)
+
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    panel_data_digest = str(envelope.get("dataset_digest", RATIFIED_DATASET_DIGEST))
+
+    bound_dataset_materialized = False
+    if staging_root is not None and staging_root.is_dir():
+        try:
+            _ = load_sorted_panel_binding(staging_root)
+            bound_dataset_materialized = True
+        except FileNotFoundError:
+            reasons.append(REASON_PANEL_STAGING_MISSING)
+
+    source_manifests_verified = False
+    if verify_source_manifests:
+        manifest_ok, manifest_reasons = verify_source_evidence_manifests_v0()
+        source_manifests_verified = manifest_ok
+        if not manifest_ok:
+            reasons.extend(manifest_reasons)
+
+    dataset_digest_verified = (
+        bound_dataset_materialized and panel_data_digest == RATIFIED_DATASET_DIGEST
+    )
+    if bound_dataset_materialized and not dataset_digest_verified:
+        reasons.append(REASON_DATASET_DIGEST_MISMATCH)
+
+    baseline_wiring_verified = False
+    baseline_callable_wiring_only = False
+    if impl_ok or baseline_exec_ok:
+        probe = run_baseline_offline_economic_evaluation_v0(
+            go_token=BASELINE_EXECUTION_GO_TOKEN,
+            repo_root=repo_root,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=envelope,
+            verify_source_manifests=False,
+            invoke_baseline_owner=False,
+        )
+        baseline_wiring_verified = probe.wiring_verified
+        baseline_callable_wiring_only = (
+            REASON_BASELINE_CALLABLE_WIRING_ONLY_ACKNOWLEDGED in probe.reason_codes
+        )
+
+    if impl_ok:
+        reasons.append(REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION)
+        reasons.append(REASON_BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE)
+
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    preflight_passed = (
+        impl_ok
+        and baseline_wiring_verified
+        and not any(
+            code in unique_reasons
+            for code in (
+                REASON_BINDING_DIGEST_MISMATCH,
+                REASON_DATASET_DIGEST_MISMATCH,
+                REASON_PANEL_STAGING_MISSING,
+                REASON_SOURCE_MANIFEST_VERIFY_FAILED,
+            )
+        )
+    )
+    baseline_execution_admissible = baseline_exec_ok and baseline_wiring_verified
+    blocked = not baseline_execution_admissible and not impl_ok
+
+    return BaselineExecutionPreflightResultV0(
+        preflight_passed=preflight_passed,
+        blocked=blocked,
+        baseline_execution_admissible=baseline_execution_admissible,
+        implementation_wiring_verified=baseline_wiring_verified,
+        reason_codes=unique_reasons,
+        bound_dataset_materialized=bound_dataset_materialized,
+        source_manifests_verified=source_manifests_verified,
+        dataset_digest_verified=dataset_digest_verified,
+        panel_data_digest=panel_data_digest,
+        ratified_dataset_digest=RATIFIED_DATASET_DIGEST,
+        baseline_wiring_verified=baseline_wiring_verified,
+        baseline_executed=False,
+        baseline_callable_wiring_only=baseline_callable_wiring_only,
+        economic_evaluation_executed=False,
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def verify_actual_baseline_backtest_call_present_in_production_source_v0() -> bool:
+    source = inspect.getsource(run_baseline_offline_economic_evaluation_v0)
+    return "_run_candidate_with_runtime_config_v0(" in source
+
+
+def phase_result_to_dict(result: PhaseExecutionBlockedResultV0) -> dict[str, Any]:
+    return {
+        "phase": result.phase,
+        "executed": result.executed,
+        "blocked": result.blocked,
+        "wiring_verified": result.wiring_verified,
+        "canonical_owner": result.canonical_owner,
+        "actual_baseline_backtest_call_present": result.actual_baseline_backtest_call_present,
+        "baseline_backtest_owner_call_count": result.baseline_backtest_owner_call_count,
+        "reason_codes": list(result.reason_codes),
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+        "economic_evaluation_executed": False,
+    }
+
+
+def preflight_result_to_dict(result: BaselineExecutionPreflightResultV0) -> dict[str, Any]:
+    return {
+        "preflight_passed": result.preflight_passed,
+        "blocked": result.blocked,
+        "baseline_execution_admissible": result.baseline_execution_admissible,
+        "implementation_wiring_verified": result.implementation_wiring_verified,
+        "reason_codes": list(result.reason_codes),
+        "bound_dataset_materialized": result.bound_dataset_materialized,
+        "source_manifests_verified": result.source_manifests_verified,
+        "dataset_digest_verified": result.dataset_digest_verified,
+        "panel_data_digest": result.panel_data_digest,
+        "ratified_dataset_digest": result.ratified_dataset_digest,
+        "baseline_wiring_verified": result.baseline_wiring_verified,
+        "baseline_executed": result.baseline_executed,
+        "baseline_callable_wiring_only": result.baseline_callable_wiring_only,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+    }
+
+
+def build_baseline_owner_inventory() -> dict[str, Any]:
+    return {
+        "schema_version": "owner_inventory.v0",
+        "canonical_entry_point": CANONICAL_BASELINE_ENTRY_POINT,
+        "canonical_backtest_owner": CANONICAL_BASELINE_BACKTEST_OWNER,
+        "baseline_evaluator_owner": BASELINE_EVALUATOR_OWNER,
+        "versioned_binding_owner": (
+            "src.research.trend_following_v2_versioned_research_binding_v0"
+        ),
+        "panel_adapter_owner": "src.research.panel_sequential_signal_density_research_adapter_v0",
+        "dataset_materialization_owner": (
+            "panel_sequential_signal_density_research_adapter_v0."
+            "materialize_panel_member_evaluation_dataset_v0"
+        ),
+        "runtime_config_owner": (
+            "panel_sequential_signal_density_research_adapter_v0."
+            "build_sparse_signal_runtime_step31f_config_v0"
+        ),
+        "evidence_output_owner": "scripts.ops.primary_evidence_retention_v0",
+    }
+
+
+def build_baseline_reuse_decision() -> dict[str, Any]:
+    return {
+        "schema_version": "reuse_decision.v0",
+        "decision": "REUSE_WITH_NARROW_ADAPTER",
+        "canonical_backtest_owner_reused": True,
+        "new_backtest_owner_created": False,
+        "strategy_logic_duplicated": False,
+        "digest_algorithm_duplicated": False,
+        "rationale": (
+            "Materialize run_baseline_offline_economic_evaluation_v0 as narrow adapter over "
+            "existing sparse-signal panel adapter and _run_candidate_with_runtime_config_v0."
+        ),
+    }
+
+
+def build_baseline_runner_decision() -> dict[str, Any]:
+    return {
+        "schema_version": "runner_decision.v0",
+        "runner_script": RUNNER_SCRIPT,
+        "baseline_implementation_branch": _BRANCH_BASELINE_EXECUTION_IMPLEMENTATION_V0,
+        "baseline_execution_branch": _BRANCH_BASELINE_EXECUTION_V0,
+        "implementation_go_authorizes_baseline_execution": False,
+        "baseline_execution_go_separately_gated": True,
+    }
+
+
+def build_baseline_test_assertion_matrix() -> dict[str, Any]:
+    assertions = [
+        "baseline_entry_point_materialized_and_importable",
+        "valid_path_reaches_canonical_backtest_owner",
+        "canonical_backtest_owner_invoked_exactly_once_in_spy_test",
+        "trend_following_v2_binding_contract_passed",
+        "roundtrip_cost_bps_unchanged_at_40",
+        "wrong_go_token_blocks_before_backtest",
+        "stale_binding_digest_blocks_before_backtest",
+        "missing_staging_blocks_fail_closed_on_invoke",
+        "futures_only_enforced",
+        "bitcoin_exclusion_enforced",
+        "no_economic_evaluation_in_implementation_scope",
+        "runtime_effect_none",
+        "authority_effect_none",
+    ]
+    return {
+        "schema_version": "test_assertion_matrix.v0",
+        "assertions": assertions,
+        "assertion_count": len(assertions),
+    }
+
+
+def materialize_baseline_implementation_contract_v0() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "execution_id": EXECUTION_ID,
+        "canonical_entry_point": CANONICAL_BASELINE_ENTRY_POINT,
+        "canonical_backtest_owner": CANONICAL_BASELINE_BACKTEST_OWNER,
+        "baseline_execution_go_token": BASELINE_EXECUTION_GO_TOKEN,
+        "baseline_execution_implementation_go_token": BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+        "roundtrip_cost_bps": ROUNDTRIP_COST_BPS,
+        "entry_point_status": BASELINE_ENTRY_POINT_STATUS,
+        "baseline_entry_point_status": BASELINE_ENTRY_POINT_STATUS,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+    }
+
+
 def materialize_execution_contract_v0() -> dict[str, Any]:
     return {
         "schema_version": SCHEMA_VERSION,
@@ -792,6 +1348,12 @@ def materialize_execution_contract_v0() -> dict[str, Any]:
         "dispatch_implementation_go_token": DISPATCH_IMPLEMENTATION_GO_TOKEN,
         "execution_go_token": EXECUTION_GO_TOKEN,
         "entry_point_status": ENTRY_POINT_STATUS,
+        "baseline_entry_point_status": BASELINE_ENTRY_POINT_STATUS,
+        "canonical_baseline_entry_point": CANONICAL_BASELINE_ENTRY_POINT,
+        "canonical_baseline_backtest_owner": CANONICAL_BASELINE_BACKTEST_OWNER,
+        "baseline_execution_go_token": BASELINE_EXECUTION_GO_TOKEN,
+        "baseline_execution_implementation_go_token": BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+        "roundtrip_cost_bps": ROUNDTRIP_COST_BPS,
         "harness_binding_ref": HARNESS_BINDING_REF,
         "runner_binding_ref": RUNNER_BINDING_REF,
         "adapter_kind": ADAPTER_KIND,
@@ -816,6 +1378,7 @@ def materialize_dispatch_contract_v0() -> dict[str, Any]:
         "dispatch_implementation_go_token": DISPATCH_IMPLEMENTATION_GO_TOKEN,
         "execution_go_token": EXECUTION_GO_TOKEN,
         "entry_point_status": ENTRY_POINT_STATUS,
+        "baseline_entry_point_status": BASELINE_ENTRY_POINT_STATUS,
         "economic_evaluation_executed": False,
         "baseline_executed": False,
         "robustness_executed": False,
@@ -914,12 +1477,16 @@ def entrypoint_result_to_dict(result: FullEvaluationEntrypointResultV1) -> dict[
 __all__ = [
     "AUTHORITY_EFFECT",
     "BASELINE_EVALUATOR_OWNER",
+    "BASELINE_EXECUTION_GO_TOKEN",
+    "BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN",
+    "CANONICAL_BASELINE_BACKTEST_OWNER",
+    "CANONICAL_BASELINE_ENTRY_POINT",
     "CANONICAL_DISPATCH_CALLABLE",
     "CANONICAL_EVALUATION_CALLABLE",
     "CANONICAL_FULL_EVALUATION_CALLABLE",
     "CONFIG_REL_PATH_OPS",
     "DISPATCH_IMPLEMENTATION_GO_TOKEN",
-    "ENTRY_POINT_STATUS",
+    "BASELINE_ENTRY_POINT_STATUS",
     "EXECUTION_GO_TOKEN",
     "EXECUTION_VERSION",
     "GO_TOKEN",
@@ -929,30 +1496,45 @@ __all__ = [
     "ORDER_EFFECT",
     "RATIFIED_BINDING_DIGEST",
     "RATIFIED_DATASET_DIGEST",
+    "REASON_BASELINE_BACKTEST_OWNER_INVOKED",
     "REASON_BINDING_DIGEST_MISMATCH",
     "REASON_DATASET_DIGEST_MISMATCH",
     "REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION",
     "REASON_ECONOMIC_EXECUTION_FORBIDDEN",
     "REASON_GO_TOKEN_INVALID",
+    "REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION",
+    "ROUNDTRIP_COST_BPS",
     "RUNNER_SCRIPT",
     "RUNTIME_EFFECT",
+    "build_baseline_owner_inventory",
+    "build_baseline_reuse_decision",
+    "build_baseline_runner_decision",
+    "build_baseline_test_assertion_matrix",
     "dispatch_result_to_dict",
     "entrypoint_result_to_dict",
     "load_authorization_ratification_v0",
     "load_ops_evaluation_config_v0",
     "load_versioned_research_binding_v0",
+    "materialize_baseline_implementation_contract_v0",
     "materialize_dispatch_contract_v0",
     "materialize_execution_contract_v0",
     "materialize_infrastructure_summary_v0",
+    "phase_result_to_dict",
+    "preflight_result_to_dict",
+    "run_baseline_execution_preflight_v0",
+    "run_baseline_offline_economic_evaluation_v0",
     "run_contract_smoke_evaluation_v0",
     "run_full_evaluation_entrypoint_dry_run_v1",
     "run_full_offline_economic_evaluation_v0",
     "run_offline_economic_evaluation_execution_dispatch_v0",
+    "validate_baseline_execution_go_token_v0",
+    "validate_baseline_execution_implementation_go_token_v0",
     "validate_dispatch_implementation_go_token_v0",
     "validate_entry_point_go_token_v0",
     "validate_evaluation_dispatch_go_token_v0",
     "validate_execution_go_token_v0",
     "validate_infrastructure_go_token_v0",
+    "verify_actual_baseline_backtest_call_present_in_production_source_v0",
     "verify_execution_start_state_v0",
     "verify_ratified_digests_v0",
     "verify_source_evidence_manifests_v0",

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -160,6 +160,13 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
                 "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
             ],
             [
+                "src/research/trend_following_v2_offline_economic_evaluation_execution_v0.py",
+                "scripts/ops/run_trend_following_v2_offline_economic_evaluation_execution_v0.py",
+                "scripts/ops/materialize_trend_following_v2_offline_economic_evaluation_baseline_execution_implementation_v0.py",
+                "tests/research/test_trend_following_v2_offline_economic_evaluation_baseline_execution_implementation_v0.py",
+                "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+            ],
+            [
                 "src/research/cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_v0.py",
                 "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_execution_infrastructure_v0.py",
                 "tests/research/test_cross_sectional_futures_lead_lag_information_diffusion_v0_offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",

--- a/tests/research/test_trend_following_v2_offline_economic_evaluation_baseline_execution_implementation_v0.py
+++ b/tests/research/test_trend_following_v2_offline_economic_evaluation_baseline_execution_implementation_v0.py
@@ -1,0 +1,337 @@
+"""Baseline execution implementation contract tests for trend_following v2."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
+    CandidateExecutionResultV0,
+    CandidateTerminalStatus,
+)
+from src.research.trend_following_v2_offline_economic_evaluation_authorization_ratification_v0 import (
+    materialize_offline_economic_evaluation_authorization_ratification_v0,
+)
+from src.research.trend_following_v2_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    BASELINE_EXECUTION_GO_TOKEN,
+    BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+    CANONICAL_BASELINE_BACKTEST_OWNER,
+    CANONICAL_BASELINE_ENTRY_POINT,
+    ENTRY_POINT_DISPATCH_REGISTRY,
+    RATIFIED_BINDING_DIGEST,
+    RATIFIED_DATASET_DIGEST,
+    REASON_BASELINE_BACKTEST_OWNER_INVOKED,
+    REASON_BINDING_DIGEST_MISMATCH,
+    REASON_DATASET_DIGEST_MISMATCH,
+    REASON_GO_TOKEN_INVALID,
+    REASON_GO_TOKEN_MISSING,
+    REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION,
+    ROUNDTRIP_COST_BPS,
+    RUNNER_SCRIPT,
+    RUNTIME_EFFECT,
+    run_baseline_offline_economic_evaluation_v0,
+    validate_baseline_execution_go_token_v0,
+    validate_baseline_execution_implementation_go_token_v0,
+    verify_actual_baseline_backtest_call_present_in_production_source_v0,
+)
+from src.research.trend_following_v2_versioned_research_binding_v0 import (
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+    materialize_versioned_research_binding_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_IMPL_GO = BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN
+_BASELINE_EXEC_GO = BASELINE_EXECUTION_GO_TOKEN
+RUNNER_MODULE = REPO_ROOT / RUNNER_SCRIPT
+STAGING_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/"
+    "extended_chronological_v1"
+)
+FORBIDDEN_RUNTIME_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+    "src.orders",
+)
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_research_binding_v0(repo_root=REPO_ROOT)
+
+
+@pytest.fixture(name="authorization_ratification")
+def fixture_authorization_ratification(complete_binding: dict) -> dict:
+    return materialize_offline_economic_evaluation_authorization_ratification_v0(
+        repo_root=REPO_ROOT,
+        versioned_binding=complete_binding,
+    )
+
+
+class TestBaselineEntryPointMaterialized:
+    def test_entry_point_importable(self) -> None:
+        assert run_baseline_offline_economic_evaluation_v0 is not None
+        assert CANONICAL_BASELINE_ENTRY_POINT.endswith(
+            "run_baseline_offline_economic_evaluation_v0"
+        )
+
+    def test_actual_baseline_backtest_call_present_in_production_source(self) -> None:
+        assert verify_actual_baseline_backtest_call_present_in_production_source_v0() is True
+
+    def test_baseline_function_source_contains_canonical_backtest_owner(self) -> None:
+        source = inspect.getsource(run_baseline_offline_economic_evaluation_v0)
+        assert "_run_candidate_with_runtime_config_v0(" in source
+        assert CANONICAL_BASELINE_BACKTEST_OWNER.endswith("_run_candidate_with_runtime_config_v0")
+
+
+class TestBaselineGoTokenRegistration:
+    def test_implementation_go_token_accepted(self) -> None:
+        ok, reasons = validate_baseline_execution_implementation_go_token_v0(_IMPL_GO)
+        assert ok is True
+        assert reasons == ()
+
+    def test_baseline_execution_go_token_registered_in_dispatch_registry(self) -> None:
+        assert ENTRY_POINT_DISPATCH_REGISTRY[_BASELINE_EXEC_GO] == "BASELINE_EXECUTION_V0"
+        assert ENTRY_POINT_DISPATCH_REGISTRY[_IMPL_GO] == "BASELINE_EXECUTION_IMPLEMENTATION_V0"
+
+
+class TestImplementationGoAuthorizationBoundary:
+    def test_implementation_go_does_not_authorize_baseline_execution(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token=_IMPL_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            invoke_baseline_owner=True,
+            staging_root=STAGING_ROOT,
+        )
+        assert result.executed is False
+        assert result.blocked is True
+        assert REASON_GO_TOKEN_INVALID in result.reason_codes
+        assert REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION in result.reason_codes
+
+    def test_baseline_execution_go_reaches_wiring_only_stop(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token=_BASELINE_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+        )
+        assert result.executed is False
+        assert result.blocked is False
+        assert result.wiring_verified is True
+        assert result.canonical_owner == CANONICAL_BASELINE_BACKTEST_OWNER
+        assert result.baseline_backtest_owner_call_count == 0
+
+
+class TestHappyPathCanonicalBacktestOwnerInvocation:
+    def test_valid_bindings_invoke_canonical_backtest_owner_exactly_once(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+        tmp_path: Path,
+    ) -> None:
+        metrics = MagicMock(evaluation_instrument_id="okx:linear_perpetual:ETH:USDT:USDT:perp")
+        backtest_result = CandidateExecutionResultV0(
+            strategy_id=STRATEGY_ID,
+            strategy_version=STRATEGY_VERSION,
+            canonical_candidate_identifier="trend_following/v2",
+            config_path=str(tmp_path / "config.json"),
+            output_dir=str(tmp_path / "output"),
+            run_id="test-run",
+            terminal_status=CandidateTerminalStatus.INCONCLUSIVE,
+            economic_validity_result="BLOCKED",
+            economic_validity_offline_gate_pass=False,
+            evidence_status="",
+            manifest_verify_rc=0,
+            reason_codes=(),
+            stage_return_codes={"economic_viability_runner": 0},
+            runner_execution_success=False,
+        )
+        backtest_spy = MagicMock(return_value=backtest_result)
+        config_path = tmp_path / "step31f_trend_following_v2_economic_evaluation_v1.json"
+        config_path.write_text("{}", encoding="utf-8")
+
+        with (
+            patch(
+                "src.research.trend_following_v2_offline_economic_evaluation_execution_v0."
+                "compute_sparse_signal_density_metrics_v0",
+                return_value=metrics,
+            ),
+            patch(
+                "src.research.trend_following_v2_offline_economic_evaluation_execution_v0."
+                "build_sparse_signal_runtime_step31f_config_v0",
+                return_value=config_path,
+            ),
+            patch(
+                "src.research.trend_following_v2_offline_economic_evaluation_execution_v0."
+                "_run_candidate_with_runtime_config_v0",
+                backtest_spy,
+            ),
+        ):
+            result = run_baseline_offline_economic_evaluation_v0(
+                go_token=_BASELINE_EXEC_GO,
+                repo_root=REPO_ROOT,
+                authorization_ratification=authorization_ratification,
+                versioned_binding=complete_binding,
+                staging_root=STAGING_ROOT,
+                scratch_root=tmp_path,
+                invoke_baseline_owner=True,
+            )
+
+        assert result.blocked is False
+        assert result.executed is False
+        assert result.actual_baseline_backtest_call_present is True
+        assert result.baseline_backtest_owner_call_count == 1
+        assert REASON_BASELINE_BACKTEST_OWNER_INVOKED in result.reason_codes
+        backtest_spy.assert_called_once()
+        _, kwargs = backtest_spy.call_args
+        assert kwargs["strategy_id"] == STRATEGY_ID
+        assert kwargs["strategy_version"] == STRATEGY_VERSION
+        assert kwargs["config_path"] == config_path
+
+
+class TestBindingAndCostContracts:
+    def test_roundtrip_cost_bps_unchanged(self, complete_binding: dict) -> None:
+        execution_model = complete_binding["binding"]["execution_model_binding"]
+        assert execution_model["roundtrip_cost_bps"] == ROUNDTRIP_COST_BPS
+        assert ROUNDTRIP_COST_BPS == 40.0
+
+    def test_binding_digest_mismatch_blocks_before_backtest(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        stale = deepcopy(complete_binding)
+        stale["binding_digest"] = "f" * 64
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token=_BASELINE_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=stale,
+            invoke_baseline_owner=True,
+            staging_root=STAGING_ROOT,
+        )
+        assert result.blocked is True
+        assert REASON_BINDING_DIGEST_MISMATCH in result.reason_codes
+
+    def test_dataset_digest_mismatch_blocks_before_backtest(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        stale = deepcopy(complete_binding)
+        stale["dataset_digest"] = "f" * 64
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token=_BASELINE_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=stale,
+            invoke_baseline_owner=True,
+            staging_root=STAGING_ROOT,
+        )
+        assert result.blocked is True
+        assert REASON_DATASET_DIGEST_MISMATCH in result.reason_codes
+
+    def test_ratified_digests_match_fixture(self, complete_binding: dict) -> None:
+        assert complete_binding["binding_digest"] == RATIFIED_BINDING_DIGEST
+        assert complete_binding["dataset_digest"] == RATIFIED_DATASET_DIGEST
+
+
+class TestFuturesOnlyAndBitcoinExclusion:
+    def test_futures_only_enforced(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        mutated = deepcopy(complete_binding)
+        mutated["binding"]["instrument_binding"]["futures_only"] = False
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token=_BASELINE_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=mutated,
+        )
+        assert result.blocked is True
+        assert "FUTURES_ONLY_VIOLATION" in result.reason_codes
+
+    def test_bitcoin_exclusion_enforced(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        mutated = deepcopy(complete_binding)
+        mutated["binding"]["instrument_binding"]["bitcoin_direction_allowed"] = True
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token=_BASELINE_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=mutated,
+        )
+        assert result.blocked is True
+        assert "BITCOIN_DIRECTION_VIOLATION" in result.reason_codes
+
+
+class TestGoTokenGate:
+    def test_missing_go_token_fail_closed(self) -> None:
+        ok, reasons = validate_baseline_execution_go_token_v0(None)
+        assert ok is False
+        assert REASON_GO_TOKEN_MISSING in reasons
+
+    def test_wrong_go_token_fail_closed(self, complete_binding: dict) -> None:
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token="GO_WRONG_TOKEN",
+            repo_root=REPO_ROOT,
+            versioned_binding=complete_binding,
+        )
+        assert result.blocked is True
+        assert REASON_GO_TOKEN_INVALID in result.reason_codes
+
+
+class TestOfflineBoundary:
+    def test_no_economic_evaluation_executed_in_implementation_scope(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_baseline_offline_economic_evaluation_v0(
+            go_token=_BASELINE_EXEC_GO,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+        )
+        assert result.executed is False
+
+    def test_runtime_and_authority_effect_none(self) -> None:
+        assert AUTHORITY_EFFECT == "NONE"
+        assert RUNTIME_EFFECT == "NONE"
+
+    def test_runner_has_no_forbidden_runtime_imports(self) -> None:
+        tree = ast.parse(RUNNER_MODULE.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert not any(
+                        alias.name.startswith(prefix)
+                        for prefix in FORBIDDEN_RUNTIME_IMPORT_PREFIXES
+                    )
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert not any(
+                    node.module.startswith(prefix) for prefix in FORBIDDEN_RUNTIME_IMPORT_PREFIXES
+                )


### PR DESCRIPTION
## Summary
- Materializes the missing fail-closed baseline entry point `run_baseline_offline_economic_evaluation_v0` for `trend_following/v2`, wired reuse-first to `_run_candidate_with_runtime_config_v0` via the existing sparse-signal panel adapter.
- Registers separate baseline implementation and baseline execution GO tokens in the harness dispatch registry and ops runner.
- Adds focused contract tests proving entry-point materialization, canonical backtest-owner invocation (spy), GO/binding/digest guards, futures-only/Bitcoin exclusion, and unchanged `ROUNDTRIP_COST_BPS=40.0`.

## Test plan
- [x] `pytest tests/research/test_trend_following_v2_offline_economic_evaluation_baseline_execution_implementation_v0.py`
- [x] `pytest tests/research/test_trend_following_v2_offline_economic_evaluation_execution_dispatch_implementation_v0.py`
- [x] `pytest tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py`
- [x] `ruff format --check` / `ruff check` on touched Python files
- [ ] No economic evaluation executed in this PR (implementation scope only)


Made with [Cursor](https://cursor.com)