### PR TITLE
Market Dashboard: bind Universe Selection on canonical default path

### DIFF
--- a/config/webui/workflow_dashboard_archive_root_v1.json
+++ b/config/webui/workflow_dashboard_archive_root_v1.json
@@ -24,7 +24,8 @@
   "empty_directory_is_valid_data": false,
   "notes": [
     "Sole configuration owner for Workflow/Market Dashboard durable archive root location.",
-    "Does not authorize live trading, orders, runtime activation, or dashboard Universe autoload.",
+    "Does not authorize live trading, orders, or runtime activation.",
+    "GET /market may read-only bind universe_selection_readmodel.v1 via this resolved root without Env when the canonical default directory exists.",
     "Missing readmodels under a resolved root remain fail-closed MISSING_SOURCE at consumer boundaries.",
     "PEAK_TRADE_DATA_ARCHIVE_ROOT and review_server .run/ state are non-owners for this contract."
   ]

--- a/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
+++ b/docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md
@@ -30,6 +30,7 @@ This document defines the **normative persistence contract** for **`universe_sel
 | Storage target | `{ARCHIVE_ROOT}&#47;readmodels&#47;universe_selection_readmodel.v1.json` |
 | Validation module | `src/webui/workflow_dashboard_readmodel_v1/universe_selection_contract_v1.py` |
 | Dashboard consumer (Slice 3+) | `src/webui/workflow_dashboard_readmodel_v1/builder.py` |
+| Market Landscape consumer | `src/webui/market_dashboard_landscape_producer_binding_v2.py` (`bind_market_universe_slots` on `GET &#47;market`) — Selected Future identity + venue only; **no** OHLCV |
 | Workflow SSR gate | `PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ENABLED=1` + archive root via [WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md](WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md) (Env override still supported) |
 | Archive root owner | `src/webui/workflow_dashboard_archive_root_v1.py` |
 

--- a/docs/webui/observability/WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md
+++ b/docs/webui/observability/WORKFLOW_DASHBOARD_ARCHIVE_ROOT_V1.md
@@ -11,8 +11,15 @@ This contract owns **where** the archive root is resolved. It does **not**:
 - authorize live trading, orders, runtime activation, or scheduler work;
 - create directories during import or resolution;
 - write or copy readmodels;
-- autoload Universe onto `GET &#47;market`;
-- change visible dashboard panels by itself.
+- invent Universe &#47; Selected Future &#47; OHLCV when the readmodel is absent.
+
+**Market Landscape consumer (authorized after archive-root contract):**
+`GET &#47;market` resolves this archive root (explicit → Env override → canonical
+default) and read-only-loads `universe_selection_readmodel.v1` via
+`bind_market_universe_slots`. No Env var is required when the canonical default
+directory exists with a manifest-verified readmodel. Missing &#47; invalid
+readmodels remain fail-closed `MISSING_SOURCE` &#47; `INVALID`. OHLCV, Decision,
+Risk, Execution, and Timeline stay unbound in the Universe default-path slice.
 
 ## Ownership
 

--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -2,11 +2,13 @@
 
 Read-only SSR surface. No POST/PUT/PATCH/DELETE. No command endpoints.
 No execution / order / runtime-activation imports.
-Phase 4.1 binds market_instrument / universe_ranking fail-closed.
+Phase 4.1 binds market_instrument / universe_ranking fail-closed from the
+canonical Workflow Dashboard archive root (explicit → Env → platform default)
+via universe_selection_readmodel.v1 — no Env required when the default exists.
 Phase 4.2 binds dynamic_scope lifecycle identity fail-closed (injection only).
 Phase 4.3A binds canonical_decision fail-closed (injection only).
 Phase 4.3B binds double_play display fail-closed (injection only).
