### PR TITLE
ops: fail-closed path/reference validation for shadow readiness gate

### DIFF
--- a/config/ops/shadow_preparation_readiness_gate_v0.toml
+++ b/config/ops/shadow_preparation_readiness_gate_v0.toml
@@ -21,6 +21,11 @@ known_canonical_authority_identifiers = [
   "runbook.STEP_29V.paper_absent",
 ]
 
+# Single repository-relative STEP 29U semantics/runbook reference.
+# Existence proves the reference file is present only — not binding, not
+# implementation, and not activation authority.
+canonical_step_29u_semantics_reference = "docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.12.md"
+
 dashboard_blocker_id = "MARKET_DASHBOARD_VISIBLE_INTRABAR_CONTINUITY"
 dashboard_blocker_state = "OPEN"
 dashboard_blocker_resolved = false
@@ -86,19 +91,19 @@ notes = "Blocked preflight contract; does not authorize activation."
 
 [[historical_surfaces]]
 surface_id = "shadow_no_order_proof"
-path = "src/shadow_no_order_proof"
+path = "src/shadow_no_order_proof/__init__.py"
 classification = "EVIDENCE_ONLY"
 notes = "Declarative no-order proof markers; not a runtime entrypoint."
 
 [[historical_surfaces]]
 surface_id = "data_shadow_pipeline"
-path = "src/data/shadow"
+path = "src/data/shadow/__init__.py"
 classification = "OFFLINE_REPLAY"
 notes = "Shadow trading data pipeline (tick→OHLCV); blocked from live mode."
 
 [[historical_surfaces]]
 surface_id = "webui_paper_shadow_summary_readmodel"
-path = "src/webui/paper_shadow_summary_readmodel_v0"
+path = "src/webui/paper_shadow_summary_readmodel_v0/__init__.py"
 classification = "HISTORICAL"
 notes = "Paper/shadow WebUI readmodel; observability only; non-authorizing."
 
