### PR TITLE
fix(webui): align last-paper structure contract with Landscape V2

### DIFF
--- a/tests/webui/test_observability_last_paper_run_panel_structure_contract_v0.py
+++ b/tests/webui/test_observability_last_paper_run_panel_structure_contract_v0.py
@@ -60,7 +60,10 @@ def test_panel_present_when_gate_enabled(client_on: TestClient) -> None:
 def test_btc_usd_not_paper_instrument_truth(client_on: TestClient) -> None:
     html = client_on.get("/observability").text
     assert "selected_symbol" not in html or "BTC/USD" not in html.split("Instrument")[1][:500]
-    assert "Removed Market Dashboard BTC/USD dummy is not Paper Run Truth" in html
+    assert (
+        "Removed Market Dashboard BTC/USD dummy is <strong>not</strong> Future or Paper runtime truth."
+        in html
+    )
 
 
 def test_no_forms_or_post(client_on: TestClient) -> None:
@@ -82,8 +85,9 @@ def test_safety_flags_false(client_on: TestClient) -> None:
 
 def test_market_without_last_paper_primary_panel(client_off: TestClient) -> None:
     response = client_off.get("/market")
-    assert response.status_code == 404
-    html = response.text.lower()
-    assert "market dashboard" not in html
+    assert response.status_code == 200
+    html = response.text
+    assert 'data-market-landscape-v2="true"' in html
+    assert 'data-observability-last-paper-run-panel-v0="true"' not in html
     assert "data-market-dashboard-product-surface-v1" not in html
-    assert "architecture reset in progress" not in html
+    assert "architecture reset in progress" not in html.lower()


### PR DESCRIPTION
## Summary
- Align `test_observability_last_paper_run_panel_structure_contract_v0.py` with the ratified Landscape V2 surface.
- BTC disclaimer assertion now matches the live Observability Hub wording (`<strong>not</strong> Future or Paper runtime truth`).
- `GET /market` expectation updated from historical 404 to Landscape V2 `200` with explicit separation from Last Paper Run panel markers.

## Scope
- Tests only; no production/template/runtime changes.

## Test plan
- [x] `pytest tests/webui/test_observability_last_paper_run_panel_structure_contract_v0.py`
- [x] `ruff format --check` / `ruff check` on the updated test file
- [ ] GitHub CI confirmation

## Safety
- `LIVE_AUTHORIZED=false` · read-only contract update · no Core/runtime/orders changes

Made with [Cursor](https://cursor.com)