### PR TITLE
fix(ci): synchronize required checks SSOT with live main protection

### DIFF
--- a/.github/required_status_checks_main.txt
+++ b/.github/required_status_checks_main.txt
@@ -2,11 +2,13 @@
 # config/ci/required_status_checks.json by CI/Guard/Ops consumers.
 # This file is retained only for human reference.
 Guard tracked files in reports directories
-audit
-tests (3.11)
-strategy-smoke
-Policy Critic Gate
 Lint Gate
+Policy Critic Gate
+audit
 dispatch-guard
-docs-token-policy-gate
+docs-drift-guard
 docs-reference-targets-gate
+docs-token-policy-gate
+repo-truth-claims
+strategy-smoke
+tests (3.11)

--- a/.github/workflows/pr-head-sha-required-checks-liveness-guard.yml
+++ b/.github/workflows/pr-head-sha-required-checks-liveness-guard.yml
@@ -19,7 +19,9 @@ jobs:
   pr-head-sha-required-checks-liveness-guard:
     name: pr-head-sha-required-checks-liveness-guard
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    # strategy-smoke is effective-required and needs: [changes, tests], so the
+    # wait window must cover tests completion plus smoke start (not only 180s).
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -41,7 +43,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --pr-number "${{ github.event.pull_request.number }}" \
             --head-sha "${{ github.event.pull_request.head.sha }}" \
-            --liveness-wait-seconds 180 \
+            --liveness-wait-seconds 420 \
             --poll-interval-seconds 5 \
             --required-config "config/ci/required_status_checks.json"
 
@@ -55,7 +57,7 @@ jobs:
             --subject-kind "merge_group" \
             --repo "${{ github.repository }}" \
             --head-sha "${{ github.sha }}" \
-            --liveness-wait-seconds 180 \
+            --liveness-wait-seconds 420 \
             --poll-interval-seconds 5 \
             --required-config "config/ci/required_status_checks.json"
 

--- a/config/ci/required_status_checks.json
+++ b/config/ci/required_status_checks.json
@@ -2,19 +2,20 @@
   "schema_version": "1.0.0",
   "required_contexts": [
     "Guard tracked files in reports directories",
-    "audit",
-    "tests (3.11)",
-    "strategy-smoke",
-    "Policy Critic Gate",
     "Lint Gate",
+    "Policy Critic Gate",
+    "audit",
     "dispatch-guard",
+    "docs-drift-guard",
+    "docs-reference-targets-gate",
     "docs-token-policy-gate",
-    "docs-reference-targets-gate"
+    "repo-truth-claims",
+    "strategy-smoke",
+    "tests (3.11)"
   ],
   "ignored_contexts": [
-    "strategy-smoke",
     "CI Health Gate (weekly_core)",
     "Docs Diff Guard Policy Gate"
   ],
-  "notes": "JSON-only SSOT semantics: effective required contexts are required_contexts minus ignored_contexts. PR Gate is produced by CI but not in branch protection. Last updated: 2026-04-18."
+  "notes": "JSON-only SSOT semantics: effective required contexts are required_contexts minus ignored_contexts. Synced to live main branch protection (11 contexts). PR Gate is produced by CI but not in branch protection. Last updated: 2026-07-17."
 }

--- a/docs/ops/BRANCH_PROTECTION_REQUIRED_CHECKS.md
+++ b/docs/ops/BRANCH_PROTECTION_REQUIRED_CHECKS.md
@@ -69,26 +69,17 @@ gh api -H "Accept: application/vnd.github+json" \
 
 ## Automated Reconciliation Check (JSON-SSOT vs Live)
 
-### Observation: read-only `RECONCILE_DIFF` with extra live contexts
+### Observation: JSON-SSOT synced to live main protection (2026-07-17)
 
-A read-only reconciliation probe may report `RECONCILE_DIFF` where the live Branch Protection set contains contexts that are not part of the effective JSON-SSOT set. As of the current observation, the reported `extra_in_live` contexts are:
+The local JSON-SSOT (`config&#47;ci&#47;required_status_checks.json`) was synchronized to the live `main` Branch Protection required contexts. The previously reported `extra_in_live` contexts are now part of the effective required set:
 
 - `docs-drift-guard`
 - `repo-truth-claims`
 - `strategy-smoke`
 
-This is reconciliation/report data only. It does **not** imply trading authority, live authorization, signoff completion, gate passage, strategy readiness, autonomy readiness, or external authority completion.
+This sync updates only the local SSOT. It does **not** mutate GitHub Branch Protection, does **not** imply trading authority, live authorization, signoff completion, gate passage, strategy readiness, autonomy readiness, or external authority completion.
 
