### PR TITLE
Add Phase 9.2 productive restart/recovery Session-GO capability

### DIFF
--- a/config/ops/phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.json
+++ b/config/ops/phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.json
@@ -23,6 +23,9 @@
   "authorization_issuance_authorized": false,
   "authorization_consumption_authorized": false,
   "productive_network_session_execution_authorized": false,
+  "session_go_authority_capability_id": "PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1",
+  "session_go_authority_config": "config/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1.json",
+  "session_go_authority_consumer": "src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.gate_v1",
   "reuses": {
     "wallclock_runner": "src.ops.integrated_paper_shadow_productive_authorization_issuance_and_real_network_execution_v1.productive_run_entrypoint_v1",
     "offline_harness": "src.ops.phase_9_2_restart_recovery_session_contract_and_productive_harness_v1",
@@ -36,6 +39,8 @@
   },
   "later_real_session_requires": [
     "SEPARATE_OWNER_SESSION_GO",
+    "PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1",
+    "BOUND_ACTIVE_SESSION_GO_ARTIFACT",
     "NEW_SINGLE_USE_AUTHORIZATION_PER_SEGMENT",
     "NETWORK_SESSION_ALLOWED_TRUE_ONLY_IN_SESSION_GO",
     "CONFIRM_TOKEN_VIA_CANONICAL_SECURE_PATH"

--- a/config/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1.json
+++ b/config/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "phase_9_2_productive_restart_recovery_session_go.v1",
+  "capability_id": "PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1",
+  "authority_owner": "ops.phase_9_2_productive_restart_recovery_session_go_capability_v1",
+  "predecessor_capability_id": "PHASE_9_2_PRODUCTIVE_PUBLIC_MD_RESTART_RECOVERY_NETWORK_ENTRYPOINT_V1",
+  "predecessor_merge_sha": "0cc5c91583733e37ccc2f4b3ad8696ec76b0c5d5",
+  "target_session_id": "phase_9_2_public_md_restart_recovery_session_v1",
+  "target_entrypoint_id": "PHASE_9_2_PRODUCTIVE_PUBLIC_MD_RESTART_RECOVERY_NETWORK_ENTRYPOINT_V1",
+  "target_entrypoint_path": "scripts/ops/run_phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.py",
+  "restart_recovery_scope": "PHASE_9_2_RESTART_RECOVERY_PRE_POST_SEGMENTS",
+  "default_max_session_duration_seconds": 3600,
+  "default_activation_status": "INACTIVE",
+  "session_execution_allowed_by_capability_config": false,
+  "network_session_allowed_by_capability_config": false,
+  "authorization_issuance_allowed_by_capability_config": false,
+  "authorization_consumption_allowed_by_capability_config": false,
+  "no_permanent_unscoped_enable_flag": true,
+  "productive_network_session_execution_authorized": false,
+  "public_md_only": true,
+  "http_get_only": true,
+  "consumers": {
+    "session_go_gate": "src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.gate_v1",
+    "productive_entrypoint": "src.ops.phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.orchestrator_v1"
+  },
+  "ordering": [
+    "SESSION_GO_EVALUATION",
+    "OWNER_GO_AND_OWNER_SESSION_GO",
+    "SINGLE_USE_AUTHORIZATION",
+    "CONFIRM_TOKEN",
+    "LOCK_ACQUISITION",
+    "NETWORK_ACCESS",
+    "SESSION_START"
+  ],
+  "notes": [
+    "Capability creates bound Session-GO authority surface only.",
+    "ACTIVE Session-GO artifacts are issued by a later Owner session execution order.",
+    "Does not flip productive_network_session_execution_authorized permanently."
+  ]
+}

--- a/docs/ops/specs/CAPABILITY_PHASE_9_2_PRODUCTIVE_PUBLIC_MD_RESTART_RECOVERY_NETWORK_ENTRYPOINT_V1.md
+++ b/docs/ops/specs/CAPABILITY_PHASE_9_2_PRODUCTIVE_PUBLIC_MD_RESTART_RECOVERY_NETWORK_ENTRYPOINT_V1.md
@@ -104,7 +104,16 @@ SESSION_ACTIVATED=false
 NETWORK_SESSION_STARTED=false
 ```
 
-Documentation and merge do not authorize a session.
+Documentation and merge do not authorize a session. Unlock requires the separate
+Session-GO capability:
+
+```text
+PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1
+```
+
+bound ACTIVE Session-GO artifact + Owner-GO + Owner-Session-GO + single-use
+authorization + confirm token. The permanent config flag
+`productive_network_session_execution_authorized` remains `false`.
 
 ## Rollback
 

--- a/docs/ops/specs/CAPABILITY_PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1.md
+++ b/docs/ops/specs/CAPABILITY_PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1.md
@@ -1,0 +1,103 @@
+---
+docs_token: DOCS_TOKEN_CAPABILITY_PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1
+status: active
+scope: Phase 9.2 Session-GO authority surface; no session execution
+capability: PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1
+architecture_spec: PEAK_TRADE_MASTER_RUNBOOK
+last_updated: 2026-08-03
+---
+
+# Capability — Phase 9.2 Productive Restart/Recovery Session-GO Capability V1
+
+## Problem / Root Cause
+
+PR #5666 merged the productive Public-MD restart/recovery network entrypoint, but
+left productive session execution permanently blocked:
+
+```text
+PRODUCTIVE_NETWORK_SESSION_EXECUTION_ALLOWED=false
+productive_network_session_execution_authorized=false
+```
+
+Owner-GO and OWNER_SESSION_GO alone cannot unlock that path. A separate bound
+Session-GO authority surface was required.
+
+## Goal
+
+Create the smallest complete Session-GO authority that makes the existing
+entrypoint unlockable for a later separately authorized execution order.
+
+```text
+CORE_LOGIC_CHANGE=false
+SESSION_EXECUTION_ALLOWED=false
+NETWORK_SESSION_ALLOWED=false
+AUTHORIZATION_ISSUANCE_ALLOWED=false
+AUTHORIZATION_CONSUMPTION_ALLOWED=false
+NO_PERMANENT_UNSCOPED_ENABLE_FLAG=true
+```
+
+This capability does **not** execute a productive session.
+
+## Authority bindings
+
+A Session-GO artifact must bind:
+
+- capability_id
+- session_id
+- repository SHA
+- config digest
+- entrypoint id + path
+- public-MD-only
+- HTTP GET-only
+- max session duration
+- restart/recovery scope
+- expiry window
+- activation_status (`INACTIVE` | `ACTIVE` | `EXPIRED` | `REVOKED`)
+
+## Ordering
+
+```text
+Session-GO evaluation
+→ Owner-GO + Owner-Session-GO
+→ single-use authorization present
+→ confirm-token present
+→ (only then) lock / network / session start may proceed
+```
+
+Missing, expired, inactive, revoked, or mismatched Session-GO fails closed before
+authorization consumption, confirm-token processing, lock acquisition, network
+access, or session start.
+
+## Distinctions
+
+| Surface | Authority |
+| --- | --- |
+| Owner-GO / Owner-Session-GO | Necessary but insufficient alone |
+| Session-GO (this) | Bound unlock authority for the entrypoint |
+| Single-use authorization | Separate; still required after Session-GO |
+| Confirm token | Separate secure path; still required |
+| Productive entrypoint | Consumer of Session-GO gate |
+| Actual session execution | Later Owner execution order only |
+
+## Entrypoints
+
+| Role | Path |
+| --- | --- |
+| Session-GO CLI | `scripts&#47;ops&#47;run_phase_9_2_productive_restart_recovery_session_go_capability_v1.py` |
+| Productive consumer | `scripts&#47;ops&#47;run_phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.py` |
+
+## Config
+
+- Capability config: `config&#47;ops&#47;phase_9_2_productive_restart_recovery_session_go_capability_v1.json`
+- Entrypoint config retains `productive_network_session_execution_authorized=false`
+- Entrypoint config gains Session-GO authority references only
+
+## Out of scope
+
+- Real session execution
+- Authorization issuance/consumption
+- Confirm-token minting
+- Lock acquisition
+- Network requests
+- Core trading logic / threshold changes
+- Notion or ruleset mutation

--- a/scripts/ops/run_phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.py
+++ b/scripts/ops/run_phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.py
@@ -5,11 +5,11 @@ Commands:
   preflight              — offline readiness / segment plan / boundary proof
   offline-integration    — fake public-MD transport + PR#5665 harness/verifier
   materialize-evidence   — write capability evidence fixtures
