### PR TITLE
feat(governance): Deferred-Work Recovery Register + Rotation-Policy Wiedervorlage (Capability 0.4)

### DIFF
--- a/docs/governance/PEAK_TRADE_CANONICAL_RUNTIME_TRUTH_MAP_V1.md
+++ b/docs/governance/PEAK_TRADE_CANONICAL_RUNTIME_TRUTH_MAP_V1.md
@@ -238,7 +238,7 @@ numeric max-age non-enforcing; `BOUND_NOT_ACTIVATED` unchanged.
 5. Restart/recovery proof for productive runtime
 6. Strategy registry full productive binding
 7. Config truth alignment for `max_open_positions` effective consumers — **closed by Capability 0.3** (`CONFIG_TRUTH_ALIGNMENT_V1`)
-8. Active-set rotation policy is deferred design reminder only (not productive Top-5)
+8. Active-set rotation policy — **registered by Capability 0.4** as `DEFERRED_REQUIRED_CAPABILITY` in `PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1` / `docs/governance/deferred_work_recovery_register_v1.json` (Phase 6; not productive Top-5; implementation/activation unauthorized; prior reminder remains `REMINDER_ONLY`)
 
 ### 3.7 Last verifiable evidence anchors
 
@@ -280,7 +280,8 @@ Primary target/governance SSOT documents:
 
 - `docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.12.md` — `DOCUMENT_CLASS=TARGET_ARCHITECTURE` (contains Phase-1 safety bounds that remain currently binding)
 - `docs/architecture/PEAK_TRADE_CANONICAL_UNIFIED_TRADING_SYSTEM_RUNBOOK_V2_6.md` — `DOCUMENT_CLASS=TARGET_ARCHITECTURE`
-- `docs/planning/deferred/MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md` — deferred required capability reminder (not productive Top-5)
+- `docs/governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md` + `docs/governance/deferred_work_recovery_register_v1.json` — canonical Deferred-Work Recovery Register (Capability 0.4; `MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0` = `DEFERRED_REQUIRED_CAPABILITY`; not productive Top-5)
+- `docs/planning/deferred/MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md` — `REMINDER_ONLY` surface; authority superseded by the canonical register
 
 **Forbidden reading:** Do not treat target architecture, DTOs, offline tests, or deactivated bindings as activated runtime capabilities.
 
@@ -358,7 +359,8 @@ Legend for `DOCUMENT_CLASS_*`:
 | `docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md` | CURRENT | CURRENT | contract v0 | MARKET_DASHBOARD_AUTHORITY=false | lane taxonomy | authority levels | none | none material | DOCUMENT_CLASS | yes |
 | `docs/ops/specs/RECONCILIATION_FLOW_SPEC.md` | TARGET/spec | TARGET | spec | pilot/safety recon | recon flow | safety | not productive host-bound | productive recon unbound | DOCUMENT_CLASS=TARGET_ARCHITECTURE | yes |
 | `docs/ops/runbooks/STEP_29U_CANONICAL_BINDING_AND_IMPLEMENTATION_INVENTORY_V0.md` | CURRENT | CURRENT | inventory | reconciliation PRESENT_BUT_UNBOUND | later bind | none live | none | none | DOCUMENT_CLASS | yes |
-| `docs/planning/deferred/MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md` | deferred reminder | TARGET/deferred | reminder | IMPLEMENTATION_STARTED=false | Top20→TopN later | ranking≠authority | none | Top-5 must not be called productive/regressed | DOCUMENT_CLASS=TARGET_ARCHITECTURE + deferred marker | yes |
+| `docs/governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md` / `docs/governance/deferred_work_recovery_register_v1.json` | CURRENT register | CURRENT | Capability 0.4 | CURRENT_RUNTIME_EFFECT=NONE | Phase-6 deferred rotation | register only | none | Top-5 not productive; multi-future unauthorized | create + register rotation workstream | yes |
+| `docs/planning/deferred/MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md` | deferred reminder | REMINDER_ONLY | reminder | IMPLEMENTATION_STARTED=false | Top20→TopN later | ranking≠authority | none | Top-5 must not be called productive/regressed; authority superseded by Deferred-Work Register | DOCUMENT_CLASS=TARGET_ARCHITECTURE + deferred marker + register pointer | yes |
 | `docs/PHASE_42_TOPN_PROMOTION.md` | HIST/TARGET risk | HIST | phase doc | promotion language risk | TopN | INSUFFICIENT_EVIDENCE | INSUFFICIENT_EVIDENCE | may over-claim TopN readiness | DOCUMENT_CLASS=HISTORICAL; no Top5 productive claim | yes |
 | `docs&#47;ops&#47;specs&#47;MASTER_V2_CANONICAL_VOLATILITY_*` (family) | research/CURRENT | CURRENT research | many | watchdog/research | later enforcement discussion only | non-enforcing | research sessions only | enforcement must stay false | no enforcement uplift; family noted | partial (family rule in Truth Map; no mass rewrite) |
 | `docs/webui/observability/UNIVERSE_SELECTION_READMODEL_V1.md` | CURRENT readmodel | CURRENT | webui | universe readmodel | selection UI | not trading authority | none | ranking≠trading authority | DOCUMENT_CLASS + authority false note | yes |