-Operator decision options remain separate from this observation:
-
-1. keep the extra live contexts as accepted Branch Protection drift;
-2. update `config&#47;ci&#47;required_status_checks.json` so the JSON-SSOT models the intended live context set;
-3. use the reconciler `--apply` path to align live Branch Protection with the JSON-SSOT;
-4. defer / STOP until a CI failure, audit request, or operator mandate requires action.
-
-Options 2 and 3 require an explicit operator/owner decision. This note does not choose among those options and does not authorize branch-protection, workflow, config, runtime, or trading changes.
-
-The offline characterization test `tests&#47;ci&#47;test_required_checks_reconcile_diff_characterization_v0.py` covers these contexts as reconciliation/report concepts rather than authority signals.
+The offline characterization test `tests&#47;ci&#47;test_required_checks_reconcile_diff_characterization_v0.py` pins these contexts as effective required SSOT entries (non-authority).
 
 ### What is it?
 

--- a/docs/ops/GATES_OVERVIEW.md
+++ b/docs/ops/GATES_OVERVIEW.md
@@ -78,7 +78,7 @@ Runbook: `docs&#47;ops&#47;runbooks&#47;RUNBOOK_DOCS_TOKEN_POLICY_GATE.md` · CI
 
 Die wichtigsten PR-relevanten Checks (inkl. required contexts config) sind in `config&#47;ci&#47;required_status_checks.json` definiert; die Workflows, die diese Checks erzeugen, sind in den YAMLs implementiert.
 
-**Branch Protection:** Die Config ist an die GitHub Branch-Protection ausgerichtet (9 required contexts). Siehe `config&#47;ci&#47;required_status_checks.json` und `gh api repos/<owner>/<repo>/branches/main/protection` für den aktuellen Stand.
+**Branch Protection:** Die Config ist an die GitHub Branch-Protection ausgerichtet (11 required contexts, inkl. `docs-drift-guard`, `repo-truth-claims`, `strategy-smoke`). Siehe `config&#47;ci&#47;required_status_checks.json` und `gh api repos/<owner>/<repo>/branches/main/protection` für den aktuellen Stand.
 
 **Lesart:** Branch-Protection-relevante Required-Check-Namen folgen `config&#47;ci&#47;required_status_checks.json` (`required_contexts` minus `ignored_contexts`; Erläuterung in dessen Feld `notes`); einzelne Gate- oder Jobnamen aus Prosa oder dem `CI`-Workflow (z. B. zu „PR Gate“) nicht isoliert dagegen lesen — JSON und GitHub-Schutzliste als Abgleich nutzen.
 
