### PR TITLE
feat(gov): ratify trend_following ENTRY as entry_side=LONG

### DIFF
--- a/config/governance/obl_b05_trend_following_entry_side_ratification_v1.json
+++ b/config/governance/obl_b05_trend_following_entry_side_ratification_v1.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "obl_b05_trend_following_entry_side_ratification.v1",
+  "slice_id": "OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1",
+  "base_sha": "589099fed2445920531066cd89549e1c4391301e",
+  "parent_decision": "OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1",
+  "parent_carrier_contract": "OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1",
+  "encoding_owner": "src/backtest/strategy_signal_suitability_agreement_adapter_v1.py::_ENTRY_EXIT_EVENT_OWNERS",
+  "side_emission_owner": "src/backtest/strategy_signal_suitability_agreement_adapter_v1.py::_resolve_entry_side_carrier_v1",
+  "producer_id": "trend_following",
+  "productive_producer_path": "src/strategies/trend_following.py",
+  "TREND_FOLLOWING_SIDE_RATIFIED": true,
+  "PRODUCTIVE_TREND_FOLLOWING_SIDE_EMISSION_CHANGED": true,
+  "OTHER_PRODUCER_SIDE_EMISSION_CHANGED": false,
+  "BOLLINGER_SIDE_ACTIVATED": false,
+  "MACD_SIDE_ACTIVATED": false,
+  "LIVE_AUTHORIZED": false,
+  "ORDERS_ENABLED": false,
+  "short_entry_condition_present": false,
+  "short_side_emitted": false,
+  "exit_never_mapped_to_short": true,
+  "generic_cycle_sign_not_side_authority_for_other_producers": true,
+  "productive_contract_proof": {
+    "meaning_plus_one": "LONG_ENTRY",
+    "meaning_minus_one": "EXIT_EVENT",
+    "meaning_zero": "NONE_OR_FLAT",
+    "long_entry_condition": "rising edge ADX>threshold and +DI>-DI (optional MA filter)",
+    "short_entry_condition": null,
+    "exit_condition": "rising edge ADX<exit_threshold or -DI>+DI",
+    "authority_surfaces": [
+      "src/strategies/trend_following.py::TrendFollowingStrategy.generate_signals docstring (1=long, -1=exit, 0=neutral)",
+      "src/strategies/trend_following.py module docstring Long-Entry / Exit",
+      "config/governance/obl_b05_entry_exit_producer_side_authority_decision_v1.json producers[trend_following]"
+    ]
+  },
+  "emission_rules": [
+    {
+      "when": "executed_strategy_id==trend_following AND encoding==ENTRY_EXIT_EVENT_V1 AND event_kind==ENTRY AND cycle_signal_value==1",
+      "entry_side": "LONG"
+    },
+    {
+      "when": "executed_strategy_id==trend_following AND event_kind==EXIT",
+      "entry_side": "NONE",
+      "note": "EXIT is not SHORT; downtrend exit must not be read as short entry"
+    },
+    {
+      "when": "executed_strategy_id==trend_following AND cycle_signal_value==0",
+      "entry_side": "NONE"
+    },
+    {
+      "when": "SHORT_ENTRY (absent in productive contract)",
+      "entry_side": "SHORT",
+      "active": false,
+      "reason": "short_entry_condition_present=false"
+    },
+    {
+      "when": "any other ENTRY_EXIT producer (bollinger_bands, macd, momentum_1h, mean_reversion, my_strategy, ecm_cycle)",
+      "entry_side": "NONE"
+    }
+  ],
+  "forbidden_derivations": [
+    "ENTRY_NEVER_IMPLIES_LONG_FOR_UNRATIFIED_PRODUCERS",
+    "CYCLE_SIGNAL_PLUS_ONE_IS_NOT_SIDE_AUTHORITY_OUTSIDE_TREND_FOLLOWING_RATIFICATION",
+    "EXIT_IS_NOT_OPPOSITE_ENTRY_SIDE",
+    "SUPPORTED_SIDES_IS_NOT_SIGNAL_AUTHORITY",
+    "SUITABILITY_ENTRY_AGREE_LONG_IS_NOT_PRODUCER_AUTHORITY",
+    "NO_NAME_OR_CLASS_HEURISTIC_FOR_OTHER_PRODUCERS"
+  ]
+}

