### PR TITLE
research: add Bollinger MR midband exit-efficiency V4 evaluation surface (definition-only)

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -817,6 +817,16 @@
       ],
       "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V3 (evaluation_run_count 0->1); identical definition to V2/V1; binds EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 and PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE; not a V1/V2 rerun; no V2 partial-result reuse; Economic offline gate closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders."
     },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4": {
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/",
+        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v4.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v4.py",
+        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v4/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4.md"
+      ],
+      "note": "Definition-only evaluation surface for exactly one future DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V4; reuses frozen V1 mechanism/gate/decision by import; binds measurement-validity preflight, EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1, PANEL_RUNNER_FALSY_ZERO hygiene, and MV2_WIRING_MOD_CAPTURE_ALIAS_OPEN_SIDE_BINDING_FIX; V4 contract remains DEFINITION_ONLY_PREREGISTERED with evaluation_run_count=0 in this slice; no evaluation executed here; evidence directory created only by a future authorized run; not a V1/V2/V3 rerun; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders."
+    },
     "EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1": {
       "path_prefixes": [
         "src/research/evaluation_runner_lifecycle_observability_v1/",

--- a/config/governance/technical_canonical_wiring_authorization_v1.json
+++ b/config/governance/technical_canonical_wiring_authorization_v1.json
@@ -579,7 +579,14 @@
     "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v4/safety_attestation.md",
     "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v4/timing_proof.txt",
     "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v4/timing_proof_meta.txt",
-    "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V4.md"
+    "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V4.md",
+    "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/__init__.py",
+    "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/constants_v4.py",
+    "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/measurement_validity_preflight_v4.py",
+    "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/panel_runner_v4.py",
+    "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v4.py",
+    "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v4.py",
+    "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4.md"
   ],
   "allowed_surface_classes": [
     "TECHNICAL_CANONICAL_REPLAY_INPUT_BUILDER_WIRING",
@@ -621,7 +628,8 @@
     "TECHNICAL_BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V2_WIRING",
     "TECHNICAL_BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_V3_PREREGISTRATION_WIRING",
     "TECHNICAL_BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V3_WIRING",
-    "TECHNICAL_BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_V4_PREREGISTRATION_WIRING"
+    "TECHNICAL_BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_V4_PREREGISTRATION_WIRING",
+    "TECHNICAL_BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4_WIRING"
   ],
   "forbidden_effects": {
     "RUNTIME_EFFECT": "NONE",
@@ -688,6 +696,7 @@
     "Includes evaluation surfaces (constants_v2/panel_runner_v2, runner script, focused tests, governance stub) for exactly one future DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V2; reuses frozen V1 mechanism/gate/decision modules by import only; no V1 rerun or partial-result reuse; V2 contract remains DEFINITION_ONLY_PREREGISTERED with evaluation_run_count=0 in this slice; no evaluation executed here; evidence directory is created only by a future authorized run (not pre-created); no holdout access; no Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V2.",
     "Includes definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V3 with identical economic/definition semantics to terminal V2/V1; EVALUATION_RUN_COUNT=0; not a V2 or V1 rerun; no V2 partial-result or economic-result import; mandatory EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 and PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE bindings to the already-merged falsy-zero runner correction; V1 and V2 remain terminal unchanged; no evaluation/runtime/orders. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V3.",
     "Includes evaluation surfaces (constants_v3/panel_runner_v3, runner script, focused tests, governance stub) and the sole authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V3 (evaluation_run_count 0\u21921); identical definition to V2/V1; binds EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 and PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE; not a V1/V2 rerun; no V2 partial-result reuse; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V3.",
-    "Includes definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V4 after terminal V3 FAIL; EVALUATION_RUN_COUNT=0; presupposes merged MV2 wiring_mod capture-alias open_side binding fix; fail-closed measurement-validity gates; not a V3/V2/V1 rerun; no V3 partial/economic import; V1/V2/V3 remain terminal unchanged; no evaluation/runtime/orders. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V4."
+    "Includes definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V4 after terminal V3 FAIL; EVALUATION_RUN_COUNT=0; presupposes merged MV2 wiring_mod capture-alias open_side binding fix; fail-closed measurement-validity gates; not a V3/V2/V1 rerun; no V3 partial/economic import; V1/V2/V3 remain terminal unchanged; no evaluation/runtime/orders. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V4.",
+    "Includes evaluation surfaces (constants_v4/measurement_validity_preflight_v4/panel_runner_v4, runner script, focused tests, governance stub) for exactly one future DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V4; measurement-validity fail-closed preflight; MV2 wiring_mod capture-alias binding fix; V4 contract remains DEFINITION_ONLY_PREREGISTERED with evaluation_run_count=0 in this slice; no evaluation executed here; evidence directory is created only by a future authorized run (not pre-created); not a V1/V2/V3 rerun; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4."
   ]
 }

--- a/docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4.md
+++ b/docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4.md
@@ -1,0 +1,52 @@
+# Bollinger/MR midband exit-efficiency — DEVELOPMENT evaluation v4
+
+---
+docs_token: DOCS_TOKEN_BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4
+STATUS: AWAITING_EVALUATION_EXECUTION
+scope: research, offline-only, non-authorizing, evaluation-surface
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+SCHEDULER_RUNTIME_ALLOWED: false
+---
+
+> **Non-authorizing:** Evaluation surface for the sole authorized DEVELOPMENT_ONLY
+> run of hypothesis
+> `BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_NON_BITCOIN_PERPETUALS_DEVELOPMENT_V4`.
+> This stub precedes the one-shot run. No evaluation executed in this slice.
+> No holdout access. No Economic/Promotion gate open. No Master-V2 / Double-Play /
+> risk / sizing / execution mutation. V1, V2, and V3 remain terminal and are not
+> rerun.
+
+## Status
+
+`AWAITING_EVALUATION_EXECUTION`
+
+- `EVALUATION_RUN_COUNT=0` (authorized later: exactly one run `0→1`)
+- `EVALUATION_STARTED=false`
+- `EVALUATION_COMPLETED=false`
+- `RESULT_CLASS=NOT_EVALUATED`
+- `ECONOMIC_VERDICT=NOT_EVALUATED`
+- Evidence directory is created only by a future authorized run (not pre-created)
+
+## Binding
+
+- Hypothesis: `BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_NON_BITCOIN_PERPETUALS_DEVELOPMENT_V4`
+- Predecessor (terminal FAIL, not rerun):
+  `BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_NON_BITCOIN_PERPETUALS_DEVELOPMENT_V3`
+- Contract: `config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v4.json`
+- Dataset: `pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_dev_pre_holdout_v1` (`DEVELOPMENT_ONLY`)
+- Evidence (future): `docs&#47;evidence&#47;evaluate_bollinger_mr_midband_exit_efficiency_development_v4&#47;`
+- Observability: `EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1`
+- Falsy-zero hygiene: `PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE`
+- Binding fix: `MV2_WIRING_MOD_CAPTURE_ALIAS_OPEN_SIDE_BINDING_FIX`
+- Measurement-validity prerequisites (fail-closed before real panel):
+  effective config digest inequality; open_side binding; exit observability;
+  synthetic divergence
+
+## Gates
+
+- Economic offline gate closed
+- Promotion closed
+- Holdout untouched
+- No runtime / orders
+- No evaluation run in this slice

