### PR TITLE
Secret Hygiene and Redaction Unification V1

### DIFF
--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -1,7 +1,7 @@
 # Security Notes — Peak_Trade Cybersecurity Baseline Pointers
 
 **Scope ID:** `PEAK_TRADE_CYBERSECURITY_BASELINE_REFRESH_V1`
-**Capability overlay:** `CYBER_CI_SUPPLY_CHAIN_HARDENING_V1` (2026-07-26)
+**Capability overlay:** `CYBER_CI_SUPPLY_CHAIN_HARDENING_V1` (2026-07-26); `SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1` (2026-07-26)
 **Last Reviewed (repo-static):** 2026-07-26
 **Mode:** Documentation + pointers to existing SSOT owners. **Non-authorizing.**
 **Does not:** rotate secrets, change GitHub org/repo security toggles, enable live/testnet/orders, or claim unverified scanner results.
@@ -18,6 +18,8 @@
 | Local bounded secret env file contract | [`docs/ops/specs/LOCAL_BOUNDED_SECRET_ENV_FILE_CONTRACT.md`](docs/ops/specs/LOCAL_BOUNDED_SECRET_ENV_FILE_CONTRACT.md) |
 | Optional Semgrep/SAST (default-off concept) | [`docs/ops/specs/SEMGREP_SAST_ADOPTION_CONCEPT_V0.md`](docs/ops/specs/SEMGREP_SAST_ADOPTION_CONCEPT_V0.md) |
 | Optional ZAP/DAST (default-off concept) | [`docs/ops/specs/ZAP_DAST_SHADOW_CONCEPT_V0.md`](docs/ops/specs/ZAP_DAST_SHADOW_CONCEPT_V0.md) |
+| Secret hygiene / canonical redaction owner | [`scripts/security/secret_hygiene_redaction_v1.py`](scripts/security/secret_hygiene_redaction_v1.py) + [`docs/ops/specs/SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1.md`](docs/ops/specs/SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1.md) |
+| Tracked secret-like policy gate | [`scripts/ci/check_tracked_credential_hygiene_policy_v1.py`](scripts/ci/check_tracked_credential_hygiene_policy_v1.py) + [`docs/ops/specs/tracked_credential_like_allowlist_v1.json`](docs/ops/specs/tracked_credential_like_allowlist_v1.json) |
 | Incident handling | [`docs/RUNBOOKS_AND_INCIDENT_HANDLING.md`](docs/RUNBOOKS_AND_INCIDENT_HANDLING.md) |
 | Disaster recovery | [`docs/DISASTER_RECOVERY_RUNBOOK.md`](docs/DISASTER_RECOVERY_RUNBOOK.md) |
 | Required CI contexts (branch protection sync, repo-evidenced) | [`config/ci/required_status_checks.json`](config/ci/required_status_checks.json) |
