### PR TITLE
Phase 9.2: wallclock outcome telemetry and verifier completeness binding

### DIFF
--- a/docs/ops/runbooks/PHASE_9_2_WALLCLOCK_OUTCOME_TELEMETRY_AND_VERIFIER_COMPLETENESS_BINDING_V1.md
+++ b/docs/ops/runbooks/PHASE_9_2_WALLCLOCK_OUTCOME_TELEMETRY_AND_VERIFIER_COMPLETENESS_BINDING_V1.md
@@ -1,0 +1,58 @@
+# PHASE_9_2_WALLCLOCK_OUTCOME_TELEMETRY_AND_VERIFIER_COMPLETENESS_BINDING_V1
+
+```text
+status: ACTIVE
+capability: PHASE_9_2_WALLCLOCK_OUTCOME_TELEMETRY_AND_VERIFIER_COMPLETENESS_BINDING_V1
+owner: ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1
+authority_effect: NONE
+decision_authority: false
+runtime_behavior_effect: false
+alpha_effect: false
+risk_effect: false
+safety_effect: false
+execution_effect: false
+core_logic_change: false
+```
+
+## Goal
+
+Close the Phase-9.2 wallclock session telemetry aggregation gap and the
+bundle-verifier coverage gap for decision-outcome completeness.
+
+## Source of truth
+
+```text
+SUMMARY_SOURCE_OF_TRUTH=bridge_cycle_ledger.jsonl
+TERMINAL_OUTCOME_PROJECTION_OWNER=ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.terminal_outcome_projection_v1
+```
+
+The session summary is derived exclusively from the canonical bridge cycle
+ledger. The terminal outcome projection is a deterministic, non-authoritative
+read model over existing ledger fields. It does not change Master V2, Double
+Play, confirmation, Dynamic Scope, volatility policy, risk, safety, or
+execution behavior.
+
+## Verifier contract
+
+`verify_wallclock_evidence_bundle_v1` now fail-closed requires:
+
+```text
+TERMINAL_OUTCOME_SUM == SESSION_CYCLE_COUNT
+UNACCOUNTED_CYCLE_COUNT == 0
+MULTI_CLASSIFIED_CYCLE_COUNT == 0
+SUMMARY_COUNTS_MATCH_LEDGER == true
+HOLD_COUNT == count(intended_side == HOLD)
+NO_ACTION_COUNT == count(intent_action == NONE)
+ENTRY_FILL_COUNT + REDUCE_FILL_COUNT + EXIT_FILL_COUNT == productive_fill_count
+```
+
+Zero-cycle sessions are not implicitly complete. Only explicit `ABORT` or
+`incomplete=true` empty sessions are admissible.
+
+## Non-goals
+
+- No session rerun
+- No network session
+- No authorization issuance or consumption
+- No mutation of existing Phase-9.2 evidence files
+- No trading-path semantic changes

--- a/src/ops/integrated_paper_shadow_observation_wallclock_session_execution_v1/bundle_verifier_v1.py
+++ b/src/ops/integrated_paper_shadow_observation_wallclock_session_execution_v1/bundle_verifier_v1.py
@@ -19,6 +19,9 @@ from src.ops.integrated_paper_shadow_observation_wallclock_session_execution_v1.
     APPEND_ONLY,
     REQUIRED_IMMUTABLE,
 )
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.outcome_completeness_verifier_v1 import (
+    verify_wallclock_outcome_completeness_v1,
+)
 
 VERIFIER_ID = "ops.paper_shadow_wallclock_evidence_verifier_v1"
 RESULT_PASS = "WALLCLOCK_OBSERVATION_EVIDENCE_VERIFIED"
