### PR TITLE
fix(research): wire RESEARCH_EQUAL_WEIGHT_NORMALIZED_SLEEVE_COMBINE_V1 into productive PnL metrics

### DIFF
--- a/src/research/volatility_compression_breakout_v1_development_evaluation_v1/productive_exit_pnl_evaluator_v1.py
+++ b/src/research/volatility_compression_breakout_v1_development_evaluation_v1/productive_exit_pnl_evaluator_v1.py
@@ -28,6 +28,10 @@ from src.backtest.engine import (
 )
 from src.backtest.stats import compute_backtest_stats
 from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+from src.research.regime_gated_standaside_mr_development_evaluation_v1.shared_portfolio_equity_research_v1 import (
+    PORTFOLIO_AGGREGATION_ID,
+    build_equal_weight_portfolio_equity,
+)
 from src.research.volatility_compression_breakout_v1_development_evaluation_v1.constants_v1 import (
     DATASET_ID,
     FEE_BPS_PER_SIDE,
@@ -52,6 +56,10 @@ PRODUCTIVE_EXIT_PNL_EVALUATOR_OWNER = (
 )
 CANONICAL_PNL_PRIMITIVE_OWNER = "backtest.engine._compute_directional_gross_pnl_v0"
 UNIT_RISK_NOTIONAL_V1 = 1.0
+# Canonical RESEARCH_EQUAL_WEIGHT_NORMALIZED_SLEEVE_COMBINE_V1 shared book capital.
+SHARED_INITIAL_CAPITAL_V1 = 10_000.0
+HOURLY_PERIODS_PER_YEAR_V1 = 24 * 365
+_FLAT_SLEEVE_ANCHOR_UTC = pd.Timestamp("1970-01-01T00:00:00Z")
 
 ExitReasonV1 = Literal[
     "INITIAL_STOP",
@@ -359,8 +367,83 @@ def simulate_arm_roundtrips_v1(
     return tuple(trades)
 
 
-def _metrics_from_trades(trades: Sequence[RoundtripTradeV1]) -> dict[str, float]:
+def _as_utc_timestamp(value: str) -> pd.Timestamp:
+    ts = pd.Timestamp(value)
+    if ts.tzinfo is None:
+        return ts.tz_localize("UTC")
+    return ts.tz_convert("UTC")
+
+
+def _flat_sleeve_equity_v1() -> pd.Series:
+    """No-trade sleeve: constant unit-risk cash; equal-weight dilutes inactive sleeves."""
+    return pd.Series(
+        [UNIT_RISK_NOTIONAL_V1],
+        index=pd.DatetimeIndex([_FLAT_SLEEVE_ANCHOR_UTC]),
+        dtype=float,
+    )
+
+
+def _sleeve_equity_curve_from_trades_v1(trades: Sequence[RoundtripTradeV1]) -> pd.Series:
+    """Build one instrument sleeve equity from existing roundtrip net PnL truth."""
     if not trades:
+        return _flat_sleeve_equity_v1()
+    ordered = sorted(
+        trades,
+        key=lambda tr: (
+            str(tr.exit_time),
+            str(tr.entry_time),
+            tr.instrument_id,
+            int(tr.entry_index),
+            int(tr.exit_index),
+        ),
+    )
+    t0 = _as_utc_timestamp(ordered[0].entry_time)
+    times: list[pd.Timestamp] = [t0]
+    values: list[float] = [UNIT_RISK_NOTIONAL_V1]
+    running = UNIT_RISK_NOTIONAL_V1
+    for tr in ordered:
+        running += float(tr.pnl)
+        times.append(_as_utc_timestamp(tr.exit_time))
+        values.append(running)
+    series = pd.Series(values, index=pd.DatetimeIndex(times), dtype=float)
+    if series.index.duplicated().any():
+        series = series[~series.index.duplicated(keep="last")]
+    return series
+
+
+def _combined_portfolio_equity_from_trades_v1(
+    trades: Sequence[RoundtripTradeV1],
+    *,
+    sleeve_instrument_ids: Sequence[str] | None = None,
+) -> pd.Series:
+    """Sole gate-facing equity: RESEARCH_EQUAL_WEIGHT_NORMALIZED_SLEEVE_COMBINE_V1."""
+    if PORTFOLIO_AGGREGATION_ID != "RESEARCH_EQUAL_WEIGHT_NORMALIZED_SLEEVE_COMBINE_V1":
+        raise ValueError(f"PORTFOLIO_AGGREGATION_ID_DRIFT:{PORTFOLIO_AGGREGATION_ID}")
+    by_instrument: dict[str, list[RoundtripTradeV1]] = {}
+    for tr in trades:
+        by_instrument.setdefault(str(tr.instrument_id), []).append(tr)
+    sleeve_ids = (
+        [str(x) for x in sleeve_instrument_ids]
+        if sleeve_instrument_ids is not None
+        else sorted(by_instrument)
+    )
+    if not sleeve_ids:
+        raise ValueError("EMPTY_SLEEVE_INSTRUMENT_IDS")
+    sleeves: dict[str, pd.Series] = {}
+    for instrument_id in sleeve_ids:
+        sleeves[instrument_id] = _sleeve_equity_curve_from_trades_v1(
+            by_instrument.get(instrument_id, [])
+        )
+    return build_equal_weight_portfolio_equity(sleeves, initial_capital=SHARED_INITIAL_CAPITAL_V1)
+
+
+def _metrics_from_trades(
+    trades: Sequence[RoundtripTradeV1],
+    *,
+    sleeve_instrument_ids: Sequence[str] | None = None,
+) -> dict[str, float]:
+    """Gate-facing metrics from equal-weight normalized sleeve combine equity only."""
+    if not trades and not sleeve_instrument_ids:
         return {
             "gross_return": 0.0,
             "net_return": 0.0,
@@ -373,14 +456,10 @@ def _metrics_from_trades(trades: Sequence[RoundtripTradeV1]) -> dict[str, float]
             "trade_count": 0.0,
         }
     records = [t.to_stats_record() for t in trades]
-    equity = pd.Series(
-        [UNIT_RISK_NOTIONAL_V1]
-        + [
-            UNIT_RISK_NOTIONAL_V1 + sum(tr.pnl for tr in trades[: idx + 1])
-            for idx in range(len(trades))
-        ]
+    equity = _combined_portfolio_equity_from_trades_v1(
+        trades, sleeve_instrument_ids=sleeve_instrument_ids
     )
-    stats = compute_backtest_stats(records, equity, periods_per_year=24 * 365)
+    stats = compute_backtest_stats(records, equity, periods_per_year=HOURLY_PERIODS_PER_YEAR_V1)
     gross_pnls = [t.gross_pnl for t in trades]
     gross_wins = sum(x for x in gross_pnls if x > 0)
     gross_losses = sum(-x for x in gross_pnls if x < 0)
@@ -392,7 +471,7 @@ def _metrics_from_trades(trades: Sequence[RoundtripTradeV1]) -> dict[str, float]
         "gross_profit_factor": float(gpf),
         "net_profit_factor": float(stats.get("profit_factor") or 0.0),
         "gross_pnl": float(sum(gross_pnls)),
-        "net_expectancy": float(sum(net_pnls) / len(net_pnls)),
+        "net_expectancy": float(sum(net_pnls) / len(net_pnls)) if net_pnls else 0.0,
         "sharpe": float(stats.get("sharpe") or 0.0),
         "max_drawdown": float(abs(stats.get("max_drawdown") or 0.0)),
         "trade_count": float(len(trades)),
@@ -408,7 +487,7 @@ def evaluate_arm_productive_pnl_v1(
     trades = simulate_arm_roundtrips_v1(
         panel_series=panel_series, arm=arm, effective_cost=effective_cost
     )
-    metrics = _metrics_from_trades(trades)
+    metrics = _metrics_from_trades(trades, sleeve_instrument_ids=(arm.instrument_id,))
     return ArmPnLResultV1(
         arm_id=arm.arm_id,
         trades=trades,
@@ -445,17 +524,18 @@ def evaluate_treatment_and_baseline_productive_pnl_v1(
     if not handoff.baseline:
         raise ValueError("EMPTY_BASELINE_ARMS")
 
-    # Aggregate multi-instrument arms with identical evaluator.
+    # Aggregate multi-instrument arms with identical evaluator + contracted portfolio.
     def _agg(arms: tuple[ArmEventSeriesV1, ...], arm_id: str) -> ArmPnLResultV1:
         all_trades: list[RoundtripTradeV1] = []
         events = 0
+        sleeve_ids = [str(arm.instrument_id) for arm in arms]
         for arm in arms:
             one = evaluate_arm_productive_pnl_v1(
                 panel_series=panel_series, arm=arm, effective_cost=effective
             )
             all_trades.extend(one.trades)
             events += one.evaluable_entry_events
-        metrics = _metrics_from_trades(all_trades)
+        metrics = _metrics_from_trades(all_trades, sleeve_instrument_ids=sleeve_ids)
         return ArmPnLResultV1(
             arm_id=arm_id,
             trades=tuple(all_trades),

--- a/tests/research/test_volatility_compression_breakout_v1_productive_exit_pnl_evaluator_v1.py
+++ b/tests/research/test_volatility_compression_breakout_v1_productive_exit_pnl_evaluator_v1.py
@@ -289,3 +289,229 @@ def test_real_boundary_no_longer_raises_unbound() -> None:
     assert bundle.evaluable_treatment_breakout_events == 1
     assert bundle.extras.get("productive_exit_pnl_evaluator_bound") is True
     assert read_run_counters(REPO) == before
+
+
+def _synthetic_trade(
+    *,
+    instrument_id: str,
+    pnl: float,
+    exit_day: int,
+    entry_day: int | None = None,
+    gross_pnl: float | None = None,
+    entry_fee: float = 0.0,
+    exit_fee: float = 0.0,
+    entry_slippage: float = 0.0,
+    exit_slippage: float = 0.0,
+) -> RoundtripTradeV1:
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        RoundtripTradeV1,
+    )
+
+    ed = entry_day if entry_day is not None else exit_day
+    g = float(pnl if gross_pnl is None else gross_pnl)
+    return RoundtripTradeV1(
+        instrument_id=instrument_id,
+        side="long",
+        entry_index=ed,
+        exit_index=exit_day,
+        entry_time=f"2022-06-{ed:02d}T00:00:00Z",
+        exit_time=f"2022-06-{exit_day:02d}T01:00:00Z",
+        entry_price=100.0,
+        exit_price=101.0,
+        size=1.0,
+        stop_price_at_entry=98.5,
+        exit_reason="TIME_EXIT",
+        gross_pnl=g,
+        entry_fee=entry_fee,
+        exit_fee=exit_fee,
+        entry_slippage=entry_slippage,
+        exit_slippage=exit_slippage,
+        pnl=float(pnl),
+    )
+
+
+def test_equal_weight_two_identical_sleeves_do_not_double_return() -> None:
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        PORTFOLIO_AGGREGATION_ID,
+        _metrics_from_trades,
+    )
+
+    assert PORTFOLIO_AGGREGATION_ID == "RESEARCH_EQUAL_WEIGHT_NORMALIZED_SLEEVE_COMBINE_V1"
+    one = (_synthetic_trade(instrument_id="A", pnl=0.50, exit_day=1),)
+    two = (
+        _synthetic_trade(instrument_id="A", pnl=0.50, exit_day=1),
+        _synthetic_trade(instrument_id="B", pnl=0.50, exit_day=1),
+    )
+    m1 = _metrics_from_trades(one, sleeve_instrument_ids=("A",))
+    m2 = _metrics_from_trades(two, sleeve_instrument_ids=("A", "B"))
+    assert m2["net_return"] == pytest.approx(m1["net_return"], rel=1e-12)
+    assert m2["net_return"] == pytest.approx(0.50, rel=1e-12)
+
+
+def test_equal_weight_n_identical_sleeves_independent_of_n() -> None:
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        _metrics_from_trades,
+    )
+
+    returns = []
+    for n in (1, 2, 5, 20):
+        trades = tuple(
+            _synthetic_trade(instrument_id=f"I{i}", pnl=0.25, exit_day=1) for i in range(n)
+        )
+        sleeve_ids = tuple(f"I{i}" for i in range(n))
+        m = _metrics_from_trades(trades, sleeve_instrument_ids=sleeve_ids)
+        returns.append(m["net_return"])
+    assert all(abs(r - returns[0]) < 1e-12 for r in returns)
+    assert returns[0] == pytest.approx(0.25, rel=1e-12)
+
+
+def test_equal_weight_mixed_sleeve_returns_mean() -> None:
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        _metrics_from_trades,
+    )
+
+    trades = (
+        _synthetic_trade(instrument_id="A", pnl=0.90, exit_day=1),
+        _synthetic_trade(instrument_id="B", pnl=0.30, exit_day=1),
+    )
+    m = _metrics_from_trades(trades, sleeve_instrument_ids=("A", "B"))
+    assert m["net_return"] == pytest.approx(0.60, rel=1e-12)
+
+
+def test_equal_weight_win_and_loss_sleeves_combine() -> None:
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        _metrics_from_trades,
+    )
+
+    trades = (
+        _synthetic_trade(instrument_id="WIN", pnl=0.40, exit_day=2),
+        _synthetic_trade(instrument_id="LOSS", pnl=-0.20, exit_day=2),
+    )
+    m = _metrics_from_trades(trades, sleeve_instrument_ids=("WIN", "LOSS"))
+    assert m["net_return"] == pytest.approx(0.10, rel=1e-12)
+    assert m["max_drawdown"] >= 0.0
+
+
+def test_equal_weight_instrument_without_trades_dilutes() -> None:
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        _metrics_from_trades,
+    )
+
+    trades = (_synthetic_trade(instrument_id="A", pnl=0.60, exit_day=1),)
+    active_only = _metrics_from_trades(trades, sleeve_instrument_ids=("A",))
+    with_idle = _metrics_from_trades(trades, sleeve_instrument_ids=("A", "IDLE"))
+    assert with_idle["net_return"] == pytest.approx(0.30, rel=1e-12)
+    assert with_idle["net_return"] < active_only["net_return"]
+
+
+def test_equal_weight_staggered_exit_times_align() -> None:
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        _combined_portfolio_equity_from_trades_v1,
+        _metrics_from_trades,
+    )
+
+    trades = (
+        _synthetic_trade(instrument_id="A", pnl=0.20, exit_day=1),
+        _synthetic_trade(instrument_id="B", pnl=0.40, exit_day=3),
+    )
+    equity = _combined_portfolio_equity_from_trades_v1(trades, sleeve_instrument_ids=("A", "B"))
+    assert equity.index.is_monotonic_increasing
+    m = _metrics_from_trades(trades, sleeve_instrument_ids=("A", "B"))
+    assert m["net_return"] == pytest.approx(0.30, rel=1e-12)
+
+
+def test_equal_weight_fees_slippage_remain_in_net_pnl_truth() -> None:
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        _metrics_from_trades,
+    )
+
+    trades = (
+        _synthetic_trade(
+            instrument_id="A",
+            pnl=0.40,
+            gross_pnl=0.55,
+            entry_fee=0.05,
+            exit_fee=0.05,
+            entry_slippage=0.025,
+            exit_slippage=0.025,
+            exit_day=1,
+        ),
+    )
+    m = _metrics_from_trades(trades, sleeve_instrument_ids=("A",))
+    assert trades[0].pnl == pytest.approx(0.40)
+    assert trades[0].gross_pnl == pytest.approx(0.55)
+    assert m["net_return"] == pytest.approx(0.40, rel=1e-12)
+    assert m["gross_pnl"] == pytest.approx(0.55, rel=1e-12)
+
+
+def test_single_instrument_semantics_match_unit_risk_sleeve_return() -> None:
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        UNIT_RISK_NOTIONAL_V1,
+        _metrics_from_trades,
+    )
+
+    trades = (
+        _synthetic_trade(instrument_id="SOLO", pnl=0.12, exit_day=1),
+        _synthetic_trade(instrument_id="SOLO", pnl=-0.04, exit_day=2),
+    )
+    m = _metrics_from_trades(trades, sleeve_instrument_ids=("SOLO",))
+    expected = sum(t.pnl for t in trades) / UNIT_RISK_NOTIONAL_V1
+    assert m["net_return"] == pytest.approx(expected, rel=1e-12)
+
+
+def test_gate_facing_stats_use_combined_equity_not_n_scaled_absolute_sum() -> None:
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        SHARED_INITIAL_CAPITAL_V1,
+        UNIT_RISK_NOTIONAL_V1,
+        _combined_portfolio_equity_from_trades_v1,
+        _metrics_from_trades,
+    )
+
+    n = 50
+    trades = tuple(_synthetic_trade(instrument_id=f"I{i}", pnl=0.10, exit_day=1) for i in range(n))
+    sleeve_ids = tuple(f"I{i}" for i in range(n))
+    m = _metrics_from_trades(trades, sleeve_instrument_ids=sleeve_ids)
+    legacy_n_scaled = sum(t.pnl for t in trades) / UNIT_RISK_NOTIONAL_V1
+    assert m["net_return"] == pytest.approx(0.10, rel=1e-12)
+    assert m["net_return"] != pytest.approx(legacy_n_scaled, rel=1e-6)
+    equity = _combined_portfolio_equity_from_trades_v1(trades, sleeve_instrument_ids=sleeve_ids)
+    assert float(equity.iloc[0]) == pytest.approx(SHARED_INITIAL_CAPITAL_V1, rel=1e-12)
+
+
+def test_calmar_overflow_guard_still_reachable_via_combined_equity_path() -> None:
+    """Combined equity still routes through compute_backtest_stats (Calmar guard preserved)."""
+    from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+        RoundtripTradeV1,
+        _metrics_from_trades,
+    )
+
+    # Explosive sleeve PnLs with drawdowns so Calmar annualization is attempted.
+    trades = []
+    for i in range(30):
+        pnl = 1e8 if i % 5 else -2e7
+        day = (i % 28) + 1
+        minute = (i * 2) % 60
+        trades.append(
+            RoundtripTradeV1(
+                instrument_id="BOMB",
+                side="long",
+                entry_index=i,
+                exit_index=i + 1,
+                entry_time=f"2022-06-{day:02d}T00:{minute:02d}:00Z",
+                exit_time=f"2022-06-{day:02d}T01:{minute:02d}:00Z",
+                entry_price=1.0,
+                exit_price=1.1,
+                size=1.0,
+                stop_price_at_entry=0.9,
+                exit_reason="TIME_EXIT",
+                gross_pnl=pnl,
+                entry_fee=0.0,
+                exit_fee=0.0,
+                entry_slippage=0.0,
+                exit_slippage=0.0,
+                pnl=pnl,
+            )
+        )
+    m = _metrics_from_trades(tuple(trades), sleeve_instrument_ids=("BOMB",))
+    assert isinstance(m["net_return"], float)
+    assert m["net_return"] == m["net_return"]  # finite


