### PR TITLE
ci: pin lint gate to ruff 0.15.22

### DIFF
--- a/.github/workflows/lint_gate.yml
+++ b/.github/workflows/lint_gate.yml
@@ -96,7 +96,7 @@ jobs:
         if: steps.detect.outputs.applicable == 'true'
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install ruff==0.15.22
 
       - name: Run ruff check
         if: steps.detect.outputs.applicable == 'true'


### PR DESCRIPTION
## Summary
- pins the previously unpinned lint-gate Ruff installation
- restores the last-known-green formatter behavior
- prevents automatic CI breakage from future Ruff releases
- main passes with Ruff 0.15.22 and fails with Ruff 0.16.0 on seven pre-existing Markdown files
- no Markdown reformatting
- no production changes
- independent of PR #5503

## Test plan
- [x] Local `ruff==0.15.22` install
- [x] `ruff format --check src/ tests/ scripts/` PASS
- [x] `ruff check src/ tests/ scripts/` PASS
- [x] Workflow YAML parses
- [ ] CI Lint Gate on this PR


Made with [Cursor](https://cursor.com)