### PR TITLE
fix(research): VEPC durable run-state claim on technical fail-closed

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -1,1280 +1,1299 @@
 {
-    "allowed_optimization_surfaces": {
-        "ADVERSE_EXIT_DOWNSCOPE_DUAL_DIMENSION_RESEARCH_FIXTURE_ALIGN": {
-            "path_globs": [
-                "tests/research/test_adverse_exit_and_reversal_preparation_backtest_parity_narrow_rewire_v0.py",
-                "tests/research/test_adverse_exit_and_reversal_preparation_backtest_parity_wiring_assessment_or_narrow_rewire_v0.py",
-                "tests/research/test_adverse_scope_exit_reversal_preparation_narrow_reuse_first_rewire_v0.py",
-                "tests/research/test_scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py",
-                "tests/research/test_scope_adverse_exit_reversal_backtest_runtime_decision_parity_pass_assertion_surface_only_v0.py",
-            ],
-            "path_prefixes": [
-                "scripts/research/adverse_exit_and_reversal_preparation_backtest_parity_narrow_rewire_v0.py",
-                "scripts/research/adverse_scope_exit_reversal_preparation_narrow_reuse_first_rewire_v0.py",
-                "scripts/research/scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py",
-            ],
-        },
-        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-            "note": "Single preregistered DEVELOPMENT-only offline evaluation of Wilder ADX(14) +DI/−DI direction-confirmation pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=PASS, ALL_PASS_REQUIRES_MET); research-only entry-eligibility gate; economic offline gate remains closed; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-            "path_prefixes": [
-                "src/research/adx_di_direction_confirmation_mr_eligibility_development_evaluation_v1/",
-                "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_development_v1.py",
-                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_development_evaluation_v1.py",
-                "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_development_v1/",
-                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
-            ],
-        },
-        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_EVALUATION_V1": {
-            "note": "Single authorized HOLDOUT evaluation of Wilder ADX(14) +DI/-DI direction-confirmation MR eligibility versus immutable bollinger baseline on the sealed FINAL_AUDIT panel (holdout_run_count 1/1, RESULT_CLASS=ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN after MV2 replay signal-index mismatch); no retry/post-result tuning; economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-            "path_prefixes": [
-                "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v1/",
-                "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v1.py",
-                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v1.py",
-                "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v1/",
-                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md",
-            ],
-        },
-        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_EVALUATION_V2": {
-            "note": "Single authorized HOLDOUT v2 evaluation of Wilder ADX(14) +DI/-DI direction-confirmation MR eligibility versus immutable bollinger baseline on the sealed FINAL_AUDIT panel (holdout_run_count 1/1, RESULT_CLASS=FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED); new evaluation ID not a V1 rerun; economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-            "path_prefixes": [
-                "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v2/",
-                "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v2.py",
-                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v2.py",
-                "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v2/",
-                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V2.md",
-            ],
-        },
-        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only holdout preregistration for ADX DI direction-confirmation MR eligibility after DEVELOPMENT PASS; freezes sealed FINAL_AUDIT holdout split digest from existing SSOT registry metadata, acceptance criteria, run-limit=1, and execution-GO gate; no holdout data access, no backtest, no economic metrics, no productive authority mutation.",
-            "path_prefixes": [
-                "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v1.py",
-                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v1.py",
-                "config/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistered_measurement_contract_v1.json",
-                "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_holdout_v1/",
-                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md",
-            ],
-        },
-        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V2": {
-            "note": "Holdout preregistration v2 for ADX DI direction-confirmation MR eligibility; evaluation executed and terminal as FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); V1 remains terminal ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN; no productive authority mutation.",
-            "path_prefixes": [
-                "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v2.py",
-                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v2.py",
-                "config/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistered_measurement_contract_v2.json",
-                "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_holdout_v2/",
-                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V2.md",
-            ],
-        },
-        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of a single Wilder ADX(14) +DI/−DI direction-confirmation pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to six prior FAILs (regime, ATR, RSI, ADX-level, MA, MACD); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-            "path_prefixes": [
-                "src/research/adx_di_direction_confirmation_mr_eligibility_hypothesis_preregistration_v1.py",
-                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_hypothesis_preregistration_v1.py",
-                "config/research/adx_di_direction_confirmation_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_hypothesis_v1/",
-                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-            ],
-        },
-        "ADX_RANGE_ADMISSION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-            "note": "Single preregistered DEVELOPMENT-only offline evaluation of ADX(14) range-admission pre-entry MR eligibility filter versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-            "path_prefixes": [
-                "src/research/adx_range_admission_mr_eligibility_development_evaluation_v1/",
-                "scripts/research/run_evaluate_adx_range_admission_mr_eligibility_development_v1.py",
-                "tests/research/test_adx_range_admission_mr_eligibility_development_evaluation_v1.py",
-                "docs/evidence/evaluate_adx_range_admission_mr_eligibility_development_v1/",
-                "docs/governance/ADX_RANGE_ADMISSION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
-            ],
-        },
-        "ADX_RANGE_ADMISSION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of a single ADX(14) range-admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to failed regime-gated, ATR-percentile, and RSI-exhaustion mechanisms; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-            "path_prefixes": [
-                "src/research/adx_range_admission_mr_eligibility_hypothesis_preregistration_v1.py",
-                "tests/research/test_adx_range_admission_mr_eligibility_hypothesis_preregistration_v1.py",
-                "config/research/adx_range_admission_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "docs/evidence/preregister_adx_range_admission_mr_eligibility_hypothesis_v1/",
-                "docs/governance/ADX_RANGE_ADMISSION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-            ],
-        },
-        "BOLLINGER_MR_ECONOMIC_FAILURE_DECOMPOSITION_DEVELOPMENT_V1": {
-            "note": "Canonical development-only read-only economic failure decomposition of the immutable Bollinger/MR baseline on the sealed DEVELOPMENT_ONLY panel; diagnostic classification only; no new hypothesis; no holdout access; no Economic/Promotion gate open; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders.",
-            "path_prefixes": [
-                "config/research/bollinger_mr_economic_failure_decomposition_development_v1.json",
-                "src/research/bollinger_mr_economic_failure_decomposition_development_v1/",
-                "scripts/research/run_bollinger_mr_economic_failure_decomposition_development_v1.py",
-                "tests/research/test_bollinger_mr_economic_failure_decomposition_development_v1.py",
-                "docs/governance/BOLLINGER_MR_ECONOMIC_FAILURE_DECOMPOSITION_DEVELOPMENT_V1.md",
-                "docs/evidence/bollinger_mr_economic_failure_decomposition_development_v1/",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V1": {
-            "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR side-aware middle-band exit-efficiency versus immutable bollinger baseline on sealed DEVELOPMENT panel (evaluation_run_count 0->1); Economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders. Gate-binding contract test covers MV2 wiring_mod capture-alias open_side binding only.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1/",
-                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v1.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v1.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_gate_binding_v1.py",
-                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v1/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V1.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V2": {
-            "note": "Terminal DEVELOPMENT_ONLY evaluation closeout for hypothesis ...DEVELOPMENT_V2 (evaluation_run_count 0->1 exactly once; RESULT_CLASS=INCONCLUSIVE_INFRASTRUCTURE_FAILURE; ROOT_CAUSE=PREMEASUREMENT_GATE_FALSE_POSITIVE_ZERO_OR_SENTINEL); reuses frozen V1 mechanism/gate/decision by import only; not a V1 rerun; no V1 partial-result reuse; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders; no V2 rerun.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v2/",
-                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v2.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v2.py",
-                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v2/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V2.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V3": {
-            "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V3 (evaluation_run_count 0->1); identical definition to V2/V1; binds EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 and PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE; not a V1/V2 rerun; no V2 partial-result reuse; Economic offline gate closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v3/",
-                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v3.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v3.py",
-                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v3/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V3.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4": {
-            "note": "Definition-only evaluation surface for exactly one future DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V4; reuses frozen V1 mechanism/gate/decision by import; binds measurement-validity preflight, EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1, PANEL_RUNNER_FALSY_ZERO hygiene, and MV2_WIRING_MOD_CAPTURE_ALIAS_OPEN_SIDE_BINDING_FIX; V4 contract remains DEFINITION_ONLY_PREREGISTERED with evaluation_run_count=0 in this slice; no evaluation executed here; evidence directory created only by a future authorized run; not a V1/V2/V3 rerun; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/",
-                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v4.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v4.py",
-                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v4/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5": {
-            "note": "Terminal DEVELOPMENT evaluation closeout for Bollinger/MR midband exit-efficiency V5 after one authorized run (0→1): RESULT_CLASS=INFRASTRUCTURE_FAILURE; DIAGNOSTIC_CLASS=PROCESS_DIED_INCOMPLETE_PANEL_RUN_NO_LIFECYCLE_TERMINAL; baseline 3/46; not a V4/V3/V2/V1 rerun; no V4 partial-result reuse; no holdout/runtime/orders; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no V5 rerun. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v5/",
-                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v5.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v5.py",
-                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v5/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6": {
-            "note": "Terminal DEVELOPMENT evaluation closeout for Bollinger/MR composite exit-efficiency V6 after one authorized run (0→1): RESULT_CLASS=FAIL; REASON=NET_PROFIT_FACTOR_NOT_IMPROVED; exit divergence observed; treatment binding confirmed; not a V5/V4/V3/V2/V1 rerun; no V5 partial-result reuse; no holdout/runtime/orders; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no V6 rerun. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v6/",
-                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v6.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v6.py",
-                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v6/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of a single DEVELOPMENT_ONLY Bollinger/MR side-aware middle-band exit-efficiency measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v1.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v1.py",
-                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v1/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V2": {
-            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V2 with identical definition semantics to terminal V1; EVALUATION_RUN_COUNT=0; not a V1 rerun; no V1 partial-result reuse; mandatory EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 binding; no evaluation/runtime/orders.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v2.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v2.py",
-                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v2.json",
-                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v2/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V2.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V3": {
-            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V3 with identical economic/definition semantics to terminal V2/V1; EVALUATION_RUN_COUNT=0; not a V2 or V1 rerun; no V2 partial-result or economic-result import; mandatory EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 and PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE bindings; V2 remains terminal INCONCLUSIVE_INFRASTRUCTURE_FAILURE run count 1; no evaluation/runtime/orders.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v3.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v3.py",
-                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v3.json",
-                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v3/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V3.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V4": {
-            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V4 after terminal V3 FAIL; EVALUATION_RUN_COUNT=0; presupposes merged MV2 wiring_mod capture-alias open_side binding fix; fail-closed measurement-validity gates (effective config digest inequality, open_side binding, exit observability, synthetic divergence); not a V3/V2/V1 rerun; no evaluation/runtime/orders.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v4.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v4.py",
-                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v4.json",
-                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v4/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V4.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V5": {
-            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V5 after terminal V4 INFRASTRUCTURE_FAILURE; EVALUATION_RUN_COUNT=0; preserves V4 economic hypothesis/exit mechanism; adds process-lifecycle checkpoint observability; not a V4/V3/V2/V1 rerun; no evaluation/runtime/orders.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v5.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v5.py",
-                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v5.json",
-                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v5/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V5.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V6": {
-            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V6 after terminal V5 INFRASTRUCTURE_FAILURE; EVALUATION_RUN_COUNT=0; genuine economic change vs V5 (midband-cross OR frozen max-holding-horizon=48h); reuses V5 process-lifecycle checkpoint; not a V5/V4/V3/V2/V1 rerun; no V5 partial metrics; no evaluation/runtime/orders.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v6.py",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v6.py",
-                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v6.json",
-                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v6/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V6.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PROCESS_LIFECYCLE_CHECKPOINT_V5": {
-            "note": "Definition-only process-lifecycle checkpoint scaffold for V5: monotonic lifecycle states, atomic checkpoints, read-only recovery diagnostics; import cannot start runner; checkpoints cannot reclaim run slots or authorize automatic reruns; partial metrics non-authoritative.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_efficiency_process_lifecycle_checkpoint_v5/",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_process_lifecycle_checkpoint_v5.py",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_V6_FAILURE_ATTRIBUTION": {
-            "note": "Evidence-only read-only failure attribution for terminal V6 FAIL (NET_PROFIT_FACTOR_NOT_IMPROVED). No evaluation/backtest/panel/holdout access; does not mutate V6 artifacts/run count; does not preregister or authorize V7; no promotion/runtime/orders; no Master-V2/Double-Play/risk/sizing/execution mutation.",
-            "path_prefixes": [
-                "docs/evidence/attribute_bollinger_mr_midband_exit_efficiency_v6_failure/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_V6_FAILURE_ATTRIBUTION.md",
-                "tests/research/test_bollinger_mr_midband_exit_efficiency_v6_failure_attribution.py",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V7": {
-            "note": "Separate Operator ratification authorizing exactly one later V7 DEVELOPMENT evaluation run; does not mutate preregistration digest/field; requires released DEVELOPMENT panel; does not start runner or claim slot.",
-            "path_prefixes": [
-                "config/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.json",
-                "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.py",
-                "scripts/research/run_authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7.py",
-                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.py",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V7.md",
-                "docs/evidence/authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7/",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V8": {
-            "note": "Separate Operator ratification surface authorizing exactly one later V8 DEVELOPMENT evaluation run; requires pre-authorization parity PASS and released DEVELOPMENT panel; does not start runner or claim slot in wiring slice.",
-            "path_prefixes": [
-                "config/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.json",
-                "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.py",
-                "scripts/research/run_authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8.py",
-                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.py",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V8.md",
-                "docs/evidence/authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8/",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V7": {
-            "note": "V7 reentry-cooldown DEVELOPMENT evaluation surfaces; single authorized evaluate process consumed slot and terminated INCONCLUSIVE_INFRASTRUCTURE_FAILURE (PRE_PANEL_FROZEN_EXIT_PARAMETERS_MISMATCH_NO_PANEL_BACKTEST); no rerun; no holdout.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7/",
-                "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v7.py",
-                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7.py",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V7.md",
-                "docs/evidence/preflight_bollinger_mr_midband_exit_reentry_cooldown_v7_wiring/",
-                "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v7/",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V8": {
-            "note": "V8 reentry-cooldown DEVELOPMENT evaluation wiring; pre-authorization parity before auth/slot; EVALUATION_RUN_COUNT=0; default CLI preflight-only; evaluate requires ratification+flag; evaluate evidence not pre-created; no evaluation/runtime/orders; V7 terminal unreopened.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8/",
-                "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v8.py",
-                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8.py",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V8.md",
-                "docs/evidence/preflight_bollinger_mr_midband_exit_reentry_cooldown_v8_wiring/",
-                "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v8/",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_EVALUATION_V1": {
-            "note": "Single authorized HOLDOUT_V1 evaluation of frozen Exit V8 midband reentry-cooldown treatment on sealed FINAL_AUDIT panel; terminal FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); economic/promotion/runtime/orders closed; V7/V8 terminals unchanged.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_evaluation_v1/",
-                "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1.py",
-                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_holdout_evaluation_v1.py",
-                "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_EVALUATION_V1.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Holdout confirmation preregistration of frozen V8 midband exit reentry-cooldown (hypothesis HOLDOUT_V1; digest a0658fe3fb883939ed2a2de2c426f2e4edf21eeeb91d1b902d45b4d05a38fd1d); evaluation executed terminal FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); V8 digest immutable; no second run; no runtime/orders.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistration_v1.py",
-                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistration_v1.py",
-                "config/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistered_measurement_contract_v1.json",
-                "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V7": {
-            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit reentry-cooldown V7 after terminal V6 FAIL + evidence-only attribution; EVALUATION_RUN_COUNT=0; control=exact V6 semantics; treatment=same-side reentry cooldown 24h after forced midband; not a V6 rerun; no V6 partial import; no evaluation/runtime/orders.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v7.py",
-                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v7.py",
-                "config/research/bollinger_mr_midband_exit_reentry_cooldown_preregistered_economic_hypothesis_measurement_contract_v7.json",
-                "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_v7/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V7.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V8": {
-            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit reentry-cooldown V8 after terminal V7 INCONCLUSIVE_INFRASTRUCTURE_FAILURE (FROZEN_EXIT_PARAMETERS_MISMATCH); EVALUATION_RUN_COUNT=0; control=exact V6 semantics; treatment=same-side reentry cooldown 24h; complete exit_mechanism.frozen_parameters SSOT; pre-authorization parity validator; not a V7 reopen/retry; no evaluation/runtime/orders.",
-            "path_prefixes": [
-                "src/research/bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v8.py",
-                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v8.py",
-                "config/research/bollinger_mr_midband_exit_reentry_cooldown_preregistered_economic_hypothesis_measurement_contract_v8.json",
-                "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_v8/",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V8.md",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V7": {
-            "note": "Governance overlay clarifying V7 implementation ambiguities B1-B6 without mutating immutable preregistration digest; operator_decisions_status OPERATOR_DECISIONS_RECORDED_IMPLEMENTATION_ONLY; lifecycle may transition READY_FOR_OPERATOR_EVALUATION_AUTHORIZATION -> EVALUATION_AUTHORIZED via separate ratification; evaluation_run_count=0 until run GO; no runtime/orders.",
-            "path_prefixes": [
-                "config/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.json",
-                "src/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.py",
-                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.py",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V7.md",
-                "docs/evidence/operator_clarification_bollinger_mr_midband_exit_reentry_cooldown_v7/",
-            ],
-        },
-        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V8": {
-            "note": "Governance overlay clarifying V8 B1-B6 without mutating immutable preregistration digest; lifecycle READY_FOR_OPERATOR_EVALUATION_AUTHORIZATION; evaluation_authorized=false until separate ratification; evaluation_run_count=0; no runtime/orders.",
-            "path_prefixes": [
-                "config/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.json",
-                "src/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.py",
-                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.py",
-                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V8.md",
-                "docs/evidence/operator_clarification_bollinger_mr_midband_exit_reentry_cooldown_v8/",
-            ],
-        },
-        "CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1": {
-            "note": "Canonical SSOT backlog for open MR entry-eligibility hypotheses; explicit operator CLOSE_LANE_NO_FURTHER_RESEARCH under shared research-lane post-terminal lifecycle contract V1 (status=LANE_CLOSED_NO_FURTHER_RESEARCH; explicit_closeout_decision=true; lane_auto_closed=false); inventories empty; historical terminals immutable; no runtime/orders.",
-            "path_prefixes": [
-                "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json",
-                "src/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
-                "tests/research/test_canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
-                "docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md",
-            ],
-        },
-        "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1": {
-            "note": "Canonical SSOT backlog for open MR exit-efficiency hypotheses; explicit operator CREATE_SUCCESSOR_HYPOTHESIS under shared lifecycle contract V1 after V8 TERMINAL_PASS (status=OPEN_BACKLOG; holdout successor HOLDOUT_V1 DEFINITION_ONLY_PREREGISTERED; digest a0658fe3fb883939ed2a2de2c426f2e4edf21eeeb91d1b902d45b4d05a38fd1d); V8 identity unreopened; holdout execution unauthorized; Entry sibling LANE_CLOSED_NO_FURTHER_RESEARCH; Economic/promotion closed; no runtime/orders.",
-            "path_prefixes": [
-                "config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json",
-                "src/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py",
-                "tests/research/test_canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py",
-                "docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md",
-            ],
-        },
-        "CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1": {
-            "note": "Shared definition-only research-lane post-terminal lifecycle contract; canonical lane-state vocabulary, totality invariant, operator-decision contract, and historical-immutability/live-mirror policy. Entry-Eligibility and Exit-Efficiency backlog SSOTs migrate in separate operator-authorized slices; no evaluation/runtime/orders.",
-            "path_prefixes": [
-                "config/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.json",
-                "src/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.py",
-                "tests/research/test_canonical_research_lane_post_terminal_lifecycle_contract_v1.py",
-                "docs/governance/CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1.md",
-            ],
-        },
-        "COST_MODEL_DIAGNOSTICS": {
-            "path_globs": [
-                "tests/research/test_offline_linear_cost_model_diagnostics_*",
-                "tests/research/test_offline_signal_orthogonality_diagnostics_*",
-                "tests/research/test_offline_productive_signal_orthogonality_results_interpretation_v0.py",
-                "tests/research/test_offline_productive_factor_exposure_diagnostics_v0.py",
-                "tests/research/test_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-                "tests/research/test_offline_productive_rolling_linear_drift_diagnostics_v0.py",
-                "tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py",
-                "tests/research/test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-                "tests/research/test_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-                "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
-                "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
-                "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-                "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-                "tests/research/test_offline_factor_exposure_diagnostics_*",
-                "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
-                "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
-                "tests/research/test_offline_final_research_fleet_signal_matrix_productive_input_join_materializer_*",
-                "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
-                "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_*",
-                "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
-                "tests/research/test_offline_parameter_sensitivity_model_spec_alignment_*",
-                "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*",
-                "tests/research/test_offline_rolling_linear_drift_diagnostics_v0.py",
-                "tests/research/test_offline_outlier_and_window_robustness_diagnostic_v0.py",
-                "tests/research/test_linear_evidence_*",
-            ],
-            "path_prefixes": [
-                "src/research/linear_evidence/cost_model.py",
-                "src/research/linear_evidence/diagnostics.py",
-                "src/research/linear_evidence/fitters.py",
-                "src/research/linear_evidence/drift.py",
-                "src/research/linear_evidence/window_robustness.py",
-                "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
-                "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
-                "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
-                "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
-                "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
-                "scripts/research/offline_linear_cost_model_diagnostics_v0.py",
-                "scripts/research/offline_signal_orthogonality_diagnostics_v0.py",
-                "scripts/research/offline_factor_exposure_diagnostics_v0.py",
-                "scripts/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
-                "scripts/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
-                "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
-                "scripts/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
-                "scripts/research/offline_rolling_linear_drift_diagnostics_v0.py",
-                "scripts/research/offline_outlier_and_window_robustness_diagnostic_v0.py",
-                "scripts/ops/materialize_offline_productive_signal_orthogonality_results_interpretation_v0.py",
-                "scripts/ops/materialize_offline_productive_factor_exposure_diagnostics_v0.py",
-                "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-                "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
-                "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
-                "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-                "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-                "scripts/ops/materialize_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
-                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-                "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
-                "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
-                "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
-                "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-                "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-                "src/research/linear_evidence/offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-            ],
-        },
-        "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-            "note": "DEVELOPMENT evaluation entry point/owner for CS relative-strength momentum v1: executable evaluate path under fail-closed authorization, CLI preflight/dry-validate, digests/dataset/time-segment/rebalance-observation/evidence-registry/admission gates, wiring into canonical single-slot backtest metrics owners. Development evaluation authorized on HEAD; no runner start/run-slot consumption without separate execution GO; no holdout/runtime/orders; measurement thresholds and strategy score/selection semantics unchanged.",
-            "path_prefixes": [
-                "config/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_binding_v1.json",
-                "docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/",
-                "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-                "scripts/research/run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py",
-                "src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/",
-                "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_v1.py",
-                "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_executable_path_v1.py",
-                "tests/research/test_cross_sectional_relative_strength_momentum_v1_panel_loader_alignment_repair_v1.py",
-            ],
-        },
-        "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of cross-sectional relative-strength momentum v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; directional form D mutually exclusive single-slot selection; bounded DEV grid frozen; operator-authorized robustness thresholds (minimum_rebalance_observations=30, time_segment_robustness_pass_ratio=0.5) and CHRONOLOGICAL_EQUAL_DURATION_QUARTERS_V1 bound; development evaluation authorized; evaluation not executed; no holdout/runtime/orders; closed Entry/Exit Bollinger lanes untouched.",
-            "path_prefixes": [
-                "config/research/cross_sectional_relative_strength_momentum_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "src/research/cross_sectional_relative_strength_momentum_v1_hypothesis_preregistration_v1.py",
-                "tests/research/test_cross_sectional_relative_strength_momentum_v1_hypothesis_preregistration_v1.py",
-                "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-                "docs/evidence/preregister_cross_sectional_relative_strength_momentum_hypothesis_v1/",
-            ],
-        },
-        "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-            "note": "Strategy-implementation-only surfaces for CS relative-strength momentum v1 (raw trailing log-return score + single-top1 rank-intent selection + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; no Master-V2/Double-Play mutation.",
-            "path_prefixes": [
-                "src/research/cross_sectional_relative_strength_momentum_v1_score_v1.py",
-                "src/research/cross_sectional_relative_strength_momentum_v1_selection_v1.py",
-                "src/research/cross_sectional_relative_strength_momentum_v1_strategy_implementation_binding_v1.py",
-                "config/research/cross_sectional_relative_strength_momentum_v1_strategy_implementation_binding_v1.json",
-                "tests/research/test_cross_sectional_relative_strength_momentum_v1_score_and_selection_v1.py",
-                "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
-            ],
-        },
-        "DATA_BINDING_REPAIR": {
-            "path_prefixes": [
-                "src/research/offline_source_evidence_",
-                "scripts/research/offline_source_evidence_",
-            ]
-        },
-        "DETERMINISTIC_MATERIALIZATION_REPAIR": {
-            "path_prefixes": [
-                "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
-                "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
-                "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
-                "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
-                "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
-                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
-                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
-                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
-            ]
-        },
-        "DIGEST_BINDING_AND_PROVENANCE_REPAIR": {
-            "path_globs": ["scripts/ops/*digest*", "scripts/ops/*binding*"],
-            "path_prefixes": ["scripts/ops/primary_evidence_retention_v0.py"],
-        },
-        "DOUBLE_PLAY_COMPOSITION_NARROW_RESEARCH_REWIRE": {
-            "path_globs": [
-                "tests/research/test_double_play_composition_narrow_reuse_first_rewire_v0.py"
-            ],
-            "path_prefixes": [
-                "scripts/research/double_play_composition_narrow_reuse_first_rewire_v0.py"
-            ],
-        },
-        "ENTRY_EFFECTIVE_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-            "note": "Single preregistered DEVELOPMENT-only offline evaluation of entry-effective pre-entry ATR-percentile mid-band MR eligibility filter (STRICT bounds) versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of the prior failed regime_gated evaluation's shared_portfolio_equity_research_v1 helper only (no mutation of that package); no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-            "path_prefixes": [
-                "src/research/entry_effective_mr_eligibility_development_evaluation_v1/",
-                "scripts/research/run_evaluate_entry_effective_mr_eligibility_development_v1.py",
-                "tests/research/test_entry_effective_mr_eligibility_development_evaluation_v1.py",
-                "docs/evidence/evaluate_entry_effective_mr_eligibility_development_v1/",
-                "docs/governance/ENTRY_EFFECTIVE_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
-            ],
-        },
-        "ENTRY_EFFECTIVE_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of a single entry-effective pre-entry ATR-percentile MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-            "path_prefixes": [
-                "src/research/entry_effective_mr_eligibility_hypothesis_preregistration_v1.py",
-                "tests/research/test_entry_effective_mr_eligibility_hypothesis_preregistration_v1.py",
-                "config/research/entry_effective_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "docs/evidence/preregister_entry_effective_mr_eligibility_hypothesis_v1/",
-                "docs/governance/ENTRY_EFFECTIVE_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-            ],
-        },
-        "EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1": {
-            "note": "Generic research-infrastructure observability for evaluation-runner process death (atomic heartbeat/progress, catchable signal handlers, exit/signal normalization, supervised child reap, INCONCLUSIVE_INFRASTRUCTURE_FAILURE classification without auto-rerun); no strategy/Master-V2/Double-Play/risk/sizing/execution/economic semantics mutation; no evaluation rerun; no holdout access; no runtime/orders.",
-            "path_prefixes": [
-                "src/research/evaluation_runner_lifecycle_observability_v1/",
-                "tests/research/test_evaluation_runner_lifecycle_observability_v1.py",
-                "docs/evidence/evaluation_runner_lifecycle_observability_v1/",
-            ],
-        },
-        "EXPLICITLY_CALIBRATABLE_RESEARCH_PARAMETERS_WITHIN_PREDECLARED_RANGES": {
-            "path_prefixes": [
-                "src/research/linear_evidence/sensitivity.py",
-                "src/research/linear_evidence/drift.py",
-                "src/research/linear_evidence/window_robustness.py",
-                "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
-                "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
-                "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
-                "scripts/research/offline_parameter_sensitivity_surface_v0.py",
-                "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
-                "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-                "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
-            ]
-        },
-        "FEATURE_SCALING_OR_NUMERICAL_CONDITIONING_WITHOUT_TRADING_SEMANTIC_EFFECT": {
-            "path_prefixes": [
-                "src/research/linear_evidence/feature_matrix.py",
-                "src/research/linear_evidence/contracts.py",
-                "src/research/linear_evidence/signal_orthogonality.py",
-                "src/research/linear_evidence/signal_orthogonality_results_interpretation_v0.py",
-                "src/research/linear_evidence/offline_productive_factor_exposure_diagnostics_v0.py",
-                "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
-                "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
-                "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
-                "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-                "src/research/linear_evidence/offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-                "src/research/linear_evidence/factor_exposure.py",
-                "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
-                "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
-                "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
-                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
-                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
-                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
-            ]
-        },
-        "GOVERNANCE_ONLY_OPERATOR_RATIFICATION_AND_RESEARCH_SCOPE_DEFINITION_WITHOUT_TRADING_SEMANTIC_EFFECT": {
-            "note": "Governance-only operator ratification and research scope definition without trading semantic mutation or runtime authority.",
-            "path_globs": [
-                "src/research/*terminal_inconclusive_insufficient_sample_and_distinct_futures_research_scope_definition_v0.py",
-                "src/research/*terminal_insufficient_sample_and_distinct_futures_research_scope_ratification_v0.py",
-                "src/research/*research_scope_ratification_v0.py",
-                "src/research/*versioned_hypothesis_binding_v0.py",
-                "src/research/*versioned_research_binding_v0.py",
-                "src/research/*score_and_ranking_contract_v0.py",
-                "src/research/*portfolio_binding_v0.py",
-                "src/research/cross_sectional_futures_pairwise_lead_lag_spillover_*_score_v0.py",
-                "scripts/research/materialize_*operator_ratification*",
-                "scripts/research/materialize_*scope_ratification*",
-                "scripts/research/materialize_*terminal_*research_scope*",
-                "scripts/research/materialize_*versioned_hypothesis_binding_v0.py",
-                "scripts/research/materialize_*versioned_research_binding_v0.py",
-                "scripts/research/materialize_*score_and_ranking_contract_v0.py",
-                "scripts/research/materialize_*portfolio_binding_implementation_v0.py",
-                "scripts/research/materialize_*offline_economic_evaluation_authorization_ratification_v0.py",
-                "src/research/*offline_economic_evaluation_authorization_ratification_v0.py",
-                "src/research/full_canonical_system_economic_evidence_generation_v1.py",
-                "scripts/research/materialize_full_canonical_system_economic_evidence_generation_v1_binding_ratification_v0.py",
-                "tests/research/test_*versioned_hypothesis_binding_v0_contract.py",
-                "tests/research/test_*versioned_research_binding_v0_contract.py",
-                "tests/research/test_*score_and_ranking_contract_v0_contract.py",
-                "tests/research/test_*portfolio_binding_implementation_v0_contract.py",
-                "tests/research/test_*offline_economic_evaluation_authorization_ratification_v0_contract.py",
-                "tests/research/test_full_canonical_system_economic_evidence_generation_v1_binding_ratification_v0_contract.py",
-                "config/research/*governance_closeout_v0.json",
-                "docs/governance/*GOVERNANCE_CLOSEOUT_V0.md",
-                "tests/ops/test_*governance_closeout_v0_contract.py",
-            ],
-        },
-        "INDEPENDENT_DEV_PANEL_QUARANTINE_RELEASE_V1": {
-            "note": "Byte-identical quarantine to RELEASED_DEVELOPMENT_ONLY panel release; no transform; no holdout; does not authorize evaluation.",
-            "path_prefixes": [
-                "config/research/independent_dev_panel_quarantine_release_contract_v1.json",
-                "src/research/independent_dev_panel_quarantine_release_v1.py",
-                "scripts/research/run_release_independent_dev_panel_quarantine_v1.py",
-                "tests/research/test_independent_dev_panel_quarantine_release_v1.py",
-                "docs/governance/INDEPENDENT_DEV_PANEL_QUARANTINE_RELEASE_V1.md",
-                "docs/evidence/release_independent_dev_panel_quarantine_byte_identical_v1/",
-            ],
-        },
-        "LONGER_CHRONOLOGICAL_PIT_PUBLIC_HISTORY_ACQUISITION_SCAFFOLD_AND_DEPTH_PROBE_V1": {
-            "note": "Research-only public OKX history acquisition scaffold, bounded history-depth probe, sealed production-lifecycle long-panel binding/acquisition, and independent pre-holdout development-panel seal; dry-run/no-credentials defaults; no economic optimization; no strategy/risk/execution/Master-V2/Double-Play mutation.",
-            "path_prefixes": [
-                "src/research/longer_chronological_pit_acquisition_v1/",
-                "tests/research/test_longer_chronological_pit_acquisition_scaffold_v1.py",
-                "tests/research/test_longer_chronological_pit_okx_history_depth_probe_v1.py",
-                "tests/research/test_longer_chronological_pit_sealed_lifecycle_acquisition_v1.py",
-                "config/research/longer_chronological_pit_acquisition_chrono_3y_v1.json",
-                "config/research/longer_chronological_pit_sealed_lifecycle_long_panel_v1.json",
-                "config/research/regime_gated_standaside_mr_independent_dev_panel_acquisition_contract_v1.json",
-                "config/research/regime_gated_standaside_mr_independent_dev_panel_seal_registry_v1.json",
-                "docs/evidence/longer_chronological_pit_sealed_lifecycle_acquisition_v1/",
-                "docs/evidence/acquire_and_seal_okx_independent_dev_panel_v1/",
-                "docs/governance/REGIME_GATED_STANDASIDE_MR_INDEPENDENT_DEV_PANEL_SEALED_V1.md",
-                "tests/governance/test_acquire_and_seal_okx_independent_dev_panel_v1.py",
-            ],
-        },
-        "MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-            "note": "Single preregistered DEVELOPMENT-only offline evaluation of MACD(12,26,9) histogram-sign countertrend pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=FAIL, NET_PROFIT_FACTOR_NOT_IMPROVED); research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-            "path_prefixes": [
-                "src/research/macd_histogram_countertrend_mr_eligibility_development_evaluation_v1/",
-                "scripts/research/run_evaluate_macd_histogram_countertrend_mr_eligibility_development_v1.py",
-                "tests/research/test_macd_histogram_countertrend_mr_eligibility_development_evaluation_v1.py",
-                "docs/evidence/evaluate_macd_histogram_countertrend_mr_eligibility_development_v1/",
-                "docs/governance/MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
-            ],
-        },
-        "MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of a single MACD(12,26,9) histogram-sign countertrend admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to five prior FAILs (regime, ATR, RSI, ADX, MA); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-            "path_prefixes": [
-                "src/research/macd_histogram_countertrend_mr_eligibility_hypothesis_preregistration_v1.py",
-                "tests/research/test_macd_histogram_countertrend_mr_eligibility_hypothesis_preregistration_v1.py",
-                "config/research/macd_histogram_countertrend_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "docs/evidence/preregister_macd_histogram_countertrend_mr_eligibility_hypothesis_v1/",
-                "docs/governance/MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-            ],
-        },
-        "MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_HYPOTHESIS_BACKLOG_V1": {
-            "note": "Closed lane SSOT for material-different cross-sectional momentum program after CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1 FAIL_CLOSED_NO_RETRY; inventories empty of open/preregistered candidates; terminal hypothesis recorded; no successor; retry/reopen forbidden; evaluation/holdout/promotion/runtime closed; sibling Entry/Exit lanes remain LANE_CLOSED_NO_FURTHER_RESEARCH unreopened.",
-            "path_prefixes": [
-                "config/research/material_different_cross_sectional_momentum_hypothesis_backlog_v1.json",
-                "src/research/material_different_cross_sectional_momentum_hypothesis_backlog_v1.py",
-                "tests/research/test_material_different_cross_sectional_momentum_hypothesis_backlog_v1.py",
-                "docs/governance/MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_HYPOTHESIS_BACKLOG_V1.md",
-            ],
-        },
-        "MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_PROGRAM_V1": {
-            "note": "Closed research-program SSOT after CS-RS-Momentum v1 FAIL_CLOSED_NO_RETRY; run budget consumed (1/1); no successor; no retry/reopen; no holdout/runtime/orders; causal independence from closed Bollinger Entry/Exit lanes retained; new research requires separate operator authorization and preregistration.",
-            "path_prefixes": [
-                "config/research/material_different_cross_sectional_momentum_program_v1.json",
-                "src/research/material_different_cross_sectional_momentum_program_v1.py",
-                "tests/research/test_material_different_cross_sectional_momentum_program_v1.py",
-                "docs/governance/MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_PROGRAM_V1.md",
-            ],
-        },
-        "MA_TREND_ALIGNMENT_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-            "note": "Single preregistered DEVELOPMENT-only offline evaluation of SMA(50) side-aware with-trend admission pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=FAIL, NET_PROFIT_FACTOR_NOT_IMPROVED); research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-            "path_prefixes": [
-                "src/research/ma_trend_alignment_mr_eligibility_development_evaluation_v1/",
-                "scripts/research/run_evaluate_ma_trend_alignment_mr_eligibility_development_v1.py",
-                "tests/research/test_ma_trend_alignment_mr_eligibility_development_evaluation_v1.py",
-                "docs/evidence/evaluate_ma_trend_alignment_mr_eligibility_development_v1/",
-                "docs/governance/MA_TREND_ALIGNMENT_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
-            ],
-        },
-        "MA_TREND_ALIGNMENT_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of a single SMA(50) side-aware with-trend admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to four prior FAILs (regime, ATR, RSI, ADX); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-            "path_prefixes": [
-                "src/research/ma_trend_alignment_mr_eligibility_hypothesis_preregistration_v1.py",
-                "tests/research/test_ma_trend_alignment_mr_eligibility_hypothesis_preregistration_v1.py",
-                "config/research/ma_trend_alignment_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "docs/evidence/preregister_ma_trend_alignment_mr_eligibility_hypothesis_v1/",
-                "docs/governance/MA_TREND_ALIGNMENT_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-            ],
-        },
-        "OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_WITHOUT_TRADING_SEMANTIC_EFFECT": {
-            "note": "Offline economic evaluation execution infrastructure, preexecution guards, invocation-bound authorization repair, and contract tests without trading semantic mutation or runtime authority.",
-            "path_globs": [
-                "src/research/*offline_economic_evaluation_execution_v0.py",
-                "src/research/cross_sectional_cost_execution_binding_normalization_v0.py",
-                "src/research/*offline_economic_evaluation_scope_ratification_v0.py",
-                "tests/research/test_*offline_economic_evaluation_execution_infrastructure_v0.py",
-                "tests/research/test_*offline_economic_evaluation_execution_dispatch_implementation_v0.py",
-                "tests/research/test_*offline_economic_evaluation_execution_implementation_repair_v0.py",
-                "tests/research/test_*offline_economic_evaluation_dispatch_to_baseline_repair_v0.py",
-                "tests/research/test_*offline_economic_evaluation_reevaluation_execution_implementation_v0.py",
-                "tests/research/test_*offline_economic_evaluation_reevaluation_execution_ops_runner_branch_v0.py",
-                "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_ops_runner_branch_v0.py",
-                "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py",
-                "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_actual_execution_owner_implementation_v0.py",
-                "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_dataset_digest_reconciliation_repair_v0.py",
-                "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_data_unavailable_repair_v0.py",
-                "tests/research/test_*offline_economic_evaluation_baseline_execution_implementation_v0.py",
-                "tests/research/test_*baseline_execution_entry_point_result_contract_repair_v0.py",
-                "tests/research/test_trend_following_v2_baseline_owner_single_member_end_to_end_repair_v0.py",
-                "tests/research/test_trend_following_v2_mandatory_boundary_state_file_binding_rewire_v0.py",
-                "tests/research/test_trend_following_v2_canonical_wiring_map_contract_v0.py",
-                "tests/research/test_*offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",
-                "src/backtest/economic_viability_evidence_v1.py",
-                "config/ops/trend_following_v2_economic_evaluation_v1.json",
-                "src/research/panel_sequential_signal_density_research_adapter_v0.py",
-                "src/research/versioned_final_fleet_bindings_offline_economic_evaluation_v0.py",
-                "src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py",
-                "scripts/ops/run_*offline_economic_evaluation_execution_v0.py",
-                "scripts/ops/materialize_*offline_economic_evaluation_baseline_execution_implementation_v0.py",
-                "scripts/ops/materialize_*offline_economic_evaluation_execution_*_implementation_v0.py",
-                "tests/research/test_*offline_economic_evaluation_execution_authorization_ratification_repair_v0.py",
-                "tests/research/test_*execution_v1_token_binding_repair_v0.py",
-                "tests/research/test_*offline_economic_evaluation_full_runner_v0.py",
-                "src/research/*offline_economic_evaluation_execution_authorization_supersession_v*.py",
-                "scripts/research/materialize_*offline_economic_evaluation_execution_authorization_supersession_v*.py",
-                "config/research/*offline_economic_evaluation_execution_authorization_supersession_v*.json",
-                "config/research/full_canonical_system_economic_evidence_generation_v1_offline_execution_result_v0.json",
-                "tests/research/test_full_canonical_system_economic_evidence_generation_v1_offline_execution_result_v0_contract.py",
-            ],
-        },
-        "OFFLINE_MV2_ZERO_TRADE_PER_BAR_DECISION_OUTCOME_DIAGNOSTIC_WITHOUT_TRADING_SEMANTIC_EFFECT": {
-            "note": "Offline-only per-bar MV2 decision-outcome diagnostic for zero-trade root-cause observability; observational hook only; no trading/runtime/authority/sizing semantic mutation.",
-            "path_prefixes": [
-                "src/research/mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
-                "scripts/research/run_mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
-                "tests/research/test_mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
-                "config/research/mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.json",
-            ],
-        },
-        "POINT_IN_TIME_DATA_QUALITY_REPAIR": {
-            "path_prefixes": [
-                "src/backtest/admissible_versioned_futures_dataset_v1.py",
-                "src/research/admissible_",
-            ]
-        },
-        "PORTFOLIO_RESEARCH_AND_ECONOMIC_ATTRIBUTION_WITHOUT_RUNTIME_AUTHORITY": {
-            "path_prefixes": [
-                "src/experiments/evidence_chain.py",
-                "src/experiments/strategy_profiles.py",
-                "src/research/offline_economic_viability_evidence_gap_assessment_v0.py",
-            ]
-        },
-        "REAL_FILL_BINDING": {
-            "note": "Real fill binding repair only; no trading semantic mutation.",
-            "path_prefixes": ["src/backtest/engine.py"],
-        },
-        "REGIME_GATED_STANDASIDE_MR_DEVELOPMENT_EVALUATION_V1": {
-            "note": "Single preregistered DEVELOPMENT-only offline evaluation of regime-gated standaside MR versus immutable bollinger baseline; research-only entry-eligibility gate; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-            "path_prefixes": [
-                "src/research/regime_gated_standaside_mr_development_evaluation_v1/",
-                "scripts/research/run_evaluate_regime_gated_standaside_mr_development_v1.py",
-                "tests/research/test_regime_gated_standaside_mr_development_evaluation_v1.py",
-                "docs/evidence/evaluate_regime_gated_standaside_mr_development_v1/",
-                "docs/governance/REGIME_GATED_STANDASIDE_MR_DEVELOPMENT_EVALUATION_V1.md",
-            ],
-        },
-        "REGIME_GATED_STANDASIDE_MR_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of a single regime-gated stand-aside mean-reversion measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-            "path_prefixes": [
-                "src/research/regime_gated_standaside_mr_hypothesis_preregistration_v1.py",
-                "tests/research/test_regime_gated_standaside_mr_hypothesis_preregistration_v1.py",
-                "config/research/regime_gated_standaside_mr_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "docs/evidence/preregister_regime_gated_standaside_mr_hypothesis_v1/",
-                "docs/governance/REGIME_GATED_STANDASIDE_MR_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-            ],
-        },
-        "REPORTING_AND_EVIDENCE_REPAIR": {
-            "path_globs": ["scripts/ops/*evidence*", "scripts/ops/*manifest*"],
-            "path_prefixes": [
-                "scripts/ops/primary_evidence_retention_v0.py",
-                "scripts/ops/verify_pre_pr_validation_result_v0.py",
-                "scripts/ops/materialize_offline_productive_signal_orthogonality_results_interpretation_v0.py",
-                "scripts/ops/materialize_offline_productive_factor_exposure_diagnostics_v0.py",
-                "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-                "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
-                "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
-                "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-                "scripts/ops/materialize_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-                "scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py",
-                "scripts/research/materialize_bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
-                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
-                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
-                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-                "tests/research/test_step29l2_import_boundary_classification_v0.py",
-            ],
-        },
-        "RSI_EXHAUSTION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-            "note": "Single preregistered DEVELOPMENT-only offline evaluation of RSI(14)-exhaustion pre-entry MR eligibility filter versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-            "path_prefixes": [
-                "src/research/rsi_exhaustion_mr_eligibility_development_evaluation_v1/",
-                "scripts/research/run_evaluate_rsi_exhaustion_mr_eligibility_development_v1.py",
-                "tests/research/test_rsi_exhaustion_mr_eligibility_development_evaluation_v1.py",
-                "docs/evidence/evaluate_rsi_exhaustion_mr_eligibility_development_v1/",
-                "docs/governance/RSI_EXHAUSTION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
-            ],
-        },
-        "RSI_EXHAUSTION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of a single RSI(14)-exhaustion pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to the failed ATR-percentile mid-band and failed regime-gated absolute-threshold mechanisms; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-            "path_prefixes": [
-                "src/research/rsi_exhaustion_mr_eligibility_hypothesis_preregistration_v1.py",
-                "tests/research/test_rsi_exhaustion_mr_eligibility_hypothesis_preregistration_v1.py",
-                "config/research/rsi_exhaustion_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "docs/evidence/preregister_rsi_exhaustion_mr_eligibility_hypothesis_v1/",
-                "docs/governance/RSI_EXHAUSTION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-            ],
-        },
-        "SIMULATED_FILL_BINDING_USING_EXISTING_CANONICAL_EXECUTION_OWNER": {
-            "note": "Simulated fill binding must reuse existing canonical execution owners; no new runtime authority.",
-            "path_globs": [
-                "tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py",
-                "tests/research/test_cross_sectional_lead_lag_v0_backtest_engine_mv2_replay_signal_parity_v0.py",
-                "tests/research/test_cross_sectional_lead_lag_v0_research_eval_decision_parity_contract_suite_v0.py",
-            ],
-            "path_prefixes": [
-                "src/backtest/mv2_research_wiring_v1.py",
-                "src/backtest/strategy_signal_binding_v1.py",
-            ],
-        },
-        "SLIPPAGE_MODEL_DIAGNOSTICS": {
-            "path_prefixes": ["src/research/linear_evidence/cost_model.py"]
-        },
-        "TARGET_BINDING_REPAIR": {
-            "path_globs": [
-                "tests/research/test_offline_linear_cost_diagnostic_row_materializer_*",
-                "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
-                "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
-                "tests/research/test_offline_final_research_fleet_signal_matrix_productive_input_join_materializer_*",
-                "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
-                "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_*",
-                "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*",
-            ],
-            "path_prefixes": [
-                "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
-                "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
-                "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
-                "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
-                "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
-                "src/research/linear_evidence/feature_matrix.py",
-                "src/research/linear_evidence/sensitivity.py",
-                "src/research/linear_evidence/drift.py",
-                "src/research/linear_evidence/window_robustness.py",
-                "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
-                "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
-                "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
-                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
-                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
-                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
-            ],
-        },
-        "TIME_ORDERED_VALIDATION": {
-            "path_prefixes": ["src/backtest/walkforward.py", "tests/backtest/test_walkforward*"]
-        },
-        "VOLATILITY_COMPRESSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-            "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_COMPRESSION_BREAKOUT_V1: executable evaluate path with panel execution boundary and productive exit/PnL evaluator bound to canonical BacktestEngine fee/slippage/gross-PnL primitives; authorized on HEAD; no evaluation execution/run-slot consumption without separate GO; no holdout/runtime/orders; measurement thresholds and strategy/baseline parameters unchanged.",
-            "path_prefixes": [
-                "config/research/volatility_compression_breakout_v1_development_evaluation_entry_point_binding_v1.json",
-                "docs/evidence/evaluate_volatility_compression_breakout_development_v1/",
-                "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-                "scripts/research/run_evaluate_volatility_compression_breakout_development_v1.py",
-                "src/research/volatility_compression_breakout_v1_development_evaluation_v1/",
-                "tests/research/test_volatility_compression_breakout_v1_development_evaluation_entry_point_v1.py",
-                "tests/research/test_volatility_compression_breakout_v1_development_evaluation_executable_path_v1.py",
-                "tests/research/test_volatility_compression_breakout_v1_development_evaluation_fail_closed_report_v1.py",
-                "tests/research/test_volatility_compression_breakout_v1_productive_exit_pnl_evaluator_v1.py",
-            ],
-        },
-        "VOLATILITY_COMPRESSION_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of own-instrument volatility compression→expansion→channel-breakout v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; frozen ATR(20)/close percentile-rank admission, unconditional channel-breakout baseline, event-sufficiency gates; material difference vs terminal VOL_BREAKOUT_COILED_SPRING explicit; development evaluation authorized; evaluation not executed; no holdout/runtime/orders.",
-            "path_prefixes": [
-                "config/research/volatility_compression_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "src/research/volatility_compression_breakout_v1_hypothesis_preregistration_v1.py",
-                "tests/research/test_volatility_compression_breakout_v1_hypothesis_preregistration_v1.py",
-                "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-                "docs/evidence/preregister_volatility_compression_breakout_hypothesis_v1/",
-            ],
-        },
-        "VOLATILITY_COMPRESSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-            "note": "Strategy-implementation-only surfaces for VOLATILITY_COMPRESSION_BREAKOUT_V1 (shared 20-bar price-channel core + ATR20/close percentile vol-state + compression/release admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; no Master-V2/Double-Play/risk/execution mutation.",
-            "path_prefixes": [
-                "src/research/price_channel_breakout_core_v1.py",
-                "src/research/volatility_compression_breakout_v1_vol_state_v1.py",
-                "src/research/volatility_compression_breakout_v1_strategy_v1.py",
-                "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
-                "src/research/volatility_compression_breakout_v1_strategy_implementation_binding_v1.py",
-                "config/research/volatility_compression_breakout_v1_strategy_implementation_binding_v1.json",
-                "tests/research/test_volatility_compression_breakout_v1_strategy_implementation_v1.py",
-                "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
-            ],
-        },
-        "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-            "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1: development evaluation slot consumed FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; productive exit/PnL evaluator reused from VCB package (not duplicated). No retry; no holdout/runtime/orders; strategy/baseline parameters unchanged; VDBX/VDB/VEP/VCB artifacts unchanged.",
-            "path_prefixes": [
-                "config/research/volatility_contraction_expansion_breakout_v1_development_evaluation_entry_point_binding_v1.json",
-                "docs/evidence/evaluate_volatility_contraction_expansion_breakout_development_v1/",
-                "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-                "scripts/research/run_evaluate_volatility_contraction_expansion_breakout_development_v1.py",
-                "src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/",
-                "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_entry_point_v1.py",
-                "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_executable_path_v1.py",
-                "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_fail_closed_report_v1.py",
-            ],
-        },
-        "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1 after terminal VDBX FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; frozen realized-vol contraction->expansion joint breakout admission + pairable exit precedence; productive PnL evaluator referenced only; no Development evaluation/holdout/runtime/orders; VDBX/VDB/VEP/VCB retry forbidden.",
-            "path_prefixes": [
-                "config/research/volatility_contraction_expansion_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "src/research/volatility_contraction_expansion_breakout_v1_hypothesis_preregistration_v1.py",
-                "tests/research/test_volatility_contraction_expansion_breakout_v1_hypothesis_preregistration_v1.py",
-                "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-                "docs/evidence/preregister_volatility_contraction_expansion_breakout_hypothesis_v1/",
-            ],
-        },
-        "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-            "note": "Strategy + exit state machine for VCEB v1 (RV24 contraction->expansion joint break + opposite-break exits without trailing); productive PnL evaluator referenced not duplicated; measurement digest frozen; no evaluation/holdout/runtime/orders; VDBX/VDB/VEP/VCB retry forbidden.",
-            "path_prefixes": [
-                "src/research/price_channel_breakout_core_v1.py",
-                "src/research/volatility_contraction_expansion_breakout_v1_vol_state_v1.py",
-                "src/research/volatility_contraction_expansion_breakout_v1_exit_state_machine_v1.py",
-                "src/research/volatility_contraction_expansion_breakout_v1_strategy_v1.py",
-                "src/research/volatility_contraction_expansion_breakout_v1_strategy_implementation_binding_v1.py",
-                "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
-                "config/research/volatility_contraction_expansion_breakout_v1_strategy_implementation_binding_v1.json",
-                "tests/research/test_volatility_contraction_expansion_breakout_v1_strategy_and_exit_state_machine_v1.py",
-                "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
-            ],
-        },
-        "VOLATILITY_DECAY_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-            "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_DECAY_BREAKOUT_V1: panel execution boundary materialized; productive exit/PnL evaluator reused from VCB. Single bounded development attempt fail-closed at PRODUCTIVE_PNL_OVERFLOW with durable run slot consumed (1/1); archival panel-boundary fail_closed_report retained; bounded corrective measurement reevaluation executed once and fail-closed at UNPAIRABLE_ENTRY_NO_EXIT (corrective slot 1/1; development counters preserved at 1; prior development evidence unmodified; supersession audited in corrective bundle); no holdout/runtime/orders; no development or corrective retry; VCB/VEP slots not reused.",
-            "path_prefixes": [
-                "config/research/volatility_decay_breakout_v1_development_evaluation_entry_point_binding_v1.json",
-                "docs/evidence/evaluate_volatility_decay_breakout_corrective_measurement_reevaluation_v1/",
-                "docs/evidence/evaluate_volatility_decay_breakout_development_v1/",
-                "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-                "scripts/research/run_evaluate_volatility_decay_breakout_development_v1.py",
-                "src/research/volatility_decay_breakout_v1_development_evaluation_v1/",
-                "tests/research/test_volatility_decay_breakout_v1_corrective_measurement_reevaluation_v1.py",
-                "tests/research/test_volatility_decay_breakout_v1_development_evaluation_entry_point_v1.py",
-                "tests/research/test_volatility_decay_breakout_v1_development_evaluation_fail_closed_report_v1.py",
-                "tests/research/test_volatility_decay_breakout_v1_development_evaluation_executable_path_v1.py",
-            ],
-        },
-        "VOLATILITY_DECAY_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of own-instrument volatility decay-breakout v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures after terminal VEP-V1 UNPAIRABLE_ENTRY_NO_EXIT; frozen ATR(14)/close high→low decay admission + channel-breakout baseline; material difference vs VEP/VCB/coiled-spring explicit; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced only; VEP retry/exit-repair forbidden.",
-            "path_prefixes": [
-                "config/research/volatility_decay_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "src/research/volatility_decay_breakout_v1_hypothesis_preregistration_v1.py",
-                "tests/research/test_volatility_decay_breakout_v1_hypothesis_preregistration_v1.py",
-                "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-                "docs/evidence/preregister_volatility_decay_breakout_hypothesis_v1/",
-                "docs/evidence/forensic_classify_vep_v1_unpairable_entry_no_exit_v1/",
-            ],
-        },
-        "VOLATILITY_DECAY_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-            "note": "Strategy-implementation-only surfaces for VOLATILITY_DECAY_BREAKOUT_V1 (shared 20-bar price-channel core + ATR14/close percentile vol-state + high→low decay admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced not duplicated; no Master-V2/Double-Play/risk/execution mutation; VEP/VCB retry forbidden.",
-            "path_prefixes": [
-                "src/research/price_channel_breakout_core_v1.py",
-                "src/research/volatility_decay_breakout_v1_vol_state_v1.py",
-                "src/research/volatility_decay_breakout_v1_strategy_v1.py",
-                "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
-                "src/research/volatility_decay_breakout_v1_strategy_implementation_binding_v1.py",
-                "config/research/volatility_decay_breakout_v1_strategy_implementation_binding_v1.json",
-                "tests/research/test_volatility_decay_breakout_v1_strategy_implementation_v1.py",
-                "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
-            ],
-        },
-        "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-            "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1: executable evaluate path with strategy-emitted exits + productive exit/PnL evaluator reuse from VCB package (not duplicated). Development evaluation authorized; run counters remain 0 until the single bounded productive evaluation executes; no holdout/runtime/orders; hypothesis parameters unchanged.",
-            "path_prefixes": [
-                "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_entry_point_binding_v1.json",
-                "docs/evidence/evaluate_volatility_decay_breakout_with_explicit_decay_exit_development_v1/",
-                "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-                "scripts/research/run_evaluate_volatility_decay_breakout_with_explicit_decay_exit_development_v1.py",
-                "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_v1/",
-                "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_entry_point_v1.py",
-                "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_executable_path_v1.py",
-                "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_fail_closed_report_v1.py",
-            ],
-        },
-        "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of VDBX explicit-decay-exit successor after terminal VDB UNPAIRABLE_ENTRY_NO_EXIT; frozen decay entry + explicit exit state machine; productive PnL evaluator referenced only; no Development evaluation/holdout/runtime/orders; VDB/VEP/VCB retry forbidden.",
-            "path_prefixes": [
-                "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_hypothesis_preregistration_v1.py",
-                "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_hypothesis_preregistration_v1.py",
-                "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-                "docs/evidence/preregister_volatility_decay_breakout_with_explicit_decay_exit_hypothesis_v1/",
-            ],
-        },
-        "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-            "note": "Strategy + explicit exit state machine for VDBX v1; reuses VDB vol-state/channel core; productive PnL evaluator referenced not duplicated; no evaluation/holdout/runtime/orders; no predecessor artifact mutation.",
-            "path_prefixes": [
-                "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_exit_state_machine_v1.py",
-                "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_v1.py",
-                "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_implementation_binding_v1.py",
-                "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_implementation_binding_v1.json",
-                "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_and_exit_state_machine_v1.py",
-                "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
-            ],
-        },
-        "VOLATILITY_EXPANSION_PERSISTENCE_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-            "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_EXPANSION_PERSISTENCE_V1: executable evaluate path with materialized panel execution boundary (loader/wiring/injectable boundary); productive exit/PnL evaluator referenced from VCB package (not duplicated). Development evaluation authorized on HEAD; run counters remain 0 until a separate operator GO executes the single bounded development evaluation; no holdout/runtime/orders; measurement thresholds and strategy/baseline parameters unchanged.",
-            "path_prefixes": [
-                "config/research/volatility_expansion_persistence_v1_development_evaluation_entry_point_binding_v1.json",
-                "docs/evidence/evaluate_volatility_expansion_persistence_development_v1/",
-                "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-                "scripts/research/run_evaluate_volatility_expansion_persistence_development_v1.py",
-                "src/research/volatility_expansion_persistence_v1_development_evaluation_v1/",
-                "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_entry_point_v1.py",
-                "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_executable_path_v1.py",
-                "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_fail_closed_report_v1.py",
-            ],
-        },
-        "VOLATILITY_EXPANSION_PERSISTENCE_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of own-instrument volatility expansion-persistence v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; frozen ATR(14)/close percentile-rank expansion confirmation + persistence window admission, unconditional channel-breakout baseline, event-sufficiency gates; material difference vs terminal VCB-V1 and coiled-spring explicit; development evaluation authorized; evaluation not executed; no holdout/runtime/orders; productive PnL evaluator referenced only.",
-            "path_prefixes": [
-                "config/research/volatility_expansion_persistence_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "src/research/volatility_expansion_persistence_v1_hypothesis_preregistration_v1.py",
-                "tests/research/test_volatility_expansion_persistence_v1_hypothesis_preregistration_v1.py",
-                "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-                "docs/evidence/preregister_volatility_expansion_persistence_hypothesis_v1/",
-            ],
-        },
-        "VOLATILITY_EXPANSION_PERSISTENCE_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-            "note": "Strategy-implementation-only surfaces for VOLATILITY_EXPANSION_PERSISTENCE_V1 (shared 20-bar price-channel core + ATR14/close percentile vol-state + expansion confirmation/persistence admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced not duplicated; no Master-V2/Double-Play/risk/execution mutation.",
-            "path_prefixes": [
-                "src/research/price_channel_breakout_core_v1.py",
-                "src/research/volatility_expansion_persistence_v1_vol_state_v1.py",
-                "src/research/volatility_expansion_persistence_v1_strategy_v1.py",
-                "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
-                "src/research/volatility_expansion_persistence_v1_strategy_implementation_binding_v1.py",
-                "config/research/volatility_expansion_persistence_v1_strategy_implementation_binding_v1.json",
-                "tests/research/test_volatility_expansion_persistence_v1_strategy_implementation_v1.py",
-                "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
-            ],
-        },
-        "VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-            "note": "Definition-only preregistration of VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1 after terminal VCEB FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; expansion then limited pullback continuation + explicit invalidation/time/protective exits; productive PnL evaluator referenced only; measurement contract remains frozen; VCEB/VDBX/VDB/VEP/VCB retry forbidden.",
-            "path_prefixes": [
-                "config/research/volatility_expansion_pullback_continuation_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-                "src/research/volatility_expansion_pullback_continuation_v1_hypothesis_preregistration_v1.py",
-                "tests/research/test_volatility_expansion_pullback_continuation_v1_hypothesis_preregistration_v1.py",
-                "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-                "docs/evidence/preregister_volatility_expansion_pullback_continuation_hypothesis_v1/",
-            ],
-        },
-        "VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-            "note": "Strategy implementation + productive development entry path for VEPC v1; exit SM with pullback-structure invalidation; productive PnL evaluator reused; forensic run-state accounting for technical fail-closed after runner start; no holdout/runtime/orders; no PnL pairing semantics change in accounting fix.",
-            "path_prefixes": [
-                "src/research/volatility_expansion_pullback_continuation_v1_strategy_v1.py",
-                "src/research/volatility_expansion_pullback_continuation_v1_exit_state_machine_v1.py",
-                "src/research/volatility_expansion_pullback_continuation_v1_vol_state_v1.py",
-                "src/research/volatility_expansion_pullback_continuation_v1_strategy_implementation_binding_v1.py",
-                "config/research/volatility_expansion_pullback_continuation_v1_strategy_implementation_binding_v1.json",
-                "src/research/volatility_expansion_pullback_continuation_v1_development_evaluation_v1/",
-                "config/research/volatility_expansion_pullback_continuation_v1_development_evaluation_entry_point_binding_v1.json",
-                "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
-                "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-                "scripts/research/run_evaluate_volatility_expansion_pullback_continuation_development_v1.py",
-                "tests/research/test_volatility_expansion_pullback_continuation_v1_strategy_implementation_v1.py",
-                "tests/research/test_volatility_expansion_pullback_continuation_v1_development_evaluation_entry_point_v1.py",
-                "tests/research/test_volatility_expansion_pullback_continuation_v1_forensic_unpairable_run_state_v1.py",
-            ],
-        },
-        "VOLATILITY_REGIME_HYPOTHESIS_BACKLOG_V1": {
-            "note": "Open backlog SSOT for volatility-regime research program with exactly one definition-only preregistration (VEP-V1) and terminal VCB-V1 FAIL_CLOSED_NO_RETRY; evaluation/holdout/promotion/runtime closed; sibling Entry/Exit and closed CS momentum lanes remain unreopened. Active open preregistration is VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1; VDB terminal.",
-            "path_prefixes": [
-                "config/research/volatility_regime_hypothesis_backlog_v1.json",
-                "src/research/volatility_regime_hypothesis_backlog_v1.py",
-                "tests/research/test_volatility_regime_hypothesis_backlog_v1.py",
-                "docs/governance/VOLATILITY_REGIME_HYPOTHESIS_BACKLOG_V1.md",
-            ],
-        },
-        "VOLATILITY_REGIME_RESEARCH_PROGRAM_V1": {
-            "note": "Definition-only research-program SSOT for operator-authorized volatility-regime expansion-persistence hypothesis VEP-V1; causal independence from closed Bollinger Entry/Exit and CS momentum lanes; material difference vs terminal coiled-spring and terminal VCB-V1; development evaluation authorized (not executed); no holdout/runtime/orders. Active open preregistration is VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1; VDB terminal.",
-            "path_prefixes": [
-                "config/research/volatility_regime_research_program_v1.json",
-                "src/research/volatility_regime_research_program_v1.py",
-                "tests/research/test_volatility_regime_research_program_v1.py",
-                "docs/governance/VOLATILITY_REGIME_RESEARCH_PROGRAM_V1.md",
-            ],
-        },
-        "WALK_FORWARD_MONTE_CARLO_STRESS_AND_PARAMETER_SENSITIVITY": {
-            "path_globs": [
-                "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
-                "tests/research/test_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-                "tests/research/test_offline_productive_rolling_linear_drift_diagnostics_v0.py",
-                "tests/research/test_offline_parameter_sensitivity_model_spec_alignment_*",
-                "tests/research/test_offline_rolling_linear_drift_diagnostics_v0.py",
-                "tests/research/test_offline_outlier_and_window_robustness_diagnostic_v0.py",
-            ],
-            "path_prefixes": [
-                "src/experiments/monte_carlo.py",
-                "src/experiments/stress_tests.py",
-                "src/experiments/portfolio_robustness.py",
-                "scripts/research/offline_parameter_sensitivity_surface_v0.py",
-                "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-                "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
-                "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
-                "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
-                "scripts/research/offline_rolling_linear_drift_diagnostics_v0.py",
-                "scripts/research/offline_outlier_and_window_robustness_diagnostic_v0.py",
-            ],
-        },
+  "allowed_optimization_surfaces": {
+    "ADVERSE_EXIT_DOWNSCOPE_DUAL_DIMENSION_RESEARCH_FIXTURE_ALIGN": {
+      "path_globs": [
+        "tests/research/test_adverse_exit_and_reversal_preparation_backtest_parity_narrow_rewire_v0.py",
+        "tests/research/test_adverse_exit_and_reversal_preparation_backtest_parity_wiring_assessment_or_narrow_rewire_v0.py",
+        "tests/research/test_adverse_scope_exit_reversal_preparation_narrow_reuse_first_rewire_v0.py",
+        "tests/research/test_scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py",
+        "tests/research/test_scope_adverse_exit_reversal_backtest_runtime_decision_parity_pass_assertion_surface_only_v0.py"
+      ],
+      "path_prefixes": [
+        "scripts/research/adverse_exit_and_reversal_preparation_backtest_parity_narrow_rewire_v0.py",
+        "scripts/research/adverse_scope_exit_reversal_preparation_narrow_reuse_first_rewire_v0.py",
+        "scripts/research/scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py"
+      ]
     },
-    "forbidden_mutation_surfaces": {
-        "BULL_BEAR_ASSESSMENT": {
-            "description": "Canonical Bull/Bear assessment and state-switch owners",
-            "path_globs": [
-                "tests/trading/master_v2/test_bull_bear_*",
-                "tests/research/test_bull_bear_*",
-                "docs/research/bull_bear_*",
-            ],
-            "path_prefixes": [
-                "src/trading/master_v2/directional_assessment_v1.py",
-                "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
-                "src/research/owner_bindings/bull_bear_state_switch_owner_binding_v0.py",
-            ],
-        },
-        "CAPITAL_RISK_SIZING": {
-            "description": "Capital, risk and position-sizing owners",
-            "path_globs": [
-                "tests/governance/test_capital_risk_sizing_*",
-                "tests/trading/master_v2/test_capital_risk_sizing_*",
-                "tests/trading/master_v2/test_*capital_slot*",
-                "tests/ops/test_master_v2_capital_slot_owner_boundary_*",
-            ],
-            "path_prefixes": [
-                "src/governance/capital_risk_sizing_v1.py",
-                "src/trading/master_v2/double_play_capital_slot.py",
-                "src/trading/master_v2/capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0.py",
-                "src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py",
-                "config/research/mv2_backtest_mandatory_boundary_state_files_v0/capital_risk_sizing.json",
-            ],
-        },
-        "DOUBLE_PLAY_COMPOSITION": {
-            "description": "Double-Play composition and state owners",
-            "path_globs": [
-                "tests/trading/master_v2/test_double_play_*",
-                "docs/ops/specs/MASTER_V2_DOUBLE_PLAY_*",
-                "docs/ops/specs/FUTURES_DOUBLE_PLAY_*",
-            ],
-            "path_prefixes": [
-                "src/trading/master_v2/double_play_composition.py",
-                "src/trading/master_v2/double_play_composition_matrix_v1.py",
-                "src/trading/master_v2/double_play_composition_scenario_matrix_adapter_v0.py",
-                "src/trading/master_v2/double_play_state.py",
-                "src/trading/master_v2/double_play_dashboard_display.py",
-                "src/trading/master_v2/double_play_futures_input_producer.py",
-                "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
-                "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py",
-            ],
-        },
-        "ENTRY_POSITION_EXIT_REVERSAL_POLICY": {
-            "description": "Entry, position-management, exit and reversal policy owners",
-            "path_globs": [
-                "tests/trading/master_v2/test_*entry_exit*",
-                "tests/trading/master_v2/test_*survival*",
-                "tests/trading/master_v2/test_*suitability*",
-            ],
-            "path_prefixes": [
-                "src/trading/master_v2/double_play_entry_exit_policy_v0.py",
-                "src/trading/master_v2/double_play_entry_exit_scenario_binding_adapter_v0.py",
-                "src/trading/master_v2/double_play_survival.py",
-                "src/trading/master_v2/double_play_suitability.py",
-                "src/trading/master_v2/survival_assessment_v1.py",
-                "src/trading/master_v2/suitability_binding_v1.py",
-            ],
-        },
-        "KILLSWITCH": {
-            "description": "KillSwitch semantics and binding owners",
-            "path_globs": [
-                "tests/trading/master_v2/test_killswitch_*",
-                "tests/test_backtest_killswitch_*",
-            ],
-            "path_prefixes": [
-                "src/trading/master_v2/killswitch_boundary_backtest_state_file_binding_adapter_v0.py",
-                "src/trading/master_v2/killswitch_boundary_offline_replay_binding_adapter_v0.py",
-                "config/research/mv2_backtest_mandatory_boundary_state_files_v0/killswitch.json",
-                "docs/risk/KILL_SWITCH_RUNBOOK.md",
-            ],
-        },
-        "MASTER_V2": {
-            "description": "All canonical Master V2 trading logic owners",
-            "path_globs": ["tests/trading/master_v2/test_*"],
-            "path_prefixes": ["src/trading/master_v2/"],
-        },
-        "PROMOTION_RUNTIME_ORDER_CREDENTIAL_SCHEDULER_AUTHORITY": {
-            "description": "Promotion, runtime, order, credential, scheduler and authority semantics",
-            "path_globs": [
-                "tests/governance/promotion_loop/*",
-                "tests/trading/master_v2/test_promotion_gate_*",
-                "tests/trading/master_v2/test_runtime_bridge_*",
-                "tests/ops/test_master_v2_runtime_governance_boundary_*",
-                "scripts/run_scheduler.py",
-            ],
-            "path_prefixes": [
-                "src/governance/promotion_loop/",
-                "src/trading/master_v2/promotion_gate_boundary_backtest_state_file_binding_adapter_v0.py",
-                "src/trading/master_v2/promotion_gate_boundary_offline_replay_binding_adapter_v0.py",
-                "src/trading/master_v2/runtime_bridge_pre_activation_gate_v0.py",
-                "src/trading/master_v2/runtime_bridge_pre_activation_gate_assessment_v0.py",
-                "src/trading/master_v2/staged_execution_enablement_v1.py",
-                "src/trading/master_v2/canonical_core_runtime_integration_bridge_v0.py",
-                "src/trading/master_v2/canonical_core_runtime_integration_intent_pipeline_bridge_v0.py",
-                "src/trading/master_v2/canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0.py",
-                "src/trading/master_v2/canonical_order_intent_offline_replay_binding_adapter_v0.py",
-                "src/governance/canonical_order_intent_v1.py",
-                "config/research/mv2_backtest_mandatory_boundary_state_files_v0/canonical_order_intent.json",
-            ],
-        },
-        "RECONCILIATION_UNKNOWN_OUTCOME": {
-            "description": "Reconciliation and unknown-outcome semantics",
-            "path_globs": [
-                "tests/trading/master_v2/test_reconciliation_*",
-                "tests/test_backtest_reconciliation_*",
-            ],
-            "path_prefixes": [
-                "src/trading/master_v2/reconciliation_boundary_backtest_state_file_binding_adapter_v0.py",
-                "src/trading/master_v2/reconciliation_unknown_outcome_offline_replay_binding_adapter_v0.py",
-                "config/research/mv2_backtest_mandatory_boundary_state_files_v0/reconciliation.json",
-            ],
-        },
-        "SAFETY_KERNEL": {
-            "description": "Safety kernel semantics and binding owners",
-            "path_globs": [
-                "tests/trading/master_v2/test_safety_kernel_*",
-                "tests/research/test_safety_kernel_*",
-                "scripts/run_independent_pre_trade_safety_kernel_v1.py",
-            ],
-            "path_prefixes": [
-                "src/trading/master_v2/safety_kernel_boundary_backtest_state_file_binding_adapter_v0.py",
-                "src/trading/master_v2/safety_kernel_offline_replay_binding_adapter_v0.py",
-                "src/meta/learning_loop/independent_pre_trade_safety_kernel_v1.py",
-                "config/research/mv2_backtest_mandatory_boundary_state_files_v0/safety_kernel.json",
-            ],
-        },
-        "SCOPE_INITIALIZATION_AND_EVENTS": {
-            "description": "Scope initialization, scope events, adverse-exit and reversal owners",
-            "path_globs": [
-                "tests/trading/master_v2/test_*scope*",
-                "tests/trading/master_v2/test_*reversal*",
-            ],
-            "path_prefixes": [
-                "src/trading/master_v2/canonical_scope_initialization_v1.py",
-                "src/trading/master_v2/deterministic_scope_event_generator_v1.py",
-                "src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py",
-                "src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py",
-                "src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py",
-            ],
-        },
+    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+      "note": "Single preregistered DEVELOPMENT-only offline evaluation of Wilder ADX(14) +DI/−DI direction-confirmation pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=PASS, ALL_PASS_REQUIRES_MET); research-only entry-eligibility gate; economic offline gate remains closed; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+      "path_prefixes": [
+        "src/research/adx_di_direction_confirmation_mr_eligibility_development_evaluation_v1/",
+        "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_development_v1.py",
+        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_development_evaluation_v1.py",
+        "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_development_v1/",
+        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
+      ]
     },
-    "no_path_guessing": true,
-    "resolution_method": "READ_ONLY_FROM_EXISTING_BOUNDARY_CONTRACTS_AND_PROGRESS_OWNERS",
-    "schema_version": "economic_diagnostic_optimization_boundary_canonical_owner_map_v0",
-    "source_owners": [
-        "tests/ops/test_master_v2_dynamic_scope_owner_boundary_contract_v0.py",
-        "tests/ops/test_master_v2_state_switch_owner_boundary_contract_v0.py",
-        "tests/ops/test_master_v2_capital_slot_owner_boundary_contract_v0.py",
-        "tests/ops/test_master_v2_runtime_governance_boundary_contract_static_v0.py",
-        "tests/governance/test_capital_risk_sizing_mathematics_consolidation_contract_v0.py",
-        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/MANIFEST.json",
-        "docs/governance/PEAK_TRADE_IMPLEMENTATION_CONTRACT.md",
-        "docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.10_IMPLEMENTATION_CONTRACT.md",
-        "config/governance/technical_canonical_wiring_authorization_v1.json",
-    ],
-    "technical_canonical_wiring_authorization": {
-        "authorized_scope_class": "TECHNICAL_CANONICAL_WIRING_ONLY",
-        "contract_path": "config/governance/technical_canonical_wiring_authorization_v1.json",
-        "note": "Narrow fail-closed override for versioned technical wiring paths only; does not waive MASTER_V2_MUTATION_ALLOWED=false.",
+    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_EVALUATION_V1": {
+      "note": "Single authorized HOLDOUT evaluation of Wilder ADX(14) +DI/-DI direction-confirmation MR eligibility versus immutable bollinger baseline on the sealed FINAL_AUDIT panel (holdout_run_count 1/1, RESULT_CLASS=ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN after MV2 replay signal-index mismatch); no retry/post-result tuning; economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+      "path_prefixes": [
+        "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v1/",
+        "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v1.py",
+        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v1.py",
+        "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v1/",
+        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md"
+      ]
     },
+    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_EVALUATION_V2": {
+      "note": "Single authorized HOLDOUT v2 evaluation of Wilder ADX(14) +DI/-DI direction-confirmation MR eligibility versus immutable bollinger baseline on the sealed FINAL_AUDIT panel (holdout_run_count 1/1, RESULT_CLASS=FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED); new evaluation ID not a V1 rerun; economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+      "path_prefixes": [
+        "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v2/",
+        "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v2.py",
+        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v2.py",
+        "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v2/",
+        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V2.md"
+      ]
+    },
+    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only holdout preregistration for ADX DI direction-confirmation MR eligibility after DEVELOPMENT PASS; freezes sealed FINAL_AUDIT holdout split digest from existing SSOT registry metadata, acceptance criteria, run-limit=1, and execution-GO gate; no holdout data access, no backtest, no economic metrics, no productive authority mutation.",
+      "path_prefixes": [
+        "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v1.py",
+        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v1.py",
+        "config/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistered_measurement_contract_v1.json",
+        "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_holdout_v1/",
+        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md"
+      ]
+    },
+    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V2": {
+      "note": "Holdout preregistration v2 for ADX DI direction-confirmation MR eligibility; evaluation executed and terminal as FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); V1 remains terminal ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN; no productive authority mutation.",
+      "path_prefixes": [
+        "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v2.py",
+        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v2.py",
+        "config/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistered_measurement_contract_v2.json",
+        "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_holdout_v2/",
+        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V2.md"
+      ]
+    },
+    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of a single Wilder ADX(14) +DI/−DI direction-confirmation pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to six prior FAILs (regime, ATR, RSI, ADX-level, MA, MACD); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+      "path_prefixes": [
+        "src/research/adx_di_direction_confirmation_mr_eligibility_hypothesis_preregistration_v1.py",
+        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_hypothesis_preregistration_v1.py",
+        "config/research/adx_di_direction_confirmation_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_hypothesis_v1/",
+        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
+      ]
+    },
+    "ADX_RANGE_ADMISSION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+      "note": "Single preregistered DEVELOPMENT-only offline evaluation of ADX(14) range-admission pre-entry MR eligibility filter versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+      "path_prefixes": [
+        "src/research/adx_range_admission_mr_eligibility_development_evaluation_v1/",
+        "scripts/research/run_evaluate_adx_range_admission_mr_eligibility_development_v1.py",
+        "tests/research/test_adx_range_admission_mr_eligibility_development_evaluation_v1.py",
+        "docs/evidence/evaluate_adx_range_admission_mr_eligibility_development_v1/",
+        "docs/governance/ADX_RANGE_ADMISSION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
+      ]
+    },
+    "ADX_RANGE_ADMISSION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of a single ADX(14) range-admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to failed regime-gated, ATR-percentile, and RSI-exhaustion mechanisms; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+      "path_prefixes": [
+        "src/research/adx_range_admission_mr_eligibility_hypothesis_preregistration_v1.py",
+        "tests/research/test_adx_range_admission_mr_eligibility_hypothesis_preregistration_v1.py",
+        "config/research/adx_range_admission_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "docs/evidence/preregister_adx_range_admission_mr_eligibility_hypothesis_v1/",
+        "docs/governance/ADX_RANGE_ADMISSION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
+      ]
+    },
+    "BOLLINGER_MR_ECONOMIC_FAILURE_DECOMPOSITION_DEVELOPMENT_V1": {
+      "note": "Canonical development-only read-only economic failure decomposition of the immutable Bollinger/MR baseline on the sealed DEVELOPMENT_ONLY panel; diagnostic classification only; no new hypothesis; no holdout access; no Economic/Promotion gate open; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders.",
+      "path_prefixes": [
+        "config/research/bollinger_mr_economic_failure_decomposition_development_v1.json",
+        "src/research/bollinger_mr_economic_failure_decomposition_development_v1/",
+        "scripts/research/run_bollinger_mr_economic_failure_decomposition_development_v1.py",
+        "tests/research/test_bollinger_mr_economic_failure_decomposition_development_v1.py",
+        "docs/governance/BOLLINGER_MR_ECONOMIC_FAILURE_DECOMPOSITION_DEVELOPMENT_V1.md",
+        "docs/evidence/bollinger_mr_economic_failure_decomposition_development_v1/"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V1": {
+      "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR side-aware middle-band exit-efficiency versus immutable bollinger baseline on sealed DEVELOPMENT panel (evaluation_run_count 0->1); Economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders. Gate-binding contract test covers MV2 wiring_mod capture-alias open_side binding only.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1/",
+        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v1.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v1.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_gate_binding_v1.py",
+        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v1/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V1.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V2": {
+      "note": "Terminal DEVELOPMENT_ONLY evaluation closeout for hypothesis ...DEVELOPMENT_V2 (evaluation_run_count 0->1 exactly once; RESULT_CLASS=INCONCLUSIVE_INFRASTRUCTURE_FAILURE; ROOT_CAUSE=PREMEASUREMENT_GATE_FALSE_POSITIVE_ZERO_OR_SENTINEL); reuses frozen V1 mechanism/gate/decision by import only; not a V1 rerun; no V1 partial-result reuse; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders; no V2 rerun.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v2/",
+        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v2.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v2.py",
+        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v2/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V2.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V3": {
+      "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V3 (evaluation_run_count 0->1); identical definition to V2/V1; binds EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 and PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE; not a V1/V2 rerun; no V2 partial-result reuse; Economic offline gate closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v3/",
+        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v3.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v3.py",
+        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v3/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V3.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4": {
+      "note": "Definition-only evaluation surface for exactly one future DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V4; reuses frozen V1 mechanism/gate/decision by import; binds measurement-validity preflight, EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1, PANEL_RUNNER_FALSY_ZERO hygiene, and MV2_WIRING_MOD_CAPTURE_ALIAS_OPEN_SIDE_BINDING_FIX; V4 contract remains DEFINITION_ONLY_PREREGISTERED with evaluation_run_count=0 in this slice; no evaluation executed here; evidence directory created only by a future authorized run; not a V1/V2/V3 rerun; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/",
+        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v4.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v4.py",
+        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v4/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5": {
+      "note": "Terminal DEVELOPMENT evaluation closeout for Bollinger/MR midband exit-efficiency V5 after one authorized run (0→1): RESULT_CLASS=INFRASTRUCTURE_FAILURE; DIAGNOSTIC_CLASS=PROCESS_DIED_INCOMPLETE_PANEL_RUN_NO_LIFECYCLE_TERMINAL; baseline 3/46; not a V4/V3/V2/V1 rerun; no V4 partial-result reuse; no holdout/runtime/orders; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no V5 rerun. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v5/",
+        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v5.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v5.py",
+        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v5/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6": {
+      "note": "Terminal DEVELOPMENT evaluation closeout for Bollinger/MR composite exit-efficiency V6 after one authorized run (0→1): RESULT_CLASS=FAIL; REASON=NET_PROFIT_FACTOR_NOT_IMPROVED; exit divergence observed; treatment binding confirmed; not a V5/V4/V3/V2/V1 rerun; no V5 partial-result reuse; no holdout/runtime/orders; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no V6 rerun. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v6/",
+        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v6.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v6.py",
+        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v6/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of a single DEVELOPMENT_ONLY Bollinger/MR side-aware middle-band exit-efficiency measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v1.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v1.py",
+        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v1/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V2": {
+      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V2 with identical definition semantics to terminal V1; EVALUATION_RUN_COUNT=0; not a V1 rerun; no V1 partial-result reuse; mandatory EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 binding; no evaluation/runtime/orders.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v2.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v2.py",
+        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v2.json",
+        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v2/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V2.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V3": {
+      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V3 with identical economic/definition semantics to terminal V2/V1; EVALUATION_RUN_COUNT=0; not a V2 or V1 rerun; no V2 partial-result or economic-result import; mandatory EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 and PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE bindings; V2 remains terminal INCONCLUSIVE_INFRASTRUCTURE_FAILURE run count 1; no evaluation/runtime/orders.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v3.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v3.py",
+        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v3.json",
+        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v3/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V3.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V4": {
+      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V4 after terminal V3 FAIL; EVALUATION_RUN_COUNT=0; presupposes merged MV2 wiring_mod capture-alias open_side binding fix; fail-closed measurement-validity gates (effective config digest inequality, open_side binding, exit observability, synthetic divergence); not a V3/V2/V1 rerun; no evaluation/runtime/orders.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v4.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v4.py",
+        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v4.json",
+        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v4/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V4.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V5": {
+      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V5 after terminal V4 INFRASTRUCTURE_FAILURE; EVALUATION_RUN_COUNT=0; preserves V4 economic hypothesis/exit mechanism; adds process-lifecycle checkpoint observability; not a V4/V3/V2/V1 rerun; no evaluation/runtime/orders.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v5.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v5.py",
+        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v5.json",
+        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v5/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V5.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V6": {
+      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V6 after terminal V5 INFRASTRUCTURE_FAILURE; EVALUATION_RUN_COUNT=0; genuine economic change vs V5 (midband-cross OR frozen max-holding-horizon=48h); reuses V5 process-lifecycle checkpoint; not a V5/V4/V3/V2/V1 rerun; no V5 partial metrics; no evaluation/runtime/orders.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v6.py",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v6.py",
+        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v6.json",
+        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v6/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V6.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PROCESS_LIFECYCLE_CHECKPOINT_V5": {
+      "note": "Definition-only process-lifecycle checkpoint scaffold for V5: monotonic lifecycle states, atomic checkpoints, read-only recovery diagnostics; import cannot start runner; checkpoints cannot reclaim run slots or authorize automatic reruns; partial metrics non-authoritative.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_efficiency_process_lifecycle_checkpoint_v5/",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_process_lifecycle_checkpoint_v5.py"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_V6_FAILURE_ATTRIBUTION": {
+      "note": "Evidence-only read-only failure attribution for terminal V6 FAIL (NET_PROFIT_FACTOR_NOT_IMPROVED). No evaluation/backtest/panel/holdout access; does not mutate V6 artifacts/run count; does not preregister or authorize V7; no promotion/runtime/orders; no Master-V2/Double-Play/risk/sizing/execution mutation.",
+      "path_prefixes": [
+        "docs/evidence/attribute_bollinger_mr_midband_exit_efficiency_v6_failure/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_V6_FAILURE_ATTRIBUTION.md",
+        "tests/research/test_bollinger_mr_midband_exit_efficiency_v6_failure_attribution.py"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V7": {
+      "note": "Separate Operator ratification authorizing exactly one later V7 DEVELOPMENT evaluation run; does not mutate preregistration digest/field; requires released DEVELOPMENT panel; does not start runner or claim slot.",
+      "path_prefixes": [
+        "config/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.json",
+        "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.py",
+        "scripts/research/run_authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7.py",
+        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.py",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V7.md",
+        "docs/evidence/authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7/"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V8": {
+      "note": "Separate Operator ratification surface authorizing exactly one later V8 DEVELOPMENT evaluation run; requires pre-authorization parity PASS and released DEVELOPMENT panel; does not start runner or claim slot in wiring slice.",
+      "path_prefixes": [
+        "config/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.json",
+        "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.py",
+        "scripts/research/run_authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8.py",
+        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.py",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V8.md",
+        "docs/evidence/authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8/"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V7": {
+      "note": "V7 reentry-cooldown DEVELOPMENT evaluation surfaces; single authorized evaluate process consumed slot and terminated INCONCLUSIVE_INFRASTRUCTURE_FAILURE (PRE_PANEL_FROZEN_EXIT_PARAMETERS_MISMATCH_NO_PANEL_BACKTEST); no rerun; no holdout.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7/",
+        "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v7.py",
+        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7.py",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V7.md",
+        "docs/evidence/preflight_bollinger_mr_midband_exit_reentry_cooldown_v7_wiring/",
+        "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v7/"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V8": {
+      "note": "V8 reentry-cooldown DEVELOPMENT evaluation wiring; pre-authorization parity before auth/slot; EVALUATION_RUN_COUNT=0; default CLI preflight-only; evaluate requires ratification+flag; evaluate evidence not pre-created; no evaluation/runtime/orders; V7 terminal unreopened.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8/",
+        "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v8.py",
+        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8.py",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V8.md",
+        "docs/evidence/preflight_bollinger_mr_midband_exit_reentry_cooldown_v8_wiring/",
+        "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v8/"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_EVALUATION_V1": {
+      "note": "Single authorized HOLDOUT_V1 evaluation of frozen Exit V8 midband reentry-cooldown treatment on sealed FINAL_AUDIT panel; terminal FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); economic/promotion/runtime/orders closed; V7/V8 terminals unchanged.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_evaluation_v1/",
+        "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1.py",
+        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_holdout_evaluation_v1.py",
+        "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_EVALUATION_V1.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Holdout confirmation preregistration of frozen V8 midband exit reentry-cooldown (hypothesis HOLDOUT_V1; digest a0658fe3fb883939ed2a2de2c426f2e4edf21eeeb91d1b902d45b4d05a38fd1d); evaluation executed terminal FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); V8 digest immutable; no second run; no runtime/orders.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistration_v1.py",
+        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistration_v1.py",
+        "config/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistered_measurement_contract_v1.json",
+        "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V7": {
+      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit reentry-cooldown V7 after terminal V6 FAIL + evidence-only attribution; EVALUATION_RUN_COUNT=0; control=exact V6 semantics; treatment=same-side reentry cooldown 24h after forced midband; not a V6 rerun; no V6 partial import; no evaluation/runtime/orders.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v7.py",
+        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v7.py",
+        "config/research/bollinger_mr_midband_exit_reentry_cooldown_preregistered_economic_hypothesis_measurement_contract_v7.json",
+        "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_v7/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V7.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V8": {
+      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit reentry-cooldown V8 after terminal V7 INCONCLUSIVE_INFRASTRUCTURE_FAILURE (FROZEN_EXIT_PARAMETERS_MISMATCH); EVALUATION_RUN_COUNT=0; control=exact V6 semantics; treatment=same-side reentry cooldown 24h; complete exit_mechanism.frozen_parameters SSOT; pre-authorization parity validator; not a V7 reopen/retry; no evaluation/runtime/orders.",
+      "path_prefixes": [
+        "src/research/bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v8.py",
+        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v8.py",
+        "config/research/bollinger_mr_midband_exit_reentry_cooldown_preregistered_economic_hypothesis_measurement_contract_v8.json",
+        "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_v8/",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V8.md"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V7": {
+      "note": "Governance overlay clarifying V7 implementation ambiguities B1-B6 without mutating immutable preregistration digest; operator_decisions_status OPERATOR_DECISIONS_RECORDED_IMPLEMENTATION_ONLY; lifecycle may transition READY_FOR_OPERATOR_EVALUATION_AUTHORIZATION -> EVALUATION_AUTHORIZED via separate ratification; evaluation_run_count=0 until run GO; no runtime/orders.",
+      "path_prefixes": [
+        "config/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.json",
+        "src/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.py",
+        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.py",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V7.md",
+        "docs/evidence/operator_clarification_bollinger_mr_midband_exit_reentry_cooldown_v7/"
+      ]
+    },
+    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V8": {
+      "note": "Governance overlay clarifying V8 B1-B6 without mutating immutable preregistration digest; lifecycle READY_FOR_OPERATOR_EVALUATION_AUTHORIZATION; evaluation_authorized=false until separate ratification; evaluation_run_count=0; no runtime/orders.",
+      "path_prefixes": [
+        "config/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.json",
+        "src/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.py",
+        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.py",
+        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V8.md",
+        "docs/evidence/operator_clarification_bollinger_mr_midband_exit_reentry_cooldown_v8/"
+      ]
+    },
+    "CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1": {
+      "note": "Canonical SSOT backlog for open MR entry-eligibility hypotheses; explicit operator CLOSE_LANE_NO_FURTHER_RESEARCH under shared research-lane post-terminal lifecycle contract V1 (status=LANE_CLOSED_NO_FURTHER_RESEARCH; explicit_closeout_decision=true; lane_auto_closed=false); inventories empty; historical terminals immutable; no runtime/orders.",
+      "path_prefixes": [
+        "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json",
+        "src/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
+        "tests/research/test_canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
+        "docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md"
+      ]
+    },
+    "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1": {
+      "note": "Canonical SSOT backlog for open MR exit-efficiency hypotheses; explicit operator CREATE_SUCCESSOR_HYPOTHESIS under shared lifecycle contract V1 after V8 TERMINAL_PASS (status=OPEN_BACKLOG; holdout successor HOLDOUT_V1 DEFINITION_ONLY_PREREGISTERED; digest a0658fe3fb883939ed2a2de2c426f2e4edf21eeeb91d1b902d45b4d05a38fd1d); V8 identity unreopened; holdout execution unauthorized; Entry sibling LANE_CLOSED_NO_FURTHER_RESEARCH; Economic/promotion closed; no runtime/orders.",
+      "path_prefixes": [
+        "config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json",
+        "src/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py",
+        "tests/research/test_canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py",
+        "docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md"
+      ]
+    },
+    "CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1": {
+      "note": "Shared definition-only research-lane post-terminal lifecycle contract; canonical lane-state vocabulary, totality invariant, operator-decision contract, and historical-immutability/live-mirror policy. Entry-Eligibility and Exit-Efficiency backlog SSOTs migrate in separate operator-authorized slices; no evaluation/runtime/orders.",
+      "path_prefixes": [
+        "config/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.json",
+        "src/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.py",
+        "tests/research/test_canonical_research_lane_post_terminal_lifecycle_contract_v1.py",
+        "docs/governance/CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1.md"
+      ]
+    },
+    "COST_MODEL_DIAGNOSTICS": {
+      "path_globs": [
+        "tests/research/test_offline_linear_cost_model_diagnostics_*",
+        "tests/research/test_offline_signal_orthogonality_diagnostics_*",
+        "tests/research/test_offline_productive_signal_orthogonality_results_interpretation_v0.py",
+        "tests/research/test_offline_productive_factor_exposure_diagnostics_v0.py",
+        "tests/research/test_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+        "tests/research/test_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "tests/research/test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "tests/research/test_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+        "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
+        "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
+        "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+        "tests/research/test_offline_factor_exposure_diagnostics_*",
+        "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
+        "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
+        "tests/research/test_offline_final_research_fleet_signal_matrix_productive_input_join_materializer_*",
+        "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
+        "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_*",
+        "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
+        "tests/research/test_offline_parameter_sensitivity_model_spec_alignment_*",
+        "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*",
+        "tests/research/test_offline_rolling_linear_drift_diagnostics_v0.py",
+        "tests/research/test_offline_outlier_and_window_robustness_diagnostic_v0.py",
+        "tests/research/test_linear_evidence_*"
+      ],
+      "path_prefixes": [
+        "src/research/linear_evidence/cost_model.py",
+        "src/research/linear_evidence/diagnostics.py",
+        "src/research/linear_evidence/fitters.py",
+        "src/research/linear_evidence/drift.py",
+        "src/research/linear_evidence/window_robustness.py",
+        "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
+        "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
+        "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+        "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
+        "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
+        "scripts/research/offline_linear_cost_model_diagnostics_v0.py",
+        "scripts/research/offline_signal_orthogonality_diagnostics_v0.py",
+        "scripts/research/offline_factor_exposure_diagnostics_v0.py",
+        "scripts/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+        "scripts/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
+        "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
+        "scripts/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
+        "scripts/research/offline_rolling_linear_drift_diagnostics_v0.py",
+        "scripts/research/offline_outlier_and_window_robustness_diagnostic_v0.py",
+        "scripts/ops/materialize_offline_productive_signal_orthogonality_results_interpretation_v0.py",
+        "scripts/ops/materialize_offline_productive_factor_exposure_diagnostics_v0.py",
+        "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+        "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
+        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+        "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
+        "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py"
+      ]
+    },
+    "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+      "note": "DEVELOPMENT evaluation entry point/owner for CS relative-strength momentum v1: executable evaluate path under fail-closed authorization, CLI preflight/dry-validate, digests/dataset/time-segment/rebalance-observation/evidence-registry/admission gates, wiring into canonical single-slot backtest metrics owners. Development evaluation authorized on HEAD; no runner start/run-slot consumption without separate execution GO; no holdout/runtime/orders; measurement thresholds and strategy score/selection semantics unchanged.",
+      "path_prefixes": [
+        "config/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_binding_v1.json",
+        "docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/",
+        "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+        "scripts/research/run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py",
+        "src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/",
+        "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_v1.py",
+        "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_executable_path_v1.py",
+        "tests/research/test_cross_sectional_relative_strength_momentum_v1_panel_loader_alignment_repair_v1.py"
+      ]
+    },
+    "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of cross-sectional relative-strength momentum v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; directional form D mutually exclusive single-slot selection; bounded DEV grid frozen; operator-authorized robustness thresholds (minimum_rebalance_observations=30, time_segment_robustness_pass_ratio=0.5) and CHRONOLOGICAL_EQUAL_DURATION_QUARTERS_V1 bound; development evaluation authorized; evaluation not executed; no holdout/runtime/orders; closed Entry/Exit Bollinger lanes untouched.",
+      "path_prefixes": [
+        "config/research/cross_sectional_relative_strength_momentum_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "src/research/cross_sectional_relative_strength_momentum_v1_hypothesis_preregistration_v1.py",
+        "tests/research/test_cross_sectional_relative_strength_momentum_v1_hypothesis_preregistration_v1.py",
+        "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+        "docs/evidence/preregister_cross_sectional_relative_strength_momentum_hypothesis_v1/"
+      ]
+    },
+    "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+      "note": "Strategy-implementation-only surfaces for CS relative-strength momentum v1 (raw trailing log-return score + single-top1 rank-intent selection + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; no Master-V2/Double-Play mutation.",
+      "path_prefixes": [
+        "src/research/cross_sectional_relative_strength_momentum_v1_score_v1.py",
+        "src/research/cross_sectional_relative_strength_momentum_v1_selection_v1.py",
+        "src/research/cross_sectional_relative_strength_momentum_v1_strategy_implementation_binding_v1.py",
+        "config/research/cross_sectional_relative_strength_momentum_v1_strategy_implementation_binding_v1.json",
+        "tests/research/test_cross_sectional_relative_strength_momentum_v1_score_and_selection_v1.py",
+        "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
+      ]
+    },
+    "DATA_BINDING_REPAIR": {
+      "path_prefixes": [
+        "src/research/offline_source_evidence_",
+        "scripts/research/offline_source_evidence_"
+      ]
+    },
+    "DETERMINISTIC_MATERIALIZATION_REPAIR": {
+      "path_prefixes": [
+        "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
+        "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+        "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
+        "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
+        "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
+        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
+        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
+        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py"
+      ]
+    },
+    "DIGEST_BINDING_AND_PROVENANCE_REPAIR": {
+      "path_globs": [
+        "scripts/ops/*digest*",
+        "scripts/ops/*binding*"
+      ],
+      "path_prefixes": [
+        "scripts/ops/primary_evidence_retention_v0.py"
+      ]
+    },
+    "DOUBLE_PLAY_COMPOSITION_NARROW_RESEARCH_REWIRE": {
+      "path_globs": [
+        "tests/research/test_double_play_composition_narrow_reuse_first_rewire_v0.py"
+      ],
+      "path_prefixes": [
+        "scripts/research/double_play_composition_narrow_reuse_first_rewire_v0.py"
+      ]
+    },
+    "ENTRY_EFFECTIVE_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+      "note": "Single preregistered DEVELOPMENT-only offline evaluation of entry-effective pre-entry ATR-percentile mid-band MR eligibility filter (STRICT bounds) versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of the prior failed regime_gated evaluation's shared_portfolio_equity_research_v1 helper only (no mutation of that package); no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+      "path_prefixes": [
+        "src/research/entry_effective_mr_eligibility_development_evaluation_v1/",
+        "scripts/research/run_evaluate_entry_effective_mr_eligibility_development_v1.py",
+        "tests/research/test_entry_effective_mr_eligibility_development_evaluation_v1.py",
+        "docs/evidence/evaluate_entry_effective_mr_eligibility_development_v1/",
+        "docs/governance/ENTRY_EFFECTIVE_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
+      ]
+    },
+    "ENTRY_EFFECTIVE_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of a single entry-effective pre-entry ATR-percentile MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+      "path_prefixes": [
+        "src/research/entry_effective_mr_eligibility_hypothesis_preregistration_v1.py",
+        "tests/research/test_entry_effective_mr_eligibility_hypothesis_preregistration_v1.py",
+        "config/research/entry_effective_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "docs/evidence/preregister_entry_effective_mr_eligibility_hypothesis_v1/",
+        "docs/governance/ENTRY_EFFECTIVE_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
+      ]
+    },
+    "EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1": {
+      "note": "Generic research-infrastructure observability for evaluation-runner process death (atomic heartbeat/progress, catchable signal handlers, exit/signal normalization, supervised child reap, INCONCLUSIVE_INFRASTRUCTURE_FAILURE classification without auto-rerun); no strategy/Master-V2/Double-Play/risk/sizing/execution/economic semantics mutation; no evaluation rerun; no holdout access; no runtime/orders.",
+      "path_prefixes": [
+        "src/research/evaluation_runner_lifecycle_observability_v1/",
+        "tests/research/test_evaluation_runner_lifecycle_observability_v1.py",
+        "docs/evidence/evaluation_runner_lifecycle_observability_v1/"
+      ]
+    },
+    "EXPLICITLY_CALIBRATABLE_RESEARCH_PARAMETERS_WITHIN_PREDECLARED_RANGES": {
+      "path_prefixes": [
+        "src/research/linear_evidence/sensitivity.py",
+        "src/research/linear_evidence/drift.py",
+        "src/research/linear_evidence/window_robustness.py",
+        "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
+        "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
+        "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "scripts/research/offline_parameter_sensitivity_surface_v0.py",
+        "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
+        "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+        "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py"
+      ]
+    },
+    "FEATURE_SCALING_OR_NUMERICAL_CONDITIONING_WITHOUT_TRADING_SEMANTIC_EFFECT": {
+      "path_prefixes": [
+        "src/research/linear_evidence/feature_matrix.py",
+        "src/research/linear_evidence/contracts.py",
+        "src/research/linear_evidence/signal_orthogonality.py",
+        "src/research/linear_evidence/signal_orthogonality_results_interpretation_v0.py",
+        "src/research/linear_evidence/offline_productive_factor_exposure_diagnostics_v0.py",
+        "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
+        "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "src/research/linear_evidence/offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+        "src/research/linear_evidence/factor_exposure.py",
+        "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
+        "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
+        "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
+        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
+        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
+        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py"
+      ]
+    },
+    "GOVERNANCE_ONLY_OPERATOR_RATIFICATION_AND_RESEARCH_SCOPE_DEFINITION_WITHOUT_TRADING_SEMANTIC_EFFECT": {
+      "note": "Governance-only operator ratification and research scope definition without trading semantic mutation or runtime authority.",
+      "path_globs": [
+        "src/research/*terminal_inconclusive_insufficient_sample_and_distinct_futures_research_scope_definition_v0.py",
+        "src/research/*terminal_insufficient_sample_and_distinct_futures_research_scope_ratification_v0.py",
+        "src/research/*research_scope_ratification_v0.py",
+        "src/research/*versioned_hypothesis_binding_v0.py",
+        "src/research/*versioned_research_binding_v0.py",
+        "src/research/*score_and_ranking_contract_v0.py",
+        "src/research/*portfolio_binding_v0.py",
+        "src/research/cross_sectional_futures_pairwise_lead_lag_spillover_*_score_v0.py",
+        "scripts/research/materialize_*operator_ratification*",
+        "scripts/research/materialize_*scope_ratification*",
+        "scripts/research/materialize_*terminal_*research_scope*",
+        "scripts/research/materialize_*versioned_hypothesis_binding_v0.py",
+        "scripts/research/materialize_*versioned_research_binding_v0.py",
+        "scripts/research/materialize_*score_and_ranking_contract_v0.py",
+        "scripts/research/materialize_*portfolio_binding_implementation_v0.py",
+        "scripts/research/materialize_*offline_economic_evaluation_authorization_ratification_v0.py",
+        "src/research/*offline_economic_evaluation_authorization_ratification_v0.py",
+        "src/research/full_canonical_system_economic_evidence_generation_v1.py",
+        "scripts/research/materialize_full_canonical_system_economic_evidence_generation_v1_binding_ratification_v0.py",
+        "tests/research/test_*versioned_hypothesis_binding_v0_contract.py",
+        "tests/research/test_*versioned_research_binding_v0_contract.py",
+        "tests/research/test_*score_and_ranking_contract_v0_contract.py",
+        "tests/research/test_*portfolio_binding_implementation_v0_contract.py",
+        "tests/research/test_*offline_economic_evaluation_authorization_ratification_v0_contract.py",
+        "tests/research/test_full_canonical_system_economic_evidence_generation_v1_binding_ratification_v0_contract.py",
+        "config/research/*governance_closeout_v0.json",
+        "docs/governance/*GOVERNANCE_CLOSEOUT_V0.md",
+        "tests/ops/test_*governance_closeout_v0_contract.py"
+      ]
+    },
+    "INDEPENDENT_DEV_PANEL_QUARANTINE_RELEASE_V1": {
+      "note": "Byte-identical quarantine to RELEASED_DEVELOPMENT_ONLY panel release; no transform; no holdout; does not authorize evaluation.",
+      "path_prefixes": [
+        "config/research/independent_dev_panel_quarantine_release_contract_v1.json",
+        "src/research/independent_dev_panel_quarantine_release_v1.py",
+        "scripts/research/run_release_independent_dev_panel_quarantine_v1.py",
+        "tests/research/test_independent_dev_panel_quarantine_release_v1.py",
+        "docs/governance/INDEPENDENT_DEV_PANEL_QUARANTINE_RELEASE_V1.md",
+        "docs/evidence/release_independent_dev_panel_quarantine_byte_identical_v1/"
+      ]
+    },
+    "LONGER_CHRONOLOGICAL_PIT_PUBLIC_HISTORY_ACQUISITION_SCAFFOLD_AND_DEPTH_PROBE_V1": {
+      "note": "Research-only public OKX history acquisition scaffold, bounded history-depth probe, sealed production-lifecycle long-panel binding/acquisition, and independent pre-holdout development-panel seal; dry-run/no-credentials defaults; no economic optimization; no strategy/risk/execution/Master-V2/Double-Play mutation.",
+      "path_prefixes": [
+        "src/research/longer_chronological_pit_acquisition_v1/",
+        "tests/research/test_longer_chronological_pit_acquisition_scaffold_v1.py",
+        "tests/research/test_longer_chronological_pit_okx_history_depth_probe_v1.py",
+        "tests/research/test_longer_chronological_pit_sealed_lifecycle_acquisition_v1.py",
+        "config/research/longer_chronological_pit_acquisition_chrono_3y_v1.json",
+        "config/research/longer_chronological_pit_sealed_lifecycle_long_panel_v1.json",
+        "config/research/regime_gated_standaside_mr_independent_dev_panel_acquisition_contract_v1.json",
+        "config/research/regime_gated_standaside_mr_independent_dev_panel_seal_registry_v1.json",
+        "docs/evidence/longer_chronological_pit_sealed_lifecycle_acquisition_v1/",
+        "docs/evidence/acquire_and_seal_okx_independent_dev_panel_v1/",
+        "docs/governance/REGIME_GATED_STANDASIDE_MR_INDEPENDENT_DEV_PANEL_SEALED_V1.md",
+        "tests/governance/test_acquire_and_seal_okx_independent_dev_panel_v1.py"
+      ]
+    },
+    "MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+      "note": "Single preregistered DEVELOPMENT-only offline evaluation of MACD(12,26,9) histogram-sign countertrend pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=FAIL, NET_PROFIT_FACTOR_NOT_IMPROVED); research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+      "path_prefixes": [
+        "src/research/macd_histogram_countertrend_mr_eligibility_development_evaluation_v1/",
+        "scripts/research/run_evaluate_macd_histogram_countertrend_mr_eligibility_development_v1.py",
+        "tests/research/test_macd_histogram_countertrend_mr_eligibility_development_evaluation_v1.py",
+        "docs/evidence/evaluate_macd_histogram_countertrend_mr_eligibility_development_v1/",
+        "docs/governance/MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
+      ]
+    },
+    "MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of a single MACD(12,26,9) histogram-sign countertrend admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to five prior FAILs (regime, ATR, RSI, ADX, MA); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+      "path_prefixes": [
+        "src/research/macd_histogram_countertrend_mr_eligibility_hypothesis_preregistration_v1.py",
+        "tests/research/test_macd_histogram_countertrend_mr_eligibility_hypothesis_preregistration_v1.py",
+        "config/research/macd_histogram_countertrend_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "docs/evidence/preregister_macd_histogram_countertrend_mr_eligibility_hypothesis_v1/",
+        "docs/governance/MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
+      ]
+    },
+    "MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_HYPOTHESIS_BACKLOG_V1": {
+      "note": "Closed lane SSOT for material-different cross-sectional momentum program after CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1 FAIL_CLOSED_NO_RETRY; inventories empty of open/preregistered candidates; terminal hypothesis recorded; no successor; retry/reopen forbidden; evaluation/holdout/promotion/runtime closed; sibling Entry/Exit lanes remain LANE_CLOSED_NO_FURTHER_RESEARCH unreopened.",
+      "path_prefixes": [
+        "config/research/material_different_cross_sectional_momentum_hypothesis_backlog_v1.json",
+        "src/research/material_different_cross_sectional_momentum_hypothesis_backlog_v1.py",
+        "tests/research/test_material_different_cross_sectional_momentum_hypothesis_backlog_v1.py",
+        "docs/governance/MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_HYPOTHESIS_BACKLOG_V1.md"
+      ]
+    },
+    "MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_PROGRAM_V1": {
+      "note": "Closed research-program SSOT after CS-RS-Momentum v1 FAIL_CLOSED_NO_RETRY; run budget consumed (1/1); no successor; no retry/reopen; no holdout/runtime/orders; causal independence from closed Bollinger Entry/Exit lanes retained; new research requires separate operator authorization and preregistration.",
+      "path_prefixes": [
+        "config/research/material_different_cross_sectional_momentum_program_v1.json",
+        "src/research/material_different_cross_sectional_momentum_program_v1.py",
+        "tests/research/test_material_different_cross_sectional_momentum_program_v1.py",
+        "docs/governance/MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_PROGRAM_V1.md"
+      ]
+    },
+    "MA_TREND_ALIGNMENT_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+      "note": "Single preregistered DEVELOPMENT-only offline evaluation of SMA(50) side-aware with-trend admission pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=FAIL, NET_PROFIT_FACTOR_NOT_IMPROVED); research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+      "path_prefixes": [
+        "src/research/ma_trend_alignment_mr_eligibility_development_evaluation_v1/",
+        "scripts/research/run_evaluate_ma_trend_alignment_mr_eligibility_development_v1.py",
+        "tests/research/test_ma_trend_alignment_mr_eligibility_development_evaluation_v1.py",
+        "docs/evidence/evaluate_ma_trend_alignment_mr_eligibility_development_v1/",
+        "docs/governance/MA_TREND_ALIGNMENT_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
+      ]
+    },
+    "MA_TREND_ALIGNMENT_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of a single SMA(50) side-aware with-trend admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to four prior FAILs (regime, ATR, RSI, ADX); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+      "path_prefixes": [
+        "src/research/ma_trend_alignment_mr_eligibility_hypothesis_preregistration_v1.py",
+        "tests/research/test_ma_trend_alignment_mr_eligibility_hypothesis_preregistration_v1.py",
+        "config/research/ma_trend_alignment_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "docs/evidence/preregister_ma_trend_alignment_mr_eligibility_hypothesis_v1/",
+        "docs/governance/MA_TREND_ALIGNMENT_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
+      ]
+    },
+    "OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_WITHOUT_TRADING_SEMANTIC_EFFECT": {
+      "note": "Offline economic evaluation execution infrastructure, preexecution guards, invocation-bound authorization repair, and contract tests without trading semantic mutation or runtime authority.",
+      "path_globs": [
+        "src/research/*offline_economic_evaluation_execution_v0.py",
+        "src/research/cross_sectional_cost_execution_binding_normalization_v0.py",
+        "src/research/*offline_economic_evaluation_scope_ratification_v0.py",
+        "tests/research/test_*offline_economic_evaluation_execution_infrastructure_v0.py",
+        "tests/research/test_*offline_economic_evaluation_execution_dispatch_implementation_v0.py",
+        "tests/research/test_*offline_economic_evaluation_execution_implementation_repair_v0.py",
+        "tests/research/test_*offline_economic_evaluation_dispatch_to_baseline_repair_v0.py",
+        "tests/research/test_*offline_economic_evaluation_reevaluation_execution_implementation_v0.py",
+        "tests/research/test_*offline_economic_evaluation_reevaluation_execution_ops_runner_branch_v0.py",
+        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_ops_runner_branch_v0.py",
+        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py",
+        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_actual_execution_owner_implementation_v0.py",
+        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_dataset_digest_reconciliation_repair_v0.py",
+        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_data_unavailable_repair_v0.py",
+        "tests/research/test_*offline_economic_evaluation_baseline_execution_implementation_v0.py",
+        "tests/research/test_*baseline_execution_entry_point_result_contract_repair_v0.py",
+        "tests/research/test_trend_following_v2_baseline_owner_single_member_end_to_end_repair_v0.py",
+        "tests/research/test_trend_following_v2_mandatory_boundary_state_file_binding_rewire_v0.py",
+        "tests/research/test_trend_following_v2_canonical_wiring_map_contract_v0.py",
+        "tests/research/test_*offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",
+        "src/backtest/economic_viability_evidence_v1.py",
+        "config/ops/trend_following_v2_economic_evaluation_v1.json",
+        "src/research/panel_sequential_signal_density_research_adapter_v0.py",
+        "src/research/versioned_final_fleet_bindings_offline_economic_evaluation_v0.py",
+        "src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py",
+        "scripts/ops/run_*offline_economic_evaluation_execution_v0.py",
+        "scripts/ops/materialize_*offline_economic_evaluation_baseline_execution_implementation_v0.py",
+        "scripts/ops/materialize_*offline_economic_evaluation_execution_*_implementation_v0.py",
+        "tests/research/test_*offline_economic_evaluation_execution_authorization_ratification_repair_v0.py",
+        "tests/research/test_*execution_v1_token_binding_repair_v0.py",
+        "tests/research/test_*offline_economic_evaluation_full_runner_v0.py",
+        "src/research/*offline_economic_evaluation_execution_authorization_supersession_v*.py",
+        "scripts/research/materialize_*offline_economic_evaluation_execution_authorization_supersession_v*.py",
+        "config/research/*offline_economic_evaluation_execution_authorization_supersession_v*.json",
+        "config/research/full_canonical_system_economic_evidence_generation_v1_offline_execution_result_v0.json",
+        "tests/research/test_full_canonical_system_economic_evidence_generation_v1_offline_execution_result_v0_contract.py"
+      ]
+    },
+    "OFFLINE_MV2_ZERO_TRADE_PER_BAR_DECISION_OUTCOME_DIAGNOSTIC_WITHOUT_TRADING_SEMANTIC_EFFECT": {
+      "note": "Offline-only per-bar MV2 decision-outcome diagnostic for zero-trade root-cause observability; observational hook only; no trading/runtime/authority/sizing semantic mutation.",
+      "path_prefixes": [
+        "src/research/mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
+        "scripts/research/run_mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
+        "tests/research/test_mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
+        "config/research/mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.json"
+      ]
+    },
+    "POINT_IN_TIME_DATA_QUALITY_REPAIR": {
+      "path_prefixes": [
+        "src/backtest/admissible_versioned_futures_dataset_v1.py",
+        "src/research/admissible_"
+      ]
+    },
+    "PORTFOLIO_RESEARCH_AND_ECONOMIC_ATTRIBUTION_WITHOUT_RUNTIME_AUTHORITY": {
+      "path_prefixes": [
+        "src/experiments/evidence_chain.py",
+        "src/experiments/strategy_profiles.py",
+        "src/research/offline_economic_viability_evidence_gap_assessment_v0.py"
+      ]
+    },
+    "REAL_FILL_BINDING": {
+      "note": "Real fill binding repair only; no trading semantic mutation.",
+      "path_prefixes": [
+        "src/backtest/engine.py"
+      ]
+    },
+    "REGIME_GATED_STANDASIDE_MR_DEVELOPMENT_EVALUATION_V1": {
+      "note": "Single preregistered DEVELOPMENT-only offline evaluation of regime-gated standaside MR versus immutable bollinger baseline; research-only entry-eligibility gate; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+      "path_prefixes": [
+        "src/research/regime_gated_standaside_mr_development_evaluation_v1/",
+        "scripts/research/run_evaluate_regime_gated_standaside_mr_development_v1.py",
+        "tests/research/test_regime_gated_standaside_mr_development_evaluation_v1.py",
+        "docs/evidence/evaluate_regime_gated_standaside_mr_development_v1/",
+        "docs/governance/REGIME_GATED_STANDASIDE_MR_DEVELOPMENT_EVALUATION_V1.md"
+      ]
+    },
+    "REGIME_GATED_STANDASIDE_MR_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of a single regime-gated stand-aside mean-reversion measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+      "path_prefixes": [
+        "src/research/regime_gated_standaside_mr_hypothesis_preregistration_v1.py",
+        "tests/research/test_regime_gated_standaside_mr_hypothesis_preregistration_v1.py",
+        "config/research/regime_gated_standaside_mr_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "docs/evidence/preregister_regime_gated_standaside_mr_hypothesis_v1/",
+        "docs/governance/REGIME_GATED_STANDASIDE_MR_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
+      ]
+    },
+    "REPORTING_AND_EVIDENCE_REPAIR": {
+      "path_globs": [
+        "scripts/ops/*evidence*",
+        "scripts/ops/*manifest*"
+      ],
+      "path_prefixes": [
+        "scripts/ops/primary_evidence_retention_v0.py",
+        "scripts/ops/verify_pre_pr_validation_result_v0.py",
+        "scripts/ops/materialize_offline_productive_signal_orthogonality_results_interpretation_v0.py",
+        "scripts/ops/materialize_offline_productive_factor_exposure_diagnostics_v0.py",
+        "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+        "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "scripts/ops/materialize_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+        "scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py",
+        "scripts/research/materialize_bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
+        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
+        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
+        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+        "tests/research/test_step29l2_import_boundary_classification_v0.py"
+      ]
+    },
+    "RSI_EXHAUSTION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+      "note": "Single preregistered DEVELOPMENT-only offline evaluation of RSI(14)-exhaustion pre-entry MR eligibility filter versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+      "path_prefixes": [
+        "src/research/rsi_exhaustion_mr_eligibility_development_evaluation_v1/",
+        "scripts/research/run_evaluate_rsi_exhaustion_mr_eligibility_development_v1.py",
+        "tests/research/test_rsi_exhaustion_mr_eligibility_development_evaluation_v1.py",
+        "docs/evidence/evaluate_rsi_exhaustion_mr_eligibility_development_v1/",
+        "docs/governance/RSI_EXHAUSTION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
+      ]
+    },
+    "RSI_EXHAUSTION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of a single RSI(14)-exhaustion pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to the failed ATR-percentile mid-band and failed regime-gated absolute-threshold mechanisms; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+      "path_prefixes": [
+        "src/research/rsi_exhaustion_mr_eligibility_hypothesis_preregistration_v1.py",
+        "tests/research/test_rsi_exhaustion_mr_eligibility_hypothesis_preregistration_v1.py",
+        "config/research/rsi_exhaustion_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "docs/evidence/preregister_rsi_exhaustion_mr_eligibility_hypothesis_v1/",
+        "docs/governance/RSI_EXHAUSTION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
+      ]
+    },
+    "SIMULATED_FILL_BINDING_USING_EXISTING_CANONICAL_EXECUTION_OWNER": {
+      "note": "Simulated fill binding must reuse existing canonical execution owners; no new runtime authority.",
+      "path_globs": [
+        "tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py",
+        "tests/research/test_cross_sectional_lead_lag_v0_backtest_engine_mv2_replay_signal_parity_v0.py",
+        "tests/research/test_cross_sectional_lead_lag_v0_research_eval_decision_parity_contract_suite_v0.py"
+      ],
+      "path_prefixes": [
+        "src/backtest/mv2_research_wiring_v1.py",
+        "src/backtest/strategy_signal_binding_v1.py"
+      ]
+    },
+    "SLIPPAGE_MODEL_DIAGNOSTICS": {
+      "path_prefixes": [
+        "src/research/linear_evidence/cost_model.py"
+      ]
+    },
+    "TARGET_BINDING_REPAIR": {
+      "path_globs": [
+        "tests/research/test_offline_linear_cost_diagnostic_row_materializer_*",
+        "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
+        "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
+        "tests/research/test_offline_final_research_fleet_signal_matrix_productive_input_join_materializer_*",
+        "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
+        "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_*",
+        "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*"
+      ],
+      "path_prefixes": [
+        "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
+        "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+        "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
+        "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
+        "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
+        "src/research/linear_evidence/feature_matrix.py",
+        "src/research/linear_evidence/sensitivity.py",
+        "src/research/linear_evidence/drift.py",
+        "src/research/linear_evidence/window_robustness.py",
+        "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
+        "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
+        "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
+        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
+        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
+        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py"
+      ]
+    },
+    "TIME_ORDERED_VALIDATION": {
+      "path_prefixes": [
+        "src/backtest/walkforward.py",
+        "tests/backtest/test_walkforward*"
+      ]
+    },
+    "VOLATILITY_COMPRESSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_COMPRESSION_BREAKOUT_V1: executable evaluate path with panel execution boundary and productive exit/PnL evaluator bound to canonical BacktestEngine fee/slippage/gross-PnL primitives; authorized on HEAD; no evaluation execution/run-slot consumption without separate GO; no holdout/runtime/orders; measurement thresholds and strategy/baseline parameters unchanged.",
+      "path_prefixes": [
+        "config/research/volatility_compression_breakout_v1_development_evaluation_entry_point_binding_v1.json",
+        "docs/evidence/evaluate_volatility_compression_breakout_development_v1/",
+        "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+        "scripts/research/run_evaluate_volatility_compression_breakout_development_v1.py",
+        "src/research/volatility_compression_breakout_v1_development_evaluation_v1/",
+        "tests/research/test_volatility_compression_breakout_v1_development_evaluation_entry_point_v1.py",
+        "tests/research/test_volatility_compression_breakout_v1_development_evaluation_executable_path_v1.py",
+        "tests/research/test_volatility_compression_breakout_v1_development_evaluation_fail_closed_report_v1.py",
+        "tests/research/test_volatility_compression_breakout_v1_productive_exit_pnl_evaluator_v1.py"
+      ]
+    },
+    "VOLATILITY_COMPRESSION_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of own-instrument volatility compression→expansion→channel-breakout v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; frozen ATR(20)/close percentile-rank admission, unconditional channel-breakout baseline, event-sufficiency gates; material difference vs terminal VOL_BREAKOUT_COILED_SPRING explicit; development evaluation authorized; evaluation not executed; no holdout/runtime/orders.",
+      "path_prefixes": [
+        "config/research/volatility_compression_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "src/research/volatility_compression_breakout_v1_hypothesis_preregistration_v1.py",
+        "tests/research/test_volatility_compression_breakout_v1_hypothesis_preregistration_v1.py",
+        "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+        "docs/evidence/preregister_volatility_compression_breakout_hypothesis_v1/"
+      ]
+    },
+    "VOLATILITY_COMPRESSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+      "note": "Strategy-implementation-only surfaces for VOLATILITY_COMPRESSION_BREAKOUT_V1 (shared 20-bar price-channel core + ATR20/close percentile vol-state + compression/release admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; no Master-V2/Double-Play/risk/execution mutation.",
+      "path_prefixes": [
+        "src/research/price_channel_breakout_core_v1.py",
+        "src/research/volatility_compression_breakout_v1_vol_state_v1.py",
+        "src/research/volatility_compression_breakout_v1_strategy_v1.py",
+        "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
+        "src/research/volatility_compression_breakout_v1_strategy_implementation_binding_v1.py",
+        "config/research/volatility_compression_breakout_v1_strategy_implementation_binding_v1.json",
+        "tests/research/test_volatility_compression_breakout_v1_strategy_implementation_v1.py",
+        "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
+      ]
+    },
+    "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1: development evaluation slot consumed FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; productive exit/PnL evaluator reused from VCB package (not duplicated). No retry; no holdout/runtime/orders; strategy/baseline parameters unchanged; VDBX/VDB/VEP/VCB artifacts unchanged.",
+      "path_prefixes": [
+        "config/research/volatility_contraction_expansion_breakout_v1_development_evaluation_entry_point_binding_v1.json",
+        "docs/evidence/evaluate_volatility_contraction_expansion_breakout_development_v1/",
+        "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+        "scripts/research/run_evaluate_volatility_contraction_expansion_breakout_development_v1.py",
+        "src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/",
+        "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_entry_point_v1.py",
+        "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_executable_path_v1.py",
+        "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_fail_closed_report_v1.py"
+      ]
+    },
+    "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1 after terminal VDBX FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; frozen realized-vol contraction->expansion joint breakout admission + pairable exit precedence; productive PnL evaluator referenced only; no Development evaluation/holdout/runtime/orders; VDBX/VDB/VEP/VCB retry forbidden.",
+      "path_prefixes": [
+        "config/research/volatility_contraction_expansion_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "src/research/volatility_contraction_expansion_breakout_v1_hypothesis_preregistration_v1.py",
+        "tests/research/test_volatility_contraction_expansion_breakout_v1_hypothesis_preregistration_v1.py",
+        "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+        "docs/evidence/preregister_volatility_contraction_expansion_breakout_hypothesis_v1/"
+      ]
+    },
+    "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+      "note": "Strategy + exit state machine for VCEB v1 (RV24 contraction->expansion joint break + opposite-break exits without trailing); productive PnL evaluator referenced not duplicated; measurement digest frozen; no evaluation/holdout/runtime/orders; VDBX/VDB/VEP/VCB retry forbidden.",
+      "path_prefixes": [
+        "src/research/price_channel_breakout_core_v1.py",
+        "src/research/volatility_contraction_expansion_breakout_v1_vol_state_v1.py",
+        "src/research/volatility_contraction_expansion_breakout_v1_exit_state_machine_v1.py",
+        "src/research/volatility_contraction_expansion_breakout_v1_strategy_v1.py",
+        "src/research/volatility_contraction_expansion_breakout_v1_strategy_implementation_binding_v1.py",
+        "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
+        "config/research/volatility_contraction_expansion_breakout_v1_strategy_implementation_binding_v1.json",
+        "tests/research/test_volatility_contraction_expansion_breakout_v1_strategy_and_exit_state_machine_v1.py",
+        "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
+      ]
+    },
+    "VOLATILITY_DECAY_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_DECAY_BREAKOUT_V1: panel execution boundary materialized; productive exit/PnL evaluator reused from VCB. Single bounded development attempt fail-closed at PRODUCTIVE_PNL_OVERFLOW with durable run slot consumed (1/1); archival panel-boundary fail_closed_report retained; bounded corrective measurement reevaluation executed once and fail-closed at UNPAIRABLE_ENTRY_NO_EXIT (corrective slot 1/1; development counters preserved at 1; prior development evidence unmodified; supersession audited in corrective bundle); no holdout/runtime/orders; no development or corrective retry; VCB/VEP slots not reused.",
+      "path_prefixes": [
+        "config/research/volatility_decay_breakout_v1_development_evaluation_entry_point_binding_v1.json",
+        "docs/evidence/evaluate_volatility_decay_breakout_corrective_measurement_reevaluation_v1/",
+        "docs/evidence/evaluate_volatility_decay_breakout_development_v1/",
+        "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+        "scripts/research/run_evaluate_volatility_decay_breakout_development_v1.py",
+        "src/research/volatility_decay_breakout_v1_development_evaluation_v1/",
+        "tests/research/test_volatility_decay_breakout_v1_corrective_measurement_reevaluation_v1.py",
+        "tests/research/test_volatility_decay_breakout_v1_development_evaluation_entry_point_v1.py",
+        "tests/research/test_volatility_decay_breakout_v1_development_evaluation_fail_closed_report_v1.py",
+        "tests/research/test_volatility_decay_breakout_v1_development_evaluation_executable_path_v1.py"
+      ]
+    },
+    "VOLATILITY_DECAY_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of own-instrument volatility decay-breakout v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures after terminal VEP-V1 UNPAIRABLE_ENTRY_NO_EXIT; frozen ATR(14)/close high→low decay admission + channel-breakout baseline; material difference vs VEP/VCB/coiled-spring explicit; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced only; VEP retry/exit-repair forbidden.",
+      "path_prefixes": [
+        "config/research/volatility_decay_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "src/research/volatility_decay_breakout_v1_hypothesis_preregistration_v1.py",
+        "tests/research/test_volatility_decay_breakout_v1_hypothesis_preregistration_v1.py",
+        "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+        "docs/evidence/preregister_volatility_decay_breakout_hypothesis_v1/",
+        "docs/evidence/forensic_classify_vep_v1_unpairable_entry_no_exit_v1/"
+      ]
+    },
+    "VOLATILITY_DECAY_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+      "note": "Strategy-implementation-only surfaces for VOLATILITY_DECAY_BREAKOUT_V1 (shared 20-bar price-channel core + ATR14/close percentile vol-state + high→low decay admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced not duplicated; no Master-V2/Double-Play/risk/execution mutation; VEP/VCB retry forbidden.",
+      "path_prefixes": [
+        "src/research/price_channel_breakout_core_v1.py",
+        "src/research/volatility_decay_breakout_v1_vol_state_v1.py",
+        "src/research/volatility_decay_breakout_v1_strategy_v1.py",
+        "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
+        "src/research/volatility_decay_breakout_v1_strategy_implementation_binding_v1.py",
+        "config/research/volatility_decay_breakout_v1_strategy_implementation_binding_v1.json",
+        "tests/research/test_volatility_decay_breakout_v1_strategy_implementation_v1.py",
+        "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
+      ]
+    },
+    "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1: executable evaluate path with strategy-emitted exits + productive exit/PnL evaluator reuse from VCB package (not duplicated). Development evaluation authorized; run counters remain 0 until the single bounded productive evaluation executes; no holdout/runtime/orders; hypothesis parameters unchanged.",
+      "path_prefixes": [
+        "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_entry_point_binding_v1.json",
+        "docs/evidence/evaluate_volatility_decay_breakout_with_explicit_decay_exit_development_v1/",
+        "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+        "scripts/research/run_evaluate_volatility_decay_breakout_with_explicit_decay_exit_development_v1.py",
+        "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_v1/",
+        "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_entry_point_v1.py",
+        "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_executable_path_v1.py",
+        "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_fail_closed_report_v1.py"
+      ]
+    },
+    "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of VDBX explicit-decay-exit successor after terminal VDB UNPAIRABLE_ENTRY_NO_EXIT; frozen decay entry + explicit exit state machine; productive PnL evaluator referenced only; no Development evaluation/holdout/runtime/orders; VDB/VEP/VCB retry forbidden.",
+      "path_prefixes": [
+        "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_hypothesis_preregistration_v1.py",
+        "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_hypothesis_preregistration_v1.py",
+        "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+        "docs/evidence/preregister_volatility_decay_breakout_with_explicit_decay_exit_hypothesis_v1/"
+      ]
+    },
+    "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+      "note": "Strategy + explicit exit state machine for VDBX v1; reuses VDB vol-state/channel core; productive PnL evaluator referenced not duplicated; no evaluation/holdout/runtime/orders; no predecessor artifact mutation.",
+      "path_prefixes": [
+        "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_exit_state_machine_v1.py",
+        "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_v1.py",
+        "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_implementation_binding_v1.py",
+        "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_implementation_binding_v1.json",
+        "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_and_exit_state_machine_v1.py",
+        "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
+      ]
+    },
+    "VOLATILITY_EXPANSION_PERSISTENCE_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_EXPANSION_PERSISTENCE_V1: executable evaluate path with materialized panel execution boundary (loader/wiring/injectable boundary); productive exit/PnL evaluator referenced from VCB package (not duplicated). Development evaluation authorized on HEAD; run counters remain 0 until a separate operator GO executes the single bounded development evaluation; no holdout/runtime/orders; measurement thresholds and strategy/baseline parameters unchanged.",
+      "path_prefixes": [
+        "config/research/volatility_expansion_persistence_v1_development_evaluation_entry_point_binding_v1.json",
+        "docs/evidence/evaluate_volatility_expansion_persistence_development_v1/",
+        "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+        "scripts/research/run_evaluate_volatility_expansion_persistence_development_v1.py",
+        "src/research/volatility_expansion_persistence_v1_development_evaluation_v1/",
+        "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_entry_point_v1.py",
+        "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_executable_path_v1.py",
+        "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_fail_closed_report_v1.py"
+      ]
+    },
+    "VOLATILITY_EXPANSION_PERSISTENCE_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of own-instrument volatility expansion-persistence v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; frozen ATR(14)/close percentile-rank expansion confirmation + persistence window admission, unconditional channel-breakout baseline, event-sufficiency gates; material difference vs terminal VCB-V1 and coiled-spring explicit; development evaluation authorized; evaluation not executed; no holdout/runtime/orders; productive PnL evaluator referenced only.",
+      "path_prefixes": [
+        "config/research/volatility_expansion_persistence_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "src/research/volatility_expansion_persistence_v1_hypothesis_preregistration_v1.py",
+        "tests/research/test_volatility_expansion_persistence_v1_hypothesis_preregistration_v1.py",
+        "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+        "docs/evidence/preregister_volatility_expansion_persistence_hypothesis_v1/"
+      ]
+    },
+    "VOLATILITY_EXPANSION_PERSISTENCE_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+      "note": "Strategy-implementation-only surfaces for VOLATILITY_EXPANSION_PERSISTENCE_V1 (shared 20-bar price-channel core + ATR14/close percentile vol-state + expansion confirmation/persistence admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced not duplicated; no Master-V2/Double-Play/risk/execution mutation.",
+      "path_prefixes": [
+        "src/research/price_channel_breakout_core_v1.py",
+        "src/research/volatility_expansion_persistence_v1_vol_state_v1.py",
+        "src/research/volatility_expansion_persistence_v1_strategy_v1.py",
+        "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
+        "src/research/volatility_expansion_persistence_v1_strategy_implementation_binding_v1.py",
+        "config/research/volatility_expansion_persistence_v1_strategy_implementation_binding_v1.json",
+        "tests/research/test_volatility_expansion_persistence_v1_strategy_implementation_v1.py",
+        "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
+      ]
+    },
+    "VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+      "note": "Definition-only preregistration of VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1 after terminal VCEB FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; expansion then limited pullback continuation + explicit invalidation/time/protective exits; productive PnL evaluator referenced only; measurement contract remains frozen; VCEB/VDBX/VDB/VEP/VCB retry forbidden.",
+      "path_prefixes": [
+        "config/research/volatility_expansion_pullback_continuation_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+        "src/research/volatility_expansion_pullback_continuation_v1_hypothesis_preregistration_v1.py",
+        "tests/research/test_volatility_expansion_pullback_continuation_v1_hypothesis_preregistration_v1.py",
+        "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+        "docs/evidence/preregister_volatility_expansion_pullback_continuation_hypothesis_v1/"
+      ]
+    },
+    "VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+      "note": "Strategy implementation + productive development entry path for VEPC v1; exit SM with pullback-structure invalidation; productive PnL evaluator reused; forensic run-state accounting for technical fail-closed after runner start; no holdout/runtime/orders; no PnL pairing semantics change in accounting fix.",
+      "path_prefixes": [
+        "src/research/volatility_expansion_pullback_continuation_v1_strategy_v1.py",
+        "src/research/volatility_expansion_pullback_continuation_v1_exit_state_machine_v1.py",
+        "src/research/volatility_expansion_pullback_continuation_v1_vol_state_v1.py",
+        "src/research/volatility_expansion_pullback_continuation_v1_strategy_implementation_binding_v1.py",
+        "config/research/volatility_expansion_pullback_continuation_v1_strategy_implementation_binding_v1.json",
+        "src/research/volatility_expansion_pullback_continuation_v1_development_evaluation_v1/",
+        "config/research/volatility_expansion_pullback_continuation_v1_development_evaluation_entry_point_binding_v1.json",
+        "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
+        "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+        "scripts/research/run_evaluate_volatility_expansion_pullback_continuation_development_v1.py",
+        "tests/research/test_volatility_expansion_pullback_continuation_v1_strategy_implementation_v1.py",
+        "tests/research/test_volatility_expansion_pullback_continuation_v1_development_evaluation_entry_point_v1.py",
+        "tests/research/test_volatility_expansion_pullback_continuation_v1_forensic_unpairable_run_state_v1.py"
+      ]
+    },
+    "VOLATILITY_REGIME_HYPOTHESIS_BACKLOG_V1": {
+      "note": "Open backlog SSOT for volatility-regime research program with exactly one definition-only preregistration (VEP-V1) and terminal VCB-V1 FAIL_CLOSED_NO_RETRY; evaluation/holdout/promotion/runtime closed; sibling Entry/Exit and closed CS momentum lanes remain unreopened. Active open preregistration is VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1; VDB terminal.",
+      "path_prefixes": [
+        "config/research/volatility_regime_hypothesis_backlog_v1.json",
+        "src/research/volatility_regime_hypothesis_backlog_v1.py",
+        "tests/research/test_volatility_regime_hypothesis_backlog_v1.py",
+        "docs/governance/VOLATILITY_REGIME_HYPOTHESIS_BACKLOG_V1.md"
+      ]
+    },
+    "VOLATILITY_REGIME_RESEARCH_PROGRAM_V1": {
+      "note": "Definition-only research-program SSOT for operator-authorized volatility-regime expansion-persistence hypothesis VEP-V1; causal independence from closed Bollinger Entry/Exit and CS momentum lanes; material difference vs terminal coiled-spring and terminal VCB-V1; development evaluation authorized (not executed); no holdout/runtime/orders. Active open preregistration is VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1; VDB terminal.",
+      "path_prefixes": [
+        "config/research/volatility_regime_research_program_v1.json",
+        "src/research/volatility_regime_research_program_v1.py",
+        "tests/research/test_volatility_regime_research_program_v1.py",
+        "docs/governance/VOLATILITY_REGIME_RESEARCH_PROGRAM_V1.md"
+      ]
+    },
+    "WALK_FORWARD_MONTE_CARLO_STRESS_AND_PARAMETER_SENSITIVITY": {
+      "path_globs": [
+        "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
+        "tests/research/test_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+        "tests/research/test_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "tests/research/test_offline_parameter_sensitivity_model_spec_alignment_*",
+        "tests/research/test_offline_rolling_linear_drift_diagnostics_v0.py",
+        "tests/research/test_offline_outlier_and_window_robustness_diagnostic_v0.py"
+      ],
+      "path_prefixes": [
+        "src/experiments/monte_carlo.py",
+        "src/experiments/stress_tests.py",
+        "src/experiments/portfolio_robustness.py",
+        "scripts/research/offline_parameter_sensitivity_surface_v0.py",
+        "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+        "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
+        "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
+        "scripts/research/offline_rolling_linear_drift_diagnostics_v0.py",
+        "scripts/research/offline_outlier_and_window_robustness_diagnostic_v0.py"
+      ]
+    }
+  },
+  "forbidden_mutation_surfaces": {
+    "BULL_BEAR_ASSESSMENT": {
+      "description": "Canonical Bull/Bear assessment and state-switch owners",
+      "path_globs": [
+        "tests/trading/master_v2/test_bull_bear_*",
+        "tests/research/test_bull_bear_*",
+        "docs/research/bull_bear_*"
+      ],
+      "path_prefixes": [
+        "src/trading/master_v2/directional_assessment_v1.py",
+        "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
+        "src/research/owner_bindings/bull_bear_state_switch_owner_binding_v0.py"
+      ]
+    },
+    "CAPITAL_RISK_SIZING": {
+      "description": "Capital, risk and position-sizing owners",
+      "path_globs": [
+        "tests/governance/test_capital_risk_sizing_*",
+        "tests/trading/master_v2/test_capital_risk_sizing_*",
+        "tests/trading/master_v2/test_*capital_slot*",
+        "tests/ops/test_master_v2_capital_slot_owner_boundary_*"
+      ],
+      "path_prefixes": [
+        "src/governance/capital_risk_sizing_v1.py",
+        "src/trading/master_v2/double_play_capital_slot.py",
+        "src/trading/master_v2/capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0.py",
+        "src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py",
+        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/capital_risk_sizing.json"
+      ]
+    },
+    "DOUBLE_PLAY_COMPOSITION": {
+      "description": "Double-Play composition and state owners",
+      "path_globs": [
+        "tests/trading/master_v2/test_double_play_*",
+        "docs/ops/specs/MASTER_V2_DOUBLE_PLAY_*",
+        "docs/ops/specs/FUTURES_DOUBLE_PLAY_*"
+      ],
+      "path_prefixes": [
+        "src/trading/master_v2/double_play_composition.py",
+        "src/trading/master_v2/double_play_composition_matrix_v1.py",
+        "src/trading/master_v2/double_play_composition_scenario_matrix_adapter_v0.py",
+        "src/trading/master_v2/double_play_state.py",
+        "src/trading/master_v2/double_play_dashboard_display.py",
+        "src/trading/master_v2/double_play_futures_input_producer.py",
+        "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+        "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py"
+      ]
+    },
+    "ENTRY_POSITION_EXIT_REVERSAL_POLICY": {
+      "description": "Entry, position-management, exit and reversal policy owners",
+      "path_globs": [
+        "tests/trading/master_v2/test_*entry_exit*",
+        "tests/trading/master_v2/test_*survival*",
+        "tests/trading/master_v2/test_*suitability*"
+      ],
+      "path_prefixes": [
+        "src/trading/master_v2/double_play_entry_exit_policy_v0.py",
+        "src/trading/master_v2/double_play_entry_exit_scenario_binding_adapter_v0.py",
+        "src/trading/master_v2/double_play_survival.py",
+        "src/trading/master_v2/double_play_suitability.py",
+        "src/trading/master_v2/survival_assessment_v1.py",
+        "src/trading/master_v2/suitability_binding_v1.py"
+      ]
+    },
+    "KILLSWITCH": {
+      "description": "KillSwitch semantics and binding owners",
+      "path_globs": [
+        "tests/trading/master_v2/test_killswitch_*",
+        "tests/test_backtest_killswitch_*"
+      ],
+      "path_prefixes": [
+        "src/trading/master_v2/killswitch_boundary_backtest_state_file_binding_adapter_v0.py",
+        "src/trading/master_v2/killswitch_boundary_offline_replay_binding_adapter_v0.py",
+        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/killswitch.json",
+        "docs/risk/KILL_SWITCH_RUNBOOK.md"
+      ]
+    },
+    "MASTER_V2": {
+      "description": "All canonical Master V2 trading logic owners",
+      "path_globs": [
+        "tests/trading/master_v2/test_*"
+      ],
+      "path_prefixes": [
+        "src/trading/master_v2/"
+      ]
+    },
+    "PROMOTION_RUNTIME_ORDER_CREDENTIAL_SCHEDULER_AUTHORITY": {
+      "description": "Promotion, runtime, order, credential, scheduler and authority semantics",
+      "path_globs": [
+        "tests/governance/promotion_loop/*",
+        "tests/trading/master_v2/test_promotion_gate_*",
+        "tests/trading/master_v2/test_runtime_bridge_*",
+        "tests/ops/test_master_v2_runtime_governance_boundary_*",
+        "scripts/run_scheduler.py"
+      ],
+      "path_prefixes": [
+        "src/governance/promotion_loop/",
+        "src/trading/master_v2/promotion_gate_boundary_backtest_state_file_binding_adapter_v0.py",
+        "src/trading/master_v2/promotion_gate_boundary_offline_replay_binding_adapter_v0.py",
+        "src/trading/master_v2/runtime_bridge_pre_activation_gate_v0.py",
+        "src/trading/master_v2/runtime_bridge_pre_activation_gate_assessment_v0.py",
+        "src/trading/master_v2/staged_execution_enablement_v1.py",
+        "src/trading/master_v2/canonical_core_runtime_integration_bridge_v0.py",
+        "src/trading/master_v2/canonical_core_runtime_integration_intent_pipeline_bridge_v0.py",
+        "src/trading/master_v2/canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0.py",
+        "src/trading/master_v2/canonical_order_intent_offline_replay_binding_adapter_v0.py",
+        "src/governance/canonical_order_intent_v1.py",
+        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/canonical_order_intent.json"
+      ]
+    },
+    "RECONCILIATION_UNKNOWN_OUTCOME": {
+      "description": "Reconciliation and unknown-outcome semantics",
+      "path_globs": [
+        "tests/trading/master_v2/test_reconciliation_*",
+        "tests/test_backtest_reconciliation_*"
+      ],
+      "path_prefixes": [
+        "src/trading/master_v2/reconciliation_boundary_backtest_state_file_binding_adapter_v0.py",
+        "src/trading/master_v2/reconciliation_unknown_outcome_offline_replay_binding_adapter_v0.py",
+        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/reconciliation.json"
+      ]
+    },
+    "SAFETY_KERNEL": {
+      "description": "Safety kernel semantics and binding owners",
+      "path_globs": [
+        "tests/trading/master_v2/test_safety_kernel_*",
+        "tests/research/test_safety_kernel_*",
+        "scripts/run_independent_pre_trade_safety_kernel_v1.py"
+      ],
+      "path_prefixes": [
+        "src/trading/master_v2/safety_kernel_boundary_backtest_state_file_binding_adapter_v0.py",
+        "src/trading/master_v2/safety_kernel_offline_replay_binding_adapter_v0.py",
+        "src/meta/learning_loop/independent_pre_trade_safety_kernel_v1.py",
+        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/safety_kernel.json"
+      ]
+    },
+    "SCOPE_INITIALIZATION_AND_EVENTS": {
+      "description": "Scope initialization, scope events, adverse-exit and reversal owners",
+      "path_globs": [
+        "tests/trading/master_v2/test_*scope*",
+        "tests/trading/master_v2/test_*reversal*"
+      ],
+      "path_prefixes": [
+        "src/trading/master_v2/canonical_scope_initialization_v1.py",
+        "src/trading/master_v2/deterministic_scope_event_generator_v1.py",
+        "src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py",
+        "src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py",
+        "src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py"
+      ]
+    }
+  },
+  "no_path_guessing": true,
+  "resolution_method": "READ_ONLY_FROM_EXISTING_BOUNDARY_CONTRACTS_AND_PROGRESS_OWNERS",
+  "schema_version": "economic_diagnostic_optimization_boundary_canonical_owner_map_v0",
+  "source_owners": [
+    "tests/ops/test_master_v2_dynamic_scope_owner_boundary_contract_v0.py",
+    "tests/ops/test_master_v2_state_switch_owner_boundary_contract_v0.py",
+    "tests/ops/test_master_v2_capital_slot_owner_boundary_contract_v0.py",
+    "tests/ops/test_master_v2_runtime_governance_boundary_contract_static_v0.py",
+    "tests/governance/test_capital_risk_sizing_mathematics_consolidation_contract_v0.py",
+    "config/research/mv2_backtest_mandatory_boundary_state_files_v0/MANIFEST.json",
+    "docs/governance/PEAK_TRADE_IMPLEMENTATION_CONTRACT.md",
+    "docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.10_IMPLEMENTATION_CONTRACT.md",
+    "config/governance/technical_canonical_wiring_authorization_v1.json"
+  ],
+  "technical_canonical_wiring_authorization": {
+    "authorized_scope_class": "TECHNICAL_CANONICAL_WIRING_ONLY",
+    "contract_path": "config/governance/technical_canonical_wiring_authorization_v1.json",
+    "note": "Narrow fail-closed override for versioned technical wiring paths only; does not waive MASTER_V2_MUTATION_ALLOWED=false."
+  }
 }

--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -1,1298 +1,1280 @@
 {
-  "allowed_optimization_surfaces": {
-    "ADVERSE_EXIT_DOWNSCOPE_DUAL_DIMENSION_RESEARCH_FIXTURE_ALIGN": {
-      "path_globs": [
-        "tests/research/test_adverse_exit_and_reversal_preparation_backtest_parity_narrow_rewire_v0.py",
-        "tests/research/test_adverse_exit_and_reversal_preparation_backtest_parity_wiring_assessment_or_narrow_rewire_v0.py",
-        "tests/research/test_adverse_scope_exit_reversal_preparation_narrow_reuse_first_rewire_v0.py",
-        "tests/research/test_scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py",
-        "tests/research/test_scope_adverse_exit_reversal_backtest_runtime_decision_parity_pass_assertion_surface_only_v0.py"
-      ],
-      "path_prefixes": [
-        "scripts/research/adverse_exit_and_reversal_preparation_backtest_parity_narrow_rewire_v0.py",
-        "scripts/research/adverse_scope_exit_reversal_preparation_narrow_reuse_first_rewire_v0.py",
-        "scripts/research/scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py"
-      ]
+    "allowed_optimization_surfaces": {
+        "ADVERSE_EXIT_DOWNSCOPE_DUAL_DIMENSION_RESEARCH_FIXTURE_ALIGN": {
+            "path_globs": [
+                "tests/research/test_adverse_exit_and_reversal_preparation_backtest_parity_narrow_rewire_v0.py",
+                "tests/research/test_adverse_exit_and_reversal_preparation_backtest_parity_wiring_assessment_or_narrow_rewire_v0.py",
+                "tests/research/test_adverse_scope_exit_reversal_preparation_narrow_reuse_first_rewire_v0.py",
+                "tests/research/test_scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py",
+                "tests/research/test_scope_adverse_exit_reversal_backtest_runtime_decision_parity_pass_assertion_surface_only_v0.py",
+            ],
+            "path_prefixes": [
+                "scripts/research/adverse_exit_and_reversal_preparation_backtest_parity_narrow_rewire_v0.py",
+                "scripts/research/adverse_scope_exit_reversal_preparation_narrow_reuse_first_rewire_v0.py",
+                "scripts/research/scope_adverse_exit_and_reversal_preparation_narrow_reuse_first_rewire_v0.py",
+            ],
+        },
+        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+            "note": "Single preregistered DEVELOPMENT-only offline evaluation of Wilder ADX(14) +DI/−DI direction-confirmation pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=PASS, ALL_PASS_REQUIRES_MET); research-only entry-eligibility gate; economic offline gate remains closed; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+            "path_prefixes": [
+                "src/research/adx_di_direction_confirmation_mr_eligibility_development_evaluation_v1/",
+                "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_development_v1.py",
+                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_development_evaluation_v1.py",
+                "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_development_v1/",
+                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
+            ],
+        },
+        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_EVALUATION_V1": {
+            "note": "Single authorized HOLDOUT evaluation of Wilder ADX(14) +DI/-DI direction-confirmation MR eligibility versus immutable bollinger baseline on the sealed FINAL_AUDIT panel (holdout_run_count 1/1, RESULT_CLASS=ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN after MV2 replay signal-index mismatch); no retry/post-result tuning; economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+            "path_prefixes": [
+                "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v1/",
+                "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v1.py",
+                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v1.py",
+                "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v1/",
+                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md",
+            ],
+        },
+        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_EVALUATION_V2": {
+            "note": "Single authorized HOLDOUT v2 evaluation of Wilder ADX(14) +DI/-DI direction-confirmation MR eligibility versus immutable bollinger baseline on the sealed FINAL_AUDIT panel (holdout_run_count 1/1, RESULT_CLASS=FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED); new evaluation ID not a V1 rerun; economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+            "path_prefixes": [
+                "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v2/",
+                "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v2.py",
+                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v2.py",
+                "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v2/",
+                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V2.md",
+            ],
+        },
+        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only holdout preregistration for ADX DI direction-confirmation MR eligibility after DEVELOPMENT PASS; freezes sealed FINAL_AUDIT holdout split digest from existing SSOT registry metadata, acceptance criteria, run-limit=1, and execution-GO gate; no holdout data access, no backtest, no economic metrics, no productive authority mutation.",
+            "path_prefixes": [
+                "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v1.py",
+                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v1.py",
+                "config/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistered_measurement_contract_v1.json",
+                "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_holdout_v1/",
+                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md",
+            ],
+        },
+        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V2": {
+            "note": "Holdout preregistration v2 for ADX DI direction-confirmation MR eligibility; evaluation executed and terminal as FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); V1 remains terminal ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN; no productive authority mutation.",
+            "path_prefixes": [
+                "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v2.py",
+                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v2.py",
+                "config/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistered_measurement_contract_v2.json",
+                "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_holdout_v2/",
+                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V2.md",
+            ],
+        },
+        "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of a single Wilder ADX(14) +DI/−DI direction-confirmation pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to six prior FAILs (regime, ATR, RSI, ADX-level, MA, MACD); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+            "path_prefixes": [
+                "src/research/adx_di_direction_confirmation_mr_eligibility_hypothesis_preregistration_v1.py",
+                "tests/research/test_adx_di_direction_confirmation_mr_eligibility_hypothesis_preregistration_v1.py",
+                "config/research/adx_di_direction_confirmation_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_hypothesis_v1/",
+                "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+            ],
+        },
+        "ADX_RANGE_ADMISSION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+            "note": "Single preregistered DEVELOPMENT-only offline evaluation of ADX(14) range-admission pre-entry MR eligibility filter versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+            "path_prefixes": [
+                "src/research/adx_range_admission_mr_eligibility_development_evaluation_v1/",
+                "scripts/research/run_evaluate_adx_range_admission_mr_eligibility_development_v1.py",
+                "tests/research/test_adx_range_admission_mr_eligibility_development_evaluation_v1.py",
+                "docs/evidence/evaluate_adx_range_admission_mr_eligibility_development_v1/",
+                "docs/governance/ADX_RANGE_ADMISSION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
+            ],
+        },
+        "ADX_RANGE_ADMISSION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of a single ADX(14) range-admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to failed regime-gated, ATR-percentile, and RSI-exhaustion mechanisms; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+            "path_prefixes": [
+                "src/research/adx_range_admission_mr_eligibility_hypothesis_preregistration_v1.py",
+                "tests/research/test_adx_range_admission_mr_eligibility_hypothesis_preregistration_v1.py",
+                "config/research/adx_range_admission_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "docs/evidence/preregister_adx_range_admission_mr_eligibility_hypothesis_v1/",
+                "docs/governance/ADX_RANGE_ADMISSION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+            ],
+        },
+        "BOLLINGER_MR_ECONOMIC_FAILURE_DECOMPOSITION_DEVELOPMENT_V1": {
+            "note": "Canonical development-only read-only economic failure decomposition of the immutable Bollinger/MR baseline on the sealed DEVELOPMENT_ONLY panel; diagnostic classification only; no new hypothesis; no holdout access; no Economic/Promotion gate open; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders.",
+            "path_prefixes": [
+                "config/research/bollinger_mr_economic_failure_decomposition_development_v1.json",
+                "src/research/bollinger_mr_economic_failure_decomposition_development_v1/",
+                "scripts/research/run_bollinger_mr_economic_failure_decomposition_development_v1.py",
+                "tests/research/test_bollinger_mr_economic_failure_decomposition_development_v1.py",
+                "docs/governance/BOLLINGER_MR_ECONOMIC_FAILURE_DECOMPOSITION_DEVELOPMENT_V1.md",
+                "docs/evidence/bollinger_mr_economic_failure_decomposition_development_v1/",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V1": {
+            "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR side-aware middle-band exit-efficiency versus immutable bollinger baseline on sealed DEVELOPMENT panel (evaluation_run_count 0->1); Economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders. Gate-binding contract test covers MV2 wiring_mod capture-alias open_side binding only.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1/",
+                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v1.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v1.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_gate_binding_v1.py",
+                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v1/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V1.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V2": {
+            "note": "Terminal DEVELOPMENT_ONLY evaluation closeout for hypothesis ...DEVELOPMENT_V2 (evaluation_run_count 0->1 exactly once; RESULT_CLASS=INCONCLUSIVE_INFRASTRUCTURE_FAILURE; ROOT_CAUSE=PREMEASUREMENT_GATE_FALSE_POSITIVE_ZERO_OR_SENTINEL); reuses frozen V1 mechanism/gate/decision by import only; not a V1 rerun; no V1 partial-result reuse; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders; no V2 rerun.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v2/",
+                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v2.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v2.py",
+                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v2/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V2.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V3": {
+            "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V3 (evaluation_run_count 0->1); identical definition to V2/V1; binds EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 and PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE; not a V1/V2 rerun; no V2 partial-result reuse; Economic offline gate closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v3/",
+                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v3.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v3.py",
+                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v3/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V3.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4": {
+            "note": "Definition-only evaluation surface for exactly one future DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V4; reuses frozen V1 mechanism/gate/decision by import; binds measurement-validity preflight, EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1, PANEL_RUNNER_FALSY_ZERO hygiene, and MV2_WIRING_MOD_CAPTURE_ALIAS_OPEN_SIDE_BINDING_FIX; V4 contract remains DEFINITION_ONLY_PREREGISTERED with evaluation_run_count=0 in this slice; no evaluation executed here; evidence directory created only by a future authorized run; not a V1/V2/V3 rerun; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/",
+                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v4.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v4.py",
+                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v4/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5": {
+            "note": "Terminal DEVELOPMENT evaluation closeout for Bollinger/MR midband exit-efficiency V5 after one authorized run (0→1): RESULT_CLASS=INFRASTRUCTURE_FAILURE; DIAGNOSTIC_CLASS=PROCESS_DIED_INCOMPLETE_PANEL_RUN_NO_LIFECYCLE_TERMINAL; baseline 3/46; not a V4/V3/V2/V1 rerun; no V4 partial-result reuse; no holdout/runtime/orders; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no V5 rerun. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v5/",
+                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v5.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v5.py",
+                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v5/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6": {
+            "note": "Terminal DEVELOPMENT evaluation closeout for Bollinger/MR composite exit-efficiency V6 after one authorized run (0→1): RESULT_CLASS=FAIL; REASON=NET_PROFIT_FACTOR_NOT_IMPROVED; exit divergence observed; treatment binding confirmed; not a V5/V4/V3/V2/V1 rerun; no V5 partial-result reuse; no holdout/runtime/orders; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no V6 rerun. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v6/",
+                "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v6.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v6.py",
+                "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v6/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of a single DEVELOPMENT_ONLY Bollinger/MR side-aware middle-band exit-efficiency measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v1.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v1.py",
+                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v1/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V2": {
+            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V2 with identical definition semantics to terminal V1; EVALUATION_RUN_COUNT=0; not a V1 rerun; no V1 partial-result reuse; mandatory EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 binding; no evaluation/runtime/orders.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v2.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v2.py",
+                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v2.json",
+                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v2/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V2.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V3": {
+            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V3 with identical economic/definition semantics to terminal V2/V1; EVALUATION_RUN_COUNT=0; not a V2 or V1 rerun; no V2 partial-result or economic-result import; mandatory EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 and PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE bindings; V2 remains terminal INCONCLUSIVE_INFRASTRUCTURE_FAILURE run count 1; no evaluation/runtime/orders.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v3.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v3.py",
+                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v3.json",
+                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v3/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V3.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V4": {
+            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V4 after terminal V3 FAIL; EVALUATION_RUN_COUNT=0; presupposes merged MV2 wiring_mod capture-alias open_side binding fix; fail-closed measurement-validity gates (effective config digest inequality, open_side binding, exit observability, synthetic divergence); not a V3/V2/V1 rerun; no evaluation/runtime/orders.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v4.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v4.py",
+                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v4.json",
+                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v4/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V4.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V5": {
+            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V5 after terminal V4 INFRASTRUCTURE_FAILURE; EVALUATION_RUN_COUNT=0; preserves V4 economic hypothesis/exit mechanism; adds process-lifecycle checkpoint observability; not a V4/V3/V2/V1 rerun; no evaluation/runtime/orders.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v5.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v5.py",
+                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v5.json",
+                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v5/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V5.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V6": {
+            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V6 after terminal V5 INFRASTRUCTURE_FAILURE; EVALUATION_RUN_COUNT=0; genuine economic change vs V5 (midband-cross OR frozen max-holding-horizon=48h); reuses V5 process-lifecycle checkpoint; not a V5/V4/V3/V2/V1 rerun; no V5 partial metrics; no evaluation/runtime/orders.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v6.py",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v6.py",
+                "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v6.json",
+                "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v6/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V6.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PROCESS_LIFECYCLE_CHECKPOINT_V5": {
+            "note": "Definition-only process-lifecycle checkpoint scaffold for V5: monotonic lifecycle states, atomic checkpoints, read-only recovery diagnostics; import cannot start runner; checkpoints cannot reclaim run slots or authorize automatic reruns; partial metrics non-authoritative.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_efficiency_process_lifecycle_checkpoint_v5/",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_process_lifecycle_checkpoint_v5.py",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_V6_FAILURE_ATTRIBUTION": {
+            "note": "Evidence-only read-only failure attribution for terminal V6 FAIL (NET_PROFIT_FACTOR_NOT_IMPROVED). No evaluation/backtest/panel/holdout access; does not mutate V6 artifacts/run count; does not preregister or authorize V7; no promotion/runtime/orders; no Master-V2/Double-Play/risk/sizing/execution mutation.",
+            "path_prefixes": [
+                "docs/evidence/attribute_bollinger_mr_midband_exit_efficiency_v6_failure/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_V6_FAILURE_ATTRIBUTION.md",
+                "tests/research/test_bollinger_mr_midband_exit_efficiency_v6_failure_attribution.py",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V7": {
+            "note": "Separate Operator ratification authorizing exactly one later V7 DEVELOPMENT evaluation run; does not mutate preregistration digest/field; requires released DEVELOPMENT panel; does not start runner or claim slot.",
+            "path_prefixes": [
+                "config/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.json",
+                "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.py",
+                "scripts/research/run_authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7.py",
+                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.py",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V7.md",
+                "docs/evidence/authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7/",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V8": {
+            "note": "Separate Operator ratification surface authorizing exactly one later V8 DEVELOPMENT evaluation run; requires pre-authorization parity PASS and released DEVELOPMENT panel; does not start runner or claim slot in wiring slice.",
+            "path_prefixes": [
+                "config/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.json",
+                "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.py",
+                "scripts/research/run_authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8.py",
+                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.py",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V8.md",
+                "docs/evidence/authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8/",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V7": {
+            "note": "V7 reentry-cooldown DEVELOPMENT evaluation surfaces; single authorized evaluate process consumed slot and terminated INCONCLUSIVE_INFRASTRUCTURE_FAILURE (PRE_PANEL_FROZEN_EXIT_PARAMETERS_MISMATCH_NO_PANEL_BACKTEST); no rerun; no holdout.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7/",
+                "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v7.py",
+                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7.py",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V7.md",
+                "docs/evidence/preflight_bollinger_mr_midband_exit_reentry_cooldown_v7_wiring/",
+                "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v7/",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V8": {
+            "note": "V8 reentry-cooldown DEVELOPMENT evaluation wiring; pre-authorization parity before auth/slot; EVALUATION_RUN_COUNT=0; default CLI preflight-only; evaluate requires ratification+flag; evaluate evidence not pre-created; no evaluation/runtime/orders; V7 terminal unreopened.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8/",
+                "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v8.py",
+                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8.py",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V8.md",
+                "docs/evidence/preflight_bollinger_mr_midband_exit_reentry_cooldown_v8_wiring/",
+                "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v8/",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_EVALUATION_V1": {
+            "note": "Single authorized HOLDOUT_V1 evaluation of frozen Exit V8 midband reentry-cooldown treatment on sealed FINAL_AUDIT panel; terminal FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); economic/promotion/runtime/orders closed; V7/V8 terminals unchanged.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_evaluation_v1/",
+                "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1.py",
+                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_holdout_evaluation_v1.py",
+                "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_EVALUATION_V1.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Holdout confirmation preregistration of frozen V8 midband exit reentry-cooldown (hypothesis HOLDOUT_V1; digest a0658fe3fb883939ed2a2de2c426f2e4edf21eeeb91d1b902d45b4d05a38fd1d); evaluation executed terminal FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); V8 digest immutable; no second run; no runtime/orders.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistration_v1.py",
+                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistration_v1.py",
+                "config/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistered_measurement_contract_v1.json",
+                "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V7": {
+            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit reentry-cooldown V7 after terminal V6 FAIL + evidence-only attribution; EVALUATION_RUN_COUNT=0; control=exact V6 semantics; treatment=same-side reentry cooldown 24h after forced midband; not a V6 rerun; no V6 partial import; no evaluation/runtime/orders.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v7.py",
+                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v7.py",
+                "config/research/bollinger_mr_midband_exit_reentry_cooldown_preregistered_economic_hypothesis_measurement_contract_v7.json",
+                "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_v7/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V7.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V8": {
+            "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit reentry-cooldown V8 after terminal V7 INCONCLUSIVE_INFRASTRUCTURE_FAILURE (FROZEN_EXIT_PARAMETERS_MISMATCH); EVALUATION_RUN_COUNT=0; control=exact V6 semantics; treatment=same-side reentry cooldown 24h; complete exit_mechanism.frozen_parameters SSOT; pre-authorization parity validator; not a V7 reopen/retry; no evaluation/runtime/orders.",
+            "path_prefixes": [
+                "src/research/bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v8.py",
+                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v8.py",
+                "config/research/bollinger_mr_midband_exit_reentry_cooldown_preregistered_economic_hypothesis_measurement_contract_v8.json",
+                "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_v8/",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V8.md",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V7": {
+            "note": "Governance overlay clarifying V7 implementation ambiguities B1-B6 without mutating immutable preregistration digest; operator_decisions_status OPERATOR_DECISIONS_RECORDED_IMPLEMENTATION_ONLY; lifecycle may transition READY_FOR_OPERATOR_EVALUATION_AUTHORIZATION -> EVALUATION_AUTHORIZED via separate ratification; evaluation_run_count=0 until run GO; no runtime/orders.",
+            "path_prefixes": [
+                "config/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.json",
+                "src/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.py",
+                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.py",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V7.md",
+                "docs/evidence/operator_clarification_bollinger_mr_midband_exit_reentry_cooldown_v7/",
+            ],
+        },
+        "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V8": {
+            "note": "Governance overlay clarifying V8 B1-B6 without mutating immutable preregistration digest; lifecycle READY_FOR_OPERATOR_EVALUATION_AUTHORIZATION; evaluation_authorized=false until separate ratification; evaluation_run_count=0; no runtime/orders.",
+            "path_prefixes": [
+                "config/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.json",
+                "src/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.py",
+                "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.py",
+                "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V8.md",
+                "docs/evidence/operator_clarification_bollinger_mr_midband_exit_reentry_cooldown_v8/",
+            ],
+        },
+        "CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1": {
+            "note": "Canonical SSOT backlog for open MR entry-eligibility hypotheses; explicit operator CLOSE_LANE_NO_FURTHER_RESEARCH under shared research-lane post-terminal lifecycle contract V1 (status=LANE_CLOSED_NO_FURTHER_RESEARCH; explicit_closeout_decision=true; lane_auto_closed=false); inventories empty; historical terminals immutable; no runtime/orders.",
+            "path_prefixes": [
+                "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json",
+                "src/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
+                "tests/research/test_canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
+                "docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md",
+            ],
+        },
+        "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1": {
+            "note": "Canonical SSOT backlog for open MR exit-efficiency hypotheses; explicit operator CREATE_SUCCESSOR_HYPOTHESIS under shared lifecycle contract V1 after V8 TERMINAL_PASS (status=OPEN_BACKLOG; holdout successor HOLDOUT_V1 DEFINITION_ONLY_PREREGISTERED; digest a0658fe3fb883939ed2a2de2c426f2e4edf21eeeb91d1b902d45b4d05a38fd1d); V8 identity unreopened; holdout execution unauthorized; Entry sibling LANE_CLOSED_NO_FURTHER_RESEARCH; Economic/promotion closed; no runtime/orders.",
+            "path_prefixes": [
+                "config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json",
+                "src/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py",
+                "tests/research/test_canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py",
+                "docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md",
+            ],
+        },
+        "CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1": {
+            "note": "Shared definition-only research-lane post-terminal lifecycle contract; canonical lane-state vocabulary, totality invariant, operator-decision contract, and historical-immutability/live-mirror policy. Entry-Eligibility and Exit-Efficiency backlog SSOTs migrate in separate operator-authorized slices; no evaluation/runtime/orders.",
+            "path_prefixes": [
+                "config/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.json",
+                "src/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.py",
+                "tests/research/test_canonical_research_lane_post_terminal_lifecycle_contract_v1.py",
+                "docs/governance/CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1.md",
+            ],
+        },
+        "COST_MODEL_DIAGNOSTICS": {
+            "path_globs": [
+                "tests/research/test_offline_linear_cost_model_diagnostics_*",
+                "tests/research/test_offline_signal_orthogonality_diagnostics_*",
+                "tests/research/test_offline_productive_signal_orthogonality_results_interpretation_v0.py",
+                "tests/research/test_offline_productive_factor_exposure_diagnostics_v0.py",
+                "tests/research/test_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+                "tests/research/test_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+                "tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py",
+                "tests/research/test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+                "tests/research/test_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+                "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
+                "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
+                "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+                "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+                "tests/research/test_offline_factor_exposure_diagnostics_*",
+                "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
+                "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
+                "tests/research/test_offline_final_research_fleet_signal_matrix_productive_input_join_materializer_*",
+                "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
+                "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_*",
+                "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
+                "tests/research/test_offline_parameter_sensitivity_model_spec_alignment_*",
+                "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*",
+                "tests/research/test_offline_rolling_linear_drift_diagnostics_v0.py",
+                "tests/research/test_offline_outlier_and_window_robustness_diagnostic_v0.py",
+                "tests/research/test_linear_evidence_*",
+            ],
+            "path_prefixes": [
+                "src/research/linear_evidence/cost_model.py",
+                "src/research/linear_evidence/diagnostics.py",
+                "src/research/linear_evidence/fitters.py",
+                "src/research/linear_evidence/drift.py",
+                "src/research/linear_evidence/window_robustness.py",
+                "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
+                "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
+                "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+                "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
+                "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
+                "scripts/research/offline_linear_cost_model_diagnostics_v0.py",
+                "scripts/research/offline_signal_orthogonality_diagnostics_v0.py",
+                "scripts/research/offline_factor_exposure_diagnostics_v0.py",
+                "scripts/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+                "scripts/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
+                "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
+                "scripts/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
+                "scripts/research/offline_rolling_linear_drift_diagnostics_v0.py",
+                "scripts/research/offline_outlier_and_window_robustness_diagnostic_v0.py",
+                "scripts/ops/materialize_offline_productive_signal_orthogonality_results_interpretation_v0.py",
+                "scripts/ops/materialize_offline_productive_factor_exposure_diagnostics_v0.py",
+                "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+                "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+                "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
+                "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+                "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+                "scripts/ops/materialize_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
+                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+                "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
+                "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
+                "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
+                "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+                "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+                "src/research/linear_evidence/offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+            ],
+        },
+        "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+            "note": "DEVELOPMENT evaluation entry point/owner for CS relative-strength momentum v1: executable evaluate path under fail-closed authorization, CLI preflight/dry-validate, digests/dataset/time-segment/rebalance-observation/evidence-registry/admission gates, wiring into canonical single-slot backtest metrics owners. Development evaluation authorized on HEAD; no runner start/run-slot consumption without separate execution GO; no holdout/runtime/orders; measurement thresholds and strategy score/selection semantics unchanged.",
+            "path_prefixes": [
+                "config/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_binding_v1.json",
+                "docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/",
+                "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+                "scripts/research/run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py",
+                "src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/",
+                "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_v1.py",
+                "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_executable_path_v1.py",
+                "tests/research/test_cross_sectional_relative_strength_momentum_v1_panel_loader_alignment_repair_v1.py",
+            ],
+        },
+        "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of cross-sectional relative-strength momentum v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; directional form D mutually exclusive single-slot selection; bounded DEV grid frozen; operator-authorized robustness thresholds (minimum_rebalance_observations=30, time_segment_robustness_pass_ratio=0.5) and CHRONOLOGICAL_EQUAL_DURATION_QUARTERS_V1 bound; development evaluation authorized; evaluation not executed; no holdout/runtime/orders; closed Entry/Exit Bollinger lanes untouched.",
+            "path_prefixes": [
+                "config/research/cross_sectional_relative_strength_momentum_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "src/research/cross_sectional_relative_strength_momentum_v1_hypothesis_preregistration_v1.py",
+                "tests/research/test_cross_sectional_relative_strength_momentum_v1_hypothesis_preregistration_v1.py",
+                "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+                "docs/evidence/preregister_cross_sectional_relative_strength_momentum_hypothesis_v1/",
+            ],
+        },
+        "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+            "note": "Strategy-implementation-only surfaces for CS relative-strength momentum v1 (raw trailing log-return score + single-top1 rank-intent selection + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; no Master-V2/Double-Play mutation.",
+            "path_prefixes": [
+                "src/research/cross_sectional_relative_strength_momentum_v1_score_v1.py",
+                "src/research/cross_sectional_relative_strength_momentum_v1_selection_v1.py",
+                "src/research/cross_sectional_relative_strength_momentum_v1_strategy_implementation_binding_v1.py",
+                "config/research/cross_sectional_relative_strength_momentum_v1_strategy_implementation_binding_v1.json",
+                "tests/research/test_cross_sectional_relative_strength_momentum_v1_score_and_selection_v1.py",
+                "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
+            ],
+        },
+        "DATA_BINDING_REPAIR": {
+            "path_prefixes": [
+                "src/research/offline_source_evidence_",
+                "scripts/research/offline_source_evidence_",
+            ]
+        },
+        "DETERMINISTIC_MATERIALIZATION_REPAIR": {
+            "path_prefixes": [
+                "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
+                "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+                "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
+                "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
+                "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
+                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
+                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
+                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
+            ]
+        },
+        "DIGEST_BINDING_AND_PROVENANCE_REPAIR": {
+            "path_globs": ["scripts/ops/*digest*", "scripts/ops/*binding*"],
+            "path_prefixes": ["scripts/ops/primary_evidence_retention_v0.py"],
+        },
+        "DOUBLE_PLAY_COMPOSITION_NARROW_RESEARCH_REWIRE": {
+            "path_globs": [
+                "tests/research/test_double_play_composition_narrow_reuse_first_rewire_v0.py"
+            ],
+            "path_prefixes": [
+                "scripts/research/double_play_composition_narrow_reuse_first_rewire_v0.py"
+            ],
+        },
+        "ENTRY_EFFECTIVE_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+            "note": "Single preregistered DEVELOPMENT-only offline evaluation of entry-effective pre-entry ATR-percentile mid-band MR eligibility filter (STRICT bounds) versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of the prior failed regime_gated evaluation's shared_portfolio_equity_research_v1 helper only (no mutation of that package); no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+            "path_prefixes": [
+                "src/research/entry_effective_mr_eligibility_development_evaluation_v1/",
+                "scripts/research/run_evaluate_entry_effective_mr_eligibility_development_v1.py",
+                "tests/research/test_entry_effective_mr_eligibility_development_evaluation_v1.py",
+                "docs/evidence/evaluate_entry_effective_mr_eligibility_development_v1/",
+                "docs/governance/ENTRY_EFFECTIVE_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
+            ],
+        },
+        "ENTRY_EFFECTIVE_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of a single entry-effective pre-entry ATR-percentile MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+            "path_prefixes": [
+                "src/research/entry_effective_mr_eligibility_hypothesis_preregistration_v1.py",
+                "tests/research/test_entry_effective_mr_eligibility_hypothesis_preregistration_v1.py",
+                "config/research/entry_effective_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "docs/evidence/preregister_entry_effective_mr_eligibility_hypothesis_v1/",
+                "docs/governance/ENTRY_EFFECTIVE_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+            ],
+        },
+        "EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1": {
+            "note": "Generic research-infrastructure observability for evaluation-runner process death (atomic heartbeat/progress, catchable signal handlers, exit/signal normalization, supervised child reap, INCONCLUSIVE_INFRASTRUCTURE_FAILURE classification without auto-rerun); no strategy/Master-V2/Double-Play/risk/sizing/execution/economic semantics mutation; no evaluation rerun; no holdout access; no runtime/orders.",
+            "path_prefixes": [
+                "src/research/evaluation_runner_lifecycle_observability_v1/",
+                "tests/research/test_evaluation_runner_lifecycle_observability_v1.py",
+                "docs/evidence/evaluation_runner_lifecycle_observability_v1/",
+            ],
+        },
+        "EXPLICITLY_CALIBRATABLE_RESEARCH_PARAMETERS_WITHIN_PREDECLARED_RANGES": {
+            "path_prefixes": [
+                "src/research/linear_evidence/sensitivity.py",
+                "src/research/linear_evidence/drift.py",
+                "src/research/linear_evidence/window_robustness.py",
+                "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
+                "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
+                "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
+                "scripts/research/offline_parameter_sensitivity_surface_v0.py",
+                "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
+                "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+                "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+            ]
+        },
+        "FEATURE_SCALING_OR_NUMERICAL_CONDITIONING_WITHOUT_TRADING_SEMANTIC_EFFECT": {
+            "path_prefixes": [
+                "src/research/linear_evidence/feature_matrix.py",
+                "src/research/linear_evidence/contracts.py",
+                "src/research/linear_evidence/signal_orthogonality.py",
+                "src/research/linear_evidence/signal_orthogonality_results_interpretation_v0.py",
+                "src/research/linear_evidence/offline_productive_factor_exposure_diagnostics_v0.py",
+                "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
+                "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
+                "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
+                "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+                "src/research/linear_evidence/offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+                "src/research/linear_evidence/factor_exposure.py",
+                "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
+                "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
+                "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
+                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
+                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
+                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
+            ]
+        },
+        "GOVERNANCE_ONLY_OPERATOR_RATIFICATION_AND_RESEARCH_SCOPE_DEFINITION_WITHOUT_TRADING_SEMANTIC_EFFECT": {
+            "note": "Governance-only operator ratification and research scope definition without trading semantic mutation or runtime authority.",
+            "path_globs": [
+                "src/research/*terminal_inconclusive_insufficient_sample_and_distinct_futures_research_scope_definition_v0.py",
+                "src/research/*terminal_insufficient_sample_and_distinct_futures_research_scope_ratification_v0.py",
+                "src/research/*research_scope_ratification_v0.py",
+                "src/research/*versioned_hypothesis_binding_v0.py",
+                "src/research/*versioned_research_binding_v0.py",
+                "src/research/*score_and_ranking_contract_v0.py",
+                "src/research/*portfolio_binding_v0.py",
+                "src/research/cross_sectional_futures_pairwise_lead_lag_spillover_*_score_v0.py",
+                "scripts/research/materialize_*operator_ratification*",
+                "scripts/research/materialize_*scope_ratification*",
+                "scripts/research/materialize_*terminal_*research_scope*",
+                "scripts/research/materialize_*versioned_hypothesis_binding_v0.py",
+                "scripts/research/materialize_*versioned_research_binding_v0.py",
+                "scripts/research/materialize_*score_and_ranking_contract_v0.py",
+                "scripts/research/materialize_*portfolio_binding_implementation_v0.py",
+                "scripts/research/materialize_*offline_economic_evaluation_authorization_ratification_v0.py",
+                "src/research/*offline_economic_evaluation_authorization_ratification_v0.py",
+                "src/research/full_canonical_system_economic_evidence_generation_v1.py",
+                "scripts/research/materialize_full_canonical_system_economic_evidence_generation_v1_binding_ratification_v0.py",
+                "tests/research/test_*versioned_hypothesis_binding_v0_contract.py",
+                "tests/research/test_*versioned_research_binding_v0_contract.py",
+                "tests/research/test_*score_and_ranking_contract_v0_contract.py",
+                "tests/research/test_*portfolio_binding_implementation_v0_contract.py",
+                "tests/research/test_*offline_economic_evaluation_authorization_ratification_v0_contract.py",
+                "tests/research/test_full_canonical_system_economic_evidence_generation_v1_binding_ratification_v0_contract.py",
+                "config/research/*governance_closeout_v0.json",
+                "docs/governance/*GOVERNANCE_CLOSEOUT_V0.md",
+                "tests/ops/test_*governance_closeout_v0_contract.py",
+            ],
+        },
+        "INDEPENDENT_DEV_PANEL_QUARANTINE_RELEASE_V1": {
+            "note": "Byte-identical quarantine to RELEASED_DEVELOPMENT_ONLY panel release; no transform; no holdout; does not authorize evaluation.",
+            "path_prefixes": [
+                "config/research/independent_dev_panel_quarantine_release_contract_v1.json",
+                "src/research/independent_dev_panel_quarantine_release_v1.py",
+                "scripts/research/run_release_independent_dev_panel_quarantine_v1.py",
+                "tests/research/test_independent_dev_panel_quarantine_release_v1.py",
+                "docs/governance/INDEPENDENT_DEV_PANEL_QUARANTINE_RELEASE_V1.md",
+                "docs/evidence/release_independent_dev_panel_quarantine_byte_identical_v1/",
+            ],
+        },
+        "LONGER_CHRONOLOGICAL_PIT_PUBLIC_HISTORY_ACQUISITION_SCAFFOLD_AND_DEPTH_PROBE_V1": {
+            "note": "Research-only public OKX history acquisition scaffold, bounded history-depth probe, sealed production-lifecycle long-panel binding/acquisition, and independent pre-holdout development-panel seal; dry-run/no-credentials defaults; no economic optimization; no strategy/risk/execution/Master-V2/Double-Play mutation.",
+            "path_prefixes": [
+                "src/research/longer_chronological_pit_acquisition_v1/",
+                "tests/research/test_longer_chronological_pit_acquisition_scaffold_v1.py",
+                "tests/research/test_longer_chronological_pit_okx_history_depth_probe_v1.py",
+                "tests/research/test_longer_chronological_pit_sealed_lifecycle_acquisition_v1.py",
+                "config/research/longer_chronological_pit_acquisition_chrono_3y_v1.json",
+                "config/research/longer_chronological_pit_sealed_lifecycle_long_panel_v1.json",
+                "config/research/regime_gated_standaside_mr_independent_dev_panel_acquisition_contract_v1.json",
+                "config/research/regime_gated_standaside_mr_independent_dev_panel_seal_registry_v1.json",
+                "docs/evidence/longer_chronological_pit_sealed_lifecycle_acquisition_v1/",
+                "docs/evidence/acquire_and_seal_okx_independent_dev_panel_v1/",
+                "docs/governance/REGIME_GATED_STANDASIDE_MR_INDEPENDENT_DEV_PANEL_SEALED_V1.md",
+                "tests/governance/test_acquire_and_seal_okx_independent_dev_panel_v1.py",
+            ],
+        },
+        "MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+            "note": "Single preregistered DEVELOPMENT-only offline evaluation of MACD(12,26,9) histogram-sign countertrend pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=FAIL, NET_PROFIT_FACTOR_NOT_IMPROVED); research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+            "path_prefixes": [
+                "src/research/macd_histogram_countertrend_mr_eligibility_development_evaluation_v1/",
+                "scripts/research/run_evaluate_macd_histogram_countertrend_mr_eligibility_development_v1.py",
+                "tests/research/test_macd_histogram_countertrend_mr_eligibility_development_evaluation_v1.py",
+                "docs/evidence/evaluate_macd_histogram_countertrend_mr_eligibility_development_v1/",
+                "docs/governance/MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
+            ],
+        },
+        "MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of a single MACD(12,26,9) histogram-sign countertrend admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to five prior FAILs (regime, ATR, RSI, ADX, MA); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+            "path_prefixes": [
+                "src/research/macd_histogram_countertrend_mr_eligibility_hypothesis_preregistration_v1.py",
+                "tests/research/test_macd_histogram_countertrend_mr_eligibility_hypothesis_preregistration_v1.py",
+                "config/research/macd_histogram_countertrend_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "docs/evidence/preregister_macd_histogram_countertrend_mr_eligibility_hypothesis_v1/",
+                "docs/governance/MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+            ],
+        },
+        "MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_HYPOTHESIS_BACKLOG_V1": {
+            "note": "Closed lane SSOT for material-different cross-sectional momentum program after CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1 FAIL_CLOSED_NO_RETRY; inventories empty of open/preregistered candidates; terminal hypothesis recorded; no successor; retry/reopen forbidden; evaluation/holdout/promotion/runtime closed; sibling Entry/Exit lanes remain LANE_CLOSED_NO_FURTHER_RESEARCH unreopened.",
+            "path_prefixes": [
+                "config/research/material_different_cross_sectional_momentum_hypothesis_backlog_v1.json",
+                "src/research/material_different_cross_sectional_momentum_hypothesis_backlog_v1.py",
+                "tests/research/test_material_different_cross_sectional_momentum_hypothesis_backlog_v1.py",
+                "docs/governance/MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_HYPOTHESIS_BACKLOG_V1.md",
+            ],
+        },
+        "MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_PROGRAM_V1": {
+            "note": "Closed research-program SSOT after CS-RS-Momentum v1 FAIL_CLOSED_NO_RETRY; run budget consumed (1/1); no successor; no retry/reopen; no holdout/runtime/orders; causal independence from closed Bollinger Entry/Exit lanes retained; new research requires separate operator authorization and preregistration.",
+            "path_prefixes": [
+                "config/research/material_different_cross_sectional_momentum_program_v1.json",
+                "src/research/material_different_cross_sectional_momentum_program_v1.py",
+                "tests/research/test_material_different_cross_sectional_momentum_program_v1.py",
+                "docs/governance/MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_PROGRAM_V1.md",
+            ],
+        },
+        "MA_TREND_ALIGNMENT_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+            "note": "Single preregistered DEVELOPMENT-only offline evaluation of SMA(50) side-aware with-trend admission pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=FAIL, NET_PROFIT_FACTOR_NOT_IMPROVED); research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+            "path_prefixes": [
+                "src/research/ma_trend_alignment_mr_eligibility_development_evaluation_v1/",
+                "scripts/research/run_evaluate_ma_trend_alignment_mr_eligibility_development_v1.py",
+                "tests/research/test_ma_trend_alignment_mr_eligibility_development_evaluation_v1.py",
+                "docs/evidence/evaluate_ma_trend_alignment_mr_eligibility_development_v1/",
+                "docs/governance/MA_TREND_ALIGNMENT_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
+            ],
+        },
+        "MA_TREND_ALIGNMENT_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of a single SMA(50) side-aware with-trend admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to four prior FAILs (regime, ATR, RSI, ADX); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+            "path_prefixes": [
+                "src/research/ma_trend_alignment_mr_eligibility_hypothesis_preregistration_v1.py",
+                "tests/research/test_ma_trend_alignment_mr_eligibility_hypothesis_preregistration_v1.py",
+                "config/research/ma_trend_alignment_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "docs/evidence/preregister_ma_trend_alignment_mr_eligibility_hypothesis_v1/",
+                "docs/governance/MA_TREND_ALIGNMENT_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+            ],
+        },
+        "OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_WITHOUT_TRADING_SEMANTIC_EFFECT": {
+            "note": "Offline economic evaluation execution infrastructure, preexecution guards, invocation-bound authorization repair, and contract tests without trading semantic mutation or runtime authority.",
+            "path_globs": [
+                "src/research/*offline_economic_evaluation_execution_v0.py",
+                "src/research/cross_sectional_cost_execution_binding_normalization_v0.py",
+                "src/research/*offline_economic_evaluation_scope_ratification_v0.py",
+                "tests/research/test_*offline_economic_evaluation_execution_infrastructure_v0.py",
+                "tests/research/test_*offline_economic_evaluation_execution_dispatch_implementation_v0.py",
+                "tests/research/test_*offline_economic_evaluation_execution_implementation_repair_v0.py",
+                "tests/research/test_*offline_economic_evaluation_dispatch_to_baseline_repair_v0.py",
+                "tests/research/test_*offline_economic_evaluation_reevaluation_execution_implementation_v0.py",
+                "tests/research/test_*offline_economic_evaluation_reevaluation_execution_ops_runner_branch_v0.py",
+                "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_ops_runner_branch_v0.py",
+                "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py",
+                "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_actual_execution_owner_implementation_v0.py",
+                "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_dataset_digest_reconciliation_repair_v0.py",
+                "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_data_unavailable_repair_v0.py",
+                "tests/research/test_*offline_economic_evaluation_baseline_execution_implementation_v0.py",
+                "tests/research/test_*baseline_execution_entry_point_result_contract_repair_v0.py",
+                "tests/research/test_trend_following_v2_baseline_owner_single_member_end_to_end_repair_v0.py",
+                "tests/research/test_trend_following_v2_mandatory_boundary_state_file_binding_rewire_v0.py",
+                "tests/research/test_trend_following_v2_canonical_wiring_map_contract_v0.py",
+                "tests/research/test_*offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",
+                "src/backtest/economic_viability_evidence_v1.py",
+                "config/ops/trend_following_v2_economic_evaluation_v1.json",
+                "src/research/panel_sequential_signal_density_research_adapter_v0.py",
+                "src/research/versioned_final_fleet_bindings_offline_economic_evaluation_v0.py",
+                "src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py",
+                "scripts/ops/run_*offline_economic_evaluation_execution_v0.py",
+                "scripts/ops/materialize_*offline_economic_evaluation_baseline_execution_implementation_v0.py",
+                "scripts/ops/materialize_*offline_economic_evaluation_execution_*_implementation_v0.py",
+                "tests/research/test_*offline_economic_evaluation_execution_authorization_ratification_repair_v0.py",
+                "tests/research/test_*execution_v1_token_binding_repair_v0.py",
+                "tests/research/test_*offline_economic_evaluation_full_runner_v0.py",
+                "src/research/*offline_economic_evaluation_execution_authorization_supersession_v*.py",
+                "scripts/research/materialize_*offline_economic_evaluation_execution_authorization_supersession_v*.py",
+                "config/research/*offline_economic_evaluation_execution_authorization_supersession_v*.json",
+                "config/research/full_canonical_system_economic_evidence_generation_v1_offline_execution_result_v0.json",
+                "tests/research/test_full_canonical_system_economic_evidence_generation_v1_offline_execution_result_v0_contract.py",
+            ],
+        },
+        "OFFLINE_MV2_ZERO_TRADE_PER_BAR_DECISION_OUTCOME_DIAGNOSTIC_WITHOUT_TRADING_SEMANTIC_EFFECT": {
+            "note": "Offline-only per-bar MV2 decision-outcome diagnostic for zero-trade root-cause observability; observational hook only; no trading/runtime/authority/sizing semantic mutation.",
+            "path_prefixes": [
+                "src/research/mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
+                "scripts/research/run_mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
+                "tests/research/test_mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
+                "config/research/mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.json",
+            ],
+        },
+        "POINT_IN_TIME_DATA_QUALITY_REPAIR": {
+            "path_prefixes": [
+                "src/backtest/admissible_versioned_futures_dataset_v1.py",
+                "src/research/admissible_",
+            ]
+        },
+        "PORTFOLIO_RESEARCH_AND_ECONOMIC_ATTRIBUTION_WITHOUT_RUNTIME_AUTHORITY": {
+            "path_prefixes": [
+                "src/experiments/evidence_chain.py",
+                "src/experiments/strategy_profiles.py",
+                "src/research/offline_economic_viability_evidence_gap_assessment_v0.py",
+            ]
+        },
+        "REAL_FILL_BINDING": {
+            "note": "Real fill binding repair only; no trading semantic mutation.",
+            "path_prefixes": ["src/backtest/engine.py"],
+        },
+        "REGIME_GATED_STANDASIDE_MR_DEVELOPMENT_EVALUATION_V1": {
+            "note": "Single preregistered DEVELOPMENT-only offline evaluation of regime-gated standaside MR versus immutable bollinger baseline; research-only entry-eligibility gate; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+            "path_prefixes": [
+                "src/research/regime_gated_standaside_mr_development_evaluation_v1/",
+                "scripts/research/run_evaluate_regime_gated_standaside_mr_development_v1.py",
+                "tests/research/test_regime_gated_standaside_mr_development_evaluation_v1.py",
+                "docs/evidence/evaluate_regime_gated_standaside_mr_development_v1/",
+                "docs/governance/REGIME_GATED_STANDASIDE_MR_DEVELOPMENT_EVALUATION_V1.md",
+            ],
+        },
+        "REGIME_GATED_STANDASIDE_MR_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of a single regime-gated stand-aside mean-reversion measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+            "path_prefixes": [
+                "src/research/regime_gated_standaside_mr_hypothesis_preregistration_v1.py",
+                "tests/research/test_regime_gated_standaside_mr_hypothesis_preregistration_v1.py",
+                "config/research/regime_gated_standaside_mr_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "docs/evidence/preregister_regime_gated_standaside_mr_hypothesis_v1/",
+                "docs/governance/REGIME_GATED_STANDASIDE_MR_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+            ],
+        },
+        "REPORTING_AND_EVIDENCE_REPAIR": {
+            "path_globs": ["scripts/ops/*evidence*", "scripts/ops/*manifest*"],
+            "path_prefixes": [
+                "scripts/ops/primary_evidence_retention_v0.py",
+                "scripts/ops/verify_pre_pr_validation_result_v0.py",
+                "scripts/ops/materialize_offline_productive_signal_orthogonality_results_interpretation_v0.py",
+                "scripts/ops/materialize_offline_productive_factor_exposure_diagnostics_v0.py",
+                "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+                "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+                "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
+                "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+                "scripts/ops/materialize_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+                "scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py",
+                "scripts/research/materialize_bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
+                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
+                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
+                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
+                "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
+                "tests/research/test_step29l2_import_boundary_classification_v0.py",
+            ],
+        },
+        "RSI_EXHAUSTION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
+            "note": "Single preregistered DEVELOPMENT-only offline evaluation of RSI(14)-exhaustion pre-entry MR eligibility filter versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
+            "path_prefixes": [
+                "src/research/rsi_exhaustion_mr_eligibility_development_evaluation_v1/",
+                "scripts/research/run_evaluate_rsi_exhaustion_mr_eligibility_development_v1.py",
+                "tests/research/test_rsi_exhaustion_mr_eligibility_development_evaluation_v1.py",
+                "docs/evidence/evaluate_rsi_exhaustion_mr_eligibility_development_v1/",
+                "docs/governance/RSI_EXHAUSTION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md",
+            ],
+        },
+        "RSI_EXHAUSTION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of a single RSI(14)-exhaustion pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to the failed ATR-percentile mid-band and failed regime-gated absolute-threshold mechanisms; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
+            "path_prefixes": [
+                "src/research/rsi_exhaustion_mr_eligibility_hypothesis_preregistration_v1.py",
+                "tests/research/test_rsi_exhaustion_mr_eligibility_hypothesis_preregistration_v1.py",
+                "config/research/rsi_exhaustion_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "docs/evidence/preregister_rsi_exhaustion_mr_eligibility_hypothesis_v1/",
+                "docs/governance/RSI_EXHAUSTION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+            ],
+        },
+        "SIMULATED_FILL_BINDING_USING_EXISTING_CANONICAL_EXECUTION_OWNER": {
+            "note": "Simulated fill binding must reuse existing canonical execution owners; no new runtime authority.",
+            "path_globs": [
+                "tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py",
+                "tests/research/test_cross_sectional_lead_lag_v0_backtest_engine_mv2_replay_signal_parity_v0.py",
+                "tests/research/test_cross_sectional_lead_lag_v0_research_eval_decision_parity_contract_suite_v0.py",
+            ],
+            "path_prefixes": [
+                "src/backtest/mv2_research_wiring_v1.py",
+                "src/backtest/strategy_signal_binding_v1.py",
+            ],
+        },
+        "SLIPPAGE_MODEL_DIAGNOSTICS": {
+            "path_prefixes": ["src/research/linear_evidence/cost_model.py"]
+        },
+        "TARGET_BINDING_REPAIR": {
+            "path_globs": [
+                "tests/research/test_offline_linear_cost_diagnostic_row_materializer_*",
+                "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
+                "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
+                "tests/research/test_offline_final_research_fleet_signal_matrix_productive_input_join_materializer_*",
+                "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
+                "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_*",
+                "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*",
+            ],
+            "path_prefixes": [
+                "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
+                "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
+                "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
+                "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
+                "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
+                "src/research/linear_evidence/feature_matrix.py",
+                "src/research/linear_evidence/sensitivity.py",
+                "src/research/linear_evidence/drift.py",
+                "src/research/linear_evidence/window_robustness.py",
+                "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
+                "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
+                "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
+                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
+                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
+                "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
+            ],
+        },
+        "TIME_ORDERED_VALIDATION": {
+            "path_prefixes": ["src/backtest/walkforward.py", "tests/backtest/test_walkforward*"]
+        },
+        "VOLATILITY_COMPRESSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+            "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_COMPRESSION_BREAKOUT_V1: executable evaluate path with panel execution boundary and productive exit/PnL evaluator bound to canonical BacktestEngine fee/slippage/gross-PnL primitives; authorized on HEAD; no evaluation execution/run-slot consumption without separate GO; no holdout/runtime/orders; measurement thresholds and strategy/baseline parameters unchanged.",
+            "path_prefixes": [
+                "config/research/volatility_compression_breakout_v1_development_evaluation_entry_point_binding_v1.json",
+                "docs/evidence/evaluate_volatility_compression_breakout_development_v1/",
+                "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+                "scripts/research/run_evaluate_volatility_compression_breakout_development_v1.py",
+                "src/research/volatility_compression_breakout_v1_development_evaluation_v1/",
+                "tests/research/test_volatility_compression_breakout_v1_development_evaluation_entry_point_v1.py",
+                "tests/research/test_volatility_compression_breakout_v1_development_evaluation_executable_path_v1.py",
+                "tests/research/test_volatility_compression_breakout_v1_development_evaluation_fail_closed_report_v1.py",
+                "tests/research/test_volatility_compression_breakout_v1_productive_exit_pnl_evaluator_v1.py",
+            ],
+        },
+        "VOLATILITY_COMPRESSION_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of own-instrument volatility compression→expansion→channel-breakout v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; frozen ATR(20)/close percentile-rank admission, unconditional channel-breakout baseline, event-sufficiency gates; material difference vs terminal VOL_BREAKOUT_COILED_SPRING explicit; development evaluation authorized; evaluation not executed; no holdout/runtime/orders.",
+            "path_prefixes": [
+                "config/research/volatility_compression_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "src/research/volatility_compression_breakout_v1_hypothesis_preregistration_v1.py",
+                "tests/research/test_volatility_compression_breakout_v1_hypothesis_preregistration_v1.py",
+                "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+                "docs/evidence/preregister_volatility_compression_breakout_hypothesis_v1/",
+            ],
+        },
+        "VOLATILITY_COMPRESSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+            "note": "Strategy-implementation-only surfaces for VOLATILITY_COMPRESSION_BREAKOUT_V1 (shared 20-bar price-channel core + ATR20/close percentile vol-state + compression/release admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; no Master-V2/Double-Play/risk/execution mutation.",
+            "path_prefixes": [
+                "src/research/price_channel_breakout_core_v1.py",
+                "src/research/volatility_compression_breakout_v1_vol_state_v1.py",
+                "src/research/volatility_compression_breakout_v1_strategy_v1.py",
+                "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
+                "src/research/volatility_compression_breakout_v1_strategy_implementation_binding_v1.py",
+                "config/research/volatility_compression_breakout_v1_strategy_implementation_binding_v1.json",
+                "tests/research/test_volatility_compression_breakout_v1_strategy_implementation_v1.py",
+                "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
+            ],
+        },
+        "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+            "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1: development evaluation slot consumed FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; productive exit/PnL evaluator reused from VCB package (not duplicated). No retry; no holdout/runtime/orders; strategy/baseline parameters unchanged; VDBX/VDB/VEP/VCB artifacts unchanged.",
+            "path_prefixes": [
+                "config/research/volatility_contraction_expansion_breakout_v1_development_evaluation_entry_point_binding_v1.json",
+                "docs/evidence/evaluate_volatility_contraction_expansion_breakout_development_v1/",
+                "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+                "scripts/research/run_evaluate_volatility_contraction_expansion_breakout_development_v1.py",
+                "src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/",
+                "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_entry_point_v1.py",
+                "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_executable_path_v1.py",
+                "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_fail_closed_report_v1.py",
+            ],
+        },
+        "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1 after terminal VDBX FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; frozen realized-vol contraction->expansion joint breakout admission + pairable exit precedence; productive PnL evaluator referenced only; no Development evaluation/holdout/runtime/orders; VDBX/VDB/VEP/VCB retry forbidden.",
+            "path_prefixes": [
+                "config/research/volatility_contraction_expansion_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "src/research/volatility_contraction_expansion_breakout_v1_hypothesis_preregistration_v1.py",
+                "tests/research/test_volatility_contraction_expansion_breakout_v1_hypothesis_preregistration_v1.py",
+                "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+                "docs/evidence/preregister_volatility_contraction_expansion_breakout_hypothesis_v1/",
+            ],
+        },
+        "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+            "note": "Strategy + exit state machine for VCEB v1 (RV24 contraction->expansion joint break + opposite-break exits without trailing); productive PnL evaluator referenced not duplicated; measurement digest frozen; no evaluation/holdout/runtime/orders; VDBX/VDB/VEP/VCB retry forbidden.",
+            "path_prefixes": [
+                "src/research/price_channel_breakout_core_v1.py",
+                "src/research/volatility_contraction_expansion_breakout_v1_vol_state_v1.py",
+                "src/research/volatility_contraction_expansion_breakout_v1_exit_state_machine_v1.py",
+                "src/research/volatility_contraction_expansion_breakout_v1_strategy_v1.py",
+                "src/research/volatility_contraction_expansion_breakout_v1_strategy_implementation_binding_v1.py",
+                "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
+                "config/research/volatility_contraction_expansion_breakout_v1_strategy_implementation_binding_v1.json",
+                "tests/research/test_volatility_contraction_expansion_breakout_v1_strategy_and_exit_state_machine_v1.py",
+                "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
+            ],
+        },
+        "VOLATILITY_DECAY_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+            "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_DECAY_BREAKOUT_V1: panel execution boundary materialized; productive exit/PnL evaluator reused from VCB. Single bounded development attempt fail-closed at PRODUCTIVE_PNL_OVERFLOW with durable run slot consumed (1/1); archival panel-boundary fail_closed_report retained; bounded corrective measurement reevaluation executed once and fail-closed at UNPAIRABLE_ENTRY_NO_EXIT (corrective slot 1/1; development counters preserved at 1; prior development evidence unmodified; supersession audited in corrective bundle); no holdout/runtime/orders; no development or corrective retry; VCB/VEP slots not reused.",
+            "path_prefixes": [
+                "config/research/volatility_decay_breakout_v1_development_evaluation_entry_point_binding_v1.json",
+                "docs/evidence/evaluate_volatility_decay_breakout_corrective_measurement_reevaluation_v1/",
+                "docs/evidence/evaluate_volatility_decay_breakout_development_v1/",
+                "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+                "scripts/research/run_evaluate_volatility_decay_breakout_development_v1.py",
+                "src/research/volatility_decay_breakout_v1_development_evaluation_v1/",
+                "tests/research/test_volatility_decay_breakout_v1_corrective_measurement_reevaluation_v1.py",
+                "tests/research/test_volatility_decay_breakout_v1_development_evaluation_entry_point_v1.py",
+                "tests/research/test_volatility_decay_breakout_v1_development_evaluation_fail_closed_report_v1.py",
+                "tests/research/test_volatility_decay_breakout_v1_development_evaluation_executable_path_v1.py",
+            ],
+        },
+        "VOLATILITY_DECAY_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of own-instrument volatility decay-breakout v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures after terminal VEP-V1 UNPAIRABLE_ENTRY_NO_EXIT; frozen ATR(14)/close high→low decay admission + channel-breakout baseline; material difference vs VEP/VCB/coiled-spring explicit; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced only; VEP retry/exit-repair forbidden.",
+            "path_prefixes": [
+                "config/research/volatility_decay_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "src/research/volatility_decay_breakout_v1_hypothesis_preregistration_v1.py",
+                "tests/research/test_volatility_decay_breakout_v1_hypothesis_preregistration_v1.py",
+                "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+                "docs/evidence/preregister_volatility_decay_breakout_hypothesis_v1/",
+                "docs/evidence/forensic_classify_vep_v1_unpairable_entry_no_exit_v1/",
+            ],
+        },
+        "VOLATILITY_DECAY_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+            "note": "Strategy-implementation-only surfaces for VOLATILITY_DECAY_BREAKOUT_V1 (shared 20-bar price-channel core + ATR14/close percentile vol-state + high→low decay admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced not duplicated; no Master-V2/Double-Play/risk/execution mutation; VEP/VCB retry forbidden.",
+            "path_prefixes": [
+                "src/research/price_channel_breakout_core_v1.py",
+                "src/research/volatility_decay_breakout_v1_vol_state_v1.py",
+                "src/research/volatility_decay_breakout_v1_strategy_v1.py",
+                "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
+                "src/research/volatility_decay_breakout_v1_strategy_implementation_binding_v1.py",
+                "config/research/volatility_decay_breakout_v1_strategy_implementation_binding_v1.json",
+                "tests/research/test_volatility_decay_breakout_v1_strategy_implementation_v1.py",
+                "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
+            ],
+        },
+        "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+            "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1: executable evaluate path with strategy-emitted exits + productive exit/PnL evaluator reuse from VCB package (not duplicated). Development evaluation authorized; run counters remain 0 until the single bounded productive evaluation executes; no holdout/runtime/orders; hypothesis parameters unchanged.",
+            "path_prefixes": [
+                "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_entry_point_binding_v1.json",
+                "docs/evidence/evaluate_volatility_decay_breakout_with_explicit_decay_exit_development_v1/",
+                "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+                "scripts/research/run_evaluate_volatility_decay_breakout_with_explicit_decay_exit_development_v1.py",
+                "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_v1/",
+                "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_entry_point_v1.py",
+                "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_executable_path_v1.py",
+                "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_fail_closed_report_v1.py",
+            ],
+        },
+        "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of VDBX explicit-decay-exit successor after terminal VDB UNPAIRABLE_ENTRY_NO_EXIT; frozen decay entry + explicit exit state machine; productive PnL evaluator referenced only; no Development evaluation/holdout/runtime/orders; VDB/VEP/VCB retry forbidden.",
+            "path_prefixes": [
+                "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_hypothesis_preregistration_v1.py",
+                "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_hypothesis_preregistration_v1.py",
+                "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+                "docs/evidence/preregister_volatility_decay_breakout_with_explicit_decay_exit_hypothesis_v1/",
+            ],
+        },
+        "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+            "note": "Strategy + explicit exit state machine for VDBX v1; reuses VDB vol-state/channel core; productive PnL evaluator referenced not duplicated; no evaluation/holdout/runtime/orders; no predecessor artifact mutation.",
+            "path_prefixes": [
+                "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_exit_state_machine_v1.py",
+                "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_v1.py",
+                "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_implementation_binding_v1.py",
+                "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_implementation_binding_v1.json",
+                "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_and_exit_state_machine_v1.py",
+                "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
+            ],
+        },
+        "VOLATILITY_EXPANSION_PERSISTENCE_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
+            "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_EXPANSION_PERSISTENCE_V1: executable evaluate path with materialized panel execution boundary (loader/wiring/injectable boundary); productive exit/PnL evaluator referenced from VCB package (not duplicated). Development evaluation authorized on HEAD; run counters remain 0 until a separate operator GO executes the single bounded development evaluation; no holdout/runtime/orders; measurement thresholds and strategy/baseline parameters unchanged.",
+            "path_prefixes": [
+                "config/research/volatility_expansion_persistence_v1_development_evaluation_entry_point_binding_v1.json",
+                "docs/evidence/evaluate_volatility_expansion_persistence_development_v1/",
+                "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+                "scripts/research/run_evaluate_volatility_expansion_persistence_development_v1.py",
+                "src/research/volatility_expansion_persistence_v1_development_evaluation_v1/",
+                "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_entry_point_v1.py",
+                "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_executable_path_v1.py",
+                "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_fail_closed_report_v1.py",
+            ],
+        },
+        "VOLATILITY_EXPANSION_PERSISTENCE_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of own-instrument volatility expansion-persistence v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; frozen ATR(14)/close percentile-rank expansion confirmation + persistence window admission, unconditional channel-breakout baseline, event-sufficiency gates; material difference vs terminal VCB-V1 and coiled-spring explicit; development evaluation authorized; evaluation not executed; no holdout/runtime/orders; productive PnL evaluator referenced only.",
+            "path_prefixes": [
+                "config/research/volatility_expansion_persistence_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "src/research/volatility_expansion_persistence_v1_hypothesis_preregistration_v1.py",
+                "tests/research/test_volatility_expansion_persistence_v1_hypothesis_preregistration_v1.py",
+                "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+                "docs/evidence/preregister_volatility_expansion_persistence_hypothesis_v1/",
+            ],
+        },
+        "VOLATILITY_EXPANSION_PERSISTENCE_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+            "note": "Strategy-implementation-only surfaces for VOLATILITY_EXPANSION_PERSISTENCE_V1 (shared 20-bar price-channel core + ATR14/close percentile vol-state + expansion confirmation/persistence admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced not duplicated; no Master-V2/Double-Play/risk/execution mutation.",
+            "path_prefixes": [
+                "src/research/price_channel_breakout_core_v1.py",
+                "src/research/volatility_expansion_persistence_v1_vol_state_v1.py",
+                "src/research/volatility_expansion_persistence_v1_strategy_v1.py",
+                "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
+                "src/research/volatility_expansion_persistence_v1_strategy_implementation_binding_v1.py",
+                "config/research/volatility_expansion_persistence_v1_strategy_implementation_binding_v1.json",
+                "tests/research/test_volatility_expansion_persistence_v1_strategy_implementation_v1.py",
+                "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
+            ],
+        },
+        "VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
+            "note": "Definition-only preregistration of VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1 after terminal VCEB FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; expansion then limited pullback continuation + explicit invalidation/time/protective exits; productive PnL evaluator referenced only; measurement contract remains frozen; VCEB/VDBX/VDB/VEP/VCB retry forbidden.",
+            "path_prefixes": [
+                "config/research/volatility_expansion_pullback_continuation_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
+                "src/research/volatility_expansion_pullback_continuation_v1_hypothesis_preregistration_v1.py",
+                "tests/research/test_volatility_expansion_pullback_continuation_v1_hypothesis_preregistration_v1.py",
+                "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
+                "docs/evidence/preregister_volatility_expansion_pullback_continuation_hypothesis_v1/",
+            ],
+        },
+        "VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
+            "note": "Strategy implementation + productive development entry path for VEPC v1; exit SM with pullback-structure invalidation; productive PnL evaluator reused; forensic run-state accounting for technical fail-closed after runner start; no holdout/runtime/orders; no PnL pairing semantics change in accounting fix.",
+            "path_prefixes": [
+                "src/research/volatility_expansion_pullback_continuation_v1_strategy_v1.py",
+                "src/research/volatility_expansion_pullback_continuation_v1_exit_state_machine_v1.py",
+                "src/research/volatility_expansion_pullback_continuation_v1_vol_state_v1.py",
+                "src/research/volatility_expansion_pullback_continuation_v1_strategy_implementation_binding_v1.py",
+                "config/research/volatility_expansion_pullback_continuation_v1_strategy_implementation_binding_v1.json",
+                "src/research/volatility_expansion_pullback_continuation_v1_development_evaluation_v1/",
+                "config/research/volatility_expansion_pullback_continuation_v1_development_evaluation_entry_point_binding_v1.json",
+                "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
+                "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
+                "scripts/research/run_evaluate_volatility_expansion_pullback_continuation_development_v1.py",
+                "tests/research/test_volatility_expansion_pullback_continuation_v1_strategy_implementation_v1.py",
+                "tests/research/test_volatility_expansion_pullback_continuation_v1_development_evaluation_entry_point_v1.py",
+                "tests/research/test_volatility_expansion_pullback_continuation_v1_forensic_unpairable_run_state_v1.py",
+            ],
+        },
+        "VOLATILITY_REGIME_HYPOTHESIS_BACKLOG_V1": {
+            "note": "Open backlog SSOT for volatility-regime research program with exactly one definition-only preregistration (VEP-V1) and terminal VCB-V1 FAIL_CLOSED_NO_RETRY; evaluation/holdout/promotion/runtime closed; sibling Entry/Exit and closed CS momentum lanes remain unreopened. Active open preregistration is VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1; VDB terminal.",
+            "path_prefixes": [
+                "config/research/volatility_regime_hypothesis_backlog_v1.json",
+                "src/research/volatility_regime_hypothesis_backlog_v1.py",
+                "tests/research/test_volatility_regime_hypothesis_backlog_v1.py",
+                "docs/governance/VOLATILITY_REGIME_HYPOTHESIS_BACKLOG_V1.md",
+            ],
+        },
+        "VOLATILITY_REGIME_RESEARCH_PROGRAM_V1": {
+            "note": "Definition-only research-program SSOT for operator-authorized volatility-regime expansion-persistence hypothesis VEP-V1; causal independence from closed Bollinger Entry/Exit and CS momentum lanes; material difference vs terminal coiled-spring and terminal VCB-V1; development evaluation authorized (not executed); no holdout/runtime/orders. Active open preregistration is VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1; VDB terminal.",
+            "path_prefixes": [
+                "config/research/volatility_regime_research_program_v1.json",
+                "src/research/volatility_regime_research_program_v1.py",
+                "tests/research/test_volatility_regime_research_program_v1.py",
+                "docs/governance/VOLATILITY_REGIME_RESEARCH_PROGRAM_V1.md",
+            ],
+        },
+        "WALK_FORWARD_MONTE_CARLO_STRESS_AND_PARAMETER_SENSITIVITY": {
+            "path_globs": [
+                "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
+                "tests/research/test_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+                "tests/research/test_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+                "tests/research/test_offline_parameter_sensitivity_model_spec_alignment_*",
+                "tests/research/test_offline_rolling_linear_drift_diagnostics_v0.py",
+                "tests/research/test_offline_outlier_and_window_robustness_diagnostic_v0.py",
+            ],
+            "path_prefixes": [
+                "src/experiments/monte_carlo.py",
+                "src/experiments/stress_tests.py",
+                "src/experiments/portfolio_robustness.py",
+                "scripts/research/offline_parameter_sensitivity_surface_v0.py",
+                "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
+                "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
+                "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
+                "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
+                "scripts/research/offline_rolling_linear_drift_diagnostics_v0.py",
+                "scripts/research/offline_outlier_and_window_robustness_diagnostic_v0.py",
+            ],
+        },
+    },
+    "forbidden_mutation_surfaces": {
+        "BULL_BEAR_ASSESSMENT": {
+            "description": "Canonical Bull/Bear assessment and state-switch owners",
+            "path_globs": [
+                "tests/trading/master_v2/test_bull_bear_*",
+                "tests/research/test_bull_bear_*",
+                "docs/research/bull_bear_*",
+            ],
+            "path_prefixes": [
+                "src/trading/master_v2/directional_assessment_v1.py",
+                "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
+                "src/research/owner_bindings/bull_bear_state_switch_owner_binding_v0.py",
+            ],
+        },
+        "CAPITAL_RISK_SIZING": {
+            "description": "Capital, risk and position-sizing owners",
+            "path_globs": [
+                "tests/governance/test_capital_risk_sizing_*",
+                "tests/trading/master_v2/test_capital_risk_sizing_*",
+                "tests/trading/master_v2/test_*capital_slot*",
+                "tests/ops/test_master_v2_capital_slot_owner_boundary_*",
+            ],
+            "path_prefixes": [
+                "src/governance/capital_risk_sizing_v1.py",
+                "src/trading/master_v2/double_play_capital_slot.py",
+                "src/trading/master_v2/capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0.py",
+                "src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py",
+                "config/research/mv2_backtest_mandatory_boundary_state_files_v0/capital_risk_sizing.json",
+            ],
+        },
+        "DOUBLE_PLAY_COMPOSITION": {
+            "description": "Double-Play composition and state owners",
+            "path_globs": [
+                "tests/trading/master_v2/test_double_play_*",
+                "docs/ops/specs/MASTER_V2_DOUBLE_PLAY_*",
+                "docs/ops/specs/FUTURES_DOUBLE_PLAY_*",
+            ],
+            "path_prefixes": [
+                "src/trading/master_v2/double_play_composition.py",
+                "src/trading/master_v2/double_play_composition_matrix_v1.py",
+                "src/trading/master_v2/double_play_composition_scenario_matrix_adapter_v0.py",
+                "src/trading/master_v2/double_play_state.py",
+                "src/trading/master_v2/double_play_dashboard_display.py",
+                "src/trading/master_v2/double_play_futures_input_producer.py",
+                "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+                "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py",
+            ],
+        },
+        "ENTRY_POSITION_EXIT_REVERSAL_POLICY": {
+            "description": "Entry, position-management, exit and reversal policy owners",
+            "path_globs": [
+                "tests/trading/master_v2/test_*entry_exit*",
+                "tests/trading/master_v2/test_*survival*",
+                "tests/trading/master_v2/test_*suitability*",
+            ],
+            "path_prefixes": [
+                "src/trading/master_v2/double_play_entry_exit_policy_v0.py",
+                "src/trading/master_v2/double_play_entry_exit_scenario_binding_adapter_v0.py",
+                "src/trading/master_v2/double_play_survival.py",
+                "src/trading/master_v2/double_play_suitability.py",
+                "src/trading/master_v2/survival_assessment_v1.py",
+                "src/trading/master_v2/suitability_binding_v1.py",
+            ],
+        },
+        "KILLSWITCH": {
+            "description": "KillSwitch semantics and binding owners",
+            "path_globs": [
+                "tests/trading/master_v2/test_killswitch_*",
+                "tests/test_backtest_killswitch_*",
+            ],
+            "path_prefixes": [
+                "src/trading/master_v2/killswitch_boundary_backtest_state_file_binding_adapter_v0.py",
+                "src/trading/master_v2/killswitch_boundary_offline_replay_binding_adapter_v0.py",
+                "config/research/mv2_backtest_mandatory_boundary_state_files_v0/killswitch.json",
+                "docs/risk/KILL_SWITCH_RUNBOOK.md",
+            ],
+        },
+        "MASTER_V2": {
+            "description": "All canonical Master V2 trading logic owners",
+            "path_globs": ["tests/trading/master_v2/test_*"],
+            "path_prefixes": ["src/trading/master_v2/"],
+        },
+        "PROMOTION_RUNTIME_ORDER_CREDENTIAL_SCHEDULER_AUTHORITY": {
+            "description": "Promotion, runtime, order, credential, scheduler and authority semantics",
+            "path_globs": [
+                "tests/governance/promotion_loop/*",
+                "tests/trading/master_v2/test_promotion_gate_*",
+                "tests/trading/master_v2/test_runtime_bridge_*",
+                "tests/ops/test_master_v2_runtime_governance_boundary_*",
+                "scripts/run_scheduler.py",
+            ],
+            "path_prefixes": [
+                "src/governance/promotion_loop/",
+                "src/trading/master_v2/promotion_gate_boundary_backtest_state_file_binding_adapter_v0.py",
+                "src/trading/master_v2/promotion_gate_boundary_offline_replay_binding_adapter_v0.py",
+                "src/trading/master_v2/runtime_bridge_pre_activation_gate_v0.py",
+                "src/trading/master_v2/runtime_bridge_pre_activation_gate_assessment_v0.py",
+                "src/trading/master_v2/staged_execution_enablement_v1.py",
+                "src/trading/master_v2/canonical_core_runtime_integration_bridge_v0.py",
+                "src/trading/master_v2/canonical_core_runtime_integration_intent_pipeline_bridge_v0.py",
+                "src/trading/master_v2/canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0.py",
+                "src/trading/master_v2/canonical_order_intent_offline_replay_binding_adapter_v0.py",
+                "src/governance/canonical_order_intent_v1.py",
+                "config/research/mv2_backtest_mandatory_boundary_state_files_v0/canonical_order_intent.json",
+            ],
+        },
+        "RECONCILIATION_UNKNOWN_OUTCOME": {
+            "description": "Reconciliation and unknown-outcome semantics",
+            "path_globs": [
+                "tests/trading/master_v2/test_reconciliation_*",
+                "tests/test_backtest_reconciliation_*",
+            ],
+            "path_prefixes": [
+                "src/trading/master_v2/reconciliation_boundary_backtest_state_file_binding_adapter_v0.py",
+                "src/trading/master_v2/reconciliation_unknown_outcome_offline_replay_binding_adapter_v0.py",
+                "config/research/mv2_backtest_mandatory_boundary_state_files_v0/reconciliation.json",
+            ],
+        },
+        "SAFETY_KERNEL": {
+            "description": "Safety kernel semantics and binding owners",
+            "path_globs": [
+                "tests/trading/master_v2/test_safety_kernel_*",
+                "tests/research/test_safety_kernel_*",
+                "scripts/run_independent_pre_trade_safety_kernel_v1.py",
+            ],
+            "path_prefixes": [
+                "src/trading/master_v2/safety_kernel_boundary_backtest_state_file_binding_adapter_v0.py",
+                "src/trading/master_v2/safety_kernel_offline_replay_binding_adapter_v0.py",
+                "src/meta/learning_loop/independent_pre_trade_safety_kernel_v1.py",
+                "config/research/mv2_backtest_mandatory_boundary_state_files_v0/safety_kernel.json",
+            ],
+        },
+        "SCOPE_INITIALIZATION_AND_EVENTS": {
+            "description": "Scope initialization, scope events, adverse-exit and reversal owners",
+            "path_globs": [
+                "tests/trading/master_v2/test_*scope*",
+                "tests/trading/master_v2/test_*reversal*",
+            ],
+            "path_prefixes": [
+                "src/trading/master_v2/canonical_scope_initialization_v1.py",
+                "src/trading/master_v2/deterministic_scope_event_generator_v1.py",
+                "src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py",
+                "src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py",
+                "src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py",
+            ],
+        },
+    },
+    "no_path_guessing": true,
+    "resolution_method": "READ_ONLY_FROM_EXISTING_BOUNDARY_CONTRACTS_AND_PROGRESS_OWNERS",
+    "schema_version": "economic_diagnostic_optimization_boundary_canonical_owner_map_v0",
+    "source_owners": [
+        "tests/ops/test_master_v2_dynamic_scope_owner_boundary_contract_v0.py",
+        "tests/ops/test_master_v2_state_switch_owner_boundary_contract_v0.py",
+        "tests/ops/test_master_v2_capital_slot_owner_boundary_contract_v0.py",
+        "tests/ops/test_master_v2_runtime_governance_boundary_contract_static_v0.py",
+        "tests/governance/test_capital_risk_sizing_mathematics_consolidation_contract_v0.py",
+        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/MANIFEST.json",
+        "docs/governance/PEAK_TRADE_IMPLEMENTATION_CONTRACT.md",
+        "docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.10_IMPLEMENTATION_CONTRACT.md",
+        "config/governance/technical_canonical_wiring_authorization_v1.json",
+    ],
+    "technical_canonical_wiring_authorization": {
+        "authorized_scope_class": "TECHNICAL_CANONICAL_WIRING_ONLY",
+        "contract_path": "config/governance/technical_canonical_wiring_authorization_v1.json",
+        "note": "Narrow fail-closed override for versioned technical wiring paths only; does not waive MASTER_V2_MUTATION_ALLOWED=false.",
     },
-    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-      "note": "Single preregistered DEVELOPMENT-only offline evaluation of Wilder ADX(14) +DI/−DI direction-confirmation pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=PASS, ALL_PASS_REQUIRES_MET); research-only entry-eligibility gate; economic offline gate remains closed; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-      "path_prefixes": [
-        "src/research/adx_di_direction_confirmation_mr_eligibility_development_evaluation_v1/",
-        "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_development_v1.py",
-        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_development_evaluation_v1.py",
-        "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_development_v1/",
-        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
-      ]
-    },
-    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_EVALUATION_V1": {
-      "note": "Single authorized HOLDOUT evaluation of Wilder ADX(14) +DI/-DI direction-confirmation MR eligibility versus immutable bollinger baseline on the sealed FINAL_AUDIT panel (holdout_run_count 1/1, RESULT_CLASS=ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN after MV2 replay signal-index mismatch); no retry/post-result tuning; economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-      "path_prefixes": [
-        "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v1/",
-        "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v1.py",
-        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v1.py",
-        "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v1/",
-        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md"
-      ]
-    },
-    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_EVALUATION_V2": {
-      "note": "Single authorized HOLDOUT v2 evaluation of Wilder ADX(14) +DI/-DI direction-confirmation MR eligibility versus immutable bollinger baseline on the sealed FINAL_AUDIT panel (holdout_run_count 1/1, RESULT_CLASS=FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED); new evaluation ID not a V1 rerun; economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-      "path_prefixes": [
-        "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v2/",
-        "scripts/research/run_evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v2.py",
-        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_evaluation_v2.py",
-        "docs/evidence/evaluate_adx_di_direction_confirmation_mr_eligibility_holdout_v2/",
-        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V2.md"
-      ]
-    },
-    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only holdout preregistration for ADX DI direction-confirmation MR eligibility after DEVELOPMENT PASS; freezes sealed FINAL_AUDIT holdout split digest from existing SSOT registry metadata, acceptance criteria, run-limit=1, and execution-GO gate; no holdout data access, no backtest, no economic metrics, no productive authority mutation.",
-      "path_prefixes": [
-        "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v1.py",
-        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v1.py",
-        "config/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistered_measurement_contract_v1.json",
-        "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_holdout_v1/",
-        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md"
-      ]
-    },
-    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V2": {
-      "note": "Holdout preregistration v2 for ADX DI direction-confirmation MR eligibility; evaluation executed and terminal as FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); V1 remains terminal ARTIFACT_OR_EXECUTION_FAILURE_NO_RERUN; no productive authority mutation.",
-      "path_prefixes": [
-        "src/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v2.py",
-        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_holdout_preregistration_v2.py",
-        "config/research/adx_di_direction_confirmation_mr_eligibility_holdout_preregistered_measurement_contract_v2.json",
-        "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_holdout_v2/",
-        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HOLDOUT_PREREGISTERED_MEASUREMENT_V2.md"
-      ]
-    },
-    "ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of a single Wilder ADX(14) +DI/−DI direction-confirmation pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to six prior FAILs (regime, ATR, RSI, ADX-level, MA, MACD); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-      "path_prefixes": [
-        "src/research/adx_di_direction_confirmation_mr_eligibility_hypothesis_preregistration_v1.py",
-        "tests/research/test_adx_di_direction_confirmation_mr_eligibility_hypothesis_preregistration_v1.py",
-        "config/research/adx_di_direction_confirmation_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "docs/evidence/preregister_adx_di_direction_confirmation_mr_eligibility_hypothesis_v1/",
-        "docs/governance/ADX_DI_DIRECTION_CONFIRMATION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
-      ]
-    },
-    "ADX_RANGE_ADMISSION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-      "note": "Single preregistered DEVELOPMENT-only offline evaluation of ADX(14) range-admission pre-entry MR eligibility filter versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-      "path_prefixes": [
-        "src/research/adx_range_admission_mr_eligibility_development_evaluation_v1/",
-        "scripts/research/run_evaluate_adx_range_admission_mr_eligibility_development_v1.py",
-        "tests/research/test_adx_range_admission_mr_eligibility_development_evaluation_v1.py",
-        "docs/evidence/evaluate_adx_range_admission_mr_eligibility_development_v1/",
-        "docs/governance/ADX_RANGE_ADMISSION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
-      ]
-    },
-    "ADX_RANGE_ADMISSION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of a single ADX(14) range-admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to failed regime-gated, ATR-percentile, and RSI-exhaustion mechanisms; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-      "path_prefixes": [
-        "src/research/adx_range_admission_mr_eligibility_hypothesis_preregistration_v1.py",
-        "tests/research/test_adx_range_admission_mr_eligibility_hypothesis_preregistration_v1.py",
-        "config/research/adx_range_admission_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "docs/evidence/preregister_adx_range_admission_mr_eligibility_hypothesis_v1/",
-        "docs/governance/ADX_RANGE_ADMISSION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
-      ]
-    },
-    "BOLLINGER_MR_ECONOMIC_FAILURE_DECOMPOSITION_DEVELOPMENT_V1": {
-      "note": "Canonical development-only read-only economic failure decomposition of the immutable Bollinger/MR baseline on the sealed DEVELOPMENT_ONLY panel; diagnostic classification only; no new hypothesis; no holdout access; no Economic/Promotion gate open; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders.",
-      "path_prefixes": [
-        "config/research/bollinger_mr_economic_failure_decomposition_development_v1.json",
-        "src/research/bollinger_mr_economic_failure_decomposition_development_v1/",
-        "scripts/research/run_bollinger_mr_economic_failure_decomposition_development_v1.py",
-        "tests/research/test_bollinger_mr_economic_failure_decomposition_development_v1.py",
-        "docs/governance/BOLLINGER_MR_ECONOMIC_FAILURE_DECOMPOSITION_DEVELOPMENT_V1.md",
-        "docs/evidence/bollinger_mr_economic_failure_decomposition_development_v1/"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V1": {
-      "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR side-aware middle-band exit-efficiency versus immutable bollinger baseline on sealed DEVELOPMENT panel (evaluation_run_count 0->1); Economic offline gate remains closed; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders. Gate-binding contract test covers MV2 wiring_mod capture-alias open_side binding only.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v1/",
-        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v1.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v1.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_gate_binding_v1.py",
-        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v1/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V1.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V2": {
-      "note": "Terminal DEVELOPMENT_ONLY evaluation closeout for hypothesis ...DEVELOPMENT_V2 (evaluation_run_count 0->1 exactly once; RESULT_CLASS=INCONCLUSIVE_INFRASTRUCTURE_FAILURE; ROOT_CAUSE=PREMEASUREMENT_GATE_FALSE_POSITIVE_ZERO_OR_SENTINEL); reuses frozen V1 mechanism/gate/decision by import only; not a V1 rerun; no V1 partial-result reuse; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders; no V2 rerun.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v2/",
-        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v2.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v2.py",
-        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v2/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V2.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V3": {
-      "note": "Single authorized DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V3 (evaluation_run_count 0->1); identical definition to V2/V1; binds EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 and PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE; not a V1/V2 rerun; no V2 partial-result reuse; Economic offline gate closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v3/",
-        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v3.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v3.py",
-        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v3/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V3.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4": {
-      "note": "Definition-only evaluation surface for exactly one future DEVELOPMENT_ONLY evaluation of Bollinger/MR midband exit-efficiency V4; reuses frozen V1 mechanism/gate/decision by import; binds measurement-validity preflight, EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1, PANEL_RUNNER_FALSY_ZERO hygiene, and MV2_WIRING_MOD_CAPTURE_ALIAS_OPEN_SIDE_BINDING_FIX; V4 contract remains DEFINITION_ONLY_PREREGISTERED with evaluation_run_count=0 in this slice; no evaluation executed here; evidence directory created only by a future authorized run; not a V1/V2/V3 rerun; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v4/",
-        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v4.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v4.py",
-        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v4/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V4.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5": {
-      "note": "Terminal DEVELOPMENT evaluation closeout for Bollinger/MR midband exit-efficiency V5 after one authorized run (0→1): RESULT_CLASS=INFRASTRUCTURE_FAILURE; DIAGNOSTIC_CLASS=PROCESS_DIED_INCOMPLETE_PANEL_RUN_NO_LIFECYCLE_TERMINAL; baseline 3/46; not a V4/V3/V2/V1 rerun; no V4 partial-result reuse; no holdout/runtime/orders; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no V5 rerun. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v5/",
-        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v5.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v5.py",
-        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v5/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V5.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6": {
-      "note": "Terminal DEVELOPMENT evaluation closeout for Bollinger/MR composite exit-efficiency V6 after one authorized run (0→1): RESULT_CLASS=FAIL; REASON=NET_PROFIT_FACTOR_NOT_IMPROVED; exit divergence observed; treatment binding confirmed; not a V5/V4/V3/V2/V1 rerun; no V5 partial-result reuse; no holdout/runtime/orders; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no V6 rerun. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_development_evaluation_v6/",
-        "scripts/research/run_evaluate_bollinger_mr_midband_exit_efficiency_development_v6.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_development_evaluation_v6.py",
-        "docs/evidence/evaluate_bollinger_mr_midband_exit_efficiency_development_v6/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_DEVELOPMENT_EVALUATION_V6.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of a single DEVELOPMENT_ONLY Bollinger/MR side-aware middle-band exit-efficiency measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v1.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v1.py",
-        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v1/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V2": {
-      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V2 with identical definition semantics to terminal V1; EVALUATION_RUN_COUNT=0; not a V1 rerun; no V1 partial-result reuse; mandatory EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 binding; no evaluation/runtime/orders.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v2.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v2.py",
-        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v2.json",
-        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v2/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V2.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V3": {
-      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V3 with identical economic/definition semantics to terminal V2/V1; EVALUATION_RUN_COUNT=0; not a V2 or V1 rerun; no V2 partial-result or economic-result import; mandatory EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1 and PANEL_RUNNER_FALSY_ZERO_PREMEASUREMENT_HYGIENE bindings; V2 remains terminal INCONCLUSIVE_INFRASTRUCTURE_FAILURE run count 1; no evaluation/runtime/orders.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v3.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v3.py",
-        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v3.json",
-        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v3/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V3.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V4": {
-      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V4 after terminal V3 FAIL; EVALUATION_RUN_COUNT=0; presupposes merged MV2 wiring_mod capture-alias open_side binding fix; fail-closed measurement-validity gates (effective config digest inequality, open_side binding, exit observability, synthetic divergence); not a V3/V2/V1 rerun; no evaluation/runtime/orders.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v4.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v4.py",
-        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v4.json",
-        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v4/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V4.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V5": {
-      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V5 after terminal V4 INFRASTRUCTURE_FAILURE; EVALUATION_RUN_COUNT=0; preserves V4 economic hypothesis/exit mechanism; adds process-lifecycle checkpoint observability; not a V4/V3/V2/V1 rerun; no evaluation/runtime/orders.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v5.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v5.py",
-        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v5.json",
-        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v5/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V5.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V6": {
-      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit-efficiency V6 after terminal V5 INFRASTRUCTURE_FAILURE; EVALUATION_RUN_COUNT=0; genuine economic change vs V5 (midband-cross OR frozen max-holding-horizon=48h); reuses V5 process-lifecycle checkpoint; not a V5/V4/V3/V2/V1 rerun; no V5 partial metrics; no evaluation/runtime/orders.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v6.py",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_hypothesis_preregistration_v6.py",
-        "config/research/bollinger_mr_midband_exit_efficiency_preregistered_economic_hypothesis_measurement_contract_v6.json",
-        "docs/evidence/preregister_bollinger_mr_midband_exit_efficiency_hypothesis_v6/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V6.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_PROCESS_LIFECYCLE_CHECKPOINT_V5": {
-      "note": "Definition-only process-lifecycle checkpoint scaffold for V5: monotonic lifecycle states, atomic checkpoints, read-only recovery diagnostics; import cannot start runner; checkpoints cannot reclaim run slots or authorize automatic reruns; partial metrics non-authoritative.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_efficiency_process_lifecycle_checkpoint_v5/",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_process_lifecycle_checkpoint_v5.py"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_V6_FAILURE_ATTRIBUTION": {
-      "note": "Evidence-only read-only failure attribution for terminal V6 FAIL (NET_PROFIT_FACTOR_NOT_IMPROVED). No evaluation/backtest/panel/holdout access; does not mutate V6 artifacts/run count; does not preregister or authorize V7; no promotion/runtime/orders; no Master-V2/Double-Play/risk/sizing/execution mutation.",
-      "path_prefixes": [
-        "docs/evidence/attribute_bollinger_mr_midband_exit_efficiency_v6_failure/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_EFFICIENCY_V6_FAILURE_ATTRIBUTION.md",
-        "tests/research/test_bollinger_mr_midband_exit_efficiency_v6_failure_attribution.py"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V7": {
-      "note": "Separate Operator ratification authorizing exactly one later V7 DEVELOPMENT evaluation run; does not mutate preregistration digest/field; requires released DEVELOPMENT panel; does not start runner or claim slot.",
-      "path_prefixes": [
-        "config/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.json",
-        "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.py",
-        "scripts/research/run_authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7.py",
-        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v7.py",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V7.md",
-        "docs/evidence/authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7/"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V8": {
-      "note": "Separate Operator ratification surface authorizing exactly one later V8 DEVELOPMENT evaluation run; requires pre-authorization parity PASS and released DEVELOPMENT panel; does not start runner or claim slot in wiring slice.",
-      "path_prefixes": [
-        "config/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.json",
-        "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.py",
-        "scripts/research/run_authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8.py",
-        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_authorization_ratification_v8.py",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V8.md",
-        "docs/evidence/authorize_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8/"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V7": {
-      "note": "V7 reentry-cooldown DEVELOPMENT evaluation surfaces; single authorized evaluate process consumed slot and terminated INCONCLUSIVE_INFRASTRUCTURE_FAILURE (PRE_PANEL_FROZEN_EXIT_PARAMETERS_MISMATCH_NO_PANEL_BACKTEST); no rerun; no holdout.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7/",
-        "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v7.py",
-        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v7.py",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V7.md",
-        "docs/evidence/preflight_bollinger_mr_midband_exit_reentry_cooldown_v7_wiring/",
-        "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v7/"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V8": {
-      "note": "V8 reentry-cooldown DEVELOPMENT evaluation wiring; pre-authorization parity before auth/slot; EVALUATION_RUN_COUNT=0; default CLI preflight-only; evaluate requires ratification+flag; evaluate evidence not pre-created; no evaluation/runtime/orders; V7 terminal unreopened.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8/",
-        "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v8.py",
-        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_development_evaluation_v8.py",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V8.md",
-        "docs/evidence/preflight_bollinger_mr_midband_exit_reentry_cooldown_v8_wiring/",
-        "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_development_v8/"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_EVALUATION_V1": {
-      "note": "Single authorized HOLDOUT_V1 evaluation of frozen Exit V8 midband reentry-cooldown treatment on sealed FINAL_AUDIT panel; terminal FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); economic/promotion/runtime/orders closed; V7/V8 terminals unchanged.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_evaluation_v1/",
-        "scripts/research/run_evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1.py",
-        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_holdout_evaluation_v1.py",
-        "docs/evidence/evaluate_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_EVALUATION_V1.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Holdout confirmation preregistration of frozen V8 midband exit reentry-cooldown (hypothesis HOLDOUT_V1; digest a0658fe3fb883939ed2a2de2c426f2e4edf21eeeb91d1b902d45b4d05a38fd1d); evaluation executed terminal FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); V8 digest immutable; no second run; no runtime/orders.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistration_v1.py",
-        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistration_v1.py",
-        "config/research/bollinger_mr_midband_exit_reentry_cooldown_holdout_preregistered_measurement_contract_v1.json",
-        "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_PREREGISTERED_MEASUREMENT_V1.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V7": {
-      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit reentry-cooldown V7 after terminal V6 FAIL + evidence-only attribution; EVALUATION_RUN_COUNT=0; control=exact V6 semantics; treatment=same-side reentry cooldown 24h after forced midband; not a V6 rerun; no V6 partial import; no evaluation/runtime/orders.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v7.py",
-        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v7.py",
-        "config/research/bollinger_mr_midband_exit_reentry_cooldown_preregistered_economic_hypothesis_measurement_contract_v7.json",
-        "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_v7/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V7.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V8": {
-      "note": "Definition-only preregistration of DEVELOPMENT_ONLY Bollinger/MR midband exit reentry-cooldown V8 after terminal V7 INCONCLUSIVE_INFRASTRUCTURE_FAILURE (FROZEN_EXIT_PARAMETERS_MISMATCH); EVALUATION_RUN_COUNT=0; control=exact V6 semantics; treatment=same-side reentry cooldown 24h; complete exit_mechanism.frozen_parameters SSOT; pre-authorization parity validator; not a V7 reopen/retry; no evaluation/runtime/orders.",
-      "path_prefixes": [
-        "src/research/bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v8.py",
-        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_preregistration_v8.py",
-        "config/research/bollinger_mr_midband_exit_reentry_cooldown_preregistered_economic_hypothesis_measurement_contract_v8.json",
-        "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_hypothesis_v8/",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V8.md"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V7": {
-      "note": "Governance overlay clarifying V7 implementation ambiguities B1-B6 without mutating immutable preregistration digest; operator_decisions_status OPERATOR_DECISIONS_RECORDED_IMPLEMENTATION_ONLY; lifecycle may transition READY_FOR_OPERATOR_EVALUATION_AUTHORIZATION -> EVALUATION_AUTHORIZED via separate ratification; evaluation_run_count=0 until run GO; no runtime/orders.",
-      "path_prefixes": [
-        "config/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.json",
-        "src/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.py",
-        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v7.py",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V7.md",
-        "docs/evidence/operator_clarification_bollinger_mr_midband_exit_reentry_cooldown_v7/"
-      ]
-    },
-    "BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V8": {
-      "note": "Governance overlay clarifying V8 B1-B6 without mutating immutable preregistration digest; lifecycle READY_FOR_OPERATOR_EVALUATION_AUTHORIZATION; evaluation_authorized=false until separate ratification; evaluation_run_count=0; no runtime/orders.",
-      "path_prefixes": [
-        "config/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.json",
-        "src/research/bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.py",
-        "tests/research/test_bollinger_mr_midband_exit_reentry_cooldown_operator_clarification_authority_v8.py",
-        "docs/governance/BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V8.md",
-        "docs/evidence/operator_clarification_bollinger_mr_midband_exit_reentry_cooldown_v8/"
-      ]
-    },
-    "CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1": {
-      "note": "Canonical SSOT backlog for open MR entry-eligibility hypotheses; explicit operator CLOSE_LANE_NO_FURTHER_RESEARCH under shared research-lane post-terminal lifecycle contract V1 (status=LANE_CLOSED_NO_FURTHER_RESEARCH; explicit_closeout_decision=true; lane_auto_closed=false); inventories empty; historical terminals immutable; no runtime/orders.",
-      "path_prefixes": [
-        "config/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.json",
-        "src/research/canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
-        "tests/research/test_canonical_open_mr_entry_eligibility_hypothesis_backlog_v1.py",
-        "docs/governance/CANONICAL_OPEN_MR_ENTRY_ELIGIBILITY_HYPOTHESIS_BACKLOG_V1.md"
-      ]
-    },
-    "CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1": {
-      "note": "Canonical SSOT backlog for open MR exit-efficiency hypotheses; explicit operator CREATE_SUCCESSOR_HYPOTHESIS under shared lifecycle contract V1 after V8 TERMINAL_PASS (status=OPEN_BACKLOG; holdout successor HOLDOUT_V1 DEFINITION_ONLY_PREREGISTERED; digest a0658fe3fb883939ed2a2de2c426f2e4edf21eeeb91d1b902d45b4d05a38fd1d); V8 identity unreopened; holdout execution unauthorized; Entry sibling LANE_CLOSED_NO_FURTHER_RESEARCH; Economic/promotion closed; no runtime/orders.",
-      "path_prefixes": [
-        "config/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.json",
-        "src/research/canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py",
-        "tests/research/test_canonical_open_mr_exit_efficiency_hypothesis_backlog_v1.py",
-        "docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md"
-      ]
-    },
-    "CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1": {
-      "note": "Shared definition-only research-lane post-terminal lifecycle contract; canonical lane-state vocabulary, totality invariant, operator-decision contract, and historical-immutability/live-mirror policy. Entry-Eligibility and Exit-Efficiency backlog SSOTs migrate in separate operator-authorized slices; no evaluation/runtime/orders.",
-      "path_prefixes": [
-        "config/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.json",
-        "src/research/canonical_research_lane_post_terminal_lifecycle_contract_v1.py",
-        "tests/research/test_canonical_research_lane_post_terminal_lifecycle_contract_v1.py",
-        "docs/governance/CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1.md"
-      ]
-    },
-    "COST_MODEL_DIAGNOSTICS": {
-      "path_globs": [
-        "tests/research/test_offline_linear_cost_model_diagnostics_*",
-        "tests/research/test_offline_signal_orthogonality_diagnostics_*",
-        "tests/research/test_offline_productive_signal_orthogonality_results_interpretation_v0.py",
-        "tests/research/test_offline_productive_factor_exposure_diagnostics_v0.py",
-        "tests/research/test_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-        "tests/research/test_offline_productive_rolling_linear_drift_diagnostics_v0.py",
-        "tests/research/test_offline_productive_linear_diagnostics_support_bundle_v0.py",
-        "tests/research/test_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-        "tests/research/test_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-        "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
-        "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
-        "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-        "tests/research/test_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-        "tests/research/test_offline_factor_exposure_diagnostics_*",
-        "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
-        "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
-        "tests/research/test_offline_final_research_fleet_signal_matrix_productive_input_join_materializer_*",
-        "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
-        "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_*",
-        "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
-        "tests/research/test_offline_parameter_sensitivity_model_spec_alignment_*",
-        "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*",
-        "tests/research/test_offline_rolling_linear_drift_diagnostics_v0.py",
-        "tests/research/test_offline_outlier_and_window_robustness_diagnostic_v0.py",
-        "tests/research/test_linear_evidence_*"
-      ],
-      "path_prefixes": [
-        "src/research/linear_evidence/cost_model.py",
-        "src/research/linear_evidence/diagnostics.py",
-        "src/research/linear_evidence/fitters.py",
-        "src/research/linear_evidence/drift.py",
-        "src/research/linear_evidence/window_robustness.py",
-        "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
-        "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
-        "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
-        "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
-        "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
-        "scripts/research/offline_linear_cost_model_diagnostics_v0.py",
-        "scripts/research/offline_signal_orthogonality_diagnostics_v0.py",
-        "scripts/research/offline_factor_exposure_diagnostics_v0.py",
-        "scripts/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
-        "scripts/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
-        "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
-        "scripts/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
-        "scripts/research/offline_rolling_linear_drift_diagnostics_v0.py",
-        "scripts/research/offline_outlier_and_window_robustness_diagnostic_v0.py",
-        "scripts/ops/materialize_offline_productive_signal_orthogonality_results_interpretation_v0.py",
-        "scripts/ops/materialize_offline_productive_factor_exposure_diagnostics_v0.py",
-        "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-        "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
-        "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
-        "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-        "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-        "scripts/ops/materialize_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
-        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-        "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
-        "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
-        "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
-        "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-        "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-        "src/research/linear_evidence/offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py"
-      ]
-    },
-    "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-      "note": "DEVELOPMENT evaluation entry point/owner for CS relative-strength momentum v1: executable evaluate path under fail-closed authorization, CLI preflight/dry-validate, digests/dataset/time-segment/rebalance-observation/evidence-registry/admission gates, wiring into canonical single-slot backtest metrics owners. Development evaluation authorized on HEAD; no runner start/run-slot consumption without separate execution GO; no holdout/runtime/orders; measurement thresholds and strategy score/selection semantics unchanged.",
-      "path_prefixes": [
-        "config/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_binding_v1.json",
-        "docs/evidence/evaluate_cross_sectional_relative_strength_momentum_development_v1/",
-        "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-        "scripts/research/run_evaluate_cross_sectional_relative_strength_momentum_development_v1.py",
-        "src/research/cross_sectional_relative_strength_momentum_v1_development_evaluation_v1/",
-        "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_entry_point_v1.py",
-        "tests/research/test_cross_sectional_relative_strength_momentum_v1_development_evaluation_executable_path_v1.py",
-        "tests/research/test_cross_sectional_relative_strength_momentum_v1_panel_loader_alignment_repair_v1.py"
-      ]
-    },
-    "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of cross-sectional relative-strength momentum v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; directional form D mutually exclusive single-slot selection; bounded DEV grid frozen; operator-authorized robustness thresholds (minimum_rebalance_observations=30, time_segment_robustness_pass_ratio=0.5) and CHRONOLOGICAL_EQUAL_DURATION_QUARTERS_V1 bound; development evaluation authorized; evaluation not executed; no holdout/runtime/orders; closed Entry/Exit Bollinger lanes untouched.",
-      "path_prefixes": [
-        "config/research/cross_sectional_relative_strength_momentum_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "src/research/cross_sectional_relative_strength_momentum_v1_hypothesis_preregistration_v1.py",
-        "tests/research/test_cross_sectional_relative_strength_momentum_v1_hypothesis_preregistration_v1.py",
-        "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-        "docs/evidence/preregister_cross_sectional_relative_strength_momentum_hypothesis_v1/"
-      ]
-    },
-    "CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-      "note": "Strategy-implementation-only surfaces for CS relative-strength momentum v1 (raw trailing log-return score + single-top1 rank-intent selection + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; no Master-V2/Double-Play mutation.",
-      "path_prefixes": [
-        "src/research/cross_sectional_relative_strength_momentum_v1_score_v1.py",
-        "src/research/cross_sectional_relative_strength_momentum_v1_selection_v1.py",
-        "src/research/cross_sectional_relative_strength_momentum_v1_strategy_implementation_binding_v1.py",
-        "config/research/cross_sectional_relative_strength_momentum_v1_strategy_implementation_binding_v1.json",
-        "tests/research/test_cross_sectional_relative_strength_momentum_v1_score_and_selection_v1.py",
-        "docs/governance/CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
-      ]
-    },
-    "DATA_BINDING_REPAIR": {
-      "path_prefixes": [
-        "src/research/offline_source_evidence_",
-        "scripts/research/offline_source_evidence_"
-      ]
-    },
-    "DETERMINISTIC_MATERIALIZATION_REPAIR": {
-      "path_prefixes": [
-        "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
-        "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
-        "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
-        "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
-        "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
-        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
-        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
-        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py"
-      ]
-    },
-    "DIGEST_BINDING_AND_PROVENANCE_REPAIR": {
-      "path_globs": [
-        "scripts/ops/*digest*",
-        "scripts/ops/*binding*"
-      ],
-      "path_prefixes": [
-        "scripts/ops/primary_evidence_retention_v0.py"
-      ]
-    },
-    "DOUBLE_PLAY_COMPOSITION_NARROW_RESEARCH_REWIRE": {
-      "path_globs": [
-        "tests/research/test_double_play_composition_narrow_reuse_first_rewire_v0.py"
-      ],
-      "path_prefixes": [
-        "scripts/research/double_play_composition_narrow_reuse_first_rewire_v0.py"
-      ]
-    },
-    "ENTRY_EFFECTIVE_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-      "note": "Single preregistered DEVELOPMENT-only offline evaluation of entry-effective pre-entry ATR-percentile mid-band MR eligibility filter (STRICT bounds) versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of the prior failed regime_gated evaluation's shared_portfolio_equity_research_v1 helper only (no mutation of that package); no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-      "path_prefixes": [
-        "src/research/entry_effective_mr_eligibility_development_evaluation_v1/",
-        "scripts/research/run_evaluate_entry_effective_mr_eligibility_development_v1.py",
-        "tests/research/test_entry_effective_mr_eligibility_development_evaluation_v1.py",
-        "docs/evidence/evaluate_entry_effective_mr_eligibility_development_v1/",
-        "docs/governance/ENTRY_EFFECTIVE_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
-      ]
-    },
-    "ENTRY_EFFECTIVE_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of a single entry-effective pre-entry ATR-percentile MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-      "path_prefixes": [
-        "src/research/entry_effective_mr_eligibility_hypothesis_preregistration_v1.py",
-        "tests/research/test_entry_effective_mr_eligibility_hypothesis_preregistration_v1.py",
-        "config/research/entry_effective_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "docs/evidence/preregister_entry_effective_mr_eligibility_hypothesis_v1/",
-        "docs/governance/ENTRY_EFFECTIVE_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
-      ]
-    },
-    "EVALUATION_RUNNER_LIFECYCLE_OBSERVABILITY_V1": {
-      "note": "Generic research-infrastructure observability for evaluation-runner process death (atomic heartbeat/progress, catchable signal handlers, exit/signal normalization, supervised child reap, INCONCLUSIVE_INFRASTRUCTURE_FAILURE classification without auto-rerun); no strategy/Master-V2/Double-Play/risk/sizing/execution/economic semantics mutation; no evaluation rerun; no holdout access; no runtime/orders.",
-      "path_prefixes": [
-        "src/research/evaluation_runner_lifecycle_observability_v1/",
-        "tests/research/test_evaluation_runner_lifecycle_observability_v1.py",
-        "docs/evidence/evaluation_runner_lifecycle_observability_v1/"
-      ]
-    },
-    "EXPLICITLY_CALIBRATABLE_RESEARCH_PARAMETERS_WITHIN_PREDECLARED_RANGES": {
-      "path_prefixes": [
-        "src/research/linear_evidence/sensitivity.py",
-        "src/research/linear_evidence/drift.py",
-        "src/research/linear_evidence/window_robustness.py",
-        "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
-        "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
-        "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
-        "scripts/research/offline_parameter_sensitivity_surface_v0.py",
-        "scripts/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
-        "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-        "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py"
-      ]
-    },
-    "FEATURE_SCALING_OR_NUMERICAL_CONDITIONING_WITHOUT_TRADING_SEMANTIC_EFFECT": {
-      "path_prefixes": [
-        "src/research/linear_evidence/feature_matrix.py",
-        "src/research/linear_evidence/contracts.py",
-        "src/research/linear_evidence/signal_orthogonality.py",
-        "src/research/linear_evidence/signal_orthogonality_results_interpretation_v0.py",
-        "src/research/linear_evidence/offline_productive_factor_exposure_diagnostics_v0.py",
-        "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
-        "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
-        "src/research/linear_evidence/offline_productive_linear_diagnostics_support_bundle_v0.py",
-        "src/research/linear_evidence/offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-        "src/research/linear_evidence/offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-        "src/research/linear_evidence/factor_exposure.py",
-        "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
-        "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
-        "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
-        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
-        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
-        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py"
-      ]
-    },
-    "GOVERNANCE_ONLY_OPERATOR_RATIFICATION_AND_RESEARCH_SCOPE_DEFINITION_WITHOUT_TRADING_SEMANTIC_EFFECT": {
-      "note": "Governance-only operator ratification and research scope definition without trading semantic mutation or runtime authority.",
-      "path_globs": [
-        "src/research/*terminal_inconclusive_insufficient_sample_and_distinct_futures_research_scope_definition_v0.py",
-        "src/research/*terminal_insufficient_sample_and_distinct_futures_research_scope_ratification_v0.py",
-        "src/research/*research_scope_ratification_v0.py",
-        "src/research/*versioned_hypothesis_binding_v0.py",
-        "src/research/*versioned_research_binding_v0.py",
-        "src/research/*score_and_ranking_contract_v0.py",
-        "src/research/*portfolio_binding_v0.py",
-        "src/research/cross_sectional_futures_pairwise_lead_lag_spillover_*_score_v0.py",
-        "scripts/research/materialize_*operator_ratification*",
-        "scripts/research/materialize_*scope_ratification*",
-        "scripts/research/materialize_*terminal_*research_scope*",
-        "scripts/research/materialize_*versioned_hypothesis_binding_v0.py",
-        "scripts/research/materialize_*versioned_research_binding_v0.py",
-        "scripts/research/materialize_*score_and_ranking_contract_v0.py",
-        "scripts/research/materialize_*portfolio_binding_implementation_v0.py",
-        "scripts/research/materialize_*offline_economic_evaluation_authorization_ratification_v0.py",
-        "src/research/*offline_economic_evaluation_authorization_ratification_v0.py",
-        "src/research/full_canonical_system_economic_evidence_generation_v1.py",
-        "scripts/research/materialize_full_canonical_system_economic_evidence_generation_v1_binding_ratification_v0.py",
-        "tests/research/test_*versioned_hypothesis_binding_v0_contract.py",
-        "tests/research/test_*versioned_research_binding_v0_contract.py",
-        "tests/research/test_*score_and_ranking_contract_v0_contract.py",
-        "tests/research/test_*portfolio_binding_implementation_v0_contract.py",
-        "tests/research/test_*offline_economic_evaluation_authorization_ratification_v0_contract.py",
-        "tests/research/test_full_canonical_system_economic_evidence_generation_v1_binding_ratification_v0_contract.py",
-        "config/research/*governance_closeout_v0.json",
-        "docs/governance/*GOVERNANCE_CLOSEOUT_V0.md",
-        "tests/ops/test_*governance_closeout_v0_contract.py"
-      ]
-    },
-    "INDEPENDENT_DEV_PANEL_QUARANTINE_RELEASE_V1": {
-      "note": "Byte-identical quarantine to RELEASED_DEVELOPMENT_ONLY panel release; no transform; no holdout; does not authorize evaluation.",
-      "path_prefixes": [
-        "config/research/independent_dev_panel_quarantine_release_contract_v1.json",
-        "src/research/independent_dev_panel_quarantine_release_v1.py",
-        "scripts/research/run_release_independent_dev_panel_quarantine_v1.py",
-        "tests/research/test_independent_dev_panel_quarantine_release_v1.py",
-        "docs/governance/INDEPENDENT_DEV_PANEL_QUARANTINE_RELEASE_V1.md",
-        "docs/evidence/release_independent_dev_panel_quarantine_byte_identical_v1/"
-      ]
-    },
-    "LONGER_CHRONOLOGICAL_PIT_PUBLIC_HISTORY_ACQUISITION_SCAFFOLD_AND_DEPTH_PROBE_V1": {
-      "note": "Research-only public OKX history acquisition scaffold, bounded history-depth probe, sealed production-lifecycle long-panel binding/acquisition, and independent pre-holdout development-panel seal; dry-run/no-credentials defaults; no economic optimization; no strategy/risk/execution/Master-V2/Double-Play mutation.",
-      "path_prefixes": [
-        "src/research/longer_chronological_pit_acquisition_v1/",
-        "tests/research/test_longer_chronological_pit_acquisition_scaffold_v1.py",
-        "tests/research/test_longer_chronological_pit_okx_history_depth_probe_v1.py",
-        "tests/research/test_longer_chronological_pit_sealed_lifecycle_acquisition_v1.py",
-        "config/research/longer_chronological_pit_acquisition_chrono_3y_v1.json",
-        "config/research/longer_chronological_pit_sealed_lifecycle_long_panel_v1.json",
-        "config/research/regime_gated_standaside_mr_independent_dev_panel_acquisition_contract_v1.json",
-        "config/research/regime_gated_standaside_mr_independent_dev_panel_seal_registry_v1.json",
-        "docs/evidence/longer_chronological_pit_sealed_lifecycle_acquisition_v1/",
-        "docs/evidence/acquire_and_seal_okx_independent_dev_panel_v1/",
-        "docs/governance/REGIME_GATED_STANDASIDE_MR_INDEPENDENT_DEV_PANEL_SEALED_V1.md",
-        "tests/governance/test_acquire_and_seal_okx_independent_dev_panel_v1.py"
-      ]
-    },
-    "MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-      "note": "Single preregistered DEVELOPMENT-only offline evaluation of MACD(12,26,9) histogram-sign countertrend pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=FAIL, NET_PROFIT_FACTOR_NOT_IMPROVED); research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-      "path_prefixes": [
-        "src/research/macd_histogram_countertrend_mr_eligibility_development_evaluation_v1/",
-        "scripts/research/run_evaluate_macd_histogram_countertrend_mr_eligibility_development_v1.py",
-        "tests/research/test_macd_histogram_countertrend_mr_eligibility_development_evaluation_v1.py",
-        "docs/evidence/evaluate_macd_histogram_countertrend_mr_eligibility_development_v1/",
-        "docs/governance/MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
-      ]
-    },
-    "MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of a single MACD(12,26,9) histogram-sign countertrend admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to five prior FAILs (regime, ATR, RSI, ADX, MA); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-      "path_prefixes": [
-        "src/research/macd_histogram_countertrend_mr_eligibility_hypothesis_preregistration_v1.py",
-        "tests/research/test_macd_histogram_countertrend_mr_eligibility_hypothesis_preregistration_v1.py",
-        "config/research/macd_histogram_countertrend_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "docs/evidence/preregister_macd_histogram_countertrend_mr_eligibility_hypothesis_v1/",
-        "docs/governance/MACD_HISTOGRAM_COUNTERTREND_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
-      ]
-    },
-    "MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_HYPOTHESIS_BACKLOG_V1": {
-      "note": "Closed lane SSOT for material-different cross-sectional momentum program after CROSS_SECTIONAL_RELATIVE_STRENGTH_MOMENTUM_V1 FAIL_CLOSED_NO_RETRY; inventories empty of open/preregistered candidates; terminal hypothesis recorded; no successor; retry/reopen forbidden; evaluation/holdout/promotion/runtime closed; sibling Entry/Exit lanes remain LANE_CLOSED_NO_FURTHER_RESEARCH unreopened.",
-      "path_prefixes": [
-        "config/research/material_different_cross_sectional_momentum_hypothesis_backlog_v1.json",
-        "src/research/material_different_cross_sectional_momentum_hypothesis_backlog_v1.py",
-        "tests/research/test_material_different_cross_sectional_momentum_hypothesis_backlog_v1.py",
-        "docs/governance/MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_HYPOTHESIS_BACKLOG_V1.md"
-      ]
-    },
-    "MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_PROGRAM_V1": {
-      "note": "Closed research-program SSOT after CS-RS-Momentum v1 FAIL_CLOSED_NO_RETRY; run budget consumed (1/1); no successor; no retry/reopen; no holdout/runtime/orders; causal independence from closed Bollinger Entry/Exit lanes retained; new research requires separate operator authorization and preregistration.",
-      "path_prefixes": [
-        "config/research/material_different_cross_sectional_momentum_program_v1.json",
-        "src/research/material_different_cross_sectional_momentum_program_v1.py",
-        "tests/research/test_material_different_cross_sectional_momentum_program_v1.py",
-        "docs/governance/MATERIAL_DIFFERENT_CROSS_SECTIONAL_MOMENTUM_PROGRAM_V1.md"
-      ]
-    },
-    "MA_TREND_ALIGNMENT_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-      "note": "Single preregistered DEVELOPMENT-only offline evaluation of SMA(50) side-aware with-trend admission pre-entry MR eligibility filter versus immutable bollinger baseline (run count 1/1, RESULT_CLASS=FAIL, NET_PROFIT_FACTOR_NOT_IMPROVED); research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-      "path_prefixes": [
-        "src/research/ma_trend_alignment_mr_eligibility_development_evaluation_v1/",
-        "scripts/research/run_evaluate_ma_trend_alignment_mr_eligibility_development_v1.py",
-        "tests/research/test_ma_trend_alignment_mr_eligibility_development_evaluation_v1.py",
-        "docs/evidence/evaluate_ma_trend_alignment_mr_eligibility_development_v1/",
-        "docs/governance/MA_TREND_ALIGNMENT_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
-      ]
-    },
-    "MA_TREND_ALIGNMENT_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of a single SMA(50) side-aware with-trend admission pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to four prior FAILs (regime, ATR, RSI, ADX); no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-      "path_prefixes": [
-        "src/research/ma_trend_alignment_mr_eligibility_hypothesis_preregistration_v1.py",
-        "tests/research/test_ma_trend_alignment_mr_eligibility_hypothesis_preregistration_v1.py",
-        "config/research/ma_trend_alignment_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "docs/evidence/preregister_ma_trend_alignment_mr_eligibility_hypothesis_v1/",
-        "docs/governance/MA_TREND_ALIGNMENT_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
-      ]
-    },
-    "OFFLINE_ECONOMIC_EVALUATION_EXECUTION_INFRASTRUCTURE_WITHOUT_TRADING_SEMANTIC_EFFECT": {
-      "note": "Offline economic evaluation execution infrastructure, preexecution guards, invocation-bound authorization repair, and contract tests without trading semantic mutation or runtime authority.",
-      "path_globs": [
-        "src/research/*offline_economic_evaluation_execution_v0.py",
-        "src/research/cross_sectional_cost_execution_binding_normalization_v0.py",
-        "src/research/*offline_economic_evaluation_scope_ratification_v0.py",
-        "tests/research/test_*offline_economic_evaluation_execution_infrastructure_v0.py",
-        "tests/research/test_*offline_economic_evaluation_execution_dispatch_implementation_v0.py",
-        "tests/research/test_*offline_economic_evaluation_execution_implementation_repair_v0.py",
-        "tests/research/test_*offline_economic_evaluation_dispatch_to_baseline_repair_v0.py",
-        "tests/research/test_*offline_economic_evaluation_reevaluation_execution_implementation_v0.py",
-        "tests/research/test_*offline_economic_evaluation_reevaluation_execution_ops_runner_branch_v0.py",
-        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_ops_runner_branch_v0.py",
-        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_implementation_v0.py",
-        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_actual_execution_owner_implementation_v0.py",
-        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_dataset_digest_reconciliation_repair_v0.py",
-        "tests/research/test_*offline_economic_evaluation_reevaluation_baseline_execution_data_unavailable_repair_v0.py",
-        "tests/research/test_*offline_economic_evaluation_baseline_execution_implementation_v0.py",
-        "tests/research/test_*baseline_execution_entry_point_result_contract_repair_v0.py",
-        "tests/research/test_trend_following_v2_baseline_owner_single_member_end_to_end_repair_v0.py",
-        "tests/research/test_trend_following_v2_mandatory_boundary_state_file_binding_rewire_v0.py",
-        "tests/research/test_trend_following_v2_canonical_wiring_map_contract_v0.py",
-        "tests/research/test_*offline_economic_evaluation_entry_point_guard_and_dispatch_repair_v0.py",
-        "src/backtest/economic_viability_evidence_v1.py",
-        "config/ops/trend_following_v2_economic_evaluation_v1.json",
-        "src/research/panel_sequential_signal_density_research_adapter_v0.py",
-        "src/research/versioned_final_fleet_bindings_offline_economic_evaluation_v0.py",
-        "src/research/final_research_fleet_offline_economic_evaluation_execution_v0.py",
-        "scripts/ops/run_*offline_economic_evaluation_execution_v0.py",
-        "scripts/ops/materialize_*offline_economic_evaluation_baseline_execution_implementation_v0.py",
-        "scripts/ops/materialize_*offline_economic_evaluation_execution_*_implementation_v0.py",
-        "tests/research/test_*offline_economic_evaluation_execution_authorization_ratification_repair_v0.py",
-        "tests/research/test_*execution_v1_token_binding_repair_v0.py",
-        "tests/research/test_*offline_economic_evaluation_full_runner_v0.py",
-        "src/research/*offline_economic_evaluation_execution_authorization_supersession_v*.py",
-        "scripts/research/materialize_*offline_economic_evaluation_execution_authorization_supersession_v*.py",
-        "config/research/*offline_economic_evaluation_execution_authorization_supersession_v*.json",
-        "config/research/full_canonical_system_economic_evidence_generation_v1_offline_execution_result_v0.json",
-        "tests/research/test_full_canonical_system_economic_evidence_generation_v1_offline_execution_result_v0_contract.py"
-      ]
-    },
-    "OFFLINE_MV2_ZERO_TRADE_PER_BAR_DECISION_OUTCOME_DIAGNOSTIC_WITHOUT_TRADING_SEMANTIC_EFFECT": {
-      "note": "Offline-only per-bar MV2 decision-outcome diagnostic for zero-trade root-cause observability; observational hook only; no trading/runtime/authority/sizing semantic mutation.",
-      "path_prefixes": [
-        "src/research/mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
-        "scripts/research/run_mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
-        "tests/research/test_mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.py",
-        "config/research/mv2_zero_trade_per_bar_decision_outcome_diagnostic_v1.json"
-      ]
-    },
-    "POINT_IN_TIME_DATA_QUALITY_REPAIR": {
-      "path_prefixes": [
-        "src/backtest/admissible_versioned_futures_dataset_v1.py",
-        "src/research/admissible_"
-      ]
-    },
-    "PORTFOLIO_RESEARCH_AND_ECONOMIC_ATTRIBUTION_WITHOUT_RUNTIME_AUTHORITY": {
-      "path_prefixes": [
-        "src/experiments/evidence_chain.py",
-        "src/experiments/strategy_profiles.py",
-        "src/research/offline_economic_viability_evidence_gap_assessment_v0.py"
-      ]
-    },
-    "REAL_FILL_BINDING": {
-      "note": "Real fill binding repair only; no trading semantic mutation.",
-      "path_prefixes": [
-        "src/backtest/engine.py"
-      ]
-    },
-    "REGIME_GATED_STANDASIDE_MR_DEVELOPMENT_EVALUATION_V1": {
-      "note": "Single preregistered DEVELOPMENT-only offline evaluation of regime-gated standaside MR versus immutable bollinger baseline; research-only entry-eligibility gate; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-      "path_prefixes": [
-        "src/research/regime_gated_standaside_mr_development_evaluation_v1/",
-        "scripts/research/run_evaluate_regime_gated_standaside_mr_development_v1.py",
-        "tests/research/test_regime_gated_standaside_mr_development_evaluation_v1.py",
-        "docs/evidence/evaluate_regime_gated_standaside_mr_development_v1/",
-        "docs/governance/REGIME_GATED_STANDASIDE_MR_DEVELOPMENT_EVALUATION_V1.md"
-      ]
-    },
-    "REGIME_GATED_STANDASIDE_MR_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of a single regime-gated stand-aside mean-reversion measurement contract on the sealed DEVELOPMENT_ONLY panel; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-      "path_prefixes": [
-        "src/research/regime_gated_standaside_mr_hypothesis_preregistration_v1.py",
-        "tests/research/test_regime_gated_standaside_mr_hypothesis_preregistration_v1.py",
-        "config/research/regime_gated_standaside_mr_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "docs/evidence/preregister_regime_gated_standaside_mr_hypothesis_v1/",
-        "docs/governance/REGIME_GATED_STANDASIDE_MR_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
-      ]
-    },
-    "REPORTING_AND_EVIDENCE_REPAIR": {
-      "path_globs": [
-        "scripts/ops/*evidence*",
-        "scripts/ops/*manifest*"
-      ],
-      "path_prefixes": [
-        "scripts/ops/primary_evidence_retention_v0.py",
-        "scripts/ops/verify_pre_pr_validation_result_v0.py",
-        "scripts/ops/materialize_offline_productive_signal_orthogonality_results_interpretation_v0.py",
-        "scripts/ops/materialize_offline_productive_factor_exposure_diagnostics_v0.py",
-        "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-        "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
-        "scripts/ops/materialize_offline_productive_linear_diagnostics_support_bundle_v0.py",
-        "scripts/ops/materialize_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-        "scripts/ops/materialize_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-        "scripts/research/classify_step29l2_offline_linear_evidence_status_after_pr5044_v0.py",
-        "scripts/research/materialize_bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
-        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
-        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py",
-        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_economic_evidence_consumer_binding_v0.py",
-        "scripts/ops/materialize_bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_promotion_economic_gate_consumer_binding_v0.py",
-        "tests/research/test_step29l2_import_boundary_classification_v0.py"
-      ]
-    },
-    "RSI_EXHAUSTION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1": {
-      "note": "Single preregistered DEVELOPMENT-only offline evaluation of RSI(14)-exhaustion pre-entry MR eligibility filter versus immutable bollinger baseline; research-only entry-eligibility gate; read-only reuse of entry_effective decision/gate helpers and regime_gated shared_portfolio_equity_research_v1; no holdout access; no productive Master-V2/Double-Play/risk/sizing/execution mutation; no promotion/runtime/orders.",
-      "path_prefixes": [
-        "src/research/rsi_exhaustion_mr_eligibility_development_evaluation_v1/",
-        "scripts/research/run_evaluate_rsi_exhaustion_mr_eligibility_development_v1.py",
-        "tests/research/test_rsi_exhaustion_mr_eligibility_development_evaluation_v1.py",
-        "docs/evidence/evaluate_rsi_exhaustion_mr_eligibility_development_v1/",
-        "docs/governance/RSI_EXHAUSTION_MR_ELIGIBILITY_DEVELOPMENT_EVALUATION_V1.md"
-      ]
-    },
-    "RSI_EXHAUSTION_MR_ELIGIBILITY_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of a single RSI(14)-exhaustion pre-entry MR eligibility measurement contract on the sealed DEVELOPMENT_ONLY panel, orthogonal to the failed ATR-percentile mid-band and failed regime-gated absolute-threshold mechanisms; no backtest, no economic metrics, no holdout access, no productive authority mutation.",
-      "path_prefixes": [
-        "src/research/rsi_exhaustion_mr_eligibility_hypothesis_preregistration_v1.py",
-        "tests/research/test_rsi_exhaustion_mr_eligibility_hypothesis_preregistration_v1.py",
-        "config/research/rsi_exhaustion_mr_eligibility_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "docs/evidence/preregister_rsi_exhaustion_mr_eligibility_hypothesis_v1/",
-        "docs/governance/RSI_EXHAUSTION_MR_ELIGIBILITY_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md"
-      ]
-    },
-    "SIMULATED_FILL_BINDING_USING_EXISTING_CANONICAL_EXECUTION_OWNER": {
-      "note": "Simulated fill binding must reuse existing canonical execution owners; no new runtime authority.",
-      "path_globs": [
-        "tests/backtest/test_engine_signal_source_mv2_replay_binding_contract_v0.py",
-        "tests/research/test_cross_sectional_lead_lag_v0_backtest_engine_mv2_replay_signal_parity_v0.py",
-        "tests/research/test_cross_sectional_lead_lag_v0_research_eval_decision_parity_contract_suite_v0.py"
-      ],
-      "path_prefixes": [
-        "src/backtest/mv2_research_wiring_v1.py",
-        "src/backtest/strategy_signal_binding_v1.py"
-      ]
-    },
-    "SLIPPAGE_MODEL_DIAGNOSTICS": {
-      "path_prefixes": [
-        "src/research/linear_evidence/cost_model.py"
-      ]
-    },
-    "TARGET_BINDING_REPAIR": {
-      "path_globs": [
-        "tests/research/test_offline_linear_cost_diagnostic_row_materializer_*",
-        "tests/research/test_offline_factor_exposure_productive_contract_v0.py",
-        "tests/research/test_offline_factor_exposure_productive_input_join_materializer_*",
-        "tests/research/test_offline_final_research_fleet_signal_matrix_productive_input_join_materializer_*",
-        "tests/research/test_offline_parameter_sensitivity_productive_contract_v0.py",
-        "tests/research/test_offline_parameter_sensitivity_productive_input_join_materializer_*",
-        "tests/research/test_offline_productive_point_in_time_factor_snapshot_rematerializer_*"
-      ],
-      "path_prefixes": [
-        "src/research/offline_linear_cost_diagnostic_row_materializer_v0.py",
-        "src/research/offline_factor_exposure_productive_input_join_materializer_v0.py",
-        "src/research/offline_final_research_fleet_signal_matrix_productive_input_join_materializer_v0.py",
-        "src/research/offline_parameter_sensitivity_productive_input_join_materializer_v0.py",
-        "src/research/offline_productive_point_in_time_factor_snapshot_rematerializer_v0.py",
-        "src/research/linear_evidence/feature_matrix.py",
-        "src/research/linear_evidence/sensitivity.py",
-        "src/research/linear_evidence/drift.py",
-        "src/research/linear_evidence/window_robustness.py",
-        "src/research/linear_evidence/factor_exposure_productive_contract_v0.py",
-        "src/research/linear_evidence/signal_matrix_productive_contract_v0.py",
-        "src/research/linear_evidence/parameter_sensitivity_productive_contract_v0.py",
-        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_research_generation_preparation_v0.py",
-        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_feature_matrix_binding_v0.py",
-        "src/research/bouchaud_microstructure_ohlcv_proxy_v1_offline_productive_linear_diagnostics_execution_and_support_evidence_v0.py"
-      ]
-    },
-    "TIME_ORDERED_VALIDATION": {
-      "path_prefixes": [
-        "src/backtest/walkforward.py",
-        "tests/backtest/test_walkforward*"
-      ]
-    },
-    "VOLATILITY_COMPRESSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_COMPRESSION_BREAKOUT_V1: executable evaluate path with panel execution boundary and productive exit/PnL evaluator bound to canonical BacktestEngine fee/slippage/gross-PnL primitives; authorized on HEAD; no evaluation execution/run-slot consumption without separate GO; no holdout/runtime/orders; measurement thresholds and strategy/baseline parameters unchanged.",
-      "path_prefixes": [
-        "config/research/volatility_compression_breakout_v1_development_evaluation_entry_point_binding_v1.json",
-        "docs/evidence/evaluate_volatility_compression_breakout_development_v1/",
-        "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-        "scripts/research/run_evaluate_volatility_compression_breakout_development_v1.py",
-        "src/research/volatility_compression_breakout_v1_development_evaluation_v1/",
-        "tests/research/test_volatility_compression_breakout_v1_development_evaluation_entry_point_v1.py",
-        "tests/research/test_volatility_compression_breakout_v1_development_evaluation_executable_path_v1.py",
-        "tests/research/test_volatility_compression_breakout_v1_development_evaluation_fail_closed_report_v1.py",
-        "tests/research/test_volatility_compression_breakout_v1_productive_exit_pnl_evaluator_v1.py"
-      ]
-    },
-    "VOLATILITY_COMPRESSION_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of own-instrument volatility compression→expansion→channel-breakout v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; frozen ATR(20)/close percentile-rank admission, unconditional channel-breakout baseline, event-sufficiency gates; material difference vs terminal VOL_BREAKOUT_COILED_SPRING explicit; development evaluation authorized; evaluation not executed; no holdout/runtime/orders.",
-      "path_prefixes": [
-        "config/research/volatility_compression_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "src/research/volatility_compression_breakout_v1_hypothesis_preregistration_v1.py",
-        "tests/research/test_volatility_compression_breakout_v1_hypothesis_preregistration_v1.py",
-        "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-        "docs/evidence/preregister_volatility_compression_breakout_hypothesis_v1/"
-      ]
-    },
-    "VOLATILITY_COMPRESSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-      "note": "Strategy-implementation-only surfaces for VOLATILITY_COMPRESSION_BREAKOUT_V1 (shared 20-bar price-channel core + ATR20/close percentile vol-state + compression/release admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; no Master-V2/Double-Play/risk/execution mutation.",
-      "path_prefixes": [
-        "src/research/price_channel_breakout_core_v1.py",
-        "src/research/volatility_compression_breakout_v1_vol_state_v1.py",
-        "src/research/volatility_compression_breakout_v1_strategy_v1.py",
-        "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
-        "src/research/volatility_compression_breakout_v1_strategy_implementation_binding_v1.py",
-        "config/research/volatility_compression_breakout_v1_strategy_implementation_binding_v1.json",
-        "tests/research/test_volatility_compression_breakout_v1_strategy_implementation_v1.py",
-        "docs/governance/VOLATILITY_COMPRESSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
-      ]
-    },
-    "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1: development evaluation slot consumed FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; productive exit/PnL evaluator reused from VCB package (not duplicated). No retry; no holdout/runtime/orders; strategy/baseline parameters unchanged; VDBX/VDB/VEP/VCB artifacts unchanged.",
-      "path_prefixes": [
-        "config/research/volatility_contraction_expansion_breakout_v1_development_evaluation_entry_point_binding_v1.json",
-        "docs/evidence/evaluate_volatility_contraction_expansion_breakout_development_v1/",
-        "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-        "scripts/research/run_evaluate_volatility_contraction_expansion_breakout_development_v1.py",
-        "src/research/volatility_contraction_expansion_breakout_v1_development_evaluation_v1/",
-        "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_entry_point_v1.py",
-        "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_executable_path_v1.py",
-        "tests/research/test_volatility_contraction_expansion_breakout_v1_development_evaluation_fail_closed_report_v1.py"
-      ]
-    },
-    "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1 after terminal VDBX FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; frozen realized-vol contraction->expansion joint breakout admission + pairable exit precedence; productive PnL evaluator referenced only; no Development evaluation/holdout/runtime/orders; VDBX/VDB/VEP/VCB retry forbidden.",
-      "path_prefixes": [
-        "config/research/volatility_contraction_expansion_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "src/research/volatility_contraction_expansion_breakout_v1_hypothesis_preregistration_v1.py",
-        "tests/research/test_volatility_contraction_expansion_breakout_v1_hypothesis_preregistration_v1.py",
-        "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-        "docs/evidence/preregister_volatility_contraction_expansion_breakout_hypothesis_v1/"
-      ]
-    },
-    "VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-      "note": "Strategy + exit state machine for VCEB v1 (RV24 contraction->expansion joint break + opposite-break exits without trailing); productive PnL evaluator referenced not duplicated; measurement digest frozen; no evaluation/holdout/runtime/orders; VDBX/VDB/VEP/VCB retry forbidden.",
-      "path_prefixes": [
-        "src/research/price_channel_breakout_core_v1.py",
-        "src/research/volatility_contraction_expansion_breakout_v1_vol_state_v1.py",
-        "src/research/volatility_contraction_expansion_breakout_v1_exit_state_machine_v1.py",
-        "src/research/volatility_contraction_expansion_breakout_v1_strategy_v1.py",
-        "src/research/volatility_contraction_expansion_breakout_v1_strategy_implementation_binding_v1.py",
-        "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
-        "config/research/volatility_contraction_expansion_breakout_v1_strategy_implementation_binding_v1.json",
-        "tests/research/test_volatility_contraction_expansion_breakout_v1_strategy_and_exit_state_machine_v1.py",
-        "docs/governance/VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
-      ]
-    },
-    "VOLATILITY_DECAY_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_DECAY_BREAKOUT_V1: panel execution boundary materialized; productive exit/PnL evaluator reused from VCB. Single bounded development attempt fail-closed at PRODUCTIVE_PNL_OVERFLOW with durable run slot consumed (1/1); archival panel-boundary fail_closed_report retained; bounded corrective measurement reevaluation executed once and fail-closed at UNPAIRABLE_ENTRY_NO_EXIT (corrective slot 1/1; development counters preserved at 1; prior development evidence unmodified; supersession audited in corrective bundle); no holdout/runtime/orders; no development or corrective retry; VCB/VEP slots not reused.",
-      "path_prefixes": [
-        "config/research/volatility_decay_breakout_v1_development_evaluation_entry_point_binding_v1.json",
-        "docs/evidence/evaluate_volatility_decay_breakout_corrective_measurement_reevaluation_v1/",
-        "docs/evidence/evaluate_volatility_decay_breakout_development_v1/",
-        "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-        "scripts/research/run_evaluate_volatility_decay_breakout_development_v1.py",
-        "src/research/volatility_decay_breakout_v1_development_evaluation_v1/",
-        "tests/research/test_volatility_decay_breakout_v1_corrective_measurement_reevaluation_v1.py",
-        "tests/research/test_volatility_decay_breakout_v1_development_evaluation_entry_point_v1.py",
-        "tests/research/test_volatility_decay_breakout_v1_development_evaluation_fail_closed_report_v1.py",
-        "tests/research/test_volatility_decay_breakout_v1_development_evaluation_executable_path_v1.py"
-      ]
-    },
-    "VOLATILITY_DECAY_BREAKOUT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of own-instrument volatility decay-breakout v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures after terminal VEP-V1 UNPAIRABLE_ENTRY_NO_EXIT; frozen ATR(14)/close high→low decay admission + channel-breakout baseline; material difference vs VEP/VCB/coiled-spring explicit; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced only; VEP retry/exit-repair forbidden.",
-      "path_prefixes": [
-        "config/research/volatility_decay_breakout_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "src/research/volatility_decay_breakout_v1_hypothesis_preregistration_v1.py",
-        "tests/research/test_volatility_decay_breakout_v1_hypothesis_preregistration_v1.py",
-        "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-        "docs/evidence/preregister_volatility_decay_breakout_hypothesis_v1/",
-        "docs/evidence/forensic_classify_vep_v1_unpairable_entry_no_exit_v1/"
-      ]
-    },
-    "VOLATILITY_DECAY_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-      "note": "Strategy-implementation-only surfaces for VOLATILITY_DECAY_BREAKOUT_V1 (shared 20-bar price-channel core + ATR14/close percentile vol-state + high→low decay admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced not duplicated; no Master-V2/Double-Play/risk/execution mutation; VEP/VCB retry forbidden.",
-      "path_prefixes": [
-        "src/research/price_channel_breakout_core_v1.py",
-        "src/research/volatility_decay_breakout_v1_vol_state_v1.py",
-        "src/research/volatility_decay_breakout_v1_strategy_v1.py",
-        "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
-        "src/research/volatility_decay_breakout_v1_strategy_implementation_binding_v1.py",
-        "config/research/volatility_decay_breakout_v1_strategy_implementation_binding_v1.json",
-        "tests/research/test_volatility_decay_breakout_v1_strategy_implementation_v1.py",
-        "docs/governance/VOLATILITY_DECAY_BREAKOUT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
-      ]
-    },
-    "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1: executable evaluate path with strategy-emitted exits + productive exit/PnL evaluator reuse from VCB package (not duplicated). Development evaluation authorized; run counters remain 0 until the single bounded productive evaluation executes; no holdout/runtime/orders; hypothesis parameters unchanged.",
-      "path_prefixes": [
-        "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_entry_point_binding_v1.json",
-        "docs/evidence/evaluate_volatility_decay_breakout_with_explicit_decay_exit_development_v1/",
-        "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-        "scripts/research/run_evaluate_volatility_decay_breakout_with_explicit_decay_exit_development_v1.py",
-        "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_v1/",
-        "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_entry_point_v1.py",
-        "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_executable_path_v1.py",
-        "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_development_evaluation_fail_closed_report_v1.py"
-      ]
-    },
-    "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of VDBX explicit-decay-exit successor after terminal VDB UNPAIRABLE_ENTRY_NO_EXIT; frozen decay entry + explicit exit state machine; productive PnL evaluator referenced only; no Development evaluation/holdout/runtime/orders; VDB/VEP/VCB retry forbidden.",
-      "path_prefixes": [
-        "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_hypothesis_preregistration_v1.py",
-        "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_hypothesis_preregistration_v1.py",
-        "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-        "docs/evidence/preregister_volatility_decay_breakout_with_explicit_decay_exit_hypothesis_v1/"
-      ]
-    },
-    "VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-      "note": "Strategy + explicit exit state machine for VDBX v1; reuses VDB vol-state/channel core; productive PnL evaluator referenced not duplicated; no evaluation/holdout/runtime/orders; no predecessor artifact mutation.",
-      "path_prefixes": [
-        "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_exit_state_machine_v1.py",
-        "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_v1.py",
-        "src/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_implementation_binding_v1.py",
-        "config/research/volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_implementation_binding_v1.json",
-        "tests/research/test_volatility_decay_breakout_with_explicit_decay_exit_v1_strategy_and_exit_state_machine_v1.py",
-        "docs/governance/VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
-      ]
-    },
-    "VOLATILITY_EXPANSION_PERSISTENCE_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1": {
-      "note": "DEVELOPMENT evaluation entry point/owner for VOLATILITY_EXPANSION_PERSISTENCE_V1: executable evaluate path with materialized panel execution boundary (loader/wiring/injectable boundary); productive exit/PnL evaluator referenced from VCB package (not duplicated). Development evaluation authorized on HEAD; run counters remain 0 until a separate operator GO executes the single bounded development evaluation; no holdout/runtime/orders; measurement thresholds and strategy/baseline parameters unchanged.",
-      "path_prefixes": [
-        "config/research/volatility_expansion_persistence_v1_development_evaluation_entry_point_binding_v1.json",
-        "docs/evidence/evaluate_volatility_expansion_persistence_development_v1/",
-        "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-        "scripts/research/run_evaluate_volatility_expansion_persistence_development_v1.py",
-        "src/research/volatility_expansion_persistence_v1_development_evaluation_v1/",
-        "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_entry_point_v1.py",
-        "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_executable_path_v1.py",
-        "tests/research/test_volatility_expansion_persistence_v1_development_evaluation_fail_closed_report_v1.py"
-      ]
-    },
-    "VOLATILITY_EXPANSION_PERSISTENCE_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of own-instrument volatility expansion-persistence v1 measurement contract on DEVELOPMENT_ONLY non-BTC linear USDT futures; frozen ATR(14)/close percentile-rank expansion confirmation + persistence window admission, unconditional channel-breakout baseline, event-sufficiency gates; material difference vs terminal VCB-V1 and coiled-spring explicit; development evaluation authorized; evaluation not executed; no holdout/runtime/orders; productive PnL evaluator referenced only.",
-      "path_prefixes": [
-        "config/research/volatility_expansion_persistence_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "src/research/volatility_expansion_persistence_v1_hypothesis_preregistration_v1.py",
-        "tests/research/test_volatility_expansion_persistence_v1_hypothesis_preregistration_v1.py",
-        "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-        "docs/evidence/preregister_volatility_expansion_persistence_hypothesis_v1/"
-      ]
-    },
-    "VOLATILITY_EXPANSION_PERSISTENCE_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-      "note": "Strategy-implementation-only surfaces for VOLATILITY_EXPANSION_PERSISTENCE_V1 (shared 20-bar price-channel core + ATR14/close percentile vol-state + expansion confirmation/persistence admission + unconditional baseline + implementation binding). Measurement contract digest frozen; no evaluation/holdout/runtime/orders; productive PnL evaluator referenced not duplicated; no Master-V2/Double-Play/risk/execution mutation.",
-      "path_prefixes": [
-        "src/research/price_channel_breakout_core_v1.py",
-        "src/research/volatility_expansion_persistence_v1_vol_state_v1.py",
-        "src/research/volatility_expansion_persistence_v1_strategy_v1.py",
-        "src/research/unconditional_20_bar_price_channel_breakout_v1.py",
-        "src/research/volatility_expansion_persistence_v1_strategy_implementation_binding_v1.py",
-        "config/research/volatility_expansion_persistence_v1_strategy_implementation_binding_v1.json",
-        "tests/research/test_volatility_expansion_persistence_v1_strategy_implementation_v1.py",
-        "docs/governance/VOLATILITY_EXPANSION_PERSISTENCE_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md"
-      ]
-    },
-    "VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_HYPOTHESIS_PREREGISTRATION_DEFINITION_ONLY_V1": {
-      "note": "Definition-only preregistration of VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1 after terminal VCEB FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT; expansion then limited pullback continuation + explicit invalidation/time/protective exits; productive PnL evaluator referenced only; measurement contract remains frozen; VCEB/VDBX/VDB/VEP/VCB retry forbidden.",
-      "path_prefixes": [
-        "config/research/volatility_expansion_pullback_continuation_v1_preregistered_economic_hypothesis_measurement_contract_v1.json",
-        "src/research/volatility_expansion_pullback_continuation_v1_hypothesis_preregistration_v1.py",
-        "tests/research/test_volatility_expansion_pullback_continuation_v1_hypothesis_preregistration_v1.py",
-        "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_PREREGISTERED_HYPOTHESIS_MEASUREMENT_V1.md",
-        "docs/evidence/preregister_volatility_expansion_pullback_continuation_hypothesis_v1/"
-      ]
-    },
-    "VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_STRATEGY_IMPLEMENTATION_ONLY_V1": {
-      "note": "Strategy implementation + unauthorized productive development entry path for VEPC v1; exit SM with pullback-structure invalidation; productive PnL evaluator reused; no Development evaluation execution/slot consumption/holdout/runtime/orders.",
-      "path_prefixes": [
-        "src/research/volatility_expansion_pullback_continuation_v1_strategy_v1.py",
-        "src/research/volatility_expansion_pullback_continuation_v1_exit_state_machine_v1.py",
-        "src/research/volatility_expansion_pullback_continuation_v1_vol_state_v1.py",
-        "src/research/volatility_expansion_pullback_continuation_v1_strategy_implementation_binding_v1.py",
-        "config/research/volatility_expansion_pullback_continuation_v1_strategy_implementation_binding_v1.json",
-        "src/research/volatility_expansion_pullback_continuation_v1_development_evaluation_v1/",
-        "config/research/volatility_expansion_pullback_continuation_v1_development_evaluation_entry_point_binding_v1.json",
-        "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_STRATEGY_IMPLEMENTATION_ONLY_V1.md",
-        "docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_DEVELOPMENT_EVALUATION_ENTRY_POINT_V1.md",
-        "scripts/research/run_evaluate_volatility_expansion_pullback_continuation_development_v1.py",
-        "tests/research/test_volatility_expansion_pullback_continuation_v1_strategy_implementation_v1.py",
-        "tests/research/test_volatility_expansion_pullback_continuation_v1_development_evaluation_entry_point_v1.py"
-      ]
-    },
-    "VOLATILITY_REGIME_HYPOTHESIS_BACKLOG_V1": {
-      "note": "Open backlog SSOT for volatility-regime research program with exactly one definition-only preregistration (VEP-V1) and terminal VCB-V1 FAIL_CLOSED_NO_RETRY; evaluation/holdout/promotion/runtime closed; sibling Entry/Exit and closed CS momentum lanes remain unreopened. Active open preregistration is VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1; VDB terminal.",
-      "path_prefixes": [
-        "config/research/volatility_regime_hypothesis_backlog_v1.json",
-        "src/research/volatility_regime_hypothesis_backlog_v1.py",
-        "tests/research/test_volatility_regime_hypothesis_backlog_v1.py",
-        "docs/governance/VOLATILITY_REGIME_HYPOTHESIS_BACKLOG_V1.md"
-      ]
-    },
-    "VOLATILITY_REGIME_RESEARCH_PROGRAM_V1": {
-      "note": "Definition-only research-program SSOT for operator-authorized volatility-regime expansion-persistence hypothesis VEP-V1; causal independence from closed Bollinger Entry/Exit and CS momentum lanes; material difference vs terminal coiled-spring and terminal VCB-V1; development evaluation authorized (not executed); no holdout/runtime/orders. Active open preregistration is VOLATILITY_DECAY_BREAKOUT_WITH_EXPLICIT_DECAY_EXIT_V1; VDB terminal.",
-      "path_prefixes": [
-        "config/research/volatility_regime_research_program_v1.json",
-        "src/research/volatility_regime_research_program_v1.py",
-        "tests/research/test_volatility_regime_research_program_v1.py",
-        "docs/governance/VOLATILITY_REGIME_RESEARCH_PROGRAM_V1.md"
-      ]
-    },
-    "WALK_FORWARD_MONTE_CARLO_STRESS_AND_PARAMETER_SENSITIVITY": {
-      "path_globs": [
-        "tests/research/test_offline_parameter_sensitivity_surface_v0.py",
-        "tests/research/test_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-        "tests/research/test_offline_productive_rolling_linear_drift_diagnostics_v0.py",
-        "tests/research/test_offline_parameter_sensitivity_model_spec_alignment_*",
-        "tests/research/test_offline_rolling_linear_drift_diagnostics_v0.py",
-        "tests/research/test_offline_outlier_and_window_robustness_diagnostic_v0.py"
-      ],
-      "path_prefixes": [
-        "src/experiments/monte_carlo.py",
-        "src/experiments/stress_tests.py",
-        "src/experiments/portfolio_robustness.py",
-        "scripts/research/offline_parameter_sensitivity_surface_v0.py",
-        "scripts/ops/materialize_offline_productive_parameter_sensitivity_diagnostics_v0.py",
-        "scripts/ops/materialize_offline_productive_rolling_linear_drift_diagnostics_v0.py",
-        "src/research/linear_evidence/offline_productive_parameter_sensitivity_diagnostics_v0.py",
-        "src/research/linear_evidence/offline_productive_rolling_linear_drift_diagnostics_v0.py",
-        "scripts/research/offline_rolling_linear_drift_diagnostics_v0.py",
-        "scripts/research/offline_outlier_and_window_robustness_diagnostic_v0.py"
-      ]
-    }
-  },
-  "forbidden_mutation_surfaces": {
-    "BULL_BEAR_ASSESSMENT": {
-      "description": "Canonical Bull/Bear assessment and state-switch owners",
-      "path_globs": [
-        "tests/trading/master_v2/test_bull_bear_*",
-        "tests/research/test_bull_bear_*",
-        "docs/research/bull_bear_*"
-      ],
-      "path_prefixes": [
-        "src/trading/master_v2/directional_assessment_v1.py",
-        "src/trading/master_v2/bull_bear_state_switch_scenario_binding_adapter_v0.py",
-        "src/research/owner_bindings/bull_bear_state_switch_owner_binding_v0.py"
-      ]
-    },
-    "CAPITAL_RISK_SIZING": {
-      "description": "Capital, risk and position-sizing owners",
-      "path_globs": [
-        "tests/governance/test_capital_risk_sizing_*",
-        "tests/trading/master_v2/test_capital_risk_sizing_*",
-        "tests/trading/master_v2/test_*capital_slot*",
-        "tests/ops/test_master_v2_capital_slot_owner_boundary_*"
-      ],
-      "path_prefixes": [
-        "src/governance/capital_risk_sizing_v1.py",
-        "src/trading/master_v2/double_play_capital_slot.py",
-        "src/trading/master_v2/capital_risk_sizing_boundary_backtest_state_file_binding_adapter_v0.py",
-        "src/trading/master_v2/capital_risk_sizing_offline_replay_binding_adapter_v0.py",
-        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/capital_risk_sizing.json"
-      ]
-    },
-    "DOUBLE_PLAY_COMPOSITION": {
-      "description": "Double-Play composition and state owners",
-      "path_globs": [
-        "tests/trading/master_v2/test_double_play_*",
-        "docs/ops/specs/MASTER_V2_DOUBLE_PLAY_*",
-        "docs/ops/specs/FUTURES_DOUBLE_PLAY_*"
-      ],
-      "path_prefixes": [
-        "src/trading/master_v2/double_play_composition.py",
-        "src/trading/master_v2/double_play_composition_matrix_v1.py",
-        "src/trading/master_v2/double_play_composition_scenario_matrix_adapter_v0.py",
-        "src/trading/master_v2/double_play_state.py",
-        "src/trading/master_v2/double_play_dashboard_display.py",
-        "src/trading/master_v2/double_play_futures_input_producer.py",
-        "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
-        "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py"
-      ]
-    },
-    "ENTRY_POSITION_EXIT_REVERSAL_POLICY": {
-      "description": "Entry, position-management, exit and reversal policy owners",
-      "path_globs": [
-        "tests/trading/master_v2/test_*entry_exit*",
-        "tests/trading/master_v2/test_*survival*",
-        "tests/trading/master_v2/test_*suitability*"
-      ],
-      "path_prefixes": [
-        "src/trading/master_v2/double_play_entry_exit_policy_v0.py",
-        "src/trading/master_v2/double_play_entry_exit_scenario_binding_adapter_v0.py",
-        "src/trading/master_v2/double_play_survival.py",
-        "src/trading/master_v2/double_play_suitability.py",
-        "src/trading/master_v2/survival_assessment_v1.py",
-        "src/trading/master_v2/suitability_binding_v1.py"
-      ]
-    },
-    "KILLSWITCH": {
-      "description": "KillSwitch semantics and binding owners",
-      "path_globs": [
-        "tests/trading/master_v2/test_killswitch_*",
-        "tests/test_backtest_killswitch_*"
-      ],
-      "path_prefixes": [
-        "src/trading/master_v2/killswitch_boundary_backtest_state_file_binding_adapter_v0.py",
-        "src/trading/master_v2/killswitch_boundary_offline_replay_binding_adapter_v0.py",
-        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/killswitch.json",
-        "docs/risk/KILL_SWITCH_RUNBOOK.md"
-      ]
-    },
-    "MASTER_V2": {
-      "description": "All canonical Master V2 trading logic owners",
-      "path_globs": [
-        "tests/trading/master_v2/test_*"
-      ],
-      "path_prefixes": [
-        "src/trading/master_v2/"
-      ]
-    },
-    "PROMOTION_RUNTIME_ORDER_CREDENTIAL_SCHEDULER_AUTHORITY": {
-      "description": "Promotion, runtime, order, credential, scheduler and authority semantics",
-      "path_globs": [
-        "tests/governance/promotion_loop/*",
-        "tests/trading/master_v2/test_promotion_gate_*",
-        "tests/trading/master_v2/test_runtime_bridge_*",
-        "tests/ops/test_master_v2_runtime_governance_boundary_*",
-        "scripts/run_scheduler.py"
-      ],
-      "path_prefixes": [
-        "src/governance/promotion_loop/",
-        "src/trading/master_v2/promotion_gate_boundary_backtest_state_file_binding_adapter_v0.py",
-        "src/trading/master_v2/promotion_gate_boundary_offline_replay_binding_adapter_v0.py",
-        "src/trading/master_v2/runtime_bridge_pre_activation_gate_v0.py",
-        "src/trading/master_v2/runtime_bridge_pre_activation_gate_assessment_v0.py",
-        "src/trading/master_v2/staged_execution_enablement_v1.py",
-        "src/trading/master_v2/canonical_core_runtime_integration_bridge_v0.py",
-        "src/trading/master_v2/canonical_core_runtime_integration_intent_pipeline_bridge_v0.py",
-        "src/trading/master_v2/canonical_order_intent_boundary_backtest_state_file_binding_adapter_v0.py",
-        "src/trading/master_v2/canonical_order_intent_offline_replay_binding_adapter_v0.py",
-        "src/governance/canonical_order_intent_v1.py",
-        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/canonical_order_intent.json"
-      ]
-    },
-    "RECONCILIATION_UNKNOWN_OUTCOME": {
-      "description": "Reconciliation and unknown-outcome semantics",
-      "path_globs": [
-        "tests/trading/master_v2/test_reconciliation_*",
-        "tests/test_backtest_reconciliation_*"
-      ],
-      "path_prefixes": [
-        "src/trading/master_v2/reconciliation_boundary_backtest_state_file_binding_adapter_v0.py",
-        "src/trading/master_v2/reconciliation_unknown_outcome_offline_replay_binding_adapter_v0.py",
-        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/reconciliation.json"
-      ]
-    },
-    "SAFETY_KERNEL": {
-      "description": "Safety kernel semantics and binding owners",
-      "path_globs": [
-        "tests/trading/master_v2/test_safety_kernel_*",
-        "tests/research/test_safety_kernel_*",
-        "scripts/run_independent_pre_trade_safety_kernel_v1.py"
-      ],
-      "path_prefixes": [
-        "src/trading/master_v2/safety_kernel_boundary_backtest_state_file_binding_adapter_v0.py",
-        "src/trading/master_v2/safety_kernel_offline_replay_binding_adapter_v0.py",
-        "src/meta/learning_loop/independent_pre_trade_safety_kernel_v1.py",
-        "config/research/mv2_backtest_mandatory_boundary_state_files_v0/safety_kernel.json"
-      ]
-    },
-    "SCOPE_INITIALIZATION_AND_EVENTS": {
-      "description": "Scope initialization, scope events, adverse-exit and reversal owners",
-      "path_globs": [
-        "tests/trading/master_v2/test_*scope*",
-        "tests/trading/master_v2/test_*reversal*"
-      ],
-      "path_prefixes": [
-        "src/trading/master_v2/canonical_scope_initialization_v1.py",
-        "src/trading/master_v2/deterministic_scope_event_generator_v1.py",
-        "src/trading/master_v2/scope_event_generator_scenario_binding_adapter_v0.py",
-        "src/trading/master_v2/reversal_preparation_scenario_binding_adapter_v0.py",
-        "src/trading/master_v2/flat_before_opposite_side_scenario_binding_adapter_v0.py"
-      ]
-    }
-  },
-  "no_path_guessing": true,
-  "resolution_method": "READ_ONLY_FROM_EXISTING_BOUNDARY_CONTRACTS_AND_PROGRESS_OWNERS",
-  "schema_version": "economic_diagnostic_optimization_boundary_canonical_owner_map_v0",
-  "source_owners": [
-    "tests/ops/test_master_v2_dynamic_scope_owner_boundary_contract_v0.py",
-    "tests/ops/test_master_v2_state_switch_owner_boundary_contract_v0.py",
-    "tests/ops/test_master_v2_capital_slot_owner_boundary_contract_v0.py",
-    "tests/ops/test_master_v2_runtime_governance_boundary_contract_static_v0.py",
-    "tests/governance/test_capital_risk_sizing_mathematics_consolidation_contract_v0.py",
-    "config/research/mv2_backtest_mandatory_boundary_state_files_v0/MANIFEST.json",
-    "docs/governance/PEAK_TRADE_IMPLEMENTATION_CONTRACT.md",
-    "docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.10_IMPLEMENTATION_CONTRACT.md",
-    "config/governance/technical_canonical_wiring_authorization_v1.json"
-  ],
-  "technical_canonical_wiring_authorization": {
-    "authorized_scope_class": "TECHNICAL_CANONICAL_WIRING_ONLY",
-    "contract_path": "config/governance/technical_canonical_wiring_authorization_v1.json",
-    "note": "Narrow fail-closed override for versioned technical wiring paths only; does not waive MASTER_V2_MUTATION_ALLOWED=false."
-  }
 }

--- a/scripts/research/run_evaluate_volatility_expansion_pullback_continuation_development_v1.py
+++ b/scripts/research/run_evaluate_volatility_expansion_pullback_continuation_development_v1.py
@@ -104,6 +104,8 @@ def main(argv: list[str] | None = None) -> int:
             output_dir=Path(output_dir),
         )
         print(json.dumps(report, sort_keys=True, default=str))
+        if report.get("status") != "EVALUATION_COMPLETE":
+            return 2
         return 0
     except GuardError as exc:
         print(

--- a/src/research/volatility_expansion_pullback_continuation_v1_development_evaluation_v1/evaluate_path_v1.py
+++ b/src/research/volatility_expansion_pullback_continuation_v1_development_evaluation_v1/evaluate_path_v1.py
@@ -41,6 +41,7 @@ from src.research.volatility_expansion_pullback_continuation_v1_development_eval
 from src.research.volatility_expansion_pullback_continuation_v1_development_evaluation_v1.evidence_materialization_v1 import (
     build_registry_metadata_v1,
     build_run_slot_claim_v1,
+    build_technical_fail_closed_summary_v1,
     validate_evidence_and_registry_contracts_v1,
     write_evidence_bundle_v1,
 )
@@ -305,150 +306,229 @@ def run_authorized_development_evaluation_v1(
 
     boundary = execution_boundary or RealExecutionBoundaryV1()
     runner_started = True
-    panel = boundary.load_development_panel(
-        repo_root=repo_root,
-        archive_root=archive_root,
-        expected_dataset_id=DATASET_ID,
-        time_segment_definition_id=TIME_SEGMENT_DEFINITION_ID,
-        expected_config_digest=config_digest,
-    )
-    if panel.holdout_accessed or panel.dataset_id != DATASET_ID:
-        raise GuardError("DATASET_OR_HOLDOUT_VIOLATION")
-    if not panel.panel_series or panel.instrument_count <= 0:
-        raise GuardError("EMPTY_PANEL_MATERIALIZATION")
-
-    cost_binding = resolve_cost_execution_binding(contract)
-    canonical = boundary.run_canonical_backtest(
-        panel,
-        cost_execution_binding=cost_binding,
-        cost_multiplier=1.0,
-    )
-    stress = boundary.run_canonical_backtest(
-        panel,
-        cost_execution_binding=cost_binding,
-        cost_multiplier=1.5,
-    )
-
-    segments = partition_chronological_equal_duration_quarters_v1()
-    handoff = boundary.wire_treatment_baseline(panel)
-    per_seg_counts = {s.segment_id: 0 for s in segments}
-    for arm in handoff.treatment:
-        for ts, is_entry in zip(arm.timestamps_utc, arm.entry_event_mask):
-            if not is_entry:
-                continue
-            seg_id = assign_timestamp_to_segment(ts, segments)
-            if seg_id:
-                per_seg_counts[seg_id] += 1
-    per_seg_metrics: dict[str, BacktestMetricsBundleV1] = {
-        seg.segment_id: canonical for seg in segments if per_seg_counts[seg.segment_id] > 0
-    }
-    segment_results = _segment_results_from_metrics(
-        contract=contract,
-        per_segment_metrics=per_seg_metrics,
-        per_segment_event_counts=per_seg_counts,
-    )
-    gates = evaluate_admission_gates_v1(
-        contract=contract,
-        evaluable_treatment_breakout_events=canonical.evaluable_treatment_breakout_events,
-        trade_count=canonical.trade_count,
-        gross_profit_factor=canonical.gross_profit_factor,
-        gross_pnl=canonical.gross_pnl,
-        net_profit_factor=canonical.net_profit_factor,
-        baseline_net_profit_factor=canonical.baseline_net_profit_factor,
-        net_expectancy=canonical.net_expectancy,
-        max_drawdown=canonical.max_drawdown,
-        cost_stress_1_5x_net_profit_factor=stress.net_profit_factor,
-        segment_results=segment_results,
-    )
-    terminal = (
-        "DEVELOPMENT_EVALUATION_EXECUTED_TERMINAL/PASS"
-        if gates.all_pass
-        else "DEVELOPMENT_EVALUATION_EXECUTED_TERMINAL/FAIL"
-    )
+    development_dataset_loaded = False
+    dataset_digest = "NOT_RESOLVED_TECHNICAL_FAIL_CLOSED"
     strategy_params_digest = compute_strategy_params_digest(contract)
-    evidence = {
-        "schema_version": "evaluate_volatility_expansion_pullback_continuation_development_summary.v1",
-        "evaluation_executed": True,
-        "runner_started": True,
-        "development_dataset_loaded": True,
-        "time_segment_definition_id": TIME_SEGMENT_DEFINITION_ID,
-        "time_segment_count": 4,
-        "config_digest": config_digest,
-        "strategy_params_digest": strategy_params_digest,
-        "dataset_id": panel.dataset_id,
-        "dataset_digest": panel.dataset_digest,
-        "gross_return": canonical.gross_return,
-        "net_return": canonical.net_return,
-        "gross_profit_factor": canonical.gross_profit_factor,
-        "net_profit_factor": canonical.net_profit_factor,
-        "max_drawdown": canonical.max_drawdown,
-        "trade_count": canonical.trade_count,
-        "evaluable_treatment_breakout_events": canonical.evaluable_treatment_breakout_events,
-        "baseline_net_profit_factor": canonical.baseline_net_profit_factor,
-        "baseline_net_return": canonical.extras.get("baseline_net_return"),
-        "long_trade_count": canonical.extras.get("long_trade_count"),
-        "short_trade_count": canonical.extras.get("short_trade_count"),
-        "exit_reason_attribution": canonical.extras.get("exit_reason_attribution"),
-        "productive_exit_pnl_evaluator_bound": canonical.extras.get(
-            "productive_exit_pnl_evaluator_bound"
-        ),
-        "strategy_emitted_exits_used_for_treatment": canonical.extras.get(
-            "strategy_emitted_exits_used_for_treatment"
-        ),
-        "evaluator_reconstruction_used_for_treatment": canonical.extras.get(
-            "evaluator_reconstruction_used_for_treatment"
-        ),
-        "segment_boundaries": segment_results,
-        "segment_results": [
-            {"segment_id": s["segment_id"], "result": s["result"]} for s in segment_results
-        ],
-        "passing_segments": sum(1 for s in segment_results if s["result"] == "PASS"),
-        "time_segment_robustness_pass_ratio": (
-            sum(1 for s in segment_results if s["result"] == "PASS") / 4.0
-        ),
-        "gates": gates.to_dict(),
-        "holdout_accessed": False,
-        "economic_gate_pass": gates.all_pass,
-    }
-    registry = build_registry_metadata_v1(
-        evaluation_executed=True,
-        runner_started=True,
-        evaluation_run_count=1,
-        runner_start_count=1,
-        development_evaluation_authorized=True,
-        config_digest=config_digest,
-        strategy_params_digest=strategy_params_digest,
-        dataset_id=panel.dataset_id,
-        dataset_digest=panel.dataset_digest,
-        terminal_development_verdict=terminal,
-        holdout_accessed=False,
-    )
-    validate_evidence_and_registry_contracts_v1(evidence, registry)
-    claim = build_run_slot_claim_v1(
-        config_digest=config_digest,
-        strategy_params_digest=strategy_params_digest,
-        dataset_id=panel.dataset_id,
-        dataset_digest=panel.dataset_digest,
-    )
-    if persist_evidence:
-        write_evidence_bundle_v1(out_dir, summary=evidence, registry=registry, run_slot_claim=claim)
-    if counter_mutator is not None:
-        counter_mutator(repo_root)
 
-    after = read_run_counters(repo_root)
-    return EvaluatePathResultV1(
-        status="EVALUATION_COMPLETE",
-        mode="evaluate",
-        runner_started=runner_started,
-        evaluation_executed=True,
-        holdout_accessed=False,
-        development_dataset_loaded=True,
-        authorization=auth,
-        run_counters=after,
-        evidence_surface=evidence,
-        registry=registry,
-        gates=gates.to_dict(),
-        terminal_development_verdict=terminal,
-        executable_path_reached=True,
-        reason=None,
-    )
+    def _persist_technical_fail_closed(exc: BaseException) -> EvaluatePathResultV1:
+        reason = (
+            str(exc) if isinstance(exc, GuardError) else f"UNEXPECTED:{type(exc).__name__}:{exc}"
+        )
+        if "UNPAIRABLE_ENTRY_NO_EXIT" in reason:
+            terminal = (
+                "DEVELOPMENT_EVALUATION_EXECUTED_TERMINAL/FAIL_CLOSED_UNPAIRABLE_ENTRY_NO_EXIT"
+            )
+            if "NOT_RESOLVED" in dataset_digest:
+                digest_for_claim = "NOT_RESOLVED_UNPAIRABLE_ENTRY_NO_EXIT"
+            else:
+                digest_for_claim = dataset_digest
+        else:
+            terminal = "DEVELOPMENT_EVALUATION_EXECUTED_TERMINAL/FAIL_CLOSED_TECHNICAL"
+            digest_for_claim = dataset_digest
+        evidence = build_technical_fail_closed_summary_v1(
+            config_digest=config_digest,
+            strategy_params_digest=strategy_params_digest,
+            dataset_id=DATASET_ID,
+            dataset_digest=digest_for_claim,
+            reason=reason,
+            development_dataset_loaded=development_dataset_loaded,
+            terminal_development_verdict=terminal,
+        )
+        registry = build_registry_metadata_v1(
+            evaluation_executed=False,
+            runner_started=True,
+            evaluation_run_count=1,
+            runner_start_count=1,
+            development_evaluation_authorized=True,
+            config_digest=config_digest,
+            strategy_params_digest=strategy_params_digest,
+            dataset_id=DATASET_ID,
+            dataset_digest=digest_for_claim,
+            terminal_development_verdict=terminal,
+            holdout_accessed=False,
+        )
+        claim = build_run_slot_claim_v1(
+            config_digest=config_digest,
+            strategy_params_digest=strategy_params_digest,
+            dataset_id=DATASET_ID,
+            dataset_digest=digest_for_claim,
+            slot_consumption_boundary=(
+                "RUNNER_STARTED_BEFORE_TECHNICAL_FAIL_CLOSED_PRE_EVIDENCE_SUCCESS_PATH"
+            ),
+        )
+        validate_evidence_and_registry_contracts_v1(evidence, registry)
+        if persist_evidence:
+            write_evidence_bundle_v1(
+                out_dir, summary=evidence, registry=registry, run_slot_claim=claim
+            )
+        after = read_run_counters(repo_root)
+        return EvaluatePathResultV1(
+            status="FAIL_CLOSED",
+            mode="evaluate",
+            runner_started=True,
+            evaluation_executed=False,
+            holdout_accessed=False,
+            development_dataset_loaded=development_dataset_loaded,
+            authorization=auth,
+            run_counters=after,
+            evidence_surface=evidence,
+            registry=registry,
+            gates=None,
+            terminal_development_verdict=terminal,
+            executable_path_reached=True,
+            reason=reason,
+        )
+
+    try:
+        panel = boundary.load_development_panel(
+            repo_root=repo_root,
+            archive_root=archive_root,
+            expected_dataset_id=DATASET_ID,
+            time_segment_definition_id=TIME_SEGMENT_DEFINITION_ID,
+            expected_config_digest=config_digest,
+        )
+        if panel.holdout_accessed or panel.dataset_id != DATASET_ID:
+            raise GuardError("DATASET_OR_HOLDOUT_VIOLATION")
+        if not panel.panel_series or panel.instrument_count <= 0:
+            raise GuardError("EMPTY_PANEL_MATERIALIZATION")
+        development_dataset_loaded = True
+        dataset_digest = str(panel.dataset_digest)
+
+        cost_binding = resolve_cost_execution_binding(contract)
+        canonical = boundary.run_canonical_backtest(
+            panel,
+            cost_execution_binding=cost_binding,
+            cost_multiplier=1.0,
+        )
+        stress = boundary.run_canonical_backtest(
+            panel,
+            cost_execution_binding=cost_binding,
+            cost_multiplier=1.5,
+        )
+
+        segments = partition_chronological_equal_duration_quarters_v1()
+        handoff = boundary.wire_treatment_baseline(panel)
+        per_seg_counts = {s.segment_id: 0 for s in segments}
+        for arm in handoff.treatment:
+            for ts, is_entry in zip(arm.timestamps_utc, arm.entry_event_mask):
+                if not is_entry:
+                    continue
+                seg_id = assign_timestamp_to_segment(ts, segments)
+                if seg_id:
+                    per_seg_counts[seg_id] += 1
+        per_seg_metrics: dict[str, BacktestMetricsBundleV1] = {
+            seg.segment_id: canonical for seg in segments if per_seg_counts[seg.segment_id] > 0
+        }
+        segment_results = _segment_results_from_metrics(
+            contract=contract,
+            per_segment_metrics=per_seg_metrics,
+            per_segment_event_counts=per_seg_counts,
+        )
+        gates = evaluate_admission_gates_v1(
+            contract=contract,
+            evaluable_treatment_breakout_events=canonical.evaluable_treatment_breakout_events,
+            trade_count=canonical.trade_count,
+            gross_profit_factor=canonical.gross_profit_factor,
+            gross_pnl=canonical.gross_pnl,
+            net_profit_factor=canonical.net_profit_factor,
+            baseline_net_profit_factor=canonical.baseline_net_profit_factor,
+            net_expectancy=canonical.net_expectancy,
+            max_drawdown=canonical.max_drawdown,
+            cost_stress_1_5x_net_profit_factor=stress.net_profit_factor,
+            segment_results=segment_results,
+        )
+        terminal = (
+            "DEVELOPMENT_EVALUATION_EXECUTED_TERMINAL/PASS"
+            if gates.all_pass
+            else "DEVELOPMENT_EVALUATION_EXECUTED_TERMINAL/FAIL"
+        )
+        evidence = {
+            "schema_version": "evaluate_volatility_expansion_pullback_continuation_development_summary.v1",
+            "evaluation_executed": True,
+            "runner_started": True,
+            "development_dataset_loaded": True,
+            "time_segment_definition_id": TIME_SEGMENT_DEFINITION_ID,
+            "time_segment_count": 4,
+            "config_digest": config_digest,
+            "strategy_params_digest": strategy_params_digest,
+            "dataset_id": panel.dataset_id,
+            "dataset_digest": panel.dataset_digest,
+            "gross_return": canonical.gross_return,
+            "net_return": canonical.net_return,
+            "gross_profit_factor": canonical.gross_profit_factor,
+            "net_profit_factor": canonical.net_profit_factor,
+            "max_drawdown": canonical.max_drawdown,
+            "trade_count": canonical.trade_count,
+            "evaluable_treatment_breakout_events": canonical.evaluable_treatment_breakout_events,
+            "baseline_net_profit_factor": canonical.baseline_net_profit_factor,
+            "baseline_net_return": canonical.extras.get("baseline_net_return"),
+            "long_trade_count": canonical.extras.get("long_trade_count"),
+            "short_trade_count": canonical.extras.get("short_trade_count"),
+            "exit_reason_attribution": canonical.extras.get("exit_reason_attribution"),
+            "productive_exit_pnl_evaluator_bound": canonical.extras.get(
+                "productive_exit_pnl_evaluator_bound"
+            ),
+            "strategy_emitted_exits_used_for_treatment": canonical.extras.get(
+                "strategy_emitted_exits_used_for_treatment"
+            ),
+            "evaluator_reconstruction_used_for_treatment": canonical.extras.get(
+                "evaluator_reconstruction_used_for_treatment"
+            ),
+            "segment_boundaries": segment_results,
+            "segment_results": [
+                {"segment_id": s["segment_id"], "result": s["result"]} for s in segment_results
+            ],
+            "passing_segments": sum(1 for s in segment_results if s["result"] == "PASS"),
+            "time_segment_robustness_pass_ratio": (
+                sum(1 for s in segment_results if s["result"] == "PASS") / 4.0
+            ),
+            "gates": gates.to_dict(),
+            "holdout_accessed": False,
+            "economic_gate_pass": gates.all_pass,
+        }
+        registry = build_registry_metadata_v1(
+            evaluation_executed=True,
+            runner_started=True,
+            evaluation_run_count=1,
+            runner_start_count=1,
+            development_evaluation_authorized=True,
+            config_digest=config_digest,
+            strategy_params_digest=strategy_params_digest,
+            dataset_id=panel.dataset_id,
+            dataset_digest=panel.dataset_digest,
+            terminal_development_verdict=terminal,
+            holdout_accessed=False,
+        )
+        validate_evidence_and_registry_contracts_v1(evidence, registry)
+        claim = build_run_slot_claim_v1(
+            config_digest=config_digest,
+            strategy_params_digest=strategy_params_digest,
+            dataset_id=panel.dataset_id,
+            dataset_digest=panel.dataset_digest,
+        )
+        if persist_evidence:
+            write_evidence_bundle_v1(
+                out_dir, summary=evidence, registry=registry, run_slot_claim=claim
+            )
+        if counter_mutator is not None:
+            counter_mutator(repo_root)
+
+        after = read_run_counters(repo_root)
+        return EvaluatePathResultV1(
+            status="EVALUATION_COMPLETE",
+            mode="evaluate",
+            runner_started=runner_started,
+            evaluation_executed=True,
+            holdout_accessed=False,
+            development_dataset_loaded=True,
+            authorization=auth,
+            run_counters=after,
+            evidence_surface=evidence,
+            registry=registry,
+            gates=gates.to_dict(),
+            terminal_development_verdict=terminal,
+            executable_path_reached=True,
+            reason=None,
+        )
+    except Exception as exc:  # noqa: BLE001 - durable fail-closed after runner start
+        return _persist_technical_fail_closed(exc)

--- a/src/research/volatility_expansion_pullback_continuation_v1_development_evaluation_v1/evidence_materialization_v1.py
+++ b/src/research/volatility_expansion_pullback_continuation_v1_development_evaluation_v1/evidence_materialization_v1.py
@@ -41,8 +41,9 @@ def build_run_slot_claim_v1(
     strategy_params_digest: str,
     dataset_id: str,
     dataset_digest: str,
+    slot_consumption_boundary: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    payload: dict[str, Any] = {
         "schema_version": "evaluate_volatility_expansion_pullback_continuation_run_slot_claim.v1",
         "evaluation_run_id": EVALUATION_RUN_ID,
         "hypothesis_id": HYPOTHESIS_ID,
@@ -56,6 +57,52 @@ def build_run_slot_claim_v1(
         "retry_forbidden": True,
         "holdout_accessed": False,
     }
+    if slot_consumption_boundary is not None:
+        payload["slot_consumption_boundary"] = slot_consumption_boundary
+    return payload
+
+
+def build_technical_fail_closed_summary_v1(
+    *,
+    config_digest: str,
+    strategy_params_digest: str,
+    dataset_id: str,
+    dataset_digest: str,
+    reason: str,
+    development_dataset_loaded: bool,
+    terminal_development_verdict: str,
+) -> dict[str, Any]:
+    """Durable fail-closed surface after runner start; does not invent metrics."""
+    from src.research.volatility_expansion_pullback_continuation_v1_development_evaluation_v1.evidence_schema_v1 import (
+        empty_evidence_surface_template,
+    )
+
+    evidence = empty_evidence_surface_template(
+        config_digest=config_digest,
+        strategy_params_digest=strategy_params_digest,
+        dataset_id=dataset_id,
+        dataset_digest=dataset_digest,
+    )
+    evidence.update(
+        {
+            "status": "FAIL_CLOSED",
+            "reason": reason,
+            "evaluation_executed": False,
+            "evaluation_run_count": 1,
+            "runner_started": True,
+            "runner_start_count": 1,
+            "budget_consumed": True,
+            "retry_forbidden": True,
+            "development_dataset_loaded": development_dataset_loaded,
+            "terminal_development_verdict": terminal_development_verdict,
+            "slot_consumption_boundary": (
+                "RUNNER_STARTED_BEFORE_TECHNICAL_FAIL_CLOSED_PRE_EVIDENCE_SUCCESS_PATH"
+            ),
+            "productive_pnl_semantics_changed": False,
+            "holdout_accessed": False,
+        }
+    )
+    return evidence
 
 
 def build_registry_metadata_v1(

--- a/src/research/volatility_expansion_pullback_continuation_v1_development_evaluation_v1/guards_v1.py
+++ b/src/research/volatility_expansion_pullback_continuation_v1_development_evaluation_v1/guards_v1.py
@@ -125,6 +125,19 @@ def assert_run_counters_unchanged(before: Mapping[str, int], after: Mapping[str,
 
 
 def slot_already_consumed(output_dir: Path) -> bool:
+    """Durable slot lock: success path OR technical fail-closed after runner start."""
+    claim_path = output_dir / "run_slot_claim.json"
+    if claim_path.is_file():
+        try:
+            claim = json.loads(claim_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            claim = {}
+        if (
+            int(claim.get("evaluation_run_count", -1)) >= 1
+            or int(claim.get("runner_start_count", -1)) >= 1
+        ):
+            return True
+
     summary_path = output_dir / "summary.json"
     if not summary_path.is_file():
         return False
@@ -132,9 +145,15 @@ def slot_already_consumed(output_dir: Path) -> bool:
         existing = json.loads(summary_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return False
-    return int(existing.get("evaluation_run_count", -1)) >= 1 or bool(
-        existing.get("evaluation_executed")
-    )
+    if int(existing.get("evaluation_run_count", -1)) >= 1:
+        return True
+    if bool(existing.get("evaluation_executed")):
+        return True
+    if bool(existing.get("budget_consumed")):
+        return True
+    if bool(existing.get("runner_started")) and str(existing.get("status", "")) == "FAIL_CLOSED":
+        return True
+    return False
 
 
 def assert_no_slot_reuse(output_dir: Path) -> None:

--- a/tests/research/test_volatility_expansion_pullback_continuation_v1_forensic_unpairable_run_state_v1.py
+++ b/tests/research/test_volatility_expansion_pullback_continuation_v1_forensic_unpairable_run_state_v1.py
@@ -1,0 +1,296 @@
+"""Forensic regression: baseline UNPAIRABLE near panel end + durable run-state claim.
+
+Does not re-execute the canonical development evaluation against the real panel.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+import pytest
+
+from src.research.pit_okx_pt1h_panel_ohlcv_dataset_v1 import InstrumentPanelSeriesV1, PanelBarV1
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.panel_wiring_v1 import (
+    ArmEventSeriesV1,
+)
+from src.research.volatility_compression_breakout_v1_development_evaluation_v1.productive_exit_pnl_evaluator_v1 import (
+    EXIT_PARAMS_DECLARATIVE_V1,
+    SIGNAL_LAG_BARS_V1,
+    build_effective_cost_config_from_binding_v1,
+    evaluate_arm_productive_pnl_v1,
+)
+from src.research.volatility_expansion_pullback_continuation_v1_development_evaluation_v1.authorization_v1 import (
+    AuthorizationDecisionV1,
+)
+from src.research.volatility_expansion_pullback_continuation_v1_development_evaluation_v1.binding_v1 import (
+    resolve_cost_execution_binding,
+    resolve_measurement_contract,
+)
+from src.research.volatility_expansion_pullback_continuation_v1_development_evaluation_v1.constants_v1 import (
+    DATASET_ID,
+    HYPOTHESIS_ID,
+)
+from src.research.volatility_expansion_pullback_continuation_v1_development_evaluation_v1.evaluate_path_v1 import (
+    run_authorized_development_evaluation_v1,
+)
+from src.research.volatility_expansion_pullback_continuation_v1_development_evaluation_v1.execution_boundary_v1 import (
+    BacktestMetricsBundleV1,
+    FakeExecutionBoundaryV1,
+    PanelLoadResultV1,
+)
+from src.research.volatility_expansion_pullback_continuation_v1_development_evaluation_v1.guards_v1 import (
+    assert_no_slot_reuse,
+    slot_already_consumed,
+)
+from src.research.volatility_expansion_pullback_continuation_v1_development_evaluation_v1.panel_wiring_v1 import (
+    VepcTreatmentBaselineWiringHandoffV1,
+)
+from src.research.volatility_expansion_pullback_continuation_v1_development_evaluation_v1.time_segments_v1 import (
+    partition_chronological_equal_duration_quarters_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Forensic reproduction constants matching the authorized VEPC attempt.
+FORENSIC_INSTRUMENT_ID = "okx:linear_perpetual:AGLD:USDT:USDT:perp"
+FORENSIC_ENTRY_INDEX = 10575
+FORENSIC_SERIES_LENGTH = 10586
+FORENSIC_ENTRY_SIDE = "SHORT"
+
+
+def _authorized_decision() -> AuthorizationDecisionV1:
+    return AuthorizationDecisionV1(
+        authorized=True,
+        authorize_token_valid=True,
+        repo_development_evaluation_authorized=True,
+        program_development_evaluation_authorized=True,
+        entry_point_binding_authorized=True,
+        reason_codes=(),
+    )
+
+
+def _effective_cost():
+    contract = resolve_measurement_contract(REPO)
+    return build_effective_cost_config_from_binding_v1(
+        resolve_cost_execution_binding(contract),
+        cost_multiplier=1.0,
+    )
+
+
+def _synthetic_agld_geometry_panel() -> tuple[InstrumentPanelSeriesV1, int]:
+    """Compact series with the same end-of-panel geometry as AGLD@10575.
+
+    Real panel: n=10586, entry_i=10575, fill_i=10576, only 9 post-fill bars,
+    TIME_EXIT requires 48 bars; SHORT never hits stop/trail/regime before EOI.
+    """
+    max_bars = int(EXIT_PARAMS_DECLARATIVE_V1["time_exit_max_bars"])
+    lag = int(SIGNAL_LAG_BARS_V1)
+    # Warmup for ATR20 + percentile_rank_120, then late entry with 9 post-fill bars.
+    warmup = 160
+    post_fill = 9
+    entry_i = warmup
+    fill_i = entry_i + lag
+    n = fill_i + 1 + post_fill
+    assert n - (fill_i + 1) == post_fill
+    assert fill_i + max_bars >= n  # TIME_EXIT geometrically unreachable
+
+    bars: list[PanelBarV1] = []
+    # Calm path after SHORT fill: price drifts down (no stop hit for SHORT).
+    start = pd.Timestamp("2023-01-01T00:00:00Z")
+    for i in range(n):
+        base = 0.58
+        px = base - 0.0001 * max(0, i - fill_i)
+        ts = (start + pd.Timedelta(hours=i)).isoformat().replace("+00:00", "Z")
+        bars.append(
+            PanelBarV1(
+                instrument_id=FORENSIC_INSTRUMENT_ID,
+                timestamp_utc=ts,
+                open=f"{px:.6f}",
+                high=f"{px + 0.001:.6f}",
+                low=f"{px - 0.001:.6f}",
+                close=f"{px:.6f}",
+                volume="1",
+                is_final=True,
+            )
+        )
+    series = InstrumentPanelSeriesV1(
+        instrument_id=FORENSIC_INSTRUMENT_ID,
+        native_instrument_id="AGLD",
+        bars=tuple(bars),
+        series_digest="forensic_agld_geometry_v1",
+    )
+    return series, entry_i
+
+
+def test_baseline_declarative_pairing_fail_closed_agld_end_of_series_geometry() -> None:
+    """Documents PRODUCTIVE_EXIT_PAIRING_DEFECT: late SHORT entry, no EOI/EOP close."""
+    series, entry_i = _synthetic_agld_geometry_panel()
+    n = len(series.bars)
+    lag = int(SIGNAL_LAG_BARS_V1)
+    fill_i = entry_i + lag
+    max_bars = int(EXIT_PARAMS_DECLARATIVE_V1["time_exit_max_bars"])
+    assert FORENSIC_ENTRY_SIDE == "SHORT"
+    assert n - (fill_i + 1) == 9
+    assert fill_i + max_bars >= n
+
+    mask = tuple(i == entry_i for i in range(n))
+    sides = tuple(FORENSIC_ENTRY_SIDE if i == entry_i else "NONE" for i in range(n))
+    timestamps = tuple(b.timestamp_utc for b in series.bars)
+    arm = ArmEventSeriesV1(
+        arm_id="BASELINE",
+        instrument_id=FORENSIC_INSTRUMENT_ID,
+        timestamps_utc=timestamps,
+        entry_sides=sides,
+        entry_event_mask=mask,
+    )
+    with pytest.raises(ValueError, match=r"UNPAIRABLE_ENTRY_NO_EXIT:.*:\d+$") as excinfo:
+        evaluate_arm_productive_pnl_v1(
+            panel_series=[series],
+            arm=arm,
+            effective_cost=_effective_cost(),
+        )
+    assert f":{entry_i}" in str(excinfo.value)
+    assert FORENSIC_INSTRUMENT_ID in str(excinfo.value)
+
+
+class _RaisingBoundary(FakeExecutionBoundaryV1):
+    """Raises the forensic UNPAIRABLE reason during productive backtest."""
+
+    def run_canonical_backtest(
+        self,
+        panel: PanelLoadResultV1,
+        *,
+        cost_execution_binding: Mapping[str, Any],
+        cost_multiplier: float = 1.0,
+    ) -> BacktestMetricsBundleV1:
+        _ = panel, cost_execution_binding, cost_multiplier
+        self.backtest_calls += 1
+        raise ValueError(
+            f"UNPAIRABLE_ENTRY_NO_EXIT:{FORENSIC_INSTRUMENT_ID}:{FORENSIC_ENTRY_INDEX}"
+        )
+
+
+def _panel_for_boundary() -> PanelLoadResultV1:
+    segments = partition_chronological_equal_duration_quarters_v1()
+    timestamps = tuple(seg.start_inclusive for seg in segments)
+    bars = tuple(
+        PanelBarV1(
+            instrument_id="INST_A",
+            timestamp_utc=ts,
+            open="100",
+            high="101",
+            low="99",
+            close="100.5",
+            volume="1",
+            is_final=True,
+        )
+        for ts in timestamps
+    )
+    series = InstrumentPanelSeriesV1(
+        instrument_id="INST_A",
+        native_instrument_id="INST_A",
+        bars=bars,
+        series_digest="fake_dataset_digest",
+    )
+    return PanelLoadResultV1(
+        dataset_id=DATASET_ID,
+        dataset_digest="fake_dataset_digest",
+        panel_series=(series,),
+        timestamps_utc=timestamps,
+        instrument_count=1,
+        holdout_accessed=False,
+    )
+
+
+def test_technical_fail_after_runner_start_persists_durable_slot_claim(tmp_path: Path) -> None:
+    """RUN_STATE_ACCOUNTING: runner_started=true + durable claim even if metrics absent."""
+    panel = _panel_for_boundary()
+    n = len(panel.timestamps_utc)
+    arm = ArmEventSeriesV1(
+        arm_id="TREATMENT",
+        instrument_id="INST_A",
+        timestamps_utc=panel.timestamps_utc,
+        entry_sides=tuple("LONG" if i == 0 else "NONE" for i in range(n)),
+        entry_event_mask=tuple(i == 0 for i in range(n)),
+    )
+    handoff = VepcTreatmentBaselineWiringHandoffV1(
+        treatment=(arm,),
+        baseline=(arm,),
+        treatment_strategy_roundtrips=(),
+        shared_channel_core_bound=True,
+        time_segment_definition_id="CHRONOLOGICAL_EQUAL_DURATION_QUARTERS_V1",
+        baseline_id="UNCONDITIONAL_20_BAR_PRICE_CHANNEL_BREAKOUT_V1",
+        strategy_identity="VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1",
+        timestamps_utc=panel.timestamps_utc,
+    )
+    boundary = _RaisingBoundary(
+        panel=panel,
+        canonical_metrics=BacktestMetricsBundleV1(
+            gross_return=0.0,
+            net_return=0.0,
+            gross_profit_factor=0.0,
+            net_profit_factor=0.0,
+            gross_pnl=0.0,
+            net_expectancy=0.0,
+            sharpe=0.0,
+            max_drawdown=0.0,
+            trade_count=0,
+            evaluable_treatment_breakout_events=0,
+            baseline_net_profit_factor=0.0,
+            baseline_gross_profit_factor=0.0,
+            baseline_trade_count=0,
+            cost_multiplier=1.0,
+        ),
+        stress_metrics=BacktestMetricsBundleV1(
+            gross_return=0.0,
+            net_return=0.0,
+            gross_profit_factor=0.0,
+            net_profit_factor=0.0,
+            gross_pnl=0.0,
+            net_expectancy=0.0,
+            sharpe=0.0,
+            max_drawdown=0.0,
+            trade_count=0,
+            evaluable_treatment_breakout_events=0,
+            baseline_net_profit_factor=0.0,
+            baseline_gross_profit_factor=0.0,
+            baseline_trade_count=0,
+            cost_multiplier=1.5,
+        ),
+        wiring_handoff=handoff,
+    )
+    result = run_authorized_development_evaluation_v1(
+        REPO,
+        authorize_token=HYPOTHESIS_ID,
+        output_dir=tmp_path,
+        execution_boundary=boundary,
+        authorization_decision=_authorized_decision(),
+        persist_evidence=True,
+    )
+    assert result.status == "FAIL_CLOSED"
+    assert result.runner_started is True
+    assert result.evaluation_executed is False
+    assert result.development_dataset_loaded is True
+    assert result.reason is not None
+    assert "UNPAIRABLE_ENTRY_NO_EXIT" in result.reason
+    assert FORENSIC_INSTRUMENT_ID in result.reason
+    assert str(FORENSIC_ENTRY_INDEX) in result.reason
+    assert slot_already_consumed(tmp_path) is True
+    assert (tmp_path / "summary.json").is_file()
+    assert (tmp_path / "run_slot_claim.json").is_file()
+    assert (tmp_path / "registry.json").is_file()
+    with pytest.raises(Exception, match="RETRY_OR_SLOT_REUSE_REJECTED"):
+        assert_no_slot_reuse(tmp_path)
+
+
+def test_forensic_index_constants_match_observed_incident() -> None:
+    """Pin the observed AGLD incident coordinates for governance continuity."""
+    assert FORENSIC_ENTRY_INDEX == 10575
+    assert FORENSIC_SERIES_LENGTH == 10586
+    assert FORENSIC_SERIES_LENGTH - FORENSIC_ENTRY_INDEX == 11
+    lag = int(SIGNAL_LAG_BARS_V1)
+    fill_i = FORENSIC_ENTRY_INDEX + lag
+    assert FORENSIC_SERIES_LENGTH - (fill_i + 1) == 9
+    assert int(EXIT_PARAMS_DECLARATIVE_V1["time_exit_max_bars"]) == 48


### PR DESCRIPTION
## Summary
- Forensic classification of VEPC `UNPAIRABLE_ENTRY_NO_EXIT` on AGLD/`10575`: first failure is **baseline declarative pairing** (no EOI/EOP; TIME_EXIT unreachable with 9 post-fill bars); VEPC treatment strategy-emitted path is intact.
- Infrastructure-only fix: after authorized runner start, technical exceptions now persist `runner_started=true`, durable `run_slot_claim` / fail-closed summary, and correct CLI exit semantics — **no** PnL pairing change, **no** strategy-parameter change, **no** evaluation re-run.
- Regression tests cover AGLD end-of-series geometry and durable claim-on-technical-fail.

## Test plan
- [x] `pytest tests/research/test_volatility_expansion_pullback_continuation_v1_forensic_unpairable_run_state_v1.py`
- [x] `pytest tests/research/test_volatility_expansion_pullback_continuation_v1_development_evaluation_entry_point_v1.py`
- [x] PR_BOUNDED path timing proof (~37s, 721 passed)
- [ ] CI confirmation on PR
- [ ] **Do not merge** without separate Merge-GO
- [ ] Separate governance decision still required for: (a) historical VEPC slot normative consumption, (b) any future pairing/EOI change (explicitly out of this PR)


Made with [Cursor](https://cursor.com)