### PR TITLE
research: close Exit Efficiency lane after holdout terminal FAIL

### DIFF
--- a/config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json
+++ b/config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json
@@ -68,9 +68,13 @@
     "NO_SECOND_HOLDOUT_RUN_OF_HOLDOUT_V1",
     "NO_MECHANISM_MUTATION_VS_FROZEN_V8",
     "NO_RETRY_AFTER_HOLDOUT_FAIL",
-    "NO_POST_RESULT_TUNING_AFTER_HOLDOUT"
+    "NO_POST_RESULT_TUNING_AFTER_HOLDOUT",
+    "NO_IMPLICIT_SUCCESSOR_AFTER_CLOSE",
+    "NO_AUTO_REOPEN",
+    "NO_REOPEN_WITHOUT_NEW_HYPOTHESIS_ID",
+    "NO_SUCCESSOR_SYNTHESIS_FROM_ATTRIBUTION_CANDIDATES"
   ],
-  "governance_note": "After single authorized holdout successor BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_NON_BITCOIN_PERPETUALS_HOLDOUT_V1 executed and terminated as FAIL / NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1; retry forbidden), Exit Efficiency lane status under CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1 is POST_TERMINAL_OPERATOR_DECISION_REQUIRED with empty open and preregistered inventories. V8 DEVELOPMENT remains TERMINAL_PASS unreopened/unrerun; V8 identity remains holdout_allowed=false. V7 remains TERMINAL_INCONCLUSIVE_INFRASTRUCTURE_FAILURE unreopened. No auto-close; no explicit awaiting/closeout decision recorded in this slice. Entry Eligibility sibling status=LANE_CLOSED_NO_FURTHER_RESEARCH. Economic offline gate remains closed; promotion closed; no runtime/orders.",
+  "governance_note": "Explicit operator decision CLOSE_LANE_NO_FURTHER_RESEARCH recorded under CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1 as sole lane-status authority after single authorized holdout successor BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_NON_BITCOIN_PERPETUALS_HOLDOUT_V1 executed and terminated as FAIL / NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1; retry forbidden; slot consumed). Status=LANE_CLOSED_NO_FURTHER_RESEARCH with explicit_closeout_decision=true; explicit_waiting_decision=false; lane_auto_closed=false. Inventories remain empty (open=0, preregistered=0); no eligible independent successor exists; no automatic successor generation; no V9 auto-create. V8 DEVELOPMENT remains TERMINAL_PASS unreopened/unrerun; V8 identity remains holdout_allowed=false; holdout terminal annotations immutable. V7 remains TERMINAL_INCONCLUSIVE_INFRASTRUCTURE_FAILURE unreopened. Entry Eligibility sibling status=LANE_CLOSED_NO_FURTHER_RESEARCH. Economic offline gate remains closed; promotion closed; no runtime/orders. Reopen requires REOPEN_CLOSED_LANE_WITH_NEW_HYPOTHESIS_IDENTITY under a future separately governed authority contract.",
   "governance_rules": {
     "candidate_combination_forbidden": true,
     "cost_model_weakening_forbidden": true,
@@ -90,7 +94,7 @@
   "holdout_candidate_preregistered": false,
   "holdout_forbidden": true,
   "implementation_authorized": false,
-  "next_canonical_step": "REVIEW_TERMINAL_HOLDOUT_FAIL_NO_RETRY",
+  "next_canonical_step": "LANE_CLOSED_NO_FURTHER_RESEARCH_NO_EXECUTABLE_GO",
   "open_unpreregistered_candidates": [],
   "parent_diagnostic_class": "COSTS_DESTROY_MARGINAL_EDGE",
   "parent_diagnostic_scope_id": "bollinger_mr_economic_failure_decomposition_development_v1",
@@ -122,12 +126,12 @@
   "sealed_holdout_content_inspection_authorized": false,
   "sealed_holdout_id": "offline_economic_reevaluation_sealed_long_panel_v1",
   "short_side_hypothesis_preregistered": false,
-  "slice_class": "DEFINITION_ONLY_PREREGISTRATION",
-  "status": "POST_TERMINAL_OPERATOR_DECISION_REQUIRED",
+  "slice_class": "DEFINITION_ONLY_GOVERNANCE",
+  "status": "LANE_CLOSED_NO_FURTHER_RESEARCH",
   "lifecycle_contract_id": "CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1",
   "lifecycle_contract_ref": "config/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.json",
   "lifecycle_authority": "SHARED_POST_TERMINAL_LIFECYCLE_CONTRACT_V1_SOLE_AUTHORITY",
-  "explicit_closeout_decision": false,
+  "explicit_closeout_decision": true,
   "explicit_waiting_decision": false,
   "lane_auto_closed": false,
   "terminal_hypotheses": [
@@ -539,6 +543,6 @@
       "holdout_evaluation_evidence_ref": "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/"
     }
   ],
-  "verdict": "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_POST_TERMINAL_OPERATOR_DECISION_REQUIRED_AFTER_HOLDOUT_V1_TERMINAL_FAIL",
+  "verdict": "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_LANE_CLOSED_NO_FURTHER_RESEARCH_AFTER_EXPLICIT_OPERATOR_CLOSEOUT_AFTER_HOLDOUT_V1_TERMINAL_FAIL",
   "entry_eligibility_lane_status_authority": "SIBLING_ENTRY_ELIGIBILITY_BACKLOG_UNDER_SHARED_LIFECYCLE_CONTRACT_V1"
 }

--- a/docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md
+++ b/docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md
@@ -2,27 +2,30 @@
 
 ## Current SSOT status
 
