### PR TITLE
research: bind VCB v1 productive exit/PnL evaluator (implementation-only, no evaluation)

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -898,7 +898,7 @@
       ]
     },
     "VOLATILITY_COMPRESSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_COMPRESSION_BREAKOUT_V1: executable evaluate path with injectable panel execution boundary; authorized on HEAD; single bounded attempt fail-closed at PRODUCTIVE_EXIT_PNL_EVALUATOR_NOT_BOUND without run-slot consumption; no holdout/runtime/orders; measurement thresholds and strategy/baseline semantics unchanged.",
+      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_COMPRESSION_BREAKOUT_V1: executable evaluate path with panel execution boundary and productive exit/PnL evaluator bound to canonical BacktestEngine fee/slippage/gross-PnL primitives; authorized on HEAD; no evaluation execution/run-slot consumption without separate GO; no holdout/runtime/orders; measurement thresholds and strategy/baseline parameters unchanged.",
       "path_prefixes": [
         "config/research/volatility_compression_breakout_v1_development_evaluation_entry_point_binding_v1.json",
         "docs/evidence/evaluate_volatility_compression_breakout_development_v1/",
@@ -907,7 +907,8 @@
         "src/research/volatility_compression_breakout_v1_development_evaluation_v1/",
         "tests/research/test_volatility_compression_breakout_v1_development_evaluation_entry_point_v1.py",
         "tests/research/test_volatility_compression_breakout_v1_development_evaluation_executable_path_v1.py",
-        "tests/research/test_volatility_compression_breakout_v1_development_evaluation_fail_closed_report_v1.py"
+        "tests/research/test_volatility_compression_breakout_v1_development_evaluation_fail_closed_report_v1.py",
+        "tests/research/test_volatility_compression_breakout_v1_productive_exit_pnl_evaluator_v1.py"
       ]
     },
     "VOLATILITY_REGIME_HYPOTHESIS_BACKLOG_V1": {

--- a/src/research/volatility_compression_breakout_v1_development_evaluation_v1/execution_boundary_v1.py
+++ b/src/research/volatility_compression_breakout_v1_development_evaluation_v1/execution_boundary_v1.py
@@ -137,15 +137,42 @@ class RealExecutionBoundaryV1:
         cost_execution_binding: Mapping[str, Any],
         cost_multiplier: float = 1.0,
     ) -> BacktestMetricsBundleV1:
-        """Wire treatment/baseline, then hand off to productive PnL evaluator.
+        """Wire treatment/baseline, then realize PnL via productive exit evaluator."""
+        from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+            evaluate_treatment_and_baseline_productive_pnl_v1,
+            productive_exit_pnl_evaluator_is_bound,
+        )
 
-        Exit-state / cost PnL evaluation is not bound in this panel-boundary slice.
-        """
-        _ = (cost_execution_binding, cost_multiplier)
+        if not productive_exit_pnl_evaluator_is_bound():
+            raise ValueError("PRODUCTIVE_EXIT_PNL_EVALUATOR_NOT_BOUND")
         handoff = self.wire_treatment_baseline(panel)
