### PR TITLE
Market Landscape V2: bind canonical Dynamic Scope lifecycle

### DIFF
--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -1,7 +1,7 @@
-"""Phase 4.1 read-only producer binding for Market Landscape V2.
+"""Phase 4.1 + 4.2 read-only producer binding for Market Landscape V2.
 
-Binds market_instrument and universe_ranking only.
-Dynamic scope / regime / switch remain unbound (Phase 4.2).
+Binds market_instrument, universe_ranking, and dynamic_scope lifecycle identity.
+Regime / bull-bear / switch remain unbound (Phase 4.2 exclusions).
 Lives outside market_dashboard_landscape_v2 so that package stays free of
 trading/webui producer imports (architecture guard).
 
@@ -9,8 +9,9 @@ Fail-closed:
 - Wired slots without durable producer output → MISSING_SOURCE / INVALID
 - Producer timestamps preserved; page-assembly time is observation-only
 - Aged producer snapshots → STALE (never silently refreshed)
-- Never fabricate OHLCV, ranking, eligibility, or selected instrument
-- No decision / Double Play / risk / safety / execution / scope binding
+- Never fabricate OHLCV, ranking, eligibility, selected instrument, or scope
+- Never call scope initializers, trailing-scope runtime owners, or switch owners
+- No decision / Double Play / risk / safety / execution binding
 """
 
 from __future__ import annotations
@@ -23,10 +24,12 @@ from typing import Any, Mapping
 
 from .market_dashboard_landscape_v2.availability import Availability
 from .market_dashboard_landscape_v2.projections import (
+    project_dynamic_scope_snapshot_v1,
     project_market_instrument_snapshot_v1,
     project_universe_ranking_snapshot_v1,
 )
 from .market_dashboard_landscape_v2.unavailable import (
+    unavailable_dynamic_scope,
     unavailable_market_instrument,
     unavailable_universe_ranking,
 )
@@ -40,11 +43,13 @@ from .workflow_dashboard_readmodel_v1.universe_selection_reader_v1 import (
 # Reuse the existing workflow-dashboard archive env — no second archive owner.
 ENV_ARCHIVE_ROOT = "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT"
 
-# F2 consuming-surface max_allowed_staleness_seconds for Landscape Phase 4.1.
+# F2 consuming-surface max_allowed_staleness_seconds for Landscape Phase 4.1/4.2.
 # Declared here as the dashboard consumer policy; never invent freshness via now().
 LANDSCAPE_PHASE41_MAX_AGE_SECONDS = 86_400
+LANDSCAPE_PHASE42_MAX_AGE_SECONDS = LANDSCAPE_PHASE41_MAX_AGE_SECONDS
 
 REASON_MARKET_CONTEXT_NOT_PERSISTED = "CANONICAL_MARKET_CONTEXT_NOT_PERSISTED_FOR_DASHBOARD"
+REASON_SCOPE_NOT_PERSISTED = "CANONICAL_SCOPE_SNAPSHOT_NOT_PERSISTED_FOR_DASHBOARD"
 REASON_UNIVERSE_ABSENT = "UNIVERSE_SELECTION_READMODEL_ABSENT"
 REASON_ARCHIVE_ROOT_UNSET = "UNIVERSE_ARCHIVE_ROOT_UNSET"
 REASON_SELECTED_FORBIDDEN_SYMBOL = "SELECTED_INSTRUMENT_FORBIDDEN_BTC_USD_OR_SPOT_DUMMY"
@@ -55,10 +60,14 @@ REASON_PRODUCER_TIMESTAMP_MISSING = "PRODUCER_TIMESTAMP_MISSING"
 REASON_PRODUCER_TIMESTAMP_INVALID = "PRODUCER_TIMESTAMP_INVALID"
 REASON_PRODUCER_DATA_STALE = "PRODUCER_DATA_EXCEEDED_LANDSCAPE_MAX_AGE"
 
+SCOPE_PRODUCER_MODULE = "trading.master_v2.canonical_scope_initialization_v1"
+SCOPE_SOURCE_KIND = "canonical_scope_snapshot"
+
 PHASE_4_1_BOUND_SLOTS: tuple[str, ...] = (
     "market_instrument",
     "universe_ranking",
 )
+PHASE_4_2_BOUND_SLOTS: tuple[str, ...] = ("dynamic_scope",)
 
 _ISO8601_UTC_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|\+00:00)$")
 
@@ -367,14 +376,155 @@ def _market_from_universe_selected(
     )
 
 
+def _enum_or_str(value: Any) -> str:
+    if hasattr(value, "value"):
+        return str(value.value)
+    return str(value)
+
+
+def _resolve_injected_aware_timestamp(
+    raw: Any,
+) -> tuple[datetime | None, str | None]:
+    """Return (aware_utc_dt, error_reason). None+None means absent."""
+    if raw is None:
+        return None, None
+    if isinstance(raw, datetime):
+        if raw.tzinfo is None:
+            return None, REASON_PRODUCER_TIMESTAMP_INVALID
+        return raw.astimezone(timezone.utc), None
+    if isinstance(raw, str):
+        try:
+            parsed = parse_producer_utc_timestamp(raw)
+        except ValueError:
+            return None, REASON_PRODUCER_TIMESTAMP_INVALID
+        return parsed, None
+    return None, REASON_PRODUCER_TIMESTAMP_INVALID
+
+
+def _bind_dynamic_scope_lifecycle(
+    *,
+    as_of: datetime,
+    git_sha: str | None,
+    dynamic_scope_fields: Mapping[str, Any] | None,
+) -> Any:
+    """Project injected CanonicalScopeSnapshotV1-compatible lifecycle fields.
+
+    No durable dashboard scope readmodel. Without injection → MISSING_SOURCE.
+    Never runs canonical scope initialization or switch-transition owners.
+    """
+    if dynamic_scope_fields is None:
+        return unavailable_dynamic_scope(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=as_of,
+            reason=REASON_SCOPE_NOT_PERSISTED,
+        )
+
+    if "scope_state" in dynamic_scope_fields and dynamic_scope_fields["scope_state"] is not None:
+        scope_state = _enum_or_str(dynamic_scope_fields["scope_state"])
+    elif (
+        "lifecycle_state" in dynamic_scope_fields
+        and dynamic_scope_fields["lifecycle_state"] is not None
+    ):
+        scope_state = _enum_or_str(dynamic_scope_fields["lifecycle_state"])
+    else:
+        raise KeyError(
+            "dynamic_scope_fields missing required keys: ['scope_state'|'lifecycle_state']"
+        )
+
+    if (
+        "current_scope_ref" in dynamic_scope_fields
+        and dynamic_scope_fields["current_scope_ref"] is not None
+    ):
+        current_scope_ref = str(dynamic_scope_fields["current_scope_ref"])
+    elif "scope_id" in dynamic_scope_fields and dynamic_scope_fields["scope_id"] is not None:
+        current_scope_ref = str(dynamic_scope_fields["scope_id"])
+    else:
+        raise KeyError(
+            "dynamic_scope_fields missing required keys: ['current_scope_ref'|'scope_id']"
+        )
+
+    next_scope_ref: str | None = None
+    if "next_scope_ref" in dynamic_scope_fields:
+        raw_next = dynamic_scope_fields["next_scope_ref"]
+        next_scope_ref = None if raw_next is None else str(raw_next)
+
+    generated_at_raw = dynamic_scope_fields.get("generated_at")
+    producer_at, gen_error = _resolve_injected_aware_timestamp(generated_at_raw)
+    if gen_error is not None:
+        return unavailable_dynamic_scope(
+            availability=Availability.INVALID,
+            generated_at=as_of,
+            reason=gen_error,
+        )
+    if producer_at is None:
+        return unavailable_dynamic_scope(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=as_of,
+            reason=REASON_PRODUCER_TIMESTAMP_MISSING,
+        )
+
+    effective_at: datetime | None = None
+    if "effective_at" in dynamic_scope_fields:
+        effective_at, eff_error = _resolve_injected_aware_timestamp(
+            dynamic_scope_fields.get("effective_at")
+        )
+        if eff_error is not None:
+            return unavailable_dynamic_scope(
+                availability=Availability.INVALID,
+                generated_at=as_of,
+                reason=eff_error,
+            )
+
+    try:
+        availability, is_stale, stale_reason = classify_producer_freshness(
+            producer_at=producer_at,
+            as_of=as_of,
+            max_age_seconds=LANDSCAPE_PHASE42_MAX_AGE_SECONDS,
+        )
+    except ValueError:
+        return unavailable_dynamic_scope(
+            availability=Availability.INVALID,
+            generated_at=as_of,
+            reason=REASON_PRODUCER_TIMESTAMP_INVALID,
+        )
+
+    reason_codes = tuple(str(code) for code in dynamic_scope_fields.get("reason_codes", ()) or ())
+    evidence_digest = dynamic_scope_fields.get("evidence_digest")
+    if evidence_digest is None:
+        evidence_digest = dynamic_scope_fields.get("semantic_digest")
+
+    return project_dynamic_scope_snapshot_v1(
+        scope_state=scope_state,
+        current_scope_ref=current_scope_ref,
+        next_scope_ref=next_scope_ref,
+        reason_codes=reason_codes,
+        generated_at=producer_at,
+        effective_at=effective_at,
+        source_reference=(
+            None
+            if dynamic_scope_fields.get("source_reference") is None
+            else str(dynamic_scope_fields.get("source_reference"))
+        ),
+        evidence_digest=None if evidence_digest is None else str(evidence_digest),
+        git_sha=git_sha,
+        producer_module=SCOPE_PRODUCER_MODULE,
+        source_kind=SCOPE_SOURCE_KIND,
+        availability=availability,
+        max_age_seconds=LANDSCAPE_PHASE42_MAX_AGE_SECONDS,
+        is_stale=is_stale,
+        stale_reason=stale_reason,
+    )
+
+
 def bind_market_universe_slots(
     *,
     generated_at: datetime,
     archive_root: str | Path | None = None,
     git_sha: str | None = None,
     market_instrument_fields: Mapping[str, Any] | None = None,
+    dynamic_scope_fields: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Return Phase 4.1 slot overrides (market_instrument + universe_ranking).
+    """Return Phase 4.1+4.2 slot overrides (market, universe, dynamic_scope).
 
     ``generated_at`` is the dashboard observation/as-of clock only. It must never
     overwrite producer provenance timestamps or fabricate freshness.
