### PR TITLE
research: migrate exit-efficiency lane to shared post-terminal lifecycle

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -335,7 +335,7 @@
       ]
     },
     "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1": {
-      "note": "Canonical SSOT backlog for open MR exit-efficiency hypotheses; exactly one DEFINITION_ONLY_PREREGISTERED DEVELOPMENT_ONLY V8 candidate after V1/V2 terminal INCONCLUSIVE_INFRASTRUCTURE_FAILURE, V3 terminal FAIL, V4/V5 terminal INFRASTRUCTURE_FAILURE, V6 terminal FAIL, and V7 terminal INCONCLUSIVE_INFRASTRUCTURE_FAILURE; no SHORT-side parallel hypothesis; no holdout candidate; no evaluation/runtime/orders.",
+      "note": "Canonical SSOT backlog for open MR exit-efficiency hypotheses; migrated to POST_TERMINAL_OPERATOR_DECISION_REQUIRED under shared research-lane post-terminal lifecycle contract V1 as sole lane-status authority after V8 DEVELOPMENT TERMINAL_PASS; empty open candidate queue and empty preregistered list; V1-V8 terminal; no auto-close; no SHORT-side parallel hypothesis; no holdout candidate; no evaluation/runtime/orders.",
       "path_prefixes": [
         "config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json",
         "src/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py",
@@ -344,7 +344,7 @@
       ]
     },
     "CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1": {
-      "note": "Shared definition-only research-lane post-terminal lifecycle contract; canonical lane-state vocabulary, totality invariant, operator-decision contract, and historical-immutability/live-mirror policy. Does not migrate Entry-Eligibility or Exit-Efficiency backlog SSOTs; no evaluation/runtime/orders.",
+      "note": "Shared definition-only research-lane post-terminal lifecycle contract; canonical lane-state vocabulary, totality invariant, operator-decision contract, and historical-immutability/live-mirror policy. Entry-Eligibility and Exit-Efficiency backlog SSOTs migrate in separate operator-authorized slices; no evaluation/runtime/orders.",
       "path_prefixes": [
         "config/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.json",
         "src/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.py",

--- a/config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json
+++ b/config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json
@@ -12,7 +12,7 @@
   "dataset_id": "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_dev_pre_holdout_v1",
   "development_run_count": 8,
   "entry_eligibility_backlog_ref": "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json",
-  "entry_eligibility_lane_status": "CLOSED_NO_OPEN_CANDIDATES",
+  "entry_eligibility_lane_status": "POST_TERMINAL_OPERATOR_DECISION_REQUIRED",
   "evaluation_authorized": false,
   "evaluation_results_embedded": false,
   "exactly_one_authoritative_truth": true,
@@ -66,7 +66,7 @@
     "NO_HOLDOUT_AFTER_PASS",
     "NO_RUNTIME_PROMOTION_FROM_DEVELOPMENT_PASS"
   ],
-  "governance_note": "V8 DEVELOPMENT evaluation executed once and terminated as PASS (ALL_PASS_REQUIRES_MET) on sealed DEVELOPMENT_ONLY panel; run slot consumed; rerun/reopen forbidden. Open DEFINITION_ONLY queue empty (preregistered_count_exact=0). V1-V7 remain terminal unchanged. Economic offline gate remains closed; promotion closed; no holdout; no runtime/orders. Next requires separate Operator-GO for any new definition-only preregistration.",
+  "governance_note": "Migrated onto CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1 as sole lane-status authority. Status=POST_TERMINAL_OPERATOR_DECISION_REQUIRED because inventories are empty and V1-V8 are terminal, without an explicit closeout or awaiting-successor decision (auto-close forbidden). V8 DEVELOPMENT evaluation executed once and terminated as PASS (ALL_PASS_REQUIRES_MET) on sealed DEVELOPMENT_ONLY panel; run slot consumed; rerun/reopen forbidden. Open DEFINITION_ONLY queue empty (preregistered_count_exact=0). V1-V7 remain terminal unchanged. Economic offline gate remains closed; promotion closed; no holdout; no runtime/orders. Next requires separate Operator-GO with concrete target under the shared lifecycle operator-decision contract. Entry Eligibility is not modified in this slice; cross-lane status mirror uses the sibling canonical lifecycle status.",
   "governance_rules": {
     "candidate_combination_forbidden": true,
     "cost_model_weakening_forbidden": true,
@@ -119,7 +119,13 @@
   "sealed_holdout_id": "offline_economic_reevaluation_sealed_long_panel_v1",
   "short_side_hypothesis_preregistered": false,
   "slice_class": "DEFINITION_ONLY_PREREGISTRATION",
-  "status": "OPEN_BACKLOG",
+  "status": "POST_TERMINAL_OPERATOR_DECISION_REQUIRED",
+  "lifecycle_contract_id": "CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1",
+  "lifecycle_contract_ref": "config/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.json",
+  "lifecycle_authority": "SHARED_POST_TERMINAL_LIFECYCLE_CONTRACT_V1_SOLE_AUTHORITY",
+  "explicit_closeout_decision": false,
+  "explicit_waiting_decision": false,
+  "lane_auto_closed": false,
   "terminal_hypotheses": [
     {
       "baseline_members_completed": "2/46",
@@ -517,5 +523,6 @@
       "v8_rerun_forbidden": true
     }
   ],
-  "verdict": "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_BACKLOG_V8_TERMINAL_PASS_AWAITING_OPERATOR_GO_FOR_ANY_NEW_DEFINITION_ONLY_PREREGISTRATION"
+  "verdict": "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_BACKLOG_V8_TERMINAL_PASS_AWAITING_OPERATOR_GO_FOR_ANY_NEW_DEFINITION_ONLY_PREREGISTRATION",
+  "entry_eligibility_lane_status_authority": "SIBLING_ENTRY_ELIGIBILITY_BACKLOG_UNDER_SHARED_LIFECYCLE_CONTRACT_V1"
 }

--- a/config/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.json
+++ b/config/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.json
@@ -115,10 +115,10 @@
     "entry_eligibility_backlog_ssot": "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json",
     "entry_eligibility_impact": "Migrated to status=POST_TERMINAL_OPERATOR_DECISION_REQUIRED with shared lifecycle contract as sole lane-status authority; inventories remain empty; no auto-close; no explicit awaiting or closeout decision recorded in the migration slice. Cross-lane status label CLOSED_NO_OPEN_CANDIDATES on Exit-Efficiency remains non-canonical and is deferred with Exit-Efficiency migration.",
     "exit_efficiency_backlog_ssot": "config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json",
-    "exit_efficiency_impact": "Currently status=OPEN_BACKLOG with empty open_unpreregistered_candidates and empty preregistered_hypotheses after V8 TERMINAL_PASS; under this contract that combination is invalid. Migration to AWAITING_EXPLICIT_SUCCESSOR_HYPOTHESIS or LANE_CLOSED_NO_FURTHER_RESEARCH requires a separate operator-authorized slice; historical V8 artifacts must remain immutable.",
+    "exit_efficiency_impact": "Migrated to status=POST_TERMINAL_OPERATOR_DECISION_REQUIRED with shared lifecycle contract as sole lane-status authority; inventories remain empty after V8 TERMINAL_PASS; no auto-close; no explicit awaiting or closeout decision recorded in the migration slice. Historical V8 economic/evaluation/run-slot/preregistration artifacts remain immutable. Non-canonical cross-lane label CLOSED_NO_OPEN_CANDIDATES removed from Exit-Efficiency SSOT.",
     "migrate_in_this_slice": false,
     "entry_eligibility_migrated": true,
-    "exit_efficiency_migrated": false
+    "exit_efficiency_migrated": true
   },
   "non_goals": [
     "NO_ENTRY_ELIGIBILITY_MIGRATION",

--- a/docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md
+++ b/docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md
@@ -2,7 +2,9 @@
 
 ## Current SSOT status
 
-- Verdict: `CANONICAL_OPEN_MR_EXIT_EFFICIENCY_BACKLOG_V8_TERMINAL_PASS_AWAITING_OPERATOR_GO_FOR_ANY_NEW_DEFINITION_ONLY_PREREGISTRATION`
+- Lane status: `POST_TERMINAL_OPERATOR_DECISION_REQUIRED` under shared lifecycle contract V1
+- Lifecycle authority (sole): `CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1`
+- Auto-close: forbidden (`lane_auto_closed=false`)
 - Preregistered: none (`preregistered_count_exact=0`)
 - Terminal: V1&#47;V2&#47;V7 `INCONCLUSIVE_INFRASTRUCTURE_FAILURE`; V3&#47;V6 `FAIL`; V4&#47;V5 `INFRASTRUCTURE_FAILURE`; V8 `TERMINAL_PASS`
 - V7 remains terminal unreopened: `RESULT_CLASS=INCONCLUSIVE_INFRASTRUCTURE_FAILURE`; `FAILURE_CLASS=FROZEN_EXIT_PARAMETERS_MISMATCH`; `FAILURE_TIMING=BEFORE_PANEL_ACCESS`
@@ -11,12 +13,12 @@
 - V8 panel digest: `4a1978fe0e69a6cd7b19b32f5f95882cfdc3e36397aaec87bce2c4139ab1cfca`
 - Development run count: `8`
 - No V8&#47;V7&#47;V6&#47;V5&#47;V4&#47;V3&#47;V2&#47;V1 rerun. No V7&#47;V8 reopen. No V9 auto-create. No holdout after PASS. No runtime promotion from DEVELOPMENT PASS.
-- `NEXT_CANONICAL_ACTION=OPERATOR_GO_REQUIRED_FOR_ANY_NEW_DEFINITION_ONLY_PREREGISTRATION`
+- `NEXT_CANONICAL_ACTION=OPERATOR_GO_REQUIRED_FOR_ANY_NEW_DEFINITION_ONLY_PREREGISTRATION` (GO alone is not executable without a concrete target under the shared operator-decision contract)
 - Economic&#47;promotion gates closed. No runtime&#47;orders.
 
 ---
 docs_token: DOCS_TOKEN_CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1
-STATUS: OPEN_BACKLOG
+STATUS: POST_TERMINAL_OPERATOR_DECISION_REQUIRED
 scope: research, offline-only, non-authorizing, terminal-governance closeout
 LIVE_AUTHORIZED: false
 ORDERS_ALLOWED: false
@@ -25,14 +27,22 @@ SCHEDULER_RUNTIME_ALLOWED: false
 
 ## Status
 
-`OPEN_BACKLOG` — versioned canonical SSOT for Mean-Reversion exit-efficiency
-research candidates. Zero preregistered hypotheses. V1–V8 are terminal.
-No holdout access. No runtime activation. No productive trading-logic mutation.
+`POST_TERMINAL_OPERATOR_DECISION_REQUIRED` — migrated onto the shared research-lane
+post-terminal lifecycle contract. Inventories are empty; V1–V8 are terminal; no
+explicit closeout and no explicit awaiting-successor decision has been recorded.
+Auto-close is forbidden.
+
+Lane-status vocabulary and post-terminal legality are owned solely by
+`CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1`.
+`OPEN_BACKLOG` is invalid for this empty-inventory posture.
+The non-canonical cross-lane label `CLOSED_NO_OPEN_CANDIDATES` is removed; the
+sibling Entry Eligibility status mirror uses the canonical lifecycle status only.
 
 ## Binding
 
 - SSOT: `config&#47;research&#47;canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json`
 - Validator: `src&#47;research&#47;canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py`
+- Lifecycle authority (sole): `config&#47;research&#47;canonical_research_lane_post_terminal_lifecycle_contract_v1.json`
 - Baseline (immutable): `bollinger_bands_v2_full_canonical_system_economic_binding_v1`
 - Required treatment type: `POST_ENTRY_EXIT_EFFICIENCY_MECHANISM`
 - Dataset: `pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_dev_pre_holdout_v1`
@@ -150,14 +160,22 @@ Exactly eight:
 - No holdout candidate
 - No cost-structure-weakening hypothesis
 - No entry-eligibility reopen
+- No lane auto-close
 - Open unpreregistered exit-efficiency candidates: empty
 
 ## Next separate action
 
 `NEXT_CANONICAL_ACTION=OPERATOR_GO_REQUIRED_FOR_ANY_NEW_DEFINITION_ONLY_PREREGISTRATION`
 
+Enumerated shared-contract operator decisions remain available (not executed here):
+
+- `DECLARE_AWAITING_EXPLICIT_SUCCESSOR_HYPOTHESIS`
+- `CLOSE_LANE_NO_FURTHER_RESEARCH`
+- `CREATE_SUCCESSOR_HYPOTHESIS` (requires explicit `hypothesis_id` + mechanism)
+
 No V8 rerun. No V8 reopen. No holdout. No runtime&#47;orders. No V9 auto-create.
 
 ## V8 terminal closeout
 
 V8 DEVELOPMENT evaluation consumed its one-shot slot and terminated as `PASS` (`DECISION_REASON=ALL_PASS_REQUIRES_MET`) on the sealed DEVELOPMENT_ONLY panel. V8 remains terminal and unreopened. PASS is a development evaluation result only — not a trading, shadow, testnet, scheduler, or live authorization. Economic offline gate remains closed; promotion remains closed. No V8 rerun. No V8 reopen. No V9 auto-create.
+Historical V8 economic, evaluation, run-slot, and preregistration artifacts remain immutable.

--- a/docs/governance/CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1.md
+++ b/docs/governance/CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1.md
@@ -158,9 +158,11 @@ Shared-contract definition slice remains non-migrating (`migrate_in_this_slice: 
 
 - Entry-Eligibility backlog has been migrated in a separate operator-authorized slice to
   `POST_TERMINAL_OPERATOR_DECISION_REQUIRED` under this contract as sole lane-status authority
-  (no auto-close). Cross-lane status label `CLOSED_NO_OPEN_CANDIDATES` remains non-canonical.
-- Exit-Efficiency backlog currently still uses `OPEN_BACKLOG` with empty inventory
-  after V8 `TERMINAL_PASS` and remains deferred.
+  (no auto-close).
+- Exit-Efficiency backlog has been migrated in a separate operator-authorized slice to
+  `POST_TERMINAL_OPERATOR_DECISION_REQUIRED` under this contract as sole lane-status authority
+  (no auto-close). The non-canonical cross-lane label `CLOSED_NO_OPEN_CANDIDATES` is removed
+  from the Exit-Efficiency SSOT.
 
 Historical V8 economic, evaluation, run-slot, and preregistration artifacts remain immutable.
 

--- a/src/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py
+++ b/src/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py
@@ -6,6 +6,9 @@ activation, or productive trading-logic mutation.
 Post V8 terminal PASS closeout: zero DEFINITION_ONLY_PREREGISTERED candidates;
 V1-V8 terminal (V8 PASS after one authorized DEVELOPMENT evaluation);
 development_run_count=8; no V8 rerun/reopen; no V9 auto-create; economic/promotion closed.
+
+Lane status vocabulary and post-terminal legality are owned solely by
+CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1.
 """
 
 from __future__ import annotations
@@ -14,10 +17,26 @@ import json
 from pathlib import Path
 from typing import Any, Mapping
 
+from src.research.canonical_research_lane_post_terminal_lifecycle_contract_v1 import (
+    CONTRACT_ID as LIFECYCLE_CONTRACT_ID,
+    CONTRACT_REL_PATH as LIFECYCLE_CONTRACT_REL_PATH,
+    ResearchLaneLifecycleContractError,
+    resolve_post_terminal_transition,
+    validate_lane_snapshot,
+)
+
 PACKAGE_MARKER = "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1=true"
 BACKLOG_REL_PATH = "config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json"
 GOVERNANCE_REL_PATH = "docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md"
-REQUIRED_STATUS = "OPEN_BACKLOG"
+REQUIRED_STATUS = "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+REQUIRED_LIFECYCLE_AUTHORITY = "SHARED_POST_TERMINAL_LIFECYCLE_CONTRACT_V1_SOLE_AUTHORITY"
+ENTRY_ELIGIBILITY_BACKLOG_REL_PATH = (
+    "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json"
+)
+REQUIRED_ENTRY_ELIGIBILITY_LANE_STATUS = "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+REQUIRED_ENTRY_ELIGIBILITY_STATUS_AUTHORITY = (
+    "SIBLING_ENTRY_ELIGIBILITY_BACKLOG_UNDER_SHARED_LIFECYCLE_CONTRACT_V1"
+)
 REQUIRED_DATASET_ID = "pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_dev_pre_holdout_v1"
 REQUIRED_TREATMENT_TYPE = "POST_ENTRY_EXIT_EFFICIENCY_MECHANISM"
 REQUIRED_HYPOTHESIS_ID = (
@@ -238,7 +257,34 @@ def _assert_terminal_infrastructure_entry(
 
 
 def validate_backlog_contract(backlog: Mapping[str, Any]) -> dict[str, Any]:
-    _assert_true(backlog.get("status") == REQUIRED_STATUS, "STATUS_NOT_OPEN_BACKLOG")
+    _assert_true(
+        backlog.get("status") == REQUIRED_STATUS,
+        "STATUS_NOT_POST_TERMINAL_OPERATOR_DECISION_REQUIRED",
+    )
+    _assert_true(
+        backlog.get("lifecycle_contract_id") == LIFECYCLE_CONTRACT_ID,
+        "LIFECYCLE_CONTRACT_ID_MISMATCH",
+    )
+    _assert_true(
+        backlog.get("lifecycle_contract_ref") == LIFECYCLE_CONTRACT_REL_PATH,
+        "LIFECYCLE_CONTRACT_REF_MISMATCH",
+    )
+    _assert_true(
+        backlog.get("lifecycle_authority") == REQUIRED_LIFECYCLE_AUTHORITY,
+        "LIFECYCLE_AUTHORITY_MISMATCH",
+    )
+    _assert_true(backlog.get("explicit_closeout_decision") is False, "UNEXPECTED_CLOSEOUT_DECISION")
+    _assert_true(backlog.get("explicit_waiting_decision") is False, "UNEXPECTED_WAITING_DECISION")
+    _assert_true(backlog.get("lane_auto_closed") is False, "LANE_AUTO_CLOSED_FORBIDDEN")
+    _assert_true(
+        backlog.get("entry_eligibility_lane_status") == REQUIRED_ENTRY_ELIGIBILITY_LANE_STATUS,
+        "ENTRY_ELIGIBILITY_LANE_STATUS_NOT_CANONICAL",
+    )
+    _assert_true(
+        backlog.get("entry_eligibility_lane_status_authority")
+        == REQUIRED_ENTRY_ELIGIBILITY_STATUS_AUTHORITY,
+        "ENTRY_ELIGIBILITY_STATUS_AUTHORITY_MISMATCH",
+    )
     _assert_true(backlog.get("canonical_ssot") is True, "NOT_CANONICAL_SSOT")
     _assert_true(
         backlog.get("exactly_one_authoritative_truth") is True,
@@ -607,9 +653,63 @@ def validate_backlog_contract(backlog: Mapping[str, Any]) -> dict[str, Any]:
     _assert_true("NO_V3_ECONOMIC_RESULT_IMPORT" in non_actions, "NO_V3_ECON_IMPORT_REQUIRED")
     _assert_true("NO_V4_AUTO_CREATE" not in non_actions, "NO_V4_AUTO_CREATE_MUST_BE_ABSENT")
 
+    # Shared post-terminal lifecycle is the sole status authority.
+    open_cands = list(backlog.get("open_unpreregistered_candidates") or [])
+    prereg = list(backlog.get("preregistered_hypotheses") or [])
+    lifecycle_snapshot = {
+        "status": backlog.get("status"),
+        "open_unpreregistered_candidates": open_cands,
+        "preregistered_hypotheses": prereg,
+        "explicit_closeout_decision": bool(backlog.get("explicit_closeout_decision")),
+        "explicit_waiting_decision": bool(backlog.get("explicit_waiting_decision")),
+        "go_executable": False,
+        "auto_created_successor": False,
+        "implicit_successor": False,
+        "lane_auto_closed": bool(backlog.get("lane_auto_closed")),
+    }
+    try:
+        lifecycle_report = validate_lane_snapshot(lifecycle_snapshot)
+    except ResearchLaneLifecycleContractError as exc:
+        raise BacklogValidationError(f"LIFECYCLE_CONTRACT_REJECTED:{exc}") from exc
+    _assert_true(lifecycle_report.get("valid") is True, "LIFECYCLE_SNAPSHOT_INVALID")
+    _assert_true(lifecycle_report.get("status") == REQUIRED_STATUS, "LIFECYCLE_STATUS_DRIFT")
+    _assert_true(
+        lifecycle_report.get("inventory_non_empty") is False,
+        "LIFECYCLE_INVENTORY_MUST_BE_EMPTY",
+    )
+    resolved = resolve_post_terminal_transition(
+        result_class="PASS",
+        inventory_non_empty_flag=False,
+    )
+    _assert_true(
+        resolved.get("next_state") == REQUIRED_STATUS,
+        "POST_TERMINAL_RESOLUTION_DRIFT",
+        str(resolved.get("next_state")),
+    )
+    _assert_true(
+        resolved.get("operator_decision_required") is True,
+        "POST_TERMINAL_OPERATOR_DECISION_NOT_REQUIRED",
+    )
+
+    # Read-only sibling mirror: Entry Eligibility status under shared contract (no mutation).
+    entry_path = _repo_root() / ENTRY_ELIGIBILITY_BACKLOG_REL_PATH
+    _assert_true(entry_path.is_file(), "ENTRY_ELIGIBILITY_BACKLOG_MISSING", str(entry_path))
+    entry_backlog = _load_json(entry_path)
+    _assert_true(
+        entry_backlog.get("status") == REQUIRED_ENTRY_ELIGIBILITY_LANE_STATUS,
+        "ENTRY_ELIGIBILITY_SIBLING_STATUS_DRIFT",
+        str(entry_backlog.get("status")),
+    )
+    _assert_true(
+        backlog.get("entry_eligibility_lane_status") == entry_backlog.get("status"),
+        "ENTRY_ELIGIBILITY_STATUS_MIRROR_MISMATCH",
+    )
+
     return {
         "valid": True,
         "status": REQUIRED_STATUS,
+        "lifecycle_contract_id": LIFECYCLE_CONTRACT_ID,
+        "lifecycle_authority": REQUIRED_LIFECYCLE_AUTHORITY,
         "preregistered_count": 0,
         "terminal_count": 8,
         "open_unpreregistered_count": 0,

--- a/tests/research/test_canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py
+++ b/tests/research/test_canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
+
+import pytest
 
 from src.research.canonical_open_mr_exit_efficiency_hypothesis_backlog_v1 import (
     BACKLOG_REL_PATH,
@@ -19,8 +22,10 @@ from src.research.canonical_open_mr_exit_efficiency_hypothesis_backlog_v1 import
     REQUIRED_V6_MECHANISM_ID,
     REQUIRED_V7_HYPOTHESIS_ID,
     REQUIRED_V8_HYPOTHESIS_ID,
+    BacklogValidationError,
     assert_exactly_one_exit_efficiency_backlog_ssot,
     load_and_validate_repo_backlog,
+    validate_backlog_contract,
 )
 
 REPO = Path(__file__).resolve().parents[2]
@@ -41,6 +46,13 @@ def test_exactly_one_exit_efficiency_backlog_ssot() -> None:
 def test_repo_backlog_one_definition_only_v8_preregistered() -> None:
     report = load_and_validate_repo_backlog(REPO)
     assert report["valid"] is True
+    assert report["status"] == "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+    assert report["lifecycle_contract_id"] == (
+        "CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1"
+    )
+    assert report["lifecycle_authority"] == (
+        "SHARED_POST_TERMINAL_LIFECYCLE_CONTRACT_V1_SOLE_AUTHORITY"
+    )
     assert report["preregistered_count"] == 0
     assert report["terminal_count"] == 8
     assert report["open_unpreregistered_count"] == 0
@@ -85,6 +97,15 @@ def test_one_preregistered_v8_and_v7_terminal_entry_shape() -> None:
     assert backlog["preregistered_hypotheses"] == []
     assert backlog["governance_rules"]["preregistered_count_exact"] == 0
     assert backlog["open_unpreregistered_candidates"] == []
+    assert backlog["status"] == "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+    assert backlog["lifecycle_authority"] == (
+        "SHARED_POST_TERMINAL_LIFECYCLE_CONTRACT_V1_SOLE_AUTHORITY"
+    )
+    assert backlog["explicit_closeout_decision"] is False
+    assert backlog["explicit_waiting_decision"] is False
+    assert backlog["lane_auto_closed"] is False
+    assert backlog["entry_eligibility_lane_status"] == ("POST_TERMINAL_OPERATOR_DECISION_REQUIRED")
+    assert "CLOSED_NO_OPEN_CANDIDATES" not in json.dumps(backlog)
     assert backlog["development_run_count"] == 8
     assert len(backlog["terminal_hypotheses"]) == 8
     by_id = {e["hypothesis_id"]: e for e in backlog["terminal_hypotheses"]}
@@ -196,6 +217,10 @@ def test_governance_doc_mentions_v8_prereg_and_v7_terminal() -> None:
     text = (
         REPO / "docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md"
     ).read_text(encoding="utf-8")
+    assert "POST_TERMINAL_OPERATOR_DECISION_REQUIRED" in text
+    assert "CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1" in text
+    assert "OPEN_BACKLOG` is invalid" in text or "OPEN_BACKLOG is invalid" in text
+    assert "CLOSED_NO_OPEN_CANDIDATES" in text  # mentioned as removed/non-canonical
     assert "V6" in text
     assert "TERMINAL_FAIL" in text or "FAIL" in text
     assert "NET_PROFIT_FACTOR_NOT_IMPROVED" in text
@@ -211,3 +236,37 @@ def test_governance_doc_mentions_v8_prereg_and_v7_terminal() -> None:
     assert "V4" in text
     assert "INFRASTRUCTURE_FAILURE" in text or "Infrastructure" in text
     assert "NO_V8" in text or "No V8" in text or "No V8 auto-create" in text
+
+
+def test_rejects_open_backlog_with_empty_inventory() -> None:
+    backlog = _load(BACKLOG_PATH)
+    bad = copy.deepcopy(backlog)
+    bad["status"] = "OPEN_BACKLOG"
+    with pytest.raises(
+        BacklogValidationError, match="STATUS_NOT_POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+    ):
+        validate_backlog_contract(bad)
+
+
+def test_rejects_missing_shared_lifecycle_authority() -> None:
+    backlog = _load(BACKLOG_PATH)
+    bad = copy.deepcopy(backlog)
+    bad["lifecycle_authority"] = "LANE_LOCAL_STATUS_AUTHORITY"
+    with pytest.raises(BacklogValidationError, match="LIFECYCLE_AUTHORITY_MISMATCH"):
+        validate_backlog_contract(bad)
+
+
+def test_rejects_auto_close_flag() -> None:
+    backlog = _load(BACKLOG_PATH)
+    bad = copy.deepcopy(backlog)
+    bad["lane_auto_closed"] = True
+    with pytest.raises(BacklogValidationError, match="LANE_AUTO_CLOSED_FORBIDDEN"):
+        validate_backlog_contract(bad)
+
+
+def test_rejects_noncanonical_entry_eligibility_status_label() -> None:
+    backlog = _load(BACKLOG_PATH)
+    bad = copy.deepcopy(backlog)
+    bad["entry_eligibility_lane_status"] = "CLOSED_NO_OPEN_CANDIDATES"
+    with pytest.raises(BacklogValidationError, match="ENTRY_ELIGIBILITY_LANE_STATUS_NOT_CANONICAL"):
+        validate_backlog_contract(bad)

--- a/tests/research/test_canonical_research_lane_post_terminal_lifecycle_contract_v1.py
+++ b/tests/research/test_canonical_research_lane_post_terminal_lifecycle_contract_v1.py
@@ -267,12 +267,17 @@ def test_migration_deferred_and_production_lanes_untouched() -> None:
         REPO_ROOT / "config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json"
     )
     entry_payload = json.loads(entry.read_text(encoding="utf-8"))
-    exit_payload = exit_eff.read_text(encoding="utf-8")
+    exit_payload = json.loads(exit_eff.read_text(encoding="utf-8"))
     assert entry_payload["status"] == "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
     assert entry_payload["lifecycle_contract_id"] == CONTRACT_ID
     assert entry_payload["lane_auto_closed"] is False
+    assert exit_payload["status"] == "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+    assert exit_payload["lifecycle_contract_id"] == CONTRACT_ID
+    assert exit_payload["lane_auto_closed"] is False
+    assert exit_payload["entry_eligibility_lane_status"] == (
+        "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+    )
+    assert "CLOSED_NO_OPEN_CANDIDATES" not in json.dumps(exit_payload)
     assert contract["migration_deferred"].get("entry_eligibility_migrated") is True
-    assert contract["migration_deferred"].get("exit_efficiency_migrated") is False
-    assert '"status": "OPEN_BACKLOG"' in exit_payload
-    assert "LANE_CLOSED_NO_FURTHER_RESEARCH" not in exit_payload
-    assert "POST_TERMINAL_OPERATOR_DECISION_REQUIRED" not in exit_payload
+    assert contract["migration_deferred"].get("exit_efficiency_migrated") is True
+    assert "LANE_CLOSED_NO_FURTHER_RESEARCH" not in json.dumps(exit_payload)


### PR DESCRIPTION
## Summary
- Migrates Exit Efficiency backlog status from invalid empty `OPEN_BACKLOG` to `POST_TERMINAL_OPERATOR_DECISION_REQUIRED` under the shared post-terminal lifecycle contract V1 as sole lane-status authority.
- Removes non-canonical cross-lane label `CLOSED_NO_OPEN_CANDIDATES`; sibling Entry Eligibility status is mirrored read-only under the shared contract.
- Does **not** auto-close the lane, create a successor, start evaluation/runner, mutate historical V8 artifacts, or change Entry Eligibility.

## Diff scope
- Exit Efficiency SSOT, validator, governance doc, focused tests
- Shared lifecycle migration bookkeeping + compatibility test update
- Owner-map notes for Exit Efficiency / shared lifecycle

## Test plan
- [x] Exit Efficiency contract tests
- [x] Shared lifecycle contract tests
- [x] Entry Eligibility tests unchanged/green
- [x] V8 preregistration compatibility tests
- [x] Boundary guard tests
- [x] PR_BOUNDED_FULL timing proof
- [x] Docs token + reference-target gates

## Explicit non-goals
- No Entry-Eligibility mutation
- No new lifecycle definitions
- No hypothesis / evaluation / runner / run-slot / promotion
- No live/orders/shadow/testnet/scheduler/capital

Made with [Cursor](https://cursor.com)