### PR TITLE
Market Dashboard Phase 4.7B: ratify Autonomy OPTION_D closeout

### DIFF
--- a/docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md
+++ b/docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md
@@ -821,7 +821,7 @@ as inputs to one Autonomy aggregate.
 
 Canonical owner registry note:
 `src/webui/market_dashboard_landscape_v2/owner_registry.py` slot
-`autonomy_stage` → `reuse_status=NOT_BOUND`, `owner=NONE`, `source/contract=NONE`.
+`autonomy_stage` → `reuse_status=NOT_BOUND`, `owner=NONE`, `source&#47;contract=NONE`.
 
 ### Gate pro Bindung
 

--- a/docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md
+++ b/docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md
@@ -468,7 +468,7 @@ Die neue Surface vollständig spezifizieren, bevor produktive UI gebaut wird.
 | Runtime State | Runtime Bridge State | canonical status | `MISSING` | Header |
 | Kill Switch | Safety Authority | veto authority | `MISSING` | Header/Risk |
 | Economic Gate | Economic Evidence | promotion-only | `MISSING` | Secondary |
-| Autonomy Stage | Autonomy/Governance State | canonical status | `NOT_BOUND` | Secondary |
+| Autonomy Stage | NONE (OPTION_D; docs-only ladder; no productive aggregate) | non-source / NOT_BOUND | `NOT_BOUND` | Secondary |
 
 ### Gate
 
@@ -765,12 +765,63 @@ Canonical owner registry note:
 `src/webui/market_dashboard_landscape_v2/owner_registry.py` slot
 `diagnostics_summary` → `reuse_status=NOT_BOUND`, `owner=UNRESOLVED`.
 
-#### 4.7 Autonomy State
+#### 4.7 Autonomy State — Architecture Ratification Closeout (RATIFIED OPTION D)
 
-- aktuelle Autonomy-Stufe
-- erfüllte/nicht erfüllte Gates
-- nächste formal zulässige Stufe
-- `future-only` klar von `active` trennen
+```text
+PHASE=PHASE_4_7B_AUTONOMY_OPTION_D_CLOSEOUT
+PHASE_4_7A_RATIFIED_OPTION_D=true
+RATIFY_OPTION_D_NO_CANONICAL_AGGREGATE_REQUIRED=true
+AUTONOMY_STAGE_BINDING_STATUS=NOT_BOUND
+AUTONOMY_AGGREGATE_REQUIRED=false
+AUTONOMY_BINDING_COMPLETE_BY_EXPLICIT_NOT_BOUND=true
+SOLE_AUTONOMY_OWNER=NONE
+SOLE_AUTONOMY_PRODUCER=NONE
+SOLE_AUTONOMY_CONTRACT=NONE
+SOURCE_TYPE=DOCS_ONLY
+AUTHORITY_EFFECT=NONE
+STAGE_LADDER_PRODUCTIVE_OR_DOCS_ONLY=DOCS_ONLY
+CROSS_SOURCE_SYNTHESIS_AUTHORIZED=false
+WORKFLOW_DASHBOARD_READMODEL_V1=NON_SOURCE
+DASHBOARD_CAN_BE_OWNER=false
+BINDING_AUTHORIZED=false
+PRODUCER_CREATION_AUTHORIZED=false
+CONTRACT_CREATION_AUTHORIZED=false
+ADAPTER_CREATION_AUTHORIZED=false
+DASHBOARD_INJECTION_AUTHORIZED=false
+```
+
+**D_STATUS — RATIFIED NO CANONICAL AGGREGATE; KEEP NOT_BOUND**
+
+- `autonomy_stage` remains explicitly `NOT_BOUND`.
+- Phase 4.7 does **not** require a canonical unified Autonomy-State aggregate.
+- Autonomy stages 0–7 remain **docs-only informative review vocabulary**
+  (roadmap §3.1 / Runtime Lane Taxonomy §12). They are **not** productive
+  operational state.
+- Autonomy stage is **not** runtime bridge status (`BOUND_NOT_ACTIVATED` /
+  `CANONICAL_RUNTIME_ENTRYPOINT_STATUS` remain a separate Runtime State fact).
+- Autonomy stage is **not** promotion eligibility, scheduler status, worker/
+  job status, safety veto, capital authorization, operator-GO, or live
+  authorization.
+- Separate canonical facts may be displayed only through their own
+  independently ratified source families.
+- No cross-source synthesis into an Autonomy state is allowed.
+- `WorkflowDashboardReadModelV1` remains `NON_SOURCE`.
+- The Market Dashboard cannot own or infer Autonomy state.
+- No Autonomy producer, contract, adapter, projection helper, or dashboard
+  injection is authorized by this closeout.
+
+**Product intent (unchanged, not binding under OPTION_D)**
+
+Operators may still *want* a future coherent Autonomy readout. Under OPTION_D
+that intent stays aspirational / `NOT_BOUND` until a separate, explicitly
+authorized architecture decision supersedes this closeout. Do **not** calculate
+a next permissible stage, synthesize gate results into one ladder state, or treat
+Runtime Bridge / Pre-Activation / Promotion / Scheduler / Worker / Operator-GO
+as inputs to one Autonomy aggregate.
+
+Canonical owner registry note:
+`src/webui/market_dashboard_landscape_v2/owner_registry.py` slot
+`autonomy_stage` → `reuse_status=NOT_BOUND`, `owner=NONE`, `source/contract=NONE`.
 
 ### Gate pro Bindung
 