@@ -71,6 +73,8 @@ Historical remediation notes: [`docs/ops/AUDIT_DEPENDENCY_REMEDIATION_2026-01-07
 | GitHub Secret Protection / Push Protection | **Operator-stated** UI snapshot in credential runbook (2026-05-12) — **not** re-verified by this refresh; humans must re-check UI |
 | gitleaks / detect-secrets in pre-commit | **Not** configured in `.pre-commit-config.yaml` |
 | gitleaks as required PR check | **Not** present |
+| Repo-tracked secret-like policy gate (high-confidence classes) | Present: `scripts/ci/check_tracked_credential_hygiene_policy_v1.py` (fail-closed; no secret values printed) |
+| Canonical redaction marker / adapters | `[REDACTED]` via `scripts/security/secret_hygiene_redaction_v1.py` (logging/diagnostics/evidence/WebUI serialization helpers) |
 | Cursor/AI may access real secret values | **Forbidden** (credential runbook) |
 
 **This refresh did not rotate any secrets and did not change external GitHub security settings.**
@@ -123,7 +127,7 @@ Docs live-enable pattern guard: [`scripts/ci/check_docs_no_live_enable_patterns.
 |----|------|------------------------|
 | RR-CB-001 | Actions tag-pinned, not SHA-pinned | **Closed** by `CYBER_CI_SUPPLY_CHAIN_HARDENING_V1` (full 40-hex SHA pins + regression contract) |
 | RR-CB-002 | Many workflows lack explicit top-level `permissions:` | **Closed** by `CYBER_CI_SUPPLY_CHAIN_HARDENING_V1` (every workflow declares top-level permissions; write allowlist retained) |
-| RR-CB-003 | No required secret-scanning job on every PR | Rely on GitHub Push Protection (operator-stated) + local discipline; optional gitleaks remains human-gated |
+| RR-CB-003 | No required secret-scanning job on every PR | **Partially closed** by `SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1` tracked secret-like policy gate (high-confidence classes + bounded allowlist). Optional gitleaks and GitHub Push Protection remain complementary / operator-stated |
 | RR-CB-004 | Semgrep/SAST not enforced | Accepted default-off per concept |
 | RR-CB-005 | Python 3.9 conditional older pins | Prefer 3.11; drop 3.9 only via explicit support decision |
 | RR-CB-006 | Branch-protection UI state not re-snapshotted in this refresh | Reuse `config/ci/required_status_checks.json`; human UI re-verify when needed |

--- a/docs/ops/specs/SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1.md
+++ b/docs/ops/specs/SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1.md
@@ -1,0 +1,69 @@
+# SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1
+
+**Capability ID:** `SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1`  
+**Mode:** Repository policy + pure redaction utility. **Non-authorizing.**  
+**Does not:** rotate secrets, mutate GitHub security toggles, enable live/testnet/orders, rewrite history, or change Runtime/trading authority.
+
+## Design decision
+
+**Option B — ratify one narrowly scoped canonical redaction owner** because no repository-wide redaction SSOT existed.
+
+| Role | Path |
+|------|------|
+| Canonical redaction owner | [`scripts/security/secret_hygiene_redaction_v1.py`](../../../scripts/security/secret_hygiene_redaction_v1.py) |
+| Tracked secret-like policy gate | [`scripts/ci/check_tracked_credential_hygiene_policy_v1.py`](../../../scripts/ci/check_tracked_credential_hygiene_policy_v1.py) |
+| Bounded allowlist | [`tracked_credential_like_allowlist_v1.json`](tracked_credential_like_allowlist_v1.json) |
+| Regression contracts | [`tests/ci/test_credential_hygiene_redaction_unification_v1.py`](../../../tests/ci/test_credential_hygiene_redaction_unification_v1.py) |
+
+`CONTRACT_ID = secret_hygiene_redaction_v1`. A second module defining the same contract id is forbidden.
+
+## Redaction contract (fail-closed)
+
+| Concern | Rule |
+|---------|------|
+| Marker | `[REDACTED]` (deterministic, unmistakable) |
+| Null / empty | Preserved unchanged (no secret material) |
+| Sensitive keys | Entire value replaced with marker (nested maps included) |
+| Embedded strings | Bearer/Basic tokens, JWT-like, `sk-…`, `AKIA…`, PEM private key blocks, `key=value` assignments, URL userinfo |
+| Headers | `authorization`, `cookie`, `set-cookie`, `x-api-key`, and key-name matches |
+| URLs | Userinfo credentials replaced with bracketless `REDACTED:REDACTED@` (keeps host/path parseable; `[REDACTED]` would break `urlsplit` IPv6 parsing); sensitive query keys replaced with `[REDACTED]` |
+| Nested dict/list/tuple/dataclass | Recursed with depth cap (`MAX_RECURSION_DEPTH`) |
+| Unsupported objects | `[REDACTED:UNSUPPORTED_PAYLOAD]` — never raw `repr` passthrough |
+| Idempotence | Re-redacting already redacted output is stable |
+| Fabrication | Never invents replacement business data |
+
+## Approved boundaries (adapters)
+
+Call these helpers at the serialization/logging edge — do not mutate domain truth solely for display safety:
+
+- `redact_for_logging` / `SecretRedactionLoggingFilter` / `install_logging_redaction_filter`
+- `redact_for_diagnostics`
+- `redact_for_evidence_export`
+- `redact_for_webui_payload` (dashboard remains a pure read-only consumer, not a security authority)
+- `redact_headers`, `redact_exception`, `redact_structured`
+
+## Legacy / incomplete consumers (not second owners)
+
+These remain domain-specific helpers and must not grow parallel policy:
+
+- `src/ai_orchestration/evidence_pack_generator.py` (`_redact_content`) — incomplete local subset; new evidence export paths should call the canonical owner
+- `src/ai_orchestration/model_client.py` (`redact_outbound_envelope`) — allowlist envelope, not general redaction
+- `scripts/ops/run_shadow_bounded_observation_adapter_v0.py` (`_sanitize_command_for_transcript`) — command transcript scrub
+- Private-readonly / order-capability `value_redacted` flags — evidence shape contracts, not string redaction
+
+## Tracked secret-like policy
+
+Gate scans tracked textual files for high-confidence classes (PEM private key headers, AWS access key ids, OpenAI-style keys, JWT-like triples, URL userinfo). Hits outside the bounded allowlist fail closed. Matched values are never printed.
+
+## Residual risks
+
+| ID | Risk | Notes |
+|----|------|-------|
+| RR-SH-001 | Not every historical call site is migrated | Legacy local helpers remain; new boundaries must use the owner |
+| RR-SH-002 | Pattern detection is best-effort | High-entropy opaque secrets without known shape may evade string detectors; sensitive key names still catch structured fields |
+| RR-SH-003 | External gitleaks job still optional | Repo gate covers high-confidence classes; GitHub Push Protection remains operator-stated |
+| RR-SH-004 | Generated artifacts outside git | Untracked local evidence may still need operators to run export through adapters |
+
+## Explicit non-claims
+
+This capability does not claim secret rotation, provider revocation, Git history purge, or Runtime/Live authorization changes.

--- a/docs/ops/specs/tracked_credential_like_allowlist_v1.json
+++ b/docs/ops/specs/tracked_credential_like_allowlist_v1.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "tracked_credential_like_allowlist_v1",
+  "capability_id": "SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1",
+  "notes": [
+    "Allowlist entries must be visibly synthetic/placeholder/fixture and narrowly scoped.",
+    "Never allowlist real credentials. Reasons must state why the hit is safe.",
+    "Entries are path + pattern_class; matched values are never stored here."
+  ],
+  "entries": [
+    {
+      "path": "tests/ci/test_credential_hygiene_redaction_unification_v1.py",
+      "pattern_class": "OPENAI_STYLE_KEY",
+      "bounded": true,
+      "reason": "Synthetic unmistakably fake fixture for redaction regression only."
+    },
+    {
+      "path": "tests/ci/test_credential_hygiene_redaction_unification_v1.py",
+      "pattern_class": "AWS_ACCESS_KEY_ID",
+      "bounded": true,
+      "reason": "Synthetic unmistakably fake fixture for redaction regression only."
+    },
+    {
+      "path": "tests/ci/test_credential_hygiene_redaction_unification_v1.py",
+      "pattern_class": "JWT_LIKE",
+      "bounded": true,
+      "reason": "Synthetic unmistakably fake fixture for redaction regression only."
+    },
+    {
+      "path": "tests/ci/test_credential_hygiene_redaction_unification_v1.py",
+      "pattern_class": "PEM_PRIVATE_KEY",
+      "bounded": true,
+      "reason": "Synthetic unmistakably fake fixture for redaction regression only."
+    },
+    {
+      "path": "tests/ci/test_credential_hygiene_redaction_unification_v1.py",
+      "pattern_class": "URL_USERINFO_CREDENTIAL",
+      "bounded": true,
+      "reason": "Synthetic unmistakably fake fixture for redaction regression only."
+    },
+    {
+      "path": "tests/ai_orchestration/test_evidence_pack_generator.py",
+      "pattern_class": "OPENAI_STYLE_KEY",
+      "bounded": true,
+      "reason": "Pre-existing synthetic fixture asserting local evidence-pack redaction."
+    },
+    {
+      "path": "tests/ai_orchestration/test_evidence_pack_generator.py",
+      "pattern_class": "AWS_ACCESS_KEY_ID",
+      "bounded": true,
+      "reason": "Pre-existing synthetic fixture asserting local evidence-pack redaction."
+    },
+    {
+      "path": "tests/governance/policy_critic/test_rules.py",
+      "pattern_class": "AWS_ACCESS_KEY_ID",
+      "bounded": true,
+      "reason": "Synthetic fixture for policy-critic secret detection rule tests."
+    },
+    {
+      "path": "tests/risk_layer/alerting/channels/test_webhook_channel.py",
+      "pattern_class": "URL_USERINFO_CREDENTIAL",
+      "bounded": true,
+      "reason": "Synthetic webhook URL fixture with placeholder userinfo."
+    },
+    {
+      "path": "docs/MLFLOW_SETUP_GUIDE.md",
+      "pattern_class": "URL_USERINFO_CREDENTIAL",
+      "bounded": true,
+      "reason": "Documentation placeholder database URL examples only."
+    },
+    {
+      "path": "docs/_worklogs/2025-12-23_untracked_salvage/STRATEGY_LAYER_VNEXT_PHASE3_REPORT.md",
+      "pattern_class": "URL_USERINFO_CREDENTIAL",
+      "bounded": true,
+      "reason": "Historical worklog placeholder storage URL example only."
+    },
+    {
+      "path": "docs/ops/AUDIT_VALIDATION_NOTES.md",
+      "pattern_class": "AWS_ACCESS_KEY_ID",
+      "bounded": true,
+      "reason": "Documentation mentions example/test key shape placeholder only."
+    }
+  ]
+}

