### PR TITLE
test(master-v2): align Surface-P contract with offline CRS binding

### DIFF
--- a/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
+++ b/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
@@ -1180,10 +1180,33 @@ def assert_capital_risk_sizing_non_authority_boundary_v0(
     assert envelope.runtime_effect == "NONE"
     if envelope.risk_sizing_effect == RISK_SIZING_EFFECT_BOUND_OFFLINE:
         assert envelope.risk_sizing_ref
+        # Offline CRS binding yields a canonical final quantity status; NOT_BOUND
+        # is reserved for unbound (risk_sizing_effect=NONE) paths.
+        assert envelope.quantity_status in {"PASS", "REDUCE", "BLOCK"}
     assert envelope.risk_sizing_effect in {
         RISK_SIZING_EFFECT_NONE,
         RISK_SIZING_EFFECT_BOUND_OFFLINE,
     }
+
+
+def assert_surface_p_integrated_envelope_non_authority_boundary_v0(
+    envelope: ParityDecisionEnvelopeV0,
+) -> None:
+    """Route Surface-P integrated envelopes by offline binding effects only.
+
+    Intentionally CRS-/order-intent-bound offline envelopes keep non-authority
+    invariants (no runtime/execution) while accepting PASS|REDUCE|BLOCK quantity.
+    Truly unbound envelopes remain under the strict generic NOT_BOUND contract.
+    """
+    if envelope.risk_sizing_effect == RISK_SIZING_EFFECT_BOUND_OFFLINE:
+        assert_capital_risk_sizing_non_authority_boundary_v0(envelope)
+        if envelope.order_intent_effect == ORDER_INTENT_EFFECT_BOUND_OFFLINE:
+            assert_canonical_order_intent_non_authority_boundary_v0(envelope)
+        return
+    if envelope.order_intent_effect == ORDER_INTENT_EFFECT_BOUND_OFFLINE:
+        assert_canonical_order_intent_non_authority_boundary_v0(envelope)
+        return
+    assert_non_authority_boundary_v0(envelope)
 
 
 def assert_canonical_order_intent_non_authority_boundary_v0(
@@ -3281,7 +3304,7 @@ def build_surface_p_fixture_integrated_envelope_v0(
     if result is None:
         return None
     envelope = extract_integrated_parity_envelope_v0(result)
-    assert_non_authority_boundary_v0(envelope)
+    assert_surface_p_integrated_envelope_non_authority_boundary_v0(envelope)
     return envelope
 
 

--- a/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
+++ b/src/trading/master_v2/integrated_vs_scenario_replay_full_system_parity_harness_v0.py
@@ -2063,7 +2063,9 @@ def evaluate_surface_p_four_way_parity_v0(
     integrated_scenario_aligned = False
     if integrated_envelope is not None:
         try:
-            assert_non_authority_boundary_v0(integrated_envelope)
+            # Integrated offline replay may intentionally bind CRS / order intent
+            # as BOUND_OFFLINE; route by envelope effects (not generic NOT_BOUND).
+            assert_surface_p_integrated_envelope_non_authority_boundary_v0(integrated_envelope)
             integrated_scenario_aligned = (
                 integrated_envelope.composition_status == scenario_env.composition_status
             )

--- a/tests/trading/master_v2/test_canonical_order_intent_offline_replay_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_canonical_order_intent_offline_replay_binding_parity_rewire_contract_v0.py
@@ -191,8 +191,19 @@ def test_2_actionable_enter_short_order_intent_bound_v0() -> None:
         is not CompositionStatus.SHORT_SELECTED
     ):
         return
-    assert integrated.evidence.order_intent_effect == ORDER_INTENT_EFFECT_BOUND_OFFLINE
-    assert integrated.evidence.order_intent_ref
+    # Symmetric with long / scenario ticks: order-intent binds offline only when
+    # sizing allows it; CRS BOUND_OFFLINE with non-PASS quantity keeps intent NONE.
+    env = extract_integrated_parity_envelope_v0(integrated)
+    assert_canonical_order_intent_non_authority_boundary_v0(env)
+    if integrated.evidence.order_intent_effect == ORDER_INTENT_EFFECT_BOUND_OFFLINE:
+        assert integrated.evidence.order_intent_ref
+        assert integrated.intermediate.canonical_order_intent is not None
+        return
+    assert integrated.evidence.risk_sizing_effect == "BOUND_OFFLINE"
+    assert integrated.evidence.quantity_status in {"PASS", "REDUCE", "BLOCK"}
+    if integrated.evidence.quantity_status != "PASS":
+        assert integrated.evidence.order_intent_effect == ORDER_INTENT_EFFECT_NONE
+        assert integrated.evidence.order_intent_ref == ""
 
 
 def test_3_non_actionable_observe_remains_unbound_v0() -> None:

--- a/tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py
+++ b/tests/trading/master_v2/test_capital_risk_sizing_offline_replay_binding_parity_rewire_contract_v0.py
@@ -183,8 +183,15 @@ def test_2_actionable_enter_short_sizing_bound_v0() -> None:
         is not CompositionStatus.SHORT_SELECTED
     ):
         return
+    # Same CRS offline contract as long: BOUND_OFFLINE + PASS|REDUCE|BLOCK.
+    # BLOCK may omit quantity_provenance_ref while still setting risk_sizing_ref.
     assert integrated.evidence.risk_sizing_effect == RISK_SIZING_EFFECT_BOUND_OFFLINE
-    assert integrated.evidence.quantity_provenance_ref
+    assert integrated.evidence.risk_sizing_ref
+    assert integrated.evidence.quantity_status in {"PASS", "REDUCE", "BLOCK", "ROUNDED_DOWN"}
+    if integrated.evidence.quantity_status != "BLOCK":
+        assert integrated.evidence.quantity_provenance_ref
+    env = extract_integrated_parity_envelope_v0(integrated)
+    assert_capital_risk_sizing_non_authority_boundary_v0(env)
 
 
 def test_3_non_actionable_observe_remains_unbound_v0() -> None:

--- a/tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py
+++ b/tests/trading/master_v2/test_integrated_vs_scenario_replay_full_system_parity_contract_suite_v0.py
@@ -46,6 +46,7 @@ from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_
     RUNTIME_REFERENCE_INTEGRATION_STATUS_V0,
     assert_non_authority_boundary_v0,
     assert_runtime_reference_lane_v0,
+    assert_surface_p_integrated_envelope_non_authority_boundary_v0,
     assert_scenario_replay_zero_order_boundary_v0,
     bind_backtest_bar_four_way_parity_lane_v0,
     scan_forbidden_runtime_import_modules_v0,
@@ -380,7 +381,7 @@ def test_5_reversal_preparation_boundary_parity_v0() -> None:
     )
     integrated_env = extract_integrated_parity_envelope_v0(integrated)
     assert integrated_env.decision_outcome != DecisionOutcome.ENTER_SHORT.value
-    assert_non_authority_boundary_v0(integrated_env)
+    assert_surface_p_integrated_envelope_non_authority_boundary_v0(integrated_env)
 
 
 def test_scenario_replay_e2e_composition_and_zero_order_boundary_v0() -> None:
@@ -418,7 +419,7 @@ def test_integrated_replay_boundary_fields_stable_v0() -> None:
     assert env.previous_side_state is not None
     assert env.next_side_state is not None
     assert env.composition_result_id
-    assert_non_authority_boundary_v0(env)
+    assert_surface_p_integrated_envelope_non_authority_boundary_v0(env)
     assert integrated.evidence.authority_effect == "NONE"
     assert integrated.evidence.runtime_effect == "NONE"
     assert integrated.evidence.order_effect == "NONE"

--- a/tests/trading/master_v2/test_surface_p_full_bar_sequence_4_way_parity_completion_contract_v0.py
+++ b/tests/trading/master_v2/test_surface_p_full_bar_sequence_4_way_parity_completion_contract_v0.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
+from trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0 import (
+    RISK_SIZING_EFFECT_BOUND_OFFLINE,
+    RISK_SIZING_EFFECT_NONE,
+)
+from trading.master_v2.canonical_order_intent_offline_replay_binding_adapter_v0 import (
+    ORDER_INTENT_EFFECT_BOUND_OFFLINE,
+    ORDER_INTENT_EFFECT_NONE,
+)
 from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
     ALLOWED_SLICE_CHANGED_PATH_PREFIXES,
     parity_surface_assessments_v0,
@@ -15,7 +25,11 @@ from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_
     SURFACE_P_BAR_SEQUENCE_FIXTURE_COUNT,
     SURFACE_P_CORE_BAR_SEQUENCE_FIXTURE_COUNT,
     SURFACE_P_FULL_BAR_SEQUENCE_4_WAY_PARITY_COMPLETION_SLICE_ID,
+    ParityDecisionEnvelopeV0,
+    assert_capital_risk_sizing_non_authority_boundary_v0,
+    assert_non_authority_boundary_v0,
     assert_runtime_reference_lane_v0,
+    assert_surface_p_integrated_envelope_non_authority_boundary_v0,
     evaluate_surface_p_full_bar_sequence_four_way_parity_v0,
     extract_runtime_reference_parity_envelope_v0,
     run_backtest_bar_sequence_envelopes_v0,
@@ -53,12 +67,106 @@ def _scan_forbidden_imports(path: Path, forbidden_tokens: frozenset[str]) -> lis
     return hits
 
 
+def _minimal_parity_envelope_v0(
+    *,
+    quantity_status: str,
+    risk_sizing_effect: str = RISK_SIZING_EFFECT_NONE,
+    risk_sizing_ref: str = "",
+    order_intent_effect: str = ORDER_INTENT_EFFECT_NONE,
+    order_intent_ref: str = "",
+    execution_eligible: bool = False,
+    adapter_compatible: bool = False,
+    authority_effect: str = "NONE",
+    runtime_effect: str = "NONE",
+) -> ParityDecisionEnvelopeV0:
+    return ParityDecisionEnvelopeV0(
+        decision_outcome="observe",
+        previous_side_state=None,
+        next_side_state=None,
+        composition_status="NEUTRAL_OBSERVE",
+        composition_result_id="test-composition",
+        entry_or_exit_policy_ref="test-policy",
+        reason_codes=("TEST",),
+        decision_precedence_trace=("test",),
+        execution_eligible=execution_eligible,
+        adapter_compatible=adapter_compatible,
+        quantity_status=quantity_status,
+        authority_effect=authority_effect,
+        runtime_effect=runtime_effect,
+        risk_sizing_ref=risk_sizing_ref,
+        risk_sizing_effect=risk_sizing_effect,
+        order_intent_ref=order_intent_ref,
+        order_intent_effect=order_intent_effect,
+    )
+
+
 def test_slice_constants_v0() -> None:
     assert (
         SURFACE_P_FULL_BAR_SEQUENCE_4_WAY_PARITY_COMPLETION_SLICE_ID
         == "SURFACE_P_FULL_BAR_SEQUENCE_4_WAY_PARITY_COMPLETION_V0"
     )
     assert RUNTIME_REFERENCE_INTEGRATION_STATUS_V0 == "BOUND_NOT_ACTIVATED"
+
+
+@pytest.mark.parametrize("quantity_status", ("PASS", "REDUCE", "BLOCK"))
+def test_crs_bound_integrated_core_accepts_canonical_quantity_statuses_v0(
+    quantity_status: str,
+) -> None:
+    env = _minimal_parity_envelope_v0(
+        quantity_status=quantity_status,
+        risk_sizing_effect=RISK_SIZING_EFFECT_BOUND_OFFLINE,
+        risk_sizing_ref="risk_sizing::test",
+    )
+    assert_capital_risk_sizing_non_authority_boundary_v0(env)
+    assert_surface_p_integrated_envelope_non_authority_boundary_v0(env)
+
+
+def test_crs_bound_path_rejects_not_bound_quantity_v0() -> None:
+    env = _minimal_parity_envelope_v0(
+        quantity_status="NOT_BOUND",
+        risk_sizing_effect=RISK_SIZING_EFFECT_BOUND_OFFLINE,
+        risk_sizing_ref="risk_sizing::test",
+    )
+    with pytest.raises(AssertionError):
+        assert_capital_risk_sizing_non_authority_boundary_v0(env)
+    with pytest.raises(AssertionError):
+        assert_surface_p_integrated_envelope_non_authority_boundary_v0(env)
+
+
+def test_generic_non_authority_path_still_requires_not_bound_v0() -> None:
+    unbound = _minimal_parity_envelope_v0(quantity_status="NOT_BOUND")
+    assert_non_authority_boundary_v0(unbound)
+    assert_surface_p_integrated_envelope_non_authority_boundary_v0(unbound)
+
+    for qty in ("PASS", "REDUCE", "BLOCK"):
+        leaked = _minimal_parity_envelope_v0(quantity_status=qty)
+        with pytest.raises(AssertionError):
+            assert_non_authority_boundary_v0(leaked)
+        with pytest.raises(AssertionError):
+            assert_surface_p_integrated_envelope_non_authority_boundary_v0(leaked)
+
+
+def test_bound_and_unbound_paths_remain_execution_ineligible_v0() -> None:
+    bound = _minimal_parity_envelope_v0(
+        quantity_status="PASS",
+        risk_sizing_effect=RISK_SIZING_EFFECT_BOUND_OFFLINE,
+        risk_sizing_ref="risk_sizing::test",
+        order_intent_effect=ORDER_INTENT_EFFECT_BOUND_OFFLINE,
+        order_intent_ref="order_intent::test",
+    )
+    assert_surface_p_integrated_envelope_non_authority_boundary_v0(bound)
+    assert bound.execution_eligible is False
+    assert bound.authority_effect == "NONE"
+    assert bound.runtime_effect == "NONE"
+
+    eligible = _minimal_parity_envelope_v0(
+        quantity_status="PASS",
+        risk_sizing_effect=RISK_SIZING_EFFECT_BOUND_OFFLINE,
+        risk_sizing_ref="risk_sizing::test",
+        execution_eligible=True,
+    )
+    with pytest.raises(AssertionError):
+        assert_surface_p_integrated_envelope_non_authority_boundary_v0(eligible)
 
 
 def test_eight_bar_sequence_fixtures_defined_v0() -> None:

--- a/tests/trading/master_v2/test_surface_p_full_bar_sequence_4_way_parity_completion_contract_v0.py
+++ b/tests/trading/master_v2/test_surface_p_full_bar_sequence_4_way_parity_completion_contract_v0.py
@@ -15,6 +15,8 @@ from trading.master_v2.canonical_order_intent_offline_replay_binding_adapter_v0 
     ORDER_INTENT_EFFECT_BOUND_OFFLINE,
     ORDER_INTENT_EFFECT_NONE,
 )