@@ -382,6 +532,10 @@ def bind_market_universe_slots(
     market_instrument_fields accepts already-computed CanonicalMarketContext
     field dicts for tests and future durable loaders. Those fields must carry
     producer ``generated_at`` and/or ``effective_at``.
+
+    dynamic_scope_fields accepts already-computed CanonicalScopeSnapshotV1-
+    compatible lifecycle identity fields plus producer wall-clock timestamps.
+    Without injection, dynamic_scope is MISSING_SOURCE (no durable readmodel).
     """
     if generated_at.tzinfo is None:
         raise ValueError("generated_at must be timezone-aware")
@@ -392,6 +546,11 @@ def bind_market_universe_slots(
         as_of=as_of,
         archive_root=root,
         git_sha=git_sha,
+    )
+    scope = _bind_dynamic_scope_lifecycle(
+        as_of=as_of,
+        git_sha=git_sha,
+        dynamic_scope_fields=dynamic_scope_fields,
     )
 
     if market_instrument_fields is not None:
@@ -525,4 +684,5 @@ def bind_market_universe_slots(
     return {
         "market_instrument": market,
         "universe_ranking": universe,
+        "dynamic_scope": scope,
     }

--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -1,9 +1,10 @@
-"""GET /market Landscape Shell router (Phase 4.1 market/universe binding).
+"""GET /market Landscape Shell router (Phase 4.2 dynamic-scope lifecycle binding).
 
 Read-only SSR surface. No POST/PUT/PATCH/DELETE. No command endpoints.
 No execution / order / runtime-activation imports.
 Phase 4.1 binds market_instrument / universe_ranking fail-closed.
-Dynamic scope and later Phase 4 slots remain unbound.
+Phase 4.2 binds dynamic_scope lifecycle identity fail-closed (injection only).
+Regime / bull-bear / switch and later Phase 4 slots remain unbound.
 """
 
 from __future__ import annotations
@@ -40,16 +41,17 @@ def get_templates() -> Jinja2Templates:
 
 @router.get("/market", response_class=HTMLResponse, name="market_landscape_v2")
 async def market_landscape_dashboard(request: Request) -> Any:
-    """Read-only Landscape surface with Phase 4.1 market/universe binding."""
+    """Read-only Landscape surface with Phase 4.1+4.2 producer binding."""
     # Lazy import avoids circular import during create_app().
     from .app import get_project_status
 
     generated_at = datetime.now(timezone.utc)
-    phase41_slots = bind_market_universe_slots(generated_at=generated_at, git_sha=None)
+    # Observation clock only — never used as producer freshness inside binding.
+    phase_slots = bind_market_universe_slots(generated_at=generated_at, git_sha=None)
     page = _READ_SERVICE.load_page_snapshot(
         generated_at=generated_at,
         git_sha=None,
-        slot_overrides=phase41_slots,
+        slot_overrides=phase_slots,
     )
     context = present_market_landscape_v2(page)
     return get_templates().TemplateResponse(

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -49,8 +49,12 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
         owner_module="trading.master_v2.canonical_scope_initialization_v1",
         owner_symbol="CanonicalScopeLifecycleState",
         authority_class="dynamic_scope",
-        reuse_status="PROJECTION_ONLY",
-        notes="Scope authority remains Master V2; Landscape projects only.",
+        reuse_status="REUSED",
+        notes=(
+            "Phase 4.2: Landscape projects CanonicalScopeSnapshotV1 lifecycle "
+            "identity only (scope_state/current_scope_ref); Regime/Switch/"
+            "RuntimeScopeState/transition_state remain unbound."
+        ),
     ),
     CanonicalOwnerRefV1(
         slot="canonical_decision",

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -27,11 +27,23 @@ MISSING_STATE_REASON_HINTS = (
     "INVALID_PROVENANCE",
 )
 
+_NOT_BOUND_VIEW: dict[str, Any] = {
+    "availability": Availability.NOT_BOUND.value,
+    "availability_label": AVAILABILITY_LABELS[Availability.NOT_BOUND],
+}
+
 
 def _display_value(raw: Any, availability: Availability) -> str:
     if availability is not Availability.AVAILABLE or raw is None:
         return AVAILABILITY_LABELS[availability]
     return str(raw)
+
+
+def _lifecycle_fact_display(raw: Any, availability: Availability) -> str:
+    """Retain producer lifecycle facts for AVAILABLE and STALE; never invent."""
+    if availability in (Availability.AVAILABLE, Availability.STALE) and raw is not None:
+        return str(raw)
+    return AVAILABILITY_LABELS[availability]
 
 
 def _slot_view(snap: _ProjectionBase) -> dict[str, Any]:
@@ -41,6 +53,7 @@ def _slot_view(snap: _ProjectionBase) -> dict[str, Any]:
         "availability": availability.value,
         "availability_label": AVAILABILITY_LABELS[availability],
         "is_available": availability is Availability.AVAILABLE,
+        "is_stale": availability is Availability.STALE,
         "reason_codes": list(getattr(snap, "reason_codes", ()) or ()),
         "blockers": list(getattr(snap, "blockers", ()) or ()),
         "provenance": payload.get("provenance"),
@@ -124,6 +137,20 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
         )
     )
 
