### PR TITLE
feat(master-v2): productive runtime CMC typed volatility binding v1

### DIFF
--- a/config/governance/technical_canonical_wiring_authorization_v1.json
+++ b/config/governance/technical_canonical_wiring_authorization_v1.json
@@ -751,7 +751,11 @@
     "src/trading/master_v2/canonical_volatility_runtime_mark_history_v1.py",
     "src/trading/master_v2/canonical_volatility_typed_runtime_producer_scaffold_v1.py",
     "tests/trading/master_v2/test_canonical_volatility_typed_runtime_producer_scaffold_v1.py",
-    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_TYPED_RUNTIME_PRODUCER_SCAFFOLD_V1.md"
+    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_TYPED_RUNTIME_PRODUCER_SCAFFOLD_V1.md",
+    "src/trading/master_v2/canonical_volatility_productive_runtime_cmc_typed_binding_v1.py",
+    "tests/trading/master_v2/test_canonical_volatility_productive_runtime_cmc_typed_binding_v1.py",
+    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1.md",
+    "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2/hardening_cycle_bridge_v2.py"
   ],
   "allowed_surface_classes": [
     "TECHNICAL_CANONICAL_REPLAY_INPUT_BUILDER_WIRING",
@@ -899,7 +903,8 @@
     "Includes V8 DEVELOPMENT evaluation authorization ratification separate from immutable preregistration; requires pre-authorization parity PASS and released DEVELOPMENT panel; transitions lifecycle to EVALUATION_AUTHORIZED; does not start runner or claim run slot; next step awaits separate run Operator-GO. Owner surface: BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_DEVELOPMENT_EVALUATION_AUTHORIZATION_RATIFICATION_V8.",
     "C3 DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1: authorize exact-file Master-V2 confirmation-integration adapter, legacy DA quarantine comments, and C3 contract tests. No runtime activation, no config/threshold mutation, no broad master_v2 grant.",
     "C4 POST_CONFIRMATION_SURVIVAL_SUITABILITY_COMPOSITION_BINDING_V1: authorize post-C3 Survival/Suitability/Composition binding guards, Research C1 DISTINCT wiring, C4 contract tests and docs. Composition remains sole CONFIRMED admissibility gate. No runtime activation, no parameter/volatility mutation.",
-    "MASTER_V2_CANONICAL_VOLATILITY_TYPED_RUNTIME_PRODUCER_SCAFFOLD_V1: authorize exact-file typed runtime producer scaffold, mark-history host, materializer observation_count provenance helper, typed-factory provenance reuse, focused tests and docs. No runtime cutover, no Double-Play/CMC bind_typed wiring, no parameter-value decision, no broad master_v2 grant."
+    "MASTER_V2_CANONICAL_VOLATILITY_TYPED_RUNTIME_PRODUCER_SCAFFOLD_V1: authorize exact-file typed runtime producer scaffold, mark-history host, materializer observation_count provenance helper, typed-factory provenance reuse, focused tests and docs. No runtime cutover, no Double-Play/CMC bind_typed wiring, no parameter-value decision, no broad master_v2 grant.",
+    "MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1: authorize exact-file productive Producer→bind_typed→CMC host, hardening-bridge productive caller wiring, focused tests and docs. Reuses existing producer/validation/binding/adapter authorities. No Double-Play typed cutover, no numeric max-age, no global typed-only enforcement, no competing-producer mutation, no parameter research, no live/orders."
   ],
   "pr_specific_exception": false,
   "required_check_waiver": false,
@@ -921,6 +926,7 @@
     "Includes fail-closed Shadow-Prep reconciliation rename of runtime-bridge pre-activation economic evidence field to integrated economic evidence bundle verified status; no activation, no orders, no readiness PASS coercion. Owner surface: INTEGRATED_PAPER_SHADOW_OBSERVATION_SESSION_CAPABILITY_V1.",
     "DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1 exact-file allowlist for C3 adapter + DA quarantine + C3 tests (offline confirmation integration only)",
     "POST_CONFIRMATION_SURVIVAL_SUITABILITY_COMPOSITION_BINDING_V1 exact-file allowlist for C4 binding guards + Research C1 DISTINCT + C4 tests/docs (offline binding only)",
-    "CANONICAL_VOLATILITY_TYPED_RUNTIME_PRODUCER_SCAFFOLD_V1 exact-file allowlist for offline producer scaffold + mark history + observation_count provenance (no cutover/wiring)"
+    "CANONICAL_VOLATILITY_TYPED_RUNTIME_PRODUCER_SCAFFOLD_V1 exact-file allowlist for offline producer scaffold + mark history + observation_count provenance (no cutover/wiring)",
+    "CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1 exact-file allowlist for productive CMC typed binding host + hardening bridge caller (CMC transport only; no Double-Play typed cutover)"
   ]
 }

--- a/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1.md
+++ b/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1.md
@@ -93,7 +93,7 @@ regular `PRODUCED` outcome. No rematerialize API is added here.
 
 | Artifact | Path |
 |---|---|
-| Binding host | `src/trading/master_v2/canonical_volatility_productive_runtime_cmc_typed_binding_v1.py` |
-| Productive caller | `src&#47;ops&#47;...&#47;hardening_cycle_bridge_v2.py` |
+| Binding host | `src&#47;trading&#47;master_v2&#47;canonical_volatility_productive_runtime_cmc_typed_binding_v1.py` |
+| Productive caller | `src&#47;ops&#47;wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2&#47;hardening_cycle_bridge_v2.py` |
 | Spec | this document |
-| Tests | `tests/trading/master_v2/test_canonical_volatility_productive_runtime_cmc_typed_binding_v1.py` |
+| Tests | `tests&#47;trading&#47;master_v2&#47;test_canonical_volatility_productive_runtime_cmc_typed_binding_v1.py` |

