### PR TITLE
feat(webui): Market Landscape V2 read-only projection contracts (PR1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,8 @@ jobs:
             tests/webui/test_observability_last_paper_run_panel_structure_contract_v0.py \
             tests/ops/test_last_paper_run_panel_env_schema_boundary_v0.py \
             tests/webui/test_market_dashboard_tombstone_v1.py \
+            tests/webui/test_market_landscape_dashboard_v2_contracts_v0.py \
+            tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py \
             -q --tb=short -m "not network and not external_tools"
 
   # ============================================================================

--- a/src/webui/market_dashboard_landscape_v2/__init__.py
+++ b/src/webui/market_dashboard_landscape_v2/__init__.py
@@ -1,0 +1,78 @@
+"""Market Dashboard Landscape V2 — read-only projection contracts.
+
+Consumer foundation only. No routes, templates, runtime activation, orders,
+or domain recomputation.
+"""
+
+from __future__ import annotations
+
+from .availability import AVAILABILITY_VALUES, Availability, parse_availability
+from .contracts import (
+    SCHEMA_FAMILY,
+    SCHEMA_VERSION,
+    AutonomyStageSnapshotV1,
+    CanonicalDecisionSnapshotV1,
+    DiagnosticsSummarySnapshotV1,
+    DoublePlaySnapshotV1,
+    DynamicScopeSnapshotV1,
+    EconomicSummarySnapshotV1,
+    ExecutionReconciliationSnapshotV1,
+    MarketInstrumentSnapshotV1,
+    RiskSizingCapitalSnapshotV1,
+    SafetyAuthoritySnapshotV1,
+    UniverseRankingSnapshotV1,
+)
+from .owner_registry import (
+    CANONICAL_OWNER_REGISTRY_V1,
+    REQUIRED_PROJECTION_SLOTS,
+    owner_registry_by_slot,
+)
+from .projections import (
+    project_canonical_decision_snapshot_v1,
+    project_double_play_snapshot_v1,
+)
+from .provenance import FreshnessV1, SnapshotProvenanceV1
+from .serialization import dumps_projection_canonical, serialize_projection
+from .source_health import (
+    SOURCE_HEALTH_SCHEMA_ID,
+    DashboardSourceHealthSnapshotV1,
+    build_source_health_from_snapshots,
+)
+from .unavailable import default_not_bound_bundle
+
+PACKAGE_MARKER = "MARKET_DASHBOARD_LANDSCAPE_V2_READMODEL_CONTRACTS=true"
+LAYER_VERSION = "v1"
+
+__all__ = [
+    "AVAILABILITY_VALUES",
+    "Availability",
+    "AutonomyStageSnapshotV1",
+    "CANONICAL_OWNER_REGISTRY_V1",
+    "CanonicalDecisionSnapshotV1",
+    "DashboardSourceHealthSnapshotV1",
+    "DiagnosticsSummarySnapshotV1",
+    "DoublePlaySnapshotV1",
+    "DynamicScopeSnapshotV1",
+    "EconomicSummarySnapshotV1",
+    "ExecutionReconciliationSnapshotV1",
+    "FreshnessV1",
+    "LAYER_VERSION",
+    "MarketInstrumentSnapshotV1",
+    "PACKAGE_MARKER",
+    "REQUIRED_PROJECTION_SLOTS",
+    "RiskSizingCapitalSnapshotV1",
+    "SCHEMA_FAMILY",
+    "SCHEMA_VERSION",
+    "SOURCE_HEALTH_SCHEMA_ID",
+    "SafetyAuthoritySnapshotV1",
+    "SnapshotProvenanceV1",
+    "UniverseRankingSnapshotV1",
+    "build_source_health_from_snapshots",
+    "default_not_bound_bundle",
+    "dumps_projection_canonical",
+    "owner_registry_by_slot",
+    "parse_availability",
+    "project_canonical_decision_snapshot_v1",
+    "project_double_play_snapshot_v1",
+    "serialize_projection",
+]

--- a/src/webui/market_dashboard_landscape_v2/availability.py
+++ b/src/webui/market_dashboard_landscape_v2/availability.py
@@ -1,0 +1,38 @@
+"""Canonical availability vocabulary for Market Dashboard Landscape V2.
+
+Fail-closed: missing or unknown sources must surface explicitly. Silent
+defaults and invented "healthy" states are forbidden.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Availability(str, Enum):
+    """Dashboard-facing availability; sole vocabulary for Source Health."""
+
+    AVAILABLE = "AVAILABLE"
+    NOT_BOUND = "NOT_BOUND"
+    MISSING_SOURCE = "MISSING_SOURCE"
+    STALE = "STALE"
+    INVALID = "INVALID"
+
+
+AVAILABILITY_VALUES: frozenset[str] = frozenset(member.value for member in Availability)
+
+
+def parse_availability(raw: str) -> Availability:
+    """Parse an availability token; unknown values fail closed as INVALID."""
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("availability must be a non-empty string")
+    try:
+        return Availability(raw)
+    except ValueError as exc:
+        raise ValueError(f"unknown availability={raw!r}") from exc
+
+
+def assert_no_silent_default(availability: Availability) -> None:
+    """Guard helper: AVAILABLE is never implied; caller must set it explicitly."""
+    if not isinstance(availability, Availability):
+        raise TypeError("availability must be Availability enum member")

--- a/src/webui/market_dashboard_landscape_v2/contracts.py
+++ b/src/webui/market_dashboard_landscape_v2/contracts.py
@@ -1,0 +1,240 @@
+"""Immutable dashboard-facing projection contracts (Landscape V2).
+
+These are consumer snapshots only. They do not recompute decision, risk,
+sizing, scope, or Double Play authority. Unbound slots use explicit
+Availability states — never silent defaults.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from .availability import Availability
+from .provenance import FreshnessV1, SnapshotProvenanceV1
+
+SCHEMA_FAMILY = "market_dashboard_landscape_projection"
+SCHEMA_VERSION = "v1"
+
+
+def _require_provenance(provenance: SnapshotProvenanceV1) -> SnapshotProvenanceV1:
+    if not isinstance(provenance, SnapshotProvenanceV1):
+        raise TypeError("provenance must be SnapshotProvenanceV1")
+    return provenance
+
+
+def _require_freshness(freshness: FreshnessV1) -> FreshnessV1:
+    if not isinstance(freshness, FreshnessV1):
+        raise TypeError("freshness must be FreshnessV1")
+    return freshness
+
+
+@dataclass(frozen=True)
+class _ProjectionBase:
+    """Shared envelope fields for all Landscape projections."""
+
+    schema_id: str
+    schema_version: str
+    provenance: SnapshotProvenanceV1
+    freshness: FreshnessV1
+    availability: Availability
+
+    def __post_init__(self) -> None:
+        if not self.schema_id or not isinstance(self.schema_id, str):
+            raise ValueError("schema_id required")
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(
+                f"schema_version must be {SCHEMA_VERSION!r}, got {self.schema_version!r}"
+            )
+        _require_provenance(self.provenance)
+        _require_freshness(self.freshness)
+        if not isinstance(self.availability, Availability):
+            raise TypeError("availability must be Availability")
+        if self.availability != self.provenance.availability:
+            raise ValueError("availability must match provenance.availability")
+        if self.freshness.is_stale and self.availability is Availability.AVAILABLE:
+            raise ValueError("stale freshness cannot pair with AVAILABLE")
+
+
+@dataclass(frozen=True)
+class MarketInstrumentSnapshotV1(_ProjectionBase):
+    instrument_id: str | None
+    venue: str | None
+    market_type: str | None
+    mark_price: float | None
+    reason_codes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
+        if self.availability is Availability.AVAILABLE:
+            if not self.instrument_id:
+                raise ValueError("instrument_id required when AVAILABLE")
+
+
+@dataclass(frozen=True)
+class UniverseRankingSnapshotV1(_ProjectionBase):
+    ranking: tuple[Mapping[str, Any], ...]
+    selected_instrument_id: str | None
+    reason_codes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "ranking", tuple(dict(row) for row in self.ranking))
+        object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
+
+
+@dataclass(frozen=True)
+class DynamicScopeSnapshotV1(_ProjectionBase):
+    scope_state: str | None
+    current_scope_ref: str | None
+    next_scope_ref: str | None
+    reason_codes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
+
+
+@dataclass(frozen=True)
+class CanonicalDecisionSnapshotV1(_ProjectionBase):
+    instrument_id: str | None
+    decision: str | None
+    direction: str | None
+    reason_codes: tuple[str, ...]
+    blockers: tuple[str, ...]
+    decision_id: str | None
+    evidence_schema_version: str | None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
+        object.__setattr__(self, "blockers", tuple(self.blockers))
+        if self.availability is Availability.AVAILABLE:
+            if self.decision is None or self.direction is None:
+                raise ValueError("decision and direction required when AVAILABLE")
+
+
+@dataclass(frozen=True)
+class DoublePlaySnapshotV1(_ProjectionBase):
+    overall_status: str | None
+    panel_summaries: tuple[Mapping[str, Any], ...]
+    blockers: tuple[str, ...]
+    display_only: bool
+    live_authorization: bool
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(
+            self, "panel_summaries", tuple(dict(row) for row in self.panel_summaries)
+        )
+        object.__setattr__(self, "blockers", tuple(self.blockers))
+        if self.live_authorization is not False:
+            raise ValueError("live_authorization must remain False on Landscape projection")
+        if self.availability is Availability.AVAILABLE and not self.display_only:
+            raise ValueError("AVAILABLE DoublePlaySnapshot must be display_only=True")
+
+
+@dataclass(frozen=True)
+class RiskSizingCapitalSnapshotV1(_ProjectionBase):
+    risk_status: str | None
+    sizing_status: str | None
+    capital_status: str | None
+    reason_codes: tuple[str, ...]
+    quantity: float | None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
+        # Landscape must never invent sizing quantities.
+        if self.availability is not Availability.AVAILABLE and self.quantity is not None:
+            raise ValueError("quantity forbidden unless AVAILABLE from canonical producer")
+
+
+@dataclass(frozen=True)
+class SafetyAuthoritySnapshotV1(_ProjectionBase):
+    kill_switch_state: str | None
+    veto_active: bool | None
+    reason_codes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
+
+
+@dataclass(frozen=True)
+class ExecutionReconciliationSnapshotV1(_ProjectionBase):
+    execution_status: str | None
+    reconciliation_status: str | None
+    order_intent_ref: str | None
+    reason_codes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
+
+
+@dataclass(frozen=True)
+class EconomicSummarySnapshotV1(_ProjectionBase):
+    economic_gate_status: str | None
+    evidence_ref: str | None
+    reason_codes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
+
+
+@dataclass(frozen=True)
+class AutonomyStageSnapshotV1(_ProjectionBase):
+    autonomy_stage: str | None
+    runtime_bridge_status: str | None
+    reason_codes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
+
+
+@dataclass(frozen=True)
+class DiagnosticsSummarySnapshotV1(_ProjectionBase):
+    diagnostic_codes: tuple[str, ...]
+    summary: str | None
+    reason_codes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "diagnostic_codes", tuple(self.diagnostic_codes))
+        object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
+
+
+ProjectionSnapshot = (
+    MarketInstrumentSnapshotV1
+    | UniverseRankingSnapshotV1
+    | DynamicScopeSnapshotV1
+    | CanonicalDecisionSnapshotV1
+    | DoublePlaySnapshotV1
+    | RiskSizingCapitalSnapshotV1
+    | SafetyAuthoritySnapshotV1
+    | ExecutionReconciliationSnapshotV1
+    | EconomicSummarySnapshotV1
+    | AutonomyStageSnapshotV1
+    | DiagnosticsSummarySnapshotV1
+)
+
+
+def projection_envelope_dict(snapshot: _ProjectionBase) -> dict[str, Any]:
+    return {
+        "schema_id": snapshot.schema_id,
+        "schema_version": snapshot.schema_version,
+        "availability": snapshot.availability.value,
+        "provenance": snapshot.provenance.to_json_dict(),
+        "freshness": snapshot.freshness.to_json_dict(),
+    }
+
+
+def require_sequence(name: str, value: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise TypeError(f"{name} must be a sequence of strings")
+    out = tuple(str(item) for item in value)
+    return out

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -1,0 +1,132 @@
+"""Reuse-before-new owner registry for Market Dashboard Landscape V2.
+
+Maps dashboard projection slots to existing canonical producer modules.
+This package is a consumer boundary only — it does not own trading truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class CanonicalOwnerRefV1:
+    """Pointer to an existing sole-authority producer (path + role)."""
+
+    slot: str
+    owner_module: str
+    owner_symbol: str
+    authority_class: str
+    reuse_status: str  # REUSED | PROJECTION_ONLY | NOT_BOUND
+    notes: str
+
+
+# Phase-0 inventory (read-only): existing immutable contracts preferred over new truth.
+CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
+    CanonicalOwnerRefV1(
+        slot="market_instrument",
+        owner_module="trading.master_v2.canonical_market_context_v1",
+        owner_symbol="CanonicalMarketContextV1",
+        authority_class="market_context",
+        reuse_status="PROJECTION_ONLY",
+        notes="Producer exists; Landscape projection unbound until PR3.",
+    ),
+    CanonicalOwnerRefV1(
+        slot="universe_ranking",
+        owner_module="webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1",
+        owner_symbol="universe_selection_readmodel.v1",
+        authority_class="universe_projection",
+        reuse_status="PROJECTION_ONLY",
+        notes="Observability universe contract reused as source shape; not Market UI.",
+    ),
+    CanonicalOwnerRefV1(
+        slot="dynamic_scope",
+        owner_module="trading.master_v2.canonical_scope_initialization_v1",
+        owner_symbol="CanonicalScopeLifecycleState",
+        authority_class="dynamic_scope",
+        reuse_status="PROJECTION_ONLY",
+        notes="Scope authority remains Master V2; Landscape projects only.",
+    ),
+    CanonicalOwnerRefV1(
+        slot="canonical_decision",
+        owner_module="trading.master_v2.canonical_trading_decision_evidence_v1",
+        owner_symbol="CanonicalTradingDecisionEvidenceV1",
+        authority_class="decision",
+        reuse_status="REUSED",
+        notes="Immutable decision evidence projected field-for-field; no recomputation.",
+    ),
+    CanonicalOwnerRefV1(
+        slot="double_play",
+        owner_module="trading.master_v2.double_play_dashboard_display",
+        owner_symbol="DoublePlayDashboardDisplaySnapshot",
+        authority_class="double_play",
+        reuse_status="REUSED",
+        notes="Existing DP display snapshot; Landscape wraps with Availability/provenance.",
+    ),
+    CanonicalOwnerRefV1(
+        slot="risk_sizing_capital",
+        owner_module="trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0",
+        owner_symbol="capital_risk_sizing_offline_replay_binding",
+        authority_class="risk_sizing",
+        reuse_status="NOT_BOUND",
+        notes="No Landscape projection binding yet; NOT_BOUND until PR5.",
+    ),
+    CanonicalOwnerRefV1(
+        slot="safety_authority",
+        owner_module="trading.master_v2.killswitch_boundary_offline_replay_binding_adapter_v0",
+        owner_symbol="killswitch_boundary_offline_replay_binding",
+        authority_class="safety_veto",
+        reuse_status="NOT_BOUND",
+        notes="Safety remains independent veto; Landscape unbound until PR5.",
+    ),
+    CanonicalOwnerRefV1(
+        slot="execution_reconciliation",
+        owner_module="trading.master_v2.canonical_order_intent_offline_replay_binding_adapter_v0",
+        owner_symbol="canonical_order_intent_offline_replay_binding",
+        authority_class="execution_intent",
+        reuse_status="NOT_BOUND",
+        notes="Order/execution APIs must never be imported by Landscape UI.",
+    ),
+    CanonicalOwnerRefV1(
+        slot="economic_summary",
+        owner_module="backtest.economic_viability_evidence_v1",
+        owner_symbol="economic_viability_evidence",
+        authority_class="economic_evidence",
+        reuse_status="NOT_BOUND",
+        notes="Promotion-only economic evidence; Landscape unbound until PR6.",
+    ),
+    CanonicalOwnerRefV1(
+        slot="autonomy_stage",
+        owner_module="trading.master_v2.runtime_bridge_pre_activation_gate_v0",
+        owner_symbol="BOUND_NOT_ACTIVATED",
+        authority_class="runtime_status",
+        reuse_status="NOT_BOUND",
+        notes="Runtime BOUND_NOT_ACTIVATED is intentional; display-only later.",
+    ),
+    CanonicalOwnerRefV1(
+        slot="diagnostics_summary",
+        owner_module="webui.workflow_dashboard_readmodel_v1.types",
+        owner_symbol="WorkflowDashboardReadModelV1",
+        authority_class="diagnostics",
+        reuse_status="PROJECTION_ONLY",
+        notes="Observability diagnostics reused as reference; no second owner.",
+    ),
+    CanonicalOwnerRefV1(
+        slot="source_health",
+        owner_module="webui.market_dashboard_landscape_v2.source_health",
+        owner_symbol="DashboardSourceHealthSnapshotV1",
+        authority_class="dashboard_aggregation",
+        reuse_status="REUSED",
+        notes="Aggregation-only; never invents per-slot truth.",
+    ),
+)
+
+
+def owner_registry_by_slot() -> Mapping[str, CanonicalOwnerRefV1]:
+    return {entry.slot: entry for entry in CANONICAL_OWNER_REGISTRY_V1}
+
+
+REQUIRED_PROJECTION_SLOTS: tuple[str, ...] = tuple(
+    entry.slot for entry in CANONICAL_OWNER_REGISTRY_V1
+)

--- a/src/webui/market_dashboard_landscape_v2/projections.py
+++ b/src/webui/market_dashboard_landscape_v2/projections.py
@@ -1,0 +1,124 @@
+"""Pure field-projection adapters — no decision/risk/sizing recomputation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Mapping, Sequence
+
+from .availability import Availability
+from .contracts import (
+    SCHEMA_FAMILY,
+    SCHEMA_VERSION,
+    CanonicalDecisionSnapshotV1,
+    DoublePlaySnapshotV1,
+)
+from .provenance import FreshnessV1, SnapshotProvenanceV1
+
+
+def project_canonical_decision_snapshot_v1(
+    *,
+    instrument_id: str,
+    decision: str,
+    direction: str,
+    reason_codes: Sequence[str],
+    blockers: Sequence[str],
+    decision_id: str | None,
+    evidence_schema_version: str,
+    evidence_digest: str | None,
+    generated_at: datetime,
+    effective_at: datetime | None,
+    source_reference: str | None,
+    git_sha: str | None = None,
+    producer_module: str = "trading.master_v2.canonical_trading_decision_evidence_v1",
+) -> CanonicalDecisionSnapshotV1:
+    """Project already-computed decision evidence fields into a Landscape snapshot.
+
+    Forbidden: inventing decision/direction, synthesizing reason codes, or
+    deriving blockers from non-evidence sources.
+    """
+    if not instrument_id or not decision or not direction:
+        raise ValueError("instrument_id, decision, and direction are required for AVAILABLE")
+    if not evidence_schema_version:
+        raise ValueError("evidence_schema_version required")
+    codes = tuple(str(code) for code in reason_codes)
+    block = tuple(str(code) for code in blockers)
+    schema_id = f"{SCHEMA_FAMILY}.canonical_decision.{SCHEMA_VERSION}"
+    provenance = SnapshotProvenanceV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        producer_module=producer_module,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_kind="canonical_trading_decision_evidence",
+        source_reference=source_reference,
+        evidence_digest=evidence_digest,
+        git_sha=git_sha,
+        availability=Availability.AVAILABLE,
+    )
+    freshness = FreshnessV1(
+        observed_at=generated_at,
+        max_age_seconds=None,
+        is_stale=False,
+        stale_reason=None,
+    )
+    return CanonicalDecisionSnapshotV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=freshness,
+        availability=Availability.AVAILABLE,
+        instrument_id=instrument_id,
+        decision=decision,
+        direction=direction,
+        reason_codes=codes,
+        blockers=block,
+        decision_id=decision_id,
+        evidence_schema_version=evidence_schema_version,
+    )
+
+
+def project_double_play_snapshot_v1(
+    *,
+    overall_status: str,
+    panel_summaries: Sequence[Mapping[str, Any]],
+    blockers: Sequence[str],
+    generated_at: datetime,
+    source_reference: str | None,
+    evidence_digest: str | None = None,
+    git_sha: str | None = None,
+    producer_module: str = "trading.master_v2.double_play_dashboard_display",
+) -> DoublePlaySnapshotV1:
+    """Project an existing Double Play display snapshot into Landscape form."""
+    if not overall_status:
+        raise ValueError("overall_status required for AVAILABLE")
+    schema_id = f"{SCHEMA_FAMILY}.double_play.{SCHEMA_VERSION}"
+    provenance = SnapshotProvenanceV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        producer_module=producer_module,
+        generated_at=generated_at,
+        effective_at=generated_at,
+        source_kind="double_play_dashboard_display",
+        source_reference=source_reference,
+        evidence_digest=evidence_digest,
+        git_sha=git_sha,
+        availability=Availability.AVAILABLE,
+    )
+    freshness = FreshnessV1(
+        observed_at=generated_at,
+        max_age_seconds=None,
+        is_stale=False,
+        stale_reason=None,
+    )
+    return DoublePlaySnapshotV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=freshness,
+        availability=Availability.AVAILABLE,
+        overall_status=overall_status,
+        panel_summaries=tuple(dict(row) for row in panel_summaries),
+        blockers=tuple(str(code) for code in blockers),
+        display_only=True,
+        live_authorization=False,
+    )

