### PR TITLE
Workflow Dashboard: define canonical durable archive root

### DIFF
--- a/config/webui/workflow_dashboard_archive_root_v1.json
+++ b/config/webui/workflow_dashboard_archive_root_v1.json
@@ -1,0 +1,31 @@
+{
+  "schema_id": "workflow_dashboard_archive_root_v1",
+  "schema_version": 1,
+  "non_authorizing": true,
+  "owner_module": "src.webui.workflow_dashboard_archive_root_v1",
+  "owner_symbol": "resolve_workflow_dashboard_archive_root",
+  "config_contract_path": "config/webui/workflow_dashboard_archive_root_v1.json",
+  "env_override": "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT",
+  "precedence": [
+    "explicit_injection",
+    "environment_override",
+    "canonical_default"
+  ],
+  "canonical_default": {
+    "convention": "platform_aware_user_state",
+    "darwin": "~/Library/Application Support/Peak_Trade/workflow_dashboard_v1",
+    "linux": "${XDG_STATE_HOME:-~/.local/state}/peak_trade/workflow_dashboard_v1",
+    "win32": "%LOCALAPPDATA%/Peak_Trade/workflow_dashboard_v1"
+  },
+  "resolver_creates_filesystem": false,
+  "fixture_fallback_allowed": false,
+  "repo_local_runtime_truth_allowed": false,
+  "tmp_default_allowed": false,
+  "empty_directory_is_valid_data": false,
+  "notes": [
+    "Sole configuration owner for Workflow/Market Dashboard durable archive root location.",
+    "Does not authorize live trading, orders, runtime activation, or dashboard Universe autoload.",
+    "Missing readmodels under a resolved root remain fail-closed MISSING_SOURCE at consumer boundaries.",
+    "PEAK_TRADE_DATA_ARCHIVE_ROOT and review_server .run/ state are non-owners for this contract."
+  ]
+}

--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -47,7 +47,8 @@ Stable Markers sind **Anzeige-/Test-Anker**, keine Claims zu Betriebsreadiness o
 
 **Route:** **`GET &#47;observability`** only (extends hub; no duplicate route).
 
-- **Gate (default off):** `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED=1` and `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT=<durable archive root>` — implemented in `src/webui/workflow_dashboard_runtime_v1.py`.
+- **Gate (default off):** `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED=1` — implemented in `src/webui/workflow_dashboard_runtime_v1.py`.
+- **Archive root owner:** [WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md](WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md) — sole resolver `src/webui/workflow_dashboard_archive_root_v1.py` (explicit → `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT` → canonical user-state default). Env remains a supported override; default does not create directories or invent readmodels.
 - **Readmodel:** `workflow_dashboard_readmodel.v1` with embedded `workflow_pipeline_aggregate.v1` — builder `src/webui/workflow_dashboard_readmodel_v1/`.
 - **Panels (A–J):** Safety, Universe/Top20/Selected/Future missing-truth, Pipeline P1→T3, Orders/Fills/PnL, Evidence, KillSwitch, Next GO.
 - **Missing truth:** `UNIVERSE_SOURCE_NOT_PERSISTED`, `TOP20_RANKING_NOT_PERSISTED`, `SELECTED_FUTURE_NOT_PERSISTED`, `FUTURE_DETAIL_NOT_AVAILABLE` — **never** inferred from removed Market Dashboard routes or dummy OHLCV fixtures.
@@ -71,7 +72,7 @@ Additive Workflow Dashboard V1 panel — **diagnostic-only**, **not** observabil
 
 **Contract doc:** [**Universe Selection Read-model Schema v1**](UNIVERSE_SELECTION_READMODEL_V1.md) — `schema_name=universe_selection_readmodel.v1`.
 
-- **Storage target (Slice 2+):** `{ARCHIVE_ROOT}&#47;readmodels&#47;universe_selection_readmodel.v1.json` under `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT`.
+- **Storage target (Slice 2+):** `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json` where `{ARCHIVE_ROOT}` is resolved by [WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md](WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md) (Env override `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT` still supported).
 - **Validation (Slice 1):** `src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py` — offline schema only; **no archive writes**, **no runtime I/O**.
 - **Dashboard today:** Panels B–E remain **Missing Truth** (`UNIVERSE_SOURCE_NOT_PERSISTED`, `TOP20_RANKING_NOT_PERSISTED`, `SELECTED_FUTURE_NOT_PERSISTED`, `FUTURE_DETAIL_NOT_AVAILABLE`). Slice 1 does **not** populate rows.
 - **Slice 3 (future):** `workflow_dashboard_readmodel.v1` builder will read the persisted file when present and manifest-verified; until then Missing Truth stays valid.

--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -72,7 +72,7 @@ Additive Workflow Dashboard V1 panel — **diagnostic-only**, **not** observabil
 
 **Contract doc:** [**Universe Selection Read-model Schema v1**](UNIVERSE_SELECTION_READMODEL_V1.md) — `schema_name=universe_selection_readmodel.v1`.
 
