### PR TITLE
infra: fail-closed Calmar annualization OverflowError guard

### DIFF
--- a/docs/evidence/forensic_productive_pnl_overflow_calmar_annualization_v1/README.md
+++ b/docs/evidence/forensic_productive_pnl_overflow_calmar_annualization_v1/README.md
@@ -1,0 +1,44 @@
+# Forensic: productive PnL OverflowError → Calmar annualization
+
+```text
+SCOPE=INFRASTRUCTURE_ONLY
+BASE_SHA=c1e20a28faee4242d93309942ee4548826c5d668
+FIRST_LOSS_BOUNDARY=src/backtest/stats.py::compute_calmar_ratio
+OVERFLOW_CLASS=ACCUMULATION
+PRODUCTIVE_PNL_REEXECUTED=false
+DEVELOPMENT_EVALUATION_REEXECUTED=false
+HOLDOUT_ACCESSED=false
+STRATEGY_PARAMETERS_CHANGED=false
+SECOND_PNL_TRUTH_CREATED=false
+```
+
+## Finding
+
+Terminal VCB/VDB evidence recorded `UNEXPECTED:OverflowError:(34, 'Result too large')`
+during productive PnL/metrics materialization. Static + synthetic reproduction shows
+the exception is raised in `compute_calmar_ratio` when:
+
+1. equity has non-zero drawdown (annualization path is entered),
+2. `total_return` is explosively large,
+3. `years = (len(equity)-1) / periods_per_year` is small (hourly `24*365`).
+
+Python's `**` raises `OverflowError` before the existing `np.isfinite` guard runs.
+
+## Not repaired in this slice
+
+Equity construction in
+`productive_exit_pnl_evaluator_v1._metrics_from_trades`
+(`UNIT_RISK_NOTIONAL=1.0` + absolute multi-instrument quote PnL) amplifies
+`total_return`. Changing that would alter evaluation metric semantics and needs a
+separate operator GO.
+
+## Infra-only repair
+
+Catch `OverflowError` on the annualization power and return the existing catastrophic
+non-finite Calmar sentinel. No strategy parameters, hypothesis, or PnL primitive change.
+
+---
+docs_token: DOCS_TOKEN_FORENSIC_PRODUCTIVE_PNL_OVERFLOW_CALMAR_ANNUALIZATION_V1
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+---

--- a/docs/evidence/forensic_productive_pnl_overflow_calmar_annualization_v1/README.md
+++ b/docs/evidence/forensic_productive_pnl_overflow_calmar_annualization_v1/README.md
@@ -20,7 +20,7 @@ the exception is raised in `compute_calmar_ratio` when:
 
 1. equity has non-zero drawdown (annualization path is entered),
 2. `total_return` is explosively large,
-3. `years = (len(equity)-1) / periods_per_year` is small (hourly `24*365`).
+3. `years = (len(equity)-1) &#47; periods_per_year` is small (hourly `24*365`).
 
 Python's `**` raises `OverflowError` before the existing `np.isfinite` guard runs.
 

--- a/docs/evidence/forensic_productive_pnl_overflow_calmar_annualization_v1/summary.json
+++ b/docs/evidence/forensic_productive_pnl_overflow_calmar_annualization_v1/summary.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "forensic_productive_pnl_overflow_calmar_annualization.v1",
+  "scope_type": "INFRASTRUCTURE_ONLY",
+  "base_sha": "c1e20a28faee4242d93309942ee4548826c5d668",
+  "related_prs": [5451],
+  "strategies_affected": [
+    "VOLATILITY_COMPRESSION_BREAKOUT_V1",
+    "VOLATILITY_DECAY_BREAKOUT_V1"
+  ],
+  "terminal_evidence_reason": "UNEXPECTED:OverflowError:(34, 'Result too large')",
+  "productive_pnl_reexecuted": false,
+  "development_evaluation_reexecuted": false,
+  "holdout_accessed": false,
+  "strategy_parameters_changed": false,
+  "hypothesis_changed": false,
+  "second_pnl_truth_created": false,
+  "first_loss_boundary": "src/backtest/stats.py::compute_calmar_ratio",
+  "overflow_class": "ACCUMULATION",
+  "root_cause": "compute_calmar_ratio annualizes via annualization_base ** (1/years). For explosively large positive total_return and small years, Python raises OverflowError:(34,'Result too large') before the existing np.isfinite guard. Productive exit/PnL evaluator always calls compute_backtest_stats (which always computes calmar) even though VCB/VDB gates do not consume calmar.",
+  "upstream_amplifier_not_repaired_here": "productive_exit_pnl_evaluator_v1._metrics_from_trades builds equity as UNIT_RISK_NOTIONAL(1.0)+cumsum(absolute multi-instrument quote PnL), which can produce huge total_return vs start=1. Changing that alters evaluation metric semantics and requires separate operator GO.",
+  "synthetic_reproduction": {
+    "periods_per_year": 8760,
+    "equity_start": 1.0,
+    "pnl_pattern": "[1e8 if i%5 else -2e7 for i in range(30)]",
+    "observed_exception": "OverflowError:(34, 'Result too large')"
+  },
+  "infrastructure_only_fix": "Catch OverflowError around the annualization power and return the existing catastrophic non-finite sentinel; no strategy/hypothesis/PnL-primitive change.",
+  "regression_tests": [
+    "tests/backtest/test_stats_calmar_negative_equity_v0.py::test_compute_calmar_ratio_positive_annualization_overflow_returns_finite_sentinel",
+    "tests/backtest/test_stats_calmar_negative_equity_v0.py::test_compute_backtest_stats_positive_annualization_overflow_no_overflow_error"
+  ],
+  "next_canonical_action": "MERGE_INFRA_CALMAR_OVERFLOW_GUARD_THEN_SEPARATE_OPERATOR_GO_IF_EQUITY_SCALING_SEMANTICS_OR_NEW_HYPOTHESIS_REQUIRED"
+}

