### PR TITLE
Master V2: add non-enforcing volatility max-age policy contract and telemetry

### DIFF
--- a/config/governance/technical_canonical_wiring_authorization_v1.json
+++ b/config/governance/technical_canonical_wiring_authorization_v1.json
@@ -758,7 +758,10 @@
     "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2/hardening_cycle_bridge_v2.py",
     "src/trading/master_v2/double_play_runtime_typed_volatility_presence_gate_v1.py",
     "tests/trading/master_v2/test_double_play_runtime_typed_volatility_presence_gate_v1.py",
-    "docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1.md"
+    "docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1.md",
+    "src/trading/master_v2/canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1.py",
+    "tests/trading/master_v2/test_canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1.py",
+    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_POLICY_CONTRACT_AND_NON_ENFORCING_TELEMETRY_V1.md"
   ],
   "allowed_surface_classes": [
     "TECHNICAL_CANONICAL_REPLAY_INPUT_BUILDER_WIRING",
@@ -908,7 +911,8 @@
     "C4 POST_CONFIRMATION_SURVIVAL_SUITABILITY_COMPOSITION_BINDING_V1: authorize post-C3 Survival/Suitability/Composition binding guards, Research C1 DISTINCT wiring, C4 contract tests and docs. Composition remains sole CONFIRMED admissibility gate. No runtime activation, no parameter/volatility mutation.",
     "MASTER_V2_CANONICAL_VOLATILITY_TYPED_RUNTIME_PRODUCER_SCAFFOLD_V1: authorize exact-file typed runtime producer scaffold, mark-history host, materializer observation_count provenance helper, typed-factory provenance reuse, focused tests and docs. No runtime cutover, no Double-Play/CMC bind_typed wiring, no parameter-value decision, no broad master_v2 grant.",
     "MASTER_V2_CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1: authorize exact-file productive Producer→bind_typed→CMC host, hardening-bridge productive caller wiring, focused tests and docs. Reuses existing producer/validation/binding/adapter authorities. No Double-Play typed cutover, no numeric max-age, no global typed-only enforcement, no competing-producer mutation, no parameter research, no live/orders.",
-    "MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1: authorize exact-file productive Double-Play typed volatility presence gate, replay opt-in flag wiring, hardening-bridge productive gate consumption, eligibility-result reuse on CMC typed binding host, focused tests and docs. Reuses existing eligibility/validation/binding/adapter authorities. No Direct-Typed consumer refactor, no numeric max-age, no global typed-only enforcement, no offline Replay/Research/Scenario default mutation, no parameter research, no live/orders."
+    "MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1: authorize exact-file productive Double-Play typed volatility presence gate, replay opt-in flag wiring, hardening-bridge productive gate consumption, eligibility-result reuse on CMC typed binding host, focused tests and docs. Reuses existing eligibility/validation/binding/adapter authorities. No Direct-Typed consumer refactor, no numeric max-age, no global typed-only enforcement, no offline Replay/Research/Scenario default mutation, no parameter research, no live/orders.",
+    "MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_POLICY_CONTRACT_AND_NON_ENFORCING_TELEMETRY_V1: authorize exact-file non-enforcing Event-Time max-age policy contract, diagnostic age evidence evaluator, presence-gate evidence attachment, focused tests and docs. Threshold remains UNRESOLVED_MAX_AGE; enforcement_enabled=false; no Alpha age blocking; no second clock/volatility/freshness gate; rematerialization forbidden; no parameter research; no live/orders."
   ],
   "pr_specific_exception": false,
   "required_check_waiver": false,
@@ -932,6 +936,7 @@
     "POST_CONFIRMATION_SURVIVAL_SUITABILITY_COMPOSITION_BINDING_V1 exact-file allowlist for C4 binding guards + Research C1 DISTINCT + C4 tests/docs (offline binding only)",
     "CANONICAL_VOLATILITY_TYPED_RUNTIME_PRODUCER_SCAFFOLD_V1 exact-file allowlist for offline producer scaffold + mark history + observation_count provenance (no cutover/wiring)",
     "CANONICAL_VOLATILITY_PRODUCTIVE_RUNTIME_CMC_TYPED_BINDING_V1 exact-file allowlist for productive CMC typed binding host + hardening bridge caller (CMC transport only; no Double-Play typed cutover)",
-    "DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1 exact-file allowlist for productive typed presence gate + replay opt-in + hardening bridge consumption + tests/docs (no Direct-Typed consumer; no numeric max-age; no global typed-only)"
+    "DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1 exact-file allowlist for productive typed presence gate + replay opt-in + hardening bridge consumption + tests/docs (no Direct-Typed consumer; no numeric max-age threshold; no global typed-only)",
+    "CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_POLICY_CONTRACT_AND_NON_ENFORCING_TELEMETRY_V1 exact-file allowlist for non-enforcing max-age policy contract + diagnostic age evidence + presence-gate attachment + tests/docs (threshold unresolved; no Alpha enforcement; no second freshness gate)"
   ]
 }

--- a/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_POLICY_CONTRACT_AND_NON_ENFORCING_TELEMETRY_V1.md
+++ b/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_POLICY_CONTRACT_AND_NON_ENFORCING_TELEMETRY_V1.md
@@ -1,0 +1,168 @@
+# MASTER_V2 Canonical Volatility Numeric Max-Age Policy Contract And Non-Enforcing Telemetry v1
+
+---
+docs_token: DOCS_TOKEN_MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_POLICY_CONTRACT_AND_NON_ENFORCING_TELEMETRY_V1
+STATUS: CAPABILITY_AVAILABLE
+scope: versioned non-enforcing estimate-age policy contract and diagnostic telemetry
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+NUMERIC_MAX_AGE_DECIDED: false
+NUMERIC_THRESHOLD_SELECTED: false
+THRESHOLD_STATUS: UNRESOLVED_MAX_AGE
+ENFORCEMENT_ENABLED: false
+COMPUTED_AGE_DIAGNOSTIC_ONLY: true
+HARD_STOP: true
+---
+
+> **Non-enforcing policy contract.** Implements the ratified Event-Time age
+> semantics for `CanonicalVolatilityEstimateV1` as typed policy &#47; evidence
+> types and diagnostic telemetry attached to the existing Double-Play typed
+> volatility presence gate. Does **not** select a numeric threshold, enable
+> Alpha enforcement, rematerialize estimates, or create a second clock &#47;
+> volatility &#47; Alpha authority.
+
+## Machine summary
+
+```
+CAPABILITY_ID=MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_POLICY_CONTRACT_AND_NON_ENFORCING_TELEMETRY_V1
+POLICY_NAME=canonical_volatility_numeric_max_age_policy
+POLICY_VERSION=canonical_volatility_numeric_max_age_policy/v1
+AGE_REFERENCE_CLOCK=MARKET_EVENT_TIME
+AGE_REFERENCE_FIELD=CanonicalMarketContextV1.market_event_time
+AGE_TIMESTAMP_FIELD=CanonicalVolatilityEstimateV1.as_of_event_time
+AGE_FORMULA=reference_market_event_time_-_estimate.as_of_event_time
+THRESHOLD_STATUS=UNRESOLVED_MAX_AGE
+NUMERIC_MAX_AGE_SECONDS=null
+ENFORCEMENT_ENABLED=false
+UNRESOLVED_MAX_AGE_IS_NOT_FRESHNESS_APPROVAL=true
+COMPUTED_AGE_IS_DIAGNOSTIC_ONLY=true
+NO_NUMERIC_THRESHOLD_SELECTED=true
+NO_ALPHA_ENFORCEMENT_ENABLED=true
+REMATERIALIZATION_POLICY=FORBIDDEN
+GATE_OWNER=evaluate_double_play_runtime_typed_volatility_presence_gate_v1
+SEPARATE_FRESHNESS_GATE_CREATED=false
+SECOND_CLOCK_AUTHORITY_CREATED=false
+SECOND_VOLATILITY_AUTHORITY_CREATED=false
+SECOND_ALPHA_DECISION_AUTHORITY_CREATED=false
+GLOBAL_STALENESS_GATE_CREATED=false
+LIVE_AUTHORIZATION=false
+HARD_STOP=true
+```
+
+## Goals
+
+- Typed policy contract with unresolved threshold
+- Deterministic Event-Time age computation (`computed_age_seconds`)
+- Non-enforcing evidence attached to the existing presence gate
+- Compose ClockTrust &#47; DataIntegrity &#47; Presence &#47; Reuse &#47; Restart without replacing them
+- Offline &#47; runtime equivalence for identical Event-Time inputs
+
+## Non-goals
+
+- numeric `max_age_seconds` selection or derivation
+- FRESH &#47; STALE productive enforcement
+- Alpha &#47; Scope &#47; Boundary &#47; Directional blocking by age
+- Rematerialization
+- Separate freshness gate or global staleness gate
+- Live &#47; Testnet &#47; Shadow &#47; order routing
+- Parameter research
+
+## Ratified Event-Time semantics
+
+```
+volatility_estimate_age
+  = reference_market_event_time
+  - estimate.as_of_event_time
+```
+
+- `decision_time` is not a freshness clock
+- Wallclock &#47; receive time &#47; runtime &#47; replay cycle are not freshness clocks
+- Duplicate &#47; no-sample &#47; process reuse do not refresh age
+- Restart &#47; restore leave age `UNDEFINED` until a regular `PRODUCED`
+- Rematerialization remains `FORBIDDEN`
+
+## Policy contract
+
+Required structural fields and ratified unresolved values:
+
+| Field | Value |
+|---|---|
+| threshold_status | `UNRESOLVED_MAX_AGE` |
+| numeric_max_age_seconds | `None` |
+| enforcement_enabled | `false` |
+| rematerialization_policy | `FORBIDDEN` |
+| duplicate_reuse_refreshes | `false` |
+| no_sample_reuse_refreshes | `false` |
+| restart_age_policy | `UNDEFINED_FAIL_CLOSED_UNTIL_PRODUCED` |
+| restore_policy | `HISTORY_ONLY_NO_ESTIMATE_NO_FRESH_MARK` |
+
+Illegal constructions are rejected fail-closed (unresolved + numeric threshold,
+enforcement without ratified threshold, wrong reference clock, rematerialize
+as freshness reset).
+
+## Evidence schema
+
+Evidence fields include `policy_name`, `policy_version`,
+`estimate_as_of_event_time`, `reference_event_time`, `computed_age_seconds`,
+`max_age_status`, `threshold_status`, `presence_status`, `clock_trust_status`,
+`data_integrity_status`, `reuse_status`, `restart_status`, `source_digest`,
+`decision`, `reason_code`, `enforcement_applied=false`.
+
+`computed_age_seconds` is emitted only when both Event Times are parseable and
+`reference_event_time >= estimate_as_of_event_time`.
+
+## Reason codes
+
+Structural codes include presence &#47; restart &#47; time-coherence codes and
+composition hints for untrusted clock &#47; data. `VOLATILITY_ESTIMATE_FRESH` and
+`VOLATILITY_ESTIMATE_STALE` exist structurally but are **not** emitted while
+`threshold_status=UNRESOLVED_MAX_AGE`. With a computable age and unresolved
+threshold the productive diagnostic reason is
+`VOLATILITY_ESTIMATE_AGE_UNRESOLVED`.
+
+## Precedence
+
+1. Presence missing &#47; invalid &#47; restart unavailable
+2. Data Integrity untrusted &#47; invalid &#47; unknown
+3. Clock Trust untrusted &#47; invalid &#47; unknown
+4. Volatility Age unresolved
+5. Fresh &#47; Stale only after a separate ratified threshold capability
+
+DataIntegrity and ClockTrust remain primary CMC authorities. Age evidence is
+secondary &#47; diagnostic only.
+
+## Integration
+
+```
+evaluate_double_play_runtime_typed_volatility_presence_gate_v1
+  → existing presence Alpha decision (unchanged)
+  → evaluate_canonical_volatility_estimate_age_policy_v1 (attached evidence)
+```
+
+- `REUSE_EXISTING_TYPED_VOLATILITY_PRESENCE_GATE=true`
+- `NO_SEPARATE_FRESHNESS_GATE=true`
+- Exit &#47; Risk &#47; Safety authority preserved
+
+## Offline &#47; runtime equivalence
+
+Identical Event-Time inputs yield identical age evidence. Wallclock and
+execution duration must not affect results. Productive isolation remains via
+`require_productive_typed_volatility_presence_gate`.
+
+## Explicit remaining boundary
+
+```
+NEXT_AFTER_THIS_CAPABILITY=
+SEPARATE_OPERATOR_AUTHORIZED_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_AND_SELECTION
+```
+
+That later capability is **not** part of this delivery.
+
+## Owners
+
+| Artifact | Path |
+|---|---|
+| Policy &#47; evaluation | `src&#47;trading&#47;master_v2&#47;canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1.py` |
+| Presence-gate attach | `src&#47;trading&#47;master_v2&#47;double_play_runtime_typed_volatility_presence_gate_v1.py` |
+| Spec | this document |
+| Tests | `tests&#47;trading&#47;master_v2&#47;test_canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1.py` |