-- Lane status: `POST_TERMINAL_OPERATOR_DECISION_REQUIRED` under shared lifecycle contract V1
-- Explicit operator decision pending (no awaiting/closeout/successor recorded in this slice)
+- Lane status: `LANE_CLOSED_NO_FURTHER_RESEARCH` under shared lifecycle contract V1
+- Explicit operator decision recorded: `CLOSE_LANE_NO_FURTHER_RESEARCH`
 - Lifecycle authority (sole): `CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1`
 - Auto-close: forbidden (`lane_auto_closed=false`)
 - Explicit waiting: `explicit_waiting_decision=false`
-- Explicit closeout: `explicit_closeout_decision=false` (lane is **not** closed)
+- Explicit closeout: `explicit_closeout_decision=true` (lane **is** closed)
 - Preregistered: none (`preregistered_count_exact=0`)
+- Open unpreregistered candidates: empty
 - Terminal: V1&#47;V2&#47;V7 `INCONCLUSIVE_INFRASTRUCTURE_FAILURE`; V3&#47;V6 `FAIL`; V4&#47;V5 `INFRASTRUCTURE_FAILURE`; V8 `TERMINAL_PASS`
-- Holdout V1 terminal FAIL: `RESULT_CLASS=FAIL`; `REASON=NET_PROFIT_FACTOR_NOT_IMPROVED`; `HOLDOUT_RUN_COUNT=1`; evidence under `docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/`
+- Holdout V1 terminal FAIL (final): `RESULT_CLASS=FAIL`; `REASON=NET_PROFIT_FACTOR_NOT_IMPROVED`; `HOLDOUT_RUN_COUNT=1`; `RUNNER_START_COUNT=1`; `RETRY_ALLOWED=false`; `RUN_SLOT_CONSUMED=true`; evidence under `docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/`
+- Control net PF (immutable evidence): `0.5774036019332512` (reported as `0.577404`)
+- Treatment net PF (immutable evidence): `0.5280135615083571` (reported as `0.528014`)
 - V7 remains terminal unreopened: `RESULT_CLASS=INCONCLUSIVE_INFRASTRUCTURE_FAILURE`; `FAILURE_CLASS=FROZEN_EXIT_PARAMETERS_MISMATCH`; `FAILURE_TIMING=BEFORE_PANEL_ACCESS`
 - V8 terminal PASS: `RESULT_CLASS=PASS`; `DECISION_REASON=ALL_PASS_REQUIRES_MET`; `EVALUATION_RUN_COUNT=1`; `RUN_SLOT_CONSUMED=true`; `RERUN_ALLOWED=false`; `V8_REOPEN_ALLOWED=false`
 - V8 digest: `610460038f56bddda426f4169876a4ead00c186d1601256174033b4e4fca0a0c` (immutable)
 - V8 panel digest: `4a1978fe0e69a6cd7b19b32f5f95882cfdc3e36397aaec87bce2c4139ab1cfca`
 - Development run count: `8`
-- No V8&#47;V7&#47;V6&#47;V5&#47;V4&#47;V3&#47;V2&#47;V1 rerun. No V7&#47;V8 reopen. No V9 auto-create. No second holdout run. No runtime promotion from DEVELOPMENT PASS.
-- `NEXT_CANONICAL_ACTION=REVIEW_TERMINAL_HOLDOUT_FAIL_NO_RETRY`
+- No V8&#47;V7&#47;V6&#47;V5&#47;V4&#47;V3&#47;V2&#47;V1 rerun. No V7&#47;V8 reopen. No V9 auto-create. No second holdout run. No runtime promotion from DEVELOPMENT PASS. No successor synthesis from attribution candidates.
+- `NEXT_CANONICAL_ACTION=LANE_CLOSED_NO_FURTHER_RESEARCH_NO_EXECUTABLE_GO`
 - Economic&#47;promotion gates closed. No runtime&#47;orders.
 
 ---
 docs_token: DOCS_TOKEN_CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1
-STATUS: POST_TERMINAL_OPERATOR_DECISION_REQUIRED_AFTER_HOLDOUT_V1_TERMINAL_FAIL
+STATUS: LANE_CLOSED_NO_FURTHER_RESEARCH_AFTER_EXPLICIT_OPERATOR_CLOSEOUT_AFTER_HOLDOUT_V1_TERMINAL_FAIL
 scope: research, offline-only, non-authorizing, terminal-governance
 LIVE_AUTHORIZED: false
 ORDERS_ALLOWED: false
@@ -31,16 +34,25 @@ SCHEDULER_RUNTIME_ALLOWED: false
 
 ## Status
 
-`POST_TERMINAL_OPERATOR_DECISION_REQUIRED` — after the single authorized holdout
-successor terminated as `FAIL` / `NET_PROFIT_FACTOR_NOT_IMPROVED`, inventories are
-empty and no explicit awaiting, closeout, or successor-creation decision is
-recorded yet. Auto-close is forbidden.
+`LANE_CLOSED_NO_FURTHER_RESEARCH` — after the single authorized holdout
+successor terminated as `FAIL` / `NET_PROFIT_FACTOR_NOT_IMPROVED`, the lane
+first entered the historical holding state
+`POST_TERMINAL_OPERATOR_DECISION_REQUIRED` with empty inventories. No eligible
+independent successor existed in the canonical backlog. The operator then
+recorded an explicit `CLOSE_LANE_NO_FURTHER_RESEARCH` decision. Auto-close
+remains forbidden. `DECLARE_AWAITING_EXPLICIT_SUCCESSOR_HYPOTHESIS` /
+`AWAITING_EXPLICIT_SUCCESSOR_HYPOTHESIS` were not selected.
 
 Lane-status vocabulary and post-terminal legality are owned solely by
 `CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1`.
 `OPEN_BACKLOG` is invalid for this empty-inventory posture.
 The non-canonical cross-lane label `CLOSED_NO_OPEN_CANDIDATES` remains removed; the
 sibling Entry Eligibility status mirror uses the canonical lifecycle status only.