@@ -1454,7 +1505,7 @@ NOT_BOUND_SOURCES=[
   "safety_authority",
   "execution_reconciliation",
   "economic_summary",
-  "autonomy_stage producer binding",
+  "autonomy_stage (OPTION_D explicit NOT_BOUND; no producer/contract)",
   "diagnostics_summary",
   "event_decision_timeline"
 ]
@@ -1462,7 +1513,7 @@ MISSING_READ_PROJECTIONS=[
   "market/universe/scope UI binding (PR 3 / Phase 4.1-4.2)",
   "decision/DP UI binding (PR 4 / Phase 4.3)",
   "safety/risk/execution UI binding (PR 5 / Phase 4.4-4.5)",
-  "economic/diagnostics/autonomy UI binding (PR 6 / Phase 4.6-4.7)"
+  "economic/diagnostics UI binding (PR 6 / Phase 4.6); autonomy remains OPTION_D NOT_BOUND"
 ]
 MISSING_PRODUCERS=[]
 KNOWN_INTENTIONAL_LOCKS=[
@@ -1471,7 +1522,8 @@ KNOWN_INTENTIONAL_LOCKS=[
   "Strategy Signal Selection D / Slice 2 blocked",
   "Ops Double Play projection-only",
   "Phase 4 producer binding not authorized in this PR",
-  "Phase 4.6C diagnostics_summary OPTION_A KEEP_NOT_BOUND (owner UNRESOLVED; WorkflowDashboardReadModelV1 NON_SOURCE)"
+  "Phase 4.6C diagnostics_summary OPTION_A KEEP_NOT_BOUND (owner UNRESOLVED; WorkflowDashboardReadModelV1 NON_SOURCE)",
+  "Phase 4.7A/4.7B autonomy_stage OPTION_D KEEP_NOT_BOUND (aggregate not required; owner/producer/contract=NONE; runtime bridge status separate NON_SOURCE)"
 ]
 
 PHASE_PR_MAPPING=[

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -132,11 +132,25 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
     ),
     CanonicalOwnerRefV1(
         slot="autonomy_stage",
-        owner_module="trading.master_v2.runtime_bridge_pre_activation_gate_v0",
-        owner_symbol="BOUND_NOT_ACTIVATED",
-        authority_class="runtime_status",
+        owner_module="NONE",
+        owner_symbol="NONE",
+        authority_class="autonomy",
         reuse_status="NOT_BOUND",
-        notes="Runtime BOUND_NOT_ACTIVATED is intentional; display-only later.",
+        notes=(
+            "Phase 4.7B OPTION_D closeout: autonomy_stage remains NOT_BOUND; "
+            "no canonical productive Autonomy State aggregate required; "
+            "sole owner/producer/contract=NONE; Autonomy stages 0–7 are "
+            "docs-only informative review vocabulary (not productive "
+            "operational state); AUTHORITY_EFFECT=NONE; runtime bridge status "
+            "(BOUND_NOT_ACTIVATED / CANONICAL_RUNTIME_ENTRYPOINT_STATUS) is a "
+            "separate fact and NON_SOURCE for autonomy_stage; "
+            "RuntimeBridgePreActivationGate, promotion_economic_gate_v1, "
+            "KillSwitch, scheduler/worker, and WorkflowDashboardReadModelV1 "
+            "MUST NOT be named as autonomy_stage owner/source; "
+            "cross-source synthesis into Autonomy state unauthorized; "
+            "dashboard cannot own or infer Autonomy state; "
+            "binding/producer/contract/adapter/injection authorized=false."
+        ),
     ),
     CanonicalOwnerRefV1(
         slot="diagnostics_summary",

--- a/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
@@ -652,3 +652,100 @@ def test_owner_registry_diagnostics_summary_option_a_keep_not_bound() -> None:
         in runbook
     )
     assert "WORKFLOW_DASHBOARD_READMODEL_V1=NON_SOURCE_PROJECTION_ONLY" in runbook
+
+
+def test_owner_registry_autonomy_stage_option_d_keep_not_bound() -> None:
+    """Phase 4.7B OPTION_D: autonomy_stage NOT_BOUND; no aggregate; runtime separate."""
+    from datetime import datetime, timezone
+
+    from webui.market_dashboard_landscape_v2.availability import Availability
+    from webui.market_dashboard_landscape_v2.owner_registry import owner_registry_by_slot
+    from webui.market_dashboard_landscape_v2.unavailable import default_not_bound_bundle
+
+    entry = owner_registry_by_slot()["autonomy_stage"]
+    assert entry.owner_module == "NONE"
+    assert entry.owner_symbol == "NONE"
+    assert entry.reuse_status == "NOT_BOUND"
+    assert entry.authority_class == "autonomy"
+    stamp = datetime(2026, 7, 24, 0, 0, 0, tzinfo=timezone.utc)
+    snap = default_not_bound_bundle(generated_at=stamp)["autonomy_stage"]
+    assert snap.availability is Availability.NOT_BOUND
+    assert snap.autonomy_stage is None
+    assert snap.runtime_bridge_status is None
+
+    registry_text = (LANDSCAPE_PKG / "owner_registry.py").read_text(encoding="utf-8")
+    assert 'slot="autonomy_stage"' in registry_text
+    autonomy_block = registry_text.split('slot="autonomy_stage"', 1)[1].split(
+        "CanonicalOwnerRefV1(", 1
+    )[0]
+    assert 'owner_module="NONE"' in autonomy_block
+    assert 'owner_symbol="NONE"' in autonomy_block
+    assert 'reuse_status="NOT_BOUND"' in autonomy_block
+    assert 'authority_class="autonomy"' in autonomy_block
+    assert "Phase 4.7B" in autonomy_block
+    assert "OPTION_D" in autonomy_block
+    assert "docs-only" in autonomy_block
+    assert "AUTHORITY_EFFECT=NONE" in autonomy_block
+    assert "NON_SOURCE" in autonomy_block
+    assert "WorkflowDashboardReadModelV1" in autonomy_block
+    assert "MUST NOT" in autonomy_block
+    # Runtime bridge status must not be named as autonomy_stage owner/source.
+    assert "runtime_bridge_pre_activation_gate_v0" not in autonomy_block
+    assert 'owner_symbol="BOUND_NOT_ACTIVATED"' not in autonomy_block
+    assert 'authority_class="runtime_status"' not in autonomy_block
+    assert "CANONICAL_RUNTIME_ENTRYPOINT_STATUS" in autonomy_block
+    assert "separate fact" in autonomy_block
+    # Must not reclaim WorkflowDashboardReadModelV1 or other productive owners.
+    assert 'owner_module="webui.workflow_dashboard_readmodel_v1.types"' not in autonomy_block
+    assert 'owner_symbol="WorkflowDashboardReadModelV1"' not in autonomy_block
+    assert "promotion_economic_gate_v1" in autonomy_block
+    assert 'reuse_status="REUSED"' not in autonomy_block
+    assert 'reuse_status="PROJECTION_ONLY"' not in autonomy_block
+
+    # Runtime State vs Autonomy Stage remain distinct registry semantics.
+    assert 'slot="autonomy_stage"' in registry_text
+    assert "BOUND_NOT_ACTIVATED" in registry_text
+    assert "separate fact and NON_SOURCE for autonomy_stage" in autonomy_block
+
+    # No Autonomy producer / injection / project_autonomy_* adapter.
+    landscape_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in _iter_py_files(LANDSCAPE_PKG)
+    )
+    producer = PRODUCER_BINDING.read_text(encoding="utf-8")
+    projections = (LANDSCAPE_PKG / "projections.py").read_text(encoding="utf-8")
+    contracts = (LANDSCAPE_PKG / "contracts.py").read_text(encoding="utf-8")
+    for token in (
+        "project_autonomy_",
+        "project_autonomy_stage",
+        "bind_autonomy",
+        "AutonomyStateAggregate",
+        "CanonicalAutonomyState",
+    ):
+        assert token not in landscape_text, token
+        assert token not in producer, token
+        assert token not in projections, token
+    assert "class AutonomyStageSnapshotV1" in contracts
+    assert "class AutonomyStateAggregate" not in contracts
+    assert "WorkflowDashboardReadModelV1" not in producer
+
+    runbook = (
+        REPO
+        / "docs"
+        / "ops"
+        / "market_dashboard"
+        / "PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md"
+    ).read_text(encoding="utf-8")
+    assert "PHASE_4_7A_RATIFIED_OPTION_D=true" in runbook
+    assert "RATIFY_OPTION_D_NO_CANONICAL_AGGREGATE_REQUIRED=true" in runbook
+    assert "AUTONOMY_STAGE_BINDING_STATUS=NOT_BOUND" in runbook
+    assert "AUTONOMY_AGGREGATE_REQUIRED=false" in runbook
+    assert "AUTONOMY_BINDING_COMPLETE_BY_EXPLICIT_NOT_BOUND=true" in runbook
+    assert "SOLE_AUTONOMY_OWNER=NONE" in runbook
+    assert "SOLE_AUTONOMY_PRODUCER=NONE" in runbook
+    assert "SOLE_AUTONOMY_CONTRACT=NONE" in runbook
+    assert "CROSS_SOURCE_SYNTHESIS_AUTHORIZED=false" in runbook
+    assert "WORKFLOW_DASHBOARD_READMODEL_V1=NON_SOURCE" in runbook
+    assert "DASHBOARD_CAN_BE_OWNER=false" in runbook
+    # Visible-fact registry keeps Runtime State distinct from Autonomy Stage.
+    assert "| Runtime State | Runtime Bridge State |" in runbook
+    assert "OPTION_D; docs-only ladder; no productive aggregate" in runbook


