### PR TITLE
docs(gov): Bollinger side remains ambiguous + quantitative baseline

### DIFF
--- a/config/governance/obl_b05_bollinger_long_semantic_decision_v1.json
+++ b/config/governance/obl_b05_bollinger_long_semantic_decision_v1.json
@@ -1,0 +1,230 @@
+{
+  "BOLLINGER_DECISION": "CONTRACT_REMAINS_AMBIGUOUS",
+  "BOLLINGER_LONG_SEMANTIC_DECISION_COMPLETE": true,
+  "BOLLINGER_QUANTITATIVE_BASELINE_COMPLETE": true,
+  "BOLLINGER_SHORT_EMISSION": false,
+  "BOLLINGER_SIDE_ACTIVATED": false,
+  "LIVE_AUTHORIZED": false,
+  "ORDERS_ENABLED": false,
+  "OTHER_PRODUCER_SIDE_EMISSION_CHANGED": false,
+  "PRODUCTIVE_SEMANTICS_CHANGED": false,
+  "archive_dir": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/full_canonical_system_economic_evidence_generation_v1_offline_execution_v0_20260716T015033Z",
+  "base_sha": "8ed59484959504e7d477dc9e8d4adedd2ec022b0",
+  "binding": "config/research/bollinger_bands_v2_full_canonical_system_economic_binding_v1.json",
+  "bollinger_eval_entry_mv2": {
+    "BLOCKED_COMPOSITION": 0,
+    "BLOCKED_DIRECTIONAL_AGREEMENT": 1,
+    "BLOCKED_SUITABILITY": 0,
+    "BLOCKED_WARMUP": 0,
+    "ENTER_LONG": 0,
+    "ENTER_SHORT": 0,
+    "EXIT_OR_DEMOTION": 0,
+    "HOLD": 0,
+    "UNOBSERVABLE_FAIL_CLOSED": 0,
+    "agreement_direction_counts": {
+      "unresolved": 1
+    },
+    "composition_outcome_counts": {
+      "observe": 1
+    },
+    "dominant_first_failed_stage": "directional_agreement",
+    "entry_bar_count": 1,
+    "entry_side_counts": {
+      "NONE": 1
+    },
+    "first_failed_stage_counts": {
+      "directional_agreement": 1
+    },
+    "taxonomy_outcome_counts": {
+      "BLOCKED_DIRECTIONAL_AGREEMENT": 1
+    }
+  },
+  "bollinger_event_baseline_eval": {
+    "entry_plus_one": 1,
+    "exit_minus_one": 168,
+    "neutral_zero": 2784,
+    "total_bars": 2953
+  },
+  "bollinger_event_baseline_panel": {
+    "entry_plus_one": 185,
+    "exit_minus_one": 20754,
+    "neutral_zero": 327515,
+    "total_bars": 348454
+  },
+  "bollinger_panel_entry_mv2": {
+    "BLOCKED_COMPOSITION": 0,
+    "BLOCKED_DIRECTIONAL_AGREEMENT": 185,
+    "BLOCKED_SUITABILITY": 0,
+    "BLOCKED_WARMUP": 0,
+    "ENTER_LONG": 0,
+    "ENTER_SHORT": 0,
+    "EXIT_OR_DEMOTION": 0,
+    "HOLD": 0,
+    "UNOBSERVABLE_FAIL_CLOSED": 0,
+    "agreement_direction_counts": {
+      "unresolved": 185
+    },
+    "composition_outcome_counts": {
+      "observe": 185
+    },
+    "dominant_first_failed_stage": "directional_agreement",
+    "entry_bar_count": 185,
+    "entry_side_counts": {
+      "NONE": 185
+    },
+    "first_failed_stage_counts": {
+      "directional_agreement": 185
+    },
+    "taxonomy_outcome_counts": {
+      "BLOCKED_DIRECTIONAL_AGREEMENT": 185
+    }
+  },
+  "changed_bar_count": 0,
+  "comparison_table": {
+    "bollinger_ENTER_LONG": 0,
+    "bollinger_ENTER_SHORT": 0,
+    "bollinger_HOLD": 0,
+    "bollinger_agreement_block": 185,
+    "bollinger_agreement_pass": 0,
+    "bollinger_composition_observe_or_block": 0,
+    "bollinger_dominant_first_failed_stage": "directional_agreement",
+    "bollinger_entry_plus_one": 185,
+    "bollinger_entry_side_long": 0,
+    "bollinger_entry_side_none": 185,
+    "bollinger_entry_side_short": 0,
+    "bollinger_exit_minus_one": 20754,
+    "bollinger_side_resolved": 0,
+    "scope": "identical_panel_member_set_and_bars; strategy differs by design",
+    "short_reference_dominant_note": "rsi_reversion -1 is positional SHORT; Bollinger -1 is EXIT (never SHORT). Bollinger ENTRY remains side-unresolved (NONE) under decision C.",
+    "short_reference_entry_count": 53870,
+    "short_reference_long_plus_one_count": 64110
+  },
+  "control_dominant_first_failed_stage": "directional_agreement",
+  "decision_evidence": {
+    "canonical_side_authority_present": false,
+    "parent_bollinger_entry_side_decision": "BLOCKED_AMBIGUITY",
+    "productive_minus_one_meaning": "EXIT_EVENT",
+    "productive_plus_one_meaning": "ENTRY_EVENT",
+    "short_entry_condition_present": false,
+    "variant_a_rejected_reason": "productive code/tests/owner contract not consistently long-only (class doc vs method return vs Decision D vs adapter NONE)",
+    "variant_b_rejected_reason": "producer package not ratified as EVENT_ONLY_NO_SIDE_AUTHORITY; parent audit class remains AMBIGUOUS_OR_CONTRADICTORY"
+  },
+  "elapsed_seconds": 753.59,
+  "evaluation_instrument_id": "okx:linear_perpetual:1INCH:USDT:USDT:perp",
+  "macd_side_activated": false,
+  "next_dominant_blocker": {
+    "contract_path": "trading.master_v2 / resolve_agreement_bound_directional_cycle_v1 (ENTRY_EXIT entry_side=NONE \u2192 no directional cycle)",
+    "note": "No side ratification in this slice; DA remains fail-closed for Bollinger ENTRY.",
+    "panel_count": 185,
+    "stage": "directional_agreement"
+  },
+  "panel_member_count": 118,
+  "panel_total_bars": 348454,
+  "parent_decision": "OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1",
+  "ratified_dominant_first_failed_stage": "directional_agreement",
+  "runner": "scripts/ops/run_obl_b05_bollinger_long_semantic_decision_baseline_v1.py",
+  "schema_version": "obl_b05_bollinger_long_semantic_decision.v1",
+  "scope_note": "Identical durable full-canonical panel scratch + bollinger runtime config; SHORT reference overlays rsi_reversion POSITIONAL_LS on same bars (documented strategy-id difference; -1 is SHORT entry there, EXIT for bollinger).",
+  "short_reference": {
+    "encoding": "POSITIONAL_LS_STATE_V1",
+    "eval_long_plus_one_mv2": {
+      "BLOCKED_COMPOSITION": 18,
+      "BLOCKED_DIRECTIONAL_AGREEMENT": 0,
+      "BLOCKED_SUITABILITY": 0,
+      "BLOCKED_WARMUP": 0,
+      "ENTER_LONG": 53,
+      "ENTER_SHORT": 0,
+      "EXIT_OR_DEMOTION": 0,
+      "HOLD": 405,
+      "UNOBSERVABLE_FAIL_CLOSED": 0,
+      "agreement_direction_counts": {
+        "LONG": 476
+      },
+      "composition_outcome_counts": {
+        "long_selected": 458,
+        "observe": 18
+      },
+      "dominant_first_failed_stage": "entry_exit",
+      "entry_bar_count": 476,
+      "entry_side_counts": {
+        "NONE": 476
+      },
+      "first_failed_stage_counts": {
+        "composition": 18,
+        "entry_exit": 405,
+        "none": 53
+      },
+      "taxonomy_outcome_counts": {
+        "BLOCKED_COMPOSITION": 18,
+        "ENTER_LONG": 53,
+        "HOLD": 405
+      }
+    },
+    "eval_short_entry_minus_one": 345,
+    "minus_one_meaning": "SHORT_ENTRY_POSITIONAL",
+    "panel_event_counts": {
+      "entry_plus_one": 64110,
+      "exit_minus_one": 53870,
+      "neutral_zero": 230474,
+      "note": "exit_minus_one key reused from event counter helper; for rsi_reversion it counts positional SHORT entries (raw==-1)",
+      "short_entry_minus_one": 53870,
+      "total_bars": 348454
+    },
+    "panel_long_plus_one_mv2": {
+      "BLOCKED_COMPOSITION": 2602,
+      "BLOCKED_DIRECTIONAL_AGREEMENT": 0,
+      "BLOCKED_SUITABILITY": 0,
+      "BLOCKED_WARMUP": 56,
+      "ENTER_LONG": 9838,
+      "ENTER_SHORT": 0,
+      "EXIT_OR_DEMOTION": 0,
+      "HOLD": 50602,
+      "UNOBSERVABLE_FAIL_CLOSED": 0,
+      "agreement_direction_counts": {
+        "LONG": 64054,
+        "unresolved": 56
+      },
+      "composition_outcome_counts": {
+        "long_selected": 61452,
+        "null": 56,
+        "observe": 2602
+      },
+      "dominant_first_failed_stage": "entry_exit",
+      "entry_bar_count": 64110,
+      "entry_side_counts": {
+        "NONE": 64110
+      },
+      "first_failed_stage_counts": {
+        "composition": 2602,
+        "entry_exit": 51614,
+        "none": 9838,
+        "warmup": 56
+      },
+      "taxonomy_outcome_counts": {
+        "BLOCKED_COMPOSITION": 2602,
+        "BLOCKED_ENTRY_EXIT": 1012,
+        "BLOCKED_WARMUP": 56,
+        "ENTER_LONG": 9838,
+        "HOLD": 50602
+      }
+    },
+    "panel_short_entry_minus_one": 53870,
+    "params": {
+      "lower": 30.0,
+      "rsi_window": 14,
+      "upper": 70.0
+    },
+    "plus_one_meaning": "LONG_ENTRY_POSITIONAL",
+    "producer_id": "rsi_reversion",
+    "scope": "same_panel_bars_identical_archive_strategy_overlay"
+  },
+  "slice_id": "OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_AND_QUANTITATIVE_BASELINE_V1",
+  "unresolved_contradictions": [
+    "CP02_class_doc_1_long_vs_method_return_1_entry",
+    "CP01_base_strategy_abc_long_short_vs_entry_exit",
+    "CP03_registry_supported_sides_long_short_vs_long_only_code",
+    "decision_d_entry_never_implies_long",
+    "adapter_keeps_bollinger_entry_side_none",
+    "parent_ssot_blocked_ambiguity"
+  ]
+}

