### PR TITLE
feat(research): add momentum 1h v2 offline evaluation execution infrastructure

### DIFF
--- a/config/ops/momentum_1h_v2_economic_evaluation_v1.json
+++ b/config/ops/momentum_1h_v2_economic_evaluation_v1.json
@@ -1,0 +1,119 @@
+{
+  "backtest": {
+    "cost_model_version": "backtest_cost_v0",
+    "economic_research_execution_cost": {
+      "conservative_half_spread_bps": 5.0,
+      "execution_price_observation_source": "MODELLED_NOT_OBSERVED",
+      "fee_bps": 10.0,
+      "slippage_bps": 5.0,
+      "spread_model_version": "research_conservative_bps_v1"
+    },
+    "fee_bps": 10.0,
+    "fee_model_version": "backtest_fee_taker_symmetric_v0",
+    "funding": {
+      "bind": true,
+      "model_version": "backtest_funding_perpetual_interval_v1"
+    },
+    "initial_cash": 10000.0,
+    "parameter_sensitivity": {
+      "bind": true,
+      "grid_version": "v1",
+      "parameter_search_forbidden": true,
+      "policy_version": "parameter_sensitivity_v1",
+      "primary_binding_only": true
+    },
+    "slippage_bps": 5.0,
+    "slippage_model_version": "backtest_slippage_symmetric_v0"
+  },
+  "binding_digest": "366f7aeb21d781a2531d477ef32943c04d5edb262b7be9e540bbfcfc2528985f",
+  "config_schema_version": "momentum_1h_v2_economic_evaluation_admissibility_v1",
+  "config_version": "v1",
+  "economic_evaluation_v1": {
+    "economic_validity_policy_version": "economic_validity_policy_v1",
+    "engine_signal_source": "mv2_decision_replay_series",
+    "monte_carlo": {
+      "bind": true,
+      "policy_version": "monte_carlo_v1",
+      "runs": 64,
+      "seed": 42
+    },
+    "parameter_sensitivity_policy_version": "parameter_sensitivity_v1",
+    "strategy_id": "momentum_1h",
+    "strategy_params": {
+      "entry_threshold": 0.02,
+      "exit_threshold": -0.01,
+      "lookback_period": 20
+    },
+    "strategy_version": "v2",
+    "stress": {
+      "bind": true,
+      "policy_version": "stress_class_suite_v1"
+    },
+    "walk_forward": {
+      "bind": true,
+      "policy_version": "walk_forward_v1",
+      "step_bars": 1440,
+      "test_bars": 1440,
+      "train_bars": 4320
+    }
+  },
+  "mv2_research_backtest_mandatory_boundary_state_file_binding_v0": {
+    "canonical_order_intent": {
+      "expected_state_file_digest_ref": "3fc5a99ca38101b3017b00260b2bdbbd7a0fb96e7f2c600333e40876c98e06b5",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/canonical_order_intent.json"
+    },
+    "capital_risk_sizing": {
+      "expected_state_file_digest_ref": "82a8b8ae2f38a90c93915c97c912243b3fca64b68e1e1490e062049cdff728a7",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/capital_risk_sizing.json"
+    },
+    "killswitch": {
+      "expected_state_file_digest_ref": "e8acdea6f07b3e5e232aef82ad9e6ce0e2dbf1bf09f7c1395a13e5cb176f9aeb",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/killswitch.json"
+    },
+    "reconciliation": {
+      "expected_state_file_digest_ref": "3475daedda9ec7d490f395972fd82356ac81288379fa708b43fc0a6c4870dcaf",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/reconciliation.json"
+    },
+    "safety_kernel": {
+      "expected_state_file_digest_ref": "21e11676f47a579032cfb594cc003271483e342f6edd49dd5e573c06da7bd30b",
+      "state_file_path": "config/research/mv2_backtest_mandatory_boundary_state_files_v0/safety_kernel.json"
+    },
+    "schema_version": "mv2_research_backtest_mandatory_boundary_state_file_binding_v0"
+  },
+  "offline_only": true,
+  "sparse_signal_evaluation_binding_v0": {
+    "adapter_kind": "PANEL_SEQUENTIAL_SIGNAL_DENSITY_RESEARCH_ADAPTER_v0",
+    "candidate_binding_ref": "config/research/momentum_1h_v2_versioned_research_binding_v0.json",
+    "data_digest": "0083e0502a05667f5b0ca31d374b3bef066f65aacfdb05ee020490cc1f15c638",
+    "dataset_digest": "0083e0502a05667f5b0ca31d374b3bef066f65aacfdb05ee020490cc1f15c638",
+    "dataset_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1",
+    "panel_staging_root": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/extended_chronological_v1",
+    "parameter_binding": {
+      "binding_class": "SPARSE_SIGNAL_ZERO_TRADE_RESEARCH_V0",
+      "entry_threshold": 0.02,
+      "exit_threshold": -0.01,
+      "lookback_period": 20,
+      "parameter_optimization_forbidden": true,
+      "parameter_rescue_forbidden": true,
+      "parameter_schema_version": "step31f_momentum_1h_v1_economic_evaluation_admissibility_v1",
+      "threshold_lowering_forbidden": true,
+      "unchanged_from_terminal_class_d_v1": true
+    },
+    "period_binding": {
+      "coverage_period_end_utc": "2024-09-01T00:00:00Z",
+      "coverage_period_start_utc": "2024-05-01T00:00:00Z",
+      "embargo_duration": "PT2H",
+      "period_binding_id": "extended_chronological_sparse_signal_research_v0",
+      "period_binding_ref": "extended_chronological_sparse_signal_research_v0:v0",
+      "period_binding_version": "v0",
+      "period_digest": "96b5b8c7759511e810e72e0ac2623c4b21124520e625364f75081c59f4066f03",
+      "purge_duration": "PT2H",
+      "sparse_signal_research_binding": true,
+      "split_policy_id": "extended_chronological_sparse_signal_research_v0",
+      "split_policy_version": "v0"
+    },
+    "rotation_policy": "deterministic_instrument_id_asc"
+  },
+  "strategy_id": "momentum_1h",
+  "strategy_version": "v2"
+}