+    scope_lifecycle_display = _lifecycle_fact_display(
+        page.dynamic_scope.scope_state, page.dynamic_scope.availability
+    )
+    current_scope_ref_display = _lifecycle_fact_display(
+        page.dynamic_scope.current_scope_ref, page.dynamic_scope.availability
+    )
+    if page.dynamic_scope.availability in (Availability.AVAILABLE, Availability.STALE):
+        if page.dynamic_scope.next_scope_ref is None:
+            next_scope_ref_display = "—"
+        else:
+            next_scope_ref_display = str(page.dynamic_scope.next_scope_ref)
+    else:
+        next_scope_ref_display = AVAILABILITY_LABELS[page.dynamic_scope.availability]
+
     return {
         "page_schema_id": page.schema_id,
         "generated_at": page.generated_at.isoformat().replace("+00:00", "Z"),
@@ -131,16 +158,15 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
         "runtime_bridge_display": page.runtime_bridge_display,
         "shell_authority_class": page.shell_authority_class,
         "consumer_role": "read_only_consumer",
-        "phase": "PHASE_4_1_MARKET_UNIVERSE_BINDING",
+        "phase": "PHASE_4_2_DYNAMIC_SCOPE_LIFECYCLE_BINDING",
         "global_strip": {
             "instrument": instrument_display,
             "venue": _display_value(
                 page.market_instrument.venue, page.market_instrument.availability
             ),
-            "scope": _display_value(
-                page.dynamic_scope.scope_state, page.dynamic_scope.availability
-            ),
-            "regime": AVAILABILITY_LABELS[page.dynamic_scope.availability],
+            "scope": scope_lifecycle_display,
+            # Regime / bull-bear / switch stay NOT_BOUND — never mirror scope availability.
+            "regime": AVAILABILITY_LABELS[Availability.NOT_BOUND],
             "runtime_state": page.runtime_bridge_display,
             "runtime_state_class": page.shell_authority_class,
             "freshness": health.freshness.to_json_dict(),
@@ -164,7 +190,15 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
             "rank_label": ranking_label,
             "selected_instrument_id": selected_instrument_id,
         },
-        "scope": scope,
+        "scope": {
+            **scope,
+            "lifecycle_display": scope_lifecycle_display,
+            "current_scope_ref_display": current_scope_ref_display,
+            "next_scope_ref_display": next_scope_ref_display,
+        },
+        "regime": dict(_NOT_BOUND_VIEW),
+        "bull_bear": dict(_NOT_BOUND_VIEW),
+        "switch": dict(_NOT_BOUND_VIEW),
         "decision": decision,
         "double_play": double_play,
         "risk": risk,
@@ -202,6 +236,9 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
                 "market_instrument",
                 "universe_ranking",
             ],