+
+Reopening requires `REOPEN_CLOSED_LANE_WITH_NEW_HYPOTHESIS_IDENTITY` under a
+future, separately governed authority contract with a new explicit hypothesis
+identity and mechanism. GO alone is never executable. No automatic successor
+generation is permitted.
 
 ## Binding
 
@@ -162,6 +174,11 @@ Exactly eight:
 - No V9 auto-create
 - No parallel SHORT-side hypothesis
 - No second HOLDOUT_V1 run &#47; no retry after holdout FAIL
+- No post-result tuning after holdout
+- No successor synthesis from attribution candidates
+- No implicit successor after close
+- No auto-reopen
+- No reopen without new hypothesis identity
 - No cost-structure-weakening hypothesis
 - No entry-eligibility reopen
 - No lane auto-close
@@ -170,21 +187,18 @@ Exactly eight:
 
 ## Next separate action
 
-`NEXT_CANONICAL_ACTION=REVIEW_TERMINAL_HOLDOUT_FAIL_NO_RETRY`
+`NEXT_CANONICAL_ACTION=LANE_CLOSED_NO_FURTHER_RESEARCH_NO_EXECUTABLE_GO`
 
-Lane is in `POST_TERMINAL_OPERATOR_DECISION_REQUIRED`. Enumerated further
-operator decisions from this state (shared contract):
-
-- `CREATE_SUCCESSOR_HYPOTHESIS` (requires explicit `hypothesis_id` + mechanism)
-- `DECLARE_AWAITING_EXPLICIT_SUCCESSOR_HYPOTHESIS` (requires explicit waiting decision; transitions toward `AWAITING_EXPLICIT_SUCCESSOR_HYPOTHESIS`)
-- `CLOSE_LANE_NO_FURTHER_RESEARCH` (requires explicit closeout decision)
-
-GO alone is never executable without a concrete target. Awaiting authorizes
-neither V9, nor holdout, nor runtime&#47;orders.
+Lane is intentionally closed with no further Exit-Efficiency research.
+Reopening requires `REOPEN_CLOSED_LANE_WITH_NEW_HYPOTHESIS_IDENTITY` with a new
+explicit hypothesis identity and mechanism under a future separately governed
+authority contract. GO alone is never executable. Awaiting&#47;create-successor
+paths are not active after this closeout.
 
 No V8 rerun. No V8 reopen. No holdout. No runtime&#47;orders. No V9 auto-create.
+No successor invention from this governance slice.
 
-## V8 terminal evaluation closeout (not lane closeout)
+## V8 terminal evaluation closeout (not lane closeout historically)
 
 V8 DEVELOPMENT evaluation consumed its one-shot slot and terminated as `PASS`
 (`DECISION_REASON=ALL_PASS_REQUIRES_MET`) on the sealed DEVELOPMENT_ONLY panel.
@@ -195,4 +209,6 @@ No V9 auto-create.
 Historical V8 economic, evaluation, run-slot, and preregistration artifacts
 remain immutable, including digest
 `610460038f56bddda426f4169876a4ead00c186d1601256174033b4e4fca0a0c`.
-Evaluation closeout is not `CLOSE_LANE_NO_FURTHER_RESEARCH`.
+Evaluation closeout was not itself `CLOSE_LANE_NO_FURTHER_RESEARCH`; the lane
+closeout recorded in this SSOT is the later explicit operator decision after
+holdout V1 terminal FAIL with empty inventory and no eligible successor.

--- a/src/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py
+++ b/src/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py
@@ -3,9 +3,10 @@
 Definition-only governance. No evaluation, backtest, holdout access, runtime
 activation, or productive trading-logic mutation.
 
-Post V8 terminal PASS closeout: zero DEFINITION_ONLY_PREREGISTERED candidates;
-V1-V8 terminal (V8 PASS after one authorized DEVELOPMENT evaluation);
-development_run_count=8; no V8 rerun/reopen; no V9 auto-create; economic/promotion closed.
+Post holdout V1 terminal FAIL + explicit operator CLOSE_LANE_NO_FURTHER_RESEARCH:
+zero DEFINITION_ONLY_PREREGISTERED candidates; empty open inventory;
+V1-V8 terminal (V8 DEVELOPMENT PASS; HOLDOUT_V1 FAIL once); development_run_count=8;
+no V8/V7 rerun/reopen; no V9 auto-create; no successor synthesis; economic/promotion closed.
 
 Lane status vocabulary and post-terminal legality are owned solely by
 CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1.
@@ -28,8 +29,9 @@ from src.research.canonical_research_lane_post_terminal_lifecycle_contract_v1 im
 PACKAGE_MARKER = "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1=true"
 BACKLOG_REL_PATH = "config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json"
 GOVERNANCE_REL_PATH = "docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md"