--- a/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1.md
+++ b/docs/ops/specs/MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1.md
@@ -66,8 +66,9 @@ HARD_STOP=true
 4. **Lifecycle** — Warmup &#47; restart without estimate &#47; duplicate without prior &#47;
    out-of-order &#47; history gap &#47; persistence &#47; materialization failures remain
    fail-closed until a valid typed estimate is bound. Duplicate&#47;cycle reuse with a
-   valid prior keeps existing reuse semantics. `UNRESOLVED_MAX_AGE` stays
-   telemetry only — no numeric max-age policy.
+   valid prior keeps existing reuse semantics. Non-enforcing max-age policy
+   evidence may be attached; `UNRESOLVED_MAX_AGE` is diagnostic only — no
+   numeric threshold and no Alpha enforcement by age.
 
 5. **Isolation** — Opt-in via
    `require_productive_typed_volatility_presence_gate=True` on the productive
@@ -85,7 +86,7 @@ HARD_STOP=true
 
 ## Explicit non-goals
 
-- no numeric max-age policy
+- no numeric max-age **threshold** decision &#47; Alpha enforcement by age
 - no global typed-only enforcement
 - no Direct-Typed consumer refactor in Scope &#47; Rules &#47; Bridge
 - no second estimator &#47; binder &#47; adapter &#47; validator

