### PR TITLE
feat(master-v2): Double-Play runtime typed volatility presence gate v1

### DIFF
--- a/config/governance/technical_canonical_wiring_authorization_v1.json
+++ b/config/governance/technical_canonical_wiring_authorization_v1.json
@@ -755,7 +755,10 @@
     "src/trading/master_v2/canonical_volatility_productive_runtime_cmc_typed_binding_v1.py",
     "tests/trading/master_v2/test_canonical_volatility_productive_runtime_cmc_typed_binding_v1.py",
     "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1.md",
-    "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2/hardening_cycle_bridge_v2.py"
+    "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2/hardening_cycle_bridge_v2.py",
+    "src/trading/master_v2/double_play_runtime_typed_volatility_presence_gate_v1.py",
+    "tests/trading/master_v2/test_double_play_runtime_typed_volatility_presence_gate_v1.py",
+    "docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1.md"
   ],
   "allowed_surface_classes": [
     "TECHNICAL_CANONICAL_REPLAY_INPUT_BUILDER_WIRING",
@@ -904,7 +907,8 @@
     "C3 DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1: authorize exact-file Master-V2 confirmation-integration adapter, legacy DA quarantine comments, and C3 contract tests. No runtime activation, no config/threshold mutation, no broad master_v2 grant.",
     "C4 POST_CONFIRMATION_SURVIVAL_SUITABILITY_COMPOSITION_BINDING_V1: authorize post-C3 Survival/Suitability/Composition binding guards, Research C1 DISTINCT wiring, C4 contract tests and docs. Composition remains sole CONFIRMED admissibility gate. No runtime activation, no parameter/volatility mutation.",
     "MASTER_V2_CANONICAL_VOLATILITY_TYPED_RUNTIME_PRODUCER_SCAFFOLD_V1: authorize exact-file typed runtime producer scaffold, mark-history host, materializer observation_count provenance helper, typed-factory provenance reuse, focused tests and docs. No runtime cutover, no Double-Play/CMC bind_typed wiring, no parameter-value decision, no broad master_v2 grant.",
-    "MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1: authorize exact-file productive Producer→bind_typed→CMC host, hardening-bridge productive caller wiring, focused tests and docs. Reuses existing producer/validation/binding/adapter authorities. No Double-Play typed cutover, no numeric max-age, no global typed-only enforcement, no competing-producer mutation, no parameter research, no live/orders."
+    "MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1: authorize exact-file productive Producer→bind_typed→CMC host, hardening-bridge productive caller wiring, focused tests and docs. Reuses existing producer/validation/binding/adapter authorities. No Double-Play typed cutover, no numeric max-age, no global typed-only enforcement, no competing-producer mutation, no parameter research, no live/orders.",
+    "MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1: authorize exact-file productive Double-Play typed volatility presence gate, replay opt-in flag wiring, hardening-bridge productive gate consumption, eligibility-result reuse on CMC typed binding host, focused tests and docs. Reuses existing eligibility/validation/binding/adapter authorities. No Direct-Typed consumer refactor, no numeric max-age, no global typed-only enforcement, no offline Replay/Research/Scenario default mutation, no parameter research, no live/orders."
   ],
   "pr_specific_exception": false,
   "required_check_waiver": false,
@@ -927,6 +931,7 @@
     "DIRECTIONAL_ASSESSMENT_CONFIRMATION_INTEGRATION_V1 exact-file allowlist for C3 adapter + DA quarantine + C3 tests (offline confirmation integration only)",
     "POST_CONFIRMATION_SURVIVAL_SUITABILITY_COMPOSITION_BINDING_V1 exact-file allowlist for C4 binding guards + Research C1 DISTINCT + C4 tests/docs (offline binding only)",
     "CANONICAL_VOLATILITY_TYPED_RUNTIME_PRODUCER_SCAFFOLD_V1 exact-file allowlist for offline producer scaffold + mark history + observation_count provenance (no cutover/wiring)",
-    "CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1 exact-file allowlist for productive CMC typed binding host + hardening bridge caller (CMC transport only; no Double-Play typed cutover)"
+    "CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1 exact-file allowlist for productive CMC typed binding host + hardening bridge caller (CMC transport only; no Double-Play typed cutover)",
+    "DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1 exact-file allowlist for productive typed presence gate + replay opt-in + hardening bridge consumption + tests/docs (no Direct-Typed consumer; no numeric max-age; no global typed-only)"
   ]
 }

--- a/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1.md
+++ b/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1.md
@@ -3,7 +3,7 @@
 ---
 docs_token: DOCS_TOKEN_MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1
 STATUS: CAPABILITY_AVAILABLE
-scope: productive Producer→bind_typed→CMC edge; non-authorizing for Double-Play typed cutover
+scope: productive Producer→bind_typed→CMC edge; typed cutover closed by presence-gate capability
 LIVE_AUTHORIZED: false
 ORDERS_ALLOWED: false
 RUNTIME_WIRING: true
@@ -21,7 +21,11 @@ HARD_STOP: true
 > mark samples, and on `PRODUCED` binds via the existing
 > `bind_typed_canonical_volatility_estimate_into_market_context_v1` into
 > `CanonicalMarketContextV1`. Does **not** decide numeric max-age, promote
-> defaults, cut over Double-Play typed-only, or replace competing producers.
+> defaults, or replace competing producers. Double-Play typed cutover authority
+> is owned by
+> `MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1`
+> (this module remains `DOUBLE_PLAY_TYPED_CUTOVER=false` and always returns
+> typed binding eligibility for that gate to consume).
 
 ## Machine summary
 

--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1.md
@@ -1,0 +1,94 @@
+# MASTER_V2 Double Play Runtime Typed Volatility Presence Gate v1
+
+---
+docs_token: DOCS_TOKEN_MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1
+STATUS: CAPABILITY_AVAILABLE
+scope: productive Double-Play typed presence gate; closes typed cutover without Direct-Typed consumers
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+RUNTIME_WIRING: true
+DOUBLE_PLAY_TYPED_CUTOVER: true
+GLOBAL_TYPED_ONLY_ENFORCEMENT: false
+NUMERIC_MAX_AGE_DECIDED: false
+PARAMETER_EFFECT: false
+HARD_STOP: true
+---
+
+> **Productive Double-Play typed cutover (OPTION_2 presence gate).** Scope,
+> Boundary, and Entry authority run only when
+> `CanonicalMarketContextV1.canonical_volatility_estimate` is present, validated,
+> and atomically synchronized with the legacy float. The adapted float remains
+> the numeric input for existing consumers. Exit &#47; risk &#47; safety authority is
+> preserved. Offline Replay 0.02 &#47; Research 0.2 &#47; Scenario paths stay unchanged.
+
+## Machine summary
+
+```
+CAPABILITY_ID=MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1
+PRESENCE_GATE_OWNER=evaluate_double_play_runtime_typed_volatility_presence_gate_v1
+ELIGIBILITY_OWNER=evaluate_typed_volatility_binding_eligibility_v1
+PRODUCTIVE_RUNTIME_CALLER=hardening_cycle_bridge_v2.run_hardened_bridge_cycle_v2
+BINDING_OWNER=bind_typed_canonical_volatility_estimate_into_market_context_v1
+LEGACY_ADAPTATION=adapt_canonical_volatility_estimate_to_legacy_float_v1
+FLOAT_RESOLUTION=resolve_legacy_volatility_float_for_consumer_v1
+REASON_CODE_TYPED_MISSING=TYPED_VOLATILITY_ESTIMATE_MISSING
+DOUBLE_PLAY_TYPED_CUTOVER=true
+GLOBAL_TYPED_ONLY_ENFORCEMENT=false
+NUMERIC_MAX_AGE_DECIDED=false
+SECOND_ESTIMATOR_CREATED=false
+SECOND_ADAPTER_CREATED=false
+SECOND_VALIDATOR_CREATED=false
+LOCAL_TYPED_VALUE_EXTRACTION_CREATED=false
+LIVE_AUTHORIZATION=false
+HARD_STOP=true
+```
+
+## Semantics
+
+1. **Presence gate (productive only)** — Before productive Double-Play
+   scope &#47; boundary &#47; entry evaluation,
+   `canonical_volatility_estimate is not None` and existing typed validation plus
+   typed&#47;float consistency must succeed. Reuses
+   `evaluate_typed_volatility_binding_eligibility_v1`; the eligibility result is
+   never discarded.
+
+2. **Typed absent + legacy float present** — Fail-closed with
+   `TYPED_VOLATILITY_ESTIMATE_MISSING`. No new entry, no scope initialization from
+   the float, no dynamic boundary update from the float, no alpha state
+   progression. `feature_regime` volatility remains NON_ALIAS and cannot authorize
+   productive Double Play when typed is absent.
+
+3. **Exit &#47; risk &#47; safety independence** — Safety Exit, Hard-Risk Reduce,
+   Position Reconciliation, and Mandatory Exit&#47;Reduce remain executable when an
+   open position or protection signal requires them. The gate blocks alpha
+   authority, not protection authority.
+
+4. **Lifecycle** — Warmup &#47; restart without estimate &#47; duplicate without prior &#47;
+   out-of-order &#47; history gap &#47; persistence &#47; materialization failures remain
+   fail-closed until a valid typed estimate is bound. Duplicate&#47;cycle reuse with a
+   valid prior keeps existing reuse semantics. `UNRESOLVED_MAX_AGE` stays
+   telemetry only — no numeric max-age policy.
+
+5. **Isolation** — Opt-in via
+   `require_productive_typed_volatility_presence_gate=True` on the productive
+   bridge path only. Offline Replay default 0.02, Research 0.2, Scenario HIGH_VOL
+   0.08, and explicit quarantine paths remain unchanged. No global typed-only rule.
+
+## Owners
+
+| Artifact | Path |
+|---|---|
+| Presence gate | `src&#47;trading&#47;master_v2&#47;double_play_runtime_typed_volatility_presence_gate_v1.py` |
+| Productive caller | `src&#47;ops&#47;wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2&#47;hardening_cycle_bridge_v2.py` |
+| Spec | this document |
+| Tests | `tests&#47;trading&#47;master_v2&#47;test_double_play_runtime_typed_volatility_presence_gate_v1.py` |
+
+## Explicit non-goals
+
+- no numeric max-age policy
+- no global typed-only enforcement
+- no Direct-Typed consumer refactor in Scope &#47; Rules &#47; Bridge
+- no second estimator &#47; binder &#47; adapter &#47; validator
+- no Replay 0.02 &#47; Research 0.2 &#47; Scenario mutation
+- no Live &#47; Testnet &#47; order routing
+- no Survival-Ratio &#47; Suitability &#47; ATR &#47; feature_regime semantic change

