### PR TITLE
security: enforce canonical branch ruleset governance v1

### DIFF
--- a/.github/workflows/lint_gate.yml
+++ b/.github/workflows/lint_gate.yml
@@ -238,6 +238,16 @@ jobs:
           #   python3 scripts/ci/check_tracked_credential_hygiene_policy_v1.py
           python3 scripts/ci/check_tracked_credential_hygiene_policy_v1.py
 
+      - name: Branch ruleset enforcement governance v1
+        if: ${{ steps.reuse_norm.outputs.reuse != 'true' }}
+        run: |
+          set -euo pipefail
+          echo "🛡️  Verifying branch ruleset enforcement governance (offline evidence)..."
+          # Fail-closed offline verifier against committed sanitized API evidence.
+          # Does not mutate GitHub settings. Local equivalent:
+          #   python3 scripts/ci/check_branch_ruleset_enforcement_governance_v1.py
+          python3 scripts/ci/check_branch_ruleset_enforcement_governance_v1.py
+
       - name: Governance AI matrix consistency gate
         if: ${{ steps.reuse_norm.outputs.reuse != 'true' }}
         run: |

--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -1,7 +1,7 @@
 # Security Notes — Peak_Trade Cybersecurity Baseline Pointers
 
 **Scope ID:** `PEAK_TRADE_CYBERSECURITY_BASELINE_REFRESH_V1`
-**Capability overlay:** `CYBER_CI_SUPPLY_CHAIN_HARDENING_V1` (2026-07-26); `SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1` (2026-07-26); `SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1` (2026-07-26)
+**Capability overlay:** `CYBER_CI_SUPPLY_CHAIN_HARDENING_V1` (2026-07-26); `SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1` (2026-07-26); `SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1` (2026-07-26); `BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1` (2026-07-26)
 **Last Reviewed (repo-static):** 2026-07-26
 **Mode:** Documentation + pointers to existing SSOT owners. **Non-authorizing.**
 **Does not:** rotate secrets, change GitHub org/repo security toggles, enable live/testnet/orders, or claim unverified scanner results.
@@ -21,6 +21,7 @@
 | Secret hygiene / canonical redaction owner | [`scripts/security/secret_hygiene_redaction_v1.py`](scripts/security/secret_hygiene_redaction_v1.py) + [`docs/ops/specs/SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1.md`](docs/ops/specs/SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1.md) |
 | Tracked secret-like policy gate | [`scripts/ci/check_tracked_credential_hygiene_policy_v1.py`](scripts/ci/check_tracked_credential_hygiene_policy_v1.py) + [`docs/ops/specs/tracked_credential_like_allowlist_v1.json`](docs/ops/specs/tracked_credential_like_allowlist_v1.json) |
 | Secret scanning / push-protection governance | [`docs/ops/specs/SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1.md`](docs/ops/specs/SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1.md) (extends tracked gate; CI via Lint Gate) |
+| Branch ruleset enforcement governance | [`docs/ops/specs/BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1.md`](docs/ops/specs/BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1.md) + [`config/ci/branch_ruleset_enforcement_contract_v1.json`](config/ci/branch_ruleset_enforcement_contract_v1.json) (verifier via Lint Gate; required checks SSOT unchanged) |
 | Incident handling | [`docs/RUNBOOKS_AND_INCIDENT_HANDLING.md`](docs/RUNBOOKS_AND_INCIDENT_HANDLING.md) |
 | Disaster recovery | [`docs/DISASTER_RECOVERY_RUNBOOK.md`](docs/DISASTER_RECOVERY_RUNBOOK.md) |
 | Required CI contexts (branch protection sync, repo-evidenced) | [`config/ci/required_status_checks.json`](config/ci/required_status_checks.json) |

--- a/config/ci/branch_ruleset_enforcement_contract_v1.json
+++ b/config/ci/branch_ruleset_enforcement_contract_v1.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "branch_ruleset_enforcement_contract_v1",
+  "capability_id": "BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1",
+  "canonical_protected_branch": "main",
+  "canonical_ref_include": ["refs/heads/main"],
+  "ruleset": {
+    "expected_name": "peak_trade",
+    "expected_id": 11192468,
+    "expected_target": "branch",
+    "expected_enforcement": "active",
+    "required_rule_types": [
+      "deletion",
+      "non_fast_forward",
+      "pull_request",
+      "required_status_checks"
+    ],
+    "pull_request": {
+      "required_approving_review_count": 0,
+      "dismiss_stale_reviews_on_push": true,
+      "require_code_owner_review": false,
+      "require_last_push_approval": true,
+      "required_review_thread_resolution": true,
+      "allowed_merge_methods": ["merge", "rebase", "squash"]
+    },
+    "required_status_checks": {
+      "strict_required_status_checks_policy": true,
+      "contexts_ssot": "config/ci/required_status_checks.json"
+    },
+    "bypass_actors_allowed": [],
+    "broad_bypass_forbidden": true,
+    "force_push_allowed": false,
+    "branch_deletion_allowed": false
+  },
+  "notes": "Canonical required-check names are owned by config/ci/required_status_checks.json (no parallel check SSOT). Approval count 0 preserves the existing solo-operator PR-flow policy while enabling stale-dismissal, latest-push approval flag, and conversation resolution."
+}