-- **Storage target (Slice 2+):** `{ARCHIVE_ROOT}/readmodels/universe_selection_readmodel.v1.json` where `{ARCHIVE_ROOT}` is resolved by [WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md](WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md) (Env override `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT` still supported).
+- **Storage target (Slice 2+):** `{ARCHIVE_ROOT}&#47;readmodels&#47;universe_selection_readmodel.v1.json` where `{ARCHIVE_ROOT}` is resolved by [WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md](WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md) (Env override `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT` still supported).
 - **Validation (Slice 1):** `src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py` — offline schema only; **no archive writes**, **no runtime I/O**.
 - **Dashboard today:** Panels B–E remain **Missing Truth** (`UNIVERSE_SOURCE_NOT_PERSISTED`, `TOP20_RANKING_NOT_PERSISTED`, `SELECTED_FUTURE_NOT_PERSISTED`, `FUTURE_DETAIL_NOT_AVAILABLE`). Slice 1 does **not** populate rows.
 - **Slice 3 (future):** `workflow_dashboard_readmodel.v1` builder will read the persisted file when present and manifest-verified; until then Missing Truth stays valid.

--- a/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
+++ b/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
@@ -30,7 +30,8 @@ This document defines the **normative persistence contract** for **`universe_sel
 | Storage target | `{ARCHIVE_ROOT}&#47;readmodels&#47;universe_selection_readmodel.v1.json` |
 | Validation module | `src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py` |
 | Dashboard consumer (Slice 3+) | `src/webui/workflow_dashboard_readmodel_v1/builder.py` |
-| Workflow SSR gate | `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED=1` + `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT` |
+| Workflow SSR gate | `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED=1` + archive root via [WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md](WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md) (Env override still supported) |
+| Archive root owner | `src/webui/workflow_dashboard_archive_root_v1.py` |
 
 ## 4. Required top-level fields
 
@@ -237,7 +238,7 @@ Governed bundles with `u2b_candidate_validation_only=true` and `candidate_valida
 
 **Module:** `src/webui/workflow_dashboard_readmodel_v1/universe_selection_reader_v1.py`  
 **Consumer:** `src/webui/workflow_dashboard_readmodel_v1/builder.py`  
-**SSR gate:** `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED=1` + `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT` (unchanged)  
+**SSR gate:** `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED=1` + archive root via [WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md](WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md) (Env override still supported)  
 **Tests:** `tests/webui/test_universe_selection_reader_v1.py`
 
 **Storage path:** `{ARCHIVE_ROOT}&#47;readmodels&#47;universe_selection_readmodel.v1.json`

--- a/docs/webui/observability/WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md
+++ b/docs/webui/observability/WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md
@@ -4,14 +4,14 @@
 
 Sole configuration owner for the **durable archive root location** used by
 Workflow Dashboard V1 and Market Landscape V2 consumers that read
-`universe_selection_readmodel.v1` under `{ARCHIVE_ROOT}/readmodels/`.
+`universe_selection_readmodel.v1` under `{ARCHIVE_ROOT}&#47;readmodels&#47;`.
 
 This contract owns **where** the archive root is resolved. It does **not**:
 
 - authorize live trading, orders, runtime activation, or scheduler work;
 - create directories during import or resolution;
 - write or copy readmodels;
-- autoload Universe onto `GET /market`;
+- autoload Universe onto `GET &#47;market`;
 - change visible dashboard panels by itself.
 
 ## Ownership
@@ -27,8 +27,8 @@ This contract owns **where** the archive root is resolved. It does **not**:
 Non-owners (must not become a second dashboard archive convention):
 
 - `PEAK_TRADE_DATA_ARCHIVE_ROOT` (research data archive)
-- `scripts/webui/review_server.sh` `.run/webui_review_server` process state
-- `tests/fixtures/**`
+- `scripts/webui/review_server.sh` `.run&#47;webui_review_server` process state
+- `tests&#47;fixtures&#47;**`
 
 ## Precedence
 
@@ -42,15 +42,15 @@ Deterministic, absolute, cwd-independent user-state location:
 
 | Platform | Default |
 |----------|---------|
-| macOS | `~/Library/Application Support/Peak_Trade/workflow_dashboard_v1` |
-| Linux | `${XDG_STATE_HOME:-~/.local/state}/peak_trade/workflow_dashboard_v1` |
-| Windows | `%LOCALAPPDATA%/Peak_Trade/workflow_dashboard_v1` |
+| macOS | `~&#47;Library&#47;Application Support&#47;Peak_Trade&#47;workflow_dashboard_v1` |
+| Linux | `${XDG_STATE_HOME:-~&#47;.local&#47;state}&#47;peak_trade&#47;workflow_dashboard_v1` |
+| Windows | `%LOCALAPPDATA%&#47;Peak_Trade&#47;workflow_dashboard_v1` |
 
 Default selection rejects:
 
 - repository working tree / tracked truth