--- a/docs/governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md
+++ b/docs/governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md
@@ -1,0 +1,106 @@
+# PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1
+
+---
+docs_token: DOCS_TOKEN_PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1
+STATUS: CAPABILITY_AVAILABLE
+scope: Deferred-Work Recovery Register and Rotation-Policy resubmission (Capability 0.4); governance recovery only
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+RUNTIME_ACTIVATION_ALLOWED: false
+MULTI_FUTURE_RUNTIME_AUTHORIZED: false
+IMPLEMENTATION_AUTHORIZED: false
+ACTIVATION_AUTHORIZED: false
+CORE_LOGIC_CHANGE: false
+ACTIVATION_STATE: BOUND_NOT_ACTIVATED
+HARD_STOP: true
+DOCUMENT_CLASS: CURRENT_RUNTIME_TRUTH
+---
+
+```text
+REGISTER_ID=PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1
+CAPABILITY_RECOVERY_ID=CAPABILITY_0_4_DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1
+MACHINE_READABLE_SSOT=docs/governance/deferred_work_recovery_register_v1.json
+AUTHORITY_OWNER=ops.deferred_work_recovery_register_contract_v1
+PARALLEL_REGISTER_FORBIDDEN=true
+CURRENT_RUNTIME_CHANGED=false
+```
+
+## Purpose
+
+Canonical Deferred-Work Recovery Register for Peak Trade.
+
+This surface formally re-admits forgotten or reminder-only required capabilities into the active trading roadmap with owner, dependencies, review trigger, and target phase — without authorizing implementation or activation.
+
+## Semantic guards (must remain true)
+
+```text
+TOP20_IS_CONTEXT_ONLY=true
+SINGLE_SELECTED_FUTURE_IS_CURRENT_AUTHORITY=true
+TOP_N_ACTIVE_SET_IS_DEFERRED=true
+TOP5_PRODUCTIVE=false
+TOP5_REGRESSED=false
+MULTI_FUTURE_IMPLEMENTED=false
+MULTI_FUTURE_AUTHORIZED=false
+MULTI_FUTURE_RUNTIME_AUTHORIZED=false
+MAX_POSITIONS_EFFECTIVE=1
+PHASE_1_SELECTION=SINGLE_SELECTED_FUTURE
+PHASE_1_MAX_POSITIONS=1
+ROTATION_POLICY_RATIFIED=false
+ROTATION_IMPLEMENTATION_STARTED=false
+CURRENT_RUNTIME_CHANGED=false
+DASHBOARD_RANKING_IS_RUNTIME_AUTHORITY=false
+```
+
+## Registered deferred required capability
+
+### MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0
+
+| Field | Value |
+|---|---|
+| CLASSIFICATION | `DEFERRED_REQUIRED_CAPABILITY` |
+| CURRENT_STATE | `POLICY_NOT_RATIFIED_IMPLEMENTATION_NOT_AUTHORIZED` |
+| TARGET_STATE | `ROTATION_POLICY_RATIFIED_READY_FOR_SEPARATE_IMPLEMENTATION_GO` |
+| TARGET_PHASE | `PHASE_6` |
+| IMPLEMENTATION_AUTHORIZED | `false` |
+| ACTIVATION_AUTHORIZED | `false` |
+| CURRENT_RUNTIME_EFFECT | `NONE` |
+| PHASE_1_SELECTION | `SINGLE_SELECTED_FUTURE` |
+| PHASE_1_MAX_POSITIONS | `1` |
+| MULTI_FUTURE_RUNTIME_AUTHORIZED | `false` |
+
+**Owner requirement (summary):** dynamically evaluated futures universe; ranking as context; later controlled promotion/demotion; replacement hysteresis; state retention for open positions (no hard removal with open position); global risk/capital allocation; per-instrument state isolation; restart/recovery semantics; Top-N-capable target architecture; a later first ratified configuration may use `N=5`; Top-5 is currently neither productive nor activated.
+
+**Trading-path value:**
+
+```text
+Universe
+→ Ranking
+→ spätere Active-Set Selection
+→ per-instrument Market State
+→ Master V2
+→ Double Play
+→ Global Risk
+→ Global Safety
+→ Intent Arbitration
+→ Execution
+```
+
+This Capability 0.4 registration only prevents the required later work from being forgotten again. It does **not** change the current trading path.
+
+**Blocking dependencies:** Productive Reconciliation Runtime Closure; Governed Futures Universe Authority; Productive Ranking Authority; Single Selected Future Persistence; Single Selected Future Restart Recovery; Futures Accounting Runtime Closure; Per-Instrument State Isolation Design; Global Portfolio Risk Design; Global Safety Arbitration; Single Global Execution Writer; Canonical Runtime Pre-Activation Closure.
+
+**Review trigger (event-based):** Review immediately after successful closure and merge of (1) Productive Reconciliation, (2) Single Selected Future Authority and Runtime Binding, (3) Futures Accounting Runtime Wiring, (4) Canonical Runtime Pre-Activation Closure.
+
+**Open policy decisions for later ratification** (not decided here): `active_set_size`, `candidate_set_size`, ranking refresh cadence, promotion/demotion thresholds, replacement margin, distinct-observation confirmation, hysteresis, cooldown, minimum active/candidate duration, data-quality disqualification, stale/invalid instrument behavior, open-position demotion semantics, instrument lifecycle states (`ACTIVE_ALPHA`, `ACTIVE_POSITION_ONLY`, `DEMOTION_PENDING`, `EXIT_ONLY`, `RETIRED`), capital allocation, correlation budget, concentration limits, gross/net exposure, maximum concurrent positions, liquidity-adjusted sizing, state persistence, restart reconstruction, per-instrument reconciliation, deterministic replay, evidence and verifier requirements.
+
+## Reminder surface (non-authority)
+
+`docs/planning/deferred/MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md` remains `REMINDER_ONLY`. Authority for deferred registration is this register.
+
+## Related surfaces
+
+- Capability closure runbook: `docs/governance/Peak_Trade_Canonical_Capability_Closure_Runtime_Recovery_Trading_Path_Runbook_V1_2_Trading_First.md` (Capability 0.4 / Phase 6)
+- Runtime Truth Map: `docs/governance/PEAK_TRADE_CANONICAL_RUNTIME_TRUTH_MAP_V1.md`
+- Capability spec: `docs/ops/specs/DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1.md`
+- Contract owner: `src/ops/deferred_work_recovery_register_contract_v1.py`
+- Tests: `tests/governance/test_deferred_work_recovery_register_v1.py`

--- a/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
+++ b/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
@@ -118,6 +118,7 @@ Weitere Architektur-Landkarten (deep dives, keine parallele Trading-SSOT):
 | Dokument | Rolle |
 |----------|-------|
 | [`PEAK_TRADE_CANONICAL_RUNTIME_TRUTH_MAP_V1.md`](PEAK_TRADE_CANONICAL_RUNTIME_TRUTH_MAP_V1.md) | Canonical Runtime Ist-Zustand (CURRENT_RUNTIME_TRUTH; non-authorizing) |
+| [`PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md`](PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md) | Deferred-Work Recovery Register (Capability 0.4; Rotation-Policy Wiedervorlage; non-activating) |
 | [`docs/ops/specs/REAL_MARKET_247_RUNTIME_ARCHITECTURE_V1.md`](../ops/specs/REAL_MARKET_247_RUNTIME_ARCHITECTURE_V1.md) | Runtime-Architektur |
 | [`docs/ops/runbooks/README.md`](../ops/runbooks/README.md) | Ops-Runbooks-Index |
 | [`docs/ops/RUNBOOK_INDEX.md`](../ops/RUNBOOK_INDEX.md) | Runbook-Index |

--- a/docs/governance/Peak_Trade_Canonical_Capability_Closure_Runtime_Recovery_Trading_Path_Runbook_V1_2_Trading_First.md
+++ b/docs/governance/Peak_Trade_Canonical_Capability_Closure_Runtime_Recovery_Trading_Path_Runbook_V1_2_Trading_First.md
@@ -731,6 +731,16 @@ Der als Reminder-only identifizierte Workstream `MULTI_FUTURE_ACTIVE_SET_ROTATIO
 
 Diese Capability in Phase 0 ist **nur Design-/Governance-Recovery**, keine Multi-Future-Implementierung und keine Aktivierung.
 
+Kanonisches Register (SSOT):
+
+```text
+docs/governance/deferred_work_recovery_register_v1.json
+docs/governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md
+docs/ops/specs/DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1.md
+src/ops/deferred_work_recovery_register_contract_v1.py
+tests/governance/test_deferred_work_recovery_register_v1.py
+```
+
 Pflichtartefakte:
 
 - eindeutiger Owner
@@ -1847,16 +1857,45 @@ Nach jeder dritten Capability oder jedem Activation-relevanten Merge muss ein er
 
 ## Deferred Work Register
 
-Jede deferred Capability benötigt:
+Kanonische Authority (Capability 0.4):
 
 ```text
