### PR TITLE
feat(ops): ratify OKX min-notional and freshness policies

### DIFF
--- a/config/ops/okx_captured_at_freshness_policy_ratification_v1.json
+++ b/config/ops/okx_captured_at_freshness_policy_ratification_v1.json
@@ -1,0 +1,47 @@
+{
+  "schema_id": "okx_captured_at_freshness_policy_ratification_v1",
+  "schema_version": 1,
+  "policy_ratification_id": "okx_captured_at_freshness_policy_ratification_v1",
+  "non_authorizing": true,
+  "dashboard_authority": false,
+  "trading_authorization": false,
+  "OKX_CAPTURED_AT_SEMANTICS_PROVEN": true,
+  "OKX_CAPTURED_AT_MAPPING_AUTHORIZED": true,
+  "OKX_CAPTURED_AT_POLICY_STATUS": "RATIFIED",
+  "owner_module": "src.ops.okx_captured_at_freshness_policy_v1",
+  "owner_symbol": "build_okx_capture_clocks_v1",
+  "timestamp_policy": {
+    "capture_started_at": "local_utc_clock_immediately_before_request",
+    "response_received_at": "local_utc_clock_immediately_after_complete_response",
+    "provider_timestamp": "exact_okx_timestamp_when_supplied",
+    "captured_at": "response_received_at",
+    "effective_at": "provider_timestamp_when_semantics_valid_else_null",
+    "filesystem_mtime_forbidden": true,
+    "git_timestamp_forbidden": true,
+    "storage_format": "UTC_ISO8601"
+  },
+  "freshness_thresholds_seconds": {
+    "instrument_metadata": 86400,
+    "reference_mark_price": 120,
+    "ohlcv_latest_candle": 7200,
+    "universe_selection": 86400,
+    "dashboard_aggregate": 86400
+  },
+  "stale_render_policy": {
+    "stale_data_loadable_when_contract_permits": true,
+    "must_render_STALE_visibly": true,
+    "silent_fresh_render_forbidden": true
+  },
+  "capture_record_required_fields": [
+    "request_url",
+    "request_path",
+    "query_parameters",
+    "http_status",
+    "provider_code",
+    "provider_message",
+    "capture_started_at",
+    "response_received_at",
+    "captured_at",
+    "raw_payload_digest"
+  ]
+}

--- a/config/ops/okx_min_notional_official_mapping_ratification_v1.json
+++ b/config/ops/okx_min_notional_official_mapping_ratification_v1.json
@@ -1,0 +1,61 @@
+{
+  "schema_id": "okx_min_notional_official_mapping_ratification_v1",
+  "schema_version": 1,
+  "mapping_ratification_id": "okx_min_notional_official_mapping_ratification_v1",
+  "non_authorizing": true,
+  "dashboard_authority": false,
+  "trading_authorization": false,
+  "live_authorized": false,
+  "orders": false,
+  "OKX_MIN_NOTIONAL_DIRECT_FIELD_AVAILABLE": false,
+  "OKX_MIN_NOTIONAL_MAPPING_AUTHORIZED": true,
+  "MAPPING_INPUTS_PROVIDER_AUTHENTIC": true,
+  "REFERENCE_PRICE_REQUIRED": true,
+  "INVERSE_OR_AMBIGUOUS_CONTRACTS_FAIL_CLOSED": true,
+  "DASHBOARD_AUTHORITY": false,
+  "TRADING_AUTHORIZATION": false,
+  "owner_module": "src.ops.okx_min_notional_mapping_v1",
+  "owner_symbol": "map_okx_linear_swap_min_notional_v1",
+  "formula_id": "OKX_LINEAR_SWAP_MIN_QUOTE_NOTIONAL_FROM_MINSZ_CTVAL_MARKPX_V1",
+  "formula_version": "v1",
+  "min_notional_kind": "REFERENCE_PRICE_DERIVED_FROM_PROVIDER_AUTHENTIC_FIELDS",
+  "eligible_ct_type": ["linear"],
+  "eligible_inst_type": ["SWAP"],
+  "eligible_settle_ccy": ["USDT"],
+  "reference_price_type": "okx_public_mark_price",
+  "reference_price_endpoint": "/api/v5/public/mark-price",
+  "instruments_endpoint": "/api/v5/public/instruments",
+  "official_documentation_reference": "https://www.okx.com/docs-v5/en/#public-data-rest-api-get-instruments",
+  "official_mark_price_documentation_reference": "https://www.okx.com/docs-v5/en/#public-data-rest-api-get-mark-price",
+  "formula_semantics": {
+    "minimum_contract_quantity": "Decimal(minSz)",
+    "minimum_base_quantity": "minimum_contract_quantity * Decimal(ctVal)",
+    "computed_min_notional": "minimum_base_quantity * Decimal(markPx)",
+    "units": {
+      "minimum_contract_quantity": "contracts",
+      "ctVal": "base_currency_per_contract",
+      "ctValCcy": "base_currency",
+      "reference_price": "quote_currency_per_base",
+      "computed_min_notional": "quote_currency_notional_at_reference_price"
+    },
+    "note": "Not a timeless provider constant. Persist kind + reference-price provenance always."
+  },
+  "reject_when": [
+    "ctType != linear",
+    "ctValCcy does not match base asset of uly/instId",
+    "settleCcy not in eligible_settle_ccy",
+    "missing minSz/ctVal/markPx",
+    "non-positive Decimal inputs",
+    "stale reference price beyond freshness threshold",
+    "BTC / Spot / inverse / ambiguous units"
+  ],
+  "forbidden": [
+    "hardcoded_price",
+    "dashboard_displayed_price",
+    "local_estimate",
+    "kraken_price",
+    "cross_exchange_price",
+    "float_money_arithmetic",
+    "storing_derived_value_as_unqualified_static_exchange_minimum"
+  ]
+}