--- a/docs/governance/OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md
+++ b/docs/governance/OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md
@@ -1,0 +1,121 @@
+# OBL_B05 Bollinger Long-Semantic Decision + Quantitative Baseline v1
+
+---
+docs_token: DOCS_TOKEN_OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1
+STATUS: BOLLINGER_LONG_SEMANTIC_DECISION_COMPLETE
+scope: decision + quantitative event baseline; non-authorizing
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+SCHEDULER_RUNTIME_ALLOWED: false
+BOLLINGER_LONG_SEMANTIC_DECISION_COMPLETE: true
+BOLLINGER_DECISION: CONTRACT_REMAINS_AMBIGUOUS
+BOLLINGER_QUANTITATIVE_BASELINE_COMPLETE: true
+BOLLINGER_SIDE_ACTIVATED: false
+BOLLINGER_SHORT_EMISSION: false
+OTHER_PRODUCER_SIDE_EMISSION_CHANGED: false
+PRODUCTIVE_SEMANTICS_CHANGED: false
+---
+
+> Decision&#47;Evidence-Slice only. No productive `entry_side` activation.
+> Bollinger `-1` remains EXIT (never SHORT). MACD and other producers unchanged.
+
+## A. Verdict
+
+| Feld | Wert |
+|---|---|
+| `SLICE_ID` | `OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_AND_QUANTITATIVE_BASELINE_V1` |
+| `BASE_SHA` | `8ed59484959504e7d477dc9e8d4adedd2ec022b0` |
+| `PR_5319_MERGE_SHA` | `8ed59484959504e7d477dc9e8d4adedd2ec022b0` |
+| `BOLLINGER_DECISION` | `CONTRACT_REMAINS_AMBIGUOUS` |
+| `BOLLINGER_SIDE_ACTIVATED` | `false` |
+| `BOLLINGER_SHORT_EMISSION` | `false` |
+| `PRODUCTIVE_SEMANTICS_CHANGED` | `false` |
+| `LIVE_AUTHORIZED` | `false` |
+| `ORDERS_ENABLED` | `false` |
+| `SSOT_JSON` | `config&#47;governance&#47;obl_b05_bollinger_long_semantic_decision_v1.json` |
+
+## B. Decision (Variant C)
+
+Chosen exclusively: **C — `CONTRACT_REMAINS_AMBIGUOUS`**.
+
+| Variant | Result | Why |
+|---|---|---|
+| A `LONG_ONLY_ENTRY_EXIT` | rejected | Class doc `1 (long)` vs method `1=entry`; Decision D ENTRY≠LONG; adapter keeps `entry_side=NONE`; parent SSOT `BLOCKED_AMBIGUITY` |
+| B `SIDE_NEUTRAL_ENTRY_EXIT` | rejected | Consumer path is event-neutral, but producer package is not ratified as `EVENT_ONLY_NO_SIDE_AUTHORITY` (class remains `AMBIGUOUS_OR_CONTRADICTORY`) |
+| C `CONTRACT_REMAINS_AMBIGUOUS` | **selected** | Matches parent audit; contradictions unresolved |
+
+Unresolved contradictions (must stay explicit):
+
+1. `CP02` — class doc `1 (long)` vs method return `1=entry`
+2. `CP01` — `BaseStrategy` ±1 long&#47;short position vocab vs ENTRY&#47;EXIT encoding
+3. `CP03` — registry `supported_sides=(long,short)` vs long-only geometry
+4. Decision D — `+1` is ENTRY, never LONG authority
+5. Adapter — Bollinger `entry_side` forced `NONE`
+6. Parent SSOT — `bollinger_entry_side_decision=BLOCKED_AMBIGUITY`
+
+`-1` is productive EXIT (middle-band cross), never SHORT.
+
+## C. Quantitative baseline (canonical panel)
+
+Identical durable archive + bollinger binding as TF impact diagnostic &#47; full-canonical economic panel:
+
+- archive: full_canonical_system_economic_evidence_generation_v1_offline_execution_v0_20260716T015033Z
+- binding: `config&#47;research&#47;bollinger_bands_v2_full_canonical_system_economic_binding_v1.json`
+- panel members: 118
+- total bars: 348454
+
+### Bollinger events
+
+| Metric | Panel | Eval (1INCH) |
+|---|---:|---:|
+| total bars | 348454 | 2953 |
+| ENTRY (`+1`) | 185 | 1 |
+| EXIT (`-1`) | 20754 | 168 |
+| neutral (`0`) | 327515 | 2784 |
+| `entry_side` LONG | 0 | 0 |
+| `entry_side` SHORT | 0 | 0 |
+| `entry_side` NONE | 185 | 1 |
+| agreement | unresolved×185 | unresolved×1 |
+| first_failed_stage | directional_agreement×185 | directional_agreement×1 |
+| ENTER&#47;HOLD&#47;EXIT outcomes | 0 | 0 |
+
+### SHORT reference (`rsi_reversion`, POSITIONAL_LS)
+
+Same bars&#47;panel; documented strategy overlay (not Bollinger).
+
+| Metric | Panel |
+|---|---:|
+| SHORT entries (`-1` positional) | 53870 |
+| LONG entries (`+1` positional) | 64110 |
+
+Contrast rule: Bollinger `-1` = EXIT event; RSI `-1` = SHORT entry. Methodologically comparable only as same-scope event counts under explicit encoding difference.
+
+## D. Comparison (SHORT vs Bollinger&#47;LONG-candidate)
+
+| Field | Bollinger ENTRY_EXIT | RSI POSITIONAL_LS SHORT ref |
+|---|---|---|
+| Scope | identical panel bars | identical panel bars |
+| Entry count | 185 (`+1` ENTRY) | 53870 (`-1` SHORT) |
+| Side resolved | 0 (all NONE) | cycle carrier (±1) |
+| Agreement | blocked×185 | LONG path reaches later stages on `+1` |
+| Composition | not reached for Bollinger ENTRY | observe&#47;selected on RSI `+1` |
+| ENTER&#47;HOLD | 0 &#47; 0 | present on RSI `+1` MV2 path |
+
+## E. Next steps (no repair in this slice)
+
+- No productive Bollinger side emission
+- Next dominant blocker for Bollinger ENTRY: `directional_agreement` (entry_side=NONE)
+- Future activation only after doc-alignment GO:
+  `OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1`
+
+## F. Owners &#47; navigation
+
+| Surface | Owner |
+|---|---|
+| SSOT JSON | `config&#47;governance&#47;obl_b05_bollinger_long_semantic_decision_v1.json` |
+| Governance narrative | this document |
+| Baseline runner | `scripts&#47;ops&#47;run_obl_b05_bollinger_long_semantic_decision_baseline_v1.py` |
+| Tests | `tests&#47;backtest&#47;test_obl_b05_bollinger_long_semantic_decision_v1.py` |
+| Parent authority audit | `docs&#47;governance&#47;OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md` |
+| TF impact diagnostic | `docs&#47;governance&#47;OBL_B05_TREND_FOLLOWING_SIDE_IMPACT_DIAGNOSTIC_V1.md` |
+| Evidence pointer | `docs&#47;product&#47;evidence&#47;obl_b05_bollinger_long_semantic_decision_v1_20260717T231700Z&#47;` |

