### PR TITLE
fix(webui): Cap7 review-server macOS /tmp path identity

### DIFF
--- a/scripts/webui/review_server.sh
+++ b/scripts/webui/review_server.sh
@@ -140,6 +140,16 @@ process_cwd() {
   lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1 || true
 }
 
+# Resolve a directory to its physical path (macOS /tmp -> /private/tmp safe).
+# Bash 3.2 compatible; uses pwd -P (no GNU realpath dependency).
+physical_path() {
+  local target="$1"
+  if [[ -z "$target" || ! -d "$target" ]]; then
+    return 1
+  fi
+  (cd "$target" && pwd -P) 2>/dev/null
+}
+
 listening_pids_on_port() {
   # Prefer lsof; empty string if none
   if command -v lsof >/dev/null 2>&1; then
@@ -163,7 +173,7 @@ pid_list_contains() {
 
 identity_ok() {
   local pid="$1"
-  local cmd cwd
+  local cmd cwd cwd_phys repo_phys
   cmd="$(process_command "$pid")"
   [[ -n "$cmd" ]] || return 1
   # Must be uvicorn ASGI for this app; never trust PID alone.
@@ -183,9 +193,14 @@ identity_ok() {
     *) return 1 ;;
   esac
   cwd="$(process_cwd "$pid")"
-  if [[ -n "$cwd" && "$cwd" != "$REPO_ROOT" ]]; then
-    # Fail closed if cwd is resolvable and not this repo worktree.
-    return 1
+  if [[ -n "$cwd" ]]; then
+    # Compare physical paths so macOS /tmp vs /private/tmp aliases match.
+    cwd_phys="$(physical_path "$cwd" || true)"
+    repo_phys="$(physical_path "$REPO_ROOT" || true)"
+    if [[ -z "$cwd_phys" || -z "$repo_phys" || "$cwd_phys" != "$repo_phys" ]]; then
+      # Fail closed if cwd is resolvable and not this repo worktree.
+      return 1
+    fi
   fi
   return 0
 }

--- a/tests/webui/test_review_server_harness_v1.py
+++ b/tests/webui/test_review_server_harness_v1.py
@@ -9,7 +9,9 @@ import os
 import re
 import socket
 import subprocess
+import sys
 import time
+import uuid
 from pathlib import Path
 from urllib.request import urlopen
 
@@ -18,6 +20,29 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HARNESS = REPO_ROOT / "scripts" / "webui" / "review_server.sh"
 PLAYWRIGHT_WEBSERVER = REPO_ROOT / "scripts" / "webui" / "review_server_playwright_webserver_v1.py"
+
+
+def _harness_physical_path(target: Path | str) -> str:
+    """Invoke the harness physical_path() helper without starting a server."""
+    extract = subprocess.run(
+        [
+            "bash",
+            "-c",
+            r"""
+set -euo pipefail
+eval "$(sed -n '/^physical_path()/,/^}/p' "$1")"
+physical_path "$2"
+""",
+            "physical_path",
+            str(HARNESS),
+            str(target),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert extract.returncode == 0, extract.stdout + extract.stderr
+    return extract.stdout.strip()
 
 
 def _free_port() -> int:
@@ -100,6 +125,52 @@ def test_macos_bash_32_static_compat() -> None:
     assert "readarray" not in text
     assert re.search(r"\buvicorn\b.*--reload", text) is None
     assert "UVICORN_RELOAD=false" in raw
+
+
+def test_identity_ok_uses_physical_path_comparison() -> None:
+    """Static contract: cwd vs REPO_ROOT must not use raw string inequality alone."""
+    raw = HARNESS.read_text(encoding="utf-8")
+    assert "physical_path()" in raw
+    assert "pwd -P" in raw
+    assert "cwd_phys" in raw
+    assert "repo_phys" in raw
+    # Proven bug form must remain gone.
+    assert '[[ -n "$cwd" && "$cwd" != "$REPO_ROOT" ]]' not in raw
+
+
+def test_physical_path_tmp_private_tmp_equivalence_and_distinct_rejection() -> None:
+    """macOS /tmp vs /private/tmp alias equivalence; distinct dirs stay fail-closed."""
+    marker = uuid.uuid4().hex
+    logical_root = Path("/tmp") / f"peak_trade_review_server_path_identity_{marker}"
+    logical_root.mkdir(parents=True, exist_ok=True)
+    other_root = Path("/tmp") / f"peak_trade_review_server_path_identity_other_{marker}"
+    other_root.mkdir(parents=True, exist_ok=True)
+    try:
+        logical = str(logical_root)
+        private_alias = str(Path("/private/tmp") / logical_root.name)
+        assert Path(private_alias).is_dir()
+
+        phys_logical = _harness_physical_path(logical)
+        phys_private = _harness_physical_path(private_alias)
+        assert phys_logical == phys_private
+        assert phys_logical == os.path.realpath(logical)
+
+        if sys.platform == "darwin":
+            # On macOS the lexical forms differ while physical forms match.
+            assert logical != private_alias
+
+        phys_other = _harness_physical_path(other_root)
+        assert phys_other != phys_logical
+
+        # identity_ok comparison contract (physical equality only).
+        assert phys_logical == phys_private
+        assert not (phys_logical == phys_other)
+    finally:
+        for path in (logical_root, other_root):
+            try:
+                path.rmdir()
+            except OSError:
+                pass
 
 
 def test_start_status_idempotent_stop_logs_and_bind(tmp_path: Path, isolated_port: int) -> None:

--- a/tests/webui/test_review_server_harness_v1.py
+++ b/tests/webui/test_review_server_harness_v1.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
+import shutil
 import socket
 import subprocess
 import sys
@@ -43,6 +45,36 @@ physical_path "$2"
     )
     assert extract.returncode == 0, extract.stdout + extract.stderr
     return extract.stdout.strip()
+
+
+def _resolve_uv_bin(tmp_path: Path) -> str:
+    """Prefer real uv; otherwise provide a minimal `uv run` shim for CI matrices."""
+    found = shutil.which("uv")
+    if found:
+        return found
+    shim_dir = tmp_path / "_peak_trade_uv_shim"
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    shim = shim_dir / "uv"
+    if not shim.exists():
+        py = shlex.quote(sys.executable)
+        shim.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            f"PY={py}\n"
+            "# Emulate: uv run python -m uvicorn ... using the active test interpreter.\n"
+            'if [[ "${1:-}" == "run" ]]; then\n'
+            "  shift\n"
+            '  if [[ "${1:-}" == "python" || "${1:-}" == "python3" ]]; then\n'
+            "    shift\n"
+            '    exec "$PY" "$@"\n'
+            "  fi\n"
+            '  exec "$@"\n'
+            "fi\n"
+            'exec "$@"\n',
+            encoding="utf-8",
+        )
+        shim.chmod(0o755)
+    return str(shim)
 
 
 def _free_port() -> int:
@@ -91,12 +123,24 @@ def _base_env(tmp_path: Path, port: int, **overrides: str) -> dict[str, str]:
             "PEAK_TRADE_WEBUI_STOP_TIMEOUT_SECONDS": "15",
             "PEAK_TRADE_WEBUI_HEALTH_PATH": "/api/health",
             "PEAK_TRADE_WEBUI_REVIEW_PATH": "/",
+            "PEAK_TRADE_WEBUI_UV": _resolve_uv_bin(tmp_path),
             "LIVE_AUTHORIZED": "false",
             "ORDERS_ALLOWED": "false",
         }
     )
     env.update(overrides)
     return env
