### PR TITLE
ops: invoke offline OKX Shadow no-order cycle despite activation BLOCKED

### DIFF
--- a/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
+++ b/docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md
@@ -142,6 +142,12 @@ executing the complete offline OKX Futures Shadow preparation chain:
 readiness gate → durable projection writer → projection verifier →
 OKX Futures no-order HOLD cycle → e2e binding result.
 
+Activation readiness may remain `BLOCKED` with `CANONICAL_STEP_29U_ABSENT`
+(and related activation gaps). That activation classification remains truthful
+and non-authorizing; it does **not** veto the offline no-order HOLD cycle when
+the offline Shadow-preparation path remains permitted. The binding must not
+require activation `READY` before invoking the offline cycle.
+
 Related readiness-path component owners (offline projection pipeline,
 readiness-only operator entrypoint, readiness bundle) remain valid for the
 readiness projection subpath and do **not** introduce a second readiness,

--- a/src/ops/okx_futures_shadow_offline_e2e_projection_binding_v0.py
+++ b/src/ops/okx_futures_shadow_offline_e2e_projection_binding_v0.py
@@ -1,11 +1,14 @@
 """OKX Futures Shadow offline end-to-end projection binding v0.
 
 Composition-only boundary:
-  readiness gate → (if offline path permitted and READY) canonical no-order cycle →
-  durable readiness projection write → reader/verifier.
+  readiness gate → durable readiness projection write → reader/verifier →
+  (if offline preparation path permitted) canonical no-order cycle.
 
-Reuses existing canonical owners only. No second decision/risk/safety/execution/
-reconciliation/readiness/writer/reader/projection truth. Offline, non-activating.
+Activation readiness may remain BLOCKED (including CANONICAL_STEP_29U_ABSENT);
+that activation gap does not veto the offline no-order preparation cycle when
+the offline path remains permitted. Reuses existing canonical owners only. No
+second decision/risk/safety/execution/reconciliation/readiness/writer/reader/
+projection truth. Offline, non-activating.
 """
 
 from __future__ import annotations
@@ -445,37 +448,9 @@ def run_okx_futures_shadow_offline_e2e_projection_binding_v0(
             verification_verified=verification.verified,
         )
 