+            "phase_4_2_bound_slots": [
+                "dynamic_scope",
+            ],
             "slots": {
                 "market_instrument": market,
                 "universe_ranking": universe,
@@ -226,6 +263,7 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
             "write_endpoints": False,
             "dashboard_authority": False,
             "phase_4_1_binding_active": True,
+            "phase_4_2_binding_active": True,
             "phase_4_full_pass": False,
             "phase_4_authorized": True,
             "operator_skeleton_approval": "PENDING",

--- a/src/webui/market_dashboard_landscape_v2/projections.py
+++ b/src/webui/market_dashboard_landscape_v2/projections.py
@@ -11,6 +11,7 @@ from .contracts import (
     SCHEMA_VERSION,
     CanonicalDecisionSnapshotV1,
     DoublePlaySnapshotV1,
+    DynamicScopeSnapshotV1,
     MarketInstrumentSnapshotV1,
     UniverseRankingSnapshotV1,
 )
@@ -147,6 +148,73 @@ def project_universe_ranking_snapshot_v1(
         ranking=ranking_rows,
         universe=universe_rows,
         selected_instrument_id=selected_instrument_id,
+        reason_codes=tuple(str(code) for code in reason_codes),
+    )
+
+
+def project_dynamic_scope_snapshot_v1(
+    *,
+    scope_state: str,
+    current_scope_ref: str,
+    reason_codes: Sequence[str],
+    generated_at: datetime,
+    effective_at: datetime | None,
+    source_reference: str | None,
+    next_scope_ref: str | None = None,
+    evidence_digest: str | None = None,
+    git_sha: str | None = None,
+    producer_module: str = "trading.master_v2.canonical_scope_initialization_v1",
+    source_kind: str = "canonical_scope_snapshot",
+    availability: Availability = Availability.AVAILABLE,
+    max_age_seconds: int | None = None,
+    is_stale: bool = False,
+    stale_reason: str | None = None,
+) -> DynamicScopeSnapshotV1:
+    """Project already-computed canonical scope lifecycle identity fields.
+
+    Forbidden: inventing lifecycle state/refs, deriving regime/bull-bear/switch,
+    calling scope initializers or switch-transition owners, or using page-assembly
+    time as producer freshness.
+    generated_at/effective_at must be producer timestamps — never page-assembly time.
+    """
+    if not scope_state:
+        raise ValueError("scope_state required for AVAILABLE/STALE projection")
+    if not current_scope_ref:
+        raise ValueError("current_scope_ref required for AVAILABLE/STALE projection")
+    if availability not in (Availability.AVAILABLE, Availability.STALE):
+        raise ValueError("project_dynamic_scope only emits AVAILABLE or STALE")
+    if availability is Availability.AVAILABLE and is_stale:
+        raise ValueError("AVAILABLE cannot be stale")
+    if availability is Availability.STALE and not is_stale:
+        raise ValueError("STALE requires is_stale=True")
+    schema_id = f"{SCHEMA_FAMILY}.dynamic_scope.{SCHEMA_VERSION}"
+    provenance = SnapshotProvenanceV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        producer_module=producer_module,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_kind=source_kind,
+        source_reference=source_reference,
+        evidence_digest=evidence_digest,
+        git_sha=git_sha,
+        availability=availability,
+    )
+    freshness = FreshnessV1(
+        observed_at=generated_at,
+        max_age_seconds=max_age_seconds,
+        is_stale=is_stale,
+        stale_reason=stale_reason,
+    )
+    return DynamicScopeSnapshotV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=freshness,
+        availability=availability,
+        scope_state=str(scope_state),
+        current_scope_ref=str(current_scope_ref),
+        next_scope_ref=None if next_scope_ref is None else str(next_scope_ref),
         reason_codes=tuple(str(code) for code in reason_codes),
     )
 

--- a/templates/peak_trade_dashboard/market_landscape_v2.html
+++ b/templates/peak_trade_dashboard/market_landscape_v2.html
@@ -4,7 +4,7 @@
 {% block main_class %}mdl-v2-main{% endblock %}
 {% block extra_head %}
 <link rel="stylesheet" href="/static/css/market_dashboard_landscape_v2.css" />
-<meta name="peak-trade-market-landscape-v2" content="phase4-1-market-universe-binding" />
+<meta name="peak-trade-market-landscape-v2" content="phase4-2-dynamic-scope-lifecycle-binding" />
 <meta name="peak-trade-dashboard-authority" content="false" />
 <meta name="peak-trade-live-authorized" content="false" />
 {% endblock %}
@@ -23,7 +23,7 @@
   data-market-dashboard-authority="false"
   data-live-authorized="false"
   data-orders="false"
-  data-phase="PHASE_4_1_MARKET_UNIVERSE_BINDING"
+  data-phase="PHASE_4_2_DYNAMIC_SCOPE_LIFECYCLE_BINDING"
   data-runtime-bridge="{{ runtime_bridge_display }}"
   aria-label="Market Dashboard Landscape V2 read-only workspace"
 >
@@ -102,9 +102,34 @@
       <aside class="mdl-v2-rail mdl-v2-rail--right" data-mdl-region="SYSTEM_CONTEXT_RAIL" aria-label="System context">
         <h2>Context</h2>
         <dl class="mdl-v2-kv">
