### PR TITLE
ops: durable shadow preparation readiness projection v0

### DIFF
--- a/config/ops/shadow_preparation_readiness_gate_v0.toml
+++ b/config/ops/shadow_preparation_readiness_gate_v0.toml
@@ -44,6 +44,10 @@ runtime_activation_authorized = false
 live_authorized = false
 orders_authorized = false
 
+# Durable readiness projection output (generated evidence only).
+# Not an activation input. Not written by evaluate/import; requires explicit writer call.
+readiness_projection_output_path = "out/ops/shadow_preparation_readiness_projection_v0.json"
+
 required_preparation_gates = [
   "CANONICAL_STEP_29U_BOUND",
   "ECONOMIC_VALIDITY_OFFLINE_GATE_PASS",

--- a/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
+++ b/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
@@ -137,6 +137,7 @@ READINESS_PRODUCER_CANNOT_ACTIVATE_STEP_29U=true
 | Contract doc (this file) | `docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md` |
 | Related charter (non-activating) | `docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md` |
 | Focused tests | `tests/ops/test_shadow_preparation_readiness_gate_v0.py` |
+| Durable projection output (generated) | `out/ops/shadow_preparation_readiness_projection_v0.json` |
 
 ## Fail-closed conditions
 
@@ -206,6 +207,89 @@ non-canonical (`LEGACY_NON_CANONICAL` / historical surface classifications).
 STEP 29V Paper Mode remains canonically undefined
 (`CANONICAL_STEP_29V_PAPER_MODE_EXISTS=false`). This contract does not define
 STEP 29V semantics.
+
+## Durable readiness projection (projection-only, non-authoritative)
+
+```text
+PROJECTION_SCHEMA_ID=shadow_preparation_readiness_projection
+PROJECTION_SCHEMA_VERSION=v0
+PROJECTION_ONLY=true
+AUTHORITY_EFFECT=NONE
+ACTIVATION_AUTHORITY=false
+EXPLICIT_WRITE_CALL_REQUIRED=true
+NOT_STEP_29U_IMPLEMENTATION=true
+NOT_READINESS_APPROVAL=true
+NOT_ACTIVATION_AUTHORITY=true
+NOT_SCHEDULER_INPUT=true
+NOT_RUNTIME_COMMAND=true
+NOT_DASHBOARD_AUTHORITY=true
+```
+
+An optional durable projection writer may serialize **one already-computed**
+readiness evaluation into immutable, versioned, deterministic UTF-8 JSON bytes
+and atomically replace an explicitly configured repository-relative output path.
+
+- Writing requires an **explicit** writer call
+  (`write_shadow_preparation_readiness_projection_v0`).
+- Evaluation alone remains side-effect free and writes **no** artifact.
+- The writer does **not** recompute readiness, filesystem evidence, blockers, or
+  STEP-29U semantics; it consumes the canonical evaluation payload
+  (`evaluation.to_dict()`).
+- Default configured path:
+  `out/ops/shadow_preparation_readiness_projection_v0.json`
+  (generated evidence/projection only; not an activation input; does not
+  overwrite historical source evidence).
+
+### Deterministic serialization contract
+
+- UTF-8 JSON
+- deterministic key ordering (`sort_keys=true`)
+- deterministic separators (`","`, `":"`)
+- trailing newline explicitly defined
+- fixed `evaluated_at` yields byte-identical output
+- no wall-clock timestamp inside the writer
+- no random IDs
+- no host-specific absolute paths in serialized content
+- complete file replacement only (no append)
+
+### Atomic-write contract
+
+1. serialize complete deterministic bytes
+2. write to a temporary sibling file in the same directory
+3. flush + fsync (where supported)
+4. atomically replace the destination
+5. clean up temporary files on failure
+
+No partial destination is left on write failure. A failed atomic replace must
+preserve any previous complete destination.
+
+### Path containment rules
+
+The projection output path must be:
+
+- explicit and repository-relative
+- resolved inside `repo_root` (independent of current working directory)
+- reject empty values, absolute paths, and traversal outside `repo_root`
+- reject an existing directory target
+- require the parent directory to already exist (fail closed; no silent nested
+  directory creation)
+
+Stable failure reason prefixes include:
+
+- `PROJECTION_OUTPUT_PATH_EMPTY`
+- `PROJECTION_OUTPUT_PATH_ABSOLUTE`
+- `PROJECTION_OUTPUT_PATH_OUTSIDE_REPO`
+- `PROJECTION_OUTPUT_PARENT_MISSING`
+- `PROJECTION_OUTPUT_PATH_IS_DIRECTORY`
+- `PROJECTION_SERIALIZATION_FAILED`
+- `PROJECTION_TEMP_WRITE_FAILED`
+- `PROJECTION_ATOMIC_REPLACE_FAILED`
+
+Write failure must not be converted into a successful readiness result and must
+not alter evaluation blocker order or readiness outcome.
+
+The projection is **not**: STEP-29U implementation; readiness approval;
+activation authority; scheduler input; runtime command; or dashboard authority.
 
 ## Next permitted action
 

--- a/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
+++ b/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
@@ -137,7 +137,7 @@ READINESS_PRODUCER_CANNOT_ACTIVATE_STEP_29U=true
 | Contract doc (this file) | `docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md` |
 | Related charter (non-activating) | `docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md` |
 | Focused tests | `tests/ops/test_shadow_preparation_readiness_gate_v0.py` |
-| Durable projection output (generated) | `out/ops/shadow_preparation_readiness_projection_v0.json` |
+| Durable projection output (generated) | `out&#47;ops&#47;shadow_preparation_readiness_projection_v0.json` |
 
 ## Fail-closed conditions
 
@@ -236,7 +236,7 @@ and atomically replace an explicitly configured repository-relative output path.
   STEP-29U semantics; it consumes the canonical evaluation payload
   (`evaluation.to_dict()`).
 - Default configured path:
-  `out/ops/shadow_preparation_readiness_projection_v0.json`
+  `out&#47;ops&#47;shadow_preparation_readiness_projection_v0.json`
   (generated evidence/projection only; not an activation input; does not
   overwrite historical source evidence).
 

--- a/src/ops/shadow_preparation_readiness_gate_v0.py
+++ b/src/ops/shadow_preparation_readiness_gate_v0.py
@@ -11,11 +11,18 @@ This module:
 - does not implement, activate, schedule, start, simulate, or execute Shadow,
   Paper, Testnet, Runtime, or Orders;
 - has ``authority_effect=NONE`` and cannot modify another owner;
-- performs no network I/O and starts no scheduler/worker/process.
+- performs no network I/O and starts no scheduler/worker/process;
+- may optionally serialize an already-computed readiness evaluation into a
+  durable, projection-only artifact via an explicit writer call (never by
+  evaluation alone).
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
+import tempfile
 from dataclasses import asdict, dataclass
 from enum import Enum
 from pathlib import Path
@@ -31,6 +38,11 @@ PRODUCER_FAMILY = "ops.shadow_preparation_readiness_gate_v0"
 SCHEMA_ID = "ops.shadow_preparation_readiness_gate_v0"
 SCHEMA_VERSION = "v0"
 CONTRACT_CONFIG_SCHEMA_VERSION = "shadow_preparation_readiness_gate.v0"
+
+PROJECTION_SCHEMA_ID = "shadow_preparation_readiness_projection"
+PROJECTION_SCHEMA_VERSION = "v0"
+PROJECTION_OUTPUT_PATH_CONFIG_KEY = "readiness_projection_output_path"
+DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH = "out/ops/shadow_preparation_readiness_projection_v0.json"
 
 # Deterministic evaluation timestamp convention for pure offline contracts:
 # callers may override; default is a fixed epoch sentinel (no wall-clock).
@@ -221,6 +233,26 @@ class ShadowPreparationReadinessGateResultV0:
         return payload
 
 
+@dataclass(frozen=True)
+class ShadowPreparationReadinessProjectionWriteMetadataV0:
+    """Non-authoritative write metadata for a durable readiness projection."""
+
+    output_path: str
+    schema_id: str
+    schema_version: str
+    byte_length: int
+    sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "output_path": self.output_path,
+            "schema_id": self.schema_id,
+            "schema_version": self.schema_version,
+            "byte_length": self.byte_length,
+            "sha256": self.sha256,
+        }
+
+
 def default_config_path(*, repo_root: Path | None = None) -> Path:
     root = repo_root if repo_root is not None else _infer_repo_root()
     return (root / DEFAULT_CONFIG_RELATIVE_PATH).resolve()
