### PR TITLE
fix(backtest): restore mandatory mv2 boundary fixture binding

### DIFF
--- a/tests/backtest/test_admissible_versioned_futures_dataset_v1.py
+++ b/tests/backtest/test_admissible_versioned_futures_dataset_v1.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+from pathlib import Path
 from typing import Any, Mapping
 
 import pandas as pd
@@ -13,6 +14,22 @@ from scripts.ops.primary_evidence_retention_v0 import verify_manifest_sha256, wr
 from src.backtest import admissible_versioned_futures_dataset_v1 as ds
 from src.backtest import economic_viability_evidence_v1 as ev
 from src.backtest import mv2_research_wiring_v1 as wiring
+from src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0 import (
+    MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_REFERENCE_MANDATORY_BINDING_CONFIG = (
+    _REPO_ROOT
+    / "config/ops/cross_sectional_futures_lead_lag_information_diffusion_v0_economic_evaluation_v1.json"
+)
+
+
+def _mandatory_mv2_boundary_state_file_binding_section() -> dict[str, Any]:
+    """Reuse canonical mandatory MV2 boundary fixtures for evidence wiring."""
+    return json.loads(_REFERENCE_MANDATORY_BINDING_CONFIG.read_text(encoding="utf-8"))[
+        MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION
+    ]
 
 
 def _bars(n: int = 24) -> pd.DataFrame:
@@ -137,6 +154,9 @@ def _cfg_with_dataset(bars: pd.DataFrame, **descriptor_overrides: Any) -> Mappin
                 "slow_window": 3,
             },
         },
+        MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION: (
+            _mandatory_mv2_boundary_state_file_binding_section()
+        ),
     }
 
 
@@ -294,6 +314,9 @@ class TestEconomicViabilityDatasetIntegration:
                 "economic_evaluation_v1": {
                     "strategy_params": {"fast_window": 2, "slow_window": 3},
                 },
+                MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION: (
+                    _mandatory_mv2_boundary_state_file_binding_section()
+                ),
             },
         )
         assert result.status is ev.EconomicViabilityStatus.RESEARCH_ONLY


### PR DESCRIPTION
## Summary
- Restores the mandatory `mv2_research_backtest_mandatory_boundary_state_file_binding_v0` section in admissible futures dataset evidence fixtures so `build_economic_viability_evidence_v1` can resolve canonical MV2 boundary state-file bindings.
- Fixes baseline regression `mandatory_mv2_boundary_state_file_binding_failed:MANDATORY_STATE_FILE_BINDING_SECTION_MISSING` for `test_evidence_without_admissible_dataset_stays_research_only` without weakening the mandatory production contract.
- Scope is fixture-only; no production, runtime, authority, or execution changes.

## Test plan
- [x] `pytest ...::test_evidence_without_admissible_dataset_stays_research_only`
- [x] `pytest tests/backtest/test_admissible_versioned_futures_dataset_v1.py`
- [x] `ruff format --check` / `ruff check` on changed file
- [ ] CI confirmation on focused path
- Note: `test_admissible_versioned_futures_dataset_profile_v1.py` still fails on origin/main due to independent volatility-binding baseline (`BLOCKED_REQUIRED_FIELD_MISSING`); tracked separately, not in this PR.


Made with [Cursor](https://cursor.com)