### PR TITLE
Phase 9.2: fix rate_limit_event_count hash false positives

### DIFF
--- a/src/ops/phase_9_2_public_md_session_preflight_v1/rate_limit_metric_v1.py
+++ b/src/ops/phase_9_2_public_md_session_preflight_v1/rate_limit_metric_v1.py
@@ -1,0 +1,224 @@
+"""Structured Phase 9.2 rate-limit event counting (no substring false positives).
+
+``rate_limit_event_count`` counts only semantically classified rate-limit
+events from:
+
+- exact HTTP status ``429`` on typed status fields;
+- canonical transport ``error_code`` / reason tokens
+  (``RATE_LIMIT_HTTP_429`` and siblings);
+- authoritative transport telemetry field ``http_429_count``.
+
+It must never count bare ``"429"`` substrings inside hashes, digests, IDs,
+timestamps or free-text blobs.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+# Canonical EEA public-MD transport rate-limit classification codes.
+# Source: ops.integrated_paper_shadow_observation_wallclock_session_execution_v1.eea_public_md_transport_v1
+CANONICAL_RATE_LIMIT_ERROR_CODES: frozenset[str] = frozenset(
+    {
+        "RATE_LIMIT_HTTP_429",
+        "RATE_LIMIT_SESSION_BUDGET_EXCEEDED",
+        "RATE_LIMIT_RETRY_EXHAUSTED",
+        "RATE_LIMIT_RETRY_SCHEDULED",
+        "RATE_LIMIT_RETRY_AFTER_INVALID",
+    }
+)
+
+# Colon-/underscore-/slash-delimited token splitter for error chains such as
+# FETCH_FAILED:RATE_LIMIT_RETRY_EXHAUSTED:RATE_LIMIT_HTTP_429
+_TOKEN_SPLIT_RE = re.compile(r"[^A-Za-z0-9_]+")
+
+# Typed status field names (exact equality to 429 only).
+_HTTP_STATUS_FIELDS: frozenset[str] = frozenset(
+    {
+        "status",
+        "http_status",
+        "status_code",
+        "http_status_code",
+        "response_status",
+    }
+)
+
+# Typed classification field names that may carry canonical error codes.
+_CLASSIFICATION_FIELDS: frozenset[str] = frozenset(
+    {
+        "error_code",
+        "reason_code",
+        "reason",
+        "event",
+        "trigger",
+        "classification",
+        "detail",
+    }
+)
+
+# JSON / JSONL surfaces under a wallclock evidence root that may carry rate-limit telemetry.
+_EVIDENCE_SCAN_NAMES: tuple[str, ...] = (
+    "connectivity_events.jsonl",
+    "reconnect_events.jsonl",
+    "stale_events.jsonl",
+    "killstate_events.jsonl",
+    "runtime_events.jsonl",
+    "shutdown_reason.json",
+    "transport_telemetry.json",
+    "observation_cycle_counters.json",
+    "integrity_manifest.json",
+)
+
+
+def is_exact_http_429_status_v1(value: Any) -> bool:
+    """True only for typed HTTP status exactly 429."""
+    if value is True or value is False or value is None:
+        return False
+    if isinstance(value, int):
+        return value == 429
+    if isinstance(value, str):
+        return value.strip() == "429"
+    return False
+
+
+def tokens_from_classification_value_v1(value: Any) -> frozenset[str]:
+    """Extract alphanumeric/underscore tokens from a classification string."""
+    if not isinstance(value, str):
+        return frozenset()
+    raw = value.strip()
+    if not raw:
+        return frozenset()
+    return frozenset(tok for tok in _TOKEN_SPLIT_RE.split(raw.upper()) if tok)
+
+
+def has_canonical_rate_limit_code_v1(value: Any) -> bool:
+    """True when a classification value contains a canonical rate-limit code token."""
+    return bool(tokens_from_classification_value_v1(value) & CANONICAL_RATE_LIMIT_ERROR_CODES)
+
+
+def leaf_event_is_rate_limit_v1(event: Mapping[str, Any]) -> bool:
+    """Classify one mapping as a rate-limit event using only its own typed fields."""
+    if not isinstance(event, Mapping):
+        return False
+
+    if event.get("http_429") is True or event.get("rate_limit") is True:
+        return True
+
+    for key in _HTTP_STATUS_FIELDS:
+        if key in event and is_exact_http_429_status_v1(event.get(key)):
+            return True
+
+    for key in _CLASSIFICATION_FIELDS:
+        if key in event and has_canonical_rate_limit_code_v1(event.get(key)):
+            return True
+
+    return False
+
+
+def event_is_rate_limit_v1(event: Mapping[str, Any]) -> bool:
+    """Public predicate: leaf or nested envelope contains a rate-limit classification."""
+    if leaf_event_is_rate_limit_v1(event):
+        return True
+    for nested_key in ("killstate", "transport", "telemetry", "events"):
+        nested = event.get(nested_key)
+        if isinstance(nested, Mapping) and event_is_rate_limit_v1(nested):
+            return True
+        if isinstance(nested, list):
+            for item in nested:
+                if isinstance(item, Mapping) and event_is_rate_limit_v1(item):
+                    return True
+    return False
+
+
+def _authoritative_http_429_count_v1(payload: Mapping[str, Any]) -> int | None:
+    """Return transport telemetry http_429_count when present and typed.
+
+    Does not trust packaged ``rate_limit_event_count`` (may be a defective value).
+    """
+    for key in ("http_429_count", "http_429_event_count"):
+        if key in payload:
+            value = payload[key]
+            if isinstance(value, int) and value >= 0:
+                return value
+            if isinstance(value, str) and value.strip().isdigit():
+                return int(value.strip())
+    telemetry = payload.get("transport_telemetry")
+    if isinstance(telemetry, Mapping):
+        return _authoritative_http_429_count_v1(telemetry)
+    return None
+
+
+def count_rate_limit_events_in_payloads_v1(payloads: Iterable[Any]) -> int:
+    """Count rate-limit events across structured payloads (dicts / nested lists)."""
+    discrete = 0
+    authoritative: list[int] = []
+
+    def _walk(node: Any) -> None:
+        nonlocal discrete
+        if isinstance(node, Mapping):
+            auth = _authoritative_http_429_count_v1(node)
+            if auth is not None:
+                authoritative.append(auth)
+            if leaf_event_is_rate_limit_v1(node):
+                discrete += 1
+            for value in node.values():
+                if isinstance(value, (Mapping, list, tuple)):
+                    _walk(value)
+        elif isinstance(node, (list, tuple)):
+            for item in node:
+                _walk(item)
+
+    for payload in payloads:
+        _walk(payload)
+
+    # Prefer authoritative transport counter when present (single session source).
+    if authoritative:
+        return max(authoritative)
+    return discrete
+
+
+def _load_json_or_jsonl_v1(path: Path) -> list[Any]:
+    if not path.is_file():
+        return []
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        return []
+    if path.suffix == ".jsonl":
+        out: list[Any] = []
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            out.append(json.loads(line))
+        return out
+    payload = json.loads(text)
+    return [payload]
+
+
+def count_rate_limit_events_from_evidence_root_v1(evidence_root: Path) -> int:
+    """Count structured rate-limit events under a session or wallclock evidence directory."""
+    root = Path(evidence_root)
+    scan_roots = [root]
+    wallclock = root / "wallclock_run"
+    if wallclock.is_dir():
+        scan_roots.append(wallclock)
+    payloads: list[Any] = []
+    for scan_root in scan_roots:
+        for name in _EVIDENCE_SCAN_NAMES:
+            payloads.extend(_load_json_or_jsonl_v1(scan_root / name))
+    return count_rate_limit_events_in_payloads_v1(payloads)
+
+
+def compute_rate_limit_event_count_v1(
+    *,
+    evidence_root: Path | None = None,
+    payloads: Iterable[Any] | None = None,
+) -> int:
+    """Public Phase 9.2 metric entrypoint for ``rate_limit_event_count``."""
+    if evidence_root is not None:
+        return count_rate_limit_events_from_evidence_root_v1(Path(evidence_root))
+    if payloads is not None:
+        return count_rate_limit_events_in_payloads_v1(payloads)
+    raise ValueError("RATE_LIMIT_METRIC_INPUT_REQUIRED")

--- a/tests/ops/test_phase_9_2_rate_limit_metric_false_positive_v1.py
+++ b/tests/ops/test_phase_9_2_rate_limit_metric_false_positive_v1.py
@@ -1,0 +1,168 @@
+"""False-positive fix tests for Phase 9.2 rate_limit_event_count."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ops.phase_9_2_public_md_session_preflight_v1.rate_limit_metric_v1 import (
+    compute_rate_limit_event_count_v1,
+    count_rate_limit_events_in_payloads_v1,
+    event_is_rate_limit_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ONE_HOUR_EVIDENCE = (
+    REPO_ROOT
+    / "docs/evidence/capability_phase_9_2_long_running_stateful_public_md_simulation_evidence_v1"
+    / "sessions/phase_9_2_public_md_one_hour_governed_session_v1"
+    / "phase_9_2_public_md_one_hour_governed_session_evidence_v1.json"
+)
+
+
+def _defective_substring_count(payloads: list[object]) -> int:
+    """Reproduce the confirmed false-positive antipattern (do not use in production)."""
+    return sum(1 for row in payloads if "429" in json.dumps(row, sort_keys=True))
+
+
+def test_a_hash_false_positive_not_counted() -> None:
+    payloads = [
+        {
+            "feature_digest": "9b429a1c0ffee0123456789abcdef429deadbeef",
+            "sha256": "aa429bbccdddeeefff00112233445566778899aa",
+            "id": "evt_429abc",
+            "observation_id": "obs-429-hash-only",
+        }
+    ]
+    assert _defective_substring_count(payloads) >= 1
+    assert compute_rate_limit_event_count_v1(payloads=payloads) == 0
+
+
+def test_b_real_http_429_counted_once() -> None:
+    payloads = [{"event": "http_response", "http_status": 429, "path": "/api/v5/market/ticker"}]
+    assert compute_rate_limit_event_count_v1(payloads=payloads) == 1
+    assert event_is_rate_limit_v1(payloads[0]) is True
+
+
+def test_c_multiple_real_http_429_exact_count() -> None:
+    payloads = [
+        {"http_status": 429, "seq": 1},
+        {"status": 429, "seq": 2},
+        {"status_code": "429", "seq": 3},
+        {"error_code": "RATE_LIMIT_HTTP_429", "seq": 4},
+    ]
+    assert compute_rate_limit_event_count_v1(payloads=payloads) == 4
+
+
+def test_d_free_text_429_without_classification_not_counted() -> None:
+    payloads = [
+        {
+            "exception": "upstream returned 429 in message body snippet",
+            "message": "retry later: code=429",
+            "note": "contains 429 but is not a rate-limit classification",
+        }
+    ]
+    assert _defective_substring_count(payloads) >= 1
+    assert compute_rate_limit_event_count_v1(payloads=payloads) == 0
+
+
+def test_e_dns_abort_not_counted_as_rate_limit() -> None:
+    payloads = [
+        {
+            "event": "killstate",
+            "detail": (
+                "TRANSPORT_FAILURE:FETCH_FAILED:DNS_RESOLUTION_FAILED:"
+                "[Errno 8] nodename nor servname provided, or not known"
+            ),
+            "trigger": "INVARIANT_VIOLATION",
+        }
+    ]
+    assert compute_rate_limit_event_count_v1(payloads=payloads) == 0
+
+
+def test_f_mixed_events_exactly_one_real_429() -> None:
+    payloads = [
+        {"feature_digest": "deadbeef429cafe"},
+        {
+            "detail": (
+                "TRANSPORT_FAILURE:FETCH_FAILED:DNS_RESOLUTION_FAILED:"
+                "[Errno 8] nodename nor servname provided, or not known"
+            )
+        },
+        {"error": "timeout", "message": "read timed out after 429ms"},
+        {"http_status": 429, "path": "/api/v5/market/books"},
+        {"exception": "saw 429 in free text"},
+    ]
+    assert compute_rate_limit_event_count_v1(payloads=payloads) == 1
+
+
+def test_authoritative_transport_http_429_count_preferred() -> None:
+    payloads = [
+        {"transport_telemetry": {"http_429_count": 2}},
+        {"http_status": 429},
+        {"http_status": 429},
+        {"http_status": 429},
+    ]
+    assert compute_rate_limit_event_count_v1(payloads=payloads) == 2
+
+
+def test_canonical_error_chain_token_match() -> None:
+    payloads = [
+        {
+            "detail": "FETCH_FAILED:RATE_LIMIT_RETRY_EXHAUSTED:RATE_LIMIT_HTTP_429",
+        }
+    ]
+    assert compute_rate_limit_event_count_v1(payloads=payloads) == 1
+
+
+def test_evidence_root_scan_tmp(tmp_path: Path) -> None:
+    root = tmp_path / "session"
+    root.mkdir()
+    (root / "connectivity_events.jsonl").write_text(
+        json.dumps({"feature_digest": "x429y"}) + "\n" + json.dumps({"http_status": 429}) + "\n",
+        encoding="utf-8",
+    )
+    (root / "shutdown_reason.json").write_text(
+        json.dumps(
+            {
+                "detail": (
+                    "TRANSPORT_FAILURE:FETCH_FAILED:DNS_RESOLUTION_FAILED:"
+                    "[Errno 8] nodename nor servname provided, or not known"
+                )
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert compute_rate_limit_event_count_v1(evidence_root=root) == 1
+
+
+def test_g_regression_historical_one_hour_package_not_mutated_and_metric_zero() -> None:
+    """Historical packaged evidence stays byte-identical; structured recount is 0."""
+    if not ONE_HOUR_EVIDENCE.is_file():
+        # Untracked local evidence may be absent in clean CI clones.
+        return
+    before = ONE_HOUR_EVIDENCE.read_bytes()
+    packaged = json.loads(before.decode("utf-8"))
+    assert packaged["metrics"]["rate_limit_event_count"] == 24
+
+    session_dir = ONE_HOUR_EVIDENCE.parent
+    wallclock = session_dir / "wallclock_run"
+    runtime_path = wallclock / "runtime_events.jsonl"
+
+    # Defective packager scanned runtime_events via bare "429" substring (== 24).
+    payloads: list[object] = []
+    if runtime_path.is_file():
+        for line in runtime_path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                payloads.append(json.loads(line))
+
+    structured = compute_rate_limit_event_count_v1(evidence_root=session_dir)
+    assert structured == 0
+
+    if payloads:
+        defective = _defective_substring_count(payloads)
+        assert defective == 24
+        assert count_rate_limit_events_in_payloads_v1(payloads) == 0
+
+    after = ONE_HOUR_EVIDENCE.read_bytes()
+    assert after == before


### PR DESCRIPTION
## Summary
- Confirmed root cause: ad-hoc Phase 9.2 evidence packaging counted `rate_limit_event_count` via bare `"429"` substring search over runtime event JSON, so SHA/digest/ID substrings inflated the metric (aborted one-hour session: packaged `24`, true HTTP-429 count `0`).
- Previous wrong semantics: any JSON text containing the characters `429` was counted as a rate-limit event.
- New structured semantics (canonical owner `src/ops/phase_9_2_public_md_session_preflight_v1/rate_limit_metric_v1.py`): count only exact typed HTTP status `429`, canonical `RATE_LIMIT_*` classification tokens, or authoritative transport `http_429_count` / `http_429_event_count`. No free-text / hash substring matching.
- Historical one-hour/smoke evidence is intentionally left byte-identical; this PR does not rewrite packaged metrics.

## Test matrix
- A Hash false positive → `rate_limit_event_count == 0`
- B Real HTTP 429 → count `1`
- C Multiple real 429 → exact count
- D Free-text `"429"` without classification → `0`
- E DNS abort (`Errno 8`) → `0`
- F Mixed (hash/DNS/timeout + one real 429) → `1`
- G Regression: historical packaged value remains `24` on disk; structured recount of session evidence is `0`; defective substring on `runtime_events.jsonl` still reproduces `24`

## Flags
- `CORE_LOGIC_CHANGED=false`
- `SESSION_SEMANTICS_CHANGED=false`
- `HISTORICAL_EVIDENCE_MUTATED=false`
- `METRIC_DEFINITION_CORRECTED=true`

## Important
A new one-hour governed public-MD session is only permissible after this PR is merged and a fresh authorization is issued. Do not re-run or re-package the aborted historical session.

## Test plan
- [x] `pytest tests/ops/test_phase_9_2_rate_limit_metric_false_positive_v1.py`
- [x] `pytest tests/ops/test_phase_9_2_public_md_session_preflight_v1.py tests/ops/test_phase_9_2_evidence_generator_portable_path_v1.py`
- [x] PR-bounded selector targets (729 passed)
- [x] `ruff format --check` / `ruff check` on changed files
- [ ] GitHub CI confirmation on PR


Made with [Cursor](https://cursor.com)