--- a/docs/governance/OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md
+++ b/docs/governance/OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md
@@ -132,3 +132,4 @@ Homogene Sammelaktivierung ist **nicht** autorisiert.
 | Encoding owner map (reuse) | `src&#47;backtest&#47;strategy_signal_suitability_agreement_adapter_v1.py` |
 | Static contract tests | `tests&#47;backtest&#47;test_entry_exit_producer_side_authority_decision_v1.py` |
 | Parent carrier contract | `docs&#47;governance&#47;OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md` |
+| Bollinger long-semantic decision | `docs&#47;governance&#47;OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md` |

--- a/docs/governance/OBL_B05_TREND_FOLLOWING_SIDE_IMPACT_DIAGNOSTIC_V1.md
+++ b/docs/governance/OBL_B05_TREND_FOLLOWING_SIDE_IMPACT_DIAGNOSTIC_V1.md
@@ -99,3 +99,4 @@ Runner: `scripts&#47;ops&#47;run_obl_b05_trend_following_side_impact_diagnostic_
 | Tests | `tests&#47;backtest&#47;test_obl_b05_trend_following_side_impact_diagnostic_v1.py` |
 | Parent ratification | `docs&#47;governance&#47;OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1.md` |
 | Evidence pointer | `docs&#47;product&#47;evidence&#47;obl_b05_trend_following_side_impact_diagnostic_v1_20260717T225700Z&#47;` |
+| Bollinger long-semantic decision | `docs&#47;governance&#47;OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md` |

--- a/docs/product/evidence/obl_b05_bollinger_long_semantic_decision_v1_20260717T231700Z/AUDIT.md
+++ b/docs/product/evidence/obl_b05_bollinger_long_semantic_decision_v1_20260717T231700Z/AUDIT.md
@@ -1,0 +1,28 @@
+# AUDIT — Bollinger Long-Semantic Decision v1
+
+## Decision
+
+`BOLLINGER_DECISION=CONTRACT_REMAINS_AMBIGUOUS`
+
+- Variant A rejected: productive docs&#47;adapter&#47;parent SSOT not consistently long-only.
+- Variant B rejected: producer not ratified as side-neutral authority class.
+- No productive `src/` mutation. `entry_side` remains NONE.
+
+## Quantitative panel baseline
+
+| Metric | Value |
+|---|---:|
+| total bars | 348454 |
+| Bollinger ENTRY (`+1`) | 185 |
+| Bollinger EXIT (`-1`) | 20754 |
+| entry_side NONE on ENTRY | 185 |
+| first_failed_stage DA | 185 |
+| ENTER outcomes | 0 |
+| SHORT reference (`rsi_reversion` `-1`) | 53870 |
+
+## Invariants verified
+
+- `-1` never interpreted as SHORT for Bollinger
+- EXIT never emits LONG&#47;SHORT
+- MACD&#47;other producers unchanged
+- LIVE&#47;ORDERS false

--- a/docs/product/evidence/obl_b05_bollinger_long_semantic_decision_v1_20260717T231700Z/README.md
+++ b/docs/product/evidence/obl_b05_bollinger_long_semantic_decision_v1_20260717T231700Z/README.md
@@ -1,0 +1,14 @@
+# OBL_B05 Bollinger Long-Semantic Decision v1 — Evidence
+
+Pointer package (decision C + quantitative baseline).
+
+- slice_id: `OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_AND_QUANTITATIVE_BASELINE_V1`
+- base_sha: `8ed59484959504e7d477dc9e8d4adedd2ec022b0`
+- governance_ref: `docs&#47;governance&#47;OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md`
+- ssot_json: `config&#47;governance&#47;obl_b05_bollinger_long_semantic_decision_v1.json`
+- BOLLINGER_DECISION: `CONTRACT_REMAINS_AMBIGUOUS`
+- BOLLINGER_SIDE_ACTIVATED: `false`
+- BOLLINGER_SHORT_EMISSION: `false`
+- PRODUCTIVE_SEMANTICS_CHANGED: `false`
+- LIVE_AUTHORIZED: `false`
+- ORDERS_ENABLED: `false`