-    if readiness_status == READINESS_STATUS_BLOCKED:
-        return OkxFuturesShadowOfflineE2EProjectionBindingResultV0(
-            binding_status=BINDING_STATUS_BLOCKED,
-            schema_id=SCHEMA_ID,
-            schema_version=SCHEMA_VERSION,
-            generated_at=generated_at,
-            readiness_result=READINESS_STATUS_BLOCKED,
-            final_decision=None,
-            risk_sizing_result=None,
-            safety_result=None,
-            execution_projection_result=None,
-            reconciliation_result=None,
-            venue=None,
-            instrument_class=None,
-            btc_excluded=None,
-            spot_excluded=None,
-            futures_only=None,
-            order_submission_count=0,
-            order_capable_client_instantiated=False,
-            cycle_invoked=False,
-            projection_path=write_meta.output_path,
-            projection_schema_id=write_meta.schema_id,
-            projection_schema_version=write_meta.schema_version,
-            projection_sha256=write_meta.sha256,
-            verification_status=verification.overall_status,
-            verification_verified=verification.verified,
-            verification_result="PASS",
-            reason_codes=("READINESS_BLOCKED_CYCLE_NOT_INVOKED",),
-            cycle_projection=None,
-        )
-
+    # Activation readiness READY is not required for the offline no-order cycle.
+    # Gate blockers such as CANONICAL_STEP_29U_ABSENT remain activation truth and
+    # must not invent a second readiness truth or authorize Shadow activation.
     selected = (
         PRODUCTION_INSTRUMENT_ID
         if instrument_id is None or str(instrument_id).strip() == ""
@@ -533,7 +508,7 @@ def run_okx_futures_shadow_offline_e2e_projection_binding_v0(
         schema_id=SCHEMA_ID,
         schema_version=SCHEMA_VERSION,
         generated_at=generated_at,
-        readiness_result=READINESS_STATUS_READY,
+        readiness_result=readiness_status,
         final_decision=cycle.decision_result,
         risk_sizing_result=cycle.risk_sizing_result,
         safety_result=cycle.safety_result,

--- a/tests/ops/test_okx_futures_shadow_offline_e2e_projection_binding_v0.py
+++ b/tests/ops/test_okx_futures_shadow_offline_e2e_projection_binding_v0.py
@@ -167,9 +167,10 @@ def test_a_valid_hold_cycle_produces_verified_durable_projection(
     assert result.background_process_left_running is False
 
 
-def test_b_readiness_blocked_prevents_cycle_invocation(
+def test_b_activation_readiness_blocked_still_invokes_offline_no_order_cycle(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Canonical gate stays activation-BLOCKED; offline cycle must still run."""
     root, _cfg = _materialize_temp_repo(tmp_path)
     cycle_calls = {"n": 0}
 
@@ -185,12 +186,27 @@ def test_b_readiness_blocked_prevents_cycle_invocation(
         mode="shadow",
         cycle_runner=_cycle,
     )
-    assert result.binding_status == BINDING_STATUS_BLOCKED
+    assert result.binding_status == BINDING_STATUS_PASS
     assert result.readiness_result == READINESS_STATUS_BLOCKED
-    assert result.cycle_invoked is False
-    assert cycle_calls["n"] == 0
-    assert "READINESS_BLOCKED_CYCLE_NOT_INVOKED" in result.reason_codes
+    assert result.cycle_invoked is True
+    assert cycle_calls["n"] == 1
+    assert result.final_decision == EXPECTED_DECISION
+    assert result.risk_sizing_result == EXPECTED_RISK_SIZING
+    assert result.safety_result == EXPECTED_SAFETY
+    assert result.execution_projection_result == EXPECTED_EXECUTION_PROJECTION
+    assert result.reconciliation_result == EXPECTED_RECONCILIATION
+    assert result.btc_excluded is True
+    assert result.spot_excluded is True
+    assert result.futures_only is True
+    assert result.order_submission_count == 0
+    assert "READINESS_BLOCKED_CYCLE_NOT_INVOKED" not in result.reason_codes
     assert result.verification_verified is True
+    # Activation truth remains in the durable projection (not invented away).
+    projection = json.loads((root / result.projection_path).read_text(encoding="utf-8"))
+    assert "CANONICAL_STEP_29U_ABSENT" in projection["blockers"]
+    assert projection["shadow_preparation_complete"] is False
+    assert projection["step_29u_implemented"] is False
+    assert projection["activation_authority"] is False
 
 
 def test_c_invalid_or_missing_cycle_result_fails_closed(
@@ -510,7 +526,8 @@ def test_n_no_network_and_no_background_after_cli(
     assert result.background_process_left_running is False
     assert opened == []
 
-    # Natural blocked CLI path (no monkeypatch in child): exit 2, no hang.
+    # Natural CLI path (no monkeypatch in child): activation readiness stays
+    # BLOCKED, but offline no-order cycle is invoked; exit 0, no hang.
     proc = subprocess.run(
         [
             sys.executable,
@@ -533,9 +550,13 @@ def test_n_no_network_and_no_background_after_cli(
         check=False,
         timeout=60,
     )
-    assert proc.returncode == 2
+    assert proc.returncode == 0
     payload = json.loads(proc.stdout)
-    assert payload["binding_status"] == BINDING_STATUS_BLOCKED
-    assert payload["cycle_invoked"] is False
+    assert payload["binding_status"] == BINDING_STATUS_PASS
+    assert payload["readiness_result"] == READINESS_STATUS_BLOCKED
+    assert payload["cycle_invoked"] is True
+    assert payload["final_decision"] == EXPECTED_DECISION
+    assert payload["order_submission_count"] == 0
     assert payload["network_access"] is False
     assert payload["background_process_left_running"] is False
+    assert payload["activation_authority"] is False


### PR DESCRIPTION
## Summary
- Forensic fix for the sole canonical offline OKX Futures Shadow command failing every invocation with `BINDING_BLOCKED` / `READINESS_BLOCKED_CYCLE_NOT_INVOKED` while readiness projection listed `CANONICAL_STEP_29U_ABSENT`.
- Root cause: activation readiness (intentionally BLOCKED while STEP 29U remains unbound) was incorrectly used as a veto on the documented offline no-order preparation cycle.
- Minimal repair in the e2e binding owner: after gate → write → verify, invoke the canonical offline no-order cycle whenever the offline preparation path remains permitted; preserve activation truth (`READINESS_RESULT=BLOCKED`, projection still lists `CANONICAL_STEP_29U_ABSENT`, `activation_authority=false`).

## Test plan
- [x] `pytest -q tests/ops/test_okx_futures_shadow_offline_e2e_projection_binding_v0.py` (15 passed)
- [x] One canonical invocation: `python scripts/ops/run_okx_futures_shadow_offline_e2e_projection_binding_v0.py --mode shadow` → `BINDING_PASS`, `CYCLE_INVOKED=true`, Decision/Risk/Execution/Reconciliation observed, no orders/activation
- [x] PR-bounded selector suite (728 passed)


Made with [Cursor](https://cursor.com)