### PR TITLE
fix(webui): make canonical archive root safe on CI runners

### DIFF
--- a/tests/webui/archive_root_durable_home_v1.py
+++ b/tests/webui/archive_root_durable_home_v1.py
@@ -1,0 +1,60 @@
+"""Durable isolated HOME for Workflow Dashboard archive-root contract tests.
+
+On Linux GitHub Actions, pytest ``tmp_path`` lives under ``/tmp``. The production
+canonical-default safety gate correctly rejects defaults under ``/tmp`` and
+``/var/tmp``. Tests that assert no-env production default-path semantics must
+therefore isolate HOME outside those ephemeral roots and outside the git
+worktree — not under pytest's ephemeral basetemp.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.webui.workflow_dashboard_archive_root_v1 import (
+    ENV_ARCHIVE_ROOT,
+    _is_under,
+    _path_is_under_tmp,
+    _repo_root,
+)
+
+_CACHE_LEAF = "peak_trade_pytest_durable_homes"
+
+
+def durable_isolated_home(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    *,
+    label: str = "case",
+) -> Path:
+    """Return an absolute isolated HOME suitable for canonical-default assertions.
+
+    Captures the real operator/runner home *before* monkeypatching ``HOME``.
+    Creates the home under ``~/.cache/...`` (durable) via TemporaryDirectory so
+    cleanup is automatic and the resolved path is not under ``/tmp``.
+    """
+    real_home = Path(os.path.expanduser("~")).resolve()
+    repo = _repo_root()
+    parent = real_home / ".cache" / _CACHE_LEAF / label
+    if _path_is_under_tmp(parent):
+        raise RuntimeError(f"durable home parent resolved under ephemeral tmp: {parent}")
+    if _is_under(parent, repo) or parent == repo.resolve():
+        raise RuntimeError(f"durable home parent resolved inside git repo: {parent}")
+    parent.mkdir(parents=True, exist_ok=True)
+    tmp = tempfile.TemporaryDirectory(dir=str(parent), prefix="home_")
+    request.addfinalizer(tmp.cleanup)
+    home = Path(tmp.name) / "home"
+    home.mkdir()
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    return home
+
+
+__all__ = ["durable_isolated_home"]

--- a/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py
@@ -1354,18 +1354,18 @@ def test_economic_page_aggregate_and_presenter_injection() -> None:
     assert page.risk_sizing_capital.availability is Availability.NOT_BOUND
 
 
-def _isolate_home_without_archive_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    monkeypatch.delenv("PEAK_TRADE_WORKFLOW_DASHBOARD_V1_ARCHIVE_ROOT", raising=False)
-    home = tmp_path / "default_home"
-    home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
-    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
-    monkeypatch.delenv("LOCALAPPDATA", raising=False)
-    return home
+def _isolate_home_without_archive_env(
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
+) -> Path:
+    """Isolate HOME for no-env canonical-default assertions (not under /tmp)."""
+    from tests.webui.archive_root_durable_home_v1 import durable_isolated_home
+
+    return durable_isolated_home(monkeypatch, request, label="producer_binding_default_path")
 
 
 def test_exact_canonical_default_path_resolution_without_env(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> None:
     import sys
 
@@ -1374,7 +1374,7 @@ def test_exact_canonical_default_path_resolution_without_env(
         resolve_workflow_dashboard_archive_root,
     )
 
-    home = _isolate_home_without_archive_env(monkeypatch, tmp_path)
+    home = _isolate_home_without_archive_env(monkeypatch, request)
     expected = canonical_default_workflow_dashboard_archive_root(
         home=home, platform=sys.platform, environ={}, repo_root=REPO
     )
@@ -1392,7 +1392,8 @@ def test_exact_canonical_default_path_resolution_without_env(
 
 
 def test_default_path_binds_selected_instrument_and_venue_without_env(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> None:
     import sys
 
@@ -1400,7 +1401,7 @@ def test_default_path_binds_selected_instrument_and_venue_without_env(
         canonical_default_workflow_dashboard_archive_root,
     )
 
-    home = _isolate_home_without_archive_env(monkeypatch, tmp_path)
+    home = _isolate_home_without_archive_env(monkeypatch, request)
     default_root = canonical_default_workflow_dashboard_archive_root(
         home=home, platform=sys.platform, environ={}, repo_root=REPO
     )
@@ -1435,9 +1436,10 @@ def test_default_path_binds_selected_instrument_and_venue_without_env(
 
 
 def test_default_path_missing_archive_remains_fail_closed(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> None:
-    _isolate_home_without_archive_env(monkeypatch, tmp_path)
+    _isolate_home_without_archive_env(monkeypatch, request)
     slots = bind_market_universe_slots(generated_at=STAMP)
     assert slots["universe_ranking"].availability is Availability.MISSING_SOURCE
     assert REASON_ARCHIVE_ROOT_UNSET in slots["universe_ranking"].reason_codes
@@ -1445,7 +1447,8 @@ def test_default_path_missing_archive_remains_fail_closed(
 
 
 def test_default_path_missing_readmodel_remains_fail_closed(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> None:
     import sys
 
@@ -1453,7 +1456,7 @@ def test_default_path_missing_readmodel_remains_fail_closed(
         canonical_default_workflow_dashboard_archive_root,
     )
 
-    home = _isolate_home_without_archive_env(monkeypatch, tmp_path)
+    home = _isolate_home_without_archive_env(monkeypatch, request)
     default_root = canonical_default_workflow_dashboard_archive_root(
         home=home, platform=sys.platform, environ={}, repo_root=REPO
     )
@@ -1464,7 +1467,8 @@ def test_default_path_missing_readmodel_remains_fail_closed(
 
 
 def test_default_path_invalid_schema_remains_fail_closed(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> None:
     import sys
 
@@ -1472,7 +1476,7 @@ def test_default_path_invalid_schema_remains_fail_closed(
         canonical_default_workflow_dashboard_archive_root,
     )
 
-    home = _isolate_home_without_archive_env(monkeypatch, tmp_path)
+    home = _isolate_home_without_archive_env(monkeypatch, request)
     default_root = canonical_default_workflow_dashboard_archive_root(
         home=home, platform=sys.platform, environ={}, repo_root=REPO
     )

--- a/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
@@ -427,7 +427,7 @@ def test_shell_assets_exist() -> None:
 
 def test_get_market_default_path_projects_selected_instrument_without_env(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Canonical default archive root (no Env) binds Selected Future + venue."""
     import json
