### PR TITLE
feat(webui): continuous read-only OKX OHLCV refresh for /market

### DIFF
--- a/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
+++ b/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import os
@@ -23,8 +24,13 @@ from src.ops.okx_public_market_data_client_v1 import OkxPublicMarketDataClientV1
 PACKAGE_MARKER = "OKX_SELECTED_INSTRUMENT_OHLCV_READMODEL_V1=true"
 OHLCV_SCHEMA = "okx_selected_instrument_ohlcv_readmodel.v1"
 OHLCV_RELATIVE_PATH = "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
+UNIVERSE_SELECTION_RELATIVE_PATH = "readmodels/universe_selection_readmodel.v1.json"
+REFRESH_LOCK_NAME = ".okx_selected_instrument_ohlcv_refresh.lock"
 DEFAULT_BAR = "1H"
 DEFAULT_LIMIT = 100
+# Bounded default for PT1H candles: continuous snapshot refresh without OKX hammering.
+# Derived from candle timeframe (1H); not faster than necessary for closed-bar cadence.
+DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS = 60
 
 
 class OkxOhlcvReadmodelError(ValueError):
@@ -249,3 +255,149 @@ def load_ohlcv_readmodel_v1(archive_root: Path) -> Mapping[str, Any] | None:
     if data.get("schema_name") != OHLCV_SCHEMA:
         raise OkxOhlcvReadmodelError("OHLCV_SCHEMA_MISMATCH")
     return data
+
+
+def _parse_aware_utc(raw: Any) -> datetime | None:
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def resolve_selected_instrument_for_ohlcv_refresh_v1(
+    archive_root: Path,
+) -> dict[str, Any]:
+    """Resolve canonical selected OKX instrument from universe_selection_readmodel.v1."""
+    selection_path = archive_root / UNIVERSE_SELECTION_RELATIVE_PATH
+    if not selection_path.is_file():
+        raise OkxOhlcvReadmodelError("MISSING_SOURCE:UNIVERSE_SELECTION")
+    payload = json.loads(selection_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise OkxOhlcvReadmodelError("INVALID:UNIVERSE_SELECTION_NOT_OBJECT")
+    selected = payload.get("selected_future")
+    if not isinstance(selected, dict):
+        raise OkxOhlcvReadmodelError("MISSING_SOURCE:SELECTED_INSTRUMENT")
+    symbol = str(selected.get("symbol") or "").strip()
+    if not symbol:
+        raise OkxOhlcvReadmodelError("MISSING_SOURCE:SELECTED_INSTRUMENT")
+    if "BTC" in symbol.upper().split("-"):
+        raise OkxOhlcvReadmodelError("INVALID:BTC_EXCLUDED")
+    venue = "okx"
+    for row in payload.get("universe") or []:
+        if isinstance(row, dict) and str(row.get("symbol") or "") == symbol and row.get("exchange"):
+            venue = str(row["exchange"]).strip().lower() or "okx"
+            break
+    if venue not in {"okx", "okx_europe_eea"}:
+        raise OkxOhlcvReadmodelError("INVALID:SELECTED_VENUE_NOT_OKX")
+    bundle_id = str(
+        payload.get("source_run_id")
+        or (payload.get("evidence") or {}).get("source_run_id")
+        or "universe_selection_readmodel.v1"
+    )
+    return {
+        "selected_instrument": symbol,
+        "selected_provider_instrument_id": symbol,
+        "selected_venue": venue,
+        "selection_bundle_id": bundle_id,
+        "selection_path": selection_path,
+    }
+
+
+def refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
+    *,
+    archive_root: Path,
+    client: OkxPublicMarketDataClientV1 | None = None,
+    bar: str = DEFAULT_BAR,
+    min_interval_seconds: int = DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Rate-limited public OHLCV rematerialization for the canonically selected instrument.
+
+    Fail-closed: provider/network errors do not invent candles or rewrite the
+    readmodel with fabricated bars. Concurrent refreshes are exclusive via flock.
+    """
+    root = archive_root.expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path = root / REFRESH_LOCK_NAME
+    lock_fh = lock_path.open("w", encoding="utf-8")
+    try:
+        try:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise OkxOhlcvReadmodelError("REFRESH_IN_PROGRESS") from exc
+
+        selection = resolve_selected_instrument_for_ohlcv_refresh_v1(root)
+        existing = load_ohlcv_readmodel_v1(root)
+        if existing is not None:
+            if str(existing.get("instrument_id") or "") != selection["selected_instrument"]:
+                raise OkxOhlcvReadmodelError("INVALID:INSTRUMENT_MISMATCH")
+            if str(existing.get("venue") or "").lower() not in {"okx", "okx_europe_eea"}:
+                raise OkxOhlcvReadmodelError("INVALID:OHLCV_VENUE_NOT_OKX")
+            captured_at = _parse_aware_utc(existing.get("captured_at"))
+            if not force and captured_at is not None and min_interval_seconds > 0:
+                age = (datetime.now(timezone.utc) - captured_at).total_seconds()
+                if age < float(min_interval_seconds):
+                    return {
+                        "status": "SKIPPED_RECENT",
+                        "refresh_attempted": False,
+                        "selected_instrument": selection["selected_instrument"],
+                        "selected_venue": selection["selected_venue"],
+                        "captured_at": existing.get("captured_at"),
+                        "last_timestamp": existing.get("last_timestamp"),
+                        "digest": hashlib.sha256(
+                            json.dumps(existing, sort_keys=True).encode()
+                        ).hexdigest(),
+                        "ohlcv": dict(existing),
+                    }
+
+        try:
+            materialize = materialize_selected_okx_ohlcv_readmodel_v1(
+                archive_root=root,
+                selected_instrument=selection["selected_instrument"],
+                selected_provider_instrument_id=selection["selected_provider_instrument_id"],
+                selected_venue=selection["selected_venue"],
+                selection_bundle_id=selection["selection_bundle_id"],
+                selection_path=selection["selection_path"],
+                bar=bar,
+                client=client,
+            )
+        except Exception as exc:  # noqa: BLE001 — surface provider failures fail-closed
+            retained = load_ohlcv_readmodel_v1(root)
+            return {
+                "status": "REFRESH_FAILED",
+                "refresh_attempted": True,
+                "refresh_error": f"{type(exc).__name__}:{exc}",
+                "selected_instrument": selection["selected_instrument"],
+                "selected_venue": selection["selected_venue"],
+                "captured_at": None if retained is None else retained.get("captured_at"),
+                "last_timestamp": None if retained is None else retained.get("last_timestamp"),
+                "digest": None
+                if retained is None
+                else hashlib.sha256(json.dumps(retained, sort_keys=True).encode()).hexdigest(),
+                "ohlcv": None if retained is None else dict(retained),
+                "fabricated": False,
+            }
+
+        refreshed = load_ohlcv_readmodel_v1(root)
+        return {
+            "status": "OK",
+            "refresh_attempted": True,
+            "selected_instrument": selection["selected_instrument"],
+            "selected_venue": selection["selected_venue"],
+            "captured_at": None if refreshed is None else refreshed.get("captured_at"),
+            "last_timestamp": None if refreshed is None else refreshed.get("last_timestamp"),
+            "digest": materialize.get("digest"),
+            "ohlcv": None if refreshed is None else dict(refreshed),
+            "materialize": materialize,
+        }
+    finally:
+        try:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+        except Exception:  # noqa: BLE001
+            pass
+        lock_fh.close()

--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -9,6 +9,8 @@ Phase 4.2 binds dynamic_scope lifecycle identity fail-closed (injection only).
 Phase 4.3A binds canonical_decision fail-closed (injection only).
 Phase 4.3B binds double_play display fail-closed (injection only).
 OHLCV binds from materialized okx_selected_instrument_ohlcv_readmodel.v1 only.
+Continuous refresh: GET /api/market/landscape/ohlcv rate-limits rematerialization
+via the OKX OHLCV readmodel owner; browser polls read-only JSON only.
 Regime / bull-bear / switch stay unbound.
 """
 
@@ -17,16 +19,22 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 
 from .market_dashboard_landscape_producer_binding_v2 import (
     bind_market_universe_slots,
     load_bound_okx_ohlcv_readmodel_v1,
+    resolve_landscape_archive_root,
 )
+from .market_dashboard_landscape_v2.availability import Availability
 from .market_dashboard_landscape_v2.page_aggregate import MarketDashboardReadServiceV1
-from .market_dashboard_landscape_v2.presenter import present_market_landscape_v2
+from .market_dashboard_landscape_v2.presenter import (
+    OHLCV_POLL_PATH,
+    present_market_landscape_v2,
+    serialize_ohlcv_browser_payload_v1,
+)
 
 router = APIRouter(tags=["market-dashboard-landscape-v2", "read-only"])
 
@@ -45,6 +53,142 @@ def get_templates() -> Jinja2Templates:
             "Market landscape shell not configured. Call set_market_landscape_shell_config()."
         )
     return _TEMPLATES