### PR DESCRIPTION
## Summary
- Implements preregistered `RESEARCH_EQUAL_WEIGHT_NORMALIZED_SLEEVE_COMBINE_V1` as the **sole** gate-facing portfolio equity/return path in the shared productive exit/PnL evaluator.
- Reuses the canonical `build_equal_weight_portfolio_equity` owner; no second PnL/equity/stats truth.
- Removes N-instrument return scaling caused by cumsum of absolute quote PnL against `UNIT_RISK_NOTIONAL=1.0` as portfolio capital.
- No strategy/hypothesis/sizing/ATR/entry/exit/fee/slippage change. No evaluation or re-evaluation. Development slot remains 1/1 consumed.

## Contract repair
- First divergence was `_metrics_from_trades` (absolute multi-instrument PnL on unit-risk capital).
- Sleeve = `instrument_id`; sleeve equity starts at existing unit-risk cash and accumulates existing roundtrip net PnL.
- Sleeves are normalized and equal-weighted onto shared `initial_capital=10000` via the canonical combine helper.
- Instruments without trades contribute a flat sleeve (dilution), matching inactive-sleeve equal-weight semantics.
- Temporal alignment uses the canonical DataFrame/`ffill`/`bfill` path.
- Gate-facing return/DD/Sharpe/Calmar continue through `compute_backtest_stats` (Calmar overflow guard preserved).

## Non-goals / safety
- Previous VCB/VDB development evaluation results remain terminal FAIL_CLOSED and are **not** rewritten or re-interpreted here.
- A separately authorized evaluation would be required before any new economic read of results.
- `HOLDOUT_ACCESSED=false`, `LIVE_AUTHORIZED=false`, `ORDERS=false`.

## RISK_LIMIT_JUSTIFICATION
- Measurement/contract wiring only inside research productive evaluator metrics aggregation.
- No Master V2, Double-Play, risk/sizing authority, execution kernel, runtime, shadow, testnet, live, or order activation.
- Existing trade/fill/PnL primitives unchanged; fees/slippage remain inside sleeve net PnL truth.

## Test plan
- [x] New equal-weight sleeve combine regression tests (identical sleeves, N-independence, mixed/loss, idle dilution, staggered times, fees, single-instrument stability, anti-N-scaling, Calmar path)
- [x] Existing productive evaluator tests
- [x] Existing Calmar overflow-guard tests
- [ ] CI confirmation on PR head


Made with [Cursor](https://cursor.com)