### PR TITLE
feat(webui): true live OKX intrabar mark updates on /market

### DIFF
--- a/src/ops/okx_public_market_data_client_v1.py
+++ b/src/ops/okx_public_market_data_client_v1.py
@@ -29,6 +29,9 @@ ALLOWED_PATHS = frozenset(
         "/api/v5/market/tickers",
         "/api/v5/market/history-candles",
         "/api/v5/market/candles",
+        # Public recent trades (no auth). Used server-side only to revise the
+        # selected instrument's open PT1H candle from authentic prints.
+        "/api/v5/market/trades",
     }
 )
 USER_AGENT = "PeakTradeOkxPublicMarketData/1.0 (+read-only; no-credentials; no-orders)"

--- a/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
+++ b/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
@@ -28,9 +28,12 @@ UNIVERSE_SELECTION_RELATIVE_PATH = "readmodels/universe_selection_readmodel.v1.j
 REFRESH_LOCK_NAME = ".okx_selected_instrument_ohlcv_refresh.lock"
 DEFAULT_BAR = "1H"
 DEFAULT_LIMIT = 100
-# Bounded default for PT1H candles: continuous snapshot refresh without OKX hammering.
-# Derived from candle timeframe (1H); not faster than necessary for closed-bar cadence.
-DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS = 60
+# Recent candles endpoint includes the incomplete open candle (confirm=0).
+OKX_CANDLES_PATH = "/api/v5/market/candles"
+OKX_MARK_PRICE_PATH = "/api/v5/public/mark-price"
+LIVE_MARK_PROJECTION_V1 = "okx_ohlcv_live_mark_v1"
+# Bounded dashboard refresh: visible intrabar feedback ≤5s under normal availability.
+DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS = 3
 
 
 class OkxOhlcvReadmodelError(ValueError):