--- a/src/webui/market_dashboard_landscape_v2/provenance.py
+++ b/src/webui/market_dashboard_landscape_v2/provenance.py
@@ -1,0 +1,111 @@
+"""Immutable provenance + freshness envelope for Landscape V2 projections."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from .availability import Availability
+
+
+def _require_non_empty(name: str, value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _require_utc(name: str, value: datetime) -> datetime:
+    if not isinstance(value, datetime):
+        raise TypeError(f"{name} must be datetime")
+    if value.tzinfo is None:
+        raise ValueError(f"{name} must be timezone-aware UTC")
+    # Normalize to UTC for stable serialization.
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class SnapshotProvenanceV1:
+    """Mandatory provenance for every Landscape V2 projection.
+
+    All fields are explicit. Callers must not invent digests, timestamps, or
+    availability. Use Availability.NOT_BOUND / MISSING_SOURCE when unbound.
+    """
+
+    schema_id: str
+    schema_version: str
+    producer_module: str
+    generated_at: datetime
+    effective_at: datetime | None
+    source_kind: str
+    source_reference: str | None
+    evidence_digest: str | None
+    git_sha: str | None
+    availability: Availability
+
+    def __post_init__(self) -> None:
+        _require_non_empty("schema_id", self.schema_id)
+        _require_non_empty("schema_version", self.schema_version)
+        _require_non_empty("producer_module", self.producer_module)
+        _require_non_empty("source_kind", self.source_kind)
+        object.__setattr__(self, "generated_at", _require_utc("generated_at", self.generated_at))
+        if self.effective_at is not None:
+            object.__setattr__(
+                self, "effective_at", _require_utc("effective_at", self.effective_at)
+            )
+        if not isinstance(self.availability, Availability):
+            raise TypeError("availability must be Availability")
+        if self.source_reference is not None and not isinstance(self.source_reference, str):
+            raise TypeError("source_reference must be str|None")
+        if self.evidence_digest is not None and not isinstance(self.evidence_digest, str):
+            raise TypeError("evidence_digest must be str|None")
+        if self.git_sha is not None and not isinstance(self.git_sha, str):
+            raise TypeError("git_sha must be str|None")
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "schema_id": self.schema_id,
+            "schema_version": self.schema_version,
+            "producer_module": self.producer_module,
+            "generated_at": self.generated_at.isoformat().replace("+00:00", "Z"),
+            "effective_at": (
+                None
+                if self.effective_at is None
+                else self.effective_at.isoformat().replace("+00:00", "Z")
+            ),
+            "source_kind": self.source_kind,
+            "source_reference": self.source_reference,
+            "evidence_digest": self.evidence_digest,
+            "git_sha": self.git_sha,
+            "availability": self.availability.value,
+        }
+
+
+@dataclass(frozen=True)
+class FreshnessV1:
+    """Freshness metadata; stale thresholds are caller-supplied, never invented."""
+
+    observed_at: datetime
+    max_age_seconds: int | None
+    is_stale: bool
+    stale_reason: str | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "observed_at", _require_utc("observed_at", self.observed_at))
+        if self.max_age_seconds is not None:
+            if not isinstance(self.max_age_seconds, int) or self.max_age_seconds < 0:
+                raise ValueError("max_age_seconds must be int>=0 or None")
+        if not isinstance(self.is_stale, bool):
+            raise TypeError("is_stale must be bool")
+        if self.is_stale and (self.stale_reason is None or not str(self.stale_reason).strip()):
+            raise ValueError("stale_reason required when is_stale=True")
+        if not self.is_stale and self.stale_reason is not None:
+            raise ValueError("stale_reason must be None when is_stale=False")
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "observed_at": self.observed_at.isoformat().replace("+00:00", "Z"),
+            "max_age_seconds": self.max_age_seconds,
+            "is_stale": self.is_stale,
+            "stale_reason": self.stale_reason,
+        }

--- a/src/webui/market_dashboard_landscape_v2/serialization.py
+++ b/src/webui/market_dashboard_landscape_v2/serialization.py
@@ -1,0 +1,164 @@
+"""Deterministic JSON serialization for Landscape V2 projections."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .contracts import (
+    AutonomyStageSnapshotV1,
+    CanonicalDecisionSnapshotV1,
+    DiagnosticsSummarySnapshotV1,
+    DoublePlaySnapshotV1,
+    DynamicScopeSnapshotV1,
+    EconomicSummarySnapshotV1,
+    ExecutionReconciliationSnapshotV1,
+    MarketInstrumentSnapshotV1,
+    RiskSizingCapitalSnapshotV1,
+    SafetyAuthoritySnapshotV1,
+    UniverseRankingSnapshotV1,
+    projection_envelope_dict,
+)
+from .source_health import DashboardSourceHealthSnapshotV1
+
+
+def _base(snapshot: Any) -> dict[str, Any]:
+    return projection_envelope_dict(snapshot)
+
+
+def serialize_projection(snapshot: Any) -> dict[str, Any]:
+    if isinstance(snapshot, MarketInstrumentSnapshotV1):
+        payload = _base(snapshot)
+        payload.update(
+            {
+                "instrument_id": snapshot.instrument_id,
+                "venue": snapshot.venue,
+                "market_type": snapshot.market_type,
+                "mark_price": snapshot.mark_price,
+                "reason_codes": list(snapshot.reason_codes),
+            }
+        )
+        return payload
+    if isinstance(snapshot, UniverseRankingSnapshotV1):
+        payload = _base(snapshot)
+        payload.update(
+            {
+                "ranking": [dict(row) for row in snapshot.ranking],
+                "selected_instrument_id": snapshot.selected_instrument_id,
+                "reason_codes": list(snapshot.reason_codes),
+            }
+        )
+        return payload
+    if isinstance(snapshot, DynamicScopeSnapshotV1):
+        payload = _base(snapshot)
+        payload.update(
+            {
+                "scope_state": snapshot.scope_state,
+                "current_scope_ref": snapshot.current_scope_ref,
+                "next_scope_ref": snapshot.next_scope_ref,
+                "reason_codes": list(snapshot.reason_codes),
+            }
+        )
+        return payload
+    if isinstance(snapshot, CanonicalDecisionSnapshotV1):
+        payload = _base(snapshot)
+        payload.update(
+            {
+                "instrument_id": snapshot.instrument_id,
+                "decision": snapshot.decision,
+                "direction": snapshot.direction,
+                "reason_codes": list(snapshot.reason_codes),
+                "blockers": list(snapshot.blockers),
+                "decision_id": snapshot.decision_id,
+                "evidence_schema_version": snapshot.evidence_schema_version,
+            }
+        )
+        return payload
+    if isinstance(snapshot, DoublePlaySnapshotV1):
+        payload = _base(snapshot)
+        payload.update(
+            {
+                "overall_status": snapshot.overall_status,
+                "panel_summaries": [dict(row) for row in snapshot.panel_summaries],
+                "blockers": list(snapshot.blockers),
+                "display_only": snapshot.display_only,
+                "live_authorization": snapshot.live_authorization,
+            }
+        )
+        return payload
+    if isinstance(snapshot, RiskSizingCapitalSnapshotV1):
+        payload = _base(snapshot)
+        payload.update(
+            {
+                "risk_status": snapshot.risk_status,
+                "sizing_status": snapshot.sizing_status,
+                "capital_status": snapshot.capital_status,
+                "reason_codes": list(snapshot.reason_codes),
+                "quantity": snapshot.quantity,
+            }
+        )
+        return payload
+    if isinstance(snapshot, SafetyAuthoritySnapshotV1):
+        payload = _base(snapshot)
+        payload.update(
+            {
+                "kill_switch_state": snapshot.kill_switch_state,
+                "veto_active": snapshot.veto_active,
+                "reason_codes": list(snapshot.reason_codes),
+            }
+        )
+        return payload
+    if isinstance(snapshot, ExecutionReconciliationSnapshotV1):
+        payload = _base(snapshot)
+        payload.update(
+            {
+                "execution_status": snapshot.execution_status,
+                "reconciliation_status": snapshot.reconciliation_status,
+                "order_intent_ref": snapshot.order_intent_ref,
+                "reason_codes": list(snapshot.reason_codes),
+            }
+        )
+        return payload
+    if isinstance(snapshot, EconomicSummarySnapshotV1):
+        payload = _base(snapshot)
+        payload.update(
+            {
+                "economic_gate_status": snapshot.economic_gate_status,
+                "evidence_ref": snapshot.evidence_ref,
+                "reason_codes": list(snapshot.reason_codes),
+            }
+        )
+        return payload
+    if isinstance(snapshot, AutonomyStageSnapshotV1):
+        payload = _base(snapshot)
+        payload.update(
+            {
+                "autonomy_stage": snapshot.autonomy_stage,
+                "runtime_bridge_status": snapshot.runtime_bridge_status,
+                "reason_codes": list(snapshot.reason_codes),
+            }
+        )
+        return payload
+    if isinstance(snapshot, DiagnosticsSummarySnapshotV1):
+        payload = _base(snapshot)
+        payload.update(
+            {
+                "diagnostic_codes": list(snapshot.diagnostic_codes),
+                "summary": snapshot.summary,
+                "reason_codes": list(snapshot.reason_codes),
+            }
+        )
+        return payload
+    if isinstance(snapshot, DashboardSourceHealthSnapshotV1):
+        return snapshot.to_json_dict()
+    raise TypeError(f"unsupported snapshot type: {type(snapshot)!r}")
+
+
+def dumps_projection_canonical(snapshot: Any) -> str:
+    """Stable canonical JSON (sorted keys, compact separators)."""
+    return json.dumps(
+        serialize_projection(snapshot),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )

--- a/src/webui/market_dashboard_landscape_v2/source_health.py
+++ b/src/webui/market_dashboard_landscape_v2/source_health.py
@@ -1,0 +1,149 @@
+"""Unified Source Health aggregation for Market Dashboard Landscape V2.
+
+Aggregation-only: never invents per-slot truth, never upgrades MISSING to
+AVAILABLE, never recomputes domain decisions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping
+
+from .availability import Availability
+from .contracts import SCHEMA_FAMILY, SCHEMA_VERSION, ProjectionSnapshot, _ProjectionBase
+from .owner_registry import REQUIRED_PROJECTION_SLOTS
+from .provenance import FreshnessV1, SnapshotProvenanceV1
+
+SOURCE_HEALTH_SCHEMA_ID = f"{SCHEMA_FAMILY}.source_health.{SCHEMA_VERSION}"
+
+
+@dataclass(frozen=True)
+class DashboardSourceHealthSnapshotV1:
+    """Complete availability map across required Landscape projection slots."""
+
+    schema_id: str
+    schema_version: str
+    provenance: SnapshotProvenanceV1
+    freshness: FreshnessV1
+    availability: Availability
+    slot_availability: Mapping[str, Availability]
+    incomplete_slots: tuple[str, ...]
+    generated_at: datetime
+
+    def __post_init__(self) -> None:
+        if self.schema_id != SOURCE_HEALTH_SCHEMA_ID:
+            raise ValueError(f"schema_id must be {SOURCE_HEALTH_SCHEMA_ID!r}")
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {SCHEMA_VERSION!r}")
+        if not isinstance(self.provenance, SnapshotProvenanceV1):
+            raise TypeError("provenance required")
+        if not isinstance(self.freshness, FreshnessV1):
+            raise TypeError("freshness required")
+        if not isinstance(self.availability, Availability):
+            raise TypeError("availability required")
+        if self.availability != self.provenance.availability:
+            raise ValueError("availability must match provenance.availability")
+        normalized = {str(k): v for k, v in self.slot_availability.items()}
+        for slot in REQUIRED_PROJECTION_SLOTS:
+            if slot == "source_health":
+                continue
+            if slot not in normalized:
+                raise ValueError(f"missing required slot in source health: {slot}")
+            if not isinstance(normalized[slot], Availability):
+                raise TypeError(f"slot {slot} availability must be Availability")
+        unexpected = set(normalized) - (set(REQUIRED_PROJECTION_SLOTS) - {"source_health"})
+        if unexpected:
+            raise ValueError(f"unexpected source-health slots: {sorted(unexpected)}")
+        object.__setattr__(self, "slot_availability", dict(normalized))
+        object.__setattr__(self, "incomplete_slots", tuple(self.incomplete_slots))
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "schema_id": self.schema_id,
+            "schema_version": self.schema_version,
+            "availability": self.availability.value,
+            "provenance": self.provenance.to_json_dict(),
+            "freshness": self.freshness.to_json_dict(),
+            "slot_availability": {
+                slot: state.value for slot, state in sorted(self.slot_availability.items())
+            },
+            "incomplete_slots": list(self.incomplete_slots),
+            "generated_at": self.generated_at.isoformat().replace("+00:00", "Z"),
+        }
+
+
+def _aggregate_availability(states: Mapping[str, Availability]) -> Availability:
+    values = list(states.values())
+    if any(state is Availability.INVALID for state in values):
+        return Availability.INVALID
+    if any(state is Availability.MISSING_SOURCE for state in values):
+        return Availability.MISSING_SOURCE
+    if any(state is Availability.STALE for state in values):
+        return Availability.STALE
+    if any(state is Availability.NOT_BOUND for state in values):
+        return Availability.NOT_BOUND
+    if values and all(state is Availability.AVAILABLE for state in values):
+        return Availability.AVAILABLE
+    # Empty map is invalid — callers must supply complete slot maps.
+    raise ValueError("cannot aggregate empty availability map")
+
+
+def build_source_health_from_snapshots(
+    snapshots: Mapping[str, _ProjectionBase | ProjectionSnapshot],
+    *,
+    generated_at: datetime,
+    producer_module: str = "webui.market_dashboard_landscape_v2.source_health",
+    git_sha: str | None = None,
+) -> DashboardSourceHealthSnapshotV1:
+    """Build Source Health from explicit projection snapshots.
+
+    Fail-closed: every required slot except source_health itself must be present.
+    """
+    if generated_at.tzinfo is None:
+        raise ValueError("generated_at must be timezone-aware")
+    slot_availability: dict[str, Availability] = {}
+    for slot in REQUIRED_PROJECTION_SLOTS:
+        if slot == "source_health":
+            continue
+        if slot not in snapshots:
+            raise ValueError(f"MISSING_SOURCE: required snapshot slot absent: {slot}")
+        snap = snapshots[slot]
+        if not isinstance(snap, _ProjectionBase):
+            raise TypeError(f"snapshot for {slot} must be a Landscape projection")
+        slot_availability[slot] = snap.availability
+
+    incomplete = tuple(
+        sorted(
+            slot for slot, state in slot_availability.items() if state is not Availability.AVAILABLE
+        )
+    )
+    aggregate = _aggregate_availability(slot_availability)
+    provenance = SnapshotProvenanceV1(
+        schema_id=SOURCE_HEALTH_SCHEMA_ID,
+        schema_version=SCHEMA_VERSION,
+        producer_module=producer_module,
+        generated_at=generated_at,
+        effective_at=generated_at,
+        source_kind="source_health_aggregation",
+        source_reference="slot_availability_map",
+        evidence_digest=None,
+        git_sha=git_sha,
+        availability=aggregate,
+    )
+    freshness = FreshnessV1(
+        observed_at=generated_at,
+        max_age_seconds=None,
+        is_stale=aggregate is Availability.STALE,
+        stale_reason="AGGREGATE_CONTAINS_STALE_SLOT" if aggregate is Availability.STALE else None,
+    )
+    return DashboardSourceHealthSnapshotV1(
+        schema_id=SOURCE_HEALTH_SCHEMA_ID,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=freshness,
+        availability=aggregate,
+        slot_availability=slot_availability,
+        incomplete_slots=incomplete,
+        generated_at=generated_at,
+    )

--- a/src/webui/market_dashboard_landscape_v2/unavailable.py
+++ b/src/webui/market_dashboard_landscape_v2/unavailable.py
@@ -1,0 +1,454 @@
+"""Unavailable / unbound snapshot factories — no silent defaults."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Callable
+
+from .availability import Availability
+from .contracts import (
+    SCHEMA_FAMILY,
+    SCHEMA_VERSION,
+    AutonomyStageSnapshotV1,
+    CanonicalDecisionSnapshotV1,
+    DiagnosticsSummarySnapshotV1,
+    DoublePlaySnapshotV1,
+    DynamicScopeSnapshotV1,
+    EconomicSummarySnapshotV1,
+    ExecutionReconciliationSnapshotV1,
+    MarketInstrumentSnapshotV1,
+    RiskSizingCapitalSnapshotV1,
+    SafetyAuthoritySnapshotV1,
+    UniverseRankingSnapshotV1,
+)
+from .owner_registry import owner_registry_by_slot
+from .provenance import FreshnessV1, SnapshotProvenanceV1
+
+_UNAVAILABLE_STATES = frozenset(
+    {
+        Availability.NOT_BOUND,
+        Availability.MISSING_SOURCE,
+        Availability.STALE,
+        Availability.INVALID,
+    }
+)
+
+
+def _utc_now_for_tests(generated_at: datetime | None) -> datetime:
+    if generated_at is None:
+        raise ValueError("generated_at must be supplied explicitly (no silent clock default)")
+    return generated_at
+
+
+def build_unavailable_provenance(
+    *,
+    slot: str,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+    source_reference: str | None = None,
+    evidence_digest: str | None = None,
+    git_sha: str | None = None,
+) -> SnapshotProvenanceV1:
+    if availability not in _UNAVAILABLE_STATES:
+        raise ValueError(
+            f"unavailable provenance requires non-AVAILABLE state, got {availability.value}"
+        )
+    if not reason or not str(reason).strip():
+        raise ValueError("reason required for unavailable provenance")
+    owners = owner_registry_by_slot()
+    if slot not in owners:
+        raise ValueError(f"unknown projection slot={slot!r}")
+    owner = owners[slot]
+    return SnapshotProvenanceV1(
+        schema_id=f"{SCHEMA_FAMILY}.{slot}.{SCHEMA_VERSION}",
+        schema_version=SCHEMA_VERSION,
+        producer_module=owner.owner_module,
+        generated_at=_utc_now_for_tests(generated_at),
+        effective_at=None,
+        source_kind=f"unavailable:{availability.value}",
+        source_reference=source_reference or reason,
+        evidence_digest=evidence_digest,
+        git_sha=git_sha,
+        availability=availability,
+    )
+
+
+def build_unavailable_freshness(
+    *,
+    observed_at: datetime,
+    availability: Availability,
+    stale_reason: str | None = None,
+) -> FreshnessV1:
+    if availability is Availability.STALE:
+        if not stale_reason:
+            raise ValueError("stale_reason required for STALE")
+        return FreshnessV1(
+            observed_at=observed_at,
+            max_age_seconds=None,
+            is_stale=True,
+            stale_reason=stale_reason,
+        )
+    return FreshnessV1(
+        observed_at=observed_at,
+        max_age_seconds=None,
+        is_stale=False,
+        stale_reason=None,
+    )
+
+
+def unavailable_market_instrument(
+    *,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+) -> MarketInstrumentSnapshotV1:
+    provenance = build_unavailable_provenance(
+        slot="market_instrument",
+        availability=availability,
+        generated_at=generated_at,
+        reason=reason,
+    )
+    return MarketInstrumentSnapshotV1(
+        schema_id=provenance.schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=build_unavailable_freshness(
+            observed_at=generated_at,
+            availability=availability,
+            stale_reason=reason if availability is Availability.STALE else None,
+        ),
+        availability=availability,
+        instrument_id=None,
+        venue=None,
+        market_type=None,
+        mark_price=None,
+        reason_codes=(reason,),
+    )
+
+
+def unavailable_universe_ranking(
+    *,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+) -> UniverseRankingSnapshotV1:
+    provenance = build_unavailable_provenance(
+        slot="universe_ranking",
+        availability=availability,
+        generated_at=generated_at,
+        reason=reason,
+    )
+    return UniverseRankingSnapshotV1(
+        schema_id=provenance.schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=build_unavailable_freshness(
+            observed_at=generated_at,
+            availability=availability,
+            stale_reason=reason if availability is Availability.STALE else None,
+        ),
+        availability=availability,
+        ranking=(),
+        selected_instrument_id=None,
+        reason_codes=(reason,),
+    )
+
+
+def unavailable_dynamic_scope(
+    *,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+) -> DynamicScopeSnapshotV1:
+    provenance = build_unavailable_provenance(
+        slot="dynamic_scope",
+        availability=availability,
+        generated_at=generated_at,
+        reason=reason,
+    )
+    return DynamicScopeSnapshotV1(
+        schema_id=provenance.schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=build_unavailable_freshness(
+            observed_at=generated_at,
+            availability=availability,
+            stale_reason=reason if availability is Availability.STALE else None,
+        ),
+        availability=availability,
+        scope_state=None,
+        current_scope_ref=None,
+        next_scope_ref=None,
+        reason_codes=(reason,),
+    )
+
+
+def unavailable_canonical_decision(
+    *,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+) -> CanonicalDecisionSnapshotV1:
+    provenance = build_unavailable_provenance(
+        slot="canonical_decision",
+        availability=availability,
+        generated_at=generated_at,
+        reason=reason,
+    )
+    return CanonicalDecisionSnapshotV1(
+        schema_id=provenance.schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=build_unavailable_freshness(
+            observed_at=generated_at,
+            availability=availability,
+            stale_reason=reason if availability is Availability.STALE else None,
+        ),
+        availability=availability,
+        instrument_id=None,
+        decision=None,
+        direction=None,
+        reason_codes=(reason,),
+        blockers=(reason,),
+        decision_id=None,
+        evidence_schema_version=None,
+    )
+
+
+def unavailable_double_play(
+    *,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+) -> DoublePlaySnapshotV1:
+    provenance = build_unavailable_provenance(
+        slot="double_play",
+        availability=availability,
+        generated_at=generated_at,
+        reason=reason,
+    )
+    return DoublePlaySnapshotV1(
+        schema_id=provenance.schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=build_unavailable_freshness(
+            observed_at=generated_at,
+            availability=availability,
+            stale_reason=reason if availability is Availability.STALE else None,
+        ),
+        availability=availability,
+        overall_status=None,
+        panel_summaries=(),
+        blockers=(reason,),
+        display_only=True,
+        live_authorization=False,
+    )
+
+
+def unavailable_risk_sizing_capital(
+    *,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+) -> RiskSizingCapitalSnapshotV1:
+    provenance = build_unavailable_provenance(
+        slot="risk_sizing_capital",
+        availability=availability,
+        generated_at=generated_at,
+        reason=reason,
+    )
+    return RiskSizingCapitalSnapshotV1(
+        schema_id=provenance.schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=build_unavailable_freshness(
+            observed_at=generated_at,
+            availability=availability,
+            stale_reason=reason if availability is Availability.STALE else None,
+        ),
+        availability=availability,
+        risk_status=None,
+        sizing_status=None,
+        capital_status=None,
+        reason_codes=(reason,),
+        quantity=None,
+    )
+
+
+def unavailable_safety_authority(
+    *,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+) -> SafetyAuthoritySnapshotV1:
+    provenance = build_unavailable_provenance(
+        slot="safety_authority",
+        availability=availability,
+        generated_at=generated_at,
+        reason=reason,
+    )
+    return SafetyAuthoritySnapshotV1(
+        schema_id=provenance.schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=build_unavailable_freshness(
+            observed_at=generated_at,
+            availability=availability,
+            stale_reason=reason if availability is Availability.STALE else None,
+        ),
+        availability=availability,
+        kill_switch_state=None,
+        veto_active=None,
+        reason_codes=(reason,),
+    )
+
+
+def unavailable_execution_reconciliation(
+    *,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+) -> ExecutionReconciliationSnapshotV1:
+    provenance = build_unavailable_provenance(
+        slot="execution_reconciliation",
+        availability=availability,
+        generated_at=generated_at,
+        reason=reason,
+    )
+    return ExecutionReconciliationSnapshotV1(
+        schema_id=provenance.schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=build_unavailable_freshness(
+            observed_at=generated_at,
+            availability=availability,
+            stale_reason=reason if availability is Availability.STALE else None,
+        ),
+        availability=availability,
+        execution_status=None,
+        reconciliation_status=None,
+        order_intent_ref=None,
+        reason_codes=(reason,),
+    )
+
+
+def unavailable_economic_summary(
+    *,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+) -> EconomicSummarySnapshotV1:
+    provenance = build_unavailable_provenance(
+        slot="economic_summary",
+        availability=availability,
+        generated_at=generated_at,
+        reason=reason,
+    )
+    return EconomicSummarySnapshotV1(
+        schema_id=provenance.schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=build_unavailable_freshness(
+            observed_at=generated_at,
+            availability=availability,
+            stale_reason=reason if availability is Availability.STALE else None,
+        ),
+        availability=availability,
+        economic_gate_status=None,
+        evidence_ref=None,
+        reason_codes=(reason,),
+    )
+
+
+def unavailable_autonomy_stage(
+    *,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+) -> AutonomyStageSnapshotV1:
+    provenance = build_unavailable_provenance(
+        slot="autonomy_stage",
+        availability=availability,
+        generated_at=generated_at,
+        reason=reason,
+    )
+    return AutonomyStageSnapshotV1(
+        schema_id=provenance.schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=build_unavailable_freshness(
+            observed_at=generated_at,
+            availability=availability,
+            stale_reason=reason if availability is Availability.STALE else None,
+        ),
+        availability=availability,
+        autonomy_stage=None,
+        runtime_bridge_status=None,
+        reason_codes=(reason,),
+    )
+
+
+def unavailable_diagnostics_summary(
+    *,
+    availability: Availability,
+    generated_at: datetime,
+    reason: str,
+) -> DiagnosticsSummarySnapshotV1:
+    provenance = build_unavailable_provenance(
+        slot="diagnostics_summary",
+        availability=availability,
+        generated_at=generated_at,
+        reason=reason,
+    )
+    return DiagnosticsSummarySnapshotV1(
+        schema_id=provenance.schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=build_unavailable_freshness(
+            observed_at=generated_at,
+            availability=availability,
+            stale_reason=reason if availability is Availability.STALE else None,
+        ),
+        availability=availability,
+        diagnostic_codes=(),
+        summary=None,
+        reason_codes=(reason,),
+    )
+
+
+UNAVAILABLE_BUILDERS: dict[str, Callable[..., object]] = {
+    "market_instrument": unavailable_market_instrument,
+    "universe_ranking": unavailable_universe_ranking,
+    "dynamic_scope": unavailable_dynamic_scope,
+    "canonical_decision": unavailable_canonical_decision,
+    "double_play": unavailable_double_play,
+    "risk_sizing_capital": unavailable_risk_sizing_capital,
+    "safety_authority": unavailable_safety_authority,
+    "execution_reconciliation": unavailable_execution_reconciliation,
+    "economic_summary": unavailable_economic_summary,
+    "autonomy_stage": unavailable_autonomy_stage,
+    "diagnostics_summary": unavailable_diagnostics_summary,
+}
+
+
+def default_not_bound_bundle(*, generated_at: datetime | None = None) -> dict[str, object]:
+    """Explicit NOT_BOUND bundle for all unbound Landscape slots.
+
+    generated_at is mandatory via keyword; no wall-clock silent default.
+    """
+    if generated_at is None:
+        raise ValueError("generated_at required (no silent datetime.now default)")
+    if generated_at.tzinfo is None:
+        raise ValueError("generated_at must be timezone-aware")
+    # Normalize intent: accept any tz-aware; factories enforce UTC via provenance.
+    stamp = generated_at.astimezone(timezone.utc)
+    reason = "LANDSCAPE_V2_SLOT_NOT_BOUND"
+    return {
+        slot: builder(
+            availability=Availability.NOT_BOUND,
+            generated_at=stamp,
+            reason=reason,
+        )
+        for slot, builder in UNAVAILABLE_BUILDERS.items()
+    }