+
+
+@pytest.fixture(autouse=True)
+def _harness_uv_env(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch):
+    """Ensure harness starts work in CI jobs where `uv` is not on PATH."""
+    if shutil.which("uv"):
+        yield
+        return
+    shim_root = tmp_path_factory.mktemp("harness_uv")
+    monkeypatch.setenv("PEAK_TRADE_WEBUI_UV", _resolve_uv_bin(shim_root))
+    yield
 
 
 def _http_code(url: str, timeout: float = 3.0) -> int:
@@ -138,37 +182,47 @@ def test_identity_ok_uses_physical_path_comparison() -> None:
     assert '[[ -n "$cwd" && "$cwd" != "$REPO_ROOT" ]]' not in raw
 
 
-def test_physical_path_tmp_private_tmp_equivalence_and_distinct_rejection() -> None:
-    """macOS /tmp vs /private/tmp alias equivalence; distinct dirs stay fail-closed."""
-    marker = uuid.uuid4().hex
-    logical_root = Path("/tmp") / f"peak_trade_review_server_path_identity_{marker}"
-    logical_root.mkdir(parents=True, exist_ok=True)
-    other_root = Path("/tmp") / f"peak_trade_review_server_path_identity_other_{marker}"
-    other_root.mkdir(parents=True, exist_ok=True)
-    try:
-        logical = str(logical_root)
-        private_alias = str(Path("/private/tmp") / logical_root.name)
-        assert Path(private_alias).is_dir()
+def test_physical_path_tmp_private_tmp_equivalence_and_distinct_rejection(
+    tmp_path: Path,
+) -> None:
+    """Lexical path aliases resolve equal; distinct directories stay fail-closed.
 
-        phys_logical = _harness_physical_path(logical)
-        phys_private = _harness_physical_path(private_alias)
-        assert phys_logical == phys_private
-        assert phys_logical == os.path.realpath(logical)
+    Portable contract uses a symlink alias (Linux CI has no /private/tmp).
+    On macOS, also prove /tmp vs /private/tmp when that alias exists.
+    """
+    real_dir = tmp_path / "real_worktree"
+    real_dir.mkdir()
+    alias_dir = tmp_path / "alias_worktree_link"
+    alias_dir.symlink_to(real_dir, target_is_directory=True)
+    other_dir = tmp_path / "other_worktree"
+    other_dir.mkdir()
 