-deferred_reason
-blocking_dependency
-owner_requirement
-target_phase
-review_trigger
-expiry_or_review_date
-current_status
+docs/governance/deferred_work_recovery_register_v1.json
+docs/governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md
+```
+
+Keine parallelen Register. Reminder-only Surfaces (z. B. `docs/planning/deferred/MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md`) sind nicht Authority.
+
+Jede deferred Capability benötigt mindestens:
+
+```text
+CAPABILITY_ID
+TITLE
+CLASSIFICATION
+OWNER_REQUIREMENT
+TRADING_PATH_VALUE
+CURRENT_STATE
+TARGET_STATE
+DEFERRED_REASON
+BLOCKING_DEPENDENCIES
+DEPENDENCY_STATUS
+AUTHORITY_OWNER
+TARGET_PHASE
+REVIEW_TRIGGER
+REVIEW_DATE_OR_EVENT
+EXPIRY_OR_REASSESSMENT_RULE
+IMPLEMENTATION_AUTHORIZED
+ACTIVATION_AUTHORIZED
+CORE_LOGIC_CHANGE_ALLOWED
+CURRENT_RUNTIME_EFFECT
+EXPECTED_FUTURE_RUNTIME_EFFECT
+SAFETY_INVARIANTS
+SOURCE_REFERENCES
+REPOSITORY_SHA
+LAST_VERIFIED_AT
+CURRENT_STATUS
+NEXT_REQUIRED_DECISION
+CLOSURE_CRITERIA
 ```
 
 Ein Reminder-only Dokument ohne Review Trigger ist nicht ausreichend.

--- a/docs/governance/deferred_work_recovery_register_v1.json
+++ b/docs/governance/deferred_work_recovery_register_v1.json
@@ -1,0 +1,216 @@
+{
+  "schema_version": "deferred_work_recovery_register.v1",
+  "register_id": "PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1",
+  "capability_recovery_id": "CAPABILITY_0_4_DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1",
+  "document_class": "CURRENT_RUNTIME_TRUTH",
+  "authority_owner": "ops.deferred_work_recovery_register_contract_v1",
+  "canonical_register_path": "docs/governance/deferred_work_recovery_register_v1.json",
+  "human_readable_companion": "docs/governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md",
+  "capability_spec": "docs/ops/specs/DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1.md",
+  "parallel_register_forbidden": true,
+  "implementation_authorized": false,
+  "activation_authorized": false,
+  "core_logic_change_allowed": false,
+  "current_runtime_changed": false,
+  "repository_sha_at_registration": "8155bd448c5acb0b2cc3ff485d63eaef9f6f074d",
+  "last_verified_at": "2026-08-02T03:33:53Z",
+  "semantic_guards": {
+    "TOP20_IS_CONTEXT_ONLY": true,
+    "SINGLE_SELECTED_FUTURE_IS_CURRENT_AUTHORITY": true,
+    "TOP_N_ACTIVE_SET_IS_DEFERRED": true,
+    "TOP5_PRODUCTIVE": false,
+    "TOP5_REGRESSED": false,
+    "MULTI_FUTURE_IMPLEMENTED": false,
+    "MULTI_FUTURE_AUTHORIZED": false,
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED": false,
+    "MAX_POSITIONS_EFFECTIVE": 1,
+    "PHASE_1_SELECTION": "SINGLE_SELECTED_FUTURE",
+    "PHASE_1_MAX_POSITIONS": 1,
+    "ROTATION_POLICY_RATIFIED": false,
+    "ROTATION_IMPLEMENTATION_STARTED": false,
+    "CURRENT_RUNTIME_CHANGED": false,
+    "DASHBOARD_RANKING_IS_RUNTIME_AUTHORITY": false
+  },
+  "forbidden_claims": [
+    "Top-5 Rotation exists productively",
+    "Top-5 Rotation was lost or regressed",
+    "Active Set is already authoritative",
+    "Multi-Future is ready",
+    "Multi-Future is activated",
+    "Ranking currently authorizes multiple instruments",
+    "Dashboard ranking is Runtime Authority"
+  ],
+  "artifact_classification": [
+    {
+      "path": "docs/governance/deferred_work_recovery_register_v1.json",
+      "classification": "CURRENT_RUNTIME_TRUTH",
+      "notes": "Canonical Deferred-Work Recovery Register (machine-readable SSOT)."
+    },
+    {
+      "path": "docs/governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md",
+      "classification": "CURRENT_RUNTIME_TRUTH",
+      "notes": "Human-readable companion to the canonical register."
+    },
+    {
+      "path": "docs/ops/specs/DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1.md",
+      "classification": "CURRENT_RUNTIME_TRUTH",
+      "notes": "Capability 0.4 recovery/resubmission contract."
+    },
+    {
+      "path": "docs/planning/deferred/MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md",
+      "classification": "REMINDER_ONLY",
+      "notes": "Historical reminder surface; superseded as authority by this register. Remains discoverable, non-authorizing."
+    },
+    {
+      "path": "docs/governance/Peak_Trade_Canonical_Capability_Closure_Runtime_Recovery_Trading_Path_Runbook_V1_2_Trading_First.md",
+      "classification": "CURRENT_RUNTIME_TRUTH",
+      "notes": "Working capability closure runbook; Phase 6 target for rotation policy ratification."
+    },
+    {
+      "path": "docs/governance/PEAK_TRADE_CANONICAL_RUNTIME_TRUTH_MAP_V1.md",
+      "classification": "CURRENT_RUNTIME_TRUTH",
+      "notes": "Current runtime truth map; points to deferred rotation as non-productive."
+    },
+    {
+      "path": "docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.12.md",
+      "classification": "TARGET_ARCHITECTURE",
+      "notes": "Target autonomy SSOT; Phase-1 bounds remain currently binding."
+    },
+    {
+      "path": "docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.1_multi_future_target_model_clarification.md",
+      "classification": "TARGET_ARCHITECTURE",
+      "notes": "Multi-future target model clarification; not current runtime authority."
+    },
+    {
+      "path": "docs/architecture/PEAK_TRADE_CANONICAL_UNIFIED_TRADING_SYSTEM_RUNBOOK_V2_6.md",
+      "classification": "TARGET_ARCHITECTURE",
+      "notes": "Unified trading system target architecture."
+    },
+    {
+      "path": "docs/PHASE_42_TOPN_PROMOTION.md",
+      "classification": "HISTORICAL",
+      "notes": "Historical Top-N promotion pipeline docs; not productive Top-5 runtime."
+    },
+    {
+      "path": "docs/ops/specs/CONFIG_TRUTH_ALIGNMENT_V1.md",
+      "classification": "CURRENT_RUNTIME_TRUTH",
+      "notes": "Phase-1 max_open_positions=1 truth alignment; MULTI_FUTURE_RUNTIME_AUTHORIZED=false."
+    }
+  ],
+  "entries": [
+    {
+      "CAPABILITY_ID": "MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0",
+      "TITLE": "Multi-Future Active-Set Rotation / Replacement Policy v0",
+      "CLASSIFICATION": "DEFERRED_REQUIRED_CAPABILITY",
+      "OWNER_REQUIREMENT": "Provide a later-ratifiable portfolio active-set rotation/replacement policy for a dynamically evaluated futures universe, using ranking as context only, with controlled promotion and demotion, replacement hysteresis, state retention for open positions (no hard removal of an instrument with an open position), global risk/capital allocation, per-instrument state isolation, restart/recovery semantics, and a Top-N-capable technical target architecture. A later first ratified configuration may use N=5; Top-5 is currently neither productive nor activated.",
+      "TRADING_PATH_VALUE": "Universe → Ranking → spätere Active-Set Selection → per-instrument Market State → Master V2 → Double Play → Global Risk → Global Safety → Intent Arbitration → Execution. This Capability 0.4 registration only prevents the required later work from being forgotten again; it does not alter the current trading path.",
+      "CURRENT_STATE": "POLICY_NOT_RATIFIED_IMPLEMENTATION_NOT_AUTHORIZED",
+      "TARGET_STATE": "ROTATION_POLICY_RATIFIED_READY_FOR_SEPARATE_IMPLEMENTATION_GO",
+      "DEFERRED_REASON": "Safety and Phase-1 single-future runtime closures must complete before any Multi-Future rotation policy ratification or implementation. Prior surface was reminder-only without a machine-readable deferred register entry.",
+      "BLOCKING_DEPENDENCIES": [
+        "Productive Reconciliation Runtime Closure",
+        "Governed Futures Universe Authority",
+        "Productive Ranking Authority",
+        "Single Selected Future Persistence",
+        "Single Selected Future Restart Recovery",
+        "Futures Accounting Runtime Closure",
+        "Per-Instrument State Isolation Design",
+        "Global Portfolio Risk Design",
+        "Global Safety Arbitration",
+        "Single Global Execution Writer",
+        "Canonical Runtime Pre-Activation Closure"
+      ],
+      "DEPENDENCY_STATUS": "ALL_BLOCKING_DEPENDENCIES_OPEN_OR_NOT_YET_CLOSED",
+      "AUTHORITY_OWNER": "ops.deferred_work_recovery_register_contract_v1",
+      "TARGET_PHASE": "PHASE_6",
+      "REVIEW_TRIGGER": {
+        "trigger_id": "MULTI_FUTURE_ROTATION_POLICY_V0_POST_CLOSURE_REVIEW",
+        "event_based": true,
+        "reminder_only": false,
+        "description": "Review immediately after successful closure and merge of: (1) Productive Reconciliation, (2) Single Selected Future Authority and Runtime Binding, (3) Futures Accounting Runtime Wiring, (4) Canonical Runtime Pre-Activation Closure.",
+        "required_closures": [
+          "Productive Reconciliation",
+          "Single Selected Future Authority and Runtime Binding",
+          "Futures Accounting Runtime Wiring",
+          "Canonical Runtime Pre-Activation Closure"
+        ]
+      },
+      "REVIEW_DATE_OR_EVENT": "EVENT:POST_CLOSURE_AND_MERGE_OF_REQUIRED_CLOSURES_LISTED_IN_REVIEW_TRIGGER",
+      "EXPIRY_OR_REASSESSMENT_RULE": "Reassess at REVIEW_TRIGGER event; if any required closure reopens or fails verification, keep DEFERRED_REQUIRED_CAPABILITY and block Phase-6 ratification until closures re-pass.",
+      "IMPLEMENTATION_AUTHORIZED": false,
+      "ACTIVATION_AUTHORIZED": false,
+      "CORE_LOGIC_CHANGE_ALLOWED": false,
+      "CURRENT_RUNTIME_EFFECT": "NONE",
+      "EXPECTED_FUTURE_RUNTIME_EFFECT": "After separate Phase-6 ratification and a later explicit implementation GO: governed Top-N active-set rotation/replacement may be designed; first ratified configuration may use N=5. No current runtime effect.",
+      "SAFETY_INVARIANTS": [
+        "TOP20_IS_CONTEXT_ONLY=true",
+        "SINGLE_SELECTED_FUTURE_IS_CURRENT_AUTHORITY=true",
+        "TOP_N_ACTIVE_SET_IS_DEFERRED=true",
+        "TOP5_PRODUCTIVE=false",
+        "TOP5_REGRESSED=false",
+        "MULTI_FUTURE_IMPLEMENTED=false",
+        "MULTI_FUTURE_AUTHORIZED=false",
+        "MULTI_FUTURE_RUNTIME_AUTHORIZED=false",
+        "MAX_POSITIONS_EFFECTIVE=1",
+        "PHASE_1_SELECTION=SINGLE_SELECTED_FUTURE",
+        "PHASE_1_MAX_POSITIONS=1",
+        "ROTATION_POLICY_RATIFIED=false",
+        "ROTATION_IMPLEMENTATION_STARTED=false",
+        "CURRENT_RUNTIME_EFFECT=NONE",
+        "No hard removal of instrument with open position",
+        "Ranking is context only until separately ratified",
+        "Dashboard ranking is not runtime authority"
+      ],
+      "SOURCE_REFERENCES": [
+        "docs/planning/deferred/MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md",
+        "docs/governance/Peak_Trade_Canonical_Capability_Closure_Runtime_Recovery_Trading_Path_Runbook_V1_2_Trading_First.md",
+        "docs/governance/PEAK_TRADE_CANONICAL_RUNTIME_TRUTH_MAP_V1.md",
+        "docs/governance/Peak_Trade_Kanonisches_Vollautonomie_Runbook_v4.4.1_multi_future_target_model_clarification.md",
+        "docs/ops/specs/CONFIG_TRUTH_ALIGNMENT_V1.md",
+        "docs/PHASE_42_TOPN_PROMOTION.md"
+      ],
+      "REPOSITORY_SHA": "8155bd448c5acb0b2cc3ff485d63eaef9f6f074d",
+      "LAST_VERIFIED_AT": "2026-08-02T03:33:53Z",
+      "CURRENT_STATUS": "REGISTERED_DEFERRED_REQUIRED_CAPABILITY_AWAITING_DEPENDENCY_CLOSURES",
+      "NEXT_REQUIRED_DECISION": "After REVIEW_TRIGGER closures merge: open Phase-6 policy ratification for MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0 under a separate explicit GO; do not start implementation from this registration alone.",
+      "CLOSURE_CRITERIA": "Phase-6 policy ratified with all open policy decisions resolved; IMPLEMENTATION_AUTHORIZED remains false until a separate implementation GO; ACTIVATION_AUTHORIZED remains false until a separate activation GO; semantic guards remain true until then.",
+      "PHASE_1_SELECTION": "SINGLE_SELECTED_FUTURE",
+      "PHASE_1_MAX_POSITIONS": 1,
+      "MULTI_FUTURE_RUNTIME_AUTHORIZED": false,
+      "OPEN_POLICY_DECISIONS_FOR_LATER_RATIFICATION": [
+        "active_set_size",
+        "candidate_set_size",
+        "ranking refresh cadence",
+        "promotion threshold",
+        "demotion threshold",
+        "replacement margin",
+        "distinct-observation confirmation",
+        "hysteresis",
+        "cooldown",
+        "minimum active duration",
+        "minimum candidate duration",
+        "data-quality disqualification",
+        "stale-data behavior",
+        "invalid-instrument behavior",
+        "open-position demotion semantics",
+        "ACTIVE_ALPHA",
+        "ACTIVE_POSITION_ONLY",
+        "DEMOTION_PENDING",
+        "EXIT_ONLY",
+        "RETIRED",
+        "capital allocation",
+        "correlation budget",
+        "concentration limits",
+        "gross exposure",
+        "net directional exposure",
+        "maximum concurrent positions",
+        "liquidity-adjusted sizing",
+        "state persistence",
+        "restart reconstruction",
+        "per-instrument reconciliation",
+        "deterministic replay",
+        "evidence and verifier requirements"
+      ]
+    }
+  ]
+}

--- a/docs/ops/specs/DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1.md
+++ b/docs/ops/specs/DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1.md
@@ -1,0 +1,75 @@
+# DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1
+
+---
+docs_token: DOCS_TOKEN_DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1
+STATUS: CAPABILITY_AVAILABLE
+scope: Capability 0.4 Deferred-Work Recovery Register + MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0 roadmap resubmission
+LIVE_AUTHORIZED: false
+ORDERS_ALLOWED: false
+RUNTIME_ACTIVATION_ALLOWED: false
+MULTI_FUTURE_RUNTIME_AUTHORIZED: false
+IMPLEMENTATION_AUTHORIZED: false
+ACTIVATION_AUTHORIZED: false
+CORE_LOGIC_CHANGE: false
+SELECTION_LOGIC_CHANGE: false
+RANKING_LOGIC_CHANGE: false
+RISK_LOGIC_CHANGE: false
+SAFETY_LOGIC_CHANGE: false
+ACTIVATION_STATE: BOUND_NOT_ACTIVATED
+HARD_STOP: true
+---
+
+```text
+CAPABILITY_ID=CAPABILITY_0_4_DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1
+TITLE=Deferred-Work Recovery Register and Rotation-Policy Resubmission (Capability 0.4)
+OWNER_REQUIREMENT=Create and integrate a canonical Deferred-Work Recovery Register and formally re-admit MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0 as DEFERRED_REQUIRED_CAPABILITY into the active trading roadmap
+CURRENT_STATE=Reminder-only rotation policy surface existed; no canonical deferred-work register
+TARGET_STATE=Canonical register present; rotation workstream registered with dependencies, review trigger, Phase 6 target; implementation/activation unauthorized
+OUT_OF_SCOPE=Multi-Future runtime implementation; rotation code; ranking/selection changes; Top-5 activation; position-limit increase; runtime activation; session execution; network access; authorization consumption; Notion mutation; Master V2/Double Play/Bull-Bear/Risk/Safety mutation
+AUTHORITY_OWNER=ops.deferred_work_recovery_register_contract_v1
+REGISTER_SSOT=docs/governance/deferred_work_recovery_register_v1.json
+REGISTER_COMPANION=docs/governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md
+ROTATION_CAPABILITY_ID=MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0
+CLASSIFICATION=DEFERRED_REQUIRED_CAPABILITY
+TARGET_PHASE=PHASE_6
+IMPLEMENTATION_AUTHORIZED=false
+ACTIVATION_AUTHORIZED=false
+CURRENT_RUNTIME_EFFECT=NONE
+PHASE_1_SELECTION=SINGLE_SELECTED_FUTURE
+PHASE_1_MAX_POSITIONS=1
+MULTI_FUTURE_RUNTIME_AUTHORIZED=false
+TOP5_PRODUCTIVE=false
+TOP5_REGRESSED=false
+TEST_PLAN=tests/governance/test_deferred_work_recovery_register_v1.py
+DOCS_UPDATE=docs/governance/PEAK_TRADE_CANONICAL_RUNTIME_TRUTH_MAP_V1.md; docs/governance/Peak_Trade_Canonical_Capability_Closure_Runtime_Recovery_Trading_Path_Runbook_V1_2_Trading_First.md; docs/planning/deferred/MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md
+```
+
+## Trading-path value
+
+```text
+Universe
+→ Ranking
+→ spätere Active-Set Selection
+→ per-instrument Market State
+→ Master V2
+→ Double Play
+→ Global Risk
+→ Global Safety
+→ Intent Arbitration
+→ Execution
+```
+
+Capability 0.4 only prevents this required later work from being forgotten again. It does not alter the current trading path.
+
+## Review trigger
+
+Review immediately after successful closure and merge of:
+
+1. Productive Reconciliation
+2. Single Selected Future Authority and Runtime Binding
+3. Futures Accounting Runtime Wiring
+4. Canonical Runtime Pre-Activation Closure
+
+## Owner module
+
+`src&#47;ops&#47;deferred_work_recovery_register_contract_v1.py`

