### PR TITLE
fix: make evaluation runner process death observable and fail-closed

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -765,6 +765,14 @@
         "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V1.md"
       ],
       "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR side-aware middle-band exit-efficiency versus immutable bollinger baseline on sealed DEVELOPMENT panel (evaluation_run_count 0->1); Economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders."
+    },
+    "EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1": {
+      "path_prefixes": [
+        "src/research/evaluation_runner_lifecycle_observability_v1/",
+        "tests/research/test_evaluation_runner_lifecycle_observability_v1.py",
+        "docs/evidence/evaluation_runner_lifecycle_observability_v1/"
+      ],
+      "note": "Generic research-infrastructure observability for evaluation-runner process death (atomic heartbeat/progress, catchable signal handlers, exit/signal normalization, supervised child reap, INCONCLUSIVE_INFRASTRUCTURE_FAILURE classification without auto-rerun); no strategy/Master-V2/Double-Play/risk/sizing/execution/economic semantics mutation; no evaluation rerun; no holdout access; no runtime/orders."
     }
   }
 }

--- a/docs/evidence/evaluation_runner_lifecycle_observability_v1/README.md
+++ b/docs/evidence/evaluation_runner_lifecycle_observability_v1/README.md
@@ -1,0 +1,23 @@
+# Evaluation runner lifecycle observability v1
+
+Generic infrastructure fix for unobservable evaluation-runner process death.
+
+## Diagnosis (machine-readable)
+
+See `diagnosis.json`.
+
+| Field | Value |
+|---|---|
+| ROOT_CAUSE_STATUS | NOT_IDENTIFIED (historical concrete cause) |
+| GENERIC_OBSERVABILITY_GAP_CONFIRMED | true |
+| FIRST_DIVERGENCE_BOUNDARY | after stdout member progress, before durable lifecycle persist / exit harvest |
+| SYNTHETIC_REPRODUCTION | true |
+| GENERIC_FIX_CLASS | evaluation_runner_lifecycle_observability_v1 |
+| RERUN_EXECUTED | false |
+| HOLDOUT_DATA_ACCESSED | false |
+| EVALUATION_RUN_COUNT_UNCHANGED | true |
+
+## Distinction
+
+- Historical process-death cause for the midband 2/46 incident remains `UNKNOWN`.
+- Generic observability gap (stdout-only progress, no exit/signal harvest, no atomic member checkpoint) is confirmed and covered by synthetic failure-mode tests.

--- a/docs/evidence/evaluation_runner_lifecycle_observability_v1/diagnosis.json
+++ b/docs/evidence/evaluation_runner_lifecycle_observability_v1/diagnosis.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "evaluation_runner_lifecycle_observability_fix_evidence.v1",
+  "ROOT_CAUSE_STATUS": "NOT_IDENTIFIED",
+  "HISTORICAL_PROCESS_DEATH_CAUSE": "UNKNOWN",
+  "HISTORICAL_NOTE": "PR #5392 / BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY development evaluation died after baseline member 2/46 with process_exit_code=null and no traceback. Concrete historical kill class (SIGTERM vs parent reap vs other) remains unproven.",
+  "GENERIC_OBSERVABILITY_GAP_CONFIRMED": true,
+  "FIRST_DIVERGENCE_BOUNDARY": "after_stdout_member_progress_before_durable_lifecycle_persist_or_exit_harvest",
+  "FIRST_DIVERGENCE_LOCUS": "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1/panel_runner_v1.py member-loop progress emit (stdout-only prior to this fix)",
+  "SYNTHETIC_REPRODUCTION": true,
+  "SYNTHETIC_FAILURE_MODES_COVERED": [
+    "WORKER_EXCEPTION",
+    "NONZERO_EXIT",
+    "SIGNAL_TERMINATION",
+    "NO_RESULT_ABRUPT_EOF",
+    "TIMEOUT_OR_MISSING_HEARTBEAT",
+    "PERSISTENCE_FAILURE_AFTER_MEMBER"
+  ],
+  "GENERIC_FIX_CLASS": "evaluation_runner_lifecycle_observability_v1",
+  "GENERIC_FIX_SURFACES": [
+    "atomic_heartbeat_and_member_progress",
+    "catchable_signal_handlers",
+    "exit_code_and_signal_normalization",
+    "supervised_child_reap_and_pipe_drain",
+    "exception_type_and_truncated_traceback_persist",
+    "incomplete_run_INCONCLUSIVE_INFRASTRUCTURE_FAILURE_no_autorun"
+  ],
+  "RERUN_EXECUTED": false,
+  "HOLDOUT_DATA_ACCESSED": false,
+  "EVALUATION_RUN_COUNT_UNCHANGED": true,
+  "EVALUATION_RUN_COUNT_BEFORE": 1,
+  "EVALUATION_RUN_COUNT_AFTER": 1,
+  "STRATEGY_SEMANTICS_CHANGED": false,
+  "MASTER_V2_OR_DOUBLE_PLAY_CHANGED": false,
+  "RISK_SIZING_EXECUTION_CHANGED": false,
+  "RUNTIME_ACTIVATED": false,
+  "ORDERS_SENT": false,
+  "related_historical_evidence": "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v1/process_death_root_cause.json"
+}