--- a/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
@@ -1,0 +1,207 @@
+"""Architecture / import-boundary guards for Market Dashboard Landscape V2.
+
+Prevents:
+- Landscape package importing mutable runtime / execution / order APIs
+- UI templates importing Landscape via forbidden execution paths
+- Duplicate truth owners inside the Landscape package
+- UI-side recomputation of decision / risk / sizing
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+LANDSCAPE_PKG = REPO / "src" / "webui" / "market_dashboard_landscape_v2"
+WEBUI_ROOT = REPO / "src" / "webui"
+TEMPLATES_ROOT = REPO / "templates" / "peak_trade_dashboard"
+
+FORBIDDEN_IMPORT_PREFIXES = (
+    "src.execution",
+    "execution.",
+    "src.trading.orders",
+    "trading.orders",
+    "src.broker",
+    "broker.",
+    "src.webui.execution_watch_api",
+    "webui.execution_watch_api",
+    "src.webui.live_track",
+    "webui.live_track",
+    "src.webui.workflow_dashboard_runtime_v1",
+    "webui.workflow_dashboard_runtime_v1",
+    "src.webui.last_paper_run_panel_runtime_v0",
+    "webui.last_paper_run_panel_runtime_v0",
+    "src.meta.learning_loop.deploy_inactive",
+    "meta.learning_loop.deploy_inactive",
+)
+
+FORBIDDEN_NAME_TOKENS_IN_LANDSCAPE = (
+    "place_order",
+    "submit_order",
+    "create_order",
+    "activate_runtime",
+    "arm_live",
+    "compute_decision",
+    "recompute_decision",
+    "compute_risk",
+    "recompute_risk",
+    "compute_sizing",
+    "recompute_sizing",
+    "select_direction",
+    "switch_scope",
+)
+
+# Decision/risk/sizing truth must remain outside this consumer package.
+FORBIDDEN_SECOND_TRUTH_DEFINITIONS = (
+    "class CanonicalTradingDecisionEvidence",
+    "def evaluate_double_play",
+    "def compute_position_size",
+    "def compute_risk_budget",
+)
+
+
+def _iter_py_files(root: Path) -> list[Path]:
+    return sorted(p for p in root.rglob("*.py") if p.is_file())
+
+
+def _import_modules(path: Path) -> list[tuple[str, int]]:
+    """Return (module, level) pairs. level>0 means relative import."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.append((alias.name, 0))
+        elif isinstance(node, ast.ImportFrom):
+            modules.append((node.module or "", node.level))
+    return modules
+
+
+def test_landscape_package_has_no_forbidden_imports() -> None:
+    hits: list[str] = []
+    for path in _iter_py_files(LANDSCAPE_PKG):
+        for module, level in _import_modules(path):
+            if level > 0:
+                continue
+            for prefix in FORBIDDEN_IMPORT_PREFIXES:
+                if module == prefix or module.startswith(prefix + "."):
+                    hits.append(f"{path.relative_to(REPO)}:{module}")
+    assert hits == [], f"FORBIDDEN_IMPORTS={hits}"
+
+
+def test_landscape_package_stdlib_and_relative_only() -> None:
+    """Contracts stay free of trading/runtime imports (projection uses field args)."""
+    allowed_external = {
+        "dataclasses",
+        "datetime",
+        "enum",
+        "json",
+        "typing",
+        "__future__",
+    }
+    hits: list[str] = []
+    for path in _iter_py_files(LANDSCAPE_PKG):
+        for module, level in _import_modules(path):
+            if level > 0:
+                continue
+            if not module:
+                continue
+            root = module.split(".", 1)[0]
+            if root in allowed_external:
+                continue
+            hits.append(f"{path.relative_to(REPO)}:{module}")
+    assert hits == [], f"non-stdlib imports in Landscape package: {hits}"
+
+
+def test_no_ui_side_recomputation_markers() -> None:
+    hits: list[str] = []
+    for path in _iter_py_files(LANDSCAPE_PKG):
+        text = path.read_text(encoding="utf-8")
+        for token in FORBIDDEN_NAME_TOKENS_IN_LANDSCAPE:
+            if token in text:
+                # Allow mentions inside forbid-lists / docstrings that say "Forbidden:"
+                if f'"{token}"' in text or f"'{token}'" in text:
+                    continue
+                if "Forbidden" in text and token in text:
+                    # still fail if defined as function
+                    tree = ast.parse(text)
+                    for node in ast.walk(tree):
+                        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                            if node.name == token:
+                                hits.append(f"{path.relative_to(REPO)}:def {token}")
+                    continue
+                tree = ast.parse(text)
+                for node in ast.walk(tree):
+                    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                        if node.name == token:
+                            hits.append(f"{path.relative_to(REPO)}:{node.name}")
+    assert hits == [], f"UI recomputation markers present: {hits}"
+
+
+def test_no_second_truth_owner_definitions() -> None:
+    hits: list[str] = []
+    for path in _iter_py_files(LANDSCAPE_PKG):
+        text = path.read_text(encoding="utf-8")
+        for needle in FORBIDDEN_SECOND_TRUTH_DEFINITIONS:
+            if needle in text:
+                hits.append(f"{path.relative_to(REPO)}:{needle}")
+    assert hits == [], f"SECOND_TRUTH_OWNERS={hits}"
+
+
+def test_webui_templates_do_not_import_execution_or_landscape_runtime() -> None:
+    """No Jinja/HTML surface may reference order/execution activation APIs."""
+    if not TEMPLATES_ROOT.is_dir():
+        return
+    forbidden_substrings = (
+        "execution_watch_api",
+        "place_order",
+        "submit_order",
+        "activate_runtime",
+        "arm_live",
+        "market_dashboard_landscape_v2",  # no UI wiring in PR1
+    )
+    hits: list[str] = []
+    for path in TEMPLATES_ROOT.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in {".html", ".js", ".css", ".jinja", ".j2"}:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for token in forbidden_substrings:
+            if token in text:
+                hits.append(f"{path.relative_to(REPO)}:{token}")
+    assert hits == [], f"template forbidden refs: {hits}"
+
+
+def test_no_market_route_wired_in_app_for_landscape_v2() -> None:
+    app_text = (WEBUI_ROOT / "app.py").read_text(encoding="utf-8")
+    assert "market_dashboard_landscape_v2" not in app_text
+    assert '@app.get("/market"' not in app_text
+    assert "create_market_router" not in app_text
+
+
+def test_projection_helpers_are_field_copy_only() -> None:
+    proj_path = LANDSCAPE_PKG / "projections.py"
+    proj = proj_path.read_text(encoding="utf-8")
+    assert "project_canonical_decision_snapshot_v1" in proj
+    assert "Forbidden" in proj
+    tree = ast.parse(proj)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            assert node.level > 0 or (node.module or "").split(".", 1)[0] in {
+                "__future__",
+                "datetime",
+                "typing",
+            }
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] in {"__future__", "datetime", "typing"}
+    # Must not import producer evidence modules as runtime dependencies.
+    for module, level in _import_modules(proj_path):
+        if level > 0:
+            continue
+        assert "canonical_trading_decision_evidence" not in module
+        assert "double_play_dashboard_display" not in module
+        assert "execution" not in module
+        assert "order" not in module