+
+
+def _chart_availability_for_ohlcv(ohlcv: dict[str, Any] | None) -> Availability:
+    if ohlcv is None:
+        return Availability.MISSING_SOURCE
+    freshness = str(ohlcv.get("freshness_state") or "").lower()
+    if freshness == "stale" or bool(ohlcv.get("is_stale")):
+        return Availability.STALE
+    return Availability.AVAILABLE
+
+
+def build_ohlcv_poll_response_v1(
+    *,
+    force_refresh: bool = False,
+    client: Any | None = None,
+) -> dict[str, Any]:
+    """Compose read-only OHLCV poll JSON; optional rate-limited rematerialization."""
+    from src.ops.okx_selected_instrument_ohlcv_readmodel_v1 import (
+        DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS,
+        OkxOhlcvReadmodelError,
+        refresh_selected_okx_ohlcv_readmodel_from_archive_v1,
+    )
+
+    generated_at = datetime.now(timezone.utc)
+    phase_slots = bind_market_universe_slots(generated_at=generated_at, git_sha=None)
+    page = _READ_SERVICE.load_page_snapshot(
+        generated_at=generated_at,
+        git_sha=None,
+        slot_overrides=phase_slots,
+    )
+    selected = page.market_instrument.instrument_id or page.universe_ranking.selected_instrument_id
+    selected_venue = page.market_instrument.venue
+    archive_root = resolve_landscape_archive_root()
+    refresh_meta: dict[str, Any] = {
+        "status": "NO_ARCHIVE",
+        "refresh_attempted": False,
+        "refresh_error": None,
+    }
+    if archive_root is None:
+        return {
+            "schema_name": "market_landscape_ohlcv_poll_response.v1",
+            "schema_version": 1,
+            "status": "MISSING_SOURCE",
+            "availability": Availability.MISSING_SOURCE.value,
+            "poll_path": OHLCV_POLL_PATH,
+            "poll_interval_seconds": DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS,
+            "selected_instrument_id": selected,
+            "venue": selected_venue,
+            "refresh": refresh_meta,
+            "browser_payload": None,
+            "write_methods": [],
+            "orders": False,
+            "runtime_activation": False,
+            "direct_browser_okx": False,
+        }
+
+    try:
+        refresh_meta = refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
+            archive_root=archive_root,
+            client=client,
+            force=force_refresh,
+            min_interval_seconds=0
+            if force_refresh
+            else DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS,
+        )
+    except OkxOhlcvReadmodelError as exc:
+        refresh_meta = {
+            "status": "REFRESH_FAILED",
+            "refresh_attempted": True,
+            "refresh_error": str(exc),
+            "fabricated": False,
+        }
+
+    ohlcv = load_bound_okx_ohlcv_readmodel_v1(
+        selected_instrument_id=selected,
+        selected_venue=selected_venue,
+    )
+    if ohlcv is None and isinstance(refresh_meta.get("ohlcv"), dict):
+        # Retained prior snapshot after failed refresh, when identity still matches.
+        retained = refresh_meta["ohlcv"]
+        if selected and str(retained.get("instrument_id") or "") == str(selected):
+            ohlcv = retained
+
+    browser_payload = serialize_ohlcv_browser_payload_v1(ohlcv)
+    availability = _chart_availability_for_ohlcv(ohlcv)
+    status = str(refresh_meta.get("status") or "OK")
+    if ohlcv is None and selected is None:
+        status = "MISSING_SOURCE"
+        availability = Availability.MISSING_SOURCE
+    elif ohlcv is None:
+        status = "MISSING_SOURCE"
+        availability = Availability.MISSING_SOURCE
+    elif str(refresh_meta.get("refresh_error") or "").startswith("INVALID:"):
+        status = "INVALID"
+        availability = Availability.INVALID
+    elif status == "REFRESH_FAILED" and ohlcv is not None:
+        # Honest failure: retain prior candles but do not claim a successful refresh.
+        availability = (
+            Availability.STALE if availability is Availability.AVAILABLE else availability
+        )
+
+    return {
+        "schema_name": "market_landscape_ohlcv_poll_response.v1",
+        "schema_version": 1,
+        "status": status,
+        "availability": availability.value,
+        "poll_path": OHLCV_POLL_PATH,
+        "poll_interval_seconds": DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS,
+        "selected_instrument_id": selected
+        or (None if ohlcv is None else ohlcv.get("instrument_id")),
+        "venue": "OKX"
+        if (selected_venue and str(selected_venue).lower().startswith("okx"))
+        or (ohlcv and str(ohlcv.get("venue") or "").lower().startswith("okx"))
+        else selected_venue,
+        "interval": None if ohlcv is None else ohlcv.get("interval"),
+        "captured_at": None if ohlcv is None else ohlcv.get("captured_at"),
+        "effective_at": None if ohlcv is None else ohlcv.get("effective_at"),
+        "last_timestamp": None if ohlcv is None else ohlcv.get("last_timestamp"),
+        "last_closed_timestamp": None if ohlcv is None else ohlcv.get("last_closed_timestamp"),
+        "freshness_state": None if ohlcv is None else ohlcv.get("freshness_state"),
+        "is_stale": False if ohlcv is None else bool(ohlcv.get("is_stale")),
+        "payload_digest": None
+        if browser_payload is None
+        else browser_payload.get("payload_digest"),
+        "refresh": {
+            "status": refresh_meta.get("status"),
+            "refresh_attempted": bool(refresh_meta.get("refresh_attempted")),
+            "refresh_error": refresh_meta.get("refresh_error"),
+            "fabricated": bool(refresh_meta.get("fabricated", False)),
+        },
+        "browser_payload": browser_payload,
+        "write_methods": [],
+        "orders": False,
+        "runtime_activation": False,
+        "direct_browser_okx": False,
+    }
 
 
 @router.get("/market", response_class=HTMLResponse, name="market_landscape_v2")
