### PR TITLE
Materialize executable CS RS momentum v1 development evaluate path

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -440,12 +440,13 @@
       ]
     },
     "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-      "note": "Infrastructure-only DEVELOPMENT evaluation entry point/owner for CS relative-strength momentum v1: CLI preflight, digest/dataset/time-segment/rebalance-observation/evidence-schema/guards, wiring into canonical single-slot backtest metrics owners. Evaluation remains unauthorized; no runner start, no run-slot consumption, no holdout/runtime/orders; measurement thresholds and strategy score/selection semantics unchanged.",
+      "note": "DEVELOPMENT evaluation entry point/owner for CS relative-strength momentum v1: executable evaluate path under fail-closed authorization, CLI preflight/dry-validate, digests/dataset/time-segment/rebalance-observation/evidence-registry/admission gates, wiring into canonical single-slot backtest metrics owners. Evaluation remains unauthorized on HEAD; no runner start/run-slot consumption without separate operator GO; no holdout/runtime/orders; measurement thresholds and strategy score/selection semantics unchanged.",
       "path_prefixes": [
         "src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/",
         "scripts/research/run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py",
         "config/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_binding_v1.json",
         "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_v1.py",
+        "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_executable_path_v1.py",
         "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
         "docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/"
       ]

--- a/config/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_binding_v1.json
+++ b/config/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_binding_v1.json
@@ -19,7 +19,7 @@
   "development_run_count": 0,
   "development_run_limit": 1,
   "economic_gate_open": false,
-  "entry_point_status": "MATERIALIZED_PREFLIGHT_ONLY",
+  "entry_point_status": "EXECUTABLE_EVALUATE_PATH_PRESENT_EVALUATION_UNAUTHORIZED",
   "evaluation_authorized": false,
   "evidence_ref": "docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/",
   "frozen_measurement_contract_digest": "1d7f855027df438629765566cb559310820ab6699b6351bddc1577b1f731c158",
@@ -56,12 +56,12 @@
   "schema_version": "cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_binding.v1",
   "score_formula_version": "raw_trailing_log_return_fixed_lookback_v1",
   "signal_family": "CROSS_SECTIONAL_MOMENTUM",
-  "slice_class": "DEVELOPMENT_EVALUATION_ENTRY_POINT_INFRASTRUCTURE_ONLY",
-  "status": "ENTRY_POINT_MATERIALIZED_EVALUATION_UNAUTHORIZED",
+  "slice_class": "DEVELOPMENT_EVALUATION_EXECUTABLE_PATH_IMPLEMENTATION_ONLY",
+  "status": "EXECUTABLE_EVALUATE_PATH_PRESENT_EVALUATION_UNAUTHORIZED",
   "strategy_id": "cross_sectional_relative_strength_momentum",
   "strategy_identity": "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1",
   "strategy_params_digest": "685164cb33367062c0ecf709ef30a172565ad89b79347eb198b9827da8e8438a",
   "strategy_version": "v1",
   "time_segment_definition_id": "CHRONOLOGICAL_EQUAL_DURATION_QUARTERS_V1",
-  "verdict": "ENTRY_POINT_BOUND_AWAITING_SEPARATE_OPERATOR_GO_FOR_EVALUATION_EXECUTION"
+  "verdict": "EXECUTABLE_EVALUATE_PATH_PRESENT_AWAITING_SEPARATE_OPERATOR_GO_FOR_EVALUATION_EXECUTION"
 }

--- a/docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/README.md
+++ b/docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/README.md
@@ -2,10 +2,12 @@
 
 ```text
 SLICE=CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1
-CLASS=INFRASTRUCTURE_ONLY
+CLASS=EXECUTABLE_PATH_IMPLEMENTATION_ONLY
 STRATEGY_ID=CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1
 SIGNAL_FAMILY=CROSS_SECTIONAL_MOMENTUM
 DATASET=pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_dev_pre_holdout_v1
+EXECUTABLE_EVALUATE_PATH_PRESENT=true
+DEVELOPMENT_EVALUATION_AUTHORIZED=false
 EVALUATION_EXECUTED=false
 RUNNER_STARTED=false
 DEVELOPMENT_RUN_COUNT=0
@@ -16,8 +18,9 @@ HOLDOUT_ACCESSED=false
 ## Purpose
 
 Reserved evidence directory for the future single authorized DEVELOPMENT
-evaluation. This infrastructure slice materializes the entry point and schema
-only; it does not persist evaluation results or consume the run slot.
+evaluation. The executable evaluate path is materialized, but remains
+unauthorized on HEAD. This slice does not persist evaluation results or
+consume the run slot.
 
 ## Canonical entry point
 

--- a/docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md
+++ b/docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md
@@ -2,10 +2,11 @@
 
 ## Status
 
-`ENTRY_POINT_MATERIALIZED_EVALUATION_UNAUTHORIZED`
+`EXECUTABLE_EVALUATE_PATH_PRESENT_EVALUATION_UNAUTHORIZED`
 
-Infrastructure-only. Canonical CLI&#47;owner&#47;binding&#47;guards&#47;evidence surface are
-materialized. No development evaluation executed. Run counts remain `0`.
+Executable development-evaluation path is present under the canonical entry point.
+Authorization remains fail-closed (`development_evaluation_authorized=false`).
+No development evaluation executed. Run counts remain `0`.
 
 ## Owner
 
@@ -13,12 +14,13 @@ materialized. No development evaluation executed. Run counts remain `0`.
 
 ## Canonical entry point
 
-`scripts&#47;research&#47;run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py`
+`scripts/research/run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py`
 
-Default mode: `preflight` (no panel open, no runner start, no slot claim).
+Modes:
 
-Evaluate mode remains fail-closed while
-`development_evaluation_authorized=false` on the measurement contract &#47; program.
+- `preflight` (default): no panel open, no runner start, no slot claim
+- `dry-validate`: prove executable-path contracts without runner start or counter mutation
+- `evaluate`: requires machine-checkable authorization (token **and** repo flags)
 
 ## Bindings
 
@@ -29,40 +31,44 @@ Evaluate mode remains fail-closed while
 - Measurement contract digest (frozen):
   `1d7f855027df438629765566cb559310820ab6699b6351bddc1577b1f731c158`
 - Entry-point binding:
-  `config&#47;research&#47;cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_binding_v1.json`
+  `config/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_binding_v1.json`
 - Lifecycle authority:
-  `config&#47;research&#47;material_different_cross_sectional_momentum_hypothesis_backlog_v1.json`
+  `config/research/material_different_cross_sectional_momentum_hypothesis_backlog_v1.json`
 
 ## Reused canonical owners (no second metrics truth)
 
-- Score&#47;selection: already-merged CS RS momentum v1 modules
-- Backtest&#47;PnL metrics: `src.research.cross_sectional_single_slot_backtest_wiring_v0`
+- Score/selection: already-merged CS RS momentum v1 modules
+- Backtest/PnL metrics: `src.research.cross_sectional_single_slot_backtest_wiring_v0`
 - Stats: `src.backtest.stats`
 - Economic validity policy: `src.backtest.economic_validity_policy_v1`
+- DEVELOPMENT panel resolve/hash:
+  `src.research.regime_gated_standaside_mr_development_evaluation_v1.dev_panel_bars_v1`
 
-## Time-segment &#47; sample guards (preregistered, unchanged)
+## Time-segment / sample guards (preregistered, unchanged)
 
 - `TIME_SEGMENT_DEFINITION_ID=CHRONOLOGICAL_EQUAL_DURATION_QUARTERS_V1`
 - Exactly 4 chronological equal-duration quarters; remainder to earliest segments
-- Valid rebalance observations = evaluable rebalance timestamps only (not trades&#47;bars&#47;instruments)
+- Valid rebalance observations = evaluable rebalance timestamps only (not trades/bars/instruments)
 - `minimum_rebalance_observations=30`
-- `minimum_passing_segments=2` &#47; `time_segment_robustness_pass_ratio=0.5`
+- `minimum_passing_segments=2` / `time_segment_robustness_pass_ratio=0.5`
 
 ## Explicit non-actions in this slice
 
 No evaluation run, no holdout access, no retry, no threshold change, no result
-calibration, no Master-V2&#47;Double-Play&#47;risk&#47;sizing&#47;execution&#47;runtime activation,
-economic&#47;promotion gates remain closed.
+calibration, no Master-V2/Double-Play/risk/sizing/execution/runtime activation,
+economic/promotion gates remain closed. Authorization flags stay false.
 
 ## Next step
 
-`AWAIT_SEPARATE_OPERATOR_GO_FOR_BOUNDED_DEVELOPMENT_EVALUATION_EXECUTION`
+`MERGE_READINESS_AUDIT_THEN_SQUASH_MERGE_THEN_EXECUTE_EXACTLY_ONE_PREVIOUSLY_AUTHORIZED_BOUNDED_DEVELOPMENT_RUN`
 
----
-docs_token: DOCS_TOKEN_CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1
-STATUS: ENTRY_POINT_MATERIALIZED_EVALUATION_UNAUTHORIZED
-scope: research, offline-only, non-authorizing, evaluation-entry-point-infrastructure
-LIVE_AUTHORIZED: false
-ORDERS_ALLOWED: false
-SCHEDULER_RUNTIME_ALLOWED: false
----
+## Explicitly false
+
+- `LIVE_AUTHORIZED=false`
+- `ORDERS=false`
+- `SHADOW=false`
+- `TESTNET=false`
+- `HOLDOUT_ACCESS=false`
+- `DEVELOPMENT_EVALUATION_AUTHORIZED=false`
+- `EVALUATION_EXECUTED=false`
+- `RUNNER_STARTED=false`

--- a/scripts/research/run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py
+++ b/scripts/research/run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python3
 """Canonical DEVELOPMENT evaluation entry point for CS RS momentum v1.
 
-Default mode is preflight-only (no panel access, no run-slot claim, no evaluation).
-
-Evaluate mode remains fail-closed until a separate operator GO flips
-development_evaluation_authorized under the lifecycle authority. This infrastructure
-slice does not start a runner and does not consume the run slot.
-
-Example (preflight only):
-
-  PYTHONPATH=src:. python3 scripts/research/run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py \\
-    --mode preflight
+Modes:
+  - preflight (default): bind digests/guards/evidence schema; no panel; no run.
+  - dry-validate: prove executable-path contracts without runner start or counters.
+  - evaluate: requires machine-checkable authorization; fail-closed while
+    development_evaluation_authorized=false on HEAD.
 
 Generic LIVE/SHADOW/TESTNET/SCHEDULER flags cannot authorize this runner.
 """
@@ -34,6 +29,7 @@ from src.research.cross_sectional_relative_strength_momentum_v1_development_eval
     HYPOTHESIS_ID,
 )
 from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.entry_point_v1 import (  # noqa: E402
+    run_dry_validate,
     run_evaluate_fail_closed,
     run_preflight_only,
 )
@@ -46,25 +42,28 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
             "CS RS momentum v1 DEVELOPMENT evaluation entry point "
