### PR TITLE
fix: panel-loader alignment repair (no evaluation, no retry authorization)

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -442,13 +442,14 @@
     "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
       "note": "DEVELOPMENT evaluation entry point/owner for CS relative-strength momentum v1: executable evaluate path under fail-closed authorization, CLI preflight/dry-validate, digests/dataset/time-segment/rebalance-observation/evidence-registry/admission gates, wiring into canonical single-slot backtest metrics owners. Development evaluation authorized on HEAD; no runner start/run-slot consumption without separate execution GO; no holdout/runtime/orders; measurement thresholds and strategy score/selection semantics unchanged.",
       "path_prefixes": [
-        "src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/",
-        "scripts/research/run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py",
         "config/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_binding_v1.json",
+        "docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/",
+        "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+        "scripts/research/run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py",
+        "src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/",
         "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_v1.py",
         "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_executable_path_v1.py",
-        "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-        "docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/"
+        "tests/research/test_cross_sectional_relative_strength_momentum_v1_panel_loader_alignment_repair_v1.py"
       ]
     },
     "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {

--- a/docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/PANEL_LOADER_ALIGNMENT_ROOT_CAUSE_V1.md
+++ b/docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/PANEL_LOADER_ALIGNMENT_ROOT_CAUSE_V1.md
@@ -1,0 +1,32 @@
+# Panel-loader alignment root cause (implementation-only)
+
+## Observed failure
+
+Canonical evaluate attempt (`PR #5428`) terminated `FAIL_CLOSED` with:
+
+`UNEXPECTED:ValueError:ALIGNMENT_GAP:okx:linear_perpetual:1INCH:USDT:USDT:perp`
+
+Run budget remains consumed (`RUN_COUNT=1`, `RUNNER_START_COUNT=1`). No retry authorization.
+
+## First divergent boundary
+
+`src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/panel_loader_v1.py`
+
+After timestamp-intersection alignment, the loader treated **any** NaN in the member
+DataFrame as an alignment gap (via `aligned.isna().any().any()` + `dropna()`).
+
+## Reproduced fact
+
+On the sealed DEVELOPMENT archive:
+
+- timestamp intersection length equals each member length (no missing timestamps)
+- required OHLCV columns (`open/high/low/close/volume`) have **zero** NaNs on the grid
+- auxiliary column `volatility_estimate` contains warmup NaNs (46–59 rows)
+
+Therefore the fail-closed exit was caused by **auxiliary-column warmup NaNs**, not by
+OHLCV timestamp misalignment / wide-vs-long / symbol-universe drift.
+
+## Repair class
+
+Implementation-only: validate alignment exclusively on columns required to materialize
+`PanelBarV1`. Do not execute evaluation, do not reopen the run slot.

--- a/docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/PANEL_LOADER_ALIGNMENT_ROOT_CAUSE_V1.md
+++ b/docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/PANEL_LOADER_ALIGNMENT_ROOT_CAUSE_V1.md
@@ -20,7 +20,7 @@ DataFrame as an alignment gap (via `aligned.isna().any().any()` + `dropna()`).
 On the sealed DEVELOPMENT archive:
 
 - timestamp intersection length equals each member length (no missing timestamps)
-- required OHLCV columns (`open/high/low/close/volume`) have **zero** NaNs on the grid
+- required OHLCV columns (`open&#47;high&#47;low&#47;close&#47;volume`) have **zero** NaNs on the grid
 - auxiliary column `volatility_estimate` contains warmup NaNs (46–59 rows)
 
 Therefore the fail-closed exit was caused by **auxiliary-column warmup NaNs**, not by

--- a/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/panel_loader_v1.py
+++ b/src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/panel_loader_v1.py
@@ -1,6 +1,11 @@
 """Load DEVELOPMENT-only panel into InstrumentPanelSeriesV1 for CS RS momentum eval.
 
 Reuses sealed independent DEVELOPMENT panel loader. Holdout paths are rejected.
+
+Alignment contract:
+  Timestamp intersection must be complete for required OHLCV columns consumed by
+  PanelBarV1. Auxiliary research columns (e.g. volatility_estimate warmup NaNs)
+  must not be treated as timestamp alignment gaps.
 """
 
 from __future__ import annotations
