### PR TITLE
fix(webui): make CI-health GET surfaces strictly read-only

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -42,7 +42,7 @@ Ports **8000** (Operator WebUI, `src.webui.app`) and **8010** (live.web, `src.li
 - `/ops` — Ops Cockpit (read-only, local artifacts)
 - `/ops/stage1` — Stage1 ops dashboard
 - `/ops/workflows` — Ops workflow hub
-- `/ops/ci-health` — CI & governance health panel
+- `/ops/ci-health` — CI & governance health panel (GET read-only snapshot; POST `/ops/ci-health/run` auth-gated execution)
 - `/session/{session_id}` — session detail HTML (read-only)
 
 **Additional Operator WebUI nav** (read-only; labels as in the header: `templates/peak_trade_dashboard/base.html`):

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -16,7 +16,7 @@
 
 - **PR #3237** — Double Play WebUI **read-only** route contract aligned with the pure-stack **dashboard display map** (docs coherence): [`MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md`](specs/MASTER_V2_DOUBLE_PLAY_WEBUI_READONLY_ROUTE_CONTRACT_V0.md), [`MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md`](specs/MASTER_V2_DOUBLE_PLAY_PURE_STACK_DASHBOARD_DISPLAY_MAP_V0.md). **Display/read-only only**; **no** live authorization; **no** order or execution authority; **no** gate bypass and **no** replacement for Master V2, Double Play execution semantics, Risk, Kill Switch, or execution gates.
 
-- **PR #3238** — Observability **read-model** contract **tests** (`tests/webui/test_market_depth_readmodel_v0.py`, `tests/webui/test_paper_shadow_summary_readmodel_v0.py`): **tests-only** fixture-backed regression/readability anchors; **not** operational readiness, telemetry guarantees, or authorization.
+- **PR #3238** — Observability **read-model** contract **tests** (`tests&#47;webui&#47;test_market_depth_readmodel_v0.py`, `tests&#47;webui&#47;test_paper_shadow_summary_readmodel_v0.py`): **tests-only** fixture-backed regression/readability anchors; **not** operational readiness, telemetry guarantees, or authorization.
 
 - **AI/KI CI cost & autonomy (v0)** — Operator policy: paid LLM **default-off** on PR/push/schedule; explicit opt-in for billable paths; InfoStream / Market Outlook / Promptfoo posture: [`AI_KI_COST_AUTONOMY_CI_POLICY_V0.md`](AI_KI_COST_AUTONOMY_CI_POLICY_V0.md).
 
@@ -42,7 +42,7 @@ Ports **8000** (Operator WebUI, `src.webui.app`) and **8010** (live.web, `src.li
 - `/ops` — Ops Cockpit (read-only, local artifacts)
 - `/ops/stage1` — Stage1 ops dashboard
 - `/ops/workflows` — Ops workflow hub
-- `/ops/ci-health` — CI & governance health panel (GET read-only snapshot; POST `/ops/ci-health/run` auth-gated execution)
+- `&#47;ops&#47;ci-health` — CI & governance health panel (GET read-only snapshot; POST `&#47;ops&#47;ci-health&#47;run` auth-gated execution)
 - `/session/{session_id}` — session detail HTML (read-only)
 
 **Additional Operator WebUI nav** (read-only; labels as in the header: `templates/peak_trade_dashboard/base.html`):

--- a/docs/ops/specs/WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1.md
+++ b/docs/ops/specs/WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1.md
@@ -1,0 +1,98 @@
+# WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1
+
+**Capability ID:** `WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1`  
+**Mode:** Make CI-health GET surfaces strictly read-only. **Non-authorizing for trading.**  
+**Does not:** change Local-Admin auth, Knowledge POSTs, Market Dashboard, Runtime, Orders, Host/CSRF/Bind gates, GitHub, or Notion.
+
+## Objective
+
+Ensure:
+
+- `GET /ops/ci-health`
+- `GET /ops/ci-health/status`
+
+are safe and idempotent:
+
+- no check execution
+- no subprocess
+- no git command
+- no snapshot write / directory creation
+- no hidden refresh
+
+Only authenticated `POST /ops/ci-health/run` may execute checks and refresh snapshots.
+
+## Canonical owners (reuse)
+
+| Role | Path |
+|------|------|
+| Router / runner / writer / reader | [`src/webui/ops_ci_health_router.py`](../../../src/webui/ops_ci_health_router.py) |
+| Local-admin write auth (unchanged) | [`src/webui/local_admin_write_auth_v1.py`](../../../src/webui/local_admin_write_auth_v1.py) |
+| Snapshot JSON | `reports/ops/ci_health_latest.json` |
+| Redaction boundary (reuse) | [`scripts/security/secret_hygiene_redaction_v1.py`](../../../scripts/security/secret_hygiene_redaction_v1.py) |
+| UI | [`templates/peak_trade_dashboard/ops_ci_health.html`](../../../templates/peak_trade_dashboard/ops_ci_health.html) |
+
+A second CI-health router/runner/writer/auth owner is forbidden.
+
+## Route contracts
+
+| Method | Path | Behavior |
+|--------|------|----------|
+| `GET` | `/ops/ci-health` | Render persisted snapshot state only |
+| `GET` | `/ops/ci-health/status` | Return persisted snapshot JSON projection only |
+| `POST` | `/ops/ci-health/run` | Auth-gated execution + snapshot write (unchanged auth model) |
+
+### GET contract
+
+- safe, idempotent
+- no subprocess / git / filesystem mutation / background task / hidden execution
+- missing snapshot => controlled `SNAPSHOT_ABSENT` (no file/dir creation)
+- invalid JSON/structure/size/encoding => controlled `SNAPSHOT_INVALID`
+- aged snapshot => `SNAPSHOT_STALE` (data still returned when parseable)
+- fresh valid snapshot => `SNAPSHOT_AVAILABLE`
+
+### POST /run contract
+
+Owned by `WEBUI_LOCAL_ADMIN_WRITE_SURFACE_AUTH_GATE_V1`:
+
+- fail-closed Local-Admin token gate
+- runner + writer allowed only after auth
+- token transport/redaction unchanged
+
+## Snapshot read states
+
+| State | Meaning |
+|-------|---------|
+| `SNAPSHOT_ABSENT` | Canonical JSON file not present |
+| `SNAPSHOT_INVALID` | Unreadable, oversized, non-UTF8, non-JSON, or wrong structure |
+| `SNAPSHOT_STALE` | Valid payload older than 24h |
+| `SNAPSHOT_AVAILABLE` | Valid payload within freshness window |
+
+Reader constraints:
+
+- fixed path only (`reports/ops/ci_health_latest.json`)
+- no request-derived paths
+- bounded file size
+- controlled UTF-8/JSON parsing
+- WebUI redaction via `redact_for_webui_payload`
+- no host/traceback leakage in client payloads
+
+## Explicit non-goals
+
+- Changing Local-Admin auth semantics
+- Securing unrelated GET routes outside CI-health
+- Market Dashboard authentication
+- Trading / risk / execution / runtime / order authority
+- Snapshot schema redesign beyond controlled reading
+- Host/CSRF/bind gates
+
+## Proof owners
+
+| Proof | Owner |
+|-------|-------|
+| GET no side effects + snapshot states | `tests/webui/test_ops_ci_health_router.py` |
+| POST auth + runner/writer | `tests/webui/test_ops_ci_health_router.py` |
+| Local-admin owner uniqueness | `tests/webui/test_webui_local_admin_write_surface_auth_gate_v1.py` |
+
+## Authority statement
+
+This capability does **not** change trading, risk, execution, scheduler, runtime, promotion, or capital semantics. It only removes execution/write side effects from CI-health GET surfaces.

--- a/docs/ops/specs/WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1.md
+++ b/docs/ops/specs/WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1.md
@@ -8,8 +8,8 @@
 
 Ensure:
 
-- `GET /ops/ci-health`
-- `GET /ops/ci-health/status`
+- `GET &#47;ops&#47;ci-health`
+- `GET &#47;ops&#47;ci-health&#47;status`
 
 are safe and idempotent:
 
@@ -19,7 +19,7 @@ are safe and idempotent:
 - no snapshot write / directory creation
 - no hidden refresh
 
-Only authenticated `POST /ops/ci-health/run` may execute checks and refresh snapshots.
+Only authenticated `POST &#47;ops&#47;ci-health&#47;run` may execute checks and refresh snapshots.
 
 ## Canonical owners (reuse)
 
@@ -27,7 +27,7 @@ Only authenticated `POST /ops/ci-health/run` may execute checks and refresh snap
 |------|------|
 | Router / runner / writer / reader | [`src/webui/ops_ci_health_router.py`](../../../src/webui/ops_ci_health_router.py) |
 | Local-admin write auth (unchanged) | [`src/webui/local_admin_write_auth_v1.py`](../../../src/webui/local_admin_write_auth_v1.py) |
-| Snapshot JSON | `reports/ops/ci_health_latest.json` |
+| Snapshot JSON | `reports&#47;ops&#47;ci_health_latest.json` |
 | Redaction boundary (reuse) | [`scripts/security/secret_hygiene_redaction_v1.py`](../../../scripts/security/secret_hygiene_redaction_v1.py) |
 | UI | [`templates/peak_trade_dashboard/ops_ci_health.html`](../../../templates/peak_trade_dashboard/ops_ci_health.html) |
 
@@ -37,9 +37,9 @@ A second CI-health router/runner/writer/auth owner is forbidden.
 
 | Method | Path | Behavior |
 |--------|------|----------|
-| `GET` | `/ops/ci-health` | Render persisted snapshot state only |
-| `GET` | `/ops/ci-health/status` | Return persisted snapshot JSON projection only |
-| `POST` | `/ops/ci-health/run` | Auth-gated execution + snapshot write (unchanged auth model) |
+| `GET` | `&#47;ops&#47;ci-health` | Render persisted snapshot state only |
+| `GET` | `&#47;ops&#47;ci-health&#47;status` | Return persisted snapshot JSON projection only |
+| `POST` | `&#47;ops&#47;ci-health&#47;run` | Auth-gated execution + snapshot write (unchanged auth model) |
 
 ### GET contract
 
@@ -69,7 +69,7 @@ Owned by `WEBUI_LOCAL_ADMIN_WRITE_SURFACE_AUTH_GATE_V1`:
 
 Reader constraints:
 
-- fixed path only (`reports/ops/ci_health_latest.json`)
+- fixed path only (`reports&#47;ops&#47;ci_health_latest.json`)
 - no request-derived paths
 - bounded file size
 - controlled UTF-8/JSON parsing

--- a/docs/ops/specs/WEBUI_LOCAL_ADMIN_WRITE_SURFACE_AUTH_GATE_V1.md
+++ b/docs/ops/specs/WEBUI_LOCAL_ADMIN_WRITE_SURFACE_AUTH_GATE_V1.md
@@ -36,7 +36,7 @@ A second auth/redaction/scanner/ruleset owner is forbidden.
 | `POST` | `&#47;api&#47;knowledge&#47;snippets` | Mutates Knowledge snippet store |
 | `POST` | `&#47;api&#47;knowledge&#47;strategies` | Mutates Knowledge strategy store |
 
-GET/read-only routes are unchanged by this capability.
+GET/read-only routes are unchanged by this auth capability (no Local-Admin requirement on GET). CI-health GET side-effect elimination is a separate capability: `WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1`.
 
 ## Auth model
 

--- a/docs/webui/observability/OBSERVABILITY_HUB_V0.md
+++ b/docs/webui/observability/OBSERVABILITY_HUB_V0.md
@@ -135,14 +135,16 @@ Stabile Marker fuer Tests/Vertrag:
 
 Das OPS-CI-Panel auf `GET &#47;observability` bleibt eine **statische Erklaer- und Linkflaeche** zu den bestehenden OPS-CI-**GET**-Oberflaechen:
 
-- **`GET &#47;ops&#47;ci-health`** — HTML-Dashboard (dedizierte CI-Health-Oberflaeche; kann dort eigene Schritte anbieten).
-- **`GET &#47;ops&#47;ci-health&#47;status`** — **bevorzugter read-only Status-Pfad** (JSON-Lesestatus vom Server; der Hub aggregiert nicht und ruft nichts serverseitig ab).
+- **`GET &#47;ops&#47;ci-health`** — HTML-Dashboard; liest ausschliesslich den persistierten Snapshot (`reports&#47;ops&#47;ci_health_latest.json`); fuehrt keine Checks aus.
+- **`GET &#47;ops&#47;ci-health&#47;status`** — bevorzugter read-only Status-Pfad; JSON-Projektion des letzten persistierten Snapshots; keine Check-Ausfuehrung, kein Snapshot-Write.
+- **`POST &#47;ops&#47;ci-health&#47;run`** — einzige explizite, Local-Admin-auth-gated Execution- und Snapshot-Write-Flaeche (nicht Teil des Observability Hub).
 
 Semantik und Grenzen (explizit):
 
 - The Observability Hub only links to OPS CI GET surfaces.
-- **`GET &#47;ops&#47;ci-health&#47;status`** ist der bevorzugte read-only Status-Pfad.
-- **`GET &#47;ops&#47;ci-health`** kann das dedizierte CI-Dashboard zeigen; der Hub selbst loest nichts aus.
+- **`GET &#47;ops&#47;ci-health&#47;status`** liest nur den letzten persistierten Snapshot und fuehrt keine Checks aus.
+- **`GET &#47;ops&#47;ci-health`** rendert denselben persistierten Zustand; der Hub selbst loest nichts aus.
+- Check-Ausfuehrung bleibt ausschliesslich bei authentisiertem **`POST &#47;ops&#47;ci-health&#47;run`** (`WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1`).
 - The Hub does not trigger workflows.
 - The Hub does not start GitHub Actions.
 - CI status display is not readiness approval.

--- a/src/webui/ops_ci_health_router.py
+++ b/src/webui/ops_ci_health_router.py
@@ -20,14 +20,18 @@ v0.2 Features:
   - Running state + error handling
 
 Endpoints:
-- GET  /ops/ci-health        - HTML dashboard page (with interactive controls)
-- GET  /ops/ci-health/status - JSON API für health checks (read-only)
-- POST /ops/ci-health/run    - Trigger check execution (with lock; local-admin auth required)
+- GET  /ops/ci-health        - HTML dashboard (strict read-only; persisted snapshot only)
+- GET  /ops/ci-health/status - JSON API (strict read-only; persisted snapshot only)
+- POST /ops/ci-health/run    - Trigger check execution + snapshot write (local-admin auth)
+
+Capability: WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1
+- GET routes never run checks, subprocess, git, or snapshot writers
+- Only POST /run may execute checks and refresh snapshots
 
 Safety:
 - Offline-lokal, keine externen Secrets
-- Read-only checks, keine destructive operations
-- In-memory lock prevents parallel runs (HTTP 409 on conflict)
+- GET is safe/idempotent (no filesystem mutation)
+- In-memory lock prevents parallel POST /run (HTTP 409 on conflict)
 - POST /run requires PEAK_TRADE_WEBUI_LOCAL_ADMIN_TOKEN via X-Peak-Trade-Local-Admin-Token
 """
 
@@ -47,6 +51,7 @@ from fastapi import APIRouter, Depends, Request, HTTPException
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 
+from scripts.security.secret_hygiene_redaction_v1 import redact_for_webui_payload
 from src.webui.local_admin_write_auth_v1 import require_local_admin_write_auth
 
 logger = logging.getLogger(__name__)
@@ -61,6 +66,20 @@ _TEMPLATES: Optional[Jinja2Templates] = None
 # In-memory lock for check execution (prevents parallel runs)
 _CHECK_LOCK = threading.Lock()
 _LAST_RUN_TIMESTAMP: Optional[datetime] = None
+
+# Canonical snapshot read contract (GET surfaces only)
+SNAPSHOT_JSON_RELATIVE_PATH = Path("reports") / "ops" / "ci_health_latest.json"
+SNAPSHOT_MAX_BYTES = 1_048_576
+SNAPSHOT_STALE_AFTER_SECONDS = 86_400
+SNAPSHOT_CHECK_FIELD_MAX_CHARS = 4_096
+SNAPSHOT_MAX_CHECKS = 64
+
+SNAPSHOT_STATE_ABSENT = "SNAPSHOT_ABSENT"
+SNAPSHOT_STATE_INVALID = "SNAPSHOT_INVALID"
+SNAPSHOT_STATE_STALE = "SNAPSHOT_STALE"
+SNAPSHOT_STATE_AVAILABLE = "SNAPSHOT_AVAILABLE"
+
+_SNAPSHOT_REQUIRED_TOP_LEVEL = frozenset({"overall_status", "summary", "checks", "generated_at"})
 
 
 @dataclass
@@ -397,6 +416,288 @@ def _write_markdown_summary(file, status_data: Dict[str, Any]) -> None:
 
 
 # =============================================================================
+# Snapshot read path (GET surfaces; no mutation)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class SnapshotReadModel:
+    """Controlled read-only projection of the canonical CI-health snapshot."""
+
+    state: str
+    message: str
+    data: Dict[str, Any]
+
+
+def _canonical_snapshot_json_path() -> Path:
+    """Return the fixed canonical snapshot path (never derived from request input)."""
+    return get_repo_root() / SNAPSHOT_JSON_RELATIVE_PATH
+
+
+def _empty_summary() -> Dict[str, int]:
+    return {"total": 0, "ok": 0, "warn": 0, "fail": 0, "skip": 0}
+
+
+def _parse_snapshot_timestamp(raw: Any) -> Optional[datetime]:
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    value = raw.strip()
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _truncate_text(value: Any, *, max_chars: int = SNAPSHOT_CHECK_FIELD_MAX_CHARS) -> str:
+    if value is None:
+        return ""
+    text = value if isinstance(value, str) else str(value)
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "…[truncated]"
+
+
+def _project_checks(raw_checks: Any) -> List[Dict[str, Any]]:
+    if not isinstance(raw_checks, list):
+        return []
+    projected: List[Dict[str, Any]] = []
+    for item in raw_checks[:SNAPSHOT_MAX_CHECKS]:
+        if not isinstance(item, dict):
+            continue
+        docs_refs = item.get("docs_refs") or []
+        if not isinstance(docs_refs, list):
+            docs_refs = []
+        projected.append(
+            {
+                "check_id": _truncate_text(item.get("check_id", "unknown"), max_chars=128),
+                "title": _truncate_text(item.get("title", "Unknown"), max_chars=256),
+                "description": _truncate_text(item.get("description", ""), max_chars=1024),
+                "status": _truncate_text(item.get("status", "UNKNOWN"), max_chars=32),
+                "exit_code": int(item["exit_code"])
+                if isinstance(item.get("exit_code"), int)
+                else -1,
+                "output": _truncate_text(item.get("output", "")),
+                "error_excerpt": _truncate_text(item.get("error_excerpt", "")),
+                "duration_ms": int(item["duration_ms"])
+                if isinstance(item.get("duration_ms"), int)
+                else 0,
+                "timestamp": _truncate_text(item.get("timestamp", ""), max_chars=64),
+                "script_path": _truncate_text(item.get("script_path", ""), max_chars=512),
+                "docs_refs": [
+                    _truncate_text(ref, max_chars=512)
+                    for ref in docs_refs[:16]
+                    if isinstance(ref, str)
+                ],
+            }
+        )
+    return projected
+
+
+def _checks_as_results(checks: List[Dict[str, Any]]) -> List[HealthCheckResult]:
+    return [
+        HealthCheckResult(
+            check_id=str(c.get("check_id", "unknown")),
+            title=str(c.get("title", "Unknown")),
+            description=str(c.get("description", "")),
+            status=str(c.get("status", "UNKNOWN")),
+            exit_code=int(c.get("exit_code", -1)),
+            output=str(c.get("output", "")),
+            error_excerpt=str(c.get("error_excerpt", "")),
+            duration_ms=int(c.get("duration_ms", 0)),
+            timestamp=str(c.get("timestamp", "")),
+            script_path=str(c.get("script_path", "")),
+            docs_refs=list(c.get("docs_refs") or []),
+        )
+        for c in checks
+    ]
+
+
+def _validate_snapshot_structure(payload: Any) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return "snapshot top-level value must be a JSON object"
+    missing = sorted(_SNAPSHOT_REQUIRED_TOP_LEVEL - set(payload.keys()))
+    if missing:
+        return f"snapshot missing required keys: {', '.join(missing)}"
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        return "snapshot.summary must be an object"
+    for key in ("total", "ok", "warn", "fail", "skip"):
+        if key not in summary:
+            return f"snapshot.summary missing key: {key}"
+    if not isinstance(payload.get("checks"), list):
+        return "snapshot.checks must be an array"
+    if not isinstance(payload.get("overall_status"), str):
+        return "snapshot.overall_status must be a string"
+    if not isinstance(payload.get("generated_at"), str):
+        return "snapshot.generated_at must be a string"
+    return None
+
+
+def read_canonical_ci_health_snapshot() -> SnapshotReadModel:
+    """Read the canonical CI-health JSON snapshot without mutation or execution.
+
+    Returns a controlled state machine:
+    SNAPSHOT_ABSENT | SNAPSHOT_INVALID | SNAPSHOT_STALE | SNAPSHOT_AVAILABLE
+    """
+    path = _canonical_snapshot_json_path()
+    try:
+        if not path.exists():
+            return SnapshotReadModel(
+                state=SNAPSHOT_STATE_ABSENT,
+                message="No persisted CI-health snapshot is available",
+                data={},
+            )
+        if not path.is_file():
+            return SnapshotReadModel(
+                state=SNAPSHOT_STATE_INVALID,
+                message="Canonical snapshot path is not a regular file",
+                data={},
+            )
+
+        size = path.stat().st_size
+        if size > SNAPSHOT_MAX_BYTES:
+            return SnapshotReadModel(
+                state=SNAPSHOT_STATE_INVALID,
+                message="Persisted snapshot exceeds maximum allowed size",
+                data={},
+            )
+
+        raw_bytes = path.read_bytes()
+        try:
+            raw_text = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            return SnapshotReadModel(
+                state=SNAPSHOT_STATE_INVALID,
+                message="Persisted snapshot is not valid UTF-8",
+                data={},
+            )
+
+        try:
+            payload = json.loads(raw_text)
+        except json.JSONDecodeError:
+            return SnapshotReadModel(
+                state=SNAPSHOT_STATE_INVALID,
+                message="Persisted snapshot is not valid JSON",
+                data={},
+            )
+
+        structure_error = _validate_snapshot_structure(payload)
+        if structure_error is not None:
+            return SnapshotReadModel(
+                state=SNAPSHOT_STATE_INVALID,
+                message=structure_error,
+                data={},
+            )
+
+        checks = _project_checks(payload.get("checks"))
+        summary_raw = payload.get("summary") or {}
+        summary = {
+            "total": int(summary_raw.get("total", len(checks)) or 0),
+            "ok": int(summary_raw.get("ok", 0) or 0),
+            "warn": int(summary_raw.get("warn", 0) or 0),
+            "fail": int(summary_raw.get("fail", 0) or 0),
+            "skip": int(summary_raw.get("skip", 0) or 0),
+        }
+
+        projected = {
+            "overall_status": str(payload.get("overall_status", "UNKNOWN")),
+            "summary": summary,
+            "checks": checks,
+            "generated_at": str(payload.get("generated_at")),
+            "server_timestamp_utc": (
+                str(payload["server_timestamp_utc"])
+                if isinstance(payload.get("server_timestamp_utc"), str)
+                else None
+            ),
+            "git_head_sha": (
+                str(payload["git_head_sha"])
+                if isinstance(payload.get("git_head_sha"), str)
+                else None
+            ),
+            "app_version": (
+                str(payload["app_version"])
+                if isinstance(payload.get("app_version"), str)
+                else "0.2.0"
+            ),
+        }
+
+        # Redact at WebUI serialization boundary (reuse canonical owner).
+        projected = redact_for_webui_payload(projected)
+        if not isinstance(projected, dict):
+            return SnapshotReadModel(
+                state=SNAPSHOT_STATE_INVALID,
+                message="Snapshot redaction produced an unexpected payload type",
+                data={},
+            )
+
+        ts = _parse_snapshot_timestamp(
+            projected.get("server_timestamp_utc") or projected.get("generated_at")
+        )
+        if ts is None:
+            return SnapshotReadModel(
+                state=SNAPSHOT_STATE_INVALID,
+                message="Snapshot timestamp is missing or unparseable",
+                data={},
+            )
+
+        age_seconds = (datetime.now(timezone.utc) - ts).total_seconds()
+        if age_seconds > SNAPSHOT_STALE_AFTER_SECONDS:
+            return SnapshotReadModel(
+                state=SNAPSHOT_STATE_STALE,
+                message="Persisted CI-health snapshot is stale; run POST /ops/ci-health/run to refresh",
+                data=projected,
+            )
+
+        return SnapshotReadModel(
+            state=SNAPSHOT_STATE_AVAILABLE,
+            message="Persisted CI-health snapshot is available",
+            data=projected,
+        )
+    except OSError:
+        logger.info("ci_health snapshot read failed with OSError (controlled invalid state)")
+        return SnapshotReadModel(
+            state=SNAPSHOT_STATE_INVALID,
+            message="Persisted snapshot could not be read",
+            data={},
+        )
+
+
+def _status_payload_from_snapshot(read_model: SnapshotReadModel) -> Dict[str, Any]:
+    """Build the GET /status JSON body from a SnapshotReadModel."""
+    data = read_model.data if isinstance(read_model.data, dict) else {}
+    summary = data.get("summary") if isinstance(data.get("summary"), dict) else _empty_summary()
+    checks = data.get("checks") if isinstance(data.get("checks"), list) else []
+    overall = data.get("overall_status")
+    if not isinstance(overall, str) or not overall:
+        overall = "UNKNOWN"
+
+    return {
+        "snapshot_state": read_model.state,
+        "message": read_model.message,
+        "read_only": True,
+        "execution_triggered": False,
+        "overall_status": overall,
+        "summary": {
+            "total": int(summary.get("total", 0) or 0),
+            "ok": int(summary.get("ok", 0) or 0),
+            "warn": int(summary.get("warn", 0) or 0),
+            "fail": int(summary.get("fail", 0) or 0),
+            "skip": int(summary.get("skip", 0) or 0),
+        },
+        "checks": checks,
+        "generated_at": data.get("generated_at"),
+        "server_timestamp_utc": data.get("server_timestamp_utc"),
+        "git_head_sha": data.get("git_head_sha"),
+        "app_version": data.get("app_version") or "0.2.0",
+    }
+
+
+# =============================================================================
 # API ENDPOINTS
 # =============================================================================
 
@@ -404,71 +705,15 @@ def _write_markdown_summary(file, status_data: Dict[str, Any]) -> None:
 @router.get("/status")
 async def get_ci_health_status() -> Dict[str, Any]:
     """
-    JSON API: Get CI & Governance health status (v0.2 with snapshot persistence).
+    JSON API: read the last persisted CI & Governance health snapshot.
 
-    Returns:
-        Dict with health check results and summary.
-
-    v0.2 Features:
-        - Persists snapshot to reports/ops/ci_health_latest.{json,md}
-        - Adds server_timestamp_utc, git_head_sha, app_version
-        - snapshot_write_error field if persistence failed
-        - Always returns 200 OK (even if snapshot write failed)
+    Strict read-only:
+        - no check execution
+        - no subprocess / git
+        - no snapshot write / directory creation
     """
-    results = _run_all_checks()
-
-    # Compute summary
-    total = len(results)
-    ok_count = sum(1 for r in results if r.status == "OK")
-    warn_count = sum(1 for r in results if r.status == "WARN")
-    fail_count = sum(1 for r in results if r.status == "FAIL")
-    skip_count = sum(1 for r in results if r.status == "SKIP")
-
-    overall_status = "OK"
-    if fail_count > 0:
-        overall_status = "FAIL"
-    elif warn_count > 0:
-        overall_status = "WARN"
-
-    # Build response (v0.2: enriched with git/timestamp)
-    response = {
-        "overall_status": overall_status,
-        "summary": {
-            "total": total,
-            "ok": ok_count,
-            "warn": warn_count,
-            "fail": fail_count,
-            "skip": skip_count,
-        },
-        "checks": [
-            {
-                "check_id": r.check_id,
-                "title": r.title,
-                "description": r.description,
-                "status": r.status,
-                "exit_code": r.exit_code,
-                "output": r.output,
-                "error_excerpt": r.error_excerpt,
-                "duration_ms": r.duration_ms,
-                "timestamp": r.timestamp,
-                "script_path": r.script_path,
-                "docs_refs": r.docs_refs,
-            }
-            for r in results
-        ],
-        "generated_at": datetime.now().isoformat(),
-        "server_timestamp_utc": datetime.now(timezone.utc).isoformat(),
-        "git_head_sha": _get_git_head_sha(),
-        "app_version": "0.2.0",  # CI Health API version
-    }
-
-    # v0.2: Persist snapshot (errors do NOT fail the API)
-    snapshot_error = _persist_snapshot(response)
-    if snapshot_error:
-        response["snapshot_write_error"] = snapshot_error
-        logger.warning(f"Snapshot write failed but API returns 200: {snapshot_error}")
-
-    return response
+    read_model = read_canonical_ci_health_snapshot()
+    return _status_payload_from_snapshot(read_model)
 
 
 @router.post("/run")
@@ -598,43 +843,33 @@ async def run_ci_health_checks(
 @router.get("", response_class=HTMLResponse)
 async def ci_health_dashboard(request: Request) -> Any:
     """
-    HTML Dashboard: CI & Governance Health Panel.
+    HTML Dashboard: CI & Governance Health Panel (persisted snapshot only).
 
-    Shows:
-    - Status cards (OK/FAIL/WARN) für jeden Check
-    - Letzte Laufzeit
-    - Kurzer Fehlerauszug (max 20 Zeilen)
-    - Links zu Dokumentation
+    Strict read-only:
+        - no check execution on page load
+        - no subprocess / git
+        - no snapshot write / directory creation
     """
     templates = get_templates()
-    results = _run_all_checks()
+    read_model = read_canonical_ci_health_snapshot()
+    payload = _status_payload_from_snapshot(read_model)
+    results = _checks_as_results(list(payload.get("checks") or []))
 
-    # Compute summary
-    total = len(results)
-    ok_count = sum(1 for r in results if r.status == "OK")
-    warn_count = sum(1 for r in results if r.status == "WARN")
-    fail_count = sum(1 for r in results if r.status == "FAIL")
-    skip_count = sum(1 for r in results if r.status == "SKIP")
-
-    overall_status = "OK"
-    if fail_count > 0:
-        overall_status = "FAIL"
-    elif warn_count > 0:
-        overall_status = "WARN"
+    generated_at = payload.get("generated_at")
+    if isinstance(generated_at, str) and generated_at.strip():
+        display_generated = generated_at
+    else:
+        display_generated = "n/a"
 
     context = {
         "request": request,
         "results": results,
-        "summary": {
-            "total": total,
-            "ok": ok_count,
-            "warn": warn_count,
-            "fail": fail_count,
-            "skip": skip_count,
-        },
-        "overall_status": overall_status,
+        "summary": payload["summary"],
+        "overall_status": payload["overall_status"],
+        "snapshot_state": payload["snapshot_state"],
+        "snapshot_message": payload["message"],
         "repo_root": str(get_repo_root()),
-        "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "generated_at": display_generated,
     }
 
     return templates.TemplateResponse(request, "ops_ci_health.html", context)

--- a/templates/peak_trade_dashboard/ops_ci_health.html
+++ b/templates/peak_trade_dashboard/ops_ci_health.html
@@ -63,8 +63,9 @@
               <div>
                 <h1 class="text-2xl font-bold mb-2">🔧 CI & Governance Health</h1>
                 <p class="text-sm text-slate-400">
-                  Lokale CI-Checks & Governance-Validierung
+                  Persistierter CI-Health-Snapshot (GET read-only; Ausführung nur via POST /run)
                   <span class="ml-2 text-xs text-slate-500" id="generated-at">Generated: {{ generated_at }}</span>
+                  <span class="ml-2 text-xs text-slate-500" id="snapshot-state">State: {{ snapshot_state }}</span>
                 </p>
               </div>
               <!-- Control Buttons (v0.2) -->
@@ -93,6 +94,19 @@
             </div>
           </div>
 
+          <!-- Snapshot read-state banner -->
+          <div id="snapshot-state-banner" class="mb-6 p-4 rounded-lg border
+                      {% if snapshot_state == 'SNAPSHOT_AVAILABLE' %}
+                        bg-emerald-500/10 border-emerald-500/30
+                      {% elif snapshot_state == 'SNAPSHOT_STALE' %}
+                        bg-amber-500/10 border-amber-500/30
+                      {% else %}
+                        bg-slate-500/10 border-slate-500/30
+                      {% endif %}">
+            <div class="text-sm font-semibold mb-1" id="snapshot-state-title">{{ snapshot_state }}</div>
+            <div class="text-xs opacity-80" id="snapshot-state-message">{{ snapshot_message }}</div>
+          </div>
+
           <!-- Error Banner (hidden by default) -->
           <div id="error-banner" class="hidden mb-6 p-4 bg-red-500/10 border border-red-500/30 rounded-lg">
             <div class="flex items-start gap-3">
@@ -112,12 +126,14 @@
                           bg-emerald-500/10 border-emerald-500/30 text-emerald-300
                         {% elif overall_status == 'WARN' %}
                           bg-amber-500/10 border-amber-500/30 text-amber-300
+                        {% elif overall_status == 'UNKNOWN' %}
+                          bg-slate-500/10 border-slate-500/30 text-slate-300
                         {% else %}
                           bg-red-500/10 border-red-500/30 text-red-300
                         {% endif %}"
                  id="overall-status-badge">
               <div class="text-3xl" id="overall-status-icon">
-                {% if overall_status == 'OK' %}✅{% elif overall_status == 'WARN' %}⚠️{% else %}❌{% endif %}
+                {% if overall_status == 'OK' %}✅{% elif overall_status == 'WARN' %}⚠️{% elif overall_status == 'UNKNOWN' %}ℹ️{% else %}❌{% endif %}
               </div>
               <div>
                 <div class="text-lg font-semibold" id="overall-status-text">{{ overall_status }}</div>
@@ -133,6 +149,12 @@
 
           <!-- Health Checks Grid -->
           <div class="grid gap-4" id="checks-container">
+            {% if not results %}
+            <div class="bg-slate-900/50 border border-slate-800 rounded-lg p-5 text-sm text-slate-400">
+              Keine Check-Ergebnisse im persistierten Snapshot. Explizit
+              <code>POST /ops/ci-health/run</code> mit Local-Admin-Token ausführen.
+            </div>
+            {% endif %}
             {% for result in results %}
             <div class="bg-slate-900/50 border border-slate-800 rounded-lg p-5">
               <!-- Check Header -->
@@ -379,21 +401,30 @@
 
       // Update UI with new data
       function updateUI(data) {
-        // Update timestamp
         const generatedAt = document.getElementById('generated-at');
-        if (generatedAt && data.generated_at) {
-          const date = new Date(data.generated_at);
-          generatedAt.textContent = `Generated: ${date.toLocaleString('de-DE')}`;
+        if (generatedAt) {
+          if (data.generated_at) {
+            const date = new Date(data.generated_at);
+            generatedAt.textContent = `Generated: ${date.toLocaleString('de-DE')}`;
+          } else {
+            generatedAt.textContent = 'Generated: n/a';
+          }
         }
 
-        // Update overall status badge
-        updateOverallStatus(data.overall_status, data.summary);
+        const stateEl = document.getElementById('snapshot-state');
+        if (stateEl && data.snapshot_state) {
+          stateEl.textContent = `State: ${data.snapshot_state}`;
+        }
+        const stateTitle = document.getElementById('snapshot-state-title');
+        const stateMsg = document.getElementById('snapshot-state-message');
+        if (stateTitle && data.snapshot_state) stateTitle.textContent = data.snapshot_state;
+        if (stateMsg && data.message) stateMsg.textContent = data.message;
 
-        // Update checks
-        updateChecks(data.checks);
+        const summary = data.summary || { total: 0, ok: 0, warn: 0, fail: 0, skip: 0 };
+        updateOverallStatus(data.overall_status || 'UNKNOWN', summary);
+        updateChecks(Array.isArray(data.checks) ? data.checks : []);
       }
 
-      // Update overall status badge
       function updateOverallStatus(status, summary) {
         const badge = document.getElementById('overall-status-badge');
         const icon = document.getElementById('overall-status-icon');
@@ -402,42 +433,44 @@
 
         if (!badge || !icon || !text || !summaryEl) return;
 
-        // Update icon
         if (status === 'OK') {
           icon.textContent = '✅';
         } else if (status === 'WARN') {
           icon.textContent = '⚠️';
+        } else if (status === 'UNKNOWN') {
+          icon.textContent = 'ℹ️';
         } else {
           icon.textContent = '❌';
         }
 
-        // Update text
         text.textContent = status;
 
-        // Update summary
-        let summaryText = `${summary.ok}/${summary.total} Checks OK`;
-        if (summary.warn > 0) summaryText += ` · ${summary.warn} Warnings`;
-        if (summary.fail > 0) summaryText += ` · ${summary.fail} Failed`;
-        if (summary.skip > 0) summaryText += ` · ${summary.skip} Skipped`;
+        let summaryText = `${summary.ok || 0}/${summary.total || 0} Checks OK`;
+        if ((summary.warn || 0) > 0) summaryText += ` · ${summary.warn} Warnings`;
+        if ((summary.fail || 0) > 0) summaryText += ` · ${summary.fail} Failed`;
+        if ((summary.skip || 0) > 0) summaryText += ` · ${summary.skip} Skipped`;
         summaryEl.textContent = summaryText;
 
-        // Update badge colors
         badge.className = 'inline-flex items-center gap-3 px-4 py-3 rounded-lg border ';
         if (status === 'OK') {
           badge.className += 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300';
         } else if (status === 'WARN') {
           badge.className += 'bg-amber-500/10 border-amber-500/30 text-amber-300';
+        } else if (status === 'UNKNOWN') {
+          badge.className += 'bg-slate-500/10 border-slate-500/30 text-slate-300';
         } else {
           badge.className += 'bg-red-500/10 border-red-500/30 text-red-300';
         }
       }
 
-      // Update checks cards
       function updateChecks(checks) {
         const container = document.getElementById('checks-container');
         if (!container) return;
+        if (!checks.length) {
+          container.innerHTML = '<div class="bg-slate-900/50 border border-slate-800 rounded-lg p-5 text-sm text-slate-400">Keine Check-Ergebnisse im persistierten Snapshot. Explizit <code>POST /ops/ci-health/run</code> mit Local-Admin-Token ausführen.</div>';
+          return;
+        }
 
-        // Rebuild checks HTML
         container.innerHTML = checks.map(check => `
           <div class="bg-slate-900/50 border border-slate-800 rounded-lg p-5">
             <div class="flex items-start justify-between mb-3">

--- a/tests/webui/test_ops_ci_health_router.py
+++ b/tests/webui/test_ops_ci_health_router.py
@@ -1,32 +1,38 @@
 """
 Tests for CI & Governance Health Router (ops_ci_health_router.py)
 
-Smoke tests for the CI Health Panel v0.2 (with snapshot persistence).
+Covers:
+- WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1 (GET read-only)
+- POST /ops/ci-health/run auth-gated execution + snapshot write
 """
 
 from __future__ import annotations
 
 import json
-from datetime import datetime
+import os
+import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
-# Patched: skip cleanly if optional dependency is not installed
 pytest.importorskip("fastapi")
 from fastapi import FastAPI
 from fastapi.templating import Jinja2Templates
 from fastapi.testclient import TestClient
 
-from src.webui.ops_ci_health_router import (
-    HealthCheckResult,
-    router as ci_health_router,
-    set_ci_health_config,
-)
 from src.webui.local_admin_write_auth_v1 import (
     AUTH_HEADER_NAME,
     AUTH_TOKEN_ENV_NAME,
+)
+from src.webui.ops_ci_health_router import (
+    SNAPSHOT_STATE_ABSENT,
+    SNAPSHOT_STATE_AVAILABLE,
+    SNAPSHOT_STATE_INVALID,
+    SNAPSHOT_STATE_STALE,
+    router as ci_health_router,
+    set_ci_health_config,
 )
 
 # Synthetic fixture token — deliberately not shaped like a production secret.
@@ -37,75 +43,92 @@ def _admin_headers() -> dict[str, str]:
     return {AUTH_HEADER_NAME: _FIXTURE_LOCAL_ADMIN_TOKEN}
 
 
+def _sample_snapshot(*, age: timedelta = timedelta(minutes=5), overall: str = "OK") -> dict:
+    ts = datetime.now(timezone.utc) - age
+    return {
+        "overall_status": overall,
+        "summary": {"total": 2, "ok": 2, "warn": 0, "fail": 0, "skip": 0},
+        "checks": [
+            {
+                "check_id": "contract_guard",
+                "title": "Contract Guard",
+                "description": "desc",
+                "status": "OK",
+                "exit_code": 0,
+                "output": "ok",
+                "error_excerpt": "",
+                "duration_ms": 12,
+                "timestamp": ts.isoformat(),
+                "script_path": "scripts/ops/check_required_ci_contexts_present.sh",
+                "docs_refs": ["docs/ops/README.md"],
+            },
+            {
+                "check_id": "docs_reference_validation",
+                "title": "Docs Reference Validation",
+                "description": "desc",
+                "status": "OK",
+                "exit_code": 0,
+                "output": "ok",
+                "error_excerpt": "",
+                "duration_ms": 8,
+                "timestamp": ts.isoformat(),
+                "script_path": "scripts/ops/verify_docs_reference_targets.sh",
+                "docs_refs": ["docs/ops/README.md"],
+            },
+        ],
+        "generated_at": ts.isoformat(),
+        "server_timestamp_utc": ts.isoformat(),
+        "git_head_sha": "deadbeef",
+        "app_version": "0.2.0",
+    }
+
+
+def _write_snapshot(repo_root: Path, payload: dict) -> Path:
+    path = repo_root / "reports" / "ops" / "ci_health_latest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
 @pytest.fixture
 def local_admin_token_env(monkeypatch: pytest.MonkeyPatch) -> str:
-    """Configure the local-admin server token for authenticated POST /run tests."""
     monkeypatch.setenv(AUTH_TOKEN_ENV_NAME, _FIXTURE_LOCAL_ADMIN_TOKEN)
     return _FIXTURE_LOCAL_ADMIN_TOKEN
 
 
 @pytest.fixture
 def mock_repo_root(tmp_path: Path) -> Path:
-    """Create a mock repository root with CI scripts."""
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
-
-    # Create scripts directory
     scripts_dir = repo_root / "scripts" / "ops"
     scripts_dir.mkdir(parents=True)
-
-    # Create mock CI check scripts
-    contract_guard = scripts_dir / "check_required_ci_contexts_present.sh"
-    contract_guard.write_text(
-        """#!/usr/bin/env bash
-set -euo pipefail
-echo "✅ CI required context contract looks good."
-exit 0
-"""
-    )
-    contract_guard.chmod(0o755)
-
-    docs_check = scripts_dir / "verify_docs_reference_targets.sh"
-    docs_check.write_text(
-        """#!/usr/bin/env bash
-set -euo pipefail
-echo "✅ All docs references valid."
-exit 0
-"""
-    )
-    docs_check.chmod(0o755)
-
+    for name in (
+        "check_required_ci_contexts_present.sh",
+        "verify_docs_reference_targets.sh",
+    ):
+        script = scripts_dir / name
+        script.write_text("#!/usr/bin/env bash\nset -euo pipefail\necho OK\nexit 0\n")
+        script.chmod(0o755)
     return repo_root
 
 
 @pytest.fixture
 def mock_templates(tmp_path: Path) -> Jinja2Templates:
-    """Create mock Jinja2Templates."""
     templates_dir = tmp_path / "templates"
     templates_dir.mkdir()
-
-    # Create minimal template (v0.2 with interactive controls)
-    template_file = templates_dir / "ops_ci_health.html"
-    template_file.write_text(
+    (templates_dir / "ops_ci_health.html").write_text(
         """<!doctype html>
 <html>
 <head><title>CI Health</title></head>
 <body>
 <h1>CI & Governance Health</h1>
 <p>Status: {{ overall_status }}</p>
+<p>Snapshot: {{ snapshot_state }}</p>
 <p>Total: {{ summary.total }}</p>
-
-<!-- v0.2 Interactive Controls -->
 <button id="run-checks-btn" onclick="runChecks()">Run checks now</button>
 <button id="refresh-btn" onclick="refreshStatus()">Refresh status</button>
 <input type="checkbox" id="auto-refresh-toggle" onchange="toggleAutoRefresh(this.checked)">
-
-<!-- Error Banner -->
-<div id="error-banner" class="hidden">
-  <div id="error-message"></div>
-  <button onclick="hideError()">Close</button>
-</div>
-
+<div id="error-banner" class="hidden"><div id="error-message"></div><button onclick="hideError()">Close</button></div>
 <script>
   async function runChecks() {
     const headers = {'Accept': 'application/json', 'Content-Type': 'application/json'};
@@ -122,31 +145,24 @@ def mock_templates(tmp_path: Path) -> Jinja2Templates:
 </html>
 """
     )
-
     return Jinja2Templates(directory=str(templates_dir))
 
 
 @pytest.fixture
 def test_app(mock_repo_root: Path, mock_templates: Jinja2Templates) -> FastAPI:
-    """Create test FastAPI app with CI Health router."""
     app = FastAPI()
-
-    # Configure router
     set_ci_health_config(mock_repo_root, mock_templates)
     app.include_router(ci_health_router)
-
     return app
 
 
 @pytest.fixture
 def client(test_app: FastAPI) -> TestClient:
-    """Create test client."""
     return TestClient(test_app)
 
 
 @pytest.fixture
 def client_real_ops_ci_health_template(mock_repo_root: Path) -> TestClient:
-    """GET /ops/ci-health using the repo's ops_ci_health.html (hub nav parity)."""
     repo_root = Path(__file__).resolve().parents[2]
     templates = Jinja2Templates(directory=str(repo_root / "templates" / "peak_trade_dashboard"))
     set_ci_health_config(mock_repo_root, templates)
@@ -155,24 +171,55 @@ def client_real_ops_ci_health_template(mock_repo_root: Path) -> TestClient:
     return TestClient(app)
 
 
+def _assert_get_no_side_effects(client: TestClient, mock_repo_root: Path, path: str) -> None:
+    reports = mock_repo_root / "reports"
+    before_exists = reports.exists()
+    snapshot = mock_repo_root / "reports" / "ops" / "ci_health_latest.json"
+    before_mtime = snapshot.stat().st_mtime_ns if snapshot.exists() else None
+    before_content = snapshot.read_bytes() if snapshot.exists() else None
+
+    with (
+        patch("src.webui.ops_ci_health_router._run_all_checks") as run_all,
+        patch("src.webui.ops_ci_health_router._run_check") as run_one,
+        patch("src.webui.ops_ci_health_router._persist_snapshot") as persist,
+        patch("src.webui.ops_ci_health_router._get_git_head_sha") as git_sha,
+        patch("src.webui.ops_ci_health_router.subprocess.run") as sp_run,
+    ):
+        response = client.get(path)
+        assert response.status_code == 200
+        run_all.assert_not_called()
+        run_one.assert_not_called()
+        persist.assert_not_called()
+        git_sha.assert_not_called()
+        sp_run.assert_not_called()
+
+    if before_exists:
+        assert reports.exists()
+    else:
+        assert not reports.exists()
+
+    if before_mtime is not None and before_content is not None:
+        assert snapshot.exists()
+        assert snapshot.stat().st_mtime_ns == before_mtime
+        assert snapshot.read_bytes() == before_content
+
+
 # =============================================================================
-# TESTS: HTML Dashboard Endpoint
+# GET root / status — no side effects
 # =============================================================================
 
 
 def test_ci_health_dashboard_renders(client: TestClient) -> None:
-    """Test that CI health dashboard renders successfully."""
     response = client.get("/ops/ci-health")
-
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
     assert "CI & Governance Health" in response.text
+    assert SNAPSHOT_STATE_ABSENT in response.text
 
 
 def test_ci_health_dashboard_standalone_hub_nav(
     client_real_ops_ci_health_template: TestClient,
 ) -> None:
-    """Standalone CI Health page includes same hub crosslinks as other Ops standalones."""
     response = client_real_ops_ci_health_template.get("/ops/ci-health")
     assert response.status_code == 200
     html = response.text
@@ -185,623 +232,341 @@ def test_ci_health_dashboard_standalone_hub_nav(
     assert "Run UI (companion)" in html
 
 
-def test_ci_health_dashboard_shows_status(client: TestClient) -> None:
-    """Test that dashboard shows overall status."""
-    response = client.get("/ops/ci-health")
-
-    assert response.status_code == 200
-    # Should show either OK, WARN, or FAIL
-    assert any(status in response.text for status in ["OK", "WARN", "FAIL"])
+def test_get_root_no_side_effects_absent(client: TestClient, mock_repo_root: Path) -> None:
+    _assert_get_no_side_effects(client, mock_repo_root, "/ops/ci-health")
+    assert not (mock_repo_root / "reports").exists()
 
 
-def test_ci_health_dashboard_shows_check_count(client: TestClient) -> None:
-    """Test that dashboard shows check count."""
-    response = client.get("/ops/ci-health")
-
-    assert response.status_code == 200
-    # Should show total count (we have 2 checks)
-    assert "Total:" in response.text or "summary" in response.text.lower()
-
-
-# =============================================================================
-# TESTS: JSON API Endpoint
-# =============================================================================
+def test_get_status_no_side_effects_absent(client: TestClient, mock_repo_root: Path) -> None:
+    _assert_get_no_side_effects(client, mock_repo_root, "/ops/ci-health/status")
+    data = client.get("/ops/ci-health/status").json()
+    assert data["snapshot_state"] == SNAPSHOT_STATE_ABSENT
+    assert data["read_only"] is True
+    assert data["execution_triggered"] is False
+    assert data["checks"] == []
+    assert not (mock_repo_root / "reports").exists()
 
 
-def test_ci_health_status_json(client: TestClient) -> None:
-    """Test that JSON status endpoint returns valid data."""
+def test_get_root_and_status_preserve_existing_snapshot(
+    client: TestClient, mock_repo_root: Path
+) -> None:
+    path = _write_snapshot(mock_repo_root, _sample_snapshot())
+    # Stabilize mtime across rapid successive stats on some filesystems.
+    os.utime(path, None)
+    time.sleep(0.01)
+    _assert_get_no_side_effects(client, mock_repo_root, "/ops/ci-health")
+    _assert_get_no_side_effects(client, mock_repo_root, "/ops/ci-health/status")
+
+
+def test_get_status_available_snapshot(client: TestClient, mock_repo_root: Path) -> None:
+    _write_snapshot(mock_repo_root, _sample_snapshot(age=timedelta(minutes=1)))
     response = client.get("/ops/ci-health/status")
-
     assert response.status_code == 200
     data = response.json()
+    assert data["snapshot_state"] == SNAPSHOT_STATE_AVAILABLE
+    assert data["overall_status"] == "OK"
+    assert data["summary"]["total"] == 2
+    assert len(data["checks"]) == 2
+    assert data["git_head_sha"] == "deadbeef"
+    assert data["read_only"] is True
 
-    # Validate structure
-    assert "overall_status" in data
-    assert "summary" in data
-    assert "checks" in data
-    assert "generated_at" in data
-    assert "server_timestamp_utc" in data
-    assert isinstance(data["generated_at"], str)
-    assert isinstance(data["server_timestamp_utc"], str)
-    assert datetime.fromisoformat(data["generated_at"].replace("Z", "+00:00"))
-    assert datetime.fromisoformat(data["server_timestamp_utc"].replace("Z", "+00:00"))
 
-    # Validate summary
-    summary = data["summary"]
-    assert "total" in summary
-    assert "ok" in summary
-    assert "warn" in summary
-    assert "fail" in summary
-    assert "skip" in summary
-
-    # Should have 2 checks
-    assert summary["total"] == 2
+def test_get_status_stale_snapshot(client: TestClient, mock_repo_root: Path) -> None:
+    _write_snapshot(mock_repo_root, _sample_snapshot(age=timedelta(hours=48)))
+    data = client.get("/ops/ci-health/status").json()
+    assert data["snapshot_state"] == SNAPSHOT_STATE_STALE
+    assert data["overall_status"] == "OK"
     assert len(data["checks"]) == 2
 
 
-def test_ci_health_status_check_structure(client: TestClient) -> None:
-    """Test that each check has required fields."""
-    response = client.get("/ops/ci-health/status")
-
-    assert response.status_code == 200
-    data = response.json()
-
-    for check in data["checks"]:
-        assert "check_id" in check
-        assert "title" in check
-        assert "description" in check
-        assert "status" in check
-        assert "exit_code" in check
-        assert "output" in check
-        assert "error_excerpt" in check
-        assert "duration_ms" in check
-        assert "timestamp" in check
-        assert "script_path" in check
-        assert "docs_refs" in check
-
-
-def test_ci_health_status_includes_contract_guard(client: TestClient) -> None:
-    """Test that contract guard check is included."""
-    response = client.get("/ops/ci-health/status")
-
-    assert response.status_code == 200
-    data = response.json()
-
-    check_ids = [check["check_id"] for check in data["checks"]]
-    assert "contract_guard" in check_ids
-
-
-def test_ci_health_status_includes_docs_validation(client: TestClient) -> None:
-    """Test that docs validation check is included."""
-    response = client.get("/ops/ci-health/status")
-
-    assert response.status_code == 200
-    data = response.json()
-
-    check_ids = [check["check_id"] for check in data["checks"]]
-    assert "docs_reference_validation" in check_ids
-
-
-# =============================================================================
-# TESTS: Check Execution
-# =============================================================================
-
-
-def test_ci_health_executes_checks(client: TestClient) -> None:
-    """Test that checks are actually executed."""
-    response = client.get("/ops/ci-health/status")
-
-    assert response.status_code == 200
-    data = response.json()
-
-    # At least one check should have OK status (our mock scripts return 0)
-    statuses = [check["status"] for check in data["checks"]]
-    assert "OK" in statuses or "SKIP" in statuses
-
-
-def test_ci_health_handles_missing_script(tmp_path: Path, mock_templates: Jinja2Templates) -> None:
-    """Test that missing scripts are handled gracefully."""
-    # Create repo without scripts
-    empty_repo = tmp_path / "empty_repo"
-    empty_repo.mkdir()
-
-    app = FastAPI()
-    set_ci_health_config(empty_repo, mock_templates)
-    app.include_router(ci_health_router)
-
-    client = TestClient(app)
-    response = client.get("/ops/ci-health/status")
-
-    assert response.status_code == 200
-    data = response.json()
-
-    # All checks should be skipped
-    statuses = [check["status"] for check in data["checks"]]
-    assert all(status == "SKIP" for status in statuses)
-
-
-# =============================================================================
-# TESTS: Error Handling
-# =============================================================================
-
-
-def test_ci_health_handles_failing_check(tmp_path: Path, mock_templates: Jinja2Templates) -> None:
-    """Test that failing checks are handled correctly."""
-    repo_root = tmp_path / "repo"
-    repo_root.mkdir()
-
-    scripts_dir = repo_root / "scripts" / "ops"
-    scripts_dir.mkdir(parents=True)
-
-    # Create failing script
-    failing_script = scripts_dir / "check_required_ci_contexts_present.sh"
-    failing_script.write_text(
-        """#!/usr/bin/env bash
-echo "❌ CI check failed!"
-exit 1
-"""
-    )
-    failing_script.chmod(0o755)
-
-    # Create passing script
-    passing_script = scripts_dir / "verify_docs_reference_targets.sh"
-    passing_script.write_text(
-        """#!/usr/bin/env bash
-echo "✅ OK"
-exit 0
-"""
-    )
-    passing_script.chmod(0o755)
-
-    app = FastAPI()
-    set_ci_health_config(repo_root, mock_templates)
-    app.include_router(ci_health_router)
-
-    client = TestClient(app)
-    response = client.get("/ops/ci-health/status")
-
-    assert response.status_code == 200
-    data = response.json()
-
-    # Overall status should be FAIL
-    assert data["overall_status"] == "FAIL"
-
-    # Should have 1 fail and 1 ok
-    assert data["summary"]["fail"] >= 1
-    assert data["summary"]["ok"] >= 1
-
-
-def test_ci_health_handles_warning_check(tmp_path: Path, mock_templates: Jinja2Templates) -> None:
-    """Test that warning checks (exit 2) are handled correctly."""
-    repo_root = tmp_path / "repo"
-    repo_root.mkdir()
-
-    scripts_dir = repo_root / "scripts" / "ops"
-    scripts_dir.mkdir(parents=True)
-
-    # Create warning script (exit 2)
-    warning_script = scripts_dir / "check_required_ci_contexts_present.sh"
-    warning_script.write_text(
-        """#!/usr/bin/env bash
-echo "⚠️ Warning: some issues found"
-exit 2
-"""
-    )
-    warning_script.chmod(0o755)
-
-    # Create passing script
-    passing_script = scripts_dir / "verify_docs_reference_targets.sh"
-    passing_script.write_text(
-        """#!/usr/bin/env bash
-echo "✅ OK"
-exit 0
-"""
-    )
-    passing_script.chmod(0o755)
-
-    app = FastAPI()
-    set_ci_health_config(repo_root, mock_templates)
-    app.include_router(ci_health_router)
-
-    client = TestClient(app)
-    response = client.get("/ops/ci-health/status")
-
-    assert response.status_code == 200
-    data = response.json()
-
-    # Overall status should be WARN
-    assert data["overall_status"] == "WARN"
-
-    # Should have 1 warn and 1 ok
-    assert data["summary"]["warn"] >= 1
-    assert data["summary"]["ok"] >= 1
-
-
-# =============================================================================
-# TESTS: Integration
-# =============================================================================
-
-
-def test_ci_health_full_workflow(client: TestClient) -> None:
-    """Test full workflow: HTML dashboard + JSON API."""
-    # 1. Get HTML dashboard
-    html_response = client.get("/ops/ci-health")
-    assert html_response.status_code == 200
-    assert "CI & Governance Health" in html_response.text
-
-    # 2. Get JSON status
-    json_response = client.get("/ops/ci-health/status")
-    assert json_response.status_code == 200
-    data = json_response.json()
-
-    # 3. Verify consistency
-    assert "overall_status" in data
-    assert data["summary"]["total"] == 2
-
-
-# =============================================================================
-# TESTS: v0.2 Snapshot Persistence
-# =============================================================================
-
-
-def test_ci_health_status_includes_v02_fields(client: TestClient) -> None:
-    """Test that v0.2 fields are present in status response."""
-    response = client.get("/ops/ci-health/status")
-
-    assert response.status_code == 200
-    data = response.json()
-
-    # v0.2 fields
-    assert "server_timestamp_utc" in data
-    assert "git_head_sha" in data
-    assert "app_version" in data
-    assert data["app_version"] == "0.2.0"
-
-
-def test_ci_health_snapshot_files_created(mock_repo_root: Path, client: TestClient) -> None:
-    """Test that snapshot files are created on successful status call."""
-    # Call status endpoint
-    response = client.get("/ops/ci-health/status")
-    assert response.status_code == 200
-
-    # Check that snapshot files exist
-    snapshot_dir = mock_repo_root / "reports" / "ops"
-    json_file = snapshot_dir / "ci_health_latest.json"
-    md_file = snapshot_dir / "ci_health_latest.md"
-
-    assert json_file.exists(), "JSON snapshot file should be created"
-    assert md_file.exists(), "Markdown snapshot file should be created"
-
-
-def test_ci_health_snapshot_json_content(mock_repo_root: Path, client: TestClient) -> None:
-    """Test that JSON snapshot contains complete status data."""
-    # Call status endpoint
-    response = client.get("/ops/ci-health/status")
-    assert response.status_code == 200
-    api_data = response.json()
-
-    # Read snapshot file
-    snapshot_file = mock_repo_root / "reports" / "ops" / "ci_health_latest.json"
-    assert snapshot_file.exists()
-
-    with open(snapshot_file, "r", encoding="utf-8") as f:
-        snapshot_data = json.load(f)
-
-    # Verify structure matches API response
-    assert snapshot_data["overall_status"] == api_data["overall_status"]
-    assert snapshot_data["summary"] == api_data["summary"]
-    assert len(snapshot_data["checks"]) == len(api_data["checks"])
-    assert "server_timestamp_utc" in snapshot_data
-    assert "git_head_sha" in snapshot_data
-
-
-def test_ci_health_snapshot_md_content(mock_repo_root: Path, client: TestClient) -> None:
-    """Test that Markdown snapshot is human-readable."""
-    # Call status endpoint
-    response = client.get("/ops/ci-health/status")
-    assert response.status_code == 200
-
-    # Read markdown file
-    md_file = mock_repo_root / "reports" / "ops" / "ci_health_latest.md"
-    assert md_file.exists()
-
-    content = md_file.read_text(encoding="utf-8")
-
-    # Verify markdown structure
-    assert "# CI & Governance Health Snapshot" in content
-    assert "**Overall Status:**" in content
-    assert "## Summary" in content
-    assert "## Checks" in content
-    assert "**Total Checks:**" in content
-
-
-def test_ci_health_snapshot_atomic_write(mock_repo_root: Path, client: TestClient) -> None:
-    """Test that snapshot uses atomic writes (no .tmp files left behind)."""
-    # Call status endpoint
-    response = client.get("/ops/ci-health/status")
-    assert response.status_code == 200
-
-    # Check that no temp files exist
-    snapshot_dir = mock_repo_root / "reports" / "ops"
-    tmp_files = list(snapshot_dir.glob("*.tmp"))
-
-    assert len(tmp_files) == 0, "No temporary files should remain after atomic write"
-
-
-def test_ci_health_snapshot_error_handling(tmp_path: Path, mock_templates: Jinja2Templates) -> None:
-    """Test that snapshot write errors do NOT fail the API."""
-    # Create repo with unwritable reports directory
-    repo_root = tmp_path / "repo"
-    repo_root.mkdir()
-
-    scripts_dir = repo_root / "scripts" / "ops"
-    scripts_dir.mkdir(parents=True)
-
-    # Create passing scripts
-    contract_guard = scripts_dir / "check_required_ci_contexts_present.sh"
-    contract_guard.write_text("#!/usr/bin/env bash\necho 'OK'\nexit 0\n")
-    contract_guard.chmod(0o755)
-
-    docs_check = scripts_dir / "verify_docs_reference_targets.sh"
-    docs_check.write_text("#!/usr/bin/env bash\necho 'OK'\nexit 0\n")
-    docs_check.chmod(0o755)
-
-    # Create reports dir but make it read-only
-    reports_dir = repo_root / "reports" / "ops"
-    reports_dir.mkdir(parents=True)
-    reports_dir.chmod(0o444)  # Read-only
-
-    app = FastAPI()
-    set_ci_health_config(repo_root, mock_templates)
-    app.include_router(ci_health_router)
-
-    client = TestClient(app)
-
-    try:
-        # Call status endpoint - should still return 200
-        response = client.get("/ops/ci-health/status")
-        assert response.status_code == 200
-
-        data = response.json()
-
-        # Should have snapshot_write_error field
-        assert "snapshot_write_error" in data
-        assert "Failed to persist snapshot" in data["snapshot_write_error"]
-
-        # But overall status should still be valid
-        assert "overall_status" in data
-        assert "checks" in data
-
-    finally:
-        # Cleanup: restore permissions
-        reports_dir.chmod(0o755)
-
-
-def test_ci_health_snapshot_multiple_calls(mock_repo_root: Path, client: TestClient) -> None:
-    """Test that multiple status calls overwrite snapshot (latest wins)."""
-    # First call
-    response1 = client.get("/ops/ci-health/status")
-    assert response1.status_code == 200
-    data1 = response1.json()
-
-    # Read first snapshot
-    json_file = mock_repo_root / "reports" / "ops" / "ci_health_latest.json"
-    with open(json_file, "r", encoding="utf-8") as f:
-        snapshot1 = json.load(f)
-
-    # Second call (should overwrite)
-    response2 = client.get("/ops/ci-health/status")
-    assert response2.status_code == 200
-    data2 = response2.json()
-
-    # Read second snapshot
-    with open(json_file, "r", encoding="utf-8") as f:
-        snapshot2 = json.load(f)
-
-    # Timestamps should differ
-    assert snapshot1["generated_at"] != snapshot2["generated_at"]
-
-    # File should contain latest data
-    assert snapshot2["generated_at"] == data2["generated_at"]
-
-
-def test_ci_health_snapshot_directory_creation(
-    tmp_path: Path, mock_templates: Jinja2Templates
+def test_get_status_invalid_json(client: TestClient, mock_repo_root: Path) -> None:
+    path = mock_repo_root / "reports" / "ops" / "ci_health_latest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not-json", encoding="utf-8")
+    data = client.get("/ops/ci-health/status").json()
+    assert data["snapshot_state"] == SNAPSHOT_STATE_INVALID
+    assert data["checks"] == []
+    assert data["overall_status"] == "UNKNOWN"
+
+
+def test_get_status_invalid_structure(client: TestClient, mock_repo_root: Path) -> None:
+    _write_snapshot(mock_repo_root, {"overall_status": "OK", "checks": []})
+    data = client.get("/ops/ci-health/status").json()
+    assert data["snapshot_state"] == SNAPSHOT_STATE_INVALID
+    assert data["checks"] == []
+
+
+def test_get_status_does_not_depend_on_admin_token(
+    client: TestClient, mock_repo_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test that snapshot directory is created if missing."""
-    # Create repo WITHOUT reports directory
-    repo_root = tmp_path / "repo"
-    repo_root.mkdir()
-
-    scripts_dir = repo_root / "scripts" / "ops"
-    scripts_dir.mkdir(parents=True)
-
-    # Create passing scripts
-    contract_guard = scripts_dir / "check_required_ci_contexts_present.sh"
-    contract_guard.write_text("#!/usr/bin/env bash\necho 'OK'\nexit 0\n")
-    contract_guard.chmod(0o755)
-
-    docs_check = scripts_dir / "verify_docs_reference_targets.sh"
-    docs_check.write_text("#!/usr/bin/env bash\necho 'OK'\nexit 0\n")
-    docs_check.chmod(0o755)
-
-    # Verify reports dir does NOT exist
-    reports_dir = repo_root / "reports" / "ops"
-    assert not reports_dir.exists()
-
-    app = FastAPI()
-    set_ci_health_config(repo_root, mock_templates)
-    app.include_router(ci_health_router)
-
-    client = TestClient(app)
-
-    # Call status endpoint
+    monkeypatch.delenv(AUTH_TOKEN_ENV_NAME, raising=False)
+    _write_snapshot(mock_repo_root, _sample_snapshot())
     response = client.get("/ops/ci-health/status")
     assert response.status_code == 200
+    assert response.json()["snapshot_state"] == SNAPSHOT_STATE_AVAILABLE
 
-    # Directory should now exist
-    assert reports_dir.exists()
-    assert (reports_dir / "ci_health_latest.json").exists()
-    assert (reports_dir / "ci_health_latest.md").exists()
+
+def test_get_root_renders_available_snapshot(client: TestClient, mock_repo_root: Path) -> None:
+    _write_snapshot(mock_repo_root, _sample_snapshot())
+    response = client.get("/ops/ci-health")
+    assert response.status_code == 200
+    assert SNAPSHOT_STATE_AVAILABLE in response.text
+    assert "OK" in response.text
+    assert "Total: 2" in response.text
+
+
+def test_ci_health_dashboard_contains_buttons(client: TestClient) -> None:
+    response = client.get("/ops/ci-health")
+    assert response.status_code == 200
+    html = response.text
+    assert "run-checks-btn" in html
+    assert "refresh-btn" in html
+    assert "auto-refresh-toggle" in html
+    assert "runChecks()" in html
+    assert "refreshStatus()" in html
+    assert "/ops/ci-health/run" in html
+    assert "/ops/ci-health/status" in html
+    assert AUTH_HEADER_NAME in html
+    assert AUTH_TOKEN_ENV_NAME not in html
+    assert _FIXTURE_LOCAL_ADMIN_TOKEN not in html
+
+
+def test_ci_health_dashboard_has_error_banner(client: TestClient) -> None:
+    response = client.get("/ops/ci-health")
+    assert response.status_code == 200
+    assert "error-banner" in response.text
+    assert "hideError()" in response.text
+
+
+def test_ci_health_full_workflow_read_then_run(
+    client: TestClient, mock_repo_root: Path, local_admin_token_env: str
+) -> None:
+    absent = client.get("/ops/ci-health/status").json()
+    assert absent["snapshot_state"] == SNAPSHOT_STATE_ABSENT
+
+    run = client.post("/ops/ci-health/run", headers=_admin_headers())
+    assert run.status_code == 200
+    assert run.json()["run_triggered"] is True
+
+    status = client.get("/ops/ci-health/status").json()
+    assert status["snapshot_state"] in {SNAPSHOT_STATE_AVAILABLE, SNAPSHOT_STATE_STALE}
+    assert status["summary"]["total"] == 2
+    assert local_admin_token_env not in run.text
 
 
 # =============================================================================
-# TESTS: v0.2 Run-Now Buttons & Interactive Controls
+# POST /run — execution + auth (unchanged contract)
 # =============================================================================
 
 
 def test_ci_health_run_endpoint_returns_200(client: TestClient, local_admin_token_env: str) -> None:
-    """Test that POST /run endpoint returns 200 with valid JSON."""
     response = client.post("/ops/ci-health/run", headers=_admin_headers())
-
     assert response.status_code == 200
     data = response.json()
-
-    # Validate structure (same as GET /status)
     assert "overall_status" in data
     assert "summary" in data
     assert "checks" in data
-    assert "generated_at" in data
-    assert "server_timestamp_utc" in data
-    assert isinstance(data["generated_at"], str)
-    assert isinstance(data["server_timestamp_utc"], str)
-    assert datetime.fromisoformat(data["generated_at"].replace("Z", "+00:00"))
-    assert datetime.fromisoformat(data["server_timestamp_utc"].replace("Z", "+00:00"))
-    assert "git_head_sha" in data
-    assert "app_version" in data
-
-    # v0.2 run-specific field
-    assert "run_triggered" in data
     assert data["run_triggered"] is True
+    assert data["app_version"] == "0.2.0"
     assert local_admin_token_env not in response.text
 
 
 def test_ci_health_run_endpoint_executes_checks(
     client: TestClient, local_admin_token_env: str
 ) -> None:
-    """Test that POST /run actually executes checks."""
     response = client.post("/ops/ci-health/run", headers=_admin_headers())
-
     assert response.status_code == 200
     data = response.json()
-
-    # Should have 2 checks
     assert len(data["checks"]) == 2
     assert data["summary"]["total"] == 2
-
-    # At least one check should have OK status (our mock scripts return 0)
     statuses = [check["status"] for check in data["checks"]]
     assert "OK" in statuses or "SKIP" in statuses
-
-
-def test_ci_health_run_parallel_returns_409(client: TestClient, local_admin_token_env: str) -> None:
-    """Test that parallel run attempts return HTTP 409."""
-    # Note: TestClient is synchronous, so we test the lock mechanism directly
-    # by calling the endpoint multiple times rapidly
-
-    # First call should succeed
-    response1 = client.post("/ops/ci-health/run", headers=_admin_headers())
-    assert response1.status_code == 200
-
-    # For testing lock behavior, we verify that sequential calls work
-    # (lock is released after first call completes)
-    response2 = client.post("/ops/ci-health/run", headers=_admin_headers())
-    assert response2.status_code == 200
-
-    # Both should have valid data
-    data1 = response1.json()
-    data2 = response2.json()
-
-    assert "overall_status" in data1
-    assert "overall_status" in data2
-    assert data1["run_triggered"] is True
-    assert data2["run_triggered"] is True
 
 
 def test_ci_health_run_creates_snapshot(
     mock_repo_root: Path, client: TestClient, local_admin_token_env: str
 ) -> None:
-    """Test that POST /run creates snapshot files."""
-    # Call run endpoint
     response = client.post("/ops/ci-health/run", headers=_admin_headers())
     assert response.status_code == 200
-
-    # Check that snapshot files exist
     snapshot_dir = mock_repo_root / "reports" / "ops"
-    json_file = snapshot_dir / "ci_health_latest.json"
-    md_file = snapshot_dir / "ci_health_latest.md"
-
-    assert json_file.exists(), "JSON snapshot should be created by /run"
-    assert md_file.exists(), "Markdown snapshot should be created by /run"
+    assert (snapshot_dir / "ci_health_latest.json").exists()
+    assert (snapshot_dir / "ci_health_latest.md").exists()
 
 
-def test_ci_health_dashboard_contains_buttons(client: TestClient) -> None:
-    """Test that HTML dashboard contains interactive control buttons."""
-    response = client.get("/ops/ci-health")
-
+def test_ci_health_run_snapshot_json_content(
+    mock_repo_root: Path, client: TestClient, local_admin_token_env: str
+) -> None:
+    response = client.post("/ops/ci-health/run", headers=_admin_headers())
     assert response.status_code == 200
-    html = response.text
-
-    # Check for button elements
-    assert "run-checks-btn" in html, "Run checks button should be present"
-    assert "refresh-btn" in html, "Refresh button should be present"
-    assert "auto-refresh-toggle" in html, "Auto-refresh toggle should be present"
-
-    # Check for JavaScript functions
-    assert "runChecks()" in html, "runChecks() function should be present"
-    assert "refreshStatus()" in html, "refreshStatus() function should be present"
-    assert "toggleAutoRefresh" in html, "toggleAutoRefresh() function should be present"
-
-    # Check for fetch API calls
-    assert "/ops/ci-health/run" in html, "POST /run endpoint should be referenced"
-    assert "/ops/ci-health/status" in html, "GET /status endpoint should be referenced"
-    assert AUTH_HEADER_NAME in html, "Local-admin auth header name should be referenced"
-    assert AUTH_TOKEN_ENV_NAME not in html
-    assert _FIXTURE_LOCAL_ADMIN_TOKEN not in html
+    api_data = response.json()
+    snapshot_file = mock_repo_root / "reports" / "ops" / "ci_health_latest.json"
+    snapshot_data = json.loads(snapshot_file.read_text(encoding="utf-8"))
+    assert snapshot_data["overall_status"] == api_data["overall_status"]
+    assert snapshot_data["summary"] == api_data["summary"]
+    assert len(snapshot_data["checks"]) == len(api_data["checks"])
 
 
-def test_ci_health_dashboard_has_error_banner(client: TestClient) -> None:
-    """Test that HTML dashboard has error banner element."""
-    response = client.get("/ops/ci-health")
-
+def test_ci_health_run_snapshot_md_content(
+    mock_repo_root: Path, client: TestClient, local_admin_token_env: str
+) -> None:
+    response = client.post("/ops/ci-health/run", headers=_admin_headers())
     assert response.status_code == 200
-    html = response.text
+    content = (mock_repo_root / "reports" / "ops" / "ci_health_latest.md").read_text(
+        encoding="utf-8"
+    )
+    assert "# CI & Governance Health Snapshot" in content
+    assert "**Overall Status:**" in content
 
-    # Check for error banner
-    assert "error-banner" in html, "Error banner should be present"
-    assert "error-message" in html, "Error message element should be present"
-    assert "hideError()" in html, "hideError() function should be present"
+
+def test_ci_health_run_atomic_write(
+    mock_repo_root: Path, client: TestClient, local_admin_token_env: str
+) -> None:
+    response = client.post("/ops/ci-health/run", headers=_admin_headers())
+    assert response.status_code == 200
+    tmp_files = list((mock_repo_root / "reports" / "ops").glob("*.tmp"))
+    assert tmp_files == []
+
+
+def test_ci_health_run_directory_creation(
+    tmp_path: Path, mock_templates: Jinja2Templates, local_admin_token_env: str
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    scripts_dir = repo_root / "scripts" / "ops"
+    scripts_dir.mkdir(parents=True)
+    for name in (
+        "check_required_ci_contexts_present.sh",
+        "verify_docs_reference_targets.sh",
+    ):
+        script = scripts_dir / name
+        script.write_text("#!/usr/bin/env bash\necho OK\nexit 0\n")
+        script.chmod(0o755)
+
+    reports_dir = repo_root / "reports" / "ops"
+    assert not reports_dir.exists()
+
+    app = FastAPI()
+    set_ci_health_config(repo_root, mock_templates)
+    app.include_router(ci_health_router)
+    client = TestClient(app)
+
+    response = client.post("/ops/ci-health/run", headers=_admin_headers())
+    assert response.status_code == 200
+    assert reports_dir.exists()
+    assert (reports_dir / "ci_health_latest.json").exists()
+
+
+def test_ci_health_run_handles_failing_check(
+    tmp_path: Path, mock_templates: Jinja2Templates, local_admin_token_env: str
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    scripts_dir = repo_root / "scripts" / "ops"
+    scripts_dir.mkdir(parents=True)
+    failing = scripts_dir / "check_required_ci_contexts_present.sh"
+    failing.write_text("#!/usr/bin/env bash\necho FAIL\nexit 1\n")
+    failing.chmod(0o755)
+    passing = scripts_dir / "verify_docs_reference_targets.sh"
+    passing.write_text("#!/usr/bin/env bash\necho OK\nexit 0\n")
+    passing.chmod(0o755)
+
+    app = FastAPI()
+    set_ci_health_config(repo_root, mock_templates)
+    app.include_router(ci_health_router)
+    client = TestClient(app)
+
+    data = client.post("/ops/ci-health/run", headers=_admin_headers()).json()
+    assert data["overall_status"] == "FAIL"
+    assert data["summary"]["fail"] >= 1
+
+
+def test_ci_health_run_handles_warning_check(
+    tmp_path: Path, mock_templates: Jinja2Templates, local_admin_token_env: str
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    scripts_dir = repo_root / "scripts" / "ops"
+    scripts_dir.mkdir(parents=True)
+    warning = scripts_dir / "check_required_ci_contexts_present.sh"
+    warning.write_text("#!/usr/bin/env bash\necho WARN\nexit 2\n")
+    warning.chmod(0o755)
+    passing = scripts_dir / "verify_docs_reference_targets.sh"
+    passing.write_text("#!/usr/bin/env bash\necho OK\nexit 0\n")
+    passing.chmod(0o755)
+
+    app = FastAPI()
+    set_ci_health_config(repo_root, mock_templates)
+    app.include_router(ci_health_router)
+    client = TestClient(app)
+
+    data = client.post("/ops/ci-health/run", headers=_admin_headers()).json()
+    assert data["overall_status"] == "WARN"
+    assert data["summary"]["warn"] >= 1
+
+
+def test_ci_health_run_handles_missing_script(
+    tmp_path: Path, mock_templates: Jinja2Templates, local_admin_token_env: str
+) -> None:
+    empty_repo = tmp_path / "empty_repo"
+    empty_repo.mkdir()
+    app = FastAPI()
+    set_ci_health_config(empty_repo, mock_templates)
+    app.include_router(ci_health_router)
+    client = TestClient(app)
+    data = client.post("/ops/ci-health/run", headers=_admin_headers()).json()
+    assert all(status == "SKIP" for status in [c["status"] for c in data["checks"]])
+
+
+def test_ci_health_run_snapshot_error_handling(
+    tmp_path: Path, mock_templates: Jinja2Templates, local_admin_token_env: str
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    scripts_dir = repo_root / "scripts" / "ops"
+    scripts_dir.mkdir(parents=True)
+    for name in (
+        "check_required_ci_contexts_present.sh",
+        "verify_docs_reference_targets.sh",
+    ):
+        script = scripts_dir / name
+        script.write_text("#!/usr/bin/env bash\necho OK\nexit 0\n")
+        script.chmod(0o755)
+
+    reports_dir = repo_root / "reports" / "ops"
+    reports_dir.mkdir(parents=True)
+    reports_dir.chmod(0o444)
+
+    app = FastAPI()
+    set_ci_health_config(repo_root, mock_templates)
+    app.include_router(ci_health_router)
+    client = TestClient(app)
+    try:
+        response = client.post("/ops/ci-health/run", headers=_admin_headers())
+        assert response.status_code == 200
+        data = response.json()
+        assert "snapshot_write_error" in data
+        assert "Failed to persist snapshot" in data["snapshot_write_error"]
+        assert "overall_status" in data
+    finally:
+        reports_dir.chmod(0o755)
 
 
 def test_ci_health_run_sequential_calls_work(
     client: TestClient, local_admin_token_env: str
 ) -> None:
-    """Test that sequential run calls work (lock is released)."""
-    # First call
     response1 = client.post("/ops/ci-health/run", headers=_admin_headers())
-    assert response1.status_code == 200
-
-    # Second call (should also succeed since lock was released)
     response2 = client.post("/ops/ci-health/run", headers=_admin_headers())
+    assert response1.status_code == 200
     assert response2.status_code == 200
-
-    # Both should have valid data
-    data1 = response1.json()
-    data2 = response2.json()
-
-    assert "overall_status" in data1
-    assert "overall_status" in data2
-    assert data1["run_triggered"] is True
-    assert data2["run_triggered"] is True
+    assert response1.json()["run_triggered"] is True
+    assert response2.json()["run_triggered"] is True
 
 
 def test_ci_health_run_rejects_missing_auth_without_side_effects(
     mock_repo_root: Path, client: TestClient, local_admin_token_env: str
 ) -> None:
-    """Unauthenticated POST /run must not execute checks or write reports."""
     snapshot_dir = mock_repo_root / "reports" / "ops"
     assert not snapshot_dir.exists()
-
     with patch(
         "src.webui.ops_ci_health_router._run_all_checks",
         side_effect=AssertionError("subprocess path must not run"),
@@ -810,18 +575,14 @@ def test_ci_health_run_rejects_missing_auth_without_side_effects(
         assert response.status_code == 401
         assert response.json()["detail"]["error"] == "LOCAL_ADMIN_AUTH_MISSING"
         mocked.assert_not_called()
-
     assert not snapshot_dir.exists()
-    assert local_admin_token_env not in response.text
 
 
 def test_ci_health_run_rejects_invalid_auth_without_side_effects(
     mock_repo_root: Path, client: TestClient, local_admin_token_env: str
 ) -> None:
-    """Invalid-token POST /run must not execute checks or write reports."""
     snapshot_dir = mock_repo_root / "reports" / "ops"
     assert not snapshot_dir.exists()
-
     with patch(
         "src.webui.ops_ci_health_router._run_all_checks",
         side_effect=AssertionError("subprocess path must not run"),
@@ -833,13 +594,4 @@ def test_ci_health_run_rejects_invalid_auth_without_side_effects(
         assert response.status_code == 403
         assert response.json()["detail"]["error"] == "LOCAL_ADMIN_AUTH_INVALID"
         mocked.assert_not_called()
-
     assert not snapshot_dir.exists()
-    assert local_admin_token_env not in response.text
-
-
-def test_ci_health_get_status_unchanged_without_admin_token(client: TestClient) -> None:
-    """GET /status remains available without local-admin authentication."""
-    response = client.get("/ops/ci-health/status")
-    assert response.status_code == 200
-    assert "overall_status" in response.json()


### PR DESCRIPTION
## Summary
- Make `GET /ops/ci-health` and `GET /ops/ci-health/status` strictly read-only: they only read `reports/ops/ci_health_latest.json` via a canonical in-module snapshot reader (`SNAPSHOT_ABSENT|INVALID|STALE|AVAILABLE`).
- Keep check execution and snapshot writes exclusively on auth-gated `POST /ops/ci-health/run` (`local_admin_write_auth_v1` unchanged).
- Update CI-health tests, Observability Hub wording, and add capability spec `WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1`.

## Test plan
- [x] `pytest tests/webui/test_ops_ci_health_router.py tests/webui/test_webui_local_admin_write_surface_auth_gate_v1.py`
- [x] PR-bounded selector gate batch (774 tests) green in ~49s
- [x] AST proof: GET handlers call only snapshot-read path (no runner/writer/subprocess)
- [ ] CI confirmation on PR

## Capability
`WEBUI_CI_HEALTH_READ_SURFACE_SIDE_EFFECT_ELIMINATION_V1`


Made with [Cursor](https://cursor.com)