### PR TITLE
Market Dashboard: bind economic evidence by explicit injection

### DIFF
--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -1,8 +1,9 @@
-"""Phase 4.1 + 4.2 + 4.3A + 4.3B + 4.4A read-only producer binding for Market Landscape V2.
+"""Phase 4.1 + 4.2 + 4.3A + 4.3B + 4.4A + 4.6B read-only producer binding for Market Landscape V2.
 
 Binds market_instrument, universe_ranking, dynamic_scope lifecycle identity,
-canonical_decision evidence, double_play display projection, and safety
-authority KillSwitch/boundary field projection.
+canonical_decision evidence, double_play display projection, safety
+authority KillSwitch/boundary field projection, and economic summary
+EconomicViabilityEvidenceV1 field projection.
 Regime / bull-bear / switch remain unbound.
 Lives outside market_dashboard_landscape_v2 so that package stays free of
 trading/webui producer imports (architecture guard).
@@ -12,11 +13,15 @@ Fail-closed:
 - Producer timestamps preserved; page-assembly time is observation-only
 - Aged producer snapshots → STALE (never silently refreshed)
 - Never fabricate OHLCV, ranking, eligibility, selected instrument, scope,
-  decisions, Double Play composition, or Safety/KillSwitch state
+  decisions, Double Play composition, Safety/KillSwitch state, or economic
+  metrics/status
 - Never call scope initializers, trailing-scope runtime owners, switch owners,
   decision producers, compose_double_play_decision, or build_dashboard_display_snapshot
 - Never instantiate KillSwitch, call trigger/recover, evaluate_offline_killswitch_boundary_v0,
   or any bind_* Safety evaluator; no live state-file autoload
