### PR TITLE
fix(auth-005): El Karoui/Armstrong non-authority research classification

### DIFF
--- a/config/strategy_tiering.toml
+++ b/config/strategy_tiering.toml
@@ -137,10 +137,11 @@ tags = ["cycles", "timing", "ecm", "long-term"]
 recommended_config_id = "armstrong_cycle_v0_research"
 allow_live = false
 notes = """
-Armstrong ECM-Zyklus-Strategie (Research-Only).
+Armstrong ECM-Zyklus-Strategie (Research-Only / Non-Authority).
+PRIMARY_ROLE=CYCLE_INFORMATION · AUTH-005.
 Basiert auf Martin Armstrongs Economic Confidence Model (8.6-Jahre-Zyklus).
 ⚠️ NICHT FÜR LIVE-TRADING - Nur für Research/Backtests.
-Deployment erst nach Phase-X-Freigabe möglich.
+Keine Master-V2-/Double-Play-/Scope-/Agreement-/Risk-/Sizing-Authority.
 """
 
 [strategy.el_karoui_vol_model]
@@ -153,10 +154,11 @@ tags = ["volatility", "stochastic-vol", "risk-model", "options"]
 recommended_config_id = "el_karoui_vol_v0_research"
 allow_live = false
 notes = """
-El Karoui Stochastisches Volatilitätsmodell (Research-Only).
-Basiert auf Nicole El Karouis Arbeiten zu stoch. Vol-Modellen.
+El Karoui Vol-Regime-Modell (Research-Only / Non-Authority).
+PRIMARY_ROLE=REGIME_INFORMATION · AUTH-005.
+Pragmatische rolling/EWM-Vol (nicht BSDE-Publikationsmath).
 ⚠️ NICHT FÜR LIVE-TRADING - Nur für Research/Backtests.
-Deployment erst nach Phase-X-Freigabe möglich.
+Keine Master-V2-/Double-Play-/Scope-/Agreement-/Risk-/Sizing-Authority.
 """
 
 [strategy.ehlers_cycle_filter]

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/README.md
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/README.md
@@ -6,7 +6,7 @@ Registry/tiering metadata triangle closed: both strategies are consistent Resear
 - `src/strategies/registry.py` — AUTH-005 Spec alignment
 - `config/strategy_tiering.toml` — clarifying notes
 - Docstrings on armstrong / el_karoui / ecm / combi experiment
-- Contract tests under `tests/strategies/test_auth_005_*`
+- Contract tests under `tests&#47;strategies&#47;test_auth_005_*`
 
 ## Unchanged
 - Rolling-vol math, 3141d cycle math, Master V2, Double Play, Risk/Sizing/Execution owners

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/README.md
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/README.md
@@ -1,0 +1,12 @@
+# AUTH-005 El Karoui / Armstrong Non-Authority Classification v1
+
+Registry/tiering metadata triangle closed: both strategies are consistent Research Information Sources (Non-Authority), not live/execution/canonical-chain authorities.
+
+## Changed (productive metadata only)
+- `src/strategies/registry.py` — AUTH-005 Spec alignment
+- `config/strategy_tiering.toml` — clarifying notes
+- Docstrings on armstrong / el_karoui / ecm / combi experiment
+- Contract tests under `tests/strategies/test_auth_005_*`
+
+## Unchanged
+- Rolling-vol math, 3141d cycle math, Master V2, Double Play, Risk/Sizing/Execution owners

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/changed_files.txt
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/changed_files.txt
@@ -1,0 +1,8 @@
+src/strategies/registry.py
+src/strategies/armstrong/armstrong_cycle_strategy.py
+src/strategies/el_karoui/el_karoui_vol_model_strategy.py
+src/strategies/ecm.py
+src/experiments/armstrong_elkaroui_combi_experiment.py
+config/strategy_tiering.toml
+tests/strategies/test_auth_005_el_karoui_armstrong_non_authority_classification_v1.py
+docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/competing_authority_resolution.md
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/competing_authority_resolution.md
@@ -1,0 +1,30 @@
+# Competing Authority Resolution (before=2 → after=0)
+
+## Hit 1 — AUTH-005 Registry live-readiness triangle
+
+| Field | Value |
+|---|---|
+| File | `src/strategies/registry.py` |
+| Symbols | `StrategySpec` entries `armstrong_cycle`, `el_karoui_vol_model` |
+| Before | `is_live_ready=True`, `tier="production"`, envs include `paper`/`live` |
+| Semantic | Contradicted class `IS_LIVE_READY=False` + `config/strategy_tiering.toml` `allow_live=false` |
+| Callers | `create_strategy_from_config`, registry snapshot / capability tags |
+| Reachability | Statically registered; live gate used Spec `is_live_ready` |
+| Authority claim | Theoretical Execution Eligibility / live activation via registry metadata |
+| Why COMPETING | Dual truth: registry said live/production, class/tiering said R&D |
+| Resolution | Registry corrected to `is_live_ready=False`, `tier=r_and_d`, envs=`offline_backtest,research` |
+| Extra guard needed? | No — existing create_strategy gates + tiering R&D blocks suffice |
+
+## Hit 2 — ECM vs Armstrong dual identity (AUTH-001/004 surface)
+
+| Field | Value |
+|---|---|
+| Files | `src/strategies/ecm.py` (`ecm_cycle`) vs `src/strategies/armstrong/*` (`armstrong_cycle`) |
+| Semantic | Two named surfaces for Armstrong/ECM cycle ideas |
+| Authority claim | **None** for Master V2 system-state after clarification |
+| Why previously counted | Identity dual can be misread as competing producers |
+| Resolution | Docstring reclassification: dual naming = NON_COMPETING_IDENTITY_DUAL_NON_AUTHORITY; OBL_B05 KEEP_NONE for `ecm_cycle` side authority |
+| Extra guard needed? | No new guard; leave functional math unchanged |
+
+## After
+`COMPETING_AUTHORITY_COUNT_AFTER=0` for El-Karoui/Armstrong scope (no MV2 Direction/Scope/Switch/Agreement/Risk/Sizing/Execution competing authority remains).

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/competing_authority_resolution.md
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/competing_authority_resolution.md
@@ -19,7 +19,7 @@
 
 | Field | Value |
 |---|---|
