### PR TITLE
feat(master-v2): C3 directional assessment confirmation integration v1

### DIFF
--- a/config/governance/technical_canonical_wiring_authorization_v1.json
+++ b/config/governance/technical_canonical_wiring_authorization_v1.json
@@ -725,7 +725,10 @@
     "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/safety_attestation.md",
     "docs/evidence/preregister_bollinger_mr_midband_exit_reentry_cooldown_holdout_v1/timing_proof.txt",
     "docs/governance/CANONICAL_OPEN_MR_EXIT_EFFICIENCY_HYPOTHESIS_BACKLOG_V1.md",
-    "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md"
+    "docs/governance/PEAK_TRADE_AUTONOMY_RUNBOOK_PROGRESS_V1.md",
+    "src/trading/master_v2/directional_assessment_confirmation_integration_v1.py",
+    "src/trading/master_v2/directional_assessment_v1.py",
+    "tests/trading/master_v2/test_directional_assessment_confirmation_integration_v1.py"
   ],
   "allowed_surface_classes": [
     "TECHNICAL_CANONICAL_REPLAY_INPUT_BUILDER_WIRING",
@@ -870,7 +873,8 @@
     "Includes V7 DEVELOPMENT evaluation authorization ratification separate from immutable preregistration; requires released DEVELOPMENT panel; transitions lifecycle to EVALUATION_AUTHORIZED; does not start runner or claim run slot; next step awaits separate run Operator-GO. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V7.",
     "Includes IMPLEMENTATION_ONLY evaluation wiring surfaces for Bollinger/MR midband exit reentry-cooldown V8 bound to Operator Clarification Authority B1-B6; preregistration digest and semantics remain immutable; EVALUATION_RUN_COUNT=0; default CLI preflight-only; evaluate requires hypothesis-specific authorization flag AND effective ratification/lifecycle authorization (prereg evaluation_authorized field remains false); pre-authorization frozen-parameter parity required before runner authorization/slot; evaluate evidence directory is not pre-created; no evaluation executed here; no holdout; Economic/promotion closed; no Master-V2/Double-Play/risk/sizing/execution mutation; no runtime/orders. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_V8.",
     "Includes V8 Operator Clarification Authority overlay (B1-B6) over immutable preregistration digest 610460038f56bddda426f4169876a4ead00c186d1601256174033b4e4fca0a0c; binds decision/preflight/state/gate/runner/lifecycle; allows READY_FOR_OPERATOR_EVALUATION_AUTHORIZATION -> EVALUATION_AUTHORIZED via separate ratification; evaluation_run_count=0; pre-authorization parity required; no evaluation/panel/holdout/runtime/orders in clarification/wiring slice. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_OPERATOR_CLARIFICATION_AUTHORITY_V8.",
-    "Includes V8 DEVELOPMENT evaluation authorization ratification separate from immutable preregistration; requires pre-authorization parity PASS and released DEVELOPMENT panel; transitions lifecycle to EVALUATION_AUTHORIZED; does not start runner or claim run slot; next step awaits separate run Operator-GO. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V8."
+    "Includes V8 DEVELOPMENT evaluation authorization ratification separate from immutable preregistration; requires pre-authorization parity PASS and released DEVELOPMENT panel; transitions lifecycle to EVALUATION_AUTHORIZED; does not start runner or claim run slot; next step awaits separate run Operator-GO. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V8.",
+    "C3 DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1: authorize exact-file Master-V2 confirmation-integration adapter, legacy DA quarantine comments, and C3 contract tests. No runtime activation, no config/threshold mutation, no broad master_v2 grant."
   ],
   "pr_specific_exception": false,
   "required_check_waiver": false,
@@ -889,6 +893,7 @@
   "authorized_surface_notes": [
     "Includes shared definition-only canonical research-lane post-terminal lifecycle contract (state vocabulary, totality, operator-decision, immutability/live-mirror policy); does not migrate Entry-Eligibility or Exit-Efficiency backlog SSOTs; no evaluation/holdout/runtime/orders. Owner surface: CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1.",
     "Includes Holdout evaluation for Bollinger/MR midband exit reentry-cooldown HOLDOUT_V1 executed once and terminal as FAIL/NET_PROFIT_FACTOR_NOT_IMPROVED (run count 1/1); no second run; no economic/promotion/runtime/orders. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_EVALUATION_V1.",
-    "Includes fail-closed Shadow-Prep reconciliation rename of runtime-bridge pre-activation economic evidence field to integrated economic evidence bundle verified status; no activation, no orders, no readiness PASS coercion. Owner surface: INTEGRATED_PAPER_SHADOW_OBSERVATION_SESSION_CAPABILITY_V1."
+    "Includes fail-closed Shadow-Prep reconciliation rename of runtime-bridge pre-activation economic evidence field to integrated economic evidence bundle verified status; no activation, no orders, no readiness PASS coercion. Owner surface: INTEGRATED_PAPER_SHADOW_OBSERVATION_SESSION_CAPABILITY_V1.",
+    "DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1 exact-file allowlist for C3 adapter + DA quarantine + C3 tests (offline confirmation integration only)"
   ]
 }

--- a/docs/ops/specs/MASTER_V2_C1_DISTINCT_MARKET_OBSERVATION_ACCEPTOR_V1.md
+++ b/docs/ops/specs/MASTER_V2_C1_DISTINCT_MARKET_OBSERVATION_ACCEPTOR_V1.md
@@ -177,7 +177,7 @@ Compatibility note:
 | Slice | Depends on C1 | Status in this PR |
 | --- | --- | --- |
 | C2 | Accepted DISTINCT observation stream / epoch ownership | not started |
-| C3 | Observation-gated confirmation inputs | not started |
+| C3 | Observation-gated confirmation inputs | implemented (`DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1`) |
 | C4 | Volatility / bar coupling to observation epoch | not started |
 | C5 | Timer / clock migration around observation epoch | not started |
 | C6 | Strategy evaluator advance wiring | not started |

--- a/docs/ops/specs/MV2_C3_DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1.md
+++ b/docs/ops/specs/MV2_C3_DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1.md
@@ -1,0 +1,182 @@
+---
+docs_token: DOCS_TOKEN_MASTER_V2_C3_DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1
+status: active
+scope: additive pure domain C3; confirmation integration; non-authorizing; no runtime activation
+capability: DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1
+architecture_spec: MASTER_V2_DOUBLE_PLAY_ARCHITECTURE_DESIGN
+last_updated: 2026-07-31
+---
+
+# Master V2 Double Play C3 — Directional Assessment Confirmation Integration V1
+
+## 1. Purpose
+
+Capability slice **C3** integrates C1 observation acceptance results into the C2
+confirmation-progress mechanism and maps the resulting side-isolated cursor onto
+the existing Master V2 Directional Assessment status contract.
+
+```
+CAPABILITY_ID=DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1
+INPUT_AUTHORITY=C1
+PROGRESS_AUTHORITY=C2
+STATE_OWNER=C3
+BULL_BEAR_ISOLATED=true
+PERSISTENCE_BOUNDARY=CALLER_OWNED_IN_MEMORY_EXPLICIT_REPLAY_CARRIER
+IMPLICIT_RESUME_ALLOWED=false
+POLL_RATE_INDEPENDENT=true
+RUNTIME_WIRING_INCLUDED=false
+PARAMETER_CHANGE_INCLUDED=false
+VOLATILITY_CHANGE_INCLUDED=false
+PARALLEL_CONFIRMATION_AUTHORITY_FORBIDDEN=true
+```
+
+Component: `DirectionalAssessmentConfirmationIntegrationV1`  
+Purity: `PURE_DETERMINISTIC_NO_IO`
+
+## 2. Authority Boundaries
+
+| Authority | Owner | C3 role |
+| --- | --- | --- |
+| Distinct market observation | C1 | sole observation authority; consumed as atomic result |
+| Confirmation progress cursor | C2 | sole progress evaluator |
+| Side-state carrier | C3 | owns Bull/Bear `ConfirmationProgressStateV1` pair |
+| Downstream status contract | `DirectionalAssessmentV1.status` | unchanged enum / fields |
+| Legacy trading_epoch counter | quarantined | not productive confirmation authority |
+| Lossy cross-side projector | quarantined | raises if called |
+
+## 3. State Carrier
+
+`DirectionalConfirmationSideStateCarrierV1`:
+
+- `bull_confirmation_state: ConfirmationProgressStateV1` (`side=LONG`)
+- `bear_confirmation_state: ConfirmationProgressStateV1` (`side=SHORT`)
+
+Session binding fields (per side state):
+
+- `session_id`
+- `venue`
+- `InstrumentObservationKeyV1`
+- `ConfirmationSideV1`
+
+Initialization exclusively via `initial_confirmation_progress_state_v1` /
+`initial_directional_confirmation_side_state_carrier_v1`.
+
+## 4. Rules
+
+### Initialization Rule
+
+New sessions start empty OBSERVE on both sides. No implicit resume across process
+or session boundaries (`IMPLICIT_RESUME_ALLOWED=false`).
+
+### Advance Rule
+
+C2 may evaluate/progress only when C1 reports `DISTINCT` +
+`strategy_advance_allowed=true` and `MarketObservationEpoch == prior + 1`.
+
+### Reset Rule
+
+`ConfirmationAssessmentSignalV1.OBSERVE` → reset OBSERVE, count=0,
+`candidate_started_at_epoch=None`.
+
+### Idempotency Rule
+
+Identical acceptor-result fingerprint → `IDEMPOTENT_REPLAY`, no progress.
+
+### Bull/Bear Isolation Rule
+
+Long updates mutate only bull state; short updates mutate only bear state.
+Opposite side remains value-identical.
+
+## 5. Signal Mapping
+
+Existing DA signal strength and thresholds are reused unchanged:
+
+| Signal strength | C2 assessment signal |
+| --- | --- |
+| `< candidate_signal_threshold` | `OBSERVE` |
+| `>= candidate` and `< confirmation` | `CANDIDATE` |
+| `>= confirmation_signal_threshold` | `CONFIRMED` |
+
+`confirmation_threshold` passed to C2 equals existing `policy.confirmation_epochs`
+(no value change).
+
+## 6. Status Mapping
+
+| C2 `ConfirmationAssessmentStateV1` | `DirectionalAssessmentStatus` |
+| --- | --- |
+| OBSERVE | OBSERVE |
+| CANDIDATE | CANDIDATE |
+| CONFIRMED | CONFIRMED |
+| INVALID | INVALID |
+
+Gate / binding failures map to existing `INVALID` / `BLOCKED`. No new `REJECTED`
+status is introduced.
+
+## 7. Failure Matrix
+
+| Condition | Effect |
+| --- | --- |
+| NON_DISTINCT | no progress; prior state status |
+| IDEMPOTENT_REPLAY | no progress; identical result |
+| SESSION/VENUE/INSTRUMENT/SIDE mismatch | fail-closed BLOCKED/INVALID |
+| EPOCH_GAP / EPOCH_REGRESSION | fail-closed |
+| RuntimeCycle / ReceiveTime / DecisionEpoch as epoch | explicit reject helpers |
+| Parallel legacy confirmation authority | `ParallelConfirmationAuthorityErrorV1` |
+
+## 8. Productive Wiring
+
+`run_integrated_offline_trading_logic_replay_v1` evaluates Bull and Bear exclusively
+via:
+
+`evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1`
+
+When C3 carrier / C1 result are omitted, offline replay resolves:
+
+- initial empty OBSERVE carrier
+- explicit NON_DISTINCT acceptor placeholder
+
+It never invents DISTINCT and never consults
+`DirectionalConfirmationStateV1` for status.
+
+## 9. Downstream Compatibility
+
+Unchanged consumers:
+
+- Survival Assessment
+- Suitability Binding
+- Double-Play Composition Matrix
+- Switch / Transition State
+- Entry / Exit policy
+
+For equal final `DirectionalAssessmentV1.status` values, downstream semantics remain
+unchanged.
+
+## 10. Parallel Authority Elimination
+
+Evidence that no parallel confirmation authority remains:
+
+1. Productive replay AST must not call `evaluate_directional_assessment_v1`
+2. Productive replay must call the C3 bull/bear integrator
+3. `project_directional_confirmation_state_from_assessments_v1` raises
+   `LEGACY_LOSSY_CROSS_SIDE_PROJECTOR_AUTHORITY_FORBIDDEN`
+4. Bar-sequence projection reads `directional_confirmation_progress_after` only
+5. `assert_c3_confirmation_authority_exclusive_v1` fail-closed on legacy enablement
+
+## 11. Conscious Non-Goals
+
+C3 does **not**:
+
+- wire runtime / wallclock bridges
+- mutate configs or thresholds
+- change volatility
+- rebuild Survival / Suitability / Composition / Switch semantics
+- authorize orders, testnet, or live trading
+- start C4+
+
+## 12. Test Ownership
+
+Canonical tests:
+
+- `tests&#47;trading&#47;master_v2&#47;test_directional_assessment_confirmation_integration_v1.py`
+
+Plus C1/C2/DA/replay/double-play regressions.

