### PR TITLE
feat(research): execute canonical volatility numeric max-age study

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ out/
 # research artifacts (new listings crawler)
 out/research/new_listings/
 
+# Local-only max-age parameter research execution evidence (execution_id-bound)
+docs/evidence/canonical_volatility_numeric_max_age_parameter_research_execution_v1/
+
 # local scratch (never commit)
 docs/_scratch/
 

--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -381,6 +381,15 @@
         "docs/governance/CANONICAL_RESEARCH_LANE_POST_TERMINAL_LIFECYCLE_CONTRACT_V1.md"
       ]
     },
+    "CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1": {
+      "note": "Offline research-only numeric max-age parameter study execution (preregistered candidates, splits/embargo, robustness, fail-closed unresolved threshold); no numeric threshold selection, no Alpha/policy enforcement, no Master-V2/Double-Play/risk/sizing/execution mutation, no promotion/runtime/orders.",
+      "path_prefixes": [
+        "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/",
+        "scripts/ops/run_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py",
+        "tests/research/test_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py",
+        "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1.md"
+      ]
+    },
     "COST_MODEL_DIAGNOSTICS": {
       "path_globs": [
         "tests/research/test_offline_linear_cost_model_diagnostics_*",

--- a/config/governance/technical_canonical_wiring_authorization_v1.json
+++ b/config/governance/technical_canonical_wiring_authorization_v1.json
@@ -764,7 +764,20 @@
     "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_POLICY_CONTRACT_AND_NON_ENFORCING_TELEMETRY_V1.md",
     "src/trading/master_v2/canonical_volatility_numeric_max_age_parameter_research_design_and_evidence_accumulation_contract_v1.py",
     "tests/trading/master_v2/test_canonical_volatility_numeric_max_age_parameter_research_design_and_evidence_accumulation_contract_v1.py",
-    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_DESIGN_AND_EVIDENCE_ACCUMULATION_CONTRACT_V1.md"
+    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_DESIGN_AND_EVIDENCE_ACCUMULATION_CONTRACT_V1.md",
+    "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/__init__.py",
+    "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/architecture_guards_v1.py",
+    "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/constants_v1.py",
+    "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/contracts_v1.py",
+    "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/evaluator_v1.py",
+    "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/evidence_loader_v1.py",
+    "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/robustness_v1.py",
+    "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/runner_v1.py",
+    "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/serialization_v1.py",
+    "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/split_engine_v1.py",
+    "scripts/ops/run_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py",
+    "tests/research/test_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py",
+    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1.md"
   ],
   "allowed_surface_classes": [
     "TECHNICAL_CANONICAL_REPLAY_INPUT_BUILDER_WIRING",

--- a/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1.md
+++ b/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1.md
@@ -1,0 +1,113 @@
+# MASTER_V2 Canonical Volatility Numeric Max-Age Parameter Research Execution v1
+
+---
+docs_token: DOCS_TOKEN_MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1
+STATUS: CAPABILITY_AVAILABLE
+scope: non-enforcing parameter research execution for canonical volatility numeric max-age
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+NUMERIC_MAX_AGE_DECIDED: false
+NUMERIC_MAX_AGE_SECONDS: null
+THRESHOLD_STATUS: UNRESOLVED_MAX_AGE
+ENFORCEMENT_ENABLED: false
+ENFORCEMENT_APPLIED: false
+NUMERIC_THRESHOLD_SELECTED: false
+PARAMETER_PROMOTED: false
+ALPHA_DECISION_MUTATION_ALLOWED: false
+COUNTERFACTUAL_ONLY: true
+HARD_STOP: true
+---
+
+> **Research execution only.** Runs the preregistered, reproducible, strictly
+> non-enforcing parameter study for Canonical Volatility Numeric Max Age.
+> May emit evidence and diagnostic results. Must **not** select, ratify,
+> promote, or productively apply a numeric threshold.
+
+## Machine summary
+
+```
+CAPABILITY_ID=MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1
+PREREGISTRATION_CONTRACT=CanonicalVolatilityMaxAgeResearchDesignContractV1
+EXPECTED_PREREGISTRATION_DIGEST=965f6e09e50e434e363d380c2d62e43041a37ad7d87956e590609a16f011b537
+AGE_REFERENCE_CLOCK=MARKET_EVENT_TIME
+AGE_UNIT=SECONDS
+AGE_FORMULA=reference_market_event_time_minus_volatility_as_of_event_time
+BASELINE=UNRESOLVED_MAX_AGE_NON_ENFORCING
+ENFORCEMENT_DURING_RESEARCH=false
+COUNTERFACTUAL_ONLY=true
+ALPHA_DECISION_MUTATION_ALLOWED=false
+NUMERIC_THRESHOLD_SELECTED=false
+PARAMETER_PROMOTED=false
+THRESHOLD_STATUS=UNRESOLVED_MAX_AGE
+HARD_STOP=true
+```
+
+## Authority boundary
+
+| Surface | Authority |
+|---|---|
+| Research evidence &#47; diagnostics | this capability |
+| Preregistration design &#47; join &#47; ledger schema | design accumulation contract |
+| Productive Alpha &#47; entry &#47; exit &#47; risk &#47; safety | unchanged; out of scope |
+| Numeric max-age selection &#47; promotion &#47; enforcement | forbidden |
+
+## Owners
+
+| Artifact | Path |
+|---|---|
+| Research execution package | `src&#47;research&#47;canonical_volatility_numeric_max_age_parameter_research_execution_v1&#47;` |
+| CLI entrypoint | `scripts&#47;ops&#47;run_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py` |
+| Spec | this document |
+| Tests | `tests&#47;research&#47;test_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py` |
+| Preregistration owner | `src&#47;trading&#47;master_v2&#47;canonical_volatility_numeric_max_age_parameter_research_design_and_evidence_accumulation_contract_v1.py` |
+
+## Pre-evaluation artifacts
+
+Before any result scoring the runner binds and digests:
+
+1. `research_execution_manifest.json`
+2. `candidate_domain.json`
+3. `hypothesis_contract.json`
+4. `split_and_embargo_contract.json`
+5. `robustness_execution_contract.json`
+
+Candidate values are explicit operator &#47; caller research arguments only. They
+are **not** config defaults, policy literals, or productive thresholds.
+
+## Leakage controls
+
+- purged chronological splits
+- walk-forward on non-holdout only
+- sealed final holdout until terminal evaluation
+- event-time embargo derived from lookback &#47; holding &#47; survival &#47; label horizons
+- no random IID shuffle of overlapping samples
+- no holdout-driven candidate selection
+- no retrospective regime relabeling
+- no future event-time labels
+
+## Evidence output
+
+Versioned under:
+
+`docs&#47;evidence&#47;canonical_volatility_numeric_max_age_parameter_research_execution_v1&#47;<execution_id>&#47;`
+
+Local evidence output is gitignored. Productive ledgers are never invented.
+
+## Non-goals
+
+- numeric threshold selection or single-point recommendation
+- parameter promotion into productive policy &#47; config
+- Alpha enforcement or decision mutation
+- live &#47; testnet &#47; paper order activation
+- synthetic invention of missing productive evidence
+
+## Explicit remaining boundary
+
+```
+NEXT_AFTER_THIS_CAPABILITY=
+SEPARATE_OWNER_AUTHORIZED_THRESHOLD_SELECTION_OR_FURTHER_EVIDENCE_ACCUMULATION
+```
+
+`HARD_STOP=true` remains. `READY_FOR_THRESHOLD_SELECTION=false`,
+`READY_FOR_PARAMETER_PROMOTION=false`, `READY_FOR_ENFORCEMENT=false`.
+)

--- a/scripts/ops/run_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py
+++ b/scripts/ops/run_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""CLI entrypoint: non-enforcing canonical volatility max-age research execution v1."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+for _path in (ROOT, ROOT / "src"):
+    text = str(_path)
+    if text not in sys.path:
+        sys.path.insert(0, text)
+
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.runner_v1 import (  # noqa: E402
+    run_max_age_parameter_research_execution_v1,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Execute non-enforcing canonical volatility numeric max-age "
+            "parameter research. Never selects or promotes a threshold."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=ROOT,
+        help="Repository root (default: detected from script location)",
+    )
+    parser.add_argument(
+        "--ledger-path",
+        type=Path,
+        default=None,
+        help="Optional path to research evidence ledger JSONL",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=None,
+        help="Optional output evidence root (defaults under docs/evidence/.../execution_id)",
+    )
+    parser.add_argument(
+        "--repository-sha",
+        type=str,
+        default=None,
+        help="Optional explicit repository SHA binding",
+    )
+    args = parser.parse_args(argv)
+
+    result = run_max_age_parameter_research_execution_v1(
+        repo_root=args.repo_root.resolve(),
+        ledger_path=None if args.ledger_path is None else args.ledger_path.resolve(),
+        output_root=None if args.output_root is None else args.output_root.resolve(),
+        repository_sha=args.repository_sha,
+    )
+    print(json.dumps(result, sort_keys=True, indent=2, default=str))
+    return 0 if result.get("status") == "PASS" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/__init__.py
+++ b/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/__init__.py
@@ -1,0 +1,49 @@
+"""Canonical volatility numeric max-age parameter research execution v1.
+
+Non-enforcing, counterfactual-only research capability. Does not select,
+promote, or enforce a numeric max-age threshold.
+"""
+
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.architecture_guards_v1 import (
+    assert_architecture_guards_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.constants_v1 import (
+    CAPABILITY_ID,
+    CAPABILITY_VERSION,
+    EXPECTED_PREREGISTRATION_DIGEST,
+    HARD_STOP,
+    NUMERIC_THRESHOLD_SELECTED,
+    PACKAGE_MARKER,
+    PARAMETER_PROMOTED,
+    THRESHOLD_STATUS,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.contracts_v1 import (
+    MaxAgeResearchExecutionError,
+    bind_candidate_domain_v1,
+    bind_hypothesis_contract_v1,
+    bind_robustness_execution_contract_v1,
+    bind_split_and_embargo_contract_v1,
+    verify_preregistration_digest_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.runner_v1 import (
+    run_max_age_parameter_research_execution_v1,
+)
+
+__all__ = [
+    "CAPABILITY_ID",
+    "CAPABILITY_VERSION",
+    "EXPECTED_PREREGISTRATION_DIGEST",
+    "HARD_STOP",
+    "MaxAgeResearchExecutionError",
+    "NUMERIC_THRESHOLD_SELECTED",
+    "PACKAGE_MARKER",
+    "PARAMETER_PROMOTED",
+    "THRESHOLD_STATUS",
+    "assert_architecture_guards_v1",
+    "bind_candidate_domain_v1",
+    "bind_hypothesis_contract_v1",
+    "bind_robustness_execution_contract_v1",
+    "bind_split_and_embargo_contract_v1",
+    "run_max_age_parameter_research_execution_v1",
+    "verify_preregistration_digest_v1",
+]

--- a/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/architecture_guards_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/architecture_guards_v1.py
@@ -1,0 +1,104 @@
+"""Architecture guards: research evidence must not become trading authority."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.constants_v1 import (
+    ALPHA_DECISION_MUTATION_ALLOWED,
+    ENFORCEMENT_APPLIED,
+    ENFORCEMENT_DURING_RESEARCH,
+    FORBIDDEN_IMPORT_SUBSTRINGS,
+    HARD_STOP,
+    LIVE_AUTHORIZATION,
+    NUMERIC_MAX_AGE_DECIDED,
+    NUMERIC_THRESHOLD_SELECTED,
+    PARAMETER_PROMOTED,
+    READY_FOR_ENFORCEMENT,
+    READY_FOR_PARAMETER_PROMOTION,
+    READY_FOR_THRESHOLD_SELECTION,
+    THRESHOLD_STATUS,
+)
+
+
+def assert_architecture_guards_v1(*, repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or Path(__file__).resolve().parents[3]
+    package_dir = (
+        root / "src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1"
+    )
+    sources: list[str] = []
+    import_lines: list[str] = []
+    for path in sorted(package_dir.glob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        sources.append(text)
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("import ") or stripped.startswith("from "):
+                import_lines.append(stripped)
+    blob = "\n".join(sources)
+    imports_blob = "\n".join(import_lines)
+
+    for token in FORBIDDEN_IMPORT_SUBSTRINGS:
+        if token in imports_blob:
+            raise RuntimeError(f"TRADING_AUTHORITY_IMPORT_FORBIDDEN:{token}")
+
+    # Scan logic excluding the architecture-guard definition itself.
+    code_before_guards = "\n".join(
+        p.read_text(encoding="utf-8")
+        for p in sorted(package_dir.glob("*.py"))
+        if p.name != "architecture_guards_v1.py" and p.name != "constants_v1.py"
+    )
+
+    forbidden_true_assignments = (
+        "NUMERIC_THRESHOLD_SELECTED = True",
+        "PARAMETER_PROMOTED = True",
+        "ENFORCEMENT_APPLIED = True",
+        "ENFORCEMENT_DURING_RESEARCH = True",
+        "ALPHA_DECISION_MUTATION_ALLOWED = True",
+        "NUMERIC_MAX_AGE_DECIDED = True",
+        "LIVE_AUTHORIZATION = True",
+        "READY_FOR_THRESHOLD_SELECTION = True",
+        "READY_FOR_PARAMETER_PROMOTION = True",
+        "READY_FOR_ENFORCEMENT = True",
+    )
+    for token in forbidden_true_assignments:
+        if token in code_before_guards:
+            raise RuntimeError(f"FORBIDDEN_AUTHORITY_FLAG:{token}")
+
+    if "RECOMMENDED_SINGLE_THRESHOLD =" in code_before_guards:
+        raise RuntimeError("SINGLE_THRESHOLD_RECOMMENDATION_FORBIDDEN")
+    if "demote_trading_gate" in code_before_guards:
+        raise RuntimeError("TRADING_GATE_DEMOTION_FORBIDDEN")
+    for order_token in ("place_order(", "submit_order("):
+        if order_token in code_before_guards:
+            raise RuntimeError("ORDER_PATH_FORBIDDEN")
+    _ = blob  # retained for full-package presence in future extensions
+
+    if (
+        NUMERIC_THRESHOLD_SELECTED
+        or PARAMETER_PROMOTED
+        or ENFORCEMENT_APPLIED
+        or ENFORCEMENT_DURING_RESEARCH
+        or ALPHA_DECISION_MUTATION_ALLOWED
+        or NUMERIC_MAX_AGE_DECIDED
+        or LIVE_AUTHORIZATION
+        or READY_FOR_THRESHOLD_SELECTION
+        or READY_FOR_PARAMETER_PROMOTION
+        or READY_FOR_ENFORCEMENT
+    ):
+        raise RuntimeError("AUTHORITY_FLAG_DRIFT")
+    if THRESHOLD_STATUS != "UNRESOLVED_MAX_AGE":
+        raise RuntimeError("THRESHOLD_STATUS_DRIFT")
+    if not HARD_STOP:
+        raise RuntimeError("HARD_STOP_REQUIRED")
+
+    return {
+        "guards_pass": True,
+        "threshold_status": THRESHOLD_STATUS,
+        "numeric_threshold_selected": NUMERIC_THRESHOLD_SELECTED,
+        "parameter_promoted": PARAMETER_PROMOTED,
+        "enforcement_applied": ENFORCEMENT_APPLIED,
+        "hard_stop": HARD_STOP,
+        "trading_authority_imports_absent": True,
+    }

--- a/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/constants_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/constants_v1.py
@@ -1,0 +1,153 @@
+"""Constants for non-enforcing numeric max-age parameter research execution v1."""
+
+from __future__ import annotations
+
+PACKAGE_MARKER = (
+    "MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1=true"
+)
+
+CAPABILITY_ID = "MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1"
+CAPABILITY_VERSION = "canonical_volatility_numeric_max_age_parameter_research_execution/v1"
+RESEARCH_EXECUTION_OWNER = (
+    "research.canonical_volatility_numeric_max_age_parameter_research_execution_v1"
+)
+
+SCHEMA_VERSION = "canonical_volatility_numeric_max_age_parameter_research_execution/v1"
+CANDIDATE_DOMAIN_SCHEMA_VERSION = "canonical_volatility_numeric_max_age_candidate_domain/v1"
+HYPOTHESIS_SCHEMA_VERSION = "canonical_volatility_numeric_max_age_hypothesis_contract/v1"
+SPLIT_SCHEMA_VERSION = "canonical_volatility_numeric_max_age_split_and_embargo_contract/v1"
+ROBUSTNESS_SCHEMA_VERSION = "canonical_volatility_numeric_max_age_robustness_execution_contract/v1"
+MANIFEST_SCHEMA_VERSION = "canonical_volatility_numeric_max_age_research_execution_manifest/v1"
+INPUT_EVIDENCE_MANIFEST_SCHEMA_VERSION = (
+    "canonical_volatility_numeric_max_age_input_evidence_manifest/v1"
+)
+CONCLUSION_SCHEMA_VERSION = "canonical_volatility_numeric_max_age_research_conclusion/v1"
+INTEGRITY_SCHEMA_VERSION = "canonical_volatility_numeric_max_age_research_integrity_manifest/v1"
+
+EXPECTED_PREREGISTRATION_DIGEST = "965f6e09e50e434e363d380c2d62e43041a37ad7d87956e590609a16f011b537"
+
+# Operator-bound research arguments only (not config / policy / productive defaults).
+# Source authority: EXPLICIT_OPERATOR_OR_CALLER_SUPPLIED_CANDIDATE_ARGUMENTS_ONLY
+# from CanonicalVolatilityMaxAgeResearchDesignContractV1.
+OPERATOR_BOUND_CANDIDATE_MAX_AGE_SECONDS: tuple[int, ...] = (
+    60,
+    120,
+    300,
+    600,
+    900,
+    1800,
+    3600,
+    7200,
+)
+BASELINE_CANDIDATE_ID = "UNRESOLVED_MAX_AGE_NON_ENFORCING"
+AGE_REFERENCE_CLOCK = "MARKET_EVENT_TIME"
+AGE_UNIT = "SECONDS"
+AGE_FORMULA = "reference_market_event_time_minus_volatility_as_of_event_time"
+
+RESEARCH_QUESTION = (
+    "Welcher, falls überhaupt ein solcher existiert, robuste Bereich für die "
+    "maximal zulässige Event-Time-Alterung eines kanonischen "
+    "VolatilityEstimate reduziert stale-estimate exposure, ohne belastbare "
+    "Entscheidungsqualität, Coverage oder Regime-Robustheit unvertretbar zu "
+    "verschlechtern?"
+)
+NULL_HYPOTHESIS_H0 = (
+    "Innerhalb des preregistrierten Candidate-Domains existiert kein "
+    "robuster numerischer Maximum-Age-Bereich, der gegenüber der "
+    "unresolved/non-enforcing Baseline über Walk-Forward-, Holdout-, "
+    "Regime- und Stress-Auswertungen hinweg einen stabilen Nettonutzen zeigt."
+)
+ALTERNATIVE_HYPOTHESIS_H1 = (
+    "Mindestens ein zusammenhängender Candidate-Bereich zeigt gegenüber der "
+    "unresolved/non-enforcing Baseline einen reproduzierbaren und robusten "
+    "Nettonutzen, ohne die preregistrierten Rejection Criteria zu verletzen."
+)
+
+# Deterministic embargo derivation horizons (seconds), bound before evaluation.
+LOOKBACK_BARS = 60
+BAR_INTERVAL_SECONDS = 60
+LOOKBACK_HORIZON_SECONDS = LOOKBACK_BARS * BAR_INTERVAL_SECONDS  # 3600
+HOLDING_HORIZON_SECONDS = LOOKBACK_HORIZON_SECONDS
+SURVIVAL_HORIZON_SECONDS = LOOKBACK_HORIZON_SECONDS
+LABEL_HORIZON_SECONDS = LOOKBACK_HORIZON_SECONDS
+EMBARGO_SECONDS = max(
+    LOOKBACK_HORIZON_SECONDS,
+    HOLDING_HORIZON_SECONDS,
+    SURVIVAL_HORIZON_SECONDS,
+    LABEL_HORIZON_SECONDS,
+)
+
+WALK_FORWARD_FOLDS = 3
+HOLDOUT_FRACTION = 0.20
+TRAIN_FRACTION_WITHIN_NON_HOLDOUT = 0.70
+BOOTSTRAP_REPETITIONS = 200
+BOOTSTRAP_BLOCK_SECONDS = EMBARGO_SECONDS
+BOOTSTRAP_SEED = 0xC0FFEE01
+NEIGHBORHOOD_PERTURBATION_FACTORS: tuple[float, ...] = (0.9, 1.1)
+
+MINIMUM_SESSION_COUNT = 2
+MINIMUM_REGIME_COUNT = 2
+MINIMUM_EVIDENCE_COUNT = 8
+MAX_STALE_REJECTION_RATE = 0.85
+MAX_COVERAGE_REDUCTION_VS_BASELINE = 0.50
+MAX_NEIGHBORHOOD_SENSITIVITY = 0.35
+MAX_WALK_FORWARD_INSTABILITY = 0.40
+
+DEFAULT_INPUT_LEDGER_RELATIVE_PATH = (
+    "docs/evidence/canonical_volatility_numeric_max_age_research_evidence_ledger_v1/"
+    "research_evidence_ledger.jsonl"
+)
+DEFAULT_OUTPUT_EVIDENCE_RELATIVE_ROOT = (
+    "docs/evidence/canonical_volatility_numeric_max_age_parameter_research_execution_v1"
+)
+
+# Hard safety flags — research evidence only, never trading authority.
+NUMERIC_MAX_AGE_DECIDED = False
+THRESHOLD_STATUS = "UNRESOLVED_MAX_AGE"
+NUMERIC_THRESHOLD_SELECTED = False
+PARAMETER_PROMOTED = False
+ENFORCEMENT_APPLIED = False
+ENFORCEMENT_DURING_RESEARCH = False
+COUNTERFACTUAL_ONLY = True
+ALPHA_DECISION_MUTATION_ALLOWED = False
+ALPHA_MUTATION_OCCURRED = False
+PRODUCTIVE_TRADING_BEHAVIOR_CHANGED = False
+LIVE_TESTNET_ORDER_ACTIVATION_OCCURRED = False
+LIVE_AUTHORIZATION = False
+HARD_STOP = True
+READY_FOR_THRESHOLD_SELECTION = False
+READY_FOR_PARAMETER_PROMOTION = False
+READY_FOR_ENFORCEMENT = False
+
+AUTHORITY_SCOPE = "RESEARCH_EVIDENCE_ONLY"
+NON_AUTHORITY_SCOPE = (
+    "NOT_TRADING_AUTHORITY;"
+    "NOT_ALPHA_AUTHORITY;"
+    "NOT_POLICY_DEFAULT;"
+    "NOT_CONFIG_DEFAULT;"
+    "NOT_ORDER_AUTHORITY;"
+    "NOT_LIVE_AUTHORITY"
+)
+
+FORBIDDEN_IMPORT_SUBSTRINGS: tuple[str, ...] = (
+    "trading.execution",
+    "src.execution",
+    "trading.live",
+    "src.live",
+    "exchange_order",
+    "place_order",
+    "submit_order",
+    "broker_adapter",
+)
+
+RESEARCH_CONCLUSION_NO_ROBUST = "NO_ROBUST_NUMERIC_MAX_AGE_ESTABLISHED"
+RESEARCH_CONCLUSION_REGION_PENDING = "ROBUST_CANDIDATE_REGION_IDENTIFIED_PENDING_OWNER_RATIFICATION"
+RESEARCH_CONCLUSION_INSUFFICIENT = "INSUFFICIENT_RESEARCH_EVIDENCE"
+
+CLI_REL_PATH = (
+    "scripts/ops/run_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py"
+)
+SPEC_REL_PATH = (
+    "docs/ops/specs/"
+    "MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1.md"
+)

--- a/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/contracts_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/contracts_v1.py
@@ -1,0 +1,567 @@
+"""Pre-evaluation research contracts bound and digested before result scoring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Sequence
+
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.constants_v1 import (
+    AGE_FORMULA,
+    AGE_REFERENCE_CLOCK,
+    AGE_UNIT,
+    ALTERNATIVE_HYPOTHESIS_H1,
+    AUTHORITY_SCOPE,
+    BASELINE_CANDIDATE_ID,
+    BOOTSTRAP_BLOCK_SECONDS,
+    BOOTSTRAP_REPETITIONS,
+    BOOTSTRAP_SEED,
+    CANDIDATE_DOMAIN_SCHEMA_VERSION,
+    COUNTERFACTUAL_ONLY,
+    EMBARGO_SECONDS,
+    ENFORCEMENT_DURING_RESEARCH,
+    EXPECTED_PREREGISTRATION_DIGEST,
+    HOLDING_HORIZON_SECONDS,
+    HOLDOUT_FRACTION,
+    HYPOTHESIS_SCHEMA_VERSION,
+    LABEL_HORIZON_SECONDS,
+    LOOKBACK_HORIZON_SECONDS,
+    MANIFEST_SCHEMA_VERSION,
+    NEIGHBORHOOD_PERTURBATION_FACTORS,
+    NON_AUTHORITY_SCOPE,
+    NULL_HYPOTHESIS_H0,
+    NUMERIC_THRESHOLD_SELECTED,
+    OPERATOR_BOUND_CANDIDATE_MAX_AGE_SECONDS,
+    PARAMETER_PROMOTED,
+    RESEARCH_QUESTION,
+    ROBUSTNESS_SCHEMA_VERSION,
+    SPLIT_SCHEMA_VERSION,
+    SURVIVAL_HORIZON_SECONDS,
+    THRESHOLD_STATUS,
+    TRAIN_FRACTION_WITHIN_NON_HOLDOUT,
+    WALK_FORWARD_FOLDS,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.serialization_v1 import (
+    digest_excluding_keys,
+)
+
+
+class MaxAgeResearchExecutionError(ValueError):
+    """Fail-closed research execution contract / evidence error."""
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class CandidateDomainContractV1:
+    schema_version: str
+    repository_sha: str
+    preregistration_digest: str
+    execution_id: str
+    created_at_utc: str
+    candidate_max_age_seconds: tuple[int, ...]
+    baseline_candidate_id: str
+    age_unit: str
+    candidate_authority: str
+    non_authority: str
+    immutable_after_bind: bool
+    domain_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "age_unit": self.age_unit,
+            "authority_scope": AUTHORITY_SCOPE,
+            "baseline_candidate_id": self.baseline_candidate_id,
+            "candidate_authority": self.candidate_authority,
+            "candidate_max_age_seconds": list(self.candidate_max_age_seconds),
+            "created_at_utc": self.created_at_utc,
+            "domain_digest": self.domain_digest,
+            "execution_id": self.execution_id,
+            "immutable_after_bind": self.immutable_after_bind,
+            "non_authority": self.non_authority,
+            "non_authority_scope": NON_AUTHORITY_SCOPE,
+            "preregistration_digest": self.preregistration_digest,
+            "repository_sha": self.repository_sha,
+            "schema_version": self.schema_version,
+        }
+
+
+@dataclass(frozen=True)
+class HypothesisContractV1:
+    schema_version: str
+    repository_sha: str
+    preregistration_digest: str
+    execution_id: str
+    created_at_utc: str
+    research_question: str
+    null_hypothesis_h0: str
+    alternative_hypothesis_h1: str
+    baseline: str
+    age_reference_clock: str
+    age_unit: str
+    age_formula: str
+    enforcement_during_research: bool
+    counterfactual_only: bool
+    alpha_decision_mutation_allowed: bool
+    threshold_status: str
+    numeric_threshold_selected: bool
+    parameter_promoted: bool
+    hypothesis_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "age_formula": self.age_formula,
+            "age_reference_clock": self.age_reference_clock,
+            "age_unit": self.age_unit,
+            "alpha_decision_mutation_allowed": self.alpha_decision_mutation_allowed,
+            "alternative_hypothesis_h1": self.alternative_hypothesis_h1,
+            "authority_scope": AUTHORITY_SCOPE,
+            "baseline": self.baseline,
+            "counterfactual_only": self.counterfactual_only,
+            "created_at_utc": self.created_at_utc,
+            "enforcement_during_research": self.enforcement_during_research,
+            "execution_id": self.execution_id,
+            "hypothesis_digest": self.hypothesis_digest,
+            "non_authority_scope": NON_AUTHORITY_SCOPE,
+            "null_hypothesis_h0": self.null_hypothesis_h0,
+            "numeric_threshold_selected": self.numeric_threshold_selected,
+            "parameter_promoted": self.parameter_promoted,
+            "preregistration_digest": self.preregistration_digest,
+            "repository_sha": self.repository_sha,
+            "research_question": self.research_question,
+            "schema_version": self.schema_version,
+            "threshold_status": self.threshold_status,
+        }
+
+
+@dataclass(frozen=True)
+class SplitAndEmbargoContractV1:
+    schema_version: str
+    repository_sha: str
+    preregistration_digest: str
+    execution_id: str
+    created_at_utc: str
+    split_policy: str
+    walk_forward_folds: int
+    holdout_fraction: float
+    train_fraction_within_non_holdout: float
+    lookback_horizon_seconds: int
+    holding_horizon_seconds: int
+    survival_horizon_seconds: int
+    label_horizon_seconds: int
+    embargo_seconds: int
+    embargo_derivation: str
+    holdout_untouched_until_final_evaluation: bool
+    no_random_iid_shuffle: bool
+    no_future_event_time_labels: bool
+    no_holdout_candidate_selection: bool
+    no_retrospective_regime_relabel: bool
+    split_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "authority_scope": AUTHORITY_SCOPE,
+            "created_at_utc": self.created_at_utc,
+            "embargo_derivation": self.embargo_derivation,
+            "embargo_seconds": self.embargo_seconds,
+            "execution_id": self.execution_id,
+            "holding_horizon_seconds": self.holding_horizon_seconds,
+            "holdout_fraction": self.holdout_fraction,
+            "holdout_untouched_until_final_evaluation": (
+                self.holdout_untouched_until_final_evaluation
+            ),
+            "label_horizon_seconds": self.label_horizon_seconds,
+            "lookback_horizon_seconds": self.lookback_horizon_seconds,
+            "no_future_event_time_labels": self.no_future_event_time_labels,
+            "no_holdout_candidate_selection": self.no_holdout_candidate_selection,
+            "no_random_iid_shuffle": self.no_random_iid_shuffle,
+            "no_retrospective_regime_relabel": self.no_retrospective_regime_relabel,
+            "non_authority_scope": NON_AUTHORITY_SCOPE,
+            "preregistration_digest": self.preregistration_digest,
+            "repository_sha": self.repository_sha,
+            "schema_version": self.schema_version,
+            "split_digest": self.split_digest,
+            "split_policy": self.split_policy,
+            "survival_horizon_seconds": self.survival_horizon_seconds,
+            "train_fraction_within_non_holdout": self.train_fraction_within_non_holdout,
+            "walk_forward_folds": self.walk_forward_folds,
+        }
+
+
+@dataclass(frozen=True)
+class RobustnessExecutionContractV1:
+    schema_version: str
+    repository_sha: str
+    preregistration_digest: str
+    execution_id: str
+    created_at_utc: str
+    methods: tuple[str, ...]
+    bootstrap_repetitions: int
+    bootstrap_block_seconds: int
+    bootstrap_seed: int
+    neighborhood_perturbation_factors: tuple[float, ...]
+    resampling_policy: str
+    monte_carlo_policy: str
+    limitations: tuple[str, ...]
+    robustness_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "authority_scope": AUTHORITY_SCOPE,
+            "bootstrap_block_seconds": self.bootstrap_block_seconds,
+            "bootstrap_repetitions": self.bootstrap_repetitions,
+            "bootstrap_seed": self.bootstrap_seed,
+            "created_at_utc": self.created_at_utc,
+            "execution_id": self.execution_id,
+            "limitations": list(self.limitations),
+            "methods": list(self.methods),
+            "monte_carlo_policy": self.monte_carlo_policy,
+            "neighborhood_perturbation_factors": list(self.neighborhood_perturbation_factors),
+            "non_authority_scope": NON_AUTHORITY_SCOPE,
+            "preregistration_digest": self.preregistration_digest,
+            "repository_sha": self.repository_sha,
+            "resampling_policy": self.resampling_policy,
+            "robustness_digest": self.robustness_digest,
+            "schema_version": self.schema_version,
+        }
+
+
+def verify_preregistration_digest_v1(actual_digest: str) -> None:
+    if actual_digest != EXPECTED_PREREGISTRATION_DIGEST:
+        raise MaxAgeResearchExecutionError(
+            "preregistration_digest_mismatch:"
+            f"expected={EXPECTED_PREREGISTRATION_DIGEST}:actual={actual_digest}"
+        )
+
+
+def bind_candidate_domain_v1(
+    *,
+    repository_sha: str,
+    preregistration_digest: str,
+    execution_id: str,
+    created_at_utc: Optional[str] = None,
+    candidate_max_age_seconds: Sequence[int] | None = None,
+) -> CandidateDomainContractV1:
+    verify_preregistration_digest_v1(preregistration_digest)
+    candidates = tuple(
+        int(x)
+        for x in (
+            candidate_max_age_seconds
+            if candidate_max_age_seconds is not None
+            else OPERATOR_BOUND_CANDIDATE_MAX_AGE_SECONDS
+        )
+    )
+    if not candidates:
+        raise MaxAgeResearchExecutionError("candidate_domain_empty")
+    if candidates != tuple(sorted(candidates)):
+        raise MaxAgeResearchExecutionError("candidate_domain_must_be_ordered_ascending")
+    if len(set(candidates)) != len(candidates):
+        raise MaxAgeResearchExecutionError("candidate_domain_duplicate_values")
+    if any(c < 0 for c in candidates):
+        raise MaxAgeResearchExecutionError("candidate_domain_negative_forbidden")
+
+    created = created_at_utc or _utc_now_iso()
+    provisional = {
+        "age_unit": AGE_UNIT,
+        "authority_scope": AUTHORITY_SCOPE,
+        "baseline_candidate_id": BASELINE_CANDIDATE_ID,
+        "candidate_authority": (
+            "EXPLICIT_OPERATOR_OR_CALLER_SUPPLIED_RESEARCH_ARGUMENT_ONLY;"
+            "NOT_CONFIG;"
+            "NOT_POLICY;"
+            "NOT_PRODUCTIVE_DEFAULT"
+        ),
+        "candidate_max_age_seconds": list(candidates),
+        "created_at_utc": created,
+        "execution_id": execution_id,
+        "immutable_after_bind": True,
+        "non_authority": (
+            "CANDIDATE_VALUES_ARE_RESEARCH_ARGUMENTS_ONLY;NO_CONFIG_AUTHORITY;NO_POLICY_AUTHORITY"
+        ),
+        "non_authority_scope": NON_AUTHORITY_SCOPE,
+        "preregistration_digest": preregistration_digest,
+        "repository_sha": repository_sha,
+        "schema_version": CANDIDATE_DOMAIN_SCHEMA_VERSION,
+    }
+    digest = digest_excluding_keys(
+        provisional, exclude={"domain_digest", "execution_id", "created_at_utc"}
+    )
+    return CandidateDomainContractV1(
+        schema_version=CANDIDATE_DOMAIN_SCHEMA_VERSION,
+        repository_sha=repository_sha,
+        preregistration_digest=preregistration_digest,
+        execution_id=execution_id,
+        created_at_utc=created,
+        candidate_max_age_seconds=candidates,
+        baseline_candidate_id=BASELINE_CANDIDATE_ID,
+        age_unit=AGE_UNIT,
+        candidate_authority=str(provisional["candidate_authority"]),
+        non_authority=str(provisional["non_authority"]),
+        immutable_after_bind=True,
+        domain_digest=digest,
+    )
+
+
+def bind_hypothesis_contract_v1(
+    *,
+    repository_sha: str,
+    preregistration_digest: str,
+    execution_id: str,
+    created_at_utc: Optional[str] = None,
+) -> HypothesisContractV1:
+    verify_preregistration_digest_v1(preregistration_digest)
+    created = created_at_utc or _utc_now_iso()
+    provisional = {
+        "age_formula": AGE_FORMULA,
+        "age_reference_clock": AGE_REFERENCE_CLOCK,
+        "age_unit": AGE_UNIT,
+        "alpha_decision_mutation_allowed": False,
+        "alternative_hypothesis_h1": ALTERNATIVE_HYPOTHESIS_H1,
+        "authority_scope": AUTHORITY_SCOPE,
+        "baseline": BASELINE_CANDIDATE_ID,
+        "counterfactual_only": COUNTERFACTUAL_ONLY,
+        "created_at_utc": created,
+        "enforcement_during_research": ENFORCEMENT_DURING_RESEARCH,
+        "execution_id": execution_id,
+        "non_authority_scope": NON_AUTHORITY_SCOPE,
+        "null_hypothesis_h0": NULL_HYPOTHESIS_H0,
+        "numeric_threshold_selected": NUMERIC_THRESHOLD_SELECTED,
+        "parameter_promoted": PARAMETER_PROMOTED,
+        "preregistration_digest": preregistration_digest,
+        "repository_sha": repository_sha,
+        "research_question": RESEARCH_QUESTION,
+        "schema_version": HYPOTHESIS_SCHEMA_VERSION,
+        "threshold_status": THRESHOLD_STATUS,
+    }
+    digest = digest_excluding_keys(
+        provisional, exclude={"hypothesis_digest", "execution_id", "created_at_utc"}
+    )
+    return HypothesisContractV1(
+        schema_version=HYPOTHESIS_SCHEMA_VERSION,
+        repository_sha=repository_sha,
+        preregistration_digest=preregistration_digest,
+        execution_id=execution_id,
+        created_at_utc=created,
+        research_question=RESEARCH_QUESTION,
+        null_hypothesis_h0=NULL_HYPOTHESIS_H0,
+        alternative_hypothesis_h1=ALTERNATIVE_HYPOTHESIS_H1,
+        baseline=BASELINE_CANDIDATE_ID,
+        age_reference_clock=AGE_REFERENCE_CLOCK,
+        age_unit=AGE_UNIT,
+        age_formula=AGE_FORMULA,
+        enforcement_during_research=ENFORCEMENT_DURING_RESEARCH,
+        counterfactual_only=COUNTERFACTUAL_ONLY,
+        alpha_decision_mutation_allowed=False,
+        threshold_status=THRESHOLD_STATUS,
+        numeric_threshold_selected=NUMERIC_THRESHOLD_SELECTED,
+        parameter_promoted=PARAMETER_PROMOTED,
+        hypothesis_digest=digest,
+    )
+
+
+def bind_split_and_embargo_contract_v1(
+    *,
+    repository_sha: str,
+    preregistration_digest: str,
+    execution_id: str,
+    created_at_utc: Optional[str] = None,
+) -> SplitAndEmbargoContractV1:
+    verify_preregistration_digest_v1(preregistration_digest)
+    created = created_at_utc or _utc_now_iso()
+    derivation = (
+        "embargo_seconds=max("
+        "lookback_horizon_seconds,"
+        "holding_horizon_seconds,"
+        "survival_horizon_seconds,"
+        "label_horizon_seconds"
+        f")={EMBARGO_SECONDS};"
+        "horizons_bound_before_evaluation=true;"
+        "source=canonical_volatility_lookback_bars*bar_interval_seconds"
+    )
+    provisional = {
+        "authority_scope": AUTHORITY_SCOPE,
+        "created_at_utc": created,
+        "embargo_derivation": derivation,
+        "embargo_seconds": EMBARGO_SECONDS,
+        "execution_id": execution_id,
+        "holding_horizon_seconds": HOLDING_HORIZON_SECONDS,
+        "holdout_fraction": HOLDOUT_FRACTION,
+        "holdout_untouched_until_final_evaluation": True,
+        "label_horizon_seconds": LABEL_HORIZON_SECONDS,
+        "lookback_horizon_seconds": LOOKBACK_HORIZON_SECONDS,
+        "no_future_event_time_labels": True,
+        "no_holdout_candidate_selection": True,
+        "no_random_iid_shuffle": True,
+        "no_retrospective_regime_relabel": True,
+        "non_authority_scope": NON_AUTHORITY_SCOPE,
+        "preregistration_digest": preregistration_digest,
+        "repository_sha": repository_sha,
+        "schema_version": SPLIT_SCHEMA_VERSION,
+        "split_policy": "PURGED_CHRONOLOGICAL_SPLITS_WITH_EVENT_TIME_EMBARGO",
+        "survival_horizon_seconds": SURVIVAL_HORIZON_SECONDS,
+        "train_fraction_within_non_holdout": TRAIN_FRACTION_WITHIN_NON_HOLDOUT,
+        "walk_forward_folds": WALK_FORWARD_FOLDS,
+    }
+    digest = digest_excluding_keys(
+        provisional, exclude={"split_digest", "execution_id", "created_at_utc"}
+    )
+    return SplitAndEmbargoContractV1(
+        schema_version=SPLIT_SCHEMA_VERSION,
+        repository_sha=repository_sha,
+        preregistration_digest=preregistration_digest,
+        execution_id=execution_id,
+        created_at_utc=created,
+        split_policy="PURGED_CHRONOLOGICAL_SPLITS_WITH_EVENT_TIME_EMBARGO",
+        walk_forward_folds=WALK_FORWARD_FOLDS,
+        holdout_fraction=HOLDOUT_FRACTION,
+        train_fraction_within_non_holdout=TRAIN_FRACTION_WITHIN_NON_HOLDOUT,
+        lookback_horizon_seconds=LOOKBACK_HORIZON_SECONDS,
+        holding_horizon_seconds=HOLDING_HORIZON_SECONDS,
+        survival_horizon_seconds=SURVIVAL_HORIZON_SECONDS,
+        label_horizon_seconds=LABEL_HORIZON_SECONDS,
+        embargo_seconds=EMBARGO_SECONDS,
+        embargo_derivation=derivation,
+        holdout_untouched_until_final_evaluation=True,
+        no_random_iid_shuffle=True,
+        no_future_event_time_labels=True,
+        no_holdout_candidate_selection=True,
+        no_retrospective_regime_relabel=True,
+        split_digest=digest,
+    )
+
+
+def bind_robustness_execution_contract_v1(
+    *,
+    repository_sha: str,
+    preregistration_digest: str,
+    execution_id: str,
+    created_at_utc: Optional[str] = None,
+) -> RobustnessExecutionContractV1:
+    verify_preregistration_digest_v1(preregistration_digest)
+    created = created_at_utc or _utc_now_iso()
+    methods = (
+        "WALK_FORWARD",
+        "FINAL_HOLDOUT",
+        "CANDIDATE_NEIGHBORHOOD_PERTURBATION",
+        "REGIME_SLICES",
+        "SESSION_SLICES",
+        "MISSING_SAMPLE_STRESS",
+        "DUPLICATE_SAMPLE_STRESS",
+        "OUT_OF_ORDER_STRESS",
+        "STALE_DATA_STRESS",
+        "RESTART_RESUME_CONSISTENCY",
+        "LEDGER_RELOAD_CONSISTENCY",
+        "BLOCK_BOOTSTRAP_CONFIDENCE_INTERVALS",
+    )
+    limitations = (
+        "BOOTSTRAP_PRESERVES_TEMPORAL_BLOCKS_NOT_IID",
+        "MONTE_CARLO_REQUIRES_REAL_FILL_SEQUENCE",
+        "ECONOMIC_METRICS_ONLY_WHEN_JOINABLE",
+        "NO_SYNTHETIC_PRODUCTIVE_EVIDENCE_INVENTION",
+    )
+    provisional = {
+        "authority_scope": AUTHORITY_SCOPE,
+        "bootstrap_block_seconds": BOOTSTRAP_BLOCK_SECONDS,
+        "bootstrap_repetitions": BOOTSTRAP_REPETITIONS,
+        "bootstrap_seed": BOOTSTRAP_SEED,
+        "created_at_utc": created,
+        "execution_id": execution_id,
+        "limitations": list(limitations),
+        "methods": list(methods),
+        "monte_carlo_policy": (
+            "TRADE_SEQUENCE_MONTE_CARLO_ONLY_IF_REAL_FILL_SEQUENCE_PRESENT;ELSE_NOT_APPLICABLE"
+        ),
+        "neighborhood_perturbation_factors": list(NEIGHBORHOOD_PERTURBATION_FACTORS),
+        "non_authority_scope": NON_AUTHORITY_SCOPE,
+        "preregistration_digest": preregistration_digest,
+        "repository_sha": repository_sha,
+        "resampling_policy": "BLOCK_BOOTSTRAP_EVENT_TIME_PRESERVING",
+        "schema_version": ROBUSTNESS_SCHEMA_VERSION,
+    }
+    digest = digest_excluding_keys(
+        provisional, exclude={"robustness_digest", "execution_id", "created_at_utc"}
+    )
+    return RobustnessExecutionContractV1(
+        schema_version=ROBUSTNESS_SCHEMA_VERSION,
+        repository_sha=repository_sha,
+        preregistration_digest=preregistration_digest,
+        execution_id=execution_id,
+        created_at_utc=created,
+        methods=methods,
+        bootstrap_repetitions=BOOTSTRAP_REPETITIONS,
+        bootstrap_block_seconds=BOOTSTRAP_BLOCK_SECONDS,
+        bootstrap_seed=BOOTSTRAP_SEED,
+        neighborhood_perturbation_factors=NEIGHBORHOOD_PERTURBATION_FACTORS,
+        resampling_policy="BLOCK_BOOTSTRAP_EVENT_TIME_PRESERVING",
+        monte_carlo_policy=str(provisional["monte_carlo_policy"]),
+        limitations=limitations,
+        robustness_digest=digest,
+    )
+
+
+def build_research_execution_manifest_shell_v1(
+    *,
+    repository_sha: str,
+    preregistration_digest: str,
+    execution_id: str,
+    candidate_domain_digest: str,
+    hypothesis_contract_digest: str,
+    split_contract_digest: str,
+    robustness_contract_digest: str,
+    input_evidence_manifest_digest: str,
+    created_at_utc: Optional[str] = None,
+) -> dict[str, Any]:
+    created = created_at_utc or _utc_now_iso()
+    provisional: dict[str, Any] = {
+        "authority_scope": AUTHORITY_SCOPE,
+        "candidate_domain_digest": candidate_domain_digest,
+        "capability_id": "MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1",
+        "created_at_utc": created,
+        "enforcement_applied": False,
+        "execution_id": execution_id,
+        "hypothesis_contract_digest": hypothesis_contract_digest,
+        "input_evidence_manifest_digest": input_evidence_manifest_digest,
+        "non_authority_scope": NON_AUTHORITY_SCOPE,
+        "numeric_threshold_selected": False,
+        "parameter_promoted": False,
+        "preregistration_digest": preregistration_digest,
+        "repository_sha": repository_sha,
+        "robustness_contract_digest": robustness_contract_digest,
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "split_contract_digest": split_contract_digest,
+        "threshold_status": THRESHOLD_STATUS,
+    }
+    provisional["manifest_digest"] = digest_excluding_keys(provisional, exclude={"manifest_digest"})
+    return provisional
+
+
+def assert_candidate_domain_immutable_v1(
+    bound: CandidateDomainContractV1,
+    *,
+    attempted_candidates: Sequence[int],
+) -> None:
+    if tuple(int(x) for x in attempted_candidates) != bound.candidate_max_age_seconds:
+        raise MaxAgeResearchExecutionError("candidate_domain_immutable_after_bind")
+
+
+def assert_candidates_not_config_authority_v1(domain: Mapping[str, Any]) -> None:
+    text = json_blob(domain)
+    for forbidden in (
+        "productive_policy_default",
+        "config_default_max_age",
+        "NUMERIC_MAX_AGE_SECONDS=",
+    ):
+        if forbidden in text:
+            raise MaxAgeResearchExecutionError("candidate_values_must_not_be_config_authority")
+    if domain.get("candidate_authority", "").find("NOT_CONFIG") < 0:
+        raise MaxAgeResearchExecutionError("candidate_authority_missing_not_config")
+
+
+def json_blob(payload: Mapping[str, Any]) -> str:
+    from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.serialization_v1 import (
+        canonical_json_dumps,
+    )
+
+    return canonical_json_dumps(payload)

--- a/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/evaluator_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/evaluator_v1.py
@@ -1,0 +1,256 @@
+"""Counterfactual-only candidate evaluation (diagnostic, non-enforcing)."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Mapping, Optional, Sequence
+
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.constants_v1 import (
+    BASELINE_CANDIDATE_ID,
+    MAX_COVERAGE_REDUCTION_VS_BASELINE,
+    MAX_NEIGHBORHOOD_SENSITIVITY,
+    MAX_STALE_REJECTION_RATE,
+    MAX_WALK_FORWARD_INSTABILITY,
+    MINIMUM_REGIME_COUNT,
+    MINIMUM_SESSION_COUNT,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.evidence_loader_v1 import (
+    ResearchEvidenceRecordV1,
+)
+from trading.master_v2.canonical_volatility_numeric_max_age_parameter_research_design_and_evidence_accumulation_contract_v1 import (
+    CounterfactualAgeLabelV1,
+    evaluate_counterfactual_max_age_threshold_diagnostic_v1,
+)
+
+
+def _distribution(values: Sequence[Optional[str]]) -> dict[str, int]:
+    counter: Counter[str] = Counter()
+    for value in values:
+        key = "MISSING" if value is None or not str(value).strip() else str(value)
+        counter[key] += 1
+    return dict(sorted(counter.items()))
+
+
+def _age_distribution(ages: Sequence[Optional[float]]) -> dict[str, Any]:
+    present = [float(a) for a in ages if a is not None]
+    if not present:
+        return {"count": 0, "min": None, "max": None, "mean": None, "p50": None}
+    present_sorted = sorted(present)
+    mid = len(present_sorted) // 2
+    p50 = (
+        present_sorted[mid]
+        if len(present_sorted) % 2 == 1
+        else 0.5 * (present_sorted[mid - 1] + present_sorted[mid])
+    )
+    return {
+        "count": len(present_sorted),
+        "min": present_sorted[0],
+        "max": present_sorted[-1],
+        "mean": sum(present_sorted) / len(present_sorted),
+        "p50": p50,
+    }
+
+
+def _economic_diagnostics(
+    records: Sequence[ResearchEvidenceRecordV1],
+) -> Optional[dict[str, Any]]:
+    metrics_rows = [dict(r.economic_metrics) for r in records if r.economic_metrics]
+    if not metrics_rows:
+        return None
+
+    def _sum(key: str) -> Optional[float]:
+        vals = []
+        for row in metrics_rows:
+            if key in row and row[key] is not None:
+                try:
+                    vals.append(float(row[key]))
+                except (TypeError, ValueError):
+                    continue
+        if not vals:
+            return None
+        return float(sum(vals))
+
+    out = {
+        "trade_count": _sum("trade_count"),
+        "exposure": _sum("exposure"),
+        "turnover": _sum("turnover"),
+        "gross_pnl": _sum("gross_pnl"),
+        "net_pnl_after_fees_and_slippage": _sum("net_pnl_after_fees_and_slippage"),
+        "sharpe": _sum("sharpe"),
+        "sortino": _sum("sortino"),
+        "profit_factor": _sum("profit_factor"),
+        "max_drawdown": _sum("max_drawdown"),
+        "average_holding_period": _sum("average_holding_period"),
+        "long_short_asymmetry": _sum("long_short_asymmetry"),
+        "diagnostic_only": True,
+        "invented": False,
+    }
+    if all(v is None for k, v in out.items() if k not in {"diagnostic_only", "invented"}):
+        return None
+    return out
+
+
+def evaluate_candidate_on_records_v1(
+    records: Sequence[ResearchEvidenceRecordV1],
+    *,
+    candidate_id: str,
+    candidate_max_age_seconds: Optional[float],
+    baseline_decision_outcomes: Optional[Mapping[str, Optional[str]]] = None,
+) -> dict[str, Any]:
+    """Evaluate one candidate or the unresolved baseline counterfactually."""
+    n = len(records)
+    sessions = {r.session_id for r in records}
+    regimes = {r.regime_id for r in records}
+    accepted = 0
+    rejected_stale = 0
+    missing_estimate = 0
+    decision_changes = 0
+    ages: list[Optional[float]] = []
+
+    baseline_map = baseline_decision_outcomes or {}
+
+    for record in records:
+        ages.append(record.computed_age_seconds)
+        if record.estimate_present is False or record.computed_age_seconds is None:
+            missing_estimate += 1
+            continue
+
+        if candidate_max_age_seconds is None:
+            # Baseline: unresolved / non-enforcing — no stale rejection.
+            accepted += 1
+            continue
+
+        diagnostic = evaluate_counterfactual_max_age_threshold_diagnostic_v1(
+            computed_age_seconds=record.computed_age_seconds,
+            candidate_max_age_seconds_argument=float(candidate_max_age_seconds),
+        )
+        if diagnostic.enforcement_applied or diagnostic.alpha_decision_mutated:
+            raise RuntimeError("alpha_or_enforcement_leak_in_counterfactual")
+        if (
+            diagnostic.counterfactual_label
+            == CounterfactualAgeLabelV1.WOULD_BE_STALE_IF_THRESHOLD.value
+        ):
+            rejected_stale += 1
+            # Counterfactual decision change diagnostic vs baseline acceptance.
+            if baseline_map.get(record.cycle_id) is not None:
+                decision_changes += 1
+        elif (
+            diagnostic.counterfactual_label
+            == CounterfactualAgeLabelV1.WOULD_BE_FRESH_IF_THRESHOLD.value
+        ):
+            accepted += 1
+        else:
+            missing_estimate += 1
+
+    denom = max(n, 1)
+    decision_coverage = accepted / denom
+    result: dict[str, Any] = {
+        "accepted_estimate_count": accepted,
+        "age_distribution": _age_distribution(ages),
+        "alpha_decision_mutated": False,
+        "candidate_id": candidate_id,
+        "candidate_max_age_seconds_argument": candidate_max_age_seconds,
+        "counterfactual_decision_change_count": decision_changes,
+        "decision_coverage": decision_coverage,
+        "enforcement_applied": False,
+        "evaluation_mode": "DIAGNOSTIC_COUNTERFACTUAL_NO_ENFORCEMENT",
+        "evidence_count": n,
+        "final_holdout_result": None,
+        "missing_estimate_rate": missing_estimate / denom,
+        "parameter_stability": None,
+        "regime_count": len(regimes),
+        "regime_distribution": _distribution([r.regime_id for r in records]),
+        "rejected_as_stale_count": rejected_stale,
+        "restart_status_distribution": _distribution([r.restart_status for r in records]),
+        "reuse_status_distribution": _distribution([r.reuse_status for r in records]),
+        "session_count": len(sessions),
+        "stale_rejection_rate": rejected_stale / denom,
+        "threshold_boundary_sensitivity": None,
+        "walk_forward_stability": None,
+    }
+    econ = _economic_diagnostics(records)
+    if econ is not None:
+        result["economic_diagnostics"] = econ
+    return result
+
+
+def evaluate_all_candidates_v1(
+    records: Sequence[ResearchEvidenceRecordV1],
+    *,
+    candidate_max_age_seconds: Sequence[int],
+) -> list[dict[str, Any]]:
+    baseline_outcomes = {r.cycle_id: r.decision_outcome for r in records}
+    results = [
+        evaluate_candidate_on_records_v1(
+            records,
+            candidate_id=BASELINE_CANDIDATE_ID,
+            candidate_max_age_seconds=None,
+            baseline_decision_outcomes=baseline_outcomes,
+        )
+    ]
+    for seconds in candidate_max_age_seconds:
+        results.append(
+            evaluate_candidate_on_records_v1(
+                records,
+                candidate_id=f"CANDIDATE_{int(seconds)}_S",
+                candidate_max_age_seconds=float(seconds),
+                baseline_decision_outcomes=baseline_outcomes,
+            )
+        )
+    return results
+
+
+def apply_rejection_criteria_v1(
+    candidate_result: Mapping[str, Any],
+    *,
+    baseline_result: Mapping[str, Any],
+    walk_forward_stability: Optional[float],
+    neighborhood_sensitivity: Optional[float],
+    holdout_degraded: bool,
+    single_session_only: bool,
+    single_regime_only: bool,
+    leakage_or_digest_violation: bool,
+    restart_ledger_nondeterminism: bool,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    if int(candidate_result.get("session_count") or 0) < MINIMUM_SESSION_COUNT:
+        reasons.append("INSUFFICIENT_SESSION_COVERAGE")
+    if int(candidate_result.get("regime_count") or 0) < MINIMUM_REGIME_COUNT:
+        reasons.append("INSUFFICIENT_REGIME_COVERAGE")
+    if walk_forward_stability is not None and walk_forward_stability > MAX_WALK_FORWARD_INSTABILITY:
+        reasons.append("UNSTABLE_WALK_FORWARD")
+    if holdout_degraded:
+        reasons.append("HOLDOUT_DEGRADATION")
+    if (
+        neighborhood_sensitivity is not None
+        and neighborhood_sensitivity > MAX_NEIGHBORHOOD_SENSITIVITY
+    ):
+        reasons.append("HIGH_NEIGHBORHOOD_SENSITIVITY")
+    baseline_coverage = float(baseline_result.get("decision_coverage") or 0.0)
+    candidate_coverage = float(candidate_result.get("decision_coverage") or 0.0)
+    if baseline_coverage > 0:
+        reduction = (baseline_coverage - candidate_coverage) / baseline_coverage
+        if reduction > MAX_COVERAGE_REDUCTION_VS_BASELINE:
+            reasons.append("EXCESSIVE_COVERAGE_REDUCTION")
+    if float(candidate_result.get("stale_rejection_rate") or 0.0) > MAX_STALE_REJECTION_RATE:
+        reasons.append("EXCESSIVE_STALE_REJECTION")
+    if single_session_only:
+        reasons.append("BENEFIT_ONLY_IN_SINGLE_SESSION")
+    if single_regime_only:
+        reasons.append("BENEFIT_ONLY_IN_SINGLE_REGIME")
+    if leakage_or_digest_violation:
+        reasons.append("LEAKAGE_OR_DIGEST_VIOLATION")
+    if restart_ledger_nondeterminism:
+        reasons.append("RESTART_LEDGER_NONDETERMINISM")
+    if int(candidate_result.get("evidence_count") or 0) < 1:
+        reasons.append("INSUFFICIENT_STATISTICAL_POWER")
+
+    return {
+        "candidate_id": candidate_result.get("candidate_id"),
+        "rejected": bool(reasons),
+        "rejection_reasons": reasons,
+        "alpha_decision_mutated": False,
+        "enforcement_applied": False,
+        "numeric_threshold_selected": False,
+        "parameter_promoted": False,
+    }

--- a/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/evidence_loader_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/evidence_loader_v1.py
@@ -1,0 +1,352 @@
+"""Fail-closed loader for joinable max-age research evidence."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.constants_v1 import (
+    AUTHORITY_SCOPE,
+    INPUT_EVIDENCE_MANIFEST_SCHEMA_VERSION,
+    MINIMUM_EVIDENCE_COUNT,
+    MINIMUM_REGIME_COUNT,
+    MINIMUM_SESSION_COUNT,
+    NON_AUTHORITY_SCOPE,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.contracts_v1 import (
+    MaxAgeResearchExecutionError,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.serialization_v1 import (
+    digest_excluding_keys,
+    sha256_hex_bytes,
+)
+from trading.master_v2.canonical_volatility_numeric_max_age_parameter_research_design_and_evidence_accumulation_contract_v1 import (
+    JOIN_CONTRACT_VERSION,
+    MaxAgeResearchDesignContractError,
+    load_max_age_research_evidence_ledger_v1,
+)
+
+
+@dataclass(frozen=True)
+class ResearchEvidenceRecordV1:
+    session_id: str
+    cycle_id: str
+    instrument_id: str
+    regime_id: str
+    join_contract_version: str
+    join_digest: str
+    volatility_source_digest: Optional[str]
+    market_event_time: Optional[str]
+    volatility_as_of_event_time: Optional[str]
+    computed_age_seconds: Optional[float]
+    reuse_status: Optional[str]
+    restart_status: Optional[str]
+    estimate_present: Optional[bool]
+    decision_outcome: Optional[str]
+    selected_side: Optional[str]
+    economic_metrics: Optional[Mapping[str, Any]]
+    event_time_epoch_seconds: Optional[float]
+    raw: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "computed_age_seconds": self.computed_age_seconds,
+            "cycle_id": self.cycle_id,
+            "decision_outcome": self.decision_outcome,
+            "economic_metrics": (
+                None if self.economic_metrics is None else dict(self.economic_metrics)
+            ),
+            "estimate_present": self.estimate_present,
+            "event_time_epoch_seconds": self.event_time_epoch_seconds,
+            "instrument_id": self.instrument_id,
+            "join_contract_version": self.join_contract_version,
+            "join_digest": self.join_digest,
+            "market_event_time": self.market_event_time,
+            "regime_id": self.regime_id,
+            "restart_status": self.restart_status,
+            "reuse_status": self.reuse_status,
+            "selected_side": self.selected_side,
+            "session_id": self.session_id,
+            "volatility_as_of_event_time": self.volatility_as_of_event_time,
+            "volatility_source_digest": self.volatility_source_digest,
+        }
+
+
+def _parse_event_time_epoch(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except (TypeError, ValueError):
+        pass
+    normalized = text.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise MaxAgeResearchExecutionError(
+            f"incomplete_event_time_reference:unparseable={text}"
+        ) from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+def _map_join_to_record(join_payload: Mapping[str, Any]) -> ResearchEvidenceRecordV1:
+    if join_payload.get("join_contract_version") not in (None, JOIN_CONTRACT_VERSION):
+        # Unknown schema versions fail closed.
+        if join_payload.get("join_contract_version") != JOIN_CONTRACT_VERSION:
+            raise MaxAgeResearchExecutionError(
+                f"unknown_schema_version:{join_payload.get('join_contract_version')}"
+            )
+    for field in ("session_id", "cycle_id", "instrument_id", "regime_id", "join_digest"):
+        value = join_payload.get(field)
+        if value is None or not str(value).strip():
+            raise MaxAgeResearchExecutionError(f"empty_identity:{field}")
+
+    if join_payload.get("threshold_status") not in (None, "UNRESOLVED_MAX_AGE"):
+        raise MaxAgeResearchExecutionError("resolved_threshold_in_input_forbidden")
+    if join_payload.get("numeric_threshold_selected") is True:
+        raise MaxAgeResearchExecutionError("numeric_threshold_selected_in_input_forbidden")
+    if join_payload.get("enforcement_applied") is True:
+        raise MaxAgeResearchExecutionError("enforcement_applied_in_input_forbidden")
+
+    market_event_time = join_payload.get("reference_event_time")
+    as_of = join_payload.get("estimate_as_of_event_time")
+    age = join_payload.get("computed_age_seconds")
+    if age is not None and (market_event_time is None or as_of is None):
+        raise MaxAgeResearchExecutionError("incomplete_event_time_reference")
+
+    return ResearchEvidenceRecordV1(
+        session_id=str(join_payload["session_id"]),
+        cycle_id=str(join_payload["cycle_id"]),
+        instrument_id=str(join_payload["instrument_id"]),
+        regime_id=str(join_payload["regime_id"]),
+        join_contract_version=str(
+            join_payload.get("join_contract_version") or JOIN_CONTRACT_VERSION
+        ),
+        join_digest=str(join_payload["join_digest"]),
+        volatility_source_digest=(
+            None
+            if join_payload.get("source_digest") is None
+            else str(join_payload.get("source_digest"))
+        ),
+        market_event_time=None if market_event_time is None else str(market_event_time),
+        volatility_as_of_event_time=None if as_of is None else str(as_of),
+        computed_age_seconds=(None if age is None else float(age)),
+        reuse_status=(
+            None if join_payload.get("reuse_status") is None else str(join_payload["reuse_status"])
+        ),
+        restart_status=(
+            None
+            if join_payload.get("restart_status") is None
+            else str(join_payload["restart_status"])
+        ),
+        estimate_present=(
+            None
+            if join_payload.get("estimate_present") is None
+            else bool(join_payload.get("estimate_present"))
+        ),
+        decision_outcome=(
+            None
+            if join_payload.get("decision_outcome") is None
+            else str(join_payload["decision_outcome"])
+        ),
+        selected_side=(
+            None
+            if join_payload.get("selected_side") is None
+            else str(join_payload["selected_side"])
+        ),
+        economic_metrics=(
+            None
+            if join_payload.get("economic_metrics") is None
+            else dict(join_payload.get("economic_metrics") or {})
+        ),
+        event_time_epoch_seconds=_parse_event_time_epoch(market_event_time),
+        raw=dict(join_payload),
+    )
+
+
+def load_research_evidence_records_v1(
+    ledger_path: Path,
+) -> tuple[ResearchEvidenceRecordV1, ...]:
+    if not ledger_path.exists():
+        raise MaxAgeResearchExecutionError(f"missing_join_ledger:{ledger_path}")
+    try:
+        joins = load_max_age_research_evidence_ledger_v1(ledger_path)
+    except MaxAgeResearchDesignContractError as exc:
+        code = str(exc)
+        if "ledger_join_digest_mismatch" in code:
+            raise MaxAgeResearchExecutionError("join_digest_mismatch") from exc
+        if "ledger_duplicate_identity_digest_conflict" in code:
+            raise MaxAgeResearchExecutionError("duplicate_identity_divergent_digest") from exc
+        if "unknown" in code.lower() and "schema" in code.lower():
+            raise MaxAgeResearchExecutionError("unknown_schema_version") from exc
+        if "enforcement" in code:
+            raise MaxAgeResearchExecutionError("enforcement_applied_in_input_forbidden") from exc
+        if "numeric_threshold_selected" in code:
+            raise MaxAgeResearchExecutionError(
+                "numeric_threshold_selected_in_input_forbidden"
+            ) from exc
+        if "threshold" in code:
+            raise MaxAgeResearchExecutionError("resolved_threshold_in_input_forbidden") from exc
+        if "corrupt" in code:
+            raise MaxAgeResearchExecutionError("corrupt_ledger") from exc
+        raise MaxAgeResearchExecutionError(f"missing_join:{code}") from exc
+
+    records = tuple(_map_join_to_record(j.to_dict()) for j in joins)
+    _assert_no_cross_identity_conflicts(records)
+    return records
+
+
+def load_research_evidence_from_payloads_v1(
+    payloads: Sequence[Mapping[str, Any]],
+) -> tuple[ResearchEvidenceRecordV1, ...]:
+    """Test/helper path: validate payloads through the same mapping rules."""
+    records = tuple(_map_join_to_record(dict(p)) for p in payloads)
+    _assert_no_cross_identity_conflicts(records)
+    return records
+
+
+def _assert_no_cross_identity_conflicts(
+    records: Sequence[ResearchEvidenceRecordV1],
+) -> None:
+    by_cycle: dict[str, ResearchEvidenceRecordV1] = {}
+    for record in records:
+        prior = by_cycle.get(record.cycle_id)
+        if prior is None:
+            by_cycle[record.cycle_id] = record
+            continue
+        if prior.session_id != record.session_id:
+            raise MaxAgeResearchExecutionError("cross_session_conflict")
+        if prior.instrument_id != record.instrument_id:
+            raise MaxAgeResearchExecutionError("cross_instrument_conflict")
+        if prior.regime_id != record.regime_id:
+            raise MaxAgeResearchExecutionError("cross_regime_conflict")
+        if prior.join_digest != record.join_digest:
+            raise MaxAgeResearchExecutionError("duplicate_identity_divergent_digest")
+
+
+def assert_restore_does_not_invent_estimate_evidence_v1(
+    *,
+    before: Sequence[ResearchEvidenceRecordV1],
+    after: Sequence[ResearchEvidenceRecordV1],
+) -> None:
+    before_ids = {(r.session_id, r.cycle_id, r.instrument_id, r.join_digest) for r in before}
+    after_ids = {(r.session_id, r.cycle_id, r.instrument_id, r.join_digest) for r in after}
+    invented = after_ids - before_ids
+    if invented:
+        raise MaxAgeResearchExecutionError("restore_invented_estimate_evidence")
+
+
+def coverage_summary_v1(records: Sequence[ResearchEvidenceRecordV1]) -> dict[str, Any]:
+    sessions = {r.session_id for r in records}
+    regimes = {r.regime_id for r in records}
+    instruments = {r.instrument_id for r in records}
+    ages = [r.computed_age_seconds for r in records if r.computed_age_seconds is not None]
+    return {
+        "evidence_count": len(records),
+        "session_count": len(sessions),
+        "regime_count": len(regimes),
+        "instrument_count": len(instruments),
+        "computed_age_observation_count": len(ages),
+        "multi_session_coverage": len(sessions) >= MINIMUM_SESSION_COUNT,
+        "multi_regime_coverage": len(regimes) >= MINIMUM_REGIME_COUNT,
+        "sufficient_for_research": (
+            len(records) >= MINIMUM_EVIDENCE_COUNT
+            and len(sessions) >= MINIMUM_SESSION_COUNT
+            and len(regimes) >= MINIMUM_REGIME_COUNT
+            and len(ages) >= 1
+        ),
+    }
+
+
+def build_input_evidence_manifest_v1(
+    *,
+    repository_sha: str,
+    preregistration_digest: str,
+    execution_id: str,
+    ledger_path: Optional[Path],
+    records: Sequence[ResearchEvidenceRecordV1],
+    created_at_utc: str,
+) -> dict[str, Any]:
+    coverage = coverage_summary_v1(records)
+    record_digests = sorted(r.join_digest for r in records)
+    ledger_sha = None
+    if ledger_path is not None and ledger_path.exists():
+        ledger_sha = sha256_hex_bytes(ledger_path.read_bytes())
+    provisional: dict[str, Any] = {
+        "authority_scope": AUTHORITY_SCOPE,
+        "coverage": coverage,
+        "created_at_utc": created_at_utc,
+        "execution_id": execution_id,
+        "join_contract_version": JOIN_CONTRACT_VERSION,
+        "ledger_path": None if ledger_path is None else str(ledger_path),
+        "ledger_sha256": ledger_sha,
+        "non_authority_scope": NON_AUTHORITY_SCOPE,
+        "preregistration_digest": preregistration_digest,
+        "record_count": len(records),
+        "record_join_digests": record_digests,
+        "repository_sha": repository_sha,
+        "schema_version": INPUT_EVIDENCE_MANIFEST_SCHEMA_VERSION,
+        "synthetic_evidence_invented": False,
+    }
+    provisional["input_evidence_manifest_digest"] = digest_excluding_keys(
+        provisional,
+        exclude={"input_evidence_manifest_digest", "execution_id", "created_at_utc"},
+    )
+    return provisional
+
+
+def empty_input_evidence_manifest_v1(
+    *,
+    repository_sha: str,
+    preregistration_digest: str,
+    execution_id: str,
+    created_at_utc: str,
+    reason: str,
+) -> dict[str, Any]:
+    provisional: dict[str, Any] = {
+        "authority_scope": AUTHORITY_SCOPE,
+        "coverage": {
+            "evidence_count": 0,
+            "session_count": 0,
+            "regime_count": 0,
+            "instrument_count": 0,
+            "computed_age_observation_count": 0,
+            "multi_session_coverage": False,
+            "multi_regime_coverage": False,
+            "sufficient_for_research": False,
+        },
+        "created_at_utc": created_at_utc,
+        "execution_id": execution_id,
+        "insufficient_research_evidence": True,
+        "join_contract_version": JOIN_CONTRACT_VERSION,
+        "ledger_path": None,
+        "ledger_sha256": None,
+        "non_authority_scope": NON_AUTHORITY_SCOPE,
+        "preregistration_digest": preregistration_digest,
+        "reason": reason,
+        "record_count": 0,
+        "record_join_digests": [],
+        "repository_sha": repository_sha,
+        "schema_version": INPUT_EVIDENCE_MANIFEST_SCHEMA_VERSION,
+        "synthetic_evidence_invented": False,
+    }
+    provisional["input_evidence_manifest_digest"] = digest_excluding_keys(
+        provisional,
+        exclude={"input_evidence_manifest_digest", "execution_id", "created_at_utc"},
+    )
+    return provisional
+
+
+def stable_records_fingerprint_v1(records: Sequence[ResearchEvidenceRecordV1]) -> str:
+    material = "|".join(
+        f"{r.session_id}:{r.cycle_id}:{r.instrument_id}:{r.join_digest}" for r in records
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()

--- a/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/robustness_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/robustness_v1.py
@@ -1,0 +1,293 @@
+"""Robustness / uncertainty analyses with time-structure-preserving resampling."""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Optional, Sequence
+
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.constants_v1 import (
+    BASELINE_CANDIDATE_ID,
+    BOOTSTRAP_BLOCK_SECONDS,
+    BOOTSTRAP_REPETITIONS,
+    BOOTSTRAP_SEED,
+    NEIGHBORHOOD_PERTURBATION_FACTORS,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.evaluator_v1 import (
+    evaluate_candidate_on_records_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.evidence_loader_v1 import (
+    ResearchEvidenceRecordV1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.split_engine_v1 import (
+    SplitAssignmentV1,
+    access_final_holdout_v1,
+    build_walk_forward_folds_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.contracts_v1 import (
+    SplitAndEmbargoContractV1,
+)
+
+
+def _coverage(records: Sequence[ResearchEvidenceRecordV1], seconds: Optional[float]) -> float:
+    result = evaluate_candidate_on_records_v1(
+        records,
+        candidate_id="tmp",
+        candidate_max_age_seconds=seconds,
+    )
+    return float(result["decision_coverage"])
+
+
+def walk_forward_matrix_v1(
+    records: Sequence[ResearchEvidenceRecordV1],
+    *,
+    split_contract: SplitAndEmbargoContractV1,
+    candidate_seconds: Sequence[int],
+) -> dict[str, Any]:
+    folds = build_walk_forward_folds_v1(records, split_contract=split_contract)
+    fold_rows: list[dict[str, Any]] = []
+    stabilities: list[float] = []
+    for fold in folds:
+        row: dict[str, Any] = {"fold_id": fold.fold_id, "candidates": {}}
+        coverages: list[float] = []
+        for seconds in candidate_seconds:
+            cov = _coverage(fold.validation, float(seconds))
+            row["candidates"][f"CANDIDATE_{seconds}_S"] = {
+                "validation_decision_coverage": cov,
+                "validation_count": len(fold.validation),
+                "holdout_accessed": fold.holdout_accessed,
+            }
+            coverages.append(cov)
+        if coverages:
+            mean = sum(coverages) / len(coverages)
+            var = sum((c - mean) ** 2 for c in coverages) / len(coverages)
+            stability = var**0.5
+            stabilities.append(stability)
+            row["fold_coverage_stdev"] = stability
+        fold_rows.append(row)
+    overall = sum(stabilities) / len(stabilities) if stabilities else None
+    return {
+        "executed": True,
+        "folds": fold_rows,
+        "walk_forward_stability": overall,
+        "holdout_untouched_during_walk_forward": all(not f.holdout_accessed for f in folds),
+    }
+
+
+def final_holdout_matrix_v1(
+    sealed_split: SplitAssignmentV1,
+    *,
+    candidate_seconds: Sequence[int],
+) -> dict[str, Any]:
+    opened = access_final_holdout_v1(sealed_split)
+    rows: dict[str, Any] = {}
+    baseline = evaluate_candidate_on_records_v1(
+        opened.holdout,
+        candidate_id=BASELINE_CANDIDATE_ID,
+        candidate_max_age_seconds=None,
+    )
+    rows[BASELINE_CANDIDATE_ID] = baseline
+    for seconds in candidate_seconds:
+        rows[f"CANDIDATE_{seconds}_S"] = evaluate_candidate_on_records_v1(
+            opened.holdout,
+            candidate_id=f"CANDIDATE_{seconds}_S",
+            candidate_max_age_seconds=float(seconds),
+        )
+    return {
+        "executed": True,
+        "holdout_accessed": opened.holdout_accessed,
+        "holdout_count": len(opened.holdout),
+        "results": rows,
+    }
+
+
+def regime_session_matrices_v1(
+    records: Sequence[ResearchEvidenceRecordV1],
+    *,
+    candidate_seconds: Sequence[int],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    by_regime: dict[str, list[ResearchEvidenceRecordV1]] = {}
+    by_session: dict[str, list[ResearchEvidenceRecordV1]] = {}
+    for record in records:
+        by_regime.setdefault(record.regime_id, []).append(record)
+        by_session.setdefault(record.session_id, []).append(record)
+
+    def _slice_matrix(groups: dict[str, list[ResearchEvidenceRecordV1]]) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for key, rows in sorted(groups.items()):
+            out[key] = {
+                BASELINE_CANDIDATE_ID: evaluate_candidate_on_records_v1(
+                    rows,
+                    candidate_id=BASELINE_CANDIDATE_ID,
+                    candidate_max_age_seconds=None,
+                ),
+            }
+            for seconds in candidate_seconds:
+                out[key][f"CANDIDATE_{seconds}_S"] = evaluate_candidate_on_records_v1(
+                    rows,
+                    candidate_id=f"CANDIDATE_{seconds}_S",
+                    candidate_max_age_seconds=float(seconds),
+                )
+        return {"executed": True, "slices": out}
+
+    return _slice_matrix(by_regime), _slice_matrix(by_session)
+
+
+def neighborhood_perturbation_v1(
+    records: Sequence[ResearchEvidenceRecordV1],
+    *,
+    candidate_seconds: Sequence[int],
+) -> dict[str, Any]:
+    rows: dict[str, Any] = {}
+    for seconds in candidate_seconds:
+        base = _coverage(records, float(seconds))
+        perturbed = []
+        for factor in NEIGHBORHOOD_PERTURBATION_FACTORS:
+            perturbed.append(_coverage(records, float(seconds) * float(factor)))
+        sensitivity = max(abs(p - base) for p in perturbed) if perturbed else 0.0
+        rows[f"CANDIDATE_{seconds}_S"] = {
+            "base_coverage": base,
+            "perturbed_coverages": perturbed,
+            "neighborhood_sensitivity": sensitivity,
+            "factors": list(NEIGHBORHOOD_PERTURBATION_FACTORS),
+        }
+    return {"executed": True, "results": rows}
+
+
+def _event_time_blocks(
+    records: Sequence[ResearchEvidenceRecordV1],
+    *,
+    block_seconds: int,
+) -> list[list[ResearchEvidenceRecordV1]]:
+    ordered = sorted(
+        records,
+        key=lambda r: (float(r.event_time_epoch_seconds or 0.0), r.cycle_id),
+    )
+    if not ordered:
+        return []
+    blocks: list[list[ResearchEvidenceRecordV1]] = []
+    current: list[ResearchEvidenceRecordV1] = []
+    block_start = float(ordered[0].event_time_epoch_seconds or 0.0)
+    for record in ordered:
+        ts = float(record.event_time_epoch_seconds or 0.0)
+        if current and (ts - block_start) >= float(block_seconds):
+            blocks.append(current)
+            current = [record]
+            block_start = ts
+        else:
+            current.append(record)
+    if current:
+        blocks.append(current)
+    return blocks
+
+
+def block_bootstrap_confidence_v1(
+    records: Sequence[ResearchEvidenceRecordV1],
+    *,
+    candidate_seconds: Sequence[int],
+    repetitions: int = BOOTSTRAP_REPETITIONS,
+    block_seconds: int = BOOTSTRAP_BLOCK_SECONDS,
+    seed: int = BOOTSTRAP_SEED,
+) -> dict[str, Any]:
+    blocks = _event_time_blocks(records, block_seconds=block_seconds)
+    if not blocks:
+        return {
+            "executed": False,
+            "reason": "no_blocks",
+            "method": "BLOCK_BOOTSTRAP_EVENT_TIME_PRESERVING",
+            "seed": seed,
+            "repetitions": repetitions,
+        }
+    rng = random.Random(seed)
+    out: dict[str, Any] = {}
+    for seconds in candidate_seconds:
+        samples: list[float] = []
+        for _ in range(repetitions):
+            drawn: list[ResearchEvidenceRecordV1] = []
+            for _b in range(len(blocks)):
+                drawn.extend(rng.choice(blocks))
+            samples.append(_coverage(drawn, float(seconds)))
+        samples_sorted = sorted(samples)
+        lo = samples_sorted[int(0.025 * (len(samples_sorted) - 1))]
+        hi = samples_sorted[int(0.975 * (len(samples_sorted) - 1))]
+        out[f"CANDIDATE_{seconds}_S"] = {
+            "mean_coverage": sum(samples) / len(samples),
+            "ci95_low": lo,
+            "ci95_high": hi,
+            "n": len(samples),
+        }
+    return {
+        "executed": True,
+        "method": "BLOCK_BOOTSTRAP_EVENT_TIME_PRESERVING",
+        "seed": seed,
+        "repetitions": repetitions,
+        "block_seconds": block_seconds,
+        "limitations": [
+            "TEMPORAL_DEPENDENCE_PRESERVED_VIA_BLOCKS",
+            "NOT_IID_RESAMPLE",
+        ],
+        "results": out,
+    }
+
+
+def stress_matrices_v1(
+    records: Sequence[ResearchEvidenceRecordV1],
+    *,
+    candidate_seconds: Sequence[int],
+) -> dict[str, Any]:
+    if not records:
+        return {"executed": False, "reason": "no_records"}
+
+    missing = [r for r in records if r.estimate_present is not False][: max(1, len(records) // 2)]
+    duplicates = list(records) + list(records[: max(1, len(records) // 4)])
+    out_of_order = list(reversed(records))
+    stale_heavy = [
+        r
+        for r in records
+        if r.computed_age_seconds is not None and float(r.computed_age_seconds) >= 300.0
+    ] or list(records)
+
+    def _pack(label: str, rows: Sequence[ResearchEvidenceRecordV1]) -> dict[str, Any]:
+        return {
+            label: {
+                f"CANDIDATE_{seconds}_S": evaluate_candidate_on_records_v1(
+                    rows,
+                    candidate_id=f"CANDIDATE_{seconds}_S",
+                    candidate_max_age_seconds=float(seconds),
+                )
+                for seconds in candidate_seconds
+            }
+        }
+
+    return {
+        "executed": True,
+        "missing_sample_stress": _pack("subset", missing),
+        "duplicate_sample_stress": _pack("with_duplicates", duplicates),
+        "out_of_order_stress": _pack("reversed_event_order_diagnostic", out_of_order),
+        "stale_data_stress": _pack("stale_heavy", stale_heavy),
+        "note": "Stress views are diagnostic only; out-of-order does not authorize shuffled splits.",
+    }
+
+
+def monte_carlo_applicability_v1(
+    records: Sequence[ResearchEvidenceRecordV1],
+) -> dict[str, Any]:
+    has_fill_sequence = any(
+        r.economic_metrics is not None
+        and isinstance(r.economic_metrics, dict)
+        and r.economic_metrics.get("fill_sequence")
+        for r in records
+    )
+    if not has_fill_sequence:
+        return {
+            "executed": False,
+            "monte_carlo_not_applicable_reason": (
+                "NO_REAL_FILL_SEQUENCE_IN_JOINABLE_ECONOMIC_EVIDENCE"
+            ),
+        }
+    return {
+        "executed": False,
+        "monte_carlo_not_applicable_reason": (
+            "FILL_SEQUENCE_PRESENT_BUT_TRADE_SEQUENCE_MONTE_CARLO_NOT_WIRED_IN_V1;"
+            "FAIL_CLOSED_NO_IID_FALLBACK"
+        ),
+    }

--- a/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/runner_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/runner_v1.py
@@ -1,0 +1,593 @@
+"""Deterministic research execution runner and artifact writer."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.architecture_guards_v1 import (
+    assert_architecture_guards_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.constants_v1 import (
+    AUTHORITY_SCOPE,
+    BASELINE_CANDIDATE_ID,
+    CAPABILITY_ID,
+    CONCLUSION_SCHEMA_VERSION,
+    DEFAULT_INPUT_LEDGER_RELATIVE_PATH,
+    DEFAULT_OUTPUT_EVIDENCE_RELATIVE_ROOT,
+    EXPECTED_PREREGISTRATION_DIGEST,
+    HARD_STOP,
+    INTEGRITY_SCHEMA_VERSION,
+    NON_AUTHORITY_SCOPE,
+    NUMERIC_THRESHOLD_SELECTED,
+    PARAMETER_PROMOTED,
+    RESEARCH_CONCLUSION_INSUFFICIENT,
+    RESEARCH_CONCLUSION_NO_ROBUST,
+    RESEARCH_CONCLUSION_REGION_PENDING,
+    THRESHOLD_STATUS,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.contracts_v1 import (
+    MaxAgeResearchExecutionError,
+    assert_candidate_domain_immutable_v1,
+    assert_candidates_not_config_authority_v1,
+    bind_candidate_domain_v1,
+    bind_hypothesis_contract_v1,
+    bind_robustness_execution_contract_v1,
+    bind_split_and_embargo_contract_v1,
+    build_research_execution_manifest_shell_v1,
+    verify_preregistration_digest_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.evaluator_v1 import (
+    apply_rejection_criteria_v1,
+    evaluate_all_candidates_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.evidence_loader_v1 import (
+    ResearchEvidenceRecordV1,
+    assert_restore_does_not_invent_estimate_evidence_v1,
+    build_input_evidence_manifest_v1,
+    coverage_summary_v1,
+    empty_input_evidence_manifest_v1,
+    load_research_evidence_from_payloads_v1,
+    load_research_evidence_records_v1,
+    stable_records_fingerprint_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.robustness_v1 import (
+    block_bootstrap_confidence_v1,
+    final_holdout_matrix_v1,
+    monte_carlo_applicability_v1,
+    neighborhood_perturbation_v1,
+    regime_session_matrices_v1,
+    stress_matrices_v1,
+    walk_forward_matrix_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.serialization_v1 import (
+    build_execution_id_v1,
+    canonical_json_dumps,
+    digest_excluding_keys,
+    sha256_hex,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.split_engine_v1 import (
+    build_purged_chronological_splits_v1,
+)
+from trading.master_v2.canonical_volatility_numeric_max_age_parameter_research_design_and_evidence_accumulation_contract_v1 import (
+    build_ratified_max_age_research_design_contract_v1,
+)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = canonical_json_dumps(dict(payload))
+    path.write_text(text + "\n", encoding="utf-8")
+    return sha256_hex(dict(payload))
+
+
+def _write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [canonical_json_dumps(dict(row)) for row in rows]
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return sha256_hex({"rows": list(rows)})
+
+
+def resolve_repository_sha_v1(repo_root: Path, *, repository_sha: Optional[str] = None) -> str:
+    if repository_sha:
+        return repository_sha
+    head = repo_root / ".git" / "HEAD"
+    if not head.exists():
+        raise MaxAgeResearchExecutionError("repository_sha_unavailable")
+    # Prefer explicit caller/git SHA; fallback is non-authoritative for formal runs.
+    import subprocess
+
+    proc = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(repo_root),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise MaxAgeResearchExecutionError("repository_sha_unavailable")
+    return proc.stdout.strip()
+
+
+def run_max_age_parameter_research_execution_v1(
+    *,
+    repo_root: Path,
+    ledger_path: Optional[Path] = None,
+    output_root: Optional[Path] = None,
+    repository_sha: Optional[str] = None,
+    records: Optional[Sequence[ResearchEvidenceRecordV1]] = None,
+    created_at_utc: Optional[str] = None,
+) -> dict[str, Any]:
+    """Execute non-enforcing max-age parameter research and write evidence artifacts."""
+    assert_architecture_guards_v1(repo_root=repo_root)
+    created = created_at_utc or _utc_now_iso()
+    sha = resolve_repository_sha_v1(repo_root, repository_sha=repository_sha)
+
+    design = build_ratified_max_age_research_design_contract_v1()
+    prereg_digest = design.preregistration_digest
+    verify_preregistration_digest_v1(prereg_digest)
+
+    # Placeholder execution id for pre-bind artifacts; replaced after digest chain.
+    provisional_execution_id = "provisional_pending_digest_chain"
+    candidate_domain = bind_candidate_domain_v1(
+        repository_sha=sha,
+        preregistration_digest=prereg_digest,
+        execution_id=provisional_execution_id,
+        created_at_utc=created,
+    )
+    assert_candidates_not_config_authority_v1(candidate_domain.to_dict())
+    assert_candidate_domain_immutable_v1(
+        candidate_domain,
+        attempted_candidates=candidate_domain.candidate_max_age_seconds,
+    )
+    hypothesis = bind_hypothesis_contract_v1(
+        repository_sha=sha,
+        preregistration_digest=prereg_digest,
+        execution_id=provisional_execution_id,
+        created_at_utc=created,
+    )
+    split_contract = bind_split_and_embargo_contract_v1(
+        repository_sha=sha,
+        preregistration_digest=prereg_digest,
+        execution_id=provisional_execution_id,
+        created_at_utc=created,
+    )
+    robustness_contract = bind_robustness_execution_contract_v1(
+        repository_sha=sha,
+        preregistration_digest=prereg_digest,
+        execution_id=provisional_execution_id,
+        created_at_utc=created,
+    )
+
+    input_valid = True
+    insufficient = False
+    load_error: Optional[str] = None
+    loaded_records: tuple[ResearchEvidenceRecordV1, ...] = ()
+
+    if records is not None:
+        loaded_records = tuple(records)
+        input_manifest = build_input_evidence_manifest_v1(
+            repository_sha=sha,
+            preregistration_digest=prereg_digest,
+            execution_id=provisional_execution_id,
+            ledger_path=ledger_path,
+            records=loaded_records,
+            created_at_utc=created,
+        )
+    else:
+        resolved_ledger = ledger_path or (repo_root / DEFAULT_INPUT_LEDGER_RELATIVE_PATH)
+        try:
+            loaded_records = load_research_evidence_records_v1(resolved_ledger)
+            input_manifest = build_input_evidence_manifest_v1(
+                repository_sha=sha,
+                preregistration_digest=prereg_digest,
+                execution_id=provisional_execution_id,
+                ledger_path=resolved_ledger,
+                records=loaded_records,
+                created_at_utc=created,
+            )
+        except MaxAgeResearchExecutionError as exc:
+            input_valid = False
+            insufficient = True
+            load_error = str(exc)
+            input_manifest = empty_input_evidence_manifest_v1(
+                repository_sha=sha,
+                preregistration_digest=prereg_digest,
+                execution_id=provisional_execution_id,
+                created_at_utc=created,
+                reason=load_error,
+            )
+
+    coverage = coverage_summary_v1(loaded_records)
+    if not coverage.get("sufficient_for_research"):
+        insufficient = True
+
+    execution_id = build_execution_id_v1(
+        repository_sha=sha,
+        preregistration_digest=prereg_digest,
+        candidate_domain_digest=candidate_domain.domain_digest,
+        hypothesis_contract_digest=hypothesis.hypothesis_digest,
+        split_contract_digest=split_contract.split_digest,
+        robustness_contract_digest=robustness_contract.robustness_digest,
+        input_evidence_manifest_digest=str(input_manifest["input_evidence_manifest_digest"]),
+    )
+
+    # Re-bind contracts with final execution_id (digests of body exclude execution_id?
+    # Execution id is IN the body, so rebinding changes digests. Keep provisional digests
+    # as identity inputs and stamp final execution_id on output copies.)
+    candidate_domain_out = dict(candidate_domain.to_dict())
+    candidate_domain_out["execution_id"] = execution_id
+    hypothesis_out = dict(hypothesis.to_dict())
+    hypothesis_out["execution_id"] = execution_id
+    split_out = dict(split_contract.to_dict())
+    split_out["execution_id"] = execution_id
+    robustness_out = dict(robustness_contract.to_dict())
+    robustness_out["execution_id"] = execution_id
+    input_manifest_out = dict(input_manifest)
+    input_manifest_out["execution_id"] = execution_id
+
+    out_root = output_root or (repo_root / DEFAULT_OUTPUT_EVIDENCE_RELATIVE_ROOT / execution_id)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    artifact_digests: dict[str, str] = {}
+    artifact_digests["candidate_domain.json"] = _write_json(
+        out_root / "candidate_domain.json", candidate_domain_out
+    )
+    artifact_digests["hypothesis_contract.json"] = _write_json(
+        out_root / "hypothesis_contract.json", hypothesis_out
+    )
+    artifact_digests["split_and_embargo_contract.json"] = _write_json(
+        out_root / "split_and_embargo_contract.json", split_out
+    )
+    artifact_digests["robustness_execution_contract.json"] = _write_json(
+        out_root / "robustness_execution_contract.json", robustness_out
+    )
+    artifact_digests["input_evidence_manifest.json"] = _write_json(
+        out_root / "input_evidence_manifest.json", input_manifest_out
+    )
+
+    status = "BLOCKED" if insufficient or not input_valid else "PASS"
+    candidate_results: list[dict[str, Any]] = []
+    walk_forward: dict[str, Any] = {"executed": False}
+    holdout: dict[str, Any] = {"executed": False}
+    regime_results: dict[str, Any] = {"executed": False}
+    session_results: dict[str, Any] = {"executed": False}
+    robustness_results: dict[str, Any] = {"executed": False}
+    rejection_rows: list[dict[str, Any]] = []
+    research_conclusion = RESEARCH_CONCLUSION_INSUFFICIENT
+    robust_region: Optional[list[int]] = None
+    deterministic_reexec_pass = False
+    ledger_resume_pass = False
+    monte_carlo = {"executed": False, "monte_carlo_not_applicable_reason": "NOT_RUN"}
+
+    if not insufficient and loaded_records:
+        # Ledger reload / resume equivalence
+        if ledger_path is not None and Path(ledger_path).exists():
+            reloaded = load_research_evidence_records_v1(Path(ledger_path))
+            assert_restore_does_not_invent_estimate_evidence_v1(
+                before=loaded_records, after=reloaded
+            )
+            ledger_resume_pass = stable_records_fingerprint_v1(
+                loaded_records
+            ) == stable_records_fingerprint_v1(reloaded)
+        else:
+            # In-memory path: reload via payloads must be identical.
+            payloads = [r.raw for r in loaded_records]
+            reloaded = load_research_evidence_from_payloads_v1(payloads)
+            assert_restore_does_not_invent_estimate_evidence_v1(
+                before=loaded_records, after=reloaded
+            )
+            ledger_resume_pass = stable_records_fingerprint_v1(
+                loaded_records
+            ) == stable_records_fingerprint_v1(reloaded)
+
+        sealed = build_purged_chronological_splits_v1(
+            loaded_records,
+            split_contract=split_contract,
+            access_holdout=False,
+        )
+        researchable = sealed.train + sealed.validation
+        candidate_results = evaluate_all_candidates_v1(
+            researchable,
+            candidate_max_age_seconds=candidate_domain.candidate_max_age_seconds,
+        )
+        # Deterministic re-execution check
+        candidate_results_2 = evaluate_all_candidates_v1(
+            researchable,
+            candidate_max_age_seconds=candidate_domain.candidate_max_age_seconds,
+        )
+        deterministic_reexec_pass = candidate_results == candidate_results_2
+
+        walk_forward = walk_forward_matrix_v1(
+            loaded_records,
+            split_contract=split_contract,
+            candidate_seconds=candidate_domain.candidate_max_age_seconds,
+        )
+        holdout = final_holdout_matrix_v1(
+            sealed,
+            candidate_seconds=candidate_domain.candidate_max_age_seconds,
+        )
+        regime_results, session_results = regime_session_matrices_v1(
+            researchable,
+            candidate_seconds=candidate_domain.candidate_max_age_seconds,
+        )
+        neighborhood = neighborhood_perturbation_v1(
+            researchable,
+            candidate_seconds=candidate_domain.candidate_max_age_seconds,
+        )
+        bootstrap = block_bootstrap_confidence_v1(
+            researchable,
+            candidate_seconds=candidate_domain.candidate_max_age_seconds,
+            repetitions=robustness_contract.bootstrap_repetitions,
+            block_seconds=robustness_contract.bootstrap_block_seconds,
+            seed=robustness_contract.bootstrap_seed,
+        )
+        stresses = stress_matrices_v1(
+            researchable,
+            candidate_seconds=candidate_domain.candidate_max_age_seconds,
+        )
+        monte_carlo = monte_carlo_applicability_v1(loaded_records)
+        robustness_results = {
+            "executed": True,
+            "neighborhood_perturbation": neighborhood,
+            "block_bootstrap": bootstrap,
+            "stress": stresses,
+            "monte_carlo": monte_carlo,
+            "restart_resume_consistency": {
+                "executed": True,
+                "ledger_resume_equivalence_pass": ledger_resume_pass,
+            },
+            "ledger_reload_consistency": {
+                "executed": True,
+                "pass": ledger_resume_pass,
+            },
+        }
+
+        baseline = next(r for r in candidate_results if r["candidate_id"] == BASELINE_CANDIDATE_ID)
+        wf_stability = walk_forward.get("walk_forward_stability")
+        accepted_region: list[int] = []
+        for result in candidate_results:
+            if result["candidate_id"] == BASELINE_CANDIDATE_ID:
+                continue
+            seconds = int(result["candidate_max_age_seconds_argument"])
+            cand_id = result["candidate_id"]
+            neigh = neighborhood.get("results", {}).get(cand_id, {}).get("neighborhood_sensitivity")
+            holdout_row = holdout.get("results", {}).get(cand_id, {})
+            baseline_holdout = holdout.get("results", {}).get(BASELINE_CANDIDATE_ID, {})
+            holdout_degraded = False
+            if holdout_row and baseline_holdout:
+                holdout_degraded = float(holdout_row.get("decision_coverage") or 0.0) < (
+                    float(baseline_holdout.get("decision_coverage") or 0.0) - 0.25
+                )
+            regime_slices = regime_results.get("slices", {})
+            session_slices = session_results.get("slices", {})
+            single_regime = len(regime_slices) <= 1
+            single_session = len(session_slices) <= 1
+            rejection = apply_rejection_criteria_v1(
+                result,
+                baseline_result=baseline,
+                walk_forward_stability=(None if wf_stability is None else float(wf_stability)),
+                neighborhood_sensitivity=None if neigh is None else float(neigh),
+                holdout_degraded=holdout_degraded,
+                single_session_only=single_session,
+                single_regime_only=single_regime,
+                leakage_or_digest_violation=False,
+                restart_ledger_nondeterminism=not ledger_resume_pass,
+            )
+            rejection_rows.append(rejection)
+            result["threshold_boundary_sensitivity"] = neigh
+            result["walk_forward_stability"] = wf_stability
+            result["final_holdout_result"] = {
+                "decision_coverage": holdout_row.get("decision_coverage"),
+                "evidence_count": holdout_row.get("evidence_count"),
+            }
+            result["parameter_stability"] = {
+                "rejected": rejection["rejected"],
+                "rejection_reasons": rejection["rejection_reasons"],
+            }
+            if not rejection["rejected"]:
+                # Region membership requires non-worse stale exposure vs very open thresholds
+                # without catastrophic coverage loss — still not a selection.
+                if float(result.get("stale_rejection_rate") or 0.0) > 0.0:
+                    accepted_region.append(seconds)
+
+        # Contiguous robust region only; never promote a point threshold.
+        if accepted_region:
+            accepted_region = sorted(set(accepted_region))
+            # Keep only contiguous runs; pick longest contiguous block as non-binding region.
+            runs: list[list[int]] = []
+            current: list[int] = []
+            cand_set = list(candidate_domain.candidate_max_age_seconds)
+            for value in cand_set:
+                if value in accepted_region:
+                    current.append(value)
+                elif current:
+                    runs.append(current)
+                    current = []
+            if current:
+                runs.append(current)
+            if runs:
+                robust_region = max(runs, key=len)
+                research_conclusion = RESEARCH_CONCLUSION_REGION_PENDING
+            else:
+                research_conclusion = RESEARCH_CONCLUSION_NO_ROBUST
+        else:
+            research_conclusion = RESEARCH_CONCLUSION_NO_ROBUST
+            robust_region = None
+    else:
+        research_conclusion = RESEARCH_CONCLUSION_INSUFFICIENT
+        status = "BLOCKED"
+
+    conclusion = {
+        "schema_version": CONCLUSION_SCHEMA_VERSION,
+        "repository_sha": sha,
+        "preregistration_digest": prereg_digest,
+        "execution_id": execution_id,
+        "created_at_utc": created,
+        "authority_scope": AUTHORITY_SCOPE,
+        "non_authority_scope": NON_AUTHORITY_SCOPE,
+        "status": status,
+        "research_conclusion": research_conclusion,
+        "robust_candidate_region_identified": bool(robust_region),
+        "robust_candidate_region": robust_region,
+        "no_robust_numeric_max_age_established": research_conclusion
+        in {RESEARCH_CONCLUSION_NO_ROBUST, RESEARCH_CONCLUSION_INSUFFICIENT},
+        "insufficient_research_evidence": insufficient,
+        "input_evidence_valid": input_valid,
+        "load_error": load_error,
+        "threshold_status": THRESHOLD_STATUS,
+        "numeric_max_age_decided": False,
+        "numeric_threshold_selected": NUMERIC_THRESHOLD_SELECTED,
+        "parameter_promoted": PARAMETER_PROMOTED,
+        "enforcement_applied": False,
+        "alpha_mutation_occurred": False,
+        "recommended_single_threshold": None,
+        "hard_stop": HARD_STOP,
+        "rejection_matrix": rejection_rows,
+    }
+    # Hard guarantee: conclusion cannot promote a threshold.
+    if conclusion["numeric_threshold_selected"] or conclusion["parameter_promoted"]:
+        raise MaxAgeResearchExecutionError("research_conclusion_must_not_promote_threshold")
+    if conclusion.get("recommended_single_threshold") is not None:
+        raise MaxAgeResearchExecutionError("research_conclusion_must_not_select_threshold")
+    conclusion["conclusion_digest"] = digest_excluding_keys(
+        conclusion, exclude={"conclusion_digest"}
+    )
+
+    artifact_digests["candidate_results.jsonl"] = _write_jsonl(
+        out_root / "candidate_results.jsonl", candidate_results
+    )
+    artifact_digests["walk_forward_results.json"] = _write_json(
+        out_root / "walk_forward_results.json", walk_forward
+    )
+    artifact_digests["holdout_results.json"] = _write_json(
+        out_root / "holdout_results.json", holdout
+    )
+    artifact_digests["regime_results.json"] = _write_json(
+        out_root / "regime_results.json", regime_results
+    )
+    artifact_digests["session_results.json"] = _write_json(
+        out_root / "session_results.json", session_results
+    )
+    artifact_digests["robustness_results.json"] = _write_json(
+        out_root / "robustness_results.json", robustness_results
+    )
+    artifact_digests["research_conclusion.json"] = _write_json(
+        out_root / "research_conclusion.json", conclusion
+    )
+
+    manifest = build_research_execution_manifest_shell_v1(
+        repository_sha=sha,
+        preregistration_digest=prereg_digest,
+        execution_id=execution_id,
+        candidate_domain_digest=candidate_domain.domain_digest,
+        hypothesis_contract_digest=hypothesis.hypothesis_digest,
+        split_contract_digest=split_contract.split_digest,
+        robustness_contract_digest=robustness_contract.robustness_digest,
+        input_evidence_manifest_digest=str(input_manifest["input_evidence_manifest_digest"]),
+        created_at_utc=created,
+    )
+    manifest["status"] = status
+    manifest["research_conclusion"] = research_conclusion
+    manifest["output_evidence_path"] = str(out_root)
+    manifest["artifact_relative_paths"] = sorted(artifact_digests.keys()) + [
+        "research_execution_manifest.json",
+        "integrity_manifest.json",
+    ]
+    manifest["manifest_digest"] = digest_excluding_keys(manifest, exclude={"manifest_digest"})
+    artifact_digests["research_execution_manifest.json"] = _write_json(
+        out_root / "research_execution_manifest.json", manifest
+    )
+
+    integrity = {
+        "schema_version": INTEGRITY_SCHEMA_VERSION,
+        "repository_sha": sha,
+        "preregistration_digest": prereg_digest,
+        "execution_id": execution_id,
+        "created_at_utc": created,
+        "authority_scope": AUTHORITY_SCOPE,
+        "non_authority_scope": NON_AUTHORITY_SCOPE,
+        "artifacts": [
+            {
+                "relative_path": name,
+                "sha256": digest,
+                "schema_version_hint": CAPABILITY_ID,
+                "execution_id": execution_id,
+                "repository_sha": sha,
+                "preregistration_digest": prereg_digest,
+            }
+            for name, digest in sorted(artifact_digests.items())
+        ],
+        "deterministic_reexecution_pass": deterministic_reexec_pass,
+        "ledger_resume_equivalence_pass": ledger_resume_pass,
+        "expected_preregistration_digest": EXPECTED_PREREGISTRATION_DIGEST,
+        "preregistration_digest_match": prereg_digest == EXPECTED_PREREGISTRATION_DIGEST,
+    }
+    integrity["integrity_digest"] = digest_excluding_keys(integrity, exclude={"integrity_digest"})
+    artifact_digests["integrity_manifest.json"] = _write_json(
+        out_root / "integrity_manifest.json", integrity
+    )
+    # Rewrite integrity with self-inclusion of final digest map.
+    integrity["artifacts"] = [
+        {
+            "relative_path": name,
+            "sha256": digest,
+            "schema_version_hint": CAPABILITY_ID,
+            "execution_id": execution_id,
+            "repository_sha": sha,
+            "preregistration_digest": prereg_digest,
+        }
+        for name, digest in sorted(artifact_digests.items())
+    ]
+    integrity["integrity_digest"] = digest_excluding_keys(integrity, exclude={"integrity_digest"})
+    _write_json(out_root / "integrity_manifest.json", integrity)
+
+    return {
+        "status": status,
+        "execution_id": execution_id,
+        "repository_sha": sha,
+        "preregistration_digest": prereg_digest,
+        "preregistration_digest_match": prereg_digest == EXPECTED_PREREGISTRATION_DIGEST,
+        "candidate_domain_digest": candidate_domain.domain_digest,
+        "hypothesis_contract_digest": hypothesis.hypothesis_digest,
+        "split_contract_digest": split_contract.split_digest,
+        "robustness_contract_digest": robustness_contract.robustness_digest,
+        "input_evidence_manifest_digest": input_manifest["input_evidence_manifest_digest"],
+        "output_evidence_path": str(out_root),
+        "coverage": coverage,
+        "input_evidence_valid": input_valid,
+        "insufficient_research_evidence": insufficient,
+        "research_conclusion": research_conclusion,
+        "robust_candidate_region": robust_region,
+        "walk_forward_executed": bool(walk_forward.get("executed")),
+        "final_holdout_executed": bool(holdout.get("executed")),
+        "regime_slices_executed": bool(regime_results.get("executed")),
+        "session_slices_executed": bool(session_results.get("executed")),
+        "parameter_perturbation_executed": bool(
+            robustness_results.get("neighborhood_perturbation", {}).get("executed")
+        ),
+        "bootstrap_executed": bool(robustness_results.get("block_bootstrap", {}).get("executed")),
+        "monte_carlo_executed": bool(monte_carlo.get("executed")),
+        "monte_carlo_not_applicable_reason": monte_carlo.get("monte_carlo_not_applicable_reason"),
+        "deterministic_reexecution_pass": deterministic_reexec_pass,
+        "ledger_resume_equivalence_pass": ledger_resume_pass,
+        "artifact_digests": artifact_digests,
+        "numeric_threshold_selected": False,
+        "parameter_promoted": False,
+        "enforcement_applied": False,
+        "threshold_status": THRESHOLD_STATUS,
+        "hard_stop": HARD_STOP,
+        "candidate_results": candidate_results,
+        "rejection_matrix": rejection_rows,
+        "conclusion": conclusion,
+    }
+
+
+def dumps_summary_v1(result: Mapping[str, Any]) -> str:
+    return json.dumps(dict(result), sort_keys=True, indent=2, default=str)

--- a/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/serialization_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/serialization_v1.py
@@ -1,0 +1,57 @@
+"""Canonical serialization, digests, and deterministic execution identity."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+
+def canonical_json_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    ).encode("utf-8")
+
+
+def canonical_json_dumps(payload: Mapping[str, Any]) -> str:
+    return canonical_json_bytes(payload).decode("utf-8")
+
+
+def sha256_hex(payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+
+
+def sha256_hex_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def digest_excluding_keys(payload: Mapping[str, Any], *, exclude: set[str]) -> str:
+    body = {k: v for k, v in payload.items() if k not in exclude}
+    return sha256_hex(body)
+
+
+def build_execution_id_v1(
+    *,
+    repository_sha: str,
+    preregistration_digest: str,
+    candidate_domain_digest: str,
+    hypothesis_contract_digest: str,
+    split_contract_digest: str,
+    robustness_contract_digest: str,
+    input_evidence_manifest_digest: str,
+) -> str:
+    """Deterministic execution identity — no random / wallclock component."""
+    material = {
+        "candidate_domain_digest": candidate_domain_digest,
+        "hypothesis_contract_digest": hypothesis_contract_digest,
+        "input_evidence_manifest_digest": input_evidence_manifest_digest,
+        "preregistration_digest": preregistration_digest,
+        "repository_sha": repository_sha,
+        "robustness_contract_digest": robustness_contract_digest,
+        "split_contract_digest": split_contract_digest,
+    }
+    return "maxage_research_exec_" + sha256_hex(material)[:32]

--- a/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/split_engine_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_parameter_research_execution_v1/split_engine_v1.py
@@ -1,0 +1,256 @@
+"""Purged chronological splits with event-time embargo and sealed holdout."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.contracts_v1 import (
+    MaxAgeResearchExecutionError,
+    SplitAndEmbargoContractV1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.evidence_loader_v1 import (
+    ResearchEvidenceRecordV1,
+)
+
+
+@dataclass(frozen=True)
+class SplitAssignmentV1:
+    train: tuple[ResearchEvidenceRecordV1, ...]
+    validation: tuple[ResearchEvidenceRecordV1, ...]
+    holdout: tuple[ResearchEvidenceRecordV1, ...]
+    embargo_seconds: int
+    holdout_accessed: bool
+    fold_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "embargo_seconds": self.embargo_seconds,
+            "fold_id": self.fold_id,
+            "holdout_accessed": self.holdout_accessed,
+            "holdout_count": len(self.holdout),
+            "train_count": len(self.train),
+            "validation_count": len(self.validation),
+        }
+
+
+def _require_event_times(
+    records: Sequence[ResearchEvidenceRecordV1],
+) -> list[ResearchEvidenceRecordV1]:
+    ordered: list[ResearchEvidenceRecordV1] = []
+    for record in records:
+        if record.event_time_epoch_seconds is None:
+            raise MaxAgeResearchExecutionError("incomplete_event_time_reference")
+        ordered.append(record)
+    ordered.sort(key=lambda r: (float(r.event_time_epoch_seconds), r.cycle_id, r.join_digest))
+    return ordered
+
+
+def _purge_with_embargo(
+    left: Sequence[ResearchEvidenceRecordV1],
+    right: Sequence[ResearchEvidenceRecordV1],
+    *,
+    embargo_seconds: int,
+) -> tuple[tuple[ResearchEvidenceRecordV1, ...], tuple[ResearchEvidenceRecordV1, ...]]:
+    if not left or not right:
+        return tuple(left), tuple(right)
+    left_max = max(float(r.event_time_epoch_seconds or 0.0) for r in left)
+    right_min = min(float(r.event_time_epoch_seconds or 0.0) for r in right)
+    # Purge overlapping windows within embargo of the boundary.
+    purged_left = tuple(
+        r
+        for r in left
+        if float(r.event_time_epoch_seconds or 0.0) <= (right_min - float(embargo_seconds))
+    )
+    purged_right = tuple(
+        r
+        for r in right
+        if float(r.event_time_epoch_seconds or 0.0) >= (left_max + float(embargo_seconds))
+        or float(r.event_time_epoch_seconds or 0.0) >= right_min
+    )
+    # Keep right side chronologically after left + embargo when both nonempty.
+    if purged_left and purged_right:
+        boundary = max(float(r.event_time_epoch_seconds or 0.0) for r in purged_left)
+        purged_right = tuple(
+            r
+            for r in purged_right
+            if float(r.event_time_epoch_seconds or 0.0) >= boundary + float(embargo_seconds)
+        )
+    return purged_left, purged_right
+
+
+def build_purged_chronological_splits_v1(
+    records: Sequence[ResearchEvidenceRecordV1],
+    *,
+    split_contract: SplitAndEmbargoContractV1,
+    access_holdout: bool = False,
+) -> SplitAssignmentV1:
+    ordered = _require_event_times(records)
+    n = len(ordered)
+    if n == 0:
+        return SplitAssignmentV1(
+            train=(),
+            validation=(),
+            holdout=(),
+            embargo_seconds=split_contract.embargo_seconds,
+            holdout_accessed=False,
+            fold_id="empty",
+        )
+
+    holdout_n = max(1, int(round(n * split_contract.holdout_fraction))) if n >= 5 else 0
+    if holdout_n >= n:
+        holdout_n = max(0, n // 5)
+    non_holdout = ordered[: n - holdout_n] if holdout_n else ordered
+    holdout = tuple(ordered[n - holdout_n :]) if holdout_n else ()
+
+    if holdout and non_holdout:
+        non_holdout_t, holdout = _purge_with_embargo(
+            non_holdout,
+            holdout,
+            embargo_seconds=split_contract.embargo_seconds,
+        )
+        non_holdout = list(non_holdout_t)
+
+    train_n = int(len(non_holdout) * split_contract.train_fraction_within_non_holdout)
+    train = tuple(non_holdout[:train_n])
+    validation = tuple(non_holdout[train_n:])
+    if train and validation:
+        train, validation = _purge_with_embargo(
+            train,
+            validation,
+            embargo_seconds=split_contract.embargo_seconds,
+        )
+
+    if access_holdout is False:
+        # Seal holdout identities until final evaluation.
+        sealed_holdout = holdout
+        holdout_accessed = False
+    else:
+        sealed_holdout = holdout
+        holdout_accessed = True
+
+    _assert_chronological(train, validation, sealed_holdout if holdout_accessed else ())
+    _assert_embargo(
+        train,
+        validation,
+        sealed_holdout if holdout_accessed else (),
+        embargo_seconds=split_contract.embargo_seconds,
+    )
+
+    return SplitAssignmentV1(
+        train=train,
+        validation=validation,
+        holdout=sealed_holdout,
+        embargo_seconds=split_contract.embargo_seconds,
+        holdout_accessed=holdout_accessed,
+        fold_id="primary_purged_split",
+    )
+
+
+def build_walk_forward_folds_v1(
+    records: Sequence[ResearchEvidenceRecordV1],
+    *,
+    split_contract: SplitAndEmbargoContractV1,
+) -> tuple[SplitAssignmentV1, ...]:
+    ordered = _require_event_times(records)
+    n = len(ordered)
+    folds = split_contract.walk_forward_folds
+    if n < folds + 2:
+        primary = build_purged_chronological_splits_v1(
+            ordered, split_contract=split_contract, access_holdout=False
+        )
+        return (primary,)
+
+    holdout_n = max(1, int(round(n * split_contract.holdout_fraction)))
+    researchable = ordered[: n - holdout_n]
+    holdout = tuple(ordered[n - holdout_n :])
+    out: list[SplitAssignmentV1] = []
+    for fold_idx in range(folds):
+        # Anchored expanding walk-forward on researchable segment only.
+        cut = int(len(researchable) * ((fold_idx + 1) / (folds + 1)))
+        if cut < 1 or cut >= len(researchable):
+            continue
+        train_raw = tuple(researchable[:cut])
+        val_raw = tuple(researchable[cut:])
+        train, validation = _purge_with_embargo(
+            train_raw,
+            val_raw,
+            embargo_seconds=split_contract.embargo_seconds,
+        )
+        out.append(
+            SplitAssignmentV1(
+                train=train,
+                validation=validation,
+                holdout=holdout,
+                embargo_seconds=split_contract.embargo_seconds,
+                holdout_accessed=False,
+                fold_id=f"walk_forward_{fold_idx + 1}",
+            )
+        )
+    if not out:
+        return (
+            build_purged_chronological_splits_v1(
+                ordered, split_contract=split_contract, access_holdout=False
+            ),
+        )
+    return tuple(out)
+
+
+def access_final_holdout_v1(
+    sealed: SplitAssignmentV1,
+) -> SplitAssignmentV1:
+    """Explicit final-holdout access — only for terminal evaluation."""
+    return SplitAssignmentV1(
+        train=sealed.train,
+        validation=sealed.validation,
+        holdout=sealed.holdout,
+        embargo_seconds=sealed.embargo_seconds,
+        holdout_accessed=True,
+        fold_id=f"{sealed.fold_id}_final_holdout",
+    )
+
+
+def _assert_chronological(
+    train: Sequence[ResearchEvidenceRecordV1],
+    validation: Sequence[ResearchEvidenceRecordV1],
+    holdout: Sequence[ResearchEvidenceRecordV1],
+) -> None:
+    def _times(rows: Sequence[ResearchEvidenceRecordV1]) -> list[float]:
+        return [float(r.event_time_epoch_seconds or 0.0) for r in rows]
+
+    for rows in (train, validation, holdout):
+        ts = _times(rows)
+        if ts != sorted(ts):
+            raise MaxAgeResearchExecutionError("split_not_chronological")
+    if train and validation and max(_times(train)) > min(_times(validation)):
+        raise MaxAgeResearchExecutionError("split_train_validation_overlap")
+    if validation and holdout and max(_times(validation)) > min(_times(holdout)):
+        raise MaxAgeResearchExecutionError("split_validation_holdout_overlap")
+    if train and holdout and max(_times(train)) > min(_times(holdout)):
+        raise MaxAgeResearchExecutionError("split_train_holdout_overlap")
+
+
+def _assert_embargo(
+    train: Sequence[ResearchEvidenceRecordV1],
+    validation: Sequence[ResearchEvidenceRecordV1],
+    holdout: Sequence[ResearchEvidenceRecordV1],
+    *,
+    embargo_seconds: int,
+) -> None:
+    def _gap_ok(
+        left: Sequence[ResearchEvidenceRecordV1],
+        right: Sequence[ResearchEvidenceRecordV1],
+    ) -> bool:
+        if not left or not right:
+            return True
+        return (
+            min(float(r.event_time_epoch_seconds or 0.0) for r in right)
+            - max(float(r.event_time_epoch_seconds or 0.0) for r in left)
+        ) >= float(embargo_seconds)
+
+    if not _gap_ok(train, validation):
+        raise MaxAgeResearchExecutionError("embargo_violation_train_validation")
+    if not _gap_ok(validation, holdout):
+        raise MaxAgeResearchExecutionError("embargo_violation_validation_holdout")
+    if not _gap_ok(train, holdout):
+        raise MaxAgeResearchExecutionError("embargo_violation_train_holdout")

--- a/tests/research/test_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py
+++ b/tests/research/test_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py
@@ -1,0 +1,506 @@
+"""Tests for non-enforcing max-age parameter research execution v1."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.architecture_guards_v1 import (
+    assert_architecture_guards_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.constants_v1 import (
+    EXPECTED_PREREGISTRATION_DIGEST,
+    OPERATOR_BOUND_CANDIDATE_MAX_AGE_SECONDS,
+    SPEC_REL_PATH,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.contracts_v1 import (
+    MaxAgeResearchExecutionError,
+    assert_candidate_domain_immutable_v1,
+    assert_candidates_not_config_authority_v1,
+    bind_candidate_domain_v1,
+    bind_hypothesis_contract_v1,
+    bind_robustness_execution_contract_v1,
+    bind_split_and_embargo_contract_v1,
+    verify_preregistration_digest_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.evidence_loader_v1 import (
+    assert_restore_does_not_invent_estimate_evidence_v1,
+    load_research_evidence_from_payloads_v1,
+    load_research_evidence_records_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.runner_v1 import (
+    run_max_age_parameter_research_execution_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.serialization_v1 import (
+    build_execution_id_v1,
+)
+from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.split_engine_v1 import (
+    access_final_holdout_v1,
+    build_purged_chronological_splits_v1,
+)
+from trading.master_v2.canonical_volatility_numeric_max_age_parameter_research_design_and_evidence_accumulation_contract_v1 import (
+    JOIN_CONTRACT_VERSION,
+    append_max_age_research_evidence_ledger_record_v1,
+    build_max_age_research_evidence_join_v1,
+    build_ratified_max_age_research_design_contract_v1,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+T0 = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def _join(
+    *,
+    session_id: str,
+    cycle_id: str,
+    regime_id: str,
+    age_seconds: float,
+    event_offset_seconds: int,
+    instrument_id: str = "ETH-USD_UM_XPERP-310404",
+):
+    ref = T0 + timedelta(seconds=event_offset_seconds)
+    as_of = ref - timedelta(seconds=age_seconds)
+    return build_max_age_research_evidence_join_v1(
+        session_id=session_id,
+        cycle_id=cycle_id,
+        instrument_id=instrument_id,
+        regime_id=regime_id,
+        max_age_policy_evidence={
+            "estimate_as_of_event_time": as_of.isoformat().replace("+00:00", "Z"),
+            "reference_event_time": ref.isoformat().replace("+00:00", "Z"),
+            "computed_age_seconds": float(age_seconds),
+            "max_age_status": "AGE_COMPUTED_THRESHOLD_UNRESOLVED",
+            "threshold_status": "UNRESOLVED_MAX_AGE",
+            "presence_status": "PRESENT",
+            "clock_trust_status": "TRUSTED",
+            "data_integrity_status": "TRUSTED",
+            "reuse_status": "FRESHLY_PRODUCED",
+            "restart_status": "NOT_APPLICABLE",
+            "source_digest": "abc123",
+            "decision": "AGE_COMPUTED",
+            "reason_code": "VOLATILITY_ESTIMATE_AGE_UNRESOLVED",
+            "enforcement_applied": False,
+            "numeric_threshold_selected": False,
+            "session_id": session_id,
+            "cycle_id": cycle_id,
+            "instrument_id": instrument_id,
+            "regime_id": regime_id,
+        },
+        producer_outcome="PRODUCED",
+        reuse_status="FRESHLY_PRODUCED",
+        restart_status="NOT_APPLICABLE",
+        restart_without_estimate=False,
+        estimate_present=True,
+        observation_count=60,
+        source_digest="abc123",
+        trading_epoch=1,
+        cycle_index=0,
+        alpha_scope_entry_authority_allowed=True,
+        decision_outcome="HOLD",
+        selected_side="none",
+        economic_metrics={"net_pnl_after_fees_and_slippage": 0.0, "trade_count": 0},
+    )
+
+
+def _fixture_records():
+    ages = [30, 90, 250, 500, 800, 1200, 2000, 4000, 100, 400, 700, 1500]
+    sessions = [
+        "sess-a",
+        "sess-a",
+        "sess-a",
+        "sess-a",
+        "sess-a",
+        "sess-a",
+        "sess-b",
+        "sess-b",
+        "sess-b",
+        "sess-b",
+        "sess-b",
+        "sess-b",
+    ]
+    regimes = [
+        "trending",
+        "trending",
+        "trending",
+        "choppy",
+        "choppy",
+        "choppy",
+        "trending",
+        "trending",
+        "choppy",
+        "choppy",
+        "trending",
+        "choppy",
+    ]
+    joins = []
+    for i, age in enumerate(ages):
+        joins.append(
+            _join(
+                session_id=sessions[i],
+                cycle_id=f"{sessions[i]}-c{i}",
+                regime_id=regimes[i],
+                age_seconds=float(age),
+                event_offset_seconds=i * 7200,
+            )
+        )
+    from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.evidence_loader_v1 import (
+        load_research_evidence_from_payloads_v1,
+    )
+
+    return load_research_evidence_from_payloads_v1([j.to_dict() for j in joins])
+
+
+def test_01_preregistration_digest_mismatch_fail_closed() -> None:
+    with pytest.raises(MaxAgeResearchExecutionError, match="preregistration_digest_mismatch"):
+        verify_preregistration_digest_v1("0" * 64)
+    design = build_ratified_max_age_research_design_contract_v1()
+    assert design.preregistration_digest == EXPECTED_PREREGISTRATION_DIGEST
+    verify_preregistration_digest_v1(design.preregistration_digest)
+
+
+def test_02_candidate_domain_immutable_after_start() -> None:
+    domain = bind_candidate_domain_v1(
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        preregistration_digest=EXPECTED_PREREGISTRATION_DIGEST,
+        execution_id="exec-test",
+        created_at_utc="2026-08-01T00:00:00Z",
+    )
+    assert_candidate_domain_immutable_v1(
+        domain, attempted_candidates=domain.candidate_max_age_seconds
+    )
+    with pytest.raises(MaxAgeResearchExecutionError, match="immutable"):
+        assert_candidate_domain_immutable_v1(domain, attempted_candidates=(1, 2, 3))
+
+
+def test_03_candidate_values_not_config_policy_authority() -> None:
+    domain = bind_candidate_domain_v1(
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        preregistration_digest=EXPECTED_PREREGISTRATION_DIGEST,
+        execution_id="exec-test",
+        created_at_utc="2026-08-01T00:00:00Z",
+    )
+    payload = domain.to_dict()
+    assert_candidates_not_config_authority_v1(payload)
+    assert "NOT_CONFIG" in payload["candidate_authority"]
+    assert domain.candidate_max_age_seconds == OPERATOR_BOUND_CANDIDATE_MAX_AGE_SECONDS
+
+
+def test_04_missing_join_fail_closed(tmp_path: Path) -> None:
+    with pytest.raises(MaxAgeResearchExecutionError, match="missing_join_ledger"):
+        load_research_evidence_records_v1(tmp_path / "absent.jsonl")
+
+
+def test_05_join_digest_mismatch_fail_closed(tmp_path: Path) -> None:
+    join = _join(
+        session_id="s1",
+        cycle_id="s1-c0",
+        regime_id="trending",
+        age_seconds=10.0,
+        event_offset_seconds=0,
+    )
+    path = tmp_path / "ledger.jsonl"
+    append_max_age_research_evidence_ledger_record_v1(ledger_path=path, record=join)
+    text = path.read_text(encoding="utf-8")
+    row = json.loads(text)
+    row["join_digest"] = "0" * 64
+    path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+    with pytest.raises(MaxAgeResearchExecutionError, match="join_digest_mismatch"):
+        load_research_evidence_records_v1(path)
+
+
+def test_06_unknown_schema_fail_closed() -> None:
+    with pytest.raises(MaxAgeResearchExecutionError, match="unknown_schema_version"):
+        load_research_evidence_from_payloads_v1(
+            [
+                {
+                    "session_id": "s",
+                    "cycle_id": "c",
+                    "instrument_id": "i",
+                    "regime_id": "r",
+                    "join_contract_version": "unknown/v9",
+                    "join_digest": "x",
+                    "threshold_status": "UNRESOLVED_MAX_AGE",
+                    "enforcement_applied": False,
+                    "numeric_threshold_selected": False,
+                }
+            ]
+        )
+
+
+def test_07_resolved_threshold_in_input_fail_closed() -> None:
+    with pytest.raises(MaxAgeResearchExecutionError, match="resolved_threshold"):
+        load_research_evidence_from_payloads_v1(
+            [
+                {
+                    "session_id": "s",
+                    "cycle_id": "c",
+                    "instrument_id": "i",
+                    "regime_id": "r",
+                    "join_contract_version": JOIN_CONTRACT_VERSION,
+                    "join_digest": "x",
+                    "threshold_status": "RESOLVED_MAX_AGE",
+                    "enforcement_applied": False,
+                    "numeric_threshold_selected": False,
+                }
+            ]
+        )
+
+
+def test_08_enforcement_in_input_fail_closed() -> None:
+    with pytest.raises(MaxAgeResearchExecutionError, match="enforcement_applied"):
+        load_research_evidence_from_payloads_v1(
+            [
+                {
+                    "session_id": "s",
+                    "cycle_id": "c",
+                    "instrument_id": "i",
+                    "regime_id": "r",
+                    "join_contract_version": JOIN_CONTRACT_VERSION,
+                    "join_digest": "x",
+                    "threshold_status": "UNRESOLVED_MAX_AGE",
+                    "enforcement_applied": True,
+                    "numeric_threshold_selected": False,
+                }
+            ]
+        )
+
+
+def test_09_duplicate_identity_divergent_digest_fail_closed(tmp_path: Path) -> None:
+    j1 = _join(
+        session_id="s1",
+        cycle_id="s1-c0",
+        regime_id="trending",
+        age_seconds=10.0,
+        event_offset_seconds=0,
+    )
+    j2 = _join(
+        session_id="s1",
+        cycle_id="s1-c0",
+        regime_id="trending",
+        age_seconds=99.0,
+        event_offset_seconds=0,
+    )
+    path = tmp_path / "ledger.jsonl"
+    append_max_age_research_evidence_ledger_record_v1(ledger_path=path, record=j1)
+    with pytest.raises(Exception):
+        append_max_age_research_evidence_ledger_record_v1(ledger_path=path, record=j2)
+
+
+def test_10_restore_does_not_invent_estimate_evidence() -> None:
+    records = _fixture_records()
+    assert_restore_does_not_invent_estimate_evidence_v1(before=records, after=records)
+    invented = list(records) + list(records[:1])
+    # Same digests already present — inventing a new identity should fail.
+    from research.canonical_volatility_numeric_max_age_parameter_research_execution_v1.evidence_loader_v1 import (
+        ResearchEvidenceRecordV1,
+    )
+
+    extra = ResearchEvidenceRecordV1(
+        session_id="invented",
+        cycle_id="invented-c0",
+        instrument_id="X",
+        regime_id="r",
+        join_contract_version=JOIN_CONTRACT_VERSION,
+        join_digest="inventeddigest",
+        volatility_source_digest=None,
+        market_event_time=None,
+        volatility_as_of_event_time=None,
+        computed_age_seconds=1.0,
+        reuse_status=None,
+        restart_status=None,
+        estimate_present=True,
+        decision_outcome=None,
+        selected_side=None,
+        economic_metrics=None,
+        event_time_epoch_seconds=1.0,
+        raw={},
+    )
+    with pytest.raises(MaxAgeResearchExecutionError, match="restore_invented"):
+        assert_restore_does_not_invent_estimate_evidence_v1(
+            before=records, after=tuple(list(records) + [extra])
+        )
+    _ = invented
+
+
+def test_11_12_split_chronological_purged_and_embargo() -> None:
+    records = _fixture_records()
+    split_contract = bind_split_and_embargo_contract_v1(
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        preregistration_digest=EXPECTED_PREREGISTRATION_DIGEST,
+        execution_id="exec-test",
+        created_at_utc="2026-08-01T00:00:00Z",
+    )
+    sealed = build_purged_chronological_splits_v1(
+        records, split_contract=split_contract, access_holdout=False
+    )
+    assert sealed.embargo_seconds == split_contract.embargo_seconds
+    assert sealed.holdout_accessed is False
+    for rows in (sealed.train, sealed.validation):
+        times = [float(r.event_time_epoch_seconds or 0.0) for r in rows]
+        assert times == sorted(times)
+
+
+def test_13_holdout_untouched_until_final() -> None:
+    records = _fixture_records()
+    split_contract = bind_split_and_embargo_contract_v1(
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        preregistration_digest=EXPECTED_PREREGISTRATION_DIGEST,
+        execution_id="exec-test",
+        created_at_utc="2026-08-01T00:00:00Z",
+    )
+    sealed = build_purged_chronological_splits_v1(
+        records, split_contract=split_contract, access_holdout=False
+    )
+    assert sealed.holdout_accessed is False
+    opened = access_final_holdout_v1(sealed)
+    assert opened.holdout_accessed is True
+
+
+def test_14_15_16_17_18_19_20_full_runner_no_alpha_enforcement_deterministic(
+    tmp_path: Path,
+) -> None:
+    records = _fixture_records()
+    out1 = tmp_path / "run1"
+    result1 = run_max_age_parameter_research_execution_v1(
+        repo_root=ROOT,
+        output_root=out1,
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        records=records,
+        created_at_utc="2026-08-01T00:00:00Z",
+    )
+    assert result1["preregistration_digest_match"] is True
+    assert result1["numeric_threshold_selected"] is False
+    assert result1["parameter_promoted"] is False
+    assert result1["enforcement_applied"] is False
+    assert result1["threshold_status"] == "UNRESOLVED_MAX_AGE"
+    assert result1["hard_stop"] is True
+    assert result1["deterministic_reexecution_pass"] is True
+    assert result1["ledger_resume_equivalence_pass"] is True
+    assert result1["conclusion"]["recommended_single_threshold"] is None
+    assert result1["conclusion"]["numeric_threshold_selected"] is False
+
+    for row in result1["candidate_results"]:
+        assert row["alpha_decision_mutated"] is False
+        assert row["enforcement_applied"] is False
+        assert row["evaluation_mode"] == "DIAGNOSTIC_COUNTERFACTUAL_NO_ENFORCEMENT"
+
+    out2 = tmp_path / "run2"
+    result2 = run_max_age_parameter_research_execution_v1(
+        repo_root=ROOT,
+        output_root=out2,
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        records=records,
+        created_at_utc="2026-08-01T00:00:00Z",
+    )
+    assert result1["execution_id"] == result2["execution_id"]
+    assert result1["candidate_domain_digest"] == result2["candidate_domain_digest"]
+    assert result1["candidate_results"] == result2["candidate_results"]
+
+    required = [
+        "research_execution_manifest.json",
+        "candidate_domain.json",
+        "hypothesis_contract.json",
+        "split_and_embargo_contract.json",
+        "robustness_execution_contract.json",
+        "input_evidence_manifest.json",
+        "candidate_results.jsonl",
+        "walk_forward_results.json",
+        "holdout_results.json",
+        "regime_results.json",
+        "session_results.json",
+        "robustness_results.json",
+        "research_conclusion.json",
+        "integrity_manifest.json",
+    ]
+    for name in required:
+        assert (out1 / name).exists(), name
+
+
+def test_16_deterministic_execution_id() -> None:
+    a = build_execution_id_v1(
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        preregistration_digest=EXPECTED_PREREGISTRATION_DIGEST,
+        candidate_domain_digest="a" * 64,
+        hypothesis_contract_digest="b" * 64,
+        split_contract_digest="c" * 64,
+        robustness_contract_digest="d" * 64,
+        input_evidence_manifest_digest="e" * 64,
+    )
+    b = build_execution_id_v1(
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        preregistration_digest=EXPECTED_PREREGISTRATION_DIGEST,
+        candidate_domain_digest="a" * 64,
+        hypothesis_contract_digest="b" * 64,
+        split_contract_digest="c" * 64,
+        robustness_contract_digest="d" * 64,
+        input_evidence_manifest_digest="e" * 64,
+    )
+    assert a == b
+    assert a.startswith("maxage_research_exec_")
+
+
+def test_21_architecture_guard_against_trading_authority_import() -> None:
+    guards = assert_architecture_guards_v1(repo_root=ROOT)
+    assert guards["guards_pass"] is True
+    assert guards["trading_authority_imports_absent"] is True
+    assert guards["numeric_threshold_selected"] is False
+
+
+def test_22_docs_and_reference_gates() -> None:
+    spec = ROOT / SPEC_REL_PATH
+    assert spec.exists()
+    text = spec.read_text(encoding="utf-8")
+    assert (
+        "DOCS_TOKEN_MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PARAMETER_RESEARCH_EXECUTION_V1"
+        in text
+    )
+    assert "NUMERIC_THRESHOLD_SELECTED: false" in text
+    assert "ENFORCEMENT_APPLIED: false" in text
+    assert "HARD_STOP: true" in text
+    # Docs token policy: inline code paths must use &#47;
+    assert "src&#47;research&#47;" in text or "scripts&#47;ops&#47;" in text
+
+
+def test_hypothesis_and_split_bindings_before_eval() -> None:
+    hyp = bind_hypothesis_contract_v1(
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        preregistration_digest=EXPECTED_PREREGISTRATION_DIGEST,
+        execution_id="exec-test",
+        created_at_utc="2026-08-01T00:00:00Z",
+    )
+    assert hyp.enforcement_during_research is False
+    assert hyp.counterfactual_only is True
+    assert hyp.alpha_decision_mutation_allowed is False
+    split = bind_split_and_embargo_contract_v1(
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        preregistration_digest=EXPECTED_PREREGISTRATION_DIGEST,
+        execution_id="exec-test",
+        created_at_utc="2026-08-01T00:00:00Z",
+    )
+    assert split.embargo_seconds > 0
+    assert split.holdout_untouched_until_final_evaluation is True
+    rob = bind_robustness_execution_contract_v1(
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        preregistration_digest=EXPECTED_PREREGISTRATION_DIGEST,
+        execution_id="exec-test",
+        created_at_utc="2026-08-01T00:00:00Z",
+    )
+    assert "BLOCK_BOOTSTRAP_CONFIDENCE_INTERVALS" in rob.methods
+
+
+def test_insufficient_productive_ledger_blocks_without_extrapolation(tmp_path: Path) -> None:
+    result = run_max_age_parameter_research_execution_v1(
+        repo_root=ROOT,
+        ledger_path=tmp_path / "missing.jsonl",
+        output_root=tmp_path / "blocked",
+        repository_sha="e03426f0250fbc55f95c044c6a904e059746125c",
+        created_at_utc="2026-08-01T00:00:00Z",
+    )
+    assert result["status"] == "BLOCKED"
+    assert result["insufficient_research_evidence"] is True
+    assert result["numeric_threshold_selected"] is False
+    assert result["parameter_promoted"] is False
+    assert (tmp_path / "blocked" / "research_conclusion.json").exists()


### PR DESCRIPTION
## Summary
- Adds non-enforcing Canonical Volatility Numeric Max-Age parameter research execution v1 (contracts, purged splits/embargo, counterfactual candidate evaluation, robustness diagnostics, deterministic CLI/artifacts).
- Binds and verifies the preregistered design digest `965f6e09…`; never selects, promotes, or enforces a numeric threshold (`THRESHOLD_STATUS=UNRESOLVED_MAX_AGE`, `HARD_STOP=true`).
- Productive ledger currently insufficient for research results (`INSUFFICIENT_RESEARCH_EVIDENCE`); capability + tests/docs ship for owner research review only.

## Test plan
- [x] `pytest tests/research/test_canonical_volatility_numeric_max_age_parameter_research_execution_v1.py` (18 passed)
- [x] PR-bounded selector targets + owner tests (746 passed, ~52s wallclock)
- [x] `ruff format --check` / `ruff check` on touched surfaces
- [x] Docs token policy + docs reference targets
- [x] CLI dry-run against missing productive ledger → `STATUS=BLOCKED`, no threshold selection


Made with [Cursor](https://cursor.com)