### PR TITLE
docs: ratify ADX DI holdout terminal technical-failure backlog SSOT

### DIFF
--- a/docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md
+++ b/docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md
@@ -31,16 +31,26 @@ Open candidates are empty. Exactly zero hypotheses are `DEFINITION_ONLY_PREREGIS
 5. `MA_TREND_ALIGNMENT_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1`
 6. `MACD_HISTOGRAM_COUNTERTREND_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1`
 
-### TERMINAL_PASS
+### TERMINAL_PASS (development) + holdout terminal technical failure
 
 7. `ADX_DI_DIRECTION_CONFIRMATION_MR_ENTRY_ELIGIBILITY_NON_BITCOIN_PERPETUALS_V1` —
-   PASS / `ALL_PASS_REQUIRES_MET` (Wilder ADX(14) +DI/−DI direction confirmation;
-   development run count 1/1; evidence under
+   Development: `TERMINAL_PASS` / `ALL_PASS_REQUIRES_MET` (Wilder ADX(14) +DI/−DI
+   direction confirmation; development run count 1/1; evidence under
    `docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_development_v1/`).
-   Economic offline gate remains closed. Promotion remains closed. Definition-only
-   holdout preregistration is registered (`holdout_run_count=0`, `holdout_run_limit=1`);
-   holdout execution remains forbidden without a separate operator GO. No second ADX DI
-   development evaluation run is permitted.
+   Holdout: single authorized run consumed (`holdout_run_count=1`,
+   `holdout_run_limit=1`); registry status
+   `HOLDOUT_EVALUATION_EXECUTED_TERMINAL`; result class
+   `ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN` after sealed-panel data access failed on
+   MV2 replay signal-index mismatch (`mv2_replay_signal_index_mismatch`). Primary
+   economic metrics were not produced (`evaluable=false`; no PASS / FAIL_ECONOMIC
+   claim). Evidence:
+   `docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v1/`.
+   Provenance of count transition `0 → 1`: merge commit
+   `0cd6e71d0d20345a5a66a23c5b63983effc20b1a` / PR `#5384`
+   (prior count-zero preregistration commit
+   `f9654e03acff05837cc6121bb6a5877bccd054ac` / PR `#5383`). Retry / second holdout
+   run forbidden. Economic offline gate remains closed. Promotion remains closed.
+   No second ADX DI development evaluation run is permitted.
 
 Semantic duplicates and parameter retunes of these terminals are forbidden.
 `adx_di_direction_confirmation` remains forbidden for any future open candidates.
@@ -58,10 +68,11 @@ None. `open_candidates=[]`. No `NEXT_ELIGIBLE_FOR_PREREGISTRATION`.
 - At most one open preregistration at a time
 - Exactly one development run per hypothesis
 - No retuning after FAIL
-- No holdout use without separate operator GO
+- No holdout use / no second ADX DI holdout run (slot already consumed terminal)
 - No candidate combination / multi-gate stacks
 - No reprioritization without a separate versioned governance PR
 - Development PASS does not open the economic offline gate
+- Holdout technical failure does not open the economic offline gate
 - Runtime / shadow / paper / testnet / live / orders remain locked
 - `exactly_one_next_eligible_for_preregistration=false` while open queue is empty
 - `open_candidate_count_min=0`
@@ -72,12 +83,16 @@ None. `open_candidates=[]`. No `NEXT_ELIGIBLE_FOR_PREREGISTRATION`.
 - Economic offline gate unchanged/closed
 - `PRODUCTIVE_TRADING_LOGIC_CHANGED=false`
 - `AUTHORITY_CHANGED=false`
-- `EVALUATION_EXECUTED=false` (for any remaining open work; ADX DI consumed 1/1)
+- `EVALUATION_EXECUTED=false` (for any remaining open work; ADX DI development 1/1
+  and holdout 1/1 already consumed)
 - `DEVELOPMENT_RUN_COUNT=0` (backlog-level)
+- `RERUN_ALLOWED=false` for the ADX DI holdout run-id
+  `evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v1`
 
 ## Next step
 
-`REVIEW_AND_MERGE_ADX_DI_HOLDOUT_PREREGISTRATION_THEN_SEPARATE_OPERATOR_GO_FOR_EXACTLY_ONE_HOLDOUT_RUN`
+`REVIEW_TERMINAL_HOLDOUT_ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN_NO_RETRY`
 
-Any holdout use or further research candidates require a separate PR and operator GO.
-No second ADX DI evaluation run is permitted. No reopen of terminal hypotheses.
+Do **not** re-run the ADX DI holdout evaluation. Further research candidates require a
+separate PR and operator GO. No reopen of terminal hypotheses without a new
+hypothesis id.


### PR DESCRIPTION
## Summary
- Aligns `docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md` with the already-merged holdout registry/evidence state.
- Documents holdout run-count `1/1`, terminal class `ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN`, no retry, closed economic/promotion/runtime gates, and provenance (`0cd6e71d` / PR `#5384`; prior count-zero `f9654e03` / PR `#5383`).
- No holdout re-run; no production/runtime/order changes; no metric invention.

## Test plan
- [x] Docs reference-targets verify
- [x] Docs token-policy preflight on changed Markdown
- [x] CI selector `NO_OP` for this docs-only file
- [ ] Required GitHub checks green (docs path only; do **not** re-run holdout)


Made with [Cursor](https://cursor.com)