--- a/docs/planning/deferred/MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md
+++ b/docs/planning/deferred/MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md
@@ -5,7 +5,14 @@
 ```text
 DOCUMENT_CLASS=TARGET_ARCHITECTURE
 PROCESS_CLASSIFICATION=DEFERRED_DESIGN_REMINDER_ONLY
+CLASSIFICATION=REMINDER_ONLY
+AUTHORITY_SUPERSEDED_BY_CANONICAL_REGISTER=true
+CANONICAL_REGISTER=docs/governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md
+CANONICAL_REGISTER_JSON=docs/governance/deferred_work_recovery_register_v1.json
+REGISTERED_AS=DEFERRED_REQUIRED_CAPABILITY
 TOP20_TO_TOP5_PRODUCTIVE_ROTATION=false
+TOP5_PRODUCTIVE=false
+TOP5_REGRESSED=false
 TOP5_IS_NOT_EXISTING_PRODUCTIVE_OR_REGRESSED_FUNCTION=true
 SCOPE_CLASSIFICATION=MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_REMINDER_NO_IMPLEMENTATION_NO_RUNTIME_NO_ECONOMIC_EVAL_NO_AUTHORITY
 REMINDER_ID=MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0
@@ -19,7 +26,12 @@ ECONOMIC_EVALUATION_AUTHORIZED=false
 RUNTIME_REWIRE_ADMISSIBLE=false
 ```
 
