### PR TITLE
docs(gov): Bollinger ENTRY side doc alignment + open LONG decision brief

### DIFF
--- a/config/governance/obl_b05_bollinger_entry_side_doc_alignment_then_long_decision_v1.json
+++ b/config/governance/obl_b05_bollinger_entry_side_doc_alignment_then_long_decision_v1.json
@@ -1,0 +1,221 @@
+{
+  "ACTIVE_SSOT_ALIGNED": true,
+  "BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_COMPLETE": true,
+  "BOLLINGER_SIDE_ACTIVATED": false,
+  "CONTRACT_STATE": "CONTRACT_REMAINS_AMBIGUOUS",
+  "ENTRY_SIDE_CURRENT": "NONE",
+  "LIVE_AUTHORIZED": false,
+  "LONG_DECISION_MADE_IN_THIS_SLICE": false,
+  "OPEN_DECISION": "BOLLINGER_ENTRY_SIDE_AUTHORITY_PENDING_SEPARATE_OPERATOR_GO",
+  "ORDERS_ENABLED": false,
+  "PRODUCTIVE_SRC_CHANGED": false,
+  "SIDE_ACTIVATED": false,
+  "active_ssot_updates": [
+    {
+      "change": "Mark governance-docs alignment complete; keep BLOCKED_AMBIGUITY; split next activation candidate",
+      "path": "config/governance/obl_b05_entry_exit_producer_side_authority_decision_v1.json"
+    },
+    {
+      "change": "Align next-step wording; fail-closed NONE invariants; open decision pointer",
+      "path": "docs/governance/OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md"
+    },
+    {
+      "change": "Replace pending doc-alignment next step with completed alignment + open authority decision",
+      "path": "docs/governance/OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md"
+    },
+    {
+      "change": "Navigation + explicit fail-closed NONE for Bollinger; no activation",
+      "path": "docs/governance/OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md"
+    },
+    {
+      "change": "Pointer to doc-alignment slice; keep ENTRY\u2260LONG",
+      "path": "docs/governance/STRATEGY_SIGNAL_CANONICAL_CONSUMER_ARCHITECTURE_DECISION_D_V1.md"
+    }
+  ],
+  "base_sha": "236a3ed9d39b0346e00662929e911bb44b2095fc",
+  "before_after_contract_statement": {
+    "after": {
+      "bollinger_entry_authorized_side": "NONE",
+      "cycle_signal_plus_one_authorizes_long": false,
+      "entry_side_none_is_intentional_fail_closed": true,
+      "governance_docs_aligned": true,
+      "long_activation_requires_separate_go": true,
+      "productive_src_doc_cp02_still_present": true
+    },
+    "before": {
+      "bollinger_entry_authorized_side": "NONE",
+      "cycle_signal_plus_one_authorizes_long": false,
+      "entry_side_none_is_intentional_fail_closed": true,
+      "governance_docs_aligned": "partial_next_step_pointed_to_this_slice",
+      "long_activation_requires_separate_go": true,
+      "productive_src_doc_cp02_still_present": true
+    },
+    "delta": "Active governance narratives and machine-readable future-slice pointers now state fail-closed NONE as current law and separate the open LONG-authority GO from this non-authorizing doc alignment."
+  },
+  "findings_matrix": [
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "config/governance/obl_b05_entry_exit_producer_side_authority_decision_v1.json",
+      "statement": "bollinger_entry_side_decision=BLOCKED_AMBIGUITY; KEEP_NONE; activation ineligible",
+      "status": "ALIGNED_UPDATED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "config/governance/obl_b05_bollinger_long_semantic_decision_v1.json",
+      "statement": "BOLLINGER_DECISION=CONTRACT_REMAINS_AMBIGUOUS; entry_side NONE; SIDE_ACTIVATED=false",
+      "status": "ALIGNED_UNCHANGED_AUTHORITY"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md",
+      "statement": "ENTRY never implies LONG; Bollinger BLOCKED_AMBIGUITY; next = open authority GO",
+      "status": "ALIGNED_UPDATED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md",
+      "statement": "Variant C frozen; quantitative baseline; doc-alignment completed pointer",
+      "status": "ALIGNED_UPDATED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md",
+      "statement": "Bollinger entry_side=NONE; +1 is ENTRY only; carrier non-authorizing",
+      "status": "ALIGNED_UPDATED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/STRATEGY_SIGNAL_CANONICAL_CONSUMER_ARCHITECTURE_DECISION_D_V1.md",
+      "statement": "ENTRY_EXIT +1 never LONG; Bollinger BLOCKED_AMBIGUITY referenced",
+      "status": "ALIGNED_UPDATED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1.md",
+      "statement": "BOLLINGER_SIDE_ACTIVATED=false; TF-only ratification",
+      "status": "ALIGNED_NO_CHANGE_REQUIRED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/OBL_B05_TREND_FOLLOWING_SIDE_IMPACT_DIAGNOSTIC_V1.md",
+      "statement": "Bollinger control path NONE/DA; SIDE_ACTIVATED=false",
+      "status": "ALIGNED_NO_CHANGE_REQUIRED"
+    },
+    {
+      "layer": "PRODUCTIVE_SOURCE_OUT_OF_SCOPE",
+      "path": "src/strategies/bollinger.py",
+      "statement": "CP02: class doc '1 (long)' vs method '1=entry'; not mutated in this slice",
+      "status": "CONTRADICTION_REMAINS_UNTOUCHED"
+    },
+    {
+      "layer": "PRODUCTIVE_SOURCE_OUT_OF_SCOPE",
+      "path": "src/strategies/base.py",
+      "statement": "CP01: \u00b11 long/short position vocab vs ENTRY_EXIT encoding",
+      "status": "CONTRADICTION_REMAINS_UNTOUCHED"
+    },
+    {
+      "layer": "PRODUCTIVE_SOURCE_OUT_OF_SCOPE",
+      "path": "src/strategies/registry.py",
+      "statement": "CP03: supported_sides=(long,short) capability \u2260 signal authority",
+      "status": "CONTRADICTION_REMAINS_UNTOUCHED"
+    },
+    {
+      "layer": "PRODUCTIVE_SOURCE_OUT_OF_SCOPE",
+      "path": "src/backtest/strategy_signal_suitability_agreement_adapter_v1.py",
+      "statement": "Bollinger entry_side forced NONE; only trend_following ratified LONG",
+      "status": "ALIGNED_BEHAVIOR_DOCUMENTED"
+    },
+    {
+      "layer": "HISTORICAL_EVIDENCE",
+      "path": "docs/product/evidence/obl_b05_bollinger_long_semantic_decision_v1_20260717T231700Z/",
+      "statement": "Frozen quantitative baseline; not rewritten",
+      "status": "PRESERVED_NOT_REINTERPRETED"
+    },
+    {
+      "layer": "HISTORICAL_EVIDENCE",
+      "path": "docs/product/evidence/obl_b05_entry_exit_producer_side_authority_decision_v1_20260717T220147Z/",
+      "statement": "Frozen BLOCKED_AMBIGUITY audit package",
+      "status": "PRESERVED_NOT_REINTERPRETED"
+    },
+    {
+      "layer": "GENERAL_DEV_GUIDE",
+      "path": "docs/STRATEGY_DEV_GUIDE.md",
+      "statement": "Generic '1 (long)' strategy template; not Bollinger authority SSOT",
+      "status": "OUT_OF_SCOPE_GENERIC_VOCAB"
+    },
+    {
+      "layer": "GENERAL_DEV_GUIDE",
+      "path": "docs/DEV_GUIDE_ADD_STRATEGY.md",
+      "statement": "Generic template; not Bollinger authority SSOT",
+      "status": "OUT_OF_SCOPE_GENERIC_VOCAB"
+    }
+  ],
+  "open_decision_brief": {
+    "current_law": {
+      "authorized_entry_side": "NONE",
+      "contract_state": "CONTRACT_REMAINS_AMBIGUOUS",
+      "minus_one_meaning": "EXIT_EVENT_NEVER_SHORT",
+      "plus_one_meaning": "ENTRY_EVENT_ONLY"
+    },
+    "next_go_candidates": [
+      "OBL_B05_BOLLINGER_ENTRY_SIDE_LONG_ACTIVATION_V1",
+      "OBL_B05_BOLLINGER_KEEP_FAIL_CLOSED_NONE_RATIFICATION_V1",
+      "OBL_B05_BOLLINGER_EVENT_ONLY_NO_SIDE_AUTHORITY_RATIFICATION_V1"
+    ],
+    "options": [
+      {
+        "id": "OPTION_A_AUTHORIZE_LONG",
+        "requires": [
+          "separate Operator-GO",
+          "productive bollinger.py doc alignment (src mutation in that later GO)",
+          "adapter producer-scoped ratification analogous to trend_following",
+          "A/B impact diagnostic before composition claims"
+        ],
+        "summary": "After productive producer-doc alignment (CP02) and explicit GO, emit entry_side=LONG only on ENTRY (+1); EXIT/FLAT remain NONE; never SHORT.",
+        "title": "Authorize LONG on Bollinger ENTRY",
+        "trade_offs": [
+          "Unblocks DA for Bollinger ENTRY bars (185 panel baseline)",
+          "Composition likely becomes next dominant blocker (TF precedent)",
+          "Touches productive adapter emission \u2014 highest review bar"
+        ]
+      },
+      {
+        "id": "OPTION_B_KEEP_AMBIGUOUS_FAIL_CLOSED",
+        "requires": [
+          "no productive mutation",
+          "optional continued evidence-only work"
+        ],
+        "summary": "Leave entry_side=NONE; retain BLOCKED_AMBIGUITY; no producer activation.",
+        "title": "Keep contract ambiguous / fail-closed NONE",
+        "trade_offs": [
+          "Safest; preserves fail-closed DA block",
+          "Does not progress Bollinger economic ENTER path",
+          "CP02 remains in productive source docs until a src-touching GO"
+        ]
+      },
+      {
+        "id": "OPTION_C_EXTEND_PRODUCER_CONTRACT_DIFFERENTLY",
+        "requires": [
+          "separate Operator-GO defining the alternate owner",
+          "Decision D / carrier contract amendment if ownership moves"
+        ],
+        "summary": "e.g. ratify EVENT_ONLY_NO_SIDE_AUTHORITY, or introduce a separate side owner outside ENTRY_EXIT carrier.",
+        "title": "Extend producer contract differently",
+        "trade_offs": [
+          "Can resolve ambiguity without implying LONG",
+          "Larger architecture change than TF-style ratification",
+          "Risk of second authority map if not reuse-before-new"
+        ]
+      }
+    ],
+    "question": "What should the next Operator-GO authorize for bollinger_bands ENTRY side?",
+    "recommendation_for_operator": "Do not auto-select. Prefer OPTION_B until a dedicated GO authorizes either producer-doc alignment + LONG (A) or an alternate contract extension (C)."
+  },
+  "parent_slices": [
+    "OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1",
+    "OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_AND_QUANTITATIVE_BASELINE_V1",
+    "OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1"
+  ],
+  "schema_version": "obl_b05_bollinger_entry_side_doc_alignment_then_long_decision.v1",
+  "slice_id": "OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1"
+}