--- a/scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v4.py
+++ b/scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v4.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Run exactly one preregistered DEVELOPMENT midband exit-efficiency evaluation (v4).
+
+Research-only. No holdout. No runtime / orders / productive authority mutation.
+Not a rerun of V1, V2, or V3; V1/V2/V3 remain terminal and are not touched by this script.
+
+Lifecycle observability: catchable signals, durable member progress, and
+exception diagnostics are persisted under the output directory. Incomplete runs
+are classified as INCONCLUSIVE_INFRASTRUCTURE_FAILURE without auto-rerun.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v4.constants_v4 import (  # noqa: E402
+    EVALUATION_RUN_ID,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v4.panel_runner_v4 import (  # noqa: E402
+    run_development_evaluation,
+)
+from src.research.entry_effective_mr_eligibility_development_evaluation_v1.dev_panel_bars_v1 import (  # noqa: E402
+    DEV_PANEL_SUBDIR,
+)
+from src.research.evaluation_runner_lifecycle_observability_v1 import (  # noqa: E402
+    EvaluationRunnerLifecycleObservabilityV1,
+)
+
+
+def _default_archive_root() -> Path | None:
+    env = os.environ.get("PEAK_TRADE_DATA_ARCHIVE_ROOT")
+    if not env:
+        return None
+    return Path(env).expanduser().resolve() / DEV_PANEL_SUBDIR
+
+
+def _slot_already_consumed(output_dir: Path) -> bool:
+    summary_path = output_dir / "summary.json"
+    if not summary_path.is_file():
+        return False
+    try:
+        existing = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return int(existing.get("evaluation_run_count") or 0) >= 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate Bollinger/MR midband exit-efficiency (DEVELOPMENT v4, one run)."
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=REPO_ROOT
+        / "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v4",
+    )
+    parser.add_argument(
+        "--archive-root",
+        type=Path,
+        default=None,
+        help="Optional sealed DEVELOPMENT panel archive root override.",
+    )
+    args = parser.parse_args()
+    archive = args.archive_root
+    if archive is None:
+        archive = _default_archive_root()
+        if archive is None:
+            raise SystemExit("PEAK_TRADE_DATA_ARCHIVE_ROOT_UNSET")
+
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Fail-closed before lifecycle attach so a consumed slot cannot pollute
+    # historical evidence SSOT with new heartbeat/terminal files.
+    if _slot_already_consumed(output_dir):
+        print("RESULT_CLASS=INCONCLUSIVE_INFRASTRUCTURE_FAILURE")
+        print("REASON=EVALUATION_RUN_SLOT_ALREADY_CONSUMED")
+        print("EVALUATION_RUN_COUNT=1")
+        print("HOLDOUT_DATA_ACCESSED=false")
+        print("AUTO_RERUN_EXECUTED=false")
+        return 2
+
+    lifecycle = EvaluationRunnerLifecycleObservabilityV1(
+        output_dir,
+        run_id=EVALUATION_RUN_ID,
+    )
+    lifecycle.install_signal_handlers()
+    try:
+        summary = run_development_evaluation(
+            output_dir=output_dir,
+            archive_root=archive,
+            lifecycle=lifecycle,
+        )
+    except Exception as exc:  # noqa: BLE001 — persist then fail-closed
+        terminal = lifecycle.record_exception(exc)
+        print(f"RESULT_CLASS={terminal.get('result_class')}")
+        print(f"REASON={terminal.get('death_class')}")
+        print("EVALUATION_RUN_COUNT_UNCHANGED_BY_LIFECYCLE=true")
+        print("HOLDOUT_DATA_ACCESSED=false")
+        print("AUTO_RERUN_EXECUTED=false")
+        return 1
+    finally:
+        lifecycle.uninstall_signal_handlers()
+
+    print(f"RESULT_CLASS={summary.get('result_class')}")
+    print(f"REASON={summary.get('decision', {}).get('reason')}")
+    print(f"EVALUATION_RUN_COUNT={summary.get('evaluation_run_count')}")
+    print(f"HOLDOUT_DATA_ACCESSED={summary.get('holdout_data_accessed')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/__init__.py
+++ b/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/__init__.py
@@ -1,0 +1,13 @@
+"""Single preregistered DEVELOPMENT-only midband exit-efficiency evaluation package (v4).
+
+Research-only. No holdout. No Master-V2 / Double-Play / risk / sizing / execution
+mutation. No economic or promotion gate open. No runtime / orders.
+
+New independently preregistered DEVELOPMENT_ONLY measurement after V3 terminal FAIL;
+not a V1/V2/V3 rerun; no V3 partial-result reuse. Binds measurement-validity
+prerequisites and MV2 wiring_mod capture-alias open_side binding fix.
+"""
+
+PACKAGE_MARKER = "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4=true"
+
+__all__ = ["PACKAGE_MARKER"]

--- a/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/constants_v4.py
+++ b/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/constants_v4.py
@@ -1,0 +1,64 @@
+"""Frozen constants for Bollinger/MR midband exit-efficiency DEVELOPMENT evaluation v4.
+
+Identical fees/params/hashes/seeds to v1/v2/v3. Only scope/run/hypothesis/path identity
+is versioned. V4 is a new independently preregistered measurement; not a V1/V2/V3 rerun.
+"""
+
+from __future__ import annotations
+
+SCOPE_ID = "bollinger_mr_midband_exit_efficiency_development_evaluation_v4"
+EVALUATION_RUN_ID = "evaluate_bollinger_mr_midband_exit_efficiency_development_v4"
+HYPOTHESIS_ID = "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_NON_BITCOIN_PERPETUALS_DEVELOPMENT_V4"
+DATASET_ID = "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_dev_pre_holdout_v1"
+DATASET_CLASS = "DEVELOPMENT_ONLY"
+BASELINE_CONFIG_ID = "bollinger_bands_v2_full_canonical_system_economic_binding_v1"
+STRATEGY_ID = "bollinger_bands"
+STRATEGY_VERSION = "v2"
+PORTFOLIO_AGGREGATION_ID = "RESEARCH_EQUAL_WEIGHT_NORMALIZED_SLEEVE_COMBINE_V1"
+
+FEE_BPS = 10.0
+SLIPPAGE_BPS = 5.0
+HALF_SPREAD_BPS = 5.0
+STOP_PCT = 0.025
+COST_MULTIPLIER = 1.0
+PRIMARY_SEED = 20220601
+
+DECISION_START = "2023-05-20T00:00:00Z"
+DECISION_END_EXCLUSIVE = "2023-08-16T05:55:00Z"
+DEVELOPMENT_SPLIT_DIGEST = "a35783bf0268c174dfe585c9839ba45cc6e3835021699786f4490a0d8c9b33db"
+EXPECTED_MANIFEST_SHA256 = "be953c559ac3dd797961bdda8cbc190076353c91d3299b9031ae1ee767d4b594"
+EXPECTED_CONTENT_HASH = "4a1978fe0e69a6cd7b19b32f5f95882cfdc3e36397aaec87bce2c4139ab1cfca"
+MAX_FEATURE_LOOKBACK_HOURS = 20
+
+BB_PERIOD = 20
+BB_STD = 2.0
+EXIT_LEVEL = "middle_band"
+EXIT_THRESHOLD_BINDING_VALUE = 0.5
+
+MINIMUM_TRADE_COUNT = 20
+MAX_TRADE_COUNT_REDUCTION_FRACTION = 0.5
+INSTRUMENT_CONCENTRATION_WORST1_ABS_NET_SHARE_MAX = 0.35
+
+SLEEVE_INITIAL_CASH = 10_000.0
+SHARED_INITIAL_CAPITAL = 10_000.0
+
+CONTRACT_REL_PATH = (
+    "config/research/"
+    "bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v4.json"
+)
+EVIDENCE_REL_PATH = "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v4/"
+GOVERNANCE_REL_PATH = (
+    "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4.md"
+)
+HOLDOUT_OPAQUE_ID = "offline_economic_reevaluation_sealed_long_panel_v1"
+BINDING_FIX_SURFACE = "MV2_WIRING_MOD_CAPTURE_ALIAS_OPEN_SIDE_BINDING_FIX"
+
+REQUIRED_FROZEN_EXIT_PARAMETERS = {
+    "bb_period": BB_PERIOD,
+    "bb_std": BB_STD,
+    "exit_level": EXIT_LEVEL,
+    "exit_threshold_binding_value": EXIT_THRESHOLD_BINDING_VALUE,
+    "long_exit_rule": "close_crosses_middle_from_below_to_at_or_above",
+    "short_exit_rule": "close_crosses_middle_from_above_to_at_or_below",
+    "stop_loss_remains_active_if_hit_first": True,
+}

--- a/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/measurement_validity_preflight_v4.py
+++ b/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/measurement_validity_preflight_v4.py
@@ -1,0 +1,228 @@
+"""Fail-closed measurement-validity preflight for V4 (no panel archive access).
+
+Runs before the real DEVELOPMENT panel evaluation. Proves:
+1) effective baseline/treatment config digests differ (gate enabled vs disabled)
+2) open_side binds via wiring_mod capture alias
+3) exit_bars_observed > 0 on an admissible synthetic case
+4) synthetic baseline-vs-treatment divergence at the exit-decision boundary
+
+Does not load sealed panel members or holdout paths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pandas as pd
+
+from src.backtest.backtest_engine_position_feedback_adapter_v1 import (
+    LegacyRealisticBarLoopStateV1,
+)
+from src.backtest.engine import Trade
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v1.exit_efficiency_gate_v1 import (
+    optional_treatment_exit_efficiency_gate,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v1.midband_exit_mechanism_v1 import (
+    short_exit_mask_from_bars,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v4.constants_v4 import (
+    BINDING_FIX_SURFACE,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v4 import (
+    canonical_json_sha256,
+)
+
+RESULT_IDENTICAL = "INVALID_MEASUREMENT_IDENTICAL_EFFECTIVE_CONFIGS"
+RESULT_BINDING = "INVALID_MEASUREMENT_BINDING_MISSING"
+RESULT_NO_EXIT = "INVALID_MEASUREMENT_NO_EXIT_OBSERVABILITY"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _gate_module_sha256(repo: Path) -> str:
+    path = (
+        repo
+        / "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1"
+        / "exit_efficiency_gate_v1.py"
+    )
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _synthetic_short_midband_cross_bars() -> pd.DataFrame:
+    idx = pd.date_range("2023-05-20", periods=40, freq="h", tz="UTC")
+    close = [100.0] * 20 + [105.0, 106.0, 107.0, 108.0, 109.0, 110.0, 109.0, 100.0]
+    close = close + [100.0] * (40 - len(close))
+    return pd.DataFrame(
+        {
+            "open": close,
+            "high": [c + 1.0 for c in close],
+            "low": [c - 1.0 for c in close],
+            "close": close,
+        },
+        index=idx,
+    )
+
+
+def _open_short_loop_state(*, entry_ts: pd.Timestamp) -> LegacyRealisticBarLoopStateV1:
+    return LegacyRealisticBarLoopStateV1(
+        equity=10_000.0,
+        current_trade=Trade(
+            entry_time=entry_ts,
+            entry_price=110.0,
+            size=-1.0,
+            stop_price=120.0,
+        ),
+    )
+
+
+def _effective_digest(*, declared: str, gate_enabled: bool, gate_sha: str) -> str:
+    payload = {
+        "declared_config_digest": declared,
+        "gate_enabled": bool(gate_enabled),
+        "exit_efficiency_gate_v1_sha256": gate_sha,
+        "binding_fix_surface": BINDING_FIX_SURFACE,
+    }
+    return canonical_json_sha256(payload)
+
+
+def run_measurement_validity_preflight(
+    *,
+    declared_runtime_cfg: dict[str, Any] | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Return diagnostics; result_class is None iff all prerequisites pass."""
+    repo = repo_root or _repo_root()
+    cfg = (
+        declared_runtime_cfg
+        if declared_runtime_cfg is not None
+        else {"strategy_id": "bollinger_bands", "version": "v2"}
+    )
+    declared = canonical_json_sha256(cfg)
+    gate_sha = _gate_module_sha256(repo)
+    baseline_eff = _effective_digest(declared=declared, gate_enabled=False, gate_sha=gate_sha)
+    treatment_eff = _effective_digest(declared=declared, gate_enabled=True, gate_sha=gate_sha)
+    effective_configs_differ = baseline_eff != treatment_eff
+
+    bars = _synthetic_short_midband_cross_bars()
+    short_mask = short_exit_mask_from_bars(bars)
+    trigger_positions = [i for i, v in enumerate(short_mask.tolist()) if v]
+    if not trigger_positions:
+        return {
+            "passed": False,
+            "result_class": RESULT_NO_EXIT,
+            "reason": "synthetic_fixture_missing_short_midband_cross",
+            "declared_configs_differ": False,
+            "baseline_declared_config_digest": declared,
+            "treatment_declared_config_digest": declared,
+            "baseline_effective_config_digest": baseline_eff,
+            "treatment_effective_config_digest": treatment_eff,
+            "effective_configs_differ": effective_configs_differ,
+            "open_side_binding_observed": False,
+            "exit_bars_observed": 0,
+            "synthetic_divergence_expected": True,
+            "synthetic_divergence_observed": False,
+            "binding_fix_surface": BINDING_FIX_SURFACE,
+            "first_divergence_or_collapse_boundary": "synthetic_fixture",
+        }
+
+    trigger_i = int(trigger_positions[0])
+    entry_ts = bars.index[max(0, trigger_i - 3)]
+
+    import src.backtest.mv2_research_wiring_v1 as wiring_mod
+
+    def _fake_bind_bar(
+        *, bar, instrument_id, trading_epoch, profile_binding, research_execution_cost=None
+    ):
+        return ("context", "l1_status", True)
+
+    def _fake_map(_evidence) -> int:
+        return 0
+
+    # Isolate from live MV2 map/bind while still exercising the gate's wiring_mod
+    # capture-alias patch path (same pattern as gate_binding contract tests).
+    orig_bind = wiring_mod.bind_bar_for_mv2_wiring_v1
+    orig_map = wiring_mod.map_decision_evidence_to_position_signal_v1
+    wiring_mod.bind_bar_for_mv2_wiring_v1 = _fake_bind_bar  # type: ignore[assignment]
+    wiring_mod.map_decision_evidence_to_position_signal_v1 = _fake_map  # type: ignore[assignment]
+    try:
+        evidence = SimpleNamespace(decision_outcome="hold")
+        baseline_signal = int(wiring_mod.map_decision_evidence_to_position_signal_v1(evidence))
+
+        open_side_binding_observed = False
+        exit_bars_observed = 0
+        exits_forced = 0
+        treatment_signal = baseline_signal
+
+        with optional_treatment_exit_efficiency_gate(enabled=True, bars=bars) as counters:
+            wiring_mod.capture_backtest_engine_position_feedback_v1(
+                state=_open_short_loop_state(entry_ts=entry_ts),
+                feedback_source_bar_epoch=trigger_i - 1,
+            )
+            wiring_mod.bind_bar_for_mv2_wiring_v1(
+                bar=bars.iloc[trigger_i],
+                instrument_id="synthetic_preflight",
+                trading_epoch=trigger_i,
+                profile_binding=None,
+            )
+            treatment_signal = int(wiring_mod.map_decision_evidence_to_position_signal_v1(evidence))
+            exit_bars_observed = int(counters["exit_bars_observed"])
+            exits_forced = int(counters["exits_forced_by_gate"])
+            open_side_binding_observed = exit_bars_observed > 0 or exits_forced > 0
+    finally:
+        wiring_mod.bind_bar_for_mv2_wiring_v1 = orig_bind  # type: ignore[assignment]
+        wiring_mod.map_decision_evidence_to_position_signal_v1 = orig_map  # type: ignore[assignment]
+
+    synthetic_divergence_observed = treatment_signal != baseline_signal and exits_forced > 0
+
+    result_class: str | None = None
+    reason = "measurement_validity_prerequisites_passed"
+    if not effective_configs_differ:
+        result_class = RESULT_IDENTICAL
+        reason = "identical_effective_config_digests"
+    elif not open_side_binding_observed:
+        result_class = RESULT_BINDING
+        reason = "open_side_binding_missing"
+    elif exit_bars_observed <= 0:
+        result_class = RESULT_NO_EXIT
+        reason = "exit_bars_observed_le_0"
+    elif not synthetic_divergence_observed:
+        result_class = RESULT_BINDING
+        reason = "synthetic_divergence_absent"
+
+    return {
+        "passed": result_class is None,
+        "result_class": result_class,
+        "reason": reason,
+        "declared_configs_differ": False,
+        "baseline_declared_config_digest": declared,
+        "treatment_declared_config_digest": declared,
+        "baseline_effective_config_digest": baseline_eff,
+        "treatment_effective_config_digest": treatment_eff,
+        "effective_configs_differ": effective_configs_differ,
+        "open_side_binding_observed": open_side_binding_observed,
+        "exit_bars_observed": exit_bars_observed,
+        "exits_forced_by_gate": exits_forced,
+        "baseline_signal": baseline_signal,
+        "treatment_signal": treatment_signal,
+        "synthetic_divergence_expected": True,
+        "synthetic_divergence_observed": synthetic_divergence_observed,
+        "binding_fix_surface": BINDING_FIX_SURFACE,
+        "first_divergence_or_collapse_boundary": (
+            "wiring_mod.capture_backtest_engine_position_feedback_v1"
+            if open_side_binding_observed
+            else "feedback_mod_only_collapse_or_unbound"
+        ),
+    }
+
+
+__all__ = [
+    "RESULT_BINDING",
+    "RESULT_IDENTICAL",
+    "RESULT_NO_EXIT",
+    "run_measurement_validity_preflight",
+]

--- a/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/panel_runner_v4.py
+++ b/src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/panel_runner_v4.py
@@ -1,0 +1,904 @@
+"""Single-run DEVELOPMENT panel evaluation v4: baseline vs midband exit-efficiency gate.
+
+New independently preregistered DEVELOPMENT_ONLY measurement
+(HYPOTHESIS_ID ...DEVELOPMENT_V4). Not a rerun of V1, V2, or V3. Reuses the frozen
+V1 mechanism/gate/decision modules by import only; no V1/V2/V3 partial result,
+checkpoint, or economic claim is transferred. Binds PANEL_RUNNER_FALSY_ZERO
+hygiene, MV2 wiring_mod capture-alias open_side binding fix, and fail-closed
+measurement-validity prerequisites before the real panel run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+
+from src.backtest.admissible_versioned_futures_dataset_v1 import (
+    DatasetProfileBindingV1,
+    DatasetProfileV1,
+    ExecutionCostBindingV1,
+    L1ObservationStatusV1,
+)
+from src.backtest.mv2_research_wiring_v1 import run_mv2_research_backtest_wiring_v1
+from src.research.adx_di_direction_confirmation_mr_eligibility_development_evaluation_v1.panel_runner_v1 import (
+    _classify_side,
+    load_runtime_cfg,
+)
+from src.research.bollinger_mr_economic_failure_decomposition_development_v1.metrics_v1 import (
+    aggregate_core_metrics,
+    concentration_stats,
+    enrich_trade_excursions,
+    instrument_attribution,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v1.decision_v1 import (
+    decide_development_evaluation,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v1.exit_efficiency_gate_v1 import (
+    optional_treatment_exit_efficiency_gate,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v1.midband_exit_mechanism_v1 import (
+    assert_frozen_parameters_match_contract,
+    mechanism_freeze_payload,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v4.constants_v4 import (
+    BINDING_FIX_SURFACE,
+    BASELINE_CONFIG_ID,
+    BB_PERIOD,
+    CONTRACT_REL_PATH,
+    COST_MULTIPLIER,
+    DATASET_CLASS,
+    DATASET_ID,
+    DECISION_END_EXCLUSIVE,
+    DECISION_START,
+    DEVELOPMENT_SPLIT_DIGEST,
+    EVALUATION_RUN_ID,
+    EXPECTED_CONTENT_HASH,
+    EXPECTED_MANIFEST_SHA256,
+    FEE_BPS,
+    HALF_SPREAD_BPS,
+    HYPOTHESIS_ID,
+    INSTRUMENT_CONCENTRATION_WORST1_ABS_NET_SHARE_MAX,
+    MAX_FEATURE_LOOKBACK_HOURS,
+    MAX_TRADE_COUNT_REDUCTION_FRACTION,
+    MINIMUM_TRADE_COUNT,
+    PORTFOLIO_AGGREGATION_ID,
+    PRIMARY_SEED,
+    SHARED_INITIAL_CAPITAL,
+    SLEEVE_INITIAL_CASH,
+    SLIPPAGE_BPS,
+    STOP_PCT,
+    STRATEGY_ID,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v4.measurement_validity_preflight_v4 import (
+    run_measurement_validity_preflight,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v4 import (
+    FORBIDDEN_PARTIAL_TRANSFER_KEYS,
+    REQUIRED_PREDECESSOR_HYPOTHESIS_ID,
+    canonical_json_sha256,
+    load_and_validate_repo_contract,
+    load_json,
+    reject_holdout_dataset_or_path,
+)
+from src.research.entry_effective_mr_eligibility_development_evaluation_v1.dev_panel_bars_v1 import (
+    included_panel_members,
+    load_member_bars,
+    resolve_development_archive_root,
+    verify_development_panel_hashes,
+)
+from src.research.final_research_fleet_v0_versioned_binding_manifest_contract_v0 import (
+    CANONICAL_INSTRUMENT_ID,
+)
+from src.research.regime_gated_standaside_mr_development_evaluation_v1.shared_portfolio_equity_research_v1 import (
+    build_equal_weight_portfolio_equity,
+    portfolio_metrics_from_equity,
+)
+from scripts.ops.primary_evidence_retention_v0 import write_manifest_sha256
+
+
+@dataclass(frozen=True)
+class ArmResult:
+    arm: str
+    rows: list[dict[str, Any]]
+    metrics: dict[str, Any]
+    enriched_trades: list[dict[str, Any]]
+    exit_attribution: dict[str, Any]
+    wallclock_seconds: float
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _git_base_sha(repo: Path) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        sha = out.stdout.strip()
+        return sha or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _profile() -> DatasetProfileBindingV1:
+    return DatasetProfileBindingV1(
+        dataset_profile=DatasetProfileV1.ECONOMIC_RESEARCH_V1,
+        execution_cost_binding=ExecutionCostBindingV1(
+            spread_model_version="research_conservative_bps_v1",
+            execution_price_observation_source="MODELLED_NOT_OBSERVED",
+            conservative_half_spread_bps=HALF_SPREAD_BPS,
+        ),
+        l1_observation_status=L1ObservationStatusV1.EXECUTION_MODEL_BOUND_NOT_OBSERVED,
+    )
+
+
+def _extract_member_trades(
+    result: Any,
+    *,
+    instrument_id: str,
+    decision_start: pd.Timestamp,
+    decision_end: pd.Timestamp,
+) -> tuple[list[dict[str, Any]], pd.Series]:
+    bt = result.backtest_result
+    trades_df = getattr(bt, "trades", None)
+    trade_records: list[dict[str, Any]] = []
+    if trades_df is not None and hasattr(trades_df, "empty") and not trades_df.empty:
+        trade_records = trades_df.to_dict(orient="records")
+
+    filtered: list[dict[str, Any]] = []
+    for rec in trade_records:
+        et = rec.get("entry_time")
+        if et is None:
+            continue
+        ets = pd.Timestamp(et)
+        if ets.tzinfo is None:
+            ets = ets.tz_localize("UTC")
+        else:
+            ets = ets.tz_convert("UTC")
+        if not (decision_start <= ets < decision_end):
+            continue
+        side = _classify_side(rec)
+        if side not in {"long", "short"}:
+            raise ValueError(f"TRADE_SIDE_UNKNOWN:{side}")
+        fees = rec.get("fee_total")
+        if fees is None:
+            fees = rec.get("fee")
+        if fees is None:
+            raise ValueError("TRADE_FEES_MISSING")
+        slip = rec.get("slippage_total")
+        if slip is None:
+            raise ValueError("TRADE_SLIPPAGE_MISSING")
+        gross = rec.get("gross_pnl")
+        net = rec.get("pnl")
+        if gross is None or net is None:
+            raise ValueError("TRADE_PNL_MISSING")
+        if rec.get("entry_price") is None:
+            raise ValueError("ENTRY_PRICE_MISSING")
+        filtered.append(
+            {
+                "instrument_id": instrument_id,
+                "side": side,
+                "entry_time": str(rec.get("entry_time")),
+                "exit_time": str(rec.get("exit_time")),
+                "entry_price": float(rec["entry_price"]),
+                "exit_price": float(rec["exit_price"])
+                if rec.get("exit_price") is not None
+                else None,
+                "size": float(rec["size"]) if rec.get("size") is not None else None,
+                "gross_pnl": float(gross),
+                "fees": float(fees),
+                "slippage": float(slip),
+                "net_pnl": float(net),
+                "exit_reason": str(rec.get("exit_reason") or "UNKNOWN"),
+            }
+        )
+
+    equity = getattr(bt, "equity_curve", None)
+    if equity is None or len(equity) == 0:
+        raise ValueError(f"MISSING_EQUITY:{instrument_id}")
+    eq = equity.astype(float)
+    eq.index = pd.to_datetime(eq.index, utc=True)
+    eq_dec = eq[(eq.index >= decision_start) & (eq.index < decision_end)]
+    if eq_dec.empty:
+        pre = eq[eq.index < decision_start]
+        start_val = float(pre.iloc[-1]) if len(pre) else SLEEVE_INITIAL_CASH
+        eq_dec = pd.Series(
+            [start_val, start_val],
+            index=pd.DatetimeIndex([decision_start, decision_end - pd.Timedelta(hours=1)]),
+        )
+    return filtered, eq_dec
+
+
+def _aggregate_arm(
+    *,
+    enriched: list[dict[str, Any]],
+    equity_curves: dict[str, pd.Series],
+    exits_forced_by_gate: int,
+) -> dict[str, Any]:
+    core = aggregate_core_metrics(enriched)
+    instruments = instrument_attribution(enriched)
+    concentration = concentration_stats(instruments)
+    portfolio_eq = build_equal_weight_portfolio_equity(
+        equity_curves, initial_capital=SHARED_INITIAL_CAPITAL
+    )
+    port = portfolio_metrics_from_equity(portfolio_eq, initial_capital=SHARED_INITIAL_CAPITAL)
+    long_n = sum(1 for t in enriched if str(t["side"]).lower() == "long")
+    short_n = sum(1 for t in enriched if str(t["side"]).lower() == "short")
+    return {
+        "portfolio_aggregation_id": PORTFOLIO_AGGREGATION_ID,
+        "initial_capital": SHARED_INITIAL_CAPITAL,
+        "instrument_count": len(equity_curves),
+        "trade_count": int(core["trade_count"]),
+        "long_trades": long_n,
+        "short_trades": short_n,
+        "gross_pnl": float(core["gross_pnl"]),
+        "net_pnl": float(core["net_pnl"]),
+        "fees": float(core["fees"]),
+        "slippage": float(core["slippage"]),
+        "cost_drag": float(core["gross_pnl"]) - float(core["net_pnl"]),
+        "net_return": float(port["net_return"]),
+        "sharpe": float(port["sharpe"]),
+        "max_drawdown": float(port["max_drawdown"]),
+        "profit_factor": core["net_profit_factor"],
+        "net_profit_factor": core["net_profit_factor"],
+        "turnover": float(core["trade_count"]),
+        "mean_realized_pnl_over_mfe_capture_ratio": core[
+            "mean_realized_pnl_over_mfe_capture_ratio"
+        ],
+        "mean_mfe_to_exit_leakage": core["mean_mfe_to_exit_leakage"],
+        "mean_holding_period_hours": core["mean_holding_period_hours"],
+        "worst1_abs_net_share": concentration["worst1_abs_net_share"],
+        "worst5_abs_net_share": concentration["worst5_abs_net_share"],
+        "exits_forced_by_gate": int(exits_forced_by_gate),
+        "cost_multiplier": COST_MULTIPLIER,
+        "final_equity": float(port["final_equity"]),
+        "_portfolio_equity": portfolio_eq,
+        "_instrument_attribution": instruments,
+        "_concentration": concentration,
+        "_core": core,
+    }
+
+
+def run_arm(
+    *,
+    arm: str,
+    cfg: dict[str, Any],
+    archive_root: Path,
+    members: list[dict[str, str]],
+    load_start: str,
+    decision_start: str,
+    decision_end: str,
+    gate: bool,
+    lifecycle: Any | None = None,
+) -> ArmResult:
+    t0 = time.perf_counter()
+    d_start = pd.Timestamp(decision_start)
+    d_end = pd.Timestamp(decision_end)
+    all_trades: list[dict[str, Any]] = []
+    equity_curves: dict[str, pd.Series] = {}
+    bars_by_instrument: dict[str, pd.DataFrame] = {}
+    rows: list[dict[str, Any]] = []
+    exits_forced_total = 0
+    exit_bars_total = 0
+
+    for i, member in enumerate(members, start=1):
+        native = member["native_instrument_id"]
+        canon = member["canonical_instrument_id"]
+        bars = load_member_bars(
+            archive_root,
+            native_instrument_id=native,
+            start_inclusive=load_start,
+            end_exclusive=decision_end,
+        )
+        bars_by_instrument[canon] = bars
+        with optional_treatment_exit_efficiency_gate(enabled=gate, bars=bars) as counters:
+            result = run_mv2_research_backtest_wiring_v1(
+                bars,
+                strategy_id=STRATEGY_ID,
+                cfg=cfg,
+                instrument_id=CANONICAL_INSTRUMENT_ID,
+                profile_binding=_profile(),
+                observational_panel_member_instrument_id=canon,
+            )
+        trades, eq_dec = _extract_member_trades(
+            result,
+            instrument_id=canon,
+            decision_start=d_start,
+            decision_end=d_end,
+        )
+        forced = int(counters["exits_forced_by_gate"])
+        exits_forced_total += forced
+        exit_bars_total += int(counters["exit_bars_observed"])
+        all_trades.extend(trades)
+        equity_curves[canon] = eq_dec
+        rows.append(
+            {
+                "member_id": canon,
+                "trade_count": len(trades),
+                "exits_forced_by_gate": forced,
+                "exit_bars_observed": int(counters["exit_bars_observed"]),
+                "entries_altered_by_gate": int(counters["entries_altered_by_gate"]),
+            }
+        )
+        print(
+            json.dumps(
+                {
+                    "phase": arm,
+                    "i": i,
+                    "n": len(members),
+                    "member": native,
+                    "trades": len(trades),
+                    "exits_forced_by_gate": forced,
+                }
+            ),
+            flush=True,
+        )
+        # Durable lifecycle progress (stdout alone is not a death diagnostic).
+        if lifecycle is not None:
+            lifecycle.record_member_progress(
+                phase=arm,
+                member_index=i,
+                members_total=len(members),
+                member_id=native,
+                extra={
+                    "trades": len(trades),
+                    "exits_forced_by_gate": forced,
+                },
+            )
+
+    enriched = enrich_trade_excursions(all_trades, bars_by_instrument)
+    metrics = _aggregate_arm(
+        enriched=enriched,
+        equity_curves=equity_curves,
+        exits_forced_by_gate=exits_forced_total,
+    )
+    exit_attr = {
+        "exit_efficiency_gate_enabled": gate,
+        "exits_forced_by_gate": exits_forced_total,
+        "exit_bars_observed": exit_bars_total,
+        "instruments_with_forced_exits_count": sum(
+            1 for r in rows if int(r["exits_forced_by_gate"]) > 0
+        ),
+    }
+    return ArmResult(
+        arm=arm,
+        rows=rows,
+        metrics=metrics,
+        enriched_trades=enriched,
+        exit_attribution=exit_attr,
+        wallclock_seconds=float(time.perf_counter() - t0),
+    )
+
+
+def _assert_no_predecessor_partial_result_reuse(contract: Mapping[str, Any]) -> None:
+    for banned in FORBIDDEN_PARTIAL_TRANSFER_KEYS:
+        if banned in contract:
+            raise RuntimeError(f"PARTIAL_TRANSFER_FORBIDDEN:{banned}")
+    predecessor = contract.get("predecessor_development_v3") or {}
+    if predecessor.get("hypothesis_id") != REQUIRED_PREDECESSOR_HYPOTHESIS_ID:
+        raise RuntimeError("PREDECESSOR_V3_HYPOTHESIS_ID_MISMATCH")
+    if predecessor.get("partial_results_reused") is not False:
+        raise RuntimeError("PREDECESSOR_V3_PARTIAL_RESULTS_REUSED")
+
+
+def run_development_evaluation(
+    *,
+    output_dir: Path,
+    archive_root: Path | None = None,
+    repo_root: Path | None = None,
+    lifecycle: Any | None = None,
+) -> dict[str, Any]:
+    repo = repo_root or _repo_root()
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Single-run lock: refuse if evidence summary already claims run_count=1.
+    summary_path = output_dir / "summary.json"
+    if summary_path.is_file():
+        existing = json.loads(summary_path.read_text(encoding="utf-8"))
+        if int(existing.get("evaluation_run_count") or 0) >= 1:
+            raise RuntimeError("EVALUATION_RUN_SLOT_ALREADY_CONSUMED")
+
+    # Reject holdout *dataset/path* misuse only. The opaque holdout id string itself
+    # is an exclusion label in the contract and must not be passed to the path rejector.
+    reject_holdout_dataset_or_path(DATASET_ID)
+
+    # Validate against the V4 preregistration validator BEFORE any measurement /
+    # contract mutation. The V4 validator accepts DEFINITION_ONLY_PREREGISTERED
+    # with evaluation_run_count=0 at the start of this run.
+    report = load_and_validate_repo_contract(repo)
+    if report.get("hypothesis_id") != HYPOTHESIS_ID:
+        raise RuntimeError("CONTRACT_HYPOTHESIS_ID_NOT_V4")
+    # Use dict.get default — do NOT use `x or -1` (Python treats 0 as falsy).
+    if int(report.get("evaluation_run_count", -1)) != 0:
+        raise RuntimeError("CONTRACT_EVALUATION_RUN_COUNT_NOT_ZERO")
+
+    contract = load_json(repo / CONTRACT_REL_PATH)
+    if contract.get("hypothesis_id") != HYPOTHESIS_ID:
+        raise RuntimeError("CONTRACT_HYPOTHESIS_ID_NOT_V4")
+    if int(contract.get("evaluation_run_count", -1)) != 0:
+        raise RuntimeError("CONTRACT_EVALUATION_RUN_COUNT_NOT_ZERO")
+    if contract.get("development_only") is not True:
+        raise RuntimeError("CONTRACT_NOT_DEVELOPMENT_ONLY")
+    if contract.get("holdout_allowed") is not False:
+        raise RuntimeError("CONTRACT_HOLDOUT_ALLOWED")
+    _assert_no_predecessor_partial_result_reuse(contract)
+    assert_frozen_parameters_match_contract(contract)
+
+    # Measurement-validity prerequisites BEFORE real panel (synthetic only; no archive).
+    # Fail-closed INVALID_* terminalizes without panel backtest. Slot claim / summary
+    # persistence for INVALID_* happens only when this function is invoked by an
+    # authorized evaluation Operator-GO — not at import time.
+    validity = run_measurement_validity_preflight(
+        declared_runtime_cfg={"seed": PRIMARY_SEED, "strategy_id": STRATEGY_ID},
+        repo_root=repo,
+    )
+    (output_dir / "measurement_validity_preflight.json").write_text(
+        json.dumps(validity, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    if validity.get("passed") is not True:
+        invalid_class = str(validity.get("result_class") or "INVALID_MEASUREMENT_BINDING_MISSING")
+        freeze = mechanism_freeze_payload()
+        (output_dir / "exit_mechanism_formula_freeze.json").write_text(
+            json.dumps(freeze, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        command = (
+            "PYTHONPATH=src:. python3 scripts/research/"
+            "run_evaluate_bollinger_mr_midband_exit_efficiency_development_v4.py "
+            f"--output-dir {output_dir}"
+        )
+        summary = {
+            "schema_version": "evaluate_bollinger_mr_midband_exit_efficiency_development_summary.v4",
+            "evaluation_run_id": EVALUATION_RUN_ID,
+            "evaluation_run_count": 1,
+            "evaluation_started": True,
+            "evaluation_completed": True,
+            "backtest_executed": False,
+            "panel_backtest_executed": False,
+            "hypothesis_id": HYPOTHESIS_ID,
+            "predecessor_hypothesis_id": REQUIRED_PREDECESSOR_HYPOTHESIS_ID,
+            "v1_rerun": False,
+            "v2_rerun": False,
+            "v3_rerun": False,
+            "v1_partial_results_reused": False,
+            "v2_partial_results_reused": False,
+            "v3_partial_results_reused": False,
+            "contract_id": contract["schema_version"],
+            "contract_ref": CONTRACT_REL_PATH,
+            "config_id": BASELINE_CONFIG_ID,
+            "dataset_id": DATASET_ID,
+            "dataset_class": DATASET_CLASS,
+            "development_only": True,
+            "development_panel_accessed": False,
+            "measurement_validity": validity,
+            "result_class": invalid_class,
+            "economic_verdict": "NOT_EVALUATED",
+            "decision": {
+                "result_class": invalid_class,
+                "reason": validity.get("reason"),
+                "evaluable": False,
+            },
+            "pass": False,
+            "fail": False,
+            "acceptance_criteria_met": False,
+            "command": command,
+            "holdout_accessed": False,
+            "holdout_data_accessed": False,
+            "sealed_holdout_content_inspected": False,
+            "productive_trading_logic_changed": False,
+            "production_strategy_semantics_changed": False,
+            "double_play_authority_changed": False,
+            "risk_sizing_execution_semantics_changed": False,
+            "authority_changed": False,
+            "economic_validity_offline_gate_changed": False,
+            "economic_gate_open": False,
+            "promotion_eligible": False,
+            "runtime_activated": False,
+            "shadow_activated": False,
+            "testnet_activated": False,
+            "orders_sent": False,
+            "pass_criteria_changed": False,
+            "cost_model_changed": False,
+            "entry_eligibility_retuned": False,
+            "observability_surface": "EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1",
+            "observability_surface_bound": True,
+            "binding_fix_surface": BINDING_FIX_SURFACE,
+            "binding_fix_bound": True,
+            "auto_rerun_executed": False,
+            "rerun_allowed": False,
+            "base_sha": _git_base_sha(repo),
+            "python_version": sys.version.split()[0],
+        }
+        (output_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8"
+        )
+        (output_dir / "README.md").write_text(
+            "\n".join(
+                [
+                    "# Evaluate Bollinger/MR midband exit-efficiency DEVELOPMENT v4",
+                    "",
+                    f"HYPOTHESIS_ID={HYPOTHESIS_ID}",
+                    f"PREDECESSOR_HYPOTHESIS_ID={REQUIRED_PREDECESSOR_HYPOTHESIS_ID}",
+                    f"DATASET={DATASET_ID}",
+                    "DEVELOPMENT_ONLY=true",
+                    "EVALUATION_RUN_COUNT=1",
+                    "HOLDOUT_DATA_ACCESSED=false",
+                    "PANEL_BACKTEST_EXECUTED=false",
+                    f"RESULT_CLASS={invalid_class}",
+                    f"REASON={validity.get('reason')}",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        write_manifest_sha256(output_dir)
+        if lifecycle is not None:
+            lifecycle.mark_complete()
+        return summary
+
+    freeze = mechanism_freeze_payload()
+    (output_dir / "exit_mechanism_formula_freeze.json").write_text(
+        json.dumps(freeze, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    root = resolve_development_archive_root(archive_root)
+    panel_proof = verify_development_panel_hashes(root)
+    if panel_proof["manifest_sha256"] != EXPECTED_MANIFEST_SHA256:
+        raise RuntimeError("PANEL_MANIFEST_SHA_MISMATCH")
+    if panel_proof["content_hash"] != EXPECTED_CONTENT_HASH:
+        raise RuntimeError("PANEL_CONTENT_HASH_MISMATCH")
+    members = included_panel_members(root)
+    cfg = load_runtime_cfg(repo, seed=PRIMARY_SEED)
+    if float(cfg["backtest"]["fee_bps"]) != FEE_BPS:
+        raise RuntimeError("FEE_BPS_MISMATCH")
+    if float(cfg["backtest"]["slippage_bps"]) != SLIPPAGE_BPS:
+        raise RuntimeError("SLIPPAGE_BPS_MISMATCH")
+
+    load_start_ts = pd.Timestamp(DECISION_START) - pd.Timedelta(
+        hours=MAX_FEATURE_LOOKBACK_HOURS + BB_PERIOD
+    )
+    load_start = load_start_ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    baseline = run_arm(
+        arm="baseline",
+        cfg=cfg,
+        archive_root=root,
+        members=members,
+        load_start=load_start,
+        decision_start=DECISION_START,
+        decision_end=DECISION_END_EXCLUSIVE,
+        gate=False,
+        lifecycle=lifecycle,
+    )
+    treatment = run_arm(
+        arm="treatment",
+        cfg=cfg,
+        archive_root=root,
+        members=members,
+        load_start=load_start,
+        decision_start=DECISION_START,
+        decision_end=DECISION_END_EXCLUSIVE,
+        gate=True,
+        lifecycle=lifecycle,
+    )
+
+    exits_forced = int(treatment.metrics["exits_forced_by_gate"])
+    baseline_exit_times = {
+        (t["instrument_id"], t["entry_time"]): t["exit_time"] for t in baseline.enriched_trades
+    }
+    treatment_exit_times = {
+        (t["instrument_id"], t["entry_time"]): t["exit_time"] for t in treatment.enriched_trades
+    }
+    shared_keys = set(baseline_exit_times) & set(treatment_exit_times)
+    exit_time_differs = any(baseline_exit_times[k] != treatment_exit_times[k] for k in shared_keys)
+    trade_count_differs = int(treatment.metrics["trade_count"]) != int(
+        baseline.metrics["trade_count"]
+    )
+    exit_reason_baseline = [t.get("exit_reason") for t in baseline.enriched_trades]
+    exit_reason_treatment = [t.get("exit_reason") for t in treatment.enriched_trades]
+    exit_reasons_differ = exit_reason_baseline != exit_reason_treatment
+    exit_divergence_observed = bool(
+        exits_forced > 0 or exit_time_differs or trade_count_differs or exit_reasons_differ
+    )
+
+    exit_attribution = {
+        "exits_forced_by_gate": exits_forced,
+        "exit_time_differs": exit_time_differs,
+        "trade_count_differs": trade_count_differs,
+        "exit_reasons_differ": exit_reasons_differ,
+        "exit_divergence_observed": exit_divergence_observed,
+        "baseline": baseline.exit_attribution,
+        "treatment": treatment.exit_attribution,
+    }
+    if lifecycle is not None:
+        lifecycle.record_persist_phase(note="pre_evidence_persist")
+    try:
+        (output_dir / "exit_attribution.json").write_text(
+            json.dumps(exit_attribution, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    except OSError as exc:
+        if lifecycle is not None:
+            lifecycle.record_persistence_failure(exc)
+        raise
+
+    decision_out = decide_development_evaluation(
+        baseline=baseline.metrics,
+        treatment=treatment.metrics,
+        exit_divergence_observed=exit_divergence_observed,
+        minimum_trade_count=MINIMUM_TRADE_COUNT,
+        max_trade_count_reduction_fraction=MAX_TRADE_COUNT_REDUCTION_FRACTION,
+        instrument_concentration_worst1_max=INSTRUMENT_CONCENTRATION_WORST1_ABS_NET_SHARE_MAX,
+        cost_multiplier_treatment=COST_MULTIPLIER,
+        cost_assumption_below_canonical_1x=False,
+        cost_drag_fully_included=True,
+    )
+
+    def _public_metrics(m: dict[str, Any]) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for k, v in m.items():
+            if str(k).startswith("_"):
+                continue
+            if isinstance(v, float) and (math.isnan(v) or math.isinf(v)):
+                out[k] = None
+            else:
+                out[k] = v
+        return out
+
+    baseline.metrics["_portfolio_equity"].to_csv(output_dir / "portfolio_equity_baseline.csv")
+    treatment.metrics["_portfolio_equity"].to_csv(output_dir / "portfolio_equity_treatment.csv")
+
+    (output_dir / "baseline_metrics.json").write_text(
+        json.dumps(_public_metrics(baseline.metrics), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "treatment_metrics.json").write_text(
+        json.dumps(_public_metrics(treatment.metrics), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "comparison_decision.json").write_text(
+        json.dumps(decision_out, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (output_dir / "instrument_attribution.json").write_text(
+        json.dumps(
+            {
+                "baseline": baseline.metrics["_instrument_attribution"],
+                "treatment": treatment.metrics["_instrument_attribution"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "trade_ledger_baseline.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "bollinger_mr_midband_exit_efficiency_trade_ledger.v4",
+                "arm": "baseline",
+                "trade_count": len(baseline.enriched_trades),
+                "trades": baseline.enriched_trades,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "trade_ledger_treatment.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "bollinger_mr_midband_exit_efficiency_trade_ledger.v4",
+                "arm": "treatment",
+                "trade_count": len(treatment.enriched_trades),
+                "trades": treatment.enriched_trades,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    config_snapshot = {
+        "schema_version": "evaluate_bollinger_mr_midband_exit_efficiency_development_config_snapshot.v4",
+        "hypothesis_id": HYPOTHESIS_ID,
+        "predecessor_hypothesis_id": REQUIRED_PREDECESSOR_HYPOTHESIS_ID,
+        "contract_id": contract["schema_version"],
+        "baseline_config_id": BASELINE_CONFIG_ID,
+        "treatment_id": contract["treatment"]["treatment_id"],
+        "dataset_id": DATASET_ID,
+        "decision_segment": {"start": DECISION_START, "end_exclusive": DECISION_END_EXCLUSIVE},
+        "decision_thresholds": contract["decision_thresholds"],
+        "cost_model": contract["cost_model"],
+        "seed": PRIMARY_SEED,
+        "stop_pct": STOP_PCT,
+        "mechanism_id": freeze["mechanism_id"],
+    }
+    (output_dir / "config_snapshot.json").write_text(
+        json.dumps(config_snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    v1_pkg = repo / "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1"
+    v3_pkg = repo / "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4"
+    code_hashes = {
+        "midband_exit_mechanism_v1.py": _sha256_file(v1_pkg / "midband_exit_mechanism_v1.py"),
+        "exit_efficiency_gate_v1.py": _sha256_file(v1_pkg / "exit_efficiency_gate_v1.py"),
+        "decision_v1.py": _sha256_file(v1_pkg / "decision_v1.py"),
+        "panel_runner_v4.py": _sha256_file(v3_pkg / "panel_runner_v4.py"),
+        "contract": canonical_json_sha256(contract),
+    }
+    (output_dir / "code_config_hashes.json").write_text(
+        json.dumps(code_hashes, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    command = (
+        "PYTHONPATH=src:. python3 scripts/research/"
+        "run_evaluate_bollinger_mr_midband_exit_efficiency_development_v4.py "
+        f"--output-dir {output_dir}"
+    )
+    summary = {
+        "schema_version": "evaluate_bollinger_mr_midband_exit_efficiency_development_summary.v4",
+        "evaluation_run_id": EVALUATION_RUN_ID,
+        "evaluation_run_count": 1,
+        "backtest_executed": True,
+        "hypothesis_id": HYPOTHESIS_ID,
+        "predecessor_hypothesis_id": REQUIRED_PREDECESSOR_HYPOTHESIS_ID,
+        "v1_rerun": False,
+        "v2_rerun": False,
+        "v3_rerun": False,
+        "v1_partial_results_reused": False,
+        "v2_partial_results_reused": False,
+        "v3_partial_results_reused": False,
+        "measurement_validity": validity,
+        "binding_fix_surface": BINDING_FIX_SURFACE,
+        "binding_fix_bound": True,
+        "evaluation_started": True,
+        "evaluation_completed": True,
+        "panel_backtest_executed": True,
+        "economic_verdict": (
+            decision_out["result_class"] if decision_out.get("evaluable") else "NOT_EVALUATED"
+        ),
+        "pass": decision_out.get("result_class") == "PASS",
+        "fail": decision_out.get("result_class") == "FAIL",
+        "acceptance_criteria_met": decision_out.get("result_class") == "PASS",
+        "auto_rerun_executed": False,
+        "rerun_allowed": False,
+        "contract_id": contract["schema_version"],
+        "contract_ref": CONTRACT_REL_PATH,
+        "config_id": BASELINE_CONFIG_ID,
+        "dataset_id": DATASET_ID,
+        "dataset_class": DATASET_CLASS,
+        "development_only": True,
+        "development_panel_accessed": True,
+        "development_period": f"{DECISION_START}..{DECISION_END_EXCLUSIVE}",
+        "development_split_digest": DEVELOPMENT_SPLIT_DIGEST,
+        "instrument_count": len(members),
+        "seed": PRIMARY_SEED,
+        "cost_model": contract["cost_model"],
+        "cost_multiplier": COST_MULTIPLIER,
+        "stop_pct": STOP_PCT,
+        "command": command,
+        "panel_proof": panel_proof,
+        "baseline_metrics": _public_metrics(baseline.metrics),
+        "treatment_metrics": _public_metrics(treatment.metrics),
+        "exit_attribution": exit_attribution,
+        "decision": decision_out,
+        "result_class": decision_out["result_class"],
+        "baseline_wallclock_seconds": baseline.wallclock_seconds,
+        "treatment_wallclock_seconds": treatment.wallclock_seconds,
+        "holdout_accessed": False,
+        "holdout_data_accessed": False,
+        "sealed_holdout_content_inspected": False,
+        "productive_trading_logic_changed": False,
+        "production_strategy_semantics_changed": False,
+        "double_play_authority_changed": False,
+        "risk_sizing_execution_semantics_changed": False,
+        "authority_changed": False,
+        "economic_validity_offline_gate_changed": False,
+        "economic_gate_open": False,
+        "promotion_eligible": False,
+        "runtime_activated": False,
+        "shadow_activated": False,
+        "testnet_activated": False,
+        "orders_sent": False,
+        "pass_criteria_changed": False,
+        "cost_model_changed": False,
+        "entry_eligibility_retuned": False,
+        "observability_surface": "EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1",
+        "observability_surface_bound": True,
+        "base_sha": _git_base_sha(repo),
+        "python_version": sys.version.split()[0],
+    }
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8"
+    )
+
+    (output_dir / "determinism_repro.txt").write_text(
+        "\n".join(
+            [
+                f"COMMAND={command}",
+                f"DATASET_ID={DATASET_ID}",
+                f"SEED={PRIMARY_SEED}",
+                f"DECISION_START={DECISION_START}",
+                f"DECISION_END_EXCLUSIVE={DECISION_END_EXCLUSIVE}",
+                "EVALUATION_RUN_COUNT=1",
+                f"MANIFEST_SHA256={panel_proof['manifest_sha256']}",
+                f"CONTENT_HASH={panel_proof['content_hash']}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "safety_attestation.md").write_text(
+        "\n".join(
+            [
+                "# Safety attestation — midband exit-efficiency DEVELOPMENT evaluation v4",
+                "",
+                f"- Hypothesis: `{HYPOTHESIS_ID}`",
+                f"- Predecessor (terminal, not rerun): `{REQUIRED_PREDECESSOR_HYPOTHESIS_ID}`",
+                "- DEVELOPMENT_ONLY=true",
+                "- EVALUATION_RUN_COUNT=1",
+                "- HOLDOUT_DATA_ACCESSED=false",
+                "- V1_PARTIAL_RESULTS_REUSED=false",
+                "- V3_PARTIAL_RESULTS_REUSED=false",
+                "- V3_RERUN=false",
+                "- Economic / promotion gates closed",
+                "- No Master-V2 / Double-Play / risk / sizing / execution mutation",
+                "- No runtime / orders",
+                "- PASS_CRITERIA frozen; COST_MODEL_CANONICAL frozen at 1.0x",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "README.md").write_text(
+        "\n".join(
+            [
+                "# Evaluate Bollinger/MR midband exit-efficiency DEVELOPMENT v4",
+                "",
+                f"HYPOTHESIS_ID={HYPOTHESIS_ID}",
+                f"PREDECESSOR_HYPOTHESIS_ID={REQUIRED_PREDECESSOR_HYPOTHESIS_ID}",
+                f"DATASET={DATASET_ID}",
+                "DEVELOPMENT_ONLY=true",
+                "EVALUATION_RUN_COUNT=1",
+                "HOLDOUT_DATA_ACCESSED=false",
+                "V1_PARTIAL_RESULTS_REUSED=false",
+                "V3_PARTIAL_RESULTS_REUSED=false",
+                "V3_RERUN=false",
+                f"RESULT_CLASS={decision_out['result_class']}",
+                f"REASON={decision_out['reason']}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    write_manifest_sha256(output_dir)
+    if lifecycle is not None:
+        lifecycle.mark_complete()
+    return summary
+
+
+__all__ = ["run_development_evaluation", "EVALUATION_RUN_ID", "BASELINE_CONFIG_ID"]

--- a/tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v4.py
+++ b/tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v4.py
@@ -1,0 +1,201 @@
+"""Contract/unit tests for midband exit-efficiency DEVELOPMENT evaluation v4 surface.
+
+Definition-only / pre-run safe. Must never invoke the panel runner, start a run,
+claim a run slot, or access panel/holdout archives.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v4 import (
+    PACKAGE_MARKER as PACKAGE_MARKER_V4,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v4.constants_v4 import (
+    BINDING_FIX_SURFACE,
+    CONTRACT_REL_PATH,
+    EVALUATION_RUN_ID,
+    EVIDENCE_REL_PATH,
+    GOVERNANCE_REL_PATH,
+    HYPOTHESIS_ID,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_development_evaluation_v4.measurement_validity_preflight_v4 import (
+    run_measurement_validity_preflight,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v3 import (
+    load_and_validate_repo_contract as load_v3_repo_contract,
+)
+from src.research.bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v4 import (
+    load_and_validate_repo_contract as load_v4_repo_contract,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+TEST_FILE = Path(__file__).resolve()
+PREFLIGHT_FILE = (
+    REPO
+    / "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4"
+    / "measurement_validity_preflight_v4.py"
+)
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_unit_tests_do_not_call_panel_runner_or_start_a_run() -> None:
+    tree = ast.parse(TEST_FILE.read_text(encoding="utf-8"))
+    banned = {
+        "run_development_evaluation",
+        "run_arm",
+        "load_member_bars",
+        "resolve_development_archive_root",
+        "verify_development_panel_hashes",
+        "included_panel_members",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id in banned:
+                raise AssertionError(f"banned_call:{node.func.id}")
+            if isinstance(node.func, ast.Attribute) and node.func.attr in banned:
+                raise AssertionError(f"banned_call:{node.func.attr}")
+    imports_os = False
+    touches_environ = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import) and any(alias.name == "os" for alias in node.names):
+            imports_os = True
+        if isinstance(node, ast.ImportFrom) and node.module == "os":
+            imports_os = True
+        if isinstance(node, ast.Attribute) and node.attr == "environ":
+            touches_environ = True
+    assert imports_os is False
+    assert touches_environ is False
+
+
+def test_preflight_module_does_not_import_panel_loaders() -> None:
+    tree = ast.parse(PREFLIGHT_FILE.read_text(encoding="utf-8"))
+    banned_modules = {
+        "src.research.entry_effective_mr_eligibility_development_evaluation_v1.dev_panel_bars_v1",
+    }
+    banned_names = {
+        "load_member_bars",
+        "resolve_development_archive_root",
+        "verify_development_panel_hashes",
+        "included_panel_members",
+        "run_development_evaluation",
+        "run_arm",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module in banned_modules:
+                raise AssertionError(f"banned_import:{node.module}")
+            for alias in node.names:
+                if alias.name in banned_names:
+                    raise AssertionError(f"banned_import_name:{alias.name}")
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in banned_modules:
+                    raise AssertionError(f"banned_import:{alias.name}")
+
+
+def test_package_marker_v4() -> None:
+    assert (
+        PACKAGE_MARKER_V4 == "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4=true"
+    )
+
+
+def test_constants_v4_identity() -> None:
+    assert HYPOTHESIS_ID == (
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_NON_BITCOIN_PERPETUALS_DEVELOPMENT_V4"
+    )
+    assert EVALUATION_RUN_ID == "evaluate_bollinger_mr_midband_exit_efficiency_development_v4"
+    assert CONTRACT_REL_PATH.endswith(
+        "bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v4.json"
+    )
+    assert (
+        EVIDENCE_REL_PATH
+        == "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v4/"
+    )
+    assert GOVERNANCE_REL_PATH == (
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4.md"
+    )
+    assert BINDING_FIX_SURFACE == "MV2_WIRING_MOD_CAPTURE_ALIAS_OPEN_SIDE_BINDING_FIX"
+
+
+def test_runner_script_exists() -> None:
+    script = (
+        REPO
+        / "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v4.py"
+    )
+    assert script.is_file()
+    text = script.read_text(encoding="utf-8")
+    assert "run_development_evaluation" in text
+    assert "EvaluationRunnerLifecycleObservabilityV1" in text
+    assert "AUTO_RERUN_EXECUTED=false" in text
+    assert "OPERATOR_GO" not in text
+    assert 'os.environ.get("GO_' not in text
+    assert "while True" not in text
+
+
+def test_panel_runner_falsy_zero_hygiene_and_validity_gate() -> None:
+    path = (
+        REPO
+        / "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4"
+        / "panel_runner_v4.py"
+    )
+    text = path.read_text(encoding="utf-8")
+    assert 'evaluation_run_count") or -1' not in text
+    assert 'evaluation_run_count", -1)' in text
+    assert "run_measurement_validity_preflight" in text
+    assert "BINDING_FIX_SURFACE" in text
+    assert "predecessor_development_v3" in text
+
+
+def test_v4_contract_still_definition_only_run_count_zero() -> None:
+    report = load_v4_repo_contract(REPO)
+    assert report["valid"] is True
+    assert report["definition_only"] is True
+    assert report["hypothesis_id"] == HYPOTHESIS_ID
+    assert report["evaluation_run_count"] == 0
+    assert report["preregistration_state"] == "DEFINITION_ONLY_PREREGISTERED"
+    assert report["result_class"] == "NOT_EVALUATED"
+    contract = _load(REPO / CONTRACT_REL_PATH)
+    assert contract["preregistration_state"] == "DEFINITION_ONLY_PREREGISTERED"
+    assert int(contract["evaluation_run_count"]) == 0
+    assert contract["holdout_data_accessed"] is False
+    assert int(contract["evaluation_run_count_authorized"]) == 1
+
+
+def test_v3_remains_terminal_fail_run_count_one() -> None:
+    v3_report = load_v3_repo_contract(REPO)
+    assert v3_report["evaluation_run_count"] == 1
+    assert v3_report["result_class"] == "FAIL"
+    assert v3_report["rerun_allowed"] is False
+
+
+def test_no_evaluation_evidence_or_slot_claim_in_definition_only_slice() -> None:
+    evidence = REPO / EVIDENCE_REL_PATH
+    assert evidence.exists() is False or not (evidence / "summary.json").exists()
+    assert not (evidence / "run_slot_claim.json").exists() if evidence.exists() else True
+
+
+def test_measurement_validity_preflight_passes_on_synthetic_fixture() -> None:
+    result = run_measurement_validity_preflight(repo_root=REPO)
+    assert result["passed"] is True
+    assert result["result_class"] is None
+    assert result["effective_configs_differ"] is True
+    assert result["open_side_binding_observed"] is True
+    assert int(result["exit_bars_observed"]) > 0
+    assert result["synthetic_divergence_observed"] is True
+    assert result["binding_fix_surface"] == BINDING_FIX_SURFACE
+
+
+def test_governance_doc_awaiting_execution() -> None:
+    governance = REPO / GOVERNANCE_REL_PATH
+    assert governance.is_file()
+    text = governance.read_text(encoding="utf-8")
+    assert "DOCS_TOKEN_BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4" in text
+    assert "AWAITING_EVALUATION_EXECUTION" in text
+    assert "EVALUATION_RUN_COUNT=0" in text
+    assert "MV2_WIRING_MOD_CAPTURE_ALIAS_OPEN_SIDE_BINDING_FIX" in text


### PR DESCRIPTION
## Summary
- Add definition-only DEVELOPMENT evaluation surface for `BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_NON_BITCOIN_PERPETUALS_DEVELOPMENT_V4` (constants, measurement-validity preflight, panel_runner_v4, runner script, focused tests, governance stub).
- V4 contract remains `DEFINITION_ONLY_PREREGISTERED` with `evaluation_run_count=0`; no evaluation executed, no evidence/summary/slot claim, no panel/holdout access in this slice.
- Wires owner-map + technical wiring authorization for the future one-shot run; V1/V2/V3 terminal results unchanged.

## Test plan
- [x] `pytest` V4 surface + gate_binding tests (no panel runner invocation)
- [x] Ruff format/check on changed Python
- [x] Docs token policy scan of new governance doc
- [x] Docs reference targets
- [x] Post-change guards: `evaluation_run_count=0`, no eval evidence dir


Made with [Cursor](https://cursor.com)