### PR TITLE
ops: shadow preparation readiness bundle v0

### DIFF
--- a/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
+++ b/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
@@ -135,12 +135,14 @@ READINESS_PRODUCER_CANNOT_ACTIVATE_STEP_29U=true
 | Producer | `src/ops/shadow_preparation_readiness_gate_v0.py` |
 | Offline projection pipeline | `src/ops/shadow_preparation_readiness_offline_projection_pipeline_v0.py` |
 | Offline operator entrypoint | `src/ops/shadow_preparation_readiness_offline_operator_entrypoint_v0.py` |
+| Readiness bundle (read-only aggregate) | `src/ops/shadow_preparation_readiness_bundle_v0.py` |
 | Config (static, non-activating) | `config/ops/shadow_preparation_readiness_gate_v0.toml` |
 | Contract doc (this file) | `docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md` |
 | Related charter (non-activating) | `docs/ops/runbooks/SHADOW_247_GOVERNANCE_CHARTER_V0.md` |
 | Focused tests | `tests/ops/test_shadow_preparation_readiness_gate_v0.py` |
 | Pipeline focused tests | `tests/ops/test_shadow_preparation_readiness_offline_projection_pipeline_v0.py` |
 | Operator entrypoint focused tests | `tests/ops/test_shadow_preparation_readiness_offline_operator_entrypoint_v0.py` |
+| Bundle focused tests | `tests/ops/test_shadow_preparation_readiness_bundle_v0.py` |
 | Durable projection output (generated) | `out&#47;ops&#47;shadow_preparation_readiness_projection_v0.json` |
 
 ## Fail-closed conditions
@@ -427,6 +429,33 @@ python -m src.ops.shadow_preparation_readiness_offline_operator_entrypoint_v0 \
 This command is **not** a scheduler entrypoint and **not** a runtime entrypoint.
 It is offline preparation tooling only. `PIPELINE_BLOCKED` never authorizes
 Shadow, Paper, Testnet, Scheduler, Orders, or Runtime.
+
+### Shadow Preparation Readiness Bundle v0 (read-only aggregate)
+
+```text
+SHADOW_PREPARATION_READINESS_BUNDLE_V0=true
+BUNDLE_ONLY=true
+READ_ONLY=true
+PROJECTION_ONLY=true
+AUTHORITY_EFFECT=NONE
+ACTIVATION_AUTHORITY=false
+ZERO_RUNTIME_ACTIVATION=true
+```
+
+`build_shadow_preparation_readiness_bundle_v0` (producer
+`ops.shadow_preparation_readiness_bundle_v0`) aggregates already-existing
+canonical offline artifacts into one operator-consumption bundle:
+
+- canonical offline projection pipeline result (`to_dict()`);
+- durable projection payload reread from disk (no re-serialization of gate
+  truth);
+- canonical reader/verifier result (`to_dict()`).
+
+It invokes the canonical pipeline exactly once (reusing gate, writer, and
+reader/verifier) and never introduces a second readiness truth. Missing or
+unreadable required artifacts fail closed as `BUNDLE_BLOCKED` with reason codes;
+values are never synthesized. Bundle statuses: `BUNDLE_PASS`, `BUNDLE_BLOCKED`,
+`BUNDLE_ERROR`. The bundle authorizes nothing.
 
 ## Next permitted action
 