--- a/config/governance/obl_b05_entry_exit_producer_side_authority_decision_v1.json
+++ b/config/governance/obl_b05_entry_exit_producer_side_authority_decision_v1.json
@@ -1,16 +1,4 @@
 {
-  "schema_version": "obl_b05_entry_exit_producer_side_authority_decision.v1",
-  "slice_id": "OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1",
-  "base_sha": "5039a9666afefe8b5e18cca2d6be19ae3ded9bc2",
-  "parent_contract": "OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1",
-  "encoding_owner": "src/backtest/strategy_signal_suitability_agreement_adapter_v1.py::_ENTRY_EXIT_EVENT_OWNERS",
-  "entry_exit_owner_set_closed": true,
-  "productive_side_emission_changed": false,
-  "legacy_behavior_unchanged": true,
-  "bollinger_side_activated": false,
-  "semantic_activation_requires_separate_go": true,
-  "live_authorized": false,
-  "orders_enabled": false,
   "allowed_classes": [
     "CANONICAL_EXISTING_SIDE_AUTHORITY",
     "RATIFIABLE_PRODUCER_SEMANTICS",
@@ -18,7 +6,59 @@
     "AMBIGUOUS_OR_CONTRADICTORY",
     "LEGACY_OR_SPECIALIST_ONLY"
   ],
+  "base_sha": "5039a9666afefe8b5e18cca2d6be19ae3ded9bc2",
   "bollinger_entry_side_decision": "BLOCKED_AMBIGUITY",
+  "bollinger_side_activated": false,
+  "closed_owner_set": [
+    "bollinger_bands",
+    "ecm_cycle",
+    "macd",
+    "mean_reversion",
+    "momentum_1h",
+    "my_strategy",
+    "trend_following"
+  ],
+  "conflict_provenance": [
+    {
+      "applies_to": "all_entry_exit_owners",
+      "claim": "+1 long position / -1 short position / 0 flat",
+      "conflicts_with": "Decision D ENTRY_EXIT +1 entry / -1 exit",
+      "id": "CP01_BASE_STRATEGY_ABC_LONG_SHORT",
+      "surface": "src/strategies/base.py::BaseStrategy.generate_signals"
+    },
+    {
+      "applies_to": [
+        "bollinger_bands"
+      ],
+      "claim": "class docstring 1 (long) vs method Returns 1=entry",
+      "conflicts_with": "internal producer contract consistency and Decision D",
+      "id": "CP02_BOLLINGER_CLASS_DOC_LONG_VS_METHOD_ENTRY",
+      "surface": "src/strategies/bollinger.py"
+    },
+    {
+      "applies_to": "all_entry_exit_owners",
+      "claim": "capability metadata implies short support",
+      "conflicts_with": "long-only ENTRY_EXIT producer implementations; OBL_B05 forbids as signal authority",
+      "id": "CP03_REGISTRY_SUPPORTED_SIDES_UNIVERSAL",
+      "surface": "src/strategies/registry.py supported_sides=(long,short)"
+    },
+    {
+      "applies_to": "all_entry_exit_owners",
+      "claim": "ENTRY agrees only with LONG DA side",
+      "conflicts_with": "producer side authority / Decision D entry_side carrier; consumer-only eligibility heuristic",
+      "id": "CP04_SUITABILITY_ENTRY_AGREE_LONG",
+      "surface": "src/trading/master_v2/suitability_binding_v1.py::derive_effective_strategy_side_agreement_v1"
+    },
+    {
+      "applies_to": [
+        "macd"
+      ],
+      "claim": "-1 or dual polarity as short",
+      "conflicts_with": "adapter EXIT-not-short contract",
+      "id": "CP05_MACD_BINDING_TEST_VOCAB",
+      "surface": "tests implying macd long_and_short signals"
+    }
+  ],
   "decision_rules_applied": [
     "ENTRY_NEVER_IMPLIES_LONG",
     "CYCLE_SIGNAL_PLUS_ONE_IS_NOT_SIDE_AUTHORITY",
@@ -29,31 +69,85 @@
     "NO_POSITIONAL_RECLASSIFICATION_IN_THIS_SLICE",
     "DEFAULT_ENTRY_SIDE_REMAINS_NONE"
   ],
-  "closed_owner_set": [
-    "bollinger_bands",
-    "ecm_cycle",
-    "macd",
-    "mean_reversion",
-    "momentum_1h",
-    "my_strategy",
-    "trend_following"
+  "encoding_owner": "src/backtest/strategy_signal_suitability_agreement_adapter_v1.py::_ENTRY_EXIT_EVENT_OWNERS",
+  "entry_exit_owner_set_closed": true,
+  "future_activation_slices": [
+    {
+      "prerequisite": "separate Operator-GO; align producer docs with Decision D; emit entry_side=LONG only on ENTRY",
+      "producers": [
+        "momentum_1h"
+      ],
+      "slice_id_candidate": "OBL_B05_MOMENTUM_1H_ENTRY_SIDE_LONG_ACTIVATION_V1"
+    },
+    {
+      "prerequisite": "separate Operator-GO; confirm exit remains EXIT not SHORT",
+      "producers": [
+        "trend_following"
+      ],
+      "slice_id_candidate": "OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_LONG_ACTIVATION_V1"
+    },
+    {
+      "prerequisite": "separate Operator-GO; isolate from mean_reversion_channel POSITIONAL_LS",
+      "producers": [
+        "mean_reversion"
+      ],
+      "slice_id_candidate": "OBL_B05_MEAN_REVERSION_ENTRY_SIDE_LONG_ACTIVATION_V1"
+    },
+    {
+      "prerequisite": "separate Operator-GO; align docs with ENTRY_EXIT carrier",
+      "producers": [
+        "my_strategy"
+      ],
+      "slice_id_candidate": "OBL_B05_MY_STRATEGY_ENTRY_SIDE_LONG_ACTIVATION_V1"
+    },
+    {
+      "prerequisite": "align active governance docs to fail-closed NONE; prepare open LONG-authority decision brief without activating side",
+      "producers": [
+        "bollinger_bands"
+      ],
+      "slice_id_candidate": "OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1",
+      "status": "COMPLETE_NON_AUTHORIZING"
+    },
+    {
+      "prerequisite": "explicit GO choosing OPTION_A; productive CP02 doc alignment; producer-scoped adapter ratification; never treat +1 alone as LONG",
+      "producers": [
+        "bollinger_bands"
+      ],
+      "slice_id_candidate": "OBL_B05_BOLLINGER_ENTRY_SIDE_LONG_ACTIVATION_V1",
+      "status": "PENDING_SEPARATE_OPERATOR_GO"
+    },
+    {
+      "prerequisite": "explicit GO choosing OPTION_B to freeze KEEP_NONE without productive activation",
+      "producers": [
+        "bollinger_bands"
+      ],
+      "slice_id_candidate": "OBL_B05_BOLLINGER_KEEP_FAIL_CLOSED_NONE_RATIFICATION_V1",
+      "status": "PENDING_SEPARATE_OPERATOR_GO"
+    },
+    {
+      "prerequisite": "explicit GO choosing OPTION_C alternate contract extension; reuse-before-new carrier ownership",
+      "producers": [
+        "bollinger_bands"
+      ],
+      "slice_id_candidate": "OBL_B05_BOLLINGER_EVENT_ONLY_NO_SIDE_AUTHORITY_RATIFICATION_V1",
+      "status": "PENDING_SEPARATE_OPERATOR_GO"
+    },
+    {
+      "prerequisite": "resolve AMBIGUOUS_OR_CONTRADICTORY vocab before activation",
+      "producers": [
+        "macd"
+      ],
+      "slice_id_candidate": "OBL_B05_MACD_ENTRY_SIDE_DOC_AND_TEST_ALIGNMENT_V1"
+    }
   ],
+  "legacy_behavior_unchanged": true,
+  "live_authorized": false,
+  "orders_enabled": false,
+  "parent_contract": "OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1",
   "producers": [
     {
-      "producer_id": "bollinger_bands",
-      "encoding": "ENTRY_EXIT_EVENT_V1",
-      "raw_output_domain": [-1, 0, 1],
-      "meaning_plus_one": "ENTRY_EVENT",
-      "meaning_minus_one": "EXIT_EVENT",
-      "meaning_zero": "NONE",
-      "entry_condition": "close crosses entry_level (lower*entry_threshold) from above to below",
-      "exit_condition": "close crosses middle band from below to above",
-      "short_entry_condition_present": false,
-      "canonical_side_authority_present": false,
-      "candidate_entry_side": "LONG",
-      "authority_source": "NONE",
-      "class": "AMBIGUOUS_OR_CONTRADICTORY",
-      "confidence": "HIGH",
+      "activation_blocked_reason": "BOLLINGER_ENTRY_SIDE_DECISION=BLOCKED_AMBIGUITY",
+      "activation_slice_eligible": false,
       "ambiguity_or_contradiction": [
         "class_doc_1_long_vs_method_return_1_entry",
         "decision_d_entry_not_long",
@@ -61,219 +155,200 @@
         "registry_supported_sides_long_short_vs_long_only_code",
         "suitability_entry_agree_long_is_consumer_not_producer"
       ],
-      "recommended_disposition": "KEEP_NONE",
-      "activation_slice_eligible": false,
-      "activation_blocked_reason": "BOLLINGER_ENTRY_SIDE_DECISION=BLOCKED_AMBIGUITY"
-    },
-    {
-      "producer_id": "macd",
-      "encoding": "ENTRY_EXIT_EVENT_V1",
-      "raw_output_domain": [-1, 0, 1],
-      "meaning_plus_one": "ENTRY_EVENT",
-      "meaning_minus_one": "EXIT_EVENT",
-      "meaning_zero": "NONE",
-      "entry_condition": "MACD crosses signal line from below",
-      "exit_condition": "MACD crosses signal line from above",
-      "short_entry_condition_present": false,
-      "canonical_side_authority_present": false,
-      "candidate_entry_side": "LONG",
       "authority_source": "NONE",
+      "candidate_entry_side": "LONG",
+      "canonical_side_authority_present": false,
       "class": "AMBIGUOUS_OR_CONTRADICTORY",
       "confidence": "HIGH",
+      "cycle_signal_plus_one_authorizes_long": false,
+      "encoding": "ENTRY_EXIT_EVENT_V1",
+      "entry_condition": "close crosses entry_level (lower*entry_threshold) from above to below",
+      "entry_side_current": "NONE",
+      "exit_condition": "close crosses middle band from below to above",
+      "governance_docs_aligned_to_fail_closed_none": true,
+      "governance_docs_alignment_slice": "OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1",
+      "meaning_minus_one": "EXIT_EVENT",
+      "meaning_plus_one": "ENTRY_EVENT",
+      "meaning_zero": "NONE",
+      "open_authority_decision": "BOLLINGER_ENTRY_SIDE_AUTHORITY_PENDING_SEPARATE_OPERATOR_GO",
+      "producer_id": "bollinger_bands",
+      "productive_source_doc_contradiction_cp02_still_present": true,
+      "raw_output_domain": [
+        -1,
+        0,
+        1
+      ],
+      "recommended_disposition": "KEEP_NONE",
+      "short_entry_condition_present": false
+    },
+    {
+      "activation_blocked_reason": "doc_and_test_vocab_contradict_entry_exit_contract",
+      "activation_slice_eligible": false,
       "ambiguity_or_contradiction": [
         "class_doc_1_long_vs_encoding_entry",
         "binding_test_name_implies_short_signals",
         "base_strategy_abc_long_short_position_vocab",
         "registry_supported_sides_long_short_vs_long_only_code"
       ],
+      "authority_source": "NONE",
+      "candidate_entry_side": "LONG",
+      "canonical_side_authority_present": false,
+      "class": "AMBIGUOUS_OR_CONTRADICTORY",
+      "confidence": "HIGH",
+      "encoding": "ENTRY_EXIT_EVENT_V1",
+      "entry_condition": "MACD crosses signal line from below",
+      "exit_condition": "MACD crosses signal line from above",
+      "meaning_minus_one": "EXIT_EVENT",
+      "meaning_plus_one": "ENTRY_EVENT",
+      "meaning_zero": "NONE",
+      "producer_id": "macd",
+      "raw_output_domain": [
+        -1,
+        0,
+        1
+      ],
       "recommended_disposition": "KEEP_NONE",
-      "activation_slice_eligible": false,
-      "activation_blocked_reason": "doc_and_test_vocab_contradict_entry_exit_contract"
+      "short_entry_condition_present": false
     },
     {
-      "producer_id": "momentum_1h",
-      "encoding": "ENTRY_EXIT_EVENT_V1",
-      "raw_output_domain": [-1, 0, 1],
-      "meaning_plus_one": "ENTRY_EVENT",
-      "meaning_minus_one": "EXIT_EVENT",
-      "meaning_zero": "NONE",
-      "entry_condition": "momentum crosses up through entry_threshold",
-      "exit_condition": "momentum crosses down through exit_threshold",
-      "short_entry_condition_present": false,
-      "canonical_side_authority_present": false,
-      "candidate_entry_side": "LONG",
-      "authority_source": "NONE",
-      "class": "RATIFIABLE_PRODUCER_SEMANTICS",
-      "confidence": "HIGH",
+      "activation_slice_eligible": true,
+      "activation_slice_id_candidate": "OBL_B05_MOMENTUM_1H_ENTRY_SIDE_LONG_ACTIVATION_V1",
       "ambiguity_or_contradiction": [
         "module_and_class_docs_say_long_while_decision_d_says_entry",
         "registry_supported_sides_capability_only"
       ],
-      "recommended_disposition": "KEEP_NONE_PENDING_SEPARATE_ACTIVATION_GO",
-      "activation_slice_eligible": true,
-      "activation_slice_id_candidate": "OBL_B05_MOMENTUM_1H_ENTRY_SIDE_LONG_ACTIVATION_V1"
-    },
-    {
-      "producer_id": "trend_following",
-      "encoding": "ENTRY_EXIT_EVENT_V1",
-      "raw_output_domain": [-1, 0, 1],
-      "meaning_plus_one": "ENTRY_EVENT",
-      "meaning_minus_one": "EXIT_EVENT",
-      "meaning_zero": "NONE",
-      "entry_condition": "rising edge ADX>threshold and +DI>-DI (optional MA filter)",
-      "exit_condition": "rising edge ADX<exit_threshold or -DI>+DI",
-      "short_entry_condition_present": false,
-      "canonical_side_authority_present": false,
-      "candidate_entry_side": "LONG",
       "authority_source": "NONE",
+      "candidate_entry_side": "LONG",
+      "canonical_side_authority_present": false,
       "class": "RATIFIABLE_PRODUCER_SEMANTICS",
       "confidence": "HIGH",
+      "encoding": "ENTRY_EXIT_EVENT_V1",
+      "entry_condition": "momentum crosses up through entry_threshold",
+      "exit_condition": "momentum crosses down through exit_threshold",
+      "meaning_minus_one": "EXIT_EVENT",
+      "meaning_plus_one": "ENTRY_EVENT",
+      "meaning_zero": "NONE",
+      "producer_id": "momentum_1h",
+      "raw_output_domain": [
+        -1,
+        0,
+        1
+      ],
+      "recommended_disposition": "KEEP_NONE_PENDING_SEPARATE_ACTIVATION_GO",
+      "short_entry_condition_present": false
+    },
+    {
+      "activation_slice_eligible": true,
+      "activation_slice_id_candidate": "OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_LONG_ACTIVATION_V1",
       "ambiguity_or_contradiction": [
         "downtrend_exit_must_not_be_read_as_short_entry",
         "docs_say_long_while_decision_d_says_entry"
       ],
-      "recommended_disposition": "KEEP_NONE_PENDING_SEPARATE_ACTIVATION_GO",
-      "activation_slice_eligible": true,
-      "activation_slice_id_candidate": "OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_LONG_ACTIVATION_V1"
-    },
-    {
-      "producer_id": "mean_reversion",
-      "encoding": "ENTRY_EXIT_EVENT_V1",
-      "raw_output_domain": [-1, 0, 1],
-      "meaning_plus_one": "ENTRY_EVENT",
-      "meaning_minus_one": "EXIT_EVENT",
-      "meaning_zero": "NONE",
-      "entry_condition": "rising edge zscore < entry_threshold",
-      "exit_condition": "rising edge zscore > exit_threshold",
-      "short_entry_condition_present": false,
-      "canonical_side_authority_present": false,
-      "candidate_entry_side": "LONG",
       "authority_source": "NONE",
+      "candidate_entry_side": "LONG",
+      "canonical_side_authority_present": false,
       "class": "RATIFIABLE_PRODUCER_SEMANTICS",
       "confidence": "HIGH",
+      "encoding": "ENTRY_EXIT_EVENT_V1",
+      "entry_condition": "rising edge ADX>threshold and +DI>-DI (optional MA filter)",
+      "exit_condition": "rising edge ADX<exit_threshold or -DI>+DI",
+      "meaning_minus_one": "EXIT_EVENT",
+      "meaning_plus_one": "ENTRY_EVENT",
+      "meaning_zero": "NONE",
+      "producer_id": "trend_following",
+      "raw_output_domain": [
+        -1,
+        0,
+        1
+      ],
+      "recommended_disposition": "KEEP_NONE_PENDING_SEPARATE_ACTIVATION_GO",
+      "short_entry_condition_present": false
+    },
+    {
+      "activation_slice_eligible": true,
+      "activation_slice_id_candidate": "OBL_B05_MEAN_REVERSION_ENTRY_SIDE_LONG_ACTIVATION_V1",
       "ambiguity_or_contradiction": [
         "confusion_risk_with_mean_reversion_channel_positional_ls",
         "docs_say_long_while_decision_d_says_entry"
       ],
-      "recommended_disposition": "KEEP_NONE_PENDING_SEPARATE_ACTIVATION_GO",
-      "activation_slice_eligible": true,
-      "activation_slice_id_candidate": "OBL_B05_MEAN_REVERSION_ENTRY_SIDE_LONG_ACTIVATION_V1"
-    },
-    {
-      "producer_id": "my_strategy",
-      "encoding": "ENTRY_EXIT_EVENT_V1",
-      "raw_output_domain": [-1, 0, 1],
-      "meaning_plus_one": "ENTRY_EVENT",
-      "meaning_minus_one": "EXIT_EVENT",
-      "meaning_zero": "NONE",
-      "entry_condition": "rising edge close > ma + atr*entry_multiplier",
-      "exit_condition": "rising edge close < ma - atr*exit_multiplier",
-      "short_entry_condition_present": false,
-      "canonical_side_authority_present": false,
-      "candidate_entry_side": "LONG",
       "authority_source": "NONE",
+      "candidate_entry_side": "LONG",
+      "canonical_side_authority_present": false,
       "class": "RATIFIABLE_PRODUCER_SEMANTICS",
       "confidence": "HIGH",
+      "encoding": "ENTRY_EXIT_EVENT_V1",
+      "entry_condition": "rising edge zscore < entry_threshold",
+      "exit_condition": "rising edge zscore > exit_threshold",
+      "meaning_minus_one": "EXIT_EVENT",
+      "meaning_plus_one": "ENTRY_EVENT",
+      "meaning_zero": "NONE",
+      "producer_id": "mean_reversion",
+      "raw_output_domain": [
+        -1,
+        0,
+        1
+      ],
+      "recommended_disposition": "KEEP_NONE_PENDING_SEPARATE_ACTIVATION_GO",
+      "short_entry_condition_present": false
+    },
+    {
+      "activation_slice_eligible": true,
+      "activation_slice_id_candidate": "OBL_B05_MY_STRATEGY_ENTRY_SIDE_LONG_ACTIVATION_V1",
       "ambiguity_or_contradiction": [
         "docs_say_long_while_decision_d_says_entry",
         "registry_supported_sides_capability_only"
       ],
+      "authority_source": "NONE",
+      "candidate_entry_side": "LONG",
+      "canonical_side_authority_present": false,
+      "class": "RATIFIABLE_PRODUCER_SEMANTICS",
+      "confidence": "HIGH",
+      "encoding": "ENTRY_EXIT_EVENT_V1",
+      "entry_condition": "rising edge close > ma + atr*entry_multiplier",
+      "exit_condition": "rising edge close < ma - atr*exit_multiplier",
+      "meaning_minus_one": "EXIT_EVENT",
+      "meaning_plus_one": "ENTRY_EVENT",
+      "meaning_zero": "NONE",
+      "producer_id": "my_strategy",
+      "raw_output_domain": [
+        -1,
+        0,
+        1
+      ],
       "recommended_disposition": "KEEP_NONE_PENDING_SEPARATE_ACTIVATION_GO",
-      "activation_slice_eligible": true,
-      "activation_slice_id_candidate": "OBL_B05_MY_STRATEGY_ENTRY_SIDE_LONG_ACTIVATION_V1"
+      "short_entry_condition_present": false
     },
     {
-      "producer_id": "ecm_cycle",
-      "encoding": "ENTRY_EXIT_EVENT_V1",
-      "raw_output_domain": [-1, 0, 1],
-      "meaning_plus_one": "ENTRY_EVENT",
-      "meaning_minus_one": "EXIT_EVENT",
-      "meaning_zero": "NONE",
-      "entry_condition": "rising edge high ECM confidence and close > MA",
-      "exit_condition": "rising edge low confidence or not bullish",
-      "short_entry_condition_present": false,
-      "canonical_side_authority_present": false,
-      "candidate_entry_side": "LONG",
-      "authority_source": "NONE",
-      "class": "LEGACY_OR_SPECIALIST_ONLY",
-      "confidence": "MEDIUM",
+      "activation_blocked_reason": "legacy_or_specialist_only_requires_separate_scope_ratification",
+      "activation_slice_eligible": false,
       "ambiguity_or_contradiction": [
         "functional_only_loader_path",
         "docs_say_1_equals_long_vs_decision_d_entry",
         "sparse_consumer_contract_coverage"
       ],
+      "authority_source": "NONE",
+      "candidate_entry_side": "LONG",
+      "canonical_side_authority_present": false,
+      "class": "LEGACY_OR_SPECIALIST_ONLY",
+      "confidence": "MEDIUM",
+      "encoding": "ENTRY_EXIT_EVENT_V1",
+      "entry_condition": "rising edge high ECM confidence and close > MA",
+      "exit_condition": "rising edge low confidence or not bullish",
+      "meaning_minus_one": "EXIT_EVENT",
+      "meaning_plus_one": "ENTRY_EVENT",
+      "meaning_zero": "NONE",
+      "producer_id": "ecm_cycle",
+      "raw_output_domain": [
+        -1,
+        0,
+        1
+      ],
       "recommended_disposition": "KEEP_NONE",
-      "activation_slice_eligible": false,
-      "activation_blocked_reason": "legacy_or_specialist_only_requires_separate_scope_ratification"
+      "short_entry_condition_present": false
     }
   ],
-  "conflict_provenance": [
-    {
-      "id": "CP01_BASE_STRATEGY_ABC_LONG_SHORT",
-      "surface": "src/strategies/base.py::BaseStrategy.generate_signals",
-      "claim": "+1 long position / -1 short position / 0 flat",
-      "conflicts_with": "Decision D ENTRY_EXIT +1 entry / -1 exit",
-      "applies_to": "all_entry_exit_owners"
-    },
-    {
-      "id": "CP02_BOLLINGER_CLASS_DOC_LONG_VS_METHOD_ENTRY",
-      "surface": "src/strategies/bollinger.py",
-      "claim": "class docstring 1 (long) vs method Returns 1=entry",
-      "conflicts_with": "internal producer contract consistency and Decision D",
-      "applies_to": ["bollinger_bands"]
-    },
-    {
-      "id": "CP03_REGISTRY_SUPPORTED_SIDES_UNIVERSAL",
-      "surface": "src/strategies/registry.py supported_sides=(long,short)",
-      "claim": "capability metadata implies short support",
-      "conflicts_with": "long-only ENTRY_EXIT producer implementations; OBL_B05 forbids as signal authority",
-      "applies_to": "all_entry_exit_owners"
-    },
-    {
-      "id": "CP04_SUITABILITY_ENTRY_AGREE_LONG",
-      "surface": "src/trading/master_v2/suitability_binding_v1.py::derive_effective_strategy_side_agreement_v1",
-      "claim": "ENTRY agrees only with LONG DA side",
-      "conflicts_with": "producer side authority / Decision D entry_side carrier; consumer-only eligibility heuristic",
-      "applies_to": "all_entry_exit_owners"
-    },
-    {
-      "id": "CP05_MACD_BINDING_TEST_VOCAB",
-      "surface": "tests implying macd long_and_short signals",
-      "claim": "-1 or dual polarity as short",
-      "conflicts_with": "adapter EXIT-not-short contract",
-      "applies_to": ["macd"]
-    }
-  ],
-  "future_activation_slices": [
-    {
-      "slice_id_candidate": "OBL_B05_MOMENTUM_1H_ENTRY_SIDE_LONG_ACTIVATION_V1",
-      "producers": ["momentum_1h"],
-      "prerequisite": "separate Operator-GO; align producer docs with Decision D; emit entry_side=LONG only on ENTRY"
-    },
-    {
-      "slice_id_candidate": "OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_LONG_ACTIVATION_V1",
-      "producers": ["trend_following"],
-      "prerequisite": "separate Operator-GO; confirm exit remains EXIT not SHORT"
-    },
-    {
-      "slice_id_candidate": "OBL_B05_MEAN_REVERSION_ENTRY_SIDE_LONG_ACTIVATION_V1",
-      "producers": ["mean_reversion"],
-      "prerequisite": "separate Operator-GO; isolate from mean_reversion_channel POSITIONAL_LS"
-    },
-    {
-      "slice_id_candidate": "OBL_B05_MY_STRATEGY_ENTRY_SIDE_LONG_ACTIVATION_V1",
-      "producers": ["my_strategy"],
-      "prerequisite": "separate Operator-GO; align docs with ENTRY_EXIT carrier"
-    },
-    {
-      "slice_id_candidate": "OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1",
-      "producers": ["bollinger_bands"],
-      "prerequisite": "resolve BLOCKED_AMBIGUITY (class/method/Decision D/registry) before any LONG emission"
-    },
-    {
-      "slice_id_candidate": "OBL_B05_MACD_ENTRY_SIDE_DOC_AND_TEST_ALIGNMENT_V1",
-      "producers": ["macd"],
-      "prerequisite": "resolve AMBIGUOUS_OR_CONTRADICTORY vocab before activation"
-    }
-  ]
+  "productive_side_emission_changed": false,
+  "schema_version": "obl_b05_entry_exit_producer_side_authority_decision.v1",
+  "semantic_activation_requires_separate_go": true,
+  "slice_id": "OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1"
 }

--- a/docs/governance/OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1.md
+++ b/docs/governance/OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1.md
@@ -1,0 +1,98 @@
+# OBL_B05 Bollinger Entry-Side Doc Alignment Then Long Decision v1
+
+---
+docs_token: DOCS_TOKEN_OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1
+STATUS: BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_COMPLETE
+scope: governance/docs alignment + open decision brief; non-authorizing
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+SCHEDULER_RUNTIME_ALLOWED: false
+BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_COMPLETE: true
+BOLLINGER_SIDE_ACTIVATED: false
+SIDE_ACTIVATED: false
+ENTRY_SIDE_CURRENT: NONE
+CONTRACT_STATE: CONTRACT_REMAINS_AMBIGUOUS
+LONG_DECISION_MADE_IN_THIS_SLICE: false
+PRODUCTIVE_SRC_CHANGED: false
+ACTIVE_SSOT_ALIGNED: true
+---
+
+> Non-authorizing. Aligns **active** governance SSOTs to the current fail-closed
+> law for Bollinger ENTRY. Does **not** activate `entry_side`, does **not**
+> mutate productive `src/`, and does **not** choose LONG unilaterally.
+> Historical evidence packages are preserved unchanged.
+
+## A. Verdict
+
+| Feld | Wert |
+|---|---|
+| `SLICE_ID` | `OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1` |
+| `BASE_SHA` | `236a3ed9d39b0346e00662929e911bb44b2095fc` |
+| `ENTRY_SIDE_CURRENT` | `NONE` |
+| `CONTRACT_STATE` | `CONTRACT_REMAINS_AMBIGUOUS` |
+| `BOLLINGER_SIDE_ACTIVATED` | `false` |
+| `LONG_DECISION_MADE_IN_THIS_SLICE` | `false` |
+| `PRODUCTIVE_SRC_CHANGED` | `false` |
+| `OPEN_DECISION` | `BOLLINGER_ENTRY_SIDE_AUTHORITY_PENDING_SEPARATE_OPERATOR_GO` |
+| `LIVE_AUTHORIZED` | `false` |
+| `ORDERS_ENABLED` | `false` |
+| `SSOT_JSON` | `config&#47;governance&#47;obl_b05_bollinger_entry_side_doc_alignment_then_long_decision_v1.json` |
+
+## B. Current law (aligned)
+
+1. Bollinger ENTRY has **no authorized side**.
+2. `entry_side=NONE` is intentional fail-closed.
+3. `cycle_signal_value=+1` alone does **not** authorize LONG.
+4. Later LONG (or alternate contract) requires a **separate** explicit Operator-GO.
+5. `-1` remains EXIT, never SHORT.
+
+## C. Before &#47; after (contract statement)
+
+| Aspect | Before this slice | After this slice |
+|---|---|---|
+| Authorized Bollinger ENTRY side | NONE | NONE (unchanged) |
+| `+1` ⇒ LONG? | false | false (restated) |
+| Active docs next-step wording | pointed at this slice as pending | this slice complete; open authority GO pending |
+| Productive `src/` | CP02 present | CP02 still present (untouched) |
+| Historical evidence | frozen | preserved, not reinterpreted |
+
+## D. Findings matrix (summary)
+
+Full machine-readable matrix: SSOT JSON `findings_matrix[]`.
+
+| Layer | Action |
+|---|---|
+| ACTIVE_SSOT | Updated&#47;verified aligned to fail-closed NONE |
+| HISTORICAL_EVIDENCE | Preserved; not rewritten |
+| PRODUCTIVE_SOURCE | Out of scope; contradictions documented only |
+| GENERAL_DEV_GUIDE | Out of scope (generic templates ≠ Bollinger authority) |
+
+## E. Open decision (not decided here)
+
+`OPEN_DECISION=BOLLINGER_ENTRY_SIDE_AUTHORITY_PENDING_SEPARATE_OPERATOR_GO`
+
+| Option | Title | Trade-off (short) |
+|---|---|---|
+| A | Authorize LONG on ENTRY | Unblocks DA; needs src doc alignment + adapter ratification |
+| B | Keep ambiguous &#47; fail-closed NONE | Safest; no ENTER progress |
+| C | Extend contract differently | May ratify event-only or alternate side owner; architecture risk |
+
+Operator recommendation recorded in SSOT: do **not** auto-select; prefer B until a dedicated GO chooses A or C.
+
+Candidate follow-on GOs:
+
+- `OBL_B05_BOLLINGER_ENTRY_SIDE_LONG_ACTIVATION_V1`
+- `OBL_B05_BOLLINGER_KEEP_FAIL_CLOSED_NONE_RATIFICATION_V1`
+- `OBL_B05_BOLLINGER_EVENT_ONLY_NO_SIDE_AUTHORITY_RATIFICATION_V1`
+
+## F. Owners &#47; navigation
+
+| Surface | Owner |
+|---|---|
+| This slice SSOT | `config&#47;governance&#47;obl_b05_bollinger_entry_side_doc_alignment_then_long_decision_v1.json` |
+| This narrative | this document |
+| Parent authority | `docs&#47;governance&#47;OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md` |
+| Parent semantic decision | `docs&#47;governance&#47;OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md` |
+| Carrier contract | `docs&#47;governance&#47;OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md` |
+| Static tests | `tests&#47;backtest&#47;test_obl_b05_bollinger_entry_side_doc_alignment_v1.py` |
+| Evidence pointer | `docs&#47;product&#47;evidence&#47;obl_b05_bollinger_entry_side_doc_alignment_v1_20260717T234000Z&#47;` |

--- a/docs/governance/OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md
+++ b/docs/governance/OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md
@@ -105,8 +105,11 @@ Contrast rule: Bollinger `-1` = EXIT event; RSI `-1` = SHORT entry. Methodologic
 
 - No productive Bollinger side emission
 - Next dominant blocker for Bollinger ENTRY: `directional_agreement` (entry_side=NONE)
-- Future activation only after doc-alignment GO:
+- Governance-doc alignment (fail-closed NONE restatement + open decision brief) is
+  complete in
   `OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1`
+- LONG &#47; keep-NONE &#47; alternate-contract remains an **open** separate Operator-GO
+  (`BOLLINGER_ENTRY_SIDE_AUTHORITY_PENDING_SEPARATE_OPERATOR_GO`)
 
 ## F. Owners &#47; navigation
 
@@ -117,5 +120,6 @@ Contrast rule: Bollinger `-1` = EXIT event; RSI `-1` = SHORT entry. Methodologic
 | Baseline runner | `scripts&#47;ops&#47;run_obl_b05_bollinger_long_semantic_decision_baseline_v1.py` |
 | Tests | `tests&#47;backtest&#47;test_obl_b05_bollinger_long_semantic_decision_v1.py` |
 | Parent authority audit | `docs&#47;governance&#47;OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md` |
+| Doc alignment &#47; open decision | `docs&#47;governance&#47;OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1.md` |
 | TF impact diagnostic | `docs&#47;governance&#47;OBL_B05_TREND_FOLLOWING_SIDE_IMPACT_DIAGNOSTIC_V1.md` |
 | Evidence pointer | `docs&#47;product&#47;evidence&#47;obl_b05_bollinger_long_semantic_decision_v1_20260717T231700Z&#47;` |

--- a/docs/governance/OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md
+++ b/docs/governance/OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md
@@ -96,3 +96,10 @@ SEMANTIC_PRODUCER_DECISION_STILL_REQUIRED: true
 
 Next semantic producer decision (separate Operator-GO) is required before any
 ENTRY_EXIT producer may emit `entry_side=LONG|SHORT`.
+
+Bollinger-specific current law (doc-aligned, non-authorizing):
+
+- `entry_side=NONE` is intentional fail-closed for `bollinger_bands`.
+- `cycle_signal_value=+1` alone never authorizes LONG.
+- Open authority decision brief:
+  `docs&#47;governance&#47;OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1.md`

--- a/docs/governance/OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md
+++ b/docs/governance/OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md
@@ -98,6 +98,17 @@ Begründung:
 
 Daher: **keine** LONG-Aktivierung in diesem Slice; `entry_side` bleibt `NONE`.
 
+Governance-Doc-Alignment (nicht-autorisierend) ist abgeschlossen in
+`OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1`:
+
+- Bollinger ENTRY besitzt derzeit keine autorisierte Side.
+- `entry_side=NONE` ist beabsichtigt fail-closed.
+- `cycle_signal_value=+1` allein autorisiert keine LONG-Direction.
+- Produktives `src&#47;strategies&#47;bollinger.py` CP02 bleibt unberührt bis zu einem
+  separaten, expliziten Operator-GO.
+- Offene Authority-Frage:
+  `BOLLINGER_ENTRY_SIDE_AUTHORITY_PENDING_SEPARATE_OPERATOR_GO`.
+
 ## F. Konflikt-&#47;Provenance-Tabelle (Index)
 
 | id | surface | conflict |
@@ -118,7 +129,10 @@ Nur nach eigenem Operator-GO; jeweils ein Producer (oder Doc-Alignment zuerst):
 - `OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_LONG_ACTIVATION_V1`
 - `OBL_B05_MEAN_REVERSION_ENTRY_SIDE_LONG_ACTIVATION_V1`
 - `OBL_B05_MY_STRATEGY_ENTRY_SIDE_LONG_ACTIVATION_V1`
-- `OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1`
+- `OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1` (**complete**, non-authorizing)
+- `OBL_B05_BOLLINGER_ENTRY_SIDE_LONG_ACTIVATION_V1` (pending separate GO &#47; OPTION_A)
+- `OBL_B05_BOLLINGER_KEEP_FAIL_CLOSED_NONE_RATIFICATION_V1` (pending &#47; OPTION_B)
+- `OBL_B05_BOLLINGER_EVENT_ONLY_NO_SIDE_AUTHORITY_RATIFICATION_V1` (pending &#47; OPTION_C)
 - `OBL_B05_MACD_ENTRY_SIDE_DOC_AND_TEST_ALIGNMENT_V1`
 
 Homogene Sammelaktivierung ist **nicht** autorisiert.
@@ -133,3 +147,4 @@ Homogene Sammelaktivierung ist **nicht** autorisiert.
 | Static contract tests | `tests&#47;backtest&#47;test_entry_exit_producer_side_authority_decision_v1.py` |
 | Parent carrier contract | `docs&#47;governance&#47;OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md` |
 | Bollinger long-semantic decision | `docs&#47;governance&#47;OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md` |
+| Bollinger doc alignment &#47; open decision | `docs&#47;governance&#47;OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1.md` |

--- a/docs/governance/STRATEGY_SIGNAL_CANONICAL_CONSUMER_ARCHITECTURE_DECISION_D_V1.md
+++ b/docs/governance/STRATEGY_SIGNAL_CANONICAL_CONSUMER_ARCHITECTURE_DECISION_D_V1.md
@@ -103,7 +103,7 @@ StrategySignalBindingResultV1
 |---|---|---|
 | `POSITIONAL_LS_STATE_V1` | `+1` long / `-1` short / `0` flat | side agreement vs DA side |
 | `POSITIONAL_LONG01_STATE_V1` | `+1` long / `0` flat; `-1` fail-closed | long-only agreement |
-| `ENTRY_EXIT_EVENT_V1` | `+1` entry / `-1` exit / `0` none | EXIT demotes eligibility only; never exit authority. Optional explicit `entry_side` ∈ {LONG, SHORT, NONE} (default NONE) is the only DA side carrier; `+1` alone is never LONG. Producer-side ratification status is frozen in [`OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md`](OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md) (`BOLLINGER_ENTRY_SIDE_DECISION=BLOCKED_AMBIGUITY`). |
+| `ENTRY_EXIT_EVENT_V1` | `+1` entry / `-1` exit / `0` none | EXIT demotes eligibility only; never exit authority. Optional explicit `entry_side` ∈ {LONG, SHORT, NONE} (default NONE) is the only DA side carrier; `+1` alone is never LONG. Producer-side ratification status is frozen in [`OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md`](OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md) (`BOLLINGER_ENTRY_SIDE_DECISION=BLOCKED_AMBIGUITY`). Bollinger governance-doc alignment (still non-authorizing, `entry_side=NONE`) is recorded in [`OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1.md`](OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1.md). |
 | `FILTER_MASK01_V1` | `1` allow / `0` block | eligibility gate |
 | `UNKNOWN_OR_STUB_V1` | n/a | fail-closed |
 

--- a/docs/product/evidence/obl_b05_bollinger_entry_side_doc_alignment_v1_20260717T234000Z/AUDIT.md
+++ b/docs/product/evidence/obl_b05_bollinger_entry_side_doc_alignment_v1_20260717T234000Z/AUDIT.md
@@ -1,0 +1,21 @@
+# AUDIT — Bollinger Entry-Side Doc Alignment v1
+
+## Scope
+
+Active governance SSOT alignment only. No productive `src/` mutation.
+No side activation. Historical evidence preserved.
+
+## Contract statement
+
+| | Before | After |
+|---|---|---|
+| Authorized side | NONE | NONE |
+| `+1` authorizes LONG | false | false |
+| Docs next-step | pending this slice | alignment complete; open authority GO |
+| CP02 in `bollinger.py` | present | present (untouched) |
+
+## Open decision
+
+`BOLLINGER_ENTRY_SIDE_AUTHORITY_PENDING_SEPARATE_OPERATOR_GO`
+
+Options A&#47;B&#47;C and trade-offs: see SSOT `open_decision_brief`.

--- a/docs/product/evidence/obl_b05_bollinger_entry_side_doc_alignment_v1_20260717T234000Z/README.md
+++ b/docs/product/evidence/obl_b05_bollinger_entry_side_doc_alignment_v1_20260717T234000Z/README.md
@@ -1,0 +1,15 @@
+# OBL_B05 Bollinger Entry-Side Doc Alignment v1 — Evidence
+
+Pointer package (non-authorizing governance alignment).
+
+- slice_id: `OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1`
+- base_sha: `236a3ed9d39b0346e00662929e911bb44b2095fc`
+- governance_ref: `docs&#47;governance&#47;OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1.md`
+- ssot_json: `config&#47;governance&#47;obl_b05_bollinger_entry_side_doc_alignment_then_long_decision_v1.json`
+- ENTRY_SIDE_CURRENT: `NONE`
+- CONTRACT_STATE: `CONTRACT_REMAINS_AMBIGUOUS`
+- BOLLINGER_SIDE_ACTIVATED: `false`
+- PRODUCTIVE_SRC_CHANGED: `false`
+- LONG_DECISION_MADE_IN_THIS_SLICE: `false`
+- LIVE_AUTHORIZED: `false`
+- ORDERS_ENABLED: `false`

--- a/docs/product/evidence/obl_b05_bollinger_entry_side_doc_alignment_v1_20260717T234000Z/alignment_ssot.json
+++ b/docs/product/evidence/obl_b05_bollinger_entry_side_doc_alignment_v1_20260717T234000Z/alignment_ssot.json
@@ -1,0 +1,221 @@
+{
+  "ACTIVE_SSOT_ALIGNED": true,
+  "BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_COMPLETE": true,
+  "BOLLINGER_SIDE_ACTIVATED": false,
+  "CONTRACT_STATE": "CONTRACT_REMAINS_AMBIGUOUS",
+  "ENTRY_SIDE_CURRENT": "NONE",
+  "LIVE_AUTHORIZED": false,
+  "LONG_DECISION_MADE_IN_THIS_SLICE": false,
+  "OPEN_DECISION": "BOLLINGER_ENTRY_SIDE_AUTHORITY_PENDING_SEPARATE_OPERATOR_GO",
+  "ORDERS_ENABLED": false,
+  "PRODUCTIVE_SRC_CHANGED": false,
+  "SIDE_ACTIVATED": false,
+  "active_ssot_updates": [
+    {
+      "change": "Mark governance-docs alignment complete; keep BLOCKED_AMBIGUITY; split next activation candidate",
+      "path": "config/governance/obl_b05_entry_exit_producer_side_authority_decision_v1.json"
+    },
+    {
+      "change": "Align next-step wording; fail-closed NONE invariants; open decision pointer",
+      "path": "docs/governance/OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md"
+    },
+    {
+      "change": "Replace pending doc-alignment next step with completed alignment + open authority decision",
+      "path": "docs/governance/OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md"
+    },
+    {
+      "change": "Navigation + explicit fail-closed NONE for Bollinger; no activation",
+      "path": "docs/governance/OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md"
+    },
+    {
+      "change": "Pointer to doc-alignment slice; keep ENTRY\u2260LONG",
+      "path": "docs/governance/STRATEGY_SIGNAL_CANONICAL_CONSUMER_ARCHITECTURE_DECISION_D_V1.md"
+    }
+  ],
+  "base_sha": "236a3ed9d39b0346e00662929e911bb44b2095fc",
+  "before_after_contract_statement": {
+    "after": {
+      "bollinger_entry_authorized_side": "NONE",
+      "cycle_signal_plus_one_authorizes_long": false,
+      "entry_side_none_is_intentional_fail_closed": true,
+      "governance_docs_aligned": true,
+      "long_activation_requires_separate_go": true,
+      "productive_src_doc_cp02_still_present": true
+    },
+    "before": {
+      "bollinger_entry_authorized_side": "NONE",
+      "cycle_signal_plus_one_authorizes_long": false,
+      "entry_side_none_is_intentional_fail_closed": true,
+      "governance_docs_aligned": "partial_next_step_pointed_to_this_slice",
+      "long_activation_requires_separate_go": true,
+      "productive_src_doc_cp02_still_present": true
+    },
+    "delta": "Active governance narratives and machine-readable future-slice pointers now state fail-closed NONE as current law and separate the open LONG-authority GO from this non-authorizing doc alignment."
+  },
+  "findings_matrix": [
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "config/governance/obl_b05_entry_exit_producer_side_authority_decision_v1.json",
+      "statement": "bollinger_entry_side_decision=BLOCKED_AMBIGUITY; KEEP_NONE; activation ineligible",
+      "status": "ALIGNED_UPDATED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "config/governance/obl_b05_bollinger_long_semantic_decision_v1.json",
+      "statement": "BOLLINGER_DECISION=CONTRACT_REMAINS_AMBIGUOUS; entry_side NONE; SIDE_ACTIVATED=false",
+      "status": "ALIGNED_UNCHANGED_AUTHORITY"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md",
+      "statement": "ENTRY never implies LONG; Bollinger BLOCKED_AMBIGUITY; next = open authority GO",
+      "status": "ALIGNED_UPDATED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md",
+      "statement": "Variant C frozen; quantitative baseline; doc-alignment completed pointer",
+      "status": "ALIGNED_UPDATED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md",
+      "statement": "Bollinger entry_side=NONE; +1 is ENTRY only; carrier non-authorizing",
+      "status": "ALIGNED_UPDATED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/STRATEGY_SIGNAL_CANONICAL_CONSUMER_ARCHITECTURE_DECISION_D_V1.md",
+      "statement": "ENTRY_EXIT +1 never LONG; Bollinger BLOCKED_AMBIGUITY referenced",
+      "status": "ALIGNED_UPDATED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/OBL_B05_TREND_FOLLOWING_ENTRY_SIDE_RATIFICATION_V1.md",
+      "statement": "BOLLINGER_SIDE_ACTIVATED=false; TF-only ratification",
+      "status": "ALIGNED_NO_CHANGE_REQUIRED"
+    },
+    {
+      "layer": "ACTIVE_SSOT",
+      "path": "docs/governance/OBL_B05_TREND_FOLLOWING_SIDE_IMPACT_DIAGNOSTIC_V1.md",
+      "statement": "Bollinger control path NONE/DA; SIDE_ACTIVATED=false",
+      "status": "ALIGNED_NO_CHANGE_REQUIRED"
+    },
+    {
+      "layer": "PRODUCTIVE_SOURCE_OUT_OF_SCOPE",
+      "path": "src/strategies/bollinger.py",
+      "statement": "CP02: class doc '1 (long)' vs method '1=entry'; not mutated in this slice",
+      "status": "CONTRADICTION_REMAINS_UNTOUCHED"
+    },
+    {
+      "layer": "PRODUCTIVE_SOURCE_OUT_OF_SCOPE",
+      "path": "src/strategies/base.py",
+      "statement": "CP01: \u00b11 long/short position vocab vs ENTRY_EXIT encoding",
+      "status": "CONTRADICTION_REMAINS_UNTOUCHED"
+    },
+    {
+      "layer": "PRODUCTIVE_SOURCE_OUT_OF_SCOPE",
+      "path": "src/strategies/registry.py",
+      "statement": "CP03: supported_sides=(long,short) capability \u2260 signal authority",
+      "status": "CONTRADICTION_REMAINS_UNTOUCHED"
+    },
+    {
+      "layer": "PRODUCTIVE_SOURCE_OUT_OF_SCOPE",
+      "path": "src/backtest/strategy_signal_suitability_agreement_adapter_v1.py",
+      "statement": "Bollinger entry_side forced NONE; only trend_following ratified LONG",
+      "status": "ALIGNED_BEHAVIOR_DOCUMENTED"
+    },
+    {
+      "layer": "HISTORICAL_EVIDENCE",
+      "path": "docs/product/evidence/obl_b05_bollinger_long_semantic_decision_v1_20260717T231700Z/",
+      "statement": "Frozen quantitative baseline; not rewritten",
+      "status": "PRESERVED_NOT_REINTERPRETED"
+    },
+    {
+      "layer": "HISTORICAL_EVIDENCE",
+      "path": "docs/product/evidence/obl_b05_entry_exit_producer_side_authority_decision_v1_20260717T220147Z/",
+      "statement": "Frozen BLOCKED_AMBIGUITY audit package",
+      "status": "PRESERVED_NOT_REINTERPRETED"
+    },
+    {
+      "layer": "GENERAL_DEV_GUIDE",
+      "path": "docs/STRATEGY_DEV_GUIDE.md",
+      "statement": "Generic '1 (long)' strategy template; not Bollinger authority SSOT",
+      "status": "OUT_OF_SCOPE_GENERIC_VOCAB"
+    },
+    {
+      "layer": "GENERAL_DEV_GUIDE",
+      "path": "docs/DEV_GUIDE_ADD_STRATEGY.md",
+      "statement": "Generic template; not Bollinger authority SSOT",
+      "status": "OUT_OF_SCOPE_GENERIC_VOCAB"
+    }
+  ],
+  "open_decision_brief": {
+    "current_law": {
+      "authorized_entry_side": "NONE",
+      "contract_state": "CONTRACT_REMAINS_AMBIGUOUS",
+      "minus_one_meaning": "EXIT_EVENT_NEVER_SHORT",
+      "plus_one_meaning": "ENTRY_EVENT_ONLY"
+    },
+    "next_go_candidates": [
+      "OBL_B05_BOLLINGER_ENTRY_SIDE_LONG_ACTIVATION_V1",
+      "OBL_B05_BOLLINGER_KEEP_FAIL_CLOSED_NONE_RATIFICATION_V1",
+      "OBL_B05_BOLLINGER_EVENT_ONLY_NO_SIDE_AUTHORITY_RATIFICATION_V1"
+    ],
+    "options": [
+      {
+        "id": "OPTION_A_AUTHORIZE_LONG",
+        "requires": [
+          "separate Operator-GO",
+          "productive bollinger.py doc alignment (src mutation in that later GO)",
+          "adapter producer-scoped ratification analogous to trend_following",
+          "A/B impact diagnostic before composition claims"
+        ],
+        "summary": "After productive producer-doc alignment (CP02) and explicit GO, emit entry_side=LONG only on ENTRY (+1); EXIT/FLAT remain NONE; never SHORT.",
+        "title": "Authorize LONG on Bollinger ENTRY",
+        "trade_offs": [
+          "Unblocks DA for Bollinger ENTRY bars (185 panel baseline)",
+          "Composition likely becomes next dominant blocker (TF precedent)",
+          "Touches productive adapter emission \u2014 highest review bar"
+        ]
+      },
+      {
+        "id": "OPTION_B_KEEP_AMBIGUOUS_FAIL_CLOSED",
+        "requires": [
+          "no productive mutation",
+          "optional continued evidence-only work"
+        ],
+        "summary": "Leave entry_side=NONE; retain BLOCKED_AMBIGUITY; no producer activation.",
+        "title": "Keep contract ambiguous / fail-closed NONE",
+        "trade_offs": [
+          "Safest; preserves fail-closed DA block",
+          "Does not progress Bollinger economic ENTER path",
+          "CP02 remains in productive source docs until a src-touching GO"
+        ]
+      },
+      {
+        "id": "OPTION_C_EXTEND_PRODUCER_CONTRACT_DIFFERENTLY",
+        "requires": [
+          "separate Operator-GO defining the alternate owner",
+          "Decision D / carrier contract amendment if ownership moves"
+        ],
+        "summary": "e.g. ratify EVENT_ONLY_NO_SIDE_AUTHORITY, or introduce a separate side owner outside ENTRY_EXIT carrier.",
+        "title": "Extend producer contract differently",
+        "trade_offs": [
+          "Can resolve ambiguity without implying LONG",
+          "Larger architecture change than TF-style ratification",
+          "Risk of second authority map if not reuse-before-new"
+        ]
+      }
+    ],
+    "question": "What should the next Operator-GO authorize for bollinger_bands ENTRY side?",
+    "recommendation_for_operator": "Do not auto-select. Prefer OPTION_B until a dedicated GO authorizes either producer-doc alignment + LONG (A) or an alternate contract extension (C)."
+  },
+  "parent_slices": [
+    "OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1",
+    "OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_AND_QUANTITATIVE_BASELINE_V1",
+    "OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1"
+  ],
+  "schema_version": "obl_b05_bollinger_entry_side_doc_alignment_then_long_decision.v1",
+  "slice_id": "OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1"
+}

--- a/tests/backtest/test_obl_b05_bollinger_entry_side_doc_alignment_v1.py
+++ b/tests/backtest/test_obl_b05_bollinger_entry_side_doc_alignment_v1.py
@@ -1,0 +1,178 @@
+"""Static contracts for Bollinger entry-side doc alignment + open decision v1.
+
+Non-authorizing: no productive src mutation, no side activation.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SSOT_PATH = (
+    REPO_ROOT
+    / "config"
+    / "governance"
+    / "obl_b05_bollinger_entry_side_doc_alignment_then_long_decision_v1.json"
+)
+GOV_DOC = (
+    REPO_ROOT
+    / "docs"
+    / "governance"
+    / "OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1.md"
+)
+AUTHORITY_SSOT = (
+    REPO_ROOT
+    / "config"
+    / "governance"
+    / "obl_b05_entry_exit_producer_side_authority_decision_v1.json"
+)
+AUTHORITY_DOC = (
+    REPO_ROOT / "docs" / "governance" / "OBL_B05_ENTRY_EXIT_PRODUCER_SIDE_AUTHORITY_DECISION_V1.md"
+)
+SEMANTIC_DOC = REPO_ROOT / "docs" / "governance" / "OBL_B05_BOLLINGER_LONG_SEMANTIC_DECISION_V1.md"
+CARRIER_DOC = (
+    REPO_ROOT / "docs" / "governance" / "OBL_B05_ENTRY_EXIT_OPTIONAL_SIDE_CARRIER_CONTRACT_V1.md"
+)
+DECISION_D = (
+    REPO_ROOT
+    / "docs"
+    / "governance"
+    / "STRATEGY_SIGNAL_CANONICAL_CONSUMER_ARCHITECTURE_DECISION_D_V1.md"
+)
+
+_OPTION_IDS = frozenset(
+    {
+        "OPTION_A_AUTHORIZE_LONG",
+        "OPTION_B_KEEP_AMBIGUOUS_FAIL_CLOSED",
+        "OPTION_C_EXTEND_PRODUCER_CONTRACT_DIFFERENTLY",
+    }
+)
+
+
+def _ssot() -> dict:
+    return json.loads(SSOT_PATH.read_text(encoding="utf-8"))
+
+
+def test_alignment_markers_and_non_authorizing_invariants() -> None:
+    assert SSOT_PATH.is_file()
+    assert GOV_DOC.is_file()
+    data = _ssot()
+    body = GOV_DOC.read_text(encoding="utf-8")
+    assert data["slice_id"] == "OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1"
+    assert data["BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_COMPLETE"] is True
+    assert data["ACTIVE_SSOT_ALIGNED"] is True
+    assert data["ENTRY_SIDE_CURRENT"] == "NONE"
+    assert data["CONTRACT_STATE"] == "CONTRACT_REMAINS_AMBIGUOUS"
+    assert data["BOLLINGER_SIDE_ACTIVATED"] is False
+    assert data["SIDE_ACTIVATED"] is False
+    assert data["PRODUCTIVE_SRC_CHANGED"] is False
+    assert data["LONG_DECISION_MADE_IN_THIS_SLICE"] is False
+    assert data["LIVE_AUTHORIZED"] is False
+    assert data["ORDERS_ENABLED"] is False
+    assert data["OPEN_DECISION"] == "BOLLINGER_ENTRY_SIDE_AUTHORITY_PENDING_SEPARATE_OPERATOR_GO"
+    assert "DOCS_TOKEN_OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1" in body
+    assert "ENTRY_SIDE_CURRENT: NONE" in body
+    assert "LONG_DECISION_MADE_IN_THIS_SLICE: false" in body
+
+
+def test_findings_matrix_separates_active_historical_and_productive() -> None:
+    data = _ssot()
+    matrix = data["findings_matrix"]
+    assert isinstance(matrix, list) and len(matrix) >= 10
+    layers = {row["layer"] for row in matrix}
+    assert "ACTIVE_SSOT" in layers
+    assert "HISTORICAL_EVIDENCE" in layers
+    assert "PRODUCTIVE_SOURCE_OUT_OF_SCOPE" in layers
+    preserved = [r for r in matrix if r["status"] == "PRESERVED_NOT_REINTERPRETED"]
+    assert preserved
+    untouched = [r for r in matrix if r["status"] == "CONTRADICTION_REMAINS_UNTOUCHED"]
+    assert any("bollinger.py" in r["path"] for r in untouched)
+
+
+def test_before_after_contract_and_open_options() -> None:
+    data = _ssot()
+    ba = data["before_after_contract_statement"]
+    assert ba["before"]["bollinger_entry_authorized_side"] == "NONE"
+    assert ba["after"]["bollinger_entry_authorized_side"] == "NONE"
+    assert ba["after"]["cycle_signal_plus_one_authorizes_long"] is False
+    assert ba["after"]["entry_side_none_is_intentional_fail_closed"] is True
+    assert ba["after"]["long_activation_requires_separate_go"] is True
+    options = {opt["id"] for opt in data["open_decision_brief"]["options"]}
+    assert options == _OPTION_IDS
+    assert data["LONG_DECISION_MADE_IN_THIS_SLICE"] is False
+
+
+def test_active_authority_ssot_updated_without_activation() -> None:
+    authority = json.loads(AUTHORITY_SSOT.read_text(encoding="utf-8"))
+    assert authority["bollinger_entry_side_decision"] == "BLOCKED_AMBIGUITY"
+    assert authority["bollinger_side_activated"] is False
+    boll = next(r for r in authority["producers"] if r["producer_id"] == "bollinger_bands")
+    assert boll["governance_docs_aligned_to_fail_closed_none"] is True
+    assert boll["entry_side_current"] == "NONE"
+    assert boll["cycle_signal_plus_one_authorizes_long"] is False
+    assert boll["activation_slice_eligible"] is False
+    assert (
+        boll["open_authority_decision"]
+        == "BOLLINGER_ENTRY_SIDE_AUTHORITY_PENDING_SEPARATE_OPERATOR_GO"
+    )
+    future = {row["slice_id_candidate"]: row for row in authority["future_activation_slices"]}
+    assert (
+        future["OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1"]["status"]
+        == "COMPLETE_NON_AUTHORIZING"
+    )
+    assert (
+        future["OBL_B05_BOLLINGER_ENTRY_SIDE_LONG_ACTIVATION_V1"]["status"]
+        == "PENDING_SEPARATE_OPERATOR_GO"
+    )
+
+
+def test_active_narratives_point_to_alignment_and_fail_closed_law() -> None:
+    for path in (AUTHORITY_DOC, SEMANTIC_DOC, CARRIER_DOC, DECISION_D, GOV_DOC):
+        body = path.read_text(encoding="utf-8")
+        assert "OBL_B05_BOLLINGER_ENTRY_SIDE_DOC_ALIGNMENT_THEN_LONG_DECISION_V1" in body
+    authority_body = AUTHORITY_DOC.read_text(encoding="utf-8")
+    assert "entry_side=NONE" in authority_body or "entry_side` bleibt `NONE`" in authority_body
+    assert "cycle_signal_value=+1" in authority_body
+    semantic_body = SEMANTIC_DOC.read_text(encoding="utf-8")
+    assert "BOLLINGER_ENTRY_SIDE_AUTHORITY_PENDING_SEPARATE_OPERATOR_GO" in semantic_body
+
+
+def test_diff_contains_no_productive_src_paths() -> None:
+    """Guard: this slice must not change productive src/ (vs origin/main when available)."""
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        proc = subprocess.run(
+            ["git", "diff", "--name-only", "origin/main"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    files = [ln.strip() for ln in proc.stdout.splitlines() if ln.strip()]
+    # Also include unstaged/staged working tree against origin/main for local runs.
+    proc2 = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    files.extend(ln.strip() for ln in proc2.stdout.splitlines() if ln.strip())
+    proc3 = subprocess.run(
+        ["git", "diff", "--name-only", "--cached", "origin/main"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    files.extend(ln.strip() for ln in proc3.stdout.splitlines() if ln.strip())
+    src_hits = sorted({f for f in files if f.startswith("src/")})
+    assert src_hits == [], f"unexpected productive src changes: {src_hits}"


### PR DESCRIPTION
## Summary
- Align active Bollinger ENTRY-side governance SSOTs to fail-closed `entry_side=NONE` (`CONTRACT_REMAINS_AMBIGUOUS`).
- Publish findings matrix (active vs historical vs productive-out-of-scope) and open authority options A/B/C without choosing LONG.
- No productive `src/` changes; no side activation; historical evidence preserved.

## Test plan
- [x] `tests/backtest/test_obl_b05_bollinger_entry_side_doc_alignment_v1.py`
- [x] parent authority + semantic decision contracts
- [x] docs-reference-targets / ruff / PR_BOUNDED timing (~38s)
- [ ] Required GitHub checks green


Made with [Cursor](https://cursor.com)