@@ -165,7 +168,7 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
 
     http = client or OkxPublicMarketDataClientV1()
     envelope = http.get_json(
-        "/api/v5/market/history-candles",
+        OKX_CANDLES_PATH,
         {
             "instId": selected_provider_instrument_id,
             "bar": okx_bar,
@@ -195,10 +198,52 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         if note.startswith("GAP_COUNT:"):
             gap_count = int(note.split(":", 1)[1])
 
+    live_mark_price: str | None = None
+    live_mark_provider_ts: str | None = None
+    live_mark_request_url: str | None = None
+    live_mark_raw_digest: str | None = None
+    mark_envelope = http.get_json(
+        OKX_MARK_PRICE_PATH,
+        {
+            "instType": "SWAP",
+            "instId": selected_provider_instrument_id,
+        },
+    )
+    mark_payload = json.loads(mark_envelope.raw_body_utf8)
+    mark_rows = mark_payload.get("data")
+    if not isinstance(mark_rows, list) or not mark_rows:
+        raise OkxOhlcvReadmodelError("MARK_PRICE_EMPTY")
+    mark_row = mark_rows[0]
+    if not isinstance(mark_row, Mapping):
+        raise OkxOhlcvReadmodelError("MARK_PRICE_ROW_INVALID")
+    mark_inst = str(mark_row.get("instId") or "").strip()
+    if mark_inst and mark_inst.upper() != selected_provider_instrument_id.upper():
+        raise OkxOhlcvReadmodelError("MARK_PRICE_INSTRUMENT_MISMATCH")
+    live_mark_price = format(_dec(mark_row.get("markPx"), field="markPx"), "f")
+    live_mark_provider_ts = provider_ms_to_utc_iso(mark_row.get("ts"))
+    live_mark_request_url = mark_envelope.request_url
+    live_mark_raw_digest = mark_envelope.raw_payload_digest
+
     raw_path = (
         archive_root / "raw" / "okx_ohlcv" / f"{selected_provider_instrument_id}_{okx_bar}.json"
     )
     _atomic_write_text(raw_path, envelope.raw_body_utf8)
+    mark_raw_path = (
+        archive_root / "raw" / "okx_mark_price" / f"{selected_provider_instrument_id}.json"
+    )
+    _atomic_write_text(mark_raw_path, mark_envelope.raw_body_utf8)
+
+    # Capture clocks: prefer the later of candles vs mark responses for honest freshness.
+    captured_at = envelope.captured_at
+    effective_at = envelope.effective_at or envelope.captured_at
+    try:
+        candle_cap = datetime.fromisoformat(str(envelope.captured_at).replace("Z", "+00:00"))
+        mark_cap = datetime.fromisoformat(str(mark_envelope.captured_at).replace("Z", "+00:00"))
+        if mark_cap > candle_cap:
+            captured_at = mark_envelope.captured_at
+            effective_at = mark_envelope.effective_at or mark_envelope.captured_at
+    except ValueError:
+        pass
 
     doc = {
         "schema_name": OHLCV_SCHEMA,
@@ -209,12 +254,13 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         "market_type": "perpetual",
         "interval": "PT1H",
         "provider_bar": okx_bar,
+        "candle_endpoint": OKX_CANDLES_PATH,
         "instrument_id": selected_instrument,
         "provider_instrument_id": selected_provider_instrument_id,
         "selection_bundle_id": selection_bundle_id,
         "selection_path": str(selection_path.resolve()),
-        "captured_at": envelope.captured_at,
-        "effective_at": envelope.effective_at or envelope.captured_at,
+        "captured_at": captured_at,
+        "effective_at": effective_at,
         "freshness_state": freshness_state,
         "is_stale": is_stale,
         "stale_reason": stale_reason,
@@ -230,6 +276,16 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         "volume_unit": "contracts",
         "bars": [b.to_json_dict() for b in bars],
         "notes": notes,
+        # Additive live-mark projection (v1): authentic OKX public mark only.
+        # Does not rewrite closed candle OHLC; browser may use mark for open-bar tip.
+        "live_mark_projection": LIVE_MARK_PROJECTION_V1,
+        "live_mark_price": live_mark_price,
+        "live_mark_provider_ts": live_mark_provider_ts,
+        "live_mark_captured_at": mark_envelope.captured_at,
+        "live_mark_request_url": live_mark_request_url,
+        "live_mark_raw_digest": live_mark_raw_digest,
+        "live_mark_raw_path": str(mark_raw_path.resolve()),
+        "live_price_kind": "mark",
     }
     out_path = archive_root / OHLCV_RELATIVE_PATH
     _atomic_write_text(out_path, json.dumps(doc, indent=2) + "\n")

--- a/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
+++ b/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
@@ -1,4 +1,4 @@
-"""Selected-instrument OKX OHLCV readmodel materializer (public candles only)."""
+"""Selected-instrument OKX OHLCV readmodel materializer (public candles + trades)."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import json
 import os
 import tempfile
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -28,10 +28,17 @@ UNIVERSE_SELECTION_RELATIVE_PATH = "readmodels/universe_selection_readmodel.v1.j
 REFRESH_LOCK_NAME = ".okx_selected_instrument_ohlcv_refresh.lock"
 DEFAULT_BAR = "1H"
 DEFAULT_LIMIT = 100
+DEFAULT_TRADES_LIMIT = 100
+MAX_APPLIED_TRADE_IDS = 500
 # Recent candles endpoint includes the incomplete open candle (confirm=0).
 OKX_CANDLES_PATH = "/api/v5/market/candles"
+# Public recent trades — server-side only; revises the active open PT1H candle.
+OKX_TRADES_PATH = "/api/v5/market/trades"
 OKX_MARK_PRICE_PATH = "/api/v5/public/mark-price"
 LIVE_MARK_PROJECTION_V1 = "okx_ohlcv_live_mark_v1"
+OPEN_CANDLE_LIVE_SOURCE_V1 = "okx_public_trades_into_pt1h_v1"
+# OKX SWAP trade `sz` is contract count (not quote/base currency).
+TRADE_VOLUME_UNIT = "contracts"
 # Bounded dashboard refresh: visible intrabar feedback ≤5s under normal availability.
 DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS = 3
 
@@ -50,6 +57,21 @@ class OhlcvBarV1:
     volume: str
     volume_ccy: str | None
     confirm: bool
+    provider_ts_ms: str
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class OkxPublicTradeV1:
+    """One authentic OKX public trade print (`/api/v5/market/trades`)."""
+
+    trade_id: str
+    price: str
+    size: str
+    side: str
+    ts: str
     provider_ts_ms: str
 
     def to_json_dict(self) -> dict[str, Any]:
@@ -223,6 +245,183 @@ def reduce_okx_ohlcv_bars_v1(
     return nxt, "AUTHENTIC_FULL_REPLACE"
 
 
+def parse_okx_public_trades_v1(rows: Sequence[Any]) -> list[OkxPublicTradeV1]:
+    """Parse OKX public trades rows (newest-first dicts with tradeId/px/sz/side/ts)."""
+    out: list[OkxPublicTradeV1] = []
+    seen: set[str] = set()
+    for raw in rows:
+        if not isinstance(raw, Mapping):
+            continue
+        trade_id = str(raw.get("tradeId") or "").strip()
+        if not trade_id or trade_id in seen:
+            continue
+        ts_iso = provider_ms_to_utc_iso(raw.get("ts"))
+        if ts_iso is None:
+            continue
+        px = format(_dec(raw.get("px"), field="trade_px"), "f")
+        sz = format(_dec(raw.get("sz"), field="trade_sz"), "f")
+        if _dec(sz, field="trade_sz") < 0:
+            raise OkxOhlcvReadmodelError(f"NEGATIVE_TRADE_SIZE:{trade_id}")
+        seen.add(trade_id)
+        out.append(
+            OkxPublicTradeV1(
+                trade_id=trade_id,
+                price=px,
+                size=sz,
+                side=str(raw.get("side") or "").strip().lower(),
+                ts=ts_iso,
+                provider_ts_ms=str(raw.get("ts") or ""),
+            )
+        )
+    out.sort(key=lambda t: (int(t.provider_ts_ms or "0"), t.trade_id))
+    return out
+
+
+def _bucket_start_utc(ts_iso: str, *, interval_seconds: int) -> datetime:
+    dt = datetime.fromisoformat(ts_iso.replace("Z", "+00:00")).astimezone(timezone.utc)
+    if interval_seconds != 3600:
+        raise OkxOhlcvReadmodelError("UNSUPPORTED_TRADE_BUCKET_INTERVAL")
+    return dt.replace(minute=0, second=0, microsecond=0)
+
+
+def apply_okx_public_trades_to_open_candle_v1(
+    bars: Sequence[Mapping[str, Any] | OhlcvBarV1],
+    trades: Sequence[OkxPublicTradeV1],
+    *,
+    previously_applied_trade_ids: Sequence[str] | None = None,
+    interval_seconds: int = 3600,
+) -> tuple[list[OhlcvBarV1], str, list[str], dict[str, Any]]:
+    """Revise the active PT1H candle from authentic OKX public trades.
+
+    Bootstrap rule: when no trade IDs were applied yet, seed IDs already present in
+    the current bucket without mutating geometry (candle bootstrap already priced
+    them). Subsequent new trade IDs revise the open tip:
+
+    - open preserved from candle bootstrap (or first trade when appending a bucket)
+    - high = max(previous high, trade price)
+    - low = min(previous low, trade price)
+    - close = newest applied trade price
+    - volume += trade size (OKX SWAP ``sz`` = contracts)
+    - closed historical candles are never rewritten
+    """
+    if not bars:
+        raise OkxOhlcvReadmodelError("TRADE_REDUCE_EMPTY_BARS")
+    working = [_as_ohlcv_bar(b) for b in bars]
+    working.sort(key=lambda b: b.ts)
+    applied = {str(x) for x in (previously_applied_trade_ids or []) if str(x)}
+    meta: dict[str, Any] = {
+        "old_trade_count": 0,
+        "duplicate_trade_count": 0,
+        "new_trade_count": 0,
+        "seeded": False,
+        "trade_volume_unit": TRADE_VOLUME_UNIT,
+    }
+    if not trades:
+        return working, "NO_OP", sorted(applied)[-MAX_APPLIED_TRADE_IDS:], meta
+
+    tip = working[-1]
+    tip_start = datetime.fromisoformat(tip.ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+    tip_end = tip_start + timedelta(seconds=interval_seconds)
+
+    # First observation after candle bootstrap / new bucket: seed current-bucket
+    # IDs only so candle-included prints are not double-counted into volume.
+    if previously_applied_trade_ids is None:
+        seeded = [
+            t.trade_id
+            for t in trades
+            if tip_start
+            <= datetime.fromisoformat(t.ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+            < tip_end
+        ]
+        meta["seeded"] = True
+        meta["new_trade_count"] = 0
+        return working, "NO_OP", seeded[-MAX_APPLIED_TRADE_IDS:], meta
+
+    revision_kind = "NO_OP"
+    for trade in trades:
+        trade_dt = datetime.fromisoformat(trade.ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+        tip = working[-1]
+        tip_start = datetime.fromisoformat(tip.ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+        tip_end = tip_start + timedelta(seconds=interval_seconds)
+        px = _dec(trade.price, field="trade_px")
+        sz = _dec(trade.size, field="trade_sz")
+
+        if trade_dt < tip_start:
+            meta["old_trade_count"] += 1
+            continue
+
+        if trade.trade_id in applied:
+            meta["duplicate_trade_count"] += 1
+            continue
+
+        if trade_dt >= tip_end:
+            # Next PT1H bucket from an authentic trade print.
+            bucket_ts = _bucket_start_utc(trade.ts, interval_seconds=interval_seconds)
+            # Only append when the trade lands in the immediate next bucket (or later
+            # empty buckets advanced one-at-a-time from the tip).
+            expected_next = tip_end
+            if bucket_ts != expected_next:
+                # Non-adjacent: ignore until candle history realigns (fail-soft).
+                meta["old_trade_count"] += 1
+                continue
+            sealed = tip
+            if not sealed.confirm:
+                sealed = OhlcvBarV1(
+                    ts=sealed.ts,
+                    open=sealed.open,
+                    high=sealed.high,
+                    low=sealed.low,
+                    close=sealed.close,
+                    volume=sealed.volume,
+                    volume_ccy=sealed.volume_ccy,
+                    confirm=True,
+                    provider_ts_ms=sealed.provider_ts_ms,
+                )
+            new_tip = OhlcvBarV1(
+                ts=bucket_ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                open=format(px, "f"),
+                high=format(px, "f"),
+                low=format(px, "f"),
+                close=format(px, "f"),
+                volume=format(sz, "f"),
+                volume_ccy=None,
+                confirm=False,
+                provider_ts_ms=trade.provider_ts_ms,
+            )
+            working = list(working[:-1]) + [sealed, new_tip]
+            applied.add(trade.trade_id)
+            meta["new_trade_count"] += 1
+            revision_kind = "NEW_INTERVAL_APPEND"
+            continue
+
+        # Same open-candle bucket revision.
+        if tip.confirm:
+            # Sealed tip must not be rewritten by late prints.
+            meta["old_trade_count"] += 1
+            continue
+        new_high = max(_dec(tip.high, field="high"), px)
+        new_low = min(_dec(tip.low, field="low"), px)
+        new_vol = _dec(tip.volume, field="volume") + sz
+        new_tip = OhlcvBarV1(
+            ts=tip.ts,
+            open=tip.open,
+            high=format(new_high, "f"),
+            low=format(new_low, "f"),
+            close=format(px, "f"),
+            volume=format(new_vol, "f"),
+            volume_ccy=tip.volume_ccy,
+            confirm=False,
+            provider_ts_ms=trade.provider_ts_ms or tip.provider_ts_ms,
+        )
+        working = list(working[:-1]) + [new_tip]
+        applied.add(trade.trade_id)
+        meta["new_trade_count"] += 1
+        if revision_kind != "NEW_INTERVAL_APPEND":
+            revision_kind = "SAME_TIMESTAMP_REVISION"
+
+    return working, revision_kind, sorted(applied)[-MAX_APPLIED_TRADE_IDS:], meta
+
+
 def parse_okx_history_candles(
     rows: Sequence[Sequence[Any]],
 ) -> tuple[list[OhlcvBarV1], list[str]]:
@@ -334,15 +533,54 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         and isinstance(existing_doc.get("bars"), list)
     ):
         previous_bars = list(existing_doc["bars"])
-    bars, revision_kind = reduce_okx_ohlcv_bars_v1(previous_bars, incoming_bars)
+    bars, candle_revision_kind = reduce_okx_ohlcv_bars_v1(previous_bars, incoming_bars)
+
+    # Public trades revise the open candle when the candles endpoint is static.
+    trades_envelope = http.get_json(
+        OKX_TRADES_PATH,
+        {
+            "instId": selected_provider_instrument_id,
+            "limit": str(DEFAULT_TRADES_LIMIT),
+        },
+    )
+    trades_payload = json.loads(trades_envelope.raw_body_utf8)
+    trades_data = trades_payload.get("data")
+    if not isinstance(trades_data, list):
+        raise OkxOhlcvReadmodelError("TRADES_PAYLOAD_INVALID")
+    trades = parse_okx_public_trades_v1(trades_data)
+    prev_applied: list[str] | None = None
+    if (
+        isinstance(existing_doc, Mapping)
+        and previous_bars
+        and bars
+        and _as_ohlcv_bar(previous_bars[-1]).ts == bars[-1].ts
+        and "applied_trade_ids" in existing_doc
+    ):
+        raw_ids = existing_doc.get("applied_trade_ids")
+        if isinstance(raw_ids, list):
+            prev_applied = [str(x) for x in raw_ids]
+        else:
+            prev_applied = []
+    bars, trade_revision_kind, applied_trade_ids, trade_meta = (
+        apply_okx_public_trades_to_open_candle_v1(
+            bars,
+            trades,
+            previously_applied_trade_ids=prev_applied,
+        )
+    )
+    if trade_revision_kind in {"SAME_TIMESTAMP_REVISION", "NEW_INTERVAL_APPEND"}:
+        revision_kind = trade_revision_kind
+    else:
+        revision_kind = candle_revision_kind
 
     closed = [b for b in bars if b.confirm]
     last_closed = closed[-1] if closed else None
     as_of = utc_now_iso()
     policy = load_freshness_policy_v1()
-    # OHLCV feed freshness keys off the candle capture clock — never mark-only ticks.
-    candle_captured_at = envelope.captured_at
-    candle_effective_at = envelope.effective_at or envelope.captured_at
+    # Live open-candle freshness keys off the public trades capture clock (the
+    # authentic revision source). Mark-only ticks never drive OHLCV freshness.
+    candle_captured_at = trades_envelope.captured_at
+    candle_effective_at = trades_envelope.effective_at or trades_envelope.captured_at
     freshness_state, is_stale, stale_reason = classify_freshness_v1(
         reference_at=candle_captured_at,
         as_of=as_of,
@@ -384,12 +622,16 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         archive_root / "raw" / "okx_ohlcv" / f"{selected_provider_instrument_id}_{okx_bar}.json"
     )
     _atomic_write_text(raw_path, envelope.raw_body_utf8)
+    trades_raw_path = (
+        archive_root / "raw" / "okx_trades" / f"{selected_provider_instrument_id}.json"
+    )
+    _atomic_write_text(trades_raw_path, trades_envelope.raw_body_utf8)
     mark_raw_path = (
         archive_root / "raw" / "okx_mark_price" / f"{selected_provider_instrument_id}.json"
     )
     _atomic_write_text(mark_raw_path, mark_envelope.raw_body_utf8)
 
-    # Primary OHLCV clocks stay on the candles endpoint. Mark has its own capture fields.
+    # Primary live OHLCV clocks follow the public trades capture (open-candle source).
     captured_at = candle_captured_at
     effective_at = candle_effective_at
 
@@ -403,6 +645,9 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         "interval": "PT1H",
         "provider_bar": okx_bar,
         "candle_endpoint": OKX_CANDLES_PATH,
+        "trades_endpoint": OKX_TRADES_PATH,
+        "open_candle_live_source": OPEN_CANDLE_LIVE_SOURCE_V1,
+        "open_candle_bootstrap_source": OKX_CANDLES_PATH,
         "instrument_id": selected_instrument,
         "provider_instrument_id": selected_provider_instrument_id,
         "selection_bundle_id": selection_bundle_id,
@@ -411,7 +656,11 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         "effective_at": effective_at,
         "candle_captured_at": candle_captured_at,
         "candle_effective_at": candle_effective_at,
+        "candles_captured_at": envelope.captured_at,
+        "trades_captured_at": trades_envelope.captured_at,
         "ohlcv_revision_kind": revision_kind,
+        "candle_revision_kind": candle_revision_kind,
+        "trade_revision_kind": trade_revision_kind,
         "freshness_state": freshness_state,
         "is_stale": is_stale,
         "stale_reason": stale_reason,
@@ -424,9 +673,21 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         "raw_capture_digest": envelope.raw_payload_digest,
         "raw_capture_path": str(raw_path.resolve()),
         "request_url": envelope.request_url,
-        "volume_unit": "contracts",
+        "trades_raw_capture_digest": trades_envelope.raw_payload_digest,
+        "trades_raw_capture_path": str(trades_raw_path.resolve()),
+        "trades_request_url": trades_envelope.request_url,
+        "applied_trade_ids": applied_trade_ids,
+        "trade_reduce_meta": trade_meta,
+        "volume_unit": TRADE_VOLUME_UNIT,
+        "trade_volume_unit": TRADE_VOLUME_UNIT,
         "bars": [b.to_json_dict() for b in bars],
-        "notes": [*notes, f"REVISION_KIND:{revision_kind}"],
+        "notes": [
+            *notes,
+            f"REVISION_KIND:{revision_kind}",
+            f"CANDLE_REVISION_KIND:{candle_revision_kind}",
+            f"TRADE_REVISION_KIND:{trade_revision_kind}",
+            f"OPEN_CANDLE_LIVE_SOURCE:{OPEN_CANDLE_LIVE_SOURCE_V1}",
+        ],
         # Additive live-mark projection (v1): authentic OKX public mark only.
         # Distinct fact from candle close — never rewrites OHLCV geometry.
         "live_mark_projection": LIVE_MARK_PROJECTION_V1,

--- a/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
+++ b/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
@@ -81,6 +81,148 @@ def _dec(value: Any, *, field: str) -> Decimal:
     return parsed
 
 
+def _bar_ohlcv_tuple(bar: OhlcvBarV1) -> tuple[str, str, str, str, str]:
+    return (bar.open, bar.high, bar.low, bar.close, bar.volume)
+
+
+def _as_ohlcv_bar(raw: Mapping[str, Any] | OhlcvBarV1) -> OhlcvBarV1:
+    if isinstance(raw, OhlcvBarV1):
+        return raw
+    confirm_raw = raw.get("confirm")
+    if confirm_raw is None:
+        confirm = True
+    elif isinstance(confirm_raw, bool):
+        confirm = confirm_raw
+    else:
+        confirm = str(confirm_raw) in {"1", "true", "True"}
+    return OhlcvBarV1(
+        ts=str(raw["ts"]),
+        open=format(_dec(raw.get("open"), field="open"), "f"),
+        high=format(_dec(raw.get("high"), field="high"), "f"),
+        low=format(_dec(raw.get("low"), field="low"), "f"),
+        close=format(_dec(raw.get("close"), field="close"), "f"),
+        volume=format(_dec(raw.get("volume"), field="volume"), "f"),
+        volume_ccy=(
+            None
+            if raw.get("volume_ccy") in (None, "")
+            else format(_dec(raw.get("volume_ccy"), field="volume_ccy"), "f")
+        ),
+        confirm=confirm,
+        provider_ts_ms=str(raw.get("provider_ts_ms") or ""),
+    )
+
+
+def reduce_okx_ohlcv_bars_v1(
+    previous: Sequence[Mapping[str, Any] | OhlcvBarV1] | None,
+    incoming: Sequence[Mapping[str, Any] | OhlcvBarV1],
+    *,
+    interval_seconds: int = 3600,
+) -> tuple[list[OhlcvBarV1], str]:
+    """Reduce authentic OKX candle series revisions for one selected instrument.
+
+    Revision kinds:
+    - BOOTSTRAP: no previous series
+    - NO_OP: same final timestamp and identical O/H/L/C/V
+    - SAME_TIMESTAMP_REVISION: final timestamp equal, OHLCV changed → replace tip only
+    - NEW_INTERVAL_APPEND: final timestamp advanced by exactly one interval → append once
+    - AUTHENTIC_FULL_REPLACE: longer authentic window / bootstrap alignment from OKX
+
+    Open-candle invariants for SAME_TIMESTAMP_REVISION:
+    open fixed; high may only increase; low may only decrease; close/volume follow source.
+    """
+    if not incoming:
+        raise OkxOhlcvReadmodelError("OHLCV_REDUCE_EMPTY_INCOMING")
+    nxt = [_as_ohlcv_bar(b) for b in incoming]
+    nxt.sort(key=lambda b: b.ts)
+    seen: set[str] = set()
+    for bar in nxt:
+        if bar.ts in seen:
+            raise OkxOhlcvReadmodelError(f"DUPLICATE_CANDLE_TIMESTAMP:{bar.ts}")
+        seen.add(bar.ts)
+
+    if not previous:
+        return nxt, "BOOTSTRAP"
+
+    prev = [_as_ohlcv_bar(b) for b in previous]
+    prev.sort(key=lambda b: b.ts)
+    if not prev:
+        return nxt, "BOOTSTRAP"
+
+    prev_last = prev[-1]
+    next_last = nxt[-1]
+    if prev_last.ts == next_last.ts:
+        if len(prev) != len(nxt):
+            # Same tip timestamp but different window length — accept authentic OKX window
+            # only when historical prefixes for the overlapping closed range are unchanged.
+            return nxt, "AUTHENTIC_FULL_REPLACE"
+        for older_p, older_n in zip(prev[:-1], nxt[:-1]):
+            if older_p.ts != older_n.ts or _bar_ohlcv_tuple(older_p) != _bar_ohlcv_tuple(older_n):
+                # Authentic upstream correction of sealed history → accept OKX window.
+                return nxt, "AUTHENTIC_FULL_REPLACE"
+        if _bar_ohlcv_tuple(prev_last) == _bar_ohlcv_tuple(next_last):
+            # Identical OHLCV at same timestamp is a no-op (preserve prior confirm/metadata).
+            return prev, "NO_OP"
+        # Open-candle revision rules.
+        if _dec(next_last.open, field="open") != _dec(prev_last.open, field="open"):
+            raise OkxOhlcvReadmodelError(f"OPEN_REGRESSION:{prev_last.ts}")
+        if _dec(next_last.high, field="high") < _dec(prev_last.high, field="high"):
+            raise OkxOhlcvReadmodelError(f"HIGH_REGRESSION:{prev_last.ts}")
+        if _dec(next_last.low, field="low") > _dec(prev_last.low, field="low"):
+            raise OkxOhlcvReadmodelError(f"LOW_REGRESSION:{prev_last.ts}")
+        if _dec(next_last.volume, field="volume") < 0:
+            raise OkxOhlcvReadmodelError(f"NEGATIVE_VOLUME:{prev_last.ts}")
+        reduced = list(prev[:-1]) + [next_last]
+        return reduced, "SAME_TIMESTAMP_REVISION"
+
+    prev_dt = datetime.fromisoformat(prev_last.ts.replace("Z", "+00:00"))
+    next_dt = datetime.fromisoformat(next_last.ts.replace("Z", "+00:00"))
+    delta = (next_dt - prev_dt).total_seconds()
+    if abs(delta - float(interval_seconds)) <= 1e-9:
+        # Seal prior tip from incoming prefix when present; else mark previous tip closed.
+        sealed = prev_last
+        if len(nxt) >= 2 and nxt[-2].ts == prev_last.ts:
+            sealed = nxt[-2]
+            if not sealed.confirm:
+                sealed = OhlcvBarV1(
+                    ts=sealed.ts,
+                    open=sealed.open,
+                    high=sealed.high,
+                    low=sealed.low,
+                    close=sealed.close,
+                    volume=sealed.volume,
+                    volume_ccy=sealed.volume_ccy,
+                    confirm=True,
+                    provider_ts_ms=sealed.provider_ts_ms,
+                )
+        elif not sealed.confirm:
+            sealed = OhlcvBarV1(
+                ts=sealed.ts,
+                open=sealed.open,
+                high=sealed.high,
+                low=sealed.low,
+                close=sealed.close,
+                volume=sealed.volume,
+                volume_ccy=sealed.volume_ccy,
+                confirm=True,
+                provider_ts_ms=sealed.provider_ts_ms,
+            )
+        # Historical prefix before sealed tip must remain unchanged when lengths align.
+        if len(prev) >= 2 and len(nxt) >= 2 and nxt[-2].ts == sealed.ts:
+            overlap_prev = prev[:-1]
+            overlap_in = nxt[:-2]
+            if len(overlap_in) == len(overlap_prev):
+                for older_p, older_n in zip(overlap_prev, overlap_in):
+                    if older_p.ts != older_n.ts or _bar_ohlcv_tuple(older_p) != _bar_ohlcv_tuple(
+                        older_n
+                    ):
+                        return nxt, "AUTHENTIC_FULL_REPLACE"
+        reduced = list(prev[:-1]) + [sealed, next_last]
+        return reduced, "NEW_INTERVAL_APPEND"
+
+    # Non-adjacent advance or rewind: accept only full authentic replacement window.
+    return nxt, "AUTHENTIC_FULL_REPLACE"
+
+
 def parse_okx_history_candles(
     rows: Sequence[Sequence[Any]],
 ) -> tuple[list[OhlcvBarV1], list[str]]:
@@ -179,16 +321,30 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
     data = payload.get("data")
     if not isinstance(data, list) or not data:
         raise OkxOhlcvReadmodelError("OHLCV_EMPTY")
-    bars, notes = parse_okx_history_candles(data)
-    if not bars:
+    incoming_bars, notes = parse_okx_history_candles(data)
+    if not incoming_bars:
         raise OkxOhlcvReadmodelError("OHLCV_PARSE_EMPTY")
+
+    existing_doc = load_ohlcv_readmodel_v1(archive_root)
+    previous_bars: list[Any] | None = None
+    if (
+        isinstance(existing_doc, Mapping)
+        and str(existing_doc.get("instrument_id") or "") == selected_instrument
+        and str(existing_doc.get("venue") or "").lower() in {"okx", "okx_europe_eea"}
+        and isinstance(existing_doc.get("bars"), list)
+    ):
+        previous_bars = list(existing_doc["bars"])
+    bars, revision_kind = reduce_okx_ohlcv_bars_v1(previous_bars, incoming_bars)
 
     closed = [b for b in bars if b.confirm]
     last_closed = closed[-1] if closed else None
     as_of = utc_now_iso()
     policy = load_freshness_policy_v1()
+    # OHLCV feed freshness keys off the candle capture clock — never mark-only ticks.
+    candle_captured_at = envelope.captured_at
+    candle_effective_at = envelope.effective_at or envelope.captured_at
     freshness_state, is_stale, stale_reason = classify_freshness_v1(
-        reference_at=(last_closed.ts if last_closed else envelope.captured_at),
+        reference_at=candle_captured_at,
         as_of=as_of,
         source_type="ohlcv_latest_candle",
         policy=policy,
@@ -233,17 +389,9 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
     )
     _atomic_write_text(mark_raw_path, mark_envelope.raw_body_utf8)
 
-    # Capture clocks: prefer the later of candles vs mark responses for honest freshness.
-    captured_at = envelope.captured_at
-    effective_at = envelope.effective_at or envelope.captured_at
-    try:
-        candle_cap = datetime.fromisoformat(str(envelope.captured_at).replace("Z", "+00:00"))
-        mark_cap = datetime.fromisoformat(str(mark_envelope.captured_at).replace("Z", "+00:00"))
-        if mark_cap > candle_cap:
-            captured_at = mark_envelope.captured_at
-            effective_at = mark_envelope.effective_at or mark_envelope.captured_at
-    except ValueError:
-        pass
+    # Primary OHLCV clocks stay on the candles endpoint. Mark has its own capture fields.
+    captured_at = candle_captured_at
+    effective_at = candle_effective_at
 
     doc = {
         "schema_name": OHLCV_SCHEMA,
@@ -261,6 +409,9 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         "selection_path": str(selection_path.resolve()),
         "captured_at": captured_at,
         "effective_at": effective_at,
+        "candle_captured_at": candle_captured_at,
+        "candle_effective_at": candle_effective_at,
+        "ohlcv_revision_kind": revision_kind,
         "freshness_state": freshness_state,
         "is_stale": is_stale,
         "stale_reason": stale_reason,
@@ -275,9 +426,9 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         "request_url": envelope.request_url,
         "volume_unit": "contracts",
         "bars": [b.to_json_dict() for b in bars],
-        "notes": notes,
+        "notes": [*notes, f"REVISION_KIND:{revision_kind}"],
         # Additive live-mark projection (v1): authentic OKX public mark only.
-        # Does not rewrite closed candle OHLC; browser may use mark for open-bar tip.
+        # Distinct fact from candle close — never rewrites OHLCV geometry.
         "live_mark_projection": LIVE_MARK_PROJECTION_V1,
         "live_mark_price": live_mark_price,
         "live_mark_provider_ts": live_mark_provider_ts,
@@ -297,6 +448,7 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         "freshness_state": freshness_state,
         "last_closed_timestamp": last_closed.ts if last_closed else None,
         "first_timestamp": bars[0].ts,
+        "ohlcv_revision_kind": revision_kind,
         "digest": hashlib.sha256(json.dumps(doc, sort_keys=True).encode()).hexdigest(),
     }
 

--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -177,6 +177,10 @@ def build_ohlcv_poll_response_v1(
         "payload_digest": None
         if browser_payload is None
         else browser_payload.get("payload_digest"),
+        "chart_digest": None if browser_payload is None else browser_payload.get("chart_digest"),
+        "live_mark_price": None
+        if browser_payload is None
+        else browser_payload.get("live_mark_price"),
         "refresh": {
             "status": refresh_meta.get("status"),
             "refresh_attempted": bool(refresh_meta.get("refresh_attempted")),
@@ -188,6 +192,15 @@ def build_ohlcv_poll_response_v1(
         "orders": False,
         "runtime_activation": False,
         "direct_browser_okx": False,
+        "data_connection_state": (
+            "MISSING_SOURCE"
+            if availability is Availability.MISSING_SOURCE
+            else "STALE"
+            if availability is Availability.STALE or status in {"REFRESH_FAILED", "INVALID"}
+            else "LIVE_DATA"
+            if ohlcv is not None and availability is Availability.AVAILABLE
+            else "MISSING_SOURCE"
+        ),
     }
 
 

--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -204,7 +204,15 @@ def build_ohlcv_poll_response_v1(
             else "STALE"
             if availability is Availability.STALE or status in {"REFRESH_FAILED", "INVALID"}
             else "LIVE_DATA"
-            if ohlcv is not None and availability is Availability.AVAILABLE
+            if (
+                ohlcv is not None
+                and availability is Availability.AVAILABLE
+                and browser_payload is not None
+                and bool(ohlcv.get("candle_captured_at") or ohlcv.get("captured_at"))
+                and not bool(ohlcv.get("is_stale"))
+                and str(ohlcv.get("freshness_state") or "").lower() != "stale"
+                and bool(ohlcv.get("bars"))
+            )
             else "MISSING_SOURCE"
         ),
     }

--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -178,6 +178,12 @@ def build_ohlcv_poll_response_v1(
         if browser_payload is None
         else browser_payload.get("payload_digest"),
         "chart_digest": None if browser_payload is None else browser_payload.get("chart_digest"),
+        "candle_series_digest": None
+        if browser_payload is None
+        else browser_payload.get("candle_series_digest"),
+        "metadata_digest": None
+        if browser_payload is None
+        else browser_payload.get("metadata_digest"),
         "live_mark_price": None
         if browser_payload is None
         else browser_payload.get("live_mark_price"),

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -115,9 +115,9 @@ def serialize_ohlcv_browser_payload_v1(
     projection never fabricates candles; missing/non-finite values fail closed.
 
     Identity domains (local browser payload only):
-    - candle_series_digest: authentic timestamp + O/H/L/C (+ confirm) only
-    - metadata_digest: captured_at / freshness / provenance clocks
-    - live_mark_price: distinct annotation — never mutates candle close/geometry
+    - candle_series_digest: authentic timestamp + O/H/L/C/V (+ confirm)
+    - metadata_digest: captured_at / freshness / mark provenance clocks
+    - live_mark_price: distinct OKX mark fact — never mutates candle close/geometry
     """
     if not isinstance(ohlcv_readmodel, Mapping):
         return None
@@ -136,10 +136,11 @@ def serialize_ohlcv_browser_payload_v1(
         high_v = _finite_ohlc_float(row.get("high"))
         low_v = _finite_ohlc_float(row.get("low"))
         close_v = _finite_ohlc_float(row.get("close"))
-        if None in (open_v, high_v, low_v, close_v):
+        volume_v = _finite_ohlc_float(row.get("volume"))
+        if None in (open_v, high_v, low_v, close_v, volume_v):
             return None
         assert open_v is not None and high_v is not None
-        assert low_v is not None and close_v is not None
+        assert low_v is not None and close_v is not None and volume_v is not None
         confirm_raw = row.get("confirm")
         if confirm_raw is None:
             confirm = True
@@ -147,7 +148,7 @@ def serialize_ohlcv_browser_payload_v1(
             confirm = confirm_raw
         else:
             confirm = str(confirm_raw) in {"1", "true", "True"}
-        # Geometry uses authentic OHLC only — mark never overwrites close/high/low.
+        # Geometry uses authentic OHLCV only — mark never overwrites close/high/low.
         bars.append(
             {
                 "ts": ts.strip(),
@@ -155,6 +156,7 @@ def serialize_ohlcv_browser_payload_v1(
                 "high": high_v,
                 "low": low_v,
                 "close": close_v,
+                "volume": volume_v,
                 "display_close": close_v,
                 "display_high": high_v,
                 "display_low": low_v,
@@ -177,6 +179,7 @@ def serialize_ohlcv_browser_payload_v1(
                 "high": b["high"],
                 "low": b["low"],
                 "close": b["close"],
+                "volume": b["volume"],
                 "confirm": b["confirm"],
             }
             for b in bars
@@ -188,12 +191,16 @@ def serialize_ohlcv_browser_payload_v1(
     metadata_source = {
         "captured_at": ohlcv_readmodel.get("captured_at"),
         "effective_at": ohlcv_readmodel.get("effective_at"),
+        "candle_captured_at": ohlcv_readmodel.get("candle_captured_at")
+        or ohlcv_readmodel.get("captured_at"),
         "freshness_state": ohlcv_readmodel.get("freshness_state"),
         "is_stale": bool(ohlcv_readmodel.get("is_stale")),
         "live_mark_price": live_mark,
         "live_mark_provider_ts": ohlcv_readmodel.get("live_mark_provider_ts"),
+        "live_mark_captured_at": ohlcv_readmodel.get("live_mark_captured_at"),
         "gap_count": ohlcv_readmodel.get("gap_count"),
         "last_closed_timestamp": ohlcv_readmodel.get("last_closed_timestamp"),
+        "ohlcv_revision_kind": ohlcv_readmodel.get("ohlcv_revision_kind"),
     }
     metadata_digest = hashlib.sha256(
         json.dumps(metadata_source, sort_keys=True, separators=(",", ":")).encode("utf-8")
@@ -224,12 +231,20 @@ def serialize_ohlcv_browser_payload_v1(
         "gap_count": ohlcv_readmodel.get("gap_count"),
         "live_mark_price": live_mark,
         "live_mark_provider_ts": ohlcv_readmodel.get("live_mark_provider_ts"),
+        "live_mark_captured_at": ohlcv_readmodel.get("live_mark_captured_at"),
         "live_price_kind": ohlcv_readmodel.get("live_price_kind") or "mark",
         "live_mark_projection": ohlcv_readmodel.get("live_mark_projection"),
+        "candle_endpoint": ohlcv_readmodel.get("candle_endpoint"),
+        "candle_captured_at": ohlcv_readmodel.get("candle_captured_at")
+        or ohlcv_readmodel.get("captured_at"),
+        "ohlcv_revision_kind": ohlcv_readmodel.get("ohlcv_revision_kind"),
         "candle_series_digest": candle_series_digest,
         "metadata_digest": metadata_digest,
         "chart_digest": chart_digest,
         "payload_digest": payload_digest,
+        "close_source_semantics": "okx_market_candles_close",
+        "volume_source_semantics": "okx_market_candles_vol_contracts",
+        "mark_source_semantics": "okx_public_mark_price_markPx",
         "bars": bars,
     }
 

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -374,6 +374,48 @@ def _present_source_health_compact(
     }
 
 
+def _ohlcv_source_feed_is_live(
+    *,
+    browser_payload: Mapping[str, Any] | None,
+    ohlcv_payload: Mapping[str, Any] | None,
+    chart_availability: Availability,
+) -> bool:
+    """LIVE_DATA requires a fresh OHLCV candle feed — not mark/captured_at cosmetics."""
+    if browser_payload is None or chart_availability is not Availability.AVAILABLE:
+        return False
+    source = ohlcv_payload or {}
+    if bool(source.get("is_stale")) or str(source.get("freshness_state") or "").lower() == "stale":
+        return False
+    candle_cap = source.get("candle_captured_at") or source.get("captured_at")
+    if not isinstance(candle_cap, str) or not candle_cap.strip():
+        return False
+    # Reject mark-only documents that never recorded a candle capture clock.
+    if source.get("candle_endpoint") in (None, "") and not source.get("bars"):
+        return False
+    return True
+
+
+def _ohlcv_data_connection_state(
+    *,
+    browser_payload: Mapping[str, Any] | None,
+    ohlcv_payload: Mapping[str, Any] | None,
+    chart_availability: Availability,
+) -> str:
+    if chart_availability is Availability.STALE:
+        return "STALE"
+    if chart_availability is Availability.MISSING_SOURCE:
+        return "MISSING_SOURCE"
+    if _ohlcv_source_feed_is_live(
+        browser_payload=browser_payload,
+        ohlcv_payload=ohlcv_payload,
+        chart_availability=chart_availability,
+    ):
+        return "LIVE_DATA"
+    if chart_availability in (Availability.INVALID, Availability.NOT_BOUND):
+        return "MISSING_SOURCE"
+    return "MISSING_SOURCE"
+
+
 def present_market_landscape_v2(
     page: MarketDashboardPageSnapshotV1,
     *,
@@ -566,7 +608,8 @@ def present_market_landscape_v2(
             "last_closed_timestamp": (ohlcv_payload or {}).get("last_closed_timestamp"),
             "first_timestamp": (browser_payload or {}).get("first_timestamp"),
             "last_timestamp": (browser_payload or {}).get("last_timestamp"),
-            "captured_at": (browser_payload or ohlcv_payload or {}).get("captured_at"),
+            "captured_at": (browser_payload or ohlcv_payload or {}).get("candle_captured_at")
+            or (browser_payload or ohlcv_payload or {}).get("captured_at"),
             "effective_at": (browser_payload or ohlcv_payload or {}).get("effective_at"),
             "payload_digest": (browser_payload or {}).get("payload_digest"),
             "chart_digest": (browser_payload or {}).get("chart_digest"),
@@ -574,19 +617,31 @@ def present_market_landscape_v2(
             "metadata_digest": (browser_payload or {}).get("metadata_digest"),
             "live_mark_price": (browser_payload or {}).get("live_mark_price"),
             "live_price_kind": (browser_payload or {}).get("live_price_kind"),
+            "ohlcv_revision_kind": (browser_payload or ohlcv_payload or {}).get(
+                "ohlcv_revision_kind"
+            ),
+            "open_price": None
+            if not browser_payload or not browser_payload.get("bars")
+            else browser_payload["bars"][-1].get("open"),
+            "high_price": None
+            if not browser_payload or not browser_payload.get("bars")
+            else browser_payload["bars"][-1].get("high"),
+            "low_price": None
+            if not browser_payload or not browser_payload.get("bars")
+            else browser_payload["bars"][-1].get("low"),
+            "close_price": None
+            if not browser_payload or not browser_payload.get("bars")
+            else browser_payload["bars"][-1].get("close"),
+            "volume": None
+            if not browser_payload or not browser_payload.get("bars")
+            else browser_payload["bars"][-1].get("volume"),
             "is_stale": bool((ohlcv_payload or {}).get("is_stale")),
             "poll_path": OHLCV_POLL_PATH,
             "poll_interval_seconds": _ohlcv_poll_interval_seconds(),
-            "data_connection_state": (
-                "STALE"
-                if chart_availability is Availability.STALE
-                else "MISSING_SOURCE"
-                if chart_availability is Availability.MISSING_SOURCE
-                else "LIVE_DATA"
-                if browser_payload is not None and chart_availability is Availability.AVAILABLE
-                else "MISSING_SOURCE"
-                if chart_availability in (Availability.INVALID, Availability.NOT_BOUND)
-                else "MISSING_SOURCE"
+            "data_connection_state": _ohlcv_data_connection_state(
+                browser_payload=browser_payload,
+                ohlcv_payload=ohlcv_payload,
+                chart_availability=chart_availability,
             ),
         },
         "timeline": {

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -114,9 +114,10 @@ def serialize_ohlcv_browser_payload_v1(
     Source bars may store OHLC as decimal strings (canonical readmodel). This
     projection never fabricates candles; missing/non-finite values fail closed.
 
-    Chart digest excludes captured_at so metadata-only refresh does not imply
-    a market-value change. Open (provisional) bars may expose display_close from
-    authentic live_mark_price without rewriting closed candle OHLC.
+    Identity domains (local browser payload only):
+    - candle_series_digest: authentic timestamp + O/H/L/C (+ confirm) only
+    - metadata_digest: captured_at / freshness / provenance clocks
+    - live_mark_price: distinct annotation — never mutates candle close/geometry
     """
     if not isinstance(ohlcv_readmodel, Mapping):
         return None
@@ -125,7 +126,7 @@ def serialize_ohlcv_browser_payload_v1(
         return None
     live_mark = _finite_ohlc_float(ohlcv_readmodel.get("live_mark_price"))
     bars: list[dict[str, Any]] = []
-    for idx, row in enumerate(bars_raw):
+    for row in bars_raw:
         if not isinstance(row, Mapping):
             return None
         ts = row.get("ts")
@@ -146,15 +147,7 @@ def serialize_ohlcv_browser_payload_v1(
             confirm = confirm_raw
         else:
             confirm = str(confirm_raw) in {"1", "true", "True"}
-        provisional = not confirm
-        display_close = close_v
-        display_high = high_v
-        display_low = low_v
-        # Only the current open candle may tip with authentic mark; closed bars stay stable.
-        if provisional and idx == len(bars_raw) - 1 and live_mark is not None:
-            display_close = live_mark
-            display_high = max(high_v, live_mark)
-            display_low = min(low_v, live_mark)
+        # Geometry uses authentic OHLC only — mark never overwrites close/high/low.
         bars.append(
             {
                 "ts": ts.strip(),
@@ -162,24 +155,21 @@ def serialize_ohlcv_browser_payload_v1(
                 "high": high_v,
                 "low": low_v,
                 "close": close_v,
-                "display_close": display_close,
-                "display_high": display_high,
-                "display_low": display_low,
+                "display_close": close_v,
+                "display_high": high_v,
+                "display_low": low_v,
                 "confirm": confirm,
-                "provisional": provisional,
+                "provisional": not confirm,
             }
         )
     venue_raw = ohlcv_readmodel.get("venue")
     venue_display = None
     if isinstance(venue_raw, str) and venue_raw.strip():
         venue_display = _venue_display(venue_raw, Availability.AVAILABLE)
-    # Market-value digest: OHLC + live mark tip — never captured_at alone.
-    chart_digest_source = {
+    candle_series_source = {
         "instrument_id": ohlcv_readmodel.get("instrument_id"),
         "venue": venue_display or venue_raw,
         "interval": ohlcv_readmodel.get("interval"),
-        "last_closed_timestamp": ohlcv_readmodel.get("last_closed_timestamp"),
-        "live_mark_price": live_mark,
         "bars": [
             {
                 "ts": b["ts"],
@@ -187,24 +177,35 @@ def serialize_ohlcv_browser_payload_v1(
                 "high": b["high"],
                 "low": b["low"],
                 "close": b["close"],
-                "display_close": b["display_close"],
-                "display_high": b["display_high"],
-                "display_low": b["display_low"],
                 "confirm": b["confirm"],
             }
             for b in bars
         ],
     }
-    chart_digest = hashlib.sha256(
-        json.dumps(chart_digest_source, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    candle_series_digest = hashlib.sha256(
+        json.dumps(candle_series_source, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
-    # Full payload digest retains captured_at for snapshot identity diagnostics only.
-    digest_source = {
-        **chart_digest_source,
+    metadata_source = {
         "captured_at": ohlcv_readmodel.get("captured_at"),
+        "effective_at": ohlcv_readmodel.get("effective_at"),
+        "freshness_state": ohlcv_readmodel.get("freshness_state"),
+        "is_stale": bool(ohlcv_readmodel.get("is_stale")),
+        "live_mark_price": live_mark,
+        "live_mark_provider_ts": ohlcv_readmodel.get("live_mark_provider_ts"),
+        "gap_count": ohlcv_readmodel.get("gap_count"),
+        "last_closed_timestamp": ohlcv_readmodel.get("last_closed_timestamp"),
     }
+    metadata_digest = hashlib.sha256(
+        json.dumps(metadata_source, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    # Backward-compatible aliases: chart_digest == candle geometry only.
+    chart_digest = candle_series_digest
     payload_digest = hashlib.sha256(
-        json.dumps(digest_source, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        json.dumps(
+            {**candle_series_source, **metadata_source},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
     ).hexdigest()
     return {
         "schema_name": OHLCV_BROWSER_PAYLOAD_SCHEMA,
@@ -225,6 +226,8 @@ def serialize_ohlcv_browser_payload_v1(
         "live_mark_provider_ts": ohlcv_readmodel.get("live_mark_provider_ts"),
         "live_price_kind": ohlcv_readmodel.get("live_price_kind") or "mark",
         "live_mark_projection": ohlcv_readmodel.get("live_mark_projection"),
+        "candle_series_digest": candle_series_digest,
+        "metadata_digest": metadata_digest,
         "chart_digest": chart_digest,
         "payload_digest": payload_digest,
         "bars": bars,
@@ -552,6 +555,8 @@ def present_market_landscape_v2(
             "effective_at": (browser_payload or ohlcv_payload or {}).get("effective_at"),
             "payload_digest": (browser_payload or {}).get("payload_digest"),
             "chart_digest": (browser_payload or {}).get("chart_digest"),
+            "candle_series_digest": (browser_payload or {}).get("candle_series_digest"),
+            "metadata_digest": (browser_payload or {}).get("metadata_digest"),
             "live_mark_price": (browser_payload or {}).get("live_mark_price"),
             "live_price_kind": (browser_payload or {}).get("live_price_kind"),
             "is_stale": bool((ohlcv_payload or {}).get("is_stale")),

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -18,6 +18,16 @@ from .source_health import DashboardSourceHealthSnapshotV1
 # Presentation-only poll contract; server owns refresh cadence/materialization.
 OHLCV_POLL_PATH = "/api/market/landscape/ohlcv"
 OHLCV_BROWSER_PAYLOAD_SCHEMA = "market_landscape_ohlcv_browser_payload.v1"
+# Must stay equal to DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS in
+# src.ops.okx_selected_instrument_ohlcv_readmodel_v1 (contract-tested).
+# Landscape package must not import ops owners (architecture guard).
+OHLCV_POLL_INTERVAL_SECONDS = 3
+
+
+def _ohlcv_poll_interval_seconds() -> int:
+    """Presentation mirror of the canonical OKX OHLCV poll cadence."""
+    return int(OHLCV_POLL_INTERVAL_SECONDS)
+
 
 AVAILABILITY_LABELS: Mapping[Availability, str] = {
     Availability.AVAILABLE: "AVAILABLE",
@@ -96,15 +106,6 @@ def _finite_ohlc_float(raw: Any) -> float | None:
     return value
 
 
-def _ohlcv_poll_interval_seconds() -> int:
-    """Reuse canonical OKX OHLCV poll cadence; presentation never invents a second owner."""
-    from src.ops.okx_selected_instrument_ohlcv_readmodel_v1 import (
-        DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS,
-    )
-
-    return int(DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS)
-
-
 def serialize_ohlcv_browser_payload_v1(
     ohlcv_readmodel: Mapping[str, Any] | None,
 ) -> dict[str, Any] | None:
@@ -112,14 +113,19 @@ def serialize_ohlcv_browser_payload_v1(
 
     Source bars may store OHLC as decimal strings (canonical readmodel). This
     projection never fabricates candles; missing/non-finite values fail closed.
+
+    Chart digest excludes captured_at so metadata-only refresh does not imply
+    a market-value change. Open (provisional) bars may expose display_close from
+    authentic live_mark_price without rewriting closed candle OHLC.
     """
     if not isinstance(ohlcv_readmodel, Mapping):
         return None
     bars_raw = ohlcv_readmodel.get("bars")
     if not isinstance(bars_raw, list) or not bars_raw:
         return None
+    live_mark = _finite_ohlc_float(ohlcv_readmodel.get("live_mark_price"))
     bars: list[dict[str, Any]] = []
-    for row in bars_raw:
+    for idx, row in enumerate(bars_raw):
         if not isinstance(row, Mapping):
             return None
         ts = row.get("ts")
@@ -140,6 +146,15 @@ def serialize_ohlcv_browser_payload_v1(
             confirm = confirm_raw
         else:
             confirm = str(confirm_raw) in {"1", "true", "True"}
+        provisional = not confirm
+        display_close = close_v
+        display_high = high_v
+        display_low = low_v
+        # Only the current open candle may tip with authentic mark; closed bars stay stable.
+        if provisional and idx == len(bars_raw) - 1 and live_mark is not None:
+            display_close = live_mark
+            display_high = max(high_v, live_mark)
+            display_low = min(low_v, live_mark)
         bars.append(
             {
                 "ts": ts.strip(),
@@ -147,20 +162,24 @@ def serialize_ohlcv_browser_payload_v1(
                 "high": high_v,
                 "low": low_v,
                 "close": close_v,
+                "display_close": display_close,
+                "display_high": display_high,
+                "display_low": display_low,
                 "confirm": confirm,
-                "provisional": not confirm,
+                "provisional": provisional,
             }
         )
     venue_raw = ohlcv_readmodel.get("venue")
     venue_display = None
     if isinstance(venue_raw, str) and venue_raw.strip():
         venue_display = _venue_display(venue_raw, Availability.AVAILABLE)
-    digest_source = {
+    # Market-value digest: OHLC + live mark tip — never captured_at alone.
+    chart_digest_source = {
         "instrument_id": ohlcv_readmodel.get("instrument_id"),
         "venue": venue_display or venue_raw,
         "interval": ohlcv_readmodel.get("interval"),
         "last_closed_timestamp": ohlcv_readmodel.get("last_closed_timestamp"),
-        "captured_at": ohlcv_readmodel.get("captured_at"),
+        "live_mark_price": live_mark,
         "bars": [
             {
                 "ts": b["ts"],
@@ -168,10 +187,21 @@ def serialize_ohlcv_browser_payload_v1(
                 "high": b["high"],
                 "low": b["low"],
                 "close": b["close"],
+                "display_close": b["display_close"],
+                "display_high": b["display_high"],
+                "display_low": b["display_low"],
                 "confirm": b["confirm"],
             }
             for b in bars
         ],
+    }
+    chart_digest = hashlib.sha256(
+        json.dumps(chart_digest_source, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    # Full payload digest retains captured_at for snapshot identity diagnostics only.
+    digest_source = {
+        **chart_digest_source,
+        "captured_at": ohlcv_readmodel.get("captured_at"),
     }
     payload_digest = hashlib.sha256(
         json.dumps(digest_source, sort_keys=True, separators=(",", ":")).encode("utf-8")
@@ -191,6 +221,11 @@ def serialize_ohlcv_browser_payload_v1(
         "freshness_state": ohlcv_readmodel.get("freshness_state"),
         "is_stale": bool(ohlcv_readmodel.get("is_stale")),
         "gap_count": ohlcv_readmodel.get("gap_count"),
+        "live_mark_price": live_mark,
+        "live_mark_provider_ts": ohlcv_readmodel.get("live_mark_provider_ts"),
+        "live_price_kind": ohlcv_readmodel.get("live_price_kind") or "mark",
+        "live_mark_projection": ohlcv_readmodel.get("live_mark_projection"),
+        "chart_digest": chart_digest,
         "payload_digest": payload_digest,
         "bars": bars,
     }
@@ -516,9 +551,23 @@ def present_market_landscape_v2(
             "captured_at": (browser_payload or ohlcv_payload or {}).get("captured_at"),
             "effective_at": (browser_payload or ohlcv_payload or {}).get("effective_at"),
             "payload_digest": (browser_payload or {}).get("payload_digest"),
+            "chart_digest": (browser_payload or {}).get("chart_digest"),
+            "live_mark_price": (browser_payload or {}).get("live_mark_price"),
+            "live_price_kind": (browser_payload or {}).get("live_price_kind"),
             "is_stale": bool((ohlcv_payload or {}).get("is_stale")),
             "poll_path": OHLCV_POLL_PATH,
             "poll_interval_seconds": _ohlcv_poll_interval_seconds(),
+            "data_connection_state": (
+                "STALE"
+                if chart_availability is Availability.STALE
+                else "MISSING_SOURCE"
+                if chart_availability is Availability.MISSING_SOURCE
+                else "LIVE_DATA"
+                if browser_payload is not None and chart_availability is Availability.AVAILABLE
+                else "MISSING_SOURCE"
+                if chart_availability in (Availability.INVALID, Availability.NOT_BOUND)
+                else "MISSING_SOURCE"
+            ),
         },
         "timeline": {
             "availability": Availability.NOT_BOUND.value,

--- a/static/css/market_dashboard_landscape_v2.css
+++ b/static/css/market_dashboard_landscape_v2.css
@@ -55,12 +55,16 @@
   --mdl-ink: #e2e8f0;
   --mdl-muted: #8b9bb0;
   --mdl-warn: #fbbf24;
-  --mdl-chart-min: min(56vh, 580px);
+  /* Stable primary chart band — leaves room for Decision strip in 982px viewport. */
+  --mdl-stage-height: 300px;
+  --mdl-chart-chrome-band: 1.5rem;
+  --mdl-chart-meta-band: 5.5rem;
+  --mdl-chart-message-band: 1.25rem;
   box-sizing: border-box;
   max-width: 100vw;
-  min-height: calc(100vh - 36px);
+  min-height: 0;
   margin: 0;
-  padding: 4px 18px 16px;
+  padding: 4px 18px 10px;
   color: var(--mdl-ink);
   background: var(--mdl-bg);
   font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
@@ -96,7 +100,7 @@
   background: transparent;
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - 48px);
+  min-height: 0;
   gap: 0;
 }
 
@@ -170,9 +174,9 @@
   grid-template-columns: minmax(150px, 190px) minmax(0, 1fr) minmax(160px, 210px);
   column-gap: 28px;
   row-gap: 0;
-  min-height: var(--mdl-chart-min);
-  flex: 1 1 auto;
-  padding: 8px 0 18px;
+  min-height: 0;
+  flex: 0 0 auto;
+  padding: 4px 0 8px;
 }
 
 .mdl-v2-rail,
@@ -218,14 +222,15 @@
 .mdl-v2-primary {
   display: flex;
   flex-direction: column;
-  min-height: var(--mdl-chart-min);
+  min-height: 0;
+  flex: 0 0 auto;
 }
 
 .mdl-v2-chart {
-  flex: 1;
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
-  min-height: var(--mdl-chart-min);
+  min-height: 0;
 }
 
 .mdl-v2-chart__chrome {
@@ -233,10 +238,10 @@
   justify-content: space-between;
   align-items: center;
   gap: 8px;
-  margin-bottom: 6px;
+  margin-bottom: 4px;
   flex-wrap: nowrap;
-  min-height: 1.5rem;
-  max-height: 1.5rem;
+  min-height: var(--mdl-chart-chrome-band);
+  max-height: var(--mdl-chart-chrome-band);
   overflow: hidden;
 }
 
@@ -256,12 +261,12 @@
 .mdl-v2-chart__meta {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 8px 12px;
-  margin: 0 0 8px;
+  gap: 4px 10px;
+  margin: 0 0 6px;
   padding: 0;
-  /* Reserved fixed band so Captured/Mark text never pushes the chart down. */
-  min-height: 2.75rem;
-  max-height: 2.75rem;
+  /* Two reserved rows: provenance + open-candle O/H/L/C/V (no layout growth). */
+  min-height: var(--mdl-chart-meta-band);
+  max-height: var(--mdl-chart-meta-band);
   overflow: hidden;
   align-content: start;
 }
@@ -295,16 +300,14 @@
 
 @media (max-width: 1100px) {
   .mdl-v2-chart__meta {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    /* Two rows still reserved; do not grow beyond this band on poll. */
-    min-height: 5.5rem;
-    max-height: 5.5rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    min-height: 7.5rem;
+    max-height: 7.5rem;
   }
 }
 
 .mdl-v2-chart__stage {
   /* CSS-owned fixed box — polling must never change this height. */
-  --mdl-stage-height: calc(var(--mdl-chart-min) - 88px);
   flex: 0 0 auto;
   margin: 0;
   border-radius: 0;
@@ -314,7 +317,7 @@
   justify-content: flex-start;
   align-items: stretch;
   text-align: left;
-  padding: 8px 0 0;
+  padding: 4px 0 0;
   height: var(--mdl-stage-height);
   min-height: var(--mdl-stage-height);
   max-height: var(--mdl-stage-height);
@@ -467,10 +470,11 @@
 
 .mdl-v2-decision {
   background: transparent;
-  padding: 18px 0 14px;
+  padding: 8px 0 8px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
+  flex: 0 0 auto;
 }
 
 /* Phase 5 PR2: Decision → Why → Blockers primary reading flow */
@@ -553,8 +557,9 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   column-gap: 32px;
-  padding: 16px 0 12px;
+  padding: 8px 0 8px;
   background: transparent;
+  flex: 0 0 auto;
 }
 
 .mdl-v2-ops__col {

--- a/static/css/market_dashboard_landscape_v2.css
+++ b/static/css/market_dashboard_landscape_v2.css
@@ -234,7 +234,10 @@
   align-items: center;
   gap: 8px;
   margin-bottom: 6px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  min-height: 1.5rem;
+  max-height: 1.5rem;
+  overflow: hidden;
 }
 
 .mdl-v2-chart__chrome .mdl-v2-state[data-connection-state="LIVE_DATA"] {
@@ -256,6 +259,11 @@
   gap: 8px 12px;
   margin: 0 0 8px;
   padding: 0;
+  /* Reserved fixed band so Captured/Mark text never pushes the chart down. */
+  min-height: 2.75rem;
+  max-height: 2.75rem;
+  overflow: hidden;
+  align-content: start;
 }
 
 .mdl-v2-chart__meta > div {
@@ -268,24 +276,36 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: #64748b;
+  white-space: nowrap;
 }
 
 .mdl-v2-chart__meta dd {
   margin: 2px 0 0;
   font-family: "IBM Plex Mono", ui-monospace, monospace;
   font-size: 11px;
+  line-height: 1.25;
+  min-height: 1.25em;
+  max-height: 1.25em;
   color: #cbd5e1;
-  overflow-wrap: anywhere;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  overflow-wrap: normal;
 }
 
 @media (max-width: 1100px) {
   .mdl-v2-chart__meta {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    /* Two rows still reserved; do not grow beyond this band on poll. */
+    min-height: 5.5rem;
+    max-height: 5.5rem;
   }
 }
 
 .mdl-v2-chart__stage {
-  flex: 1;
+  /* CSS-owned fixed box — polling must never change this height. */
+  --mdl-stage-height: calc(var(--mdl-chart-min) - 88px);
+  flex: 0 0 auto;
   margin: 0;
   border-radius: 0;
   background: transparent;
@@ -295,24 +315,37 @@
   align-items: stretch;
   text-align: left;
   padding: 8px 0 0;
-  min-height: calc(var(--mdl-chart-min) - 24px);
+  height: var(--mdl-stage-height);
+  min-height: var(--mdl-stage-height);
+  max-height: var(--mdl-stage-height);
   position: relative;
+  overflow: hidden;
 }
 
 .mdl-v2-chart__message {
-  margin: 0 0 8px;
+  flex: 0 0 auto;
+  margin: 0 0 4px;
+  height: 1.25rem;
+  min-height: 1.25rem;
+  max-height: 1.25rem;
   font-size: 13px;
   font-weight: 500;
   color: #94a3b8;
   max-width: 48rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .mdl-v2-chart__canvas {
+  /* Layout size is CSS-only; JS sets only backing-store width/height attributes. */
   display: block;
   width: 100%;
-  flex: 1;
-  min-height: calc(var(--mdl-chart-min) - 64px);
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto;
   max-width: 100%;
+  max-height: 100%;
 }
 
 .mdl-v2-state {

--- a/static/css/market_dashboard_landscape_v2.css
+++ b/static/css/market_dashboard_landscape_v2.css
@@ -234,11 +234,25 @@
   align-items: center;
   gap: 8px;
   margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+
+.mdl-v2-chart__chrome .mdl-v2-state[data-connection-state="LIVE_DATA"] {
+  color: #34d399;
+}
+
+.mdl-v2-chart__chrome .mdl-v2-state[data-connection-state="RECONNECTING"] {
+  color: #fbbf24;
+}
+
+.mdl-v2-chart__chrome .mdl-v2-state[data-connection-state="STALE"],
+.mdl-v2-chart__chrome .mdl-v2-state[data-connection-state="MISSING_SOURCE"] {
+  color: #f87171;
 }
 
 .mdl-v2-chart__meta {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 8px 12px;
   margin: 0 0 8px;
   padding: 0;

--- a/static/css/market_dashboard_landscape_v2.css
+++ b/static/css/market_dashboard_landscape_v2.css
@@ -177,6 +177,7 @@
   min-height: 0;
   flex: 0 0 auto;
   padding: 4px 0 8px;
+  align-items: start;
 }
 
 .mdl-v2-rail,
@@ -185,6 +186,20 @@
   padding: 4px 0;
   min-height: 0;
   border-radius: 0;
+}
+
+.mdl-v2-rail--right {
+  /* Context rail must not stretch the primary chart column height. */
+  max-height: calc(
+    var(--mdl-stage-height) + var(--mdl-chart-meta-band) + var(--mdl-chart-chrome-band) +
+      var(--mdl-chart-message-band) + 24px
+  );
+  overflow: auto;
+}
+
+.mdl-v2-source-health__sources {
+  max-height: 7.5rem;
+  overflow: auto;
 }
 
 .mdl-v2-rail h2,
@@ -624,7 +639,7 @@
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 10px 18px;
   margin-top: 10px;
-  max-height: 42vh;
+  max-height: 12rem;
   overflow: auto;
   padding: 0 0 4px;
 }

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -654,14 +654,36 @@
     scheduleNext();
   }
 
+  var resizeTimer = null;
+  var resizeRaf1 = null;
+  var resizeRaf2 = null;
+
+  function paintAfterLayoutSettled() {
+    // Double-rAF waits for CSS layout to settle after viewport/stage size changes
+    // so backing-store width/height are derived from final CSS box × DPR once.
+    if (resizeRaf1 !== null) window.cancelAnimationFrame(resizeRaf1);
+    if (resizeRaf2 !== null) window.cancelAnimationFrame(resizeRaf2);
+    resizeRaf1 = window.requestAnimationFrame(function () {
+      resizeRaf1 = null;
+      resizeRaf2 = window.requestAnimationFrame(function () {
+        resizeRaf2 = null;
+        if (!lastBars || !lastBars.length) {
+          renderOhlcvCanvas();
+          return;
+        }
+        setUpdateClass("VIEWPORT_RESIZE");
+        renderOhlcvCanvas(null, { mode: "FULL_SERIES" });
+      });
+    });
+  }
+
   function onViewportResize() {
-    // True viewport/layout resize only — full series re-render once with CSS box.
-    if (!lastBars || !lastBars.length) {
-      renderOhlcvCanvas();
-      return;
-    }
-    setUpdateClass("VIEWPORT_RESIZE");
-    renderOhlcvCanvas(null, { mode: "FULL_SERIES" });
+    // True viewport/layout resize only — never from poll metadata updates.
+    if (resizeTimer !== null) window.clearTimeout(resizeTimer);
+    resizeTimer = window.setTimeout(function () {
+      resizeTimer = null;
+      paintAfterLayoutSettled();
+    }, 50);
   }
 
   if (document.readyState === "loading") {
@@ -674,4 +696,30 @@
     startOhlcvPolling();
   }
   window.addEventListener("resize", onViewportResize);
+  if (typeof ResizeObserver === "function") {
+    var stageEl = root.querySelector("[data-mdl-chart-stage]");
+    if (stageEl) {
+      var lastObservedBox = { w: 0, h: 0 };
+      var stageObserverReady = false;
+      var ro = new ResizeObserver(function (entries) {
+        var entry = entries && entries[0];
+        if (!entry || !stageObserverReady) return;
+        var box = entry.contentRect || {};
+        var w = Math.floor(box.width || 0);
+        var h = Math.floor(box.height || 0);
+        if (w <= 0 || h <= 0) return;
+        if (w === lastObservedBox.w && h === lastObservedBox.h) return;
+        lastObservedBox = { w: w, h: h };
+        if (!lastBars || !lastBars.length) return;
+        onViewportResize();
+      });
+      // Seed after first paint so the initial RO callback does not re-render.
+      window.requestAnimationFrame(function () {
+        var r = stageEl.getBoundingClientRect();
+        lastObservedBox = { w: Math.floor(r.width), h: Math.floor(r.height) };
+        stageObserverReady = true;
+        ro.observe(stageEl);
+      });
+    }
+  }
 })();

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -34,6 +34,11 @@
     });
   }
 
+  // Primary landscape composition assumes the diagnostic drawer starts closed.
+  if (engineering && engineering.open) {
+    engineering.open = false;
+  }
+
   root.addEventListener("keydown", function (event) {
     if (event.key !== "Escape") return;
     if (engineering && engineering.open) {

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -280,6 +280,18 @@
       "data-mdl-chart-candle-close",
       String(bars[n - 1].close !== undefined ? bars[n - 1].close : "")
     );
+    if (bars[n - 1].open !== undefined) {
+      canvas.setAttribute("data-mdl-chart-candle-open", String(bars[n - 1].open));
+    }
+    if (bars[n - 1].high !== undefined) {
+      canvas.setAttribute("data-mdl-chart-candle-high", String(bars[n - 1].high));
+    }
+    if (bars[n - 1].low !== undefined) {
+      canvas.setAttribute("data-mdl-chart-candle-low", String(bars[n - 1].low));
+    }
+    if (bars[n - 1].volume !== undefined) {
+      canvas.setAttribute("data-mdl-chart-candle-volume", String(bars[n - 1].volume));
+    }
     canvas.setAttribute("data-mdl-chart-instance-id", chartInstanceId);
     canvas.setAttribute(
       "data-mdl-full-series-clearrect",
@@ -411,7 +423,8 @@
           Number(prevBars[i].open) !== Number(nextBars[i].open) ||
           Number(prevBars[i].high) !== Number(nextBars[i].high) ||
           Number(prevBars[i].low) !== Number(nextBars[i].low) ||
-          Number(prevBars[i].close) !== Number(nextBars[i].close)
+          Number(prevBars[i].close) !== Number(nextBars[i].close) ||
+          Number(prevBars[i].volume || 0) !== Number(nextBars[i].volume || 0)
         ) {
           histChanged = true;
           break;
@@ -478,6 +491,7 @@
           high: b.high,
           low: b.low,
           close: b.close,
+          volume: b.volume,
           confirm: b.confirm,
         };
       });

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -64,13 +64,32 @@
     root.setAttribute("data-mdl-ohlcv-update-class", kind);
   }
 
+  function formatMetaNumber(value) {
+    if (value === undefined || value === null || value === "") return "—";
+    var n = Number(value);
+    if (!Number.isFinite(n)) return String(value);
+    if (Math.abs(n) > 0 && Math.abs(n) < 1e-4) return n.toExponential(3);
+    return String(n);
+  }
+
+  function lastBarFromPayload(payload) {
+    if (!payload || !Array.isArray(payload.bars) || !payload.bars.length) return null;
+    return payload.bars[payload.bars.length - 1];
+  }
+
   function updateMetaFromPayload(payload, availability, connectionState) {
     var intervalNode = root.querySelector('[data-mdl-field="ohlcv_interval"]');
     var latestNode = root.querySelector('[data-mdl-field="ohlcv_latest_candle_at"]');
     var capturedNode = root.querySelector('[data-mdl-field="ohlcv_captured_at"]');
     var markNode = root.querySelector('[data-mdl-field="ohlcv_live_mark"]');
-    var freshnessNode = root.querySelector('[data-mdl-field="ohlcv_freshness"]');
+    var revisionNode = root.querySelector('[data-mdl-field="ohlcv_revision"]');
+    var openNode = root.querySelector('[data-mdl-field="ohlcv_open"]');
+    var highNode = root.querySelector('[data-mdl-field="ohlcv_high"]');
+    var lowNode = root.querySelector('[data-mdl-field="ohlcv_low"]');
+    var closeNode = root.querySelector('[data-mdl-field="ohlcv_close"]');
+    var volumeNode = root.querySelector('[data-mdl-field="ohlcv_volume"]');
     var availNode = root.querySelector("[data-mdl-chart-availability]");
+    var last = lastBarFromPayload(payload);
     if (intervalNode) {
       intervalNode.textContent = (payload && payload.interval) || "—";
     }
@@ -78,7 +97,8 @@
       latestNode.textContent = (payload && payload.last_timestamp) || "—";
     }
     if (capturedNode) {
-      capturedNode.textContent = (payload && payload.captured_at) || "—";
+      capturedNode.textContent =
+        (payload && (payload.candle_captured_at || payload.captured_at)) || "—";
     }
     if (markNode) {
       var mark =
@@ -87,14 +107,17 @@
           : "—";
       markNode.textContent = mark;
     }
-    if (freshnessNode) {
-      var fresh =
-        (payload && payload.freshness_state && String(payload.freshness_state).toUpperCase()) ||
-        availability ||
+    if (revisionNode) {
+      revisionNode.textContent =
+        (payload && payload.ohlcv_revision_kind) ||
+        root.getAttribute("data-mdl-ohlcv-update-class") ||
         "—";
-      freshnessNode.textContent = fresh;
-      if (availability) freshnessNode.setAttribute("data-availability", availability);
     }
+    if (openNode) openNode.textContent = last ? formatMetaNumber(last.open) : "—";
+    if (highNode) highNode.textContent = last ? formatMetaNumber(last.high) : "—";
+    if (lowNode) lowNode.textContent = last ? formatMetaNumber(last.low) : "—";
+    if (closeNode) closeNode.textContent = last ? formatMetaNumber(last.close) : "—";
+    if (volumeNode) volumeNode.textContent = last ? formatMetaNumber(last.volume) : "—";
     if (availNode && availability) {
       availNode.textContent = availability;
       availNode.setAttribute("data-availability", availability);
@@ -538,6 +561,8 @@
       metaDigest
     );
     setUpdateClass(kind);
+    // Expose poll classification as revision label (metadata-only ≠ candle motion).
+    payload.ohlcv_revision_kind = payload.ohlcv_revision_kind || kind;
 
     if (kind === "NO_CHANGE") {
       updateMetaFromPayload(payload, availability, connectionState);
@@ -552,8 +577,11 @@
       if (canvas && mark !== undefined && mark !== null) {
         canvas.setAttribute("data-mdl-chart-live-mark", String(mark));
       }
-      if (canvas && payload.captured_at) {
-        canvas.setAttribute("data-mdl-chart-captured-at", String(payload.captured_at));
+      if (canvas && (payload.candle_captured_at || payload.captured_at)) {
+        canvas.setAttribute(
+          "data-mdl-chart-captured-at",
+          String(payload.candle_captured_at || payload.captured_at)
+        );
       }
       root.setAttribute("data-mdl-full-series-clearrect", "false");
       return;

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -566,8 +566,17 @@
       metaDigest
     );
     setUpdateClass(kind);
-    // Expose poll classification as revision label (metadata-only ≠ candle motion).
-    payload.ohlcv_revision_kind = payload.ohlcv_revision_kind || kind;
+    // Prefer client poll class for candle-motion events so sticky server NO_OP
+    // cannot mask an authentic same-timestamp OHLCV change in the Revision field.
+    if (
+      kind === "SAME_TIMESTAMP_LAST_CANDLE_CHANGE" ||
+      kind === "NEW_CANDLE_APPEND" ||
+      kind === "HISTORICAL_SERIES_CHANGE"
+    ) {
+      payload.ohlcv_revision_kind = kind;
+    } else {
+      payload.ohlcv_revision_kind = payload.ohlcv_revision_kind || kind;
+    }
 
     if (kind === "NO_CHANGE") {
       updateMetaFromPayload(payload, availability, connectionState);

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -3,6 +3,7 @@
  * No fetch mutation, no decision/risk/sizing logic, no write endpoints.
  * Renders materialized OHLCV from SSR/poll JSON only (never fabricates candles).
  * Polls the read-only /api/market/landscape/ohlcv snapshot endpoint; never calls OKX.
+ * Chart redraw keys off chart_digest (market values), not captured_at alone.
  */
 (function () {
   "use strict";
@@ -36,10 +37,20 @@
     if (reason) canvas.setAttribute("data-mdl-chart-error", reason);
   }
 
-  function updateMetaFromPayload(payload, availability) {
+  function setConnectionState(state) {
+    var node = root.querySelector("[data-mdl-data-connection-state]");
+    if (node) {
+      node.textContent = state;
+      node.setAttribute("data-connection-state", state);
+    }
+    root.setAttribute("data-mdl-data-connection-state", state);
+  }
+
+  function updateMetaFromPayload(payload, availability, connectionState) {
     var intervalNode = root.querySelector('[data-mdl-field="ohlcv_interval"]');
     var latestNode = root.querySelector('[data-mdl-field="ohlcv_latest_candle_at"]');
     var capturedNode = root.querySelector('[data-mdl-field="ohlcv_captured_at"]');
+    var markNode = root.querySelector('[data-mdl-field="ohlcv_live_mark"]');
     var freshnessNode = root.querySelector('[data-mdl-field="ohlcv_freshness"]');
     var availNode = root.querySelector("[data-mdl-chart-availability]");
     if (intervalNode) {
@@ -50,6 +61,13 @@
     }
     if (capturedNode) {
       capturedNode.textContent = (payload && payload.captured_at) || "—";
+    }
+    if (markNode) {
+      var mark =
+        payload && payload.live_mark_price !== undefined && payload.live_mark_price !== null
+          ? String(payload.live_mark_price)
+          : "—";
+      markNode.textContent = mark;
     }
     if (freshnessNode) {
       var fresh =
@@ -63,6 +81,7 @@
       availNode.textContent = availability;
       availNode.setAttribute("data-availability", availability);
     }
+    if (connectionState) setConnectionState(connectionState);
   }
 
   function renderOhlcvCanvas(optionalPayload) {
@@ -105,9 +124,21 @@
     for (i = 0; i < bars.length; i += 1) {
       var bar = bars[i];
       var o = Number(bar.open);
-      var h = Number(bar.high);
-      var l = Number(bar.low);
-      var c = Number(bar.close);
+      var h = Number(
+        bar.display_high !== undefined && bar.display_high !== null
+          ? bar.display_high
+          : bar.high
+      );
+      var l = Number(
+        bar.display_low !== undefined && bar.display_low !== null
+          ? bar.display_low
+          : bar.low
+      );
+      var c = Number(
+        bar.display_close !== undefined && bar.display_close !== null
+          ? bar.display_close
+          : bar.close
+      );
       if (![o, h, l, c].every(function (v) { return Number.isFinite(v); })) {
         markBlank(canvas, "non_finite_ohlc");
         return;
@@ -188,7 +219,7 @@
       drawnPixels += bodyW * bodyH;
     }
 
-    // Close polyline overlay for continuous series geometry.
+    // Close polyline overlay for continuous series geometry (uses display closes).
     ctx.beginPath();
     ctx.strokeStyle = "#93c5fd";
     ctx.lineWidth = 1.25;
@@ -202,6 +233,8 @@
     drawnPixels += plotW;
 
     var geometryOk = drawnPixels > 0 && canvas.width > 0 && canvas.height > 0;
+    var lastBar = bars[n - 1];
+    var renderedClose = closes[n - 1];
     canvas.setAttribute(
       "data-mdl-chart-geometry",
       geometryOk ? "nonzero" : "absent"
@@ -210,10 +243,23 @@
     canvas.setAttribute("data-mdl-chart-bar-count", String(n));
     canvas.setAttribute("data-mdl-chart-first-ts", String(bars[0].ts || ""));
     canvas.setAttribute("data-mdl-chart-last-ts", String(bars[n - 1].ts || ""));
+    canvas.setAttribute("data-mdl-chart-rendered-close", String(renderedClose));
+    canvas.setAttribute(
+      "data-mdl-chart-candle-close",
+      String(lastBar && lastBar.close !== undefined ? lastBar.close : "")
+    );
+    if (payload.live_mark_price !== undefined && payload.live_mark_price !== null) {
+      canvas.setAttribute(
+        "data-mdl-chart-live-mark",
+        String(payload.live_mark_price)
+      );
+    }
     if (payload.captured_at) {
       canvas.setAttribute("data-mdl-chart-captured-at", String(payload.captured_at));
     }
-    if (payload.payload_digest) {
+    if (payload.chart_digest) {
+      canvas.setAttribute("data-mdl-chart-digest", String(payload.chart_digest));
+    } else if (payload.payload_digest) {
       canvas.setAttribute("data-mdl-chart-digest", String(payload.payload_digest));
     }
     if (payload.instrument_id) {
@@ -229,25 +275,35 @@
       "data-mdl-chart-bound-without-geometry",
       geometryOk ? "false" : "true"
     );
+    root.setAttribute("data-mdl-chart-rendered-close", String(renderedClose));
   }
 
   function startOhlcvPolling() {
     var chart = root.querySelector("[data-mdl-chart]");
     if (!chart) return;
     var pollPath = chart.getAttribute("data-mdl-ohlcv-poll-path") || "";
-    var intervalSeconds = Number(
+    var baseIntervalSeconds = Number(
       chart.getAttribute("data-mdl-ohlcv-poll-interval-seconds") || "0"
     );
-    if (!pollPath || !(intervalSeconds > 0)) return;
+    if (!pollPath || !(baseIntervalSeconds > 0)) return;
     if (pollPath.indexOf("/api/market/") !== 0) return;
 
     var inFlight = false;
     var timerId = null;
-    var lastDigest = "";
+    var lastChartDigest = "";
+    var failStreak = 0;
+    var backoffSeconds = 0;
+    var MAX_BACKOFF_SECONDS = 15;
+    var STALE_AFTER_FAILURES = 3;
+
+    function nextDelaySeconds() {
+      if (backoffSeconds > 0) return backoffSeconds;
+      return baseIntervalSeconds;
+    }
 
     function scheduleNext() {
       if (timerId !== null) window.clearTimeout(timerId);
-      timerId = window.setTimeout(tick, intervalSeconds * 1000);
+      timerId = window.setTimeout(tick, nextDelaySeconds() * 1000);
     }
 
     function tick() {
@@ -261,6 +317,9 @@
       }
       inFlight = true;
       root.setAttribute("data-mdl-ohlcv-poll-in-flight", "true");
+      if (failStreak > 0) {
+        setConnectionState("RECONNECTING");
+      }
       fetch(pollPath, {
         method: "GET",
         credentials: "same-origin",
@@ -280,11 +339,24 @@
           if (body.direct_browser_okx) {
             throw new Error("poll_forbidden_direct_okx");
           }
+          failStreak = 0;
+          backoffSeconds = 0;
           var availability = body.availability || "";
           if (availability) {
             chart.setAttribute("data-availability", availability);
           }
-          updateMetaFromPayload(body.browser_payload || body, availability);
+          var connectionState =
+            body.data_connection_state ||
+            (availability === "MISSING_SOURCE"
+              ? "MISSING_SOURCE"
+              : availability === "STALE"
+                ? "STALE"
+                : "LIVE_DATA");
+          updateMetaFromPayload(
+            body.browser_payload || body,
+            availability,
+            connectionState
+          );
           var message = root.querySelector("[data-mdl-chart-message]");
           if (message && body.refresh && body.refresh.refresh_error) {
             message.setAttribute(
@@ -295,23 +367,51 @@
             message.removeAttribute("data-mdl-ohlcv-refresh-error");
           }
           if (body.browser_payload && body.browser_payload.bars) {
-            var digest = body.browser_payload.payload_digest || "";
-            if (digest !== lastDigest) {
-              lastDigest = digest;
+            var digest =
+              body.browser_payload.chart_digest ||
+              body.browser_payload.payload_digest ||
+              "";
+            if (digest !== lastChartDigest) {
+              lastChartDigest = digest;
               renderOhlcvCanvas(body.browser_payload);
             } else {
-              updateMetaFromPayload(body.browser_payload, availability);
+              updateMetaFromPayload(
+                body.browser_payload,
+                availability,
+                connectionState
+              );
             }
+          } else if (
+            availability === "MISSING_SOURCE" ||
+            connectionState === "MISSING_SOURCE"
+          ) {
+            setConnectionState("MISSING_SOURCE");
           }
           root.setAttribute("data-mdl-ohlcv-poll-status", String(body.status || "OK"));
           root.setAttribute("data-mdl-ohlcv-poll-ok", "true");
+          root.removeAttribute("data-mdl-ohlcv-poll-error");
         })
         .catch(function (err) {
+          failStreak += 1;
+          // Bounded exponential backoff: 1, 2, 4, … capped — no tight retry loop.
+          backoffSeconds = Math.min(
+            MAX_BACKOFF_SECONDS,
+            Math.max(1, Math.pow(2, Math.min(failStreak - 1, 3)))
+          );
           root.setAttribute("data-mdl-ohlcv-poll-ok", "false");
           root.setAttribute(
             "data-mdl-ohlcv-poll-error",
             String((err && err.message) || "poll_failed")
           );
+          root.setAttribute(
+            "data-mdl-ohlcv-poll-backoff-seconds",
+            String(backoffSeconds)
+          );
+          if (failStreak >= STALE_AFTER_FAILURES) {
+            setConnectionState("STALE");
+          } else {
+            setConnectionState("RECONNECTING");
+          }
         })
         .then(function () {
           inFlight = false;
@@ -321,6 +421,13 @@
     }
 
     root.setAttribute("data-mdl-ohlcv-poll-armed", "true");
+    setConnectionState(
+      chart.getAttribute("data-availability") === "MISSING_SOURCE"
+        ? "MISSING_SOURCE"
+        : chart.getAttribute("data-availability") === "STALE"
+          ? "STALE"
+          : "LIVE_DATA"
+    );
     scheduleNext();
   }
 

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -2,13 +2,27 @@
  * Market Dashboard Landscape V2 — presentation-only client helpers.
  * No fetch mutation, no decision/risk/sizing logic, no write endpoints.
  * Renders materialized OHLCV from SSR/poll JSON only (never fabricates candles).
- * Polls the read-only /api/market/landscape/ohlcv snapshot endpoint; never calls OKX.
- * Chart redraw keys off chart_digest (market values), not captured_at alone.
+ * Polls local /api/market/landscape/ohlcv only; never calls OKX.
+ *
+ * Update classification:
+ *   NO_CHANGE | METADATA_ONLY | MARK_ONLY | SAME_TIMESTAMP_LAST_CANDLE_CHANGE
+ *   | NEW_CANDLE_APPEND | HISTORICAL_SERIES_CHANGE | SCALE_DOMAIN_ESCAPE
+ *
+ * Candle geometry keys off candle_series_digest (authentic O/H/L/C only).
+ * Mark and captured_at never trigger full-series redraw.
+ * Canvas CSS size is CSS-owned; JS only sets backing-store width/height.
  */
 (function () {
   "use strict";
   var root = document.querySelector('[data-market-landscape-v2="true"]');
   if (!root) return;
+
+  var chartLayout = null;
+  var lastBars = null;
+  var lastCandleSeriesDigest = "";
+  var lastMetadataDigest = "";
+  var lastMark = null;
+  var chartInstanceId = "mdl-chart-" + String(Date.now());
 
   var engineering = root.querySelector("[data-mdl-engineering]");
   if (engineering) {
@@ -38,12 +52,16 @@
   }
 
   function setConnectionState(state) {
-    var node = root.querySelector("[data-mdl-data-connection-state]");
+    var node = root.querySelector(".mdl-v2-chart__chrome [data-mdl-data-connection-state]");
     if (node) {
       node.textContent = state;
       node.setAttribute("data-connection-state", state);
     }
     root.setAttribute("data-mdl-data-connection-state", state);
+  }
+
+  function setUpdateClass(kind) {
+    root.setAttribute("data-mdl-ohlcv-update-class", kind);
   }
 
   function updateMetaFromPayload(payload, availability, connectionState) {
@@ -84,7 +102,331 @@
     if (connectionState) setConnectionState(connectionState);
   }
 
-  function renderOhlcvCanvas(optionalPayload) {
+  function extractOhlcArrays(bars) {
+    var opens = [];
+    var highs = [];
+    var lows = [];
+    var closes = [];
+    var i;
+    for (i = 0; i < bars.length; i += 1) {
+      var bar = bars[i];
+      var o = Number(bar.open);
+      var h = Number(bar.high);
+      var l = Number(bar.low);
+      var c = Number(bar.close);
+      if (![o, h, l, c].every(function (v) { return Number.isFinite(v); })) {
+        return null;
+      }
+      opens.push(o);
+      highs.push(h);
+      lows.push(l);
+      closes.push(c);
+    }
+    return { opens: opens, highs: highs, lows: lows, closes: closes };
+  }
+
+  function resolveCssBox(canvas, stage) {
+    // CSS owns layout size. Never write style.width/height from measured stage height
+    // (that feedback loop caused cumulative vertical growth on each poll).
+    var cssWidth = Math.max(
+      1,
+      Math.floor(
+        (canvas.clientWidth > 0 && canvas.clientWidth) ||
+          (stage && stage.clientWidth) ||
+          640
+      )
+    );
+    var cssHeight = Math.max(
+      1,
+      Math.floor(
+        (canvas.clientHeight > 0 && canvas.clientHeight) ||
+          (stage && stage.clientHeight) ||
+          360
+      )
+    );
+    return { cssWidth: cssWidth, cssHeight: cssHeight };
+  }
+
+  function syncBackingStore(canvas, cssWidth, cssHeight) {
+    var dpr = window.devicePixelRatio || 1;
+    var nextW = Math.floor(cssWidth * dpr);
+    var nextH = Math.floor(cssHeight * dpr);
+    var resized = canvas.width !== nextW || canvas.height !== nextH;
+    if (resized) {
+      canvas.width = nextW;
+      canvas.height = nextH;
+    }
+    return { dpr: dpr, resized: resized };
+  }
+
+  function domainFor(highs, lows) {
+    var minP = Math.min.apply(null, lows);
+    var maxP = Math.max.apply(null, highs);
+    if (!(Number.isFinite(minP) && Number.isFinite(maxP)) || maxP <= minP) {
+      return null;
+    }
+    var span = maxP - minP;
+    minP -= span * 0.04;
+    maxP += span * 0.04;
+    return { minP: minP, maxP: maxP, span: maxP - minP };
+  }
+
+  function paintFullSeries(canvas, payload, bars, arrays, forceResize) {
+    var stage = canvas.parentElement;
+    var box = resolveCssBox(canvas, stage);
+    var cssWidth = box.cssWidth;
+    var cssHeight = box.cssHeight;
+    var store = syncBackingStore(canvas, cssWidth, cssHeight);
+    var ctx = canvas.getContext("2d");
+    if (!ctx) {
+      markBlank(canvas, "no_2d_context");
+      return false;
+    }
+    ctx.setTransform(store.dpr, 0, 0, store.dpr, 0, 0);
+    ctx.clearRect(0, 0, cssWidth, cssHeight);
+    root.setAttribute("data-mdl-full-series-clearrect", "true");
+
+    var padL = 12;
+    var padR = 12;
+    var padT = 16;
+    var padB = 28;
+    var plotW = Math.max(1, cssWidth - padL - padR);
+    var plotH = Math.max(1, cssHeight - padT - padB);
+    var domain = domainFor(arrays.highs, arrays.lows);
+    if (!domain) {
+      markBlank(canvas, "degenerate_range");
+      return false;
+    }
+
+    function yFor(price) {
+      return padT + (1 - (price - domain.minP) / domain.span) * plotH;
+    }
+
+    var n = bars.length;
+    var slot = plotW / n;
+    var bodyW = Math.max(1, Math.min(8, slot * 0.62));
+    var drawnPixels = 0;
+    var i;
+
+    ctx.lineWidth = 1;
+    for (i = 0; i < n; i += 1) {
+      var xCenter = padL + slot * (i + 0.5);
+      var yO = yFor(arrays.opens[i]);
+      var yH = yFor(arrays.highs[i]);
+      var yL = yFor(arrays.lows[i]);
+      var yC = yFor(arrays.closes[i]);
+      var up = arrays.closes[i] >= arrays.opens[i];
+      ctx.strokeStyle = up ? "#34d399" : "#f87171";
+      ctx.fillStyle = up ? "#34d399" : "#f87171";
+      ctx.beginPath();
+      ctx.moveTo(xCenter, yH);
+      ctx.lineTo(xCenter, yL);
+      ctx.stroke();
+      drawnPixels += Math.abs(yL - yH);
+      var top = Math.min(yO, yC);
+      var bodyH = Math.max(1, Math.abs(yC - yO));
+      ctx.fillRect(xCenter - bodyW / 2, top, bodyW, bodyH);
+      drawnPixels += bodyW * bodyH;
+    }
+
+    ctx.beginPath();
+    ctx.strokeStyle = "#93c5fd";
+    ctx.lineWidth = 1.25;
+    for (i = 0; i < n; i += 1) {
+      var x = padL + slot * (i + 0.5);
+      var y = yFor(arrays.closes[i]);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+    drawnPixels += plotW;
+
+    chartLayout = {
+      cssWidth: cssWidth,
+      cssHeight: cssHeight,
+      padL: padL,
+      padR: padR,
+      padT: padT,
+      padB: padB,
+      plotW: plotW,
+      plotH: plotH,
+      minP: domain.minP,
+      maxP: domain.maxP,
+      span: domain.span,
+      n: n,
+      slot: slot,
+      bodyW: bodyW,
+      dpr: store.dpr,
+      instanceId: chartInstanceId,
+    };
+
+    var geometryOk = drawnPixels > 0 && canvas.width > 0 && canvas.height > 0;
+    finishCanvasAttrs(canvas, payload, bars, arrays.closes[n - 1], geometryOk, forceResize);
+    return geometryOk;
+  }
+
+  function finishCanvasAttrs(canvas, payload, bars, renderedClose, geometryOk, fullClear) {
+    var n = bars.length;
+    canvas.setAttribute(
+      "data-mdl-chart-geometry",
+      geometryOk ? "nonzero" : "absent"
+    );
+    canvas.setAttribute("data-mdl-chart-blank", geometryOk ? "false" : "true");
+    canvas.setAttribute("data-mdl-chart-bar-count", String(n));
+    canvas.setAttribute("data-mdl-chart-first-ts", String(bars[0].ts || ""));
+    canvas.setAttribute("data-mdl-chart-last-ts", String(bars[n - 1].ts || ""));
+    canvas.setAttribute("data-mdl-chart-rendered-close", String(renderedClose));
+    canvas.setAttribute(
+      "data-mdl-chart-candle-close",
+      String(bars[n - 1].close !== undefined ? bars[n - 1].close : "")
+    );
+    canvas.setAttribute("data-mdl-chart-instance-id", chartInstanceId);
+    canvas.setAttribute(
+      "data-mdl-full-series-clearrect",
+      fullClear ? "true" : "false"
+    );
+    if (payload.live_mark_price !== undefined && payload.live_mark_price !== null) {
+      canvas.setAttribute(
+        "data-mdl-chart-live-mark",
+        String(payload.live_mark_price)
+      );
+    }
+    if (payload.captured_at) {
+      canvas.setAttribute("data-mdl-chart-captured-at", String(payload.captured_at));
+    }
+    var seriesDigest =
+      payload.candle_series_digest || payload.chart_digest || "";
+    if (seriesDigest) {
+      canvas.setAttribute("data-mdl-chart-digest", String(seriesDigest));
+      canvas.setAttribute("data-mdl-candle-series-digest", String(seriesDigest));
+    }
+    if (payload.metadata_digest) {
+      canvas.setAttribute(
+        "data-mdl-metadata-digest",
+        String(payload.metadata_digest)
+      );
+    }
+    if (payload.instrument_id) {
+      canvas.setAttribute(
+        "data-mdl-chart-instrument",
+        String(payload.instrument_id)
+      );
+    }
+    if (payload.venue) {
+      canvas.setAttribute("data-mdl-chart-venue", String(payload.venue));
+    }
+    root.setAttribute(
+      "data-mdl-chart-bound-without-geometry",
+      geometryOk ? "false" : "true"
+    );
+    root.setAttribute("data-mdl-chart-rendered-close", String(renderedClose));
+    root.setAttribute("data-mdl-chart-instance-id", chartInstanceId);
+    root.setAttribute(
+      "data-mdl-full-series-clearrect",
+      fullClear ? "true" : "false"
+    );
+  }
+
+  function paintLastCandleInPlace(canvas, payload, bars, arrays) {
+    if (!chartLayout || chartLayout.n !== bars.length) {
+      return paintFullSeries(canvas, payload, bars, arrays, true);
+    }
+    var last = bars.length - 1;
+    var hi = arrays.highs[last];
+    var lo = arrays.lows[last];
+    if (hi > chartLayout.maxP || lo < chartLayout.minP) {
+      setUpdateClass("SCALE_DOMAIN_ESCAPE");
+      return paintFullSeries(canvas, payload, bars, arrays, true);
+    }
+
+    var ctx = canvas.getContext("2d");
+    if (!ctx) {
+      markBlank(canvas, "no_2d_context");
+      return false;
+    }
+    var L = chartLayout;
+    ctx.setTransform(L.dpr, 0, 0, L.dpr, 0, 0);
+
+    function yFor(price) {
+      return L.padT + (1 - (price - L.minP) / L.span) * L.plotH;
+    }
+
+    // Clear only the last candle slot (plus a small overlap), not the full series.
+    var clearX = Math.max(0, L.padL + L.slot * (last - 0.15));
+    var clearW = Math.min(L.cssWidth - clearX, L.slot * 1.3);
+    ctx.clearRect(clearX, 0, clearW, L.cssHeight);
+    root.setAttribute("data-mdl-full-series-clearrect", "false");
+
+    var xCenter = L.padL + L.slot * (last + 0.5);
+    var yO = yFor(arrays.opens[last]);
+    var yH = yFor(arrays.highs[last]);
+    var yL = yFor(arrays.lows[last]);
+    var yC = yFor(arrays.closes[last]);
+    var up = arrays.closes[last] >= arrays.opens[last];
+    ctx.strokeStyle = up ? "#34d399" : "#f87171";
+    ctx.fillStyle = up ? "#34d399" : "#f87171";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(xCenter, yH);
+    ctx.lineTo(xCenter, yL);
+    ctx.stroke();
+    var top = Math.min(yO, yC);
+    var bodyH = Math.max(1, Math.abs(yC - yO));
+    ctx.fillRect(xCenter - L.bodyW / 2, top, L.bodyW, bodyH);
+
+    // Redraw last polyline segment from previous close to new close.
+    if (last > 0) {
+      var xPrev = L.padL + L.slot * (last - 0.5);
+      var yPrev = yFor(arrays.closes[last - 1]);
+      ctx.beginPath();
+      ctx.strokeStyle = "#93c5fd";
+      ctx.lineWidth = 1.25;
+      ctx.moveTo(xPrev, yPrev);
+      ctx.lineTo(xCenter, yC);
+      ctx.stroke();
+    }
+
+    finishCanvasAttrs(canvas, payload, bars, arrays.closes[last], true, false);
+    return true;
+  }
+
+  function classifyUpdate(prevBars, nextBars, prevSeriesDigest, nextSeriesDigest, prevMark, nextMark, prevMeta, nextMeta) {
+    if (!nextBars || !nextBars.length) return "NO_CHANGE";
+    if (!prevBars || !prevBars.length) return "NEW_CANDLE_APPEND";
+    if (prevSeriesDigest && nextSeriesDigest && prevSeriesDigest === nextSeriesDigest) {
+      if (String(prevMark) !== String(nextMark) && nextMark !== undefined) {
+        return "MARK_ONLY";
+      }
+      if (prevMeta !== nextMeta) return "METADATA_ONLY";
+      return "NO_CHANGE";
+    }
+    if (prevBars.length === nextBars.length) {
+      var last = nextBars.length - 1;
+      var sameTs = String(prevBars[last].ts) === String(nextBars[last].ts);
+      var histChanged = false;
+      var i;
+      for (i = 0; i < last; i += 1) {
+        if (
+          String(prevBars[i].ts) !== String(nextBars[i].ts) ||
+          Number(prevBars[i].open) !== Number(nextBars[i].open) ||
+          Number(prevBars[i].high) !== Number(nextBars[i].high) ||
+          Number(prevBars[i].low) !== Number(nextBars[i].low) ||
+          Number(prevBars[i].close) !== Number(nextBars[i].close)
+        ) {
+          histChanged = true;
+          break;
+        }
+      }
+      if (histChanged) return "HISTORICAL_SERIES_CHANGE";
+      if (sameTs) return "SAME_TIMESTAMP_LAST_CANDLE_CHANGE";
+      return "NEW_CANDLE_APPEND";
+    }
+    if (nextBars.length === prevBars.length + 1) return "NEW_CANDLE_APPEND";
+    return "HISTORICAL_SERIES_CHANGE";
+  }
+
+  function renderOhlcvCanvas(optionalPayload, options) {
+    options = options || {};
     var chart = root.querySelector("[data-mdl-chart]");
     var payloadNode = root.querySelector("[data-mdl-ohlcv-json]");
     var canvas = root.querySelector("[data-mdl-chart-canvas]");
@@ -115,167 +457,101 @@
       markBlank(canvas, "empty_bars");
       return;
     }
+    var arrays = extractOhlcArrays(bars);
+    if (!arrays) {
+      markBlank(canvas, "non_finite_ohlc");
+      return;
+    }
 
-    var opens = [];
-    var highs = [];
-    var lows = [];
-    var closes = [];
-    var i;
-    for (i = 0; i < bars.length; i += 1) {
-      var bar = bars[i];
-      var o = Number(bar.open);
-      var h = Number(
-        bar.display_high !== undefined && bar.display_high !== null
-          ? bar.display_high
-          : bar.high
-      );
-      var l = Number(
-        bar.display_low !== undefined && bar.display_low !== null
-          ? bar.display_low
-          : bar.low
-      );
-      var c = Number(
-        bar.display_close !== undefined && bar.display_close !== null
-          ? bar.display_close
-          : bar.close
-      );
-      if (![o, h, l, c].every(function (v) { return Number.isFinite(v); })) {
-        markBlank(canvas, "non_finite_ohlc");
-        return;
+    var mode = options.mode || "FULL_SERIES";
+    var ok;
+    if (mode === "LAST_CANDLE_IN_PLACE") {
+      ok = paintLastCandleInPlace(canvas, payload, bars, arrays);
+    } else {
+      ok = paintFullSeries(canvas, payload, bars, arrays, true);
+    }
+    if (ok) {
+      lastBars = bars.map(function (b) {
+        return {
+          ts: b.ts,
+          open: b.open,
+          high: b.high,
+          low: b.low,
+          close: b.close,
+          confirm: b.confirm,
+        };
+      });
+      lastCandleSeriesDigest =
+        payload.candle_series_digest || payload.chart_digest || "";
+      lastMetadataDigest = payload.metadata_digest || "";
+      lastMark =
+        payload.live_mark_price !== undefined ? payload.live_mark_price : null;
+    }
+  }
+
+  function applyPollPayload(body) {
+    var chart = root.querySelector("[data-mdl-chart]");
+    if (!chart) return;
+    var availability = body.availability || "";
+    if (availability) {
+      chart.setAttribute("data-availability", availability);
+    }
+    var connectionState =
+      body.data_connection_state ||
+      (availability === "MISSING_SOURCE"
+        ? "MISSING_SOURCE"
+        : availability === "STALE"
+          ? "STALE"
+          : "LIVE_DATA");
+    var payload = body.browser_payload;
+    if (!payload || !payload.bars) {
+      updateMetaFromPayload(body, availability, connectionState);
+      if (availability === "MISSING_SOURCE") setConnectionState("MISSING_SOURCE");
+      return;
+    }
+
+    var seriesDigest = payload.candle_series_digest || payload.chart_digest || "";
+    var metaDigest = payload.metadata_digest || "";
+    var mark = payload.live_mark_price;
+    var kind = classifyUpdate(
+      lastBars,
+      payload.bars,
+      lastCandleSeriesDigest,
+      seriesDigest,
+      lastMark,
+      mark,
+      lastMetadataDigest,
+      metaDigest
+    );
+    setUpdateClass(kind);
+
+    if (kind === "NO_CHANGE") {
+      updateMetaFromPayload(payload, availability, connectionState);
+      root.setAttribute("data-mdl-full-series-clearrect", "false");
+      return;
+    }
+    if (kind === "METADATA_ONLY" || kind === "MARK_ONLY") {
+      updateMetaFromPayload(payload, availability, connectionState);
+      lastMetadataDigest = metaDigest;
+      lastMark = mark;
+      var canvas = root.querySelector("[data-mdl-chart-canvas]");
+      if (canvas && mark !== undefined && mark !== null) {
+        canvas.setAttribute("data-mdl-chart-live-mark", String(mark));
       }
-      opens.push(o);
-      highs.push(h);
-      lows.push(l);
-      closes.push(c);
-    }
-
-    var stage = canvas.parentElement;
-    var cssWidth = Math.max(
-      320,
-      (stage && stage.clientWidth) || canvas.clientWidth || 640
-    );
-    var cssHeight = Math.max(
-      220,
-      (stage && stage.clientHeight) || 360
-    );
-    var dpr = window.devicePixelRatio || 1;
-    canvas.width = Math.floor(cssWidth * dpr);
-    canvas.height = Math.floor(cssHeight * dpr);
-    canvas.style.width = cssWidth + "px";
-    canvas.style.height = cssHeight + "px";
-
-    var ctx = canvas.getContext("2d");
-    if (!ctx) {
-      markBlank(canvas, "no_2d_context");
+      if (canvas && payload.captured_at) {
+        canvas.setAttribute("data-mdl-chart-captured-at", String(payload.captured_at));
+      }
+      root.setAttribute("data-mdl-full-series-clearrect", "false");
       return;
     }
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    ctx.clearRect(0, 0, cssWidth, cssHeight);
-
-    var padL = 12;
-    var padR = 12;
-    var padT = 16;
-    var padB = 28;
-    var plotW = Math.max(1, cssWidth - padL - padR);
-    var plotH = Math.max(1, cssHeight - padT - padB);
-    var minP = Math.min.apply(null, lows);
-    var maxP = Math.max.apply(null, highs);
-    if (!(Number.isFinite(minP) && Number.isFinite(maxP)) || maxP <= minP) {
-      markBlank(canvas, "degenerate_range");
+    if (kind === "SAME_TIMESTAMP_LAST_CANDLE_CHANGE") {
+      updateMetaFromPayload(payload, availability, connectionState);
+      renderOhlcvCanvas(payload, { mode: "LAST_CANDLE_IN_PLACE" });
       return;
     }
-    var span = maxP - minP;
-    minP -= span * 0.04;
-    maxP += span * 0.04;
-    span = maxP - minP;
-
-    function yFor(price) {
-      return padT + (1 - (price - minP) / span) * plotH;
-    }
-
-    var n = bars.length;
-    var slot = plotW / n;
-    var bodyW = Math.max(1, Math.min(8, slot * 0.62));
-    var drawnPixels = 0;
-
-    ctx.lineWidth = 1;
-    for (i = 0; i < n; i += 1) {
-      var xCenter = padL + slot * (i + 0.5);
-      var yO = yFor(opens[i]);
-      var yH = yFor(highs[i]);
-      var yL = yFor(lows[i]);
-      var yC = yFor(closes[i]);
-      var up = closes[i] >= opens[i];
-      ctx.strokeStyle = up ? "#34d399" : "#f87171";
-      ctx.fillStyle = up ? "#34d399" : "#f87171";
-      ctx.beginPath();
-      ctx.moveTo(xCenter, yH);
-      ctx.lineTo(xCenter, yL);
-      ctx.stroke();
-      drawnPixels += Math.abs(yL - yH);
-      var top = Math.min(yO, yC);
-      var bodyH = Math.max(1, Math.abs(yC - yO));
-      ctx.fillRect(xCenter - bodyW / 2, top, bodyW, bodyH);
-      drawnPixels += bodyW * bodyH;
-    }
-
-    // Close polyline overlay for continuous series geometry (uses display closes).
-    ctx.beginPath();
-    ctx.strokeStyle = "#93c5fd";
-    ctx.lineWidth = 1.25;
-    for (i = 0; i < n; i += 1) {
-      var x = padL + slot * (i + 0.5);
-      var y = yFor(closes[i]);
-      if (i === 0) ctx.moveTo(x, y);
-      else ctx.lineTo(x, y);
-    }
-    ctx.stroke();
-    drawnPixels += plotW;
-
-    var geometryOk = drawnPixels > 0 && canvas.width > 0 && canvas.height > 0;
-    var lastBar = bars[n - 1];
-    var renderedClose = closes[n - 1];
-    canvas.setAttribute(
-      "data-mdl-chart-geometry",
-      geometryOk ? "nonzero" : "absent"
-    );
-    canvas.setAttribute("data-mdl-chart-blank", geometryOk ? "false" : "true");
-    canvas.setAttribute("data-mdl-chart-bar-count", String(n));
-    canvas.setAttribute("data-mdl-chart-first-ts", String(bars[0].ts || ""));
-    canvas.setAttribute("data-mdl-chart-last-ts", String(bars[n - 1].ts || ""));
-    canvas.setAttribute("data-mdl-chart-rendered-close", String(renderedClose));
-    canvas.setAttribute(
-      "data-mdl-chart-candle-close",
-      String(lastBar && lastBar.close !== undefined ? lastBar.close : "")
-    );
-    if (payload.live_mark_price !== undefined && payload.live_mark_price !== null) {
-      canvas.setAttribute(
-        "data-mdl-chart-live-mark",
-        String(payload.live_mark_price)
-      );
-    }
-    if (payload.captured_at) {
-      canvas.setAttribute("data-mdl-chart-captured-at", String(payload.captured_at));
-    }
-    if (payload.chart_digest) {
-      canvas.setAttribute("data-mdl-chart-digest", String(payload.chart_digest));
-    } else if (payload.payload_digest) {
-      canvas.setAttribute("data-mdl-chart-digest", String(payload.payload_digest));
-    }
-    if (payload.instrument_id) {
-      canvas.setAttribute(
-        "data-mdl-chart-instrument",
-        String(payload.instrument_id)
-      );
-    }
-    if (payload.venue) {
-      canvas.setAttribute("data-mdl-chart-venue", String(payload.venue));
-    }
-    root.setAttribute(
-      "data-mdl-chart-bound-without-geometry",
-      geometryOk ? "false" : "true"
-    );
-    root.setAttribute("data-mdl-chart-rendered-close", String(renderedClose));
+    // NEW_CANDLE_APPEND | HISTORICAL_SERIES_CHANGE | SCALE_DOMAIN_ESCAPE
+    updateMetaFromPayload(payload, availability, connectionState);
+    renderOhlcvCanvas(payload, { mode: "FULL_SERIES" });
   }
 
   function startOhlcvPolling() {
@@ -290,7 +566,6 @@
 
     var inFlight = false;
     var timerId = null;
-    var lastChartDigest = "";
     var failStreak = 0;
     var backoffSeconds = 0;
     var MAX_BACKOFF_SECONDS = 15;
@@ -317,9 +592,7 @@
       }
       inFlight = true;
       root.setAttribute("data-mdl-ohlcv-poll-in-flight", "true");
-      if (failStreak > 0) {
-        setConnectionState("RECONNECTING");
-      }
+      if (failStreak > 0) setConnectionState("RECONNECTING");
       fetch(pollPath, {
         method: "GET",
         credentials: "same-origin",
@@ -327,9 +600,7 @@
         cache: "no-store",
       })
         .then(function (response) {
-          if (!response.ok) {
-            throw new Error("poll_http_" + response.status);
-          }
+          if (!response.ok) throw new Error("poll_http_" + response.status);
           return response.json();
         })
         .then(function (body) {
@@ -341,59 +612,13 @@
           }
           failStreak = 0;
           backoffSeconds = 0;
-          var availability = body.availability || "";
-          if (availability) {
-            chart.setAttribute("data-availability", availability);
-          }
-          var connectionState =
-            body.data_connection_state ||
-            (availability === "MISSING_SOURCE"
-              ? "MISSING_SOURCE"
-              : availability === "STALE"
-                ? "STALE"
-                : "LIVE_DATA");
-          updateMetaFromPayload(
-            body.browser_payload || body,
-            availability,
-            connectionState
-          );
-          var message = root.querySelector("[data-mdl-chart-message]");
-          if (message && body.refresh && body.refresh.refresh_error) {
-            message.setAttribute(
-              "data-mdl-ohlcv-refresh-error",
-              String(body.refresh.refresh_error)
-            );
-          } else if (message) {
-            message.removeAttribute("data-mdl-ohlcv-refresh-error");
-          }
-          if (body.browser_payload && body.browser_payload.bars) {
-            var digest =
-              body.browser_payload.chart_digest ||
-              body.browser_payload.payload_digest ||
-              "";
-            if (digest !== lastChartDigest) {
-              lastChartDigest = digest;
-              renderOhlcvCanvas(body.browser_payload);
-            } else {
-              updateMetaFromPayload(
-                body.browser_payload,
-                availability,
-                connectionState
-              );
-            }
-          } else if (
-            availability === "MISSING_SOURCE" ||
-            connectionState === "MISSING_SOURCE"
-          ) {
-            setConnectionState("MISSING_SOURCE");
-          }
+          applyPollPayload(body);
           root.setAttribute("data-mdl-ohlcv-poll-status", String(body.status || "OK"));
           root.setAttribute("data-mdl-ohlcv-poll-ok", "true");
           root.removeAttribute("data-mdl-ohlcv-poll-error");
         })
         .catch(function (err) {
           failStreak += 1;
-          // Bounded exponential backoff: 1, 2, 4, … capped — no tight retry loop.
           backoffSeconds = Math.min(
             MAX_BACKOFF_SECONDS,
             Math.max(1, Math.pow(2, Math.min(failStreak - 1, 3)))
@@ -407,11 +632,9 @@
             "data-mdl-ohlcv-poll-backoff-seconds",
             String(backoffSeconds)
           );
-          if (failStreak >= STALE_AFTER_FAILURES) {
-            setConnectionState("STALE");
-          } else {
-            setConnectionState("RECONNECTING");
-          }
+          setConnectionState(
+            failStreak >= STALE_AFTER_FAILURES ? "STALE" : "RECONNECTING"
+          );
         })
         .then(function () {
           inFlight = false;
@@ -431,6 +654,16 @@
     scheduleNext();
   }
 
+  function onViewportResize() {
+    // True viewport/layout resize only — full series re-render once with CSS box.
+    if (!lastBars || !lastBars.length) {
+      renderOhlcvCanvas();
+      return;
+    }
+    setUpdateClass("VIEWPORT_RESIZE");
+    renderOhlcvCanvas(null, { mode: "FULL_SERIES" });
+  }
+
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", function () {
       renderOhlcvCanvas();
@@ -440,7 +673,5 @@
     renderOhlcvCanvas();
     startOhlcvPolling();
   }
-  window.addEventListener("resize", function () {
-    renderOhlcvCanvas();
-  });
+  window.addEventListener("resize", onViewportResize);
 })();

--- a/templates/peak_trade_dashboard/market_landscape_v2.html
+++ b/templates/peak_trade_dashboard/market_landscape_v2.html
@@ -104,6 +104,11 @@
         >
           <div class="mdl-v2-chart__chrome">
             <h2>Chart</h2>
+            <span
+              class="mdl-v2-state"
+              data-mdl-data-connection-state="true"
+              data-connection-state="{{ chart.data_connection_state }}"
+            >{{ chart.data_connection_state }}</span>
             <span class="mdl-v2-state" data-availability="{{ chart.availability }}" data-mdl-chart-availability="true">{{ chart.availability_label }}</span>
           </div>
           <dl class="mdl-v2-chart__meta" data-mdl-ohlcv-meta="true" aria-label="OHLCV freshness">
@@ -118,6 +123,10 @@
             <div>
               <dt>Captured</dt>
               <dd data-mdl-field="ohlcv_captured_at">{% if chart.captured_at %}{{ chart.captured_at }}{% else %}—{% endif %}</dd>
+            </div>
+            <div>
+              <dt>Mark</dt>
+              <dd data-mdl-field="ohlcv_live_mark">{% if chart.live_mark_price is not none %}{{ chart.live_mark_price }}{% else %}—{% endif %}</dd>
             </div>
             <div>
               <dt>Freshness</dt>

--- a/templates/peak_trade_dashboard/market_landscape_v2.html
+++ b/templates/peak_trade_dashboard/market_landscape_v2.html
@@ -111,13 +111,13 @@
             >{{ chart.data_connection_state }}</span>
             <span class="mdl-v2-state" data-availability="{{ chart.availability }}" data-mdl-chart-availability="true">{{ chart.availability_label }}</span>
           </div>
-          <dl class="mdl-v2-chart__meta" data-mdl-ohlcv-meta="true" aria-label="OHLCV freshness">
+          <dl class="mdl-v2-chart__meta" data-mdl-ohlcv-meta="true" aria-label="Open candle OHLCV and freshness">
             <div>
               <dt>Interval</dt>
               <dd data-mdl-field="ohlcv_interval">{% if chart.interval %}{{ chart.interval }}{% else %}—{% endif %}</dd>
             </div>
             <div>
-              <dt>Latest candle</dt>
+              <dt>Candle start</dt>
               <dd data-mdl-field="ohlcv_latest_candle_at">{% if chart.last_timestamp %}{{ chart.last_timestamp }}{% else %}—{% endif %}</dd>
             </div>
             <div>
@@ -129,11 +129,28 @@
               <dd data-mdl-field="ohlcv_live_mark">{% if chart.live_mark_price is not none %}{{ chart.live_mark_price }}{% else %}—{% endif %}</dd>
             </div>
             <div>
-              <dt>Freshness</dt>
-              <dd
-                data-mdl-field="ohlcv_freshness"
-                data-availability="{{ chart.availability }}"
-              >{% if chart.freshness_state %}{{ chart.freshness_state|upper }}{% else %}{{ chart.availability_label }}{% endif %}</dd>
+              <dt>Revision</dt>
+              <dd data-mdl-field="ohlcv_revision">{% if chart.ohlcv_revision_kind %}{{ chart.ohlcv_revision_kind }}{% else %}—{% endif %}</dd>
+            </div>
+            <div>
+              <dt>Open</dt>
+              <dd data-mdl-field="ohlcv_open">{% if chart.open_price is not none %}{{ chart.open_price }}{% else %}—{% endif %}</dd>
+            </div>
+            <div>
+              <dt>High</dt>
+              <dd data-mdl-field="ohlcv_high">{% if chart.high_price is not none %}{{ chart.high_price }}{% else %}—{% endif %}</dd>
+            </div>
+            <div>
+              <dt>Low</dt>
+              <dd data-mdl-field="ohlcv_low">{% if chart.low_price is not none %}{{ chart.low_price }}{% else %}—{% endif %}</dd>
+            </div>
+            <div>
+              <dt>Close</dt>
+              <dd data-mdl-field="ohlcv_close">{% if chart.close_price is not none %}{{ chart.close_price }}{% else %}—{% endif %}</dd>
+            </div>
+            <div>
+              <dt>Volume</dt>
+              <dd data-mdl-field="ohlcv_volume">{% if chart.volume is not none %}{{ chart.volume }}{% else %}—{% endif %}</dd>
             </div>
           </dl>
           <div class="mdl-v2-chart__stage" role="img" aria-label="{{ chart.message }}" data-mdl-chart-stage="true">

--- a/tests/ops/test_okx_public_trades_open_candle_v1.py
+++ b/tests/ops/test_okx_public_trades_open_candle_v1.py
@@ -1,0 +1,213 @@
+"""Public OKX trades allowlist + open-candle trade reducer contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from src.ops.okx_public_market_data_client_v1 import (
+    ALLOWED_PATHS,
+    OkxPublicMarketDataClientError,
+    OkxPublicMarketDataClientV1,
+)
+from src.ops.okx_selected_instrument_ohlcv_readmodel_v1 import (
+    OKX_TRADES_PATH,
+    OhlcvBarV1,
+    OkxPublicTradeV1,
+    apply_okx_public_trades_to_open_candle_v1,
+    parse_okx_public_trades_v1,
+    reduce_okx_ohlcv_bars_v1,
+)
+
+
+def _ms(iso: str) -> str:
+    dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    return str(int(dt.timestamp() * 1000))
+
+
+def _bar(
+    *,
+    ts: str,
+    o: str,
+    h: str,
+    l: str,
+    c: str,
+    v: str,
+    confirm: bool = False,
+) -> OhlcvBarV1:
+    return OhlcvBarV1(
+        ts=ts,
+        open=o,
+        high=h,
+        low=l,
+        close=c,
+        volume=v,
+        volume_ccy=None,
+        confirm=confirm,
+        provider_ts_ms="0",
+    )
+
+
+def _trade(
+    *,
+    trade_id: str,
+    px: str,
+    sz: str,
+    ts_ms: str,
+    side: str = "buy",
+) -> OkxPublicTradeV1:
+    from src.ops.okx_captured_at_freshness_policy_v1 import provider_ms_to_utc_iso
+
+    ts = provider_ms_to_utc_iso(ts_ms)
+    assert ts is not None
+    return OkxPublicTradeV1(
+        trade_id=trade_id,
+        price=px,
+        size=sz,
+        side=side,
+        ts=ts,
+        provider_ts_ms=ts_ms,
+    )
+
+
+def test_public_trades_path_allowed_private_paths_rejected() -> None:
+    assert OKX_TRADES_PATH in ALLOWED_PATHS
+    client = OkxPublicMarketDataClientV1(
+        fetcher=lambda url, timeout: (200, b'{"code":"0","msg":"","data":[]}')
+    )
+    env = client.get_json(OKX_TRADES_PATH, {"instId": "SATS-USDT-SWAP", "limit": "5"})
+    assert env.request_path == OKX_TRADES_PATH
+    assert env.provider_code == "0"
+
+    forbidden = [
+        "/api/v5/account/balance",
+        "/api/v5/trade/order",
+        "/api/v5/trade/orders-pending",
+        "/api/v5/account/positions",
+        "/api/v5/account/set-leverage",
+        "/api/v5/users/subaccount/list",
+    ]
+    for path in forbidden:
+        with pytest.raises(OkxPublicMarketDataClientError, match="PATH_NOT_ALLOWED"):
+            client.get_json(path, {})
+
+
+def test_same_bucket_trade_revises_final_candle_and_dedupes() -> None:
+    t0 = "2026-07-25T00:00:00Z"
+    bars = [_bar(ts=t0, o="100", h="102", l="99", c="101", v="10", confirm=False)]
+    seed_trade = _trade(trade_id="t0", px="101", sz="1", ts_ms=_ms("2026-07-25T00:05:00Z"))
+    bars_s, kind_s, applied_s, meta_s = apply_okx_public_trades_to_open_candle_v1(
+        bars, [seed_trade], previously_applied_trade_ids=None
+    )
+    assert kind_s == "NO_OP"
+    assert meta_s["seeded"] is True
+    assert applied_s == ["t0"]
+    assert bars_s[0].close == "101"
+    assert bars_s[0].volume == "10"
+
+    t1 = _trade(trade_id="t1", px="103", sz="2", ts_ms=_ms("2026-07-25T00:10:00Z"))
+    t2 = _trade(trade_id="t2", px="98", sz="3", ts_ms=_ms("2026-07-25T00:12:00Z"))
+    bars_r, kind_r, applied_r, meta_r = apply_okx_public_trades_to_open_candle_v1(
+        bars_s, [seed_trade, t1, t2], previously_applied_trade_ids=applied_s
+    )
+    assert kind_r == "SAME_TIMESTAMP_REVISION"
+    assert meta_r["new_trade_count"] == 2
+    assert len(bars_r) == 1
+    assert bars_r[0].open == "100"
+    assert bars_r[0].high == "103"
+    assert bars_r[0].low == "98"
+    assert bars_r[0].close == "98"
+    assert bars_r[0].volume == "15"  # 10 + 2 + 3
+    assert set(applied_r) == {"t0", "t1", "t2"}
+
+    # Duplicate trade IDs must not double-count volume.
+    bars_d, kind_d, applied_d, meta_d = apply_okx_public_trades_to_open_candle_v1(
+        bars_r, [seed_trade, t1, t2], previously_applied_trade_ids=applied_r
+    )
+    assert kind_d == "NO_OP"
+    assert meta_d["duplicate_trade_count"] == 3
+    assert bars_d[0].volume == "15"
+    assert applied_d == applied_r
+
+
+def test_next_bucket_trade_appends_exactly_one_candle() -> None:
+    t0 = "2026-07-25T00:00:00Z"
+    t1 = "2026-07-25T01:00:00Z"
+    bars = [_bar(ts=t0, o="100", h="102", l="99", c="101", v="10", confirm=False)]
+    _, _, applied, _ = apply_okx_public_trades_to_open_candle_v1(
+        bars,
+        [_trade(trade_id="seed", px="101", sz="1", ts_ms=_ms("2026-07-25T00:05:00Z"))],
+        previously_applied_trade_ids=None,
+    )
+    nxt = _trade(trade_id="n1", px="110", sz="4", ts_ms=_ms("2026-07-25T01:00:05Z"))
+    bars_n, kind_n, applied_n, meta_n = apply_okx_public_trades_to_open_candle_v1(
+        bars, [nxt], previously_applied_trade_ids=applied
+    )
+    assert kind_n == "NEW_INTERVAL_APPEND"
+    assert meta_n["new_trade_count"] == 1
+    assert len(bars_n) == 2
+    assert bars_n[0].ts == t0
+    assert bars_n[0].confirm is True
+    assert bars_n[0].close == "101"
+    assert bars_n[1].ts == t1
+    assert bars_n[1].open == "110"
+    assert bars_n[1].close == "110"
+    assert bars_n[1].volume == "4"
+    assert "n1" in applied_n
+
+
+def test_old_trade_before_tip_is_ignored() -> None:
+    t0 = "2026-07-25T01:00:00Z"
+    bars = [_bar(ts=t0, o="100", h="100", l="100", c="100", v="1", confirm=False)]
+    _, _, applied, _ = apply_okx_public_trades_to_open_candle_v1(
+        bars, [], previously_applied_trade_ids=[]
+    )
+    old = _trade(trade_id="old", px="90", sz="9", ts_ms=_ms("2026-07-25T00:30:00Z"))
+    bars_o, kind_o, _, meta_o = apply_okx_public_trades_to_open_candle_v1(
+        bars, [old], previously_applied_trade_ids=applied
+    )
+    assert kind_o == "NO_OP"
+    assert meta_o["old_trade_count"] == 1
+    assert bars_o[0].close == "100"
+    assert bars_o[0].volume == "1"
+
+
+def test_candle_reducer_same_timestamp_numeric_contract() -> None:
+    """Deterministic A/B contract: same-ts OHLCV change vs identical NO_OP."""
+    t0 = "2026-07-25T00:00:00Z"
+    existing = [_bar(ts=t0, o="100", h="102", l="99", c="101", v="10", confirm=False)]
+    incoming = [_bar(ts=t0, o="100", h="103", l="98", c="102", v="12", confirm=False)]
+    bars, kind = reduce_okx_ohlcv_bars_v1(existing, incoming)
+    assert kind == "SAME_TIMESTAMP_REVISION"
+    assert kind != "NO_OP"
+    assert len(bars) == 1
+    assert bars[0].high == "103"
+    assert bars[0].low == "98"
+    assert bars[0].close == "102"
+    assert bars[0].volume == "12"
+    bars_n, kind_n = reduce_okx_ohlcv_bars_v1(bars, incoming)
+    assert kind_n == "NO_OP"
+
+
+def test_parse_okx_public_trades_newest_first_input() -> None:
+    rows = [
+        {
+            "instId": "SATS-USDT-SWAP",
+            "tradeId": "2",
+            "px": "0.000000009200",
+            "sz": "3",
+            "side": "sell",
+            "ts": _ms("2026-07-25T00:10:00Z"),
+        },
+        {
+            "instId": "SATS-USDT-SWAP",
+            "tradeId": "1",
+            "px": "0.000000009100",
+            "sz": "1",
+            "side": "buy",
+            "ts": _ms("2026-07-25T00:00:00Z"),
+        },
+    ]
+    parsed = parse_okx_public_trades_v1(rows)
+    assert [t.trade_id for t in parsed] == ["1", "2"]

--- a/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py
@@ -135,6 +135,7 @@ def test_landscape_package_stdlib_and_relative_only() -> None:
         "dataclasses",
         "datetime",
         "enum",
+        "hashlib",
         "json",
         "typing",
         "__future__",

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -387,10 +387,10 @@ def test_market_page_exposes_poll_contract_and_no_order_controls(
     assert "kraken" not in html.lower() or "historical" in html.lower()
 
 
-def test_open_candle_mark_update_same_timestamp_changes_chart_not_metadata_only(
+def test_open_candle_mark_update_same_timestamp_is_mark_only_not_geometry(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Same candle ts + changed mark ⇒ chart_digest moves; captured_at-only is insufficient."""
+    """Same candle ts + changed mark ⇒ candle_series_digest stable; mark never mutates close."""
     from src.webui.market_dashboard_landscape_v2.presenter import (
         serialize_ohlcv_browser_payload_v1,
     )
@@ -424,7 +424,10 @@ def test_open_candle_mark_update_same_timestamp_changes_chart_not_metadata_only(
     close1 = first_payload["bars"][-1]["close"]
     display1 = first_payload["bars"][-1]["display_close"]
     chart1 = first_payload["chart_digest"]
+    series1 = first_payload["candle_series_digest"]
+    meta1 = first_payload["metadata_digest"]
     assert first_payload["bars"][-1]["provisional"] is True
+    assert chart1 == series1
 
     second_client = _FakeOkxClient(
         captured_at="2026-07-25T00:00:03Z",
@@ -447,11 +450,15 @@ def test_open_candle_mark_update_same_timestamp_changes_chart_not_metadata_only(
     close2 = second_payload["bars"][-1]["close"]
     display2 = second_payload["bars"][-1]["display_close"]
     chart2 = second_payload["chart_digest"]
+    series2 = second_payload["candle_series_digest"]
+    meta2 = second_payload["metadata_digest"]
     assert ts1 == ts2
     assert close1 == close2
-    assert display1 != display2
-    assert display2 == pytest.approx(9.25e-09)
-    assert chart1 != chart2
+    assert display1 == display2
+    assert display2 == pytest.approx(9.1e-09)
+    assert chart1 == chart2
+    assert series1 == series2
+    assert meta1 != meta2
     assert second_payload["live_mark_price"] == pytest.approx(9.25e-09)
     # Closed bars remain ordered / not duplicated.
     bars = second_payload["bars"]
@@ -530,16 +537,92 @@ def test_captured_at_only_does_not_change_chart_digest(
     second_payload = serialize_ohlcv_browser_payload_v1(second_doc)
     assert first_payload is not None and second_payload is not None
     assert first_payload["chart_digest"] == second_payload["chart_digest"]
+    assert first_payload["candle_series_digest"] == second_payload["candle_series_digest"]
+    assert first_payload["metadata_digest"] != second_payload["metadata_digest"]
     assert first_payload["captured_at"] != second_payload["captured_at"]
     assert first_payload["payload_digest"] != second_payload["payload_digest"]
 
 
-def test_js_uses_display_close_and_chart_digest_not_okx_host() -> None:
+def test_same_timestamp_ohlc_change_moves_candle_series_digest_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Authentic O/H/L/C change at same open-candle ts must move candle_series_digest."""
+    from src.webui.market_dashboard_landscape_v2.presenter import (
+        serialize_ohlcv_browser_payload_v1,
+    )
+
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive)
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=_FakeOkxClient(  # type: ignore[arg-type]
+            captured_at="2026-07-25T00:00:00Z",
+            close_px="0.000000009100",
+            mark_px="0.000000009100",
+        ),
+    )
+    path = archive / "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
+    first_payload = serialize_ohlcv_browser_payload_v1(json.loads(path.read_text(encoding="utf-8")))
+    assert first_payload is not None
+    refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
+        archive_root=archive,
+        client=_FakeOkxClient(  # type: ignore[arg-type]
+            captured_at="2026-07-25T00:00:03Z",
+            close_px="0.000000009220",
+            mark_px="0.000000009220",
+        ),
+        force=True,
+    )
+    second_payload = serialize_ohlcv_browser_payload_v1(
+        json.loads(path.read_text(encoding="utf-8"))
+    )
+    assert second_payload is not None
+    assert first_payload["last_timestamp"] == second_payload["last_timestamp"]
+    assert first_payload["bars"][-1]["close"] != second_payload["bars"][-1]["close"]
+    assert first_payload["candle_series_digest"] != second_payload["candle_series_digest"]
+    assert first_payload["chart_digest"] != second_payload["chart_digest"]
+    assert second_payload["bars"][-1]["display_close"] == second_payload["bars"][-1]["close"]
+
+
+def test_js_layout_stability_and_update_classification_contracts() -> None:
     js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
-    assert "display_close" in js
-    assert "chart_digest" in js
+    css = (REPO / "static/css/market_dashboard_landscape_v2.css").read_text(encoding="utf-8")
+    assert "candle_series_digest" in js
+    assert "metadata_digest" in js
+    assert "SAME_TIMESTAMP_LAST_CANDLE_CHANGE" in js
+    assert "MARK_ONLY" in js
+    assert "METADATA_ONLY" in js
+    assert "LAST_CANDLE_IN_PLACE" in js
+    assert "resolveCssBox" in js
+    assert "syncBackingStore" in js
+    assert "devicePixelRatio" in js
+    # Must not feed stage/clientHeight back into canvas.style.height (growth loop).
+    assert "canvas.style.height" not in js
+    assert "canvas.style.width" not in js
+    assert "stage.scrollHeight" not in js
+    assert "stage.clientHeight || 360" not in js
+    assert "Math.max(220, stage.clientHeight" not in js
+    assert "www.okx.com" not in js
+    assert "wss://ws.okx.com" not in js
+    assert "kraken" not in js.lower()
     assert "RECONNECTING" in js
     assert "MAX_BACKOFF_SECONDS" in js
+    # CSS owns fixed stage/meta bands.
+    assert "--mdl-stage-height" in css
+    assert "max-height: var(--mdl-stage-height)" in css
+    assert "max-height: 2.75rem" in css
+    assert "text-overflow: ellipsis" in css
+
+
+def test_js_uses_chart_digest_alias_and_never_okx_host() -> None:
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+    assert "chart_digest" in js
     assert "www.okx.com" not in js
     assert "wss://ws.okx.com" not in js
     assert "kraken" not in js.lower()

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -34,15 +34,57 @@ def _iso(dt: datetime) -> str:
 
 
 class _FakeOkxClient:
-    def __init__(self, *, captured_at: str, close_px: str = "0.000000009176") -> None:
+    def __init__(
+        self,
+        *,
+        captured_at: str,
+        close_px: str = "0.000000009176",
+        mark_px: str | None = None,
+    ) -> None:
         self.captured_at = captured_at
         self.close_px = close_px
+        self.mark_px = mark_px if mark_px is not None else close_px
         self.calls = 0
+        self.paths: list[str] = []
 
     def get_json(self, path: str, params: dict[str, str]) -> OkxPublicCaptureEnvelopeV1:
-        assert path == "/api/v5/market/history-candles"
-        assert params["instId"] == INSTRUMENT
         self.calls += 1
+        self.paths.append(path)
+        if path == "/api/v5/public/mark-price":
+            assert params["instId"] == INSTRUMENT
+            assert params["instType"] == "SWAP"
+            body = json.dumps(
+                {
+                    "code": "0",
+                    "msg": "",
+                    "data": [
+                        {
+                            "instId": INSTRUMENT,
+                            "instType": "SWAP",
+                            "markPx": self.mark_px,
+                            "ts": "1784934000123",
+                        }
+                    ],
+                }
+            )
+            return OkxPublicCaptureEnvelopeV1(
+                request_url=f"https://www.okx.com{path}?instId={INSTRUMENT}",
+                request_path=path,
+                query_parameters=dict(params),
+                http_status=200,
+                provider_code="0",
+                provider_message="",
+                capture_started_at=self.captured_at,
+                response_received_at=self.captured_at,
+                captured_at=self.captured_at,
+                effective_at=self.captured_at,
+                provider_timestamp=None,
+                raw_payload_digest="b" * 64,
+                byte_size=len(body.encode("utf-8")),
+                raw_body_utf8=body,
+            )
+        assert path == "/api/v5/market/candles"
+        assert params["instId"] == INSTRUMENT
         start = datetime(2026, 7, 20, 18, 0, 0, tzinfo=timezone.utc)
         rows: list[list[str]] = []
         for i in range(100):
@@ -171,7 +213,10 @@ def test_authentic_okx_maps_and_newer_snapshot_advances(
     assert second["ohlcv"]["instrument_id"] == INSTRUMENT
     assert second["ohlcv"]["venue"] == "okx"
     assert second["ohlcv"]["bars"][-1]["close"] == "0.000000009500"
-    assert client_b.calls == 1
+    assert second["ohlcv"]["live_mark_price"] == "0.000000009500"
+    assert "/api/v5/market/candles" in client_b.paths
+    assert "/api/v5/public/mark-price" in client_b.paths
+    assert client_b.calls == 2
 
 
 def test_provider_failure_does_not_fabricate_or_advance(
@@ -330,6 +375,9 @@ def test_market_page_exposes_poll_contract_and_no_order_controls(
     assert 'data-mdl-field="ohlcv_captured_at"' in html
     assert 'data-mdl-field="ohlcv_latest_candle_at"' in html
     assert 'data-mdl-field="ohlcv_freshness"' in html
+    assert 'data-mdl-field="ohlcv_live_mark"' in html
+    assert "data-mdl-data-connection-state" in html
+    assert "LIVE_DATA" in html or "MISSING_SOURCE" in html or "STALE" in html
     assert "OKX" in html
     assert INSTRUMENT in html
     assert "www.okx.com" not in html
@@ -337,6 +385,174 @@ def test_market_page_exposes_poll_contract_and_no_order_controls(
     assert "place order" not in html.lower()
     assert "LIVE_AUTHORIZED" not in html or 'content="false"' in html
     assert "kraken" not in html.lower() or "historical" in html.lower()
+
+
+def test_open_candle_mark_update_same_timestamp_changes_chart_not_metadata_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same candle ts + changed mark ⇒ chart_digest moves; captured_at-only is insufficient."""
+    from src.webui.market_dashboard_landscape_v2.presenter import (
+        serialize_ohlcv_browser_payload_v1,
+    )
+
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive)
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    first_client = _FakeOkxClient(
+        captured_at="2026-07-25T00:00:00Z",
+        close_px="0.000000009100",
+        mark_px="0.000000009100",
+    )
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=first_client,  # type: ignore[arg-type]
+    )
+    path = archive / "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
+    first_doc = json.loads(path.read_text(encoding="utf-8"))
+    # Honest freshness for connection-state projection (synthetic bars are aged).
+    first_doc["freshness_state"] = "fresh"
+    first_doc["is_stale"] = False
+    path.write_text(json.dumps(first_doc, indent=2) + "\n", encoding="utf-8")
+    first_payload = serialize_ohlcv_browser_payload_v1(first_doc)
+    assert first_payload is not None
+    ts1 = first_payload["last_timestamp"]
+    close1 = first_payload["bars"][-1]["close"]
+    display1 = first_payload["bars"][-1]["display_close"]
+    chart1 = first_payload["chart_digest"]
+    assert first_payload["bars"][-1]["provisional"] is True
+
+    second_client = _FakeOkxClient(
+        captured_at="2026-07-25T00:00:03Z",
+        close_px="0.000000009100",
+        mark_px="0.000000009250",
+    )
+    refreshed = refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
+        archive_root=archive,
+        client=second_client,  # type: ignore[arg-type]
+        force=True,
+    )
+    assert refreshed["status"] == "OK"
+    second_doc = json.loads(path.read_text(encoding="utf-8"))
+    second_doc["freshness_state"] = "fresh"
+    second_doc["is_stale"] = False
+    path.write_text(json.dumps(second_doc, indent=2) + "\n", encoding="utf-8")
+    second_payload = serialize_ohlcv_browser_payload_v1(second_doc)
+    assert second_payload is not None
+    ts2 = second_payload["last_timestamp"]
+    close2 = second_payload["bars"][-1]["close"]
+    display2 = second_payload["bars"][-1]["display_close"]
+    chart2 = second_payload["chart_digest"]
+    assert ts1 == ts2
+    assert close1 == close2
+    assert display1 != display2
+    assert display2 == pytest.approx(9.25e-09)
+    assert chart1 != chart2
+    assert second_payload["live_mark_price"] == pytest.approx(9.25e-09)
+    # Closed bars remain ordered / not duplicated.
+    bars = second_payload["bars"]
+    assert len(bars) == 100
+    assert [b["ts"] for b in bars] == sorted(b["ts"] for b in bars)
+    assert len({b["ts"] for b in bars}) == 100
+    # Closed candle OHLC unchanged relative to first refresh for early bars.
+    assert first_payload["bars"][0]["close"] == bars[0]["close"]
+    assert bars[0]["confirm"] is True
+
+    # Poll response connection state with injected skip refresh (no live OKX).
+    def _skip(**kwargs: Any) -> dict[str, Any]:
+        retained = json.loads(path.read_text(encoding="utf-8"))
+        retained["freshness_state"] = "fresh"
+        retained["is_stale"] = False
+        return {
+            "status": "SKIPPED_RECENT",
+            "refresh_attempted": False,
+            "selected_instrument": INSTRUMENT,
+            "selected_venue": "okx",
+            "captured_at": retained.get("captured_at"),
+            "last_timestamp": retained.get("last_timestamp"),
+            "ohlcv": retained,
+        }
+
+    import src.ops.okx_selected_instrument_ohlcv_readmodel_v1 as ohlcv_mod
+
+    monkeypatch.setattr(
+        ohlcv_mod,
+        "refresh_selected_okx_ohlcv_readmodel_from_archive_v1",
+        _skip,
+    )
+    poll = build_ohlcv_poll_response_v1(force_refresh=False)
+    assert poll["data_connection_state"] == "LIVE_DATA"
+    assert poll["direct_browser_okx"] is False
+    assert poll["orders"] is False
+
+
+def test_captured_at_only_does_not_change_chart_digest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from src.webui.market_dashboard_landscape_v2.presenter import (
+        serialize_ohlcv_browser_payload_v1,
+    )
+
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive)
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    client_a = _FakeOkxClient(
+        captured_at="2026-07-25T00:00:00Z",
+        close_px="0.000000009100",
+        mark_px="0.000000009100",
+    )
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=client_a,  # type: ignore[arg-type]
+    )
+    path = archive / "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
+    first_payload = serialize_ohlcv_browser_payload_v1(json.loads(path.read_text(encoding="utf-8")))
+    client_b = _FakeOkxClient(
+        captured_at="2026-07-25T00:00:05Z",
+        close_px="0.000000009100",
+        mark_px="0.000000009100",
+    )
+    refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
+        archive_root=archive,
+        client=client_b,  # type: ignore[arg-type]
+        force=True,
+    )
+    second_doc = json.loads(path.read_text(encoding="utf-8"))
+    second_payload = serialize_ohlcv_browser_payload_v1(second_doc)
+    assert first_payload is not None and second_payload is not None
+    assert first_payload["chart_digest"] == second_payload["chart_digest"]
+    assert first_payload["captured_at"] != second_payload["captured_at"]
+    assert first_payload["payload_digest"] != second_payload["payload_digest"]
+
+
+def test_js_uses_display_close_and_chart_digest_not_okx_host() -> None:
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+    assert "display_close" in js
+    assert "chart_digest" in js
+    assert "RECONNECTING" in js
+    assert "MAX_BACKOFF_SECONDS" in js
+    assert "www.okx.com" not in js
+    assert "wss://ws.okx.com" not in js
+    assert "kraken" not in js.lower()
+
+
+def test_poll_interval_targets_visible_intrabar_feedback() -> None:
+    from src.webui.market_dashboard_landscape_v2.presenter import (
+        OHLCV_POLL_INTERVAL_SECONDS,
+    )
+
+    assert DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS <= 5
+    assert DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS >= 1
+    assert OHLCV_POLL_INTERVAL_SECONDS == DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS
 
 
 def test_stale_and_missing_source_fail_closed(

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -558,9 +558,13 @@ def test_market_page_exposes_poll_contract_and_no_order_controls(
     )
     assert 'data-mdl-field="ohlcv_captured_at"' in html
     assert 'data-mdl-field="ohlcv_latest_candle_at"' in html
-    assert 'data-mdl-field="ohlcv_freshness"' in html
+    assert 'data-mdl-field="ohlcv_open"' in html
+    assert 'data-mdl-field="ohlcv_close"' in html
+    assert 'data-mdl-field="ohlcv_volume"' in html
+    assert 'data-mdl-field="ohlcv_revision"' in html
     assert 'data-mdl-field="ohlcv_live_mark"' in html
     assert "data-mdl-data-connection-state" in html
+    assert 'data-mdl-decision-strip="true"' in html
     assert "LIVE_DATA" in html or "MISSING_SOURCE" in html or "STALE" in html
     assert "OKX" in html
     assert INSTRUMENT in html
@@ -783,6 +787,9 @@ def test_same_timestamp_ohlc_change_moves_candle_series_digest_only(
 def test_js_layout_stability_and_update_classification_contracts() -> None:
     js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
     css = (REPO / "static/css/market_dashboard_landscape_v2.css").read_text(encoding="utf-8")
+    html = (REPO / "templates/peak_trade_dashboard/market_landscape_v2.html").read_text(
+        encoding="utf-8"
+    )
     assert "candle_series_digest" in js
     assert "metadata_digest" in js
     assert "SAME_TIMESTAMP_LAST_CANDLE_CHANGE" in js
@@ -791,6 +798,10 @@ def test_js_layout_stability_and_update_classification_contracts() -> None:
     assert "LAST_CANDLE_IN_PLACE" in js
     assert "volume" in js
     assert "data-mdl-chart-candle-volume" in js
+    assert 'data-mdl-field="ohlcv_open"' in js or 'data-mdl-field="ohlcv_open"' in html
+    assert 'data-mdl-field="ohlcv_close"' in html
+    assert 'data-mdl-field="ohlcv_volume"' in html
+    assert 'data-mdl-field="ohlcv_revision"' in html
     assert "resolveCssBox" in js
     assert "syncBackingStore" in js
     assert "devicePixelRatio" in js
@@ -805,11 +816,75 @@ def test_js_layout_stability_and_update_classification_contracts() -> None:
     assert "kraken" not in js.lower()
     assert "RECONNECTING" in js
     assert "MAX_BACKOFF_SECONDS" in js
-    # CSS owns fixed stage/meta bands.
+    # CSS owns fixed stage/meta bands; chart must not flex-grow the Decision strip away.
     assert "--mdl-stage-height" in css
     assert "max-height: var(--mdl-stage-height)" in css
-    assert "max-height: 2.75rem" in css
+    assert "--mdl-chart-meta-band" in css
+    assert "flex: 0 0 auto" in css
+    assert "min(56vh, 580px)" not in css
+    assert 'data-mdl-decision-strip="true"' in html
     assert "text-overflow: ellipsis" in css
+
+
+def test_live_data_requires_fresh_ohlcv_source_not_mark_cosmetics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from src.webui.market_dashboard_landscape_v2.presenter import (
+        _ohlcv_data_connection_state,
+        serialize_ohlcv_browser_payload_v1,
+    )
+    from src.webui.market_dashboard_landscape_v2.availability import Availability
+
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive)
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=_FakeOkxClient(captured_at="2026-07-25T00:00:00Z"),
+    )
+    path = archive / "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    doc["freshness_state"] = "fresh"
+    doc["is_stale"] = False
+    payload = serialize_ohlcv_browser_payload_v1(doc)
+    assert payload is not None
+    assert (
+        _ohlcv_data_connection_state(
+            browser_payload=payload,
+            ohlcv_payload=doc,
+            chart_availability=Availability.AVAILABLE,
+        )
+        == "LIVE_DATA"
+    )
+    # Stale OHLCV source must not claim LIVE_DATA even if captured_at text exists.
+    stale = dict(doc)
+    stale["freshness_state"] = "stale"
+    stale["is_stale"] = True
+    assert (
+        _ohlcv_data_connection_state(
+            browser_payload=payload,
+            ohlcv_payload=stale,
+            chart_availability=Availability.STALE,
+        )
+        == "STALE"
+    )
+    # Missing candle capture clock → not LIVE_DATA.
+    no_cap = dict(doc)
+    no_cap.pop("candle_captured_at", None)
+    no_cap["captured_at"] = None
+    assert (
+        _ohlcv_data_connection_state(
+            browser_payload=payload,
+            ohlcv_payload=no_cap,
+            chart_availability=Availability.AVAILABLE,
+        )
+        == "MISSING_SOURCE"
+    )
 
 
 def test_js_uses_chart_digest_alias_and_never_okx_host() -> None:

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -70,6 +70,7 @@ class _FakeOkxClient:
         low_px: str | None = None,
         open_px: str | None = None,
         volume: str = "10",
+        trades: list[dict[str, str]] | None = None,
     ) -> None:
         self.captured_at = captured_at
         self.close_px = close_px
@@ -78,6 +79,7 @@ class _FakeOkxClient:
         self.low_px = low_px if low_px is not None else close_px
         self.volume = volume
         self.mark_px = mark_px if mark_px is not None else close_px
+        self.trades = list(trades or [])
         self.calls = 0
         self.paths: list[str] = []
 
@@ -114,6 +116,25 @@ class _FakeOkxClient:
                 effective_at=self.captured_at,
                 provider_timestamp=None,
                 raw_payload_digest="b" * 64,
+                byte_size=len(body.encode("utf-8")),
+                raw_body_utf8=body,
+            )
+        if path == "/api/v5/market/trades":
+            assert params["instId"] == INSTRUMENT
+            body = json.dumps({"code": "0", "msg": "", "data": self.trades})
+            return OkxPublicCaptureEnvelopeV1(
+                request_url=f"https://www.okx.com{path}?instId={INSTRUMENT}",
+                request_path=path,
+                query_parameters=dict(params),
+                http_status=200,
+                provider_code="0",
+                provider_message="",
+                capture_started_at=self.captured_at,
+                response_received_at=self.captured_at,
+                captured_at=self.captured_at,
+                effective_at=self.captured_at,
+                provider_timestamp=None,
+                raw_payload_digest="c" * 64,
                 byte_size=len(body.encode("utf-8")),
                 raw_body_utf8=body,
             )
@@ -399,8 +420,93 @@ def test_authentic_okx_maps_and_newer_snapshot_advances(
     assert second["ohlcv"]["live_mark_price"] == "0.000000009500"
     assert second["ohlcv"].get("ohlcv_revision_kind") == "SAME_TIMESTAMP_REVISION"
     assert "/api/v5/market/candles" in client_b.paths
+    assert "/api/v5/market/trades" in client_b.paths
     assert "/api/v5/public/mark-price" in client_b.paths
-    assert client_b.calls == 2
+    assert client_b.calls == 3
+    assert second["ohlcv"].get("open_candle_live_source") == "okx_public_trades_into_pt1h_v1"
+    assert second["ohlcv"].get("trades_endpoint") == "/api/v5/market/trades"
+
+
+def test_public_trades_revise_open_candle_when_candles_static(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Static candles + new authentic trade IDs must revise tip OHLCV and digest."""
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive)
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    tip_ms = "1784926800000"  # FakeOkx open tip 2026-07-24T21:00:00Z
+    seed_ms = "1784926900000"
+    new_ms = "1784927400000"
+    seed_trades = [
+        {
+            "instId": INSTRUMENT,
+            "tradeId": "seed-1",
+            "px": "0.000000009100",
+            "sz": "1",
+            "side": "buy",
+            "ts": seed_ms,
+        }
+    ]
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=_FakeOkxClient(  # type: ignore[arg-type]
+            captured_at="2026-07-24T21:05:00Z",
+            open_px="0.000000009100",
+            high_px="0.000000009100",
+            low_px="0.000000009100",
+            close_px="0.000000009100",
+            volume="10",
+            trades=seed_trades,
+        ),
+    )
+    path = archive / "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
+    first = json.loads(path.read_text(encoding="utf-8"))
+    assert first["last_timestamp"].startswith("2026-07-24T21:00:00")
+    assert first["applied_trade_ids"] == ["seed-1"]
+    assert first["bars"][-1]["close"] == "0.000000009100"
+    assert first["bars"][-1]["volume"] == "10"
+
+    new_trades = seed_trades + [
+        {
+            "instId": INSTRUMENT,
+            "tradeId": "new-2",
+            "px": "0.000000009250",
+            "sz": "5",
+            "side": "sell",
+            "ts": new_ms,
+        }
+    ]
+    second = refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
+        archive_root=archive,
+        client=_FakeOkxClient(  # type: ignore[arg-type]
+            captured_at="2026-07-24T21:10:00Z",
+            open_px="0.000000009100",
+            high_px="0.000000009100",
+            low_px="0.000000009100",
+            close_px="0.000000009100",
+            volume="10",
+            trades=new_trades,
+        ),
+        force=True,
+    )
+    assert second["status"] == "OK"
+    tip = second["ohlcv"]["bars"][-1]
+    assert tip["ts"].startswith("2026-07-24T21:00:00")
+    assert tip["open"] == "0.000000009100"
+    assert tip["high"] == "0.000000009250"
+    assert tip["low"] == "0.000000009100"
+    assert tip["close"] == "0.000000009250"
+    assert tip["volume"] == "15"
+    assert second["ohlcv"]["ohlcv_revision_kind"] == "SAME_TIMESTAMP_REVISION"
+    assert second["ohlcv"]["trade_revision_kind"] == "SAME_TIMESTAMP_REVISION"
+    assert second["ohlcv"]["candle_revision_kind"] == "NO_OP"
+    assert "new-2" in second["ohlcv"]["applied_trade_ids"]
+    assert tip_ms  # tip bucket provenance anchor
 
 
 def test_provider_failure_does_not_fabricate_or_advance(

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -16,7 +16,10 @@ from scripts.ops.primary_evidence_retention_v0 import (
 from src.ops.okx_public_market_data_client_v1 import OkxPublicCaptureEnvelopeV1
 from src.ops.okx_selected_instrument_ohlcv_readmodel_v1 import (
     DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS,
+    OhlcvBarV1,
+    OkxOhlcvReadmodelError,
     materialize_selected_okx_ohlcv_readmodel_v1,
+    reduce_okx_ohlcv_bars_v1,
     refresh_selected_okx_ohlcv_readmodel_from_archive_v1,
 )
 from src.webui.app import create_app
@@ -33,6 +36,29 @@ def _iso(dt: datetime) -> str:
     return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _bar(
+    *,
+    ts: str,
+    o: str,
+    h: str,
+    l: str,
+    c: str,
+    v: str,
+    confirm: bool = False,
+) -> OhlcvBarV1:
+    return OhlcvBarV1(
+        ts=ts,
+        open=o,
+        high=h,
+        low=l,
+        close=c,
+        volume=v,
+        volume_ccy=None,
+        confirm=confirm,
+        provider_ts_ms="0",
+    )
+
+
 class _FakeOkxClient:
     def __init__(
         self,
@@ -40,9 +66,17 @@ class _FakeOkxClient:
         captured_at: str,
         close_px: str = "0.000000009176",
         mark_px: str | None = None,
+        high_px: str | None = None,
+        low_px: str | None = None,
+        open_px: str | None = None,
+        volume: str = "10",
     ) -> None:
         self.captured_at = captured_at
         self.close_px = close_px
+        self.open_px = open_px if open_px is not None else close_px
+        self.high_px = high_px if high_px is not None else close_px
+        self.low_px = low_px if low_px is not None else close_px
+        self.volume = volume
         self.mark_px = mark_px if mark_px is not None else close_px
         self.calls = 0
         self.paths: list[str] = []
@@ -91,8 +125,23 @@ class _FakeOkxClient:
             ts = start + timedelta(hours=i)
             ms = str(int(ts.timestamp() * 1000))
             confirm = "0" if i == 99 else "1"
-            close = self.close_px if i == 99 else "0.000000009200"
-            rows.append([ms, close, close, close, close, "10", "10", "10", confirm])
+            if i == 99:
+                rows.append(
+                    [
+                        ms,
+                        self.open_px,
+                        self.high_px,
+                        self.low_px,
+                        self.close_px,
+                        self.volume,
+                        self.volume,
+                        self.volume,
+                        confirm,
+                    ]
+                )
+            else:
+                close = "0.000000009200"
+                rows.append([ms, close, close, close, close, "10", "10", "10", confirm])
         body = json.dumps({"code": "0", "msg": "", "data": rows})
         return OkxPublicCaptureEnvelopeV1(
             request_url=f"https://www.okx.com{path}?instId={INSTRUMENT}",
@@ -180,6 +229,127 @@ def _write_universe(archive_root: Path, *, symbol: str = INSTRUMENT) -> Path:
     return path
 
 
+def test_open_candle_reducer_same_timestamp_revisions_then_append() -> None:
+    """Mandatory A/B/C same-ts revisions + D new-interval append at the reduce boundary."""
+    t0 = "2026-07-25T00:00:00Z"
+    t1 = "2026-07-25T01:00:00Z"
+    a = [_bar(ts=t0, o="100", h="100", l="100", c="100", v="1", confirm=False)]
+    bars_a, kind_a = reduce_okx_ohlcv_bars_v1(None, a)
+    assert kind_a == "BOOTSTRAP"
+    assert len(bars_a) == 1
+    assert bars_a[0].close == "100"
+
+    b = [_bar(ts=t0, o="100", h="103", l="100", c="103", v="2", confirm=False)]
+    bars_b, kind_b = reduce_okx_ohlcv_bars_v1(bars_a, b)
+    assert kind_b == "SAME_TIMESTAMP_REVISION"
+    assert len(bars_b) == 1
+    assert bars_b[0].open == "100"
+    assert bars_b[0].high == "103"
+    assert bars_b[0].low == "100"
+    assert bars_b[0].close == "103"
+    assert bars_b[0].volume == "2"
+
+    c = [_bar(ts=t0, o="100", h="103", l="98", c="98", v="3", confirm=False)]
+    bars_c, kind_c = reduce_okx_ohlcv_bars_v1(bars_b, c)
+    assert kind_c == "SAME_TIMESTAMP_REVISION"
+    assert len(bars_c) == 1
+    assert bars_c[0].open == "100"
+    assert bars_c[0].high == "103"
+    assert bars_c[0].low == "98"
+    assert bars_c[0].close == "98"
+    assert bars_c[0].volume == "3"
+
+    # Identical OHLCV at same timestamp is a no-op (not candle motion).
+    bars_noop, kind_noop = reduce_okx_ohlcv_bars_v1(bars_c, c)
+    assert kind_noop == "NO_OP"
+    assert bars_noop is bars_c or [x.to_json_dict() for x in bars_noop] == [
+        x.to_json_dict() for x in bars_c
+    ]
+
+    d_prev_sealed = _bar(ts=t0, o="100", h="103", l="98", c="98", v="3", confirm=True)
+    d_new = _bar(ts=t1, o="101", h="101", l="101", c="101", v="1", confirm=False)
+    bars_d, kind_d = reduce_okx_ohlcv_bars_v1(bars_c, [d_prev_sealed, d_new])
+    assert kind_d == "NEW_INTERVAL_APPEND"
+    assert len(bars_d) == 2
+    assert bars_d[0].ts == t0
+    assert bars_d[0].confirm is True
+    assert bars_d[0].close == "98"
+    assert bars_d[1].ts == t1
+    assert bars_d[1].close == "101"
+
+    # Open regression and high/low regressions fail closed.
+    with pytest.raises(OkxOhlcvReadmodelError, match="OPEN_REGRESSION"):
+        reduce_okx_ohlcv_bars_v1(
+            bars_c,
+            [_bar(ts=t0, o="99", h="103", l="98", c="98", v="3", confirm=False)],
+        )
+    with pytest.raises(OkxOhlcvReadmodelError, match="HIGH_REGRESSION"):
+        reduce_okx_ohlcv_bars_v1(
+            bars_c,
+            [_bar(ts=t0, o="100", h="102", l="98", c="98", v="3", confirm=False)],
+        )
+    with pytest.raises(OkxOhlcvReadmodelError, match="LOW_REGRESSION"):
+        reduce_okx_ohlcv_bars_v1(
+            bars_c,
+            [_bar(ts=t0, o="100", h="103", l="99", c="98", v="3", confirm=False)],
+        )
+
+
+def test_volume_revision_moves_candle_series_digest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from src.webui.market_dashboard_landscape_v2.presenter import (
+        serialize_ohlcv_browser_payload_v1,
+    )
+
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive)
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        client=_FakeOkxClient(  # type: ignore[arg-type]
+            captured_at="2026-07-25T00:00:00Z",
+            open_px="0.000000009100",
+            high_px="0.000000009100",
+            low_px="0.000000009100",
+            close_px="0.000000009100",
+            volume="10",
+            mark_px="0.000000009100",
+        ),
+    )
+    path = archive / "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
+    first = serialize_ohlcv_browser_payload_v1(json.loads(path.read_text(encoding="utf-8")))
+    assert first is not None
+    refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
+        archive_root=archive,
+        client=_FakeOkxClient(  # type: ignore[arg-type]
+            captured_at="2026-07-25T00:00:03Z",
+            open_px="0.000000009100",
+            high_px="0.000000009100",
+            low_px="0.000000009100",
+            close_px="0.000000009100",
+            volume="25",
+            mark_px="0.000000009100",
+        ),
+        force=True,
+    )
+    second_doc = json.loads(path.read_text(encoding="utf-8"))
+    second = serialize_ohlcv_browser_payload_v1(second_doc)
+    assert second is not None
+    assert first["last_timestamp"] == second["last_timestamp"]
+    assert first["bars"][-1]["close"] == second["bars"][-1]["close"]
+    assert first["bars"][-1]["volume"] != second["bars"][-1]["volume"]
+    assert first["candle_series_digest"] != second["candle_series_digest"]
+    assert second_doc.get("ohlcv_revision_kind") == "SAME_TIMESTAMP_REVISION"
+    assert second.get("close_source_semantics") == "okx_market_candles_close"
+    assert second.get("mark_source_semantics") == "okx_public_mark_price_markPx"
+
+
 def test_authentic_okx_maps_and_newer_snapshot_advances(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -187,7 +357,13 @@ def test_authentic_okx_maps_and_newer_snapshot_advances(
     selection = _write_universe(archive)
     monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
 
-    client_a = _FakeOkxClient(captured_at="2026-07-25T00:00:00Z", close_px="0.000000009100")
+    client_a = _FakeOkxClient(
+        captured_at="2026-07-25T00:00:00Z",
+        open_px="0.000000009100",
+        high_px="0.000000009100",
+        low_px="0.000000009100",
+        close_px="0.000000009100",
+    )
     first = materialize_selected_okx_ohlcv_readmodel_v1(
         archive_root=archive,
         selected_instrument=INSTRUMENT,
@@ -200,7 +376,13 @@ def test_authentic_okx_maps_and_newer_snapshot_advances(
     assert first["bar_count"] == 100
     assert first["last_closed_timestamp"] is not None
 
-    client_b = _FakeOkxClient(captured_at="2026-07-25T00:05:00Z", close_px="0.000000009500")
+    client_b = _FakeOkxClient(
+        captured_at="2026-07-25T00:05:00Z",
+        open_px="0.000000009100",
+        high_px="0.000000009500",
+        low_px="0.000000009100",
+        close_px="0.000000009500",
+    )
     second = refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
         archive_root=archive,
         client=client_b,  # type: ignore[arg-type]
@@ -213,7 +395,9 @@ def test_authentic_okx_maps_and_newer_snapshot_advances(
     assert second["ohlcv"]["instrument_id"] == INSTRUMENT
     assert second["ohlcv"]["venue"] == "okx"
     assert second["ohlcv"]["bars"][-1]["close"] == "0.000000009500"
+    assert second["ohlcv"]["bars"][-1]["open"] == "0.000000009100"
     assert second["ohlcv"]["live_mark_price"] == "0.000000009500"
+    assert second["ohlcv"].get("ohlcv_revision_kind") == "SAME_TIMESTAMP_REVISION"
     assert "/api/v5/market/candles" in client_b.paths
     assert "/api/v5/public/mark-price" in client_b.paths
     assert client_b.calls == 2
@@ -563,6 +747,9 @@ def test_same_timestamp_ohlc_change_moves_candle_series_digest_only(
         selection_path=selection,
         client=_FakeOkxClient(  # type: ignore[arg-type]
             captured_at="2026-07-25T00:00:00Z",
+            open_px="0.000000009100",
+            high_px="0.000000009100",
+            low_px="0.000000009100",
             close_px="0.000000009100",
             mark_px="0.000000009100",
         ),
@@ -574,6 +761,9 @@ def test_same_timestamp_ohlc_change_moves_candle_series_digest_only(
         archive_root=archive,
         client=_FakeOkxClient(  # type: ignore[arg-type]
             captured_at="2026-07-25T00:00:03Z",
+            open_px="0.000000009100",
+            high_px="0.000000009220",
+            low_px="0.000000009100",
             close_px="0.000000009220",
             mark_px="0.000000009220",
         ),
@@ -599,6 +789,8 @@ def test_js_layout_stability_and_update_classification_contracts() -> None:
     assert "MARK_ONLY" in js
     assert "METADATA_ONLY" in js
     assert "LAST_CANDLE_IN_PLACE" in js
+    assert "volume" in js
+    assert "data-mdl-chart-candle-volume" in js
     assert "resolveCssBox" in js
     assert "syncBackingStore" in js
     assert "devicePixelRatio" in js


### PR DESCRIPTION
## Summary
- Server-side OKX `/market/candles` + public mark-price feed the selected OHLCV readmodel every ≤3s so the open PT1H candle tip updates before rollover.
- Browser polls local `/api/market/landscape/ohlcv` only; chart redraw keys off `chart_digest` (market values), not `captured_at` alone; connection states `LIVE_DATA` / `RECONNECTING` / `STALE` / `MISSING_SOURCE`.
- Read-only dashboard remains non-authorizing (`LIVE_AUTHORIZED=false`, no orders/runtime activation, no browser→OKX, no Kraken fallback).

## Test plan
- [x] Focused webui/ops OHLCV continuous-refresh + architecture + shell route tests
- [x] PR-bounded CI target suite locally (~40s)
- [x] Real Chrome proof: same open candle timestamp, rendered close/mark changed, no full reload, `DIRECT_BROWSER_OKX_CALL_COUNT=0`
- [ ] Required GitHub checks on this PR head


Made with [Cursor](https://cursor.com)