--- a/src/backtest/stats.py
+++ b/src/backtest/stats.py
@@ -178,7 +178,13 @@ def compute_calmar_ratio(equity: pd.Series, periods_per_year: int = 252) -> floa
     if annualization_base <= 0.0:
         return float(_CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL)
 
-    annual_return = annualization_base ** (1 / years) - 1
+    # Positive explosion (e.g. huge total_return / tiny years) raises OverflowError
+    # from Python's ``**`` before a non-finite float is returned. Mirror the
+    # existing non-finite fail-closed contract — do not crash metrics callers.
+    try:
+        annual_return = annualization_base ** (1 / years) - 1.0
+    except OverflowError:
+        return float(_CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL)
     if not np.isfinite(annual_return):
         return float(_CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL)
 

--- a/tests/backtest/test_stats_calmar_negative_equity_v0.py
+++ b/tests/backtest/test_stats_calmar_negative_equity_v0.py
@@ -78,3 +78,35 @@ def test_compute_backtest_stats_negative_equity_no_type_error():
     assert isinstance(stats["calmar"], float)
     assert math.isfinite(stats["calmar"])
     assert stats["calmar"] <= 0.0
+
+
+def test_compute_calmar_ratio_positive_annualization_overflow_returns_finite_sentinel():
+    """VCB/VDB productive-PnL class: huge equity vs start=1 must not raise OverflowError.
+
+    Reproduces ``OverflowError: (34, 'Result too large')`` from
+    ``annualization_base ** (1 / years)`` when total_return is explosive, years is
+    tiny (hourly ppy), and drawdown is non-zero so annualization is attempted.
+    """
+    unit = 1.0
+    pnls = [1e8 if i % 5 else -2e7 for i in range(30)]
+    equity = pd.Series([unit] + [unit + sum(pnls[: i + 1]) for i in range(len(pnls))])
+
+    calmar = compute_calmar_ratio(equity, periods_per_year=24 * 365)
+
+    assert isinstance(calmar, float)
+    assert math.isfinite(calmar)
+    assert calmar == _CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL
+
+
+def test_compute_backtest_stats_positive_annualization_overflow_no_overflow_error():
+    """Productive evaluator metrics path must remain fail-closed finite under explosion."""
+    unit = 1.0
+    pnls = [1e8 if i % 5 else -2e7 for i in range(30)]
+    equity = pd.Series([unit] + [unit + sum(pnls[: i + 1]) for i in range(len(pnls))])
+    trades = [{"pnl": float(p)} for p in pnls]
+
+    stats = compute_backtest_stats(trades, equity, periods_per_year=24 * 365)
+
+    assert math.isfinite(float(stats["calmar"]))
+    assert math.isfinite(float(stats["total_return"]))
+    assert stats["calmar"] == _CALMAR_CATASTROPHIC_NEGATIVE_RETURN_SENTINEL


### PR DESCRIPTION
## Summary
- Forensic root cause of VCB/VDB terminal `OverflowError:(34, 'Result too large')`: unguarded `annualization_base ** (1/years)` in `compute_calmar_ratio`.
- Infrastructure-only fix: catch `OverflowError` and return the existing catastrophic non-finite Calmar sentinel (same contract as `np.isfinite` path).
- Adds synthetic regression tests + durable forensic evidence. No strategy/hypothesis/PnL-primitive change. No evaluation re-run. No holdout access.

## Forensics
- `FIRST_LOSS_BOUNDARY=src/backtest/stats.py::compute_calmar_ratio`
- `OVERFLOW_CLASS=ACCUMULATION`
- Upstream amplifier (not repaired): productive evaluator equity `UNIT_RISK_NOTIONAL=1.0 + cumsum(absolute multi-instrument quote PnL)` can inflate `total_return`; changing that alters evaluation semantics and needs separate GO.
- Evidence: `docs/evidence/forensic_productive_pnl_overflow_calmar_annualization_v1/`

## RISK_LIMIT_JUSTIFICATION
- Shared stats infrastructure fail-closed only. No Master V2 / Double-Play / risk-sizing / execution-authority mutation.
- `LIVE_AUTHORIZED=false`, `ORDERS=false`, `HOLDOUT_ACCESSED=false`, `SECOND_PNL_TRUTH_CREATED=false`.
- Development slots remain consumed; no retry/re-evaluation in this PR.

## Test plan
- [x] `pytest tests/backtest/test_stats_calmar_negative_equity_v0.py`
- [x] PR-bounded selector targets for central `src/` path
- [x] docs token policy + docs reference targets
- [ ] CI confirmation on PR head


Made with [Cursor](https://cursor.com)