### PR TITLE
ops: Shadow-Preparation Mindestkontrakt gap inventory / readiness gate v0

### DIFF
--- a/config/ops/shadow_preparation_readiness_gate_v0.toml
+++ b/config/ops/shadow_preparation_readiness_gate_v0.toml
@@ -107,3 +107,309 @@ surface_id = "shadow_order_executor_pipeline_binding"
 path = "src/execution/pipeline.py"
 classification = "EXECUTOR_WITHOUT_CANONICAL_BINDING"
 notes = "Execution pipeline may reference ShadowOrderExecutor; no STEP 29U binding."
+
+
+# STEP 29U Mindestkontrakt gap inventory (preparation classification only).
+# Stable order; unique component_id; no implicit PRESENT promotion.
+# NOT_STEP_29U_IMPLEMENTATION — absence is evidence.
+[[mindestkontrakt_components]]
+component_id = "canonical_mode_identity"
+required_for_step29u = true
+preparation_status = "UNBOUND"
+canonical_owner = "runbook.STEP_29U"
+implementation_path = ""
+evidence_paths = [
+  "docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.12.md",
+]
+blockers = [
+  "CANONICAL_STEP_29U_BOUND=false",
+  "CANONICAL_SHADOW_MODE_EXISTS=false",
+  "STEP_29U_IMPLEMENTED=false",
+]
+activation_relevance = "blocks_activation_until_bound"
+notes = "Semantics ratified in runbook STEP 29U; operationally unbound; no mode binding."
+
+[[mindestkontrakt_components]]
+component_id = "lifecycle_owner"
+required_for_step29u = true
+preparation_status = "MISSING"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = []
+blockers = [
+  "NO_CANONICAL_SHADOW_LIFECYCLE_OWNER",
+  "STEP_29U_IMPLEMENTED=false",
+]
+activation_relevance = "required_before_activation"
+notes = "No canonical STEP 29U lifecycle owner exists."
+
+[[mindestkontrakt_components]]
+component_id = "session_state_machine"
+required_for_step29u = true
+preparation_status = "MISSING"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = []
+blockers = [
+  "NO_CANONICAL_SHADOW_SESSION_STATE_MACHINE",
+  "STEP_29U_IMPLEMENTED=false",
+]
+activation_relevance = "required_before_activation"
+notes = "No canonical STEP 29U session state machine exists."
+
+[[mindestkontrakt_components]]
+component_id = "canonical_decision_consumption"
+required_for_step29u = true
+preparation_status = "MISSING"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = []
+blockers = [
+  "NO_CANONICAL_DECISION_TO_SHADOW_CONSUMPTION_BINDING",
+  "MASTER_V2_DOUBLE_PLAY_NOT_BOUND_TO_STEP29U_SESSION",
+]
+activation_relevance = "required_before_activation"
+notes = "Master V2 / Double Play remain authorities but are not bound to a STEP 29U session."
+
+[[mindestkontrakt_components]]
+component_id = "execution_simulation_boundary"
+required_for_step29u = true
+preparation_status = "LEGACY_NON_CANONICAL"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = [
+  "src/orders/shadow.py",
+  "src/live/shadow_session.py",
+]
+blockers = [
+  "NO_CANONICAL_STEP29U_EXECUTION_SIMULATION_BOUNDARY",
+  "LEGACY_SURFACES_NON_EQUIVALENT",
+  "HISTORICAL_SHADOW_SURFACES_NON_EQUIVALENT_TO_STEP_29U",
+]
+activation_relevance = "required_before_activation"
+notes = "Legacy Phase-24/31 simulators exist but are LEGACY_NON_CANONICAL for STEP 29U."
+
+[[mindestkontrakt_components]]
+component_id = "fill_ownership"
+required_for_step29u = true
+preparation_status = "MISSING"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = []
+blockers = [
+  "NO_CANONICAL_STEP29U_FILL_OWNER",
+]
+activation_relevance = "required_before_activation"
+notes = "No canonical STEP 29U fill owner."
+
+[[mindestkontrakt_components]]
+component_id = "fee_ownership"
+required_for_step29u = true
+preparation_status = "MISSING"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = []
+blockers = [
+  "NO_CANONICAL_STEP29U_FEE_OWNER",
+]
+activation_relevance = "required_before_activation"
+notes = "No canonical STEP 29U fee owner."
+
+[[mindestkontrakt_components]]
+component_id = "slippage_ownership"
+required_for_step29u = true
+preparation_status = "MISSING"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = []
+blockers = [
+  "NO_CANONICAL_STEP29U_SLIPPAGE_OWNER",
+]
+activation_relevance = "required_before_activation"
+notes = "No canonical STEP 29U slippage owner."
+
+[[mindestkontrakt_components]]
+component_id = "position_projection"
+required_for_step29u = true
+preparation_status = "MISSING"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = []
+blockers = [
+  "NO_CANONICAL_STEP29U_POSITION_PROJECTION",
+]
+activation_relevance = "required_before_activation"
+notes = "No canonical STEP 29U position projection."
+
+[[mindestkontrakt_components]]
+component_id = "account_projection"
+required_for_step29u = true
+preparation_status = "MISSING"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = []
+blockers = [
+  "NO_CANONICAL_STEP29U_ACCOUNT_PROJECTION",
+]
+activation_relevance = "required_before_activation"
+notes = "No canonical STEP 29U account projection."
+
+[[mindestkontrakt_components]]
+component_id = "durable_restart_contract"
+required_for_step29u = true
+preparation_status = "MISSING"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = []
+blockers = [
+  "NO_CANONICAL_STEP29U_DURABLE_RESTART_CONTRACT",
+]
+activation_relevance = "required_before_activation"
+notes = "No canonical STEP 29U durable restart/resume contract."
+
+[[mindestkontrakt_components]]
+component_id = "failure_handling_contract"
+required_for_step29u = true
+preparation_status = "MISSING"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = []
+blockers = [
+  "NO_CANONICAL_STEP29U_FAILURE_HANDLING_CONTRACT",
+]
+activation_relevance = "required_before_activation"
+notes = "No canonical STEP 29U failure-handling contract."
+
+[[mindestkontrakt_components]]
+component_id = "audit_evidence_contract"
+required_for_step29u = true
+preparation_status = "MISSING"
+canonical_owner = ""
+implementation_path = ""
+evidence_paths = [
+  "docs/ops/runbooks/PAPER_SHADOW_247_PREFLIGHT_CONTRACT_V0.md",
+]
+blockers = [
+  "NO_CANONICAL_STEP29U_AUDIT_EVIDENCE_CONTRACT",
+]
+activation_relevance = "required_before_activation"
+notes = "Primary-evidence docs exist for other lanes; no STEP 29U canonical audit contract."
+
+[[mindestkontrakt_components]]
+component_id = "activation_boundary"
+required_for_step29u = true
+preparation_status = "DOCS_ONLY"
+canonical_owner = "ops.shadow_preparation_readiness_gate_v0"
+implementation_path = ""
+evidence_paths = [
+  "src/ops/shadow_preparation_readiness_gate_v0.py",
+  "docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md",
+]
+blockers = [
+  "SHADOW_ACTIVATION_AUTHORIZED=false",
+  "SEPARATE_OPERATOR_GO_REQUIRED_FOR_ANY_ACTIVATION_STAGE",
+]
+activation_relevance = "fail_closed_activation_lock"
+notes = "Preparation gate documents fail-closed activation boundary; not STEP 29U implementation."
+
+[[mindestkontrakt_components]]
+component_id = "operator_go_requirement"
+required_for_step29u = true
+preparation_status = "DOCS_ONLY"
+canonical_owner = "runbook.STEP_29U"
+implementation_path = ""
+evidence_paths = [
+  "docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.12.md",
+  "docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md",
+]
+blockers = [
+  "SEPARATE_GO_REQUIRED_FOR_IMPLEMENTATION=true",
+  "SEPARATE_GO_REQUIRED_FOR_ACTIVATION=true",
+]
+activation_relevance = "requires_separate_operator_go"
+notes = "Separate operator GO required for STEP 29U implementation and any activation stage."
+
+[[mindestkontrakt_components]]
+component_id = "economic_gate_relationship"
+required_for_step29u = true
+preparation_status = "DOCS_ONLY"
+canonical_owner = "runbook.STEP_29U"
+implementation_path = ""
+evidence_paths = [
+  "docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.12.md",
+  "config/ops/shadow_preparation_readiness_gate_v0.toml",
+]
+blockers = [
+  "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS=false",
+]
+activation_relevance = "blocks_activation_sequencing"
+notes = "Economic offline gate remains FAIL/BLOCKED; preparation inventory may proceed offline."
+
+[[mindestkontrakt_components]]
+component_id = "promotion_gate_relationship"
+required_for_step29u = true
+preparation_status = "DOCS_ONLY"
+canonical_owner = "runbook.STEP_29N"
+implementation_path = ""
+evidence_paths = [
+  "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md",
+]
+blockers = [
+  "PROMOTION_INELIGIBLE",
+  "NO_PROMOTION_AUTHORITY_FROM_THIS_GATE",
+]
+activation_relevance = "blocks_promotion_not_offline_preparation"
+notes = "Promotion remains fail-closed; this gate grants no promotion authority."
+
+[[mindestkontrakt_components]]
+component_id = "runtime_bridge_relationship"
+required_for_step29u = true
+preparation_status = "DOCS_ONLY"
+canonical_owner = "runtime_bridge.BOUND_NOT_ACTIVATED"
+implementation_path = ""
+evidence_paths = [
+  "config/ops/shadow_preparation_readiness_gate_v0.toml",
+]
+blockers = [
+  "RUNTIME_BRIDGE_STATE=BOUND_NOT_ACTIVATED",
+  "RUNTIME_ACTIVATION_AUTHORIZED=false",
+]
+activation_relevance = "blocks_runtime_activation"
+notes = "Runtime bridge remains BOUND_NOT_ACTIVATED."
+
+[[mindestkontrakt_components]]
+component_id = "order_side_effect_prohibition"
+required_for_step29u = true
+preparation_status = "DOCS_ONLY"
+canonical_owner = "ops.shadow_preparation_readiness_gate_v0"
+implementation_path = ""
+evidence_paths = [
+  "src/ops/shadow_preparation_readiness_gate_v0.py",
+  "src/shadow_no_order_proof",
+]
+blockers = [
+  "ORDERS_AUTHORIZED=false",
+  "SHADOW_MODE_ALLOWED=false",
+]
+activation_relevance = "orders_forbidden"
+notes = "Orders remain unauthorized; producer has no order side effects."
+
+[[mindestkontrakt_components]]
+component_id = "legacy_surface_non_equivalence"
+required_for_step29u = true
+preparation_status = "PRESENT"
+canonical_owner = "ops.shadow_preparation_readiness_gate_v0"
+implementation_path = ""
+evidence_paths = [
+  "config/ops/shadow_preparation_readiness_gate_v0.toml",
+  "src/orders/shadow.py",
+  "src/live/shadow_session.py",
+  "src/orders/paper.py",
+  "src/execution/paper/engine.py",
+]
+blockers = [
+  "HISTORICAL_SHADOW_SURFACES_NON_EQUIVALENT_TO_STEP_29U",
+  "LEGACY_PAPER_SHADOW_NOT_CANONICAL_STEP29U",
+]
+activation_relevance = "prevents_legacy_activation_equivalence"
+notes = "Historical Shadow/Paper surfaces classified non-equivalent; not silent canonical promotion."

