### PR TITLE
feat(master-v2): canonical volatility binding and provenance transport v1

### DIFF
--- a/config/governance/technical_canonical_wiring_authorization_v1.json
+++ b/config/governance/technical_canonical_wiring_authorization_v1.json
@@ -737,7 +737,13 @@
     "docs/ops/specs/MV2_TIME_SAMPLE_EPOCH_SEMANTICS_V1.md",
     "src/trading/master_v2/canonical_volatility_estimate_typed_consumption_contract_v1.py",
     "tests/trading/master_v2/test_canonical_volatility_estimate_typed_consumption_contract_v1.py",
-    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_ESTIMATE_TYPED_CONSUMPTION_CONTRACT_V1.md"
+    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_ESTIMATE_TYPED_CONSUMPTION_CONTRACT_V1.md",
+    "src/trading/master_v2/canonical_volatility_binding_and_provenance_transport_v1.py",
+    "src/trading/master_v2/canonical_market_context_v1.py",
+    "src/trading/master_v2/canonical_trading_decision_evidence_v1.py",
+    "src/trading/master_v2/canonical_scope_initialization_v1.py",
+    "tests/trading/master_v2/test_canonical_volatility_binding_and_provenance_transport_v1.py",
+    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_BINDING_AND_PROVENANCE_TRANSPORT_V1.md"
   ],
   "allowed_surface_classes": [
     "TECHNICAL_CANONICAL_REPLAY_INPUT_BUILDER_WIRING",

--- a/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_BINDING_AND_PROVENANCE_TRANSPORT_V1.md
+++ b/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_BINDING_AND_PROVENANCE_TRANSPORT_V1.md
@@ -1,0 +1,117 @@
+# MASTER_V2 Canonical Volatility Binding and Provenance Transport v1
+
+---
+docs_token: DOCS_TOKEN_MASTER_V2_CANONICAL_VOLATILITY_BINDING_AND_PROVENANCE_TRANSPORT_V1
+STATUS: CAPABILITY_AVAILABLE
+scope: typed CMC transport + single validation + single legacy adaptation + evidence identity; non-authorizing
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+RUNTIME_WIRING: false
+RUNTIME_PRODUCER_CUTOVER: false
+DEFAULT_MUTATION: false
+PARAMETER_EFFECT: false
+TRADING_LOGIC_EFFECT: false
+VOLATILITY_MAX_AGE_VALUE_UNRESOLVED: true
+HARD_STOP: true
+---
+
+> **Non-authorizing C1 scaffold.** Implements Typed-Transport Model A for
+> Master V2 &#47; Double Play volatility. Reuses existing semantics, materializer,
+> and typed consumption&#47;adapter owners. Does **not** mutate defaults
+> (`0.2` &#47; `0.02` &#47; `1.0` &#47; `1e-9`), cut over wallclock&#47;panel producers,
+> change survival&#47;futures profile semantics, authorize runtime, or invent a
+> numeric max-age.
+
+## Machine summary
+
+```
+CAPABILITY_ID=MASTER_V2_CANONICAL_VOLATILITY_BINDING_AND_PROVENANCE_TRANSPORT_V1
+TYPED_TRANSPORT_MODEL=A
+TYPED_CARRIER_END_BOUNDARY=CanonicalMarketContextV1.canonical_volatility_estimate
+SINGLE_VALIDATION_BOUNDARY=validate_canonical_volatility_estimate_v1
+LEGACY_ADAPTATION_BOUNDARY=adapt_canonical_volatility_estimate_to_legacy_float_v1
+SECOND_ESTIMATOR_REQUIRED=false
+SECOND_SEMANTICS_AUTHORITY_REQUIRED=false
+GENERAL_INPUT_DIGEST_ALONE_SUFFICIENT=false
+READY_FOR_RUNTIME_WIRING=false
+READY_FOR_PARAMETER_RESEARCH=false
+LIVE_AUTHORIZATION=false
+HARD_STOP=true
+VOLATILITY_MAX_AGE_VALUE_UNRESOLVED=true
+```
+
+## Owner decisions consumed
+
+| ID | Decision |
+|---|---|
+| O4 | Single canonical producer chain ratified; non-aliases unchanged |
+| O9 | Typed transport Model A; CMC typed end-boundary; single adapter before float consumers |
+| O10 | Full estimate identity in Decision Evidence + volatility input binding digest |
+| O12 | Typed-path fail-closed domain matrix for missing&#47;invalid (legacy eligibility unchanged) |
+| O13 | Equivalence target scaffolding only; no producer unification in C1 |
+
+## Zielgraph
+
+```
+finalized PT1M mark_prices
+  → materializer (REUSE)
+  → CanonicalVolatilityEstimateV1
+  → validate_canonical_volatility_estimate_v1          [SINGLE_VALIDATION]
+  → CanonicalMarketContextV1.canonical_volatility_estimate  [TYPED_END]
+  → adapt_canonical_volatility_estimate_to_legacy_float_v1  [SINGLE_LEGACY]
+  → Scope Snapshot &#47; DynamicScopeRules &#47; update_dynamic_boundaries (float)
+  → CanonicalTradingDecisionEvidenceV1.volatility_provenance
+```
+
+## Evidence schema
+
+`CanonicalVolatilityDecisionEvidenceProvenanceV1` persists at least:
+
+- `volatility_contract_version`, `value`, `unit`, `horizon`, `annualized`
+- `estimator`, `observation_count`, `as_of_event_time`, `fallback_used`
+- `source_digest`, `typed_estimate_digest`, `legacy_adaptation_digest`
+- `stale_status`, `validation_result`, `volatility_input_binding_digest`
+- `legacy_float_value` (adapted consumer value)
+
+`input_digest` remains; alone it is **not** sufficient.
+
+## Fail-closed matrix (typed binding path)
+
+| Condition | Exposure | Scope init | Observation&#47;Recon | Risk&#47;Safety&#47;Exit |
+|---|---|---|---|---|
+| MISSING_TYPED_ESTIMATE | block | block | allowed | independent |
+| INVALID &#47; FALLBACK &#47; WRONG META | block | block | allowed | independent |
+| WARMUP (CMC warmup_status) | block | block | observation-only | independent |
+| STALE status | transport-only in C1; numeric age unresolved | | | independent |
+
+Legacy float-only CMC construction remains eligible under the pre-existing
+eligibility function (G8 global enforcement deferred).
+
+## Gaps
+
+Closed by C1: `G3_TRANSPORT`, `G6_BINDING_SCAFFOLD`, `G11_EVIDENCE_SCHEMA`
+
+Remaining: `G1`, `G2`, `G4`, `G5`, `G7`, `G8`, `G9`, `G10_NUMERIC_MAX_AGE`,
+`G12`, `G13`, `G14`, `G15`
+
+## Scope exclusions
+
+No change to historical `0.2`, scenario `0.02`, rules default `1.0`, floor
+`1e-9`, wallclock&#47;panel producers, survival ratio, futures profile, risk&#47;
+safety&#47;exit&#47;entry&#47;composition, parameter research, runtime&#47;live.
+
+## Rollback boundary
+
+Remove typed CMC field usage, evidence provenance attachment, and binding
+module; float-only paths remain behavior-compatible when typed field is
+absent (`None` omitted from digests).
+
+## Owners (reuse-before-new)
+
+| Surface | Owner |
+|---|---|
+| Semantics | `canonical_volatility_estimate_feature_contract_v1` |
+| Estimator | `canonical_volatility_estimate_materializer_v1` |
+| Typed carrier &#47; legacy adapter | `canonical_volatility_estimate_typed_consumption_contract_v1` |
+| Binding &#47; provenance transport | `canonical_volatility_binding_and_provenance_transport_v1` |
+| Tests | `tests&#47;trading&#47;master_v2&#47;test_canonical_volatility_binding_and_provenance_transport_v1.py` |

--- a/src/trading/master_v2/canonical_market_context_v1.py
+++ b/src/trading/master_v2/canonical_market_context_v1.py
@@ -11,15 +11,21 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
-from typing import Mapping, Optional, Tuple
+from typing import TYPE_CHECKING, Mapping, Optional, Tuple
 
 from trading.master_v2.double_play_futures_input import (
     FuturesInputSnapshot,
     FuturesMarketType,
 )
+
+if TYPE_CHECKING:
+    from trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1 import (
+        CanonicalVolatilityEstimateV1,
+    )
 
 CANONICAL_MARKET_CONTEXT_LAYER_VERSION = "v1"
 FEATURE_CONTRACT_VERSION = "canonical_market_context_feature_contract_v1"
@@ -83,6 +89,9 @@ class CanonicalMarketContextBlockReason(str, Enum):
     OPEN_INTEREST_INVALID = "open_interest_invalid"
     FUNDING_RATE_INVALID = "funding_rate_invalid"
     VOLATILITY_ESTIMATE_INVALID = "volatility_estimate_invalid"
+    TYPED_VOLATILITY_ESTIMATE_MISSING = "typed_volatility_estimate_missing"
+    TYPED_VOLATILITY_ESTIMATE_INVALID = "typed_volatility_estimate_invalid"
+    TYPED_VOLATILITY_LEGACY_FLOAT_MISMATCH = "typed_volatility_legacy_float_mismatch"
     FEATURE_CONTRACT_VERSION_INVALID = "feature_contract_version_invalid"
     DATA_INTEGRITY_UNTRUSTED = "data_integrity_untrusted"
     DATA_INTEGRITY_UNKNOWN = "data_integrity_unknown"
@@ -146,6 +155,8 @@ class CanonicalMarketContextV1:
     warmup_status: WarmupStatus
     feature_contract_version: str = FEATURE_CONTRACT_VERSION
     input_digest: str = ""
+    # Typed transport Model A end-boundary (optional for legacy float-only paths).
+    canonical_volatility_estimate: Optional["CanonicalVolatilityEstimateV1"] = None
 
     def __post_init__(self) -> None:
         if self.input_digest and not _valid_sha256_hex(self.input_digest):
@@ -288,6 +299,9 @@ def validate_canonical_market_context_fields(
         blocks.append(CanonicalMarketContextBlockReason.FUNDING_RATE_INVALID)
     if not _non_negative_finite(context.volatility_estimate):
         blocks.append(CanonicalMarketContextBlockReason.VOLATILITY_ESTIMATE_INVALID)
+    elif context.canonical_volatility_estimate is not None:
+        typed_blocks = _validate_typed_volatility_consistency(context)
+        blocks.extend(typed_blocks)
 
     if (
         not context.feature_contract_version
@@ -316,9 +330,32 @@ def validate_canonical_market_context_fields(
     return tuple(dict.fromkeys(blocks))
 
 
+def _validate_typed_volatility_consistency(
+    context: CanonicalMarketContextV1,
+) -> Tuple[CanonicalMarketContextBlockReason, ...]:
+    """When typed carrier is present, it is authority; float must match adapted value."""
+    from trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1 import (
+        CanonicalVolatilityTypedConsumptionError,
+        adapt_canonical_volatility_estimate_to_legacy_float_v1,
+        validate_canonical_volatility_estimate_v1,
+    )
+
+    estimate = context.canonical_volatility_estimate
+    if estimate is None:
+        return ()
+    try:
+        validated = validate_canonical_volatility_estimate_v1(estimate)
+        legacy = float(adapt_canonical_volatility_estimate_to_legacy_float_v1(validated))
+    except (CanonicalVolatilityTypedConsumptionError, TypeError, ValueError):
+        return (CanonicalMarketContextBlockReason.TYPED_VOLATILITY_ESTIMATE_INVALID,)
+    if not math.isclose(float(context.volatility_estimate), legacy, rel_tol=0.0, abs_tol=0.0):
+        return (CanonicalMarketContextBlockReason.TYPED_VOLATILITY_LEGACY_FLOAT_MISMATCH,)
+    return ()
+
+
 def serialize_canonical_market_context_canonical(context: CanonicalMarketContextV1) -> str:
     """Deterministic JSON serialization for digest (excludes input_digest field)."""
-    payload = {
+    payload: dict = {
         "bar_finality_status": context.bar_finality_status.value,
         "bar_interval": context.bar_interval,
         "best_ask": context.best_ask,
@@ -349,6 +386,30 @@ def serialize_canonical_market_context_canonical(context: CanonicalMarketContext
         "volume": context.volume,
         "warmup_status": context.warmup_status.value,
     }
+    # Omit None typed carrier so legacy float-only digests remain unchanged.
+    if context.canonical_volatility_estimate is not None:
+        from datetime import timezone
+
+        estimate = context.canonical_volatility_estimate
+        as_of = estimate.as_of_event_time
+        if as_of.tzinfo is None:
+            as_of_iso = as_of.isoformat() + "+00:00"
+        else:
+            as_of_iso = as_of.astimezone(timezone.utc).isoformat()
+        payload["canonical_volatility_estimate"] = {
+            "annualized": bool(estimate.annualized),
+            "as_of_event_time": as_of_iso,
+            "bar_interval_seconds": int(estimate.bar_interval_seconds),
+            "contract_version": str(estimate.contract_version),
+            "estimator": str(estimate.estimator),
+            "fallback_used": bool(estimate.fallback_used),
+            "horizon_seconds": int(estimate.horizon_seconds),
+            "lookback_bars": int(estimate.lookback_bars),
+            "observation_count": int(estimate.observation_count),
+            "source_digest": str(estimate.source_digest),
+            "unit": str(estimate.unit),
+            "value": float(estimate.value),
+        }
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
 
@@ -360,34 +421,7 @@ def compute_canonical_market_context_input_digest(context: CanonicalMarketContex
 
 def with_computed_input_digest(context: CanonicalMarketContextV1) -> CanonicalMarketContextV1:
     digest = compute_canonical_market_context_input_digest(context)
-    return CanonicalMarketContextV1(
-        context_id=context.context_id,
-        instrument_id=context.instrument_id,
-        market_type=context.market_type,
-        trading_epoch=context.trading_epoch,
-        market_event_time=context.market_event_time,
-        decision_time=context.decision_time,
-        bar_interval=context.bar_interval,
-        bar_finality_status=context.bar_finality_status,
-        mark_price=context.mark_price,
-        index_price=context.index_price,
-        best_bid=context.best_bid,
-        best_ask=context.best_ask,
-        spread=context.spread,
-        volume=context.volume,
-        open_interest=context.open_interest,
-        funding_rate=context.funding_rate,
-        volatility_estimate=context.volatility_estimate,
-        trend_feature_set=context.trend_feature_set,
-        momentum_feature_set=context.momentum_feature_set,
-        liquidity_feature_set=context.liquidity_feature_set,
-        market_structure_feature_set=context.market_structure_feature_set,
-        data_integrity_status=context.data_integrity_status,
-        clock_trust_status=context.clock_trust_status,
-        warmup_status=context.warmup_status,
-        feature_contract_version=context.feature_contract_version,
-        input_digest=digest,
-    )
+    return replace(context, input_digest=digest)
 
 
 def _warmup_blocks_directional_and_scope(

--- a/src/trading/master_v2/canonical_scope_initialization_v1.py
+++ b/src/trading/master_v2/canonical_scope_initialization_v1.py
@@ -349,9 +349,14 @@ def _build_initialized_scope(
     *,
     reason_codes: Tuple[str, ...] = (),
 ) -> CanonicalScopeSnapshotV1:
+    from trading.master_v2.canonical_volatility_binding_and_provenance_transport_v1 import (
+        resolve_legacy_volatility_float_for_consumer_v1,
+    )
+
     bound_context = context if context.input_digest else with_computed_input_digest(context)
     reference_price = float(bound_context.mark_price)
-    volatility_estimate = float(bound_context.volatility_estimate)
+    # Typed present → single owned adapter; typed absent → legacy float unchanged.
+    volatility_estimate = float(resolve_legacy_volatility_float_for_consumer_v1(bound_context))
     initial_volatility_distance = volatility_estimate * reference_price
     scope_band = clamp_scope_band(
         initial_volatility_distance,

--- a/src/trading/master_v2/canonical_trading_decision_evidence_v1.py
+++ b/src/trading/master_v2/canonical_trading_decision_evidence_v1.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from dataclasses import dataclass
-from typing import Mapping, Tuple
+from dataclasses import dataclass, replace
+from typing import Any, Mapping, Optional, Tuple
 
 CANONICAL_TRADING_DECISION_EVIDENCE_LAYER_VERSION = "v1"
 EVIDENCE_SCHEMA_VERSION = "canonical_trading_decision_evidence_v1"
@@ -42,6 +42,60 @@ class ComponentRefV1:
         if self.semantic_digest and not _valid_sha256_hex(self.semantic_digest):
             msg = "semantic_digest must be empty or a 64-char lowercase sha256 hex"
             raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class CanonicalVolatilityDecisionEvidenceProvenanceV1:
+    """Versioned volatility estimate identity for decision evidence (O10)."""
+
+    volatility_contract_version: str
+    value: float
+    unit: str
+    horizon: str
+    annualized: bool
+    estimator: str
+    observation_count: int
+    as_of_event_time: str
+    fallback_used: bool
+    source_digest: str
+    typed_estimate_digest: str
+    legacy_adaptation_digest: str
+    stale_status: str
+    validation_result: str
+    volatility_input_binding_digest: str
+    legacy_float_value: float
+
+    def __post_init__(self) -> None:
+        for digest_name in (
+            "source_digest",
+            "typed_estimate_digest",
+            "legacy_adaptation_digest",
+            "volatility_input_binding_digest",
+        ):
+            digest = getattr(self, digest_name)
+            if digest and not _valid_sha256_hex(digest):
+                msg = f"{digest_name} must be empty or a 64-char lowercase sha256 hex"
+                raise ValueError(msg)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "annualized": bool(self.annualized),
+            "as_of_event_time": str(self.as_of_event_time),
+            "estimator": str(self.estimator),
+            "fallback_used": bool(self.fallback_used),
+            "horizon": str(self.horizon),
+            "legacy_adaptation_digest": str(self.legacy_adaptation_digest),
+            "legacy_float_value": float(self.legacy_float_value),
+            "observation_count": int(self.observation_count),
+            "source_digest": str(self.source_digest),
+            "stale_status": str(self.stale_status),
+            "typed_estimate_digest": str(self.typed_estimate_digest),
+            "unit": str(self.unit),
+            "validation_result": str(self.validation_result),
+            "value": float(self.value),
+            "volatility_contract_version": str(self.volatility_contract_version),
+            "volatility_input_binding_digest": str(self.volatility_input_binding_digest),
+        }
 
 
 @dataclass(frozen=True)
@@ -96,6 +150,7 @@ class CanonicalTradingDecisionEvidenceV1:
     reconciliation_unknown_outcome_effect: str = _RECONCILIATION_UNKNOWN_OUTCOME_EFFECT_NONE
     killswitch_boundary_ref: str = ""
     killswitch_boundary_effect: str = _KILLSWITCH_BOUNDARY_EFFECT_NONE
+    volatility_provenance: Optional[CanonicalVolatilityDecisionEvidenceProvenanceV1] = None
 
     def __post_init__(self) -> None:
         if self.semantic_digest and not _valid_sha256_hex(self.semantic_digest):
@@ -114,7 +169,7 @@ def serialize_canonical_trading_decision_evidence_canonical(
     evidence: CanonicalTradingDecisionEvidenceV1,
 ) -> str:
     """Deterministic JSON serialization for semantic digest (excludes semantic_digest)."""
-    payload = {
+    payload: dict[str, Any] = {
         "adapter_compatible": evidence.adapter_compatible,
         "authority_effect": evidence.authority_effect,
         "bear_assessment_ref": evidence.bear_assessment_ref,
@@ -165,6 +220,9 @@ def serialize_canonical_trading_decision_evidence_canonical(
         "state_switch_ref": evidence.state_switch_ref,
         "trading_epoch": evidence.trading_epoch,
     }
+    # Omit None so legacy evidence digests remain unchanged.
+    if evidence.volatility_provenance is not None:
+        payload["volatility_provenance"] = evidence.volatility_provenance.to_dict()
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
 
@@ -180,57 +238,14 @@ def finalize_offline_replay_decision_evidence_v1(
 ) -> CanonicalTradingDecisionEvidenceV1:
     """Compute semantic digest while preserving offline capital/risk/sizing binding fields."""
     digest = compute_canonical_trading_decision_evidence_semantic_digest(evidence)
-    return CanonicalTradingDecisionEvidenceV1(
-        decision_id=evidence.decision_id,
-        replay_id=evidence.replay_id,
-        instrument_id=evidence.instrument_id,
-        trading_epoch=evidence.trading_epoch,
-        market_context_ref=evidence.market_context_ref,
-        scope_initialization_ref=evidence.scope_initialization_ref,
-        scope_event_ref=evidence.scope_event_ref,
-        bull_assessment_ref=evidence.bull_assessment_ref,
-        bear_assessment_ref=evidence.bear_assessment_ref,
-        state_switch_ref=evidence.state_switch_ref,
-        bull_survival_ref=evidence.bull_survival_ref,
-        bear_survival_ref=evidence.bear_survival_ref,
-        bull_suitability_ref=evidence.bull_suitability_ref,
-        bear_suitability_ref=evidence.bear_suitability_ref,
-        composition_result_ref=evidence.composition_result_ref,
-        entry_exit_policy_ref=evidence.entry_exit_policy_ref,
-        current_scope_ref=evidence.current_scope_ref,
-        next_scope_ref=evidence.next_scope_ref,
-        previous_direction_state=evidence.previous_direction_state,
-        next_direction_state=evidence.next_direction_state,
-        selected_side=evidence.selected_side,
-        selected_strategy_ref=evidence.selected_strategy_ref,
-        decision_outcome=evidence.decision_outcome,
-        entry_or_exit_policy_ref=evidence.entry_or_exit_policy_ref,
-        reason_codes=evidence.reason_codes,
-        decision_precedence_trace=evidence.decision_precedence_trace,
-        component_versions=evidence.component_versions,
-        policy_versions=evidence.policy_versions,
-        config_digest=evidence.config_digest,
-        implementation_digest=evidence.implementation_digest,
-        input_digest=evidence.input_digest,
+    return replace(
+        evidence,
         semantic_digest=digest,
-        evidence_schema_version=evidence.evidence_schema_version,
         execution_eligible=False,
         adapter_compatible=False,
-        quantity_status=evidence.quantity_status,
-        quantity_provenance_ref=evidence.quantity_provenance_ref,
-        risk_sizing_ref=evidence.risk_sizing_ref,
-        order_intent_ref=evidence.order_intent_ref,
         authority_effect=_AUTHORITY_EFFECT_NONE,
         runtime_effect=_RUNTIME_EFFECT_NONE,
         order_effect=_ORDER_EFFECT_NONE,
-        risk_sizing_effect=evidence.risk_sizing_effect,
-        order_intent_effect=evidence.order_intent_effect,
-        safety_boundary_ref=evidence.safety_boundary_ref,
-        safety_boundary_effect=evidence.safety_boundary_effect,
-        reconciliation_unknown_outcome_ref=evidence.reconciliation_unknown_outcome_ref,
-        reconciliation_unknown_outcome_effect=evidence.reconciliation_unknown_outcome_effect,
-        killswitch_boundary_ref=evidence.killswitch_boundary_ref,
-        killswitch_boundary_effect=evidence.killswitch_boundary_effect,
     )
 
 
@@ -238,40 +253,9 @@ def with_computed_evidence_semantic_digest(
     evidence: CanonicalTradingDecisionEvidenceV1,
 ) -> CanonicalTradingDecisionEvidenceV1:
     return finalize_offline_replay_decision_evidence_v1(
-        CanonicalTradingDecisionEvidenceV1(
-            decision_id=evidence.decision_id,
-            replay_id=evidence.replay_id,
-            instrument_id=evidence.instrument_id,
-            trading_epoch=evidence.trading_epoch,
-            market_context_ref=evidence.market_context_ref,
-            scope_initialization_ref=evidence.scope_initialization_ref,
-            scope_event_ref=evidence.scope_event_ref,
-            bull_assessment_ref=evidence.bull_assessment_ref,
-            bear_assessment_ref=evidence.bear_assessment_ref,
-            state_switch_ref=evidence.state_switch_ref,
-            bull_survival_ref=evidence.bull_survival_ref,
-            bear_survival_ref=evidence.bear_survival_ref,
-            bull_suitability_ref=evidence.bull_suitability_ref,
-            bear_suitability_ref=evidence.bear_suitability_ref,
-            composition_result_ref=evidence.composition_result_ref,
-            entry_exit_policy_ref=evidence.entry_exit_policy_ref,
-            current_scope_ref=evidence.current_scope_ref,
-            next_scope_ref=evidence.next_scope_ref,
-            previous_direction_state=evidence.previous_direction_state,
-            next_direction_state=evidence.next_direction_state,
-            selected_side=evidence.selected_side,
-            selected_strategy_ref=evidence.selected_strategy_ref,
-            decision_outcome=evidence.decision_outcome,
-            entry_or_exit_policy_ref=evidence.entry_or_exit_policy_ref,
-            reason_codes=evidence.reason_codes,
-            decision_precedence_trace=evidence.decision_precedence_trace,
-            component_versions=evidence.component_versions,
-            policy_versions=evidence.policy_versions,
-            config_digest=evidence.config_digest,
-            implementation_digest=evidence.implementation_digest,
-            input_digest=evidence.input_digest,
+        replace(
+            evidence,
             semantic_digest="",
-            evidence_schema_version=evidence.evidence_schema_version,
             execution_eligible=False,
             adapter_compatible=False,
             quantity_status=_QUANTITY_STATUS_NOT_BOUND,
@@ -289,6 +273,8 @@ def with_computed_evidence_semantic_digest(
             reconciliation_unknown_outcome_effect=_RECONCILIATION_UNKNOWN_OUTCOME_EFFECT_NONE,
             killswitch_boundary_ref="",
             killswitch_boundary_effect=_KILLSWITCH_BOUNDARY_EFFECT_NONE,
+            # Preserve volatility_provenance when present (identity must survive digesting).
+            volatility_provenance=evidence.volatility_provenance,
         )
     )
 

--- a/src/trading/master_v2/canonical_volatility_binding_and_provenance_transport_v1.py
+++ b/src/trading/master_v2/canonical_volatility_binding_and_provenance_transport_v1.py
@@ -1,0 +1,625 @@
+"""Canonical volatility binding and provenance transport v1 (C1).
+
+Typed-transport Model A: ``CanonicalVolatilityEstimateV1`` ends on
+``CanonicalMarketContextV1.canonical_volatility_estimate``. Exactly one
+typed validation and exactly one legacy-float adaptation (owned by the
+typed consumption contract) occur before float consumers.
+
+Pure offline scaffold: no runtime producer cutover, no default mutation,
+no parameter change, no live authorization.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from trading.master_v2.canonical_market_context_v1 import (
+    CanonicalMarketContextBindingOutcome,
+    CanonicalMarketContextBlockReason,
+    CanonicalMarketContextEligibilityV1,
+    CanonicalMarketContextV1,
+    evaluate_canonical_market_context_eligibility,
+    with_computed_input_digest,
+)
+from trading.master_v2.canonical_trading_decision_evidence_v1 import (
+    CanonicalTradingDecisionEvidenceV1,
+    CanonicalVolatilityDecisionEvidenceProvenanceV1,
+)
+from trading.master_v2.canonical_volatility_estimate_feature_contract_v1 import (
+    CONTRACT_OWNER as SEMANTICS_OWNER,
+)
+from trading.master_v2.canonical_volatility_estimate_materializer_v1 import (
+    MATERIALIZER_OWNER as ESTIMATOR_OWNER,
+)
+from trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1 import (
+    CANONICAL_HORIZON,
+    CanonicalVolatilityEstimateV1,
+    CanonicalVolatilityTypedConsumptionError,
+    LEGACY_ADAPTER_OWNER,
+    TYPED_CARRIER_OWNER,
+    adapt_canonical_volatility_estimate_to_legacy_float_v1,
+    validate_canonical_volatility_estimate_v1,
+)
+
+PACKAGE_MARKER = "MASTER_V2_CANONICAL_VOLATILITY_BINDING_AND_PROVENANCE_TRANSPORT_V1=true"
+
+CAPABILITY_ID = "MASTER_V2_CANONICAL_VOLATILITY_BINDING_AND_PROVENANCE_TRANSPORT_V1"
+CAPABILITY_VERSION = "canonical_volatility_binding_and_provenance_transport/v1"
+BINDING_OWNER = "trading.master_v2.canonical_volatility_binding_and_provenance_transport_v1"
+
+TYPED_TRANSPORT_MODEL = "A"
+TYPED_CARRIER_END_BOUNDARY = "CanonicalMarketContextV1.canonical_volatility_estimate"
+SINGLE_VALIDATION_BOUNDARY = "validate_canonical_volatility_estimate_v1"
+LEGACY_ADAPTATION_BOUNDARY = "adapt_canonical_volatility_estimate_to_legacy_float_v1"
+
+RUNTIME_EFFECT = False
+TRADING_LOGIC_EFFECT = False
+PARAMETER_EFFECT = False
+LIVE_AUTHORIZATION = False
+RUNTIME_WIRING = False
+RUNTIME_PRODUCER_CUTOVER = False
+DEFAULT_MUTATION = False
+VOLATILITY_MAX_AGE_VALUE_UNRESOLVED = True
+
+GAPS_CLOSED: tuple[str, ...] = (
+    "G3_TRANSPORT",
+    "G6_BINDING_SCAFFOLD",
+    "G11_EVIDENCE_SCHEMA",
+)
+GAPS_REMAINING: tuple[str, ...] = (
+    "G1",
+    "G2",
+    "G4",
+    "G5",
+    "G7",
+    "G8",
+    "G9",
+    "G10_NUMERIC_MAX_AGE",
+    "G12",
+    "G13",
+    "G14",
+    "G15",
+)
+
+
+class VolatilityStaleStatusV1(str, Enum):
+    """Transport-only stale representation; no numeric max-age in C1."""
+
+    NOT_EVALUATED = "NOT_EVALUATED"
+    UNRESOLVED_MAX_AGE = "UNRESOLVED_MAX_AGE"
+
+
+class VolatilityValidationResultV1(str, Enum):
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+    MISSING = "MISSING"
+
+
+class CanonicalVolatilityBindingErrorCode(str, Enum):
+    MISSING_TYPED_ESTIMATE = "MISSING_TYPED_ESTIMATE"
+    INVALID_ESTIMATE = "INVALID_ESTIMATE"
+    UNTYPED_FLOAT_REJECTED = "UNTYPED_FLOAT_REJECTED"
+    LEGACY_FLOAT_MISMATCH = "LEGACY_FLOAT_MISMATCH"
+    METADATA_LOSS_BEFORE_BOUNDARY = "METADATA_LOSS_BEFORE_BOUNDARY"
+    ADAPTATION_WITHOUT_VALIDATION = "ADAPTATION_WITHOUT_VALIDATION"
+    SECOND_ADAPTER_FORBIDDEN = "SECOND_ADAPTER_FORBIDDEN"
+
+
+class CanonicalVolatilityBindingError(ValueError):
+    def __init__(self, code: CanonicalVolatilityBindingErrorCode, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code.value}:{message}")
+
+
+def _raise(code: CanonicalVolatilityBindingErrorCode, message: str) -> None:
+    raise CanonicalVolatilityBindingError(code, message)
+
+
+def _stable_digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def serialize_canonical_volatility_estimate_for_digest_v1(
+    estimate: CanonicalVolatilityEstimateV1,
+) -> dict[str, Any]:
+    """Deterministic carrier payload (timezone-aware ISO event time)."""
+    as_of = estimate.as_of_event_time
+    if as_of.tzinfo is None:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.INVALID_ESTIMATE,
+            "as_of_event_time_must_be_timezone_aware_for_digest",
+        )
+    return {
+        "annualized": bool(estimate.annualized),
+        "as_of_event_time": as_of.astimezone(timezone.utc).isoformat(),
+        "bar_interval_seconds": int(estimate.bar_interval_seconds),
+        "contract_version": str(estimate.contract_version),
+        "estimator": str(estimate.estimator),
+        "fallback_used": bool(estimate.fallback_used),
+        "horizon_seconds": int(estimate.horizon_seconds),
+        "lookback_bars": int(estimate.lookback_bars),
+        "observation_count": int(estimate.observation_count),
+        "source_digest": str(estimate.source_digest),
+        "unit": str(estimate.unit),
+        "value": float(estimate.value),
+    }
+
+
+def compute_typed_estimate_digest_v1(estimate: CanonicalVolatilityEstimateV1) -> str:
+    return _stable_digest(serialize_canonical_volatility_estimate_for_digest_v1(estimate))
+
+
+def compute_legacy_adaptation_digest_v1(
+    *,
+    estimate: CanonicalVolatilityEstimateV1,
+    legacy_float: float,
+) -> str:
+    return _stable_digest(
+        {
+            "adapter_owner": LEGACY_ADAPTER_OWNER,
+            "adapter_symbol": LEGACY_ADAPTATION_BOUNDARY,
+            "legacy_float_value": float(legacy_float),
+            "source_digest": estimate.source_digest,
+            "typed_estimate_digest": compute_typed_estimate_digest_v1(estimate),
+            "validation_boundary": SINGLE_VALIDATION_BOUNDARY,
+        }
+    )
+
+
+def compute_volatility_input_binding_digest_v1(
+    *,
+    estimate: CanonicalVolatilityEstimateV1,
+    legacy_float: float,
+    stale_status: VolatilityStaleStatusV1,
+    validation_result: VolatilityValidationResultV1,
+) -> str:
+    return _stable_digest(
+        {
+            "capability_version": CAPABILITY_VERSION,
+            "legacy_adaptation_digest": compute_legacy_adaptation_digest_v1(
+                estimate=estimate,
+                legacy_float=legacy_float,
+            ),
+            "legacy_float_value": float(legacy_float),
+            "source_digest": estimate.source_digest,
+            "stale_status": stale_status.value,
+            "typed_carrier_end_boundary": TYPED_CARRIER_END_BOUNDARY,
+            "typed_estimate_digest": compute_typed_estimate_digest_v1(estimate),
+            "typed_transport_model": TYPED_TRANSPORT_MODEL,
+            "validation_result": validation_result.value,
+        }
+    )
+
+
+def reject_untyped_float_at_typed_cmc_boundary_v1(
+    *,
+    raw_float: float | None,
+    typed_estimate: CanonicalVolatilityEstimateV1 | None,
+) -> None:
+    """Fail-closed: unproven floats may not enter the typed CMC field."""
+    if typed_estimate is not None:
+        return
+    _raise(
+        CanonicalVolatilityBindingErrorCode.UNTYPED_FLOAT_REJECTED,
+        f"untyped_float_cannot_populate_typed_cmc_field:value={raw_float!r}",
+    )
+
+
+def validate_typed_estimate_for_cmc_binding_v1(
+    estimate: CanonicalVolatilityEstimateV1 | None,
+) -> CanonicalVolatilityEstimateV1:
+    """Single validation boundary before CMC acceptance."""
+    if estimate is None:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.MISSING_TYPED_ESTIMATE,
+            "canonical_volatility_estimate_is_none",
+        )
+    try:
+        return validate_canonical_volatility_estimate_v1(estimate)
+    except CanonicalVolatilityTypedConsumptionError as exc:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.INVALID_ESTIMATE,
+            str(exc),
+        )
+        raise  # pragma: no cover
+
+
+def adapt_validated_typed_estimate_to_legacy_float_v1(
+    estimate: CanonicalVolatilityEstimateV1,
+    *,
+    already_validated: bool,
+) -> float:
+    """Single legacy adaptation; refuses adaptation without prior validation flag."""
+    if not already_validated:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.ADAPTATION_WITHOUT_VALIDATION,
+            "legacy_adaptation_requires_prior_successful_validation",
+        )
+    # Re-validate inside the owned adapter (idempotent single authority).
+    return float(adapt_canonical_volatility_estimate_to_legacy_float_v1(estimate))
+
+
+def bind_typed_canonical_volatility_estimate_into_market_context_v1(
+    context: CanonicalMarketContextV1,
+    estimate: CanonicalVolatilityEstimateV1,
+) -> CanonicalMarketContextV1:
+    """Accept typed carrier into CMC after single validation; derive legacy float."""
+    validated = validate_typed_estimate_for_cmc_binding_v1(estimate)
+    legacy_float = adapt_validated_typed_estimate_to_legacy_float_v1(
+        validated,
+        already_validated=True,
+    )
+    bound = replace(
+        context,
+        canonical_volatility_estimate=validated,
+        volatility_estimate=legacy_float,
+        input_digest="",
+    )
+    return with_computed_input_digest(bound)
+
+
+def assert_typed_metadata_preserved_until_boundary_v1(
+    estimate: CanonicalVolatilityEstimateV1,
+) -> None:
+    """Detect metadata loss before legacy adaptation boundary."""
+    required = (
+        estimate.unit,
+        estimate.estimator,
+        estimate.source_digest,
+        estimate.contract_version,
+        estimate.as_of_event_time,
+    )
+    if any(x is None or x == "" for x in required):
+        _raise(
+            CanonicalVolatilityBindingErrorCode.METADATA_LOSS_BEFORE_BOUNDARY,
+            "required_typed_metadata_missing_before_legacy_boundary",
+        )
+    if not isinstance(estimate.as_of_event_time, datetime):
+        _raise(
+            CanonicalVolatilityBindingErrorCode.METADATA_LOSS_BEFORE_BOUNDARY,
+            "as_of_event_time_type_invalid",
+        )
+    if estimate.as_of_event_time.tzinfo is None:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.METADATA_LOSS_BEFORE_BOUNDARY,
+            "as_of_event_time_naive_forbidden",
+        )
+
+
+def resolve_legacy_volatility_float_for_consumer_v1(
+    context: CanonicalMarketContextV1,
+) -> float:
+    """Legacy float for Scope/Rules consumers.
+
+    Typed present → sole adapter path. Typed absent → existing float field
+    (legacy path unchanged; global enforcement deferred to C2/G8).
+    """
+    typed_estimate = context.canonical_volatility_estimate
+    if typed_estimate is None:
+        return float(context.volatility_estimate)
+    assert_typed_metadata_preserved_until_boundary_v1(typed_estimate)
+    validated = validate_typed_estimate_for_cmc_binding_v1(typed_estimate)
+    legacy = adapt_validated_typed_estimate_to_legacy_float_v1(
+        validated,
+        already_validated=True,
+    )
+    if not math.isclose(float(context.volatility_estimate), legacy, rel_tol=0.0, abs_tol=0.0):
+        _raise(
+            CanonicalVolatilityBindingErrorCode.LEGACY_FLOAT_MISMATCH,
+            "cmc_float_does_not_match_adapted_typed_value",
+        )
+    return legacy
+
+
+def build_volatility_decision_evidence_provenance_v1(
+    context: CanonicalMarketContextV1,
+    *,
+    stale_status: VolatilityStaleStatusV1 = VolatilityStaleStatusV1.UNRESOLVED_MAX_AGE,
+) -> CanonicalVolatilityDecisionEvidenceProvenanceV1:
+    """Persist full estimate identity for decision evidence (O10)."""
+    estimate = context.canonical_volatility_estimate
+    if estimate is None:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.MISSING_TYPED_ESTIMATE,
+            "cannot_build_evidence_provenance_without_typed_estimate",
+        )
+    assert_typed_metadata_preserved_until_boundary_v1(estimate)
+    validated = validate_typed_estimate_for_cmc_binding_v1(estimate)
+    legacy_float = adapt_validated_typed_estimate_to_legacy_float_v1(
+        validated,
+        already_validated=True,
+    )
+    typed_digest = compute_typed_estimate_digest_v1(validated)
+    legacy_digest = compute_legacy_adaptation_digest_v1(
+        estimate=validated,
+        legacy_float=legacy_float,
+    )
+    binding_digest = compute_volatility_input_binding_digest_v1(
+        estimate=validated,
+        legacy_float=legacy_float,
+        stale_status=stale_status,
+        validation_result=VolatilityValidationResultV1.ACCEPTED,
+    )
+    return CanonicalVolatilityDecisionEvidenceProvenanceV1(
+        volatility_contract_version=validated.contract_version,
+        value=float(validated.value),
+        unit=validated.unit,
+        horizon=CANONICAL_HORIZON,
+        annualized=bool(validated.annualized),
+        estimator=validated.estimator,
+        observation_count=int(validated.observation_count),
+        as_of_event_time=validated.as_of_event_time.astimezone(timezone.utc).isoformat(),
+        fallback_used=bool(validated.fallback_used),
+        source_digest=validated.source_digest,
+        typed_estimate_digest=typed_digest,
+        legacy_adaptation_digest=legacy_digest,
+        stale_status=stale_status.value,
+        validation_result=VolatilityValidationResultV1.ACCEPTED.value,
+        volatility_input_binding_digest=binding_digest,
+        legacy_float_value=float(legacy_float),
+    )
+
+
+def attach_volatility_provenance_to_decision_evidence_v1(
+    evidence: CanonicalTradingDecisionEvidenceV1,
+    provenance: CanonicalVolatilityDecisionEvidenceProvenanceV1,
+) -> CanonicalTradingDecisionEvidenceV1:
+    return replace(evidence, volatility_provenance=provenance)
+
+
+def assert_general_input_digest_alone_insufficient_v1(
+    *,
+    input_digest: str,
+    provenance: CanonicalVolatilityDecisionEvidenceProvenanceV1 | None,
+) -> None:
+    if provenance is None:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.MISSING_TYPED_ESTIMATE,
+            "general_input_digest_alone_insufficient_without_volatility_identity",
+        )
+    if not input_digest:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.INVALID_ESTIMATE,
+            "input_digest_empty",
+        )
+    if not provenance.volatility_input_binding_digest:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.INVALID_ESTIMATE,
+            "volatility_input_binding_digest_required",
+        )
+
+
+def collect_typed_volatility_binding_block_reasons_v1(
+    context: CanonicalMarketContextV1,
+) -> tuple[CanonicalMarketContextBlockReason, ...]:
+    """Fail-closed typed-path gates (does not mutate legacy-only eligibility)."""
+    blocks: list[CanonicalMarketContextBlockReason] = []
+    typed_estimate = context.canonical_volatility_estimate
+    if typed_estimate is None:
+        blocks.append(CanonicalMarketContextBlockReason.TYPED_VOLATILITY_ESTIMATE_MISSING)
+        return tuple(blocks)
+    try:
+        validated = validate_typed_estimate_for_cmc_binding_v1(typed_estimate)
+        legacy = adapt_validated_typed_estimate_to_legacy_float_v1(
+            validated,
+            already_validated=True,
+        )
+    except (CanonicalVolatilityBindingError, CanonicalVolatilityTypedConsumptionError):
+        blocks.append(CanonicalMarketContextBlockReason.TYPED_VOLATILITY_ESTIMATE_INVALID)
+        return tuple(blocks)
+    if not math.isclose(float(context.volatility_estimate), legacy, rel_tol=0.0, abs_tol=0.0):
+        blocks.append(CanonicalMarketContextBlockReason.TYPED_VOLATILITY_LEGACY_FLOAT_MISMATCH)
+    return tuple(blocks)
+
+
+def evaluate_typed_volatility_binding_eligibility_v1(
+    context: CanonicalMarketContextV1,
+    *,
+    binding_outcome: CanonicalMarketContextBindingOutcome = CanonicalMarketContextBindingOutcome.ACCEPTED,
+) -> CanonicalMarketContextEligibilityV1:
+    """Eligibility under typed binding path: missing/invalid typed blocks exposure/scope."""
+    typed_blocks = collect_typed_volatility_binding_block_reasons_v1(context)
+    return evaluate_canonical_market_context_eligibility(
+        context,
+        binding_outcome=binding_outcome,
+        extra_blocks=typed_blocks,
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalVolatilityBindingCapabilityManifestV1:
+    capability_id: str
+    capability_version: str
+    typed_transport_model: str
+    typed_carrier_end_boundary: str
+    single_validation_boundary: str
+    legacy_adaptation_boundary: str
+    typed_carrier_owner: str
+    legacy_adapter_owner: str
+    semantics_owner: str
+    estimator_owner: str
+    binding_owner: str
+    runtime_wiring: bool
+    runtime_producer_cutover: bool
+    default_mutation: bool
+    live_authorization: bool
+    volatility_max_age_value_unresolved: bool
+    gaps_closed: tuple[str, ...]
+    gaps_remaining: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "binding_owner": self.binding_owner,
+            "capability_id": self.capability_id,
+            "capability_version": self.capability_version,
+            "default_mutation": self.default_mutation,
+            "estimator_owner": self.estimator_owner,
+            "gaps_closed": list(self.gaps_closed),
+            "gaps_remaining": list(self.gaps_remaining),
+            "legacy_adaptation_boundary": self.legacy_adaptation_boundary,
+            "legacy_adapter_owner": self.legacy_adapter_owner,
+            "live_authorization": self.live_authorization,
+            "runtime_producer_cutover": self.runtime_producer_cutover,
+            "runtime_wiring": self.runtime_wiring,
+            "semantics_owner": self.semantics_owner,
+            "single_validation_boundary": self.single_validation_boundary,
+            "typed_carrier_end_boundary": self.typed_carrier_end_boundary,
+            "typed_carrier_owner": self.typed_carrier_owner,
+            "typed_transport_model": self.typed_transport_model,
+            "volatility_max_age_value_unresolved": self.volatility_max_age_value_unresolved,
+        }
+
+
+def assert_capability_non_goals_v1() -> dict[str, Any]:
+    return CanonicalVolatilityBindingCapabilityManifestV1(
+        capability_id=CAPABILITY_ID,
+        capability_version=CAPABILITY_VERSION,
+        typed_transport_model=TYPED_TRANSPORT_MODEL,
+        typed_carrier_end_boundary=TYPED_CARRIER_END_BOUNDARY,
+        single_validation_boundary=SINGLE_VALIDATION_BOUNDARY,
+        legacy_adaptation_boundary=LEGACY_ADAPTATION_BOUNDARY,
+        typed_carrier_owner=TYPED_CARRIER_OWNER,
+        legacy_adapter_owner=LEGACY_ADAPTER_OWNER,
+        semantics_owner=SEMANTICS_OWNER,
+        estimator_owner=ESTIMATOR_OWNER,
+        binding_owner=BINDING_OWNER,
+        runtime_wiring=RUNTIME_WIRING,
+        runtime_producer_cutover=RUNTIME_PRODUCER_CUTOVER,
+        default_mutation=DEFAULT_MUTATION,
+        live_authorization=LIVE_AUTHORIZATION,
+        volatility_max_age_value_unresolved=VOLATILITY_MAX_AGE_VALUE_UNRESOLVED,
+        gaps_closed=GAPS_CLOSED,
+        gaps_remaining=GAPS_REMAINING,
+    ).to_dict()
+
+
+def assert_architecture_guards_v1(*, repo_root: Optional[Path] = None) -> dict[str, Any]:
+    """Static guards: single adapter/validation owners; no second authorities."""
+    root = repo_root or Path(__file__).resolve().parents[3]
+    binding_src = (
+        root / "src/trading/master_v2/canonical_volatility_binding_and_provenance_transport_v1.py"
+    ).read_text(encoding="utf-8")
+    typed_src = (
+        root
+        / "src/trading/master_v2/canonical_volatility_estimate_typed_consumption_contract_v1.py"
+    ).read_text(encoding="utf-8")
+    cmc_src = (root / "src/trading/master_v2/canonical_market_context_v1.py").read_text(
+        encoding="utf-8"
+    )
+
+    # Build needle without embedding a full def-line that would self-match.
+    adapter_def_needle = "def " + "adapt_canonical_volatility_estimate_to_legacy_float_v1("
+    adapter_defs_in_binding = binding_src.count(adapter_def_needle)
+    adapter_defs_in_typed = typed_src.count(adapter_def_needle)
+    if adapter_defs_in_binding != 0:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.SECOND_ADAPTER_FORBIDDEN,
+            "second_adapter_function_in_binding_module",
+        )
+    if adapter_defs_in_typed != 1:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.SECOND_ADAPTER_FORBIDDEN,
+            f"expected_exactly_one_typed_adapter_def:actual={adapter_defs_in_typed}",
+        )
+
+    # Binding must call owned adapter; must not reimplement validation formulas.
+    if "adapt_canonical_volatility_estimate_to_legacy_float_v1" not in binding_src:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.SECOND_ADAPTER_FORBIDDEN,
+            "binding_must_reuse_typed_adapter",
+        )
+    if "validate_canonical_volatility_estimate_v1" not in binding_src:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.INVALID_ESTIMATE,
+            "binding_must_reuse_typed_validation",
+        )
+    # Forbidden producer aliases (split tokens avoid self-match on this guard text).
+    forbidden_tokens = (
+        "feature_regime_" + "pipeline",
+        "FuturesVolatility" + "Profile",
+        "panel_sequential",
+    )
+    code_before_guards = binding_src.split("def assert_architecture_guards_v1", 1)[0]
+    for token in forbidden_tokens:
+        if token in code_before_guards:
+            _raise(
+                CanonicalVolatilityBindingErrorCode.INVALID_ESTIMATE,
+                f"non_canonical_producer_token_forbidden:{token}",
+            )
+    true_assign = " = " + "True"
+    if ("RUNTIME_WIRING" + true_assign) in code_before_guards or (
+        "LIVE_AUTHORIZATION" + true_assign
+    ) in code_before_guards:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.INVALID_ESTIMATE,
+            "runtime_or_live_flags_must_remain_false",
+        )
+    if "canonical_volatility_estimate" not in cmc_src:
+        _raise(
+            CanonicalVolatilityBindingErrorCode.INVALID_ESTIMATE,
+            "cmc_typed_field_missing",
+        )
+
+    return {
+        "adapter_defs_in_typed": adapter_defs_in_typed,
+        "adapter_defs_in_binding": adapter_defs_in_binding,
+        "legacy_adapter_owner": LEGACY_ADAPTER_OWNER,
+        "typed_carrier_owner": TYPED_CARRIER_OWNER,
+        "runtime_wiring": RUNTIME_WIRING,
+        "live_authorization": LIVE_AUTHORIZATION,
+        "guards_pass": True,
+    }
+
+
+__all__ = [
+    "BINDING_OWNER",
+    "CAPABILITY_ID",
+    "CAPABILITY_VERSION",
+    "CanonicalVolatilityBindingCapabilityManifestV1",
+    "CanonicalVolatilityBindingError",
+    "CanonicalVolatilityBindingErrorCode",
+    "DEFAULT_MUTATION",
+    "ESTIMATOR_OWNER",
+    "GAPS_CLOSED",
+    "GAPS_REMAINING",
+    "LEGACY_ADAPTATION_BOUNDARY",
+    "LIVE_AUTHORIZATION",
+    "PACKAGE_MARKER",
+    "PARAMETER_EFFECT",
+    "RUNTIME_EFFECT",
+    "RUNTIME_PRODUCER_CUTOVER",
+    "RUNTIME_WIRING",
+    "SEMANTICS_OWNER",
+    "SINGLE_VALIDATION_BOUNDARY",
+    "TRADING_LOGIC_EFFECT",
+    "TYPED_CARRIER_END_BOUNDARY",
+    "TYPED_TRANSPORT_MODEL",
+    "VOLATILITY_MAX_AGE_VALUE_UNRESOLVED",
+    "VolatilityStaleStatusV1",
+    "VolatilityValidationResultV1",
+    "adapt_validated_typed_estimate_to_legacy_float_v1",
+    "assert_architecture_guards_v1",
+    "assert_capability_non_goals_v1",
+    "assert_general_input_digest_alone_insufficient_v1",
+    "assert_typed_metadata_preserved_until_boundary_v1",
+    "attach_volatility_provenance_to_decision_evidence_v1",
+    "bind_typed_canonical_volatility_estimate_into_market_context_v1",
+    "build_volatility_decision_evidence_provenance_v1",
+    "collect_typed_volatility_binding_block_reasons_v1",
+    "compute_legacy_adaptation_digest_v1",
+    "compute_typed_estimate_digest_v1",
+    "compute_volatility_input_binding_digest_v1",
+    "evaluate_typed_volatility_binding_eligibility_v1",
+    "reject_untyped_float_at_typed_cmc_boundary_v1",
+    "resolve_legacy_volatility_float_for_consumer_v1",
+    "serialize_canonical_volatility_estimate_for_digest_v1",
+    "validate_typed_estimate_for_cmc_binding_v1",
+]

--- a/tests/trading/master_v2/test_canonical_volatility_binding_and_provenance_transport_v1.py
+++ b/tests/trading/master_v2/test_canonical_volatility_binding_and_provenance_transport_v1.py
@@ -1,0 +1,383 @@
+"""Tests for C1 canonical volatility binding and provenance transport v1."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from trading.master_v2.canonical_market_context_v1 import (
+    FEATURE_CONTRACT_VERSION,
+    BarFinalityStatus,
+    CanonicalMarketContextBlockReason,
+    CanonicalMarketContextV1,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+    WarmupStatus,
+    compute_canonical_market_context_input_digest,
+    evaluate_canonical_market_context_eligibility,
+    with_computed_input_digest,
+)
+from trading.master_v2.canonical_scope_initialization_v1 import (
+    CanonicalScopeInitializationPolicyV1,
+    ScopeInitializationPrerequisitesV1,
+    initialize_canonical_scope,
+)
+from trading.master_v2.canonical_trading_decision_evidence_v1 import (
+    CanonicalTradingDecisionEvidenceV1,
+    finalize_offline_replay_decision_evidence_v1,
+    serialize_canonical_trading_decision_evidence_canonical,
+)
+from trading.master_v2.canonical_volatility_binding_and_provenance_transport_v1 import (
+    CAPABILITY_ID,
+    PACKAGE_MARKER,
+    VOLATILITY_MAX_AGE_VALUE_UNRESOLVED,
+    CanonicalVolatilityBindingError,
+    CanonicalVolatilityBindingErrorCode,
+    VolatilityStaleStatusV1,
+    VolatilityValidationResultV1,
+    adapt_validated_typed_estimate_to_legacy_float_v1,
+    assert_architecture_guards_v1,
+    assert_capability_non_goals_v1,
+    assert_general_input_digest_alone_insufficient_v1,
+    attach_volatility_provenance_to_decision_evidence_v1,
+    bind_typed_canonical_volatility_estimate_into_market_context_v1,
+    build_volatility_decision_evidence_provenance_v1,
+    compute_legacy_adaptation_digest_v1,
+    compute_typed_estimate_digest_v1,
+    compute_volatility_input_binding_digest_v1,
+    evaluate_typed_volatility_binding_eligibility_v1,
+    reject_untyped_float_at_typed_cmc_boundary_v1,
+    resolve_legacy_volatility_float_for_consumer_v1,
+)
+from trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1 import (
+    LEGACY_ADAPTER_OWNER,
+    TYPED_CARRIER_OWNER,
+    build_canonical_volatility_estimate_v1,
+    with_mutated_field_for_tests_v1,
+)
+from trading.master_v2.double_play_futures_input import FuturesMarketType
+from trading.master_v2.double_play_state import DynamicScopeRules
+from trading.master_v2.integrated_offline_trading_logic_replay_v1 import _DEFAULT_SCOPE_RULES
+from trading.master_v2.offline_double_play_scenario_replay_v0 import _DEFAULT_RULES
+
+ROOT = Path(__file__).resolve().parents[3]
+AS_OF = datetime(2026, 6, 1, 1, 0, tzinfo=timezone.utc)
+
+
+def _valid_estimate(**overrides: object):
+    base: dict[str, object] = {
+        "value": 0.004321,
+        "observation_count": 60,
+        "as_of_event_time": AS_OF,
+        "fallback_used": False,
+    }
+    base.update(overrides)
+    return build_canonical_volatility_estimate_v1(**base)  # type: ignore[arg-type]
+
+
+def _context(**overrides: object) -> CanonicalMarketContextV1:
+    base: dict = {
+        "context_id": "ctx-eth-perp-epoch42-ev1",
+        "instrument_id": "inst-eth-usdt-perp",
+        "market_type": FuturesMarketType.PERPETUAL,
+        "trading_epoch": 42,
+        "market_event_time": "2026-06-30T12:00:00+00:00",
+        "decision_time": "2026-06-30T12:00:01+00:00",
+        "bar_interval": "1m",
+        "bar_finality_status": BarFinalityStatus.FINALIZED,
+        "mark_price": 3500.0,
+        "index_price": 3499.5,
+        "best_bid": 3499.8,
+        "best_ask": 3500.2,
+        "spread": 0.4,
+        "volume": 1_250_000.0,
+        "open_interest": 85_000_000.0,
+        "funding_rate": 0.00012,
+        "volatility_estimate": 0.38,
+        "trend_feature_set": {"slope": 0.02},
+        "momentum_feature_set": {"rsi": 55.0},
+        "liquidity_feature_set": {"depth_score": 0.88},
+        "market_structure_feature_set": {"range_ratio": 0.42},
+        "data_integrity_status": DataIntegrityStatus.TRUSTED,
+        "clock_trust_status": ClockTrustStatus.TRUSTED,
+        "warmup_status": WarmupStatus.WARMUP_COMPLETE,
+        "feature_contract_version": FEATURE_CONTRACT_VERSION,
+        "input_digest": "",
+        "canonical_volatility_estimate": None,
+    }
+    base.update(overrides)
+    return CanonicalMarketContextV1(**base)
+
+
+def _minimal_evidence(**overrides: object) -> CanonicalTradingDecisionEvidenceV1:
+    base: dict = {
+        "decision_id": "decision-1",
+        "replay_id": "replay-1",
+        "instrument_id": "inst-eth-usdt-perp",
+        "trading_epoch": 42,
+        "market_context_ref": "ctx-1",
+        "scope_initialization_ref": "scope-1",
+        "scope_event_ref": "sev-1",
+        "bull_assessment_ref": "bull-1",
+        "bear_assessment_ref": "bear-1",
+        "state_switch_ref": "sw-1",
+        "bull_survival_ref": "bs-1",
+        "bear_survival_ref": "brs-1",
+        "bull_suitability_ref": "bsu-1",
+        "bear_suitability_ref": "brsu-1",
+        "composition_result_ref": "comp-1",
+        "entry_exit_policy_ref": "ee-1",
+        "current_scope_ref": "cs-1",
+        "next_scope_ref": "ns-1",
+        "previous_direction_state": "NEUTRAL",
+        "next_direction_state": "NEUTRAL",
+        "selected_side": "NONE",
+        "selected_strategy_ref": "",
+        "decision_outcome": "observe",
+        "entry_or_exit_policy_ref": "ee-1",
+        "reason_codes": (),
+        "decision_precedence_trace": (),
+        "component_versions": {},
+        "policy_versions": {},
+        "config_digest": "a" * 64,
+        "implementation_digest": "b" * 64,
+        "input_digest": "c" * 64,
+        "semantic_digest": "",
+    }
+    base.update(overrides)
+    return CanonicalTradingDecisionEvidenceV1(**base)
+
+
+def test_package_marker_and_manifest() -> None:
+    assert PACKAGE_MARKER.endswith("=true")
+    manifest = assert_capability_non_goals_v1()
+    assert manifest["capability_id"] == CAPABILITY_ID
+    assert manifest["typed_transport_model"] == "A"
+    assert manifest["runtime_wiring"] is False
+    assert manifest["live_authorization"] is False
+    assert manifest["default_mutation"] is False
+    assert VOLATILITY_MAX_AGE_VALUE_UNRESOLVED is True
+    assert manifest["typed_carrier_owner"] == TYPED_CARRIER_OWNER
+    assert manifest["legacy_adapter_owner"] == LEGACY_ADAPTER_OWNER
+
+
+def test_architecture_guards_pass() -> None:
+    result = assert_architecture_guards_v1(repo_root=ROOT)
+    assert result["guards_pass"] is True
+    assert result["adapter_defs_in_typed"] == 1
+    assert result["adapter_defs_in_binding"] == 0
+
+
+def test_proven_typed_estimate_accepted_into_cmc() -> None:
+    estimate = _valid_estimate()
+    ctx = bind_typed_canonical_volatility_estimate_into_market_context_v1(_context(), estimate)
+    assert ctx.canonical_volatility_estimate is not None
+    assert ctx.canonical_volatility_estimate.value == pytest.approx(0.004321)
+    assert ctx.volatility_estimate == pytest.approx(0.004321)
+    assert ctx.canonical_volatility_estimate.unit == estimate.unit
+    assert ctx.canonical_volatility_estimate.source_digest == estimate.source_digest
+    assert ctx.canonical_volatility_estimate.as_of_event_time == estimate.as_of_event_time
+
+
+def test_legacy_float_matches_typed_carrier_for_float_consumer() -> None:
+    estimate = _valid_estimate(value=0.012345)
+    ctx = bind_typed_canonical_volatility_estimate_into_market_context_v1(_context(), estimate)
+    legacy = resolve_legacy_volatility_float_for_consumer_v1(ctx)
+    assert legacy == pytest.approx(0.012345)
+    assert legacy == pytest.approx(ctx.canonical_volatility_estimate.value)  # type: ignore[union-attr]
+
+
+def test_digests_deterministic() -> None:
+    estimate = _valid_estimate()
+    d1 = compute_typed_estimate_digest_v1(estimate)
+    d2 = compute_typed_estimate_digest_v1(estimate)
+    assert d1 == d2
+    legacy = 0.004321
+    a1 = compute_legacy_adaptation_digest_v1(estimate=estimate, legacy_float=legacy)
+    a2 = compute_legacy_adaptation_digest_v1(estimate=estimate, legacy_float=legacy)
+    assert a1 == a2
+    b1 = compute_volatility_input_binding_digest_v1(
+        estimate=estimate,
+        legacy_float=legacy,
+        stale_status=VolatilityStaleStatusV1.UNRESOLVED_MAX_AGE,
+        validation_result=VolatilityValidationResultV1.ACCEPTED,
+    )
+    b2 = compute_volatility_input_binding_digest_v1(
+        estimate=estimate,
+        legacy_float=legacy,
+        stale_status=VolatilityStaleStatusV1.UNRESOLVED_MAX_AGE,
+        validation_result=VolatilityValidationResultV1.ACCEPTED,
+    )
+    assert b1 == b2
+    assert len(d1) == 64 and len(a1) == 64 and len(b1) == 64
+
+
+def test_evidence_contains_full_identity_and_roundtrip() -> None:
+    estimate = _valid_estimate()
+    ctx = bind_typed_canonical_volatility_estimate_into_market_context_v1(_context(), estimate)
+    provenance = build_volatility_decision_evidence_provenance_v1(ctx)
+    assert provenance.volatility_contract_version
+    assert provenance.source_digest == estimate.source_digest
+    assert provenance.typed_estimate_digest
+    assert provenance.legacy_adaptation_digest
+    assert provenance.volatility_input_binding_digest
+    assert provenance.stale_status == "UNRESOLVED_MAX_AGE"
+    assert provenance.validation_result == "ACCEPTED"
+    assert provenance.legacy_float_value == pytest.approx(estimate.value)
+    evidence = attach_volatility_provenance_to_decision_evidence_v1(
+        _minimal_evidence(),
+        provenance,
+    )
+    finalized = finalize_offline_replay_decision_evidence_v1(evidence)
+    assert finalized.volatility_provenance is not None
+    assert finalized.volatility_provenance.to_dict() == provenance.to_dict()
+    serialized = serialize_canonical_trading_decision_evidence_canonical(finalized)
+    assert "volatility_provenance" in serialized
+    assert provenance.volatility_input_binding_digest in serialized
+
+
+def test_legacy_cmc_digest_unchanged_without_typed_field() -> None:
+    ctx = with_computed_input_digest(_context(volatility_estimate=0.38))
+    assert ctx.canonical_volatility_estimate is None
+    # Recompute from float-only context; digest path omits None typed field.
+    again = compute_canonical_market_context_input_digest(
+        _context(volatility_estimate=0.38, input_digest="")
+    )
+    assert ctx.input_digest == again
+
+
+def test_scope_init_uses_adapted_typed_value() -> None:
+    estimate = _valid_estimate(value=0.25)
+    ctx = bind_typed_canonical_volatility_estimate_into_market_context_v1(
+        _context(mark_price=1000.0),
+        estimate,
+    )
+    result = initialize_canonical_scope(
+        ctx,
+        CanonicalScopeInitializationPolicyV1(min_scope_band=1.0, max_scope_band=10_000.0),
+        ScopeInitializationPrerequisitesV1(
+            required_window_complete=True,
+            instrument_metadata_valid=True,
+            finalized_market_context=True,
+        ),
+    )
+    assert result.scope is not None
+    assert result.scope.volatility_estimate == pytest.approx(0.25)
+    assert result.scope.initial_volatility_distance == pytest.approx(250.0)
+
+
+def test_untyped_float_rejected_at_typed_boundary() -> None:
+    with pytest.raises(CanonicalVolatilityBindingError) as exc:
+        reject_untyped_float_at_typed_cmc_boundary_v1(raw_float=0.2, typed_estimate=None)
+    assert exc.value.code is CanonicalVolatilityBindingErrorCode.UNTYPED_FLOAT_REJECTED
+
+
+def test_fallback_used_rejected() -> None:
+    estimate = _valid_estimate()
+    bad = with_mutated_field_for_tests_v1(estimate, fallback_used=True)
+    with pytest.raises(CanonicalVolatilityBindingError) as exc:
+        bind_typed_canonical_volatility_estimate_into_market_context_v1(_context(), bad)
+    assert exc.value.code is CanonicalVolatilityBindingErrorCode.INVALID_ESTIMATE
+
+
+def test_unsupported_version_rejected() -> None:
+    estimate = _valid_estimate()
+    bad = with_mutated_field_for_tests_v1(estimate, contract_version="not/a/version")
+    with pytest.raises(CanonicalVolatilityBindingError):
+        bind_typed_canonical_volatility_estimate_into_market_context_v1(_context(), bad)
+
+
+def test_wrong_unit_horizon_estimator_rejected() -> None:
+    estimate = _valid_estimate()
+    for kwargs in (
+        {"unit": "ANNUALIZED_VOL"},
+        {"horizon_seconds": 999},
+        {"estimator": "OTHER"},
+    ):
+        bad = with_mutated_field_for_tests_v1(estimate, **kwargs)
+        with pytest.raises(CanonicalVolatilityBindingError):
+            bind_typed_canonical_volatility_estimate_into_market_context_v1(_context(), bad)
+
+
+def test_insufficient_observations_rejected() -> None:
+    estimate = _valid_estimate()
+    bad = with_mutated_field_for_tests_v1(estimate, observation_count=10)
+    with pytest.raises(CanonicalVolatilityBindingError):
+        bind_typed_canonical_volatility_estimate_into_market_context_v1(_context(), bad)
+
+
+def test_naive_event_time_rejected() -> None:
+    estimate = _valid_estimate()
+    bad = with_mutated_field_for_tests_v1(
+        estimate,
+        as_of_event_time=datetime(2026, 6, 1, 1, 0),
+    )
+    with pytest.raises(CanonicalVolatilityBindingError):
+        bind_typed_canonical_volatility_estimate_into_market_context_v1(_context(), bad)
+
+
+def test_missing_source_digest_rejected() -> None:
+    estimate = _valid_estimate()
+    bad = with_mutated_field_for_tests_v1(estimate, source_digest="")
+    with pytest.raises(CanonicalVolatilityBindingError):
+        bind_typed_canonical_volatility_estimate_into_market_context_v1(_context(), bad)
+
+
+def test_adaptation_without_validation_flag_rejected() -> None:
+    estimate = _valid_estimate()
+    with pytest.raises(CanonicalVolatilityBindingError) as exc:
+        adapt_validated_typed_estimate_to_legacy_float_v1(estimate, already_validated=False)
+    assert exc.value.code is CanonicalVolatilityBindingErrorCode.ADAPTATION_WITHOUT_VALIDATION
+
+
+def test_general_input_digest_alone_insufficient() -> None:
+    with pytest.raises(CanonicalVolatilityBindingError) as exc:
+        assert_general_input_digest_alone_insufficient_v1(
+            input_digest="c" * 64,
+            provenance=None,
+        )
+    assert exc.value.code is CanonicalVolatilityBindingErrorCode.MISSING_TYPED_ESTIMATE
+
+
+def test_typed_path_missing_estimate_blocks_exposure_and_scope() -> None:
+    ctx = with_computed_input_digest(_context())
+    elig = evaluate_typed_volatility_binding_eligibility_v1(ctx)
+    assert elig.new_directional_exposure_allowed is False
+    assert elig.scope_confirmation_allowed is False
+    assert elig.observation_and_reconciliation_only is True
+    assert CanonicalMarketContextBlockReason.TYPED_VOLATILITY_ESTIMATE_MISSING in elig.block_reasons
+
+
+def test_legacy_eligibility_unchanged_without_typed_requirement() -> None:
+    ctx = with_computed_input_digest(_context())
+    elig = evaluate_canonical_market_context_eligibility(ctx)
+    assert elig.trading_decision_allowed is True
+    assert elig.new_directional_exposure_allowed is True
+
+
+def test_defaults_unchanged_regression() -> None:
+    assert DynamicScopeRules().volatility_estimate == 1.0
+    assert _DEFAULT_RULES.volatility_estimate == 0.02
+    assert _DEFAULT_SCOPE_RULES.volatility_estimate == 0.02
+    # Historical bind default still present in source (C2 not in scope).
+    wiring = (ROOT / "src/backtest/mv2_research_wiring_v1.py").read_text(encoding="utf-8")
+    assert 'bar.get("volatility_estimate", 0.2)' in wiring
+    integrated = (
+        ROOT / "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py"
+    ).read_text(encoding="utf-8")
+    assert "max(float(snapshot.volatility_estimate), 1e-9)" in integrated
+
+
+def test_no_runtime_wiring_flags() -> None:
+    manifest = assert_capability_non_goals_v1()
+    assert manifest["runtime_wiring"] is False
+    assert manifest["runtime_producer_cutover"] is False
+    binding_src = (
+        ROOT / "src/trading/master_v2/canonical_volatility_binding_and_provenance_transport_v1.py"
+    ).read_text(encoding="utf-8")
+    code_before_guards = binding_src.split("def assert_architecture_guards_v1", 1)[0]
+    assert "feature_regime_pipeline" not in code_before_guards
+    assert "FuturesVolatilityProfile" not in code_before_guards
+    assert "panel_sequential" not in code_before_guards


### PR DESCRIPTION
## Summary
- Implements C1 Typed-Transport Model A: `CanonicalVolatilityEstimateV1` on `CanonicalMarketContextV1.canonical_volatility_estimate` with single owned validation and single legacy-float adaptation before Scope/Rules float consumers.
- Persists full volatility estimate identity in `CanonicalTradingDecisionEvidenceV1.volatility_provenance` (including typed/legacy/binding digests); general `input_digest` alone remains insufficient.
- No default mutation (`0.2` / `0.02` / `1.0` / `1e-9`), no runtime producer cutover, no trading-logic or parameter change, no live authorization.

## Test plan
- [x] Focused C1 contract tests (`test_canonical_volatility_binding_and_provenance_transport_v1.py`)
- [x] CMC / scope / typed-consumption / double_play_state regressions
- [x] Architecture guards (single adapter/validation owners)
- [x] Ruff format + check on changed files
- [x] Docs token policy + docs reference targets
- [x] CI selector path: `PR_BOUNDED_FULL` (config auth path) + local PR-bounded targets
- [x] Strategy smoke pytest + CLI
- [ ] GitHub required checks terminal success

## Non-goals (remain open)
G1/G2/G4/G5/G7/G8/G9/G10_NUMERIC_MAX_AGE/G12/G13/G14/G15 — deferred to C2–C4.

`READY_FOR_RUNTIME_WIRING=false` · `READY_FOR_PARAMETER_RESEARCH=false` · `LIVE_AUTHORIZATION=false` · `HARD_STOP=true`


Made with [Cursor](https://cursor.com)