### PR TITLE
ops: OKX Futures Shadow offline e2e projection binding v0

### DIFF
--- a/scripts/ops/run_okx_futures_shadow_offline_e2e_projection_binding_v0.py
+++ b/scripts/ops/run_okx_futures_shadow_offline_e2e_projection_binding_v0.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Operator CLI: OKX Futures Shadow offline e2e projection binding v0.
+
+Composes readiness gate → canonical no-order cycle → durable projection → verify.
+Offline, fail-closed. No orders, network, scheduler, or activation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from src.ops.bounded_futures_testnet_venue_binding_v0 import (  # noqa: E402
+    PRODUCTION_INSTRUMENT_ID,
+)
+from src.ops.okx_futures_shadow_offline_e2e_projection_binding_v0 import (  # noqa: E402
+    BINDING_STATUS_BLOCKED,
+    BINDING_STATUS_PASS,
+    result_to_machine_lines,
+    run_okx_futures_shadow_offline_e2e_projection_binding_v0,
+)
+
+EXIT_PASS = 0
+EXIT_ERROR = 1
+EXIT_BLOCKED = 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Bind OKX Futures Shadow no-order cycle to Shadow Preparation "
+            "Readiness offline projection pipeline (offline, no order submission)."
+        )
+    )
+    p.add_argument(
+        "--repo-root",
+        type=Path,
+        default=_REPO_ROOT,
+        help="Repository root for readiness evaluation and projection I/O.",
+    )
+    p.add_argument(
+        "--mode",
+        required=True,
+        help="Must be exactly 'shadow' (fail-closed otherwise).",
+    )
+    p.add_argument(
+        "--instrument-id",
+        default=PRODUCTION_INSTRUMENT_ID,
+        help=f"Canonical non-BTC OKX Futures instrument (default: {PRODUCTION_INSTRUMENT_ID}).",
+    )
+    p.add_argument(
+        "--output-path",
+        default=None,
+        help="Optional relative readiness projection output path (repo-rooted).",
+    )
+    p.add_argument(
+        "--config-path",
+        type=Path,
+        default=None,
+        help="Optional path to readiness gate config TOML.",
+    )
+    p.add_argument(
+        "--evaluated-at",
+        default=None,
+        help="Optional ISO-8601 evaluation timestamp.",
+    )
+    p.add_argument(
+        "--as-of",
+        default=None,
+        help="Optional ISO-8601 verifier as-of timestamp.",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON result on stdout (default: machine lines).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=Path(args.repo_root),
+        output_path=args.output_path,
+        config_path=args.config_path,
+        evaluated_at=args.evaluated_at,
+        as_of=args.as_of,
+        mode=args.mode,
+        instrument_id=args.instrument_id,
+    )
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        for line in result_to_machine_lines(result):
+            print(line)
+    if result.binding_status == BINDING_STATUS_PASS:
+        return EXIT_PASS
+    if result.binding_status == BINDING_STATUS_BLOCKED:
+        return EXIT_BLOCKED
+    return EXIT_ERROR
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ops/okx_futures_shadow_offline_e2e_projection_binding_v0.py
+++ b/src/ops/okx_futures_shadow_offline_e2e_projection_binding_v0.py
@@ -1,0 +1,604 @@
+"""OKX Futures Shadow offline end-to-end projection binding v0.
+
+Composition-only boundary:
+  readiness gate → (if offline path permitted and READY) canonical no-order cycle →
+  durable readiness projection write → reader/verifier.
+
+Reuses existing canonical owners only. No second decision/risk/safety/execution/
+reconciliation/readiness/writer/reader/projection truth. Offline, non-activating.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal, Mapping, Optional
+
+from src.ops.bounded_futures_testnet_venue_binding_v0 import (
+    PRODUCTION_INSTRUMENT_ID,
+    PRODUCTION_INSTRUMENT_TYPE,
+    VENUE_OKX_EUROPE,
+)
+from src.ops.okx_futures_shadow_no_order_entrypoint_v0 import (
+    OkxFuturesShadowNoOrderCycleResultV0,
+    run_okx_futures_shadow_no_order_cycle_v0,
+    serialize_okx_futures_shadow_no_order_cycle_result_v0,
+)
+from src.ops.shadow_preparation_readiness_gate_v0 import (
+    DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+    PROJECTION_OUTPUT_PATH_CONFIG_KEY,
+    PROJECTION_OVERALL_STATUS_VERIFIED,
+    PROJECTION_SCHEMA_ID,
+    PROJECTION_SCHEMA_VERSION,
+    ShadowPreparationReadinessGateError,
+    ShadowPreparationReadinessGateResultV0,
+    evaluate_shadow_preparation_readiness_gate_v0,
+    load_shadow_preparation_readiness_gate_config_v0,
+    verify_shadow_preparation_readiness_projection_v0,
+    write_shadow_preparation_readiness_projection_v0,
+)
+
+PACKAGE_MARKER = "OKX_FUTURES_SHADOW_OFFLINE_E2E_PROJECTION_BINDING_V0=true"
+PRODUCER_FAMILY = "ops.okx_futures_shadow_offline_e2e_projection_binding_v0"
+SCHEMA_ID = PRODUCER_FAMILY
+SCHEMA_VERSION = "v0"
+CLI_RELPATH = "scripts/ops/run_okx_futures_shadow_offline_e2e_projection_binding_v0.py"
+ENTRYPOINT_OWNER = PRODUCER_FAMILY
+
+BINDING_STATUS_PASS: Literal["BINDING_PASS"] = "BINDING_PASS"
+BINDING_STATUS_BLOCKED: Literal["BINDING_BLOCKED"] = "BINDING_BLOCKED"
+BINDING_STATUS_ERROR: Literal["BINDING_ERROR"] = "BINDING_ERROR"
+
+READINESS_STATUS_READY: Literal["READY"] = "READY"
+READINESS_STATUS_BLOCKED: Literal["BLOCKED"] = "BLOCKED"
+
+OFFLINE_PATH_TOKEN = "CONTINUE_OFFLINE_SHADOW_PREPARATION"
+
+EXPECTED_DECISION = "hold"
+EXPECTED_RISK_SIZING = "NONE"
+EXPECTED_SAFETY = "PASS"
+EXPECTED_EXECUTION_PROJECTION = "NOT_APPLICABLE:NONE"
+EXPECTED_RECONCILIATION = "BOUND_OFFLINE"
+
+BindingStatusV0 = Literal["BINDING_PASS", "BINDING_BLOCKED", "BINDING_ERROR"]
+ReadinessStatusV0 = Literal["READY", "BLOCKED"]
+
+CycleRunnerV0 = Callable[..., OkxFuturesShadowNoOrderCycleResultV0]
+
+
+@dataclass(frozen=True)
+class OkxFuturesShadowOfflineE2EProjectionBindingResultV0:
+    """Structured fail-closed outcome for one offline e2e binding invocation."""
+
+    binding_status: BindingStatusV0
+    schema_id: str
+    schema_version: str
+    generated_at: str | None
+    readiness_result: ReadinessStatusV0 | None
+    final_decision: str | None
+    risk_sizing_result: str | None
+    safety_result: str | None
+    execution_projection_result: str | None
+    reconciliation_result: str | None
+    venue: str | None
+    instrument_class: str | None
+    btc_excluded: bool | None
+    spot_excluded: bool | None
+    futures_only: bool | None
+    order_submission_count: int
+    order_capable_client_instantiated: bool
+    cycle_invoked: bool
+    projection_path: str | None
+    projection_schema_id: str | None
+    projection_schema_version: str | None
+    projection_sha256: str | None
+    verification_status: Literal["VERIFIED", "BLOCKED"] | None
+    verification_verified: bool | None
+    verification_result: str | None
+    reason_codes: tuple[str, ...]
+    cycle_projection: Mapping[str, Any] | None
+    network_access: bool = False
+    background_process_left_running: bool = False
+    package_marker: str = PACKAGE_MARKER
+    entrypoint_owner: str = ENTRYPOINT_OWNER
+    cli_relpath: str = CLI_RELPATH
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_id": self.schema_id,
+            "schema_version": self.schema_version,
+            "binding_status": self.binding_status,
+            "generated_at": self.generated_at,
+            "readiness_result": self.readiness_result,
+            "final_decision": self.final_decision,
+            "risk_sizing_result": self.risk_sizing_result,
+            "safety_result": self.safety_result,
+            "execution_projection_result": self.execution_projection_result,
+            "reconciliation_result": self.reconciliation_result,
+            "venue": self.venue,
+            "instrument_class": self.instrument_class,
+            "btc_excluded": self.btc_excluded,
+            "spot_excluded": self.spot_excluded,
+            "futures_only": self.futures_only,
+            "order_submission_count": self.order_submission_count,
+            "order_capable_client_instantiated": self.order_capable_client_instantiated,
+            "cycle_invoked": self.cycle_invoked,
+            "projection_path": self.projection_path,
+            "projection_schema_id": self.projection_schema_id,
+            "projection_schema_version": self.projection_schema_version,
+            "projection_sha256": self.projection_sha256,
+            "verification_status": self.verification_status,
+            "verification_verified": self.verification_verified,
+            "verification_result": self.verification_result,
+            "reason_codes": list(self.reason_codes),
+            "cycle_projection": (
+                dict(self.cycle_projection) if self.cycle_projection is not None else None
+            ),
+            "network_access": False,
+            "background_process_left_running": False,
+            "authority_effect": "NONE",
+            "activation_authority": False,
+            "projection_only": True,
+            "package_marker": self.package_marker,
+            "entrypoint_owner": self.entrypoint_owner,
+            "cli_relpath": self.cli_relpath,
+        }
+
+
+def _error_result(
+    *,
+    reason_codes: tuple[str, ...],
+    generated_at: str | None = None,
+    readiness_result: ReadinessStatusV0 | None = None,
+    cycle_invoked: bool = False,
+    cycle: OkxFuturesShadowNoOrderCycleResultV0 | None = None,
+    projection_path: str | None = None,
+    projection_schema_id: str | None = None,
+    projection_schema_version: str | None = None,
+    projection_sha256: str | None = None,
+    verification_status: Literal["VERIFIED", "BLOCKED"] | None = None,
+    verification_verified: bool | None = None,
+) -> OkxFuturesShadowOfflineE2EProjectionBindingResultV0:
+    return OkxFuturesShadowOfflineE2EProjectionBindingResultV0(
+        binding_status=BINDING_STATUS_ERROR,
+        schema_id=SCHEMA_ID,
+        schema_version=SCHEMA_VERSION,
+        generated_at=generated_at,
+        readiness_result=readiness_result,
+        final_decision=cycle.decision_result if cycle is not None else None,
+        risk_sizing_result=cycle.risk_sizing_result if cycle is not None else None,
+        safety_result=cycle.safety_result if cycle is not None else None,
+        execution_projection_result=(cycle.execution_intent_result if cycle is not None else None),
+        reconciliation_result=(cycle.reconciliation_audit_result if cycle is not None else None),
+        venue=cycle.venue if cycle is not None else None,
+        instrument_class=cycle.market_classification if cycle is not None else None,
+        btc_excluded=cycle.btc_excluded if cycle is not None else None,
+        spot_excluded=cycle.spot_excluded if cycle is not None else None,
+        futures_only=cycle.futures_only if cycle is not None else None,
+        order_submission_count=_order_submission_count(cycle) if cycle is not None else 0,
+        order_capable_client_instantiated=(
+            bool(cycle.order_capable_client_instantiated) if cycle is not None else False
+        ),
+        cycle_invoked=cycle_invoked,
+        projection_path=projection_path,
+        projection_schema_id=projection_schema_id,
+        projection_schema_version=projection_schema_version,
+        projection_sha256=projection_sha256,
+        verification_status=verification_status,
+        verification_verified=verification_verified,
+        verification_result=(
+            None if verification_status is None else ("PASS" if verification_verified else "FAIL")
+        ),
+        reason_codes=reason_codes,
+        cycle_projection=(
+            serialize_okx_futures_shadow_no_order_cycle_result_v0(cycle)
+            if cycle is not None
+            else None
+        ),
+    )
+
+
+def _classify_readiness_status(
+    evaluation: ShadowPreparationReadinessGateResultV0,
+) -> ReadinessStatusV0:
+    if (
+        evaluation.shadow_preparation_complete
+        and not evaluation.blockers
+        and not evaluation.unmet_gates
+    ):
+        return READINESS_STATUS_READY
+    return READINESS_STATUS_BLOCKED
+
+
+def _offline_shadow_preparation_path_permitted(
+    evaluation: ShadowPreparationReadinessGateResultV0,
+) -> bool:
+    """Existing contract: offline classification only; never activation."""
+    if evaluation.authority_effect != "NONE":
+        return False
+    if evaluation.shadow_activation_authorized:
+        return False
+    if evaluation.paper_activation_authorized:
+        return False
+    if evaluation.testnet_activation_authorized:
+        return False
+    if evaluation.scheduler_activation_authorized:
+        return False
+    if evaluation.runtime_activation_authorized:
+        return False
+    if evaluation.live_authorized or evaluation.orders_authorized:
+        return False
+    if OFFLINE_PATH_TOKEN not in evaluation.next_permitted_action:
+        return False
+    return True
+
+
+def _resolve_output_path(
+    *,
+    repo_root: Path,
+    output_path: str | None,
+    config: Mapping[str, Any] | None,
+    config_path: Path | None,
+) -> str:
+    if output_path is not None:
+        if not isinstance(output_path, str) or not output_path.strip():
+            raise ShadowPreparationReadinessGateError("BINDING_OUTPUT_PATH_EMPTY")
+        return output_path.strip()
+    cfg = (
+        dict(config)
+        if config is not None
+        else load_shadow_preparation_readiness_gate_config_v0(config_path, repo_root=repo_root)
+    )
+    raw = cfg.get(PROJECTION_OUTPUT_PATH_CONFIG_KEY)
+    if not isinstance(raw, str) or not raw.strip():
+        raise ShadowPreparationReadinessGateError("BINDING_OUTPUT_PATH_UNCONFIGURED")
+    return raw.strip()
+
+
+def _order_submission_count(cycle: OkxFuturesShadowNoOrderCycleResultV0) -> int:
+    flags = (
+        bool(cycle.real_order_submission),
+        bool(cycle.exchange_order_submission),
+        bool(cycle.testnet_order_submission),
+    )
+    return sum(1 for flag in flags if flag)
+
+
+def validate_cycle_projection_for_binding_v0(
+    cycle: OkxFuturesShadowNoOrderCycleResultV0 | None,
+) -> tuple[str, ...]:
+    """Fail-closed validation of the exact returned cycle (no recomputation)."""
+    if cycle is None:
+        return ("CYCLE_RESULT_MISSING",)
+    reasons: list[str] = []
+    if cycle.terminal_status != "PASS":
+        reasons.append("CYCLE_TERMINAL_STATUS_NOT_PASS")
+    if not isinstance(cycle.decision_result, str) or not cycle.decision_result.strip():
+        reasons.append("CYCLE_RESULT_INVALID:decision_result")
+    elif cycle.decision_result != EXPECTED_DECISION:
+        reasons.append("CYCLE_DECISION_NOT_HOLD")
+    if cycle.risk_sizing_result != EXPECTED_RISK_SIZING:
+        reasons.append("CYCLE_RISK_SIZING_NOT_NONE")
+    if cycle.safety_result != EXPECTED_SAFETY:
+        reasons.append("CYCLE_SAFETY_NOT_PASS")
+    if cycle.execution_intent_result != EXPECTED_EXECUTION_PROJECTION:
+        reasons.append("CYCLE_EXECUTION_PROJECTION_NOT_APPLICABLE_NONE")
+    if cycle.reconciliation_audit_result != EXPECTED_RECONCILIATION:
+        reasons.append("CYCLE_RECONCILIATION_NOT_BOUND_OFFLINE")
+    if cycle.venue != VENUE_OKX_EUROPE:
+        reasons.append("CYCLE_VENUE_NOT_OKX")
+    if cycle.market_classification != PRODUCTION_INSTRUMENT_TYPE:
+        reasons.append("CYCLE_INSTRUMENT_CLASS_NOT_FUTURES")
+    if not cycle.futures_only:
+        reasons.append("CYCLE_FUTURES_ONLY_REQUIRED")
+    if not cycle.btc_excluded:
+        reasons.append("CYCLE_BTC_NOT_EXCLUDED")
+    if not cycle.spot_excluded:
+        reasons.append("CYCLE_SPOT_NOT_EXCLUDED")
+    if _order_submission_count(cycle) != 0:
+        reasons.append("CYCLE_ORDER_SUBMISSION_COUNT_NONZERO")
+    if cycle.order_capable_client_instantiated:
+        reasons.append("CYCLE_ORDER_CAPABLE_CLIENT_INSTANTIATED")
+    if cycle.background_process_left_running:
+        reasons.append("CYCLE_BACKGROUND_PROCESS_LEFT_RUNNING")
+    if cycle.live_activation or cycle.scheduler:
+        reasons.append("CYCLE_ACTIVATION_SURFACE_FORBIDDEN")
+    # Preserve order, drop duplicates.
+    deduped: list[str] = []
+    for code in reasons:
+        if code not in deduped:
+            deduped.append(code)
+    return tuple(deduped)
+
+
+def run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+    *,
+    repo_root: Path,
+    output_path: str | None = None,
+    config: Mapping[str, Any] | None = None,
+    config_path: Path | None = None,
+    evaluated_at: str | None = None,
+    as_of: str | None = None,
+    mode: str = "shadow",
+    instrument_id: Optional[str] = None,
+    cycle_runner: CycleRunnerV0 | None = None,
+) -> OkxFuturesShadowOfflineE2EProjectionBindingResultV0:
+    """Bind readiness → canonical no-order cycle → durable projection → verify."""
+    root = repo_root.resolve()
+    runner = cycle_runner or run_okx_futures_shadow_no_order_cycle_v0
+
+    try:
+        resolved_output = _resolve_output_path(
+            repo_root=root,
+            output_path=output_path,
+            config=config,
+            config_path=config_path,
+        )
+    except ShadowPreparationReadinessGateError as exc:
+        return _error_result(reason_codes=(f"BINDING_INPUT_INVALID:{exc}",))
+
+    try:
+        evaluation = evaluate_shadow_preparation_readiness_gate_v0(
+            config=config,
+            config_path=config_path,
+            repo_root=root,
+            evaluated_at=evaluated_at,
+        )
+    except ShadowPreparationReadinessGateError as exc:
+        return _error_result(reason_codes=(f"GATE_EVALUATION_FAILED:{exc}",))
+    except Exception as exc:  # pragma: no cover - defensive fail-closed
+        return _error_result(reason_codes=(f"GATE_EVALUATION_FAILED:{type(exc).__name__}:{exc}",))
+
+    generated_at = evaluation.evaluated_at
+    readiness_status = _classify_readiness_status(evaluation)
+
+    if not _offline_shadow_preparation_path_permitted(evaluation):
+        return _error_result(
+            reason_codes=("OFFLINE_SHADOW_PREPARATION_PATH_NOT_PERMITTED",),
+            generated_at=generated_at,
+            readiness_result=readiness_status,
+        )
+
+    try:
+        write_meta = write_shadow_preparation_readiness_projection_v0(
+            evaluation=evaluation,
+            repo_root=root,
+            output_path=resolved_output,
+            evaluated_at=generated_at,
+        )
+    except ShadowPreparationReadinessGateError as exc:
+        return _error_result(
+            reason_codes=(f"PROJECTION_WRITE_FAILED:{exc}",),
+            generated_at=generated_at,
+            readiness_result=readiness_status,
+            projection_path=resolved_output,
+        )
+    except Exception as exc:  # pragma: no cover - defensive fail-closed
+        return _error_result(
+            reason_codes=(f"PROJECTION_WRITE_FAILED:{type(exc).__name__}:{exc}",),
+            generated_at=generated_at,
+            readiness_result=readiness_status,
+            projection_path=resolved_output,
+        )
+
+    verify_as_of = as_of if as_of is not None else generated_at
+    try:
+        verification = verify_shadow_preparation_readiness_projection_v0(
+            repo_root=root,
+            projection_path=write_meta.output_path,
+            config=config,
+            config_path=config_path,
+            as_of=verify_as_of,
+            expected_sha256=write_meta.sha256,
+        )
+    except Exception as exc:  # pragma: no cover - defensive fail-closed
+        return _error_result(
+            reason_codes=(f"PROJECTION_VERIFY_FAILED:{type(exc).__name__}:{exc}",),
+            generated_at=generated_at,
+            readiness_result=readiness_status,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+        )
+
+    if (
+        not verification.verified
+        or verification.overall_status != PROJECTION_OVERALL_STATUS_VERIFIED
+    ):
+        codes = tuple(verification.reason_codes) or ("PROJECTION_VERIFICATION_BLOCKED",)
+        # Schema/digest mismatches surface through verifier reason codes.
+        return _error_result(
+            reason_codes=codes,
+            generated_at=generated_at,
+            readiness_result=readiness_status,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+            verification_status=verification.overall_status,
+            verification_verified=verification.verified,
+        )
+
+    if write_meta.schema_id != PROJECTION_SCHEMA_ID:
+        return _error_result(
+            reason_codes=("SCHEMA_MISMATCH",),
+            generated_at=generated_at,
+            readiness_result=readiness_status,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+            verification_status=verification.overall_status,
+            verification_verified=verification.verified,
+        )
+    if write_meta.schema_version != PROJECTION_SCHEMA_VERSION:
+        return _error_result(
+            reason_codes=("SCHEMA_MISMATCH",),
+            generated_at=generated_at,
+            readiness_result=readiness_status,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+            verification_status=verification.overall_status,
+            verification_verified=verification.verified,
+        )
+
+    if readiness_status == READINESS_STATUS_BLOCKED:
+        return OkxFuturesShadowOfflineE2EProjectionBindingResultV0(
+            binding_status=BINDING_STATUS_BLOCKED,
+            schema_id=SCHEMA_ID,
+            schema_version=SCHEMA_VERSION,
+            generated_at=generated_at,
+            readiness_result=READINESS_STATUS_BLOCKED,
+            final_decision=None,
+            risk_sizing_result=None,
+            safety_result=None,
+            execution_projection_result=None,
+            reconciliation_result=None,
+            venue=None,
+            instrument_class=None,
+            btc_excluded=None,
+            spot_excluded=None,
+            futures_only=None,
+            order_submission_count=0,
+            order_capable_client_instantiated=False,
+            cycle_invoked=False,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+            verification_status=verification.overall_status,
+            verification_verified=verification.verified,
+            verification_result="PASS",
+            reason_codes=("READINESS_BLOCKED_CYCLE_NOT_INVOKED",),
+            cycle_projection=None,
+        )
+
+    selected = (
+        PRODUCTION_INSTRUMENT_ID
+        if instrument_id is None or str(instrument_id).strip() == ""
+        else str(instrument_id).strip()
+    )
+    try:
+        cycle = runner(mode=mode, instrument_id=selected)
+    except Exception as exc:  # pragma: no cover - defensive fail-closed
+        return _error_result(
+            reason_codes=(f"CYCLE_INVOCATION_FAILED:{type(exc).__name__}:{exc}",),
+            generated_at=generated_at,
+            readiness_result=readiness_status,
+            cycle_invoked=True,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+            verification_status=verification.overall_status,
+            verification_verified=verification.verified,
+        )
+
+    if cycle is None:
+        return _error_result(
+            reason_codes=("CYCLE_RESULT_MISSING",),
+            generated_at=generated_at,
+            readiness_result=readiness_status,
+            cycle_invoked=True,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+            verification_status=verification.overall_status,
+            verification_verified=verification.verified,
+        )
+
+    cycle_codes = validate_cycle_projection_for_binding_v0(cycle)
+    if cycle_codes:
+        return _error_result(
+            reason_codes=cycle_codes,
+            generated_at=generated_at,
+            readiness_result=readiness_status,
+            cycle_invoked=True,
+            cycle=cycle,
+            projection_path=write_meta.output_path,
+            projection_schema_id=write_meta.schema_id,
+            projection_schema_version=write_meta.schema_version,
+            projection_sha256=write_meta.sha256,
+            verification_status=verification.overall_status,
+            verification_verified=verification.verified,
+        )
+
+    cycle_payload = serialize_okx_futures_shadow_no_order_cycle_result_v0(cycle)
+    return OkxFuturesShadowOfflineE2EProjectionBindingResultV0(
+        binding_status=BINDING_STATUS_PASS,
+        schema_id=SCHEMA_ID,
+        schema_version=SCHEMA_VERSION,
+        generated_at=generated_at,
+        readiness_result=READINESS_STATUS_READY,
+        final_decision=cycle.decision_result,
+        risk_sizing_result=cycle.risk_sizing_result,
+        safety_result=cycle.safety_result,
+        execution_projection_result=cycle.execution_intent_result,
+        reconciliation_result=cycle.reconciliation_audit_result,
+        venue=cycle.venue,
+        instrument_class=cycle.market_classification,
+        btc_excluded=cycle.btc_excluded,
+        spot_excluded=cycle.spot_excluded,
+        futures_only=cycle.futures_only,
+        order_submission_count=0,
+        order_capable_client_instantiated=False,
+        cycle_invoked=True,
+        projection_path=write_meta.output_path,
+        projection_schema_id=write_meta.schema_id,
+        projection_schema_version=write_meta.schema_version,
+        projection_sha256=write_meta.sha256,
+        verification_status=verification.overall_status,
+        verification_verified=verification.verified,
+        verification_result="PASS",
+        reason_codes=(),
+        cycle_projection=cycle_payload,
+    )
+
+
+def result_to_machine_lines(
+    result: OkxFuturesShadowOfflineE2EProjectionBindingResultV0,
+) -> list[str]:
+    data = result.to_dict()
+    lines: list[str] = []
+    for key, value in data.items():
+        if key == "cycle_projection":
+            rendered = "present" if value is not None else "none"
+        elif isinstance(value, list):
+            rendered = "[" + ",".join(str(v) for v in value) + "]"
+        elif isinstance(value, bool):
+            rendered = str(value).lower()
+        elif value is None:
+            rendered = "none"
+        else:
+            rendered = str(value)
+        lines.append(f"{key.upper()}={rendered}")
+    return lines
+
+
+__all__ = [
+    "BINDING_STATUS_BLOCKED",
+    "BINDING_STATUS_ERROR",
+    "BINDING_STATUS_PASS",
+    "CLI_RELPATH",
+    "DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH",
+    "ENTRYPOINT_OWNER",
+    "EXPECTED_DECISION",
+    "EXPECTED_EXECUTION_PROJECTION",
+    "EXPECTED_RECONCILIATION",
+    "EXPECTED_RISK_SIZING",
+    "EXPECTED_SAFETY",
+    "OkxFuturesShadowOfflineE2EProjectionBindingResultV0",
+    "PACKAGE_MARKER",
+    "PRODUCER_FAMILY",
+    "READINESS_STATUS_BLOCKED",
+    "READINESS_STATUS_READY",
+    "SCHEMA_ID",
+    "SCHEMA_VERSION",
+    "result_to_machine_lines",
+    "run_okx_futures_shadow_offline_e2e_projection_binding_v0",
+    "validate_cycle_projection_for_binding_v0",
+]

--- a/tests/ops/test_okx_futures_shadow_offline_e2e_projection_binding_v0.py
+++ b/tests/ops/test_okx_futures_shadow_offline_e2e_projection_binding_v0.py
@@ -1,0 +1,541 @@
+"""Focused tests for OKX Futures Shadow offline e2e projection binding v0."""
+
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.ops.bounded_futures_testnet_venue_binding_v0 import (
+    PRODUCTION_INSTRUMENT_ID,
+    VENUE_OKX_EUROPE,
+)
+from src.ops.okx_futures_shadow_no_order_entrypoint_v0 import (
+    OkxFuturesShadowNoOrderCycleResultV0,
+    run_okx_futures_shadow_no_order_cycle_v0,
+)
+from src.ops.okx_futures_shadow_offline_e2e_projection_binding_v0 import (
+    BINDING_STATUS_BLOCKED,
+    BINDING_STATUS_ERROR,
+    BINDING_STATUS_PASS,
+    CLI_RELPATH,
+    EXPECTED_DECISION,
+    EXPECTED_EXECUTION_PROJECTION,
+    EXPECTED_RECONCILIATION,
+    EXPECTED_RISK_SIZING,
+    EXPECTED_SAFETY,
+    PACKAGE_MARKER,
+    PRODUCER_FAMILY,
+    READINESS_STATUS_BLOCKED,
+    READINESS_STATUS_READY,
+    SCHEMA_ID,
+    run_okx_futures_shadow_offline_e2e_projection_binding_v0,
+)
+from src.ops.shadow_preparation_readiness_gate_v0 import (
+    CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY,
+    DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+    PreparationStatusV0,
+    PROJECTION_SCHEMA_ID,
+    ShadowPreparationReadinessGateError,
+    evaluate_shadow_preparation_readiness_gate_v0,
+    load_shadow_preparation_readiness_gate_config_v0,
+    write_shadow_preparation_readiness_projection_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG = REPO_ROOT / "config" / "ops" / "shadow_preparation_readiness_gate_v0.toml"
+CLI = REPO_ROOT / CLI_RELPATH
+BINDING_MODULE = (
+    REPO_ROOT / "src" / "ops" / "okx_futures_shadow_offline_e2e_projection_binding_v0.py"
+)
+EVALUATED_AT = "2026-07-25T18:00:00Z"
+AS_OF = "2026-07-25T18:00:30Z"
+
+
+def _collect_required_relative_paths(cfg: dict) -> set[str]:
+    paths: set[str] = set()
+    for surface in cfg["historical_surfaces"]:
+        paths.add(str(surface["path"]).strip())
+    for component in cfg["mindestkontrakt_components"]:
+        for evidence_path in component.get("evidence_paths") or []:
+            paths.add(str(evidence_path).strip())
+    paths.add(str(cfg[CANONICAL_STEP_29U_SEMANTICS_REFERENCE_KEY]).strip())
+    return paths
+
+
+def _materialize_temp_repo(tmp_path: Path) -> tuple[Path, dict]:
+    cfg = load_shadow_preparation_readiness_gate_config_v0(CONFIG, repo_root=REPO_ROOT)
+    for relative in _collect_required_relative_paths(cfg):
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if not target.exists():
+            target.write_text(f"# stub:{relative}\n", encoding="utf-8")
+    config_dest = tmp_path / "config" / "ops" / "shadow_preparation_readiness_gate_v0.toml"
+    config_dest.parent.mkdir(parents=True, exist_ok=True)
+    config_dest.write_text(CONFIG.read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / "out" / "ops").mkdir(parents=True, exist_ok=True)
+    return tmp_path, cfg
+
+
+def _ready_like_evaluation(base):
+    inventory = tuple(
+        replace(record, preparation_status=PreparationStatusV0.PRESENT)
+        for record in base.mindestkontrakt_inventory
+    )
+    return replace(
+        base,
+        shadow_preparation_complete=True,
+        blockers=(),
+        unmet_gates=(),
+        mindestkontrakt_inventory=inventory,
+    )
+
+
+def _patch_ready_evaluate(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    real_evaluate = evaluate_shadow_preparation_readiness_gate_v0
+    calls = {"n": 0}
+
+    def _ready_evaluate(**kwargs):
+        calls["n"] += 1
+        return _ready_like_evaluation(real_evaluate(**kwargs))
+
+    monkeypatch.setattr(
+        "src.ops.okx_futures_shadow_offline_e2e_projection_binding_v0."
+        "evaluate_shadow_preparation_readiness_gate_v0",
+        _ready_evaluate,
+    )
+    return calls
+
+
+def _pass_cycle(**kwargs: Any) -> OkxFuturesShadowNoOrderCycleResultV0:
+    return run_okx_futures_shadow_no_order_cycle_v0(
+        mode=kwargs.get("mode", "shadow"),
+        instrument_id=kwargs.get("instrument_id", PRODUCTION_INSTRUMENT_ID),
+    )
+
+
+def test_package_marker_and_schema_identity() -> None:
+    assert PACKAGE_MARKER == "OKX_FUTURES_SHADOW_OFFLINE_E2E_PROJECTION_BINDING_V0=true"
+    assert PRODUCER_FAMILY == SCHEMA_ID
+    assert PRODUCER_FAMILY.endswith("_v0")
+    assert CLI.is_file()
+    assert BINDING_MODULE.is_file()
+
+
+def test_a_valid_hold_cycle_produces_verified_durable_projection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        instrument_id=PRODUCTION_INSTRUMENT_ID,
+    )
+    assert result.binding_status == BINDING_STATUS_PASS
+    assert result.readiness_result == READINESS_STATUS_READY
+    assert result.cycle_invoked is True
+    assert result.final_decision == EXPECTED_DECISION
+    assert result.risk_sizing_result == EXPECTED_RISK_SIZING
+    assert result.safety_result == EXPECTED_SAFETY
+    assert result.execution_projection_result == EXPECTED_EXECUTION_PROJECTION
+    assert result.reconciliation_result == EXPECTED_RECONCILIATION
+    assert result.venue == VENUE_OKX_EUROPE
+    assert result.instrument_class == "FUTURES"
+    assert result.btc_excluded is True
+    assert result.spot_excluded is True
+    assert result.futures_only is True
+    assert result.order_submission_count == 0
+    assert result.order_capable_client_instantiated is False
+    assert result.verification_verified is True
+    assert result.verification_result == "PASS"
+    assert result.projection_schema_id == PROJECTION_SCHEMA_ID
+    assert result.projection_sha256
+    assert (root / result.projection_path).is_file()
+    assert result.cycle_projection is not None
+    assert result.cycle_projection["decision_result"] == "hold"
+    assert result.network_access is False
+    assert result.background_process_left_running is False
+
+
+def test_b_readiness_blocked_prevents_cycle_invocation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    cycle_calls = {"n": 0}
+
+    def _cycle(**kwargs):
+        cycle_calls["n"] += 1
+        return _pass_cycle(**kwargs)
+
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        cycle_runner=_cycle,
+    )
+    assert result.binding_status == BINDING_STATUS_BLOCKED
+    assert result.readiness_result == READINESS_STATUS_BLOCKED
+    assert result.cycle_invoked is False
+    assert cycle_calls["n"] == 0
+    assert "READINESS_BLOCKED_CYCLE_NOT_INVOKED" in result.reason_codes
+    assert result.verification_verified is True
+
+
+def test_c_invalid_or_missing_cycle_result_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+
+    missing = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        cycle_runner=lambda **_kwargs: None,  # type: ignore[return-value, misc]
+    )
+    assert missing.binding_status == BINDING_STATUS_ERROR
+    assert "CYCLE_RESULT_MISSING" in missing.reason_codes
+    assert missing.binding_status != BINDING_STATUS_PASS
+
+    def _invalid(**_kwargs):
+        base = _pass_cycle()
+        return replace(base, decision_result="")
+
+    invalid = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        cycle_runner=_invalid,
+    )
+    assert invalid.binding_status == BINDING_STATUS_ERROR
+    assert any(code.startswith("CYCLE_RESULT_INVALID") for code in invalid.reason_codes)
+
+
+def test_d_non_okx_venue_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+
+    def _bad_venue(**_kwargs):
+        return replace(_pass_cycle(), venue="kraken")
+
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        cycle_runner=_bad_venue,
+    )
+    assert result.binding_status == BINDING_STATUS_ERROR
+    assert "CYCLE_VENUE_NOT_OKX" in result.reason_codes
+
+
+def test_e_spot_instrument_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+
+    def _spot(**_kwargs):
+        return replace(
+            _pass_cycle(),
+            market_classification="SPOT",
+            futures_only=False,
+            spot_excluded=False,
+        )
+
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        cycle_runner=_spot,
+    )
+    assert result.binding_status == BINDING_STATUS_ERROR
+    assert "CYCLE_SPOT_NOT_EXCLUDED" in result.reason_codes or (
+        "CYCLE_INSTRUMENT_CLASS_NOT_FUTURES" in result.reason_codes
+    )
+
+
+def test_f_btc_instrument_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+
+    def _btc(**_kwargs):
+        return replace(_pass_cycle(), btc_excluded=False)
+
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        cycle_runner=_btc,
+    )
+    assert result.binding_status == BINDING_STATUS_ERROR
+    assert "CYCLE_BTC_NOT_EXCLUDED" in result.reason_codes
+
+
+def test_g_nonzero_order_submission_count_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+
+    def _submitted(**_kwargs):
+        return replace(_pass_cycle(), real_order_submission=True)
+
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        cycle_runner=_submitted,
+    )
+    assert result.binding_status == BINDING_STATUS_ERROR
+    assert "CYCLE_ORDER_SUBMISSION_COUNT_NONZERO" in result.reason_codes
+
+
+def test_h_order_capable_client_instantiation_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+
+    def _client(**_kwargs):
+        return replace(_pass_cycle(), order_capable_client_instantiated=True)
+
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        cycle_runner=_client,
+    )
+    assert result.binding_status == BINDING_STATUS_ERROR
+    assert "CYCLE_ORDER_CAPABLE_CLIENT_INSTANTIATED" in result.reason_codes
+
+
+def test_i_safety_result_other_than_pass_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+
+    def _unsafe(**_kwargs):
+        return replace(_pass_cycle(), safety_result="BLOCK")
+
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        cycle_runner=_unsafe,
+    )
+    assert result.binding_status == BINDING_STATUS_ERROR
+    assert "CYCLE_SAFETY_NOT_PASS" in result.reason_codes
+
+
+def test_j_projection_writer_failure_returns_error_no_false_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+
+    def _fail_write(**_kwargs):
+        raise ShadowPreparationReadinessGateError("PROJECTION_TEMP_WRITE_FAILED:boom")
+
+    monkeypatch.setattr(
+        "src.ops.okx_futures_shadow_offline_e2e_projection_binding_v0."
+        "write_shadow_preparation_readiness_projection_v0",
+        _fail_write,
+    )
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+    )
+    assert result.binding_status == BINDING_STATUS_ERROR
+    assert result.binding_status != BINDING_STATUS_PASS
+    assert any(code.startswith("PROJECTION_WRITE_FAILED:") for code in result.reason_codes)
+    assert result.cycle_invoked is False
+
+
+def test_k_projection_reader_verifier_failure_returns_error_no_false_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+
+    def _fail_verify(**_kwargs):
+        raise OSError("verify boom")
+
+    monkeypatch.setattr(
+        "src.ops.okx_futures_shadow_offline_e2e_projection_binding_v0."
+        "verify_shadow_preparation_readiness_projection_v0",
+        _fail_verify,
+    )
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+    )
+    assert result.binding_status == BINDING_STATUS_ERROR
+    assert result.binding_status != BINDING_STATUS_PASS
+    assert any(code.startswith("PROJECTION_VERIFY_FAILED:") for code in result.reason_codes)
+
+
+def test_l_schema_or_digest_mismatch_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+    real_write = write_shadow_preparation_readiness_projection_v0
+
+    def _write_bad_schema(**kwargs):
+        meta = real_write(**kwargs)
+        dest = root / meta.output_path
+        payload = json.loads(dest.read_text(encoding="utf-8"))
+        payload["schema_id"] = "wrong.schema"
+        dest.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+        return meta
+
+    monkeypatch.setattr(
+        "src.ops.okx_futures_shadow_offline_e2e_projection_binding_v0."
+        "write_shadow_preparation_readiness_projection_v0",
+        _write_bad_schema,
+    )
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+    )
+    assert result.binding_status == BINDING_STATUS_ERROR
+    assert result.binding_status != BINDING_STATUS_PASS
+    assert result.reason_codes
+    assert any(
+        code in {"SCHEMA_MISMATCH", "DIGEST_MISMATCH"} or "SCHEMA" in code or "DIGEST" in code
+        for code in result.reason_codes
+    )
+
+
+def test_m_repeated_deterministic_invocation_no_competing_truth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    _patch_ready_evaluate(monkeypatch)
+    first = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        instrument_id=PRODUCTION_INSTRUMENT_ID,
+    )
+    second = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+        instrument_id=PRODUCTION_INSTRUMENT_ID,
+    )
+    assert first.binding_status == BINDING_STATUS_PASS
+    assert second.binding_status == BINDING_STATUS_PASS
+    assert first.schema_id == second.schema_id == SCHEMA_ID
+    assert first.projection_schema_id == second.projection_schema_id == PROJECTION_SCHEMA_ID
+    assert first.projection_path == second.projection_path
+    assert first.projection_sha256 == second.projection_sha256
+    assert first.cycle_projection == second.cycle_projection
+
+
+def test_n_no_network_and_no_background_after_cli(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, _cfg = _materialize_temp_repo(tmp_path)
+    real_evaluate = evaluate_shadow_preparation_readiness_gate_v0
+
+    def _ready_evaluate(**kwargs):
+        return _ready_like_evaluation(real_evaluate(**kwargs))
+
+    # CLI imports the binding module; patch at source used by subprocess is harder.
+    # Prove binding result flags + no socket usage in-process, then CLI blocked path.
+    monkeypatch.setattr(
+        "src.ops.okx_futures_shadow_offline_e2e_projection_binding_v0."
+        "evaluate_shadow_preparation_readiness_gate_v0",
+        _ready_evaluate,
+    )
+    opened: list[Any] = []
+    real_socket = socket.socket
+
+    class _GuardSocket(real_socket):
+        def __init__(self, *args, **kwargs):
+            opened.append(True)
+            raise AssertionError("network socket opened")
+
+    monkeypatch.setattr(socket, "socket", _GuardSocket)
+    result = run_okx_futures_shadow_offline_e2e_projection_binding_v0(
+        repo_root=root,
+        output_path=DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+        evaluated_at=EVALUATED_AT,
+        as_of=AS_OF,
+        mode="shadow",
+    )
+    assert result.binding_status == BINDING_STATUS_PASS
+    assert result.network_access is False
+    assert result.background_process_left_running is False
+    assert opened == []
+
+    # Natural blocked CLI path (no monkeypatch in child): exit 2, no hang.
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "--repo-root",
+            str(root),
+            "--mode",
+            "shadow",
+            "--output-path",
+            DEFAULT_PROJECTION_OUTPUT_RELATIVE_PATH,
+            "--evaluated-at",
+            EVALUATED_AT,
+            "--as-of",
+            AS_OF,
+            "--json",
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+    assert proc.returncode == 2
+    payload = json.loads(proc.stdout)
+    assert payload["binding_status"] == BINDING_STATUS_BLOCKED
+    assert payload["cycle_invoked"] is False
+    assert payload["network_access"] is False
+    assert payload["background_process_left_running"] is False


### PR DESCRIPTION
## Summary
- Bind the canonical OKX Futures Shadow no-order cycle entrypoint to the existing Shadow Preparation Readiness offline projection pipeline.
- One offline invocation: readiness → (READY only) HOLD cycle → durable readiness projection write → reader/verifier.
- Reuses existing gate/writer/verifier and cycle owners; fail-closed for venue/spot/BTC/orders/safety/writer/verifier mismatches.

## Test plan
- [x] `pytest tests/ops/test_okx_futures_shadow_offline_e2e_projection_binding_v0.py` (15 focused cases A–N)
- [x] `ruff format --check` / `ruff check` on changed files
- [x] Selector `PR_BOUNDED_FULL` probe targets green (~47s)
- [ ] CI confirmation only (no manual reruns)


Made with [Cursor](https://cursor.com)