--- a/scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v1.py
+++ b/scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v1.py
@@ -2,11 +2,16 @@
 """Run exactly one preregistered DEVELOPMENT midband exit-efficiency evaluation.
 
 Research-only. No holdout. No runtime / orders / productive authority mutation.
+
+Lifecycle observability: catchable signals, durable member progress, and
+exception diagnostics are persisted under the output directory. Incomplete runs
+are classified as INCONCLUSIVE_INFRASTRUCTURE_FAILURE without auto-rerun.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 from pathlib import Path
@@ -18,11 +23,17 @@ SRC = REPO_ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v1.constants_v1 import (  # noqa: E402
+    EVALUATION_RUN_ID,
+)
 from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v1.panel_runner_v1 import (  # noqa: E402
     run_development_evaluation,
 )
 from src.research.entry_effective_mr_eligibility_development_evaluation_v1.dev_panel_bars_v1 import (  # noqa: E402
     DEV_PANEL_SUBDIR,
+)
+from src.research.evaluation_runner_lifecycle_observability_v1 import (  # noqa: E402
+    EvaluationRunnerLifecycleObservabilityV1,
 )
 
 
@@ -31,6 +42,17 @@ def _default_archive_root() -> Path | None:
     if not env:
         return None
     return Path(env).expanduser().resolve() / DEV_PANEL_SUBDIR
+
+
+def _slot_already_consumed(output_dir: Path) -> bool:
+    summary_path = output_dir / "summary.json"
+    if not summary_path.is_file():
+        return False
+    try:
+        existing = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return int(existing.get("evaluation_run_count") or 0) >= 1
 
 
 def main() -> int:
@@ -55,7 +77,42 @@ def main() -> int:
         archive = _default_archive_root()
         if archive is None:
             raise SystemExit("PEAK_TRADE_DATA_ARCHIVE_ROOT_UNSET")
-    summary = run_development_evaluation(output_dir=args.output_dir, archive_root=archive)
+
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Fail-closed before lifecycle attach so a consumed slot cannot pollute
+    # historical evidence SSOT with new heartbeat/terminal files.
+    if _slot_already_consumed(output_dir):
+        print("RESULT_CLASS=INCONCLUSIVE_INFRASTRUCTURE_FAILURE")
+        print("REASON=EVALUATION_RUN_SLOT_ALREADY_CONSUMED")
+        print("EVALUATION_RUN_COUNT=1")
+        print("HOLDOUT_DATA_ACCESSED=false")
+        print("AUTO_RERUN_EXECUTED=false")
+        return 2
+
+    lifecycle = EvaluationRunnerLifecycleObservabilityV1(
+        output_dir,
+        run_id=EVALUATION_RUN_ID,
+    )
+    lifecycle.install_signal_handlers()
+    try:
+        summary = run_development_evaluation(
+            output_dir=output_dir,
+            archive_root=archive,
+            lifecycle=lifecycle,
+        )
+    except Exception as exc:  # noqa: BLE001 — persist then fail-closed
+        terminal = lifecycle.record_exception(exc)
+        print(f"RESULT_CLASS={terminal.get('result_class')}")
+        print(f"REASON={terminal.get('death_class')}")
+        print("EVALUATION_RUN_COUNT_UNCHANGED_BY_LIFECYCLE=true")
+        print("HOLDOUT_DATA_ACCESSED=false")
+        print("AUTO_RERUN_EXECUTED=false")
+        return 1
+    finally:
+        lifecycle.uninstall_signal_handlers()
+
     print(f"RESULT_CLASS={summary.get('result_class')}")
     print(f"REASON={summary.get('decision', {}).get('reason')}")
     print(f"EVALUATION_RUN_COUNT={summary.get('evaluation_run_count')}")

--- a/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1/panel_runner_v1.py
+++ b/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1/panel_runner_v1.py
@@ -278,6 +278,7 @@ def run_arm(
     decision_start: str,
     decision_end: str,
     gate: bool,
+    lifecycle: Any | None = None,
 ) -> ArmResult:
     t0 = time.perf_counter()
     d_start = pd.Timestamp(decision_start)
@@ -341,6 +342,18 @@ def run_arm(
             ),
             flush=True,
         )
+        # Durable lifecycle progress (stdout alone is not a death diagnostic).
+        if lifecycle is not None:
+            lifecycle.record_member_progress(
+                phase=arm,
+                member_index=i,
+                members_total=len(members),
+                member_id=native,
+                extra={
+                    "trades": len(trades),
+                    "exits_forced_by_gate": forced,
+                },
+            )
 
     enriched = enrich_trade_excursions(all_trades, bars_by_instrument)
     metrics = _aggregate_arm(
@@ -371,6 +384,7 @@ def run_development_evaluation(
     output_dir: Path,
     archive_root: Path | None = None,
     repo_root: Path | None = None,
+    lifecycle: Any | None = None,
 ) -> dict[str, Any]:
     repo = repo_root or _repo_root()
     output_dir = Path(output_dir)
@@ -428,6 +442,7 @@ def run_development_evaluation(
         decision_start=DECISION_START,
         decision_end=DECISION_END_EXCLUSIVE,
         gate=False,
+        lifecycle=lifecycle,
     )
     treatment = run_arm(
         arm="treatment",
@@ -438,6 +453,7 @@ def run_development_evaluation(
         decision_start=DECISION_START,
         decision_end=DECISION_END_EXCLUSIVE,
         gate=True,
+        lifecycle=lifecycle,
     )
 
     exits_forced = int(treatment.metrics["exits_forced_by_gate"])
@@ -468,9 +484,16 @@ def run_development_evaluation(
         "baseline": baseline.exit_attribution,
         "treatment": treatment.exit_attribution,
     }
-    (output_dir / "exit_attribution.json").write_text(
-        json.dumps(exit_attribution, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    if lifecycle is not None:
+        lifecycle.record_persist_phase(note="pre_evidence_persist")
+    try:
+        (output_dir / "exit_attribution.json").write_text(
+            json.dumps(exit_attribution, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    except OSError as exc:
+        if lifecycle is not None:
+            lifecycle.record_persistence_failure(exc)
+        raise
 
     decision_out = decide_development_evaluation(
         baseline=baseline.metrics,
@@ -691,6 +714,8 @@ def run_development_evaluation(
         encoding="utf-8",
     )
     write_manifest_sha256(output_dir)
+    if lifecycle is not None:
+        lifecycle.mark_complete()
     return summary
 
 

--- a/src/research/evaluation_runner_lifecycle_observability_v1/__init__.py
+++ b/src/research/evaluation_runner_lifecycle_observability_v1/__init__.py
@@ -1,0 +1,32 @@
+"""Generic evaluation-runner lifecycle observability (process death / fail-closed).
+
+Research infrastructure only. Does not alter strategy, Master-V2, Double-Play,
+risk, sizing, execution, or economic decision semantics. Does not start
+evaluation runs and does not access holdout data.
+"""
+
+from __future__ import annotations
+
+from src.research.evaluation_runner_lifecycle_observability_v1.classification_v1 import (
+    INCONCLUSIVE_INFRASTRUCTURE_FAILURE,
+    RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE,
+    classify_incomplete_run_v1,
+    normalize_process_exit_v1,
+)
+from src.research.evaluation_runner_lifecycle_observability_v1.lifecycle_v1 import (
+    EvaluationRunnerLifecycleObservabilityV1,
+)
+from src.research.evaluation_runner_lifecycle_observability_v1.supervised_process_v1 import (
+    SupervisedProcessResultV1,
+    run_supervised_python_worker_v1,
+)
+
+__all__ = [
+    "INCONCLUSIVE_INFRASTRUCTURE_FAILURE",
+    "RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE",
+    "EvaluationRunnerLifecycleObservabilityV1",
+    "SupervisedProcessResultV1",
+    "classify_incomplete_run_v1",
+    "normalize_process_exit_v1",
+    "run_supervised_python_worker_v1",
+]

--- a/src/research/evaluation_runner_lifecycle_observability_v1/atomic_io_v1.py
+++ b/src/research/evaluation_runner_lifecycle_observability_v1/atomic_io_v1.py
@@ -1,0 +1,46 @@
+"""Atomic JSON persistence helpers for runner lifecycle diagnostics."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def atomic_write_json_v1(path: Path, payload: Mapping[str, Any]) -> None:
+    """Write JSON via temp file + fsync + os.replace (crash-safe replace)."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = (json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n").encode("utf-8")
+    fd, temp_path = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".tmp_{path.stem}_",
+        suffix=path.suffix or ".json",
+    )
+    closed = False
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            closed = True
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    except Exception:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise
+    finally:
+        if not closed:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def read_json_if_present_v1(path: Path) -> dict[str, Any] | None:
+    path = Path(path)
+    if not path.is_file():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/src/research/evaluation_runner_lifecycle_observability_v1/classification_v1.py
+++ b/src/research/evaluation_runner_lifecycle_observability_v1/classification_v1.py
@@ -1,0 +1,111 @@
+"""Fail-closed classification for incomplete / dead evaluation runner processes."""
+
+from __future__ import annotations
+
+import signal
+from typing import Any, Mapping
+
+from src.research.evaluation_runner_lifecycle_observability_v1.constants_v1 import (
+    AUTO_RERUN_ALLOWED,
+    AUTO_RESUME_ALLOWED,
+    RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE,
+)
+
+INCONCLUSIVE_INFRASTRUCTURE_FAILURE = RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE
+
+DEATH_CLASS_CLEAN_EXIT = "CLEAN_EXIT"
+DEATH_CLASS_NONZERO_EXIT = "NONZERO_EXIT"
+DEATH_CLASS_SIGNAL = "SIGNAL_TERMINATION"
+DEATH_CLASS_NO_RESULT_EOF = "NO_RESULT_ABRUPT_EOF"
+DEATH_CLASS_TIMEOUT_OR_MISSING_HEARTBEAT = "TIMEOUT_OR_MISSING_HEARTBEAT"
+DEATH_CLASS_WORKER_EXCEPTION = "WORKER_EXCEPTION"
+DEATH_CLASS_PERSISTENCE_FAILURE = "PERSISTENCE_FAILURE_AFTER_MEMBER"
+DEATH_CLASS_UNKNOWN = "UNKNOWN_PROCESS_DEATH"
+
+
+def _signal_name_from_negative_returncode(returncode: int) -> str | None:
+    # POSIX convention used by subprocess: -N means killed by signal N.
+    if returncode >= 0:
+        return None
+    sig_num = -returncode
+    try:
+        return signal.Signals(sig_num).name
+    except ValueError:
+        return f"SIGNAL_{sig_num}"
+
+
+def normalize_process_exit_v1(
+    *,
+    returncode: int | None,
+    signal_name: str | None = None,
+) -> dict[str, Any]:
+    """Normalize exit code / signal into a machine-readable death record."""
+    if returncode is None and not signal_name:
+        return {
+            "exit_code": None,
+            "signal_name": None,
+            "death_class": DEATH_CLASS_UNKNOWN,
+            "process_completed": False,
+        }
+    resolved_signal = signal_name or (
+        _signal_name_from_negative_returncode(returncode) if returncode is not None else None
+    )
+    if resolved_signal:
+        return {
+            "exit_code": returncode,
+            "signal_name": resolved_signal,
+            "death_class": DEATH_CLASS_SIGNAL,
+            "process_completed": False,
+        }
+    assert returncode is not None
+    if returncode == 0:
+        return {
+            "exit_code": 0,
+            "signal_name": None,
+            "death_class": DEATH_CLASS_CLEAN_EXIT,
+            "process_completed": True,
+        }
+    return {
+        "exit_code": returncode,
+        "signal_name": None,
+        "death_class": DEATH_CLASS_NONZERO_EXIT,
+        "process_completed": False,
+    }
+
+
+def classify_incomplete_run_v1(
+    *,
+    death_class: str,
+    last_confirmed_phase: str | None,
+    last_confirmed_member_index: int | None,
+    last_confirmed_member_id: str | None,
+    members_total: int | None,
+    exception_type: str | None = None,
+    exception_message_truncated: str | None = None,
+    exit_code: int | None = None,
+    signal_name: str | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Classify an incomplete evaluation as infrastructure-inconclusive (no rerun)."""
+    payload: dict[str, Any] = {
+        "result_class": RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE,
+        "economic_verdict": "NOT_EVALUATED",
+        "rerun_allowed": AUTO_RERUN_ALLOWED,
+        "resume_allowed": AUTO_RESUME_ALLOWED,
+        "auto_rerun_executed": False,
+        "death_class": death_class,
+        "last_confirmed_phase": last_confirmed_phase,
+        "last_confirmed_member_index": last_confirmed_member_index,
+        "last_confirmed_member_id": last_confirmed_member_id,
+        "members_total": members_total,
+        "exception_type": exception_type,
+        "exception_message_truncated": exception_message_truncated,
+        "exit_code": exit_code,
+        "signal_name": signal_name,
+        "fail_closed": True,
+    }
+    if extra:
+        for key, value in extra.items():
+            if key not in payload:
+                payload[key] = value
+    return payload

