### PR TITLE
feat(master-v2): typed volatility estimate consumption contract v1

### DIFF
--- a/config/governance/technical_canonical_wiring_authorization_v1.json
+++ b/config/governance/technical_canonical_wiring_authorization_v1.json
@@ -734,7 +734,10 @@
     "docs/ops/specs/MV2_C4_POST_CONFIRMATION_SURVIVAL_SUITABILITY_COMPOSITION_BINDING_V1.md",
     "src/trading/market_state/time_sample_epoch_semantics_v1.py",
     "tests/trading/market_state/test_time_sample_epoch_semantics_v1.py",
-    "docs/ops/specs/MV2_TIME_SAMPLE_EPOCH_SEMANTICS_V1.md"
+    "docs/ops/specs/MV2_TIME_SAMPLE_EPOCH_SEMANTICS_V1.md",
+    "src/trading/master_v2/canonical_volatility_estimate_typed_consumption_contract_v1.py",
+    "tests/trading/master_v2/test_canonical_volatility_estimate_typed_consumption_contract_v1.py",
+    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_ESTIMATE_TYPED_CONSUMPTION_CONTRACT_V1.md"
   ],
   "allowed_surface_classes": [
     "TECHNICAL_CANONICAL_REPLAY_INPUT_BUILDER_WIRING",

--- a/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_ESTIMATE_TYPED_CONSUMPTION_CONTRACT_V1.md
+++ b/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_ESTIMATE_TYPED_CONSUMPTION_CONTRACT_V1.md
@@ -1,0 +1,154 @@
+# MASTER_V2 Canonical Volatility Estimate Typed Consumption Contract v1
+
+---
+docs_token: DOCS_TOKEN_MASTER_V2_CANONICAL_VOLATILITY_ESTIMATE_TYPED_CONSUMPTION_CONTRACT_V1
+STATUS: CAPABILITY_AVAILABLE
+scope: typed carrier + fail-closed legacy float adapter; non-authorizing; no runtime wiring
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+RUNTIME_WIRING: false
+HOT_PATH_BINDING: false
+PARAMETER_EFFECT: false
+TRADING_LOGIC_EFFECT: false
+---
+
+> **Non-authorizing.** Reuses ratified
+> `canonical_volatility_estimate_feature_contract&#47;v1` semantics and the existing
+> canonical materializer. Provides a typed carrier and a fail-closed legacy-float
+> adapter only. Does **not** wire Double Play, mutate hot-path defaults
+> (`0.2` &#47; `0.02` &#47; `1.0`), change parameters, composition, entry&#47;exit,
+> survival, suitability, market state, or authorize live &#47; testnet &#47; orders.
+
+## Machine summary
+
+```
+SEMANTICS_OWNER=trading.master_v2.canonical_volatility_estimate_feature_contract_v1
+ESTIMATOR_OWNER=trading.master_v2.canonical_volatility_estimate_materializer_v1
+TYPED_CARRIER_OWNER=trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1
+LEGACY_ADAPTER_OWNER=trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1
+CANONICAL_UNIT=PER_BAR_DECIMAL_RETURN_VOLATILITY
+CANONICAL_HORIZON=PT60M
+CANONICAL_ESTIMATOR=POPULATION_STANDARD_DEVIATION_OF_LOG_RETURNS
+OBSERVATION_REQUIREMENT=61_prices_60_returns
+UNKNOWN_BEHAVIOR=FAIL_CLOSED
+FALLBACK_POLICY=REJECT_FALLBACK_USED_AND_IMPLICIT_DEFAULTS
+RUNTIME_EFFECT=false
+TRADING_LOGIC_EFFECT=false
+PARAMETER_EFFECT=false
+LIVE_AUTHORIZATION=false
+IMPLICIT_DEFAULT_ALLOWED=false
+MV2_FALLBACK_0_2_ADMISSIBLE=false
+WARMUP_BEHAVIOR=NULL_FAIL_CLOSED
+READY_FOR_HOT_PATH_BINDING=false
+READY_FOR_PARAMETER_RESEARCH=false
+```
+
+## Owners (reuse-before-new)
+
+| Surface | Owner |
+|---|---|
+| Semantics | `trading.master_v2.canonical_volatility_estimate_feature_contract_v1` |
+| Estimator &#47; materializer | `trading.master_v2.canonical_volatility_estimate_materializer_v1` |
+| Typed carrier | `src&#47;trading&#47;master_v2&#47;canonical_volatility_estimate_typed_consumption_contract_v1.py` |
+| Legacy float adapter | same module (`adapt_canonical_volatility_estimate_to_legacy_float_v1`) |
+| Tests | `tests&#47;trading&#47;master_v2&#47;test_canonical_volatility_estimate_typed_consumption_contract_v1.py` |
+
+No second semantics authority and no second estimator implementation are introduced.
+
+## Carrier
+
+Immutable `CanonicalVolatilityEstimateV1`:
+
+- `value`, `unit`, `bar_interval_seconds`, `lookback_bars`, `horizon_seconds`
+- `annualized`, `estimator`, `observation_count`, `as_of_event_time`
+- `fallback_used`, `source_digest`, `contract_version`
+
+Fail-closed validation rejects missing &#47; non-finite &#47; negative values, wrong unit &#47;
+interval &#47; lookback &#47; horizon, annualization, wrong estimator, insufficient
+observations, naive event time, empty digest, unsupported contract version, and
+`fallback_used=true`.
+
+## Factory boundary
+
+```
+canonical mark-price observations
+  → existing materializer (REUSE)
+  → validated CanonicalVolatilityEstimateV1
+```
+
+- `REUSE_EXISTING_MATERIALIZER=true`
+- `DUPLICATE_ESTIMATOR_IMPLEMENTATION=false`
+- `RUNTIME_CYCLE_AS_MARKET_TIME=false`
+- `POLL_COUNT_AS_OBSERVATION_COUNT=false`
+- `EVENT_TIME_PRESERVED=true`
+- `SOURCE_DIGEST_DETERMINISTIC=true`
+
+## Legacy float adapter
+
+`CanonicalVolatilityEstimateV1` → legacy float succeeds only when the estimate is
+fully validated with `fallback_used=false` and canonical unit &#47; horizon &#47;
+estimator &#47; observations &#47; contract version.
+
+The adapter:
+
+- does not insert defaults
+- does not replace `None`
+- does not silently insert `0.2`, `0.02`, or `1.0`
+- does not guess unit &#47; horizon
+- does not silently accept annualized or foreign-horizon producers
+
+Numeric equality with `0.2` &#47; `0.02` &#47; `1.0` is allowed only when the value is a
+validated typed estimate with proven canonical provenance.
+
+## Contract gates (new path only)
+
+```
+IMPLICIT_FALLBACK_REJECTED=true
+MV2_FALLBACK_0_2_REJECTED=true
+UNKNOWN_PROVENANCE_REJECTED=true
+UNKNOWN_UNIT_REJECTED=true
+UNKNOWN_HORIZON_REJECTED=true
+ANNUALIZED_INPUT_REJECTED=true
+INSUFFICIENT_OBSERVATIONS_REJECTED=true
+FALLBACK_USED_REJECTED=true
+```
+
+Existing legacy hot-path defaults are **not** mutated by this capability.
+
+## Non-goals / non-aliases
+
+Not unified with this estimate:
+
+- `volatility_survival_ratio`
+- `FuturesVolatilityProfile.realized_volatility`
+- `volatility_profile_present`
+- regime analytics annualized volatility
+- wallclock `feature_regime_pipeline` volatility
+- research panel 1h volatility
+- ATR
+
+## Open hot-path gaps (remain open)
+
+```
+G1_SILENT_0_2_IN_HISTORICAL_BIND
+G2_SILENT_0_02_SCENARIO_INTEGRATED_DEFAULTS
+G3_UNTYPED_EXISTING_HOT_PATH_FLOAT
+G4_COMPETING_PRODUCERS_DIFFERENT_SCALING
+G5_PANEL_1H_REUSES_PT1M_LOOKBACK
+G6_MATERIALIZER_NOT_WIRED_TO_DOUBLE_PLAY
+G7_SEPARATE_SURVIVAL_AND_SUITABILITY_VOL_CONCEPTS
+G8_LEGACY_PATH_NOT_YET_GLOBALLY_ENFORCED
+G9_FUTURES_PROFILE_PRIMARY_METRIC_OQ001_OPEN
+```
+
+These gaps are intentionally left open. Closing any of them requires a separate
+Operator-GO and must not be performed silently under this capability.
+
+## Forbidden without separate GO
+
+- Runtime &#47; Double Play wiring
+- Historical bind &#47; scenario &#47; integrated-replay &#47; dynamic-scope default mutation
+- Parameter recommendation or change
+- Composition &#47; entry&#47;exit &#47; directional &#47; survival &#47; suitability &#47; scope &#47; C1 &#47;
+  confirmation changes
+- Live &#47; testnet &#47; order authorization

--- a/src/trading/master_v2/canonical_volatility_estimate_typed_consumption_contract_v1.py
+++ b/src/trading/master_v2/canonical_volatility_estimate_typed_consumption_contract_v1.py
@@ -1,0 +1,537 @@
+"""Canonical volatility estimate typed consumption contract v1.
+
+Typed carrier and fail-closed legacy-float adapter over the ratified
+``canonical_volatility_estimate_feature_contract/v1`` and the existing
+canonical materializer. Pure offline capability: no runtime wiring, no
+trading-logic mutation, no parameter change, no hot-path binding.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+from src.trading.master_v2 import canonical_volatility_estimate_feature_contract_v1 as contract
+from src.trading.master_v2 import canonical_volatility_estimate_materializer_v1 as materializer
+
+PACKAGE_MARKER = "MASTER_V2_CANONICAL_VOLATILITY_ESTIMATE_TYPED_CONSUMPTION_CONTRACT_V1=true"
+
+TYPED_CARRIER_OWNER = (
+    "trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1"
+)
+LEGACY_ADAPTER_OWNER = TYPED_CARRIER_OWNER
+CAPABILITY_ID = "MASTER_V2_CANONICAL_VOLATILITY_ESTIMATE_TYPED_CONSUMPTION_CONTRACT_V1"
+CAPABILITY_VERSION = "canonical_volatility_estimate_typed_consumption_contract/v1"
+
+# Reuse ratified semantics / estimator owners — no parallel authority.
+SEMANTICS_OWNER = contract.CONTRACT_OWNER
+ESTIMATOR_OWNER = materializer.MATERIALIZER_OWNER
+
+CANONICAL_UNIT = contract.OUTPUT_UNIT
+CANONICAL_BAR_INTERVAL = contract.BAR_INTERVAL
+CANONICAL_BAR_INTERVAL_SECONDS = materializer.BAR_INTERVAL_SECONDS
+CANONICAL_LOOKBACK_BARS = contract.LOOKBACK_BARS
+CANONICAL_HORIZON = contract.WINDOW_DURATION
+CANONICAL_HORIZON_SECONDS = 3600
+CANONICAL_ESTIMATOR = "POPULATION_STANDARD_DEVIATION_OF_LOG_RETURNS"
+CANONICAL_DDOF = contract.DDOF
+CANONICAL_ANNUALIZED = contract.OUTPUT_ANNUALIZED
+MINIMUM_PRICE_OBSERVATIONS = contract.WARMUP_REQUIRED_PRICE_COUNT
+MINIMUM_RETURN_OBSERVATIONS = contract.WARMUP_REQUIRED_RETURN_COUNT
+SUPPORTED_CONTRACT_VERSION = contract.CONTRACT_VERSION
+
+IMPLICIT_DEFAULT_ALLOWED = False
+MV2_FALLBACK_0_2_ADMISSIBLE = False
+WARMUP_BEHAVIOR = "NULL_FAIL_CLOSED"
+RUNTIME_EFFECT = False
+TRADING_LOGIC_EFFECT = False
+PARAMETER_EFFECT = False
+LIVE_AUTHORIZATION = False
+
+# Explicit open hot-path gaps (must remain open; not closed by this capability).
+OPEN_HOT_PATH_GAPS: tuple[str, ...] = (
+    "G1_SILENT_0_2_IN_HISTORICAL_BIND",
+    "G2_SILENT_0_02_SCENARIO_INTEGRATED_DEFAULTS",
+    "G3_UNTYPED_EXISTING_HOT_PATH_FLOAT",
+    "G4_COMPETING_PRODUCERS_DIFFERENT_SCALING",
+    "G5_PANEL_1H_REUSES_PT1M_LOOKBACK",
+    "G6_MATERIALIZER_NOT_WIRED_TO_DOUBLE_PLAY",
+    "G7_SEPARATE_SURVIVAL_AND_SUITABILITY_VOL_CONCEPTS",
+    "G8_LEGACY_PATH_NOT_YET_GLOBALLY_ENFORCED",
+    "G9_FUTURES_PROFILE_PRIMARY_METRIC_OQ001_OPEN",
+)
+
+# Non-alias surfaces — must not be treated as the canonical estimate.
+NON_ALIAS_VOLATILITY_SURFACES: tuple[str, ...] = (
+    "volatility_survival_ratio",
+    "FuturesVolatilityProfile.realized_volatility",
+    "volatility_profile_present",
+    "regime analytics annualized volatility",
+    "wallclock feature_regime_pipeline volatility",
+    "research panel 1h volatility",
+    "ATR",
+)
+
+
+class CanonicalVolatilityTypedConsumptionErrorCode(str, Enum):
+    MISSING_VALUE = "MISSING_VALUE"
+    NON_FINITE_VALUE = "NON_FINITE_VALUE"
+    NEGATIVE_VALUE = "NEGATIVE_VALUE"
+    UNIT_MISMATCH = "UNIT_MISMATCH"
+    BAR_INTERVAL_MISMATCH = "BAR_INTERVAL_MISMATCH"
+    LOOKBACK_MISMATCH = "LOOKBACK_MISMATCH"
+    HORIZON_MISMATCH = "HORIZON_MISMATCH"
+    ANNUALIZATION_MISMATCH = "ANNUALIZATION_MISMATCH"
+    ESTIMATOR_MISMATCH = "ESTIMATOR_MISMATCH"
+    INSUFFICIENT_OBSERVATIONS = "INSUFFICIENT_OBSERVATIONS"
+    EVENT_TIME_INVALID = "EVENT_TIME_INVALID"
+    FALLBACK_PROHIBITED = "FALLBACK_PROHIBITED"
+    SOURCE_DIGEST_INVALID = "SOURCE_DIGEST_INVALID"
+    CONTRACT_VERSION_UNSUPPORTED = "CONTRACT_VERSION_UNSUPPORTED"
+    WARMUP_INCOMPLETE = "WARMUP_INCOMPLETE"
+    UNKNOWN_PROVENANCE = "UNKNOWN_PROVENANCE"
+    IMPLICIT_FALLBACK_REJECTED = "IMPLICIT_FALLBACK_REJECTED"
+
+
+class CanonicalVolatilityTypedConsumptionError(ValueError):
+    """Fail-closed typed consumption / adapter error with diagnostic code."""
+
+    def __init__(
+        self,
+        code: CanonicalVolatilityTypedConsumptionErrorCode,
+        message: str,
+    ) -> None:
+        self.code = code
+        super().__init__(f"{code.value}:{message}")
+
+
+@dataclass(frozen=True)
+class CanonicalVolatilityEstimateV1:
+    """Immutable typed carrier for a validated canonical volatility estimate."""
+
+    value: float
+    unit: str
+    bar_interval_seconds: int
+    lookback_bars: int
+    horizon_seconds: int
+    annualized: bool
+    estimator: str
+    observation_count: int
+    as_of_event_time: datetime
+    fallback_used: bool
+    source_digest: str
+    contract_version: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "value": self.value,
+            "unit": self.unit,
+            "bar_interval_seconds": self.bar_interval_seconds,
+            "lookback_bars": self.lookback_bars,
+            "horizon_seconds": self.horizon_seconds,
+            "annualized": self.annualized,
+            "estimator": self.estimator,
+            "observation_count": self.observation_count,
+            "as_of_event_time": self.as_of_event_time.isoformat(),
+            "fallback_used": self.fallback_used,
+            "source_digest": self.source_digest,
+            "contract_version": self.contract_version,
+        }
+
+
+def _raise(
+    code: CanonicalVolatilityTypedConsumptionErrorCode,
+    message: str,
+) -> None:
+    raise CanonicalVolatilityTypedConsumptionError(code, message)
+
+
+def compute_source_digest_v1(
+    *,
+    value: float,
+    unit: str,
+    bar_interval_seconds: int,
+    lookback_bars: int,
+    horizon_seconds: int,
+    annualized: bool,
+    estimator: str,
+    observation_count: int,
+    as_of_event_time: datetime,
+    fallback_used: bool,
+    contract_version: str,
+    mark_prices: Sequence[float] | None = None,
+) -> str:
+    """Deterministic SHA-256 digest over carrier provenance fields (+ optional prices)."""
+    payload: dict[str, Any] = {
+        "annualized": annualized,
+        "as_of_event_time": as_of_event_time.astimezone(timezone.utc).isoformat(),
+        "bar_interval_seconds": bar_interval_seconds,
+        "contract_version": contract_version,
+        "estimator": estimator,
+        "fallback_used": fallback_used,
+        "horizon_seconds": horizon_seconds,
+        "lookback_bars": lookback_bars,
+        "observation_count": observation_count,
+        "unit": unit,
+        "value": value,
+    }
+    if mark_prices is not None:
+        payload["mark_prices"] = [float(x) for x in mark_prices]
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def validate_canonical_volatility_estimate_v1(
+    estimate: CanonicalVolatilityEstimateV1,
+) -> CanonicalVolatilityEstimateV1:
+    """Fail-closed validation of a typed canonical volatility estimate."""
+    if estimate.value is None:  # type: ignore[comparison-overlap]
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.MISSING_VALUE,
+            "value_is_none",
+        )
+    if isinstance(estimate.value, bool) or not isinstance(estimate.value, (int, float)):
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.MISSING_VALUE,
+            f"value_type_invalid:{type(estimate.value).__name__}",
+        )
+    value = float(estimate.value)
+    if not math.isfinite(value):
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.NON_FINITE_VALUE,
+            f"value={value!r}",
+        )
+    if value < 0.0:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.NEGATIVE_VALUE,
+            f"value={value!r}",
+        )
+    if estimate.unit != CANONICAL_UNIT:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.UNIT_MISMATCH,
+            f"expected={CANONICAL_UNIT!r}:actual={estimate.unit!r}",
+        )
+    if estimate.bar_interval_seconds != CANONICAL_BAR_INTERVAL_SECONDS:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.BAR_INTERVAL_MISMATCH,
+            f"expected={CANONICAL_BAR_INTERVAL_SECONDS}:actual={estimate.bar_interval_seconds}",
+        )
+    if estimate.lookback_bars != CANONICAL_LOOKBACK_BARS:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.LOOKBACK_MISMATCH,
+            f"expected={CANONICAL_LOOKBACK_BARS}:actual={estimate.lookback_bars}",
+        )
+    if estimate.horizon_seconds != CANONICAL_HORIZON_SECONDS:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.HORIZON_MISMATCH,
+            f"expected={CANONICAL_HORIZON_SECONDS}:actual={estimate.horizon_seconds}",
+        )
+    if estimate.annualized is not CANONICAL_ANNUALIZED:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.ANNUALIZATION_MISMATCH,
+            f"expected={CANONICAL_ANNUALIZED}:actual={estimate.annualized}",
+        )
+    if estimate.estimator != CANONICAL_ESTIMATOR:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.ESTIMATOR_MISMATCH,
+            f"expected={CANONICAL_ESTIMATOR!r}:actual={estimate.estimator!r}",
+        )
+    if int(estimate.observation_count) < MINIMUM_RETURN_OBSERVATIONS:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.INSUFFICIENT_OBSERVATIONS,
+            f"observation_count={estimate.observation_count}:minimum={MINIMUM_RETURN_OBSERVATIONS}",
+        )
+    as_of = estimate.as_of_event_time
+    if not isinstance(as_of, datetime) or as_of.tzinfo is None:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.EVENT_TIME_INVALID,
+            "as_of_event_time_must_be_timezone_aware",
+        )
+    if estimate.fallback_used is not False:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.FALLBACK_PROHIBITED,
+            f"fallback_used={estimate.fallback_used!r}",
+        )
+    digest = estimate.source_digest
+    if not isinstance(digest, str) or not digest.strip():
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.SOURCE_DIGEST_INVALID,
+            "source_digest_empty",
+        )
+    if estimate.contract_version != SUPPORTED_CONTRACT_VERSION:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.CONTRACT_VERSION_UNSUPPORTED,
+            f"expected={SUPPORTED_CONTRACT_VERSION!r}:actual={estimate.contract_version!r}",
+        )
+    return estimate
+
+
+def build_canonical_volatility_estimate_v1(
+    *,
+    value: float | None,
+    unit: str = CANONICAL_UNIT,
+    bar_interval_seconds: int = CANONICAL_BAR_INTERVAL_SECONDS,
+    lookback_bars: int = CANONICAL_LOOKBACK_BARS,
+    horizon_seconds: int = CANONICAL_HORIZON_SECONDS,
+    annualized: bool = CANONICAL_ANNUALIZED,
+    estimator: str = CANONICAL_ESTIMATOR,
+    observation_count: int,
+    as_of_event_time: datetime,
+    fallback_used: bool = False,
+    source_digest: str | None = None,
+    contract_version: str = SUPPORTED_CONTRACT_VERSION,
+    mark_prices: Sequence[float] | None = None,
+) -> CanonicalVolatilityEstimateV1:
+    """Factory that constructs and fail-closed validates a typed estimate."""
+    if value is None:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.MISSING_VALUE,
+            "value_is_none",
+        )
+    if fallback_used:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.FALLBACK_PROHIBITED,
+            "fallback_used_true_rejected_at_factory",
+        )
+    digest = source_digest
+    if digest is None:
+        digest = compute_source_digest_v1(
+            value=float(value),
+            unit=unit,
+            bar_interval_seconds=bar_interval_seconds,
+            lookback_bars=lookback_bars,
+            horizon_seconds=horizon_seconds,
+            annualized=annualized,
+            estimator=estimator,
+            observation_count=observation_count,
+            as_of_event_time=as_of_event_time,
+            fallback_used=False,
+            contract_version=contract_version,
+            mark_prices=mark_prices,
+        )
+    estimate = CanonicalVolatilityEstimateV1(
+        value=float(value),
+        unit=unit,
+        bar_interval_seconds=bar_interval_seconds,
+        lookback_bars=lookback_bars,
+        horizon_seconds=horizon_seconds,
+        annualized=annualized,
+        estimator=estimator,
+        observation_count=int(observation_count),
+        as_of_event_time=as_of_event_time,
+        fallback_used=False,
+        source_digest=digest,
+        contract_version=contract_version,
+    )
+    return validate_canonical_volatility_estimate_v1(estimate)
+
+
+def materialize_typed_canonical_volatility_estimate_v1(
+    mark_prices: pd.Series,
+    *,
+    is_final: pd.Series | None = None,
+    as_of_event_time: datetime | None = None,
+) -> CanonicalVolatilityEstimateV1:
+    """Pure boundary: mark prices → existing materializer → typed carrier.
+
+    Reuses ``compute_canonical_volatility_estimate_from_mark_prices_v1``.
+    Does not treat runtime cycle or poll count as market/observation time.
+    """
+    volatility = materializer.compute_canonical_volatility_estimate_from_mark_prices_v1(
+        mark_prices,
+        is_final=is_final,
+    )
+    valid = volatility.dropna()
+    if valid.empty:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.WARMUP_INCOMPLETE,
+            "no_valid_volatility_after_materialization",
+        )
+    last_ts = valid.index[-1]
+    value = float(valid.iloc[-1])
+    if as_of_event_time is None:
+        ts = pd.Timestamp(last_ts)
+        if ts.tzinfo is None:
+            ts = ts.tz_localize("UTC")
+        else:
+            ts = ts.tz_convert("UTC")
+        as_of = ts.to_pydatetime()
+    else:
+        as_of = as_of_event_time
+
+    ordered = mark_prices.sort_index().astype(float)
+    # observation_count = number of log-return observations contributing to the estimate
+    # at the selected bar (= lookback when valid).
+    observation_count = MINIMUM_RETURN_OBSERVATIONS
+    prices_for_digest = ordered.loc[:last_ts].astype(float).tolist()
+    if len(prices_for_digest) < MINIMUM_PRICE_OBSERVATIONS:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.INSUFFICIENT_OBSERVATIONS,
+            f"price_observations={len(prices_for_digest)}:minimum={MINIMUM_PRICE_OBSERVATIONS}",
+        )
+
+    return build_canonical_volatility_estimate_v1(
+        value=value,
+        observation_count=observation_count,
+        as_of_event_time=as_of,
+        mark_prices=prices_for_digest[-MINIMUM_PRICE_OBSERVATIONS:],
+    )
+
+
+def adapt_canonical_volatility_estimate_to_legacy_float_v1(
+    estimate: CanonicalVolatilityEstimateV1 | None,
+) -> float:
+    """Fail-closed adapter: typed estimate → legacy float consumer value.
+
+    Performs no substitution. Rejects None, fallback, wrong unit/horizon,
+    annualized inputs, insufficient observations, and unsupported versions.
+    Does not invent 0.2 / 0.02 / 1.0.
+    """
+    if estimate is None:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.MISSING_VALUE,
+            "estimate_is_none_no_substitution",
+        )
+    validated = validate_canonical_volatility_estimate_v1(estimate)
+    # Numeric equality with legacy fallback constants is allowed only when the
+    # estimate is fully provenance-valid (fallback_used=false already enforced).
+    return float(validated.value)
+
+
+def reject_implicit_legacy_float_input_v1(
+    *,
+    raw_value: float | None,
+    provenance: Mapping[str, Any] | None,
+) -> None:
+    """Reject silent / unproven legacy float inputs on the new contract path.
+
+    The numeric values 0.2, 0.02, and 1.0 are not globally banned. Their use as
+    silent, unproven, or fallback-based contract input is rejected.
+    """
+    if provenance is None:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.UNKNOWN_PROVENANCE,
+            "provenance_missing",
+        )
+    if raw_value is None:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.MISSING_VALUE,
+            "raw_value_none_no_substitution",
+        )
+    if provenance.get("fallback_used") is True:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.FALLBACK_PROHIBITED,
+            "fallback_used_in_provenance",
+        )
+    if provenance.get("implicit_default") is True:
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.IMPLICIT_FALLBACK_REJECTED,
+            "implicit_default_true",
+        )
+    if provenance.get("typed_estimate") is not True:
+        # Unproven bare floats (including 0.2 / 0.02 / 1.0) are rejected.
+        _raise(
+            CanonicalVolatilityTypedConsumptionErrorCode.UNKNOWN_PROVENANCE,
+            f"untyped_legacy_float_rejected:value={raw_value!r}",
+        )
+
+
+def assert_capability_non_goals_v1() -> dict[str, Any]:
+    """Machine-readable non-goals / authority boundary for this capability."""
+    return {
+        "capability_id": CAPABILITY_ID,
+        "capability_version": CAPABILITY_VERSION,
+        "semantics_owner": SEMANTICS_OWNER,
+        "estimator_owner": ESTIMATOR_OWNER,
+        "typed_carrier_owner": TYPED_CARRIER_OWNER,
+        "legacy_adapter_owner": LEGACY_ADAPTER_OWNER,
+        "canonical_unit": CANONICAL_UNIT,
+        "canonical_horizon": CANONICAL_HORIZON,
+        "canonical_estimator": CANONICAL_ESTIMATOR,
+        "observation_requirement": {
+            "minimum_price_observations": MINIMUM_PRICE_OBSERVATIONS,
+            "minimum_return_observations": MINIMUM_RETURN_OBSERVATIONS,
+        },
+        "unknown_behavior": "FAIL_CLOSED",
+        "fallback_policy": "REJECT_FALLBACK_USED_AND_IMPLICIT_DEFAULTS",
+        "non_goals": [
+            "runtime_wiring",
+            "hot_path_binding",
+            "parameter_change",
+            "trading_logic_change",
+            "composition_change",
+            "entry_exit_change",
+            "survival_change",
+            "suitability_change",
+            "closing_open_hot_path_gaps",
+            "aliasing_non_canonical_volatility_surfaces",
+        ],
+        "non_alias_surfaces": list(NON_ALIAS_VOLATILITY_SURFACES),
+        "open_hot_path_gaps": list(OPEN_HOT_PATH_GAPS),
+        "runtime_effect": RUNTIME_EFFECT,
+        "trading_logic_effect": TRADING_LOGIC_EFFECT,
+        "parameter_effect": PARAMETER_EFFECT,
+        "live_authorization": LIVE_AUTHORIZATION,
+        "implicit_default_allowed": IMPLICIT_DEFAULT_ALLOWED,
+        "mv2_fallback_0_2_admissible": MV2_FALLBACK_0_2_ADMISSIBLE,
+        "warmup_behavior": WARMUP_BEHAVIOR,
+        "package_marker": PACKAGE_MARKER,
+    }
+
+
+def with_mutated_field_for_tests_v1(
+    estimate: CanonicalVolatilityEstimateV1,
+    **changes: Any,
+) -> CanonicalVolatilityEstimateV1:
+    """Test helper: produce a replaced carrier without re-validating."""
+    return replace(estimate, **changes)
+
+
+__all__ = [
+    "CANONICAL_ANNUALIZED",
+    "CANONICAL_BAR_INTERVAL",
+    "CANONICAL_BAR_INTERVAL_SECONDS",
+    "CANONICAL_DDOF",
+    "CANONICAL_ESTIMATOR",
+    "CANONICAL_HORIZON",
+    "CANONICAL_HORIZON_SECONDS",
+    "CANONICAL_LOOKBACK_BARS",
+    "CANONICAL_UNIT",
+    "CAPABILITY_ID",
+    "CAPABILITY_VERSION",
+    "CanonicalVolatilityEstimateV1",
+    "CanonicalVolatilityTypedConsumptionError",
+    "CanonicalVolatilityTypedConsumptionErrorCode",
+    "ESTIMATOR_OWNER",
+    "IMPLICIT_DEFAULT_ALLOWED",
+    "LEGACY_ADAPTER_OWNER",
+    "LIVE_AUTHORIZATION",
+    "MINIMUM_PRICE_OBSERVATIONS",
+    "MINIMUM_RETURN_OBSERVATIONS",
+    "MV2_FALLBACK_0_2_ADMISSIBLE",
+    "NON_ALIAS_VOLATILITY_SURFACES",
+    "OPEN_HOT_PATH_GAPS",
+    "PACKAGE_MARKER",
+    "PARAMETER_EFFECT",
+    "RUNTIME_EFFECT",
+    "SEMANTICS_OWNER",
+    "SUPPORTED_CONTRACT_VERSION",
+    "TRADING_LOGIC_EFFECT",
+    "TYPED_CARRIER_OWNER",
+    "WARMUP_BEHAVIOR",
+    "adapt_canonical_volatility_estimate_to_legacy_float_v1",
+    "assert_capability_non_goals_v1",
+    "build_canonical_volatility_estimate_v1",
+    "compute_source_digest_v1",
+    "materialize_typed_canonical_volatility_estimate_v1",
+    "reject_implicit_legacy_float_input_v1",
+    "validate_canonical_volatility_estimate_v1",
+    "with_mutated_field_for_tests_v1",
+]

--- a/tests/trading/master_v2/test_canonical_volatility_estimate_typed_consumption_contract_v1.py
+++ b/tests/trading/master_v2/test_canonical_volatility_estimate_typed_consumption_contract_v1.py
@@ -1,0 +1,322 @@
+"""Unit and contract tests for typed volatility estimate consumption v1."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.trading.master_v2 import canonical_volatility_estimate_feature_contract_v1 as contract
+from src.trading.master_v2 import canonical_volatility_estimate_materializer_v1 as materializer
+from src.trading.master_v2 import (
+    canonical_volatility_estimate_typed_consumption_contract_v1 as typed,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+AS_OF = datetime(2026, 6, 1, 1, 0, tzinfo=timezone.utc)
+
+
+def _valid_kwargs(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "value": 0.001234,
+        "observation_count": 60,
+        "as_of_event_time": AS_OF,
+        "fallback_used": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_estimate(**overrides: object) -> typed.CanonicalVolatilityEstimateV1:
+    return typed.build_canonical_volatility_estimate_v1(**_valid_kwargs(**overrides))  # type: ignore[arg-type]
+
+
+def test_package_marker_and_owners() -> None:
+    assert typed.PACKAGE_MARKER.endswith("=true")
+    assert typed.SEMANTICS_OWNER == contract.CONTRACT_OWNER
+    assert typed.ESTIMATOR_OWNER == materializer.MATERIALIZER_OWNER
+    assert typed.CANONICAL_UNIT == "PER_BAR_DECIMAL_RETURN_VOLATILITY"
+    assert typed.CANONICAL_HORIZON_SECONDS == 3600
+    assert typed.CANONICAL_ESTIMATOR == "POPULATION_STANDARD_DEVIATION_OF_LOG_RETURNS"
+    assert typed.IMPLICIT_DEFAULT_ALLOWED is False
+    assert typed.MV2_FALLBACK_0_2_ADMISSIBLE is False
+    assert typed.RUNTIME_EFFECT is False
+    assert typed.LIVE_AUTHORIZATION is False
+
+
+def test_valid_canonical_estimate_accepted() -> None:
+    estimate = _valid_estimate()
+    assert estimate.value == pytest.approx(0.001234)
+    assert estimate.fallback_used is False
+    assert estimate.unit == typed.CANONICAL_UNIT
+    assert estimate.horizon_seconds == 3600
+    assert estimate.observation_count == 60
+
+
+def test_zero_volatility_accepted_when_otherwise_valid() -> None:
+    estimate = _valid_estimate(value=0.0)
+    assert estimate.value == 0.0
+    assert typed.adapt_canonical_volatility_estimate_to_legacy_float_v1(estimate) == 0.0
+
+
+def test_carrier_immutable() -> None:
+    estimate = _valid_estimate()
+    with pytest.raises(Exception):
+        estimate.value = 9.9  # type: ignore[misc]
+
+
+def test_deterministic_source_digest() -> None:
+    first = _valid_estimate(source_digest=None)
+    second = _valid_estimate(source_digest=None)
+    assert first.source_digest == second.source_digest
+    assert len(first.source_digest) == 64
+
+
+def test_materializer_output_wrapped_successfully() -> None:
+    fixture = materializer.exact_known_61_price_fixture_v1()
+    estimate = typed.materialize_typed_canonical_volatility_estimate_v1(fixture["mark_price"])
+    expected = materializer.expected_population_std_for_fixture_v1(fixture["mark_price"].tolist())
+    assert estimate.value == pytest.approx(expected)
+    assert estimate.observation_count == 60
+    assert estimate.fallback_used is False
+    assert estimate.as_of_event_time.tzinfo is not None
+    assert estimate.unit == typed.CANONICAL_UNIT
+    assert estimate.contract_version == contract.CONTRACT_VERSION
+
+
+def test_existing_materializer_semantics_unchanged() -> None:
+    fixture = materializer.exact_known_61_price_fixture_v1()
+    series = materializer.compute_canonical_volatility_estimate_from_mark_prices_v1(
+        fixture["mark_price"]
+    )
+    expected = materializer.expected_population_std_for_fixture_v1(fixture["mark_price"].tolist())
+    assert float(series.iloc[-1]) == pytest.approx(expected)
+    assert series.iloc[:60].isna().all()
+    assert contract.DDOF == 0
+    assert contract.OUTPUT_ANNUALIZED is False
+    assert contract.LOOKBACK_BARS == 60
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "code"),
+    [
+        ({"value": None}, typed.CanonicalVolatilityTypedConsumptionErrorCode.MISSING_VALUE),
+        ({"value": math.nan}, typed.CanonicalVolatilityTypedConsumptionErrorCode.NON_FINITE_VALUE),
+        (
+            {"value": math.inf},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.NON_FINITE_VALUE,
+        ),
+        ({"value": -0.01}, typed.CanonicalVolatilityTypedConsumptionErrorCode.NEGATIVE_VALUE),
+        (
+            {"fallback_used": True},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.FALLBACK_PROHIBITED,
+        ),
+        (
+            {"unit": "ANNUALIZED_RETURN_VOLATILITY"},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.UNIT_MISMATCH,
+        ),
+        (
+            {"horizon_seconds": 60},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.HORIZON_MISMATCH,
+        ),
+        (
+            {"bar_interval_seconds": 300},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.BAR_INTERVAL_MISMATCH,
+        ),
+        (
+            {"lookback_bars": 20},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.LOOKBACK_MISMATCH,
+        ),
+        (
+            {"annualized": True},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.ANNUALIZATION_MISMATCH,
+        ),
+        (
+            {"estimator": "SAMPLE_STDEV"},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.ESTIMATOR_MISMATCH,
+        ),
+        (
+            {"observation_count": 59},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.INSUFFICIENT_OBSERVATIONS,
+        ),
+        (
+            {"as_of_event_time": datetime(2026, 6, 1, 1, 0)},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.EVENT_TIME_INVALID,
+        ),
+        (
+            {"source_digest": ""},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.SOURCE_DIGEST_INVALID,
+        ),
+        (
+            {"contract_version": "unsupported/v0"},
+            typed.CanonicalVolatilityTypedConsumptionErrorCode.CONTRACT_VERSION_UNSUPPORTED,
+        ),
+    ],
+)
+def test_factory_rejects_invalid_inputs(kwargs: dict[str, object], code: object) -> None:
+    with pytest.raises(typed.CanonicalVolatilityTypedConsumptionError) as exc:
+        typed.build_canonical_volatility_estimate_v1(**_valid_kwargs(**kwargs))  # type: ignore[arg-type]
+    assert exc.value.code == code
+
+
+def test_numeric_0_2_accepted_when_canonically_proven() -> None:
+    estimate = _valid_estimate(value=0.2)
+    assert typed.adapt_canonical_volatility_estimate_to_legacy_float_v1(estimate) == 0.2
+
+
+def test_numeric_0_02_accepted_when_canonically_proven() -> None:
+    estimate = _valid_estimate(value=0.02)
+    assert typed.adapt_canonical_volatility_estimate_to_legacy_float_v1(estimate) == 0.02
+
+
+def test_numeric_1_0_accepted_when_canonically_proven() -> None:
+    estimate = _valid_estimate(value=1.0)
+    assert typed.adapt_canonical_volatility_estimate_to_legacy_float_v1(estimate) == 1.0
+
+
+@pytest.mark.parametrize("raw", [0.2, 0.02, 1.0, 0.5, None])
+def test_implicit_unproven_legacy_floats_rejected(raw: float | None) -> None:
+    with pytest.raises(typed.CanonicalVolatilityTypedConsumptionError) as exc:
+        typed.reject_implicit_legacy_float_input_v1(raw_value=raw, provenance=None)
+    assert exc.value.code == typed.CanonicalVolatilityTypedConsumptionErrorCode.UNKNOWN_PROVENANCE
+
+
+@pytest.mark.parametrize("raw", [0.2, 0.02, 1.0])
+def test_implicit_fallback_flag_rejected(raw: float) -> None:
+    with pytest.raises(typed.CanonicalVolatilityTypedConsumptionError) as exc:
+        typed.reject_implicit_legacy_float_input_v1(
+            raw_value=raw,
+            provenance={"implicit_default": True, "typed_estimate": True},
+        )
+    assert (
+        exc.value.code
+        == typed.CanonicalVolatilityTypedConsumptionErrorCode.IMPLICIT_FALLBACK_REJECTED
+    )
+
+
+@pytest.mark.parametrize("raw", [0.2, 0.02, 1.0])
+def test_mv2_fallback_provenance_rejected(raw: float) -> None:
+    with pytest.raises(typed.CanonicalVolatilityTypedConsumptionError) as exc:
+        typed.reject_implicit_legacy_float_input_v1(
+            raw_value=raw,
+            provenance={"fallback_used": True, "typed_estimate": True},
+        )
+    assert exc.value.code == typed.CanonicalVolatilityTypedConsumptionErrorCode.FALLBACK_PROHIBITED
+
+
+def test_adapter_rejects_none_without_substitution() -> None:
+    with pytest.raises(typed.CanonicalVolatilityTypedConsumptionError) as exc:
+        typed.adapt_canonical_volatility_estimate_to_legacy_float_v1(None)
+    assert exc.value.code == typed.CanonicalVolatilityTypedConsumptionErrorCode.MISSING_VALUE
+    assert "no_substitution" in str(exc.value)
+
+
+def test_adapter_rejects_fallback_used_carrier() -> None:
+    estimate = typed.with_mutated_field_for_tests_v1(_valid_estimate(), fallback_used=True)
+    with pytest.raises(typed.CanonicalVolatilityTypedConsumptionError) as exc:
+        typed.adapt_canonical_volatility_estimate_to_legacy_float_v1(estimate)
+    assert exc.value.code == typed.CanonicalVolatilityTypedConsumptionErrorCode.FALLBACK_PROHIBITED
+
+
+def test_adapter_output_equals_validated_estimate_value() -> None:
+    estimate = _valid_estimate(value=0.004321)
+    assert typed.adapt_canonical_volatility_estimate_to_legacy_float_v1(estimate) == 0.004321
+
+
+def test_adapter_performs_no_substitution_for_wrong_unit() -> None:
+    estimate = typed.with_mutated_field_for_tests_v1(
+        _valid_estimate(),
+        unit="PERCENT_VOLATILITY",
+    )
+    with pytest.raises(typed.CanonicalVolatilityTypedConsumptionError) as exc:
+        typed.adapt_canonical_volatility_estimate_to_legacy_float_v1(estimate)
+    assert exc.value.code == typed.CanonicalVolatilityTypedConsumptionErrorCode.UNIT_MISMATCH
+
+
+def test_adapter_rejects_annualized_and_wrong_horizon() -> None:
+    annualized = typed.with_mutated_field_for_tests_v1(_valid_estimate(), annualized=True)
+    with pytest.raises(typed.CanonicalVolatilityTypedConsumptionError) as exc:
+        typed.adapt_canonical_volatility_estimate_to_legacy_float_v1(annualized)
+    assert (
+        exc.value.code == typed.CanonicalVolatilityTypedConsumptionErrorCode.ANNUALIZATION_MISMATCH
+    )
+
+    wrong_horizon = typed.with_mutated_field_for_tests_v1(_valid_estimate(), horizon_seconds=60)
+    with pytest.raises(typed.CanonicalVolatilityTypedConsumptionError) as exc2:
+        typed.adapt_canonical_volatility_estimate_to_legacy_float_v1(wrong_horizon)
+    assert exc2.value.code == typed.CanonicalVolatilityTypedConsumptionErrorCode.HORIZON_MISMATCH
+
+
+def test_warmup_incomplete_materialization_rejected() -> None:
+    idx = pd.date_range("2026-06-01T00:00:00Z", periods=30, freq="1min", tz="UTC")
+    mark = pd.Series([100.0 + 0.1 * i for i in range(30)], index=idx)
+    with pytest.raises(typed.CanonicalVolatilityTypedConsumptionError) as exc:
+        typed.materialize_typed_canonical_volatility_estimate_v1(mark)
+    assert exc.value.code == typed.CanonicalVolatilityTypedConsumptionErrorCode.WARMUP_INCOMPLETE
+
+
+def test_explicit_contract_gates_machine_readable() -> None:
+    goals = typed.assert_capability_non_goals_v1()
+    assert goals["runtime_effect"] is False
+    assert goals["trading_logic_effect"] is False
+    assert goals["parameter_effect"] is False
+    assert goals["live_authorization"] is False
+    assert goals["implicit_default_allowed"] is False
+    assert goals["mv2_fallback_0_2_admissible"] is False
+    for gap in typed.OPEN_HOT_PATH_GAPS:
+        assert gap in goals["open_hot_path_gaps"]
+    for surface in typed.NON_ALIAS_VOLATILITY_SURFACES:
+        assert surface in goals["non_alias_surfaces"]
+
+
+def test_open_gaps_remain_documented_and_unclosed() -> None:
+    assert len(typed.OPEN_HOT_PATH_GAPS) == 9
+    assert "G1_SILENT_0_2_IN_HISTORICAL_BIND" in typed.OPEN_HOT_PATH_GAPS
+    assert "G6_MATERIALIZER_NOT_WIRED_TO_DOUBLE_PLAY" in typed.OPEN_HOT_PATH_GAPS
+    assert "G9_FUTURES_PROFILE_PRIMARY_METRIC_OQ001_OPEN" in typed.OPEN_HOT_PATH_GAPS
+
+
+def test_composition_entry_exit_and_runtime_paths_unchanged() -> None:
+    guarded = (
+        "src/trading/master_v2/double_play_composition.py",
+        "src/trading/master_v2/double_play_entry_exit_policy_v0.py",
+        "src/trading/master_v2/canonical_core_runtime_integration_bridge_v0.py",
+        "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py",
+        "src/trading/master_v2/offline_double_play_scenario_replay_v0.py",
+        "src/trading/master_v2/double_play_state.py",
+        "src/trading/master_v2/double_play_survival.py",
+        "src/trading/master_v2/double_play_suitability.py",
+        "src/trading/master_v2/canonical_volatility_estimate_feature_contract_v1.py",
+        "src/trading/master_v2/canonical_volatility_estimate_materializer_v1.py",
+    )
+    needle = "canonical_volatility_estimate_typed_consumption_contract_v1"
+    for rel in guarded:
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert needle not in text, rel
+
+
+def test_second_estimator_not_created() -> None:
+    src = (
+        ROOT
+        / "src/trading/master_v2/canonical_volatility_estimate_typed_consumption_contract_v1.py"
+    ).read_text(encoding="utf-8")
+    assert "compute_canonical_volatility_estimate_from_mark_prices_v1" in src
+    assert "rolling(" not in src
+    assert ".std(" not in src
+    assert "_compute_log_returns" not in src
+
+
+def test_capability_spec_exists() -> None:
+    path = (
+        ROOT
+        / "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_ESTIMATE_TYPED_CONSUMPTION_CONTRACT_V1.md"
+    )
+    assert path.is_file()
+    text = path.read_text(encoding="utf-8")
+    assert "SEMANTICS_OWNER" in text
+    assert "RUNTIME_EFFECT=false" in text
+    assert "G1_SILENT_0_2_IN_HISTORICAL_BIND" in text
+    assert "G9_FUTURES_PROFILE_PRIMARY_METRIC_OQ001_OPEN" in text


### PR DESCRIPTION
## Summary
- Adds immutable typed carrier `CanonicalVolatilityEstimateV1` reusing ratified `canonical_volatility_estimate_feature_contract/v1` semantics and the existing materializer (no second estimator).
- Adds fail-closed legacy-float adapter with diagnostic rejection codes; rejects unproven `0.2` / `0.02` / `1.0` substitution while allowing the same numerics when canonically proven.
- Documents capability owners, non-goals, and intentionally open hot-path gaps G1–G9; no runtime wiring, parameter, composition, entry/exit, survival, or suitability changes.

## Test plan
- [x] `pytest tests/trading/master_v2/test_canonical_volatility_estimate_typed_consumption_contract_v1.py` (+ existing feature-contract tests)
- [x] `ruff format --check` / `ruff check` on new Python files
- [x] Docs token policy + docs reference targets
- [x] Selector path-equivalent `PR_BOUNDED_FULL` timing proof (~37s, 728 passed)
- [ ] GitHub CI confirmation on this PR head
- [ ] Do **not** merge in this Auftrag; no ruleset mutation


Made with [Cursor](https://cursor.com)