--- a/docs/governance/OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md
+++ b/docs/governance/OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md
@@ -66,7 +66,7 @@ SEMANTIC_PRODUCER_DECISION_STILL_REQUIRED: true
 | `bollinger_bands` | `ENTRY_EXIT_EVENT_V1` | no (`NONE`) | `None` | flat `price_path`; DA block |
 | `macd` | `ENTRY_EXIT_EVENT_V1` | no (`NONE`) | `None` | flat `price_path`; DA block |
 | `momentum_1h` | `ENTRY_EXIT_EVENT_V1` | no (`NONE`) | `None` | flat `price_path`; DA block |
-| `trend_following` | `ENTRY_EXIT_EVENT_V1` | no (`NONE`) | `None` | flat `price_path`; DA block |
+| `trend_following` | `ENTRY_EXIT_EVENT_V1` | yes on ENTRY (`LONG`); EXIT&#47;FLAT `NONE` | `+1` on ENTRY else `None` | see `OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1` |
 | `mean_reversion` | `ENTRY_EXIT_EVENT_V1` | no (`NONE`) | `None` | flat `price_path`; DA block |
 | `my_strategy` | `ENTRY_EXIT_EVENT_V1` | no (`NONE`) | `None` | flat `price_path`; DA block |
 | `ecm_cycle` | `ENTRY_EXIT_EVENT_V1` | no (`NONE`) | `None` | flat `price_path`; DA block |

