### PR TITLE
docs(webui): Phase 4.6C diagnostics_summary OPTION_A NOT_BOUND ratification

### DIFF
--- a/docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md
+++ b/docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md
@@ -715,12 +715,55 @@ policy_digest
 Rules: direct copy only; no recomputation; no promotion/research-workflow/
 risk-capital-sizing fields; optional source absences remain absent/None.
 
-##### 4.6B+ — Binding / Research / Diagnostics (not started in 4.6A)
+##### 4.6B — Economic Explicit Injection Binding (RATIFIED separately)
 
 - Explicit injection binding of one EconomicViabilityEvidenceV1 instance
-- Diagnostics ausdrücklich non-authoritative
 - keine Anlageempfehlung
 - Lifecycle context only after separate ratification
+
+##### 4.6C — Diagnostics Summary Contract Architecture Ratification (RATIFIED OPTION A)
+
+```text
+PHASE=PHASE_4_6C_DIAGNOSTICS_SUMMARY_CONTRACT_ARCHITECTURE_RATIFICATION
+RATIFY_OPTION_A_KEEP_NOT_BOUND=true
+DIAGNOSTICS_SUMMARY_STATUS=NOT_BOUND
+SOLE_DIAGNOSTICS_OWNER=UNRESOLVED
+IMPLEMENTATION_AUTHORIZED=false
+TYPED_INJECTION_BOUNDARY_AUTHORIZED=false
+SUMMARY_PRODUCER_EVIDENCE_RATIFIED=false
+CONSUMER_CONTRACT_REDESIGN_REQUIRED=true
+WORKFLOW_DASHBOARD_READMODEL_V1=NON_SOURCE_PROJECTION_ONLY
+OPTION_B_NEW_DOMAIN_NEUTRAL_DIAGNOSTICS_EVIDENCE=REJECTED
+OPTION_D_SOURCE_HEALTH_ONLY=REJECTED
+OPTION_C_MULTIPLE_DOMAIN_SPECIFIC_DIAGNOSTICS=DEFERRED_SEPARATE_OPERATOR_AUTHORIZED_REDESIGN
+```
+
+**A_STATUS — RATIFIED KEEP NOT_BOUND**
+
+- `diagnostics_summary` remains `NOT_BOUND`.
+- Sole owner remains `UNRESOLVED`.
+- No diagnostics producer, adapter, typed injection boundary, or evidence
+  contract is authorized by this decision.
+- `DiagnosticsSummarySnapshotV1` MUST NOT be bound to
+  `WorkflowDashboardReadModelV1`.
+- `WorkflowDashboardReadModelV1` remains `NON_SOURCE` / `PROJECTION_ONLY`.
+- `summary` is not ratified as producer-owned evidence; treat as
+  unresolved/presenter-oriented semantics until a separate consumer-contract
+  redesign is ratified.
+- No inference, cross-source aggregation, archive selection, or free-text
+  evidence generation is permitted.
+
+**REJECTED / DEFERRED**
+
+- OPTION_B (new domain-neutral diagnostics evidence): explicitly rejected.
+- OPTION_D (source-health only): explicitly rejected.
+- OPTION_C (multiple domain-specific diagnostics): architecturally admissible
+  only as a future separately authorized surface-and-contract redesign phase;
+  not part of this closeout.
+
+Canonical owner registry note:
+`src/webui/market_dashboard_landscape_v2/owner_registry.py` slot
+`diagnostics_summary` → `reuse_status=NOT_BOUND`, `owner=UNRESOLVED`.
 
 #### 4.7 Autonomy State
 