--- a/src/ops/shadow_preparation_readiness_bundle_v0.py
+++ b/src/ops/shadow_preparation_readiness_bundle_v0.py
@@ -1,0 +1,244 @@
+"""Shadow Preparation Readiness Bundle v0.
+
+Aggregates already-existing canonical offline Shadow Preparation Readiness
+artifacts into one read-only bundle for operator consumption.
+
+Reuses the canonical offline projection pipeline (gate evaluation, durable
+projection writer, and reader/verifier). Does not duplicate projection
+serialization and does not introduce a second readiness truth or activation
+authority.
+
+Non-activating. No Shadow/Paper/Testnet/Runtime/Scheduler/Orders/Live side
+effects. No network I/O.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Mapping
+
+from src.ops.shadow_preparation_readiness_gate_v0 import (
+    ShadowPreparationReadinessGateError,
+    ShadowPreparationReadinessProjectionVerificationResultV0,
+    verify_shadow_preparation_readiness_projection_v0,
+)
+from src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0 import (
+    PIPELINE_STATUS_BLOCKED,
+    PIPELINE_STATUS_ERROR,
+    PIPELINE_STATUS_PASS,
+    ShadowPreparationReadinessOfflineProjectionPipelineResultV0,
+    run_shadow_preparation_readiness_offline_projection_pipeline_v0,
+)
+
+PACKAGE_MARKER = "SHADOW_PREPARATION_READINESS_BUNDLE_V0=true"
+PRODUCER_FAMILY = "ops.shadow_preparation_readiness_bundle_v0"
+SCHEMA_ID = PRODUCER_FAMILY
+SCHEMA_VERSION = "v0"
+
+BUNDLE_STATUS_PASS: Literal["BUNDLE_PASS"] = "BUNDLE_PASS"
+BUNDLE_STATUS_BLOCKED: Literal["BUNDLE_BLOCKED"] = "BUNDLE_BLOCKED"
+BUNDLE_STATUS_ERROR: Literal["BUNDLE_ERROR"] = "BUNDLE_ERROR"
+
+BundleStatusV0 = Literal["BUNDLE_PASS", "BUNDLE_BLOCKED", "BUNDLE_ERROR"]
+
+
+@dataclass(frozen=True)
+class ShadowPreparationReadinessBundleV0:
+    """Read-only aggregate of canonical offline readiness artifacts."""
+
+    bundle_status: BundleStatusV0
+    reason_codes: tuple[str, ...]
+    pipeline: dict[str, Any] | None
+    projection: dict[str, Any] | None
+    verification: dict[str, Any] | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_id": SCHEMA_ID,
+            "schema_version": SCHEMA_VERSION,
+            "bundle_status": self.bundle_status,
+            "reason_codes": list(self.reason_codes),
+            "pipeline": self.pipeline,
+            "projection": self.projection,
+            "verification": self.verification,
+            "authority_effect": "NONE",
+            "activation_authority": False,
+            "projection_only": True,
+            "bundle_only": True,
+            "read_only": True,
+        }
+
+
+def serialize_shadow_preparation_readiness_bundle_v0(
+    bundle: ShadowPreparationReadinessBundleV0,
+) -> str:
+    """Deterministic JSON serialization of an already-built bundle."""
+    return (
+        json.dumps(bundle.to_dict(), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    )
+
+
+def _blocked(
+    *,
+    reason_codes: tuple[str, ...],
+    pipeline: dict[str, Any] | None = None,
+    projection: dict[str, Any] | None = None,
+    verification: dict[str, Any] | None = None,
+) -> ShadowPreparationReadinessBundleV0:
+    return ShadowPreparationReadinessBundleV0(
+        bundle_status=BUNDLE_STATUS_BLOCKED,
+        reason_codes=reason_codes,
+        pipeline=pipeline,
+        projection=projection,
+        verification=verification,
+    )
+
+
+def _error(
+    *,
+    reason_codes: tuple[str, ...],
+    pipeline: dict[str, Any] | None = None,
+) -> ShadowPreparationReadinessBundleV0:
+    return ShadowPreparationReadinessBundleV0(
+        bundle_status=BUNDLE_STATUS_ERROR,
+        reason_codes=reason_codes,
+        pipeline=pipeline,
+        projection=None,
+        verification=None,
+    )
+
+
+def _read_projection_payload(*, repo_root: Path, projection_path: str) -> dict[str, Any]:
+    destination = (repo_root / projection_path).resolve()
+    try:
+        destination.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise ShadowPreparationReadinessGateError("BUNDLE_PROJECTION_PATH_OUTSIDE_REPO") from exc
+    if not destination.is_file():
+        raise ShadowPreparationReadinessGateError("BUNDLE_PROJECTION_ARTIFACT_UNAVAILABLE")
+    try:
+        raw = destination.read_bytes()
+    except OSError as exc:
+        raise ShadowPreparationReadinessGateError(f"BUNDLE_PROJECTION_READ_FAILED:{exc}") from exc
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ShadowPreparationReadinessGateError("BUNDLE_PROJECTION_INVALID_JSON") from exc
+    if not isinstance(payload, dict):
+        raise ShadowPreparationReadinessGateError("BUNDLE_PROJECTION_INVALID_JSON")
+    return payload
+
+
+def _bundle_status_for_pipeline(
+    pipeline_status: str,
+) -> BundleStatusV0:
+    if pipeline_status == PIPELINE_STATUS_PASS:
+        return BUNDLE_STATUS_PASS
+    if pipeline_status == PIPELINE_STATUS_BLOCKED:
+        return BUNDLE_STATUS_BLOCKED
+    return BUNDLE_STATUS_ERROR
+
+
+def build_shadow_preparation_readiness_bundle_v0(
+    *,
+    repo_root: Path,
+    output_path: str | None = None,
+    config: Mapping[str, Any] | None = None,
+    config_path: Path | None = None,
+    evaluated_at: str | None = None,
+    as_of: str | None = None,
+) -> ShadowPreparationReadinessBundleV0:
+    """Run the canonical pipeline once and aggregate its durable artifacts.
+
+    Fail-closed: missing or unreadable required artifacts yield BLOCKED with
+    reason codes. Values are never synthesized.
+    """
+    root = repo_root.resolve()
+
+    pipeline_result: ShadowPreparationReadinessOfflineProjectionPipelineResultV0 = (
+        run_shadow_preparation_readiness_offline_projection_pipeline_v0(
+            repo_root=root,
+            output_path=output_path,
+            config=config,
+            config_path=config_path,
+            evaluated_at=evaluated_at,
+            as_of=as_of,
+        )
+    )
+    pipeline_dict = pipeline_result.to_dict()
+
+    if pipeline_result.pipeline_status == PIPELINE_STATUS_ERROR:
+        codes = tuple(pipeline_result.reason_codes) or ("PIPELINE_ERROR",)
+        return _error(reason_codes=codes, pipeline=pipeline_dict)
+
+    projection_path = pipeline_result.projection_path
+    if not isinstance(projection_path, str) or not projection_path.strip():
+        return _blocked(
+            reason_codes=("BUNDLE_PROJECTION_ARTIFACT_UNAVAILABLE",),
+            pipeline=pipeline_dict,
+        )
+
+    try:
+        projection_payload = _read_projection_payload(
+            repo_root=root,
+            projection_path=projection_path,
+        )
+    except ShadowPreparationReadinessGateError as exc:
+        return _blocked(
+            reason_codes=(f"BUNDLE_ARTIFACT_UNAVAILABLE:{exc}",),
+            pipeline=pipeline_dict,
+        )
+
+    verify_as_of = as_of if as_of is not None else pipeline_result.evaluated_at
+    try:
+        verification: ShadowPreparationReadinessProjectionVerificationResultV0 = (
+            verify_shadow_preparation_readiness_projection_v0(
+                repo_root=root,
+                projection_path=projection_path,
+                config=config,
+                config_path=config_path,
+                as_of=verify_as_of,
+                expected_sha256=pipeline_result.projection_sha256,
+            )
+        )
+    except Exception as exc:  # pragma: no cover - defensive fail-closed
+        return _blocked(
+            reason_codes=(f"BUNDLE_VERIFICATION_ARTIFACT_UNAVAILABLE:{type(exc).__name__}:{exc}",),
+            pipeline=pipeline_dict,
+            projection=projection_payload,
+        )
+
+    verification_dict = verification.to_dict()
+    if not verification.verified:
+        codes = tuple(verification.reason_codes) or ("BUNDLE_VERIFICATION_BLOCKED",)
+        return _blocked(
+            reason_codes=codes,
+            pipeline=pipeline_dict,
+            projection=projection_payload,
+            verification=verification_dict,
+        )
+
+    return ShadowPreparationReadinessBundleV0(
+        bundle_status=_bundle_status_for_pipeline(pipeline_result.pipeline_status),
+        reason_codes=(),
+        pipeline=pipeline_dict,
+        projection=projection_payload,
+        verification=verification_dict,
+    )
+
+
+__all__ = [
+    "BUNDLE_STATUS_BLOCKED",
+    "BUNDLE_STATUS_ERROR",
+    "BUNDLE_STATUS_PASS",
+    "PACKAGE_MARKER",
+    "PRODUCER_FAMILY",
+    "SCHEMA_ID",
+    "SCHEMA_VERSION",
+    "ShadowPreparationReadinessBundleV0",
+    "build_shadow_preparation_readiness_bundle_v0",
+    "serialize_shadow_preparation_readiness_bundle_v0",
+]

--- a/tests/ops/test_shadow_preparation_readiness_bundle_v0.py
+++ b/tests/ops/test_shadow_preparation_readiness_bundle_v0.py
@@ -1,0 +1,271 @@
+"""Focused tests for Shadow Preparation Readiness Bundle v0."""
+
+from __future__ import annotations
+
+import ast
+import json
+import socket
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.ops.shadow_preparation_readiness_bundle_v0 import (
+    BUNDLE_STATUS_BLOCKED,
+    BUNDLE_STATUS_ERROR,
+    BUNDLE_STATUS_PASS,
+    PACKAGE_MARKER,
+    PRODUCER_FAMILY,
+    SCHEMA_ID,
+    build_shadow_preparation_readiness_bundle_v0,
+    serialize_shadow_preparation_readiness_bundle_v0,
+)
+from src.ops.shadow_preparation_readiness_gate_v0 import (
+    CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY,
+    DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+    PreparationStatusV0,
+    evaluate_shadow_preparation_readiness_gate_v0,
+    load_shadow_preparation_readiness_gate_config_v0,
+)
+from src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0 import (
+    PIPELINE_STATUS_BLOCKED,
+    PIPELINE_STATUS_ERROR,
+    PIPELINE_STATUS_PASS,
+    READINESS_STATUS_BLOCKED,
+    READINESS_STATUS_READY,
+    ShadowPreparationReadinessOfflineProjectionPipelineResultV0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG = REPO_ROOT / "config" / "ops" / "shadow_preparation_readiness_gate_v0.toml"
+BUNDLE_MODULE = REPO_ROOT / "src" / "ops" / "shadow_preparation_readiness_bundle_v0.py"
+CONTRACT_DOC = (
+    REPO_ROOT / "docs" / "ops" / "runbooks" / "SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md"
+)
+EVALUATED_AT = "2026-07-25T12:00:00Z"
+AS_OF = "2026-07-25T12:00:30Z"
+
+FORBIDDEN_IMPORT_PREFIXES = (
+    "src.webui",
+    "src.orders",
+    "src.execution",
+    "src.live",
+    "src.scheduler",
+    "src.trading.master_v2",
+)
+
+
+def _collect_required_relative_paths(cfg: dict) -> set[str]:
+    paths: set[str] = set()
+    for surface in cfg["historical_surfaces"]:
+        paths.add(str(surface["path"]).strip())
+    for component in cfg["mindestkontrakt_components"]:
+        for evidence_path in component.get("evidence_paths") or []:
+            paths.add(str(evidence_path).strip())
+    paths.add(str(cfg[CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY]).strip())
+    return paths
+
+
+def _materialize_temp_repo(tmp_path: Path) -> tuple[Path, dict]:
+    cfg = load_shadow_preparation_readiness_gate_config_v0(CONFIG, repo_root=REPO_ROOT)
+    for relative in _collect_required_relative_paths(cfg):
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if not target.exists():
+            target.write_text(f"# stub:{relative}\n", encoding="utf-8")
+    config_dest = tmp_path / "config" / "ops" / "shadow_preparation_readiness_gate_v0.toml"
+    config_dest.parent.mkdir(parents=True, exist_ok=True)
+    config_dest.write_text(CONFIG.read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / "out" / "ops").mkdir(parents=True, exist_ok=True)
+    return tmp_path, cfg
+
+
+def _ready_like_evaluation(base):
+    inventory = tuple(
+        replace(record, preparation_status=PreparationStatusV0.PRESENT)
+        for record in base.mindestkontrakt_inventory
+    )
+    return replace(
+        base,
+        shadow_preparation_complete=True,
+        blockers=(),
+        unmet_gates=(),
+        mindestkontrakt_inventory=inventory,
+    )
+
+
+def test_package_marker_and_schema_identity() -> None:
+    assert PACKAGE_MARKER == "SHADOW_PREPARATION_READINESS_BUNDLE_V0=true"
+    assert PRODUCER_FAMILY == SCHEMA_ID
+    assert PRODUCER_FAMILY.endswith("_v0")
+
+
+def test_blocked_pipeline_yields_bundle_blocked_with_canonical_artifacts(
+    tmp_path: Path,
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    bundle = build_shadow_preparation_readiness_bundle_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert bundle.bundle_status == BUNDLE_STATUS_BLOCKED
+    assert bundle.pipeline is not None
+    assert bundle.pipeline["pipeline_status"] == PIPELINE_STATUS_BLOCKED
+    assert bundle.pipeline["readiness_status"] == READINESS_STATUS_BLOCKED
+    assert bundle.projection is not None
+    assert bundle.projection["schema_id"] == "shadow_preparation_readiness_projection"
+    assert bundle.projection["shadow_preparation_complete"] is False
+    assert bundle.verification is not None
+    assert bundle.verification["verified"] is True
+    assert bundle.verification["overall_status"] == "VERIFIED"
+    assert bundle.to_dict()["authority_effect"] == "NONE"
+    assert bundle.to_dict()["activation_authority"] is False
+    assert bundle.to_dict()["read_only"] is True
+    assert bundle.to_dict()["bundle_only"] is True
+
+
+def test_ready_like_pipeline_yields_bundle_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    real_evaluate = evaluate_shadow_preparation_readiness_gate_v0
+
+    def _ready_evaluate(**kwargs):
+        return _ready_like_evaluation(real_evaluate(**kwargs))
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_offline_projection_pipeline_v0."
+        "evaluate_shadow_preparation_readiness_gate_v0",
+        _ready_evaluate,
+    )
+    bundle = build_shadow_preparation_readiness_bundle_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    assert bundle.bundle_status == BUNDLE_STATUS_PASS
+    assert bundle.pipeline is not None
+    assert bundle.pipeline["pipeline_status"] == PIPELINE_STATUS_PASS
+    assert bundle.pipeline["readiness_status"] == READINESS_STATUS_READY
+    assert bundle.projection is not None
+    assert bundle.projection["shadow_preparation_complete"] is True
+    assert bundle.verification is not None
+    assert bundle.verification["verified"] is True
+    assert bundle.reason_codes == ()
+
+
+def test_pipeline_error_does_not_synthesize_projection_or_verification(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+
+    def _error_pipeline(**_kwargs):
+        return ShadowPreparationReadinessOfflineProjectionPipelineResultV0(
+            pipeline_status=PIPELINE_STATUS_ERROR,
+            readiness_status=None,
+            evaluated_at=None,
+            projection_path=None,
+            projection_schema_id=None,
+            projection_schema_version=None,
+            projection_sha256=None,
+            verification_status=None,
+            verification_verified=None,
+            reason_codes=("GATE_EVALUATION_FAILED:synthetic",),
+            evidence_reference_count=None,
+        )
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_bundle_v0."
+        "run_shadow_preparation_readiness_offline_projection_pipeline_v0",
+        _error_pipeline,
+    )
+    bundle = build_shadow_preparation_readiness_bundle_v0(repo_root=root)
+    assert bundle.bundle_status == BUNDLE_STATUS_ERROR
+    assert bundle.projection is None
+    assert bundle.verification is None
+    assert bundle.pipeline is not None
+    assert "GATE_EVALUATION_FAILED:synthetic" in bundle.reason_codes
+
+
+def test_missing_projection_artifact_fail_closed_blocked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+
+    def _blocked_without_file(**_kwargs):
+        return ShadowPreparationReadinessOfflineProjectionPipelineResultV0(
+            pipeline_status=PIPELINE_STATUS_BLOCKED,
+            readiness_status=READINESS_STATUS_BLOCKED,
+            evaluated_at=EVALUATED_AT,
+            projection_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+            projection_schema_id="shadow_preparation_readiness_projection",
+            projection_schema_version="v0",
+            projection_sha256="deadbeef",
+            verification_status="VERIFIED",
+            verification_verified=True,
+            reason_codes=(),
+            evidence_reference_count=0,
+        )
+
+    monkeypatch.setattr(
+        "src.ops.shadow_preparation_readiness_bundle_v0."
+        "run_shadow_preparation_readiness_offline_projection_pipeline_v0",
+        _blocked_without_file,
+    )
+    # Do not create the projection file — fail closed.
+    bundle = build_shadow_preparation_readiness_bundle_v0(repo_root=root)
+    assert bundle.bundle_status == BUNDLE_STATUS_BLOCKED
+    assert bundle.projection is None
+    assert bundle.verification is None
+    assert any(code.startswith("BUNDLE_ARTIFACT_UNAVAILABLE:") for code in bundle.reason_codes)
+
+
+def test_serialize_is_deterministic_and_includes_canonical_pipeline_dict(
+    tmp_path: Path,
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    bundle = build_shadow_preparation_readiness_bundle_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+    )
+    raw_a = serialize_shadow_preparation_readiness_bundle_v0(bundle)
+    raw_b = serialize_shadow_preparation_readiness_bundle_v0(bundle)
+    assert raw_a == raw_b
+    payload = json.loads(raw_a)
+    assert payload["schema_id"] == SCHEMA_ID
+    assert payload["pipeline"]["schema_id"].endswith(
+        "shadow_preparation_readiness_offline_projection_pipeline_v0"
+    )
+    assert payload["projection"]["evaluation"]["schema_id"].endswith(
+        "shadow_preparation_readiness_gate_v0"
+    )
+
+
+def test_no_forbidden_imports_or_network() -> None:
+    tree = ast.parse(BUNDLE_MODULE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                for prefix in FORBIDDEN_IMPORT_PREFIXES:
+                    assert not alias.name.startswith(prefix)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for prefix in FORBIDDEN_IMPORT_PREFIXES:
+                assert not node.module.startswith(prefix)
+        elif isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            assert not (node.value.id == "socket" and node.attr == "socket")
+    assert "socket" not in BUNDLE_MODULE.read_text(encoding="utf-8")
+    # socket must remain unused (guard against accidental network deps).
+    assert socket.AF_INET
+
+
+def test_contract_doc_mentions_bundle() -> None:
+    text = CONTRACT_DOC.read_text(encoding="utf-8")
+    assert "SHADOW_PREPARATION_READINESS_BUNDLE_V0" in text
+    assert "shadow_preparation_readiness_bundle_v0" in text
+    assert "bundle_only" in text or "BUNDLE_PASS" in text


### PR DESCRIPTION
## Summary
- Add read-only `Shadow Preparation Readiness Bundle v0` that aggregates canonical offline pipeline, durable projection, and verifier artifacts for operator consumption.
- Reuses the existing offline projection pipeline (gate + writer + reader/verifier); does not duplicate projection serialization or introduce a second readiness truth.
- Update the existing readiness gate contract/runbook with bundle ownership and fail-closed guarantees. Non-activating.

## Test plan
- [x] `pytest tests/ops/test_shadow_preparation_readiness_bundle_v0.py` (8 passed, ~0.17s)
- [x] ruff format/check on changed Python files
- [x] docs reference targets gate
- [x] docs token policy (no violations in changed contract)

## Explicit non-goals
- No Shadow/Paper/Testnet/Scheduler/Orders/Runtime activation
- No dashboard work
- No new readiness authority / second truth
- Draft only — do not mark Ready / merge / auto-merge


Made with [Cursor](https://cursor.com)