@@ -22,6 +27,21 @@ from src.research.regime_gated_standaside_mr_development_evaluation_v1.dev_panel
     load_member_bars,
     verify_development_panel_hashes,
 )
+
+# Columns required to materialize PanelBarV1. Auxiliary columns may be present
+# with legitimate warmup/diagnostic NaNs and are ignored for alignment.
+REQUIRED_PANEL_BAR_COLUMNS: tuple[str, ...] = ("open", "high", "low", "close", "volume")
+
+
+def _require_ohlcv_alignment(aligned: pd.DataFrame, *, instrument_id: str) -> pd.DataFrame:
+    """Fail closed only when required OHLCV values are missing on the common grid."""
+    missing = [c for c in REQUIRED_PANEL_BAR_COLUMNS if c not in aligned.columns]
+    if missing:
+        raise ValueError(f"OHLCV_COLUMNS_MISSING:{instrument_id}:{','.join(missing)}")
+    required = aligned.loc[:, list(REQUIRED_PANEL_BAR_COLUMNS)]
+    if required.isna().any().any():
+        raise ValueError(f"ALIGNMENT_GAP:{instrument_id}")
+    return required
 
 
 def load_instrument_panel_series_from_development_archive_v1(
@@ -63,13 +83,12 @@ def load_instrument_panel_series_from_development_archive_v1(
     series_list: list[InstrumentPanelSeriesV1] = []
     for canon, frame in sorted(frames.items()):
         aligned = frame.reindex(common_index)
-        if aligned.isna().any().any():
-            aligned = aligned.dropna()
-            # Fail closed if alignment drops rows — intersection should already be clean.
-            if len(aligned) != len(common_index):
-                raise ValueError(f"ALIGNMENT_GAP:{canon}")
+        required = _require_ohlcv_alignment(aligned, instrument_id=canon)
         bars: list[PanelBarV1] = []
-        for ts, row in zip(timestamps, aligned.itertuples(index=False), strict=True):
+        rows = list(required.itertuples(index=False))
+        if len(rows) != len(timestamps):
+            raise ValueError(f"TIMESTAMP_ROW_LENGTH_MISMATCH:{canon}")
+        for ts, row in zip(timestamps, rows):
             bars.append(
                 PanelBarV1(
                     instrument_id=canon,

--- a/tests/research/test_cross_sectional_relative_strength_momentum_v1_panel_loader_alignment_repair_v1.py
+++ b/tests/research/test_cross_sectional_relative_strength_momentum_v1_panel_loader_alignment_repair_v1.py
@@ -1,0 +1,106 @@
+"""Regression: panel loader alignment must ignore auxiliary warmup NaNs.
+
+Implementation-only. Does not authorize/execute development evaluation or mutate
+run counters / run slots.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.panel_loader_v1 import (
+    REQUIRED_PANEL_BAR_COLUMNS,
+    _require_ohlcv_alignment,
+    load_instrument_panel_series_from_development_archive_v1,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.constants_v1 import (
+    DATASET_ID,
+    MEASUREMENT_CONTRACT_REL_PATH,
+    PROGRAM_REL_PATH,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.entry_point_v1 import (
+    run_preflight_only,
+)
+from src.research.cross_sectional_relative_strength_momentum_v1_development_evaluation_v1.guards_v1 import (
+    read_run_counters,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _synthetic_frame_with_volatility_warmup_nans() -> pd.DataFrame:
+    idx = pd.date_range("2022-06-01T04:00:00Z", periods=8, freq="h", tz="UTC")
+    frame = pd.DataFrame(
+        {
+            "open": [1.0] * 8,
+            "high": [1.1] * 8,
+            "low": [0.9] * 8,
+            "close": [1.05] * 8,
+            "volume": [10.0] * 8,
+            "volatility_estimate": [float("nan")] * 3 + [0.2] * 5,
+            "warmup_status": ["WARMUP"] * 3 + ["READY"] * 5,
+        },
+        index=idx,
+    )
+    return frame
+
+
+def test_required_panel_bar_columns_are_ohlcv_only() -> None:
+    assert REQUIRED_PANEL_BAR_COLUMNS == ("open", "high", "low", "close", "volume")
+
+
+def test_alignment_ignores_auxiliary_volatility_warmup_nans() -> None:
+    frame = _synthetic_frame_with_volatility_warmup_nans()
+    # Legacy-all-columns check would fail-closed on volatility_estimate NaNs.
+    assert bool(frame.isna().any().any())
+    required = _require_ohlcv_alignment(frame, instrument_id="synth:perp")
+    assert list(required.columns) == list(REQUIRED_PANEL_BAR_COLUMNS)
+    assert not bool(required.isna().any().any())
+
+
+def test_alignment_still_fail_closed_on_true_ohlcv_gap() -> None:
+    frame = _synthetic_frame_with_volatility_warmup_nans()
+    frame.loc[frame.index[0], "close"] = float("nan")
+    with pytest.raises(ValueError, match="ALIGNMENT_GAP:synth:perp"):
+        _require_ohlcv_alignment(frame, instrument_id="synth:perp")
+
+
+def test_load_validate_development_archive_without_evaluation() -> None:
+    """Load/validate only. Must not execute evaluation or consume/alter run budget."""
+    before = read_run_counters(REPO)
+    assert before["contract_development_run_count"] == 1
+    assert before["contract_runner_start_count"] == 1
+
+    from src.research.regime_gated_standaside_mr_development_evaluation_v1.dev_panel_bars_v1 import (
+        resolve_development_archive_root,
+    )
+
+    archive = resolve_development_archive_root(None)
+    series, timestamps, digest = load_instrument_panel_series_from_development_archive_v1(archive)
+    assert len(series) >= 1
+    assert len(timestamps) == len(series[0].bars)
+    assert digest
+    # First instrument previously failed with ALIGNMENT_GAP under all-column NaN checks.
+    assert any(s.instrument_id.endswith(":1INCH:USDT:USDT:perp") for s in series)
+
+    after = read_run_counters(REPO)
+    assert after == before
+
+    # Preflight remains read-only and must not start evaluate.
+    pre = run_preflight_only(REPO)
+    assert pre["evaluation_executed"] is False
+    assert pre["runner_started"] is False
+    assert pre["holdout_accessed"] is False
+    assert pre["dataset_id"] == DATASET_ID
+    assert read_run_counters(REPO) == before
+
+    mc = json.loads((REPO / MEASUREMENT_CONTRACT_REL_PATH).read_text(encoding="utf-8"))
+    prog = json.loads((REPO / PROGRAM_REL_PATH).read_text(encoding="utf-8"))
+    assert mc["development_run_count"] == 1
+    assert mc["runner_start_count"] == 1
+    assert prog["development_run_count"] == 1
+    assert prog["runner_start_count"] == 1


### PR DESCRIPTION
## Summary
- Panel-loader alignment repair: fail-closed `ALIGNMENT_GAP` now applies only to required OHLCV columns consumed by `PanelBarV1`, not auxiliary warmup NaNs (e.g. `volatility_estimate`).
- Root cause of the consumed development evaluate run (`PR #5428`, exit 2) documented from sealed DEVELOPMENT archive evidence.
- Deterministic regression + load/validate coverage; owner-map entry for the new test owner.

## Explicit non-claims / constraints
- **no evaluation** — this PR does not execute or authorize a development evaluation run
- **no retry authorization** — run budget remains consumed (`RUN_COUNT=1`, `RUNNER_START_COUNT=1`)
- **run budget remains consumed** — does not reopen the single authorized development run slot
- Does **not** claim that this hypothesis may be re-evaluated

## Test plan
- [x] `pytest` repair + entry-point preflight tests (load/validate only)
- [x] economic diagnostic optimization boundary guard (changed files admissible)
- [x] policy critic ALLOW
- [x] ruff format/check
- [x] CI selector `PR_BOUNDED_FULL` path-equivalent targets timing proof (~46s)
- [ ] GitHub required checks on this PR (do not merge in this mandate)


Made with [Cursor](https://cursor.com)