### PR TITLE
docs(governance): OPTION_D final fail-closed closeout

### DIFF
--- a/docs/evidence/option_d_final_closeout_v1/README.md
+++ b/docs/evidence/option_d_final_closeout_v1/README.md
@@ -1,0 +1,32 @@
+# OPTION_D Final Fail-Closed Closeout v1
+
+```text
+BASE_SHA=7d1d822c0808915d38a1f8556ac715133e070c7a
+PR_5335_MERGE=7d1d822c0808915d38a1f8556ac715133e070c7a
+RECOMMENDED_CONTRACT=OPTION_D
+ENTRY_SIDE_CURRENT=NONE
+PRODUCTIVE_FILES_CHANGED=false
+LIVE_AUTHORIZED=false
+ORDERS=false
+```
+
+## Purpose
+
+Governance&#47;Evidence closeout after PR #5335. Documents that **OPTION_D** is the accepted, active contract decision: Bollinger `ENTRY_SIDE=NONE` remains intentionally fail-closed. No side activation, no productive trading-logic change, no runtime&#47;orders&#47;live activation.
+
+## Artifacts
+
+| File | Content |
+|------|---------|
+| `option_d_final_closeout.md` | Binding decision record |
+| `canonical_authority_snapshot.txt` | Direction &#47; Composition &#47; Bridge &#47; SSOT |
+| `classic_quarantine_snapshot.txt` | Classic bypass quarantine |
+| `test_results.txt` | Established 127-test smoke |
+| `git_state.txt` | Preflight git &#47; stash &#47; foreign untracked |
+
+## Safety
+
+- Evidence only under this directory
+- Foreign untracked evidence dirs untouched
+- Stashes unchanged
+- PR remains open (no merge in this slice)

