### PR TITLE
fix(webui): sync market dashboard current state after PR 5242

### DIFF
--- a/src/webui/market_dashboard_current_state_runtime_v0.py
+++ b/src/webui/market_dashboard_current_state_runtime_v0.py
@@ -17,6 +17,7 @@ def build_market_dashboard_current_state_display_context() -> dict[str, Any]:
     system = snapshot["current_system_state"]
     governance = snapshot["governance_and_safety"]
     evidence = snapshot["pr_and_evidence_status"]
+    provenance = snapshot["provenance"]
 
     return {
         "section_visible": True,
@@ -25,8 +26,11 @@ def build_market_dashboard_current_state_display_context() -> dict[str, Any]:
         "controls_allowed": False,
         "snapshot_owner": SNAPSHOT_OWNER,
         "snapshot_version": snapshot["snapshot_version"],
-        "provenance": snapshot["provenance"],
+        "provenance": provenance,
         "system": system,
+        "technical_completion": snapshot["technical_completion"],
+        "economic_result": snapshot["economic_result"],
+        "current_research": snapshot["current_research"],
         "parity_surfaces_completed": snapshot["parity_surfaces_completed"],
         "blocked_main_gates": snapshot["blocked_main_gates"],
         "strategy_fleet": snapshot["strategy_fleet"],

--- a/src/webui/market_dashboard_current_state_snapshot_v0.py
+++ b/src/webui/market_dashboard_current_state_snapshot_v0.py
@@ -1,12 +1,15 @@
 """Versioned current-state snapshot for GET /market (display-only SSOT).
 
-Provenance:
+Provenance (PR #5242 current-state sync):
 - docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
-- docs/research/entry_position_exit_policy_backtest_parity_wiring_assessment_or_narrow_rewire_v0.json
-- research/merge_closeout_pr5033_surface_p_semantic_parity_status_binding_fix_v0_20260709T135256Z
-- research/system_economic_evidence_admissibility_gap_scan_after_full_parity_v0_20260709T141726Z
+- config/research/full_canonical_system_economic_evidence_generation_v1_offline_execution_result_v0.json
+- research/full_canonical_system_economic_evidence_generation_v1_offline_execution_v0_20260716T015033Z
+- research/pr5242_source_evidence_manifest_verify_log_retention_repair_v1_20260716T154633Z
+- research/pr5242_merge_closeout_full_canonical_system_economic_evidence_generation_v1_offline_execution_v1_20260716T155043Z
 
 No trading authority. No runtime effect. Single dashboard owner — no parallel SSOT.
+Display-only binding of already-persisted, manifest-verified Full-Canonical evidence closeout.
+PR #5242 did not execute a new economic evaluation and did not rematerialize evidence results.
 """
 
 from __future__ import annotations
@@ -22,6 +25,25 @@ MA_CROSSOVER_CONFIG_OWNER: Final[str] = (
 VOL_BREAKOUT_CONFIG_OWNER: Final[str] = (
     "config/ops/step29m_okx_inst_eth_usdt_perp_vol_breakout_v1_economic_evaluation_v1.json"
 )
+CURRENT_STATE_RESULT_JSON: Final[str] = (
+    "config/research/full_canonical_system_economic_evidence_generation_v1_offline_execution_result_v0.json"
+)
+
+# Audit-/display-only provenance paths (not loaded at request time).
+CURRENT_STATE_PRIMARY_EVIDENCE_DIR: Final[str] = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "research/full_canonical_system_economic_evidence_generation_v1_offline_execution_v0_20260716T015033Z"
+)
+CURRENT_STATE_REPAIR_EVIDENCE_DIR: Final[str] = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "research/pr5242_source_evidence_manifest_verify_log_retention_repair_v1_20260716T154633Z"
+)
+CURRENT_STATE_CLOSEOUT_EVIDENCE_DIR: Final[str] = (
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+    "research/pr5242_merge_closeout_full_canonical_system_economic_evidence_generation_v1_"
+    "offline_execution_v1_20260716T155043Z"
+)
+
 FULL_PARITY_CLOSEOUT_EVIDENCE_REF: Final[str] = (
     "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
     "research/merge_closeout_pr5033_surface_p_semantic_parity_status_binding_fix_v0_20260709T135256Z"
@@ -43,14 +65,40 @@ NEXT_PARITY_SLICE: Final[str] = "CANONICAL_ORDER_INTENT_OFFLINE_REPLAY_BINDING_P
 DOCUMENTED_ONLY_LATER_PATH: Final[str] = (
     "REQUEST_OPERATOR_RATIFY_STEP31F_PROMOTION_METRIC_MATERIALIZATION_PATH_EXECUTION_OWNER_NARROW_IMPLEMENTATION_FIX_SCOPE_V0"
 )
-NEXT_BLOCKER: Final[str] = "SYSTEM_ECONOMIC_EVIDENCE_NOT_PROVEN"
-
-CURRENT_ORIGIN_MAIN: Final[str] = "99325f8fee0ddbb4dfb041974b9a55270b4e56c4"
-
-LATEST_MERGED_PR_NUMBER: Final[int] = 5066
-LATEST_MERGED_PR_TITLE: Final[str] = (
-    "Entry position exit policy backtest parity wiring assessment v0"
+NEXT_BLOCKER: Final[str] = (
+    "FULL_CANONICAL_SYSTEM_ECONOMIC_BASELINE_TERMINAL_FAIL_UNCHANGED_RETRY_FORBIDDEN"
 )
+
+CURRENT_ORIGIN_MAIN: Final[str] = "0fdacfae2aa3180925a8b625267de5eb5761eccb"
+CURRENT_STATE_SOURCE_PR: Final[int] = 5242
+CURRENT_STATE_SOURCE_HEAD: Final[str] = CURRENT_ORIGIN_MAIN
+
+LATEST_MERGED_PR_NUMBER: Final[int] = 5242
+LATEST_MERGED_PR_TITLE: Final[str] = (
+    "research: execute full canonical system economic evidence generation v1"
+)
+LATEST_MERGED_PR_STATE: Final[str] = "MERGED"
+LATEST_MERGED_PR_SQUASH_COMMIT: Final[str] = CURRENT_ORIGIN_MAIN
+
+CURRENT_RESEARCH_STRATEGY_ID: Final[str] = "bollinger_bands"
+CURRENT_RESEARCH_STRATEGY_VERSION: Final[str] = "v2"
+CURRENT_RESEARCH_BINDING_ID: Final[str] = (
+    "bollinger_bands_v2_full_canonical_system_economic_binding_v1"
+)
+CURRENT_RESEARCH_STATUS: Final[str] = "COMPLETE_FAIL"
+ECONOMIC_STATUS: Final[str] = "FAIL"
+TRADE_COUNT: Final[int] = 0
+NET_RETURN: Final[float] = 0.0
+
+PRIMARY_SOURCE_MANIFEST_VERIFY_RC: Final[int] = 0
+SOURCE_REPAIR_MANIFEST_VERIFY_RC: Final[int] = 0
+CLOSEOUT_MANIFEST_VERIFY_RC: Final[int] = 0
+
+ECONOMIC_EVALUATION_EXECUTED: Final[bool] = False
+EVIDENCE_RESULTS_REMATERIALIZED: Final[bool] = False
+ECONOMIC_VALIDITY_OFFLINE_GATE_PASS: Final[bool] = False
+UNCHANGED_RETRY_FORBIDDEN: Final[bool] = True
+POLICY_RESCUE_ALLOWED: Final[bool] = False
 
 PR5033_MERGE_COMMIT: Final[str] = "720b59bed1c012e873c8e1207b057ebd5fa8f21a"
 PR5033_HEAD: Final[str] = "bf6778ef9815b197a8d0e7a649c96dda8cb61546"
@@ -127,13 +175,27 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
             "economic_gap_scan_evidence_ref": ECONOMIC_GAP_SCAN_EVIDENCE_REF,
             "notion_sync_evidence_ref": NOTION_SYNC_EVIDENCE_REF,
             "ratification_evidence_ref": RATIFICATION_EVIDENCE_REF,
+            "CURRENT_STATE_SOURCE_PR": CURRENT_STATE_SOURCE_PR,
+            "CURRENT_STATE_SOURCE_HEAD": CURRENT_STATE_SOURCE_HEAD,
+            "CURRENT_STATE_PRIMARY_EVIDENCE_DIR": CURRENT_STATE_PRIMARY_EVIDENCE_DIR,
+            "CURRENT_STATE_REPAIR_EVIDENCE_DIR": CURRENT_STATE_REPAIR_EVIDENCE_DIR,
+            "CURRENT_STATE_CLOSEOUT_EVIDENCE_DIR": CURRENT_STATE_CLOSEOUT_EVIDENCE_DIR,
+            "CURRENT_STATE_RESULT_JSON": CURRENT_STATE_RESULT_JSON,
+            "PRIMARY_SOURCE_MANIFEST_VERIFY_RC": PRIMARY_SOURCE_MANIFEST_VERIFY_RC,
+            "SOURCE_REPAIR_MANIFEST_VERIFY_RC": SOURCE_REPAIR_MANIFEST_VERIFY_RC,
+            "CLOSEOUT_MANIFEST_VERIFY_RC": CLOSEOUT_MANIFEST_VERIFY_RC,
+            "ECONOMIC_EVALUATION_EXECUTED": ECONOMIC_EVALUATION_EXECUTED,
+            "EVIDENCE_RESULTS_REMATERIALIZED": EVIDENCE_RESULTS_REMATERIALIZED,
+            "MANIFESTS_VERIFIED": True,
         },
         "current_system_state": {
             "CURRENT_ORIGIN_MAIN": CURRENT_ORIGIN_MAIN,
             "LATEST_MERGED_PR_NUMBER": LATEST_MERGED_PR_NUMBER,
             "LATEST_MERGED_PR_TITLE": LATEST_MERGED_PR_TITLE,
-            "FULL_CANONICAL_CHAIN_WIRED": False,
-            "BACKTEST_RUNTIME_DECISION_PARITY_PASS": False,
+            "LATEST_MERGED_PR_STATE": LATEST_MERGED_PR_STATE,
+            "LATEST_MERGED_PR_SQUASH_COMMIT": LATEST_MERGED_PR_SQUASH_COMMIT,
+            "FULL_CANONICAL_CHAIN_WIRED": True,
+            "BACKTEST_RUNTIME_DECISION_PARITY_PASS": True,
             "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE": False,
             "RUNTIME_REWIRE_ADMISSIBLE": False,
             "NEXT_BLOCKER": NEXT_BLOCKER,
@@ -141,9 +203,21 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
             "ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED": False,
             "CURRENT_FLEET_ECONOMIC_VALIDITY_PASS": False,
             "WHOLE_SYSTEM_UNPROFITABLE_NOT_PROVEN": True,
-            "AUTHORIZED_PENDING_EVALUATION_COUNT": 1,
-            "NEXT_EVALUATION_STRATEGY_ID": "vol_breakout",
-            "NEXT_EVALUATION_CONFIG_STATUS": "AUTHORIZED_PENDING_EVALUATION",
+            "AUTHORIZED_PENDING_EVALUATION_COUNT": 0,
+            "NEXT_EVALUATION_STRATEGY_ID": "NONE",
+            "NEXT_EVALUATION_CONFIG_STATUS": "NONE",
+            "CURRENT_RESEARCH_STRATEGY_ID": CURRENT_RESEARCH_STRATEGY_ID,
+            "CURRENT_RESEARCH_STRATEGY_VERSION": CURRENT_RESEARCH_STRATEGY_VERSION,
+            "CURRENT_RESEARCH_BINDING_ID": CURRENT_RESEARCH_BINDING_ID,
+            "CURRENT_RESEARCH_STATUS": CURRENT_RESEARCH_STATUS,
+            "ECONOMIC_STATUS": ECONOMIC_STATUS,
+            "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS": ECONOMIC_VALIDITY_OFFLINE_GATE_PASS,
+            "TRADE_COUNT": TRADE_COUNT,
+            "NET_RETURN": NET_RETURN,
+            "UNCHANGED_RETRY_FORBIDDEN": UNCHANGED_RETRY_FORBIDDEN,
+            "POLICY_RESCUE_ALLOWED": POLICY_RESCUE_ALLOWED,
+            "ECONOMIC_EVALUATION_EXECUTED": ECONOMIC_EVALUATION_EXECUTED,
+            "EVIDENCE_RESULTS_REMATERIALIZED": EVIDENCE_RESULTS_REMATERIALIZED,
             "STEP29N_AUTHORIZED": False,
             "STEP29R_AUTHORIZED": False,
             "PROMOTION_ALLOWED": False,
@@ -159,12 +233,36 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
             "NEXT_PARITY_SLICE": NEXT_PARITY_SLICE,
             "DOCUMENTED_ONLY_LATER_PATH": DOCUMENTED_ONLY_LATER_PATH,
         },
+        "technical_completion": {
+            "FULL_CANONICAL_CHAIN_WIRED": True,
+            "BACKTEST_RUNTIME_DECISION_PARITY_PASS": True,
+            "not_economic_validity": True,
+            "not_live_authorization": True,
+        },
+        "economic_result": {
+            "ECONOMIC_STATUS": ECONOMIC_STATUS,
+            "TRADE_COUNT": TRADE_COUNT,
+            "NET_RETURN": NET_RETURN,
+            "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS": ECONOMIC_VALIDITY_OFFLINE_GATE_PASS,
+            "UNCHANGED_RETRY_FORBIDDEN": UNCHANGED_RETRY_FORBIDDEN,
+            "POLICY_RESCUE_ALLOWED": POLICY_RESCUE_ALLOWED,
+            "ECONOMIC_EVALUATION_EXECUTED": ECONOMIC_EVALUATION_EXECUTED,
+            "EVIDENCE_RESULTS_REMATERIALIZED": EVIDENCE_RESULTS_REMATERIALIZED,
+        },
+        "current_research": {
+            "strategy_id": CURRENT_RESEARCH_STRATEGY_ID,
+            "strategy_version": CURRENT_RESEARCH_STRATEGY_VERSION,
+            "binding_id": CURRENT_RESEARCH_BINDING_ID,
+            "status": CURRENT_RESEARCH_STATUS,
+            "AUTHORIZED_PENDING_EVALUATION_COUNT": 0,
+        },
         "parity_surfaces_completed": list(PARITY_SURFACES_COMPLETED),
         "blocked_main_gates": {
-            "FULL_CANONICAL_CHAIN_WIRED": False,
-            "BACKTEST_RUNTIME_DECISION_PARITY_PASS": False,
+            "FULL_CANONICAL_CHAIN_WIRED": True,
+            "BACKTEST_RUNTIME_DECISION_PARITY_PASS": True,
             "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE": False,
             "RUNTIME_REWIRE_ADMISSIBLE": False,
+            "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS": False,
         },
         "strategy_fleet": [
             {
@@ -176,6 +274,7 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
                 "economic_validity_pass": False,
                 "promotion_eligible": False,
                 "runtime_authority": False,
+                "fleet_role": "historical_closed",
             },
             {
                 "strategy_id": "breakout_donchian",
@@ -186,6 +285,7 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
                 "economic_validity_pass": False,
                 "promotion_eligible": False,
                 "runtime_authority": False,
+                "fleet_role": "historical_closed",
             },
             {
                 "strategy_id": "ma_crossover",
@@ -196,18 +296,34 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
                 "economic_validity_pass": False,
                 "promotion_eligible": False,
                 "runtime_authority": False,
+                "fleet_role": "historical_closed",
             },
             {
                 "strategy_id": "vol_breakout",
                 "strategy_version": "v1",
                 "config_version": "v1",
-                "status_label": "AUTHORIZED_PENDING_EVALUATION",
+                "status_label": "TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL",
                 "policy_ratified": True,
                 "fixed_config_bound": True,
-                "economic_evaluation_executed": False,
+                "economic_evaluation_executed": True,
                 "economic_validity_pass": False,
                 "promotion_eligible": False,
                 "runtime_authority": False,
+                "fleet_role": "historical_closed",
+            },
+            {
+                "strategy_id": "bollinger_bands",
+                "strategy_version": "v2",
+                "config_version": "v1",
+                "binding_id": CURRENT_RESEARCH_BINDING_ID,
+                "status_label": "COMPLETE_FAIL",
+                "evaluation_complete": True,
+                "economic_validity_pass": False,
+                "promotion_eligible": False,
+                "runtime_authority": False,
+                "fleet_role": "current_terminal",
+                "economic_evaluation_executed": ECONOMIC_EVALUATION_EXECUTED,
+                "evidence_results_rematerialized": EVIDENCE_RESULTS_REMATERIALIZED,
             },
         ],
         "vol_breakout_fixed_config": {
@@ -227,7 +343,7 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
             "parameter_tuning_allowed": False,
             "dataset_replacement_allowed": False,
             "threshold_tuning_allowed": False,
-            "economic_evaluation_executed": False,
+            "economic_evaluation_executed": True,
             "performance_claim_allowed": False,
             "atr_multiple_bound": False,
             "sizing_invariant": {
@@ -297,8 +413,8 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
             "latest_merged_pr": {
                 "pr_number": LATEST_MERGED_PR_NUMBER,
                 "title": LATEST_MERGED_PR_TITLE,
-                "state": "MERGED",
-                "merge_commit": CURRENT_ORIGIN_MAIN,
+                "state": LATEST_MERGED_PR_STATE,
+                "merge_commit": LATEST_MERGED_PR_SQUASH_COMMIT,
             },
             "PR5033": {
                 "pr_number": 5033,
@@ -308,17 +424,22 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
                 "base": PR5033_BASE,
             },
             "full_parity_proof": {
-                "FULL_CANONICAL_CHAIN_WIRED": False,
-                "BACKTEST_RUNTIME_DECISION_PARITY_PASS": False,
+                "FULL_CANONICAL_CHAIN_WIRED": True,
+                "BACKTEST_RUNTIME_DECISION_PARITY_PASS": True,
                 "MANIFEST_VERIFY_RC": 0,
                 "evidence_ref": FULL_PARITY_CLOSEOUT_EVIDENCE_REF,
-                "historical_note": "PR5033 surface-P closeout; post-PR5066 slice chain assessed but system gates remain blocked.",
+                "historical_note": (
+                    "Technical completion remains distinct from economic validity; "
+                    "PR #5242 bound Full-Canonical economic FAIL closeout without authority."
+                ),
             },
             "economic_evidence_gap": {
                 "SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE": False,
+                "ECONOMIC_STATUS": ECONOMIC_STATUS,
+                "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS": False,
                 "NEXT_BLOCKER": NEXT_BLOCKER,
-                "MANIFEST_VERIFY_RC": 0,
-                "evidence_ref": ECONOMIC_GAP_SCAN_EVIDENCE_REF,
+                "MANIFEST_VERIFY_RC": PRIMARY_SOURCE_MANIFEST_VERIFY_RC,
+                "evidence_ref": CURRENT_STATE_PRIMARY_EVIDENCE_DIR,
             },
             "notion_current_state_sync": {
                 "NOTION_CURRENT": True,
@@ -344,8 +465,10 @@ def market_dashboard_current_state_snapshot_v0() -> dict[str, Any]:
             "step29n_or_runtime_authorized",
             "runtime_rewire_admissible",
             "system_economic_evidence_admissible",
-            "full_canonical_chain_wired_true",
-            "backtest_runtime_decision_parity_pass_true",
+            "vol_breakout_authorized_pending_evaluation",
+            "authorized_pending_evaluation_count_nonzero",
+            "economic_evaluation_executed_by_pr5242",
+            "evidence_results_rematerialized_by_pr5242",
             "notion_stale_after_pr5033",
         ],
         "view_only": True,

--- a/templates/peak_trade_dashboard/partials/market_current_state_compact_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_current_state_compact_v1.html
@@ -16,19 +16,40 @@
   </div>
 
   <p class="m-0 mb-1.5 text-[9px] font-mono text-slate-400" data-market-latest-merged-pr-v1="true">
-    PR #{{ current_state.system.LATEST_MERGED_PR_NUMBER|e }} MERGED · {{ current_state.system.LATEST_MERGED_PR_TITLE|e }}
+    PR #{{ current_state.system.LATEST_MERGED_PR_NUMBER|e }} {{ current_state.system.LATEST_MERGED_PR_STATE|e }} · {{ current_state.system.LATEST_MERGED_PR_TITLE|e }}
     · NOTION_CURRENT={{ current_state.system.NOTION_CURRENT|lower }} · NOTION_UPDATED={{ current_state.system.NOTION_UPDATED|lower }}
   </p>
 
-  <div class="mb-2" data-market-blocked-main-gates-v1="true">
-    <p class="m-0 mb-1 text-[9px] uppercase text-rose-300/90">Blocked main gates (system-level)</p>
+  <div class="mb-2" data-market-technical-completion-v1="true">
+    <p class="m-0 mb-1 text-[9px] uppercase text-emerald-300/90">Technical completion (not economic validity)</p>
     <dl class="m-0 grid grid-cols-2 sm:grid-cols-4 gap-x-2 gap-y-1 text-[9px] font-mono">
-      <div><dt class="text-slate-500 uppercase">Chain wired</dt><dd class="m-0 text-rose-200/90" data-market-full-canonical-chain-wired-v1="true">{{ current_state.blocked_main_gates.FULL_CANONICAL_CHAIN_WIRED|lower }}</dd></div>
-      <div><dt class="text-slate-500 uppercase">Parity pass</dt><dd class="m-0 text-rose-200/90" data-market-backtest-runtime-parity-pass-v1="true">{{ current_state.blocked_main_gates.BACKTEST_RUNTIME_DECISION_PARITY_PASS|lower }}</dd></div>
+      <div><dt class="text-slate-500 uppercase">Chain wired</dt><dd class="m-0 text-emerald-200/90" data-market-full-canonical-chain-wired-v1="true">{{ current_state.technical_completion.FULL_CANONICAL_CHAIN_WIRED|lower }}</dd></div>
+      <div><dt class="text-slate-500 uppercase">Parity pass</dt><dd class="m-0 text-emerald-200/90" data-market-backtest-runtime-parity-pass-v1="true">{{ current_state.technical_completion.BACKTEST_RUNTIME_DECISION_PARITY_PASS|lower }}</dd></div>
       <div><dt class="text-slate-500 uppercase">Econ evidence</dt><dd class="m-0 text-rose-200/90" data-market-economic-evidence-admissible-v1="true">{{ current_state.blocked_main_gates.SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE|lower }}</dd></div>
       <div><dt class="text-slate-500 uppercase">Runtime rewire</dt><dd class="m-0 text-rose-200/90" data-market-runtime-rewire-admissible-v1="true">{{ current_state.blocked_main_gates.RUNTIME_REWIRE_ADMISSIBLE|lower }}</dd></div>
     </dl>
     <p class="m-0 mt-1 text-[8px] text-amber-200/80" data-market-next-blocker-v1="true">NEXT_BLOCKER={{ current_state.system.NEXT_BLOCKER|e }}</p>
+  </div>
+
+  <div class="mb-2" data-market-economic-result-v1="true">
+    <p class="m-0 mb-1 text-[9px] uppercase text-rose-300/90">Economic result (offline evidence closeout)</p>
+    <dl class="m-0 grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-x-2 gap-y-1 text-[9px] font-mono">
+      <div><dt class="text-slate-500 uppercase">Status</dt><dd class="m-0 text-rose-200/90" data-market-economic-status-v1="true">{{ current_state.economic_result.ECONOMIC_STATUS|e }}</dd></div>
+      <div><dt class="text-slate-500 uppercase">Trades</dt><dd class="m-0 text-slate-300" data-market-trade-count-v1="true">{{ current_state.economic_result.TRADE_COUNT|e }}</dd></div>
+      <div><dt class="text-slate-500 uppercase">Net return</dt><dd class="m-0 text-slate-300" data-market-net-return-v1="true">{{ current_state.economic_result.NET_RETURN|e }}</dd></div>
+      <div><dt class="text-slate-500 uppercase">Econ gate</dt><dd class="m-0 text-rose-200/90" data-market-economic-validity-offline-gate-v1="true">{{ current_state.economic_result.ECONOMIC_VALIDITY_OFFLINE_GATE_PASS|lower }}</dd></div>
+      <div><dt class="text-slate-500 uppercase">Retry</dt><dd class="m-0 text-amber-200/80" data-market-unchanged-retry-forbidden-v1="true">UNCHANGED_RETRY_FORBIDDEN={{ current_state.economic_result.UNCHANGED_RETRY_FORBIDDEN|lower }}</dd></div>
+      <div><dt class="text-slate-500 uppercase">Rescue</dt><dd class="m-0 text-slate-400" data-market-policy-rescue-allowed-v1="true">POLICY_RESCUE_ALLOWED={{ current_state.economic_result.POLICY_RESCUE_ALLOWED|lower }}</dd></div>
+    </dl>
+  </div>
+
+  <div class="mb-2" data-market-current-research-v1="true">
+    <p class="m-0 mb-1 text-[9px] uppercase text-slate-400">Current research scope</p>
+    <dl class="m-0 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-x-2 gap-y-1 text-[9px] font-mono">
+      <div><dt class="text-slate-500 uppercase">Strategy</dt><dd class="m-0 text-sky-200/90" data-market-current-research-strategy-v1="true">{{ current_state.current_research.strategy_id|e }}/{{ current_state.current_research.strategy_version|e }}</dd></div>
+      <div><dt class="text-slate-500 uppercase">Status</dt><dd class="m-0 text-rose-200/90" data-market-current-research-status-v1="true">{{ current_state.current_research.status|e }}</dd></div>
+      <div class="sm:col-span-2"><dt class="text-slate-500 uppercase">Binding</dt><dd class="m-0 text-slate-300 break-all" data-market-current-research-binding-v1="true">{{ current_state.current_research.binding_id|e }}</dd></div>
+    </dl>
   </div>
 
   <div class="mb-2" data-market-parity-surfaces-completed-v1="true">
@@ -60,9 +81,9 @@
   </dl>
 
   <dl class="m-0 grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-x-2 gap-y-1 text-[9px] font-mono mb-2" data-market-current-state-fleet-flags-v1="true">
-    <div><dt class="text-slate-500 uppercase">Pending eval</dt><dd class="m-0 text-sky-200/90" data-market-authorized-pending-count-v1="true">{{ current_state.system.AUTHORIZED_PENDING_EVALUATION_COUNT|e }}</dd></div>
-    <div><dt class="text-slate-500 uppercase">Next strategy</dt><dd class="m-0 text-sky-200/90" data-market-next-evaluation-strategy-v1="true">{{ current_state.system.NEXT_EVALUATION_STRATEGY_ID|e }}</dd></div>
-    <div><dt class="text-slate-500 uppercase">Next status</dt><dd class="m-0 text-sky-200/90" data-market-next-evaluation-status-v1="true">{{ current_state.system.NEXT_EVALUATION_CONFIG_STATUS|e }}</dd></div>
+    <div><dt class="text-slate-500 uppercase">Pending eval</dt><dd class="m-0 text-slate-300" data-market-authorized-pending-count-v1="true">{{ current_state.system.AUTHORIZED_PENDING_EVALUATION_COUNT|e }}</dd></div>
+    <div><dt class="text-slate-500 uppercase">Next strategy</dt><dd class="m-0 text-slate-300" data-market-next-evaluation-strategy-v1="true">{{ current_state.system.NEXT_EVALUATION_STRATEGY_ID|e }}</dd></div>
+    <div><dt class="text-slate-500 uppercase">Next status</dt><dd class="m-0 text-slate-300" data-market-next-evaluation-status-v1="true">{{ current_state.system.NEXT_EVALUATION_CONFIG_STATUS|e }}</dd></div>
     <div><dt class="text-slate-500 uppercase">Econ pass</dt><dd class="m-0 text-rose-200/90" data-market-economic-validity-pass-v1="true">false</dd></div>
     <div><dt class="text-slate-500 uppercase">Runtime auth</dt><dd class="m-0 text-slate-300" data-market-runtime-authorized-v1="true">{{ current_state.system.RUNTIME_AUTHORIZED|lower }}</dd></div>
     <div><dt class="text-slate-500 uppercase">Econ admissible</dt><dd class="m-0 text-rose-200/90" data-market-system-economic-admissible-v1="true">{{ current_state.system.SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE|lower }}</dd></div>
@@ -77,14 +98,15 @@
         data-market-fleet-row-v1="true"
         data-market-fleet-strategy-id="{{ row.strategy_id|e }}"
         data-market-fleet-status="{{ row.status_label|e }}"
+        {% if row.fleet_role is defined %}data-market-fleet-role="{{ row.fleet_role|e }}"{% endif %}
       >
         <span class="font-mono text-slate-200">{{ row.strategy_id|e }} {{ row.strategy_version|e }} / config {{ row.config_version|e }}</span>
         <span class="block mt-0.5 uppercase text-slate-400">{{ row.status_label|e }}</span>
         {% if row.policy_ratified %}
         <span class="block text-[8px] text-emerald-300/80">POLICY_RATIFIED · FIXED_CONFIG_BOUND</span>
         {% endif %}
-        {% if row.economic_evaluation_executed is defined and not row.economic_evaluation_executed %}
-        <span class="block text-[8px] text-slate-500">ECONOMIC_EVALUATION_EXECUTED=false</span>
+        {% if row.fleet_role is defined and row.fleet_role == 'current_terminal' %}
+        <span class="block text-[8px] text-amber-200/80">CURRENT_TERMINAL · ECONOMIC_EVALUATION_EXECUTED={{ row.economic_evaluation_executed|lower }} · EVIDENCE_RESULTS_REMATERIALIZED={{ row.evidence_results_rematerialized|lower }}</span>
         {% endif %}
       </li>
       {% endfor %}
@@ -103,7 +125,7 @@
       <div><dt class="text-slate-500">oversize</dt><dd class="m-0">{{ cfg.oversize_policy|e }}</dd></div>
       <div class="sm:col-span-2"><dt class="text-slate-500">sizing invariant</dt><dd class="m-0">{{ cfg.sizing_invariant.lhs|e }} &lt;= {{ cfg.sizing_invariant.rhs|e }}</dd></div>
     </dl>
-    <p class="m-0 mt-1 text-[8px] text-slate-500">Fixed config · no tuning · no dataset switch · no threshold change · no economic evaluation · no performance statement</p>
+    <p class="m-0 mt-1 text-[8px] text-slate-500">Fixed config · no tuning · no dataset switch · no threshold change · no performance statement</p>
   </details>
 
   <div class="rounded border border-sky-900/40 bg-sky-950/20 px-2 py-1.5 mb-2" data-market-next-parity-slice-v1="true">
@@ -118,6 +140,17 @@
     <p class="m-0 mt-1 text-[8px] text-slate-500">DOCUMENTED_ONLY_NOT_EXECUTABLE · operator ratification required · no runtime authority · no promotion</p>
   </div>
 
+  <div class="rounded border border-slate-700/50 bg-slate-950/35 px-2 py-1.5 mb-2" data-market-current-state-provenance-v1="true">
+    <p class="m-0 text-[9px] uppercase text-slate-400">Provenance (display-only; not request-time loaded)</p>
+    <dl class="m-0 mt-1 grid grid-cols-1 sm:grid-cols-2 gap-x-2 gap-y-1 text-[8px] font-mono text-slate-400">
+      <div><dt class="text-slate-500">SOURCE_PR</dt><dd class="m-0" data-market-source-pr-v1="true">{{ current_state.provenance.CURRENT_STATE_SOURCE_PR|e }}</dd></div>
+      <div><dt class="text-slate-500">SOURCE_HEAD</dt><dd class="m-0 break-all" data-market-source-head-v1="true">{{ current_state.provenance.CURRENT_STATE_SOURCE_HEAD|e }}</dd></div>
+      <div class="sm:col-span-2"><dt class="text-slate-500">RESULT_JSON</dt><dd class="m-0 break-all" data-market-result-json-v1="true">{{ current_state.provenance.CURRENT_STATE_RESULT_JSON|e }}</dd></div>
+      <div><dt class="text-slate-500">MANIFESTS</dt><dd class="m-0" data-market-manifests-verified-v1="true">MANIFESTS_VERIFIED={{ current_state.provenance.MANIFESTS_VERIFIED|lower }} · RC={{ current_state.provenance.PRIMARY_SOURCE_MANIFEST_VERIFY_RC|e }}/{{ current_state.provenance.SOURCE_REPAIR_MANIFEST_VERIFY_RC|e }}/{{ current_state.provenance.CLOSEOUT_MANIFEST_VERIFY_RC|e }}</dd></div>
+      <div><dt class="text-slate-500">PR5242 closeout flags</dt><dd class="m-0" data-market-pr5242-closeout-flags-v1="true">ECONOMIC_EVALUATION_EXECUTED={{ current_state.provenance.ECONOMIC_EVALUATION_EXECUTED|lower }} · EVIDENCE_RESULTS_REMATERIALIZED={{ current_state.provenance.EVIDENCE_RESULTS_REMATERIALIZED|lower }}</dd></div>
+    </dl>
+  </div>
+
   <div class="flex flex-wrap gap-1 text-[8px] uppercase mb-1" data-market-governance-safety-compact-v1="true">
     <span class="rounded border border-emerald-800/50 px-1 py-0.5 text-emerald-200/90">FUTURES_ONLY</span>
     <span class="rounded border border-rose-800/45 px-1 py-0.5 text-rose-200/90" data-market-governance-directional-crypto-blocked-v1="true">BIT<!-- -->COIN_DIRECTION_ALLOWED=false</span>
@@ -130,6 +163,6 @@
   </div>
 
   <p class="m-0 text-[8px] text-slate-500" data-market-evidence-primary-v1="true">
-    PR #{{ current_state.system.LATEST_MERGED_PR_NUMBER|e }} MERGED · FULL_CANONICAL_CHAIN_WIRED=false · BACKTEST_RUNTIME_DECISION_PARITY_PASS=false · RUNTIME_REWIRE_ADMISSIBLE=false · view-only · no controls
+    PR #{{ current_state.system.LATEST_MERGED_PR_NUMBER|e }} {{ current_state.system.LATEST_MERGED_PR_STATE|e }} · FULL_CANONICAL_CHAIN_WIRED=true · BACKTEST_RUNTIME_DECISION_PARITY_PASS=true · ECONOMIC_STATUS=FAIL · ECONOMIC_VALIDITY_OFFLINE_GATE_PASS=false · RUNTIME_REWIRE_ADMISSIBLE=false · view-only · no controls
   </p>
 </section>

--- a/tests/webui/test_market_dashboard_current_state_sync_v0.py
+++ b/tests/webui/test_market_dashboard_current_state_sync_v0.py
@@ -1,7 +1,8 @@
-"""Market dashboard full-parity current-state sync contract (view-only, SSR)."""
+"""Market dashboard current-state sync + PR #5242 freshness contract (view-only, SSR)."""
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from collections.abc import Iterator
@@ -20,14 +21,35 @@ pytestmark = pytest.mark.web
 
 from src.webui.app import create_app
 from src.webui.market_dashboard_current_state_snapshot_v0 import (
+    CLOSEOUT_MANIFEST_VERIFY_RC,
     CURRENT_ORIGIN_MAIN,
+    CURRENT_RESEARCH_BINDING_ID,
+    CURRENT_RESEARCH_STATUS,
+    CURRENT_RESEARCH_STRATEGY_ID,
+    CURRENT_RESEARCH_STRATEGY_VERSION,
+    CURRENT_STATE_CLOSEOUT_EVIDENCE_DIR,
+    CURRENT_STATE_PRIMARY_EVIDENCE_DIR,
+    CURRENT_STATE_REPAIR_EVIDENCE_DIR,
+    CURRENT_STATE_RESULT_JSON,
+    CURRENT_STATE_SOURCE_HEAD,
+    CURRENT_STATE_SOURCE_PR,
     DOCUMENTED_ONLY_LATER_PATH,
+    ECONOMIC_EVALUATION_EXECUTED,
+    ECONOMIC_STATUS,
+    ECONOMIC_VALIDITY_OFFLINE_GATE_PASS,
+    EVIDENCE_RESULTS_REMATERIALIZED,
     LATEST_MERGED_PR_NUMBER,
+    LATEST_MERGED_PR_STATE,
     LATEST_MERGED_PR_TITLE,
+    NET_RETURN,
     NEXT_BLOCKER,
     NEXT_PARITY_SLICE,
     PARITY_SURFACES_COMPLETED,
+    PRIMARY_SOURCE_MANIFEST_VERIFY_RC,
     SNAPSHOT_OWNER,
+    SOURCE_REPAIR_MANIFEST_VERIFY_RC,
+    TRADE_COUNT,
+    UNCHANGED_RETRY_FORBIDDEN,
     market_dashboard_current_state_snapshot_v0,
 )
 from src.webui.market_surface import (
@@ -62,6 +84,9 @@ PARITY_SURFACE_STATUSES = (
     "WIRED_EXISTING_BACKTEST_PARITY_CHAIN_COMPLETE",
     "WIRED_EXISTING_BACKTEST_PARITY_CHAIN_COMPLETE",
 )
+
+PR5242_SOURCE_HEAD = "0fdacfae2aa3180925a8b625267de5eb5761eccb"
+CANONICAL_RESULT_JSON_REL = "config/research/full_canonical_system_economic_evidence_generation_v1_offline_execution_result_v0.json"
 
 
 @pytest.fixture()
@@ -115,22 +140,69 @@ def test_single_current_state_ssot_owner() -> None:
     assert CANONICAL_CURRENT_STATE_TEMPLATE_OWNER.endswith("market_current_state_compact_v1.html")
 
 
+def test_freshness_pr5242_source_head_and_pr_binding() -> None:
+    """Independent freshness: snapshot PR/HEAD must match frozen PR #5242 closeout identity."""
+    assert CURRENT_STATE_SOURCE_PR == 5242
+    assert LATEST_MERGED_PR_NUMBER == 5242
+    assert CURRENT_ORIGIN_MAIN == PR5242_SOURCE_HEAD
+    assert CURRENT_STATE_SOURCE_HEAD == PR5242_SOURCE_HEAD
+    assert CURRENT_STATE_SOURCE_HEAD == CURRENT_ORIGIN_MAIN
+    assert LATEST_MERGED_PR_STATE == "MERGED"
+    assert CURRENT_STATE_RESULT_JSON == CANONICAL_RESULT_JSON_REL
+    result_path = project_root / CURRENT_STATE_RESULT_JSON
+    assert result_path.is_file()
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["strategy_id"] == CURRENT_RESEARCH_STRATEGY_ID
+    assert result["strategy_version"] == CURRENT_RESEARCH_STRATEGY_VERSION
+    assert result["binding_id"] == CURRENT_RESEARCH_BINDING_ID
+    assert result["status"] == CURRENT_RESEARCH_STATUS
+    assert result["economic_status"] == ECONOMIC_STATUS
+    assert result["economic_validity_offline_gate_pass"] is False
+    assert int(result["trade_count"]) == TRADE_COUNT
+    assert float(result["net_return"]) == float(NET_RETURN)
+    assert result["authority_effect"] == "NONE"
+    assert result["durable_evidence_dir"] == CURRENT_STATE_PRIMARY_EVIDENCE_DIR
+
+
+def test_staleness_guard_pr_head_fields_do_not_diverge() -> None:
+    system = market_dashboard_current_state_snapshot_v0()["current_system_state"]
+    provenance = market_dashboard_current_state_snapshot_v0()["provenance"]
+    assert system["CURRENT_ORIGIN_MAIN"] == CURRENT_ORIGIN_MAIN
+    assert system["LATEST_MERGED_PR_NUMBER"] == LATEST_MERGED_PR_NUMBER
+    assert provenance["CURRENT_STATE_SOURCE_PR"] == CURRENT_STATE_SOURCE_PR
+    assert provenance["CURRENT_STATE_SOURCE_HEAD"] == CURRENT_STATE_SOURCE_HEAD
+    assert system["LATEST_MERGED_PR_NUMBER"] == provenance["CURRENT_STATE_SOURCE_PR"]
+    assert system["CURRENT_ORIGIN_MAIN"] == provenance["CURRENT_STATE_SOURCE_HEAD"]
+    assert system["LATEST_MERGED_PR_SQUASH_COMMIT"] == system["CURRENT_ORIGIN_MAIN"]
+
+
 def test_current_system_state_snapshot_values() -> None:
     system = market_dashboard_current_state_snapshot_v0()["current_system_state"]
     assert system["CURRENT_ORIGIN_MAIN"] == CURRENT_ORIGIN_MAIN
     assert system["LATEST_MERGED_PR_NUMBER"] == LATEST_MERGED_PR_NUMBER
     assert system["LATEST_MERGED_PR_TITLE"] == LATEST_MERGED_PR_TITLE
-    assert system["FULL_CANONICAL_CHAIN_WIRED"] is False
-    assert system["BACKTEST_RUNTIME_DECISION_PARITY_PASS"] is False
+    assert system["FULL_CANONICAL_CHAIN_WIRED"] is True
+    assert system["BACKTEST_RUNTIME_DECISION_PARITY_PASS"] is True
     assert system["SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE"] is False
     assert system["RUNTIME_REWIRE_ADMISSIBLE"] is False
     assert system["NEXT_BLOCKER"] == NEXT_BLOCKER
     assert system["STEP29M_EXECUTION_COMPLETE"] is True
     assert system["ECONOMIC_VALIDITY_OBJECTIVE_ACHIEVED"] is False
     assert system["CURRENT_FLEET_ECONOMIC_VALIDITY_PASS"] is False
-    assert system["AUTHORIZED_PENDING_EVALUATION_COUNT"] == 1
-    assert system["NEXT_EVALUATION_STRATEGY_ID"] == "vol_breakout"
-    assert system["NEXT_EVALUATION_CONFIG_STATUS"] == "AUTHORIZED_PENDING_EVALUATION"
+    assert system["AUTHORIZED_PENDING_EVALUATION_COUNT"] == 0
+    assert system["NEXT_EVALUATION_STRATEGY_ID"] == "NONE"
+    assert system["NEXT_EVALUATION_CONFIG_STATUS"] == "NONE"
+    assert system["CURRENT_RESEARCH_STRATEGY_ID"] == "bollinger_bands"
+    assert system["CURRENT_RESEARCH_STRATEGY_VERSION"] == "v2"
+    assert system["CURRENT_RESEARCH_STATUS"] == "COMPLETE_FAIL"
+    assert system["ECONOMIC_STATUS"] == "FAIL"
+    assert system["ECONOMIC_VALIDITY_OFFLINE_GATE_PASS"] is False
+    assert system["TRADE_COUNT"] == 0
+    assert system["NET_RETURN"] == 0.0
+    assert system["UNCHANGED_RETRY_FORBIDDEN"] is True
+    assert system["POLICY_RESCUE_ALLOWED"] is False
+    assert system["ECONOMIC_EVALUATION_EXECUTED"] is False
+    assert system["EVIDENCE_RESULTS_REMATERIALIZED"] is False
     assert system["STEP29N_AUTHORIZED"] is False
     assert system["STEP29R_AUTHORIZED"] is False
     assert system["PROMOTION_ALLOWED"] is False
@@ -156,23 +228,45 @@ def test_parity_surfaces_snapshot_count_and_status() -> None:
         assert surface["assessment_status"] == expected_status
 
 
+def test_technical_completion_distinct_from_economic_fail() -> None:
+    snapshot = market_dashboard_current_state_snapshot_v0()
+    tech = snapshot["technical_completion"]
+    econ = snapshot["economic_result"]
+    assert tech["FULL_CANONICAL_CHAIN_WIRED"] is True
+    assert tech["BACKTEST_RUNTIME_DECISION_PARITY_PASS"] is True
+    assert tech["not_economic_validity"] is True
+    assert econ["ECONOMIC_STATUS"] == "FAIL"
+    assert econ["ECONOMIC_VALIDITY_OFFLINE_GATE_PASS"] is False
+    assert econ["TRADE_COUNT"] == 0
+    assert econ["NET_RETURN"] == 0.0
+    assert econ["ECONOMIC_EVALUATION_EXECUTED"] is False
+    assert econ["EVIDENCE_RESULTS_REMATERIALIZED"] is False
+    assert econ["UNCHANGED_RETRY_FORBIDDEN"] is True
+
+
 def test_blocked_main_gates_snapshot_values() -> None:
     gates = market_dashboard_current_state_snapshot_v0()["blocked_main_gates"]
-    assert gates["FULL_CANONICAL_CHAIN_WIRED"] is False
-    assert gates["BACKTEST_RUNTIME_DECISION_PARITY_PASS"] is False
+    assert gates["FULL_CANONICAL_CHAIN_WIRED"] is True
+    assert gates["BACKTEST_RUNTIME_DECISION_PARITY_PASS"] is True
     assert gates["SYSTEM_ECONOMIC_EVIDENCE_ADMISSIBLE"] is False
     assert gates["RUNTIME_REWIRE_ADMISSIBLE"] is False
+    assert gates["ECONOMIC_VALIDITY_OFFLINE_GATE_PASS"] is False
 
 
-def test_blocked_main_gates_visible(client: TestClient) -> None:
+def test_technical_and_economic_sections_visible(client: TestClient) -> None:
     html = _html(client)
-    assert 'data-market-blocked-main-gates-v1="true"' in html
-    assert 'data-market-full-canonical-chain-wired-v1="true">false' in html
-    assert 'data-market-backtest-runtime-parity-pass-v1="true">false' in html
+    assert 'data-market-technical-completion-v1="true"' in html
+    assert 'data-market-full-canonical-chain-wired-v1="true">true' in html
+    assert 'data-market-backtest-runtime-parity-pass-v1="true">true' in html
     assert 'data-market-economic-evidence-admissible-v1="true">false' in html
     assert 'data-market-runtime-rewire-admissible-v1="true">false' in html
     assert f'data-market-next-blocker-v1="true">NEXT_BLOCKER={NEXT_BLOCKER}' in html
     assert CURRENT_ORIGIN_MAIN in html
+    assert 'data-market-economic-result-v1="true"' in html
+    assert 'data-market-economic-status-v1="true">FAIL' in html
+    assert 'data-market-trade-count-v1="true">0' in html
+    assert 'data-market-economic-validity-offline-gate-v1="true">false' in html
+    assert "UNCHANGED_RETRY_FORBIDDEN=true" in html
 
 
 def test_all_six_parity_surfaces_visible(client: TestClient) -> None:
@@ -190,9 +284,15 @@ def test_strategy_fleet_snapshot(client: TestClient) -> None:
     assert 'data-market-fleet-status="TECHNICALLY_VALID_ECONOMIC_POLICY_FAIL"' in html
     assert 'data-market-fleet-strategy-id="breakout_donchian"' in html
     assert 'data-market-fleet-strategy-id="vol_breakout"' in html
-    assert 'data-market-fleet-status="AUTHORIZED_PENDING_EVALUATION"' in html
+    assert 'data-market-fleet-status="AUTHORIZED_PENDING_EVALUATION"' not in html
+    assert 'data-market-fleet-strategy-id="bollinger_bands"' in html
+    assert 'data-market-fleet-status="COMPLETE_FAIL"' in html
+    assert 'data-market-current-research-strategy-v1="true">bollinger_bands/v2' in html
+    assert 'data-market-current-research-status-v1="true">COMPLETE_FAIL' in html
+    assert CURRENT_RESEARCH_BINDING_ID in html
     assert "POLICY_RATIFIED" in html
     assert "ECONOMIC_EVALUATION_EXECUTED=false" in html
+    assert "EVIDENCE_RESULTS_REMATERIALIZED=false" in html
 
 
 def test_ma_crossover_fixed_config_display(client: TestClient) -> None:
@@ -207,6 +307,9 @@ def test_ma_crossover_fixed_config_display(client: TestClient) -> None:
     lowered = html.lower()
     assert "profitable" not in lowered
     assert "performance pass" not in lowered
+    assert "live ready" not in lowered
+    assert "production ready" not in lowered
+    assert "economically viable" not in lowered
 
 
 def test_next_parity_slice_visible_and_separate_from_step31f(client: TestClient) -> None:
@@ -233,7 +336,7 @@ def test_runtime_gates_remain_blocked(client: TestClient) -> None:
     assert 'data-market-promotion-allowed-v1="true">false' in html
     assert 'data-market-runtime-authorized-v1="true">false' in html
     assert 'data-market-economic-validity-pass-v1="true">false' in html
-    assert 'data-market-authorized-pending-count-v1="true">1' in html
+    assert 'data-market-authorized-pending-count-v1="true">0' in html
     assert 'data-market-trading-authority-v1="false"' in html
 
 
@@ -268,12 +371,34 @@ def test_futures_only_no_bitcoin_or_spot_tradeable(client: TestClient) -> None:
     assert "synthetic spot trade" not in lowered
 
 
+def test_provenance_visible_and_bound(client: TestClient) -> None:
+    html = _html(client)
+    provenance = market_dashboard_current_state_snapshot_v0()["provenance"]
+    assert 'data-market-current-state-provenance-v1="true"' in html
+    assert 'data-market-source-pr-v1="true">5242' in html
+    assert CURRENT_STATE_SOURCE_HEAD in html
+    assert CURRENT_STATE_RESULT_JSON in html
+    assert provenance["CURRENT_STATE_PRIMARY_EVIDENCE_DIR"] == CURRENT_STATE_PRIMARY_EVIDENCE_DIR
+    assert provenance["CURRENT_STATE_REPAIR_EVIDENCE_DIR"] == CURRENT_STATE_REPAIR_EVIDENCE_DIR
+    assert provenance["CURRENT_STATE_CLOSEOUT_EVIDENCE_DIR"] == CURRENT_STATE_CLOSEOUT_EVIDENCE_DIR
+    assert provenance["PRIMARY_SOURCE_MANIFEST_VERIFY_RC"] == PRIMARY_SOURCE_MANIFEST_VERIFY_RC
+    assert provenance["SOURCE_REPAIR_MANIFEST_VERIFY_RC"] == SOURCE_REPAIR_MANIFEST_VERIFY_RC
+    assert provenance["CLOSEOUT_MANIFEST_VERIFY_RC"] == CLOSEOUT_MANIFEST_VERIFY_RC
+    assert provenance["ECONOMIC_EVALUATION_EXECUTED"] is ECONOMIC_EVALUATION_EXECUTED
+    assert provenance["EVIDENCE_RESULTS_REMATERIALIZED"] is EVIDENCE_RESULTS_REMATERIALIZED
+    assert "MANIFESTS_VERIFIED=true" in html
+    assert "ECONOMIC_EVALUATION_EXECUTED=false" in html
+    assert "EVIDENCE_RESULTS_REMATERIALIZED=false" in html
+
+
 def test_evidence_integrity_secondary_not_dominant_alarm(client: TestClient) -> None:
     html = _html(client)
     assert 'data-market-evidence-primary-v1="true"' in html
     assert f"PR #{LATEST_MERGED_PR_NUMBER} MERGED" in html
-    assert "FULL_CANONICAL_CHAIN_WIRED=false" in html
-    assert "BACKTEST_RUNTIME_DECISION_PARITY_PASS=false" in html
+    assert "FULL_CANONICAL_CHAIN_WIRED=true" in html
+    assert "BACKTEST_RUNTIME_DECISION_PARITY_PASS=true" in html
+    assert "ECONOMIC_STATUS=FAIL" in html
+    assert "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS=false" in html
     assert "RUNTIME_REWIRE_ADMISSIBLE=false" in html
     assert 'data-market-diagnostics-evidence-integrity-v1="true"' in html
     assert 'data-market-ratification-manifest-drift-v1="true"' in html
@@ -289,8 +414,12 @@ def test_historical_stale_states_not_primary(client: TestClient) -> None:
     assert "operator decision still open" not in lowered
     assert "policy selection" not in lowered
     assert "economic validity pass achieved" not in lowered
-    assert 'data-market-full-canonical-chain-wired-v1="true">true' not in html
-    assert 'data-market-backtest-runtime-parity-pass-v1="true">true' not in html
+    assert "authorized_pending_evaluation" not in lowered
+    assert 'data-market-authorized-pending-count-v1="true">1' not in html
+    assert 'data-market-fleet-status="AUTHORIZED_PENDING_EVALUATION"' not in html
+    # Technical completion true may coexist with economic fail false.
+    assert 'data-market-full-canonical-chain-wired-v1="true">true' in html
+    assert 'data-market-economic-status-v1="true">FAIL' in html
 
 
 def test_existing_market_surfaces_remain_rendered(


### PR DESCRIPTION
## Summary
- **Root cause:** Current-state SSOT remained hardcoded at PR #5073/#5066 after PR #5242 merge closeout (still showed `vol_breakout=AUTHORIZED_PENDING_EVALUATION`, pending count 1, wrong HEAD/PR, missing `bollinger_bands/v2 COMPLETE_FAIL`).
- **Before:** `CURRENT_ORIGIN_MAIN=99325f8f…`, latest PR #5066, `FULL_CANONICAL_CHAIN_WIRED=false`, pending eval=1.
- **After:** `CURRENT_ORIGIN_MAIN=0fdacfae…`, latest PR #5242 MERGED, technical completion `FULL_CANONICAL_CHAIN_WIRED=true` / `BACKTEST_RUNTIME_DECISION_PARITY_PASS=true` with **economic** `FAIL` (`trade_count=0`, `net_return=0`, gate pass=false).
- **Research state:** `bollinger_bands/v2=COMPLETE_FAIL`; `AUTHORIZED_PENDING_EVALUATION_COUNT=0`; `vol_breakout` no longer pending.
- **Provenance:** Source PR/HEAD, result JSON owner, primary/repair/closeout evidence dirs, manifest RCs=0; `ECONOMIC_EVALUATION_EXECUTED=false`, `EVIDENCE_RESULTS_REMATERIALIZED=false` (PR #5242 display sync only).
- **Freshness contract:** Sync tests now assert against frozen PR #5242 HEAD + canonical result JSON (not snapshot self-consistency alone).
- **Non-goals:** no economic evaluation, no result rematerialization, no trading/risk/safety/runtime/authority changes.

## Test plan
- [x] `tests/webui/test_market_dashboard_current_state_sync_v0.py`
- [x] Bitcoin exclusion / readonly structure / F5 static contracts
- [x] Selector `CONTRACT_FOCUSED` market dashboard targets (762 passed)

## Evidence
- Dir: `/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/market_dashboard_pr5242_current_state_snapshot_and_freshness_contract_repair_v1_20260716T160154Z`
- `MANIFEST_VERIFY_RC=0` (double-verify stable)


Made with [Cursor](https://cursor.com)