### PR TITLE
PHASE 4.1 — Market / Universe / Selected-Instrument Binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,8 @@ jobs:
             tests/webui/test_market_dashboard_tombstone_v1.py \
             tests/webui/test_market_landscape_dashboard_v2_contracts_v0.py \
             tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py \
+            tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py \
+            tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py \
             -q --tb=short -m "not network and not external_tools"
 
   # ============================================================================

--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -7,6 +7,8 @@ trading/webui producer imports (architecture guard).
 
 Fail-closed:
 - Wired slots without durable producer output → MISSING_SOURCE / INVALID
+- Producer timestamps preserved; page-assembly time is observation-only
+- Aged producer snapshots → STALE (never silently refreshed)
 - Never fabricate OHLCV, ranking, eligibility, or selected instrument
 - No decision / Double Play / risk / safety / execution / scope binding
 """
@@ -14,7 +16,8 @@ Fail-closed:
 from __future__ import annotations
 
 import os
-from datetime import datetime
+import re
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -37,6 +40,10 @@ from .workflow_dashboard_readmodel_v1.universe_selection_reader_v1 import (
 # Reuse the existing workflow-dashboard archive env — no second archive owner.
 ENV_ARCHIVE_ROOT = "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT"
 
+# F2 consuming-surface max_allowed_staleness_seconds for Landscape Phase 4.1.
+# Declared here as the dashboard consumer policy; never invent freshness via now().
+LANDSCAPE_PHASE41_MAX_AGE_SECONDS = 86_400
+
 REASON_MARKET_CONTEXT_NOT_PERSISTED = "CANONICAL_MARKET_CONTEXT_NOT_PERSISTED_FOR_DASHBOARD"
 REASON_UNIVERSE_ABSENT = "UNIVERSE_SELECTION_READMODEL_ABSENT"
 REASON_ARCHIVE_ROOT_UNSET = "UNIVERSE_ARCHIVE_ROOT_UNSET"
@@ -44,11 +51,16 @@ REASON_SELECTED_FORBIDDEN_SYMBOL = "SELECTED_INSTRUMENT_FORBIDDEN_BTC_USD_OR_SPO
 REASON_SELECTED_NOT_IN_UNIVERSE = "SELECTED_INSTRUMENT_NOT_IN_CANONICAL_UNIVERSE"
 REASON_SOURCE_CONTRADICTION = "MARKET_AND_UNIVERSE_SELECTED_INSTRUMENT_CONTRADICTION"
 REASON_SELECTED_IDENTITY_PROJECTED = "SELECTED_INSTRUMENT_IDENTITY_FROM_UNIVERSE_SELECTION"
+REASON_PRODUCER_TIMESTAMP_MISSING = "PRODUCER_TIMESTAMP_MISSING"
+REASON_PRODUCER_TIMESTAMP_INVALID = "PRODUCER_TIMESTAMP_INVALID"
+REASON_PRODUCER_DATA_STALE = "PRODUCER_DATA_EXCEEDED_LANDSCAPE_MAX_AGE"
 
 PHASE_4_1_BOUND_SLOTS: tuple[str, ...] = (
     "market_instrument",
     "universe_ranking",
 )
+
+_ISO8601_UTC_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|\+00:00)$")
 
 
 def resolve_landscape_archive_root(
@@ -76,6 +88,44 @@ def resolve_landscape_archive_root(
     return path if path.is_dir() else None
 
 
+def parse_producer_utc_timestamp(raw: str | None) -> datetime | None:
+    """Parse a producer ISO-8601 UTC timestamp.
+
+    Returns None when absent. Raises ValueError for naive/invalid values
+    (fail-closed; never silently coerce to local/now).
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(REASON_PRODUCER_TIMESTAMP_INVALID)
+    text = raw.strip()
+    if not _ISO8601_UTC_PATTERN.match(text):
+        raise ValueError(REASON_PRODUCER_TIMESTAMP_INVALID)
+    normalized = text.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        raise ValueError(REASON_PRODUCER_TIMESTAMP_INVALID)
+    return parsed.astimezone(timezone.utc)
+
+
+def classify_producer_freshness(
+    *,
+    producer_at: datetime,
+    as_of: datetime,
+    max_age_seconds: int = LANDSCAPE_PHASE41_MAX_AGE_SECONDS,
+) -> tuple[Availability, bool, str | None]:
+    """Compare producer timestamp to observation clock; never refresh producer time."""
+    if as_of.tzinfo is None or producer_at.tzinfo is None:
+        raise ValueError(REASON_PRODUCER_TIMESTAMP_INVALID)
+    age = (as_of.astimezone(timezone.utc) - producer_at.astimezone(timezone.utc)).total_seconds()
+    if age < 0:
+        # Future producer timestamps are invalid for this consumer surface.
+        raise ValueError(REASON_PRODUCER_TIMESTAMP_INVALID)
+    if age > max_age_seconds:
+        return Availability.STALE, True, REASON_PRODUCER_DATA_STALE
+    return Availability.AVAILABLE, False, None
+
+
 def _row_dict(row: Any) -> dict[str, Any]:
     return {
         "row_id": row.row_id,
@@ -89,28 +139,59 @@ def _row_dict(row: Any) -> dict[str, Any]:
 
 def _bind_universe_ranking(
     *,
-    generated_at: datetime,
+    as_of: datetime,
     archive_root: Path | None,
     git_sha: str | None,
-) -> Any:
+) -> tuple[Any, Any | None]:
+    """Return (universe_snapshot, loaded_slice_or_none)."""
     if archive_root is None:
-        return unavailable_universe_ranking(
-            availability=Availability.MISSING_SOURCE,
-            generated_at=generated_at,
-            reason=REASON_ARCHIVE_ROOT_UNSET,
+        return (
+            unavailable_universe_ranking(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_ARCHIVE_ROOT_UNSET,
+            ),
+            None,
         )
     slice_v1 = try_load_universe_selection_for_dashboard(archive_root)
     if slice_v1.load_errors:
-        return unavailable_universe_ranking(
-            availability=Availability.INVALID,
-            generated_at=generated_at,
-            reason=str(slice_v1.load_errors[0]),
+        return (
+            unavailable_universe_ranking(
+                availability=Availability.INVALID,
+                generated_at=as_of,
+                reason=str(slice_v1.load_errors[0]),
+            ),
+            None,
         )
     if not slice_v1.loaded:
-        return unavailable_universe_ranking(
-            availability=Availability.MISSING_SOURCE,
-            generated_at=generated_at,
-            reason=REASON_UNIVERSE_ABSENT,
+        return (
+            unavailable_universe_ranking(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_UNIVERSE_ABSENT,
+            ),
+            None,
+        )
+
+    try:
+        producer_at = parse_producer_utc_timestamp(slice_v1.generated_at)
+    except ValueError:
+        return (
+            unavailable_universe_ranking(
+                availability=Availability.INVALID,
+                generated_at=as_of,
+                reason=REASON_PRODUCER_TIMESTAMP_INVALID,
+            ),
+            slice_v1,
+        )
+    if producer_at is None:
+        return (
+            unavailable_universe_ranking(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_PRODUCER_TIMESTAMP_MISSING,
+            ),
+            slice_v1,
         )
 
     ranking_rows = [_row_dict(row) for row in slice_v1.ranking]
@@ -120,19 +201,25 @@ def _bind_universe_ranking(
         selected_id = slice_v1.selected_future.symbol
 
     if selected_id is not None and selected_id in FORBIDDEN_SELECTED_SYMBOLS:
-        return unavailable_universe_ranking(
-            availability=Availability.INVALID,
-            generated_at=generated_at,
-            reason=REASON_SELECTED_FORBIDDEN_SYMBOL,
+        return (
+            unavailable_universe_ranking(
+                availability=Availability.INVALID,
+                generated_at=as_of,
+                reason=REASON_SELECTED_FORBIDDEN_SYMBOL,
+            ),
+            slice_v1,
         )
 
     if selected_id is not None and universe_rows:
         membership = {str(row["symbol"]) for row in universe_rows}
         if selected_id not in membership:
-            return unavailable_universe_ranking(
-                availability=Availability.INVALID,
-                generated_at=generated_at,
-                reason=REASON_SELECTED_NOT_IN_UNIVERSE,
+            return (
+                unavailable_universe_ranking(
+                    availability=Availability.INVALID,
+                    generated_at=as_of,
+                    reason=REASON_SELECTED_NOT_IN_UNIVERSE,
+                ),
+                slice_v1,
             )
 
     reason_codes = ["UNIVERSE_SELECTION_READMODEL_PROJECTED"]
@@ -144,65 +231,139 @@ def _bind_universe_ranking(
         reason_codes.append("SELECTED_FUTURE_NOT_PRESENT_IN_READMODEL")
 
     if not ranking_rows and not universe_rows and selected_id is None:
-        return unavailable_universe_ranking(
-            availability=Availability.MISSING_SOURCE,
-            generated_at=generated_at,
-            reason=REASON_UNIVERSE_ABSENT,
+        return (
+            unavailable_universe_ranking(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_UNIVERSE_ABSENT,
+            ),
+            slice_v1,
         )
 
-    return project_universe_ranking_snapshot_v1(
-        ranking=ranking_rows,
-        universe=universe_rows,
-        selected_instrument_id=selected_id,
-        reason_codes=tuple(reason_codes),
-        generated_at=generated_at,
-        effective_at=generated_at,
-        source_reference=str(archive_root / "readmodels" / "universe_selection_readmodel.v1.json"),
-        git_sha=git_sha,
+    try:
+        availability, is_stale, stale_reason = classify_producer_freshness(
+            producer_at=producer_at,
+            as_of=as_of,
+        )
+    except ValueError:
+        return (
+            unavailable_universe_ranking(
+                availability=Availability.INVALID,
+                generated_at=as_of,
+                reason=REASON_PRODUCER_TIMESTAMP_INVALID,
+            ),
+            slice_v1,
+        )
+    if is_stale and stale_reason:
+        reason_codes.append(stale_reason)
+
+    return (
+        project_universe_ranking_snapshot_v1(
+            ranking=ranking_rows,
+            universe=universe_rows,
+            selected_instrument_id=selected_id,
+            reason_codes=tuple(reason_codes),
+            generated_at=producer_at,
+            effective_at=producer_at,
+            source_reference=str(
+                archive_root / "readmodels" / "universe_selection_readmodel.v1.json"
+            ),
+            git_sha=git_sha,
+            availability=availability,
+            max_age_seconds=LANDSCAPE_PHASE41_MAX_AGE_SECONDS,
+            is_stale=is_stale,
+            stale_reason=stale_reason,
+        ),
+        slice_v1,
     )
 
 
 def _market_from_universe_selected(
     *,
-    generated_at: datetime,
+    as_of: datetime,
     archive_root: Path,
     git_sha: str | None,
     universe_snap: Any,
+    slice_v1: Any | None,
 ) -> Any:
     """Project selected-instrument identity from universe selection only.
 
+    Uses market_snapshot.captured_at as the market producer timestamp.
     Does not invent market_type or mark_price. OHLCV remains unbound.
     """
-    if universe_snap.availability is not Availability.AVAILABLE:
+    if universe_snap.availability not in (Availability.AVAILABLE, Availability.STALE):
         return unavailable_market_instrument(
             availability=Availability.MISSING_SOURCE,
-            generated_at=generated_at,
+            generated_at=as_of,
             reason=REASON_MARKET_CONTEXT_NOT_PERSISTED,
         )
     selected = universe_snap.selected_instrument_id
     if not selected:
         return unavailable_market_instrument(
             availability=Availability.MISSING_SOURCE,
-            generated_at=generated_at,
+            generated_at=as_of,
             reason=REASON_MARKET_CONTEXT_NOT_PERSISTED,
         )
+    if slice_v1 is None or slice_v1.market_snapshot is None:
+        return unavailable_market_instrument(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=as_of,
+            reason=REASON_PRODUCER_TIMESTAMP_MISSING,
+        )
+    try:
+        producer_at = parse_producer_utc_timestamp(slice_v1.market_snapshot.captured_at)
+    except ValueError:
+        return unavailable_market_instrument(
+            availability=Availability.INVALID,
+            generated_at=as_of,
+            reason=REASON_PRODUCER_TIMESTAMP_INVALID,
+        )
+    if producer_at is None:
+        return unavailable_market_instrument(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=as_of,
+            reason=REASON_PRODUCER_TIMESTAMP_MISSING,
+        )
+
     venue = None
     for row in (*universe_snap.universe, *universe_snap.ranking):
         if row.get("symbol") == selected and row.get("exchange"):
             venue = str(row["exchange"])
             break
+    if venue is None and slice_v1.market_snapshot.exchange:
+        venue = str(slice_v1.market_snapshot.exchange)
+
+    try:
+        availability, is_stale, stale_reason = classify_producer_freshness(
+            producer_at=producer_at,
+            as_of=as_of,
+        )
+    except ValueError:
+        return unavailable_market_instrument(
+            availability=Availability.INVALID,
+            generated_at=as_of,
+            reason=REASON_PRODUCER_TIMESTAMP_INVALID,
+        )
+    reason_codes = [REASON_SELECTED_IDENTITY_PROJECTED]
+    if stale_reason:
+        reason_codes.append(stale_reason)
+
     return project_market_instrument_snapshot_v1(
         instrument_id=str(selected),
         venue=venue,
         market_type=None,
         mark_price=None,
-        reason_codes=(REASON_SELECTED_IDENTITY_PROJECTED,),
-        generated_at=generated_at,
-        effective_at=generated_at,
+        reason_codes=tuple(reason_codes),
+        generated_at=producer_at,
+        effective_at=producer_at,
         source_reference=str(archive_root / "readmodels" / "universe_selection_readmodel.v1.json"),
         git_sha=git_sha,
         producer_module=("webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1"),
         source_kind="universe_selection_selected_instrument",
+        availability=availability,
+        max_age_seconds=LANDSCAPE_PHASE41_MAX_AGE_SECONDS,
+        is_stale=is_stale,
+        stale_reason=stale_reason,
     )
 
 
@@ -215,17 +376,20 @@ def bind_market_universe_slots(
 ) -> dict[str, Any]:
     """Return Phase 4.1 slot overrides (market_instrument + universe_ranking).
 
+    ``generated_at`` is the dashboard observation/as-of clock only. It must never
+    overwrite producer provenance timestamps or fabricate freshness.
+
     market_instrument_fields accepts already-computed CanonicalMarketContext
-    field dicts for tests and future durable loaders. Absent producer fields
-    may still bind identity from universe selected_future when present.
-    Never invent mark price, OHLCV, ranking, or eligibility.
+    field dicts for tests and future durable loaders. Those fields must carry
+    producer ``generated_at`` and/or ``effective_at``.
     """
     if generated_at.tzinfo is None:
         raise ValueError("generated_at must be timezone-aware")
+    as_of = generated_at.astimezone(timezone.utc)
     root = resolve_landscape_archive_root(archive_root)
 
-    universe = _bind_universe_ranking(
-        generated_at=generated_at,
+    universe, slice_v1 = _bind_universe_ranking(
+        as_of=as_of,
         archive_root=root,
         git_sha=git_sha,
     )
@@ -235,65 +399,126 @@ def bind_market_universe_slots(
         missing = [key for key in required if key not in market_instrument_fields]
         if missing:
             raise KeyError(f"market_instrument_fields missing required keys: {missing}")
-        market = project_market_instrument_snapshot_v1(
-            instrument_id=str(market_instrument_fields["instrument_id"]),
-            venue=(
-                None
-                if market_instrument_fields.get("venue") is None
-                else str(market_instrument_fields["venue"])
-            ),
-            market_type=(
-                None
-                if market_instrument_fields.get("market_type") is None
-                else str(market_instrument_fields["market_type"])
-            ),
-            mark_price=(
-                None
-                if market_instrument_fields.get("mark_price") is None
-                else float(market_instrument_fields["mark_price"])
-            ),
-            reason_codes=tuple(
-                str(code) for code in market_instrument_fields.get("reason_codes", ())
-            ),
-            generated_at=generated_at,
-            effective_at=market_instrument_fields.get("effective_at", generated_at),
-            source_reference=market_instrument_fields.get("source_reference"),
-            evidence_digest=market_instrument_fields.get("evidence_digest"),
-            git_sha=git_sha,
-            producer_module=str(
-                market_instrument_fields.get(
-                    "producer_module",
-                    "trading.master_v2.canonical_market_context_v1",
+
+        raw_producer = market_instrument_fields.get("effective_at")
+        if raw_producer is None:
+            raw_producer = market_instrument_fields.get("generated_at")
+
+        producer_at: datetime | None
+        parse_error: str | None = None
+        if isinstance(raw_producer, datetime):
+            if raw_producer.tzinfo is None:
+                producer_at = None
+                parse_error = REASON_PRODUCER_TIMESTAMP_INVALID
+            else:
+                producer_at = raw_producer.astimezone(timezone.utc)
+        elif isinstance(raw_producer, str) or raw_producer is None:
+            try:
+                producer_at = parse_producer_utc_timestamp(
+                    None if raw_producer is None else str(raw_producer)
                 )
-            ),
-        )
+            except ValueError:
+                producer_at = None
+                parse_error = REASON_PRODUCER_TIMESTAMP_INVALID
+        else:
+            producer_at = None
+            parse_error = REASON_PRODUCER_TIMESTAMP_INVALID
+
+        if parse_error is not None:
+            market = unavailable_market_instrument(
+                availability=Availability.INVALID,
+                generated_at=as_of,
+                reason=parse_error,
+            )
+        elif producer_at is None:
+            market = unavailable_market_instrument(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_PRODUCER_TIMESTAMP_MISSING,
+            )
+        else:
+            try:
+                availability, is_stale, stale_reason = classify_producer_freshness(
+                    producer_at=producer_at,
+                    as_of=as_of,
+                )
+            except ValueError:
+                market = unavailable_market_instrument(
+                    availability=Availability.INVALID,
+                    generated_at=as_of,
+                    reason=REASON_PRODUCER_TIMESTAMP_INVALID,
+                )
+            else:
+                reason_codes = [
+                    str(code) for code in market_instrument_fields.get("reason_codes", ())
+                ]
+                if stale_reason:
+                    reason_codes.append(stale_reason)
+                market = project_market_instrument_snapshot_v1(
+                    instrument_id=str(market_instrument_fields["instrument_id"]),
+                    venue=(
+                        None
+                        if market_instrument_fields.get("venue") is None
+                        else str(market_instrument_fields["venue"])
+                    ),
+                    market_type=(
+                        None
+                        if market_instrument_fields.get("market_type") is None
+                        else str(market_instrument_fields["market_type"])
+                    ),
+                    mark_price=(
+                        None
+                        if market_instrument_fields.get("mark_price") is None
+                        else float(market_instrument_fields["mark_price"])
+                    ),
+                    reason_codes=tuple(reason_codes),
+                    generated_at=producer_at,
+                    effective_at=producer_at,
+                    source_reference=market_instrument_fields.get("source_reference"),
+                    evidence_digest=market_instrument_fields.get("evidence_digest"),
+                    git_sha=git_sha,
+                    producer_module=str(
+                        market_instrument_fields.get(
+                            "producer_module",
+                            "trading.master_v2.canonical_market_context_v1",
+                        )
+                    ),
+                    availability=availability,
+                    max_age_seconds=LANDSCAPE_PHASE41_MAX_AGE_SECONDS,
+                    is_stale=is_stale,
+                    stale_reason=stale_reason,
+                )
+
         selected = getattr(universe, "selected_instrument_id", None)
         if (
-            universe.availability is Availability.AVAILABLE
+            universe.availability in (Availability.AVAILABLE, Availability.STALE)
             and selected
+            and getattr(market, "instrument_id", None) is not None
             and market.instrument_id != selected
+            and market.availability in (Availability.AVAILABLE, Availability.STALE)
         ):
             market = unavailable_market_instrument(
                 availability=Availability.INVALID,
-                generated_at=generated_at,
+                generated_at=as_of,
                 reason=REASON_SOURCE_CONTRADICTION,
             )
             universe = unavailable_universe_ranking(
                 availability=Availability.INVALID,
-                generated_at=generated_at,
+                generated_at=as_of,
                 reason=REASON_SOURCE_CONTRADICTION,
             )
     elif root is not None:
         market = _market_from_universe_selected(
-            generated_at=generated_at,
+            as_of=as_of,
             archive_root=root,
             git_sha=git_sha,
             universe_snap=universe,
+            slice_v1=slice_v1,
         )
     else:
         market = unavailable_market_instrument(
             availability=Availability.MISSING_SOURCE,
-            generated_at=generated_at,
+            generated_at=as_of,
             reason=REASON_MARKET_CONTEXT_NOT_PERSISTED,
         )
 

--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -1,0 +1,303 @@
+"""Phase 4.1 read-only producer binding for Market Landscape V2.
+
+Binds market_instrument and universe_ranking only.
+Dynamic scope / regime / switch remain unbound (Phase 4.2).
+Lives outside market_dashboard_landscape_v2 so that package stays free of
+trading/webui producer imports (architecture guard).
+
+Fail-closed:
+- Wired slots without durable producer output → MISSING_SOURCE / INVALID
+- Never fabricate OHLCV, ranking, eligibility, or selected instrument
+- No decision / Double Play / risk / safety / execution / scope binding
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+from .market_dashboard_landscape_v2.availability import Availability
+from .market_dashboard_landscape_v2.projections import (
+    project_market_instrument_snapshot_v1,
+    project_universe_ranking_snapshot_v1,
+)
+from .market_dashboard_landscape_v2.unavailable import (
+    unavailable_market_instrument,
+    unavailable_universe_ranking,
+)
+from .workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
+    FORBIDDEN_SELECTED_SYMBOLS,
+)
+from .workflow_dashboard_readmodel_v1.universe_selection_reader_v1 import (
+    try_load_universe_selection_for_dashboard,
+)
+
+# Reuse the existing workflow-dashboard archive env — no second archive owner.
+ENV_ARCHIVE_ROOT = "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT"
+
+REASON_MARKET_CONTEXT_NOT_PERSISTED = "CANONICAL_MARKET_CONTEXT_NOT_PERSISTED_FOR_DASHBOARD"
+REASON_UNIVERSE_ABSENT = "UNIVERSE_SELECTION_READMODEL_ABSENT"
+REASON_ARCHIVE_ROOT_UNSET = "UNIVERSE_ARCHIVE_ROOT_UNSET"
+REASON_SELECTED_FORBIDDEN_SYMBOL = "SELECTED_INSTRUMENT_FORBIDDEN_BTC_USD_OR_SPOT_DUMMY"
+REASON_SELECTED_NOT_IN_UNIVERSE = "SELECTED_INSTRUMENT_NOT_IN_CANONICAL_UNIVERSE"
+REASON_SOURCE_CONTRADICTION = "MARKET_AND_UNIVERSE_SELECTED_INSTRUMENT_CONTRADICTION"
+REASON_SELECTED_IDENTITY_PROJECTED = "SELECTED_INSTRUMENT_IDENTITY_FROM_UNIVERSE_SELECTION"
+
+PHASE_4_1_BOUND_SLOTS: tuple[str, ...] = (
+    "market_instrument",
+    "universe_ranking",
+)
+
+
+def resolve_landscape_archive_root(
+    archive_root: str | Path | None = None,
+) -> Path | None:
+    """Resolve durable archive root for universe_selection readmodel load."""
+    if archive_root is not None:
+        raw = str(archive_root).strip()
+        if not raw:
+            return None
+        path = Path(raw).expanduser()
+        try:
+            path = path.resolve(strict=True)
+        except OSError:
+            return None
+        return path if path.is_dir() else None
+    env_raw = (os.getenv(ENV_ARCHIVE_ROOT) or "").strip()
+    if not env_raw:
+        return None
+    path = Path(env_raw).expanduser()
+    try:
+        path = path.resolve(strict=True)
+    except OSError:
+        return None
+    return path if path.is_dir() else None
+
+
+def _row_dict(row: Any) -> dict[str, Any]:
+    return {
+        "row_id": row.row_id,
+        "symbol": row.symbol,
+        "rank": row.rank,
+        "exchange": row.exchange,
+        "display_score": row.display_score,
+        "notes": row.notes,
+    }
+
+
+def _bind_universe_ranking(
+    *,
+    generated_at: datetime,
+    archive_root: Path | None,
+    git_sha: str | None,
+) -> Any:
+    if archive_root is None:
+        return unavailable_universe_ranking(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=generated_at,
+            reason=REASON_ARCHIVE_ROOT_UNSET,
+        )
+    slice_v1 = try_load_universe_selection_for_dashboard(archive_root)
+    if slice_v1.load_errors:
+        return unavailable_universe_ranking(
+            availability=Availability.INVALID,
+            generated_at=generated_at,
+            reason=str(slice_v1.load_errors[0]),
+        )
+    if not slice_v1.loaded:
+        return unavailable_universe_ranking(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=generated_at,
+            reason=REASON_UNIVERSE_ABSENT,
+        )
+
+    ranking_rows = [_row_dict(row) for row in slice_v1.ranking]
+    universe_rows = [_row_dict(row) for row in slice_v1.universe]
+    selected_id = None
+    if slice_v1.selected_future is not None:
+        selected_id = slice_v1.selected_future.symbol
+
+    if selected_id is not None and selected_id in FORBIDDEN_SELECTED_SYMBOLS:
+        return unavailable_universe_ranking(
+            availability=Availability.INVALID,
+            generated_at=generated_at,
+            reason=REASON_SELECTED_FORBIDDEN_SYMBOL,
+        )
+
+    if selected_id is not None and universe_rows:
+        membership = {str(row["symbol"]) for row in universe_rows}
+        if selected_id not in membership:
+            return unavailable_universe_ranking(
+                availability=Availability.INVALID,
+                generated_at=generated_at,
+                reason=REASON_SELECTED_NOT_IN_UNIVERSE,
+            )
+
+    reason_codes = ["UNIVERSE_SELECTION_READMODEL_PROJECTED"]
+    if not ranking_rows:
+        reason_codes.append("TOP20_RANKING_NOT_PRESENT_IN_READMODEL")
+    if not universe_rows:
+        reason_codes.append("UNIVERSE_MEMBERSHIP_NOT_PRESENT_IN_READMODEL")
+    if selected_id is None:
+        reason_codes.append("SELECTED_FUTURE_NOT_PRESENT_IN_READMODEL")
+
+    if not ranking_rows and not universe_rows and selected_id is None:
+        return unavailable_universe_ranking(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=generated_at,
+            reason=REASON_UNIVERSE_ABSENT,
+        )
+
+    return project_universe_ranking_snapshot_v1(
+        ranking=ranking_rows,
+        universe=universe_rows,
+        selected_instrument_id=selected_id,
+        reason_codes=tuple(reason_codes),
+        generated_at=generated_at,
+        effective_at=generated_at,
+        source_reference=str(archive_root / "readmodels" / "universe_selection_readmodel.v1.json"),
+        git_sha=git_sha,
+    )
+
+
+def _market_from_universe_selected(
+    *,
+    generated_at: datetime,
+    archive_root: Path,
+    git_sha: str | None,
+    universe_snap: Any,
+) -> Any:
+    """Project selected-instrument identity from universe selection only.
+
+    Does not invent market_type or mark_price. OHLCV remains unbound.
+    """
+    if universe_snap.availability is not Availability.AVAILABLE:
+        return unavailable_market_instrument(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=generated_at,
+            reason=REASON_MARKET_CONTEXT_NOT_PERSISTED,
+        )
+    selected = universe_snap.selected_instrument_id
+    if not selected:
+        return unavailable_market_instrument(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=generated_at,
+            reason=REASON_MARKET_CONTEXT_NOT_PERSISTED,
+        )
+    venue = None
+    for row in (*universe_snap.universe, *universe_snap.ranking):
+        if row.get("symbol") == selected and row.get("exchange"):
+            venue = str(row["exchange"])
+            break
+    return project_market_instrument_snapshot_v1(
+        instrument_id=str(selected),
+        venue=venue,
+        market_type=None,
+        mark_price=None,
+        reason_codes=(REASON_SELECTED_IDENTITY_PROJECTED,),
+        generated_at=generated_at,
+        effective_at=generated_at,
+        source_reference=str(archive_root / "readmodels" / "universe_selection_readmodel.v1.json"),
+        git_sha=git_sha,
+        producer_module=("webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1"),
+        source_kind="universe_selection_selected_instrument",
+    )
+
+
+def bind_market_universe_slots(
+    *,
+    generated_at: datetime,
+    archive_root: str | Path | None = None,
+    git_sha: str | None = None,
+    market_instrument_fields: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return Phase 4.1 slot overrides (market_instrument + universe_ranking).
+
+    market_instrument_fields accepts already-computed CanonicalMarketContext
+    field dicts for tests and future durable loaders. Absent producer fields
+    may still bind identity from universe selected_future when present.
+    Never invent mark price, OHLCV, ranking, or eligibility.
+    """
+    if generated_at.tzinfo is None:
+        raise ValueError("generated_at must be timezone-aware")
+    root = resolve_landscape_archive_root(archive_root)
+
+    universe = _bind_universe_ranking(
+        generated_at=generated_at,
+        archive_root=root,
+        git_sha=git_sha,
+    )
+
+    if market_instrument_fields is not None:
+        required = ("instrument_id",)
+        missing = [key for key in required if key not in market_instrument_fields]
+        if missing:
+            raise KeyError(f"market_instrument_fields missing required keys: {missing}")
+        market = project_market_instrument_snapshot_v1(
+            instrument_id=str(market_instrument_fields["instrument_id"]),
+            venue=(
+                None
+                if market_instrument_fields.get("venue") is None
+                else str(market_instrument_fields["venue"])
+            ),
+            market_type=(
+                None
+                if market_instrument_fields.get("market_type") is None
+                else str(market_instrument_fields["market_type"])
+            ),
+            mark_price=(
+                None
+                if market_instrument_fields.get("mark_price") is None
+                else float(market_instrument_fields["mark_price"])
+            ),
+            reason_codes=tuple(
+                str(code) for code in market_instrument_fields.get("reason_codes", ())
+            ),
+            generated_at=generated_at,
+            effective_at=market_instrument_fields.get("effective_at", generated_at),
+            source_reference=market_instrument_fields.get("source_reference"),
+            evidence_digest=market_instrument_fields.get("evidence_digest"),
+            git_sha=git_sha,
+            producer_module=str(
+                market_instrument_fields.get(
+                    "producer_module",
+                    "trading.master_v2.canonical_market_context_v1",
+                )
+            ),
+        )
+        selected = getattr(universe, "selected_instrument_id", None)
+        if (
+            universe.availability is Availability.AVAILABLE
+            and selected
+            and market.instrument_id != selected
+        ):
+            market = unavailable_market_instrument(
+                availability=Availability.INVALID,
+                generated_at=generated_at,
+                reason=REASON_SOURCE_CONTRADICTION,
+            )
+            universe = unavailable_universe_ranking(
+                availability=Availability.INVALID,
+                generated_at=generated_at,
+                reason=REASON_SOURCE_CONTRADICTION,
+            )
+    elif root is not None:
+        market = _market_from_universe_selected(
+            generated_at=generated_at,
+            archive_root=root,
+            git_sha=git_sha,
+            universe_snap=universe,
+        )
+    else:
+        market = unavailable_market_instrument(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=generated_at,
+            reason=REASON_MARKET_CONTEXT_NOT_PERSISTED,
+        )
+
+    return {
+        "market_instrument": market,
+        "universe_ranking": universe,
+    }

--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -1,7 +1,9 @@
-"""GET /market Landscape Shell router (Phase 3 / PR 2).
+"""GET /market Landscape Shell router (Phase 4.1 market/universe binding).
 
 Read-only SSR surface. No POST/PUT/PATCH/DELETE. No command endpoints.
 No execution / order / runtime-activation imports.
+Phase 4.1 binds market_instrument / universe_ranking fail-closed.
+Dynamic scope and later Phase 4 slots remain unbound.
 """
 
 from __future__ import annotations
@@ -13,6 +15,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from .market_dashboard_landscape_producer_binding_v2 import bind_market_universe_slots
 from .market_dashboard_landscape_v2.page_aggregate import MarketDashboardReadServiceV1
 from .market_dashboard_landscape_v2.presenter import present_market_landscape_v2
 
@@ -37,13 +40,16 @@ def get_templates() -> Jinja2Templates:
 
 @router.get("/market", response_class=HTMLResponse, name="market_landscape_v2")
 async def market_landscape_dashboard(request: Request) -> Any:
-    """Read-only Landscape product skeleton. Formatting only via presenter."""
+    """Read-only Landscape surface with Phase 4.1 market/universe binding."""
     # Lazy import avoids circular import during create_app().
     from .app import get_project_status
 
+    generated_at = datetime.now(timezone.utc)
+    phase41_slots = bind_market_universe_slots(generated_at=generated_at, git_sha=None)
     page = _READ_SERVICE.load_page_snapshot(
-        generated_at=datetime.now(timezone.utc),
+        generated_at=generated_at,
         git_sha=None,
+        slot_overrides=phase41_slots,
     )
     context = present_market_landscape_v2(page)
     return get_templates().TemplateResponse(

--- a/src/webui/market_dashboard_landscape_v2/__init__.py
+++ b/src/webui/market_dashboard_landscape_v2/__init__.py
@@ -1,8 +1,8 @@
 """Market Dashboard Landscape V2 — read-only projection contracts + page shell.
 
-Consumer foundation and Phase 3 page aggregate/presenter. Route lives in
-market_dashboard_landscape_shell_router_v2. No runtime activation, orders,
-or domain recomputation.
+Consumer foundation, page aggregate/presenter, and Phase 4.1 binding via
+market_dashboard_landscape_producer_binding_v2 (outside this package).
+No runtime activation, orders, or domain recomputation.
 """
 
 from __future__ import annotations
@@ -37,6 +37,8 @@ from .presenter import present_market_landscape_v2
 from .projections import (
     project_canonical_decision_snapshot_v1,
     project_double_play_snapshot_v1,
+    project_market_instrument_snapshot_v1,
+    project_universe_ranking_snapshot_v1,
 )
 from .provenance import FreshnessV1, SnapshotProvenanceV1
 from .serialization import dumps_projection_canonical, serialize_projection
@@ -85,5 +87,7 @@ __all__ = [
     "present_market_landscape_v2",
     "project_canonical_decision_snapshot_v1",
     "project_double_play_snapshot_v1",
+    "project_market_instrument_snapshot_v1",
+    "project_universe_ranking_snapshot_v1",
     "serialize_projection",
 ]

--- a/src/webui/market_dashboard_landscape_v2/contracts.py
+++ b/src/webui/market_dashboard_landscape_v2/contracts.py
@@ -8,7 +8,7 @@ Availability states — never silent defaults.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Sequence, Union
 
 from .availability import Availability
 from .provenance import FreshnessV1, SnapshotProvenanceV1
@@ -77,10 +77,12 @@ class UniverseRankingSnapshotV1(_ProjectionBase):
     ranking: tuple[Mapping[str, Any], ...]
     selected_instrument_id: str | None
     reason_codes: tuple[str, ...]
+    universe: tuple[Mapping[str, Any], ...] = ()
 
     def __post_init__(self) -> None:
         super().__post_init__()
         object.__setattr__(self, "ranking", tuple(dict(row) for row in self.ranking))
+        object.__setattr__(self, "universe", tuple(dict(row) for row in self.universe))
         object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
 
 
@@ -208,19 +210,19 @@ class DiagnosticsSummarySnapshotV1(_ProjectionBase):
         object.__setattr__(self, "reason_codes", tuple(self.reason_codes))
 
 
-ProjectionSnapshot = (
-    MarketInstrumentSnapshotV1
-    | UniverseRankingSnapshotV1
-    | DynamicScopeSnapshotV1
-    | CanonicalDecisionSnapshotV1
-    | DoublePlaySnapshotV1
-    | RiskSizingCapitalSnapshotV1
-    | SafetyAuthoritySnapshotV1
-    | ExecutionReconciliationSnapshotV1
-    | EconomicSummarySnapshotV1
-    | AutonomyStageSnapshotV1
-    | DiagnosticsSummarySnapshotV1
-)
+ProjectionSnapshot = Union[
+    MarketInstrumentSnapshotV1,
+    UniverseRankingSnapshotV1,
+    DynamicScopeSnapshotV1,
+    CanonicalDecisionSnapshotV1,
+    DoublePlaySnapshotV1,
+    RiskSizingCapitalSnapshotV1,
+    SafetyAuthoritySnapshotV1,
+    ExecutionReconciliationSnapshotV1,
+    EconomicSummarySnapshotV1,
+    AutonomyStageSnapshotV1,
+    DiagnosticsSummarySnapshotV1,
+]
 
 
 def projection_envelope_dict(snapshot: _ProjectionBase) -> dict[str, Any]:

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -29,16 +29,20 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
         owner_module="trading.master_v2.canonical_market_context_v1",
         owner_symbol="CanonicalMarketContextV1",
         authority_class="market_context",
-        reuse_status="PROJECTION_ONLY",
-        notes="Producer exists; Landscape projection unbound until PR3.",
+        reuse_status="REUSED",
+        notes=(
+            "Phase 4.1: identity may also project from universe_selection "
+            "selected_future when CanonicalMarketContext is not persisted for dashboard; "
+            "OHLCV remains unbound."
+        ),
     ),
     CanonicalOwnerRefV1(
         slot="universe_ranking",
         owner_module="webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1",
         owner_symbol="universe_selection_readmodel.v1",
         authority_class="universe_projection",
-        reuse_status="PROJECTION_ONLY",
-        notes="Observability universe contract reused as source shape; not Market UI.",
+        reuse_status="REUSED",
+        notes="Phase 4.1: Landscape binds verify-before-trust universe_selection_readmodel.v1.",
     ),
     CanonicalOwnerRefV1(
         slot="dynamic_scope",

--- a/src/webui/market_dashboard_landscape_v2/page_aggregate.py
+++ b/src/webui/market_dashboard_landscape_v2/page_aggregate.py
@@ -1,8 +1,9 @@
-"""Page aggregate for Market Dashboard Landscape V2 (Phase 3 shell).
+"""Page aggregate for Market Dashboard Landscape V2.
 
 Read-only composition of Phase 2 projection slots. Does not recompute
-decision, direction, risk, sizing, scope, or Double Play. Phase 3 shell
-loads explicit NOT_BOUND slots until Phase 4 producer binding.
+decision, direction, risk, sizing, scope, or Double Play. Phase 4.1 route
+supplies market_instrument / universe_ranking overrides; other slots stay
+explicit NOT_BOUND until later Phase 4 bindings.
 """
 
 from __future__ import annotations
@@ -88,8 +89,8 @@ def _slot_map_from_bundle(bundle: Mapping[str, Any]) -> dict[str, Any]:
 class MarketDashboardReadServiceV1:
     """Sole page-aggregate owner for Landscape V2 shell.
 
-    Consumes Phase 2 unavailable/NOT_BOUND factories only in this PR.
-    No producer imports; no domain recomputation.
+    Accepts optional slot_overrides from the read-only producer-binding layer.
+    No producer imports inside this package; no domain recomputation.
     """
 
     def load_page_snapshot(

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -78,6 +78,52 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
     health = page.source_health
 
     chart_availability = page.market_instrument.availability
+    if chart_availability is Availability.AVAILABLE:
+        chart_message = (
+            "Primary chart market instrument bound; OHLCV producer still unbound "
+            "(no fabricated candles)."
+        )
+    elif chart_availability is Availability.MISSING_SOURCE:
+        chart_message = (
+            "Primary chart MISSING_SOURCE — market identity / OHLCV not persisted "
+            "for dashboard; no OHLCV fabricated."
+        )
+    elif chart_availability is Availability.INVALID:
+        chart_message = (
+            "Primary chart INVALID — market producer output rejected; no OHLCV fabricated."
+        )
+    else:
+        chart_message = "Primary chart NOT_BOUND — no OHLCV fabricated for Landscape shell."
+
+    ranking_rows: list[dict[str, Any]] = []
+    universe_rows: list[dict[str, Any]] = []
+    selected_instrument_id = None
+    membership_label = AVAILABILITY_LABELS[page.universe_ranking.availability]
+    ranking_label = AVAILABILITY_LABELS[page.universe_ranking.availability]
+    if page.universe_ranking.availability is Availability.AVAILABLE:
+        ranking_rows = [dict(row) for row in page.universe_ranking.ranking]
+        universe_rows = [dict(row) for row in page.universe_ranking.universe]
+        selected_instrument_id = page.universe_ranking.selected_instrument_id
+        if not ranking_rows:
+            ranking_label = "NOT_AVAILABLE"
+        if selected_instrument_id and universe_rows:
+            membership = {str(row.get("symbol")) for row in universe_rows}
+            membership_label = (
+                "IN_UNIVERSE" if selected_instrument_id in membership else "NOT_IN_UNIVERSE"
+            )
+        elif selected_instrument_id is None:
+            membership_label = "NOT_AVAILABLE"
+        elif not universe_rows:
+            membership_label = "NOT_AVAILABLE"
+
+    instrument_display = (
+        selected_instrument_id
+        if selected_instrument_id
+        else _display_value(
+            page.market_instrument.instrument_id, page.market_instrument.availability
+        )
+    )
+
     return {
         "page_schema_id": page.schema_id,
         "generated_at": page.generated_at.isoformat().replace("+00:00", "Z"),
@@ -85,11 +131,9 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
         "runtime_bridge_display": page.runtime_bridge_display,
         "shell_authority_class": page.shell_authority_class,
         "consumer_role": "read_only_consumer",
-        "phase": "PHASE_3_LANDSCAPE_SHELL",
+        "phase": "PHASE_4_1_MARKET_UNIVERSE_BINDING",
         "global_strip": {
-            "instrument": _display_value(
-                page.market_instrument.instrument_id, page.market_instrument.availability
-            ),
+            "instrument": instrument_display,
             "venue": _display_value(
                 page.market_instrument.venue, page.market_instrument.availability
             ),
@@ -107,6 +151,16 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
         },
         "market": market,
         "universe": universe,
+        "universe_ranking_rows": ranking_rows,
+        "universe_membership_rows": universe_rows,
+        "selected_instrument_id": selected_instrument_id,
+        "universe_rail": {
+            "watchlist_availability": page.universe_ranking.availability.value,
+            "watchlist_label": AVAILABILITY_LABELS[page.universe_ranking.availability],
+            "eligibility_label": membership_label,
+            "rank_label": ranking_label,
+            "selected_instrument_id": selected_instrument_id,
+        },
         "scope": scope,
         "decision": decision,
         "double_play": double_play,
@@ -129,11 +183,7 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
             "availability": chart_availability.value,
             "availability_label": AVAILABILITY_LABELS[chart_availability],
             "bound": chart_availability is Availability.AVAILABLE,
-            "message": (
-                "Primary chart bound to market read-model."
-                if chart_availability is Availability.AVAILABLE
-                else "Primary chart NOT_BOUND — no OHLCV fabricated for Landscape shell."
-            ),
+            "message": chart_message,
             "ohlcv": None,
         },
         "timeline": {
@@ -145,6 +195,10 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
         "engineering": {
             "label": "Engineering drawer — diagnostic / non-authoritative",
             "missing_state_hints": list(MISSING_STATE_REASON_HINTS),
+            "phase_4_1_bound_slots": [
+                "market_instrument",
+                "universe_ranking",
+            ],
             "slots": {
                 "market_instrument": market,
                 "universe_ranking": universe,
@@ -168,7 +222,9 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
             "scheduler": False,
             "write_endpoints": False,
             "dashboard_authority": False,
-            "phase_4_authorized": False,
+            "phase_4_1_binding_active": True,
+            "phase_4_full_pass": False,
+            "phase_4_authorized": True,
             "operator_skeleton_approval": "PENDING",
         },
     }

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -157,6 +157,9 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
         "universe_rail": {
             "watchlist_availability": page.universe_ranking.availability.value,
             "watchlist_label": AVAILABILITY_LABELS[page.universe_ranking.availability],
+            # Membership of selected in projected universe rows — not a separate
+            # eligibility producer / ranking recomputation.
+            "membership_label": membership_label,
             "eligibility_label": membership_label,
             "rank_label": ranking_label,
             "selected_instrument_id": selected_instrument_id,

--- a/src/webui/market_dashboard_landscape_v2/projections.py
+++ b/src/webui/market_dashboard_landscape_v2/projections.py
@@ -31,15 +31,26 @@ def project_market_instrument_snapshot_v1(
     git_sha: str | None = None,
     producer_module: str = "trading.master_v2.canonical_market_context_v1",
     source_kind: str = "canonical_market_context",
+    availability: Availability = Availability.AVAILABLE,
+    max_age_seconds: int | None = None,
+    is_stale: bool = False,
+    stale_reason: str | None = None,
 ) -> MarketInstrumentSnapshotV1:
     """Project already-computed market identity fields into a Landscape snapshot.
 
     Forbidden: inventing instrument/venue/mark_price, fabricating OHLCV, or
     deriving futures/spot eligibility from symbol heuristics.
     market_type and mark_price may remain None when the producer did not supply them.
+    generated_at/effective_at must be producer timestamps — never page-assembly time.
     """
     if not instrument_id:
-        raise ValueError("instrument_id required for AVAILABLE")
+        raise ValueError("instrument_id required for AVAILABLE/STALE projection")
+    if availability not in (Availability.AVAILABLE, Availability.STALE):
+        raise ValueError("project_market_instrument only emits AVAILABLE or STALE")
+    if availability is Availability.AVAILABLE and is_stale:
+        raise ValueError("AVAILABLE cannot be stale")
+    if availability is Availability.STALE and not is_stale:
+        raise ValueError("STALE requires is_stale=True")
     schema_id = f"{SCHEMA_FAMILY}.market_instrument.{SCHEMA_VERSION}"
     provenance = SnapshotProvenanceV1(
         schema_id=schema_id,
@@ -51,20 +62,20 @@ def project_market_instrument_snapshot_v1(
         source_reference=source_reference,
         evidence_digest=evidence_digest,
         git_sha=git_sha,
-        availability=Availability.AVAILABLE,
+        availability=availability,
     )
     freshness = FreshnessV1(
         observed_at=generated_at,
-        max_age_seconds=None,
-        is_stale=False,
-        stale_reason=None,
+        max_age_seconds=max_age_seconds,
+        is_stale=is_stale,
+        stale_reason=stale_reason,
     )
     return MarketInstrumentSnapshotV1(
         schema_id=schema_id,
         schema_version=SCHEMA_VERSION,
         provenance=provenance,
         freshness=freshness,
-        availability=Availability.AVAILABLE,
+        availability=availability,
         instrument_id=instrument_id,
         venue=venue,
         market_type=market_type,
@@ -85,16 +96,29 @@ def project_universe_ranking_snapshot_v1(
     evidence_digest: str | None = None,
     git_sha: str | None = None,
     producer_module: str = ("webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1"),
+    availability: Availability = Availability.AVAILABLE,
+    max_age_seconds: int | None = None,
+    is_stale: bool = False,
+    stale_reason: str | None = None,
 ) -> UniverseRankingSnapshotV1:
     """Project an existing universe_selection ranking into Landscape form.
 
     Forbidden: recomputing ranks, inventing selected instruments, or enriching
     rows with decision/risk/sizing semantics.
+    generated_at/effective_at must be producer timestamps — never page-assembly time.
     """
     ranking_rows = tuple(dict(row) for row in ranking)
     universe_rows = tuple(dict(row) for row in universe)
     if not ranking_rows and not universe_rows and not selected_instrument_id:
-        raise ValueError("ranking, universe, or selected_instrument_id required for AVAILABLE")
+        raise ValueError(
+            "ranking, universe, or selected_instrument_id required for AVAILABLE/STALE"
+        )
+    if availability not in (Availability.AVAILABLE, Availability.STALE):
+        raise ValueError("project_universe_ranking only emits AVAILABLE or STALE")
+    if availability is Availability.AVAILABLE and is_stale:
+        raise ValueError("AVAILABLE cannot be stale")
+    if availability is Availability.STALE and not is_stale:
+        raise ValueError("STALE requires is_stale=True")
     schema_id = f"{SCHEMA_FAMILY}.universe_ranking.{SCHEMA_VERSION}"
     provenance = SnapshotProvenanceV1(
         schema_id=schema_id,
@@ -106,20 +130,20 @@ def project_universe_ranking_snapshot_v1(
         source_reference=source_reference,
         evidence_digest=evidence_digest,
         git_sha=git_sha,
-        availability=Availability.AVAILABLE,
+        availability=availability,
     )
     freshness = FreshnessV1(
         observed_at=generated_at,
-        max_age_seconds=None,
-        is_stale=False,
-        stale_reason=None,
+        max_age_seconds=max_age_seconds,
+        is_stale=is_stale,
+        stale_reason=stale_reason,
     )
     return UniverseRankingSnapshotV1(
         schema_id=schema_id,
         schema_version=SCHEMA_VERSION,
         provenance=provenance,
         freshness=freshness,
-        availability=Availability.AVAILABLE,
+        availability=availability,
         ranking=ranking_rows,
         universe=universe_rows,
         selected_instrument_id=selected_instrument_id,

--- a/src/webui/market_dashboard_landscape_v2/projections.py
+++ b/src/webui/market_dashboard_landscape_v2/projections.py
@@ -11,8 +11,120 @@ from .contracts import (
     SCHEMA_VERSION,
     CanonicalDecisionSnapshotV1,
     DoublePlaySnapshotV1,
+    MarketInstrumentSnapshotV1,
+    UniverseRankingSnapshotV1,
 )
 from .provenance import FreshnessV1, SnapshotProvenanceV1
+
+
+def project_market_instrument_snapshot_v1(
+    *,
+    instrument_id: str,
+    venue: str | None,
+    market_type: str | None,
+    mark_price: float | None,
+    reason_codes: Sequence[str],
+    generated_at: datetime,
+    effective_at: datetime | None,
+    source_reference: str | None,
+    evidence_digest: str | None = None,
+    git_sha: str | None = None,
+    producer_module: str = "trading.master_v2.canonical_market_context_v1",
+    source_kind: str = "canonical_market_context",
+) -> MarketInstrumentSnapshotV1:
+    """Project already-computed market identity fields into a Landscape snapshot.
+
+    Forbidden: inventing instrument/venue/mark_price, fabricating OHLCV, or
+    deriving futures/spot eligibility from symbol heuristics.
+    market_type and mark_price may remain None when the producer did not supply them.
+    """
+    if not instrument_id:
+        raise ValueError("instrument_id required for AVAILABLE")
+    schema_id = f"{SCHEMA_FAMILY}.market_instrument.{SCHEMA_VERSION}"
+    provenance = SnapshotProvenanceV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        producer_module=producer_module,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_kind=source_kind,
+        source_reference=source_reference,
+        evidence_digest=evidence_digest,
+        git_sha=git_sha,
+        availability=Availability.AVAILABLE,
+    )
+    freshness = FreshnessV1(
+        observed_at=generated_at,
+        max_age_seconds=None,
+        is_stale=False,
+        stale_reason=None,
+    )
+    return MarketInstrumentSnapshotV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=freshness,
+        availability=Availability.AVAILABLE,
+        instrument_id=instrument_id,
+        venue=venue,
+        market_type=market_type,
+        mark_price=None if mark_price is None else float(mark_price),
+        reason_codes=tuple(str(code) for code in reason_codes),
+    )
+
+
+def project_universe_ranking_snapshot_v1(
+    *,
+    ranking: Sequence[Mapping[str, Any]],
+    selected_instrument_id: str | None,
+    reason_codes: Sequence[str],
+    generated_at: datetime,
+    effective_at: datetime | None,
+    source_reference: str | None,
+    universe: Sequence[Mapping[str, Any]] = (),
+    evidence_digest: str | None = None,
+    git_sha: str | None = None,
+    producer_module: str = ("webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1"),
+) -> UniverseRankingSnapshotV1:
+    """Project an existing universe_selection ranking into Landscape form.
+
+    Forbidden: recomputing ranks, inventing selected instruments, or enriching
+    rows with decision/risk/sizing semantics.
+    """
+    ranking_rows = tuple(dict(row) for row in ranking)
+    universe_rows = tuple(dict(row) for row in universe)
+    if not ranking_rows and not universe_rows and not selected_instrument_id:
+        raise ValueError("ranking, universe, or selected_instrument_id required for AVAILABLE")
+    schema_id = f"{SCHEMA_FAMILY}.universe_ranking.{SCHEMA_VERSION}"
+    provenance = SnapshotProvenanceV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        producer_module=producer_module,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_kind="universe_selection_readmodel",
+        source_reference=source_reference,
+        evidence_digest=evidence_digest,
+        git_sha=git_sha,
+        availability=Availability.AVAILABLE,
+    )
+    freshness = FreshnessV1(
+        observed_at=generated_at,
+        max_age_seconds=None,
+        is_stale=False,
+        stale_reason=None,
+    )
+    return UniverseRankingSnapshotV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=freshness,
+        availability=Availability.AVAILABLE,
+        ranking=ranking_rows,
+        universe=universe_rows,
+        selected_instrument_id=selected_instrument_id,
+        reason_codes=tuple(str(code) for code in reason_codes),
+    )
 
 
 def project_canonical_decision_snapshot_v1(

--- a/src/webui/market_dashboard_landscape_v2/serialization.py
+++ b/src/webui/market_dashboard_landscape_v2/serialization.py
@@ -44,6 +44,7 @@ def serialize_projection(snapshot: Any) -> dict[str, Any]:
         payload.update(
             {
                 "ranking": [dict(row) for row in snapshot.ranking],
+                "universe": [dict(row) for row in snapshot.universe],
                 "selected_instrument_id": snapshot.selected_instrument_id,
                 "reason_codes": list(snapshot.reason_codes),
             }

--- a/src/webui/market_dashboard_landscape_v2/unavailable.py
+++ b/src/webui/market_dashboard_landscape_v2/unavailable.py
@@ -150,6 +150,7 @@ def unavailable_universe_ranking(
         ),
         availability=availability,
         ranking=(),
+        universe=(),
         selected_instrument_id=None,
         reason_codes=(reason,),
     )

--- a/templates/peak_trade_dashboard/market_landscape_v2.html
+++ b/templates/peak_trade_dashboard/market_landscape_v2.html
@@ -62,8 +62,8 @@
             </span>
           </li>
           <li>
-            <span class="mdl-v2-rail-rows__label">Eligibility</span>
-            <span class="mdl-v2-state" data-mdl-field="eligibility">{{ universe_rail.eligibility_label }}</span>
+            <span class="mdl-v2-rail-rows__label">Membership</span>
+            <span class="mdl-v2-state" data-mdl-field="universe_membership">{{ universe_rail.membership_label }}</span>
           </li>
           <li>
             <span class="mdl-v2-rail-rows__label">Rank</span>

--- a/templates/peak_trade_dashboard/market_landscape_v2.html
+++ b/templates/peak_trade_dashboard/market_landscape_v2.html
@@ -4,7 +4,7 @@
 {% block main_class %}mdl-v2-main{% endblock %}
 {% block extra_head %}
 <link rel="stylesheet" href="/static/css/market_dashboard_landscape_v2.css" />
-<meta name="peak-trade-market-landscape-v2" content="phase3-shell" />
+<meta name="peak-trade-market-landscape-v2" content="phase4-1-market-universe-binding" />
 <meta name="peak-trade-dashboard-authority" content="false" />
 <meta name="peak-trade-live-authorized" content="false" />
 {% endblock %}
@@ -23,7 +23,7 @@
   data-market-dashboard-authority="false"
   data-live-authorized="false"
   data-orders="false"
-  data-phase="PHASE_3_LANDSCAPE_SHELL"
+  data-phase="PHASE_4_1_MARKET_UNIVERSE_BINDING"
   data-runtime-bridge="{{ runtime_bridge_display }}"
   aria-label="Market Dashboard Landscape V2 read-only workspace"
 >
@@ -50,20 +50,36 @@
     <div class="mdl-v2-workspace" data-mdl-workspace="true">
       <aside class="mdl-v2-rail mdl-v2-rail--left" data-mdl-region="UNIVERSE_RANK_RAIL" aria-label="Universe and rank">
         <h2>Universe</h2>
-        <ul class="mdl-v2-rail-rows" aria-label="Watchlist unavailable">
+        <ul class="mdl-v2-rail-rows" aria-label="Universe projection">
           <li>
             <span class="mdl-v2-rail-rows__label">Watchlist</span>
-            <span class="mdl-v2-state" data-availability="{{ universe.availability }}">{{ universe.availability_label }}</span>
+            <span class="mdl-v2-state" data-availability="{{ universe_rail.watchlist_availability }}" data-mdl-field="universe_watchlist">{{ universe_rail.watchlist_label }}</span>
+          </li>
+          <li>
+            <span class="mdl-v2-rail-rows__label">Selected</span>
+            <span class="mdl-v2-state" data-mdl-field="selected_instrument">
+              {% if universe_rail.selected_instrument_id %}{{ universe_rail.selected_instrument_id }}{% else %}{{ universe.availability_label }}{% endif %}
+            </span>
           </li>
           <li>
             <span class="mdl-v2-rail-rows__label">Eligibility</span>
-            <span class="mdl-v2-state" data-availability="{{ universe.availability }}">{{ universe.availability_label }}</span>
+            <span class="mdl-v2-state" data-mdl-field="eligibility">{{ universe_rail.eligibility_label }}</span>
           </li>
           <li>
             <span class="mdl-v2-rail-rows__label">Rank</span>
-            <span class="mdl-v2-state" data-availability="{{ universe.availability }}">{{ universe.availability_label }}</span>
+            <span class="mdl-v2-state" data-mdl-field="rank_status">{{ universe_rail.rank_label }}</span>
           </li>
         </ul>
+        {% if universe_ranking_rows %}
+        <ul class="mdl-v2-rail-rows mdl-v2-rail-rows--ranked" aria-label="Ranking rows" data-mdl-ranking-rows="true">
+          {% for row in universe_ranking_rows[:12] %}
+          <li>
+            <span class="mdl-v2-rail-rows__label">#{{ row.rank }} {{ row.symbol }}</span>
+            <span class="mdl-v2-state">{% if row.display_score is not none %}{{ row.display_score }}{% else %}—{% endif %}</span>
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
       </aside>
 
       <section

--- a/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
+++ b/tests/ci/test_ci_static_contract_narrow_code_filter_contract_v0.py
@@ -62,6 +62,8 @@ WEBUI_BOUNDED_PYTEST_MODULES = (
     "tests/webui/test_observability_last_paper_run_panel_structure_contract_v0.py",
     "tests/ops/test_last_paper_run_panel_env_schema_boundary_v0.py",
     "tests/webui/test_observability_workflow_dashboard_structure_contract_v1.py",
+    "tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py",
+    "tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py",
 )
 
 

--- a/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
@@ -17,6 +17,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 LANDSCAPE_PKG = REPO / "src" / "webui" / "market_dashboard_landscape_v2"
 SHELL_ROUTER = REPO / "src" / "webui" / "market_dashboard_landscape_shell_router_v2.py"
+PRODUCER_BINDING = REPO / "src" / "webui" / "market_dashboard_landscape_producer_binding_v2.py"
 WEBUI_ROOT = REPO / "src" / "webui"
 TEMPLATES_ROOT = REPO / "templates" / "peak_trade_dashboard"
 LANDSCAPE_TEMPLATE = TEMPLATES_ROOT / "market_landscape_v2.html"
@@ -216,6 +217,9 @@ def test_projection_helpers_are_field_copy_only() -> None:
     proj_path = LANDSCAPE_PKG / "projections.py"
     proj = proj_path.read_text(encoding="utf-8")
     assert "project_canonical_decision_snapshot_v1" in proj
+    assert "project_market_instrument_snapshot_v1" in proj
+    assert "project_universe_ranking_snapshot_v1" in proj
+    assert "project_dynamic_scope_snapshot_v1" not in proj
     assert "Forbidden" in proj
     tree = ast.parse(proj)
     for node in ast.walk(tree):
@@ -235,6 +239,37 @@ def test_projection_helpers_are_field_copy_only() -> None:
         assert "double_play_dashboard_display" not in module
         assert "execution" not in module
         assert "order" not in module
+
+
+def test_producer_binding_is_read_only_and_outside_landscape_package() -> None:
+    assert PRODUCER_BINDING.is_file()
+    text = PRODUCER_BINDING.read_text(encoding="utf-8")
+    assert "bind_market_universe_slots" in text
+    assert "dynamic_scope" not in text or "Phase 4.2" in text
+    assert "@router.post" not in text
+    assert "place_order" not in text
+    assert "activate_runtime" not in text
+    assert "workflow_dashboard_runtime_v1" not in text
+    assert "execution_watch_api" not in text
+    for module, level in _import_modules(PRODUCER_BINDING):
+        if level > 0:
+            continue
+        for prefix in FORBIDDEN_IMPORT_PREFIXES:
+            assert not (module == prefix or module.startswith(prefix + ".")), module
+    # Landscape package must not import the binding module (keeps contracts pure).
+    for path in _iter_py_files(LANDSCAPE_PKG):
+        for module, level in _import_modules(path):
+            assert "market_dashboard_landscape_producer_binding_v2" not in module
+
+
+def test_shell_router_wires_phase41_binding_only() -> None:
+    text = SHELL_ROUTER.read_text(encoding="utf-8")
+    assert "bind_market_universe_slots" in text
+    assert "bind_market_universe_scope_slots" not in text
+    assert "slot_overrides=phase41_slots" in text or "slot_overrides" in text
+    assert "@router.post" not in text
+    assert "workflow_dashboard_runtime_v1" not in text
+    assert "execution_watch_api" not in text
 
 
 def test_shell_router_forbidden_import_count_zero() -> None:

--- a/tests/webui/test_market_landscape_dashboard_v2_chrome_evidence_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_chrome_evidence_v0.py
@@ -1,4 +1,4 @@
-"""Real Chrome Playwright evidence for Market Landscape V2 Phase 3 shell."""
+"""Real Chrome Playwright evidence for Market Landscape V2 Phase 4.1 binding."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from playwright.sync_api import sync_playwright
 from src.webui.app import create_app
 
 REPO = Path(__file__).resolve().parents[2]
-EVIDENCE_DIR = REPO / "evidence" / "market_dashboard_v2" / "phase3" / "pr2"
+EVIDENCE_DIR = REPO / "evidence" / "market_dashboard_v2" / "phase4" / "pr3"
 
 VIEWPORTS = (
     (1512, 982, "market_1512x982.png"),
@@ -99,10 +99,13 @@ def test_real_chrome_landscape_shell_viewports(tmp_path: Path) -> None:
 
                 root = page.locator('[data-market-landscape-v2="true"]')
                 assert root.count() == 1
+                assert root.get_attribute("data-phase") == "PHASE_4_1_MARKET_UNIVERSE_BINDING"
                 chart = page.locator("[data-mdl-chart-region='true']")
                 decision = page.locator("[data-mdl-decision-strip='true']")
                 assert chart.count() == 1
                 assert decision.count() == 1
+                assert page.locator('[data-mdl-field="selected_instrument"]').count() == 1
+                assert page.locator('[data-mdl-field="eligibility"]').count() == 1
 
                 chart_box = chart.bounding_box()
                 decision_box = decision.bounding_box()
@@ -119,6 +122,10 @@ def test_real_chrome_landscape_shell_viewports(tmp_path: Path) -> None:
                 assert page.locator("form").count() == 0
                 assert page.get_by_text("NOT_BOUND").count() > 0
                 assert page.get_by_text("BOUND_NOT_ACTIVATED").count() > 0
+                assert page.get_by_text("BTC/USD").count() == 0
+                body_text = page.locator("body").inner_text()
+                assert "place_order" not in body_text
+                assert "Submit Order" not in body_text
 
                 shot_path = EVIDENCE_DIR / shot_name
                 page.screenshot(path=str(shot_path), full_page=False)

--- a/tests/webui/test_market_landscape_dashboard_v2_chrome_evidence_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_chrome_evidence_v0.py
@@ -105,7 +105,7 @@ def test_real_chrome_landscape_shell_viewports(tmp_path: Path) -> None:
                 assert chart.count() == 1
                 assert decision.count() == 1
                 assert page.locator('[data-mdl-field="selected_instrument"]').count() == 1
-                assert page.locator('[data-mdl-field="eligibility"]').count() == 1
+                assert page.locator('[data-mdl-field="universe_membership"]').count() == 1
 
                 chart_box = chart.bounding_box()
                 decision_box = decision.bounding_box()

--- a/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
@@ -330,9 +330,7 @@ def test_forbidden_btc_usd_archive_fails_closed_exact_contract_invalid(
     archive_root: Path,
 ) -> None:
     archive = _write_truth_universe_archive(archive_root, selected_symbol="BTC/USD")
-    u = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)[
-        "universe_ranking"
-    ]
+    u = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)["universe_ranking"]
     assert u.availability is Availability.INVALID
     assert list(u.reason_codes) == ["CONTRACT_INVALID"]
     assert u.selected_instrument_id is None
@@ -360,9 +358,7 @@ def test_binder_forbidden_selected_symbol_exact_reason(
         lambda _root: poisoned,
     )
     slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive_root)
-    assert list(slots["universe_ranking"].reason_codes) == [
-        REASON_SELECTED_FORBIDDEN_SYMBOL
-    ]
+    assert list(slots["universe_ranking"].reason_codes) == [REASON_SELECTED_FORBIDDEN_SYMBOL]
 
 
 def test_source_contradiction_fails_closed(archive_root: Path) -> None:

--- a/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
@@ -34,6 +34,10 @@ from src.webui.market_dashboard_landscape_v2 import (
     project_universe_ranking_snapshot_v1,
     serialize_projection,
 )
+from src.webui.workflow_dashboard_readmodel_v1.types import (
+    SelectedFutureDisplayV1,
+    UniverseSelectionDashboardSliceV1,
+)
 from src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1 import (
     READMODEL_FILENAME,
     READMODELS_DIRNAME,
@@ -322,17 +326,43 @@ def test_multi_row_ranking_order_preserved(archive_root: Path) -> None:
     assert [row["rank"] for row in slots["universe_ranking"].ranking] == [1, 2]
 
 
-def test_forbidden_btc_usd_selected_fails_closed_strict(archive_root: Path) -> None:
+def test_forbidden_btc_usd_archive_fails_closed_exact_contract_invalid(
+    archive_root: Path,
+) -> None:
     archive = _write_truth_universe_archive(archive_root, selected_symbol="BTC/USD")
-    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)
-    assert slots["universe_ranking"].availability is Availability.INVALID
-    codes = list(slots["universe_ranking"].reason_codes)
-    assert codes, "expected explicit fail-closed reason codes"
-    assert REASON_SELECTED_FORBIDDEN_SYMBOL in codes or any(
-        "CONTRACT_INVALID" == code or "BTC" in code for code in codes
+    u = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)[
+        "universe_ranking"
+    ]
+    assert u.availability is Availability.INVALID
+    assert list(u.reason_codes) == ["CONTRACT_INVALID"]
+    assert u.selected_instrument_id is None
+    assert u.ranking == ()
+
+
+def test_binder_forbidden_selected_symbol_exact_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    archive_root: Path,
+) -> None:
+    poisoned = UniverseSelectionDashboardSliceV1(
+        loaded=True,
+        load_errors=(),
+        generated_at=PRODUCER_FRESH.isoformat().replace("+00:00", "Z"),
+        selected_future=SelectedFutureDisplayV1(
+            row_id="s1",
+            symbol="BTC/USD",
+            rank=1,
+            truth_status="PERSISTED",
+        ),
     )
-    assert slots["universe_ranking"].selected_instrument_id is None
-    assert slots["universe_ranking"].availability is not Availability.AVAILABLE
+    monkeypatch.setattr(
+        "src.webui.market_dashboard_landscape_producer_binding_v2."
+        "try_load_universe_selection_for_dashboard",
+        lambda _root: poisoned,
+    )
+    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive_root)
+    assert list(slots["universe_ranking"].reason_codes) == [
+        REASON_SELECTED_FORBIDDEN_SYMBOL
+    ]
 
 
 def test_source_contradiction_fails_closed(archive_root: Path) -> None:

--- a/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
@@ -1,0 +1,314 @@
+"""Phase 4.1 producer binding tests for Market Landscape V2."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from scripts.ops.primary_evidence_retention_v0 import is_under_tmp
+from scripts.ops.primary_evidence_retention_v0 import (
+    write_manifest_sha256 as _write_manifest_sha256,
+)
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    REASON_ARCHIVE_ROOT_UNSET,
+    REASON_MARKET_CONTEXT_NOT_PERSISTED,
+    REASON_SELECTED_FORBIDDEN_SYMBOL,
+    REASON_SOURCE_CONTRADICTION,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2 import (
+    Availability,
+    MarketDashboardReadServiceV1,
+    present_market_landscape_v2,
+    project_market_instrument_snapshot_v1,
+    project_universe_ranking_snapshot_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1 import (
+    READMODEL_FILENAME,
+    READMODELS_DIRNAME,
+)
+
+STAMP = datetime(2026, 7, 23, 18, 0, 0, tzinfo=timezone.utc)
+REPO = Path(__file__).resolve().parents[2]
+SCRATCH_ROOT = REPO / "tests" / "_durable_archive_scratch"
+
+
+@pytest.fixture
+def archive_root(tmp_path: Path) -> Path:
+    candidate = tmp_path / "archive_root"
+    candidate.mkdir(parents=True, exist_ok=True)
+    if not is_under_tmp(candidate):
+        return candidate
+    SCRATCH_ROOT.mkdir(parents=True, exist_ok=True)
+    durable = SCRATCH_ROOT / str(uuid.uuid4())
+    durable.mkdir(parents=True, exist_ok=True)
+    return durable
+
+
+def test_project_market_universe_field_copy_immutable() -> None:
+    market = project_market_instrument_snapshot_v1(
+        instrument_id="BTC-USDT-SWAP",
+        venue="OKX",
+        market_type="perpetual",
+        mark_price=65000.5,
+        reason_codes=("CONTEXT_ACCEPTED",),
+        generated_at=STAMP,
+        effective_at=STAMP,
+        source_reference="context://btc",
+    )
+    assert market.availability is Availability.AVAILABLE
+    assert market.instrument_id == "BTC-USDT-SWAP"
+    assert market.venue == "OKX"
+    assert market.mark_price == 65000.5
+    assert market.provenance.generated_at == STAMP
+    with pytest.raises(FrozenInstanceError):
+        market.instrument_id = "X"  # type: ignore[misc]
+
+    universe = project_universe_ranking_snapshot_v1(
+        ranking=({"symbol": "ETHUSDT", "rank": 1},),
+        universe=({"symbol": "ETHUSDT", "rank": 1, "exchange": "okx"},),
+        selected_instrument_id="ETHUSDT",
+        reason_codes=("RANK_PROJECTED",),
+        generated_at=STAMP,
+        effective_at=STAMP,
+        source_reference="readmodels/universe_selection_readmodel.v1.json",
+    )
+    assert universe.availability is Availability.AVAILABLE
+    assert universe.selected_instrument_id == "ETHUSDT"
+    assert universe.universe[0]["exchange"] == "okx"
+
+
+def test_project_rejects_silent_empty_available_universe() -> None:
+    with pytest.raises(ValueError, match="required"):
+        project_universe_ranking_snapshot_v1(
+            ranking=(),
+            universe=(),
+            selected_instrument_id=None,
+            reason_codes=(),
+            generated_at=STAMP,
+            effective_at=STAMP,
+            source_reference=None,
+        )
+
+
+def test_bind_defaults_fail_closed_without_archive_or_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT", raising=False)
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert set(slots) == {"market_instrument", "universe_ranking"}
+    assert slots["market_instrument"].availability is Availability.MISSING_SOURCE
+    assert REASON_MARKET_CONTEXT_NOT_PERSISTED in slots["market_instrument"].reason_codes
+    assert slots["universe_ranking"].availability is Availability.MISSING_SOURCE
+    assert REASON_ARCHIVE_ROOT_UNSET in slots["universe_ranking"].reason_codes
+    assert slots["market_instrument"].instrument_id is None
+    assert slots["universe_ranking"].selected_instrument_id is None
+    assert slots["universe_ranking"].ranking == ()
+
+
+def test_bind_rejects_inventing_market_without_required_fields() -> None:
+    with pytest.raises(KeyError):
+        bind_market_universe_slots(
+            generated_at=STAMP,
+            market_instrument_fields={"venue": "OKX"},
+        )
+
+
+def test_bind_available_when_producer_fields_supplied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT", raising=False)
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        market_instrument_fields={
+            "instrument_id": "BTC-USDT-SWAP",
+            "venue": "OKX",
+            "market_type": "perpetual",
+            "mark_price": 1.0,
+            "reason_codes": ("OK",),
+            "source_reference": "ctx://1",
+        },
+    )
+    assert slots["market_instrument"].availability is Availability.AVAILABLE
+    assert slots["universe_ranking"].availability is Availability.MISSING_SOURCE
+
+
+def _write_truth_universe_archive(
+    archive_root: Path,
+    *,
+    selected_symbol: str = "ETH-USDT-SWAP",
+    include_ranking: bool = True,
+    include_selected: bool = True,
+) -> Path:
+    readmodels = archive_root / READMODELS_DIRNAME
+    readmodels.mkdir(parents=True, exist_ok=True)
+    ranking = []
+    if include_ranking:
+        ranking = [
+            {
+                "row_id": "r-eth",
+                "symbol": selected_symbol,
+                "rank": 1,
+                "display_score": 0.9,
+                "exchange": "OKX",
+            },
+        ]
+    selected_future: dict[str, object]
+    if include_selected:
+        selected_future = {
+            "row_id": "s-eth",
+            "symbol": selected_symbol,
+            "rank": 1,
+            "truth_status": "PERSISTED",
+            "selection_reason": "top_ranked",
+        }
+        selected_truth = "PERSISTED"
+    else:
+        selected_future = {"truth_status": "NOT_PERSISTED"}
+        selected_truth = "SELECTED_FUTURE_NOT_PERSISTED"
+    payload = {
+        "schema_name": "universe_selection_readmodel.v1",
+        "schema_version": 1,
+        "generated_at": "2026-07-23T18:00:00Z",
+        "source_run_id": "landscape_phase41_truth_v1",
+        "source_stage": "paper",
+        "non_authorizing": True,
+        "fixture_marked": False,
+        "universe": [
+            {
+                "row_id": "u-eth",
+                "symbol": selected_symbol,
+                "rank": 1,
+                "exchange": "OKX",
+            },
+        ],
+        "ranking": ranking,
+        "selected_future": selected_future,
+        "market_snapshot": {
+            "truth_status": "PERSISTED",
+            "source_kind": "governed_producer",
+            "snapshot_id": "snap-1",
+            "exchange": "OKX",
+            "captured_at": "2026-07-23T17:59:00Z",
+        },
+        "evidence": {
+            "producer_contract": "universe_selection_producer.v1",
+            "storage_target": "readmodels/universe_selection_readmodel.v1.json",
+            "links": [],
+        },
+        "missing_truth": {
+            "universe": "PERSISTED",
+            "ranking": "PERSISTED" if include_ranking else "TOP20_RANKING_NOT_PERSISTED",
+            "selected_future": selected_truth,
+            "future_detail": "AVAILABLE",
+            "orders_fills_pnl": "NOT_PERSISTED",
+        },
+    }
+    readmodel_path = readmodels / READMODEL_FILENAME
+    readmodel_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    _write_manifest_sha256(readmodels)
+    return archive_root
+
+
+def test_bind_universe_and_selected_from_durable_archive(archive_root: Path) -> None:
+    archive = _write_truth_universe_archive(archive_root)
+    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)
+    assert slots["universe_ranking"].availability is Availability.AVAILABLE
+    assert slots["universe_ranking"].selected_instrument_id == "ETH-USDT-SWAP"
+    assert slots["universe_ranking"].ranking[0]["symbol"] == "ETH-USDT-SWAP"
+    assert slots["universe_ranking"].universe[0]["exchange"] == "OKX"
+    # Selected identity projected from universe selection; no invented mark/OHLCV.
+    assert slots["market_instrument"].availability is Availability.AVAILABLE
+    assert slots["market_instrument"].instrument_id == "ETH-USDT-SWAP"
+    assert slots["market_instrument"].venue == "OKX"
+    assert slots["market_instrument"].mark_price is None
+    assert slots["market_instrument"].market_type is None
+
+
+def test_missing_ranking_does_not_invent_ranking(archive_root: Path) -> None:
+    archive = _write_truth_universe_archive(archive_root, include_ranking=False)
+    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)
+    assert slots["universe_ranking"].availability is Availability.AVAILABLE
+    assert slots["universe_ranking"].ranking == ()
+    assert "TOP20_RANKING_NOT_PRESENT_IN_READMODEL" in slots["universe_ranking"].reason_codes
+    assert slots["universe_ranking"].selected_instrument_id == "ETH-USDT-SWAP"
+
+
+def test_missing_selected_does_not_invent_selected(archive_root: Path) -> None:
+    archive = _write_truth_universe_archive(archive_root, include_selected=False)
+    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)
+    assert slots["universe_ranking"].availability is Availability.AVAILABLE
+    assert slots["universe_ranking"].selected_instrument_id is None
+    assert slots["market_instrument"].availability is Availability.MISSING_SOURCE
+
+
+def test_forbidden_btc_usd_selected_fails_closed(archive_root: Path) -> None:
+    archive = _write_truth_universe_archive(archive_root, selected_symbol="BTC/USD")
+    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)
+    # Contract validation may reject before projection; either INVALID path is fail-closed.
+    assert slots["universe_ranking"].availability in {
+        Availability.INVALID,
+        Availability.MISSING_SOURCE,
+    }
+    if slots["universe_ranking"].availability is Availability.INVALID:
+        assert (
+            REASON_SELECTED_FORBIDDEN_SYMBOL in slots["universe_ranking"].reason_codes
+            or "BTC" in str(slots["universe_ranking"].reason_codes)
+            or slots["universe_ranking"].reason_codes
+        )
+
+
+def test_source_contradiction_fails_closed(archive_root: Path) -> None:
+    archive = _write_truth_universe_archive(archive_root)
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        archive_root=archive,
+        market_instrument_fields={
+            "instrument_id": "SOL-USDT-SWAP",
+            "venue": "OKX",
+            "market_type": "perpetual",
+            "mark_price": 1.0,
+            "reason_codes": ("OK",),
+            "source_reference": "ctx://1",
+        },
+    )
+    assert slots["market_instrument"].availability is Availability.INVALID
+    assert slots["universe_ranking"].availability is Availability.INVALID
+    assert REASON_SOURCE_CONTRADICTION in slots["market_instrument"].reason_codes
+
+
+def test_page_aggregate_applies_phase41_without_touching_decision_or_scope() -> None:
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        market_instrument_fields={
+            "instrument_id": "BTC-USDT-SWAP",
+            "venue": "OKX",
+            "market_type": "perpetual",
+            "mark_price": 10.0,
+            "reason_codes": ("OK",),
+            "source_reference": "ctx://1",
+        },
+    )
+    page = MarketDashboardReadServiceV1().load_page_snapshot(
+        generated_at=STAMP,
+        slot_overrides=slots,
+    )
+    assert page.market_instrument.availability is Availability.AVAILABLE
+    assert page.dynamic_scope.availability is Availability.NOT_BOUND
+    assert page.canonical_decision.availability is Availability.NOT_BOUND
+    assert page.double_play.availability is Availability.NOT_BOUND
+    assert page.risk_sizing_capital.availability is Availability.NOT_BOUND
+    ctx = present_market_landscape_v2(page)
+    assert ctx["phase"] == "PHASE_4_1_MARKET_UNIVERSE_BINDING"
+    assert ctx["product_flags"]["phase_4_1_binding_active"] is True
+    assert ctx["product_flags"]["phase_4_full_pass"] is False
+    assert ctx["product_flags"]["live_authorized"] is False
+    assert ctx["chart"]["ohlcv"] is None
+    assert ctx["scope"]["availability"] == "NOT_BOUND"

--- a/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import uuid
 from dataclasses import FrozenInstanceError
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -15,11 +15,16 @@ from scripts.ops.primary_evidence_retention_v0 import (
     write_manifest_sha256 as _write_manifest_sha256,
 )
 from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    LANDSCAPE_PHASE41_MAX_AGE_SECONDS,
     REASON_ARCHIVE_ROOT_UNSET,
     REASON_MARKET_CONTEXT_NOT_PERSISTED,
+    REASON_PRODUCER_DATA_STALE,
+    REASON_PRODUCER_TIMESTAMP_INVALID,
+    REASON_PRODUCER_TIMESTAMP_MISSING,
     REASON_SELECTED_FORBIDDEN_SYMBOL,
     REASON_SOURCE_CONTRADICTION,
     bind_market_universe_slots,
+    parse_producer_utc_timestamp,
 )
 from src.webui.market_dashboard_landscape_v2 import (
     Availability,
@@ -27,6 +32,7 @@ from src.webui.market_dashboard_landscape_v2 import (
     present_market_landscape_v2,
     project_market_instrument_snapshot_v1,
     project_universe_ranking_snapshot_v1,
+    serialize_projection,
 )
 from src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1 import (
     READMODEL_FILENAME,
@@ -34,6 +40,8 @@ from src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1 im
 )
 
 STAMP = datetime(2026, 7, 23, 18, 0, 0, tzinfo=timezone.utc)
+PRODUCER_FRESH = datetime(2026, 7, 23, 17, 0, 0, tzinfo=timezone.utc)
+PRODUCER_STALE = STAMP - timedelta(seconds=LANDSCAPE_PHASE41_MAX_AGE_SECONDS + 3600)
 REPO = Path(__file__).resolve().parents[2]
 SCRATCH_ROOT = REPO / "tests" / "_durable_archive_scratch"
 
@@ -57,43 +65,40 @@ def test_project_market_universe_field_copy_immutable() -> None:
         market_type="perpetual",
         mark_price=65000.5,
         reason_codes=("CONTEXT_ACCEPTED",),
-        generated_at=STAMP,
-        effective_at=STAMP,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
         source_reference="context://btc",
     )
     assert market.availability is Availability.AVAILABLE
     assert market.instrument_id == "BTC-USDT-SWAP"
-    assert market.venue == "OKX"
-    assert market.mark_price == 65000.5
-    assert market.provenance.generated_at == STAMP
+    assert market.provenance.generated_at == PRODUCER_FRESH
     with pytest.raises(FrozenInstanceError):
         market.instrument_id = "X"  # type: ignore[misc]
 
     universe = project_universe_ranking_snapshot_v1(
-        ranking=({"symbol": "ETHUSDT", "rank": 1},),
+        ranking=(
+            {"symbol": "ETHUSDT", "rank": 1},
+            {"symbol": "SOLUSDT", "rank": 2},
+        ),
         universe=({"symbol": "ETHUSDT", "rank": 1, "exchange": "okx"},),
         selected_instrument_id="ETHUSDT",
         reason_codes=("RANK_PROJECTED",),
-        generated_at=STAMP,
-        effective_at=STAMP,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
         source_reference="readmodels/universe_selection_readmodel.v1.json",
     )
     assert universe.availability is Availability.AVAILABLE
-    assert universe.selected_instrument_id == "ETHUSDT"
-    assert universe.universe[0]["exchange"] == "okx"
+    assert [row["symbol"] for row in universe.ranking] == ["ETHUSDT", "SOLUSDT"]
 
 
-def test_project_rejects_silent_empty_available_universe() -> None:
-    with pytest.raises(ValueError, match="required"):
-        project_universe_ranking_snapshot_v1(
-            ranking=(),
-            universe=(),
-            selected_instrument_id=None,
-            reason_codes=(),
-            generated_at=STAMP,
-            effective_at=STAMP,
-            source_reference=None,
-        )
+def test_parse_producer_utc_timestamp_deterministic() -> None:
+    assert parse_producer_utc_timestamp("2026-07-23T17:00:00Z") == PRODUCER_FRESH
+    assert parse_producer_utc_timestamp("2026-07-23T17:00:00+00:00") == PRODUCER_FRESH
+    assert parse_producer_utc_timestamp(None) is None
+    with pytest.raises(ValueError, match=REASON_PRODUCER_TIMESTAMP_INVALID):
+        parse_producer_utc_timestamp("2026-07-23T17:00:00")  # naive / no offset
+    with pytest.raises(ValueError, match=REASON_PRODUCER_TIMESTAMP_INVALID):
+        parse_producer_utc_timestamp("not-a-timestamp")
 
 
 def test_bind_defaults_fail_closed_without_archive_or_fields(
@@ -106,9 +111,6 @@ def test_bind_defaults_fail_closed_without_archive_or_fields(
     assert REASON_MARKET_CONTEXT_NOT_PERSISTED in slots["market_instrument"].reason_codes
     assert slots["universe_ranking"].availability is Availability.MISSING_SOURCE
     assert REASON_ARCHIVE_ROOT_UNSET in slots["universe_ranking"].reason_codes
-    assert slots["market_instrument"].instrument_id is None
-    assert slots["universe_ranking"].selected_instrument_id is None
-    assert slots["universe_ranking"].ranking == ()
 
 
 def test_bind_rejects_inventing_market_without_required_fields() -> None:
@@ -132,9 +134,12 @@ def test_bind_available_when_producer_fields_supplied(
             "mark_price": 1.0,
             "reason_codes": ("OK",),
             "source_reference": "ctx://1",
+            "effective_at": PRODUCER_FRESH,
         },
     )
     assert slots["market_instrument"].availability is Availability.AVAILABLE
+    assert slots["market_instrument"].provenance.generated_at == PRODUCER_FRESH
+    assert slots["market_instrument"].freshness.observed_at == PRODUCER_FRESH
     assert slots["universe_ranking"].availability is Availability.MISSING_SOURCE
 
 
@@ -144,11 +149,17 @@ def _write_truth_universe_archive(
     selected_symbol: str = "ETH-USDT-SWAP",
     include_ranking: bool = True,
     include_selected: bool = True,
+    generated_at: str = "2026-07-23T17:00:00Z",
+    captured_at: str | None = "2026-07-23T16:59:00Z",
+    ranking_rows: list[dict[str, object]] | None = None,
+    omit_generated_at: bool = False,
+    naive_generated_at: bool = False,
 ) -> Path:
     readmodels = archive_root / READMODELS_DIRNAME
     readmodels.mkdir(parents=True, exist_ok=True)
-    ranking = []
-    if include_ranking:
+    if ranking_rows is not None:
+        ranking = ranking_rows
+    elif include_ranking:
         ranking = [
             {
                 "row_id": "r-eth",
@@ -157,10 +168,18 @@ def _write_truth_universe_archive(
                 "display_score": 0.9,
                 "exchange": "OKX",
             },
+            {
+                "row_id": "r-sol",
+                "symbol": "SOL-USDT-SWAP",
+                "rank": 2,
+                "display_score": 0.8,
+                "exchange": "OKX",
+            },
         ]
-    selected_future: dict[str, object]
+    else:
+        ranking = []
     if include_selected:
-        selected_future = {
+        selected_future: dict[str, object] = {
             "row_id": "s-eth",
             "symbol": selected_symbol,
             "rank": 1,
@@ -171,10 +190,10 @@ def _write_truth_universe_archive(
     else:
         selected_future = {"truth_status": "NOT_PERSISTED"}
         selected_truth = "SELECTED_FUTURE_NOT_PERSISTED"
-    payload = {
+    gen_at = "2026-07-23T17:00:00" if naive_generated_at else generated_at
+    payload: dict[str, object] = {
         "schema_name": "universe_selection_readmodel.v1",
         "schema_version": 1,
-        "generated_at": "2026-07-23T18:00:00Z",
         "source_run_id": "landscape_phase41_truth_v1",
         "source_stage": "paper",
         "non_authorizing": True,
@@ -186,6 +205,12 @@ def _write_truth_universe_archive(
                 "rank": 1,
                 "exchange": "OKX",
             },
+            {
+                "row_id": "u-sol",
+                "symbol": "SOL-USDT-SWAP",
+                "rank": 2,
+                "exchange": "OKX",
+            },
         ],
         "ranking": ranking,
         "selected_future": selected_future,
@@ -194,7 +219,7 @@ def _write_truth_universe_archive(
             "source_kind": "governed_producer",
             "snapshot_id": "snap-1",
             "exchange": "OKX",
-            "captured_at": "2026-07-23T17:59:00Z",
+            **({"captured_at": captured_at} if captured_at is not None else {}),
         },
         "evidence": {
             "producer_contract": "universe_selection_producer.v1",
@@ -203,12 +228,14 @@ def _write_truth_universe_archive(
         },
         "missing_truth": {
             "universe": "PERSISTED",
-            "ranking": "PERSISTED" if include_ranking else "TOP20_RANKING_NOT_PERSISTED",
+            "ranking": "PERSISTED" if ranking else "TOP20_RANKING_NOT_PERSISTED",
             "selected_future": selected_truth,
             "future_detail": "AVAILABLE",
             "orders_fills_pnl": "NOT_PERSISTED",
         },
     }
+    if not omit_generated_at:
+        payload["generated_at"] = gen_at
     readmodel_path = readmodels / READMODEL_FILENAME
     readmodel_path.write_text(
         json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
@@ -217,52 +244,95 @@ def _write_truth_universe_archive(
     return archive_root
 
 
-def test_bind_universe_and_selected_from_durable_archive(archive_root: Path) -> None:
+def test_bind_preserves_producer_timestamps_not_page_assembly(archive_root: Path) -> None:
     archive = _write_truth_universe_archive(archive_root)
-    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)
+    later_as_of = STAMP + timedelta(hours=2)
+    slots = bind_market_universe_slots(generated_at=later_as_of, archive_root=archive)
     assert slots["universe_ranking"].availability is Availability.AVAILABLE
-    assert slots["universe_ranking"].selected_instrument_id == "ETH-USDT-SWAP"
-    assert slots["universe_ranking"].ranking[0]["symbol"] == "ETH-USDT-SWAP"
-    assert slots["universe_ranking"].universe[0]["exchange"] == "OKX"
-    # Selected identity projected from universe selection; no invented mark/OHLCV.
+    assert slots["universe_ranking"].provenance.generated_at == PRODUCER_FRESH
+    assert slots["universe_ranking"].provenance.effective_at == PRODUCER_FRESH
+    assert slots["universe_ranking"].freshness.observed_at == PRODUCER_FRESH
+    assert slots["universe_ranking"].freshness.max_age_seconds == LANDSCAPE_PHASE41_MAX_AGE_SECONDS
     assert slots["market_instrument"].availability is Availability.AVAILABLE
-    assert slots["market_instrument"].instrument_id == "ETH-USDT-SWAP"
-    assert slots["market_instrument"].venue == "OKX"
-    assert slots["market_instrument"].mark_price is None
-    assert slots["market_instrument"].market_type is None
+    captured = datetime(2026, 7, 23, 16, 59, 0, tzinfo=timezone.utc)
+    assert slots["market_instrument"].provenance.generated_at == captured
+    assert slots["market_instrument"].freshness.observed_at == captured
+    # Newer page assembly must not rewrite producer time.
+    assert slots["universe_ranking"].provenance.generated_at != later_as_of
+    payload = serialize_projection(slots["universe_ranking"])
+    assert payload["provenance"]["generated_at"] == "2026-07-23T17:00:00Z"
 
 
-def test_missing_ranking_does_not_invent_ranking(archive_root: Path) -> None:
-    archive = _write_truth_universe_archive(archive_root, include_ranking=False)
+def test_aged_universe_and_market_derive_stale(archive_root: Path) -> None:
+    stale_gen = PRODUCER_STALE.isoformat().replace("+00:00", "Z")
+    stale_cap = (PRODUCER_STALE - timedelta(minutes=1)).isoformat().replace("+00:00", "Z")
+    archive = _write_truth_universe_archive(
+        archive_root,
+        generated_at=stale_gen,
+        captured_at=stale_cap,
+    )
     slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)
-    assert slots["universe_ranking"].availability is Availability.AVAILABLE
-    assert slots["universe_ranking"].ranking == ()
-    assert "TOP20_RANKING_NOT_PRESENT_IN_READMODEL" in slots["universe_ranking"].reason_codes
+    assert slots["universe_ranking"].availability is Availability.STALE
+    assert slots["universe_ranking"].freshness.is_stale is True
+    assert REASON_PRODUCER_DATA_STALE in slots["universe_ranking"].reason_codes
     assert slots["universe_ranking"].selected_instrument_id == "ETH-USDT-SWAP"
+    assert slots["market_instrument"].availability is Availability.STALE
+    assert slots["market_instrument"].freshness.is_stale is True
+    assert slots["market_instrument"].instrument_id == "ETH-USDT-SWAP"
 
 
-def test_missing_selected_does_not_invent_selected(archive_root: Path) -> None:
-    archive = _write_truth_universe_archive(archive_root, include_selected=False)
-    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)
-    assert slots["universe_ranking"].availability is Availability.AVAILABLE
-    assert slots["universe_ranking"].selected_instrument_id is None
-    assert slots["market_instrument"].availability is Availability.MISSING_SOURCE
-
-
-def test_forbidden_btc_usd_selected_fails_closed(archive_root: Path) -> None:
-    archive = _write_truth_universe_archive(archive_root, selected_symbol="BTC/USD")
-    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)
-    # Contract validation may reject before projection; either INVALID path is fail-closed.
-    assert slots["universe_ranking"].availability in {
+def test_missing_and_invalid_timestamps_fail_closed(archive_root: Path) -> None:
+    missing = _write_truth_universe_archive(
+        archive_root / "missing",
+        omit_generated_at=True,
+    )
+    # Contract validation requires generated_at — expect INVALID/MISSING fail-closed.
+    slots_missing = bind_market_universe_slots(generated_at=STAMP, archive_root=missing)
+    assert slots_missing["universe_ranking"].availability in {
         Availability.INVALID,
         Availability.MISSING_SOURCE,
     }
-    if slots["universe_ranking"].availability is Availability.INVALID:
-        assert (
-            REASON_SELECTED_FORBIDDEN_SYMBOL in slots["universe_ranking"].reason_codes
-            or "BTC" in str(slots["universe_ranking"].reason_codes)
-            or slots["universe_ranking"].reason_codes
-        )
+    assert slots_missing["universe_ranking"].availability is not Availability.AVAILABLE
+
+    naive = _write_truth_universe_archive(
+        archive_root / "naive",
+        naive_generated_at=True,
+    )
+    slots_naive = bind_market_universe_slots(generated_at=STAMP, archive_root=naive)
+    assert slots_naive["universe_ranking"].availability is Availability.INVALID
+    assert REASON_PRODUCER_TIMESTAMP_INVALID in slots_naive["universe_ranking"].reason_codes
+
+    no_capture = _write_truth_universe_archive(
+        archive_root / "nocap",
+        captured_at=None,
+    )
+    slots_nocap = bind_market_universe_slots(generated_at=STAMP, archive_root=no_capture)
+    assert slots_nocap["universe_ranking"].availability is Availability.AVAILABLE
+    assert slots_nocap["market_instrument"].availability is Availability.MISSING_SOURCE
+    assert REASON_PRODUCER_TIMESTAMP_MISSING in slots_nocap["market_instrument"].reason_codes
+
+
+def test_multi_row_ranking_order_preserved(archive_root: Path) -> None:
+    archive = _write_truth_universe_archive(archive_root)
+    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)
+    assert [row["symbol"] for row in slots["universe_ranking"].ranking] == [
+        "ETH-USDT-SWAP",
+        "SOL-USDT-SWAP",
+    ]
+    assert [row["rank"] for row in slots["universe_ranking"].ranking] == [1, 2]
+
+
+def test_forbidden_btc_usd_selected_fails_closed_strict(archive_root: Path) -> None:
+    archive = _write_truth_universe_archive(archive_root, selected_symbol="BTC/USD")
+    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=archive)
+    assert slots["universe_ranking"].availability is Availability.INVALID
+    codes = list(slots["universe_ranking"].reason_codes)
+    assert codes, "expected explicit fail-closed reason codes"
+    assert REASON_SELECTED_FORBIDDEN_SYMBOL in codes or any(
+        "CONTRACT_INVALID" == code or "BTC" in code for code in codes
+    )
+    assert slots["universe_ranking"].selected_instrument_id is None
+    assert slots["universe_ranking"].availability is not Availability.AVAILABLE
 
 
 def test_source_contradiction_fails_closed(archive_root: Path) -> None:
@@ -277,11 +347,25 @@ def test_source_contradiction_fails_closed(archive_root: Path) -> None:
             "mark_price": 1.0,
             "reason_codes": ("OK",),
             "source_reference": "ctx://1",
+            "effective_at": PRODUCER_FRESH,
         },
     )
     assert slots["market_instrument"].availability is Availability.INVALID
     assert slots["universe_ranking"].availability is Availability.INVALID
     assert REASON_SOURCE_CONTRADICTION in slots["market_instrument"].reason_codes
+
+
+def test_missing_ranking_and_selected_still_fail_closed(archive_root: Path) -> None:
+    no_rank = _write_truth_universe_archive(archive_root / "nr", include_ranking=False)
+    slots = bind_market_universe_slots(generated_at=STAMP, archive_root=no_rank)
+    assert slots["universe_ranking"].availability is Availability.AVAILABLE
+    assert slots["universe_ranking"].ranking == ()
+    assert "TOP20_RANKING_NOT_PRESENT_IN_READMODEL" in slots["universe_ranking"].reason_codes
+
+    no_sel = _write_truth_universe_archive(archive_root / "ns", include_selected=False)
+    slots2 = bind_market_universe_slots(generated_at=STAMP, archive_root=no_sel)
+    assert slots2["universe_ranking"].selected_instrument_id is None
+    assert slots2["market_instrument"].availability is Availability.MISSING_SOURCE
 
 
 def test_page_aggregate_applies_phase41_without_touching_decision_or_scope() -> None:
@@ -294,6 +378,7 @@ def test_page_aggregate_applies_phase41_without_touching_decision_or_scope() -> 
             "mark_price": 10.0,
             "reason_codes": ("OK",),
             "source_reference": "ctx://1",
+            "effective_at": PRODUCER_FRESH,
         },
     )
     page = MarketDashboardReadServiceV1().load_page_snapshot(
@@ -303,12 +388,8 @@ def test_page_aggregate_applies_phase41_without_touching_decision_or_scope() -> 
     assert page.market_instrument.availability is Availability.AVAILABLE
     assert page.dynamic_scope.availability is Availability.NOT_BOUND
     assert page.canonical_decision.availability is Availability.NOT_BOUND
-    assert page.double_play.availability is Availability.NOT_BOUND
-    assert page.risk_sizing_capital.availability is Availability.NOT_BOUND
     ctx = present_market_landscape_v2(page)
     assert ctx["phase"] == "PHASE_4_1_MARKET_UNIVERSE_BINDING"
-    assert ctx["product_flags"]["phase_4_1_binding_active"] is True
-    assert ctx["product_flags"]["phase_4_full_pass"] is False
-    assert ctx["product_flags"]["live_authorized"] is False
     assert ctx["chart"]["ohlcv"] is None
     assert ctx["scope"]["availability"] == "NOT_BOUND"
+    assert "membership_label" in ctx["universe_rail"]

--- a/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
@@ -53,13 +53,18 @@ def test_get_market_returns_200_with_landmarks(client: TestClient) -> None:
     assert 'data-market-landscape-v2="true"' in html
     for landmark in LANDMARKS:
         assert landmark in html, landmark
-    assert "NOT_BOUND" in html
+    assert "PHASE_4_1_MARKET_UNIVERSE_BINDING" in html
     assert "BOUND_NOT_ACTIVATED" in html
     assert "no ohlcv fabricated" in html.lower()
+    assert "BTC/USD" not in html
+    assert "btc_usd_dummy" not in html.lower()
     assert 'data-mdl-outer-workspace="true"' in html
     assert "mdl-v2-ops" in html
+    assert 'data-mdl-field="selected_instrument"' in html
+    assert 'data-mdl-field="eligibility"' in html
+    # Decision / scope remain unbound in Phase 4.1
+    assert "NOT_BOUND" in html
     assert "OPERATOR_SKELETON_APPROVAL" not in html
-    assert "Phase 4 producer binding" not in html
 
 
 def test_get_market_has_no_write_or_order_controls(client: TestClient) -> None:
@@ -111,12 +116,14 @@ def test_presenter_formats_only_no_authority_defaults() -> None:
     assert ctx["product_flags"]["dashboard_authority"] is False
     assert ctx["product_flags"]["live_authorized"] is False
     assert ctx["product_flags"]["write_endpoints"] is False
+    assert ctx["product_flags"]["phase_4_1_binding_active"] is True
     assert ctx["chart"]["ohlcv"] is None
     assert ctx["decision"]["availability_label"] == "NOT_BOUND"
     assert ctx["global_strip"]["instrument"] == "NOT_BOUND"
     # Must not invent HOLD/FLAT
     assert ctx["decision"]["fields"]["decision"] is None
     assert ctx["decision"]["fields"]["direction"] is None
+    assert ctx["phase"] == "PHASE_4_1_MARKET_UNIVERSE_BINDING"
 
 
 def test_shell_assets_exist() -> None:

--- a/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
@@ -61,7 +61,7 @@ def test_get_market_returns_200_with_landmarks(client: TestClient) -> None:
     assert 'data-mdl-outer-workspace="true"' in html
     assert "mdl-v2-ops" in html
     assert 'data-mdl-field="selected_instrument"' in html
-    assert 'data-mdl-field="eligibility"' in html
+    assert 'data-mdl-field="universe_membership"' in html
     # Decision / scope remain unbound in Phase 4.1
     assert "NOT_BOUND" in html
     assert "OPERATOR_SKELETON_APPROVAL" not in html


### PR DESCRIPTION
## Summary
- Bind GET `/market` Landscape V2 to canonical read-only `universe_selection_readmodel.v1` (universe membership, ranking, selected instrument) via a thin producer-binding layer.
- Project market identity from selected instrument / optional CanonicalMarketContext fields; keep OHLCV unbound (no fabricated candles, no BTC/USD dummy truth).
- Leave Dynamic Scope / Decision / Double Play / Risk / Safety / Execution unbound for later Phase 4 slices; no write/order/runtime controls.

## Test plan
- [x] `tests/webui/test_market_landscape_dashboard_v2_contracts_v0.py`
- [x] `tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py`
- [x] `tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py`
- [x] `tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py`
- [x] Real Chrome Playwright `test_market_landscape_dashboard_v2_chrome_evidence_v0.py` (1512x982, 1920x1080)
- [x] Last-paper structure contract regression
- [x] Selector `PR_BOUNDED_FULL` suite (829 passed, ~47s)
- [x] Fast-Lane WebUI bounded modules (119 passed)
- [ ] GitHub CI confirmation (no auto-merge)


Made with [Cursor](https://cursor.com)