### PR TITLE
diagnose: midband exit identical-arms binding fix (V3)

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -781,10 +781,11 @@
         "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1/",
         "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v1.py",
         "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v1.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_gate_binding_v1.py",
         "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v1/",
         "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V1.md"
       ],
-      "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR side-aware middle-band exit-efficiency versus immutable bollinger baseline on sealed DEVELOPMENT panel (evaluation_run_count 0->1); Economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders."
+      "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR side-aware middle-band exit-efficiency versus immutable bollinger baseline on sealed DEVELOPMENT panel (evaluation_run_count 0->1); Economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders. Gate-binding contract test covers MV2 wiring_mod capture-alias open_side binding only."
     },
     "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V2": {
       "path_prefixes": [

--- a/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1/exit_efficiency_gate_v1.py
+++ b/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1/exit_efficiency_gate_v1.py
@@ -47,7 +47,10 @@ def optional_treatment_exit_efficiency_gate(
     original_bind_bar = wiring_mod.bind_bar_for_mv2_wiring_v1
     original_bind_warmup = wiring_mod._bind_economic_research_warmup_observation_bar_v1
     original_map = wiring_mod.map_decision_evidence_to_position_signal_v1
-    original_capture = feedback_mod.capture_backtest_engine_position_feedback_v1
+    # MV2 bar loop calls the name bound on wiring_mod (from-import alias). Patching
+    # only feedback_mod leaves that live call site unbound → open_side never set.
+    original_capture_wiring = wiring_mod.capture_backtest_engine_position_feedback_v1
+    original_capture_feedback = feedback_mod.capture_backtest_engine_position_feedback_v1
 
     def _bind_bar_tracked(**kwargs):  # type: ignore[no-untyped-def]
         state["current_ts"] = pd.Timestamp(kwargs["bar"].name)
@@ -58,7 +61,7 @@ def optional_treatment_exit_efficiency_gate(
         return original_bind_warmup(**kwargs)
 
     def _capture_tracked(**kwargs):  # type: ignore[no-untyped-def]
-        feedback = original_capture(**kwargs)
+        feedback = original_capture_feedback(**kwargs)
         if feedback.has_open_trade:
             if feedback.existing_position_side == ExistingPositionSide.LONG:
                 state["open_side"] = "long"
@@ -102,6 +105,7 @@ def optional_treatment_exit_efficiency_gate(
     wiring_mod.bind_bar_for_mv2_wiring_v1 = _bind_bar_tracked  # type: ignore[assignment]
     wiring_mod._bind_economic_research_warmup_observation_bar_v1 = _bind_warmup_tracked  # type: ignore[assignment]
     wiring_mod.map_decision_evidence_to_position_signal_v1 = _map_gated  # type: ignore[assignment]
+    wiring_mod.capture_backtest_engine_position_feedback_v1 = _capture_tracked  # type: ignore[assignment]
     feedback_mod.capture_backtest_engine_position_feedback_v1 = _capture_tracked  # type: ignore[assignment]
     try:
         yield counters
@@ -109,7 +113,10 @@ def optional_treatment_exit_efficiency_gate(
         wiring_mod.bind_bar_for_mv2_wiring_v1 = original_bind_bar  # type: ignore[assignment]
         wiring_mod._bind_economic_research_warmup_observation_bar_v1 = original_bind_warmup  # type: ignore[assignment]
         wiring_mod.map_decision_evidence_to_position_signal_v1 = original_map  # type: ignore[assignment]
-        feedback_mod.capture_backtest_engine_position_feedback_v1 = original_capture  # type: ignore[assignment]
+        wiring_mod.capture_backtest_engine_position_feedback_v1 = original_capture_wiring  # type: ignore[assignment]
+        feedback_mod.capture_backtest_engine_position_feedback_v1 = (  # type: ignore[assignment]
+            original_capture_feedback
+        )
 
 
 __all__ = ["optional_treatment_exit_efficiency_gate"]

--- a/tests/research/test_bollinger_mr_midband_exit_efficiency_gate_binding_v1.py
+++ b/tests/research/test_bollinger_mr_midband_exit_efficiency_gate_binding_v1.py
@@ -1,0 +1,143 @@
+"""Synthetic binding contracts for midband exit-efficiency gate open_side wiring.
+
+No panel archive, no evaluation runner, no holdout. Proves the V3
+``identical_arms_no_exit_divergence`` root cause: position-feedback capture
+must patch the MV2 wiring_mod from-import alias (live bar-loop call site),
+not only ``feedback_mod``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from src.backtest.backtest_engine_position_feedback_adapter_v1 import (
+    LegacyRealisticBarLoopStateV1,
+)
+from src.backtest.engine import Trade
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v1.exit_efficiency_gate_v1 import (
+    optional_treatment_exit_efficiency_gate,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v1.midband_exit_mechanism_v1 import (
+    short_exit_mask_from_bars,
+)
+
+
+def _synthetic_short_midband_cross_bars() -> pd.DataFrame:
+    """Deterministic bars with at least one SHORT midband cross after warmup."""
+    idx = pd.date_range("2023-05-20", periods=40, freq="h", tz="UTC")
+    # Flat warmup, then rise above middle, then drop through middle (short exit).
+    close = [100.0] * 20 + [105.0, 106.0, 107.0, 108.0, 109.0, 110.0, 109.0, 100.0]
+    close = close + [100.0] * (40 - len(close))
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [c + 1.0 for c in close],
+            "low": [c - 1.0 for c in close],
+            "close": close,
+        },
+        index=idx,
+    )
+
+
+def _open_short_loop_state(*, entry_ts: pd.Timestamp) -> LegacyRealisticBarLoopStateV1:
+    return LegacyRealisticBarLoopStateV1(
+        equity=10_000.0,
+        current_trade=Trade(
+            entry_time=entry_ts,
+            entry_price=110.0,
+            size=-1.0,
+            stop_price=120.0,
+        ),
+    )
+
+
+def test_feedback_mod_only_patch_leaves_wiring_mod_capture_unbound() -> None:
+    """Historical collapse boundary: from-import alias is a separate binding."""
+    import src.backtest.backtest_engine_position_feedback_adapter_v1 as feedback_mod
+    import src.backtest.mv2_research_wiring_v1 as wiring_mod
+
+    orig_wiring = wiring_mod.capture_backtest_engine_position_feedback_v1
+    orig_feedback = feedback_mod.capture_backtest_engine_position_feedback_v1
+    assert orig_wiring is orig_feedback
+
+    def _feedback_only_patch(**kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("feedback_only_patch_must_not_be_reached_via_wiring_mod")
+
+    feedback_mod.capture_backtest_engine_position_feedback_v1 = _feedback_only_patch
+    try:
+        assert wiring_mod.capture_backtest_engine_position_feedback_v1 is orig_wiring
+        assert wiring_mod.capture_backtest_engine_position_feedback_v1 is not _feedback_only_patch
+    finally:
+        feedback_mod.capture_backtest_engine_position_feedback_v1 = orig_feedback
+
+
+def test_gate_patches_wiring_mod_and_feedback_mod_capture_aliases() -> None:
+    bars = _synthetic_short_midband_cross_bars()
+    import src.backtest.backtest_engine_position_feedback_adapter_v1 as feedback_mod
+    import src.backtest.mv2_research_wiring_v1 as wiring_mod
+
+    before_w = wiring_mod.capture_backtest_engine_position_feedback_v1
+    before_f = feedback_mod.capture_backtest_engine_position_feedback_v1
+    with optional_treatment_exit_efficiency_gate(enabled=True, bars=bars):
+        assert wiring_mod.capture_backtest_engine_position_feedback_v1 is not before_w
+        assert feedback_mod.capture_backtest_engine_position_feedback_v1 is not before_f
+        assert (
+            wiring_mod.capture_backtest_engine_position_feedback_v1
+            is feedback_mod.capture_backtest_engine_position_feedback_v1
+        )
+    assert wiring_mod.capture_backtest_engine_position_feedback_v1 is before_w
+    assert feedback_mod.capture_backtest_engine_position_feedback_v1 is before_f
+
+
+def test_synthetic_short_midband_exit_diverges_when_open_side_bound_via_wiring_capture(
+    monkeypatch,
+) -> None:
+    """Baseline map stays flat; treatment forces cover (+1) on short midband cross."""
+    import src.backtest.mv2_research_wiring_v1 as wiring_mod
+
+    bars = _synthetic_short_midband_cross_bars()
+    short_mask = short_exit_mask_from_bars(bars)
+    trigger_positions = [i for i, v in enumerate(short_mask.tolist()) if v]
+    assert trigger_positions, "fixture_must_contain_short_midband_cross"
+    trigger_i = int(trigger_positions[0])
+    trigger_ts = bars.index[trigger_i]
+    entry_ts = bars.index[max(0, trigger_i - 3)]
+
+    def _fake_bind_bar(
+        *, bar, instrument_id, trading_epoch, profile_binding, research_execution_cost=None
+    ):
+        return ("context", "l1_status", True)
+
+    def _fake_map(_evidence) -> int:
+        return 0
+
+    monkeypatch.setattr(wiring_mod, "bind_bar_for_mv2_wiring_v1", _fake_bind_bar)
+    monkeypatch.setattr(wiring_mod, "map_decision_evidence_to_position_signal_v1", _fake_map)
+
+    loop_state = _open_short_loop_state(entry_ts=entry_ts)
+    evidence = SimpleNamespace(decision_outcome="hold")
+
+    baseline_signal = wiring_mod.map_decision_evidence_to_position_signal_v1(evidence)
+    assert baseline_signal == 0
+
+    with optional_treatment_exit_efficiency_gate(enabled=True, bars=bars) as counters:
+        # Live MV2 call site: wiring_mod.capture_... (not feedback_mod alone).
+        wiring_mod.capture_backtest_engine_position_feedback_v1(
+            state=loop_state,
+            feedback_source_bar_epoch=trigger_i - 1,
+        )
+        wiring_mod.bind_bar_for_mv2_wiring_v1(
+            bar=bars.iloc[trigger_i],
+            instrument_id="x",
+            trading_epoch=trigger_i,
+            profile_binding=None,
+        )
+        treatment_signal = wiring_mod.map_decision_evidence_to_position_signal_v1(evidence)
+
+    assert treatment_signal == 1
+    assert treatment_signal != baseline_signal
+    assert counters["exit_bars_observed"] >= 1
+    assert counters["exits_forced_by_gate"] >= 1
+    assert trigger_ts is not None


### PR DESCRIPTION
## Summary
- Root cause of V3 `identical_arms_no_exit_divergence`: the treatment exit-efficiency gate patched `feedback_mod.capture_backtest_engine_position_feedback_v1`, but the MV2 bar loop calls the from-import alias on `wiring_mod`, so `open_side` stayed unbound (`exit_bars_observed=0`).
- Minimal generic fix: also patch/restore `wiring_mod.capture_backtest_engine_position_feedback_v1` (live call site).
- Synthetic contract tests prove the alias mismatch and expected short midband exit divergence after binding.

## Non-goals / invariants
- No V3 evaluation rerun
- No mutation of terminal V3 result / `evaluation_run_count`
- No panel/holdout access
- No production strategy, Double Play, risk/sizing, or execution semantics changes

## Test plan
- [x] `tests/research/test_bollinger_mr_midband_exit_efficiency_gate_binding_v1.py`
- [x] V3/V1 evaluation contract tests (terminal state unchanged)
- [x] ruff format/check on touched files
- [x] docs token policy + docs reference targets
- [x] selector `PR_BOUNDED_FULL` path targets (~47s)


Made with [Cursor](https://cursor.com)