+- Never discover/select EconomicViabilityEvidenceV1 instances (no filesystem,
+  registry, latest-file, or environment selector)
+- Never bind promotion_economic_gate_v1 or infer lifecycle labels
 - No risk / capital / sizing / execution binding
 """
 
@@ -33,6 +38,7 @@ from .market_dashboard_landscape_v2.projections import (
     project_canonical_decision_snapshot_v1,
     project_double_play_snapshot_v1,
     project_dynamic_scope_snapshot_v1,
+    project_economic_summary_snapshot_v1,
     project_market_instrument_snapshot_v1,
     project_safety_authority_snapshot_v1,
     project_universe_ranking_snapshot_v1,
@@ -41,6 +47,7 @@ from .market_dashboard_landscape_v2.unavailable import (
     unavailable_canonical_decision,
     unavailable_double_play,
     unavailable_dynamic_scope,
+    unavailable_economic_summary,
     unavailable_market_instrument,
     unavailable_safety_authority,
     unavailable_universe_ranking,
@@ -62,12 +69,14 @@ LANDSCAPE_PHASE42_MAX_AGE_SECONDS = LANDSCAPE_PHASE41_MAX_AGE_SECONDS
 LANDSCAPE_PHASE43A_MAX_AGE_SECONDS = LANDSCAPE_PHASE41_MAX_AGE_SECONDS
 LANDSCAPE_PHASE43B_MAX_AGE_SECONDS = LANDSCAPE_PHASE41_MAX_AGE_SECONDS
 LANDSCAPE_PHASE44A_MAX_AGE_SECONDS = LANDSCAPE_PHASE41_MAX_AGE_SECONDS
+LANDSCAPE_PHASE46B_MAX_AGE_SECONDS = LANDSCAPE_PHASE41_MAX_AGE_SECONDS
 
 REASON_MARKET_CONTEXT_NOT_PERSISTED = "CANONICAL_MARKET_CONTEXT_NOT_PERSISTED_FOR_DASHBOARD"
 REASON_SCOPE_NOT_PERSISTED = "CANONICAL_SCOPE_SNAPSHOT_NOT_PERSISTED_FOR_DASHBOARD"
 REASON_DECISION_NOT_PERSISTED = "CANONICAL_DECISION_EVIDENCE_NOT_PERSISTED_FOR_DASHBOARD"
 REASON_DOUBLE_PLAY_NOT_PERSISTED = "CANONICAL_DOUBLE_PLAY_DISPLAY_NOT_PERSISTED_FOR_DASHBOARD"
 REASON_SAFETY_NOT_PERSISTED = "CANONICAL_SAFETY_AUTHORITY_NOT_PERSISTED_FOR_DASHBOARD"
+REASON_ECONOMIC_NOT_PERSISTED = "CANONICAL_ECONOMIC_EVIDENCE_NOT_PERSISTED_FOR_DASHBOARD"
 REASON_UNIVERSE_ABSENT = "UNIVERSE_SELECTION_READMODEL_ABSENT"
 REASON_ARCHIVE_ROOT_UNSET = "UNIVERSE_ARCHIVE_ROOT_UNSET"
 REASON_SELECTED_FORBIDDEN_SYMBOL = "SELECTED_INSTRUMENT_FORBIDDEN_BTC_USD_OR_SPOT_DUMMY"
@@ -91,6 +100,9 @@ SAFETY_EVIDENCE_PRODUCER_MODULE = (
     "trading.master_v2.killswitch_boundary_offline_replay_binding_adapter_v0"
 )
 SAFETY_SOURCE_KIND = "killswitch_boundary_offline_replay_boundary"
+ECONOMIC_PRODUCER_MODULE = "backtest.economic_viability_evidence_v1"
+ECONOMIC_SOURCE_KIND = "economic_viability_evidence_v1"
+ECONOMIC_CONTRACT_SCHEMA_VERSION = "v1"
 
 PHASE_4_1_BOUND_SLOTS: tuple[str, ...] = (
     "market_instrument",
@@ -100,6 +112,7 @@ PHASE_4_2_BOUND_SLOTS: tuple[str, ...] = ("dynamic_scope",)
 PHASE_4_3A_BOUND_SLOTS: tuple[str, ...] = ("canonical_decision",)
 PHASE_4_3B_BOUND_SLOTS: tuple[str, ...] = ("double_play",)
 PHASE_4_4A_BOUND_SLOTS: tuple[str, ...] = ("safety_authority",)
+PHASE_4_6B_BOUND_SLOTS: tuple[str, ...] = ("economic_summary",)
 
 _ISO8601_UTC_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|\+00:00)$")
 
@@ -947,6 +960,279 @@ def _bind_safety_authority(
     )
 
 
+def _metric_mapping(raw: Any) -> dict[str, Any]:
+    """Copy MetricFieldV1.to_dict() shape or an already-projected mapping."""
+    if hasattr(raw, "to_dict") and callable(raw.to_dict):
+        return dict(raw.to_dict())
+    if isinstance(raw, Mapping):
+        return dict(raw)
+    raise TypeError("metric fields must be MetricFieldV1 or Mapping")
+
+
+def economic_viability_evidence_fields_from_v1(
+    evidence: Any,
+    *,
+    generated_at: datetime,
+    source_reference: str | None = None,
+) -> dict[str, Any]:
+    """Extract direct EconomicViabilityEvidenceV1 fields for injection.
+
+    Does not recompute metrics, apply thresholds, or invent lifecycle/promotion.
+    ``generated_at`` is supplied by the upstream injector (not fabricated here).
+    """
+    from src.backtest.economic_viability_evidence_v1 import EconomicViabilityEvidenceV1
+
+    if not isinstance(evidence, EconomicViabilityEvidenceV1):
+        raise TypeError("evidence must be EconomicViabilityEvidenceV1")
+    status = evidence.status
+    status_value = status.value if hasattr(status, "value") else str(status)
+    return {
+        "status": status_value,
+        "economic_validity_proven": evidence.economic_validity_proven,
+        "profitability_claim_allowed": evidence.profitability_claim_allowed,
+        "policy_threshold_status": evidence.policy_threshold_status,
+        "policy_version": evidence.policy_version,
+        "authority_effect": evidence.authority_effect,
+        "runtime_effect": evidence.runtime_effect,
+        "order_effect": evidence.order_effect,
+        "reason_codes": tuple(evidence.reason_codes),
+        "profit_factor": _metric_mapping(evidence.profit_factor),
+        "net_return": _metric_mapping(evidence.net_return),
+        "max_drawdown": _metric_mapping(evidence.max_drawdown),
+        "sharpe": _metric_mapping(evidence.sharpe),
+        "trade_count": _metric_mapping(evidence.trade_count),
+        "funding_drag": _metric_mapping(evidence.funding_drag),
+        "contract_version": evidence.contract_version,
+        "owner": evidence.owner,
+        "strategy_id": evidence.strategy_id,
+        "strategy_version": evidence.strategy_version,
+        "config_digest": evidence.config_digest,
+        "implementation_digest": evidence.implementation_digest,
+        "data_digest": evidence.data_digest,
+        "manifest_digest": evidence.manifest_digest,
+        "wiring_chain_digest": evidence.wiring_chain_digest,
+        "policy_digest": evidence.policy_digest,
+        "generated_at": generated_at,
+        "source_reference": source_reference,
+        "evidence_digest": evidence.manifest_digest,
+    }
+
+
+def project_economic_viability_evidence_v1(
+    evidence: Any,
+    *,
+    generated_at: datetime,
+    as_of: datetime | None = None,
+    git_sha: str | None = None,
+    source_reference: str | None = None,
+) -> Any:
+    """Pure field-for-field projection of one injected EconomicViabilityEvidenceV1.
+
+    No I/O, no selector, no promotion/lifecycle inference, no metric recomputation.
+    """
+    fields = economic_viability_evidence_fields_from_v1(
+        evidence,
+        generated_at=generated_at,
+        source_reference=source_reference,
+    )
+    stamp = generated_at if as_of is None else as_of
+    if stamp.tzinfo is None:
+        raise ValueError("as_of/generated_at must be timezone-aware")
+    return _bind_economic_summary(
+        as_of=stamp.astimezone(timezone.utc),
+        git_sha=git_sha,
+        economic_viability_evidence_fields=fields,
+    )
+
+
+def _bind_economic_summary(
+    *,
+    as_of: datetime,
+    git_sha: str | None,
+    economic_viability_evidence_fields: Mapping[str, Any] | None,
+) -> Any:
+    """Project injected EconomicViabilityEvidenceV1-compatible fields.
+
+    No durable dashboard economic readmodel. Without injection → MISSING_SOURCE.
+    Never discovers evidence files, never binds promotion_economic_gate_v1,
+    and never infers DEVELOPMENT/HOLDOUT/SEALED from paths.
+    """
+    if economic_viability_evidence_fields is None:
+        return unavailable_economic_summary(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=as_of,
+            reason=REASON_ECONOMIC_NOT_PERSISTED,
+        )
+
+    required = (
+        "status",
+        "economic_validity_proven",
+        "profitability_claim_allowed",
+        "policy_threshold_status",
+        "policy_version",
+        "authority_effect",
+        "runtime_effect",
+        "order_effect",
+        "profit_factor",
+        "net_return",
+        "max_drawdown",
+        "sharpe",
+        "trade_count",
+        "funding_drag",
+        "contract_version",
+        "owner",
+        "strategy_id",
+        "strategy_version",
+        "config_digest",
+        "implementation_digest",
+        "data_digest",
+        "manifest_digest",
+        "wiring_chain_digest",
+        "policy_digest",
+    )
+    missing = [key for key in required if key not in economic_viability_evidence_fields]
+    if missing:
+        raise KeyError(f"economic_viability_evidence_fields missing required keys: {missing}")
+
+    status_raw = economic_viability_evidence_fields["status"]
+    economic_viability_status = (
+        status_raw.value if hasattr(status_raw, "value") else str(status_raw)
+    )
+    if not economic_viability_status:
+        return unavailable_economic_summary(
+            availability=Availability.INVALID,
+            generated_at=as_of,
+            reason="CANONICAL_ECONOMIC_STATUS_EMPTY",
+        )
+
+    economic_validity_proven = economic_viability_evidence_fields["economic_validity_proven"]
+    profitability_claim_allowed = economic_viability_evidence_fields["profitability_claim_allowed"]
+    runtime_effect = economic_viability_evidence_fields["runtime_effect"]
+    order_effect = economic_viability_evidence_fields["order_effect"]
+    if not isinstance(economic_validity_proven, bool):
+        return unavailable_economic_summary(
+            availability=Availability.INVALID,
+            generated_at=as_of,
+            reason="CANONICAL_ECONOMIC_VALIDITY_PROVEN_INVALID",
+        )
+    if not isinstance(profitability_claim_allowed, bool):
+        return unavailable_economic_summary(
+            availability=Availability.INVALID,
+            generated_at=as_of,
+            reason="CANONICAL_ECONOMIC_PROFITABILITY_CLAIM_INVALID",
+        )
+    if not isinstance(runtime_effect, bool) or not isinstance(order_effect, bool):
+        return unavailable_economic_summary(
+            availability=Availability.INVALID,
+            generated_at=as_of,
+            reason="CANONICAL_ECONOMIC_EFFECT_FLAGS_INVALID",
+        )
+
+    generated_at_raw = economic_viability_evidence_fields.get("generated_at")
+    producer_at, gen_error = _resolve_injected_aware_timestamp(generated_at_raw)
+    if gen_error is not None:
+        return unavailable_economic_summary(
+            availability=Availability.INVALID,
+            generated_at=as_of,
+            reason=gen_error,
+        )
+    if producer_at is None:
+        return unavailable_economic_summary(
+            availability=Availability.MISSING_SOURCE,
+            generated_at=as_of,
+            reason=REASON_PRODUCER_TIMESTAMP_MISSING,
+        )
+
+    effective_at: datetime | None = None
+    if "effective_at" in economic_viability_evidence_fields:
+        effective_at, eff_error = _resolve_injected_aware_timestamp(
+            economic_viability_evidence_fields.get("effective_at")
+        )
+        if eff_error is not None:
+            return unavailable_economic_summary(
+                availability=Availability.INVALID,
+                generated_at=as_of,
+                reason=eff_error,
+            )
+
+    try:
+        availability, is_stale, stale_reason = classify_producer_freshness(
+            producer_at=producer_at,
+            as_of=as_of,
+            max_age_seconds=LANDSCAPE_PHASE46B_MAX_AGE_SECONDS,
+        )
+    except ValueError:
+        return unavailable_economic_summary(
+            availability=Availability.INVALID,
+            generated_at=as_of,
+            reason=REASON_PRODUCER_TIMESTAMP_INVALID,
+        )
+
+    raw_reasons = economic_viability_evidence_fields.get("reason_codes", ()) or ()
+    reason_codes = tuple(str(code) for code in raw_reasons)
+
+    evidence_digest = economic_viability_evidence_fields.get("evidence_digest")
+    if evidence_digest is None:
+        evidence_digest = economic_viability_evidence_fields.get("manifest_digest")
+    if evidence_digest is not None:
+        evidence_digest = str(evidence_digest)
+        if not evidence_digest:
+            evidence_digest = None
+
+    source_reference = economic_viability_evidence_fields.get("source_reference")
+    if source_reference is not None:
+        source_reference = str(source_reference)
+
+    evidence_ref = economic_viability_evidence_fields.get("evidence_ref")
+    if evidence_ref is not None:
+        evidence_ref = str(evidence_ref)
+
+    producer_module = str(
+        economic_viability_evidence_fields.get("producer_module", ECONOMIC_PRODUCER_MODULE)
+    )
+    source_kind = str(economic_viability_evidence_fields.get("source_kind", ECONOMIC_SOURCE_KIND))
+
+    return project_economic_summary_snapshot_v1(
+        economic_viability_status=economic_viability_status,
+        economic_validity_proven=economic_validity_proven,
+        profitability_claim_allowed=profitability_claim_allowed,
+        policy_threshold_status=str(economic_viability_evidence_fields["policy_threshold_status"]),
+        policy_version=str(economic_viability_evidence_fields["policy_version"]),
+        authority_effect=str(economic_viability_evidence_fields["authority_effect"]),
+        runtime_effect=runtime_effect,
+        order_effect=order_effect,
+        reason_codes=reason_codes,
+        profit_factor=_metric_mapping(economic_viability_evidence_fields["profit_factor"]),
+        net_return=_metric_mapping(economic_viability_evidence_fields["net_return"]),
+        max_drawdown=_metric_mapping(economic_viability_evidence_fields["max_drawdown"]),
+        sharpe=_metric_mapping(economic_viability_evidence_fields["sharpe"]),
+        trade_count=_metric_mapping(economic_viability_evidence_fields["trade_count"]),
+        funding_drag=_metric_mapping(economic_viability_evidence_fields["funding_drag"]),
+        contract_version=str(economic_viability_evidence_fields["contract_version"]),
+        owner=str(economic_viability_evidence_fields["owner"]),
+        strategy_id=str(economic_viability_evidence_fields["strategy_id"]),
+        strategy_version=str(economic_viability_evidence_fields["strategy_version"]),
+        config_digest=str(economic_viability_evidence_fields["config_digest"]),
+        implementation_digest=str(economic_viability_evidence_fields["implementation_digest"]),
+        data_digest=str(economic_viability_evidence_fields["data_digest"]),
+        manifest_digest=str(economic_viability_evidence_fields["manifest_digest"]),
+        wiring_chain_digest=str(economic_viability_evidence_fields["wiring_chain_digest"]),
+        policy_digest=str(economic_viability_evidence_fields["policy_digest"]),
+        generated_at=producer_at,
+        effective_at=effective_at,
+        source_reference=source_reference,
+        evidence_ref=evidence_ref,
+        evidence_digest=evidence_digest,
+        git_sha=git_sha,
+        producer_module=producer_module,
+        source_kind=source_kind,
+        availability=availability,
+        max_age_seconds=LANDSCAPE_PHASE46B_MAX_AGE_SECONDS,
+        is_stale=is_stale,
+        stale_reason=stale_reason,
+    )
+
+
 def bind_market_universe_slots(
     *,
     generated_at: datetime,
@@ -957,8 +1243,9 @@ def bind_market_universe_slots(
     canonical_decision_fields: Mapping[str, Any] | None = None,
     double_play_fields: Mapping[str, Any] | None = None,
     safety_authority_fields: Mapping[str, Any] | None = None,
+    economic_viability_evidence_fields: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Return Phase 4.1+4.2+4.3A+4.3B+4.4A slot overrides.
+    """Return Phase 4.1+4.2+4.3A+4.3B+4.4A+4.6B slot overrides.
 
     ``generated_at`` is the dashboard observation/as-of clock only. It must never
     overwrite producer provenance timestamps or fabricate freshness.