-This document is a **deferred design reminder only**. It does **not** implement portfolio rotation, active-set allocation, Multi-Future runtime, economic evaluation, or any trading authority. It does **not** modify Backtest Parity Surface work, scheduler, credentials, orders, adapters, shadow, paper, testnet, canary, live, Master V2, Double Play, Risk/Sizing, Safety, Reconciliation, Promotion, or canonical trading logic.
+This document remains a **deferred design reminder only** (`REMINDER_ONLY`). Canonical deferred-capability authority for roadmap recovery is the Deferred-Work Recovery Register:
+
+- [`docs/governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md`](../../governance/PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md)
+- [`docs/governance/deferred_work_recovery_register_v1.json`](../../governance/deferred_work_recovery_register_v1.json)
+
+There the workstream is registered as `DEFERRED_REQUIRED_CAPABILITY` (Phase 6) with machine-readable dependencies and an event-based review trigger. This reminder does **not** implement portfolio rotation, active-set allocation, Multi-Future runtime, economic evaluation, or any trading authority. It does **not** modify Backtest Parity Surface work, scheduler, credentials, orders, adapters, shadow, paper, testnet, canary, live, Master V2, Double Play, Risk/Sizing, Safety, Reconciliation, Promotion, or canonical trading logic.
 
 ## Purpose
 