--- a/tests/webui/test_market_landscape_dashboard_v2_contracts_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_contracts_v0.py
@@ -1,0 +1,230 @@
+"""Contract tests for Market Dashboard Landscape V2 read-only projections."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.webui.market_dashboard_landscape_v2 import (
+    AVAILABILITY_VALUES,
+    SCHEMA_VERSION,
+    Availability,
+    CanonicalDecisionSnapshotV1,
+    build_source_health_from_snapshots,
+    default_not_bound_bundle,
+    dumps_projection_canonical,
+    owner_registry_by_slot,
+    project_canonical_decision_snapshot_v1,
+    project_double_play_snapshot_v1,
+    serialize_projection,
+)
+from src.webui.market_dashboard_landscape_v2.unavailable import (
+    unavailable_canonical_decision,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+STAMP = datetime(2026, 7, 23, 14, 0, 0, tzinfo=timezone.utc)
+
+
+def test_availability_vocabulary_exact() -> None:
+    assert AVAILABILITY_VALUES == frozenset(
+        {"AVAILABLE", "NOT_BOUND", "MISSING_SOURCE", "STALE", "INVALID"}
+    )
+
+
+def test_default_not_bound_bundle_covers_all_slots_without_silent_clock() -> None:
+    with pytest.raises(ValueError, match="generated_at required"):
+        default_not_bound_bundle()
+    bundle = default_not_bound_bundle(generated_at=STAMP)
+    assert "source_health" not in bundle
+    for slot, snap in bundle.items():
+        assert snap.availability is Availability.NOT_BOUND
+        assert snap.schema_version == SCHEMA_VERSION
+        assert snap.provenance.availability is Availability.NOT_BOUND
+        assert snap.freshness.is_stale is False
+        payload = serialize_projection(snap)
+        assert payload["availability"] == "NOT_BOUND"
+        assert payload["provenance"]["schema_id"]
+        assert payload["freshness"]["observed_at"].endswith("Z")
+
+
+def test_immutability_frozen_snapshots() -> None:
+    snap = unavailable_canonical_decision(
+        availability=Availability.NOT_BOUND,
+        generated_at=STAMP,
+        reason="TEST_NOT_BOUND",
+    )
+    with pytest.raises(FrozenInstanceError):
+        snap.decision = "BUY"  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        snap.provenance.availability = Availability.AVAILABLE  # type: ignore[misc]
+
+
+def test_provenance_completeness_on_available_decision() -> None:
+    snap = project_canonical_decision_snapshot_v1(
+        instrument_id="PF_XBTUSD",
+        decision="HOLD",
+        direction="FLAT",
+        reason_codes=("REASON_A",),
+        blockers=(),
+        decision_id="dec-1",
+        evidence_schema_version="canonical_trading_decision_evidence_v1",
+        evidence_digest="a" * 64,
+        generated_at=STAMP,
+        effective_at=STAMP,
+        source_reference="evidence://dec-1",
+        git_sha="deadbeef",
+    )
+    assert snap.availability is Availability.AVAILABLE
+    prov = snap.provenance.to_json_dict()
+    for key in (
+        "schema_id",
+        "schema_version",
+        "producer_module",
+        "generated_at",
+        "source_kind",
+        "availability",
+    ):
+        assert prov[key]
+    assert prov["evidence_digest"] == "a" * 64
+    assert prov["git_sha"] == "deadbeef"
+
+
+def test_available_decision_rejects_missing_fields() -> None:
+    with pytest.raises(ValueError, match="required"):
+        project_canonical_decision_snapshot_v1(
+            instrument_id="",
+            decision="HOLD",
+            direction="FLAT",
+            reason_codes=(),
+            blockers=(),
+            decision_id=None,
+            evidence_schema_version="canonical_trading_decision_evidence_v1",
+            evidence_digest=None,
+            generated_at=STAMP,
+            effective_at=None,
+            source_reference=None,
+        )
+
+
+def test_stale_and_invalid_semantics() -> None:
+    stale = unavailable_canonical_decision(
+        availability=Availability.STALE,
+        generated_at=STAMP,
+        reason="EVIDENCE_STALE",
+    )
+    assert stale.availability is Availability.STALE
+    assert stale.freshness.is_stale is True
+    assert stale.freshness.stale_reason == "EVIDENCE_STALE"
+    assert stale.decision is None
+
+    invalid = unavailable_canonical_decision(
+        availability=Availability.INVALID,
+        generated_at=STAMP,
+        reason="SCHEMA_MISMATCH",
+    )
+    assert invalid.availability is Availability.INVALID
+    assert invalid.decision is None
+
+
+def test_missing_source_and_not_bound_no_invented_decision() -> None:
+    missing = unavailable_canonical_decision(
+        availability=Availability.MISSING_SOURCE,
+        generated_at=STAMP,
+        reason="PRODUCER_OUTPUT_ABSENT",
+    )
+    assert missing.decision is None
+    assert missing.direction is None
+    assert "PRODUCER_OUTPUT_ABSENT" in missing.blockers
+
+
+def test_source_health_aggregation_fail_closed_and_complete() -> None:
+    bundle = default_not_bound_bundle(generated_at=STAMP)
+    health = build_source_health_from_snapshots(bundle, generated_at=STAMP)
+    assert health.availability is Availability.NOT_BOUND
+    assert set(health.slot_availability) == set(bundle)
+    assert set(health.incomplete_slots) == set(bundle)
+    payload = health.to_json_dict()
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["slot_availability"]["canonical_decision"] == "NOT_BOUND"
+
+    with pytest.raises(ValueError, match="required snapshot slot absent"):
+        build_source_health_from_snapshots({}, generated_at=STAMP)
+
+
+def test_source_health_prefers_invalid_over_available() -> None:
+    from src.webui.market_dashboard_landscape_v2.unavailable import (
+        unavailable_safety_authority,
+    )
+
+    bundle = default_not_bound_bundle(generated_at=STAMP)
+    bundle["canonical_decision"] = project_canonical_decision_snapshot_v1(
+        instrument_id="PF_XBTUSD",
+        decision="HOLD",
+        direction="FLAT",
+        reason_codes=("OK",),
+        blockers=(),
+        decision_id="d1",
+        evidence_schema_version="canonical_trading_decision_evidence_v1",
+        evidence_digest=None,
+        generated_at=STAMP,
+        effective_at=STAMP,
+        source_reference="ref",
+    )
+    bundle["safety_authority"] = unavailable_safety_authority(
+        availability=Availability.INVALID,
+        generated_at=STAMP,
+        reason="BAD",
+    )
+    health = build_source_health_from_snapshots(bundle, generated_at=STAMP)
+    assert health.availability is Availability.INVALID
+    assert health.slot_availability["canonical_decision"] is Availability.AVAILABLE
+
+
+def test_serialization_stability() -> None:
+    snap = project_double_play_snapshot_v1(
+        overall_status="display_ready",
+        panel_summaries=({"name": "composition", "status": "display_ready"},),
+        blockers=(),
+        generated_at=STAMP,
+        source_reference="dp-display",
+    )
+    first = dumps_projection_canonical(snap)
+    second = dumps_projection_canonical(snap)
+    assert first == second
+    parsed = json.loads(first)
+    assert parsed["availability"] == "AVAILABLE"
+    assert parsed["live_authorization"] is False
+    assert parsed["display_only"] is True
+
+
+def test_owner_registry_reuses_canonical_modules_no_second_truth() -> None:
+    registry = owner_registry_by_slot()
+    decision = registry["canonical_decision"]
+    assert decision.owner_module.endswith("canonical_trading_decision_evidence_v1")
+    assert decision.reuse_status == "REUSED"
+    dp = registry["double_play"]
+    assert "double_play_dashboard_display" in dp.owner_module
+    # Landscape package must not claim decision authority.
+    assert "market_dashboard_landscape_v2" not in decision.owner_module
+
+
+def test_schema_version_stable() -> None:
+    snap = unavailable_canonical_decision(
+        availability=Availability.NOT_BOUND,
+        generated_at=STAMP,
+        reason="X",
+    )
+    assert isinstance(snap, CanonicalDecisionSnapshotV1)
+    assert snap.schema_version == "v1"
+
+
+def test_package_lives_under_webui_not_deleted_names() -> None:
+    pkg = REPO / "src" / "webui" / "market_dashboard_landscape_v2"
+    assert pkg.is_dir()
+    deleted = REPO / "src" / "webui" / "market_dashboard_readmodels_v1"
+    assert not deleted.exists()


### PR DESCRIPTION
## Summary
- Adds Market Dashboard Landscape V2 **read-only** projection contracts under `src/webui/market_dashboard_landscape_v2/` (Availability, provenance/freshness, immutable snapshots, Source Health aggregation).
- Reuses existing canonical owners via registry (`CanonicalTradingDecisionEvidenceV1`, Double Play display snapshot, market/scope/universe producers) without creating second truth owners.
- Adds contract + architecture-guard tests and wires them into the WebUI bounded Fast-Lane pytest list.
- **No** routes, templates/CSS, runtime activation, orders, or core/trading logic changes (`CORE_DIFF=0`, `RUNTIME_DIFF=0`).

## Test plan
- [x] `pytest tests/webui/test_market_landscape_dashboard_v2_contracts_v0.py tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py`
- [x] Tombstone regression still green (`test_market_dashboard_tombstone_v1.py`)
- [x] Path-equivalent timing probe: PR_BOUNDED_FULL targets + WebUI bounded suite — **926 passed in ~38s**
- [x] `ruff format --check` / `ruff check` on changed Python
- [ ] GitHub CI confirmation (Fast-Lane WebUI bounded + PR_BOUNDED_FULL matrix)


Made with [Cursor](https://cursor.com)