### PR TITLE
Phase 9.2: portable repository-relative evidence path serialization

### DIFF
--- a/src/ops/phase_9_2_public_md_session_preflight_v1/authorization_path_v1.py
+++ b/src/ops/phase_9_2_public_md_session_preflight_v1/authorization_path_v1.py
@@ -23,22 +23,52 @@ from src.ops.phase_9_2_public_md_session_preflight_v1.constants_v1 import (
     CONFIRM_TOKEN_OWNER,
     PREREGISTRATION_OWNER,
     PUBLIC_MD_SHADOW_AUTH_OWNER,
+    repo_root_v1,
+)
+from src.ops.phase_9_2_public_md_session_preflight_v1.path_portability_v1 import (
+    PathPortabilityError,
+    to_repository_relative_posix_path_v1,
 )
 from src.ops.single_future_canonical_runtime_public_md_no_order_shadow_evidence_v1 import (
     authorization_consumption_v1 as shadow_auth,
 )
 
 
+def _module_path_repository_relative_v1(source_file: str | None, *, repo_root: Path) -> str:
+    """Persist inspect.getsourcefile() as a repository-relative POSIX path."""
+    raw = source_file or ""
+    try:
+        return to_repository_relative_posix_path_v1(raw, repo_root=repo_root)
+    except PathPortabilityError:
+        # Modules are loaded from the package repository even when evidence is
+        # materialized into an isolated fixture root. Bind to package root.
+        return to_repository_relative_posix_path_v1(raw, repo_root=repo_root_v1())
+
+
 def prove_authorization_and_confirm_token_path_v1(
     *,
     repo_root: Path | None = None,
 ) -> dict[str, Any]:
-    _ = repo_root
+    root = Path(repo_root) if repo_root is not None else repo_root_v1()
     # Identify canonical modules (no issuance / consumption in this preflight).
-    confirm_mod = inspect.getsourcefile(confirm_token_v1) or ""
-    prereg_mod = inspect.getsourcefile(preregistration_contract_v1) or ""
-    wallclock_mod = inspect.getsourcefile(wallclock_auth) or ""
-    shadow_mod = inspect.getsourcefile(shadow_auth) or ""
+    # inspect.getsourcefile returns absolute local paths; persist only
+    # repository-relative POSIX paths for portable evidence digests.
+    confirm_mod = _module_path_repository_relative_v1(
+        inspect.getsourcefile(confirm_token_v1),
+        repo_root=root,
+    )
+    prereg_mod = _module_path_repository_relative_v1(
+        inspect.getsourcefile(preregistration_contract_v1),
+        repo_root=root,
+    )
+    wallclock_mod = _module_path_repository_relative_v1(
+        inspect.getsourcefile(wallclock_auth),
+        repo_root=root,
+    )
+    shadow_mod = _module_path_repository_relative_v1(
+        inspect.getsourcefile(shadow_auth),
+        repo_root=root,
+    )
 
     plaintext_guard = "assert_no_plaintext_token_fields" in dir(confirm_token_v1)
     fingerprint_only = "fingerprint_confirm_token" in dir(confirm_token_v1)

--- a/src/ops/phase_9_2_public_md_session_preflight_v1/evidence_v1.py
+++ b/src/ops/phase_9_2_public_md_session_preflight_v1/evidence_v1.py
@@ -47,6 +47,9 @@ from src.ops.phase_9_2_public_md_session_preflight_v1.pacing_safety_v1 import (
     prove_pacing_and_staleness_safety_v1,
 )
 from src.ops.phase_9_2_public_md_session_preflight_v1.parity_v1 import prove_phase92_parity_v1
+from src.ops.phase_9_2_public_md_session_preflight_v1.path_portability_v1 import (
+    assert_no_absolute_local_paths_v1,
+)
 from src.ops.phase_9_2_public_md_session_preflight_v1.prerequisites_v1 import (
     prove_phase92_prerequisites_v1,
 )
