### PR TITLE
ops: add Step-29U activation eligibility inventory v0

### DIFF
--- a/docs/ops/EVIDENCE_INDEX.md
+++ b/docs/ops/EVIDENCE_INDEX.md
@@ -1,5 +1,17 @@
 # Peak_Trade – Evidence Index (v0.15)
 
+<a id="ev-20260726-step-29u-activation-eligibility-inventory"></a>
+- **EV-20260726-STEP-29U-ACTIVATION-ELIGIBILITY-INVENTORY** | Date: 2026-07-26 | Owner: ops | Scope: offline non-activating inventory capability | Risk: LOW
+  - Source: [Eligibility inventory contract](runbooks/STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0.md) · Owner: `ops.step_29u_activation_eligibility_inventory_v0` · Command: `python scripts/ops/run_step_29u_activation_eligibility_inventory_v0.py`
+  - Claim: Machine-readable fail-closed inventory of Step-29U activation
+    prerequisites; evaluator health `STATUS=PASS` with
+    `ACTIVATION_ELIGIBLE=false` and `STEP_29U_ACTIVATED=false` on current
+    canonical sources (binding + post-merge soak recognized; audit/economic/
+    future Operator-GO remain blockers).
+  - Non-claims: not Activation; not Activation Binding; not Activation Readiness
+    approval; does not authorize Runtime/Scheduler/Network/Orders/Paper/Testnet/Live;
+    implementation authorization is not future activation Operator-GO.
+
 <a id="ev-20260726-step-29u-post-merge-shadow-soak"></a>
 - **EV-20260726-STEP-29U-POST-MERGE-SHADOW-SOAK** | Date: 2026-07-26 | Owner: ops | Scope: docs/evidence capability closeout | Risk: LOW
   - Source: [Durable soak bundle](../../evidence/ops/step_29u_post_merge_shadow_soak/20260725T222915Z/) · Contract: [STEP_29U_CANONICAL_BINDING_AND_IMPLEMENTATION_INVENTORY_V0.md](runbooks/STEP_29U_CANONICAL_BINDING_AND_IMPLEMENTATION_INVENTORY_V0.md) · Merge: `cd6d465c83c6c65733e5d85238aa223d4bffd548` (PR **#5550**)

--- a/docs/ops/roadmap/CURRENT_FOCUS.md
+++ b/docs/ops/roadmap/CURRENT_FOCUS.md
@@ -35,7 +35,17 @@ This is **not** produced by Workflow Officer or Update Officer; officers aggrega
 
 - `STEP_29U_ACTIVATED=false`, `CANONICAL_STEP_29U_ACTIVATION_BOUND=false`
 - Runtime = `BOUND_NOT_ACTIVATED`; no Scheduler/Paper/Testnet/Live/network GO
-- Next: `STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_ONLY_AFTER_SEPARATE_OPERATOR_GO`
+
+**Eligibility inventory (implemented, non-activating):**
+
+- Owner: `ops.step_29u_activation_eligibility_inventory_v0`
+- Contract: [STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0.md](../runbooks/STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0.md)
+- Command: `python scripts/ops/run_step_29u_activation_eligibility_inventory_v0.py`
+- Canonical result remains `ACTIVATION_ELIGIBLE=false` (inventory only — not Activation)
+- Current blockers include: audit provenance absent, economic validity not proven,
+  explicit future Operator-GO absent
+- Next action: separate operator review/merge only; Activation remains forbidden
+  without a new explicit Operator-GO
 
 ---
 

--- a/docs/ops/runbooks/STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0.md
+++ b/docs/ops/runbooks/STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0.md
@@ -1,0 +1,113 @@
+# STEP 29U Activation Eligibility Inventory v0
+
+```text
+status: DRAFT
+capability: STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0
+owner: ops.step_29u_activation_eligibility_inventory_v0
+authority_effect: NONE
+```
+
+> **Inventory only — not Activation.**  
+> This contract inventories fail-closed prerequisites for any *future*,
+> separately authorized Step-29U activation consideration. It does **not**
+> activate, arm, schedule, connect, submit, promote, or mutate runtime state.
+> It is **not** Activation Binding and **not** Activation Readiness approval.
+
+## Machine tokens
+
+```text
+STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0=true
+CAPABILITY_TYPE=OFFLINE_NON_ACTIVATING_FAIL_CLOSED_INVENTORY
+ACTIVATION_ELIGIBLE=false
+STEP_29U_ACTIVATED=false
+RUNTIME_ACTIVATED=false
+SCHEDULER_ACTIVATED=false
+NETWORK_USED=false
+ORDERS_CREATED=false
+ORDERS_SUBMITTED=false
+OPERATOR_GO_PRESENT=false
+IMPLEMENTATION_AUTHORIZATION_IS_NOT_ACTIVATION_GO=true
+```
+
+## Owner surfaces
+
+| Surface | Path |
+|---|---|
+| Evaluator | `src/ops/step_29u_activation_eligibility_inventory_v0.py` |
+| CLI | `scripts/ops/run_step_29u_activation_eligibility_inventory_v0.py` |
+| Tests | `tests/ops/test_step_29u_activation_eligibility_inventory_v0.py` |
+| Binding inventory SSOT | `docs/ops/runbooks/STEP_29U_CANONICAL_BINDING_AND_IMPLEMENTATION_INVENTORY_V0.md` |
+
+## Operator command
+
+```bash
+python scripts/ops/run_step_29u_activation_eligibility_inventory_v0.py
+python scripts/ops/run_step_29u_activation_eligibility_inventory_v0.py --json --output-path PATH
+```
+
+Expected current canonical result:
+
+```text
+STATUS=PASS
+EVALUATOR_VALID=true
+ACTIVATION_ELIGIBLE=false
+STEP_29U_ACTIVATED=false
+```
+
+Exit code `0` means evaluator health PASS. It does **not** mean activation
+eligible.
+
+## Semantic boundary
+
+May answer only:
+
+- which formal prerequisite IDs exist;
+- which canonical source owns each;
+- SATISFIED / UNSATISFIED / ABSENT / INVALID;
+- evidence/provenance and blockers;
+- whether activation eligibility is established (currently always false while
+  mandatory blockers remain, including absent future Operator-GO).
+
+Must not answer whether/when activation should occur, capital allocation,
+Runtime/Scheduler/Network/Orders enablement, or whether an operator should
+grant later authorization.
+
+## Prerequisite IDs
+
+1. `STEP_29U_BINDING_PROVEN`
+2. `STEP_29U_POST_MERGE_SOAK_PROVEN`
+3. `STEP_29U_AUDIT_PROVENANCE_COMPLETE`
+4. `RUNTIME_BRIDGE_BOUND`
+5. `RUNTIME_REMAINS_NOT_ACTIVATED`
+6. `SCHEDULER_REMAINS_LOCKED`
+7. `NETWORK_REMAINS_PROHIBITED`
+8. `ORDERS_REMAIN_PROHIBITED`
+9. `ECONOMIC_VALIDITY_PROVEN`
+10. `SAFETY_AUTHORITY_VALID`
+11. `RECONCILIATION_PRECONDITIONS_PROVEN`
+12. `ACTIVATION_AUTHORITY_CONTRACT_PRESENT`
+13. `EXPLICIT_FUTURE_OPERATOR_GO_PRESENT`
+14. `BTC_EXCLUDED`
+15. `SPOT_EXCLUDED`
+16. `KRAKEN_LEGACY_EXCLUDED`
+
+## Fail-closed rules
+
+- Unknown / missing / malformed sources → ABSENT or INVALID, never satisfied.
+- Digest mismatch / wrong soak head → INVALID.
+- Runtime/Scheduler/Network/Orders true in soak input → INVALID.
+- BTC/Spot/Kraken-legacy observed → INVALID for exclusion prerequisites.
+- This implementation GO must not be inferred as future activation GO.
+- `activation_eligible` cannot be true while blockers exist.
+- `step_29u_activated` always remains false in this capability.
+
+## Explicit non-claims
+
+```text
+NOT_ACTIVATION=true
+NOT_ACTIVATION_BINDING=true
+NOT_ACTIVATION_READINESS_APPROVAL=true
+DOES_NOT_AUTHORIZE_LATER_ACTION=true
+NEXT_ACTION=SEPARATE_OPERATOR_REVIEW_AND_MERGE_ONLY
+ACTIVATION_REMAINS_FORBIDDEN_WITHOUT_NEW_EXPLICIT_OPERATOR_GO=true
+```

--- a/docs/ops/runbooks/STEP_29U_CANONICAL_BINDING_AND_IMPLEMENTATION_INVENTORY_V0.md
+++ b/docs/ops/runbooks/STEP_29U_CANONICAL_BINDING_AND_IMPLEMENTATION_INVENTORY_V0.md
@@ -351,9 +351,20 @@ Composition root chain:
 
 ```text
 IMPLEMENTED_BINDING=STEP_29U_CANONICAL_SHADOW_BINDING_V0
-NEXT_AUTHORIZED_SLICE=STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_ONLY_AFTER_SEPARATE_OPERATOR_GO
+IMPLEMENTED_ELIGIBILITY_INVENTORY=STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0
+ELIGIBILITY_INVENTORY_OWNER=ops.step_29u_activation_eligibility_inventory_v0
+ELIGIBILITY_INVENTORY_COMMAND=python scripts/ops/run_step_29u_activation_eligibility_inventory_v0.py
+ELIGIBILITY_INVENTORY_CONTRACT=docs/ops/runbooks/STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0.md
+ACTIVATION_ELIGIBLE=false
+STEP_29U_ACTIVATED=false
 SEPARATE_OPERATOR_GO_REQUIRED=true
+NEXT_AUTHORIZED_SLICE=SEPARATE_OPERATOR_REVIEW_ONLY_NO_ACTIVATION
 ```
+
+The eligibility inventory is **offline / non-activating**. It records blockers
+(including absent future Operator-GO, economic validity not proven, and missing
+STEP 29U audit contract) and must not be read as Activation, Activation Binding,
+or Activation Readiness approval.
 
 Activation, Scheduler, network Runtime, Paper/Testnet/Live remain unauthorized.
 

--- a/scripts/ops/run_step_29u_activation_eligibility_inventory_v0.py
+++ b/scripts/ops/run_step_29u_activation_eligibility_inventory_v0.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Operator CLI: STEP 29U Activation Eligibility Inventory v0.
+
+Offline, read-only, non-activating. Distinguishes evaluator health (exit code)
+from eligibility result (ACTIVATION_ELIGIBLE field; expected false).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from src.ops.step_29u_activation_eligibility_inventory_v0 import (  # noqa: E402
+    EligibilityInventoryOverridesV0,
+    Step29UActivationEligibilityInventoryError,
+    evaluate_step_29u_activation_eligibility_inventory_v0,
+    result_to_machine_lines,
+    serialize_result_json_v0,
+)
+
+EXIT_PASS = 0
+EXIT_ERROR = 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Evaluate STEP 29U activation eligibility inventory (offline, "
+            "fail-closed, non-activating). Inventory only — not Activation."
+        )
+    )
+    p.add_argument("--repo-root", type=Path, default=_REPO_ROOT)
+    p.add_argument(
+        "--soak-dir",
+        type=Path,
+        default=None,
+        help="Optional override path to soak evidence directory (read-only).",
+    )
+    p.add_argument(
+        "--binding-evidence-dir",
+        type=Path,
+        default=None,
+        help="Optional override path to Step 29U binding evidence (read-only).",
+    )
+    p.add_argument(
+        "--readiness-config",
+        type=Path,
+        default=None,
+        help="Optional override path to readiness gate TOML (read-only).",
+    )
+    p.add_argument(
+        "--output-path",
+        type=Path,
+        default=None,
+        help="Optional path to write deterministic JSON artifact.",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Print full JSON to stdout (default: machine lines).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    try:
+        result = evaluate_step_29u_activation_eligibility_inventory_v0(
+            repo_root=repo_root,
+            overrides=EligibilityInventoryOverridesV0(
+                soak_dir=args.soak_dir,
+                binding_evidence_dir=args.binding_evidence_dir,
+                readiness_config_path=args.readiness_config,
+            ),
+        )
+    except Step29UActivationEligibilityInventoryError as exc:
+        print(f"STATUS=ERROR", file=sys.stderr)
+        print(f"EVALUATOR_VALID=false", file=sys.stderr)
+        print(f"ERROR={exc}", file=sys.stderr)
+        return EXIT_ERROR
+    except Exception as exc:  # noqa: BLE001
+        print(f"STATUS=ERROR", file=sys.stderr)
+        print(f"EVALUATOR_VALID=false", file=sys.stderr)
+        print(f"ERROR={type(exc).__name__}:{exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if args.output_path is not None:
+        out = args.output_path.resolve()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(serialize_result_json_v0(result), encoding="utf-8")
+
+    if args.json:
+        sys.stdout.write(serialize_result_json_v0(result))
+    else:
+        for line in result_to_machine_lines(result):
+            print(line)
+
+    # Nonzero only for evaluator/input failure — not for ACTIVATION_ELIGIBLE=false.
+    return EXIT_PASS if result.evaluator_valid and result.status == "PASS" else EXIT_ERROR
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ops/step_29u_activation_eligibility_inventory_v0.py
+++ b/src/ops/step_29u_activation_eligibility_inventory_v0.py
@@ -1,0 +1,1255 @@
+"""STEP 29U Activation Eligibility Inventory v0.
+
+Offline, non-activating, fail-closed inventory of prerequisites that would
+have to be satisfied before any future, separately authorized Step-29U
+activation could even be considered.
+
+This capability is not Activation, not Activation Binding, and not Activation
+Readiness approval. It never arms, schedules, connects, submits, promotes, or
+mutates runtime state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+from src.ops.shadow_preparation_readiness_gate_v0 import (
+    RUNTIME_BRIDGE_STATE_BOUND_NOT_ACTIVATED,
+    load_shadow_preparation_readiness_gate_config_v0,
+)
+from src.ops.step_29u_canonical_shadow_binding_v0 import (
+    BINDING_OWNER,
+    observe_canonical_step_29u_bound_v0,
+    verify_canonical_step_29u_binding_evidence_v0,
+)
+
+PACKAGE_MARKER = "STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0=true"
+PRODUCER_FAMILY = "ops.step_29u_activation_eligibility_inventory_v0"
+SCHEMA_ID = PRODUCER_FAMILY
+SCHEMA_VERSION = "v0"
+CAPABILITY_ID = "STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0"
+CLI_RELPATH = "scripts/ops/run_step_29u_activation_eligibility_inventory_v0.py"
+
+INVENTORY_RUNBOOK = "docs/ops/runbooks/STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0.md"
+BINDING_INVENTORY_RUNBOOK = (
+    "docs/ops/runbooks/STEP_29U_CANONICAL_BINDING_AND_IMPLEMENTATION_INVENTORY_V0.md"
+)
+READINESS_CONFIG_RELPATH = "config/ops/shadow_preparation_readiness_gate_v0.toml"
+CANONICAL_SOAK_RELPATH = "evidence/ops/step_29u_post_merge_shadow_soak/20260725T222915Z"
+EXPECTED_SOAK_TESTED_HEAD_SHA = "cd6d465c83c6c65733e5d85238aa223d4bffd548"
+
+STATE_SATISFIED = "SATISFIED"
+STATE_UNSATISFIED = "UNSATISFIED"
+STATE_ABSENT = "ABSENT"
+STATE_INVALID = "INVALID"
+VALID_STATES = frozenset({STATE_SATISFIED, STATE_UNSATISFIED, STATE_ABSENT, STATE_INVALID})
+
+PREREQUISITE_IDS: tuple[str, ...] = (
+    "STEP_29U_BINDING_PROVEN",
+    "STEP_29U_POST_MERGE_SOAK_PROVEN",
+    "STEP_29U_AUDIT_PROVENANCE_COMPLETE",
+    "RUNTIME_BRIDGE_BOUND",
+    "RUNTIME_REMAINS_NOT_ACTIVATED",
+    "SCHEDULER_REMAINS_LOCKED",
+    "NETWORK_REMAINS_PROHIBITED",
+    "ORDERS_REMAIN_PROHIBITED",
+    "ECONOMIC_VALIDITY_PROVEN",
+    "SAFETY_AUTHORITY_VALID",
+    "RECONCILIATION_PRECONDITIONS_PROVEN",
+    "ACTIVATION_AUTHORITY_CONTRACT_PRESENT",
+    "EXPLICIT_FUTURE_OPERATOR_GO_PRESENT",
+    "BTC_EXCLUDED",
+    "SPOT_EXCLUDED",
+    "KRAKEN_LEGACY_EXCLUDED",
+)
+
+FORBIDDEN_IMPORT_SURFACES = frozenset(
+    {
+        "src.orders.shadow",
+        "scripts.run_shadow_execution",
+        "src.live.shadow_session",
+        "scripts.run_shadow_paper_session",
+        "src.webui",
+    }
+)
+
+
+class Step29UActivationEligibilityInventoryError(ValueError):
+    """Fail-closed inventory execution error (evaluator health, not eligibility)."""
+
+
+@dataclass(frozen=True)
+class PrerequisiteRecordV0:
+    prerequisite_id: str
+    description: str
+    canonical_owner: str
+    source_reference: str
+    state: str
+    reason_code: str
+    evidence_reference: str
+    evidence_digest: Optional[str]
+    observed_value: str
+    expected_condition: str
+    evaluated_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "prerequisite_id": self.prerequisite_id,
+            "description": self.description,
+            "canonical_owner": self.canonical_owner,
+            "source_reference": self.source_reference,
+            "state": self.state,
+            "reason_code": self.reason_code,
+            "evidence_reference": self.evidence_reference,
+            "evidence_digest": self.evidence_digest,
+            "observed_value": self.observed_value,
+            "expected_condition": self.expected_condition,
+            "evaluated_at": self.evaluated_at,
+        }
+
+
+@dataclass(frozen=True)
+class ActivationEligibilityInventoryResultV0:
+    schema_id: str
+    schema_version: str
+    generated_at: str
+    evaluated_main_sha: str
+    capability_id: str
+    evaluator_valid: bool
+    status: str
+    activation_eligible: bool
+    step_29u_activated: bool
+    runtime_activated: bool
+    scheduler_activated: bool
+    network_used: bool
+    orders_created: bool
+    orders_submitted: bool
+    operator_go_present: bool
+    btc_excluded: bool
+    spot_excluded: bool
+    kraken_legacy_excluded: bool
+    prerequisites: tuple[PrerequisiteRecordV0, ...]
+    blockers: tuple[str, ...]
+    summary: Mapping[str, int]
+    provenance: Mapping[str, Any]
+    safety_facts: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_id": self.schema_id,
+            "schema_version": self.schema_version,
+            "generated_at": self.generated_at,
+            "evaluated_main_sha": self.evaluated_main_sha,
+            "capability_id": self.capability_id,
+            "evaluator_valid": self.evaluator_valid,
+            "status": self.status,
+            "activation_eligible": self.activation_eligible,
+            "step_29u_activated": self.step_29u_activated,
+            "runtime_activated": self.runtime_activated,
+            "scheduler_activated": self.scheduler_activated,
+            "network_used": self.network_used,
+            "orders_created": self.orders_created,
+            "orders_submitted": self.orders_submitted,
+            "operator_go_present": self.operator_go_present,
+            "btc_excluded": self.btc_excluded,
+            "spot_excluded": self.spot_excluded,
+            "kraken_legacy_excluded": self.kraken_legacy_excluded,
+            "prerequisites": [p.to_dict() for p in self.prerequisites],
+            "blockers": list(self.blockers),
+            "summary": dict(self.summary),
+            "provenance": dict(self.provenance),
+            "safety_facts": dict(self.safety_facts),
+        }
+
+
+@dataclass(frozen=True)
+class EligibilityInventoryOverridesV0:
+    """Test-only / explicit path overrides. Never authorizes activation."""
+
+    soak_dir: Optional[Path] = None
+    binding_evidence_dir: Optional[Path] = None
+    readiness_config_path: Optional[Path] = None
+    soak_summary_overlay: Optional[Mapping[str, Any]] = None
+    force_unknown_prerequisite: bool = False
+    evaluated_main_sha: Optional[str] = None
+
+
+def default_repo_root_v0() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _git_sha(repo_root: Path) -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "UNKNOWN"
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _read_manifest(manifest_path: Path) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for line in manifest_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            raise Step29UActivationEligibilityInventoryError(
+                f"MANIFEST_LINE_INVALID:{manifest_path}"
+            )
+        digest, rel = parts
+        mapping[rel.strip()] = digest.strip().lower()
+    return mapping
+
+
+def _verify_manifest(dir_path: Path, manifest_path: Path) -> tuple[bool, str, Optional[str]]:
+    if not manifest_path.is_file():
+        return False, "MANIFEST_MISSING", None
+    try:
+        expected = _read_manifest(manifest_path)
+    except (OSError, UnicodeError, Step29UActivationEligibilityInventoryError):
+        return False, "MANIFEST_MALFORMED", None
+    if not expected:
+        return False, "MANIFEST_EMPTY", None
+    for rel, digest in sorted(expected.items()):
+        target = dir_path / rel
+        if not target.is_file():
+            return False, f"MANIFEST_FILE_MISSING:{rel}", None
+        actual = _sha256_file(target)
+        if actual.lower() != digest.lower():
+            return False, f"DIGEST_MISMATCH:{rel}", actual
+    return True, "MANIFEST_OK", _sha256_file(manifest_path)
+
+
+def _record(
+    *,
+    prerequisite_id: str,
+    description: str,
+    canonical_owner: str,
+    source_reference: str,
+    state: str,
+    reason_code: str,
+    evidence_reference: str,
+    evidence_digest: Optional[str],
+    observed_value: str,
+    expected_condition: str,
+    evaluated_at: str,
+) -> PrerequisiteRecordV0:
+    if state not in VALID_STATES:
+        raise Step29UActivationEligibilityInventoryError(f"INVALID_STATE:{state}")
+    if prerequisite_id not in PREREQUISITE_IDS:
+        raise Step29UActivationEligibilityInventoryError(f"UNKNOWN_PREREQUISITE:{prerequisite_id}")
+    return PrerequisiteRecordV0(
+        prerequisite_id=prerequisite_id,
+        description=description,
+        canonical_owner=canonical_owner,
+        source_reference=source_reference,
+        state=state,
+        reason_code=reason_code,
+        evidence_reference=evidence_reference,
+        evidence_digest=evidence_digest,
+        observed_value=observed_value,
+        expected_condition=expected_condition,
+        evaluated_at=evaluated_at,
+    )
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise Step29UActivationEligibilityInventoryError(f"JSON_MALFORMED:{path}:{exc}") from exc
+    except OSError as exc:
+        raise Step29UActivationEligibilityInventoryError(f"JSON_UNREADABLE:{path}:{exc}") from exc
+
+
+def _boolish(value: Any) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def evaluate_step_29u_activation_eligibility_inventory_v0(
+    *,
+    repo_root: Path | None = None,
+    overrides: EligibilityInventoryOverridesV0 | None = None,
+) -> ActivationEligibilityInventoryResultV0:
+    """Evaluate canonical eligibility inventory. Always non-activating."""
+    root = (repo_root or default_repo_root_v0()).resolve()
+    ov = overrides or EligibilityInventoryOverridesV0()
+    evaluated_at = _utc_now()
+    evaluated_sha = ov.evaluated_main_sha or _git_sha(root)
+
+    if ov.force_unknown_prerequisite:
+        raise Step29UActivationEligibilityInventoryError(
+            "UNKNOWN_PREREQUISITE:NOT_A_CANONICAL_PREREQUISITE_ID"
+        )
+
+    soak_dir = (
+        ov.soak_dir.resolve()
+        if ov.soak_dir is not None
+        else (root / CANONICAL_SOAK_RELPATH).resolve()
+    )
+    readiness_path = (
+        ov.readiness_config_path.resolve()
+        if ov.readiness_config_path is not None
+        else (root / READINESS_CONFIG_RELPATH).resolve()
+    )
+
+    records: list[PrerequisiteRecordV0] = []
+    blockers: list[str] = []
+
+    # --- Binding ---
+    binding_ok, binding_reasons, _binding_payload = verify_canonical_step_29u_binding_evidence_v0(
+        repo_root=root,
+        evidence_dir=ov.binding_evidence_dir,
+    )
+    bound_obs, bound_obs_reasons = observe_canonical_step_29u_bound_v0(
+        repo_root=root,
+        evidence_dir=ov.binding_evidence_dir,
+    )
+    if binding_ok and bound_obs:
+        records.append(
+            _record(
+                prerequisite_id="STEP_29U_BINDING_PROVEN",
+                description="Canonical Step 29U Shadow no-order binding evidence verified",
+                canonical_owner=BINDING_OWNER,
+                source_reference="src/ops/step_29u_canonical_shadow_binding_v0.py",
+                state=STATE_SATISFIED,
+                reason_code="BINDING_EVIDENCE_VERIFIED",
+                evidence_reference="evidence/ops/step_29u_offline_capability/2026-07-25_capability_hold_cycle",
+                evidence_digest=None,
+                observed_value="bound=true verified=true",
+                expected_condition="canonical binding evidence verifies and observe_bound=true",
+                evaluated_at=evaluated_at,
+            )
+        )
+    elif not (root / "src/ops/step_29u_canonical_shadow_binding_v0.py").is_file():
+        records.append(
+            _record(
+                prerequisite_id="STEP_29U_BINDING_PROVEN",
+                description="Canonical Step 29U Shadow no-order binding evidence verified",
+                canonical_owner=BINDING_OWNER,
+                source_reference="src/ops/step_29u_canonical_shadow_binding_v0.py",
+                state=STATE_ABSENT,
+                reason_code="BINDING_OWNER_ABSENT",
+                evidence_reference="",
+                evidence_digest=None,
+                observed_value="absent",
+                expected_condition="canonical binding evidence verifies and observe_bound=true",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("STEP_29U_BINDING_PROVEN:ABSENT")
+    else:
+        reason = ",".join(binding_reasons or bound_obs_reasons or ("BINDING_UNSATISFIED",))
+        state = (
+            STATE_INVALID
+            if any(
+                "INVALID" in r or "DIGEST" in r or "MALFORMED" in r or "SCHEMA" in r
+                for r in (binding_reasons or ())
+            )
+            else STATE_UNSATISFIED
+        )
+        records.append(
+            _record(
+                prerequisite_id="STEP_29U_BINDING_PROVEN",
+                description="Canonical Step 29U Shadow no-order binding evidence verified",
+                canonical_owner=BINDING_OWNER,
+                source_reference="src/ops/step_29u_canonical_shadow_binding_v0.py",
+                state=state,
+                reason_code=reason[:200],
+                evidence_reference="evidence/ops/step_29u_offline_capability/2026-07-25_capability_hold_cycle",
+                evidence_digest=None,
+                observed_value=f"bound={bound_obs} verified={binding_ok}",
+                expected_condition="canonical binding evidence verifies and observe_bound=true",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append(f"STEP_29U_BINDING_PROVEN:{state}")
+
+    # --- Soak ---
+    soak_summary_path = soak_dir / "soak_summary.json"
+    soak_manifest_path = soak_dir / "evidence_manifest.sha256"
+    soak_exact_head_path = soak_dir / "exact_head.txt"
+    soak_digest: Optional[str] = None
+    soak_payload: dict[str, Any] = {}
+
+    if not soak_dir.is_dir():
+        records.append(
+            _record(
+                prerequisite_id="STEP_29U_POST_MERGE_SOAK_PROVEN",
+                description="Post-merge Step 29U bound Shadow soak evidence proven",
+                canonical_owner="ops.step_29u_post_merge_shadow_soak",
+                source_reference=CANONICAL_SOAK_RELPATH,
+                state=STATE_ABSENT,
+                reason_code="SOAK_DIR_ABSENT",
+                evidence_reference=str(soak_dir.relative_to(root))
+                if soak_dir.is_relative_to(root)
+                else str(soak_dir),
+                evidence_digest=None,
+                observed_value="absent",
+                expected_condition=f"STATUS=PASS tested_head={EXPECTED_SOAK_TESTED_HEAD_SHA} manifest digests match",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("STEP_29U_POST_MERGE_SOAK_PROVEN:ABSENT")
+        soak_safety = {
+            "RUNTIME_ACTIVATED": None,
+            "SCHEDULER_ACTIVATED": None,
+            "NETWORK_USED": None,
+            "ORDERS_CREATED": None,
+            "ORDERS_SUBMITTED": None,
+            "BTC_OBSERVED": None,
+            "SPOT_OBSERVED": None,
+            "KRAKEN_LEGACY_OBSERVED": None,
+        }
+    elif not soak_summary_path.is_file():
+        records.append(
+            _record(
+                prerequisite_id="STEP_29U_POST_MERGE_SOAK_PROVEN",
+                description="Post-merge Step 29U bound Shadow soak evidence proven",
+                canonical_owner="ops.step_29u_post_merge_shadow_soak",
+                source_reference=CANONICAL_SOAK_RELPATH,
+                state=STATE_ABSENT,
+                reason_code="SOAK_SUMMARY_ABSENT",
+                evidence_reference=CANONICAL_SOAK_RELPATH,
+                evidence_digest=None,
+                observed_value="summary_absent",
+                expected_condition=f"STATUS=PASS tested_head={EXPECTED_SOAK_TESTED_HEAD_SHA} manifest digests match",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("STEP_29U_POST_MERGE_SOAK_PROVEN:ABSENT")
+        soak_safety = {
+            "RUNTIME_ACTIVATED": None,
+            "SCHEDULER_ACTIVATED": None,
+            "NETWORK_USED": None,
+            "ORDERS_CREATED": None,
+            "ORDERS_SUBMITTED": None,
+            "BTC_OBSERVED": None,
+            "SPOT_OBSERVED": None,
+            "KRAKEN_LEGACY_OBSERVED": None,
+        }
+    else:
+        try:
+            loaded = _load_json(soak_summary_path)
+            if not isinstance(loaded, dict):
+                raise Step29UActivationEligibilityInventoryError("SOAK_SUMMARY_NOT_OBJECT")
+            soak_payload = dict(loaded)
+            if ov.soak_summary_overlay:
+                soak_payload.update(dict(ov.soak_summary_overlay))
+            manifest_ok, manifest_reason, soak_digest = _verify_manifest(
+                soak_dir, soak_manifest_path
+            )
+            exact_head = (
+                soak_exact_head_path.read_text(encoding="utf-8").strip()
+                if soak_exact_head_path.is_file()
+                else ""
+            )
+            tested_head = str(soak_payload.get("TESTED_HEAD_SHA") or "").strip()
+            status = str(soak_payload.get("STATUS") or "")
+            wallclock_ok = soak_payload.get("WALLCLOCK_REQUIREMENT_PASS") is True
+
+            def _int_field(key: str, *, missing: int) -> int:
+                if key not in soak_payload or soak_payload[key] is None:
+                    return missing
+                return int(soak_payload[key])
+
+            verified = _int_field("STEP_29U_VERIFIED_CYCLES", missing=0)
+            total = _int_field("TOTAL_CYCLES", missing=0)
+            full_chain = _int_field("FULL_CHAIN_CYCLES", missing=0)
+            absent_count = _int_field("STEP_29U_ABSENT_COUNT", missing=-1)
+            invalid_count = _int_field("STEP_29U_INVALID_COUNT", missing=-1)
+
+            soak_safety = {
+                "RUNTIME_ACTIVATED": _boolish(soak_payload.get("RUNTIME_ACTIVATED")),
+                "SCHEDULER_ACTIVATED": _boolish(soak_payload.get("SCHEDULER_ACTIVATED")),
+                "NETWORK_USED": _boolish(soak_payload.get("NETWORK_USED")),
+                "ORDERS_CREATED": _boolish(soak_payload.get("ORDERS_CREATED")),
+                "ORDERS_SUBMITTED": _boolish(soak_payload.get("ORDERS_SUBMITTED")),
+                "BTC_OBSERVED": _boolish(soak_payload.get("BTC_OBSERVED")),
+                "SPOT_OBSERVED": _boolish(soak_payload.get("SPOT_OBSERVED")),
+                "KRAKEN_LEGACY_OBSERVED": _boolish(soak_payload.get("KRAKEN_LEGACY_OBSERVED")),
+            }
+
+            invalid_reasons: list[str] = []
+            if not manifest_ok:
+                invalid_reasons.append(manifest_reason)
+            if tested_head != EXPECTED_SOAK_TESTED_HEAD_SHA:
+                invalid_reasons.append("SOAK_TESTED_HEAD_MISMATCH")
+            if exact_head and exact_head != tested_head:
+                invalid_reasons.append("SOAK_EXACT_HEAD_MISMATCH")
+            if exact_head and exact_head != EXPECTED_SOAK_TESTED_HEAD_SHA:
+                invalid_reasons.append("SOAK_EXACT_HEAD_UNEXPECTED")
+            for key, expected_false in (
+                ("RUNTIME_ACTIVATED", False),
+                ("SCHEDULER_ACTIVATED", False),
+                ("NETWORK_USED", False),
+                ("ORDERS_CREATED", False),
+                ("ORDERS_SUBMITTED", False),
+            ):
+                val = soak_safety[key]
+                if val is True:
+                    invalid_reasons.append(f"SOAK_{key}_TRUE_INVALID")
+                elif val is None:
+                    invalid_reasons.append(f"SOAK_{key}_MISSING")
+
+            if invalid_reasons:
+                records.append(
+                    _record(
+                        prerequisite_id="STEP_29U_POST_MERGE_SOAK_PROVEN",
+                        description="Post-merge Step 29U bound Shadow soak evidence proven",
+                        canonical_owner="ops.step_29u_post_merge_shadow_soak",
+                        source_reference=CANONICAL_SOAK_RELPATH,
+                        state=STATE_INVALID,
+                        reason_code=",".join(invalid_reasons)[:200],
+                        evidence_reference=CANONICAL_SOAK_RELPATH,
+                        evidence_digest=soak_digest,
+                        observed_value=(
+                            f"status={status} tested_head={tested_head} manifest_ok={manifest_ok}"
+                        ),
+                        expected_condition=(
+                            f"STATUS=PASS tested_head={EXPECTED_SOAK_TESTED_HEAD_SHA} "
+                            "manifest digests match; safety flags false"
+                        ),
+                        evaluated_at=evaluated_at,
+                    )
+                )
+                blockers.append("STEP_29U_POST_MERGE_SOAK_PROVEN:INVALID")
+            elif (
+                status == "PASS"
+                and wallclock_ok
+                and verified == total == full_chain
+                and verified > 0
+                and absent_count == 0
+                and invalid_count == 0
+            ):
+                records.append(
+                    _record(
+                        prerequisite_id="STEP_29U_POST_MERGE_SOAK_PROVEN",
+                        description="Post-merge Step 29U bound Shadow soak evidence proven",
+                        canonical_owner="ops.step_29u_post_merge_shadow_soak",
+                        source_reference=CANONICAL_SOAK_RELPATH,
+                        state=STATE_SATISFIED,
+                        reason_code="POST_MERGE_SOAK_VERIFIED",
+                        evidence_reference=CANONICAL_SOAK_RELPATH,
+                        evidence_digest=soak_digest,
+                        observed_value=(
+                            f"status=PASS cycles={total} verified={verified} "
+                            f"tested_head={tested_head}"
+                        ),
+                        expected_condition=(
+                            f"STATUS=PASS tested_head={EXPECTED_SOAK_TESTED_HEAD_SHA} "
+                            "manifest digests match; safety flags false"
+                        ),
+                        evaluated_at=evaluated_at,
+                    )
+                )
+            else:
+                records.append(
+                    _record(
+                        prerequisite_id="STEP_29U_POST_MERGE_SOAK_PROVEN",
+                        description="Post-merge Step 29U bound Shadow soak evidence proven",
+                        canonical_owner="ops.step_29u_post_merge_shadow_soak",
+                        source_reference=CANONICAL_SOAK_RELPATH,
+                        state=STATE_UNSATISFIED,
+                        reason_code="SOAK_ASSERTIONS_UNMET",
+                        evidence_reference=CANONICAL_SOAK_RELPATH,
+                        evidence_digest=soak_digest,
+                        observed_value=(
+                            f"status={status} verified={verified} total={total} "
+                            f"absent={absent_count} invalid={invalid_count}"
+                        ),
+                        expected_condition=(
+                            f"STATUS=PASS tested_head={EXPECTED_SOAK_TESTED_HEAD_SHA} "
+                            "manifest digests match; safety flags false"
+                        ),
+                        evaluated_at=evaluated_at,
+                    )
+                )
+                blockers.append("STEP_29U_POST_MERGE_SOAK_PROVEN:UNSATISFIED")
+        except Step29UActivationEligibilityInventoryError as exc:
+            records.append(
+                _record(
+                    prerequisite_id="STEP_29U_POST_MERGE_SOAK_PROVEN",
+                    description="Post-merge Step 29U bound Shadow soak evidence proven",
+                    canonical_owner="ops.step_29u_post_merge_shadow_soak",
+                    source_reference=CANONICAL_SOAK_RELPATH,
+                    state=STATE_INVALID,
+                    reason_code=str(exc)[:200],
+                    evidence_reference=CANONICAL_SOAK_RELPATH,
+                    evidence_digest=None,
+                    observed_value="malformed",
+                    expected_condition=(
+                        f"STATUS=PASS tested_head={EXPECTED_SOAK_TESTED_HEAD_SHA} "
+                        "manifest digests match"
+                    ),
+                    evaluated_at=evaluated_at,
+                )
+            )
+            blockers.append("STEP_29U_POST_MERGE_SOAK_PROVEN:INVALID")
+            soak_safety = {
+                "RUNTIME_ACTIVATED": None,
+                "SCHEDULER_ACTIVATED": None,
+                "NETWORK_USED": None,
+                "ORDERS_CREATED": None,
+                "ORDERS_SUBMITTED": None,
+                "BTC_OBSERVED": None,
+                "SPOT_OBSERVED": None,
+                "KRAKEN_LEGACY_OBSERVED": None,
+            }
+
+    # --- Audit provenance (STEP 29U audit owner still missing per inventory SSOT) ---
+    records.append(
+        _record(
+            prerequisite_id="STEP_29U_AUDIT_PROVENANCE_COMPLETE",
+            description="Dedicated STEP 29U activation audit/provenance contract complete",
+            canonical_owner="MISSING",
+            source_reference=BINDING_INVENTORY_RUNBOOK,
+            state=STATE_ABSENT,
+            reason_code="STEP_29U_AUDIT_CONTRACT_MISSING",
+            evidence_reference=BINDING_INVENTORY_RUNBOOK,
+            evidence_digest=None,
+            observed_value="audit_owner=MISSING",
+            expected_condition="dedicated STEP 29U audit contract owner present and verified",
+            evaluated_at=evaluated_at,
+        )
+    )
+    blockers.append("STEP_29U_AUDIT_PROVENANCE_COMPLETE:ABSENT")
+
+    # --- Readiness / runtime bridge / economic / authority ---
+    if not readiness_path.is_file():
+        runtime_state = None
+        econ_pass = None
+        activation_flags = {}
+        authorities: Sequence[str] = ()
+        readiness_state_note = "READINESS_CONFIG_ABSENT"
+        readiness_digest = None
+    else:
+        try:
+            cfg = load_shadow_preparation_readiness_gate_config_v0(
+                config_path=readiness_path, repo_root=root
+            )
+            runtime_state = str(
+                cfg.get("runtime_bridge_state") or RUNTIME_BRIDGE_STATE_BOUND_NOT_ACTIVATED
+            )
+            econ_pass = cfg.get("economic_validity_offline_gate_pass") is True
+            activation_flags = {
+                "shadow_activation_authorized": bool(cfg.get("shadow_activation_authorized")),
+                "scheduler_activation_authorized": bool(cfg.get("scheduler_activation_authorized")),
+                "runtime_activation_authorized": bool(cfg.get("runtime_activation_authorized")),
+                "orders_authorized": bool(cfg.get("orders_authorized")),
+                "live_authorized": bool(cfg.get("live_authorized")),
+            }
+            authorities = tuple(cfg.get("known_canonical_authority_identifiers") or ())
+            readiness_state_note = "READINESS_CONFIG_LOADED"
+            readiness_digest = _sha256_file(readiness_path)
+            if any(activation_flags.values()):
+                readiness_state_note = "READINESS_ACTIVATION_FLAG_TRUE_INVALID"
+        except Exception as exc:  # noqa: BLE001 — fail-closed classification
+            runtime_state = None
+            econ_pass = None
+            activation_flags = {}
+            authorities = ()
+            readiness_state_note = f"READINESS_CONFIG_INVALID:{type(exc).__name__}"
+            readiness_digest = None
+
+    if readiness_state_note == "READINESS_CONFIG_ABSENT":
+        records.append(
+            _record(
+                prerequisite_id="RUNTIME_BRIDGE_BOUND",
+                description="Runtime bridge remains BOUND_NOT_ACTIVATED",
+                canonical_owner="ops.shadow_preparation_readiness_gate_v0",
+                source_reference=READINESS_CONFIG_RELPATH,
+                state=STATE_ABSENT,
+                reason_code="READINESS_CONFIG_ABSENT",
+                evidence_reference=READINESS_CONFIG_RELPATH,
+                evidence_digest=None,
+                observed_value="absent",
+                expected_condition="runtime_bridge_state=BOUND_NOT_ACTIVATED",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("RUNTIME_BRIDGE_BOUND:ABSENT")
+    elif readiness_state_note.startswith("READINESS_CONFIG_INVALID") or (
+        readiness_state_note == "READINESS_ACTIVATION_FLAG_TRUE_INVALID"
+    ):
+        records.append(
+            _record(
+                prerequisite_id="RUNTIME_BRIDGE_BOUND",
+                description="Runtime bridge remains BOUND_NOT_ACTIVATED",
+                canonical_owner="ops.shadow_preparation_readiness_gate_v0",
+                source_reference=READINESS_CONFIG_RELPATH,
+                state=STATE_INVALID,
+                reason_code=readiness_state_note[:200],
+                evidence_reference=READINESS_CONFIG_RELPATH,
+                evidence_digest=readiness_digest,
+                observed_value=str(runtime_state),
+                expected_condition="runtime_bridge_state=BOUND_NOT_ACTIVATED",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("RUNTIME_BRIDGE_BOUND:INVALID")
+    elif runtime_state == RUNTIME_BRIDGE_STATE_BOUND_NOT_ACTIVATED:
+        records.append(
+            _record(
+                prerequisite_id="RUNTIME_BRIDGE_BOUND",
+                description="Runtime bridge remains BOUND_NOT_ACTIVATED",
+                canonical_owner="ops.shadow_preparation_readiness_gate_v0",
+                source_reference=READINESS_CONFIG_RELPATH,
+                state=STATE_SATISFIED,
+                reason_code="RUNTIME_BRIDGE_BOUND_NOT_ACTIVATED",
+                evidence_reference=READINESS_CONFIG_RELPATH,
+                evidence_digest=readiness_digest,
+                observed_value=runtime_state,
+                expected_condition="runtime_bridge_state=BOUND_NOT_ACTIVATED",
+                evaluated_at=evaluated_at,
+            )
+        )
+    else:
+        records.append(
+            _record(
+                prerequisite_id="RUNTIME_BRIDGE_BOUND",
+                description="Runtime bridge remains BOUND_NOT_ACTIVATED",
+                canonical_owner="ops.shadow_preparation_readiness_gate_v0",
+                source_reference=READINESS_CONFIG_RELPATH,
+                state=STATE_INVALID,
+                reason_code="RUNTIME_BRIDGE_STATE_UNEXPECTED",
+                evidence_reference=READINESS_CONFIG_RELPATH,
+                evidence_digest=readiness_digest,
+                observed_value=str(runtime_state),
+                expected_condition="runtime_bridge_state=BOUND_NOT_ACTIVATED",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("RUNTIME_BRIDGE_BOUND:INVALID")
+
+    def _safety_prereq(
+        pid: str,
+        *,
+        description: str,
+        soak_key: str,
+        readiness_false_keys: Sequence[str],
+        expected: str,
+    ) -> None:
+        soak_val = soak_safety.get(soak_key)
+        readiness_bad = any(activation_flags.get(k) for k in readiness_false_keys)
+        if soak_val is True or readiness_bad:
+            records.append(
+                _record(
+                    prerequisite_id=pid,
+                    description=description,
+                    canonical_owner="ops.step_29u_activation_eligibility_inventory_v0",
+                    source_reference=CANONICAL_SOAK_RELPATH,
+                    state=STATE_INVALID,
+                    reason_code=f"{soak_key}_OR_READINESS_ACTIVATION_TRUE",
+                    evidence_reference=CANONICAL_SOAK_RELPATH,
+                    evidence_digest=soak_digest,
+                    observed_value=f"soak={soak_val} readiness_bad={readiness_bad}",
+                    expected_condition=expected,
+                    evaluated_at=evaluated_at,
+                )
+            )
+            blockers.append(f"{pid}:INVALID")
+        elif soak_val is False and not readiness_bad and readiness_path.is_file():
+            records.append(
+                _record(
+                    prerequisite_id=pid,
+                    description=description,
+                    canonical_owner="ops.step_29u_activation_eligibility_inventory_v0",
+                    source_reference=CANONICAL_SOAK_RELPATH,
+                    state=STATE_SATISFIED,
+                    reason_code=f"{soak_key}_FALSE_AND_READINESS_LOCKED",
+                    evidence_reference=CANONICAL_SOAK_RELPATH,
+                    evidence_digest=soak_digest,
+                    observed_value="false",
+                    expected_condition=expected,
+                    evaluated_at=evaluated_at,
+                )
+            )
+        elif not soak_dir.is_dir() or soak_val is None:
+            records.append(
+                _record(
+                    prerequisite_id=pid,
+                    description=description,
+                    canonical_owner="ops.step_29u_activation_eligibility_inventory_v0",
+                    source_reference=CANONICAL_SOAK_RELPATH,
+                    state=STATE_ABSENT if not soak_dir.is_dir() else STATE_UNSATISFIED,
+                    reason_code=f"{soak_key}_NOT_PROVEN",
+                    evidence_reference=CANONICAL_SOAK_RELPATH,
+                    evidence_digest=soak_digest,
+                    observed_value=str(soak_val),
+                    expected_condition=expected,
+                    evaluated_at=evaluated_at,
+                )
+            )
+            blockers.append(f"{pid}:NOT_PROVEN")
+        else:
+            records.append(
+                _record(
+                    prerequisite_id=pid,
+                    description=description,
+                    canonical_owner="ops.step_29u_activation_eligibility_inventory_v0",
+                    source_reference=CANONICAL_SOAK_RELPATH,
+                    state=STATE_UNSATISFIED,
+                    reason_code=f"{soak_key}_UNSATISFIED",
+                    evidence_reference=CANONICAL_SOAK_RELPATH,
+                    evidence_digest=soak_digest,
+                    observed_value=str(soak_val),
+                    expected_condition=expected,
+                    evaluated_at=evaluated_at,
+                )
+            )
+            blockers.append(f"{pid}:UNSATISFIED")
+
+    _safety_prereq(
+        "RUNTIME_REMAINS_NOT_ACTIVATED",
+        description="Runtime remains not activated",
+        soak_key="RUNTIME_ACTIVATED",
+        readiness_false_keys=("runtime_activation_authorized",),
+        expected="RUNTIME_ACTIVATED=false and runtime_activation_authorized=false",
+    )
+    _safety_prereq(
+        "SCHEDULER_REMAINS_LOCKED",
+        description="Scheduler remains locked / not activated",
+        soak_key="SCHEDULER_ACTIVATED",
+        readiness_false_keys=("scheduler_activation_authorized",),
+        expected="SCHEDULER_ACTIVATED=false and scheduler_activation_authorized=false",
+    )
+    _safety_prereq(
+        "NETWORK_REMAINS_PROHIBITED",
+        description="Network runtime remains prohibited",
+        soak_key="NETWORK_USED",
+        readiness_false_keys=(),
+        expected="NETWORK_USED=false",
+    )
+    _safety_prereq(
+        "ORDERS_REMAIN_PROHIBITED",
+        description="Orders remain prohibited (created/submitted false)",
+        soak_key="ORDERS_CREATED",
+        readiness_false_keys=("orders_authorized",),
+        expected="ORDERS_CREATED=false ORDERS_SUBMITTED=false orders_authorized=false",
+    )
+    # Tighten orders if submitted true even when created false.
+    orders_rec = next(r for r in records if r.prerequisite_id == "ORDERS_REMAIN_PROHIBITED")
+    if soak_safety.get("ORDERS_SUBMITTED") is True and orders_rec.state == STATE_SATISFIED:
+        records[records.index(orders_rec)] = _record(
+            prerequisite_id="ORDERS_REMAIN_PROHIBITED",
+            description=orders_rec.description,
+            canonical_owner=orders_rec.canonical_owner,
+            source_reference=orders_rec.source_reference,
+            state=STATE_INVALID,
+            reason_code="ORDERS_SUBMITTED_TRUE_INVALID",
+            evidence_reference=orders_rec.evidence_reference,
+            evidence_digest=orders_rec.evidence_digest,
+            observed_value="orders_submitted=true",
+            expected_condition=orders_rec.expected_condition,
+            evaluated_at=evaluated_at,
+        )
+        blockers.append("ORDERS_REMAIN_PROHIBITED:INVALID")
+
+    if econ_pass is True:
+        # Canonical config currently false; if ever true still require durable proof.
+        records.append(
+            _record(
+                prerequisite_id="ECONOMIC_VALIDITY_PROVEN",
+                description="Economic validity offline gate proven",
+                canonical_owner="ops.shadow_preparation_readiness_gate_v0",
+                source_reference=READINESS_CONFIG_RELPATH,
+                state=STATE_UNSATISFIED,
+                reason_code="ECONOMIC_VALIDITY_FLAG_TRUE_WITHOUT_DURABLE_PROOF",
+                evidence_reference=READINESS_CONFIG_RELPATH,
+                evidence_digest=readiness_digest,
+                observed_value="economic_validity_offline_gate_pass=true",
+                expected_condition="durable economic validity proof under separate GO",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("ECONOMIC_VALIDITY_PROVEN:UNSATISFIED")
+    elif readiness_path.is_file() and econ_pass is False:
+        records.append(
+            _record(
+                prerequisite_id="ECONOMIC_VALIDITY_PROVEN",
+                description="Economic validity offline gate proven",
+                canonical_owner="ops.shadow_preparation_readiness_gate_v0",
+                source_reference=READINESS_CONFIG_RELPATH,
+                state=STATE_UNSATISFIED,
+                reason_code="ECONOMIC_VALIDITY_NOT_PROVEN_BLOCKED",
+                evidence_reference=READINESS_CONFIG_RELPATH,
+                evidence_digest=readiness_digest,
+                observed_value="economic_validity_offline_gate_pass=false",
+                expected_condition="economic_validity_offline_gate_pass proven by durable evidence",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("ECONOMIC_VALIDITY_PROVEN:UNSATISFIED")
+    else:
+        records.append(
+            _record(
+                prerequisite_id="ECONOMIC_VALIDITY_PROVEN",
+                description="Economic validity offline gate proven",
+                canonical_owner="ops.shadow_preparation_readiness_gate_v0",
+                source_reference=READINESS_CONFIG_RELPATH,
+                state=STATE_ABSENT,
+                reason_code="ECONOMIC_VALIDITY_SOURCE_ABSENT",
+                evidence_reference=READINESS_CONFIG_RELPATH,
+                evidence_digest=None,
+                observed_value="absent",
+                expected_condition="economic_validity_offline_gate_pass proven by durable evidence",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("ECONOMIC_VALIDITY_PROVEN:ABSENT")
+
+    required_authorities = {
+        "trading.master_v2",
+        "trading.double_play",
+        "safety.independent_veto",
+        "runtime_bridge.BOUND_NOT_ACTIVATED",
+    }
+    if not readiness_path.is_file():
+        records.append(
+            _record(
+                prerequisite_id="SAFETY_AUTHORITY_VALID",
+                description="Known safety/trading authorities remain referenced and non-mutated",
+                canonical_owner="ops.shadow_preparation_readiness_gate_v0",
+                source_reference=READINESS_CONFIG_RELPATH,
+                state=STATE_ABSENT,
+                reason_code="AUTHORITY_SOURCE_ABSENT",
+                evidence_reference=READINESS_CONFIG_RELPATH,
+                evidence_digest=None,
+                observed_value="absent",
+                expected_condition="known_canonical_authority_identifiers contains required set",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("SAFETY_AUTHORITY_VALID:ABSENT")
+    elif required_authorities.issubset(set(authorities)) and not any(activation_flags.values()):
+        records.append(
+            _record(
+                prerequisite_id="SAFETY_AUTHORITY_VALID",
+                description="Known safety/trading authorities remain referenced and non-mutated",
+                canonical_owner="ops.shadow_preparation_readiness_gate_v0",
+                source_reference=READINESS_CONFIG_RELPATH,
+                state=STATE_SATISFIED,
+                reason_code="AUTHORITY_IDENTIFIERS_PRESENT_NON_ACTIVATING",
+                evidence_reference=READINESS_CONFIG_RELPATH,
+                evidence_digest=readiness_digest,
+                observed_value=",".join(sorted(required_authorities)),
+                expected_condition="known_canonical_authority_identifiers contains required set",
+                evaluated_at=evaluated_at,
+            )
+        )
+    else:
+        records.append(
+            _record(
+                prerequisite_id="SAFETY_AUTHORITY_VALID",
+                description="Known safety/trading authorities remain referenced and non-mutated",
+                canonical_owner="ops.shadow_preparation_readiness_gate_v0",
+                source_reference=READINESS_CONFIG_RELPATH,
+                state=STATE_UNSATISFIED,
+                reason_code="AUTHORITY_SET_INCOMPLETE_OR_ACTIVATION_FLAG",
+                evidence_reference=READINESS_CONFIG_RELPATH,
+                evidence_digest=readiness_digest,
+                observed_value=",".join(sorted(authorities)),
+                expected_condition="known_canonical_authority_identifiers contains required set",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("SAFETY_AUTHORITY_VALID:UNSATISFIED")
+
+    soak_proven = any(
+        r.prerequisite_id == "STEP_29U_POST_MERGE_SOAK_PROVEN" and r.state == STATE_SATISFIED
+        for r in records
+    )
+    if soak_proven:
+        records.append(
+            _record(
+                prerequisite_id="RECONCILIATION_PRECONDITIONS_PROVEN",
+                description="Offline full-chain reconciliation preconditions proven via soak",
+                canonical_owner="ops.step_29u_post_merge_shadow_soak",
+                source_reference=CANONICAL_SOAK_RELPATH,
+                state=STATE_SATISFIED,
+                reason_code="SOAK_FULL_CHAIN_HOLD_RECON_OBSERVED",
+                evidence_reference=CANONICAL_SOAK_RELPATH,
+                evidence_digest=soak_digest,
+                observed_value="full_chain_hold_cycles_match_total",
+                expected_condition="post-merge soak full-chain HOLD cycles proven",
+                evaluated_at=evaluated_at,
+            )
+        )
+    else:
+        records.append(
+            _record(
+                prerequisite_id="RECONCILIATION_PRECONDITIONS_PROVEN",
+                description="Offline full-chain reconciliation preconditions proven via soak",
+                canonical_owner="ops.step_29u_post_merge_shadow_soak",
+                source_reference=CANONICAL_SOAK_RELPATH,
+                state=STATE_UNSATISFIED,
+                reason_code="SOAK_NOT_PROVEN_FOR_RECON",
+                evidence_reference=CANONICAL_SOAK_RELPATH,
+                evidence_digest=soak_digest,
+                observed_value="soak_not_satisfied",
+                expected_condition="post-merge soak full-chain HOLD cycles proven",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("RECONCILIATION_PRECONDITIONS_PROVEN:UNSATISFIED")
+
+    authority_contract_present = (root / BINDING_INVENTORY_RUNBOOK).is_file() and (
+        root / "docs/ops/runbooks/SHADOW_PREPARATION_READINESS_GATE_CONTRACT_V0.md"
+    ).is_file()
+    if authority_contract_present:
+        records.append(
+            _record(
+                prerequisite_id="ACTIVATION_AUTHORITY_CONTRACT_PRESENT",
+                description="Activation authority contract text present (separate GO required)",
+                canonical_owner="runbook.STEP_29U",
+                source_reference=BINDING_INVENTORY_RUNBOOK,
+                state=STATE_SATISFIED,
+                reason_code="ACTIVATION_AUTHORITY_CONTRACT_DOCUMENTED",
+                evidence_reference=BINDING_INVENTORY_RUNBOOK,
+                evidence_digest=None,
+                observed_value="contract_present=true activation_authorized=false",
+                expected_condition="authority contract present; does not grant GO",
+                evaluated_at=evaluated_at,
+            )
+        )
+    else:
+        records.append(
+            _record(
+                prerequisite_id="ACTIVATION_AUTHORITY_CONTRACT_PRESENT",
+                description="Activation authority contract text present (separate GO required)",
+                canonical_owner="runbook.STEP_29U",
+                source_reference=BINDING_INVENTORY_RUNBOOK,
+                state=STATE_ABSENT,
+                reason_code="ACTIVATION_AUTHORITY_CONTRACT_ABSENT",
+                evidence_reference=BINDING_INVENTORY_RUNBOOK,
+                evidence_digest=None,
+                observed_value="absent",
+                expected_condition="authority contract present; does not grant GO",
+                evaluated_at=evaluated_at,
+            )
+        )
+        blockers.append("ACTIVATION_AUTHORITY_CONTRACT_PRESENT:ABSENT")
+
+    # This IMPLEMENTATION_ONLY authorization must never be inferred as future activation GO.
+    records.append(
+        _record(
+            prerequisite_id="EXPLICIT_FUTURE_OPERATOR_GO_PRESENT",
+            description="Explicit future Operator-GO for Step 29U activation present",
+            canonical_owner="operator.activation_authority",
+            source_reference=INVENTORY_RUNBOOK,
+            state=STATE_ABSENT,
+            reason_code="FUTURE_ACTIVATION_OPERATOR_GO_ABSENT",
+            evidence_reference=INVENTORY_RUNBOOK,
+            evidence_digest=None,
+            observed_value="OPERATOR_GO_PRESENT=false",
+            expected_condition="separate explicit future activation Operator-GO artifact",
+            evaluated_at=evaluated_at,
+        )
+    )
+    blockers.append("EXPLICIT_FUTURE_OPERATOR_GO_PRESENT:ABSENT")
+
+    def _exclusion(pid: str, soak_key: str, description: str) -> None:
+        val = soak_safety.get(soak_key)
+        if val is True:
+            records.append(
+                _record(
+                    prerequisite_id=pid,
+                    description=description,
+                    canonical_owner="ops.step_29u_post_merge_shadow_soak",
+                    source_reference=CANONICAL_SOAK_RELPATH,
+                    state=STATE_INVALID,
+                    reason_code=f"{soak_key}_TRUE_BLOCKS",
+                    evidence_reference=CANONICAL_SOAK_RELPATH,
+                    evidence_digest=soak_digest,
+                    observed_value="true",
+                    expected_condition=f"{soak_key}=false",
+                    evaluated_at=evaluated_at,
+                )
+            )
+            blockers.append(f"{pid}:INVALID")
+        elif val is False:
+            records.append(
+                _record(
+                    prerequisite_id=pid,
+                    description=description,
+                    canonical_owner="ops.step_29u_post_merge_shadow_soak",
+                    source_reference=CANONICAL_SOAK_RELPATH,
+                    state=STATE_SATISFIED,
+                    reason_code=f"{soak_key}_FALSE",
+                    evidence_reference=CANONICAL_SOAK_RELPATH,
+                    evidence_digest=soak_digest,
+                    observed_value="false",
+                    expected_condition=f"{soak_key}=false",
+                    evaluated_at=evaluated_at,
+                )
+            )
+        else:
+            records.append(
+                _record(
+                    prerequisite_id=pid,
+                    description=description,
+                    canonical_owner="ops.step_29u_post_merge_shadow_soak",
+                    source_reference=CANONICAL_SOAK_RELPATH,
+                    state=STATE_ABSENT if not soak_dir.is_dir() else STATE_UNSATISFIED,
+                    reason_code=f"{soak_key}_NOT_OBSERVED",
+                    evidence_reference=CANONICAL_SOAK_RELPATH,
+                    evidence_digest=soak_digest,
+                    observed_value=str(val),
+                    expected_condition=f"{soak_key}=false",
+                    evaluated_at=evaluated_at,
+                )
+            )
+            blockers.append(f"{pid}:NOT_PROVEN")
+
+    _exclusion("BTC_EXCLUDED", "BTC_OBSERVED", "BTC instruments excluded")
+    _exclusion("SPOT_EXCLUDED", "SPOT_OBSERVED", "Spot instruments excluded")
+    _exclusion(
+        "KRAKEN_LEGACY_EXCLUDED",
+        "KRAKEN_LEGACY_OBSERVED",
+        "Kraken legacy surfaces excluded",
+    )
+
+    # Deterministic ordering by PREREQUISITE_IDS
+    by_id = {r.prerequisite_id: r for r in records}
+    missing = [pid for pid in PREREQUISITE_IDS if pid not in by_id]
+    if missing:
+        raise Step29UActivationEligibilityInventoryError(
+            f"INCOMPLETE_PREREQUISITE_SET:{','.join(missing)}"
+        )
+    ordered = tuple(by_id[pid] for pid in PREREQUISITE_IDS)
+
+    summary = {
+        "prerequisite_count": len(ordered),
+        "satisfied_count": sum(1 for r in ordered if r.state == STATE_SATISFIED),
+        "unsatisfied_count": sum(1 for r in ordered if r.state == STATE_UNSATISFIED),
+        "absent_count": sum(1 for r in ordered if r.state == STATE_ABSENT),
+        "invalid_count": sum(1 for r in ordered if r.state == STATE_INVALID),
+        "blocker_count": len(blockers),
+    }
+
+    # Hard terminal defaults for this capability.
+    step_29u_activated = False
+    operator_go_present = False
+    btc_excluded = soak_safety.get("BTC_OBSERVED") is False
+    spot_excluded = soak_safety.get("SPOT_OBSERVED") is False
+    kraken_legacy_excluded = soak_safety.get("KRAKEN_LEGACY_OBSERVED") is False
+
+    all_satisfied = all(r.state == STATE_SATISFIED for r in ordered)
+    dedup_blockers = tuple(dict.fromkeys(blockers))
+    # Future activation GO is always absent here; eligibility cannot be true.
+    activation_eligible = False
+    if all_satisfied and not dedup_blockers:
+        # Defensive: even a fully satisfied set cannot authorize activation in v0.
+        activation_eligible = False
+
+    return ActivationEligibilityInventoryResultV0(
+        schema_id=SCHEMA_ID,
+        schema_version=SCHEMA_VERSION,
+        generated_at=evaluated_at,
+        evaluated_main_sha=evaluated_sha,
+        capability_id=CAPABILITY_ID,
+        evaluator_valid=True,
+        status="PASS",
+        activation_eligible=activation_eligible,
+        step_29u_activated=step_29u_activated,
+        # Terminal defaults for this capability (never report activation truth).
+        runtime_activated=False,
+        scheduler_activated=False,
+        network_used=False,
+        orders_created=False,
+        orders_submitted=False,
+        operator_go_present=operator_go_present,
+        btc_excluded=btc_excluded,
+        spot_excluded=spot_excluded,
+        kraken_legacy_excluded=kraken_legacy_excluded,
+        prerequisites=ordered,
+        blockers=dedup_blockers,
+        summary=summary,
+        provenance={
+            "package_marker": PACKAGE_MARKER,
+            "producer_family": PRODUCER_FAMILY,
+            "inventory_runbook": INVENTORY_RUNBOOK,
+            "binding_inventory_runbook": BINDING_INVENTORY_RUNBOOK,
+            "canonical_soak_relpath": CANONICAL_SOAK_RELPATH,
+            "expected_soak_tested_head_sha": EXPECTED_SOAK_TESTED_HEAD_SHA,
+            "readiness_config_relpath": READINESS_CONFIG_RELPATH,
+            "cli_relpath": CLI_RELPATH,
+            "implementation_authorization": "IMPLEMENTATION_ONLY_NOT_ACTIVATION",
+            "forbidden_import_surfaces": sorted(FORBIDDEN_IMPORT_SURFACES),
+        },
+        safety_facts={
+            "ACTIVATION_ELIGIBLE": False,
+            "STEP_29U_ACTIVATED": False,
+            "RUNTIME_ACTIVATED": False,
+            "SCHEDULER_ACTIVATED": False,
+            "NETWORK_USED": False,
+            "ORDERS_CREATED": False,
+            "ORDERS_SUBMITTED": False,
+            "OPERATOR_GO_PRESENT": False,
+            "RUNTIME_BRIDGE_STATE": runtime_state or "UNKNOWN",
+            "SOAK_OBSERVED_RUNTIME_ACTIVATED": soak_safety.get("RUNTIME_ACTIVATED"),
+            "SOAK_OBSERVED_SCHEDULER_ACTIVATED": soak_safety.get("SCHEDULER_ACTIVATED"),
+            "SOAK_OBSERVED_NETWORK_USED": soak_safety.get("NETWORK_USED"),
+            "SOAK_OBSERVED_ORDERS_CREATED": soak_safety.get("ORDERS_CREATED"),
+            "SOAK_OBSERVED_ORDERS_SUBMITTED": soak_safety.get("ORDERS_SUBMITTED"),
+        },
+    )
+
+
+def result_to_machine_lines(
+    result: ActivationEligibilityInventoryResultV0,
+) -> list[str]:
+    return [
+        f"STATUS={result.status}",
+        f"EVALUATOR_VALID={str(result.evaluator_valid).lower()}",
+        f"ACTIVATION_ELIGIBLE={str(result.activation_eligible).lower()}",
+        f"STEP_29U_ACTIVATED={str(result.step_29u_activated).lower()}",
+        f"PREREQUISITE_COUNT={result.summary['prerequisite_count']}",
+        f"SATISFIED_COUNT={result.summary['satisfied_count']}",
+        f"UNSATISFIED_COUNT={result.summary['unsatisfied_count']}",
+        f"ABSENT_COUNT={result.summary['absent_count']}",
+        f"INVALID_COUNT={result.summary['invalid_count']}",
+        f"BLOCKERS={list(result.blockers)}",
+        f"RUNTIME_ACTIVATED={str(result.runtime_activated).lower()}",
+        f"SCHEDULER_ACTIVATED={str(result.scheduler_activated).lower()}",
+        f"NETWORK_USED={str(result.network_used).lower()}",
+        f"ORDERS_CREATED={str(result.orders_created).lower()}",
+        f"ORDERS_SUBMITTED={str(result.orders_submitted).lower()}",
+        f"OPERATOR_GO_PRESENT={str(result.operator_go_present).lower()}",
+        f"BTC_EXCLUDED={str(result.btc_excluded).lower()}",
+        f"SPOT_EXCLUDED={str(result.spot_excluded).lower()}",
+        f"KRAKEN_LEGACY_EXCLUDED={str(result.kraken_legacy_excluded).lower()}",
+        f"EVALUATED_MAIN_SHA={result.evaluated_main_sha}",
+        f"SCHEMA_ID={result.schema_id}",
+        f"CAPABILITY_ID={result.capability_id}",
+    ]
+
+
+def serialize_result_json_v0(result: ActivationEligibilityInventoryResultV0) -> str:
+    return json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n"

--- a/tests/ops/test_step_29u_activation_eligibility_inventory_v0.py
+++ b/tests/ops/test_step_29u_activation_eligibility_inventory_v0.py
@@ -1,0 +1,333 @@
+"""Focused tests: Step 29U activation eligibility inventory v0."""
+
+from __future__ import annotations
+
+import ast
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.ops.step_29u_activation_eligibility_inventory_v0 import (
+    CAPABILITY_ID,
+    EXPECTED_SOAK_TESTED_HEAD_SHA,
+    FORBIDDEN_IMPORT_SURFACES,
+    PACKAGE_MARKER,
+    PREREQUISITE_IDS,
+    SCHEMA_ID,
+    STATE_ABSENT,
+    STATE_INVALID,
+    STATE_SATISFIED,
+    STATE_UNSATISFIED,
+    EligibilityInventoryOverridesV0,
+    Step29UActivationEligibilityInventoryError,
+    evaluate_step_29u_activation_eligibility_inventory_v0,
+    serialize_result_json_v0,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_SOAK = REPO_ROOT / "evidence/ops/step_29u_post_merge_shadow_soak/20260725T222915Z"
+CLI = REPO_ROOT / "scripts/ops/run_step_29u_activation_eligibility_inventory_v0.py"
+SRC = REPO_ROOT / "src/ops/step_29u_activation_eligibility_inventory_v0.py"
+
+
+def _by_id(result):
+    return {p.prerequisite_id: p for p in result.prerequisites}
+
+
+def _copy_soak(tmp_path: Path) -> Path:
+    dest = tmp_path / "soak"
+    shutil.copytree(CANONICAL_SOAK, dest)
+    return dest
+
+
+def _rewrite_summary(soak_dir: Path, **updates):
+    path = soak_dir / "soak_summary.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload.update(updates)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    # Refresh manifest digest for soak_summary.json only when requested by caller.
+
+
+def _refresh_manifest_entry(soak_dir: Path, rel: str) -> None:
+    import hashlib
+
+    manifest = soak_dir / "evidence_manifest.sha256"
+    lines = []
+    digest = hashlib.sha256((soak_dir / rel).read_bytes()).hexdigest()
+    for line in manifest.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        d, name = line.split(None, 1)
+        if name.strip() == rel:
+            lines.append(f"{digest}  {rel}")
+        else:
+            lines.append(line)
+    manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_normal_current_state_ineligible() -> None:
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(repo_root=REPO_ROOT)
+    assert result.evaluator_valid is True
+    assert result.status == "PASS"
+    assert result.activation_eligible is False
+    assert result.step_29u_activated is False
+    assert result.schema_id == SCHEMA_ID
+    assert result.capability_id == CAPABILITY_ID
+    assert PACKAGE_MARKER.startswith("STEP_29U_ACTIVATION_ELIGIBILITY")
+    assert result.summary["prerequisite_count"] == len(PREREQUISITE_IDS)
+    assert "ECONOMIC_VALIDITY_PROVEN:UNSATISFIED" in result.blockers
+    assert "EXPLICIT_FUTURE_OPERATOR_GO_PRESENT:ABSENT" in result.blockers
+    assert "STEP_29U_AUDIT_PROVENANCE_COMPLETE:ABSENT" in result.blockers
+    by = _by_id(result)
+    assert by["STEP_29U_BINDING_PROVEN"].state == STATE_SATISFIED
+    assert by["STEP_29U_POST_MERGE_SOAK_PROVEN"].state == STATE_SATISFIED
+    assert by["ECONOMIC_VALIDITY_PROVEN"].state == STATE_UNSATISFIED
+    assert by["EXPLICIT_FUTURE_OPERATOR_GO_PRESENT"].state == STATE_ABSENT
+
+
+def test_binding_alone_cannot_establish_eligibility(tmp_path: Path) -> None:
+    empty_soak = tmp_path / "no_soak"
+    empty_soak.mkdir()
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(
+        repo_root=REPO_ROOT,
+        overrides=EligibilityInventoryOverridesV0(soak_dir=empty_soak),
+    )
+    assert result.activation_eligible is False
+    assert _by_id(result)["STEP_29U_BINDING_PROVEN"].state == STATE_SATISFIED
+    assert _by_id(result)["STEP_29U_POST_MERGE_SOAK_PROVEN"].state in {
+        STATE_ABSENT,
+        STATE_UNSATISFIED,
+        STATE_INVALID,
+    }
+    assert any("SOAK" in b or "STEP_29U_POST_MERGE_SOAK" in b for b in result.blockers)
+
+
+def test_soak_alone_cannot_establish_eligibility(tmp_path: Path) -> None:
+    # Binding evidence override to empty dir → binding not proven; soak still canonical.
+    empty_bind = tmp_path / "no_bind"
+    empty_bind.mkdir()
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(
+        repo_root=REPO_ROOT,
+        overrides=EligibilityInventoryOverridesV0(binding_evidence_dir=empty_bind),
+    )
+    assert result.activation_eligible is False
+    assert _by_id(result)["STEP_29U_POST_MERGE_SOAK_PROVEN"].state == STATE_SATISFIED
+    assert _by_id(result)["STEP_29U_BINDING_PROVEN"].state != STATE_SATISFIED
+    assert any("BINDING" in b for b in result.blockers)
+
+
+def test_5551_soak_recognized_with_manifest_digest_and_head() -> None:
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(repo_root=REPO_ROOT)
+    soak = _by_id(result)["STEP_29U_POST_MERGE_SOAK_PROVEN"]
+    assert soak.state == STATE_SATISFIED
+    assert soak.evidence_digest
+    assert EXPECTED_SOAK_TESTED_HEAD_SHA in soak.observed_value
+    exact = (CANONICAL_SOAK / "exact_head.txt").read_text(encoding="utf-8").strip()
+    assert exact == EXPECTED_SOAK_TESTED_HEAD_SHA
+
+
+def test_missing_audit_provenance_blocks() -> None:
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(repo_root=REPO_ROOT)
+    assert _by_id(result)["STEP_29U_AUDIT_PROVENANCE_COMPLETE"].state == STATE_ABSENT
+    assert "STEP_29U_AUDIT_PROVENANCE_COMPLETE:ABSENT" in result.blockers
+
+
+def test_economic_validity_not_proven_blocks() -> None:
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(repo_root=REPO_ROOT)
+    assert _by_id(result)["ECONOMIC_VALIDITY_PROVEN"].state == STATE_UNSATISFIED
+    assert any("ECONOMIC_VALIDITY" in b for b in result.blockers)
+
+
+def test_future_operator_go_absent_blocks() -> None:
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(repo_root=REPO_ROOT)
+    assert result.operator_go_present is False
+    assert _by_id(result)["EXPLICIT_FUTURE_OPERATOR_GO_PRESENT"].state == STATE_ABSENT
+    assert "EXPLICIT_FUTURE_OPERATOR_GO_PRESENT:ABSENT" in result.blockers
+
+
+@pytest.mark.parametrize(
+    ("flag", "prereq"),
+    [
+        ("RUNTIME_ACTIVATED", "RUNTIME_REMAINS_NOT_ACTIVATED"),
+        ("SCHEDULER_ACTIVATED", "SCHEDULER_REMAINS_LOCKED"),
+        ("NETWORK_USED", "NETWORK_REMAINS_PROHIBITED"),
+        ("ORDERS_CREATED", "ORDERS_REMAIN_PROHIBITED"),
+        ("ORDERS_SUBMITTED", "ORDERS_REMAIN_PROHIBITED"),
+    ],
+)
+def test_unsafe_soak_flags_invalid(tmp_path: Path, flag: str, prereq: str) -> None:
+    soak = _copy_soak(tmp_path)
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(
+        repo_root=REPO_ROOT,
+        overrides=EligibilityInventoryOverridesV0(
+            soak_dir=soak,
+            soak_summary_overlay={flag: True},
+        ),
+    )
+    assert result.activation_eligible is False
+    assert result.step_29u_activated is False
+    assert _by_id(result)[prereq].state == STATE_INVALID
+    # Soak proven also invalid when safety flags true.
+    assert _by_id(result)["STEP_29U_POST_MERGE_SOAK_PROVEN"].state == STATE_INVALID
+
+
+@pytest.mark.parametrize(
+    ("flag", "prereq"),
+    [
+        ("BTC_OBSERVED", "BTC_EXCLUDED"),
+        ("SPOT_OBSERVED", "SPOT_EXCLUDED"),
+        ("KRAKEN_LEGACY_OBSERVED", "KRAKEN_LEGACY_EXCLUDED"),
+    ],
+)
+def test_inclusion_flags_block(tmp_path: Path, flag: str, prereq: str) -> None:
+    soak = _copy_soak(tmp_path)
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(
+        repo_root=REPO_ROOT,
+        overrides=EligibilityInventoryOverridesV0(
+            soak_dir=soak,
+            soak_summary_overlay={flag: True},
+        ),
+    )
+    assert result.activation_eligible is False
+    assert _by_id(result)[prereq].state == STATE_INVALID
+
+
+def test_missing_canonical_source_absent(tmp_path: Path) -> None:
+    missing_cfg = tmp_path / "missing.toml"
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(
+        repo_root=REPO_ROOT,
+        overrides=EligibilityInventoryOverridesV0(readiness_config_path=missing_cfg),
+    )
+    assert _by_id(result)["RUNTIME_BRIDGE_BOUND"].state == STATE_ABSENT
+    assert _by_id(result)["ECONOMIC_VALIDITY_PROVEN"].state == STATE_ABSENT
+
+
+def test_malformed_canonical_source_invalid(tmp_path: Path) -> None:
+    soak = _copy_soak(tmp_path)
+    (soak / "soak_summary.json").write_text("{not-json", encoding="utf-8")
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(
+        repo_root=REPO_ROOT,
+        overrides=EligibilityInventoryOverridesV0(soak_dir=soak),
+    )
+    assert _by_id(result)["STEP_29U_POST_MERGE_SOAK_PROVEN"].state == STATE_INVALID
+
+
+def test_digest_mismatch_invalid(tmp_path: Path) -> None:
+    soak = _copy_soak(tmp_path)
+    _rewrite_summary(soak, VERDICT="TAMPERED_FOR_DIGEST_MISMATCH")
+    # Intentionally do not refresh manifest → digest mismatch.
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(
+        repo_root=REPO_ROOT,
+        overrides=EligibilityInventoryOverridesV0(soak_dir=soak),
+    )
+    assert _by_id(result)["STEP_29U_POST_MERGE_SOAK_PROVEN"].state == STATE_INVALID
+    assert "DIGEST" in _by_id(result)["STEP_29U_POST_MERGE_SOAK_PROVEN"].reason_code
+
+
+def test_unknown_prerequisite_fails_closed() -> None:
+    with pytest.raises(Step29UActivationEligibilityInventoryError) as exc:
+        evaluate_step_29u_activation_eligibility_inventory_v0(
+            repo_root=REPO_ROOT,
+            overrides=EligibilityInventoryOverridesV0(force_unknown_prerequisite=True),
+        )
+    assert "UNKNOWN_PREREQUISITE" in str(exc.value)
+
+
+def test_output_ordering_and_serialization_deterministic() -> None:
+    a = evaluate_step_29u_activation_eligibility_inventory_v0(
+        repo_root=REPO_ROOT,
+        overrides=EligibilityInventoryOverridesV0(evaluated_main_sha="deadbeef"),
+    )
+    b = evaluate_step_29u_activation_eligibility_inventory_v0(
+        repo_root=REPO_ROOT,
+        overrides=EligibilityInventoryOverridesV0(evaluated_main_sha="deadbeef"),
+    )
+    assert [p.prerequisite_id for p in a.prerequisites] == list(PREREQUISITE_IDS)
+    assert [p.prerequisite_id for p in b.prerequisites] == list(PREREQUISITE_IDS)
+    # Stabilize generated_at by comparing structural fields
+    da, db = a.to_dict(), b.to_dict()
+    da["generated_at"] = db["generated_at"] = "FIXED"
+    assert json.dumps(da, sort_keys=True) == json.dumps(db, sort_keys=True)
+    assert serialize_result_json_v0(a).count("\n") > 10
+
+
+def test_activation_eligible_false_while_blockers_exist() -> None:
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(repo_root=REPO_ROOT)
+    assert result.blockers
+    assert result.activation_eligible is False
+
+
+def test_step_29u_activated_always_false(tmp_path: Path) -> None:
+    soak = _copy_soak(tmp_path)
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(
+        repo_root=REPO_ROOT,
+        overrides=EligibilityInventoryOverridesV0(
+            soak_dir=soak,
+            soak_summary_overlay={"RUNTIME_ACTIVATED": True},
+        ),
+    )
+    assert result.step_29u_activated is False
+    assert result.runtime_activated is False
+
+
+def test_no_network_runtime_scheduler_order_imports_or_calls() -> None:
+    src = SRC.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imported.add(node.module)
+    for forbidden in FORBIDDEN_IMPORT_SURFACES:
+        assert forbidden not in imported
+    # Forbidden surfaces may appear only as deny-list string constants.
+    assert "from src.orders" not in src
+    assert "import socket" not in src
+    assert "import requests" not in src
+    assert "create_order(" not in src
+    assert "socket" not in imported
+    assert "requests" not in imported
+
+
+def test_cli_pass_with_eligibility_false(tmp_path: Path) -> None:
+    out = tmp_path / "inventory.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "--repo-root",
+            str(REPO_ROOT),
+            "--output-path",
+            str(out),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "STATUS=PASS" in proc.stdout
+    assert "EVALUATOR_VALID=true" in proc.stdout
+    assert "ACTIVATION_ELIGIBLE=false" in proc.stdout
+    assert "STEP_29U_ACTIVATED=false" in proc.stdout
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["activation_eligible"] is False
+    assert payload["evaluator_valid"] is True
+
+
+def test_canonical_exclusions_satisfied() -> None:
+    result = evaluate_step_29u_activation_eligibility_inventory_v0(repo_root=REPO_ROOT)
+    assert result.btc_excluded is True
+    assert result.spot_excluded is True
+    assert result.kraken_legacy_excluded is True
+    by = _by_id(result)
+    assert by["BTC_EXCLUDED"].state == STATE_SATISFIED
+    assert by["SPOT_EXCLUDED"].state == STATE_SATISFIED
+    assert by["KRAKEN_LEGACY_EXCLUDED"].state == STATE_SATISFIED


### PR DESCRIPTION
## Summary

**Inventory only — not Activation.**

- Adds offline, fail-closed `STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0` evaluator + CLI.
- Inventories 16 canonical prerequisites with SATISFIED / UNSATISFIED / ABSENT / INVALID states, blockers, and provenance.
- Canonical current-state result: `STATUS=PASS`, `EVALUATOR_VALID=true`, **`ACTIVATION_ELIGIBLE=false`**, **`STEP_29U_ACTIVATED=false`**.
- Runtime / Scheduler / Network / Orders remain disabled; this implementation GO is not future activation Operator-GO.

### Current blockers (canonical evaluation)
- `STEP_29U_AUDIT_PROVENANCE_COMPLETE:ABSENT`
- `ECONOMIC_VALIDITY_PROVEN:UNSATISFIED`
- `EXPLICIT_FUTURE_OPERATOR_GO_PRESENT:ABSENT`

### Changed-file scope (7)
- `src/ops/step_29u_activation_eligibility_inventory_v0.py`
- `scripts/ops/run_step_29u_activation_eligibility_inventory_v0.py`
- `tests/ops/test_step_29u_activation_eligibility_inventory_v0.py`
- `docs/ops/runbooks/STEP_29U_ACTIVATION_ELIGIBILITY_INVENTORY_V0.md`
- `docs/ops/runbooks/STEP_29U_CANONICAL_BINDING_AND_IMPLEMENTATION_INVENTORY_V0.md`
- `docs/ops/roadmap/CURRENT_FOCUS.md`
- `docs/ops/EVIDENCE_INDEX.md`

### Focused tests
- `tests/ops/test_step_29u_activation_eligibility_inventory_v0.py` — 25 passed (~3s)
- Binding owner smoke: `tests/ops/test_step_29u_canonical_shadow_binding_v0.py` — passed
- CI classification: `PR_BOUNDED_FULL` (`category_central_src_requires_full`)

### Evidence
- Local untracked pre-PR evidence:
  `evidence/ops/step_29u_activation_eligibility_inventory/20260725T225900Z_local_pre_pr/`
- Not post-merge evidence; not committed.

### Non-claims / safety
- No primary-checkout mutation
- No Runtime / Scheduler / Network / Orders activation
- No auto-merge; Draft only; merge not requested

## Test plan
- [x] Focused inventory tests (25)
- [x] CLI distinguishes evaluator PASS from eligibility false
- [x] Ruff format/check on touched Python
- [x] Docs reference targets
- [ ] CI confirmation on Draft PR

Made with [Cursor](https://cursor.com)