### PR DESCRIPTION
## Summary
- Ratifies Phase 4.7A **OPTION_D**: no canonical unified Autonomy-State aggregate is required; `autonomy_stage` remains explicitly `NOT_BOUND` with owner/producer/contract=`NONE`.
- Keeps runtime bridge status (`BOUND_NOT_ACTIVATED`) a **separate** fact and **NON_SOURCE** for `autonomy_stage`; productive authorities (promotion, safety, scheduler/worker, operator/live) remain separate.
- Docs + owner-registry + architecture guards only — no producer, contract, adapter, binding, injection, route/presenter/template change.

## Test plan
- [x] Focused architecture/registry guards for OPTION_D NOT_BOUND
- [x] PR-bounded selector suite (`PR_BOUNDED_FULL`) — 736 passed (~37s)
- [x] `ruff format --check` / `ruff check` on modified Python
- [x] Docs reference targets + token policy preflight
- [x] Unrelated dirty/untracked fingerprints preserved byte-identically

## Authority / safety
- LIVE/ORDERS/RUNTIME/SCHEDULER/PROMOTION/CAPITAL unchanged and false
- Dashboard remains consumer-only; WorkflowDashboardReadModelV1 remains NON_SOURCE
- Cross-source Autonomy synthesis unauthorized
- No merge / no auto-merge requested