@@ -385,7 +390,7 @@ canonical_owner = "ops.shadow_preparation_readiness_gate_v0"
 implementation_path = ""
 evidence_paths = [
   "src/ops/shadow_preparation_readiness_gate_v0.py",
-  "src/shadow_no_order_proof",
+  "src/shadow_no_order_proof/__init__.py",
 ]
 blockers = [
   "ORDERS_AUTHORIZED=false",

--- a/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
+++ b/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
@@ -144,11 +144,36 @@ Evaluation fails closed when:
 
 - config is missing or invalid;
 - a required canonical reference cannot be established;
+- the configured `canonical_step_29u_semantics_reference` is missing, empty,
+  absolute, outside `repo_root`, not a file, or otherwise invalid;
+- any `historical_surfaces[].path` is missing, empty, absolute, outside
+  `repo_root`, not a file (directories are rejected), or otherwise invalid;
+- any configured Mindestkontrakt `evidence_paths` entry is missing, empty,
+  absolute, outside `repo_root`, not a file, or otherwise invalid;
 - contradictory activation state is supplied;
 - any activation flag is true;
 - dashboard blocker state is missing or claims resolved/waived/accepted;
 - historical surfaces are ambiguously classified (`UNKNOWN_FAIL_CLOSED`);
 - `authority_effect` is not `NONE`.
+
+### Repository-relative path / reference validation
+
+Evaluation requires an explicit or deterministically inferred `repo_root`.
+Required repository-relative references are validated before a readiness result
+is accepted. Invalid references raise
+`ShadowPreparationReadinessGateError` (exception fail-closed) and do **not**
+produce a normal BLOCKED readiness result.
+
+Reason-code prefixes (context id appended after `:`):
+
+- `HISTORICAL_SURFACE_PATH_MISSING|NOT_FILE|OUTSIDE_REPO|ABSOLUTE|EMPTY`
+- `EVIDENCE_PATH_MISSING|NOT_FILE|OUTSIDE_REPO|ABSOLUTE|EMPTY`
+- `CANONICAL_STEP_29U_SEMANTICS_REFERENCE_MISSING|NOT_FILE|OUTSIDE_REPO|ABSOLUTE|EMPTY|INVALID`
+
+Existence of `canonical_step_29u_semantics_reference` proves only that the
+canonical STEP 29U semantics/runbook file is present. It does **not** set
+`STEP_29U_IMPLEMENTED`, `CANONICAL_STEP_29U_BOUND`, or
+`SHADOW_PREPARATION_COMPLETE`, and grants no activation authority.
 
 
 ## STEP 29U Mindestkontrakt gap inventory (preparation only)

--- a/src/ops/shadow_preparation_readiness_gate_v0.py
+++ b/src/ops/shadow_preparation_readiness_gate_v0.py
@@ -42,6 +42,7 @@ DASHBOARD_BLOCKER_ID_CANONICAL = "MARKET_DASHBOARD_VISIBLE_INTRABAR_CONTINUITY"
 DASHBOARD_BLOCKER_STATE_OPEN = "OPEN"
 
 DEFAULT_CONFIG_RELATIVE_PATH = Path("config/ops/shadow_preparation_readiness_gate_v0.toml")
+CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY = "canonical_step_29u_semantics_reference"
 
 ALLOWED_CLASSIFICATIONS = frozenset(
     {
@@ -257,7 +258,7 @@ def evaluate_shadow_preparation_readiness_gate_v0(
     historical_surface_overrides: tuple[HistoricalSurfaceRecordV0, ...] | None = None,
 ) -> ShadowPreparationReadinessGateResultV0:
     """Evaluate Shadow-preparation readiness (offline, fail-closed, no side effects)."""
-    root = repo_root if repo_root is not None else _infer_repo_root()
+    root = (repo_root if repo_root is not None else _infer_repo_root()).resolve()
     cfg = (
         dict(config)
         if config is not None
@@ -311,15 +312,18 @@ def evaluate_shadow_preparation_readiness_gate_v0(
         else _parse_historical_surfaces(cfg)
     )
     _assert_surfaces_fail_closed(surfaces)
+    _validate_historical_surface_paths(repo_root=root, surfaces=surfaces)
 
     mindestkontrakt = _parse_mindestkontrakt_inventory(cfg)
     _assert_mindestkontrakt_inventory(mindestkontrakt)
+    _validate_mindestkontrakt_evidence_paths(repo_root=root, records=mindestkontrakt)
 
     canonical_refs = cfg.get("known_canonical_authority_identifiers") or []
     if not isinstance(canonical_refs, list) or not canonical_refs:
         raise ShadowPreparationReadinessGateError(
             "required_canonical_reference_missing:known_canonical_authority_identifiers"
         )
+    _validate_canonical_step_29u_semantics_reference(repo_root=root, cfg=cfg)
 
     required_gates = _parse_string_tuple(
         cfg.get("required_preparation_gates"),
@@ -384,6 +388,89 @@ def evaluate_shadow_preparation_readiness_gate_v0(
 
 def _infer_repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
+
+
+def _require_repo_relative_file(
+    *,
+    repo_root: Path,
+    relative_path: str,
+    context_id: str,
+    code_prefix: str,
+) -> Path:
+    """Fail-closed: require a non-empty repo-relative path that resolves to a file.
+
+    Rejects empty strings, absolute paths, paths escaping ``repo_root`` (including
+    via ``..`` / symlink resolution), missing paths, and directories.
+    """
+    if not isinstance(relative_path, str) or not relative_path.strip():
+        raise ShadowPreparationReadinessGateError(f"{code_prefix}_EMPTY:{context_id}")
+    rel = relative_path.strip()
+    candidate = Path(rel)
+    if candidate.is_absolute():
+        raise ShadowPreparationReadinessGateError(f"{code_prefix}_ABSOLUTE:{context_id}")
+    root = repo_root.resolve()
+    try:
+        resolved = (root / candidate).resolve()
+    except OSError as exc:
+        raise ShadowPreparationReadinessGateError(f"{code_prefix}_MISSING:{context_id}") from exc
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ShadowPreparationReadinessGateError(
+            f"{code_prefix}_OUTSIDE_REPO:{context_id}"
+        ) from exc
+    if not resolved.exists():
+        raise ShadowPreparationReadinessGateError(f"{code_prefix}_MISSING:{context_id}")
+    if not resolved.is_file():
+        raise ShadowPreparationReadinessGateError(f"{code_prefix}_NOT_FILE:{context_id}")
+    return resolved
+
+
+def _validate_historical_surface_paths(
+    *,
+    repo_root: Path,
+    surfaces: tuple[HistoricalSurfaceRecordV0, ...],
+) -> None:
+    for surface in surfaces:
+        _require_repo_relative_file(
+            repo_root=repo_root,
+            relative_path=surface.path,
+            context_id=surface.surface_id,
+            code_prefix="HISTORICAL_SURFACE_PATH",
+        )
+
+
+def _validate_mindestkontrakt_evidence_paths(
+    *,
+    repo_root: Path,
+    records: tuple[MindestkontraktComponentRecordV0, ...],
+) -> None:
+    for record in records:
+        for evidence_path in record.evidence_paths:
+            _require_repo_relative_file(
+                repo_root=repo_root,
+                relative_path=evidence_path,
+                context_id=record.component_id,
+                code_prefix="EVIDENCE_PATH",
+            )
+
+
+def _validate_canonical_step_29u_semantics_reference(
+    *,
+    repo_root: Path,
+    cfg: Mapping[str, Any],
+) -> None:
+    raw = cfg.get(CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY)
+    if raw is None:
+        raise ShadowPreparationReadinessGateError("CANONICAL_STEP_29U_SEMANTICS_REFERENCE_MISSING")
+    if not isinstance(raw, str):
+        raise ShadowPreparationReadinessGateError("CANONICAL_STEP_29U_SEMANTICS_REFERENCE_INVALID")
+    _require_repo_relative_file(
+        repo_root=repo_root,
+        relative_path=raw,
+        context_id=CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY,
+        code_prefix="CANONICAL_STEP_29U_SEMANTICS_REFERENCE",
+    )
 
 
 def _validate_config_document(doc: Mapping[str, Any]) -> None:
@@ -688,6 +775,7 @@ __all__ = [
     "SCHEMA_ID",
     "SCHEMA_VERSION",
     "CONTRACT_CONFIG_SCHEMA_VERSION",
+    "CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY",
     "DETERMINISTIC_EVALUATED_AT_DEFAULT",
     "AUTHORITY_EFFECT_NONE",
     "RUNTIME_BRIDGE_STATE_BOUND_NOT_ACTIVATED",

--- a/tests/ops/test_shadow_preparation_readiness_gate_v0.py
+++ b/tests/ops/test_shadow_preparation_readiness_gate_v0.py
@@ -13,6 +13,7 @@ from src.ops.shadow_preparation_readiness_gate_v0 import (
     ACTIVATION_FLAG_KEYS,
     ALLOWED_PREPARATION_STATUSES,
     AUTHORITY_EFFECT_NONE,
+    CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY,
     DASHBOARD_BLOCKER_ID_CANONICAL,
     DASHBOARD_BLOCKER_STATE_OPEN,
     DETERMINISTIC_EVALUATED_AT_DEFAULT,
@@ -362,5 +363,264 @@ def test_docs_declare_mindestkontrakt_inventory_non_activating() -> None:
         "LEGACY_NON_CANONICAL",
         "SEPARATE_GO_REQUIRED_FOR_IMPLEMENTATION=true",
         "SEPARATE_GO_REQUIRED_FOR_ACTIVATION=true",
+    ):
+        assert token in text, token
+
+
+EXPECTED_DEFAULT_BLOCKERS = (
+    "CANONICAL_STEP_29U_ABSENT",
+    "ECONOMIC_VALIDITY_OFFLINE_GATE_FAIL_BLOCKED",
+    "DASHBOARD_BLOCKER_OPEN:MARKET_DASHBOARD_VISIBLE_INTRABAR_CONTINUITY",
+    "RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED",
+    "HISTORICAL_SHADOW_SURFACES_NON_EQUIVALENT_TO_STEP_29U",
+    "NO_ACTIVATION_AUTHORIZED",
+)
+
+
+def _collect_required_relative_paths(cfg: dict) -> set[str]:
+    paths: set[str] = set()
+    for surface in cfg["historical_surfaces"]:
+        paths.add(str(surface["path"]).strip())
+    for component in cfg["mindestkontrakt_components"]:
+        for evidence_path in component.get("evidence_paths") or []:
+            paths.add(str(evidence_path).strip())
+    paths.add(str(cfg[CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY]).strip())
+    return paths
+
+
+def _materialize_temp_repo(tmp_path: Path) -> tuple[Path, dict]:
+    """Build an isolated offline repo_root with stub files for all required refs."""
+    cfg = load_shadow_preparation_readiness_gate_config_v0(CONFIG, repo_root=REPO_ROOT)
+    for relative in _collect_required_relative_paths(cfg):
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if not target.exists():
+            target.write_text(f"# stub:{relative}\n", encoding="utf-8")
+    config_dest = tmp_path / "config" / "ops" / "shadow_preparation_readiness_gate_v0.toml"
+    config_dest.parent.mkdir(parents=True, exist_ok=True)
+    config_dest.write_text(CONFIG.read_text(encoding="utf-8"), encoding="utf-8")
+    return tmp_path, cfg
+
+
+def _assert_blocked_non_activating(result) -> None:
+    assert result.shadow_preparation_complete is False
+    assert result.shadow_activatable is False
+    assert result.step_29u_implemented is False
+    assert result.canonical_step_29u_bound is False
+    assert result.shadow_activation_authorized is False
+    assert result.paper_activation_authorized is False
+    assert result.testnet_activation_authorized is False
+    assert result.scheduler_activation_authorized is False
+    assert result.runtime_activation_authorized is False
+    assert result.live_authorized is False
+    assert result.orders_authorized is False
+    assert result.blockers == EXPECTED_DEFAULT_BLOCKERS
+
+
+def test_default_canonical_config_reference_validation_still_blocked() -> None:
+    result = _default_result()
+    _assert_blocked_non_activating(result)
+    cfg = load_shadow_preparation_readiness_gate_config_v0(CONFIG, repo_root=REPO_ROOT)
+    assert CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY in cfg
+    assert (REPO_ROOT / cfg[CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY]).is_file()
+
+
+def test_explicit_temporary_repo_root_works_deterministically(tmp_path: Path) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    a = evaluate_shadow_preparation_readiness_gate_v0(
+        repo_root=root, evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT
+    )
+    b = evaluate_shadow_preparation_readiness_gate_v0(
+        repo_root=root, evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT
+    )
+    assert a.to_dict() == b.to_dict()
+    _assert_blocked_non_activating(a)
+
+
+def test_missing_historical_surface_file_fails_closed(tmp_path: Path) -> None:
+    root, cfg = _materialize_temp_repo(tmp_path)
+    surface_id = cfg["historical_surfaces"][0]["surface_id"]
+    target = root / cfg["historical_surfaces"][0]["path"]
+    target.unlink()
+    with pytest.raises(
+        ShadowPreparationReadinessGateError,
+        match=f"HISTORICAL_SURFACE_PATH_MISSING:{surface_id}",
+    ):
+        evaluate_shadow_preparation_readiness_gate_v0(repo_root=root)
+
+
+def test_historical_surface_directory_fails_closed(tmp_path: Path) -> None:
+    root, cfg = _materialize_temp_repo(tmp_path)
+    surface_id = cfg["historical_surfaces"][0]["surface_id"]
+    target = root / cfg["historical_surfaces"][0]["path"]
+    target.unlink()
+    target.mkdir()
+    with pytest.raises(
+        ShadowPreparationReadinessGateError,
+        match=f"HISTORICAL_SURFACE_PATH_NOT_FILE:{surface_id}",
+    ):
+        evaluate_shadow_preparation_readiness_gate_v0(repo_root=root)
+
+
+def test_historical_surface_absolute_path_rejected(tmp_path: Path) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    absolute = str((root / "src" / "orders" / "shadow.py").resolve())
+    overrides = (
+        HistoricalSurfaceRecordV0(
+            surface_id="phase24_shadow_order_executor",
+            path=absolute,
+            classification=HistoricalSurfaceClassification.NON_CANONICAL_STEP29U,
+        ),
+    )
+    with pytest.raises(
+        ShadowPreparationReadinessGateError,
+        match="HISTORICAL_SURFACE_PATH_ABSOLUTE:phase24_shadow_order_executor",
+    ):
+        evaluate_shadow_preparation_readiness_gate_v0(
+            repo_root=root, historical_surface_overrides=overrides
+        )
+
+
+def test_historical_surface_traversal_outside_repo_rejected(tmp_path: Path) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    outside = tmp_path.parent / "outside_escape_probe.py"
+    outside.write_text("# outside\n", encoding="utf-8")
+    overrides = (
+        HistoricalSurfaceRecordV0(
+            surface_id="phase24_shadow_order_executor",
+            path="../outside_escape_probe.py",
+            classification=HistoricalSurfaceClassification.NON_CANONICAL_STEP29U,
+        ),
+    )
+    with pytest.raises(
+        ShadowPreparationReadinessGateError,
+        match="HISTORICAL_SURFACE_PATH_OUTSIDE_REPO:phase24_shadow_order_executor",
+    ):
+        evaluate_shadow_preparation_readiness_gate_v0(
+            repo_root=root, historical_surface_overrides=overrides
+        )
+
+
+def test_missing_mindestkontrakt_evidence_file_fails_closed(tmp_path: Path) -> None:
+    root, cfg = _materialize_temp_repo(tmp_path)
+    component = next(c for c in cfg["mindestkontrakt_components"] if c.get("evidence_paths"))
+    component_id = component["component_id"]
+    evidence = component["evidence_paths"][0]
+    (root / evidence).unlink()
+    with pytest.raises(
+        ShadowPreparationReadinessGateError,
+        match=f"EVIDENCE_PATH_MISSING:{component_id}",
+    ):
+        evaluate_shadow_preparation_readiness_gate_v0(repo_root=root)
+
+
+def test_evidence_path_directory_fails_closed(tmp_path: Path) -> None:
+    root, cfg = _materialize_temp_repo(tmp_path)
+    component = next(c for c in cfg["mindestkontrakt_components"] if c.get("evidence_paths"))
+    component_id = component["component_id"]
+    evidence = component["evidence_paths"][0]
+    target = root / evidence
+    target.unlink()
+    target.mkdir()
+    with pytest.raises(
+        ShadowPreparationReadinessGateError,
+        match=f"EVIDENCE_PATH_NOT_FILE:{component_id}",
+    ):
+        evaluate_shadow_preparation_readiness_gate_v0(repo_root=root)
+
+
+def test_evidence_path_outside_repo_rejected(tmp_path: Path) -> None:
+    root, cfg = _materialize_temp_repo(tmp_path)
+    component = next(
+        c
+        for c in cfg["mindestkontrakt_components"]
+        if c["component_id"] == "execution_simulation_boundary"
+    )
+    mutated = dict(cfg)
+    components = []
+    for item in cfg["mindestkontrakt_components"]:
+        if item["component_id"] == component["component_id"]:
+            replaced = dict(item)
+            replaced["evidence_paths"] = ["../outside_escape_probe.py"]
+            components.append(replaced)
+        else:
+            components.append(item)
+    mutated["mindestkontrakt_components"] = components
+    outside = tmp_path.parent / "outside_escape_probe.py"
+    outside.write_text("# outside\n", encoding="utf-8")
+    with pytest.raises(
+        ShadowPreparationReadinessGateError,
+        match="EVIDENCE_PATH_OUTSIDE_REPO:execution_simulation_boundary",
+    ):
+        evaluate_shadow_preparation_readiness_gate_v0(repo_root=root, config=mutated)
+
+
+def test_missing_canonical_step29u_semantics_reference_fails_closed(tmp_path: Path) -> None:
+    root, cfg = _materialize_temp_repo(tmp_path)
+    mutated = dict(cfg)
+    mutated.pop(CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY, None)
+    with pytest.raises(
+        ShadowPreparationReadinessGateError,
+        match="CANONICAL_STEP_29U_SEMANTICS_REFERENCE_MISSING",
+    ):
+        evaluate_shadow_preparation_readiness_gate_v0(repo_root=root, config=mutated)
+
+
+def test_canonical_step29u_reference_does_not_mark_implemented_or_bound() -> None:
+    result = _default_result()
+    cfg = load_shadow_preparation_readiness_gate_config_v0(CONFIG, repo_root=REPO_ROOT)
+    assert (REPO_ROOT / cfg[CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY]).is_file()
+    assert result.step_29u_implemented is False
+    assert result.canonical_step_29u_bound is False
+    assert result.shadow_preparation_complete is False
+
+
+def test_valid_legacy_evidence_paths_remain_legacy_non_canonical() -> None:
+    result = _default_result()
+    by_id = {item.component_id: item for item in result.mindestkontrakt_inventory}
+    assert by_id["execution_simulation_boundary"].preparation_status == (
+        PreparationStatusV0.LEGACY_NON_CANONICAL
+    )
+    assert by_id["execution_simulation_boundary"].evidence_paths
+    for path in by_id["execution_simulation_boundary"].evidence_paths:
+        assert (REPO_ROOT / path).is_file()
+
+
+def test_valid_references_preserve_blocker_order_and_readiness_semantics() -> None:
+    result = _default_result()
+    _assert_blocked_non_activating(result)
+    assert list(result.blockers) == list(EXPECTED_DEFAULT_BLOCKERS)
+
+
+def test_path_validation_performs_no_file_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    original_write_text = Path.write_text
+    original_write_bytes = Path.write_bytes
+
+    def _block_write_text(self: Path, *args, **kwargs):  # pragma: no cover
+        raise AssertionError(f"unexpected write_text:{self}")
+
+    def _block_write_bytes(self: Path, *args, **kwargs):  # pragma: no cover
+        raise AssertionError(f"unexpected write_bytes:{self}")
+
+    monkeypatch.setattr(Path, "write_text", _block_write_text)
+    monkeypatch.setattr(Path, "write_bytes", _block_write_bytes)
+    result = evaluate_shadow_preparation_readiness_gate_v0(repo_root=root)
+    _assert_blocked_non_activating(result)
+    # Restore is automatic via monkeypatch teardown; keep originals referenced.
+    assert original_write_text is not None
+    assert original_write_bytes is not None
+
+
+def test_docs_declare_path_reference_fail_closed_tokens() -> None:
+    text = CONTRACT_DOC.read_text(encoding="utf-8")
+    for token in (
+        "HISTORICAL_SURFACE_PATH_MISSING",
+        "EVIDENCE_PATH_MISSING",
+        "CANONICAL_STEP_29U_SEMANTICS_REFERENCE",
+        "ShadowPreparationReadinessGateError",
+        "directories are rejected",
     ):
         assert token in text, token


### PR DESCRIPTION
## Summary
- Add offline fail-closed validation of `historical_surfaces[].path`, Mindestkontrakt `evidence_paths`, and `canonical_step_29u_semantics_reference` against an explicit `repo_root`.
- Reject empty/absolute/escaping/non-file references via `ShadowPreparationReadinessGateError` before a readiness result is accepted.
- Keep default evaluation BLOCKED and non-activating; no STEP 29U implementation, projection emitter, or activation changes.

## Test plan
- [x] `pytest -q tests/ops/test_shadow_preparation_readiness_gate_v0.py tests/ops/test_step29u_canonical_semantics_contract_v0.py`
- [x] focused selector contracts for `shadow_preparation_readiness_gate_focused`
- [ ] GitHub CI confirmation (draft only; not Ready-for-Review)


Made with [Cursor](https://cursor.com)