### PR TITLE
fix(test): repair OBL_B05 Bollinger smoke baseline

### DIFF
--- a/tests/backtest/test_obl_b05_bollinger_long_semantic_decision_v1.py
+++ b/tests/backtest/test_obl_b05_bollinger_long_semantic_decision_v1.py
@@ -183,6 +183,13 @@ def test_eval_only_runner_smoke(tmp_path: Path) -> None:
     assert summary["BOLLINGER_DECISION"] == "CONTRACT_REMAINS_AMBIGUOUS"
     assert summary["BOLLINGER_SIDE_ACTIVATED"] is False
     assert summary["bollinger_eval_entry_mv2"]["entry_side_counts"].get("NONE", 0) == 1
-    assert summary["bollinger_eval_entry_mv2"]["dominant_first_failed_stage"] == (
-        "directional_agreement"
+    # Post chain-unblock baseline (suitability wildcard / zero-trade chain): the single
+    # eval ENTRY bar remains side-unresolved (NONE) but first-fails at entry_exit
+    # (BLOCKED_ENTRY_EXIT), not directional_agreement. Do not treat this as side ratification.
+    assert summary["bollinger_eval_entry_mv2"]["dominant_first_failed_stage"] == "entry_exit"
+    assert (
+        summary["bollinger_eval_entry_mv2"]["taxonomy_outcome_counts"].get("BLOCKED_ENTRY_EXIT", 0)
+        == 1
     )
+    assert summary["bollinger_eval_entry_mv2"]["ENTER_LONG"] == 0
+    assert summary["bollinger_eval_entry_mv2"]["ENTER_SHORT"] == 0


### PR DESCRIPTION
## Summary
- Updates `test_eval_only_runner_smoke` to expect the live eval-only first-failed stage `entry_exit` / taxonomy `BLOCKED_ENTRY_EXIT` after post-baseline chain unblocks.
- Keeps Bollinger decision C invariants: `CONTRACT_REMAINS_AMBIGUOUS`, `BOLLINGER_SIDE_ACTIVATED=false`, `entry_side=NONE`, no ENTER_LONG/SHORT.
- Fixture/harness-only; no productive Bollinger semantics, authority, runtime, or trading-logic changes.

## Root cause
Frozen smoke expectation still required `dominant_first_failed_stage=directional_agreement`. Live eval-only on the durable archive now first-fails at `entry_exit` while remaining side-unresolved (`NONE`).

## Test plan
- [x] `pytest ...::test_eval_only_runner_smoke`
- [x] `pytest tests/backtest/test_obl_b05_bollinger_long_semantic_decision_v1.py`
- [x] related frozen SSOT reaudit tests
- [x] ruff format/check
- [ ] CI confirmation

## Safety negatives
- No production trading logic / Bollinger strategy / side ratification changes
- `entry_side=NONE` unchanged; no Holdout/Runtime/Orders
- Separate origin/main baseline remains: `test_obl_b05_trend_following_side_impact_diagnostic_v1.py::test_eval_only_control_ratified_shift_dynamic` (`composition` vs `directional_agreement`); not in this PR


Made with [Cursor](https://cursor.com)