--- a/src/ops/okx_captured_at_freshness_policy_v1.py
+++ b/src/ops/okx_captured_at_freshness_policy_v1.py
@@ -1,0 +1,136 @@
+"""Ratified OKX capture-clock and freshness policy owner."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+PACKAGE_MARKER = "OKX_CAPTURED_AT_FRESHNESS_POLICY_V1=true"
+POLICY_RATIFICATION_ID = "okx_captured_at_freshness_policy_ratification_v1"
+CONFIG_RELATIVE_PATH = "config/ops/okx_captured_at_freshness_policy_ratification_v1.json"
+
+DEFAULT_THRESHOLDS_SECONDS = {
+    "instrument_metadata": 86400,
+    "reference_mark_price": 120,
+    "ohlcv_latest_candle": 7200,
+    "universe_selection": 86400,
+    "dashboard_aggregate": 86400,
+}
+
+
+class OkxCapturedAtFreshnessPolicyError(ValueError):
+    """Fail-closed freshness / capture-clock policy error."""
+
+
+@dataclass(frozen=True)
+class OkxCaptureClocksV1:
+    capture_started_at: str
+    response_received_at: str
+    provider_timestamp: str | None
+    captured_at: str
+    effective_at: str | None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_utc_iso(value: str) -> datetime:
+    raw = str(value or "").strip()
+    if not raw:
+        raise OkxCapturedAtFreshnessPolicyError("EMPTY_TIMESTAMP")
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    dt = datetime.fromisoformat(raw)
+    if dt.tzinfo is None:
+        raise OkxCapturedAtFreshnessPolicyError("TIMESTAMP_MUST_BE_AWARE_UTC")
+    return dt.astimezone(timezone.utc)
+
+
+def provider_ms_to_utc_iso(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    text = str(value).strip()
+    if not text.isdigit():
+        return None
+    ms = int(text)
+    if ms <= 0:
+        return None
+    return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_freshness_policy_v1(*, repo_root: Path | None = None) -> Mapping[str, Any]:
+    root = repo_root or _repo_root()
+    path = root / CONFIG_RELATIVE_PATH
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise OkxCapturedAtFreshnessPolicyError("policy config must be object")
+    if data.get("schema_id") != POLICY_RATIFICATION_ID:
+        raise OkxCapturedAtFreshnessPolicyError("policy schema_id mismatch")
+    if data.get("OKX_CAPTURED_AT_MAPPING_AUTHORIZED") is not True:
+        raise OkxCapturedAtFreshnessPolicyError("captured_at mapping not authorized")
+    return data
+
+
+def build_okx_capture_clocks_v1(
+    *,
+    capture_started_at: str,
+    response_received_at: str,
+    provider_timestamp: str | None,
+) -> OkxCaptureClocksV1:
+    """captured_at := response_received_at; effective_at := provider_timestamp when valid."""
+    # Validate clocks are parseable UTC ISO-8601.
+    parse_utc_iso(capture_started_at)
+    parse_utc_iso(response_received_at)
+    effective = None
+    if provider_timestamp:
+        parse_utc_iso(provider_timestamp)
+        effective = provider_timestamp
+    return OkxCaptureClocksV1(
+        capture_started_at=capture_started_at,
+        response_received_at=response_received_at,
+        provider_timestamp=provider_timestamp,
+        captured_at=response_received_at,
+        effective_at=effective,
+    )
+
+
+def freshness_threshold_seconds(source_type: str, *, policy: Mapping[str, Any] | None = None) -> int:
+    thresholds = dict(DEFAULT_THRESHOLDS_SECONDS)
+    if policy is not None:
+        raw = policy.get("freshness_thresholds_seconds") or {}
+        if isinstance(raw, Mapping):
+            for key, value in raw.items():
+                thresholds[str(key)] = int(value)
+    if source_type not in thresholds:
+        raise OkxCapturedAtFreshnessPolicyError(f"UNKNOWN_SOURCE_TYPE:{source_type}")
+    return int(thresholds[source_type])
+
+
+def classify_freshness_v1(
+    *,
+    reference_at: str,
+    as_of: str,
+    source_type: str,
+    policy: Mapping[str, Any] | None = None,
+) -> tuple[str, bool, str | None]:
+    """Return (freshness_state, is_stale, stale_reason)."""
+    max_age = freshness_threshold_seconds(source_type, policy=policy)
+    ref = parse_utc_iso(reference_at)
+    now = parse_utc_iso(as_of)
+    age = (now - ref).total_seconds()
+    if age < 0:
+        return "invalid", True, "CAPTURE_TIMESTAMP_IN_FUTURE"
+    if age > max_age:
+        return "stale", True, f"STALE_OVER_MAX_AGE_SECONDS:{max_age}"
+    return "fresh", False, None

--- a/src/ops/okx_captured_at_freshness_policy_v1.py
+++ b/src/ops/okx_captured_at_freshness_policy_v1.py
@@ -105,7 +105,9 @@ def build_okx_capture_clocks_v1(
     )
 
 
-def freshness_threshold_seconds(source_type: str, *, policy: Mapping[str, Any] | None = None) -> int:
+def freshness_threshold_seconds(
+    source_type: str, *, policy: Mapping[str, Any] | None = None
+) -> int:
     thresholds = dict(DEFAULT_THRESHOLDS_SECONDS)
     if policy is not None:
         raw = policy.get("freshness_thresholds_seconds") or {}

--- a/src/ops/okx_min_notional_mapping_v1.py
+++ b/src/ops/okx_min_notional_mapping_v1.py
@@ -1,0 +1,218 @@
+"""Sole owner: official OKX linear SWAP min-notional mapping (Decimal only).
+
+Non-authorizing. Does not place orders, activate runtime, or invent missing units.
+Inverse / ambiguous contract semantics fail closed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Mapping
+
+PACKAGE_MARKER = "OKX_MIN_NOTIONAL_MAPPING_V1=true"
+MAPPING_RATIFICATION_ID = "okx_min_notional_official_mapping_ratification_v1"
+FORMULA_ID = "OKX_LINEAR_SWAP_MIN_QUOTE_NOTIONAL_FROM_MINSZ_CTVAL_MARKPX_V1"
+FORMULA_VERSION = "v1"
+MIN_NOTIONAL_KIND = "REFERENCE_PRICE_DERIVED_FROM_PROVIDER_AUTHENTIC_FIELDS"
+REFERENCE_PRICE_TYPE = "okx_public_mark_price"
+OFFICIAL_DOCUMENTATION_REFERENCE = (
+    "https://www.okx.com/docs-v5/en/#public-data-rest-api-get-instruments"
+)
+CONFIG_RELATIVE_PATH = "config/ops/okx_min_notional_official_mapping_ratification_v1.json"
+
+REASON_INVERSE_OR_AMBIGUOUS = "OKX_MIN_NOTIONAL_INVERSE_OR_AMBIGUOUS_REJECTED"
+REASON_MISSING_REFERENCE_PRICE = "OKX_MIN_NOTIONAL_MISSING_REFERENCE_PRICE"
+REASON_STALE_REFERENCE_PRICE = "OKX_MIN_NOTIONAL_STALE_REFERENCE_PRICE"
+REASON_NON_POSITIVE_INPUT = "OKX_MIN_NOTIONAL_NON_POSITIVE_INPUT"
+REASON_MISSING_PROVIDER_FIELD = "OKX_MIN_NOTIONAL_MISSING_PROVIDER_FIELD"
+REASON_BTC_EXCLUDED = "OKX_MIN_NOTIONAL_BTC_EXCLUDED"
+REASON_SPOT_EXCLUDED = "OKX_MIN_NOTIONAL_SPOT_EXCLUDED"
+REASON_UNSUPPORTED_SETTLE = "OKX_MIN_NOTIONAL_UNSUPPORTED_SETTLE_CCY"
+
+
+class OkxMinNotionalMappingError(ValueError):
+    """Fail-closed mapping rejection."""
+
+
+@dataclass(frozen=True)
+class OkxMinNotionalMappingResultV1:
+    eligible: bool
+    min_notional_kind: str
+    minimum_contract_quantity: str | None
+    ct_val: str | None
+    ct_val_ccy: str | None
+    ct_type: str | None
+    reference_price: str | None
+    reference_price_type: str | None
+    reference_price_captured_at: str | None
+    computed_min_notional: str | None
+    formula_id: str
+    formula_version: str
+    official_documentation_reference: str
+    raw_capture_digest: str | None
+    mapping_ratification_id: str
+    reason_codes: tuple[str, ...]
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def load_mapping_ratification_v1(*, repo_root: Path | None = None) -> Mapping[str, Any]:
+    root = repo_root or _repo_root()
+    path = root / CONFIG_RELATIVE_PATH
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise OkxMinNotionalMappingError("ratification config must be object")
+    if data.get("schema_id") != MAPPING_RATIFICATION_ID:
+        raise OkxMinNotionalMappingError("ratification schema_id mismatch")
+    if data.get("OKX_MIN_NOTIONAL_DIRECT_FIELD_AVAILABLE") is not False:
+        raise OkxMinNotionalMappingError("direct field claim must remain false")
+    if data.get("OKX_MIN_NOTIONAL_MAPPING_AUTHORIZED") is not True:
+        raise OkxMinNotionalMappingError("mapping not authorized")
+    return data
+
+
+def _dec(value: Any, *, field: str) -> Decimal:
+    if value is None or value == "":
+        raise OkxMinNotionalMappingError(f"{REASON_MISSING_PROVIDER_FIELD}:{field}")
+    if isinstance(value, float):
+        raise OkxMinNotionalMappingError(f"FLOAT_MONEY_FORBIDDEN:{field}")
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise OkxMinNotionalMappingError(f"{REASON_MISSING_PROVIDER_FIELD}:{field}") from exc
+    if parsed <= 0:
+        raise OkxMinNotionalMappingError(f"{REASON_NON_POSITIVE_INPUT}:{field}")
+    return parsed
+
+
+def _base_from_inst(inst: Mapping[str, Any]) -> str:
+    uly = str(inst.get("uly") or "").strip().upper()
+    if uly and "-" in uly:
+        return uly.split("-", 1)[0]
+    inst_id = str(inst.get("instId") or "").strip().upper()
+    if inst_id and "-" in inst_id:
+        return inst_id.split("-", 1)[0]
+    return str(inst.get("baseCcy") or "").strip().upper()
+
+
+def _is_btc(inst: Mapping[str, Any]) -> bool:
+    tokens = (
+        str(inst.get("instId") or ""),
+        str(inst.get("uly") or ""),
+        str(inst.get("baseCcy") or ""),
+        str(inst.get("ctValCcy") or ""),
+        _base_from_inst(inst),
+    )
+    for token in tokens:
+        upper = token.upper()
+        if upper in {"BTC", "XBT", "WBTC", "TBTC"} or upper.startswith("BTC-") or "-BTC-" in upper:
+            return True
+        if upper.endswith("-BTC") or upper.startswith("BTC"):
+            # ETH-BTC-SWAP style / BTC-*
+            parts = upper.replace("_", "-").split("-")
+            if "BTC" in parts or "XBT" in parts:
+                return True
+    return False
+
+
+def map_okx_linear_swap_min_notional_v1(
+    *,
+    instrument: Mapping[str, Any],
+    reference_price: Any,
+    reference_price_captured_at: str,
+    raw_capture_digest: str | None,
+    reference_price_fresh: bool = True,
+) -> OkxMinNotionalMappingResultV1:
+    """Map provider-authentic OKX fields to typed reference-price-derived min notional."""
+    reasons: list[str] = []
+    inst_type = str(instrument.get("instType") or "").strip().upper()
+    ct_type = str(instrument.get("ctType") or "").strip().lower()
+    settle = str(instrument.get("settleCcy") or "").strip().upper()
+    ct_val_ccy = str(instrument.get("ctValCcy") or "").strip().upper()
+    base = _base_from_inst(instrument)
+
+    if inst_type == "SPOT" or str(instrument.get("instId") or "").upper().endswith("-SPOT"):
+        reasons.append(REASON_SPOT_EXCLUDED)
+    if _is_btc(instrument):
+        reasons.append(REASON_BTC_EXCLUDED)
+    if inst_type not in {"SWAP", "FUTURES"}:
+        reasons.append(REASON_INVERSE_OR_AMBIGUOUS)
+    if ct_type != "linear":
+        reasons.append(REASON_INVERSE_OR_AMBIGUOUS)
+    if settle != "USDT":
+        reasons.append(REASON_UNSUPPORTED_SETTLE)
+    if not ct_val_ccy or not base or ct_val_ccy != base:
+        reasons.append(REASON_INVERSE_OR_AMBIGUOUS)
+    if reference_price is None or reference_price == "":
+        reasons.append(REASON_MISSING_REFERENCE_PRICE)
+    if not reference_price_fresh:
+        reasons.append(REASON_STALE_REFERENCE_PRICE)
+    if not reference_price_captured_at:
+        reasons.append(REASON_MISSING_REFERENCE_PRICE)
+
+    if reasons:
+        return OkxMinNotionalMappingResultV1(
+            eligible=False,
+            min_notional_kind=MIN_NOTIONAL_KIND,
+            minimum_contract_quantity=None,
+            ct_val=None,
+            ct_val_ccy=ct_val_ccy or None,
+            ct_type=ct_type or None,
+            reference_price=None,
+            reference_price_type=REFERENCE_PRICE_TYPE,
+            reference_price_captured_at=reference_price_captured_at or None,
+            computed_min_notional=None,
+            formula_id=FORMULA_ID,
+            formula_version=FORMULA_VERSION,
+            official_documentation_reference=OFFICIAL_DOCUMENTATION_REFERENCE,
+            raw_capture_digest=raw_capture_digest,
+            mapping_ratification_id=MAPPING_RATIFICATION_ID,
+            reason_codes=tuple(sorted(set(reasons))),
+        )
+
+    min_sz = _dec(instrument.get("minSz"), field="minSz")
+    ct_val = _dec(instrument.get("ctVal"), field="ctVal")
+    mark = _dec(reference_price, field="markPx")
+    minimum_base = min_sz * ct_val
+    computed = minimum_base * mark
+
+    return OkxMinNotionalMappingResultV1(
+        eligible=True,
+        min_notional_kind=MIN_NOTIONAL_KIND,
+        minimum_contract_quantity=format(min_sz, "f"),
+        ct_val=format(ct_val, "f"),
+        ct_val_ccy=ct_val_ccy,
+        ct_type=ct_type,
+        reference_price=format(mark, "f"),
+        reference_price_type=REFERENCE_PRICE_TYPE,
+        reference_price_captured_at=reference_price_captured_at,
+        computed_min_notional=format(computed, "f"),
+        formula_id=FORMULA_ID,
+        formula_version=FORMULA_VERSION,
+        official_documentation_reference=OFFICIAL_DOCUMENTATION_REFERENCE,
+        raw_capture_digest=raw_capture_digest,
+        mapping_ratification_id=MAPPING_RATIFICATION_ID,
+        reason_codes=(),
+    )
+
+
+def assert_no_adhoc_min_notional_expression(source_text: str) -> None:
+    """Static helper used by architecture guards — detect float-ish ad-hoc expressions."""
+    banned = (
+        "minSz * price",
+        "min_sz * price",
+        "float(minSz)",
+        "float(min_sz)",
+    )
+    lowered = source_text.replace(" ", "")
+    for token in banned:
+        if token.replace(" ", "") in lowered:
+            raise OkxMinNotionalMappingError(f"ADHOC_MIN_NOTIONAL_EXPRESSION:{token}")