--- a/src/ops/deferred_work_recovery_register_contract_v1.py
+++ b/src/ops/deferred_work_recovery_register_contract_v1.py
@@ -1,0 +1,317 @@
+"""DEFERRED_WORK_RECOVERY_REGISTER_V1 — Capability 0.4 register owner.
+
+Governance recovery surface only. Loads and validates the canonical
+Deferred-Work Recovery Register. Does not authorize implementation,
+activation, multi-future runtime, ranking/selection changes, live trading,
+network sessions, or authorization consumption.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+CAPABILITY_RECOVERY_ID = (
+    "CAPABILITY_0_4_DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1"
+)
+REGISTER_ID = "PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1"
+SCHEMA_VERSION = "deferred_work_recovery_register.v1"
+PRODUCER_FAMILY = "ops.deferred_work_recovery_register_contract_v1"
+OWNER = PRODUCER_FAMILY
+ROTATION_CAPABILITY_ID = "MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0"
+CLASSIFICATION_DEFERRED_REQUIRED = "DEFERRED_REQUIRED_CAPABILITY"
+TARGET_PHASE_6 = "PHASE_6"
+
+IMPLEMENTATION_AUTHORIZED = False
+ACTIVATION_AUTHORIZED = False
+CORE_LOGIC_CHANGE_ALLOWED = False
+CURRENT_RUNTIME_CHANGED = False
+MULTI_FUTURE_RUNTIME_AUTHORIZED = False
+MAX_POSITIONS_EFFECTIVE = 1
+PHASE_1_SELECTION = "SINGLE_SELECTED_FUTURE"
+PHASE_1_MAX_POSITIONS = 1
+
+REQUIRED_ENTRY_FIELDS: frozenset[str] = frozenset(
+    {
+        "CAPABILITY_ID",
+        "TITLE",
+        "CLASSIFICATION",
+        "OWNER_REQUIREMENT",
+        "TRADING_PATH_VALUE",
+        "CURRENT_STATE",
+        "TARGET_STATE",
+        "DEFERRED_REASON",
+        "BLOCKING_DEPENDENCIES",
+        "DEPENDENCY_STATUS",
+        "AUTHORITY_OWNER",
+        "TARGET_PHASE",
+        "REVIEW_TRIGGER",
+        "REVIEW_DATE_OR_EVENT",
+        "EXPIRY_OR_REASSESSMENT_RULE",
+        "IMPLEMENTATION_AUTHORIZED",
+        "ACTIVATION_AUTHORIZED",
+        "CORE_LOGIC_CHANGE_ALLOWED",
+        "CURRENT_RUNTIME_EFFECT",
+        "EXPECTED_FUTURE_RUNTIME_EFFECT",
+        "SAFETY_INVARIANTS",
+        "SOURCE_REFERENCES",
+        "REPOSITORY_SHA",
+        "LAST_VERIFIED_AT",
+        "CURRENT_STATUS",
+        "NEXT_REQUIRED_DECISION",
+        "CLOSURE_CRITERIA",
+    }
+)
+
+REQUIRED_BLOCKING_DEPENDENCIES: frozenset[str] = frozenset(
+    {
+        "Productive Reconciliation Runtime Closure",
+        "Governed Futures Universe Authority",
+        "Productive Ranking Authority",
+        "Single Selected Future Persistence",
+        "Single Selected Future Restart Recovery",
+        "Futures Accounting Runtime Closure",
+        "Per-Instrument State Isolation Design",
+        "Global Portfolio Risk Design",
+        "Global Safety Arbitration",
+        "Single Global Execution Writer",
+        "Canonical Runtime Pre-Activation Closure",
+    }
+)
+
+REQUIRED_REVIEW_CLOSURES: frozenset[str] = frozenset(
+    {
+        "Productive Reconciliation",
+        "Single Selected Future Authority and Runtime Binding",
+        "Futures Accounting Runtime Wiring",
+        "Canonical Runtime Pre-Activation Closure",
+    }
+)
+
+REQUIRED_SEMANTIC_GUARDS: Mapping[str, Any] = {
+    "TOP20_IS_CONTEXT_ONLY": True,
+    "SINGLE_SELECTED_FUTURE_IS_CURRENT_AUTHORITY": True,
+    "TOP_N_ACTIVE_SET_IS_DEFERRED": True,
+    "TOP5_PRODUCTIVE": False,
+    "TOP5_REGRESSED": False,
+    "MULTI_FUTURE_IMPLEMENTED": False,
+    "MULTI_FUTURE_AUTHORIZED": False,
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED": False,
+    "MAX_POSITIONS_EFFECTIVE": 1,
+    "PHASE_1_SELECTION": "SINGLE_SELECTED_FUTURE",
+    "PHASE_1_MAX_POSITIONS": 1,
+    "ROTATION_POLICY_RATIFIED": False,
+    "ROTATION_IMPLEMENTATION_STARTED": False,
+    "CURRENT_RUNTIME_CHANGED": False,
+    "DASHBOARD_RANKING_IS_RUNTIME_AUTHORITY": False,
+}
+
+FORBIDDEN_PRODUCTIVE_TOP5_PHRASES: tuple[str, ...] = (
+    "Top-5 Rotation exists productively",
+    "Top-5 is productive",
+    "TOP5_PRODUCTIVE=true",
+    "Top-5 Rotation was lost or regressed",
+    "Active Set is already authoritative",
+    "Multi-Future is ready",
+    "Multi-Future is activated",
+    "Ranking currently authorizes multiple instruments",
+    "Dashboard ranking is Runtime Authority",
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_REGISTER_PATH = (
+    _REPO_ROOT / "docs" / "governance" / "deferred_work_recovery_register_v1.json"
+)
+HUMAN_COMPANION_PATH = (
+    _REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1.md"
+)
+REMINDER_PATH = (
+    _REPO_ROOT
+    / "docs"
+    / "planning"
+    / "deferred"
+    / "MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0_DEFERRED_REMINDER.md"
+)
+
+
+class DeferredWorkRecoveryRegisterError(ValueError):
+    """Fail-closed deferred-work recovery register violation."""
+
+
+def load_register(path: Path | None = None) -> dict[str, Any]:
+    """Load the canonical deferred-work recovery register JSON."""
+    register_path = path or CANONICAL_REGISTER_PATH
+    if not register_path.is_file():
+        raise DeferredWorkRecoveryRegisterError(
+            f"canonical deferred-work register missing: {register_path}"
+        )
+    raw = json.loads(register_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise DeferredWorkRecoveryRegisterError("register root must be object")
+    return raw
+
+
+def get_entry(register: Mapping[str, Any], capability_id: str) -> dict[str, Any]:
+    entries = register.get("entries")
+    if not isinstance(entries, list):
+        raise DeferredWorkRecoveryRegisterError("register.entries must be a list")
+    for item in entries:
+        if isinstance(item, dict) and item.get("CAPABILITY_ID") == capability_id:
+            return item
+    raise DeferredWorkRecoveryRegisterError(f"capability not registered: {capability_id}")
+
+
+def validate_register(register: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """Validate register schema and rotation-policy entry invariants."""
+    payload = dict(register) if register is not None else load_register()
+
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise DeferredWorkRecoveryRegisterError("schema_version mismatch")
+    if payload.get("register_id") != REGISTER_ID:
+        raise DeferredWorkRecoveryRegisterError("register_id mismatch")
+    if payload.get("capability_recovery_id") != CAPABILITY_RECOVERY_ID:
+        raise DeferredWorkRecoveryRegisterError("capability_recovery_id mismatch")
+    if payload.get("parallel_register_forbidden") is not True:
+        raise DeferredWorkRecoveryRegisterError("parallel register must be forbidden")
+    if payload.get("implementation_authorized") is not False:
+        raise DeferredWorkRecoveryRegisterError("register implementation_authorized must be false")
+    if payload.get("activation_authorized") is not False:
+        raise DeferredWorkRecoveryRegisterError("register activation_authorized must be false")
+    if payload.get("current_runtime_changed") is not False:
+        raise DeferredWorkRecoveryRegisterError("current_runtime_changed must be false")
+
+    guards = payload.get("semantic_guards")
+    if not isinstance(guards, dict):
+        raise DeferredWorkRecoveryRegisterError("semantic_guards missing")
+    for key, expected in REQUIRED_SEMANTIC_GUARDS.items():
+        if guards.get(key) != expected:
+            raise DeferredWorkRecoveryRegisterError(
+                f"semantic guard mismatch: {key} expected={expected!r} actual={guards.get(key)!r}"
+            )
+
+    entry = get_entry(payload, ROTATION_CAPABILITY_ID)
+    missing = sorted(REQUIRED_ENTRY_FIELDS - set(entry))
+    if missing:
+        raise DeferredWorkRecoveryRegisterError(
+            f"rotation entry missing required fields: {missing}"
+        )
+
+    if entry.get("CLASSIFICATION") != CLASSIFICATION_DEFERRED_REQUIRED:
+        raise DeferredWorkRecoveryRegisterError("rotation CLASSIFICATION mismatch")
+    if entry.get("TARGET_PHASE") != TARGET_PHASE_6:
+        raise DeferredWorkRecoveryRegisterError("rotation TARGET_PHASE must be PHASE_6")
+    if entry.get("IMPLEMENTATION_AUTHORIZED") is not False:
+        raise DeferredWorkRecoveryRegisterError("rotation IMPLEMENTATION_AUTHORIZED must be false")
+    if entry.get("ACTIVATION_AUTHORIZED") is not False:
+        raise DeferredWorkRecoveryRegisterError("rotation ACTIVATION_AUTHORIZED must be false")
+    if entry.get("CORE_LOGIC_CHANGE_ALLOWED") is not False:
+        raise DeferredWorkRecoveryRegisterError("rotation CORE_LOGIC_CHANGE_ALLOWED must be false")
+    if entry.get("CURRENT_RUNTIME_EFFECT") != "NONE":
+        raise DeferredWorkRecoveryRegisterError("CURRENT_RUNTIME_EFFECT must be NONE")
+    if entry.get("PHASE_1_SELECTION") != PHASE_1_SELECTION:
+        raise DeferredWorkRecoveryRegisterError("PHASE_1_SELECTION must be SINGLE_SELECTED_FUTURE")
+    if entry.get("PHASE_1_MAX_POSITIONS") != PHASE_1_MAX_POSITIONS:
+        raise DeferredWorkRecoveryRegisterError("PHASE_1_MAX_POSITIONS must be 1")
+    if entry.get("MULTI_FUTURE_RUNTIME_AUTHORIZED") is not False:
+        raise DeferredWorkRecoveryRegisterError(
+            "MULTI_FUTURE_RUNTIME_AUTHORIZED must be false on rotation entry"
+        )
+
+    deps = entry.get("BLOCKING_DEPENDENCIES")
+    if not isinstance(deps, list):
+        raise DeferredWorkRecoveryRegisterError("BLOCKING_DEPENDENCIES must be a list")
+    missing_deps = sorted(REQUIRED_BLOCKING_DEPENDENCIES - set(deps))
+    if missing_deps:
+        raise DeferredWorkRecoveryRegisterError(f"missing blocking dependencies: {missing_deps}")
+
+    trigger = entry.get("REVIEW_TRIGGER")
+    if not isinstance(trigger, dict):
+        raise DeferredWorkRecoveryRegisterError("REVIEW_TRIGGER must be an object")
+    if trigger.get("event_based") is not True:
+        raise DeferredWorkRecoveryRegisterError("REVIEW_TRIGGER.event_based must be true")
+    if trigger.get("reminder_only") is not False:
+        raise DeferredWorkRecoveryRegisterError("REVIEW_TRIGGER.reminder_only must be false")
+    closures = trigger.get("required_closures")
+    if not isinstance(closures, list):
+        raise DeferredWorkRecoveryRegisterError("REVIEW_TRIGGER.required_closures must be a list")
+    missing_closures = sorted(REQUIRED_REVIEW_CLOSURES - set(closures))
+    if missing_closures:
+        raise DeferredWorkRecoveryRegisterError(
+            f"missing review trigger closures: {missing_closures}"
+        )
+
+    owner_req = str(entry.get("OWNER_REQUIREMENT") or "")
+    for token in (
+        "dynamically evaluated futures universe",
+        "ranking as context",
+        "promotion",
+        "demotion",
+        "hysteresis",
+        "open position",
+        "global risk",
+        "state isolation",
+        "restart",
+        "Top-N",
+        "N=5",
+        "neither productive nor activated",
+    ):
+        if token.lower() not in owner_req.lower():
+            raise DeferredWorkRecoveryRegisterError(
+                f"OWNER_REQUIREMENT missing required token: {token}"
+            )
+
+    trading_path = str(entry.get("TRADING_PATH_VALUE") or "")
+    for token in (
+        "Universe",
+        "Ranking",
+        "Active-Set",
+        "Master V2",
+        "Double Play",
+        "Global Risk",
+        "Global Safety",
+        "Intent Arbitration",
+        "Execution",
+        "does not alter the current trading path",
+    ):
+        if token not in trading_path:
+            raise DeferredWorkRecoveryRegisterError(
+                f"TRADING_PATH_VALUE missing required token: {token}"
+            )
+
+    return payload
+
+
+def assert_no_productive_top5_claims(*texts: str) -> None:
+    """Fail closed if any provided text asserts productive/regressed Top-5 rotation.
+
+    Mentions inside an explicit denylist / ``forbidden_claims`` enumeration are
+    allowed when they appear only as prohibited examples, not as affirmations.
+    """
+    for text in texts:
+        lowered = text.lower()
+        for phrase in FORBIDDEN_PRODUCTIVE_TOP5_PHRASES:
+            needle = phrase.lower()
+            search_from = 0
+            while True:
+                idx = lowered.find(needle, search_from)
+                if idx < 0:
+                    break
+                window_start = max(0, idx - 80)
+                window = lowered[window_start : idx + len(needle) + 40]
+                denylist_context = (
+                    "forbidden_claims" in window
+                    or "forbidden claim" in window
+                    or "must not" in window
+                    or "verbot" in window
+                    or "prevent" in window
+                    or "misverständliche" in window
+                    or "denylist" in window
+                )
+                if not denylist_context:
+                    raise DeferredWorkRecoveryRegisterError(
+                        f"forbidden productive/regressed Top-5 or multi-future claim: {phrase}"
+                    )
+                search_from = idx + len(needle)
+        if "top5_productive=true" in lowered.replace(" ", ""):
+            raise DeferredWorkRecoveryRegisterError("TOP5_PRODUCTIVE=true is forbidden")

--- a/tests/governance/test_deferred_work_recovery_register_v1.py
+++ b/tests/governance/test_deferred_work_recovery_register_v1.py
@@ -1,0 +1,169 @@
+"""Capability 0.4 — Deferred-Work Recovery Register + rotation policy resubmission."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.ops.deferred_work_recovery_register_contract_v1 import (
+    ACTIVATION_AUTHORIZED,
+    CANONICAL_REGISTER_PATH,
+    CAPABILITY_RECOVERY_ID,
+    CLASSIFICATION_DEFERRED_REQUIRED,
+    HUMAN_COMPANION_PATH,
+    IMPLEMENTATION_AUTHORIZED,
+    MAX_POSITIONS_EFFECTIVE,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    PHASE_1_MAX_POSITIONS,
+    PHASE_1_SELECTION,
+    REMINDER_PATH,
+    REQUIRED_BLOCKING_DEPENDENCIES,
+    REQUIRED_REVIEW_CLOSURES,
+    ROTATION_CAPABILITY_ID,
+    TARGET_PHASE_6,
+    DeferredWorkRecoveryRegisterError,
+    assert_no_productive_top5_claims,
+    get_entry,
+    load_register,
+    validate_register,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_TRUTH_MAP = (
+    REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_CANONICAL_RUNTIME_TRUTH_MAP_V1.md"
+)
+CAPABILITY_RUNBOOK = (
+    REPO_ROOT
+    / "docs"
+    / "governance"
+    / "Peak_Trade_Canonical_Capability_Closure_Runtime_Recovery_Trading_Path_Runbook_V1_2_Trading_First.md"
+)
+CAPABILITY_SPEC = (
+    REPO_ROOT
+    / "docs"
+    / "ops"
+    / "specs"
+    / "DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1.md"
+)
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing required file: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_capability_constants_stable() -> None:
+    assert CAPABILITY_RECOVERY_ID.endswith("ROTATION_POLICY_RESUBMISSION_V1")
+    assert ROTATION_CAPABILITY_ID == "MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0"
+    assert IMPLEMENTATION_AUTHORIZED is False
+    assert ACTIVATION_AUTHORIZED is False
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert MAX_POSITIONS_EFFECTIVE == 1
+    assert PHASE_1_SELECTION == "SINGLE_SELECTED_FUTURE"
+    assert PHASE_1_MAX_POSITIONS == 1
+
+
+def test_canonical_register_present_and_validates() -> None:
+    assert CANONICAL_REGISTER_PATH.is_file()
+    register = validate_register()
+    assert register["register_id"] == "PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1"
+    assert register["parallel_register_forbidden"] is True
+
+
+def test_rotation_capability_registered_with_required_semantics() -> None:
+    register = load_register()
+    entry = get_entry(register, ROTATION_CAPABILITY_ID)
+    assert entry["CLASSIFICATION"] == CLASSIFICATION_DEFERRED_REQUIRED
+    assert entry["TARGET_PHASE"] == TARGET_PHASE_6
+    assert entry["IMPLEMENTATION_AUTHORIZED"] is False
+    assert entry["ACTIVATION_AUTHORIZED"] is False
+    assert entry["CURRENT_RUNTIME_EFFECT"] == "NONE"
+    assert entry["PHASE_1_SELECTION"] == "SINGLE_SELECTED_FUTURE"
+    assert entry["PHASE_1_MAX_POSITIONS"] == 1
+    assert entry["MULTI_FUTURE_RUNTIME_AUTHORIZED"] is False
+
+    deps = set(entry["BLOCKING_DEPENDENCIES"])
+    assert REQUIRED_BLOCKING_DEPENDENCIES.issubset(deps)
+
+    trigger = entry["REVIEW_TRIGGER"]
+    assert trigger["event_based"] is True
+    assert trigger["reminder_only"] is False
+    assert REQUIRED_REVIEW_CLOSURES.issubset(set(trigger["required_closures"]))
+
+    guards = register["semantic_guards"]
+    assert guards["SINGLE_SELECTED_FUTURE_IS_CURRENT_AUTHORITY"] is True
+    assert guards["TOP_N_ACTIVE_SET_IS_DEFERRED"] is True
+    assert guards["TOP5_PRODUCTIVE"] is False
+    assert guards["TOP5_REGRESSED"] is False
+    assert guards["MULTI_FUTURE_IMPLEMENTED"] is False
+    assert guards["MULTI_FUTURE_AUTHORIZED"] is False
+    assert guards["MAX_POSITIONS_EFFECTIVE"] == 1
+    assert guards["ROTATION_POLICY_RATIFIED"] is False
+    assert guards["ROTATION_IMPLEMENTATION_STARTED"] is False
+
+
+def test_human_companion_and_spec_crosslinks() -> None:
+    companion = _read(HUMAN_COMPANION_PATH)
+    assert "DOCS_TOKEN_PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1" in companion
+    assert ROTATION_CAPABILITY_ID in companion
+    assert "DEFERRED_REQUIRED_CAPABILITY" in companion
+    assert "PHASE_6" in companion
+    assert "TOP5_PRODUCTIVE=false" in companion
+    assert "SINGLE_SELECTED_FUTURE" in companion
+    assert "does **not** change the current trading path" in companion
+
+    spec = _read(CAPABILITY_SPEC)
+    assert "DOCS_TOKEN_DEFERRED_WORK_RECOVERY_REGISTER_ROTATION_POLICY_RESUBMISSION_V1" in spec
+    assert CAPABILITY_RECOVERY_ID in spec
+    assert "IMPLEMENTATION_AUTHORIZED=false" in spec
+    assert "ACTIVATION_AUTHORIZED=false" in spec
+    assert "MULTI_FUTURE_RUNTIME_AUTHORIZED=false" in spec
+
+
+def test_reminder_remains_reminder_only_and_points_to_register() -> None:
+    reminder = _read(REMINDER_PATH)
+    assert "REMINDER" in reminder.upper() or "reminder" in reminder
+    assert "IMPLEMENTATION_STARTED=false" in reminder
+    assert "TOP20_TO_TOP5_PRODUCTIVE_ROTATION=false" in reminder
+    assert "PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1" in reminder
+    assert "DEFERRED_REQUIRED_CAPABILITY" in reminder
+    assert "AUTHORITY_SUPERSEDED_BY_CANONICAL_REGISTER=true" in reminder
+
+
+def test_runtime_truth_map_and_runbook_point_to_register() -> None:
+    truth = _read(RUNTIME_TRUTH_MAP)
+    assert "PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1" in truth
+    assert "deferred_work_recovery_register_v1.json" in truth
+    assert "TOP20_TO_TOP5_PRODUCTIVE_ROTATION=false" in truth
+
+    runbook = _read(CAPABILITY_RUNBOOK)
+    assert "PEAK_TRADE_DEFERRED_WORK_RECOVERY_REGISTER_V1" in runbook
+    assert "deferred_work_recovery_register_v1.json" in runbook
+    assert "MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0" in runbook
+
+
+def test_no_productive_top5_claims_in_capability_surfaces() -> None:
+    register = load_register()
+    assert register["semantic_guards"]["TOP5_PRODUCTIVE"] is False
+    assert "Top-5 Rotation exists productively" in register["forbidden_claims"]
+
+    prose = [
+        _read(HUMAN_COMPANION_PATH),
+        _read(CAPABILITY_SPEC),
+        _read(REMINDER_PATH),
+    ]
+    assert_no_productive_top5_claims(*prose)
+    for text in prose:
+        assert "TOP5_PRODUCTIVE=true" not in text
+        assert "Top-5 is productive" not in text.lower()
+        # Affirmative productive claim must not appear outside denylist context.
+        assert "Top-5 Rotation exists productively." not in text
+
+
+def test_validate_register_rejects_authorized_implementation() -> None:
+    register = load_register()
+    entry = get_entry(register, ROTATION_CAPABILITY_ID)
+    entry["IMPLEMENTATION_AUTHORIZED"] = True
+    with pytest.raises(DeferredWorkRecoveryRegisterError, match="IMPLEMENTATION_AUTHORIZED"):
+        validate_register(register)


### PR DESCRIPTION
## Summary
- Canonical Deferred-Work Recovery Register (`docs/governance/deferred_work_recovery_register_v1.json` + companion) for Capability 0.4 roadmap recovery.
- Formally re-admits `MULTI_FUTURE_ACTIVE_SET_ROTATION_REPLACEMENT_POLICY_V0` as `DEFERRED_REQUIRED_CAPABILITY` (Phase 6) with blocking dependencies, event-based review trigger, and semantic guards.
- Docs/contract tests enforce `implementation_authorized=false`, `activation_authorized=false`, `SINGLE_SELECTED_FUTURE` authority, `MAX_POSITIONS=1`, and that Top-5 is not productive.
- No runtime activation, no Multi-Future implementation, no ranking/selection/risk/safety mutation.

## Test plan
- [x] `uv run pytest tests/governance/test_deferred_work_recovery_register_v1.py`
- [x] `uv run pytest tests/governance/test_config_truth_alignment_v1.py`
- [x] Docs token policy + docs reference targets
- [x] CI selector: `CONTRACT_FOCUSED` → `tests/governance/test_deferred_work_recovery_register_v1.py`
- [ ] GitHub CI confirmation on PR head


Made with [Cursor](https://cursor.com)