--- a/docs/ops/specs/BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1.md
+++ b/docs/ops/specs/BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1.md
@@ -1,0 +1,114 @@
+# BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1
+
+**Capability ID:** `BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1`  
+**Mode:** Repository governance — enforced GitHub branch ruleset for the canonical integration branch, with fail-closed offline verification and regression contracts.  
+**Does not:** alter trading/runtime/dashboard/strategy/risk/execution/capital/scheduler behavior, enable live/testnet/orders, grant admin bypass, rename required checks, or create a second required-check SSOT.
+
+## Authority and ownership
+
+| Role | Path |
+|------|------|
+| Required-check SSOT (unchanged) | [`config/ci/required_status_checks.json`](../../../config/ci/required_status_checks.json) |
+| Ruleset enforcement contract | [`config/ci/branch_ruleset_enforcement_contract_v1.json`](../../../config/ci/branch_ruleset_enforcement_contract_v1.json) |
+| Fail-closed verifier | [`scripts/ci/check_branch_ruleset_enforcement_governance_v1.py`](../../../scripts/ci/check_branch_ruleset_enforcement_governance_v1.py) |
+| Sanitized API evidence (after) | [`branch_ruleset_enforcement_api_evidence_after_v1.json`](branch_ruleset_enforcement_api_evidence_after_v1.json) |
+| Sanitized API evidence (before / rollback) | [`branch_ruleset_enforcement_api_evidence_before_v1.json`](branch_ruleset_enforcement_api_evidence_before_v1.json) |
+| Regression contracts | [`tests/ci/test_branch_ruleset_enforcement_governance_v1.py`](../../../tests/ci/test_branch_ruleset_enforcement_governance_v1.py) |
+| CI enforcement surface | [`.github/workflows/lint_gate.yml`](../../../.github/workflows/lint_gate.yml) step *Branch ruleset enforcement governance v1* (inside required context `Lint Gate`) |
+| Complementary security pointers | [`SECURITY_NOTES.md`](../../../SECURITY_NOTES.md) |
+| Prior capability — secret scanning / push protection | [`SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1.md`](SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1.md) |
+| Prior capability — SHA-pinned Actions / explicit permissions | `CYBER_CI_SUPPLY_CHAIN_HARDENING_V1` (see SECURITY_NOTES) |
+| Canonical redaction owner (unchanged) | [`scripts/security/secret_hygiene_redaction_v1.py`](../../../scripts/security/secret_hygiene_redaction_v1.py) |
+| Canonical credential-hygiene scanner (unchanged) | [`scripts/ci/check_tracked_credential_hygiene_policy_v1.py`](../../../scripts/ci/check_tracked_credential_hygiene_policy_v1.py) |
+
+**Reuse-before-new:** This capability extends existing CI/security governance owners. It does **not** introduce a second required-check baseline, second scanner, or second redaction owner.
+
+## Canonical protected branch
+
+- GitHub default branch (API): `main`
+- Ruleset target include: `refs/heads/main`
+- Enforcement mechanism: Repository ruleset `peak_trade` (`id=11192468`) with `enforcement=active` (not evaluate-only, not disabled)
+- Classic branch protection on `main` remains as a complementary layer; required-check names stay owned by `config/ci/required_status_checks.json`
+
+## Required reviews (canonical policy)
+
+Preserves the existing solo-operator **PR-flow without mandatory approvals** while strengthening review hygiene flags:
+
+| Setting | Value |
+|---------|-------|
+| Pull request required | **true** (ruleset `pull_request` rule) |
+| Required approving review count | **0** (matches pre-existing classic protection policy) |
+| Dismiss stale approvals | **true** (`dismiss_stale_reviews_on_push`) |
+| Require approval of the latest reviewable push | **true** (applies when approvals &gt; 0) |
+| Require conversation resolution | **true** |
+| Code owner reviews | **false** (unchanged) |
+
+## Required checks
+
+Exact contexts must match the effective set from [`config/ci/required_status_checks.json`](../../../config/ci/required_status_checks.json) (`required_contexts` minus `ignored_contexts`).  
+Do **not** rename workflow/job/matrix display names merely for implementation convenience. Drift (missing, extra, duplicate, or renamed contexts) fails closed.
+
+`strict_required_status_checks_policy=true` (branch must be up to date before merge). Compatible: no merge queue is configured on this repository.
+
+## Bypass / force-push / deletion
+
+| Control | Policy |
+|---------|--------|
+| Bypass actors | **none** (`BROAD_BYPASS_ACTOR_COUNT=0`) |
+| Hidden / unconditional admin bypass via ruleset | **forbidden** |
+| Force push | **blocked** (`non_fast_forward` rule present) |
+| Branch deletion | **blocked** (`deletion` rule present) |
+| Emergency path | Operator-visible GitHub settings change with explicit GO; restore from before-evidence; never silent token/admin bypass in CI |
+
+## API evidence contract
+
+- Evidence schema: `branch_ruleset_enforcement_api_evidence_v1`
+- Evidence must be sanitized (no tokens, Authorization headers, cookies, or credential-bearing command traces)
+- Offline CI uses committed after-evidence; operators may re-verify with `--fetch`
+- Verifier never prints credentials
+
+## Failure semantics
+
+Verifier exits non-zero when any of the following hold:
+
+- ruleset absent / partial / malformed evidence
+- `enforcement` is `disabled` or `evaluate`
+- wrong target branch / empty include
+- missing required rule types
+- required-check set mismatch (including stale/renamed contexts)
+- broad bypass actors present
+- force-push or branch-deletion allowed (missing protective rules)
+
+## CI integration
+
+- Workflow: `lint_gate.yml` (required context name: `Lint Gate`)
+- Top-level permissions unchanged (read-only; no write expansion)
+- No `pull_request_target`
+- No privileged live ruleset mutation from PR CI
+- Third-party Actions remain full 40-hex SHA pinned
+- Local equivalent: `python3 scripts/ci/check_branch_ruleset_enforcement_governance_v1.py`
+
+## Operator recovery / rollback
+
+1. Re-read live state: `python3 scripts/ci/check_branch_ruleset_enforcement_governance_v1.py --fetch --json`
+2. If broken, restore ruleset from [`branch_ruleset_enforcement_api_evidence_before_v1.json`](branch_ruleset_enforcement_api_evidence_before_v1.json) via GitHub Settings → Rules → Rulesets, or `gh api` PUT using the before payload (operator action; not CI).
+3. Re-verify after restore with `--fetch`.
+4. Do **not** disable required checks or grant broad bypass to unblock merges without a separate explicit governance GO.
+
+## Exact local reproduction commands
+
+```bash
+# Offline fail-closed verifier (CI equivalent)
+python3 scripts/ci/check_branch_ruleset_enforcement_governance_v1.py
+python3 scripts/ci/check_branch_ruleset_enforcement_governance_v1.py --json
+
+# Live operator re-query (network; still redacts credentials from output)
+python3 scripts/ci/check_branch_ruleset_enforcement_governance_v1.py --fetch --json
+
+# Regression contracts
+python3 -m pytest -q tests/ci/test_branch_ruleset_enforcement_governance_v1.py
+```
+
+## Explicit non-claims
+
+This capability does not claim runtime/live authorization, order capability, merge of this PR, auto-merge enablement, or admin bypass usage.

--- a/docs/ops/specs/BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1.md
+++ b/docs/ops/specs/BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1.md
@@ -26,7 +26,7 @@
 ## Canonical protected branch
 
 - GitHub default branch (API): `main`
-- Ruleset target include: `refs/heads/main`
+- Ruleset target include: `refs&#47;heads&#47;main`
 - Enforcement mechanism: Repository ruleset `peak_trade` (`id=11192468`) with `enforcement=active` (not evaluate-only, not disabled)
 - Classic branch protection on `main` remains as a complementary layer; required-check names stay owned by `config/ci/required_status_checks.json`
 

--- a/docs/ops/specs/SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1.md
+++ b/docs/ops/specs/SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1.md
@@ -57,7 +57,7 @@ Snapshot taken read-only via GitHub API against `rauterfrank-ui&#47;Peak_Trade` 
 | Secret scanning | **ENFORCED** | `security_and_analysis.secret_scanning.status=enabled` |
 | Push protection | **ENFORCED** | `security_and_analysis.secret_scanning_push_protection.status=enabled` |
 | Branch protection (`main`) | **ENFORCED** | Required status checks + `enforce_admins=true` (API) |
-| Repository ruleset `peak_trade` | **AVAILABLE_NOT_ENFORCED** | Ruleset exists with `enforcement=disabled` |
+| Repository ruleset `peak_trade` | **ENFORCED** | Ruleset `id=11192468` with `enforcement=active`, target `refs/heads/main` (see `BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1`) |
 | New dedicated secret-scan check context | **NOT_APPLICABLE** | Enforced inside existing required `Lint Gate` (no BP mutation) |
 
 Repository code does **not** mutate GitHub security settings. Classifications above are evidence snapshots, not authorization to change billing/org policy.
@@ -90,7 +90,7 @@ Repository code does **not** mutate GitHub security settings. Classifications ab
 
 - Optional third-party tools (`gitleaks` / `detect-secrets`) remain **not** configured in pre-commit; complementary only.
 - Full blob-level Git history scanning is not CI-enforced (`HISTORY_SCAN_STATUS=MANUAL_BOUNDED`).