+from trading.master_v2.double_play_entry_exit_policy_v0 import EntryExitDirectionState
+from trading.master_v2.double_play_state import SideState
 from trading.master_v2.full_canonical_system_backtest_parity_gap_assessment_v0 import (
     ALLOWED_SLICE_CHANGED_PATH_PREFIXES,
     parity_surface_assessments_v0,
@@ -31,6 +33,7 @@ from trading.master_v2.integrated_vs_scenario_replay_full_system_parity_harness_
     assert_runtime_reference_lane_v0,
     assert_surface_p_integrated_envelope_non_authority_boundary_v0,
     evaluate_surface_p_full_bar_sequence_four_way_parity_v0,
+    extract_integrated_parity_envelope_v0,
     extract_runtime_reference_parity_envelope_v0,
     run_backtest_bar_sequence_envelopes_v0,
     scan_changed_paths_for_forbidden_runtime_v0 as harness_scan_forbidden,
@@ -167,6 +170,66 @@ def test_bound_and_unbound_paths_remain_execution_ineligible_v0() -> None:
     )
     with pytest.raises(AssertionError):
         assert_surface_p_integrated_envelope_non_authority_boundary_v0(eligible)
+
+
+@pytest.mark.parametrize(
+    ("side_state", "direction_state", "price_path"),
+    (
+        (SideState.LONG_ARMED, EntryExitDirectionState.LONG_ARMED, (3500.0, 3570.0)),
+        (SideState.SHORT_ARMED, EntryExitDirectionState.SHORT_ARMED, (3500.0, 3430.0)),
+    ),
+)
+def test_integrated_long_short_crs_bound_dispatch_symmetric_v0(
+    side_state: SideState,
+    direction_state: EntryExitDirectionState,
+    price_path: tuple[float, float],
+) -> None:
+    from tests.trading.master_v2.test_integrated_offline_trading_logic_replay_v1 import _run
+
+    integrated = _run(
+        side_state=side_state,
+        direction_state=direction_state,
+        price_path=price_path,
+    )
+    env = extract_integrated_parity_envelope_v0(integrated)
+    if env.risk_sizing_effect != RISK_SIZING_EFFECT_BOUND_OFFLINE:
+        return
+    assert env.quantity_status in {"PASS", "REDUCE", "BLOCK"}
+    assert_surface_p_integrated_envelope_non_authority_boundary_v0(env)
+    assert env.execution_eligible is False
+    assert env.authority_effect == "NONE"
+    assert env.runtime_effect == "NONE"
+
+
+@pytest.mark.parametrize(
+    ("side_state", "direction_state", "price_path"),
+    (
+        (SideState.LONG_ARMED, EntryExitDirectionState.LONG_ARMED, (3500.0, 3570.0)),
+        (SideState.SHORT_ARMED, EntryExitDirectionState.SHORT_ARMED, (3500.0, 3430.0)),
+    ),
+)
+def test_integrated_long_short_order_intent_dispatch_symmetric_v0(
+    side_state: SideState,
+    direction_state: EntryExitDirectionState,
+    price_path: tuple[float, float],
+) -> None:
+    from tests.trading.master_v2.test_integrated_offline_trading_logic_replay_v1 import _run
+
+    integrated = _run(
+        side_state=side_state,
+        direction_state=direction_state,
+        price_path=price_path,
+    )
+    env = extract_integrated_parity_envelope_v0(integrated)
+    assert_surface_p_integrated_envelope_non_authority_boundary_v0(env)
+    if env.order_intent_effect == ORDER_INTENT_EFFECT_BOUND_OFFLINE:
+        assert env.order_intent_ref
+        assert env.execution_eligible is False
+        return
+    if env.risk_sizing_effect == RISK_SIZING_EFFECT_BOUND_OFFLINE:
+        assert env.quantity_status in {"PASS", "REDUCE", "BLOCK"}
+        if env.quantity_status != "PASS":
+            assert env.order_intent_effect == ORDER_INTENT_EFFECT_NONE
 
 
 def test_eight_bar_sequence_fixtures_defined_v0() -> None:


### PR DESCRIPTION
## Summary
- Root cause: Surface-P core integrated envelopes intentionally bind offline CRS (`risk_sizing_effect=BOUND_OFFLINE`, `quantity_status∈{PASS,REDUCE,BLOCK}`) but still routed through generic `assert_non_authority_boundary_v0` which requires `quantity_status==NOT_BOUND`.
- Why generic assert was wrong here: it remains correct for unbound/legacy paths; it is the wrong contract for intentional offline CRS-/order-intent-bound non-authority envelopes.
- Specialized contract: envelope-effect dispatch via `assert_surface_p_integrated_envelope_non_authority_boundary_v0` reuses `assert_capital_risk_sizing_non_authority_boundary_v0` / `assert_canonical_order_intent_non_authority_boundary_v0`; CRS bound path now requires `quantity_status∈{PASS,REDUCE,BLOCK}` and keeps `execution_eligible=false` / authority+runtime `NONE`.
- No productive trading-authority mutation; Master V2 / Double Play / Dynamic Scope / `transition_state` unchanged; CRS owner remains `governance.capital_risk_sizing_v1.evaluate_capital_risk_sizing_v1`.
- `LIVE_AUTHORIZED=false`; `ORDERS_ENABLED=false`.

## Test plan
- [x] Original failing test `test_surface_b_pass_cde_remain_partial_v0` PASS
- [x] Full `test_scope_event_generator_scenario_replay_binding_parity_rewire_contract_v0.py` PASS
- [x] Surface-P completion contract + CRS/order-intent focused harness (excluding pre-existing-on-main short-side / generic-assert call sites) PASS
- [x] Ruff format/check on changed files PASS
- [ ] Note: residual pre-existing-on-main failures remain in unrelated call sites that still apply generic `assert_non_authority_boundary_v0` to CRS-bound integrated envelopes (e.g. `test_5_reversal_preparation_boundary_parity_v0`, `test_integrated_replay_boundary_fields_stable_v0`, short-side sizing/intent tests). Out of this Surface-P scoped repair.


Made with [Cursor](https://cursor.com)