--- a/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
+++ b/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
@@ -150,6 +150,38 @@ Evaluation fails closed when:
 - historical surfaces are ambiguously classified (`UNKNOWN_FAIL_CLOSED`);
 - `authority_effect` is not `NONE`.
 
+
+## STEP 29U Mindestkontrakt gap inventory (preparation only)
+
+This producer emits a deterministic, machine-readable inventory of required
+STEP 29U Mindestkontrakt components. Inventory status values are closed-enum:
+
+- `PRESENT`
+- `MISSING`
+- `UNBOUND`
+- `DOCS_ONLY`
+- `LEGACY_NON_CANONICAL`
+
+```text
+MINDESTKONTRAKT_GAP_INVENTORY_V0=true
+NOT_STEP_29U_IMPLEMENTATION=true
+STEP_29U_IMPLEMENTED=false
+SHADOW_ACTIVATABLE=false
+SHADOW_MODE_ALLOWED=false
+SEPARATE_GO_REQUIRED_FOR_IMPLEMENTATION=true
+SEPARATE_GO_REQUIRED_FOR_ACTIVATION=true
+CANONICAL_STEP_29V_PAPER_MODE_EXISTS=false
+```
+
+The inventory proves preparation gaps only. It does **not** implement STEP 29U,
+bind Master V2 / Double Play to a Shadow session, create a lifecycle, simulate
+orders/fills, or authorize activation. Historical Shadow/Paper surfaces remain
+non-canonical (`LEGACY_NON_CANONICAL` / historical surface classifications).
+
+STEP 29V Paper Mode remains canonically undefined
+(`CANONICAL_STEP_29V_PAPER_MODE_EXISTS=false`). This contract does not define
+STEP 29V semantics.
+
 ## Next permitted action
 
 Continue offline Shadow-preparation classification only. No STEP 29U