-        raise ValueError(
-            "PRODUCTIVE_EXIT_PNL_EVALUATOR_NOT_BOUND:"
-            f"evaluable_treatment_events={handoff.evaluable_treatment_breakout_events}"
+        treatment, baseline = evaluate_treatment_and_baseline_productive_pnl_v1(
+            dataset_id=panel.dataset_id,
+            panel_series=panel.panel_series,
+            handoff=handoff,
+            cost_execution_binding=cost_execution_binding,
+            cost_multiplier=cost_multiplier,
+        )
+        return BacktestMetricsBundleV1(
+            gross_return=treatment.gross_return,
+            net_return=treatment.net_return,
+            gross_profit_factor=treatment.gross_profit_factor,
+            net_profit_factor=treatment.net_profit_factor,
+            gross_pnl=treatment.gross_pnl,
+            net_expectancy=treatment.net_expectancy,
+            sharpe=treatment.sharpe,
+            max_drawdown=treatment.max_drawdown,
+            trade_count=treatment.trade_count,
+            evaluable_treatment_breakout_events=treatment.evaluable_entry_events,
+            baseline_net_profit_factor=baseline.net_profit_factor,
+            baseline_gross_profit_factor=baseline.gross_profit_factor,
+            baseline_trade_count=baseline.trade_count,
+            cost_multiplier=float(cost_multiplier),
+            extras={
+                "productive_exit_pnl_evaluator_bound": True,
+                "baseline_trade_count": baseline.trade_count,
+                "treatment_trade_count": treatment.trade_count,
+            },
         )
 
 

--- a/src/research/volatility_compression_breakout_v1_development_evaluation_v1/productive_exit_pnl_evaluator_v1.py
+++ b/src/research/volatility_compression_breakout_v1_development_evaluation_v1/productive_exit_pnl_evaluator_v1.py
@@ -1,0 +1,476 @@
+"""Productive exit/PnL evaluator for VCB v1 development evaluation.
+
+Consumes panel wiring handoffs and applies preregistered declarative exit
+semantics, then realizes roundtrip PnL via the canonical BacktestEngine
+fee/slippage/gross-PnL primitives. No second PnL truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+
+import pandas as pd
+
+from src.backtest.cost_config_v0 import (
+    COST_MODEL_VERSION,
+    EXECUTION_MODEL_VERSION,
+    FEE_MODEL_VERSION,
+    FUNDING_MODEL_VERSION,
+    SLIPPAGE_MODEL_VERSION,
+    SPREAD_MODEL_VERSION,
+    EffectiveBacktestCostConfigV0,
+    compute_cost_config_digest,
+)
+from src.backtest.engine import (
+    _compute_directional_gross_pnl_v0,
+    _compute_roundtrip_fee_slippage_components_v0,
+)
+from src.backtest.stats import compute_backtest_stats
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.constants_v1 import (
+    DATASET_ID,
+    FEE_BPS_PER_SIDE,
+    SLIPPAGE_BPS_PER_SIDE,
+)
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.panel_wiring_v1 import (
+    ArmEventSeriesV1,
+    TreatmentBaselineWiringHandoffV1,
+)
+from src.research.volatility_compression_breakout_v1_strategy_v1 import (
+    EXIT_PARAMS_DECLARATIVE_V1,
+    SIGNAL_LAG_BARS_V1,
+)
+from src.research.volatility_compression_breakout_v1_vol_state_v1 import (
+    compute_atr20_v1,
+    compute_vol_state_panel_column_v1,
+)
+
+PRODUCTIVE_EXIT_PNL_EVALUATOR_OWNER = (
+    "research.volatility_compression_breakout_v1_development_evaluation_v1."
+    "productive_exit_pnl_evaluator_v1"
+)
+CANONICAL_PNL_PRIMITIVE_OWNER = "backtest.engine._compute_directional_gross_pnl_v0"
+UNIT_RISK_NOTIONAL_V1 = 1.0
+
+ExitReasonV1 = Literal[
+    "INITIAL_STOP",
+    "TRAILING_STOP",
+    "REGIME_EXIT",
+    "TIME_EXIT",
+]
+
+
+@dataclass(frozen=True)
+class RoundtripTradeV1:
+    instrument_id: str
+    side: str
+    entry_index: int
+    exit_index: int
+    entry_time: str
+    exit_time: str
+    entry_price: float
+    exit_price: float
+    size: float
+    stop_price_at_entry: float
+    exit_reason: ExitReasonV1
+    gross_pnl: float
+    entry_fee: float
+    exit_fee: float
+    entry_slippage: float
+    exit_slippage: float
+    pnl: float
+
+    def to_stats_record(self) -> dict[str, Any]:
+        return {
+            "entry_time": self.entry_time,
+            "exit_time": self.exit_time,
+            "instrument_id": self.instrument_id,
+            "side": self.side,
+            "entry_price": self.entry_price,
+            "exit_price": self.exit_price,
+            "size": self.size,
+            "pnl": self.pnl,
+            "gross_pnl": self.gross_pnl,
+            "entry_cost": self.entry_fee + self.entry_slippage,
+            "exit_cost": self.exit_fee + self.exit_slippage,
+            "gross_pnl_frac": (self.gross_pnl / abs(self.size * self.entry_price))
+            if self.size and self.entry_price
+            else 0.0,
+            "pnl_unit": "absolute_quote_currency",
+            "exit_reason": self.exit_reason,
+        }
+
+
+@dataclass(frozen=True)
+class ArmPnLResultV1:
+    arm_id: str
+    trades: tuple[RoundtripTradeV1, ...]
+    evaluable_entry_events: int
+    gross_return: float
+    net_return: float
+    gross_profit_factor: float
+    net_profit_factor: float
+    gross_pnl: float
+    net_expectancy: float
+    sharpe: float
+    max_drawdown: float
+    trade_count: int
+
+
+def productive_exit_pnl_evaluator_is_bound() -> bool:
+    return True
+
+
+def assert_development_dataset_only(dataset_id: str) -> None:
+    if dataset_id != DATASET_ID:
+        raise ValueError(f"DATASET_ID_NOT_BOUND:{dataset_id}")
+    if "holdout" in dataset_id.lower() and "pre_holdout" not in dataset_id.lower():
+        raise ValueError(f"HOLDOUT_DATASET_REJECTED:{dataset_id}")
+
+
+def build_effective_cost_config_from_binding_v1(
+    cost_execution_binding: Mapping[str, Any],
+    *,
+    cost_multiplier: float = 1.0,
+) -> EffectiveBacktestCostConfigV0:
+    fee = float(cost_execution_binding["fee_model_binding"]["fee_bps_per_side"])
+    slip = float(cost_execution_binding["slippage_model_binding"]["slippage_bps_per_side"])
+    if abs(fee - FEE_BPS_PER_SIDE) > 1e-12:
+        raise ValueError("FEE_BPS_BINDING_DRIFT")
+    if abs(slip - SLIPPAGE_BPS_PER_SIDE) > 1e-12:
+        raise ValueError("SLIPPAGE_BPS_BINDING_DRIFT")
+    mult = float(cost_multiplier)
+    if mult <= 0 or not (mult == mult):
+        raise ValueError("COST_MULTIPLIER_INVALID")
+    fee_eff = fee * mult
+    slip_eff = slip * mult
+    fields = {
+        "cost_model_version": COST_MODEL_VERSION,
+        "fee_model_version": FEE_MODEL_VERSION,
+        "slippage_model_version": SLIPPAGE_MODEL_VERSION,
+        "funding_model_version": FUNDING_MODEL_VERSION,
+        "spread_model_version": SPREAD_MODEL_VERSION,
+        "execution_model_version": EXECUTION_MODEL_VERSION,
+        "maker_fee_bps": fee_eff,
+        "taker_fee_bps": fee_eff,
+        "entry_slippage_bps": slip_eff,
+        "exit_slippage_bps": slip_eff,
+        "funding_rate_source": "NOT_BOUND",
+        "funding_application_policy": "DEFERRED_TO_LATER_STEP",
+        "spread_application_policy": "NOT_APPLICABLE",
+        "latency_assumption": "NOT_BOUND",
+        "partial_fill_assumption": "NOT_BOUND",
+        "config_source": "vcb_development_evaluation_cost_binding_v1",
+    }
+    digest = compute_cost_config_digest(fields)
+    return EffectiveBacktestCostConfigV0(
+        **fields,
+        config_digest=digest,
+        override_source=None,
+        override_digest=None,
+        economic_interpretation_allowed=True,
+        zero_cost_explicitly_requested=False,
+        reason_codes=["VCB_DEVELOPMENT_EVALUATION_COST_BINDING"],
+    )
+
+
+def _panel_to_frame(series: InstrumentPanelSeriesV1) -> pd.DataFrame:
+    rows = [
+        {
+            "timestamp_utc": bar.timestamp_utc,
+            "open": float(bar.open),
+            "high": float(bar.high),
+            "low": float(bar.low),
+            "close": float(bar.close),
+            "volume": float(bar.volume),
+        }
+        for bar in series.bars
+    ]
+    if not rows:
+        raise ValueError(f"EMPTY_INSTRUMENT_SERIES:{series.instrument_id}")
+    frame = pd.DataFrame(rows)
+    frame.index = pd.RangeIndex(len(frame))
+    return frame
+
+
+def _position_size_from_atr_stop_v1(*, entry_price: float, atr_at_entry: float) -> float:
+    multiple = float(EXIT_PARAMS_DECLARATIVE_V1["initial_stop_atr_multiple"])
+    if entry_price <= 0 or atr_at_entry <= 0 or not (entry_price == entry_price):
+        raise ValueError("INVALID_ENTRY_OR_ATR_FOR_SIZING")
+    stop_distance = atr_at_entry * multiple
+    if stop_distance <= 0:
+        raise ValueError("NON_POSITIVE_STOP_DISTANCE")
+    return UNIT_RISK_NOTIONAL_V1 / stop_distance
+
+
+def _realize_roundtrip_v1(
+    *,
+    instrument_id: str,
+    side: str,
+    entry_index: int,
+    exit_index: int,
+    entry_time: str,
+    exit_time: str,
+    entry_price: float,
+    exit_price: float,
+    size: float,
+    stop_price_at_entry: float,
+    exit_reason: ExitReasonV1,
+    effective_cost: EffectiveBacktestCostConfigV0,
+) -> RoundtripTradeV1:
+    side_l = side.lower()
+    if side_l not in {"long", "short"}:
+        raise ValueError(f"UNSUPPORTED_SIDE:{side}")
+    gross = _compute_directional_gross_pnl_v0(
+        size=size,
+        entry_price=entry_price,
+        exit_price=exit_price,
+        side=side_l,
+    )
+    entry_fee, exit_fee, entry_slip, exit_slip = _compute_roundtrip_fee_slippage_components_v0(
+        size=size,
+        entry_price=entry_price,
+        exit_price=exit_price,
+        effective_cost=effective_cost,
+    )
+    net = gross - entry_fee - exit_fee - entry_slip - exit_slip
+    return RoundtripTradeV1(
+        instrument_id=instrument_id,
+        side=side_l,
+        entry_index=entry_index,
+        exit_index=exit_index,
+        entry_time=entry_time,
+        exit_time=exit_time,
+        entry_price=entry_price,
+        exit_price=exit_price,
+        size=size,
+        stop_price_at_entry=stop_price_at_entry,
+        exit_reason=exit_reason,
+        gross_pnl=float(gross),
+        entry_fee=float(entry_fee),
+        exit_fee=float(exit_fee),
+        entry_slippage=float(entry_slip),
+        exit_slippage=float(exit_slip),
+        pnl=float(net),
+    )
+
+
+def simulate_arm_roundtrips_v1(
+    *,
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    arm: ArmEventSeriesV1,
+    effective_cost: EffectiveBacktestCostConfigV0,
+) -> tuple[RoundtripTradeV1, ...]:
+    """Pair entry events with first-event-wins exits; fail-closed if unpairable."""
+    by_id = {s.instrument_id: s for s in panel_series}
+    if arm.instrument_id not in by_id:
+        raise ValueError(f"ARM_INSTRUMENT_MISSING:{arm.instrument_id}")
+    frame = _panel_to_frame(by_id[arm.instrument_id])
+    atr = compute_atr20_v1(frame["high"], frame["low"], frame["close"])
+    vol = compute_vol_state_panel_column_v1(frame)
+    percentile = vol["percentile_rank_120"]
+    lag = int(SIGNAL_LAG_BARS_V1)
+    init_mult = float(EXIT_PARAMS_DECLARATIVE_V1["initial_stop_atr_multiple"])
+    trail_mult = float(EXIT_PARAMS_DECLARATIVE_V1["trailing_stop_atr_multiple"])
+    regime_lt = float(EXIT_PARAMS_DECLARATIVE_V1["regime_exit_percentile_rank_lt"])
+    max_bars = int(EXIT_PARAMS_DECLARATIVE_V1["time_exit_max_bars"])
+    if not EXIT_PARAMS_DECLARATIVE_V1["first_event_wins"]:
+        raise ValueError("FIRST_EVENT_WINS_REQUIRED")
+
+    trades: list[RoundtripTradeV1] = []
+    n = len(frame)
+    i = 0
+    while i < len(arm.entry_event_mask):
+        if not arm.entry_event_mask[i]:
+            i += 1
+            continue
+        side = str(arm.entry_sides[i]).upper()
+        if side not in {"LONG", "SHORT"}:
+            raise ValueError(f"ENTRY_SIDE_INVALID:{side}")
+        fill_i = i + lag
+        if fill_i >= n:
+            raise ValueError(f"UNPAIRABLE_ENTRY_NO_FILL_BAR:{arm.instrument_id}:{i}")
+        entry_price = float(frame.loc[fill_i, "open"])
+        atr_entry = float(atr.iloc[fill_i])
+        if not (atr_entry == atr_entry) or atr_entry <= 0:
+            raise ValueError(f"ATR_INVALID_AT_ENTRY:{arm.instrument_id}:{fill_i}")
+        size = _position_size_from_atr_stop_v1(entry_price=entry_price, atr_at_entry=atr_entry)
+        if side == "LONG":
+            stop = entry_price - init_mult * atr_entry
+            peak = entry_price
+        else:
+            stop = entry_price + init_mult * atr_entry
+            peak = entry_price
+        exit_i: int | None = None
+        exit_reason: ExitReasonV1 | None = None
+        exit_price = 0.0
+        for j in range(fill_i + 1, min(n, fill_i + 1 + max_bars)):
+            high = float(frame.loc[j, "high"])
+            low = float(frame.loc[j, "low"])
+            close = float(frame.loc[j, "close"])
+            atr_j = float(atr.iloc[j])
+            pct = float(percentile.iloc[j]) if percentile.iloc[j] == percentile.iloc[j] else None
+            candidates: list[tuple[int, ExitReasonV1, float]] = []
+            if side == "LONG":
+                peak = max(peak, high)
+                trail = peak - trail_mult * atr_j if atr_j == atr_j and atr_j > 0 else None
+                if low <= stop:
+                    candidates.append((0, "INITIAL_STOP", stop))
+                if trail is not None and low <= trail:
+                    candidates.append((1, "TRAILING_STOP", trail))
+            else:
+                peak = min(peak, low)
+                trail = peak + trail_mult * atr_j if atr_j == atr_j and atr_j > 0 else None
+                if high >= stop:
+                    candidates.append((0, "INITIAL_STOP", stop))
+                if trail is not None and high >= trail:
+                    candidates.append((1, "TRAILING_STOP", trail))
+            if pct is not None and pct < regime_lt:
+                candidates.append((2, "REGIME_EXIT", close))
+            held = j - fill_i
+            if held >= max_bars:
+                candidates.append((3, "TIME_EXIT", close))
+            if candidates:
+                candidates.sort(key=lambda t: t[0])
+                _, exit_reason, exit_price = candidates[0]
+                exit_i = j
+                break
+        if exit_i is None or exit_reason is None:
+            raise ValueError(f"UNPAIRABLE_ENTRY_NO_EXIT:{arm.instrument_id}:{i}")
+        trades.append(
+            _realize_roundtrip_v1(
+                instrument_id=arm.instrument_id,
+                side=side.lower(),
+                entry_index=fill_i,
+                exit_index=exit_i,
+                entry_time=str(frame.loc[fill_i, "timestamp_utc"]),
+                exit_time=str(frame.loc[exit_i, "timestamp_utc"]),
+                entry_price=entry_price,
+                exit_price=float(exit_price),
+                size=size,
+                stop_price_at_entry=float(stop),
+                exit_reason=exit_reason,
+                effective_cost=effective_cost,
+            )
+        )
+        # No overlapping positions / pyramiding: resume after exit.
+        i = exit_i + 1
+    return tuple(trades)
+
+
+def _metrics_from_trades(trades: Sequence[RoundtripTradeV1]) -> dict[str, float]:
+    if not trades:
+        return {
+            "gross_return": 0.0,
+            "net_return": 0.0,
+            "gross_profit_factor": 0.0,
+            "net_profit_factor": 0.0,
+            "gross_pnl": 0.0,
+            "net_expectancy": 0.0,
+            "sharpe": 0.0,
+            "max_drawdown": 0.0,
+            "trade_count": 0.0,
+        }
+    records = [t.to_stats_record() for t in trades]
+    equity = pd.Series(
+        [UNIT_RISK_NOTIONAL_V1]
+        + [
+            UNIT_RISK_NOTIONAL_V1 + sum(tr.pnl for tr in trades[: idx + 1])
+            for idx in range(len(trades))
+        ]
+    )
+    stats = compute_backtest_stats(records, equity, periods_per_year=24 * 365)
+    gross_pnls = [t.gross_pnl for t in trades]
+    gross_wins = sum(x for x in gross_pnls if x > 0)
+    gross_losses = sum(-x for x in gross_pnls if x < 0)
+    gpf = (gross_wins / gross_losses) if gross_losses > 0 else (999.0 if gross_wins > 0 else 0.0)
+    net_pnls = [t.pnl for t in trades]
+    return {
+        "gross_return": float(stats.get("total_return") or 0.0),
+        "net_return": float(stats.get("total_return") or 0.0),
+        "gross_profit_factor": float(gpf),
+        "net_profit_factor": float(stats.get("profit_factor") or 0.0),
+        "gross_pnl": float(sum(gross_pnls)),
+        "net_expectancy": float(sum(net_pnls) / len(net_pnls)),
+        "sharpe": float(stats.get("sharpe") or 0.0),
+        "max_drawdown": float(abs(stats.get("max_drawdown") or 0.0)),
+        "trade_count": float(len(trades)),
+    }
+
+
+def evaluate_arm_productive_pnl_v1(
+    *,
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    arm: ArmEventSeriesV1,
+    effective_cost: EffectiveBacktestCostConfigV0,
+) -> ArmPnLResultV1:
+    trades = simulate_arm_roundtrips_v1(
+        panel_series=panel_series, arm=arm, effective_cost=effective_cost
+    )
+    metrics = _metrics_from_trades(trades)
+    return ArmPnLResultV1(
+        arm_id=arm.arm_id,
+        trades=trades,
+        evaluable_entry_events=arm.evaluable_entry_event_count,
+        gross_return=metrics["gross_return"],
+        net_return=metrics["net_return"],
+        gross_profit_factor=metrics["gross_profit_factor"],
+        net_profit_factor=metrics["net_profit_factor"],
+        gross_pnl=metrics["gross_pnl"],
+        net_expectancy=metrics["net_expectancy"],
+        sharpe=metrics["sharpe"],
+        max_drawdown=metrics["max_drawdown"],
+        trade_count=int(metrics["trade_count"]),
+    )
+
+
+def evaluate_treatment_and_baseline_productive_pnl_v1(
+    *,
+    dataset_id: str,
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    handoff: TreatmentBaselineWiringHandoffV1,
+    cost_execution_binding: Mapping[str, Any],
+    cost_multiplier: float = 1.0,
+) -> tuple[ArmPnLResultV1, ArmPnLResultV1]:
+    """Identical productive PnL semantics for treatment and baseline arms."""
+    assert_development_dataset_only(dataset_id)
+    if handoff.holdout_accessed if hasattr(handoff, "holdout_accessed") else False:
+        raise ValueError("HOLDOUT_ACCESSED_TRUE")
+    effective = build_effective_cost_config_from_binding_v1(
+        cost_execution_binding, cost_multiplier=cost_multiplier
+    )
+    if not handoff.treatment:
+        raise ValueError("EMPTY_TREATMENT_ARMS")
+    if not handoff.baseline:
+        raise ValueError("EMPTY_BASELINE_ARMS")
+
+    # Aggregate multi-instrument arms with identical evaluator.
+    def _agg(arms: tuple[ArmEventSeriesV1, ...], arm_id: str) -> ArmPnLResultV1:
+        all_trades: list[RoundtripTradeV1] = []
+        events = 0
+        for arm in arms:
+            one = evaluate_arm_productive_pnl_v1(
+                panel_series=panel_series, arm=arm, effective_cost=effective
+            )
+            all_trades.extend(one.trades)
+            events += one.evaluable_entry_events
+        metrics = _metrics_from_trades(all_trades)
+        return ArmPnLResultV1(
+            arm_id=arm_id,
+            trades=tuple(all_trades),
+            evaluable_entry_events=events,
+            gross_return=metrics["gross_return"],
+            net_return=metrics["net_return"],
+            gross_profit_factor=metrics["gross_profit_factor"],
+            net_profit_factor=metrics["net_profit_factor"],
+            gross_pnl=metrics["gross_pnl"],
+            net_expectancy=metrics["net_expectancy"],
+            sharpe=metrics["sharpe"],
+            max_drawdown=metrics["max_drawdown"],
+            trade_count=int(metrics["trade_count"]),
+        )
+
+    treatment = _agg(handoff.treatment, "TREATMENT")
+    baseline = _agg(handoff.baseline, "BASELINE")
+    return treatment, baseline

--- a/tests/research/test_volatility_compression_breakout_v1_development_evaluation_executable_path_v1.py
+++ b/tests/research/test_volatility_compression_breakout_v1_development_evaluation_executable_path_v1.py
@@ -35,7 +35,6 @@ from src.research.volatility_compression_breakout_v1_development_evaluation_v1.e
     BacktestMetricsBundleV1,
     FakeExecutionBoundaryV1,
     PanelLoadResultV1,
-    RealExecutionBoundaryV1,
 )
 from src.research.volatility_compression_breakout_v1_development_evaluation_v1.guards_v1 import (
     GuardError,
@@ -317,14 +316,15 @@ def test_dry_validate_and_preflight_leave_counters_unchanged() -> None:
     assert read_run_counters(REPO) == before
 
 
-def test_real_boundary_wires_but_does_not_invent_pnl_without_exit_evaluator() -> None:
-    """Unit-level: Real wiring path is bound; productive PnL evaluator remains unbound."""
-    panel = _synthetic_panel()
-    real = RealExecutionBoundaryV1()
-    # Real load would open the sealed archive; skip load. Prove run_canonical_backtest
-    # wires then fail-closes without inventing PnL.
-    with pytest.raises(ValueError, match="PRODUCTIVE_EXIT_PNL_EVALUATOR_NOT_BOUND"):
-        real.run_canonical_backtest(panel, cost_execution_binding={}, cost_multiplier=1.0)
+def test_real_boundary_wires_and_binds_productive_exit_pnl_evaluator() -> None:
+    """Unit-level: Real wiring path is bound to productive exit/PnL evaluator."""
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        productive_exit_pnl_evaluator_is_bound,
+    )
+
+    assert productive_exit_pnl_evaluator_is_bound() is True
+    # Keep Fake-path coverage elsewhere; Real load would open the sealed archive.
+    # Boundedness is asserted via productive_exit_pnl_evaluator_is_bound + dedicated tests.
 
 
 def test_run_counters_still_zero_after_boundary_tests() -> None:

--- a/tests/research/test_volatility_compression_breakout_v1_productive_exit_pnl_evaluator_v1.py
+++ b/tests/research/test_volatility_compression_breakout_v1_productive_exit_pnl_evaluator_v1.py
@@ -1,0 +1,291 @@
+"""Focused tests for VCB productive exit/PnL evaluator binding (no evaluation run)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1, PanelBarV1
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.constants_v1 import (
+    DATASET_ID,
+    FEE_BPS_PER_SIDE,
+    SLIPPAGE_BPS_PER_SIDE,
+)
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.execution_boundary_v1 import (
+    PanelLoadResultV1,
+    RealExecutionBoundaryV1,
+)
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.guards_v1 import (
+    read_run_counters,
+)
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.panel_wiring_v1 import (
+    ArmEventSeriesV1,
+    TreatmentBaselineWiringHandoffV1,
+)
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+    CANONICAL_PNL_PRIMITIVE_OWNER,
+    PRODUCTIVE_EXIT_PNL_EVALUATOR_OWNER,
+    assert_development_dataset_only,
+    build_effective_cost_config_from_binding_v1,
+    evaluate_arm_productive_pnl_v1,
+    evaluate_treatment_and_baseline_productive_pnl_v1,
+    productive_exit_pnl_evaluator_is_bound,
+    simulate_arm_roundtrips_v1,
+)
+from src.backtest.engine import (
+    _compute_directional_gross_pnl_v0,
+    _compute_roundtrip_fee_slippage_components_v0,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+FAIL_CLOSED_REPORT = (
+    REPO
+    / "docs/evidence/evaluate_volatility_compression_breakout_development_v1/fail_closed_report.json"
+)
+
+
+def _cost_binding() -> dict:
+    return {
+        "binding_version": "v1",
+        "implicit_zero_cost_forbidden": True,
+        "fee_model_binding": {
+            "fee_bps_per_side": FEE_BPS_PER_SIDE,
+            "fee_model_version": "backtest_fee_taker_symmetric_v0",
+        },
+        "slippage_model_binding": {
+            "slippage_bps_per_side": SLIPPAGE_BPS_PER_SIDE,
+            "slippage_model_version": "backtest_slippage_symmetric_v0",
+        },
+        "spread_model_binding": {
+            "conservative_half_spread_bps": 5.0,
+            "spread_model_version": "research_conservative_bps_v1",
+        },
+    }
+
+
+def _bars_trending(
+    *,
+    n: int = 200,
+    start: float = 100.0,
+    drift: float = 0.2,
+    instrument_id: str = "INST_A",
+) -> InstrumentPanelSeriesV1:
+    bars = []
+    px = start
+    for i in range(n):
+        o = px
+        c = px + drift
+        h = max(o, c) + 0.5
+        l = min(o, c) - 0.5
+        bars.append(
+            PanelBarV1(
+                instrument_id=instrument_id,
+                timestamp_utc=f"2022-06-01T{i % 24:02d}:00:00Z",
+                open=str(o),
+                high=str(h),
+                low=str(l),
+                close=str(c),
+                volume="1",
+                is_final=True,
+            )
+        )
+        px = c
+    return InstrumentPanelSeriesV1(
+        instrument_id=instrument_id,
+        native_instrument_id=instrument_id,
+        bars=tuple(bars),
+        series_digest="synthetic",
+    )
+
+
+def _arm(
+    *,
+    arm_id: str,
+    instrument_id: str,
+    n: int,
+    entry_indexes: list[int],
+    side: str = "LONG",
+) -> ArmEventSeriesV1:
+    mask = [False] * n
+    sides = ["NONE"] * n
+    for idx in entry_indexes:
+        mask[idx] = True
+        sides[idx] = side
+    ts = tuple(f"2022-06-01T{i % 24:02d}:00:00Z" for i in range(n))
+    return ArmEventSeriesV1(
+        arm_id=arm_id,
+        instrument_id=instrument_id,
+        timestamps_utc=ts,
+        entry_sides=tuple(sides),
+        entry_event_mask=tuple(mask),
+    )
+
+
+def test_import_safe_no_runner_no_counter_mutation() -> None:
+    before = read_run_counters(REPO)
+    mod = importlib.import_module(
+        "src.research.volatility_compression_breakout_v1_development_evaluation_v1."
+        "productive_exit_pnl_evaluator_v1"
+    )
+    importlib.reload(mod)
+    assert productive_exit_pnl_evaluator_is_bound() is True
+    assert PRODUCTIVE_EXIT_PNL_EVALUATOR_OWNER
+    assert CANONICAL_PNL_PRIMITIVE_OWNER.endswith("_compute_directional_gross_pnl_v0")
+    after = read_run_counters(REPO)
+    assert after == before
+    assert after["contract_runner_start_count"] == 0
+    assert after["contract_development_run_count"] == 0
+
+
+def test_productive_evaluator_bound_and_reuses_engine_primitives() -> None:
+    assert productive_exit_pnl_evaluator_is_bound() is True
+    cost = build_effective_cost_config_from_binding_v1(_cost_binding(), cost_multiplier=1.0)
+    gross = _compute_directional_gross_pnl_v0(
+        size=1.0, entry_price=100.0, exit_price=110.0, side="long"
+    )
+    assert gross == pytest.approx(10.0)
+    fees = _compute_roundtrip_fee_slippage_components_v0(
+        size=1.0, entry_price=100.0, exit_price=110.0, effective_cost=cost
+    )
+    assert fees[0] > 0 and fees[1] > 0 and fees[2] > 0 and fees[3] > 0
+
+
+def test_long_and_short_roundtrip_pnl_and_costs() -> None:
+    series = _bars_trending(n=220, drift=0.3)
+    cost = build_effective_cost_config_from_binding_v1(_cost_binding())
+    long_arm = _arm(arm_id="T", instrument_id="INST_A", n=220, entry_indexes=[150], side="LONG")
+    short_series = _bars_trending(n=220, drift=-0.3)
+    short_arm = _arm(arm_id="T", instrument_id="INST_A", n=220, entry_indexes=[150], side="SHORT")
+    long_trades = simulate_arm_roundtrips_v1(
+        panel_series=(series,), arm=long_arm, effective_cost=cost
+    )
+    short_trades = simulate_arm_roundtrips_v1(
+        panel_series=(short_series,), arm=short_arm, effective_cost=cost
+    )
+    assert len(long_trades) == 1
+    assert len(short_trades) == 1
+    assert long_trades[0].side == "long"
+    assert short_trades[0].side == "short"
+    assert long_trades[0].entry_fee > 0
+    assert long_trades[0].exit_fee > 0
+    assert long_trades[0].entry_slippage > 0
+    assert long_trades[0].exit_slippage > 0
+    assert long_trades[0].stop_price_at_entry < long_trades[0].entry_price
+    assert short_trades[0].stop_price_at_entry > short_trades[0].entry_price
+    assert long_trades[0].size > 0
+    assert short_trades[0].size > 0
+
+
+def test_baseline_treatment_identical_pnl_semantics() -> None:
+    series = _bars_trending(n=220, drift=0.25)
+    arm_t = _arm(arm_id="TREATMENT", instrument_id="INST_A", n=220, entry_indexes=[160])
+    arm_b = _arm(arm_id="BASELINE", instrument_id="INST_A", n=220, entry_indexes=[160])
+    handoff = TreatmentBaselineWiringHandoffV1(
+        treatment=(arm_t,),
+        baseline=(arm_b,),
+        shared_channel_core_bound=True,
+        time_segment_definition_id="CHRONOLOGICAL_EQUAL_DURATION_QUARTERS_V1",
+        baseline_id="UNCONDITIONAL_20_BAR_PRICE_CHANNEL_BREAKOUT_V1",
+        strategy_identity="VOLATILITY_COMPRESSION_BREAKOUT_V1",
+        timestamps_utc=arm_t.timestamps_utc,
+    )
+    treatment, baseline = evaluate_treatment_and_baseline_productive_pnl_v1(
+        dataset_id=DATASET_ID,
+        panel_series=(series,),
+        handoff=handoff,
+        cost_execution_binding=_cost_binding(),
+        cost_multiplier=1.0,
+    )
+    assert treatment.trade_count == baseline.trade_count == 1
+    assert treatment.net_profit_factor == pytest.approx(baseline.net_profit_factor)
+    assert treatment.gross_pnl == pytest.approx(baseline.gross_pnl)
+
+
+def test_unpairable_entry_fail_closed() -> None:
+    series = _bars_trending(n=180, drift=0.1)
+    # Entry too late for lag+exit window → unpairable.
+    arm = _arm(arm_id="T", instrument_id="INST_A", n=180, entry_indexes=[179])
+    cost = build_effective_cost_config_from_binding_v1(_cost_binding())
+    with pytest.raises(ValueError, match="UNPAIRABLE_ENTRY"):
+        simulate_arm_roundtrips_v1(panel_series=(series,), arm=arm, effective_cost=cost)
+
+
+def test_holdout_and_wrong_dataset_rejected() -> None:
+    with pytest.raises(ValueError, match="HOLDOUT_DATASET_REJECTED|DATASET_ID_NOT_BOUND"):
+        assert_development_dataset_only("offline_economic_reevaluation_sealed_long_panel_v1")
+    with pytest.raises(ValueError, match="DATASET_ID_NOT_BOUND"):
+        assert_development_dataset_only("some_other_dataset")
+    assert_development_dataset_only(DATASET_ID)
+
+
+def test_development_only_enforced_on_evaluator() -> None:
+    series = _bars_trending(n=220)
+    arm = _arm(arm_id="T", instrument_id="INST_A", n=220, entry_indexes=[160])
+    handoff = TreatmentBaselineWiringHandoffV1(
+        treatment=(arm,),
+        baseline=(arm,),
+        shared_channel_core_bound=True,
+        time_segment_definition_id="CHRONOLOGICAL_EQUAL_DURATION_QUARTERS_V1",
+        baseline_id="UNCONDITIONAL_20_BAR_PRICE_CHANNEL_BREAKOUT_V1",
+        strategy_identity="VOLATILITY_COMPRESSION_BREAKOUT_V1",
+        timestamps_utc=arm.timestamps_utc,
+    )
+    with pytest.raises(ValueError, match="DATASET_ID_NOT_BOUND"):
+        evaluate_treatment_and_baseline_productive_pnl_v1(
+            dataset_id="wrong",
+            panel_series=(series,),
+            handoff=handoff,
+            cost_execution_binding=_cost_binding(),
+        )
+
+
+def test_prior_125_treatment_events_recognized_without_evaluation() -> None:
+    before = read_run_counters(REPO)
+    payload = json.loads(FAIL_CLOSED_REPORT.read_text(encoding="utf-8"))
+    assert payload["evaluable_treatment_events_observed_before_fail_closed"] == 125
+    assert payload["evaluation_executed"] is False
+    # Principally evaluable count is a wiring property, not an evaluation run.
+    arm = _arm(arm_id="T", instrument_id="INST_A", n=125, entry_indexes=list(range(125)))
+    assert arm.evaluable_entry_event_count == 125
+    assert read_run_counters(REPO) == before
+    assert before["contract_runner_start_count"] == 0
+
+
+def test_real_boundary_no_longer_raises_unbound() -> None:
+    series = _bars_trending(n=220, drift=0.2)
+    arm = _arm(arm_id="TREATMENT", instrument_id="INST_A", n=220, entry_indexes=[155])
+    panel = PanelLoadResultV1(
+        dataset_id=DATASET_ID,
+        dataset_digest="synthetic",
+        panel_series=(series,),
+        timestamps_utc=arm.timestamps_utc,
+        instrument_count=1,
+        holdout_accessed=False,
+    )
+    real = RealExecutionBoundaryV1()
+
+    def _fake_wire(p: PanelLoadResultV1) -> TreatmentBaselineWiringHandoffV1:
+        a = _arm(arm_id="TREATMENT", instrument_id="INST_A", n=220, entry_indexes=[155])
+        b = _arm(arm_id="BASELINE", instrument_id="INST_A", n=220, entry_indexes=[155])
+        return TreatmentBaselineWiringHandoffV1(
+            treatment=(a,),
+            baseline=(b,),
+            shared_channel_core_bound=True,
+            time_segment_definition_id="CHRONOLOGICAL_EQUAL_DURATION_QUARTERS_V1",
+            baseline_id="UNCONDITIONAL_20_BAR_PRICE_CHANNEL_BREAKOUT_V1",
+            strategy_identity="VOLATILITY_COMPRESSION_BREAKOUT_V1",
+            timestamps_utc=a.timestamps_utc,
+        )
+
+    real.wire_treatment_baseline = _fake_wire  # type: ignore[method-assign]
+    before = read_run_counters(REPO)
+    bundle = real.run_canonical_backtest(
+        panel, cost_execution_binding=_cost_binding(), cost_multiplier=1.0
+    )
+    assert bundle.trade_count >= 1
+    assert bundle.evaluable_treatment_breakout_events == 1
+    assert bundle.extras.get("productive_exit_pnl_evaluator_bound") is True
+    assert read_run_counters(REPO) == before


### PR DESCRIPTION
## Summary
- **Implementation-only** binding of the missing productive Exit-PnL / roundtrip evaluator for `VOLATILITY_COMPRESSION_BREAKOUT_V1` development evaluation.
- `RealExecutionBoundaryV1` now consumes panel wiring and realizes treatment/baseline roundtrips via canonical BacktestEngine gross-PnL + fee/slippage primitives (no second PnL truth).
- **No evaluation**, run budget untouched (`RUN_COUNT=0`), holdout untouched.

## Explicit non-goals
- No development evaluation execution / runner start
- No strategy-parameter, preregistration, or measurement-contract semantic changes
- No Master V2 / Double-Play / risk-sizing / execution-kernel authority mutation
- No holdout access; development-only enforced

## Test plan
- [x] Focused productive-exit-PnL + entry/executable tests (29 passed)
- [x] Docs token/reference gates
- [x] Selector `PR_BOUNDED_FULL` timing batch including focused owners (734 passed, ~36s)
- [ ] GitHub required checks confirmation
- [ ] **Do not** execute evaluation from this PR

## RISK_LIMIT_JUSTIFICATION
No live/runtime/portfolio risk limits are raised or mutated.

Policy Critic may match research metric field assignment `max_drawdown=treatment.max_drawdown` in the development-evaluation boundary. This is a metrics handoff field from the productive evaluator into the existing BacktestMetricsBundle, not a live risk-limit raise. Risk/sizing/execution/live authorities remain closed.


Made with [Cursor](https://cursor.com)