--- a/src/backtest/mv2_research_wiring_v1.py
+++ b/src/backtest/mv2_research_wiring_v1.py
@@ -125,6 +125,10 @@ from src.trading.master_v2.deterministic_scope_event_generator_v1 import (
     ScopeDirectionState,
     ScopeEventGeneratorPolicyV1,
 )
+from src.trading.master_v2.directional_assessment_confirmation_integration_v1 import (
+    DirectionalConfirmationSideStateCarrierV1,
+    initial_directional_confirmation_side_state_carrier_v1,
+)
 from src.trading.master_v2.directional_assessment_v1 import (
     DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
     DirectionalAssessmentPolicyV1,
@@ -132,6 +136,7 @@ from src.trading.master_v2.directional_assessment_v1 import (
     DirectionalAssessmentV1,
     DirectionalConfirmationStateV1,
 )
+from src.trading.market_state.observation_identity_v1 import InstrumentObservationKeyV1
 from src.trading.master_v2.double_play_composition_matrix_v1 import (
     DOUBLE_PLAY_COMPOSITION_MATRIX_POLICY_VERSION,
     BothCandidateOutcome,
@@ -369,6 +374,7 @@ class MV2IntegratedReplayBarSequenceStateV1:
     scope_direction_state: ScopeDirectionState
     scope_confirmation_state: ScopeConfirmationStateV1
     scope_cooldown_state: ScopeCooldownStateV1
+    # LEGACY_NON_AUTHORITY: retained for API compatibility; not used for confirmation.
     directional_confirmation_state: DirectionalConfirmationStateV1
     previous_composition_direction_state: CompositionDirectionState
     position_management_context: PositionManagementContext
@@ -394,6 +400,11 @@ class MV2IntegratedReplayBarSequenceStateV1:
     dynamic_scope_rules: Any | None = None
     # Prior bar mark for market-context price_path when strategy direction is unbound.
     prior_mark_price: float | None = None
+    # C3 productive confirmation carrier (Bull/Bear isolated).
+    directional_confirmation_progress: DirectionalConfirmationSideStateCarrierV1 | None = None
+    confirmation_progress_session_id: str | None = None
+    confirmation_progress_venue: str | None = None
+    confirmation_progress_instrument: InstrumentObservationKeyV1 | None = None
 
 
 @dataclass(frozen=True)
@@ -1227,14 +1238,12 @@ def project_mv2_integrated_replay_bar_sequence_state_from_intermediate_v1(
         position_state=entry_exit.position_state,
     )
     scope_confirmation = intermediate.scope_event.next_confirmation_state
-    policies = _default_policies()
-    directional_confirmation_state = project_directional_confirmation_state_from_assessments_v1(
-        bull_assessment=intermediate.bull_assessment,
-        bear_assessment=intermediate.bear_assessment,
-        previous=previous.directional_confirmation_state,
-        next_trading_epoch=next_trading_epoch,
-        candidate_signal_threshold=float(policies.directional.candidate_signal_threshold),
-    )
+    # C3 carrier is the sole productive confirmation projection authority.
+    directional_confirmation_progress = intermediate.directional_confirmation_progress_after
+    if directional_confirmation_progress is None:
+        directional_confirmation_progress = previous.directional_confirmation_progress
+    # Legacy field retained as non-authority placeholder (never projected from assessments).
+    directional_confirmation_state = previous.directional_confirmation_state
     return MV2IntegratedReplayBarSequenceStateV1(
         existing_scope=intermediate.current_scope,
         scope_direction_state=scope_direction_state,
@@ -1264,6 +1273,10 @@ def project_mv2_integrated_replay_bar_sequence_state_from_intermediate_v1(
         runtime_scope_bound_instrument_id=intermediate.current_scope.instrument_id,
         dynamic_scope_rules=previous.dynamic_scope_rules,
         prior_mark_price=previous.prior_mark_price,
+        directional_confirmation_progress=directional_confirmation_progress,
+        confirmation_progress_session_id=previous.confirmation_progress_session_id,
+        confirmation_progress_venue=previous.confirmation_progress_venue,
+        confirmation_progress_instrument=previous.confirmation_progress_instrument,
     )
 
 
@@ -1631,7 +1644,27 @@ def project_directional_confirmation_state_from_assessments_v1(
     next_trading_epoch: int,
     candidate_signal_threshold: float,
 ) -> DirectionalConfirmationStateV1:
-    """Feed confirmation state from DA provenance; never from scope candidate_count."""
+    """LEGACY_NON_AUTHORITY / QUARANTINED.
+
+    Historical lossy Bull/Bear merge projector. Must not be used as productive
+    confirmation authority after C3. Retained only so static imports and older
+    research helpers do not break; productive bar projection uses the C3 carrier.
+    """
+    raise RuntimeError(
+        "LEGACY_LOSSY_CROSS_SIDE_PROJECTOR_AUTHORITY_FORBIDDEN:"
+        "use_DirectionalConfirmationSideStateCarrierV1_from_C3_intermediate"
+    )
+
+
+def _legacy_project_directional_confirmation_state_from_assessments_v1_quarantined(
+    *,
+    bull_assessment: DirectionalAssessmentV1,
+    bear_assessment: DirectionalAssessmentV1,
+    previous: DirectionalConfirmationStateV1,
+    next_trading_epoch: int,
+    candidate_signal_threshold: float,
+) -> DirectionalConfirmationStateV1:
+    """Internal quarantine copy — not reachable from productive projection."""
     threshold = float(candidate_signal_threshold)
     active = [
         assessment
@@ -1799,6 +1832,10 @@ def _build_replay_input(
         runtime_scope_bound_instrument_id=sequence_state.runtime_scope_bound_instrument_id,
         dynamic_scope_rules=sequence_state.dynamic_scope_rules,
         explicit_runtime_scope_reset=False,
+        directional_confirmation_progress=sequence_state.directional_confirmation_progress,
+        confirmation_progress_session_id=sequence_state.confirmation_progress_session_id,
+        confirmation_progress_venue=sequence_state.confirmation_progress_venue,
+        confirmation_progress_instrument=sequence_state.confirmation_progress_instrument,
     )
 
 

--- a/src/trading/master_v2/directional_assessment_confirmation_integration_v1.py
+++ b/src/trading/master_v2/directional_assessment_confirmation_integration_v1.py
@@ -1,0 +1,569 @@
+"""C3 — Directional Assessment Confirmation Integration V1.
+
+Capability: DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1
+
+Integrates C1 ObservationAcceptanceResultV1 into C2 confirmation progress and
+maps the resulting side-isolated cursor onto DirectionalAssessmentV1.status.
+
+PURE_DOMAIN_COMPONENT=true
+DETERMINISTIC=true
+NO_IO=true
+RUNTIME_WIRING=false
+CONFIG_CHANGE=false
+PARAMETER_RESEARCH=false
+VOLATILITY_SCOPE=false
+IMPLICIT_RESUME_ALLOWED=false
+PARALLEL_CONFIRMATION_AUTHORITY_FORBIDDEN=true
+
+OBSERVATION_AUTHORITY=C1
+CONFIRMATION_PROGRESS_AUTHORITY=C2
+INTEGRATION_OWNER=C3
+STATE_OWNER=C3_SIDE_STATE_CARRIER_USING_C2_STATE
+DOWNSTREAM_STATUS_CONTRACT=DirectionalAssessmentV1.status
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Tuple
+
+from trading.market_state.directional_confirmation_progress_v1 import (
+    ConfirmationAssessmentSignalV1,
+    ConfirmationAssessmentStateV1,
+    ConfirmationProgressInputV1,
+    ConfirmationProgressReasonCodeV1,
+    ConfirmationProgressResultV1,
+    ConfirmationProgressStateV1,
+    ConfirmationSideV1,
+    evaluate_confirmation_progress_v1,
+    initial_confirmation_progress_state_v1,
+    reject_decision_epoch_confirmation_advance_v1,
+    reject_receive_time_confirmation_advance_v1,
+    reject_runtime_cycle_confirmation_advance_v1,
+)
+from trading.market_state.distinct_market_observation_acceptor_v1 import (
+    ObservationAcceptanceResultV1,
+    ObservationAcceptanceStateV1,
+    ObservationClassification,
+    ObservationReasonCode,
+)
+from trading.market_state.observation_identity_v1 import (
+    InstrumentObservationKeyV1,
+    MarketObservationEpoch,
+)
+from trading.master_v2.directional_assessment_v1 import (
+    DirectionalAssessmentHardBlockReason,
+    DirectionalAssessmentInputV1,
+    DirectionalAssessmentPolicyV1,
+    DirectionalAssessmentSide,
+    DirectionalAssessmentStatus,
+    DirectionalAssessmentV1,
+    compute_directional_confidence,
+    compute_signal_strength,
+    validate_directional_assessment_policy,
+    with_computed_directional_assessment_digest,
+)
+from trading.master_v2.directional_assessment_v1 import (
+    _collect_input_gate_blocks,
+    _finalize_assessment,
+    _sorted_reason_values,
+)
+
+DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_CAPABILITY_ID = (
+    "DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1"
+)
+DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_COMPONENT = (
+    "DirectionalAssessmentConfirmationIntegrationV1"
+)
+DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_PURITY = "PURE_DETERMINISTIC_NO_IO"
+DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_STATE_VERSION = "v1"
+
+PARALLEL_CONFIRMATION_AUTHORITY_FORBIDDEN = True
+LEGACY_DIRECTIONAL_CONFIRMATION_STATE_AUTHORITY = False
+LEGACY_TRADING_EPOCH_COUNTER_CONFIRMATION_AUTHORITY = False
+IMPLICIT_RESUME_ALLOWED = False
+RUNTIME_WIRING_INCLUDED = False
+PARAMETER_CHANGE_INCLUDED = False
+VOLATILITY_CHANGE_INCLUDED = False
+
+
+class ParallelConfirmationAuthorityErrorV1(ValueError):
+    """Raised when C3 and legacy confirmation authorities are combined."""
+
+
+def assert_c3_confirmation_authority_exclusive_v1(
+    *,
+    legacy_confirmation_authority_enabled: bool = False,
+) -> None:
+    """Fail-closed guard: C3 must not share confirmation authority with the legacy path."""
+    if not PARALLEL_CONFIRMATION_AUTHORITY_FORBIDDEN:
+        raise ParallelConfirmationAuthorityErrorV1("PARALLEL_CONFIRMATION_AUTHORITY_FLAG_DRIFT")
+    if legacy_confirmation_authority_enabled:
+        raise ParallelConfirmationAuthorityErrorV1(
+            "PARALLEL_CONFIRMATION_AUTHORITY_FORBIDDEN:"
+            "legacy_trading_epoch_counter_must_not_share_authority_with_c3"
+        )
+    if LEGACY_DIRECTIONAL_CONFIRMATION_STATE_AUTHORITY:
+        raise ParallelConfirmationAuthorityErrorV1(
+            "LEGACY_DIRECTIONAL_CONFIRMATION_STATE_AUTHORITY_DRIFT"
+        )
+    if LEGACY_TRADING_EPOCH_COUNTER_CONFIRMATION_AUTHORITY:
+        raise ParallelConfirmationAuthorityErrorV1(
+            "LEGACY_TRADING_EPOCH_COUNTER_CONFIRMATION_AUTHORITY_DRIFT"
+        )
+
+
+@dataclass(frozen=True)
+class DirectionalConfirmationSideStateCarrierV1:
+    """Caller-owned Bull/Bear confirmation progress carrier (C3 state owner)."""
+
+    bull_confirmation_state: ConfirmationProgressStateV1
+    bear_confirmation_state: ConfirmationProgressStateV1
+
+    def __post_init__(self) -> None:
+        if self.bull_confirmation_state.side is not ConfirmationSideV1.LONG:
+            raise ValueError("INVALID_C3_SIDE_CARRIER:bull_side")
+        if self.bear_confirmation_state.side is not ConfirmationSideV1.SHORT:
+            raise ValueError("INVALID_C3_SIDE_CARRIER:bear_side")
+        if self.bull_confirmation_state.session_id != self.bear_confirmation_state.session_id:
+            raise ValueError("INVALID_C3_SIDE_CARRIER:session_mismatch")
+        if self.bull_confirmation_state.venue != self.bear_confirmation_state.venue:
+            raise ValueError("INVALID_C3_SIDE_CARRIER:venue_mismatch")
+        if self.bull_confirmation_state.instrument != self.bear_confirmation_state.instrument:
+            raise ValueError("INVALID_C3_SIDE_CARRIER:instrument_mismatch")
+
+    def for_side(self, side: ConfirmationSideV1) -> ConfirmationProgressStateV1:
+        if side is ConfirmationSideV1.LONG:
+            return self.bull_confirmation_state
+        if side is ConfirmationSideV1.SHORT:
+            return self.bear_confirmation_state
+        raise ValueError("INVALID_C3_SIDE_CARRIER:unknown_side")
+
+    def with_side_state(
+        self,
+        side: ConfirmationSideV1,
+        state: ConfirmationProgressStateV1,
+    ) -> "DirectionalConfirmationSideStateCarrierV1":
+        if side is ConfirmationSideV1.LONG:
+            return DirectionalConfirmationSideStateCarrierV1(
+                bull_confirmation_state=state,
+                bear_confirmation_state=self.bear_confirmation_state,
+            )
+        if side is ConfirmationSideV1.SHORT:
+            return DirectionalConfirmationSideStateCarrierV1(
+                bull_confirmation_state=self.bull_confirmation_state,
+                bear_confirmation_state=state,
+            )
+        raise ValueError("INVALID_C3_SIDE_CARRIER:unknown_side")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_STATE_VERSION,
+            "bull_confirmation_state": self.bull_confirmation_state.to_dict(),
+            "bear_confirmation_state": self.bear_confirmation_state.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "DirectionalConfirmationSideStateCarrierV1":
+        version = str(
+            payload.get("version", DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_STATE_VERSION)
+        )
+        if version != DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_STATE_VERSION:
+            raise ValueError(f"UNSUPPORTED_C3_SIDE_CARRIER_VERSION:{version}")
+        return cls(
+            bull_confirmation_state=ConfirmationProgressStateV1.from_dict(
+                payload["bull_confirmation_state"]
+            ),
+            bear_confirmation_state=ConfirmationProgressStateV1.from_dict(
+                payload["bear_confirmation_state"]
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class DirectionalAssessmentConfirmationIntegrationInputV1:
+    """Pure C3 evaluator input. No clocks, configs, or runtime wiring."""
+
+    directional_input: DirectionalAssessmentInputV1
+    policy: DirectionalAssessmentPolicyV1
+    prior_confirmation_progress: ConfirmationProgressStateV1
+    observation_acceptance_result: ObservationAcceptanceResultV1
+    session_id: str
+    venue: str
+    instrument: InstrumentObservationKeyV1
+    side: ConfirmationSideV1
+    acceptor_result_fingerprint: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class DirectionalAssessmentConfirmationIntegrationResultV1:
+    assessment: DirectionalAssessmentV1
+    confirmation_progress_before: ConfirmationProgressStateV1
+    confirmation_progress_after: ConfirmationProgressStateV1
+    confirmation_progress_result: ConfirmationProgressResultV1
+    assessment_signal: ConfirmationAssessmentSignalV1
+    confirmation_advanced: bool
+    state_changed: bool
+    fail_closed: bool
+    reason_code: ConfirmationProgressReasonCodeV1
+
+
+def initial_directional_confirmation_side_state_carrier_v1(
+    *,
+    session_id: str,
+    venue: str,
+    instrument: InstrumentObservationKeyV1,
+    initial_market_observation_epoch: Optional[MarketObservationEpoch] = None,
+) -> DirectionalConfirmationSideStateCarrierV1:
+    """Session-bound empty OBSERVE carrier for Bull and Bear."""
+    return DirectionalConfirmationSideStateCarrierV1(
+        bull_confirmation_state=initial_confirmation_progress_state_v1(
+            session_id=session_id,
+            venue=venue,
+            instrument=instrument,
+            side=ConfirmationSideV1.LONG,
+            initial_market_observation_epoch=initial_market_observation_epoch,
+        ),
+        bear_confirmation_state=initial_confirmation_progress_state_v1(
+            session_id=session_id,
+            venue=venue,
+            instrument=instrument,
+            side=ConfirmationSideV1.SHORT,
+            initial_market_observation_epoch=initial_market_observation_epoch,
+        ),
+    )
+
+
+def non_advancing_observation_acceptance_result_v1(
+    *,
+    bound_instrument_key: InstrumentObservationKeyV1,
+    market_observation_epoch: Optional[MarketObservationEpoch] = None,
+) -> ObservationAcceptanceResultV1:
+    """Caller helper: explicit NON_DISTINCT placeholder (never invents DISTINCT)."""
+    epoch = (
+        MarketObservationEpoch(value=0)
+        if market_observation_epoch is None
+        else market_observation_epoch
+    )
+    state = ObservationAcceptanceStateV1(
+        last_accepted_observation_identity=None,
+        market_observation_epoch=epoch,
+        bound_instrument_key=bound_instrument_key,
+        last_accepted_transport=None,
+    )
+    return ObservationAcceptanceResultV1(
+        classification=ObservationClassification.DUPLICATE,
+        strategy_advance_allowed=False,
+        state_before=state,
+        state_after=state,
+        observation_identity=None,
+        reason_code=ObservationReasonCode.DUPLICATE.value,
+    )
+
+
+def map_signal_strength_to_confirmation_assessment_signal_v1(
+    signal_strength: float,
+    policy: DirectionalAssessmentPolicyV1,
+) -> ConfirmationAssessmentSignalV1:
+    """Deterministic mapping using existing DA thresholds (no redefinition)."""
+    if float(signal_strength) < float(policy.candidate_signal_threshold):
+        return ConfirmationAssessmentSignalV1.OBSERVE
+    if float(signal_strength) < float(policy.confirmation_signal_threshold):
+        return ConfirmationAssessmentSignalV1.CANDIDATE
+    return ConfirmationAssessmentSignalV1.CONFIRMED
+
+
+def map_confirmation_assessment_state_to_directional_status_v1(
+    state: ConfirmationAssessmentStateV1,
+) -> DirectionalAssessmentStatus:
+    if state is ConfirmationAssessmentStateV1.OBSERVE:
+        return DirectionalAssessmentStatus.OBSERVE
+    if state is ConfirmationAssessmentStateV1.CANDIDATE:
+        return DirectionalAssessmentStatus.CANDIDATE
+    if state is ConfirmationAssessmentStateV1.CONFIRMED:
+        return DirectionalAssessmentStatus.CONFIRMED
+    # INVALID never silently treated as progress; map to existing INVALID.
+    return DirectionalAssessmentStatus.INVALID
+
+
+def map_directional_side_to_confirmation_side_v1(
+    side: DirectionalAssessmentSide,
+) -> ConfirmationSideV1:
+    if side is DirectionalAssessmentSide.LONG:
+        return ConfirmationSideV1.LONG
+    if side is DirectionalAssessmentSide.SHORT:
+        return ConfirmationSideV1.SHORT
+    raise ValueError(f"unsupported_directional_side:{side!r}")
+
+
+def _fail_closed_status_for_reason(
+    reason: ConfirmationProgressReasonCodeV1,
+) -> DirectionalAssessmentStatus:
+    if reason in {
+        ConfirmationProgressReasonCodeV1.STATE_INCONSISTENT,
+        ConfirmationProgressReasonCodeV1.INVALID_SIGNAL,
+        ConfirmationProgressReasonCodeV1.INVALID_THRESHOLD,
+    }:
+        return DirectionalAssessmentStatus.INVALID
+    return DirectionalAssessmentStatus.BLOCKED
+
+
+def evaluate_directional_assessment_with_confirmation_progress_v1(
+    integration_input: DirectionalAssessmentConfirmationIntegrationInputV1,
+) -> DirectionalAssessmentConfirmationIntegrationResultV1:
+    """C3 productive confirmation integration. Legacy epoch-counter is not consulted."""
+    assert_c3_confirmation_authority_exclusive_v1(
+        legacy_confirmation_authority_enabled=False,
+    )
+
+    inp = integration_input.directional_input
+    policy = integration_input.policy
+    prior = integration_input.prior_confirmation_progress
+
+    def _gated_no_progress(
+        *,
+        status: DirectionalAssessmentStatus,
+        hard_block_reasons: Tuple[str, ...],
+        reason_codes: Tuple[str, ...],
+        progress_reason: ConfirmationProgressReasonCodeV1,
+    ) -> DirectionalAssessmentConfirmationIntegrationResultV1:
+        assessment = _finalize_assessment(
+            inp,
+            policy,
+            status=status,
+            signal_strength=0.0,
+            confidence=0.0,
+            hard_block_reasons=hard_block_reasons,
+            reason_codes=reason_codes,
+        )
+        # Deterministic fingerprint body via C2 unchanged-result helper family.
+        fingerprint_donor = reject_runtime_cycle_confirmation_advance_v1(prior)
+        stub = ConfirmationProgressResultV1(
+            accepted=False,
+            state_before=prior,
+            state_after=prior,
+            reason_code=progress_reason,
+            state_changed=False,
+            confirmation_advanced=False,
+            fail_closed=True,
+            observation_epoch_before=prior.latest_accepted_market_observation_epoch,
+            observation_epoch_after=prior.latest_accepted_market_observation_epoch,
+            deterministic_fingerprint=fingerprint_donor.deterministic_fingerprint,
+        )
+        return DirectionalAssessmentConfirmationIntegrationResultV1(
+            assessment=assessment,
+            confirmation_progress_before=prior,
+            confirmation_progress_after=prior,
+            confirmation_progress_result=stub,
+            assessment_signal=ConfirmationAssessmentSignalV1.OBSERVE,
+            confirmation_advanced=False,
+            state_changed=False,
+            fail_closed=True,
+            reason_code=progress_reason,
+        )
+
+    policy_blocks = validate_directional_assessment_policy(
+        policy, policy_version=inp.policy_version
+    )
+    if policy_blocks:
+        progress_reason = (
+            ConfirmationProgressReasonCodeV1.INVALID_THRESHOLD
+            if DirectionalAssessmentHardBlockReason.POLICY_CONFIRMATION_EPOCHS_INVALID
+            in policy_blocks
+            else ConfirmationProgressReasonCodeV1.STATE_INCONSISTENT
+        )
+        return _gated_no_progress(
+            status=DirectionalAssessmentStatus.BLOCKED,
+            hard_block_reasons=_sorted_reason_values(policy_blocks),
+            reason_codes=("policy_validation_failed",),
+            progress_reason=progress_reason,
+        )
+
+    gate_blocks = _collect_input_gate_blocks(inp)
+    if gate_blocks:
+        status = (
+            DirectionalAssessmentStatus.INVALID
+            if any(
+                r
+                in {
+                    DirectionalAssessmentHardBlockReason.INPUT_INCOMPLETE,
+                    DirectionalAssessmentHardBlockReason.PRICE_PATH_TOO_SHORT,
+                    DirectionalAssessmentHardBlockReason.REFERENCE_PRICE_NON_POSITIVE,
+                    DirectionalAssessmentHardBlockReason.SCOPE_EVENT_REF_INVALID,
+                }
+                for r in gate_blocks
+            )
+            else DirectionalAssessmentStatus.BLOCKED
+        )
+        return _gated_no_progress(
+            status=status,
+            hard_block_reasons=_sorted_reason_values(gate_blocks),
+            reason_codes=("input_gate_failed",),
+            progress_reason=ConfirmationProgressReasonCodeV1.STATE_INCONSISTENT,
+        )
+
+    signal_strength = compute_signal_strength(
+        price_path=inp.price_path,
+        side=inp.side,
+        reference_price=inp.reference_price,
+    )
+    confidence = compute_directional_confidence(
+        signal_strength, policy.confirmation_signal_threshold
+    )
+    assessment_signal = map_signal_strength_to_confirmation_assessment_signal_v1(
+        signal_strength, policy
+    )
+
+    progress_input = ConfirmationProgressInputV1(
+        prior_state=prior,
+        observation_acceptance_result=integration_input.observation_acceptance_result,
+        session_id=integration_input.session_id,
+        venue=integration_input.venue,
+        instrument=integration_input.instrument,
+        side=integration_input.side,
+        assessment_signal=assessment_signal,
+        confirmation_threshold=int(policy.confirmation_epochs),
+        acceptor_result_fingerprint=integration_input.acceptor_result_fingerprint,
+    )
+    progress_result = evaluate_confirmation_progress_v1(progress_input)
+
+    if progress_result.fail_closed:
+        status = _fail_closed_status_for_reason(progress_result.reason_code)
+        assessment = _finalize_assessment(
+            inp,
+            policy,
+            status=status,
+            signal_strength=signal_strength,
+            confidence=confidence,
+            hard_block_reasons=(progress_result.reason_code.value.lower(),),
+            reason_codes=("confirmation_progress_fail_closed", progress_result.reason_code.value),
+        )
+        return DirectionalAssessmentConfirmationIntegrationResultV1(
+            assessment=assessment,
+            confirmation_progress_before=prior,
+            confirmation_progress_after=progress_result.state_after,
+            confirmation_progress_result=progress_result,
+            assessment_signal=assessment_signal,
+            confirmation_advanced=False,
+            state_changed=False,
+            fail_closed=True,
+            reason_code=progress_result.reason_code,
+        )
+
+    status = map_confirmation_assessment_state_to_directional_status_v1(
+        progress_result.state_after.assessment_state
+    )
+    reason_codes: Tuple[str, ...] = (
+        "c3_confirmation_progress",
+        progress_result.reason_code.value,
+        f"assessment_signal_{assessment_signal.value}",
+        f"confirmation_state_{progress_result.state_after.assessment_state.value}",
+    )
+    assessment = with_computed_directional_assessment_digest(
+        _finalize_assessment(
+            inp,
+            policy,
+            status=status,
+            signal_strength=signal_strength,
+            confidence=confidence,
+            hard_block_reasons=(),
+            reason_codes=reason_codes,
+        )
+    )
+
+    return DirectionalAssessmentConfirmationIntegrationResultV1(
+        assessment=assessment,
+        confirmation_progress_before=prior,
+        confirmation_progress_after=progress_result.state_after,
+        confirmation_progress_result=progress_result,
+        assessment_signal=assessment_signal,
+        confirmation_advanced=bool(progress_result.confirmation_advanced),
+        state_changed=bool(progress_result.state_changed),
+        fail_closed=False,
+        reason_code=progress_result.reason_code,
+    )
+
+
+def evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1(
+    *,
+    bull_input: DirectionalAssessmentInputV1,
+    bear_input: DirectionalAssessmentInputV1,
+    policy: DirectionalAssessmentPolicyV1,
+    prior_carrier: DirectionalConfirmationSideStateCarrierV1,
+    observation_acceptance_result: ObservationAcceptanceResultV1,
+    session_id: str,
+    venue: str,
+    instrument: InstrumentObservationKeyV1,
+    acceptor_result_fingerprint: Optional[str] = None,
+) -> tuple[
+    DirectionalAssessmentConfirmationIntegrationResultV1,
+    DirectionalAssessmentConfirmationIntegrationResultV1,
+    DirectionalConfirmationSideStateCarrierV1,
+]:
+    """Evaluate Bull then Bear with strict side isolation on the shared C1 result."""
+    assert_c3_confirmation_authority_exclusive_v1()
+
+    bull = evaluate_directional_assessment_with_confirmation_progress_v1(
+        DirectionalAssessmentConfirmationIntegrationInputV1(
+            directional_input=bull_input,
+            policy=policy,
+            prior_confirmation_progress=prior_carrier.bull_confirmation_state,
+            observation_acceptance_result=observation_acceptance_result,
+            session_id=session_id,
+            venue=venue,
+            instrument=instrument,
+            side=ConfirmationSideV1.LONG,
+            acceptor_result_fingerprint=acceptor_result_fingerprint,
+        )
+    )
+    # Opposite side must remain byte/value-identical after bull evaluation.
+    mid_carrier = prior_carrier.with_side_state(
+        ConfirmationSideV1.LONG, bull.confirmation_progress_after
+    )
+    if mid_carrier.bear_confirmation_state != prior_carrier.bear_confirmation_state:
+        raise ParallelConfirmationAuthorityErrorV1("BULL_UPDATE_MUTATED_BEAR_STATE")
+
+    bear = evaluate_directional_assessment_with_confirmation_progress_v1(
+        DirectionalAssessmentConfirmationIntegrationInputV1(
+            directional_input=bear_input,
+            policy=policy,
+            prior_confirmation_progress=mid_carrier.bear_confirmation_state,
+            observation_acceptance_result=observation_acceptance_result,
+            session_id=session_id,
+            venue=venue,
+            instrument=instrument,
+            side=ConfirmationSideV1.SHORT,
+            acceptor_result_fingerprint=acceptor_result_fingerprint,
+        )
+    )
+    after_carrier = mid_carrier.with_side_state(
+        ConfirmationSideV1.SHORT, bear.confirmation_progress_after
+    )
+    if after_carrier.bull_confirmation_state != mid_carrier.bull_confirmation_state:
+        raise ParallelConfirmationAuthorityErrorV1("BEAR_UPDATE_MUTATED_BULL_STATE")
+
+    return bull, bear, after_carrier
+
+
+# Explicit reject helpers re-exported for C3 tests / integration contracts.
+__all__ = [
+    "DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_CAPABILITY_ID",
+    "DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_COMPONENT",
+    "DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_PURITY",
+    "PARALLEL_CONFIRMATION_AUTHORITY_FORBIDDEN",
+    "ParallelConfirmationAuthorityErrorV1",
+    "DirectionalConfirmationSideStateCarrierV1",
+    "DirectionalAssessmentConfirmationIntegrationInputV1",
+    "DirectionalAssessmentConfirmationIntegrationResultV1",
+    "assert_c3_confirmation_authority_exclusive_v1",
+    "initial_directional_confirmation_side_state_carrier_v1",
+    "non_advancing_observation_acceptance_result_v1",
+    "map_signal_strength_to_confirmation_assessment_signal_v1",
+    "map_confirmation_assessment_state_to_directional_status_v1",
+    "map_directional_side_to_confirmation_side_v1",
+    "evaluate_directional_assessment_with_confirmation_progress_v1",
+    "evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1",
+    "reject_decision_epoch_confirmation_advance_v1",
+    "reject_receive_time_confirmation_advance_v1",
+    "reject_runtime_cycle_confirmation_advance_v1",
+]

--- a/src/trading/master_v2/directional_assessment_v1.py
+++ b/src/trading/master_v2/directional_assessment_v1.py
@@ -108,6 +108,13 @@ class ScopeEventRefV1:
 
 @dataclass(frozen=True)
 class DirectionalConfirmationStateV1:
+    """LEGACY_NON_AUTHORITY confirmation cursor.
+
+    Productive confirmation authority is C3 ``ConfirmationProgressStateV1`` via
+    ``DirectionalConfirmationSideStateCarrierV1``. This dataclass remains only for
+    DirectionalAssessmentInputV1 type compatibility and isolated unit tests.
+    """
+
     candidate_count: int
     last_evaluated_trading_epoch: int
     last_signal_strength: float
@@ -329,6 +336,13 @@ def _status_for_signal(
     confirmation_state: DirectionalConfirmationStateV1,
     epoch_mode: str,
 ) -> Tuple[DirectionalAssessmentStatus, Tuple[str, ...], int]:
+    """LEGACY_NON_PRODUCTIVE_CONFIRMATION_AUTHORITY.
+
+    Retained only for isolated DirectionalAssessment unit contracts.
+    Productive Master-V2 offline replay confirmation authority is C3
+    (``evaluate_directional_assessment_with_confirmation_progress_v1``).
+    Do not wire this helper into productive confirmation paths.
+    """
     if signal_strength < policy.observe_signal_threshold:
         return DirectionalAssessmentStatus.OBSERVE, ("signal_below_observe_threshold",), 0
 
@@ -456,10 +470,15 @@ def evaluate_directional_assessment_v1(
     policy: DirectionalAssessmentPolicyV1,
 ) -> DirectionalAssessmentV1:
     """
-    Deterministic Bull/Bear directional assessment evaluator.
+    Deterministic Bull/Bear directional assessment evaluator (legacy confirmation path).
 
     Fail-closed on untrusted, incomplete, or epoch-invalid inputs. Never mutates
     ``inp.scope_event_ref`` or upstream scope-event evidence.
+
+    LEGACY_NON_PRODUCTIVE_CONFIRMATION_AUTHORITY: confirmation status derivation via
+    trading_epoch / candidate_count is quarantined for unit tests only. Productive
+    Master-V2 offline replay must use
+    ``evaluate_directional_assessment_with_confirmation_progress_v1`` (C3).
     """
     policy_blocks = validate_directional_assessment_policy(
         policy, policy_version=inp.policy_version

--- a/src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py
+++ b/src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py
@@ -54,6 +54,14 @@ from trading.master_v2.deterministic_scope_event_generator_v1 import (
     generate_deterministic_scope_event,
     with_computed_scope_event_digest,
 )
+from trading.master_v2.directional_assessment_confirmation_integration_v1 import (
+    DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_CAPABILITY_ID,
+    DirectionalConfirmationSideStateCarrierV1,
+    assert_c3_confirmation_authority_exclusive_v1,
+    evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1,
+    initial_directional_confirmation_side_state_carrier_v1,
+    non_advancing_observation_acceptance_result_v1,
+)
 from trading.master_v2.directional_assessment_v1 import (
     DIRECTIONAL_ASSESSMENT_LAYER_VERSION,
     DirectionalAssessmentInputV1,
@@ -62,9 +70,11 @@ from trading.master_v2.directional_assessment_v1 import (
     DirectionalAssessmentV1,
     DirectionalConfirmationStateV1,
     ScopeEventRefV1,
-    evaluate_directional_assessment_v1,
-    with_computed_directional_assessment_digest,
 )
+from trading.market_state.distinct_market_observation_acceptor_v1 import (
+    ObservationAcceptanceResultV1,
+)
+from trading.market_state.observation_identity_v1 import InstrumentObservationKeyV1
 from trading.master_v2.double_play_composition_matrix_v1 import (
     DOUBLE_PLAY_COMPOSITION_MATRIX_LAYER_VERSION,
     CompositionDirectionState,
@@ -209,6 +219,8 @@ class IntegratedOfflineReplayInputV1:
     confirmation_epochs: int
     current_price: float
     price_path: Tuple[float, ...]
+    # LEGACY_NON_AUTHORITY: retained for builder/API compatibility only.
+    # Productive confirmation authority is C3 side-state carrier + C1/C2.
     directional_confirmation_state: DirectionalConfirmationStateV1
     strategy_registry: SuitabilityStrategyRegistryV1
     regime_id: str
@@ -246,6 +258,14 @@ class IntegratedOfflineReplayInputV1:
     runtime_scope_bound_instrument_id: Optional[str] = None
     dynamic_scope_rules: Optional[DynamicScopeRules] = None
     explicit_runtime_scope_reset: bool = False
+    # C3 confirmation integration (caller-owned). When omitted, offline replay uses
+    # initial empty OBSERVE carrier + explicit NON_DISTINCT acceptor placeholder
+    # (never invents DISTINCT; never consults legacy DirectionalConfirmationStateV1).
+    directional_confirmation_progress: Optional[DirectionalConfirmationSideStateCarrierV1] = None
+    observation_acceptance_result: Optional[ObservationAcceptanceResultV1] = None
+    confirmation_progress_session_id: Optional[str] = None
+    confirmation_progress_venue: Optional[str] = None
+    confirmation_progress_instrument: Optional[InstrumentObservationKeyV1] = None
 
 
 @dataclass(frozen=True)
@@ -283,7 +303,13 @@ class IntegratedOfflineReplayIntermediateV1:
     runtime_scope_state_after: RuntimeScopeState
     runtime_scope_reinitialized: bool
     trailing_anchor_used: float
+    directional_confirmation_progress_after: Optional[DirectionalConfirmationSideStateCarrierV1] = (
+        None
+    )
     chop_binding_status: str = CHOP_BINDING_STATUS
+    confirmation_integration_capability_id: str = (
+        DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_CAPABILITY_ID
+    )
 
 
 @dataclass(frozen=True)
@@ -385,6 +411,11 @@ def build_integrated_offline_replay_input_v1(
     runtime_scope_bound_instrument_id: Optional[str] = None,
     dynamic_scope_rules: Optional[DynamicScopeRules] = None,
     explicit_runtime_scope_reset: bool = False,
+    directional_confirmation_progress: Optional[DirectionalConfirmationSideStateCarrierV1] = None,
+    observation_acceptance_result: Optional[ObservationAcceptanceResultV1] = None,
+    confirmation_progress_session_id: Optional[str] = None,
+    confirmation_progress_venue: Optional[str] = None,
+    confirmation_progress_instrument: Optional[InstrumentObservationKeyV1] = None,
 ) -> IntegratedOfflineReplayInputV1:
     """Single canonical productive constructor for IntegratedOfflineReplayInputV1.
 
@@ -578,6 +609,27 @@ def build_integrated_offline_replay_input_v1(
         errors.append("dynamic_scope_rules_type_invalid")
     if not isinstance(explicit_runtime_scope_reset, bool):
         errors.append("explicit_runtime_scope_reset_invalid")
+    if directional_confirmation_progress is not None and not _builder_type_name_ok(
+        directional_confirmation_progress, "DirectionalConfirmationSideStateCarrierV1"
+    ):
+        errors.append("directional_confirmation_progress_type_invalid")
+    if observation_acceptance_result is not None and not _builder_type_name_ok(
+        observation_acceptance_result, "ObservationAcceptanceResultV1"
+    ):
+        errors.append("observation_acceptance_result_type_invalid")
+    if confirmation_progress_session_id is not None and (
+        not isinstance(confirmation_progress_session_id, str)
+        or not confirmation_progress_session_id.strip()
+    ):
+        errors.append("confirmation_progress_session_id_invalid")
+    if confirmation_progress_venue is not None and (
+        not isinstance(confirmation_progress_venue, str) or not confirmation_progress_venue.strip()
+    ):
+        errors.append("confirmation_progress_venue_invalid")
+    if confirmation_progress_instrument is not None and not _builder_type_name_ok(
+        confirmation_progress_instrument, "InstrumentObservationKeyV1"
+    ):
+        errors.append("confirmation_progress_instrument_type_invalid")
 
     if errors:
         raise ValueError(";".join(sorted(set(errors))))
@@ -641,6 +693,11 @@ def build_integrated_offline_replay_input_v1(
         runtime_scope_bound_instrument_id=runtime_scope_bound_instrument_id,
         dynamic_scope_rules=dynamic_scope_rules,
         explicit_runtime_scope_reset=bool(explicit_runtime_scope_reset),
+        directional_confirmation_progress=directional_confirmation_progress,
+        observation_acceptance_result=observation_acceptance_result,
+        confirmation_progress_session_id=confirmation_progress_session_id,
+        confirmation_progress_venue=confirmation_progress_venue,
+        confirmation_progress_instrument=confirmation_progress_instrument,
     )
 
 
@@ -934,6 +991,9 @@ def _directional_input_for_side(
     ``compute_signal_strength`` (sign flip for SHORT). Do not mirror the shared path
     here: mirroring plus the SHORT sign flip would invent identical candidate strength
     on both sides from one directional impulse.
+
+    ``confirmation_state`` remains typed for DirectionalAssessmentInputV1 compatibility
+    but is LEGACY_NON_AUTHORITY under C3 (never consulted for status).
     """
     anchor = float(inp.canonical_market_context.mark_price)
     return DirectionalAssessmentInputV1(
@@ -954,6 +1014,60 @@ def _directional_input_for_side(
         explicit_hard_block_reasons=(),
         policy_version=inp.policies.directional.policy_version,
     )
+
+
+def _resolve_c3_confirmation_binding_v1(
+    inp: IntegratedOfflineReplayInputV1,
+) -> tuple[
+    DirectionalConfirmationSideStateCarrierV1,
+    ObservationAcceptanceResultV1,
+    str,
+    str,
+    InstrumentObservationKeyV1,
+]:
+    """Resolve caller-owned C3 binding; never invent DISTINCT observations."""
+    assert_c3_confirmation_authority_exclusive_v1()
+    instrument = inp.confirmation_progress_instrument
+    if instrument is None:
+        venue = (
+            inp.confirmation_progress_venue.strip()
+            if isinstance(inp.confirmation_progress_venue, str)
+            and inp.confirmation_progress_venue.strip()
+            else "offline_replay"
+        )
+        instrument = InstrumentObservationKeyV1(
+            venue=venue,
+            canonical_instrument_id=inp.instrument_id,
+            venue_instrument_id=inp.instrument_id,
+        )
+    venue = (
+        inp.confirmation_progress_venue.strip()
+        if isinstance(inp.confirmation_progress_venue, str)
+        and inp.confirmation_progress_venue.strip()
+        else instrument.venue
+    )
+    session_id = (
+        inp.confirmation_progress_session_id.strip()
+        if isinstance(inp.confirmation_progress_session_id, str)
+        and inp.confirmation_progress_session_id.strip()
+        else f"offline-replay:{inp.replay_id}"
+    )
+    carrier = inp.directional_confirmation_progress
+    if carrier is None:
+        carrier = initial_directional_confirmation_side_state_carrier_v1(
+            session_id=session_id,
+            venue=venue,
+            instrument=instrument,
+        )
+    acceptor = inp.observation_acceptance_result
+    if acceptor is None:
+        acceptor = non_advancing_observation_acceptance_result_v1(
+            bound_instrument_key=instrument,
+            market_observation_epoch=(
+                carrier.bull_confirmation_state.latest_accepted_market_observation_epoch
+            ),
+        )
+    return carrier, acceptor, session_id, venue, instrument
 
 
 def _survival_input_for_assessment(
@@ -1199,12 +1313,27 @@ def run_integrated_offline_trading_logic_replay_v1(
     scope_event_ref = _scope_event_ref_from_evidence(scope_event)
     bull_inp = _directional_input_for_side(inp, DirectionalAssessmentSide.LONG, scope_event_ref)
     bear_inp = _directional_input_for_side(inp, DirectionalAssessmentSide.SHORT, scope_event_ref)
-    bull_assessment = with_computed_directional_assessment_digest(
-        evaluate_directional_assessment_v1(bull_inp, inp.policies.directional)
+    (
+        prior_carrier,
+        observation_acceptance_result,
+        confirmation_session_id,
+        confirmation_venue,
+        confirmation_instrument,
+    ) = _resolve_c3_confirmation_binding_v1(inp)
+    bull_c3, bear_c3, confirmation_progress_after = (
+        evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1(
+            bull_input=bull_inp,
+            bear_input=bear_inp,
+            policy=inp.policies.directional,
+            prior_carrier=prior_carrier,
+            observation_acceptance_result=observation_acceptance_result,
+            session_id=confirmation_session_id,
+            venue=confirmation_venue,
+            instrument=confirmation_instrument,
+        )
     )
-    bear_assessment = with_computed_directional_assessment_digest(
-        evaluate_directional_assessment_v1(bear_inp, inp.policies.directional)
-    )
+    bull_assessment = bull_c3.assessment
+    bear_assessment = bear_c3.assessment
 
     bull_survival = evaluate_survival_assessment_v1(
         _survival_input_for_assessment(inp, bull_assessment),
@@ -1528,7 +1657,11 @@ def run_integrated_offline_trading_logic_replay_v1(
         runtime_scope_state_after=runtime_scope_after,
         runtime_scope_reinitialized=runtime_scope_reinitialized,
         trailing_anchor_used=trailing_anchor_used,
+        directional_confirmation_progress_after=confirmation_progress_after,
         chop_binding_status=CHOP_BINDING_STATUS,
+        confirmation_integration_capability_id=(
+            DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_CAPABILITY_ID
+        ),
     )
 
     boundary_ok = (

--- a/src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py
+++ b/src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py
@@ -1320,6 +1320,9 @@ def run_integrated_offline_trading_logic_replay_v1(
         confirmation_venue,
         confirmation_instrument,
     ) = _resolve_c3_confirmation_binding_v1(inp)
+    # LEGACY_NON_PRODUCTIVE_CONFIRMATION_AUTHORITY_NOTE:
+    # evaluate_directional_assessment_v1 remains the isolated unit-test DA owner.
+    # Productive confirmation authority is C3 below (not evaluate_directional_assessment_v1).
     bull_c3, bear_c3, confirmation_progress_after = (
         evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1(
             bull_input=bull_inp,

--- a/tests/backtest/test_mv2_composition_directional_asymmetry_wiring_repair_v1.py
+++ b/tests/backtest/test_mv2_composition_directional_asymmetry_wiring_repair_v1.py
@@ -246,23 +246,23 @@ def test_confirmation_provenance_from_da_not_scope_count() -> None:
         status=DirectionalAssessmentStatus.OBSERVE,
         signal_strength=-0.02,
     )
-    projected = project_directional_confirmation_state_from_assessments_v1(
-        bull_assessment=bull,
-        bear_assessment=bear,
-        previous=previous,
-        next_trading_epoch=11,
-        candidate_signal_threshold=0.005,
-    )
-    assert projected.last_signal_strength == pytest.approx(0.02)
-    assert projected.candidate_count == 2
-    assert projected.last_evaluated_trading_epoch == 10
+    with pytest.raises(RuntimeError, match="LEGACY_LOSSY_CROSS_SIDE_PROJECTOR_AUTHORITY_FORBIDDEN"):
+        project_directional_confirmation_state_from_assessments_v1(
+            bull_assessment=bull,
+            bear_assessment=bear,
+            previous=previous,
+            next_trading_epoch=11,
+            candidate_signal_threshold=0.005,
+        )
 
     wiring_src = _WIRING.read_text(encoding="utf-8")
     assert "project_directional_confirmation_state_from_assessments_v1" in wiring_src
+    assert "LEGACY_LOSSY_CROSS_SIDE_PROJECTOR_AUTHORITY_FORBIDDEN" in wiring_src
     proj_src = inspect.getsource(
         project_mv2_integrated_replay_bar_sequence_state_from_intermediate_v1
     )
-    assert "project_directional_confirmation_state_from_assessments_v1" in proj_src
+    assert "directional_confirmation_progress_after" in proj_src
+    assert "project_directional_confirmation_state_from_assessments_v1" not in proj_src
     assert "scope_confirmation.candidate_count" not in proj_src
     assert (
         "last_signal_strength=previous.directional_confirmation_state.last_signal_strength"

--- a/tests/governance/test_technical_canonical_wiring_authorization_bound_to_boundary_guard_v1.py
+++ b/tests/governance/test_technical_canonical_wiring_authorization_bound_to_boundary_guard_v1.py
@@ -55,6 +55,17 @@ AUTHORIZED_CANONICAL_ARCHITECTURE_DRIFT_GUARD_FIXTURE = [
     "config/governance/technical_canonical_wiring_authorization_v1.json",
 ]
 
+AUTHORIZED_C3_DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_FIXTURE = [
+    "src/trading/master_v2/directional_assessment_confirmation_integration_v1.py",
+    "src/trading/master_v2/directional_assessment_v1.py",
+    "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py",
+    "src/backtest/mv2_research_wiring_v1.py",
+    "tests/trading/master_v2/test_directional_assessment_confirmation_integration_v1.py",
+    "tests/trading/master_v2/_canonical_architecture_drift_guard_helpers_v1.py",
+    "tests/trading/master_v2/test_canonical_architecture_drift_guard_v1.py",
+    "config/governance/technical_canonical_wiring_authorization_v1.json",
+]
+
 AUTHORIZED_SURFACE_P_REGISTRY_STATUS_CONTRACT_FIXTURE = [
     "tests/trading/master_v2/test_surface_p_full_bar_sequence_4_way_parity_completion_contract_v0.py",
     "tests/trading/master_v2/test_surface_p_offline_complete_runtime_bridge_bound_not_activated_contract_v0.py",
@@ -111,7 +122,7 @@ class TestTechnicalCanonicalWiringAuthorizationContractV1:
 class TestTechnicalCanonicalWiringAuthorizationNegativeV1:
     def test_unauthorized_master_v2_mutation_fails(self) -> None:
         report = build_boundary_report(
-            ["src/trading/master_v2/directional_assessment_v1.py"],
+            ["src/trading/master_v2/survival_assessment_v1.py"],
             repo_root=REPO_ROOT,
         )
         assert report.admissible is False
@@ -234,7 +245,7 @@ class TestTechnicalCanonicalWiringAuthorizationNegativeV1:
     def test_research_plus_forbidden_core_without_matching_auth_fails(self) -> None:
         changed = [
             "src/research/linear_evidence/cost_model.py",
-            "src/trading/master_v2/directional_assessment_v1.py",
+            "src/trading/master_v2/survival_assessment_v1.py",
         ]
         report = build_boundary_report(changed, repo_root=REPO_ROOT)
         assert report.admissible is False

--- a/tests/research/test_double_play_composition_backtest_parity_wiring_assessment_or_narrow_rewire_v0.py
+++ b/tests/research/test_double_play_composition_backtest_parity_wiring_assessment_or_narrow_rewire_v0.py
@@ -182,14 +182,7 @@ def test_integrated_replay_and_backtest_call_canonical_composition_matrix() -> N
     backtest_source = BACKTEST_WIRING.read_text(encoding="utf-8")
     matrix_source = COMPOSITION_MATRIX.read_text(encoding="utf-8")
 
-    assert (
-        "evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1" in replay_source
-    )
-    assert "evaluate_directional_assessment_with_confirmation_progress_v1" in (
-        Path(
-            "src/trading/master_v2/directional_assessment_confirmation_integration_v1.py"
-        ).read_text(encoding="utf-8")
-    )
+    assert "evaluate_directional_assessment_v1" in replay_source
     assert "evaluate_survival_assessment_v1" in replay_source
     assert "evaluate_suitability_binding_v1" in replay_source
     assert "evaluate_double_play_composition_matrix_v1" in replay_source
@@ -230,14 +223,7 @@ def test_bull_bear_assessment_uses_shared_directional_contract() -> None:
     directional_source = DIRECTIONAL_ASSESSMENT.read_text(encoding="utf-8")
     assert "DirectionalAssessmentSide.LONG" in replay_source
     assert "DirectionalAssessmentSide.SHORT" in replay_source
-    assert (
-        "evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1" in replay_source
-    )
-    assert "evaluate_directional_assessment_with_confirmation_progress_v1" in (
-        Path(
-            "src/trading/master_v2/directional_assessment_confirmation_integration_v1.py"
-        ).read_text(encoding="utf-8")
-    )
+    assert "evaluate_directional_assessment_v1" in replay_source
     assert DirectionalAssessmentSide.LONG.value in directional_source
     assert DirectionalAssessmentSide.SHORT.value in directional_source
     assert DIRECTIONAL_ASSESSMENT_POLICY_VERSION

--- a/tests/research/test_double_play_composition_backtest_parity_wiring_assessment_or_narrow_rewire_v0.py
+++ b/tests/research/test_double_play_composition_backtest_parity_wiring_assessment_or_narrow_rewire_v0.py
@@ -182,7 +182,14 @@ def test_integrated_replay_and_backtest_call_canonical_composition_matrix() -> N
     backtest_source = BACKTEST_WIRING.read_text(encoding="utf-8")
     matrix_source = COMPOSITION_MATRIX.read_text(encoding="utf-8")
 
-    assert "evaluate_directional_assessment_v1" in replay_source
+    assert (
+        "evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1" in replay_source
+    )
+    assert "evaluate_directional_assessment_with_confirmation_progress_v1" in (
+        Path(
+            "src/trading/master_v2/directional_assessment_confirmation_integration_v1.py"
+        ).read_text(encoding="utf-8")
+    )
     assert "evaluate_survival_assessment_v1" in replay_source
     assert "evaluate_suitability_binding_v1" in replay_source
     assert "evaluate_double_play_composition_matrix_v1" in replay_source
@@ -223,7 +230,14 @@ def test_bull_bear_assessment_uses_shared_directional_contract() -> None:
     directional_source = DIRECTIONAL_ASSESSMENT.read_text(encoding="utf-8")
     assert "DirectionalAssessmentSide.LONG" in replay_source
     assert "DirectionalAssessmentSide.SHORT" in replay_source
-    assert "evaluate_directional_assessment_v1" in replay_source
+    assert (
+        "evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1" in replay_source
+    )
+    assert "evaluate_directional_assessment_with_confirmation_progress_v1" in (
+        Path(
+            "src/trading/master_v2/directional_assessment_confirmation_integration_v1.py"
+        ).read_text(encoding="utf-8")
+    )
     assert DirectionalAssessmentSide.LONG.value in directional_source
     assert DirectionalAssessmentSide.SHORT.value in directional_source
     assert DIRECTIONAL_ASSESSMENT_POLICY_VERSION

--- a/tests/trading/master_v2/_canonical_architecture_drift_guard_helpers_v1.py
+++ b/tests/trading/master_v2/_canonical_architecture_drift_guard_helpers_v1.py
@@ -42,7 +42,8 @@ _AUTHORIZED_CONSTRUCTOR_REL_PATH = (
 # Core decision stages composed only by the canonical total decision owner.
 _PARTIAL_DECISION_STAGE_CALLS = frozenset(
     {
-        "evaluate_directional_assessment_v1",
+        "evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1",
+        "evaluate_directional_assessment_with_confirmation_progress_v1",
         "evaluate_survival_assessment_v1",
         "evaluate_suitability_binding_v1",
         "evaluate_double_play_composition_matrix_v1",

--- a/tests/trading/master_v2/test_canonical_architecture_drift_guard_v1.py
+++ b/tests/trading/master_v2/test_canonical_architecture_drift_guard_v1.py
@@ -115,7 +115,7 @@ def test_negative_fixture_competing_partial_stage_orchestrator_rejected(
     owner_dir.mkdir(parents=True)
     (owner_dir / owner_rel.name).write_text(
         "def run_integrated_offline_trading_logic_replay_v1(replay_input):\n"
-        "    evaluate_directional_assessment_v1()\n"
+        "    evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1()\n"
         "    evaluate_survival_assessment_v1()\n"
         "    evaluate_suitability_binding_v1()\n"
         "    evaluate_double_play_composition_matrix_v1()\n"
@@ -127,7 +127,7 @@ def test_negative_fixture_competing_partial_stage_orchestrator_rejected(
     rogue.parent.mkdir(parents=True, exist_ok=True)
     rogue.write_text(
         "def run_parallel_total_decision_v0(replay_input):\n"
-        "    evaluate_directional_assessment_v1()\n"
+        "    evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1()\n"
         "    evaluate_survival_assessment_v1()\n"
         "    evaluate_suitability_binding_v1()\n"
         "    evaluate_double_play_composition_matrix_v1()\n"

--- a/tests/trading/master_v2/test_directional_assessment_confirmation_integration_v1.py
+++ b/tests/trading/master_v2/test_directional_assessment_confirmation_integration_v1.py
@@ -705,4 +705,16 @@ def test_22_legacy_candidate_count_ignored_by_c3() -> None:
 def test_23_run_integrated_imports_c3_not_legacy_da_evaluator() -> None:
     source = inspect.getsource(run_integrated_offline_trading_logic_replay_v1)
     assert "evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1" in source
-    assert "evaluate_directional_assessment_v1" not in source
+    tree = ast.parse(source)
+    call_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                call_names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                call_names.add(func.attr)
+    assert "evaluate_directional_assessment_v1" not in call_names
+    assert "evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1" in call_names
+    # Legacy name may appear only as quarantine documentation, never as a call.
+    assert "LEGACY_NON_PRODUCTIVE_CONFIRMATION_AUTHORITY_NOTE" in source

--- a/tests/trading/master_v2/test_directional_assessment_confirmation_integration_v1.py
+++ b/tests/trading/master_v2/test_directional_assessment_confirmation_integration_v1.py
@@ -1,0 +1,708 @@
+"""Contract and integration tests for C3 Directional Assessment Confirmation Integration."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from trading.market_state.directional_confirmation_progress_v1 import (
+    ConfirmationAssessmentSignalV1,
+    ConfirmationAssessmentStateV1,
+    ConfirmationProgressReasonCodeV1,
+    ConfirmationSideV1,
+    reject_decision_epoch_confirmation_advance_v1,
+    reject_receive_time_confirmation_advance_v1,
+    reject_runtime_cycle_confirmation_advance_v1,
+)
+from trading.market_state.distinct_market_observation_acceptor_v1 import (
+    ObservationAcceptanceResultV1,
+    ObservationCandidateV1,
+    ObservationClassification,
+    ObservationTransportMetadataV1,
+    commit_observation_acceptance_v1,
+    evaluate_distinct_market_observation_v1,
+    initial_observation_acceptance_state_v1,
+)
+from trading.market_state.observation_identity_v1 import (
+    InstrumentObservationKeyV1,
+    MarketObservationEpoch,
+)
+from trading.master_v2.canonical_market_context_v1 import (
+    BarFinalityStatus,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+)
+from trading.master_v2.directional_assessment_confirmation_integration_v1 import (
+    DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_CAPABILITY_ID,
+    PARALLEL_CONFIRMATION_AUTHORITY_FORBIDDEN,
+    DirectionalAssessmentConfirmationIntegrationInputV1,
+    DirectionalConfirmationSideStateCarrierV1,
+    ParallelConfirmationAuthorityErrorV1,
+    assert_c3_confirmation_authority_exclusive_v1,
+    evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1,
+    evaluate_directional_assessment_with_confirmation_progress_v1,
+    initial_directional_confirmation_side_state_carrier_v1,
+    map_confirmation_assessment_state_to_directional_status_v1,
+    map_signal_strength_to_confirmation_assessment_signal_v1,
+    non_advancing_observation_acceptance_result_v1,
+)
+from trading.master_v2.directional_assessment_v1 import (
+    DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+    DirectionalAssessmentInputV1,
+    DirectionalAssessmentPolicyV1,
+    DirectionalAssessmentSide,
+    DirectionalAssessmentStatus,
+    DirectionalConfirmationStateV1,
+    ScopeEventRefV1,
+    compute_signal_strength,
+)
+from trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
+    run_integrated_offline_trading_logic_replay_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REPLAY_MODULE = REPO_ROOT / "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py"
+C3_MODULE = (
+    REPO_ROOT / "src/trading/master_v2/directional_assessment_confirmation_integration_v1.py"
+)
+WIRING_MODULE = REPO_ROOT / "src/backtest/mv2_research_wiring_v1.py"
+
+
+def _key(
+    *,
+    venue: str = "okx_eea",
+    canonical: str = "ETH-USD-SWAP-CANON",
+    venue_inst: str = "ETH-USD-SWAP",
+) -> InstrumentObservationKeyV1:
+    return InstrumentObservationKeyV1(
+        venue=venue,
+        canonical_instrument_id=canonical,
+        venue_instrument_id=venue_inst,
+    )
+
+
+def _policy(**overrides: object) -> DirectionalAssessmentPolicyV1:
+    base = {
+        "observe_signal_threshold": 0.001,
+        "candidate_signal_threshold": 0.005,
+        "confirmation_signal_threshold": 0.01,
+        "confirmation_epochs": 2,
+        "validity_epochs": 3,
+        "policy_version": DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+    }
+    base.update(overrides)
+    return DirectionalAssessmentPolicyV1(**base)  # type: ignore[arg-type]
+
+
+def _scope_ref(trading_epoch: int = 10) -> ScopeEventRefV1:
+    return ScopeEventRefV1(
+        scope_event_id="scope-evt-1",
+        semantic_digest="a" * 64,
+        event_type="UPSCOPE_CONFIRMED",
+        trading_epoch=trading_epoch,
+    )
+
+
+def _da_input(
+    *,
+    side: DirectionalAssessmentSide = DirectionalAssessmentSide.LONG,
+    price_path: tuple[float, ...] = (3500.0, 3550.0),
+    trading_epoch: int = 10,
+) -> DirectionalAssessmentInputV1:
+    return DirectionalAssessmentInputV1(
+        instrument_id="ETH-USD-SWAP-CANON",
+        trading_epoch=trading_epoch,
+        side=side,
+        price_path=price_path,
+        reference_price=3500.0,
+        feature_refs=("feat-momentum-v1",),
+        scope_event_ref=_scope_ref(trading_epoch),
+        survival_preconditions=("survival_precondition_ref_only",),
+        confirmation_state=DirectionalConfirmationStateV1(
+            candidate_count=99,
+            last_evaluated_trading_epoch=0,
+            last_signal_strength=9.0,
+        ),
+        data_integrity_status=DataIntegrityStatus.TRUSTED,
+        clock_trust_status=ClockTrustStatus.TRUSTED,
+        bar_finality_status=BarFinalityStatus.FINALIZED,
+        trusted_data=True,
+        input_complete=True,
+        explicit_hard_block_reasons=(),
+        policy_version=DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
+    )
+
+
+def _candidate(
+    *,
+    event_time: float,
+    mark: float,
+    receive_time: Optional[float] = None,
+    poll_attempt: Optional[int] = None,
+    runtime_cycle_index: Optional[int] = None,
+    key: Optional[InstrumentObservationKeyV1] = None,
+) -> ObservationCandidateV1:
+    instrument = key or _key()
+    transport = None
+    if receive_time is not None or poll_attempt is not None or runtime_cycle_index is not None:
+        transport = ObservationTransportMetadataV1(
+            receive_time=receive_time,
+            poll_attempt=poll_attempt,
+            runtime_cycle_index=runtime_cycle_index,
+        )
+    return ObservationCandidateV1(
+        venue=instrument.venue,
+        canonical_instrument_id=instrument.canonical_instrument_id,
+        venue_instrument_id=instrument.venue_instrument_id,
+        venue_event_time=event_time,
+        mark_price=mark,
+        transport=transport,
+    )
+
+
+def _eval_c1(state, candidate):
+    result = evaluate_distinct_market_observation_v1(state, candidate)
+    if result.classification == ObservationClassification.DISTINCT:
+        state = commit_observation_acceptance_v1(current_state=state, result=result)
+    return result, state
+
+
+def _carrier(session_id: str = "sess-c3") -> DirectionalConfirmationSideStateCarrierV1:
+    return initial_directional_confirmation_side_state_carrier_v1(
+        session_id=session_id,
+        venue="okx_eea",
+        instrument=_key(),
+    )
+
+
+def _progress_side(
+    *,
+    side: ConfirmationSideV1,
+    prior_carrier: DirectionalConfirmationSideStateCarrierV1,
+    acceptor: ObservationAcceptanceResultV1,
+    price_path: tuple[float, ...],
+    session_id: str = "sess-c3",
+    venue: str = "okx_eea",
+    instrument: Optional[InstrumentObservationKeyV1] = None,
+    policy: Optional[DirectionalAssessmentPolicyV1] = None,
+):
+    instrument = instrument or _key()
+    policy = policy or _policy()
+    da_side = (
+        DirectionalAssessmentSide.LONG
+        if side is ConfirmationSideV1.LONG
+        else DirectionalAssessmentSide.SHORT
+    )
+    return evaluate_directional_assessment_with_confirmation_progress_v1(
+        DirectionalAssessmentConfirmationIntegrationInputV1(
+            directional_input=_da_input(side=da_side, price_path=price_path),
+            policy=policy,
+            prior_confirmation_progress=prior_carrier.for_side(side),
+            observation_acceptance_result=acceptor,
+            session_id=session_id,
+            venue=venue,
+            instrument=instrument,
+            side=side,
+        )
+    )
+
+
+def test_01_bull_observe_candidate_confirmed() -> None:
+    policy = _policy(confirmation_epochs=2)
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    # strong bull path
+    path = (3500.0, 3550.0)
+    assert (
+        map_signal_strength_to_confirmation_assessment_signal_v1(
+            compute_signal_strength(
+                price_path=path, side=DirectionalAssessmentSide.LONG, reference_price=3500.0
+            ),
+            policy,
+        )
+        is ConfirmationAssessmentSignalV1.CONFIRMED
+    )
+    a1, c1 = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    r1 = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=path,
+        policy=policy,
+    )
+    assert r1.assessment.status is DirectionalAssessmentStatus.CANDIDATE
+    carrier = carrier.with_side_state(ConfirmationSideV1.LONG, r1.confirmation_progress_after)
+
+    a2, c1 = _eval_c1(c1, _candidate(event_time=1001.0, mark=11.0))
+    r2 = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a2,
+        price_path=path,
+        policy=policy,
+    )
+    assert r2.assessment.status is DirectionalAssessmentStatus.CONFIRMED
+    assert (
+        r2.confirmation_progress_after.assessment_state is ConfirmationAssessmentStateV1.CONFIRMED
+    )
+
+
+def test_02_bear_observe_candidate_confirmed() -> None:
+    policy = _policy(confirmation_epochs=2)
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    path = (3500.0, 3450.0)  # down move → SHORT strength positive
+    a1, c1 = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    r1 = _progress_side(
+        side=ConfirmationSideV1.SHORT,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=path,
+        policy=policy,
+    )
+    assert r1.assessment.status is DirectionalAssessmentStatus.CANDIDATE
+    carrier = carrier.with_side_state(ConfirmationSideV1.SHORT, r1.confirmation_progress_after)
+    a2, _ = _eval_c1(c1, _candidate(event_time=1001.0, mark=11.0))
+    r2 = _progress_side(
+        side=ConfirmationSideV1.SHORT,
+        prior_carrier=carrier,
+        acceptor=a2,
+        price_path=path,
+        policy=policy,
+    )
+    assert r2.assessment.status is DirectionalAssessmentStatus.CONFIRMED
+
+
+def test_03_bull_bear_state_isolation() -> None:
+    policy = _policy(confirmation_epochs=2)
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    a1, c1 = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    bull_before = carrier.bull_confirmation_state
+    bear_before = carrier.bear_confirmation_state
+    bull, bear, after = evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1(
+        bull_input=_da_input(side=DirectionalAssessmentSide.LONG, price_path=(3500.0, 3550.0)),
+        bear_input=_da_input(side=DirectionalAssessmentSide.SHORT, price_path=(3500.0, 3550.0)),
+        policy=policy,
+        prior_carrier=carrier,
+        observation_acceptance_result=a1,
+        session_id="sess-c3",
+        venue="okx_eea",
+        instrument=_key(),
+    )
+    assert after.bull_confirmation_state != bull_before
+    assert after.bear_confirmation_state != bear_before or bear.assessment.status in {
+        DirectionalAssessmentStatus.OBSERVE,
+        DirectionalAssessmentStatus.CANDIDATE,
+        DirectionalAssessmentStatus.CONFIRMED,
+        DirectionalAssessmentStatus.BLOCKED,
+        DirectionalAssessmentStatus.INVALID,
+    }
+    # Bull-only update must not touch bear prior when evaluated alone.
+    alone = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+        policy=policy,
+    )
+    mid = carrier.with_side_state(ConfirmationSideV1.LONG, alone.confirmation_progress_after)
+    assert mid.bear_confirmation_state == bear_before
+    assert alone.assessment.status is DirectionalAssessmentStatus.CANDIDATE
+
+
+def test_04_non_distinct_noop() -> None:
+    carrier = _carrier()
+    acceptor = non_advancing_observation_acceptance_result_v1(bound_instrument_key=_key())
+    out = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=acceptor,
+        price_path=(3500.0, 3550.0),
+    )
+    assert out.reason_code is ConfirmationProgressReasonCodeV1.NON_DISTINCT_NOOP
+    assert out.confirmation_advanced is False
+    assert out.confirmation_progress_after == carrier.bull_confirmation_state
+    assert out.assessment.status is DirectionalAssessmentStatus.OBSERVE
+
+
+def test_05_idempotent_replay() -> None:
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    a1, _ = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    first = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+    )
+    carrier2 = carrier.with_side_state(ConfirmationSideV1.LONG, first.confirmation_progress_after)
+    replay = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier2,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+    )
+    assert replay.reason_code is ConfirmationProgressReasonCodeV1.IDEMPOTENT_REPLAY
+    assert replay.confirmation_advanced is False
+    assert replay.confirmation_progress_after == first.confirmation_progress_after
+
+
+def test_06_epoch_gap_fail_closed() -> None:
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    a1, c1 = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    progressed = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+    )
+    carrier = carrier.with_side_state(
+        ConfirmationSideV1.LONG, progressed.confirmation_progress_after
+    )
+    # Force gap: advance C1 twice without feeding C2 the intermediate result.
+    a2, c1 = _eval_c1(c1, _candidate(event_time=1001.0, mark=11.0))
+    a3, _ = _eval_c1(c1, _candidate(event_time=1002.0, mark=12.0))
+    assert a3.state_after.market_observation_epoch.value == (
+        progressed.confirmation_progress_after.latest_accepted_market_observation_epoch.value + 2
+    )
+    gap = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a3,
+        price_path=(3500.0, 3550.0),
+    )
+    assert gap.fail_closed is True
+    assert gap.reason_code is ConfirmationProgressReasonCodeV1.EPOCH_GAP
+    assert gap.assessment.status is DirectionalAssessmentStatus.BLOCKED
+
+
+def test_07_epoch_regression_fail_closed() -> None:
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    a1, c1 = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    first = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+    )
+    carrier = carrier.with_side_state(ConfirmationSideV1.LONG, first.confirmation_progress_after)
+    a2, _ = _eval_c1(c1, _candidate(event_time=1001.0, mark=11.0))
+    # Replay older acceptor epoch by manufacturing stale result via non-advancing at epoch 0.
+    stale = non_advancing_observation_acceptance_result_v1(
+        bound_instrument_key=_key(),
+        market_observation_epoch=MarketObservationEpoch(value=0),
+    )
+    # Make it look DISTINCT with strategy_advance to trigger epoch check.
+    from trading.market_state.distinct_market_observation_acceptor_v1 import (
+        ObservationAcceptanceStateV1,
+    )
+
+    stale_distinct = ObservationAcceptanceResultV1(
+        classification=ObservationClassification.DISTINCT,
+        strategy_advance_allowed=True,
+        state_before=ObservationAcceptanceStateV1(
+            last_accepted_observation_identity=None,
+            market_observation_epoch=MarketObservationEpoch(value=0),
+            bound_instrument_key=_key(),
+            last_accepted_transport=None,
+        ),
+        state_after=ObservationAcceptanceStateV1(
+            last_accepted_observation_identity=a1.observation_identity,
+            market_observation_epoch=MarketObservationEpoch(value=0),
+            bound_instrument_key=_key(),
+            last_accepted_transport=None,
+        ),
+        observation_identity=a1.observation_identity,
+        reason_code="forced_regression",
+    )
+    out = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=stale_distinct,
+        price_path=(3500.0, 3550.0),
+    )
+    assert out.fail_closed is True
+    assert out.reason_code is ConfirmationProgressReasonCodeV1.EPOCH_REGRESSION
+    _ = a2
+    _ = stale
+
+
+def test_08_session_mismatch() -> None:
+    carrier = _carrier(session_id="sess-a")
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    a1, _ = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    out = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+        session_id="other-session",
+    )
+    assert out.fail_closed is True
+    assert out.reason_code is ConfirmationProgressReasonCodeV1.SESSION_MISMATCH
+
+
+def test_09_venue_mismatch() -> None:
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    a1, _ = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    out = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+        venue="other-venue",
+    )
+    assert out.fail_closed is True
+    assert out.reason_code is ConfirmationProgressReasonCodeV1.VENUE_MISMATCH
+
+
+def test_10_instrument_mismatch() -> None:
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    a1, _ = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    other = _key(canonical="OTHER-CANON", venue_inst="OTHER")
+    out = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+        instrument=other,
+    )
+    assert out.fail_closed is True
+    assert out.reason_code is ConfirmationProgressReasonCodeV1.INSTRUMENT_MISMATCH
+
+
+def test_11_side_mismatch() -> None:
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    a1, _ = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    # Feed LONG input but claim SHORT side against LONG prior state.
+    out = evaluate_directional_assessment_with_confirmation_progress_v1(
+        DirectionalAssessmentConfirmationIntegrationInputV1(
+            directional_input=_da_input(side=DirectionalAssessmentSide.SHORT),
+            policy=_policy(),
+            prior_confirmation_progress=carrier.bull_confirmation_state,
+            observation_acceptance_result=a1,
+            session_id="sess-c3",
+            venue="okx_eea",
+            instrument=_key(),
+            side=ConfirmationSideV1.SHORT,
+        )
+    )
+    assert out.fail_closed is True
+    assert out.reason_code is ConfirmationProgressReasonCodeV1.SIDE_MISMATCH
+
+
+def test_12_runtime_cycle_rejected() -> None:
+    carrier = _carrier()
+    reject = reject_runtime_cycle_confirmation_advance_v1(carrier.bull_confirmation_state)
+    assert reject.reason_code is ConfirmationProgressReasonCodeV1.RUNTIME_CYCLE_NOT_OBSERVATION
+    assert reject.fail_closed is True
+
+
+def test_13_receive_time_rejected() -> None:
+    carrier = _carrier()
+    reject = reject_receive_time_confirmation_advance_v1(carrier.bull_confirmation_state)
+    assert reject.reason_code is ConfirmationProgressReasonCodeV1.RECEIVE_TIME_NOT_EPOCH
+
+
+def test_14_decision_epoch_rejected() -> None:
+    carrier = _carrier()
+    reject = reject_decision_epoch_confirmation_advance_v1(carrier.bull_confirmation_state)
+    assert reject.reason_code is ConfirmationProgressReasonCodeV1.DECISION_EPOCH_FORBIDDEN
+
+
+def test_15_observe_signal_resets() -> None:
+    policy = _policy(confirmation_epochs=2)
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    a1, c1 = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    cand = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+        policy=policy,
+    )
+    carrier = carrier.with_side_state(ConfirmationSideV1.LONG, cand.confirmation_progress_after)
+    a2, _ = _eval_c1(c1, _candidate(event_time=1001.0, mark=11.0))
+    reset = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a2,
+        price_path=(3500.0, 3500.5),  # below candidate threshold → OBSERVE signal
+        policy=policy,
+    )
+    assert reset.assessment_signal is ConfirmationAssessmentSignalV1.OBSERVE
+    assert (
+        reset.confirmation_progress_after.assessment_state is ConfirmationAssessmentStateV1.OBSERVE
+    )
+    assert reset.confirmation_progress_after.distinct_confirmation_observation_count == 0
+    assert reset.confirmation_progress_after.candidate_started_at_epoch is None
+
+
+def test_16_confirmed_hold_stable() -> None:
+    policy = _policy(confirmation_epochs=2)
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    path = (3500.0, 3550.0)
+    a1, c1 = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    r1 = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=path,
+        policy=policy,
+    )
+    carrier = carrier.with_side_state(ConfirmationSideV1.LONG, r1.confirmation_progress_after)
+    a2, c1 = _eval_c1(c1, _candidate(event_time=1001.0, mark=11.0))
+    r2 = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a2,
+        price_path=path,
+        policy=policy,
+    )
+    assert r2.assessment.status is DirectionalAssessmentStatus.CONFIRMED
+    count = r2.confirmation_progress_after.distinct_confirmation_observation_count
+    carrier = carrier.with_side_state(ConfirmationSideV1.LONG, r2.confirmation_progress_after)
+    a3, _ = _eval_c1(c1, _candidate(event_time=1002.0, mark=12.0))
+    hold = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a3,
+        price_path=path,
+        policy=policy,
+    )
+    assert hold.assessment.status is DirectionalAssessmentStatus.CONFIRMED
+    assert hold.confirmation_progress_after.distinct_confirmation_observation_count == count
+    assert hold.reason_code is ConfirmationProgressReasonCodeV1.ACCEPTED_DISTINCT_HOLD_CONFIRMED
+
+
+def test_17_deterministic_serialization_and_fingerprints() -> None:
+    carrier = _carrier()
+    restored = DirectionalConfirmationSideStateCarrierV1.from_dict(carrier.to_dict())
+    assert restored == carrier
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    a1, _ = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    r1 = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+    )
+    r2 = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+    )
+    assert r1.confirmation_progress_result.deterministic_fingerprint == (
+        r2.confirmation_progress_result.deterministic_fingerprint
+    )
+    assert r1.assessment.semantic_digest == r2.assessment.semantic_digest
+
+
+def test_18_downstream_status_mapping_stable() -> None:
+    assert (
+        map_confirmation_assessment_state_to_directional_status_v1(
+            ConfirmationAssessmentStateV1.OBSERVE
+        )
+        is DirectionalAssessmentStatus.OBSERVE
+    )
+    assert (
+        map_confirmation_assessment_state_to_directional_status_v1(
+            ConfirmationAssessmentStateV1.CANDIDATE
+        )
+        is DirectionalAssessmentStatus.CANDIDATE
+    )
+    assert (
+        map_confirmation_assessment_state_to_directional_status_v1(
+            ConfirmationAssessmentStateV1.CONFIRMED
+        )
+        is DirectionalAssessmentStatus.CONFIRMED
+    )
+
+
+def test_19_no_config_or_threshold_mutation() -> None:
+    policy = _policy()
+    assert policy.confirmation_epochs == 2
+    assert policy.observe_signal_threshold == 0.001
+    assert policy.candidate_signal_threshold == 0.005
+    assert policy.confirmation_signal_threshold == 0.01
+    source = C3_MODULE.read_text(encoding="utf-8")
+    assert "confirmation_epochs" in source
+    assert "PARAMETER_CHANGE_INCLUDED = False" in source
+    assert "VOLATILITY_CHANGE_INCLUDED = False" in source
+
+
+def test_20_old_confirmation_counter_not_productive_authority() -> None:
+    replay_src = REPLAY_MODULE.read_text(encoding="utf-8")
+    assert "evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1" in replay_src
+    assert "evaluate_directional_assessment_v1(" not in replay_src
+    tree = ast.parse(replay_src)
+    call_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                call_names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                call_names.add(func.attr)
+    assert "evaluate_directional_assessment_v1" not in call_names
+    assert "evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1" in call_names
+    wiring_src = WIRING_MODULE.read_text(encoding="utf-8")
+    assert "LEGACY_LOSSY_CROSS_SIDE_PROJECTOR_AUTHORITY_FORBIDDEN" in wiring_src
+    wiring_tree = ast.parse(wiring_src)
+    proj_fn = None
+    for node in wiring_tree.body:
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "project_mv2_integrated_replay_bar_sequence_state_from_intermediate_v1"
+        ):
+            proj_fn = node
+            break
+    assert proj_fn is not None
+    proj_src = ast.get_source_segment(wiring_src, proj_fn) or ""
+    assert "directional_confirmation_progress_after" in proj_src
+    assert "project_directional_confirmation_state_from_assessments_v1" not in proj_src
+
+
+def test_21_parallel_authority_guard() -> None:
+    assert PARALLEL_CONFIRMATION_AUTHORITY_FORBIDDEN is True
+    assert_c3_confirmation_authority_exclusive_v1()
+    with pytest.raises(ParallelConfirmationAuthorityErrorV1):
+        assert_c3_confirmation_authority_exclusive_v1(legacy_confirmation_authority_enabled=True)
+    assert DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_CAPABILITY_ID == (
+        "DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1"
+    )
+
+
+def test_22_legacy_candidate_count_ignored_by_c3() -> None:
+    """Poisoned legacy DirectionalConfirmationStateV1 must not drive C3 status."""
+    carrier = _carrier()
+    c1 = initial_observation_acceptance_state_v1(bound_instrument_key=_key())
+    a1, _ = _eval_c1(c1, _candidate(event_time=1000.0, mark=10.0))
+    out = _progress_side(
+        side=ConfirmationSideV1.LONG,
+        prior_carrier=carrier,
+        acceptor=a1,
+        price_path=(3500.0, 3550.0),
+    )
+    # Legacy input had candidate_count=99; first DISTINCT CONFIRMED-signal → CANDIDATE at threshold 2.
+    assert out.assessment.status is DirectionalAssessmentStatus.CANDIDATE
+    assert out.confirmation_progress_after.distinct_confirmation_observation_count == 1
+
+
+def test_23_run_integrated_imports_c3_not_legacy_da_evaluator() -> None:
+    source = inspect.getsource(run_integrated_offline_trading_logic_replay_v1)
+    assert "evaluate_bull_bear_directional_assessment_with_confirmation_progress_v1" in source
+    assert "evaluate_directional_assessment_v1" not in source


### PR DESCRIPTION
## Summary
- Integrate C1 `ObservationAcceptanceResultV1` and C2 `evaluate_confirmation_progress_v1` into productive Master-V2 directional assessment via `evaluate_directional_assessment_with_confirmation_progress_v1` / bull-bear carrier.
- Wire `run_integrated_offline_trading_logic_replay_v1` to isolated Bull/Bear `ConfirmationProgressStateV1`; quarantine legacy trading_epoch counter and lossy cross-side projector as non-authority.
- Add C3 spec and full contract/regression matrix; no runtime activation, config, threshold, volatility, or C4 scope.

## Test plan
- [x] `tests/trading/master_v2/test_directional_assessment_confirmation_integration_v1.py` (23)
- [x] C1/C2/DA regressions
- [x] Integrated offline replay + composition + entry/exit + drift-guard + asymmetry wiring
- [x] Docs token / reference-target gates
- [x] `ruff format --check` / `ruff check` on changed Python
- [ ] GitHub CI confirmation on PR


Made with [Cursor](https://cursor.com)