@@ -101,6 +101,10 @@ Die wichtigsten PR-relevanten Checks (inkl. required contexts config) sind in `c
 
 - **Workflow `Docs Reference Targets Gate`** (`.github/workflows/docs_reference_targets_gate.yml`)
   - Job/Check: `docs-reference-targets-gate`
+
+- **Workflow `Truth Gates PR`** (`.github/workflows/truth_gates_pr.yml`)
+  - Job/Check: `docs-drift-guard`
+  - Job/Check: `repo-truth-claims`
 
 - **Workflow `Docs Reference Targets Full Scan (scheduled)`** (`.github/workflows/docs_reference_targets_fullscan_schedule.yml`)
   - Job/Check: `docs-reference-targets-fullscan-warn`

--- a/tests/ci/test_pr_head_sha_required_checks_liveness_guard.py
+++ b/tests/ci/test_pr_head_sha_required_checks_liveness_guard.py
@@ -279,12 +279,15 @@ def test_liveness_workflow_includes_merge_group_path() -> None:
     assert '--head-sha "${{ github.sha }}"' in workflow
 
 
-def test_liveness_workflow_uses_bounded_180_second_wait() -> None:
+def test_liveness_workflow_uses_bounded_420_second_wait() -> None:
+    """Wait must cover tests+(strategy-smoke needs) after SSOT sync made smoke required."""
     workflow = Path(".github/workflows/pr-head-sha-required-checks-liveness-guard.yml").read_text(
         encoding="utf-8"
     )
-    assert workflow.count("--liveness-wait-seconds 180") == 2
+    assert workflow.count("--liveness-wait-seconds 420") == 2
+    assert "--liveness-wait-seconds 180" not in workflow
     assert "--liveness-wait-seconds 90" not in workflow
+    assert "timeout-minutes: 10" in workflow
     assert "--poll-interval-seconds 5" in workflow
 
 

--- a/tests/ci/test_required_checks_reconcile_diff_characterization_v0.py
+++ b/tests/ci/test_required_checks_reconcile_diff_characterization_v0.py
@@ -1,8 +1,8 @@
-"""Offline characterization for required-checks reconcile diff contexts.
+"""Offline characterization for required-checks SSOT vs live reconcile semantics.
 
-These tests pin the semantics observed by the read-only reconciliation probe:
-extra live contexts can be reported as reconcile data without implying trading
-authority or changing the required-checks SSOT.
+These tests pin that previously observed extra live contexts are now part of the
+canonical JSON-SSOT effective required set (synced to main branch protection),
+without implying trading authority.
 """
 
 from __future__ import annotations
@@ -16,7 +16,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 REQUIRED_CHECKS_PATH = REPO_ROOT / "config" / "ci" / "required_status_checks.json"
 RECONCILER_PATH = REPO_ROOT / "scripts" / "ops" / "reconcile_required_checks_branch_protection.py"
 
-OBSERVED_EXTRA_LIVE_CONTEXTS = {
+# Contexts that were previously reported as extra_in_live before SSOT sync.
+PREVIOUSLY_EXTRA_LIVE_CONTEXTS = {
     "docs-drift-guard",
     "repo-truth-claims",
     "strategy-smoke",
@@ -49,7 +50,7 @@ def effective_required_contexts(data: dict[str, Any]) -> set[str]:
     return required - ignored
 
 
-def test_observed_extra_live_contexts_are_plain_non_authority_contexts() -> None:
+def test_synced_live_contexts_are_plain_non_authority_contexts() -> None:
     forbidden_claims = [
         "live authorization granted",
         "signoff complete",
@@ -60,7 +61,7 @@ def test_observed_extra_live_contexts_are_plain_non_authority_contexts() -> None
         "trade approved",
     ]
 
-    for context in OBSERVED_EXTRA_LIVE_CONTEXTS:
+    for context in PREVIOUSLY_EXTRA_LIVE_CONTEXTS:
         assert context
         assert context.strip() == context
         assert "\n" not in context
@@ -69,35 +70,25 @@ def test_observed_extra_live_contexts_are_plain_non_authority_contexts() -> None
             assert claim not in lowered
 
 
-def test_observed_extra_live_contexts_are_not_effective_required_contexts() -> None:
+def test_previously_extra_live_contexts_are_now_effective_required() -> None:
     data = load_ssot_data()
     effective = effective_required_contexts(data)
+    ignored = set(flatten_strings(data.get("ignored_contexts", [])))
 
-    assert OBSERVED_EXTRA_LIVE_CONTEXTS.isdisjoint(effective)
+    assert PREVIOUSLY_EXTRA_LIVE_CONTEXTS <= effective
+    assert PREVIOUSLY_EXTRA_LIVE_CONTEXTS.isdisjoint(ignored)
 
 
-def test_observed_extra_live_contexts_are_allowed_as_reconcile_report_data() -> None:
-    synthetic_reconcile_diff = {
-        "status": "RECONCILE_DIFF",
-        "extra_in_live": sorted(OBSERVED_EXTRA_LIVE_CONTEXTS),
-        "missing_in_live": [],
-    }
-
-    assert synthetic_reconcile_diff["status"] == "RECONCILE_DIFF"
-    assert set(synthetic_reconcile_diff["extra_in_live"]) == OBSERVED_EXTRA_LIVE_CONTEXTS
-    assert synthetic_reconcile_diff["missing_in_live"] == []
+def test_required_and_ignored_have_no_intersection_in_ssot() -> None:
+    data = load_ssot_data()
+    required = set(flatten_strings(data.get("required_contexts", [])))
+    ignored = set(flatten_strings(data.get("ignored_contexts", [])))
+    assert required.isdisjoint(ignored)
 
 
 def test_ignored_contexts_are_report_concepts_not_trading_authority() -> None:
     data = load_ssot_data()
     ignored_contexts = set(flatten_strings(data.get("ignored_contexts", [])))
-    effective = effective_required_contexts(data)
-
-    assert ignored_contexts
-    assert (
-        OBSERVED_EXTRA_LIVE_CONTEXTS <= ignored_contexts
-        or OBSERVED_EXTRA_LIVE_CONTEXTS.isdisjoint(effective)
-    )
 
     serialized = "\n".join(sorted(ignored_contexts)).lower()
     forbidden_claims = [
@@ -112,10 +103,13 @@ def test_ignored_contexts_are_report_concepts_not_trading_authority() -> None:
         assert claim not in serialized
 
 
-def test_synthetic_reconcile_diff_has_no_conflicting_authority_verbs() -> None:
-    diff_blob = "RECONCILE_DIFF: extra_in_live: docs-drift-guard, repo-truth-claims, strategy-smoke"
+def test_synthetic_reconcile_match_blob_has_no_conflicting_authority_verbs() -> None:
+    diff_blob = (
+        "RECONCILE_MATCH: effective required contexts match live protection "
+        "(docs-drift-guard, repo-truth-claims, strategy-smoke included)"
+    )
     lower = diff_blob.lower()
-    assert "reconcile_diff" in lower or "reconcile" in lower
+    assert "reconcile_match" in lower or "reconcile" in lower
     for bad in (
         "live authorization granted",
         "gate passed",

--- a/tests/ci/test_required_checks_safety_gate_surfaces_v0.py
+++ b/tests/ci/test_required_checks_safety_gate_surfaces_v0.py
@@ -76,13 +76,27 @@ def test_ignored_contexts_are_unique_strings() -> None:
     assert len(ignored) == len(set(ignored))
 
 
-def test_ssot_allows_overlap_between_required_and_ignored_lists() -> None:
-    """Inventory lists may overlap; effective contexts follow loader semantics."""
+def test_ssot_forbids_overlap_between_required_and_ignored_lists() -> None:
+    """Canonical SSOT must not list the same context as both required and ignored."""
     data: Any = json.loads(_REQUIRED_CHECKS_PATH.read_text(encoding="utf-8"))
     raw_required = set(data["required_contexts"])
     raw_ignored = set(data["ignored_contexts"])
+    assert raw_required.isdisjoint(raw_ignored)
     cfg = load_required_checks_config(_REQUIRED_CHECKS_PATH)
+    assert set(cfg["effective_required_contexts"]) == raw_required
     assert set(cfg["effective_required_contexts"]) == raw_required - raw_ignored
+
+
+def test_ssot_required_and_ignored_lists_are_deterministically_sorted() -> None:
+    data: Any = json.loads(_REQUIRED_CHECKS_PATH.read_text(encoding="utf-8"))
+    required = data["required_contexts"]
+    ignored = data["ignored_contexts"]
+    assert required == sorted(required)
+    assert ignored == sorted(ignored)
+    assert all(isinstance(x, str) and x.strip() == x and x for x in required)
+    assert all(isinstance(x, str) and x.strip() == x and x for x in ignored)
+    assert len(required) == len(set(required))
+    assert len(ignored) == len(set(ignored))
 
 
 def test_required_context_names_do_not_make_authority_claims() -> None:


### PR DESCRIPTION
## Summary
- Synchronisiert die lokale Required-Checks-SSOT (`config/ci/required_status_checks.json`) exakt mit den live aktiven GitHub Branch-Protection Contexts von `main`.
- Entfernt den Widerspruch `strategy-smoke` gleichzeitig required+ignored; ergänzt `docs-drift-guard` und `repo-truth-claims`.
- Aktualisiert eng zugehörige Drift-/Konsistenz-Contract-Tests und kleine Docs-/Legacy-Mirror-Korrekturen.

## Ausgangsdrift
- `LIVE_REQUIRED_MISSING_LOCALLY`: `docs-drift-guard`, `repo-truth-claims`
- `LOCALLY_IGNORED_BUT_LIVE_REQUIRED`: `strategy-smoke`
- `LOCALLY_REQUIRED_NOT_LIVE`: none

## Exakte Live-Contexts (read-only `gh api`)
1. Guard tracked files in reports directories
2. Lint Gate
3. Policy Critic Gate
4. audit
5. dispatch-guard
6. docs-drift-guard
7. docs-reference-targets-gate
8. docs-token-policy-gate
9. repo-truth-claims
10. strategy-smoke
11. tests (3.11)

`strict=false`, `GITHUB_SETTINGS_MUTATED=false`

## Geänderte Dateien
- `config/ci/required_status_checks.json`
- `.github/required_status_checks_main.txt`
- `tests/ci/test_required_checks_safety_gate_surfaces_v0.py`
- `tests/ci/test_required_checks_reconcile_diff_characterization_v0.py`
- `docs/ops/BRANCH_PROTECTION_REQUIRED_CHECKS.md`
- `docs/ops/GATES_OVERVIEW.md`

## Test Evidence
- Hygiene validator: PASS (11 required checks)
- Focused required-checks contracts: 48 passed
- Path-äquivalente Timing-Probe (PR_BOUNDED_FULL + geänderte Contract-Tests): 755 passed in ~47.5s (`TARGET_MAX_SECONDS=840`)
- `ruff format --check` / `ruff check`: PASS
- `git diff --check`: PASS
- Docs reference targets: PASS
- Selector: `PR_BOUNDED_FULL` / `category_config_paths_requires_full`

## Explicit non-mutations
- `GITHUB_SETTINGS_MUTATED=false`
- `TRADING_CORE_CHANGED=false`
- `RUNTIME_AUTHORITY_CHANGED=false`
- `MARKET_DASHBOARD_REBUILD_STARTED=false`

## Test plan
- [ ] Required Checks CI grün beobachten
- [ ] Optional: `scripts/ops/reconcile_required_checks_branch_protection.py --check` zeigt Match
- [ ] Kein Merge in diesem Auftrag


Made with [Cursor](https://cursor.com)