--- a/src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2/hardening_cycle_bridge_v2.py
+++ b/src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2/hardening_cycle_bridge_v2.py
@@ -75,6 +75,10 @@ from trading.master_v2.canonical_market_context_v1 import (
 from trading.master_v2.canonical_volatility_productive_runtime_cmc_typed_binding_v1 import (
     CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1,
 )
+from trading.master_v2.double_play_runtime_typed_volatility_presence_gate_v1 import (
+    demote_trading_gate_for_typed_presence_failure_v1,
+    evaluate_double_play_runtime_typed_volatility_presence_gate_v1,
+)
 from trading.master_v2.canonical_scope_initialization_v1 import (
     CANONICAL_SCOPE_INITIALIZATION_LAYER_VERSION,
     CanonicalScopeInitializationPolicyV1,
@@ -519,6 +523,17 @@ def run_hardened_bridge_cycle_v2(
     state.last_typed_volatility_binding_telemetry = typed_binding.telemetry.to_dict()
     _ = input_digest  # retained for provenance continuity with prior bridge evidence shape
 
+    # Productive Double-Play typed cutover: consume host eligibility; do not discard.
+    presence_gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        market_context,
+        eligibility=typed_binding.typed_binding_eligibility,
+    )
+    effective_trading_gate = safety.trading_gate_enum
+    if not presence_gate.alpha_scope_entry_authority_allowed:
+        effective_trading_gate = demote_trading_gate_for_typed_presence_failure_v1(
+            safety.trading_gate_enum
+        )
+
     replay_input = build_integrated_offline_replay_input_v1(
         replay_id=f"{session_id}-{cycle_id}",
         instrument_id=state.instrument_id,
@@ -566,7 +581,7 @@ def run_hardened_bridge_cycle_v2(
         direction_state=state.direction_state,
         position_state=state.position_state,
         reconciliation_state=ReconciliationState.RECONCILED,
-        trading_gate=safety.trading_gate_enum,
+        trading_gate=effective_trading_gate,
         safety_mode=safety.safety_mode_enum,
         existing_position_side=state.existing_position_side,
         venue_flat=state.venue_flat,
@@ -586,6 +601,8 @@ def run_hardened_bridge_cycle_v2(
         expected_component_contracts=_component_versions(),
         context_reference=f"hardening-v2-context-epoch-{state.trading_epoch}",
         now_tick=state.cycle_index,
+        require_productive_typed_volatility_presence_gate=True,
+        productive_typed_volatility_binding_eligibility=(typed_binding.typed_binding_eligibility),
     )
 
     replay = run_integrated_offline_trading_logic_replay_v1(replay_input)
@@ -715,6 +732,7 @@ def run_hardened_bridge_cycle_v2(
         "canonical_market_context_typed_estimate_present": (
             market_context.canonical_volatility_estimate is not None
         ),
+        "double_play_typed_volatility_presence_gate": presence_gate.to_dict(),
         "config_digest": config_digest,
         "price_basis": basis.to_dict(),
         "market_data_reference": basis.market_data_reference,

--- a/src/trading/master_v2/canonical_volatility_productive_runtime_cmc_typed_binding_v1.py
+++ b/src/trading/master_v2/canonical_volatility_productive_runtime_cmc_typed_binding_v1.py
@@ -23,7 +23,10 @@ from trading.market_state.distinct_market_observation_acceptor_v1 import (
     ObservationTransportMetadataV1,
 )
 from trading.market_state.time_sample_epoch_semantics_v1 import MarketSampleIdentityV1
-from trading.master_v2.canonical_market_context_v1 import CanonicalMarketContextV1
+from trading.master_v2.canonical_market_context_v1 import (
+    CanonicalMarketContextEligibilityV1,
+    CanonicalMarketContextV1,
+)
 from trading.master_v2.canonical_volatility_binding_and_provenance_transport_v1 import (
     BINDING_OWNER,
     LEGACY_ADAPTATION_BOUNDARY,
@@ -147,6 +150,9 @@ class ProductiveRuntimeCmcTypedBindingResultV1:
     telemetry: ProductiveRuntimeCmcTypedBindingTelemetryV1
     typed_cutover_fail_closed: bool
     bound_estimate: Optional[CanonicalVolatilityEstimateV1]
+    # Eligibility is always computed and must be consumed by the presence gate —
+    # never discarded.
+    typed_binding_eligibility: CanonicalMarketContextEligibilityV1
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -155,6 +161,15 @@ class ProductiveRuntimeCmcTypedBindingResultV1:
             "bound_estimate_present": self.bound_estimate is not None,
             "producer_outcome": self.producer_result.outcome.value,
             "producer_reason": self.producer_result.reason,
+            "typed_binding_eligibility_block_reasons": [
+                r.value for r in self.typed_binding_eligibility.block_reasons
+            ],
+            "typed_binding_eligibility_scope_allowed": (
+                self.typed_binding_eligibility.scope_confirmation_allowed
+            ),
+            "typed_binding_eligibility_exposure_allowed": (
+                self.typed_binding_eligibility.new_directional_exposure_allowed
+            ),
         }
 
 
@@ -398,10 +413,9 @@ class CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1:
         )
         self._last_telemetry = telemetry
 
-        # Typed cutover path eligibility is fail-closed when unbound; legacy float path
-        # remains outside this capability (no global typed-only enforcement).
-        if typed_cutover_fail_closed:
-            _ = evaluate_typed_volatility_binding_eligibility_v1(bound_context)
+        # Always compute eligibility and return it for the presence gate to consume.
+        # This capability does not itself authorize Double-Play cutover.
+        typed_binding_eligibility = evaluate_typed_volatility_binding_eligibility_v1(bound_context)
 
         return ProductiveRuntimeCmcTypedBindingResultV1(
             context=bound_context,
@@ -409,6 +423,7 @@ class CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1:
             telemetry=telemetry,
             typed_cutover_fail_closed=typed_cutover_fail_closed,
             bound_estimate=bound_estimate,
+            typed_binding_eligibility=typed_binding_eligibility,
         )
 
 

--- a/src/trading/master_v2/double_play_runtime_typed_volatility_presence_gate_v1.py
+++ b/src/trading/master_v2/double_play_runtime_typed_volatility_presence_gate_v1.py
@@ -1,0 +1,576 @@
+"""Double-Play runtime typed volatility presence gate v1.
+
+Closes productive Double-Play typed cutover: Scope / Boundary / Entry authority
+may run only when CMC.canonical_volatility_estimate is present, validated, and
+atomically synchronized with the legacy float. Reuses the existing typed
+eligibility authority — never discards its result. Does not invent max-age,
+global typed-only enforcement, a second estimator/adapter/validator, or
+offline/research/scenario mutations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+from trading.master_v2.canonical_market_context_v1 import (
+    CanonicalMarketContextBindingOutcome,
+    CanonicalMarketContextBlockReason,
+    CanonicalMarketContextEligibilityV1,
+    CanonicalMarketContextV1,
+)
+from trading.master_v2.canonical_volatility_binding_and_provenance_transport_v1 import (
+    collect_typed_volatility_binding_block_reasons_v1,
+    evaluate_typed_volatility_binding_eligibility_v1,
+)
+from trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1 import (
+    LEGACY_ADAPTER_OWNER,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import (
+    DecisionOutcome,
+    DoublePlayEntryExitPolicyInputV0,
+    DoublePlayEntryExitPolicyV0,
+    EntryEligibility,
+    EntryExitDirectionState,
+    EntryExitPolicyDecisionV0,
+    ExistingPositionSide,
+    PositionState,
+    PolicySignalV0,
+    ReconciliationState,
+    SafetyMode,
+    TradingGate,
+    compute_entry_exit_policy_input_digest,
+    evaluate_double_play_entry_exit_policy_v0,
+)
+from trading.master_v2.double_play_composition_matrix_v1 import (
+    CompositionChopGuardStatus,
+    CompositionConflictStatus,
+    CompositionDirectionState,
+    CompositionSelectedSide,
+    CompositionStatus,
+    DoublePlayCompositionResultV1,
+    PositionManagementContext,
+    SuitabilityResultRefV1,
+)
+from trading.master_v2.directional_assessment_v1 import DirectionalAssessmentSide
+from trading.master_v2.suitability_binding_v1 import (
+    DirectionalAssessmentRefV1,
+    SuitabilityBindingStatus,
+    SurvivalResultRefV1,
+)
+from trading.master_v2.survival_assessment_v1 import SurvivalAssessmentStatus
+from trading.master_v2.canonical_market_context_v1 import (
+    ClockTrustStatus,
+    DataIntegrityStatus,
+)
+
+PACKAGE_MARKER = "MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1=true"
+
+CAPABILITY_ID = "MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1"
+CAPABILITY_VERSION = "double_play_runtime_typed_volatility_presence_gate/v1"
+PRESENCE_GATE_OWNER = "trading.master_v2.double_play_runtime_typed_volatility_presence_gate_v1"
+PRODUCTIVE_RUNTIME_CALLER_OWNER = (
+    "ops.wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2"
+    ".hardening_cycle_bridge_v2"
+)
+
+# Explicit gate reason code (deterministic, reconstructible).
+TYPED_VOLATILITY_ESTIMATE_MISSING_REASON = "TYPED_VOLATILITY_ESTIMATE_MISSING"
+
+DOUBLE_PLAY_TYPED_CUTOVER = True
+GLOBAL_TYPED_ONLY_ENFORCEMENT = False
+NUMERIC_MAX_AGE_DECIDED = False
+NUMERIC_MAX_AGE_POLICY_CREATED = False
+LIVE_AUTHORIZATION = False
+HARD_STOP = True
+SECOND_ESTIMATOR_CREATED = False
+SECOND_ADAPTER_CREATED = False
+SECOND_VALIDATOR_CREATED = False
+LOCAL_TYPED_VALUE_EXTRACTION_CREATED = False
+VOLATILITY_SEMANTICS_CHANGED = False
+OFFLINE_REPLAY_LEGACY_DEFAULTS_UNCHANGED = True
+RESEARCH_LEGACY_FALLBACKS_UNCHANGED = True
+SCENARIO_REPLAY_UNCHANGED = True
+
+SINGLE_ESTIMATOR_AUTHORITY_PRESERVED = True
+SINGLE_VALIDATION_BOUNDARY_PRESERVED = True
+SINGLE_TYPED_FLOAT_ADAPTER_AUTHORITY_PRESERVED = True
+LEGACY_FLOAT_ADAPTATION_OWNER = LEGACY_ADAPTER_OWNER
+
+_TYPED_BLOCK_REASONS: frozenset[CanonicalMarketContextBlockReason] = frozenset(
+    {
+        CanonicalMarketContextBlockReason.TYPED_VOLATILITY_ESTIMATE_MISSING,
+        CanonicalMarketContextBlockReason.TYPED_VOLATILITY_ESTIMATE_INVALID,
+        CanonicalMarketContextBlockReason.TYPED_VOLATILITY_LEGACY_FLOAT_MISMATCH,
+    }
+)
+
+
+@dataclass(frozen=True)
+class DoublePlayTypedVolatilityPresenceGateResultV1:
+    """Presence-gate outcome; always carries the reused eligibility result."""
+
+    eligibility: CanonicalMarketContextEligibilityV1
+    typed_estimate_present: bool
+    typed_validation_ok: bool
+    typed_float_consistent: bool
+    alpha_scope_entry_authority_allowed: bool
+    exit_risk_safety_authority_preserved: bool
+    block_reasons: Tuple[CanonicalMarketContextBlockReason, ...]
+    reason_codes: Tuple[str, ...]
+    double_play_typed_cutover: bool = DOUBLE_PLAY_TYPED_CUTOVER
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "alpha_scope_entry_authority_allowed": self.alpha_scope_entry_authority_allowed,
+            "block_reasons": [r.value for r in self.block_reasons],
+            "double_play_typed_cutover": self.double_play_typed_cutover,
+            "exit_risk_safety_authority_preserved": self.exit_risk_safety_authority_preserved,
+            "reason_codes": list(self.reason_codes),
+            "typed_estimate_present": self.typed_estimate_present,
+            "typed_float_consistent": self.typed_float_consistent,
+            "typed_validation_ok": self.typed_validation_ok,
+            "eligibility_trading_decision_allowed": (self.eligibility.trading_decision_allowed),
+            "eligibility_scope_confirmation_allowed": (self.eligibility.scope_confirmation_allowed),
+            "eligibility_new_directional_exposure_allowed": (
+                self.eligibility.new_directional_exposure_allowed
+            ),
+            "eligibility_observation_and_reconciliation_only": (
+                self.eligibility.observation_and_reconciliation_only
+            ),
+        }
+
+
+def evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+    context: CanonicalMarketContextV1,
+    *,
+    binding_outcome: CanonicalMarketContextBindingOutcome = (
+        CanonicalMarketContextBindingOutcome.ACCEPTED
+    ),
+    eligibility: CanonicalMarketContextEligibilityV1 | None = None,
+) -> DoublePlayTypedVolatilityPresenceGateResultV1:
+    """Evaluate productive DP presence gate; reuse (never discard) eligibility."""
+    typed_blocks = collect_typed_volatility_binding_block_reasons_v1(context)
+    elig = eligibility
+    if elig is None:
+        elig = evaluate_typed_volatility_binding_eligibility_v1(
+            context,
+            binding_outcome=binding_outcome,
+        )
+    else:
+        # Precomputed eligibility must already include typed blocks; do not drop it.
+        missing = [b for b in typed_blocks if b not in elig.block_reasons]
+        if missing:
+            elig = evaluate_typed_volatility_binding_eligibility_v1(
+                context,
+                binding_outcome=binding_outcome,
+            )
+
+    typed_present = context.canonical_volatility_estimate is not None
+    typed_invalid = (
+        CanonicalMarketContextBlockReason.TYPED_VOLATILITY_ESTIMATE_INVALID in typed_blocks
+    )
+    typed_mismatch = (
+        CanonicalMarketContextBlockReason.TYPED_VOLATILITY_LEGACY_FLOAT_MISMATCH in typed_blocks
+    )
+    typed_missing = (
+        CanonicalMarketContextBlockReason.TYPED_VOLATILITY_ESTIMATE_MISSING in typed_blocks
+    )
+
+    alpha_ok = (
+        typed_present
+        and not typed_invalid
+        and not typed_mismatch
+        and not typed_missing
+        and elig.scope_confirmation_allowed
+        and elig.new_directional_exposure_allowed
+        and not any(b in _TYPED_BLOCK_REASONS for b in elig.block_reasons)
+    )
+
+    reason_codes: list[str] = []
+    if typed_missing or not typed_present:
+        reason_codes.append(TYPED_VOLATILITY_ESTIMATE_MISSING_REASON)
+    for block in typed_blocks:
+        if block.value not in reason_codes:
+            reason_codes.append(block.value)
+
+    return DoublePlayTypedVolatilityPresenceGateResultV1(
+        eligibility=elig,
+        typed_estimate_present=typed_present,
+        typed_validation_ok=typed_present and not typed_invalid,
+        typed_float_consistent=typed_present and not typed_mismatch and not typed_invalid,
+        alpha_scope_entry_authority_allowed=alpha_ok,
+        exit_risk_safety_authority_preserved=True,
+        block_reasons=tuple(typed_blocks),
+        reason_codes=tuple(reason_codes),
+    )
+
+
+def demote_trading_gate_for_typed_presence_failure_v1(trading_gate: TradingGate) -> TradingGate:
+    """Block new entry/increase; preserve EXIT_ONLY / BLOCKED for protection."""
+    if trading_gate in (TradingGate.ENTRY_ALLOWED, TradingGate.INCREASE_ALLOWED):
+        return TradingGate.EXIT_ONLY
+    return trading_gate
+
+
+def protection_authority_required_v1(
+    *,
+    position_state: PositionState,
+    existing_position_side: ExistingPositionSide,
+    reconciliation_state: ReconciliationState,
+    safety_exit_signal: PolicySignalV0,
+    hard_risk_reduction_signal: PolicySignalV0,
+    scope_adverse_exit_signal: PolicySignalV0,
+    profit_protection_signal: PolicySignalV0,
+    time_exit_signal: PolicySignalV0,
+    strategy_invalidation_signal: PolicySignalV0,
+    safety_mode: SafetyMode,
+) -> bool:
+    """True when exit / risk / safety / reconcile authority must still run."""
+    if safety_exit_signal.triggered or hard_risk_reduction_signal.triggered:
+        return True
+    if scope_adverse_exit_signal.triggered or profit_protection_signal.triggered:
+        return True
+    if time_exit_signal.triggered or strategy_invalidation_signal.triggered:
+        return True
+    if reconciliation_state is not ReconciliationState.RECONCILED:
+        return True
+    if position_state in (
+        PositionState.OPEN_FULL,
+        PositionState.OPEN_PARTIAL,
+        PositionState.REDUCING_PARTIAL,
+        PositionState.EXIT_PENDING,
+        PositionState.SUBMISSION_UNKNOWN,
+        PositionState.RECONCILIATION_REQUIRED,
+    ):
+        return True
+    if existing_position_side is not ExistingPositionSide.NONE:
+        return True
+    if safety_mode in (SafetyMode.EXIT_ONLY, SafetyMode.BLOCKED, SafetyMode.DEGRADED):
+        return True
+    return False
+
+
+def _non_authorizing_observe_composition_v1(
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+    context_reference: str,
+    previous_direction_state: CompositionDirectionState,
+    position_management_context: PositionManagementContext,
+) -> DoublePlayCompositionResultV1:
+    """Minimal OBSERVE composition for protection-only entry/exit evaluation.
+
+    Does not authorize scope/entry; carries identity only so safety/hard-risk
+    precedence can run without inventing alpha authority.
+    """
+    empty = ""
+    bull_a = DirectionalAssessmentRefV1(
+        assessment_id="presence-gate-protection-bull",
+        semantic_digest=empty,
+        trading_epoch=trading_epoch,
+        side=DirectionalAssessmentSide.LONG,
+        status="observe",
+    )
+    bear_a = DirectionalAssessmentRefV1(
+        assessment_id="presence-gate-protection-bear",
+        semantic_digest=empty,
+        trading_epoch=trading_epoch,
+        side=DirectionalAssessmentSide.SHORT,
+        status="observe",
+    )
+    bull_s = SurvivalResultRefV1(
+        survival_id="presence-gate-protection-bull-survival",
+        semantic_digest=empty,
+        trading_epoch=trading_epoch,
+        side=DirectionalAssessmentSide.LONG,
+        status=SurvivalAssessmentStatus.BLOCKED,
+    )
+    bear_s = SurvivalResultRefV1(
+        survival_id="presence-gate-protection-bear-survival",
+        semantic_digest=empty,
+        trading_epoch=trading_epoch,
+        side=DirectionalAssessmentSide.SHORT,
+        status=SurvivalAssessmentStatus.BLOCKED,
+    )
+    bull_u = SuitabilityResultRefV1(
+        suitability_id="presence-gate-protection-bull-suit",
+        semantic_digest=empty,
+        trading_epoch=trading_epoch,
+        side=DirectionalAssessmentSide.LONG,
+        status=SuitabilityBindingStatus.BLOCKED,
+    )
+    bear_u = SuitabilityResultRefV1(
+        suitability_id="presence-gate-protection-bear-suit",
+        semantic_digest=empty,
+        trading_epoch=trading_epoch,
+        side=DirectionalAssessmentSide.SHORT,
+        status=SuitabilityBindingStatus.BLOCKED,
+    )
+    return DoublePlayCompositionResultV1(
+        composition_id="presence-gate-protection-observe",
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+        bull_assessment_ref=bull_a,
+        bear_assessment_ref=bear_a,
+        bull_survival_ref=bull_s,
+        bear_survival_ref=bear_s,
+        bull_suitability_ref=bull_u,
+        bear_suitability_ref=bear_u,
+        previous_direction_state=previous_direction_state,
+        position_management_context=position_management_context,
+        composition_status=CompositionStatus.OBSERVE,
+        selected_side=CompositionSelectedSide.NONE,
+        conflict_status=CompositionConflictStatus.NONE,
+        chop_guard_status=CompositionChopGuardStatus.NONE,
+        reason_codes=(TYPED_VOLATILITY_ESTIMATE_MISSING_REASON, "protection_only_observe"),
+        policy_version="double_play_composition_matrix_policy_v1",
+        input_digest=empty,
+        semantic_digest=empty,
+    )
+
+
+def evaluate_protection_authority_when_typed_absent_v1(
+    *,
+    instrument_id: str,
+    trading_epoch: int,
+    context_reference: str,
+    direction_state: EntryExitDirectionState,
+    position_state: PositionState,
+    reconciliation_state: ReconciliationState,
+    trading_gate: TradingGate,
+    safety_mode: SafetyMode,
+    data_integrity_state: DataIntegrityStatus,
+    clock_trust_status: ClockTrustStatus,
+    cooldown_pass: bool,
+    existing_position_side: ExistingPositionSide,
+    venue_flat: bool,
+    scope_adverse_exit_signal: PolicySignalV0,
+    profit_protection_signal: PolicySignalV0,
+    time_exit_signal: PolicySignalV0,
+    strategy_invalidation_signal: PolicySignalV0,
+    hard_risk_reduction_signal: PolicySignalV0,
+    safety_exit_signal: PolicySignalV0,
+    previous_direction_state: CompositionDirectionState,
+    position_management_context: PositionManagementContext,
+    entry_exit_policy: DoublePlayEntryExitPolicyV0,
+    gate: DoublePlayTypedVolatilityPresenceGateResultV1,
+) -> EntryExitPolicyDecisionV0:
+    """Run entry/exit for safety/hard-risk/reconcile/mandatory without alpha authority."""
+    demoted = demote_trading_gate_for_typed_presence_failure_v1(trading_gate)
+    composition = _non_authorizing_observe_composition_v1(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+        previous_direction_state=previous_direction_state,
+        position_management_context=position_management_context,
+    )
+    inp = DoublePlayEntryExitPolicyInputV0(
+        instrument_id=instrument_id,
+        trading_epoch=trading_epoch,
+        context_reference=context_reference,
+        composition_result=composition,
+        direction_state=direction_state,
+        position_state=position_state,
+        reconciliation_state=reconciliation_state,
+        trading_gate=demoted,
+        safety_mode=safety_mode,
+        data_integrity_state=data_integrity_state,
+        clock_trust_status=clock_trust_status,
+        clock_trust_valid=clock_trust_status is ClockTrustStatus.TRUSTED,
+        cooldown_pass=cooldown_pass,
+        existing_position_side=existing_position_side,
+        venue_flat=venue_flat,
+        scope_adverse_exit_signal=scope_adverse_exit_signal,
+        profit_protection_signal=profit_protection_signal,
+        time_exit_signal=time_exit_signal,
+        strategy_invalidation_signal=strategy_invalidation_signal,
+        hard_risk_reduction_signal=hard_risk_reduction_signal,
+        safety_exit_signal=safety_exit_signal,
+        input_complete=True,
+        input_digest="",
+        explicit_blocked_reasons=(),
+        policy_version=entry_exit_policy.policy_version,
+    )
+    inp = replace(inp, input_digest=compute_entry_exit_policy_input_digest(inp))
+    decision = evaluate_double_play_entry_exit_policy_v0(inp, entry_exit_policy)
+    # Preserve protection outcomes; annotate fail-closed typed absence on non-entry paths.
+    if decision.decision_outcome in (
+        DecisionOutcome.ENTER_LONG,
+        DecisionOutcome.ENTER_SHORT,
+    ):
+        # Presence gate must never allow entry when typed is absent.
+        return replace(
+            decision,
+            decision_outcome=DecisionOutcome.BLOCKED,
+            entry_eligibility=EntryEligibility.BLOCKED,
+            reason_codes=tuple(
+                dict.fromkeys(
+                    (
+                        *gate.reason_codes,
+                        TYPED_VOLATILITY_ESTIMATE_MISSING_REASON,
+                        "entry_blocked_typed_volatility_estimate_missing",
+                        *decision.reason_codes,
+                    )
+                )
+            ),
+        )
+    annotated = tuple(dict.fromkeys((*gate.reason_codes, *decision.reason_codes)))
+    return replace(decision, reason_codes=annotated)
+
+
+def assert_architecture_guards_v1(*, repo_root: Optional[Path] = None) -> dict[str, Any]:
+    """Guards: single authorities; productive gate wired; no local .value extract."""
+    root = repo_root or Path(__file__).resolve().parents[3]
+    this_src = (
+        root / "src/trading/master_v2/double_play_runtime_typed_volatility_presence_gate_v1.py"
+    ).read_text(encoding="utf-8")
+    typed_src = (
+        root
+        / "src/trading/master_v2/canonical_volatility_estimate_typed_consumption_contract_v1.py"
+    ).read_text(encoding="utf-8")
+    binding_src = (
+        root / "src/trading/master_v2/canonical_volatility_binding_and_provenance_transport_v1.py"
+    ).read_text(encoding="utf-8")
+    bridge_src = (
+        root
+        / "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2"
+        / "hardening_cycle_bridge_v2.py"
+    ).read_text(encoding="utf-8")
+    replay_src = (
+        root / "src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py"
+    ).read_text(encoding="utf-8")
+    scope_src = (root / "src/trading/master_v2/canonical_scope_initialization_v1.py").read_text(
+        encoding="utf-8"
+    )
+    offline_scenario = (
+        root / "src/trading/master_v2/offline_double_play_scenario_replay_v0.py"
+    ).read_text(encoding="utf-8")
+
+    adapter_def = "def " + "adapt_canonical_volatility_estimate_to_legacy_float_v1("
+    binder_def = "def " + "bind_typed_canonical_volatility_estimate_into_market_context_v1("
+    materializer_def = "def " + "compute_canonical_volatility_estimate_from_mark_prices_v1("
+    validate_def = "def " + "validate_canonical_volatility_estimate_v1("
+
+    if typed_src.count(adapter_def) != 1:
+        raise RuntimeError("EXPECTED_EXACTLY_ONE_TYPED_TO_FLOAT_ADAPTER_DEF")
+    if typed_src.count(validate_def) != 1:
+        raise RuntimeError("EXPECTED_EXACTLY_ONE_VALIDATION_BOUNDARY_DEF")
+    if binding_src.count(binder_def) != 1:
+        raise RuntimeError("EXPECTED_EXACTLY_ONE_BIND_TYPED_DEF")
+    if this_src.count(adapter_def) != 0:
+        raise RuntimeError("SECOND_ADAPTER_DEF_IN_PRESENCE_GATE_FORBIDDEN")
+    if this_src.count(binder_def) != 0:
+        raise RuntimeError("SECOND_BINDER_DEF_IN_PRESENCE_GATE_FORBIDDEN")
+    if this_src.count(materializer_def) != 0:
+        raise RuntimeError("SECOND_ESTIMATOR_DEF_IN_PRESENCE_GATE_FORBIDDEN")
+    if this_src.count(validate_def) != 0:
+        raise RuntimeError("SECOND_VALIDATOR_DEF_IN_PRESENCE_GATE_FORBIDDEN")
+
+    code_before_guards = this_src.split("def assert_architecture_guards_v1", 1)[0]
+    if "canonical_volatility_estimate.value" in code_before_guards:
+        raise RuntimeError("LOCAL_TYPED_VALUE_EXTRACTION_FORBIDDEN")
+    if "canonical_volatility_estimate.value" in bridge_src:
+        raise RuntimeError("LOCAL_TYPED_VALUE_EXTRACTION_IN_BRIDGE_FORBIDDEN")
+    if "canonical_volatility_estimate.value" in scope_src:
+        raise RuntimeError("LOCAL_TYPED_VALUE_EXTRACTION_IN_SCOPE_FORBIDDEN")
+
+    if "evaluate_double_play_runtime_typed_volatility_presence_gate_v1" not in bridge_src:
+        raise RuntimeError("PRESENCE_GATE_NOT_WIRED_IN_PRODUCTIVE_BRIDGE")
+    if "require_productive_typed_volatility_presence_gate" not in bridge_src:
+        raise RuntimeError("PRESENCE_GATE_FLAG_NOT_SET_IN_PRODUCTIVE_BRIDGE")
+    if "require_productive_typed_volatility_presence_gate" not in replay_src:
+        raise RuntimeError("PRESENCE_GATE_FLAG_MISSING_IN_REPLAY_INPUT")
+
+    # Offline scenario must not require the productive presence gate.
+    if "require_productive_typed_volatility_presence_gate=True" in offline_scenario:
+        raise RuntimeError("OFFLINE_SCENARIO_MUST_NOT_ENABLE_PRODUCTIVE_PRESENCE_GATE")
+
+    if GLOBAL_TYPED_ONLY_ENFORCEMENT or LIVE_AUTHORIZATION:
+        raise RuntimeError("GLOBAL_TYPED_ONLY_OR_LIVE_FLAG_DRIFT")
+    if NUMERIC_MAX_AGE_DECIDED or NUMERIC_MAX_AGE_POLICY_CREATED:
+        raise RuntimeError("NUMERIC_MAX_AGE_FLAG_DRIFT")
+    if not DOUBLE_PLAY_TYPED_CUTOVER:
+        raise RuntimeError("DOUBLE_PLAY_TYPED_CUTOVER_MUST_BE_TRUE")
+    if (
+        SECOND_ESTIMATOR_CREATED
+        or SECOND_ADAPTER_CREATED
+        or SECOND_VALIDATOR_CREATED
+        or LOCAL_TYPED_VALUE_EXTRACTION_CREATED
+    ):
+        raise RuntimeError("SECOND_AUTHORITY_OR_EXTRACTION_FLAG_DRIFT")
+
+    # Productive path cannot bypass: eligibility evaluate must be referenced.
+    if "evaluate_typed_volatility_binding_eligibility_v1" not in code_before_guards:
+        raise RuntimeError("PRESENCE_GATE_MUST_REUSE_TYPED_ELIGIBILITY")
+
+    return {
+        "adapter_defs_in_typed": typed_src.count(adapter_def),
+        "binder_defs_in_binding": binding_src.count(binder_def),
+        "validator_defs_in_typed": typed_src.count(validate_def),
+        "double_play_typed_cutover": DOUBLE_PLAY_TYPED_CUTOVER,
+        "global_typed_only_enforcement": GLOBAL_TYPED_ONLY_ENFORCEMENT,
+        "numeric_max_age_decided": NUMERIC_MAX_AGE_DECIDED,
+        "legacy_float_adaptation_owner": LEGACY_FLOAT_ADAPTATION_OWNER,
+        "productive_runtime_caller_owner": PRODUCTIVE_RUNTIME_CALLER_OWNER,
+        "presence_gate_owner": PRESENCE_GATE_OWNER,
+        "live_authorization": LIVE_AUTHORIZATION,
+        "hard_stop": HARD_STOP,
+        "guards_pass": True,
+    }
+
+
+def assert_capability_non_goals_v1() -> dict[str, Any]:
+    return {
+        "capability_id": CAPABILITY_ID,
+        "capability_version": CAPABILITY_VERSION,
+        "presence_gate_owner": PRESENCE_GATE_OWNER,
+        "double_play_typed_cutover": DOUBLE_PLAY_TYPED_CUTOVER,
+        "global_typed_only_enforcement": GLOBAL_TYPED_ONLY_ENFORCEMENT,
+        "numeric_max_age_decided": NUMERIC_MAX_AGE_DECIDED,
+        "numeric_max_age_policy_created": NUMERIC_MAX_AGE_POLICY_CREATED,
+        "live_authorization": LIVE_AUTHORIZATION,
+        "hard_stop": HARD_STOP,
+        "second_estimator_created": SECOND_ESTIMATOR_CREATED,
+        "second_adapter_created": SECOND_ADAPTER_CREATED,
+        "second_validator_created": SECOND_VALIDATOR_CREATED,
+        "local_typed_value_extraction_created": LOCAL_TYPED_VALUE_EXTRACTION_CREATED,
+        "volatility_semantics_changed": VOLATILITY_SEMANTICS_CHANGED,
+        "offline_replay_legacy_defaults_unchanged": OFFLINE_REPLAY_LEGACY_DEFAULTS_UNCHANGED,
+        "research_legacy_fallbacks_unchanged": RESEARCH_LEGACY_FALLBACKS_UNCHANGED,
+        "scenario_replay_unchanged": SCENARIO_REPLAY_UNCHANGED,
+        "single_estimator_authority_preserved": SINGLE_ESTIMATOR_AUTHORITY_PRESERVED,
+        "single_validation_boundary_preserved": SINGLE_VALIDATION_BOUNDARY_PRESERVED,
+        "single_typed_float_adapter_authority_preserved": (
+            SINGLE_TYPED_FLOAT_ADAPTER_AUTHORITY_PRESERVED
+        ),
+        "package_marker": PACKAGE_MARKER,
+        "gaps_remaining": (
+            "C1_G10_NUMERIC_MAX_AGE",
+            "G3_UNTYPED_EXPLICIT_LEGACY_STILL_ADMISSIBLE",
+            "G8_ESTIMATOR_AMBIGUITY_ON_EXPLICIT_LEGACY",
+        ),
+    }
+
+
+__all__ = [
+    "CAPABILITY_ID",
+    "CAPABILITY_VERSION",
+    "DOUBLE_PLAY_TYPED_CUTOVER",
+    "DoublePlayTypedVolatilityPresenceGateResultV1",
+    "GLOBAL_TYPED_ONLY_ENFORCEMENT",
+    "HARD_STOP",
+    "LIVE_AUTHORIZATION",
+    "PACKAGE_MARKER",
+    "PRESENCE_GATE_OWNER",
+    "PRODUCTIVE_RUNTIME_CALLER_OWNER",
+    "TYPED_VOLATILITY_ESTIMATE_MISSING_REASON",
+    "assert_architecture_guards_v1",
+    "assert_capability_non_goals_v1",
+    "demote_trading_gate_for_typed_presence_failure_v1",
+    "evaluate_double_play_runtime_typed_volatility_presence_gate_v1",
+    "evaluate_protection_authority_when_typed_absent_v1",
+    "protection_authority_required_v1",
+]

--- a/src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py
+++ b/src/trading/master_v2/integrated_offline_trading_logic_replay_v1.py
@@ -38,6 +38,7 @@ from trading.master_v2.canonical_market_context_v1 import (
     CANONICAL_MARKET_CONTEXT_LAYER_VERSION,
     CanonicalMarketContextBindingOutcome,
     CanonicalMarketContextBindingStateV1,
+    CanonicalMarketContextEligibilityV1,
     CanonicalMarketContextV1,
     bind_canonical_market_context_event,
     with_computed_input_digest,
@@ -301,6 +302,13 @@ class IntegratedOfflineReplayInputV1:
     confirmation_progress_session_id: Optional[str] = None
     confirmation_progress_venue: Optional[str] = None
     confirmation_progress_instrument: Optional[InstrumentObservationKeyV1] = None
+    # Productive runtime only: require typed volatility presence before DP
+    # scope/boundary/entry authority. Default False preserves offline/research/scenario.
+    require_productive_typed_volatility_presence_gate: bool = False
+    # Optional precomputed eligibility from productive CMC typed binding host.
+    productive_typed_volatility_binding_eligibility: Optional[
+        CanonicalMarketContextEligibilityV1
+    ] = None
 
 
 @dataclass(frozen=True)
@@ -454,6 +462,10 @@ def build_integrated_offline_replay_input_v1(
     confirmation_progress_session_id: Optional[str] = None,
     confirmation_progress_venue: Optional[str] = None,
     confirmation_progress_instrument: Optional[InstrumentObservationKeyV1] = None,
+    require_productive_typed_volatility_presence_gate: bool = False,
+    productive_typed_volatility_binding_eligibility: Optional[
+        CanonicalMarketContextEligibilityV1
+    ] = None,
 ) -> IntegratedOfflineReplayInputV1:
     """Single canonical productive constructor for IntegratedOfflineReplayInputV1.
 
@@ -736,6 +748,12 @@ def build_integrated_offline_replay_input_v1(
         confirmation_progress_session_id=confirmation_progress_session_id,
         confirmation_progress_venue=confirmation_progress_venue,
         confirmation_progress_instrument=confirmation_progress_instrument,
+        require_productive_typed_volatility_presence_gate=bool(
+            require_productive_typed_volatility_presence_gate
+        ),
+        productive_typed_volatility_binding_eligibility=(
+            productive_typed_volatility_binding_eligibility
+        ),
     )
 
 
@@ -1278,6 +1296,96 @@ def run_integrated_offline_trading_logic_replay_v1(
         return IntegratedOfflineReplayResultV1(False, ("missing_market_context_output",), evidence)
 
     bound_context = binding.context
+
+    if inp.require_productive_typed_volatility_presence_gate:
+        from trading.master_v2.double_play_runtime_typed_volatility_presence_gate_v1 import (
+            TYPED_VOLATILITY_ESTIMATE_MISSING_REASON,
+            demote_trading_gate_for_typed_presence_failure_v1,
+            evaluate_double_play_runtime_typed_volatility_presence_gate_v1,
+            evaluate_protection_authority_when_typed_absent_v1,
+            protection_authority_required_v1,
+        )
+
+        presence_gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+            bound_context,
+            binding_outcome=binding.eligibility.binding_outcome,
+            eligibility=inp.productive_typed_volatility_binding_eligibility,
+        )
+        # Eligibility result is consumed via presence_gate.eligibility (never discarded).
+        _ = presence_gate.eligibility
+
+        if not presence_gate.alpha_scope_entry_authority_allowed:
+            reasons = presence_gate.reason_codes or (TYPED_VOLATILITY_ESTIMATE_MISSING_REASON,)
+            needs_protection = protection_authority_required_v1(
+                position_state=inp.position_state,
+                existing_position_side=inp.existing_position_side,
+                reconciliation_state=inp.reconciliation_state,
+                safety_exit_signal=inp.safety_exit_signal,
+                hard_risk_reduction_signal=inp.hard_risk_reduction_signal,
+                scope_adverse_exit_signal=inp.scope_adverse_exit_signal,
+                profit_protection_signal=inp.profit_protection_signal,
+                time_exit_signal=inp.time_exit_signal,
+                strategy_invalidation_signal=inp.strategy_invalidation_signal,
+                safety_mode=inp.safety_mode,
+            )
+            if needs_protection:
+                protection_decision = evaluate_protection_authority_when_typed_absent_v1(
+                    instrument_id=inp.instrument_id,
+                    trading_epoch=inp.trading_epoch,
+                    context_reference=inp.context_reference,
+                    direction_state=inp.direction_state,
+                    position_state=inp.position_state,
+                    reconciliation_state=inp.reconciliation_state,
+                    trading_gate=demote_trading_gate_for_typed_presence_failure_v1(
+                        inp.trading_gate
+                    ),
+                    safety_mode=inp.safety_mode,
+                    data_integrity_state=bound_context.data_integrity_status,
+                    clock_trust_status=bound_context.clock_trust_status,
+                    cooldown_pass=inp.cooldown_pass,
+                    existing_position_side=inp.existing_position_side,
+                    venue_flat=inp.venue_flat,
+                    scope_adverse_exit_signal=inp.scope_adverse_exit_signal,
+                    profit_protection_signal=inp.profit_protection_signal,
+                    time_exit_signal=inp.time_exit_signal,
+                    strategy_invalidation_signal=inp.strategy_invalidation_signal,
+                    hard_risk_reduction_signal=inp.hard_risk_reduction_signal,
+                    safety_exit_signal=inp.safety_exit_signal,
+                    previous_direction_state=inp.previous_composition_direction_state,
+                    position_management_context=inp.position_management_context,
+                    entry_exit_policy=inp.policies.entry_exit,
+                    gate=presence_gate,
+                )
+                evidence = _blocked_evidence(
+                    inp,
+                    fail_reasons=tuple(
+                        dict.fromkeys((*reasons, *protection_decision.reason_codes))
+                    ),
+                    decision_outcome=protection_decision.decision_outcome.value,
+                )
+                evidence = replace(
+                    evidence,
+                    reason_codes=tuple(
+                        dict.fromkeys((*reasons, *protection_decision.reason_codes))
+                    ),
+                    entry_exit_policy_ref=protection_decision.policy_decision_id,
+                    entry_or_exit_policy_ref=protection_decision.policy_decision_id,
+                    decision_precedence_trace=protection_decision.decision_precedence_trace,
+                    market_context_ref=bound_context.context_id,
+                )
+                evidence = with_computed_evidence_semantic_digest(evidence)
+                return IntegratedOfflineReplayResultV1(
+                    replay_pass=False,
+                    fail_reasons=tuple(dict.fromkeys((*reasons,))),
+                    evidence=evidence,
+                )
+
+            evidence = _blocked_evidence(
+                inp,
+                fail_reasons=reasons,
+                decision_outcome="blocked",
+            )
+            return IntegratedOfflineReplayResultV1(False, reasons, evidence)
 
     scope_init = initialize_canonical_scope(
         bound_context,

--- a/tests/trading/master_v2/test_double_play_runtime_typed_volatility_presence_gate_v1.py
+++ b/tests/trading/master_v2/test_double_play_runtime_typed_volatility_presence_gate_v1.py
@@ -1,0 +1,659 @@
+"""Focused tests for Double-Play runtime typed volatility presence gate v1."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from trading.master_v2.canonical_market_context_v1 import (
+    FEATURE_CONTRACT_VERSION,
+    BarFinalityStatus,
+    CanonicalMarketContextBlockReason,
+    CanonicalMarketContextV1,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+    WarmupStatus,
+    with_computed_input_digest,
+)
+from trading.master_v2.canonical_volatility_binding_and_provenance_transport_v1 import (
+    bind_typed_canonical_volatility_estimate_into_market_context_v1,
+    evaluate_typed_volatility_binding_eligibility_v1,
+)
+from trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1 import (
+    build_canonical_volatility_estimate_v1,
+    with_mutated_field_for_tests_v1,
+)
+from trading.master_v2.canonical_volatility_productive_runtime_cmc_typed_binding_v1 import (
+    CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1,
+    ProductiveTypedBindingFailClosedReasonV1,
+)
+from trading.master_v2.canonical_volatility_typed_runtime_producer_scaffold_v1 import (
+    TypedRuntimeProducerOutcomeV1,
+)
+from trading.master_v2.double_play_composition_matrix_v1 import (
+    CompositionDirectionState,
+    PositionManagementContext,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import (
+    DecisionOutcome,
+    DoublePlayEntryExitPolicyV0,
+    ENTRY_EXIT_POLICY_VERSION,
+    ExistingPositionSide,
+    PolicySignalV0,
+    PositionState,
+    ReconciliationState,
+    SafetyMode,
+    TradingGate,
+    EntryExitDirectionState,
+)
+from trading.master_v2.double_play_futures_input import FuturesMarketType
+from trading.master_v2.double_play_runtime_typed_volatility_presence_gate_v1 import (
+    CAPABILITY_ID,
+    DOUBLE_PLAY_TYPED_CUTOVER,
+    PACKAGE_MARKER,
+    TYPED_VOLATILITY_ESTIMATE_MISSING_REASON,
+    assert_architecture_guards_v1,
+    assert_capability_non_goals_v1,
+    demote_trading_gate_for_typed_presence_failure_v1,
+    evaluate_double_play_runtime_typed_volatility_presence_gate_v1,
+    evaluate_protection_authority_when_typed_absent_v1,
+    protection_authority_required_v1,
+)
+from trading.master_v2.integrated_offline_trading_logic_replay_v1 import (
+    _REPLAY_DEFAULT_VOL_QUARANTINE,
+)
+from trading.market_state.distinct_market_observation_acceptor_v1 import (
+    ObservationTransportMetadataV1,
+)
+from trading.market_state.time_sample_epoch_semantics_v1 import (
+    EventTimeInstantV1,
+    MarketSampleIdentityV1,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+VENUE = "okx_europe"
+CANON = "ETH-USD_UM_XPERP-310404"
+VENUE_INST = "ETH-USD_UM_XPERP-310404"
+T0 = 1_700_000_000.0
+
+
+def _price_at(i: int) -> float:
+    return 100.0 * math.exp(0.001 * i)
+
+
+def _sample(i: int) -> MarketSampleIdentityV1:
+    return MarketSampleIdentityV1(
+        venue=VENUE,
+        canonical_instrument_id=CANON,
+        venue_instrument_id=VENUE_INST,
+        event_time=EventTimeInstantV1(unix_seconds=T0 + float(i * 60)),
+        mark_price=_price_at(i),
+    )
+
+
+def _context(**overrides: object) -> CanonicalMarketContextV1:
+    base: dict = {
+        "context_id": "ctx-eth-presence-gate",
+        "instrument_id": CANON,
+        "market_type": FuturesMarketType.PERPETUAL,
+        "trading_epoch": 1,
+        "market_event_time": "2026-06-30T12:00:00+00:00",
+        "decision_time": "2026-06-30T12:00:01+00:00",
+        "bar_interval": "1m",
+        "bar_finality_status": BarFinalityStatus.FINALIZED,
+        "mark_price": 3500.0,
+        "index_price": 3499.5,
+        "best_bid": 3499.8,
+        "best_ask": 3500.2,
+        "spread": 0.4,
+        "volume": 1_250_000.0,
+        "open_interest": 85_000_000.0,
+        "funding_rate": 0.00012,
+        "volatility_estimate": 0.38,
+        "trend_feature_set": {"slope": 0.02},
+        "momentum_feature_set": {"rsi": 55.0},
+        "liquidity_feature_set": {"depth_score": 0.88},
+        "market_structure_feature_set": {"range_ratio": 0.42},
+        "data_integrity_status": DataIntegrityStatus.TRUSTED,
+        "clock_trust_status": ClockTrustStatus.TRUSTED,
+        "warmup_status": WarmupStatus.WARMUP_COMPLETE,
+        "feature_contract_version": FEATURE_CONTRACT_VERSION,
+        "input_digest": "",
+        "canonical_volatility_estimate": None,
+    }
+    base.update(overrides)
+    return CanonicalMarketContextV1(**base)
+
+
+def _valid_estimate(*, value: float = 0.004321):
+    return build_canonical_volatility_estimate_v1(
+        value=value,
+        observation_count=61,
+        as_of_event_time=datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc),
+        fallback_used=False,
+        source_digest="a" * 64,
+    )
+
+
+def _host(
+    tmp_path: Path | None = None,
+) -> CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1:
+    path = None if tmp_path is None else tmp_path / "mark_history.json"
+    return CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.create(
+        venue=VENUE,
+        canonical_instrument_id=CANON,
+        venue_instrument_id=VENUE_INST,
+        persistence_path=path,
+    )
+
+
+def _ingest_range(host, ctx, start: int, end: int):
+    result = None
+    for i in range(start, end + 1):
+        result = host.apply_to_market_context_v1(
+            ctx,
+            sample=_sample(i),
+            transport=ObservationTransportMetadataV1(receive_time=T0 + i * 60 + 0.5),
+            ingest_sample=True,
+        )
+    assert result is not None
+    return result
+
+
+# ---------------------------------------------------------------------------
+# A. Productive runtime
+# ---------------------------------------------------------------------------
+
+
+def test_a1_typed_present_float_synced_allows_double_play() -> None:
+    estimate = _valid_estimate()
+    ctx = bind_typed_canonical_volatility_estimate_into_market_context_v1(
+        with_computed_input_digest(_context(volatility_estimate=0.0)),
+        estimate,
+    )
+    elig = evaluate_typed_volatility_binding_eligibility_v1(ctx)
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(ctx, eligibility=elig)
+    assert gate.typed_estimate_present is True
+    assert gate.alpha_scope_entry_authority_allowed is True
+    assert gate.eligibility is elig
+    assert TYPED_VOLATILITY_ESTIMATE_MISSING_REASON not in gate.reason_codes
+
+
+def test_a2_typed_missing_feature_regime_float_fail_closed() -> None:
+    ctx = with_computed_input_digest(_context(volatility_estimate=0.38))
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(ctx)
+    assert gate.alpha_scope_entry_authority_allowed is False
+    assert TYPED_VOLATILITY_ESTIMATE_MISSING_REASON in gate.reason_codes
+    assert CanonicalMarketContextBlockReason.TYPED_VOLATILITY_ESTIMATE_MISSING in gate.block_reasons
+
+
+def test_a3_typed_missing_other_legacy_float_fail_closed() -> None:
+    ctx = with_computed_input_digest(_context(volatility_estimate=0.02))
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(ctx)
+    assert gate.alpha_scope_entry_authority_allowed is False
+    assert TYPED_VOLATILITY_ESTIMATE_MISSING_REASON in gate.reason_codes
+
+
+def test_a4_typed_present_float_mismatch_fail_closed() -> None:
+    from dataclasses import replace
+
+    estimate = _valid_estimate(value=0.004321)
+    ctx = bind_typed_canonical_volatility_estimate_into_market_context_v1(
+        with_computed_input_digest(_context(volatility_estimate=0.0)),
+        estimate,
+    )
+    mismatched = replace(ctx, volatility_estimate=0.99)
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(mismatched)
+    assert gate.alpha_scope_entry_authority_allowed is False
+    assert (
+        CanonicalMarketContextBlockReason.TYPED_VOLATILITY_LEGACY_FLOAT_MISMATCH
+        in gate.block_reasons
+    )
+
+
+def test_a5_typed_present_float_absent_atomic_bind_invariant() -> None:
+    """Binder always sets both; missing float after typed is mismatch/invalid path."""
+    estimate = _valid_estimate()
+    ctx = bind_typed_canonical_volatility_estimate_into_market_context_v1(
+        with_computed_input_digest(_context()),
+        estimate,
+    )
+    assert ctx.canonical_volatility_estimate is not None
+    assert ctx.volatility_estimate == pytest.approx(estimate.value)
+
+
+def test_a6_wrong_unit_horizon_annualization_blocked() -> None:
+    estimate = _valid_estimate()
+    bad = with_mutated_field_for_tests_v1(estimate, unit="percent")
+    with pytest.raises(Exception):
+        bind_typed_canonical_volatility_estimate_into_market_context_v1(
+            with_computed_input_digest(_context()),
+            bad,
+        )
+
+
+# ---------------------------------------------------------------------------
+# B. Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_b_lifecycle_warmup_restart_produced_duplicate_cycle_rejects(
+    tmp_path: Path,
+) -> None:
+    host = _host(tmp_path)
+    # Warmup without estimate
+    warm = host.apply_to_market_context_v1(
+        _context(),
+        sample=_sample(0),
+        transport=ObservationTransportMetadataV1(receive_time=T0 + 0.5),
+        ingest_sample=True,
+    )
+    assert warm.bound_estimate is None
+    gate_w = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        warm.context, eligibility=warm.typed_binding_eligibility
+    )
+    assert gate_w.alpha_scope_entry_authority_allowed is False
+
+    # Fill history to PRODUCED
+    produced = _ingest_range(host, _context(), 1, 60)
+    assert produced.producer_result.outcome is TypedRuntimeProducerOutcomeV1.PRODUCED
+    assert produced.bound_estimate is not None
+    gate_p = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        produced.context, eligibility=produced.typed_binding_eligibility
+    )
+    assert gate_p.alpha_scope_entry_authority_allowed is True
+
+    # Duplicate with prior — reuse allowed
+    dup = host.apply_to_market_context_v1(
+        _context(),
+        sample=_sample(60),
+        transport=ObservationTransportMetadataV1(receive_time=T0 + 60 * 60 + 0.5),
+        ingest_sample=True,
+    )
+    assert dup.producer_result.outcome is TypedRuntimeProducerOutcomeV1.DUPLICATE_NOOP
+    assert dup.bound_estimate is not None
+    gate_d = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        dup.context, eligibility=dup.typed_binding_eligibility
+    )
+    assert gate_d.alpha_scope_entry_authority_allowed is True
+
+    # Cycle without sample with prior — reuse allowed
+    cycle = host.apply_to_market_context_v1(_context(), ingest_sample=False)
+    assert cycle.bound_estimate is not None
+    gate_c = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        cycle.context, eligibility=cycle.typed_binding_eligibility
+    )
+    assert gate_c.alpha_scope_entry_authority_allowed is True
+
+    # Restart without rematerialized estimate
+    path = tmp_path / "mark_history.json"
+    restored = (
+        CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.restore_from_persistence_v1(
+            persistence_path=path,
+        )
+    )
+    restart = restored.apply_to_market_context_v1(_context(), ingest_sample=False)
+    assert restart.bound_estimate is None
+    assert (
+        restart.telemetry.fail_closed_reason
+        == ProductiveTypedBindingFailClosedReasonV1.RESTART_WITHOUT_ESTIMATE.value
+    )
+    gate_r = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        restart.context, eligibility=restart.typed_binding_eligibility
+    )
+    assert gate_r.alpha_scope_entry_authority_allowed is False
+
+
+def test_b_duplicate_without_prior_blocks(tmp_path: Path) -> None:
+    host = _host(tmp_path)
+    # Single sample — warmup, not enough for PRODUCED; then duplicate same sample
+    first = host.apply_to_market_context_v1(
+        _context(),
+        sample=_sample(0),
+        transport=ObservationTransportMetadataV1(receive_time=T0 + 0.5),
+        ingest_sample=True,
+    )
+    assert first.bound_estimate is None
+    # Fresh host duplicate-without-prior: ingest same identity on new host after one sample
+    host2 = _host(tmp_path / "h2")
+    host2.apply_to_market_context_v1(
+        _context(),
+        sample=_sample(0),
+        transport=ObservationTransportMetadataV1(receive_time=T0 + 0.5),
+        ingest_sample=True,
+    )
+    dup = host2.apply_to_market_context_v1(
+        _context(),
+        sample=_sample(0),
+        transport=ObservationTransportMetadataV1(receive_time=T0 + 1.0),
+        ingest_sample=True,
+    )
+    assert dup.bound_estimate is None
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        dup.context, eligibility=dup.typed_binding_eligibility
+    )
+    assert gate.alpha_scope_entry_authority_allowed is False
+
+
+def test_b_out_of_order_history_gap_block(tmp_path: Path) -> None:
+    host = _host(tmp_path)
+    warm = _ingest_range(host, _context(), 0, 5)
+    ooo = host.apply_to_market_context_v1(
+        warm.context,
+        sample=_sample(3),
+        ingest_sample=True,
+    )
+    assert ooo.producer_result.outcome is TypedRuntimeProducerOutcomeV1.OUT_OF_ORDER_REJECTED
+    assert ooo.bound_estimate is None
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        ooo.context, eligibility=ooo.typed_binding_eligibility
+    )
+    assert gate.alpha_scope_entry_authority_allowed is False
+
+    host3 = _host(tmp_path / "gap2")
+    produced = _ingest_range(host3, _context(), 0, 60)
+    assert produced.bound_estimate is not None
+    jumped = host3.apply_to_market_context_v1(
+        produced.context,
+        sample=_sample(63),
+        ingest_sample=True,
+    )
+    assert jumped.producer_result.outcome is TypedRuntimeProducerOutcomeV1.HISTORY_GAP_REJECTED
+    assert jumped.bound_estimate is None
+    gate_g = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        jumped.context, eligibility=jumped.typed_binding_eligibility
+    )
+    assert gate_g.alpha_scope_entry_authority_allowed is False
+
+
+def test_b_persistence_and_materialization_fail_closed(tmp_path: Path) -> None:
+    # Persistence restore without rematerialized estimate → presence gate fail-closed.
+    host = _host(tmp_path)
+    produced = _ingest_range(host, _context(), 0, 60)
+    assert produced.bound_estimate is not None
+    path = tmp_path / "mark_history.json"
+    restored = (
+        CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.restore_from_persistence_v1(
+            persistence_path=path,
+        )
+    )
+    cycle = restored.apply_to_market_context_v1(_context(), ingest_sample=False)
+    assert cycle.bound_estimate is None
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        cycle.context, eligibility=cycle.typed_binding_eligibility
+    )
+    assert gate.alpha_scope_entry_authority_allowed is False
+    assert TYPED_VOLATILITY_ESTIMATE_MISSING_REASON in gate.reason_codes
+
+
+# ---------------------------------------------------------------------------
+# C. Authority separation
+# ---------------------------------------------------------------------------
+
+
+def test_c_entry_scope_boundary_blocked_safety_preserved() -> None:
+    ctx = with_computed_input_digest(_context(volatility_estimate=0.38))
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(ctx)
+    assert gate.alpha_scope_entry_authority_allowed is False
+    assert gate.exit_risk_safety_authority_preserved is True
+    assert demote_trading_gate_for_typed_presence_failure_v1(TradingGate.ENTRY_ALLOWED) is (
+        TradingGate.EXIT_ONLY
+    )
+
+    policy = DoublePlayEntryExitPolicyV0(policy_version=ENTRY_EXIT_POLICY_VERSION)
+
+    # Safety exit still executable
+    safety = evaluate_protection_authority_when_typed_absent_v1(
+        instrument_id=CANON,
+        trading_epoch=1,
+        context_reference="ctx",
+        direction_state=EntryExitDirectionState.LONG_ACTIVE,
+        position_state=PositionState.OPEN_FULL,
+        reconciliation_state=ReconciliationState.RECONCILED,
+        trading_gate=TradingGate.ENTRY_ALLOWED,
+        safety_mode=SafetyMode.EXIT_ONLY,
+        data_integrity_state=DataIntegrityStatus.TRUSTED,
+        clock_trust_status=ClockTrustStatus.TRUSTED,
+        cooldown_pass=True,
+        existing_position_side=ExistingPositionSide.LONG,
+        venue_flat=False,
+        scope_adverse_exit_signal=PolicySignalV0(triggered=False),
+        profit_protection_signal=PolicySignalV0(triggered=False),
+        time_exit_signal=PolicySignalV0(triggered=False),
+        strategy_invalidation_signal=PolicySignalV0(triggered=False),
+        hard_risk_reduction_signal=PolicySignalV0(triggered=False),
+        safety_exit_signal=PolicySignalV0(triggered=True, reason_code="safety"),
+        previous_direction_state=CompositionDirectionState.LONG,
+        position_management_context=PositionManagementContext.LONG_POSITION,
+        entry_exit_policy=policy,
+        gate=gate,
+    )
+    assert safety.decision_outcome is DecisionOutcome.EXIT
+
+    # Hard-risk reduce still executable
+    hard = evaluate_protection_authority_when_typed_absent_v1(
+        instrument_id=CANON,
+        trading_epoch=1,
+        context_reference="ctx",
+        direction_state=EntryExitDirectionState.LONG_ACTIVE,
+        position_state=PositionState.OPEN_FULL,
+        reconciliation_state=ReconciliationState.RECONCILED,
+        trading_gate=TradingGate.ENTRY_ALLOWED,
+        safety_mode=SafetyMode.NORMAL,
+        data_integrity_state=DataIntegrityStatus.TRUSTED,
+        clock_trust_status=ClockTrustStatus.TRUSTED,
+        cooldown_pass=True,
+        existing_position_side=ExistingPositionSide.LONG,
+        venue_flat=False,
+        scope_adverse_exit_signal=PolicySignalV0(triggered=False),
+        profit_protection_signal=PolicySignalV0(triggered=False),
+        time_exit_signal=PolicySignalV0(triggered=False),
+        strategy_invalidation_signal=PolicySignalV0(triggered=False),
+        hard_risk_reduction_signal=PolicySignalV0(triggered=True, reason_code="hard"),
+        safety_exit_signal=PolicySignalV0(triggered=False),
+        previous_direction_state=CompositionDirectionState.LONG,
+        position_management_context=PositionManagementContext.LONG_POSITION,
+        entry_exit_policy=policy,
+        gate=gate,
+    )
+    assert hard.decision_outcome is DecisionOutcome.REDUCE
+
+    # Reconciliation still executable
+    recon = evaluate_protection_authority_when_typed_absent_v1(
+        instrument_id=CANON,
+        trading_epoch=1,
+        context_reference="ctx",
+        direction_state=EntryExitDirectionState.LONG_ACTIVE,
+        position_state=PositionState.RECONCILIATION_REQUIRED,
+        reconciliation_state=ReconciliationState.RECONCILIATION_REQUIRED,
+        trading_gate=TradingGate.ENTRY_ALLOWED,
+        safety_mode=SafetyMode.NORMAL,
+        data_integrity_state=DataIntegrityStatus.TRUSTED,
+        clock_trust_status=ClockTrustStatus.TRUSTED,
+        cooldown_pass=True,
+        existing_position_side=ExistingPositionSide.LONG,
+        venue_flat=False,
+        scope_adverse_exit_signal=PolicySignalV0(triggered=False),
+        profit_protection_signal=PolicySignalV0(triggered=False),
+        time_exit_signal=PolicySignalV0(triggered=False),
+        strategy_invalidation_signal=PolicySignalV0(triggered=False),
+        hard_risk_reduction_signal=PolicySignalV0(triggered=False),
+        safety_exit_signal=PolicySignalV0(triggered=False),
+        previous_direction_state=CompositionDirectionState.LONG,
+        position_management_context=PositionManagementContext.LONG_POSITION,
+        entry_exit_policy=policy,
+        gate=gate,
+    )
+    assert recon.decision_outcome.value in {"reconcile_only", "blocked", "hold", "observe"}
+
+    # Mandatory adverse-scope reduce still executable
+    mandatory = evaluate_protection_authority_when_typed_absent_v1(
+        instrument_id=CANON,
+        trading_epoch=1,
+        context_reference="ctx",
+        direction_state=EntryExitDirectionState.LONG_ACTIVE,
+        position_state=PositionState.OPEN_FULL,
+        reconciliation_state=ReconciliationState.RECONCILED,
+        trading_gate=TradingGate.ENTRY_ALLOWED,
+        safety_mode=SafetyMode.NORMAL,
+        data_integrity_state=DataIntegrityStatus.TRUSTED,
+        clock_trust_status=ClockTrustStatus.TRUSTED,
+        cooldown_pass=True,
+        existing_position_side=ExistingPositionSide.LONG,
+        venue_flat=False,
+        scope_adverse_exit_signal=PolicySignalV0(triggered=True, reason_code="adverse"),
+        profit_protection_signal=PolicySignalV0(triggered=False),
+        time_exit_signal=PolicySignalV0(triggered=False),
+        strategy_invalidation_signal=PolicySignalV0(triggered=False),
+        hard_risk_reduction_signal=PolicySignalV0(triggered=False),
+        safety_exit_signal=PolicySignalV0(triggered=False),
+        previous_direction_state=CompositionDirectionState.LONG,
+        position_management_context=PositionManagementContext.LONG_POSITION,
+        entry_exit_policy=policy,
+        gate=gate,
+    )
+    assert mandatory.decision_outcome is DecisionOutcome.REDUCE
+
+    # Mandatory time exit still executable
+    time_exit = evaluate_protection_authority_when_typed_absent_v1(
+        instrument_id=CANON,
+        trading_epoch=1,
+        context_reference="ctx",
+        direction_state=EntryExitDirectionState.LONG_ACTIVE,
+        position_state=PositionState.OPEN_FULL,
+        reconciliation_state=ReconciliationState.RECONCILED,
+        trading_gate=TradingGate.ENTRY_ALLOWED,
+        safety_mode=SafetyMode.NORMAL,
+        data_integrity_state=DataIntegrityStatus.TRUSTED,
+        clock_trust_status=ClockTrustStatus.TRUSTED,
+        cooldown_pass=True,
+        existing_position_side=ExistingPositionSide.LONG,
+        venue_flat=False,
+        scope_adverse_exit_signal=PolicySignalV0(triggered=False),
+        profit_protection_signal=PolicySignalV0(triggered=False),
+        time_exit_signal=PolicySignalV0(triggered=True, reason_code="time"),
+        strategy_invalidation_signal=PolicySignalV0(triggered=False),
+        hard_risk_reduction_signal=PolicySignalV0(triggered=False),
+        safety_exit_signal=PolicySignalV0(triggered=False),
+        previous_direction_state=CompositionDirectionState.LONG,
+        position_management_context=PositionManagementContext.LONG_POSITION,
+        entry_exit_policy=policy,
+        gate=gate,
+    )
+    assert time_exit.decision_outcome is DecisionOutcome.EXIT
+
+    assert protection_authority_required_v1(
+        position_state=PositionState.OPEN_FULL,
+        existing_position_side=ExistingPositionSide.LONG,
+        reconciliation_state=ReconciliationState.RECONCILED,
+        safety_exit_signal=PolicySignalV0(triggered=False),
+        hard_risk_reduction_signal=PolicySignalV0(triggered=False),
+        scope_adverse_exit_signal=PolicySignalV0(triggered=False),
+        profit_protection_signal=PolicySignalV0(triggered=False),
+        time_exit_signal=PolicySignalV0(triggered=False),
+        strategy_invalidation_signal=PolicySignalV0(triggered=False),
+        safety_mode=SafetyMode.NORMAL,
+    )
+
+
+# ---------------------------------------------------------------------------
+# D. Isolation
+# ---------------------------------------------------------------------------
+
+
+def test_d_offline_research_scenario_isolation() -> None:
+    from trading.master_v2.canonical_volatility_default_quarantine_v1 import (
+        LEGACY_HISTORICAL_BIND_DEFAULT_VALUE,
+        LEGACY_REPLAY_RULES_DEFAULT_VALUE,
+    )
+    from trading.master_v2.offline_double_play_scenario_replay_v0 import (
+        _HIGH_VOL_RULES,
+        _DEFAULT_RULES,
+    )
+
+    assert float(LEGACY_REPLAY_RULES_DEFAULT_VALUE) == 0.02
+    assert float(_REPLAY_DEFAULT_VOL_QUARANTINE.legacy_value) == 0.02
+    assert float(LEGACY_HISTORICAL_BIND_DEFAULT_VALUE) == 0.2
+    assert float(_DEFAULT_RULES.volatility_estimate) == 0.02
+    assert float(_HIGH_VOL_RULES.volatility_estimate) == 0.08
+
+    non_goals = assert_capability_non_goals_v1()
+    assert non_goals["global_typed_only_enforcement"] is False
+    assert non_goals["numeric_max_age_policy_created"] is False
+    assert non_goals["offline_replay_legacy_defaults_unchanged"] is True
+    assert non_goals["research_legacy_fallbacks_unchanged"] is True
+    assert non_goals["scenario_replay_unchanged"] is True
+
+    # Offline eligibility without presence requirement still allows legacy float path.
+    ctx = with_computed_input_digest(_context())
+    from trading.master_v2.canonical_market_context_v1 import (
+        evaluate_canonical_market_context_eligibility,
+    )
+
+    legacy_elig = evaluate_canonical_market_context_eligibility(ctx)
+    assert legacy_elig.trading_decision_allowed is True
+
+
+# ---------------------------------------------------------------------------
+# E. Architecture guards
+# ---------------------------------------------------------------------------
+
+
+def test_e_architecture_guards() -> None:
+    guards = assert_architecture_guards_v1(repo_root=ROOT)
+    assert guards["adapter_defs_in_typed"] == 1
+    assert guards["binder_defs_in_binding"] == 1
+    assert guards["validator_defs_in_typed"] == 1
+    assert guards["double_play_typed_cutover"] is True
+    assert guards["global_typed_only_enforcement"] is False
+    assert guards["numeric_max_age_decided"] is False
+    assert DOUBLE_PLAY_TYPED_CUTOVER is True
+    assert PACKAGE_MARKER.startswith("MASTER_V2_DOUBLE_PLAY_RUNTIME")
+    assert CAPABILITY_ID == "MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1"
+
+    non_goals = assert_capability_non_goals_v1()
+    assert non_goals["second_estimator_created"] is False
+    assert non_goals["second_adapter_created"] is False
+    assert non_goals["second_validator_created"] is False
+    assert non_goals["local_typed_value_extraction_created"] is False
+    assert non_goals["volatility_semantics_changed"] is False
+
+    # feature_regime remains NON_ALIAS competing seed (not removed).
+    feature_regime = (
+        ROOT
+        / "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2"
+        / "feature_regime_pipeline_v2.py"
+    ).read_text(encoding="utf-8")
+    assert "compute_feature_regime_from_mid_prices_v2" in feature_regime
+
+    # Productive path cannot bypass presence gate.
+    bridge = (
+        ROOT
+        / "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2"
+        / "hardening_cycle_bridge_v2.py"
+    ).read_text(encoding="utf-8")
+    assert "require_productive_typed_volatility_presence_gate=True" in bridge
+    assert "evaluate_double_play_runtime_typed_volatility_presence_gate_v1" in bridge
+
+    spec = (
+        ROOT / "docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1.md"
+    ).read_text(encoding="utf-8")
+    assert "DOCS_TOKEN_MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1" in spec
+
+
+def test_eligibility_not_discarded_by_host(tmp_path: Path) -> None:
+    host = _host(tmp_path)
+    result = host.apply_to_market_context_v1(
+        _context(),
+        sample=_sample(0),
+        transport=ObservationTransportMetadataV1(receive_time=T0 + 0.5),
+        ingest_sample=True,
+    )
+    assert result.typed_binding_eligibility is not None
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        result.context, eligibility=result.typed_binding_eligibility
+    )
+    assert gate.eligibility is result.typed_binding_eligibility


### PR DESCRIPTION
## Summary
- Closes productive Double-Play typed cutover via `MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1`.
- Productive Scope/Boundary/Entry authority requires `canonical_volatility_estimate` present, validated, and atomically synced with the legacy float; missing typed fails closed with `TYPED_VOLATILITY_ESTIMATE_MISSING` (feature_regime float cannot authorize).
- Reuses existing eligibility/binding/adapter authorities; preserves Safety Exit, Hard-Risk Reduce, Reconciliation, and Mandatory Exit; offline Replay 0.02 / Research 0.2 / Scenario paths unchanged.

## Test plan
- [x] Presence-gate focused tests A–E
- [x] Related productive binding + provenance transport tests
- [x] Architecture guards
- [x] Strategy smoke
- [x] Ruff format/check
- [x] Docs token + docs-reference-targets
- [x] PR-bounded full timing proof (52s << 840s)


Made with [Cursor](https://cursor.com)