@@ -985,6 +1272,11 @@ def bind_market_universe_slots(
     compatible fields (kill_switch_state, veto_active, reason_codes) plus
     producer wall-clock timestamps. Without injection, safety_authority is
     MISSING_SOURCE. Never calls KillSwitch.trigger/recover or offline evaluators.
+
+    economic_viability_evidence_fields accepts already-selected
+    EconomicViabilityEvidenceV1-compatible fields plus producer wall-clock
+    timestamps. Without injection, economic_summary is MISSING_SOURCE.
+    Never discovers evidence artifacts or binds promotion_economic_gate_v1.
     """
     if generated_at.tzinfo is None:
         raise ValueError("generated_at must be timezone-aware")
@@ -1015,6 +1307,11 @@ def bind_market_universe_slots(
         as_of=as_of,
         git_sha=git_sha,
         safety_authority_fields=safety_authority_fields,
+    )
+    economic = _bind_economic_summary(
+        as_of=as_of,
+        git_sha=git_sha,
+        economic_viability_evidence_fields=economic_viability_evidence_fields,
     )
 
     if market_instrument_fields is not None:
@@ -1152,4 +1449,5 @@ def bind_market_universe_slots(
         "canonical_decision": decision,
         "double_play": double_play,
         "safety_authority": safety,
+        "economic_summary": economic,
     }

--- a/src/webui/market_dashboard_landscape_v2/__init__.py
+++ b/src/webui/market_dashboard_landscape_v2/__init__.py
@@ -37,6 +37,7 @@ from .presenter import present_market_landscape_v2
 from .projections import (
     project_canonical_decision_snapshot_v1,
     project_double_play_snapshot_v1,
+    project_economic_summary_snapshot_v1,
     project_market_instrument_snapshot_v1,
     project_universe_ranking_snapshot_v1,
 )
@@ -87,6 +88,7 @@ __all__ = [
     "present_market_landscape_v2",
     "project_canonical_decision_snapshot_v1",
     "project_double_play_snapshot_v1",
+    "project_economic_summary_snapshot_v1",
     "project_market_instrument_snapshot_v1",
     "project_universe_ranking_snapshot_v1",
     "serialize_projection",

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -119,16 +119,15 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
         owner_module="backtest.economic_viability_evidence_v1",
         owner_symbol="EconomicViabilityEvidenceV1",
         authority_class="economic_evidence",
-        reuse_status="NOT_BOUND",
+        reuse_status="REUSED",
         notes=(
-            "Phase 4.6A: EconomicSummarySnapshotV1 ratified as minimal direct "
-            "projection of EconomicViabilityEvidenceV1; status field is "
-            "economic_viability_status (exact EVI.status enum; economic_gate_status "
-            "forbidden for this value); promotion_economic_gate_v1 remains a "
-            "separate owner; selector policy=EXPLICIT_UPSTREAM_INJECTION_ONLY "
-            "(zero→NOT_BOUND; one→field-for-field; many→INVALID/"
-            "AMBIGUOUS_ECONOMIC_EVIDENCE_SOURCE); lifecycle context ABSENT; "
-            "binding deferred to Phase 4.6B."
+            "Phase 4.6B: Landscape projects injected EconomicViabilityEvidenceV1 "
+            "field-for-field (economic_viability_status=status enum value; "
+            "economic_validity_proven/policy_threshold_status/metrics/digests); "
+            "AUTHORITY_EFFECT=NONE; explicit injection only; without injection "
+            "MISSING_SOURCE; no filesystem/registry/latest selector; "
+            "promotion_economic_gate_v1 remains a separate owner; lifecycle "
+            "labels ABSENT (not inferred)."
         ),
     ),
     CanonicalOwnerRefV1(

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -90,6 +90,16 @@ def _safety_strip_display(page: MarketDashboardPageSnapshotV1) -> str:
     return " · ".join(parts)
 
 
+def _economic_status_display(page: MarketDashboardPageSnapshotV1) -> str:
+    """Format economic viability status from exact projected fields only."""
+    snap = page.economic_summary
+    if snap.availability not in (Availability.AVAILABLE, Availability.STALE):
+        return AVAILABILITY_LABELS[snap.availability]
+    if snap.economic_viability_status is not None:
+        return str(snap.economic_viability_status)
+    return AVAILABILITY_LABELS[snap.availability]
+
+
 def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str, Any]:
     """Format page snapshot for SSR template context (presentation only)."""
     market = _slot_view(page.market_instrument)
@@ -166,6 +176,8 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
     else:
         next_scope_ref_display = AVAILABILITY_LABELS[page.dynamic_scope.availability]
 
+    economic_status_display = _economic_status_display(page)
+
     return {
         "page_schema_id": page.schema_id,
         "generated_at": page.generated_at.isoformat().replace("+00:00", "Z"),
@@ -173,7 +185,7 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
         "runtime_bridge_display": page.runtime_bridge_display,
         "shell_authority_class": page.shell_authority_class,
         "consumer_role": "read_only_consumer",
-        "phase": "PHASE_4_4A_CANONICAL_SAFETY_PROJECTION_BINDING",
+        "phase": "PHASE_4_6B_ECONOMIC_EVIDENCE_EXPLICIT_INJECTION_BINDING",
         "global_strip": {
             "instrument": instrument_display,
             "venue": _display_value(
@@ -217,7 +229,10 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
         "risk": risk,
         "safety": safety,
         "execution": execution,
-        "economic": economic,
+        "economic": {
+            **economic,
+            "status_display": economic_status_display,
+        },
         "autonomy": autonomy,
         "diagnostics": diagnostics,
         "source_health": {
@@ -261,6 +276,9 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
             "phase_4_4a_bound_slots": [
                 "safety_authority",
             ],
+            "phase_4_6b_bound_slots": [
+                "economic_summary",
+            ],
             "slots": {
                 "market_instrument": market,
                 "universe_ranking": universe,
@@ -270,7 +288,10 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
                 "risk_sizing_capital": risk,
                 "safety_authority": safety,
                 "execution_reconciliation": execution,
-                "economic_summary": economic,
+                "economic_summary": {
+                    **economic,
+                    "status_display": economic_status_display,
+                },
                 "autonomy_stage": autonomy,
                 "diagnostics_summary": diagnostics,
             },
@@ -289,6 +310,7 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
             "phase_4_3a_binding_active": True,
             "phase_4_3b_binding_active": True,
             "phase_4_4a_binding_active": True,
+            "phase_4_6b_binding_active": True,
             "phase_4_full_pass": False,
             "phase_4_authorized": True,
             "operator_skeleton_approval": "PENDING",

--- a/src/webui/market_dashboard_landscape_v2/projections.py
+++ b/src/webui/market_dashboard_landscape_v2/projections.py
@@ -12,6 +12,7 @@ from .contracts import (
     CanonicalDecisionSnapshotV1,
     DoublePlaySnapshotV1,
     DynamicScopeSnapshotV1,
+    EconomicSummarySnapshotV1,
     MarketInstrumentSnapshotV1,
     SafetyAuthoritySnapshotV1,
     UniverseRankingSnapshotV1,
@@ -427,4 +428,120 @@ def project_safety_authority_snapshot_v1(
         kill_switch_state=str(kill_switch_state),
         veto_active=veto_active,
         reason_codes=tuple(str(code) for code in reason_codes),
+    )
+
+
+def project_economic_summary_snapshot_v1(
+    *,
+    economic_viability_status: str,
+    economic_validity_proven: bool,
+    profitability_claim_allowed: bool,
+    policy_threshold_status: str,
+    policy_version: str,
+    authority_effect: str,
+    runtime_effect: bool,
+    order_effect: bool,
+    reason_codes: Sequence[str],
+    profit_factor: Mapping[str, Any],
+    net_return: Mapping[str, Any],
+    max_drawdown: Mapping[str, Any],
+    sharpe: Mapping[str, Any],
+    trade_count: Mapping[str, Any],
+    funding_drag: Mapping[str, Any],
+    contract_version: str,
+    owner: str,
+    strategy_id: str,
+    strategy_version: str,
+    config_digest: str,
+    implementation_digest: str,
+    data_digest: str,
+    manifest_digest: str,
+    wiring_chain_digest: str,
+    policy_digest: str,
+    generated_at: datetime,
+    source_reference: str | None,
+    evidence_ref: str | None = None,
+    evidence_digest: str | None = None,
+    git_sha: str | None = None,
+    producer_module: str = "backtest.economic_viability_evidence_v1",
+    source_kind: str = "economic_viability_evidence_v1",
+    effective_at: datetime | None = None,
+    availability: Availability = Availability.AVAILABLE,
+    max_age_seconds: int | None = None,
+    is_stale: bool = False,
+    stale_reason: str | None = None,
+) -> EconomicSummarySnapshotV1:
+    """Project already-selected EconomicViabilityEvidenceV1 fields field-for-field.
+
+    Forbidden: recomputing metrics, synthesizing PASS/FAIL, mapping promotion
+    gate status, inferring lifecycle labels, or selecting among evidence instances.
+    generated_at/effective_at must be producer timestamps — never page-assembly time.
+    """
+    if not economic_viability_status:
+        raise ValueError("economic_viability_status required for AVAILABLE/STALE")
+    if not isinstance(economic_validity_proven, bool):
+        raise TypeError("economic_validity_proven must be bool")
+    if not isinstance(profitability_claim_allowed, bool):
+        raise TypeError("profitability_claim_allowed must be bool")
+    if not isinstance(runtime_effect, bool):
+        raise TypeError("runtime_effect must be bool")
+    if not isinstance(order_effect, bool):
+        raise TypeError("order_effect must be bool")
+    if availability not in (Availability.AVAILABLE, Availability.STALE):
+        raise ValueError("project_economic_summary only emits AVAILABLE or STALE")
+    if availability is Availability.AVAILABLE and is_stale:
+        raise ValueError("AVAILABLE cannot be stale")
+    if availability is Availability.STALE and not is_stale:
+        raise ValueError("STALE requires is_stale=True")
+    schema_id = f"{SCHEMA_FAMILY}.economic_summary.{SCHEMA_VERSION}"
+    provenance = SnapshotProvenanceV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        producer_module=producer_module,
+        generated_at=generated_at,
+        effective_at=generated_at if effective_at is None else effective_at,
+        source_kind=source_kind,
+        source_reference=source_reference,
+        evidence_digest=evidence_digest,
+        git_sha=git_sha,
+        availability=availability,
+    )
+    freshness = FreshnessV1(
+        observed_at=generated_at,
+        max_age_seconds=max_age_seconds,
+        is_stale=is_stale,
+        stale_reason=stale_reason,
+    )
+    return EconomicSummarySnapshotV1(
+        schema_id=schema_id,
+        schema_version=SCHEMA_VERSION,
+        provenance=provenance,
+        freshness=freshness,
+        availability=availability,
+        economic_viability_status=str(economic_viability_status),
+        economic_validity_proven=economic_validity_proven,
+        profitability_claim_allowed=profitability_claim_allowed,
+        policy_threshold_status=str(policy_threshold_status),
+        policy_version=str(policy_version),
+        authority_effect=str(authority_effect),
+        runtime_effect=runtime_effect,
+        order_effect=order_effect,
+        reason_codes=tuple(str(code) for code in reason_codes),
+        profit_factor=dict(profit_factor),
+        net_return=dict(net_return),
+        max_drawdown=dict(max_drawdown),
+        sharpe=dict(sharpe),
+        trade_count=dict(trade_count),
+        funding_drag=dict(funding_drag),
+        evidence_ref=None if evidence_ref is None else str(evidence_ref),
+        contract_version=str(contract_version),
+        owner=str(owner),
+        strategy_id=str(strategy_id),
+        strategy_version=str(strategy_version),
+        config_digest=str(config_digest),
+        implementation_digest=str(implementation_digest),
+        data_digest=str(data_digest),
+        manifest_digest=str(manifest_digest),
+        wiring_chain_digest=str(wiring_chain_digest),
+        policy_digest=str(policy_digest),
     )

--- a/templates/peak_trade_dashboard/market_landscape_v2.html
+++ b/templates/peak_trade_dashboard/market_landscape_v2.html
@@ -4,7 +4,7 @@
 {% block main_class %}mdl-v2-main{% endblock %}
 {% block extra_head %}
 <link rel="stylesheet" href="/static/css/market_dashboard_landscape_v2.css" />
-<meta name="peak-trade-market-landscape-v2" content="phase4-4a-canonical-safety-projection-binding" />
+<meta name="peak-trade-market-landscape-v2" content="phase4-6b-economic-evidence-explicit-injection-binding" />
 <meta name="peak-trade-dashboard-authority" content="false" />
 <meta name="peak-trade-live-authorized" content="false" />
 {% endblock %}
@@ -199,7 +199,11 @@
       </div>
       <div class="mdl-v2-ops__col">
         <h3>Economic</h3>
-        <p class="mdl-v2-state" data-availability="{{ economic.availability }}">{{ economic.availability_label }}</p>
+        <p
+          class="mdl-v2-state"
+          data-availability="{{ economic.availability }}"
+          data-mdl-field="economic"
+        >{{ economic.status_display }}</p>
       </div>
     </section>
 

--- a/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
@@ -233,8 +233,9 @@ def test_landscape_shell_template_has_no_write_controls() -> None:
     assert 'data-market-dashboard-authority="false"' in text
     assert "method=" not in text.lower()
     assert re.search(r"<form\b", text, flags=re.IGNORECASE) is None
-    assert "phase4-4a-canonical-safety-projection-binding" in text
+    assert "phase4-6b-economic-evidence-explicit-injection-binding" in text
     assert 'data-mdl-field="safety"' in text
+    assert 'data-mdl-field="economic"' in text
     assert "<button" not in text.lower()
 
 
@@ -246,6 +247,7 @@ def test_projection_helpers_are_field_copy_only() -> None:
     assert "project_universe_ranking_snapshot_v1" in proj
     assert "project_dynamic_scope_snapshot_v1" in proj
     assert "project_safety_authority_snapshot_v1" in proj
+    assert "project_economic_summary_snapshot_v1" in proj
     assert "Forbidden" in proj
     tree = ast.parse(proj)
     # Guard against executable references, not documentation mentions.
@@ -280,6 +282,7 @@ def test_projection_helpers_are_field_copy_only() -> None:
         assert "double_play_dashboard_display" not in module
         assert "killswitch_boundary" not in module
         assert "kill_switch" not in module
+        assert "economic_viability_evidence" not in module
         assert "execution" not in module
         assert "order" not in module
 
@@ -288,11 +291,14 @@ def test_producer_binding_is_read_only_and_outside_landscape_package() -> None:
     assert PRODUCER_BINDING.is_file()
     text = PRODUCER_BINDING.read_text(encoding="utf-8")
     assert "bind_market_universe_slots" in text
-    assert "4.4A" in text
+    assert "4.6B" in text
     assert "project_dynamic_scope_snapshot_v1" in text
     assert "project_canonical_decision_snapshot_v1" in text
     assert "project_double_play_snapshot_v1" in text
     assert "project_safety_authority_snapshot_v1" in text
+    assert "project_economic_summary_snapshot_v1" in text
+    assert "economic_viability_evidence_fields" in text
+    assert "project_economic_viability_evidence_v1" in text
     assert "canonical_decision_fields" in text
     assert "double_play_fields" in text
     assert "safety_authority_fields" in text
@@ -334,6 +340,14 @@ def test_producer_binding_is_read_only_and_outside_landscape_package() -> None:
     assert "StatePersistence" not in text
     assert "RiskGate" not in text
     assert "evaluate_capital_risk_sizing_v1" not in text
+    assert "latest_economic" not in text
+    assert "discover_economic" not in text
+    assert "resolve_latest_economic" not in text
+    # Documentation may mention promotion_economic_gate_v1 as a separate owner;
+    # forbid executable imports / bindings of that owner.
+    assert "from src.governance" not in text
+    assert "import promotion_economic_gate" not in text
+    assert "promotion_economic_gate_v1(" not in text
     for needle in FORBIDDEN_HEALTHY_SAFETY_DEFAULTS:
         assert needle not in text, needle
     for module, level in _import_modules(PRODUCER_BINDING):
@@ -350,6 +364,7 @@ def test_producer_binding_is_read_only_and_outside_landscape_package() -> None:
         assert "kill_switch" not in module
         assert "risk_gate" not in module
         assert "capital_risk_sizing" not in module
+        assert "promotion_economic_gate" not in module
     # Landscape package must not import the binding module (keeps contracts pure).
     for path in _iter_py_files(LANDSCAPE_PKG):
         for module, level in _import_modules(path):
@@ -365,6 +380,22 @@ def test_owner_registry_distinguishes_safety_authority_from_projection_source() 
     assert 'reuse_status="REUSED"' in registry_text
     assert 'slot="risk_sizing_capital"' in registry_text
     assert 'reuse_status="NOT_BOUND"' in registry_text
+
+
+def test_owner_registry_economic_summary_reused_explicit_injection() -> None:
+    registry_text = (LANDSCAPE_PKG / "owner_registry.py").read_text(encoding="utf-8")
+    assert 'slot="economic_summary"' in registry_text
+    assert 'owner_module="backtest.economic_viability_evidence_v1"' in registry_text
+    assert "EconomicViabilityEvidenceV1" in registry_text
+    assert "Phase 4.6B" in registry_text
+    assert "explicit injection only" in registry_text
+    assert "MISSING_SOURCE" in registry_text
+    assert "promotion_economic_gate_v1 remains a separate owner" in registry_text
+    # Ensure economic slot is REUSED (bound), not left NOT_BOUND.
+    economic_block = registry_text.split('slot="economic_summary"', 1)[1].split(
+        "CanonicalOwnerRefV1(", 1
+    )[0]
+    assert 'reuse_status="REUSED"' in economic_block
 
 
 def test_shell_router_wires_phase41_through_phase43b_binding() -> None:
@@ -513,7 +544,7 @@ def test_landscape_v2_css_has_no_visible_structural_divider_lines() -> None:
 
 
 def test_economic_summary_forbids_gate_status_alias_and_selector_logic() -> None:
-    """Phase 4.6A: economic_viability_status only; no discovery/selector binding."""
+    """Phase 4.6B: economic_viability_status only; injection binding; no discovery."""
     contracts = (LANDSCAPE_PKG / "contracts.py").read_text(encoding="utf-8")
     unavailable = (LANDSCAPE_PKG / "unavailable.py").read_text(encoding="utf-8")
     serialization = (LANDSCAPE_PKG / "serialization.py").read_text(encoding="utf-8")
@@ -528,12 +559,12 @@ def test_economic_summary_forbids_gate_status_alias_and_selector_logic() -> None
     assert "economic_gate_status" not in unavailable
     assert "economic_gate_status" not in serialization
 
-    # No Phase 4.6B projection/binding yet.
-    assert "project_economic_summary" not in projections
-    assert "economic_viability_evidence" not in producer
-    assert "bind_economic" not in producer
+    assert "project_economic_summary_snapshot_v1" in projections
+    assert "project_economic_viability_evidence_v1" in producer
+    assert "economic_viability_evidence_fields" in producer
+    assert "REASON_ECONOMIC_NOT_PERSISTED" in producer
 
-    # No repository-wide evidence discovery / latest-file selector in Landscape.
+    # No repository-wide evidence discovery / latest-file selector.
     forbidden_selector_tokens = (
         "latest_economic",
         "discover_economic",
@@ -560,6 +591,9 @@ def test_economic_summary_forbids_gate_status_alias_and_selector_logic() -> None
         assert re.search(rf"\b{label}\s*:", contracts) is None
 
     assert 'slot="economic_summary"' in registry
-    assert "EXPLICIT_UPSTREAM_INJECTION_ONLY" in registry
     assert "EconomicViabilityEvidenceV1" in registry
-    assert 'reuse_status="NOT_BOUND"' in registry
+    assert "Phase 4.6B" in registry
+    economic_block = registry.split('slot="economic_summary"', 1)[1].split(
+        "CanonicalOwnerRefV1(", 1
+    )[0]
+    assert 'reuse_status="REUSED"' in economic_block

--- a/tests/webui/test_market_landscape_dashboard_v2_chrome_evidence_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_chrome_evidence_v0.py
@@ -142,7 +142,7 @@ def _run_chrome_against_html(
                 root = page.locator('[data-market-landscape-v2="true"]')
                 assert root.count() == 1
                 assert root.get_attribute("data-phase") == (
-                    "PHASE_4_4A_CANONICAL_SAFETY_PROJECTION_BINDING"
+                    "PHASE_4_6B_ECONOMIC_EVIDENCE_EXPLICIT_INJECTION_BINDING"
                 )
                 chart = page.locator("[data-mdl-chart-region='true']")
                 decision = page.locator("[data-mdl-decision-strip='true']")

--- a/tests/webui/test_market_landscape_dashboard_v2_contracts_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_contracts_v0.py
@@ -412,11 +412,11 @@ def test_economic_summary_immutable_and_serializable() -> None:
     assert parsed["profit_factor"] == {"semantic": "COMPUTED", "value": 1.25}
 
 
-def test_economic_owner_registry_ratified_not_bound() -> None:
+def test_economic_owner_registry_ratified_bound() -> None:
     entry = owner_registry_by_slot()["economic_summary"]
     assert entry.owner_module == "backtest.economic_viability_evidence_v1"
     assert entry.owner_symbol == "EconomicViabilityEvidenceV1"
-    assert entry.reuse_status == "NOT_BOUND"
+    assert entry.reuse_status == "REUSED"
     assert "economic_viability_status" in entry.notes
-    assert "EXPLICIT_UPSTREAM_INJECTION_ONLY" in entry.notes
-    assert "economic_gate_status" in entry.notes
+    assert "explicit injection only" in entry.notes
+    assert "MISSING_SOURCE" in entry.notes

--- a/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
@@ -28,6 +28,7 @@ from src.webui.market_dashboard_landscape_producer_binding_v2 import (
     REASON_ARCHIVE_ROOT_UNSET,
     REASON_DECISION_NOT_PERSISTED,
     REASON_DOUBLE_PLAY_NOT_PERSISTED,
+    REASON_ECONOMIC_NOT_PERSISTED,
     REASON_MARKET_CONTEXT_NOT_PERSISTED,
     REASON_PRODUCER_DATA_STALE,
     REASON_PRODUCER_TIMESTAMP_INVALID,
@@ -42,7 +43,9 @@ from src.webui.market_dashboard_landscape_producer_binding_v2 import (
     SCOPE_PRODUCER_MODULE,
     SCOPE_SOURCE_KIND,
     bind_market_universe_slots,
+    economic_viability_evidence_fields_from_v1,
     parse_producer_utc_timestamp,
+    project_economic_viability_evidence_v1,
 )
 from src.webui.market_dashboard_landscape_v2 import (
     Availability,
@@ -149,6 +152,7 @@ def test_bind_defaults_fail_closed_without_archive_or_fields(
         "canonical_decision",
         "double_play",
         "safety_authority",
+        "economic_summary",
     }
     assert slots["market_instrument"].availability is Availability.MISSING_SOURCE
     assert REASON_MARKET_CONTEXT_NOT_PERSISTED in slots["market_instrument"].reason_codes
@@ -174,6 +178,10 @@ def test_bind_defaults_fail_closed_without_archive_or_fields(
     assert REASON_SAFETY_NOT_PERSISTED in slots["safety_authority"].reason_codes
     assert slots["safety_authority"].kill_switch_state is None
     assert slots["safety_authority"].veto_active is None
+    assert slots["economic_summary"].availability is Availability.MISSING_SOURCE
+    assert REASON_ECONOMIC_NOT_PERSISTED in slots["economic_summary"].reason_codes
+    assert slots["economic_summary"].economic_viability_status is None
+    assert slots["economic_summary"].profit_factor is None
 
 
 def test_bind_rejects_inventing_market_without_required_fields() -> None:
@@ -476,7 +484,7 @@ def test_page_aggregate_applies_phase41_and_phase42_scope_missing_without_inject
     assert page.canonical_decision.availability is Availability.MISSING_SOURCE
     assert REASON_DECISION_NOT_PERSISTED in page.canonical_decision.reason_codes
     ctx = present_market_landscape_v2(page)
-    assert ctx["phase"] == "PHASE_4_4A_CANONICAL_SAFETY_PROJECTION_BINDING"
+    assert ctx["phase"] == "PHASE_4_6B_ECONOMIC_EVIDENCE_EXPLICIT_INJECTION_BINDING"
     assert ctx["chart"]["ohlcv"] is None
     assert ctx["scope"]["availability"] == "MISSING_SOURCE"
     assert ctx["decision"]["availability"] == "MISSING_SOURCE"
@@ -742,7 +750,7 @@ def test_bind_canonical_decision_does_not_bind_double_play() -> None:
     assert page.double_play.availability is Availability.MISSING_SOURCE
     assert REASON_DOUBLE_PLAY_NOT_PERSISTED in page.double_play.blockers
     assert ctx["double_play"]["availability"] == "MISSING_SOURCE"
-    assert ctx["phase"] == "PHASE_4_4A_CANONICAL_SAFETY_PROJECTION_BINDING"
+    assert ctx["phase"] == "PHASE_4_6B_ECONOMIC_EVIDENCE_EXPLICIT_INJECTION_BINDING"
     assert ctx["product_flags"]["phase_4_3a_binding_active"] is True
     assert ctx["product_flags"]["phase_4_3b_binding_active"] is True
     assert ctx["product_flags"]["phase_4_4a_binding_active"] is True
@@ -909,7 +917,7 @@ def test_decision_and_double_play_remain_separate_projections() -> None:
     assert page.double_play.overall_status == "display_blocked"
     assert ctx["decision"]["fields"]["decision"] == "observe"
     assert ctx["double_play"]["fields"]["overall_status"] == "display_blocked"
-    assert ctx["phase"] == "PHASE_4_4A_CANONICAL_SAFETY_PROJECTION_BINDING"
+    assert ctx["phase"] == "PHASE_4_6B_ECONOMIC_EVIDENCE_EXPLICIT_INJECTION_BINDING"
 
 
 def _safety_authority_fields(**overrides: object) -> dict[str, object]:
@@ -1031,6 +1039,302 @@ def test_safety_does_not_bind_risk_capital_sizing() -> None:
     assert page.risk_sizing_capital.quantity is None
     assert ctx["risk"]["availability"] == "NOT_BOUND"
     assert ctx["global_strip"]["safety_status"] == "KILLED · veto=True"
-    assert ctx["phase"] == "PHASE_4_4A_CANONICAL_SAFETY_PROJECTION_BINDING"
+    assert ctx["phase"] == "PHASE_4_6B_ECONOMIC_EVIDENCE_EXPLICIT_INJECTION_BINDING"
     assert ctx["product_flags"]["phase_4_4a_binding_active"] is True
+    assert ctx["product_flags"]["phase_4_6b_binding_active"] is True
     assert ctx["product_flags"]["dashboard_authority"] is False
+
+
+def _metric(*, value: float | None = None, semantic: str = "COMPUTED") -> dict[str, object]:
+    payload: dict[str, object] = {"semantic": semantic}
+    if value is not None:
+        payload["value"] = value
+    return payload
+
+
+def _economic_fields(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "status": "ECONOMICALLY_VIABLE_OFFLINE",
+        "economic_validity_proven": True,
+        "profitability_claim_allowed": False,
+        "policy_threshold_status": "PASS",
+        "policy_version": "economic_validity_policy_v1",
+        "authority_effect": "NONE",
+        "runtime_effect": False,
+        "order_effect": False,
+        "reason_codes": ("SENTINEL_REASON_A", "SENTINEL_REASON_B"),
+        "profit_factor": _metric(value=1.77),
+        "net_return": _metric(value=0.123),
+        "max_drawdown": _metric(value=-0.045),
+        "sharpe": _metric(value=0.88),
+        "trade_count": _metric(value=42.0),
+        "funding_drag": _metric(value=-0.003),
+        "contract_version": "v1",
+        "owner": "backtest.economic_viability_evidence_v1",
+        "strategy_id": "sentinel_strategy",
+        "strategy_version": "sentinel_v9",
+        "config_digest": "c" * 64,
+        "implementation_digest": "i" * 64,
+        "data_digest": "d" * 64,
+        "manifest_digest": "m" * 64,
+        "wiring_chain_digest": "w" * 64,
+        "policy_digest": "p" * 64,
+        "generated_at": SAFETY_PRODUCER_FRESH,
+        "source_reference": "evidence://economic/sentinel",
+        "evidence_digest": "m" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_economic_evidence(**overrides: object):
+    from src.backtest.economic_viability_evidence_v1 import (
+        EconomicViabilityEvidenceV1,
+        EconomicViabilityStatus,
+        MetricFieldV1,
+        MetricSemantic,
+    )
+
+    def mf(value: float | None = None) -> MetricFieldV1:
+        if value is None:
+            return MetricFieldV1(semantic=MetricSemantic.NOT_COMPUTED)
+        return MetricFieldV1(semantic=MetricSemantic.COMPUTED, value=value)
+
+    kwargs: dict[str, object] = {
+        "contract_version": "v1",
+        "owner": "backtest.economic_viability_evidence_v1",
+        "strategy_id": "sentinel_strategy",
+        "strategy_version": "sentinel_v9",
+        "instrument_id_or_universe": "ETH-USDT-SWAP",
+        "canonical_trading_logic_version": "v1",
+        "data_period": "p",
+        "training_period": "p",
+        "validation_period": "p",
+        "out_of_sample_period": "p",
+        "fee_model_version": "backtest_cost_v0",
+        "slippage_model_version": "backtest_cost_v0",
+        "funding_model_version": "funding_v1",
+        "execution_model_version": "research_conservative_bps_v1",
+        "config_digest": "c" * 64,
+        "implementation_digest": "i" * 64,
+        "data_digest": "d" * 64,
+        "gross_return": mf(0.2),
+        "net_return": mf(0.123),
+        "net_expectancy": mf(0.01),
+        "profit_factor": mf(1.77),
+        "sharpe": mf(0.88),
+        "sortino": mf(),
+        "max_drawdown": mf(-0.045),
+        "calmar": mf(),
+        "trade_count": mf(42.0),
+        "turnover": mf(),
+        "fee_drag": mf(),
+        "funding_drag": mf(-0.003),
+        "slippage_impact": mf(),
+        "tail_loss": mf(),
+        "time_in_market": mf(),
+        "long_contribution": mf(),
+        "short_contribution": mf(),
+        "regime_breakdown": {},
+        "portfolio_contribution": {},
+        "walk_forward_results": {},
+        "monte_carlo_results": {},
+        "stress_results": {},
+        "parameter_sensitivity_results": {},
+        "parameter_neighbor_degradation": mf(),
+        "single_trade_profit_contribution": mf(),
+        "single_regime_profit_contribution": mf(),
+        "status": EconomicViabilityStatus.ECONOMICALLY_VIABLE_OFFLINE,
+        "reason_codes": ("SENTINEL_REASON_A", "SENTINEL_REASON_B"),
+        "manifest_digest": "m" * 64,
+        "wiring_chain_digest": "w" * 64,
+        "randomness_seed": 7,
+        "data_admissibility": {},
+        "cost_binding": {},
+        "policy_version": "economic_validity_policy_v1",
+        "policy_digest": "p" * 64,
+        "policy_threshold_status": "PASS",
+        "economic_validity_proven": True,
+        "profitability_claim_allowed": False,
+        "authority_effect": "NONE",
+        "runtime_effect": False,
+        "order_effect": False,
+    }
+    kwargs.update(overrides)
+    return EconomicViabilityEvidenceV1(**kwargs)
+
+
+def test_economic_missing_source_without_injection() -> None:
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    economic = slots["economic_summary"]
+    assert economic.availability is Availability.MISSING_SOURCE
+    assert REASON_ECONOMIC_NOT_PERSISTED in economic.reason_codes
+    assert economic.economic_viability_status is None
+    assert economic.economic_validity_proven is None
+    assert economic.policy_threshold_status is None
+    assert economic.profit_factor is None
+    assert economic.evidence_ref is None
+
+
+def test_economic_field_for_field_injection_via_fields() -> None:
+    fields = _economic_fields()
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        economic_viability_evidence_fields=fields,
+    )
+    economic = slots["economic_summary"]
+    assert economic.availability is Availability.AVAILABLE
+    assert economic.economic_viability_status == "ECONOMICALLY_VIABLE_OFFLINE"
+    assert economic.economic_validity_proven is True
+    assert economic.profitability_claim_allowed is False
+    assert economic.policy_threshold_status == "PASS"
+    assert economic.policy_version == "economic_validity_policy_v1"
+    assert economic.authority_effect == "NONE"
+    assert economic.runtime_effect is False
+    assert economic.order_effect is False
+    assert economic.reason_codes == ("SENTINEL_REASON_A", "SENTINEL_REASON_B")
+    assert economic.profit_factor == {"semantic": "COMPUTED", "value": 1.77}
+    assert economic.net_return == {"semantic": "COMPUTED", "value": 0.123}
+    assert economic.max_drawdown == {"semantic": "COMPUTED", "value": -0.045}
+    assert economic.sharpe == {"semantic": "COMPUTED", "value": 0.88}
+    assert economic.trade_count == {"semantic": "COMPUTED", "value": 42.0}
+    assert economic.funding_drag == {"semantic": "COMPUTED", "value": -0.003}
+    assert economic.contract_version == "v1"
+    assert economic.owner == "backtest.economic_viability_evidence_v1"
+    assert economic.strategy_id == "sentinel_strategy"
+    assert economic.strategy_version == "sentinel_v9"
+    assert economic.config_digest == "c" * 64
+    assert economic.implementation_digest == "i" * 64
+    assert economic.data_digest == "d" * 64
+    assert economic.manifest_digest == "m" * 64
+    assert economic.wiring_chain_digest == "w" * 64
+    assert economic.policy_digest == "p" * 64
+    assert economic.provenance.evidence_digest == "m" * 64
+    assert economic.provenance.source_reference == "evidence://economic/sentinel"
+    assert economic.provenance.producer_module.endswith("economic_viability_evidence_v1")
+    payload = serialize_projection(economic)
+    assert "economic_gate_status" not in payload
+    assert "promotion" not in payload
+    assert "HOLDOUT" not in payload
+    assert "DEVELOPMENT" not in payload
+    assert "SEALED" not in payload
+
+
+def test_economic_explicit_evidence_object_projection_immutable() -> None:
+    evidence = _make_economic_evidence()
+    before = (
+        evidence.status.value,
+        evidence.economic_validity_proven,
+        evidence.profit_factor.to_dict(),
+        evidence.reason_codes,
+        evidence.manifest_digest,
+    )
+    snap = project_economic_viability_evidence_v1(
+        evidence,
+        generated_at=SAFETY_PRODUCER_FRESH,
+        as_of=STAMP,
+        source_reference="path/DEVELOPMENT/HOLDOUT/SEALED/artifact.json",
+    )
+    assert snap.availability is Availability.AVAILABLE
+    assert snap.economic_viability_status == "ECONOMICALLY_VIABLE_OFFLINE"
+    assert snap.economic_validity_proven is True
+    assert snap.profit_factor == {"semantic": "COMPUTED", "value": 1.77}
+    assert snap.reason_codes == ("SENTINEL_REASON_A", "SENTINEL_REASON_B")
+    payload = serialize_projection(snap)
+    assert payload.get("lifecycle_label") is None
+    assert "DEVELOPMENT_ONLY" not in payload
+    assert "HOLDOUT" not in payload
+    assert "SEALED_LONG_PANEL" not in payload
+    assert before == (
+        evidence.status.value,
+        evidence.economic_validity_proven,
+        evidence.profit_factor.to_dict(),
+        evidence.reason_codes,
+        evidence.manifest_digest,
+    )
+    with pytest.raises(FrozenInstanceError):
+        snap.economic_viability_status = "RESEARCH_ONLY"  # type: ignore[misc]
+
+
+def test_economic_validity_proven_not_recomputed_from_status() -> None:
+    fields = _economic_fields(
+        status="RESEARCH_ONLY",
+        economic_validity_proven=True,
+        policy_threshold_status="BELOW_THRESHOLD",
+    )
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        economic_viability_evidence_fields=fields,
+    )
+    economic = slots["economic_summary"]
+    assert economic.economic_viability_status == "RESEARCH_ONLY"
+    assert economic.economic_validity_proven is True
+    assert economic.policy_threshold_status == "BELOW_THRESHOLD"
+
+
+def test_economic_promotion_isolation() -> None:
+    fields = _economic_fields()
+    fields["promotion_economic_gate_status"] = "PASS"
+    fields["promotion_eligibility"] = True
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        economic_viability_evidence_fields=fields,
+    )
+    economic = slots["economic_summary"]
+    payload = serialize_projection(economic)
+    assert "promotion_economic_gate_status" not in payload
+    assert "promotion_eligibility" not in payload
+    assert economic.economic_viability_status == "ECONOMICALLY_VIABLE_OFFLINE"
+    assert economic.authority_effect == "NONE"
+
+
+def test_economic_no_lifecycle_inference_from_source_reference() -> None:
+    fields = _economic_fields(
+        source_reference="artifacts/DEVELOPMENT/HOLDOUT/SEALED/run.json",
+        status="PROMISING",
+        economic_validity_proven=False,
+        policy_threshold_status="BELOW_THRESHOLD",
+    )
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        economic_viability_evidence_fields=fields,
+    )
+    economic = slots["economic_summary"]
+    payload = serialize_projection(economic)
+    for forbidden in (
+        "DEVELOPMENT_ONLY",
+        "HOLDOUT",
+        "SEALED_LONG_PANEL",
+        "TERMINAL",
+        "PREREGISTRATION_ONLY",
+        "NOT_EVALUATED",
+        "lifecycle_label",
+        "research_lifecycle",
+    ):
+        assert forbidden not in payload
+    assert economic.provenance.source_reference == ("artifacts/DEVELOPMENT/HOLDOUT/SEALED/run.json")
+
+
+def test_economic_page_aggregate_and_presenter_injection() -> None:
+    evidence = _make_economic_evidence()
+    fields = economic_viability_evidence_fields_from_v1(
+        evidence,
+        generated_at=SAFETY_PRODUCER_FRESH,
+        source_reference="evidence://economic/page",
+    )
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        economic_viability_evidence_fields=fields,
+    )
+    page = MarketDashboardReadServiceV1().load_page_snapshot(
+        generated_at=STAMP,
+        slot_overrides=slots,
+    )
+    ctx = present_market_landscape_v2(page)
+    assert page.economic_summary.availability is Availability.AVAILABLE
+    assert page.economic_summary.economic_viability_status == ("ECONOMICALLY_VIABLE_OFFLINE")
+    assert ctx["economic"]["availability"] == "AVAILABLE"
+    assert ctx["economic"]["status_display"] == "ECONOMICALLY_VIABLE_OFFLINE"
+    assert ctx["product_flags"]["phase_4_6b_binding_active"] is True
+    assert ctx["phase"] == "PHASE_4_6B_ECONOMIC_EVIDENCE_EXPLICIT_INJECTION_BINDING"
+    assert page.risk_sizing_capital.availability is Availability.NOT_BOUND

--- a/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
@@ -53,7 +53,7 @@ def test_get_market_returns_200_with_landmarks(client: TestClient) -> None:
     assert 'data-market-landscape-v2="true"' in html
     for landmark in LANDMARKS:
         assert landmark in html, landmark
-    assert "PHASE_4_4A_CANONICAL_SAFETY_PROJECTION_BINDING" in html
+    assert "PHASE_4_6B_ECONOMIC_EVIDENCE_EXPLICIT_INJECTION_BINDING" in html
     assert "BOUND_NOT_ACTIVATED" in html
     assert "no ohlcv fabricated" in html.lower()
     assert "BTC/USD" not in html
@@ -79,10 +79,13 @@ def test_get_market_returns_200_with_landmarks(client: TestClient) -> None:
         'data-mdl-field="double_play" data-availability="MISSING_SOURCE"' in html
     )
     assert 'data-mdl-field="safety"' in html
+    assert 'data-mdl-field="economic"' in html
     assert 'data-availability="MISSING_SOURCE"' in html
     assert "MISSING_SOURCE" in html
     # Safety strip value is MISSING_SOURCE without injection.
     assert ">MISSING_SOURCE</dd>" in html or "MISSING_SOURCE" in html
+    # Economic region is MISSING_SOURCE without injection (wired slot, no evidence).
+    assert 'data-mdl-field="economic"' in html
     assert "Risk / Sizing / Capital" in html
     assert "OPERATOR_SKELETON_APPROVAL" not in html
     assert "<button" not in html.lower()
@@ -144,8 +147,10 @@ def test_presenter_formats_only_no_authority_defaults() -> None:
     assert ctx["product_flags"]["phase_4_3a_binding_active"] is True
     assert ctx["product_flags"]["phase_4_3b_binding_active"] is True
     assert ctx["product_flags"]["phase_4_4a_binding_active"] is True
+    assert ctx["product_flags"]["phase_4_6b_binding_active"] is True
     assert ctx["chart"]["ohlcv"] is None
     assert ctx["decision"]["availability_label"] == "NOT_BOUND"
+    assert ctx["economic"]["availability_label"] == "NOT_BOUND"
     assert ctx["global_strip"]["instrument"] == "NOT_BOUND"
     assert ctx["global_strip"]["safety_status"] == "NOT_BOUND"
     assert ctx["risk"]["availability"] == "NOT_BOUND"
@@ -155,7 +160,7 @@ def test_presenter_formats_only_no_authority_defaults() -> None:
     # Must not invent HOLD/FLAT
     assert ctx["decision"]["fields"]["decision"] is None
     assert ctx["decision"]["fields"]["direction"] is None
-    assert ctx["phase"] == "PHASE_4_4A_CANONICAL_SAFETY_PROJECTION_BINDING"
+    assert ctx["phase"] == "PHASE_4_6B_ECONOMIC_EVIDENCE_EXPLICIT_INJECTION_BINDING"
 
 
 def test_shell_assets_exist() -> None:


### PR DESCRIPTION
## Summary
- Bind already-ratified `EconomicViabilityEvidenceV1` (`backtest.economic_viability_evidence_v1`, schema version `v1`) into Market Landscape via explicit injection only.
- Add pure `project_economic_summary_snapshot_v1` + `project_economic_viability_evidence_v1` field-for-field projection; production route without injection stays `MISSING_SOURCE`.
- Keep promotion (`promotion_economic_gate_v1`) separate; no selector, no lifecycle inference, no economic recomputation; `AUTHORITY_EFFECT=NONE`.

## Source contract
- **SOURCE_CONTRACT:** `EconomicViabilityEvidenceV1`
- **SOURCE_OWNER:** `backtest.economic_viability_evidence_v1`
- **SOURCE_SCHEMA_VERSION:** `v1`
- **INJECTION_BOUNDARY:** `bind_market_universe_slots(..., economic_viability_evidence_fields=...)` / `project_economic_viability_evidence_v1(evidence, generated_at=...)`

## Direct field mapping
- `economic_viability_status` ← `status` (exact enum value)
- `economic_validity_proven` ← `economic_validity_proven`
- `profitability_claim_allowed` ← `profitability_claim_allowed`
- `policy_threshold_status` ← `policy_threshold_status`
- `policy_version` ← `policy_version`
- `authority_effect` ← `authority_effect`
- `runtime_effect` ← `runtime_effect`
- `order_effect` ← `order_effect`
- `reason_codes` ← `reason_codes`
- `profit_factor`/`net_return`/`max_drawdown`/`sharpe`/`trade_count`/`funding_drag` ← corresponding `MetricFieldV1.to_dict()`
- identity digests ← `contract_version`/`owner`/`strategy_id`/`strategy_version`/`config_digest`/`implementation_digest`/`data_digest`/`manifest_digest`/`wiring_chain_digest`/`policy_digest`
- `evidence_ref` left absent unless explicitly supplied on injection mapping (no direct EVI field)

## Guarantees
- No automatic evidence selector (filesystem/registry/latest/env)
- Promotion not bound / not imported
- DEVELOPMENT/HOLDOUT/SEALED not inferred from paths
- No economic calculation / threshold application
- Live/orders/scheduler/runtime unchanged (`false`)

## Test plan
- [x] Focused Landscape contracts / architecture / producer-binding / shell-route (90 passed)
- [x] PR-bounded FULL + Landscape suite (806 passed, ~50s)
- [x] ruff format/check on touched Python
- [x] docs-reference-targets
- [x] Unrelated dirty/untracked paths byte-identical

## Files changed
Production (6): producer binding, projections, `__init__`, owner_registry, presenter, template  
Tests: contracts, architecture guards, producer binding, shell route, chrome phase string


Made with [Cursor](https://cursor.com)