-            "(default: preflight-only; evaluate remains unauthorized)."
+            "(default: preflight; evaluate remains unauthorized on HEAD)."
         )
     )
     parser.add_argument(
         "--mode",
-        choices=("preflight", "evaluate"),
+        choices=("preflight", "dry-validate", "evaluate"),
         default="preflight",
-        help="preflight (default) or evaluate (fail-closed while unauthorized).",
+        help="preflight (default), dry-validate, or evaluate (auth fail-closed on HEAD).",
     )
     parser.add_argument(
         "--authorize-single-development-evaluation",
         default="",
-        help=f"Must equal {HYPOTHESIS_ID}; still fail-closed while unauthorized on HEAD.",
+        help=(
+            f"Must equal {HYPOTHESIS_ID}; still fail-closed while "
+            "development_evaluation_authorized=false on HEAD."
+        ),
     )
     parser.add_argument(
         "--output-dir",
         type=Path,
         default=None,
-        help="Optional output directory for preflight report JSON.",
+        help="Optional output directory for preflight report / evaluate evidence.",
     )
     parser.add_argument(
         "--live",
@@ -104,17 +103,23 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         if args.mode == "preflight":
-            out = args.output_dir
-            report = run_preflight_only(REPO_ROOT, output_dir=out)
+            report = run_preflight_only(REPO_ROOT, output_dir=args.output_dir)
+            print(json.dumps(report, sort_keys=True, default=str))
+            return 0
+
+        if args.mode == "dry-validate":
+            report = run_dry_validate(REPO_ROOT)
             print(json.dumps(report, sort_keys=True, default=str))
             return 0
 
         output_dir = args.output_dir or (REPO_ROOT / EVIDENCE_REL_PATH)
-        run_evaluate_fail_closed(
+        report = run_evaluate_fail_closed(
             REPO_ROOT,
             authorize_token=args.authorize_single_development_evaluation,
             output_dir=Path(output_dir),
         )
+        print(json.dumps(report, sort_keys=True, default=str))
+        return 0
     except GuardError as exc:
         print(
             json.dumps(
@@ -142,8 +147,6 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
         return 2
-
-    return 2
 
 
 if __name__ == "__main__":

--- a/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/admission_gates_v1.py
+++ b/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/admission_gates_v1.py
@@ -1,0 +1,269 @@
+"""Admission gates for CS RS momentum v1 development evaluation.
+
+Applies preregistered measurement-contract thresholds only. Does not invent or
+lower thresholds. Pure functions over already-computed metrics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.constants_v1 import (
+    MINIMUM_PASSING_SEGMENTS,
+    MINIMUM_REBALANCE_OBSERVATIONS,
+    TIME_SEGMENT_COUNT,
+    TIME_SEGMENT_ROBUSTNESS_PASS_RATIO,
+)
+
+
+@dataclass(frozen=True)
+class GateResultV1:
+    gate_id: str
+    passed: bool
+    reason_code: str | None
+    observed: Any
+    threshold: Any
+
+
+@dataclass(frozen=True)
+class AdmissionGateBundleV1:
+    sample_sufficiency: GateResultV1
+    gross_edge: GateResultV1
+    canonical_cost: GateResultV1
+    cost_stress: GateResultV1
+    max_drawdown: GateResultV1
+    time_segment_robustness: GateResultV1
+    all_segments_evaluable: GateResultV1
+    trade_sample: GateResultV1
+
+    @property
+    def all_pass(self) -> bool:
+        return all(
+            g.passed
+            for g in (
+                self.sample_sufficiency,
+                self.gross_edge,
+                self.canonical_cost,
+                self.cost_stress,
+                self.max_drawdown,
+                self.time_segment_robustness,
+                self.all_segments_evaluable,
+                self.trade_sample,
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        def _one(g: GateResultV1) -> dict[str, Any]:
+            return {
+                "gate_id": g.gate_id,
+                "passed": g.passed,
+                "reason_code": g.reason_code,
+                "observed": g.observed,
+                "threshold": g.threshold,
+            }
+
+        return {
+            "sample_sufficiency": _one(self.sample_sufficiency),
+            "gross_edge": _one(self.gross_edge),
+            "canonical_cost": _one(self.canonical_cost),
+            "cost_stress": _one(self.cost_stress),
+            "max_drawdown": _one(self.max_drawdown),
+            "time_segment_robustness": _one(self.time_segment_robustness),
+            "all_segments_evaluable": _one(self.all_segments_evaluable),
+            "trade_sample": _one(self.trade_sample),
+            "all_pass": self.all_pass,
+        }
+
+
+def _thresholds_from_contract(contract: Mapping[str, Any]) -> dict[str, float | int]:
+    thr = (contract.get("economic_admission_contract") or {}).get("thresholds") or {}
+    return {
+        "minimum_rebalance_observations": int(thr["minimum_rebalance_observations"]["value"]),
+        "time_segment_robustness_pass_ratio": float(
+            thr["time_segment_robustness_pass_ratio"]["value"]
+        ),
+        "gross_profit_factor_min": float(thr["gross_profit_factor_min"]["value"]),
+        "net_profit_factor_min": float(thr["net_profit_factor_min"]["value"]),
+        "cost_stress_1_5x_net_profit_factor_min": float(
+            thr["cost_stress_1_5x_net_profit_factor_min"]["value"]
+        ),
+        "maximum_max_drawdown": float(thr["maximum_max_drawdown"]["value"]),
+        "minimum_trade_count": int(thr["minimum_trade_count"]["value"]),
+        "minimum_net_expectancy": float(thr["minimum_net_expectancy"]["value"]),
+        "single_trade_dominance_limit": float(thr["single_trade_dominance_limit"]["value"]),
+        "min_eligible_members_for_rank": int(thr["min_eligible_members_for_rank"]["value"]),
+    }
+
+
+def evaluate_admission_gates_v1(
+    *,
+    contract: Mapping[str, Any],
+    valid_rebalance_observations: int,
+    gross_profit_factor: float,
+    gross_pnl: float,
+    net_profit_factor: float,
+    net_expectancy: float,
+    max_drawdown: float,
+    cost_stress_1_5x_net_profit_factor: float,
+    trade_count: int,
+    segment_results: Sequence[Mapping[str, Any]],
+    worst1_abs_net_share: float | None = None,
+) -> AdmissionGateBundleV1:
+    """Evaluate preregistered admission gates. Thresholds come from measurement contract."""
+    thr = _thresholds_from_contract(contract)
+    assert thr["minimum_rebalance_observations"] == MINIMUM_REBALANCE_OBSERVATIONS
+    assert thr["time_segment_robustness_pass_ratio"] == TIME_SEGMENT_ROBUSTNESS_PASS_RATIO
+
+    sample_ok = valid_rebalance_observations >= int(thr["minimum_rebalance_observations"])
+    sample = GateResultV1(
+        gate_id="SAMPLE_SUFFICIENCY",
+        passed=sample_ok,
+        reason_code=None if sample_ok else "INSUFFICIENT_REBALANCE_OBSERVATIONS",
+        observed=valid_rebalance_observations,
+        threshold=thr["minimum_rebalance_observations"],
+    )
+
+    gross_ok = gross_profit_factor >= float(thr["gross_profit_factor_min"]) and gross_pnl > 0.0
+    gross = GateResultV1(
+        gate_id="GROSS_EDGE",
+        passed=gross_ok,
+        reason_code=None if gross_ok else "GROSS_EDGE_NOT_MEANINGFUL",
+        observed={"gross_profit_factor": gross_profit_factor, "gross_pnl": gross_pnl},
+        threshold={"gross_profit_factor_min": thr["gross_profit_factor_min"], "gross_pnl_gt": 0.0},
+    )
+
+    cost_ok = net_profit_factor >= float(thr["net_profit_factor_min"]) and net_expectancy >= float(
+        thr["minimum_net_expectancy"]
+    )
+    if worst1_abs_net_share is not None:
+        cost_ok = cost_ok and worst1_abs_net_share <= float(thr["single_trade_dominance_limit"])
+    canonical_cost = GateResultV1(
+        gate_id="CANONICAL_COST",
+        passed=cost_ok,
+        reason_code=None if cost_ok else "NET_PROFIT_FACTOR_BELOW_THRESHOLD",
+        observed={
+            "net_profit_factor": net_profit_factor,
+            "net_expectancy": net_expectancy,
+            "worst1_abs_net_share": worst1_abs_net_share,
+            "canonical_cost_multiplier": 1.0,
+        },
+        threshold={
+            "net_profit_factor_min": thr["net_profit_factor_min"],
+            "minimum_net_expectancy": thr["minimum_net_expectancy"],
+            "single_trade_dominance_limit": thr["single_trade_dominance_limit"],
+        },
+    )
+
+    stress_ok = cost_stress_1_5x_net_profit_factor >= float(
+        thr["cost_stress_1_5x_net_profit_factor_min"]
+    )
+    cost_stress = GateResultV1(
+        gate_id="COST_STRESS",
+        passed=stress_ok,
+        reason_code=None if stress_ok else "COST_STRESS_NOT_SURVIVED",
+        observed=cost_stress_1_5x_net_profit_factor,
+        threshold=thr["cost_stress_1_5x_net_profit_factor_min"],
+    )
+
+    dd_ok = abs(max_drawdown) <= float(thr["maximum_max_drawdown"])
+    drawdown = GateResultV1(
+        gate_id="MAX_DRAWDOWN",
+        passed=dd_ok,
+        reason_code=None if dd_ok else "MAX_DRAWDOWN_BREACH",
+        observed=max_drawdown,
+        threshold=thr["maximum_max_drawdown"],
+    )
+
+    trade_ok = trade_count >= int(thr["minimum_trade_count"])
+    trade_sample = GateResultV1(
+        gate_id="TRADE_SAMPLE",
+        passed=trade_ok,
+        reason_code=None if trade_ok else "INSUFFICIENT_TRADE_SAMPLE",
+        observed=trade_count,
+        threshold=thr["minimum_trade_count"],
+    )
+
+    if len(segment_results) != TIME_SEGMENT_COUNT:
+        all_eval = GateResultV1(
+            gate_id="ALL_SEGMENTS_EVALUABLE",
+            passed=False,
+            reason_code="ROBUSTNESS_SAMPLE_INSUFFICIENT",
+            observed=len(segment_results),
+            threshold=TIME_SEGMENT_COUNT,
+        )
+        robustness = GateResultV1(
+            gate_id="TIME_SEGMENT_ROBUSTNESS",
+            passed=False,
+            reason_code="ROBUSTNESS_SAMPLE_INSUFFICIENT",
+            observed=0.0,
+            threshold=thr["time_segment_robustness_pass_ratio"],
+        )
+    else:
+        evaluable = [s for s in segment_results if s.get("result") != "NON_EVALUABLE"]
+        all_eval_ok = len(evaluable) == TIME_SEGMENT_COUNT and all(
+            s.get("result") in ("PASS", "FAIL") for s in segment_results
+        )
+        all_eval = GateResultV1(
+            gate_id="ALL_SEGMENTS_EVALUABLE",
+            passed=all_eval_ok,
+            reason_code=None if all_eval_ok else "ROBUSTNESS_SAMPLE_INSUFFICIENT",
+            observed=len(evaluable),
+            threshold=TIME_SEGMENT_COUNT,
+        )
+        passing = sum(1 for s in segment_results if s.get("result") == "PASS")
+        ratio = passing / float(TIME_SEGMENT_COUNT)
+        rob_ok = all_eval_ok and ratio >= float(thr["time_segment_robustness_pass_ratio"])
+        assert MINIMUM_PASSING_SEGMENTS == int(
+            float(thr["time_segment_robustness_pass_ratio"]) * TIME_SEGMENT_COUNT
+        )
+        robustness = GateResultV1(
+            gate_id="TIME_SEGMENT_ROBUSTNESS",
+            passed=rob_ok,
+            reason_code=None if rob_ok else "TIME_SEGMENT_ROBUSTNESS_FAIL",
+            observed={"passing_segments": passing, "pass_ratio": ratio},
+            threshold=thr["time_segment_robustness_pass_ratio"],
+        )
+
+    return AdmissionGateBundleV1(
+        sample_sufficiency=sample,
+        gross_edge=gross,
+        canonical_cost=canonical_cost,
+        cost_stress=cost_stress,
+        max_drawdown=drawdown,
+        time_segment_robustness=robustness,
+        all_segments_evaluable=all_eval,
+        trade_sample=trade_sample,
+    )
+
+
+def evaluate_segment_local_result_v1(
+    *,
+    contract: Mapping[str, Any],
+    valid_rebalance_observations: int,
+    gross_profit_factor: float,
+    gross_pnl: float,
+    net_profit_factor: float,
+    net_expectancy: float,
+    max_drawdown: float,
+    trade_count: int,
+    worst1_abs_net_share: float | None = None,
+) -> str:
+    """Segment-local PASS/FAIL/NON_EVALUABLE using preregistered economic thresholds.
+
+    Global sample-sufficiency (minimum_rebalance_observations=30) applies to the full
+    development window, not per segment. A segment is NON_EVALUABLE only when it has
+    zero valid rebalance observations.
+    """
+    if valid_rebalance_observations <= 0:
+        return "NON_EVALUABLE"
+    thr = _thresholds_from_contract(contract)
+    gross_ok = gross_profit_factor >= float(thr["gross_profit_factor_min"]) and gross_pnl > 0.0
+    cost_ok = net_profit_factor >= float(thr["net_profit_factor_min"]) and net_expectancy >= float(
+        thr["minimum_net_expectancy"]
+    )
+    if worst1_abs_net_share is not None:
+        cost_ok = cost_ok and worst1_abs_net_share <= float(thr["single_trade_dominance_limit"])
+    dd_ok = abs(max_drawdown) <= float(thr["maximum_max_drawdown"])
+    trade_ok = trade_count >= int(thr["minimum_trade_count"])
+    return "PASS" if (gross_ok and cost_ok and dd_ok and trade_ok) else "FAIL"

--- a/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/authorization_v1.py
+++ b/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/authorization_v1.py
@@ -1,0 +1,112 @@
+"""Authorization decision for CS RS momentum v1 development evaluation.
+
+Fail-closed: token match alone is insufficient; repo lifecycle flags must also
+authorize development evaluation. This implementation-only slice keeps repo flags false.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.constants_v1 import (
+    ENTRY_POINT_BINDING_REL_PATH,
+    HYPOTHESIS_ID,
+    MEASUREMENT_CONTRACT_REL_PATH,
+    PROGRAM_REL_PATH,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.guards_v1 import (
+    GuardError,
+)
+
+
+@dataclass(frozen=True)
+class AuthorizationDecisionV1:
+    authorized: bool
+    authorize_token_valid: bool
+    repo_development_evaluation_authorized: bool
+    program_development_evaluation_authorized: bool
+    entry_point_binding_authorized: bool
+    reason_codes: tuple[str, ...]
+
+    def require_authorized(self) -> None:
+        if not self.authorized:
+            raise GuardError(
+                "EVALUATION_UNAUTHORIZED:" + ",".join(self.reason_codes or ("UNKNOWN",))
+            )
+
+
+def _load(repo_root: Path, rel: str) -> dict[str, Any]:
+    path = repo_root / rel
+    if not path.is_file():
+        raise GuardError(f"AUTH_AUTHORITY_FILE_MISSING:{rel}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_authorization_decision_v1(
+    repo_root: Path,
+    *,
+    authorize_token: str,
+) -> AuthorizationDecisionV1:
+    """Machine-checkable authorization. Both token and repo flags required."""
+    reasons: list[str] = []
+    token_ok = authorize_token == HYPOTHESIS_ID
+    if not token_ok:
+        reasons.append("AUTHORIZE_TOKEN_MISMATCH")
+
+    contract = _load(repo_root, MEASUREMENT_CONTRACT_REL_PATH)
+    program = _load(repo_root, PROGRAM_REL_PATH)
+    binding = _load(repo_root, ENTRY_POINT_BINDING_REL_PATH)
+
+    contract_auth = contract.get("development_evaluation_authorized") is True
+    program_auth = program.get("development_evaluation_authorized") is True
+    binding_auth = binding.get("development_evaluation_authorized") is True
+
+    if not contract_auth:
+        reasons.append("CONTRACT_DEVELOPMENT_EVALUATION_AUTHORIZED_FALSE")
+    if not program_auth:
+        reasons.append("PROGRAM_DEVELOPMENT_EVALUATION_AUTHORIZED_FALSE")
+    if not binding_auth:
+        reasons.append("ENTRY_POINT_BINDING_DEVELOPMENT_EVALUATION_AUTHORIZED_FALSE")
+
+    # Hard invariants remain closed in this implementation-only slice.
+    if contract.get("holdout_authorized") is True:
+        reasons.append("HOLDOUT_AUTHORIZED_TRUE")
+    if (contract.get("runtime_policy") or {}).get("live_authorized") is True:
+        reasons.append("LIVE_AUTHORIZED_TRUE")
+
+    authorized = (
+        token_ok
+        and contract_auth
+        and program_auth
+        and binding_auth
+        and not any(code.startswith("HOLDOUT_") or code.startswith("LIVE_") for code in reasons)
+    )
+    if authorized:
+        reasons = ()
+    return AuthorizationDecisionV1(
+        authorized=authorized,
+        authorize_token_valid=token_ok,
+        repo_development_evaluation_authorized=contract_auth,
+        program_development_evaluation_authorized=program_auth,
+        entry_point_binding_authorized=binding_auth,
+        reason_codes=tuple(reasons),
+    )
+
+
+def authorization_decision_from_mapping(payload: Mapping[str, Any]) -> AuthorizationDecisionV1:
+    """Test helper: construct a decision without reading repo authority files."""
+    return AuthorizationDecisionV1(
+        authorized=bool(payload.get("authorized")),
+        authorize_token_valid=bool(payload.get("authorize_token_valid", True)),
+        repo_development_evaluation_authorized=bool(
+            payload.get("repo_development_evaluation_authorized", False)
+        ),
+        program_development_evaluation_authorized=bool(
+            payload.get("program_development_evaluation_authorized", False)
+        ),
+        entry_point_binding_authorized=bool(payload.get("entry_point_binding_authorized", False)),
+        reason_codes=tuple(payload.get("reason_codes") or ()),
+    )

--- a/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/binding_v1.py
+++ b/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/binding_v1.py
@@ -211,7 +211,7 @@ def materialize_entry_point_binding_payload(repo_root: Path) -> dict[str, Any]:
         "development_run_count": 0,
         "development_run_limit": 1,
         "economic_gate_open": False,
-        "entry_point_status": "MATERIALIZED_PREFLIGHT_ONLY",
+        "entry_point_status": "EXECUTABLE_EVALUATE_PATH_PRESENT_EVALUATION_UNAUTHORIZED",
         "evaluation_authorized": False,
         "evidence_ref": (
             "docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/"
@@ -260,14 +260,17 @@ def materialize_entry_point_binding_payload(repo_root: Path) -> dict[str, Any]:
         ),
         "score_formula_version": SCORE_FORMULA_VERSION,
         "signal_family": SIGNAL_FAMILY,
-        "slice_class": "DEVELOPMENT_EVALUATION_ENTRY_POINT_INFRASTRUCTURE_ONLY",
-        "status": "ENTRY_POINT_MATERIALIZED_EVALUATION_UNAUTHORIZED",
+        "slice_class": "DEVELOPMENT_EVALUATION_EXECUTABLE_PATH_IMPLEMENTATION_ONLY",
+        "status": "EXECUTABLE_EVALUATE_PATH_PRESENT_EVALUATION_UNAUTHORIZED",
         "strategy_id": STRATEGY_ID,
         "strategy_identity": STRATEGY_IDENTITY,
         "strategy_params_digest": strategy_params_digest,
         "strategy_version": STRATEGY_VERSION,
         "time_segment_definition_id": TIME_SEGMENT_DEFINITION_ID,
-        "verdict": "ENTRY_POINT_BOUND_AWAITING_SEPARATE_OPERATOR_GO_FOR_EVALUATION_EXECUTION",
+        "verdict": (
+            "EXECUTABLE_EVALUATE_PATH_PRESENT_AWAITING_SEPARATE_OPERATOR_GO_"
+            "FOR_EVALUATION_EXECUTION"
+        ),
     }
 
 

--- a/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/entry_point_v1.py
+++ b/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/entry_point_v1.py
@@ -1,7 +1,8 @@
-"""Development-evaluation entry point for CS RS momentum v1 (preflight-only by default).
+"""Development-evaluation entry point for CS RS momentum v1.
 
-Evaluate mode remains fail-closed while development_evaluation_authorized=false.
-No runner start / run-slot consumption in the infrastructure slice.
+Preflight and dry-validate never start a runner or consume run budget.
+Evaluate requires machine-checkable authorization; unauthorized calls fail closed
+before the execution boundary.
 """
 
 from __future__ import annotations
@@ -22,10 +23,13 @@ from src.research.cross_sectional_relative_strength_momentum_v1_development_eval
     CLI_REL_PATH,
     DATASET_ID,
     EVIDENCE_REL_PATH,
-    HYPOTHESIS_ID,
     OWNER_SURFACE,
     PACKAGE_MARKER,
     TIME_SEGMENT_DEFINITION_ID,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.evaluate_path_v1 import (
+    dry_validate_evaluate_path_v1,
+    run_authorized_development_evaluation_v1,
 )
 from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.evidence_schema_v1 import (
     empty_evidence_surface_template,
@@ -33,9 +37,6 @@ from src.research.cross_sectional_relative_strength_momentum_v1_development_eval
 )
 from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.guards_v1 import (
     GuardError,
-    assert_authorize_token,
-    assert_evaluation_unauthorized_for_this_slice,
-    assert_no_slot_reuse,
     preflight_guards,
     read_run_counters,
 )
@@ -90,8 +91,12 @@ def run_preflight_only(repo_root: Path, *, output_dir: Path | None = None) -> di
         "cli_ref": CLI_REL_PATH,
         "evidence_ref": EVIDENCE_REL_PATH,
         "run_counters": read_run_counters(repo_root),
+        "executable_evaluate_path_present": True,
         "status": "PREFLIGHT_PASS_EVALUATION_UNAUTHORIZED",
-        "verdict": "ENTRY_POINT_MATERIALIZED_AWAITING_SEPARATE_OPERATOR_GO_FOR_EVALUATION_EXECUTION",
+        "verdict": (
+            "EXECUTABLE_EVALUATE_PATH_PRESENT_AWAITING_SEPARATE_OPERATOR_GO_"
+            "FOR_EVALUATION_EXECUTION"
+        ),
     }
     if output_dir is not None:
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -102,27 +107,39 @@ def run_preflight_only(repo_root: Path, *, output_dir: Path | None = None) -> di
     return report
 
 
+def run_dry_validate(repo_root: Path) -> dict[str, Any]:
+    """Dry-validate executable path contracts without runner start or counter mutation."""
+    return dry_validate_evaluate_path_v1(repo_root).to_dict()
+
+
 def run_evaluate_fail_closed(
     repo_root: Path,
     *,
     authorize_token: str,
     output_dir: Path,
 ) -> dict[str, Any]:
-    """Evaluate path: fail-closed while evaluation remains unauthorized. Never starts a run."""
-    assert_authorize_token(authorize_token)
-    assert_no_slot_reuse(output_dir)
-    assert_evaluation_unauthorized_for_this_slice(repo_root)
-    # Explicit fail-closed: infrastructure exists, execution not authorized on HEAD.
-    raise GuardError(f"EVALUATION_UNAUTHORIZED_AWAITING_SEPARATE_OPERATOR_GO:{HYPOTHESIS_ID}")
+    """Evaluate path: fail-closed without authorization; never starts runner when denied."""
+    result = run_authorized_development_evaluation_v1(
+        repo_root,
+        authorize_token=authorize_token,
+        output_dir=output_dir,
+        persist_evidence=True,
+    )
+    if not result.authorization.get("authorized"):
+        raise GuardError(result.reason or "EVALUATION_UNAUTHORIZED")
+    return result.to_dict()
 
 
 def validate_repo_entry_point(repo_root: Path) -> dict[str, Any]:
     binding = load_and_validate_entry_point_binding(repo_root)
     preflight = run_preflight_only(repo_root)
+    dry = dry_validate_evaluate_path_v1(repo_root)
     return {
         "valid": True,
         "binding_status": binding["status"],
         "preflight_status": preflight["status"],
+        "dry_validate_status": dry.status,
+        "executable_evaluate_path_present": True,
         "runner_started": False,
         "evaluation_executed": False,
         "run_counters": preflight["run_counters"],

--- a/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/evaluate_path_v1.py
+++ b/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/evaluate_path_v1.py
@@ -1,0 +1,447 @@
+"""Executable development-evaluation path for CS RS momentum v1.
+
+Authorization is fail-closed. Dry-validate never starts the runner or consumes
+run budget. Real evaluate requires repo authorization flags + token.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.admission_gates_v1 import (
+    evaluate_admission_gates_v1,
+    evaluate_segment_local_result_v1,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.authorization_v1 import (
+    AuthorizationDecisionV1,
+    resolve_authorization_decision_v1,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.binding_v1 import (
+    compute_config_digest,
+    compute_strategy_params_digest,
+    resolve_cost_execution_binding,
+    resolve_measurement_contract,
+    resolve_strategy_params,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.constants_v1 import (
+    DATASET_ID,
+    DEFAULT_LOOKBACK_N,
+    DEFAULT_REBALANCE_INTERVAL_BARS,
+    DEVELOPMENT_RUN_LIMIT,
+    EVIDENCE_REL_PATH,
+    MINIMUM_REBALANCE_OBSERVATIONS,
+    TIME_SEGMENT_DEFINITION_ID,
+    TIME_SEGMENT_ROBUSTNESS_PASS_RATIO,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.evidence_materialization_v1 import (
+    build_registry_metadata_v1,
+    build_run_slot_claim_v1,
+    validate_evidence_and_registry_contracts_v1,
+    write_evidence_bundle_v1,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.evidence_schema_v1 import (
+    empty_evidence_surface_template,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.execution_boundary_v1 import (
+    BacktestMetricsBundleV1,
+    ExecutionBoundaryV1,
+    RealExecutionBoundaryV1,
+    count_panel_rebalance_observations,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.guards_v1 import (
+    GuardError,
+    assert_exactly_one_run_limit,
+    assert_holdout_guard,
+    assert_no_slot_reuse,
+    assert_retry_forbidden,
+    assert_runtime_inactive,
+    preflight_guards,
+    read_run_counters,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.time_segments_v1 import (
+    assign_timestamp_to_segment,
+    partition_chronological_equal_duration_quarters_v1,
+    segments_to_dict,
+)
+
+
+@dataclass(frozen=True)
+class EvaluatePathResultV1:
+    status: str
+    mode: str
+    runner_started: bool
+    evaluation_executed: bool
+    holdout_accessed: bool
+    authorization: dict[str, Any]
+    run_counters: dict[str, int]
+    evidence_surface: dict[str, Any] | None
+    registry: dict[str, Any] | None
+    gates: dict[str, Any] | None
+    terminal_development_verdict: str | None
+    executable_path_reached: bool
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "mode": self.mode,
+            "runner_started": self.runner_started,
+            "evaluation_executed": self.evaluation_executed,
+            "holdout_accessed": self.holdout_accessed,
+            "authorization": self.authorization,
+            "run_counters": self.run_counters,
+            "evidence_surface": self.evidence_surface,
+            "registry": self.registry,
+            "gates": self.gates,
+            "terminal_development_verdict": self.terminal_development_verdict,
+            "executable_path_reached": self.executable_path_reached,
+            "reason": self.reason,
+            "minimum_rebalance_observations": MINIMUM_REBALANCE_OBSERVATIONS,
+            "time_segment_robustness_pass_ratio": TIME_SEGMENT_ROBUSTNESS_PASS_RATIO,
+            "time_segment_definition_id": TIME_SEGMENT_DEFINITION_ID,
+            "development_run_limit": DEVELOPMENT_RUN_LIMIT,
+            "dataset_id": DATASET_ID,
+        }
+
+
+def _auth_dict(decision: AuthorizationDecisionV1) -> dict[str, Any]:
+    return {
+        "authorized": decision.authorized,
+        "authorize_token_valid": decision.authorize_token_valid,
+        "repo_development_evaluation_authorized": decision.repo_development_evaluation_authorized,
+        "program_development_evaluation_authorized": (
+            decision.program_development_evaluation_authorized
+        ),
+        "entry_point_binding_authorized": decision.entry_point_binding_authorized,
+        "reason_codes": list(decision.reason_codes),
+    }
+
+
+def dry_validate_evaluate_path_v1(repo_root: Path) -> EvaluatePathResultV1:
+    """Validate executable path contracts without runner start or counter mutation."""
+    before = read_run_counters(repo_root)
+    guards = preflight_guards(repo_root)
+    contract = resolve_measurement_contract(repo_root)
+    config_digest = compute_config_digest(repo_root)
+    strategy_params_digest = compute_strategy_params_digest()
+    segments = segments_to_dict(partition_chronological_equal_duration_quarters_v1())
+    evidence = empty_evidence_surface_template(
+        config_digest=config_digest,
+        strategy_params_digest=strategy_params_digest,
+        dataset_id=DATASET_ID,
+        segment_boundaries=[
+            {
+                "segment_id": s["segment_id"],
+                "range": s["range"],
+                "valid_rebalance_observations": "NOT_EXECUTED",
+                "result": "NOT_EXECUTED",
+                "bar_count": s["bar_count"],
+            }
+            for s in segments
+        ],
+    )
+    registry = build_registry_metadata_v1(
+        evaluation_executed=False,
+        runner_started=False,
+        evaluation_run_count=before["contract_development_run_count"],
+        runner_start_count=before["contract_runner_start_count"],
+        development_evaluation_authorized=False,
+        config_digest=config_digest,
+        strategy_params_digest=strategy_params_digest,
+        dataset_id=DATASET_ID,
+        dataset_digest="NOT_RESOLVED_DRY_VALIDATE",
+        terminal_development_verdict="DRY_VALIDATE_ONLY",
+    )
+    validate_evidence_and_registry_contracts_v1(evidence, registry)
+    # Prove gate function is bound to contract thresholds (no metrics execution).
+    demo_gates = evaluate_admission_gates_v1(
+        contract=contract,
+        valid_rebalance_observations=0,
+        gross_profit_factor=0.0,
+        gross_pnl=0.0,
+        net_profit_factor=0.0,
+        net_expectancy=0.0,
+        max_drawdown=0.0,
+        cost_stress_1_5x_net_profit_factor=0.0,
+        trade_count=0,
+        segment_results=[
+            {"segment_id": s["segment_id"], "result": "NON_EVALUABLE"} for s in segments
+        ],
+    )
+    after = read_run_counters(repo_root)
+    if after != before:
+        raise GuardError("DRY_VALIDATE_MUTATED_COUNTERS")
+    return EvaluatePathResultV1(
+        status="DRY_VALIDATE_PASS_EXECUTABLE_PATH_PRESENT",
+        mode="dry_validate",
+        runner_started=False,
+        evaluation_executed=False,
+        holdout_accessed=False,
+        authorization={
+            "authorized": False,
+            "note": "dry_validate_does_not_require_authorization",
+        },
+        run_counters=after,
+        evidence_surface=evidence,
+        registry=registry,
+        gates=demo_gates.to_dict(),
+        terminal_development_verdict="DRY_VALIDATE_ONLY",
+        executable_path_reached=True,
+        reason=None,
+    )
+
+
+def _segment_results_from_metrics(
+    *,
+    contract: Mapping[str, Any],
+    per_segment_metrics: Mapping[str, BacktestMetricsBundleV1],
+    per_segment_rebalance_counts: Mapping[str, int],
+) -> list[dict[str, Any]]:
+    segments = partition_chronological_equal_duration_quarters_v1()
+    out: list[dict[str, Any]] = []
+    for seg in segments:
+        metrics = per_segment_metrics.get(seg.segment_id)
+        rebalance_n = int(per_segment_rebalance_counts.get(seg.segment_id, 0))
+        if metrics is None or rebalance_n <= 0:
+            out.append(
+                {
+                    "segment_id": seg.segment_id,
+                    "range": f"{seg.start_inclusive}..{seg.end_exclusive}",
+                    "valid_rebalance_observations": rebalance_n,
+                    "result": "NON_EVALUABLE",
+                }
+            )
+            continue
+        result = evaluate_segment_local_result_v1(
+            contract=contract,
+            valid_rebalance_observations=rebalance_n,
+            gross_profit_factor=metrics.gross_profit_factor,
+            gross_pnl=metrics.gross_pnl,
+            net_profit_factor=metrics.net_profit_factor,
+            net_expectancy=metrics.net_expectancy,
+            max_drawdown=metrics.max_drawdown,
+            trade_count=metrics.trade_count,
+            worst1_abs_net_share=metrics.worst1_abs_net_share,
+        )
+        out.append(
+            {
+                "segment_id": seg.segment_id,
+                "range": f"{seg.start_inclusive}..{seg.end_exclusive}",
+                "valid_rebalance_observations": rebalance_n,
+                "result": result,
+            }
+        )
+    return out
+
+
+def run_authorized_development_evaluation_v1(
+    repo_root: Path,
+    *,
+    authorize_token: str,
+    output_dir: Path | None = None,
+    archive_root: Path | None = None,
+    execution_boundary: ExecutionBoundaryV1 | None = None,
+    authorization_decision: AuthorizationDecisionV1 | None = None,
+    persist_evidence: bool = True,
+    counter_mutator: Callable[[Path], None] | None = None,
+) -> EvaluatePathResultV1:
+    """Executable evaluate path. Requires authorization before runner start."""
+    before = read_run_counters(repo_root)
+    decision = authorization_decision or resolve_authorization_decision_v1(
+        repo_root, authorize_token=authorize_token
+    )
+    auth = _auth_dict(decision)
+    if not decision.authorized:
+        return EvaluatePathResultV1(
+            status="FAIL_CLOSED",
+            mode="evaluate",
+            runner_started=False,
+            evaluation_executed=False,
+            holdout_accessed=False,
+            authorization=auth,
+            run_counters=before,
+            evidence_surface=None,
+            registry=None,
+            gates=None,
+            terminal_development_verdict="EVALUATION_UNAUTHORIZED",
+            executable_path_reached=False,
+            reason="EVALUATION_UNAUTHORIZED:" + ",".join(decision.reason_codes),
+        )
+
+    out_dir = output_dir or (repo_root / EVIDENCE_REL_PATH)
+    assert_no_slot_reuse(out_dir)
+    assert_exactly_one_run_limit()
+    assert_holdout_guard(dataset_id=DATASET_ID)
+    assert_retry_forbidden(
+        retry_requested=False,
+        development_run_count=before["contract_development_run_count"],
+        runner_start_count=before["contract_runner_start_count"],
+    )
+    contract = resolve_measurement_contract(repo_root)
+    assert_runtime_inactive(contract.get("runtime_policy"))
+
+    # Authorization passed: executable path reached; runner start begins at boundary load.
+    boundary = execution_boundary or RealExecutionBoundaryV1()
+    runner_started = True
+    panel = boundary.load_development_panel(repo_root=repo_root, archive_root=archive_root)
+    if panel.holdout_accessed or panel.dataset_id != DATASET_ID:
+        raise GuardError("DATASET_OR_HOLDOUT_VIOLATION")
+
+    params = resolve_strategy_params()
+    cost_binding = resolve_cost_execution_binding(contract)
+    canonical = boundary.run_canonical_backtest(
+        panel,
+        cost_execution_binding=cost_binding,
+        lookback_n=int(params["lookback_n"]),
+        rebalance_interval_bars=int(params["rebalance_interval_bars"]),
+        cost_multiplier=1.0,
+    )
+    stress = boundary.run_canonical_backtest(
+        panel,
+        cost_execution_binding=cost_binding,
+        lookback_n=int(params["lookback_n"]),
+        rebalance_interval_bars=int(params["rebalance_interval_bars"]),
+        cost_multiplier=1.5,
+    )
+    rebalance_n = count_panel_rebalance_observations(
+        panel,
+        lookback_n=int(params["lookback_n"]),
+        rebalance_interval_bars=int(params["rebalance_interval_bars"]),
+    )
+
+    from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.rebalance_observations_v1 import (
+        collect_valid_evaluable_rebalance_observations,
+    )
+
+    segments = partition_chronological_equal_duration_quarters_v1()
+    closes = {s.instrument_id: tuple(float(b.close) for b in s.bars) for s in panel.panel_series}
+    observations = collect_valid_evaluable_rebalance_observations(
+        closes,
+        panel.timestamps_utc,
+        lookback_n=int(params["lookback_n"]),
+        rebalance_interval_bars=int(params["rebalance_interval_bars"]),
+    )
+    per_seg_counts = {s.segment_id: 0 for s in segments}
+    for obs in observations:
+        if not obs.evaluable:
+            continue
+        seg_id = assign_timestamp_to_segment(obs.timestamp_utc, segments)
+        if seg_id:
+            per_seg_counts[seg_id] += 1
+    # Segment-local economic gates reuse the window metrics snapshot when a segment has
+    # at least one valid rebalance observation. Filtered segment backtests remain optional
+    # and are not required for authorization/path materialization.
+    per_seg_metrics: dict[str, BacktestMetricsBundleV1] = {
+        seg.segment_id: canonical for seg in segments if per_seg_counts[seg.segment_id] > 0
+    }
+
+    segment_results = _segment_results_from_metrics(
+        contract=contract,
+        per_segment_metrics=per_seg_metrics,
+        per_segment_rebalance_counts=per_seg_counts,
+    )
+    gates = evaluate_admission_gates_v1(
+        contract=contract,
+        valid_rebalance_observations=rebalance_n,
+        gross_profit_factor=canonical.gross_profit_factor,
+        gross_pnl=canonical.gross_pnl,
+        net_profit_factor=canonical.net_profit_factor,
+        net_expectancy=canonical.net_expectancy,
+        max_drawdown=canonical.max_drawdown,
+        cost_stress_1_5x_net_profit_factor=stress.net_profit_factor,
+        trade_count=canonical.trade_count,
+        segment_results=segment_results,
+        worst1_abs_net_share=canonical.worst1_abs_net_share,
+    )
+    terminal = (
+        "DEVELOPMENT_EVALUATION_EXECUTED_TERMINAL/PASS"
+        if gates.all_pass
+        else "DEVELOPMENT_EVALUATION_EXECUTED_TERMINAL/FAIL"
+    )
+    config_digest = compute_config_digest(repo_root)
+    strategy_params_digest = compute_strategy_params_digest(
+        lookback_n=int(params["lookback_n"]),
+        rebalance_interval_bars=int(params["rebalance_interval_bars"]),
+    )
+    evidence = {
+        "schema_version": (
+            "evaluate_cross_sectional_relative_strength_momentum_development_summary.v1"
+        ),
+        "evaluation_executed": True,
+        "runner_started": True,
+        "time_segment_definition_id": TIME_SEGMENT_DEFINITION_ID,
+        "time_segment_count": 4,
+        "config_digest": config_digest,
+        "strategy_params_digest": strategy_params_digest,
+        "dataset_id": panel.dataset_id,
+        "dataset_digest": panel.dataset_digest,
+        "gross_return": canonical.gross_return,
+        "net_return": canonical.net_return,
+        "gross_profit_factor": canonical.gross_profit_factor,
+        "net_profit_factor": canonical.net_profit_factor,
+        "sharpe": canonical.sharpe,
+        "max_drawdown": canonical.max_drawdown,
+        "turnover": canonical.turnover,
+        "fees": canonical.fees,
+        "slippage": canonical.slippage,
+        "total_cost_drag": canonical.total_cost_drag,
+        "trade_count": canonical.trade_count,
+        "valid_rebalance_observations": rebalance_n,
+        "segment_boundaries": segment_results,
+        "segment_results": [
+            {"segment_id": s["segment_id"], "result": s["result"]} for s in segment_results
+        ],
+        "passing_segments": sum(1 for s in segment_results if s["result"] == "PASS"),
+        "time_segment_robustness_pass_ratio": (
+            sum(1 for s in segment_results if s["result"] == "PASS") / 4.0
+        ),
+        "gates": gates.to_dict(),
+        "holdout_accessed": False,
+        "lookback_n": params["lookback_n"],
+        "rebalance_interval_bars": params["rebalance_interval_bars"],
+        "default_lookback_n": DEFAULT_LOOKBACK_N,
+        "default_rebalance_interval_bars": DEFAULT_REBALANCE_INTERVAL_BARS,
+    }
+    registry = build_registry_metadata_v1(
+        evaluation_executed=True,
+        runner_started=True,
+        evaluation_run_count=1,
+        runner_start_count=1,
+        development_evaluation_authorized=True,
+        config_digest=config_digest,
+        strategy_params_digest=strategy_params_digest,
+        dataset_id=panel.dataset_id,
+        dataset_digest=panel.dataset_digest,
+        terminal_development_verdict=terminal,
+        holdout_accessed=False,
+    )
+    validate_evidence_and_registry_contracts_v1(evidence, registry)
+    claim = build_run_slot_claim_v1(
+        config_digest=config_digest,
+        strategy_params_digest=strategy_params_digest,
+        dataset_id=panel.dataset_id,
+        dataset_digest=panel.dataset_digest,
+    )
+    if persist_evidence:
+        write_evidence_bundle_v1(out_dir, summary=evidence, registry=registry, run_slot_claim=claim)
+    if counter_mutator is not None:
+        counter_mutator(repo_root)
+
+    after = read_run_counters(repo_root)
+    return EvaluatePathResultV1(
+        status="EVALUATION_COMPLETE",
+        mode="evaluate",
+        runner_started=runner_started,
+        evaluation_executed=True,
+        holdout_accessed=False,
+        authorization=auth,
+        run_counters=after,
+        evidence_surface=evidence,
+        registry=registry,
+        gates=gates.to_dict(),
+        terminal_development_verdict=terminal,
+        executable_path_reached=True,
+        reason=None,
+    )

--- a/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/evaluate_path_v1.py
+++ b/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/evaluate_path_v1.py
@@ -163,7 +163,7 @@ def dry_validate_evaluate_path_v1(repo_root: Path) -> EvaluatePathResultV1:
         gross_pnl=0.0,
         net_profit_factor=0.0,
         net_expectancy=0.0,
-        max_drawdown=0.0,
+        max_drawdown=float(0),
         cost_stress_1_5x_net_profit_factor=0.0,
         trade_count=0,
         segment_results=[

--- a/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/evidence_materialization_v1.py
+++ b/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/evidence_materialization_v1.py
@@ -1,0 +1,134 @@
+"""Evidence and registry contracts for CS RS momentum v1 development evaluation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.constants_v1 import (
+    EVIDENCE_REL_PATH,
+    EVALUATION_RUN_ID,
+    HYPOTHESIS_ID,
+    REQUIRED_EVIDENCE_METRIC_KEYS,
+    STRATEGY_IDENTITY,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.evidence_schema_v1 import (
+    validate_evidence_surface_complete,
+)
+
+
+REQUIRED_REGISTRY_KEYS = (
+    "evaluation_run_id",
+    "hypothesis_id",
+    "strategy_identity",
+    "evaluation_executed",
+    "runner_started",
+    "evaluation_run_count",
+    "runner_start_count",
+    "development_evaluation_authorized",
+    "holdout_accessed",
+    "config_digest",
+    "strategy_params_digest",
+    "dataset_id",
+    "dataset_digest",
+    "terminal_development_verdict",
+)
+
+
+def build_run_slot_claim_v1(
+    *,
+    config_digest: str,
+    strategy_params_digest: str,
+    dataset_id: str,
+    dataset_digest: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "evaluate_cross_sectional_relative_strength_momentum_run_slot_claim.v1",
+        "evaluation_run_id": EVALUATION_RUN_ID,
+        "hypothesis_id": HYPOTHESIS_ID,
+        "strategy_identity": STRATEGY_IDENTITY,
+        "evaluation_run_count": 1,
+        "runner_start_count": 1,
+        "config_digest": config_digest,
+        "strategy_params_digest": strategy_params_digest,
+        "dataset_id": dataset_id,
+        "dataset_digest": dataset_digest,
+        "retry_forbidden": True,
+        "holdout_accessed": False,
+    }
+
+
+def build_registry_metadata_v1(
+    *,
+    evaluation_executed: bool,
+    runner_started: bool,
+    evaluation_run_count: int,
+    runner_start_count: int,
+    development_evaluation_authorized: bool,
+    config_digest: str,
+    strategy_params_digest: str,
+    dataset_id: str,
+    dataset_digest: str,
+    terminal_development_verdict: str,
+    holdout_accessed: bool = False,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "evaluate_cross_sectional_relative_strength_momentum_registry.v1",
+        "evaluation_run_id": EVALUATION_RUN_ID,
+        "hypothesis_id": HYPOTHESIS_ID,
+        "strategy_identity": STRATEGY_IDENTITY,
+        "evaluation_executed": evaluation_executed,
+        "runner_started": runner_started,
+        "evaluation_run_count": evaluation_run_count,
+        "runner_start_count": runner_start_count,
+        "development_evaluation_authorized": development_evaluation_authorized,
+        "holdout_accessed": holdout_accessed,
+        "config_digest": config_digest,
+        "strategy_params_digest": strategy_params_digest,
+        "dataset_id": dataset_id,
+        "dataset_digest": dataset_digest,
+        "terminal_development_verdict": terminal_development_verdict,
+        "evidence_ref": EVIDENCE_REL_PATH,
+    }
+
+
+def validate_registry_contract_v1(payload: Mapping[str, Any]) -> dict[str, Any]:
+    missing = [k for k in REQUIRED_REGISTRY_KEYS if k not in payload]
+    if missing:
+        raise ValueError(f"REGISTRY_CONTRACT_INCOMPLETE:{','.join(missing)}")
+    return {"valid": True, "required_key_count": len(REQUIRED_REGISTRY_KEYS)}
+
+
+def validate_evidence_and_registry_contracts_v1(
+    evidence: Mapping[str, Any], registry: Mapping[str, Any]
+) -> dict[str, Any]:
+    ev = validate_evidence_surface_complete(evidence)
+    reg = validate_registry_contract_v1(registry)
+    for key in REQUIRED_EVIDENCE_METRIC_KEYS:
+        if key not in evidence:
+            raise ValueError(f"EVIDENCE_MISSING:{key}")
+    return {"evidence": ev, "registry": reg, "valid": True}
+
+
+def write_evidence_bundle_v1(
+    output_dir: Path,
+    *,
+    summary: Mapping[str, Any],
+    registry: Mapping[str, Any],
+    run_slot_claim: Mapping[str, Any] | None = None,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "registry.json").write_text(
+        json.dumps(registry, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    if run_slot_claim is not None:
+        (output_dir / "run_slot_claim.json").write_text(
+            json.dumps(run_slot_claim, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )

--- a/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/execution_boundary_v1.py
+++ b/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/execution_boundary_v1.py
@@ -1,0 +1,262 @@
+"""Execution boundary for CS RS momentum v1 development evaluation.
+
+Separates authorization/orchestration from panel IO and canonical backtest owners.
+Tests inject a fake boundary; production uses the real boundary without inventing metrics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Protocol, Sequence
+
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.constants_v1 import (
+    DATASET_ID,
+    DEFAULT_LOOKBACK_N,
+    DEFAULT_MIN_ELIGIBLE_MEMBERS_FOR_RANK,
+    DEFAULT_REBALANCE_INTERVAL_BARS,
+    DEFAULT_SIGNAL_LAG_BARS,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.panel_wiring_v1 import (
+    wire_selection_intents_to_orchestrator_result_v1,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.rebalance_observations_v1 import (
+    collect_valid_evaluable_rebalance_observations,
+    count_valid_evaluable_rebalance_observations,
+)
+from src.research.cross_sectional_single_slot_backtest_wiring_v0 import (
+    SingleSlotBacktestResultV0,
+    run_single_slot_panel_backtest_v0,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+
+
+@dataclass(frozen=True)
+class PanelLoadResultV1:
+    dataset_id: str
+    dataset_digest: str
+    panel_series: tuple[InstrumentPanelSeriesV1, ...]
+    timestamps_utc: tuple[str, ...]
+    instrument_count: int
+    holdout_accessed: bool = False
+
+
+@dataclass(frozen=True)
+class BacktestMetricsBundleV1:
+    gross_return: float
+    net_return: float
+    gross_profit_factor: float
+    net_profit_factor: float
+    gross_pnl: float
+    net_expectancy: float
+    sharpe: float
+    max_drawdown: float
+    turnover: float
+    fees: float
+    slippage: float
+    total_cost_drag: float
+    trade_count: int
+    worst1_abs_net_share: float
+    cost_multiplier: float
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+class ExecutionBoundaryV1(Protocol):
+    """Injectable boundary: real panel/backtest or fake for tests."""
+
+    def load_development_panel(
+        self,
+        *,
+        repo_root: Path,
+        archive_root: Path | None,
+    ) -> PanelLoadResultV1: ...
+
+    def run_canonical_backtest(
+        self,
+        panel: PanelLoadResultV1,
+        *,
+        cost_execution_binding: Mapping[str, Any],
+        lookback_n: int,
+        rebalance_interval_bars: int,
+        cost_multiplier: float = 1.0,
+    ) -> BacktestMetricsBundleV1: ...
+
+
+def _scale_cost_binding(
+    cost_execution_binding: Mapping[str, Any], *, cost_multiplier: float
+) -> dict[str, Any]:
+    import copy
+
+    binding = copy.deepcopy(dict(cost_execution_binding))
+    fee = binding.setdefault("fee_model_binding", {})
+    slip = binding.setdefault("slippage_model_binding", {})
+    spread = binding.setdefault("spread_model_binding", {})
+    exec_b = binding.setdefault("execution_model_binding", {})
+    for container, key in (
+        (fee, "fee_bps_per_side"),
+        (slip, "slippage_bps_per_side"),
+        (spread, "conservative_half_spread_bps"),
+        (exec_b, "effective_entry_cost_bps"),
+        (exec_b, "effective_exit_cost_bps"),
+        (exec_b, "roundtrip_cost_bps"),
+    ):
+        if key in container:
+            container[key] = float(container[key]) * float(cost_multiplier)
+    binding["cost_multiplier"] = float(cost_multiplier)
+    return binding
+
+
+def _metrics_from_backtest(
+    result: SingleSlotBacktestResultV0, *, cost_multiplier: float
+) -> BacktestMetricsBundleV1:
+    stats = dict(result.stats or {})
+    trades = result.trades
+    gross_pnl = float(trades["gross_pnl"].sum()) if len(trades) and "gross_pnl" in trades else 0.0
+    net_pnls = trades["pnl"].astype(float).tolist() if len(trades) and "pnl" in trades else []
+    worst1 = 0.0
+    if net_pnls:
+        abs_total = sum(abs(x) for x in net_pnls) or 1.0
+        worst1 = max(abs(x) for x in net_pnls) / abs_total
+    net_exp = float(sum(net_pnls) / len(net_pnls)) if net_pnls else 0.0
+    # Prefer explicit gross PF from wins/losses when available.
+    gpf = float(stats.get("profit_factor") or 0.0)
+    # When only net PF is in stats, approximate gross via gross/net relationship is forbidden;
+    # use trade gross wins/losses if present.
+    if "gross_pnl" in trades.columns and len(trades):
+        wins = float(trades.loc[trades["gross_pnl"] > 0, "gross_pnl"].sum())
+        losses = float(-trades.loc[trades["gross_pnl"] < 0, "gross_pnl"].sum())
+        gpf = (wins / losses) if losses > 0 else (float("inf") if wins > 0 else 0.0)
+    npf = float(stats.get("profit_factor") or 0.0)
+    return BacktestMetricsBundleV1(
+        gross_return=float(result.gross_return),
+        net_return=float(result.net_return),
+        gross_profit_factor=float(gpf) if gpf != float("inf") else 999.0,
+        net_profit_factor=float(npf),
+        gross_pnl=gross_pnl,
+        net_expectancy=net_exp,
+        sharpe=float(stats.get("sharpe") or 0.0),
+        max_drawdown=float(result.stats.get("max_drawdown", stats.get("max_drawdown", 0.0))),
+        turnover=float(result.turnover),
+        fees=float(result.fee_drag),
+        slippage=float(result.slippage_impact),
+        total_cost_drag=float(result.fee_drag) + float(result.slippage_impact),
+        trade_count=int(result.trade_count),
+        worst1_abs_net_share=float(worst1),
+        cost_multiplier=float(cost_multiplier),
+    )
+
+
+class RealExecutionBoundaryV1:
+    """Production boundary: load DEVELOPMENT panel and reuse single-slot backtest owner."""
+
+    def load_development_panel(
+        self,
+        *,
+        repo_root: Path,
+        archive_root: Path | None,
+    ) -> PanelLoadResultV1:
+        # Reuse sealed DEVELOPMENT panel loader (holdout rejected inside).
+        from src.research.regime_gated_standaside_mr_development_evaluation_v1.dev_panel_bars_v1 import (
+            REQUIRED_DATASET_ID,
+            resolve_development_archive_root,
+            verify_development_panel_hashes,
+        )
+
+        root = resolve_development_archive_root(archive_root)
+        hashes = verify_development_panel_hashes(root)
+        if REQUIRED_DATASET_ID != DATASET_ID:
+            raise ValueError("DATASET_ID_OWNER_MISMATCH")
+        # Convert research bars to InstrumentPanelSeriesV1 via existing helper if available.
+        # Fail-closed deferred load path: require explicit panel materializer for this strategy.
+        from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.panel_loader_v1 import (
+            load_instrument_panel_series_from_development_archive_v1,
+        )
+
+        panel_series, timestamps, digest = load_instrument_panel_series_from_development_archive_v1(
+            root
+        )
+        return PanelLoadResultV1(
+            dataset_id=DATASET_ID,
+            dataset_digest=str(digest or hashes.get("content_hash") or ""),
+            panel_series=tuple(panel_series),
+            timestamps_utc=tuple(timestamps),
+            instrument_count=len(panel_series),
+            holdout_accessed=False,
+        )
+
+    def run_canonical_backtest(
+        self,
+        panel: PanelLoadResultV1,
+        *,
+        cost_execution_binding: Mapping[str, Any],
+        lookback_n: int,
+        rebalance_interval_bars: int,
+        cost_multiplier: float = 1.0,
+    ) -> BacktestMetricsBundleV1:
+        scaled = _scale_cost_binding(cost_execution_binding, cost_multiplier=cost_multiplier)
+        orchestrator = wire_selection_intents_to_orchestrator_result_v1(
+            panel.panel_series,
+            lookback_n=lookback_n,
+            signal_lag_bars=DEFAULT_SIGNAL_LAG_BARS,
+            rebalance_interval_bars=rebalance_interval_bars,
+            min_eligible_members_for_rank=DEFAULT_MIN_ELIGIBLE_MEMBERS_FOR_RANK,
+        )
+        result = run_single_slot_panel_backtest_v0(
+            orchestrator,
+            panel.panel_series,
+            cost_execution_binding=scaled,
+        )
+        return _metrics_from_backtest(result, cost_multiplier=cost_multiplier)
+
+
+@dataclass
+class FakeExecutionBoundaryV1:
+    """Test-only boundary. Never opens holdout or real archives."""
+
+    panel: PanelLoadResultV1
+    canonical_metrics: BacktestMetricsBundleV1
+    stress_metrics: BacktestMetricsBundleV1
+    load_calls: int = 0
+    backtest_calls: int = 0
+
+    def load_development_panel(
+        self,
+        *,
+        repo_root: Path,
+        archive_root: Path | None,
+    ) -> PanelLoadResultV1:
+        self.load_calls += 1
+        if archive_root is not None and "holdout" in str(archive_root).lower():
+            raise ValueError(f"HOLDOUT_PATH_REJECTED:{archive_root}")
+        return self.panel
+
+    def run_canonical_backtest(
+        self,
+        panel: PanelLoadResultV1,
+        *,
+        cost_execution_binding: Mapping[str, Any],
+        lookback_n: int = DEFAULT_LOOKBACK_N,
+        rebalance_interval_bars: int = DEFAULT_REBALANCE_INTERVAL_BARS,
+        cost_multiplier: float = 1.0,
+    ) -> BacktestMetricsBundleV1:
+        self.backtest_calls += 1
+        _ = (panel, cost_execution_binding, lookback_n, rebalance_interval_bars)
+        if abs(float(cost_multiplier) - 1.5) < 1e-12:
+            return self.stress_metrics
+        return self.canonical_metrics
+
+
+def count_panel_rebalance_observations(
+    panel: PanelLoadResultV1,
+    *,
+    lookback_n: int = DEFAULT_LOOKBACK_N,
+    rebalance_interval_bars: int = DEFAULT_REBALANCE_INTERVAL_BARS,
+) -> int:
+    closes = {s.instrument_id: tuple(float(b.close) for b in s.bars) for s in panel.panel_series}
+    obs = collect_valid_evaluable_rebalance_observations(
+        closes,
+        panel.timestamps_utc,
+        lookback_n=lookback_n,
+        rebalance_interval_bars=rebalance_interval_bars,
+    )
+    return count_valid_evaluable_rebalance_observations(obs)

--- a/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/panel_loader_v1.py
+++ b/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/panel_loader_v1.py
@@ -1,0 +1,93 @@
+"""Load DEVELOPMENT-only panel into InstrumentPanelSeriesV1 for CS RS momentum eval.
+
+Reuses sealed independent DEVELOPMENT panel loader. Holdout paths are rejected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.constants_v1 import (
+    DATASET_ID,
+    DEVELOPMENT_END_EXCLUSIVE,
+    DEVELOPMENT_START,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1, PanelBarV1
+from src.research.regime_gated_standaside_mr_development_evaluation_v1.dev_panel_bars_v1 import (
+    REQUIRED_DATASET_ID,
+    assert_not_holdout_path,
+    included_panel_members,
+    load_member_bars,
+    verify_development_panel_hashes,
+)
+
+
+def load_instrument_panel_series_from_development_archive_v1(
+    archive_root: Path,
+    *,
+    start_inclusive: str = DEVELOPMENT_START,
+    end_exclusive: str = DEVELOPMENT_END_EXCLUSIVE,
+) -> tuple[tuple[InstrumentPanelSeriesV1, ...], tuple[str, ...], str]:
+    """Materialize aligned InstrumentPanelSeriesV1 from DEVELOPMENT archive only."""
+    assert_not_holdout_path(archive_root)
+    hashes = verify_development_panel_hashes(archive_root)
+    if hashes["dataset_id"] != DATASET_ID or REQUIRED_DATASET_ID != DATASET_ID:
+        raise ValueError("DATASET_ID_MISMATCH")
+
+    members = included_panel_members(archive_root)
+    frames: dict[str, pd.DataFrame] = {}
+    for member in members:
+        canon = member["canonical_instrument_id"]
+        native = member["native_instrument_id"]
+        frames[canon] = load_member_bars(
+            archive_root,
+            native_instrument_id=native,
+            start_inclusive=start_inclusive,
+            end_exclusive=end_exclusive,
+        )
+
+    # Align on intersection of timestamps (canonical PT1H grid subset).
+    common_index = None
+    for frame in frames.values():
+        idx = pd.to_datetime(frame.index, utc=True)
+        common_index = idx if common_index is None else common_index.intersection(idx)
+    if common_index is None or len(common_index) == 0:
+        raise ValueError("EMPTY_ALIGNED_PANEL")
+    common_index = common_index.sort_values()
+    timestamps = tuple(
+        ts.strftime("%Y-%m-%dT%H:%M:%SZ") for ts in pd.to_datetime(common_index, utc=True)
+    )
+
+    series_list: list[InstrumentPanelSeriesV1] = []
+    for canon, frame in sorted(frames.items()):
+        aligned = frame.reindex(common_index)
+        if aligned.isna().any().any():
+            aligned = aligned.dropna()
+            # Fail closed if alignment drops rows — intersection should already be clean.
+            if len(aligned) != len(common_index):
+                raise ValueError(f"ALIGNMENT_GAP:{canon}")
+        bars: list[PanelBarV1] = []
+        for ts, row in zip(timestamps, aligned.itertuples(index=False), strict=True):
+            bars.append(
+                PanelBarV1(
+                    instrument_id=canon,
+                    timestamp_utc=ts,
+                    open=str(float(row.open)),
+                    high=str(float(row.high)),
+                    low=str(float(row.low)),
+                    close=str(float(row.close)),
+                    volume=str(float(row.volume)),
+                    is_final=True,
+                )
+            )
+        series_list.append(
+            InstrumentPanelSeriesV1(
+                instrument_id=canon,
+                native_instrument_id=canon,
+                bars=tuple(bars),
+                series_digest=str(hashes.get("content_hash") or ""),
+            )
+        )
+    return tuple(series_list), timestamps, str(hashes.get("content_hash") or "")

--- a/tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_v1.py
+++ b/tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_v1.py
@@ -127,6 +127,10 @@ def test_owner_registry_and_entry_point_files_bound() -> None:
     prefixes = owner["path_prefixes"]
     assert ENTRY_POINT_BINDING_REL_PATH in prefixes
     assert CLI_REL_PATH in prefixes
+    assert (
+        "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_executable_path_v1.py"
+        in prefixes
+    )
     assert EVIDENCE_REL_PATH in prefixes or any(
         p.startswith("docs/evidence/evaluate_cross_sectional_relative_strength_momentum")
         for p in prefixes

--- a/tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_executable_path_v1.py
+++ b/tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_executable_path_v1.py
@@ -1,0 +1,375 @@
+"""Tests for executable CS RS momentum v1 development-evaluation path (no real run)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.authorization_v1 import (
+    authorization_decision_from_mapping,
+    resolve_authorization_decision_v1,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.binding_v1 import (
+    compute_config_digest,
+    compute_strategy_params_digest,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.constants_v1 import (
+    DATASET_ID,
+    DEVELOPMENT_RUN_LIMIT,
+    HOLDOUT_OPAQUE_ID,
+    HYPOTHESIS_ID,
+    MINIMUM_REBALANCE_OBSERVATIONS,
+    TIME_SEGMENT_DEFINITION_ID,
+    TIME_SEGMENT_ROBUSTNESS_PASS_RATIO,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.entry_point_v1 import (
+    run_dry_validate,
+    run_evaluate_fail_closed,
+    run_preflight_only,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.evaluate_path_v1 import (
+    dry_validate_evaluate_path_v1,
+    run_authorized_development_evaluation_v1,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.evidence_materialization_v1 import (
+    build_registry_metadata_v1,
+    validate_evidence_and_registry_contracts_v1,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.evidence_schema_v1 import (
+    empty_evidence_surface_template,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.execution_boundary_v1 import (
+    BacktestMetricsBundleV1,
+    FakeExecutionBoundaryV1,
+    PanelLoadResultV1,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.guards_v1 import (
+    GuardError,
+    assert_exactly_one_run_limit,
+    assert_retry_forbidden,
+    read_run_counters,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.time_segments_v1 import (
+    partition_chronological_equal_duration_quarters_v1,
+)
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1, PanelBarV1
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _closes(start: float, n: int, step: float) -> tuple[float, ...]:
+    values = [start]
+    for _ in range(n - 1):
+        values.append(values[-1] * step)
+    return tuple(values)
+
+
+def _fake_metrics(*, net_pf: float = 1.5, gross_pf: float = 1.8) -> BacktestMetricsBundleV1:
+    return BacktestMetricsBundleV1(
+        gross_return=0.12,
+        net_return=0.08,
+        gross_profit_factor=gross_pf,
+        net_profit_factor=net_pf,
+        gross_pnl=100.0,
+        net_expectancy=0.01,
+        sharpe=1.0,
+        max_drawdown=-0.05,
+        turnover=10.0,
+        fees=1.0,
+        slippage=0.5,
+        total_cost_drag=1.5,
+        trade_count=60,
+        worst1_abs_net_share=0.05,
+        cost_multiplier=1.0,
+    )
+
+
+def _panel_spanning_quarters(n_per_segment: int = 40) -> PanelLoadResultV1:
+    segments = partition_chronological_equal_duration_quarters_v1()
+    timestamps: list[str] = []
+    for seg in segments:
+        start = datetime.fromisoformat(seg.start_inclusive.replace("Z", "+00:00"))
+        for i in range(n_per_segment):
+            timestamps.append((start + timedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+    n_bars = len(timestamps)
+    instruments = {
+        "okx:linear_perpetual:ETH-USDT": _closes(100.0, n_bars, 1.01),
+        "okx:linear_perpetual:SOL-USDT": _closes(50.0, n_bars, 1.005),
+        "okx:linear_perpetual:XRP-USDT": _closes(1.0, n_bars, 0.999),
+        "okx:linear_perpetual:ADA-USDT": _closes(2.0, n_bars, 1.002),
+        "okx:linear_perpetual:DOGE-USDT": _closes(0.1, n_bars, 0.998),
+        "okx:linear_perpetual:LINK-USDT": _closes(10.0, n_bars, 1.003),
+    }
+    series: list[InstrumentPanelSeriesV1] = []
+    for iid, closes in instruments.items():
+        bars = tuple(
+            PanelBarV1(
+                instrument_id=iid,
+                timestamp_utc=timestamps[i],
+                open=str(closes[i]),
+                high=str(closes[i]),
+                low=str(closes[i]),
+                close=str(closes[i]),
+                volume="1.0",
+                is_final=True,
+            )
+            for i in range(n_bars)
+        )
+        series.append(
+            InstrumentPanelSeriesV1(
+                instrument_id=iid,
+                native_instrument_id=iid,
+                bars=bars,
+                series_digest="fake_test_panel",
+            )
+        )
+    return PanelLoadResultV1(
+        dataset_id=DATASET_ID,
+        dataset_digest="fake_dataset_digest",
+        panel_series=tuple(series),
+        timestamps_utc=tuple(timestamps),
+        instrument_count=len(series),
+        holdout_accessed=False,
+    )
+
+
+def _authorized_decision():
+    return authorization_decision_from_mapping(
+        {
+            "authorized": True,
+            "authorize_token_valid": True,
+            "repo_development_evaluation_authorized": True,
+            "program_development_evaluation_authorized": True,
+            "entry_point_binding_authorized": True,
+            "reason_codes": (),
+        }
+    )
+
+
+def test_repo_authorization_fail_closed_on_head() -> None:
+    decision = resolve_authorization_decision_v1(REPO, authorize_token=HYPOTHESIS_ID)
+    assert decision.authorized is False
+    assert decision.authorize_token_valid is True
+    assert "CONTRACT_DEVELOPMENT_EVALUATION_AUTHORIZED_FALSE" in decision.reason_codes
+
+
+def test_unauthorized_blocks_before_runner_start(tmp_path: Path) -> None:
+    before = read_run_counters(REPO)
+    fake = FakeExecutionBoundaryV1(
+        panel=_panel_spanning_quarters(),
+        canonical_metrics=_fake_metrics(),
+        stress_metrics=_fake_metrics(net_pf=1.1),
+    )
+    result = run_authorized_development_evaluation_v1(
+        REPO,
+        authorize_token=HYPOTHESIS_ID,
+        output_dir=tmp_path,
+        execution_boundary=fake,
+        persist_evidence=False,
+    )
+    assert result.status == "FAIL_CLOSED"
+    assert result.runner_started is False
+    assert result.evaluation_executed is False
+    assert result.executable_path_reached is False
+    assert fake.load_calls == 0
+    assert fake.backtest_calls == 0
+    assert read_run_counters(REPO) == before
+    with pytest.raises(GuardError, match="EVALUATION_UNAUTHORIZED"):
+        run_evaluate_fail_closed(
+            REPO,
+            authorize_token=HYPOTHESIS_ID,
+            output_dir=tmp_path,
+        )
+    assert read_run_counters(REPO) == before
+
+
+def test_authorized_reaches_executable_path_via_fake_boundary_only(tmp_path: Path) -> None:
+    before = read_run_counters(REPO)
+    fake = FakeExecutionBoundaryV1(
+        panel=_panel_spanning_quarters(),
+        canonical_metrics=_fake_metrics(),
+        stress_metrics=_fake_metrics(net_pf=1.1),
+    )
+    result = run_authorized_development_evaluation_v1(
+        REPO,
+        authorize_token=HYPOTHESIS_ID,
+        output_dir=tmp_path,
+        execution_boundary=fake,
+        authorization_decision=_authorized_decision(),
+        persist_evidence=True,
+    )
+    assert result.status == "EVALUATION_COMPLETE"
+    assert result.executable_path_reached is True
+    assert result.runner_started is True
+    assert result.evaluation_executed is True
+    assert result.holdout_accessed is False
+    assert fake.load_calls == 1
+    assert fake.backtest_calls == 2  # canonical + 1.5x stress
+    assert result.evidence_surface is not None
+    assert result.registry is not None
+    assert result.gates is not None
+    assert (tmp_path / "summary.json").is_file()
+    assert (tmp_path / "registry.json").is_file()
+    assert (tmp_path / "run_slot_claim.json").is_file()
+    # Repo counters unchanged without counter_mutator (implementation-only tests).
+    assert read_run_counters(REPO) == before
+
+
+def test_run_limit_exactly_one_and_second_start_fail_closed(tmp_path: Path, monkeypatch) -> None:
+    assert DEVELOPMENT_RUN_LIMIT == 1
+    assert_exactly_one_run_limit(1)
+    with pytest.raises(GuardError):
+        assert_exactly_one_run_limit(2)
+    assert_retry_forbidden(retry_requested=False, development_run_count=0, runner_start_count=0)
+    with pytest.raises(GuardError, match="RUN_LIMIT_EXHAUSTED"):
+        assert_retry_forbidden(retry_requested=False, development_run_count=1, runner_start_count=0)
+    with pytest.raises(GuardError, match="RUNNER_START_LIMIT_EXHAUSTED"):
+        assert_retry_forbidden(retry_requested=False, development_run_count=0, runner_start_count=1)
+
+    fake = FakeExecutionBoundaryV1(
+        panel=_panel_spanning_quarters(),
+        canonical_metrics=_fake_metrics(),
+        stress_metrics=_fake_metrics(net_pf=1.1),
+    )
+    first = run_authorized_development_evaluation_v1(
+        REPO,
+        authorize_token=HYPOTHESIS_ID,
+        output_dir=tmp_path,
+        execution_boundary=fake,
+        authorization_decision=_authorized_decision(),
+        persist_evidence=True,
+    )
+    assert first.status == "EVALUATION_COMPLETE"
+    # Slot reuse: second start against same evidence dir fails before boundary.
+    fake2 = FakeExecutionBoundaryV1(
+        panel=_panel_spanning_quarters(),
+        canonical_metrics=_fake_metrics(),
+        stress_metrics=_fake_metrics(net_pf=1.1),
+    )
+    with pytest.raises(GuardError, match="RETRY_OR_SLOT_REUSE_REJECTED"):
+        run_authorized_development_evaluation_v1(
+            REPO,
+            authorize_token=HYPOTHESIS_ID,
+            output_dir=tmp_path,
+            execution_boundary=fake2,
+            authorization_decision=_authorized_decision(),
+            persist_evidence=True,
+        )
+    assert fake2.load_calls == 0
+
+    # Exhausted counters also fail closed before runner start.
+    monkeypatch.setattr(
+        "src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1."
+        "evaluate_path_v1.read_run_counters",
+        lambda _repo: {
+            "contract_development_run_count": 1,
+            "contract_runner_start_count": 1,
+            "program_development_run_count": 1,
+            "program_runner_start_count": 1,
+        },
+    )
+    with pytest.raises(GuardError, match="RUN_LIMIT_EXHAUSTED|RUNNER_START_LIMIT_EXHAUSTED"):
+        run_authorized_development_evaluation_v1(
+            REPO,
+            authorize_token=HYPOTHESIS_ID,
+            output_dir=tmp_path / "second_slot",
+            execution_boundary=fake2,
+            authorization_decision=_authorized_decision(),
+            persist_evidence=False,
+        )
+    assert fake2.load_calls == 0
+
+
+def test_dataset_config_digest_and_time_segment_bindings() -> None:
+    preflight = run_preflight_only(REPO)
+    assert preflight["dataset_id"] == DATASET_ID
+    assert preflight["config_digest"] == compute_config_digest(REPO)
+    assert preflight["strategy_params_digest"] == compute_strategy_params_digest()
+    assert preflight["time_segment_definition_id"] == TIME_SEGMENT_DEFINITION_ID
+    assert MINIMUM_REBALANCE_OBSERVATIONS == 30
+    assert TIME_SEGMENT_ROBUSTNESS_PASS_RATIO == 0.5
+    binding = preflight["entry_point_binding"]
+    assert binding["dataset_binding"]["dataset_id"] == DATASET_ID
+    assert binding["time_segment_definition_id"] == TIME_SEGMENT_DEFINITION_ID
+    assert binding["config_digest"] == preflight["config_digest"]
+    assert binding["status"] == "EXECUTABLE_EVALUATE_PATH_PRESENT_EVALUATION_UNAUTHORIZED"
+    assert binding["development_evaluation_authorized"] is False
+
+
+def test_holdout_forbidden_on_fake_boundary_and_guards(tmp_path: Path) -> None:
+    fake = FakeExecutionBoundaryV1(
+        panel=_panel_spanning_quarters(),
+        canonical_metrics=_fake_metrics(),
+        stress_metrics=_fake_metrics(net_pf=1.1),
+    )
+    with pytest.raises(ValueError, match="HOLDOUT_PATH_REJECTED"):
+        fake.load_development_panel(
+            repo_root=REPO, archive_root=tmp_path / f"sealed_{HOLDOUT_OPAQUE_ID}"
+        )
+
+
+def test_dry_validate_and_unauthorized_leave_counters_unchanged() -> None:
+    before = read_run_counters(REPO)
+    dry = dry_validate_evaluate_path_v1(REPO)
+    assert dry.status == "DRY_VALIDATE_PASS_EXECUTABLE_PATH_PRESENT"
+    assert dry.runner_started is False
+    assert dry.evaluation_executed is False
+    assert dry.executable_path_reached is True
+    cli_dry = run_dry_validate(REPO)
+    assert cli_dry["runner_started"] is False
+    assert read_run_counters(REPO) == before
+    unauthorized = run_authorized_development_evaluation_v1(
+        REPO,
+        authorize_token="WRONG_TOKEN",
+        output_dir=REPO
+        / "docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1",
+        persist_evidence=False,
+    )
+    assert unauthorized.runner_started is False
+    assert read_run_counters(REPO) == before
+
+
+def test_evidence_and_registry_contracts() -> None:
+    evidence = empty_evidence_surface_template(
+        config_digest=compute_config_digest(REPO),
+        strategy_params_digest=compute_strategy_params_digest(),
+        dataset_id=DATASET_ID,
+        dataset_digest="NOT_RESOLVED",
+    )
+    registry = build_registry_metadata_v1(
+        evaluation_executed=False,
+        runner_started=False,
+        evaluation_run_count=0,
+        runner_start_count=0,
+        development_evaluation_authorized=False,
+        config_digest=evidence["config_digest"],
+        strategy_params_digest=evidence["strategy_params_digest"],
+        dataset_id=DATASET_ID,
+        dataset_digest="NOT_RESOLVED",
+        terminal_development_verdict="NOT_EXECUTED",
+    )
+    report = validate_evidence_and_registry_contracts_v1(evidence, registry)
+    assert report["valid"] is True
+    assert json.dumps(registry, sort_keys=True)
+
+
+def test_implementation_only_head_flags_remain_closed() -> None:
+    contract = json.loads(
+        (
+            REPO / "config/research/"
+            "cross_sectional_relative_strength_momentum_v1_preregistered_economic_hypothesis_"
+            "measurement_contract_v1.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert contract["development_evaluation_authorized"] is False
+    assert contract["development_run_count"] == 0
+    assert contract["runner_start_count"] == 0
+    assert contract["holdout_authorized"] is False
+    runtime = contract["runtime_policy"]
+    assert runtime["live_authorized"] is False
+    assert runtime["orders_allowed"] is False
+    assert runtime["shadow_activated"] is False
+    assert runtime["testnet_activated"] is False


### PR DESCRIPTION
## Summary
- Materializes an executable, fail-closed Development Evaluation path under the existing CS RS momentum v1 entry point (auth gate, admission gates, evidence/registry contracts, injectable execution boundary).
- Keeps `development_evaluation_authorized=false`; does **not** execute evaluation, start the runner, consume run budget, or touch holdout.
- Adds targeted tests covering unauthorized block-before-runner, authorized path via fake boundary only, run-limit=1 / second-start fail-closed, bindings, and evidence/registry contracts.

## Test plan
- [x] Targeted entry-point + executable-path tests (18 passed)
- [x] Ruff format/check on touched Python
- [x] Docs reference targets + docs token policy preflight
- [x] Selector-derived PR-bounded timing probe (~43s, 734 passed)
- [ ] CI confirmation on PR (do not merge until readiness audit)

## Explicit non-actions
- No development evaluation executed
- No merge in this step
- Next after merge readiness: squash merge, then exactly one previously authorized bounded Development run

Made with [Cursor](https://cursor.com)