@@ -89,3 +233,12 @@ async def market_landscape_dashboard(request: Request) -> Any:
             **context,
         },
     )
+
+
+@router.get("/api/market/landscape/ohlcv", name="market_landscape_ohlcv_poll_v1")
+async def market_landscape_ohlcv_poll(
+    force: bool = Query(default=False, description="Bypass min-interval skip (tests/ops)."),
+) -> JSONResponse:
+    """Read-only OHLCV snapshot poll; may rematerialize public OKX candles server-side."""
+    payload = build_ohlcv_poll_response_v1(force_refresh=force)
+    return JSONResponse(payload)

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -5,6 +5,8 @@ No decision, risk, sizing, scope, Double Play, or Safety authority logic.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Any, Mapping
 
 from .availability import Availability
@@ -12,6 +14,10 @@ from .contracts import _ProjectionBase
 from .page_aggregate import MarketDashboardPageSnapshotV1
 from .serialization import serialize_projection
 from .source_health import DashboardSourceHealthSnapshotV1
+
+# Presentation-only poll contract; server owns refresh cadence/materialization.
+OHLCV_POLL_PATH = "/api/market/landscape/ohlcv"
+OHLCV_BROWSER_PAYLOAD_SCHEMA = "market_landscape_ohlcv_browser_payload.v1"
 
 AVAILABILITY_LABELS: Mapping[Availability, str] = {
     Availability.AVAILABLE: "AVAILABLE",
@@ -90,6 +96,15 @@ def _finite_ohlc_float(raw: Any) -> float | None:
     return value
 
 
+def _ohlcv_poll_interval_seconds() -> int:
+    """Reuse canonical OKX OHLCV poll cadence; presentation never invents a second owner."""
+    from src.ops.okx_selected_instrument_ohlcv_readmodel_v1 import (
+        DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS,
+    )
+
+    return int(DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS)
+
+
 def serialize_ohlcv_browser_payload_v1(
     ohlcv_readmodel: Mapping[str, Any] | None,
 ) -> dict[str, Any] | None:
@@ -118,6 +133,13 @@ def serialize_ohlcv_browser_payload_v1(
             return None
         assert open_v is not None and high_v is not None
         assert low_v is not None and close_v is not None
+        confirm_raw = row.get("confirm")
+        if confirm_raw is None:
+            confirm = True
+        elif isinstance(confirm_raw, bool):
+            confirm = confirm_raw
+        else:
+            confirm = str(confirm_raw) in {"1", "true", "True"}
         bars.append(
             {
                 "ts": ts.strip(),
@@ -125,19 +147,51 @@ def serialize_ohlcv_browser_payload_v1(
                 "high": high_v,
                 "low": low_v,
                 "close": close_v,
+                "confirm": confirm,
+                "provisional": not confirm,
             }
         )
     venue_raw = ohlcv_readmodel.get("venue")
     venue_display = None
     if isinstance(venue_raw, str) and venue_raw.strip():
         venue_display = _venue_display(venue_raw, Availability.AVAILABLE)
+    digest_source = {
+        "instrument_id": ohlcv_readmodel.get("instrument_id"),
+        "venue": venue_display or venue_raw,
+        "interval": ohlcv_readmodel.get("interval"),
+        "last_closed_timestamp": ohlcv_readmodel.get("last_closed_timestamp"),
+        "captured_at": ohlcv_readmodel.get("captured_at"),
+        "bars": [
+            {
+                "ts": b["ts"],
+                "open": b["open"],
+                "high": b["high"],
+                "low": b["low"],
+                "close": b["close"],
+                "confirm": b["confirm"],
+            }
+            for b in bars
+        ],
+    }
+    payload_digest = hashlib.sha256(
+        json.dumps(digest_source, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
     return {
+        "schema_name": OHLCV_BROWSER_PAYLOAD_SCHEMA,
+        "schema_version": 1,
         "instrument_id": ohlcv_readmodel.get("instrument_id"),
         "venue": venue_display or venue_raw,
         "interval": ohlcv_readmodel.get("interval"),
         "bar_count": len(bars),
         "first_timestamp": bars[0]["ts"],
         "last_timestamp": bars[-1]["ts"],
+        "last_closed_timestamp": ohlcv_readmodel.get("last_closed_timestamp"),
+        "captured_at": ohlcv_readmodel.get("captured_at"),
+        "effective_at": ohlcv_readmodel.get("effective_at"),
+        "freshness_state": ohlcv_readmodel.get("freshness_state"),
+        "is_stale": bool(ohlcv_readmodel.get("is_stale")),
+        "gap_count": ohlcv_readmodel.get("gap_count"),
+        "payload_digest": payload_digest,
         "bars": bars,
     }
 
@@ -459,6 +513,12 @@ def present_market_landscape_v2(
             "last_closed_timestamp": (ohlcv_payload or {}).get("last_closed_timestamp"),
             "first_timestamp": (browser_payload or {}).get("first_timestamp"),
             "last_timestamp": (browser_payload or {}).get("last_timestamp"),
+            "captured_at": (browser_payload or ohlcv_payload or {}).get("captured_at"),
+            "effective_at": (browser_payload or ohlcv_payload or {}).get("effective_at"),
+            "payload_digest": (browser_payload or {}).get("payload_digest"),
+            "is_stale": bool((ohlcv_payload or {}).get("is_stale")),
+            "poll_path": OHLCV_POLL_PATH,
+            "poll_interval_seconds": _ohlcv_poll_interval_seconds(),
         },
         "timeline": {
             "availability": Availability.NOT_BOUND.value,

--- a/static/css/market_dashboard_landscape_v2.css
+++ b/static/css/market_dashboard_landscape_v2.css
@@ -236,6 +236,40 @@
   margin-bottom: 6px;
 }
 
+.mdl-v2-chart__meta {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px 12px;
+  margin: 0 0 8px;
+  padding: 0;
+}
+
+.mdl-v2-chart__meta > div {
+  min-width: 0;
+}
+
+.mdl-v2-chart__meta dt {
+  margin: 0;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.mdl-v2-chart__meta dd {
+  margin: 2px 0 0;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 11px;
+  color: #cbd5e1;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 1100px) {
+  .mdl-v2-chart__meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 .mdl-v2-chart__stage {
   flex: 1;
   margin: 0;

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -1,7 +1,8 @@
 /**
  * Market Dashboard Landscape V2 — presentation-only client helpers.
  * No fetch mutation, no decision/risk/sizing logic, no write endpoints.
- * Renders materialized OHLCV from SSR JSON only (never fabricates candles).
+ * Renders materialized OHLCV from SSR/poll JSON only (never fabricates candles).
+ * Polls the read-only /api/market/landscape/ohlcv snapshot endpoint; never calls OKX.
  */
 (function () {
   "use strict";
@@ -35,7 +36,37 @@
     if (reason) canvas.setAttribute("data-mdl-chart-error", reason);
   }
 
-  function renderOhlcvCanvas() {
+  function updateMetaFromPayload(payload, availability) {
+    var intervalNode = root.querySelector('[data-mdl-field="ohlcv_interval"]');
+    var latestNode = root.querySelector('[data-mdl-field="ohlcv_latest_candle_at"]');
+    var capturedNode = root.querySelector('[data-mdl-field="ohlcv_captured_at"]');
+    var freshnessNode = root.querySelector('[data-mdl-field="ohlcv_freshness"]');
+    var availNode = root.querySelector("[data-mdl-chart-availability]");
+    if (intervalNode) {
+      intervalNode.textContent = (payload && payload.interval) || "—";
+    }
+    if (latestNode) {
+      latestNode.textContent = (payload && payload.last_timestamp) || "—";
+    }
+    if (capturedNode) {
+      capturedNode.textContent = (payload && payload.captured_at) || "—";
+    }
+    if (freshnessNode) {
+      var fresh =
+        (payload && payload.freshness_state && String(payload.freshness_state).toUpperCase()) ||
+        availability ||
+        "—";
+      freshnessNode.textContent = fresh;
+      if (availability) freshnessNode.setAttribute("data-availability", availability);
+    }
+    if (availNode && availability) {
+      availNode.textContent = availability;
+      availNode.setAttribute("data-availability", availability);
+    }
+  }
+
+  function renderOhlcvCanvas(optionalPayload) {
+    var chart = root.querySelector("[data-mdl-chart]");
     var payloadNode = root.querySelector("[data-mdl-ohlcv-json]");
     var canvas = root.querySelector("[data-mdl-chart-canvas]");
     var message = root.querySelector("[data-mdl-chart-message]");
@@ -46,13 +77,20 @@
       return;
     }
 
-    var payload;
-    try {
-      payload = JSON.parse(payloadNode.textContent || "");
-    } catch (err) {
-      markBlank(canvas, "json_parse");
-      return;
+    var payload = optionalPayload;
+    if (!payload) {
+      try {
+        payload = JSON.parse(payloadNode.textContent || "");
+      } catch (err) {
+        markBlank(canvas, "json_parse");
+        return;
+      }
+    } else {
+      payloadNode.textContent = JSON.stringify(payload);
     }
+
+    updateMetaFromPayload(payload, chart && chart.getAttribute("data-availability"));
+
     var bars = payload && payload.bars;
     if (!Array.isArray(bars) || bars.length === 0) {
       markBlank(canvas, "empty_bars");
@@ -172,6 +210,12 @@
     canvas.setAttribute("data-mdl-chart-bar-count", String(n));
     canvas.setAttribute("data-mdl-chart-first-ts", String(bars[0].ts || ""));
     canvas.setAttribute("data-mdl-chart-last-ts", String(bars[n - 1].ts || ""));
+    if (payload.captured_at) {
+      canvas.setAttribute("data-mdl-chart-captured-at", String(payload.captured_at));
+    }
+    if (payload.payload_digest) {
+      canvas.setAttribute("data-mdl-chart-digest", String(payload.payload_digest));
+    }
     if (payload.instrument_id) {
       canvas.setAttribute(
         "data-mdl-chart-instrument",
@@ -187,10 +231,109 @@
     );
   }
 
+  function startOhlcvPolling() {
+    var chart = root.querySelector("[data-mdl-chart]");
+    if (!chart) return;
+    var pollPath = chart.getAttribute("data-mdl-ohlcv-poll-path") || "";
+    var intervalSeconds = Number(
+      chart.getAttribute("data-mdl-ohlcv-poll-interval-seconds") || "0"
+    );
+    if (!pollPath || !(intervalSeconds > 0)) return;
+    if (pollPath.indexOf("/api/market/") !== 0) return;
+
+    var inFlight = false;
+    var timerId = null;
+    var lastDigest = "";
+
+    function scheduleNext() {
+      if (timerId !== null) window.clearTimeout(timerId);
+      timerId = window.setTimeout(tick, intervalSeconds * 1000);
+    }
+
+    function tick() {
+      if (document.hidden) {
+        scheduleNext();
+        return;
+      }
+      if (inFlight) {
+        scheduleNext();
+        return;
+      }
+      inFlight = true;
+      root.setAttribute("data-mdl-ohlcv-poll-in-flight", "true");
+      fetch(pollPath, {
+        method: "GET",
+        credentials: "same-origin",
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+      })
+        .then(function (response) {
+          if (!response.ok) {
+            throw new Error("poll_http_" + response.status);
+          }
+          return response.json();
+        })
+        .then(function (body) {
+          if (!body || typeof body !== "object") {
+            throw new Error("poll_invalid_body");
+          }
+          if (body.direct_browser_okx) {
+            throw new Error("poll_forbidden_direct_okx");
+          }
+          var availability = body.availability || "";
+          if (availability) {
+            chart.setAttribute("data-availability", availability);
+          }
+          updateMetaFromPayload(body.browser_payload || body, availability);
+          var message = root.querySelector("[data-mdl-chart-message]");
+          if (message && body.refresh && body.refresh.refresh_error) {
+            message.setAttribute(
+              "data-mdl-ohlcv-refresh-error",
+              String(body.refresh.refresh_error)
+            );
+          } else if (message) {
+            message.removeAttribute("data-mdl-ohlcv-refresh-error");
+          }
+          if (body.browser_payload && body.browser_payload.bars) {
+            var digest = body.browser_payload.payload_digest || "";
+            if (digest !== lastDigest) {
+              lastDigest = digest;
+              renderOhlcvCanvas(body.browser_payload);
+            } else {
+              updateMetaFromPayload(body.browser_payload, availability);
+            }
+          }
+          root.setAttribute("data-mdl-ohlcv-poll-status", String(body.status || "OK"));
+          root.setAttribute("data-mdl-ohlcv-poll-ok", "true");
+        })
+        .catch(function (err) {
+          root.setAttribute("data-mdl-ohlcv-poll-ok", "false");
+          root.setAttribute(
+            "data-mdl-ohlcv-poll-error",
+            String((err && err.message) || "poll_failed")
+          );
+        })
+        .then(function () {
+          inFlight = false;
+          root.setAttribute("data-mdl-ohlcv-poll-in-flight", "false");
+          scheduleNext();
+        });
+    }
+
+    root.setAttribute("data-mdl-ohlcv-poll-armed", "true");
+    scheduleNext();
+  }
+
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", renderOhlcvCanvas);
+    document.addEventListener("DOMContentLoaded", function () {
+      renderOhlcvCanvas();
+      startOhlcvPolling();
+    });
   } else {
     renderOhlcvCanvas();
+    startOhlcvPolling();
   }
-  window.addEventListener("resize", renderOhlcvCanvas);
+  window.addEventListener("resize", function () {
+    renderOhlcvCanvas();
+  });
 })();

--- a/templates/peak_trade_dashboard/market_landscape_v2.html
+++ b/templates/peak_trade_dashboard/market_landscape_v2.html
@@ -94,11 +94,39 @@
         data-mdl-chart-region="true"
         aria-label="Primary market workspace"
       >
-        <div class="mdl-v2-chart" data-mdl-chart="true" data-chart-bound="{{ chart.bound|lower }}" data-mdl-chart-has-series="{{ chart.has_browser_series|lower }}">
+        <div
+          class="mdl-v2-chart"
+          data-mdl-chart="true"
+          data-chart-bound="{{ chart.bound|lower }}"
+          data-mdl-chart-has-series="{{ chart.has_browser_series|lower }}"
+          data-mdl-ohlcv-poll-path="{{ chart.poll_path }}"
+          data-mdl-ohlcv-poll-interval-seconds="{{ chart.poll_interval_seconds }}"
+        >
           <div class="mdl-v2-chart__chrome">
             <h2>Chart</h2>
-            <span class="mdl-v2-state" data-availability="{{ chart.availability }}">{{ chart.availability_label }}</span>
+            <span class="mdl-v2-state" data-availability="{{ chart.availability }}" data-mdl-chart-availability="true">{{ chart.availability_label }}</span>
           </div>
+          <dl class="mdl-v2-chart__meta" data-mdl-ohlcv-meta="true" aria-label="OHLCV freshness">
+            <div>
+              <dt>Interval</dt>
+              <dd data-mdl-field="ohlcv_interval">{% if chart.interval %}{{ chart.interval }}{% else %}—{% endif %}</dd>
+            </div>
+            <div>
+              <dt>Latest candle</dt>
+              <dd data-mdl-field="ohlcv_latest_candle_at">{% if chart.last_timestamp %}{{ chart.last_timestamp }}{% else %}—{% endif %}</dd>
+            </div>
+            <div>
+              <dt>Captured</dt>
+              <dd data-mdl-field="ohlcv_captured_at">{% if chart.captured_at %}{{ chart.captured_at }}{% else %}—{% endif %}</dd>
+            </div>
+            <div>
+              <dt>Freshness</dt>
+              <dd
+                data-mdl-field="ohlcv_freshness"
+                data-availability="{{ chart.availability }}"
+              >{% if chart.freshness_state %}{{ chart.freshness_state|upper }}{% else %}{{ chart.availability_label }}{% endif %}</dd>
+            </div>
+          </dl>
           <div class="mdl-v2-chart__stage" role="img" aria-label="{{ chart.message }}" data-mdl-chart-stage="true">
             <p class="mdl-v2-chart__message" data-mdl-chart-message="true">{{ chart.message }}</p>
             {% if chart.browser_payload %}

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -1,0 +1,397 @@
+"""Continuous read-only OKX OHLCV refresh contracts for Market Landscape V2."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scripts.ops.primary_evidence_retention_v0 import (
+    write_manifest_sha256 as _write_manifest_sha256,
+)
+from src.ops.okx_public_market_data_client_v1 import OkxPublicCaptureEnvelopeV1
+from src.ops.okx_selected_instrument_ohlcv_readmodel_v1 import (
+    DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS,
+    materialize_selected_okx_ohlcv_readmodel_v1,
+    refresh_selected_okx_ohlcv_readmodel_from_archive_v1,
+)
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_shell_router_v2 import (
+    build_ohlcv_poll_response_v1,
+)
+from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT
+
+REPO = Path(__file__).resolve().parents[2]
+INSTRUMENT = "SATS-USDT-SWAP"
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class _FakeOkxClient:
+    def __init__(self, *, captured_at: str, close_px: str = "0.000000009176") -> None:
+        self.captured_at = captured_at
+        self.close_px = close_px
+        self.calls = 0
+
+    def get_json(self, path: str, params: dict[str, str]) -> OkxPublicCaptureEnvelopeV1:
+        assert path == "/api/v5/market/history-candles"
+        assert params["instId"] == INSTRUMENT
+        self.calls += 1
+        start = datetime(2026, 7, 20, 18, 0, 0, tzinfo=timezone.utc)
+        rows: list[list[str]] = []
+        for i in range(100):
+            ts = start + timedelta(hours=i)
+            ms = str(int(ts.timestamp() * 1000))
+            confirm = "0" if i == 99 else "1"
+            close = self.close_px if i == 99 else "0.000000009200"
+            rows.append([ms, close, close, close, close, "10", "10", "10", confirm])
+        body = json.dumps({"code": "0", "msg": "", "data": rows})
+        return OkxPublicCaptureEnvelopeV1(
+            request_url=f"https://www.okx.com{path}?instId={INSTRUMENT}",
+            request_path=path,
+            query_parameters=dict(params),
+            http_status=200,
+            provider_code="0",
+            provider_message="",
+            capture_started_at=self.captured_at,
+            response_received_at=self.captured_at,
+            captured_at=self.captured_at,
+            effective_at=self.captured_at,
+            provider_timestamp=None,
+            raw_payload_digest="a" * 64,
+            byte_size=len(body.encode("utf-8")),
+            raw_body_utf8=body,
+        )
+
+
+class _FailingOkxClient:
+    calls = 0
+
+    def get_json(self, path: str, params: dict[str, str]) -> OkxPublicCaptureEnvelopeV1:
+        self.calls += 1
+        raise RuntimeError("PROVIDER_DOWN")
+
+
+def _write_universe(archive_root: Path, *, symbol: str = INSTRUMENT) -> Path:
+    readmodels = archive_root / "readmodels"
+    readmodels.mkdir(parents=True, exist_ok=True)
+    universe = {
+        "schema_name": "universe_selection_readmodel.v1",
+        "schema_version": 1,
+        "generated_at": "2026-07-24T21:48:23Z",
+        "source_run_id": "okx_continuous_refresh_v1",
+        "source_stage": "paper",
+        "non_authorizing": True,
+        "fixture_marked": False,
+        "universe": [
+            {
+                "row_id": f"c-{symbol}",
+                "symbol": symbol,
+                "rank": 1,
+                "exchange": "okx",
+            }
+        ],
+        "ranking": [
+            {
+                "row_id": f"r-c-{symbol}",
+                "symbol": symbol,
+                "rank": 1,
+                "notes": "futures_upstream_adapter_v1",
+            }
+        ],
+        "selected_future": {
+            "row_id": f"s-c-{symbol}",
+            "symbol": symbol,
+            "rank": 1,
+            "truth_status": "PERSISTED",
+            "selection_reason": "upstream_explicit_selection",
+        },
+        "market_snapshot": {
+            "truth_status": "PERSISTED",
+            "source_kind": "futures_upstream_adapter_v1",
+            "snapshot_id": f"u2c-{symbol}",
+            "exchange": "okx",
+            "captured_at": None,
+        },
+        "evidence": {
+            "producer_contract": "universe_selection_producer.v1",
+            "storage_target": "readmodels/universe_selection_readmodel.v1.json",
+            "links": [],
+        },
+        "missing_truth": {
+            "universe": "PERSISTED",
+            "ranking": "PERSISTED",
+            "selected_future": "PERSISTED",
+            "future_detail": "AVAILABLE",
+            "orders_fills_pnl": "NOT_PERSISTED",
+        },
+    }
+    path = readmodels / "universe_selection_readmodel.v1.json"
+    path.write_text(json.dumps(universe, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_manifest_sha256(readmodels)
+    return path
+
+
+def test_authentic_okx_maps_and_newer_snapshot_advances(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive)
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+
+    client_a = _FakeOkxClient(captured_at="2026-07-25T00:00:00Z", close_px="0.000000009100")
+    first = materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=client_a,  # type: ignore[arg-type]
+    )
+    assert first["bar_count"] == 100
+    assert first["last_closed_timestamp"] is not None
+
+    client_b = _FakeOkxClient(captured_at="2026-07-25T00:05:00Z", close_px="0.000000009500")
+    second = refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
+        archive_root=archive,
+        client=client_b,  # type: ignore[arg-type]
+        force=True,
+    )
+    assert second["status"] == "OK"
+    assert second["refresh_attempted"] is True
+    assert second["captured_at"] == "2026-07-25T00:05:00Z"
+    assert second["captured_at"] != first.get("captured_at")
+    assert second["ohlcv"]["instrument_id"] == INSTRUMENT
+    assert second["ohlcv"]["venue"] == "okx"
+    assert second["ohlcv"]["bars"][-1]["close"] == "0.000000009500"
+    assert client_b.calls == 1
+
+
+def test_provider_failure_does_not_fabricate_or_advance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive)
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    good = _FakeOkxClient(captured_at="2026-07-25T00:00:00Z")
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=good,  # type: ignore[arg-type]
+    )
+    before = json.loads(
+        (archive / "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    failing = _FailingOkxClient()
+    result = refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
+        archive_root=archive,
+        client=failing,  # type: ignore[arg-type]
+        force=True,
+    )
+    after = json.loads(
+        (archive / "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert result["status"] == "REFRESH_FAILED"
+    assert result["fabricated"] is False
+    assert failing.calls == 1
+    assert after["captured_at"] == before["captured_at"]
+    assert after["bars"] == before["bars"]
+
+
+def test_instrument_mismatch_fail_closed(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive, symbol=INSTRUMENT)
+    good = _FakeOkxClient(captured_at="2026-07-25T00:00:00Z")
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=good,  # type: ignore[arg-type]
+    )
+    # Corrupt selection identity relative to persisted OHLCV.
+    _write_universe(archive, symbol="ETH-USDT-SWAP")
+    with pytest.raises(Exception) as excinfo:
+        refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
+            archive_root=archive,
+            client=good,  # type: ignore[arg-type]
+            force=True,
+        )
+    assert "INSTRUMENT_MISMATCH" in str(excinfo.value)
+
+
+def test_poll_endpoint_readonly_and_advances_without_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive)
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    client_a = _FakeOkxClient(captured_at="2026-07-25T00:00:00Z")
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=client_a,  # type: ignore[arg-type]
+    )
+
+    app = create_app()
+    http = TestClient(app)
+    first = http.get("/api/market/landscape/ohlcv")
+    assert first.status_code == 200
+    body1 = first.json()
+    assert body1["schema_name"] == "market_landscape_ohlcv_poll_response.v1"
+    assert body1["write_methods"] == []
+    assert body1["orders"] is False
+    assert body1["runtime_activation"] is False
+    assert body1["direct_browser_okx"] is False
+    assert body1["selected_instrument_id"] == INSTRUMENT
+    assert body1["venue"] == "OKX"
+    assert body1["browser_payload"]["bar_count"] == 100
+    digest1 = body1["payload_digest"]
+    captured1 = body1["captured_at"]
+
+    client_b = _FakeOkxClient(captured_at="2026-07-25T00:10:00Z", close_px="0.000000009999")
+
+    # Inject fake client into poll builder path via monkeypatch of refresh helper.
+    def _refresh(**kwargs: Any) -> dict[str, Any]:
+        kwargs = dict(kwargs)
+        kwargs["client"] = client_b
+        kwargs["force"] = True
+        return refresh_selected_okx_ohlcv_readmodel_from_archive_v1(**kwargs)
+
+    monkeypatch.setattr(
+        "src.webui.market_dashboard_landscape_shell_router_v2.refresh_selected_okx_ohlcv_readmodel_from_archive_v1",
+        _refresh,
+        raising=False,
+    )
+    # Patch where the builder imports from.
+    import src.ops.okx_selected_instrument_ohlcv_readmodel_v1 as ohlcv_mod
+
+    monkeypatch.setattr(
+        ohlcv_mod,
+        "refresh_selected_okx_ohlcv_readmodel_from_archive_v1",
+        _refresh,
+    )
+
+    second = build_ohlcv_poll_response_v1(force_refresh=True, client=client_b)
+    assert second["captured_at"] == "2026-07-25T00:10:00Z"
+    assert second["captured_at"] != captured1
+    assert second["payload_digest"] != digest1
+    assert second["browser_payload"]["bars"][-1]["close"] == pytest.approx(9.999e-09)
+    assert http.get("/market").status_code == 200
+
+
+def test_market_page_exposes_poll_contract_and_no_order_controls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive)
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    client = _FakeOkxClient(captured_at="2026-07-25T00:00:00Z")
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=client,  # type: ignore[arg-type]
+    )
+    app = create_app()
+    http = TestClient(app)
+    resp = http.get("/market")
+    assert resp.status_code == 200
+    html = resp.text
+    assert 'data-mdl-ohlcv-poll-path="/api/market/landscape/ohlcv"' in html
+    assert (
+        f'data-mdl-ohlcv-poll-interval-seconds="{DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS}"'
+        in html
+    )
+    assert 'data-mdl-field="ohlcv_captured_at"' in html
+    assert 'data-mdl-field="ohlcv_latest_candle_at"' in html
+    assert 'data-mdl-field="ohlcv_freshness"' in html
+    assert "OKX" in html
+    assert INSTRUMENT in html
+    assert "www.okx.com" not in html
+    assert 'method="post"' not in html.lower()
+    assert "place order" not in html.lower()
+    assert "LIVE_AUTHORIZED" not in html or 'content="false"' in html
+    assert "kraken" not in html.lower() or "historical" in html.lower()
+
+
+def test_stale_and_missing_source_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = tmp_path / "archive"
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    app = create_app()
+    http = TestClient(app)
+    missing = http.get("/api/market/landscape/ohlcv")
+    assert missing.status_code == 200
+    body = missing.json()
+    assert body["status"] == "MISSING_SOURCE"
+    assert body["availability"] == "MISSING_SOURCE"
+    assert body["browser_payload"] is None
+
+    selection = _write_universe(archive)
+    old = _FakeOkxClient(captured_at="2026-07-20T00:00:00Z")
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=old,  # type: ignore[arg-type]
+    )
+    # Age the on-disk freshness classification by rewriting stale flags honestly.
+    path = archive / "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    doc["freshness_state"] = "stale"
+    doc["is_stale"] = True
+    doc["stale_reason"] = "ohlcv_latest_candle_exceeds_threshold"
+    path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+
+    def _skip_refresh(**kwargs: Any) -> dict[str, Any]:
+        retained = json.loads(path.read_text(encoding="utf-8"))
+        return {
+            "status": "SKIPPED_RECENT",
+            "refresh_attempted": False,
+            "selected_instrument": INSTRUMENT,
+            "selected_venue": "okx",
+            "captured_at": retained.get("captured_at"),
+            "last_timestamp": retained.get("last_timestamp"),
+            "ohlcv": retained,
+        }
+
+    import src.ops.okx_selected_instrument_ohlcv_readmodel_v1 as ohlcv_mod
+
+    monkeypatch.setattr(
+        ohlcv_mod,
+        "refresh_selected_okx_ohlcv_readmodel_from_archive_v1",
+        _skip_refresh,
+    )
+    poll = build_ohlcv_poll_response_v1(force_refresh=False)
+    assert poll["availability"] == "STALE"
+    assert poll["is_stale"] is True
+    assert poll["browser_payload"] is not None


### PR DESCRIPTION
## Summary
- Add rate-limited rematerialization of the canonical selected-instrument OKX OHLCV readmodel from the durable archive.
- Expose read-only `GET /api/market/landscape/ohlcv` for snapshot polling with fail-closed STALE / MISSING_SOURCE / INVALID behavior.
- Poll from Landscape V2 browser JS only against the local read-only endpoint (no direct OKX calls, no fabricated candles, no trading/runtime activation).

## Test plan
- [x] `tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py`
- [x] Existing OKX chart binding + shell route + OHLCV readmodel contracts
- [x] Selector `PR_BOUNDED_FULL` local PR-bounded targets (716 passed, ~36s)
- [ ] Required GitHub checks on exact PR head


Made with [Cursor](https://cursor.com)