-- Ruleset `peak_trade` remains disabled until an explicit operator enables enforcement (no mutation in this PR).
+- Ruleset `peak_trade` is **ENFORCED** under `BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1` (active on `refs/heads/main`).
 - Non-provider GitHub secret-scanning patterns / validity checks were observed disabled in the API snapshot — operator may enable later without this PR claiming them.
 
 ## Exact local reproduction commands

--- a/docs/ops/specs/SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1.md
+++ b/docs/ops/specs/SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1.md
@@ -57,7 +57,7 @@ Snapshot taken read-only via GitHub API against `rauterfrank-ui&#47;Peak_Trade` 
 | Secret scanning | **ENFORCED** | `security_and_analysis.secret_scanning.status=enabled` |
 | Push protection | **ENFORCED** | `security_and_analysis.secret_scanning_push_protection.status=enabled` |
 | Branch protection (`main`) | **ENFORCED** | Required status checks + `enforce_admins=true` (API) |
-| Repository ruleset `peak_trade` | **ENFORCED** | Ruleset `id=11192468` with `enforcement=active`, target `refs/heads/main` (see `BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1`) |
+| Repository ruleset `peak_trade` | **ENFORCED** | Ruleset `id=11192468` with `enforcement=active`, target `refs&#47;heads&#47;main` (see `BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1`) |
 | New dedicated secret-scan check context | **NOT_APPLICABLE** | Enforced inside existing required `Lint Gate` (no BP mutation) |
 
 Repository code does **not** mutate GitHub security settings. Classifications above are evidence snapshots, not authorization to change billing/org policy.
@@ -90,7 +90,7 @@ Repository code does **not** mutate GitHub security settings. Classifications ab
 
 - Optional third-party tools (`gitleaks` / `detect-secrets`) remain **not** configured in pre-commit; complementary only.
 - Full blob-level Git history scanning is not CI-enforced (`HISTORY_SCAN_STATUS=MANUAL_BOUNDED`).
-- Ruleset `peak_trade` is **ENFORCED** under `BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1` (active on `refs/heads/main`).
+- Ruleset `peak_trade` is **ENFORCED** under `BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1` (active on `refs&#47;heads&#47;main`).
 - Non-provider GitHub secret-scanning patterns / validity checks were observed disabled in the API snapshot — operator may enable later without this PR claiming them.
 
 ## Exact local reproduction commands

--- a/docs/ops/specs/branch_ruleset_enforcement_api_evidence_after_v1.json
+++ b/docs/ops/specs/branch_ruleset_enforcement_api_evidence_after_v1.json
@@ -1,0 +1,145 @@
+{
+  "classic_branch_protection_main": {
+    "allow_deletions": false,
+    "allow_force_pushes": false,
+    "enforce_admins": true,
+    "required_conversation_resolution": false,
+    "required_linear_history": false,
+    "required_pull_request_reviews": {
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_status_checks": {
+      "contexts": [
+        "Guard tracked files in reports directories",
+        "Lint Gate",
+        "Policy Critic Gate",
+        "audit",
+        "dispatch-guard",
+        "docs-drift-guard",
+        "docs-reference-targets-gate",
+        "docs-token-policy-gate",
+        "repo-truth-claims",
+        "strategy-smoke",
+        "tests (3.11)"
+      ],
+      "strict": false
+    }
+  },
+  "phase": "after",
+  "repository": {
+    "allow_auto_merge": true,
+    "allow_merge_commit": true,
+    "allow_rebase_merge": true,
+    "allow_squash_merge": true,
+    "default_branch": "main",
+    "delete_branch_on_merge": true,
+    "secret_scanning": "enabled",
+    "secret_scanning_push_protection": "enabled",
+    "visibility": "public"
+  },
+  "ruleset": {
+    "bypass_actors": [],
+    "conditions": {
+      "ref_name": {
+        "exclude": [],
+        "include": [
+          "refs/heads/main"
+        ]
+      }
+    },
+    "current_user_can_bypass": "never",
+    "enforcement": "active",
+    "id": 11192468,
+    "name": "peak_trade",
+    "rules": [
+      {
+        "type": "deletion"
+      },
+      {
+        "type": "non_fast_forward"
+      },
+      {
+        "parameters": {
+          "allowed_merge_methods": [
+            "merge",
+            "rebase",
+            "squash"
+          ],
+          "dismiss_stale_reviews_on_push": true,
+          "require_code_owner_review": false,
+          "require_last_push_approval": true,
+          "required_approving_review_count": 0,
+          "required_review_thread_resolution": true,
+          "required_reviewers": []
+        },
+        "type": "pull_request"
+      },
+      {
+        "parameters": {
+          "do_not_enforce_on_create": false,
+          "required_status_checks": [
+            {
+              "context": "Guard tracked files in reports directories",
+              "integration_id": 15368
+            },
+            {
+              "context": "Lint Gate",
+              "integration_id": 15368
+            },
+            {
+              "context": "Policy Critic Gate",
+              "integration_id": 15368
+            },
+            {
+              "context": "audit",
+              "integration_id": 15368
+            },
+            {
+              "context": "dispatch-guard",
+              "integration_id": 15368
+            },
+            {
+              "context": "docs-drift-guard",
+              "integration_id": 15368
+            },
+            {
+              "context": "docs-reference-targets-gate",
+              "integration_id": 15368
+            },
+            {
+              "context": "docs-token-policy-gate",
+              "integration_id": 15368
+            },
+            {
+              "context": "repo-truth-claims",
+              "integration_id": 15368
+            },
+            {
+              "context": "strategy-smoke",
+              "integration_id": 15368
+            },
+            {
+              "context": "tests (3.11)",
+              "integration_id": 15368
+            }
+          ],
+          "strict_required_status_checks_policy": true
+        },
+        "type": "required_status_checks"
+      }
+    ],
+    "target": "branch"
+  },
+  "rulesets_summary": [
+    {
+      "enforcement": "active",
+      "id": 11192468,
+      "name": "peak_trade",
+      "target": "branch"
+    }
+  ],
+  "schema_version": "branch_ruleset_enforcement_api_evidence_v1"
+}

--- a/docs/ops/specs/branch_ruleset_enforcement_api_evidence_before_v1.json
+++ b/docs/ops/specs/branch_ruleset_enforcement_api_evidence_before_v1.json
@@ -1,0 +1,74 @@
+{
+  "classic_branch_protection_main": {
+    "allow_deletions": false,
+    "allow_force_pushes": false,
+    "enforce_admins": true,
+    "required_conversation_resolution": false,
+    "required_linear_history": false,
+    "required_pull_request_reviews": {
+      "dismiss_stale_reviews": false,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false,
+      "required_approving_review_count": 0
+    },
+    "required_status_checks": {
+      "contexts": [
+        "Guard tracked files in reports directories",
+        "Lint Gate",
+        "Policy Critic Gate",
+        "audit",
+        "dispatch-guard",
+        "docs-drift-guard",
+        "docs-reference-targets-gate",
+        "docs-token-policy-gate",
+        "repo-truth-claims",
+        "strategy-smoke",
+        "tests (3.11)"
+      ],
+      "strict": false
+    }
+  },
+  "phase": "before",
+  "repository": {
+    "allow_auto_merge": true,
+    "allow_merge_commit": true,
+    "allow_rebase_merge": true,
+    "allow_squash_merge": true,
+    "default_branch": "main",
+    "delete_branch_on_merge": true,
+    "secret_scanning": "enabled",
+    "secret_scanning_push_protection": "enabled",
+    "visibility": "public"
+  },
+  "ruleset": {
+    "bypass_actors": [],
+    "conditions": {
+      "ref_name": {
+        "exclude": [],
+        "include": []
+      }
+    },
+    "current_user_can_bypass": "never",
+    "enforcement": "disabled",
+    "id": 11192468,
+    "name": "peak_trade",
+    "rules": [
+      {
+        "type": "deletion"
+      },
+      {
+        "type": "non_fast_forward"
+      }
+    ],
+    "target": "branch"
+  },
+  "rulesets_summary": [
+    {
+      "enforcement": "disabled",
+      "id": 11192468,
+      "name": "peak_trade",
+      "target": "branch"
+    }
+  ],
+  "schema_version": "branch_ruleset_enforcement_api_evidence_v1"
+}

