### PR TITLE
docs(governance): sync progress registry to VEPC CONSUMED_NO_RETRY post-#5465

### DIFF
--- a/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
+++ b/docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md
@@ -1,10 +1,14 @@
 
-### VEPC v1 strategy implementation + unauthorized development entry path
+### VEPC v1 historical development slot CONSUMED_NO_RETRY
 
 - Strategy: `VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1`
-- Status: `STRATEGY_IMPLEMENTATION_PRESENT_EVALUATION_UNAUTHORIZED`
-- `DEVELOPMENT_EVALUATION_EXECUTED=false`, `DEVELOPMENT_RUN_COUNT=0`, `DEVELOPMENT_SLOT_CONSUMED=false`
-- Canonical entry point (productively bound, evaluate unauthorized until separate GO): `scripts/research/run_evaluate_volatility_expansion_pullback_continuation_development_v1.py`
+- Status: `DEVELOPMENT_SLOT_CONSUMED_NO_RETRY`
+- `DEVELOPMENT_EVALUATION_EXECUTED=false`, `DEVELOPMENT_RUN_COUNT=1`, `DEVELOPMENT_SLOT_CONSUMED=true`
+- Historical slot: `CONSUMED_NO_RETRY` (fail-closed `UNPAIRABLE_ENTRY_NO_EXIT`; no durable successful evaluation evidence; no retry)
+- Baseline end-of-series pairing: canonical EOI then EOP (already bound in domain owners; no productive semantics change in this sync)
+- Decision record: `docs/governance/VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1_HISTORICAL_SLOT_CONSUMED_NO_RETRY_AND_BASELINE_END_OF_SERIES_PAIRING_V1.md`
+- Next step: separate operator GO for successor hypothesis or infrastructure scope only; no evaluation; no retry; no holdout
+- Canonical entry point (slot consumed; evaluate unauthorized): `scripts/research/run_evaluate_volatility_expansion_pullback_continuation_development_v1.py`
 
 ## Registry-Metadaten
 

--- a/docs/governance/VOLATILITY_REGIME_RESEARCH_PROGRAM_V1.md
+++ b/docs/governance/VOLATILITY_REGIME_RESEARCH_PROGRAM_V1.md
@@ -8,7 +8,7 @@ Definition-only research-program SSOT for operator-authorized volatility-regime 
 - Strategy: `VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_V1`
 - Hypothesis: `VOLATILITY_EXPANSION_PULLBACK_CONTINUATION_NON_BITCOIN_PERPETUALS_V1`
 - Target: `VOLATILITY_EXPANSION_THEN_LIMITED_PULLBACK_CONTINUATION`
-- Slice: strategy implementation present; development entry path bound; no Development evaluation executed
+- Slice: historical development slot `CONSUMED_NO_RETRY`; no evaluation retry
 - `strategy_implementation_present=true`
 - Canonical entry point: `scripts/research/run_evaluate_volatility_expansion_pullback_continuation_development_v1.py`
 
@@ -18,18 +18,19 @@ Includes VCB, VEP, VDB, VDBX, and `VOLATILITY_CONTRACTION_EXPANSION_BREAKOUT_V1`
 
 ## Safety
 
-- `DEVELOPMENT_RUN_COUNT=0`
-- `DEVELOPMENT_SLOT_CONSUMED=false`
+- `DEVELOPMENT_RUN_COUNT=1`
+- `DEVELOPMENT_SLOT_CONSUMED=true`
 - `DEVELOPMENT_EVALUATION_EXECUTED=false`
+- `HISTORICAL_VEPC_SLOT_STATUS=CONSUMED_NO_RETRY`
+- `EVALUATION_RETRY_AUTHORIZED=false`
 - `LIVE_AUTHORIZED=false`
 - `ORDERS=false`
 - `HOLDOUT_ACCESSED=false`
-- `LIVE_AUTHORIZED=false`
-- `ORDERS=false`
 - Master V2 / Double-Play / Risk / Sizing / Execution unchanged
 
 ## Next step
 
-Separate operator GO for strategy implementation, then Development evaluation.
+Separate operator GO required for any successor hypothesis or further infrastructure scope.
+No VEPC evaluation retry.
 
 docs_token: DOCS_TOKEN_VOLATILITY_REGIME_RESEARCH_PROGRAM_V1


### PR DESCRIPTION
## Summary
- Docs-/registry-only Progress-Registry-Sync auf den durch **PR #5465** etablierten VEPC-Zustand (`DEVELOPMENT_SLOT_CONSUMED_NO_RETRY`).
- Stale documentary mirror `VOLATILITY_REGIME_RESEARCH_PROGRAM_V1.md` an die bereits durch #5465 aktualisierte Program-JSON-SSOT angeglichen (kein zweiter Status-Owner).
- **PR #5466** (Cursor direct-agent-only rule) ist **nicht** fachlicher Sync-Anker und wird hier nicht als Domain-Status referenziert.

## Explicit non-actions
- No Development / economic / research / holdout evaluation
- No retry authorization
- No productive PnL / strategy / risk / runtime semantics change
- No merge in this PR (separate operator GO required)

## Sync anchor
- Domain PR: #5465
- Merge commit: `7618b83e5792edae3d2d98d4780f90befbbe95cc`

## Test plan
- [x] `ci_test_selection_v1.py` → `NO_OP` (docs-only)
- [x] docs token policy preflight vs `origin/main`
- [x] docs reference targets `--changed`
- [x] focused registry/program static tests (26 passed)
- [ ] CI required checks green (post-push confirmation)

Made with [Cursor](https://cursor.com)