@@ -121,6 +124,19 @@ def verify_wallclock_evidence_bundle_v1(
                 blockers.append("SAFETY_ABORT_REMAPPED_TO_FAIL")
             if verdict == TerminalVerdict.PASS.value:
                 blockers.append("SAFETY_EVENTS_WITH_PASS")
+
+    outcome = verify_wallclock_outcome_completeness_v1(evidence_root=root)
+    if not outcome.verified:
+        blockers.extend(f"OUTCOME_COMPLETENESS:{b}" for b in outcome.blockers)
+    else:
+        notes.extend(
+            [
+                "OUTCOME_COMPLETENESS_VERIFIED=true",
+                "VERIFIER_VALIDATES_OUTCOME_COMPLETENESS=true",
+                "VERIFIER_CAN_PASS_WITH_UNACCOUNTED_OUTCOMES=false",
+            ]
+        )
+        notes.extend(outcome.notes)
 
     unique = sorted(set(blockers))
     if unique:

--- a/src/ops/phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1/__init__.py
+++ b/src/ops/phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1/__init__.py
@@ -1,0 +1,37 @@
+"""Phase 9.2 wallclock outcome telemetry and verifier completeness binding."""
+
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.constants_v1 import (
+    CAPABILITY_ID,
+    OWNER,
+    PACKAGE_MARKER,
+    SUMMARY_SOURCE_OF_TRUTH,
+    TASK_ID,
+    TERMINAL_OUTCOME_PROJECTION_OWNER,
+)
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.ledger_summary_aggregator_v1 import (
+    WallclockOutcomeTelemetrySummaryV1,
+    aggregate_wallclock_outcome_telemetry_from_cycles_v1,
+    aggregate_wallclock_outcome_telemetry_from_evidence_root_v1,
+)
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.outcome_completeness_verifier_v1 import (
+    WallclockOutcomeCompletenessVerificationResultV1,
+    verify_wallclock_outcome_completeness_v1,
+)
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.terminal_outcome_projection_v1 import (
+    project_terminal_outcome_class_v1,
+)
+
+__all__ = [
+    "CAPABILITY_ID",
+    "OWNER",
+    "PACKAGE_MARKER",
+    "SUMMARY_SOURCE_OF_TRUTH",
+    "TASK_ID",
+    "TERMINAL_OUTCOME_PROJECTION_OWNER",
+    "WallclockOutcomeCompletenessVerificationResultV1",
+    "WallclockOutcomeTelemetrySummaryV1",
+    "aggregate_wallclock_outcome_telemetry_from_cycles_v1",
+    "aggregate_wallclock_outcome_telemetry_from_evidence_root_v1",
+    "project_terminal_outcome_class_v1",
+    "verify_wallclock_outcome_completeness_v1",
+]

--- a/src/ops/phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1/constants_v1.py
+++ b/src/ops/phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1/constants_v1.py
@@ -1,0 +1,98 @@
+"""Constants for wallclock outcome telemetry + verifier completeness binding."""
+
+from __future__ import annotations
+
+CAPABILITY_ID = "PHASE_9_2_WALLCLOCK_OUTCOME_TELEMETRY_AND_VERIFIER_COMPLETENESS_BINDING_V1"
+TASK_ID = "IMPLEMENT_PHASE_9_2_WALLCLOCK_OUTCOME_TELEMETRY_AND_VERIFIER_COMPLETENESS_BINDING_V1"
+OWNER = "ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1"
+PACKAGE_MARKER = "PHASE_9_2_WALLCLOCK_OUTCOME_TELEMETRY_AND_VERIFIER_COMPLETENESS_BINDING_V1=true"
+SCHEMA_VERSION = "phase_9_2_wallclock_outcome_telemetry.v1"
+PRODUCER_VERSION = "phase_9_2_wallclock_outcome_telemetry.v1"
+
+DECISION_AUTHORITY = False
+RUNTIME_BEHAVIOR_EFFECT = False
+ALPHA_EFFECT = False
+RISK_EFFECT = False
+SAFETY_EFFECT = False
+EXECUTION_EFFECT = False
+CORE_LOGIC_CHANGE = False
+
+BRIDGE_CYCLE_LEDGER_FILENAME = "bridge_cycle_ledger.jsonl"
+BRIDGE_FILL_LEDGER_FILENAME = "bridge_fill_ledger.jsonl"
+OBSERVATION_COUNTERS_FILENAME = "observation_cycle_counters.json"
+OPTIONAL_SUMMARY_FILENAME = "wallclock_outcome_telemetry_summary_v1.json"
+TERMINAL_VERDICT_FILENAME = "terminal_verdict.json"
+
+SUMMARY_SOURCE_OF_TRUTH = "bridge_cycle_ledger.jsonl"
+TERMINAL_OUTCOME_PROJECTION_OWNER = (
+    "ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1."
+    "terminal_outcome_projection_v1"
+)
+
+# Exclusive priority order for deterministic projection (first match wins).
+TERMINAL_OUTCOME_PRIORITY: tuple[str, ...] = (
+    "SESSION_WARMUP",
+    "MISSING_VOLATILITY_OBSERVE_ONLY",
+    "ENTRY_FILL",
+    "REDUCE_FILL",
+    "EXIT_FILL",
+    "SIMULATED_FILL_OTHER",
+    "ENTRY_INTENT_NO_FILL",
+    "REDUCE_INTENT_NO_FILL",
+    "EXIT_INTENT_NO_FILL",
+    "HOLD_NO_ACTION",
+    "OBSERVE_OR_HOLD",
+    "BLOCKED_OTHER",
+)
+
+ENTRY_INTENT_ACTIONS = frozenset(
+    {
+        "ENTER_LONG",
+        "ENTER_SHORT",
+        "ENTRY_LONG",
+        "ENTRY_SHORT",
+    }
+)
+REDUCE_INTENT_ACTIONS = frozenset(
+    {
+        "REDUCE",
+        "REDUCE_LONG",
+        "REDUCE_SHORT",
+        "PARTIAL_REDUCE",
+    }
+)
+EXIT_INTENT_ACTIONS = frozenset(
+    {
+        "EXIT",
+        "EXIT_LONG",
+        "EXIT_SHORT",
+        "CLOSE",
+        "FLAT",
+    }
+)
+
+TYPED_VOLATILITY_MISSING_REASON_CODES = frozenset(
+    {
+        "TYPED_VOLATILITY_ESTIMATE_MISSING",
+        "typed_volatility_estimate_missing",
+    }
+)
+WARMUP_REASON_CODES = frozenset(
+    {
+        "warmup_required",
+        "WARMUP_REQUIRED",
+    }
+)
+
+RESULT_PASS = "WALLCLOCK_OUTCOME_TELEMETRY_COMPLETENESS_VERIFIED"
+RESULT_FAIL = "WALLCLOCK_OUTCOME_TELEMETRY_COMPLETENESS_INVALID"
+
+ZERO_CYCLE_PASS_BLOCKER = "ZERO_CYCLE_SESSION_NOT_IMPLICITLY_COMPLETE"
+EMPTY_LEDGER_WITH_CYCLES_BLOCKER = "EMPTY_LEDGER_WITH_POSITIVE_CYCLE_COUNT"
+UNACCOUNTED_CYCLES_BLOCKER = "UNACCOUNTED_CYCLE_COUNT_NONZERO"
+MULTI_CLASSIFIED_CYCLES_BLOCKER = "MULTI_CLASSIFIED_CYCLE_COUNT_NONZERO"
+TERMINAL_SUM_MISMATCH_BLOCKER = "TERMINAL_OUTCOME_SUM_MISMATCH"
+SUMMARY_MISMATCH_BLOCKER = "SUMMARY_COUNTS_MISMATCH_LEDGER"
+FILL_COUNT_MISMATCH_BLOCKER = "FILL_COUNT_SUM_MISMATCH"
+HOLD_COUNT_MISMATCH_BLOCKER = "HOLD_COUNT_MISMATCH_LEDGER"
+NO_ACTION_COUNT_MISMATCH_BLOCKER = "NO_ACTION_COUNT_MISMATCH_LEDGER"

--- a/src/ops/phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1/ledger_summary_aggregator_v1.py
+++ b/src/ops/phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1/ledger_summary_aggregator_v1.py
@@ -1,0 +1,369 @@
+"""Aggregate wallclock session outcome telemetry exclusively from bridge_cycle_ledger."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.constants_v1 import (
+    BRIDGE_CYCLE_LEDGER_FILENAME,
+    CAPABILITY_ID,
+    OBSERVATION_COUNTERS_FILENAME,
+    OWNER,
+    PACKAGE_MARKER,
+    PRODUCER_VERSION,
+    SCHEMA_VERSION,
+    SUMMARY_SOURCE_OF_TRUTH,
+    TERMINAL_OUTCOME_PROJECTION_OWNER,
+)
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.terminal_outcome_projection_v1 import (
+    classify_intent_bucket_v1,
+    cycle_decision_outcome_v1,
+    cycle_fill_present_v1,
+    cycle_intent_action_v1,
+    cycle_intended_side_v1,
+    cycle_quantity_source_v1,
+    cycle_reason_codes_v1,
+    cycle_risk_sizing_result_v1,
+    cycle_safety_result_v1,
+    is_alpha_blocked_v1,
+    is_entry_blocked_v1,
+    is_risk_veto_v1,
+    is_safety_veto_v1,
+    project_terminal_outcome_class_v1,
+)
+
+
+@dataclass(frozen=True)
+class WallclockOutcomeTelemetrySummaryV1:
+    capability_id: str
+    schema_version: str
+    producer_version: str
+    owner: str
+    package_marker: str
+    summary_source_of_truth: str
+    terminal_outcome_projection_owner: str
+    session_cycle_count: int
+    distinct_observation_count: int
+    terminal_outcome_classes: list[str]
+    terminal_outcome_counts: dict[str, int]
+    terminal_outcome_sum: int
+    terminal_outcome_sum_matches_cycles: bool
+    unaccounted_cycle_count: int
+    multi_classified_cycle_count: int
+    hold_count: int
+    no_action_count: int
+    entry_intent_count: int
+    reduce_intent_count: int
+    exit_intent_count: int
+    entry_fill_count: int
+    reduce_fill_count: int
+    exit_fill_count: int
+    productive_fill_count: int
+    alpha_blocked_count: int
+    entry_blocked_count: int
+    risk_veto_count: int
+    safety_veto_count: int
+    reason_code_counts: dict[str, int]
+    decision_outcome_counts: dict[str, int]
+    safety_result_counts: dict[str, int]
+    risk_result_counts: dict[str, int]
+    quantity_source_counts: dict[str, int]
+    summary_counts_match_ledger: bool = True
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        # Stable uppercase aliases for machine status blocks.
+        payload.update(
+            {
+                "SESSION_CYCLE_COUNT": self.session_cycle_count,
+                "DISTINCT_OBSERVATION_COUNT": self.distinct_observation_count,
+                "TERMINAL_OUTCOME_CLASSES": list(self.terminal_outcome_classes),
+                "TERMINAL_OUTCOME_COUNTS": dict(self.terminal_outcome_counts),
+                "TERMINAL_OUTCOME_SUM": self.terminal_outcome_sum,
+                "TERMINAL_OUTCOME_SUM_MATCHES_CYCLES": self.terminal_outcome_sum_matches_cycles,
+                "UNACCOUNTED_CYCLE_COUNT": self.unaccounted_cycle_count,
+                "MULTI_CLASSIFIED_CYCLE_COUNT": self.multi_classified_cycle_count,
+                "HOLD_COUNT": self.hold_count,
+                "NO_ACTION_COUNT": self.no_action_count,
+                "ENTRY_INTENT_COUNT": self.entry_intent_count,
+                "REDUCE_INTENT_COUNT": self.reduce_intent_count,
+                "EXIT_INTENT_COUNT": self.exit_intent_count,
+                "ENTRY_FILL_COUNT": self.entry_fill_count,
+                "REDUCE_FILL_COUNT": self.reduce_fill_count,
+                "EXIT_FILL_COUNT": self.exit_fill_count,
+                "ALPHA_BLOCKED_COUNT": self.alpha_blocked_count,
+                "ENTRY_BLOCKED_COUNT": self.entry_blocked_count,
+                "RISK_VETO_COUNT": self.risk_veto_count,
+                "SAFETY_VETO_COUNT": self.safety_veto_count,
+                "REASON_CODE_COUNTS": dict(self.reason_code_counts),
+                "DECISION_OUTCOME_COUNTS": dict(self.decision_outcome_counts),
+                "SAFETY_RESULT_COUNTS": dict(self.safety_result_counts),
+                "RISK_RESULT_COUNTS": dict(self.risk_result_counts),
+                "QUANTITY_SOURCE_COUNTS": dict(self.quantity_source_counts),
+                "SUMMARY_COUNTS_MATCH_LEDGER": self.summary_counts_match_ledger,
+            }
+        )
+        return payload
+
+
+def load_bridge_cycle_ledger_v1(ledger_path: Path) -> list[dict[str, Any]]:
+    if not ledger_path.is_file():
+        return []
+    cycles: list[dict[str, Any]] = []
+    for line in ledger_path.read_text(encoding="utf-8").splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        payload = json.loads(text)
+        if not isinstance(payload, dict):
+            raise ValueError(f"BRIDGE_CYCLE_LEDGER_NON_OBJECT:{ledger_path}")
+        cycles.append(payload)
+    return cycles
+
+
+def _distinct_observation_count_v1(
+    cycles: Sequence[Mapping[str, Any]],
+    *,
+    evidence_root: Path | None,
+) -> int:
+    if evidence_root is not None:
+        counters_path = evidence_root / OBSERVATION_COUNTERS_FILENAME
+        if counters_path.is_file():
+            payload = json.loads(counters_path.read_text(encoding="utf-8"))
+            if isinstance(payload, Mapping):
+                for key in ("distinct_observation_count", "accepted_ticks", "cycle_count"):
+                    if key in payload:
+                        return int(payload[key])
+    refs: set[str] = set()
+    for cycle in cycles:
+        refs.add(json.dumps(cycle.get("market_data_reference"), sort_keys=True, default=str))
+    return len(refs)
+
+
+def _explicit_class_list_v1(cycle: Mapping[str, Any]) -> list[str] | None:
+    multi = cycle.get("terminal_outcome_classes")
+    if isinstance(multi, (list, tuple)):
+        return [str(x) for x in multi if str(x).strip()]
+    singular = cycle.get("terminal_outcome_class")
+    if singular is not None and str(singular).strip():
+        return [str(singular).strip()]
+    return None
+
+
+def aggregate_wallclock_outcome_telemetry_from_cycles_v1(
+    cycles: Iterable[Mapping[str, Any]],
+    *,
+    evidence_root: Path | None = None,
+    declared_summary: Mapping[str, Any] | None = None,
+) -> WallclockOutcomeTelemetrySummaryV1:
+    cycle_list = list(cycles)
+    session_cycle_count = len(cycle_list)
+
+    terminal_counts: Counter[str] = Counter()
+    reason_counts: Counter[str] = Counter()
+    decision_counts: Counter[str] = Counter()
+    safety_counts: Counter[str] = Counter()
+    risk_counts: Counter[str] = Counter()
+    quantity_counts: Counter[str] = Counter()
+
+    unaccounted = 0
+    multi_classified = 0
+    hold_count = 0
+    no_action_count = 0
+    entry_intent_count = 0
+    reduce_intent_count = 0
+    exit_intent_count = 0
+    entry_fill_count = 0
+    reduce_fill_count = 0
+    exit_fill_count = 0
+    productive_fill_count = 0
+    alpha_blocked_count = 0
+    entry_blocked_count = 0
+    risk_veto_count = 0
+    safety_veto_count = 0
+
+    for cycle in cycle_list:
+        explicit = _explicit_class_list_v1(cycle)
+        if explicit is not None:
+            if len(explicit) == 0:
+                unaccounted += 1
+            elif len(explicit) > 1:
+                multi_classified += 1
+            else:
+                terminal_counts[explicit[0]] += 1
+        else:
+            projected = project_terminal_outcome_class_v1(cycle)
+            if projected is None:
+                unaccounted += 1
+            else:
+                terminal_counts[projected] += 1
+
+        side = cycle_intended_side_v1(cycle)
+        action = cycle_intent_action_v1(cycle)
+        if side == "HOLD":
+            hold_count += 1
+        if action == "NONE":
+            no_action_count += 1
+
+        bucket = classify_intent_bucket_v1(cycle)
+        if bucket == "ENTRY":
+            entry_intent_count += 1
+        elif bucket == "REDUCE":
+            reduce_intent_count += 1
+        elif bucket == "EXIT":
+            exit_intent_count += 1
+
+        fill_present = cycle_fill_present_v1(cycle)
+        if fill_present:
+            productive_fill_count += 1
+            if bucket == "ENTRY":
+                entry_fill_count += 1
+            elif bucket == "REDUCE":
+                reduce_fill_count += 1
+            elif bucket == "EXIT":
+                exit_fill_count += 1
+
+        if is_alpha_blocked_v1(cycle):
+            alpha_blocked_count += 1
+        if is_entry_blocked_v1(cycle):
+            entry_blocked_count += 1
+        if is_risk_veto_v1(cycle):
+            risk_veto_count += 1
+        if is_safety_veto_v1(cycle):
+            safety_veto_count += 1
+
+        for reason in cycle_reason_codes_v1(cycle):
+            reason_counts[reason] += 1
+        decision_counts[cycle_decision_outcome_v1(cycle) or ""] += 1
+        safety_counts[cycle_safety_result_v1(cycle) or ""] += 1
+        risk_counts[cycle_risk_sizing_result_v1(cycle) or ""] += 1
+        quantity_counts[cycle_quantity_source_v1(cycle) or ""] += 1
+
+    terminal_outcome_sum = int(sum(terminal_counts.values()))
+    terminal_outcome_sum_matches = (
+        terminal_outcome_sum == session_cycle_count and unaccounted == 0 and multi_classified == 0
+    )
+    distinct = _distinct_observation_count_v1(cycle_list, evidence_root=evidence_root)
+
+    summary = WallclockOutcomeTelemetrySummaryV1(
+        capability_id=CAPABILITY_ID,
+        schema_version=SCHEMA_VERSION,
+        producer_version=PRODUCER_VERSION,
+        owner=OWNER,
+        package_marker=PACKAGE_MARKER,
+        summary_source_of_truth=SUMMARY_SOURCE_OF_TRUTH,
+        terminal_outcome_projection_owner=TERMINAL_OUTCOME_PROJECTION_OWNER,
+        session_cycle_count=session_cycle_count,
+        distinct_observation_count=distinct,
+        terminal_outcome_classes=sorted(terminal_counts),
+        terminal_outcome_counts={k: int(terminal_counts[k]) for k in sorted(terminal_counts)},
+        terminal_outcome_sum=terminal_outcome_sum,
+        terminal_outcome_sum_matches_cycles=terminal_outcome_sum_matches,
+        unaccounted_cycle_count=unaccounted,
+        multi_classified_cycle_count=multi_classified,
+        hold_count=hold_count,
+        no_action_count=no_action_count,
+        entry_intent_count=entry_intent_count,
+        reduce_intent_count=reduce_intent_count,
+        exit_intent_count=exit_intent_count,
+        entry_fill_count=entry_fill_count,
+        reduce_fill_count=reduce_fill_count,
+        exit_fill_count=exit_fill_count,
+        productive_fill_count=productive_fill_count,
+        alpha_blocked_count=alpha_blocked_count,
+        entry_blocked_count=entry_blocked_count,
+        risk_veto_count=risk_veto_count,
+        safety_veto_count=safety_veto_count,
+        reason_code_counts={k: int(reason_counts[k]) for k in sorted(reason_counts)},
+        decision_outcome_counts={k: int(decision_counts[k]) for k in sorted(decision_counts)},
+        safety_result_counts={k: int(safety_counts[k]) for k in sorted(safety_counts)},
+        risk_result_counts={k: int(risk_counts[k]) for k in sorted(risk_counts)},
+        quantity_source_counts={k: int(quantity_counts[k]) for k in sorted(quantity_counts)},
+        summary_counts_match_ledger=True,
+        notes=[
+            "SUMMARY_DERIVED_EXCLUSIVELY_FROM_BRIDGE_CYCLE_LEDGER",
+            "PROJECTION_DECISION_AUTHORITY=false",
+            "PROJECTION_RUNTIME_BEHAVIOR_EFFECT=false",
+        ],
+    )
+
+    if declared_summary is not None:
+        mismatches = compare_declared_summary_to_ledger_v1(summary, declared_summary)
+        if mismatches:
+            return WallclockOutcomeTelemetrySummaryV1(
+                **{
+                    **asdict(summary),
+                    "summary_counts_match_ledger": False,
+                    "notes": list(summary.notes)
+                    + ["SUMMARY_COUNTS_MATCH_LEDGER=false"]
+                    + mismatches,
+                }
+            )
+    return summary
+
+
+def compare_declared_summary_to_ledger_v1(
+    ledger_summary: WallclockOutcomeTelemetrySummaryV1,
+    declared: Mapping[str, Any],
+) -> list[str]:
+    checks = {
+        "HOLD_COUNT": ledger_summary.hold_count,
+        "hold_count": ledger_summary.hold_count,
+        "NO_ACTION_COUNT": ledger_summary.no_action_count,
+        "no_action_count": ledger_summary.no_action_count,
+        "ENTRY_FILL_COUNT": ledger_summary.entry_fill_count,
+        "entry_fill_count": ledger_summary.entry_fill_count,
+        "REDUCE_FILL_COUNT": ledger_summary.reduce_fill_count,
+        "reduce_fill_count": ledger_summary.reduce_fill_count,
+        "EXIT_FILL_COUNT": ledger_summary.exit_fill_count,
+        "exit_fill_count": ledger_summary.exit_fill_count,
+        "SESSION_CYCLE_COUNT": ledger_summary.session_cycle_count,
+        "session_cycle_count": ledger_summary.session_cycle_count,
+        "TERMINAL_OUTCOME_SUM": ledger_summary.terminal_outcome_sum,
+        "terminal_outcome_sum": ledger_summary.terminal_outcome_sum,
+        "UNACCOUNTED_CYCLE_COUNT": ledger_summary.unaccounted_cycle_count,
+        "unaccounted_cycle_count": ledger_summary.unaccounted_cycle_count,
+        "MULTI_CLASSIFIED_CYCLE_COUNT": ledger_summary.multi_classified_cycle_count,
+        "multi_classified_cycle_count": ledger_summary.multi_classified_cycle_count,
+        "RISK_VETO_COUNT": ledger_summary.risk_veto_count,
+        "risk_veto_count": ledger_summary.risk_veto_count,
+        "SAFETY_VETO_COUNT": ledger_summary.safety_veto_count,
+        "safety_veto_count": ledger_summary.safety_veto_count,
+    }
+    mismatches: list[str] = []
+    for key, expected in checks.items():
+        if key in declared and int(declared[key]) != int(expected):
+            mismatches.append(f"DECLARED_MISMATCH:{key}:{declared[key]}!={expected}")
+    if "TERMINAL_OUTCOME_COUNTS" in declared or "terminal_outcome_counts" in declared:
+        raw = declared.get("TERMINAL_OUTCOME_COUNTS", declared.get("terminal_outcome_counts"))
+        if isinstance(raw, Mapping):
+            normalized = {str(k): int(v) for k, v in raw.items()}
+            if normalized != ledger_summary.terminal_outcome_counts:
+                mismatches.append("DECLARED_MISMATCH:TERMINAL_OUTCOME_COUNTS")
+    return mismatches
+
+
+def aggregate_wallclock_outcome_telemetry_from_evidence_root_v1(
+    evidence_root: Path,
+    *,
+    declared_summary: Mapping[str, Any] | None = None,
+) -> WallclockOutcomeTelemetrySummaryV1:
+    root = Path(evidence_root)
+    cycles = load_bridge_cycle_ledger_v1(root / BRIDGE_CYCLE_LEDGER_FILENAME)
+    optional_declared = declared_summary
+    if optional_declared is None:
+        optional_path = root / "wallclock_outcome_telemetry_summary_v1.json"
+        if optional_path.is_file():
+            payload = json.loads(optional_path.read_text(encoding="utf-8"))
+            if isinstance(payload, Mapping):
+                optional_declared = payload
+    return aggregate_wallclock_outcome_telemetry_from_cycles_v1(
+        cycles,
+        evidence_root=root,
+        declared_summary=optional_declared,
+    )

--- a/src/ops/phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1/outcome_completeness_verifier_v1.py
+++ b/src/ops/phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1/outcome_completeness_verifier_v1.py
@@ -1,0 +1,188 @@
+"""Fail-closed completeness verifier for wallclock decision-outcome accounting."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.constants_v1 import (
+    BRIDGE_CYCLE_LEDGER_FILENAME,
+    CAPABILITY_ID,
+    EMPTY_LEDGER_WITH_CYCLES_BLOCKER,
+    FILL_COUNT_MISMATCH_BLOCKER,
+    HOLD_COUNT_MISMATCH_BLOCKER,
+    MULTI_CLASSIFIED_CYCLES_BLOCKER,
+    NO_ACTION_COUNT_MISMATCH_BLOCKER,
+    OBSERVATION_COUNTERS_FILENAME,
+    OWNER,
+    RESULT_FAIL,
+    RESULT_PASS,
+    SUMMARY_MISMATCH_BLOCKER,
+    TERMINAL_SUM_MISMATCH_BLOCKER,
+    TERMINAL_VERDICT_FILENAME,
+    UNACCOUNTED_CYCLES_BLOCKER,
+    ZERO_CYCLE_PASS_BLOCKER,
+)
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.ledger_summary_aggregator_v1 import (
+    WallclockOutcomeTelemetrySummaryV1,
+    aggregate_wallclock_outcome_telemetry_from_evidence_root_v1,
+    compare_declared_summary_to_ledger_v1,
+)
+
+
+@dataclass
+class WallclockOutcomeCompletenessVerificationResultV1:
+    result: str
+    verified: bool
+    blockers: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    summary: dict[str, Any] = field(default_factory=dict)
+    capability_id: str = CAPABILITY_ID
+    owner: str = OWNER
+    validates_outcome_completeness: bool = True
+    can_pass_with_unaccounted_outcomes: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _declared_cycle_count_v1(evidence_root: Path, ledger_len: int) -> int:
+    counters_path = evidence_root / OBSERVATION_COUNTERS_FILENAME
+    if counters_path.is_file():
+        payload = json.loads(counters_path.read_text(encoding="utf-8"))
+        if isinstance(payload, Mapping) and "cycle_count" in payload:
+            return int(payload["cycle_count"])
+    return ledger_len
+
+
+def _terminal_verdict_payload_v1(evidence_root: Path) -> dict[str, Any]:
+    path = evidence_root / TERMINAL_VERDICT_FILENAME
+    if not path.is_file():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else {}
+
+
+def verify_wallclock_outcome_completeness_v1(
+    *,
+    evidence_root: Path,
+    declared_summary: Mapping[str, Any] | None = None,
+) -> WallclockOutcomeCompletenessVerificationResultV1:
+    root = Path(evidence_root)
+    notes = [
+        f"CAPABILITY_ID={CAPABILITY_ID}",
+        f"OWNER={OWNER}",
+        "VERIFIER_VALIDATES_OUTCOME_COMPLETENESS=true",
+        "VERIFIER_CAN_PASS_WITH_UNACCOUNTED_OUTCOMES=false",
+        "VERIFIER_NO_NETWORK",
+        "VERIFIER_NO_MUTATION",
+    ]
+    blockers: list[str] = []
+
+    if not root.is_dir():
+        return WallclockOutcomeCompletenessVerificationResultV1(
+            result=RESULT_FAIL,
+            verified=False,
+            blockers=["EVIDENCE_ROOT_MISSING"],
+            notes=notes,
+        )
+
+    ledger_path = root / BRIDGE_CYCLE_LEDGER_FILENAME
+    ledger_exists = ledger_path.is_file()
+    summary = aggregate_wallclock_outcome_telemetry_from_evidence_root_v1(
+        root,
+        declared_summary=declared_summary,
+    )
+    declared_cycle_count = _declared_cycle_count_v1(root, summary.session_cycle_count)
+    terminal = _terminal_verdict_payload_v1(root)
+    verdict = str(terminal.get("verdict") or "")
+    incomplete = bool(terminal.get("incomplete"))
+
+    if declared_cycle_count > 0 and ((not ledger_exists) or summary.session_cycle_count == 0):
+        blockers.append(EMPTY_LEDGER_WITH_CYCLES_BLOCKER)
+
+    if declared_cycle_count == 0 and summary.session_cycle_count == 0:
+        # Explicit empty-session contract: never treat 0==0 as implicit completeness.
+        # Only ABORT or incomplete empty sessions are admissible.
+        if not (incomplete or verdict == "ABORT"):
+            blockers.append(ZERO_CYCLE_PASS_BLOCKER)
+        notes.append("ZERO_CYCLE_SESSION_EXPLICIT_CONTRACT_APPLIED")
+        unique = sorted(set(blockers))
+        return WallclockOutcomeCompletenessVerificationResultV1(
+            result=RESULT_FAIL if unique else RESULT_PASS,
+            verified=not unique,
+            blockers=unique,
+            notes=notes
+            + [
+                "ZERO_CYCLE_NOT_IMPLICITLY_COMPLETE",
+                f"TERMINAL_VERDICT={verdict or 'MISSING'}",
+                f"INCOMPLETE={incomplete}",
+            ],
+            summary=summary.to_dict(),
+        )
+
+    if summary.session_cycle_count != declared_cycle_count and declared_cycle_count > 0:
+        blockers.append(
+            f"CYCLE_COUNT_LEDGER_MISMATCH:{summary.session_cycle_count}!={declared_cycle_count}"
+        )
+
+    if summary.unaccounted_cycle_count != 0:
+        blockers.append(UNACCOUNTED_CYCLES_BLOCKER)
+    if summary.multi_classified_cycle_count != 0:
+        blockers.append(MULTI_CLASSIFIED_CYCLES_BLOCKER)
+    if summary.terminal_outcome_sum != summary.session_cycle_count:
+        blockers.append(TERMINAL_SUM_MISMATCH_BLOCKER)
+    if not summary.terminal_outcome_sum_matches_cycles:
+        blockers.append("TERMINAL_OUTCOME_SUM_MATCHES_CYCLES=false")
+
+    fill_sum = summary.entry_fill_count + summary.reduce_fill_count + summary.exit_fill_count
+    if fill_sum != summary.productive_fill_count:
+        blockers.append(FILL_COUNT_MISMATCH_BLOCKER)
+
+    if declared_summary is not None:
+        mismatches = compare_declared_summary_to_ledger_v1(summary, declared_summary)
+        if mismatches or not summary.summary_counts_match_ledger:
+            blockers.append(SUMMARY_MISMATCH_BLOCKER)
+            for item in mismatches:
+                if "HOLD_COUNT" in item or "hold_count" in item:
+                    blockers.append(HOLD_COUNT_MISMATCH_BLOCKER)
+                if "NO_ACTION_COUNT" in item or "no_action_count" in item:
+                    blockers.append(NO_ACTION_COUNT_MISMATCH_BLOCKER)
+                if "FILL_COUNT" in item or "fill_count" in item:
+                    blockers.append(FILL_COUNT_MISMATCH_BLOCKER)
+
+    if not summary.summary_counts_match_ledger:
+        blockers.append(SUMMARY_MISMATCH_BLOCKER)
+
+    unique = sorted(set(blockers))
+    return WallclockOutcomeCompletenessVerificationResultV1(
+        result=RESULT_FAIL if unique else RESULT_PASS,
+        verified=not unique,
+        blockers=unique,
+        notes=notes
+        + [
+            f"SESSION_CYCLE_COUNT={summary.session_cycle_count}",
+            f"TERMINAL_OUTCOME_SUM={summary.terminal_outcome_sum}",
+            f"UNACCOUNTED_CYCLE_COUNT={summary.unaccounted_cycle_count}",
+            f"MULTI_CLASSIFIED_CYCLE_COUNT={summary.multi_classified_cycle_count}",
+            f"SUMMARY_COUNTS_MATCH_LEDGER={summary.summary_counts_match_ledger}",
+        ],
+        summary=summary.to_dict(),
+    )
+
+
+def assert_summary_internal_invariants_v1(
+    summary: WallclockOutcomeTelemetrySummaryV1,
+) -> list[str]:
+    """Pure invariant checks used by unit tests and optional declared summaries."""
+    blockers: list[str] = []
+    if summary.hold_count < 0 or summary.no_action_count < 0:
+        blockers.append("NEGATIVE_COUNT")
+    if summary.terminal_outcome_sum != sum(summary.terminal_outcome_counts.values()):
+        blockers.append(TERMINAL_SUM_MISMATCH_BLOCKER)
+    fill_sum = summary.entry_fill_count + summary.reduce_fill_count + summary.exit_fill_count
+    if fill_sum != summary.productive_fill_count:
+        blockers.append(FILL_COUNT_MISMATCH_BLOCKER)
+    return blockers