-  productive-session     — fail-closed unless a later Owner session GO exists
+  productive-session     — Session-GO gated; no side effects without full unlock
 
 Confirm tokens are never accepted as argv plaintext. Use --confirm-token-file,
-env PEAK_TRADE_PSO_CONFIRM_TOKEN, or stdin only when a later session GO authorizes
-issuance/consumption.
+env PEAK_TRADE_PSO_CONFIRM_TOKEN, or stdin only when a bound ACTIVE Session-GO
+plus Owner flags authorize later execution.
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -97,6 +98,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--evidence-root", type=Path, default=None)
     p.add_argument("--expected-repository-sha", default=None)
     p.add_argument("--confirm-token-file", type=Path, default=None)
+    p.add_argument("--session-go-file", type=Path, default=None)
+    p.add_argument("--owner-go", action="store_true")
+    p.add_argument("--owner-session-go", action="store_true")
+    p.add_argument("--authorization-present", action="store_true")
+    p.add_argument("--confirm-token-present", action="store_true")
     p.add_argument("--real-network", action="store_true")
     p.add_argument("--json", action="store_true")
     return p
@@ -138,14 +144,47 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if summary.get("ok") else 1
 
     if args.command == "productive-session":
-        # Explicitly refuse real session execution in this capability.
-        _ = args.confirm_token_file  # accepted only for future session GO wiring
+        # Gate-only evaluation: never issue/consume auth, lock, network, or start.
+        cfg_digest = str(
+            load_activation_config_v1(
+                config_path=_REPO_ROOT
+                / "config/runtime/single_future_stateful_no_order_runtime_activation_v1.json"
+            ).config_digest
+        )
+        confirm_present = bool(args.confirm_token_present) or bool(args.confirm_token_file)
         payload = reject_productive_session_start_v1(
             use_real_network=bool(args.real_network),
             environ=os.environ,
+            expected_repository_sha=sha,
+            expected_config_digest=cfg_digest,
+            now_unix=float(time.time()),
+            owner_go=bool(args.owner_go),
+            owner_session_go=bool(args.owner_session_go),
+            session_go_path=args.session_go_file,
+            authorization_present=bool(args.authorization_present),
+            confirm_token_present=confirm_present,
+            repo_root=_REPO_ROOT,
         )
+        notes = list(payload.get("notes") or [])
+        notes.extend(
+            [
+                "PRODUCTIVE_SESSION_COMMAND_IS_GATE_EVALUATION_ONLY",
+                "NO_AUTHORIZATION_ISSUED",
+                "NO_AUTHORIZATION_CONSUMED",
+                "NO_SESSION_LOCK",
+                "NO_NETWORK_REQUEST",
+                "NO_SESSION_START",
+            ]
+        )
+        payload = dict(payload)
+        payload["notes"] = notes
+        payload["network_session_started"] = False
+        payload["authorization_consumed"] = False
+        payload["session_started"] = False
+        payload["network_request_count"] = 0
         print(json.dumps(redact_mapping_for_logs(payload), sort_keys=True, indent=2))
-        return 2
+        # Exit 0 only means Session-GO unlock evaluation passed; session is not started.
+        return 0 if payload.get("productive_session_execution_permitted") else 2
 
     # offline-integration
     if args.persistence_root is None:

--- a/scripts/ops/run_phase_9_2_productive_restart_recovery_session_go_capability_v1.py
+++ b/scripts/ops/run_phase_9_2_productive_restart_recovery_session_go_capability_v1.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""CLI for Phase 9.2 productive restart/recovery Session-GO capability.
+
+Commands:
+  preflight — schema/authority surface readiness (no session)
+  validate  — validate a Session-GO artifact against bindings (no side effects)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_REPO_ROOT, _REPO_ROOT / "src"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.constants_v1 import (  # noqa: E402
+    CAPABILITY_ID,
+    CONFIG_RELATIVE_PATH,
+    TARGET_ENTRYPOINT_PATH,
+    TARGET_SESSION_ID,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.gate_v1 import (  # noqa: E402
+    evaluate_session_go_gate_v1,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.parity_v1 import (  # noqa: E402
+    prove_phase92_session_go_parity_v1,
+)
+from src.ops.single_future_stateful_no_order_runtime_activation_v1.config_v1 import (  # noqa: E402
+    load_activation_config_v1,
+)
+
+
+def _repo_sha() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=str(_REPO_ROOT), text=True
+    ).strip()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("command", choices=("preflight", "validate"))
+    p.add_argument("--session-go-file", type=Path, default=None)
+    p.add_argument("--expected-repository-sha", default=None)
+    p.add_argument("--owner-go", action="store_true")
+    p.add_argument("--owner-session-go", action="store_true")
+    p.add_argument("--authorization-present", action="store_true")
+    p.add_argument("--confirm-token-present", action="store_true")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.command == "preflight":
+        parity = prove_phase92_session_go_parity_v1()
+        cfg_path = _REPO_ROOT / CONFIG_RELATIVE_PATH
+        payload = {
+            "ok": bool(parity.get("ok") and cfg_path.is_file()),
+            "capability_id": CAPABILITY_ID,
+            "session_id": TARGET_SESSION_ID,
+            "entrypoint_path": TARGET_ENTRYPOINT_PATH,
+            "config_path": CONFIG_RELATIVE_PATH,
+            "config_present": cfg_path.is_file(),
+            "parity": parity,
+            "session_started": False,
+            "authorization_consumed": False,
+            "network_request_count": 0,
+            "notes": [
+                "SESSION_GO_AUTHORITY_SURFACE_READY",
+                "NO_SESSION_STARTED",
+                "NO_AUTHORIZATION_ISSUED",
+                "DEFAULT_ACTIVATION_INACTIVE_IN_CAPABILITY_CONFIG",
+            ],
+        }
+        print(json.dumps(payload, sort_keys=True, indent=2))
+        return 0 if payload["ok"] else 1
+
+    sha = args.expected_repository_sha or _repo_sha()
+    cfg = str(
+        load_activation_config_v1(
+            config_path=_REPO_ROOT
+            / "config/runtime/single_future_stateful_no_order_runtime_activation_v1.json"
+        ).config_digest
+    )
+
+    if args.session_go_file is None:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "blockers": ["SESSION_GO_MISSING"],
+                    "session_started": False,
+                    "authorization_consumed": False,
+                    "network_request_count": 0,
+                },
+                sort_keys=True,
+                indent=2,
+            )
+        )
+        return 2
+
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha=sha,
+        expected_config_digest=cfg,
+        now_unix=float(time.time()),
+        owner_go=bool(args.owner_go),
+        owner_session_go=bool(args.owner_session_go),
+        session_go_path=args.session_go_file,
+        authorization_present=bool(args.authorization_present),
+        confirm_token_present=bool(args.confirm_token_present),
+    )
+    print(json.dumps(result.to_dict(), sort_keys=True, indent=2))
+    return 0 if result.ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ops/phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1/orchestrator_v1.py
+++ b/src/ops/phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1/orchestrator_v1.py
@@ -110,6 +110,11 @@ def assert_real_session_gates_closed_v1(
     use_real_network: bool,
     environ: Mapping[str, str] | None = None,
 ) -> list[str]:
+    """Offline/default gates: permanent unscoped enable remains false.
+
+    Env flags alone never unlock productive execution. Unlock requires a bound
+    ACTIVE Session-GO artifact evaluated by evaluate_productive_session_start_gates_v1.
+    """
     env = environ if environ is not None else os.environ
     blockers: list[str] = []
     if use_real_network:
