### PR TITLE
feat(research): bind natural age lifecycle into productive volatility bridge

### DIFF
--- a/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
+++ b/config/governance/economic_diagnostic_optimization_boundary_canonical_owner_map_v0.json
@@ -1751,6 +1751,14 @@
         "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_NATURAL_AGE_PROGRESSION_AND_ACTIONABLE_STRATA_EVIDENCE_PLAN_V1.md",
         "config/research/canonical_volatility_numeric_max_age_natural_age_progression_additional_evidence_coverage_plan_v1.json"
       ]
+    },
+    "CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_NATURAL_AGE_LIFECYCLE_WIRING_V1": {
+      "note": "Binds NaturalAgeProgressionLifecycleHostV1 into the productive Canonical-Volatility evidence bridge/runner path as sole produce/reuse/recompute authority for natural age accumulation; no numeric max-age selection/enforcement, authorization, preregistration, session execution, Master-V2/Double-Play/Bull/Bear/entry-exit/risk/safety mutation, or Session-02 ledger mutation.",
+      "path_prefixes": [
+        "src/research/canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1/productive_natural_age_lifecycle_binding_v1.py",
+        "tests/research/test_canonical_volatility_numeric_max_age_productive_bridge_natural_age_lifecycle_wiring_v1.py",
+        "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_NATURAL_AGE_LIFECYCLE_WIRING_V1.md"
+      ]
     }
   },
   "forbidden_mutation_surfaces": {

--- a/config/governance/technical_canonical_wiring_authorization_v1.json
+++ b/config/governance/technical_canonical_wiring_authorization_v1.json
@@ -852,7 +852,10 @@
     "src/research/canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1/coverage_plan_v1.py",
     "tests/research/test_canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.py",
     "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_NATURAL_AGE_PROGRESSION_AND_ACTIONABLE_STRATA_EVIDENCE_PLAN_V1.md",
-    "config/research/canonical_volatility_numeric_max_age_natural_age_progression_additional_evidence_coverage_plan_v1.json"
+    "config/research/canonical_volatility_numeric_max_age_natural_age_progression_additional_evidence_coverage_plan_v1.json",
+    "src/research/canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1/productive_natural_age_lifecycle_binding_v1.py",
+    "tests/research/test_canonical_volatility_numeric_max_age_productive_bridge_natural_age_lifecycle_wiring_v1.py",
+    "docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_NATURAL_AGE_LIFECYCLE_WIRING_V1.md"
   ],
   "allowed_surface_classes": [
     "TECHNICAL_CANONICAL_REPLAY_INPUT_BUILDER_WIRING",

--- a/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_NATURAL_AGE_PROGRESSION_AND_ACTIONABLE_STRATA_EVIDENCE_PLAN_V1.md
+++ b/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_NATURAL_AGE_PROGRESSION_AND_ACTIONABLE_STRATA_EVIDENCE_PLAN_V1.md
@@ -112,10 +112,22 @@ actionable long&#47;short&#47;entry strata, counterfactual stale records, and na
 7200s reachability — without artificial delay. This capability does **not**
 register or execute those sessions.
 
+## Productive bridge wiring (follow-on capability)
+
+The lifecycle host is bound into the productive bridge runner by
+
+`MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_NATURAL_AGE_LIFECYCLE_WIRING_V1`
+
+via `ProductiveNaturalAgeLifecycleCmcBindingHostV1`. That wiring capability owns
+the productive produce&#47;reuse&#47;recompute authority and Age-7200 reachability proof.
+This evidence-plan capability remains the research contract owner for lifecycle,
+strata, counterfactual impact, and coverage plan surfaces.
+
 ## Next later step
 
 A separate operator-authorized Authorization &#47; Execution plan is required before
-any productive session. This capability stops at
+any productive session. The Numeric Max-Age Evidence Derivation phase remains
+research-only. This capability stops at
 
 `READY_FOR_ADDITIONAL_EVIDENCE_AUTHORIZATION_PLAN`.
 

--- a/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_NATURAL_AGE_LIFECYCLE_WIRING_V1.md
+++ b/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_NATURAL_AGE_LIFECYCLE_WIRING_V1.md
@@ -1,0 +1,148 @@
+# MASTER_V2 Canonical Volatility Numeric Max-Age Productive Bridge Natural Age Lifecycle Wiring v1
+
+---
+docs_token: DOCS_TOKEN_MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_NATURAL_AGE_LIFECYCLE_WIRING_V1
+STATUS: CAPABILITY_AVAILABLE
+scope: bind NaturalAgeProgressionLifecycleHostV1 into the productive Canonical-Volatility evidence bridge/runner path
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+NUMERIC_MAX_AGE_DECIDED: false
+NUMERIC_MAX_AGE_SECONDS: null
+THRESHOLD_STATUS: UNRESOLVED_MAX_AGE
+ENFORCEMENT_ENABLED: false
+ENFORCEMENT_APPLIED: false
+COUNTERFACTUAL_ONLY: true
+THRESHOLD_SELECTED: false
+SESSION_EXECUTION_AUTHORIZED: false
+AUTHORIZATION_ISSUANCE_AUTHORIZED: false
+BLOCKED_FOR_PARAMETER_DECISION: true
+HARD_STOP: true
+---
+
+> **Research wiring capability only.**
+> Binds `NaturalAgeProgressionLifecycleHostV1` fail-closed into the productive
+> bridge / preregistered session runner call graph so natural Volatility ages
+> can accumulate across distinct PT1M observations.
+> Does **not** select or enforce a numeric max-age, issue/consume authorization,
+> create preregistration, execute a productive session, mutate Master-V2 /
+> Double-Play / Bull / Bear / Entry-Exit / Risk / Safety semantics, or mutate
+> existing Session-02 ledger evidence.
+
+## Machine summary
+
+```
+REVIEW_MODE=MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_NATURAL_AGE_LIFECYCLE_WIRING_V1
+CAPABILITY_ID=MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_NATURAL_AGE_LIFECYCLE_WIRING_V1
+NATURAL_AGE_LIFECYCLE_HOST_PRODUCTIVE_BOUND=true
+LEGACY_PER_SAMPLE_REMATERIALIZATION_UNREACHABLE=true
+SECOND_AGE_AUTHORITY_PRESENT=false
+SECOND_DECISION_AUTHORITY_PRESENT=false
+NUMERIC_MAX_AGE_SELECTED=false
+NUMERIC_MAX_AGE_ENFORCING=false
+SESSION_EXECUTED=false
+HARD_STOP=true
+```
+
+## Call graph (before → after)
+
+### Before
+
+```
+run_preregistered_productive_session_v1
+  → run_productive_bridge_accumulation_session_v1
+    → HardenedBridgeSessionStateV2.typed_volatility_cmc_binding_host
+         = CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1
+      → CanonicalVolatilityTypedRuntimeProducerScaffoldV1
+           rematerializes on every distinct PT1M sample
+      → as_of_event_time == market_event_time ⇒ age_seconds == 0
+      → presence gate / evidence / join / counterfactual consume age=0
+```
+
+### After
+
+```
+run_preregistered_productive_session_v1
+  → run_productive_bridge_accumulation_session_v1
+    → HardenedBridgeSessionStateV2.typed_volatility_cmc_binding_host
+         = ProductiveNaturalAgeLifecycleCmcBindingHostV1
+      → NaturalAgeProgressionLifecycleHostV1
+           (sole produce / reuse / recompute authority)
+      → evaluate_recompute_decision_v1 (research wiring, not max-age policy)
+      → bind immutable reused estimate into CMC
+      → age_seconds = market_event_time - as_of_event_time
+      → consumers (evidence, join, counterfactual, strata, safety/risk/exit)
+           project canonical age unchanged; no decision authority
+```
+
+## Lifecycle state ownership
+
+| Concern | Owner |
+|---|---|
+| Produce vs reuse vs recompute | `NaturalAgeProgressionLifecycleHostV1` |
+| Research recompute floors | `evaluate_recompute_decision_v1` and `ResearchEstimateRecomputePolicyV1` |
+| Natural age formula | `compute_natural_age_seconds_v1` |
+| Productive CMC bind adapter | `ProductiveNaturalAgeLifecycleCmcBindingHostV1` |
+| Evidence / join / CF / strata / safety | consumers only |
+
+## Produce / reuse / recompute semantics
+
+1. **First valid produce** — immutable `as_of_event_time`, `age_seconds=0`, `distinct=0`
+2. **Valid distinct reuse** — same estimate / as_of; age grows by market event time; distinct increments once
+3. **Duplicate** — `DUPLICATE_NOOP`; no age / counter / estimate drift
+4. **Out-of-order** — not evaluable; no counter progress; as_of unchanged
+5. **Warmup / not evaluable** — no artificial age / produce
+6. **Recompute** — unchanged research contract:
+
+```
+RESEARCH_RECOMPUTE_MINIMUM_NEW_DISTINCT_OBSERVATIONS=121
+RESEARCH_RECOMPUTE_MINIMUM_EVENT_TIME_ELAPSED_SECONDS=7201
+trigger = distinct >= 121 OR elapsed >= 7201
+decision evaluated before reuse increment
+```
+
+## Age-7200 timeline (PT1M)
+
+After first produce:
+
+| Step | prior.distinct | elapsed | decision | after.distinct | age_seconds |
+|---|---:|---:|---|---:|---:|
+| +7200 | 119 | 7200 | REUSE | 120 | 7200 |
+| +7260 | 120 | 7260 | RECOMPUTE | 0 | 0 |
+
+No recompute before age 7200 under the ratified research wiring.
+
+## Fail-closed invariants
+
+- missing / inconsistent lifecycle state → no evidence accumulation
+- negative age → reject
+- event-time regression → no state progress
+- duplicate must not advance confirmation / distinct counters
+- runtime cycle must not synthesize samples or ages
+- wallclock sleep must not create productive age
+- no synthetic timestamp manipulation
+- replay must not be emitted as productive evidence
+- Session-02 evidence remains byte-stable
+- existing ledgers are append-only / not rewritten by this capability
+
+## Explicit non-goals
+
+- no numeric max-age selection or enforcement
+- no Master-V2 / Double-Play / Bull / Bear / Entry-Exit / Risk / Safety mutation
+- no second decision authority / trading permission / order activation
+- no authorization issuance or consumption
+- no preregistration creation
+- no productive session execution / network requests
+- no Session-02 or historical ledger mutation
+
+## Later research phase
+
+The separate phase **Numeric Max-Age Evidence Derivation** remains research-only and
+requires a later operator-authorized plan. This wiring capability stops at
+
+`READY_FOR_POST_MERGE_AUTHORIZATION_PLAN_REASSESSMENT`
+
+with `READY_FOR_SESSION_PREREGISTRATION=false`,
+`READY_FOR_AUTHORIZATION_ISSUANCE=false`,
+`READY_FOR_PRODUCTIVE_SESSION_EXECUTION=false`,
+`READY_FOR_NUMERIC_MAX_AGE_POLICY_DECISION=false`,
+`HARD_STOP=true`.

--- a/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_RESEARCH_EVIDENCE_ACCUMULATION_V1.md
+++ b/docs/ops/specs/MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_RESEARCH_EVIDENCE_ACCUMULATION_V1.md
@@ -50,18 +50,25 @@ recommending, or enforcing a numeric threshold in this step?
 ## Producer &#47; Consumer &#47; Evidence Graph
 
 ```
-Canonical Volatility Producer (typed, productive, ddof=0, PT60M, annualized=false)
-  → VolatilityEstimateV1 + provenance &#47; source digest
+Productive bridge runner
+  → ProductiveNaturalAgeLifecycleCmcBindingHostV1
+       (NaturalAgeProgressionLifecycleHostV1 = sole produce&#47;reuse&#47;recompute authority)
+  → Typed VolatilityEstimateV1 with immutable as_of during reuse
   → Presence &#47; Trust Gate (unknown entry fail-closed; exit&#47;reduce&#47;risk&#47;safety preserved)
-  → Non-enforcing max-age telemetry (threshold unresolved)
-  → Productive evidence producer (preregistration bound first)
+  → Non-enforcing max-age telemetry (threshold unresolved; natural age from event time)
+  → Productive evidence producer (preregistration bound first; lifecycle age fail-closed)
   → Validation &#47; quarantine (fail-closed)
   → Append-only productive ledger (chained digests)
   → Research join projection (existing join contract)
   → Counterfactual age-grid diagnostics (no decision mutation)
+  → Actionable strata &#47; safety&#47;risk&#47;exit observability (consumers only)
   → Evaluability &#47; robustness report (no winner selection)
   → Later separate Parameter-Decision step (explicit GO required)
 ```
+
+Natural-age lifecycle wiring owner:
+
+`docs&#47;ops&#47;specs&#47;MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_NATURAL_AGE_LIFECYCLE_WIRING_V1.md`
 
 No node in this graph is Alpha, State, Composition, Risk, Safety, TradingGate,
 order, or threshold-selection authority.

--- a/src/research/canonical_volatility_max_age_productive_research_evidence_accumulation_v1/architecture_guards_v1.py
+++ b/src/research/canonical_volatility_max_age_productive_research_evidence_accumulation_v1/architecture_guards_v1.py
@@ -147,6 +147,12 @@ def assert_architecture_guards_v1(*, repo_root: Path | None = None) -> dict[str,
     if "bind_accumulation_state_to_hardened_bridge_session_v1" not in binding_mod:
         raise RuntimeError("PRODUCTIVE_BRIDGE_BINDING_API_MISSING")
 
+    runner_mod = (package_dir / "productive_bridge_runner_v1.py").read_text(encoding="utf-8")
+    if "ProductiveNaturalAgeLifecycleCmcBindingHostV1" not in runner_mod:
+        raise RuntimeError("PRODUCTIVE_BRIDGE_MUST_BIND_NATURAL_AGE_LIFECYCLE_HOST")
+    if "CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.create" in runner_mod:
+        raise RuntimeError("PRODUCTIVE_BRIDGE_MUST_NOT_CREATE_LEGACY_CMC_BINDING_HOST")
+
     for required_module in (
         "preregistration_v1.py",
         "counterfactual_grid_v1.py",

--- a/src/research/canonical_volatility_max_age_productive_research_evidence_accumulation_v1/producer_v1.py
+++ b/src/research/canonical_volatility_max_age_productive_research_evidence_accumulation_v1/producer_v1.py
@@ -146,6 +146,21 @@ def produce_productive_research_evidence_from_cycle_v1(
         if abs(recomputed - age_seconds) > 1e-9:
             raise ProductiveEvidenceAccumulationError("age_formula_mismatch")
 
+    # Natural-age lifecycle host is sole produce/reuse authority when bound.
+    # Missing/inconsistent lifecycle state fails closed (no evidence accumulation).
+    if binding.get("natural_age_lifecycle_host_bound") is True:
+        lifecycle_age = binding.get("natural_age_seconds")
+        if lifecycle_age is None:
+            raise ProductiveEvidenceAccumulationError(
+                "natural_age_lifecycle_state_missing_for_evaluable_estimate"
+            )
+        if abs(float(lifecycle_age) - float(age_seconds)) > 1e-9:
+            raise ProductiveEvidenceAccumulationError(
+                "natural_age_lifecycle_age_authority_mismatch"
+            )
+        if float(age_seconds) < 0.0:
+            raise ProductiveEvidenceAccumulationError("negative_age_fail_closed")
+
     source_digest = require_nonempty(
         age.get("source_digest") or binding.get("source_digest"),
         field_name="volatility_source_digest",

--- a/src/research/canonical_volatility_max_age_productive_research_evidence_accumulation_v1/productive_bridge_runner_v1.py
+++ b/src/research/canonical_volatility_max_age_productive_research_evidence_accumulation_v1/productive_bridge_runner_v1.py
@@ -246,14 +246,31 @@ def run_productive_bridge_accumulation_session_v1(
     if len(samples) > max_cycles:
         raise ProductiveEvidenceAccumulationError("session_cycle_bound_exceeded")
 
+    from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.productive_natural_age_lifecycle_binding_v1 import (
+        ProductiveNaturalAgeLifecycleCmcBindingHostV1,
+    )
+
     session_start = iso_from_unix_v1(float(samples[0].event_time_unix_seconds))
     bridge_state = HardenedBridgeSessionStateV2(
         instrument_id=canonical_instrument_id,
         typed_volatility_persistence_path=typed_volatility_persistence_path,
     )
+    # Natural-age lifecycle host is the sole produce/reuse/recompute authority on
+    # the productive research evidence path (legacy per-sample rematerialize unbound).
     if typed_volatility_persistence_path and typed_volatility_persistence_path.exists():
-        bridge_state.restore_typed_volatility_binding_host_from_persistence_v1(
-            persistence_path=typed_volatility_persistence_path
+        bridge_state.typed_volatility_cmc_binding_host = (
+            ProductiveNaturalAgeLifecycleCmcBindingHostV1.restore_from_persistence_v1(
+                persistence_path=typed_volatility_persistence_path,
+            )
+        )
+    else:
+        bridge_state.typed_volatility_cmc_binding_host = (
+            ProductiveNaturalAgeLifecycleCmcBindingHostV1.create(
+                venue=venue,
+                canonical_instrument_id=canonical_instrument_id,
+                venue_instrument_id=venue_instrument_id,
+                persistence_path=typed_volatility_persistence_path,
+            )
         )
 
     existing_session = None

--- a/src/research/canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1/__init__.py
+++ b/src/research/canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1/__init__.py
@@ -37,6 +37,11 @@ from research.canonical_volatility_numeric_max_age_natural_age_progression_and_a
 from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.lifecycle_host_v1 import (
     NaturalAgeProgressionLifecycleHostV1,
 )
+from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.productive_natural_age_lifecycle_binding_v1 import (
+    CAPABILITY_ID as PRODUCTIVE_BRIDGE_NATURAL_AGE_WIRING_CAPABILITY_ID,
+    ProductiveNaturalAgeLifecycleCmcBindingHostV1,
+    assert_natural_age_lifecycle_productive_binding_guards_v1,
+)
 from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.recompute_policy_v1 import (
     build_natural_age_research_recompute_policy_v1,
     recompute_trigger_matrix_v1,
@@ -54,11 +59,14 @@ __all__ = [
     "HARD_STOP",
     "NaturalAgeProgressionLifecycleHostV1",
     "PACKAGE_MARKER",
+    "PRODUCTIVE_BRIDGE_NATURAL_AGE_WIRING_CAPABILITY_ID",
+    "ProductiveNaturalAgeLifecycleCmcBindingHostV1",
     "READY_FOR_NUMERIC_MAX_AGE_POLICY_DECISION",
     "READY_FOR_PRODUCTIVE_SESSION_EXECUTION",
     "REVIEW_MODE_ID",
     "VolatilityEstimateLifecycleState",
     "assert_architecture_guards_v1",
+    "assert_natural_age_lifecycle_productive_binding_guards_v1",
     "assign_age_bucket_v1",
     "build_additional_evidence_coverage_plan_v1",
     "build_natural_age_research_recompute_policy_v1",

--- a/src/research/canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1/architecture_guards_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1/architecture_guards_v1.py
@@ -92,6 +92,12 @@ def assert_architecture_guards_v1(*, repo_root: Path | None = None) -> dict[str,
     ):
         raise RuntimeError("CAPABILITY_GUARD_DRIFT")
 
+    from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.productive_natural_age_lifecycle_binding_v1 import (
+        assert_natural_age_lifecycle_productive_binding_guards_v1,
+    )
+
+    productive_binding = assert_natural_age_lifecycle_productive_binding_guards_v1(repo_root=root)
+
     return {
         "review_mode": REVIEW_MODE_ID,
         "guards_pass": True,
@@ -102,4 +108,16 @@ def assert_architecture_guards_v1(*, repo_root: Path | None = None) -> dict[str,
         "blocked_for_parameter_decision": BLOCKED_FOR_PARAMETER_DECISION,
         "ready_for_productive_session_execution": READY_FOR_PRODUCTIVE_SESSION_EXECUTION,
         "ready_for_numeric_max_age_policy_decision": READY_FOR_NUMERIC_MAX_AGE_POLICY_DECISION,
+        "NATURAL_AGE_LIFECYCLE_HOST_PRODUCTIVE_BOUND": productive_binding[
+            "NATURAL_AGE_LIFECYCLE_HOST_PRODUCTIVE_BOUND"
+        ],
+        "LEGACY_PER_SAMPLE_REMATERIALIZATION_UNREACHABLE": productive_binding[
+            "LEGACY_PER_SAMPLE_REMATERIALIZATION_UNREACHABLE"
+        ],
+        "SECOND_AGE_AUTHORITY_PRESENT": productive_binding["SECOND_AGE_AUTHORITY_PRESENT"],
+        "SECOND_DECISION_AUTHORITY_PRESENT": productive_binding[
+            "SECOND_DECISION_AUTHORITY_PRESENT"
+        ],
+        "MASTER_V2_LOGIC_CHANGED": MASTER_V2_LOGIC_CHANGED,
+        "DOUBLE_PLAY_LOGIC_CHANGED": DOUBLE_PLAY_LOGIC_CHANGED,
     }

--- a/src/research/canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1/forensic_analysis_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1/forensic_analysis_v1.py
@@ -104,4 +104,25 @@ def producer_consumer_call_graph_matrix_v1() -> Mapping[str, Any]:
             "mutates_master_v2_logic": False,
             "enforces_max_age": False,
         },
+        "productive_bridge_wiring": {
+            "module": (
+                "research.canonical_volatility_numeric_max_age_natural_age_progression_"
+                "and_actionable_strata_evidence_plan_v1.productive_natural_age_lifecycle_binding_v1"
+            ),
+            "symbol": "ProductiveNaturalAgeLifecycleCmcBindingHostV1",
+            "bound_by": (
+                "research.canonical_volatility_max_age_productive_research_evidence_"
+                "accumulation_v1.productive_bridge_runner_v1."
+                "run_productive_bridge_accumulation_session_v1"
+            ),
+            "authority": "sole_produce_vs_reuse_vs_recompute_on_productive_evidence_path",
+            "legacy_per_sample_rematerialization_unreachable": True,
+            "consumers_remain_non_authority": [
+                "produce_productive_research_evidence_from_cycle_v1",
+                "join_projection_v1",
+                "counterfactual_grid_v1",
+                "actionable_strata_v1",
+                "safety_observability_v1",
+            ],
+        },
     }

--- a/src/research/canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1/productive_natural_age_lifecycle_binding_v1.py
+++ b/src/research/canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1/productive_natural_age_lifecycle_binding_v1.py
@@ -1,0 +1,475 @@
+"""Productive-bridge CMC binding host owned by NaturalAgeProgressionLifecycleHostV1.
+
+Replaces per-sample rematerialization authority on the productive research
+evidence path. Master-V2 / Double-Play decision logic is unchanged; this host
+only controls which typed estimate identity/as_of is bound into CMC so natural
+age can accumulate under the research recompute contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.constants_v1 import (
+    AGE_FORMULA_VERSION,
+    AGE_REFERENCE_CLOCK,
+    RESEARCH_WIRING_LABEL,
+)
+from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.lifecycle_contract_v1 import (
+    LifecycleOutcomeV1,
+    NaturalAgeLifecycleErrorV1,
+    NaturalAgeLifecycleObservationV1,
+)
+from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.lifecycle_host_v1 import (
+    NaturalAgeProgressionLifecycleHostV1,
+)
+from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.recompute_policy_v1 import (
+    ResearchEstimateRecomputePolicyV1,
+    build_natural_age_research_recompute_policy_v1,
+)
+from trading.market_state.distinct_market_observation_acceptor_v1 import (
+    ObservationTransportMetadataV1,
+)
+from trading.market_state.time_sample_epoch_semantics_v1 import MarketSampleIdentityV1
+from trading.master_v2.canonical_market_context_v1 import (
+    CanonicalMarketContextV1,
+)
+from trading.master_v2.canonical_volatility_binding_and_provenance_transport_v1 import (
+    bind_typed_canonical_volatility_estimate_into_market_context_v1,
+    evaluate_typed_volatility_binding_eligibility_v1,
+    validate_typed_estimate_for_cmc_binding_v1,
+)
+from trading.master_v2.canonical_volatility_estimate_typed_consumption_contract_v1 import (
+    LEGACY_ADAPTER_OWNER,
+    CanonicalVolatilityEstimateV1,
+    CanonicalVolatilityTypedConsumptionError,
+    validate_canonical_volatility_estimate_v1,
+)
+from trading.master_v2.canonical_volatility_hot_path_contract_closure_v1 import (
+    clear_untyped_productive_volatility_float_v1,
+)
+from trading.master_v2.canonical_volatility_numeric_max_age_policy_contract_and_non_enforcing_telemetry_v1 import (
+    VolatilityRestartStatusV1,
+    VolatilityReuseStatusV1,
+    derive_reuse_and_restart_status_for_age_policy_v1,
+)
+from trading.master_v2.canonical_volatility_productive_runtime_cmc_typed_binding_v1 import (
+    MAX_AGE_STATUS,
+    ProductiveRuntimeCmcTypedBindingResultV1,
+    ProductiveRuntimeCmcTypedBindingTelemetryV1,
+    ProductiveTypedBindingFailClosedReasonV1,
+)
+from trading.master_v2.canonical_volatility_typed_runtime_producer_scaffold_v1 import (
+    CanonicalVolatilityTypedRuntimeProducerScaffoldV1,
+    TypedRuntimeProducerOutcomeV1,
+    TypedRuntimeProducerResultV1,
+)
+
+PACKAGE_MARKER = (
+    "MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_"
+    "NATURAL_AGE_LIFECYCLE_WIRING_V1=true"
+)
+CAPABILITY_ID = (
+    "MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_PRODUCTIVE_BRIDGE_"
+    "NATURAL_AGE_LIFECYCLE_WIRING_V1"
+)
+NATURAL_AGE_LIFECYCLE_HOST_PRODUCTIVE_BOUND = True
+LEGACY_PER_SAMPLE_REMATERIALIZATION_UNREACHABLE = True
+SECOND_AGE_AUTHORITY_PRESENT = False
+SECOND_DECISION_AUTHORITY_PRESENT = False
+
+
+def _as_of_iso(estimate: CanonicalVolatilityEstimateV1 | None) -> Optional[str]:
+    if estimate is None:
+        return None
+    as_of = estimate.as_of_event_time
+    if isinstance(as_of, datetime):
+        return as_of.isoformat()
+    return str(as_of)
+
+
+def _map_lifecycle_to_producer_outcome(
+    outcome: str,
+) -> TypedRuntimeProducerOutcomeV1:
+    if outcome == LifecycleOutcomeV1.WARMUP.value:
+        return TypedRuntimeProducerOutcomeV1.WARMUP
+    if outcome == LifecycleOutcomeV1.DUPLICATE_NOOP.value:
+        return TypedRuntimeProducerOutcomeV1.DUPLICATE_NOOP
+    if outcome == LifecycleOutcomeV1.OUT_OF_ORDER_NOT_EVALUABLE.value:
+        return TypedRuntimeProducerOutcomeV1.OUT_OF_ORDER_REJECTED
+    if outcome == LifecycleOutcomeV1.INVALID_SAMPLE_REJECTED.value:
+        return TypedRuntimeProducerOutcomeV1.INVALID_SAMPLE_REJECTED
+    if outcome in {
+        LifecycleOutcomeV1.PRODUCED.value,
+        LifecycleOutcomeV1.REUSED.value,
+        LifecycleOutcomeV1.RECOMPUTED.value,
+    }:
+        return TypedRuntimeProducerOutcomeV1.PRODUCED
+    if outcome == LifecycleOutcomeV1.RUNTIME_CYCLE_NOOP.value:
+        return TypedRuntimeProducerOutcomeV1.DUPLICATE_NOOP
+    return TypedRuntimeProducerOutcomeV1.MATERIALIZATION_REJECTED
+
+
+def _fail_reason_for_lifecycle(
+    obs: NaturalAgeLifecycleObservationV1,
+    *,
+    has_bind_estimate: bool,
+    restart_without_estimate: bool,
+    cycle_without_sample: bool,
+) -> ProductiveTypedBindingFailClosedReasonV1:
+    if restart_without_estimate and not has_bind_estimate:
+        return ProductiveTypedBindingFailClosedReasonV1.RESTART_WITHOUT_ESTIMATE
+    if obs.outcome == LifecycleOutcomeV1.WARMUP.value:
+        return ProductiveTypedBindingFailClosedReasonV1.WARMUP_NO_ESTIMATE
+    if obs.outcome == LifecycleOutcomeV1.DUPLICATE_NOOP.value and not has_bind_estimate:
+        return ProductiveTypedBindingFailClosedReasonV1.DUPLICATE_WITHOUT_PRIOR_ESTIMATE
+    if obs.outcome == LifecycleOutcomeV1.OUT_OF_ORDER_NOT_EVALUABLE.value:
+        return ProductiveTypedBindingFailClosedReasonV1.OUT_OF_ORDER_REJECTED
+    if obs.outcome == LifecycleOutcomeV1.INVALID_SAMPLE_REJECTED.value:
+        return ProductiveTypedBindingFailClosedReasonV1.INVALID_SAMPLE_REJECTED
+    if obs.outcome == LifecycleOutcomeV1.MISSING_ESTIMATE.value:
+        return ProductiveTypedBindingFailClosedReasonV1.NO_SAMPLE_AND_NO_PRIOR_ESTIMATE
+    if cycle_without_sample and not has_bind_estimate:
+        return ProductiveTypedBindingFailClosedReasonV1.CYCLE_WITHOUT_SAMPLE_NO_ESTIMATE
+    if not has_bind_estimate:
+        return ProductiveTypedBindingFailClosedReasonV1.NO_SAMPLE_AND_NO_PRIOR_ESTIMATE
+    return ProductiveTypedBindingFailClosedReasonV1.NONE
+
+
+@dataclass(frozen=True)
+class ProductiveNaturalAgeBindingTelemetryV1(ProductiveRuntimeCmcTypedBindingTelemetryV1):
+    """CMC binding telemetry plus natural-age lifecycle authority fields."""
+
+    lifecycle_outcome: str = ""
+    natural_age_seconds: Optional[float] = None
+    distinct_observations_since_recompute: int = 0
+    recompute_reason: str = ""
+    natural_age_lifecycle_host_bound: bool = True
+    research_recompute_wiring_label: str = RESEARCH_WIRING_LABEL
+    age_formula_version: str = AGE_FORMULA_VERSION
+    age_reference_clock: str = AGE_REFERENCE_CLOCK
+    volatility_value: Optional[float] = None
+    volatility_unit: Optional[str] = None
+    volatility_horizon_seconds: Optional[float] = None
+    volatility_estimator: Optional[str] = None
+    estimate_id: Optional[str] = None
+    estimate_reused: bool = False
+    reuse_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = super().to_dict()
+        payload.update(
+            {
+                "age_formula_version": self.age_formula_version,
+                "age_reference_clock": self.age_reference_clock,
+                "distinct_observations_since_recompute": (
+                    self.distinct_observations_since_recompute
+                ),
+                "estimate_id": self.estimate_id,
+                "estimate_reused": self.estimate_reused,
+                "lifecycle_outcome": self.lifecycle_outcome,
+                "natural_age_lifecycle_host_bound": self.natural_age_lifecycle_host_bound,
+                "natural_age_seconds": self.natural_age_seconds,
+                "recompute_reason": self.recompute_reason,
+                "research_recompute_wiring_label": self.research_recompute_wiring_label,
+                "reuse_count": self.reuse_count,
+                "volatility_estimator": self.volatility_estimator,
+                "volatility_horizon_seconds": self.volatility_horizon_seconds,
+                "volatility_unit": self.volatility_unit,
+                "volatility_value": self.volatility_value,
+            }
+        )
+        return payload
+
+
+@dataclass
+class ProductiveNaturalAgeLifecycleCmcBindingHostV1:
+    """Duck-typed CMC binding host for productive bridge natural-age wiring."""
+
+    lifecycle: NaturalAgeProgressionLifecycleHostV1
+    _restart_without_estimate: bool = False
+    _produced_since_start_or_restore: bool = False
+    _last_telemetry: Optional[ProductiveNaturalAgeBindingTelemetryV1] = None
+    _last_observation: Optional[NaturalAgeLifecycleObservationV1] = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        venue: str,
+        canonical_instrument_id: str,
+        venue_instrument_id: str,
+        persistence_path: Path | None = None,
+        policy: ResearchEstimateRecomputePolicyV1 | None = None,
+    ) -> "ProductiveNaturalAgeLifecycleCmcBindingHostV1":
+        lifecycle = NaturalAgeProgressionLifecycleHostV1.create(
+            venue=venue,
+            canonical_instrument_id=canonical_instrument_id,
+            venue_instrument_id=venue_instrument_id,
+            persistence_path=persistence_path,
+            policy=policy or build_natural_age_research_recompute_policy_v1(),
+        )
+        return cls(lifecycle=lifecycle)
+
+    @classmethod
+    def restore_from_persistence_v1(
+        cls,
+        *,
+        persistence_path: Path,
+        policy: ResearchEstimateRecomputePolicyV1 | None = None,
+    ) -> "ProductiveNaturalAgeLifecycleCmcBindingHostV1":
+        producer = CanonicalVolatilityTypedRuntimeProducerScaffoldV1.restore_from_persistence_v1(
+            persistence_path=persistence_path,
+        )
+        lifecycle = NaturalAgeProgressionLifecycleHostV1(
+            producer=producer,
+            policy=policy or build_natural_age_research_recompute_policy_v1(),
+        )
+        return cls(
+            lifecycle=lifecycle,
+            _restart_without_estimate=True,
+            _produced_since_start_or_restore=False,
+        )
+
+    @property
+    def producer(self) -> CanonicalVolatilityTypedRuntimeProducerScaffoldV1:
+        return self.lifecycle.producer
+
+    @property
+    def restart_without_estimate(self) -> bool:
+        return bool(self._restart_without_estimate) and not self._produced_since_start_or_restore
+
+    @property
+    def last_telemetry(self) -> Optional[ProductiveNaturalAgeBindingTelemetryV1]:
+        return self._last_telemetry
+
+    @property
+    def last_observation(self) -> Optional[NaturalAgeLifecycleObservationV1]:
+        return self._last_observation
+
+    def apply_to_market_context_v1(
+        self,
+        context: CanonicalMarketContextV1,
+        *,
+        sample: MarketSampleIdentityV1 | None = None,
+        transport: ObservationTransportMetadataV1 | None = None,
+        venue: Any = None,
+        canonical_instrument_id: Any = None,
+        venue_instrument_id: Any = None,
+        event_time_unix_seconds: Any = None,
+        mark_price: Any = None,
+        is_final: Any = True,
+        ingest_sample: bool = False,
+    ) -> ProductiveRuntimeCmcTypedBindingResultV1:
+        cycle_without_sample = not ingest_sample
+        restart_pending_before_cycle = self.restart_without_estimate
+
+        if ingest_sample:
+            obs = self.lifecycle.ingest_finalized_pt1m_mark_sample_v1(
+                sample=sample,
+                transport=transport,
+                venue=venue,
+                canonical_instrument_id=canonical_instrument_id,
+                venue_instrument_id=venue_instrument_id,
+                event_time_unix_seconds=event_time_unix_seconds,
+                mark_price=mark_price,
+                is_final=is_final,
+            )
+        else:
+            obs = self.lifecycle.on_runtime_cycle_without_sample_v1()
+        self._last_observation = obs
+
+        producer_outcome = _map_lifecycle_to_producer_outcome(obs.outcome)
+        first_production_after_restart = False
+        bind_estimate: Optional[CanonicalVolatilityEstimateV1] = None
+
+        if obs.outcome in {
+            LifecycleOutcomeV1.PRODUCED.value,
+            LifecycleOutcomeV1.RECOMPUTED.value,
+        }:
+            if obs.lifecycle_state is None or obs.lifecycle_state.estimate is None:
+                raise NaturalAgeLifecycleErrorV1("produced_without_lifecycle_state")
+            bind_estimate = obs.lifecycle_state.estimate
+            first_production_after_restart = restart_pending_before_cycle
+            self._produced_since_start_or_restore = True
+            self._restart_without_estimate = False
+        elif obs.outcome == LifecycleOutcomeV1.REUSED.value:
+            if obs.lifecycle_state is None or obs.lifecycle_state.estimate is None:
+                raise NaturalAgeLifecycleErrorV1("reuse_without_lifecycle_state")
+            bind_estimate = obs.lifecycle_state.estimate
+            self._produced_since_start_or_restore = True
+            self._restart_without_estimate = False
+        elif obs.outcome in {
+            LifecycleOutcomeV1.DUPLICATE_NOOP.value,
+            LifecycleOutcomeV1.RUNTIME_CYCLE_NOOP.value,
+        }:
+            # Duplicate/runtime must not advance lifecycle counters; may keep prior bind.
+            if self.lifecycle.lifecycle_state is not None and not self.restart_without_estimate:
+                bind_estimate = self.lifecycle.lifecycle_state.estimate
+        else:
+            bind_estimate = None
+
+        fail_reason = _fail_reason_for_lifecycle(
+            obs,
+            has_bind_estimate=bind_estimate is not None,
+            restart_without_estimate=self.restart_without_estimate,
+            cycle_without_sample=cycle_without_sample,
+        )
+
+        bound_context = context
+        typed_binding_performed = False
+        bound_estimate: Optional[CanonicalVolatilityEstimateV1] = None
+        history_price_count = int(len(self.lifecycle.producer.history.records))
+        producer_result = TypedRuntimeProducerResultV1(
+            outcome=producer_outcome,
+            estimate=bind_estimate if obs.age_evaluable else None,
+            history_digest=str(self.lifecycle.producer.history.history_digest),
+            observation_count_prices=history_price_count,
+            as_of_event_time=None if bind_estimate is None else bind_estimate.as_of_event_time,
+            reason=obs.not_evaluable_reason or obs.outcome,
+            sample_digest=obs.source_digest,
+        )
+
+        if (
+            bind_estimate is not None
+            and fail_reason is ProductiveTypedBindingFailClosedReasonV1.NONE
+        ):
+            try:
+                validated = validate_typed_estimate_for_cmc_binding_v1(bind_estimate)
+                _ = validate_canonical_volatility_estimate_v1(validated)
+                bound_context = bind_typed_canonical_volatility_estimate_into_market_context_v1(
+                    context,
+                    validated,
+                )
+                typed_binding_performed = True
+                bound_estimate = bound_context.canonical_volatility_estimate
+                fail_reason = ProductiveTypedBindingFailClosedReasonV1.NONE
+            except (CanonicalVolatilityTypedConsumptionError, ValueError, TypeError) as exc:
+                typed_binding_performed = False
+                bound_estimate = None
+                bound_context = clear_untyped_productive_volatility_float_v1(context)
+                fail_reason = ProductiveTypedBindingFailClosedReasonV1.VALIDATION_REJECTED
+                producer_result = TypedRuntimeProducerResultV1(
+                    outcome=producer_result.outcome,
+                    estimate=None,
+                    history_digest=producer_result.history_digest,
+                    observation_count_prices=producer_result.observation_count_prices,
+                    as_of_event_time=producer_result.as_of_event_time,
+                    reason=f"{producer_result.reason};binding_or_validation_rejected:{exc}",
+                    sample_digest=producer_result.sample_digest,
+                )
+        else:
+            bound_context = clear_untyped_productive_volatility_float_v1(context)
+            typed_binding_performed = False
+            bound_estimate = None
+
+        typed_cutover_fail_closed = not typed_binding_performed
+        reuse_status, restart_status = derive_reuse_and_restart_status_for_age_policy_v1(
+            producer_outcome=producer_outcome.value,
+            cycle_without_sample=cycle_without_sample,
+            estimate_bound=bound_estimate is not None,
+            restart_without_estimate=self.restart_without_estimate,
+            first_production_after_restart=first_production_after_restart,
+        )
+        if obs.outcome == LifecycleOutcomeV1.REUSED.value and bound_estimate is not None:
+            reuse_status = VolatilityReuseStatusV1.DUPLICATE_SAMPLE_REUSE
+            restart_status = VolatilityRestartStatusV1.NOT_APPLICABLE
+        elif (
+            obs.outcome
+            in {
+                LifecycleOutcomeV1.PRODUCED.value,
+                LifecycleOutcomeV1.RECOMPUTED.value,
+            }
+            and bound_estimate is not None
+        ):
+            reuse_status = VolatilityReuseStatusV1.FRESHLY_PRODUCED
+
+        telemetry = ProductiveNaturalAgeBindingTelemetryV1(
+            producer_outcome=obs.outcome,
+            estimate_present=bound_estimate is not None,
+            estimate_as_of_event_time=_as_of_iso(bound_estimate),
+            observation_count=(
+                None if bound_estimate is None else int(bound_estimate.observation_count)
+            ),
+            source_digest=(None if bound_estimate is None else str(bound_estimate.source_digest)),
+            typed_binding_performed=typed_binding_performed,
+            legacy_float_adaptation_owner=LEGACY_ADAPTER_OWNER,
+            fail_closed_reason=fail_reason.value,
+            restart_without_estimate=self.restart_without_estimate,
+            reuse_status=reuse_status.value,
+            restart_status=restart_status.value,
+            max_age_status=MAX_AGE_STATUS,
+            typed_cutover_fail_closed=typed_cutover_fail_closed,
+            history_digest=str(self.lifecycle.producer.history.history_digest),
+            lifecycle_outcome=obs.outcome,
+            natural_age_seconds=obs.age_seconds,
+            distinct_observations_since_recompute=int(obs.distinct_observations_since_recompute),
+            recompute_reason=obs.recompute_reason,
+            estimate_reused=bool(obs.estimate_reused),
+            reuse_count=int(obs.reuse_count),
+            volatility_value=None if bound_estimate is None else float(bound_estimate.value),
+            # Evidence ledger uses research unit labels; typed carrier unit stays on estimate.
+            volatility_unit=None if bound_estimate is None else "DECIMAL_FRACTION",
+            volatility_horizon_seconds=(
+                None if bound_estimate is None else float(bound_estimate.horizon_seconds)
+            ),
+            volatility_estimator=(
+                None if bound_estimate is None else str(bound_estimate.estimator)
+            ),
+            estimate_id=(
+                None if bound_estimate is None else f"est_{str(bound_estimate.source_digest)[:24]}"
+            ),
+        )
+        self._last_telemetry = telemetry
+        typed_binding_eligibility = evaluate_typed_volatility_binding_eligibility_v1(bound_context)
+        return ProductiveRuntimeCmcTypedBindingResultV1(
+            context=bound_context,
+            producer_result=producer_result,
+            telemetry=telemetry,
+            typed_cutover_fail_closed=typed_cutover_fail_closed,
+            bound_estimate=bound_estimate,
+            typed_binding_eligibility=typed_binding_eligibility,
+        )
+
+
+def assert_natural_age_lifecycle_productive_binding_guards_v1(
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    root = repo_root or Path(__file__).resolve().parents[3]
+    binding_path = root / (
+        "src/research/canonical_volatility_numeric_max_age_natural_age_progression_"
+        "and_actionable_strata_evidence_plan_v1/productive_natural_age_lifecycle_binding_v1.py"
+    )
+    runner_path = root / (
+        "src/research/canonical_volatility_max_age_productive_research_evidence_"
+        "accumulation_v1/productive_bridge_runner_v1.py"
+    )
+    binding_src = binding_path.read_text(encoding="utf-8")
+    runner_src = runner_path.read_text(encoding="utf-8")
+
+    if "ProductiveNaturalAgeLifecycleCmcBindingHostV1" not in runner_src:
+        raise RuntimeError("NATURAL_AGE_LIFECYCLE_HOST_NOT_BOUND_IN_PRODUCTIVE_RUNNER")
+    if "CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1.create" in runner_src:
+        raise RuntimeError("LEGACY_CMC_BINDING_HOST_STILL_CREATED_IN_PRODUCTIVE_RUNNER")
+    if "NaturalAgeProgressionLifecycleHostV1" not in binding_src:
+        raise RuntimeError("LIFECYCLE_HOST_MISSING_FROM_BINDING_ADAPTER")
+    if SECOND_AGE_AUTHORITY_PRESENT or SECOND_DECISION_AUTHORITY_PRESENT:
+        raise RuntimeError("SECOND_AUTHORITY_FLAG_DRIFT")
+    if not NATURAL_AGE_LIFECYCLE_HOST_PRODUCTIVE_BOUND:
+        raise RuntimeError("NATURAL_AGE_LIFECYCLE_HOST_PRODUCTIVE_BOUND_DRIFT")
+    if not LEGACY_PER_SAMPLE_REMATERIALIZATION_UNREACHABLE:
+        raise RuntimeError("LEGACY_REMATERIALIZATION_GUARD_DRIFT")
+
+    return {
+        "NATURAL_AGE_LIFECYCLE_HOST_PRODUCTIVE_BOUND": True,
+        "LEGACY_PER_SAMPLE_REMATERIALIZATION_UNREACHABLE": True,
+        "SECOND_AGE_AUTHORITY_PRESENT": False,
+        "SECOND_DECISION_AUTHORITY_PRESENT": False,
+        "guards_pass": True,
+        "capability_id": CAPABILITY_ID,
+        "package_marker": PACKAGE_MARKER,
+    }

--- a/tests/research/test_canonical_volatility_numeric_max_age_productive_bridge_natural_age_lifecycle_wiring_v1.py
+++ b/tests/research/test_canonical_volatility_numeric_max_age_productive_bridge_natural_age_lifecycle_wiring_v1.py
@@ -1,0 +1,424 @@
+"""Productive bridge natural-age lifecycle wiring capability tests."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from research.canonical_volatility_max_age_productive_research_evidence_accumulation_v1.architecture_guards_v1 import (
+    assert_architecture_guards_v1 as assert_productive_accumulation_guards_v1,
+)
+from research.canonical_volatility_max_age_productive_research_evidence_accumulation_v1.counterfactual_grid_v1 import (
+    evaluate_counterfactual_age_grid_batch_v1,
+)
+from research.canonical_volatility_max_age_productive_research_evidence_accumulation_v1.session_v1 import (
+    open_productive_evidence_session_v1,
+)
+from research.canonical_volatility_max_age_productive_research_evidence_accumulation_v1.ledger_v1 import (
+    valid_productive_records_from_ledger_v1,
+)
+from research.canonical_volatility_max_age_productive_research_evidence_accumulation_v1.productive_bridge_runner_v1 import (
+    run_productive_bridge_accumulation_session_v1,
+)
+from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1 import (
+    NaturalAgeProgressionLifecycleHostV1,
+    assert_architecture_guards_v1,
+    assert_natural_age_lifecycle_productive_binding_guards_v1,
+    assign_age_bucket_v1,
+    compute_natural_age_seconds_v1,
+    evaluate_counterfactual_candidate_impact_v1,
+    project_actionable_alpha_strata_v1,
+    project_safety_risk_exit_observability_v1,
+)
+from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.constants_v1 import (
+    DOUBLE_PLAY_LOGIC_CHANGED,
+    MASTER_V2_LOGIC_CHANGED,
+    RESEARCH_RECOMPUTE_MINIMUM_EVENT_TIME_ELAPSED_SECONDS,
+    RESEARCH_RECOMPUTE_MINIMUM_NEW_DISTINCT_OBSERVATIONS,
+)
+from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.lifecycle_contract_v1 import (
+    LifecycleOutcomeV1,
+    NaturalAgeLifecycleErrorV1,
+)
+from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.productive_natural_age_lifecycle_binding_v1 import (
+    CAPABILITY_ID,
+    LEGACY_PER_SAMPLE_REMATERIALIZATION_UNREACHABLE,
+    NATURAL_AGE_LIFECYCLE_HOST_PRODUCTIVE_BOUND,
+    SECOND_AGE_AUTHORITY_PRESENT,
+    SECOND_DECISION_AUTHORITY_PRESENT,
+)
+from research.canonical_volatility_numeric_max_age_natural_age_progression_and_actionable_strata_evidence_plan_v1.recompute_policy_v1 import (
+    evaluate_recompute_decision_v1,
+    build_natural_age_research_recompute_policy_v1,
+)
+from trading.market_state.distinct_market_observation_acceptor_v1 import (
+    ObservationTransportMetadataV1,
+)
+from trading.market_state.time_sample_epoch_semantics_v1 import (
+    EventTimeInstantV1,
+    MarketSampleIdentityV1,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+REPO_SHA = "51a3625b3666bc905b89ba9a8ad1bcfe84494430"
+VENUE = "okx"
+CANON = "ETH-USD_UM_XPERP-310404"
+VENUE_INST = "ETH-USD_UM_XPERP-310404"
+T0 = 1_700_000_000.0
+REQUIRED_AGE_BUCKETS = (0, 60, 120, 300, 600, 900, 1800, 3600, 7200)
+SESSION_02_LEDGER = ROOT / (
+    "docs/evidence/canonical_volatility_max_age_productive_research_evidence_ledger_v1/"
+    "campaigns/cv_maxage_productive_evidence_campaign_v1_4b3bdcecab2c0bfe/"
+    "sessions/session_02_manifest.json"
+)
+
+
+def _price_at(i: int) -> float:
+    import math
+
+    return 100.0 * math.exp(0.001 * i)
+
+
+def _sample(i: int) -> MarketSampleIdentityV1:
+    return MarketSampleIdentityV1(
+        venue=VENUE,
+        canonical_instrument_id=CANON,
+        venue_instrument_id=VENUE_INST,
+        event_time=EventTimeInstantV1(unix_seconds=T0 + float(i * 60)),
+        mark_price=_price_at(i),
+    )
+
+
+def _host(tmp_path: Path | None = None) -> NaturalAgeProgressionLifecycleHostV1:
+    path = None if tmp_path is None else tmp_path / "mark_history.json"
+    return NaturalAgeProgressionLifecycleHostV1.create(
+        venue=VENUE,
+        canonical_instrument_id=CANON,
+        venue_instrument_id=VENUE_INST,
+        persistence_path=path,
+    )
+
+
+def _ingest(host: NaturalAgeProgressionLifecycleHostV1, i: int):
+    return host.ingest_finalized_pt1m_mark_sample_v1(
+        sample=_sample(i),
+        transport=ObservationTransportMetadataV1(receive_time=T0 + i * 60 + 0.5),
+    )
+
+
+def _warmup_to_first_produce(host: NaturalAgeProgressionLifecycleHostV1):
+    for i in range(0, 60):
+        obs = _ingest(host, i)
+        assert obs.outcome == LifecycleOutcomeV1.WARMUP.value
+    produced = _ingest(host, 60)
+    assert produced.outcome == LifecycleOutcomeV1.PRODUCED.value
+    return produced
+
+
+def _fingerprint_session_02() -> str | None:
+    if not SESSION_02_LEDGER.exists():
+        return None
+    digest = hashlib.sha256()
+    digest.update(SESSION_02_LEDGER.read_bytes())
+    parent = SESSION_02_LEDGER.parent
+    for path in sorted(parent.rglob("*")):
+        if path.is_file() and path.suffix != ".lock":
+            digest.update(path.relative_to(parent).as_posix().encode())
+            digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+SESSION_02_FINGERPRINT_BEFORE = _fingerprint_session_02()
+
+
+def test_unit_first_produce_age_zero_distinct_zero() -> None:
+    host = _host()
+    produced = _warmup_to_first_produce(host)
+    assert produced.age_seconds == 0.0
+    assert produced.distinct_observations_since_recompute == 0
+    assert produced.as_of_event_time is not None
+
+
+def test_unit_plus_60_distinct_reuse() -> None:
+    host = _host()
+    produced = _warmup_to_first_produce(host)
+    reused = _ingest(host, 61)
+    assert reused.outcome == LifecycleOutcomeV1.REUSED.value
+    assert reused.age_seconds == 60.0
+    assert reused.distinct_observations_since_recompute == 1
+    assert reused.as_of_event_time == produced.as_of_event_time
+
+
+def test_unit_duplicate_full_noop() -> None:
+    host = _host()
+    _warmup_to_first_produce(host)
+    first = _ingest(host, 61)
+    dup = _ingest(host, 61)
+    assert dup.outcome == LifecycleOutcomeV1.DUPLICATE_NOOP.value
+    assert dup.reuse_count == first.reuse_count
+    assert dup.distinct_observations_since_recompute == first.distinct_observations_since_recompute
+    assert dup.age_seconds is None
+
+
+def test_unit_out_of_order_no_advance() -> None:
+    host = _host()
+    produced = _warmup_to_first_produce(host)
+    _ingest(host, 65)
+    before = host.lifecycle_state
+    assert before is not None
+    ooo = _ingest(host, 63)
+    assert ooo.outcome == LifecycleOutcomeV1.OUT_OF_ORDER_NOT_EVALUABLE.value
+    after = host.lifecycle_state
+    assert after is not None
+    assert after.as_of_event_time == before.as_of_event_time
+    assert (
+        after.distinct_observations_since_recompute == before.distinct_observations_since_recompute
+    )
+    assert after.as_of_event_time.isoformat() == produced.as_of_event_time
+
+
+def test_unit_warmup_no_artificial_age() -> None:
+    host = _host()
+    warm = _ingest(host, 0)
+    assert warm.outcome == LifecycleOutcomeV1.WARMUP.value
+    assert warm.age_seconds is None
+    assert warm.age_evaluable is False
+    assert host.lifecycle_state is None
+
+
+def test_unit_reuse_sequence_to_age_7200_and_no_early_recompute() -> None:
+    host = _host()
+    produced = _warmup_to_first_produce(host)
+    policy = build_natural_age_research_recompute_policy_v1()
+    assert policy.minimum_new_distinct_observations == (
+        RESEARCH_RECOMPUTE_MINIMUM_NEW_DISTINCT_OBSERVATIONS
+    )
+    assert policy.minimum_event_time_elapsed_seconds == (
+        RESEARCH_RECOMPUTE_MINIMUM_EVENT_TIME_ELAPSED_SECONDS
+    )
+    ages: list[float] = [0.0]
+    for offset in range(1, 121):
+        obs = _ingest(host, 60 + offset)
+        assert obs.outcome == LifecycleOutcomeV1.REUSED.value, offset
+        assert obs.as_of_event_time == produced.as_of_event_time
+        assert obs.age_seconds == float(offset * 60)
+        ages.append(float(obs.age_seconds))
+        # Decision before reuse increment: at age 7200 prior.distinct was 119.
+        if offset == 120:
+            assert obs.distinct_observations_since_recompute == 120
+            assert obs.age_seconds == 7200.0
+    assert 7200.0 in ages
+    # No recompute before age 7200.
+    assert all(a < 7200.0 or a == 7200.0 for a in ages)
+    assert host.lifecycle_state is not None
+    last = host.last_observation
+    assert last is not None and last.market_event_time is not None
+    # At exactly 7200 elapsed with distinct=120: elapsed < 7201 and distinct < 121 => REUSE.
+    decision = evaluate_recompute_decision_v1(
+        policy=policy,
+        prior_state=host.lifecycle_state,
+        current_market_event_time=last.market_event_time,
+        newly_materialized_source_digest="ignored-slide",
+    )
+    assert decision[0] is False
+
+
+def test_unit_recompute_after_contract_resets_state() -> None:
+    host = _host()
+    produced = _warmup_to_first_produce(host)
+    for offset in range(1, 121):
+        _ingest(host, 60 + offset)
+    recomputed = _ingest(host, 60 + 121)
+    assert recomputed.outcome == LifecycleOutcomeV1.RECOMPUTED.value
+    assert recomputed.age_seconds == 0.0
+    assert recomputed.distinct_observations_since_recompute == 0
+    assert recomputed.as_of_event_time != produced.as_of_event_time
+    assert recomputed.source_digest != produced.source_digest
+
+
+def test_unit_negative_age_fail_closed() -> None:
+    with pytest.raises(NaturalAgeLifecycleErrorV1, match="negative_age"):
+        compute_natural_age_seconds_v1(
+            market_event_time="2026-08-01T00:00:00+00:00",
+            as_of_event_time="2026-08-01T00:01:00+00:00",
+        )
+
+
+def test_unit_missing_lifecycle_state_fail_closed_in_evidence_producer() -> None:
+    from research.canonical_volatility_max_age_productive_research_evidence_accumulation_v1.models_v1 import (
+        ProductiveEvidenceAccumulationError,
+    )
+    from research.canonical_volatility_max_age_productive_research_evidence_accumulation_v1.producer_v1 import (
+        produce_productive_research_evidence_from_cycle_v1,
+    )
+
+    session = open_productive_evidence_session_v1(
+        session_id="missing-lifecycle",
+        session_start_event_time="2023-11-14T22:13:20+00:00",
+        repository_sha=REPO_SHA,
+        venue="okx_europe",
+        canonical_instrument_id=CANON,
+        venue_instrument_id=CANON,
+    )
+    cycle = {
+        "session_id": "missing-lifecycle",
+        "cycle_id": "c1",
+        "instrument_id": CANON,
+        "venue": "okx_europe",
+        "venue_instrument_id": CANON,
+        "decision_outcome": "hold",
+        "selected_side": "none",
+        "canonical_volatility_typed_binding": {
+            "estimate_present": True,
+            "natural_age_lifecycle_host_bound": True,
+            "natural_age_seconds": None,
+            "estimate_as_of_event_time": "2023-11-14T23:13:20+00:00",
+            "source_digest": "abc123",
+            "volatility_value": 0.01,
+            "volatility_unit": "DECIMAL_FRACTION",
+            "volatility_horizon_seconds": 3600,
+            "volatility_estimator": "TYPED",
+            "observation_count": 60,
+            "estimate_id": "est_abc123",
+        },
+        "double_play_typed_volatility_presence_gate": {
+            "max_age_policy_evidence": {
+                "reference_event_time": "2023-11-14T23:13:20+00:00",
+                "estimate_as_of_event_time": "2023-11-14T23:13:20+00:00",
+                "computed_age_seconds": 0.0,
+                "clock_trust_status": "TRUSTED",
+                "data_integrity_status": "TRUSTED",
+                "presence_status": "PRESENT",
+                "source_digest": "abc123",
+            }
+        },
+        "feature_regime": {"volatility_estimate": 0.01},
+        "productive_bridge_cycle_authority": {
+            "authority_id": (
+                "MASTER_V2_FULL_CANONICAL_DECISION_TO_SIMULATED_ECONOMICS_"
+                "HARDENED_BRIDGE_CYCLE_OUTPUT"
+            ),
+            "source_is_authoritative_bridge_cycle": True,
+            "synthetic": False,
+            "fixture": False,
+            "test_data": False,
+            "campaign_id": "c",
+            "market_sample_id": "msi_x",
+            "repository_sha": REPO_SHA,
+        },
+    }
+    with pytest.raises(
+        ProductiveEvidenceAccumulationError,
+        match="natural_age_lifecycle_state_missing",
+    ):
+        produce_productive_research_evidence_from_cycle_v1(
+            cycle, session=session, repository_sha=REPO_SHA
+        )
+
+
+def test_productive_bridge_integration_age_buckets_recompute_and_consumers(
+    tmp_path: Path,
+) -> None:
+    import math
+
+    from research.canonical_volatility_max_age_productive_research_evidence_accumulation_v1.productive_bridge_runner_v1 import (
+        ProductiveBridgeMarketSampleV1,
+    )
+
+    prod = tmp_path / "prod.jsonl"
+    join = tmp_path / "join.jsonl"
+    q = tmp_path / "q.jsonl"
+    persist = tmp_path / "persist.json"
+    # warmup(60) + produce + 120 reuse to 7200 + 1 recompute = 182 samples.
+    # Explicit max_cycles override (preregistration default remains 128).
+    start_unix = 1_700_000_000.0
+    samples = [
+        ProductiveBridgeMarketSampleV1(
+            mark_price=float(100.0 * math.exp(0.001 * i)),
+            event_time_unix_seconds=float(start_unix + i * 60.0),
+            receive_time_unix_seconds=float(start_unix + i * 60.0 + 0.5),
+        )
+        for i in range(182)
+    ]
+    report = run_productive_bridge_accumulation_session_v1(
+        session_id="natage-bridge-s1",
+        campaign_id="campaign_natage_bridge_v1",
+        repository_sha=REPO_SHA,
+        samples=samples,
+        repo_root=ROOT,
+        productive_ledger_path=prod,
+        join_ledger_path=join,
+        quarantine_ledger_path=q,
+        typed_volatility_persistence_path=persist,
+        require_campaign_authorization=False,
+        max_cycles=182,
+    )
+    assert report["status"] == "PASS"
+    records = valid_productive_records_from_ledger_v1(prod)
+    ages = [float(r.age_seconds) for r in records]
+    assert ages[0] == 0.0
+    for bucket in REQUIRED_AGE_BUCKETS:
+        assert bucket in ages, f"missing age bucket {bucket}"
+    # Exactly one initial produce identity until recompute.
+    first_as_of = records[0].as_of_event_time
+    reused_block = [r for r in records if r.as_of_event_time == first_as_of]
+    assert reused_block[0].age_seconds == 0.0
+    assert max(float(r.age_seconds) for r in reused_block) == 7200.0
+    recomputed = [r for r in records if r.as_of_event_time != first_as_of]
+    assert recomputed, "expected recompute after contract boundary"
+    assert float(recomputed[0].age_seconds) == 0.0
+
+    # Evidence projections consume canonical ages unchanged (consumers, not authority).
+    for rec in records:
+        payload = rec.to_dict()
+        assert float(payload["age_seconds"]) == float(rec.age_seconds)
+        strata = project_actionable_alpha_strata_v1(productive_record=payload)
+        assert strata.age_bucket == assign_age_bucket_v1(float(rec.age_seconds))
+        assert strata.second_decision_authority is False
+        obs = project_safety_risk_exit_observability_v1(
+            strata=strata, counterfactual_stale=float(rec.age_seconds) > 60.0
+        )
+        assert obs.alpha_only_counterfactual_block is True
+        assert obs.exit_counterfactual_block is False
+        assert obs.risk_counterfactual_block is False
+        assert obs.safety_counterfactual_block is False
+
+    grid = evaluate_counterfactual_age_grid_batch_v1(records)
+    assert grid["record_count"] == len(records)
+    assert len(grid["research_age_candidate_grid_seconds"]) >= 8
+    impact = evaluate_counterfactual_candidate_impact_v1([r.to_dict() for r in records])
+    assert impact["candidate_discrimination_observed"] is True
+    buckets = {assign_age_bucket_v1(a) for a in ages}
+    assert "AGE_LE_7200_S" in buckets
+    assert len({float(a) for a in ages}) >= len(REQUIRED_AGE_BUCKETS)
+
+
+def test_architecture_guards_and_non_goals() -> None:
+    guards = assert_architecture_guards_v1(repo_root=ROOT)
+    assert guards["guards_pass"] is True
+    assert guards["NATURAL_AGE_LIFECYCLE_HOST_PRODUCTIVE_BOUND"] is True
+    assert guards["LEGACY_PER_SAMPLE_REMATERIALIZATION_UNREACHABLE"] is True
+    assert guards["SECOND_AGE_AUTHORITY_PRESENT"] is False
+    assert guards["SECOND_DECISION_AUTHORITY_PRESENT"] is False
+    assert guards["MASTER_V2_LOGIC_CHANGED"] is False
+    assert guards["DOUBLE_PLAY_LOGIC_CHANGED"] is False
+    binding = assert_natural_age_lifecycle_productive_binding_guards_v1(repo_root=ROOT)
+    assert binding["guards_pass"] is True
+    assert NATURAL_AGE_LIFECYCLE_HOST_PRODUCTIVE_BOUND is True
+    assert LEGACY_PER_SAMPLE_REMATERIALIZATION_UNREACHABLE is True
+    assert SECOND_AGE_AUTHORITY_PRESENT is False
+    assert SECOND_DECISION_AUTHORITY_PRESENT is False
+    assert MASTER_V2_LOGIC_CHANGED is False
+    assert DOUBLE_PLAY_LOGIC_CHANGED is False
+    assert CAPABILITY_ID.endswith("NATURAL_AGE_LIFECYCLE_WIRING_V1")
+    prod_guards = assert_productive_accumulation_guards_v1(repo_root=ROOT)
+    assert prod_guards["guards_pass"] is True
+
+
+def test_session_02_evidence_unchanged() -> None:
+    after = _fingerprint_session_02()
+    if SESSION_02_FINGERPRINT_BEFORE is None:
+        pytest.skip("session_02 evidence root not present locally")
+    assert after == SESSION_02_FINGERPRINT_BEFORE


### PR DESCRIPTION
## Summary

- **Baseline-SHA:** `origin/main@2e1a81bfca0867bdb7c7ac676646a01cd0cfd41c`
- **Scope:** Bind `NaturalAgeProgressionLifecycleHostV1` fail-closed into the productive Canonical-Volatility evidence bridge/runner path as the sole produce/reuse/recompute authority, so natural ages accumulate across distinct PT1M observations.
- **Call-Graph vorher:** productive bridge used `CanonicalVolatilityProductiveRuntimeCmcTypedBindingHostV1` → scaffold rematerialized every distinct sample → `as_of == market_event_time` → `age_seconds=0`.
- **Call-Graph nachher:** `run_productive_bridge_accumulation_session_v1` installs `ProductiveNaturalAgeLifecycleCmcBindingHostV1` → `NaturalAgeProgressionLifecycleHostV1` + `evaluate_recompute_decision_v1` → immutable reused estimate bound into CMC → `age_seconds = market_event_time - as_of_event_time` → evidence/join/counterfactual/strata/safety consumers project age unchanged.
- **Age-7200-Reachability:** PT1M reuse keeps first produce `as_of`; at +7200s (`prior.distinct=119`, `elapsed=7200`) decision remains `REUSE` (`after.distinct=120`, `age_seconds=7200`).
- **Recompute-Boundary:** unchanged research contract `distinct >= 121 OR elapsed >= 7201`; decision before reuse increment; next eligible sample yields `RECOMPUTED` with `age=0`, `distinct=0`, new immutable `as_of`.
- **Fail-closed-Invarianten:** missing/inconsistent lifecycle age rejects evidence accumulation; negative age rejected; duplicate/OOO/warmup/runtime-cycle do not synthesize age or advance distinct counters; no wallclock/sleep/timestamp injection; Session-02 evidence byte-stable.
- **Tests:** unit lifecycle matrix (first produce, +60 reuse, duplicate, OOO, warmup, age-7200 sequence, no early recompute, post-boundary recompute/reset, negative age, missing lifecycle); productive bridge integration with age buckets `0,60,120,300,600,900,1800,3600,7200` + recompute + consumer projections; architecture guards; session-runner / authorization / rate-limit regressions.
- **Non-Goals:** no numeric max-age selection/enforcement; no Master-V2 / Double-Play / Bull / Bear / Entry-Exit / Risk / Safety mutation; no second decision authority; no authorization issuance/consumption; no preregistration creation; no productive session execution; no network requests; no Session-02 / historical ledger mutation.
- **Session-02-Unverändertheit:** local untracked evidence fingerprint unchanged across branch creation and commit.
- **Hard stop:** no merge without separate owner order; not ready for authorization/preregistration/session/policy decision.

## Test plan

- [x] `pytest tests/research/test_canonical_volatility_numeric_max_age_productive_bridge_natural_age_lifecycle_wiring_v1.py`
- [x] Natural-age plan + productive bridge binding + preregistered runner + campaign authorization + public-MD rate-limit regressions
- [x] Architecture guards (`NATURAL_AGE_LIFECYCLE_HOST_PRODUCTIVE_BOUND`, no second age/decision authority)
- [x] Docs reference targets + capability docs token check path
- [x] PR-bounded local timing batch (~42s wallclock; budget 840s)


Made with [Cursor](https://cursor.com)