### PR TITLE
fix(dashboard): reductive fail-closed market composition

### DIFF
--- a/src/webui/market_visual_operator_surface_v1/operator_overview_display_v1.py
+++ b/src/webui/market_visual_operator_surface_v1/operator_overview_display_v1.py
@@ -146,12 +146,13 @@ def build_operator_overview_display_v1(
     contract = workspace.get("contract_metadata")
     contract_meta = contract if isinstance(contract, dict) else {}
 
-    if symbol == _UNAVAILABLE:
+    snapshot_missing = governed.get("snapshot_available") is False
+    if snapshot_missing or symbol == _UNAVAILABLE:
         sentence = (
-            f"Kein Instrument geladen (Rang {rank_display}). "
-            f"Regime {regime}. "
-            f"Entscheidung {decision_state}. "
-            f"Primärer Blocker: {blocker}."
+            "Marktdaten nicht verfügbar. "
+            "Systementscheid: BLOCKIERT. "
+            "Grund: Der kanonische Futures-Snapshot ist nicht verfügbar. "
+            "Operator-Aktion: Datenquelle prüfen oder später erneut laden."
         )
     else:
         sentence = (

--- a/static/css/peak_trade_dashboard_layout_v1.css
+++ b/static/css/peak_trade_dashboard_layout_v1.css
@@ -80,22 +80,155 @@
   max-height: none;
 }
 
-/* Product recovery: empty OHLCV → compact diagnostic chart (not dominant empty stage). */
+/* Product recovery / reductive: empty OHLCV → compact secondary surface (≤240px). */
 #market-v0-shell [data-market-chart-empty-compact-v1="true"].market-phase-1a-primary-chart,
 #market-v0-shell [data-market-chart-empty-compact-v1="true"][data-market-phase-1a-chart-above-fold-v1="true"] {
   min-height: 0;
+  max-height: 240px;
+  height: auto;
 }
 
 #market-v0-shell [data-market-v0-close-chart-integrated-frame="true"][data-market-chart-empty-compact-v1="true"] {
-  min-height: 7rem;
-  height: 8.5rem;
-  max-height: 9rem;
+  min-height: 0;
+  height: auto;
+  max-height: none;
 }
 
-#market-v0-shell [data-market-product-recovery-empty-hero-v1="true"].pt-operator-overview-hero-panel {
+#market-v0-shell [data-market-product-recovery-empty-hero-v1="true"].pt-operator-overview-hero-panel,
+#market-v0-shell [data-market-reductive-primary-surface-v1="true"].pt-operator-overview-hero-panel {
   min-height: 0;
   max-height: none;
   overflow: visible;
+}
+
+/* Reductive composition — one primary + one secondary surface above fold. */
+#market-v0-shell .pt-reductive-primary-surface {
+  border: 1px solid rgba(71, 85, 105, 0.55);
+  border-radius: 0.5rem;
+  background: rgba(15, 23, 42, 0.72);
+  padding: 0.9rem 1rem 0.85rem;
+  border-left: 3px solid rgba(148, 163, 184, 0.55);
+}
+
+#market-v0-shell .pt-reductive-secondary-surface {
+  border: 1px solid rgba(51, 65, 85, 0.55);
+  border-radius: 0.5rem;
+  background: rgba(15, 23, 42, 0.45);
+  padding: 0.65rem 0.85rem;
+}
+
+#market-v0-shell .pt-reductive-chart-empty {
+  min-height: 7.5rem;
+  max-height: 13rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+#market-v0-shell .pt-reductive-kicker {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+#market-v0-shell .pt-reductive-title {
+  margin-top: 0.2rem;
+  font-size: clamp(1.35rem, 2vw, 1.7rem);
+  line-height: 1.2;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #f8fafc;
+}
+
+#market-v0-shell .pt-reductive-primary-rows {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.7rem 1.25rem;
+  margin-top: 0.85rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(51, 65, 85, 0.55);
+}
+
+@media (min-width: 900px) {
+  #market-v0-shell .pt-reductive-primary-rows {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+#market-v0-shell .pt-reductive-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+#market-v0-shell .pt-reductive-decision {
+  margin-top: 0.2rem;
+  font-size: clamp(1.15rem, 1.6vw, 1.4rem);
+  line-height: 1.2;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+#market-v0-shell .pt-reductive-body {
+  margin-top: 0.2rem;
+  font-size: 0.9375rem;
+  line-height: 1.4;
+  font-weight: 500;
+  color: #e2e8f0;
+}
+
+#market-v0-shell .pt-reductive-safety {
+  margin-top: 0.75rem;
+  font-size: 0.8125rem;
+  line-height: 1.35;
+  color: #94a3b8;
+}
+
+#market-v0-shell .pt-reductive-narrative {
+  margin-top: 0.55rem;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: #cbd5e1;
+}
+
+#market-v0-shell .pt-reductive-tech-details {
+  margin-top: 0.65rem;
+  padding-top: 0.45rem;
+  border-top: 1px solid rgba(51, 65, 85, 0.45);
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+#market-v0-shell .pt-reductive-tech-details > summary {
+  cursor: pointer;
+  color: #94a3b8;
+}
+
+#market-v0-shell .pt-reductive-deferred-modules {
+  margin-top: 0.75rem;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: #94a3b8;
+  font-size: 0.75rem;
+}
+
+#market-v0-shell .pt-reductive-deferred-modules > summary {
+  cursor: pointer;
+  color: #64748b;
+  list-style: none;
+}
+
+#market-v0-shell .pt-reductive-deferred-modules > summary::-webkit-details-marker {
+  display: none;
+}
+
+#market-v0-shell .pt-reductive-deferred-modules-body {
+  margin-top: 0.75rem;
 }
 
 #market-v0-shell .pt-foundation-instrument-title {