--- a/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1.md
+++ b/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1.md
@@ -1,0 +1,99 @@
+# MASTER_V2 Canonical Volatility Productive Runtime CMC Typed Binding v1
+
+---
+docs_token: DOCS_TOKEN_MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1
+STATUS: CAPABILITY_AVAILABLE
+scope: productive Producer→bind_typed→CMC edge; non-authorizing for Double-Play typed cutover
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+RUNTIME_WIRING: true
+CMC_RUNTIME_WIRING: true
+PRODUCTIVE_BIND_TYPED_CALLER: true
+DOUBLE_PLAY_TYPED_CUTOVER: false
+GLOBAL_TYPED_ONLY_ENFORCEMENT: false
+NUMERIC_MAX_AGE_DECIDED: false
+PARAMETER_EFFECT: false
+HARD_STOP: true
+---
+
+> **Productive CMC typed transport edge (OPTION_2).** Hosts exactly one
+> `CanonicalVolatilityTypedRuntimeProducerScaffoldV1`, feeds finalized PT1M
+> mark samples, and on `PRODUCED` binds via the existing
+> `bind_typed_canonical_volatility_estimate_into_market_context_v1` into
+> `CanonicalMarketContextV1`. Does **not** decide numeric max-age, promote
+> defaults, cut over Double-Play typed-only, or replace competing producers.
+
+## Machine summary
+
+```
+CAPABILITY_ID=MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1
+PRODUCTIVE_RUNTIME_CALLER=hardening_cycle_bridge_v2.run_hardened_bridge_cycle_v2
+PRODUCER_OWNER=CanonicalVolatilityTypedRuntimeProducerScaffoldV1
+BINDING_OWNER=bind_typed_canonical_volatility_estimate_into_market_context_v1
+TYPED_FACTORY=materialize_typed_canonical_volatility_estimate_v1
+VALIDATION_BOUNDARY=validate_canonical_volatility_estimate_v1
+LEGACY_ADAPTATION=adapt_canonical_volatility_estimate_to_legacy_float_v1
+MAX_AGE_STATUS=UNRESOLVED_MAX_AGE
+SECOND_ESTIMATOR_CREATED=false
+SECOND_BINDING_AUTHORITY_CREATED=false
+SECOND_ADAPTATION_AUTHORITY_CREATED=false
+STATIC_RUNTIME_FALLBACK_USED=false
+GLOBAL_TYPED_ONLY_ENFORCEMENT=false
+DOUBLE_PLAY_TYPED_CUTOVER=false
+LIVE_AUTHORIZATION=false
+HARD_STOP=true
+READY_FOR_RUNTIME_CMC_TYPED_TRANSPORT=true
+READY_FOR_DOUBLE_PLAY_TYPED_CUTOVER=false
+READY_FOR_TYPED_ONLY_RUNTIME_ENFORCEMENT=false
+READY_FOR_NUMERIC_MAX_AGE_POLICY=false
+READY_FOR_PARAMETER_RESEARCH=false
+```
+
+## Productive call graph
+
+```
+finalized PT1M mark sample (optional per cycle)
+  → CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1
+       → CanonicalVolatilityTypedRuntimeProducerScaffoldV1.ingest_finalized_pt1m_mark_sample_v1
+            → sample authority + history + P1/P2
+  → on PRODUCED (or process-internal reuse via output port):
+       validate_canonical_volatility_estimate_v1
+       → bind_typed_canonical_volatility_estimate_into_market_context_v1
+            → adapt_validated_typed_estimate_to_legacy_float_v1
+            → CMC.canonical_volatility_estimate + CMC.volatility_estimate (atomic)
+  → HardenedBridgeSessionStateV2 / run_hardened_bridge_cycle_v2
+       → build_integrated_offline_replay_input_v1 / Double Play consumers (float)
+```
+
+Cycles without a new finalized PT1M sample call
+`on_runtime_cycle_without_sample_v1` and may reuse a previously PRODUCED
+estimate via the producer output port. Reject outcomes
+(`OUT_OF_ORDER`, `HISTORY_GAP`, `PERSISTENCE`, `MATERIALIZATION`, `INVALID`)
+perform no CMC typed binding. Warmup / restart-without-estimate leave the
+typed cutover path fail-closed. `UNRESOLVED_MAX_AGE` is telemetry only — not
+freshness approval.
+
+## Restart
+
+History restores through the existing persistence contract. The estimate is
+**not** rematerialized. Typed cutover remains fail-closed until the next
+regular `PRODUCED` outcome. No rematerialize API is added here.
+
+## Explicit non-goals
+
+- no numeric max-age policy (`C1_G10` remains open)
+- no global typed-only enforcement (`G3` explicit legacy remains admissible offline)
+- no competing producer mutation (`G15`)
+- no Double-Play typed cutover
+- no Replay 0.02 / Research 0.2 mutation
+- no Live / Testnet / order routing
+- no parameter research
+
+## Owners
+
+| Artifact | Path |
+|---|---|
+| Binding host | `src/trading/master_v2/canonical_volatility_productive_runtime_cmc_typed_binding_v1.py` |
+| Productive caller | `src&#47;ops&#47;...&#47;hardening_cycle_bridge_v2.py` |
+| Spec | this document |
+| Tests | `tests/trading/master_v2/test_canonical_volatility_productive_runtime_cmc_typed_binding_v1.py` |

--- a/src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2/hardening_cycle_bridge_v2.py
+++ b/src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2/hardening_cycle_bridge_v2.py
@@ -7,6 +7,7 @@ import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
+from pathlib import Path
 from typing import Any, Mapping, Optional, Sequence
 
 from src.ops.bounded_futures_testnet_venue_binding_v0 import PRODUCTION_INSTRUMENT_ID
@@ -56,6 +57,10 @@ from src.ops.wallclock_full_canonical_decision_to_simulated_economics_runtime_br
 from src.ops.wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_v1.intended_action_mapper_v1 import (
     map_replay_result_to_intended_analytical_action_v1,
 )
