### PR TITLE
research: materialize VCEB panel execution boundary (no evaluation run)

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -936,14 +936,15 @@
       ]
     },
     "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1: executable evaluate path under fail-closed authorization; productive exit/PnL evaluator referenced from VCB package (not duplicated). Development evaluation authorized on HEAD; no runner start/run-slot consumption without separate execution GO; no holdout/runtime/orders; measurement thresholds and strategy/baseline parameters unchanged; VDBX/VDB/VEP/VCB slots not reused.",
+      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1: panel execution boundary materialized (loader/wiring/injectable boundary); productive exit/PnL evaluator reused from VCB package (not duplicated). Development evaluation authorized on HEAD; no runner start/run-slot consumption without separate execution GO; no holdout/runtime/orders; measurement thresholds and strategy/baseline parameters unchanged; VDBX/VDB/VEP/VCB slots not reused.",
       "path_prefixes": [
         "config/research/volatility_contraction_expansion_breakout_v1_development_evaluation_entry_point_binding_v1.json",
         "docs/evidence/evaluate_volatility_contraction_expansion_breakout_development_v1/",
         "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
         "scripts/research/run_evaluate_volatility_contraction_expansion_breakout_development_v1.py",
         "src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/",
-        "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_entry_point_v1.py"
+        "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_entry_point_v1.py",
+        "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_executable_path_v1.py"
       ]
     },
     "VOLATILITY_DECAY_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {

--- a/docs/evidence/evaluate_volatility_contraction_expansion_breakout_development_v1/README.md
+++ b/docs/evidence/evaluate_volatility_contraction_expansion_breakout_development_v1/README.md
@@ -1,9 +1,10 @@
-# Evaluate volatility contraction-expansion breakout development v1 — entry point only
+# Evaluate volatility contraction-expansion breakout development v1 — panel boundary
 
 ```text
 SLICE=EVALUATE_VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_DEVELOPMENT_V1
-STATUS=EXECUTABLE_EVALUATE_PATH_PRESENT_DEVELOPMENT_EVALUATION_AUTHORIZED
+STATUS=EXECUTABLE_EVALUATE_PATH_PRESENT_PANEL_BOUNDARY_MATERIALIZED_DEVELOPMENT_EVALUATION_AUTHORIZED
 DEVELOPMENT_EVALUATION_AUTHORIZED=true
+PANEL_BOUNDARY_MATERIALIZED=true
 EVALUATION_EXECUTED=false
 RUNNER_STARTED=false
 DEVELOPMENT_DATASET_LOADED=false
@@ -14,12 +15,13 @@ DEVELOPMENT_SLOT_CONSUMED=false
 ```
 
 Placeholder evidence directory for the canonical entry point.
-Development evaluation is authorized; no evaluation has been executed.
+Panel execution boundary is materialized; development evaluation is authorized;
+no evaluation has been executed.
 
 ---
 docs_token: DOCS_TOKEN_EVALUATE_VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_DEVELOPMENT_V1_ENTRY_POINT_PLACEHOLDER
-STATUS: EXECUTABLE_EVALUATE_PATH_PRESENT_DEVELOPMENT_EVALUATION_AUTHORIZED
-scope: research, offline-only, authorizing-only, evidence-placeholder
+STATUS: EXECUTABLE_EVALUATE_PATH_PRESENT_PANEL_BOUNDARY_MATERIALIZED_DEVELOPMENT_EVALUATION_AUTHORIZED
+scope: research, offline-only, panel-boundary-only, evidence-placeholder
 LIVE_AUTHORIZED: false
 ORDERS_ALLOWED: false
 SCHEDULER_RUNTIME_ALLOWED: false

--- a/docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md
+++ b/docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md
@@ -4,11 +4,12 @@ DOCS_TOKEN_VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_E
 
 ## Status
 
-`EXECUTABLE_EVALUATE_PATH_PRESENT_DEVELOPMENT_EVALUATION_AUTHORIZED`
+`EXECUTABLE_EVALUATE_PATH_PRESENT_PANEL_BOUNDARY_MATERIALIZED_DEVELOPMENT_EVALUATION_AUTHORIZED`
 
 Executable development-evaluation path is present under the canonical entry point.
-Development evaluation is authorized (`development_evaluation_authorized=true`);
-execution still requires a separate operator GO and has not run.
+Panel execution boundary (loader/wiring/injectable boundary/admission/evidence) is
+materialized. Development evaluation is authorized (`development_evaluation_authorized=true`);
+productive execution still requires a separate operator GO and has not run.
 No development evaluation executed. Run counts remain `0`.
 
 ## Owner
@@ -23,7 +24,8 @@ Modes:
 
 - `preflight` (default): no panel open, no runner start, no slot claim
 - `dry-validate`: prove executable-path contracts without runner start or counter mutation
-- `evaluate`: requires machine-checkable authorization (token **and** repo flags); panel execution remains a separate operator GO
+- `evaluate`: requires machine-checkable authorization (token **and** repo flags); productive
+  panel evaluation still requires a separate operator GO
 
 ## Bindings
 
@@ -41,6 +43,9 @@ Modes:
 - Productive PnL evaluator (reused, not duplicated):
   `src&#47;research&#47;volatility_compression_breakout_v1_development_evaluation_v1&#47;productive_exit_pnl_evaluator_v1.py`
 - Shared channel core: `src&#47;research&#47;price_channel_breakout_core_v1.py`
+- Panel boundary modules:
+  `panel_loader_v1` / `panel_wiring_v1` / `execution_boundary_v1` /
+  `admission_gates_v1` / `evidence_materialization_v1`
 
 ## Non-actions
 
@@ -49,6 +54,7 @@ Modes:
 - No run-slot consumption
 - No parameter / hypothesis mutation
 - No Shadow / Testnet / Live / Orders
+- No second PnL truth
 - Development evaluation authorization is true; evaluation not executed
 
 ## Next step
@@ -66,8 +72,8 @@ Modes:
 
 ---
 docs_token: DOCS_TOKEN_VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1
-STATUS: EXECUTABLE_EVALUATE_PATH_PRESENT_DEVELOPMENT_EVALUATION_AUTHORIZED
-scope: research, offline-only, authorizing-only, no-evaluation-execution
+STATUS: EXECUTABLE_EVALUATE_PATH_PRESENT_PANEL_BOUNDARY_MATERIALIZED_DEVELOPMENT_EVALUATION_AUTHORIZED
+scope: research, offline-only, panel-boundary-only, no-evaluation-execution
 LIVE_AUTHORIZED: false
 ORDERS_ALLOWED: false
 SCHEDULER_RUNTIME_ALLOWED: false

--- a/scripts/research/run_evaluate_volatility_contraction_expansion_breakout_development_v1.py
+++ b/scripts/research/run_evaluate_volatility_contraction_expansion_breakout_development_v1.py
@@ -4,8 +4,8 @@
 Modes:
   - preflight (default): bind digests/guards/evidence schema; no panel; no run.
   - dry-validate: prove executable-path contracts without runner start or counters.