-| Files | `src/strategies/ecm.py` (`ecm_cycle`) vs `src/strategies/armstrong/*` (`armstrong_cycle`) |
+| Files | `src/strategies/ecm.py` (`ecm_cycle`) vs `src&#47;strategies&#47;armstrong&#47;*` (`armstrong_cycle`) |
 | Semantic | Two named surfaces for Armstrong/ECM cycle ideas |
 | Authority claim | **None** for Master V2 system-state after clarification |
 | Why previously counted | Identity dual can be misread as competing producers |

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/legacy_productive_path_resolution.md
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/legacy_productive_path_resolution.md
@@ -1,0 +1,15 @@
+# Legacy Productive Path Resolution (before=1 → after=0)
+
+| Field | Value |
+|---|---|
+| File | `src/strategies/ecm.py` |
+| Function | `generate_signals` / `calculate_ecm_phase` |
+| Loader key | `ecm_cycle` (functional-only; no OOP `StrategySpec`) |
+| Callers | `load_strategy("ecm_cycle")` offline/demo/scripts; not Master V2 imports |
+| Reachability | Available via functional loader; not Spec-gated live-ready |
+| Effect | Can emit ENTRY/EXIT events offline; **not** ratified side authority (OBL_B05 KEEP_NONE) |
+| Relation | Armstrong/ECM CYCLE_INFORMATION family; parallel to OOP `armstrong_cycle` |
+| Treatment | `LEAVE_UNCHANGED_WITH_EVIDENCE` + clarifying Non-Authority docstring |
+| Reclassification | `LEGACY_FUNCTIONAL_NON_AUTHORITY_FAIL_CLOSED` (not productive MV2 authority) |
+
+`LEGACY_PRODUCTIVE_COUNT_AFTER=0` (no remaining productive-authority legacy path in this scope).

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/non_authority_contract.md
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/non_authority_contract.md
@@ -5,14 +5,16 @@
 - PRIMARY_ROLE=REGIME_INFORMATION
 - AUTHORITY=NON_AUTHORITY
 - CANONICAL_BOUND=false · LIVE_READY=false · EXECUTION_ELIGIBLE=false
-- Owner: `src/strategies/el_karoui/el_karoui_vol_model_strategy.py::ElKarouiVolatilityStrategy`
+- Owner file: `src/strategies/el_karoui/el_karoui_vol_model_strategy.py`
+- Owner symbol: `ElKarouiVolatilityStrategy`
 
 ## ARMSTRONG
 - CATEGORY=RESEARCH_INFORMATION_SOURCE
 - PRIMARY_ROLE=CYCLE_INFORMATION
 - AUTHORITY=NON_AUTHORITY
 - CANONICAL_BOUND=false · LIVE_READY=false · EXECUTION_ELIGIBLE=false