-        if sys.platform == "darwin":
-            # On macOS the lexical forms differ while physical forms match.
-            assert logical != private_alias
+    assert str(real_dir) != str(alias_dir)
+    phys_real = _harness_physical_path(real_dir)
+    phys_alias = _harness_physical_path(alias_dir)
+    assert phys_real == phys_alias
+    assert phys_real == os.path.realpath(real_dir)
 
-        phys_other = _harness_physical_path(other_root)
-        assert phys_other != phys_logical
+    phys_other = _harness_physical_path(other_dir)
+    assert phys_other != phys_real
+    assert phys_real == phys_alias
+    assert not (phys_real == phys_other)
 
-        # identity_ok comparison contract (physical equality only).
-        assert phys_logical == phys_private
-        assert not (phys_logical == phys_other)
-    finally:
-        for path in (logical_root, other_root):
+    # macOS-only proven production alias when present.
+    private_tmp = Path("/private/tmp")
+    if private_tmp.is_dir():
+        marker = uuid.uuid4().hex
+        logical_root = Path("/tmp") / f"peak_trade_review_server_path_identity_{marker}"
+        logical_root.mkdir(parents=True, exist_ok=True)
+        try:
+            private_alias = private_tmp / logical_root.name
+            assert private_alias.is_dir()
+            assert _harness_physical_path(logical_root) == _harness_physical_path(private_alias)
+            if sys.platform == "darwin":
+                assert str(logical_root) != str(private_alias)
+        finally:
             try:
-                path.rmdir()
+                logical_root.rmdir()
             except OSError:
                 pass
 