@@ -383,6 +415,163 @@ def evaluate_shadow_preparation_readiness_gate_v0(
         unmet_gates=tuple(unmet),
         blockers=tuple(blockers),
         next_permitted_action=next_action,
+    )
+
+
+def build_shadow_preparation_readiness_projection_payload_v0(
+    *,
+    evaluation: ShadowPreparationReadinessGateResultV0,
+    evaluated_at: str,
+) -> dict[str, Any]:
+    """Build the deterministic projection document from an existing evaluation.
+
+    Does not re-evaluate readiness, filesystem evidence, blockers, or STEP-29U
+    semantics. Consumes ``evaluation.to_dict()`` as the sole evaluation payload.
+    """
+    if not isinstance(evaluated_at, str) or not evaluated_at.strip():
+        raise ShadowPreparationReadinessGateError("PROJECTION_EVALUATED_AT_EMPTY")
+    evaluation_payload = evaluation.to_dict()
+    return {
+        "schema_id": PROJECTION_SCHEMA_ID,
+        "schema_version": PROJECTION_SCHEMA_VERSION,
+        "evaluated_at": evaluated_at.strip(),
+        "authority_effect": AUTHORITY_EFFECT_NONE,
+        "activation_authority": False,
+        "projection_only": True,
+        "evaluation": evaluation_payload,
+        "blockers": list(evaluation.blockers),
+        "shadow_preparation_complete": evaluation.shadow_preparation_complete,
+        "shadow_activatable": evaluation.shadow_activatable,
+        "step_29u_implemented": evaluation.step_29u_implemented,
+        "canonical_step_29u_bound": evaluation.canonical_step_29u_bound,
+        "shadow_activation_authorized": evaluation.shadow_activation_authorized,
+        "paper_activation_authorized": evaluation.paper_activation_authorized,
+        "testnet_activation_authorized": evaluation.testnet_activation_authorized,
+        "scheduler_activation_authorized": evaluation.scheduler_activation_authorized,
+        "runtime_activation_authorized": evaluation.runtime_activation_authorized,
+        "live_authorized": evaluation.live_authorized,
+        "orders_authorized": evaluation.orders_authorized,
+        "evaluation_schema_id": evaluation.schema_id,
+        "evaluation_schema_version": evaluation.schema_version,
+    }
+
+
+def serialize_shadow_preparation_readiness_projection_v0(
+    payload: Mapping[str, Any],
+) -> bytes:
+    """Serialize projection payload to deterministic UTF-8 JSON with trailing newline."""
+    try:
+        text = json.dumps(
+            dict(payload),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ShadowPreparationReadinessGateError(f"PROJECTION_SERIALIZATION_FAILED:{exc}") from exc
+    return (text + "\n").encode("utf-8")
+
+
+def _resolve_projection_output_path(
+    *,
+    repo_root: Path,
+    output_path: str,
+) -> tuple[str, Path]:
+    """Resolve a repository-relative projection output path (fail-closed)."""
+    if not isinstance(output_path, str) or not output_path.strip():
+        raise ShadowPreparationReadinessGateError("PROJECTION_OUTPUT_PATH_EMPTY")
+    rel = output_path.strip()
+    candidate = Path(rel)
+    if candidate.is_absolute():
+        raise ShadowPreparationReadinessGateError("PROJECTION_OUTPUT_PATH_ABSOLUTE")
+    root = repo_root.resolve()
+    try:
+        resolved = (root / candidate).resolve()
+    except OSError as exc:
+        raise ShadowPreparationReadinessGateError("PROJECTION_OUTPUT_PATH_RESOLVE_FAILED") from exc
+    try:
+        repo_relative = resolved.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ShadowPreparationReadinessGateError("PROJECTION_OUTPUT_PATH_OUTSIDE_REPO") from exc
+    if resolved.exists() and resolved.is_dir():
+        raise ShadowPreparationReadinessGateError("PROJECTION_OUTPUT_PATH_IS_DIRECTORY")
+    parent = resolved.parent
+    if not parent.exists() or not parent.is_dir():
+        raise ShadowPreparationReadinessGateError("PROJECTION_OUTPUT_PARENT_MISSING")
+    return repo_relative, resolved
+
+
+def _atomic_write_bytes(*, destination: Path, content: bytes) -> None:
+    """Atomically replace destination with content (temp sibling + fsync + replace)."""
+    fd, temp_path = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=f".tmp_{destination.name}_",
+        suffix=".partial",
+    )
+    closed = False
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            closed = True
+            try:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            except OSError as exc:
+                raise ShadowPreparationReadinessGateError(
+                    f"PROJECTION_TEMP_WRITE_FAILED:{exc}"
+                ) from exc
+        try:
+            os.replace(temp_path, destination)
+        except OSError as exc:
+            raise ShadowPreparationReadinessGateError(
+                f"PROJECTION_ATOMIC_REPLACE_FAILED:{exc}"
+            ) from exc
+    except Exception:
+        if os.path.exists(temp_path):
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+        raise
+    finally:
+        if not closed:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def write_shadow_preparation_readiness_projection_v0(
+    *,
+    evaluation: ShadowPreparationReadinessGateResultV0,
+    repo_root: Path,
+    output_path: str,
+    evaluated_at: str,
+) -> ShadowPreparationReadinessProjectionWriteMetadataV0:
+    """Write one already-computed readiness evaluation as durable projection bytes.
+
+    Offline evidence projection only. Not activation authority. Not STEP-29U.
+    Does not recompute readiness. Evaluation alone remains side-effect free;
+    writing requires this explicit call.
+    """
+    root = repo_root.resolve()
+    repo_relative, destination = _resolve_projection_output_path(
+        repo_root=root,
+        output_path=output_path,
+    )
+    payload = build_shadow_preparation_readiness_projection_payload_v0(
+        evaluation=evaluation,
+        evaluated_at=evaluated_at,
+    )
+    content = serialize_shadow_preparation_readiness_projection_v0(payload)
+    _atomic_write_bytes(destination=destination, content=content)
+    digest = hashlib.sha256(content).hexdigest()
+    return ShadowPreparationReadinessProjectionWriteMetadataV0(
+        output_path=repo_relative,
+        schema_id=PROJECTION_SCHEMA_ID,
+        schema_version=PROJECTION_SCHEMA_VERSION,
+        byte_length=len(content),
+        sha256=digest,
     )
 
 