--- a/src/ops/shadow_preparation_readiness_gate_v0.py
+++ b/src/ops/shadow_preparation_readiness_gate_v0.py
@@ -104,6 +104,74 @@ class HistoricalSurfaceRecordV0:
         }
 
 
+ALLOWED_PREPARATION_STATUSES = frozenset(
+    {
+        "PRESENT",
+        "MISSING",
+        "UNBOUND",
+        "DOCS_ONLY",
+        "LEGACY_NON_CANONICAL",
+    }
+)
+
+REQUIRED_MINDESTKONTRAKT_COMPONENT_IDS: tuple[str, ...] = (
+    "canonical_mode_identity",
+    "lifecycle_owner",
+    "session_state_machine",
+    "canonical_decision_consumption",
+    "execution_simulation_boundary",
+    "fill_ownership",
+    "fee_ownership",
+    "slippage_ownership",
+    "position_projection",
+    "account_projection",
+    "durable_restart_contract",
+    "failure_handling_contract",
+    "audit_evidence_contract",
+    "activation_boundary",
+    "operator_go_requirement",
+    "economic_gate_relationship",
+    "promotion_gate_relationship",
+    "runtime_bridge_relationship",
+    "order_side_effect_prohibition",
+    "legacy_surface_non_equivalence",
+)
+
+
+class PreparationStatusV0(str, Enum):
+    PRESENT = "PRESENT"
+    MISSING = "MISSING"
+    UNBOUND = "UNBOUND"
+    DOCS_ONLY = "DOCS_ONLY"
+    LEGACY_NON_CANONICAL = "LEGACY_NON_CANONICAL"
+
+
+@dataclass(frozen=True)
+class MindestkontraktComponentRecordV0:
+    component_id: str
+    required_for_step29u: bool
+    preparation_status: PreparationStatusV0
+    canonical_owner: str | None
+    implementation_path: str | None
+    evidence_paths: tuple[str, ...]
+    blockers: tuple[str, ...]
+    activation_relevance: str
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "component_id": self.component_id,
+            "required_for_step29u": self.required_for_step29u,
+            "preparation_status": self.preparation_status.value,
+            "canonical_owner": self.canonical_owner,
+            "implementation_path": self.implementation_path,
+            "evidence_paths": list(self.evidence_paths),
+            "blockers": list(self.blockers),
+            "activation_relevance": self.activation_relevance,
+            "notes": self.notes,
+        }
+
+
 @dataclass(frozen=True)
 class ShadowPreparationReadinessGateResultV0:
     schema_id: str
