### PR TITLE
test(master-v2): add repo-wide canonical chain invariant guards

### DIFF
--- a/tests/trading/master_v2/test_canonical_replay_input_builder_ssot_contract_v1.py
+++ b/tests/trading/master_v2/test_canonical_replay_input_builder_ssot_contract_v1.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src"
 
 _OWNER_MODULE = REPO_ROOT / "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py"
 _PRODUCTIVE_SOURCE_ADAPTERS = (
@@ -16,9 +20,22 @@ _PRODUCTIVE_SOURCE_ADAPTERS = (
 )
 _PUBLIC_BUILDER_NAME = "build_integrated_offline_replay_input_v1"
 _INPUT_TYPE_NAME = "IntegratedOfflineReplayInputV1"
+_AUTHORIZED_CONSTRUCTOR_REL_PATH = (
+    "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py"
+)
 _TEST_ONLY_HELPER = (
     REPO_ROOT / "tests/trading/master_v2/test_integrated_offline_trading_logic_replay_v1.py"
 )
+
+
+@dataclass(frozen=True, order=True)
+class DirectReplayInputConstructionHit:
+    relative_path: str
+    lineno: int
+    enclosing_function: str
+
+    def report_line(self) -> str:
+        return f"{self.relative_path}:{self.lineno} in {self.enclosing_function}"
 
 
 def _call_name(node: ast.AST) -> str | None:
@@ -27,6 +44,25 @@ def _call_name(node: ast.AST) -> str | None:
     if isinstance(node, ast.Attribute):
         return node.attr
     return None
+
+
+def _parent_map(tree: ast.AST) -> dict[ast.AST, ast.AST]:
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+    return parents
+
+
+def _enclosing_function_name(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> str:
+    current: ast.AST | None = node
+    while current is not None:
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return current.name
+        if isinstance(current, ast.Module):
+            return "<module>"
+        current = parents.get(current)
+    return "<module>"
 
 
 def _function_defs_by_name(tree: ast.AST) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
@@ -51,6 +87,69 @@ def _builder_calls(tree: ast.AST) -> list[ast.Call]:
         if isinstance(node, ast.Call) and _call_name(node.func) == _PUBLIC_BUILDER_NAME:
             hits.append(node)
     return hits
+
+
+def collect_direct_replay_input_constructions(
+    *,
+    scan_root: Path,
+    path_root: Path,
+) -> list[DirectReplayInputConstructionHit]:
+    """AST-scan ``scan_root`` for direct IntegratedOfflineReplayInputV1 constructions."""
+    hits: list[DirectReplayInputConstructionHit] = []
+    for path in sorted(p for p in scan_root.rglob("*.py") if p.is_file()):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        parents = _parent_map(tree)
+        rel = path.resolve().relative_to(path_root.resolve()).as_posix()
+        for call in _direct_input_constructions(tree):
+            hits.append(
+                DirectReplayInputConstructionHit(
+                    relative_path=rel,
+                    lineno=int(getattr(call, "lineno", 0) or 0),
+                    enclosing_function=_enclosing_function_name(call, parents),
+                )
+            )
+    return sorted(hits)
+
+
+def authorized_direct_replay_input_constructions(
+    hits: list[DirectReplayInputConstructionHit],
+) -> list[DirectReplayInputConstructionHit]:
+    return [
+        hit
+        for hit in hits
+        if hit.relative_path == _AUTHORIZED_CONSTRUCTOR_REL_PATH
+        and hit.enclosing_function == _PUBLIC_BUILDER_NAME
+    ]
+
+
+def unauthorized_direct_replay_input_constructions(
+    hits: list[DirectReplayInputConstructionHit],
+) -> list[DirectReplayInputConstructionHit]:
+    authorized = set(authorized_direct_replay_input_constructions(hits))
+    return [hit for hit in hits if hit not in authorized]
+
+
+def assert_exactly_one_authorized_src_wide_productive_direct_replay_input_constructor(
+    *,
+    scan_root: Path | None = None,
+    path_root: Path | None = None,
+) -> DirectReplayInputConstructionHit:
+    """Enforce PRODUCTIVE_DIRECT_REPLAY_INPUT_CONSTRUCTOR_COUNT=1 across scan_root."""
+    root = scan_root if scan_root is not None else SRC_ROOT
+    base = path_root if path_root is not None else REPO_ROOT
+    hits = collect_direct_replay_input_constructions(scan_root=root, path_root=base)
+    unauthorized = unauthorized_direct_replay_input_constructions(hits)
+    assert not unauthorized, (
+        "unauthorized productive IntegratedOfflineReplayInputV1 constructions:\n"
+        + "\n".join(hit.report_line() for hit in unauthorized)
+    )
+    authorized = authorized_direct_replay_input_constructions(hits)
+    assert len(authorized) == 1, (
+        "PRODUCTIVE_DIRECT_REPLAY_INPUT_CONSTRUCTOR_COUNT must be 1; "
+        f"found {len(authorized)} authorized hit(s): "
+        + ", ".join(hit.report_line() for hit in authorized)
+    )
+    return authorized[0]
 
 
 def test_public_builder_is_only_productive_direct_construction_authority_v1() -> None:
@@ -88,21 +187,37 @@ def test_test_only_helper_is_not_classified_as_productive_authority_v1() -> None
     assert _TEST_ONLY_HELPER.as_posix().endswith(
         "tests/trading/master_v2/test_integrated_offline_trading_logic_replay_v1.py"
     )
-    # Productive authority remains exactly the public builder in owner module.
-    owner_tree = ast.parse(_OWNER_MODULE.read_text(encoding="utf-8"))
-    assert len(_direct_input_constructions(owner_tree)) == 1
+    sole = assert_exactly_one_authorized_src_wide_productive_direct_replay_input_constructor()
+    assert sole.relative_path == _AUTHORIZED_CONSTRUCTOR_REL_PATH
+    assert sole.enclosing_function == _PUBLIC_BUILDER_NAME
     # Test helper is optional: if present, ignored for productive authority.
     _ = _direct_input_constructions(tree)
 
 
 def test_productive_direct_construction_authority_count_is_one_v1() -> None:
-    productive_authority_files = {_OWNER_MODULE.resolve()}
+    sole = assert_exactly_one_authorized_src_wide_productive_direct_replay_input_constructor()
+    assert sole.relative_path == _AUTHORIZED_CONSTRUCTOR_REL_PATH
+    assert sole.enclosing_function == _PUBLIC_BUILDER_NAME
     for path in _PRODUCTIVE_SOURCE_ADAPTERS:
-        assert path.resolve() not in productive_authority_files
         tree = ast.parse(path.read_text(encoding="utf-8"))
         assert _direct_input_constructions(tree) == []
         assert _builder_calls(tree)
 
-    owner_tree = ast.parse(_OWNER_MODULE.read_text(encoding="utf-8"))
-    assert len(_direct_input_constructions(owner_tree)) == 1
-    assert len(productive_authority_files) == 1
+
+def test_src_wide_constructor_scanner_rejects_non_owner_construction_fixture(
+    tmp_path: Path,
+) -> None:
+    rogue = tmp_path / "rogue_replay_input_constructor_v0.py"
+    rogue.write_text(
+        "def build_rogue_input():\n    return IntegratedOfflineReplayInputV1()\n",
+        encoding="utf-8",
+    )
+    hits = collect_direct_replay_input_constructions(scan_root=tmp_path, path_root=tmp_path)
+    assert len(hits) == 1
+    assert hits[0].enclosing_function == "build_rogue_input"
+    assert unauthorized_direct_replay_input_constructions(hits)
+    with pytest.raises(AssertionError, match="unauthorized productive"):
+        assert_exactly_one_authorized_src_wide_productive_direct_replay_input_constructor(
+            scan_root=tmp_path,
+            path_root=tmp_path,
+        )

--- a/tests/trading/master_v2/test_runtime_backtest_parity_and_legacy_boundary_closeout_v1.py
+++ b/tests/trading/master_v2/test_runtime_backtest_parity_and_legacy_boundary_closeout_v1.py
@@ -44,6 +44,9 @@ from trading.master_v2.offline_double_play_scenario_replay_v0 import (
     build_default_bull_bear_bull_scenario_ticks,
     run_offline_double_play_scenario_replay_v0,
 )
+from tests.trading.master_v2.test_canonical_replay_input_builder_ssot_contract_v1 import (
+    assert_exactly_one_authorized_src_wide_productive_direct_replay_input_constructor,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 OWNER_MODULE = REPO_ROOT / "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py"
@@ -254,6 +257,12 @@ def test_legacy_paths_cannot_produce_system_economic_evidence() -> None:
 
 
 def test_productive_direct_replay_input_constructor_count_remains_one() -> None:
+    # Reuse src-wide SSOT authority boundary (no divergent fixed-file allowlist).
+    sole = assert_exactly_one_authorized_src_wide_productive_direct_replay_input_constructor()
+    assert (
+        sole.relative_path == "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py"
+    )
+    assert sole.enclosing_function == _PUBLIC_BUILDER
     owner_tree = _parse(OWNER_MODULE)
     assert len(_direct_input_constructions(owner_tree)) == 1
     for path in (MV2_MODULE, BRIDGE_MODULE):

--- a/tests/trading/master_v2/test_strategy_suitability_agreement_static_contract_v1.py
+++ b/tests/trading/master_v2/test_strategy_suitability_agreement_static_contract_v1.py
@@ -4,9 +4,13 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src"
 MASTER_V2_ROOT = REPO_ROOT / "src" / "trading" / "master_v2"
 BACKTEST_ROOT = REPO_ROOT / "src" / "backtest"
 
@@ -15,6 +19,11 @@ _OWNER_SUITABILITY = MASTER_V2_ROOT / "suitability_binding_v1.py"
 _OWNER_MATERIAL = MASTER_V2_ROOT / "strategy_suitability_agreement_material_v1.py"
 _ADAPTER = BACKTEST_ROOT / "strategy_signal_suitability_agreement_adapter_v1.py"
 _WIRING = BACKTEST_ROOT / "mv2_research_wiring_v1.py"
+
+_TOTAL_DECISION_OWNER_NAME = "run_integrated_offline_trading_logic_replay_v1"
+_AUTHORIZED_TOTAL_DECISION_OWNER_REL_PATH = (
+    "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py"
+)
 
 _FORBIDDEN_BACKTEST_SIGNAL_TYPES = frozenset(
     {
@@ -27,6 +36,16 @@ _FORBIDDEN_AUTHORITY_PATHS = (
     REPO_ROOT / "src" / "risk",
     REPO_ROOT / "src" / "governance" / "capital_risk_sizing_v1.py",
 )
+
+
+@dataclass(frozen=True, order=True)
+class TotalDecisionOwnerDefinitionHit:
+    relative_path: str
+    lineno: int
+    kind: str
+
+    def report_line(self) -> str:
+        return f"{self.relative_path}:{self.lineno} ({self.kind})"
 
 
 def _imported_names(path: Path) -> set[str]:
@@ -46,6 +65,53 @@ def _source_mentions(path: Path, needle: str) -> bool:
     return needle in path.read_text(encoding="utf-8")
 
 
+def collect_total_decision_owner_definitions(
+    *,
+    scan_root: Path,
+    path_root: Path,
+) -> list[TotalDecisionOwnerDefinitionHit]:
+    """AST-scan ``scan_root`` for sync/async defs of the total decision owner."""
+    hits: list[TotalDecisionOwnerDefinitionHit] = []
+    for path in sorted(p for p in scan_root.rglob("*.py") if p.is_file()):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        rel = path.resolve().relative_to(path_root.resolve()).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.name != _TOTAL_DECISION_OWNER_NAME:
+                continue
+            kind = "async" if isinstance(node, ast.AsyncFunctionDef) else "sync"
+            hits.append(
+                TotalDecisionOwnerDefinitionHit(
+                    relative_path=rel,
+                    lineno=int(getattr(node, "lineno", 0) or 0),
+                    kind=kind,
+                )
+            )
+    return sorted(hits)
+
+
+def assert_exactly_one_canonical_total_decision_owner_definition(
+    *,
+    scan_root: Path | None = None,
+    path_root: Path | None = None,
+) -> TotalDecisionOwnerDefinitionHit:
+    """Enforce CANONICAL_TOTAL_DECISION_OWNER_COUNT=1 across scan_root."""
+    root = scan_root if scan_root is not None else SRC_ROOT
+    base = path_root if path_root is not None else REPO_ROOT
+    hits = collect_total_decision_owner_definitions(scan_root=root, path_root=base)
+    assert len(hits) == 1, (
+        "CANONICAL_TOTAL_DECISION_OWNER_COUNT must be 1; found "
+        f"{len(hits)} definition(s):\n" + "\n".join(hit.report_line() for hit in hits)
+    )
+    sole = hits[0]
+    assert sole.relative_path == _AUTHORIZED_TOTAL_DECISION_OWNER_REL_PATH, (
+        "total decision owner must remain in "
+        f"{_AUTHORIZED_TOTAL_DECISION_OWNER_REL_PATH}; found {sole.report_line()}"
+    )
+    return sole
+
+
 def test_master_v2_does_not_import_backtest_signal_types() -> None:
     for path in MASTER_V2_ROOT.rglob("*.py"):
         imported = _imported_names(path)
@@ -58,6 +124,9 @@ def test_canonical_total_decision_owner_unchanged() -> None:
     assert "def run_integrated_offline_trading_logic_replay_v1(" in source
     assert "def build_integrated_offline_replay_input_v1(" in source
     assert source.count("def run_integrated_offline_trading_logic_replay_v1(") == 1
+    sole = assert_exactly_one_canonical_total_decision_owner_definition()
+    assert sole.relative_path == _AUTHORIZED_TOTAL_DECISION_OWNER_REL_PATH
+    assert sole.kind == "sync"
 
 
 def test_no_parallel_decision_stage_symbol_introduced() -> None:
@@ -122,3 +191,21 @@ def test_productive_direct_constructor_count_remains_one() -> None:
         )
     ]
     assert len(hits) == 1
+
+
+def test_src_wide_total_decision_owner_scanner_rejects_non_owner_definition_fixture(
+    tmp_path: Path,
+) -> None:
+    rogue = tmp_path / "rogue_total_decision_owner_v0.py"
+    rogue.write_text(
+        "def run_integrated_offline_trading_logic_replay_v1(replay_input):\n    return None\n",
+        encoding="utf-8",
+    )
+    hits = collect_total_decision_owner_definitions(scan_root=tmp_path, path_root=tmp_path)
+    assert len(hits) == 1
+    assert hits[0].relative_path.endswith("rogue_total_decision_owner_v0.py")
+    with pytest.raises(AssertionError, match="total decision owner must remain"):
+        assert_exactly_one_canonical_total_decision_owner_definition(
+            scan_root=tmp_path,
+            path_root=tmp_path,
+        )


### PR DESCRIPTION
## Summary
- Root cause: previous canonical-chain static guards were whitelist-/owner-file-bounded and could miss new productive `IntegratedOfflineReplayInputV1` constructions or parallel `run_integrated_offline_trading_logic_replay_v1` definitions outside those lists.
- Added a repo-wide AST constructor guard under `src/**/*.py` allowing exactly one productive authority: `build_integrated_offline_replay_input_v1` in `integrated_offline_trading_logic_replay_v1.py`.
- Added a repo-wide single total-decision-owner definition guard (`CANONICAL_TOTAL_DECISION_OWNER_COUNT=1`).
- Closeout mirror reuses the shared src-wide constructor authority helper (no divergent allowlist).
- Negative tmp_path fixture scanners prove non-owner construction/definition rejection without mutating real `src/`.

## Exact changed files
- `tests/trading/master_v2/test_canonical_replay_input_builder_ssot_contract_v1.py`
- `tests/trading/master_v2/test_strategy_suitability_agreement_static_contract_v1.py`
- `tests/trading/master_v2/test_runtime_backtest_parity_and_legacy_boundary_closeout_v1.py`

## Test plan
- [x] `.venv/bin/pytest -q tests/trading/master_v2/test_canonical_replay_input_builder_ssot_contract_v1.py` → RC=0 (6 passed)
- [x] `.venv/bin/pytest -q tests/trading/master_v2/test_strategy_suitability_agreement_static_contract_v1.py` → RC=0 (8 passed)
- [x] `.venv/bin/pytest -q tests/trading/master_v2/test_runtime_backtest_parity_and_legacy_boundary_closeout_v1.py` → RC=0 (16 passed)
- [x] Combined three-file pytest → RC=0 (30 passed)
- [x] `ruff format --check` + `ruff check` on the three files → RC=0
- [x] Canonical selector on exact final diff → `CONTRACT_FOCUSED` / `focused_script_or_test_diff`

## Effects / boundaries
- No production-code mutation
- No runtime/shadow/paper/testnet/live activation
- `RUNTIME_EFFECT=NONE`
- `AUTHORITY_EFFECT=NONE`
- `ORDER_EFFECT=NONE`
- `ECONOMIC_EFFECT=NONE`
- `CORE_SEMANTICS_CHANGED=false`
- `RISK_SIZING_SEMANTICS_CHANGED=false`
- `SAFETY_SEMANTICS_CHANGED=false`
- CI mode: FOCUSED / CONTRACT_FOCUSED
- `STOP_BEFORE_MERGE=true`


Made with [Cursor](https://cursor.com)