--- a/scripts/ci/check_branch_ruleset_enforcement_governance_v1.py
+++ b/scripts/ci/check_branch_ruleset_enforcement_governance_v1.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1 — fail-closed ruleset verifier.
+
+Read-only. Consumes sanitized API evidence JSON and/or fetches via ``gh api``.
+Never prints credentials, Authorization headers, or tokens.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+CAPABILITY_ID = "BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1"
+CONTRACT_SCHEMA = "branch_ruleset_enforcement_contract_v1"
+EVIDENCE_SCHEMA = "branch_ruleset_enforcement_api_evidence_v1"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONTRACT = REPO_ROOT / "config" / "ci" / "branch_ruleset_enforcement_contract_v1.json"
+DEFAULT_REQUIRED = REPO_ROOT / "config" / "ci" / "required_status_checks.json"
+DEFAULT_EVIDENCE = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "branch_ruleset_enforcement_api_evidence_after_v1.json"
+)
+
+FORBIDDEN_OUTPUT_NEEDLES = (
+    "authorization:",
+    "bearer ",
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "github_pat_",
+)
+
+
+class VerificationError(RuntimeError):
+    """Fail-closed verification failure."""
+
+
+def _die_on_credential_leak(text: str) -> None:
+    lowered = text.lower()
+    for needle in FORBIDDEN_OUTPUT_NEEDLES:
+        if needle in lowered:
+            raise VerificationError(
+                "REFUSING_OUTPUT: credential-like material detected in verifier I/O; fail-closed"
+            )
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    raw = path.read_text(encoding="utf-8")
+    _die_on_credential_leak(raw)
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise VerificationError(f"JSON root must be object: {path}")
+    return data
+
+
+def load_contract(path: Path = DEFAULT_CONTRACT) -> dict[str, Any]:
+    data = _load_json(path)
+    if data.get("schema_version") != CONTRACT_SCHEMA:
+        raise VerificationError(
+            f"unexpected contract schema_version: {data.get('schema_version')!r}"
+        )
+    if data.get("capability_id") != CAPABILITY_ID:
+        raise VerificationError(f"unexpected capability_id: {data.get('capability_id')!r}")
+    return data
+
+
+def load_required_contexts(path: Path = DEFAULT_REQUIRED) -> list[str]:
+    data = _load_json(path)
+    required = data.get("required_contexts")
+    ignored = set(data.get("ignored_contexts") or [])
+    if not isinstance(required, list) or not required:
+        raise VerificationError("required_contexts missing/empty; fail-closed")
+    out = sorted(
+        {str(x).strip() for x in required if str(x).strip()} - {str(i).strip() for i in ignored}
+    )
+    if not out:
+        raise VerificationError("effective required contexts empty; fail-closed")
+    return out
+
+
+def sanitize_ruleset_payload(raw: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a ruleset API object into evidence-safe fields only."""
+    return {
+        "id": raw.get("id"),
+        "name": raw.get("name"),
+        "target": raw.get("target"),
+        "enforcement": raw.get("enforcement"),
+        "conditions": raw.get("conditions") or {},
+        "rules": raw.get("rules") or [],
+        "bypass_actors": raw.get("bypass_actors") or [],
+        "current_user_can_bypass": raw.get("current_user_can_bypass"),
+    }
+
+
+def sanitize_repo_payload(raw: dict[str, Any]) -> dict[str, Any]:
+    sec = raw.get("security_and_analysis") or {}
+    return {
+        "default_branch": raw.get("default_branch"),
+        "allow_squash_merge": raw.get("allow_squash_merge"),
+        "allow_merge_commit": raw.get("allow_merge_commit"),
+        "allow_rebase_merge": raw.get("allow_rebase_merge"),
+        "allow_auto_merge": raw.get("allow_auto_merge"),
+        "delete_branch_on_merge": raw.get("delete_branch_on_merge"),
+        "visibility": raw.get("visibility"),
+        "secret_scanning": ((sec.get("secret_scanning") or {}).get("status")),
+        "secret_scanning_push_protection": (
+            (sec.get("secret_scanning_push_protection") or {}).get("status")
+        ),
+    }
+
+
+def sanitize_classic_protection(raw: dict[str, Any]) -> dict[str, Any]:
+    rsc = raw.get("required_status_checks") or {}
+    rev = raw.get("required_pull_request_reviews") or {}
+    return {
+        "required_status_checks": {
+            "strict": rsc.get("strict"),
+            "contexts": sorted(str(c) for c in (rsc.get("contexts") or []) if c),
+        },
+        "required_pull_request_reviews": {
+            "dismiss_stale_reviews": rev.get("dismiss_stale_reviews"),
+            "require_code_owner_reviews": rev.get("require_code_owner_reviews"),
+            "require_last_push_approval": rev.get("require_last_push_approval"),
+            "required_approving_review_count": rev.get("required_approving_review_count"),
+        },
+        "enforce_admins": (raw.get("enforce_admins") or {}).get("enabled"),
+        "required_linear_history": (raw.get("required_linear_history") or {}).get("enabled"),
+        "allow_force_pushes": (raw.get("allow_force_pushes") or {}).get("enabled"),
+        "allow_deletions": (raw.get("allow_deletions") or {}).get("enabled"),
+        "required_conversation_resolution": (
+            (raw.get("required_conversation_resolution") or {}).get("enabled")
+        ),
+    }
+
+
+def _gh_api_json(path: str) -> dict[str, Any] | list[Any]:
+    proc = subprocess.run(
+        ["gh", "api", "-H", "Accept: application/vnd.github+json", path],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    combined = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    _die_on_credential_leak(combined)
+    if proc.returncode != 0:
+        # Never echo raw stderr (may contain URLs with tokens in misconfigured envs).
+        raise VerificationError(f"gh api failed for {path!r} (rc={proc.returncode})")
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise VerificationError(f"malformed gh api JSON for {path!r}") from exc
+
+
+def fetch_evidence(
+    *,
+    owner: str = "rauterfrank-ui",
+    repo: str = "Peak_Trade",
+    ruleset_id: int = 11192468,
+    branch: str = "main",
+) -> dict[str, Any]:
+    base = f"repos/{owner}/{repo}"
+    repo_raw = _gh_api_json(base)
+    rulesets_raw = _gh_api_json(f"{base}/rulesets")
+    ruleset_raw = _gh_api_json(f"{base}/rulesets/{ruleset_id}")
+    try:
+        bp_raw = _gh_api_json(f"{base}/branches/{branch}/protection")
+        classic = sanitize_classic_protection(bp_raw if isinstance(bp_raw, dict) else {})
+    except VerificationError:
+        classic = {"_absent": True}
+
+    if not isinstance(repo_raw, dict) or not isinstance(ruleset_raw, dict):
+        raise VerificationError("unexpected API payload types; fail-closed")
+    if not isinstance(rulesets_raw, list):
+        raise VerificationError("rulesets list missing; fail-closed")
+
+    return {
+        "schema_version": EVIDENCE_SCHEMA,
+        "phase": "live_fetch",
+        "repository": sanitize_repo_payload(repo_raw),
+        "rulesets_summary": [
+            {
+                "id": x.get("id"),
+                "name": x.get("name"),
+                "enforcement": x.get("enforcement"),
+                "target": x.get("target"),
+            }
+            for x in rulesets_raw
+            if isinstance(x, dict)
+        ],
+        "ruleset": sanitize_ruleset_payload(ruleset_raw),
+        "classic_branch_protection_main": classic,
+    }
+
+
+def _rule_by_type(rules: list[Any], rule_type: str) -> dict[str, Any] | None:
+    matches = [r for r in rules if isinstance(r, dict) and r.get("type") == rule_type]
+    if len(matches) > 1:
+        raise VerificationError(f"duplicate rule type {rule_type!r}; fail-closed")
+    return matches[0] if matches else None
+
+
+def _contexts_from_required_status_rule(rule: dict[str, Any]) -> list[str]:
+    params = rule.get("parameters") or {}
+    if not isinstance(params, dict):
+        raise VerificationError("required_status_checks parameters malformed")
+    checks = params.get("required_status_checks") or []
+    if not isinstance(checks, list) or not checks:
+        raise VerificationError("required_status_checks list empty/malformed")
+    names: list[str] = []
+    for item in checks:
+        if not isinstance(item, dict):
+            raise VerificationError("required status check entry malformed")
+        ctx = item.get("context")
+        if not ctx or not str(ctx).strip():
+            raise VerificationError("required status check missing context")
+        names.append(str(ctx).strip())
+    # Detect duplicates / renamed ambiguity
+    if len(names) != len(set(names)):
+        raise VerificationError("duplicate required check contexts in ruleset; fail-closed")
+    return sorted(names)
+
+
+def _is_broad_bypass_actor(actor: Any) -> bool:
+    if not isinstance(actor, dict):
+        return True
+    # Any bypass actor is treated as broad unless contract allowlists it explicitly.
+    # Empty allowlist => any actor is broad/forbidden.
+    return True
+
+
+def evaluate_evidence(
+    evidence: dict[str, Any],
+    contract: dict[str, Any],
+    required_contexts: list[str],
+) -> dict[str, Any]:
+    if evidence.get("schema_version") != EVIDENCE_SCHEMA:
+        raise VerificationError(
+            f"unexpected evidence schema_version: {evidence.get('schema_version')!r}"
+        )
+
+    repo = evidence.get("repository") or {}
+    ruleset = evidence.get("ruleset") or {}
+    if not isinstance(repo, dict) or not isinstance(ruleset, dict):
+        raise VerificationError("evidence repository/ruleset missing; fail-closed")
+
+    rs_cfg = contract["ruleset"]
+    findings: list[str] = []
+
+    default_branch = repo.get("default_branch")
+    canonical = contract.get("canonical_protected_branch")
+    target_branch_match = default_branch == canonical
+
+    enforcement = ruleset.get("enforcement")
+    if enforcement in (None, "", "disabled", "evaluate"):
+        findings.append(f"enforcement_not_active:{enforcement!r}")
+    elif enforcement != rs_cfg["expected_enforcement"]:
+        findings.append(f"enforcement_mismatch:{enforcement!r}")
+
+    if ruleset.get("name") != rs_cfg["expected_name"]:
+        findings.append(f"ruleset_name_mismatch:{ruleset.get('name')!r}")
+    if ruleset.get("id") != rs_cfg["expected_id"]:
+        findings.append(f"ruleset_id_mismatch:{ruleset.get('id')!r}")
+    if ruleset.get("target") != rs_cfg["expected_target"]:
+        findings.append(f"ruleset_target_mismatch:{ruleset.get('target')!r}")
+
+    conditions = ruleset.get("conditions") or {}
+    ref_name = (conditions.get("ref_name") or {}) if isinstance(conditions, dict) else {}
+    include = list(ref_name.get("include") or [])
+    expected_include = list(contract.get("canonical_ref_include") or [])
+    if sorted(include) != sorted(expected_include):
+        findings.append(f"target_ref_include_mismatch:{include!r}")
+        target_branch_match = False
+
+    rules = ruleset.get("rules") or []
+    if not isinstance(rules, list) or not rules:
+        findings.append("rules_absent")
+        rules = []
+
+    present_types = sorted(
+        {str(r.get("type")) for r in rules if isinstance(r, dict) and r.get("type")}
+    )
+    for needed in rs_cfg["required_rule_types"]:
+        if needed not in present_types:
+            findings.append(f"missing_rule_type:{needed}")
+
+    deletion = _rule_by_type(rules, "deletion")
+    nff = _rule_by_type(rules, "non_fast_forward")
+    force_push_allowed = nff is None  # absence of non_fast_forward => force push possible
+    branch_deletion_allowed = deletion is None
+    if force_push_allowed:
+        findings.append("force_push_allowed")
+    if branch_deletion_allowed:
+        findings.append("branch_deletion_allowed")
+
+    pr_rule = _rule_by_type(rules, "pull_request")
+    pr_params: dict[str, Any] = {}
+    if pr_rule is None:
+        findings.append("pull_request_rule_absent")
+        pull_request_required = False
+    else:
+        pull_request_required = True
+        pr_params = pr_rule.get("parameters") or {}
+        if not isinstance(pr_params, dict):
+            findings.append("pull_request_parameters_malformed")
+            pr_params = {}
+        expected_pr = rs_cfg["pull_request"]
+        for key, expected in expected_pr.items():
+            actual = pr_params.get(key)
+            if isinstance(expected, list) and isinstance(actual, list):
+                if sorted(expected) != sorted(actual):
+                    findings.append(f"pull_request_param_mismatch:{key}:{actual!r}!={expected!r}")
+            elif actual != expected:
+                findings.append(f"pull_request_param_mismatch:{key}:{actual!r}!={expected!r}")
+
+    rsc_rule = _rule_by_type(rules, "required_status_checks")
+    check_set_match = False
+    require_up_to_date = False
+    live_checks: list[str] = []
+    if rsc_rule is None:
+        findings.append("required_status_checks_rule_absent")
+    else:
+        params = rsc_rule.get("parameters") or {}
+        if not isinstance(params, dict):
+            findings.append("required_status_checks_parameters_malformed")
+        else:
+            require_up_to_date = bool(params.get("strict_required_status_checks_policy"))
+            if require_up_to_date != bool(
+                rs_cfg["required_status_checks"]["strict_required_status_checks_policy"]
+            ):
+                findings.append("strict_required_status_checks_policy_mismatch")
+            try:
+                live_checks = _contexts_from_required_status_rule(rsc_rule)
+            except VerificationError as exc:
+                findings.append(str(exc))
+                live_checks = []
+            if live_checks == sorted(required_contexts):
+                check_set_match = True
+            else:
+                missing = sorted(set(required_contexts) - set(live_checks))
+                extra = sorted(set(live_checks) - set(required_contexts))
+                if missing:
+                    findings.append(f"missing_required_checks:{missing}")
+                if extra:
+                    findings.append(f"unexpected_required_checks:{extra}")
+
+    bypass_actors = ruleset.get("bypass_actors") or []
+    if not isinstance(bypass_actors, list):
+        findings.append("bypass_actors_malformed")
+        bypass_actors = ["_malformed"]
+    allowed = list(rs_cfg.get("bypass_actors_allowed") or [])
+    broad = []
+    for actor in bypass_actors:
+        # Serialize actor identity without tokens.
+        if allowed and actor in allowed:
+            continue
+        if _is_broad_bypass_actor(actor):
+            broad.append(actor)
+    broad_count = len(broad)
+    if broad_count:
+        findings.append(f"broad_bypass_actors:{broad_count}")
+
+    enforcement_status = (
+        "ENFORCED"
+        if enforcement == "active" and not findings and target_branch_match and check_set_match
+        else ("NOT_ENFORCED" if enforcement in ("disabled", "evaluate", None, "") else "UNKNOWN")
+    )
+    # If active but findings remain, still NOT_ENFORCED for fail-closed posture.
+    if enforcement == "active" and findings:
+        enforcement_status = "NOT_ENFORCED"
+
+    result = {
+        "capability_id": CAPABILITY_ID,
+        "RULESET_ENFORCEMENT_STATUS": enforcement_status,
+        "TARGET_BRANCH_MATCH": bool(target_branch_match),
+        "PULL_REQUEST_REQUIRED": bool(pull_request_required),
+        "REQUIRED_APPROVAL_COUNT": pr_params.get("required_approving_review_count"),
+        "STALE_APPROVAL_DISMISSAL": pr_params.get("dismiss_stale_reviews_on_push"),
+        "LATEST_PUSH_APPROVAL_REQUIRED": pr_params.get("require_last_push_approval"),
+        "CONVERSATION_RESOLUTION_REQUIRED": pr_params.get("required_review_thread_resolution"),
+        "REQUIRED_CHECK_SET_MATCH": bool(check_set_match),
+        "REQUIRED_CHECKS": live_checks,
+        "REQUIRE_UP_TO_DATE": bool(require_up_to_date),
+        "FORCE_PUSH_ALLOWED": bool(force_push_allowed),
+        "BRANCH_DELETION_ALLOWED": bool(branch_deletion_allowed),
+        "BROAD_BYPASS_ACTOR_COUNT": broad_count,
+        "BYPASS_ACTORS": bypass_actors,
+        "findings": findings,
+        "ok": not findings
+        and enforcement_status == "ENFORCED"
+        and target_branch_match
+        and check_set_match,
+        "network_required": False,
+        "secret_value_exposed": False,
+    }
+    return result
+
+
+def render_human(result: dict[str, Any]) -> str:
+    lines = [
+        f"CAPABILITY_ID={result['capability_id']}",
+        f"RULESET_ENFORCEMENT_STATUS={result['RULESET_ENFORCEMENT_STATUS']}",
+        f"TARGET_BRANCH_MATCH={result['TARGET_BRANCH_MATCH']}",
+        f"PULL_REQUEST_REQUIRED={result['PULL_REQUEST_REQUIRED']}",
+        f"REQUIRED_APPROVAL_COUNT={result['REQUIRED_APPROVAL_COUNT']}",
+        f"STALE_APPROVAL_DISMISSAL={result['STALE_APPROVAL_DISMISSAL']}",
+        f"LATEST_PUSH_APPROVAL_REQUIRED={result['LATEST_PUSH_APPROVAL_REQUIRED']}",
+        f"CONVERSATION_RESOLUTION_REQUIRED={result['CONVERSATION_RESOLUTION_REQUIRED']}",
+        f"REQUIRED_CHECK_SET_MATCH={result['REQUIRED_CHECK_SET_MATCH']}",
+        f"REQUIRE_UP_TO_DATE={result['REQUIRE_UP_TO_DATE']}",
+        f"FORCE_PUSH_ALLOWED={result['FORCE_PUSH_ALLOWED']}",
+        f"BRANCH_DELETION_ALLOWED={result['BRANCH_DELETION_ALLOWED']}",
+        f"BROAD_BYPASS_ACTOR_COUNT={result['BROAD_BYPASS_ACTOR_COUNT']}",
+        f"ok={result['ok']}",
+    ]
+    if result["findings"]:
+        lines.append("findings=")
+        for item in result["findings"]:
+            lines.append(f"  - {item}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
+    parser.add_argument("--required-config", type=Path, default=DEFAULT_REQUIRED)
+    parser.add_argument(
+        "--evidence-json",
+        type=Path,
+        default=None,
+        help="Sanitized evidence JSON (offline). Default: committed after-evidence.",
+    )
+    parser.add_argument(
+        "--fetch",
+        action="store_true",
+        help="Fetch live sanitized evidence via gh api (operator/network).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine JSON on stdout.")
+    args = parser.parse_args(argv)
+    as_json = bool(args.json)
+
+    try:
+        contract = load_contract(args.contract)
+        required = load_required_contexts(args.required_config)
+        if args.fetch:
+            evidence = fetch_evidence(
+                ruleset_id=int(contract["ruleset"]["expected_id"]),
+                branch=str(contract["canonical_protected_branch"]),
+            )
+            evidence["network_required"] = True
+        else:
+            evidence_path = args.evidence_json or DEFAULT_EVIDENCE
+            evidence = _load_json(evidence_path)
+            evidence["network_required"] = False
+        result = evaluate_evidence(evidence, contract, required)
+        result["network_required"] = bool(evidence.get("network_required"))
+    except (OSError, json.JSONDecodeError, VerificationError, TypeError, KeyError) as exc:
+        err = {
+            "capability_id": CAPABILITY_ID,
+            "ok": False,
+            "RULESET_ENFORCEMENT_STATUS": "UNKNOWN",
+            "error": str(exc),
+            "secret_value_exposed": False,
+            "network_required": bool(args.fetch),
+        }
+        out = json.dumps(err, sort_keys=True, indent=2) + "\n" if as_json else f"FAIL: {exc}\n"
+        _die_on_credential_leak(out)
+        sys.stdout.write(out)
+        return 2
+
+    if as_json:
+        payload = json.dumps(result, sort_keys=True, indent=2) + "\n"
+        _die_on_credential_leak(payload)
+        sys.stdout.write(payload)
+    else:
+        human = render_human(result)
+        _die_on_credential_leak(human)
+        sys.stdout.write(human)
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_branch_ruleset_enforcement_governance_v1.py
+++ b/tests/ci/test_branch_ruleset_enforcement_governance_v1.py
@@ -1,0 +1,312 @@
+"""BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1 — regression contracts.
+
+Uses sanitized synthetic evidence only. Never asserts by printing credentials.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import json
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+import scripts.ci.check_branch_ruleset_enforcement_governance_v1 as gate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = REPO_ROOT / "config" / "ci" / "branch_ruleset_enforcement_contract_v1.json"
+REQUIRED = REPO_ROOT / "config" / "ci" / "required_status_checks.json"
+SPEC = REPO_ROOT / "docs" / "ops" / "specs" / "BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1.md"
+EVIDENCE_AFTER = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "branch_ruleset_enforcement_api_evidence_after_v1.json"
+)
+EVIDENCE_BEFORE = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "branch_ruleset_enforcement_api_evidence_before_v1.json"
+)
+SECURITY_NOTES = REPO_ROOT / "SECURITY_NOTES.md"
+LINT_GATE = REPO_ROOT / ".github" / "workflows" / "lint_gate.yml"
+VERIFIER = REPO_ROOT / "scripts" / "ci" / "check_branch_ruleset_enforcement_governance_v1.py"
+SECRET_SPEC = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1.md"
+)
+REDACTION_OWNER = REPO_ROOT / "scripts" / "security" / "secret_hygiene_redaction_v1.py"
+CRED_SCANNER = REPO_ROOT / "scripts" / "ci" / "check_tracked_credential_hygiene_policy_v1.py"
+
+
+def _required_contexts() -> list[str]:
+    return gate.load_required_contexts(REQUIRED)
+
+
+def _passing_evidence() -> dict:
+    contexts = _required_contexts()
+    return {
+        "schema_version": gate.EVIDENCE_SCHEMA,
+        "phase": "synthetic_pass",
+        "repository": {
+            "default_branch": "main",
+            "allow_squash_merge": True,
+            "allow_merge_commit": True,
+            "allow_rebase_merge": True,
+            "allow_auto_merge": True,
+            "delete_branch_on_merge": True,
+            "visibility": "public",
+            "secret_scanning": "enabled",
+            "secret_scanning_push_protection": "enabled",
+        },
+        "rulesets_summary": [
+            {
+                "id": 11192468,
+                "name": "peak_trade",
+                "enforcement": "active",
+                "target": "branch",
+            }
+        ],
+        "ruleset": {
+            "id": 11192468,
+            "name": "peak_trade",
+            "target": "branch",
+            "enforcement": "active",
+            "conditions": {"ref_name": {"include": ["refs/heads/main"], "exclude": []}},
+            "rules": [
+                {"type": "deletion"},
+                {"type": "non_fast_forward"},
+                {
+                    "type": "pull_request",
+                    "parameters": {
+                        "required_approving_review_count": 0,
+                        "dismiss_stale_reviews_on_push": True,
+                        "require_code_owner_review": False,
+                        "require_last_push_approval": True,
+                        "required_review_thread_resolution": True,
+                        "allowed_merge_methods": ["merge", "rebase", "squash"],
+                    },
+                },
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        "strict_required_status_checks_policy": True,
+                        "required_status_checks": [{"context": c} for c in contexts],
+                    },
+                },
+            ],
+            "bypass_actors": [],
+            "current_user_can_bypass": "never",
+        },
+        "classic_branch_protection_main": {"_synthetic": True},
+    }
+
+
+def test_owners_and_spec_exist() -> None:
+    assert CONTRACT.is_file()
+    assert SPEC.is_file()
+    assert VERIFIER.is_file()
+    assert EVIDENCE_AFTER.is_file()
+    assert EVIDENCE_BEFORE.is_file()
+    assert REDACTION_OWNER.is_file()
+    assert CRED_SCANNER.is_file()
+    text = SPEC.read_text(encoding="utf-8")
+    assert "BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1" in text
+    assert "config/ci/required_status_checks.json" in text
+    assert "SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1" in text
+    assert "secret_hygiene_redaction_v1" in text
+    assert gate.CAPABILITY_ID == "BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1"
+
+
+def test_no_duplicate_required_check_or_redaction_truth() -> None:
+    notes = SECURITY_NOTES.read_text(encoding="utf-8")
+    assert "BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1" in notes
+    assert "required_status_checks.json" in notes
+    secret = SECRET_SPEC.read_text(encoding="utf-8")
+    assert "ENFORCED" in secret or "active" in secret.lower()
+
+
+def test_active_enforced_ruleset_passes() -> None:
+    contract = gate.load_contract(CONTRACT)
+    result = gate.evaluate_evidence(_passing_evidence(), contract, _required_contexts())
+    assert result["ok"] is True
+    assert result["RULESET_ENFORCEMENT_STATUS"] == "ENFORCED"
+    assert result["REQUIRED_CHECK_SET_MATCH"] is True
+    assert result["FORCE_PUSH_ALLOWED"] is False
+    assert result["BRANCH_DELETION_ALLOWED"] is False
+    assert result["BROAD_BYPASS_ACTOR_COUNT"] == 0
+
+
+@pytest.mark.parametrize(
+    ("mutator", "needle"),
+    [
+        (
+            lambda e: e["ruleset"].__setitem__("enforcement", "evaluate"),
+            "enforcement_not_active",
+        ),
+        (
+            lambda e: e.__setitem__("ruleset", {}),
+            "enforcement_not_active",
+        ),
+        (
+            lambda e: e["ruleset"]["conditions"]["ref_name"].__setitem__(
+                "include", ["refs/heads/develop"]
+            ),
+            "target_ref_include_mismatch",
+        ),
+        (
+            lambda e: e["ruleset"]["rules"].__setitem__(
+                3,
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        "strict_required_status_checks_policy": True,
+                        "required_status_checks": [{"context": "Lint Gate"}],
+                    },
+                },
+            ),
+            "missing_required_checks",
+        ),
+        (
+            lambda e: e["ruleset"]["rules"].__setitem__(
+                3,
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        "strict_required_status_checks_policy": True,
+                        "required_status_checks": [{"context": c} for c in _required_contexts()]
+                        + [{"context": "Renamed Legacy Gate"}],
+                    },
+                },
+            ),
+            "unexpected_required_checks",
+        ),
+        (
+            lambda e: e["ruleset"].__setitem__(
+                "bypass_actors", [{"actor_id": 1, "actor_type": "OrganizationAdmin"}]
+            ),
+            "broad_bypass_actors",
+        ),
+        (
+            lambda e: e["ruleset"].__setitem__(
+                "rules", [r for r in e["ruleset"]["rules"] if r.get("type") != "non_fast_forward"]
+            ),
+            "force_push_allowed",
+        ),
+        (
+            lambda e: e["ruleset"].__setitem__(
+                "rules", [r for r in e["ruleset"]["rules"] if r.get("type") != "deletion"]
+            ),
+            "branch_deletion_allowed",
+        ),
+    ],
+)
+def test_fail_closed_mutations(mutator, needle: str) -> None:
+    evidence = _passing_evidence()
+    mutator(evidence)
+    contract = gate.load_contract(CONTRACT)
+    result = gate.evaluate_evidence(evidence, contract, _required_contexts())
+    assert result["ok"] is False
+    assert result["RULESET_ENFORCEMENT_STATUS"] != "ENFORCED"
+    assert any(needle in f for f in result["findings"]), result["findings"]
+
+
+def test_malformed_partial_evidence_fails() -> None:
+    contract = gate.load_contract(CONTRACT)
+    with pytest.raises(gate.VerificationError):
+        gate.evaluate_evidence(
+            {"schema_version": "wrong", "ruleset": {}},
+            contract,
+            _required_contexts(),
+        )
+    bad = _passing_evidence()
+    bad["ruleset"]["rules"] = [
+        {"type": "required_status_checks", "parameters": {"required_status_checks": "nope"}}
+    ]
+    result = gate.evaluate_evidence(bad, contract, _required_contexts())
+    assert result["ok"] is False
+
+
+def test_deterministic_normalized_output(tmp_path: Path) -> None:
+    evidence = _passing_evidence()
+    path = tmp_path / "ev.json"
+    path.write_text(json.dumps(evidence, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    buf1 = StringIO()
+    buf2 = StringIO()
+    with contextlib.redirect_stdout(buf1):
+        rc1 = gate.main(["--evidence-json", str(path), "--json"])
+    with contextlib.redirect_stdout(buf2):
+        rc2 = gate.main(["--evidence-json", str(path), "--json"])
+    assert rc1 == 0 and rc2 == 0
+    assert buf1.getvalue() == buf2.getvalue()
+    payload = json.loads(buf1.getvalue())
+    assert payload["secret_value_exposed"] is False
+    assert payload["ok"] is True
+
+
+def test_secret_redaction_safety_refuses_credential_like_evidence(tmp_path: Path) -> None:
+    path = tmp_path / "leaky.json"
+    path.write_text(
+        json.dumps(
+            {"schema_version": gate.EVIDENCE_SCHEMA, "token": "Authorization: Bearer ghp_SYNTH"}
+        ),
+        encoding="utf-8",
+    )
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = gate.main(["--evidence-json", str(path), "--json"])
+    assert rc == 2
+    out = buf.getvalue()
+    assert "ghp_SYNTH" not in out
+    assert "Bearer ghp" not in out
+
+
+def test_committed_after_evidence_passes_offline_verifier() -> None:
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = gate.main(["--json"])
+    assert rc == 0, buf.getvalue()
+    payload = json.loads(buf.getvalue())
+    assert payload["RULESET_ENFORCEMENT_STATUS"] == "ENFORCED"
+    assert payload["REQUIRED_CHECK_SET_MATCH"] is True
+    assert payload["FORCE_PUSH_ALLOWED"] is False
+    assert payload["BRANCH_DELETION_ALLOWED"] is False
+    assert payload["BROAD_BYPASS_ACTOR_COUNT"] == 0
+    assert payload["secret_value_exposed"] is False
+    assert payload["network_required"] is False
+
+
+def test_before_evidence_is_not_enforced() -> None:
+    before = json.loads(EVIDENCE_BEFORE.read_text(encoding="utf-8"))
+    contract = gate.load_contract(CONTRACT)
+    # before evidence may lack full rules; evaluate should fail closed
+    result = gate.evaluate_evidence(before, contract, _required_contexts())
+    assert result["ok"] is False
+    assert result["RULESET_ENFORCEMENT_STATUS"] != "ENFORCED"
+
+
+def test_lint_gate_wires_verifier_without_privilege_expansion() -> None:
+    text = LINT_GATE.read_text(encoding="utf-8")
+    assert "check_branch_ruleset_enforcement_governance_v1.py" in text
+    assert "pull_request_target" not in text
+    # Top-level permissions remain read-only.
+    assert "permissions:" in text
+    assert "contents: read" in text
+    assert "contents: write" not in text
+
+
+def test_evaluate_only_and_absent_coverage_explicit() -> None:
+    contract = gate.load_contract(CONTRACT)
+    evaluate = _passing_evidence()
+    evaluate["ruleset"]["enforcement"] = "evaluate"
+    r1 = gate.evaluate_evidence(evaluate, contract, _required_contexts())
+    assert r1["ok"] is False
+    absent = copy.deepcopy(_passing_evidence())
+    absent["ruleset"] = {
+        "id": 999,
+        "name": "missing",
+        "target": "branch",
+        "enforcement": "disabled",
+        "conditions": {"ref_name": {"include": [], "exclude": []}},
+        "rules": [],
+        "bypass_actors": [],
+    }
+    r2 = gate.evaluate_evidence(absent, contract, _required_contexts())
+    assert r2["ok"] is False


### PR DESCRIPTION
## Summary
- Convert repository ruleset `peak_trade` (`id=11192468`) from `AVAILABLE_NOT_ENFORCED` (`enforcement=disabled`, empty target include) to **API-evidenced `ENFORCED`** on canonical branch `main` (`refs/heads/main`).
- Add fail-closed offline verifier + contract that validates enforcement mode, target branch, exact required-check set (from `config/ci/required_status_checks.json`), PR/review hygiene flags, zero broad bypass actors, and force-push/deletion blocks.
- Wire verifier into existing required `Lint Gate` without write-permission expansion and without `pull_request_target`.

## Pre-state
- `RULESET_STATE_BEFORE`: ruleset `peak_trade` present, `enforcement=disabled`, `include=[]`, rules=`deletion`+`non_fast_forward` only.
- Classic branch protection on `main` already required the 11 canonical status checks; approvals count `0`; force-push/deletion blocked; `enforce_admins=true`.
- Required-check set unambiguous and identical to `config/ci/required_status_checks.json`.

## Exact GitHub configuration changes
- PUT `repos/.../rulesets/11192468`:
  - `enforcement=active`
  - target include `refs/heads/main`
  - rules: `deletion`, `non_fast_forward`, `pull_request` (count `0`, dismiss stale on push, last-push approval flag, conversation resolution, merge methods merge/rebase/squash), `required_status_checks` (exact 11 contexts, Actions `integration_id=15368`, strict up-to-date)
  - `bypass_actors=[]`
- No classic branch-protection deletion, no required-check renames, no admin bypass, no auto-merge/merge of this PR, no runtime/live/order capability changes.
- Rollback evidence: `docs/ops/specs/branch_ruleset_enforcement_api_evidence_before_v1.json`

## Repository artifacts
- Spec: `docs/ops/specs/BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1.md`
- Contract: `config/ci/branch_ruleset_enforcement_contract_v1.json`
- Verifier: `scripts/ci/check_branch_ruleset_enforcement_governance_v1.py`
- Evidence: before/after sanitized API JSON under `docs/ops/specs/`
- Tests: `tests/ci/test_branch_ruleset_enforcement_governance_v1.py`
- Docs pointers: `SECURITY_NOTES.md`, secret-scanning governance cross-update

## Security model
- Reuse existing required-check SSOT, Lint Gate, SHA-pinned Actions posture, credential-hygiene scanner, and redaction owner.
- No second scanner / redaction / required-check baseline.
- PR CI verifies offline sanitized evidence only (no privileged settings mutation from untrusted PR code).

## Required-check contract
Exact contexts enforced (11): Guard tracked files in reports directories, Lint Gate, Policy Critic Gate, audit, dispatch-guard, docs-drift-guard, docs-reference-targets-gate, docs-token-policy-gate, repo-truth-claims, strategy-smoke, tests (3.11).

## Test evidence
- Offline + live `--fetch` verifier: `RULESET_ENFORCEMENT_STATUS=ENFORCED`
- New governance tests + related SHA-pin / permissions / no-PRT / secret-scanning / redaction / credential hygiene regressions green
- Selector: `PR_BOUNDED_FULL`; PR-bounded timing proof ~47s / 746 passed

## Rollback procedure
Restore ruleset from `branch_ruleset_enforcement_api_evidence_before_v1.json` via Settings → Rulesets or `gh api` PUT, then re-verify with `python3 scripts/ci/check_branch_ruleset_enforcement_governance_v1.py --fetch`.

## Explicit non-claims
No runtime / live / order / paper / shadow / testnet / scheduler / capital / dashboard trading capability changed. `MERGE=false`, `AUTO_MERGE=false`, `ADMIN_BYPASS=false`.

## Test plan
- [x] Local verifier offline + `--fetch`
- [x] `tests/ci/test_branch_ruleset_enforcement_governance_v1.py`
- [x] Related governance regressions + credential hygiene gate
- [ ] Required GitHub checks on this PR

Made with [Cursor](https://cursor.com)