--- a/src/ops/phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1/terminal_outcome_projection_v1.py
+++ b/src/ops/phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1/terminal_outcome_projection_v1.py
@@ -1,0 +1,245 @@
+"""Deterministic, non-authoritative terminal outcome projection from ledger cycles.
+
+Projection only. No decision, risk, safety, alpha, or execution authority.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.constants_v1 import (
+    ENTRY_INTENT_ACTIONS,
+    EXIT_INTENT_ACTIONS,
+    REDUCE_INTENT_ACTIONS,
+    TERMINAL_OUTCOME_PRIORITY,
+    TYPED_VOLATILITY_MISSING_REASON_CODES,
+    WARMUP_REASON_CODES,
+)
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def cycle_intended_action_v1(cycle: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _as_mapping(cycle.get("intended_action"))
+
+
+def cycle_reason_codes_v1(cycle: Mapping[str, Any]) -> tuple[str, ...]:
+    intended = cycle_intended_action_v1(cycle)
+    raw = intended.get("reason_codes")
+    if raw is None:
+        raw = cycle.get("reason_codes")
+    if not isinstance(raw, (list, tuple)):
+        return ()
+    return tuple(str(x) for x in raw)
+
+
+def cycle_intent_action_v1(cycle: Mapping[str, Any]) -> str:
+    intended = cycle_intended_action_v1(cycle)
+    raw = intended.get("intent_action")
+    if raw is None:
+        raw = cycle.get("intent_action")
+    text = str(raw or "NONE").strip().upper()
+    return text if text and text != "NONE" else "NONE"
+
+
+def cycle_intended_side_v1(cycle: Mapping[str, Any]) -> str:
+    intended = cycle_intended_action_v1(cycle)
+    raw = intended.get("intended_side")
+    if raw is None:
+        raw = cycle.get("intended_side")
+    return str(raw or "").strip().upper()
+
+
+def cycle_decision_outcome_v1(cycle: Mapping[str, Any]) -> str:
+    intended = cycle_intended_action_v1(cycle)
+    raw = cycle.get("decision_outcome")
+    if raw is None:
+        raw = intended.get("decision_outcome")
+    return str(raw or "").strip().lower()
+
+
+def cycle_quantity_source_v1(cycle: Mapping[str, Any]) -> str:
+    intended = cycle_intended_action_v1(cycle)
+    raw = intended.get("quantity_source")
+    if raw is None:
+        raw = cycle.get("quantity_source")
+    return str(raw or "")
+
+
+def cycle_fill_present_v1(cycle: Mapping[str, Any]) -> bool:
+    fill = cycle.get("fill")
+    if fill is None:
+        return False
+    if isinstance(fill, Mapping) and not fill:
+        return False
+    return True
+
+
+def cycle_safety_evaluation_v1(cycle: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _as_mapping(cycle.get("safety_evaluation"))
+
+
+def cycle_safety_result_v1(cycle: Mapping[str, Any]) -> str:
+    evaluation = cycle_safety_evaluation_v1(cycle)
+    raw = evaluation.get("safety_result")
+    if raw is None:
+        raw = cycle.get("safety_result")
+    return str(raw or "")
+
+
+def cycle_safety_veto_reason_v1(cycle: Mapping[str, Any]) -> str:
+    evaluation = cycle_safety_evaluation_v1(cycle)
+    return str(evaluation.get("veto_reason") or "")
+
+
+def cycle_risk_sizing_result_v1(cycle: Mapping[str, Any]) -> str:
+    return str(cycle.get("risk_sizing_result") or "")
+
+
+def cycle_double_play_gate_v1(cycle: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _as_mapping(cycle.get("double_play_typed_volatility_presence_gate"))
+
+
+def _explicit_terminal_classes_v1(cycle: Mapping[str, Any]) -> list[str] | None:
+    """Optional ledger override used only for completeness negative fixtures."""
+    multi = cycle.get("terminal_outcome_classes")
+    if isinstance(multi, (list, tuple)):
+        return [str(x) for x in multi if str(x).strip()]
+    singular = cycle.get("terminal_outcome_class")
+    if singular is not None and str(singular).strip():
+        return [str(singular).strip()]
+    return None
+
+
+def matching_terminal_outcome_predicates_v1(cycle: Mapping[str, Any]) -> list[str]:
+    """Return all predicate matches (unordered by priority).
+
+    Used to detect MULTI_CLASSIFIED cycles when an explicit multi-class
+    override is present. Normal productive cycles use exclusive projection.
+    """
+    explicit = _explicit_terminal_classes_v1(cycle)
+    if explicit is not None:
+        return list(explicit)
+
+    reasons = set(cycle_reason_codes_v1(cycle))
+    action = cycle_intent_action_v1(cycle)
+    side = cycle_intended_side_v1(cycle)
+    decision = cycle_decision_outcome_v1(cycle)
+    fill = cycle_fill_present_v1(cycle)
+    matches: list[str] = []
+
+    if reasons & WARMUP_REASON_CODES:
+        matches.append("SESSION_WARMUP")
+    if reasons & TYPED_VOLATILITY_MISSING_REASON_CODES:
+        matches.append("MISSING_VOLATILITY_OBSERVE_ONLY")
+    if fill and action in ENTRY_INTENT_ACTIONS:
+        matches.append("ENTRY_FILL")
+    if fill and action in REDUCE_INTENT_ACTIONS:
+        matches.append("REDUCE_FILL")
+    if fill and action in EXIT_INTENT_ACTIONS:
+        matches.append("EXIT_FILL")
+    if fill and action not in ENTRY_INTENT_ACTIONS | REDUCE_INTENT_ACTIONS | EXIT_INTENT_ACTIONS:
+        matches.append("SIMULATED_FILL_OTHER")
+    if (not fill) and action in ENTRY_INTENT_ACTIONS:
+        matches.append("ENTRY_INTENT_NO_FILL")
+    if (not fill) and action in REDUCE_INTENT_ACTIONS:
+        matches.append("REDUCE_INTENT_NO_FILL")
+    if (not fill) and action in EXIT_INTENT_ACTIONS:
+        matches.append("EXIT_INTENT_NO_FILL")
+    if side == "HOLD" and action == "NONE":
+        matches.append("HOLD_NO_ACTION")
+    if decision in {"observe", "hold"}:
+        matches.append("OBSERVE_OR_HOLD")
+    if decision == "blocked":
+        matches.append("BLOCKED_OTHER")
+    return matches
+
+
+def project_terminal_outcome_class_v1(cycle: Mapping[str, Any]) -> str | None:
+    """Project exactly one terminal class via exclusive priority, or None."""
+    explicit = _explicit_terminal_classes_v1(cycle)
+    if explicit is not None:
+        if len(explicit) == 1:
+            return explicit[0]
+        return None
+
+    reasons = set(cycle_reason_codes_v1(cycle))
+    action = cycle_intent_action_v1(cycle)
+    side = cycle_intended_side_v1(cycle)
+    decision = cycle_decision_outcome_v1(cycle)
+    fill = cycle_fill_present_v1(cycle)
+
+    if reasons & WARMUP_REASON_CODES:
+        return "SESSION_WARMUP"
+    if reasons & TYPED_VOLATILITY_MISSING_REASON_CODES:
+        return "MISSING_VOLATILITY_OBSERVE_ONLY"
+    if fill and action in ENTRY_INTENT_ACTIONS:
+        return "ENTRY_FILL"
+    if fill and action in REDUCE_INTENT_ACTIONS:
+        return "REDUCE_FILL"
+    if fill and action in EXIT_INTENT_ACTIONS:
+        return "EXIT_FILL"
+    if fill:
+        return "SIMULATED_FILL_OTHER"
+    if action in ENTRY_INTENT_ACTIONS:
+        return "ENTRY_INTENT_NO_FILL"
+    if action in REDUCE_INTENT_ACTIONS:
+        return "REDUCE_INTENT_NO_FILL"
+    if action in EXIT_INTENT_ACTIONS:
+        return "EXIT_INTENT_NO_FILL"
+    if side == "HOLD" and action == "NONE":
+        return "HOLD_NO_ACTION"
+    if decision in {"observe", "hold"}:
+        return "OBSERVE_OR_HOLD"
+    if decision == "blocked":
+        return "BLOCKED_OTHER"
+    _ = TERMINAL_OUTCOME_PRIORITY  # documented owner vocabulary
+    return None
+
+
+def classify_intent_bucket_v1(cycle: Mapping[str, Any]) -> str:
+    action = cycle_intent_action_v1(cycle)
+    if action in ENTRY_INTENT_ACTIONS:
+        return "ENTRY"
+    if action in REDUCE_INTENT_ACTIONS:
+        return "REDUCE"
+    if action in EXIT_INTENT_ACTIONS:
+        return "EXIT"
+    return "NONE"
+
+
+def is_alpha_blocked_v1(cycle: Mapping[str, Any]) -> bool:
+    gate = cycle_double_play_gate_v1(cycle)
+    if "alpha_scope_entry_authority_allowed" in gate:
+        return gate.get("alpha_scope_entry_authority_allowed") is False
+    return False
+
+
+def is_entry_blocked_v1(cycle: Mapping[str, Any]) -> bool:
+    gate = cycle_double_play_gate_v1(cycle)
+    if "eligibility_new_directional_exposure_allowed" in gate:
+        return gate.get("eligibility_new_directional_exposure_allowed") is False
+    if cycle.get("execution_eligible") is False:
+        return True
+    return False
+
+
+def is_risk_veto_v1(cycle: Mapping[str, Any]) -> bool:
+    sizing = cycle_risk_sizing_result_v1(cycle).upper()
+    if "VETO" in sizing or sizing in {"BLOCKED", "REJECT", "REJECTED"}:
+        return True
+    evaluation = cycle_safety_evaluation_v1(cycle)
+    signal = _as_mapping(evaluation.get("hard_risk_reduction_signal"))
+    return bool(signal.get("triggered"))
+
+
+def is_safety_veto_v1(cycle: Mapping[str, Any]) -> bool:
+    intended = cycle_intended_action_v1(cycle)
+    if intended.get("safety_blocked") is True:
+        return True
+    if cycle_safety_veto_reason_v1(cycle).strip():
+        return True
+    result = cycle_safety_result_v1(cycle).upper()
+    return result in {"EXIT_ONLY", "BLOCKED", "VETO", "SAFETY_VETO"}

--- a/tests/ops/test_phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.py
+++ b/tests/ops/test_phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.py
@@ -1,0 +1,322 @@
+"""Unit/integration/regression/negative tests for Phase 9.2 outcome telemetry binding."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from src.ops.integrated_paper_shadow_observation_wallclock_session_execution_v1.bundle_verifier_v1 import (
+    verify_wallclock_evidence_bundle_v1,
+)
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.constants_v1 import (
+    CAPABILITY_ID,
+    CORE_LOGIC_CHANGE,
+    DECISION_AUTHORITY,
+    EXECUTION_EFFECT,
+)
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.ledger_summary_aggregator_v1 import (
+    aggregate_wallclock_outcome_telemetry_from_cycles_v1,
+    aggregate_wallclock_outcome_telemetry_from_evidence_root_v1,
+)
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.outcome_completeness_verifier_v1 import (
+    verify_wallclock_outcome_completeness_v1,
+)
+from src.ops.phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.terminal_outcome_projection_v1 import (
+    project_terminal_outcome_class_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REISSUE_EVIDENCE = (
+    REPO_ROOT
+    / "docs/evidence/capability_phase_9_2_long_running_stateful_public_md_simulation_evidence_v1"
+    / "sessions/phase_9_2_public_md_one_hour_governed_session_reissue_9ba4e31c70c9"
+    / "wallclock_run"
+)
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_ledger(path: Path, cycles: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(cycle, sort_keys=True) + "\n" for cycle in cycles),
+        encoding="utf-8",
+    )
+
+
+def _base_cycle(**overrides: object) -> dict:
+    cycle = {
+        "cycle_index": 1,
+        "decision_outcome": "observe",
+        "execution_eligible": False,
+        "fill": None,
+        "intended_action": {
+            "intended_side": "HOLD",
+            "intent_action": "NONE",
+            "quantity_source": "safety_or_fail_closed",
+            "reason_codes": [
+                "TYPED_VOLATILITY_ESTIMATE_MISSING",
+                "typed_volatility_estimate_missing",
+                "observe_only",
+            ],
+            "safety_blocked": True,
+        },
+        "reason_codes": [
+            "TYPED_VOLATILITY_ESTIMATE_MISSING",
+            "typed_volatility_estimate_missing",
+            "observe_only",
+        ],
+        "risk_sizing_result": "NONE",
+        "safety_evaluation": {
+            "safety_result": "EXIT_ONLY",
+            "veto_reason": "WARMUP_OR_REGIME_INCOMPLETE",
+            "hard_risk_reduction_signal": {"triggered": False},
+        },
+        "safety_result": "EXIT_ONLY",
+        "double_play_typed_volatility_presence_gate": {
+            "alpha_scope_entry_authority_allowed": False,
+            "eligibility_new_directional_exposure_allowed": False,
+        },
+        "market_data_reference": {"mark_px": "1"},
+    }
+    cycle.update(overrides)
+    return cycle
+
+
+def test_capability_effects_are_non_authoritative() -> None:
+    assert CAPABILITY_ID.endswith("COMPLETENESS_BINDING_V1")
+    assert CORE_LOGIC_CHANGE is False
+    assert DECISION_AUTHORITY is False
+    assert EXECUTION_EFFECT is False
+
+
+def test_projection_warmup_and_missing_volatility() -> None:
+    warmup = _base_cycle(
+        decision_outcome="blocked",
+        intended_action={
+            "intended_side": "HOLD",
+            "intent_action": "NONE",
+            "reason_codes": ["warmup_required"],
+            "quantity_source": "insufficient_history",
+            "safety_blocked": True,
+        },
+        reason_codes=["warmup_required"],
+    )
+    missing = _base_cycle()
+    assert project_terminal_outcome_class_v1(warmup) == "SESSION_WARMUP"
+    assert project_terminal_outcome_class_v1(missing) == "MISSING_VOLATILITY_OBSERVE_ONLY"
+
+
+@pytest.mark.skipif(not REISSUE_EVIDENCE.is_dir(), reason="reissue evidence absent")
+def test_regression_reissue_session_outcome_accounting() -> None:
+    summary = aggregate_wallclock_outcome_telemetry_from_evidence_root_v1(REISSUE_EVIDENCE)
+    assert summary.session_cycle_count == 1507
+    assert summary.terminal_outcome_counts == {
+        "MISSING_VOLATILITY_OBSERVE_ONLY": 1505,
+        "SESSION_WARMUP": 2,
+    }
+    assert summary.terminal_outcome_sum == 1507
+    assert summary.terminal_outcome_sum_matches_cycles is True
+    assert summary.unaccounted_cycle_count == 0
+    assert summary.multi_classified_cycle_count == 0
+    assert summary.hold_count == 1507
+    assert summary.no_action_count == 1507
+    assert summary.entry_fill_count == 0
+    assert summary.reduce_fill_count == 0
+    assert summary.exit_fill_count == 0
+    assert summary.summary_counts_match_ledger is True
+
+    outcome = verify_wallclock_outcome_completeness_v1(evidence_root=REISSUE_EVIDENCE)
+    assert outcome.verified is True
+    assert outcome.result.endswith("VERIFIED")
+
+    bundle = verify_wallclock_evidence_bundle_v1(evidence_root=REISSUE_EVIDENCE)
+    assert bundle.verified is True
+    assert any("OUTCOME_COMPLETENESS_VERIFIED=true" in n for n in bundle.notes)
+
+
+def test_unknown_reason_code_is_counted(tmp_path: Path) -> None:
+    cycle = _base_cycle(
+        intended_action={
+            "intended_side": "HOLD",
+            "intent_action": "NONE",
+            "reason_codes": [
+                "TYPED_VOLATILITY_ESTIMATE_MISSING",
+                "CUSTOM_UNKNOWN_REASON_XYZ",
+            ],
+            "safety_blocked": True,
+        },
+        reason_codes=[
+            "TYPED_VOLATILITY_ESTIMATE_MISSING",
+            "CUSTOM_UNKNOWN_REASON_XYZ",
+        ],
+    )
+    summary = aggregate_wallclock_outcome_telemetry_from_cycles_v1([cycle])
+    assert summary.reason_code_counts["CUSTOM_UNKNOWN_REASON_XYZ"] == 1
+    assert summary.terminal_outcome_counts["MISSING_VOLATILITY_OBSERVE_ONLY"] == 1
+
+
+def test_negative_unclassified_cycle_fails(tmp_path: Path) -> None:
+    root = tmp_path / "ev"
+    _write_ledger(
+        root / "bridge_cycle_ledger.jsonl",
+        [
+            {
+                "cycle_index": 1,
+                "decision_outcome": "weird",
+                "intended_action": {
+                    "intended_side": "BUY",
+                    "intent_action": "UNKNOWN_ACTION",
+                    "reason_codes": [],
+                },
+                "fill": None,
+                "reason_codes": [],
+            }
+        ],
+    )
+    _write_json(root / "observation_cycle_counters.json", {"cycle_count": 1})
+    _write_json(root / "terminal_verdict.json", {"verdict": "PASS", "incomplete": False})
+    result = verify_wallclock_outcome_completeness_v1(evidence_root=root)
+    assert result.verified is False
+    assert any("UNACCOUNTED" in b for b in result.blockers)
+
+
+def test_negative_multi_classified_cycle_fails(tmp_path: Path) -> None:
+    root = tmp_path / "ev"
+    cycle = _base_cycle(
+        terminal_outcome_classes=["SESSION_WARMUP", "MISSING_VOLATILITY_OBSERVE_ONLY"]
+    )
+    _write_ledger(root / "bridge_cycle_ledger.jsonl", [cycle])
+    _write_json(root / "observation_cycle_counters.json", {"cycle_count": 1})
+    _write_json(root / "terminal_verdict.json", {"verdict": "PASS", "incomplete": False})
+    result = verify_wallclock_outcome_completeness_v1(evidence_root=root)
+    assert result.verified is False
+    assert any("MULTI_CLASSIFIED" in b for b in result.blockers)
+
+
+def test_negative_terminal_sum_too_small_fails(tmp_path: Path) -> None:
+    root = tmp_path / "ev"
+    cycles = [_base_cycle(cycle_index=1), _base_cycle(cycle_index=2)]
+    cycles[1]["terminal_outcome_classes"] = []
+    _write_ledger(root / "bridge_cycle_ledger.jsonl", cycles)
+    _write_json(root / "observation_cycle_counters.json", {"cycle_count": 2})
+    _write_json(root / "terminal_verdict.json", {"verdict": "PASS", "incomplete": False})
+    result = verify_wallclock_outcome_completeness_v1(evidence_root=root)
+    assert result.verified is False
+    assert any("TERMINAL_OUTCOME_SUM_MISMATCH" in b for b in result.blockers)
+
+
+def test_negative_terminal_sum_too_large_fails(tmp_path: Path) -> None:
+    root = tmp_path / "ev"
+    cycle = _base_cycle(
+        terminal_outcome_classes=["SESSION_WARMUP", "MISSING_VOLATILITY_OBSERVE_ONLY"]
+    )
+    _write_ledger(root / "bridge_cycle_ledger.jsonl", [cycle])
+    _write_json(root / "observation_cycle_counters.json", {"cycle_count": 1})
+    _write_json(root / "terminal_verdict.json", {"verdict": "PASS", "incomplete": False})
+    summary = aggregate_wallclock_outcome_telemetry_from_evidence_root_v1(root)
+    # Multi-classified contributes 0 to terminal sum → sum < cycles; craft declared overcount.
+    result = verify_wallclock_outcome_completeness_v1(
+        evidence_root=root,
+        declared_summary={
+            "TERMINAL_OUTCOME_SUM": 99,
+            "SESSION_CYCLE_COUNT": summary.session_cycle_count,
+        },
+    )
+    assert result.verified is False
+    assert any("SUMMARY_COUNTS_MISMATCH" in b or "TERMINAL" in b for b in result.blockers)
+
+
+def test_negative_manipulated_hold_count_fails(tmp_path: Path) -> None:
+    root = tmp_path / "ev"
+    _write_ledger(root / "bridge_cycle_ledger.jsonl", [_base_cycle()])
+    _write_json(root / "observation_cycle_counters.json", {"cycle_count": 1})
+    _write_json(root / "terminal_verdict.json", {"verdict": "PASS", "incomplete": False})
+    result = verify_wallclock_outcome_completeness_v1(
+        evidence_root=root,
+        declared_summary={"HOLD_COUNT": 0},
+    )
+    assert result.verified is False
+    assert any("HOLD_COUNT" in b or "SUMMARY_COUNTS_MISMATCH" in b for b in result.blockers)
+
+
+def test_negative_manipulated_no_action_count_fails(tmp_path: Path) -> None:
+    root = tmp_path / "ev"
+    _write_ledger(root / "bridge_cycle_ledger.jsonl", [_base_cycle()])
+    _write_json(root / "observation_cycle_counters.json", {"cycle_count": 1})
+    _write_json(root / "terminal_verdict.json", {"verdict": "PASS", "incomplete": False})
+    result = verify_wallclock_outcome_completeness_v1(
+        evidence_root=root,
+        declared_summary={"NO_ACTION_COUNT": 0},
+    )
+    assert result.verified is False
+    assert any("NO_ACTION" in b or "SUMMARY_COUNTS_MISMATCH" in b for b in result.blockers)
+
+
+def test_negative_manipulated_fill_count_fails(tmp_path: Path) -> None:
+    root = tmp_path / "ev"
+    _write_ledger(root / "bridge_cycle_ledger.jsonl", [_base_cycle()])
+    _write_json(root / "observation_cycle_counters.json", {"cycle_count": 1})
+    _write_json(root / "terminal_verdict.json", {"verdict": "PASS", "incomplete": False})
+    result = verify_wallclock_outcome_completeness_v1(
+        evidence_root=root,
+        declared_summary={"ENTRY_FILL_COUNT": 1},
+    )
+    assert result.verified is False
+    assert any("FILL" in b or "SUMMARY_COUNTS_MISMATCH" in b for b in result.blockers)
+
+
+def test_negative_empty_ledger_with_positive_cycle_count_fails(tmp_path: Path) -> None:
+    root = tmp_path / "ev"
+    root.mkdir(parents=True)
+    (root / "bridge_cycle_ledger.jsonl").write_text("", encoding="utf-8")
+    _write_json(root / "observation_cycle_counters.json", {"cycle_count": 3})
+    _write_json(root / "terminal_verdict.json", {"verdict": "PASS", "incomplete": False})
+    result = verify_wallclock_outcome_completeness_v1(evidence_root=root)
+    assert result.verified is False
+    assert any("EMPTY_LEDGER_WITH_POSITIVE_CYCLE_COUNT" in b for b in result.blockers)
+
+
+def test_negative_zero_cycle_pass_not_implicitly_complete(tmp_path: Path) -> None:
+    root = tmp_path / "ev"
+    root.mkdir(parents=True)
+    (root / "bridge_cycle_ledger.jsonl").write_text("", encoding="utf-8")
+    _write_json(root / "observation_cycle_counters.json", {"cycle_count": 0})
+    _write_json(root / "terminal_verdict.json", {"verdict": "PASS", "incomplete": False})
+    result = verify_wallclock_outcome_completeness_v1(evidence_root=root)
+    assert result.verified is False
+    assert any("ZERO_CYCLE_SESSION_NOT_IMPLICITLY_COMPLETE" in b for b in result.blockers)
+
+
+def test_zero_cycle_abort_is_explicitly_admissible(tmp_path: Path) -> None:
+    root = tmp_path / "ev"
+    root.mkdir(parents=True)
+    (root / "bridge_cycle_ledger.jsonl").write_text("", encoding="utf-8")
+    _write_json(root / "observation_cycle_counters.json", {"cycle_count": 0})
+    _write_json(root / "terminal_verdict.json", {"verdict": "ABORT", "incomplete": True})
+    result = verify_wallclock_outcome_completeness_v1(evidence_root=root)
+    assert result.verified is True
+
+
+@pytest.mark.skipif(not REISSUE_EVIDENCE.is_dir(), reason="reissue evidence absent")
+def test_existing_evidence_files_remain_byte_identical_during_temp_copy(tmp_path: Path) -> None:
+    before = {
+        path.relative_to(REISSUE_EVIDENCE): path.read_bytes()
+        for path in REISSUE_EVIDENCE.rglob("*")
+        if path.is_file()
+    }
+    copy = tmp_path / "copy"
+    shutil.copytree(REISSUE_EVIDENCE, copy)
+    verify_wallclock_outcome_completeness_v1(evidence_root=copy)
+    after = {
+        path.relative_to(REISSUE_EVIDENCE): path.read_bytes()
+        for path in REISSUE_EVIDENCE.rglob("*")
+        if path.is_file()
+    }
+    assert before == after


