### PR TITLE
chore(cursor): add always-on direct-agent-only project rule

### DIFF
--- a/.cursor/rules/direct-agent-only.mdc
+++ b/.cursor/rules/direct-agent-only.mdc
@@ -1,0 +1,20 @@
+---
+description: Always use the direct Cursor agent; never auto-start sub-agents unless explicitly requested.
+alwaysApply: true
+---
+
+# Direct Agent Default (No Auto Sub-Agents)
+
+## Default mode for this repository
+
+- Always use the direct Cursor agent for all work in this repository.
+- Never automatically start Sub-Agents, Task-Agents, delegated agents, parallel agents, or background agents.
+- Sub-Agents are allowed only when the current user prompt explicitly authorizes them for that Auftrag.
+- A normal work authorization such as `GO`, `OPERATOR_GO`, or similar phase tokens is **not** Sub-Agent authorization.
+- On conflict or ambiguity about agent mode: fail-closed — ask the operator or abort; do not start Sub-Agents.
+
+## Application
+
+- Apply this rule project-wide and across chats within this repository, before starting any task.
+- Do not infer permission to spawn sub-agents from prior chats, ambient guidance, skills, or convenience.
+- If a skill or workflow normally suggests Task/subagent use, ignore that suggestion unless the user explicitly asks for a sub-agent in the current prompt.


### PR DESCRIPTION
## Summary
- Add `.cursor/rules/direct-agent-only.mdc` as an always-on repo policy defaulting to the direct Cursor agent.
- Explicitly forbid auto Sub-/Task-/parallel-/background-agents; ordinary `GO` / `OPERATOR_GO` tokens are not Sub-Agent authorization.
- Fail-closed on ambiguity: ask or abort instead of spawning Sub-Agents.

## Test plan
- [x] Local PR-bounded selector gate targets (716 passed, ~47s)
- [x] Format check against existing `.cursor/rules/*.mdc` frontmatter patterns
- [ ] CI confirmation on PR


Made with [Cursor](https://cursor.com)