--- a/docs/evidence/option_d_final_closeout_v1/canonical_authority_snapshot.txt
+++ b/docs/evidence/option_d_final_closeout_v1/canonical_authority_snapshot.txt
@@ -1,0 +1,20 @@
+CANONICAL_DIRECTION_OWNER=trading.master_v2.double_play_state.transition_state
+CANONICAL_COMPOSITION_OWNER=trading.master_v2.double_play_composition_matrix_v1.evaluate_double_play_composition_matrix_v1
+STRATEGY_SIGNAL_OWNER=strategies.bollinger.BollingerBandsStrategy.generate_signals
+EVENT_SEMANTIC_OWNER=strategies.bollinger_event_semantic_contract_v1.classify_bollinger_raw_signal_event_v1
+ORDER_INTENT_OWNER=governance.canonical_order_intent_v1.build_canonical_order_intent_v1
+ENTRY_SIDE_CURRENT=NONE
+RECOMMENDED_CONTRACT=OPTION_D
+RUNTIME_BRIDGE_STATUS=BOUND_NOT_ACTIVATED
+LIVE_AUTHORIZED=false
+ORDERS=false
+
+--- symbol presence ---
+228:def transition_state(
+541:def evaluate_double_play_composition_matrix_v1(
+99:INTEGRATION_STATUS_BOUND_NOT_ACTIVATED = "BOUND_NOT_ACTIVATED"
+452:        integration_status=INTEGRATION_STATUS_BOUND_NOT_ACTIVATED,
+499:        integration_status=INTEGRATION_STATUS_BOUND_NOT_ACTIVATED,
+
+--- OBL_B07 SSOT ---
+{'OPERATOR_OPTION': 'OPTION_EVENT_ONLY', 'ENTRY_SIDE': 'NONE', 'STRATEGY_DIRECTION': 'NONE', 'CLASSIC_LONG_IS_CANONICAL': False, 'CLASSIC_LONG_PROPAGATES_TO_INTEGRATED': False, 'LIVE_AUTHORIZED': False, 'ORDERS_ENABLED': False, 'BOLLINGER_SIDE_ACTIVATED': False}

--- a/docs/evidence/option_d_final_closeout_v1/classic_quarantine_snapshot.txt
+++ b/docs/evidence/option_d_final_closeout_v1/classic_quarantine_snapshot.txt
@@ -1,0 +1,22 @@
+BYPASS_FILE=src/backtest/engine.py
+BYPASS_SYMBOL=BacktestEngine.run_realistic
+BYPASS_CLASSIFICATION=LEGACY_QUARANTINED
+BYPASS_SECOND_AUTHORITY=false
+BYPASS_USES_TRANSITION_STATE=false
+BYPASS_USES_COMPOSITION_MATRIX=false
+BYPASS_CAN_REACH_ORDER_INTENT=false
+BYPASS_CAN_REACH_EXECUTION=false
+CLASSIC_LONG_IS_CANONICAL=false
+CLASSIC_LONG_PROPAGATES_TO_INTEGRATED=false
+
+--- engine markers ---
+498:    def run_realistic(
+654:            if signal == 1 and current_trade is None:
+655:                # LONG ENTRY
+835:            elif signal == -1 and current_trade is not None:
+
+--- prior audit disposition ---
+2:VERDICT=Classic BacktestEngine.run_realistic LONG bypass is LEGACY_QUARANTINED; under OPTION_D it cannot set ENTRY_SIDE or reach canonical order intent — keep OPTION_D.
+9:BYPASS_CLASSIFICATION=LEGACY_QUARANTINED
+17:BYPASS_SECOND_AUTHORITY=false
+23:NEXT_RECOMMENDED_ACTION=KEEP_OPTION_D

--- a/docs/evidence/option_d_final_closeout_v1/git_state.txt
+++ b/docs/evidence/option_d_final_closeout_v1/git_state.txt
@@ -1,0 +1,26 @@
+DATE_UTC=2026-07-18T19:48:48Z
+BRANCH=docs/option-d-final-closeout-v1
+HEAD=7d1d822c0808915d38a1f8556ac715133e070c7a
+ORIGIN_MAIN=7d1d822c0808915d38a1f8556ac715133e070c7a
+BASE_SHA=7d1d822c0808915d38a1f8556ac715133e070c7a
+STASH_BEFORE=9dee9fcdfc2800d5051d82fa85a329d19ae3d15e0e896220ac9cafabfcb30c30
+FOREIGN_BEFORE=e1f582650b0acbadc3bf3d776db8547b3d1fb836cd3c934e477fe539891ed28f
+
+WORKTREE:
+?? docs/evidence/ehlers_bouchaud_system_integration_audit_v1/
+?? docs/evidence/el_karoui_armstrong_system_integration_audit_v1/
+?? docs/evidence/obl_b05_bollinger_entry_side_authority_operator_go_selection_v1/
+?? docs/evidence/option_d_final_closeout_v1/
+?? docs/evidence/post_surface_p_canonical_chain_zero_trade_blocker_reaudit_v1/
+
+STASHES:
+stash@{0}: On feat/double-play-competing-authority-fail-closed-quarantine-v1: review-temp-untracked
+stash@{1}: On feat/market-dashboard-composition-first-refactor-v1: TEMP_IGNORE_RUNTIME_TESTOUTPUT
+stash@{2}: On feat/market-dashboard-phase-3-chart-polish-v1: runtime-only-before-foundation-rework
+
+FOREIGN_UNTRACKED:
+?? docs/evidence/ehlers_bouchaud_system_integration_audit_v1/
+?? docs/evidence/el_karoui_armstrong_system_integration_audit_v1/
+?? docs/evidence/obl_b05_bollinger_entry_side_authority_operator_go_selection_v1/
+?? docs/evidence/option_d_final_closeout_v1/
+?? docs/evidence/post_surface_p_canonical_chain_zero_trade_blocker_reaudit_v1/

--- a/docs/evidence/option_d_final_closeout_v1/option_d_final_closeout.md
+++ b/docs/evidence/option_d_final_closeout_v1/option_d_final_closeout.md
@@ -1,0 +1,71 @@
+# OPTION_D Final Fail-Closed Closeout
+
+---
+docs_token: DOCS_TOKEN_OPTION_D_FINAL_CLOSEOUT_V1
+STATUS: OPTION_D_ACCEPTED_ACTIVE
+ENTRY_SIDE: NONE
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+RUNTIME_BRIDGE: BOUND_NOT_ACTIVATED
+SIDE_ACTIVATION: false
+---
+
+## Binding decision
+
+**OPTION_D is accepted and remains the active contract decision.**
+
+| Field | Value |
+|-------|-------|
+| `RECOMMENDED_CONTRACT` | `OPTION_D` |
+| `ENTRY_SIDE` | `NONE` (intentional fail-closed) |
+| Side activation without separate Operator-GO | **forbidden** |
+| Classic `BacktestEngine.run_realistic` | `LEGACY_QUARANTINED` — not fachliche Authority |
+| Sole fachliche Authority | Master V2 &#47; Double Play (`transition_state` + composition matrix) |
+| Runtime Bridge activation in this closeout | **none** |
+| Orders &#47; Live activation in this closeout | **none** |
+
+## Canonical owners (reaudit)
+
+| Role | Owner |
+|------|-------|
+| Direction &#47; State &#47; Switch | `trading.master_v2.double_play_state.transition_state` |
+| System composition | `trading.master_v2.double_play_composition_matrix_v1.evaluate_double_play_composition_matrix_v1` |
+| Bollinger raw signal | `strategies.bollinger.BollingerBandsStrategy.generate_signals` |
+| Bollinger event semantics | `strategies.bollinger_event_semantic_contract_v1.classify_bollinger_raw_signal_event_v1` |
+| Order intent | `governance.canonical_order_intent_v1.build_canonical_order_intent_v1` |
+
+## Classic quarantine (unchanged)
+
+- Classification: `LEGACY_QUARANTINED`
+- Not a second Integrated Authority
+- Does not use `transition_state` or composition matrix
+- Does not reach canonical order intent
+- Does not reach execution &#47; live
+- Must not be interpreted as Strategy Intent or Entry-Side Authority
+
+## What this closeout does **not** do
+
+- No `ENTRY_SIDE` LONG&#47;SHORT activation
+- No OPTION_B composer implementation
+- No Classic engine repair
+- No changes to Risk, Sizing, Execution, Orders, Dynamic Scope, Transition State, or Composition Matrix
+- No Runtime Bridge activation
+
+## Future side activation rule
+
+Any later Side activation requires **all** of:
+
+1. a separate explicit Operator-GO,
+2. a separate bounded plan and scope,
+3. dedicated tests,
+4. a separate implementation PR.
+
+Until then: **KEEP OPTION_D** / `ENTRY_SIDE=NONE`.
+
+## Provenance
+
+- OBL_B07 EVENT_ONLY (`ENTRY_SIDE=NONE`)
+- Authority audit PR #5333
+- Plan PR #5334 (OPTION_D prep)
+- Bypass fail-closed audit PR #5335 (`LEGACY_QUARANTINED`)
+- This closeout documents the decision on `main` at `7d1d822c0808915d38a1f8556ac715133e070c7a`

--- a/docs/evidence/option_d_final_closeout_v1/test_results.txt
+++ b/docs/evidence/option_d_final_closeout_v1/test_results.txt
@@ -1,0 +1,21 @@
+============================= test session starts ==============================
+platform darwin -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0
+rootdir: /Users/frnkhrz/Peak_Trade
+configfile: pytest.ini
+plugins: anyio-4.12.0, cov-7.0.0
+collected 127 items
+
+tests/backtest/test_obl_b07_bollinger_event_only_semantic_contract_v1.py . [  0%]
+.........                                                                [  7%]
+tests/backtest/test_strategy_signal_suitability_agreement_adapter_v1.py . [  8%]
+.....                                                                    [ 12%]
+tests/trading/master_v2/test_double_play_sole_authority_quarantine_v1.py . [ 13%]
+........                                                                 [ 19%]
+tests/trading/master_v2/test_double_play_composition_matrix_v1.py ...... [ 24%]
+.....................                                                    [ 40%]
+tests/backtest/test_mv2_composition_directional_asymmetry_wiring_repair_v1.py . [ 41%]
+............                                                             [ 51%]
+tests/governance/test_canonical_order_intent_v1.py ..................... [ 67%]
+.........................................                                [100%]
+
+============================= 127 passed in 0.89s ==============================


### PR DESCRIPTION
## Summary
- Governance/Evidence closeout after PR #5335: **OPTION_D** remains the active contract decision.
- `ENTRY_SIDE=NONE` is intentional fail-closed; Classic `run_realistic` stays `LEGACY_QUARANTINED`.
- No side activation, no productive trading-logic change, no runtime/orders/live activation.

## Test plan
- [x] Established 127-test smoke (OBL_B07/adapter/quarantine/composition/MV2 asymmetry/order-intent)
- [x] Docs token + reference-target gates
- [ ] CI confirmation

## Safety
- Evidence only under `docs/evidence/option_d_final_closeout_v1/`
- Do **not** merge in this slice without operator review of checks
- LIVE=false / ORDERS=false

Made with [Cursor](https://cursor.com)