### PR TITLE
research: version canonical open MR eligibility backlog v1

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -616,6 +616,15 @@
         "docs/governance/ADX_RANGE_ADMISSION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
       ],
       "note": "Single preregistered DEVELOPMENT-only offline evaluation of ADX(14) range-admission pre-entry MR eligibility filter versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders."
+    },
+    "CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1": {
+      "path_prefixes": [
+        "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json",
+        "src/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
+        "tests/research/test_canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
+        "docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md"
+      ],
+      "note": "Definition-only governance SSOT versioning the canonical open MR entry-eligibility hypothesis backlog after four terminal FAILs; deterministic priority with exactly one NEXT_ELIGIBLE_FOR_PREREGISTRATION; no preregistration, evaluation, holdout access, runtime activation, or productive authority mutation in this slice."
     }
   }
 }

--- a/config/governance/technical_canonical_wiring_authorization_v1.json
+++ b/config/governance/technical_canonical_wiring_authorization_v1.json
@@ -315,7 +315,11 @@
     "docs/evidence/preregister_adx_range_admission_mr_eligibility_hypothesis_v1/split_manifest.json",
     "docs/evidence/preregister_adx_range_admission_mr_eligibility_hypothesis_v1/safety_attestation.md",
     "docs/evidence/preregister_adx_range_admission_mr_eligibility_hypothesis_v1/timing_proof.txt",