--- a/tests/ops/test_okx_captured_at_freshness_policy_v1.py
+++ b/tests/ops/test_okx_captured_at_freshness_policy_v1.py
@@ -1,0 +1,41 @@
+"""Captured-at / freshness policy ratification tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.ops.okx_captured_at_freshness_policy_v1 import (
+    build_okx_capture_clocks_v1,
+    classify_freshness_v1,
+    load_freshness_policy_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_policy_ratified() -> None:
+    cfg = load_freshness_policy_v1(repo_root=REPO)
+    assert cfg["OKX_CAPTURED_AT_MAPPING_AUTHORIZED"] is True
+    assert cfg["timestamp_policy"]["captured_at"] == "response_received_at"
+    assert cfg["timestamp_policy"]["filesystem_mtime_forbidden"] is True
+
+
+def test_captured_at_equals_response_received() -> None:
+    clocks = build_okx_capture_clocks_v1(
+        capture_started_at="2026-07-24T21:00:00Z",
+        response_received_at="2026-07-24T21:00:01Z",
+        provider_timestamp="2026-07-24T20:59:59Z",
+    )
+    assert clocks.captured_at == "2026-07-24T21:00:01Z"
+    assert clocks.effective_at == "2026-07-24T20:59:59Z"
+
+
+def test_stale_classification() -> None:
+    state, is_stale, reason = classify_freshness_v1(
+        reference_at="2026-07-24T20:00:00Z",
+        as_of="2026-07-24T21:00:00Z",
+        source_type="reference_mark_price",
+    )
+    assert state == "stale"
+    assert is_stale is True
+    assert reason is not None

--- a/tests/ops/test_okx_min_notional_mapping_v1.py
+++ b/tests/ops/test_okx_min_notional_mapping_v1.py
@@ -1,0 +1,157 @@
+"""Focused tests for OKX official min-notional mapping ratification owner."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from src.ops.okx_min_notional_mapping_v1 import (
+    FORMULA_ID,
+    MIN_NOTIONAL_KIND,
+    OkxMinNotionalMappingError,
+    load_mapping_ratification_v1,
+    map_okx_linear_swap_min_notional_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_ratification_markers_and_no_direct_field_claim() -> None:
+    cfg = load_mapping_ratification_v1(repo_root=REPO)
+    assert cfg["OKX_MIN_NOTIONAL_DIRECT_FIELD_AVAILABLE"] is False
+    assert cfg["OKX_MIN_NOTIONAL_MAPPING_AUTHORIZED"] is True
+    assert cfg["REFERENCE_PRICE_REQUIRED"] is True
+    assert cfg["INVERSE_OR_AMBIGUOUS_CONTRACTS_FAIL_CLOSED"] is True
+    assert cfg["DASHBOARD_AUTHORITY"] is False
+    assert cfg["TRADING_AUTHORIZATION"] is False
+
+
+def test_linear_swap_mapping_decimal_only() -> None:
+    inst = {
+        "instId": "ETH-USDT-SWAP",
+        "instType": "SWAP",
+        "uly": "ETH-USDT",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "ctVal": "0.1",
+        "ctValCcy": "ETH",
+        "minSz": "0.01",
+        "state": "live",
+    }
+    result = map_okx_linear_swap_min_notional_v1(
+        instrument=inst,
+        reference_price="1859.58",
+        reference_price_captured_at="2026-07-24T21:00:00Z",
+        raw_capture_digest="abc",
+        reference_price_fresh=True,
+    )
+    assert result.eligible is True
+    assert result.min_notional_kind == MIN_NOTIONAL_KIND
+    assert result.formula_id == FORMULA_ID
+    expected = Decimal("0.01") * Decimal("0.1") * Decimal("1859.58")
+    assert Decimal(result.computed_min_notional) == expected
+    assert result.reference_price_type == "okx_public_mark_price"
+
+
+def test_inverse_rejected() -> None:
+    inst = {
+        "instId": "ETH-USD-SWAP",
+        "instType": "SWAP",
+        "uly": "ETH-USD",
+        "settleCcy": "ETH",
+        "ctType": "inverse",
+        "ctVal": "10",
+        "ctValCcy": "USD",
+        "minSz": "1",
+    }
+    result = map_okx_linear_swap_min_notional_v1(
+        instrument=inst,
+        reference_price="1859.58",
+        reference_price_captured_at="2026-07-24T21:00:00Z",
+        raw_capture_digest="abc",
+    )
+    assert result.eligible is False
+    assert result.computed_min_notional is None
+
+
+def test_missing_reference_price_rejected() -> None:
+    inst = {
+        "instId": "ETH-USDT-SWAP",
+        "instType": "SWAP",
+        "uly": "ETH-USDT",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "ctVal": "0.1",
+        "ctValCcy": "ETH",
+        "minSz": "0.01",
+    }
+    result = map_okx_linear_swap_min_notional_v1(
+        instrument=inst,
+        reference_price=None,
+        reference_price_captured_at="2026-07-24T21:00:00Z",
+        raw_capture_digest="abc",
+    )
+    assert result.eligible is False
+
+
+def test_stale_reference_price_rejected() -> None:
+    inst = {
+        "instId": "ETH-USDT-SWAP",
+        "instType": "SWAP",
+        "uly": "ETH-USDT",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "ctVal": "0.1",
+        "ctValCcy": "ETH",
+        "minSz": "0.01",
+    }
+    result = map_okx_linear_swap_min_notional_v1(
+        instrument=inst,
+        reference_price="1859.58",
+        reference_price_captured_at="2026-07-24T21:00:00Z",
+        raw_capture_digest="abc",
+        reference_price_fresh=False,
+    )
+    assert result.eligible is False
+
+
+def test_float_money_rejected() -> None:
+    inst = {
+        "instId": "ETH-USDT-SWAP",
+        "instType": "SWAP",
+        "uly": "ETH-USDT",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "ctVal": "0.1",
+        "ctValCcy": "ETH",
+        "minSz": "0.01",
+    }
+    with pytest.raises(OkxMinNotionalMappingError):
+        map_okx_linear_swap_min_notional_v1(
+            instrument=inst,
+            reference_price=1859.58,  # float forbidden
+            reference_price_captured_at="2026-07-24T21:00:00Z",
+            raw_capture_digest="abc",
+        )
+
+
+def test_btc_excluded() -> None:
+    inst = {
+        "instId": "BTC-USDT-SWAP",
+        "instType": "SWAP",
+        "uly": "BTC-USDT",
+        "settleCcy": "USDT",
+        "ctType": "linear",
+        "ctVal": "0.01",
+        "ctValCcy": "BTC",
+        "minSz": "0.1",
+    }
+    result = map_okx_linear_swap_min_notional_v1(
+        instrument=inst,
+        reference_price="100000",
+        reference_price_captured_at="2026-07-24T21:00:00Z",
+        raw_capture_digest="abc",
+    )
+    assert result.eligible is False


### PR DESCRIPTION
## Summary
- Ratify official OKX linear SWAP min-notional mapping (`minSz * ctVal * markPx`, Decimal-only).
- Ratify captured_at/freshness policy (`captured_at = response_received_at`).
- Add focused policy owner modules and tests.

## Dependency
- Base: `main`
- Stack position: **PR A** (no predecessor)

## Scope
- Policy configs under `config/ops/`
- Pure mapping/freshness modules under `src/ops/`
- Direct unit tests

## Excluded scope
- Network client / packet producer
- Intake / universe / OHLCV
- WebUI binding
- Core / runtime / orders

## Safety
- `LIVE_AUTHORIZED=false`
- `ORDERS=false`
- `AUTHENTICATED_FETCH=false`
- No merge / no auto-merge

## Tests
- `tests/ops/test_okx_min_notional_mapping_v1.py`
- `tests/ops/test_okx_captured_at_freshness_policy_v1.py`

## Evidence
- Targeted policy tests passed locally (13 combined with OHLCV parse tests in later PRs).


Made with [Cursor](https://cursor.com)