--- a/src/trading/master_v2/canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1.py
+++ b/src/trading/master_v2/canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1.py
@@ -1,0 +1,703 @@
+"""Canonical volatility numeric max-age policy contract + non-enforcing telemetry v1.
+
+Provides a versioned, typed policy and evidence contract for the ratified
+estimate-age semantics. Computes diagnostic ``computed_age_seconds`` from
+market event time minus ``CanonicalVolatilityEstimateV1.as_of_event_time``.
+
+Does **not** select a numeric threshold, enable Alpha enforcement, create a
+second clock/volatility/alpha authority, rematerialize estimates, or alter
+Exit/Risk/Safety authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional, Union
+
+from trading.master_v2.canonical_market_context_v1 import (
+    ClockTrustStatus,
+    DataIntegrityStatus,
+)
+from trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1 import (
+    CanonicalVolatilityEstimateV1,
+)
+
+PACKAGE_MARKER = (
+    "MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_POLICY_CONTRACT_"
+    "AND_NON_ENFORCING_TELEMETRY_V1=true"
+)
+
+CAPABILITY_ID = (
+    "MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_POLICY_CONTRACT_AND_NON_ENFORCING_TELEMETRY_V1"
+)
+CAPABILITY_VERSION = (
+    "canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry/v1"
+)
+POLICY_NAME = "canonical_volatility_numeric_max_age_policy"
+POLICY_VERSION = "canonical_volatility_numeric_max_age_policy/v1"
+POLICY_OWNER = (
+    "trading.master_v2."
+    "canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1"
+)
+PRESENCE_GATE_OWNER = "trading.master_v2.double_play_runtime_typed_volatility_presence_gate_v1"
+
+AGE_REFERENCE_CLOCK = "MARKET_EVENT_TIME"
+AGE_REFERENCE_FIELD = "CanonicalMarketContextV1.market_event_time"
+AGE_TIMESTAMP_FIELD = "CanonicalVolatilityEstimateV1.as_of_event_time"
+AGE_FORMULA = "reference_market_event_time_-_estimate.as_of_event_time"
+
+THRESHOLD_STATUS_UNRESOLVED = "UNRESOLVED_MAX_AGE"
+REMATERIALIZATION_FORBIDDEN = "FORBIDDEN"
+RESTART_AGE_POLICY = "UNDEFINED_FAIL_CLOSED_UNTIL_PRODUCED"
+RESTORE_POLICY = "HISTORY_ONLY_NO_ESTIMATE_NO_FRESH_MARK"
+
+NUMERIC_MAX_AGE_DECIDED = False
+NUMERIC_THRESHOLD_SELECTED = False
+ENFORCEMENT_ENABLED = False
+COMPUTED_AGE_DIAGNOSTIC_ONLY = True
+UNRESOLVED_MAX_AGE_IS_NOT_FRESHNESS_APPROVAL = True
+NO_ALPHA_ENFORCEMENT_ENABLED = True
+REMATERIALIZATION_ENABLED = False
+SEPARATE_FRESHNESS_GATE_CREATED = False
+SECOND_CLOCK_AUTHORITY_CREATED = False
+SECOND_VOLATILITY_AUTHORITY_CREATED = False
+SECOND_ALPHA_DECISION_AUTHORITY_CREATED = False
+GLOBAL_STALENESS_GATE_CREATED = False
+LIVE_AUTHORIZATION = False
+HARD_STOP = True
+
+NEXT_AFTER_THIS_CAPABILITY = (
+    "SEPARATE_OPERATOR_AUTHORIZED_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_AND_SELECTION"
+)
+
+_TRUSTED_CLOCK = frozenset({ClockTrustStatus.TRUSTED})
+_TRUSTED_DATA = frozenset({DataIntegrityStatus.TRUSTED})
+
+
+class CanonicalVolatilityMaxAgePolicyContractError(ValueError):
+    """Fail-closed invalid policy-contract construction."""
+
+
+class VolatilityMaxAgeReasonCodeV1(str, Enum):
+    VOLATILITY_ESTIMATE_PRESENT = "VOLATILITY_ESTIMATE_PRESENT"
+    VOLATILITY_ESTIMATE_MISSING = "VOLATILITY_ESTIMATE_MISSING"
+    VOLATILITY_ESTIMATE_INVALID = "VOLATILITY_ESTIMATE_INVALID"
+    VOLATILITY_ESTIMATE_RESTART_UNAVAILABLE = "VOLATILITY_ESTIMATE_RESTART_UNAVAILABLE"
+    VOLATILITY_ESTIMATE_AGE_UNRESOLVED = "VOLATILITY_ESTIMATE_AGE_UNRESOLVED"
+    # Structural only — must not be emitted while threshold is unresolved.
+    VOLATILITY_ESTIMATE_FRESH = "VOLATILITY_ESTIMATE_FRESH"
+    VOLATILITY_ESTIMATE_STALE = "VOLATILITY_ESTIMATE_STALE"
+    VOLATILITY_AS_OF_MISSING = "VOLATILITY_AS_OF_MISSING"
+    VOLATILITY_REFERENCE_TIME_MISSING = "VOLATILITY_REFERENCE_TIME_MISSING"
+    VOLATILITY_REFERENCE_BEFORE_AS_OF = "VOLATILITY_REFERENCE_BEFORE_AS_OF"
+    VOLATILITY_FRESHNESS_CLOCK_UNTRUSTED = "VOLATILITY_FRESHNESS_CLOCK_UNTRUSTED"
+    VOLATILITY_FRESHNESS_DATA_UNTRUSTED = "VOLATILITY_FRESHNESS_DATA_UNTRUSTED"
+
+
+class VolatilityMaxAgeStatusV1(str, Enum):
+    NOT_EVALUATED = "NOT_EVALUATED"
+    UNDEFINED = "UNDEFINED"
+    AGE_COMPUTED_THRESHOLD_UNRESOLVED = "AGE_COMPUTED_THRESHOLD_UNRESOLVED"
+    REFERENCE_BEFORE_AS_OF = "REFERENCE_BEFORE_AS_OF"
+    REFERENCE_TIME_MISSING = "REFERENCE_TIME_MISSING"
+    AS_OF_MISSING = "AS_OF_MISSING"
+    UNRESOLVED_MAX_AGE = "UNRESOLVED_MAX_AGE"
+
+
+class VolatilityPresenceStatusV1(str, Enum):
+    PRESENT = "PRESENT"
+    MISSING = "MISSING"
+    INVALID = "INVALID"
+    RESTART_UNAVAILABLE = "RESTART_UNAVAILABLE"
+
+
+class VolatilityReuseStatusV1(str, Enum):
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+    NONE = "NONE"
+    DUPLICATE_REUSE = "DUPLICATE_REUSE"
+    NO_SAMPLE_CYCLE_REUSE = "NO_SAMPLE_CYCLE_REUSE"
+    PROCESS_REUSE = "PROCESS_REUSE"
+
+
+class VolatilityRestartStatusV1(str, Enum):
+    NOT_RESTART = "NOT_RESTART"
+    RESTART_WITHOUT_ESTIMATE = "RESTART_WITHOUT_ESTIMATE"
+    HISTORY_RESTORE_WITHOUT_ESTIMATE = "HISTORY_RESTORE_WITHOUT_ESTIMATE"
+
+
+class VolatilityMaxAgeDecisionV1(str, Enum):
+    DIAGNOSTIC_ONLY = "DIAGNOSTIC_ONLY"
+    NOT_EVALUATED_PRESENCE_AUTHORITY = "NOT_EVALUATED_PRESENCE_AUTHORITY"
+    FAIL_CLOSED_DIAGNOSTIC = "FAIL_CLOSED_DIAGNOSTIC"
+    COMPOSED_TRUST_SECONDARY = "COMPOSED_TRUST_SECONDARY"
+
+
+@dataclass(frozen=True)
+class CanonicalVolatilityNumericMaxAgePolicyContractV1:
+    """Versioned non-enforcing max-age policy contract (threshold unresolved)."""
+
+    policy_name: str
+    policy_version: str
+    reference_clock: str
+    reference_field: str
+    estimate_timestamp_field: str
+    age_formula: str
+    threshold_status: str
+    numeric_max_age_seconds: Optional[float]
+    enforcement_enabled: bool
+    rematerialization_policy: str
+    duplicate_reuse_refreshes: bool
+    no_sample_reuse_refreshes: bool
+    restart_age_policy: str
+    restore_policy: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "age_formula": self.age_formula,
+            "duplicate_reuse_refreshes": self.duplicate_reuse_refreshes,
+            "enforcement_enabled": self.enforcement_enabled,
+            "estimate_timestamp_field": self.estimate_timestamp_field,
+            "no_sample_reuse_refreshes": self.no_sample_reuse_refreshes,
+            "numeric_max_age_seconds": self.numeric_max_age_seconds,
+            "policy_name": self.policy_name,
+            "policy_version": self.policy_version,
+            "reference_clock": self.reference_clock,
+            "reference_field": self.reference_field,
+            "rematerialization_policy": self.rematerialization_policy,
+            "restart_age_policy": self.restart_age_policy,
+            "restore_policy": self.restore_policy,
+            "threshold_status": self.threshold_status,
+        }
+
+
+def validate_canonical_volatility_numeric_max_age_policy_contract_v1(
+    policy: CanonicalVolatilityNumericMaxAgePolicyContractV1,
+) -> CanonicalVolatilityNumericMaxAgePolicyContractV1:
+    """Reject illegal contract states (unresolved+threshold, enforcement, wrong clock)."""
+    if policy.reference_clock != AGE_REFERENCE_CLOCK:
+        raise CanonicalVolatilityMaxAgePolicyContractError(
+            f"reference_clock_must_be_{AGE_REFERENCE_CLOCK}"
+        )
+    if policy.reference_field != AGE_REFERENCE_FIELD:
+        raise CanonicalVolatilityMaxAgePolicyContractError("reference_field_mismatch")
+    if policy.estimate_timestamp_field != AGE_TIMESTAMP_FIELD:
+        raise CanonicalVolatilityMaxAgePolicyContractError("estimate_timestamp_field_mismatch")
+    if policy.age_formula != AGE_FORMULA:
+        raise CanonicalVolatilityMaxAgePolicyContractError("age_formula_mismatch")
+    if policy.rematerialization_policy != REMATERIALIZATION_FORBIDDEN:
+        raise CanonicalVolatilityMaxAgePolicyContractError("rematerialization_must_be_forbidden")
+    if policy.duplicate_reuse_refreshes is not False:
+        raise CanonicalVolatilityMaxAgePolicyContractError("duplicate_reuse_must_not_refresh")
+    if policy.no_sample_reuse_refreshes is not False:
+        raise CanonicalVolatilityMaxAgePolicyContractError("no_sample_reuse_must_not_refresh")
+    if policy.restart_age_policy != RESTART_AGE_POLICY:
+        raise CanonicalVolatilityMaxAgePolicyContractError("restart_age_policy_mismatch")
+    if policy.restore_policy != RESTORE_POLICY:
+        raise CanonicalVolatilityMaxAgePolicyContractError("restore_policy_mismatch")
+
+    if policy.threshold_status == THRESHOLD_STATUS_UNRESOLVED:
+        if policy.numeric_max_age_seconds is not None:
+            raise CanonicalVolatilityMaxAgePolicyContractError(
+                "unresolved_threshold_forbids_numeric_max_age_seconds"
+            )
+        if policy.enforcement_enabled is not False:
+            raise CanonicalVolatilityMaxAgePolicyContractError(
+                "unresolved_threshold_forbids_enforcement"
+            )
+    elif policy.enforcement_enabled and policy.numeric_max_age_seconds is None:
+        raise CanonicalVolatilityMaxAgePolicyContractError(
+            "enforcement_requires_ratified_numeric_threshold"
+        )
+    elif policy.enforcement_enabled:
+        # This capability never admits a ratified threshold path.
+        raise CanonicalVolatilityMaxAgePolicyContractError(
+            "enforcement_forbidden_while_numeric_max_age_undecided"
+        )
+
+    if policy.enforcement_enabled is True and NUMERIC_MAX_AGE_DECIDED is False:
+        raise CanonicalVolatilityMaxAgePolicyContractError(
+            "enforcement_forbidden_while_numeric_max_age_undecided"
+        )
+
+    return policy
+
+
+def build_ratified_unresolved_max_age_policy_contract_v1() -> (
+    CanonicalVolatilityNumericMaxAgePolicyContractV1
+):
+    """Construct the single ratified non-enforcing unresolved policy."""
+    policy = CanonicalVolatilityNumericMaxAgePolicyContractV1(
+        policy_name=POLICY_NAME,
+        policy_version=POLICY_VERSION,
+        reference_clock=AGE_REFERENCE_CLOCK,
+        reference_field=AGE_REFERENCE_FIELD,
+        estimate_timestamp_field=AGE_TIMESTAMP_FIELD,
+        age_formula=AGE_FORMULA,
+        threshold_status=THRESHOLD_STATUS_UNRESOLVED,
+        numeric_max_age_seconds=None,
+        enforcement_enabled=False,
+        rematerialization_policy=REMATERIALIZATION_FORBIDDEN,
+        duplicate_reuse_refreshes=False,
+        no_sample_reuse_refreshes=False,
+        restart_age_policy=RESTART_AGE_POLICY,
+        restore_policy=RESTORE_POLICY,
+    )
+    return validate_canonical_volatility_numeric_max_age_policy_contract_v1(policy)
+
+
+@dataclass(frozen=True)
+class CanonicalVolatilityMaxAgePolicyEvidenceV1:
+    """Non-enforcing age/freshness evidence (diagnostic only)."""
+
+    policy_name: str
+    policy_version: str
+    estimate_as_of_event_time: Optional[str]
+    reference_event_time: Optional[str]
+    computed_age_seconds: Optional[float]
+    max_age_status: str
+    threshold_status: str
+    presence_status: str
+    clock_trust_status: str
+    data_integrity_status: str
+    reuse_status: str
+    restart_status: str
+    source_digest: Optional[str]
+    decision: str
+    reason_code: str
+    enforcement_applied: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "clock_trust_status": self.clock_trust_status,
+            "computed_age_seconds": self.computed_age_seconds,
+            "data_integrity_status": self.data_integrity_status,
+            "decision": self.decision,
+            "enforcement_applied": self.enforcement_applied,
+            "estimate_as_of_event_time": self.estimate_as_of_event_time,
+            "max_age_status": self.max_age_status,
+            "policy_name": self.policy_name,
+            "policy_version": self.policy_version,
+            "presence_status": self.presence_status,
+            "reason_code": self.reason_code,
+            "reference_event_time": self.reference_event_time,
+            "restart_status": self.restart_status,
+            "reuse_status": self.reuse_status,
+            "source_digest": self.source_digest,
+            "threshold_status": self.threshold_status,
+        }
+
+
+def parse_event_time_instant_v1(
+    value: Union[str, datetime, None],
+) -> Optional[datetime]:
+    """Parse timezone-aware UTC event time; reject naive / unparseable values."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return None
+        return value.astimezone(timezone.utc)
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso_utc(value: Optional[datetime]) -> Optional[str]:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _evidence(
+    *,
+    policy: CanonicalVolatilityNumericMaxAgePolicyContractV1,
+    estimate_as_of: Optional[datetime],
+    reference: Optional[datetime],
+    computed_age_seconds: Optional[float],
+    max_age_status: VolatilityMaxAgeStatusV1,
+    presence_status: VolatilityPresenceStatusV1,
+    clock_trust_status: ClockTrustStatus,
+    data_integrity_status: DataIntegrityStatus,
+    reuse_status: VolatilityReuseStatusV1,
+    restart_status: VolatilityRestartStatusV1,
+    source_digest: Optional[str],
+    decision: VolatilityMaxAgeDecisionV1,
+    reason_code: VolatilityMaxAgeReasonCodeV1,
+) -> CanonicalVolatilityMaxAgePolicyEvidenceV1:
+    # Structural FRESH/STALE must never be emitted under unresolved threshold.
+    if reason_code in (
+        VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_FRESH,
+        VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_STALE,
+    ):
+        raise CanonicalVolatilityMaxAgePolicyContractError(
+            "fresh_or_stale_forbidden_while_threshold_unresolved"
+        )
+    return CanonicalVolatilityMaxAgePolicyEvidenceV1(
+        policy_name=policy.policy_name,
+        policy_version=policy.policy_version,
+        estimate_as_of_event_time=_iso_utc(estimate_as_of),
+        reference_event_time=_iso_utc(reference),
+        computed_age_seconds=computed_age_seconds,
+        max_age_status=max_age_status.value,
+        threshold_status=policy.threshold_status,
+        presence_status=presence_status.value,
+        clock_trust_status=clock_trust_status.value,
+        data_integrity_status=data_integrity_status.value,
+        reuse_status=reuse_status.value,
+        restart_status=restart_status.value,
+        source_digest=source_digest,
+        decision=decision.value,
+        reason_code=reason_code.value,
+        enforcement_applied=False,
+    )
+
+
+def evaluate_canonical_volatility_estimate_age_policy_v1(
+    *,
+    estimate: Optional[CanonicalVolatilityEstimateV1],
+    reference_market_event_time: Union[str, datetime, None],
+    presence_status: VolatilityPresenceStatusV1,
+    reuse_status: VolatilityReuseStatusV1 = VolatilityReuseStatusV1.NOT_APPLICABLE,
+    restart_status: VolatilityRestartStatusV1 = VolatilityRestartStatusV1.NOT_RESTART,
+    clock_trust_status: ClockTrustStatus = ClockTrustStatus.TRUSTED,
+    data_integrity_status: DataIntegrityStatus = DataIntegrityStatus.TRUSTED,
+    policy: CanonicalVolatilityNumericMaxAgePolicyContractV1 | None = None,
+) -> CanonicalVolatilityMaxAgePolicyEvidenceV1:
+    """Pure deterministic age/policy evaluation; never enforces Alpha decisions."""
+    ratified = validate_canonical_volatility_numeric_max_age_policy_contract_v1(
+        policy if policy is not None else build_ratified_unresolved_max_age_policy_contract_v1()
+    )
+    source_digest = None if estimate is None else str(estimate.source_digest)
+    as_of_raw = None if estimate is None else estimate.as_of_event_time
+    as_of = parse_event_time_instant_v1(as_of_raw)
+    reference = parse_event_time_instant_v1(reference_market_event_time)
+
+    # Precedence 1: presence / restart
+    if (
+        restart_status
+        in (
+            VolatilityRestartStatusV1.RESTART_WITHOUT_ESTIMATE,
+            VolatilityRestartStatusV1.HISTORY_RESTORE_WITHOUT_ESTIMATE,
+        )
+        or presence_status is VolatilityPresenceStatusV1.RESTART_UNAVAILABLE
+    ):
+        return _evidence(
+            policy=ratified,
+            estimate_as_of=as_of,
+            reference=reference,
+            computed_age_seconds=None,
+            max_age_status=VolatilityMaxAgeStatusV1.UNDEFINED,
+            presence_status=VolatilityPresenceStatusV1.RESTART_UNAVAILABLE,
+            clock_trust_status=clock_trust_status,
+            data_integrity_status=data_integrity_status,
+            reuse_status=reuse_status,
+            restart_status=restart_status,
+            source_digest=source_digest,
+            decision=VolatilityMaxAgeDecisionV1.NOT_EVALUATED_PRESENCE_AUTHORITY,
+            reason_code=VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_RESTART_UNAVAILABLE,
+        )
+
+    if presence_status is VolatilityPresenceStatusV1.MISSING or estimate is None:
+        return _evidence(
+            policy=ratified,
+            estimate_as_of=None,
+            reference=reference,
+            computed_age_seconds=None,
+            max_age_status=VolatilityMaxAgeStatusV1.NOT_EVALUATED,
+            presence_status=VolatilityPresenceStatusV1.MISSING,
+            clock_trust_status=clock_trust_status,
+            data_integrity_status=data_integrity_status,
+            reuse_status=reuse_status,
+            restart_status=restart_status,
+            source_digest=None,
+            decision=VolatilityMaxAgeDecisionV1.NOT_EVALUATED_PRESENCE_AUTHORITY,
+            reason_code=VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_MISSING,
+        )
+
+    if presence_status is VolatilityPresenceStatusV1.INVALID:
+        return _evidence(
+            policy=ratified,
+            estimate_as_of=as_of,
+            reference=reference,
+            computed_age_seconds=None,
+            max_age_status=VolatilityMaxAgeStatusV1.NOT_EVALUATED,
+            presence_status=VolatilityPresenceStatusV1.INVALID,
+            clock_trust_status=clock_trust_status,
+            data_integrity_status=data_integrity_status,
+            reuse_status=reuse_status,
+            restart_status=restart_status,
+            source_digest=source_digest,
+            decision=VolatilityMaxAgeDecisionV1.NOT_EVALUATED_PRESENCE_AUTHORITY,
+            reason_code=VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_INVALID,
+        )
+
+    # Precedence 2: Data Integrity (primary authority preserved; freshness secondary)
+    if data_integrity_status not in _TRUSTED_DATA:
+        return _evidence(
+            policy=ratified,
+            estimate_as_of=as_of,
+            reference=reference,
+            computed_age_seconds=None,
+            max_age_status=VolatilityMaxAgeStatusV1.NOT_EVALUATED,
+            presence_status=VolatilityPresenceStatusV1.PRESENT,
+            clock_trust_status=clock_trust_status,
+            data_integrity_status=data_integrity_status,
+            reuse_status=reuse_status,
+            restart_status=restart_status,
+            source_digest=source_digest,
+            decision=VolatilityMaxAgeDecisionV1.COMPOSED_TRUST_SECONDARY,
+            reason_code=VolatilityMaxAgeReasonCodeV1.VOLATILITY_FRESHNESS_DATA_UNTRUSTED,
+        )
+
+    # Precedence 3: Clock Trust (primary authority preserved; freshness secondary)
+    if clock_trust_status not in _TRUSTED_CLOCK:
+        return _evidence(
+            policy=ratified,
+            estimate_as_of=as_of,
+            reference=reference,
+            computed_age_seconds=None,
+            max_age_status=VolatilityMaxAgeStatusV1.NOT_EVALUATED,
+            presence_status=VolatilityPresenceStatusV1.PRESENT,
+            clock_trust_status=clock_trust_status,
+            data_integrity_status=data_integrity_status,
+            reuse_status=reuse_status,
+            restart_status=restart_status,
+            source_digest=source_digest,
+            decision=VolatilityMaxAgeDecisionV1.COMPOSED_TRUST_SECONDARY,
+            reason_code=VolatilityMaxAgeReasonCodeV1.VOLATILITY_FRESHNESS_CLOCK_UNTRUSTED,
+        )
+
+    # Precedence 4: age resolution (never FRESH/STALE under unresolved threshold)
+    if as_of is None:
+        return _evidence(
+            policy=ratified,
+            estimate_as_of=None,
+            reference=reference,
+            computed_age_seconds=None,
+            max_age_status=VolatilityMaxAgeStatusV1.AS_OF_MISSING,
+            presence_status=VolatilityPresenceStatusV1.PRESENT,
+            clock_trust_status=clock_trust_status,
+            data_integrity_status=data_integrity_status,
+            reuse_status=reuse_status,
+            restart_status=restart_status,
+            source_digest=source_digest,
+            decision=VolatilityMaxAgeDecisionV1.FAIL_CLOSED_DIAGNOSTIC,
+            reason_code=VolatilityMaxAgeReasonCodeV1.VOLATILITY_AS_OF_MISSING,
+        )
+
+    if reference is None:
+        return _evidence(
+            policy=ratified,
+            estimate_as_of=as_of,
+            reference=None,
+            computed_age_seconds=None,
+            max_age_status=VolatilityMaxAgeStatusV1.REFERENCE_TIME_MISSING,
+            presence_status=VolatilityPresenceStatusV1.PRESENT,
+            clock_trust_status=clock_trust_status,
+            data_integrity_status=data_integrity_status,
+            reuse_status=reuse_status,
+            restart_status=restart_status,
+            source_digest=source_digest,
+            decision=VolatilityMaxAgeDecisionV1.FAIL_CLOSED_DIAGNOSTIC,
+            reason_code=VolatilityMaxAgeReasonCodeV1.VOLATILITY_REFERENCE_TIME_MISSING,
+        )
+
+    if reference < as_of:
+        return _evidence(
+            policy=ratified,
+            estimate_as_of=as_of,
+            reference=reference,
+            computed_age_seconds=None,
+            max_age_status=VolatilityMaxAgeStatusV1.REFERENCE_BEFORE_AS_OF,
+            presence_status=VolatilityPresenceStatusV1.PRESENT,
+            clock_trust_status=clock_trust_status,
+            data_integrity_status=data_integrity_status,
+            reuse_status=reuse_status,
+            restart_status=restart_status,
+            source_digest=source_digest,
+            decision=VolatilityMaxAgeDecisionV1.FAIL_CLOSED_DIAGNOSTIC,
+            reason_code=VolatilityMaxAgeReasonCodeV1.VOLATILITY_REFERENCE_BEFORE_AS_OF,
+        )
+
+    age_seconds = (reference - as_of).total_seconds()
+    if age_seconds < 0.0:
+        # Defensive: should be unreachable after reference < as_of guard.
+        raise CanonicalVolatilityMaxAgePolicyContractError("negative_age_forbidden")
+
+    return _evidence(
+        policy=ratified,
+        estimate_as_of=as_of,
+        reference=reference,
+        computed_age_seconds=float(age_seconds),
+        max_age_status=VolatilityMaxAgeStatusV1.AGE_COMPUTED_THRESHOLD_UNRESOLVED,
+        presence_status=VolatilityPresenceStatusV1.PRESENT,
+        clock_trust_status=clock_trust_status,
+        data_integrity_status=data_integrity_status,
+        reuse_status=reuse_status,
+        restart_status=restart_status,
+        source_digest=source_digest,
+        decision=VolatilityMaxAgeDecisionV1.DIAGNOSTIC_ONLY,
+        reason_code=VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_AGE_UNRESOLVED,
+    )
+
+
+def derive_presence_status_for_age_policy_v1(
+    *,
+    typed_estimate_present: bool,
+    typed_validation_ok: bool,
+    restart_without_estimate: bool = False,
+) -> VolatilityPresenceStatusV1:
+    if restart_without_estimate and not typed_estimate_present:
+        return VolatilityPresenceStatusV1.RESTART_UNAVAILABLE
+    if not typed_estimate_present:
+        return VolatilityPresenceStatusV1.MISSING
+    if not typed_validation_ok:
+        return VolatilityPresenceStatusV1.INVALID
+    return VolatilityPresenceStatusV1.PRESENT
+
+
+def assert_architecture_guards_v1(*, repo_root: Optional[Path] = None) -> dict[str, Any]:
+    """Guards: unresolved threshold, no enforcement, no second authorities."""
+    root = repo_root or Path(__file__).resolve().parents[3]
+    this_src = (
+        root
+        / "src/trading/master_v2"
+        / "canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1.py"
+    ).read_text(encoding="utf-8")
+    presence_src = (
+        root / "src/trading/master_v2/double_play_runtime_typed_volatility_presence_gate_v1.py"
+    ).read_text(encoding="utf-8")
+
+    code_before_guards = this_src.split("def assert_architecture_guards_v1", 1)[0]
+    if "enforcement_applied=True" in code_before_guards:
+        raise RuntimeError("ENFORCEMENT_APPLIED_TRUE_FORBIDDEN")
+    if "numeric_max_age_seconds=" in code_before_guards:
+        # Allow None assignment only via ratified builder; forbid literal numeric thresholds.
+        for line in code_before_guards.splitlines():
+            stripped = line.strip()
+            if "numeric_max_age_seconds=" not in stripped:
+                continue
+            if "numeric_max_age_seconds=None" in stripped:
+                continue
+            if "numeric_max_age_seconds:" in stripped:
+                continue
+            if "self.numeric_max_age_seconds" in stripped:
+                continue
+            if "policy.numeric_max_age_seconds" in stripped:
+                continue
+            raise RuntimeError(f"NUMERIC_THRESHOLD_LITERAL_FORBIDDEN:{stripped}")
+
+    if SEPARATE_FRESHNESS_GATE_CREATED or SECOND_ALPHA_DECISION_AUTHORITY_CREATED:
+        raise RuntimeError("SEPARATE_FRESHNESS_OR_ALPHA_GATE_FORBIDDEN")
+    if SECOND_CLOCK_AUTHORITY_CREATED or SECOND_VOLATILITY_AUTHORITY_CREATED:
+        raise RuntimeError("SECOND_AUTHORITY_FLAG_DRIFT")
+    if GLOBAL_STALENESS_GATE_CREATED or REMATERIALIZATION_ENABLED:
+        raise RuntimeError("GLOBAL_STALE_OR_REMATERIALIZE_FORBIDDEN")
+    if NUMERIC_MAX_AGE_DECIDED or ENFORCEMENT_ENABLED or LIVE_AUTHORIZATION:
+        raise RuntimeError("THRESHOLD_ENFORCEMENT_OR_LIVE_FLAG_DRIFT")
+
+    if "evaluate_canonical_volatility_estimate_age_policy_v1" not in presence_src:
+        raise RuntimeError("PRESENCE_GATE_MUST_ATTACH_MAX_AGE_EVIDENCE")
+    if (
+        "def evaluate_freshness_gate" in presence_src
+        or "def evaluate_volatility_freshness_gate" in (presence_src)
+    ):
+        raise RuntimeError("SEPARATE_FRESHNESS_GATE_FUNCTION_FORBIDDEN")
+
+    policy = build_ratified_unresolved_max_age_policy_contract_v1()
+    return {
+        "capability_id": CAPABILITY_ID,
+        "capability_version": CAPABILITY_VERSION,
+        "policy_version": policy.policy_version,
+        "threshold_status": policy.threshold_status,
+        "numeric_max_age_seconds": policy.numeric_max_age_seconds,
+        "enforcement_enabled": policy.enforcement_enabled,
+        "numeric_max_age_decided": NUMERIC_MAX_AGE_DECIDED,
+        "presence_gate_owner": PRESENCE_GATE_OWNER,
+        "policy_owner": POLICY_OWNER,
+        "separate_freshness_gate_created": SEPARATE_FRESHNESS_GATE_CREATED,
+        "second_clock_authority_created": SECOND_CLOCK_AUTHORITY_CREATED,
+        "second_volatility_authority_created": SECOND_VOLATILITY_AUTHORITY_CREATED,
+        "second_alpha_decision_authority_created": SECOND_ALPHA_DECISION_AUTHORITY_CREATED,
+        "global_staleness_gate_created": GLOBAL_STALENESS_GATE_CREATED,
+        "rematerialization_enabled": REMATERIALIZATION_ENABLED,
+        "live_authorization": LIVE_AUTHORIZATION,
+        "hard_stop": HARD_STOP,
+        "guards_pass": True,
+    }
+
+
+def assert_capability_non_goals_v1() -> Mapping[str, Any]:
+    return {
+        "capability_id": CAPABILITY_ID,
+        "capability_version": CAPABILITY_VERSION,
+        "numeric_max_age_decided": NUMERIC_MAX_AGE_DECIDED,
+        "numeric_threshold_selected": NUMERIC_THRESHOLD_SELECTED,
+        "enforcement_enabled": ENFORCEMENT_ENABLED,
+        "computed_age_diagnostic_only": COMPUTED_AGE_DIAGNOSTIC_ONLY,
+        "unresolved_max_age_is_not_freshness_approval": (
+            UNRESOLVED_MAX_AGE_IS_NOT_FRESHNESS_APPROVAL
+        ),
+        "no_alpha_enforcement_enabled": NO_ALPHA_ENFORCEMENT_ENABLED,
+        "rematerialization_enabled": REMATERIALIZATION_ENABLED,
+        "separate_freshness_gate_created": SEPARATE_FRESHNESS_GATE_CREATED,
+        "second_clock_authority_created": SECOND_CLOCK_AUTHORITY_CREATED,
+        "second_volatility_authority_created": SECOND_VOLATILITY_AUTHORITY_CREATED,
+        "second_alpha_decision_authority_created": SECOND_ALPHA_DECISION_AUTHORITY_CREATED,
+        "global_staleness_gate_created": GLOBAL_STALENESS_GATE_CREATED,
+        "live_authorization": LIVE_AUTHORIZATION,
+        "hard_stop": HARD_STOP,
+        "next_after_this_capability": NEXT_AFTER_THIS_CAPABILITY,
+        "package_marker": PACKAGE_MARKER,
+        "gaps_remaining": ("C1_G10_NUMERIC_MAX_AGE_THRESHOLD_VALUE",),
+    }
+
+
+__all__ = [
+    "AGE_FORMULA",
+    "AGE_REFERENCE_CLOCK",
+    "AGE_REFERENCE_FIELD",
+    "AGE_TIMESTAMP_FIELD",
+    "CAPABILITY_ID",
+    "CAPABILITY_VERSION",
+    "CanonicalVolatilityMaxAgePolicyContractError",
+    "CanonicalVolatilityMaxAgePolicyEvidenceV1",
+    "CanonicalVolatilityNumericMaxAgePolicyContractV1",
+    "ENFORCEMENT_ENABLED",
+    "HARD_STOP",
+    "LIVE_AUTHORIZATION",
+    "NUMERIC_MAX_AGE_DECIDED",
+    "PACKAGE_MARKER",
+    "POLICY_NAME",
+    "POLICY_OWNER",
+    "POLICY_VERSION",
+    "PRESENCE_GATE_OWNER",
+    "THRESHOLD_STATUS_UNRESOLVED",
+    "VolatilityMaxAgeDecisionV1",
+    "VolatilityMaxAgeReasonCodeV1",
+    "VolatilityMaxAgeStatusV1",
+    "VolatilityPresenceStatusV1",
+    "VolatilityRestartStatusV1",
+    "VolatilityReuseStatusV1",
+    "assert_architecture_guards_v1",
+    "assert_capability_non_goals_v1",
+    "build_ratified_unresolved_max_age_policy_contract_v1",
+    "derive_presence_status_for_age_policy_v1",
+    "evaluate_canonical_volatility_estimate_age_policy_v1",
+    "parse_event_time_instant_v1",
+    "validate_canonical_volatility_numeric_max_age_policy_contract_v1",
+]