--- a/docs/product/evidence/obl_b05_bollinger_long_semantic_decision_v1_20260717T231700Z/baseline_summary.json
+++ b/docs/product/evidence/obl_b05_bollinger_long_semantic_decision_v1_20260717T231700Z/baseline_summary.json
@@ -1,0 +1,230 @@
+{
+  "BOLLINGER_DECISION": "CONTRACT_REMAINS_AMBIGUOUS",
+  "BOLLINGER_LONG_SEMANTIC_DECISION_COMPLETE": true,
+  "BOLLINGER_QUANTITATIVE_BASELINE_COMPLETE": true,
+  "BOLLINGER_SHORT_EMISSION": false,
+  "BOLLINGER_SIDE_ACTIVATED": false,
+  "LIVE_AUTHORIZED": false,
+  "ORDERS_ENABLED": false,
+  "OTHER_PRODUCER_SIDE_EMISSION_CHANGED": false,
+  "PRODUCTIVE_SEMANTICS_CHANGED": false,
+  "archive_dir": "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/full_canonical_system_economic_evidence_generation_v1_offline_execution_v0_20260716T015033Z",
+  "base_sha": "8ed59484959504e7d477dc9e8d4adedd2ec022b0",
+  "binding": "config/research/bollinger_bands_v2_full_canonical_system_economic_binding_v1.json",
+  "bollinger_eval_entry_mv2": {
+    "BLOCKED_COMPOSITION": 0,
+    "BLOCKED_DIRECTIONAL_AGREEMENT": 1,
+    "BLOCKED_SUITABILITY": 0,
+    "BLOCKED_WARMUP": 0,
+    "ENTER_LONG": 0,
+    "ENTER_SHORT": 0,
+    "EXIT_OR_DEMOTION": 0,
+    "HOLD": 0,
+    "UNOBSERVABLE_FAIL_CLOSED": 0,
+    "agreement_direction_counts": {
+      "unresolved": 1
+    },
+    "composition_outcome_counts": {
+      "observe": 1
+    },
+    "dominant_first_failed_stage": "directional_agreement",
+    "entry_bar_count": 1,
+    "entry_side_counts": {
+      "NONE": 1
+    },
+    "first_failed_stage_counts": {
+      "directional_agreement": 1
+    },
+    "taxonomy_outcome_counts": {
+      "BLOCKED_DIRECTIONAL_AGREEMENT": 1
+    }
+  },
+  "bollinger_event_baseline_eval": {
+    "entry_plus_one": 1,
+    "exit_minus_one": 168,
+    "neutral_zero": 2784,
+    "total_bars": 2953
+  },
+  "bollinger_event_baseline_panel": {
+    "entry_plus_one": 185,
+    "exit_minus_one": 20754,
+    "neutral_zero": 327515,
+    "total_bars": 348454
+  },
+  "bollinger_panel_entry_mv2": {
+    "BLOCKED_COMPOSITION": 0,
+    "BLOCKED_DIRECTIONAL_AGREEMENT": 185,
+    "BLOCKED_SUITABILITY": 0,
+    "BLOCKED_WARMUP": 0,
+    "ENTER_LONG": 0,
+    "ENTER_SHORT": 0,
+    "EXIT_OR_DEMOTION": 0,
+    "HOLD": 0,
+    "UNOBSERVABLE_FAIL_CLOSED": 0,
+    "agreement_direction_counts": {
+      "unresolved": 185
+    },
+    "composition_outcome_counts": {
+      "observe": 185
+    },
+    "dominant_first_failed_stage": "directional_agreement",
+    "entry_bar_count": 185,
+    "entry_side_counts": {
+      "NONE": 185
+    },
+    "first_failed_stage_counts": {
+      "directional_agreement": 185
+    },
+    "taxonomy_outcome_counts": {
+      "BLOCKED_DIRECTIONAL_AGREEMENT": 185
+    }
+  },
+  "changed_bar_count": 0,
+  "comparison_table": {
+    "bollinger_ENTER_LONG": 0,
+    "bollinger_ENTER_SHORT": 0,
+    "bollinger_HOLD": 0,
+    "bollinger_agreement_block": 185,
+    "bollinger_agreement_pass": 0,
+    "bollinger_composition_observe_or_block": 0,
+    "bollinger_dominant_first_failed_stage": "directional_agreement",
+    "bollinger_entry_plus_one": 185,
+    "bollinger_entry_side_long": 0,
+    "bollinger_entry_side_none": 185,
+    "bollinger_entry_side_short": 0,
+    "bollinger_exit_minus_one": 20754,
+    "bollinger_side_resolved": 0,
+    "scope": "identical_panel_member_set_and_bars; strategy differs by design",
+    "short_reference_dominant_note": "rsi_reversion -1 is positional SHORT; Bollinger -1 is EXIT (never SHORT). Bollinger ENTRY remains side-unresolved (NONE) under decision C.",
+    "short_reference_entry_count": 53870,
+    "short_reference_long_plus_one_count": 64110
+  },
+  "control_dominant_first_failed_stage": "directional_agreement",
+  "decision_evidence": {
+    "canonical_side_authority_present": false,
+    "parent_bollinger_entry_side_decision": "BLOCKED_AMBIGUITY",
+    "productive_minus_one_meaning": "EXIT_EVENT",
+    "productive_plus_one_meaning": "ENTRY_EVENT",
+    "short_entry_condition_present": false,
+    "variant_a_rejected_reason": "productive code/tests/owner contract not consistently long-only (class doc vs method return vs Decision D vs adapter NONE)",
+    "variant_b_rejected_reason": "producer package not ratified as EVENT_ONLY_NO_SIDE_AUTHORITY; parent audit class remains AMBIGUOUS_OR_CONTRADICTORY"
+  },
+  "elapsed_seconds": 753.59,
+  "evaluation_instrument_id": "okx:linear_perpetual:1INCH:USDT:USDT:perp",
+  "macd_side_activated": false,
+  "next_dominant_blocker": {
+    "contract_path": "trading.master_v2 / resolve_agreement_bound_directional_cycle_v1 (ENTRY_EXIT entry_side=NONE \u2192 no directional cycle)",
+    "note": "No side ratification in this slice; DA remains fail-closed for Bollinger ENTRY.",
+    "panel_count": 185,
+    "stage": "directional_agreement"
+  },
+  "panel_member_count": 118,
+  "panel_total_bars": 348454,
+  "parent_decision": "OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1",
+  "ratified_dominant_first_failed_stage": "directional_agreement",
+  "runner": "scripts/ops/run_obl_b05_bollinger_long_semantic_decision_baseline_v1.py",
+  "schema_version": "obl_b05_bollinger_long_semantic_decision.v1",
+  "scope_note": "Identical durable full-canonical panel scratch + bollinger runtime config; SHORT reference overlays rsi_reversion POSITIONAL_LS on same bars (documented strategy-id difference; -1 is SHORT entry there, EXIT for bollinger).",
+  "short_reference": {
+    "encoding": "POSITIONAL_LS_STATE_V1",
+    "eval_long_plus_one_mv2": {
+      "BLOCKED_COMPOSITION": 18,
+      "BLOCKED_DIRECTIONAL_AGREEMENT": 0,
+      "BLOCKED_SUITABILITY": 0,
+      "BLOCKED_WARMUP": 0,
+      "ENTER_LONG": 53,
+      "ENTER_SHORT": 0,
+      "EXIT_OR_DEMOTION": 0,
+      "HOLD": 405,
+      "UNOBSERVABLE_FAIL_CLOSED": 0,
+      "agreement_direction_counts": {
+        "LONG": 476
+      },
+      "composition_outcome_counts": {
+        "long_selected": 458,
+        "observe": 18
+      },
+      "dominant_first_failed_stage": "entry_exit",
+      "entry_bar_count": 476,
+      "entry_side_counts": {
+        "NONE": 476
+      },
+      "first_failed_stage_counts": {
+        "composition": 18,
+        "entry_exit": 405,
+        "none": 53
+      },
+      "taxonomy_outcome_counts": {
+        "BLOCKED_COMPOSITION": 18,
+        "ENTER_LONG": 53,
+        "HOLD": 405
+      }
+    },
+    "eval_short_entry_minus_one": 345,
+    "minus_one_meaning": "SHORT_ENTRY_POSITIONAL",
+    "panel_event_counts": {
+      "entry_plus_one": 64110,
+      "exit_minus_one": 53870,
+      "neutral_zero": 230474,
+      "note": "exit_minus_one key reused from event counter helper; for rsi_reversion it counts positional SHORT entries (raw==-1)",
+      "short_entry_minus_one": 53870,
+      "total_bars": 348454
+    },
+    "panel_long_plus_one_mv2": {
+      "BLOCKED_COMPOSITION": 2602,
+      "BLOCKED_DIRECTIONAL_AGREEMENT": 0,
+      "BLOCKED_SUITABILITY": 0,
+      "BLOCKED_WARMUP": 56,
+      "ENTER_LONG": 9838,
+      "ENTER_SHORT": 0,
+      "EXIT_OR_DEMOTION": 0,
+      "HOLD": 50602,
+      "UNOBSERVABLE_FAIL_CLOSED": 0,
+      "agreement_direction_counts": {
+        "LONG": 64054,
+        "unresolved": 56
+      },
+      "composition_outcome_counts": {
+        "long_selected": 61452,
+        "null": 56,
+        "observe": 2602
+      },
+      "dominant_first_failed_stage": "entry_exit",
+      "entry_bar_count": 64110,
+      "entry_side_counts": {
+        "NONE": 64110
+      },
+      "first_failed_stage_counts": {
+        "composition": 2602,
+        "entry_exit": 51614,
+        "none": 9838,
+        "warmup": 56
+      },
+      "taxonomy_outcome_counts": {
+        "BLOCKED_COMPOSITION": 2602,
+        "BLOCKED_ENTRY_EXIT": 1012,
+        "BLOCKED_WARMUP": 56,
+        "ENTER_LONG": 9838,
+        "HOLD": 50602
+      }
+    },
+    "panel_short_entry_minus_one": 53870,
+    "params": {
+      "lower": 30.0,
+      "rsi_window": 14,
+      "upper": 70.0
+    },
+    "plus_one_meaning": "LONG_ENTRY_POSITIONAL",
+    "producer_id": "rsi_reversion",
+    "scope": "same_panel_bars_identical_archive_strategy_overlay"
+  },
+  "slice_id": "OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_AND_QUANTITATIVE_BASELINE_V1",
+  "unresolved_contradictions": [
+    "CP02_class_doc_1_long_vs_method_return_1_entry",
+    "CP01_base_strategy_abc_long_short_vs_entry_exit",
+    "CP03_registry_supported_sides_long_short_vs_long_only_code",
+    "decision_d_entry_never_implies_long",
+    "adapter_keeps_bollinger_entry_side_none",
+    "parent_ssot_blocked_ambiguity"
+  ]
+}