-- Owner: `src/strategies/armstrong/armstrong_cycle_strategy.py::ArmstrongCycleStrategy`
+- Owner file: `src/strategies/armstrong/armstrong_cycle_strategy.py`
+- Owner symbol: `ArmstrongCycleStrategy`
 
 ## COMBINED_EXPERIMENT
 - CATEGORY=RESEARCH_EXPERIMENT
@@ -20,7 +22,8 @@
 - CANONICAL_BOUND=false · LIVE_READY=false · EXECUTION_ELIGIBLE=false
 - MAY_PRODUCE_RESEARCH_METRICS=true
 - MAY_NOT_PRODUCE_CANONICAL_TRADE_INTENT=true
-- Owner: `src/experiments/armstrong_elkaroui_combi_experiment.py::run_armstrong_elkaroui_combi_experiment`
+- Owner file: `src/experiments/armstrong_elkaroui_combi_experiment.py`
+- Owner symbol: `run_armstrong_elkaroui_combi_experiment`
 
 ## Contract tests
 `tests/strategies/test_auth_005_el_karoui_armstrong_non_authority_classification_v1.py`

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/non_authority_contract.md
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/non_authority_contract.md
@@ -1,0 +1,26 @@
+# Non-Authority Contract (AUTH-005)
+
+## EL_KAROUI
+- CATEGORY=RESEARCH_INFORMATION_SOURCE
+- PRIMARY_ROLE=REGIME_INFORMATION
+- AUTHORITY=NON_AUTHORITY
+- CANONICAL_BOUND=false · LIVE_READY=false · EXECUTION_ELIGIBLE=false
+- Owner: `src/strategies/el_karoui/el_karoui_vol_model_strategy.py::ElKarouiVolatilityStrategy`
+
+## ARMSTRONG
+- CATEGORY=RESEARCH_INFORMATION_SOURCE
+- PRIMARY_ROLE=CYCLE_INFORMATION
+- AUTHORITY=NON_AUTHORITY
+- CANONICAL_BOUND=false · LIVE_READY=false · EXECUTION_ELIGIBLE=false
+- Owner: `src/strategies/armstrong/armstrong_cycle_strategy.py::ArmstrongCycleStrategy`
+
+## COMBINED_EXPERIMENT
+- CATEGORY=RESEARCH_EXPERIMENT
+- AUTHORITY=NON_AUTHORITY
+- CANONICAL_BOUND=false · LIVE_READY=false · EXECUTION_ELIGIBLE=false
+- MAY_PRODUCE_RESEARCH_METRICS=true
+- MAY_NOT_PRODUCE_CANONICAL_TRADE_INTENT=true
+- Owner: `src/experiments/armstrong_elkaroui_combi_experiment.py::run_armstrong_elkaroui_combi_experiment`
+
+## Contract tests
+`tests/strategies/test_auth_005_el_karoui_armstrong_non_authority_classification_v1.py`

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/post_change_authority_scan.md
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/post_change_authority_scan.md
@@ -1,0 +1,19 @@
+# Post-Change Authority Scan
+
+| Check | Result |
+|---|---|
+| Direct LONG/SHORT MV2 authority | Not found for El/Armstrong |
+| Dynamic Scope authority | Not found |
+| Switch / transition_state authority | Not found |
+| Agreement override | Not found |
+| Risk/Sizing MV2 authority | Not found (model-local multipliers remain research-local) |
+| Execution eligibility via registry | `is_live_ready=False`; no `live_ready` capability tag |
+| Trade Intent into execution kernel | Not bound |
+| Registry/tiering drift AUTH-005 | **Resolved** |
+| COMPETING_AUTHORITY_COUNT | **0** |
+| LEGACY_PRODUCTIVE_COUNT | **0** (ecm reclassified fail-closed non-authority) |
+| LIVE_AUTHORIZED | false (unchanged) |
+| ORDERS_ENABLED | false (unchanged) |
+| Rolling-vol logic changed | false |
+| 3141d logic changed | false |
+| Master V2 / Double Play code changed | false |

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/preexisting_worktree_classification.md
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/preexisting_worktree_classification.md
@@ -2,9 +2,9 @@
 
 | Path | Classification |
 |---|---|