@@ -1427,7 +1470,8 @@ KNOWN_INTENTIONAL_LOCKS=[
   "LIVE/ORDERS/SCHEDULER fail-closed",
   "Strategy Signal Selection D / Slice 2 blocked",
   "Ops Double Play projection-only",
-  "Phase 4 producer binding not authorized in this PR"
+  "Phase 4 producer binding not authorized in this PR",
+  "Phase 4.6C diagnostics_summary OPTION_A KEEP_NOT_BOUND (owner UNRESOLVED; WorkflowDashboardReadModelV1 NON_SOURCE)"
 ]
 
 PHASE_PR_MAPPING=[

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -140,11 +140,22 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
     ),
     CanonicalOwnerRefV1(
         slot="diagnostics_summary",
-        owner_module="webui.workflow_dashboard_readmodel_v1.types",
-        owner_symbol="WorkflowDashboardReadModelV1",
+        owner_module="UNRESOLVED",
+        owner_symbol="UNRESOLVED",
         authority_class="diagnostics",
-        reuse_status="PROJECTION_ONLY",
-        notes="Observability diagnostics reused as reference; no second owner.",
+        reuse_status="NOT_BOUND",
+        notes=(
+            "Phase 4.6C OPTION_A_KEEP_NOT_BOUND ratified: diagnostics_summary "
+            "remains NOT_BOUND; sole owner UNRESOLVED; implementation authorized="
+            "false; typed injection authorized=false; consumer-contract redesign "
+            "required before any future binding; WorkflowDashboardReadModelV1 is "
+            "NON_SOURCE/PROJECTION_ONLY and MUST NOT be named as diagnostics "
+            "owner/source; summary is unresolved/presenter-oriented semantics "
+            "until a separate redesign is ratified; OPTION_B_NEW_DOMAIN_NEUTRAL_"
+            "DIAGNOSTICS_EVIDENCE rejected; OPTION_D_SOURCE_HEALTH_ONLY rejected; "
+            "OPTION_C_MULTIPLE_DOMAIN_SPECIFIC_DIAGNOSTICS deferred to a separate "
+            "operator-authorized redesign phase (not this PR)."
+        ),
     ),
     CanonicalOwnerRefV1(
         slot="source_health",

--- a/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
@@ -597,3 +597,58 @@ def test_economic_summary_forbids_gate_status_alias_and_selector_logic() -> None
         "CanonicalOwnerRefV1(", 1
     )[0]
     assert 'reuse_status="REUSED"' in economic_block
+
+
+def test_owner_registry_diagnostics_summary_option_a_keep_not_bound() -> None:
+    """Phase 4.6C: diagnostics_summary stays NOT_BOUND; ReadModel is not its source."""
+    registry_text = (LANDSCAPE_PKG / "owner_registry.py").read_text(encoding="utf-8")
+    assert 'slot="diagnostics_summary"' in registry_text
+    diagnostics_block = registry_text.split('slot="diagnostics_summary"', 1)[1].split(
+        "CanonicalOwnerRefV1(", 1
+    )[0]
+    assert 'owner_module="UNRESOLVED"' in diagnostics_block
+    assert 'owner_symbol="UNRESOLVED"' in diagnostics_block
+    assert 'reuse_status="NOT_BOUND"' in diagnostics_block
+    assert "Phase 4.6C" in diagnostics_block
+    assert "OPTION_A_KEEP_NOT_BOUND" in diagnostics_block
+    assert "consumer-contract redesign" in diagnostics_block
+    assert "WorkflowDashboardReadModelV1" in diagnostics_block
+    assert "MUST NOT" in diagnostics_block
+    # Must not silently reclaim WorkflowDashboardReadModelV1 as bound owner/source.
+    assert 'owner_module="webui.workflow_dashboard_readmodel_v1.types"' not in diagnostics_block
+    assert 'owner_symbol="WorkflowDashboardReadModelV1"' not in diagnostics_block
+    assert 'reuse_status="PROJECTION_ONLY"' not in diagnostics_block
+    assert 'reuse_status="REUSED"' not in diagnostics_block
+
+    # No diagnostics producer / typed injection / project_* adapter authorized.
+    landscape_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in _iter_py_files(LANDSCAPE_PKG)
+    )
+    producer = PRODUCER_BINDING.read_text(encoding="utf-8")
+    for token in (
+        "project_diagnostics_summary",
+        "project_diagnostics_",
+        "bind_diagnostics",
+    ):
+        assert token not in landscape_text, token
+        assert token not in producer, token
+    assert "WorkflowDashboardReadModelV1" not in producer
+
+    runbook = (
+        REPO
+        / "docs"
+        / "ops"
+        / "market_dashboard"
+        / "PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md"
+    ).read_text(encoding="utf-8")
+    assert "##### 4.6C — Diagnostics Summary Contract Architecture Ratification" in runbook
+    assert "RATIFY_OPTION_A_KEEP_NOT_BOUND=true" in runbook
+    assert "DIAGNOSTICS_SUMMARY_STATUS=NOT_BOUND" in runbook
+    assert "SOLE_DIAGNOSTICS_OWNER=UNRESOLVED" in runbook
+    assert "OPTION_B_NEW_DOMAIN_NEUTRAL_DIAGNOSTICS_EVIDENCE=REJECTED" in runbook
+    assert "OPTION_D_SOURCE_HEALTH_ONLY=REJECTED" in runbook
+    assert (
+        "OPTION_C_MULTIPLE_DOMAIN_SPECIFIC_DIAGNOSTICS=DEFERRED_SEPARATE_OPERATOR_AUTHORIZED_REDESIGN"
+        in runbook
+    )
+    assert "WORKFLOW_DASHBOARD_READMODEL_V1=NON_SOURCE_PROJECTION_ONLY" in runbook

