### PR TITLE
Fix topn promotion test mkdtemp cleanup leak

### DIFF
--- a/tests/experiments/test_topn_promotion_learnable_context.py
+++ b/tests/experiments/test_topn_promotion_learnable_context.py
@@ -6,7 +6,10 @@ Tests for learnable-surfaces context integration in export_top_n_with_policy_che
 - When L2 + allowed surface: decision not denied by learnable-surfaces gate.
 """
 
-import tempfile
+from __future__ import annotations
+
+import shutil
+from collections.abc import Iterator
 from pathlib import Path
 
 import pandas as pd
@@ -27,25 +30,84 @@ def _minimal_df_top() -> pd.DataFrame:
     )
 
 
-def _config_with_tmp_output() -> TopNPromotionConfig:
-    """Config that writes under cwd so relative_to(Path.cwd()) in caller works."""
-    base = Path(tempfile.mkdtemp(prefix="topn_promotion_test_", dir=str(Path.cwd())))
+@pytest.fixture
+def topn_tmp_path(tmp_path: Path) -> Iterator[Path]:
+    """Export root under CWD (relative_to(Path.cwd()) in producer) with guaranteed cleanup.
+
+    Bare tempfile.mkdtemp(..., dir=cwd) previously leaked untracked
+    topn_promotion_test_* directories in the repository root. Pytest's tmp_path
+    supplies uniqueness; the CWD-nested dir is removed even if the test fails.
+    """
+    base = Path.cwd() / f"topn_promotion_test_{tmp_path.name}"
+    base.mkdir(parents=False, exist_ok=False)
+    try:
+        yield base
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+def _config_with_tmp_output(tmp_path: Path) -> TopNPromotionConfig:
+    """Config that writes under *tmp_path* (caller must pass a cleaned-up dir under CWD)."""
     return TopNPromotionConfig(
         sweep_name="test_sweep",
         metric_primary="metric_sharpe_ratio",
         top_n=1,
-        output_path=base,
-        experiments_dir=base,
+        output_path=tmp_path,
+        experiments_dir=tmp_path,
     )
+
+
+def test_topn_tmp_helper_does_not_leak_dirs_in_repo_root(
+    topn_tmp_path: Path,
+) -> None:
+    """Regression: helper / export must not leave topn_promotion_test_* under CWD."""
+    before = set(Path.cwd().glob("topn_promotion_test_*"))
+    config = _config_with_tmp_output(topn_tmp_path)
+    output_path, _gov = export_top_n_with_policy_check(
+        _minimal_df_top(),
+        config,
+        auto_apply=True,
+        context={"run_id": "leak-regression", "source": "topn_promotion"},
+    )
+    assert output_path.exists()
+    # Fixture still holds the live dir; count of matching prefix dirs must not grow
+    # beyond the single fixture-managed path.
+    during = set(Path.cwd().glob("topn_promotion_test_*"))
+    assert during == before | {topn_tmp_path.resolve()} or during == before | {topn_tmp_path}
+    assert topn_tmp_path in during or topn_tmp_path.resolve() in {p.resolve() for p in during}
+
+
+def test_topn_tmp_fixture_cleans_repo_root_after_test() -> None:
+    """After a nested test using the fixture pattern, no leaked dirs remain.
+
+    Invokes the same mkdir/cleanup contract as topn_tmp_path without relying on
+    fixture teardown order across tests.
+    """
+    before = {p.resolve() for p in Path.cwd().glob("topn_promotion_test_*")}
+    nested = Path.cwd() / "topn_promotion_test_regression_cleanup_probe"
+    nested.mkdir(parents=False, exist_ok=False)
+    try:
+        config = _config_with_tmp_output(nested)
+        output_path, _gov = export_top_n_with_policy_check(
+            _minimal_df_top(),
+            config,
+            auto_apply=False,
+            context={"run_id": "leak-cleanup", "source": "topn_promotion"},
+        )
+        assert output_path.exists()
+    finally:
+        shutil.rmtree(nested, ignore_errors=True)
+    after = {p.resolve() for p in Path.cwd().glob("topn_promotion_test_*")}
+    assert after == before
 
 
 class TestNoContextBackwardCompatible:
     """When layer_id/requested_surfaces not provided, behavior unchanged."""
 
-    def test_no_layer_or_surfaces_allowed_for_clean_change(self):
+    def test_no_layer_or_surfaces_allowed_for_clean_change(self, topn_tmp_path: Path):
         """Without learnable context, gate is skipped; clean change can be allowed."""
         df_top = _minimal_df_top()
-        config = _config_with_tmp_output()
+        config = _config_with_tmp_output(topn_tmp_path)
         output_path, gov = export_top_n_with_policy_check(
             df_top,
             config,
@@ -65,10 +127,10 @@ class TestNoContextBackwardCompatible:
 class TestL0DeniedByGate:
     """L0 + any surface => learnable-surfaces gate denies."""
 
-    def test_l0_with_surface_denied(self):
+    def test_l0_with_surface_denied(self, topn_tmp_path: Path):
         """layer_id=L0 and requested_surfaces=["x"] => auto_apply denied by gate."""
         df_top = _minimal_df_top()
-        config = _config_with_tmp_output()
+        config = _config_with_tmp_output(topn_tmp_path)
         output_path, gov = export_top_n_with_policy_check(
             df_top,
             config,
@@ -89,10 +151,10 @@ class TestL0DeniedByGate:
 class TestL2AllowedSurfaceGatePasses:
     """L2 + allowed surface from config => gate does not force MANUAL_ONLY."""
 
-    def test_l2_allowed_surface_not_denied_by_gate(self):
+    def test_l2_allowed_surface_not_denied_by_gate(self, topn_tmp_path: Path):
         """L2 + scenario_priors (in config/learning_surfaces.toml) => gate passes."""
         df_top = _minimal_df_top()
-        config = _config_with_tmp_output()
+        config = _config_with_tmp_output(topn_tmp_path)
         output_path, gov = export_top_n_with_policy_check(
             df_top,
             config,


### PR DESCRIPTION
## Summary
- Replace bare `tempfile.mkdtemp(..., dir=cwd)` in `tests/experiments/test_topn_promotion_learnable_context.py` with a pytest `tmp_path`-backed fixture that still nests under CWD (required for `output_path.relative_to(Path.cwd())`) and always `rmtree`s on teardown, including failures.
- Add regression coverage that the helper/export path does not leave `topn_promotion_test_*` directories in the repository root after cleanup.
- Tests only; no productive trading/strategy/risk/execution/authority/promotion logic changes.

## Test plan
- [x] `.venv/bin/python -m pytest tests/experiments/test_topn_promotion_learnable_context.py -q --tb=short` (5 passed)
- [x] `.venv/bin/ruff format --check` / `ruff check` on the changed file
- [x] `ls -d topn_promotion_test_*` → NONE after test run
- [ ] Wait for required GitHub checks on this PR


Made with [Cursor](https://cursor.com)