-- `tests/fixtures`
-- `/tmp` (and tmp-backed `XDG_STATE_HOME`)
+- `tests&#47;fixtures`
+- `&#47;tmp` (and tmp-backed `XDG_STATE_HOME`)
 - bare filesystem root / bare home directory
 
 ## Resolution semantics

--- a/docs/webui/observability/WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md
+++ b/docs/webui/observability/WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md
@@ -1,0 +1,71 @@
+# Workflow Dashboard Archive Root v1
+
+## Purpose
+
+Sole configuration owner for the **durable archive root location** used by
+Workflow Dashboard V1 and Market Landscape V2 consumers that read
+`universe_selection_readmodel.v1` under `{ARCHIVE_ROOT}/readmodels/`.
+
+This contract owns **where** the archive root is resolved. It does **not**:
+
+- authorize live trading, orders, runtime activation, or scheduler work;
+- create directories during import or resolution;
+- write or copy readmodels;
+- autoload Universe onto `GET /market`;
+- change visible dashboard panels by itself.
+
+## Ownership
+
+| Field | Value |
+|-------|-------|
+| Contract id | `workflow_dashboard_archive_root_v1` |
+| Config | `config/webui/workflow_dashboard_archive_root_v1.json` |
+| Owner module | `src.webui.workflow_dashboard_archive_root_v1` |
+| Owner symbol | `resolve_workflow_dashboard_archive_root` |
+| Env override | `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT` |
+
+Non-owners (must not become a second dashboard archive convention):
+
+- `PEAK_TRADE_DATA_ARCHIVE_ROOT` (research data archive)
+- `scripts/webui/review_server.sh` `.run/webui_review_server` process state
+- `tests/fixtures/**`
+
+## Precedence
+
+1. Explicit function/CLI/config injection (`explicit=` / binder `archive_root=`)
+2. Environment override `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT`
+3. Canonical platform-aware local default
+
+## Canonical default
+
+Deterministic, absolute, cwd-independent user-state location:
+
+| Platform | Default |
+|----------|---------|
+| macOS | `~/Library/Application Support/Peak_Trade/workflow_dashboard_v1` |
+| Linux | `${XDG_STATE_HOME:-~/.local/state}/peak_trade/workflow_dashboard_v1` |
+| Windows | `%LOCALAPPDATA%/Peak_Trade/workflow_dashboard_v1` |
+
+Default selection rejects:
+
+- repository working tree / tracked truth
+- `tests/fixtures`
+- `/tmp` (and tmp-backed `XDG_STATE_HOME`)
+- bare filesystem root / bare home directory
+
+## Resolution semantics
+
+- Returned paths are absolute after normalization.
+- Resolver **never** creates filesystem entries.
+- Consumer call sites use `require_existing_directory=True` so a not-yet-created
+  default remains `None` → existing `unconfigured` / `MISSING_SOURCE` /
+  `UNIVERSE_ARCHIVE_ROOT_UNSET` behavior is preserved until an explicit writer
+  creates the directory and persists readmodels.
+- An empty directory is **not** valid dashboard data.
+- Missing / invalid / unverified readmodels under a resolved root remain
+  fail-closed at the reader/binder (`MISSING_SOURCE` / `INVALID`).
+
+## Non-authority
+
+`non_authorizing: true`. Evidence and path ownership ≠ approval, live unlock,
+or Market Dashboard product completion.

--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -27,7 +27,6 @@ Fail-closed:
 
 from __future__ import annotations
 
-import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -52,15 +51,17 @@ from .market_dashboard_landscape_v2.unavailable import (
     unavailable_safety_authority,
     unavailable_universe_ranking,
 )
+from .workflow_dashboard_archive_root_v1 import (
+    ENV_ARCHIVE_ROOT,
+    WorkflowDashboardArchiveRootError,
+    resolve_workflow_dashboard_archive_root,
+)
 from .workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
     FORBIDDEN_SELECTED_SYMBOLS,
 )
 from .workflow_dashboard_readmodel_v1.universe_selection_reader_v1 import (
     try_load_universe_selection_for_dashboard,
 )
-
-# Reuse the existing workflow-dashboard archive env — no second archive owner.
-ENV_ARCHIVE_ROOT = "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT"
 
 # F2 consuming-surface max_allowed_staleness_seconds for Landscape Phase 4.1+.
 # Declared here as the dashboard consumer policy; never invent freshness via now().
@@ -120,26 +121,20 @@ _ISO8601_UTC_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?
 def resolve_landscape_archive_root(
     archive_root: str | Path | None = None,
 ) -> Path | None:
-    """Resolve durable archive root for universe_selection readmodel load."""
-    if archive_root is not None:
-        raw = str(archive_root).strip()
-        if not raw:
-            return None
-        path = Path(raw).expanduser()
-        try:
-            path = path.resolve(strict=True)
-        except OSError:
-            return None
-        return path if path.is_dir() else None
-    env_raw = (os.getenv(ENV_ARCHIVE_ROOT) or "").strip()
-    if not env_raw:
-        return None
-    path = Path(env_raw).expanduser()
+    """Resolve durable archive root for universe_selection readmodel load.
+
+    Delegates to the sole Workflow Dashboard archive-root contract owner.
+    Does not create directories. A missing default directory remains None so
+    consumers keep fail-closed MISSING_SOURCE / ARCHIVE_ROOT_UNSET semantics.
+    """
     try:
-        path = path.resolve(strict=True)
-    except OSError:
+        return resolve_workflow_dashboard_archive_root(
+            explicit=archive_root,
+            require_existing_directory=True,
+        )
+    except WorkflowDashboardArchiveRootError:
+        # Explicit empty/invalid injection stays fail-closed as unset for binder.
         return None
-    return path if path.is_dir() else None
 
 
 def parse_producer_utc_timestamp(raw: str | None) -> datetime | None:

--- a/src/webui/workflow_dashboard_archive_root_v1.py
+++ b/src/webui/workflow_dashboard_archive_root_v1.py
@@ -1,0 +1,261 @@
+"""Canonical durable archive-root contract for Workflow/Market Dashboard.
+
+Sole owner of archive-root *location* resolution for dashboard consumers.
+Does not create directories, does not write readmodels, does not authorize
+trading, and does not autoload Universe onto GET /market.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+CONTRACT_ID = "workflow_dashboard_archive_root_v1"
+CONTRACT_SCHEMA_VERSION = 1
+CONFIG_CONTRACT_RELATIVE_PATH = "config/webui/workflow_dashboard_archive_root_v1.json"
+ENV_ARCHIVE_ROOT = "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT"
+
+OWNER_MODULE = "src.webui.workflow_dashboard_archive_root_v1"
+OWNER_SYMBOL = "resolve_workflow_dashboard_archive_root"
+
+DEFAULT_APP_DIRNAME = "Peak_Trade"
+DEFAULT_ARCHIVE_LEAF = "workflow_dashboard_v1"
+LINUX_APP_DIRNAME = "peak_trade"
+
+PRECEDENCE_EXPLICIT = "explicit_injection"
+PRECEDENCE_ENV = "environment_override"
+PRECEDENCE_DEFAULT = "canonical_default"
+PRECEDENCE_CHAIN: tuple[str, ...] = (
+    PRECEDENCE_EXPLICIT,
+    PRECEDENCE_ENV,
+    PRECEDENCE_DEFAULT,
+)
+
+
+class WorkflowDashboardArchiveRootError(ValueError):
+    """Fail-closed archive-root contract error."""
+
+
+def _repo_root() -> Path:
+    # src/webui/<module>.py → parents[2] = repo root
+    return Path(__file__).resolve().parents[2]
+
+
+def _environ_map(environ: Mapping[str, str] | None) -> Mapping[str, str]:
+    return os.environ if environ is None else environ
+
+
+def _platform_name(platform: str | None) -> str:
+    return sys.platform if platform is None else platform
+
+
+def _is_under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _tmp_roots() -> tuple[Path, ...]:
+    """POSIX ephemeral roots that must not host the canonical default.
+
+    Intentionally excludes process TMPDIR/TMP (often /var/folders on macOS),
+    which is not the dashboard default convention and would break isolated tests.
+    """
+    roots: list[Path] = []
+    for raw in ("/tmp", "/var/tmp"):
+        p = Path(raw)
+        try:
+            if p.exists():
+                roots.append(p.resolve())
+            else:
+                roots.append(p)
+        except OSError:
+            roots.append(p)
+    out: list[Path] = []
+    seen: set[str] = set()
+    for root in roots:
+        key = str(root)
+        if key not in seen:
+            out.append(root)
+            seen.add(key)
+    return tuple(out)
+
+
+def _path_is_under_tmp(path: Path) -> bool:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path.absolute()
+    resolved_posix = resolved.as_posix()
+    for tmp_root in _tmp_roots():
+        tmp_posix = tmp_root.as_posix().rstrip("/")
+        if resolved_posix == tmp_posix or resolved_posix.startswith(tmp_posix + "/"):
+            return True
+    return False
+
+
+def _assert_default_path_safe(path: Path, *, repo_root: Path) -> Path:
+    if not path.is_absolute():
+        raise WorkflowDashboardArchiveRootError("DEFAULT_ARCHIVE_ROOT_NOT_ABSOLUTE")
+    if path == Path(path.anchor):
+        raise WorkflowDashboardArchiveRootError("DEFAULT_ARCHIVE_ROOT_IS_FILESYSTEM_ROOT")
+    if path == Path.home().resolve():
+        raise WorkflowDashboardArchiveRootError("DEFAULT_ARCHIVE_ROOT_IS_HOME_DIRECTORY")
+    if _is_under(path, repo_root) or path == repo_root.resolve():
+        raise WorkflowDashboardArchiveRootError("DEFAULT_ARCHIVE_ROOT_INSIDE_GIT_REPO")
+    if _is_under(path, repo_root / "tests" / "fixtures"):
+        raise WorkflowDashboardArchiveRootError("DEFAULT_ARCHIVE_ROOT_IS_FIXTURE_PATH")
+    if _path_is_under_tmp(path):
+        raise WorkflowDashboardArchiveRootError("DEFAULT_ARCHIVE_ROOT_UNDER_TMP")
+    return path
+
+
+def canonical_default_workflow_dashboard_archive_root(
+    *,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    platform: str | None = None,
+    repo_root: Path | None = None,
+) -> Path:
+    """Return the deterministic canonical default archive root (absolute).
+
+    Never creates filesystem entries. Never selects fixtures, /tmp, or the
+    repository working tree. Independent of the process cwd.
+    """
+    env_map = _environ_map(environ)
+    plat = _platform_name(platform)
+    home_path = (Path.home() if home is None else Path(home)).expanduser()
+    if not home_path.is_absolute():
+        raise WorkflowDashboardArchiveRootError("HOME_NOT_ABSOLUTE")
+    home_path = home_path.resolve()
+    repo = (_repo_root() if repo_root is None else Path(repo_root)).resolve()
+
+    if plat == "darwin":
+        candidate = (
+            home_path
+            / "Library"
+            / "Application Support"
+            / DEFAULT_APP_DIRNAME
+            / DEFAULT_ARCHIVE_LEAF
+        )
+    elif plat.startswith("linux"):
+        xdg = str(env_map.get("XDG_STATE_HOME", "") or "").strip()
+        if xdg:
+            state_home = Path(xdg).expanduser()
+            if not state_home.is_absolute():
+                state_home = (home_path / state_home).resolve()
+            else:
+                state_home = state_home.resolve()
+            # Reject tmp-backed XDG_STATE_HOME for the canonical default.
+            if _path_is_under_tmp(state_home):
+                state_home = home_path / ".local" / "state"
+        else:
+            state_home = home_path / ".local" / "state"
+        candidate = state_home / LINUX_APP_DIRNAME / DEFAULT_ARCHIVE_LEAF
+    elif plat.startswith("win"):
+        local_app = str(env_map.get("LOCALAPPDATA", "") or "").strip()
+        if local_app:
+            base = Path(local_app).expanduser()
+            if not base.is_absolute():
+                raise WorkflowDashboardArchiveRootError("LOCALAPPDATA_NOT_ABSOLUTE")
+            base = base.resolve()
+        else:
+            base = home_path / "AppData" / "Local"
+        candidate = base / DEFAULT_APP_DIRNAME / DEFAULT_ARCHIVE_LEAF
+    else:
+        # Fail-closed portable fallback: user state under home, never repo/tmp.
+        candidate = home_path / ".local" / "state" / LINUX_APP_DIRNAME / DEFAULT_ARCHIVE_LEAF
+
+    return _assert_default_path_safe(candidate.resolve(), repo_root=repo)
+
+
+def _normalize_injected_or_env_path(raw: str) -> Path:
+    text = raw.strip()
+    if not text:
+        raise WorkflowDashboardArchiveRootError("ARCHIVE_ROOT_EMPTY")
+    path = Path(text).expanduser()
+    if not path.is_absolute():
+        # Preserve historical Env/CLI behavior: resolve relative to cwd.
+        path = path.resolve()
+    else:
+        path = path.resolve()
+    if path == Path(path.anchor):
+        raise WorkflowDashboardArchiveRootError("ARCHIVE_ROOT_IS_FILESYSTEM_ROOT")
+    return path
+
+
+def resolve_workflow_dashboard_archive_root(
+    *,
+    explicit: str | Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | None = None,
+    platform: str | None = None,
+    repo_root: Path | None = None,
+    require_existing_directory: bool = True,
+) -> Path | None:
+    """Resolve durable Workflow Dashboard archive root.
+
+    Precedence:
+      1. explicit injection
+      2. PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT
+      3. canonical platform-aware default
+
+    When ``require_existing_directory`` is True (consumer default), a candidate
+    that is missing or not a directory yields ``None``. This preserves existing
+    unconfigured / MISSING_SOURCE semantics until an operator or writer creates
+    the directory. Resolution itself never creates filesystem entries.
+    """
+    env_map = _environ_map(environ)
+    source_raw: str | None = None
+    source_kind: str | None = None
+
+    if explicit is not None:
+        source_raw = str(explicit).strip()
+        source_kind = PRECEDENCE_EXPLICIT
+        if not source_raw:
+            raise WorkflowDashboardArchiveRootError("EXPLICIT_ARCHIVE_ROOT_EMPTY")
+    else:
+        env_raw = str(env_map.get(ENV_ARCHIVE_ROOT, "") or "").strip()
+        if env_raw:
+            source_raw = env_raw
+            source_kind = PRECEDENCE_ENV
+
+    if source_raw is not None:
+        try:
+            candidate = _normalize_injected_or_env_path(source_raw)
+        except WorkflowDashboardArchiveRootError:
+            if source_kind == PRECEDENCE_EXPLICIT:
+                raise
+            # Env override with invalid shape: fail soft to None (historic runtime).
+            return None
+    else:
+        candidate = canonical_default_workflow_dashboard_archive_root(
+            home=home,
+            environ=env_map,
+            platform=platform,
+            repo_root=repo_root,
+        )
+
+    if require_existing_directory:
+        if not candidate.is_dir():
+            return None
+        return candidate.resolve()
+    return candidate.resolve()
+
+
+__all__ = [
+    "CONFIG_CONTRACT_RELATIVE_PATH",
+    "CONTRACT_ID",
+    "CONTRACT_SCHEMA_VERSION",
+    "ENV_ARCHIVE_ROOT",
+    "OWNER_MODULE",
+    "OWNER_SYMBOL",
+    "PRECEDENCE_CHAIN",
+    "WorkflowDashboardArchiveRootError",
+    "canonical_default_workflow_dashboard_archive_root",
+    "resolve_workflow_dashboard_archive_root",
+]

--- a/src/webui/workflow_dashboard_runtime_v1.py
+++ b/src/webui/workflow_dashboard_runtime_v1.py
@@ -4,33 +4,28 @@ from __future__ import annotations
 
 import logging
 import os
-from pathlib import Path
 from typing import Any
 
+from .workflow_dashboard_archive_root_v1 import (
+    ENV_ARCHIVE_ROOT,
+    resolve_workflow_dashboard_archive_root,
+)
 from .workflow_dashboard_readmodel_v1 import build_workflow_dashboard_readmodel_v1, to_json_dict
 
 logger = logging.getLogger(__name__)
 
 ENV_ENABLED = "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED"
-ENV_ARCHIVE_ROOT = "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT"
 
 
 def _dashboard_enabled() -> bool:
     return (os.getenv(ENV_ENABLED) or "").strip() == "1"
 
 
-def _resolved_archive_root() -> Path | None:
-    raw = (os.getenv(ENV_ARCHIVE_ROOT) or "").strip()
-    if not raw:
-        return None
-    p = Path(raw).expanduser()
-    try:
-        p = p.resolve(strict=True)
-    except OSError:
-        return None
-    if not p.is_dir():
-        return None
-    return p
+def _resolved_archive_root():
+    # Shared contract owner: explicit N/A here; Env override; then canonical default.
+    # require_existing_directory=True preserves unconfigured semantics when the
+    # default path has not been created by an explicit writer.
+    return resolve_workflow_dashboard_archive_root(require_existing_directory=True)
 
 
 def build_workflow_dashboard_display_context() -> dict[str, Any]:

--- a/tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py
+++ b/tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py
@@ -8,10 +8,12 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_workflow_dashboard_env_constants_in_runtime_module() -> None:
+    from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT as ROOT_ENV
     from src.webui.workflow_dashboard_runtime_v1 import ENV_ARCHIVE_ROOT, ENV_ENABLED
 
     assert ENV_ENABLED == "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED"
     assert ENV_ARCHIVE_ROOT == "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT"
+    assert ENV_ARCHIVE_ROOT == ROOT_ENV
 
 
 def test_observability_hub_doc_documents_workflow_dashboard() -> None:
@@ -21,6 +23,21 @@ def test_observability_hub_doc_documents_workflow_dashboard() -> None:
     assert "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED" in doc
     assert "workflow_dashboard_readmodel.v1" in doc
     assert "UNIVERSE_SOURCE_NOT_PERSISTED" in doc
+    assert "WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md" in doc
+
+
+def test_archive_root_contract_doc_exists() -> None:
+    doc_path = PROJECT_ROOT / "docs/webui/observability/WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md"
+    assert doc_path.is_file()
+    doc = doc_path.read_text(encoding="utf-8")
+    assert "resolve_workflow_dashboard_archive_root" in doc
+    assert "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT" in doc
+    assert "canonical_default" in doc or "Canonical default" in doc
+    assert (
+        "resolver_creates_filesystem" in doc
+        or "never** creates" in doc.lower()
+        or "Never creates" in doc
+    )
 
 
 def test_universe_selection_contract_doc_exists() -> None:

--- a/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
@@ -142,8 +142,14 @@ def test_parse_producer_utc_timestamp_deterministic() -> None:
 
 def test_bind_defaults_fail_closed_without_archive_or_fields(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.delenv("PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT", raising=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
     slots = bind_market_universe_slots(generated_at=STAMP)
     assert set(slots) == {
         "market_instrument",
@@ -194,8 +200,14 @@ def test_bind_rejects_inventing_market_without_required_fields() -> None:
 
 def test_bind_available_when_producer_fields_supplied(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.delenv("PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT", raising=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
     slots = bind_market_universe_slots(
         generated_at=STAMP,
         market_instrument_fields={

--- a/tests/webui/test_workflow_dashboard_archive_root_v1.py
+++ b/tests/webui/test_workflow_dashboard_archive_root_v1.py
@@ -1,0 +1,230 @@
+"""Contract tests for Workflow Dashboard archive-root v1."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    REASON_ARCHIVE_ROOT_UNSET,
+    REASON_UNIVERSE_ABSENT,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import (
+    CONFIG_CONTRACT_RELATIVE_PATH,
+    CONTRACT_ID,
+    ENV_ARCHIVE_ROOT,
+    OWNER_MODULE,
+    OWNER_SYMBOL,
+    PRECEDENCE_CHAIN,
+    WorkflowDashboardArchiveRootError,
+    canonical_default_workflow_dashboard_archive_root,
+    resolve_workflow_dashboard_archive_root,
+)
+from src.webui.workflow_dashboard_runtime_v1 import (
+    ENV_ENABLED,
+    build_workflow_dashboard_display_context,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / CONFIG_CONTRACT_RELATIVE_PATH
+
+
+def test_config_contract_matches_owner_constants() -> None:
+    payload = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    assert payload["schema_id"] == CONTRACT_ID
+    assert payload["owner_module"] == OWNER_MODULE
+    assert payload["owner_symbol"] == OWNER_SYMBOL
+    assert payload["env_override"] == ENV_ARCHIVE_ROOT
+    assert tuple(payload["precedence"]) == PRECEDENCE_CHAIN
+    assert payload["resolver_creates_filesystem"] is False
+    assert payload["fixture_fallback_allowed"] is False
+    assert payload["repo_local_runtime_truth_allowed"] is False
+    assert payload["tmp_default_allowed"] is False
+    assert payload["non_authorizing"] is True
+
+
+def test_explicit_injected_root_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    injected = tmp_path / "injected_root"
+    injected.mkdir()
+    env_root = tmp_path / "env_root"
+    env_root.mkdir()
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(env_root))
+    resolved = resolve_workflow_dashboard_archive_root(explicit=injected)
+    assert resolved == injected.resolve()
+
+
+def test_environment_override_wins_over_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env_root = tmp_path / "env_root"
+    env_root.mkdir()
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(env_root))
+    resolved = resolve_workflow_dashboard_archive_root(explicit=None)
+    assert resolved == env_root.resolve()
+
+
+def test_default_is_deterministic_absolute_and_cwd_independent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    first = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform="darwin", environ={}
+    )
+    other = tmp_path / "other_cwd"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    second = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform="darwin", environ={}
+    )
+    assert first == second
+    assert first.is_absolute()
+    assert first == (
+        home.resolve() / "Library" / "Application Support" / "Peak_Trade" / "workflow_dashboard_v1"
+    )
+
+
+def test_resolver_performs_no_filesystem_creation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
+    home = tmp_path / "home_no_create"
+    home.mkdir()
+    default = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform="darwin", environ={}
+    )
+    assert not default.exists()
+    resolved = resolve_workflow_dashboard_archive_root(
+        home=home,
+        platform="darwin",
+        environ={},
+        require_existing_directory=True,
+    )
+    assert resolved is None
+    assert not default.exists()
+    # Non-requiring mode still does not create.
+    path = resolve_workflow_dashboard_archive_root(
+        home=home,
+        platform="darwin",
+        environ={},
+        require_existing_directory=False,
+    )
+    assert path == default
+    assert not default.exists()
+
+
+def test_fixture_tmp_and_repo_not_selected_as_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    default = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform="darwin", environ={}, repo_root=REPO_ROOT
+    )
+    assert "tests/fixtures" not in default.as_posix()
+    assert not str(default).startswith(str(REPO_ROOT))
+    assert "/tmp" not in default.as_posix() or not default.as_posix().startswith("/tmp")
+    # Linux with tmp-backed XDG_STATE_HOME falls back to ~/.local/state
+    linux_default = canonical_default_workflow_dashboard_archive_root(
+        home=home,
+        platform="linux",
+        environ={"XDG_STATE_HOME": "/tmp/xdg-state"},
+        repo_root=REPO_ROOT,
+    )
+    assert not str(linux_default).startswith("/tmp")
+    assert linux_default == (
+        home.resolve() / ".local" / "state" / "peak_trade" / "workflow_dashboard_v1"
+    )
+
+
+def test_invalid_explicit_path_shape_fails_closed() -> None:
+    with pytest.raises(WorkflowDashboardArchiveRootError):
+        resolve_workflow_dashboard_archive_root(explicit="   ")
+    with pytest.raises(WorkflowDashboardArchiveRootError):
+        resolve_workflow_dashboard_archive_root(explicit="/")
+
+
+def test_existing_env_workflows_remain_compatible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    monkeypatch.setenv(ENV_ENABLED, "1")
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    ctx = build_workflow_dashboard_display_context()
+    # Empty archive is configured (dir exists) and loads with warnings/errors — not unconfigured.
+    assert ctx["gate_enabled"] is True
+    assert ctx["display_status"] != "unconfigured"
+    assert ctx["display_status"] in ("ready", "ready_with_warnings", "error")
+
+
+def test_unconfigured_when_default_missing_preserves_runtime_semantics(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(ENV_ENABLED, "1")
+    monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
+    # Point home at a temp home so default cannot accidentally exist.
+    home = tmp_path / "isolated_home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    # Also clear LOCALAPPDATA/XDG noise for portability.
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    ctx = build_workflow_dashboard_display_context()
+    assert ctx["display_status"] == "unconfigured"
+    assert ctx["section_visible"] is False
+    assert ctx["readmodel"] is None
+
+
+def test_missing_readmodel_under_resolved_root_remains_missing_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datetime import datetime, timezone
+
+    root = tmp_path / "empty_durable_root"
+    root.mkdir()
+    monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
+    slots = bind_market_universe_slots(
+        generated_at=datetime.now(timezone.utc),
+        archive_root=root,
+    )
+    assert slots["universe_ranking"].availability is Availability.MISSING_SOURCE
+    assert REASON_UNIVERSE_ABSENT in slots["universe_ranking"].reason_codes
+
+
+def test_unset_root_still_reports_archive_root_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from datetime import datetime, timezone
+
+    monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    slots = bind_market_universe_slots(generated_at=datetime.now(timezone.utc))
+    assert slots["universe_ranking"].availability is Availability.MISSING_SOURCE
+    assert REASON_ARCHIVE_ROOT_UNSET in slots["universe_ranking"].reason_codes
+
+
+def test_linux_and_windows_default_shapes(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    linux = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform="linux", environ={}, repo_root=REPO_ROOT
+    )
+    assert linux == home.resolve() / ".local" / "state" / "peak_trade" / "workflow_dashboard_v1"
+    win = canonical_default_workflow_dashboard_archive_root(
+        home=home,
+        platform="win32",
+        environ={"LOCALAPPDATA": str(home / "AppData" / "Local")},
+        repo_root=REPO_ROOT,
+    )
+    assert win == (home.resolve() / "AppData" / "Local" / "Peak_Trade" / "workflow_dashboard_v1")

--- a/tests/webui/test_workflow_dashboard_runtime_v1.py
+++ b/tests/webui/test_workflow_dashboard_runtime_v1.py
@@ -123,9 +123,16 @@ def test_display_context_invalid_enabled_fail_closed(monkeypatch: pytest.MonkeyP
     assert ctx["readmodel"] is None
 
 
-def test_display_context_unconfigured_fail_soft(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_display_context_unconfigured_fail_soft(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.setenv(ENV_ENABLED, "1")
     monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
     ctx = build_workflow_dashboard_display_context()
     assert ctx["gate_enabled"] is True
     assert ctx["section_visible"] is False
@@ -282,9 +289,16 @@ def test_disabled_context_is_deterministic(monkeypatch: pytest.MonkeyPatch) -> N
     assert first == second
 
 
-def test_unconfigured_context_is_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_unconfigured_context_is_deterministic(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.setenv(ENV_ENABLED, "1")
     monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
     first = build_workflow_dashboard_display_context()
     second = deepcopy(first)
     assert build_workflow_dashboard_display_context() == second


### PR DESCRIPTION
## Summary
- Adds sole archive-root config contract + resolver (`workflow_dashboard_archive_root_v1`) with precedence: explicit injection → `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT` → platform user-state default.
- Migrates duplicate Env-only resolution in Workflow Dashboard runtime and Market Landscape binder to the shared owner.
- Docs ownership/precedence; no directory creation, no Universe autoload, no visible Market Dashboard binding change.

## Test plan
- [x] `uv run pytest` focused archive-root + runtime + landscape producer binding + architecture guards + env schema boundary (109 passed)
- [x] Selector `PR_BOUNDED_FULL` targets (716 passed, ~36s)
- [x] Docs reference targets + docs token policy preflight
- [x] Unrelated Bouchaud research JSON files left byte-identical and unstaged

## Non-goals
- No GET `/market` Universe autoload
- No OHLCV / decision / scope / safety / economic binding
- No runtime data creation


Made with [Cursor](https://cursor.com)