-    "docs/governance/ADX_RANGE_ADMISSION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
+    "docs/governance/ADX_RANGE_ADMISSION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+    "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json",
+    "src/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
+    "tests/research/test_canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
+    "docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md"
   ],
   "allowed_surface_classes": [
     "TECHNICAL_CANONICAL_REPLAY_INPUT_BUILDER_WIRING",

--- a/config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json
+++ b/config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json
@@ -1,0 +1,348 @@
+{
+  "artifact_kind": "canonical_open_mr_entry_eligibility_hypothesis_backlog",
+  "artifact_version": "v1",
+  "schema_version": "canonical_open_mr_entry_eligibility_hypothesis_backlog.v1",
+  "authority_effect": "NONE",
+  "runtime_effect": "NONE",
+  "status": "OPEN_BACKLOG",
+  "verdict": "CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_BACKLOG_VERSIONED",
+  "slice_class": "DEFINITION_ONLY_GOVERNANCE",
+  "canonical_ssot": true,
+  "exactly_one_authoritative_truth": true,
+  "productive_trading_logic_included": false,
+  "evaluation_authorized": false,
+  "backtest_authorized": false,
+  "implementation_authorized": false,
+  "preregistration_authorized_in_this_slice": false,
+  "evaluation_results_embedded": false,
+  "development_run_count": 0,
+  "baseline_config_id": "bollinger_bands_v2_full_canonical_system_economic_binding_v1",
+  "baseline_immutable": true,
+  "required_treatment_type": "ENTRY_EFFECTIVE_PRE_ENTRY_ELIGIBILITY_FILTER",
+  "dataset_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_dev_pre_holdout_v1",
+  "dataset_class": "DEVELOPMENT_ONLY",
+  "universe_scope": {
+    "venue": "OKX",
+    "instrument_class": "LINEAR_USDT_PERPETUAL",
+    "bitcoin_excluded": true,
+    "spot_excluded": true,
+    "frequency": "PT1H",
+    "panel_class": "DEVELOPMENT_ONLY_PRE_HOLDOUT"
+  },
+  "holdout_forbidden": true,
+  "sealed_holdout_id": "offline_economic_reevaluation_sealed_long_panel_v1",
+  "sealed_holdout_content_inspection_authorized": false,
+  "runtime_policy": {
+    "runtime_activated": false,
+    "shadow_activated": false,
+    "paper_activated": false,
+    "testnet_activated": false,
+    "live_authorized": false,
+    "orders_allowed": false,
+    "scheduler_authorized": false
+  },
+  "promotion_and_economic_gate_policy": {
+    "promotion_eligible": false,
+    "economic_validity_offline_gate_pass": false,
+    "economic_validity_offline_gate_changed": false,
+    "promotion_claim_from_backlog_forbidden": true
+  },
+  "terminal_hypotheses": [
+    {
+      "hypothesis_id": "REGIME_GATED_STANDASIDE_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1",
+      "status": "TERMINAL_FAIL",
+      "treatment_type": "ENTRY_ELIGIBILITY_STANDASIDE_GATE",
+      "feature_family": "multi_feature_absolute_threshold_regime_classifier",
+      "feature_ids": [
+        "realized_vol_168h",
+        "range_compression_72h",
+        "trend_strength_168h"
+      ],
+      "fail_reason": "PASS_REQUIRES_NOT_MET",
+      "fail_finding": "identical_arms_gate_inactive_on_entries",
+      "contract_ref": "config/research/regime_gated_standaside_mr_preregistered_economic_hypothesis_measurement_contract_v1.json",
+      "evidence_ref": "docs/evidence/evaluate_regime_gated_standaside_mr_development_v1/"
+    },
+    {
+      "hypothesis_id": "ENTRY_EFFECTIVE_MR_ELIGIBILITY_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1",
+      "status": "TERMINAL_FAIL",
+      "treatment_type": "ENTRY_EFFECTIVE_PRE_ENTRY_ELIGIBILITY_FILTER",
+      "feature_family": "atr_rolling_percentile_midband",
+      "feature_ids": [
+        "atr_14h",
+        "atr_14h_rolling_percentile_rank_100h"
+      ],
+      "fail_reason": "NET_PROFIT_FACTOR_NOT_IMPROVED",
+      "fail_finding": "net_profit_factor_not_improved_despite_entry_eligibility_divergence",
+      "contract_ref": "config/research/entry_effective_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+      "evidence_ref": "docs/evidence/evaluate_entry_effective_mr_eligibility_development_v1/"
+    },
+    {
+      "hypothesis_id": "RSI_EXHAUSTION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1",
+      "status": "TERMINAL_FAIL",
+      "treatment_type": "ENTRY_EFFECTIVE_PRE_ENTRY_ELIGIBILITY_FILTER",
+      "feature_family": "rsi_exhaustion_level",
+      "feature_ids": [
+        "rsi_14h"
+      ],
+      "fail_reason": "NET_PROFIT_FACTOR_NOT_IMPROVED",
+      "fail_finding": "net_profit_factor_not_improved_despite_entry_eligibility_divergence",
+      "contract_ref": "config/research/rsi_exhaustion_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+      "evidence_ref": "docs/evidence/evaluate_rsi_exhaustion_mr_eligibility_development_v1/"
+    },
+    {
+      "hypothesis_id": "ADX_RANGE_ADMISSION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1",
+      "status": "TERMINAL_FAIL",
+      "treatment_type": "ENTRY_EFFECTIVE_PRE_ENTRY_ELIGIBILITY_FILTER",
+      "feature_family": "adx_level_range_admission",
+      "feature_ids": [
+        "adx_14h"
+      ],
+      "fail_reason": "NET_PROFIT_FACTOR_NOT_IMPROVED",
+      "fail_finding": "net_profit_factor_not_improved_despite_entry_eligibility_divergence",
+      "contract_ref": "config/research/adx_range_admission_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+      "evidence_ref": "docs/evidence/evaluate_adx_range_admission_mr_eligibility_development_v1/"
+    }
+  ],
+  "forbidden_feature_families_for_open_candidates": [
+    "multi_feature_absolute_threshold_regime_classifier",
+    "atr_rolling_percentile_midband",
+    "rsi_exhaustion_level",
+    "adx_level_range_admission"
+  ],
+  "forbidden_retune_of_terminal_parameters": true,
+  "forbidden_semantic_duplicates": true,
+  "forbidden_multi_gate_combinations": true,
+  "priority_criteria": {
+    "selection_performance_forbidden": true,
+    "criteria_locked_a_priori": true,
+    "reprioritization_requires_separate_governance_pr": true,
+    "scored_dimensions": [
+      {
+        "dimension_id": "semantic_distance",
+        "weight": 3,
+        "higher_is_better": true,
+        "description": "Orthogonality to all terminal FAIL feature families and mechanisms"
+      },
+      {
+        "dimension_id": "entry_effectiveness",
+        "weight": 3,
+        "higher_is_better": true,
+        "description": "Causal clarity that the filter acts before entry and can diverge from control"
+      },
+      {
+        "dimension_id": "measurability",
+        "weight": 2,
+        "higher_is_better": true,
+        "description": "Deterministic PIT features with binary ELIGIBLE/STAND_ASIDE outcome"
+      },
+      {
+        "dimension_id": "low_additional_complexity",
+        "weight": 2,
+        "higher_is_better": true,
+        "description": "Single-feature single-rule gate; no multi-gate stack"
+      },
+      {
+        "dimension_id": "low_overfitting_risk",
+        "weight": 2,
+        "higher_is_better": true,
+        "description": "Frozen repo-SSOT defaults; no free threshold search"
+      },
+      {
+        "dimension_id": "repo_support",
+        "weight": 2,
+        "higher_is_better": true,
+        "description": "Existing strategy calculator / config.toml defaults reusable without new feature invention"
+      }
+    ],
+    "tie_break_rule": "If weighted totals equal, lower priority_rank integer wins only when explicitly assigned without tie; ties are forbidden in this SSOT."
+  },
+  "open_candidates": [
+    {
+      "hypothesis_id": "MA_TREND_ALIGNMENT_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1",
+      "canonical_slug": "ma-trend-alignment-mr-eligibility",
+      "status": "OPEN_UNPREREGISTERED",
+      "queue_status": "NEXT_ELIGIBLE_FOR_PREREGISTRATION",
+      "priority_rank": 1,
+      "priority_score_total": 70,
+      "priority_scores": {
+        "semantic_distance": 5,
+        "entry_effectiveness": 5,
+        "measurability": 5,
+        "low_additional_complexity": 5,
+        "low_overfitting_risk": 5,
+        "repo_support": 5
+      },
+      "feature_family": "price_vs_ma_trend_alignment",
+      "feature_ids": [
+        "close_vs_sma_50h"
+      ],
+      "causal_thesis": "Mean-reversion band fades that fight the local SMA(50) trend are disproportionately stopped out after costs; admitting long entries only when close > SMA(50) and short entries only when close < SMA(50) improves net PF and net return without worsening max drawdown versus the unfiltered Bollinger baseline.",
+      "independent_treatment_change": "Single side-aware pre-entry eligibility filter: ELIGIBLE for a long candidate iff close > SMA(50); ELIGIBLE for a short candidate iff close < SMA(50); otherwise STAND_ASIDE. No change to signal geometry, direction authority, exits, sizing, risk, fees, or slippage.",
+      "expected_effect": "Blocks counter-trend fades; reduces weak entries while preserving with-trend mean-reversion admissions; measurable entry-eligibility divergence vs control.",
+      "known_failure_modes": [
+        "Filter inactive if almost all baseline entries already align with SMA(50)",
+        "Whipsaw around SMA(50) may block good fades near trend turns",
+        "Economic improvement may fail despite divergence (as with prior terminal FAILs)"
+      ],
+      "semantic_distance_to_terminal": {
+        "REGIME_GATED_STANDASIDE_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1": "Not a multi-feature absolute-threshold regime classifier; single price-vs-MA compare.",
+        "ENTRY_EFFECTIVE_MR_ELIGIBILITY_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1": "Not ATR percentile mid-band; no volatility-rank feature.",
+        "RSI_EXHAUSTION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1": "Not RSI level exhaustion; uses SMA alignment, not oscillator extremes.",
+        "ADX_RANGE_ADMISSION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1": "Not ADX level range admission; uses price/MA side alignment, not trend-strength magnitude."
+      },
+      "repo_source_refs": [
+        "config/config.toml#[strategies.rsi_reversion.defaults].trend_ma_window",
+        "config/config.toml#[strategy.rsi_reversion_v1].trend_ma_window",
+        "src/strategies/rsi_reversion.py"
+      ],
+      "frozen_parameter_intent": {
+        "ma_period": 50,
+        "ma_type": "SMA",
+        "side_aware": true
+      },
+      "not_a_parameter_retune_of": [
+        "REGIME_GATED_STANDASIDE_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1",
+        "ENTRY_EFFECTIVE_MR_ELIGIBILITY_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1",
+        "RSI_EXHAUSTION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1",
+        "ADX_RANGE_ADMISSION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1"
+      ]
+    },
+    {
+      "hypothesis_id": "MACD_HISTOGRAM_COUNTERTREND_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1",
+      "canonical_slug": "macd-histogram-countertrend-mr-eligibility",
+      "status": "OPEN_UNPREREGISTERED",
+      "queue_status": "QUEUED",
+      "priority_rank": 2,
+      "priority_score_total": 59,
+      "priority_scores": {
+        "semantic_distance": 3,
+        "entry_effectiveness": 4,
+        "measurability": 5,
+        "low_additional_complexity": 5,
+        "low_overfitting_risk": 4,
+        "repo_support": 5
+      },
+      "feature_family": "macd_histogram_sign_countertrend",
+      "feature_ids": [
+        "macd_histogram_12_26_9"
+      ],
+      "causal_thesis": "Mean-reversion band entries are economically stronger when local MACD histogram sign confirms countertrend exhaustion context (long only when histogram < 0; short only when histogram > 0), improving net PF and net return versus the unfiltered Bollinger baseline without worsening max drawdown.",
+      "independent_treatment_change": "Single side-aware pre-entry eligibility filter on frozen MACD(12,26,9) histogram sign. No multi-gate stack; no change to baseline trading semantics beyond entry admission.",
+      "expected_effect": "Admits fades only when MACD histogram is on the countertrend side; blocks same-sign momentum-aligned fades.",
+      "known_failure_modes": [
+        "Conceptual proximity to oscillator-exhaustion ideas (RSI FAIL) may yield similar non-improvement",
+        "Histogram zero-line churn can create noisy eligibility flips",
+        "Divergence may occur without economic improvement"
+      ],
+      "semantic_distance_to_terminal": {
+        "REGIME_GATED_STANDASIDE_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1": "Not absolute multi-feature regime thresholds; single MACD histogram sign rule.",
+        "ENTRY_EFFECTIVE_MR_ELIGIBILITY_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1": "Not ATR percentile mid-band.",
+        "RSI_EXHAUSTION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1": "Different oscillator family (MACD EMA-spread histogram sign vs RSI level 30/70); not an RSI threshold retune.",
+        "ADX_RANGE_ADMISSION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1": "Not Wilder ADX level; uses MACD histogram sign."
+      },
+      "repo_source_refs": [
+        "config/config.toml#[strategies.macd.defaults]",
+        "src/strategies/macd.py::_calculate_macd"
+      ],
+      "frozen_parameter_intent": {
+        "fast_ema": 12,
+        "slow_ema": 26,
+        "signal_ema": 9,
+        "eligibility_on": "histogram_sign_side_aware"
+      },
+      "not_a_parameter_retune_of": [
+        "REGIME_GATED_STANDASIDE_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1",
+        "ENTRY_EFFECTIVE_MR_ELIGIBILITY_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1",
+        "RSI_EXHAUSTION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1",
+        "ADX_RANGE_ADMISSION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1"
+      ]
+    },
+    {
+      "hypothesis_id": "ADX_DI_DIRECTION_CONFIRMATION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1",
+      "canonical_slug": "adx-di-direction-confirmation-mr-eligibility",
+      "status": "OPEN_UNPREREGISTERED",
+      "queue_status": "QUEUED",
+      "priority_rank": 3,
+      "priority_score_total": 57,
+      "priority_scores": {
+        "semantic_distance": 3,
+        "entry_effectiveness": 4,
+        "measurability": 5,
+        "low_additional_complexity": 5,
+        "low_overfitting_risk": 3,
+        "repo_support": 5
+      },
+      "feature_family": "adx_di_direction_confirmation",
+      "feature_ids": [
+        "plus_di_14h",
+        "minus_di_14h"
+      ],
+      "causal_thesis": "Mean-reversion fades are stronger when DI direction confirms the fade side (long fade only when minus_DI > plus_DI; short fade only when plus_DI > minus_DI), improving net PF and net return versus the unfiltered Bollinger baseline without worsening max drawdown.",
+      "independent_treatment_change": "Single side-aware pre-entry eligibility filter on +DI/−DI ordering from TrendFollowingStrategy._compute_adx. Does not reuse ADX level < 25 range admission.",
+      "expected_effect": "Blocks fades that disagree with DI directional dominance; preserves DI-aligned fade admissions.",
+      "known_failure_modes": [
+        "Shares Wilder ADX calculator family with terminal ADX-level FAIL — must remain DI-order only, never ADX-level retune",
+        "DI crosses can be noisy near equilibrium",
+        "Divergence without economic improvement"
+      ],
+      "semantic_distance_to_terminal": {
+        "REGIME_GATED_STANDASIDE_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1": "Not multi-feature absolute regime classifier.",
+        "ENTRY_EFFECTIVE_MR_ELIGIBILITY_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1": "Not ATR percentile mid-band.",
+        "RSI_EXHAUSTION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1": "Not RSI exhaustion levels.",
+        "ADX_RANGE_ADMISSION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1": "Not ADX magnitude threshold (ADX < 25). Uses +DI/−DI directional ordering only; ADX level is intentionally unused."
+      },
+      "repo_source_refs": [
+        "config/config.toml#[strategies.trend_following.defaults]",
+        "src/strategies/trend_following.py::TrendFollowingStrategy._compute_adx"
+      ],
+      "frozen_parameter_intent": {
+        "adx_period": 14,
+        "uses_adx_level": false,
+        "uses_di_order_only": true,
+        "side_aware": true
+      },
+      "not_a_parameter_retune_of": [
+        "REGIME_GATED_STANDASIDE_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1",
+        "ENTRY_EFFECTIVE_MR_ELIGIBILITY_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1",
+        "RSI_EXHAUSTION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1",
+        "ADX_RANGE_ADMISSION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1"
+      ]
+    }
+  ],
+  "explicitly_excluded_from_this_backlog": [
+    {
+      "candidate_id": "BB_BANDWIDTH_PERCENTILE_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1",
+      "reason": "Excluded a priori due to elevated semantic proximity / overfit risk relative to terminal ATR-percentile mid-band FAIL (volatility-geometry family). Not a free-parameter invent; exclusion is governance hygiene, not performance selection."
+    }
+  ],
+  "governance_rules": {
+    "max_concurrent_open_preregistrations": 1,
+    "development_runs_per_hypothesis": 1,
+    "retuning_after_fail_forbidden": true,
+    "holdout_use_forbidden": true,
+    "candidate_combination_forbidden": true,
+    "reprioritization_requires_separate_versioned_governance_pr": true,
+    "evaluation_requires_separate_preregistration_pr_and_operator_go": true,
+    "economic_gate_closed": true,
+    "promotion_closed": true,
+    "exactly_one_next_eligible_for_preregistration": true,
+    "open_candidate_count_min": 2,
+    "open_candidate_count_max": 4
+  },
+  "explicit_non_actions": [
+    "NO_PREREGISTRATION_IN_THIS_SLICE",
+    "NO_BACKTEST_IN_THIS_SLICE",
+    "NO_ECONOMIC_METRICS_COMPUTATION",
+    "NO_DEVELOPMENT_PANEL_RAW_ACCESS_IN_THIS_SLICE",
+    "NO_PARAMETER_TUNING",
+    "NO_VARIANT_SEARCH",
+    "NO_HOLDOUT_ACCESS",
+    "NO_RUNTIME_ACTIVATION",
+    "NO_PRODUCTIVE_TRADING_LOGIC_CHANGE",
+    "NO_PROMOTION_CLAIM",
+    "NO_RETUNE_OF_TERMINAL_HYPOTHESES",
+    "NO_MULTI_GATE_COMBINATION"
+  ],
+  "next_canonical_step": "SEPARATE_DEFINITION_ONLY_PREREGISTRATION_PR_FOR_NEXT_ELIGIBLE_CANDIDATE_AFTER_OPERATOR_MERGE_GO"
+}

--- a/docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md
+++ b/docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md
@@ -1,0 +1,73 @@
+# Canonical open MR entry-eligibility hypothesis backlog v1
+
+## Status
+
+`OPEN_BACKLOG` — versioned canonical SSOT for open Mean-Reversion entry-eligibility
+research candidates. Definition-only governance. No preregistration, no evaluation,
+no backtest, no holdout access, no runtime activation, no productive trading-logic
+mutation in this slice.
+
+## Binding
+
+- SSOT: `config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json`
+- Validator: `src/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py`
+- Baseline (immutable): `bollinger_bands_v2_full_canonical_system_economic_binding_v1`
+- Required treatment type for future preregistrations:
+  `ENTRY_EFFECTIVE_PRE_ENTRY_ELIGIBILITY_FILTER`
+- Dataset: `pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_dev_pre_holdout_v1`
+  (`DEVELOPMENT_ONLY`, OKX Linear-USDT Non-Bitcoin Perpetuals, PT1H)
+- BTC excluded; Spot excluded
+- Holdout: `offline_economic_reevaluation_sealed_long_panel_v1` opaque exclusion only
+- Economic gate closed; promotion closed
+
+## Terminal hypotheses (referenced unchanged)
+
+1. `REGIME_GATED_STANDASIDE_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1` —
+   FAIL / `identical_arms_gate_inactive_on_entries`
+2. `ENTRY_EFFECTIVE_MR_ELIGIBILITY_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1` —
+   FAIL / `NET_PROFIT_FACTOR_NOT_IMPROVED` (ATR percentile mid-band)
+3. `RSI_EXHAUSTION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1` —
+   FAIL / `NET_PROFIT_FACTOR_NOT_IMPROVED`
+4. `ADX_RANGE_ADMISSION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1` —
+   FAIL / `NET_PROFIT_FACTOR_NOT_IMPROVED`
+
+Semantic duplicates and parameter retunes of these terminals are forbidden.
+
+## Open candidates (deterministic priority)
+
+Priority criteria are locked a priori (semantic distance, entry-effectiveness,
+measurability, low complexity, low overfit risk, repo support). No performance-based
+selection. No ties.
+
+| Rank | Hypothesis ID | Queue |
+|---:|---|---|
+| 1 | `MA_TREND_ALIGNMENT_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1` | `NEXT_ELIGIBLE_FOR_PREREGISTRATION` |
+| 2 | `MACD_HISTOGRAM_COUNTERTREND_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1` | `QUEUED` |
+| 3 | `ADX_DI_DIRECTION_CONFIRMATION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1` | `QUEUED` |
+
+All open candidates are `OPEN_UNPREREGISTERED`.
+
+## Governance rules
+
+- At most one open preregistration at a time
+- Exactly one development run per hypothesis
+- No retuning after FAIL
+- No holdout use
+- No candidate combination / multi-gate stacks
+- No reprioritization without a separate versioned governance PR
+- Evaluation only after a separate preregistration PR and operator GO
+- Runtime / shadow / paper / testnet / live / orders remain locked
+
+## Gates
+
+- `PROMOTION_ELIGIBLE=false`
+- Economic offline gate unchanged/closed
+- `PRODUCTIVE_TRADING_LOGIC_CHANGED=false`
+- `AUTHORITY_CHANGED=false`
+- `EVALUATION_EXECUTED=false`
+- `DEVELOPMENT_RUN_COUNT=0`
+
+## Next step
+
+After merge + operator GO: open a separate definition-only preregistration PR for
+`MA_TREND_ALIGNMENT_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1` only.

--- a/src/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py
+++ b/src/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py
@@ -1,0 +1,407 @@
+"""Canonical open MR entry-eligibility hypothesis backlog SSOT validator v1.
+
+Definition-only governance. No preregistration, backtest, economic metrics,
+holdout access, runtime activation, or productive trading-logic mutation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+PACKAGE_MARKER = "CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1=true"
+BACKLOG_REL_PATH = "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json"
+GOVERNANCE_REL_PATH = "docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md"
+REQUIRED_STATUS = "OPEN_BACKLOG"
+REQUIRED_DATASET_ID = "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_dev_pre_holdout_v1"
+REQUIRED_TREATMENT_TYPE = "ENTRY_EFFECTIVE_PRE_ENTRY_ELIGIBILITY_FILTER"
+HOLDOUT_OPAQUE_ID = "offline_economic_reevaluation_sealed_long_panel_v1"
+REQUIRED_TERMINAL_HYPOTHESIS_IDS = (
+    "REGIME_GATED_STANDASIDE_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1",
+    "ENTRY_EFFECTIVE_MR_ELIGIBILITY_MEAN_REVERSION_NON_BITCOIN_PERPETUALS_V1",
+    "RSI_EXHAUSTION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1",
+    "ADX_RANGE_ADMISSION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1",
+)
+FORBIDDEN_FEATURE_FAMILIES = frozenset(
+    {
+        "multi_feature_absolute_threshold_regime_classifier",
+        "atr_rolling_percentile_midband",
+        "rsi_exhaustion_level",
+        "adx_level_range_admission",
+    }
+)
+FORBIDDEN_EMBEDDED_RESULT_KEYS = frozenset(
+    {
+        "baseline_metrics",
+        "treatment_metrics",
+        "measured_net_return",
+        "measured_profit_factor",
+        "economic_metrics",
+        "RESULT_CLASS",
+        "result_class",
+        "comparison_decision",
+        "probe_summary",
+    }
+)
+NEXT_ELIGIBLE = "NEXT_ELIGIBLE_FOR_PREREGISTRATION"
+QUEUED = "QUEUED"
+OPEN_UNPREREGISTERED = "OPEN_UNPREREGISTERED"
+PRIORITY_DIMENSIONS = (
+    "semantic_distance",
+    "entry_effectiveness",
+    "measurability",
+    "low_additional_complexity",
+    "low_overfitting_risk",
+    "repo_support",
+)
+PRIORITY_WEIGHTS = {
+    "semantic_distance": 3,
+    "entry_effectiveness": 3,
+    "measurability": 2,
+    "low_additional_complexity": 2,
+    "low_overfitting_risk": 2,
+    "repo_support": 2,
+}
+
+
+class BacklogValidationError(ValueError):
+    """Fail-closed backlog SSOT validation error."""
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _assert_true(condition: bool, code: str, detail: str = "") -> None:
+    if not condition:
+        suffix = f": {detail}" if detail else ""
+        raise BacklogValidationError(f"{code}{suffix}")
+
+
+def _contains_banned_result_keys(obj: Any, path: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(obj, Mapping):
+        for key, value in obj.items():
+            key_path = f"{path}.{key}"
+            if key in FORBIDDEN_EMBEDDED_RESULT_KEYS:
+                # Allow documenting terminal fail_reason/result references only
+                # under terminal_hypotheses.*.fail_reason / fail_finding.
+                if key in {"RESULT_CLASS", "result_class"} and ".terminal_hypotheses[" not in path:
+                    found.append(key_path)
+                elif key not in {"RESULT_CLASS", "result_class"}:
+                    found.append(key_path)
+            found.extend(_contains_banned_result_keys(value, key_path))
+    elif isinstance(obj, list):
+        for idx, item in enumerate(obj):
+            found.extend(_contains_banned_result_keys(item, f"{path}[{idx}]"))
+    return found
+
+
+def compute_priority_score_total(scores: Mapping[str, Any]) -> int:
+    total = 0
+    for dim, weight in PRIORITY_WEIGHTS.items():
+        if dim not in scores:
+            raise BacklogValidationError(f"PRIORITY_SCORE_MISSING: {dim}")
+        value = scores[dim]
+        if not isinstance(value, int) or value < 1 or value > 5:
+            raise BacklogValidationError(f"PRIORITY_SCORE_RANGE: {dim}={value!r}")
+        total += weight * value
+    return total
+
+
+def validate_backlog_contract(backlog: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the canonical open MR eligibility backlog SSOT fail-closed."""
+    _assert_true(backlog.get("status") == REQUIRED_STATUS, "STATUS_NOT_OPEN_BACKLOG")
+    _assert_true(backlog.get("canonical_ssot") is True, "NOT_CANONICAL_SSOT")
+    _assert_true(
+        backlog.get("exactly_one_authoritative_truth") is True,
+        "NOT_EXACTLY_ONE_AUTHORITATIVE_TRUTH",
+    )
+    _assert_true(
+        backlog.get("productive_trading_logic_included") is False,
+        "PRODUCTIVE_TRADING_LOGIC_INCLUDED",
+    )
+    _assert_true(backlog.get("evaluation_authorized") is False, "EVALUATION_AUTHORIZED")
+    _assert_true(backlog.get("backtest_authorized") is False, "BACKTEST_AUTHORIZED")
+    _assert_true(
+        backlog.get("preregistration_authorized_in_this_slice") is False,
+        "PREREGISTRATION_AUTHORIZED_IN_SLICE",
+    )
+    _assert_true(
+        backlog.get("evaluation_results_embedded") is False,
+        "EVALUATION_RESULTS_EMBEDDED_FLAG",
+    )
+    _assert_true(backlog.get("development_run_count") == 0, "DEVELOPMENT_RUN_COUNT_NONZERO")
+    _assert_true(backlog.get("dataset_id") == REQUIRED_DATASET_ID, "DATASET_ID_MISMATCH")
+    _assert_true(backlog.get("dataset_class") == "DEVELOPMENT_ONLY", "DATASET_CLASS")
+    _assert_true(backlog.get("holdout_forbidden") is True, "HOLDOUT_NOT_FORBIDDEN")
+    _assert_true(
+        backlog.get("sealed_holdout_id") == HOLDOUT_OPAQUE_ID,
+        "HOLDOUT_ID_MISMATCH",
+    )
+    _assert_true(
+        backlog.get("sealed_holdout_content_inspection_authorized") is False,
+        "HOLDOUT_INSPECTION_AUTHORIZED",
+    )
+    _assert_true(
+        backlog.get("required_treatment_type") == REQUIRED_TREATMENT_TYPE,
+        "TREATMENT_TYPE_MISMATCH",
+    )
+
+    universe = backlog.get("universe_scope")
+    _assert_true(isinstance(universe, Mapping), "UNIVERSE_SCOPE_MISSING")
+    assert isinstance(universe, Mapping)
+    _assert_true(universe.get("bitcoin_excluded") is True, "BTC_NOT_EXCLUDED")
+    _assert_true(universe.get("spot_excluded") is True, "SPOT_NOT_EXCLUDED")
+    _assert_true(universe.get("venue") == "OKX", "VENUE_NOT_OKX")
+    _assert_true(
+        universe.get("instrument_class") == "LINEAR_USDT_PERPETUAL",
+        "INSTRUMENT_CLASS",
+    )
+    _assert_true(universe.get("frequency") == "PT1H", "FREQUENCY")
+
+    runtime = backlog.get("runtime_policy")
+    _assert_true(isinstance(runtime, Mapping), "RUNTIME_POLICY_MISSING")
+    assert isinstance(runtime, Mapping)
+    for key in (
+        "runtime_activated",
+        "shadow_activated",
+        "paper_activated",
+        "testnet_activated",
+        "live_authorized",
+        "orders_allowed",
+        "scheduler_authorized",
+    ):
+        _assert_true(runtime.get(key) is False, f"RUNTIME_UNLOCKED:{key}")
+
+    promo = backlog.get("promotion_and_economic_gate_policy")
+    _assert_true(isinstance(promo, Mapping), "PROMOTION_POLICY_MISSING")
+    assert isinstance(promo, Mapping)
+    _assert_true(promo.get("promotion_eligible") is False, "PROMOTION_ELIGIBLE")
+    _assert_true(
+        promo.get("economic_validity_offline_gate_pass") is False,
+        "ECONOMIC_GATE_OPEN",
+    )
+    _assert_true(
+        promo.get("economic_validity_offline_gate_changed") is False,
+        "ECONOMIC_GATE_CHANGED",
+    )
+
+    banned = _contains_banned_result_keys(backlog)
+    _assert_true(not banned, "EMBEDDED_RESULT_METRICS", ", ".join(banned[:8]))
+
+    terminals = backlog.get("terminal_hypotheses")
+    _assert_true(isinstance(terminals, list), "TERMINAL_HYPOTHESES_MISSING")
+    assert isinstance(terminals, list)
+    _assert_true(len(terminals) == 4, "TERMINAL_HYPOTHESIS_COUNT", str(len(terminals)))
+    terminal_ids = [t.get("hypothesis_id") for t in terminals]
+    _assert_true(
+        tuple(terminal_ids) == REQUIRED_TERMINAL_HYPOTHESIS_IDS,
+        "TERMINAL_HYPOTHESIS_IDS",
+        str(terminal_ids),
+    )
+    for terminal in terminals:
+        _assert_true(isinstance(terminal, Mapping), "TERMINAL_ENTRY_TYPE")
+        assert isinstance(terminal, Mapping)
+        _assert_true(terminal.get("status") == "TERMINAL_FAIL", "TERMINAL_STATUS")
+        _assert_true(isinstance(terminal.get("fail_reason"), str), "TERMINAL_FAIL_REASON")
+        _assert_true(isinstance(terminal.get("fail_finding"), str), "TERMINAL_FAIL_FINDING")
+        _assert_true(isinstance(terminal.get("feature_family"), str), "TERMINAL_FEATURE_FAMILY")
+        _assert_true(
+            isinstance(terminal.get("feature_ids"), list) and terminal["feature_ids"],
+            "TERMINAL_FEATURE_IDS",
+        )
+
+    forbidden_families = backlog.get("forbidden_feature_families_for_open_candidates")
+    _assert_true(isinstance(forbidden_families, list), "FORBIDDEN_FAMILIES_MISSING")
+    assert isinstance(forbidden_families, list)
+    _assert_true(
+        FORBIDDEN_FEATURE_FAMILIES.issubset(set(forbidden_families)),
+        "FORBIDDEN_FAMILIES_INCOMPLETE",
+    )
+
+    candidates = backlog.get("open_candidates")
+    _assert_true(isinstance(candidates, list), "OPEN_CANDIDATES_MISSING")
+    assert isinstance(candidates, list)
+    rules = backlog.get("governance_rules")
+    _assert_true(isinstance(rules, Mapping), "GOVERNANCE_RULES_MISSING")
+    assert isinstance(rules, Mapping)
+    min_c = int(rules.get("open_candidate_count_min", 2))
+    max_c = int(rules.get("open_candidate_count_max", 4))
+    _assert_true(min_c <= len(candidates) <= max_c, "OPEN_CANDIDATE_COUNT", str(len(candidates)))
+
+    _assert_true(rules.get("max_concurrent_open_preregistrations") == 1, "MAX_CONCURRENT_PREREG")
+    _assert_true(rules.get("development_runs_per_hypothesis") == 1, "DEV_RUNS_PER_HYP")
+    _assert_true(rules.get("retuning_after_fail_forbidden") is True, "RETUNE_ALLOWED")
+    _assert_true(rules.get("holdout_use_forbidden") is True, "HOLDOUT_USE_ALLOWED")
+    _assert_true(rules.get("candidate_combination_forbidden") is True, "COMBINATION_ALLOWED")
+    _assert_true(
+        rules.get("reprioritization_requires_separate_versioned_governance_pr") is True,
+        "REPRIORITIZATION_UNLOCKED",
+    )
+    _assert_true(
+        rules.get("evaluation_requires_separate_preregistration_pr_and_operator_go") is True,
+        "EVAL_WITHOUT_GO",
+    )
+    _assert_true(rules.get("economic_gate_closed") is True, "ECONOMIC_GATE_NOT_CLOSED")
+    _assert_true(rules.get("promotion_closed") is True, "PROMOTION_NOT_CLOSED")
+    _assert_true(
+        rules.get("exactly_one_next_eligible_for_preregistration") is True,
+        "EXACTLY_ONE_NEXT_RULE_MISSING",
+    )
+
+    candidate_ids: list[str] = []
+    ranks: list[int] = []
+    totals: list[int] = []
+    next_eligible: list[str] = []
+    for candidate in candidates:
+        _assert_true(isinstance(candidate, Mapping), "CANDIDATE_TYPE")
+        assert isinstance(candidate, Mapping)
+        hyp_id = candidate.get("hypothesis_id")
+        _assert_true(isinstance(hyp_id, str) and hyp_id, "CANDIDATE_ID_MISSING")
+        assert isinstance(hyp_id, str)
+        _assert_true(hyp_id not in candidate_ids, "DUPLICATE_CANDIDATE_ID", hyp_id)
+        _assert_true(
+            hyp_id not in REQUIRED_TERMINAL_HYPOTHESIS_IDS, "CANDIDATE_IS_TERMINAL", hyp_id
+        )
+        candidate_ids.append(hyp_id)
+
+        _assert_true(candidate.get("status") == OPEN_UNPREREGISTERED, "CANDIDATE_STATUS", hyp_id)
+        queue_status = candidate.get("queue_status")
+        _assert_true(queue_status in {NEXT_ELIGIBLE, QUEUED}, "QUEUE_STATUS", hyp_id)
+        if queue_status == NEXT_ELIGIBLE:
+            next_eligible.append(hyp_id)
+
+        family = candidate.get("feature_family")
+        _assert_true(isinstance(family, str) and family, "FEATURE_FAMILY", hyp_id)
+        assert isinstance(family, str)
+        _assert_true(
+            family not in FORBIDDEN_FEATURE_FAMILIES,
+            "SEMANTIC_DUPLICATE_FEATURE_FAMILY",
+            f"{hyp_id}:{family}",
+        )
+
+        scores = candidate.get("priority_scores")
+        _assert_true(isinstance(scores, Mapping), "PRIORITY_SCORES_MISSING", hyp_id)
+        assert isinstance(scores, Mapping)
+        for dim in PRIORITY_DIMENSIONS:
+            _assert_true(dim in scores, "PRIORITY_DIMENSION_MISSING", f"{hyp_id}:{dim}")
+        computed = compute_priority_score_total(scores)
+        declared = candidate.get("priority_score_total")
+        _assert_true(
+            declared == computed, "PRIORITY_TOTAL_MISMATCH", f"{hyp_id}:{declared}!={computed}"
+        )
+        totals.append(computed)
+
+        rank = candidate.get("priority_rank")
+        _assert_true(isinstance(rank, int) and rank >= 1, "PRIORITY_RANK", hyp_id)
+        assert isinstance(rank, int)
+        ranks.append(rank)
+
+        distance = candidate.get("semantic_distance_to_terminal")
+        _assert_true(isinstance(distance, Mapping), "SEMANTIC_DISTANCE_MISSING", hyp_id)
+        assert isinstance(distance, Mapping)
+        for terminal_id in REQUIRED_TERMINAL_HYPOTHESIS_IDS:
+            _assert_true(
+                terminal_id in distance and isinstance(distance[terminal_id], str),
+                "SEMANTIC_DISTANCE_INCOMPLETE",
+                f"{hyp_id}:{terminal_id}",
+            )
+
+        for required in (
+            "causal_thesis",
+            "independent_treatment_change",
+            "expected_effect",
+            "known_failure_modes",
+            "repo_source_refs",
+            "frozen_parameter_intent",
+            "not_a_parameter_retune_of",
+        ):
+            _assert_true(required in candidate, "CANDIDATE_FIELD_MISSING", f"{hyp_id}:{required}")
+        _assert_true(
+            set(candidate.get("not_a_parameter_retune_of", []))
+            >= set(REQUIRED_TERMINAL_HYPOTHESIS_IDS),
+            "RETUNE_DENIAL_INCOMPLETE",
+            hyp_id,
+        )
+
+    _assert_true(len(next_eligible) == 1, "EXACTLY_ONE_NEXT_ELIGIBLE", str(next_eligible))
+    _assert_true(
+        sorted(ranks) == list(range(1, len(candidates) + 1)), "PRIORITY_RANKS_NOT_PERMUTATION"
+    )
+    _assert_true(len(set(totals)) == len(totals), "PRIORITY_TOTAL_TIE")
+
+    ordered = sorted(candidates, key=lambda c: int(c["priority_rank"]))
+    _assert_true(
+        ordered[0].get("queue_status") == NEXT_ELIGIBLE,
+        "NEXT_ELIGIBLE_NOT_RANK_ONE",
+    )
+    for candidate in ordered[1:]:
+        _assert_true(candidate.get("queue_status") == QUEUED, "NON_NEXT_NOT_QUEUED")
+
+    # Deterministic descending score order must match ascending rank.
+    score_order = sorted(
+        candidates,
+        key=lambda c: (-int(c["priority_score_total"]), str(c["hypothesis_id"])),
+    )
+    _assert_true(
+        [c["hypothesis_id"] for c in score_order] == [c["hypothesis_id"] for c in ordered],
+        "PRIORITY_ORDER_NOT_DETERMINISTIC",
+    )
+
+    criteria = backlog.get("priority_criteria")
+    _assert_true(isinstance(criteria, Mapping), "PRIORITY_CRITERIA_MISSING")
+    assert isinstance(criteria, Mapping)
+    _assert_true(
+        criteria.get("selection_performance_forbidden") is True,
+        "PERFORMANCE_SELECTION_ALLOWED",
+    )
+    _assert_true(criteria.get("criteria_locked_a_priori") is True, "CRITERIA_NOT_LOCKED")
+
+    return {
+        "valid": True,
+        "status": REQUIRED_STATUS,
+        "terminal_hypothesis_count": 4,
+        "open_candidate_count": len(candidates),
+        "next_eligible_hypothesis_id": next_eligible[0],
+        "priority_order": [c["hypothesis_id"] for c in ordered],
+        "development_run_count": 0,
+        "evaluation_authorized": False,
+        "holdout_forbidden": True,
+        "runtime_locked": True,
+    }
+
+
+def load_and_validate_repo_backlog(repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or _repo_root()
+    path = root / BACKLOG_REL_PATH
+    _assert_true(path.is_file(), "BACKLOG_SSOT_MISSING", str(path))
+    governance = root / GOVERNANCE_REL_PATH
+    _assert_true(governance.is_file(), "GOVERNANCE_DOC_MISSING", str(governance))
+    backlog = _load_json(path)
+    report = validate_backlog_contract(backlog)
+    report["backlog_path"] = BACKLOG_REL_PATH
+    report["governance_path"] = GOVERNANCE_REL_PATH
+    return report
+
+
+def assert_exactly_one_backlog_ssot(repo_root: Path | None = None) -> None:
+    """Fail-closed: exactly one canonical open MR eligibility backlog SSOT file."""
+    root = repo_root or _repo_root()
+    matches = sorted((root / "config" / "research").glob("*open*mr*eligibility*backlog*.json"))
+    # Also catch alternate naming for the same surface.
+    matches += sorted(
+        (root / "config" / "research").glob("*mr_entry_eligibility_hypothesis_backlog*.json")
+    )
+    unique = sorted({p.resolve() for p in matches})
+    _assert_true(len(unique) == 1, "BACKLOG_SSOT_COUNT", str([str(p) for p in unique]))
+    _assert_true(
+        unique[0] == (root / BACKLOG_REL_PATH).resolve(),
+        "BACKLOG_SSOT_PATH_UNEXPECTED",
+        str(unique[0]),
+    )

--- a/tests/research/test_canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py
+++ b/tests/research/test_canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py
@@ -1,0 +1,202 @@
+"""Contract tests for canonical open MR entry-eligibility hypothesis backlog v1.
+
+Definition-only governance. No backtest. No economic metrics. No holdout access.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from src.research.canonical_open_mr_entry_eligibility_hypothesis_backlog_v1 import (
+    BACKLOG_REL_PATH,
+    FORBIDDEN_FEATURE_FAMILIES,
+    GOVERNANCE_REL_PATH,
+    HOLDOUT_OPAQUE_ID,
+    NEXT_ELIGIBLE,
+    QUEUED,
+    REQUIRED_TERMINAL_HYPOTHESIS_IDS,
+    BacklogValidationError,
+    assert_exactly_one_backlog_ssot,
+    load_and_validate_repo_backlog,
+    validate_backlog_contract,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+BACKLOG_PATH = REPO / BACKLOG_REL_PATH
+GOVERNANCE_PATH = REPO / GOVERNANCE_REL_PATH
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_exactly_one_backlog_ssot_exists() -> None:
+    assert_exactly_one_backlog_ssot(REPO)
+    assert BACKLOG_PATH.is_file()
+    assert GOVERNANCE_PATH.is_file()
+
+
+def test_repo_backlog_validates() -> None:
+    report = load_and_validate_repo_backlog(REPO)
+    assert report["valid"] is True
+    assert report["status"] == "OPEN_BACKLOG"
+    assert report["terminal_hypothesis_count"] == 4
+    assert 2 <= report["open_candidate_count"] <= 4
+    assert report["development_run_count"] == 0
+    assert report["evaluation_authorized"] is False
+    assert report["holdout_forbidden"] is True
+    assert report["runtime_locked"] is True
+    assert report["next_eligible_hypothesis_id"] == (
+        "MA_TREND_ALIGNMENT_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1"
+    )
+
+
+def test_all_terminal_hypotheses_captured_unchanged() -> None:
+    backlog = _load(BACKLOG_PATH)
+    terminals = backlog["terminal_hypotheses"]
+    assert [t["hypothesis_id"] for t in terminals] == list(REQUIRED_TERMINAL_HYPOTHESIS_IDS)
+    assert all(t["status"] == "TERMINAL_FAIL" for t in terminals)
+    assert terminals[0]["fail_finding"] == "identical_arms_gate_inactive_on_entries"
+    assert terminals[1]["fail_reason"] == "NET_PROFIT_FACTOR_NOT_IMPROVED"
+    assert terminals[2]["fail_reason"] == "NET_PROFIT_FACTOR_NOT_IMPROVED"
+    assert terminals[3]["fail_reason"] == "NET_PROFIT_FACTOR_NOT_IMPROVED"
+
+
+def test_open_candidate_count_and_unique_ids() -> None:
+    backlog = _load(BACKLOG_PATH)
+    candidates = backlog["open_candidates"]
+    assert 2 <= len(candidates) <= 4
+    ids = [c["hypothesis_id"] for c in candidates]
+    assert len(ids) == len(set(ids))
+    assert not set(ids) & set(REQUIRED_TERMINAL_HYPOTHESIS_IDS)
+
+
+def test_priority_order_complete_deterministic_no_ties() -> None:
+    backlog = _load(BACKLOG_PATH)
+    candidates = backlog["open_candidates"]
+    ranks = sorted(c["priority_rank"] for c in candidates)
+    assert ranks == list(range(1, len(candidates) + 1))
+    totals = [c["priority_score_total"] for c in candidates]
+    assert len(set(totals)) == len(totals)
+    ordered = sorted(candidates, key=lambda c: c["priority_rank"])
+    by_score = sorted(
+        candidates,
+        key=lambda c: (-c["priority_score_total"], c["hypothesis_id"]),
+    )
+    assert [c["hypothesis_id"] for c in ordered] == [c["hypothesis_id"] for c in by_score]
+
+
+def test_exactly_one_next_eligible_for_preregistration() -> None:
+    backlog = _load(BACKLOG_PATH)
+    next_ones = [c for c in backlog["open_candidates"] if c["queue_status"] == NEXT_ELIGIBLE]
+    queued = [c for c in backlog["open_candidates"] if c["queue_status"] == QUEUED]
+    assert len(next_ones) == 1
+    assert next_ones[0]["priority_rank"] == 1
+    assert next_ones[0]["status"] == "OPEN_UNPREREGISTERED"
+    assert all(c["queue_status"] == QUEUED for c in queued)
+    assert all(c["status"] == "OPEN_UNPREREGISTERED" for c in backlog["open_candidates"])
+
+
+def test_no_semantic_duplicate_feature_families() -> None:
+    backlog = _load(BACKLOG_PATH)
+    for candidate in backlog["open_candidates"]:
+        assert candidate["feature_family"] not in FORBIDDEN_FEATURE_FAMILIES
+        for terminal_id in REQUIRED_TERMINAL_HYPOTHESIS_IDS:
+            assert terminal_id in candidate["semantic_distance_to_terminal"]
+            assert candidate["semantic_distance_to_terminal"][terminal_id]
+            assert terminal_id in candidate["not_a_parameter_retune_of"]
+
+
+def test_no_embedded_evaluation_results_or_runs() -> None:
+    backlog = _load(BACKLOG_PATH)
+    blob = json.dumps(backlog)
+    for banned in (
+        "baseline_metrics",
+        "treatment_metrics",
+        "measured_net_return",
+        "measured_profit_factor",
+        "economic_metrics",
+        "comparison_decision",
+        "probe_summary",
+    ):
+        assert banned not in backlog
+        assert f'"{banned}"' not in blob
+    assert backlog["development_run_count"] == 0
+    assert backlog["evaluation_results_embedded"] is False
+    assert backlog["evaluation_authorized"] is False
+    assert backlog["backtest_authorized"] is False
+
+
+def test_holdout_and_runtime_remain_locked() -> None:
+    backlog = _load(BACKLOG_PATH)
+    assert backlog["holdout_forbidden"] is True
+    assert backlog["sealed_holdout_id"] == HOLDOUT_OPAQUE_ID
+    assert backlog["sealed_holdout_content_inspection_authorized"] is False
+    runtime = backlog["runtime_policy"]
+    assert runtime["runtime_activated"] is False
+    assert runtime["shadow_activated"] is False
+    assert runtime["paper_activated"] is False
+    assert runtime["testnet_activated"] is False
+    assert runtime["live_authorized"] is False
+    assert runtime["orders_allowed"] is False
+    assert runtime["scheduler_authorized"] is False
+    promo = backlog["promotion_and_economic_gate_policy"]
+    assert promo["promotion_eligible"] is False
+    assert promo["economic_validity_offline_gate_pass"] is False
+
+
+def test_universe_and_governance_bindings() -> None:
+    backlog = _load(BACKLOG_PATH)
+    universe = backlog["universe_scope"]
+    assert universe["bitcoin_excluded"] is True
+    assert universe["spot_excluded"] is True
+    assert universe["venue"] == "OKX"
+    assert universe["instrument_class"] == "LINEAR_USDT_PERPETUAL"
+    assert universe["frequency"] == "PT1H"
+    assert (
+        backlog["dataset_id"]
+        == "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_dev_pre_holdout_v1"
+    )
+    rules = backlog["governance_rules"]
+    assert rules["max_concurrent_open_preregistrations"] == 1
+    assert rules["development_runs_per_hypothesis"] == 1
+    assert rules["retuning_after_fail_forbidden"] is True
+    assert rules["candidate_combination_forbidden"] is True
+    assert rules["reprioritization_requires_separate_versioned_governance_pr"] is True
+
+
+def test_validator_rejects_second_next_eligible() -> None:
+    backlog = _load(BACKLOG_PATH)
+    bad = copy.deepcopy(backlog)
+    bad["open_candidates"][1]["queue_status"] = NEXT_ELIGIBLE
+    with pytest.raises(BacklogValidationError, match="EXACTLY_ONE_NEXT_ELIGIBLE"):
+        validate_backlog_contract(bad)
+
+
+def test_validator_rejects_forbidden_feature_family_retune() -> None:
+    backlog = _load(BACKLOG_PATH)
+    bad = copy.deepcopy(backlog)
+    bad["open_candidates"][0]["feature_family"] = "adx_level_range_admission"
+    with pytest.raises(BacklogValidationError, match="SEMANTIC_DUPLICATE_FEATURE_FAMILY"):
+        validate_backlog_contract(bad)
+
+
+def test_validator_rejects_nonzero_development_run_count() -> None:
+    backlog = _load(BACKLOG_PATH)
+    bad = copy.deepcopy(backlog)
+    bad["development_run_count"] = 1
+    with pytest.raises(BacklogValidationError, match="DEVELOPMENT_RUN_COUNT_NONZERO"):
+        validate_backlog_contract(bad)
+
+
+def test_governance_doc_marks_definition_only_and_next_eligible() -> None:
+    text = GOVERNANCE_PATH.read_text(encoding="utf-8")
+    assert "OPEN_BACKLOG" in text
+    assert "PROMOTION_ELIGIBLE=false" in text
+    assert "MA_TREND_ALIGNMENT_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1" in text
+    assert "NEXT_ELIGIBLE_FOR_PREREGISTRATION" in text
+    assert "EVALUATION_EXECUTED=false" in text


### PR DESCRIPTION
## Summary
- Version a canonical `OPEN_BACKLOG` SSOT for MR entry-eligibility research after four terminal FAILs.
- Register three orthogonal `OPEN_UNPREREGISTERED` candidates with deterministic priority; next eligible is `MA_TREND_ALIGNMENT_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1`.
- Bind governance rules (single concurrent preregistration, one development run, no retune/holdout/runtime) with fail-closed validator tests. Definition-only: no evaluation.

## Test plan
- [x] `pytest tests/research/test_canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py`
- [x] `ruff format --check` / `ruff check` on changed Python
- [x] docs token policy + docs reference targets
- [ ] CI green on PR
- [ ] No merge until explicit operator GO

Made with [Cursor](https://cursor.com)