-| `docs/evidence/el_karoui_armstrong_system_integration_audit_v1/` | EXPECTED_PRIOR_EVIDENCE |
-| `docs/evidence/obl_b05_bollinger_entry_side_authority_operator_go_selection_v1/` | EXPECTED_PRIOR_EVIDENCE |
-| `docs/evidence/post_surface_p_canonical_chain_zero_trade_blocker_reaudit_v1/` | EXPECTED_PRIOR_EVIDENCE |
+| `docs&#47;evidence&#47;el_karoui_armstrong_system_integration_audit_v1&#47;` | EXPECTED_PRIOR_EVIDENCE |
+| `docs&#47;evidence&#47;obl_b05_bollinger_entry_side_authority_operator_go_selection_v1&#47;` | EXPECTED_PRIOR_EVIDENCE |
+| `docs&#47;evidence&#47;post_surface_p_canonical_chain_zero_trade_blocker_reaudit_v1&#47;` | EXPECTED_PRIOR_EVIDENCE |
 
 - UNEXPECTED_PRODUCTIVE=false
 - UNEXPECTED_OTHER=false

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/preexisting_worktree_classification.md
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/preexisting_worktree_classification.md
@@ -1,0 +1,12 @@
+# Preexisting Worktree Classification
+
+| Path | Classification |
+|---|---|
+| `docs/evidence/el_karoui_armstrong_system_integration_audit_v1/` | EXPECTED_PRIOR_EVIDENCE |
+| `docs/evidence/obl_b05_bollinger_entry_side_authority_operator_go_selection_v1/` | EXPECTED_PRIOR_EVIDENCE |
+| `docs/evidence/post_surface_p_canonical_chain_zero_trade_blocker_reaudit_v1/` | EXPECTED_PRIOR_EVIDENCE |
+
+- UNEXPECTED_PRODUCTIVE=false
+- UNEXPECTED_OTHER=false
+- EXPECTED_PRIOR_EVIDENCE_ONLY=true (before this slice's own evidence)
+- Stashes: 3 entries, untouched

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/registry_tiering_before_after.md
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/registry_tiering_before_after.md
@@ -1,0 +1,35 @@
+# Registry / Tiering Before→After Matrix
+
+## `armstrong_cycle`
+
+| Surface | Before | After |
+|---|---|---|
+| `StrategySpec.is_live_ready` | `True` | `False` |
+| `StrategySpec.tier` | `production` | `r_and_d` |
+| `StrategySpec.allowed_environments` | `backtest,paper,live` | `offline_backtest,research` |
+| capability_tags | `futures,live_ready,production` | `futures,r_and_d` |
+| Class `IS_LIVE_READY` / `TIER` | False / r_and_d | unchanged |
+| `strategy_tiering.toml` allow_live / tier | false / r_and_d | unchanged (notes clarified) |
+| `config/config.toml` is_live_ready | false | unchanged |
+
+## `el_karoui_vol_model`
+
+| Surface | Before | After |
+|---|---|---|
+| `StrategySpec.is_live_ready` | `True` | `False` |
+| `StrategySpec.tier` | `production` | `r_and_d` |
+| `StrategySpec.allowed_environments` | `backtest,paper,live` | `offline_backtest,research` |
+| capability_tags | `futures,live_ready,production` | `futures,r_and_d` |
+| Class / tiering / config.toml | already R&D | aligned |
+
+## Combined experiment
+Not a `StrategySpec` producer before or after (`RUN_TYPE_ARMSTRONG_ELKAROUI_COMBI` research-only).
+
+## Schema field mapping (no parallel schema)
+
+| Target truth | Existing field |
+|---|---|
+| research_only / LIVE_READY=false | `is_live_ready=False` + `tier="r_and_d"` |
+| execution_eligible=false | `is_live_ready=False` and `live` ∉ `allowed_environments` |
+| authority=NON_AUTHORITY | description + module docstrings |
+| canonical_chain_bound=false | not claimed; research envs only |

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/repo_state.txt
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/repo_state.txt
@@ -1,0 +1,27 @@
+REPO_ROOT=/Users/frnkhrz/Peak_Trade
+BRANCH=fix/auth-005-el-karoui-armstrong-non-authority-v1
+HEAD=43558204d4f7bcab30ce9e8357d2513a9a5f0970
+ORIGIN_MAIN=43558204d4f7bcab30ce9e8357d2513a9a5f0970
+BASE_SHA=43558204d4f7bcab30ce9e8357d2513a9a5f0970
+CAPTURED_AT=2026-07-18T18:34:03Z
+
+GIT_STATUS:
+ M config/strategy_tiering.toml
+ M src/experiments/armstrong_elkaroui_combi_experiment.py
+ M src/strategies/armstrong/armstrong_cycle_strategy.py
+ M src/strategies/ecm.py
+ M src/strategies/el_karoui/el_karoui_vol_model_strategy.py
+ M src/strategies/registry.py
+?? docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/
+?? docs/evidence/el_karoui_armstrong_system_integration_audit_v1/
+?? docs/evidence/obl_b05_bollinger_entry_side_authority_operator_go_selection_v1/
+?? docs/evidence/post_surface_p_canonical_chain_zero_trade_blocker_reaudit_v1/
+?? tests/strategies/test_auth_005_el_karoui_armstrong_non_authority_classification_v1.py
+
+STASH_LIST:
+stash@{0}: On feat/double-play-competing-authority-fail-closed-quarantine-v1: review-temp-untracked
+stash@{1}: On feat/market-dashboard-composition-first-refactor-v1: TEMP_IGNORE_RUNTIME_TESTOUTPUT
+stash@{2}: On feat/market-dashboard-phase-3-chart-polish-v1: runtime-only-before-foundation-rework
+
+LIVE_AUTHORIZED=false
+ORDERS_ENABLED=false

--- a/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/test_results.txt
+++ b/docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/test_results.txt
@@ -1,0 +1,74 @@
+FOCUSED_TESTS=auth005+armstrong+el_karoui+combi+research_strategies+registry_consolidation
+RESULT=341 passed
+LINT=PASS (ruff format --check + ruff check on touched py files)
+---
+============================= test session starts ==============================
+platform darwin -- Python 3.9.6, pytest-8.4.2, pluggy-1.6.0
+rootdir: /Users/frnkhrz/Peak_Trade
+configfile: pytest.ini
+plugins: anyio-4.12.0, cov-7.0.0
+collected 341 items
+
+tests/strategies/test_auth_005_el_karoui_armstrong_non_authority_classification_v1.py . [  0%]
+..........                                                               [  3%]
+tests/strategies/test_r_and_d_armstrong_el_karoui_safety.py ......       [  4%]
+tests/strategies/armstrong/test_armstrong_cycle_strategy.py ............ [  8%]
+...................................                                      [ 18%]
+tests/strategies/armstrong/test_cycle_model.py ......................... [ 26%]
+..                                                                       [ 26%]
+tests/strategies/el_karoui/test_el_karoui_volatility_strategy.py ....... [ 28%]
+...........................................                              [ 41%]
+tests/strategies/el_karoui/test_vol_model.py ........................... [ 49%]
+...................................................                      [ 64%]
+tests/test_armstrong_elkaroui_combi_experiment.py ...................... [ 70%]
+..................                                                       [ 75%]
+tests/test_research_strategies.py ...................................... [ 87%]
+.                                                                        [ 87%]
+tests/strategies/test_strategy_registry_consolidation_v1.py ............ [ 90%]
+...............................                                          [100%]
+
+=============================== warnings summary ===============================
+tests/strategies/test_strategy_registry_consolidation_v1.py::test_36_research_entry_uses_registry
+  /Users/frnkhrz/Peak_Trade/tests/strategies/test_strategy_registry_consolidation_v1.py:268: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/frnkhrz/Peak_Trade/scripts/research_run_strategy.py' mode='r' encoding='UTF-8'>
+    src = open(mod.__file__).read()
+  Enable tracemalloc to get traceback where the object was allocated.
+  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
+
+tests/strategies/test_strategy_registry_consolidation_v1.py::test_37_backtest_entry_uses_registry
+  /Users/frnkhrz/Peak_Trade/tests/strategies/test_strategy_registry_consolidation_v1.py:276: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/frnkhrz/Peak_Trade/scripts/run_backtest.py' mode='r' encoding='UTF-8'>
+    src = open(mod.__file__).read()
+  Enable tracemalloc to get traceback where the object was allocated.
+  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================= 341 passed, 2 warnings in 2.87s ========================
+---RUFF---
+All checks passed!
+
+=== PR_BOUNDED_FULL_SELECTOR_TARGETS ===
+SELECTOR_MODE=PR_BOUNDED_FULL
+SELECTOR_REASON=category_central_src_requires_full
+TIMING_WALLCLOCK_SECONDS=45.30
+TIMING_TARGET_MAX_SECONDS=840
+TIMING_HARD_STOP_SECONDS=900
+RESULT=716 passed
+  /Users/frnkhrz/Peak_Trade/tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py:209: PytestCollectionWarning: cannot collect test class 'TestownerRuntimeEvidence' because it has a __init__ constructor (from: tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py)
+    @_frozen_reporting_dataclass(frozen=True, slots=True)
+
+tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py:217
+  /Users/frnkhrz/Peak_Trade/tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py:217: PytestCollectionWarning: cannot collect test class 'TestownerRuntimeReport' because it has a __init__ constructor (from: tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py)
+    @_frozen_reporting_dataclass(frozen=True, slots=True)
+
+tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py:431
+  /Users/frnkhrz/Peak_Trade/tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py:431: PytestCollectionWarning: cannot collect test class 'TestownerCategoryProvenanceReport' because it has a __init__ constructor (from: tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py)
+    @_frozen_reporting_dataclass(frozen=True, slots=True)
+
+tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py:534
+  /Users/frnkhrz/Peak_Trade/tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py:534: PytestCollectionWarning: cannot collect test class 'TestownerBudgetInventoryRow' because it has a __init__ constructor (from: tests/ci/test_ci_testowner_runtime_budget_reporting_contract_v0.py)
+    @_frozen_reporting_dataclass(frozen=True, slots=True)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================= 716 passed, 5 warnings in 44.92s =======================
+real 45.30
+user 37.05
+sys 7.12

--- a/src/experiments/armstrong_elkaroui_combi_experiment.py
+++ b/src/experiments/armstrong_elkaroui_combi_experiment.py
@@ -8,6 +8,12 @@ für denselben Markt/Zeitraum und berechnet aggregierte Kennzahlen.
 
 ⚠️ WICHTIG: RESEARCH-ONLY – NICHT FÜR LIVE-TRADING ⚠️
 
+AUTH-005 classification:
+- CATEGORY=RESEARCH_EXPERIMENT · AUTHORITY=NON_AUTHORITY
+- CANONICAL_BOUND=false · LIVE_READY=false · EXECUTION_ELIGIBLE=false
+- MAY_PRODUCE_RESEARCH_METRICS=true · MAY_NOT_PRODUCE_CANONICAL_TRADE_INTENT=true
+- Not registered as a productive StrategySpec producer
+
 Konzept:
 - Armstrong-Event-State: Markiert Event-Fenster um ECM-Turning-Points
 - El-Karoui-Regime: Klassifiziert Volatilitäts-Regime (LOW/MEDIUM/HIGH)

--- a/src/strategies/armstrong/armstrong_cycle_strategy.py
+++ b/src/strategies/armstrong/armstrong_cycle_strategy.py
@@ -8,6 +8,13 @@ Model (ECM) für explorative Research-Zwecke.
 
 ⚠️ WICHTIG: RESEARCH-ONLY – NICHT FÜR LIVE-TRADING FREIGEGEBEN ⚠️
 
+AUTH-005 classification (Non-Authority):
+- CATEGORY=RESEARCH_INFORMATION_SOURCE
+- PRIMARY_ROLE=CYCLE_INFORMATION
+- AUTHORITY=NON_AUTHORITY
+- LIVE_READY=false · EXECUTION_ELIGIBLE=false · CANONICAL_BOUND=false
+- Does not own Master V2 / Double Play / Dynamic Scope / Agreement / Risk / Sizing
+
 Diese Strategie ist ausschließlich für:
 - Offline-Backtests
 - Research & Analyse

--- a/src/strategies/ecm.py
+++ b/src/strategies/ecm.py
@@ -1,7 +1,15 @@
 """
-Peak_Trade ECM Strategy
-========================
+Peak_Trade ECM Strategy (legacy functional surface)
+===================================================
 Armstrong's Economic Confidence Model (ECM) basierte Trading-Strategie.
+
+AUTH-005 / legacy disposition (Non-Authority):
+- LEGACY functional loader key ``ecm_cycle`` (not an OOP StrategySpec live surface)
+- AUTHORITY=NON_AUTHORITY · LIVE_READY=false · EXECUTION_ELIGIBLE=false
+- CANONICAL_BOUND=false (not Master V2 / Double Play system-state authority)
+- Related to Armstrong CYCLE_INFORMATION research; dual naming vs ``armstrong_cycle``
+  is identity dual, not a competing MV2 switch authority
+- OBL_B05 side-authority disposition: KEEP_NONE / activation blocked
 
 Konzept:
 - ECM-Zyklus: 8.6 Jahre = Pi * 1000 Tage = 3141 Tage

--- a/src/strategies/el_karoui/el_karoui_vol_model_strategy.py
+++ b/src/strategies/el_karoui/el_karoui_vol_model_strategy.py
@@ -8,6 +8,14 @@ inspiriert von Nicole El Karouis Arbeiten zu stochastischen Volatilitätsmodelle
 
 ⚠️ WICHTIG: RESEARCH-ONLY – NICHT FÜR LIVE-TRADING FREIGEGEBEN ⚠️
 
+AUTH-005 classification (Non-Authority):
+- CATEGORY=RESEARCH_INFORMATION_SOURCE
+- PRIMARY_ROLE=REGIME_INFORMATION
+- AUTHORITY=NON_AUTHORITY
+- LIVE_READY=false · EXECUTION_ELIGIBLE=false · CANONICAL_BOUND=false
+- Does not own Master V2 / Double Play / Dynamic Scope / Agreement / Risk / Sizing
+- Math is pragmatic rolling/EWM realized-vol (not BSDE / El Karoui publication math)
+
 Diese Strategie ist ausschließlich für:
 - Offline-Backtests
 - Research & Analyse

--- a/src/strategies/registry.py
+++ b/src/strategies/registry.py
@@ -163,19 +163,25 @@ _STRATEGY_REGISTRY: Dict[str, StrategySpec] = {
         key="armstrong_cycle",
         cls=ArmstrongCycleStrategy,
         config_section="strategy.armstrong_cycle",
-        description="Armstrong ECM Cycle Strategy (R&D-Only, nicht für Live)",
-        is_live_ready=True,  # Armstrong ist live-ready
-        tier="production",
-        allowed_environments=("backtest", "paper", "live"),
+        description=(
+            "Armstrong ECM Cycle Strategy (R&D-Only, Non-Authority, "
+            "CYCLE_INFORMATION research; nicht live / nicht kanonisch gebunden)"
+        ),
+        is_live_ready=False,  # AUTH-005: align class + strategy_tiering.toml
+        tier="r_and_d",
+        allowed_environments=("offline_backtest", "research"),
     ),
     "el_karoui_vol_model": StrategySpec(
         key="el_karoui_vol_model",
         cls=ElKarouiVolModelStrategy,
         config_section="strategy.el_karoui_vol_model",
-        description="El Karoui Stochastic Vol Model (R&D-Only, nicht für Live)",
-        is_live_ready=True,  # El Karoui ist live-ready
-        tier="production",
-        allowed_environments=("backtest", "paper", "live"),
+        description=(
+            "El Karoui Vol Regime Model (R&D-Only, Non-Authority, "
+            "REGIME_INFORMATION research; nicht live / nicht kanonisch gebunden)"
+        ),
+        is_live_ready=False,  # AUTH-005: align class + strategy_tiering.toml
+        tier="r_and_d",
+        allowed_environments=("offline_backtest", "research"),
     ),
     "ehlers_cycle_filter": StrategySpec(
         key="ehlers_cycle_filter",

--- a/tests/strategies/test_auth_005_el_karoui_armstrong_non_authority_classification_v1.py
+++ b/tests/strategies/test_auth_005_el_karoui_armstrong_non_authority_classification_v1.py
@@ -1,0 +1,116 @@
+"""AUTH-005: El Karoui / Armstrong Non-Authority classification contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.experiments.armstrong_elkaroui_combi_experiment import (
+    ALLOWED_ENVIRONMENTS as COMBI_ALLOWED_ENVIRONMENTS,
+    RUN_TYPE_ARMSTRONG_ELKAROUI_COMBI,
+)
+from src.strategies.armstrong.armstrong_cycle_strategy import ArmstrongCycleStrategy
+from src.strategies.el_karoui.el_karoui_vol_model_strategy import ElKarouiVolatilityStrategy
+from src.strategies.registry import (
+    _STRATEGY_REGISTRY,
+    get_strategy_registry_entry,
+    get_strategy_spec,
+)
+
+
+_RESEARCH_KEYS = ("armstrong_cycle", "el_karoui_vol_model")
+
+
+@pytest.mark.parametrize("key", _RESEARCH_KEYS)
+def test_auth005_registry_spec_is_research_only_non_live(key: str) -> None:
+    spec = get_strategy_spec(key)
+    assert spec.is_live_ready is False
+    assert spec.tier == "r_and_d"
+    assert "live" not in spec.allowed_environments
+    assert "paper" not in spec.allowed_environments
+    assert set(spec.allowed_environments) <= {"offline_backtest", "research", "backtest"}
+    assert "offline_backtest" in spec.allowed_environments
+    assert "research" in spec.allowed_environments
+    assert "Non-Authority" in spec.description or "R&D" in spec.description
+
+
+@pytest.mark.parametrize("key", _RESEARCH_KEYS)
+def test_auth005_canonical_entry_has_no_live_ready_capability_tag(key: str) -> None:
+    entry = get_strategy_registry_entry(key)
+    assert "live_ready" not in entry.capability_tags
+    assert "r_and_d" in entry.capability_tags
+    assert "production" not in entry.capability_tags
+
+
+def test_auth005_class_level_flags_match_registry() -> None:
+    assert ArmstrongCycleStrategy.IS_LIVE_READY is False
+    assert ArmstrongCycleStrategy.TIER == "r_and_d"
+    assert ElKarouiVolatilityStrategy.IS_LIVE_READY is False
+    assert ElKarouiVolatilityStrategy.TIER == "r_and_d"
+
+    arm = get_strategy_spec("armstrong_cycle")
+    elk = get_strategy_spec("el_karoui_vol_model")
+    assert arm.is_live_ready is ArmstrongCycleStrategy.IS_LIVE_READY
+    assert elk.is_live_ready is ElKarouiVolatilityStrategy.IS_LIVE_READY
+    assert arm.tier == ArmstrongCycleStrategy.TIER
+    assert elk.tier == ElKarouiVolatilityStrategy.TIER
+
+
+def test_auth005_registry_rejects_live_ready_true_posture_for_research_keys() -> None:
+    """Negative: productive live posture must not remain after AUTH-005."""
+    for key in _RESEARCH_KEYS:
+        spec = get_strategy_spec(key)
+        assert spec.is_live_ready is not True
+        assert spec.tier != "production"
+        assert "live" not in spec.allowed_environments
+
+
+def test_auth005_no_execution_eligible_metadata_on_research_specs() -> None:
+    """Schema has no execution_eligible field; live gate uses is_live_ready=False."""
+    for key in _RESEARCH_KEYS:
+        spec = get_strategy_spec(key)
+        assert (
+            not hasattr(spec, "execution_eligible") or getattr(spec, "execution_eligible") is False
+        )
+        assert spec.is_live_ready is False
+
+
+def test_auth005_combi_experiment_not_registered_as_strategy_producer() -> None:
+    assert RUN_TYPE_ARMSTRONG_ELKAROUI_COMBI not in _STRATEGY_REGISTRY
+    assert "armstrong_elkaroui_combi" not in _STRATEGY_REGISTRY
+    assert set(COMBI_ALLOWED_ENVIRONMENTS) <= {"offline_backtest", "research"}
+
+
+def test_auth005_ecm_cycle_is_functional_only_not_oop_live_spec() -> None:
+    with pytest.raises(KeyError):
+        get_strategy_spec("ecm_cycle")
+    entry = get_strategy_registry_entry("ecm_cycle")
+    assert "functional" in entry.capability_tags
+    assert "live_ready" not in entry.capability_tags
+
+
+def test_auth005_no_dynamic_scope_or_agreement_override_fields_on_specs() -> None:
+    forbidden = (
+        "dynamic_scope_mutation",
+        "agreement_override",
+        "risk_authority",
+        "sizing_authority",
+        "canonical_chain_bound",
+        "direct_long_short_authority",
+    )
+    for key in _RESEARCH_KEYS:
+        spec = get_strategy_spec(key)
+        for field in forbidden:
+            assert not hasattr(spec, field)
+
+
+def test_auth005_field_mapping_documented_via_existing_schema() -> None:
+    """
+    Target classification → existing StrategySpec fields:
+    - research_only / LIVE_READY=false → is_live_ready=False + tier='r_and_d'
+    - execution_eligible=false → is_live_ready=False and 'live' not in allowed_environments
+    - authority=NON_AUTHORITY → description + class docstrings (no parallel schema)
+    - canonical_chain_bound=false → not claimed by registry; absence of live envs
+    """
+    for key in _RESEARCH_KEYS:
+        spec = get_strategy_spec(key)
+        assert (spec.is_live_ready is False) and (spec.tier == "r_and_d")


### PR DESCRIPTION
## Summary
- Align `armstrong_cycle` and `el_karoui_vol_model` StrategySpec metadata with class/tiering truth (`is_live_ready=false`, `tier=r_and_d`, research-only envs).
- Clarify Non-Authority / Research Information Source posture in docstrings and tiering notes; leave ECM functional math unchanged as fail-closed legacy non-authority.
- Add AUTH-005 contract tests and durable evidence under `docs/evidence/auth_005_el_karoui_armstrong_non_authority_classification_v1/`.

## Test plan
- [x] `pytest` AUTH-005 + armstrong/el_karoui/combi/research/registry consolidation (341 passed)
- [x] PR-bounded FULL selector targets (716 passed, ~45s)
- [x] `ruff format --check` + `ruff check` on touched Python files
- [ ] GitHub required checks green (await operator GO before merge)


Made with [Cursor](https://cursor.com)