-REQUIRED_STATUS = "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
-REQUIRED_OPERATOR_DECISION = "CREATE_SUCCESSOR_HYPOTHESIS"
+REQUIRED_STATUS = "LANE_CLOSED_NO_FURTHER_RESEARCH"
+REQUIRED_OPERATOR_DECISION = "CLOSE_LANE_NO_FURTHER_RESEARCH"
+REQUIRED_NEXT_CANONICAL_STEP = "LANE_CLOSED_NO_FURTHER_RESEARCH_NO_EXECUTABLE_GO"
 REQUIRED_LIFECYCLE_AUTHORITY = "SHARED_POST_TERMINAL_LIFECYCLE_CONTRACT_V1_SOLE_AUTHORITY"
 ENTRY_ELIGIBILITY_BACKLOG_REL_PATH = (
     "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json"
@@ -114,8 +116,9 @@ REQUIRED_TERMINAL_FAIL_STATUS = "TERMINAL_FAIL"
 REQUIRED_TERMINAL_INFRA_STATUS = "TERMINAL_INFRASTRUCTURE_FAILURE"
 REQUIRED_TERMINAL_PASS_STATUS = "TERMINAL_PASS"
 REQUIRED_V7_NEXT_STEP = "REVIEW_AND_MERGE_DEFINITION_ONLY_HOLDOUT_PREREGISTRATION_THEN_SEPARATE_OPERATOR_GO_FOR_EXACTLY_ONE_HOLDOUT_RUN"
-REQUIRED_V8_NEXT_STEP = "REVIEW_TERMINAL_HOLDOUT_FAIL_NO_RETRY"
+REQUIRED_V8_NEXT_STEP = "LANE_CLOSED_NO_FURTHER_RESEARCH_NO_EXECUTABLE_GO"
 REQUIRED_AWAITING_NEXT_STEP = REQUIRED_V8_NEXT_STEP
+REQUIRED_CLOSED_NEXT_STEP = REQUIRED_NEXT_CANONICAL_STEP
 REQUIRED_PREREGISTERED_STATUS = "DEFINITION_ONLY_HOLDOUT_PREREGISTERED"
 REQUIRED_HOLDOUT_TERMINAL_STATUS = "HOLDOUT_EVALUATION_EXECUTED_TERMINAL"
 REQUIRED_HOLDOUT_TERMINAL_RESULT_CLASS = "FAIL"
@@ -123,7 +126,7 @@ REQUIRED_HOLDOUT_TERMINAL_REASON = "NET_PROFIT_FACTOR_NOT_IMPROVED"
 REQUIRED_HOLDOUT_EVALUATION_EVIDENCE_REF = (
     "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/"
 )
-REQUIRED_BACKLOG_VERDICT_AFTER_HOLDOUT_TERMINAL = "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_POST_TERMINAL_OPERATOR_DECISION_REQUIRED_AFTER_HOLDOUT_V1_TERMINAL_FAIL"
+REQUIRED_BACKLOG_VERDICT_AFTER_HOLDOUT_TERMINAL = "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_LANE_CLOSED_NO_FURTHER_RESEARCH_AFTER_EXPLICIT_OPERATOR_CLOSEOUT_AFTER_HOLDOUT_V1_TERMINAL_FAIL"
 REQUIRED_V7_DIAGNOSTIC_CLASS = "PRE_PANEL_FROZEN_EXIT_PARAMETERS_MISMATCH_NO_PANEL_BACKTEST"
 REQUIRED_V8_DECISION_REASON = "ALL_PASS_REQUIRES_MET"
 REQUIRED_V8_LIFECYCLE_TERMINAL = "DEVELOPMENT_EVALUATION_EXECUTED_TERMINAL/PASS"
@@ -276,7 +279,7 @@ def _assert_terminal_infrastructure_entry(
 def validate_backlog_contract(backlog: Mapping[str, Any]) -> dict[str, Any]:
     _assert_true(
         backlog.get("status") == REQUIRED_STATUS,
-        "STATUS_NOT_POST_TERMINAL_OPERATOR_DECISION_REQUIRED",
+        "STATUS_NOT_LANE_CLOSED_NO_FURTHER_RESEARCH",
     )
     _assert_true(
         backlog.get("lifecycle_contract_id") == LIFECYCLE_CONTRACT_ID,
@@ -290,9 +293,13 @@ def validate_backlog_contract(backlog: Mapping[str, Any]) -> dict[str, Any]:
         backlog.get("lifecycle_authority") == REQUIRED_LIFECYCLE_AUTHORITY,
         "LIFECYCLE_AUTHORITY_MISMATCH",
     )
-    _assert_true(backlog.get("explicit_closeout_decision") is False, "UNEXPECTED_CLOSEOUT_DECISION")
+    _assert_true(backlog.get("explicit_closeout_decision") is True, "CLOSEOUT_DECISION_REQUIRED")
     _assert_true(backlog.get("explicit_waiting_decision") is False, "WAITING_DECISION_FORBIDDEN")
     _assert_true(backlog.get("lane_auto_closed") is False, "LANE_AUTO_CLOSED_FORBIDDEN")
+    _assert_true(
+        backlog.get("next_canonical_step") == REQUIRED_NEXT_CANONICAL_STEP,
+        "NEXT_CANONICAL_STEP_MISMATCH",
+    )
     _assert_true(
         backlog.get("entry_eligibility_lane_status") == REQUIRED_ENTRY_ELIGIBILITY_LANE_STATUS,
         "ENTRY_ELIGIBILITY_LANE_STATUS_NOT_CANONICAL",
@@ -417,7 +424,12 @@ def validate_backlog_contract(backlog: Mapping[str, Any]) -> dict[str, Any]:
     _assert_true(backlog.get("evaluation_authorized") is False, "TOP_EVAL_AUTHORIZED")
     _assert_true(
         backlog.get("next_canonical_step") == REQUIRED_V8_NEXT_STEP,
-        "NEXT_STEP_AFTER_HOLDOUT_TERMINAL",
+        "NEXT_STEP_AFTER_LANE_CLOSEOUT",
+    )
+    _assert_true(
+        "REVIEW_TERMINAL_HOLDOUT_FAIL_NO_RETRY"
+        not in str(backlog.get("next_canonical_step") or ""),
+        "STALE_POST_HOLDOUT_REVIEW_POINTER_FORBIDDEN",
     )
     _assert_true(
         backlog.get("verdict") == REQUIRED_BACKLOG_VERDICT_AFTER_HOLDOUT_TERMINAL,
@@ -684,6 +696,27 @@ def validate_backlog_contract(backlog: Mapping[str, Any]) -> dict[str, Any]:
     _assert_true("NO_V7_AUTO_CREATE" in non_actions, "NO_V7_AUTO_CREATE_REQUIRED")
     _assert_true("NO_V8_AUTO_CREATE" in non_actions, "NO_V8_AUTO_CREATE_REQUIRED")
     _assert_true("NO_V9_AUTO_CREATE" in non_actions, "NO_V9_AUTO_CREATE_REQUIRED")
+    _assert_true(
+        "NO_IMPLICIT_SUCCESSOR_AFTER_CLOSE" in non_actions,
+        "NO_IMPLICIT_SUCCESSOR_AFTER_CLOSE_REQUIRED",
+    )
+    _assert_true("NO_AUTO_REOPEN" in non_actions, "NO_AUTO_REOPEN_REQUIRED")
+    _assert_true(
+        "NO_REOPEN_WITHOUT_NEW_HYPOTHESIS_ID" in non_actions,
+        "NO_REOPEN_WITHOUT_NEW_HYPOTHESIS_ID_REQUIRED",
+    )
+    _assert_true(
+        "NO_SUCCESSOR_SYNTHESIS_FROM_ATTRIBUTION_CANDIDATES" in non_actions,
+        "NO_SUCCESSOR_SYNTHESIS_FROM_ATTRIBUTION_REQUIRED",
+    )
+    _assert_true(
+        "NO_RETRY_AFTER_HOLDOUT_FAIL" in non_actions,
+        "NO_RETRY_AFTER_HOLDOUT_FAIL_REQUIRED",
+    )
+    _assert_true(
+        "NO_POST_RESULT_TUNING_AFTER_HOLDOUT" in non_actions,
+        "NO_POST_RESULT_TUNING_AFTER_HOLDOUT_REQUIRED",
+    )
     _assert_true("NO_V6_AUTO_CREATE" not in non_actions, "NO_V6_AUTO_CREATE_MUST_BE_ABSENT")
     _assert_true("NO_V5_AUTO_CREATE" not in non_actions, "NO_V5_AUTO_CREATE_MUST_BE_ABSENT")
     _assert_true("NO_V3_ECONOMIC_RESULT_IMPORT" in non_actions, "NO_V3_ECON_IMPORT_REQUIRED")
@@ -717,7 +750,8 @@ def validate_backlog_contract(backlog: Mapping[str, Any]) -> dict[str, Any]:
         result_class="PASS",
         inventory_non_empty_flag=False,
     )
-    # Shared contract empty-inventory resolution remains the pre-decision holding state.
+    # Empty-inventory post-terminal resolution still yields the pre-decision holding
+    # state; the live lane has already executed CLOSE_LANE_NO_FURTHER_RESEARCH.
     _assert_true(
         resolved.get("next_state") == POST_TERMINAL_EMPTY_INVENTORY_STATE,
         "POST_TERMINAL_RESOLUTION_DRIFT",
@@ -729,7 +763,7 @@ def validate_backlog_contract(backlog: Mapping[str, Any]) -> dict[str, Any]:
     )
     _assert_true(
         REQUIRED_OPERATOR_DECISION in (resolved.get("allowed_operator_decisions") or []),
-        "CREATE_SUCCESSOR_NOT_IN_ALLOWED_DECISIONS",
+        "CLOSE_LANE_NOT_IN_ALLOWED_DECISIONS",
     )
 
     # Read-only sibling mirror: Entry Eligibility status under shared contract (no mutation).
@@ -790,9 +824,10 @@ def validate_backlog_contract(backlog: Mapping[str, Any]) -> dict[str, Any]:
         "valid": True,
         "status": REQUIRED_STATUS,
         "explicit_waiting_decision": False,
-        "explicit_closeout_decision": False,
+        "explicit_closeout_decision": True,
         "lane_auto_closed": False,
         "operator_decision": REQUIRED_OPERATOR_DECISION,
+        "next_canonical_step": REQUIRED_NEXT_CANONICAL_STEP,
         "lifecycle_contract_id": LIFECYCLE_CONTRACT_ID,
         "lifecycle_authority": REQUIRED_LIFECYCLE_AUTHORITY,
         "preregistered_count": 0,

--- a/tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_holdout_evaluation_v1.py
+++ b/tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_holdout_evaluation_v1.py
@@ -150,9 +150,11 @@ def test_canonical_lifecycle_vocabulary_excludes_invented_awaiting_label() -> No
     entry_bl = _load(
         REPO / "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json"
     )
-    assert exit_bl["status"] == "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+    assert exit_bl["status"] == "LANE_CLOSED_NO_FURTHER_RESEARCH"
+    assert exit_bl["explicit_closeout_decision"] is True
     assert entry_bl["status"] == REQUIRED_ENTRY_LANE_STATUS
     assert exit_bl["preregistered_hypotheses"] == []
+    assert exit_bl["open_unpreregistered_candidates"] == []
 
 
 def test_go_absent_blocks() -> None:
@@ -406,3 +408,53 @@ def test_evaluate_evidence_dir_present_and_run_count_one() -> None:
     assert summary["orders_sent"] is False
     assert (evaluate / ".holdout_run_consumed").is_file()
     assert (evaluate / ".holdout_runner_started").read_text(encoding="utf-8").strip() == "1"
+
+
+def test_lane_close_does_not_reenable_holdout_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Closed Exit lane still fail-closes holdout structural preflight (no re-run)."""
+    from src.research.bollinger_mr_midband_exit_reentry_cooldown_holdout_evaluation_v1 import (
+        structural_preflight_v1 as sp,
+    )
+
+    exit_bl = _load(
+        REPO / "config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json"
+    )
+    assert exit_bl["status"] == "LANE_CLOSED_NO_FURTHER_RESEARCH"
+    assert exit_bl["explicit_closeout_decision"] is True
+    assert exit_bl["preregistered_hypotheses"] == []
+    monkeypatch.setattr(sp, "git_head_sha", lambda repo: "f" * 40)
+    with pytest.raises(
+        HoldoutPreregistrationError,
+        match=(
+            "EXIT_LANE_STATUS_MISMATCH|PREREGISTERED_SUCCESSOR_COUNT_MUST_BE_1|"
+            "HOLDOUT_V1_RUN_ALREADY_CONSUMED|HOLDOUT_RUN_SLOT|SUCCESSOR_RUN_COUNT"
+        ),
+    ):
+        run_structural_preflight(
+            repo_root=REPO,
+            output_dir=tmp_path,
+            environ=_auth_env("f" * 40),
+            require_authorization=True,
+        )
+
+
+def test_holdout_terminal_evidence_invariants_unchanged_by_lane_closeout() -> None:
+    summary = _load(
+        REPO
+        / "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/summary.json"
+    )
+    assert summary["result_class"] == "FAIL"
+    assert summary["decision"]["reason"] == "NET_PROFIT_FACTOR_NOT_IMPROVED"
+    assert int(summary["holdout_run_count"]) == 1
+    assert int(summary["runner_start_count"]) == 1
+    assert summary["no_retry"] is True
+    assert abs(float(summary["baseline_metrics"]["net_profit_factor"]) - 0.5774036019332512) < 1e-12
+    assert (
+        abs(float(summary["treatment_metrics"]["net_profit_factor"]) - 0.5280135615083571) < 1e-12
+    )
+    contract = _load(CONTRACT_PATH)
+    assert contract["holdout_run_count"] == 1
+    assert contract["status"] == "HOLDOUT_EVALUATION_EXECUTED_TERMINAL"
+    assert contract["terminal_holdout_result_class"] == "FAIL"

--- a/tests/research/test_canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py
+++ b/tests/research/test_canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py
@@ -1,4 +1,4 @@
-"""Contract tests for canonical open MR exit-efficiency hypothesis backlog (V8 TERMINAL_PASS)."""
+"""Contract tests for canonical open MR exit-efficiency hypothesis backlog (lane closed)."""
 
 from __future__ import annotations
 
@@ -43,14 +43,15 @@ def test_exactly_one_exit_efficiency_backlog_ssot() -> None:
     assert GOVERNANCE_PATH.is_file()
 
 
-def test_repo_backlog_post_holdout_terminal_empty_inventory() -> None:
+def test_repo_backlog_lane_closed_after_holdout_terminal_empty_inventory() -> None:
     report = load_and_validate_repo_backlog(REPO)
     assert report["valid"] is True
-    assert report["status"] == "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+    assert report["status"] == "LANE_CLOSED_NO_FURTHER_RESEARCH"
     assert report["explicit_waiting_decision"] is False
-    assert report["explicit_closeout_decision"] is False
+    assert report["explicit_closeout_decision"] is True
     assert report["lane_auto_closed"] is False
-    assert report["operator_decision"] == "CREATE_SUCCESSOR_HYPOTHESIS"
+    assert report["operator_decision"] == "CLOSE_LANE_NO_FURTHER_RESEARCH"
+    assert report["next_canonical_step"] == "LANE_CLOSED_NO_FURTHER_RESEARCH_NO_EXECUTABLE_GO"
     assert report["lifecycle_contract_id"] == (
         "CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1"
     )
@@ -102,11 +103,11 @@ def test_empty_preregistered_after_holdout_terminal_and_v7_v8_shape() -> None:
     assert len(backlog["preregistered_hypotheses"]) == 0
     assert backlog["governance_rules"]["preregistered_count_exact"] == 0
     assert backlog["open_unpreregistered_candidates"] == []
-    assert backlog["status"] == "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+    assert backlog["status"] == "LANE_CLOSED_NO_FURTHER_RESEARCH"
     assert backlog["lifecycle_authority"] == (
         "SHARED_POST_TERMINAL_LIFECYCLE_CONTRACT_V1_SOLE_AUTHORITY"
     )
-    assert backlog["explicit_closeout_decision"] is False
+    assert backlog["explicit_closeout_decision"] is True
     assert backlog["explicit_waiting_decision"] is False
     assert backlog["lane_auto_closed"] is False
     assert backlog["entry_eligibility_lane_status"] == "LANE_CLOSED_NO_FURTHER_RESEARCH"
@@ -210,12 +211,18 @@ def test_empty_preregistered_after_holdout_terminal_and_v7_v8_shape() -> None:
     assert v8["v8_reopen_allowed"] is False
     assert v8["baseline_members_completed"] == "46/46"
     assert v8["treatment_members_completed"] == "46/46"
-    assert backlog["next_canonical_step"] == "REVIEW_TERMINAL_HOLDOUT_FAIL_NO_RETRY"
-    assert backlog["status"] == "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+    assert backlog["next_canonical_step"] == "LANE_CLOSED_NO_FURTHER_RESEARCH_NO_EXECUTABLE_GO"
+    assert backlog["status"] == "LANE_CLOSED_NO_FURTHER_RESEARCH"
     assert backlog["preregistered_hypotheses"] == []
+    assert backlog["open_unpreregistered_candidates"] == []
+    assert "NO_IMPLICIT_SUCCESSOR_AFTER_CLOSE" in backlog["explicit_non_actions"]
+    assert "NO_SUCCESSOR_SYNTHESIS_FROM_ATTRIBUTION_CANDIDATES" in backlog["explicit_non_actions"]
+    assert "NO_RETRY_AFTER_HOLDOUT_FAIL" in backlog["explicit_non_actions"]
     assert v8["holdout_executed"] is True
     assert v8["holdout_run_count"] == 1
+    assert v8["holdout_run_limit"] == 1
     assert v8["holdout_result_class"] == "FAIL"
+    assert v8["holdout_terminal_reason"] == "NET_PROFIT_FACTOR_NOT_IMPROVED"
     assert v8["development_preregistration_digest"] == (
         "610460038f56bddda426f4169876a4ead00c186d1601256174033b4e4fca0a0c"
     )
@@ -229,8 +236,6 @@ def test_governance_doc_mentions_v8_prereg_and_v7_terminal() -> None:
     text = (
         REPO / "docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md"
     ).read_text(encoding="utf-8")
-    assert "AWAITING_EXPLICIT_SUCCESSOR_HYPOTHESIS" in text
-    assert "DECLARE_AWAITING_EXPLICIT_SUCCESSOR_HYPOTHESIS" in text
     assert "CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1" in text
     assert "OPEN_BACKLOG` is invalid" in text or "OPEN_BACKLOG is invalid" in text
     assert "CLOSED_NO_OPEN_CANDIDATES" in text  # mentioned as removed/non-canonical
@@ -244,10 +249,18 @@ def test_governance_doc_mentions_v8_prereg_and_v7_terminal() -> None:
     assert "ALL_PASS_REQUIRES_MET" in text
     assert "FROZEN_EXIT_PARAMETERS_MISMATCH" in text
     assert "BEFORE_PANEL_ACCESS" in text
-    assert "REVIEW_TERMINAL_HOLDOUT_FAIL_NO_RETRY" in text
-    assert "POST_TERMINAL_OPERATOR_DECISION_REQUIRED" in text
-    assert "Evaluation closeout is not" in text or "not a lane closeout" in text.lower()
-    assert "neither V9" in text or "neither V9," in text or "authorizes neither V9" in text
+    assert "LANE_CLOSED_NO_FURTHER_RESEARCH" in text
+    assert "CLOSE_LANE_NO_FURTHER_RESEARCH" in text
+    assert "LANE_CLOSED_NO_FURTHER_RESEARCH_NO_EXECUTABLE_GO" in text
+    assert "REOPEN_CLOSED_LANE_WITH_NEW_HYPOTHESIS_IDENTITY" in text
+    assert "POST_TERMINAL_OPERATOR_DECISION_REQUIRED" in text  # historical holding state
+    assert "Evaluation closeout was not itself" in text or "not itself" in text.lower()
+    assert "No V9 auto-create" in text or "No V9" in text
+    assert (
+        "eligible independent successor" in text.lower().replace("\n", " ")
+        or "no eligible successor" in text.lower()
+    )
+    assert "Awaiting/create-successor" in text or "create-successor" in text
     assert "610460038f56bddda426f4169876a4ead00c186d1601256174033b4e4fca0a0c" in text
     assert "V5" in text or "v5" in text.lower()
     assert "V4" in text
@@ -265,7 +278,7 @@ def test_rejects_open_backlog_with_empty_inventory() -> None:
     bad["holdout_candidate_preregistered"] = False
     with pytest.raises(
         BacklogValidationError,
-        match="STATUS_NOT_POST_TERMINAL|LIFECYCLE_CONTRACT_REJECTED|OPEN_LANE_EMPTY",
+        match="STATUS_NOT_LANE_CLOSED|LIFECYCLE_CONTRACT_REJECTED|OPEN_LANE_EMPTY",
     ):
         validate_backlog_contract(bad)
 
@@ -294,11 +307,11 @@ def test_rejects_noncanonical_entry_eligibility_status_label() -> None:
         validate_backlog_contract(bad)
 
 
-def test_explicit_waiting_transition_invariants_and_v8_digest_immutable() -> None:
+def test_lane_closed_invariants_and_v8_digest_immutable() -> None:
     backlog = _load(BACKLOG_PATH)
-    assert backlog["status"] == "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+    assert backlog["status"] == "LANE_CLOSED_NO_FURTHER_RESEARCH"
     assert backlog["explicit_waiting_decision"] is False
-    assert backlog["explicit_closeout_decision"] is False
+    assert backlog["explicit_closeout_decision"] is True
     assert backlog["lane_auto_closed"] is False
     assert backlog["open_unpreregistered_candidates"] == []
     assert len(backlog["preregistered_hypotheses"]) == 0
@@ -306,20 +319,72 @@ def test_explicit_waiting_transition_invariants_and_v8_digest_immutable() -> Non
     assert backlog["runtime_policy"]["orders_allowed"] is False
     assert backlog["holdout_forbidden"] is True
     assert backlog["promotion_and_economic_gate_policy"]["promotion_eligible"] is False
+    assert backlog["promotion_and_economic_gate_policy"]["economic_gate_open"] is False
     by_id = {e["hypothesis_id"]: e for e in backlog["terminal_hypotheses"]}
     v8 = by_id[REQUIRED_V8_HYPOTHESIS_ID]
     assert v8["status"] == "TERMINAL_PASS"
     assert v8["development_preregistration_digest"] == (
         "610460038f56bddda426f4169876a4ead00c186d1601256174033b4e4fca0a0c"
     )
+    assert v8["holdout_result_class"] == "FAIL"
+    assert v8["holdout_terminal_reason"] == "NET_PROFIT_FACTOR_NOT_IMPROVED"
+    assert int(v8["holdout_run_count"]) == 1
+    assert int(v8["holdout_run_limit"]) == 1
     assert "NO_V9_AUTO_CREATE" in backlog["explicit_non_actions"]
     assert "NO_HOLDOUT_AFTER_PASS" not in backlog["explicit_non_actions"]
     assert "NO_HOLDOUT_OF_V8_DEVELOPMENT_IDENTITY" in backlog["explicit_non_actions"]
+    assert "NO_IMPLICIT_SUCCESSOR_AFTER_CLOSE" in backlog["explicit_non_actions"]
 
 
-def test_rejects_open_backlog_with_waiting_decision() -> None:
+def test_rejects_waiting_decision_while_closed() -> None:
     backlog = _load(BACKLOG_PATH)
     bad = copy.deepcopy(backlog)
     bad["explicit_waiting_decision"] = True
     with pytest.raises(BacklogValidationError, match="WAITING_DECISION_FORBIDDEN"):
+        validate_backlog_contract(bad)
+
+
+def test_rejects_missing_explicit_closeout_while_claiming_closed() -> None:
+    backlog = _load(BACKLOG_PATH)
+    bad = copy.deepcopy(backlog)
+    bad["explicit_closeout_decision"] = False
+    with pytest.raises(
+        BacklogValidationError,
+        match="CLOSEOUT_DECISION_REQUIRED|CLOSED_WITHOUT_EXPLICIT|LIFECYCLE_CONTRACT_REJECTED",
+    ):
+        validate_backlog_contract(bad)
+
+
+def test_rejects_synthesized_successor_inventory_while_closed() -> None:
+    backlog = _load(BACKLOG_PATH)
+    bad = copy.deepcopy(backlog)
+    bad["preregistered_hypotheses"] = [
+        {
+            "hypothesis_id": "SYNTHESIZED_EXIT_EFFICIENCY_SUCCESSOR_FORBIDDEN",
+            "status": "DEFINITION_ONLY_PREREGISTERED",
+            "treatment_type": "POST_ENTRY_EXIT_EFFICIENCY_MECHANISM",
+        }
+    ]
+    bad["governance_rules"] = dict(bad["governance_rules"])
+    bad["governance_rules"]["preregistered_count_exact"] = 1
+    with pytest.raises(
+        BacklogValidationError,
+        match=(
+            "PREREGISTERED_MUST_BE_EMPTY|PREREGISTERED_COUNT_RULE|"
+            "LIFECYCLE_INVENTORY|LIFECYCLE_CONTRACT_REJECTED"
+        ),
+    ):
+        validate_backlog_contract(bad)
+
+
+def test_rejects_post_terminal_holding_state_after_closeout() -> None:
+    backlog = _load(BACKLOG_PATH)
+    bad = copy.deepcopy(backlog)
+    bad["status"] = "POST_TERMINAL_OPERATOR_DECISION_REQUIRED"
+    bad["explicit_closeout_decision"] = False
+    bad["next_canonical_step"] = "REVIEW_TERMINAL_HOLDOUT_FAIL_NO_RETRY"
+    with pytest.raises(
+        BacklogValidationError,
+        match="STATUS_NOT_LANE_CLOSED|CLOSEOUT_DECISION_REQUIRED|NEXT_CANONICAL_STEP",
+    ):
         validate_backlog_contract(bad)


### PR DESCRIPTION
## Summary
- Records explicit operator decision `CLOSE_LANE_NO_FURTHER_RESEARCH` on the Exit Efficiency backlog SSOT after HOLDOUT_V1 terminal `FAIL` / `NET_PROFIT_FACTOR_NOT_IMPROVED`.
- Keeps inventories empty, preserves immutable holdout/V7/V8 terminals, and fail-closes retry/successor synthesis/holdout re-enablement.
- Definition-only governance sync across JSON SSOT, docs, validator, and contract tests. No evaluation, runner, or sealed-evidence mutation.

## Test plan
- [x] `ruff format --check` + `ruff check` on touched Python
- [x] focused pytest: exit backlog + holdout evaluation contract tests (32 passed)
- [x] docs token policy + docs reference targets
- [x] path-equivalent PR_BOUNDED_FULL timing proof (748 passed, ~48.6s)
- [ ] required GitHub CI checks terminal green

## Explicit non-goals
- No holdout panel access / no runner / no retry / no V7-V9 reopen or create
- No Entry-Eligibility mutation / no economic-promotion-runtime unlock
- Do not merge in this step


Made with [Cursor](https://cursor.com)