--- a/scripts/ci/check_tracked_credential_hygiene_policy_v1.py
+++ b/scripts/ci/check_tracked_credential_hygiene_policy_v1.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Fail-closed tracked secret-like policy gate (v1).
+
+Scans tracked textual repository content for high-confidence secret-like
+patterns. Never prints matched secret values — only path, pattern class, and
+line number.
+
+Allowlist: docs/ops/specs/tracked_credential_like_allowlist_v1.json
+Canonical redaction owner: scripts/security/secret_hygiene_redaction_v1.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALLOWLIST_PATH = REPO_ROOT / "docs" / "ops" / "specs" / "tracked_credential_like_allowlist_v1.json"
+
+# High-confidence patterns only. Matched values are never emitted.
+PATTERN_CLASSES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "PEM_PRIVATE_KEY",
+        re.compile(
+            r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----",
+        ),
+    ),
+    ("AWS_ACCESS_KEY_ID", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("OPENAI_STYLE_KEY", re.compile(r"\bsk-[A-Za-z0-9]{20,}\b")),
+    (
+        "JWT_LIKE",
+        re.compile(r"\beyJ[A-Za-z0-9_\-]{20,}\.[A-Za-z0-9_\-]{20,}\.[A-Za-z0-9_\-]{20,}\b"),
+    ),
+    (
+        "URL_USERINFO_CREDENTIAL",
+        re.compile(
+            r"(?i)\b(?:https?|postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis)://"
+            r"[^/\s:@]+:[^/\s@]+@"
+        ),
+    ),
+)
+
+TEXT_SUFFIXES = frozenset(
+    {
+        ".py",
+        ".md",
+        ".txt",
+        ".json",
+        ".yml",
+        ".yaml",
+        ".toml",
+        ".ini",
+        ".cfg",
+        ".env",
+        ".sh",
+        ".bash",
+        ".zsh",
+        ".js",
+        ".ts",
+        ".tsx",
+        ".jsx",
+        ".css",
+        ".html",
+        ".sql",
+        ".csv",
+        ".xml",
+        ".rst",
+        ".ipynb",
+    }
+)
+
+SKIP_PREFIXES = (
+    ".git/",
+    "out/",
+    "reports/",
+    "docs/reports/",
+    "node_modules/",
+    ".venv/",
+    "venv/",
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line_no: int
+    pattern_class: str
+
+
+def _git_tracked_files() -> list[str]:
+    proc = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    raw = proc.stdout.split(b"\0")
+    out: list[str] = []
+    for item in raw:
+        if not item:
+            continue
+        try:
+            out.append(item.decode("utf-8"))
+        except UnicodeDecodeError:
+            continue
+    return out
+
+
+def _is_candidate(path: str) -> bool:
+    if any(path.startswith(prefix) for prefix in SKIP_PREFIXES):
+        return False
+    p = Path(path)
+    if p.suffix.lower() in TEXT_SUFFIXES:
+        return True
+    # Extensionless tracked policy/text files commonly named exactly.
+    name = p.name.lower()
+    return name in {"dockerfile", "makefile", "jenkinsfile", "license", "readme"}
+
+
+def _load_allowlist() -> dict[str, object]:
+    if not ALLOWLIST_PATH.is_file():
+        raise FileNotFoundError(f"allowlist missing: {ALLOWLIST_PATH}")
+    data = json.loads(ALLOWLIST_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("allowlist root must be object")
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("allowlist.entries must be list")
+    return data
+
+
+def _allowlisted(path: str, pattern_class: str, allowlist: dict[str, object]) -> bool:
+    entries = allowlist.get("entries", [])
+    assert isinstance(entries, list)
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("path") == path and entry.get("pattern_class") == pattern_class:
+            reason = str(entry.get("reason") or "")
+            if (
+                "synthetic" in reason.lower()
+                or "placeholder" in reason.lower()
+                or "fixture" in reason.lower()
+            ):
+                return True
+            # Fail closed: allowlist reasons must be visibly bounded.
+            if entry.get("bounded") is True:
+                return True
+    return False
+
+
+def scan_text(path: str, text: str, allowlist: dict[str, object]) -> list[Finding]:
+    findings: list[Finding] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for pattern_class, rx in PATTERN_CLASSES:
+            if not rx.search(line):
+                continue
+            if _allowlisted(path, pattern_class, allowlist):
+                continue
+            findings.append(Finding(path=path, line_no=line_no, pattern_class=pattern_class))
+    return findings
+
+
+def scan_repo(paths: Iterable[str] | None = None) -> list[Finding]:
+    allowlist = _load_allowlist()
+    tracked = list(paths) if paths is not None else _git_tracked_files()
+    findings: list[Finding] = []
+    for rel in tracked:
+        if not _is_candidate(rel):
+            continue
+        abs_path = REPO_ROOT / rel
+        if not abs_path.is_file():
+            continue
+        try:
+            text = abs_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        except OSError:
+            continue
+        findings.extend(scan_text(rel, text, allowlist))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--paths-file",
+        help="Optional file with repo-relative paths to scan (one per line).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine JSON summary (no secret values).",
+    )
+    args = parser.parse_args(argv)
+
+    paths: list[str] | None = None
+    try:
+        if args.paths_file:
+            paths = [
+                line.strip()
+                for line in Path(args.paths_file).read_text(encoding="utf-8").splitlines()
+                if line.strip() and not line.strip().startswith("#")
+            ]
+        findings = scan_repo(paths)
+    except Exception as exc:  # fail closed
+        print(f"TRACKED_SECRET_POLICY_GATE=FAIL reason={type(exc).__name__}", file=sys.stderr)
+        return 2
+
+    summary = {
+        "gate": "tracked_credential_hygiene_policy_v1",
+        "findings_count": len(findings),
+        "findings": [
+            {
+                "path": f.path,
+                "line_no": f.line_no,
+                "pattern_class": f.pattern_class,
+                "secret_value_exposed": False,
+            }
+            for f in findings
+        ],
+        "secret_value_exposed": False,
+        "allowlist_path": str(ALLOWLIST_PATH.relative_to(REPO_ROOT)),
+    }
+
+    if args.json:
+        print(json.dumps(summary, sort_keys=True, indent=2))
+    else:
+        if findings:
+            print("TRACKED_SECRET_POLICY_GATE=FAIL")
+            for f in findings:
+                # Never print matched values.
+                print(f"SECRET_LIKE_HIT path={f.path} line={f.line_no} class={f.pattern_class}")
+        else:
+            print("TRACKED_SECRET_POLICY_GATE=PASS")
+            print("SECRET_VALUE_EXPOSED=false")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/security/__init__.py
+++ b/scripts/security/__init__.py
@@ -1,0 +1,3 @@
+"""Peak_Trade security scripts package (non-authorizing helpers)."""
+
+from __future__ import annotations

--- a/scripts/security/secret_hygiene_redaction_v1.py
+++ b/scripts/security/secret_hygiene_redaction_v1.py
@@ -1,0 +1,403 @@
+"""SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1 — canonical redaction owner.
+
+Capability: SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1
+Contract ID: secret_hygiene_redaction_v1
+
+Design decision: Option B — ratify one narrowly scoped canonical redaction owner
+because no repository-wide redaction SSOT existed. Fragmented local helpers
+(evidence_pack_generator._redact_content, model_client.redact_outbound_envelope,
+bounded shadow command sanitizer, private-readonly allowlists) remain legacy
+consumers and must not grow parallel policy; new serialization/logging/diagnostics
+/evidence boundaries must call this module.
+
+Non-authorizing. Does not rotate secrets, mutate Runtime/trading authority,
+or rewrite Git history. Dashboard/read-model callers remain pure consumers.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlsplit, urlunsplit
+
+CONTRACT_ID = "secret_hygiene_redaction_v1"
+CONTRACT_VERSION = "v1"
+CAPABILITY_ID = "SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1"
+REDACTION_MARKER = "[REDACTED]"
+UNSUPPORTED_PAYLOAD_MARKER = "[REDACTED:UNSUPPORTED_PAYLOAD]"
+MAX_RECURSION_DEPTH = 32
+MAX_STRING_CHARS = 1_000_000
+
+# Exact / suffix-oriented sensitive key names (case-insensitive match on
+# normalized key: lower, non-alnum -> underscore).
+SENSITIVE_KEY_NAMES: frozenset[str] = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "api_secret",
+        "apisecret",
+        "access_key",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "client_secret",
+        "client_secret_key",
+        "password",
+        "passwd",
+        "passphrase",
+        "secret",
+        "secrets",
+        "token",
+        "auth_token",
+        "authorization",
+        "proxy_authorization",
+        "cookie",
+        "set_cookie",
+        "session",
+        "session_id",
+        "csrf_token",
+        "confirm_token",
+        "webhook_secret",
+        "private_key",
+        "privatekey",
+        "ssh_key",
+        "signing_key",
+        "aws_secret_access_key",
+        "aws_access_key_id",
+        "database_url",
+        "db_url",
+        "db_password",
+        "redis_url",
+        "mongo_uri",
+        "connection_string",
+        "credentials",
+        "credential",
+        "exchange_api_key",
+        "exchange_secret",
+        "okx_api_key",
+        "okx_secret_key",
+        "okx_passphrase",
+        "kraken_api_key",
+        "kraken_api_secret",
+        "binance_api_key",
+        "binance_api_secret",
+    }
+)
+
+SENSITIVE_HEADER_NAMES: frozenset[str] = frozenset(
+    {
+        "authorization",
+        "proxy-authorization",
+        "cookie",
+        "set-cookie",
+        "x-api-key",
+        "x-auth-token",
+        "x-amz-security-token",
+    }
+)
+
+_BEARER_RX = re.compile(r"(?i)\b(Bearer)\s+([A-Za-z0-9_\-\.\/=+]+)")
+_BASIC_AUTH_HEADER_RX = re.compile(r"(?i)\b(Basic)\s+([A-Za-z0-9_\-\.\/=+]+)")
+_SK_RX = re.compile(r"\bsk-[A-Za-z0-9]{20,}\b")
+_AKIA_RX = re.compile(r"\bAKIA[0-9A-Z]{16}\b")
+_JWT_RX = re.compile(r"\beyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\b")
+_PEM_BLOCK_RX = re.compile(
+    r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----",
+    re.DOTALL,
+)
+_ASSIGNMENT_RX = re.compile(
+    r"(?i)\b(api[_-]?key|api[_-]?secret|client[_-]?secret|access[_-]?token|"
+    r"refresh[_-]?token|password|passwd|passphrase|secret|token|authorization|"
+    r"cookie|set[_-]?cookie|session)"
+    r"\s*[=:]\s*([^\s\"']+)"
+)
+_URL_USERINFO_RX = re.compile(
+    r"(?i)\b((?:https?|postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp)://)"
+    r"([^/\s:@]+):([^/\s@]+)@"
+)
+# Bracketless placeholder keeps urlsplit host/path intact ([REDACTED] looks like IPv6).
+_URL_USERINFO_PLACEHOLDER = "REDACTED:REDACTED@"
+
+
+def _normalize_key(key: Any) -> str:
+    text = str(key).strip().lower()
+    return re.sub(r"[^a-z0-9]+", "_", text).strip("_")
+
+
+def is_sensitive_key(key: Any) -> bool:
+    """Return True when a mapping key is treated as secret-bearing."""
+    normalized = _normalize_key(key)
+    if not normalized:
+        return False
+    if normalized in SENSITIVE_KEY_NAMES:
+        return True
+    # Suffix / compound forms: foo_api_key, my_password, auth_token_value
+    for marker in (
+        "api_key",
+        "api_secret",
+        "access_token",
+        "refresh_token",
+        "client_secret",
+        "private_key",
+        "password",
+        "passphrase",
+        "webhook_secret",
+        "secret_key",
+        "auth_token",
+    ):
+        if normalized == marker or normalized.endswith("_" + marker):
+            return True
+    if normalized.endswith("_secret") or normalized.endswith("_token"):
+        return True
+    return False
+
+
+def redact_string(value: str) -> str:
+    """Redact embedded credential-like fragments in a string. Idempotent."""
+    if value is None:  # type: ignore[unreachable]
+        return value
+    if not isinstance(value, str):
+        raise TypeError("redact_string expects str")
+    if value == "" or value == REDACTION_MARKER or value == UNSUPPORTED_PAYLOAD_MARKER:
+        return value
+    if len(value) > MAX_STRING_CHARS:
+        # Fail closed: oversized opaque blobs are not passed through raw.
+        return REDACTION_MARKER
+
+    out = value
+    if REDACTION_MARKER in out and not _still_contains_secret_like(out):
+        # Already fully redacted for detectable classes.
+        pass
+
+    out = _PEM_BLOCK_RX.sub(REDACTION_MARKER, out)
+    out = _BEARER_RX.sub(rf"\1 {REDACTION_MARKER}", out)
+    out = _BASIC_AUTH_HEADER_RX.sub(rf"\1 {REDACTION_MARKER}", out)
+    out = _JWT_RX.sub(REDACTION_MARKER, out)
+    out = _SK_RX.sub(REDACTION_MARKER, out)
+    out = _AKIA_RX.sub(REDACTION_MARKER, out)
+    out = _ASSIGNMENT_RX.sub(rf"\1={REDACTION_MARKER}", out)
+    out = _URL_USERINFO_RX.sub(rf"\1{_URL_USERINFO_PLACEHOLDER}", out)
+    out = _redact_url_query_secrets(out)
+    return out
+
+
+def _still_contains_secret_like(text: str) -> bool:
+    probes = (_PEM_BLOCK_RX, _BEARER_RX, _BASIC_AUTH_HEADER_RX, _JWT_RX, _SK_RX, _AKIA_RX)
+    return any(rx.search(text) for rx in probes)
+
+
+def _redact_url_query_secrets(text: str) -> str:
+    """Redact credential-bearing query parameters while keeping host/path."""
+
+    def _rewrite_match(match: re.Match[str]) -> str:
+        raw = match.group(0)
+        try:
+            parts = urlsplit(raw)
+        except ValueError:
+            return REDACTION_MARKER
+        if not parts.scheme or not parts.netloc:
+            return raw
+        if not parts.query:
+            return raw
+        pairs: list[str] = []
+        for item in parts.query.split("&"):
+            if not item:
+                continue
+            if "=" not in item:
+                pairs.append(item)
+                continue
+            key, _val = item.split("=", 1)
+            if is_sensitive_key(key):
+                pairs.append(f"{key}={REDACTION_MARKER}")
+            else:
+                pairs.append(item)
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, "&".join(pairs), parts.fragment))
+
+    return re.sub(r"https?://[^\s\"'<>]+", _rewrite_match, text)
+
+
+def redact_headers(headers: Mapping[Any, Any] | None) -> dict[str, Any]:
+    """Redact HTTP header maps. Preserves non-sensitive header names/values."""
+    if headers is None:
+        return {}
+    if not isinstance(headers, Mapping):
+        return {"_redaction_status": UNSUPPORTED_PAYLOAD_MARKER}
+    out: dict[str, Any] = {}
+    for key, value in headers.items():
+        key_text = str(key)
+        if key_text.lower() in SENSITIVE_HEADER_NAMES or is_sensitive_key(key_text):
+            out[key_text] = REDACTION_MARKER
+        elif isinstance(value, str):
+            out[key_text] = redact_string(value)
+        else:
+            out[key_text] = redact_structured(value, _depth=1)
+    return out
+
+
+def redact_structured(payload: Any, *, _depth: int = 0) -> Any:
+    """Recursively redact mappings/sequences/dataclasses/strings.
+
+    Fail-closed:
+    - depth overflow -> REDACTION_MARKER
+    - unsupported object types -> UNSUPPORTED_PAYLOAD_MARKER (never raw repr)
+    - never fabricates replacement business data
+    """
+    if _depth > MAX_RECURSION_DEPTH:
+        return REDACTION_MARKER
+
+    if payload is None or isinstance(payload, bool):
+        return payload
+    if isinstance(payload, (int, float)):
+        return payload
+    if isinstance(payload, str):
+        return redact_string(payload)
+    if isinstance(payload, bytes):
+        # Opaque bytes are not decoded into possibly-secret text.
+        return REDACTION_MARKER
+    if is_dataclass(payload) and not isinstance(payload, type):
+        try:
+            return redact_structured(asdict(payload), _depth=_depth + 1)
+        except Exception:
+            return UNSUPPORTED_PAYLOAD_MARKER
+    if isinstance(payload, Mapping):
+        out: dict[Any, Any] = {}
+        for key, value in payload.items():
+            if is_sensitive_key(key):
+                # Preserve empty/null as-is (no secret material).
+                if value is None or value == "":
+                    out[key] = value
+                else:
+                    out[key] = REDACTION_MARKER
+            else:
+                out[key] = redact_structured(value, _depth=_depth + 1)
+        return out
+    if isinstance(payload, tuple):
+        return tuple(redact_structured(item, _depth=_depth + 1) for item in payload)
+    if isinstance(payload, list):
+        return [redact_structured(item, _depth=_depth + 1) for item in payload]
+    if isinstance(payload, set):
+        # Deterministic ordering for testability.
+        return {redact_structured(item, _depth=_depth + 1) for item in sorted(payload, key=repr)}
+    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+        return [redact_structured(item, _depth=_depth + 1) for item in payload]
+
+    # Fail closed: do not pass through unknown objects via repr/str.
+    return UNSUPPORTED_PAYLOAD_MARKER
+
+
+def redact_exception(exc: BaseException) -> str:
+    """Render an exception for logs/diagnostics without raw secret passthrough."""
+    cls = type(exc).__name__
+    msg = redact_string(str(exc))
+    return f"{cls}: {msg}"
+
+
+def redact_for_logging(message: Any, *args: Any) -> str:
+    """Boundary helper for log messages (and %-style args already interpolated)."""
+    if args:
+        try:
+            rendered = str(message) % args
+        except Exception:
+            rendered = f"{message!s} | args={REDACTION_MARKER}"
+    else:
+        rendered = message if isinstance(message, str) else str(message)
+    return redact_string(rendered)
+
+
+def redact_for_diagnostics(payload: Any) -> Any:
+    """Boundary helper for diagnostics / audit payloads."""
+    return redact_structured(payload)
+
+
+def redact_for_evidence_export(payload: Any) -> Any:
+    """Boundary helper for evidence / report export serialization."""
+    return redact_structured(payload)
+
+
+def redact_for_webui_payload(payload: Any) -> Any:
+    """Boundary helper for dashboard/API/read-model serialization.
+
+    Dashboard remains a pure read-only consumer and not a security authority;
+    this helper is the approved serialization-edge redaction.
+    """
+    return redact_structured(payload)
+
+
+def assert_no_raw_secret(output: Any, synthetic_secret: str) -> None:
+    """Test helper: fail if a complete synthetic secret appears in output."""
+    if not synthetic_secret:
+        raise ValueError("synthetic_secret must be non-empty")
+    blob = output if isinstance(output, str) else repr(output)
+    if synthetic_secret in blob:
+        raise AssertionError("synthetic secret leaked into redacted output")
+
+
+class SecretRedactionLoggingFilter(logging.Filter):
+    """Logging filter that redacts secret-like content at the logging boundary."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+        except Exception:
+            record.msg = REDACTION_MARKER
+            record.args = ()
+            return True
+        redacted = redact_string(msg)
+        record.msg = redacted
+        record.args = ()
+        # Also scrub common extra fields if present.
+        for attr in ("api_key", "token", "password", "authorization", "secret"):
+            if hasattr(record, attr):
+                setattr(record, attr, REDACTION_MARKER)
+        return True
+
+
+def install_logging_redaction_filter(
+    logger: logging.Logger | None = None,
+) -> SecretRedactionLoggingFilter:
+    """Attach the canonical redaction filter to a logger (root if None)."""
+    target = logger if logger is not None else logging.getLogger()
+    existing = [f for f in target.filters if isinstance(f, SecretRedactionLoggingFilter)]
+    if existing:
+        return existing[0]
+    filt = SecretRedactionLoggingFilter()
+    target.addFilter(filt)
+    return filt
+
+
+def owner_identity() -> dict[str, str]:
+    """Machine-readable owner identity for uniqueness contracts."""
+    return {
+        "capability_id": CAPABILITY_ID,
+        "contract_id": CONTRACT_ID,
+        "contract_version": CONTRACT_VERSION,
+        "redaction_marker": REDACTION_MARKER,
+        "module": "scripts.security.secret_hygiene_redaction_v1",
+    }
+
+
+__all__ = [
+    "CAPABILITY_ID",
+    "CONTRACT_ID",
+    "CONTRACT_VERSION",
+    "MAX_RECURSION_DEPTH",
+    "REDACTION_MARKER",
+    "SENSITIVE_HEADER_NAMES",
+    "SENSITIVE_KEY_NAMES",
+    "UNSUPPORTED_PAYLOAD_MARKER",
+    "SecretRedactionLoggingFilter",
+    "assert_no_raw_secret",
+    "install_logging_redaction_filter",
+    "is_sensitive_key",
+    "owner_identity",
+    "redact_exception",
+    "redact_for_diagnostics",
+    "redact_for_evidence_export",
+    "redact_for_logging",
+    "redact_for_webui_payload",
+    "redact_headers",
+    "redact_string",
+    "redact_structured",
+]

--- a/tests/ci/test_ci_export_pack_download_verify_workflow_contract_v0.py
+++ b/tests/ci/test_ci_export_pack_download_verify_workflow_contract_v0.py
@@ -7,6 +7,7 @@ and never touch remote export-pack storage.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,7 @@ import pytest
 yaml = pytest.importorskip("yaml")
 
 WORKFLOW = Path(".github/workflows/ci-export-pack-download-verify.yml")
+_SHA_PIN_RX = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 
 
 def _workflow() -> dict[str, Any]:
@@ -90,16 +92,22 @@ def test_workflow_job_permissions_do_not_grant_write_all() -> None:
 
 
 def test_workflow_uses_expected_pinned_core_actions_only() -> None:
+    """Core Actions must be full 40-hex SHA pins (CYBER_CI_SUPPLY_CHAIN_HARDENING_V1)."""
     data = _workflow()
     uses_values = [step["uses"] for step in _all_steps(data) if isinstance(step.get("uses"), str)]
 
-    assert "actions/checkout@v5" in uses_values
-    assert any(value.startswith("actions/setup-python@v") for value in uses_values)
+    checkout_refs = [v for v in uses_values if v.startswith("actions/checkout@")]
+    setup_python_refs = [v for v in uses_values if v.startswith("actions/setup-python@")]
+    assert checkout_refs
+    assert setup_python_refs
 
     for value in uses_values:
         assert "@" in value
+        ref = value.rsplit("@", 1)[1]
+        assert _SHA_PIN_RX.fullmatch(ref), f"expected full SHA pin, got {value!r}"
         assert not value.endswith("@main")
         assert not value.endswith("@master")
+        assert not re.search(r"@v\d+", value), f"tag-only pin forbidden: {value!r}"
 
 
 def test_workflow_contains_guardrails_before_rclone_steps() -> None:

--- a/tests/ci/test_credential_hygiene_redaction_unification_v1.py
+++ b/tests/ci/test_credential_hygiene_redaction_unification_v1.py
@@ -1,0 +1,367 @@
+"""SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1 — regression contracts.
+
+Synthetic fixtures only. Never assert by printing secret values into
+diagnostics beyond pytest failure diffs on already-synthetic strings.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+import scripts.ci.check_tracked_credential_hygiene_policy_v1 as policy_gate
+import scripts.security.secret_hygiene_redaction_v1 as redaction
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OWNER_MODULE = REPO_ROOT / "scripts" / "security" / "secret_hygiene_redaction_v1.py"
+SPEC_DOC = REPO_ROOT / "docs" / "ops" / "specs" / "SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1.md"
+SECURITY_NOTES = REPO_ROOT / "SECURITY_NOTES.md"
+ALLOWLIST = REPO_ROOT / "docs" / "ops" / "specs" / "tracked_credential_like_allowlist_v1.json"
+
+# Unmistakably fake synthetic values (fixtures only).
+SYN_API_KEY = "sk-SYNTHETICFAKEOPENAISTYLEKEY0000001"
+SYN_AWS_KEY = "AKIAFAKESYNTH0000001"
+SYN_JWT = "eyJhbGciOiJSYNTHETICIn0.eyJzdWIiOiJzeW50aGV0aWMtZmFrZSJ9.SYNTHETICFAKESIGNATUREVALUE0001"
+SYN_PASSWORD = "synth-password-NOT-REAL-0001"
+SYN_BEARER = "synth-bearer-token-NOT-REAL-0001"
+SYN_COOKIE = "session=synth-cookie-NOT-REAL-0001"
+SYN_PEM_BODY = (
+    "-----BEGIN PRIVATE KEY-----\nSYNTHETIC_PEM_BODY_NOT_A_REAL_KEY_0001\n-----END PRIVATE KEY-----"
+)
+SYN_URL = (
+    "https://synth_user:synth_pass_NOT_REAL@example.test/v1/orders?api_key=synth-query-NOT-REAL"
+)
+
+
+def test_owner_identity_and_marker() -> None:
+    identity = redaction.owner_identity()
+    assert identity["contract_id"] == "secret_hygiene_redaction_v1"
+    assert identity["capability_id"] == "SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1"
+    assert identity["redaction_marker"] == "[REDACTED]"
+    assert redaction.REDACTION_MARKER == "[REDACTED]"
+    assert OWNER_MODULE.is_file()
+    assert SPEC_DOC.is_file()
+
+
+def test_architecture_owner_uniqueness() -> None:
+    """Exactly one module may declare the canonical contract id."""
+    import subprocess
+
+    hits: list[str] = []
+    needle = re.compile(r'CONTRACT_ID\s*=\s*"secret_hygiene_redaction_v1"')
+    tracked = subprocess.check_output(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "-z", "--", "*.py"],
+        text=False,
+    ).split(b"\0")
+    untracked = subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(REPO_ROOT),
+            "ls-files",
+            "-z",
+            "--others",
+            "--exclude-standard",
+            "--",
+            "*.py",
+        ],
+        text=False,
+    ).split(b"\0")
+    rels = []
+    for raw in tracked + untracked:
+        if not raw:
+            continue
+        rels.append(raw.decode("utf-8"))
+    for rel in sorted(set(rels)):
+        path = REPO_ROOT / rel
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if needle.search(text):
+            hits.append(rel)
+    assert hits == ["scripts/security/secret_hygiene_redaction_v1.py"]
+
+
+def test_sensitive_field_names_redacted() -> None:
+    payload = {
+        "api_key": SYN_API_KEY,
+        "password": SYN_PASSWORD,
+        "authorization": f"Bearer {SYN_BEARER}",
+        "cookie": SYN_COOKIE,
+        "client_secret": "synth-client-secret-NOT-REAL",
+        "refresh_token": "synth-refresh-NOT-REAL",
+        "ok": "safe-value",
+        "count": 3,
+        "empty_secret": "",
+        "null_token": None,
+    }
+    out = redaction.redact_structured(payload)
+    assert out["api_key"] == redaction.REDACTION_MARKER
+    assert out["password"] == redaction.REDACTION_MARKER
+    assert out["authorization"] == redaction.REDACTION_MARKER
+    assert out["cookie"] == redaction.REDACTION_MARKER
+    assert out["client_secret"] == redaction.REDACTION_MARKER
+    assert out["refresh_token"] == redaction.REDACTION_MARKER
+    assert out["ok"] == "safe-value"
+    assert out["count"] == 3
+    assert out["empty_secret"] == ""
+    assert out["null_token"] is None
+    redaction.assert_no_raw_secret(out, SYN_API_KEY)
+    redaction.assert_no_raw_secret(out, SYN_PASSWORD)
+    redaction.assert_no_raw_secret(out, SYN_BEARER)
+
+
+def test_embedded_token_formats_redacted() -> None:
+    raw = f"call with Bearer {SYN_BEARER} and key {SYN_API_KEY} aws={SYN_AWS_KEY} jwt={SYN_JWT}"
+    out = redaction.redact_string(raw)
+    assert "Bearer [REDACTED]" in out
+    assert SYN_BEARER not in out
+    assert SYN_API_KEY not in out
+    assert SYN_AWS_KEY not in out
+    assert SYN_JWT not in out
+    assert redaction.REDACTION_MARKER in out
+
+
+def test_headers_and_cookies_redacted() -> None:
+    headers = {
+        "Authorization": f"Bearer {SYN_BEARER}",
+        "Cookie": SYN_COOKIE,
+        "X-Api-Key": SYN_API_KEY,
+        "Content-Type": "application/json",
+        "X-Request-Id": "req-safe-001",
+    }
+    out = redaction.redact_headers(headers)
+    assert out["Authorization"] == redaction.REDACTION_MARKER
+    assert out["Cookie"] == redaction.REDACTION_MARKER
+    assert out["X-Api-Key"] == redaction.REDACTION_MARKER
+    assert out["Content-Type"] == "application/json"
+    assert out["X-Request-Id"] == "req-safe-001"
+    redaction.assert_no_raw_secret(out, SYN_BEARER)
+    redaction.assert_no_raw_secret(out, SYN_COOKIE)
+    redaction.assert_no_raw_secret(out, SYN_API_KEY)
+
+
+def test_credential_bearing_url_redacted_preserves_host_path() -> None:
+    out = redaction.redact_string(SYN_URL)
+    assert "example.test" in out
+    assert "/v1/orders" in out
+    assert "synth_user" not in out
+    assert "synth_pass_NOT_REAL" not in out
+    assert "synth-query-NOT-REAL" not in out
+    assert "api_key=[REDACTED]" in out
+    assert "REDACTED:REDACTED@" in out
+
+
+def test_nested_structures_and_dataclass() -> None:
+    @dataclass(frozen=True)
+    class Row:
+        instrument: str
+        api_key: str
+        note: str
+
+    payload = {
+        "rows": [
+            {"token": SYN_BEARER, "symbol": "BTC-USD"},
+            ("keep", f"password={SYN_PASSWORD}"),
+        ],
+        "meta": Row(
+            instrument="ETH-USD",
+            api_key=SYN_API_KEY,
+            note=f"Bearer {SYN_BEARER}",
+        ),
+        "flags": (True, False, None),
+    }
+    out = redaction.redact_structured(payload)
+    assert out["rows"][0]["token"] == redaction.REDACTION_MARKER
+    assert out["rows"][0]["symbol"] == "BTC-USD"
+    assert out["rows"][1][0] == "keep"
+    assert out["rows"][1][1] == f"password={redaction.REDACTION_MARKER}"
+    assert SYN_PASSWORD not in out["rows"][1][1]
+    assert out["meta"]["instrument"] == "ETH-USD"
+    assert out["meta"]["api_key"] == redaction.REDACTION_MARKER
+    assert SYN_BEARER not in out["meta"]["note"]
+    assert out["flags"] == (True, False, None)
+    redaction.assert_no_raw_secret(out, SYN_API_KEY)
+    redaction.assert_no_raw_secret(out, SYN_PASSWORD)
+
+
+def test_redaction_idempotent_and_never_returns_original() -> None:
+    raw = f"Authorization: Bearer {SYN_BEARER}; key={SYN_API_KEY}"
+    once = redaction.redact_string(raw)
+    twice = redaction.redact_string(once)
+    assert once == twice
+    assert once != raw
+    assert SYN_BEARER not in once
+    assert SYN_API_KEY not in once
+
+
+def test_does_not_fabricate_business_data() -> None:
+    payload = {"pnl": 12.5, "status": "ok", "api_key": SYN_API_KEY}
+    out = redaction.redact_structured(payload)
+    assert out["pnl"] == 12.5
+    assert out["status"] == "ok"
+    assert out["api_key"] == redaction.REDACTION_MARKER
+    # Marker is not a plausible fabricated pnl/status substitute.
+    assert out["api_key"] != SYN_API_KEY
+    assert out["api_key"] != ""
+    assert out["api_key"] != "ok"
+
+
+def test_safe_ordinary_values_unchanged() -> None:
+    payload = {
+        "instrument_id": "BTC-USD-SWAP",
+        "reason_codes": ["NO_SIGNAL", "WARMUP"],
+        "mark_price": 101.25,
+        "summary": "all clear",
+    }
+    assert redaction.redact_structured(payload) == payload
+    assert redaction.redact_string("hello world") == "hello world"
+
+
+def test_logging_boundary_filter_redacts() -> None:
+    logger = logging.getLogger("peak_trade.secret_hygiene.test")
+    logger.handlers.clear()
+    logger.filters.clear()
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+    redaction.install_logging_redaction_filter(logger)
+
+    logger.info("auth Bearer %s key=%s", SYN_BEARER, SYN_API_KEY)
+    text = stream.getvalue()
+    assert SYN_BEARER not in text
+    assert SYN_API_KEY not in text
+    assert redaction.REDACTION_MARKER in text
+    assert redaction.redact_for_logging(f"cookie={SYN_COOKIE}")
+    redaction.assert_no_raw_secret(redaction.redact_for_logging(f"cookie={SYN_COOKIE}"), SYN_COOKIE)
+
+
+def test_diagnostics_and_evidence_and_webui_boundaries() -> None:
+    diag = {
+        "error_category": "AUTH_REJECTED",
+        "source_class": "ExchangeClient",
+        "authorization": f"Bearer {SYN_BEARER}",
+        "detail": f"url={SYN_URL}",
+    }
+    for fn in (
+        redaction.redact_for_diagnostics,
+        redaction.redact_for_evidence_export,
+        redaction.redact_for_webui_payload,
+    ):
+        out = fn(diag)
+        assert out["error_category"] == "AUTH_REJECTED"
+        assert out["source_class"] == "ExchangeClient"
+        assert out["authorization"] == redaction.REDACTION_MARKER
+        redaction.assert_no_raw_secret(out, SYN_BEARER)
+        redaction.assert_no_raw_secret(out, "synth_pass_NOT_REAL")
+
+
+def test_exception_and_pem_and_fail_closed_unsupported() -> None:
+    exc = RuntimeError(f"upstream Authorization: Bearer {SYN_BEARER}")
+    rendered = redaction.redact_exception(exc)
+    assert rendered.startswith("RuntimeError:")
+    assert SYN_BEARER not in rendered
+
+    pem_out = redaction.redact_string(f"keymaterial:\n{SYN_PEM_BODY}")
+    assert "BEGIN PRIVATE KEY" not in pem_out
+    assert "SYNTHETIC_PEM_BODY" not in pem_out
+
+    class Weird:
+        def __repr__(self) -> str:
+            return f"Weird(api_key={SYN_API_KEY})"
+
+    unsupported = redaction.redact_structured({"x": Weird()})
+    assert unsupported["x"] == redaction.UNSUPPORTED_PAYLOAD_MARKER
+    redaction.assert_no_raw_secret(unsupported, SYN_API_KEY)
+
+
+def test_tracked_secret_policy_gate_pass_on_repo() -> None:
+    findings = policy_gate.scan_repo()
+    # Never include matched values in assertions beyond class/path.
+    assert findings == []
+    assert ALLOWLIST.is_file()
+    allow = json.loads(ALLOWLIST.read_text(encoding="utf-8"))
+    assert allow["schema_version"] == "tracked_credential_like_allowlist_v1"
+    assert isinstance(allow["entries"], list)
+    for entry in allow["entries"]:
+        assert entry.get("bounded") is True
+        reason = str(entry.get("reason") or "").lower()
+        assert any(
+            token in reason
+            for token in (
+                "synthetic",
+                "placeholder",
+                "fixture",
+                "pattern definition",
+                "documentation",
+            )
+        )
+
+
+def test_tracked_secret_policy_gate_rejects_new_secret_like(tmp_path: Path) -> None:
+    allow = json.loads(ALLOWLIST.read_text(encoding="utf-8"))
+    findings = policy_gate.scan_text(
+        "unallowlisted_synthetic_probe.txt",
+        f"token={SYN_API_KEY}\n",
+        allow,
+    )
+    assert any(f.pattern_class == "OPENAI_STYLE_KEY" for f in findings)
+    for finding in findings:
+        # Path/class only — never compare against embedding the secret into messages.
+        assert finding.path == "unallowlisted_synthetic_probe.txt"
+        assert (
+            finding.secret_value_exposed is False
+            if hasattr(finding, "secret_value_exposed")
+            else True
+        )
+    rc = policy_gate.main(["--paths-file", str(tmp_path / "missing_paths.txt")])
+    assert rc != 0
+
+
+def test_policy_gate_cli_pass_json() -> None:
+    # Full repo scan via API already covered; CLI JSON must not include secret values.
+    # Use empty path list file to exercise CLI without re-scanning whole repo twice if desired.
+    # Here we invoke scan summary shape via main with --json on default repo.
+    import contextlib
+    from io import StringIO
+
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = policy_gate.main(["--json"])
+    assert rc == 0
+    payload = json.loads(buf.getvalue())
+    assert payload["findings_count"] == 0
+    assert payload["secret_value_exposed"] is False
+    dumped = json.dumps(payload)
+    assert SYN_API_KEY not in dumped
+    assert SYN_AWS_KEY not in dumped
+
+
+def test_security_notes_point_to_canonical_owner() -> None:
+    text = SECURITY_NOTES.read_text(encoding="utf-8")
+    assert "SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1" in text
+    assert "scripts/security/secret_hygiene_redaction_v1.py" in text
+    assert (
+        "tracked_secret_like_policy" in text
+        or "check_tracked_credential_hygiene_policy_v1.py" in text
+    )
+
+
+def test_legacy_evidence_pack_is_not_second_contract_owner() -> None:
+    """Legacy local redactor may exist but must not declare the canonical contract id."""
+    path = REPO_ROOT / "src" / "ai_orchestration" / "evidence_pack_generator.py"
+    text = path.read_text(encoding="utf-8")
+    # Avoid embedding the exact assignment form (uniqueness scanner needle).
+    assert "secret_hygiene_redaction_v1" not in text
+    assert "def _redact_content" in text  # known legacy incomplete consumer


### PR DESCRIPTION
## Summary

- **Problem:** Secret scanning / redaction was fragmented (local evidence-pack scrub, outbound envelope allowlist, command transcript sanitizer, private-readonly flags) with no repository-wide fail-closed owner; RR-CB-003 had no required tracked secret-like gate.
- **Canonical owner (Option B):** `scripts/security/secret_hygiene_redaction_v1.py` (`CONTRACT_ID=secret_hygiene_redaction_v1`). Marker: `[REDACTED]` (URL userinfo uses bracketless `REDACTED:REDACTED@` to preserve host/path parsing).
- **Boundaries hardened (adapters):** `redact_for_logging` / `SecretRedactionLoggingFilter`, `redact_for_diagnostics`, `redact_for_evidence_export`, `redact_for_webui_payload`, `redact_headers`, `redact_exception`. Dashboard remains a pure read-only consumer.
- **Threat classes covered:** sensitive field names; Bearer/Basic; JWT-like; `sk-…`; `AKIA…`; PEM private key blocks; cookie/session assignments; credential-bearing URLs/query keys; nested dict/list/tuple/dataclass; unsupported payload fail-closed.
- **Tracked policy gate:** `scripts/ci/check_tracked_credential_hygiene_policy_v1.py` + bounded allowlist `docs/ops/specs/tracked_credential_like_allowlist_v1.json` (no matched values printed).
- **Tests / gates:** `tests/ci/test_credential_hygiene_redaction_unification_v1.py` (18); gate PASS; ruff format/check PASS; cybersecurity baseline action-pin/permissions contract PASS; selector `CONTRACT_FOCUSED`.
- **Exclusions / residual risks:** legacy local redactors not fully migrated (RR-SH-001); pattern detection best-effort (RR-SH-002); optional gitleaks / Push Protection still complementary (RR-SH-003); untracked generated evidence still operator-owned (RR-SH-004).
- **Confirmations:** no actual secret value exposed in this PR (`SECRET_VALUE_EXPOSED=false`); no Runtime/trading/authority/order/network activation changes; no workflow permission expansion; no Action pin regression; Primary Checkout not mutated.

## Test plan

- [x] `pytest tests/ci/test_credential_hygiene_redaction_unification_v1.py`
- [x] `python3 scripts/ci/check_tracked_credential_hygiene_policy_v1.py`
- [x] ruff format --check / ruff check on changed Python
- [x] cybersecurity baseline action-ref/permissions contract
- [ ] CI required checks on this PR (confirmation only)


Made with [Cursor](https://cursor.com)