### PR TITLE
fix(backtest): preserve canonical bars index in MV2 replay wiring

### DIFF
--- a/src/backtest/mv2_research_wiring_v1.py
+++ b/src/backtest/mv2_research_wiring_v1.py
@@ -2238,7 +2238,6 @@ def run_mv2_research_backtest_wiring_v1(
 
     outcomes: list[MV2ReplayBarOutcomeV1] = []
     replay_signals: list[int] = []
-    signal_index: list[pd.Timestamp] = []
     sequence_state: MV2IntegratedReplayBarSequenceStateV1 | None = None
     decision_funnel_accumulator = DecisionFunnelAccumulatorV0()
     economic_research_profile = (
@@ -2417,7 +2416,6 @@ def run_mv2_research_backtest_wiring_v1(
                     )
                 )
                 replay_signals.append(signal)
-                signal_index.append(pd.Timestamp(row.name))
                 sequence_state = replace(
                     sequence_state,
                     prior_mark_price=float(context.mark_price),
@@ -2645,7 +2643,6 @@ def run_mv2_research_backtest_wiring_v1(
             )
         )
         replay_signals.append(signal)
-        signal_index.append(pd.Timestamp(row.name))
         _emit_observational_bar_hook(
             trading_epoch=i,
             bar_row=row,
@@ -2661,7 +2658,10 @@ def run_mv2_research_backtest_wiring_v1(
             fail_reasons=tuple(replay_result.fail_reasons),
         )
 
-    mv2_replay_series = pd.Series(replay_signals, index=pd.DatetimeIndex(signal_index), dtype=int)
+    # Preserve the canonical bars.index identity (dtype/unit, tz, name, order).
+    # Rebuilding via pd.DatetimeIndex([pd.Timestamp(...), ...]) can promote
+    # datetime64[us, UTC] -> datetime64[ns, UTC] and fail Index.equals.
+    mv2_replay_series = pd.Series(replay_signals, index=bars.index, dtype=int)
     mv2_replay_digest = compute_strategy_signal_digest_v1(
         mv2_replay_series,
         strategy_id=strategy_id,

--- a/tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py
+++ b/tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py
@@ -19,6 +19,7 @@ from src.backtest.strategy_signal_binding_v1 import (
     assert_parallel_strategy_signal_does_not_control_engine_v1,
     resolve_mv2_research_engine_signal_source_v1,
     validate_engine_signal_source_v1,
+    validate_mv2_replay_engine_signal_contract_v1,
 )
 
 
@@ -205,3 +206,80 @@ def test_run_backtest_script_documents_legacy_classification() -> None:
     content = Path(text).read_text(encoding="utf-8")
     assert "RAW_SIGNAL_RESEARCH" in content
     assert "CANONICAL_SYSTEM_REPLAY" in content
+
+
+def _bars_microsecond_utc(n: int = 12) -> pd.DataFrame:
+    """Synthetic parquet-like bars index: datetime64[us, UTC] with name."""
+    idx = pd.DatetimeIndex(
+        pd.to_datetime(
+            [f"2026-06-01T{hour:02d}:00:00Z" for hour in range(n)],
+            utc=True,
+        )
+    ).astype("datetime64[us, UTC]")
+    idx = pd.to_datetime(idx, utc=True)
+    idx.name = "timestamp"
+    assert str(idx.dtype) == "datetime64[us, UTC]"
+    close = [100.0 + float(i) for i in range(n)]
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [v + 0.5 for v in close],
+            "low": [v - 0.5 for v in close],
+            "close": close,
+            "mark_price": close,
+            "index_price": [v - 0.1 for v in close],
+            "best_bid": [v - 0.05 for v in close],
+            "best_ask": [v + 0.05 for v in close],
+            "spread": [0.1 for _ in close],
+            "volume": [1000.0 for _ in close],
+            "open_interest": [10000.0 for _ in close],
+            "funding_rate": [0.0001 for _ in close],
+            "volatility_estimate": [0.2 for _ in close],
+            "is_final": [True for _ in close],
+            "bar_interval": ["1m" for _ in close],
+        },
+        index=idx,
+    )
+
+
+def test_mv2_replay_preserves_canonical_microsecond_utc_bars_index() -> None:
+    bars = _bars_microsecond_utc()
+    result = _run(bars=bars)
+    signal_index = result.mv2_replay_signals.index
+    assert signal_index.equals(bars.index)
+    assert str(signal_index.dtype) == str(bars.index.dtype) == "datetime64[us, UTC]"
+    assert str(signal_index.tz) == str(bars.index.tz) == "UTC"
+    assert signal_index.name == bars.index.name == "timestamp"
+    assert len(signal_index) == len(bars.index)
+    assert list(signal_index) == list(bars.index)
+    validated, _provenance = validate_mv2_replay_engine_signal_contract_v1(
+        result.mv2_replay_signals,
+        bars_index=bars.index,
+        strategy_id="ma_crossover",
+        mv2_replay_signal_digest=result.mv2_replay_signal_digest,
+    )
+    assert validated.index.equals(bars.index)
+    assert result.signals.index.equals(bars.index)
+
+
+def test_manual_timestamp_list_reconstruction_may_promote_us_to_ns() -> None:
+    """Document why wiring must reuse bars.index instead of rebuilding DatetimeIndex."""
+    bars_index = _bars_microsecond_utc(n=3).index
+    reconstructed = pd.DatetimeIndex([pd.Timestamp(ts) for ts in bars_index])
+    if str(reconstructed.dtype) == str(bars_index.dtype):
+        pytest.skip(
+            "installed pandas preserved datetime unit under Timestamp-list reconstruction; "
+            "promotion guard not applicable"
+        )
+    assert str(bars_index.dtype) == "datetime64[us, UTC]"
+    assert str(reconstructed.dtype) == "datetime64[ns, UTC]"
+    assert (reconstructed == bars_index).all()
+    assert not reconstructed.equals(bars_index)
+    signals = pd.Series([0, 1, 0], index=reconstructed, dtype=int)
+    with pytest.raises(StrategySignalBindingError, match="mv2_replay_signal_index_mismatch"):
+        validate_mv2_replay_engine_signal_contract_v1(
+            signals,
+            bars_index=bars_index,
+            strategy_id="ma_crossover",
+            mv2_replay_signal_digest="a" * 64,
+        )


### PR DESCRIPTION
## Summary
- Behebt einen **allgemeinen MV2-Wiring-Defekt**: `mv2_replay_series` wurde über `pd.DatetimeIndex([pd.Timestamp(...), ...])` neu aufgebaut und konnte dabei `datetime64[us, UTC]` (parquet-typisch) nach `datetime64[ns, UTC]` promoten. Länge, Werte und Zeitzone blieben identisch, aber `Index.equals(...)` schlug fehl → `mv2_replay_engine_signal_binding_failed:mv2_replay_signal_index_mismatch`.
- **Fix:** kanonischen `bars.index` direkt als Series-Index wiederverwenden (`CANONICAL_BARS_INDEX_REUSED`). Kein `astype`, keine globale ns-Normalisierung, kein permissives Reindexing.
- Der strikte Contract `signals.index.equals(bars_index)` in `validate_mv2_replay_engine_signal_contract_v1` bleibt **unverändert**.
- Regression ausschließlich mit **synthetischen** `datetime64[us, UTC]`-Bars (plus optionaler Guard für Timestamp-Listen-Rekonstruktion). **Kein Holdout-Zugriff, kein Holdout-/ADX-Rerun, kein Post-Result-Tuning.**
- Terminales Ergebnis aus PR #5384 bleibt unverändert; keine Runtime-, Testnet-, Scheduler-, Capital- oder Order-Aktivierung; keine Trading-Core-/Risk-/Execution-Semantikänderung.

## Test plan
- [x] `tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py` (inkl. neuer Microsecond-UTC-Regression + Reconstruction-Guard)
- [x] `tests/backtest/test_mv2_research_wiring_v1.py`
- [x] `tests/research/test_cross_sectional_lead_lag_v0_backtest_engine_mv2_replay_signal_parity_v0.py`
- [x] `ruff format --check` / `ruff check` auf geänderte Dateien
- [x] PR_BOUNDED_FULL Selector-Ziele lokal (~46s)


Made with [Cursor](https://cursor.com)