--- a/docs/governance/OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1.md
+++ b/docs/governance/OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1.md
@@ -1,0 +1,79 @@
+# OBL_B05 Trend-Following Entry-Side Ratification v1
+
+---
+docs_token: DOCS_TOKEN_OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1
+STATUS: TREND_FOLLOWING_SIDE_RATIFIED
+scope: producer-scoped entry_side emission for trend_following only
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+SCHEDULER_RUNTIME_ALLOWED: false
+TREND_FOLLOWING_SIDE_RATIFIED: true
+PRODUCTIVE_TREND_FOLLOWING_SIDE_EMISSION_CHANGED: true
+OTHER_PRODUCER_SIDE_EMISSION_CHANGED: false
+BOLLINGER_SIDE_ACTIVATED: false
+MACD_SIDE_ACTIVATED: false
+---
+
+> Ratifies the **existing** productive `trend_following` LONG-entry contract onto
+> the optional `entry_side` carrier. Does **not** invent SHORT entries, does
+> **not** activate Bollinger&#47;MACD&#47;other producers, and does **not** authorize
+> runtime, orders, capital, or live.
+
+## A. Verdict
+
+| Feld | Wert |
+|---|---|
+| `SLICE_ID` | `OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1` |
+| `BASE_SHA` | `589099fed2445920531066cd89549e1c4391301e` |
+| `TREND_FOLLOWING_SIDE_RATIFIED` | `true` |
+| `PRODUCTIVE_TREND_FOLLOWING_SIDE_EMISSION_CHANGED` | `true` |
+| `OTHER_PRODUCER_SIDE_EMISSION_CHANGED` | `false` |
+| `BOLLINGER_SIDE_ACTIVATED` | `false` |
+| `MACD_SIDE_ACTIVATED` | `false` |
+| `LIVE_AUTHORIZED` | `false` |
+| `ORDERS_ENABLED` | `false` |
+| `SSOT_JSON` | `config&#47;governance&#47;obl_b05_trend_following_entry_side_ratification_v1.json` |
+
+## B. Productive contract proof
+
+Owner: `src&#47;strategies&#47;trend_following.py`
+
+| Raw output | Productive meaning | `entry_side` |
+|---|---|---|
+| `+1` | LONG entry (ADX &gt; threshold and +DI &gt; -DI; optional MA filter) | `LONG` |
+| `-1` | EXIT (ADX &lt; exit_threshold or -DI &gt; +DI) | `NONE` |
+| `0` | no change &#47; flat | `NONE` |
+
+- `short_entry_condition_present=false` — no productive SHORT-ENTRY path.
+- EXIT&#47;downtrend must **not** be read as SHORT.
+- Parent audit class was `RATIFIABLE_PRODUCER_SEMANTICS` with candidate LONG.
+
+## C. Emission owner (reuse)
+
+`src&#47;backtest&#47;strategy_signal_suitability_agreement_adapter_v1.py`
+→ `_resolve_entry_side_carrier_v1`
+
+Fail-closed mapping:
+
+1. Only `executed_strategy_id == trend_following`
+2. Only `ENTRY_EXIT_EVENT_V1` + `event_kind == ENTRY` + `cycle_signal_value == 1` → `LONG`
+3. All other cases (EXIT&#47;FLAT&#47;other producers) → `NONE`
+4. No heuristic name&#47;sign&#47;class derivation for Bollinger, MACD, or others
+
+## D. Non-goals
+
+- No strategy parameter or signal-formula change
+- No composition &#47; risk &#47; sizing &#47; execution policy change
+- No runtime &#47; testnet &#47; scheduler &#47; capital &#47; live activation
+- No Bollinger or MACD side activation
+
+## E. Owners
+
+| Surface | Owner |
+|---|---|
+| Ratification SSOT JSON | `config&#47;governance&#47;obl_b05_trend_following_entry_side_ratification_v1.json` |
+| Governance narrative | this document |
+| Side emission | adapter `_resolve_entry_side_carrier_v1` |
+| Static &#47; focused tests | `tests&#47;backtest&#47;test_trend_following_entry_side_ratification_v1.py` |
+| Parent authority decision | `docs&#47;governance&#47;OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md` |
+| Parent carrier contract | `docs&#47;governance&#47;OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md` |

--- a/docs/product/evidence/obl_b05_trend_following_entry_side_ratification_v1_20260717T221702Z/AUDIT.md
+++ b/docs/product/evidence/obl_b05_trend_following_entry_side_ratification_v1_20260717T221702Z/AUDIT.md
@@ -1,0 +1,37 @@
+# OBL_B05 Trend-Following Entry-Side Ratification v1 — Audit
+
+## Contract proof
+
+| Raw | Meaning | entry_side |
+|---|---|---|
+| +1 | LONG ENTRY (ADX strong, +DI &gt; -DI) | LONG |
+| -1 | EXIT (not SHORT) | NONE |
+| 0 | FLAT &#47; no change | NONE |
+
+`short_entry_condition_present=false` — no productive SHORT-ENTRY.
+
+## Adapter emission probe (synthetic ENTRY&#47;FLAT&#47;EXIT)
+
+| producer | entry_side counts | directional |
+|---|---|---|
+| trend_following | LONG:1 NONE:2 | +1 on ENTRY else None |
+| bollinger_bands | NONE:3 | None |
+| macd | NONE:3 | None |
+| all other ENTRY_EXIT | NONE:3 | None |
+
+## Bollinger panel&#47;eval diagnostic (unchanged)
+
+Eval instrument before == after (adapter swap compare on same HEAD tree):
+
+- entry_bar_count: 1 → 1
+- entry_side (Bollinger): NONE → NONE
+- first_failed_stage: directional_agreement → directional_agreement
+- taxonomy: BLOCKED_DIRECTIONAL_AGREEMENT → BLOCKED_DIRECTIONAL_AGREEMENT
+- suitability: bull=pass;bear=pass (unchanged)
+- composition: observe (unchanged)
+- final_decision: observe (unchanged)
+- ENTER&#47;HOLD&#47;EXIT: 0 → 0
+- price_path: flat mark→mark (unchanged)
+
+Panel baseline from prior durable diagnostic remains 185 ENTRY bars on Bollinger;
+this slice does not activate Bollinger side emission.

--- a/docs/product/evidence/obl_b05_trend_following_entry_side_ratification_v1_20260717T221702Z/README.md
+++ b/docs/product/evidence/obl_b05_trend_following_entry_side_ratification_v1_20260717T221702Z/README.md
@@ -1,0 +1,17 @@
+# OBL_B05 Trend-Following Entry-Side Ratification v1 — Evidence
+
+Pointer package (producer-scoped side emission).
+
+- slice_id: `OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1`
+- base_sha: `589099fed2445920531066cd89549e1c4391301e`
+- governance_ref: `docs&#47;governance&#47;OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1.md`
+- ssot_json: `config&#47;governance&#47;obl_b05_trend_following_entry_side_ratification_v1.json`
+- TREND_FOLLOWING_SIDE_RATIFIED: `true`
+- PRODUCTIVE_TREND_FOLLOWING_SIDE_EMISSION_CHANGED: `true`
+- OTHER_PRODUCER_SIDE_EMISSION_CHANGED: `false`
+- BOLLINGER_SIDE_ACTIVATED: `false`
+- MACD_SIDE_ACTIVATED: `false`
+- LIVE_AUTHORIZED: `false`
+- ORDERS_ENABLED: `false`
+
+See `AUDIT.md` and `before_after.json`.

--- a/docs/product/evidence/obl_b05_trend_following_entry_side_ratification_v1_20260717T221702Z/TIMING_PROOF.md
+++ b/docs/product/evidence/obl_b05_trend_following_entry_side_ratification_v1_20260717T221702Z/TIMING_PROOF.md
@@ -1,0 +1,35 @@
+# Timing proof — OBL_B05 Trend-Following Entry-Side Ratification
+
+- SELECTOR_MODE: `PR_BOUNDED_FULL`
+- SELECTOR_REASON: `category_central_src_requires_full`
+- TIMING_WALLCLOCK_SECONDS: `38`
+- TIMING_TARGET_MAX_SECONDS: `840`
+- TIMING_HARD_STOP_SECONDS: `900`
+- TIMING_SAFETY_MARGIN_SECONDS: `180`
+- TIMING_EXIT: `0`
+- TEST_COUNT: `772`
+- TIMING_PROOF_STATUS: `PASS`
+
+Command:
+
+```text
+uv run python -m pytest -q --tb=line \
+  tests/backtest/test_trend_following_entry_side_ratification_v1.py \
+  tests/backtest/test_entry_exit_optional_side_carrier_contract_v1.py \
+  tests/backtest/test_entry_exit_producer_side_authority_decision_v1.py \
+  tests/backtest/test_mv2_composition_directional_asymmetry_wiring_repair_v1.py \
+  tests/backtest/test_strategy_signal_suitability_agreement_adapter_v1.py \
+  tests/ci/test_ci_diff_aware_test_selection_v1.py \
+  tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py \
+  tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py \
+  tests/ci/test_pr_head_sha_required_checks_liveness_guard.py \
+  tests/ci/test_required_checks_config.py \
+  tests/ci/test_required_checks_hygiene.py \
+  tests/ci/test_workflows_no_pull_request_target_contract_v0.py \
+  tests/test_data_contracts.py \
+  tests/test_error_taxonomy.py \
+  tests/test_resilience.py \
+  tests/test_stability_smoke.py
+```
+
+Raw log: `timing_probe.log`

--- a/docs/product/evidence/obl_b05_trend_following_entry_side_ratification_v1_20260717T221702Z/before_after.json
+++ b/docs/product/evidence/obl_b05_trend_following_entry_side_ratification_v1_20260717T221702Z/before_after.json
@@ -1,0 +1,75 @@
+{
+  "BOLLINGER_SIDE_ACTIVATED": false,
+  "LIVE_AUTHORIZED": false,
+  "MACD_SIDE_ACTIVATED": false,
+  "ORDERS_ENABLED": false,
+  "OTHER_PRODUCER_SIDE_EMISSION_CHANGED": false,
+  "PRODUCTIVE_TREND_FOLLOWING_SIDE_EMISSION_CHANGED": true,
+  "TREND_FOLLOWING_SIDE_RATIFIED": true,
+  "adapter_emission_probe": {
+    "bollinger_bands": {
+      "directional": {
+        "None": 3
+      },
+      "entry_side": {
+        "NONE": 3
+      }
+    },
+    "macd": {
+      "directional": {
+        "None": 3
+      },
+      "entry_side": {
+        "NONE": 3
+      }
+    },
+    "trend_following": {
+      "directional": {
+        "1": 1,
+        "None": 2
+      },
+      "entry_side": {
+        "LONG": 1,
+        "NONE": 2
+      }
+    }
+  },
+  "base_sha": "589099fed2445920531066cd89549e1c4391301e",
+  "bollinger_eval_diagnostic": {
+    "after": {
+      "ENTER_HOLD_EXIT": 0,
+      "composition_outcome": "observe",
+      "entry_bar_count": 1,
+      "entry_side": "NONE",
+      "final_decision_outcome": "observe",
+      "first_failed_stage": "directional_agreement",
+      "price_path": [
+        0.2505,
+        0.2505
+      ],
+      "suitability_outcome": "bull=pass;bear=pass",
+      "taxonomy_outcome": "BLOCKED_DIRECTIONAL_AGREEMENT"
+    },
+    "before": {
+      "ENTER_HOLD_EXIT": 0,
+      "composition_outcome": "observe",
+      "entry_bar_count": 1,
+      "entry_side": "NONE",
+      "final_decision_outcome": "observe",
+      "first_failed_stage": "directional_agreement",
+      "price_path": [
+        0.2505,
+        0.2505
+      ],
+      "suitability_outcome": "bull=pass;bear=pass",
+      "taxonomy_outcome": "BLOCKED_DIRECTIONAL_AGREEMENT"
+    },
+    "unchanged": true
+  },
+  "panel_baseline_reference": {
+    "note": "Bollinger panel; side emission remains NONE in this slice",
+    "panel_entry_bar_count": 185,
+    "source": "docs/product/evidence/mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1_20260717T201114Z"
+  },
+  "slice_id": "OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1"
+}

--- a/src/backtest/strategy_signal_suitability_agreement_adapter_v1.py
+++ b/src/backtest/strategy_signal_suitability_agreement_adapter_v1.py
@@ -70,6 +70,11 @@ _UNKNOWN_OR_STUB_OWNERS = frozenset(
     }
 )
 