-Regime / bull-bear / switch and later Phase 4 slots remain unbound.
+OHLCV remains unbound. Regime / bull-bear / switch stay unbound.
 """
 
 from __future__ import annotations

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -57,6 +57,13 @@ def _display_value(raw: Any, availability: Availability) -> str:
     return str(raw)
 
 
+def _identity_fact_display(raw: Any, availability: Availability) -> str:
+    """Retain selected-instrument / venue identity for AVAILABLE and STALE."""
+    if availability in (Availability.AVAILABLE, Availability.STALE) and raw is not None:
+        return str(raw)
+    return AVAILABILITY_LABELS[availability]
+
+
 def _lifecycle_fact_display(raw: Any, availability: Availability) -> str:
     """Retain producer lifecycle facts for AVAILABLE and STALE; never invent."""
     if availability in (Availability.AVAILABLE, Availability.STALE) and raw is not None:
@@ -198,7 +205,7 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
     health = page.source_health
 
     chart_availability = page.market_instrument.availability
-    if chart_availability is Availability.AVAILABLE:
+    if chart_availability in (Availability.AVAILABLE, Availability.STALE):
         chart_message = (
             "Primary chart market instrument bound; OHLCV producer still unbound "
             "(no fabricated candles)."
@@ -220,7 +227,7 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
     selected_instrument_id = None
     membership_label = AVAILABILITY_LABELS[page.universe_ranking.availability]
     ranking_label = AVAILABILITY_LABELS[page.universe_ranking.availability]
-    if page.universe_ranking.availability is Availability.AVAILABLE:
+    if page.universe_ranking.availability in (Availability.AVAILABLE, Availability.STALE):
         ranking_rows = [dict(row) for row in page.universe_ranking.ranking]
         universe_rows = [dict(row) for row in page.universe_ranking.universe]
         selected_instrument_id = page.universe_ranking.selected_instrument_id
@@ -239,7 +246,7 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
     instrument_display = (
         selected_instrument_id
         if selected_instrument_id
-        else _display_value(
+        else _identity_fact_display(
             page.market_instrument.instrument_id, page.market_instrument.availability
         )
     )
@@ -272,7 +279,7 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
             # Compact ops summary only. Scope lifecycle + Regime primary in Context rail.
             # Do not expose availability under a Freshness label (Phase 5 PR1).
             "instrument": instrument_display,
-            "venue": _display_value(
+            "venue": _identity_fact_display(
                 page.market_instrument.venue, page.market_instrument.availability
             ),
             "runtime_state": page.runtime_bridge_display,
@@ -333,7 +340,7 @@ def present_market_landscape_v2(page: MarketDashboardPageSnapshotV1) -> dict[str
         "chart": {
             "availability": chart_availability.value,
             "availability_label": AVAILABILITY_LABELS[chart_availability],
-            "bound": chart_availability is Availability.AVAILABLE,
+            "bound": chart_availability in (Availability.AVAILABLE, Availability.STALE),
             "message": chart_message,
             "ohlcv": None,
         },

--- a/src/webui/workflow_dashboard_archive_root_v1.py
+++ b/src/webui/workflow_dashboard_archive_root_v1.py
@@ -1,8 +1,9 @@
 """Canonical durable archive-root contract for Workflow/Market Dashboard.
 
 Sole owner of archive-root *location* resolution for dashboard consumers.
