### PR TITLE
fix(tombstone): normalize market path documentation

### DIFF
--- a/docs/webui/MARKET_DASHBOARD_REMOVED.md
+++ b/docs/webui/MARKET_DASHBOARD_REMOVED.md
@@ -2,7 +2,7 @@
 
 The Peak Trade Market Dashboard product was intentionally and completely removed.
 
-- `GET &#47;market` is intentionally absent (normal application not-found behavior).
+- GET /market is intentionally absent (normal application not-found behavior).
 - No Market Dashboard UI, reset shell, placeholder, redirect, quarantine, or alternate route remains.
 - No rebuild or replacement Market Dashboard is authorized by this deletion.
 - Independent domain producers (trading, risk, execution, economic, diagnostics, market-data) remain domain-owned and are not a UI product.

--- a/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
+++ b/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
@@ -696,7 +696,8 @@ def test_market_dashboard_product_tombstone_present_deleted_surfaces_absent() ->
     tombstone = MARKET_DASHBOARD_TOMBSTONE.read_text(encoding="utf-8")
     assert "Market Dashboard" in tombstone
     assert "removed" in tombstone.lower()
-    assert "GET /market" in tombstone or "GET &#47;market" in tombstone
+    assert "GET /market" in tombstone
+    assert "&#47;market" not in tombstone
 
 
 def test_market_dashboard_f5_non_authority_taxonomy_cross_ref_aligned() -> None:

--- a/tests/webui/test_market_dashboard_tombstone_v1.py
+++ b/tests/webui/test_market_dashboard_tombstone_v1.py
@@ -102,6 +102,8 @@ def test_tombstone_doc_present() -> None:
     text = TOMBSTONE.read_text(encoding="utf-8")
     assert "intentionally" in text.lower()
     assert "/market" in text
+    assert "&#47;market" not in text
+    assert "&amp;#47;market" not in text
     assert "not authorized" in text.lower() or "no rebuild" in text.lower()
 
 

--- a/tests/webui/test_market_dashboard_tombstone_v1.py
+++ b/tests/webui/test_market_dashboard_tombstone_v1.py
@@ -101,9 +101,8 @@ def test_tombstone_doc_present() -> None:
     assert TOMBSTONE.is_file()
     text = TOMBSTONE.read_text(encoding="utf-8")
     assert "intentionally" in text.lower()
-    assert "/market" in text
+    assert "GET /market" in text
     assert "&#47;market" not in text
-    assert "&amp;#47;market" not in text
     assert "not authorized" in text.lower() or "no rebuild" in text.lower()
 
 


### PR DESCRIPTION
## Summary
- Tombstone `docs/webui/MARKET_DASHBOARD_REMOVED.md` used HTML entity `&#47;market`, so `test_tombstone_doc_present` failed (`"/market" not in text`).
- Replaced with cleartext `GET /market` only in the tombstone doc; tightened related assertions to reject entity encoding.

## Scope
- Minimal docs + assertion fix only.
- No Market Dashboard rebuild, no `/market` route registration, no product-code restore.
- No Trading-Core / MV2 / Safety / Risk / Reconciliation / Runtime Authority changes.
- No GitHub Settings / Required Checks / Workflow mutations.

## Proof
- `/market` HTTP status remains **404** (no redirect, no reset shell, no product-surface markers).
- `MARKET_ROUTE_REGISTERED=false`; `src/webui/market_dashboard_product_surface_v1` absent.
- Tombstone no longer contains `&#47;market` or `&amp;#47;market`.

## Tests
- `pytest tests/webui/test_market_dashboard_tombstone_v1.py`
- `pytest tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py`
- Docs token policy + docs reference targets on changed markdown: PASS
- Ruff format/check on changed Python: PASS

## Gates
- `LIVE_AUTHORIZED=false`
- `ORDERS=false`


Made with [Cursor](https://cursor.com)