### PR TITLE
fix(backtest): bind mandatory mv2 state section in evidence fixture

### DIFF
--- a/tests/backtest/test_economic_viability_evidence_v1.py
+++ b/tests/backtest/test_economic_viability_evidence_v1.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any, Mapping
 
 import pandas as pd
@@ -9,6 +10,22 @@ import pytest
 from src.backtest import economic_validity_policy_v1 as policy_mod
 from src.backtest import economic_viability_evidence_v1 as ev
 from src.backtest import mv2_research_wiring_v1 as wiring
+from src.research.cross_sectional_futures_lead_lag_v0_mv2_research_backtest_wiring_boundary_adapter_v0 import (
+    MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_REFERENCE_MANDATORY_BINDING_CONFIG = (
+    _REPO_ROOT
+    / "config/ops/cross_sectional_futures_lead_lag_information_diffusion_v0_economic_evaluation_v1.json"
+)
+
+
+def _mandatory_mv2_boundary_state_file_binding_section() -> dict[str, Any]:
+    """Reuse canonical mandatory MV2 boundary fixtures for evidence wiring."""
+    return json.loads(_REFERENCE_MANDATORY_BINDING_CONFIG.read_text(encoding="utf-8"))[
+        MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION
+    ]
 
 
 def _cfg(*, fee_bps: float = 10.0, slippage_bps: float = 5.0) -> Mapping[str, Any]:
@@ -31,6 +48,9 @@ def _cfg(*, fee_bps: float = 10.0, slippage_bps: float = 5.0) -> Mapping[str, An
                 "slow_window": 3,
             },
         },
+        MV2_RESEARCH_BACKTEST_MANDATORY_BOUNDARY_STATE_FILE_BINDING_SECTION: (
+            _mandatory_mv2_boundary_state_file_binding_section()
+        ),
     }
 
 


### PR DESCRIPTION
## Summary
- Restores the mandatory `mv2_research_backtest_mandatory_boundary_state_file_binding_v0` section in `tests/backtest/test_economic_viability_evidence_v1.py` synthetic cfg fixtures.
- Fixes origin/main baseline `mandatory_mv2_boundary_state_file_binding_failed:MANDATORY_STATE_FILE_BINDING_SECTION_MISSING` for `test_build_evidence_research_only_for_synthetic_fixture`.
- Reuses the canonical ops binding section; does not weaken production fail-closed mandatory boundary validation.

## Root cause
After mandatory MV2 boundary state-file binding became required for default `mv2_decision_replay_series` evidence builds, the synthetic evidence test fixture omitted `mv2_research_backtest_mandatory_boundary_state_file_binding_v0`.

## Fix
Fixture-only: load the canonical mandatory binding section into `_cfg()` so all evidence builder paths in this file satisfy the contract while remaining research-only / non-admissible as asserted.

## Test plan
- [x] `pytest ...::test_build_evidence_research_only_for_synthetic_fixture`
- [x] `pytest tests/backtest/test_economic_viability_evidence_v1.py` (40 passed)
- [x] related: `test_builder_blocks_when_binding_section_missing` + `test_admissible_versioned_futures_dataset_v1.py`
- [x] `ruff format --check` / `ruff check`
- [ ] CI confirmation on focused path

## Safety negatives
- No production / Master V2 / authority / risk / sizing / execution / runtime / live-gate changes
- No holdout access, no orders, no research re-evaluation
- Independent origin/main baseline remains: `tests/backtest/test_obl_b05_bollinger_long_semantic_decision_v1.py::test_eval_only_runner_smoke` (`entry_exit` vs `directional_agreement`); not in this PR


Made with [Cursor](https://cursor.com)