### PR TITLE
docs(market-dashboard): make consumer-only truth explicit

### DIFF
--- a/docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md
+++ b/docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md
@@ -1927,4 +1927,17 @@ CAPITAL_CHANGE=false
 FIRST_ACTION=SEPARATE_EXPLICIT_GO_FOR_OPERATOR_PRODUCT_GATE_OR_SUCCESSOR_SCOPE_ONLY
 ```
 
-Das Dashboard wird damit weder zu früh als neue fachliche Wahrheit gebaut noch so spät, dass fehlende Observability erst nach Vollautonomie sichtbar wird. Es wächst kontrolliert mit der kanonischen Producer-Landschaft und bleibt dauerhaft eine reine Projektion.
+Das Dashboard ist zu keinem Zeitpunkt eine fachliche Wahrheit. Es ist dauerhaft eine reine read-only Projektion der kanonischen Producer-Landschaft und bleibt ausschließlich Consumer kanonischer ReadModels.
+
+```text
+DASHBOARD_IS_CONSUMER_ONLY=true
+DASHBOARD_IS_AUTHORITY=false
+DASHBOARD_IS_TRUTH_OWNER=false
+DASHBOARD_IS_SSOT=false
+SECOND_TRUTH_ALLOWED=false
+CANONICAL_PRODUCERS_REMAIN_OWNERS=true
+MISSING_DATA_REMAINS_FAIL_CLOSED=true
+NO_DOMAIN_LOGIC_IN_UI=true
+NO_RUNTIME_AUTHORITY=true
+NO_WRITE_PATH=true
+```


### PR DESCRIPTION
## Summary
- Removes ambiguous wording that could imply the Market Dashboard becomes a fachliche Wahrheit.
- Explicitly states the dashboard is never SSOT, authority, or owner (`DASHBOARD_IS_SSOT=false`, `DASHBOARD_IS_AUTHORITY=false`, `DASHBOARD_IS_TRUTH_OWNER=false`, `SECOND_TRUTH_ALLOWED=false`).
- Preserves the pure read-only consumer architecture: projection-only of canonical producer outputs / immutable ReadModels; Master V2, Double Play, Dynamic Scope, and Safety remain unchanged.
- No product, Core, Runtime, Strategy, or authority changes.

## Test plan
- [x] Diff is docs-only (1 file): Landscape master runbook
- [x] Canonical CI selector: `NO_OP` (`docs_workflow_or_static_contract_only`)
- [x] Docs reference targets verify PASS
- [x] Docs token policy preflight PASS
- [ ] Operator forensic review of closing invariant wording


Made with [Cursor](https://cursor.com)