### PR TITLE
fix(backtest): enforce deterministic MV2 replay signal index binding

### DIFF
--- a/src/backtest/strategy_signal_binding_v1.py
+++ b/src/backtest/strategy_signal_binding_v1.py
@@ -992,6 +992,120 @@ def validate_strategy_signal_contract_v1(
 
 MV2_RESEARCH_WIRING_OWNER_FOR_REPLAY = "backtest.mv2_research_wiring_v1"
 
+# Explicit MV2 replay → market-data index binding modes.
+# Positional RangeIndex binding is never implicit; callers must opt in.
+MV2_REPLAY_INDEX_BINDING_EXACT = "EXACT_INDEX_EQUALS"
+MV2_REPLAY_INDEX_BINDING_LOSSLESS_DATETIME_INSTANT = "LOSSLESS_DATETIME_INSTANT_EQUIVALENT"
+MV2_REPLAY_INDEX_BINDING_POSITIONAL_RANGEINDEX_EXPLICIT = "POSITIONAL_RANGEINDEX_EXPLICIT"
+
+
+def _first_index_divergence_position_v1(left: pd.Index, right: pd.Index) -> int | None:
+    """Return first positional divergence, or None when prefixes and lengths match."""
+    n = min(len(left), len(right))
+    for i in range(n):
+        try:
+            if left[i] != right[i]:
+                return i
+        except Exception:  # noqa: BLE001 — treat incomparable labels as divergence
+            return i
+    if len(left) != len(right):
+        return n
+    return None
+
+
+def format_mv2_replay_signal_index_mismatch_diagnostics_v1(
+    signals_index: pd.Index,
+    bars_index: pd.Index,
+) -> str:
+    """Machine-readable mismatch diagnostics for fail-closed MV2 replay binding."""
+    return (
+        f"expected_len={len(bars_index)};"
+        f"actual_len={len(signals_index)};"
+        f"expected_index_type={type(bars_index).__name__};"
+        f"actual_index_type={type(signals_index).__name__};"
+        f"expected_dtype={getattr(bars_index, 'dtype', None)};"
+        f"actual_dtype={getattr(signals_index, 'dtype', None)};"
+        f"expected_duplicates={bool(getattr(bars_index, 'has_duplicates', False))};"
+        f"actual_duplicates={bool(getattr(signals_index, 'has_duplicates', False))};"
+        f"first_divergence_position="
+        f"{_first_index_divergence_position_v1(signals_index, bars_index)}"
+    )
+
+
+def _datetime_indexes_lossless_instant_equivalent_v1(
+    signals_index: pd.Index,
+    bars_index: pd.Index,
+) -> bool:
+    """True when both DatetimeIndexes encode the same UTC instants positionally.
+
+    Cross-unit identity (e.g. datetime64[us, UTC] vs datetime64[ns, UTC]) is
+    accepted when element-wise ``==`` holds for every position. No ffill/bfill,
+    no label reindex, and no silent acceptance of shifted or unordered axes.
+    """
+    if not isinstance(signals_index, pd.DatetimeIndex):
+        return False
+    if not isinstance(bars_index, pd.DatetimeIndex):
+        return False
+    if len(signals_index) != len(bars_index):
+        return False
+    if bool(signals_index.isna().any()) or bool(bars_index.isna().any()):
+        return False
+    try:
+        return bool((signals_index == bars_index).all())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def bind_mv2_replay_signals_to_canonical_bars_index_v1(
+    signals: pd.Series,
+    *,
+    bars_index: pd.Index,
+    allow_positional_rangeindex_binding: bool = False,
+) -> tuple[pd.Series, str]:
+    """Bind MV2 replay signal values onto the canonical market-data bars index.
+
+    The market-data ``bars_index`` is the sole canonical time axis. Replay signals
+    must either already share that index identity (``Index.equals``) or be bound
+    via an explicit lossless path:
+
+    - ``LOSSLESS_DATETIME_INSTANT_EQUIVALENT``: same length, DatetimeIndex on both
+      sides, element-wise UTC instant equality (covers parquet ``us`` vs
+      reconstructed ``ns`` unit drift without changing timestamps).
+    - ``POSITIONAL_RANGEINDEX_EXPLICIT``: only when
+      ``allow_positional_rangeindex_binding=True`` and lengths match.
+
+    Silent positional reindexing under unclear semantics is forbidden. Semantic
+    mismatches remain fail-closed with diagnostics.
+    """
+    _fail_closed(not isinstance(bars_index, pd.DatetimeIndex), "mv2_replay_bars_index_not_datetime")
+    _fail_closed(
+        not bars_index.is_monotonic_increasing,
+        "mv2_replay_bars_index_not_monotonic",
+    )
+    _fail_closed(bars_index.has_duplicates, "mv2_replay_bars_index_duplicate_timestamps")
+    _fail_closed(len(bars_index) == 0, "mv2_replay_bars_index_empty")
+
+    if signals.index.equals(bars_index):
+        bound = pd.Series(signals.to_numpy(), index=bars_index, dtype=signals.dtype)
+        return bound, MV2_REPLAY_INDEX_BINDING_EXACT
+
+    if _datetime_indexes_lossless_instant_equivalent_v1(signals.index, bars_index):
+        bound = pd.Series(signals.to_numpy(), index=bars_index, dtype=signals.dtype)
+        return bound, MV2_REPLAY_INDEX_BINDING_LOSSLESS_DATETIME_INSTANT
+
+    if (
+        allow_positional_rangeindex_binding
+        and isinstance(signals.index, pd.RangeIndex)
+        and len(signals.index) == len(bars_index)
+    ):
+        bound = pd.Series(signals.to_numpy(), index=bars_index, dtype=signals.dtype)
+        return bound, MV2_REPLAY_INDEX_BINDING_POSITIONAL_RANGEINDEX_EXPLICIT
+
+    diagnostics = format_mv2_replay_signal_index_mismatch_diagnostics_v1(signals.index, bars_index)
+    if len(signals.index) != len(bars_index):
+        raise StrategySignalBindingError(f"mv2_replay_signal_index_length_mismatch:{diagnostics}")
+    raise StrategySignalBindingError(f"mv2_replay_signal_index_mismatch:{diagnostics}")
+
 
 def validate_mv2_replay_engine_signal_contract_v1(
     signals: pd.Series,
@@ -1000,31 +1114,46 @@ def validate_mv2_replay_engine_signal_contract_v1(
     strategy_id: str,
     mv2_replay_signal_digest: str,
     expected_mv2_replay_signal_digest: str = "",
+    allow_positional_rangeindex_binding: bool = False,
 ) -> tuple[pd.Series, StrategySignalProvenanceV1]:
-    """Validate canonical MV2 replay series before BacktestEngine ingestion."""
+    """Validate canonical MV2 replay series before BacktestEngine ingestion.
+
+    Market-data ``bars_index`` remains the canonical time axis. Replay signals are
+    bound onto that axis via
+    :func:`bind_mv2_replay_signals_to_canonical_bars_index_v1` (exact equals or
+    explicit lossless binding). Positional RangeIndex binding is opt-in only.
+    """
     _fail_closed(len(signals) == 0, "mv2_replay_signals_empty")
-    _fail_closed(
-        not isinstance(signals.index, pd.DatetimeIndex),
-        "mv2_replay_signals_index_not_datetime",
-    )
-    _fail_closed(
-        not signals.index.is_monotonic_increasing,
-        "mv2_replay_signals_index_not_monotonic",
-    )
-    _fail_closed(signals.index.has_duplicates, "mv2_replay_signals_duplicate_timestamps")
-    if not signals.index.equals(bars_index):
+
+    if isinstance(signals.index, pd.DatetimeIndex):
         _fail_closed(
-            len(signals.index) != len(bars_index), "mv2_replay_signal_index_length_mismatch"
+            not signals.index.is_monotonic_increasing,
+            "mv2_replay_signals_index_not_monotonic",
         )
-        _fail_closed(not signals.index.equals(bars_index), "mv2_replay_signal_index_mismatch")
-    if signals.isna().any():
+        _fail_closed(signals.index.has_duplicates, "mv2_replay_signals_duplicate_timestamps")
+    elif not (allow_positional_rangeindex_binding and isinstance(signals.index, pd.RangeIndex)):
+        diagnostics = format_mv2_replay_signal_index_mismatch_diagnostics_v1(
+            signals.index, bars_index
+        )
+        raise StrategySignalBindingError(f"mv2_replay_signals_index_not_datetime:{diagnostics}")
+
+    bound_signals, _binding_mode = bind_mv2_replay_signals_to_canonical_bars_index_v1(
+        signals,
+        bars_index=bars_index,
+        allow_positional_rangeindex_binding=allow_positional_rangeindex_binding,
+    )
+    _fail_closed(not bound_signals.index.equals(bars_index), "mv2_replay_signal_index_mismatch")
+
+    if bound_signals.isna().any():
         raise StrategySignalBindingError("mv2_replay_signals_contain_nan")
     if expected_mv2_replay_signal_digest and (
         mv2_replay_signal_digest != expected_mv2_replay_signal_digest
     ):
         raise StrategySignalBindingError("mv2_replay_signal_digest_mismatch")
 
-    int_signals = signals.astype(int)
+    int_signals = bound_signals.astype(int)
+    # Keep values on the canonical bars index identity after astype.
+    int_signals = pd.Series(int_signals.to_numpy(), index=bars_index, dtype=int)
     unique_values = {int(v) for v in int_signals.unique()}
     unknown = unique_values - _ALLOWED_SIGNAL_VALUES
     _fail_closed(bool(unknown), f"unknown_mv2_replay_signal_encoding:{sorted(unknown)}")

--- a/tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py
+++ b/tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py
@@ -12,11 +12,14 @@ from src.backtest.strategy_signal_binding_v1 import (
     ENGINE_SIGNAL_SOURCE_CONFIGURED_STRATEGY,
     ENGINE_SIGNAL_SOURCE_MV2_REPLAY,
     LEGACY_RAW_SIGNAL_RESEARCH_ENGINE_SIGNAL_SOURCE,
+    MV2_REPLAY_INDEX_BINDING_LOSSLESS_DATETIME_INSTANT,
+    MV2_REPLAY_INDEX_BINDING_POSITIONAL_RANGEINDEX_EXPLICIT,
     RUN_BACKTEST_PATH_CLASSIFICATION,
     StrategySignalBindingError,
     assert_backtest_engine_mv2_replay_signal_parity_v1,
     assert_decision_funnel_trade_alignment_v1,
     assert_parallel_strategy_signal_does_not_control_engine_v1,
+    bind_mv2_replay_signals_to_canonical_bars_index_v1,
     resolve_mv2_research_engine_signal_source_v1,
     validate_engine_signal_source_v1,
     validate_mv2_replay_engine_signal_contract_v1,
@@ -262,24 +265,171 @@ def test_mv2_replay_preserves_canonical_microsecond_utc_bars_index() -> None:
     assert result.signals.index.equals(bars.index)
 
 
-def test_manual_timestamp_list_reconstruction_may_promote_us_to_ns() -> None:
-    """Document why wiring must reuse bars.index instead of rebuilding DatetimeIndex."""
+def test_identical_datetime_index_binding_passes() -> None:
+    bars_index = pd.date_range("2026-06-01", periods=3, freq="1h", tz="UTC")
+    signals = pd.Series([0, 1, -1], index=bars_index, dtype=int)
+    validated, _provenance = validate_mv2_replay_engine_signal_contract_v1(
+        signals,
+        bars_index=bars_index,
+        strategy_id="ma_crossover",
+        mv2_replay_signal_digest="a" * 64,
+    )
+    assert validated.index.equals(bars_index)
+    assert validated.tolist() == [0, 1, -1]
+
+
+def test_lossless_us_to_ns_reconstruction_binds_to_canonical_bars_index() -> None:
+    """Synthetic reproduction of holdout mismatch: Timestamp-list rebuild promotes us→ns."""
     bars_index = _bars_microsecond_utc(n=3).index
     reconstructed = pd.DatetimeIndex([pd.Timestamp(ts) for ts in bars_index])
     if str(reconstructed.dtype) == str(bars_index.dtype):
         pytest.skip(
             "installed pandas preserved datetime unit under Timestamp-list reconstruction; "
-            "promotion guard not applicable"
+            "promotion path not applicable"
         )
     assert str(bars_index.dtype) == "datetime64[us, UTC]"
     assert str(reconstructed.dtype) == "datetime64[ns, UTC]"
     assert (reconstructed == bars_index).all()
     assert not reconstructed.equals(bars_index)
-    signals = pd.Series([0, 1, 0], index=reconstructed, dtype=int)
-    with pytest.raises(StrategySignalBindingError, match="mv2_replay_signal_index_mismatch"):
+    signals = pd.Series([0, 1, -1], index=reconstructed, dtype=int)
+    bound, mode = bind_mv2_replay_signals_to_canonical_bars_index_v1(signals, bars_index=bars_index)
+    assert mode == MV2_REPLAY_INDEX_BINDING_LOSSLESS_DATETIME_INSTANT
+    assert bound.index.equals(bars_index)
+    assert str(bound.index.dtype) == "datetime64[us, UTC]"
+    validated, _provenance = validate_mv2_replay_engine_signal_contract_v1(
+        signals,
+        bars_index=bars_index,
+        strategy_id="ma_crossover",
+        mv2_replay_signal_digest="a" * 64,
+    )
+    assert validated.index.equals(bars_index)
+    assert validated.tolist() == [0, 1, -1]
+
+
+def test_rangeindex_binding_fails_closed_by_default() -> None:
+    bars_index = pd.date_range("2026-06-01", periods=3, freq="1h", tz="UTC")
+    signals = pd.Series([0, 1, -1], dtype=int)  # default RangeIndex
+    with pytest.raises(StrategySignalBindingError, match="mv2_replay_signals_index_not_datetime"):
         validate_mv2_replay_engine_signal_contract_v1(
             signals,
             bars_index=bars_index,
             strategy_id="ma_crossover",
             mv2_replay_signal_digest="a" * 64,
         )
+
+
+def test_rangeindex_binding_passes_only_when_explicitly_allowed() -> None:
+    bars_index = pd.date_range("2026-06-01", periods=3, freq="1h", tz="UTC")
+    signals = pd.Series([0, 1, -1], dtype=int)
+    bound, mode = bind_mv2_replay_signals_to_canonical_bars_index_v1(
+        signals,
+        bars_index=bars_index,
+        allow_positional_rangeindex_binding=True,
+    )
+    assert mode == MV2_REPLAY_INDEX_BINDING_POSITIONAL_RANGEINDEX_EXPLICIT
+    assert bound.index.equals(bars_index)
+    validated, _provenance = validate_mv2_replay_engine_signal_contract_v1(
+        signals,
+        bars_index=bars_index,
+        strategy_id="ma_crossover",
+        mv2_replay_signal_digest="a" * 64,
+        allow_positional_rangeindex_binding=True,
+    )
+    assert validated.index.equals(bars_index)
+    assert validated.tolist() == [0, 1, -1]
+
+
+def test_shifted_index_fail_closed_with_diagnostics() -> None:
+    bars_index = pd.date_range("2026-06-01", periods=3, freq="1h", tz="UTC")
+    shifted = pd.date_range("2026-06-02", periods=3, freq="1h", tz="UTC")
+    signals = pd.Series([0, 1, -1], index=shifted, dtype=int)
+    with pytest.raises(
+        StrategySignalBindingError,
+        match=r"mv2_replay_signal_index_mismatch:.*first_divergence_position=0",
+    ):
+        validate_mv2_replay_engine_signal_contract_v1(
+            signals,
+            bars_index=bars_index,
+            strategy_id="ma_crossover",
+            mv2_replay_signal_digest="a" * 64,
+        )
+
+
+def test_missing_timestamp_fail_closed() -> None:
+    bars_index = pd.date_range("2026-06-01", periods=3, freq="1h", tz="UTC")
+    signals = pd.Series([0, 1], index=bars_index[:2], dtype=int)
+    with pytest.raises(
+        StrategySignalBindingError,
+        match=r"mv2_replay_signal_index_length_mismatch:.*expected_len=3;actual_len=2",
+    ):
+        validate_mv2_replay_engine_signal_contract_v1(
+            signals,
+            bars_index=bars_index,
+            strategy_id="ma_crossover",
+            mv2_replay_signal_digest="a" * 64,
+        )
+
+
+def test_extra_timestamp_fail_closed() -> None:
+    bars_index = pd.date_range("2026-06-01", periods=3, freq="1h", tz="UTC")
+    extended = pd.DatetimeIndex([*bars_index, bars_index[-1] + pd.Timedelta(hours=1)])
+    signals = pd.Series([0, 1, -1, 0], index=extended, dtype=int)
+    with pytest.raises(
+        StrategySignalBindingError,
+        match=r"mv2_replay_signal_index_length_mismatch:.*expected_len=3;actual_len=4",
+    ):
+        validate_mv2_replay_engine_signal_contract_v1(
+            signals,
+            bars_index=bars_index,
+            strategy_id="ma_crossover",
+            mv2_replay_signal_digest="a" * 64,
+        )
+
+
+def test_duplicate_timestamps_fail_closed() -> None:
+    bars_index = pd.date_range("2026-06-01", periods=3, freq="1h", tz="UTC")
+    dup = pd.DatetimeIndex([bars_index[0], bars_index[0], bars_index[2]])
+    signals = pd.Series([0, 1, -1], index=dup, dtype=int)
+    with pytest.raises(StrategySignalBindingError, match="mv2_replay_signals_duplicate_timestamps"):
+        validate_mv2_replay_engine_signal_contract_v1(
+            signals,
+            bars_index=bars_index,
+            strategy_id="ma_crossover",
+            mv2_replay_signal_digest="a" * 64,
+        )
+
+
+def test_unordered_index_fail_closed() -> None:
+    bars_index = pd.date_range("2026-06-01", periods=3, freq="1h", tz="UTC")
+    unordered = bars_index[[2, 0, 1]]
+    signals = pd.Series([0, 1, -1], index=unordered, dtype=int)
+    with pytest.raises(StrategySignalBindingError, match="mv2_replay_signals_index_not_monotonic"):
+        validate_mv2_replay_engine_signal_contract_v1(
+            signals,
+            bars_index=bars_index,
+            strategy_id="ma_crossover",
+            mv2_replay_signal_digest="a" * 64,
+        )
+
+
+def test_length_mismatch_fail_closed() -> None:
+    bars_index = pd.date_range("2026-06-01", periods=4, freq="1h", tz="UTC")
+    other = pd.date_range("2026-06-01", periods=3, freq="1h", tz="UTC")
+    signals = pd.Series([0, 1, -1], index=other, dtype=int)
+    with pytest.raises(StrategySignalBindingError, match="mv2_replay_signal_index_length_mismatch"):
+        validate_mv2_replay_engine_signal_contract_v1(
+            signals,
+            bars_index=bars_index,
+            strategy_id="ma_crossover",
+            mv2_replay_signal_digest="a" * 64,
+        )
+
+
+def test_no_silent_positional_reindex_on_label_permutation() -> None:
+    """Same labels, different order already blocked as non-monotonic; values must not remap."""
+    bars_index = pd.date_range("2026-06-01", periods=3, freq="1h", tz="UTC")
+    # Equal as sets but shifted by one hour → not instant-equivalent positionally.
+    shifted_one = bars_index + pd.Timedelta(hours=1)
+    signals = pd.Series([9, 8, 7], index=shifted_one, dtype=int)
+    with pytest.raises(StrategySignalBindingError, match="mv2_replay_signal_index_mismatch"):
+        bind_mv2_replay_signals_to_canonical_bars_index_v1(signals, bars_index=bars_index)


### PR DESCRIPTION
## Summary
- **Root cause:** MV2 replay signal series could fail `signals.index.equals(bars_index)` when timestamps were semantically identical but dtype units diverged (parquet-typical `datetime64[us, UTC]` vs reconstructed `datetime64[ns, UTC]`), surfacing as `mv2_replay_engine_signal_binding_failed:mv2_replay_signal_index_mismatch`.
- **Contract:** Market-data `bars_index` remains the canonical time axis. Replay signals must either already equal that index or bind via an explicit lossless path (`LOSSLESS_DATETIME_INSTANT_EQUIVALENT`). Positional `RangeIndex` binding is opt-in only (`allow_positional_rangeindex_binding=True`). No silent positional reindex, no ffill/bfill, no duplicate/missing/extra/unordered acceptance.
- **Diagnostics:** Fail-closed errors include expected/actual length, index types, dtypes, duplicate flags, and first divergence position.
- **Regression coverage:** identical DatetimeIndex PASS; lossless us→ns reconstruction PASS; RangeIndex default FAIL / explicit PASS; shifted/missing/extra/duplicate/unordered/length FAIL; wiring microsecond-UTC path unchanged.
- **Safety:** No holdout rerun or sealed-data access. ADX DI V1 remains `ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN` with `holdout_run_count=1/1`, `RERUN_ALLOWED=false`. No strategy/Double-Play/risk/sizing/execution semantic change; economic/promotion/runtime/orders closed.

## Test plan
- [x] `tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py` (25)
- [x] `tests/backtest/test_mv2_research_wiring_v1.py` (98)
- [x] lead-lag MV2 replay parity / decision-parity suites
- [x] ruff format/check on changed files
- [x] PR_BOUNDED_FULL selector targets (~46s, 716 passed)
- [ ] Required GitHub checks green


Made with [Cursor](https://cursor.com)