--- a/src/research/evaluation_runner_lifecycle_observability_v1/constants_v1.py
+++ b/src/research/evaluation_runner_lifecycle_observability_v1/constants_v1.py
@@ -1,0 +1,26 @@
+"""Constants for generic evaluation-runner lifecycle observability v1."""
+
+from __future__ import annotations
+
+SCHEMA_VERSION = "evaluation_runner_lifecycle_observability.v1"
+HEARTBEAT_FILENAME = "runner_lifecycle_heartbeat.json"
+PROGRESS_FILENAME = "runner_lifecycle_progress.json"
+TERMINAL_DIAGNOSTICS_FILENAME = "runner_lifecycle_terminal_diagnostics.json"
+EXCEPTION_FILENAME = "runner_lifecycle_exception.json"
+
+RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE = "INCONCLUSIVE_INFRASTRUCTURE_FAILURE"
+INCONCLUSIVE_INFRASTRUCTURE_FAILURE = RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE
+
+PHASE_INIT = "init"
+PHASE_MEMBER = "member"
+PHASE_PERSIST = "persist"
+PHASE_COMPLETE = "complete"
+PHASE_TERMINAL_FAILURE = "terminal_failure"
+
+MAX_TRACEBACK_CHARS = 4000
+MAX_EXCEPTION_MESSAGE_CHARS = 512
+MAX_MEMBER_ID_CHARS = 128
+
+# No automatic resume / rerun under this observability surface.
+AUTO_RERUN_ALLOWED = False
+AUTO_RESUME_ALLOWED = False