### PR DESCRIPTION
## Summary
- Adds a non-authoritative ledger-derived wallclock outcome telemetry aggregator that assigns each bridge cycle exactly one disjoint terminal outcome class and reconstructs HOLD/NO_ACTION/intent/fill/veto counters from `bridge_cycle_ledger.jsonl`.
- Extends `verify_wallclock_evidence_bundle_v1` with fail-closed outcome-completeness checks (`TERMINAL_OUTCOME_SUM == CYCLE_COUNT`, zero unaccounted/multi-classified cycles, summary/fill invariants).
- Regression-verifies the completed Phase-9.2 one-hour reissue session read-only (1507 cycles → 2 warmup + 1505 missing-volatility observe-only) without session rerun or evidence mutation.

## Test plan
- [x] `pytest tests/ops/test_phase_9_2_wallclock_outcome_telemetry_and_verifier_completeness_binding_v1.py`
- [x] `pytest tests/ops/test_integrated_paper_shadow_observation_wallclock_session_execution_v1.py`
- [x] Selector `PR_BOUNDED_FULL` contract targets + focused owners (757 passed, ~59s)
- [x] Docs token policy + docs reference targets on changed markdown
- [x] Existing reissue evidence re-verification via updated bundle verifier
- [ ] GitHub CI confirmation on PR


Made with [Cursor](https://cursor.com)