-  - evaluate: requires machine-checkable authorization; fail-closed while
-    development_evaluation_authorized=false on HEAD.
+  - evaluate: requires machine-checkable authorization; panel boundary is materialized
+    but productive evaluation still requires a separate operator GO.
 
 Generic LIVE/SHADOW/TESTNET/SCHEDULER flags cannot authorize this runner.
 """
@@ -41,22 +41,22 @@ from src.research.volatility_contraction_expansion_breakout_v1_development_evalu
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "VDB v1 DEVELOPMENT evaluation entry point "
-            "(default: preflight; evaluate remains unauthorized on HEAD)."
+            "VCEB v1 DEVELOPMENT evaluation entry point "
+            "(default: preflight; panel boundary present; productive evaluate needs separate GO)."
         )
     )
     parser.add_argument(
         "--mode",
         choices=("preflight", "dry-validate", "evaluate"),
         default="preflight",
-        help="preflight (default), dry-validate, or evaluate (auth fail-closed on HEAD).",
+        help="preflight (default), dry-validate, or evaluate (authorization-gated).",
     )
     parser.add_argument(
         "--authorize-single-development-evaluation",
         default="",
         help=(
-            f"Must equal {HYPOTHESIS_ID}; still fail-closed while "
-            "development_evaluation_authorized=false on HEAD."
+            f"Must equal {HYPOTHESIS_ID}; productive evaluate still requires a separate "
+            "operator GO and must not be invoked from this panel-boundary slice."
         ),
     )
     parser.add_argument(

--- a/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/admission_gates_v1.py
+++ b/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/admission_gates_v1.py
@@ -1,0 +1,275 @@
+"""Admission gates for VCEB v1 development evaluation.
+
+Applies preregistered measurement-contract thresholds only. Does not invent or
+lower thresholds. Pure functions over already-computed metrics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.constants_v1 import (
+    COST_STRESS_1_5X_NET_PROFIT_FACTOR_MIN,
+    GROSS_PROFIT_FACTOR_MIN,
+    MAXIMUM_MAX_DRAWDOWN,
+    MINIMUM_NET_EXPECTANCY,
+    MINIMUM_PASSING_SEGMENTS,
+    MIN_EVALUABLE_TREATMENT_BREAKOUT_EVENTS,
+    MIN_EVALUABLE_TREATMENT_EVENTS_PER_TIME_SEGMENT,
+    MIN_EXECUTED_TREATMENT_TRADES,
+    NET_PROFIT_FACTOR_MIN,
+    TIME_SEGMENT_COUNT,
+    TIME_SEGMENT_ROBUSTNESS_PASS_RATIO,
+)
+
+
+@dataclass(frozen=True)
+class GateResultV1:
+    gate_id: str
+    passed: bool
+    reason_code: str | None
+    observed: Any
+    threshold: Any
+
+
+@dataclass(frozen=True)
+class AdmissionGateBundleV1:
+    sample_sufficiency: GateResultV1
+    trades_sufficiency: GateResultV1
+    segment_event_sufficiency: GateResultV1
+    gross_edge: GateResultV1
+    canonical_cost: GateResultV1
+    cost_stress: GateResultV1
+    max_drawdown: GateResultV1
+    baseline_improvement: GateResultV1
+    time_segment_robustness: GateResultV1
+    all_segments_evaluable: GateResultV1
+
+    @property
+    def all_pass(self) -> bool:
+        return all(
+            g.passed
+            for g in (
+                self.sample_sufficiency,
+                self.trades_sufficiency,
+                self.segment_event_sufficiency,
+                self.gross_edge,
+                self.canonical_cost,
+                self.cost_stress,
+                self.max_drawdown,
+                self.baseline_improvement,
+                self.time_segment_robustness,
+                self.all_segments_evaluable,
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        def _one(g: GateResultV1) -> dict[str, Any]:
+            return {
+                "gate_id": g.gate_id,
+                "passed": g.passed,
+                "reason_code": g.reason_code,
+                "observed": g.observed,
+                "threshold": g.threshold,
+            }
+
+        return {
+            "sample_sufficiency": _one(self.sample_sufficiency),
+            "trades_sufficiency": _one(self.trades_sufficiency),
+            "segment_event_sufficiency": _one(self.segment_event_sufficiency),
+            "gross_edge": _one(self.gross_edge),
+            "canonical_cost": _one(self.canonical_cost),
+            "cost_stress": _one(self.cost_stress),
+            "max_drawdown": _one(self.max_drawdown),
+            "baseline_improvement": _one(self.baseline_improvement),
+            "time_segment_robustness": _one(self.time_segment_robustness),
+            "all_segments_evaluable": _one(self.all_segments_evaluable),
+            "all_pass": self.all_pass,
+        }
+
+
+def _thresholds_from_contract(contract: Mapping[str, Any]) -> dict[str, float | int]:
+    thr = (contract.get("economic_admission_contract") or {}).get("thresholds") or {}
+    return {
+        "min_evaluable_treatment_breakout_events": int(
+            thr["min_evaluable_treatment_breakout_events"]["value"]
+        ),
+        "min_evaluable_treatment_events_per_time_segment": int(
+            thr["min_evaluable_treatment_events_per_time_segment"]["value"]
+        ),
+        "min_executed_treatment_trades": int(thr["min_executed_treatment_trades"]["value"]),
+        "time_segment_robustness_pass_ratio": float(
+            thr["time_segment_robustness_pass_ratio"]["value"]
+        ),
+        "gross_profit_factor_min": float(thr["gross_profit_factor_min"]["value"]),
+        "net_profit_factor_min": float(thr["net_profit_factor_min"]["value"]),
+        "cost_stress_1_5x_net_profit_factor_min": float(
+            thr["cost_stress_1_5x_net_profit_factor_min"]["value"]
+        ),
+        "maximum_max_drawdown": float(thr["maximum_max_drawdown"]["value"]),
+        "minimum_net_expectancy": float(thr["minimum_net_expectancy"]["value"]),
+    }
+
+
+def evaluate_admission_gates_v1(
+    *,
+    contract: Mapping[str, Any],
+    evaluable_treatment_breakout_events: int,
+    trade_count: int,
+    gross_profit_factor: float,
+    gross_pnl: float,
+    net_profit_factor: float,
+    baseline_net_profit_factor: float,
+    net_expectancy: float,
+    max_drawdown: float,
+    cost_stress_1_5x_net_profit_factor: float,
+    segment_results: Sequence[Mapping[str, Any]],
+) -> AdmissionGateBundleV1:
+    thr = _thresholds_from_contract(contract)
+    assert thr["min_evaluable_treatment_breakout_events"] == MIN_EVALUABLE_TREATMENT_BREAKOUT_EVENTS
+    assert (
+        thr["min_evaluable_treatment_events_per_time_segment"]
+        == MIN_EVALUABLE_TREATMENT_EVENTS_PER_TIME_SEGMENT
+    )
+    assert thr["min_executed_treatment_trades"] == MIN_EXECUTED_TREATMENT_TRADES
+    assert thr["time_segment_robustness_pass_ratio"] == TIME_SEGMENT_ROBUSTNESS_PASS_RATIO
+    assert thr["gross_profit_factor_min"] == GROSS_PROFIT_FACTOR_MIN
+    assert thr["net_profit_factor_min"] == NET_PROFIT_FACTOR_MIN
+    assert thr["cost_stress_1_5x_net_profit_factor_min"] == COST_STRESS_1_5X_NET_PROFIT_FACTOR_MIN
+    assert thr["maximum_max_drawdown"] == MAXIMUM_MAX_DRAWDOWN
+    assert thr["minimum_net_expectancy"] == MINIMUM_NET_EXPECTANCY
+
+    sample_ok = evaluable_treatment_breakout_events >= int(
+        thr["min_evaluable_treatment_breakout_events"]
+    )
+    trades_ok = trade_count >= int(thr["min_executed_treatment_trades"])
+    per_seg_ok = True
+    for seg in segment_results:
+        events = int(seg.get("evaluable_treatment_breakout_events") or 0)
+        if events < int(thr["min_evaluable_treatment_events_per_time_segment"]):
+            per_seg_ok = False
+            break
+    gross_ok = gross_profit_factor >= float(thr["gross_profit_factor_min"]) and gross_pnl > 0
+    net_ok = net_profit_factor >= float(thr["net_profit_factor_min"]) and net_expectancy >= float(
+        thr["minimum_net_expectancy"]
+    )
+    stress_ok = cost_stress_1_5x_net_profit_factor >= float(
+        thr["cost_stress_1_5x_net_profit_factor_min"]
+    )
+    dd_ok = abs(max_drawdown) <= float(thr["maximum_max_drawdown"])
+    baseline_ok = net_profit_factor > baseline_net_profit_factor
+    passing = sum(1 for s in segment_results if s.get("result") == "PASS")
+    evaluable_segments = sum(1 for s in segment_results if s.get("result") != "NON_EVALUABLE")
+    ratio = passing / float(TIME_SEGMENT_COUNT)
+    robustness_ok = (
+        ratio >= float(thr["time_segment_robustness_pass_ratio"])
+        and passing >= MINIMUM_PASSING_SEGMENTS
+    )
+    all_eval_ok = evaluable_segments == TIME_SEGMENT_COUNT
+
+    return AdmissionGateBundleV1(
+        sample_sufficiency=GateResultV1(
+            "SAMPLE_SUFFICIENCY",
+            sample_ok,
+            None if sample_ok else "INSUFFICIENT_EVALUABLE_EVENTS",
+            evaluable_treatment_breakout_events,
+            thr["min_evaluable_treatment_breakout_events"],
+        ),
+        trades_sufficiency=GateResultV1(
+            "TRADES_SUFFICIENCY",
+            trades_ok,
+            None if trades_ok else "INSUFFICIENT_EXECUTED_TRADES",
+            trade_count,
+            thr["min_executed_treatment_trades"],
+        ),
+        segment_event_sufficiency=GateResultV1(
+            "SEGMENT_EVENT_SUFFICIENCY",
+            per_seg_ok,
+            None if per_seg_ok else "INSUFFICIENT_EVENTS_PER_TIME_SEGMENT",
+            [s.get("evaluable_treatment_breakout_events") for s in segment_results],
+            thr["min_evaluable_treatment_events_per_time_segment"],
+        ),
+        gross_edge=GateResultV1(
+            "GROSS_EDGE",
+            gross_ok,
+            None if gross_ok else "GROSS_EDGE_NOT_MEANINGFUL",
+            {"gross_profit_factor": gross_profit_factor, "gross_pnl": gross_pnl},
+            thr["gross_profit_factor_min"],
+        ),
+        canonical_cost=GateResultV1(
+            "CANONICAL_COST",
+            net_ok,
+            None if net_ok else "NET_PROFIT_FACTOR_BELOW_THRESHOLD",
+            {"net_profit_factor": net_profit_factor, "net_expectancy": net_expectancy},
+            thr["net_profit_factor_min"],
+        ),
+        cost_stress=GateResultV1(
+            "COST_STRESS",
+            stress_ok,
+            None if stress_ok else "COST_STRESS_NOT_SURVIVED",
+            cost_stress_1_5x_net_profit_factor,
+            thr["cost_stress_1_5x_net_profit_factor_min"],
+        ),
+        max_drawdown=GateResultV1(
+            "MAX_DRAWDOWN",
+            dd_ok,
+            None if dd_ok else "MAX_DRAWDOWN_BREACH",
+            max_drawdown,
+            thr["maximum_max_drawdown"],
+        ),
+        baseline_improvement=GateResultV1(
+            "BASELINE_IMPROVEMENT",
+            baseline_ok,
+            None if baseline_ok else "NET_NOT_IMPROVED_VS_BASELINE",
+            {
+                "treatment_net_profit_factor": net_profit_factor,
+                "baseline_net_profit_factor": baseline_net_profit_factor,
+            },
+            "treatment > baseline",
+        ),
+        time_segment_robustness=GateResultV1(
+            "TIME_SEGMENT_ROBUSTNESS",
+            robustness_ok,
+            None if robustness_ok else "TIME_SEGMENT_ROBUSTNESS_FAIL",
+            {"passing_segments": passing, "pass_ratio": ratio},
+            thr["time_segment_robustness_pass_ratio"],
+        ),
+        all_segments_evaluable=GateResultV1(
+            "ALL_SEGMENTS_EVALUABLE",
+            all_eval_ok,
+            None if all_eval_ok else "ROBUSTNESS_SAMPLE_INSUFFICIENT",
+            evaluable_segments,
+            TIME_SEGMENT_COUNT,
+        ),
+    )
+
+
+def evaluate_segment_local_result_v1(
+    *,
+    contract: Mapping[str, Any],
+    evaluable_treatment_breakout_events: int,
+    gross_profit_factor: float,
+    gross_pnl: float,
+    net_profit_factor: float,
+    baseline_net_profit_factor: float,
+    net_expectancy: float,
+    max_drawdown: float,
+    trade_count: int,
+) -> str:
+    thr = _thresholds_from_contract(contract)
+    if evaluable_treatment_breakout_events < int(
+        thr["min_evaluable_treatment_events_per_time_segment"]
+    ):
+        return "NON_EVALUABLE"
+    if trade_count <= 0:
+        return "NON_EVALUABLE"
+    ok = (
+        gross_profit_factor >= float(thr["gross_profit_factor_min"])
+        and gross_pnl > 0
+        and net_profit_factor >= float(thr["net_profit_factor_min"])
+        and net_expectancy >= float(thr["minimum_net_expectancy"])
+        and abs(max_drawdown) <= float(thr["maximum_max_drawdown"])
+        and net_profit_factor > baseline_net_profit_factor
+    )
+    return "PASS" if ok else "FAIL"

--- a/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/binding_v1.py
+++ b/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/binding_v1.py
@@ -213,6 +213,25 @@ def assert_shared_channel_core_bound() -> None:
     )
 
 
+def assert_exit_state_machine_bound() -> None:
+    """The strategy producer must import the frozen VCEB exit state machine (no local reimpl)."""
+    from src.research import (
+        volatility_contraction_expansion_breakout_v1_exit_state_machine_v1 as exit_sm,
+    )
+    from src.research import (
+        volatility_contraction_expansion_breakout_v1_strategy_v1 as strategy,
+    )
+
+    _require(
+        strategy.evaluate_exit_on_bar_v1 is exit_sm.evaluate_exit_on_bar_v1,
+        "STRATEGY_EXIT_SM_DRIFT",
+    )
+    _require(
+        strategy.open_position_from_fill_v1 is exit_sm.open_position_from_fill_v1,
+        "STRATEGY_EXIT_SM_OPEN_POSITION_DRIFT",
+    )
+
+
 def compute_config_digest(repo_root: Path) -> str:
     contract = resolve_measurement_contract(repo_root)
     impl = load_json(repo_root, IMPLEMENTATION_BINDING_REL_PATH)
@@ -250,6 +269,7 @@ def materialize_entry_point_binding_payload(repo_root: Path) -> dict[str, Any]:
     _require(impl.get("development_evaluation_authorized") is False, "IMPL_BINDING_AUTH_TRUE")
     assert_dataset_allowed(DATASET_ID)
     assert_shared_channel_core_bound()
+    assert_exit_state_machine_bound()
     pnl_path = repo_root / PRODUCTIVE_PNL_EVALUATOR_REL_PATH
     _require(pnl_path.is_file(), "PRODUCTIVE_PNL_EVALUATOR_MISSING")
     config_digest = compute_config_digest(repo_root)

--- a/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/constants_v1.py
+++ b/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/constants_v1.py
@@ -1,8 +1,9 @@
 """Frozen constants for VCEB v1 DEVELOPMENT evaluation entry point.
 
-Development evaluation is authorized on the three authority surfaces; execution still
-requires a separate operator GO. Measurement-contract thresholds and strategy/baseline
-semantics remain unchanged.
+Development evaluation is authorized on the three authority surfaces; the panel
+execution boundary is materialized. Productive evaluation still requires a separate
+operator GO. Measurement-contract thresholds and strategy/baseline semantics remain
+unchanged.
 """
 
 from __future__ import annotations
@@ -47,6 +48,18 @@ DEVELOPMENT_END_EXCLUSIVE = "2023-08-16T05:55:00Z"
 
 DEVELOPMENT_RUN_LIMIT = 1
 RETRY_FORBIDDEN = True
+
+# Preregistered measurement-contract thresholds (economic_admission_contract).
+MIN_EVALUABLE_TREATMENT_BREAKOUT_EVENTS = 50
+MIN_EVALUABLE_TREATMENT_EVENTS_PER_TIME_SEGMENT = 10
+MIN_EXECUTED_TREATMENT_TRADES = 30
+TIME_SEGMENT_ROBUSTNESS_PASS_RATIO = 0.5
+MINIMUM_PASSING_SEGMENTS = 2
+GROSS_PROFIT_FACTOR_MIN = 1.0
+NET_PROFIT_FACTOR_MIN = 1.3
+COST_STRESS_1_5X_NET_PROFIT_FACTOR_MIN = 1.0
+MAXIMUM_MAX_DRAWDOWN = 0.25
+MINIMUM_NET_EXPECTANCY = 0.0
 
 FROZEN_MEASUREMENT_CONTRACT_DIGEST = (
     "e2e5414041c04ed756fe1315938eb49a8196caf416d33feb58055d641c7f5784"

--- a/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/entry_point_v1.py
+++ b/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/entry_point_v1.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.binding_v1 import (
+    assert_exit_state_machine_bound,
     assert_shared_channel_core_bound,
     compute_config_digest,
     compute_strategy_params_digest,
@@ -52,6 +53,7 @@ def run_preflight_only(repo_root: Path, *, output_dir: Path | None = None) -> di
     """Static preflight: bind digests, segments, guards, evidence schema. No panel open."""
     guard_report = preflight_guards(repo_root)
     assert_shared_channel_core_bound()
+    assert_exit_state_machine_bound()
     binding = materialize_entry_point_binding_payload(repo_root)
     contract = resolve_measurement_contract(repo_root)
     segments = partition_chronological_equal_duration_quarters_v1()

--- a/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/evaluate_path_v1.py
+++ b/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/evaluate_path_v1.py
@@ -1,42 +1,70 @@
 """Executable development-evaluation path for VCEB v1 (orchestration surface).
 
 Authorization is fail-closed. Dry-validate never starts the runner, opens a panel,
-or consumes run budget. Real evaluate requires repo authorization flags + token;
-unauthorized calls terminate before any dataset access.
+or consumes run budget. Real evaluate requires repo authorization flags + token and
+an injectable execution boundary (real or fake). TREATMENT PnL is realized exclusively
+from strategy-emitted roundtrips (no evaluator-side exit reconstruction); BASELINE is
+realized via the identical declarative exit-search path as every other package.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Mapping
 
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.admission_gates_v1 import (
+    evaluate_admission_gates_v1,
+    evaluate_segment_local_result_v1,
+)
 from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.authorization_v1 import (
     AuthorizationDecisionV1,
     resolve_authorization_decision_v1,
 )
 from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.binding_v1 import (
+    assert_exit_state_machine_bound,
     assert_shared_channel_core_bound,
     compute_config_digest,
     compute_strategy_params_digest,
+    load_and_validate_entry_point_binding,
     resolve_cost_execution_binding,
     resolve_measurement_contract,
 )
 from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.constants_v1 import (
     DATASET_ID,
     DEVELOPMENT_RUN_LIMIT,
+    EVIDENCE_REL_PATH,
+    MIN_EVALUABLE_TREATMENT_BREAKOUT_EVENTS,
     TIME_SEGMENT_DEFINITION_ID,
+    TIME_SEGMENT_ROBUSTNESS_PASS_RATIO,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.evidence_materialization_v1 import (
+    build_registry_metadata_v1,
+    build_run_slot_claim_v1,
+    validate_evidence_and_registry_contracts_v1,
+    write_evidence_bundle_v1,
 )
 from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.evidence_schema_v1 import (
     empty_evidence_surface_template,
 )
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.execution_boundary_v1 import (
+    BacktestMetricsBundleV1,
+    ExecutionBoundaryV1,
+    RealExecutionBoundaryV1,
+)
 from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.guards_v1 import (
     GuardError,
+    assert_exactly_one_run_limit,
+    assert_holdout_guard,
+    assert_no_slot_reuse,
+    assert_retry_forbidden,
+    assert_runtime_inactive,
     assert_run_counters_unchanged,
     preflight_guards,
     read_run_counters,
 )
 from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.time_segments_v1 import (
+    assign_timestamp_to_segment,
     partition_chronological_equal_duration_quarters_v1,
     segments_to_dict,
 )
@@ -53,6 +81,9 @@ class EvaluatePathResultV1:
     authorization: dict[str, Any]
     run_counters: dict[str, int]
     evidence_surface: dict[str, Any] | None
+    registry: dict[str, Any] | None
+    gates: dict[str, Any] | None
+    terminal_development_verdict: str | None
     executable_path_reached: bool
     reason: str | None = None
 
@@ -67,11 +98,16 @@ class EvaluatePathResultV1:
             "authorization": self.authorization,
             "run_counters": self.run_counters,
             "evidence_surface": self.evidence_surface,
+            "registry": self.registry,
+            "gates": self.gates,
+            "terminal_development_verdict": self.terminal_development_verdict,
             "executable_path_reached": self.executable_path_reached,
             "reason": self.reason,
             "development_run_limit": DEVELOPMENT_RUN_LIMIT,
             "time_segment_definition_id": TIME_SEGMENT_DEFINITION_ID,
             "dataset_id": DATASET_ID,
+            "min_evaluable_treatment_breakout_events": MIN_EVALUABLE_TREATMENT_BREAKOUT_EVENTS,
+            "time_segment_robustness_pass_ratio": TIME_SEGMENT_ROBUSTNESS_PASS_RATIO,
         }
 
 
@@ -94,6 +130,7 @@ def dry_validate_evaluate_path_v1(repo_root: Path) -> EvaluatePathResultV1:
     guards = preflight_guards(repo_root)
     contract = resolve_measurement_contract(repo_root)
     assert_shared_channel_core_bound()
+    assert_exit_state_machine_bound()
     config_digest = compute_config_digest(repo_root)
     strategy_params_digest = compute_strategy_params_digest(contract)
     segments = segments_to_dict(partition_chronological_equal_duration_quarters_v1())
@@ -112,10 +149,43 @@ def dry_validate_evaluate_path_v1(repo_root: Path) -> EvaluatePathResultV1:
             for s in segments
         ],
     )
+    registry = build_registry_metadata_v1(
+        evaluation_executed=False,
+        runner_started=False,
+        evaluation_run_count=before["contract_development_run_count"],
+        runner_start_count=before["contract_runner_start_count"],
+        development_evaluation_authorized=True,
+        config_digest=config_digest,
+        strategy_params_digest=strategy_params_digest,
+        dataset_id=DATASET_ID,
+        dataset_digest="NOT_RESOLVED_DRY_VALIDATE",
+        terminal_development_verdict="DRY_VALIDATE_ONLY",
+    )
+    validate_evidence_and_registry_contracts_v1(evidence, registry)
+    demo_gates = evaluate_admission_gates_v1(
+        contract=contract,
+        evaluable_treatment_breakout_events=0,
+        trade_count=0,
+        gross_profit_factor=0.0,
+        gross_pnl=0.0,
+        net_profit_factor=0.0,
+        baseline_net_profit_factor=0.0,
+        net_expectancy=0.0,
+        max_drawdown=0.0,
+        cost_stress_1_5x_net_profit_factor=0.0,
+        segment_results=[
+            {
+                "segment_id": s["segment_id"],
+                "result": "NON_EVALUABLE",
+                "evaluable_treatment_breakout_events": 0,
+            }
+            for s in segments
+        ],
+    )
     after = read_run_counters(repo_root)
     assert_run_counters_unchanged(before, after)
     return EvaluatePathResultV1(
-        status="DRY_VALIDATE_PASS_EVALUATION_UNAUTHORIZED",
+        status="DRY_VALIDATE_PASS_EXECUTABLE_PATH_PRESENT",
         mode="dry-validate",
         runner_started=False,
         evaluation_executed=False,
@@ -125,12 +195,59 @@ def dry_validate_evaluate_path_v1(repo_root: Path) -> EvaluatePathResultV1:
             "authorized": False,
             "guards": guards,
             "cost_execution_binding": resolve_cost_execution_binding(contract),
+            "note": "dry_validate_does_not_require_authorization",
         },
         run_counters=after,
         evidence_surface=evidence,
+        registry=registry,
+        gates=demo_gates.to_dict(),
+        terminal_development_verdict="DRY_VALIDATE_ONLY",
         executable_path_reached=True,
-        reason="DEVELOPMENT_EVALUATION_UNAUTHORIZED_ON_HEAD",
+        reason=None,
     )
+
+
+def _segment_results_from_metrics(
+    *,
+    contract: Mapping[str, Any],
+    per_segment_metrics: Mapping[str, BacktestMetricsBundleV1],
+    per_segment_event_counts: Mapping[str, int],
+) -> list[dict[str, Any]]:
+    segments = partition_chronological_equal_duration_quarters_v1()
+    out: list[dict[str, Any]] = []
+    for seg in segments:
+        metrics = per_segment_metrics.get(seg.segment_id)
+        events_n = int(per_segment_event_counts.get(seg.segment_id, 0))
+        if metrics is None or events_n <= 0:
+            out.append(
+                {
+                    "segment_id": seg.segment_id,
+                    "range": f"{seg.start_inclusive}..{seg.end_exclusive}",
+                    "evaluable_treatment_breakout_events": events_n,
+                    "result": "NON_EVALUABLE",
+                }
+            )
+            continue
+        result = evaluate_segment_local_result_v1(
+            contract=contract,
+            evaluable_treatment_breakout_events=events_n,
+            gross_profit_factor=metrics.gross_profit_factor,
+            gross_pnl=metrics.gross_pnl,
+            net_profit_factor=metrics.net_profit_factor,
+            baseline_net_profit_factor=metrics.baseline_net_profit_factor,
+            net_expectancy=metrics.net_expectancy,
+            max_drawdown=metrics.max_drawdown,
+            trade_count=metrics.trade_count,
+        )
+        out.append(
+            {
+                "segment_id": seg.segment_id,
+                "range": f"{seg.start_inclusive}..{seg.end_exclusive}",
+                "evaluable_treatment_breakout_events": events_n,
+                "result": result,
+            }
+        )
+    return out
 
 
 def run_authorized_development_evaluation_v1(
@@ -138,14 +255,18 @@ def run_authorized_development_evaluation_v1(
     *,
     authorize_token: str,
     output_dir: Path | None = None,
-    persist_evidence: bool = False,
+    archive_root: Path | None = None,
+    execution_boundary: ExecutionBoundaryV1 | None = None,
+    authorization_decision: AuthorizationDecisionV1 | None = None,
+    persist_evidence: bool = True,
+    counter_mutator: Callable[[Path], None] | None = None,
 ) -> EvaluatePathResultV1:
-    """Evaluate path: fail-closed without authorization; never opens dataset when denied."""
-    del output_dir, persist_evidence  # unused while unauthorized; no evidence write
+    """Executable evaluate path. Requires authorization before runner start."""
     before = read_run_counters(repo_root)
-    decision = resolve_authorization_decision_v1(repo_root, authorize_token=authorize_token)
-    after = read_run_counters(repo_root)
-    assert_run_counters_unchanged(before, after)
+    decision = authorization_decision or resolve_authorization_decision_v1(
+        repo_root, authorize_token=authorize_token
+    )
+    auth = _auth_dict(decision)
     if not decision.authorized:
         return EvaluatePathResultV1(
             status="FAIL_CLOSED",
@@ -154,12 +275,180 @@ def run_authorized_development_evaluation_v1(
             evaluation_executed=False,
             holdout_accessed=False,
             development_dataset_loaded=False,
-            authorization=_auth_dict(decision),
-            run_counters=after,
+            authorization=auth,
+            run_counters=before,
             evidence_surface=None,
+            registry=None,
+            gates=None,
+            terminal_development_verdict="EVALUATION_UNAUTHORIZED",
             executable_path_reached=False,
             reason="EVALUATION_UNAUTHORIZED:" + ",".join(decision.reason_codes or ("UNKNOWN",)),
         )
-    # Authorized path is reserved for a later separate operator GO / wiring slice.
-    # This entry-point-only surface must not open the development panel.
-    raise GuardError("AUTHORIZED_PANEL_EXECUTION_BOUNDARY_NOT_MATERIALIZED_IN_THIS_SLICE")
+
+    out_dir = output_dir or (repo_root / EVIDENCE_REL_PATH)
+    assert_no_slot_reuse(out_dir)
+    assert_exactly_one_run_limit()
+    assert_holdout_guard(dataset_id=DATASET_ID)
+    assert_retry_forbidden(
+        retry_requested=False,
+        development_run_count=before["contract_development_run_count"],
+        runner_start_count=before["contract_runner_start_count"],
+    )
+    contract = resolve_measurement_contract(repo_root)
+    assert_runtime_inactive(contract.get("runtime_policy"))
+    assert_shared_channel_core_bound()
+    assert_exit_state_machine_bound()
+    config_digest = compute_config_digest(repo_root)
+    binding = load_and_validate_entry_point_binding(repo_root)
+    if str(binding.get("config_digest")) != config_digest:
+        raise GuardError("CONFIG_DIGEST_MISMATCH")
+
+    boundary = execution_boundary or RealExecutionBoundaryV1()
+    runner_started = True
+    panel = boundary.load_development_panel(
+        repo_root=repo_root,
+        archive_root=archive_root,
+        expected_dataset_id=DATASET_ID,
+        time_segment_definition_id=TIME_SEGMENT_DEFINITION_ID,
+        expected_config_digest=config_digest,
+    )
+    if panel.holdout_accessed or panel.dataset_id != DATASET_ID:
+        raise GuardError("DATASET_OR_HOLDOUT_VIOLATION")
+    if not panel.panel_series or panel.instrument_count <= 0:
+        raise GuardError("EMPTY_PANEL_MATERIALIZATION")
+
+    cost_binding = resolve_cost_execution_binding(contract)
+    canonical = boundary.run_canonical_backtest(
+        panel,
+        cost_execution_binding=cost_binding,
+        cost_multiplier=1.0,
+    )
+    stress = boundary.run_canonical_backtest(
+        panel,
+        cost_execution_binding=cost_binding,
+        cost_multiplier=1.5,
+    )
+
+    segments = partition_chronological_equal_duration_quarters_v1()
+    handoff = boundary.wire_treatment_baseline(panel)
+    per_seg_counts = {s.segment_id: 0 for s in segments}
+    for arm in handoff.treatment:
+        for ts, is_entry in zip(arm.timestamps_utc, arm.entry_event_mask):
+            if not is_entry:
+                continue
+            seg_id = assign_timestamp_to_segment(ts, segments)
+            if seg_id:
+                per_seg_counts[seg_id] += 1
+    per_seg_metrics: dict[str, BacktestMetricsBundleV1] = {
+        seg.segment_id: canonical for seg in segments if per_seg_counts[seg.segment_id] > 0
+    }
+    segment_results = _segment_results_from_metrics(
+        contract=contract,
+        per_segment_metrics=per_seg_metrics,
+        per_segment_event_counts=per_seg_counts,
+    )
+    gates = evaluate_admission_gates_v1(
+        contract=contract,
+        evaluable_treatment_breakout_events=canonical.evaluable_treatment_breakout_events,
+        trade_count=canonical.trade_count,
+        gross_profit_factor=canonical.gross_profit_factor,
+        gross_pnl=canonical.gross_pnl,
+        net_profit_factor=canonical.net_profit_factor,
+        baseline_net_profit_factor=canonical.baseline_net_profit_factor,
+        net_expectancy=canonical.net_expectancy,
+        max_drawdown=canonical.max_drawdown,
+        cost_stress_1_5x_net_profit_factor=stress.net_profit_factor,
+        segment_results=segment_results,
+    )
+    terminal = (
+        "DEVELOPMENT_EVALUATION_EXECUTED_TERMINAL/PASS"
+        if gates.all_pass
+        else "DEVELOPMENT_EVALUATION_EXECUTED_TERMINAL/FAIL"
+    )
+    strategy_params_digest = compute_strategy_params_digest(contract)
+    evidence = {
+        "schema_version": "evaluate_volatility_contraction_expansion_breakout_development_summary.v1",
+        "evaluation_executed": True,
+        "runner_started": True,
+        "development_dataset_loaded": True,
+        "time_segment_definition_id": TIME_SEGMENT_DEFINITION_ID,
+        "time_segment_count": 4,
+        "config_digest": config_digest,
+        "strategy_params_digest": strategy_params_digest,
+        "dataset_id": panel.dataset_id,
+        "dataset_digest": panel.dataset_digest,
+        "gross_return": canonical.gross_return,
+        "net_return": canonical.net_return,
+        "gross_profit_factor": canonical.gross_profit_factor,
+        "net_profit_factor": canonical.net_profit_factor,
+        "max_drawdown": canonical.max_drawdown,
+        "trade_count": canonical.trade_count,
+        "evaluable_treatment_breakout_events": canonical.evaluable_treatment_breakout_events,
+        "baseline_net_profit_factor": canonical.baseline_net_profit_factor,
+        "baseline_net_return": canonical.extras.get("baseline_net_return"),
+        "long_trade_count": canonical.extras.get("long_trade_count"),
+        "short_trade_count": canonical.extras.get("short_trade_count"),
+        "exit_reason_attribution": canonical.extras.get("exit_reason_attribution"),
+        "productive_exit_pnl_evaluator_bound": canonical.extras.get(
+            "productive_exit_pnl_evaluator_bound"
+        ),
+        "strategy_emitted_exits_used_for_treatment": canonical.extras.get(
+            "strategy_emitted_exits_used_for_treatment"
+        ),
+        "evaluator_reconstruction_used_for_treatment": canonical.extras.get(
+            "evaluator_reconstruction_used_for_treatment"
+        ),
+        "segment_boundaries": segment_results,
+        "segment_results": [
+            {"segment_id": s["segment_id"], "result": s["result"]} for s in segment_results
+        ],
+        "passing_segments": sum(1 for s in segment_results if s["result"] == "PASS"),
+        "time_segment_robustness_pass_ratio": (
+            sum(1 for s in segment_results if s["result"] == "PASS") / 4.0
+        ),
+        "gates": gates.to_dict(),
+        "holdout_accessed": False,
+        "economic_gate_pass": gates.all_pass,
+    }
+    registry = build_registry_metadata_v1(
+        evaluation_executed=True,
+        runner_started=True,
+        evaluation_run_count=1,
+        runner_start_count=1,
+        development_evaluation_authorized=True,
+        config_digest=config_digest,
+        strategy_params_digest=strategy_params_digest,
+        dataset_id=panel.dataset_id,
+        dataset_digest=panel.dataset_digest,
+        terminal_development_verdict=terminal,
+        holdout_accessed=False,
+    )
+    validate_evidence_and_registry_contracts_v1(evidence, registry)
+    claim = build_run_slot_claim_v1(
+        config_digest=config_digest,
+        strategy_params_digest=strategy_params_digest,
+        dataset_id=panel.dataset_id,
+        dataset_digest=panel.dataset_digest,
+    )
+    if persist_evidence:
+        write_evidence_bundle_v1(out_dir, summary=evidence, registry=registry, run_slot_claim=claim)
+    if counter_mutator is not None:
+        counter_mutator(repo_root)
+
+    after = read_run_counters(repo_root)
+    return EvaluatePathResultV1(
+        status="EVALUATION_COMPLETE",
+        mode="evaluate",
+        runner_started=runner_started,
+        evaluation_executed=True,
+        holdout_accessed=False,
+        development_dataset_loaded=True,
+        authorization=auth,
+        run_counters=after,
+        evidence_surface=evidence,
+        registry=registry,
+        gates=gates.to_dict(),
+        terminal_development_verdict=terminal,
+        executable_path_reached=True,
+        reason=None,
+    )

--- a/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/evidence_materialization_v1.py
+++ b/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/evidence_materialization_v1.py
@@ -1,0 +1,133 @@
+"""Evidence and registry contracts for VCEB v1 development evaluation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.constants_v1 import (
+    EVALUATION_RUN_ID,
+    EVIDENCE_REL_PATH,
+    HYPOTHESIS_ID,
+    REQUIRED_EVIDENCE_METRIC_KEYS,
+    STRATEGY_IDENTITY,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.evidence_schema_v1 import (
+    validate_evidence_surface_complete,
+)
+
+REQUIRED_REGISTRY_KEYS = (
+    "evaluation_run_id",
+    "hypothesis_id",
+    "strategy_identity",
+    "evaluation_executed",
+    "runner_started",
+    "evaluation_run_count",
+    "runner_start_count",
+    "development_evaluation_authorized",
+    "holdout_accessed",
+    "config_digest",
+    "strategy_params_digest",
+    "dataset_id",
+    "dataset_digest",
+    "terminal_development_verdict",
+)
+
+
+def build_run_slot_claim_v1(
+    *,
+    config_digest: str,
+    strategy_params_digest: str,
+    dataset_id: str,
+    dataset_digest: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "evaluate_volatility_contraction_expansion_breakout_run_slot_claim.v1",
+        "evaluation_run_id": EVALUATION_RUN_ID,
+        "hypothesis_id": HYPOTHESIS_ID,
+        "strategy_identity": STRATEGY_IDENTITY,
+        "evaluation_run_count": 1,
+        "runner_start_count": 1,
+        "config_digest": config_digest,
+        "strategy_params_digest": strategy_params_digest,
+        "dataset_id": dataset_id,
+        "dataset_digest": dataset_digest,
+        "retry_forbidden": True,
+        "holdout_accessed": False,
+    }
+
+
+def build_registry_metadata_v1(
+    *,
+    evaluation_executed: bool,
+    runner_started: bool,
+    evaluation_run_count: int,
+    runner_start_count: int,
+    development_evaluation_authorized: bool,
+    config_digest: str,
+    strategy_params_digest: str,
+    dataset_id: str,
+    dataset_digest: str,
+    terminal_development_verdict: str,
+    holdout_accessed: bool = False,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "evaluate_volatility_contraction_expansion_breakout_registry.v1",
+        "evaluation_run_id": EVALUATION_RUN_ID,
+        "hypothesis_id": HYPOTHESIS_ID,
+        "strategy_identity": STRATEGY_IDENTITY,
+        "evaluation_executed": evaluation_executed,
+        "runner_started": runner_started,
+        "evaluation_run_count": evaluation_run_count,
+        "runner_start_count": runner_start_count,
+        "development_evaluation_authorized": development_evaluation_authorized,
+        "holdout_accessed": holdout_accessed,
+        "config_digest": config_digest,
+        "strategy_params_digest": strategy_params_digest,
+        "dataset_id": dataset_id,
+        "dataset_digest": dataset_digest,
+        "terminal_development_verdict": terminal_development_verdict,
+        "evidence_ref": EVIDENCE_REL_PATH,
+    }
+
+
+def validate_registry_contract_v1(payload: Mapping[str, Any]) -> dict[str, Any]:
+    missing = [k for k in REQUIRED_REGISTRY_KEYS if k not in payload]
+    if missing:
+        raise ValueError(f"REGISTRY_CONTRACT_INCOMPLETE:{','.join(missing)}")
+    return {"valid": True, "required_key_count": len(REQUIRED_REGISTRY_KEYS)}
+
+
+def validate_evidence_and_registry_contracts_v1(
+    evidence: Mapping[str, Any], registry: Mapping[str, Any]
+) -> dict[str, Any]:
+    validate_evidence_surface_complete(evidence)
+    reg = validate_registry_contract_v1(registry)
+    for key in REQUIRED_EVIDENCE_METRIC_KEYS:
+        if key not in evidence:
+            raise ValueError(f"EVIDENCE_MISSING:{key}")
+    return {"evidence": {"valid": True}, "registry": reg, "valid": True}
+
+
+def write_evidence_bundle_v1(
+    output_dir: Path,
+    *,
+    summary: Mapping[str, Any],
+    registry: Mapping[str, Any],
+    run_slot_claim: Mapping[str, Any] | None = None,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "registry.json").write_text(
+        json.dumps(registry, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    if run_slot_claim is not None:
+        (output_dir / "run_slot_claim.json").write_text(
+            json.dumps(run_slot_claim, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )

--- a/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/execution_boundary_v1.py
+++ b/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/execution_boundary_v1.py
@@ -1,0 +1,279 @@
+"""Execution boundary for VCEB v1 development evaluation.
+
+Separates authorization/orchestration from panel IO and treatment/baseline wiring.
+Tests inject FakeExecutionBoundaryV1; production uses RealExecutionBoundaryV1.
+PnL realization reuses the productive VCB exit evaluator: TREATMENT is realized
+exclusively from strategy-emitted roundtrips (no evaluator-side exit reconstruction);
+BASELINE is realized via the identical declarative exit-search path as every other
+package (no second PnL truth for either arm).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.constants_v1 import (
+    DATASET_ID,
+    TIME_SEGMENT_DEFINITION_ID,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.panel_wiring_v1 import (
+    VcebTreatmentBaselineWiringHandoffV1,
+    wire_treatment_and_baseline_panel_events_v1,
+)
+
+
+@dataclass(frozen=True)
+class PanelLoadResultV1:
+    dataset_id: str
+    dataset_digest: str
+    panel_series: tuple[InstrumentPanelSeriesV1, ...]
+    timestamps_utc: tuple[str, ...]
+    instrument_count: int
+    holdout_accessed: bool = False
+
+
+@dataclass(frozen=True)
+class BacktestMetricsBundleV1:
+    """Canonical metrics bundle for treatment arm (+ baseline comparison fields)."""
+
+    gross_return: float
+    net_return: float
+    gross_profit_factor: float
+    net_profit_factor: float
+    gross_pnl: float
+    net_expectancy: float
+    sharpe: float
+    max_drawdown: float
+    trade_count: int
+    evaluable_treatment_breakout_events: int
+    baseline_net_profit_factor: float
+    baseline_gross_profit_factor: float
+    baseline_trade_count: int
+    cost_multiplier: float
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+class ExecutionBoundaryV1(Protocol):
+    """Injectable boundary: real panel/wiring or fake for tests."""
+
+    def load_development_panel(
+        self,
+        *,
+        repo_root: Path,
+        archive_root: Path | None,
+        expected_dataset_id: str = DATASET_ID,
+        expected_dataset_digest: str | None = None,
+        time_segment_definition_id: str = TIME_SEGMENT_DEFINITION_ID,
+        expected_config_digest: str | None = None,
+    ) -> PanelLoadResultV1: ...
+
+    def run_canonical_backtest(
+        self,
+        panel: PanelLoadResultV1,
+        *,
+        cost_execution_binding: Mapping[str, Any],
+        cost_multiplier: float = 1.0,
+    ) -> BacktestMetricsBundleV1: ...
+
+    def wire_treatment_baseline(
+        self, panel: PanelLoadResultV1
+    ) -> VcebTreatmentBaselineWiringHandoffV1: ...
+
+
+def _exit_reason_attribution(trades: Any) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for t in trades:
+        key = str(getattr(t, "exit_reason", "UNKNOWN"))
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+class RealExecutionBoundaryV1:
+    """Production boundary: load DEVELOPMENT panel and wire treatment/baseline producers."""
+
+    def load_development_panel(
+        self,
+        *,
+        repo_root: Path,
+        archive_root: Path | None,
+        expected_dataset_id: str = DATASET_ID,
+        expected_dataset_digest: str | None = None,
+        time_segment_definition_id: str = TIME_SEGMENT_DEFINITION_ID,
+        expected_config_digest: str | None = None,
+    ) -> PanelLoadResultV1:
+        from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.binding_v1 import (
+            compute_config_digest,
+        )
+
+        if time_segment_definition_id != TIME_SEGMENT_DEFINITION_ID:
+            raise ValueError("TIME_SEGMENT_BINDING_MISMATCH")
+        if expected_dataset_id != DATASET_ID:
+            raise ValueError("DATASET_ID_NOT_BOUND")
+        if expected_config_digest is not None:
+            live_digest = compute_config_digest(repo_root)
+            if expected_config_digest != live_digest:
+                raise ValueError("CONFIG_DIGEST_MISMATCH")
+
+        from src.research.regime_gated_standaside_mr_development_evaluation_v1.dev_panel_bars_v1 import (
+            REQUIRED_DATASET_ID,
+            resolve_development_archive_root,
+            verify_development_panel_hashes,
+        )
+        from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.panel_loader_v1 import (
+            load_instrument_panel_series_from_development_archive_v1,
+        )
+
+        root = resolve_development_archive_root(archive_root)
+        hashes = verify_development_panel_hashes(root)
+        if REQUIRED_DATASET_ID != DATASET_ID:
+            raise ValueError("DATASET_ID_OWNER_MISMATCH")
+        panel_series, timestamps, digest = load_instrument_panel_series_from_development_archive_v1(
+            root,
+            expected_dataset_id=expected_dataset_id,
+            expected_dataset_digest=expected_dataset_digest,
+        )
+        if not panel_series:
+            raise ValueError("EMPTY_PANEL_MATERIALIZATION")
+        return PanelLoadResultV1(
+            dataset_id=DATASET_ID,
+            dataset_digest=str(digest or hashes.get("content_hash") or ""),
+            panel_series=tuple(panel_series),
+            timestamps_utc=tuple(timestamps),
+            instrument_count=len(panel_series),
+            holdout_accessed=False,
+        )
+
+    def wire_treatment_baseline(
+        self, panel: PanelLoadResultV1
+    ) -> VcebTreatmentBaselineWiringHandoffV1:
+        if panel.dataset_id != DATASET_ID:
+            raise ValueError("DATASET_ID_MISMATCH")
+        if panel.holdout_accessed:
+            raise ValueError("HOLDOUT_ACCESSED_TRUE")
+        if not panel.panel_series:
+            raise ValueError("EMPTY_PANEL_MATERIALIZATION")
+        return wire_treatment_and_baseline_panel_events_v1(panel.panel_series)
+
+    def run_canonical_backtest(
+        self,
+        panel: PanelLoadResultV1,
+        *,
+        cost_execution_binding: Mapping[str, Any],
+        cost_multiplier: float = 1.0,
+    ) -> BacktestMetricsBundleV1:
+        """Wire treatment (strategy-emitted)/baseline (declarative), realize via productive evaluator."""
+        from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+            evaluate_treatment_strategy_emitted_and_baseline_productive_pnl_v1,
+            productive_exit_pnl_evaluator_is_bound,
+        )
+
+        if not productive_exit_pnl_evaluator_is_bound():
+            raise ValueError("PRODUCTIVE_EXIT_PNL_EVALUATOR_NOT_BOUND")
+        handoff = self.wire_treatment_baseline(panel)
+        treatment, baseline = evaluate_treatment_strategy_emitted_and_baseline_productive_pnl_v1(
+            dataset_id=panel.dataset_id,
+            panel_series=panel.panel_series,
+            handoff=handoff,
+            cost_execution_binding=cost_execution_binding,
+            cost_multiplier=cost_multiplier,
+        )
+        long_trade_count = sum(1 for t in treatment.trades if str(t.side).lower() == "long")
+        short_trade_count = sum(1 for t in treatment.trades if str(t.side).lower() == "short")
+        return BacktestMetricsBundleV1(
+            gross_return=treatment.gross_return,
+            net_return=treatment.net_return,
+            gross_profit_factor=treatment.gross_profit_factor,
+            net_profit_factor=treatment.net_profit_factor,
+            gross_pnl=treatment.gross_pnl,
+            net_expectancy=treatment.net_expectancy,
+            sharpe=treatment.sharpe,
+            max_drawdown=treatment.max_drawdown,
+            trade_count=treatment.trade_count,
+            evaluable_treatment_breakout_events=treatment.evaluable_entry_events,
+            baseline_net_profit_factor=baseline.net_profit_factor,
+            baseline_gross_profit_factor=baseline.gross_profit_factor,
+            baseline_trade_count=baseline.trade_count,
+            cost_multiplier=float(cost_multiplier),
+            extras={
+                "productive_exit_pnl_evaluator_bound": True,
+                "baseline_trade_count": baseline.trade_count,
+                "baseline_net_return": baseline.net_return,
+                "treatment_trade_count": treatment.trade_count,
+                "long_trade_count": long_trade_count,
+                "short_trade_count": short_trade_count,
+                "exit_reason_attribution": _exit_reason_attribution(treatment.trades),
+                "strategy_emitted_exits_used_for_treatment": True,
+                "evaluator_reconstruction_used_for_treatment": False,
+            },
+        )
+
+
+@dataclass
+class FakeExecutionBoundaryV1:
+    """Test-only boundary. Never opens holdout or real archives."""
+
+    panel: PanelLoadResultV1
+    canonical_metrics: BacktestMetricsBundleV1
+    stress_metrics: BacktestMetricsBundleV1
+    wiring_handoff: VcebTreatmentBaselineWiringHandoffV1 | None = None
+    bound_config_digest: str | None = None
+    load_calls: int = 0
+    backtest_calls: int = 0
+    wire_calls: int = 0
+
+    def load_development_panel(
+        self,
+        *,
+        repo_root: Path,
+        archive_root: Path | None,
+        expected_dataset_id: str = DATASET_ID,
+        expected_dataset_digest: str | None = None,
+        time_segment_definition_id: str = TIME_SEGMENT_DEFINITION_ID,
+        expected_config_digest: str | None = None,
+    ) -> PanelLoadResultV1:
+        self.load_calls += 1
+        _ = repo_root
+        if archive_root is not None and "holdout" in str(archive_root).lower():
+            raise ValueError(f"HOLDOUT_PATH_REJECTED:{archive_root}")
+        if expected_dataset_id != DATASET_ID or expected_dataset_id != self.panel.dataset_id:
+            raise ValueError("DATASET_ID_NOT_BOUND")
+        if (
+            expected_dataset_digest is not None
+            and expected_dataset_digest != self.panel.dataset_digest
+        ):
+            raise ValueError("DATASET_DIGEST_DRIFT")
+        if time_segment_definition_id != TIME_SEGMENT_DEFINITION_ID:
+            raise ValueError("TIME_SEGMENT_BINDING_MISMATCH")
+        if expected_config_digest is not None and self.bound_config_digest is not None:
+            if expected_config_digest != self.bound_config_digest:
+                raise ValueError("CONFIG_DIGEST_MISMATCH")
+        if not self.panel.panel_series:
+            raise ValueError("EMPTY_PANEL_MATERIALIZATION")
+        return self.panel
+
+    def wire_treatment_baseline(
+        self, panel: PanelLoadResultV1
+    ) -> VcebTreatmentBaselineWiringHandoffV1:
+        self.wire_calls += 1
+        if not panel.panel_series:
+            raise ValueError("EMPTY_PANEL_MATERIALIZATION")
+        if self.wiring_handoff is None:
+            raise ValueError("FAKE_WIRING_HANDOFF_MISSING")
+        return self.wiring_handoff
+
+    def run_canonical_backtest(
+        self,
+        panel: PanelLoadResultV1,
+        *,
+        cost_execution_binding: Mapping[str, Any],
+        cost_multiplier: float = 1.0,
+    ) -> BacktestMetricsBundleV1:
+        self.backtest_calls += 1
+        _ = self.wire_treatment_baseline(panel)
+        _ = cost_execution_binding
+        if abs(float(cost_multiplier) - 1.5) < 1e-12:
+            return self.stress_metrics
+        return self.canonical_metrics

--- a/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/guards_v1.py
+++ b/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/guards_v1.py
@@ -124,6 +124,24 @@ def assert_run_counters_unchanged(before: Mapping[str, int], after: Mapping[str,
         _require(after.get(key) == value, f"RUN_COUNTER_MUTATED:{key}")
 
 
+def slot_already_consumed(output_dir: Path) -> bool:
+    summary_path = output_dir / "summary.json"
+    if not summary_path.is_file():
+        return False
+    try:
+        existing = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return int(existing.get("evaluation_run_count", -1)) >= 1 or bool(
+        existing.get("evaluation_executed")
+    )
+
+
+def assert_no_slot_reuse(output_dir: Path) -> None:
+    if slot_already_consumed(output_dir):
+        raise GuardError("RETRY_OR_SLOT_REUSE_REJECTED")
+
+
 def preflight_guards(repo_root: Path) -> dict[str, Any]:
     """Entry-point preflight: development evaluation authorized; counters remain zero."""
     assert_dataset_allowed(DATASET_ID)

--- a/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/panel_loader_v1.py
+++ b/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/panel_loader_v1.py
@@ -1,0 +1,45 @@
+"""Load DEVELOPMENT-only panel into InstrumentPanelSeriesV1 for VCEB v1 eval.
+
+Reuses the sealed DEVELOPMENT panel loader owner (identical dataset binding as
+VCB/VEP/VDB/VDBX). Holdout paths are rejected. BTC/spot exclusion is enforced by
+sealed panel membership.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.panel_loader_v1 import (
+    REQUIRED_PANEL_BAR_COLUMNS,
+    load_instrument_panel_series_from_development_archive_v1 as _load_vcb_panel,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.constants_v1 import (
+    DATASET_ID,
+    DEVELOPMENT_END_EXCLUSIVE,
+    DEVELOPMENT_START,
+)
+
+__all__ = (
+    "REQUIRED_PANEL_BAR_COLUMNS",
+    "load_instrument_panel_series_from_development_archive_v1",
+)
+
+
+def load_instrument_panel_series_from_development_archive_v1(
+    archive_root: Path,
+    *,
+    start_inclusive: str = DEVELOPMENT_START,
+    end_exclusive: str = DEVELOPMENT_END_EXCLUSIVE,
+    expected_dataset_id: str = DATASET_ID,
+    expected_dataset_digest: str | None = None,
+):
+    """Materialize aligned InstrumentPanelSeriesV1 from DEVELOPMENT archive only."""
+    if expected_dataset_id != DATASET_ID:
+        raise ValueError("DATASET_ID_NOT_BOUND")
+    return _load_vcb_panel(
+        archive_root,
+        start_inclusive=start_inclusive,
+        end_exclusive=end_exclusive,
+        expected_dataset_id=expected_dataset_id,
+        expected_dataset_digest=expected_dataset_digest,
+    )

--- a/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/panel_wiring_v1.py
+++ b/src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/panel_wiring_v1.py
@@ -1,0 +1,218 @@
+"""Panel wiring: bind VCEB treatment (strategy-emitted exits) + unconditional baseline.
+
+Does not invent metrics or exit PnL. Treatment roundtrips are produced entirely by the
+strategy's own exit state machine (`generate_vceb_events_and_roundtrips_v1`); the
+evaluator boundary must realize PnL directly from these strategy-emitted roundtrips
+and must never reconstruct a missing exit (`simulate_arm_roundtrips_v1` is baseline-only
+in this package). Reuses VCB's `ArmEventSeriesV1` typed handoff for both arms' event
+masks (used for admission-gate event counting and baseline PnL realization).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import pandas as pd
+
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1
+from src.research.unconditional_20_bar_price_channel_breakout_v1 import (
+    generate_unconditional_20_bar_price_channel_breakout_events_v1,
+)
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.panel_wiring_v1 import (
+    ArmEventSeriesV1,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.binding_v1 import (
+    assert_exit_state_machine_bound,
+    assert_shared_channel_core_bound,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.constants_v1 import (
+    BASELINE_ID,
+    STRATEGY_IDENTITY,
+    TIME_SEGMENT_DEFINITION_ID,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_exit_state_machine_v1 import (
+    open_position_from_fill_v1,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_strategy_v1 import (
+    VcebEventV1,
+    generate_vceb_events_and_roundtrips_v1,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_vol_state_v1 import (
+    compute_atr14_v1,
+)
+from src.trading.master_v2.strategy_suitability_agreement_material_v1 import (
+    StrategyEntrySideCarrierV1,
+)
+
+__all__ = (
+    "ArmEventSeriesV1",
+    "StrategyEmittedRoundtripHandoffV1",
+    "VcebTreatmentBaselineWiringHandoffV1",
+    "wire_treatment_and_baseline_panel_events_v1",
+    "cost_binding_for_canonical_backtest",
+)
+
+
+@dataclass(frozen=True)
+class StrategyEmittedRoundtripHandoffV1:
+    """One strategy-emitted (entry, exit) roundtrip; PnL is realized, not reconstructed."""
+
+    instrument_id: str
+    side: str  # LONG/SHORT
+    signal_index: int
+    fill_index: int
+    exit_index: int
+    entry_price: float
+    exit_price: float
+    exit_reason: str
+    stop_price_at_entry: float
+
+
+@dataclass(frozen=True)
+class VcebTreatmentBaselineWiringHandoffV1:
+    """Typed handoff from panel wiring to the productive evaluator boundary.
+
+    Treatment PnL truth is carried exclusively via ``treatment_strategy_roundtrips``
+    (strategy-emitted exits). ``treatment`` event-series are retained only for
+    admission-gate event counting (evaluable_treatment_breakout_events) and time-segment
+    assignment; they are not used to re-derive treatment exits/PnL.
+    """
+
+    treatment: tuple[ArmEventSeriesV1, ...]
+    baseline: tuple[ArmEventSeriesV1, ...]
+    treatment_strategy_roundtrips: tuple[StrategyEmittedRoundtripHandoffV1, ...]
+    shared_channel_core_bound: bool
+    time_segment_definition_id: str
+    baseline_id: str
+    strategy_identity: str
+    timestamps_utc: tuple[str, ...]
+    strategy_emitted_exits_bound: bool = True
+    evaluator_reconstruction_forbidden: bool = True
+
+    @property
+    def evaluable_treatment_breakout_events(self) -> int:
+        return sum(arm.evaluable_entry_event_count for arm in self.treatment)
+
+
+def _panel_series_to_frame(series: InstrumentPanelSeriesV1) -> pd.DataFrame:
+    rows = [
+        {
+            "timestamp_utc": bar.timestamp_utc,
+            "open": float(bar.open),
+            "high": float(bar.high),
+            "low": float(bar.low),
+            "close": float(bar.close),
+            "volume": float(bar.volume),
+        }
+        for bar in series.bars
+    ]
+    if not rows:
+        raise ValueError(f"EMPTY_INSTRUMENT_SERIES:{series.instrument_id}")
+    frame = pd.DataFrame(rows)
+    frame.index = pd.to_datetime(frame["timestamp_utc"], utc=True)
+    return frame
+
+
+def _side_label(side: StrategyEntrySideCarrierV1 | object) -> str:
+    if side is StrategyEntrySideCarrierV1.LONG:
+        return "LONG"
+    if side is StrategyEntrySideCarrierV1.SHORT:
+        return "SHORT"
+    return "NONE"
+
+
+def wire_treatment_and_baseline_panel_events_v1(
+    panel_series: Sequence[InstrumentPanelSeriesV1],
+    *,
+    time_segment_definition_id: str = TIME_SEGMENT_DEFINITION_ID,
+) -> VcebTreatmentBaselineWiringHandoffV1:
+    """Bind treatment (strategy-emitted) + baseline event producers to the DEVELOPMENT panel."""
+    if time_segment_definition_id != TIME_SEGMENT_DEFINITION_ID:
+        raise ValueError("TIME_SEGMENT_BINDING_MISMATCH")
+    if not panel_series:
+        raise ValueError("EMPTY_PANEL_SERIES")
+    assert_shared_channel_core_bound()
+    assert_exit_state_machine_bound()
+
+    treatment_arms: list[ArmEventSeriesV1] = []
+    baseline_arms: list[ArmEventSeriesV1] = []
+    strategy_roundtrips: list[StrategyEmittedRoundtripHandoffV1] = []
+    reference_timestamps: tuple[str, ...] | None = None
+
+    for series in panel_series:
+        frame = _panel_series_to_frame(series)
+        timestamps = tuple(str(ts) for ts in frame["timestamp_utc"].tolist())
+        if reference_timestamps is None:
+            reference_timestamps = timestamps
+        elif timestamps != reference_timestamps:
+            raise ValueError(f"TIMESTAMP_ALIGNMENT_DRIFT:{series.instrument_id}")
+
+        bar_results, roundtrips = generate_vceb_events_and_roundtrips_v1(frame)
+        baseline_rows = generate_unconditional_20_bar_price_channel_breakout_events_v1(frame)
+        if len(bar_results) != len(timestamps) or len(baseline_rows) != len(timestamps):
+            raise ValueError(f"EVENT_LENGTH_MISMATCH:{series.instrument_id}")
+
+        entry_event_mask = tuple(r.event is VcebEventV1.ENTRY_EVENT for r in bar_results)
+        if sum(entry_event_mask) != len(roundtrips):
+            raise ValueError(f"ENTRY_ROUNDTRIP_COUNT_MISMATCH:{series.instrument_id}")
+
+        treatment_arms.append(
+            ArmEventSeriesV1(
+                arm_id="TREATMENT",
+                instrument_id=series.instrument_id,
+                timestamps_utc=timestamps,
+                entry_sides=tuple(_side_label(r.entry_side) for r in bar_results),
+                entry_event_mask=entry_event_mask,
+            )
+        )
+        baseline_arms.append(
+            ArmEventSeriesV1(
+                arm_id="BASELINE",
+                instrument_id=series.instrument_id,
+                timestamps_utc=timestamps,
+                entry_sides=tuple(_side_label(r.entry_side) for r in baseline_rows),
+                entry_event_mask=tuple(str(r.event) == "ENTRY_EVENT" for r in baseline_rows),
+            )
+        )
+
+        if roundtrips:
+            atr14 = compute_atr14_v1(frame["high"], frame["low"], frame["close"])
+            for rt in roundtrips:
+                atr_at_fill = float(atr14.iloc[rt.fill_index])
+                position = open_position_from_fill_v1(
+                    side=rt.side,  # type: ignore[arg-type]
+                    fill_index=rt.fill_index,
+                    entry_price=float(rt.entry_price),
+                    atr_at_fill=atr_at_fill,
+                )
+                strategy_roundtrips.append(
+                    StrategyEmittedRoundtripHandoffV1(
+                        instrument_id=series.instrument_id,
+                        side=rt.side,
+                        signal_index=rt.signal_index,
+                        fill_index=rt.fill_index,
+                        exit_index=rt.exit_index,
+                        entry_price=float(rt.entry_price),
+                        exit_price=float(rt.exit_price),
+                        exit_reason=rt.exit_reason.value,
+                        stop_price_at_entry=float(position.stop_price),
+                    )
+                )
+
+    assert reference_timestamps is not None
+    return VcebTreatmentBaselineWiringHandoffV1(
+        treatment=tuple(treatment_arms),
+        baseline=tuple(baseline_arms),
+        treatment_strategy_roundtrips=tuple(strategy_roundtrips),
+        shared_channel_core_bound=True,
+        time_segment_definition_id=TIME_SEGMENT_DEFINITION_ID,
+        baseline_id=BASELINE_ID,
+        strategy_identity=STRATEGY_IDENTITY,
+        timestamps_utc=reference_timestamps,
+    )
+
+
+def cost_binding_for_canonical_backtest(cost_execution_binding: dict) -> dict:
+    """Pass-through documenting reuse of canonical cost-binding shape."""
+    return cost_execution_binding

--- a/tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_executable_path_v1.py
+++ b/tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_executable_path_v1.py
@@ -1,0 +1,305 @@
+"""Executable-path / panel-boundary tests for VCEB v1 (no real panel or evaluation run)."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1, PanelBarV1
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.panel_wiring_v1 import (
+    ArmEventSeriesV1,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.authorization_v1 import (
+    AuthorizationDecisionV1,
+    resolve_authorization_decision_v1,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.binding_v1 import (
+    compute_config_digest,
+    load_and_validate_entry_point_binding,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.constants_v1 import (
+    BASELINE_ID,
+    DATASET_ID,
+    HYPOTHESIS_ID,
+    MIN_EXECUTED_TREATMENT_TRADES,
+    PRODUCTIVE_PNL_EVALUATOR_REL_PATH,
+    STRATEGY_IDENTITY,
+    TIME_SEGMENT_DEFINITION_ID,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.entry_point_v1 import (
+    run_evaluate_fail_closed,
+    run_preflight_only,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.evaluate_path_v1 import (
+    dry_validate_evaluate_path_v1,
+    run_authorized_development_evaluation_v1,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.execution_boundary_v1 import (
+    BacktestMetricsBundleV1,
+    FakeExecutionBoundaryV1,
+    PanelLoadResultV1,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.guards_v1 import (
+    GuardError,
+    read_run_counters,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.panel_wiring_v1 import (
+    StrategyEmittedRoundtripHandoffV1,
+    VcebTreatmentBaselineWiringHandoffV1,
+)
+from src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1.time_segments_v1 import (
+    partition_chronological_equal_duration_quarters_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _authorized_decision() -> AuthorizationDecisionV1:
+    return AuthorizationDecisionV1(
+        authorized=True,
+        authorize_token_valid=True,
+        repo_development_evaluation_authorized=True,
+        program_development_evaluation_authorized=True,
+        entry_point_binding_authorized=True,
+        reason_codes=(),
+    )
+
+
+def _synthetic_panel(*, empty: bool = False) -> PanelLoadResultV1:
+    segments = partition_chronological_equal_duration_quarters_v1()
+    timestamps = tuple(seg.start_inclusive for seg in segments)
+    if empty:
+        return PanelLoadResultV1(
+            dataset_id=DATASET_ID,
+            dataset_digest="fake_dataset_digest",
+            panel_series=(),
+            timestamps_utc=(),
+            instrument_count=0,
+            holdout_accessed=False,
+        )
+    bars = tuple(
+        PanelBarV1(
+            instrument_id="INST_A",
+            timestamp_utc=ts,
+            open="100",
+            high="101",
+            low="99",
+            close="100.5",
+            volume="1",
+            is_final=True,
+        )
+        for ts in timestamps
+    )
+    series = InstrumentPanelSeriesV1(
+        instrument_id="INST_A",
+        native_instrument_id="INST_A",
+        bars=bars,
+        series_digest="fake_dataset_digest",
+    )
+    return PanelLoadResultV1(
+        dataset_id=DATASET_ID,
+        dataset_digest="fake_dataset_digest",
+        panel_series=(series,),
+        timestamps_utc=timestamps,
+        instrument_count=1,
+        holdout_accessed=False,
+    )
+
+
+def _fake_handoff(panel: PanelLoadResultV1) -> VcebTreatmentBaselineWiringHandoffV1:
+    n = len(panel.timestamps_utc)
+    mask = tuple(i == 0 for i in range(n))
+    sides = tuple("LONG" if i == 0 else "NONE" for i in range(n))
+    arm = ArmEventSeriesV1(
+        arm_id="TREATMENT",
+        instrument_id="INST_A",
+        timestamps_utc=panel.timestamps_utc,
+        entry_sides=sides,
+        entry_event_mask=mask,
+    )
+    baseline = ArmEventSeriesV1(
+        arm_id="BASELINE",
+        instrument_id="INST_A",
+        timestamps_utc=panel.timestamps_utc,
+        entry_sides=sides,
+        entry_event_mask=mask,
+    )
+    exit_i = min(2, n - 1) if n > 1 else 0
+    roundtrips = (
+        StrategyEmittedRoundtripHandoffV1(
+            instrument_id="INST_A",
+            side="LONG",
+            signal_index=0,
+            fill_index=1 if n > 1 else 0,
+            exit_index=exit_i,
+            entry_price=100.0,
+            exit_price=100.5,
+            exit_reason="TIME_EXIT",
+            stop_price_at_entry=98.5,
+        ),
+    )
+    return VcebTreatmentBaselineWiringHandoffV1(
+        treatment=(arm,),
+        baseline=(baseline,),
+        treatment_strategy_roundtrips=roundtrips,
+        shared_channel_core_bound=True,
+        time_segment_definition_id=TIME_SEGMENT_DEFINITION_ID,
+        baseline_id=BASELINE_ID,
+        strategy_identity=STRATEGY_IDENTITY,
+        timestamps_utc=panel.timestamps_utc,
+        strategy_emitted_exits_bound=True,
+        evaluator_reconstruction_forbidden=True,
+    )
+
+
+def _fake_metrics(*, net_pf: float = 1.5, baseline_net_pf: float = 1.1) -> BacktestMetricsBundleV1:
+    return BacktestMetricsBundleV1(
+        gross_return=0.1,
+        net_return=0.08,
+        gross_profit_factor=1.6,
+        net_profit_factor=net_pf,
+        gross_pnl=100.0,
+        net_expectancy=0.01,
+        sharpe=1.0,
+        max_drawdown=0.1,
+        trade_count=max(35, MIN_EXECUTED_TREATMENT_TRADES),
+        evaluable_treatment_breakout_events=60,
+        baseline_net_profit_factor=baseline_net_pf,
+        baseline_gross_profit_factor=1.2,
+        baseline_trade_count=40,
+        cost_multiplier=1.0,
+        extras={
+            "productive_exit_pnl_evaluator_bound": True,
+            "strategy_emitted_exits_used_for_treatment": True,
+            "evaluator_reconstruction_used_for_treatment": False,
+            "long_trade_count": 20,
+            "short_trade_count": 15,
+            "baseline_net_return": 0.05,
+            "exit_reason_attribution": {"TIME_EXIT": 35},
+        },
+    )
+
+
+def _fake_boundary(*, empty_panel: bool = False) -> FakeExecutionBoundaryV1:
+    panel = _synthetic_panel(empty=empty_panel)
+    return FakeExecutionBoundaryV1(
+        panel=panel,
+        canonical_metrics=_fake_metrics(),
+        stress_metrics=_fake_metrics(net_pf=1.1, baseline_net_pf=1.0),
+        wiring_handoff=None if empty_panel else _fake_handoff(panel),
+        bound_config_digest=compute_config_digest(REPO),
+    )
+
+
+def test_import_safe_and_panel_modules_present() -> None:
+    before = read_run_counters(REPO)
+    mod = importlib.import_module(
+        "src.research.volatility_contraction_expansion_breakout_v1_development_evaluation_v1"
+    )
+    importlib.reload(mod)
+    pkg = (
+        REPO / "src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1"
+    )
+    assert (pkg / "panel_loader_v1.py").is_file()
+    assert (pkg / "panel_wiring_v1.py").is_file()
+    assert (pkg / "execution_boundary_v1.py").is_file()
+    assert (pkg / "admission_gates_v1.py").is_file()
+    assert (pkg / "evidence_materialization_v1.py").is_file()
+    after = read_run_counters(REPO)
+    assert after == before
+    assert before["contract_development_run_count"] == 0
+    assert before["contract_runner_start_count"] == 0
+
+
+def test_development_dataset_id_bound() -> None:
+    assert DATASET_ID == ("pit_okx_linear_usdt_non_bitcoin_cross_sectional_pt1h_dev_pre_holdout_v1")
+    binding = load_and_validate_entry_point_binding(REPO)
+    assert binding["dataset_binding"]["dataset_id"] == DATASET_ID
+    assert binding["baseline_id"] == BASELINE_ID
+    assert binding["time_segment_definition_id"] == TIME_SEGMENT_DEFINITION_ID
+    assert binding["productive_exit_pnl_evaluator_ref"] == PRODUCTIVE_PNL_EVALUATOR_REL_PATH
+    assert binding["productive_pnl_evaluator_duplicated"] is False
+
+
+def test_repo_authorization_authorized_on_head() -> None:
+    decision = resolve_authorization_decision_v1(REPO, authorize_token=HYPOTHESIS_ID)
+    assert decision.authorized is True
+    assert decision.reason_codes == ()
+
+
+def test_dry_validate_no_runner_no_counter_mutation() -> None:
+    before = read_run_counters(REPO)
+    result = dry_validate_evaluate_path_v1(REPO)
+    assert result.status == "DRY_VALIDATE_PASS_EXECUTABLE_PATH_PRESENT"
+    assert result.runner_started is False
+    assert result.evaluation_executed is False
+    assert result.development_dataset_loaded is False
+    after = read_run_counters(REPO)
+    assert after == before
+
+
+def test_fake_boundary_evaluate_writes_slot_claim_then_blocks_reuse(tmp_path: Path) -> None:
+    before = read_run_counters(REPO)
+    assert before["contract_development_run_count"] == 0
+    out = tmp_path / "evidence"
+    result = run_authorized_development_evaluation_v1(
+        REPO,
+        authorize_token=HYPOTHESIS_ID,
+        output_dir=out,
+        execution_boundary=_fake_boundary(),
+        authorization_decision=_authorized_decision(),
+        persist_evidence=True,
+    )
+    assert result.evaluation_executed is True
+    assert result.runner_started is True
+    assert (out / "run_slot_claim.json").is_file()
+    assert (out / "summary.json").is_file()
+    # Repo counters remain zero until a separate productive execution GO mutates them.
+    assert read_run_counters(REPO) == before
+    with pytest.raises(GuardError, match="RETRY_OR_SLOT_REUSE_REJECTED"):
+        run_authorized_development_evaluation_v1(
+            REPO,
+            authorize_token=HYPOTHESIS_ID,
+            output_dir=out,
+            execution_boundary=_fake_boundary(),
+            authorization_decision=_authorized_decision(),
+            persist_evidence=True,
+        )
+
+
+def test_empty_panel_fail_closed_no_slot_claim(tmp_path: Path) -> None:
+    out = tmp_path / "evidence_empty"
+    with pytest.raises((GuardError, ValueError)):
+        run_authorized_development_evaluation_v1(
+            REPO,
+            authorize_token=HYPOTHESIS_ID,
+            output_dir=out,
+            execution_boundary=_fake_boundary(empty_panel=True),
+            authorization_decision=_authorized_decision(),
+            persist_evidence=True,
+        )
+    assert not (out / "run_slot_claim.json").is_file()
+    assert read_run_counters(REPO)["contract_development_run_count"] == 0
+
+
+def test_preflight_still_safe_with_executable_path() -> None:
+    before = read_run_counters(REPO)
+    report = run_preflight_only(REPO)
+    assert report["executable_evaluate_path_present"] is True
+    assert report["runner_started"] is False
+    assert report["evaluation_executed"] is False
+    assert read_run_counters(REPO) == before
+
+
+def test_unauthorized_evaluate_via_entry_point() -> None:
+    before = read_run_counters(REPO)
+    with pytest.raises(GuardError, match="EVALUATION_UNAUTHORIZED"):
+        run_evaluate_fail_closed(
+            REPO,
+            authorize_token="BAD",
+            output_dir=REPO
+            / "docs/evidence/evaluate_volatility_contraction_expansion_breakout_development_v1",
+        )
+    assert read_run_counters(REPO) == before


### PR DESCRIPTION
## Summary
- Materialisiert die fehlende VCEB Development-Panel-Execution-Boundary (Loader, Wiring, injectable Boundary, Admission Gates, Evidence/Registry) analog VDBX.
- Wiederverwendet den produktiven VCB-Exit-PnL-Evaluator (keine zweite PnL-Wahrheit).
- Kein Development-Run: `DEVELOPMENT_RUN_COUNT=0`, Slot unverbraucht; Dry-Validate/Import-Smoke/Contract-Tests grün.

## Test plan
- [x] `ruff format` / `ruff check` auf geänderte Surfaces
- [x] `pytest` entry-point + executable-path tests (20 passed)
- [x] CLI `--mode dry-validate` → `DRY_VALIDATE_PASS_EXECUTABLE_PATH_PRESENT`, counters unverändert
- [x] CLI `--mode preflight` ohne Runner/Slot
- [x] Docs token policy + docs reference targets
- [x] Strategy smoke CLI tests
- [ ] CI confirmation on PR (not merged)


Made with [Cursor](https://cursor.com)

## RISK_LIMIT_JUSTIFICATION
Policy Critic `RISK_LIMIT_RAISE_WITHOUT_JUSTIFICATION` matched `MAXIMUM_MAX_DRAWDOWN` / `max_drawdown=…` snippets in `constants_v1.py` and `evaluate_path_v1.py`.
These constants (`MIN_EVALUABLE_TREATMENT_BREAKOUT_EVENTS`, `MIN_EVALUABLE_TREATMENT_EVENTS_PER_TIME_SEGMENT`, `MIN_EXECUTED_TREATMENT_TRADES`, `TIME_SEGMENT_ROBUSTNESS_PASS_RATIO`, `MINIMUM_PASSING_SEGMENTS`, `GROSS_PROFIT_FACTOR_MIN`, `NET_PROFIT_FACTOR_MIN`, `COST_STRESS_1_5X_NET_PROFIT_FACTOR_MIN`, `MAXIMUM_MAX_DRAWDOWN`, `MINIMUM_NET_EXPECTANCY`) mirror already-preregistered DEVELOPMENT `economic_admission_contract` thresholds (frozen digest unchanged) and are consumed only by research `admission_gates_v1` / evaluate-path reporting.
They do not control live/runtime/portfolio/capital sizing, exposure, leverage, stop, loss, or order risk limits; no productive risk consumer is raised. LIVE_AUTHORIZED=false, ORDERS=false; no risk increase and no scope expansion.