--- a/src/trading/master_v2/double_play_runtime_typed_volatility_presence_gate_v1.py
+++ b/src/trading/master_v2/double_play_runtime_typed_volatility_presence_gate_v1.py
@@ -3,9 +3,10 @@
 Closes productive Double-Play typed cutover: Scope / Boundary / Entry authority
 may run only when CMC.canonical_volatility_estimate is present, validated, and
 atomically synchronized with the legacy float. Reuses the existing typed
-eligibility authority — never discards its result. Does not invent max-age,
-global typed-only enforcement, a second estimator/adapter/validator, or
-offline/research/scenario mutations.
+eligibility authority — never discards its result. Attaches non-enforcing
+max-age policy evidence (threshold unresolved). Does not invent a numeric
+threshold, global typed-only enforcement, a second estimator/adapter/validator,
+or offline/research/scenario mutations.
 """
 
 from __future__ import annotations
@@ -64,6 +65,13 @@ from trading.master_v2.canonical_market_context_v1 import (
     ClockTrustStatus,
     DataIntegrityStatus,
 )
+from trading.master_v2.canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1 import (
+    CanonicalVolatilityMaxAgePolicyEvidenceV1,
+    VolatilityRestartStatusV1,
+    VolatilityReuseStatusV1,
+    derive_presence_status_for_age_policy_v1,
+    evaluate_canonical_volatility_estimate_age_policy_v1,
+)
 
 PACKAGE_MARKER = "MASTER_V2_DOUBLE_PLAY_RUNTIME_TYPED_VOLATILITY_PRESENCE_GATE_V1=true"
 
@@ -81,7 +89,9 @@ TYPED_VOLATILITY_ESTIMATE_MISSING_REASON = "TYPED_VOLATILITY_ESTIMATE_MISSING"
 DOUBLE_PLAY_TYPED_CUTOVER = True
 GLOBAL_TYPED_ONLY_ENFORCEMENT = False
 NUMERIC_MAX_AGE_DECIDED = False
-NUMERIC_MAX_AGE_POLICY_CREATED = False
+# Non-enforcing policy contract exists; threshold value remains unresolved.
+NUMERIC_MAX_AGE_POLICY_CREATED = True
+NUMERIC_MAX_AGE_ENFORCEMENT_ENABLED = False
 LIVE_AUTHORIZATION = False
 HARD_STOP = True
 SECOND_ESTIMATOR_CREATED = False
@@ -92,6 +102,7 @@ VOLATILITY_SEMANTICS_CHANGED = False
 OFFLINE_REPLAY_LEGACY_DEFAULTS_UNCHANGED = True
 RESEARCH_LEGACY_FALLBACKS_UNCHANGED = True
 SCENARIO_REPLAY_UNCHANGED = True
+SEPARATE_FRESHNESS_GATE_CREATED = False
 
 SINGLE_ESTIMATOR_AUTHORITY_PRESERVED = True
 SINGLE_VALIDATION_BOUNDARY_PRESERVED = True
@@ -120,9 +131,11 @@ class DoublePlayTypedVolatilityPresenceGateResultV1:
     block_reasons: Tuple[CanonicalMarketContextBlockReason, ...]
     reason_codes: Tuple[str, ...]
     double_play_typed_cutover: bool = DOUBLE_PLAY_TYPED_CUTOVER
+    # Non-enforcing diagnostic evidence; must not alter Alpha outcomes.
+    max_age_policy_evidence: Optional[CanonicalVolatilityMaxAgePolicyEvidenceV1] = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "alpha_scope_entry_authority_allowed": self.alpha_scope_entry_authority_allowed,
             "block_reasons": [r.value for r in self.block_reasons],
             "double_play_typed_cutover": self.double_play_typed_cutover,
@@ -140,6 +153,9 @@ class DoublePlayTypedVolatilityPresenceGateResultV1:
                 self.eligibility.observation_and_reconciliation_only
             ),
         }
+        if self.max_age_policy_evidence is not None:
+            payload["max_age_policy_evidence"] = self.max_age_policy_evidence.to_dict()
+        return payload
 
 
 def evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
@@ -149,6 +165,8 @@ def evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
         CanonicalMarketContextBindingOutcome.ACCEPTED
     ),
     eligibility: CanonicalMarketContextEligibilityV1 | None = None,
+    reuse_status: VolatilityReuseStatusV1 = VolatilityReuseStatusV1.NOT_APPLICABLE,
+    restart_status: VolatilityRestartStatusV1 = VolatilityRestartStatusV1.NOT_RESTART,
 ) -> DoublePlayTypedVolatilityPresenceGateResultV1:
     """Evaluate productive DP presence gate; reuse (never discard) eligibility."""
     typed_blocks = collect_typed_volatility_binding_block_reasons_v1(context)
@@ -195,15 +213,40 @@ def evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
         if block.value not in reason_codes:
             reason_codes.append(block.value)
 
+    typed_validation_ok = typed_present and not typed_invalid
+    presence_for_age = derive_presence_status_for_age_policy_v1(
+        typed_estimate_present=typed_present,
+        typed_validation_ok=typed_validation_ok,
+        restart_without_estimate=(
+            restart_status
+            in (
+                VolatilityRestartStatusV1.RESTART_WITHOUT_ESTIMATE,
+                VolatilityRestartStatusV1.HISTORY_RESTORE_WITHOUT_ESTIMATE,
+            )
+        ),
+    )
+    max_age_policy_evidence = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=context.canonical_volatility_estimate,
+        reference_market_event_time=context.market_event_time,
+        presence_status=presence_for_age,
+        reuse_status=reuse_status,
+        restart_status=restart_status,
+        clock_trust_status=context.clock_trust_status,
+        data_integrity_status=context.data_integrity_status,
+    )
+    # Presence Alpha authority is unchanged by age evidence (non-enforcing).
+    assert max_age_policy_evidence.enforcement_applied is False
+
     return DoublePlayTypedVolatilityPresenceGateResultV1(
         eligibility=elig,
         typed_estimate_present=typed_present,
-        typed_validation_ok=typed_present and not typed_invalid,
+        typed_validation_ok=typed_validation_ok,
         typed_float_consistent=typed_present and not typed_mismatch and not typed_invalid,
         alpha_scope_entry_authority_allowed=alpha_ok,
         exit_risk_safety_authority_preserved=True,
         block_reasons=tuple(typed_blocks),
         reason_codes=tuple(reason_codes),
+        max_age_policy_evidence=max_age_policy_evidence,
     )
 
 
@@ -490,8 +533,12 @@ def assert_architecture_guards_v1(*, repo_root: Optional[Path] = None) -> dict[s
 
     if GLOBAL_TYPED_ONLY_ENFORCEMENT or LIVE_AUTHORIZATION:
         raise RuntimeError("GLOBAL_TYPED_ONLY_OR_LIVE_FLAG_DRIFT")
-    if NUMERIC_MAX_AGE_DECIDED or NUMERIC_MAX_AGE_POLICY_CREATED:
-        raise RuntimeError("NUMERIC_MAX_AGE_FLAG_DRIFT")
+    if NUMERIC_MAX_AGE_DECIDED or NUMERIC_MAX_AGE_ENFORCEMENT_ENABLED:
+        raise RuntimeError("NUMERIC_MAX_AGE_THRESHOLD_OR_ENFORCEMENT_FLAG_DRIFT")
+    if not NUMERIC_MAX_AGE_POLICY_CREATED:
+        raise RuntimeError("NON_ENFORCING_MAX_AGE_POLICY_CONTRACT_MUST_BE_ATTACHED")
+    if SEPARATE_FRESHNESS_GATE_CREATED:
+        raise RuntimeError("SEPARATE_FRESHNESS_GATE_FORBIDDEN")
     if not DOUBLE_PLAY_TYPED_CUTOVER:
         raise RuntimeError("DOUBLE_PLAY_TYPED_CUTOVER_MUST_BE_TRUE")
     if (
@@ -505,6 +552,8 @@ def assert_architecture_guards_v1(*, repo_root: Optional[Path] = None) -> dict[s
     # Productive path cannot bypass: eligibility evaluate must be referenced.
     if "evaluate_typed_volatility_binding_eligibility_v1" not in code_before_guards:
         raise RuntimeError("PRESENCE_GATE_MUST_REUSE_TYPED_ELIGIBILITY")
+    if "evaluate_canonical_volatility_estimate_age_policy_v1" not in code_before_guards:
+        raise RuntimeError("PRESENCE_GATE_MUST_ATTACH_NON_ENFORCING_MAX_AGE_EVIDENCE")
 
     return {
         "adapter_defs_in_typed": typed_src.count(adapter_def),
@@ -513,6 +562,9 @@ def assert_architecture_guards_v1(*, repo_root: Optional[Path] = None) -> dict[s
         "double_play_typed_cutover": DOUBLE_PLAY_TYPED_CUTOVER,
         "global_typed_only_enforcement": GLOBAL_TYPED_ONLY_ENFORCEMENT,
         "numeric_max_age_decided": NUMERIC_MAX_AGE_DECIDED,
+        "numeric_max_age_policy_created": NUMERIC_MAX_AGE_POLICY_CREATED,
+        "numeric_max_age_enforcement_enabled": NUMERIC_MAX_AGE_ENFORCEMENT_ENABLED,
+        "separate_freshness_gate_created": SEPARATE_FRESHNESS_GATE_CREATED,
         "legacy_float_adaptation_owner": LEGACY_FLOAT_ADAPTATION_OWNER,
         "productive_runtime_caller_owner": PRODUCTIVE_RUNTIME_CALLER_OWNER,
         "presence_gate_owner": PRESENCE_GATE_OWNER,
@@ -531,6 +583,8 @@ def assert_capability_non_goals_v1() -> dict[str, Any]:
         "global_typed_only_enforcement": GLOBAL_TYPED_ONLY_ENFORCEMENT,
         "numeric_max_age_decided": NUMERIC_MAX_AGE_DECIDED,
         "numeric_max_age_policy_created": NUMERIC_MAX_AGE_POLICY_CREATED,
+        "numeric_max_age_enforcement_enabled": NUMERIC_MAX_AGE_ENFORCEMENT_ENABLED,
+        "separate_freshness_gate_created": SEPARATE_FRESHNESS_GATE_CREATED,
         "live_authorization": LIVE_AUTHORIZATION,
         "hard_stop": HARD_STOP,
         "second_estimator_created": SECOND_ESTIMATOR_CREATED,
@@ -548,7 +602,7 @@ def assert_capability_non_goals_v1() -> dict[str, Any]:
         ),
         "package_marker": PACKAGE_MARKER,
         "gaps_remaining": (
-            "C1_G10_NUMERIC_MAX_AGE",
+            "C1_G10_NUMERIC_MAX_AGE_THRESHOLD_VALUE",
             "G3_UNTYPED_EXPLICIT_LEGACY_STILL_ADMISSIBLE",
             "G8_ESTIMATOR_AMBIGUITY_ON_EXPLICIT_LEGACY",
         ),

--- a/tests/trading/master_v2/test_canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1.py
+++ b/tests/trading/master_v2/test_canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1.py
@@ -1,0 +1,593 @@
+"""Focused tests for numeric max-age policy contract + non-enforcing telemetry v1."""
+
+from __future__ import annotations
+
+import math
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from trading.master_v2.canonical_market_context_v1 import (
+    FEATURE_CONTRACT_VERSION,
+    BarFinalityStatus,
+    CanonicalMarketContextV1,
+    ClockTrustStatus,
+    DataIntegrityStatus,
+    WarmupStatus,
+    with_computed_input_digest,
+)
+from trading.master_v2.canonical_volatility_binding_and_provenance_transport_v1 import (
+    bind_typed_canonical_volatility_estimate_into_market_context_v1,
+)
+from trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1 import (
+    build_canonical_volatility_estimate_v1,
+)
+from trading.master_v2.canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1 import (
+    AGE_FORMULA,
+    AGE_REFERENCE_CLOCK,
+    CAPABILITY_ID,
+    CanonicalVolatilityMaxAgePolicyContractError,
+    CanonicalVolatilityNumericMaxAgePolicyContractV1,
+    ENFORCEMENT_ENABLED,
+    NUMERIC_MAX_AGE_DECIDED,
+    POLICY_VERSION,
+    THRESHOLD_STATUS_UNRESOLVED,
+    VolatilityMaxAgeReasonCodeV1,
+    VolatilityPresenceStatusV1,
+    VolatilityRestartStatusV1,
+    VolatilityReuseStatusV1,
+    assert_architecture_guards_v1,
+    assert_capability_non_goals_v1,
+    build_ratified_unresolved_max_age_policy_contract_v1,
+    evaluate_canonical_volatility_estimate_age_policy_v1,
+    validate_canonical_volatility_numeric_max_age_policy_contract_v1,
+)
+from trading.master_v2.canonical_volatility_productive_runtime_cmc_typed_binding_v1 import (
+    CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1,
+    ProductiveTypedBindingFailClosedReasonV1,
+)
+from trading.master_v2.double_play_composition_matrix_v1 import (
+    CompositionDirectionState,
+    PositionManagementContext,
+)
+from trading.master_v2.double_play_entry_exit_policy_v0 import (
+    DecisionOutcome,
+    DoublePlayEntryExitPolicyV0,
+    ENTRY_EXIT_POLICY_VERSION,
+    ExistingPositionSide,
+    PolicySignalV0,
+    PositionState,
+    ReconciliationState,
+    SafetyMode,
+    TradingGate,
+    EntryExitDirectionState,
+)
+from trading.master_v2.double_play_futures_input import FuturesMarketType
+from trading.master_v2.double_play_runtime_typed_volatility_presence_gate_v1 import (
+    evaluate_double_play_runtime_typed_volatility_presence_gate_v1,
+    evaluate_protection_authority_when_typed_absent_v1,
+    protection_authority_required_v1,
+)
+from trading.market_state.distinct_market_observation_acceptor_v1 import (
+    ObservationTransportMetadataV1,
+)
+from trading.market_state.time_sample_epoch_semantics_v1 import (
+    EventTimeInstantV1,
+    MarketSampleIdentityV1,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+AS_OF = datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc)
+VENUE = "okx_europe"
+CANON = "ETH-USD_UM_XPERP-310404"
+VENUE_INST = "ETH-USD_UM_XPERP-310404"
+T0 = 1_700_000_000.0
+
+
+def _estimate(*, as_of: datetime = AS_OF, value: float = 0.004321):
+    return build_canonical_volatility_estimate_v1(
+        value=value,
+        observation_count=61,
+        as_of_event_time=as_of,
+        fallback_used=False,
+        source_digest="b" * 64,
+    )
+
+
+def _context(**overrides: object) -> CanonicalMarketContextV1:
+    base: dict = {
+        "context_id": "ctx-eth-max-age-policy",
+        "instrument_id": CANON,
+        "market_type": FuturesMarketType.PERPETUAL,
+        "trading_epoch": 1,
+        "market_event_time": "2026-06-30T12:05:00+00:00",
+        "decision_time": "2026-06-30T12:05:01+00:00",
+        "bar_interval": "1m",
+        "bar_finality_status": BarFinalityStatus.FINALIZED,
+        "mark_price": 3500.0,
+        "index_price": 3499.5,
+        "best_bid": 3499.8,
+        "best_ask": 3500.2,
+        "spread": 0.4,
+        "volume": 1_250_000.0,
+        "open_interest": 85_000_000.0,
+        "funding_rate": 0.00012,
+        "volatility_estimate": 0.38,
+        "trend_feature_set": {"slope": 0.02},
+        "momentum_feature_set": {"rsi": 55.0},
+        "liquidity_feature_set": {"depth_score": 0.88},
+        "market_structure_feature_set": {"range_ratio": 0.42},
+        "data_integrity_status": DataIntegrityStatus.TRUSTED,
+        "clock_trust_status": ClockTrustStatus.TRUSTED,
+        "warmup_status": WarmupStatus.WARMUP_COMPLETE,
+        "feature_contract_version": FEATURE_CONTRACT_VERSION,
+        "input_digest": "",
+        "canonical_volatility_estimate": None,
+    }
+    base.update(overrides)
+    return CanonicalMarketContextV1(**base)
+
+
+def _price_at(i: int) -> float:
+    return 100.0 * math.exp(0.001 * i)
+
+
+def _sample(i: int) -> MarketSampleIdentityV1:
+    return MarketSampleIdentityV1(
+        venue=VENUE,
+        canonical_instrument_id=CANON,
+        venue_instrument_id=VENUE_INST,
+        event_time=EventTimeInstantV1(unix_seconds=T0 + float(i * 60)),
+        mark_price=_price_at(i),
+    )
+
+
+def test_01_valid_estimate_reference_after_as_of_computes_age() -> None:
+    estimate = _estimate()
+    ref = AS_OF + timedelta(seconds=300)
+    evidence = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=estimate,
+        reference_market_event_time=ref,
+        presence_status=VolatilityPresenceStatusV1.PRESENT,
+    )
+    assert evidence.computed_age_seconds == 300.0
+    assert evidence.threshold_status == THRESHOLD_STATUS_UNRESOLVED
+    assert evidence.enforcement_applied is False
+    assert (
+        evidence.reason_code
+        == VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_AGE_UNRESOLVED.value
+    )
+    assert evidence.reason_code not in {
+        VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_FRESH.value,
+        VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_STALE.value,
+    }
+
+
+def test_02_reference_equals_as_of_age_zero() -> None:
+    estimate = _estimate()
+    evidence = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=estimate,
+        reference_market_event_time=AS_OF,
+        presence_status=VolatilityPresenceStatusV1.PRESENT,
+    )
+    assert evidence.computed_age_seconds == 0.0
+    assert evidence.threshold_status == THRESHOLD_STATUS_UNRESOLVED
+    assert evidence.enforcement_applied is False
+
+
+def test_03_reference_before_as_of_fail_closed_no_negative_age() -> None:
+    estimate = _estimate()
+    ref = AS_OF - timedelta(seconds=60)
+    evidence = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=estimate,
+        reference_market_event_time=ref,
+        presence_status=VolatilityPresenceStatusV1.PRESENT,
+    )
+    assert evidence.computed_age_seconds is None
+    assert (
+        evidence.reason_code == VolatilityMaxAgeReasonCodeV1.VOLATILITY_REFERENCE_BEFORE_AS_OF.value
+    )
+    assert evidence.enforcement_applied is False
+
+
+def test_04_missing_reference_time() -> None:
+    evidence = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=_estimate(),
+        reference_market_event_time=None,
+        presence_status=VolatilityPresenceStatusV1.PRESENT,
+    )
+    assert (
+        evidence.reason_code == VolatilityMaxAgeReasonCodeV1.VOLATILITY_REFERENCE_TIME_MISSING.value
+    )
+    assert evidence.computed_age_seconds is None
+
+
+def test_05_missing_as_of() -> None:
+    class _EstimateWithoutAsOf:
+        source_digest = "c" * 64
+        as_of_event_time = None
+
+    evidence = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=_EstimateWithoutAsOf(),  # type: ignore[arg-type]
+        reference_market_event_time=AS_OF + timedelta(seconds=10),
+        presence_status=VolatilityPresenceStatusV1.PRESENT,
+    )
+    assert evidence.reason_code == VolatilityMaxAgeReasonCodeV1.VOLATILITY_AS_OF_MISSING.value
+
+
+def test_06_missing_typed_estimate_presence_authority_no_synthetic_age() -> None:
+    evidence = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=None,
+        reference_market_event_time=AS_OF + timedelta(seconds=10),
+        presence_status=VolatilityPresenceStatusV1.MISSING,
+    )
+    assert evidence.reason_code == VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_MISSING.value
+    assert evidence.computed_age_seconds is None
+    assert evidence.decision == "NOT_EVALUATED_PRESENCE_AUTHORITY"
+
+    ctx = with_computed_input_digest(_context(volatility_estimate=0.38))
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(ctx)
+    assert gate.alpha_scope_entry_authority_allowed is False
+    assert gate.max_age_policy_evidence is not None
+    assert gate.max_age_policy_evidence.computed_age_seconds is None
+    assert (
+        gate.max_age_policy_evidence.reason_code
+        == VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_MISSING.value
+    )
+
+
+def test_07_restart_without_estimate() -> None:
+    evidence = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=None,
+        reference_market_event_time=AS_OF,
+        presence_status=VolatilityPresenceStatusV1.RESTART_UNAVAILABLE,
+        restart_status=VolatilityRestartStatusV1.RESTART_WITHOUT_ESTIMATE,
+    )
+    assert evidence.max_age_status == "UNDEFINED"
+    assert (
+        evidence.reason_code
+        == VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_RESTART_UNAVAILABLE.value
+    )
+    assert evidence.computed_age_seconds is None
+
+
+def test_08_history_restore_no_estimate_no_fresh_mark(tmp_path: Path) -> None:
+    path = tmp_path / "hist.json"
+    host = CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.create(
+        venue=VENUE,
+        canonical_instrument_id=CANON,
+        venue_instrument_id=VENUE_INST,
+        persistence_path=path,
+    )
+    ctx = _context()
+    for i in range(0, 61):
+        host.apply_to_market_context_v1(
+            ctx,
+            sample=_sample(i),
+            transport=ObservationTransportMetadataV1(receive_time=T0 + i * 60 + 0.5),
+            ingest_sample=True,
+        )
+    restored = (
+        CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.restore_from_persistence_v1(
+            persistence_path=path,
+        )
+    )
+    assert restored.restart_without_estimate is True
+    cycle = restored.apply_to_market_context_v1(ctx, ingest_sample=False)
+    assert cycle.bound_estimate is None
+    assert (
+        cycle.telemetry.fail_closed_reason
+        == ProductiveTypedBindingFailClosedReasonV1.RESTART_WITHOUT_ESTIMATE.value
+    )
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        cycle.context,
+        restart_status=VolatilityRestartStatusV1.HISTORY_RESTORE_WITHOUT_ESTIMATE,
+    )
+    assert gate.alpha_scope_entry_authority_allowed is False
+    assert gate.max_age_policy_evidence is not None
+    assert (
+        gate.max_age_policy_evidence.reason_code
+        == VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_RESTART_UNAVAILABLE.value
+    )
+    assert gate.max_age_policy_evidence.reason_code != (
+        VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_FRESH.value
+    )
+
+
+def test_09_duplicate_reuse_as_of_unchanged_age_grows_with_market_event_time(
+    tmp_path: Path,
+) -> None:
+    host = CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.create(
+        venue=VENUE,
+        canonical_instrument_id=CANON,
+        venue_instrument_id=VENUE_INST,
+        persistence_path=tmp_path / "h.json",
+    )
+    ctx = _context()
+    produced = None
+    for i in range(0, 61):
+        produced = host.apply_to_market_context_v1(
+            ctx,
+            sample=_sample(i),
+            transport=ObservationTransportMetadataV1(receive_time=T0 + i * 60 + 0.5),
+            ingest_sample=True,
+        )
+    assert produced is not None and produced.bound_estimate is not None
+    as_of = produced.bound_estimate.as_of_event_time
+    dup = host.apply_to_market_context_v1(
+        ctx,
+        sample=_sample(60),
+        transport=ObservationTransportMetadataV1(receive_time=T0 + 60 * 60 + 0.5),
+        ingest_sample=True,
+    )
+    assert dup.bound_estimate is not None
+    assert dup.bound_estimate.as_of_event_time == as_of
+    assert dup.bound_estimate.source_digest == produced.bound_estimate.source_digest
+
+    later_ctx = with_computed_input_digest(
+        _context(
+            market_event_time=(as_of + timedelta(seconds=600)).isoformat(),
+            decision_time=(as_of + timedelta(seconds=601)).isoformat(),
+            volatility_estimate=0.0,
+        )
+    )
+    bound = bind_typed_canonical_volatility_estimate_into_market_context_v1(
+        later_ctx, dup.bound_estimate
+    )
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(
+        bound,
+        reuse_status=VolatilityReuseStatusV1.DUPLICATE_REUSE,
+    )
+    assert gate.max_age_policy_evidence is not None
+    assert gate.max_age_policy_evidence.computed_age_seconds == 600.0
+    assert gate.max_age_policy_evidence.reuse_status == (
+        VolatilityReuseStatusV1.DUPLICATE_REUSE.value
+    )
+    assert gate.alpha_scope_entry_authority_allowed is True
+
+
+def test_10_runtime_cycle_without_sample_no_refresh(tmp_path: Path) -> None:
+    host = CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.create(
+        venue=VENUE,
+        canonical_instrument_id=CANON,
+        venue_instrument_id=VENUE_INST,
+        persistence_path=tmp_path / "h2.json",
+    )
+    ctx = _context()
+    produced = None
+    for i in range(0, 61):
+        produced = host.apply_to_market_context_v1(
+            ctx,
+            sample=_sample(i),
+            transport=ObservationTransportMetadataV1(receive_time=T0 + i * 60 + 0.5),
+            ingest_sample=True,
+        )
+    assert produced is not None and produced.bound_estimate is not None
+    as_of = produced.bound_estimate.as_of_event_time
+    cycle = host.apply_to_market_context_v1(produced.context, ingest_sample=False)
+    assert cycle.bound_estimate is not None
+    assert cycle.bound_estimate.as_of_event_time == as_of
+    assert cycle.producer_result.estimate is None
+
+
+def test_11_process_reuse_monotone_age_growth() -> None:
+    estimate = _estimate()
+    ages: list[float] = []
+    for seconds in (0, 60, 120, 300):
+        evidence = evaluate_canonical_volatility_estimate_age_policy_v1(
+            estimate=estimate,
+            reference_market_event_time=AS_OF + timedelta(seconds=seconds),
+            presence_status=VolatilityPresenceStatusV1.PRESENT,
+            reuse_status=VolatilityReuseStatusV1.PROCESS_REUSE,
+        )
+        assert evidence.computed_age_seconds is not None
+        ages.append(evidence.computed_age_seconds)
+        assert evidence.enforcement_applied is False
+    assert ages == [0.0, 60.0, 120.0, 300.0]
+    assert estimate.as_of_event_time == AS_OF
+
+
+def test_12_unresolved_policy_contract_values() -> None:
+    policy = build_ratified_unresolved_max_age_policy_contract_v1()
+    assert policy.numeric_max_age_seconds is None
+    assert policy.threshold_status == THRESHOLD_STATUS_UNRESOLVED
+    assert policy.enforcement_enabled is False
+    assert policy.reference_clock == AGE_REFERENCE_CLOCK
+    assert policy.age_formula == AGE_FORMULA
+    assert policy.rematerialization_policy == "FORBIDDEN"
+    assert NUMERIC_MAX_AGE_DECIDED is False
+    assert ENFORCEMENT_ENABLED is False
+
+
+def test_13_invalid_contract_states_rejected() -> None:
+    base = build_ratified_unresolved_max_age_policy_contract_v1()
+
+    with pytest.raises(CanonicalVolatilityMaxAgePolicyContractError):
+        validate_canonical_volatility_numeric_max_age_policy_contract_v1(
+            CanonicalVolatilityNumericMaxAgePolicyContractV1(
+                **{**base.to_dict(), "numeric_max_age_seconds": 120.0}
+            )
+        )
+
+    with pytest.raises(CanonicalVolatilityMaxAgePolicyContractError):
+        validate_canonical_volatility_numeric_max_age_policy_contract_v1(
+            CanonicalVolatilityNumericMaxAgePolicyContractV1(
+                **{**base.to_dict(), "enforcement_enabled": True}
+            )
+        )
+
+    with pytest.raises(CanonicalVolatilityMaxAgePolicyContractError):
+        validate_canonical_volatility_numeric_max_age_policy_contract_v1(
+            CanonicalVolatilityNumericMaxAgePolicyContractV1(
+                **{**base.to_dict(), "reference_clock": "WALLCLOCK"}
+            )
+        )
+
+    with pytest.raises(CanonicalVolatilityMaxAgePolicyContractError):
+        validate_canonical_volatility_numeric_max_age_policy_contract_v1(
+            CanonicalVolatilityNumericMaxAgePolicyContractV1(
+                **{**base.to_dict(), "rematerialization_policy": "ALLOWED_WITH_NEW_AS_OF"}
+            )
+        )
+
+
+def test_14_clock_trust_untrusted_primary_authority_preserved() -> None:
+    evidence = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=_estimate(),
+        reference_market_event_time=AS_OF + timedelta(seconds=10),
+        presence_status=VolatilityPresenceStatusV1.PRESENT,
+        clock_trust_status=ClockTrustStatus.UNTRUSTED,
+    )
+    assert (
+        evidence.reason_code
+        == VolatilityMaxAgeReasonCodeV1.VOLATILITY_FRESHNESS_CLOCK_UNTRUSTED.value
+    )
+    assert evidence.computed_age_seconds is None
+    assert evidence.decision == "COMPOSED_TRUST_SECONDARY"
+    assert evidence.enforcement_applied is False
+
+    estimate = _estimate()
+    ctx = bind_typed_canonical_volatility_estimate_into_market_context_v1(
+        with_computed_input_digest(
+            _context(clock_trust_status=ClockTrustStatus.UNTRUSTED, volatility_estimate=0.0)
+        ),
+        estimate,
+    )
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(ctx)
+    # CMC clock trust blocks alpha via eligibility; age evidence does not replace it.
+    assert gate.alpha_scope_entry_authority_allowed is False
+    assert gate.max_age_policy_evidence is not None
+    assert gate.max_age_policy_evidence.clock_trust_status == "untrusted"
+
+
+def test_15_data_integrity_untrusted_primary_authority_preserved() -> None:
+    evidence = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=_estimate(),
+        reference_market_event_time=AS_OF + timedelta(seconds=10),
+        presence_status=VolatilityPresenceStatusV1.PRESENT,
+        data_integrity_status=DataIntegrityStatus.UNTRUSTED,
+    )
+    assert (
+        evidence.reason_code
+        == VolatilityMaxAgeReasonCodeV1.VOLATILITY_FRESHNESS_DATA_UNTRUSTED.value
+    )
+    assert evidence.enforcement_applied is False
+
+    estimate = _estimate()
+    ctx = bind_typed_canonical_volatility_estimate_into_market_context_v1(
+        with_computed_input_digest(
+            _context(
+                data_integrity_status=DataIntegrityStatus.UNTRUSTED,
+                volatility_estimate=0.0,
+            )
+        ),
+        estimate,
+    )
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(ctx)
+    assert gate.alpha_scope_entry_authority_allowed is False
+    assert gate.max_age_policy_evidence is not None
+    assert gate.max_age_policy_evidence.data_integrity_status == "untrusted"
+
+
+def test_16_exit_risk_safety_independence() -> None:
+    ctx = with_computed_input_digest(_context())
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(ctx)
+    assert gate.exit_risk_safety_authority_preserved is True
+    assert gate.alpha_scope_entry_authority_allowed is False
+    assert gate.max_age_policy_evidence is not None
+
+    assert (
+        protection_authority_required_v1(
+            position_state=PositionState.OPEN_FULL,
+            existing_position_side=ExistingPositionSide.LONG,
+            reconciliation_state=ReconciliationState.RECONCILED,
+            safety_exit_signal=PolicySignalV0(triggered=True, reason_code="safety"),
+            hard_risk_reduction_signal=PolicySignalV0(triggered=False),
+            scope_adverse_exit_signal=PolicySignalV0(triggered=False),
+            profit_protection_signal=PolicySignalV0(triggered=False),
+            time_exit_signal=PolicySignalV0(triggered=False),
+            strategy_invalidation_signal=PolicySignalV0(triggered=False),
+            safety_mode=SafetyMode.EXIT_ONLY,
+        )
+        is True
+    )
+    decision = evaluate_protection_authority_when_typed_absent_v1(
+        instrument_id=CANON,
+        trading_epoch=1,
+        context_reference="ctx-max-age",
+        direction_state=EntryExitDirectionState.LONG_ACTIVE,
+        position_state=PositionState.OPEN_FULL,
+        reconciliation_state=ReconciliationState.RECONCILED,
+        trading_gate=TradingGate.ENTRY_ALLOWED,
+        safety_mode=SafetyMode.EXIT_ONLY,
+        data_integrity_state=DataIntegrityStatus.TRUSTED,
+        clock_trust_status=ClockTrustStatus.TRUSTED,
+        cooldown_pass=True,
+        existing_position_side=ExistingPositionSide.LONG,
+        venue_flat=False,
+        scope_adverse_exit_signal=PolicySignalV0(triggered=False),
+        profit_protection_signal=PolicySignalV0(triggered=False),
+        time_exit_signal=PolicySignalV0(triggered=False),
+        strategy_invalidation_signal=PolicySignalV0(triggered=False),
+        hard_risk_reduction_signal=PolicySignalV0(triggered=False),
+        safety_exit_signal=PolicySignalV0(triggered=True, reason_code="safety"),
+        previous_direction_state=CompositionDirectionState.LONG,
+        position_management_context=PositionManagementContext.LONG_POSITION,
+        entry_exit_policy=DoublePlayEntryExitPolicyV0(policy_version=ENTRY_EXIT_POLICY_VERSION),
+        gate=gate,
+    )
+    assert decision.decision_outcome is DecisionOutcome.EXIT
+    assert gate.max_age_policy_evidence.enforcement_applied is False
+
+
+def test_17_offline_runtime_equivalence_independent_of_wallclock() -> None:
+    estimate = _estimate()
+    ref = "2026-06-30T12:10:00+00:00"
+    t0 = time.perf_counter()
+    e1 = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=estimate,
+        reference_market_event_time=ref,
+        presence_status=VolatilityPresenceStatusV1.PRESENT,
+    )
+    time.sleep(0.01)
+    e2 = evaluate_canonical_volatility_estimate_age_policy_v1(
+        estimate=estimate,
+        reference_market_event_time=datetime(2026, 6, 30, 12, 10, tzinfo=timezone.utc),
+        presence_status=VolatilityPresenceStatusV1.PRESENT,
+    )
+    _ = time.perf_counter() - t0
+    assert e1.computed_age_seconds == e2.computed_age_seconds == 600.0
+    assert e1.to_dict() == e2.to_dict()
+
+
+def test_18_backward_compatibility_presence_alpha_unchanged() -> None:
+    estimate = _estimate()
+    ctx = bind_typed_canonical_volatility_estimate_into_market_context_v1(
+        with_computed_input_digest(_context(volatility_estimate=0.0)),
+        estimate,
+    )
+    gate = evaluate_double_play_runtime_typed_volatility_presence_gate_v1(ctx)
+    assert gate.alpha_scope_entry_authority_allowed is True
+    assert gate.typed_estimate_present is True
+    assert gate.max_age_policy_evidence is not None
+    assert gate.max_age_policy_evidence.enforcement_applied is False
+    assert (
+        gate.max_age_policy_evidence.reason_code
+        == VolatilityMaxAgeReasonCodeV1.VOLATILITY_ESTIMATE_AGE_UNRESOLVED.value
+    )
+    # Age evidence must not appear as presence block reason.
+    assert all(not r.startswith("VOLATILITY_ESTIMATE_AGE") for r in gate.reason_codes)
+
+
+def test_architecture_guards_and_non_goals() -> None:
+    guards = assert_architecture_guards_v1(repo_root=ROOT)
+    assert guards["guards_pass"] is True
+    assert guards["numeric_max_age_decided"] is False
+    assert guards["enforcement_enabled"] is False
+    assert guards["separate_freshness_gate_created"] is False
+    non_goals = assert_capability_non_goals_v1()
+    assert non_goals["no_alpha_enforcement_enabled"] is True
+    assert CAPABILITY_ID.startswith("MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE")
+    assert POLICY_VERSION == "canonical_volatility_numeric_max_age_policy/v1"

--- a/tests/trading/master_v2/test_double_play_runtime_typed_volatility_presence_gate_v1.py
+++ b/tests/trading/master_v2/test_double_play_runtime_typed_volatility_presence_gate_v1.py
@@ -582,7 +582,9 @@ def test_d_offline_research_scenario_isolation() -> None:
 
     non_goals = assert_capability_non_goals_v1()
     assert non_goals["global_typed_only_enforcement"] is False
-    assert non_goals["numeric_max_age_policy_created"] is False
+    assert non_goals["numeric_max_age_policy_created"] is True
+    assert non_goals["numeric_max_age_enforcement_enabled"] is False
+    assert non_goals["numeric_max_age_decided"] is False
     assert non_goals["offline_replay_legacy_defaults_unchanged"] is True
     assert non_goals["research_legacy_fallbacks_unchanged"] is True
     assert non_goals["scenario_replay_unchanged"] is True


### PR DESCRIPTION
## Summary

- Adds `MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_POLICY_CONTRACT_AND_NON_ENFORCING_TELEMETRY_V1`: versioned Event-Time age policy contract and diagnostic evidence evaluator.
- Attaches non-enforcing `max_age_policy_evidence` to the existing Double-Play typed volatility presence gate (`evaluate_double_play_runtime_typed_volatility_presence_gate_v1`).
- Computes diagnostic `computed_age_seconds` as `market_event_time - estimate.as_of_event_time` without selecting a numeric threshold or changing Alpha outcomes.

## Explicit non-goals (this PR)

- **numeric threshold remains unresolved** (`threshold_status=UNRESOLVED_MAX_AGE`, `numeric_max_age_seconds=null`)
- **no alpha enforcement** (`enforcement_applied=false`; presence Alpha decisions unchanged)
- **no second clock authority**
- **no second volatility authority**
- **existing presence gate reused** (no separate freshness gate)
- **exit/risk/safety authority preserved**
- **rematerialization remains forbidden**
- **computed age is diagnostic only** (`UNRESOLVED_MAX_AGE` is not freshness approval)

## Test plan

- [x] Ruff format/check on changed Python files
- [x] Focused max-age policy contract tests (matrix cases 1–18)
- [x] Existing presence-gate / producer / binding / transport tests
- [x] Architecture guards + canonical architecture drift guard
- [x] Docs token policy + docs reference targets
- [x] PR-bounded selector targets
- [x] Strategy smoke


Made with [Cursor](https://cursor.com)