+# Explicit producer-scoped side ratification (OBL_B05).
+# Only trend_following is ratified: productive +1 ENTRY = LONG.
+# No heuristic name/sign/class derivation for other ENTRY_EXIT owners.
+_TREND_FOLLOWING_ENTRY_SIDE_RATIFIED_OWNER = "trend_following"
+
 
 def resolve_strategy_signal_encoding_class_v1(
     executed_strategy_id: str,
@@ -151,6 +156,32 @@ def _intrinsic_side_agreement_and_aux(
     raise StrategySuitabilityAgreementErrorV1("encoding_class_unknown")
 
 
+def _resolve_entry_side_carrier_v1(
+    *,
+    executed_strategy_id: str,
+    encoding_class: StrategySignalEncodingClassV1,
+    event_kind: Optional[StrategyAgreementEventKindV1],
+    cycle_signal_value: int,
+) -> StrategyEntrySideCarrierV1:
+    """Resolve optional ENTRY_EXIT ``entry_side`` (fail-closed, producer-explicit).
+
+    Productive ``trend_following`` contract (``src/strategies/trend_following.py``):
+    - ``+1`` / ENTRY = LONG entry (ADX strong and +DI > -DI; optional MA filter)
+    - ``-1`` / EXIT = exit event (ADX weak or -DI > +DI) — never SHORT
+    - ``0`` / NONE = no change / flat
+
+    No SHORT-entry condition exists in the productive producer. Other ENTRY_EXIT
+    owners remain ``NONE`` until a separate ratification GO.
+    """
+    if encoding_class is not StrategySignalEncodingClassV1.ENTRY_EXIT_EVENT_V1:
+        return StrategyEntrySideCarrierV1.NONE
+    if executed_strategy_id != _TREND_FOLLOWING_ENTRY_SIDE_RATIFIED_OWNER:
+        return StrategyEntrySideCarrierV1.NONE
+    if event_kind is StrategyAgreementEventKindV1.ENTRY and cycle_signal_value == 1:
+        return StrategyEntrySideCarrierV1.LONG
+    return StrategyEntrySideCarrierV1.NONE
+
+
 def normalize_strategy_signal_to_suitability_agreement_material_v1(
     binding: StrategySignalBindingResultV1,
     *,
@@ -208,9 +239,14 @@ def normalize_strategy_signal_to_suitability_agreement_material_v1(
     side_agreement, filter_pass, event_kind = _intrinsic_side_agreement_and_aux(
         encoding_class, cycle_signal_value
     )
-    # Explicit side carrier only; no producer currently emits LONG/SHORT.
-    # cycle_signal_value=+1 under ENTRY_EXIT remains an ENTRY event, not LONG.
-    entry_side = StrategyEntrySideCarrierV1.NONE
+    # Explicit producer-scoped carrier only (trend_following LONG on ENTRY).
+    # Generic cycle_signal_value=+1 is not side authority for other producers.
+    entry_side = _resolve_entry_side_carrier_v1(
+        executed_strategy_id=executed_id,
+        encoding_class=encoding_class,
+        event_kind=event_kind,
+        cycle_signal_value=cycle_signal_value,
+    )
     material_digest = compute_strategy_suitability_agreement_material_digest_v1(
         encoding_class=encoding_class,
         configured_strategy_id=configured_id,

--- a/tests/backtest/test_entry_exit_optional_side_carrier_contract_v1.py
+++ b/tests/backtest/test_entry_exit_optional_side_carrier_contract_v1.py
@@ -294,6 +294,25 @@ def test_adapter_legacy_producers_default_entry_side_none() -> None:
     assert resolve_agreement_bound_directional_cycle_v1(material) is None
 
 
+def test_adapter_trend_following_entry_emits_explicit_long_side() -> None:
+    """Carrier contract: only ratified trend_following ENTRY may emit LONG."""
+    material = normalize_strategy_signal_to_suitability_agreement_material_v1(
+        _binding(
+            [1, 0, -1],
+            provenance=_provenance(
+                configured_strategy_id="trend_following",
+                executed_strategy_id="trend_following",
+            ),
+        ),
+        instrument_id="inst-eth-usdt-perp",
+        trading_epoch=0,
+    )
+    assert material.encoding_class is StrategySignalEncodingClassV1.ENTRY_EXIT_EVENT_V1
+    assert material.event_kind is StrategyAgreementEventKindV1.ENTRY
+    assert material.entry_side is StrategyEntrySideCarrierV1.LONG
+    assert resolve_agreement_bound_directional_cycle_v1(material) == 1
+
+
 def test_bollinger_panel_baseline_predicate_unchanged_without_carrier() -> None:
     """Contract-universal baseline: 185× FF_DA_FLAT_PATH while Bollinger emits NONE."""
     assert _PANEL_ENTRY_BASELINE == 185

--- a/tests/backtest/test_entry_exit_producer_side_authority_decision_v1.py
+++ b/tests/backtest/test_entry_exit_producer_side_authority_decision_v1.py
@@ -133,11 +133,12 @@ def test_no_canonical_existing_side_authority_in_inventory() -> None:
     assert all(row["class"] != "CANONICAL_EXISTING_SIDE_AUTHORITY" for row in data["producers"])
 
 
-def test_adapter_source_does_not_emit_long_or_short_entry_side() -> None:
+def test_adapter_source_does_not_emit_short_and_scopes_long_to_ratified_owner() -> None:
+    """Parent audit: no SHORT emission; LONG only via explicit trend_following ratification."""
     source = ADAPTER_SRC.read_text(encoding="utf-8")
-    assert "entry_side = StrategyEntrySideCarrierV1.NONE" in source
-    assert "StrategyEntrySideCarrierV1.LONG" not in source
     assert "StrategyEntrySideCarrierV1.SHORT" not in source
+    assert "_resolve_entry_side_carrier_v1" in source
+    assert "_TREND_FOLLOWING_ENTRY_SIDE_RATIFIED_OWNER" in source
 
 
 def test_productive_adapter_still_defaults_bollinger_entry_side_none() -> None:

--- a/tests/backtest/test_trend_following_entry_side_ratification_v1.py
+++ b/tests/backtest/test_trend_following_entry_side_ratification_v1.py
@@ -1,0 +1,186 @@
+"""OBL_B05 trend_following entry_side ratification v1 — focused contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import src.backtest.strategy_signal_suitability_agreement_adapter_v1 as adapter_mod
+from src.backtest.mv2_research_wiring_v1 import (
+    resolve_agreement_bound_directional_cycle_v1,
+)
+from src.backtest.strategy_signal_suitability_agreement_adapter_v1 import (
+    normalize_strategy_signal_to_suitability_agreement_material_v1,
+)
+from trading.master_v2.strategy_suitability_agreement_material_v1 import (
+    StrategyAgreementEventKindV1,
+    StrategyEntrySideCarrierV1,
+    StrategySignalEncodingClassV1,
+    deserialize_strategy_suitability_agreement_material_v1,
+    serialize_strategy_suitability_agreement_material_v1,
+)
+from tests.backtest.test_strategy_signal_suitability_agreement_adapter_v1 import (
+    _binding,
+    _provenance,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SSOT_PATH = (
+    REPO_ROOT / "config" / "governance" / "obl_b05_trend_following_entry_side_ratification_v1.json"
+)
+GOV_DOC = (
+    REPO_ROOT / "docs" / "governance" / "OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1.md"
+)
+ADAPTER_SRC = REPO_ROOT / "src" / "backtest" / "strategy_signal_suitability_agreement_adapter_v1.py"
+TREND_SRC = REPO_ROOT / "src" / "strategies" / "trend_following.py"
+
+_ENTRY_EXIT_OTHERS = frozenset(
+    {
+        "bollinger_bands",
+        "ecm_cycle",
+        "macd",
+        "mean_reversion",
+        "momentum_1h",
+        "my_strategy",
+    }
+)
+
+
+def _ssot() -> dict:
+    return json.loads(SSOT_PATH.read_text(encoding="utf-8"))
+
+
+def _normalize(strategy_id: str, values: list[int], epoch: int):
+    return normalize_strategy_signal_to_suitability_agreement_material_v1(
+        _binding(
+            values,
+            provenance=_provenance(
+                configured_strategy_id=strategy_id,
+                executed_strategy_id=strategy_id,
+            ),
+        ),
+        instrument_id="inst-eth-usdt-perp",
+        trading_epoch=epoch,
+    )
+
+
+def test_ssot_and_governance_markers() -> None:
+    assert SSOT_PATH.is_file()
+    assert GOV_DOC.is_file()
+    data = _ssot()
+    body = GOV_DOC.read_text(encoding="utf-8")
+    assert data["slice_id"] == "OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1"
+    assert data["TREND_FOLLOWING_SIDE_RATIFIED"] is True
+    assert data["PRODUCTIVE_TREND_FOLLOWING_SIDE_EMISSION_CHANGED"] is True
+    assert data["OTHER_PRODUCER_SIDE_EMISSION_CHANGED"] is False
+    assert data["BOLLINGER_SIDE_ACTIVATED"] is False
+    assert data["MACD_SIDE_ACTIVATED"] is False
+    assert data["LIVE_AUTHORIZED"] is False
+    assert data["ORDERS_ENABLED"] is False
+    assert data["short_entry_condition_present"] is False
+    assert data["short_side_emitted"] is False
+    assert data["exit_never_mapped_to_short"] is True
+    assert data["producer_id"] == "trend_following"
+    assert "DOCS_TOKEN_OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1" in body
+    assert "TREND_FOLLOWING_SIDE_RATIFIED: true" in body
+
+
+def test_productive_trend_following_contract_long_entry_exit_not_short() -> None:
+    source = TREND_SRC.read_text(encoding="utf-8")
+    assert "- 1 (long):" in source
+    assert "- -1 (exit):" in source
+    assert "Long-Entry:" in source
+    assert "signals[entry_trigger] = 1" in source
+    assert "signals[exit_trigger] = -1" in source
+    # Productive generator never assigns a short-entry polarity.
+    assert "signals[entry_trigger] = -1" not in source
+    assert "short_entry" not in source.lower()
+
+
+def test_trend_following_long_entry_emits_long() -> None:
+    material = _normalize("trend_following", [1, 0, -1], 0)
+    assert material.encoding_class is StrategySignalEncodingClassV1.ENTRY_EXIT_EVENT_V1
+    assert material.event_kind is StrategyAgreementEventKindV1.ENTRY
+    assert material.cycle_signal_value == 1
+    assert material.entry_side is StrategyEntrySideCarrierV1.LONG
+    assert resolve_agreement_bound_directional_cycle_v1(material) == 1
+
+
+def test_trend_following_exit_and_flat_emit_none_not_short() -> None:
+    exit_mat = _normalize("trend_following", [1, 0, -1], 2)
+    flat_mat = _normalize("trend_following", [1, 0, -1], 1)
+    assert exit_mat.event_kind is StrategyAgreementEventKindV1.EXIT
+    assert exit_mat.cycle_signal_value == -1
+    assert exit_mat.entry_side is StrategyEntrySideCarrierV1.NONE
+    assert resolve_agreement_bound_directional_cycle_v1(exit_mat) is None
+    assert flat_mat.event_kind is StrategyAgreementEventKindV1.NONE
+    assert flat_mat.cycle_signal_value == 0
+    assert flat_mat.entry_side is StrategyEntrySideCarrierV1.NONE
+    assert resolve_agreement_bound_directional_cycle_v1(flat_mat) is None
+
+
+def test_bollinger_and_macd_remain_none() -> None:
+    for strategy_id in ("bollinger_bands", "macd"):
+        material = _normalize(strategy_id, [1, 0, -1], 0)
+        assert material.event_kind is StrategyAgreementEventKindV1.ENTRY
+        assert material.entry_side is StrategyEntrySideCarrierV1.NONE
+        assert resolve_agreement_bound_directional_cycle_v1(material) is None
+
+
+def test_all_other_entry_exit_producers_remain_none() -> None:
+    for strategy_id in sorted(_ENTRY_EXIT_OTHERS):
+        for epoch, expected_event in (
+            (0, StrategyAgreementEventKindV1.ENTRY),
+            (1, StrategyAgreementEventKindV1.NONE),
+            (2, StrategyAgreementEventKindV1.EXIT),
+        ):
+            material = _normalize(strategy_id, [1, 0, -1], epoch)
+            assert material.event_kind is expected_event
+            assert material.entry_side is StrategyEntrySideCarrierV1.NONE
+            assert resolve_agreement_bound_directional_cycle_v1(material) is None
+
+
+def test_missing_serialized_entry_side_remains_backward_compatible_none() -> None:
+    material = _normalize("trend_following", [1, 0, -1], 0)
+    assert material.entry_side is StrategyEntrySideCarrierV1.LONG
+    payload = serialize_strategy_suitability_agreement_material_v1(material)
+    del payload["entry_side"]
+    restored = deserialize_strategy_suitability_agreement_material_v1(payload)
+    assert restored.entry_side is StrategyEntrySideCarrierV1.NONE
+    assert resolve_agreement_bound_directional_cycle_v1(restored) is None
+
+
+def test_directional_cycle_only_via_explicit_long_short_carrier() -> None:
+    long_mat = _normalize("trend_following", [1], 0)
+    none_mat = _normalize("bollinger_bands", [1], 0)
+    assert resolve_agreement_bound_directional_cycle_v1(long_mat) == 1
+    assert resolve_agreement_bound_directional_cycle_v1(none_mat) is None
+
+
+def test_legacy_adapter_path_outside_trend_following_unchanged() -> None:
+    """Positional families remain entry_side=NONE; resolve still uses cycle."""
+    rsi = _normalize("rsi_reversion", [1, 0, -1], 0)
+    assert rsi.encoding_class is StrategySignalEncodingClassV1.POSITIONAL_LS_STATE_V1
+    assert rsi.entry_side is StrategyEntrySideCarrierV1.NONE
+    assert resolve_agreement_bound_directional_cycle_v1(rsi) == 1
+    rsi_short = _normalize("rsi_reversion", [1, 0, -1], 2)
+    assert rsi_short.entry_side is StrategyEntrySideCarrierV1.NONE
+    assert resolve_agreement_bound_directional_cycle_v1(rsi_short) == -1
+
+
+def test_adapter_source_scopes_long_emission_to_trend_following_only() -> None:
+    source = ADAPTER_SRC.read_text(encoding="utf-8")
+    assert "_TREND_FOLLOWING_ENTRY_SIDE_RATIFIED_OWNER" in source
+    assert "_resolve_entry_side_carrier_v1" in source
+    assert "executed_strategy_id != _TREND_FOLLOWING_ENTRY_SIDE_RATIFIED_OWNER" in source
+    assert "StrategyEntrySideCarrierV1.LONG" in source
+    # SHORT must not be emitted by the productive resolver path.
+    assert "StrategyEntrySideCarrierV1.SHORT" not in source
+    assert adapter_mod._TREND_FOLLOWING_ENTRY_SIDE_RATIFIED_OWNER == "trend_following"
+
+
+def test_closed_owner_set_unchanged_seven_entry_exit_owners() -> None:
+    assert frozenset(adapter_mod._ENTRY_EXIT_EVENT_OWNERS) == (
+        _ENTRY_EXIT_OTHERS | {"trend_following"}
+    )
+    assert len(adapter_mod._ENTRY_EXIT_EVENT_OWNERS) == 7


### PR DESCRIPTION
## Summary
- Ratifies productive `trend_following` LONG-ENTRY (`+1`) onto optional `entry_side=LONG` in the suitability-agreement adapter.
- EXIT (`-1`) / FLAT (`0`) remain `entry_side=NONE`; no SHORT entry exists in the productive producer contract.
- Bollinger, MACD, and all other ENTRY_EXIT producers stay `NONE`; `LIVE_AUTHORIZED=false`, `ORDERS_ENABLED=false`.

## Test plan
- [x] Focused ratification + carrier + authority + adapter tests
- [x] Timing proof: 772 passed in 38s (`PR_BOUNDED_FULL` + domain owners)
- [x] Docs token / docs reference targets / ruff
- [x] Read-only Bollinger eval diagnostic before/after unchanged
- [ ] Required CI checks green

## Markers
- `TREND_FOLLOWING_SIDE_RATIFIED=true`
- `OTHER_PRODUCER_SIDE_EMISSION_CHANGED=false`
- `BOLLINGER_SIDE_ACTIVATED=false`
- `MACD_SIDE_ACTIVATED=false`
- `LIVE_AUTHORIZED=false`
- `ORDERS_ENABLED=false`


Made with [Cursor](https://cursor.com)