@@ -63,7 +66,12 @@ def _sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _write_json(path: Path, payload: Dict[str, Any]) -> str:
+def _write_json(path: Path, payload: Dict[str, Any], *, repo_root: Path) -> str:
+    assert_no_absolute_local_paths_v1(
+        payload,
+        repo_root=repo_root,
+        context=path.name,
+    )
     text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
@@ -195,24 +203,34 @@ def build_preflight_evidence_v1(
         out_dir = root / "docs" / "evidence" / EVIDENCE_DIRNAME / EVIDENCE_SUBDIR
         digests: Dict[str, str] = {}
         digests[SMOKE_CONTRACT_FILENAME] = _write_json(
-            out_dir / SMOKE_CONTRACT_FILENAME, contract.to_dict()
+            out_dir / SMOKE_CONTRACT_FILENAME, contract.to_dict(), repo_root=root
         )
         digests[SESSION_LADDER_FILENAME] = _write_json(
-            out_dir / SESSION_LADDER_FILENAME, session_ladder
+            out_dir / SESSION_LADDER_FILENAME, session_ladder, repo_root=root
         )
         digests[PREREQUISITE_MATRIX_FILENAME] = _write_json(
-            out_dir / PREREQUISITE_MATRIX_FILENAME, prerequisites
+            out_dir / PREREQUISITE_MATRIX_FILENAME, prerequisites, repo_root=root
         )
-        digests[NETWORK_PROOF_FILENAME] = _write_json(out_dir / NETWORK_PROOF_FILENAME, network)
-        digests[PACING_PROOF_FILENAME] = _write_json(out_dir / PACING_PROOF_FILENAME, pacing)
-        digests[AUTH_PATH_FILENAME] = _write_json(out_dir / AUTH_PATH_FILENAME, auth_path)
-        digests[RESTART_PROOF_FILENAME] = _write_json(out_dir / RESTART_PROOF_FILENAME, restart)
-        digests[PARITY_PROOF_FILENAME] = _write_json(out_dir / PARITY_PROOF_FILENAME, parity)
+        digests[NETWORK_PROOF_FILENAME] = _write_json(
+            out_dir / NETWORK_PROOF_FILENAME, network, repo_root=root
+        )
+        digests[PACING_PROOF_FILENAME] = _write_json(
+            out_dir / PACING_PROOF_FILENAME, pacing, repo_root=root
+        )
+        digests[AUTH_PATH_FILENAME] = _write_json(
+            out_dir / AUTH_PATH_FILENAME, auth_path, repo_root=root
+        )
+        digests[RESTART_PROOF_FILENAME] = _write_json(
+            out_dir / RESTART_PROOF_FILENAME, restart, repo_root=root
+        )
+        digests[PARITY_PROOF_FILENAME] = _write_json(
+            out_dir / PARITY_PROOF_FILENAME, parity, repo_root=root
+        )
         digests[FAILURE_INJECTION_FILENAME] = _write_json(
-            out_dir / FAILURE_INJECTION_FILENAME, failures
+            out_dir / FAILURE_INJECTION_FILENAME, failures, repo_root=root
         )
         digests[CLAIM_MATRIX_FILENAME] = _write_json(
-            out_dir / CLAIM_MATRIX_FILENAME, claims.to_dict()
+            out_dir / CLAIM_MATRIX_FILENAME, claims.to_dict(), repo_root=root
         )
         readiness = {
             "ok": ready,
@@ -231,7 +249,9 @@ def build_preflight_evidence_v1(
                 "do not start network or consume authorization from this preflight."
             ),
         }
-        digests[READINESS_FILENAME] = _write_json(out_dir / READINESS_FILENAME, readiness)
+        digests[READINESS_FILENAME] = _write_json(
+            out_dir / READINESS_FILENAME, readiness, repo_root=root
+        )
         result = {
             "ok": ready,
             "capability_id": CAPABILITY_ID,
@@ -243,17 +263,21 @@ def build_preflight_evidence_v1(
             "claims": claims.to_dict(),
             "gaps": gaps,
         }
-        digests[RESULT_FILENAME] = _write_json(out_dir / RESULT_FILENAME, result)
+        digests[RESULT_FILENAME] = _write_json(out_dir / RESULT_FILENAME, result, repo_root=root)
         evidence_payload = evidence.to_dict()
-        digests[EVIDENCE_FILENAME] = _write_json(out_dir / EVIDENCE_FILENAME, evidence_payload)
+        digests[EVIDENCE_FILENAME] = _write_json(
+            out_dir / EVIDENCE_FILENAME, evidence_payload, repo_root=root
+        )
         evidence.evidence_digest = digests[EVIDENCE_FILENAME]
         # Rewrite evidence with digest filled.
-        digests[EVIDENCE_FILENAME] = _write_json(out_dir / EVIDENCE_FILENAME, evidence.to_dict())
+        digests[EVIDENCE_FILENAME] = _write_json(
+            out_dir / EVIDENCE_FILENAME, evidence.to_dict(), repo_root=root
+        )
         _write_manifest(out_dir, digests)
 
         # Canonical config mirror (preregistration draft for later Owner-GO).
         config_path = root / CONFIG_RELATIVE_PATH
-        _write_json(config_path, contract.to_dict())
+        _write_json(config_path, contract.to_dict(), repo_root=root)
 
         summary = {
             "ok": ready,
@@ -264,7 +288,11 @@ def build_preflight_evidence_v1(
             "smoke_contract_digest": contract.smoke_contract_digest,
             "evidence_digest": evidence.evidence_digest,
         }
-        _write_json(root / "docs" / "evidence" / EVIDENCE_DIRNAME / "SUMMARY.json", summary)
+        _write_json(
+            root / "docs" / "evidence" / EVIDENCE_DIRNAME / "SUMMARY.json",
+            summary,
+            repo_root=root,
+        )
         # Top-level manifest points at preflight artifacts.
         top_manifest = {
             SMOKE_CONTRACT_FILENAME: digests[SMOKE_CONTRACT_FILENAME],

--- a/src/ops/phase_9_2_public_md_session_preflight_v1/path_portability_v1.py
+++ b/src/ops/phase_9_2_public_md_session_preflight_v1/path_portability_v1.py
@@ -1,0 +1,136 @@
+"""Repository-relative POSIX path serialization for Phase 9.2 evidence.
+
+Runtime resolution may use absolute paths internally. Persisted evidence,
+JSON, manifests and digests must only contain repository-relative POSIX
+paths. Paths outside the repository root fail closed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+_FILE_URI_RE = re.compile(r"^file:", re.IGNORECASE)
+_FILE_URI_ANYWHERE_RE = re.compile(r"file://", re.IGNORECASE)
+_WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_WIN_UNC_RE = re.compile(r"^\\\\")
+# Substring leaks for local filesystem / sandbox roots.
+# Do not match bare "[A-Za-z]:/" — that false-positives on URL schemes like https://.
+_ABS_LEAK_SUBSTRINGS = (
+    "/Users/",
+    "/home/",
+    "/private/tmp/",
+    "/var/folders/",
+    "/tmp/",
+)
+
+
+class PathPortabilityError(ValueError):
+    """Fail-closed path portability violation."""
+
+
+def looks_absolute_filesystem_path_v1(value: str) -> bool:
+    raw = str(value).strip()
+    if not raw:
+        return False
+    if _FILE_URI_RE.match(raw):
+        return True
+    if raw.startswith("/"):
+        return True
+    if _WIN_DRIVE_RE.match(raw) or _WIN_UNC_RE.match(raw):
+        return True
+    return False
+
+
+def to_repository_relative_posix_path_v1(
+    path: str | Path,
+    *,
+    repo_root: Path,
+) -> str:
+    """Serialize a path as a canonical repository-relative POSIX path.
+
+    - Absolute inputs under ``repo_root`` become relative POSIX paths.
+    - Already-relative inputs remain stable after POSIX normalization.
+    - Paths outside ``repo_root``, ``file://`` URIs, and drive-letter /
+      UNC absolutes that cannot be bound to ``repo_root`` fail closed.
+    """
+    if path is None:
+        raise PathPortabilityError("path_empty")
+    raw = str(path).strip()
+    if not raw:
+        raise PathPortabilityError("path_empty")
+    if _FILE_URI_RE.match(raw):
+        raise PathPortabilityError("file_uri_forbidden")
+
+    root = Path(repo_root).resolve()
+
+    if _WIN_DRIVE_RE.match(raw) or _WIN_UNC_RE.match(raw):
+        # Windows absolute / UNC forms are not portable evidence paths.
+        # Only accept them when they resolve under the provided repo_root
+        # on a Windows host; otherwise fail closed.
+        try:
+            candidate = Path(raw).resolve()
+            return candidate.relative_to(root).as_posix()
+        except (OSError, ValueError) as exc:
+            raise PathPortabilityError("path_outside_repository_root") from exc
+
+    if looks_absolute_filesystem_path_v1(raw):
+        try:
+            candidate = Path(raw).resolve()
+            return candidate.relative_to(root).as_posix()
+        except (OSError, ValueError) as exc:
+            raise PathPortabilityError("path_outside_repository_root") from exc
+
+    normalized = raw.replace("\\", "/")
+    while "//" in normalized:
+        normalized = normalized.replace("//", "/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    if looks_absolute_filesystem_path_v1(normalized):
+        raise PathPortabilityError("absolute_path_forbidden")
+
+    try:
+        resolved = (root / PurePosixPath(normalized)).resolve()
+        return resolved.relative_to(root).as_posix()
+    except (OSError, ValueError) as exc:
+        raise PathPortabilityError("path_outside_repository_root") from exc
+
+
+def assert_no_absolute_local_paths_v1(
+    payload: Any,
+    *,
+    repo_root: Path | None = None,
+    context: str = "evidence_payload",
+) -> None:
+    """Fail closed if any string value leaks an absolute local filesystem path."""
+    root_prefixes: tuple[str, ...] = ()
+    if repo_root is not None:
+        root = Path(repo_root).resolve()
+        root_prefixes = (root.as_posix(), str(root))
+
+    for value in _iter_strings_v1(payload):
+        if any(token in value for token in _ABS_LEAK_SUBSTRINGS):
+            raise PathPortabilityError(f"absolute_local_path_in_{context}:{value[:160]}")
+        if _FILE_URI_ANYWHERE_RE.search(value):
+            raise PathPortabilityError(f"file_uri_in_{context}:{value[:160]}")
+        if _WIN_DRIVE_RE.match(value) or _WIN_UNC_RE.match(value):
+            raise PathPortabilityError(f"absolute_local_path_in_{context}:{value[:160]}")
+        for prefix in root_prefixes:
+            if prefix and prefix in value:
+                raise PathPortabilityError(f"repository_root_leak_in_{context}:{value[:160]}")
+
+
+def _iter_strings_v1(payload: Any) -> Iterable[str]:
+    if isinstance(payload, str):
+        yield payload
+        return
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if isinstance(key, str):
+                yield key
+            yield from _iter_strings_v1(value)
+        return
+    if isinstance(payload, (list, tuple)):
+        for item in payload:
+            yield from _iter_strings_v1(item)

--- a/src/ops/phase_9_2_public_md_session_preflight_v1/prerequisites_v1.py
+++ b/src/ops/phase_9_2_public_md_session_preflight_v1/prerequisites_v1.py
@@ -11,6 +11,9 @@ from src.ops.phase_9_2_public_md_session_preflight_v1.constants_v1 import (
     PREDECESSOR_CAPABILITY_ID,
     repo_root_v1,
 )
+from src.ops.phase_9_2_public_md_session_preflight_v1.path_portability_v1 import (
+    to_repository_relative_posix_path_v1,
+)
 from src.ops.single_future_stateful_no_order_runtime_activation_v1.config_v1 import (
     load_activation_config_v1,
 )
@@ -52,7 +55,7 @@ def prove_phase91_closed_v1(*, repo_root: Path | None = None) -> dict[str, Any]:
         "capability_id": result.get("capability_id"),
         "expected_capability_id": PREDECESSOR_CAPABILITY_ID,
         "LEGACY_PARALLEL_AUTHORITY_ABSENT": bool(claims.get("LEGACY_PARALLEL_AUTHORITY_ABSENT")),
-        "result_path": str(result_path.relative_to(root)),
+        "result_path": to_repository_relative_posix_path_v1(result_path, repo_root=root),
     }
 
 

--- a/tests/ops/test_phase_9_2_evidence_generator_portable_path_v1.py
+++ b/tests/ops/test_phase_9_2_evidence_generator_portable_path_v1.py
@@ -1,0 +1,239 @@
+"""Portable repository-relative path serialization for Phase 9.2 evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from src.ops.phase_9_2_public_md_session_preflight_v1.authorization_path_v1 import (
+    prove_authorization_and_confirm_token_path_v1,
+)
+from src.ops.phase_9_2_public_md_session_preflight_v1.constants_v1 import CORE_LOGIC_CHANGE
+from src.ops.phase_9_2_public_md_session_preflight_v1.evidence_v1 import (
+    build_preflight_evidence_v1,
+)
+from src.ops.phase_9_2_public_md_session_preflight_v1.path_portability_v1 import (
+    PathPortabilityError,
+    assert_no_absolute_local_paths_v1,
+    to_repository_relative_posix_path_v1,
+)
+from src.ops.phase_9_2_public_md_session_preflight_v1.prerequisites_v1 import (
+    prove_phase91_closed_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+# Case-sensitive local FS roots (avoid matching API paths like /api/v5/users/...).
+ABS_LEAK_RE = re.compile(r"(?:/Users/|/home/|/private/tmp/|/var/folders/|/tmp/|(?i:file://))")
+REPO_SHA = "debdfd7ca6151fdb3f7a28d4cd05ef9a5ab30956"
+
+
+def _sha256_canonical(payload: dict) -> str:
+    text = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def test_absolute_input_serialized_repository_relative(tmp_path: Path) -> None:
+    root = tmp_path / "repo_a"
+    target = root / "src" / "ops" / "example_v1.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("# fixture\n", encoding="utf-8")
+    rel = to_repository_relative_posix_path_v1(str(target.resolve()), repo_root=root)
+    assert rel == "src/ops/example_v1.py"
+    assert not Path(rel).is_absolute()
+    assert ABS_LEAK_RE.search(rel) is None
+
+
+def test_relative_paths_remain_stable(tmp_path: Path) -> None:
+    root = tmp_path / "repo_b"
+    (root / "docs" / "evidence").mkdir(parents=True)
+    assert (
+        to_repository_relative_posix_path_v1(
+            "docs/evidence/capability_phase_9_2/foo.json",
+            repo_root=root,
+        )
+        == "docs/evidence/capability_phase_9_2/foo.json"
+    )
+    assert (
+        to_repository_relative_posix_path_v1(
+            r"docs\evidence\capability_phase_9_2\foo.json",
+            repo_root=root,
+        )
+        == "docs/evidence/capability_phase_9_2/foo.json"
+    )
+    assert (
+        to_repository_relative_posix_path_v1(
+            "./src/ops/module_v1.py",
+            repo_root=root,
+        )
+        == "src/ops/module_v1.py"
+    )
+
+
+def test_paths_outside_repository_root_fail_closed(tmp_path: Path) -> None:
+    root = tmp_path / "repo_c"
+    root.mkdir()
+    outside = tmp_path / "outside" / "secret.py"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("x\n", encoding="utf-8")
+    with pytest.raises(PathPortabilityError, match="path_outside_repository_root"):
+        to_repository_relative_posix_path_v1(str(outside.resolve()), repo_root=root)
+    with pytest.raises(PathPortabilityError, match="file_uri_forbidden"):
+        to_repository_relative_posix_path_v1(
+            f"file://{outside.resolve().as_posix()}",
+            repo_root=root,
+        )
+    with pytest.raises(PathPortabilityError, match="path_outside_repository_root"):
+        to_repository_relative_posix_path_v1(
+            r"C:\Users\other\Peak_Trade\src\ops\x.py",
+            repo_root=root,
+        )
+    with pytest.raises(PathPortabilityError, match="path_outside_repository_root"):
+        to_repository_relative_posix_path_v1("../escape.py", repo_root=root)
+
+
+def test_windows_and_posix_path_variants(tmp_path: Path) -> None:
+    root = tmp_path / "repo_d"
+    (root / "src" / "ops").mkdir(parents=True)
+    posix_rel = to_repository_relative_posix_path_v1(
+        "src/ops/authorization_path_v1.py",
+        repo_root=root,
+    )
+    win_rel = to_repository_relative_posix_path_v1(
+        r"src\ops\authorization_path_v1.py",
+        repo_root=root,
+    )
+    assert posix_rel == win_rel == "src/ops/authorization_path_v1.py"
+
+
+def test_cross_root_digest_determinism(tmp_path: Path) -> None:
+    rel = "src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/confirm_token_v1.py"
+    digests: list[str] = []
+    for name in ("Users_alice_Peak_Trade", "home_bob_Peak_Trade"):
+        root = tmp_path / name
+        target = root / rel
+        target.parent.mkdir(parents=True)
+        target.write_text("same-bytes\n", encoding="utf-8")
+        serialized = to_repository_relative_posix_path_v1(str(target.resolve()), repo_root=root)
+        payload = {
+            "module_paths": {"confirm_token_v1": serialized},
+            "semantic_marker": "unchanged",
+        }
+        digests.append(_sha256_canonical(payload))
+        assert serialized == rel
+    assert digests[0] == digests[1]
+
+
+def test_authorization_path_persists_repository_relative_only() -> None:
+    payload = prove_authorization_and_confirm_token_path_v1(repo_root=REPO_ROOT)
+    assert payload["ok"] is True
+    module_paths = payload["module_paths"]
+    assert module_paths
+    for key, value in module_paths.items():
+        assert isinstance(value, str)
+        assert value.startswith("src/ops/")
+        assert "/" in value
+        assert "\\" not in value
+        assert not Path(value).is_absolute()
+        assert ABS_LEAK_RE.search(value) is None
+        assert str(REPO_ROOT.resolve()) not in value
+    assert_no_absolute_local_paths_v1(payload, repo_root=REPO_ROOT)
+    # Semantic identity unchanged beyond path portability.
+    assert payload["AUTHORIZATION_ISSUED"] is False
+    assert payload["AUTHORIZATION_CONSUMED"] is False
+    assert payload["CONFIRM_TOKEN_PLAINTEXT_EXPOSED"] is False
+
+
+def test_prerequisite_result_path_is_posix_relative() -> None:
+    phase91 = prove_phase91_closed_v1(repo_root=REPO_ROOT)
+    assert phase91["ok"] is True
+    result_path = phase91["result_path"]
+    assert result_path == (
+        "docs/evidence/capability_phase_9_1_strategy_registry_closure_v1/"
+        "productive_binding/phase_9_1_strategy_registry_closure_result_v1.json"
+    )
+    assert ABS_LEAK_RE.search(result_path) is None
+
+
+def test_fixture_materialize_has_no_absolute_paths(tmp_path: Path) -> None:
+    """Deterministic local generator probe into an isolated fixture root."""
+    fixture_root = tmp_path / "fixture_repo"
+    # Minimal tree: reuse productive activation/config + predecessor evidence via copies.
+    copy_pairs = [
+        "config/runtime/single_future_stateful_no_order_runtime_activation_v1.json",
+        "docs/evidence/capability_phase_9_1_strategy_registry_closure_v1/SUMMARY.json",
+        (
+            "docs/evidence/capability_phase_9_1_strategy_registry_closure_v1/"
+            "productive_binding/phase_9_1_strategy_registry_closure_result_v1.json"
+        ),
+        (
+            "docs/evidence/capability_7_2_single_future_stateful_no_order_runtime_activation_v1/"
+            "SUMMARY.json"
+        ),
+        (
+            "docs/evidence/capability_7_2_single_future_stateful_no_order_runtime_activation_v1/"
+            "productive_binding/activation_status_v1.json"
+        ),
+        (
+            "docs/evidence/capability_7_2_single_future_stateful_no_order_runtime_activation_v1/"
+            "productive_binding/single_future_stateful_no_order_runtime_activation_result_v1.json"
+        ),
+        (
+            "docs/evidence/capability_7_2_single_future_stateful_no_order_runtime_activation_v1/"
+            "productive_binding/startup_restart_reconciliation_proof_v1.json"
+        ),
+    ]
+    for rel in copy_pairs:
+        src = REPO_ROOT / rel
+        dst = fixture_root / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_bytes(src.read_bytes())
+
+    evidence = build_preflight_evidence_v1(
+        repository_sha=REPO_SHA,
+        repo_root=fixture_root,
+        materialize=True,
+    )
+    assert evidence.ok is True
+    assert CORE_LOGIC_CHANGE is False
+
+    generated_root = (
+        fixture_root
+        / "docs/evidence/capability_phase_9_2_long_running_stateful_public_md_simulation_evidence_v1"
+    )
+    findings: list[str] = []
+    for path in generated_root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix not in {".json", ".md", ".txt", ".sha256"}:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for match in ABS_LEAK_RE.finditer(text):
+            start = max(0, match.start() - 40)
+            end = min(len(text), match.end() + 80)
+            findings.append(f"{path.name}:{text[start:end]!r}")
+        assert str(REPO_ROOT.resolve()) not in text
+        assert str(fixture_root.resolve()) not in text
+    assert findings == [], findings
+
+    auth = json.loads(
+        (generated_root / "preflight" / "authorization_confirm_token_path_v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    for value in auth["module_paths"].values():
+        assert value.startswith("src/ops/")
+        assert not Path(value).is_absolute()
+
+    # Productive session evidence under the real repo must remain untouched by this probe.
+    session_marker = (
+        REPO_ROOT
+        / "docs/evidence/capability_phase_9_2_long_running_stateful_public_md_simulation_evidence_v1"
+        / "sessions"
+        / "phase_9_2_public_md_smoke_session_v1"
+        / "phase_9_2_public_md_smoke_session_evidence_v1.json"
+    )
+    assert session_marker.is_file()

--- a/tests/ops/test_phase_9_2_public_md_session_preflight_v1.py
+++ b/tests/ops/test_phase_9_2_public_md_session_preflight_v1.py
@@ -79,10 +79,12 @@ def test_failure_injections() -> None:
 
 
 def test_build_preflight_evidence_ready() -> None:
+    # materialize=False keeps productive evidence/config byte-identical; portable
+    # materialization coverage lives in test_phase_9_2_evidence_generator_portable_path_v1.
     evidence = build_preflight_evidence_v1(
         repository_sha=REPO_SHA,
         repo_root=REPO_ROOT,
-        materialize=True,
+        materialize=False,
     )
     assert evidence.ok is True
     assert evidence.capability_id == CAPABILITY_ID


### PR DESCRIPTION
## Summary
- Fix Phase 9.2 smoke evidence generator root cause: `inspect.getsourcefile()` absolute local paths are now serialized as repository-relative POSIX paths before persistence.
- Add fail-closed path portability helper + write-time absolute-local-path guard for generated JSON evidence.
- Add focused portable-path tests (absolute/relative/Windows/POSIX, outside-root fail-closed, cross-root digest determinism, fixture materialize probe) and stop the owner readiness test from rewriting productive evidence.

## Test plan
- [x] `pytest tests/ops/test_phase_9_2_evidence_generator_portable_path_v1.py`
- [x] `pytest tests/ops/test_phase_9_2_public_md_session_preflight_v1.py`
- [x] PR-bounded selector path timing proof (743 passed, ~52s)
- [x] `ruff format --check` + `ruff check` on changed files
- [ ] GitHub CI confirmation on PR

## Safety / scope
- `CORE_LOGIC_CHANGE=false`
- No network session, authorization consumption, session evidence/metrics/claims mutation
- Preexisting dirty worktree preserved byte-identical outside this PR


Made with [Cursor](https://cursor.com)