+from trading.market_state.distinct_market_observation_acceptor_v1 import (
+    ObservationTransportMetadataV1,
+)
+from trading.market_state.time_sample_epoch_semantics_v1 import MarketSampleIdentityV1
 from trading.master_v2.canonical_market_context_v1 import (
     CANONICAL_MARKET_CONTEXT_LAYER_VERSION,
     FEATURE_CONTRACT_VERSION,
@@ -66,6 +71,9 @@ from trading.master_v2.canonical_market_context_v1 import (
     DataIntegrityStatus,
     WarmupStatus,
     with_computed_input_digest,
+)
+from trading.master_v2.canonical_volatility_productive_runtime_cmc_typed_binding_v1 import (
+    CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1,
 )
 from trading.master_v2.canonical_scope_initialization_v1 import (
     CANONICAL_SCOPE_INITIALIZATION_LAYER_VERSION,
@@ -133,6 +141,7 @@ CALL_GRAPH_V2: tuple[str, ...] = (
     "okx_public_market_data",
     "feature_pipeline",
     "regime_pipeline",
+    "canonical_volatility_productive_runtime_cmc_typed_binding",
     "master_v2_double_play_integrated_offline_replay",
     "risk_position_sizing",
     "safety_kernel",
@@ -144,6 +153,24 @@ CALL_GRAPH_V2: tuple[str, ...] = (
     "evidence",
     "full_economic_reconstruction_verifier",
 )
+
+_DEFAULT_VOL_TYPED_BINDING_VENUE = "okx_europe"
+_DEFAULT_VOL_TYPED_BINDING_VENUE_INSTRUMENT_ID = PRODUCTION_INSTRUMENT_ID
+
+
+def _ensure_typed_volatility_binding_host_v1(
+    state: "HardenedBridgeSessionStateV2",
+) -> CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1:
+    if state.typed_volatility_cmc_binding_host is None:
+        state.typed_volatility_cmc_binding_host = (
+            CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.create(
+                venue=_DEFAULT_VOL_TYPED_BINDING_VENUE,
+                canonical_instrument_id=str(state.instrument_id),
+                venue_instrument_id=_DEFAULT_VOL_TYPED_BINDING_VENUE_INSTRUMENT_ID,
+                persistence_path=state.typed_volatility_persistence_path,
+            )
+        )
+    return state.typed_volatility_cmc_binding_host
 
 
 def _default_policies() -> IntegratedOfflineReplayPoliciesV1:
@@ -276,11 +303,30 @@ class HardenedBridgeSessionStateV2:
     killstate_trigger: str = ""
     config_digest: str = ""
     session_restart_policy: str = SESSION_RESTART_POLICY
+    typed_volatility_cmc_binding_host: (
+        CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1 | None
+    ) = None
+    typed_volatility_persistence_path: Path | None = None
+    last_typed_volatility_binding_telemetry: dict[str, Any] | None = None
 
     def append_mid(self, mid: float) -> None:
         self.mid_prices.append(float(mid))
         if len(self.mid_prices) > PRICE_PATH_MAX_LEN:
             self.mid_prices = self.mid_prices[-PRICE_PATH_MAX_LEN:]
+
+    def restore_typed_volatility_binding_host_from_persistence_v1(
+        self,
+        *,
+        persistence_path: Path,
+    ) -> CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1:
+        """Restart path: restore mark history only; estimate remains fail-closed until PRODUCED."""
+        self.typed_volatility_persistence_path = persistence_path
+        self.typed_volatility_cmc_binding_host = (
+            CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.restore_from_persistence_v1(
+                persistence_path=persistence_path,
+            )
+        )
+        return self.typed_volatility_cmc_binding_host
 
 
 def _update_session_state_from_replay(state: HardenedBridgeSessionStateV2, *, result: Any) -> None:
@@ -350,6 +396,10 @@ def run_hardened_bridge_cycle_v2(
     session_id: str,
     price_basis: ExplicitPriceBasisV2 | None = None,
     forced_actionable: Mapping[str, Any] | None = None,
+    finalized_pt1m_mark_sample: MarketSampleIdentityV1 | None = None,
+    finalized_pt1m_mark_price: float | None = None,
+    finalized_pt1m_event_time_unix_seconds: float | None = None,
+    finalized_pt1m_transport: ObservationTransportMetadataV1 | None = None,
 ) -> dict[str, Any]:
     if state.session_restart_policy != SESSION_RESTART_POLICY:
         raise RuntimeError("IMPLICIT_RESUME_FORBIDDEN")
@@ -435,6 +485,7 @@ def run_hardened_bridge_cycle_v2(
             volume=1_000_000.0,
             open_interest=50_000_000.0,
             funding_rate=0.0001,
+            # Competing feature_regime float remains until typed bind overwrites atomically.
             volatility_estimate=float(features.volatility_estimate),
             trend_feature_set=dict(features.trend_features),
             momentum_feature_set=dict(features.momentum_features),
@@ -447,6 +498,26 @@ def run_hardened_bridge_cycle_v2(
             input_digest="",
         )
     )
+
+    typed_host = _ensure_typed_volatility_binding_host_v1(state)
+    ingest_sample = finalized_pt1m_mark_sample is not None or (
+        finalized_pt1m_mark_price is not None and finalized_pt1m_event_time_unix_seconds is not None
+    )
+    typed_binding = typed_host.apply_to_market_context_v1(
+        market_context,
+        sample=finalized_pt1m_mark_sample,
+        transport=finalized_pt1m_transport,
+        venue=_DEFAULT_VOL_TYPED_BINDING_VENUE,
+        canonical_instrument_id=str(state.instrument_id),
+        venue_instrument_id=_DEFAULT_VOL_TYPED_BINDING_VENUE_INSTRUMENT_ID,
+        event_time_unix_seconds=finalized_pt1m_event_time_unix_seconds,
+        mark_price=finalized_pt1m_mark_price,
+        is_final=True,
+        ingest_sample=ingest_sample,
+    )
+    market_context = typed_binding.context
+    state.last_typed_volatility_binding_telemetry = typed_binding.telemetry.to_dict()
+    _ = input_digest  # retained for provenance continuity with prior bridge evidence shape
 
     replay_input = build_integrated_offline_replay_input_v1(
         replay_id=f"{session_id}-{cycle_id}",
@@ -638,6 +709,12 @@ def run_hardened_bridge_cycle_v2(
         "feature_regime": features.to_dict(),
         "feature_digest": features.feature_digest,
         "regime_digest": features.regime_digest,
+        "canonical_volatility_typed_binding": dict(
+            state.last_typed_volatility_binding_telemetry or {}
+        ),
+        "canonical_market_context_typed_estimate_present": (
+            market_context.canonical_volatility_estimate is not None
+        ),
         "config_digest": config_digest,
         "price_basis": basis.to_dict(),
         "market_data_reference": basis.market_data_reference,

--- a/src/trading/master_v2/canonical_volatility_productive_runtime_cmc_typed_binding_v1.py
+++ b/src/trading/master_v2/canonical_volatility_productive_runtime_cmc_typed_binding_v1.py
@@ -1,0 +1,554 @@
+"""Productive Runtime CMC typed binding v1 (OPTION_2 edge).
+
+Closes the productive edge:
+
+  CanonicalVolatilityTypedRuntimeProducerScaffoldV1
+    → bind_typed_canonical_volatility_estimate_into_market_context_v1
+    → CanonicalMarketContextV1
+
+Reuses existing producer, validation, binding, and Typed→Float authorities.
+Does **not** introduce a second estimator, binder, adapter, numeric max-age,
+global typed-only enforcement, or Double-Play typed cutover.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+from trading.market_state.distinct_market_observation_acceptor_v1 import (
+    ObservationTransportMetadataV1,
+)
+from trading.market_state.time_sample_epoch_semantics_v1 import MarketSampleIdentityV1
+from trading.master_v2.canonical_market_context_v1 import CanonicalMarketContextV1
+from trading.master_v2.canonical_volatility_binding_and_provenance_transport_v1 import (
+    BINDING_OWNER,
+    LEGACY_ADAPTATION_BOUNDARY,
+    VolatilityStaleStatusV1,
+    bind_typed_canonical_volatility_estimate_into_market_context_v1,
+    evaluate_typed_volatility_binding_eligibility_v1,
+    validate_typed_estimate_for_cmc_binding_v1,
+)
+from trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1 import (
+    LEGACY_ADAPTER_OWNER,
+    CanonicalVolatilityEstimateV1,
+    CanonicalVolatilityTypedConsumptionError,
+    validate_canonical_volatility_estimate_v1,
+)
+from trading.master_v2.canonical_volatility_typed_runtime_producer_scaffold_v1 import (
+    CanonicalVolatilityTypedRuntimeProducerScaffoldV1,
+    TypedRuntimeProducerOutcomeV1,
+    TypedRuntimeProducerResultV1,
+)
+
+PACKAGE_MARKER = "MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1=true"
+
+CAPABILITY_ID = "MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1"
+CAPABILITY_VERSION = "canonical_volatility_productive_runtime_cmc_typed_binding/v1"
+BINDING_RUNTIME_OWNER = (
+    "trading.master_v2.canonical_volatility_productive_runtime_cmc_typed_binding_v1"
+)
+PRODUCTIVE_RUNTIME_CALLER_OWNER = (
+    "ops.wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2"
+    ".hardening_cycle_bridge_v2"
+)
+
+PRODUCTIVE_BIND_TYPED_CALLER = True
+CMC_RUNTIME_WIRING = True
+DOUBLE_PLAY_TYPED_CUTOVER = False
+GLOBAL_TYPED_ONLY_ENFORCEMENT = False
+NUMERIC_MAX_AGE_DECIDED = False
+LIVE_AUTHORIZATION = False
+HARD_STOP = True
+SECOND_ESTIMATOR_CREATED = False
+SECOND_BINDING_AUTHORITY_CREATED = False
+SECOND_ADAPTATION_AUTHORITY_CREATED = False
+STATIC_RUNTIME_FALLBACK_USED = False
+EXPLICIT_LEGACY_QUARANTINE_CHANGED = False
+COMPETING_PRODUCERS_CHANGED = False
+
+MAX_AGE_STATUS = VolatilityStaleStatusV1.UNRESOLVED_MAX_AGE.value
+LEGACY_FLOAT_ADAPTATION_OWNER = LEGACY_ADAPTER_OWNER
+
+# Outcomes that must not bind a new or reused estimate into CMC this cycle.
+_REJECT_NO_BINDING_OUTCOMES: frozenset[TypedRuntimeProducerOutcomeV1] = frozenset(
+    {
+        TypedRuntimeProducerOutcomeV1.OUT_OF_ORDER_REJECTED,
+        TypedRuntimeProducerOutcomeV1.INVALID_SAMPLE_REJECTED,
+        TypedRuntimeProducerOutcomeV1.HISTORY_GAP_REJECTED,
+        TypedRuntimeProducerOutcomeV1.PERSISTENCE_REJECTED,
+        TypedRuntimeProducerOutcomeV1.MATERIALIZATION_REJECTED,
+    }
+)
+
+_REUSE_ALLOWED_OUTCOMES: frozenset[TypedRuntimeProducerOutcomeV1] = frozenset(
+    {
+        TypedRuntimeProducerOutcomeV1.DUPLICATE_NOOP,
+        TypedRuntimeProducerOutcomeV1.PRODUCED,
+    }
+)
+
+
+class ProductiveTypedBindingFailClosedReasonV1(str, Enum):
+    NONE = "NONE"
+    WARMUP_NO_ESTIMATE = "WARMUP_NO_ESTIMATE"
+    DUPLICATE_WITHOUT_PRIOR_ESTIMATE = "DUPLICATE_WITHOUT_PRIOR_ESTIMATE"
+    OUT_OF_ORDER_REJECTED = "OUT_OF_ORDER_REJECTED"
+    INVALID_SAMPLE_REJECTED = "INVALID_SAMPLE_REJECTED"
+    HISTORY_GAP_REJECTED = "HISTORY_GAP_REJECTED"
+    PERSISTENCE_REJECTED = "PERSISTENCE_REJECTED"
+    MATERIALIZATION_REJECTED = "MATERIALIZATION_REJECTED"
+    RESTART_WITHOUT_ESTIMATE = "RESTART_WITHOUT_ESTIMATE"
+    CYCLE_WITHOUT_SAMPLE_NO_ESTIMATE = "CYCLE_WITHOUT_SAMPLE_NO_ESTIMATE"
+    VALIDATION_REJECTED = "VALIDATION_REJECTED"
+    BINDING_REJECTED = "BINDING_REJECTED"
+    NO_SAMPLE_AND_NO_PRIOR_ESTIMATE = "NO_SAMPLE_AND_NO_PRIOR_ESTIMATE"
+
+
+@dataclass(frozen=True)
+class ProductiveRuntimeCmcTypedBindingTelemetryV1:
+    producer_outcome: str
+    estimate_present: bool
+    estimate_as_of_event_time: Optional[str]
+    observation_count: Optional[int]
+    source_digest: Optional[str]
+    typed_binding_performed: bool
+    legacy_float_adaptation_owner: str
+    fail_closed_reason: str
+    restart_without_estimate: bool
+    max_age_status: str
+    typed_cutover_fail_closed: bool
+    history_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "producer_outcome": self.producer_outcome,
+            "estimate_present": self.estimate_present,
+            "estimate_as_of_event_time": self.estimate_as_of_event_time,
+            "observation_count": self.observation_count,
+            "source_digest": self.source_digest,
+            "typed_binding_performed": self.typed_binding_performed,
+            "legacy_float_adaptation_owner": self.legacy_float_adaptation_owner,
+            "fail_closed_reason": self.fail_closed_reason,
+            "restart_without_estimate": self.restart_without_estimate,
+            "max_age_status": self.max_age_status,
+            "typed_cutover_fail_closed": self.typed_cutover_fail_closed,
+            "history_digest": self.history_digest,
+        }
+
+
+@dataclass(frozen=True)
+class ProductiveRuntimeCmcTypedBindingResultV1:
+    context: CanonicalMarketContextV1
+    producer_result: TypedRuntimeProducerResultV1
+    telemetry: ProductiveRuntimeCmcTypedBindingTelemetryV1
+    typed_cutover_fail_closed: bool
+    bound_estimate: Optional[CanonicalVolatilityEstimateV1]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "telemetry": self.telemetry.to_dict(),
+            "typed_cutover_fail_closed": self.typed_cutover_fail_closed,
+            "bound_estimate_present": self.bound_estimate is not None,
+            "producer_outcome": self.producer_result.outcome.value,
+            "producer_reason": self.producer_result.reason,
+        }
+
+
+def _as_of_iso(estimate: CanonicalVolatilityEstimateV1 | None) -> Optional[str]:
+    if estimate is None:
+        return None
+    as_of = estimate.as_of_event_time
+    if isinstance(as_of, datetime):
+        return as_of.isoformat()
+    return str(as_of)
+
+
+def _fail_reason_for_outcome(
+    outcome: TypedRuntimeProducerOutcomeV1,
+    *,
+    restart_without_estimate: bool,
+    has_reusable_estimate: bool,
+    cycle_without_sample: bool,
+) -> ProductiveTypedBindingFailClosedReasonV1:
+    if restart_without_estimate and not has_reusable_estimate:
+        return ProductiveTypedBindingFailClosedReasonV1.RESTART_WITHOUT_ESTIMATE
+    if outcome is TypedRuntimeProducerOutcomeV1.WARMUP:
+        return ProductiveTypedBindingFailClosedReasonV1.WARMUP_NO_ESTIMATE
+    if outcome is TypedRuntimeProducerOutcomeV1.DUPLICATE_NOOP and not has_reusable_estimate:
+        return ProductiveTypedBindingFailClosedReasonV1.DUPLICATE_WITHOUT_PRIOR_ESTIMATE
+    if outcome is TypedRuntimeProducerOutcomeV1.OUT_OF_ORDER_REJECTED:
+        return ProductiveTypedBindingFailClosedReasonV1.OUT_OF_ORDER_REJECTED
+    if outcome is TypedRuntimeProducerOutcomeV1.INVALID_SAMPLE_REJECTED:
+        return ProductiveTypedBindingFailClosedReasonV1.INVALID_SAMPLE_REJECTED
+    if outcome is TypedRuntimeProducerOutcomeV1.HISTORY_GAP_REJECTED:
+        return ProductiveTypedBindingFailClosedReasonV1.HISTORY_GAP_REJECTED
+    if outcome is TypedRuntimeProducerOutcomeV1.PERSISTENCE_REJECTED:
+        return ProductiveTypedBindingFailClosedReasonV1.PERSISTENCE_REJECTED
+    if outcome is TypedRuntimeProducerOutcomeV1.MATERIALIZATION_REJECTED:
+        return ProductiveTypedBindingFailClosedReasonV1.MATERIALIZATION_REJECTED
+    if cycle_without_sample and not has_reusable_estimate:
+        return ProductiveTypedBindingFailClosedReasonV1.CYCLE_WITHOUT_SAMPLE_NO_ESTIMATE
+    if not has_reusable_estimate:
+        return ProductiveTypedBindingFailClosedReasonV1.NO_SAMPLE_AND_NO_PRIOR_ESTIMATE
+    return ProductiveTypedBindingFailClosedReasonV1.NONE
+
+
+@dataclass
+class CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1:
+    """Persistent host: exactly one typed runtime producer + productive CMC bind."""
+
+    producer: CanonicalVolatilityTypedRuntimeProducerScaffoldV1
+    _restart_without_estimate: bool = False
+    _produced_since_start_or_restore: bool = False
+    _last_telemetry: Optional[ProductiveRuntimeCmcTypedBindingTelemetryV1] = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        venue: str,
+        canonical_instrument_id: str,
+        venue_instrument_id: str,
+        persistence_path: Path | None = None,
+    ) -> "CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1":
+        producer = CanonicalVolatilityTypedRuntimeProducerScaffoldV1.create(
+            venue=venue,
+            canonical_instrument_id=canonical_instrument_id,
+            venue_instrument_id=venue_instrument_id,
+            persistence_path=persistence_path,
+        )
+        return cls(producer=producer)
+
+    @classmethod
+    def restore_from_persistence_v1(
+        cls,
+        *,
+        persistence_path: Path,
+    ) -> "CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1":
+        producer = CanonicalVolatilityTypedRuntimeProducerScaffoldV1.restore_from_persistence_v1(
+            persistence_path=persistence_path,
+        )
+        # History restored; estimate is NOT rematerialized (fail-closed until PRODUCED).
+        return cls(
+            producer=producer,
+            _restart_without_estimate=True,
+            _produced_since_start_or_restore=False,
+        )
+
+    @property
+    def restart_without_estimate(self) -> bool:
+        return bool(self._restart_without_estimate) and not self._produced_since_start_or_restore
+
+    @property
+    def last_telemetry(self) -> Optional[ProductiveRuntimeCmcTypedBindingTelemetryV1]:
+        return self._last_telemetry
+
+    def _reusable_estimate_v1(self) -> Optional[CanonicalVolatilityEstimateV1]:
+        if self.restart_without_estimate:
+            return None
+        port = self.producer.output_port_v1()
+        if not port.ready_for_binding_handoff or port.estimate is None:
+            return None
+        return port.estimate
+
+    def apply_to_market_context_v1(
+        self,
+        context: CanonicalMarketContextV1,
+        *,
+        sample: MarketSampleIdentityV1 | None = None,
+        transport: ObservationTransportMetadataV1 | None = None,
+        venue: Any = None,
+        canonical_instrument_id: Any = None,
+        venue_instrument_id: Any = None,
+        event_time_unix_seconds: Any = None,
+        mark_price: Any = None,
+        is_final: Any = True,
+        ingest_sample: bool = False,
+    ) -> ProductiveRuntimeCmcTypedBindingResultV1:
+        """Ingest optional finalized PT1M sample and bind typed estimate into CMC.
+
+        ``ingest_sample=True`` requires either ``sample`` or raw finalized mark fields.
+        When ``ingest_sample=False``, treats the cycle as without a new sample and may
+        reuse a previously PRODUCED estimate via the producer output port.
+        """
+        cycle_without_sample = not ingest_sample
+        if ingest_sample:
+            producer_result = self.producer.ingest_finalized_pt1m_mark_sample_v1(
+                sample=sample,
+                transport=transport,
+                venue=venue,
+                canonical_instrument_id=canonical_instrument_id,
+                venue_instrument_id=venue_instrument_id,
+                event_time_unix_seconds=event_time_unix_seconds,
+                mark_price=mark_price,
+                is_final=is_final,
+            )
+        else:
+            producer_result = self.producer.on_runtime_cycle_without_sample_v1()
+
+        outcome = producer_result.outcome
+        if (
+            outcome is TypedRuntimeProducerOutcomeV1.PRODUCED
+            and producer_result.estimate is not None
+        ):
+            self._produced_since_start_or_restore = True
+            self._restart_without_estimate = False
+
+        reusable = self._reusable_estimate_v1()
+        bind_estimate: Optional[CanonicalVolatilityEstimateV1] = None
+        fail_reason = ProductiveTypedBindingFailClosedReasonV1.NONE
+
+        if (
+            outcome is TypedRuntimeProducerOutcomeV1.PRODUCED
+            and producer_result.estimate is not None
+        ):
+            bind_estimate = producer_result.estimate
+        elif (
+            outcome in _REUSE_ALLOWED_OUTCOMES or cycle_without_sample
+        ) and outcome not in _REJECT_NO_BINDING_OUTCOMES:
+            if reusable is not None and not self.restart_without_estimate:
+                # Process-internal reuse only; UNRESOLVED_MAX_AGE is not freshness approval.
+                bind_estimate = reusable
+            else:
+                fail_reason = _fail_reason_for_outcome(
+                    outcome,
+                    restart_without_estimate=self.restart_without_estimate,
+                    has_reusable_estimate=False,
+                    cycle_without_sample=cycle_without_sample,
+                )
+        else:
+            fail_reason = _fail_reason_for_outcome(
+                outcome,
+                restart_without_estimate=self.restart_without_estimate,
+                has_reusable_estimate=reusable is not None,
+                cycle_without_sample=cycle_without_sample,
+            )
+            bind_estimate = None
+
+        if self.restart_without_estimate and bind_estimate is None:
+            fail_reason = ProductiveTypedBindingFailClosedReasonV1.RESTART_WITHOUT_ESTIMATE
+
+        bound_context = context
+        typed_binding_performed = False
+        bound_estimate: Optional[CanonicalVolatilityEstimateV1] = None
+
+        if bind_estimate is not None:
+            try:
+                validated = validate_typed_estimate_for_cmc_binding_v1(bind_estimate)
+                # Single validation boundary (typed contract) + single binder.
+                _ = validate_canonical_volatility_estimate_v1(validated)
+                bound_context = bind_typed_canonical_volatility_estimate_into_market_context_v1(
+                    context,
+                    validated,
+                )
+                typed_binding_performed = True
+                bound_estimate = bound_context.canonical_volatility_estimate
+                fail_reason = ProductiveTypedBindingFailClosedReasonV1.NONE
+            except (CanonicalVolatilityTypedConsumptionError, ValueError, TypeError) as exc:
+                typed_binding_performed = False
+                bound_estimate = None
+                bound_context = replace(
+                    context,
+                    canonical_volatility_estimate=None,
+                )
+                fail_reason = ProductiveTypedBindingFailClosedReasonV1.VALIDATION_REJECTED
+                producer_result = TypedRuntimeProducerResultV1(
+                    outcome=producer_result.outcome,
+                    estimate=None,
+                    history_digest=producer_result.history_digest,
+                    observation_count_prices=producer_result.observation_count_prices,
+                    as_of_event_time=producer_result.as_of_event_time,
+                    reason=f"{producer_result.reason};binding_or_validation_rejected:{exc}",
+                    sample_digest=producer_result.sample_digest,
+                )
+        else:
+            # Fail-closed typed cutover: do not carry a prior typed carrier into this cycle.
+            if context.canonical_volatility_estimate is not None:
+                bound_context = replace(context, canonical_volatility_estimate=None)
+            typed_binding_performed = False
+            bound_estimate = None
+
+        typed_cutover_fail_closed = not typed_binding_performed
+        estimate_for_telemetry = bound_estimate
+        telemetry = ProductiveRuntimeCmcTypedBindingTelemetryV1(
+            producer_outcome=outcome.value,
+            estimate_present=estimate_for_telemetry is not None,
+            estimate_as_of_event_time=_as_of_iso(estimate_for_telemetry),
+            observation_count=(
+                None
+                if estimate_for_telemetry is None
+                else int(estimate_for_telemetry.observation_count)
+            ),
+            source_digest=(
+                None
+                if estimate_for_telemetry is None
+                else str(estimate_for_telemetry.source_digest)
+            ),
+            typed_binding_performed=typed_binding_performed,
+            legacy_float_adaptation_owner=LEGACY_FLOAT_ADAPTATION_OWNER,
+            fail_closed_reason=fail_reason.value,
+            restart_without_estimate=self.restart_without_estimate,
+            max_age_status=MAX_AGE_STATUS,
+            typed_cutover_fail_closed=typed_cutover_fail_closed,
+            history_digest=str(self.producer.history.history_digest),
+        )
+        self._last_telemetry = telemetry
+
+        # Typed cutover path eligibility is fail-closed when unbound; legacy float path
+        # remains outside this capability (no global typed-only enforcement).
+        if typed_cutover_fail_closed:
+            _ = evaluate_typed_volatility_binding_eligibility_v1(bound_context)
+
+        return ProductiveRuntimeCmcTypedBindingResultV1(
+            context=bound_context,
+            producer_result=producer_result,
+            telemetry=telemetry,
+            typed_cutover_fail_closed=typed_cutover_fail_closed,
+            bound_estimate=bound_estimate,
+        )
+
+
+def assert_architecture_guards_v1(*, repo_root: Optional[Path] = None) -> dict[str, Any]:
+    """Guards: single adapter/binder/estimator; productive caller outside tests."""
+    root = repo_root or Path(__file__).resolve().parents[3]
+    this_src = (
+        root
+        / "src/trading/master_v2/canonical_volatility_productive_runtime_cmc_typed_binding_v1.py"
+    ).read_text(encoding="utf-8")
+    typed_src = (
+        root
+        / "src/trading/master_v2/canonical_volatility_estimate_typed_consumption_contract_v1.py"
+    ).read_text(encoding="utf-8")
+    binding_src = (
+        root / "src/trading/master_v2/canonical_volatility_binding_and_provenance_transport_v1.py"
+    ).read_text(encoding="utf-8")
+    bridge_src = (
+        root
+        / "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2"
+        / "hardening_cycle_bridge_v2.py"
+    ).read_text(encoding="utf-8")
+    producer_src = (
+        root / "src/trading/master_v2/canonical_volatility_typed_runtime_producer_scaffold_v1.py"
+    ).read_text(encoding="utf-8")
+
+    adapter_def = "def " + "adapt_canonical_volatility_estimate_to_legacy_float_v1("
+    binder_def = "def " + "bind_typed_canonical_volatility_estimate_into_market_context_v1("
+    materializer_def = "def " + "compute_canonical_volatility_estimate_from_mark_prices_v1("
+
+    if typed_src.count(adapter_def) != 1:
+        raise RuntimeError("EXPECTED_EXACTLY_ONE_TYPED_TO_FLOAT_ADAPTER_DEF")
+    if this_src.count(adapter_def) != 0:
+        raise RuntimeError("SECOND_ADAPTER_DEF_IN_PRODUCTIVE_BINDING_FORBIDDEN")
+    if binding_src.count(binder_def) != 1:
+        raise RuntimeError("EXPECTED_EXACTLY_ONE_BIND_TYPED_DEF")
+    if this_src.count(binder_def) != 0:
+        raise RuntimeError("SECOND_BINDER_DEF_IN_PRODUCTIVE_BINDING_FORBIDDEN")
+    if this_src.count(materializer_def) != 0:
+        raise RuntimeError("SECOND_ESTIMATOR_DEF_IN_PRODUCTIVE_BINDING_FORBIDDEN")
+
+    # Productive caller must live in hardening bridge (not only tests).
+    if "CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1" not in bridge_src:
+        raise RuntimeError("PRODUCTIVE_RUNTIME_CALLER_MISSING_IN_HARDENING_BRIDGE")
+    if "apply_to_market_context_v1" not in bridge_src:
+        raise RuntimeError("PRODUCTIVE_RUNTIME_CMC_BIND_CALL_MISSING")
+    if "bind_typed_canonical_volatility_estimate_into_market_context_v1" not in this_src:
+        raise RuntimeError("PRODUCTIVE_BINDING_MUST_CALL_EXISTING_BIND_TYPED")
+
+    code_before_guards = this_src.split("def assert_architecture_guards_v1", 1)[0]
+    if "adapt_canonical_volatility_estimate_to_legacy_float_v1(" in code_before_guards:
+        raise RuntimeError("DIRECT_TYPED_TO_FLOAT_CALL_IN_HOST_FORBIDDEN")
+
+    forbidden_value_extract = "canonical_volatility_estimate.value"
+    if forbidden_value_extract in bridge_src or forbidden_value_extract in code_before_guards:
+        raise RuntimeError("LOCAL_ESTIMATE_VALUE_EXTRACTION_FORBIDDEN")
+
+    if GLOBAL_TYPED_ONLY_ENFORCEMENT or DOUBLE_PLAY_TYPED_CUTOVER or LIVE_AUTHORIZATION:
+        raise RuntimeError("CUTOVER_OR_LIVE_FLAG_DRIFT")
+    if NUMERIC_MAX_AGE_DECIDED or STATIC_RUNTIME_FALLBACK_USED:
+        raise RuntimeError("MAX_AGE_OR_FALLBACK_FLAG_DRIFT")
+    if (
+        SECOND_ESTIMATOR_CREATED
+        or SECOND_BINDING_AUTHORITY_CREATED
+        or SECOND_ADAPTATION_AUTHORITY_CREATED
+    ):
+        raise RuntimeError("SECOND_AUTHORITY_FLAG_DRIFT")
+
+    # Scaffold remains non-wiring; this capability owns productive bind.
+    if (
+        "PRODUCTIVE_BIND_TYPED_CALLER = True"
+        in producer_src.split("assert_capability_guards_v1", 1)[0]
+    ):
+        raise RuntimeError("SCAFFOLD_MUST_REMAIN_NON_WIRING")
+
+    return {
+        "adapter_defs_in_typed": typed_src.count(adapter_def),
+        "binder_defs_in_binding": binding_src.count(binder_def),
+        "productive_bind_typed_caller": PRODUCTIVE_BIND_TYPED_CALLER,
+        "cmc_runtime_wiring": CMC_RUNTIME_WIRING,
+        "double_play_typed_cutover": DOUBLE_PLAY_TYPED_CUTOVER,
+        "global_typed_only_enforcement": GLOBAL_TYPED_ONLY_ENFORCEMENT,
+        "numeric_max_age_decided": NUMERIC_MAX_AGE_DECIDED,
+        "max_age_status": MAX_AGE_STATUS,
+        "legacy_float_adaptation_owner": LEGACY_FLOAT_ADAPTATION_OWNER,
+        "legacy_adaptation_boundary": LEGACY_ADAPTATION_BOUNDARY,
+        "binding_owner_reused": BINDING_OWNER,
+        "productive_runtime_caller_owner": PRODUCTIVE_RUNTIME_CALLER_OWNER,
+        "live_authorization": LIVE_AUTHORIZATION,
+        "hard_stop": HARD_STOP,
+        "guards_pass": True,
+    }
+
+
+def assert_capability_non_goals_v1() -> dict[str, Any]:
+    return {
+        "capability_id": CAPABILITY_ID,
+        "capability_version": CAPABILITY_VERSION,
+        "binding_runtime_owner": BINDING_RUNTIME_OWNER,
+        "productive_bind_typed_caller": PRODUCTIVE_BIND_TYPED_CALLER,
+        "cmc_runtime_wiring": CMC_RUNTIME_WIRING,
+        "double_play_typed_cutover": DOUBLE_PLAY_TYPED_CUTOVER,
+        "global_typed_only_enforcement": GLOBAL_TYPED_ONLY_ENFORCEMENT,
+        "numeric_max_age_decided": NUMERIC_MAX_AGE_DECIDED,
+        "max_age_status": MAX_AGE_STATUS,
+        "live_authorization": LIVE_AUTHORIZATION,
+        "hard_stop": HARD_STOP,
+        "second_estimator_created": SECOND_ESTIMATOR_CREATED,
+        "second_binding_authority_created": SECOND_BINDING_AUTHORITY_CREATED,
+        "second_adaptation_authority_created": SECOND_ADAPTATION_AUTHORITY_CREATED,
+        "static_runtime_fallback_used": STATIC_RUNTIME_FALLBACK_USED,
+        "explicit_legacy_quarantine_changed": EXPLICIT_LEGACY_QUARANTINE_CHANGED,
+        "competing_producers_changed": COMPETING_PRODUCERS_CHANGED,
+        "package_marker": PACKAGE_MARKER,
+        "gaps_remaining": (
+            "C1_G10_NUMERIC_MAX_AGE",
+            "G3_UNTYPED_EXPLICIT_LEGACY_STILL_ADMISSIBLE",
+            "G15_COMPETING_NON_ALIAS_PRODUCERS",
+        ),
+    }
+
+
+__all__ = [
+    "BINDING_RUNTIME_OWNER",
+    "CAPABILITY_ID",
+    "CAPABILITY_VERSION",
+    "CMC_RUNTIME_WIRING",
+    "CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1",
+    "DOUBLE_PLAY_TYPED_CUTOVER",
+    "GLOBAL_TYPED_ONLY_ENFORCEMENT",
+    "HARD_STOP",
+    "LEGACY_FLOAT_ADAPTATION_OWNER",
+    "LIVE_AUTHORIZATION",
+    "MAX_AGE_STATUS",
+    "PACKAGE_MARKER",
+    "PRODUCTIVE_BIND_TYPED_CALLER",
+    "PRODUCTIVE_RUNTIME_CALLER_OWNER",
+    "ProductiveRuntimeCmcTypedBindingResultV1",
+    "ProductiveRuntimeCmcTypedBindingTelemetryV1",
+    "ProductiveTypedBindingFailClosedReasonV1",
+    "assert_architecture_guards_v1",
+    "assert_capability_non_goals_v1",
+]

--- a/tests/trading/master_v2/test_canonical_volatility_productive_runtime_cmc_typed_binding_v1.py
+++ b/tests/trading/master_v2/test_canonical_volatility_productive_runtime_cmc_typed_binding_v1.py
@@ -1,0 +1,408 @@
+"""Focused tests for productive runtime CMC typed binding v1."""
+
+from __future__ import annotations
+
+import ast
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.ops.wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2.hardening_cycle_bridge_v2 import (
+    HardenedBridgeSessionStateV2,
+    run_hardened_bridge_cycle_v2,
+)
+from trading.market_state.distinct_market_observation_acceptor_v1 import (
+    ObservationTransportMetadataV1,
+)
+from trading.market_state.time_sample_epoch_semantics_v1 import (
+    EventTimeInstantV1,
+    MarketSampleIdentityV1,
+)
+from trading.master_v2 import canonical_volatility_estimate_materializer_v1 as materializer
+from trading.master_v2 import (
+    canonical_volatility_estimate_typed_consumption_contract_v1 as typed,
+)
+from trading.master_v2.canonical_market_context_v1 import (
+    FEATURE_CONTRACT_VERSION,
+    BarFinalityStatus,
+    CanonicalMarketContextV1,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+    WarmupStatus,
+)
+from trading.master_v2.canonical_volatility_binding_and_provenance_transport_v1 import (
+    adapt_validated_typed_estimate_to_legacy_float_v1,
+    evaluate_typed_volatility_binding_eligibility_v1,
+)
+from trading.master_v2.canonical_volatility_productive_runtime_cmc_typed_binding_v1 import (
+    CAPABILITY_ID,
+    PACKAGE_MARKER,
+    CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1,
+    ProductiveTypedBindingFailClosedReasonV1,
+    assert_architecture_guards_v1,
+    assert_capability_non_goals_v1,
+)
+from trading.master_v2.canonical_volatility_typed_runtime_producer_scaffold_v1 import (
+    TypedRuntimeProducerOutcomeV1,
+)
+from trading.master_v2.double_play_futures_input import FuturesMarketType
+
+ROOT = Path(__file__).resolve().parents[3]
+VENUE = "okx_europe"
+CANON = "ETH-USD_UM_XPERP-310404"
+VENUE_INST = "ETH-USD_UM_XPERP-310404"
+T0 = 1_700_000_000.0
+
+
+def _price_at(i: int) -> float:
+    return 100.0 * math.exp(0.001 * i)
+
+
+def _sample(i: int, *, mark: float | None = None) -> MarketSampleIdentityV1:
+    return MarketSampleIdentityV1(
+        venue=VENUE,
+        canonical_instrument_id=CANON,
+        venue_instrument_id=VENUE_INST,
+        event_time=EventTimeInstantV1(unix_seconds=T0 + float(i * 60)),
+        mark_price=_price_at(i) if mark is None else mark,
+    )
+
+
+def _host(
+    tmp_path: Path | None = None,
+) -> CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1:
+    path = None if tmp_path is None else tmp_path / "mark_history.json"
+    return CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.create(
+        venue=VENUE,
+        canonical_instrument_id=CANON,
+        venue_instrument_id=VENUE_INST,
+        persistence_path=path,
+    )
+
+
+def _context(**overrides: object) -> CanonicalMarketContextV1:
+    base: dict = {
+        "context_id": "ctx-eth-typed-binding",
+        "instrument_id": CANON,
+        "market_type": FuturesMarketType.PERPETUAL,
+        "trading_epoch": 1,
+        "market_event_time": "2026-06-30T12:00:00+00:00",
+        "decision_time": "2026-06-30T12:00:01+00:00",
+        "bar_interval": "1m",
+        "bar_finality_status": BarFinalityStatus.FINALIZED,
+        "mark_price": 3500.0,
+        "index_price": 3499.5,
+        "best_bid": 3499.8,
+        "best_ask": 3500.2,
+        "spread": 0.4,
+        "volume": 1_250_000.0,
+        "open_interest": 85_000_000.0,
+        "funding_rate": 0.00012,
+        "volatility_estimate": 0.38,
+        "trend_feature_set": {"slope": 0.02},
+        "momentum_feature_set": {"rsi": 55.0},
+        "liquidity_feature_set": {"depth_score": 0.88},
+        "market_structure_feature_set": {"range_ratio": 0.42},
+        "data_integrity_status": DataIntegrityStatus.TRUSTED,
+        "clock_trust_status": ClockTrustStatus.TRUSTED,
+        "warmup_status": WarmupStatus.WARMUP_COMPLETE,
+        "feature_contract_version": FEATURE_CONTRACT_VERSION,
+        "input_digest": "",
+        "canonical_volatility_estimate": None,
+    }
+    base.update(overrides)
+    return CanonicalMarketContextV1(**base)
+
+
+def _ingest_range(
+    host: CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1,
+    context: CanonicalMarketContextV1,
+    start: int,
+    end_inclusive: int,
+):
+    last = None
+    for i in range(start, end_inclusive + 1):
+        last = host.apply_to_market_context_v1(
+            context,
+            sample=_sample(i),
+            transport=ObservationTransportMetadataV1(receive_time=T0 + i * 60 + 0.5),
+            ingest_sample=True,
+        )
+        context = last.context
+    assert last is not None
+    return last
+
+
+def test_a_productive_runtime_caller_exists_outside_tests() -> None:
+    bridge = (
+        ROOT
+        / "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2"
+        / "hardening_cycle_bridge_v2.py"
+    ).read_text(encoding="utf-8")
+    assert "CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1" in bridge
+    assert "apply_to_market_context_v1" in bridge
+    assert "tests/" not in PACKAGE_MARKER
+    assert CAPABILITY_ID.startswith("MASTER_V2_")
+    guards = assert_architecture_guards_v1(repo_root=ROOT)
+    assert guards["guards_pass"] is True
+    assert guards["productive_bind_typed_caller"] is True
+
+
+def test_b_sixty_one_contiguous_pt1m_produced_and_cmc_bound(tmp_path: Path) -> None:
+    host = _host(tmp_path)
+    result = _ingest_range(host, _context(), 0, 60)
+    assert result.producer_result.outcome is TypedRuntimeProducerOutcomeV1.PRODUCED
+    assert result.bound_estimate is not None
+    assert result.context.canonical_volatility_estimate is not None
+    expected_float = adapt_validated_typed_estimate_to_legacy_float_v1(
+        result.context.canonical_volatility_estimate,
+        already_validated=True,
+    )
+    assert result.context.volatility_estimate == expected_float
+    assert result.telemetry.typed_binding_performed is True
+    assert result.telemetry.max_age_status == "UNRESOLVED_MAX_AGE"
+    assert result.telemetry.legacy_float_adaptation_owner
+    assert result.typed_cutover_fail_closed is False
+
+
+def test_c_warmup_fail_closed_no_static_fallback() -> None:
+    host = _host()
+    result = _ingest_range(host, _context(volatility_estimate=0.38), 0, 10)
+    assert result.producer_result.outcome is TypedRuntimeProducerOutcomeV1.WARMUP
+    assert result.context.canonical_volatility_estimate is None
+    assert result.telemetry.typed_binding_performed is False
+    assert result.typed_cutover_fail_closed is True
+    assert (
+        result.telemetry.fail_closed_reason
+        == ProductiveTypedBindingFailClosedReasonV1.WARMUP_NO_ESTIMATE.value
+    )
+    # No static fallback literals applied by this capability.
+    assert result.context.volatility_estimate == 0.38
+    eligibility = evaluate_typed_volatility_binding_eligibility_v1(result.context)
+    assert eligibility.new_directional_exposure_allowed is False
+    assert eligibility.scope_confirmation_allowed is False
+
+
+def test_d_duplicate_no_advance(tmp_path: Path) -> None:
+    host = _host(tmp_path)
+    produced = _ingest_range(host, _context(), 0, 60)
+    digest_before = host.producer.history.history_digest
+    count_before = host.producer.history.observation_count_prices
+    estimate_before = produced.bound_estimate
+    assert estimate_before is not None
+    dup = host.apply_to_market_context_v1(
+        produced.context,
+        sample=_sample(60),
+        transport=ObservationTransportMetadataV1(receive_time=T0 + 60 * 60 + 0.5),
+        ingest_sample=True,
+    )
+    assert dup.producer_result.outcome is TypedRuntimeProducerOutcomeV1.DUPLICATE_NOOP
+    assert host.producer.history.history_digest == digest_before
+    assert host.producer.history.observation_count_prices == count_before
+    assert dup.bound_estimate is not None
+    assert dup.bound_estimate.source_digest == estimate_before.source_digest
+
+
+def test_e_reject_outcomes_no_cmc_binding(tmp_path: Path) -> None:
+    host = _host(tmp_path)
+    warm = _ingest_range(host, _context(), 0, 5)
+    # Out-of-order sample.
+    ooo = host.apply_to_market_context_v1(
+        warm.context,
+        sample=_sample(3),
+        ingest_sample=True,
+    )
+    assert ooo.producer_result.outcome is TypedRuntimeProducerOutcomeV1.OUT_OF_ORDER_REJECTED
+    assert ooo.context.canonical_volatility_estimate is None
+    assert ooo.typed_cutover_fail_closed is True
+    assert (
+        ooo.telemetry.fail_closed_reason
+        == ProductiveTypedBindingFailClosedReasonV1.OUT_OF_ORDER_REJECTED.value
+    )
+
+    # History gap after enough contiguous history to attempt materialization window.
+    host2 = _host(tmp_path / "gap")
+    base = _ingest_range(host2, _context(), 0, 59)
+    gap = host2.apply_to_market_context_v1(
+        base.context,
+        sample=_sample(62),  # skips 60,61 → gap > PT1M vs last=59
+        ingest_sample=True,
+    )
+    assert gap.producer_result.outcome in {
+        TypedRuntimeProducerOutcomeV1.HISTORY_GAP_REJECTED,
+        TypedRuntimeProducerOutcomeV1.OUT_OF_ORDER_REJECTED,
+        TypedRuntimeProducerOutcomeV1.INVALID_SAMPLE_REJECTED,
+    }
+    # Distinct advance with gap in trailing window after enough prices:
+    # ingest index 61 with a hole from continuing after skip may classify as OOO
+    # relative to last accepted; force contiguous then jump.
+    host3 = _host(tmp_path / "gap2")
+    produced = _ingest_range(host3, _context(), 0, 60)
+    assert produced.bound_estimate is not None
+    jumped = host3.apply_to_market_context_v1(
+        produced.context,
+        sample=_sample(63),
+        ingest_sample=True,
+    )
+    assert jumped.producer_result.outcome is TypedRuntimeProducerOutcomeV1.HISTORY_GAP_REJECTED
+    assert jumped.context.canonical_volatility_estimate is None
+    assert jumped.typed_cutover_fail_closed is True
+    assert (
+        jumped.telemetry.fail_closed_reason
+        == ProductiveTypedBindingFailClosedReasonV1.HISTORY_GAP_REJECTED.value
+    )
+
+
+def test_f_cycle_without_sample_reuses_output_port_only(tmp_path: Path) -> None:
+    host = _host(tmp_path)
+    produced = _ingest_range(host, _context(), 0, 60)
+    assert produced.bound_estimate is not None
+    cycle = host.apply_to_market_context_v1(produced.context, ingest_sample=False)
+    assert cycle.producer_result.estimate is None
+    assert "without_new_sample" in cycle.producer_result.reason
+    assert cycle.bound_estimate is not None
+    assert cycle.bound_estimate.source_digest == produced.bound_estimate.source_digest
+    assert cycle.telemetry.typed_binding_performed is True
+
+
+def test_g_restart_history_without_estimate_fail_closed(tmp_path: Path) -> None:
+    path = tmp_path / "hist.json"
+    host = _host(tmp_path)
+    # Point persistence explicitly.
+    host.producer.persistence_path = path
+    produced = _ingest_range(host, _context(), 0, 60)
+    assert produced.bound_estimate is not None
+    assert path.exists()
+
+    restored = (
+        CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.restore_from_persistence_v1(
+            persistence_path=path,
+        )
+    )
+    assert restored.restart_without_estimate is True
+    assert restored.producer.history.observation_count_prices == 61
+    cycle = restored.apply_to_market_context_v1(_context(), ingest_sample=False)
+    assert cycle.bound_estimate is None
+    assert cycle.typed_cutover_fail_closed is True
+    assert (
+        cycle.telemetry.fail_closed_reason
+        == ProductiveTypedBindingFailClosedReasonV1.RESTART_WITHOUT_ESTIMATE.value
+    )
+    # Next PRODUCED clears restart fail-closed.
+    nxt = restored.apply_to_market_context_v1(
+        _context(),
+        sample=_sample(61),
+        transport=ObservationTransportMetadataV1(receive_time=T0 + 61 * 60 + 0.5),
+        ingest_sample=True,
+    )
+    assert nxt.producer_result.outcome is TypedRuntimeProducerOutcomeV1.PRODUCED
+    assert nxt.bound_estimate is not None
+    assert restored.restart_without_estimate is False
+
+
+def test_h_architecture_guards() -> None:
+    guards = assert_architecture_guards_v1(repo_root=ROOT)
+    assert guards["adapter_defs_in_typed"] == 1
+    assert guards["binder_defs_in_binding"] == 1
+    assert guards["double_play_typed_cutover"] is False
+    assert guards["global_typed_only_enforcement"] is False
+    assert guards["numeric_max_age_decided"] is False
+    non_goals = assert_capability_non_goals_v1()
+    assert non_goals["static_runtime_fallback_used"] is False
+    assert non_goals["second_estimator_created"] is False
+    assert "C1_G10_NUMERIC_MAX_AGE" in non_goals["gaps_remaining"]
+
+    host_src = (
+        ROOT
+        / "src/trading/master_v2/canonical_volatility_productive_runtime_cmc_typed_binding_v1.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(host_src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr == "value":
+            # Allow enum .value and telemetry fields; forbid estimate.value adaptation path.
+            pass
+    assert "def adapt_canonical_volatility_estimate_to_legacy_float_v1(" not in host_src
+    assert "def bind_typed_canonical_volatility_estimate_into_market_context_v1(" not in host_src
+    assert "def compute_canonical_volatility_estimate_from_mark_prices_v1(" not in host_src
+
+
+def test_i_offline_research_paths_unchanged() -> None:
+    from trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
+        _REPLAY_DEFAULT_VOL_QUARANTINE,
+    )
+    from trading.master_v2.canonical_volatility_default_quarantine_v1 import (
+        LEGACY_HISTORICAL_BIND_DEFAULT_VALUE,
+        LEGACY_REPLAY_RULES_DEFAULT_VALUE,
+    )
+
+    assert float(LEGACY_REPLAY_RULES_DEFAULT_VALUE) == 0.02
+    assert float(_REPLAY_DEFAULT_VOL_QUARANTINE.legacy_value) == 0.02
+    assert float(LEGACY_HISTORICAL_BIND_DEFAULT_VALUE) == 0.2
+    non_goals = assert_capability_non_goals_v1()
+    assert non_goals["explicit_legacy_quarantine_changed"] is False
+    assert non_goals["competing_producers_changed"] is False
+    feature_regime = (
+        ROOT
+        / "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2"
+        / "feature_regime_pipeline_v2.py"
+    ).read_text(encoding="utf-8")
+    assert "compute_feature_regime_from_mid_prices_v2" in feature_regime
+
+
+def test_j_offline_runtime_estimator_equivalence(tmp_path: Path) -> None:
+    host = _host(tmp_path)
+    prices = [_price_at(i) for i in range(61)]
+    result = _ingest_range(host, _context(), 0, 60)
+    assert result.bound_estimate is not None
+    import pandas as pd
+
+    series = pd.Series(prices, dtype=float)
+    as_of = datetime.fromtimestamp(T0 + 60 * 60, tz=timezone.utc)
+    offline = typed.materialize_typed_canonical_volatility_estimate_v1(
+        series,
+        as_of_event_time=as_of,
+    )
+    assert result.bound_estimate.value == offline.value
+    assert result.bound_estimate.source_digest == offline.source_digest
+    assert result.bound_estimate.observation_count == offline.observation_count
+    p1 = materializer.compute_canonical_volatility_estimate_from_mark_prices_v1(series)
+    assert math.isclose(float(p1.iloc[-1]), float(offline.value), rel_tol=0.0, abs_tol=0.0)
+
+
+def test_productive_bridge_caller_with_pt1m_samples(tmp_path: Path) -> None:
+    state = HardenedBridgeSessionStateV2()
+    state.typed_volatility_persistence_path = tmp_path / "bridge_hist.json"
+    last = None
+    for i in range(61):
+        last = run_hardened_bridge_cycle_v2(
+            state,
+            mid_price=_price_at(i),
+            event_ts_unix=T0 + float(i),
+            session_id="typed-binding-bridge",
+            finalized_pt1m_mark_sample=_sample(i),
+            finalized_pt1m_transport=ObservationTransportMetadataV1(receive_time=T0 + i * 60 + 0.5),
+        )
+    assert last is not None
+    tele = last["canonical_volatility_typed_binding"]
+    assert tele["producer_outcome"] == TypedRuntimeProducerOutcomeV1.PRODUCED.value
+    assert tele["typed_binding_performed"] is True
+    assert tele["estimate_present"] is True
+    assert last["canonical_market_context_typed_estimate_present"] is True
+    assert "canonical_volatility_productive_runtime_cmc_typed_binding" in last["call_graph"]
+
+
+def test_productive_bridge_warmup_typed_fail_closed() -> None:
+    state = HardenedBridgeSessionStateV2()
+    cycle = run_hardened_bridge_cycle_v2(
+        state,
+        mid_price=3500.0,
+        event_ts_unix=T0,
+        session_id="typed-binding-warmup",
+        finalized_pt1m_mark_sample=_sample(0),
+    )
+    tele = cycle["canonical_volatility_typed_binding"]
+    assert tele["typed_binding_performed"] is False
+    assert tele["typed_cutover_fail_closed"] is True
+    assert tele["max_age_status"] == "UNRESOLVED_MAX_AGE"


### PR DESCRIPTION
## Summary
- Hosts exactly one `CanonicalVolatilityTypedRuntimeProducerScaffoldV1` and productively calls `bind_typed_canonical_volatility_estimate_into_market_context_v1` into `CanonicalMarketContextV1` from `hardening_cycle_bridge_v2`.
- On `PRODUCED` (and process-internal reuse via the producer output port), validates via the existing boundary and atomically sets typed estimate + adapted legacy float; reject/warmup/restart paths stay fail-closed for the typed cutover path.
- Does not introduce a second estimator/binder/adapter, numeric max-age, global typed-only enforcement, Double-Play typed cutover, or competing-producer / offline-legacy mutations.

## Test plan
- [x] Focused tests A–J in `test_canonical_volatility_productive_runtime_cmc_typed_binding_v1.py`
- [x] Related producer/binding/quarantine/typed-consumption + wallclock hardening tests (excluding pre-existing `test_fill_ledger_contract_canonical_attr` failure also present on origin/main)
- [x] PR_BOUNDED_FULL selector targets + focused volatility suite (863 passed / ~53s)
- [x] `ruff format --check` / `ruff check`
- [x] Docs token scan + docs reference targets
- [x] Strategy smoke CLI tests (49 passed, 1 skipped)
- [ ] GitHub CI confirmation after PR open (do not merge yet)


Made with [Cursor](https://cursor.com)