-Does not create directories, does not write readmodels, does not authorize
-trading, and does not autoload Universe onto GET /market.
+Does not create directories, does not write readmodels, and does not authorize
+trading. GET /market consumers may resolve this root (explicit → Env →
+canonical default) to read-only-load universe_selection_readmodel.v1.
 """
 
 from __future__ import annotations

--- a/tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py
+++ b/tests/ops/test_workflow_dashboard_env_schema_boundary_v1.py
@@ -33,10 +33,13 @@ def test_archive_root_contract_doc_exists() -> None:
     assert "resolve_workflow_dashboard_archive_root" in doc
     assert "PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT" in doc
     assert "canonical_default" in doc or "Canonical default" in doc
+    assert "GET &#47;market" in doc
+    assert "universe_selection_readmodel.v1" in doc
     assert (
         "resolver_creates_filesystem" in doc
         or "never** creates" in doc.lower()
         or "Never creates" in doc
+        or "never** creates filesystem" in doc.lower()
     )
 
 

--- a/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
@@ -37,6 +37,7 @@ from src.webui.market_dashboard_landscape_producer_binding_v2 import (
     REASON_SCOPE_NOT_PERSISTED,
     REASON_SELECTED_FORBIDDEN_SYMBOL,
     REASON_SOURCE_CONTRADICTION,
+    REASON_UNIVERSE_ABSENT,
     SAFETY_AUTHORITY_OWNER_MODULE,
     SAFETY_EVIDENCE_PRODUCER_MODULE,
     SAFETY_SOURCE_KIND,
@@ -1351,3 +1352,187 @@ def test_economic_page_aggregate_and_presenter_injection() -> None:
     assert ctx["product_flags"]["phase_4_6b_binding_active"] is True
     assert ctx["phase"] == "PHASE_4_6B_ECONOMIC_EVIDENCE_EXPLICIT_INJECTION_BINDING"
     assert page.risk_sizing_capital.availability is Availability.NOT_BOUND
+
+
+def _isolate_home_without_archive_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.delenv("PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT", raising=False)
+    home = tmp_path / "default_home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    return home
+
+
+def test_exact_canonical_default_path_resolution_without_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import sys
+
+    from src.webui.workflow_dashboard_archive_root_v1 import (
+        canonical_default_workflow_dashboard_archive_root,
+        resolve_workflow_dashboard_archive_root,
+    )
+
+    home = _isolate_home_without_archive_env(monkeypatch, tmp_path)
+    expected = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform=sys.platform, environ={}, repo_root=REPO
+    )
+    assert expected.is_absolute()
+    assert expected.name == "workflow_dashboard_v1"
+    assert "Peak_Trade" in expected.parts or "peak_trade" in expected.parts
+    assert resolve_workflow_dashboard_archive_root(require_existing_directory=True) is None
+    expected.mkdir(parents=True)
+    resolved = resolve_workflow_dashboard_archive_root(require_existing_directory=True)
+    assert resolved == expected.resolve()
+    assert resolved is not None
+    readmodel = resolved / READMODELS_DIRNAME / READMODEL_FILENAME
+    assert readmodel.name == "universe_selection_readmodel.v1.json"
+    assert readmodel.parent.name == "readmodels"
+
+
+def test_default_path_binds_selected_instrument_and_venue_without_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import sys
+
+    from src.webui.workflow_dashboard_archive_root_v1 import (
+        canonical_default_workflow_dashboard_archive_root,
+    )
+
+    home = _isolate_home_without_archive_env(monkeypatch, tmp_path)
+    default_root = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform=sys.platform, environ={}, repo_root=REPO
+    )
+    archive = _write_truth_universe_archive(
+        default_root,
+        selected_symbol="ETH-USDT-SWAP",
+    )
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["universe_ranking"].availability is Availability.AVAILABLE
+    assert slots["universe_ranking"].selected_instrument_id == "ETH-USDT-SWAP"
+    assert slots["market_instrument"].availability is Availability.AVAILABLE
+    assert slots["market_instrument"].instrument_id == "ETH-USDT-SWAP"
+    assert slots["market_instrument"].venue == "OKX"
+    assert slots["market_instrument"].mark_price is None
+    assert "SELECTED_INSTRUMENT_IDENTITY_FROM_UNIVERSE_SELECTION" in (
+        slots["market_instrument"].reason_codes
+    )
+    ctx = present_market_landscape_v2(
+        MarketDashboardReadServiceV1().load_page_snapshot(
+            generated_at=STAMP,
+            slot_overrides=slots,
+        )
+    )
+    assert ctx["global_strip"]["instrument"] == "ETH-USDT-SWAP"
+    assert ctx["global_strip"]["venue"] == "OKX"
+    assert ctx["selected_instrument_id"] == "ETH-USDT-SWAP"
+    assert ctx["source_health"]["slot_availability"]["universe_ranking"] == "AVAILABLE"
+    assert "OHLCV" in ctx["chart"]["message"].upper() or "ohlcv" in ctx["chart"]["message"].lower()
+    assert "unbound" in ctx["chart"]["message"].lower()
+    # Explicit injection still unused; default path alone sufficed.
+    assert archive == default_root
+
+
+def test_default_path_missing_archive_remains_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _isolate_home_without_archive_env(monkeypatch, tmp_path)
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["universe_ranking"].availability is Availability.MISSING_SOURCE
+    assert REASON_ARCHIVE_ROOT_UNSET in slots["universe_ranking"].reason_codes
+    assert slots["market_instrument"].availability is Availability.MISSING_SOURCE
+
+
+def test_default_path_missing_readmodel_remains_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import sys
+
+    from src.webui.workflow_dashboard_archive_root_v1 import (
+        canonical_default_workflow_dashboard_archive_root,
+    )
+
+    home = _isolate_home_without_archive_env(monkeypatch, tmp_path)
+    default_root = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform=sys.platform, environ={}, repo_root=REPO
+    )
+    default_root.mkdir(parents=True)
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["universe_ranking"].availability is Availability.MISSING_SOURCE
+    assert REASON_UNIVERSE_ABSENT in slots["universe_ranking"].reason_codes
+
+
+def test_default_path_invalid_schema_remains_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import sys
+
+    from src.webui.workflow_dashboard_archive_root_v1 import (
+        canonical_default_workflow_dashboard_archive_root,
+    )
+
+    home = _isolate_home_without_archive_env(monkeypatch, tmp_path)
+    default_root = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform=sys.platform, environ={}, repo_root=REPO
+    )
+    readmodels = default_root / READMODELS_DIRNAME
+    readmodels.mkdir(parents=True)
+    bad = {
+        "schema_name": "universe_selection_readmodel.v1",
+        "schema_version": 1,
+        "generated_at": "2026-07-23T17:00:00Z",
+        "source_run_id": "bad",
+        "source_stage": "paper",
+        "non_authorizing": True,
+        "universe": [],
+        "ranking": [],
+        "selected_future": {
+            "row_id": "s-btc",
+            "symbol": "BTC/USD",
+            "rank": 1,
+            "truth_status": "PERSISTED",
+        },
+        "market_snapshot": {
+            "truth_status": "PERSISTED",
+            "source_kind": "governed_producer",
+            "snapshot_id": "snap-bad",
+            "exchange": "OKX",
+            "captured_at": "2026-07-23T16:59:00Z",
+        },
+        "evidence": {
+            "producer_contract": "universe_selection_producer.v1",
+            "storage_target": "readmodels/universe_selection_readmodel.v1.json",
+            "links": [],
+        },
+        "missing_truth": {
+            "universe": "UNIVERSE_SOURCE_NOT_PERSISTED",
+            "ranking": "TOP20_RANKING_NOT_PERSISTED",
+            "selected_future": "PERSISTED",
+            "future_detail": "AVAILABLE",
+            "orders_fills_pnl": "NOT_PERSISTED",
+        },
+    }
+    (readmodels / READMODEL_FILENAME).write_text(
+        json.dumps(bad, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    _write_manifest_sha256(readmodels)
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["universe_ranking"].availability is Availability.INVALID
+
+
+def test_bind_market_universe_slots_has_no_write_capability() -> None:
+    import inspect
+
+    from src.webui import market_dashboard_landscape_producer_binding_v2 as mod
+
+    source = inspect.getsource(mod)
+    for token in (
+        "write_universe_selection_readmodel",
+        "write_missing_truth_universe_selection_readmodel",
+        "os.replace",
+        "Path.write_text",
+        "open(",
+    ):
+        assert token not in source
+    assert "try_load_universe_selection_for_dashboard" in source

--- a/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
@@ -423,3 +423,105 @@ def test_shell_assets_exist() -> None:
     assert (REPO / "templates/peak_trade_dashboard/market_landscape_v2.html").is_file()
     assert (REPO / "static/css/market_dashboard_landscape_v2.css").is_file()
     assert (REPO / "static/js/market_dashboard_landscape_v2.js").is_file()
+
+
+def test_get_market_default_path_projects_selected_instrument_without_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Canonical default archive root (no Env) binds Selected Future + venue."""
+    import json
+    import sys
+
+    from scripts.ops.primary_evidence_retention_v0 import (
+        write_manifest_sha256 as _write_manifest_sha256,
+    )
+    from src.webui.workflow_dashboard_archive_root_v1 import (
+        ENV_ARCHIVE_ROOT,
+        canonical_default_workflow_dashboard_archive_root,
+    )
+    from src.webui.workflow_dashboard_readmodel_v1.universe_selection_producer_v1 import (
+        READMODEL_FILENAME,
+        READMODELS_DIRNAME,
+    )
+
+    monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+
+    archive_root = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform=sys.platform, environ={}, repo_root=REPO
+    )
+    readmodels = archive_root / READMODELS_DIRNAME
+    readmodels.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_name": "universe_selection_readmodel.v1",
+        "schema_version": 1,
+        "generated_at": "2026-07-24T17:00:00Z",
+        "source_run_id": "shell_default_path_v1",
+        "source_stage": "paper",
+        "non_authorizing": True,
+        "fixture_marked": False,
+        "universe": [
+            {
+                "row_id": "u-eth",
+                "symbol": "ETH-USDT-SWAP",
+                "rank": 1,
+                "exchange": "OKX",
+            }
+        ],
+        "ranking": [
+            {
+                "row_id": "r-eth",
+                "symbol": "ETH-USDT-SWAP",
+                "rank": 1,
+                "exchange": "OKX",
+                "display_score": 0.9,
+            }
+        ],
+        "selected_future": {
+            "row_id": "s-eth",
+            "symbol": "ETH-USDT-SWAP",
+            "rank": 1,
+            "truth_status": "PERSISTED",
+            "selection_reason": "top_ranked",
+        },
+        "market_snapshot": {
+            "truth_status": "PERSISTED",
+            "source_kind": "governed_producer",
+            "snapshot_id": "snap-shell-1",
+            "exchange": "OKX",
+            "captured_at": "2026-07-24T16:59:00Z",
+        },
+        "evidence": {
+            "producer_contract": "universe_selection_producer.v1",
+            "storage_target": "readmodels/universe_selection_readmodel.v1.json",
+            "links": [],
+        },
+        "missing_truth": {
+            "universe": "PERSISTED",
+            "ranking": "PERSISTED",
+            "selected_future": "PERSISTED",
+            "future_detail": "AVAILABLE",
+            "orders_fills_pnl": "NOT_PERSISTED",
+        },
+    }
+    (readmodels / READMODEL_FILENAME).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    _write_manifest_sha256(readmodels)
+
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "ETH-USDT-SWAP" in html
+    assert "OKX" in html
+    assert "BTC/USD" not in html
+    assert "no ohlcv fabricated" in html.lower() or "ohlcv producer still unbound" in html.lower()
+    assert "<form" not in html.lower()
+    assert 'method="post"' not in html.lower()
+    assert "place_order" not in html.lower()