@@ -204,8 +337,8 @@
 .pt-operator-overview-decision-sentence {
   display: block;
   margin: 0.25rem 0 0;
-  font-size: 0.8125rem;
-  line-height: 1.35;
+  font-size: 0.875rem;
+  line-height: 1.4;
   color: var(--pt-color-text-primary, #e2e8f0);
   font-weight: 500;
   overflow-wrap: anywhere;

--- a/templates/peak_trade_dashboard/market_v0.html
+++ b/templates/peak_trade_dashboard/market_v0.html
@@ -293,6 +293,63 @@
     data-market-decision-surface-hierarchy-v1="true"
     aria-label="Decision surface"
   >
+    {% if futures_first and not governed_top20.snapshot_available %}
+    <details
+      class="pt-reductive-deferred-modules"
+      data-market-reductive-deferred-modules-v1="true"
+    >
+      <summary>Weitere Module · Ranking / Funnel / Safety (sekundär)</summary>
+      <div class="pt-reductive-deferred-modules-body">
+        <div
+          data-market-governed-top20-primary-slot-v1="true"
+          data-market-decision-hierarchy-primary-v1="true"
+          data-market-decision-hierarchy-tier="primary"
+        >
+          {% include "partials/market_governed_top20_primary_v1.html" %}
+        </div>
+        <div
+          data-market-decision-hierarchy-secondary-v1="true"
+          data-market-decision-hierarchy-tier="secondary"
+        >
+          {% include "partials/market_decision_funnel_visual_v1.html" %}
+        </div>
+        <div
+          class="mt-2"
+          data-market-decision-hierarchy-tertiary-v1="true"
+          data-market-decision-hierarchy-tier="tertiary"
+          data-market-decision-secondary-group-v1="true"
+          aria-label="Secondary decision modules"
+        >
+          <p class="m-0 mb-1 text-[9px] font-semibold uppercase tracking-wide text-slate-500" data-market-decision-hierarchy-tertiary-label-v1="true">
+            Secondary · F5 · Double Play · Safety · Watchlist
+          </p>
+          <div
+            class="grid grid-cols-1 lg:grid-cols-4 gap-1.5"
+            data-market-terminal-secondary-grid-v1="true"
+            data-market-remodel-secondary-grid-v2="true"
+            data-market-phase1a-decision-secondary-v1="true"
+            data-market-decision-secondary-dense-v1="true"
+            data-market-decision-hierarchy-tertiary-grid-v1="true"
+          >
+            <div class="lg:col-span-3 order-1 lg:order-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-1.5">
+              <div data-market-f5-pipeline-strip-v1="true" data-market-decision-hierarchy-tertiary-module-v1="true">
+              {% include "partials/futures_market_compact_v1.html" %}
+              </div>
+              <div data-market-double-play-visual-grid-v1="true" data-market-decision-hierarchy-tertiary-module-v1="true">
+              {% include "partials/double_play_market_compact_v1.html" %}
+              </div>
+              <div data-market-decision-hierarchy-tertiary-module-v1="true">
+              {% include "partials/market_safety_compact_v1.html" %}
+              </div>
+            </div>
+            <div class="lg:col-span-1 order-2 lg:order-1" data-market-decision-hierarchy-tertiary-module-v1="true">
+              {% include "partials/market_watchlist_compact_v1.html" %}
+            </div>
+          </div>
+        </div>
+      </div>
+    </details>
+    {% else %}
     {% if futures_first %}
     <div
       data-market-governed-top20-primary-slot-v1="true"
@@ -344,6 +401,7 @@
         </div>
       </div>
     </div>
+    {% endif %}
   </section>
 
   <section
@@ -353,6 +411,28 @@
     data-market-observability-surface-hierarchy-v1="true"
     aria-label="Observability surface"
   >
+    {% if not governed_top20.snapshot_available %}
+    <details
+      class="pt-reductive-deferred-modules"
+      data-market-reductive-deferred-observability-v1="true"
+    >
+      <summary>Observability (sekundär)</summary>
+      <div class="pt-reductive-deferred-modules-body">
+        <div
+          data-market-observability-hierarchy-primary-v1="true"
+          data-market-observability-hierarchy-tier="primary"
+        >
+          {% include "partials/market_economic_observability_visual_v1.html" %}
+        </div>
+        <div
+          data-market-observability-hierarchy-secondary-v1="true"
+          data-market-observability-hierarchy-tier="secondary"
+        >
+          {% include "partials/market_ai_linear_diagnostics_visual_v1.html" %}
+        </div>
+      </div>
+    </details>
+    {% else %}
     <div
       data-market-observability-hierarchy-primary-v1="true"
       data-market-observability-hierarchy-tier="primary"
@@ -365,6 +445,7 @@
     >
       {% include "partials/market_ai_linear_diagnostics_visual_v1.html" %}
     </div>
+    {% endif %}
   </section>
 
   <section

--- a/templates/peak_trade_dashboard/partials/market_primary_close_chart_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_primary_close_chart_v1.html
@@ -1,19 +1,20 @@
-{# Primary chart: dominant when OHLCV present; compact diagnostic when empty (product recovery). #}
+{# Secondary Market Surface: chart when data; compact empty without nested cards. #}
 {% set chart_empty = payload.bars_returned == 0 or not payload.bars or payload.bars|length == 0 %}
 <section
   data-market-chart-primary-v2="true"
   role="region"
   aria-labelledby="market-v0-landmark-close-chart-h2"
-  class="bg-slate-900/35 rounded-lg border border-slate-800/70 ring-1 ring-sky-900/10 p-2 sm:p-2.5 market-phase-1a-primary-chart{% if chart_empty %} market-chart-empty-compact{% endif %}"
+  class="market-phase-1a-primary-chart pt-reductive-secondary-surface{% if chart_empty %} market-chart-empty-compact{% endif %}"
   data-chart="market-v0-close-line"
   data-market-chart-primary-v1="true"
   data-market-chart-visual-primary-v1="true"
   data-market-chart-above-fold-v1="true"
   data-market-workspace-chart-v1="true"
-  data-market-chart-height-v1="{% if chart_empty %}140{% else %}450{% endif %}"
+  data-market-chart-height-v1="{% if chart_empty %}180{% else %}450{% endif %}"
   data-market-phase-1a-chart-above-fold-v1="true"
   data-market-foundation-primary-chart-v1="true"
-  data-market-foundation-chart-min-height-px-v1="{% if chart_empty %}140{% else %}450{% endif %}"
+  data-market-foundation-chart-min-height-px-v1="{% if chart_empty %}180{% else %}450{% endif %}"
+  data-market-reductive-secondary-surface-v1="true"
   {% if chart_empty %}data-market-chart-empty-compact-v1="true"{% endif %}
   {% if selected_instrument_workspace is defined and selected_instrument_workspace.workspace_visible %}
   data-market-workspace-ohlcv-status="{{ selected_instrument_workspace.ohlcv_status|e }}"
@@ -22,6 +23,27 @@
   {% if selected_instrument_workspace.ohlcv_status == 'stale' %}data-market-workspace-ohlcv-stale-v1="true"{% endif %}
   {% endif %}
 >
+  {% if chart_empty %}
+  <div
+    class="pt-reductive-chart-empty"
+    data-market-v0-in-chart-ohlc-svg-empty="true"
+    data-market-chart-empty-compact-v1="true"
+    data-market-empty-state="true"
+    data-market-chart-status="empty"
+    id="market-v0-chart-status"
+    role="status"
+  >
+    <div class="flex flex-wrap items-baseline justify-between gap-2">
+      <h2 id="market-v0-landmark-close-chart-h2" class="m-0 text-sm font-semibold text-slate-100 tracking-tight">Marktchart</h2>
+      <span class="text-[10px] uppercase tracking-wide text-slate-500">Read-only</span>
+    </div>
+    <p class="m-0 mt-2 text-sm text-slate-300">Chart nicht verfügbar</p>
+    <p class="m-0 mt-1 text-xs text-slate-500">Keine OHLCV-Bars. Keine synthetischen Kerzen.</p>
+  </div>
+  <div class="sr-only" data-market-chart-legend-v1="true" data-market-foundation-chart-meta-v1="true" aria-hidden="true">
+    Bars {{ payload.bars_returned }} · Timeframe {{ primary_values.timeframe|e }}
+  </div>
+  {% else %}
   <div class="flex flex-wrap items-end justify-between gap-1.5 mb-1">
     <h2 id="market-v0-landmark-close-chart-h2" class="text-sm font-semibold text-slate-100 m-0 tracking-tight">Marktchart</h2>
     <span class="text-[9px] font-semibold uppercase tracking-wide text-slate-500">Read-only · SSR</span>
@@ -40,29 +62,8 @@
     <span><span class="text-slate-600">Frische</span> {{ primary_values.generated_at_utc|e }}</span>
   </div>
 
-  {% if payload.bars_returned == 0 or (selected_instrument_workspace is defined and selected_instrument_workspace.ohlcv_status in ('malformed', 'stale', 'missing')) %}
-  <div
-    id="market-v0-chart-status"
-    role="status"
-    class="text-[11px] text-slate-200 mb-1.5 min-h-[1rem] font-medium border-l-4 border-l-amber-500/60 px-2 py-1 bg-slate-950/55 rounded-md"
-    data-market-chart-status="{% if payload.bars_returned == 0 %}empty{% elif selected_instrument_workspace is defined and selected_instrument_workspace.ohlcv_status == 'malformed' %}malformed{% elif selected_instrument_workspace is defined and selected_instrument_workspace.ohlcv_status == 'stale' %}stale{% elif selected_instrument_workspace is defined and selected_instrument_workspace.ohlcv_status == 'missing' %}missing{% else %}ready{% endif %}"
-    {% if payload.bars_returned == 0 %}data-market-empty-state="true"{% endif %}
-  >
-    {% if payload.bars_returned == 0 %}
-    Keine OHLCV-Bars für diese Abfrage. Keine synthetischen Kerzen.
-    {% elif selected_instrument_workspace is defined and selected_instrument_workspace.ohlcv_status == 'malformed' %}
-    OHLCV fehlerhaft — keine synthetischen Kerzen.
-    {% elif selected_instrument_workspace is defined and selected_instrument_workspace.ohlcv_status == 'stale' %}
-    OHLCV veraltet — Chart read-only fail-closed.
-    {% else %}
-    OHLCV nicht verfügbar — Chart read-only fail-closed.
-    {% endif %}
-  </div>
-  {% else %}
   <div id="market-v0-chart-status" role="status" class="sr-only" data-market-chart-status="ready">Chart bereit — read-only OHLCV-Anzeige.</div>
-  {% endif %}
 
-  {% if payload.bars and payload.bars|length > 0 %}
   {% set chart_bars_ic = payload.bars %}
   {% set n_ic = chart_bars_ic|length %}
   {% set mm_ic = namespace(minv=0.0, maxv=0.0, first=true) %}
@@ -113,28 +114,17 @@
   {% else %}
     {% set time_indices = [0, (n_ic - 1) // 4, (n_ic - 1) // 2, (3 * (n_ic - 1)) // 4, n_ic - 1] %}
   {% endif %}
-  {% endif %}
 
   <div
-    class="relative flex flex-col w-full max-w-full rounded-lg border border-slate-800/70 bg-gradient-to-b from-slate-950/45 to-slate-950/80 shadow-inner shadow-black/25"
+    class="relative flex flex-col w-full max-w-full bg-slate-950/40"
     data-market-v0-close-chart-integrated-frame="true"
     data-market-v0-in-chart-ohlc-svg-v1="true"
     data-market-chart-operator-readable-v1="true"
     data-market-chart-responsive-v1="true"
     data-market-foundation-chart-frame-v1="true"
-    {% if chart_empty %}data-market-chart-empty-compact-v1="true"{% endif %}
     aria-label="OHLC chart (SSR, read-only)"
   >
-    <div class="relative flex-1 min-h-0 w-full bg-slate-950/40">
-      {% if chart_empty %}
-      <div
-        class="flex h-full min-h-[7rem] max-h-[9rem] items-center justify-center px-4 py-3 text-center text-[11px] text-slate-500"
-        data-market-v0-in-chart-ohlc-svg-empty="true"
-        data-market-chart-empty-compact-v1="true"
-      >
-        <p class="m-0 max-w-md leading-snug">Keine eingebetteten OHLCV-Zeilen — kompakter leerer Chart (SSR). Keine synthetischen Kerzen.</p>
-      </div>
-      {% else %}
+    <div class="relative flex-1 min-h-0 w-full">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 {{ vb_w_ic }} {{ vb_h_ic }}"
@@ -217,29 +207,28 @@
           {% endfor %}
         </g>
       </svg>
-      {% endif %}
     </div>
-    {% if payload.bars and payload.bars|length > 0 %}
     <div
-      class="shrink-0 border-t border-slate-800/50 bg-slate-950/40 px-2.5 py-1 flex flex-wrap gap-x-4 text-[10px] text-slate-500"
+      class="shrink-0 border-t border-slate-800/50 px-2.5 py-1 flex flex-wrap gap-x-4 text-[10px] text-slate-500"
       data-market-workspace-volume-strip-v1="true"
       aria-label="Volume summary from canonical OHLCV bars"
     >
       <span data-market-workspace-volume-value-v1="true">Last vol: {% if selected_instrument_workspace is defined and selected_instrument_workspace.volume_status == 'available' %}{{ selected_instrument_workspace.volume_display|e }}{% else %}unavailable{% endif %}</span>
       <span data-market-chart-volume-series-v1="true">{{ n_ic }} volume bar(s)</span>
     </div>
-    {% endif %}
   </div>
 
-  <details class="mt-2 rounded-lg border border-slate-800/70 bg-slate-950/50 px-3 py-2 text-xs text-slate-400" data-market-diagnostics-secondary-v1="true" data-market-v11-chart-diagnostics="true">
-    <summary class="cursor-pointer font-semibold text-slate-300">Chart-Diagnostik (sekundär)</summary>
+  <details class="mt-2 text-xs text-slate-400" data-market-diagnostics-secondary-v1="true" data-market-v11-chart-diagnostics="true">
+    <summary class="cursor-pointer font-semibold text-slate-400">Chart-Diagnostik (sekundär)</summary>
     <div class="mt-2" data-market-v11-diagnostics-inner="true">
       <dl class="m-0 grid grid-cols-1 sm:grid-cols-3 gap-2 font-mono text-[11px]">
         <div><dt class="text-slate-500 m-0" data-market-v11-chart-library-status="true">Chart.js status</dt><dd id="market-v11-chartjs-state" class="m-0 text-sky-300/95">SSR only</dd></div>
         <div><dt class="text-slate-500 m-0" data-market-v11-payload-bars="true">Embedded bars</dt><dd id="market-v11-embedded-bar-count" class="m-0 text-slate-200">{{ payload.bars_returned }}</dd></div>
-        <div><dt class="text-slate-500 m-0">Render</dt><dd class="m-0">{% if payload.bars_returned == 0 %}empty{% else %}ready{% endif %}</dd></div>
+        <div><dt class="text-slate-500 m-0">Render</dt><dd class="m-0">ready</dd></div>
       </dl>
-      <div id="market-v11-render-fallback" data-market-v11-render-fallback="true" class="hidden" role="alert"></div>
+      <p class="m-0 mt-2 text-[10px] text-slate-500" data-market-v11-diagnostics-visual-rails="true">SSR only — verified in browser · Dominant panel · keine Order-UI · No backend/API/provider change</p>
+      <div id="market-v11-render-fallback" data-market-v11-render-fallback="true" data-market-v11-fallback-mode="none" class="hidden" role="alert"></div>
     </div>
   </details>
+  {% endif %}
 </section>

--- a/templates/peak_trade_dashboard/partials/market_primary_operator_hero_v1.html
+++ b/templates/peak_trade_dashboard/partials/market_primary_operator_hero_v1.html
@@ -1,7 +1,7 @@
-<!-- Selected instrument workspace — visual foundation: hero + dominant chart above fold -->
+{# Reductive composition: one Primary Operator Surface before chart; no nested cards. #}
 <section
   id="market-selected-instrument-workspace-v1"
-  class="space-y-1.5 pt-1 market-phase-1a-hero-workspace"
+  class="space-y-2 pt-1 market-phase-1a-hero-workspace"
   role="region"
   aria-labelledby="market-v0-landmark-page-title"
   data-market-selected-instrument-workspace-v1="true"
@@ -18,6 +18,7 @@
   data-market-canonical-short-url-v1="true"
   data-market-view-only="true"
   data-market-read-only="true"
+  data-market-reductive-composition-v1="true"
   {% if selected_instrument_workspace.workspace_visible %}
   data-market-selected-instrument="{{ selected_instrument_workspace.symbol|e }}"
   data-market-workspace-ohlcv-status="{{ selected_instrument_workspace.ohlcv_status|e }}"
@@ -32,77 +33,15 @@
   {% endif %}
 >
 
-  {% if query.source == 'futures' and not governed_top20.snapshot_available %}
-  <div
-    class="rounded-md border border-slate-600/60 bg-slate-950/50 px-2.5 py-1.5 text-xs text-slate-200"
-    role="alert"
-    data-market-futures-empty-state-v1="true"
-    data-market-futures-first-fail-closed-v1="true"
-    data-market-futures-data-unavailable-v1="true"
-    data-market-product-recovery-canonical-blocker-v1="true"
-  >
-    <strong class="text-slate-100">Governed Futures-Snapshot fehlt</strong>
-    — Chart, Ranking und Funnel eingeschränkt. System bleibt read-only · keine Orders · kein Live.
-    <span class="block mt-1 text-[10px] text-slate-500">Kein Spot-OHLCV und kein synthetischer Fallback auf dem kanonischen <span class="font-mono">/market</span>-Default.</span>
-    {% if primary_values.unavailable_reason %}<span class="block mt-1 font-mono text-[10px] text-slate-400">{{ primary_values.unavailable_reason|e }}</span>{% endif %}
-  </div>
-  {% elif query.source == 'futures' and data_unavailable and governed_top20.snapshot_available %}
-  <div
-    class="rounded-md border border-slate-700/55 bg-slate-950/45 px-2.5 py-1.5 text-[11px] text-slate-300"
-    role="status"
-    data-market-futures-ohlcv-not-wired-v1="true"
-    {% if primary_values.unavailable_reason == 'futures_ohlcv_malformed' %}data-market-futures-ohlcv-malformed-v1="true"{% endif %}
-    {% if primary_values.unavailable_reason == 'futures_ohlcv_stale' %}data-market-futures-ohlcv-stale-v1="true"{% endif %}
-    {% if primary_values.unavailable_reason == 'futures_symbol_not_in_governed_universe' %}data-market-futures-selector-invalid-v1="true"{% endif %}
-  >
-    {% if primary_values.unavailable_reason == 'futures_symbol_not_in_governed_universe' %}
-    <strong class="text-rose-200/90">Ungültige Futures-Instrumentauswahl</strong> — Symbol nicht im governed Universe (fail-closed).
-    {% elif primary_values.unavailable_reason == 'futures_ohlcv_malformed' %}
-    <strong class="text-rose-200/90">Futures-OHLCV ungültig/fehlerhaft</strong> — keine synthetischen Kerzen angezeigt.
-    {% elif primary_values.unavailable_reason == 'futures_ohlcv_stale' %}
-    <strong class="text-amber-200/90">Futures-OHLCV veraltet</strong> — Chart nicht verfügbar (read-only fail-closed).
-    {% else %}
-    Futures-OHLCV auf dem Standardpfad nicht verfügbar — Governed-Ranking-Snapshot ist unten verfügbar (read-only Anzeige).
-    {% endif %}
-    {% if primary_values.unavailable_reason %}<span class="block mt-1 font-mono text-[10px] text-slate-500">{{ primary_values.unavailable_reason|e }}</span>{% endif %}
-  </div>
-  {% elif query.source == 'futures' and not data_unavailable %}
-  <span class="sr-only" data-market-futures-ohlcv-wired-v1="true" data-market-futures-chart-complete-v1="true">
-    Futures-OHLCV verbunden · read-only SSR{% if futures_ohlcv.source %} · {{ futures_ohlcv.source|e }}{% endif %}
-  </span>
-  {% endif %}
-
-  {% if query.source == 'dummy' %}
-  <div
-    class="rounded-md border border-amber-600/50 bg-amber-950/40 px-2.5 py-1.5 text-xs text-amber-100"
-    role="alert"
-    data-market-dummy-explicit-synthetic-v1="true"
-    data-market-source-kind="dummy-offline-synthetic"
-  >
-    <strong class="text-amber-200">SYNTHETISCH / OFFLINE / DUMMY</strong> — nur explizite Demo. Kanonisches <span class="font-mono">/market</span> ist futures-first (SSR, fail-closed).
-  </div>
-  {% endif %}
-
-  {% if data_unavailable and query.source == 'kraken' %}
-  <div
-    class="rounded-md border border-rose-700/50 bg-rose-950/35 px-2.5 py-1.5 text-xs text-rose-100"
-    role="alert"
-    data-market-unavailable-compact-v1="true"
-  >
-    <strong class="text-rose-200">Öffentliche Marktdaten nicht verfügbar</strong>
-    {% if primary_values.unavailable_reason %} — {{ primary_values.unavailable_reason|e }}{% endif %}.
-    Kein synthetischer Fallback. Später erneut versuchen oder Netzwerk/Provider prüfen.
-  </div>
-  {% endif %}
-
   {% set ov = operator_overview_phase_2 %}
   {% set hero_last_price_empty = ov.selected_instrument.last_price in ('unavailable', '—', '') %}
   {% set hero_futures_snapshot_missing = query.source == 'futures' and not governed_top20.snapshot_available %}
   {% set hero_empty = data_unavailable or hero_futures_snapshot_missing or hero_last_price_empty %}
-  {# Compact instrument context ABOVE chart — eye path MARKET → CHART → DECISION (LDD-01). #}
+
+  {# Single Primary Operator Surface — merges banner, empty hero, decision, safety. #}
   <section
     id="market-primary-operator-hero-v1"
-    class="border-0 bg-transparent pt-operator-overview-hero-panel"
+    class="pt-reductive-primary-surface pt-operator-overview-hero-panel"
     data-market-terminal-asset-bar-v1="true"
     data-market-primary-values-panel-v1="true"
     data-market-workspace-hero-v1="true"
@@ -112,26 +51,148 @@
     data-market-operator-overview-hero-v1="true"
     data-market-foundation-hero-panel-v1="true"
     data-market-phase1a-pre-chart-context-v1="true"
-    {% if hero_empty %}data-market-product-recovery-empty-hero-v1="true"{% endif %}
-    aria-label="Selected instrument and compact market context"
+    data-market-reductive-primary-surface-v1="true"
+    data-market-phase1a-post-chart-decision-v1="true"
+    data-market-product-recovery-decision-above-fold-v1="true"
+    data-market-phase-2-hero-layout-v1="8_4"
+    {% if hero_empty %}
+    data-market-product-recovery-empty-hero-v1="true"
+    data-market-hero-empty-state-v1="true"
+    {% endif %}
+    {% if query.source == 'futures' and not governed_top20.snapshot_available %}
+    data-market-futures-empty-state-v1="true"
+    data-market-futures-first-fail-closed-v1="true"
+    data-market-futures-data-unavailable-v1="true"
+    data-market-product-recovery-canonical-blocker-v1="true"
+    {% endif %}
+    {% if query.source == 'futures' and data_unavailable and governed_top20.snapshot_available %}
+    data-market-futures-ohlcv-not-wired-v1="true"
+    {% if primary_values.unavailable_reason == 'futures_ohlcv_malformed' %}data-market-futures-ohlcv-malformed-v1="true"{% endif %}
+    {% if primary_values.unavailable_reason == 'futures_ohlcv_stale' %}data-market-futures-ohlcv-stale-v1="true"{% endif %}
+    {% if primary_values.unavailable_reason == 'futures_symbol_not_in_governed_universe' %}data-market-futures-selector-invalid-v1="true"{% endif %}
+    {% endif %}
+    {% if query.source == 'futures' and not data_unavailable %}
+    data-market-futures-ohlcv-wired-v1="true"
+    data-market-futures-chart-complete-v1="true"
+    {% endif %}
+    {% if query.source == 'dummy' %}
+    data-market-dummy-explicit-synthetic-v1="true"
+    {% endif %}
+    {% if data_unavailable and query.source == 'kraken' %}
+    data-market-unavailable-compact-v1="true"
+    {% endif %}
+    aria-label="Primary operator status"
   >
     {% if hero_empty %}
-    <div class="pt-operator-overview-hero-primary pt-foundation-empty-hero" data-market-phase-2-hero-primary-v1="true" data-market-hero-empty-state-v1="true">
-      <p class="m-0 text-sm font-semibold text-slate-200" data-market-hero-empty-title-v1="true">
-        Instrument-Kontext eingeschränkt
+    <div class="pt-operator-overview-hero-primary pt-foundation-empty-hero" data-market-phase-2-hero-primary-v1="true">
+      <p class="m-0 pt-reductive-kicker" data-market-hero-empty-title-v1="true">Marktstatus</p>
+      <h2 class="m-0 pt-reductive-title" data-market-product-primary-status-title-v1="true">
+        Marktdaten nicht verfügbar
+      </h2>
+
+      <div class="pt-reductive-primary-rows" data-market-product-primary-status-grid-v1="true">
+        <div>
+          <p class="m-0 pt-reductive-label">Systementscheidung</p>
+          <p
+            class="m-0 pt-reductive-decision"
+            data-market-foundation-decision-state-v1="true"
+            data-market-product-system-decision-v1="true"
+            data-market-phase-1a-critical-system-state-v1="true"
+            data-market-phase-2-critical-system-state-v1="true"
+            data-market-foundation-system-decision-v1="true"
+          >BLOCKIERT</p>
+        </div>
+        <div>
+          <p class="m-0 pt-reductive-label">Grund</p>
+          <p class="m-0 pt-reductive-body" data-market-product-primary-blocker-v1="true">
+            {% if hero_futures_snapshot_missing %}
+            Der kanonische Futures-Snapshot ist nicht verfügbar.
+            {% elif primary_values.unavailable_reason == 'futures_symbol_not_in_governed_universe' %}
+            Symbol nicht im governed Universe (fail-closed).
+            {% elif primary_values.unavailable_reason == 'futures_ohlcv_malformed' %}
+            Futures-OHLCV ungültig — keine synthetischen Kerzen.
+            {% elif primary_values.unavailable_reason == 'futures_ohlcv_stale' %}
+            Futures-OHLCV veraltet — Chart nicht verfügbar.
+            {% elif data_unavailable and query.source == 'kraken' %}
+            Öffentliche Marktdaten nicht verfügbar.
+            {% else %}
+            Marktdaten für diese Ansicht nicht verfügbar.
+            {% endif %}
+          </p>
+        </div>
+        <div>
+          <p class="m-0 pt-reductive-label">Operator-Aktion</p>
+          <p class="m-0 pt-reductive-body" data-market-product-operator-action-v1="true">
+            Datenquelle prüfen oder später erneut laden.
+          </p>
+        </div>
+      </div>
+
+      <p
+        class="m-0 pt-reductive-safety"
+        data-market-product-safety-summary-v1="true"
+        data-market-foundation-system-priorities-v1="true"
+      >
+        Sicherheitsstatus · Keine Orders · Kein Live · Read-only
       </p>
-      <p class="m-0 mt-1 text-[10px] font-mono text-slate-500" data-market-hero-empty-meta-v1="true">
-        Quelle · {{ query.source|e }} · Frische · {{ primary_values.generated_at_utc|default('nicht verfügbar', true)|e }} · Timeframe · {{ ov.selected_instrument.timeframe|e }}{% if primary_values.unavailable_reason %} · {{ primary_values.unavailable_reason|e }}{% endif %}
+
+      <p class="sr-only" data-market-phase-2-regime-chip-v1="true" data-market-phase-2-regime-scope-v1="{{ ov.market_regime.scope|e }}">
+        Regime · {{ ov.market_regime.trend|e }}
       </p>
-      <p class="m-0 mt-1 text-[10px] text-slate-500" data-market-phase-2-regime-chip-v1="true" data-market-phase-2-regime-scope-v1="{{ ov.market_regime.scope|e }}">
-        Regime · <span class="font-mono text-slate-400">{{ ov.market_regime.trend|e }}</span>
+
+      <p
+        class="sr-only"
+        data-market-operator-decision-narrative-v1="true"
+        data-market-phase-1a-decision-narrative-v1="true"
+        data-market-phase-2-decision-sentence-v1="true"
+      >
+        {{ ov.decision_sentence|e }}
       </p>
+
+      <dl
+        class="m-0 sr-only"
+        data-market-phase-2-decision-state-v1="true"
+        aria-label="Current decision state"
+      >
+        <div><dt>Richtung</dt><dd>{{ ov.current_decision.direction|e }}</dd></div>
+        <div><dt>AI</dt><dd data-market-phase-2-ai-activity-v1="true">{{ ov.current_decision.ai_activity_state|e }}</dd></div>
+        <div data-market-phase-2-blocker-scope-v1="{{ ov.current_decision.blocker_scope|e }}">
+          <dt>Umfang</dt><dd>{{ ov.current_decision.blocker_scope|e }}</dd>
+        </div>
+      </dl>
+
+      <p class="m-0 mt-2 text-xs text-slate-500" data-market-hero-empty-meta-v1="true">
+        Frische · {{ primary_values.generated_at_utc|default('nicht verfügbar', true)|e }}
+        · Timeframe · {{ ov.selected_instrument.timeframe|e }}
+      </p>
+
+      <details class="pt-reductive-tech-details" data-market-product-tech-details-v1="true">
+        <summary>Technische Details</summary>
+        <p class="m-0 mt-1 font-mono text-[11px] text-slate-500">
+          {% if primary_values.unavailable_reason %}{{ primary_values.unavailable_reason|e }} · {% endif %}
+          Blocker · {{ ov.current_decision.primary_blocker|e }}
+          · Scope · {{ ov.current_decision.blocker_scope|e }}
+          · Safety · {{ ov.critical_system_state.safety_status|e }}
+          · Authority · {{ ov.critical_system_state.runtime_authority|e }}
+        </p>
+        <p class="m-0 mt-1 text-[11px] text-slate-500">
+          Kein Spot-OHLCV und kein synthetischer Fallback auf dem kanonischen <span class="font-mono">/market</span>-Default.
+          Governed Futures-Snapshot fehlt.
+        </p>
+      </details>
+
+      <span class="hidden" aria-hidden="true">{{ ov.current_decision.state|e }}</span>
+      <span class="hidden" aria-hidden="true">{{ ov.current_decision.primary_blocker|e }}</span>
+      <span class="hidden" aria-hidden="true">{{ ov.critical_system_state.orders|e }}</span>
+      <span class="hidden" aria-hidden="true">{{ ov.critical_system_state.live|e }}</span>
+      <span class="hidden" aria-hidden="true">{{ ov.critical_system_state.economic_validity|e }}</span>
+      <span class="hidden" aria-hidden="true">{{ ov.critical_system_state.risk_status|e }}</span>
     </div>
     {% else %}
     <div class="pt-operator-overview-hero-primary" data-market-phase-2-hero-primary-v1="true">
       <div class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
         <p class="pt-foundation-instrument-title" data-market-workspace-symbol-v1="true">{{ ov.selected_instrument.symbol|e }}</p>
-        <span class="text-[10px] font-mono text-slate-500" data-market-phase-2-instrument-meta-v1="true">
+        <span class="text-xs font-mono text-slate-500" data-market-phase-2-instrument-meta-v1="true">
           {{ ov.selected_instrument.exchange|e }}
           · {{ ov.selected_instrument.contract_type|e }}
           · {{ ov.selected_instrument.timeframe|e }}
@@ -155,76 +216,71 @@
         </span>
         <span data-market-foundation-momentum-v1="true">Momentum · <span class="font-mono text-slate-200">{{ ov.market_regime.momentum|e }}</span></span>
       </div>
+
+      <div class="pt-reductive-primary-rows mt-3">
+        <div>
+          <p class="m-0 pt-reductive-label">Systementscheidung</p>
+          <p
+            class="m-0 pt-reductive-decision"
+            data-market-foundation-decision-state-v1="true"
+            data-market-phase-1a-critical-system-state-v1="true"
+            data-market-phase-2-critical-system-state-v1="true"
+            data-market-foundation-system-decision-v1="true"
+          >{{ ov.current_decision.state|e }}</p>
+        </div>
+        <div>
+          <p class="m-0 pt-reductive-label">Primärer Blocker</p>
+          <p class="m-0 pt-reductive-body" data-market-product-primary-blocker-v1="true">{{ ov.current_decision.primary_blocker|e }}</p>
+        </div>
+        <div>
+          <p class="m-0 pt-reductive-label">Operator-Aktion</p>
+          <p class="m-0 pt-reductive-body" data-market-product-operator-action-v1="true">Read-only Beobachtung — keine Orders, kein Live.</p>
+        </div>
+      </div>
+      <p class="m-0 pt-reductive-safety" data-market-product-safety-summary-v1="true" data-market-foundation-system-priorities-v1="true">
+        Sicherheitsstatus · Keine Orders · Kein Live · Read-only
+      </p>
+      <p
+        class="m-0 pt-reductive-narrative"
+        data-market-operator-decision-narrative-v1="true"
+        data-market-phase-1a-decision-narrative-v1="true"
+        data-market-phase-2-decision-sentence-v1="true"
+      >
+        {{ ov.decision_sentence|e }}
+      </p>
+      <dl class="m-0 sr-only" data-market-phase-2-decision-state-v1="true" aria-label="Current decision state">
+        <div><dt>Richtung</dt><dd>{{ ov.current_decision.direction|e }}</dd></div>
+        <div><dt>AI</dt><dd data-market-phase-2-ai-activity-v1="true">{{ ov.current_decision.ai_activity_state|e }}</dd></div>
+        <div data-market-phase-2-blocker-scope-v1="{{ ov.current_decision.blocker_scope|e }}">
+          <dt>Umfang</dt><dd>{{ ov.current_decision.blocker_scope|e }}</dd>
+        </div>
+      </dl>
+      <details class="pt-reductive-tech-details" data-market-product-tech-details-v1="true">
+        <summary>Technische Details</summary>
+        <p class="m-0 mt-1 font-mono text-[11px] text-slate-500">
+          Blocker · {{ ov.current_decision.primary_blocker|e }}
+          · Scope · {{ ov.current_decision.blocker_scope|e }}
+          · Safety · {{ ov.critical_system_state.safety_status|e }}
+          · Ökonomie · {{ ov.critical_system_state.economic_validity|e }}
+          · Risiko · {{ ov.critical_system_state.risk_status|e }}
+        </p>
+      </details>
+      <span class="hidden" aria-hidden="true">{{ ov.critical_system_state.orders|e }}</span>
+      <span class="hidden" aria-hidden="true">{{ ov.critical_system_state.live|e }}</span>
     </div>
     {% endif %}
   </section>
 
   {% include "partials/market_primary_close_chart_v1.html" %}
 
-  {# Decision triage AFTER chart — must remain above-fold when chart is compact-empty. #}
-  <section
-    class="mt-2 pt-phase1a-post-chart-decision"
-    data-market-phase1a-post-chart-decision-v1="true"
-    data-market-phase-2-hero-layout-v1="8_4"
-    data-market-product-recovery-decision-above-fold-v1="true"
-    aria-label="Decision narrative and primary blocker"
-  >
-    <div class="pt-operator-overview-hero-grid">
-      <div class="min-w-0">
-        <p
-          class="pt-operator-overview-decision-sentence m-0"
-          data-market-operator-decision-narrative-v1="true"
-          data-market-phase-1a-decision-narrative-v1="true"
-          data-market-phase-2-decision-sentence-v1="true"
-        >
-          {{ ov.decision_sentence|e }}
-        </p>
-        <dl
-          class="m-0 mt-1 pt-operator-overview-status-strip flex flex-wrap text-slate-400"
-          data-market-phase-2-decision-state-v1="true"
-          aria-label="Current decision state"
-        >
-          <div><dt class="inline text-slate-600">Richtung · </dt><dd class="inline m-0 font-mono">{{ ov.current_decision.direction|e }}</dd></div>
-          <div><dt class="inline text-slate-600">AI · </dt><dd class="inline m-0 font-mono" data-market-phase-2-ai-activity-v1="true">{{ ov.current_decision.ai_activity_state|e }}</dd></div>
-          <div data-market-phase-2-blocker-scope-v1="{{ ov.current_decision.blocker_scope|e }}">
-            <dt class="inline text-slate-600">Umfang · </dt>
-            <dd class="inline m-0 font-mono">{{ ov.current_decision.blocker_scope|e }}</dd>
-          </div>
-        </dl>
-      </div>
-      <aside
-        class="pt-operator-overview-hero-system shrink-0 border-0 border-l border-slate-800/70 bg-transparent pl-3 text-[10px] text-slate-300"
-        data-market-phase-1a-critical-system-state-v1="true"
-        data-market-phase-2-critical-system-state-v1="true"
-        data-market-foundation-system-decision-v1="true"
-        aria-label="Critical system state"
-      >
-        <p class="m-0 uppercase tracking-[0.12em] text-slate-500 text-[8px]">Systementscheidung</p>
-        <p class="pt-foundation-decision-state mt-1" data-market-foundation-decision-state-v1="true">{{ ov.current_decision.state|e }}</p>
-        <p class="m-0 mt-1.5 text-[11px] text-slate-200">
-          <span class="text-slate-500">Primärer Blocker</span>
-          <span class="block font-mono text-sm text-slate-100 mt-0.5">{{ ov.current_decision.primary_blocker|e }}</span>
-        </p>
-        <dl class="m-0 mt-2 space-y-0.5 font-mono text-[10px]" data-market-foundation-system-priorities-v1="true">
-          <div class="flex justify-between gap-2"><dt class="text-slate-500">Ökonomie</dt><dd class="m-0 text-slate-200">{{ ov.critical_system_state.economic_validity|e }}</dd></div>
-          <div class="flex justify-between gap-2"><dt class="text-slate-500">Risiko</dt><dd class="m-0 text-slate-200">{{ ov.critical_system_state.risk_status|e }}</dd></div>
-          <div class="flex justify-between gap-2"><dt class="text-slate-500">Sicherheit</dt><dd class="m-0 text-slate-200">{{ ov.critical_system_state.safety_status|e }}</dd></div>
-        </dl>
-        <p class="sr-only">
-          Authority {{ ov.critical_system_state.runtime_authority|e }} · Orders {{ ov.critical_system_state.orders|e }} · Live {{ ov.critical_system_state.live|e }}
-        </p>
-        <span class="hidden" aria-hidden="true">{{ ov.critical_system_state.orders|e }}</span>
-        <span class="hidden" aria-hidden="true">{{ ov.critical_system_state.live|e }}</span>
-      </aside>
-    </div>
-  </section>
-
-{% if selected_instrument_workspace.workspace_visible %}
+  {# Ranking/F5 only when snapshot present — kept after chart so it stays out of fail-closed fold. #}
+  {% if selected_instrument_workspace.workspace_visible and governed_top20.snapshot_available %}
   <details
     class="rounded-md border border-slate-800/60 bg-slate-950/40 px-2.5 py-1.5"
     data-market-phase-1a-secondary-instrument-details-v1="true"
     data-market-workspace-ranking-f5-compact-v1="true"
     data-market-workspace-ranking-context-v1="true"
+    data-market-reductive-ranking-below-fold-v1="true"
   >
     <summary class="cursor-pointer text-[10px] font-semibold uppercase tracking-wide text-slate-500">
       Ranking / F5 / Kontrakt / Frische (sekundär)

--- a/tests/webui/test_market_dashboard_phase1a_composition_foundation_v1.py
+++ b/tests/webui/test_market_dashboard_phase1a_composition_foundation_v1.py
@@ -107,14 +107,15 @@ def test_phase1a_landmark_dom_order(client_phase1a_comp: TestClient) -> None:
 
 
 def test_phase1a_eye_path_chart_before_decision_narrative(client_phase1a_comp: TestClient) -> None:
+    """Reductive composition: primary decision precedes chart; DECISION_SURFACE stays after."""
     body = _body(client_phase1a_comp)
     chart_i = body.find('data-market-phase-1a-chart-above-fold-v1="true"')
     narrative_i = body.find('data-market-operator-decision-narrative-v1="true"')
     post_i = body.find('data-market-phase1a-post-chart-decision-v1="true"')
     decision_surface_i = body.find('data-landmark="DECISION_SURFACE"')
     assert min(chart_i, narrative_i, post_i, decision_surface_i) >= 0
-    assert chart_i < narrative_i
-    assert chart_i < post_i
+    assert narrative_i < chart_i
+    assert post_i < chart_i
     assert chart_i < decision_surface_i
 
 

--- a/tests/webui/test_market_dashboard_product_recovery_v1.py
+++ b/tests/webui/test_market_dashboard_product_recovery_v1.py
@@ -43,7 +43,8 @@ def test_empty_chart_compact_markers_in_template() -> None:
     assert "Keine OHLCV" in text
     assert "Keine synthetischen Kerzen" in text
     assert "Marktchart" in text
-    assert "Chart-Diagnostik (sekundär)" in text
+    assert "Chart-Diagnostik (sekundär)" not in text
+    assert "pt-reductive-chart-empty" in text
     assert "Market chart" not in text
     assert "Chart diagnostics (secondary)" not in text
     assert "No OHLCV bars for this query" not in text
@@ -52,7 +53,8 @@ def test_empty_chart_compact_markers_in_template() -> None:
 def test_layout_css_empty_chart_compact_override() -> None:
     css = LAYOUT_CSS.read_text(encoding="utf-8")
     assert "data-market-chart-empty-compact-v1" in css
-    assert "8.5rem" in css
+    assert "max-height: 240px" in css
+    assert "pt-reductive-primary-surface" in css
 
 
 def test_hero_empty_and_decision_above_fold_markers() -> None:
@@ -60,10 +62,13 @@ def test_hero_empty_and_decision_above_fold_markers() -> None:
     assert "data-market-product-recovery-empty-hero-v1" in text
     assert "data-market-product-recovery-decision-above-fold-v1" in text
     assert "data-market-product-recovery-canonical-blocker-v1" in text
-    assert "Governed Futures-Snapshot fehlt" in text or "Instrument-Kontext" in text
+    assert "Marktdaten nicht verfügbar" in text
+    assert "Governed Futures-Snapshot fehlt" in text
     assert "Kein Spot-OHLCV" in text
     assert "No spot OHLCV" not in text
     assert "is ranked #" not in text
+    assert "data-market-reductive-primary-surface-v1" in text
+    assert "data-market-product-operator-action-v1" in text
 
 
 def test_watchlist_german_locale() -> None:

--- a/tests/webui/test_market_dashboard_product_recovery_v1.py
+++ b/tests/webui/test_market_dashboard_product_recovery_v1.py
@@ -43,8 +43,9 @@ def test_empty_chart_compact_markers_in_template() -> None:
     assert "Keine OHLCV" in text
     assert "Keine synthetischen Kerzen" in text
     assert "Marktchart" in text
-    assert "Chart-Diagnostik (sekundär)" not in text
     assert "pt-reductive-chart-empty" in text
+    empty_branch = text.split("{% if chart_empty %}", 1)[1].split("{% else %}", 1)[0]
+    assert "Chart-Diagnostik" not in empty_branch
     assert "Market chart" not in text
     assert "Chart diagnostics (secondary)" not in text
     assert "No OHLCV bars for this query" not in text

--- a/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
+++ b/tests/webui/test_market_dashboard_readonly_structure_contract_v0.py
@@ -354,6 +354,20 @@ def test_market_dashboard_v11_chart_diagnostics_readonly_structure_contract_v0(
     html = _html(client, "/market")
     lowered = html.lower()
 
+    assert 'data-market-readonly="true"' in html
+    assert 'data-market-non-authorizing="true"' in html
+    assert "fetch(" not in html
+    assert "XMLHttpRequest" not in html
+    assert "<form" not in lowered
+    assert "place order" not in lowered
+    assert "ready for live" not in lowered
+    assert "testnet approved" not in lowered
+
+    # Reductive fail-closed empty: chart diagnostics intentionally out of above-the-fold.
+    if 'data-market-chart-empty-compact-v1="true"' in html:
+        assert "Chart diagnostics (secondary)" not in html
+        return
+
     assert 'data-market-v11-chart-diagnostics="true"' in html
     assert 'data-market-v11-diagnostics-inner="true"' in html
     assert 'data-market-v11-render-fallback="true"' in html
@@ -368,16 +382,6 @@ def test_market_dashboard_v11_chart_diagnostics_readonly_structure_contract_v0(
     assert "No backend/API/provider change" in html
     assert "Dominant panel · keine Order-UI" in html
     assert "SSR only — verified in browser" in html
-
-    assert 'data-market-readonly="true"' in html
-    assert 'data-market-non-authorizing="true"' in html
-
-    assert "fetch(" not in html
-    assert "XMLHttpRequest" not in html
-    assert "<form" not in lowered
-    assert "place order" not in lowered
-    assert "ready for live" not in lowered
-    assert "testnet approved" not in lowered
 
 
 def test_double_play_market_dashboard_v11_chart_diagnostics_readonly_structure_contract_v0(

--- a/tests/webui/test_market_dashboard_reductive_composition_v1.py
+++ b/tests/webui/test_market_dashboard_reductive_composition_v1.py
@@ -1,0 +1,88 @@
+"""Reductive Market Dashboard composition contracts (fail-closed above-the-fold)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from src.webui.app import app
+
+REPO = Path(__file__).resolve().parents[2]
+HERO = REPO / "templates/peak_trade_dashboard/partials/market_primary_operator_hero_v1.html"
+CHART = REPO / "templates/peak_trade_dashboard/partials/market_primary_close_chart_v1.html"
+LAYOUT_CSS = REPO / "static/css/peak_trade_dashboard_layout_v1.css"
+
+
+def test_reductive_markers_in_templates() -> None:
+    hero = HERO.read_text(encoding="utf-8")
+    chart = CHART.read_text(encoding="utf-8")
+    css = LAYOUT_CSS.read_text(encoding="utf-8")
+    assert "data-market-reductive-primary-surface-v1" in hero
+    assert "data-market-reductive-secondary-surface-v1" in chart
+    assert "pt-reductive-primary-surface" in css
+    assert "max-height: 240px" in css
+    assert "pt-operator-decision-card" not in hero
+    assert "pt-operator-primary-status-card" not in hero
+
+
+def test_blocker_and_action_precede_chart_in_template() -> None:
+    hero = HERO.read_text(encoding="utf-8")
+    blocker_i = hero.find("data-market-product-primary-blocker-v1")
+    action_i = hero.find("data-market-product-operator-action-v1")
+    chart_include_i = hero.find('include "partials/market_primary_close_chart_v1.html"')
+    assert min(blocker_i, action_i, chart_include_i) >= 0
+    assert blocker_i < chart_include_i
+    assert action_i < chart_include_i
+
+
+def test_tech_details_default_closed_in_template() -> None:
+    hero = HERO.read_text(encoding="utf-8")
+    m = re.search(r"<details[^>]*data-market-product-tech-details-v1=\"true\"[^>]*>", hero)
+    assert m is not None
+    assert " open" not in m.group(0)
+
+
+def test_no_nested_empty_chart_frame_in_template() -> None:
+    chart = CHART.read_text(encoding="utf-8")
+    # Empty branch must not open an inner bordered frame.
+    empty_branch = chart.split("{% if chart_empty %}", 1)[1].split("{% else %}", 1)[0]
+    assert "data-market-v0-close-chart-integrated-frame" not in empty_branch
+    assert "rounded-lg border" not in empty_branch
+    assert "Chart-Diagnostik" not in empty_branch
+
+
+def test_ranking_f5_gated_to_snapshot_available() -> None:
+    hero = HERO.read_text(encoding="utf-8")
+    assert "governed_top20.snapshot_available" in hero
+    assert "data-market-reductive-ranking-below-fold-v1" in hero
+
+
+def test_fail_closed_html_reductive_surface() -> None:
+    client = TestClient(app)
+    resp = client.get("/market?timeframe=1h")
+    assert resp.status_code == 200
+    body = resp.text
+    assert 'data-market-reductive-primary-surface-v1="true"' in body
+    assert 'data-market-reductive-secondary-surface-v1="true"' in body
+    assert "Marktdaten nicht verfügbar" in body
+    assert "BLOCKIERT" in body
+    assert "Datenquelle prüfen oder später erneut laden" in body
+    assert "Keine Orders · Kein Live · Read-only" in body
+    assert body.count("data-market-product-primary-blocker-v1") == 1
+    assert body.count("data-market-product-operator-action-v1") == 1
+    assert 'data-market-chart-empty-compact-v1="true"' in body
+    assert "data-market-workspace-ranking-f5-compact-v1" not in body
+    assert 'data-market-reductive-deferred-modules-v1="true"' in body
+    m_def = re.search(
+        r"<details[^>]*data-market-reductive-deferred-modules-v1=\"true\"[^>]*>", body
+    )
+    assert m_def is not None
+    assert " open" not in m_def.group(0)
+    m = re.search(r"<details[^>]*data-market-product-tech-details-v1=\"true\"[^>]*>", body)
+    assert m is not None
+    assert " open" not in m.group(0)
+    primary_i = body.find("data-market-reductive-primary-surface-v1")
+    chart_i = body.find("data-market-reductive-secondary-surface-v1")
+    assert 0 <= primary_i < chart_i

--- a/tests/webui/test_market_dashboard_visual_foundation_rework_v1.py
+++ b/tests/webui/test_market_dashboard_visual_foundation_rework_v1.py
@@ -102,8 +102,11 @@ def test_foundation_markers_and_anti_badge_wall(client_foundation: TestClient) -
     assert 'data-market-foundation-primary-chart-v1="true"' in body
     assert 'data-market-phase-1a-primary-status-count-v1="3"' in body
     assert 'data-market-chart-height-v1="450"' in body or (
-        'data-market-chart-height-v1="140"' in body
-        and 'data-market-chart-empty-compact-v1="true"' in body
+        'data-market-chart-empty-compact-v1="true"' in body
+        and (
+            'data-market-chart-height-v1="140"' in body
+            or 'data-market-chart-height-v1="180"' in body
+        )
     )
     assert "lg:grid-cols-8" not in body
     assert "Peak Trade / Operator Console" in body


### PR DESCRIPTION
## Summary
- Collapse fail-closed `/market` above-the-fold into compact header + one primary operator surface + one secondary empty/chart surface (no nested cards).
- Merge blocker, decision, safety and operator action into the primary surface before the chart; defer ranking/funnel/safety/observability behind closed secondary summaries.
- Add reductive composition contracts; Chrome evidence at 1512x982 in `artifacts/market_dashboard_reductive_composition_v1/`.

## Test plan
- [x] Focused webui composition/recovery/phase1a/foundation/reductive tests
- [x] Real Google Chrome headed review at 1512x982 (above-fold + full)
- [ ] Operator visual review of PR screenshots


Made with [Cursor](https://cursor.com)