@@ -117,12 +122,10 @@ def assert_real_session_gates_closed_v1(
     if PRODUCTIVE_NETWORK_SESSION_EXECUTION_ALLOWED:
         blockers.append("PRODUCTIVE_NETWORK_SESSION_EXECUTION_ALLOWED_MUST_REMAIN_FALSE_HERE")
     if str(env.get(PRODUCTIVE_SESSION_GO_ENV) or "") == "1":
-        # Session GO alone is insufficient without a later dedicated session capability run.
-        blockers.append(
-            "PRODUCTIVE_SESSION_GO_ENV_SET_BUT_ENTRYPOINT_IMPLEMENTATION_BLOCKS_EXECUTION"
-        )
+        # Env alone remains insufficient; bound Session-GO capability is required.
+        blockers.append("PRODUCTIVE_SESSION_GO_ENV_INSUFFICIENT_WITHOUT_BOUND_SESSION_GO_ARTIFACT")
     if str(env.get(REAL_NETWORK_ENV) or "") == "1" and use_real_network:
-        blockers.append("REAL_NETWORK_ENV_INSUFFICIENT_WITHOUT_SEPARATE_SESSION_GO_CAPABILITY")
+        blockers.append("REAL_NETWORK_ENV_INSUFFICIENT_WITHOUT_BOUND_SESSION_GO_ARTIFACT")
     return blockers
 
 
@@ -441,28 +444,171 @@ def run_offline_productive_restart_orchestration_v1(
                 pass
 
 
-def reject_productive_session_start_v1(
+def evaluate_productive_session_start_gates_v1(
     *,
+    expected_repository_sha: str,
+    expected_config_digest: str,
+    now_unix: float,
+    owner_go: bool = False,
+    owner_session_go: bool = False,
+    session_go_path: Path | None = None,
+    session_go_payload: Mapping[str, Any] | None = None,
+    authorization_present: bool = False,
+    confirm_token_present: bool = False,
     use_real_network: bool = False,
     environ: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Fail-closed gate used by CLI productive-session command during this capability."""
-    blockers = assert_real_session_gates_closed_v1(
-        use_real_network=use_real_network, environ=environ
+    """Fail-closed productive-session gate ordered before auth/lock/network/start.
+
+    Permanent PRODUCTIVE_NETWORK_SESSION_EXECUTION_ALLOWED stays false. Unlock is
+    only via a bound ACTIVE Session-GO plus Owner flags, auth, and confirm token.
+    This function never issues/consumes authorization, acquires locks, opens
+    network, or starts a session.
+    """
+    from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.constants_v1 import (  # noqa: E501
+        TARGET_ENTRYPOINT_ID,
+        TARGET_ENTRYPOINT_PATH,
     )
-    blockers.append("PRODUCTIVE_SESSION_EXECUTION_REQUIRES_SEPARATE_OWNER_SESSION_GO")
+    from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.gate_v1 import (
+        evaluate_session_go_gate_v1,
+    )
+
+    env = environ if environ is not None else os.environ
+    notes = [
+        "ENTRYPOINT_IMPLEMENTED",
+        "NO_PERMANENT_UNSCOPED_ENABLE_FLAG=true",
+        f"PRODUCTIVE_NETWORK_SESSION_EXECUTION_ALLOWED_CONSTANT={PRODUCTIVE_NETWORK_SESSION_EXECUTION_ALLOWED}",
+        "SESSION_GO_REQUIRED_BEFORE_AUTHORIZATION_CONSUMPTION=true",
+        "SESSION_GO_REQUIRED_BEFORE_LOCK_ACQUISITION=true",
+        "SESSION_GO_REQUIRED_BEFORE_NETWORK_ACCESS=true",
+        "SESSION_GO_REQUIRED_BEFORE_SESSION_START=true",
+    ]
+    blockers: list[str] = []
+
+    # Permanent package constant must remain false; Session-GO is the unlock surface.
+    if PRODUCTIVE_NETWORK_SESSION_EXECUTION_ALLOWED:
+        blockers.append("PRODUCTIVE_NETWORK_SESSION_EXECUTION_ALLOWED_MUST_REMAIN_FALSE_HERE")
+
+    # Env alone never unlocks.
+    if (
+        str(env.get(PRODUCTIVE_SESSION_GO_ENV) or "") == "1"
+        and session_go_path is None
+        and session_go_payload is None
+    ):
+        blockers.append("PRODUCTIVE_SESSION_GO_ENV_INSUFFICIENT_WITHOUT_BOUND_SESSION_GO_ARTIFACT")
+    if (
+        use_real_network
+        and str(env.get(REAL_NETWORK_ENV) or "") == "1"
+        and session_go_path is None
+        and session_go_payload is None
+    ):
+        blockers.append("REAL_NETWORK_ENV_INSUFFICIENT_WITHOUT_BOUND_SESSION_GO_ARTIFACT")
+
+    gate = evaluate_session_go_gate_v1(
+        expected_repository_sha=expected_repository_sha,
+        expected_config_digest=expected_config_digest,
+        expected_session_id=TARGET_SESSION_ID,
+        expected_entrypoint_id=TARGET_ENTRYPOINT_ID,
+        expected_entrypoint_path=TARGET_ENTRYPOINT_PATH,
+        now_unix=now_unix,
+        owner_go=owner_go,
+        owner_session_go=owner_session_go,
+        session_go_path=session_go_path,
+        session_go_payload=session_go_payload,
+        authorization_present=authorization_present,
+        confirm_token_present=confirm_token_present,
+    )
+    blockers.extend(gate.blockers)
+    notes.extend(gate.notes)
+
+    ok = (not blockers) and bool(gate.ok) and bool(gate.productive_session_execution_permitted)
     return {
-        "ok": False,
+        "ok": ok,
         "blockers": sorted(set(blockers)),
+        "notes": notes,
         "network_session_started": False,
         "authorization_issued": False,
         "authorization_consumed": False,
         "runtime_started": False,
-        "notes": [
-            "ENTRYPOINT_IMPLEMENTED",
-            "SESSION_ACTIVATION_NOT_AUTHORIZED_IN_THIS_CAPABILITY",
-        ],
+        "session_lock_acquired": False,
+        "session_started": False,
+        "network_request_count": 0,
+        "session_go_authority_satisfied": bool(gate.session_go_authority_satisfied),
+        "productive_session_execution_permitted": bool(gate.productive_session_execution_permitted),
+        "authorization_may_proceed": bool(gate.authorization_may_proceed),
+        "lock_may_proceed": bool(gate.lock_may_proceed),
+        "network_may_proceed": bool(gate.network_may_proceed),
+        "session_start_may_proceed": bool(gate.session_start_may_proceed),
+        "session_go_gate": gate.to_dict(),
     }
+
+
+def reject_productive_session_start_v1(
+    *,
+    use_real_network: bool = False,
+    environ: Mapping[str, str] | None = None,
+    expected_repository_sha: str | None = None,
+    expected_config_digest: str | None = None,
+    now_unix: float | None = None,
+    owner_go: bool = False,
+    owner_session_go: bool = False,
+    session_go_path: Path | None = None,
+    session_go_payload: Mapping[str, Any] | None = None,
+    authorization_present: bool = False,
+    confirm_token_present: bool = False,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """CLI/compatible gate: Session-GO first; never starts a session here."""
+    root = Path(repo_root) if repo_root is not None else repo_root_v1()
+    sha = expected_repository_sha or ""
+    cfg = expected_config_digest or ""
+    if not sha or not cfg:
+        # Without bindings, fail closed before any side effect.
+        return {
+            "ok": False,
+            "blockers": sorted(
+                {
+                    *(
+                        ["SESSION_GO_MISSING"]
+                        if session_go_path is None and session_go_payload is None
+                        else []
+                    ),
+                    *(["EXPECTED_REPOSITORY_SHA_REQUIRED"] if not sha else []),
+                    *(["EXPECTED_CONFIG_DIGEST_REQUIRED"] if not cfg else []),
+                }
+            ),
+            "network_session_started": False,
+            "authorization_issued": False,
+            "authorization_consumed": False,
+            "runtime_started": False,
+            "session_lock_acquired": False,
+            "session_started": False,
+            "network_request_count": 0,
+            "session_go_authority_satisfied": False,
+            "productive_session_execution_permitted": False,
+            "notes": [
+                "ENTRYPOINT_IMPLEMENTED",
+                "SESSION_GO_BINDINGS_REQUIRED_FOR_UNLOCK_EVALUATION",
+            ],
+        }
+    if now_unix is None:
+        import time
+
+        now_unix = float(time.time())
+    _ = root  # repo_root reserved for future digest helpers; gate is pure evaluation
+    return evaluate_productive_session_start_gates_v1(
+        expected_repository_sha=sha,
+        expected_config_digest=cfg,
+        now_unix=float(now_unix),
+        owner_go=owner_go,
+        owner_session_go=owner_session_go,
+        session_go_path=session_go_path,
+        session_go_payload=session_go_payload,
+        authorization_present=authorization_present,
+        confirm_token_present=confirm_token_present,
+        use_real_network=use_real_network,
+        environ=environ,
+    )
 
 
 def orchestration_identity_digest_v1() -> str:

--- a/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/__init__.py
+++ b/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/__init__.py
@@ -1,0 +1,17 @@
+"""Phase 9.2 productive restart/recovery Session-GO capability v1."""
+
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.constants_v1 import (
+    CAPABILITY_ID,
+    PACKAGE_MARKER,
+    TARGET_SESSION_ID,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.gate_v1 import (
+    evaluate_session_go_gate_v1,
+)
+
+__all__ = [
+    "CAPABILITY_ID",
+    "PACKAGE_MARKER",
+    "TARGET_SESSION_ID",
+    "evaluate_session_go_gate_v1",
+]

--- a/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/constants_v1.py
+++ b/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/constants_v1.py
@@ -1,0 +1,102 @@
+"""Constants for PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CAPABILITY_ID = "PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1"
+SCHEMA_VERSION = "phase_9_2_productive_restart_recovery_session_go.v1"
+PRODUCER_VERSION = "phase_9_2_productive_restart_recovery_session_go.v1"
+PACKAGE_MARKER = "PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1=true"
+OWNER = "ops.phase_9_2_productive_restart_recovery_session_go_capability_v1"
+AUTHORITY_OWNER = OWNER
+
+PREDECESSOR_CAPABILITY_ID = "PHASE_9_2_PRODUCTIVE_PUBLIC_MD_RESTART_RECOVERY_NETWORK_ENTRYPOINT_V1"
+PREDECESSOR_MERGE_SHA = "0cc5c91583733e37ccc2f4b3ad8696ec76b0c5d5"
+
+CONFIG_RELATIVE_PATH = (
+    "config/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1.json"
+)
+
+TARGET_SESSION_ID = "phase_9_2_public_md_restart_recovery_session_v1"
+TARGET_ENTRYPOINT_ID = "PHASE_9_2_PRODUCTIVE_PUBLIC_MD_RESTART_RECOVERY_NETWORK_ENTRYPOINT_V1"
+TARGET_ENTRYPOINT_PATH = (
+    "scripts/ops/run_phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.py"
+)
+RESTART_RECOVERY_SCOPE = "PHASE_9_2_RESTART_RECOVERY_PRE_POST_SEGMENTS"
+DEFAULT_MAX_SESSION_DURATION_SECONDS = 3600
+
+ACTIVATION_STATUS_INACTIVE = "INACTIVE"
+ACTIVATION_STATUS_ACTIVE = "ACTIVE"
+ACTIVATION_STATUS_EXPIRED = "EXPIRED"
+ACTIVATION_STATUS_REVOKED = "REVOKED"
+ACTIVATION_STATUSES = (
+    ACTIVATION_STATUS_INACTIVE,
+    ACTIVATION_STATUS_ACTIVE,
+    ACTIVATION_STATUS_EXPIRED,
+    ACTIVATION_STATUS_REVOKED,
+)
+
+# Capability defaults: authority surface exists; no session execution here.
+SESSION_EXECUTION_ALLOWED = False
+NETWORK_SESSION_ALLOWED = False
+AUTHORIZATION_ISSUANCE_ALLOWED = False
+AUTHORIZATION_CONSUMPTION_ALLOWED = False
+RESTART_RECOVERY_EXECUTION_ALLOWED = False
+
+# Permanent unscoped enable remains forbidden; unlock only via bound ACTIVE Session-GO.
+NO_PERMANENT_UNSCOPED_ENABLE_FLAG = True
+
+PUBLIC_MD_ONLY = True
+HTTP_GET_ONLY = True
+PRIVATE_ENDPOINT_REACHABLE = False
+AUTH_HEADER_PRESENT = False
+EXCHANGE_CREDENTIALS_LOADED = False
+REAL_EXECUTION_ADAPTER_CONSTRUCTED = False
+EXCHANGE_ORDER_SUBMIT_REACHABLE = False
+
+CORE_LOGIC_CHANGE = False
+MASTER_V2_CHANGE = False
+DOUBLE_PLAY_CHANGE = False
+BULL_BEAR_CHANGE = False
+DYNAMIC_SCOPE_LOGIC_CHANGE = False
+CONFIRMATION_SEMANTICS_CHANGE = False
+RISK_CHANGE = False
+SAFETY_CHANGE = False
+
+REQUIRED_FIELDS = (
+    "schema_version",
+    "capability_id",
+    "session_go_id",
+    "session_id",
+    "expected_repository_sha",
+    "expected_config_digest",
+    "entrypoint_id",
+    "entrypoint_path",
+    "public_md_only",
+    "http_get_only",
+    "max_session_duration_seconds",
+    "restart_recovery_scope",
+    "issued_at",
+    "not_before",
+    "expires_at",
+    "activation_status",
+    "owner_go_required",
+    "owner_session_go_required",
+    "single_use_authorization_required",
+    "confirm_token_required",
+    "network_session_execution_authorized_by_this_go",
+    "fixture_non_authoritative",
+)
+
+KNOWN_FIELDS = frozenset(
+    REQUIRED_FIELDS
+    + (
+        "session_go_digest",
+        "notes",
+    )
+)
+
+
+def repo_root_v1() -> Path:
+    return Path(__file__).resolve().parents[3]

--- a/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/contract_v1.py
+++ b/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/contract_v1.py
@@ -1,0 +1,215 @@
+"""Fail-closed Session-GO authority contract parse/validate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.constants_v1 import (
+    ACTIVATION_STATUSES,
+    ACTIVATION_STATUS_ACTIVE,
+    CAPABILITY_ID,
+    DEFAULT_MAX_SESSION_DURATION_SECONDS,
+    KNOWN_FIELDS,
+    REQUIRED_FIELDS,
+    RESTART_RECOVERY_SCOPE,
+    SCHEMA_VERSION,
+    TARGET_ENTRYPOINT_ID,
+    TARGET_ENTRYPOINT_PATH,
+    TARGET_SESSION_ID,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.digest_v1 import (
+    sha256_canonical_v1,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.models_v1 import (
+    SessionGoAuthorityV1,
+)
+
+
+class SessionGoContractError(ValueError):
+    """Fail-closed Session-GO contract error."""
+
+
+def _req(raw: Mapping[str, Any], name: str) -> Any:
+    if name not in raw:
+        raise SessionGoContractError(f"SESSION_GO_FIELD_MISSING:{name}")
+    return raw[name]
+
+
+def load_session_go_dict_v1(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise SessionGoContractError("SESSION_GO_ARTIFACT_MISSING")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SessionGoContractError(f"SESSION_GO_PARSE_ERROR:{exc}") from exc
+    if not isinstance(raw, dict):
+        raise SessionGoContractError("SESSION_GO_NOT_OBJECT")
+    unknown = sorted(set(raw) - KNOWN_FIELDS)
+    if unknown:
+        raise SessionGoContractError("SESSION_GO_UNKNOWN_FIELDS:" + ",".join(unknown))
+    return raw
+
+
+def parse_session_go_authority_v1(raw: Mapping[str, Any]) -> SessionGoAuthorityV1:
+    unknown = sorted(set(raw) - KNOWN_FIELDS)
+    if unknown:
+        raise SessionGoContractError("SESSION_GO_UNKNOWN_FIELDS:" + ",".join(unknown))
+    for name in REQUIRED_FIELDS:
+        _req(raw, name)
+
+    schema = str(raw["schema_version"]).strip()
+    if schema != SCHEMA_VERSION:
+        raise SessionGoContractError(f"SESSION_GO_SCHEMA_MISMATCH:{schema}")
+
+    capability_id = str(raw["capability_id"]).strip()
+    if capability_id != CAPABILITY_ID:
+        raise SessionGoContractError(f"SESSION_GO_CAPABILITY_MISMATCH:{capability_id}")
+
+    activation_status = str(raw["activation_status"]).strip()
+    if activation_status not in ACTIVATION_STATUSES:
+        raise SessionGoContractError(f"SESSION_GO_ACTIVATION_STATUS_INVALID:{activation_status}")
+
+    max_duration = int(raw["max_session_duration_seconds"])
+    if max_duration <= 0 or max_duration > DEFAULT_MAX_SESSION_DURATION_SECONDS:
+        raise SessionGoContractError(f"SESSION_GO_MAX_DURATION_INVALID:{max_duration}")
+
+    if not bool(raw["public_md_only"]):
+        raise SessionGoContractError("SESSION_GO_PUBLIC_MD_ONLY_REQUIRED")
+    if not bool(raw["http_get_only"]):
+        raise SessionGoContractError("SESSION_GO_HTTP_GET_ONLY_REQUIRED")
+    if str(raw["restart_recovery_scope"]).strip() != RESTART_RECOVERY_SCOPE:
+        raise SessionGoContractError("SESSION_GO_RESTART_SCOPE_MISMATCH")
+    if not bool(raw["owner_go_required"]):
+        raise SessionGoContractError("SESSION_GO_OWNER_GO_REQUIRED_MUST_BE_TRUE")
+    if not bool(raw["owner_session_go_required"]):
+        raise SessionGoContractError("SESSION_GO_OWNER_SESSION_GO_REQUIRED_MUST_BE_TRUE")
+    if not bool(raw["single_use_authorization_required"]):
+        raise SessionGoContractError("SESSION_GO_SINGLE_USE_AUTH_REQUIRED_MUST_BE_TRUE")
+    if not bool(raw["confirm_token_required"]):
+        raise SessionGoContractError("SESSION_GO_CONFIRM_TOKEN_REQUIRED_MUST_BE_TRUE")
+
+    issued_at = float(raw["issued_at"])
+    not_before = float(raw["not_before"])
+    expires_at = float(raw["expires_at"])
+    if not_before < issued_at:
+        raise SessionGoContractError("SESSION_GO_NOT_BEFORE_BEFORE_ISSUED")
+    if expires_at <= not_before:
+        raise SessionGoContractError("SESSION_GO_EXPIRES_NOT_AFTER_NOT_BEFORE")
+
+    notes_raw = raw.get("notes", ())
+    notes = tuple(str(x) for x in notes_raw) if isinstance(notes_raw, (list, tuple)) else ()
+
+    provisional = {
+        "schema_version": schema,
+        "capability_id": capability_id,
+        "session_go_id": str(raw["session_go_id"]).strip(),
+        "session_id": str(raw["session_id"]).strip(),
+        "expected_repository_sha": str(raw["expected_repository_sha"]).strip(),
+        "expected_config_digest": str(raw["expected_config_digest"]).strip(),
+        "entrypoint_id": str(raw["entrypoint_id"]).strip(),
+        "entrypoint_path": str(raw["entrypoint_path"]).strip(),
+        "public_md_only": True,
+        "http_get_only": True,
+        "max_session_duration_seconds": max_duration,
+        "restart_recovery_scope": RESTART_RECOVERY_SCOPE,
+        "issued_at": issued_at,
+        "not_before": not_before,
+        "expires_at": expires_at,
+        "activation_status": activation_status,
+        "owner_go_required": True,
+        "owner_session_go_required": True,
+        "single_use_authorization_required": True,
+        "confirm_token_required": True,
+        "network_session_execution_authorized_by_this_go": bool(
+            raw["network_session_execution_authorized_by_this_go"]
+        ),
+        "fixture_non_authoritative": bool(raw["fixture_non_authoritative"]),
+        "notes": list(notes),
+    }
+    digest = sha256_canonical_v1(provisional)
+    provided = str(raw.get("session_go_digest") or "").strip()
+    if provided and provided != digest:
+        raise SessionGoContractError("SESSION_GO_DIGEST_MISMATCH")
+
+    return SessionGoAuthorityV1(
+        schema_version=schema,
+        capability_id=capability_id,
+        session_go_id=provisional["session_go_id"],
+        session_id=provisional["session_id"],
+        expected_repository_sha=provisional["expected_repository_sha"],
+        expected_config_digest=provisional["expected_config_digest"],
+        entrypoint_id=provisional["entrypoint_id"],
+        entrypoint_path=provisional["entrypoint_path"],
+        public_md_only=True,
+        http_get_only=True,
+        max_session_duration_seconds=max_duration,
+        restart_recovery_scope=RESTART_RECOVERY_SCOPE,
+        issued_at=issued_at,
+        not_before=not_before,
+        expires_at=expires_at,
+        activation_status=activation_status,
+        owner_go_required=True,
+        owner_session_go_required=True,
+        single_use_authorization_required=True,
+        confirm_token_required=True,
+        network_session_execution_authorized_by_this_go=bool(
+            raw["network_session_execution_authorized_by_this_go"]
+        ),
+        fixture_non_authoritative=bool(raw["fixture_non_authoritative"]),
+        session_go_digest=digest,
+        notes=notes,
+    )
+
+
+def build_session_go_authority_v1(
+    *,
+    session_go_id: str,
+    expected_repository_sha: str,
+    expected_config_digest: str,
+    issued_at: float,
+    not_before: float,
+    expires_at: float,
+    activation_status: str = ACTIVATION_STATUS_ACTIVE,
+    session_id: str = TARGET_SESSION_ID,
+    entrypoint_id: str = TARGET_ENTRYPOINT_ID,
+    entrypoint_path: str = TARGET_ENTRYPOINT_PATH,
+    max_session_duration_seconds: int = DEFAULT_MAX_SESSION_DURATION_SECONDS,
+    network_session_execution_authorized_by_this_go: bool = True,
+    fixture_non_authoritative: bool = False,
+    notes: tuple[str, ...] = (),
+) -> SessionGoAuthorityV1:
+    return parse_session_go_authority_v1(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "capability_id": CAPABILITY_ID,
+            "session_go_id": session_go_id,
+            "session_id": session_id,
+            "expected_repository_sha": expected_repository_sha,
+            "expected_config_digest": expected_config_digest,
+            "entrypoint_id": entrypoint_id,
+            "entrypoint_path": entrypoint_path,
+            "public_md_only": True,
+            "http_get_only": True,
+            "max_session_duration_seconds": max_session_duration_seconds,
+            "restart_recovery_scope": RESTART_RECOVERY_SCOPE,
+            "issued_at": issued_at,
+            "not_before": not_before,
+            "expires_at": expires_at,
+            "activation_status": activation_status,
+            "owner_go_required": True,
+            "owner_session_go_required": True,
+            "single_use_authorization_required": True,
+            "confirm_token_required": True,
+            "network_session_execution_authorized_by_this_go": (
+                network_session_execution_authorized_by_this_go
+            ),
+            "fixture_non_authoritative": fixture_non_authoritative,
+            "notes": list(notes),
+        }
+    )
+
+
+def load_session_go_authority_v1(path: Path) -> SessionGoAuthorityV1:
+    return parse_session_go_authority_v1(load_session_go_dict_v1(path))

--- a/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/digest_v1.py
+++ b/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/digest_v1.py
@@ -1,0 +1,32 @@
+"""Canonical digest helpers for Session-GO authority."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def sha256_canonical_v1(
+    payload: Mapping[str, Any] | list[Any] | str | int | float | bool | None,
+) -> str:
+    material = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def write_json_atomic_v1(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps(payload, sort_keys=True, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+def read_json_v1(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("json_payload_not_object")
+    return payload

--- a/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/gate_v1.py
+++ b/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/gate_v1.py
@@ -1,0 +1,180 @@
+"""Session-GO gate: fail-closed unlock evaluation before auth/lock/network/session."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.constants_v1 import (
+    ACTIVATION_STATUS_ACTIVE,
+    ACTIVATION_STATUS_EXPIRED,
+    ACTIVATION_STATUS_INACTIVE,
+    ACTIVATION_STATUS_REVOKED,
+    AUTHORITY_OWNER,
+    TARGET_ENTRYPOINT_ID,
+    TARGET_ENTRYPOINT_PATH,
+    TARGET_SESSION_ID,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.contract_v1 import (
+    SessionGoContractError,
+    load_session_go_authority_v1,
+    parse_session_go_authority_v1,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.models_v1 import (
+    SessionGoAuthorityV1,
+    SessionGoGateResultV1,
+)
+
+
+def evaluate_session_go_gate_v1(
+    *,
+    expected_repository_sha: str,
+    expected_config_digest: str,
+    expected_session_id: str = TARGET_SESSION_ID,
+    expected_entrypoint_id: str = TARGET_ENTRYPOINT_ID,
+    expected_entrypoint_path: str = TARGET_ENTRYPOINT_PATH,
+    now_unix: float,
+    owner_go: bool,
+    owner_session_go: bool,
+    session_go_path: Path | None = None,
+    session_go_payload: Mapping[str, Any] | SessionGoAuthorityV1 | None = None,
+    authorization_present: bool = False,
+    confirm_token_present: bool = False,
+) -> SessionGoGateResultV1:
+    """Evaluate Session-GO before any authorization/lock/network/session side effect.
+
+    This gate never consumes authorization, acquires locks, opens network, or starts a
+    session. It only decides whether those later steps are permitted.
+    """
+    notes = [
+        f"SESSION_GO_AUTHORITY_OWNER={AUTHORITY_OWNER}",
+        "SESSION_GO_EVALUATION_BEFORE_AUTHORIZATION=true",
+        "SESSION_GO_EVALUATION_BEFORE_LOCK=true",
+        "SESSION_GO_EVALUATION_BEFORE_NETWORK=true",
+        "SESSION_GO_EVALUATION_BEFORE_SESSION_START=true",
+        "NO_SIDE_EFFECTS_IN_SESSION_GO_GATE=true",
+    ]
+    blockers: list[str] = []
+    authority: Optional[SessionGoAuthorityV1] = None
+
+    if session_go_path is None and session_go_payload is None:
+        return SessionGoGateResultV1(
+            ok=False,
+            blockers=["SESSION_GO_MISSING"],
+            notes=notes + ["MISSING_SESSION_GO_FAILS_CLOSED=true"],
+        )
+
+    try:
+        if session_go_payload is not None:
+            if isinstance(session_go_payload, SessionGoAuthorityV1):
+                authority = session_go_payload
+            else:
+                authority = parse_session_go_authority_v1(session_go_payload)
+        else:
+            assert session_go_path is not None
+            authority = load_session_go_authority_v1(session_go_path)
+    except SessionGoContractError as exc:
+        return SessionGoGateResultV1(
+            ok=False,
+            blockers=[str(exc)],
+            notes=notes + ["SESSION_GO_PARSE_OR_SCHEMA_FAIL_CLOSED=true"],
+        )
+
+    if authority.fixture_non_authoritative:
+        blockers.append("SESSION_GO_FIXTURE_NON_AUTHORITATIVE")
+    if authority.activation_status == ACTIVATION_STATUS_INACTIVE:
+        blockers.append("SESSION_GO_INACTIVE")
+    if authority.activation_status == ACTIVATION_STATUS_REVOKED:
+        blockers.append("SESSION_GO_REVOKED")
+    if authority.activation_status == ACTIVATION_STATUS_EXPIRED or float(now_unix) >= float(
+        authority.expires_at
+    ):
+        blockers.append("SESSION_GO_EXPIRED")
+    if float(now_unix) < float(authority.not_before):
+        blockers.append("SESSION_GO_NOT_YET_VALID")
+    if (
+        authority.activation_status != ACTIVATION_STATUS_ACTIVE
+        and "SESSION_GO_EXPIRED" not in blockers
+    ):
+        if authority.activation_status not in {
+            ACTIVATION_STATUS_INACTIVE,
+            ACTIVATION_STATUS_REVOKED,
+            ACTIVATION_STATUS_EXPIRED,
+        }:
+            blockers.append(f"SESSION_GO_ACTIVATION_STATUS_INVALID:{authority.activation_status}")
+
+    if authority.expected_repository_sha != expected_repository_sha:
+        blockers.append("SESSION_GO_REPOSITORY_SHA_MISMATCH")
+    if authority.expected_config_digest != expected_config_digest:
+        blockers.append("SESSION_GO_CONFIG_DIGEST_MISMATCH")
+    if authority.session_id != expected_session_id:
+        blockers.append("SESSION_GO_SESSION_ID_MISMATCH")
+    if authority.entrypoint_id != expected_entrypoint_id:
+        blockers.append("SESSION_GO_ENTRYPOINT_ID_MISMATCH")
+    if authority.entrypoint_path != expected_entrypoint_path:
+        blockers.append("SESSION_GO_ENTRYPOINT_PATH_MISMATCH")
+    if not authority.network_session_execution_authorized_by_this_go:
+        blockers.append("SESSION_GO_NETWORK_EXECUTION_NOT_AUTHORIZED_BY_THIS_GO")
+
+    if not owner_go:
+        blockers.append("OWNER_GO_REQUIRED")
+    if not owner_session_go:
+        blockers.append("OWNER_SESSION_GO_REQUIRED")
+    if owner_go and not owner_session_go:
+        notes.append("OWNER_GO_WITHOUT_SESSION_GO_INSUFFICIENT=true")
+    if owner_session_go and not owner_go:
+        notes.append("OWNER_SESSION_GO_WITHOUT_OWNER_GO_INSUFFICIENT=true")
+
+    if blockers:
+        return SessionGoGateResultV1(
+            ok=False,
+            blockers=sorted(set(blockers)),
+            notes=notes,
+            authority=authority,
+            session_go_authority_satisfied=False,
+        )
+
+    # Session-GO authority is satisfied. Still require separate single-use auth + confirm
+    # before any side-effect-capable step.
+    auth_blockers: list[str] = []
+    if not authorization_present:
+        auth_blockers.append("SESSION_GO_VALID_BUT_AUTHORIZATION_REQUIRED")
+    if not confirm_token_present:
+        auth_blockers.append("SESSION_GO_VALID_BUT_CONFIRM_TOKEN_REQUIRED")
+
+    if auth_blockers:
+        return SessionGoGateResultV1(
+            ok=False,
+            blockers=sorted(set(auth_blockers)),
+            notes=notes
+            + [
+                "SESSION_GO_AUTHORITY_SATISFIED=true",
+                "SESSION_GO_SEPARATE_FROM_SINGLE_USE_AUTHORIZATION=true",
+                "AUTHORIZATION_CONSUMPTION_BLOCKED_UNTIL_PRESENT=true",
+            ],
+            authority=authority,
+            session_go_authority_satisfied=True,
+            productive_session_execution_permitted=False,
+            authorization_may_proceed=False,
+            lock_may_proceed=False,
+            network_may_proceed=False,
+            session_start_may_proceed=False,
+        )
+
+    return SessionGoGateResultV1(
+        ok=True,
+        blockers=[],
+        notes=notes
+        + [
+            "SESSION_GO_AUTHORITY_SATISFIED=true",
+            "PRODUCTIVE_SESSION_EXECUTION_PERMITTED=true",
+            "SIDE_EFFECTS_STILL_REQUIRE_CANONICAL_RUNTIME_INVOCATION=true",
+        ],
+        authority=authority,
+        session_go_authority_satisfied=True,
+        productive_session_execution_permitted=True,
+        authorization_may_proceed=True,
+        lock_may_proceed=True,
+        network_may_proceed=True,
+        session_start_may_proceed=True,
+    )

--- a/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/models_v1.py
+++ b/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/models_v1.py
@@ -1,0 +1,77 @@
+"""Typed models for Phase 9.2 productive restart/recovery Session-GO authority."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class SessionGoAuthorityV1:
+    schema_version: str
+    capability_id: str
+    session_go_id: str
+    session_id: str
+    expected_repository_sha: str
+    expected_config_digest: str
+    entrypoint_id: str
+    entrypoint_path: str
+    public_md_only: bool
+    http_get_only: bool
+    max_session_duration_seconds: int
+    restart_recovery_scope: str
+    issued_at: float
+    not_before: float
+    expires_at: float
+    activation_status: str
+    owner_go_required: bool
+    owner_session_go_required: bool
+    single_use_authorization_required: bool
+    confirm_token_required: bool
+    network_session_execution_authorized_by_this_go: bool
+    fixture_non_authoritative: bool = False
+    session_go_digest: str = ""
+    notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["notes"] = list(self.notes)
+        return payload
+
+
+@dataclass
+class SessionGoGateResultV1:
+    ok: bool
+    blockers: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    authority: Optional[SessionGoAuthorityV1] = None
+    session_go_authority_satisfied: bool = False
+    productive_session_execution_permitted: bool = False
+    authorization_may_proceed: bool = False
+    lock_may_proceed: bool = False
+    network_may_proceed: bool = False
+    session_start_may_proceed: bool = False
+    authorization_consumed: bool = False
+    session_lock_acquired: bool = False
+    session_started: bool = False
+    network_request_count: int = 0
+    side_effects_occurred: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "blockers": list(self.blockers),
+            "notes": list(self.notes),
+            "authority": None if self.authority is None else self.authority.to_dict(),
+            "session_go_authority_satisfied": self.session_go_authority_satisfied,
+            "productive_session_execution_permitted": self.productive_session_execution_permitted,
+            "authorization_may_proceed": self.authorization_may_proceed,
+            "lock_may_proceed": self.lock_may_proceed,
+            "network_may_proceed": self.network_may_proceed,
+            "session_start_may_proceed": self.session_start_may_proceed,
+            "authorization_consumed": self.authorization_consumed,
+            "session_lock_acquired": self.session_lock_acquired,
+            "session_started": self.session_started,
+            "network_request_count": self.network_request_count,
+            "side_effects_occurred": self.side_effects_occurred,
+        }

--- a/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/parity_v1.py
+++ b/src/ops/phase_9_2_productive_restart_recovery_session_go_capability_v1/parity_v1.py
@@ -1,0 +1,57 @@
+"""Parity proof for Session-GO capability (no trading-core mutation)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.constants_v1 import (
+    BULL_BEAR_CHANGE,
+    CONFIRMATION_SEMANTICS_CHANGE,
+    CORE_LOGIC_CHANGE,
+    DOUBLE_PLAY_CHANGE,
+    DYNAMIC_SCOPE_LOGIC_CHANGE,
+    MASTER_V2_CHANGE,
+    RISK_CHANGE,
+    SAFETY_CHANGE,
+)
+from src.ops.phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.parity_v1 import (
+    prove_phase92_productive_entrypoint_parity_v1,
+)
+
+
+def prove_phase92_session_go_parity_v1() -> dict[str, Any]:
+    """Reuse entrypoint parity surface; Session-GO must not alter trading core."""
+    base = prove_phase92_productive_entrypoint_parity_v1()
+    claims = {
+        "GOLDEN_VECTOR_PARITY_PASS": bool(base.get("GOLDEN_VECTOR_PARITY_PASS")),
+        "CALL_ORDER_PARITY_PROVEN": bool(base.get("CALL_ORDER_PARITY_PROVEN")),
+        "INPUT_OUTPUT_PARITY_PROVEN": bool(base.get("INPUT_OUTPUT_PARITY_PROVEN")),
+        "STATE_TRANSITION_PARITY_PROVEN": bool(base.get("STATE_TRANSITION_PARITY_PROVEN")),
+        "DECISION_REASON_PARITY_PROVEN": bool(base.get("DECISION_REASON_PARITY_PROVEN")),
+        "RISK_PARITY_PROVEN": bool(base.get("RISK_PARITY_PROVEN")),
+        "SAFETY_PARITY_PROVEN": bool(base.get("SAFETY_PARITY_PROVEN")),
+        "EXIT_PRECEDENCE_PARITY_PROVEN": bool(base.get("EXIT_PRECEDENCE_PARITY_PROVEN")),
+        "CORE_LOGIC_CHANGE": CORE_LOGIC_CHANGE,
+        "CORE_LOGIC_CHANGED": CORE_LOGIC_CHANGE,
+        "MASTER_V2_CHANGED": MASTER_V2_CHANGE,
+        "DOUBLE_PLAY_CHANGED": DOUBLE_PLAY_CHANGE,
+        "BULL_BEAR_CHANGED": BULL_BEAR_CHANGE,
+        "DYNAMIC_SCOPE_CHANGED": DYNAMIC_SCOPE_LOGIC_CHANGE,
+        "CONFIRMATION_SEMANTICS_CHANGED": CONFIRMATION_SEMANTICS_CHANGE,
+        "RISK_CHANGED": RISK_CHANGE,
+        "SAFETY_CHANGED": SAFETY_CHANGE,
+        "phase92_entrypoint_parity_reused": True,
+    }
+    ok = bool(base.get("ok")) and not any(
+        (
+            CORE_LOGIC_CHANGE,
+            MASTER_V2_CHANGE,
+            DOUBLE_PLAY_CHANGE,
+            BULL_BEAR_CHANGE,
+            DYNAMIC_SCOPE_LOGIC_CHANGE,
+            CONFIRMATION_SEMANTICS_CHANGE,
+            RISK_CHANGE,
+            SAFETY_CHANGE,
+        )
+    )
+    return {"ok": ok, **claims}

--- a/tests/ops/test_phase_9_2_productive_restart_recovery_session_go_capability_v1.py
+++ b/tests/ops/test_phase_9_2_productive_restart_recovery_session_go_capability_v1.py
@@ -1,0 +1,440 @@
+"""Tests for PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.ops.phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.constants_v1 import (
+    PRODUCTIVE_NETWORK_SESSION_EXECUTION_ALLOWED,
+    TARGET_SESSION_ID as ENTRYPOINT_SESSION_ID,
+)
+from src.ops.phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.orchestrator_v1 import (
+    evaluate_productive_session_start_gates_v1,
+    reject_productive_session_start_v1,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.constants_v1 import (
+    ACTIVATION_STATUS_ACTIVE,
+    ACTIVATION_STATUS_INACTIVE,
+    ACTIVATION_STATUS_REVOKED,
+    CAPABILITY_ID,
+    TARGET_ENTRYPOINT_ID,
+    TARGET_ENTRYPOINT_PATH,
+    TARGET_SESSION_ID,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.contract_v1 import (
+    SessionGoContractError,
+    build_session_go_authority_v1,
+    parse_session_go_authority_v1,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.digest_v1 import (
+    write_json_atomic_v1,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.gate_v1 import (
+    evaluate_session_go_gate_v1,
+)
+from src.ops.phase_9_2_productive_restart_recovery_session_go_capability_v1.parity_v1 import (
+    prove_phase92_session_go_parity_v1,
+)
+from src.ops.single_future_stateful_no_order_runtime_activation_v1.config_v1 import (
+    load_activation_config_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI = (
+    REPO_ROOT / "scripts/ops/run_phase_9_2_productive_restart_recovery_session_go_capability_v1.py"
+)
+ENTRYPOINT_CLI = (
+    REPO_ROOT
+    / "scripts/ops/run_phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.py"
+)
+NOW = 1_700_000_000.0
+SHA = "0cc5c91583733e37ccc2f4b3ad8696ec76b0c5d5"
+
+
+def _cfg() -> str:
+    return str(
+        load_activation_config_v1(
+            config_path=REPO_ROOT
+            / "config/runtime/single_future_stateful_no_order_runtime_activation_v1.json"
+        ).config_digest
+    )
+
+
+def _active_go(**overrides):
+    payload = build_session_go_authority_v1(
+        session_go_id="sgo_test_active_v1",
+        expected_repository_sha=overrides.pop("expected_repository_sha", SHA),
+        expected_config_digest=overrides.pop("expected_config_digest", _cfg()),
+        issued_at=overrides.pop("issued_at", NOW - 10),
+        not_before=overrides.pop("not_before", NOW - 5),
+        expires_at=overrides.pop("expires_at", NOW + 3600),
+        activation_status=overrides.pop("activation_status", ACTIVATION_STATUS_ACTIVE),
+        session_id=overrides.pop("session_id", TARGET_SESSION_ID),
+        entrypoint_id=overrides.pop("entrypoint_id", TARGET_ENTRYPOINT_ID),
+        entrypoint_path=overrides.pop("entrypoint_path", TARGET_ENTRYPOINT_PATH),
+        network_session_execution_authorized_by_this_go=overrides.pop(
+            "network_session_execution_authorized_by_this_go", True
+        ),
+        fixture_non_authoritative=overrides.pop("fixture_non_authoritative", False),
+    ).to_dict()
+    if overrides:
+        payload.update(overrides)
+        payload["session_go_digest"] = ""
+        return parse_session_go_authority_v1(payload)
+    return parse_session_go_authority_v1(payload)
+
+
+def test_01_capability_constants_and_preflight() -> None:
+    assert CAPABILITY_ID.endswith("SESSION_GO_CAPABILITY_V1")
+    assert TARGET_SESSION_ID == ENTRYPOINT_SESSION_ID
+    assert PRODUCTIVE_NETWORK_SESSION_EXECUTION_ALLOWED is False
+    proc = subprocess.run(
+        [sys.executable, str(CLI), "preflight"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["ok"] is True
+    assert payload["session_started"] is False
+    assert payload["authorization_consumed"] is False
+    assert payload["network_request_count"] == 0
+
+
+def test_02_schema_parse_and_digest() -> None:
+    auth = _active_go()
+    assert auth.session_go_digest
+    assert len(auth.session_go_digest) == 64
+    assert auth.entrypoint_path == TARGET_ENTRYPOINT_PATH
+    assert auth.entrypoint_id == TARGET_ENTRYPOINT_ID
+
+
+def test_03_missing_session_go_fails_closed() -> None:
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha=SHA,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=True,
+    )
+    assert result.ok is False
+    assert "SESSION_GO_MISSING" in result.blockers
+    assert result.session_started is False
+    assert result.authorization_consumed is False
+    assert result.network_request_count == 0
+    assert result.side_effects_occurred is False
+
+
+def test_04_inactive_session_go_fails_closed() -> None:
+    auth = _active_go(activation_status=ACTIVATION_STATUS_INACTIVE)
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha=SHA,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=True,
+        session_go_payload=auth,
+        authorization_present=True,
+        confirm_token_present=True,
+    )
+    assert result.ok is False
+    assert "SESSION_GO_INACTIVE" in result.blockers
+
+
+def test_05_expired_session_go_fails_closed() -> None:
+    auth = _active_go(expires_at=NOW - 1)
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha=SHA,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=True,
+        session_go_payload=auth,
+        authorization_present=True,
+        confirm_token_present=True,
+    )
+    assert result.ok is False
+    assert "SESSION_GO_EXPIRED" in result.blockers
+
+
+def test_06_revoked_session_go_fails_closed() -> None:
+    auth = _active_go(activation_status=ACTIVATION_STATUS_REVOKED)
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha=SHA,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=True,
+        session_go_payload=auth,
+        authorization_present=True,
+        confirm_token_present=True,
+    )
+    assert result.ok is False
+    assert "SESSION_GO_REVOKED" in result.blockers
+
+
+def test_07_sha_mismatch_fails_closed() -> None:
+    auth = _active_go()
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha="deadbeef" * 5,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=True,
+        session_go_payload=auth,
+        authorization_present=True,
+        confirm_token_present=True,
+    )
+    assert result.ok is False
+    assert "SESSION_GO_REPOSITORY_SHA_MISMATCH" in result.blockers
+
+
+def test_08_config_digest_mismatch_fails_closed() -> None:
+    auth = _active_go()
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha=SHA,
+        expected_config_digest="0" * 64,
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=True,
+        session_go_payload=auth,
+        authorization_present=True,
+        confirm_token_present=True,
+    )
+    assert result.ok is False
+    assert "SESSION_GO_CONFIG_DIGEST_MISMATCH" in result.blockers
+
+
+def test_09_session_id_mismatch_fails_closed() -> None:
+    auth = _active_go(session_id="wrong_session")
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha=SHA,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=True,
+        session_go_payload=auth,
+        authorization_present=True,
+        confirm_token_present=True,
+    )
+    assert result.ok is False
+    assert "SESSION_GO_SESSION_ID_MISMATCH" in result.blockers
+
+
+def test_10_entrypoint_mismatch_fails_closed() -> None:
+    auth = _active_go(entrypoint_path="scripts/ops/not_the_entrypoint.py")
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha=SHA,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=True,
+        session_go_payload=auth,
+        authorization_present=True,
+        confirm_token_present=True,
+    )
+    assert result.ok is False
+    assert "SESSION_GO_ENTRYPOINT_PATH_MISMATCH" in result.blockers
+
+
+def test_11_owner_go_without_session_go_fails_closed() -> None:
+    auth = _active_go()
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha=SHA,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=False,
+        session_go_payload=auth,
+        authorization_present=True,
+        confirm_token_present=True,
+    )
+    assert result.ok is False
+    assert "OWNER_SESSION_GO_REQUIRED" in result.blockers
+
+
+def test_12_session_go_without_authorization_fails_closed() -> None:
+    auth = _active_go()
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha=SHA,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=True,
+        session_go_payload=auth,
+        authorization_present=False,
+        confirm_token_present=True,
+    )
+    assert result.ok is False
+    assert result.session_go_authority_satisfied is True
+    assert "SESSION_GO_VALID_BUT_AUTHORIZATION_REQUIRED" in result.blockers
+    assert result.authorization_consumed is False
+    assert result.session_lock_acquired is False
+    assert result.session_started is False
+    assert result.network_request_count == 0
+
+
+def test_13_full_unlock_permits_without_side_effects() -> None:
+    auth = _active_go()
+    result = evaluate_session_go_gate_v1(
+        expected_repository_sha=SHA,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=True,
+        session_go_payload=auth,
+        authorization_present=True,
+        confirm_token_present=True,
+    )
+    assert result.ok is True
+    assert result.productive_session_execution_permitted is True
+    assert result.authorization_may_proceed is True
+    assert result.lock_may_proceed is True
+    assert result.network_may_proceed is True
+    assert result.session_start_may_proceed is True
+    assert result.authorization_consumed is False
+    assert result.session_lock_acquired is False
+    assert result.session_started is False
+    assert result.network_request_count == 0
+    assert result.side_effects_occurred is False
+
+
+def test_14_entrypoint_consumer_missing_session_go() -> None:
+    gate = evaluate_productive_session_start_gates_v1(
+        expected_repository_sha=SHA,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=True,
+        use_real_network=True,
+        environ={},
+    )
+    assert gate["ok"] is False
+    assert "SESSION_GO_MISSING" in gate["blockers"]
+    assert gate["session_started"] is False
+    assert gate["authorization_consumed"] is False
+    assert gate["network_request_count"] == 0
+
+
+def test_15_entrypoint_consumer_owner_go_alone_insufficient(tmp_path: Path) -> None:
+    auth = _active_go()
+    path = tmp_path / "session_go.json"
+    write_json_atomic_v1(path, auth.to_dict())
+    gate = reject_productive_session_start_v1(
+        use_real_network=True,
+        environ={},
+        expected_repository_sha=SHA,
+        expected_config_digest=_cfg(),
+        now_unix=NOW,
+        owner_go=True,
+        owner_session_go=False,
+        session_go_path=path,
+        authorization_present=True,
+        confirm_token_present=True,
+    )
+    assert gate["ok"] is False
+    assert "OWNER_SESSION_GO_REQUIRED" in gate["blockers"]
+    assert gate["session_started"] is False
+
+
+def test_16_entrypoint_cli_fail_closed_without_session_go() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(ENTRYPOINT_CLI), "productive-session", "--real-network"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+    payload = json.loads(proc.stdout)
+    assert payload["ok"] is False
+    assert payload["network_session_started"] is False
+    assert payload["session_started"] is False
+    assert payload["authorization_consumed"] is False
+    assert payload["network_request_count"] == 0
+
+
+def test_17_entrypoint_cli_unlock_evaluation_no_side_effects(tmp_path: Path) -> None:
+    import time
+
+    now = float(time.time())
+    auth = _active_go(
+        expected_repository_sha=_live_sha(),
+        issued_at=now - 10,
+        not_before=now - 5,
+        expires_at=now + 3600,
+    )
+    path = tmp_path / "session_go.json"
+    write_json_atomic_v1(path, auth.to_dict())
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ENTRYPOINT_CLI),
+            "productive-session",
+            "--session-go-file",
+            str(path),
+            "--owner-go",
+            "--owner-session-go",
+            "--authorization-present",
+            "--confirm-token-present",
+        ],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["productive_session_execution_permitted"] is True
+    assert payload["session_started"] is False
+    assert payload["authorization_consumed"] is False
+    assert payload["network_request_count"] == 0
+    assert payload["network_session_started"] is False
+
+
+def _live_sha() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=str(REPO_ROOT), text=True
+    ).strip()
+
+
+def test_18_parity() -> None:
+    parity = prove_phase92_session_go_parity_v1()
+    assert parity["ok"] is True
+    assert parity["GOLDEN_VECTOR_PARITY_PASS"] is True
+    assert parity["CALL_ORDER_PARITY_PROVEN"] is True
+    assert parity["INPUT_OUTPUT_PARITY_PROVEN"] is True
+    assert parity["RISK_PARITY_PROVEN"] is True
+    assert parity["SAFETY_PARITY_PROVEN"] is True
+    assert parity["EXIT_PRECEDENCE_PARITY_PROVEN"] is True
+    assert parity["CORE_LOGIC_CHANGED"] is False
+
+
+def test_19_permanent_enable_flag_remains_false() -> None:
+    cfg = json.loads(
+        (
+            REPO_ROOT
+            / "config/ops/phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert cfg["productive_network_session_execution_authorized"] is False
+    assert cfg["session_go_authority_capability_id"] == CAPABILITY_ID
+    assert PRODUCTIVE_NETWORK_SESSION_EXECUTION_ALLOWED is False
+
+
+def test_20_public_md_only_required() -> None:
+    with pytest.raises(SessionGoContractError, match="PUBLIC_MD_ONLY"):
+        parse_session_go_authority_v1(
+            {
+                **_active_go().to_dict(),
+                "public_md_only": False,
+                "session_go_digest": "",
+            }
+        )


### PR DESCRIPTION
## Summary
- Adds `PHASE_9_2_PRODUCTIVE_RESTART_RECOVERY_SESSION_GO_CAPABILITY_V1` as a bound Session-GO authority surface (SHA/config/session/entrypoint/expiry/activation).
- Wires the existing productive restart network entrypoint to evaluate Session-GO fail-closed before auth/lock/network/session; keeps `productive_network_session_execution_authorized=false` permanently unscoped.
- Does not issue/consume authorization, start a session, open network, or mutate trading core logic.

## Test plan
- [x] `pytest tests/ops/test_phase_9_2_productive_restart_recovery_session_go_capability_v1.py`
- [x] `pytest tests/ops/test_phase_9_2_productive_public_md_restart_recovery_network_entrypoint_v1.py`
- [x] PR-bounded selector targets (729 passed)
- [x] `ruff format --check` / `ruff check` on changed paths
- [x] docs reference targets + docs token preflight


Made with [Cursor](https://cursor.com)