@@ -775,6 +964,10 @@ __all__ = [
     "SCHEMA_ID",
     "SCHEMA_VERSION",
     "CONTRACT_CONFIG_SCHEMA_VERSION",
+    "PROJECTION_SCHEMA_ID",
+    "PROJECTION_SCHEMA_VERSION",
+    "PROJECTION_OUTPUT_PATH_CONFIG_KEY",
+    "DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH",
     "CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY",
     "DETERMINISTIC_EVALUATED_AT_DEFAULT",
     "AUTHORITY_EFFECT_NONE",
@@ -789,7 +982,11 @@ __all__ = [
     "PreparationStatusV0",
     "MindestkontraktComponentRecordV0",
     "ShadowPreparationReadinessGateResultV0",
+    "ShadowPreparationReadinessProjectionWriteMetadataV0",
     "default_config_path",
     "load_shadow_preparation_readiness_gate_config_v0",
     "evaluate_shadow_preparation_readiness_gate_v0",
+    "build_shadow_preparation_readiness_projection_payload_v0",
+    "serialize_shadow_preparation_readiness_projection_v0",
+    "write_shadow_preparation_readiness_projection_v0",
 ]

--- a/tests/ops/test_shadow_preparation_readiness_gate_v0.py
+++ b/tests/ops/test_shadow_preparation_readiness_gate_v0.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import ast
+import hashlib
 import inspect
+import json
+import os
 import socket
 from pathlib import Path
 
@@ -16,9 +19,13 @@ from src.ops.shadow_preparation_readiness_gate_v0 import (
     CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY,
     DASHBOARD_BLOCKER_ID_CANONICAL,
     DASHBOARD_BLOCKER_STATE_OPEN,
+    DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
     DETERMINISTIC_EVALUATED_AT_DEFAULT,
     PACKAGE_MARKER,
     PRODUCER_FAMILY,
+    PROJECTION_OUTPUT_PATH_CONFIG_KEY,
+    PROJECTION_SCHEMA_ID,
+    PROJECTION_SCHEMA_VERSION,
     REQUIRED_MINDESTKONTRAKT_COMPONENT_IDS,
     RUNTIME_BRIDGE_STATE_BOUND_NOT_ACTIVATED,
     SCHEMA_ID,
@@ -26,8 +33,11 @@ from src.ops.shadow_preparation_readiness_gate_v0 import (
     HistoricalSurfaceRecordV0,
     PreparationStatusV0,
     ShadowPreparationReadinessGateError,
+    build_shadow_preparation_readiness_projection_payload_v0,
     evaluate_shadow_preparation_readiness_gate_v0,
     load_shadow_preparation_readiness_gate_config_v0,
+    serialize_shadow_preparation_readiness_projection_v0,
+    write_shadow_preparation_readiness_projection_v0,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -624,3 +634,353 @@ def test_docs_declare_path_reference_fail_closed_tokens() -> None:
         "directories are rejected",
     ):
         assert token in text, token
+
+
+# ---------------------------------------------------------------------------
+# Durable readiness projection v0 (offline evidence projection only)
+# ---------------------------------------------------------------------------
+
+
+def _projection_out(tmp_path: Path, name: str = "projection.json") -> tuple[Path, str]:
+    parent = tmp_path / "out" / "ops"
+    parent.mkdir(parents=True, exist_ok=True)
+    rel = f"out/ops/{name}"
+    return tmp_path, rel
+
+
+def test_projection_valid_evaluation_writes_expected_document(tmp_path: Path) -> None:
+    root, rel = _projection_out(tmp_path)
+    evaluation = evaluate_shadow_preparation_readiness_gate_v0(
+        repo_root=REPO_ROOT, evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT
+    )
+    meta = write_shadow_preparation_readiness_projection_v0(
+        evaluation=evaluation,
+        repo_root=root,
+        output_path=rel,
+        evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+    )
+    dest = root / rel
+    assert dest.is_file()
+    payload = json.loads(dest.read_text(encoding="utf-8"))
+    assert payload["schema_id"] == PROJECTION_SCHEMA_ID
+    assert payload["schema_version"] == PROJECTION_SCHEMA_VERSION
+    assert payload["evaluated_at"] == DETERMINISTIC_EVALUATED_AT_DEFAULT
+    assert payload["evaluation"] == json.loads(json.dumps(evaluation.to_dict()))
+    assert payload["blockers"] == list(EXPECTED_DEFAULT_BLOCKERS)
+    assert meta.output_path == rel
+    assert meta.schema_id == PROJECTION_SCHEMA_ID
+    assert meta.schema_version == PROJECTION_SCHEMA_VERSION
+
+
+def test_projection_fixed_inputs_byte_identical(tmp_path: Path) -> None:
+    root, rel = _projection_out(tmp_path, "a.json")
+    evaluation = evaluate_shadow_preparation_readiness_gate_v0(
+        repo_root=REPO_ROOT, evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT
+    )
+    write_shadow_preparation_readiness_projection_v0(
+        evaluation=evaluation,
+        repo_root=root,
+        output_path=rel,
+        evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+    )
+    first = (root / rel).read_bytes()
+    write_shadow_preparation_readiness_projection_v0(
+        evaluation=evaluation,
+        repo_root=root,
+        output_path=rel,
+        evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+    )
+    second = (root / rel).read_bytes()
+    assert first == second
+
+
+def test_projection_deterministic_json_ordering_and_trailing_newline(tmp_path: Path) -> None:
+    root, rel = _projection_out(tmp_path)
+    evaluation = _default_result(evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT)
+    write_shadow_preparation_readiness_projection_v0(
+        evaluation=evaluation,
+        repo_root=root,
+        output_path=rel,
+        evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+    )
+    raw = (root / rel).read_bytes()
+    assert raw.endswith(b"\n")
+    assert not raw.endswith(b"\n\n")
+    text = raw.decode("utf-8")
+    expected = (
+        json.dumps(
+            json.loads(text),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    assert text == expected
+
+
+def test_projection_sha256_metadata_matches_exact_bytes(tmp_path: Path) -> None:
+    root, rel = _projection_out(tmp_path)
+    evaluation = _default_result(evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT)
+    meta = write_shadow_preparation_readiness_projection_v0(
+        evaluation=evaluation,
+        repo_root=root,
+        output_path=rel,
+        evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+    )
+    raw = (root / rel).read_bytes()
+    assert meta.byte_length == len(raw)
+    assert meta.sha256 == hashlib.sha256(raw).hexdigest()
+
+
+def test_projection_uses_existing_evaluation_without_recomputation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, rel = _projection_out(tmp_path)
+    evaluation = _default_result(evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT)
+
+    def _blocked(*_a, **_k):  # pragma: no cover
+        raise AssertionError("evaluate must not be called by writer")
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_gate_v0.evaluate_shadow_preparation_readiness_gate_v0",
+        _blocked,
+    )
+    meta = write_shadow_preparation_readiness_projection_v0(
+        evaluation=evaluation,
+        repo_root=root,
+        output_path=rel,
+        evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+    )
+    payload = json.loads((root / rel).read_text(encoding="utf-8"))
+    assert payload["evaluation"] == json.loads(json.dumps(evaluation.to_dict()))
+    assert meta.sha256
+
+
+def test_projection_does_not_mutate_evaluation_object(tmp_path: Path) -> None:
+    root, rel = _projection_out(tmp_path)
+    evaluation = _default_result(evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT)
+    before = evaluation.to_dict()
+    write_shadow_preparation_readiness_projection_v0(
+        evaluation=evaluation,
+        repo_root=root,
+        output_path=rel,
+        evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+    )
+    assert evaluation.to_dict() == before
+
+
+def test_projection_preserves_blocked_non_activating_readiness_semantics(
+    tmp_path: Path,
+) -> None:
+    root, rel = _projection_out(tmp_path)
+    evaluation = _default_result(evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT)
+    _assert_blocked_non_activating(evaluation)
+    write_shadow_preparation_readiness_projection_v0(
+        evaluation=evaluation,
+        repo_root=root,
+        output_path=rel,
+        evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+    )
+    payload = json.loads((root / rel).read_text(encoding="utf-8"))
+    assert payload["shadow_preparation_complete"] is False
+    assert payload["shadow_activatable"] is False
+    assert payload["step_29u_implemented"] is False
+    assert payload["canonical_step_29u_bound"] is False
+    for key in ACTIVATION_FLAG_KEYS:
+        assert payload[key] is False
+    assert payload["authority_effect"] == "NONE"
+    assert payload["activation_authority"] is False
+    assert payload["projection_only"] is True
+    assert payload["blockers"] == list(EXPECTED_DEFAULT_BLOCKERS)
+    _assert_blocked_non_activating(evaluation)
+
+
+def test_projection_absolute_path_fails_closed(tmp_path: Path) -> None:
+    evaluation = _default_result()
+    with pytest.raises(
+        ShadowPreparationReadinessGateError, match="PROJECTION_OUTPUT_PATH_ABSOLUTE"
+    ):
+        write_shadow_preparation_readiness_projection_v0(
+            evaluation=evaluation,
+            repo_root=tmp_path,
+            output_path=str(tmp_path / "out.json"),
+            evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+        )
+
+
+def test_projection_outside_repo_path_fails_closed(tmp_path: Path) -> None:
+    (tmp_path / "out" / "ops").mkdir(parents=True, exist_ok=True)
+    evaluation = _default_result()
+    with pytest.raises(
+        ShadowPreparationReadinessGateError, match="PROJECTION_OUTPUT_PATH_OUTSIDE_REPO"
+    ):
+        write_shadow_preparation_readiness_projection_v0(
+            evaluation=evaluation,
+            repo_root=tmp_path,
+            output_path="../outside_projection.json",
+            evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+        )
+
+
+def test_projection_empty_path_fails_closed(tmp_path: Path) -> None:
+    evaluation = _default_result()
+    with pytest.raises(ShadowPreparationReadinessGateError, match="PROJECTION_OUTPUT_PATH_EMPTY"):
+        write_shadow_preparation_readiness_projection_v0(
+            evaluation=evaluation,
+            repo_root=tmp_path,
+            output_path="   ",
+            evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+        )
+
+
+def test_projection_missing_parent_fails_closed(tmp_path: Path) -> None:
+    evaluation = _default_result()
+    with pytest.raises(
+        ShadowPreparationReadinessGateError, match="PROJECTION_OUTPUT_PARENT_MISSING"
+    ):
+        write_shadow_preparation_readiness_projection_v0(
+            evaluation=evaluation,
+            repo_root=tmp_path,
+            output_path="missing_parent/projection.json",
+            evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+        )
+
+
+def test_projection_directory_target_fails_closed(tmp_path: Path) -> None:
+    target_dir = tmp_path / "out" / "ops" / "projection_dir"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    evaluation = _default_result()
+    with pytest.raises(
+        ShadowPreparationReadinessGateError, match="PROJECTION_OUTPUT_PATH_IS_DIRECTORY"
+    ):
+        write_shadow_preparation_readiness_projection_v0(
+            evaluation=evaluation,
+            repo_root=tmp_path,
+            output_path="out/ops/projection_dir",
+            evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+        )
+
+
+def test_projection_temp_write_failure_leaves_no_partial_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, rel = _projection_out(tmp_path)
+    dest = root / rel
+    evaluation = _default_result(evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT)
+
+    import src.ops.shadow_preparation_readiness_gate_v0 as mod
+
+    def _fail_write(self, *_args, **_kwargs):
+        raise OSError("simulated temp write failure")
+
+    monkeypatch.setattr(mod.os, "write", _fail_write)  # unused safeguard
+
+    # Fail at flush/fsync stage after temp creation by patching fsync.
+    def _fail_fsync(_fd):
+        raise OSError("simulated temp write failure")
+
+    monkeypatch.setattr(mod.os, "fsync", _fail_fsync)
+    with pytest.raises(ShadowPreparationReadinessGateError, match="PROJECTION_TEMP_WRITE_FAILED"):
+        write_shadow_preparation_readiness_projection_v0(
+            evaluation=evaluation,
+            repo_root=root,
+            output_path=rel,
+            evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+        )
+    assert not dest.exists()
+    leftovers = list((root / "out" / "ops").glob(".tmp_*"))
+    assert leftovers == []
+
+
+def test_projection_atomic_replace_failure_preserves_previous_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, rel = _projection_out(tmp_path)
+    dest = root / rel
+    previous = b'{"previous":true}\n'
+    dest.write_bytes(previous)
+    evaluation = _default_result(evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT)
+
+    import src.ops.shadow_preparation_readiness_gate_v0 as mod
+
+    def _fail_replace(src, dst):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(mod.os, "replace", _fail_replace)
+    with pytest.raises(
+        ShadowPreparationReadinessGateError, match="PROJECTION_ATOMIC_REPLACE_FAILED"
+    ):
+        write_shadow_preparation_readiness_projection_v0(
+            evaluation=evaluation,
+            repo_root=root,
+            output_path=rel,
+            evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+        )
+    assert dest.read_bytes() == previous
+    leftovers = list((root / "out" / "ops").glob(".tmp_*"))
+    assert leftovers == []
+
+
+def test_evaluation_alone_writes_no_projection_artifact(tmp_path: Path) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    before = {p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()}
+    result = evaluate_shadow_preparation_readiness_gate_v0(repo_root=root)
+    after = {p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()}
+    assert after == before
+    _assert_blocked_non_activating(result)
+    assert not (root / DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH).exists()
+
+
+def test_projection_writer_independent_of_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, rel = _projection_out(tmp_path)
+    other = tmp_path / "other_cwd"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    evaluation = _default_result(evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT)
+    meta = write_shadow_preparation_readiness_projection_v0(
+        evaluation=evaluation,
+        repo_root=root,
+        output_path=rel,
+        evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT,
+    )
+    assert (root / rel).is_file()
+    assert not (other / rel).exists()
+    assert meta.output_path == rel
+
+
+def test_config_declares_default_projection_output_path() -> None:
+    cfg = load_shadow_preparation_readiness_gate_config_v0(CONFIG, repo_root=REPO_ROOT)
+    assert cfg[PROJECTION_OUTPUT_PATH_CONFIG_KEY] == DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH
+    assert not Path(DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH).is_absolute()
+
+
+def test_docs_declare_durable_projection_contract_tokens() -> None:
+    text = CONTRACT_DOC.read_text(encoding="utf-8")
+    for token in (
+        "PROJECTION_SCHEMA_ID=shadow_preparation_readiness_projection",
+        "PROJECTION_SCHEMA_VERSION=v0",
+        "PROJECTION_ONLY=true",
+        "EXPLICIT_WRITE_CALL_REQUIRED=true",
+        "NOT_READINESS_APPROVAL=true",
+        "NOT_ACTIVATION_AUTHORITY=true",
+        "NOT_SCHEDULER_INPUT=true",
+        "NOT_RUNTIME_COMMAND=true",
+        "NOT_DASHBOARD_AUTHORITY=true",
+        "PROJECTION_OUTPUT_PATH_EMPTY",
+        "write_shadow_preparation_readiness_projection_v0",
+        "out/ops/shadow_preparation_readiness_projection_v0.json",
+    ):
+        assert token in text, token
+
+
+def test_projection_payload_builder_uses_evaluation_to_dict() -> None:
+    evaluation = _default_result(evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT)
+    payload = build_shadow_preparation_readiness_projection_payload_v0(
+        evaluation=evaluation, evaluated_at=DETERMINISTIC_EVALUATED_AT_DEFAULT
+    )
+    assert payload["evaluation"] == evaluation.to_dict()
+    raw = serialize_shadow_preparation_readiness_projection_v0(payload)
+    assert raw.endswith(b"\n")

--- a/tests/ops/test_shadow_preparation_readiness_gate_v0.py
+++ b/tests/ops/test_shadow_preparation_readiness_gate_v0.py
@@ -971,7 +971,7 @@ def test_docs_declare_durable_projection_contract_tokens() -> None:
         "NOT_DASHBOARD_AUTHORITY=true",
         "PROJECTION_OUTPUT_PATH_EMPTY",
         "write_shadow_preparation_readiness_projection_v0",
-        "out/ops/shadow_preparation_readiness_projection_v0.json",
+        "out&#47;ops&#47;shadow_preparation_readiness_projection_v0.json",
     ):
         assert token in text, token
 


### PR DESCRIPTION
## Summary
- Add an explicit, projection-only writer that serializes an already-computed Shadow Preparation Readiness Gate evaluation into deterministic UTF-8 JSON bytes.
- Persist via atomic same-directory replace to a repository-relative generated path (`out/ops/shadow_preparation_readiness_projection_v0.json`) with fail-closed path containment.
- Extend the existing gate contract/tests only; evaluation remains side-effect free and non-activating (not STEP-29U, not activation authority).

## Test plan
- [x] `pytest -q tests/ops/test_shadow_preparation_readiness_gate_v0.py tests/ops/test_step29u_canonical_semantics_contract_v0.py` (71 passed)
- [x] CI selector maps authorized diff to `shadow_preparation_readiness_gate_focused`
- [ ] Draft PR only — do not mark Ready / merge / rerun


Made with [Cursor](https://cursor.com)