--- a/scripts/ops/run_obl_b05_bollinger_long_semantic_decision_baseline_v1.py
+++ b/scripts/ops/run_obl_b05_bollinger_long_semantic_decision_baseline_v1.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""OBL_B05 Bollinger long-semantic decision + quantitative baseline v1.
+
+Read-only / semantics-free:
+- Decision C (CONTRACT_REMAINS_AMBIGUOUS) — no productive entry_side activation.
+- Quantitative Bollinger ENTRY/EXIT baseline on canonical panel archive.
+- SHORT reference via positional mean_reversion_channel on identical bars/scope.
+
+Operator GO: GO_OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_AND_QUANTITATIVE_BASELINE_V1
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+if str(_REPO_ROOT / "src" / "trading") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src" / "trading"))
+
+from src.backtest.admissible_versioned_futures_dataset_v1 import (  # noqa: E402
+    DatasetProfileBindingV1,
+    DatasetProfileV1,
+    ExecutionCostBindingV1,
+    L1ObservationStatusV1,
+)
+from src.backtest.mv2_research_wiring_v1 import (  # noqa: E402
+    resolve_agreement_bound_directional_cycle_v1,
+    run_mv2_research_backtest_wiring_v1,
+)
+from src.research.final_research_fleet_v0_versioned_binding_manifest_contract_v0 import (  # noqa: E402
+    CANONICAL_INSTRUMENT_ID,
+)
+from src.research.mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1 import (  # noqa: E402
+    build_observational_snapshot_from_replay_v1,
+    classify_entry_bar_snapshot_v1,
+    is_strategy_entry_raw_signal_v1,
+)
+from src.strategies.bollinger import BollingerBandsStrategy  # noqa: E402
+from src.strategies.rsi_reversion import RsiReversionStrategy  # noqa: E402
+
+GO_TOKEN = "GO_OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_AND_QUANTITATIVE_BASELINE_V1"
+SLICE_ID = "OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_AND_QUANTITATIVE_BASELINE_V1"
+DEFAULT_ARCHIVE = Path(
+    "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/research/"
+    "full_canonical_system_economic_evidence_generation_v1_offline_execution_v0_20260716T015033Z"
+)
+DEFAULT_BINDING = (
+    _REPO_ROOT / "config/research/bollinger_bands_v2_full_canonical_system_economic_binding_v1.json"
+)
+EVAL_ID = "okx:linear_perpetual:1INCH:USDT:USDT:perp"
+# POSITIONAL_LS SHORT reference (same panel bars; documented strategy overlay).
+SHORT_REF_STRATEGY_ID = "rsi_reversion"
+SHORT_REF_PARAMS = {
+    "rsi_window": 14,
+    "lower": 30.0,
+    "upper": 70.0,
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"not_object:{path}")
+    return payload
+
+
+def _summarize_entry_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    stages = Counter(str(r["first_failed_stage"]) for r in rows)
+    tax = Counter(str(r["taxonomy_outcome"]) for r in rows)
+    sides = Counter("NONE" if r["entry_side"] is None else str(r["entry_side"]) for r in rows)
+    dirs = Counter(str(r["agreement_direction"]) for r in rows)
+    comps = Counter(
+        "null" if r["composition_outcome"] is None else str(r["composition_outcome"]) for r in rows
+    )
+    dominant_stage = (
+        sorted(stages.items(), key=lambda item: (-item[1], item[0]))[0][0] if stages else None
+    )
+    return {
+        "entry_bar_count": len(rows),
+        "entry_side_counts": dict(sorted(sides.items())),
+        "agreement_direction_counts": dict(sorted(dirs.items())),
+        "first_failed_stage_counts": dict(sorted(stages.items())),
+        "dominant_first_failed_stage": dominant_stage,
+        "taxonomy_outcome_counts": dict(sorted(tax.items())),
+        "composition_outcome_counts": dict(sorted(comps.items())),
+        "ENTER_LONG": int(tax.get("ENTER_LONG", 0)),
+        "ENTER_SHORT": int(tax.get("ENTER_SHORT", 0)),
+        "HOLD": int(tax.get("HOLD", 0)),
+        "EXIT_OR_DEMOTION": int(tax.get("EXIT_OR_DEMOTION", 0)),
+        "UNOBSERVABLE_FAIL_CLOSED": int(tax.get("UNOBSERVABLE_FAIL_CLOSED", 0)),
+        "BLOCKED_DIRECTIONAL_AGREEMENT": int(tax.get("BLOCKED_DIRECTIONAL_AGREEMENT", 0)),
+        "BLOCKED_COMPOSITION": int(tax.get("BLOCKED_COMPOSITION", 0)),
+        "BLOCKED_SUITABILITY": int(tax.get("BLOCKED_SUITABILITY", 0)),
+        "BLOCKED_WARMUP": int(tax.get("BLOCKED_WARMUP", 0)),
+    }
+
+
+def _event_counts_from_signals(signals: pd.Series) -> dict[str, int]:
+    values = signals.fillna(0).astype(int)
+    return {
+        "total_bars": int(len(values)),
+        "entry_plus_one": int((values == 1).sum()),
+        "exit_minus_one": int((values == -1).sum()),
+        "neutral_zero": int((values == 0).sum()),
+    }
+
+
+def _bollinger_signals(bars: pd.DataFrame, params: dict[str, Any]) -> pd.Series:
+    strategy = BollingerBandsStrategy(
+        bb_period=int(params.get("bb_period", 20)),
+        bb_std=float(params.get("bb_std", 2.0)),
+        entry_threshold=float(params.get("entry_threshold", 0.95)),
+        exit_threshold=float(params.get("exit_threshold", 0.5)),
+    )
+    return strategy.generate_signals(bars)
+
+
+def _short_ref_signals(bars: pd.DataFrame, params: dict[str, Any]) -> pd.Series:
+    strategy = RsiReversionStrategy(
+        rsi_window=int(params.get("rsi_window", 14)),
+        lower=float(params.get("lower", 30.0)),
+        upper=float(params.get("upper", 70.0)),
+    )
+    return strategy.generate_signals(bars)
+
+
+def diagnose_raw_ones(
+    *,
+    member_id: str,
+    bars: pd.DataFrame,
+    cfg: dict[str, Any],
+    profile: DatasetProfileBindingV1,
+) -> list[dict[str, Any]]:
+    """Collect MV2 taxonomy for raw strategy signal == +1 (ENTRY or positional long)."""
+    strategy_id = str(cfg["economic_evaluation_v1"]["strategy_id"])
+    params = dict(cfg["economic_evaluation_v1"]["strategy_params"])
+    if strategy_id == "bollinger_bands":
+        expected = int((_bollinger_signals(bars, params) == 1).sum())
+    elif strategy_id == SHORT_REF_STRATEGY_ID:
+        expected = int((_short_ref_signals(bars, params) == 1).sum())
+    else:
+        raise ValueError(f"unsupported_strategy:{strategy_id}")
+    collected: list[dict[str, Any]] = []
+
+    def _hook(**kwargs: Any) -> None:
+        raw = int(kwargs["raw_strategy_signal"])
+        if not is_strategy_entry_raw_signal_v1(raw):
+            return
+        mat = kwargs.get("agreement_material")
+        side = getattr(mat, "entry_side", None)
+        side_v = getattr(side, "value", None) if side is not None else None
+        event_kind = getattr(getattr(mat, "event_kind", None), "value", None)
+        direction = resolve_agreement_bound_directional_cycle_v1(mat) if mat is not None else None
+        snap = build_observational_snapshot_from_replay_v1(
+            trading_epoch=int(kwargs["trading_epoch"]),
+            bar_timestamp=str(kwargs["bar_timestamp"]),
+            instrument_id=str(kwargs["instrument_id"]),
+            panel_member_instrument_id=str(kwargs["panel_member_instrument_id"]),
+            raw_strategy_signal=raw,
+            warmup_status=str(kwargs["warmup_status"]),
+            warmup_skipped=bool(kwargs["warmup_skipped"]),
+            context_id=str(kwargs["context_id"]),
+            context_input_digest=str(kwargs["context_input_digest"]),
+            agreement_material=mat,
+            intermediate=kwargs.get("intermediate"),
+            decision_outcome=kwargs.get("decision_outcome"),
+            evidence_reason_codes=tuple(kwargs.get("evidence_reason_codes") or ()),
+            mapped_position_signal=int(kwargs["mapped_position_signal"]),
+            price_path=kwargs.get("price_path"),
+            regime_id=kwargs.get("regime_id"),
+            eligible_strategy_count=kwargs.get("eligible_strategy_count"),
+            regime_wildcard_matched=kwargs.get("regime_wildcard_matched"),
+            fail_reasons=tuple(kwargs.get("fail_reasons") or ()),
+            replay_input_built=bool(kwargs["replay_input_built"]),
+            decision_authority_reached=bool(kwargs["decision_authority_reached"]),
+        )
+        rec = classify_entry_bar_snapshot_v1(snap)
+        collected.append(
+            {
+                "panel_member_instrument_id": member_id,
+                "bar_index": rec.bar_index,
+                "bar_timestamp": rec.bar_timestamp,
+                "strategy_id": strategy_id,
+                "raw_signal": raw,
+                "event_kind": event_kind,
+                "entry_side": side_v,
+                "agreement_direction": {1: "LONG", -1: "SHORT"}.get(direction, "unresolved"),
+                "first_failed_stage": rec.first_failed_stage,
+                "taxonomy_outcome": rec.taxonomy_outcome,
+                "directional_agreement_outcome": rec.directional_agreement_outcome,
+                "suitability_outcome": rec.suitability_outcome,
+                "composition_outcome": rec.composition_outcome,
+                "final_decision_outcome": rec.final_decision_outcome,
+                "mapped_position_signal": rec.mapped_position_signal,
+            }
+        )
+
+    run_mv2_research_backtest_wiring_v1(
+        bars,
+        strategy_id=strategy_id,
+        cfg=cfg,
+        instrument_id=CANONICAL_INSTRUMENT_ID,
+        profile_binding=profile,
+        observational_bar_hook=_hook,
+        observational_panel_member_instrument_id=member_id,
+    )
+    if len(collected) != expected:
+        raise RuntimeError(
+            f"entry_bar_reconciliation_failed:{member_id}:{strategy_id}:{expected}:{len(collected)}"
+        )
+    return collected
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=GO_TOKEN)
+    parser.add_argument("--go-token", required=True)
+    parser.add_argument("--archive-dir", type=Path, default=DEFAULT_ARCHIVE)
+    parser.add_argument("--binding", type=Path, default=DEFAULT_BINDING)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--eval-only", action="store_true")
+    parser.add_argument("--max-panel-members", type=int, default=None)
+    parser.add_argument("--base-sha", default="8ed59484959504e7d477dc9e8d4adedd2ec022b0")
+    args = parser.parse_args(argv)
+    if args.go_token != GO_TOKEN:
+        print(f"go_token_mismatch:expected={GO_TOKEN}", file=sys.stderr)
+        return 2
+
+    archive = args.archive_dir
+    cfg_boll = _load_json(archive / "runtime_evaluation_config.json")
+    if str(cfg_boll["economic_evaluation_v1"]["strategy_id"]) != "bollinger_bands":
+        raise RuntimeError("archive_strategy_not_bollinger_bands")
+    binding = _load_json(args.binding)
+    panel_ids = [
+        str(item) for item in binding["binding"]["instrument_binding"]["eligible_instrument_ids"]
+    ]
+    if args.max_panel_members is not None:
+        panel_ids = panel_ids[: max(0, int(args.max_panel_members))]
+    if args.eval_only:
+        panel_ids = [EVAL_ID]
+
+    profile = DatasetProfileBindingV1(
+        dataset_profile=DatasetProfileV1.ECONOMIC_RESEARCH_V1,
+        execution_cost_binding=ExecutionCostBindingV1(
+            spread_model_version="research_conservative_bps_v1",
+            execution_price_observation_source="MODELLED_NOT_OBSERVED",
+            conservative_half_spread_bps=5.0,
+        ),
+        l1_observation_status=L1ObservationStatusV1.EXECUTION_MODEL_BOUND_NOT_OBSERVED,
+    )
+
+    cfg_short = copy.deepcopy(cfg_boll)
+    cfg_short["economic_evaluation_v1"]["strategy_id"] = SHORT_REF_STRATEGY_ID
+    cfg_short["economic_evaluation_v1"]["strategy_params"] = dict(SHORT_REF_PARAMS)
+    cfg_short["economic_evaluation_v1"]["strategy_version"] = "v1"
+
+    t0 = time.time()
+    boll_params = dict(cfg_boll["economic_evaluation_v1"]["strategy_params"])
+    event_panel = Counter()
+    short_event_panel = Counter()
+    boll_entry_rows: list[dict[str, Any]] = []
+    short_long_entry_rows: list[dict[str, Any]] = []
+    boll_eval_rows: list[dict[str, Any]] = []
+    short_eval_long_rows: list[dict[str, Any]] = []
+    total_bars = 0
+    short_minus_one_panel = 0
+    short_minus_one_eval = 0
+
+    for index, member_id in enumerate(panel_ids):
+        bars_path = archive / "scratch" / member_id.replace(":", "_") / "bars.parquet"
+        bars = pd.read_parquet(bars_path)
+        total_bars += len(bars)
+
+        boll_sig = _bollinger_signals(bars, boll_params)
+        boll_ev = _event_counts_from_signals(boll_sig)
+        for key in ("total_bars", "entry_plus_one", "exit_minus_one", "neutral_zero"):
+            event_panel[key] += boll_ev[key]
+
+        short_sig = _short_ref_signals(bars, SHORT_REF_PARAMS)
+        short_ev = _event_counts_from_signals(short_sig)
+        for key in ("total_bars", "entry_plus_one", "exit_minus_one", "neutral_zero"):
+            short_event_panel[key] += short_ev[key]
+        short_minus_one_panel += int(short_ev["exit_minus_one"])
+        # For POSITIONAL_LS, -1 is SHORT entry (not EXIT). Track explicitly.
+        if member_id == EVAL_ID:
+            short_minus_one_eval = int(short_ev["exit_minus_one"])
+
+        boll_rows = diagnose_raw_ones(member_id=member_id, bars=bars, cfg=cfg_boll, profile=profile)
+        short_rows = diagnose_raw_ones(
+            member_id=member_id, bars=bars, cfg=cfg_short, profile=profile
+        )
+        boll_entry_rows.extend(boll_rows)
+        short_long_entry_rows.extend(short_rows)
+        if member_id == EVAL_ID:
+            boll_eval_rows = list(boll_rows)
+            short_eval_long_rows = list(short_rows)
+
+        print(
+            json.dumps(
+                {
+                    "progress": index + 1,
+                    "of": len(panel_ids),
+                    "member": member_id,
+                    "bollinger_entry": len(boll_rows),
+                    "bollinger_exit": boll_ev["exit_minus_one"],
+                    "rsi_plus_one": len(short_rows),
+                    "rsi_minus_one_short": short_ev["exit_minus_one"],
+                    "elapsed_s": round(time.time() - t0, 1),
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+
+    boll_panel_summary = _summarize_entry_rows(boll_entry_rows)
+    boll_eval_summary = _summarize_entry_rows(boll_eval_rows)
+    short_plus_panel = _summarize_entry_rows(short_long_entry_rows)
+    short_plus_eval = _summarize_entry_rows(short_eval_long_rows)
+
+    for summary in (boll_panel_summary, boll_eval_summary, short_plus_panel, short_plus_eval):
+        if summary["entry_bar_count"] != sum(summary["taxonomy_outcome_counts"].values()):
+            raise RuntimeError("taxonomy_reconciliation_failed")
+        if summary["entry_bar_count"] != sum(summary["first_failed_stage_counts"].values()):
+            raise RuntimeError("stage_reconciliation_failed")
+        if summary["entry_bar_count"] != sum(summary["entry_side_counts"].values()):
+            raise RuntimeError("entry_side_reconciliation_failed")
+
+    if event_panel["entry_plus_one"] != boll_panel_summary["entry_bar_count"]:
+        raise RuntimeError("bollinger_entry_event_vs_mv2_mismatch")
+    if event_panel["total_bars"] != total_bars:
+        raise RuntimeError("total_bars_mismatch")
+
+    # Invariants for decision C / bollinger
+    if boll_panel_summary["entry_side_counts"].get("LONG", 0) != 0:
+        raise RuntimeError("bollinger_long_side_unexpected")
+    if boll_panel_summary["entry_side_counts"].get("SHORT", 0) != 0:
+        raise RuntimeError("bollinger_short_side_unexpected")
+    if boll_panel_summary["agreement_direction_counts"].get("SHORT", 0) != 0:
+        raise RuntimeError("bollinger_agreement_short_unexpected")
+
+    payload = {
+        "schema_version": "obl_b05_bollinger_long_semantic_decision.v1",
+        "slice_id": SLICE_ID,
+        "base_sha": args.base_sha,
+        "parent_decision": "OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1",
+        "BOLLINGER_LONG_SEMANTIC_DECISION_COMPLETE": True,
+        "BOLLINGER_DECISION": "CONTRACT_REMAINS_AMBIGUOUS",
+        "BOLLINGER_QUANTITATIVE_BASELINE_COMPLETE": True,
+        "BOLLINGER_SIDE_ACTIVATED": False,
+        "BOLLINGER_SHORT_EMISSION": False,
+        "OTHER_PRODUCER_SIDE_EMISSION_CHANGED": False,
+        "PRODUCTIVE_SEMANTICS_CHANGED": False,
+        "LIVE_AUTHORIZED": False,
+        "ORDERS_ENABLED": False,
+        "evaluation_instrument_id": EVAL_ID,
+        "panel_member_count": len(panel_ids),
+        "panel_total_bars": total_bars,
+        "archive_dir": str(archive),
+        "binding": str(args.binding.relative_to(_REPO_ROOT)),
+        "scope_note": (
+            "Identical durable full-canonical panel scratch + bollinger runtime config; "
+            "SHORT reference overlays rsi_reversion POSITIONAL_LS on same bars "
+            "(documented strategy-id difference; -1 is SHORT entry there, EXIT for bollinger)."
+        ),
+        "unresolved_contradictions": [
+            "CP02_class_doc_1_long_vs_method_return_1_entry",
+            "CP01_base_strategy_abc_long_short_vs_entry_exit",
+            "CP03_registry_supported_sides_long_short_vs_long_only_code",
+            "decision_d_entry_never_implies_long",
+            "adapter_keeps_bollinger_entry_side_none",
+            "parent_ssot_blocked_ambiguity",
+        ],
+        "decision_evidence": {
+            "parent_bollinger_entry_side_decision": "BLOCKED_AMBIGUITY",
+            "productive_minus_one_meaning": "EXIT_EVENT",
+            "productive_plus_one_meaning": "ENTRY_EVENT",
+            "short_entry_condition_present": False,
+            "canonical_side_authority_present": False,
+            "variant_a_rejected_reason": (
+                "productive code/tests/owner contract not consistently long-only "
+                "(class doc vs method return vs Decision D vs adapter NONE)"
+            ),
+            "variant_b_rejected_reason": (
+                "producer package not ratified as EVENT_ONLY_NO_SIDE_AUTHORITY; "
+                "parent audit class remains AMBIGUOUS_OR_CONTRADICTORY"
+            ),
+        },
+        "bollinger_event_baseline_panel": dict(sorted(event_panel.items())),
+        "bollinger_event_baseline_eval": _event_counts_from_signals(
+            _bollinger_signals(
+                pd.read_parquet(archive / "scratch" / EVAL_ID.replace(":", "_") / "bars.parquet"),
+                boll_params,
+            )
+        )
+        if EVAL_ID in panel_ids
+        else None,
+        "bollinger_eval_entry_mv2": boll_eval_summary,
+        "bollinger_panel_entry_mv2": boll_panel_summary,
+        "short_reference": {
+            "producer_id": SHORT_REF_STRATEGY_ID,
+            "encoding": "POSITIONAL_LS_STATE_V1",
+            "params": dict(SHORT_REF_PARAMS),
+            "minus_one_meaning": "SHORT_ENTRY_POSITIONAL",
+            "plus_one_meaning": "LONG_ENTRY_POSITIONAL",
+            "scope": "same_panel_bars_identical_archive_strategy_overlay",
+            "panel_event_counts": {
+                **dict(sorted(short_event_panel.items())),
+                "short_entry_minus_one": short_minus_one_panel,
+                "note": (
+                    "exit_minus_one key reused from event counter helper; "
+                    "for rsi_reversion it counts positional SHORT entries (raw==-1)"
+                ),
+            },
+            "eval_short_entry_minus_one": short_minus_one_eval,
+            "panel_short_entry_minus_one": short_minus_one_panel,
+            "panel_long_plus_one_mv2": short_plus_panel,
+            "eval_long_plus_one_mv2": short_plus_eval,
+        },
+        "comparison_table": {
+            "scope": "identical_panel_member_set_and_bars; strategy differs by design",
+            "bollinger_entry_plus_one": event_panel["entry_plus_one"],
+            "bollinger_exit_minus_one": event_panel["exit_minus_one"],
+            "bollinger_side_resolved": 0,
+            "bollinger_entry_side_long": 0,
+            "bollinger_entry_side_short": 0,
+            "bollinger_entry_side_none": boll_panel_summary["entry_side_counts"].get("NONE", 0),
+            "bollinger_agreement_pass": 0,
+            "bollinger_agreement_block": boll_panel_summary["BLOCKED_DIRECTIONAL_AGREEMENT"],
+            "bollinger_composition_observe_or_block": boll_panel_summary["BLOCKED_COMPOSITION"],
+            "bollinger_ENTER_LONG": boll_panel_summary["ENTER_LONG"],
+            "bollinger_ENTER_SHORT": boll_panel_summary["ENTER_SHORT"],
+            "bollinger_HOLD": boll_panel_summary["HOLD"],
+            "bollinger_dominant_first_failed_stage": boll_panel_summary[
+                "dominant_first_failed_stage"
+            ],
+            "short_reference_entry_count": short_minus_one_panel,
+            "short_reference_long_plus_one_count": short_event_panel["entry_plus_one"],
+            "short_reference_dominant_note": (
+                "rsi_reversion -1 is positional SHORT; Bollinger -1 is EXIT (never SHORT). "
+                "Bollinger ENTRY remains side-unresolved (NONE) under decision C."
+            ),
+        },
+        "control_dominant_first_failed_stage": boll_panel_summary["dominant_first_failed_stage"],
+        "ratified_dominant_first_failed_stage": boll_panel_summary["dominant_first_failed_stage"],
+        "changed_bar_count": 0,
+        "next_dominant_blocker": {
+            "stage": boll_panel_summary["dominant_first_failed_stage"],
+            "contract_path": (
+                "trading.master_v2 / resolve_agreement_bound_directional_cycle_v1 "
+                "(ENTRY_EXIT entry_side=NONE → no directional cycle)"
+            ),
+            "panel_count": int(
+                boll_panel_summary["first_failed_stage_counts"].get(
+                    str(boll_panel_summary["dominant_first_failed_stage"]), 0
+                )
+            ),
+            "note": "No side ratification in this slice; DA remains fail-closed for Bollinger ENTRY.",
+        },
+        "macd_side_activated": False,
+        "elapsed_seconds": round(time.time() - t0, 2),
+        "runner": "scripts/ops/run_obl_b05_bollinger_long_semantic_decision_baseline_v1.py",
+    }
+
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "baseline_summary.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "output_dir": str(out),
+                "BOLLINGER_DECISION": payload["BOLLINGER_DECISION"],
+                "panel_entry": event_panel["entry_plus_one"],
+                "panel_exit": event_panel["exit_minus_one"],
+                "short_reference_entry_count": short_minus_one_panel,
+                "dominant_stage": boll_panel_summary["dominant_first_failed_stage"],
+                "elapsed_seconds": payload["elapsed_seconds"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/backtest/test_obl_b05_bollinger_long_semantic_decision_v1.py
+++ b/tests/backtest/test_obl_b05_bollinger_long_semantic_decision_v1.py
@@ -1,0 +1,188 @@
+"""Contracts for OBL_B05 Bollinger long-semantic decision + baseline v1.
+
+Decision C: CONTRACT_REMAINS_AMBIGUOUS — no productive side activation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import src.backtest.strategy_signal_suitability_agreement_adapter_v1 as adapter_mod
+from src.backtest.strategy_signal_suitability_agreement_adapter_v1 import (
+    normalize_strategy_signal_to_suitability_agreement_material_v1,
+)
+from trading.master_v2.strategy_suitability_agreement_material_v1 import (
+    StrategyAgreementEventKindV1,
+    StrategyEntrySideCarrierV1,
+    StrategySignalEncodingClassV1,
+)
+from tests.backtest.test_strategy_signal_suitability_agreement_adapter_v1 import (
+    _binding,
+    _provenance,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SSOT_PATH = REPO_ROOT / "config" / "governance" / "obl_b05_bollinger_long_semantic_decision_v1.json"
+GOV_DOC = REPO_ROOT / "docs" / "governance" / "OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md"
+RUNNER = (
+    REPO_ROOT / "scripts" / "ops" / "run_obl_b05_bollinger_long_semantic_decision_baseline_v1.py"
+)
+ADAPTER = REPO_ROOT / "src" / "backtest" / "strategy_signal_suitability_agreement_adapter_v1.py"
+BOLLINGER_SRC = REPO_ROOT / "src" / "strategies" / "bollinger.py"
+
+_ALLOWED_DECISIONS = frozenset(
+    {
+        "LONG_ONLY_ENTRY_EXIT",
+        "SIDE_NEUTRAL_ENTRY_EXIT",
+        "CONTRACT_REMAINS_AMBIGUOUS",
+    }
+)
+
+
+def _ssot() -> dict:
+    return json.loads(SSOT_PATH.read_text(encoding="utf-8"))
+
+
+def test_ssot_and_governance_markers_present() -> None:
+    assert SSOT_PATH.is_file()
+    assert GOV_DOC.is_file()
+    assert RUNNER.is_file()
+    data = _ssot()
+    body = GOV_DOC.read_text(encoding="utf-8")
+    assert data["slice_id"].startswith("OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION")
+    assert data["BOLLINGER_LONG_SEMANTIC_DECISION_COMPLETE"] is True
+    assert data["BOLLINGER_QUANTITATIVE_BASELINE_COMPLETE"] is True
+    assert data["BOLLINGER_DECISION"] == "CONTRACT_REMAINS_AMBIGUOUS"
+    assert data["BOLLINGER_DECISION"] in _ALLOWED_DECISIONS
+    assert data["BOLLINGER_SIDE_ACTIVATED"] is False
+    assert data["BOLLINGER_SHORT_EMISSION"] is False
+    assert data["OTHER_PRODUCER_SIDE_EMISSION_CHANGED"] is False
+    assert data["PRODUCTIVE_SEMANTICS_CHANGED"] is False
+    assert data["LIVE_AUTHORIZED"] is False
+    assert data["ORDERS_ENABLED"] is False
+    assert "DOCS_TOKEN_OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1" in body
+    assert "BOLLINGER_DECISION: CONTRACT_REMAINS_AMBIGUOUS" in body
+
+
+def test_quantitative_baseline_reconciles_and_none_side() -> None:
+    data = _ssot()
+    panel_ev = data["bollinger_event_baseline_panel"]
+    panel_mv2 = data["bollinger_panel_entry_mv2"]
+    assert panel_ev["total_bars"] == 348454
+    assert panel_ev["entry_plus_one"] == panel_mv2["entry_bar_count"] == 185
+    assert panel_ev["exit_minus_one"] == 20754
+    assert (
+        panel_ev["neutral_zero"] + panel_ev["entry_plus_one"] + panel_ev["exit_minus_one"]
+        == panel_ev["total_bars"]
+    )
+    assert panel_mv2["entry_side_counts"].get("NONE", 0) == 185
+    assert panel_mv2["entry_side_counts"].get("LONG", 0) == 0
+    assert panel_mv2["entry_side_counts"].get("SHORT", 0) == 0
+    assert panel_mv2["BLOCKED_DIRECTIONAL_AGREEMENT"] == 185
+    assert panel_mv2["ENTER_LONG"] == 0
+    assert panel_mv2["ENTER_SHORT"] == 0
+    assert panel_mv2["entry_bar_count"] == sum(panel_mv2["taxonomy_outcome_counts"].values())
+    assert panel_mv2["entry_bar_count"] == sum(panel_mv2["first_failed_stage_counts"].values())
+
+
+def test_short_reference_contrast_and_minus_one_not_short_for_bollinger() -> None:
+    data = _ssot()
+    assert data["comparison_table"]["short_reference_entry_count"] == 53870
+    assert data["short_reference"]["producer_id"] == "rsi_reversion"
+    assert data["short_reference"]["minus_one_meaning"] == "SHORT_ENTRY_POSITIONAL"
+    assert data["decision_evidence"]["productive_minus_one_meaning"] == "EXIT_EVENT"
+    src = BOLLINGER_SRC.read_text(encoding="utf-8")
+    assert "-1 (exit)" in src or "1=entry" in src
+    assert "signals[cross_exit] = -1" in src
+    assert "short_entry" not in src.lower()
+
+
+def test_productive_adapter_still_emits_none_for_bollinger_entry_and_exit() -> None:
+    boll_prov = _provenance(
+        configured_strategy_id="bollinger_bands",
+        executed_strategy_id="bollinger_bands",
+        strategy_owner="strategies.bollinger",
+    )
+    # ENTRY +1
+    mat_entry = normalize_strategy_signal_to_suitability_agreement_material_v1(
+        _binding([0, 1, 0], provenance=boll_prov),
+        instrument_id="okx:linear_perpetual:1INCH:USDT:USDT:perp",
+        trading_epoch=1,
+    )
+    assert mat_entry.encoding_class is StrategySignalEncodingClassV1.ENTRY_EXIT_EVENT_V1
+    assert mat_entry.event_kind is StrategyAgreementEventKindV1.ENTRY
+    assert mat_entry.entry_side is StrategyEntrySideCarrierV1.NONE
+    # EXIT -1 must never become SHORT
+    mat_exit = normalize_strategy_signal_to_suitability_agreement_material_v1(
+        _binding([0, -1, 0], provenance=boll_prov),
+        instrument_id="okx:linear_perpetual:1INCH:USDT:USDT:perp",
+        trading_epoch=1,
+    )
+    assert mat_exit.event_kind is StrategyAgreementEventKindV1.EXIT
+    assert mat_exit.entry_side is StrategyEntrySideCarrierV1.NONE
+    # MACD unchanged
+    macd_prov = _provenance(
+        configured_strategy_id="macd",
+        executed_strategy_id="macd",
+        strategy_owner="strategies.macd",
+    )
+    mat_macd = normalize_strategy_signal_to_suitability_agreement_material_v1(
+        _binding([0, 1, 0], provenance=macd_prov),
+        instrument_id="okx:linear_perpetual:1INCH:USDT:USDT:perp",
+        trading_epoch=1,
+    )
+    assert mat_macd.entry_side is StrategyEntrySideCarrierV1.NONE
+    # Only TF remains ratified; Bollinger not in ratification owner.
+    assert adapter_mod._TREND_FOLLOWING_ENTRY_SIDE_RATIFIED_OWNER == "trend_following"
+    assert "bollinger" not in adapter_mod._TREND_FOLLOWING_ENTRY_SIDE_RATIFIED_OWNER
+
+
+def test_no_productive_semantics_and_next_blocker_is_da() -> None:
+    data = _ssot()
+    assert data["PRODUCTIVE_SEMANTICS_CHANGED"] is False
+    assert data["changed_bar_count"] == 0
+    assert data["control_dominant_first_failed_stage"] == "directional_agreement"
+    assert data["ratified_dominant_first_failed_stage"] == "directional_agreement"
+    assert data["next_dominant_blocker"]["stage"] == "directional_agreement"
+
+
+def test_eval_only_runner_smoke(tmp_path: Path) -> None:
+    archive = Path(
+        "/Users/frnkhrz/Documents/Peak_Trade_runtime_evidence_archive_20260520T161443Z/"
+        "research/full_canonical_system_economic_evidence_generation_v1_offline_execution_v0_"
+        "20260716T015033Z"
+    )
+    if not archive.is_dir():
+        pytest.skip("durable archive unavailable")
+    import subprocess
+    import sys
+
+    out = tmp_path / "baseline"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            "--go-token",
+            "GO_OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_AND_QUANTITATIVE_BASELINE_V1",
+            "--archive-dir",
+            str(archive),
+            "--output-dir",
+            str(out),
+            "--eval-only",
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    summary = json.loads((out / "baseline_summary.json").read_text(encoding="utf-8"))
+    assert summary["BOLLINGER_DECISION"] == "CONTRACT_REMAINS_AMBIGUOUS"
+    assert summary["BOLLINGER_SIDE_ACTIVATED"] is False
+    assert summary["bollinger_eval_entry_mv2"]["entry_side_counts"].get("NONE", 0) == 1
+    assert summary["bollinger_eval_entry_mv2"]["dominant_first_failed_stage"] == (
+        "directional_agreement"
+    )


### PR DESCRIPTION
## Summary
- Decide `BOLLINGER_DECISION=CONTRACT_REMAINS_AMBIGUOUS` (variant C): no productive `entry_side` activation; `-1` stays EXIT never SHORT.
- Publish reconciled Bollinger ENTRY/EXIT quantitative baseline on the canonical 118-instrument panel (185 ENTRY, all DA-blocked / `entry_side=NONE`).
- Contrast with positional SHORT reference (`rsi_reversion` on identical bars); MACD/other producers unchanged; LIVE/ORDERS false.

## Test plan
- [x] `tests/backtest/test_obl_b05_bollinger_long_semantic_decision_v1.py`
- [x] docs-reference-targets / docs-token / ruff
- [x] PR_BOUNDED timing proof (~45s local)
- [ ] Required GitHub checks green


Made with [Cursor](https://cursor.com)