--- a/tests/webui/test_review_server_harness_v1.py
+++ b/tests/webui/test_review_server_harness_v1.py
@@ -148,6 +148,18 @@ def _http_code(url: str, timeout: float = 3.0) -> int:
         return int(getattr(resp, "status", 200))
 
 
+def _process_command_line(pid: int) -> str:
+    """Full process argv; avoid truncated `ps args` (Linux default width ~80)."""
+    proc_cmdline = Path(f"/proc/{pid}/cmdline")
+    if proc_cmdline.is_file():
+        raw = proc_cmdline.read_bytes().replace(b"\x00", b" ").decode("utf-8", "replace")
+        return raw.strip()
+    return subprocess.check_output(
+        ["ps", "-ww", "-p", str(pid), "-o", "args="],
+        text=True,
+    ).strip()
+
+
 @pytest.fixture()
 def isolated_port() -> int:
     return _free_port()
@@ -266,7 +278,7 @@ def test_start_status_idempotent_stop_logs_and_bind(tmp_path: Path, isolated_por
 
         # Bind localhost only: process command must include 127.0.0.1 and no --reload
         pid = int(kv["PID"])
-        cmd = subprocess.check_output(["ps", "-p", str(pid), "-o", "args="], text=True)
+        cmd = _process_command_line(pid)
         assert "127.0.0.1" in cmd
         assert "--reload" not in cmd
         assert "src.webui.app:app" in cmd


### PR DESCRIPTION
## Summary
- Repair `identity_ok` in `scripts/webui/review_server.sh` so cwd vs `REPO_ROOT` comparison uses physical paths (`pwd -P`), fixing the proven macOS failure where a healthy listener under `/private/tmp/...` was rejected when the harness resolved `REPO_ROOT` as `/tmp/...`.
- Add focused harness contracts for `/tmp` ↔ `/private/tmp` equivalence and distinct-directory fail-closed rejection.
- No dashboard UI/product changes. Runtime, Orders, Scheduler, Capital, and activation remain unauthorized.

## Proven root cause
On macOS, `/tmp` is a symlink alias of `/private/tmp`. The harness derived `REPO_ROOT` via logical `pwd` (`/tmp/...`) while `lsof` reported process cwd as `/private/tmp/...`. Strict string inequality then failed after `/api/health` already returned 200, and the harness tore down the listener.

## Physical-path equivalence contract
- `physical_path()` resolves directories with `(cd \"$target\" && pwd -P)`.
- `identity_ok` compares `cwd_phys` and `repo_phys`.
- Equivalent aliases pass; genuinely different directories still fail closed.
- Existing fail-closed checks for wrong command, host, port, and `--reload` are unchanged.

## Negative / fail-closed cases preserved
- Unknown port owners remain rejected.
- Non-loopback host bind remains rejected.
- Distinct directories do not compare equal under `physical_path`.
- Wrong PID / non-uvicorn listeners remain rejected by existing command identity checks.

## Test plan
- [x] `tests/webui/test_review_server_harness_v1.py::test_identity_ok_uses_physical_path_comparison`
- [x] `tests/webui/test_review_server_harness_v1.py::test_physical_path_tmp_private_tmp_equivalence_and_distinct_rejection`
- [x] Full focused owner file: `tests/webui/test_review_server_harness_v1.py` (12 passed, 1 skipped)
- [x] Live verify from existing `/tmp` review worktree on port 8001: health 200, `STATUS=RUNNING_HEALTHY`, cwd `/private/tmp/...`, venv from that worktree
- [x] Selector: `CONTRACT_FOCUSED` (`focused_script_or_test_diff`)

## Explicit non-authorization
- LIVE_AUTHORIZED=false
- ORDERS=false
- SCHEDULER=false
- CAPITAL_CHANGE=false
- RUNTIME_ACTIVATION=false
- Capability 8 not started
- No merge authorized by this PR alone


Made with [Cursor](https://cursor.com)