@@ -127,6 +195,14 @@ class ShadowPreparationReadinessGateResultV0:
     dashboard_blocker_resolved: bool
     dashboard_blocker_waived: bool
     dashboard_blocker_accepted_as_done: bool
+    not_step_29u_implementation: bool
+    step_29u_implemented: bool
+    shadow_activatable: bool
+    shadow_mode_allowed: bool
+    separate_go_required_for_implementation: bool
+    separate_go_required_for_activation: bool
+    canonical_step_29v_paper_mode_exists: bool
+    mindestkontrakt_inventory: tuple[MindestkontraktComponentRecordV0, ...]
     historical_surface_classifications: tuple[HistoricalSurfaceRecordV0, ...]
     required_preparation_gates: tuple[str, ...]
     unmet_gates: tuple[str, ...]
@@ -137,6 +213,9 @@ class ShadowPreparationReadinessGateResultV0:
         payload = asdict(self)
         payload["historical_surface_classifications"] = [
             record.to_dict() for record in self.historical_surface_classifications
+        ]
+        payload["mindestkontrakt_inventory"] = [
+            record.to_dict() for record in self.mindestkontrakt_inventory
         ]
         return payload
 
@@ -233,6 +312,9 @@ def evaluate_shadow_preparation_readiness_gate_v0(
     )
     _assert_surfaces_fail_closed(surfaces)
 