--- a/scripts/ops/run_momentum_1h_v2_offline_economic_evaluation_execution_v0.py
+++ b/scripts/ops/run_momentum_1h_v2_offline_economic_evaluation_execution_v0.py
@@ -1,0 +1,728 @@
+#!/usr/bin/env python3
+"""Ops runner for momentum 1h v2 offline economic evaluation execution.
+
+Bounded modes:
+- Infrastructure/dry-run: GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_V0
+- Dispatch implementation: GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_DISPATCH_IMPLEMENTATION_V0
+- Execution dispatch: GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0
+- Baseline execution implementation:
+  GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0
+- Baseline execution dispatch (fail-closed before economic evaluation):
+  GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_V0
+
+No runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ops import primary_evidence_retention_v0 as retention  # noqa: E402
+from src.research.momentum_1h_v2_offline_economic_evaluation_execution_v0 import (  # noqa: E402
+    AUTHORITY_EFFECT,
+    BASELINE_EXECUTION_GO_TOKEN,
+    BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+    DISPATCH_IMPLEMENTATION_GO_TOKEN,
+    EXECUTION_GO_TOKEN,
+    EXECUTION_VERSION,
+    INFRASTRUCTURE_GO_TOKEN,
+    ROUNDTRIP_COST_BPS,
+    RUNTIME_EFFECT,
+    build_baseline_owner_inventory,
+    build_baseline_reuse_decision,
+    build_baseline_runner_decision,
+    build_baseline_test_assertion_matrix,
+    dispatch_result_to_dict,
+    entrypoint_result_to_dict,
+    load_authorization_ratification_v0,
+    load_versioned_research_binding_v0,
+    materialize_baseline_implementation_contract_v0,
+    materialize_dispatch_contract_v0,
+    materialize_execution_contract_v0,
+    materialize_infrastructure_summary_v0,
+    preflight_result_to_dict,
+    run_baseline_execution_preflight_v0,
+    run_contract_smoke_evaluation_v0,
+    run_full_evaluation_entrypoint_dry_run_v1,
+    run_full_offline_economic_evaluation_v0,
+    run_offline_economic_evaluation_execution_dispatch_v0,
+    verify_execution_start_state_v0,
+    verify_source_evidence_manifests_v0,
+)
+
+INFRASTRUCTURE_GO = INFRASTRUCTURE_GO_TOKEN
+DISPATCH_IMPLEMENTATION_GO = DISPATCH_IMPLEMENTATION_GO_TOKEN
+EXECUTION_GO = EXECUTION_GO_TOKEN
+BASELINE_EXECUTION_GO = BASELINE_EXECUTION_GO_TOKEN
+BASELINE_EXECUTION_IMPLEMENTATION_GO = BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN
+SCOPE_CLASSIFICATION = (
+    "BOUNDED_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_V0"
+)
+DISPATCH_IMPLEMENTATION_SCOPE_CLASSIFICATION = (
+    "BOUNDED_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_DISPATCH_IMPLEMENTATION_V0"
+)
+EXECUTION_DISPATCH_SCOPE_CLASSIFICATION = (
+    "BOUNDED_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0"
+)
+BASELINE_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION = (
+    "BOUNDED_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
+)
+BASELINE_EXECUTION_SCOPE_CLASSIFICATION = (
+    "BOUNDED_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_V0"
+)
+DEFAULT_DURABLE_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z"
+)
+DEFAULT_STAGING_ROOT = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "datasets/admissible_futures/pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_research_v1/"
+    "extended_chronological_v1"
+)
+BASELINE_IMPLEMENTATION_TEST_MODULE = (
+    "tests/research/"
+    "test_momentum_1h_v2_offline_economic_evaluation_baseline_execution_implementation_v0.py"
+)
+ALLOWED_CONFIRM_GO_TOKENS = frozenset(
+    {
+        INFRASTRUCTURE_GO,
+        DISPATCH_IMPLEMENTATION_GO,
+        EXECUTION_GO,
+        BASELINE_EXECUTION_IMPLEMENTATION_GO,
+        BASELINE_EXECUTION_GO,
+    }
+)
+MAX_RUNTIME_SECONDS = 900
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _resolve_origin_main(repo_root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "origin/main"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _primary_worktree_snapshot(primary_worktree: Path) -> dict[str, Any]:
+    head = subprocess.run(
+        ["git", "-C", str(primary_worktree), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty = subprocess.run(
+        ["git", "-C", str(primary_worktree), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty_count = len([line for line in dirty.stdout.splitlines() if line.strip()])
+    return {
+        "head": head.stdout.strip() if head.returncode == 0 else "",
+        "dirty_count": dirty_count,
+    }
+
+
+def run_execution_infrastructure_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != INFRASTRUCTURE_GO:
+        _die(f"ERR:confirm_go_token_required:{INFRASTRUCTURE_GO}")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "implementation"
+        / (f"momentum_1h_v2_offline_economic_evaluation_execution_infrastructure_v0_{ts_slug}")
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    versioned_binding = load_versioned_research_binding_v0(_REPO_ROOT)
+    authorization_ratification = load_authorization_ratification_v0(_REPO_ROOT)
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+    entrypoint = run_full_evaluation_entrypoint_dry_run_v1(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        go_token=INFRASTRUCTURE_GO,
+    )
+    readiness = run_contract_smoke_evaluation_v0(
+        repo_root=_REPO_ROOT,
+        versioned_binding=versioned_binding,
+        authorization_ratification=authorization_ratification,
+    )
+    entrypoint_payload = entrypoint_result_to_dict(entrypoint)
+    summary = materialize_infrastructure_summary_v0(
+        authorization_ratification=authorization_ratification,
+        readiness=readiness,
+        origin_main_sha=origin_main,
+        execution_bundle_dir=str(bundle_dir),
+    )
+
+    (bundle_dir / "PREFLIGHT.txt").write_text(
+        "\n".join(
+            [
+                f"ORIGIN_MAIN={origin_main}",
+                f"PRIMARY_HEAD_BEFORE={primary_before['head']}",
+                f"PRIMARY_DIRTY_COUNT_BEFORE={primary_before['dirty_count']}",
+                f"START_STATE_VALID={start_state.valid}",
+                f"START_STATE_FAIL_REASONS={list(start_state.fail_reasons)}",
+                "ROOT_CAUSE=CANONICAL_ENTRY_POINT_AND_RUNNER_NOT_MATERIALIZED",
+                f"REPAIR_SCOPE={SCOPE_CLASSIFICATION}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "EXECUTION_LOG.txt").write_text(
+        "\n".join(
+            [
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                "EXECUTION_SCOPE=INFRASTRUCTURE_ONLY_V0",
+                f"GO_TOKEN={confirm}",
+                "GO_TOKEN_CONSUMPTION=CONSUMED_ONCE",
+                f"SCOPE_CLASSIFICATION={SCOPE_CLASSIFICATION}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "ENTRYPOINT_DRY_RUN_RESULT.json").write_text(
+        json.dumps(entrypoint_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "INFRASTRUCTURE_SUMMARY.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
+        "ECONOMIC_EVALUATION_EXECUTED=false\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    payload: dict[str, Any] = {
+        "verdict": entrypoint_payload["status"],
+        "process_classification": SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "start_state_valid": start_state.valid,
+        "entrypoint": entrypoint_payload,
+        "infrastructure_summary": summary,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree": str(primary_worktree),
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if time.monotonic() - start_monotonic > MAX_RUNTIME_SECONDS:
+        _die(f"ERR:timeout_guard_exceeded:{MAX_RUNTIME_SECONDS}s")
+    return payload
+
+
+def run_execution_dispatch_implementation_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != DISPATCH_IMPLEMENTATION_GO:
+        _die(f"ERR:confirm_go_token_required:{DISPATCH_IMPLEMENTATION_GO}")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "implementation"
+        / (
+            "momentum_1h_v2_offline_economic_evaluation_execution_dispatch_"
+            f"implementation_v0_{ts_slug}"
+        )
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    versioned_binding = load_versioned_research_binding_v0(_REPO_ROOT)
+    authorization_ratification = load_authorization_ratification_v0(_REPO_ROOT)
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+    dispatch = run_offline_economic_evaluation_execution_dispatch_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        go_token=EXECUTION_GO,
+        versioned_binding=versioned_binding,
+        verify_source_manifests=True,
+    )
+    dispatch_payload = dispatch_result_to_dict(dispatch)
+    execution_contract = materialize_execution_contract_v0()
+    dispatch_contract = materialize_dispatch_contract_v0()
+
+    (bundle_dir / "PREFLIGHT.txt").write_text(
+        "\n".join(
+            [
+                f"ORIGIN_MAIN={origin_main}",
+                f"PRIMARY_HEAD_BEFORE={primary_before['head']}",
+                f"PRIMARY_DIRTY_COUNT_BEFORE={primary_before['dirty_count']}",
+                f"START_STATE_VALID={start_state.valid}",
+                f"START_STATE_FAIL_REASONS={list(start_state.fail_reasons)}",
+                "ROOT_CAUSE=AUTHORIZED_EXECUTION_GO_DISPATCH_NOT_BOUND_TO_CANONICAL_OWNER",
+                f"REPAIR_SCOPE={DISPATCH_IMPLEMENTATION_SCOPE_CLASSIFICATION}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "EXECUTION_LOG.txt").write_text(
+        "\n".join(
+            [
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                "EXECUTION_SCOPE=DISPATCH_IMPLEMENTATION_V0",
+                f"GO_TOKEN={confirm}",
+                "GO_TOKEN_CONSUMPTION=CONSUMED_ONCE",
+                f"SCOPE_CLASSIFICATION={DISPATCH_IMPLEMENTATION_SCOPE_CLASSIFICATION}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "DISPATCH_RESULT.json").write_text(
+        json.dumps(dispatch_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "EXECUTION_CONTRACT.json").write_text(
+        json.dumps(execution_contract, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "DISPATCH_CONTRACT.json").write_text(
+        json.dumps(dispatch_contract, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
+        "ECONOMIC_EVALUATION_EXECUTED=false\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    payload: dict[str, Any] = {
+        "verdict": "EXECUTION_DISPATCH_IMPLEMENTATION_COMPLETE",
+        "process_classification": DISPATCH_IMPLEMENTATION_SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "start_state_valid": start_state.valid,
+        "dispatch": dispatch_payload,
+        "execution_go_dispatch_bound": dispatch.dispatch_accepted,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree_head_before": primary_before["head"],
+        "primary_worktree_dirty_count_before": primary_before["dirty_count"],
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_DISPATCH_IMPLEMENTATION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if time.monotonic() - start_monotonic > MAX_RUNTIME_SECONDS:
+        _die(f"ERR:timeout_guard_exceeded:{MAX_RUNTIME_SECONDS}s")
+    return payload
+
+
+def run_execution_dispatch_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != EXECUTION_GO:
+        _die(f"ERR:confirm_go_token_required:{EXECUTION_GO}")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "implementation"
+        / (f"momentum_1h_v2_offline_economic_evaluation_execution_v0_{ts_slug}")
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    versioned_binding = load_versioned_research_binding_v0(_REPO_ROOT)
+    authorization_ratification = load_authorization_ratification_v0(_REPO_ROOT)
+    evaluation = run_full_offline_economic_evaluation_v0(
+        go_token=EXECUTION_GO,
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        verify_source_manifests=True,
+    )
+    (bundle_dir / "EXECUTION_LOG.txt").write_text(
+        "\n".join(
+            [
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                f"EXECUTION_SCOPE={EXECUTION_DISPATCH_SCOPE_CLASSIFICATION}",
+                f"GO_TOKEN={confirm}",
+                "GO_TOKEN_CONSUMPTION=CONSUMED_ONCE",
+                f"BLOCKED={str(evaluation.blocked).lower()}",
+                f"WIRING_VERIFIED={str(evaluation.wiring_verified).lower()}",
+                f"REASON_CODES={list(evaluation.reason_codes)}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "FULL_EVALUATION_DISPATCH_RESULT.json").write_text(
+        json.dumps(
+            {
+                "executed": evaluation.executed,
+                "blocked": evaluation.blocked,
+                "wiring_verified": evaluation.wiring_verified,
+                "reason_codes": list(evaluation.reason_codes),
+                "authority_effect": evaluation.authority_effect,
+                "runtime_effect": evaluation.runtime_effect,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
+        "ECONOMIC_EVALUATION_EXECUTED=false\n",
+        encoding="utf-8",
+    )
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    payload: dict[str, Any] = {
+        "verdict": "EXECUTION_DISPATCH_COMPLETE",
+        "process_classification": EXECUTION_DISPATCH_SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "evaluation": {
+            "executed": evaluation.executed,
+            "blocked": evaluation.blocked,
+            "wiring_verified": evaluation.wiring_verified,
+            "reason_codes": list(evaluation.reason_codes),
+        },
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree_head_before": primary_before["head"],
+        "primary_worktree_dirty_count_before": primary_before["dirty_count"],
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if time.monotonic() - start_monotonic > MAX_RUNTIME_SECONDS:
+        _die(f"ERR:timeout_guard_exceeded:{MAX_RUNTIME_SECONDS}s")
+    return payload
+
+
+def run_baseline_execution_implementation_v0(
+    *,
+    confirm: str,
+    durable_evidence_root: Path,
+    primary_worktree: Path,
+    staging_root: Path,
+) -> dict[str, Any]:
+    start_monotonic = time.monotonic()
+    if confirm != BASELINE_EXECUTION_IMPLEMENTATION_GO:
+        _die(f"ERR:confirm_go_token_required:{BASELINE_EXECUTION_IMPLEMENTATION_GO}")
+
+    origin_main = _resolve_origin_main(_REPO_ROOT)
+    primary_before = _primary_worktree_snapshot(primary_worktree)
+    ts_slug = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_dir = (
+        durable_evidence_root
+        / "implementation"
+        / (
+            "momentum_1h_v2_offline_economic_evaluation_baseline_execution_"
+            f"implementation_v0_{ts_slug}"
+        )
+    )
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    versioned_binding = load_versioned_research_binding_v0(_REPO_ROOT)
+    authorization_ratification = load_authorization_ratification_v0(_REPO_ROOT)
+    start_state = verify_execution_start_state_v0(
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        origin_main_sha=origin_main,
+    )
+    preflight = run_baseline_execution_preflight_v0(
+        go_token=confirm,
+        repo_root=_REPO_ROOT,
+        authorization_ratification=authorization_ratification,
+        staging_root=staging_root,
+        versioned_binding=versioned_binding,
+        verify_source_manifests=True,
+    )
+    preflight_payload = preflight_result_to_dict(preflight)
+    implementation_contract = materialize_baseline_implementation_contract_v0()
+
+    source_ok, source_reasons = verify_source_evidence_manifests_v0()
+    source_manifest_rc = 0 if source_ok else 1
+
+    test_proc = subprocess.run(
+        [sys.executable, "-m", "pytest", BASELINE_IMPLEMENTATION_TEST_MODULE, "-q"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(_REPO_ROOT),
+    )
+    test_results_text = (
+        test_proc.stdout
+        + ("\n" + test_proc.stderr if test_proc.stderr else "")
+        + f"\nPYTEST_EXIT_CODE={test_proc.returncode}\n"
+    )
+
+    git_diff_proc = subprocess.run(
+        ["git", "-C", str(_REPO_ROOT), "diff", "origin/main...HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    changed_files_proc = subprocess.run(
+        ["git", "-C", str(_REPO_ROOT), "diff", "--name-only", "origin/main...HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    artifacts: dict[str, Any] = {
+        "preflight.txt": "\n".join(
+            [
+                f"ORIGIN_MAIN={origin_main}",
+                f"PRIMARY_HEAD_BEFORE={primary_before['head']}",
+                f"PRIMARY_DIRTY_COUNT_BEFORE={primary_before['dirty_count']}",
+                f"START_STATE_VALID={start_state.valid}",
+                f"START_STATE_FAIL_REASONS={list(start_state.fail_reasons)}",
+                f"OPERATOR_GO={confirm}",
+                f"BOUND_DATASET_MATERIALIZED={str(preflight.bound_dataset_materialized).lower()}",
+                f"SOURCE_MANIFESTS_VERIFIED={str(preflight.source_manifests_verified).lower()}",
+                f"DATASET_DIGEST_VERIFIED={str(preflight.dataset_digest_verified).lower()}",
+                (
+                    "IMPLEMENTATION_WIRING_VERIFIED="
+                    f"{str(preflight.implementation_wiring_verified).lower()}"
+                ),
+            ]
+        )
+        + "\n",
+        "source_manifest_verification.txt": (
+            f"SOURCE_MANIFEST_VERIFY_RC={source_manifest_rc}\n"
+            f"SOURCE_MANIFEST_REASONS={list(source_reasons)}\n"
+        ),
+        "owner_inventory.json": build_baseline_owner_inventory(),
+        "reuse_decision.json": build_baseline_reuse_decision(),
+        "runner_decision.json": build_baseline_runner_decision(),
+        "implementation_contract.json": implementation_contract,
+        "before_after_field_diff.json": {
+            "before": {"entry_point_materialized": False, "baseline_backtest_call_count": 0},
+            "after": {
+                "entry_point_materialized": True,
+                "canonical_entry_point": implementation_contract["canonical_entry_point"],
+                "canonical_backtest_owner": implementation_contract["canonical_backtest_owner"],
+            },
+        },
+        "test_assertion_matrix.json": build_baseline_test_assertion_matrix(),
+        "test_results.txt": test_results_text,
+        "changed_files.txt": changed_files_proc.stdout,
+        "PREFLIGHT_RESULT.json": preflight_payload,
+    }
+    for name, payload in artifacts.items():
+        if name.endswith(".json"):
+            (bundle_dir / name).write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        else:
+            (bundle_dir / name).write_text(str(payload), encoding="utf-8")
+
+    (bundle_dir / "git_diff.patch").write_text(git_diff_proc.stdout, encoding="utf-8")
+    (bundle_dir / "ECONOMIC_EVALUATION_EXECUTED.txt").write_text(
+        "ECONOMIC_EVALUATION_EXECUTED=false\n",
+        encoding="utf-8",
+    )
+
+    manifest_rc, manifest_msg = retention.finalize_durable_bundle_manifest(bundle_dir)
+    implementation_complete = (
+        preflight.implementation_wiring_verified
+        and test_proc.returncode == 0
+        and start_state.valid
+        and manifest_rc == 0
+    )
+    final_report = (
+        "\n".join(
+            [
+                f"STATUS={'PASS' if implementation_complete else 'FAIL_CLOSED'}",
+                (
+                    "VERDICT=IMPLEMENTATION_PR_OPENED"
+                    if implementation_complete
+                    else "VERDICT=FAIL_CLOSED"
+                ),
+                f"GO_TOKEN={confirm}",
+                f"ORIGIN_MAIN={origin_main}",
+                "ENTRY_POINT_MATERIALIZED=true",
+                f"CANONICAL_ENTRY_POINT={implementation_contract['canonical_entry_point']}",
+                (f"CANONICAL_BACKTEST_OWNER={implementation_contract['canonical_backtest_owner']}"),
+                "ECONOMIC_EVALUATION_EXECUTED=false",
+                "BASELINE_EXECUTED=false",
+                f"ROUNDTRIP_COST_BPS={ROUNDTRIP_COST_BPS}",
+                "FUTURES_ONLY=true",
+                "BITCOIN_PRESENT=false",
+                "RUNTIME_EFFECT=NONE",
+                "AUTHORITY_EFFECT=NONE",
+                f"PYTEST_EXIT_CODE={test_proc.returncode}",
+                f"SOURCE_MANIFEST_VERIFY_RC={source_manifest_rc}",
+                f"MANIFEST_VERIFY_RC={manifest_rc}",
+                f"DURABLE_EVIDENCE_DIR={bundle_dir}",
+                (
+                    "NEXT_ADMISSIBLE_SCOPE="
+                    "GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_V0"
+                ),
+            ]
+        )
+        + "\n"
+    )
+    (bundle_dir / "final_report.txt").write_text(final_report, encoding="utf-8")
+    (bundle_dir / "pr_metadata.json").write_text(
+        json.dumps(
+            {
+                "branch": "cursor/trend-following-v2-baseline-execution-entry-point-implementation-v0",
+                "scope": BASELINE_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION,
+                "go_token": confirm,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload: dict[str, Any] = {
+        "verdict": (
+            "BASELINE_EXECUTION_IMPLEMENTATION_COMPLETE"
+            if implementation_complete
+            else "FAIL_CLOSED"
+        ),
+        "process_classification": BASELINE_EXECUTION_IMPLEMENTATION_SCOPE_CLASSIFICATION,
+        "execution_version": EXECUTION_VERSION,
+        "origin_main": origin_main,
+        "start_state_valid": start_state.valid,
+        "preflight": preflight_payload,
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "entry_point_materialized": True,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "primary_worktree_head_before": primary_before["head"],
+        "durable_evidence_path": str(bundle_dir),
+        "manifest_verify_rc": manifest_rc,
+        "manifest_verify_msg": manifest_msg,
+        "elapsed_seconds": round(time.monotonic() - start_monotonic, 3),
+    }
+    (bundle_dir / "EXECUTION_RESULT.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if time.monotonic() - start_monotonic > MAX_RUNTIME_SECONDS:
+        _die(f"ERR:timeout_guard_exceeded:{MAX_RUNTIME_SECONDS}s")
+    return payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--confirm", required=True)
+    parser.add_argument("--durable-evidence-root", type=Path, default=DEFAULT_DURABLE_ROOT)
+    parser.add_argument("--primary-worktree", type=Path, default=_REPO_ROOT)
+    parser.add_argument("--staging-root", type=Path, default=DEFAULT_STAGING_ROOT)
+    args = parser.parse_args()
+    if args.confirm == INFRASTRUCTURE_GO:
+        result = run_execution_infrastructure_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+        )
+    elif args.confirm == DISPATCH_IMPLEMENTATION_GO:
+        result = run_execution_dispatch_implementation_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+        )
+    elif args.confirm == EXECUTION_GO:
+        result = run_execution_dispatch_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+        )
+    elif args.confirm == BASELINE_EXECUTION_IMPLEMENTATION_GO:
+        result = run_baseline_execution_implementation_v0(
+            confirm=args.confirm,
+            durable_evidence_root=args.durable_evidence_root,
+            primary_worktree=args.primary_worktree,
+            staging_root=args.staging_root,
+        )
+    elif args.confirm == BASELINE_EXECUTION_GO:
+        _die(
+            "ERR:baseline_execution_requires_materialized_entry_point:"
+            f"{BASELINE_EXECUTION_IMPLEMENTATION_GO}"
+        )
+    else:
+        _die(
+            "ERR:confirm_go_token_required:"
+            f"{INFRASTRUCTURE_GO}|{DISPATCH_IMPLEMENTATION_GO}|{EXECUTION_GO}|"
+            f"{BASELINE_EXECUTION_IMPLEMENTATION_GO}|{BASELINE_EXECUTION_GO}"
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/research/momentum_1h_v2_offline_economic_evaluation_execution_v0.py
+++ b/src/research/momentum_1h_v2_offline_economic_evaluation_execution_v0.py
@@ -1,0 +1,1856 @@
+"""Momentum 1h v2 offline economic evaluation execution infrastructure v0.
+
+Deterministic, fail-closed execution infrastructure for the ratified momentum_1h/v2
+sparse-signal research binding. Provides binding validation, panel-adapter wiring checks,
+and contract-only dry-run paths. Full economic evaluation requires separate Operator GO.
+No runtime, order, or authority effect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256
+from src.backtest.economic_viability_evidence_v1 import ARTIFACT_FILENAME
+from src.research.final_research_fleet_offline_economic_evaluation_execution_v0 import (
+    CandidateExecutionResultV0,
+    REASON_CANDIDATE_EVIDENCE_MISSING,
+    REASON_CANDIDATE_RUN_FAILED,
+)
+from src.research.panel_sequential_signal_density_research_adapter_v0 import (
+    ADAPTER_KIND,
+    ROTATION_POLICY,
+    build_sparse_signal_runtime_step31f_config_v0,
+    compute_sparse_signal_density_metrics_v0,
+    load_sorted_panel_binding,
+    resolve_panel_staging_root,
+)
+from src.research.versioned_final_fleet_bindings_offline_economic_evaluation_v0 import (
+    _run_candidate_with_runtime_config_v0,
+)
+from src.research.momentum_1h_v2_offline_economic_evaluation_authorization_ratification_v0 import (
+    AUTHORITY_EFFECT,
+    CONFIG_REL_PATH as AUTHORIZATION_CONFIG_REL_PATH,
+    DISCOVERY_EVIDENCE_DIR,
+    ORDER_EFFECT,
+    DECISION_PACKET_DIR,
+    RUNNER_BINDING_REF,
+    HARNESS_BINDING_REF,
+    RatificationValidationVerdict,
+    materialize_offline_economic_evaluation_authorization_ratification_v0,
+    validate_offline_economic_evaluation_authorization_ratification_v0,
+)
+from src.research.momentum_1h_v2_versioned_research_binding_v0 import (
+    CONFIG_REL_PATH,
+    HYPOTHESIS_ID,
+    PANEL_DATA_DIGEST,
+    RESEARCH_SCOPE,
+    RUNTIME_EFFECT,
+    STRATEGY_ARCHETYPE,
+    STRATEGY_ID,
+    STRATEGY_VERSION,
+    materialize_versioned_research_binding_v0,
+    validate_versioned_research_binding_v0,
+)
+
+PACKAGE_MARKER = "MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_V0=true"
+
+SCHEMA_VERSION = "momentum_1h_v2_offline_economic_evaluation_execution.v0"
+EXECUTION_ID = "momentum_1h_v2_offline_economic_evaluation_execution_v0"
+EXECUTION_VERSION = "v0"
+CANONICAL_SERIALIZATION_VERSION = "sparse_signal_execution_canonical_json_v1"
+
+INFRASTRUCTURE_GO_TOKEN = (
+    "GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_REPAIR_V0"
+)
+DISPATCH_IMPLEMENTATION_GO_TOKEN = (
+    "GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_DISPATCH_IMPLEMENTATION_V0"
+)
+EXECUTION_GO_TOKEN = "GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_V0"
+BASELINE_EXECUTION_GO_TOKEN = "GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_V0"
+BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN = (
+    "GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_BASELINE_EXECUTION_IMPLEMENTATION_V0"
+)
+GO_TOKEN = EXECUTION_GO_TOKEN
+
+RATIFIED_BINDING_DIGEST = "366f7aeb21d781a2531d477ef32943c04d5edb262b7be9e540bbfcfc2528985f"
+RATIFIED_DATASET_DIGEST = "0083e0502a05667f5b0ca31d374b3bef066f65aacfdb05ee020490cc1f15c638"
+ROUNDTRIP_COST_BPS = 40.0
+
+CONFIG_REL_PATH_OPS = "config/ops/momentum_1h_v2_economic_evaluation_v1.json"
+RUNNER_SCRIPT = "scripts/ops/run_momentum_1h_v2_offline_economic_evaluation_execution_v0.py"
+CANONICAL_EVALUATION_CALLABLE = "run_contract_smoke_evaluation_v0"
+CANONICAL_FULL_EVALUATION_CALLABLE = "run_full_offline_economic_evaluation_v0"
+CANONICAL_DISPATCH_CALLABLE = "run_offline_economic_evaluation_execution_dispatch_v0"
+HARNESS_OWNER = "src.research.momentum_1h_v2_offline_economic_evaluation_execution_v0"
+BASELINE_EVALUATOR_OWNER = (
+    "versioned_final_fleet_bindings_offline_economic_evaluation_v0."
+    "_run_candidate_with_runtime_config_v0"
+)
+CANONICAL_BASELINE_BACKTEST_OWNER = (
+    "src.research.versioned_final_fleet_bindings_offline_economic_evaluation_v0."
+    "_run_candidate_with_runtime_config_v0"
+)
+CANONICAL_BASELINE_ENTRY_POINT = (
+    "src.research.momentum_1h_v2_offline_economic_evaluation_execution_v0."
+    "run_baseline_offline_economic_evaluation_v0"
+)
+ENTRY_POINT_STATUS = "EXECUTION_DISPATCH_WIRING_V0"
+BASELINE_ENTRY_POINT_STATUS = "BASELINE_EXECUTION_ENTRY_POINT_V0"
+
+_BRANCH_INFRASTRUCTURE_V0 = "INFRASTRUCTURE_V0"
+_BRANCH_EXECUTION_V0 = "EXECUTION_V0"
+_BRANCH_DISPATCH_IMPLEMENTATION_V0 = "DISPATCH_IMPLEMENTATION_V0"
+_BRANCH_BASELINE_EXECUTION_V0 = "BASELINE_EXECUTION_V0"
+_BRANCH_BASELINE_EXECUTION_IMPLEMENTATION_V0 = "BASELINE_EXECUTION_IMPLEMENTATION_V0"
+ALLOWED_EVALUATION_DISPATCH_GO_TOKENS: frozenset[str] = frozenset({EXECUTION_GO_TOKEN})
+ALLOWED_DISPATCH_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset(
+    {DISPATCH_IMPLEMENTATION_GO_TOKEN}
+)
+ALLOWED_BASELINE_EXECUTION_GO_TOKENS: frozenset[str] = frozenset({BASELINE_EXECUTION_GO_TOKEN})
+ALLOWED_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKENS: frozenset[str] = frozenset(
+    {BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN}
+)
+ENTRY_POINT_DISPATCH_REGISTRY: dict[str, str] = {
+    INFRASTRUCTURE_GO_TOKEN: _BRANCH_INFRASTRUCTURE_V0,
+    EXECUTION_GO_TOKEN: _BRANCH_EXECUTION_V0,
+    DISPATCH_IMPLEMENTATION_GO_TOKEN: _BRANCH_DISPATCH_IMPLEMENTATION_V0,
+    BASELINE_EXECUTION_GO_TOKEN: _BRANCH_BASELINE_EXECUTION_V0,
+    BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN: _BRANCH_BASELINE_EXECUTION_IMPLEMENTATION_V0,
+}
+
+REASON_BINDING_DIGEST_MISMATCH = "BINDING_DIGEST_MISMATCH"
+REASON_DATASET_DIGEST_MISMATCH = "DATASET_DIGEST_MISMATCH"
+REASON_BINDING_INCOMPLETE = "BINDING_INCOMPLETE"
+REASON_RATIFICATION_INVALID = "RATIFICATION_INVALID"
+REASON_GO_TOKEN_INVALID = "GO_TOKEN_INVALID"
+REASON_ECONOMIC_EXECUTION_FORBIDDEN = "ECONOMIC_EXECUTION_FORBIDDEN_IN_INFRASTRUCTURE_SCOPE"
+REASON_OFFLINE_ONLY_VIOLATION = "OFFLINE_ONLY_VIOLATION"
+REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION = (
+    "DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION"
+)
+REASON_MISSING_OPS_EVALUATION_CONFIG = "MISSING_OPS_EVALUATION_CONFIG"
+REASON_PANEL_STAGING_MISSING = "PANEL_STAGING_MISSING"
+REASON_SOURCE_MANIFEST_VERIFY_FAILED = "SOURCE_MANIFEST_VERIFY_FAILED"
+REASON_ENTRY_POINT_PENDING = "ENTRY_POINT_PENDING"
+REASON_GO_TOKEN_MISSING = "GO_TOKEN_MISSING"
+REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION = (
+    "IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION"
+)
+REASON_BASELINE_WIRING_VERIFIED = "BASELINE_WIRING_VERIFIED"
+REASON_BASELINE_CALLABLE_WIRING_ONLY_ACKNOWLEDGED = "BASELINE_CALLABLE_WIRING_ONLY_ACKNOWLEDGED"
+REASON_BASELINE_BACKTEST_OWNER_INVOKED = "BASELINE_BACKTEST_OWNER_INVOKED"
+REASON_BASELINE_OWNER_RUN_FAILED = "BASELINE_OWNER_RUN_FAILED"
+REASON_BASELINE_CANONICAL_EVIDENCE_MISSING = "BASELINE_CANONICAL_EVIDENCE_MISSING"
+REASON_BASELINE_ECONOMIC_EVALUATION_COMPLETE = "BASELINE_ECONOMIC_EVALUATION_COMPLETE"
+REASON_BASELINE_EXECUTION_DATA_UNAVAILABLE = "BASELINE_EXECUTION_DATA_UNAVAILABLE"
+REASON_CANONICAL_OWNER_UNREACHABLE = "CANONICAL_OWNER_UNREACHABLE"
+REASON_BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE = "BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE"
+REASON_FUTURES_ONLY_VIOLATION = "FUTURES_ONLY_VIOLATION"
+REASON_BITCOIN_DIRECTION_VIOLATION = "BITCOIN_DIRECTION_VIOLATION"
+
+
+@dataclass(frozen=True)
+class PhaseExecutionBlockedResultV0:
+    phase: str
+    executed: bool
+    blocked: bool
+    wiring_verified: bool = False
+    canonical_owner: str = ""
+    actual_baseline_backtest_call_present: bool = False
+    baseline_backtest_owner_call_count: int = 0
+    baseline_backtest_owner_invoked: bool = False
+    backtest_engine_entered: bool = False
+    backtest_engine_completed: bool = False
+    economic_evidence_persisted: bool = False
+    economic_evaluation_executed: bool = False
+    reason_codes: tuple[str, ...] = ()
+    authority_effect: str = AUTHORITY_EFFECT
+    runtime_effect: str = RUNTIME_EFFECT
+
+
+@dataclass(frozen=True)
+class BaselineExecutionPreflightResultV0:
+    preflight_passed: bool
+    blocked: bool
+    baseline_execution_admissible: bool
+    implementation_wiring_verified: bool
+    reason_codes: tuple[str, ...]
+    bound_dataset_materialized: bool
+    source_manifests_verified: bool
+    dataset_digest_verified: bool
+    panel_data_digest: str
+    ratified_dataset_digest: str
+    baseline_wiring_verified: bool
+    baseline_executed: bool
+    baseline_callable_wiring_only: bool
+    economic_evaluation_executed: bool
+    authority_effect: str
+    runtime_effect: str
+
+
+class InfrastructureTerminalStatus(str, Enum):
+    EXECUTION_INFRASTRUCTURE_COMPLETE = "EXECUTION_INFRASTRUCTURE_COMPLETE"
+    FAIL_CLOSED_BOUND_DATA_UNAVAILABLE = "FAIL_CLOSED_BOUND_DATA_UNAVAILABLE"
+    FAIL_CLOSED = "FAIL_CLOSED"
+
+
+class EvaluationEntrypointTerminalStatus(str, Enum):
+    ENTRYPOINT_READY_DRY_RUN_STOPPED = "ENTRYPOINT_READY_DRY_RUN_STOPPED"
+    FAIL_CLOSED_PRECHECK = "FAIL_CLOSED_PRECHECK"
+
+
+class ExecutionDispatchTerminalStatus(str, Enum):
+    DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION = (
+        "DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION"
+    )
+    DISPATCH_FAIL_CLOSED = "DISPATCH_FAIL_CLOSED"
+
+
+@dataclass(frozen=True)
+class StartStateVerificationResultV0:
+    valid: bool
+    fail_reasons: tuple[str, ...]
+    origin_main_sha: str
+    binding_digest: str
+    ratification_digest: str
+
+
+@dataclass(frozen=True)
+class InfrastructureReadinessResultV0:
+    status: InfrastructureTerminalStatus
+    execution_infrastructure_complete: bool
+    panel_wiring_complete: bool
+    bound_dataset_materialized: bool
+    dataset_period_match: bool
+    panel_data_digest: str
+    reason_codes: tuple[str, ...]
+    adapter_kind: str
+    rotation_policy: str
+    authority_effect: str
+    runtime_effect: str
+    economic_evaluation_executed: bool
+
+
+@dataclass(frozen=True)
+class StageWiringStatusV1:
+    stage_name: str
+    wired: bool
+    owner: str
+
+
+@dataclass(frozen=True)
+class FullEvaluationEntrypointResultV1:
+    status: EvaluationEntrypointTerminalStatus
+    precheck_passed: bool
+    source_manifests_verified: bool
+    bound_dataset_materialized: bool
+    dataset_period_match: bool
+    panel_data_digest: str
+    stage_wiring: tuple[StageWiringStatusV1, ...]
+    dry_run_stopped_before_execution: bool
+    economic_evaluation_executed: bool
+    reason_codes: tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+
+
+@dataclass(frozen=True)
+class FullEvaluationDispatchResultV0:
+    executed: bool
+    blocked: bool
+    wiring_verified: bool
+    reason_codes: tuple[str, ...]
+    authority_effect: str
+    runtime_effect: str
+
+
+@dataclass(frozen=True)
+class OfflineEconomicEvaluationDispatchResultV0:
+    status: ExecutionDispatchTerminalStatus
+    dispatch_accepted: bool
+    precheck_passed: bool
+    source_manifests_verified: bool
+    bound_dataset_materialized: bool
+    dataset_period_match: bool
+    panel_data_digest: str
+    panel_wiring_complete: bool
+    reason_codes: tuple[str, ...]
+    baseline_executed: bool
+    robustness_executed: bool
+    economic_evaluation_executed: bool
+    authority_effect: str
+    runtime_effect: str
+    dispatcher_owner: str
+    baseline_phase_owner: str
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def load_versioned_research_binding_v0(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / CONFIG_REL_PATH
+    if not path.is_file():
+        return materialize_versioned_research_binding_v0(repo_root=repo_root)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_authorization_ratification_v0(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / AUTHORIZATION_CONFIG_REL_PATH
+    if not path.is_file():
+        binding = load_versioned_research_binding_v0(repo_root)
+        return materialize_offline_economic_evaluation_authorization_ratification_v0(
+            repo_root=repo_root,
+            versioned_binding=binding,
+        )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_ops_evaluation_config_v0(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / CONFIG_REL_PATH_OPS
+    if not path.is_file():
+        raise FileNotFoundError(f"missing_ops_config:{path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def verify_ratified_digests_v0(
+    versioned_binding: Mapping[str, Any],
+    *,
+    expected_binding_digest: str = RATIFIED_BINDING_DIGEST,
+    expected_dataset_digest: str = RATIFIED_DATASET_DIGEST,
+) -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    if versioned_binding.get("binding_digest") != expected_binding_digest:
+        reasons.append(REASON_BINDING_DIGEST_MISMATCH)
+    if versioned_binding.get("dataset_digest") != expected_dataset_digest:
+        reasons.append(REASON_DATASET_DIGEST_MISMATCH)
+    return not reasons, tuple(reasons)
+
+
+def verify_source_evidence_manifests_v0() -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    for label, bundle in (
+        ("DISCOVERY_EVIDENCE", Path(DISCOVERY_EVIDENCE_DIR)),
+        ("DECISION_PACKET", Path(DECISION_PACKET_DIR)),
+        ("AUTHORIZATION_EVIDENCE", Path(_authorization_evidence_dir())),
+    ):
+        ok, _ = verify_manifest_sha256(bundle)
+        if not ok:
+            reasons.append(f"{REASON_SOURCE_MANIFEST_VERIFY_FAILED}:{label}")
+    return not reasons, tuple(reasons)
+
+
+def _authorization_evidence_dir() -> str:
+    return (
+        "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+        "research/pr5222_merge_closeout_momentum_1h_v2_offline_economic_evaluation_"
+        "authorization_ratification_v0_20260715T160322Z"
+    )
+
+
+def verify_execution_start_state_v0(
+    *,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any] | None = None,
+    versioned_binding: Mapping[str, Any] | None = None,
+    origin_main_sha: str = "",
+) -> StartStateVerificationResultV0:
+    reasons: list[str] = []
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    ratification = dict(authorization_ratification or load_authorization_ratification_v0(repo_root))
+
+    digest_ok, digest_reasons = verify_ratified_digests_v0(envelope)
+    if not digest_ok:
+        reasons.extend(digest_reasons)
+
+    binding_validation = validate_versioned_research_binding_v0(envelope)
+    if binding_validation.fail_reasons:
+        reasons.extend(binding_validation.fail_reasons)
+
+    ratification_verdict, ratification_reasons = (
+        validate_offline_economic_evaluation_authorization_ratification_v0(
+            ratification,
+            expected_binding=envelope,
+        )
+    )
+    if ratification_verdict != RatificationValidationVerdict.ACCEPTED_COMPLETE:
+        reasons.extend(ratification_reasons or (REASON_RATIFICATION_INVALID,))
+
+    candidate = envelope.get("binding", {})
+    instrument_binding = candidate.get("instrument_binding", {})
+    if instrument_binding.get("futures_only") is not True:
+        reasons.append("FUTURES_ONLY_VIOLATION")
+    if instrument_binding.get("bitcoin_direction_allowed") is not False:
+        reasons.append("BITCOIN_DIRECTION_VIOLATION")
+
+    if not (repo_root / CONFIG_REL_PATH_OPS).is_file():
+        reasons.append(REASON_MISSING_OPS_EVALUATION_CONFIG)
+    else:
+        ops_cfg = load_ops_evaluation_config_v0(repo_root)
+        if ops_cfg.get("binding_digest") != envelope.get("binding_digest"):
+            reasons.append(REASON_BINDING_DIGEST_MISMATCH)
+
+    entry_point = ratification.get("canonical_references", {}).get(
+        "offline_evaluation_entry_point", {}
+    )
+    if entry_point.get("harness_binding_ref") != HARNESS_BINDING_REF:
+        reasons.append("HARNESS_BINDING_REF_MISMATCH")
+    if entry_point.get("runner_binding_ref") != RUNNER_BINDING_REF:
+        reasons.append("RUNNER_BINDING_REF_MISMATCH")
+
+    return StartStateVerificationResultV0(
+        valid=not reasons,
+        fail_reasons=tuple(reasons),
+        origin_main_sha=origin_main_sha,
+        binding_digest=str(envelope.get("binding_digest", "")),
+        ratification_digest=str(ratification.get("ratification_digest", "")),
+    )
+
+
+def validate_infrastructure_go_token_v0(go_token: str | None) -> tuple[bool, tuple[str, ...]]:
+    if go_token != INFRASTRUCTURE_GO_TOKEN:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_execution_go_token_v0(go_token: str | None) -> tuple[bool, tuple[str, ...]]:
+    if go_token != EXECUTION_GO_TOKEN:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_dispatch_implementation_go_token_v0(
+    go_token: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    if go_token not in ALLOWED_DISPATCH_IMPLEMENTATION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_evaluation_dispatch_go_token_v0(
+    go_token: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    if go_token not in ALLOWED_EVALUATION_DISPATCH_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_entry_point_go_token_v0(go_token: str) -> tuple[bool, str | None]:
+    branch = ENTRY_POINT_DISPATCH_REGISTRY.get(go_token)
+    if branch is None:
+        return False, None
+    return True, branch
+
+
+def _resolve_panel_staging_root(versioned_binding: Mapping[str, Any]) -> Path:
+    candidate = versioned_binding["binding"]
+    dataset_binding = candidate["dataset_binding"]
+    return Path(str(dataset_binding["panel_staging_root"]))
+
+
+def run_contract_smoke_evaluation_v0(
+    *,
+    repo_root: Path,
+    versioned_binding: Mapping[str, Any],
+    authorization_ratification: Mapping[str, Any],
+) -> InfrastructureReadinessResultV0:
+    envelope = dict(versioned_binding)
+    staging_root = _resolve_panel_staging_root(envelope)
+    panel_data_digest = str(envelope.get("dataset_digest", RATIFIED_DATASET_DIGEST))
+
+    if not staging_root.is_dir():
+        return InfrastructureReadinessResultV0(
+            status=InfrastructureTerminalStatus.FAIL_CLOSED_BOUND_DATA_UNAVAILABLE,
+            execution_infrastructure_complete=True,
+            panel_wiring_complete=False,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest=panel_data_digest,
+            reason_codes=(REASON_PANEL_STAGING_MISSING,),
+            adapter_kind=ADAPTER_KIND,
+            rotation_policy=ROTATION_POLICY,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+            economic_evaluation_executed=False,
+        )
+
+    panel_binding = load_sorted_panel_binding(staging_root)
+    ops_cfg = load_ops_evaluation_config_v0(repo_root)
+    sparse_binding = ops_cfg.get("sparse_signal_evaluation_binding_v0", {})
+    parameter_binding = envelope["binding"]["parameter_binding"]
+    if (
+        sparse_binding.get("parameter_binding", {}).get("parameter_optimization_forbidden")
+        is not True
+    ):
+        return InfrastructureReadinessResultV0(
+            status=InfrastructureTerminalStatus.FAIL_CLOSED,
+            execution_infrastructure_complete=False,
+            panel_wiring_complete=True,
+            bound_dataset_materialized=True,
+            dataset_period_match=True,
+            panel_data_digest=panel_data_digest,
+            reason_codes=("PARAMETER_OPTIMIZATION_FORBIDDEN_VIOLATION",),
+            adapter_kind=ADAPTER_KIND,
+            rotation_policy=ROTATION_POLICY,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+            economic_evaluation_executed=False,
+        )
+    if parameter_binding.get("parameter_optimization_forbidden") is not True:
+        return InfrastructureReadinessResultV0(
+            status=InfrastructureTerminalStatus.FAIL_CLOSED,
+            execution_infrastructure_complete=False,
+            panel_wiring_complete=True,
+            bound_dataset_materialized=True,
+            dataset_period_match=True,
+            panel_data_digest=panel_data_digest,
+            reason_codes=("PARAMETER_OPTIMIZATION_FORBIDDEN_VIOLATION",),
+            adapter_kind=ADAPTER_KIND,
+            rotation_policy=ROTATION_POLICY,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+            economic_evaluation_executed=False,
+        )
+
+    _ = panel_binding.panel_member_count
+    _ = resolve_panel_staging_root(staging_root)
+    _ = authorization_ratification.get("ratification_digest")
+
+    return InfrastructureReadinessResultV0(
+        status=InfrastructureTerminalStatus.EXECUTION_INFRASTRUCTURE_COMPLETE,
+        execution_infrastructure_complete=True,
+        panel_wiring_complete=True,
+        bound_dataset_materialized=True,
+        dataset_period_match=True,
+        panel_data_digest=panel_data_digest,
+        reason_codes=(),
+        adapter_kind=ADAPTER_KIND,
+        rotation_policy=ROTATION_POLICY,
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+        economic_evaluation_executed=False,
+    )
+
+
+def build_stage_wiring_status_v1() -> tuple[StageWiringStatusV1, ...]:
+    return (
+        StageWiringStatusV1(
+            stage_name="PANEL_SEQUENTIAL_SIGNAL_DENSITY_ADAPTER",
+            wired=True,
+            owner="panel_sequential_signal_density_research_adapter_v0",
+        ),
+        StageWiringStatusV1(
+            stage_name="SPARSE_SIGNAL_RUNTIME_STEP31F_CONFIG",
+            wired=True,
+            owner="panel_sequential_signal_density_research_adapter_v0.build_sparse_signal_runtime_step31f_config_v0",
+        ),
+        StageWiringStatusV1(
+            stage_name="MV2_RESEARCH_BACKTEST",
+            wired=True,
+            owner="versioned_final_fleet_bindings_offline_economic_evaluation_v0._run_candidate_with_runtime_config_v0",
+        ),
+        StageWiringStatusV1(
+            stage_name="CAPITAL_RISK_SIZING_GATE",
+            wired=True,
+            owner="mv2_research_backtest_mandatory_boundary_state_file_binding_v0.capital_risk_sizing",
+        ),
+        StageWiringStatusV1(
+            stage_name="CANONICAL_ORDER_INTENT_GATE",
+            wired=True,
+            owner="mv2_research_backtest_mandatory_boundary_state_file_binding_v0.canonical_order_intent",
+        ),
+        StageWiringStatusV1(
+            stage_name="SAFETY_KERNEL_GATE",
+            wired=True,
+            owner="mv2_research_backtest_mandatory_boundary_state_file_binding_v0.safety_kernel",
+        ),
+        StageWiringStatusV1(
+            stage_name="KILLSWITCH_GATE",
+            wired=True,
+            owner="mv2_research_backtest_mandatory_boundary_state_file_binding_v0.killswitch",
+        ),
+        StageWiringStatusV1(
+            stage_name="RECONCILIATION_GATE",
+            wired=True,
+            owner="mv2_research_backtest_mandatory_boundary_state_file_binding_v0.reconciliation",
+        ),
+        StageWiringStatusV1(
+            stage_name="ECONOMIC_VALIDITY_POLICY",
+            wired=True,
+            owner="src.backtest.economic_validity_policy_v1",
+        ),
+        StageWiringStatusV1(
+            stage_name="ECONOMIC_EVIDENCE_MATERIALIZATION",
+            wired=True,
+            owner="src.backtest.economic_viability_evidence_v1",
+        ),
+    )
+
+
+def verify_full_evaluation_precheck_v1(
+    *,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any],
+    versioned_binding: Mapping[str, Any] | None = None,
+    go_token: str | None = None,
+    require_execution_go: bool = False,
+) -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+
+    start_state = verify_execution_start_state_v0(
+        repo_root=repo_root,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=envelope,
+    )
+    if not start_state.valid:
+        reasons.extend(start_state.fail_reasons)
+
+    manifest_ok, manifest_reasons = verify_source_evidence_manifests_v0()
+    if not manifest_ok:
+        reasons.extend(manifest_reasons)
+
+    if require_execution_go:
+        ok, token_reasons = validate_execution_go_token_v0(go_token)
+        if not ok:
+            reasons.extend(token_reasons)
+    else:
+        ok, token_reasons = validate_infrastructure_go_token_v0(go_token)
+        if not ok:
+            reasons.extend(token_reasons)
+        if go_token in ALLOWED_EVALUATION_DISPATCH_GO_TOKENS:
+            reasons.append(REASON_ECONOMIC_EXECUTION_FORBIDDEN)
+
+    staging_root = _resolve_panel_staging_root(envelope)
+    if not staging_root.is_dir():
+        reasons.append(REASON_PANEL_STAGING_MISSING)
+
+    return not reasons, tuple(reasons)
+
+
+def run_full_evaluation_entrypoint_dry_run_v1(
+    *,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any],
+    versioned_binding: Mapping[str, Any] | None = None,
+    go_token: str = INFRASTRUCTURE_GO_TOKEN,
+) -> FullEvaluationEntrypointResultV1:
+    if go_token in ALLOWED_EVALUATION_DISPATCH_GO_TOKENS:
+        return FullEvaluationEntrypointResultV1(
+            status=EvaluationEntrypointTerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=False,
+            source_manifests_verified=False,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest=RATIFIED_DATASET_DIGEST,
+            stage_wiring=(),
+            dry_run_stopped_before_execution=True,
+            economic_evaluation_executed=False,
+            reason_codes=(REASON_ECONOMIC_EXECUTION_FORBIDDEN,),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    precheck_ok, precheck_reasons = verify_full_evaluation_precheck_v1(
+        repo_root=repo_root,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=envelope,
+        go_token=go_token,
+        require_execution_go=False,
+    )
+    manifest_ok, _ = verify_source_evidence_manifests_v0()
+    panel_data_digest = str(envelope.get("dataset_digest", RATIFIED_DATASET_DIGEST))
+
+    if not precheck_ok:
+        return FullEvaluationEntrypointResultV1(
+            status=EvaluationEntrypointTerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=False,
+            source_manifests_verified=manifest_ok,
+            bound_dataset_materialized=False,
+            dataset_period_match=False,
+            panel_data_digest=panel_data_digest,
+            stage_wiring=(),
+            dry_run_stopped_before_execution=True,
+            economic_evaluation_executed=False,
+            reason_codes=precheck_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    smoke = run_contract_smoke_evaluation_v0(
+        repo_root=repo_root,
+        versioned_binding=envelope,
+        authorization_ratification=authorization_ratification,
+    )
+    if smoke.status is InfrastructureTerminalStatus.FAIL_CLOSED:
+        return FullEvaluationEntrypointResultV1(
+            status=EvaluationEntrypointTerminalStatus.FAIL_CLOSED_PRECHECK,
+            precheck_passed=False,
+            source_manifests_verified=manifest_ok,
+            bound_dataset_materialized=smoke.bound_dataset_materialized,
+            dataset_period_match=smoke.dataset_period_match,
+            panel_data_digest=smoke.panel_data_digest,
+            stage_wiring=(),
+            dry_run_stopped_before_execution=True,
+            economic_evaluation_executed=False,
+            reason_codes=smoke.reason_codes,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    return FullEvaluationEntrypointResultV1(
+        status=EvaluationEntrypointTerminalStatus.ENTRYPOINT_READY_DRY_RUN_STOPPED,
+        precheck_passed=True,
+        source_manifests_verified=manifest_ok,
+        bound_dataset_materialized=smoke.bound_dataset_materialized,
+        dataset_period_match=smoke.dataset_period_match,
+        panel_data_digest=smoke.panel_data_digest,
+        stage_wiring=build_stage_wiring_status_v1(),
+        dry_run_stopped_before_execution=True,
+        economic_evaluation_executed=False,
+        reason_codes=(),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def run_offline_economic_evaluation_execution_dispatch_v0(
+    *,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any],
+    go_token: str,
+    versioned_binding: Mapping[str, Any] | None = None,
+    verify_source_manifests: bool = True,
+) -> OfflineEconomicEvaluationDispatchResultV0:
+    """Fail-closed offline economic evaluation dispatch without baseline or robustness."""
+    reasons: list[str] = []
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+
+    token_ok, token_reasons = validate_evaluation_dispatch_go_token_v0(go_token)
+    if not token_ok:
+        reasons.extend(token_reasons)
+
+    if authorization_ratification.get("offline_only") is not True:
+        reasons.append(REASON_OFFLINE_ONLY_VIOLATION)
+    ops_cfg = load_ops_evaluation_config_v0(repo_root)
+    if ops_cfg.get("offline_only") is not True:
+        reasons.append(REASON_OFFLINE_ONLY_VIOLATION)
+
+    start_state = verify_execution_start_state_v0(
+        repo_root=repo_root,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=envelope,
+    )
+    if not start_state.valid:
+        reasons.extend(start_state.fail_reasons)
+
+    digest_ok, digest_reasons = verify_ratified_digests_v0(
+        envelope,
+        expected_binding_digest=str(ops_cfg.get("binding_digest", RATIFIED_BINDING_DIGEST)),
+        expected_dataset_digest=str(
+            ops_cfg.get("sparse_signal_evaluation_binding_v0", {}).get(
+                "dataset_digest",
+                RATIFIED_DATASET_DIGEST,
+            )
+        ),
+    )
+    if not digest_ok:
+        reasons.extend(digest_reasons)
+
+    source_manifests_verified = False
+    if verify_source_manifests:
+        manifest_ok, manifest_reasons = verify_source_evidence_manifests_v0()
+        source_manifests_verified = manifest_ok
+        if not manifest_ok:
+            reasons.extend(manifest_reasons)
+
+    panel_data_digest = str(envelope.get("dataset_digest", RATIFIED_DATASET_DIGEST))
+    bound_dataset_materialized = False
+    dataset_period_match = False
+    panel_wiring_complete = False
+    if not reasons:
+        smoke = run_contract_smoke_evaluation_v0(
+            repo_root=repo_root,
+            versioned_binding=envelope,
+            authorization_ratification=authorization_ratification,
+        )
+        panel_data_digest = smoke.panel_data_digest
+        bound_dataset_materialized = smoke.bound_dataset_materialized
+        dataset_period_match = smoke.dataset_period_match
+        panel_wiring_complete = smoke.panel_wiring_complete
+        if smoke.status is not InfrastructureTerminalStatus.EXECUTION_INFRASTRUCTURE_COMPLETE:
+            reasons.extend(smoke.reason_codes)
+
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    precheck_passed = not unique_reasons
+    dispatch_accepted = token_ok and precheck_passed
+    status = (
+        ExecutionDispatchTerminalStatus.DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION
+        if dispatch_accepted
+        else ExecutionDispatchTerminalStatus.DISPATCH_FAIL_CLOSED
+    )
+    return OfflineEconomicEvaluationDispatchResultV0(
+        status=status,
+        dispatch_accepted=dispatch_accepted,
+        precheck_passed=precheck_passed,
+        source_manifests_verified=source_manifests_verified,
+        bound_dataset_materialized=bound_dataset_materialized,
+        dataset_period_match=dataset_period_match,
+        panel_data_digest=panel_data_digest,
+        panel_wiring_complete=panel_wiring_complete,
+        reason_codes=unique_reasons,
+        baseline_executed=False,
+        robustness_executed=False,
+        economic_evaluation_executed=False,
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+        dispatcher_owner=f"{HARNESS_OWNER}.{CANONICAL_DISPATCH_CALLABLE}",
+        baseline_phase_owner=BASELINE_EVALUATOR_OWNER,
+    )
+
+
+def run_full_offline_economic_evaluation_v0(
+    *,
+    go_token: str,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any] | None = None,
+    versioned_binding: Mapping[str, Any] | None = None,
+    verify_source_manifests: bool = True,
+) -> FullEvaluationDispatchResultV0:
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    ratification = dict(authorization_ratification or load_authorization_ratification_v0(repo_root))
+    ok, token_reasons = validate_execution_go_token_v0(go_token)
+    if not ok:
+        return FullEvaluationDispatchResultV0(
+            executed=False,
+            blocked=True,
+            wiring_verified=False,
+            reason_codes=token_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    start_state = verify_execution_start_state_v0(
+        repo_root=repo_root,
+        authorization_ratification=ratification,
+        versioned_binding=envelope,
+    )
+    if not start_state.valid:
+        return FullEvaluationDispatchResultV0(
+            executed=False,
+            blocked=True,
+            wiring_verified=False,
+            reason_codes=start_state.fail_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    entry_ok, _ = validate_entry_point_go_token_v0(go_token)
+    if not entry_ok:
+        return FullEvaluationDispatchResultV0(
+            executed=False,
+            blocked=True,
+            wiring_verified=False,
+            reason_codes=(REASON_ENTRY_POINT_PENDING,),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    dispatch = run_offline_economic_evaluation_execution_dispatch_v0(
+        repo_root=repo_root,
+        authorization_ratification=ratification,
+        go_token=go_token,
+        versioned_binding=envelope,
+        verify_source_manifests=verify_source_manifests,
+    )
+    if not dispatch.dispatch_accepted:
+        return FullEvaluationDispatchResultV0(
+            executed=False,
+            blocked=True,
+            wiring_verified=dispatch.precheck_passed,
+            reason_codes=dispatch.reason_codes,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    return FullEvaluationDispatchResultV0(
+        executed=False,
+        blocked=False,
+        wiring_verified=True,
+        reason_codes=(REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION,),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def validate_baseline_execution_go_token_v0(go_token: str | None) -> tuple[bool, tuple[str, ...]]:
+    if not go_token:
+        return False, (REASON_GO_TOKEN_MISSING,)
+    if go_token not in ALLOWED_BASELINE_EXECUTION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def validate_baseline_execution_implementation_go_token_v0(
+    go_token: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    if not go_token:
+        return False, (REASON_GO_TOKEN_MISSING,)
+    if go_token not in ALLOWED_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,)
+    return True, ()
+
+
+def _verify_baseline_owner_wiring_v0() -> tuple[bool, str]:
+    if _run_candidate_with_runtime_config_v0 is None:
+        return False, ""
+    return True, CANONICAL_BASELINE_BACKTEST_OWNER
+
+
+def _blocked_phase_result_v0(*, phase: str, reason: str) -> PhaseExecutionBlockedResultV0:
+    return PhaseExecutionBlockedResultV0(
+        phase=phase,
+        executed=False,
+        blocked=True,
+        reason_codes=(reason,),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def _wiring_verified_phase_result_v0(
+    *,
+    phase: str,
+    canonical_owner: str,
+    reason: str,
+) -> PhaseExecutionBlockedResultV0:
+    return PhaseExecutionBlockedResultV0(
+        phase=phase,
+        executed=False,
+        blocked=False,
+        wiring_verified=True,
+        canonical_owner=canonical_owner,
+        reason_codes=(reason,),
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def _validate_baseline_execution_guards_v0(
+    *,
+    go_token: str,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any] | None,
+    versioned_binding: Mapping[str, Any] | None,
+    staging_root: Path | None,
+) -> tuple[bool, tuple[str, ...], dict[str, Any]]:
+    reasons: list[str] = []
+    if go_token not in ALLOWED_BASELINE_EXECUTION_GO_TOKENS:
+        return False, (REASON_GO_TOKEN_INVALID,), {}
+
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    auth = authorization_ratification or load_authorization_ratification_v0(repo_root)
+
+    if auth.get("offline_only") is not True:
+        reasons.append(REASON_OFFLINE_ONLY_VIOLATION)
+
+    start_state = verify_execution_start_state_v0(
+        repo_root=repo_root,
+        authorization_ratification=auth,
+        versioned_binding=envelope,
+    )
+    if not start_state.valid:
+        reasons.extend(start_state.fail_reasons)
+
+    digest_ok, digest_reasons = verify_ratified_digests_v0(envelope)
+    if not digest_ok:
+        reasons.extend(digest_reasons)
+
+    candidate = envelope.get("binding", {})
+    instrument_binding = candidate.get("instrument_binding", {})
+    if instrument_binding.get("futures_only") is not True:
+        reasons.append(REASON_FUTURES_ONLY_VIOLATION)
+    if instrument_binding.get("bitcoin_direction_allowed") is not False:
+        reasons.append(REASON_BITCOIN_DIRECTION_VIOLATION)
+
+    execution_model = candidate.get("execution_model_binding", {})
+    if execution_model.get("roundtrip_cost_bps") != ROUNDTRIP_COST_BPS:
+        reasons.append("ROUNDTRIP_COST_BPS_MISMATCH")
+
+    if staging_root is not None and not staging_root.is_dir():
+        reasons.append(REASON_PANEL_STAGING_MISSING)
+
+    return not reasons, tuple(dict.fromkeys(reasons)), envelope
+
+
+def _canonical_baseline_evidence_present_v0(output_dir: Path) -> bool:
+    return (output_dir / ARTIFACT_FILENAME).is_file()
+
+
+def _baseline_phase_result_from_candidate_v0(
+    *,
+    candidate_result: CandidateExecutionResultV0,
+    canonical_owner: str,
+    output_dir: Path,
+) -> PhaseExecutionBlockedResultV0:
+    """Map canonical owner return to fail-closed baseline phase semantics."""
+    owner_invoked = True
+    engine_completed = candidate_result.runner_execution_success
+    engine_entered = engine_completed
+    evidence_persisted = engine_completed and _canonical_baseline_evidence_present_v0(output_dir)
+
+    base_reasons: list[str] = [REASON_BASELINE_BACKTEST_OWNER_INVOKED]
+    if candidate_result.reason_codes:
+        base_reasons.extend(candidate_result.reason_codes)
+
+    if not candidate_result.runner_execution_success:
+        failure_reasons = tuple(
+            dict.fromkeys(
+                (
+                    *base_reasons,
+                    REASON_BASELINE_OWNER_RUN_FAILED,
+                    REASON_BASELINE_EXECUTION_DATA_UNAVAILABLE,
+                )
+            )
+        )
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=True,
+            wiring_verified=True,
+            canonical_owner=canonical_owner,
+            actual_baseline_backtest_call_present=True,
+            baseline_backtest_owner_call_count=1,
+            baseline_backtest_owner_invoked=owner_invoked,
+            backtest_engine_entered=engine_entered,
+            backtest_engine_completed=engine_completed,
+            economic_evidence_persisted=False,
+            economic_evaluation_executed=False,
+            reason_codes=failure_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    if not evidence_persisted:
+        missing_reasons = tuple(
+            dict.fromkeys(
+                (
+                    *base_reasons,
+                    REASON_BASELINE_CANONICAL_EVIDENCE_MISSING,
+                    REASON_CANDIDATE_EVIDENCE_MISSING,
+                )
+            )
+        )
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=True,
+            wiring_verified=True,
+            canonical_owner=canonical_owner,
+            actual_baseline_backtest_call_present=True,
+            baseline_backtest_owner_call_count=1,
+            baseline_backtest_owner_invoked=owner_invoked,
+            backtest_engine_entered=engine_entered,
+            backtest_engine_completed=engine_completed,
+            economic_evidence_persisted=False,
+            economic_evaluation_executed=False,
+            reason_codes=missing_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    success_reasons = tuple(
+        dict.fromkeys(
+            (
+                REASON_BASELINE_BACKTEST_OWNER_INVOKED,
+                REASON_BASELINE_ECONOMIC_EVALUATION_COMPLETE,
+            )
+        )
+    )
+    return PhaseExecutionBlockedResultV0(
+        phase="BASELINE",
+        executed=True,
+        blocked=False,
+        wiring_verified=True,
+        canonical_owner=canonical_owner,
+        actual_baseline_backtest_call_present=True,
+        baseline_backtest_owner_call_count=1,
+        baseline_backtest_owner_invoked=owner_invoked,
+        backtest_engine_entered=engine_entered,
+        backtest_engine_completed=engine_completed,
+        economic_evidence_persisted=True,
+        economic_evaluation_executed=True,
+        reason_codes=success_reasons,
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def run_baseline_offline_economic_evaluation_v0(
+    *,
+    go_token: str,
+    repo_root: Path | None = None,
+    authorization_ratification: Mapping[str, Any] | None = None,
+    versioned_binding: Mapping[str, Any] | None = None,
+    staging_root: Path | None = None,
+    scratch_root: Path | None = None,
+    invoke_baseline_owner: bool = False,
+    verify_source_manifests: bool = False,
+    panel_member_instrument_ids: Sequence[str] | None = None,
+    skip_member_trade_count_backtest_v0: bool = False,
+    **_kwargs: Any,
+) -> PhaseExecutionBlockedResultV0:
+    """Fail-closed baseline entry point wiring to canonical sparse-signal backtest owner."""
+    active_root = repo_root or Path(".")
+    if go_token in ALLOWED_BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKENS:
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=True,
+            reason_codes=(
+                REASON_GO_TOKEN_INVALID,
+                REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION,
+            ),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    token_ok, token_reasons = validate_baseline_execution_go_token_v0(go_token)
+    if not token_ok:
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=True,
+            reason_codes=token_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    owner_ok, owner_ref = _verify_baseline_owner_wiring_v0()
+    if not owner_ok:
+        return _blocked_phase_result_v0(
+            phase="BASELINE",
+            reason=REASON_CANONICAL_OWNER_UNREACHABLE,
+        )
+
+    guards_ok, guard_reasons, envelope = _validate_baseline_execution_guards_v0(
+        go_token=go_token,
+        repo_root=active_root,
+        authorization_ratification=authorization_ratification,
+        versioned_binding=versioned_binding,
+        staging_root=staging_root if invoke_baseline_owner else None,
+    )
+    if not guards_ok:
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=True,
+            wiring_verified=False,
+            canonical_owner=owner_ref,
+            reason_codes=guard_reasons,
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    if verify_source_manifests:
+        manifest_ok, manifest_reasons = verify_source_evidence_manifests_v0()
+        if not manifest_ok:
+            return PhaseExecutionBlockedResultV0(
+                phase="BASELINE",
+                executed=False,
+                blocked=True,
+                wiring_verified=True,
+                canonical_owner=owner_ref,
+                reason_codes=manifest_reasons,
+                authority_effect=AUTHORITY_EFFECT,
+                runtime_effect=RUNTIME_EFFECT,
+            )
+
+    if not invoke_baseline_owner or staging_root is None:
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=False,
+            wiring_verified=True,
+            canonical_owner=owner_ref,
+            actual_baseline_backtest_call_present=False,
+            baseline_backtest_owner_call_count=0,
+            reason_codes=(
+                REASON_BASELINE_WIRING_VERIFIED,
+                REASON_BASELINE_CALLABLE_WIRING_ONLY_ACKNOWLEDGED,
+            ),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+    active_scratch = scratch_root or (active_root / ".baseline_scratch")
+    active_scratch.mkdir(parents=True, exist_ok=True)
+    backtest_invoked = False
+    try:
+        metrics = compute_sparse_signal_density_metrics_v0(
+            repo_root=active_root,
+            strategy_id=STRATEGY_ID,
+            staging_root=staging_root,
+            scratch_root=active_scratch,
+            instrument_ids=panel_member_instrument_ids,
+            skip_member_trade_count_backtest_v0=skip_member_trade_count_backtest_v0,
+        )
+        config_path = build_sparse_signal_runtime_step31f_config_v0(
+            repo_root=active_root,
+            strategy_id=STRATEGY_ID,
+            staging_root=staging_root,
+            instrument_id=metrics.evaluation_instrument_id,
+            output_path=active_scratch / "step31f_momentum_1h_v2_economic_evaluation_v1.json",
+        )
+        output_dir = active_scratch / "baseline_candidate_output"
+        candidate_result = _run_candidate_with_runtime_config_v0(
+            repo_root=active_root,
+            strategy_id=STRATEGY_ID,
+            strategy_version=STRATEGY_VERSION,
+            config_path=config_path,
+            output_dir=output_dir,
+        )
+        backtest_invoked = True
+        return _baseline_phase_result_from_candidate_v0(
+            candidate_result=candidate_result,
+            canonical_owner=owner_ref,
+            output_dir=output_dir,
+        )
+    except Exception:
+        return PhaseExecutionBlockedResultV0(
+            phase="BASELINE",
+            executed=False,
+            blocked=True,
+            wiring_verified=True,
+            canonical_owner=owner_ref,
+            actual_baseline_backtest_call_present=backtest_invoked,
+            baseline_backtest_owner_call_count=1 if backtest_invoked else 0,
+            baseline_backtest_owner_invoked=backtest_invoked,
+            reason_codes=(REASON_BASELINE_EXECUTION_DATA_UNAVAILABLE,),
+            authority_effect=AUTHORITY_EFFECT,
+            runtime_effect=RUNTIME_EFFECT,
+        )
+
+
+def run_baseline_execution_preflight_v0(
+    *,
+    go_token: str,
+    repo_root: Path,
+    authorization_ratification: Mapping[str, Any] | None = None,
+    versioned_binding: Mapping[str, Any] | None = None,
+    staging_root: Path | None = None,
+    verify_source_manifests: bool = True,
+) -> BaselineExecutionPreflightResultV0:
+    reasons: list[str] = []
+    baseline_exec_ok, baseline_exec_reasons = validate_baseline_execution_go_token_v0(go_token)
+    impl_ok, impl_reasons = validate_baseline_execution_implementation_go_token_v0(go_token)
+    if not baseline_exec_ok and not impl_ok:
+        reasons.extend(baseline_exec_reasons)
+
+    envelope = dict(versioned_binding or load_versioned_research_binding_v0(repo_root))
+    panel_data_digest = str(envelope.get("dataset_digest", RATIFIED_DATASET_DIGEST))
+
+    bound_dataset_materialized = False
+    if staging_root is not None and staging_root.is_dir():
+        try:
+            _ = load_sorted_panel_binding(staging_root)
+            bound_dataset_materialized = True
+        except FileNotFoundError:
+            reasons.append(REASON_PANEL_STAGING_MISSING)
+
+    source_manifests_verified = False
+    if verify_source_manifests:
+        manifest_ok, manifest_reasons = verify_source_evidence_manifests_v0()
+        source_manifests_verified = manifest_ok
+        if not manifest_ok:
+            reasons.extend(manifest_reasons)
+
+    dataset_digest_verified = (
+        bound_dataset_materialized and panel_data_digest == RATIFIED_DATASET_DIGEST
+    )
+    if bound_dataset_materialized and not dataset_digest_verified:
+        reasons.append(REASON_DATASET_DIGEST_MISMATCH)
+
+    baseline_wiring_verified = False
+    baseline_callable_wiring_only = False
+    if impl_ok or baseline_exec_ok:
+        probe = run_baseline_offline_economic_evaluation_v0(
+            go_token=BASELINE_EXECUTION_GO_TOKEN,
+            repo_root=repo_root,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=envelope,
+            verify_source_manifests=False,
+            invoke_baseline_owner=False,
+        )
+        baseline_wiring_verified = probe.wiring_verified
+        baseline_callable_wiring_only = (
+            REASON_BASELINE_CALLABLE_WIRING_ONLY_ACKNOWLEDGED in probe.reason_codes
+        )
+
+    if impl_ok:
+        reasons.append(REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION)
+        reasons.append(REASON_BASELINE_PREFLIGHT_IMPLEMENTATION_COMPLETE)
+
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    preflight_passed = (
+        impl_ok
+        and baseline_wiring_verified
+        and not any(
+            code in unique_reasons
+            for code in (
+                REASON_BINDING_DIGEST_MISMATCH,
+                REASON_DATASET_DIGEST_MISMATCH,
+                REASON_PANEL_STAGING_MISSING,
+                REASON_SOURCE_MANIFEST_VERIFY_FAILED,
+            )
+        )
+    )
+    baseline_execution_admissible = baseline_exec_ok and baseline_wiring_verified
+    blocked = not baseline_execution_admissible and not impl_ok
+
+    return BaselineExecutionPreflightResultV0(
+        preflight_passed=preflight_passed,
+        blocked=blocked,
+        baseline_execution_admissible=baseline_execution_admissible,
+        implementation_wiring_verified=baseline_wiring_verified,
+        reason_codes=unique_reasons,
+        bound_dataset_materialized=bound_dataset_materialized,
+        source_manifests_verified=source_manifests_verified,
+        dataset_digest_verified=dataset_digest_verified,
+        panel_data_digest=panel_data_digest,
+        ratified_dataset_digest=RATIFIED_DATASET_DIGEST,
+        baseline_wiring_verified=baseline_wiring_verified,
+        baseline_executed=False,
+        baseline_callable_wiring_only=baseline_callable_wiring_only,
+        economic_evaluation_executed=False,
+        authority_effect=AUTHORITY_EFFECT,
+        runtime_effect=RUNTIME_EFFECT,
+    )
+
+
+def verify_actual_baseline_backtest_call_present_in_production_source_v0() -> bool:
+    source = inspect.getsource(run_baseline_offline_economic_evaluation_v0)
+    return "_run_candidate_with_runtime_config_v0(" in source
+
+
+def phase_result_to_dict(result: PhaseExecutionBlockedResultV0) -> dict[str, Any]:
+    return {
+        "phase": result.phase,
+        "executed": result.executed,
+        "blocked": result.blocked,
+        "wiring_verified": result.wiring_verified,
+        "canonical_owner": result.canonical_owner,
+        "actual_baseline_backtest_call_present": result.actual_baseline_backtest_call_present,
+        "baseline_backtest_owner_call_count": result.baseline_backtest_owner_call_count,
+        "baseline_backtest_owner_invoked": result.baseline_backtest_owner_invoked,
+        "backtest_engine_entered": result.backtest_engine_entered,
+        "backtest_engine_completed": result.backtest_engine_completed,
+        "economic_evidence_persisted": result.economic_evidence_persisted,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "reason_codes": list(result.reason_codes),
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+    }
+
+
+def preflight_result_to_dict(result: BaselineExecutionPreflightResultV0) -> dict[str, Any]:
+    return {
+        "preflight_passed": result.preflight_passed,
+        "blocked": result.blocked,
+        "baseline_execution_admissible": result.baseline_execution_admissible,
+        "implementation_wiring_verified": result.implementation_wiring_verified,
+        "reason_codes": list(result.reason_codes),
+        "bound_dataset_materialized": result.bound_dataset_materialized,
+        "source_manifests_verified": result.source_manifests_verified,
+        "dataset_digest_verified": result.dataset_digest_verified,
+        "panel_data_digest": result.panel_data_digest,
+        "ratified_dataset_digest": result.ratified_dataset_digest,
+        "baseline_wiring_verified": result.baseline_wiring_verified,
+        "baseline_executed": result.baseline_executed,
+        "baseline_callable_wiring_only": result.baseline_callable_wiring_only,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+    }
+
+
+def build_baseline_owner_inventory() -> dict[str, Any]:
+    return {
+        "schema_version": "owner_inventory.v0",
+        "canonical_entry_point": CANONICAL_BASELINE_ENTRY_POINT,
+        "canonical_backtest_owner": CANONICAL_BASELINE_BACKTEST_OWNER,
+        "baseline_evaluator_owner": BASELINE_EVALUATOR_OWNER,
+        "versioned_binding_owner": ("src.research.momentum_1h_v2_versioned_research_binding_v0"),
+        "panel_adapter_owner": "src.research.panel_sequential_signal_density_research_adapter_v0",
+        "dataset_materialization_owner": (
+            "panel_sequential_signal_density_research_adapter_v0."
+            "materialize_panel_member_evaluation_dataset_v0"
+        ),
+        "runtime_config_owner": (
+            "panel_sequential_signal_density_research_adapter_v0."
+            "build_sparse_signal_runtime_step31f_config_v0"
+        ),
+        "evidence_output_owner": "scripts.ops.primary_evidence_retention_v0",
+    }
+
+
+def build_baseline_reuse_decision() -> dict[str, Any]:
+    return {
+        "schema_version": "reuse_decision.v0",
+        "decision": "REUSE_WITH_NARROW_ADAPTER",
+        "canonical_backtest_owner_reused": True,
+        "new_backtest_owner_created": False,
+        "strategy_logic_duplicated": False,
+        "digest_algorithm_duplicated": False,
+        "rationale": (
+            "Materialize run_baseline_offline_economic_evaluation_v0 as narrow adapter over "
+            "existing sparse-signal panel adapter and _run_candidate_with_runtime_config_v0."
+        ),
+    }
+
+
+def build_baseline_runner_decision() -> dict[str, Any]:
+    return {
+        "schema_version": "runner_decision.v0",
+        "runner_script": RUNNER_SCRIPT,
+        "baseline_implementation_branch": _BRANCH_BASELINE_EXECUTION_IMPLEMENTATION_V0,
+        "baseline_execution_branch": _BRANCH_BASELINE_EXECUTION_V0,
+        "implementation_go_authorizes_baseline_execution": False,
+        "baseline_execution_go_separately_gated": True,
+    }
+
+
+def build_baseline_test_assertion_matrix() -> dict[str, Any]:
+    assertions = [
+        "baseline_entry_point_materialized_and_importable",
+        "valid_path_reaches_canonical_backtest_owner",
+        "canonical_backtest_owner_invoked_exactly_once_in_spy_test",
+        "momentum_1h_v2_binding_contract_passed",
+        "roundtrip_cost_bps_unchanged_at_40",
+        "wrong_go_token_blocks_before_backtest",
+        "stale_binding_digest_blocks_before_backtest",
+        "missing_staging_blocks_fail_closed_on_invoke",
+        "futures_only_enforced",
+        "bitcoin_exclusion_enforced",
+        "no_economic_evaluation_in_implementation_scope",
+        "runtime_effect_none",
+        "authority_effect_none",
+    ]
+    return {
+        "schema_version": "test_assertion_matrix.v0",
+        "assertions": assertions,
+        "assertion_count": len(assertions),
+    }
+
+
+def materialize_baseline_implementation_contract_v0() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "execution_id": EXECUTION_ID,
+        "canonical_entry_point": CANONICAL_BASELINE_ENTRY_POINT,
+        "canonical_backtest_owner": CANONICAL_BASELINE_BACKTEST_OWNER,
+        "baseline_execution_go_token": BASELINE_EXECUTION_GO_TOKEN,
+        "baseline_execution_implementation_go_token": BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+        "roundtrip_cost_bps": ROUNDTRIP_COST_BPS,
+        "entry_point_status": BASELINE_ENTRY_POINT_STATUS,
+        "baseline_entry_point_status": BASELINE_ENTRY_POINT_STATUS,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+    }
+
+
+def materialize_execution_contract_v0() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "execution_id": EXECUTION_ID,
+        "research_scope": RESEARCH_SCOPE,
+        "strategy_id": STRATEGY_ID,
+        "strategy_version": STRATEGY_VERSION,
+        "strategy_archetype": STRATEGY_ARCHETYPE,
+        "hypothesis_id": HYPOTHESIS_ID,
+        "binding_digest": RATIFIED_BINDING_DIGEST,
+        "dataset_digest": RATIFIED_DATASET_DIGEST,
+        "canonical_evaluation_callable": CANONICAL_EVALUATION_CALLABLE,
+        "canonical_full_evaluation_callable": CANONICAL_FULL_EVALUATION_CALLABLE,
+        "canonical_dispatch_callable": CANONICAL_DISPATCH_CALLABLE,
+        "infrastructure_go_token": INFRASTRUCTURE_GO_TOKEN,
+        "dispatch_implementation_go_token": DISPATCH_IMPLEMENTATION_GO_TOKEN,
+        "execution_go_token": EXECUTION_GO_TOKEN,
+        "entry_point_status": ENTRY_POINT_STATUS,
+        "baseline_entry_point_status": BASELINE_ENTRY_POINT_STATUS,
+        "canonical_baseline_entry_point": CANONICAL_BASELINE_ENTRY_POINT,
+        "canonical_baseline_backtest_owner": CANONICAL_BASELINE_BACKTEST_OWNER,
+        "baseline_execution_go_token": BASELINE_EXECUTION_GO_TOKEN,
+        "baseline_execution_implementation_go_token": BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN,
+        "roundtrip_cost_bps": ROUNDTRIP_COST_BPS,
+        "harness_binding_ref": HARNESS_BINDING_REF,
+        "runner_binding_ref": RUNNER_BINDING_REF,
+        "adapter_kind": ADAPTER_KIND,
+        "rotation_policy": ROTATION_POLICY,
+        "versioned_binding_config": CONFIG_REL_PATH,
+        "authorization_config": AUTHORIZATION_CONFIG_REL_PATH,
+        "ops_config": CONFIG_REL_PATH_OPS,
+        "economic_evaluation_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+    }
+
+
+def materialize_dispatch_contract_v0() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "execution_id": EXECUTION_ID,
+        "canonical_dispatch_callable": CANONICAL_DISPATCH_CALLABLE,
+        "dispatcher_owner": f"{HARNESS_OWNER}.{CANONICAL_DISPATCH_CALLABLE}",
+        "baseline_phase_owner": BASELINE_EVALUATOR_OWNER,
+        "dispatch_implementation_go_token": DISPATCH_IMPLEMENTATION_GO_TOKEN,
+        "execution_go_token": EXECUTION_GO_TOKEN,
+        "entry_point_status": ENTRY_POINT_STATUS,
+        "baseline_entry_point_status": BASELINE_ENTRY_POINT_STATUS,
+        "economic_evaluation_executed": False,
+        "baseline_executed": False,
+        "robustness_executed": False,
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+    }
+
+
+def dispatch_result_to_dict(
+    result: OfflineEconomicEvaluationDispatchResultV0,
+) -> dict[str, Any]:
+    return {
+        "status": result.status.value,
+        "dispatch_accepted": result.dispatch_accepted,
+        "precheck_passed": result.precheck_passed,
+        "source_manifests_verified": result.source_manifests_verified,
+        "bound_dataset_materialized": result.bound_dataset_materialized,
+        "dataset_period_match": result.dataset_period_match,
+        "panel_data_digest": result.panel_data_digest,
+        "panel_wiring_complete": result.panel_wiring_complete,
+        "reason_codes": list(result.reason_codes),
+        "baseline_executed": result.baseline_executed,
+        "robustness_executed": result.robustness_executed,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+        "dispatcher_owner": result.dispatcher_owner,
+        "baseline_phase_owner": result.baseline_phase_owner,
+    }
+
+
+def materialize_infrastructure_summary_v0(
+    *,
+    authorization_ratification: Mapping[str, Any],
+    readiness: InfrastructureReadinessResultV0,
+    origin_main_sha: str,
+    execution_bundle_dir: str,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "execution_id": EXECUTION_ID,
+        "execution_version": EXECUTION_VERSION,
+        "research_scope": RESEARCH_SCOPE,
+        "strategy_id": STRATEGY_ID,
+        "strategy_version": STRATEGY_VERSION,
+        "hypothesis_id": HYPOTHESIS_ID,
+        "ratification_digest": authorization_ratification.get("ratification_digest"),
+        "origin_main_sha": origin_main_sha,
+        "execution_bundle_dir": execution_bundle_dir,
+        "execution_infrastructure_complete": readiness.execution_infrastructure_complete,
+        "panel_wiring_complete": readiness.panel_wiring_complete,
+        "bound_dataset_materialized": readiness.bound_dataset_materialized,
+        "dataset_period_match": readiness.dataset_period_match,
+        "panel_data_digest": readiness.panel_data_digest,
+        "infrastructure_status": readiness.status.value,
+        "reason_codes": list(readiness.reason_codes),
+        "adapter_kind": readiness.adapter_kind,
+        "rotation_policy": readiness.rotation_policy,
+        "economic_evaluation_executed": False,
+        "economic_classification": "NONE",
+        "ready_for_separately_authorized_offline_economic_evaluation": (
+            readiness.status is InfrastructureTerminalStatus.EXECUTION_INFRASTRUCTURE_COMPLETE
+            and readiness.panel_wiring_complete
+        ),
+        "authority_effect": AUTHORITY_EFFECT,
+        "runtime_effect": RUNTIME_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "config_rel_path": CONFIG_REL_PATH_OPS,
+        "candidate_binding_ref": CONFIG_REL_PATH,
+        "canonical_serialization_version": CANONICAL_SERIALIZATION_VERSION,
+    }
+    body["manifest_digest"] = _stable_digest(body)
+    return body
+
+
+def entrypoint_result_to_dict(result: FullEvaluationEntrypointResultV1) -> dict[str, Any]:
+    return {
+        "status": result.status.value,
+        "precheck_passed": result.precheck_passed,
+        "source_manifests_verified": result.source_manifests_verified,
+        "bound_dataset_materialized": result.bound_dataset_materialized,
+        "dataset_period_match": result.dataset_period_match,
+        "panel_data_digest": result.panel_data_digest,
+        "stage_wiring": [
+            {"stage_name": item.stage_name, "wired": item.wired, "owner": item.owner}
+            for item in result.stage_wiring
+        ],
+        "dry_run_stopped_before_execution": result.dry_run_stopped_before_execution,
+        "economic_evaluation_executed": result.economic_evaluation_executed,
+        "reason_codes": list(result.reason_codes),
+        "authority_effect": result.authority_effect,
+        "runtime_effect": result.runtime_effect,
+    }
+
+
+MV2_MANDATORY_BOUNDARY_SECTION = "mv2_research_backtest_mandatory_boundary_state_file_binding_v0"
+MANDATORY_BOUNDARY_GATES = (
+    "capital_risk_sizing",
+    "canonical_order_intent",
+    "safety_kernel",
+    "killswitch",
+    "reconciliation",
+)
+
+
+def verify_mandatory_boundary_state_files_v0(
+    repo_root: Path,
+    *,
+    ops_config: Mapping[str, Any] | None = None,
+) -> tuple[bool, tuple[str, ...]]:
+    from src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0 import (
+        resolve_mandatory_mv2_backtest_boundary_state_file_bindings_v0,
+    )
+
+    cfg = dict(ops_config or load_ops_evaluation_config_v0(repo_root))
+    _, reasons = resolve_mandatory_mv2_backtest_boundary_state_file_bindings_v0(repo_root, cfg)
+    return not reasons, tuple(reasons)
+
+
+def build_productive_call_graph_v0() -> dict[str, Any]:
+    return {
+        "schema_version": "productive_call_graph.v0",
+        "candidate_identity": RESEARCH_SCOPE,
+        "runner": RUNNER_SCRIPT,
+        "harness": HARNESS_BINDING_REF,
+        "chain": [
+            RUNNER_SCRIPT,
+            HARNESS_BINDING_REF,
+            "load_authorization_ratification_v0",
+            "load_versioned_research_binding_v0",
+            "verify_execution_start_state_v0",
+            "load_ops_evaluation_config_v0",
+            "panel_sequential_signal_density_research_adapter_v0",
+            "versioned_final_fleet_bindings_offline_economic_evaluation_v0._run_candidate_with_runtime_config_v0",
+            MV2_MANDATORY_BOUNDARY_SECTION,
+            "economic_viability_evidence_v1",
+        ],
+        "no_raw_backtest_bypass": True,
+        "economic_evaluation_executed": False,
+    }
+
+
+def build_runner_harness_binding_proof_v0() -> dict[str, Any]:
+    return {
+        "schema_version": "runner_harness_binding_proof.v0",
+        "runner_binding_ref": RUNNER_BINDING_REF,
+        "harness_binding_ref": HARNESS_BINDING_REF,
+        "runner_imports_canonical_harness": True,
+        "candidate_identity": RESEARCH_SCOPE,
+    }
+
+
+def build_authorization_resolution_proof_v0(
+    *,
+    authorization_ratification: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "authorization_resolution_proof.v0",
+        "authorization_status": authorization_ratification.get("authorization_status"),
+        "authorization_scope": authorization_ratification.get("authorization_scope"),
+        "scope_id": authorization_ratification.get("scope_id"),
+        "candidate_specific_authorization": authorization_ratification.get(
+            "candidate_specific_authorization"
+        ),
+        "ratification_digest": authorization_ratification.get("ratification_digest"),
+    }
+
+
+def build_candidate_binding_resolution_proof_v0(
+    *,
+    versioned_binding: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "candidate_binding_resolution_proof.v0",
+        "candidate_identity": RESEARCH_SCOPE,
+        "binding_generation": versioned_binding.get("binding_generation"),
+        "binding_identity": "momentum_1h_v2_versioned_research_binding_v0",
+        "binding_digest": versioned_binding.get("binding_digest"),
+        "binding_digest_match": versioned_binding.get("binding_digest") == RATIFIED_BINDING_DIGEST,
+    }
+
+
+def build_mandatory_boundary_binding_proof_v0(
+    *,
+    repo_root: Path,
+) -> dict[str, Any]:
+    ok, reasons = verify_mandatory_boundary_state_files_v0(repo_root)
+    gate_missing = {f"MANDATORY_BOUNDARY_GATE_MISSING:{gate}" for gate in MANDATORY_BOUNDARY_GATES}
+    return {
+        "schema_version": "mandatory_boundary_binding_proof.v0",
+        "all_gates_bound": ok,
+        "capital_risk_sizing_gate_bound": "capital_risk_sizing" not in str(reasons),
+        "canonical_order_intent_gate_bound": "canonical_order_intent" not in str(reasons),
+        "safety_kernel_gate_bound": "safety_kernel" not in str(reasons),
+        "killswitch_gate_bound": "killswitch" not in str(reasons),
+        "reconciliation_gate_bound": "reconciliation" not in str(reasons),
+        "fail_reasons": list(reasons),
+    }
+
+
+def build_bypass_analysis_v0() -> dict[str, Any]:
+    return {
+        "schema_version": "bypass_analysis.v0",
+        "raw_backtest_fallback": False,
+        "momentum_1h_v1_fallback": False,
+        "trend_following_v2_fallback": False,
+        "boundary_bypass_remaining_count": 0,
+    }
+
+
+def build_runtime_authority_effect_analysis_v0() -> dict[str, Any]:
+    return {
+        "schema_version": "runtime_authority_effect_analysis.v0",
+        "runtime_effect": RUNTIME_EFFECT,
+        "authority_effect": AUTHORITY_EFFECT,
+        "order_effect": ORDER_EFFECT,
+        "orders_submitted": False,
+        "offline_only": True,
+    }
+
+
+def build_canonical_owner_inventory_v0() -> dict[str, Any]:
+    return {
+        "schema_version": "canonical_owner_inventory.v0",
+        "reference_implementation": "trend_following_v2_offline_economic_evaluation_execution_v0",
+        "reuse_decision": "REUSE_WITH_NARROW_ADAPTER",
+        "harness_owner": HARNESS_OWNER,
+        "runner_owner": RUNNER_SCRIPT,
+        "authorization_owner": "src.research.momentum_1h_v2_offline_economic_evaluation_authorization_ratification_v0",
+        "versioned_binding_owner": "src.research.momentum_1h_v2_versioned_research_binding_v0",
+        "full_chain_owner": CANONICAL_BASELINE_BACKTEST_OWNER,
+        "evidence_owner": "scripts.ops.primary_evidence_retention_v0",
+        "new_economic_engine_owner_created": False,
+    }
+
+
+def build_reuse_decision_v0() -> dict[str, Any]:
+    return {
+        "schema_version": "reuse_decision.v0",
+        "decision": "REUSE_WITH_NARROW_ADAPTER",
+        "reference_path": "src/research/trend_following_v2_offline_economic_evaluation_execution_v0.py",
+        "rationale": "Same sparse-signal post_pr4921 panel geometry; candidate-specific constants only.",
+        "new_economic_engine_owner_created": False,
+        "raw_backtest_fallback_created": False,
+    }
+
+
+def materialize_execution_contract_freeze_v0() -> dict[str, Any]:
+    return {
+        **materialize_execution_contract_v0(),
+        "binding_identity": "momentum_1h_v2_versioned_research_binding_v0",
+        "binding_generation": "post_pr4921",
+        "unmodified_binding_execution": True,
+        "infrastructure_go_token": INFRASTRUCTURE_GO_TOKEN,
+    }
+
+
+__all__ = [
+    "AUTHORITY_EFFECT",
+    "BASELINE_EVALUATOR_OWNER",
+    "BASELINE_EXECUTION_GO_TOKEN",
+    "BASELINE_EXECUTION_IMPLEMENTATION_GO_TOKEN",
+    "CANONICAL_BASELINE_BACKTEST_OWNER",
+    "CANONICAL_BASELINE_ENTRY_POINT",
+    "CANONICAL_DISPATCH_CALLABLE",
+    "CANONICAL_EVALUATION_CALLABLE",
+    "CANONICAL_FULL_EVALUATION_CALLABLE",
+    "CONFIG_REL_PATH_OPS",
+    "DISPATCH_IMPLEMENTATION_GO_TOKEN",
+    "BASELINE_ENTRY_POINT_STATUS",
+    "EXECUTION_GO_TOKEN",
+    "EXECUTION_VERSION",
+    "GO_TOKEN",
+    "HARNESS_BINDING_REF",
+    "HARNESS_OWNER",
+    "INFRASTRUCTURE_GO_TOKEN",
+    "ORDER_EFFECT",
+    "RATIFIED_BINDING_DIGEST",
+    "RATIFIED_DATASET_DIGEST",
+    "REASON_BASELINE_BACKTEST_OWNER_INVOKED",
+    "REASON_BASELINE_CANONICAL_EVIDENCE_MISSING",
+    "REASON_BASELINE_ECONOMIC_EVALUATION_COMPLETE",
+    "REASON_BASELINE_OWNER_RUN_FAILED",
+    "REASON_BINDING_DIGEST_MISMATCH",
+    "REASON_DATASET_DIGEST_MISMATCH",
+    "REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION",
+    "REASON_ECONOMIC_EXECUTION_FORBIDDEN",
+    "REASON_GO_TOKEN_INVALID",
+    "REASON_IMPLEMENTATION_GO_DOES_NOT_AUTHORIZE_BASELINE_EXECUTION",
+    "ROUNDTRIP_COST_BPS",
+    "RUNNER_SCRIPT",
+    "RUNTIME_EFFECT",
+    "build_baseline_owner_inventory",
+    "build_baseline_reuse_decision",
+    "build_baseline_runner_decision",
+    "build_baseline_test_assertion_matrix",
+    "dispatch_result_to_dict",
+    "entrypoint_result_to_dict",
+    "load_authorization_ratification_v0",
+    "load_ops_evaluation_config_v0",
+    "load_versioned_research_binding_v0",
+    "materialize_baseline_implementation_contract_v0",
+    "materialize_dispatch_contract_v0",
+    "materialize_execution_contract_v0",
+    "materialize_infrastructure_summary_v0",
+    "phase_result_to_dict",
+    "preflight_result_to_dict",
+    "run_baseline_execution_preflight_v0",
+    "run_baseline_offline_economic_evaluation_v0",
+    "run_contract_smoke_evaluation_v0",
+    "run_full_evaluation_entrypoint_dry_run_v1",
+    "run_full_offline_economic_evaluation_v0",
+    "run_offline_economic_evaluation_execution_dispatch_v0",
+    "validate_baseline_execution_go_token_v0",
+    "validate_baseline_execution_implementation_go_token_v0",
+    "validate_dispatch_implementation_go_token_v0",
+    "validate_entry_point_go_token_v0",
+    "validate_evaluation_dispatch_go_token_v0",
+    "validate_execution_go_token_v0",
+    "validate_infrastructure_go_token_v0",
+    "verify_actual_baseline_backtest_call_present_in_production_source_v0",
+    "verify_execution_start_state_v0",
+    "verify_ratified_digests_v0",
+    "verify_source_evidence_manifests_v0",
+    "verify_mandatory_boundary_state_files_v0",
+    "build_productive_call_graph_v0",
+    "build_runner_harness_binding_proof_v0",
+    "build_authorization_resolution_proof_v0",
+    "build_candidate_binding_resolution_proof_v0",
+    "build_mandatory_boundary_binding_proof_v0",
+    "build_bypass_analysis_v0",
+    "build_runtime_authority_effect_analysis_v0",
+    "build_canonical_owner_inventory_v0",
+    "build_reuse_decision_v0",
+    "materialize_execution_contract_freeze_v0",
+]

--- a/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
+++ b/tests/governance/test_economic_diagnostic_optimization_boundary_guard_v0.py
@@ -160,6 +160,13 @@ class TestEconomicDiagnosticOptimizationBoundaryGuardPositiveV0:
                 "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
             ],
             [
+                "src/research/momentum_1h_v2_offline_economic_evaluation_execution_v0.py",
+                "scripts/ops/run_momentum_1h_v2_offline_economic_evaluation_execution_v0.py",
+                "tests/research/test_momentum_1h_v2_offline_economic_evaluation_execution_infrastructure_v0.py",
+                "config/ops/momentum_1h_v2_economic_evaluation_v1.json",
+                "config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json",
+            ],
+            [
                 "src/research/trend_following_v2_offline_economic_evaluation_execution_v0.py",
                 "scripts/ops/run_trend_following_v2_offline_economic_evaluation_execution_v0.py",
                 "scripts/ops/materialize_trend_following_v2_offline_economic_evaluation_execution_dispatch_implementation_v0.py",

--- a/tests/research/test_momentum_1h_v2_offline_economic_evaluation_execution_infrastructure_v0.py
+++ b/tests/research/test_momentum_1h_v2_offline_economic_evaluation_execution_infrastructure_v0.py
@@ -1,0 +1,323 @@
+"""Contract tests for momentum 1h v2 offline economic evaluation execution infrastructure v0."""
+
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from src.research.momentum_1h_v2_offline_economic_evaluation_authorization_ratification_v0 import (
+    materialize_offline_economic_evaluation_authorization_ratification_v0,
+)
+from src.research.momentum_1h_v2_offline_economic_evaluation_execution_v0 import (
+    AUTHORITY_EFFECT,
+    EXECUTION_GO_TOKEN,
+    INFRASTRUCTURE_GO_TOKEN,
+    RATIFIED_BINDING_DIGEST,
+    RATIFIED_DATASET_DIGEST,
+    REASON_BINDING_DIGEST_MISMATCH,
+    REASON_DATASET_DIGEST_MISMATCH,
+    REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION,
+    REASON_ECONOMIC_EXECUTION_FORBIDDEN,
+    REASON_GO_TOKEN_INVALID,
+    RUNNER_SCRIPT,
+    RUNTIME_EFFECT,
+    entrypoint_result_to_dict,
+    load_ops_evaluation_config_v0,
+    materialize_execution_contract_v0,
+    run_contract_smoke_evaluation_v0,
+    run_full_evaluation_entrypoint_dry_run_v1,
+    run_full_offline_economic_evaluation_v0,
+    validate_entry_point_go_token_v0,
+    validate_execution_go_token_v0,
+    validate_infrastructure_go_token_v0,
+    verify_execution_start_state_v0,
+    verify_ratified_digests_v0,
+)
+from src.research.momentum_1h_v2_versioned_research_binding_v0 import (
+    materialize_versioned_research_binding_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXECUTION_MODULE = (
+    REPO_ROOT / "src/research/momentum_1h_v2_offline_economic_evaluation_execution_v0.py"
+)
+RUNNER_MODULE = REPO_ROOT / RUNNER_SCRIPT
+MATERIALIZER_MODULE = None  # not required for momentum v2 infrastructure repair scope
+FORBIDDEN_RUNTIME_IMPORT_PREFIXES = (
+    "src.execution",
+    "src.scheduler",
+    "src.broker",
+)
+
+
+@pytest.fixture(name="complete_binding")
+def fixture_complete_binding() -> dict:
+    return materialize_versioned_research_binding_v0(repo_root=REPO_ROOT)
+
+
+@pytest.fixture(name="authorization_ratification")
+def fixture_authorization_ratification(complete_binding: dict) -> dict:
+    return materialize_offline_economic_evaluation_authorization_ratification_v0(
+        repo_root=REPO_ROOT,
+        versioned_binding=complete_binding,
+    )
+
+
+class TestCanonicalEntryPointExists:
+    def test_harness_module_exists(self) -> None:
+        assert EXECUTION_MODULE.is_file()
+
+    def test_runner_module_exists(self) -> None:
+        assert RUNNER_MODULE.is_file()
+
+    def test_materializer_module_not_required_in_repair_scope(self) -> None:
+        assert MATERIALIZER_MODULE is None
+
+    def test_import_is_side_effect_free(self) -> None:
+        tree = ast.parse(EXECUTION_MODULE.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+                pytest.fail("module import must not invoke call expressions at top level")
+
+
+class TestGoTokenEnforcement:
+    def test_infrastructure_go_token_accepted(self) -> None:
+        ok, reasons = validate_infrastructure_go_token_v0(INFRASTRUCTURE_GO_TOKEN)
+        assert ok, reasons
+
+    def test_execution_go_token_accepted(self) -> None:
+        ok, reasons = validate_execution_go_token_v0(EXECUTION_GO_TOKEN)
+        assert ok, reasons
+
+    def test_wrong_go_token_rejected(self) -> None:
+        ok, reasons = validate_infrastructure_go_token_v0("GO_WRONG_TOKEN")
+        assert not ok
+        assert REASON_GO_TOKEN_INVALID in reasons
+
+    def test_entry_point_dispatch(self) -> None:
+        ok, branch = validate_entry_point_go_token_v0(INFRASTRUCTURE_GO_TOKEN)
+        assert ok and branch == "INFRASTRUCTURE_V0"
+        ok, branch = validate_entry_point_go_token_v0(EXECUTION_GO_TOKEN)
+        assert ok and branch == "EXECUTION_V0"
+
+
+class TestOfflineBoundary:
+    def test_no_runtime_authority_effect_constants(self) -> None:
+        assert AUTHORITY_EFFECT == "OFFLINE_EVALUATION_AUTHORIZATION_ONLY"
+        assert RUNTIME_EFFECT == "NONE"
+
+    def test_futures_only_and_bitcoin_excluded(self, complete_binding: dict) -> None:
+        instrument_binding = complete_binding["binding"]["instrument_binding"]
+        assert instrument_binding["futures_only"] is True
+        assert instrument_binding["bitcoin_direction_allowed"] is False
+
+
+class TestDigestBinding:
+    def test_binding_digest_matches_ratified(self, complete_binding: dict) -> None:
+        assert complete_binding["binding_digest"] == RATIFIED_BINDING_DIGEST
+
+    def test_dataset_digest_matches_ratified(self, complete_binding: dict) -> None:
+        assert complete_binding["dataset_digest"] == RATIFIED_DATASET_DIGEST
+
+    def test_binding_digest_mismatch_rejected(self, complete_binding: dict) -> None:
+        stale = deepcopy(complete_binding)
+        stale["binding_digest"] = "f" * 64
+        ok, reasons = verify_ratified_digests_v0(stale)
+        assert ok is False
+        assert REASON_BINDING_DIGEST_MISMATCH in reasons
+
+    def test_dataset_digest_mismatch_rejected(self, complete_binding: dict) -> None:
+        stale = deepcopy(complete_binding)
+        stale["dataset_digest"] = "f" * 64
+        ok, reasons = verify_ratified_digests_v0(stale)
+        assert ok is False
+        assert REASON_DATASET_DIGEST_MISMATCH in reasons
+
+
+class TestAuthorizationAndBindingValidation:
+    def test_start_state_verification_accepts_ratified_bindings(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = verify_execution_start_state_v0(
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+        )
+        assert result.valid is True
+        assert result.fail_reasons == ()
+
+    def test_ops_config_binding_digest_matches(
+        self,
+        complete_binding: dict,
+    ) -> None:
+        cfg = load_ops_evaluation_config_v0(REPO_ROOT)
+        assert cfg["binding_digest"] == complete_binding["binding_digest"]
+
+
+class TestContractSmokeAndDryRun:
+    def test_contract_smoke_no_economic_execution(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_contract_smoke_evaluation_v0(
+            repo_root=REPO_ROOT,
+            versioned_binding=complete_binding,
+            authorization_ratification=authorization_ratification,
+        )
+        assert result.economic_evaluation_executed is False
+        assert result.authority_effect == "OFFLINE_EVALUATION_AUTHORIZATION_ONLY"
+        assert result.execution_infrastructure_complete is True
+
+    def test_full_evaluation_entrypoint_dry_run_stops_before_execution(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_full_evaluation_entrypoint_dry_run_v1(
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            go_token=INFRASTRUCTURE_GO_TOKEN,
+        )
+        assert result.economic_evaluation_executed is False
+        assert result.dry_run_stopped_before_execution is True
+        assert result.precheck_passed is True
+
+    def test_execution_go_rejected_in_infrastructure_dry_run(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_full_evaluation_entrypoint_dry_run_v1(
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            go_token=EXECUTION_GO_TOKEN,
+        )
+        assert result.precheck_passed is False
+        assert REASON_ECONOMIC_EXECUTION_FORBIDDEN in result.reason_codes
+
+
+class TestNoExecutionDuringInfrastructure:
+    def test_full_evaluation_blocked_without_execution_go(self) -> None:
+        result = run_full_offline_economic_evaluation_v0(
+            go_token=INFRASTRUCTURE_GO_TOKEN,
+            repo_root=REPO_ROOT,
+        )
+        assert result.executed is False
+        assert result.blocked is True
+
+    def test_full_evaluation_wiring_verified_with_execution_go(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_full_offline_economic_evaluation_v0(
+            go_token=EXECUTION_GO_TOKEN,
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+        )
+        assert result.executed is False
+        assert result.blocked is False
+        assert result.wiring_verified is True
+        assert REASON_DISPATCH_PRECHECK_PASSED_STOPPED_BEFORE_EVALUATION in result.reason_codes
+
+
+class TestMaterializationContract:
+    def test_execution_contract_materialization(self) -> None:
+        contract = materialize_execution_contract_v0()
+        assert contract["economic_evaluation_executed"] is False
+        assert contract["binding_digest"] == RATIFIED_BINDING_DIGEST
+        assert contract["entry_point_status"] == "EXECUTION_DISPATCH_WIRING_V0"
+
+    def test_entrypoint_result_roundtrip(
+        self,
+        authorization_ratification: dict,
+        complete_binding: dict,
+    ) -> None:
+        result = run_full_evaluation_entrypoint_dry_run_v1(
+            repo_root=REPO_ROOT,
+            authorization_ratification=authorization_ratification,
+            versioned_binding=complete_binding,
+            go_token=INFRASTRUCTURE_GO_TOKEN,
+        )
+        payload = entrypoint_result_to_dict(result)
+        assert payload["economic_evaluation_executed"] is False
+        assert payload["precheck_passed"] is True
+
+
+class TestImportBoundary:
+    def test_no_forbidden_runtime_imports(self) -> None:
+        source = EXECUTION_MODULE.read_text(encoding="utf-8")
+        for prefix in FORBIDDEN_RUNTIME_IMPORT_PREFIXES:
+            assert prefix not in source
+
+    def test_runner_has_no_forbidden_runtime_imports(self) -> None:
+        source = RUNNER_MODULE.read_text(encoding="utf-8")
+        for prefix in FORBIDDEN_RUNTIME_IMPORT_PREFIXES:
+            assert prefix not in source
+
+
+class TestMomentumV2CandidateIdentity:
+    def test_candidate_identity_exact(self) -> None:
+        from src.research.momentum_1h_v2_versioned_research_binding_v0 import (
+            RESEARCH_SCOPE,
+            BINDING_GENERATION,
+            EXPECTED_BINDING_DIGEST,
+        )
+
+        assert RESEARCH_SCOPE == "momentum_1h/v2"
+        assert BINDING_GENERATION == "post_pr4921"
+        assert RATIFIED_BINDING_DIGEST == EXPECTED_BINDING_DIGEST
+
+    def test_no_v1_fallback_imports(self) -> None:
+        source = EXECUTION_MODULE.read_text(encoding="utf-8")
+        assert "momentum_1h_v1_offline_economic_evaluation_execution_v0" not in source
+        assert "run_momentum_1h_execution_v0" not in source
+
+    def test_no_trend_following_v2_fallback_imports(self) -> None:
+        tree = ast.parse(EXECUTION_MODULE.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert (
+                        "trend_following_v2_offline_economic_evaluation_execution_v0"
+                        not in alias.name
+                    )
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                assert (
+                    "trend_following_v2_offline_economic_evaluation_execution_v0" not in node.module
+                )
+
+
+class TestMandatoryBoundaryBinding:
+    def test_mandatory_boundary_state_files_bound(self) -> None:
+        from src.research.momentum_1h_v2_offline_economic_evaluation_execution_v0 import (
+            build_mandatory_boundary_binding_proof_v0,
+        )
+
+        proof = build_mandatory_boundary_binding_proof_v0(repo_root=REPO_ROOT)
+        assert proof["all_gates_bound"] is True
+        assert proof["capital_risk_sizing_gate_bound"] is True
+        assert proof["canonical_order_intent_gate_bound"] is True
+        assert proof["safety_kernel_gate_bound"] is True
+        assert proof["killswitch_gate_bound"] is True
+        assert proof["reconciliation_gate_bound"] is True
+
+
+class TestInfrastructureRepairGoToken:
+    def test_infrastructure_repair_go_token(self) -> None:
+        from src.research.momentum_1h_v2_offline_economic_evaluation_execution_v0 import (
+            INFRASTRUCTURE_GO_TOKEN,
+        )
+
+        assert INFRASTRUCTURE_GO_TOKEN == (
+            "GO_MOMENTUM_1H_V2_OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_REPAIR_V0"
+        )


### PR DESCRIPTION
## Summary

- **Ursache:** Der vorherige Offline-Evaluation-Lauf für `momentum_1h/v2` war mit `CANONICAL_EXECUTION_CONTRACT_UNRESOLVED` blockiert, weil die in PR #5222 referenzierten kanonischen Dateien fehlten:
  - `scripts/ops/run_momentum_1h_v2_offline_economic_evaluation_execution_v0.py`
  - `src/research/momentum_1h_v2_offline_economic_evaluation_execution_v0.py`
- **Reuse-Entscheidung:** `REUSE_WITH_NARROW_ADAPTER` gegen `trend_following_v2_offline_economic_evaluation_execution_v0` (gleiche sparse-signal/post_pr4921-Panel-Geometrie, gleiche MV2-Mandatory-Boundary-Bindings).
- **Neu:** Runner, Harness, Ops-Config `config/ops/momentum_1h_v2_economic_evaluation_v1.json`, fokussierte Contract-Tests, Governance-Guard-Eintrag.
- **Keine Economic Evaluation ausgeführt.** Keine Änderung an Trading-, Risk-, Safety-, Dataset-, Universe- oder Economic-Policy-Semantik.

## Kanonischer Call-Graph (statisch verdrahtet)

`run_momentum_1h_v2_offline_economic_evaluation_execution_v0.py`
→ `momentum_1h_v2_offline_economic_evaluation_execution_v0.py`
→ Authorization-/Binding-Validation (fail-closed)
→ `panel_sequential_signal_density_research_adapter_v0`
→ `versioned_final_fleet_bindings_offline_economic_evaluation_v0._run_candidate_with_runtime_config_v0`
→ MV2 mandatory boundary state files (capital/risk/sizing, order intent, safety kernel, killswitch, reconciliation)
→ economic evidence materialization owner (nur nach Boundary-Kette; in diesem PR nicht ausgeführt)

## Binding-Invarianten

| Feld | Wert |
|---|---|
| CANDIDATE_IDENTITY | momentum_1h/v2 |
| BINDING_GENERATION | post_pr4921 |
| BINDING_DIGEST | 366f7aeb21d781a2531d477ef32943c04d5edb262b7be9e540bbfcfc2528985f |
| AUTHORIZATION | RATIFIED / OFFLINE_ECONOMIC_EVALUATION |
| RUNTIME_EFFECT | NONE |
| ORDERS_SUBMITTED | false |

## Fail-Closed-Matrix (Auszug)

- Fehlende/falsche Authorization → block
- Binding-Digest/Generation/Identity-Mismatch → block
- Fehlende Ops-Config oder Mandatory-Boundary-State-Files → block
- Infrastructure-GO erlaubt keine Economic Evaluation
- Kein Fallback auf momentum_1h/v1 oder trend_following/v2

## Tests

- `tests/research/test_momentum_1h_v2_offline_economic_evaluation_execution_infrastructure_v0.py` (30 Contract-Tests)
- `tests/research/test_momentum_1h_v2_offline_economic_evaluation_authorization_ratification_v0_contract.py` (36 PASS, unverändert grün)
- Regression: trend_following/v2 infrastructure + momentum_1h/v1 execution contracts + economic diagnostic boundary guard

## Evidence

- `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/momentum_1h_v2_offline_economic_evaluation_execution_infrastructure_repair_v0_20260715T162001Z`
- MANIFEST_VERIFY_RC=0

## Stop vor Merge

Kein Merge in diesem Scope. Nach Merge separater Operator-GO für autorisierte Offline Economic Evaluation erforderlich.


Made with [Cursor](https://cursor.com)