@@ -446,11 +446,9 @@ def test_get_market_default_path_projects_selected_instrument_without_env(
     )
 
     monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
-    home = tmp_path / "home"
-    home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
-    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
-    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    from tests.webui.archive_root_durable_home_v1 import durable_isolated_home
+
+    home = durable_isolated_home(monkeypatch, request, label="shell_route_default_path")
 
     archive_root = canonical_default_workflow_dashboard_archive_root(
         home=home, platform=sys.platform, environ={}, repo_root=REPO

--- a/tests/webui/test_workflow_dashboard_archive_root_v1.py
+++ b/tests/webui/test_workflow_dashboard_archive_root_v1.py
@@ -69,11 +69,12 @@ def test_environment_override_wins_over_default(
 
 
 def test_default_is_deterministic_absolute_and_cwd_independent(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
 ) -> None:
+    from tests.webui.archive_root_durable_home_v1 import durable_isolated_home
+
     monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
-    home = tmp_path / "home"
-    home.mkdir()
+    home = durable_isolated_home(monkeypatch, request, label="archive_root_deterministic")
     first = canonical_default_workflow_dashboard_archive_root(
         home=home, platform="darwin", environ={}
     )
@@ -91,11 +92,13 @@ def test_default_is_deterministic_absolute_and_cwd_independent(
 
 
 def test_resolver_performs_no_filesystem_creation(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> None:
+    from tests.webui.archive_root_durable_home_v1 import durable_isolated_home
+
     monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
-    home = tmp_path / "home_no_create"
-    home.mkdir()
+    home = durable_isolated_home(monkeypatch, request, label="archive_root_no_create")
     default = canonical_default_workflow_dashboard_archive_root(
         home=home, platform="darwin", environ={}
     )
@@ -120,11 +123,13 @@ def test_resolver_performs_no_filesystem_creation(
 
 
 def test_fixture_tmp_and_repo_not_selected_as_default(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> None:
+    from tests.webui.archive_root_durable_home_v1 import durable_isolated_home
+
     monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
-    home = tmp_path / "home"
-    home.mkdir()
+    home = durable_isolated_home(monkeypatch, request, label="archive_root_reject_tmp")
     default = canonical_default_workflow_dashboard_archive_root(
         home=home, platform="darwin", environ={}, repo_root=REPO_ROOT
     )
@@ -142,6 +147,53 @@ def test_fixture_tmp_and_repo_not_selected_as_default(
     assert linux_default == (
         home.resolve() / ".local" / "state" / "peak_trade" / "workflow_dashboard_v1"
     )
+
+
+def test_home_under_ephemeral_tmp_rejected_for_canonical_default() -> None:
+    """Genuine /tmp-backed HOME must not become a canonical default (CI parity)."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory(dir="/tmp") as raw:
+        home = Path(raw) / "home"
+        home.mkdir()
+        with pytest.raises(
+            WorkflowDashboardArchiveRootError, match="DEFAULT_ARCHIVE_ROOT_UNDER_TMP"
+        ):
+            canonical_default_workflow_dashboard_archive_root(
+                home=home, platform="linux", environ={}, repo_root=REPO_ROOT
+            )
+        with pytest.raises(
+            WorkflowDashboardArchiveRootError, match="DEFAULT_ARCHIVE_ROOT_UNDER_TMP"
+        ):
+            canonical_default_workflow_dashboard_archive_root(
+                home=home, platform="darwin", environ={}, repo_root=REPO_ROOT
+            )
+
+
+def test_platform_path_matrix_durable_homes(
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
+) -> None:
+    """macOS / Linux / GitHub-runner-style durable homes remain safe; no Env required."""
+    from tests.webui.archive_root_durable_home_v1 import durable_isolated_home
+
+    home = durable_isolated_home(monkeypatch, request, label="archive_root_path_matrix")
+    darwin = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform="darwin", environ={}, repo_root=REPO_ROOT
+    )
+    linux = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform="linux", environ={}, repo_root=REPO_ROOT
+    )
+    # GitHub-hosted Linux runners use a durable /home/runner style home; same linux shape.
+    gha_like = canonical_default_workflow_dashboard_archive_root(
+        home=home, platform="linux", environ={}, repo_root=REPO_ROOT
+    )
+    assert darwin == (
+        home.resolve() / "Library" / "Application Support" / "Peak_Trade" / "workflow_dashboard_v1"
+    )
+    assert linux == home.resolve() / ".local" / "state" / "peak_trade" / "workflow_dashboard_v1"
+    assert gha_like == linux
+    assert not str(darwin).startswith("/tmp")
+    assert not str(linux).startswith("/tmp")
 
 
 def test_invalid_explicit_path_shape_fails_closed() -> None:
@@ -166,17 +218,14 @@ def test_existing_env_workflows_remain_compatible(
 
 
 def test_unconfigured_when_default_missing_preserves_runtime_semantics(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> None:
+    from tests.webui.archive_root_durable_home_v1 import durable_isolated_home
+
     monkeypatch.setenv(ENV_ENABLED, "1")
     monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
-    # Point home at a temp home so default cannot accidentally exist.
-    home = tmp_path / "isolated_home"
-    home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
-    # Also clear LOCALAPPDATA/XDG noise for portability.
-    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
-    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    durable_isolated_home(monkeypatch, request, label="archive_root_unconfigured")
     ctx = build_workflow_dashboard_display_context()
     assert ctx["display_status"] == "unconfigured"
     assert ctx["section_visible"] is False
@@ -200,23 +249,26 @@ def test_missing_readmodel_under_resolved_root_remains_missing_source(
 
 
 def test_unset_root_still_reports_archive_root_unset(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
 ) -> None:
     from datetime import datetime, timezone
 
+    from tests.webui.archive_root_durable_home_v1 import durable_isolated_home
+
     monkeypatch.delenv(ENV_ARCHIVE_ROOT, raising=False)
-    home = tmp_path / "home"
-    home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
-    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    durable_isolated_home(monkeypatch, request, label="archive_root_unset")
     slots = bind_market_universe_slots(generated_at=datetime.now(timezone.utc))
     assert slots["universe_ranking"].availability is Availability.MISSING_SOURCE
     assert REASON_ARCHIVE_ROOT_UNSET in slots["universe_ranking"].reason_codes
 
 
-def test_linux_and_windows_default_shapes(tmp_path: Path) -> None:
-    home = tmp_path / "home"
-    home.mkdir()
+def test_linux_and_windows_default_shapes(
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
+) -> None:
+    from tests.webui.archive_root_durable_home_v1 import durable_isolated_home
+
+    home = durable_isolated_home(monkeypatch, request, label="archive_root_linux_win")
     linux = canonical_default_workflow_dashboard_archive_root(
         home=home, platform="linux", environ={}, repo_root=REPO_ROOT
     )


### PR DESCRIPTION
## Summary
- **Root cause (class C):** Tests that assert production no-env canonical default-path semantics placed `HOME` under pytest `tmp_path`. On macOS that often resolves under `/var/folders/...` (not rejected). On GitHub Actions Linux, `tmp_path` lives under `/tmp`, so `canonical_default_workflow_dashboard_archive_root()` correctly raised `DEFAULT_ARCHIVE_ROOT_UNDER_TMP`. Production path safety was correct; tests masqueraded ephemeral HOME as production HOME.
- **Why PR #5522 exposed it:** Charter docs under `docs/webui/…` flipped Fast-Lane WebUI surface selection, which ran the existing default-path tests introduced with durable-default binding (#5521). The defect pre-existed; #5522 did not change archive-root production code.
- **Repair:** Shared helper `durable_isolated_home()` builds an isolated HOME under `~/.cache/peak_trade_pytest_durable_homes/` (outside `/tmp` and outside the git worktree). Genuine `/tmp`-backed HOME remains fail-closed. No production code change; no second archive-root owner; no Env required for the canonical default.

## Files changed
- `tests/webui/archive_root_durable_home_v1.py` (new)
- `tests/webui/test_workflow_dashboard_archive_root_v1.py`
- `tests/webui/test_market_landscape_dashboard_v2_producer_binding_v0.py`
- `tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py`

## Path-safety contract
| | Before | After |
|---|---|---|
| Production `_assert_default_path_safe` / `_tmp_roots` | Unchanged reject under `/tmp`, `/var/tmp` | Unchanged |
| No-env canonical default | Unique platform app-data path under HOME | Same |
| Tests asserting production default | Often used pytest `tmp_path` as HOME (CI fail on Linux) | Durable isolated HOME |
| Genuine tmp HOME | Rejected | Still rejected (`test_home_under_ephemeral_tmp_rejected_for_canonical_default`) |

## Previously failing tests (now pass under `TMPDIR=/tmp`)
- `test_get_market_default_path_projects_selected_instrument_without_env`
- `test_exact_canonical_default_path_resolution_without_env`
- `test_default_path_binds_selected_instrument_and_venue_without_env`
- `test_default_path_missing_readmodel_remains_fail_closed`
- `test_default_path_invalid_schema_remains_fail_closed`

## Bounded local results
- Exact five: PASS
- `test_workflow_dashboard_archive_root_v1.py` (14): PASS
- Fast-Lane WebUI bounded pytest (183): PASS
- Path matrix: `MACOS_DEFAULT_SAFE` / `LINUX_DEFAULT_SAFE` / `GITHUB_RUNNER_DEFAULT_SAFE` / `GENUINE_TMP_ROOT_REJECTED` / `NO_ENV_REQUIRED` / `UNIQUE_CANONICAL_DEFAULT_PRESERVED` = true
- Ruff format/check on touched files: PASS

## Explicit non-goals
- **PR #5522 was not modified** (branch/head left untouched).
- **No runtime or trading authority changed** (orders/shadow/paper/testnet/scheduler/capital/live remain false; no production `src/` edits).

## Test plan
- [x] Reproduce five failures under `TMPDIR=/tmp` + `--basetemp=/tmp/...` (pre-repair)
- [x] Re-run five + archive-root module + Fast-Lane WebUI bounded set
- [ ] GitHub Fast-Lane confirmation on this repair PR


Made with [Cursor](https://cursor.com)