--- a/src/research/evaluation_runner_lifecycle_observability_v1/lifecycle_v1.py
+++ b/src/research/evaluation_runner_lifecycle_observability_v1/lifecycle_v1.py
@@ -1,0 +1,282 @@
+"""In-process lifecycle observability: heartbeat, progress, signals, exceptions."""
+
+from __future__ import annotations
+
+import os
+import signal
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.research.evaluation_runner_lifecycle_observability_v1.atomic_io_v1 import (
+    atomic_write_json_v1,
+    read_json_if_present_v1,
+)
+from src.research.evaluation_runner_lifecycle_observability_v1.classification_v1 import (
+    DEATH_CLASS_PERSISTENCE_FAILURE,
+    DEATH_CLASS_SIGNAL,
+    DEATH_CLASS_UNKNOWN,
+    DEATH_CLASS_WORKER_EXCEPTION,
+    classify_incomplete_run_v1,
+)
+from src.research.evaluation_runner_lifecycle_observability_v1.constants_v1 import (
+    EXCEPTION_FILENAME,
+    HEARTBEAT_FILENAME,
+    MAX_EXCEPTION_MESSAGE_CHARS,
+    MAX_MEMBER_ID_CHARS,
+    MAX_TRACEBACK_CHARS,
+    PHASE_COMPLETE,
+    PHASE_INIT,
+    PHASE_MEMBER,
+    PHASE_PERSIST,
+    PHASE_TERMINAL_FAILURE,
+    PROGRESS_FILENAME,
+    RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE,
+    SCHEMA_VERSION,
+    TERMINAL_DIAGNOSTICS_FILENAME,
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)] + "..."
+
+
+def _safe_member_id(member_id: str | None) -> str | None:
+    if member_id is None:
+        return None
+    # Keep identifiers short; never dump paths or payloads.
+    cleaned = str(member_id).replace("\n", " ").replace("\r", " ").strip()
+    return _truncate(cleaned, MAX_MEMBER_ID_CHARS)
+
+
+class EvaluationRunnerLifecycleObservabilityV1:
+    """Persist runner progress/heartbeat/terminal process diagnostics fail-closed."""
+
+    def __init__(
+        self,
+        diagnostics_dir: Path,
+        *,
+        run_id: str,
+        pid: int | None = None,
+    ) -> None:
+        self.diagnostics_dir = Path(diagnostics_dir)
+        self.diagnostics_dir.mkdir(parents=True, exist_ok=True)
+        self.run_id = str(run_id)
+        self.pid = int(pid if pid is not None else os.getpid())
+        self._handlers_installed = False
+        self._previous_handlers: dict[int, Any] = {}
+        self._completed = False
+        self.last_confirmed_phase: str | None = PHASE_INIT
+        self.last_confirmed_member_index: int | None = None
+        self.last_confirmed_member_id: str | None = None
+        self.members_total: int | None = None
+        self._write_heartbeat(phase=PHASE_INIT, note="lifecycle_attached")
+
+    @property
+    def heartbeat_path(self) -> Path:
+        return self.diagnostics_dir / HEARTBEAT_FILENAME
+
+    @property
+    def progress_path(self) -> Path:
+        return self.diagnostics_dir / PROGRESS_FILENAME
+
+    @property
+    def terminal_path(self) -> Path:
+        return self.diagnostics_dir / TERMINAL_DIAGNOSTICS_FILENAME
+
+    @property
+    def exception_path(self) -> Path:
+        return self.diagnostics_dir / EXCEPTION_FILENAME
+
+    def install_signal_handlers(self) -> None:
+        """Install catchable signal handlers that persist terminal diagnostics."""
+        if self._handlers_installed:
+            return
+        for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            previous = signal.getsignal(sig)
+            self._previous_handlers[int(sig)] = previous
+
+            def _handler(
+                signum: int,
+                _frame: Any,
+                *,
+                _sig: int = int(sig),
+            ) -> None:
+                try:
+                    name = signal.Signals(signum).name
+                except ValueError:
+                    name = f"SIGNAL_{signum}"
+                self.record_signal_termination(signal_name=name, signum=signum)
+                # Re-raise default termination after durable write.
+                signal.signal(signum, signal.SIG_DFL)
+                os.kill(os.getpid(), signum)
+
+            signal.signal(sig, _handler)
+        self._handlers_installed = True
+
+    def uninstall_signal_handlers(self) -> None:
+        if not self._handlers_installed:
+            return
+        for sig_num, previous in self._previous_handlers.items():
+            try:
+                signal.signal(sig_num, previous)
+            except (ValueError, OSError):
+                pass
+        self._previous_handlers.clear()
+        self._handlers_installed = False
+
+    def _base_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "pid": self.pid,
+            "updated_at_utc": _utc_now(),
+            "last_confirmed_phase": self.last_confirmed_phase,
+            "last_confirmed_member_index": self.last_confirmed_member_index,
+            "last_confirmed_member_id": self.last_confirmed_member_id,
+            "members_total": self.members_total,
+            "completed": self._completed,
+            "auto_rerun_allowed": False,
+            "auto_resume_allowed": False,
+        }
+
+    def _write_heartbeat(self, *, phase: str, note: str | None = None) -> None:
+        payload = self._base_payload()
+        payload["phase"] = phase
+        payload["heartbeat"] = True
+        if note:
+            payload["note"] = note
+        atomic_write_json_v1(self.heartbeat_path, payload)
+
+    def record_member_progress(
+        self,
+        *,
+        phase: str,
+        member_index: int,
+        members_total: int,
+        member_id: str | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        """Atomically persist last confirmed member (durable, not stdout-only)."""
+        self.last_confirmed_phase = phase or PHASE_MEMBER
+        self.last_confirmed_member_index = int(member_index)
+        self.last_confirmed_member_id = _safe_member_id(member_id)
+        self.members_total = int(members_total)
+        progress = self._base_payload()
+        progress["phase"] = self.last_confirmed_phase
+        progress["member_index"] = self.last_confirmed_member_index
+        progress["member_id"] = self.last_confirmed_member_id
+        progress["members_total"] = self.members_total
+        progress["progress_confirmed"] = True
+        if extra:
+            # Shallow, non-sensitive extras only (counts / flags).
+            for key in sorted(extra):
+                if key.startswith("_"):
+                    continue
+                value = extra[key]
+                if isinstance(value, (bool, int, float, str)) or value is None:
+                    progress[key] = value
+        atomic_write_json_v1(self.progress_path, progress)
+        self._write_heartbeat(phase=self.last_confirmed_phase, note="member_progress")
+
+    def record_persist_phase(self, *, note: str = "persist_boundary") -> None:
+        self.last_confirmed_phase = PHASE_PERSIST
+        self._write_heartbeat(phase=PHASE_PERSIST, note=note)
+
+    def mark_complete(self) -> None:
+        self._completed = True
+        self.last_confirmed_phase = PHASE_COMPLETE
+        payload = self._base_payload()
+        payload["phase"] = PHASE_COMPLETE
+        payload["result_status"] = "COMPLETE"
+        atomic_write_json_v1(self.progress_path, payload)
+        self._write_heartbeat(phase=PHASE_COMPLETE, note="run_complete")
+        self.uninstall_signal_handlers()
+
+    def record_exception(self, exc: BaseException) -> dict[str, Any]:
+        tb = _truncate(traceback.format_exc(), MAX_TRACEBACK_CHARS)
+        message = _truncate(str(exc), MAX_EXCEPTION_MESSAGE_CHARS)
+        exc_type = type(exc).__name__
+        payload = {
+            **self._base_payload(),
+            "exception_type": exc_type,
+            "exception_message_truncated": message,
+            "traceback_truncated": tb,
+        }
+        atomic_write_json_v1(self.exception_path, payload)
+        terminal = self.write_terminal_infrastructure_failure(
+            death_class=DEATH_CLASS_WORKER_EXCEPTION,
+            exception_type=exc_type,
+            exception_message_truncated=message,
+            exit_code=1,
+            signal_name=None,
+            extra={"traceback_truncated": tb},
+        )
+        return terminal
+
+    def record_signal_termination(self, *, signal_name: str, signum: int) -> dict[str, Any]:
+        return self.write_terminal_infrastructure_failure(
+            death_class=DEATH_CLASS_SIGNAL,
+            exception_type=None,
+            exception_message_truncated=None,
+            exit_code=-int(signum),
+            signal_name=signal_name,
+            extra={"signum": int(signum)},
+        )
+
+    def record_persistence_failure(self, exc: BaseException) -> dict[str, Any]:
+        message = _truncate(str(exc), MAX_EXCEPTION_MESSAGE_CHARS)
+        return self.write_terminal_infrastructure_failure(
+            death_class=DEATH_CLASS_PERSISTENCE_FAILURE,
+            exception_type=type(exc).__name__,
+            exception_message_truncated=message,
+            exit_code=1,
+            signal_name=None,
+            extra={"persistence_failure": True},
+        )
+
+    def write_terminal_infrastructure_failure(
+        self,
+        *,
+        death_class: str,
+        exception_type: str | None,
+        exception_message_truncated: str | None,
+        exit_code: int | None,
+        signal_name: str | None,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        progress = read_json_if_present_v1(self.progress_path) or {}
+        phase = progress.get("phase", self.last_confirmed_phase)
+        member_index = progress.get("member_index", self.last_confirmed_member_index)
+        member_id = progress.get("member_id", self.last_confirmed_member_id)
+        members_total = progress.get("members_total", self.members_total)
+        classified = classify_incomplete_run_v1(
+            death_class=death_class,
+            last_confirmed_phase=phase,
+            last_confirmed_member_index=member_index,
+            last_confirmed_member_id=member_id,
+            members_total=members_total,
+            exception_type=exception_type,
+            exception_message_truncated=exception_message_truncated,
+            exit_code=exit_code,
+            signal_name=signal_name,
+            extra=extra,
+        )
+        self.last_confirmed_phase = PHASE_TERMINAL_FAILURE
+        terminal = {
+            **self._base_payload(),
+            **classified,
+            "result_class": RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE,
+            "death_class_fallback_if_unobserved": DEATH_CLASS_UNKNOWN,
+            "phase": PHASE_TERMINAL_FAILURE,
+        }
+        atomic_write_json_v1(self.terminal_path, terminal)
+        self._write_heartbeat(phase=PHASE_TERMINAL_FAILURE, note=death_class)
+        return terminal

--- a/src/research/evaluation_runner_lifecycle_observability_v1/supervised_process_v1.py
+++ b/src/research/evaluation_runner_lifecycle_observability_v1/supervised_process_v1.py
@@ -1,0 +1,229 @@
+"""Supervised child-process execution with drain, reap, and exit classification."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from src.research.evaluation_runner_lifecycle_observability_v1.classification_v1 import (
+    DEATH_CLASS_NO_RESULT_EOF,
+    DEATH_CLASS_TIMEOUT_OR_MISSING_HEARTBEAT,
+    DEATH_CLASS_WORKER_EXCEPTION,
+    normalize_process_exit_v1,
+)
+from src.research.evaluation_runner_lifecycle_observability_v1.constants_v1 import (
+    MAX_TRACEBACK_CHARS,
+)
+
+
+@dataclass(frozen=True)
+class SupervisedProcessResultV1:
+    returncode: int | None
+    exit_code: int | None
+    signal_name: str | None
+    death_class: str
+    process_completed: bool
+    stdout: str
+    stderr: str
+    timed_out: bool
+    abrupt_eof: bool
+    worker_exception_observed: bool
+    pid: int | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "returncode": self.returncode,
+            "exit_code": self.exit_code,
+            "signal_name": self.signal_name,
+            "death_class": self.death_class,
+            "process_completed": self.process_completed,
+            "stdout_chars": len(self.stdout),
+            "stderr_chars": len(self.stderr),
+            "timed_out": self.timed_out,
+            "abrupt_eof": self.abrupt_eof,
+            "worker_exception_observed": self.worker_exception_observed,
+            "pid": self.pid,
+        }
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)] + "..."
+
+
+def run_supervised_python_worker_v1(
+    *,
+    code: str,
+    timeout_seconds: float | None = None,
+    env: Mapping[str, str] | None = None,
+    cwd: Path | None = None,
+    python_executable: str | None = None,
+    send_signal: int | None = None,
+    signal_after_seconds: float = 0.05,
+) -> SupervisedProcessResultV1:
+    """Run a synthetic Python worker under Popen with stdout/stderr drain + reap.
+
+    Parent always consumes pipes and waits (or times out and terminates).
+    Does not auto-rerun. Intended for lifecycle observability / tests.
+    """
+    exe = python_executable or sys.executable
+    merged_env = dict(os.environ if env is None else env)
+    # Avoid leaking sensitive host env into worker logs; keep PATH/PYTHONPATH minimal.
+    proc = subprocess.Popen(
+        [exe, "-c", code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=str(cwd) if cwd is not None else None,
+        env=merged_env,
+        text=True,
+    )
+    pid = proc.pid
+    timed_out = False
+    abrupt_eof = False
+    stdout = ""
+    stderr = ""
+    returncode: int | None = None
+
+    try:
+        if send_signal is not None:
+            time.sleep(max(0.0, float(signal_after_seconds)))
+            if proc.poll() is None:
+                proc.send_signal(send_signal)
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout_seconds)
+            returncode = proc.returncode
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            proc.kill()
+            stdout, stderr = proc.communicate()
+            returncode = proc.returncode
+    finally:
+        # Hard reap: ensure no zombie even if communicate failed oddly.
+        if proc.poll() is None:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            try:
+                out2, err2 = proc.communicate(timeout=2)
+                stdout = stdout or out2
+                stderr = stderr or err2
+            except Exception:
+                pass
+        if returncode is None:
+            returncode = proc.poll()
+
+    stdout = stdout or ""
+    stderr = stderr or ""
+    # Abrupt EOF: process ended with empty stdout and no structured result marker.
+    if (not timed_out) and ("WORKER_RESULT=" not in stdout) and returncode != 0:
+        abrupt_eof = True
+
+    normalized = normalize_process_exit_v1(returncode=returncode)
+    death_class = normalized["death_class"]
+    worker_exception_observed = "Traceback (most recent call last)" in stderr or (
+        "WORKER_EXCEPTION=" in stdout or "WORKER_EXCEPTION=" in stderr
+    )
+    if timed_out:
+        death_class = DEATH_CLASS_TIMEOUT_OR_MISSING_HEARTBEAT
+    elif worker_exception_observed and death_class != "SIGNAL_TERMINATION":
+        death_class = DEATH_CLASS_WORKER_EXCEPTION
+    elif abrupt_eof and death_class not in {"SIGNAL_TERMINATION", "CLEAN_EXIT"}:
+        death_class = DEATH_CLASS_NO_RESULT_EOF
+
+    return SupervisedProcessResultV1(
+        returncode=returncode,
+        exit_code=normalized["exit_code"],
+        signal_name=normalized["signal_name"],
+        death_class=death_class,
+        process_completed=bool(normalized["process_completed"]),
+        stdout=_truncate(stdout, MAX_TRACEBACK_CHARS),
+        stderr=_truncate(stderr, MAX_TRACEBACK_CHARS),
+        timed_out=timed_out,
+        abrupt_eof=abrupt_eof,
+        worker_exception_observed=worker_exception_observed,
+        pid=pid,
+    )
+
+
+def portable_terminating_signal_v1() -> int:
+    """Prefer SIGTERM for portable synthetic signal-death tests."""
+    return int(signal.SIGTERM)
+
+
+def run_supervised_argv_v1(
+    argv: Sequence[str],
+    *,
+    timeout_seconds: float | None = None,
+    env: Mapping[str, str] | None = None,
+    cwd: Path | None = None,
+) -> SupervisedProcessResultV1:
+    """Supervise an arbitrary argv child (tests / harness only)."""
+    proc = subprocess.Popen(
+        list(argv),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=str(cwd) if cwd is not None else None,
+        env=dict(os.environ if env is None else env),
+        text=True,
+    )
+    pid = proc.pid
+    timed_out = False
+    stdout = ""
+    stderr = ""
+    returncode: int | None = None
+    try:
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout_seconds)
+            returncode = proc.returncode
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            proc.kill()
+            stdout, stderr = proc.communicate()
+            returncode = proc.returncode
+    finally:
+        if proc.poll() is None:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            try:
+                proc.communicate(timeout=2)
+            except Exception:
+                pass
+        if returncode is None:
+            returncode = proc.poll()
+
+    stdout = stdout or ""
+    stderr = stderr or ""
+    abrupt_eof = (not timed_out) and ("WORKER_RESULT=" not in stdout) and returncode != 0
+    normalized = normalize_process_exit_v1(returncode=returncode)
+    death_class = normalized["death_class"]
+    worker_exception_observed = "Traceback (most recent call last)" in stderr
+    if timed_out:
+        death_class = DEATH_CLASS_TIMEOUT_OR_MISSING_HEARTBEAT
+    elif worker_exception_observed:
+        death_class = DEATH_CLASS_WORKER_EXCEPTION
+    elif abrupt_eof and death_class not in {"SIGNAL_TERMINATION", "CLEAN_EXIT"}:
+        death_class = DEATH_CLASS_NO_RESULT_EOF
+
+    return SupervisedProcessResultV1(
+        returncode=returncode,
+        exit_code=normalized["exit_code"],
+        signal_name=normalized["signal_name"],
+        death_class=death_class,
+        process_completed=bool(normalized["process_completed"]),
+        stdout=_truncate(stdout, MAX_TRACEBACK_CHARS),
+        stderr=_truncate(stderr, MAX_TRACEBACK_CHARS),
+        timed_out=timed_out,
+        abrupt_eof=abrupt_eof,
+        worker_exception_observed=worker_exception_observed,
+        pid=pid,
+    )

--- a/tests/research/test_evaluation_runner_lifecycle_observability_v1.py
+++ b/tests/research/test_evaluation_runner_lifecycle_observability_v1.py
@@ -1,0 +1,198 @@
+"""Synthetic tests for generic evaluation-runner lifecycle observability v1.
+
+No real research evaluation. No holdout access. Deterministic fixtures only.
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+import time
+from pathlib import Path
+
+from src.research.evaluation_runner_lifecycle_observability_v1 import (
+    EvaluationRunnerLifecycleObservabilityV1,
+    classify_incomplete_run_v1,
+    normalize_process_exit_v1,
+    run_supervised_python_worker_v1,
+)
+from src.research.evaluation_runner_lifecycle_observability_v1.classification_v1 import (
+    DEATH_CLASS_NO_RESULT_EOF,
+    DEATH_CLASS_NONZERO_EXIT,
+    DEATH_CLASS_PERSISTENCE_FAILURE,
+    DEATH_CLASS_SIGNAL,
+    DEATH_CLASS_TIMEOUT_OR_MISSING_HEARTBEAT,
+    DEATH_CLASS_WORKER_EXCEPTION,
+)
+from src.research.evaluation_runner_lifecycle_observability_v1.constants_v1 import (
+    HEARTBEAT_FILENAME,
+    PROGRESS_FILENAME,
+    RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE,
+    TERMINAL_DIAGNOSTICS_FILENAME,
+)
+from src.research.evaluation_runner_lifecycle_observability_v1.supervised_process_v1 import (
+    portable_terminating_signal_v1,
+)
+
+
+def test_normalize_clean_and_nonzero_and_signal() -> None:
+    clean = normalize_process_exit_v1(returncode=0)
+    assert clean["death_class"] == "CLEAN_EXIT"
+    assert clean["process_completed"] is True
+    nonzero = normalize_process_exit_v1(returncode=7)
+    assert nonzero["death_class"] == DEATH_CLASS_NONZERO_EXIT
+    assert nonzero["exit_code"] == 7
+    signaled = normalize_process_exit_v1(returncode=-signal.SIGTERM)
+    assert signaled["death_class"] == DEATH_CLASS_SIGNAL
+    assert signaled["signal_name"] == "SIGTERM"
+
+
+def test_classify_incomplete_is_fail_closed_no_rerun() -> None:
+    payload = classify_incomplete_run_v1(
+        death_class=DEATH_CLASS_TIMEOUT_OR_MISSING_HEARTBEAT,
+        last_confirmed_phase="baseline",
+        last_confirmed_member_index=2,
+        last_confirmed_member_id="SYNTH-A",
+        members_total=46,
+    )
+    assert payload["result_class"] == RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE
+    assert payload["economic_verdict"] == "NOT_EVALUATED"
+    assert payload["rerun_allowed"] is False
+    assert payload["resume_allowed"] is False
+    assert payload["auto_rerun_executed"] is False
+    assert payload["fail_closed"] is True
+    assert payload["last_confirmed_member_index"] == 2
+
+
+def test_member_progress_and_heartbeat_atomic(tmp_path: Path) -> None:
+    life = EvaluationRunnerLifecycleObservabilityV1(tmp_path, run_id="synthetic-run")
+    life.record_member_progress(
+        phase="baseline",
+        member_index=2,
+        members_total=46,
+        member_id="ADA-USDT-SWAP",
+        extra={"trades": 3},
+    )
+    progress = json.loads((tmp_path / PROGRESS_FILENAME).read_text(encoding="utf-8"))
+    heartbeat = json.loads((tmp_path / HEARTBEAT_FILENAME).read_text(encoding="utf-8"))
+    assert progress["member_index"] == 2
+    assert progress["member_id"] == "ADA-USDT-SWAP"
+    assert progress["trades"] == 3
+    assert heartbeat["heartbeat"] is True
+    assert heartbeat["last_confirmed_member_index"] == 2
+
+
+def test_worker_exception_mode(tmp_path: Path) -> None:
+    result = run_supervised_python_worker_v1(
+        code=(
+            "import sys\n"
+            "print('WORKER_EXCEPTION=RuntimeError', flush=True)\n"
+            "raise RuntimeError('synthetic_worker_boom')\n"
+        ),
+        timeout_seconds=5.0,
+    )
+    assert result.worker_exception_observed is True
+    assert result.death_class == DEATH_CLASS_WORKER_EXCEPTION
+    assert result.process_completed is False
+    life = EvaluationRunnerLifecycleObservabilityV1(tmp_path, run_id="exc-run")
+    life.record_member_progress(phase="baseline", member_index=1, members_total=3, member_id="M1")
+    terminal = life.record_exception(RuntimeError("synthetic_worker_boom"))
+    assert terminal["result_class"] == RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE
+    assert terminal["death_class"] == DEATH_CLASS_WORKER_EXCEPTION
+    assert terminal["exception_type"] == "RuntimeError"
+    assert terminal["last_confirmed_member_index"] == 1
+
+
+def test_nonzero_exit_mode() -> None:
+    result = run_supervised_python_worker_v1(
+        code="import sys; print('no_result'); sys.exit(9)",
+        timeout_seconds=5.0,
+    )
+    assert result.exit_code == 9
+    assert result.death_class in {DEATH_CLASS_NONZERO_EXIT, DEATH_CLASS_NO_RESULT_EOF}
+    assert result.process_completed is False
+
+
+def test_signal_death_mode_portable() -> None:
+    sig = portable_terminating_signal_v1()
+    result = run_supervised_python_worker_v1(
+        code="import time; time.sleep(30)",
+        timeout_seconds=5.0,
+        send_signal=sig,
+        signal_after_seconds=0.1,
+    )
+    assert result.process_completed is False
+    assert result.death_class == DEATH_CLASS_SIGNAL
+    assert result.signal_name == "SIGTERM"
+    assert result.exit_code is not None
+    assert result.exit_code < 0 or result.returncode not in (0, None)
+
+
+def test_abrupt_eof_no_result_mode() -> None:
+    result = run_supervised_python_worker_v1(
+        code="import sys; sys.exit(1)",
+        timeout_seconds=5.0,
+    )
+    assert result.abrupt_eof is True
+    assert result.death_class == DEATH_CLASS_NO_RESULT_EOF
+    assert result.process_completed is False
+
+
+def test_timeout_or_missing_heartbeat_mode(tmp_path: Path) -> None:
+    result = run_supervised_python_worker_v1(
+        code="import time; time.sleep(30)",
+        timeout_seconds=0.2,
+    )
+    assert result.timed_out is True
+    assert result.death_class == DEATH_CLASS_TIMEOUT_OR_MISSING_HEARTBEAT
+    life = EvaluationRunnerLifecycleObservabilityV1(tmp_path, run_id="hb-run")
+    life.record_member_progress(phase="baseline", member_index=2, members_total=46, member_id="M2")
+    # Simulate parent observing stale heartbeat without new progress.
+    time.sleep(0.01)
+    stale = json.loads((tmp_path / HEARTBEAT_FILENAME).read_text(encoding="utf-8"))
+    assert stale["last_confirmed_member_index"] == 2
+    terminal = life.write_terminal_infrastructure_failure(
+        death_class=DEATH_CLASS_TIMEOUT_OR_MISSING_HEARTBEAT,
+        exception_type=None,
+        exception_message_truncated=None,
+        exit_code=None,
+        signal_name=None,
+    )
+    assert terminal["result_class"] == RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE
+    assert terminal["last_confirmed_member_index"] == 2
+    assert (tmp_path / TERMINAL_DIAGNOSTICS_FILENAME).is_file()
+
+
+def test_persistence_failure_after_successful_member(tmp_path: Path) -> None:
+    life = EvaluationRunnerLifecycleObservabilityV1(tmp_path, run_id="persist-run")
+    life.record_member_progress(
+        phase="baseline",
+        member_index=2,
+        members_total=46,
+        member_id="SYNTH-OK",
+    )
+    terminal = life.record_persistence_failure(OSError("synthetic_disk_full"))
+    assert terminal["death_class"] == DEATH_CLASS_PERSISTENCE_FAILURE
+    assert terminal["result_class"] == RESULT_CLASS_INCONCLUSIVE_INFRASTRUCTURE_FAILURE
+    assert terminal["last_confirmed_member_index"] == 2
+    assert terminal["exception_type"] == "OSError"
+    assert terminal["rerun_allowed"] is False
+
+
+def test_cli_source_has_lifecycle_hooks_without_rerun() -> None:
+    repo = Path(__file__).resolve().parents[2]
+    cli = (
+        repo
+        / "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v1.py"
+    ).read_text(encoding="utf-8")
+    assert "EvaluationRunnerLifecycleObservabilityV1" in cli
+    assert "install_signal_handlers" in cli
+    assert "EVALUATION_RUN_SLOT_ALREADY_CONSUMED" in cli
+    assert "AUTO_RERUN_EXECUTED=false" in cli
+    panel = (
+        repo / "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1/"
+        "panel_runner_v1.py"
+    ).read_text(encoding="utf-8")
+    assert "record_member_progress" in panel
+    assert "record_persist_phase" in panel
+    assert "mark_complete" in panel


### PR DESCRIPTION
## Summary
- Adds generic `evaluation_runner_lifecycle_observability_v1` so evaluation-runner process death is durable and fail-closed (heartbeat/progress, exit/signal normalization, exception diagnostics, supervised child reap).
- Wires observability into the midband development CLI/panel member loop without changing strategy, Master-V2, Double-Play, risk/sizing/execution, or economic decision semantics.
- Historical 2/46 death cause remains `UNKNOWN`; this PR closes the confirmed observability gap and classifies incomplete runs as `INCONCLUSIVE_INFRASTRUCTURE_FAILURE` without auto-rerun. `EVALUATION_RUN_COUNT` stays 1; no evaluation rerun; no holdout access.

## Test plan
- [x] Synthetic lifecycle failure-mode tests (`tests/research/test_evaluation_runner_lifecycle_observability_v1.py`)
- [x] Existing bollinger/preregistration/backlog terminal contracts
- [x] `ruff format --check` / `ruff check` on changed Python
- [x] Docs token policy + docs reference targets
- [x] PR-bounded selector suite (~47s wallclock; under 840s budget)
- [ ] Required GitHub checks green before merge

## Guardrails
- EVALUATION_RERUN_EXECUTED=false
- EVALUATION_RUN_COUNT unchanged (1→1)
- HOLDOUT_DATA_ACCESSED=false
- STRATEGY_SEMANTICS_CHANGED=false
- No Master V2 / Double-Play / Risk / Sizing / Execution mutation
- No runtime / orders


Made with [Cursor](https://cursor.com)