### PR TITLE
ops: offline shadow readiness projection pipeline v0

### DIFF
--- a/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
+++ b/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
@@ -133,10 +133,12 @@ READINESS_PRODUCER_CANNOT_ACTIVATE_STEP_29U=true
 | Role | Path |
 |------|------|
 | Producer | `src/ops/shadow_preparation_readiness_gate_v0.py` |
+| Offline projection pipeline | `src/ops/shadow_preparation_readiness_offline_projection_pipeline_v0.py` |
 | Config (static, non-activating) | `config/ops/shadow_preparation_readiness_gate_v0.toml` |
 | Contract doc (this file) | `docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md` |
 | Related charter (non-activating) | `docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md` |
 | Focused tests | `tests/ops/test_shadow_preparation_readiness_gate_v0.py` |
+| Pipeline focused tests | `tests/ops/test_shadow_preparation_readiness_offline_projection_pipeline_v0.py` |
 | Durable projection output (generated) | `out&#47;ops&#47;shadow_preparation_readiness_projection_v0.json` |
 
 ## Fail-closed conditions
@@ -330,6 +332,26 @@ include:
 A verified result may be returned for a valid current projection, but
 verification triggers **no** action, write, activation, scheduler, runtime, or
 order side effect.
+
+### Offline projection pipeline (orchestration only)
+
+```text
+OFFLINE_PROJECTION_PIPELINE_V0=true
+PROJECTION_ONLY=true
+AUTHORITY_EFFECT=NONE
+ACTIVATION_AUTHORITY=false
+ZERO_SIDE_EFFECTS=true
+```
+
+`run_shadow_preparation_readiness_offline_projection_pipeline_v0` (producer
+`ops.shadow_preparation_readiness_offline_projection_pipeline_v0`) composes the
+canonical gate evaluation (exactly once), durable writer, and reader/verifier.
+It proves exact semantic consistency between the evaluated result and the
+reread projection, then returns `PIPELINE_PASS`, `PIPELINE_BLOCKED`, or
+`PIPELINE_ERROR`. A blocked readiness evaluation that is successfully projected
+and verified is `PIPELINE_BLOCKED` (not an execution failure). The pipeline does
+not activate Shadow/Paper/Testnet/Runtime/Scheduler/Orders/Live and does not
+introduce a second readiness truth owner.
 
 ## Next permitted action
 

