### PR TITLE
docs: Momentum-Surface-Disambiguierung und Registry-Side-Overclaim

### DIFF
--- a/docs/governance/POLICY_CRITIC_G4_TELEMETRY_WORKFLOW.md
+++ b/docs/governance/POLICY_CRITIC_G4_TELEMETRY_WORKFLOW.md
@@ -249,7 +249,8 @@ echo "%"
 - **Result:** WARN
 - **Severity:** WARN
 - **Rules triggered:**
-  - EXECUTION_ENDPOINT_TOUCH (files: src/strategies/momentum_v2.py)
+  - EXECUTION_ENDPOINT_TOUCH (files: src&#47;strategies&#47;momentum.py) <!-- pt:ref-target-ignore -->
+    - Note: illustrative example only; there is no productive `MomentumV2` class and no `momentum_v2` strategy module.
 - **Classification:** TRUE_POSITIVE
 - **Operator action:**
   - Added test plan covering edge cases

--- a/docs/governance/feature_state_map_v1.md
+++ b/docs/governance/feature_state_map_v1.md
@@ -68,7 +68,7 @@ NOT in Runtime Decision Core → NON-OPERATIONAL (even if implemented)
 | Strategy: `ma_crossover` | B | Non-operational | Strategy · `registry.py` | Unwired | Wire (via Suitability snapshot) |
 | Strategy: `rsi_reversion` | B | Non-operational | Strategy · `registry.py` | Unwired | Wire |
 | Strategy: `breakout_donchian` | B | Non-operational | Strategy · `registry.py` | Unwired | Wire |
-| Strategy: `momentum_1h` | B | Non-operational | Strategy · `registry.py` | Unwired | Wire |
+| Strategy: `momentum_1h` | B | Non-operational | Strategy · `registry.py` → `MomentumStrategy` | Unwired (documented Class B; not a defect) | Wire only after separate Operator GO; do **not** confuse with research `momentum_1h&#47;v2`, label `feat-momentum-v1`, fixture `strat-momentum-v1`, or context field `momentum_feature_set`. Registry `supported_sides` may overclaim SHORT vs producer `+1` ENTRY / `-1` EXIT / `0` NONE — metadata-only; no safe local registry fix without shared-builder / Suitability side-effects. |
 | Strategy: `bollinger_bands` | B | Non-operational | Strategy · `registry.py` | Unwired | Wire |
 | Strategy: `macd` | B | Non-operational | Strategy · `registry.py` | Unwired | Wire |
 | Strategy: `trend_following` | B | Non-operational | Strategy · `registry.py` | Unwired | Wire |

--- a/docs/ops/specs/MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md
+++ b/docs/ops/specs/MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0.md
@@ -2,7 +2,7 @@
 docs_token: DOCS_TOKEN_MASTER_V2_STRATEGY_VISUAL_MAP_TO_REPO_SURFACE_MAP_V0
 status: draft
 scope: docs-only, non-authorizing strategy surface map
-last_updated: 2026-04-27
+last_updated: 2026-07-23
 ---
 
 # Master V2 Strategy Visual Map to Repo Surface Map V0
@@ -73,9 +73,25 @@ The examples below are discovered surfaces or representative names consistent wi
 | Mean-Reversion / Oscillator | `rsi_reversion`, `mean_reversion`, `mean_reversion_channel`, `MeanReversionStrategy`, `MeanReversionChannelStrategy` | `src/strategies/`, `config/`, `tests/` | Reversion signal, oscillator state, filter context. |
 | Regime / Context | `regime_aware_portfolio`, `RegimeAwarePortfolioStrategy`, `regime_strategy` | `src/strategies/`, `config/`, `tests/` | Regime or market-context label, portfolio context, dashboard explanation. |
 | Core / Research Strategies | `BollingerBandsStrategy`, `BreakoutStrategy`, `CompositeStrategy`, `DonchianBreakoutStrategy`, `MACDStrategy`, `MACrossoverStrategy` | `src/strategies/`, `tests/`, research or docs surfaces | Candidate signal, score, research evidence, comparison baseline. |
-| Trend / Momentum | `MomentumStrategy`, `TrendFollowingStrategy`, trend or momentum config keys | `src/strategies/`, `config/`, `tests/` | Directional filter, momentum score, candidate context. |
+| Trend / Momentum | `momentum_1h` / `MomentumStrategy`, `TrendFollowingStrategy`, trend or momentum config keys | `src/strategies/`, `config/`, `tests/` | Library candidate signal / score / context only. **Not** Master V2 Directional Assessment, **not** default Decision-Core wiring (Class B unwired for `momentum_1h`). |
 | Feature or Helper surfaces | helper functions or feature builders such as RSI, momentum, or regime helpers | code and tests | Feature production only; not strategy authority. |
 | Unclear / Needs Review | any discovered name without clear canonical role | mixed | Must not be promoted without review. |
+
+### 4.1 Momentum surface disambiguation (non-authorizing)
+
+Homonymous names are **not** the same component:
+
+| Surface | Role | Must not be read as |
+| --- | --- | --- |
+| `momentum_1h` | Strategy-Library registry ID | Default Master V2 / Double Play producer |
+| `MomentumStrategy` (`src/strategies/momentum.py`) | Executable library implementation | A class named `MomentumV2`; Decision / Side / Scope / Composition authority |
+| `momentum_1h&#47;v2` / `MOMENTUM_HORIZON_V2` | Research / offline-evaluation binding generation only | Second registry implementation or new strategy module |
+| `feat-momentum-v1` | Feature-ref **label** in Directional Assessment inputs | Executable strategy wiring |
+| `strat-momentum-v1` | Fixture / harness suitability strategy id | Identical to `momentum_1h` |
+| `momentum_feature_set` | Market-context / evidence carrier field | Directional Assessment producer input |
+| Master V2 Directional Assessment | `price_path` / `compute_signal_strength` | Output of `MomentumStrategy` |
+
+There is **no** productive `MomentumV2` class and **no** `momentum_v2` module under `src&#47;strategies/`. <!-- pt:ref-target-ignore --> Presence of any momentum-named surface in this map does **not** imply default Integrated Offline Replay wiring.
 
 ## 5. Strategy Status Lanes
 

--- a/docs/ops/specs/STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md
+++ b/docs/ops/specs/STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0.md
@@ -1,8 +1,8 @@
 ---
 title: Strategy to Master V2 Integration Contract v0
 status: DRAFT
-last_updated: 2026-04-24
-repo_ref: main@fcec89f760d6
+last_updated: 2026-07-23
+repo_ref: main@a2818c8ce379
 scope: docs-only strategy governance contract
 docs_token: DOCS_TOKEN_STRATEGY_TO_MASTER_V2_INTEGRATION_CONTRACT_V0
 ---
@@ -49,9 +49,12 @@ Strategy registry fields are catalog and compatibility metadata unless explicitl
 | `tier` | Classification or maturity label. | Live-readiness proof. |
 | `is_live_ready` | Historical or catalog signal requiring Master V2 validation. | Standalone live enablement. |
 | `allowed_environments` | Compatibility hint for tooling and validation. | Permission to execute in those environments. |
+| `supported_sides` | Catalog/compatibility metadata emitted by the generic registry entry builder. Must be read against the producer signal contract; it is not proof of LONG/SHORT entry authority. | Claim that the strategy emits SHORT entries, owns Bull/Bear state, or feeds Directional Assessment. |
 | `research` wording | Review and experimentation status. | Production authorization. |
 | `production` wording | Maturity label requiring contextual validation. | Broker/exchange order permission. |
 | `double-play` wording | Potential future observation or candidate input. | Double Play authority. |
+
+Known catalog overclaim (docs-only; no registry mutation in this contract): `momentum_1h` / `MomentumStrategy` currently appears with registry `supported_sides=("long","short")` via the generic builder, while the productive signal contract is `+1` LONG ENTRY event, `-1` EXIT event, `0` NONE (`entry_side=NONE`). `-1` is not a SHORT entry. No safe local registry override exists without changing the shared builder contract or Suitability side-eligibility derived from snapshots; leave metadata unchanged until a dedicated, fail-closed owner GO. Homonyms `feat-momentum-v1`, `strat-momentum-v1`, `momentum_feature_set`, and research `momentum_1h&#47;v2` are not this library implementation and are not default Decision-Core wiring.
 
 ## 5. Master V2 compatible strategy classification
 

--- a/docs/strategies_overview.md
+++ b/docs/strategies_overview.md
@@ -43,15 +43,16 @@ stop_pct = 0.02
 
 ---
 
-## 2️⃣ **Momentum**
+## 2️⃣ **Momentum** (`momentum_1h` / `MomentumStrategy`)
 
-**Typ:** Trend-Following  
-**Datei:** `src/strategies/momentum.py`
+**Typ:** Trend-Following (Strategy-Library)  
+**Datei:** `src/strategies/momentum.py`  
+**Registry-ID:** `momentum_1h` — **nicht** eine Klasse `MomentumV2`; Research-Binding `momentum_1h&#47;v2` ist nur Offline-Evaluation-Generation, keine zweite Registry-Implementierung.  
+**Master V2:** Class B unwired — kein Default-Producer in `integrated_offline_trading_logic_replay_v1`. Directional Assessment bleibt `price_path`-basiert.
 
 ### Konzept
 - **Momentum** = (Close heute / Close vor N Tagen) - 1
-- **Entry:** Momentum > entry_threshold (z.B. 2%)
-- **Exit:** Momentum < exit_threshold (z.B. -1%)
+- **Signal-Semantik:** `+1` = LONG ENTRY EVENT, `-1` = EXIT EVENT, `0` = NONE (`-1` ist **kein** SHORT ENTRY; `entry_side=NONE`)
 
 ### Parameter
 ```toml
@@ -66,6 +67,7 @@ stop_pct = 0.025
 - ✅ Erfasst starke Trends früh
 - ✅ Flexibel über Thresholds
 - ❌ Sensitiv auf Lookback-Periode
+- ❌ Keine Decision-/Side-/Composition-Authority; Homonyme `feat-momentum-v1` / `strat-momentum-v1` / `momentum_feature_set` sind Label/Fixture/Context, nicht dieses Modul
 
 ---
 


### PR DESCRIPTION
## Summary
- Klärt die Rollen von `momentum_1h` / `MomentumStrategy`, Research-Binding `momentum_1h/v2`, Label `feat-momentum-v1`, Fixture `strat-momentum-v1` und Context-Feld `momentum_feature_set`.
- Dokumentiert den bekannten Registry-`supported_sides`-Overclaim (long+short via generischem Builder vs. Producer `+1` ENTRY / `-1` EXIT / `0` NONE) **ohne** Registry- oder Strategy-Semantik zu ändern.
- Entfernt die missverständliche Beispielreferenz auf ein nicht existierendes `momentum_v2.py`.

## Non-goals (bewusst unverändert)
- Kein Decision-Core-Wiring
- Keine Registry-/Signal-/Authority-Änderung
- Runtime Bridge bleibt `BOUND_NOT_ACTIVATED`
- Keine LIVE/ORDERS/Evaluation/Holdout

## Test plan
- [x] `preflight_docs_token_policy_changed.sh`
- [x] `verify_docs_reference_targets.sh`
- [x] `pytest tests/strategies/test_strategy_registry_consolidation_v1.py tests/test_momentum.py tests/test_strategies_smoke.py`
- [x] Static proof: kein `MomentumStrategy`/`momentum_1h`-Import unter `src/trading/master_v2/**`
- [x] CI selector: `NO_OP` (docs-only)


Made with [Cursor](https://cursor.com)