--- a/tests/webui/test_market_landscape_dashboard_v2_contracts_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_contracts_v0.py
@@ -420,3 +420,25 @@ def test_economic_owner_registry_ratified_bound() -> None:
     assert "economic_viability_status" in entry.notes
     assert "explicit injection only" in entry.notes
     assert "MISSING_SOURCE" in entry.notes
+
+
+def test_diagnostics_summary_owner_registry_option_a_not_bound() -> None:
+    """Phase 4.6C OPTION_A: diagnostics_summary NOT_BOUND; owner UNRESOLVED."""
+    entry = owner_registry_by_slot()["diagnostics_summary"]
+    assert entry.owner_module == "UNRESOLVED"
+    assert entry.owner_symbol == "UNRESOLVED"
+    assert entry.reuse_status == "NOT_BOUND"
+    assert entry.authority_class == "diagnostics"
+    assert "Phase 4.6C" in entry.notes
+    assert "OPTION_A_KEEP_NOT_BOUND" in entry.notes
+    assert "WorkflowDashboardReadModelV1" in entry.notes
+    assert "NON_SOURCE" in entry.notes
+    assert "consumer-contract redesign" in entry.notes
+    assert "OPTION_B" in entry.notes
+    assert "OPTION_D" in entry.notes
+    assert "OPTION_C" in entry.notes
+    # Default runtime availability remains NOT_BOUND (no silent rebinding).
+    bundle = default_not_bound_bundle(generated_at=STAMP)
+    snap = bundle["diagnostics_summary"]
+    assert snap.availability is Availability.NOT_BOUND
+    assert serialize_projection(snap)["availability"] == "NOT_BOUND"


### PR DESCRIPTION
## Summary

- **Architecture decision (OPTION A ratified):** `diagnostics_summary` remains `NOT_BOUND` with sole owner `UNRESOLVED`.
- Canonical closeout only: Master Runbook §4.6C + `owner_registry.py` notes + narrow regression guards.
- `WorkflowDashboardReadModelV1` remains `NON_SOURCE` / `PROJECTION_ONLY` and is **not** the diagnostics owner/source.
- `summary` is **not** ratified as producer-owned evidence; consumer-contract redesign required before any future binding.
- **OPTION_B** (new domain-neutral diagnostics evidence) **rejected**.
- **OPTION_D** (source-health only) **rejected**.
- **OPTION_C** (multiple domain-specific diagnostics) **deferred** to a separate operator-authorized redesign phase — not part of this PR.
- **No** diagnostics producer, evidence contract, adapter, `project_diagnostics_*`, or typed injection was created.
- **No** `DiagnosticsSummarySnapshotV1` redesign / binding; **no** UI/template/CSS/screenshots; **no** Phase 5 / Product Polish.
- LIVE/ORDERS/SHADOW/PAPER/TESTNET/SCHEDULER/RUNTIME remain disabled (`LIVE_AUTHORIZED=false`, `ORDERS=false`, `RUNTIME_ACTIVATION=false`).
- Auto-merge: **false**. Do not merge from this PR body alone.

## Files changed

- `docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md`
- `src/webui/market_dashboard_landscape_v2/owner_registry.py`
- `tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py`
- `tests/webui/test_market_landscape_dashboard_v2_contracts_v0.py`

## Tests executed

- Narrow Phase 4.6C guards/contracts (diagnostics NOT_BOUND / owner UNRESOLVED)
- Full architecture_guards + contracts suites for Landscape V2
- Selector `PR_BOUNDED_FULL` path-equivalent suite (755 passed, ~49s wallclock; target max 840s)

## Test plan

- [x] Local ruff format/check on touched Python files
- [x] Docs reference targets verify
- [x] Docs token policy preflight
- [x] CI selector + PR-bounded contract suite
- [ ] GitHub CI confirmation (no merge until green)


Made with [Cursor](https://cursor.com)