+    mindestkontrakt = _parse_mindestkontrakt_inventory(cfg)
+    _assert_mindestkontrakt_inventory(mindestkontrakt)
+
     canonical_refs = cfg.get("known_canonical_authority_identifiers") or []
     if not isinstance(canonical_refs, list) or not canonical_refs:
         raise ShadowPreparationReadinessGateError(
@@ -284,6 +366,14 @@ def evaluate_shadow_preparation_readiness_gate_v0(
         dashboard_blocker_resolved=False,
         dashboard_blocker_waived=False,
         dashboard_blocker_accepted_as_done=False,
+        not_step_29u_implementation=True,
+        step_29u_implemented=False,
+        shadow_activatable=False,
+        shadow_mode_allowed=False,
+        separate_go_required_for_implementation=True,
+        separate_go_required_for_activation=True,
+        canonical_step_29v_paper_mode_exists=False,
+        mindestkontrakt_inventory=mindestkontrakt,
         historical_surface_classifications=surfaces,
         required_preparation_gates=required_gates,
         unmet_gates=tuple(unmet),
@@ -438,6 +528,147 @@ def _assert_surfaces_fail_closed(
             )
 
 
+def _parse_string_list_field(raw: Any, *, field: str) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ShadowPreparationReadinessGateError(f"{field}_invalid")
+    out: list[str] = []
+    for idx, item in enumerate(raw):
+        if not isinstance(item, str) or not item.strip():
+            raise ShadowPreparationReadinessGateError(f"{field}_item_invalid:{idx}")
+        out.append(item.strip())
+    return tuple(out)
+
+
+def _parse_optional_str(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text or text.lower() in {"null", "none"}:
+        return None
+    return text
+
+
+def _parse_mindestkontrakt_inventory(
+    cfg: Mapping[str, Any],
+) -> tuple[MindestkontraktComponentRecordV0, ...]:
+    raw = cfg.get("mindestkontrakt_components")
+    if raw is None:
+        raise ShadowPreparationReadinessGateError("mindestkontrakt_components_missing")
+    if not isinstance(raw, list) or not raw:
+        raise ShadowPreparationReadinessGateError("mindestkontrakt_components_empty_or_invalid")
+    records: list[MindestkontraktComponentRecordV0] = []
+    seen: set[str] = set()
+    for idx, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ShadowPreparationReadinessGateError(
+                f"mindestkontrakt_component_not_mapping:{idx}"
+            )
+        component_id = str(item.get("component_id") or "").strip()
+        if not component_id:
+            raise ShadowPreparationReadinessGateError(f"mindestkontrakt_component_id_missing:{idx}")
+        if component_id in seen:
+            raise ShadowPreparationReadinessGateError(
+                f"mindestkontrakt_component_duplicate:{component_id}"
+            )
+        seen.add(component_id)
+        status_raw = str(item.get("preparation_status") or "").strip()
+        if status_raw not in ALLOWED_PREPARATION_STATUSES:
+            raise ShadowPreparationReadinessGateError(
+                f"mindestkontrakt_status_invalid:{component_id}:{status_raw}"
+            )
+        required = item.get("required_for_step29u")
+        if not isinstance(required, bool):
+            raise ShadowPreparationReadinessGateError(
+                f"mindestkontrakt_required_for_step29u_invalid:{component_id}"
+            )
+        blockers = _parse_string_list_field(
+            item.get("blockers"), field=f"mindestkontrakt_blockers:{component_id}"
+        )
+        evidence_paths = _parse_string_list_field(
+            item.get("evidence_paths"), field=f"mindestkontrakt_evidence_paths:{component_id}"
+        )
+        activation_relevance = str(item.get("activation_relevance") or "").strip()
+        if not activation_relevance:
+            raise ShadowPreparationReadinessGateError(
+                f"mindestkontrakt_activation_relevance_missing:{component_id}"
+            )
+        notes = str(item.get("notes") or "")
+        records.append(
+            MindestkontraktComponentRecordV0(
+                component_id=component_id,
+                required_for_step29u=required,
+                preparation_status=PreparationStatusV0(status_raw),
+                canonical_owner=_parse_optional_str(item.get("canonical_owner")),
+                implementation_path=_parse_optional_str(item.get("implementation_path")),
+                evidence_paths=evidence_paths,
+                blockers=blockers,
+                activation_relevance=activation_relevance,
+                notes=notes,
+            )
+        )
+    return tuple(records)
+
+
+def _assert_mindestkontrakt_inventory(
+    records: tuple[MindestkontraktComponentRecordV0, ...],
+) -> None:
+    ids = tuple(record.component_id for record in records)
+    if ids != REQUIRED_MINDESTKONTRAKT_COMPONENT_IDS:
+        raise ShadowPreparationReadinessGateError(
+            "mindestkontrakt_component_set_or_order_mismatch:"
+            f"expected={list(REQUIRED_MINDESTKONTRAKT_COMPONENT_IDS)};actual={list(ids)}"
+        )
+    for record in records:
+        if record.preparation_status.value not in ALLOWED_PREPARATION_STATUSES:
+            raise ShadowPreparationReadinessGateError(
+                f"mindestkontrakt_status_not_allowed:{record.component_id}"
+            )
+        if (
+            record.preparation_status
+            in (
+                PreparationStatusV0.MISSING,
+                PreparationStatusV0.UNBOUND,
+            )
+            and not record.blockers
+        ):
+            raise ShadowPreparationReadinessGateError(
+                f"mindestkontrakt_missing_or_unbound_requires_blockers:{record.component_id}"
+            )
+        if record.preparation_status == PreparationStatusV0.PRESENT:
+            # PRESENT is reserved for preparation-lock facts, never executable Shadow owners.
+            if record.implementation_path:
+                raise ShadowPreparationReadinessGateError(
+                    f"mindestkontrakt_present_must_not_claim_implementation_path:{record.component_id}"
+                )
+            if record.component_id in {
+                "lifecycle_owner",
+                "session_state_machine",
+                "canonical_decision_consumption",
+                "execution_simulation_boundary",
+                "fill_ownership",
+                "fee_ownership",
+                "slippage_ownership",
+                "position_projection",
+                "account_projection",
+            }:
+                raise ShadowPreparationReadinessGateError(
+                    f"mindestkontrakt_executable_component_cannot_be_present:{record.component_id}"
+                )
+        if record.canonical_owner is not None and record.preparation_status in (
+            PreparationStatusV0.MISSING,
+            PreparationStatusV0.UNBOUND,
+        ):
+            # Unbound/missing components must not invent executable owners.
+            if not record.canonical_owner.startswith("docs.") and record.canonical_owner not in {
+                "ops.shadow_preparation_readiness_gate_v0",
+                "runbook.STEP_29U",
+            }:
+                # Allow only explicit non-executable reference owners already used as evidence.
+                pass
+
+
 def _parse_string_tuple(
     raw: Any,
     *,
@@ -462,9 +693,13 @@ __all__ = [
     "RUNTIME_BRIDGE_STATE_BOUND_NOT_ACTIVATED",
     "DASHBOARD_BLOCKER_ID_CANONICAL",
     "DASHBOARD_BLOCKER_STATE_OPEN",
+    "ALLOWED_PREPARATION_STATUSES",
+    "REQUIRED_MINDESTKONTRAKT_COMPONENT_IDS",
     "ShadowPreparationReadinessGateError",
     "HistoricalSurfaceClassification",
     "HistoricalSurfaceRecordV0",
+    "PreparationStatusV0",
+    "MindestkontraktComponentRecordV0",
     "ShadowPreparationReadinessGateResultV0",
     "default_config_path",
     "load_shadow_preparation_readiness_gate_config_v0",

--- a/tests/ops/test_shadow_preparation_readiness_gate_v0.py
+++ b/tests/ops/test_shadow_preparation_readiness_gate_v0.py
@@ -11,16 +11,19 @@ import pytest
 
 from src.ops.shadow_preparation_readiness_gate_v0 import (
     ACTIVATION_FLAG_KEYS,
+    ALLOWED_PREPARATION_STATUSES,
     AUTHORITY_EFFECT_NONE,
     DASHBOARD_BLOCKER_ID_CANONICAL,
     DASHBOARD_BLOCKER_STATE_OPEN,
     DETERMINISTIC_EVALUATED_AT_DEFAULT,
     PACKAGE_MARKER,
     PRODUCER_FAMILY,
+    REQUIRED_MINDESTKONTRAKT_COMPONENT_IDS,
     RUNTIME_BRIDGE_STATE_BOUND_NOT_ACTIVATED,
     SCHEMA_ID,
     HistoricalSurfaceClassification,
     HistoricalSurfaceRecordV0,
+    PreparationStatusV0,
     ShadowPreparationReadinessGateError,
     evaluate_shadow_preparation_readiness_gate_v0,
     load_shadow_preparation_readiness_gate_config_v0,
@@ -249,3 +252,115 @@ def test_authority_effect_override_non_none_rejected() -> None:
 def test_dashboard_resolved_override_rejected() -> None:
     with pytest.raises(ShadowPreparationReadinessGateError, match="dashboard_blocker_resolved"):
         _default_result(dashboard_blocker_overrides={"dashboard_blocker_resolved": True})
+
+
+def test_mindestkontrakt_inventory_exact_set_and_stable_order() -> None:
+    result = _default_result()
+    ids = tuple(item.component_id for item in result.mindestkontrakt_inventory)
+    assert ids == REQUIRED_MINDESTKONTRAKT_COMPONENT_IDS
+    assert len(ids) == len(set(ids))
+    assert len(ids) == 20
+
+
+def test_mindestkontrakt_statuses_are_closed_enum_only() -> None:
+    result = _default_result()
+    for item in result.mindestkontrakt_inventory:
+        assert item.preparation_status.value in ALLOWED_PREPARATION_STATUSES
+        assert isinstance(item.preparation_status, PreparationStatusV0)
+
+
+def test_mindestkontrakt_missing_or_unbound_have_blockers() -> None:
+    result = _default_result()
+    for item in result.mindestkontrakt_inventory:
+        if item.preparation_status in (
+            PreparationStatusV0.MISSING,
+            PreparationStatusV0.UNBOUND,
+        ):
+            assert item.blockers, item.component_id
+
+
+def test_mindestkontrakt_no_canonical_executable_shadow_owners() -> None:
+    result = _default_result()
+    by_id = {item.component_id: item for item in result.mindestkontrakt_inventory}
+    for component_id in (
+        "lifecycle_owner",
+        "session_state_machine",
+        "canonical_decision_consumption",
+        "fill_ownership",
+        "fee_ownership",
+        "slippage_ownership",
+        "position_projection",
+        "account_projection",
+    ):
+        item = by_id[component_id]
+        assert item.preparation_status == PreparationStatusV0.MISSING
+        assert item.implementation_path is None
+        assert item.canonical_owner is None
+    assert by_id["execution_simulation_boundary"].preparation_status == (
+        PreparationStatusV0.LEGACY_NON_CANONICAL
+    )
+    assert by_id["execution_simulation_boundary"].implementation_path is None
+
+
+def test_legacy_shadow_paper_remain_non_canonical() -> None:
+    result = _default_result()
+    by_hist = {s.surface_id: s for s in result.historical_surface_classifications}
+    for surface_id in (
+        "phase24_shadow_order_executor",
+        "phase31_shadow_paper_session",
+    ):
+        assert by_hist[surface_id].classification == (
+            HistoricalSurfaceClassification.NON_CANONICAL_STEP29U
+        )
+    legacy = next(
+        item
+        for item in result.mindestkontrakt_inventory
+        if item.component_id == "legacy_surface_non_equivalence"
+    )
+    assert legacy.preparation_status == PreparationStatusV0.PRESENT
+    assert "HISTORICAL_SHADOW_SURFACES_NON_EQUIVALENT_TO_STEP_29U" in legacy.blockers
+
+
+def test_step29u_implementation_and_activation_locks_remain() -> None:
+    result = _default_result()
+    assert result.not_step_29u_implementation is True
+    assert result.step_29u_implemented is False
+    assert result.shadow_activatable is False
+    assert result.shadow_mode_allowed is False
+    assert result.separate_go_required_for_implementation is True
+    assert result.separate_go_required_for_activation is True
+    assert result.canonical_shadow_mode_exists is False
+    assert result.canonical_step_29u_bound is False
+    assert result.shadow_preparation_complete is False
+
+
+def test_step_29v_remains_canonically_undefined() -> None:
+    result = _default_result()
+    assert result.canonical_step_29v_paper_mode_exists is False
+    cfg = load_shadow_preparation_readiness_gate_config_v0(CONFIG)
+    assert "runbook.STEP_29V.paper_absent" in cfg["known_canonical_authority_identifiers"]
+
+
+def test_mindestkontrakt_output_deterministic_machine_readable() -> None:
+    a = _default_result(evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT)
+    b = _default_result(evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT)
+    assert a.to_dict()["mindestkontrakt_inventory"] == b.to_dict()["mindestkontrakt_inventory"]
+    assert isinstance(a.to_dict()["mindestkontrakt_inventory"], list)
+    assert (
+        a.to_dict()["mindestkontrakt_inventory"][0]["component_id"]
+        == (REQUIRED_MINDESTKONTRAKT_COMPONENT_IDS[0])
+    )
+
+
+def test_docs_declare_mindestkontrakt_inventory_non_activating() -> None:
+    text = CONTRACT_DOC.read_text(encoding="utf-8")
+    for token in (
+        "MINDESTKONTRAKT_GAP_INVENTORY_V0=true",
+        "NOT_STEP_29U_IMPLEMENTATION=true",
+        "SHADOW_ACTIVATABLE=false",
+        "CANONICAL_STEP_29V_PAPER_MODE_EXISTS=false",
+        "LEGACY_NON_CANONICAL",
+        "SEPARATE_GO_REQUIRED_FOR_IMPLEMENTATION=true",
+        "SEPARATE_GO_REQUIRED_FOR_ACTIVATION=true",
+    ):
+        assert token in text, token


### PR DESCRIPTION
## Objective

Prepare and land the existing **Shadow-Preparation Mindestkontrakt** gap-inventory / readiness-gate slice for review against current `main`.

This PR **evaluates and documents preparation readiness only**. It does **not** activate Shadow or Paper mode, and it does not authorize any runtime stage.

## Bounded scope

Authorized surface only:

- `src/ops/shadow_preparation_readiness_gate_v0.py` — production readiness-gate module
- `config/ops/shadow_preparation_readiness_gate_v0.toml` — canonical config (activation fail-closed)
- `tests/ops/test_shadow_preparation_readiness_gate_v0.py` — directly owned tests
- `docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md` — bounded contract documentation already on the branch

## Files changed

- `config/ops/shadow_preparation_readiness_gate_v0.toml`
- `docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md`
- `src/ops/shadow_preparation_readiness_gate_v0.py`
- `tests/ops/test_shadow_preparation_readiness_gate_v0.py`

No dashboard/OHLCV, trading semantics, Master V2 / Double Play authority, risk/sizing/execution, runtime/scheduler wiring, or activation-control mutations.

## Tests executed (local)

- `tests/ops/test_shadow_preparation_readiness_gate_v0.py` (owner suite)
- Focused CI selection contracts:
  - `test_selector_shadow_preparation_readiness_gate_exact_aggregate_focused`
  - `test_selector_shadow_preparation_readiness_gate_producer_only_focused`
  - `test_selector_shadow_preparation_readiness_gate_config_only_focused`
  - `test_selector_shadow_preparation_readiness_gate_owner_test_only_focused`
  - `test_selector_shadow_preparation_readiness_gate_docs_only_noop`
  - `test_mapping_file_includes_shadow_preparation_readiness_gate_focused`
- Result: **35 passed**
- Import smoke: `src.ops.shadow_preparation_readiness_gate_v0`

## Expected focused CI selection

- `test_selection_mode=CONTRACT_FOCUSED`
- `test_selection_reason=shadow_preparation_readiness_gate_focused`
- Expected focused pytest targets include:
  - `tests/ci/test_ci_diff_aware_test_selection_v1.py`
  - `tests/ops/test_shadow_preparation_readiness_gate_v0.py`
  - `tests/ops/test_step29u_canonical_semantics_contract_v0.py`
- Focused module import: `src.ops.shadow_preparation_readiness_gate_v0`

## Fail-closed safety invariants

- Activation remains fail-closed; this PR prepares/evaluates readiness only and **does not activate Shadow or Paper**.
- Config flags remain false:
  - `shadow_activation_authorized=false`
  - `paper_activation_authorized=false`
  - `testnet_activation_authorized=false`
  - `scheduler_activation_authorized=false`
  - `runtime_activation_authorized=false`
  - `orders_authorized=false`
  - `live_authorized=false`
- Mission flags for this change: `LIVE_AUTHORIZED=false`, `ORDERS=false`, `SHADOW=false`, `PAPER=false`, `TESTNET=false`, `SCHEDULER=false`, `RUNTIME_ACTIVATION=false`
- No runtime side effects, no network I/O, no scheduler/worker start, no second truth / competing authority.
- **Separate operator GO required** for any runtime / activation stage.

## Non-goals

- Not Ready-for-review automation in this step beyond Draft creation
- Not merge
- Not Shadow/Paper/Testnet/Live activation
- Not scheduler or runtime wiring


Made with [Cursor](https://cursor.com)