### PR DESCRIPTION
## Summary
- Authorize `GET /market` to read-only bind `universe_selection_readmodel.v1` from the Workflow Dashboard archive-root canonical default (explicit → Env → platform user-state) without requiring an environment variable when the default directory exists.
- Project selected futures instrument identity and venue into the Landscape strip / universe rail; retain fail-closed `MISSING_SOURCE` / `INVALID` when archive or readmodel is absent/invalid.
- Keep OHLCV, Decision, Risk, Execution, Economic injection, and Timeline unbound in this slice; chart continues to state OHLCV is not fabricated.

## Test plan
- [x] Focused default-path resolution + selected/venue projection + missing archive/readmodel + invalid schema + no-write binder guard
- [x] `GET /market` shell route default-path projection without Env
- [x] Archive-root / env-schema boundary docs contracts + Landscape architecture guards
- [x] Selector `PR_BOUNDED_FULL` path-equivalent batch (824 passed, ~38s wallclock)
- [x] Ruff format/check on Python surfaces; docs token policy + docs reference targets
- [x] Unrelated Bouchaud research JSON left unstaged

## Non-goals
- No OHLCV / Market Identity producer binding
- No Decision / Risk / Execution / Timeline binding
- No fixture or mock data on production `/market`
- No merge in this delivery


Made with [Cursor](https://cursor.com)