-          <div><dt>Scope</dt><dd data-availability="{{ scope.availability }}">{{ scope.availability_label }}</dd></div>
-          <div><dt>Regime</dt><dd data-availability="{{ scope.availability }}">{{ scope.availability_label }}</dd></div>
-          <div><dt>Switch</dt><dd data-availability="{{ scope.availability }}">{{ scope.availability_label }}</dd></div>
+          <div>
+            <dt>Lifecycle</dt>
+            <dd data-mdl-field="scope_lifecycle" data-availability="{{ scope.availability }}">{{ scope.lifecycle_display }}</dd>
+          </div>
+          <div>
+            <dt>Current Scope</dt>
+            <dd data-mdl-field="current_scope_ref" data-availability="{{ scope.availability }}">{{ scope.current_scope_ref_display }}</dd>
+          </div>
+          <div>
+            <dt>Next Scope</dt>
+            <dd data-mdl-field="next_scope_ref" data-availability="{{ scope.availability }}">{{ scope.next_scope_ref_display }}</dd>
+          </div>
+          <div>
+            <dt>Scope Freshness</dt>
+            <dd data-mdl-field="scope_freshness" data-availability="{{ scope.availability }}">{{ scope.availability_label }}</dd>
+          </div>
+          <div>
+            <dt>Regime</dt>
+            <dd data-mdl-field="regime" data-availability="{{ regime.availability }}">{{ regime.availability_label }}</dd>
+          </div>
+          <div>
+            <dt>Bull/Bear</dt>
+            <dd data-mdl-field="bull_bear" data-availability="{{ bull_bear.availability }}">{{ bull_bear.availability_label }}</dd>
+          </div>
+          <div>
+            <dt>Switch</dt>
+            <dd data-mdl-field="switch" data-availability="{{ switch.availability }}">{{ switch.availability_label }}</dd>
+          </div>
           <div><dt>Source Health</dt><dd data-availability="{{ source_health.availability }}">{{ source_health.availability }}</dd></div>
         </dl>
       </aside>

--- a/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
@@ -219,10 +219,17 @@ def test_projection_helpers_are_field_copy_only() -> None:
     assert "project_canonical_decision_snapshot_v1" in proj
     assert "project_market_instrument_snapshot_v1" in proj
     assert "project_universe_ranking_snapshot_v1" in proj
-    assert "project_dynamic_scope_snapshot_v1" not in proj
+    assert "project_dynamic_scope_snapshot_v1" in proj
     assert "Forbidden" in proj
     tree = ast.parse(proj)
+    # Guard against executable references, not documentation mentions.
     for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            assert node.id not in {"transition_state", "RuntimeScopeState"}