--- a/src/ops/shadow_preparation_readiness_offline_projection_pipeline_v0.py
+++ b/src/ops/shadow_preparation_readiness_offline_projection_pipeline_v0.py
@@ -1,0 +1,397 @@
+"""Shadow Preparation Readiness offline projection pipeline v0.
+
+Composes the canonical readiness gate, durable projection writer, and
+reader/verifier into one offline, fail-closed orchestration entrypoint.
+
+Non-activating. No Shadow/Paper/Testnet/Runtime/Scheduler/Orders/Live side effects.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Mapping
+
+from src.ops.shadow_preparation_readiness_gate_v0 import (
+    DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+    PROJECTION_OUTPUT_PATH_CONFIG_KEY,
+    PROJECTION_OVERALL_STATUS_VERIFIED,
+    PROJECTION_SCHEMA_ID,
+    PROJECTION_SCHEMA_VERSION,
+    ShadowPreparationReadinessGateError,
+    ShadowPreparationReadinessGateResultV0,
+    ShadowPreparationReadinessProjectionVerificationResultV0,
+    ShadowPreparationReadinessProjectionWriteMetadataV0,
+    evaluate_shadow_preparation_readiness_gate_v0,
+    load_shadow_preparation_readiness_gate_config_v0,
+    verify_shadow_preparation_readiness_projection_v0,
+    write_shadow_preparation_readiness_projection_v0,
+)
+
+PACKAGE_MARKER = "SHADOW_PREPARATION_READINESS_OFFLINE_PROJECTION_PIPELINE_V0=true"
+PRODUCER_FAMILY = "ops.shadow_preparation_readiness_offline_projection_pipeline_v0"
+SCHEMA_ID = PRODUCER_FAMILY
+SCHEMA_VERSION = "v0"
+
+PIPELINE_STATUS_PASS: Literal["PIPELINE_PASS"] = "PIPELINE_PASS"
+PIPELINE_STATUS_BLOCKED: Literal["PIPELINE_BLOCKED"] = "PIPELINE_BLOCKED"
+PIPELINE_STATUS_ERROR: Literal["PIPELINE_ERROR"] = "PIPELINE_ERROR"
+
+READINESS_STATUS_READY: Literal["READY"] = "READY"
+READINESS_STATUS_BLOCKED: Literal["BLOCKED"] = "BLOCKED"
+
+PipelineStatusV0 = Literal["PIPELINE_PASS", "PIPELINE_BLOCKED", "PIPELINE_ERROR"]
+ReadinessStatusV0 = Literal["READY", "BLOCKED"]
+
+
+@dataclass(frozen=True)
+class ShadowPreparationReadinessOfflineProjectionPipelineResultV0:
+    """Machine-readable fail-closed outcome for one offline pipeline invocation."""
+
+    pipeline_status: PipelineStatusV0
+    readiness_status: ReadinessStatusV0 | None
+    evaluated_at: str | None
+    projection_path: str | None
+    projection_schema_id: str | None
+    projection_schema_version: str | None
+    projection_sha256: str | None
+    verification_status: Literal["VERIFIED", "BLOCKED"] | None
+    verification_verified: bool | None
+    reason_codes: tuple[str, ...]
+    evidence_reference_count: int | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_id": SCHEMA_ID,
+            "schema_version": SCHEMA_VERSION,
+            "pipeline_status": self.pipeline_status,
+            "readiness_status": self.readiness_status,
+            "evaluated_at": self.evaluated_at,
+            "projection_path": self.projection_path,
+            "projection_schema_id": self.projection_schema_id,
+            "projection_schema_version": self.projection_schema_version,
+            "projection_sha256": self.projection_sha256,
+            "verification_status": self.verification_status,
+            "verification_verified": self.verification_verified,
+            "reason_codes": list(self.reason_codes),
+            "evidence_reference_count": self.evidence_reference_count,
+            "authority_effect": "NONE",
+            "activation_authority": False,
+            "projection_only": True,
+        }
+
+
+def _error_result(
+    *,
+    reason_codes: tuple[str, ...],
+    readiness_status: ReadinessStatusV0 | None = None,
+    evaluated_at: str | None = None,
+    projection_path: str | None = None,
+    projection_schema_id: str | None = None,
+    projection_schema_version: str | None = None,
+    projection_sha256: str | None = None,
+    verification_status: Literal["VERIFIED", "BLOCKED"] | None = None,
+    verification_verified: bool | None = None,
+    evidence_reference_count: int | None = None,
+) -> ShadowPreparationReadinessOfflineProjectionPipelineResultV0:
+    return ShadowPreparationReadinessOfflineProjectionPipelineResultV0(
+        pipeline_status=PIPELINE_STATUS_ERROR,
+        readiness_status=readiness_status,
+        evaluated_at=evaluated_at,
+        projection_path=projection_path,
+        projection_schema_id=projection_schema_id,
+        projection_schema_version=projection_schema_version,
+        projection_sha256=projection_sha256,
+        verification_status=verification_status,
+        verification_verified=verification_verified,
+        reason_codes=reason_codes,
+        evidence_reference_count=evidence_reference_count,
+    )
+
+
+def _classify_readiness_status(
+    evaluation: ShadowPreparationReadinessGateResultV0,
+) -> ReadinessStatusV0:
+    if (
+        evaluation.shadow_preparation_complete
+        and not evaluation.blockers
+        and not evaluation.unmet_gates
+    ):
+        return READINESS_STATUS_READY
+    return READINESS_STATUS_BLOCKED
+
+
+def _resolve_pipeline_output_path(
+    *,
+    repo_root: Path,
+    output_path: str | None,
+    config: Mapping[str, Any] | None,
+    config_path: Path | None,
+) -> str:
+    if output_path is not None:
+        if not isinstance(output_path, str) or not output_path.strip():
+            raise ShadowPreparationReadinessGateError("PIPELINE_OUTPUT_PATH_EMPTY")
+        return output_path.strip()
+    cfg = (
+        dict(config)
+        if config is not None
+        else load_shadow_preparation_readiness_gate_config_v0(config_path, repo_root=repo_root)
+    )
+    raw = cfg.get(PROJECTION_OUTPUT_PATH_CONFIG_KEY)
+    if not isinstance(raw, str) or not raw.strip():
+        raise ShadowPreparationReadinessGateError("PIPELINE_OUTPUT_PATH_UNCONFIGURED")
+    return raw.strip()
+
+
+def _read_projection_payload(*, repo_root: Path, projection_path: str) -> dict[str, Any]:
+    destination = (repo_root / projection_path).resolve()
+    try:
+        destination.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise ShadowPreparationReadinessGateError("PIPELINE_PROJECTION_PATH_OUTSIDE_REPO") from exc
+    try:
+        raw = destination.read_bytes()
+    except OSError as exc:
+        raise ShadowPreparationReadinessGateError(f"PIPELINE_PROJECTION_READ_FAILED:{exc}") from exc
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ShadowPreparationReadinessGateError("PIPELINE_PROJECTION_INVALID_JSON") from exc
+    if not isinstance(payload, dict):
+        raise ShadowPreparationReadinessGateError("PIPELINE_PROJECTION_INVALID_JSON")
+    return payload
+
+
+def _assert_exact_semantic_consistency(
+    *,
+    evaluation: ShadowPreparationReadinessGateResultV0,
+    write_meta: ShadowPreparationReadinessProjectionWriteMetadataV0,
+    verification: ShadowPreparationReadinessProjectionVerificationResultV0,
+    payload: Mapping[str, Any],
+) -> tuple[str, ...]:
+    """Return reason codes when evaluated result and reread projection diverge."""
+    reasons: list[str] = []
+    if write_meta.schema_id != PROJECTION_SCHEMA_ID:
+        reasons.append("PROJECTION_SCHEMA_IDENTITY_MISMATCH")
+    if write_meta.schema_version != PROJECTION_SCHEMA_VERSION:
+        reasons.append("PROJECTION_SCHEMA_VERSION_MISMATCH")
+    if payload.get("schema_id") != PROJECTION_SCHEMA_ID:
+        reasons.append("SCHEMA_MISMATCH")
+    if payload.get("schema_version") != PROJECTION_SCHEMA_VERSION:
+        reasons.append("SCHEMA_MISMATCH")
+    if payload.get("evaluation_schema_id") != evaluation.schema_id:
+        reasons.append("PROVENANCE_MISMATCH")
+    if payload.get("evaluation_schema_version") != evaluation.schema_version:
+        reasons.append("PROVENANCE_MISMATCH")
+    if payload.get("evaluated_at") != evaluation.evaluated_at:
+        reasons.append("PROVENANCE_MISMATCH")
+    projected_evaluation = payload.get("evaluation")
+    if not isinstance(projected_evaluation, Mapping):
+        reasons.append("EVALUATED_PROJECTION_IDENTITY_MISMATCH")
+    else:
+        # Normalize via the same JSON contract the writer uses (tuples→lists).
+        expected = json.loads(json.dumps(evaluation.to_dict(), ensure_ascii=False))
+        if dict(projected_evaluation) != expected:
+            reasons.append("EVALUATED_PROJECTION_IDENTITY_MISMATCH")
+        projected_complete = projected_evaluation.get("shadow_preparation_complete")
+        if projected_complete != evaluation.shadow_preparation_complete:
+            reasons.append("EVALUATED_PROJECTION_STATUS_MISMATCH")
+        projected_blockers = projected_evaluation.get("blockers")
+        if list(projected_blockers or ()) != list(evaluation.blockers):
+            reasons.append("EVALUATED_PROJECTION_STATUS_MISMATCH")
+    if list(payload.get("blockers") or ()) != list(evaluation.blockers):
+        reasons.append("EVALUATED_PROJECTION_STATUS_MISMATCH")
+    if payload.get("shadow_preparation_complete") != evaluation.shadow_preparation_complete:
+        reasons.append("EVALUATED_PROJECTION_STATUS_MISMATCH")
+    if verification.projection_path != write_meta.output_path:
+        reasons.append("PROJECTION_PATH_REFERENCE_MISMATCH")
+    if verification.generated_at != evaluation.evaluated_at:
+        reasons.append("PROVENANCE_MISMATCH")
+    if verification.schema_id != write_meta.schema_id:
+        reasons.append("PROJECTION_SCHEMA_IDENTITY_MISMATCH")
+    if verification.schema_version != write_meta.schema_version:
+        reasons.append("PROJECTION_SCHEMA_VERSION_MISMATCH")
+    # Preserve order, drop duplicates.
+    deduped: list[str] = []
+    for code in reasons:
+        if code not in deduped:
+            deduped.append(code)
+    return tuple(deduped)
+
+
+def run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+    *,
+    repo_root: Path,
+    output_path: str | None = None,
+    config: Mapping[str, Any] | None = None,
+    config_path: Path | None = None,
+    evaluated_at: str | None = None,
+    as_of: str | None = None,
+) -> ShadowPreparationReadinessOfflineProjectionPipelineResultV0:
+    """Evaluate once, write, read/verify, and prove exact semantic consistency.
+
+    Offline operator/CI utility only. Does not activate Shadow, Paper, Testnet,
+    Runtime, Scheduler, Orders, or Live.
+    """
+    root = repo_root.resolve()
+
+    try:
+        resolved_output = _resolve_pipeline_output_path(
+            repo_root=root,
+            output_path=output_path,
+            config=config,
+            config_path=config_path,
+        )
+    except ShadowPreparationReadinessGateError as exc:
+        return _error_result(reason_codes=(f"PIPELINE_INPUT_INVALID:{exc}",))
+
+    try:
+        evaluation = evaluate_shadow_preparation_readiness_gate_v0(
+            config=config,
+            config_path=config_path,
+            repo_root=root,
+            evaluated_at=evaluated_at,
+        )
+    except ShadowPreparationReadinessGateError as exc:
+        return _error_result(reason_codes=(f"GATE_EVALUATION_FAILED:{exc}",))
+    except Exception as exc:  # pragma: no cover - defensive fail-closed
+        return _error_result(reason_codes=(f"GATE_EVALUATION_FAILED:{type(exc).__name__}:{exc}",))
+
+    readiness_status = _classify_readiness_status(evaluation)
+    evaluated_at_value = evaluation.evaluated_at
+
+    try:
+        write_meta = write_shadow_preparation_readiness_projection_v0(
+            evaluation=evaluation,
+            repo_root=root,
+            output_path=resolved_output,
+            evaluated_at=evaluated_at_value,
+        )
+    except ShadowPreparationReadinessGateError as exc:
+        return _error_result(
+            reason_codes=(f"PROJECTION_WRITE_FAILED:{exc}",),
+            readiness_status=readiness_status,
+            evaluated_at=evaluated_at_value,
+            projection_path=resolved_output,
+        )
+    except Exception as exc:  # pragma: no cover - defensive fail-closed
+        return _error_result(
+            reason_codes=(f"PROJECTION_WRITE_FAILED:{type(exc).__name__}:{exc}",),
+            readiness_status=readiness_status,
+            evaluated_at=evaluated_at_value,
+            projection_path=resolved_output,
+        )
+
+    verify_as_of = as_of if as_of is not None else evaluated_at_value
+    try:
+        verification = verify_shadow_preparation_readiness_projection_v0(
+            repo_root=root,
+            projection_path=write_meta.output_path,
+            config=config,
+            config_path=config_path,
+            as_of=verify_as_of,
+            expected_sha256=write_meta.sha256,
+        )
+    except Exception as exc:  # pragma: no cover - defensive fail-closed
+        return _error_result(
+            reason_codes=(f"PROJECTION_VERIFY_FAILED:{type(exc).__name__}:{exc}",),
+            readiness_status=readiness_status,
+            evaluated_at=evaluated_at_value,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+        )
+
+    if (
+        not verification.verified
+        or verification.overall_status != PROJECTION_OVERALL_STATUS_VERIFIED
+    ):
+        codes = tuple(verification.reason_codes) or ("PROJECTION_VERIFICATION_BLOCKED",)
+        return _error_result(
+            reason_codes=codes,
+            readiness_status=readiness_status,
+            evaluated_at=evaluated_at_value,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+            verification_status=verification.overall_status,
+            verification_verified=verification.verified,
+            evidence_reference_count=verification.evidence_reference_count,
+        )
+
+    try:
+        payload = _read_projection_payload(
+            repo_root=root,
+            projection_path=write_meta.output_path,
+        )
+    except ShadowPreparationReadinessGateError as exc:
+        return _error_result(
+            reason_codes=(f"PROJECTION_READ_FAILED:{exc}",),
+            readiness_status=readiness_status,
+            evaluated_at=evaluated_at_value,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+            verification_status=verification.overall_status,
+            verification_verified=verification.verified,
+            evidence_reference_count=verification.evidence_reference_count,
+        )
+
+    consistency_codes = _assert_exact_semantic_consistency(
+        evaluation=evaluation,
+        write_meta=write_meta,
+        verification=verification,
+        payload=payload,
+    )
+    if consistency_codes:
+        return _error_result(
+            reason_codes=consistency_codes,
+            readiness_status=readiness_status,
+            evaluated_at=evaluated_at_value,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+            verification_status=verification.overall_status,
+            verification_verified=verification.verified,
+            evidence_reference_count=verification.evidence_reference_count,
+        )
+
+    pipeline_status: PipelineStatusV0 = (
+        PIPELINE_STATUS_PASS
+        if readiness_status == READINESS_STATUS_READY
+        else PIPELINE_STATUS_BLOCKED
+    )
+    return ShadowPreparationReadinessOfflineProjectionPipelineResultV0(
+        pipeline_status=pipeline_status,
+        readiness_status=readiness_status,
+        evaluated_at=evaluated_at_value,
+        projection_path=write_meta.output_path,
+        projection_schema_id=write_meta.schema_id,
+        projection_schema_version=write_meta.schema_version,
+        projection_sha256=write_meta.sha256,
+        verification_status=verification.overall_status,
+        verification_verified=verification.verified,
+        reason_codes=(),
+        evidence_reference_count=verification.evidence_reference_count,
+    )
+
+
+__all__ = [
+    "DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH",
+    "PACKAGE_MARKER",
+    "PIPELINE_STATUS_BLOCKED",
+    "PIPELINE_STATUS_ERROR",
+    "PIPELINE_STATUS_PASS",
+    "PRODUCER_FAMILY",
+    "READINESS_STATUS_BLOCKED",
+    "READINESS_STATUS_READY",
+    "SCHEMA_ID",
+    "SCHEMA_VERSION",
+    "ShadowPreparationReadinessOfflineProjectionPipelineResultV0",
+    "run_shadow_preparation_readiness_offline_projection_pipeline_v0",
+]

--- a/tests/ops/test_shadow_preparation_readiness_offline_projection_pipeline_v0.py
+++ b/tests/ops/test_shadow_preparation_readiness_offline_projection_pipeline_v0.py
@@ -1,0 +1,610 @@
+"""Focused tests for offline shadow readiness projection pipeline v0."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import socket
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.ops.shadow_preparation_readiness_gate_v0 import (
+    CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY,
+    DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+    PreparationStatusV0,
+    PROJECTION_SCHEMA_ID,
+    PROJECTION_SCHEMA_VERSION,
+    ShadowPreparationReadinessGateError,
+    ShadowPreparationReadinessProjectionWriteMetadataV0,
+    build_shadow_preparation_readiness_projection_payload_v0,
+    evaluate_shadow_preparation_readiness_gate_v0,
+    load_shadow_preparation_readiness_gate_config_v0,
+    serialize_shadow_preparation_readiness_projection_v0,
+    verify_shadow_preparation_readiness_projection_v0,
+    write_shadow_preparation_readiness_projection_v0,
+)
+from src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0 import (
+    PACKAGE_MARKER,
+    PIPELINE_STATUS_BLOCKED,
+    PIPELINE_STATUS_ERROR,
+    PIPELINE_STATUS_PASS,
+    PRODUCER_FAMILY,
+    READINESS_STATUS_BLOCKED,
+    READINESS_STATUS_READY,
+    SCHEMA_ID,
+    run_shadow_preparation_readiness_offline_projection_pipeline_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG = REPO_ROOT / "config" / "ops" / "shadow_preparation_readiness_gate_v0.toml"
+PIPELINE_MODULE = (
+    REPO_ROOT / "src" / "ops" / "shadow_preparation_readiness_offline_projection_pipeline_v0.py"
+)
+CONTRACT_DOC = (
+    REPO_ROOT / "docs" / "ops" / "runbooks" / "SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md"
+)
+EVALUATED_AT = "2026-07-25T12:00:00Z"
+AS_OF = "2026-07-25T12:00:30Z"
+
+FORBIDDEN_IMPORT_PREFIXES = (
+    "src.webui",
+    "src.orders",
+    "src.execution",
+    "src.live",
+    "src.scheduler",
+    "src.trading.master_v2",
+)
+
+
+def _collect_required_relative_paths(cfg: dict) -> set[str]:
+    paths: set[str] = set()
+    for surface in cfg["historical_surfaces"]:
+        paths.add(str(surface["path"]).strip())
+    for component in cfg["mindestkontrakt_components"]:
+        for evidence_path in component.get("evidence_paths") or []:
+            paths.add(str(evidence_path).strip())
+    paths.add(str(cfg[CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY]).strip())
+    return paths
+
+
+def _materialize_temp_repo(tmp_path: Path) -> tuple[Path, dict]:
+    cfg = load_shadow_preparation_readiness_gate_config_v0(CONFIG, repo_root=REPO_ROOT)
+    for relative in _collect_required_relative_paths(cfg):
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if not target.exists():
+            target.write_text(f"# stub:{relative}\n", encoding="utf-8")
+    config_dest = tmp_path / "config" / "ops" / "shadow_preparation_readiness_gate_v0.toml"
+    config_dest.parent.mkdir(parents=True, exist_ok=True)
+    config_dest.write_text(CONFIG.read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / "out" / "ops").mkdir(parents=True, exist_ok=True)
+    return tmp_path, cfg
+
+
+def _ready_like_evaluation(base):
+    inventory = tuple(
+        replace(record, preparation_status=PreparationStatusV0.PRESENT)
+        for record in base.mindestkontrakt_inventory
+    )
+    return replace(
+        base,
+        shadow_preparation_complete=True,
+        blockers=(),
+        unmet_gates=(),
+        mindestkontrakt_inventory=inventory,
+    )
+
+
+def test_package_marker_and_schema_identity() -> None:
+    assert PACKAGE_MARKER == "SHADOW_PREPARATION_READINESS_OFFLINE_PROJECTION_PIPELINE_V0=true"
+    assert PRODUCER_FAMILY == SCHEMA_ID
+    assert PRODUCER_FAMILY.endswith("_v0")
+
+
+def test_ready_like_gate_result_writes_rereads_verifies_consistent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    real_evaluate = evaluate_shadow_preparation_readiness_gate_v0
+    evaluate_calls = {"n": 0}
+
+    def _ready_evaluate(**kwargs):
+        evaluate_calls["n"] += 1
+        return _ready_like_evaluation(real_evaluate(**kwargs))
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0."
+        "evaluate_shadow_preparation_readiness_gate_v0",
+        _ready_evaluate,
+    )
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert evaluate_calls["n"] == 1
+    assert result.pipeline_status == PIPELINE_STATUS_PASS
+    assert result.readiness_status == READINESS_STATUS_READY
+    assert result.verification_verified is True
+    assert result.verification_status == "VERIFIED"
+    assert result.projection_path == DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH
+    assert result.projection_schema_id == PROJECTION_SCHEMA_ID
+    assert result.projection_schema_version == PROJECTION_SCHEMA_VERSION
+    assert result.projection_sha256
+    assert (root / result.projection_path).is_file()
+    payload = json.loads((root / result.projection_path).read_text(encoding="utf-8"))
+    assert payload["shadow_preparation_complete"] is True
+    assert payload["evaluation"]["shadow_preparation_complete"] is True
+
+
+def test_blocked_gate_result_is_pipeline_blocked_not_error(tmp_path: Path) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_BLOCKED
+    assert result.readiness_status == READINESS_STATUS_BLOCKED
+    assert result.pipeline_status != PIPELINE_STATUS_ERROR
+    assert result.verification_verified is True
+    assert result.reason_codes == ()
+    assert result.projection_sha256
+
+
+def test_missing_required_input_fails_closed(tmp_path: Path) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    (root / "config" / "ops" / "shadow_preparation_readiness_gate_v0.toml").unlink()
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_ERROR
+    assert result.reason_codes
+    assert any(
+        code.startswith("PIPELINE_INPUT_INVALID:") or code.startswith("GATE_EVALUATION_FAILED:")
+        for code in result.reason_codes
+    )
+
+
+def test_writer_failure_pipeline_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+
+    def _fail_write(**_kwargs):
+        raise ShadowPreparationReadinessGateError("PROJECTION_TEMP_WRITE_FAILED:boom")
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0."
+        "write_shadow_preparation_readiness_projection_v0",
+        _fail_write,
+    )
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_ERROR
+    assert any(code.startswith("PROJECTION_WRITE_FAILED:") for code in result.reason_codes)
+
+
+def test_reader_failure_pipeline_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+
+    def _fail_verify(**_kwargs):
+        raise OSError("read failed")
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0."
+        "verify_shadow_preparation_readiness_projection_v0",
+        _fail_verify,
+    )
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_ERROR
+    assert any(code.startswith("PROJECTION_VERIFY_FAILED:") for code in result.reason_codes)
+
+
+def test_invalid_json_after_write_pipeline_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    real_write = write_shadow_preparation_readiness_projection_v0
+
+    def _write_then_corrupt(**kwargs):
+        meta = real_write(**kwargs)
+        (root / meta.output_path).write_text("{not-json", encoding="utf-8")
+        return meta
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0."
+        "write_shadow_preparation_readiness_projection_v0",
+        _write_then_corrupt,
+    )
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_ERROR
+    assert "INVALID_PROJECTION" in result.reason_codes or any(
+        "INVALID" in code for code in result.reason_codes
+    )
+
+
+def test_schema_mismatch_pipeline_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    real_write = write_shadow_preparation_readiness_projection_v0
+
+    def _write_bad_schema(**kwargs):
+        meta = real_write(**kwargs)
+        dest = root / meta.output_path
+        payload = json.loads(dest.read_text(encoding="utf-8"))
+        payload["schema_version"] = "v999"
+        content = serialize_shadow_preparation_readiness_projection_v0(payload)
+        dest.write_bytes(content)
+        return ShadowPreparationReadinessProjectionWriteMetadataV0(
+            output_path=meta.output_path,
+            schema_id=meta.schema_id,
+            schema_version=meta.schema_version,
+            byte_length=len(content),
+            sha256=hashlib.sha256(content).hexdigest(),
+        )
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0."
+        "write_shadow_preparation_readiness_projection_v0",
+        _write_bad_schema,
+    )
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_ERROR
+    assert "SCHEMA_MISMATCH" in result.reason_codes
+
+
+def test_provenance_mismatch_pipeline_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    real_build = build_shadow_preparation_readiness_projection_payload_v0
+
+    def _bad_provenance(*, evaluation, evaluated_at):
+        payload = real_build(evaluation=evaluation, evaluated_at=evaluated_at)
+        payload["evaluation_schema_id"] = "other.schema"
+        return payload
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_gate_v0."
+        "build_shadow_preparation_readiness_projection_payload_v0",
+        _bad_provenance,
+    )
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_ERROR
+    assert "PROVENANCE_MISMATCH" in result.reason_codes
+
+
+def test_evidence_path_reference_mismatch_pipeline_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    real_build = build_shadow_preparation_readiness_projection_payload_v0
+
+    def _bad_evidence(*, evaluation, evaluated_at):
+        payload = real_build(evaluation=evaluation, evaluated_at=evaluated_at)
+        inventory = payload["evaluation"]["mindestkontrakt_inventory"]
+        inventory[0]["evidence_paths"] = ["docs/missing_evidence_target_v0.md"]
+        return payload
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_gate_v0."
+        "build_shadow_preparation_readiness_projection_payload_v0",
+        _bad_evidence,
+    )
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_ERROR
+    assert "EVIDENCE_REFERENCE_MISSING" in result.reason_codes
+
+
+def test_evaluated_versus_projected_status_mismatch_pipeline_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    real_build = build_shadow_preparation_readiness_projection_payload_v0
+
+    def _status_drift(*, evaluation, evaluated_at):
+        payload = real_build(evaluation=evaluation, evaluated_at=evaluated_at)
+        payload["evaluation"]["blockers"] = list(evaluation.blockers) + ["EXTRA_BLOCKER"]
+        return payload
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_gate_v0."
+        "build_shadow_preparation_readiness_projection_payload_v0",
+        _status_drift,
+    )
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_ERROR
+    assert "EVALUATED_PROJECTION_STATUS_MISMATCH" in result.reason_codes or (
+        "EVALUATED_PROJECTION_IDENTITY_MISMATCH" in result.reason_codes
+    )
+
+
+def test_digest_identity_mismatch_pipeline_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    real_write = write_shadow_preparation_readiness_projection_v0
+
+    def _wrong_digest(**kwargs):
+        meta = real_write(**kwargs)
+        return ShadowPreparationReadinessProjectionWriteMetadataV0(
+            output_path=meta.output_path,
+            schema_id=meta.schema_id,
+            schema_version=meta.schema_version,
+            byte_length=meta.byte_length,
+            sha256="0" * 64,
+        )
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0."
+        "write_shadow_preparation_readiness_projection_v0",
+        _wrong_digest,
+    )
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_ERROR
+    assert "DIGEST_MISMATCH" in result.reason_codes
+
+
+def test_stale_preexisting_projection_cannot_satisfy_current_invocation(
+    tmp_path: Path,
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    dest = root / DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH
+    stale_eval = evaluate_shadow_preparation_readiness_gate_v0(
+        repo_root=root, evaluated_at="2026-07-20T12:00:00Z"
+    )
+    stale_meta = write_shadow_preparation_readiness_projection_v0(
+        evaluation=stale_eval,
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at="2026-07-20T12:00:00Z",
+    )
+    stale_bytes = dest.read_bytes()
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_BLOCKED
+    assert result.verification_verified is True
+    assert result.projection_sha256 != stale_meta.sha256
+    assert dest.read_bytes() != stale_bytes
+    payload = json.loads(dest.read_text(encoding="utf-8"))
+    assert payload["evaluated_at"] == EVALUATED_AT
+
+
+def test_temporary_partial_projection_cannot_satisfy_verification(tmp_path: Path) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    dest = root / DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH
+    partial = dest.parent / f".tmp_{dest.name}_partial.partial"
+    evaluation = evaluate_shadow_preparation_readiness_gate_v0(
+        repo_root=root, evaluated_at=EVALUATED_AT
+    )
+    payload = build_shadow_preparation_readiness_projection_payload_v0(
+        evaluation=evaluation, evaluated_at=EVALUATED_AT
+    )
+    partial.write_bytes(serialize_shadow_preparation_readiness_projection_v0(payload))
+    assert not dest.exists()
+    verification = verify_shadow_preparation_readiness_projection_v0(
+        repo_root=root,
+        projection_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        as_of=AS_OF,
+    )
+    assert verification.verified is False
+    assert "MISSING_PROJECTION" in verification.reason_codes
+    # Pipeline must also refuse when only a partial exists.
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_BLOCKED
+    assert result.verification_verified is True
+    assert dest.is_file()
+    assert dest.read_bytes() != partial.read_bytes() or result.projection_sha256
+
+
+def test_canonical_writer_reader_verifier_invoked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    calls = {"evaluate": 0, "write": 0, "verify": 0}
+    real_evaluate = evaluate_shadow_preparation_readiness_gate_v0
+    real_write = write_shadow_preparation_readiness_projection_v0
+    real_verify = verify_shadow_preparation_readiness_projection_v0
+
+    def _e(**kwargs):
+        calls["evaluate"] += 1
+        return real_evaluate(**kwargs)
+
+    def _w(**kwargs):
+        calls["write"] += 1
+        return real_write(**kwargs)
+
+    def _v(**kwargs):
+        calls["verify"] += 1
+        assert kwargs.get("expected_sha256")
+        return real_verify(**kwargs)
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0."
+        "evaluate_shadow_preparation_readiness_gate_v0",
+        _e,
+    )
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0."
+        "write_shadow_preparation_readiness_projection_v0",
+        _w,
+    )
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0."
+        "verify_shadow_preparation_readiness_projection_v0",
+        _v,
+    )
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert calls == {"evaluate": 1, "write": 1, "verify": 1}
+    assert result.pipeline_status == PIPELINE_STATUS_BLOCKED
+
+
+def test_no_network_runtime_scheduler_order_side_effects(tmp_path: Path) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    original_socket = socket.socket
+
+    class _BlockedSocket(original_socket):  # type: ignore[misc,valid-type]
+        def __init__(self, *args, **kwargs):  # pragma: no cover
+            raise AssertionError("network side effect forbidden")
+
+    socket.socket = _BlockedSocket  # type: ignore[misc]
+    try:
+        source = PIPELINE_MODULE.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert not any(alias.name.startswith(p) for p in FORBIDDEN_IMPORT_PREFIXES)
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert not any(node.module.startswith(p) for p in FORBIDDEN_IMPORT_PREFIXES)
+        for needle in (
+            "activate_shadow",
+            "start_scheduler",
+            "place_order",
+            "enable_paper",
+            "enable_testnet",
+            "requests.",
+            "urllib",
+        ):
+            assert needle not in source
+        result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+            repo_root=root,
+            output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+            evaluated_at=EVALUATED_AT,
+            as_of=AS_OF,
+        )
+        assert result.pipeline_status == PIPELINE_STATUS_BLOCKED
+    finally:
+        socket.socket = original_socket  # type: ignore[misc]
+
+
+def test_no_tracked_projection_output(tmp_path: Path) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_BLOCKED
+    # Projection lives under out/ (generated evidence), never under tracked src/tests/docs/config.
+    assert result.projection_path is not None
+    assert result.projection_path.startswith("out/")
+    tracked_roots = ("src/", "tests/", "docs/", "config/")
+    assert not any(result.projection_path.startswith(prefix) for prefix in tracked_roots)
+
+
+def test_deterministic_repeated_input_semantic_equivalence(tmp_path: Path) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    first = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    second = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert first.pipeline_status == second.pipeline_status == PIPELINE_STATUS_BLOCKED
+    assert first.projection_sha256 == second.projection_sha256
+    assert first.readiness_status == second.readiness_status
+    assert first.to_dict() == second.to_dict()
+
+
+def test_exact_output_path_behavior_within_existing_contract(tmp_path: Path) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    custom = "out/ops/custom_shadow_readiness_projection_v0.json"
+    result = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path=custom,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert result.pipeline_status == PIPELINE_STATUS_BLOCKED
+    assert result.projection_path == custom
+    assert (root / custom).is_file()
+    # Empty explicit path fails closed.
+    empty = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        output_path="   ",
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert empty.pipeline_status == PIPELINE_STATUS_ERROR
+    assert any("PIPELINE_INPUT_INVALID" in code for code in empty.reason_codes)
+    # Config default path is honored when output_path omitted.
+    defaulted = run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+        repo_root=root,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert defaulted.pipeline_status == PIPELINE_STATUS_BLOCKED
+    assert defaulted.projection_path == DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH
+
+
+def test_docs_declare_offline_pipeline_entrypoint() -> None:
+    text = CONTRACT_DOC.read_text(encoding="utf-8")
+    assert "OFFLINE_PROJECTION_PIPELINE_V0=true" in text
+    assert "run_shadow_preparation_readiness_offline_projection_pipeline_v0" in text


### PR DESCRIPTION
## Summary
- Adds a bounded offline orchestration entrypoint that evaluates the canonical Shadow Preparation Readiness gate once, writes the durable projection through the existing writer, then reads/verifies it through the existing verifier.
- Proves exact semantic consistency between the evaluated gate result and the reread projection, returning machine-readable `PIPELINE_PASS` / `PIPELINE_BLOCKED` / `PIPELINE_ERROR` outcomes.
- Documents the pipeline entrypoint in the existing readiness gate contract runbook. Non-activating: no Shadow/Paper/Testnet/Runtime/Scheduler/Orders/Live side effects.

## Test plan
- [x] `pytest tests/ops/test_shadow_preparation_readiness_offline_projection_pipeline_v0.py -q` (20 passed)
- [ ] Confirm CI focused/required checks on draft PR
- [ ] Confirm no tracked projection artifact under `src/`/`tests/`/`docs/`/`config/`


Made with [Cursor](https://cursor.com)