+        if isinstance(node, ast.Attribute):
+            assert node.attr not in {"transition_state", "RuntimeScopeState"}
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id != "initialize_canonical_scope"
         if isinstance(node, ast.ImportFrom):
             assert node.level > 0 or (node.module or "").split(".", 1)[0] in {
                 "__future__",
@@ -232,6 +239,7 @@ def test_projection_helpers_are_field_copy_only() -> None:
         if isinstance(node, ast.Import):
             for alias in node.names:
                 assert alias.name.split(".", 1)[0] in {"__future__", "datetime", "typing"}
+    assert "from trading.master_v2.double_play_state" not in proj
     for module, level in _import_modules(proj_path):
         if level > 0:
             continue
@@ -245,7 +253,16 @@ def test_producer_binding_is_read_only_and_outside_landscape_package() -> None:
     assert PRODUCER_BINDING.is_file()
     text = PRODUCER_BINDING.read_text(encoding="utf-8")
     assert "bind_market_universe_slots" in text
-    assert "dynamic_scope" not in text or "Phase 4.2" in text
+    assert "Phase 4.2" in text
+    assert "project_dynamic_scope_snapshot_v1" in text
+    tree = ast.parse(text)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            assert node.id not in {"transition_state", "RuntimeScopeState"}
+        if isinstance(node, ast.Attribute):
+            assert node.attr not in {"transition_state", "RuntimeScopeState"}
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id != "initialize_canonical_scope"
     assert "@router.post" not in text
     assert "place_order" not in text
     assert "activate_runtime" not in text
@@ -256,20 +273,36 @@ def test_producer_binding_is_read_only_and_outside_landscape_package() -> None:
             continue
         for prefix in FORBIDDEN_IMPORT_PREFIXES:
             assert not (module == prefix or module.startswith(prefix + ".")), module
+        assert "double_play_state" not in module
+        assert "canonical_scope_initialization" not in module
     # Landscape package must not import the binding module (keeps contracts pure).
     for path in _iter_py_files(LANDSCAPE_PKG):
         for module, level in _import_modules(path):
             assert "market_dashboard_landscape_producer_binding_v2" not in module
 
 
-def test_shell_router_wires_phase41_binding_only() -> None:
+def test_shell_router_wires_phase41_and_phase42_binding() -> None:
     text = SHELL_ROUTER.read_text(encoding="utf-8")
     assert "bind_market_universe_slots" in text
     assert "bind_market_universe_scope_slots" not in text
-    assert "slot_overrides=phase41_slots" in text or "slot_overrides" in text
+    assert "slot_overrides" in text
+    assert "Phase 4.2" in text or "4.2" in text
+    tree = ast.parse(text)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            assert node.id not in {"transition_state", "RuntimeScopeState"}
+        if isinstance(node, ast.Attribute):
+            assert node.attr not in {"transition_state", "RuntimeScopeState"}
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id != "initialize_canonical_scope"
     assert "@router.post" not in text
     assert "workflow_dashboard_runtime_v1" not in text
     assert "execution_watch_api" not in text
+    for module, level in _import_modules(SHELL_ROUTER):
+        if level > 0:
+            continue
+        assert "canonical_scope_initialization" not in module
+        assert "double_play_state" not in module
 
 
 def test_shell_router_forbidden_import_count_zero() -> None:

--- a/tests/webui/test_market_landscape_dashboard_v2_chrome_evidence_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_chrome_evidence_v0.py
@@ -1,4 +1,4 @@
-"""Real Chrome Playwright evidence for Market Landscape V2 Phase 4.1 binding."""
+"""Real Chrome Playwright evidence for Market Landscape V2 Phase 4.2 binding."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from playwright.sync_api import sync_playwright
 from src.webui.app import create_app
 
 REPO = Path(__file__).resolve().parents[2]
-EVIDENCE_DIR = REPO / "evidence" / "market_dashboard_v2" / "phase4" / "pr3"
+EVIDENCE_DIR = REPO / "evidence" / "market_dashboard_v2" / "phase4" / "pr4"
 
 VIEWPORTS = (
     (1512, 982, "market_1512x982.png"),
@@ -99,13 +99,20 @@ def test_real_chrome_landscape_shell_viewports(tmp_path: Path) -> None:
 
                 root = page.locator('[data-market-landscape-v2="true"]')
                 assert root.count() == 1
-                assert root.get_attribute("data-phase") == "PHASE_4_1_MARKET_UNIVERSE_BINDING"
+                assert root.get_attribute("data-phase") == (
+                    "PHASE_4_2_DYNAMIC_SCOPE_LIFECYCLE_BINDING"
+                )
                 chart = page.locator("[data-mdl-chart-region='true']")
                 decision = page.locator("[data-mdl-decision-strip='true']")
                 assert chart.count() == 1
                 assert decision.count() == 1
                 assert page.locator('[data-mdl-field="selected_instrument"]').count() == 1
                 assert page.locator('[data-mdl-field="universe_membership"]').count() == 1
+                assert page.locator('[data-mdl-field="scope_lifecycle"]').count() == 1
+                assert page.locator('[data-mdl-field="current_scope_ref"]').count() == 1
+                assert page.locator('[data-mdl-field="regime"]').count() >= 1
+                assert page.locator('[data-mdl-field="bull_bear"]').count() == 1
+                assert page.locator('[data-mdl-field="switch"]').count() == 1
 
                 chart_box = chart.bounding_box()
                 decision_box = decision.bounding_box()
@@ -121,11 +128,27 @@ def test_real_chrome_landscape_shell_viewports(tmp_path: Path) -> None:
 
                 assert page.locator("form").count() == 0
                 assert page.get_by_text("NOT_BOUND").count() > 0
+                assert page.get_by_text("MISSING_SOURCE").count() > 0
                 assert page.get_by_text("BOUND_NOT_ACTIVATED").count() > 0
                 assert page.get_by_text("BTC/USD").count() == 0
                 body_text = page.locator("body").inner_text()
                 assert "place_order" not in body_text
                 assert "Submit Order" not in body_text
+                # Regime / Bull-Bear / Switch remain visibly NOT_BOUND
+                assert (
+                    page.locator('[data-mdl-field="regime"][data-availability="NOT_BOUND"]').count()
+                    >= 1
+                )
+                assert (
+                    page.locator(
+                        '[data-mdl-field="bull_bear"][data-availability="NOT_BOUND"]'
+                    ).count()
+                    == 1
+                )
+                assert (
+                    page.locator('[data-mdl-field="switch"][data-availability="NOT_BOUND"]').count()
+                    == 1
+                )
 
                 shot_path = EVIDENCE_DIR / shot_name
                 page.screenshot(path=str(shot_path), full_page=False)

--- a/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
@@ -16,13 +16,17 @@ from scripts.ops.primary_evidence_retention_v0 import (
 )
 from src.webui.market_dashboard_landscape_producer_binding_v2 import (
     LANDSCAPE_PHASE41_MAX_AGE_SECONDS,
+    LANDSCAPE_PHASE42_MAX_AGE_SECONDS,
     REASON_ARCHIVE_ROOT_UNSET,
     REASON_MARKET_CONTEXT_NOT_PERSISTED,
     REASON_PRODUCER_DATA_STALE,
     REASON_PRODUCER_TIMESTAMP_INVALID,
     REASON_PRODUCER_TIMESTAMP_MISSING,
+    REASON_SCOPE_NOT_PERSISTED,
     REASON_SELECTED_FORBIDDEN_SYMBOL,
     REASON_SOURCE_CONTRADICTION,
+    SCOPE_PRODUCER_MODULE,
+    SCOPE_SOURCE_KIND,
     bind_market_universe_slots,
     parse_producer_utc_timestamp,
 )
@@ -33,6 +37,9 @@ from src.webui.market_dashboard_landscape_v2 import (
     project_market_instrument_snapshot_v1,
     project_universe_ranking_snapshot_v1,
     serialize_projection,
+)
+from src.webui.market_dashboard_landscape_v2.projections import (
+    project_dynamic_scope_snapshot_v1,
 )
 from src.webui.workflow_dashboard_readmodel_v1.types import (
     SelectedFutureDisplayV1,
@@ -46,6 +53,8 @@ from src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1 im
 STAMP = datetime(2026, 7, 23, 18, 0, 0, tzinfo=timezone.utc)
 PRODUCER_FRESH = datetime(2026, 7, 23, 17, 0, 0, tzinfo=timezone.utc)
 PRODUCER_STALE = STAMP - timedelta(seconds=LANDSCAPE_PHASE41_MAX_AGE_SECONDS + 3600)
+SCOPE_PRODUCER_FRESH = datetime(2026, 7, 23, 16, 30, 0, tzinfo=timezone.utc)
+SCOPE_PRODUCER_STALE = STAMP - timedelta(seconds=LANDSCAPE_PHASE42_MAX_AGE_SECONDS + 7200)
 REPO = Path(__file__).resolve().parents[2]
 SCRATCH_ROOT = REPO / "tests" / "_durable_archive_scratch"
 
@@ -110,11 +119,16 @@ def test_bind_defaults_fail_closed_without_archive_or_fields(
 ) -> None:
     monkeypatch.delenv("PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT", raising=False)
     slots = bind_market_universe_slots(generated_at=STAMP)
-    assert set(slots) == {"market_instrument", "universe_ranking"}
+    assert set(slots) == {"market_instrument", "universe_ranking", "dynamic_scope"}
     assert slots["market_instrument"].availability is Availability.MISSING_SOURCE
     assert REASON_MARKET_CONTEXT_NOT_PERSISTED in slots["market_instrument"].reason_codes
     assert slots["universe_ranking"].availability is Availability.MISSING_SOURCE
     assert REASON_ARCHIVE_ROOT_UNSET in slots["universe_ranking"].reason_codes
+    assert slots["dynamic_scope"].availability is Availability.MISSING_SOURCE
+    assert REASON_SCOPE_NOT_PERSISTED in slots["dynamic_scope"].reason_codes
+    assert slots["dynamic_scope"].scope_state is None
+    assert slots["dynamic_scope"].current_scope_ref is None
+    assert slots["dynamic_scope"].next_scope_ref is None
 
 
 def test_bind_rejects_inventing_market_without_required_fields() -> None:
@@ -394,7 +408,7 @@ def test_missing_ranking_and_selected_still_fail_closed(archive_root: Path) -> N
     assert slots2["market_instrument"].availability is Availability.MISSING_SOURCE
 
 
-def test_page_aggregate_applies_phase41_without_touching_decision_or_scope() -> None:
+def test_page_aggregate_applies_phase41_and_phase42_scope_missing_without_injection() -> None:
     slots = bind_market_universe_slots(
         generated_at=STAMP,
         market_instrument_fields={
@@ -412,10 +426,141 @@ def test_page_aggregate_applies_phase41_without_touching_decision_or_scope() -> 
         slot_overrides=slots,
     )
     assert page.market_instrument.availability is Availability.AVAILABLE
-    assert page.dynamic_scope.availability is Availability.NOT_BOUND
+    assert page.dynamic_scope.availability is Availability.MISSING_SOURCE
+    assert REASON_SCOPE_NOT_PERSISTED in page.dynamic_scope.reason_codes
     assert page.canonical_decision.availability is Availability.NOT_BOUND
     ctx = present_market_landscape_v2(page)
-    assert ctx["phase"] == "PHASE_4_1_MARKET_UNIVERSE_BINDING"
+    assert ctx["phase"] == "PHASE_4_2_DYNAMIC_SCOPE_LIFECYCLE_BINDING"
     assert ctx["chart"]["ohlcv"] is None
-    assert ctx["scope"]["availability"] == "NOT_BOUND"
+    assert ctx["scope"]["availability"] == "MISSING_SOURCE"
+    assert ctx["regime"]["availability"] == "NOT_BOUND"
+    assert ctx["bull_bear"]["availability"] == "NOT_BOUND"
+    assert ctx["switch"]["availability"] == "NOT_BOUND"
     assert "membership_label" in ctx["universe_rail"]
+
+
+def _scope_fields(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "lifecycle_state": "scope_valid",
+        "scope_id": "scope-btc-1",
+        "reason_codes": ("SCOPE_INITIALIZED",),
+        "generated_at": SCOPE_PRODUCER_FRESH,
+        "effective_at": SCOPE_PRODUCER_FRESH,
+        "semantic_digest": "a" * 64,
+        "source_reference": "scope://btc-1",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_project_dynamic_scope_field_copy_immutable() -> None:
+    snap = project_dynamic_scope_snapshot_v1(
+        scope_state="scope_valid",
+        current_scope_ref="scope-btc-1",
+        next_scope_ref="scope-btc-2",
+        reason_codes=("SCOPE_INITIALIZED",),
+        generated_at=SCOPE_PRODUCER_FRESH,
+        effective_at=SCOPE_PRODUCER_FRESH,
+        source_reference="scope://btc-1",
+        evidence_digest="b" * 64,
+    )
+    assert snap.availability is Availability.AVAILABLE
+    assert snap.scope_state == "scope_valid"
+    assert snap.current_scope_ref == "scope-btc-1"
+    assert snap.next_scope_ref == "scope-btc-2"
+    assert snap.provenance.producer_module == SCOPE_PRODUCER_MODULE
+    assert snap.provenance.source_kind == SCOPE_SOURCE_KIND
+    assert snap.provenance.generated_at == SCOPE_PRODUCER_FRESH
+    with pytest.raises(FrozenInstanceError):
+        snap.scope_state = "x"  # type: ignore[misc]
+
+
+def test_bind_dynamic_scope_available_exact_projection() -> None:
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        dynamic_scope_fields=_scope_fields(next_scope_ref="scope-btc-2"),
+    )
+    scope = slots["dynamic_scope"]
+    assert scope.availability is Availability.AVAILABLE
+    assert scope.scope_state == "scope_valid"
+    assert scope.current_scope_ref == "scope-btc-1"
+    assert scope.next_scope_ref == "scope-btc-2"
+    assert scope.reason_codes == ("SCOPE_INITIALIZED",)
+    assert scope.provenance.producer_module == SCOPE_PRODUCER_MODULE
+    assert scope.provenance.source_kind == SCOPE_SOURCE_KIND
+    assert scope.provenance.evidence_digest == "a" * 64
+    assert scope.provenance.generated_at == SCOPE_PRODUCER_FRESH
+    assert scope.provenance.effective_at == SCOPE_PRODUCER_FRESH
+    assert scope.freshness.observed_at == SCOPE_PRODUCER_FRESH
+    assert scope.freshness.is_stale is False
+
+
+def test_bind_dynamic_scope_null_next_scope_not_invented() -> None:
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        dynamic_scope_fields=_scope_fields(),
+    )
+    assert slots["dynamic_scope"].next_scope_ref is None
+    slots2 = bind_market_universe_slots(
+        generated_at=STAMP,
+        dynamic_scope_fields=_scope_fields(next_scope_ref=None),
+    )
+    assert slots2["dynamic_scope"].next_scope_ref is None
+
+
+def test_bind_dynamic_scope_invalid_naive_timestamp() -> None:
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        dynamic_scope_fields=_scope_fields(
+            generated_at=datetime(2026, 7, 23, 16, 30, 0),  # naive
+            effective_at=None,
+        ),
+    )
+    scope = slots["dynamic_scope"]
+    assert scope.availability is Availability.INVALID
+    assert REASON_PRODUCER_TIMESTAMP_INVALID in scope.reason_codes
+    assert scope.scope_state is None
+    assert scope.provenance.generated_at == STAMP  # observation stamp on unavailable only
+
+
+def test_bind_dynamic_scope_stale_retains_lifecycle_facts() -> None:
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        dynamic_scope_fields=_scope_fields(
+            generated_at=SCOPE_PRODUCER_STALE,
+            effective_at=SCOPE_PRODUCER_STALE,
+            next_scope_ref="scope-next",
+        ),
+    )
+    scope = slots["dynamic_scope"]
+    assert scope.availability is Availability.STALE
+    assert scope.scope_state == "scope_valid"
+    assert scope.current_scope_ref == "scope-btc-1"
+    assert scope.next_scope_ref == "scope-next"
+    assert scope.reason_codes == ("SCOPE_INITIALIZED",)
+    assert scope.freshness.is_stale is True
+    assert scope.freshness.stale_reason == REASON_PRODUCER_DATA_STALE
+    assert scope.provenance.generated_at == SCOPE_PRODUCER_STALE
+
+
+def test_regime_bull_bear_switch_remain_not_bound_for_all_scope_states() -> None:
+    cases = (
+        None,
+        _scope_fields(),
+        _scope_fields(generated_at=SCOPE_PRODUCER_STALE, effective_at=SCOPE_PRODUCER_STALE),
+        _scope_fields(generated_at=datetime(2026, 7, 23, 16, 30, 0)),
+    )
+    for fields in cases:
+        slots = bind_market_universe_slots(
+            generated_at=STAMP,
+            dynamic_scope_fields=fields,
+        )
+        page = MarketDashboardReadServiceV1().load_page_snapshot(
+            generated_at=STAMP,
+            slot_overrides=slots,
+        )
+        ctx = present_market_landscape_v2(page)
+        assert ctx["regime"]["availability"] == "NOT_BOUND"
+        assert ctx["bull_bear"]["availability"] == "NOT_BOUND"
+        assert ctx["switch"]["availability"] == "NOT_BOUND"
+        assert ctx["global_strip"]["regime"] == "NOT_BOUND"

--- a/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
@@ -53,7 +53,7 @@ def test_get_market_returns_200_with_landmarks(client: TestClient) -> None:
     assert 'data-market-landscape-v2="true"' in html
     for landmark in LANDMARKS:
         assert landmark in html, landmark
-    assert "PHASE_4_1_MARKET_UNIVERSE_BINDING" in html
+    assert "PHASE_4_2_DYNAMIC_SCOPE_LIFECYCLE_BINDING" in html
     assert "BOUND_NOT_ACTIVATED" in html
     assert "no ohlcv fabricated" in html.lower()
     assert "BTC/USD" not in html
@@ -62,8 +62,14 @@ def test_get_market_returns_200_with_landmarks(client: TestClient) -> None:
     assert "mdl-v2-ops" in html
     assert 'data-mdl-field="selected_instrument"' in html
     assert 'data-mdl-field="universe_membership"' in html
-    # Decision / scope remain unbound in Phase 4.1
+    assert 'data-mdl-field="scope_lifecycle"' in html
+    assert 'data-mdl-field="current_scope_ref"' in html
+    assert 'data-mdl-field="regime"' in html
+    assert 'data-mdl-field="bull_bear"' in html
+    assert 'data-mdl-field="switch"' in html
+    # Decision remains unbound; Regime/Bull-Bear/Switch stay NOT_BOUND
     assert "NOT_BOUND" in html
+    assert "MISSING_SOURCE" in html
     assert "OPERATOR_SKELETON_APPROVAL" not in html
 
 
@@ -117,13 +123,17 @@ def test_presenter_formats_only_no_authority_defaults() -> None:
     assert ctx["product_flags"]["live_authorized"] is False
     assert ctx["product_flags"]["write_endpoints"] is False
     assert ctx["product_flags"]["phase_4_1_binding_active"] is True
+    assert ctx["product_flags"]["phase_4_2_binding_active"] is True
     assert ctx["chart"]["ohlcv"] is None
     assert ctx["decision"]["availability_label"] == "NOT_BOUND"
     assert ctx["global_strip"]["instrument"] == "NOT_BOUND"
+    assert ctx["regime"]["availability"] == "NOT_BOUND"
+    assert ctx["bull_bear"]["availability"] == "NOT_BOUND"
+    assert ctx["switch"]["availability"] == "NOT_BOUND"
     # Must not invent HOLD/FLAT
     assert ctx["decision"]["fields"]["decision"] is None
     assert ctx["decision"]["fields"]["direction"] is None
-    assert ctx["phase"] == "PHASE_4_1_MARKET_UNIVERSE_BINDING"
+    assert ctx["phase"] == "PHASE_4_2_DYNAMIC_SCOPE_LIFECYCLE_BINDING"
 
 
 def test_shell_assets_exist() -> None:


### PR DESCRIPTION
## Summary
- Phase 4.2 lifecycle projection only: bind `CanonicalScopeSnapshotV1` / `CanonicalScopeLifecycleState` identity into existing `DynamicScopeSnapshotV1` via the Phase 4.1 read-only producer-binding seam.
- Canonical producer family: `trading.master_v2.canonical_scope_initialization_v1` (`CanonicalScopeSnapshotV1`, `CanonicalScopeLifecycleState`, `CanonicalScopeInitializationResultV1`).
- Visible facts: `scope_state`, `current_scope_ref`, producer-supplied `next_scope_ref` (or null), exact `reason_codes`, producer provenance (`source_kind=canonical_scope_snapshot`), producer-timestamp freshness (`AVAILABLE` / `STALE` / `MISSING_SOURCE` / `INVALID`).
- Fail-closed: no injected lifecycle fields → `MISSING_SOURCE` (`CANONICAL_SCOPE_SNAPSHOT_NOT_PERSISTED_FOR_DASHBOARD`); invalid/naive timestamps → `INVALID`; aged timestamps → `STALE` with facts retained.
- Regime / Bull-Bear / Switch explicitly remain `NOT_BOUND` and do not mirror Dynamic Scope availability.
- No `RuntimeScopeState`, `transition_state`, Core/Runtime/Strategy changes, write path, durable dashboard scope readmodel, or second Dynamic Scope truth owner.
- Known unrelated dirty/untracked operator files were preserved and not staged.

## Test plan
- [x] `tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py` (AVAILABLE / null next / MISSING_SOURCE / INVALID / STALE / Regime isolation + Phase 4.1 regression)
- [x] `tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py`
- [x] `tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py`
- [x] Real Chrome Playwright `tests/webui/test_market_landscape_dashboard_v2_chrome_evidence_v0.py` (1512x982, 1920x1080; console errors = 0)
- [x] `ruff format --check` + `ruff check` on changed slice files
- [ ] GitHub CI confirmation (no auto-merge)


Made with [Cursor](https://cursor.com)