### PR TITLE
feat(dashboard): serve supervised graphical market landscape

### DIFF
--- a/src/ops/canonical_local_launcher_and_process_supervision_v1/dashboard_http_host_v1.py
+++ b/src/ops/canonical_local_launcher_and_process_supervision_v1/dashboard_http_host_v1.py
@@ -1,18 +1,22 @@
 """O2 dashboard-only FastAPI HTTP host (loopback, read-only, O5-bound).
 
 Serves GET /market, GET /api/market/landscape/ohlcv, and GET /health from the
-durable O5 derived read model. Never fetches exchange candles or mutates trading
-state. Authority effect remains NONE.
+durable O5 derived read model. Additionally serves presentation-only
+GET /landscape (text/html) plus static assets. Never fetches exchange candles
+or mutates trading state. Authority effect remains NONE.
 """
 
 from __future__ import annotations
 
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from src.ops.canonical_read_model_and_market_dashboard_rebuild_v1.connection_state_v1 import (
     assert_no_healthy_render_for_cached_bad_state_v1,
@@ -41,6 +45,14 @@ from src.ops.canonical_read_model_and_market_dashboard_rebuild_v1.read_model_v1 
 
 
 LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+# Fixed non-authoritative SSR stamp — never wall-clock; never persists.
+_LANDSCAPE_BOOTSTRAP_STAMP = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _repository_root_v1() -> Path:
+    """Repo root from this module path (…/src/ops/<pkg>/<file>)."""
+    return Path(__file__).resolve().parents[3]
 
 
 def _load_or_missing(state_root: Path) -> dict[str, Any]:
@@ -78,6 +90,39 @@ def _stamp_http_observation(read_model: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def render_supervised_landscape_html_v1(*, session_id: str) -> str:
+    """Render presentation-only Landscape HTML with empty/non-authoritative bootstrap.
+
+    Does not mutate JSON APIs, durable state, producers, or trading authority.
+    Unavailable rails remain NOT_BOUND until the browser binds canonical JSON.
+    """
+    from src.webui.market_dashboard_landscape_v2 import (
+        MarketDashboardReadServiceV1,
+        present_market_landscape_v2,
+    )
+
+    page = MarketDashboardReadServiceV1().load_page_snapshot(
+        generated_at=_LANDSCAPE_BOOTSTRAP_STAMP
+    )
+    context = present_market_landscape_v2(page)
+    # Presentation-only overlays — never authoritative, never persisted.
+    # Use bare URL paths (constants include a "GET " prefix for contracts).
+    context["supervised_presentation_only"] = True
+    context["canonical_market_path"] = "/market"
+    context["canonical_ohlcv_path"] = "/api/market/landscape/ohlcv"
+    context["bootstrap_session_id"] = session_id
+    context["bootstrap_repository_sha"] = ""
+    context["non_authoritative_bootstrap"] = True
+
+    repo = _repository_root_v1()
+    env = Environment(
+        loader=FileSystemLoader(str(repo / "templates" / "peak_trade_dashboard")),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+    template = env.get_template("market_landscape_v2.html")
+    return template.render(status={"project": "Peak_Trade"}, **context)
+
+
 def create_o2_dashboard_http_app_v1(*, state_root: Path, session_id: str) -> FastAPI:
     """Build the supervised read-only FastAPI app bound to durable O5 state."""
     state_root = Path(state_root)
@@ -91,6 +136,10 @@ def create_o2_dashboard_http_app_v1(*, state_root: Path, session_id: str) -> Fas
     app.state.o2_session_id = session_id
     app.state.dashboard_authority_effect = READ_MODEL_AUTHORITY_EFFECT
     app.state.read_model_classification = READ_MODEL_CLASSIFICATION
+
+    static_root = _repository_root_v1() / "static"
+    if static_root.is_dir():
+        app.mount("/static", StaticFiles(directory=str(static_root)), name="static")
 
     @app.middleware("http")
     async def _loopback_only(request: Request, call_next):  # type: ignore[no-untyped-def]
@@ -194,6 +243,20 @@ def create_o2_dashboard_http_app_v1(*, state_root: Path, session_id: str) -> Fas
                 "independent_authoritative_recompute": False,
                 "parallel_ohlcv_producer": False,
             }
+        )
+
+    @app.get("/landscape", response_class=HTMLResponse)
+    async def landscape() -> HTMLResponse:
+        """Owner graphical Market Landscape — presentation only, authority NONE."""
+        html = render_supervised_landscape_html_v1(session_id=session_id)
+        return HTMLResponse(
+            content=html,
+            media_type="text/html",
+            headers={
+                "Cache-Control": "no-store",
+                "X-Peak-Trade-Dashboard-Authority": "NONE",
+                "X-Peak-Trade-Trading-Authority": "false",
+            },
         )
 
     return app

--- a/static/css/market_dashboard_landscape_v2.css
+++ b/static/css/market_dashboard_landscape_v2.css
@@ -771,3 +771,13 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Supervised presentation: fail-visible when canonical data is unavailable */
+.mdl-v2[data-mdl-canonical-fail="true"] .mdl-v2-chart__message {
+  color: #fca5a5;
+  font-weight: 600;
+}
+
+.mdl-v2[data-mdl-canonical-fail="true"] [data-mdl-data-connection-state] {
+  color: #fca5a5;
+}

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -2,7 +2,11 @@
  * Market Dashboard Landscape V2 — presentation-only client helpers.
  * No fetch mutation, no decision/risk/sizing logic, no write endpoints.
  * Renders materialized OHLCV from SSR/poll JSON only (never fabricates candles).
- * Polls local /api/market/landscape/ohlcv only; never calls OKX.
+ * Consumes only local GET /market and GET /api/market/landscape/ohlcv;
+ * never calls OKX or any browser-direct network venue.
+ *
+ * Canonical OHLCV accepted from body.ohlcv and/or body.read_model (and legacy
+ * body.browser_payload when present). Candle close is never used as live mark.
  *
  * Update classification:
  *   NO_CHANGE | METADATA_ONLY | MARK_ONLY | SAME_TIMESTAMP_LAST_CANDLE_CHANGE
@@ -69,6 +73,195 @@
     root.setAttribute("data-mdl-ohlcv-update-class", kind);
   }
 
+  function failVisible(reason) {
+    root.setAttribute("data-mdl-canonical-fail", "true");
+    root.setAttribute("data-mdl-canonical-fail-reason", String(reason || "canonical_unavailable"));
+    setConnectionState("MISSING_SOURCE");
+    var message = root.querySelector("[data-mdl-chart-message]");
+    if (message) {
+      message.textContent = "CANONICAL_DATA_UNAVAILABLE: " + String(reason || "unknown");
+    }
+  }
+
+  function clearFailVisible() {
+    root.removeAttribute("data-mdl-canonical-fail");
+    root.removeAttribute("data-mdl-canonical-fail-reason");
+  }
+
+  function clientDigest(text) {
+    // Client-only FNV-1a 32-bit digest for update classification — not authority.
+    var h = 2166136261;
+    var i;
+    for (i = 0; i < text.length; i += 1) {
+      h ^= text.charCodeAt(i);
+      h = Math.imul(h, 16777619);
+    }
+    return ("00000000" + (h >>> 0).toString(16)).slice(-8);
+  }
+
+  function finiteBarNumber(raw) {
+    if (raw === undefined || raw === null || raw === "") return null;
+    var n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  function normalizeCanonicalBars(rawBars) {
+    if (!Array.isArray(rawBars) || !rawBars.length) return null;
+    var bars = [];
+    var i;
+    for (i = 0; i < rawBars.length; i += 1) {
+      var row = rawBars[i];
+      if (!row || typeof row !== "object") return null;
+      var ts = row.ts;
+      if (typeof ts !== "string" || !ts.trim()) return null;
+      var openV = finiteBarNumber(row.open);
+      var highV = finiteBarNumber(row.high);
+      var lowV = finiteBarNumber(row.low);
+      var closeV = finiteBarNumber(row.close);
+      var volumeV = finiteBarNumber(row.volume);
+      if (openV === null || highV === null || lowV === null || closeV === null || volumeV === null) {
+        return null;
+      }
+      var confirmRaw = row.confirm;
+      var confirm =
+        confirmRaw === undefined || confirmRaw === null
+          ? true
+          : typeof confirmRaw === "boolean"
+            ? confirmRaw
+            : String(confirmRaw) === "1" || String(confirmRaw) === "true";
+      bars.push({
+        ts: ts.trim(),
+        open: openV,
+        high: highV,
+        low: lowV,
+        close: closeV,
+        volume: volumeV,
+        display_close: closeV,
+        display_high: highV,
+        display_low: lowV,
+        confirm: confirm,
+        provisional: !confirm,
+      });
+    }
+    return bars;
+  }
+
+  function pickCanonicalOhlcvSource(body) {
+    if (!body || typeof body !== "object") return null;
+    if (
+      body.browser_payload &&
+      Array.isArray(body.browser_payload.bars) &&
+      body.browser_payload.bars.length
+    ) {
+      return { kind: "browser_payload", source: body.browser_payload };
+    }
+    if (body.ohlcv && Array.isArray(body.ohlcv.bars) && body.ohlcv.bars.length) {
+      return { kind: "ohlcv", source: body.ohlcv };
+    }
+    if (body.read_model && Array.isArray(body.read_model.bars) && body.read_model.bars.length) {
+      return { kind: "read_model", source: body.read_model };
+    }
+    var proj = body.read_model && body.read_model.ohlcv_projection;
+    if (proj && Array.isArray(proj.bars) && proj.bars.length) {
+      return { kind: "ohlcv_projection", source: proj };
+    }
+    return null;
+  }
+
+  function buildClientPayloadFromCanonical(source, body, kind) {
+    // Prefer already-normalized browser_payload bars/digests when present.
+    if (kind === "browser_payload") {
+      var legacy = Object.assign({}, source);
+      // Never invent live mark from candle close.
+      if (legacy.live_mark_price === undefined) {
+        legacy.live_mark_price = null;
+      }
+      if (!legacy.first_timestamp && Array.isArray(legacy.bars) && legacy.bars.length) {
+        legacy.first_timestamp = legacy.bars[0].ts;
+      }
+      if (!legacy.last_timestamp && Array.isArray(legacy.bars) && legacy.bars.length) {
+        legacy.last_timestamp = legacy.bars[legacy.bars.length - 1].ts;
+      }
+      return legacy;
+    }
+    var bars = normalizeCanonicalBars(source.bars);
+    if (!bars) return null;
+    var rm = (body && body.read_model) || {};
+    var seriesKey = bars
+      .map(function (b) {
+        return [b.ts, b.open, b.high, b.low, b.close, b.volume, b.confirm ? 1 : 0].join(",");
+      })
+      .join("|");
+    var markRaw =
+      source.live_mark_price !== undefined && source.live_mark_price !== null
+        ? source.live_mark_price
+        : rm.live_mark_price !== undefined && rm.live_mark_price !== null
+          ? rm.live_mark_price
+          : null;
+    // Explicit: never substitute candle close for live mark price.
+    var liveMark = finiteBarNumber(markRaw);
+    var metaKey = [
+      source.captured_at || rm.captured_at || "",
+      source.candle_captured_at || "",
+      source.freshness_state || rm.freshness_state || "",
+      String(liveMark === null ? "" : liveMark),
+      body && body.repository_sha ? body.repository_sha : rm.repository_sha || "",
+    ].join("|");
+    return {
+      schema_name: "market_landscape_ohlcv_browser_payload.v1",
+      schema_version: 1,
+      instrument_id:
+        source.instrument_id || rm.instrument_id || rm.instrument || null,
+      venue: source.venue || rm.venue || null,
+      interval: source.interval || rm.interval || null,
+      bar_count: bars.length,
+      bars: bars,
+      first_timestamp: bars[0].ts,
+      last_timestamp: bars[bars.length - 1].ts,
+      captured_at: source.captured_at || rm.captured_at || null,
+      candle_captured_at:
+        source.candle_captured_at || source.captured_at || rm.captured_at || null,
+      freshness_state: source.freshness_state || rm.freshness_state || null,
+      is_stale: Boolean(source.is_stale || rm.is_stale),
+      live_mark_price: liveMark,
+      candle_series_digest: clientDigest(seriesKey),
+      metadata_digest: clientDigest(metaKey),
+      chart_digest: clientDigest(seriesKey),
+      canonical_source_kind: kind,
+      non_authoritative_client_derivation: true,
+    };
+  }
+
+  function extractCanonicalOhlcvPayload(body) {
+    var picked = pickCanonicalOhlcvSource(body);
+    if (!picked) return null;
+    return buildClientPayloadFromCanonical(picked.source, body, picked.kind);
+  }
+
+  function bindCanonicalIdentityFromMarket(body) {
+    if (!body || typeof body !== "object") return false;
+    var rm = body.read_model || {};
+    var sessionId = body.session_id || "";
+    var repoSha = rm.repository_sha || body.repository_sha || "";
+    var instrument = rm.instrument_id || rm.instrument || "";
+    var venue = rm.venue || "";
+    var connectionState = body.connection_state || rm.connection_state || "";
+    root.setAttribute("data-session-id", String(sessionId || ""));
+    root.setAttribute("data-repository-sha", String(repoSha || ""));
+    var sessionNode = root.querySelector('[data-mdl-field="session_id"]');
+    if (sessionNode) sessionNode.textContent = sessionId || "—";
+    var shaNode = root.querySelector('[data-mdl-field="repository_sha"]');
+    if (shaNode) shaNode.textContent = repoSha || "—";
+    var instrumentNode = root.querySelector('[data-mdl-field="instrument"]');
+    if (instrumentNode && instrument) instrumentNode.textContent = String(instrument);
+    var selectedNode = root.querySelector('[data-mdl-field="selected_instrument"]');
+    if (selectedNode && instrument) selectedNode.textContent = String(instrument);
+    var venueNode = root.querySelector('[data-mdl-field="venue"]');
+    if (venueNode && venue) venueNode.textContent = String(venue);
+    if (connectionState) setConnectionState(String(connectionState));
+    return true;
+  }
+
   function formatMetaNumber(value) {
     if (value === undefined || value === null || value === "") return "—";
     var n = Number(value);
@@ -106,8 +299,11 @@
         (payload && (payload.candle_captured_at || payload.captured_at)) || "—";
     }
     if (markNode) {
+      // Absent optional mark → em dash. Never substitute candle close.
       var mark =
-        payload && payload.live_mark_price !== undefined && payload.live_mark_price !== null
+        payload &&
+        payload.live_mark_price !== undefined &&
+        payload.live_mark_price !== null
           ? String(payload.live_mark_price)
           : "—";
       markNode.textContent = mark;
@@ -560,13 +756,22 @@
       }
     }
     if (connectionState === "LIVE_DATA") connectionState = "HEALTHY";
-    var payload = body.browser_payload;
-    if (!payload || !payload.bars) {
+    var payload = extractCanonicalOhlcvPayload(body);
+    if (!payload || !payload.bars || !payload.bars.length) {
       updateMetaFromPayload(body, availability, connectionState);
-      if (availability === "MISSING_SOURCE") setConnectionState("MISSING_SOURCE");
-      else setConnectionState(connectionState);
+      if (
+        availability === "MISSING_SOURCE" ||
+        connectionState === "MISSING_SOURCE" ||
+        connectionState === "DISCONNECTED"
+      ) {
+        failVisible(connectionState || availability || "ohlcv_unavailable");
+        setConnectionState(connectionState || "MISSING_SOURCE");
+      } else {
+        setConnectionState(connectionState);
+      }
       return;
     }
+    clearFailVisible();
 
     var seriesDigest = payload.candle_series_digest || payload.chart_digest || "";
     var metaDigest = payload.metadata_digest || "";
@@ -629,11 +834,15 @@
   function startOhlcvPolling() {
     var chart = root.querySelector("[data-mdl-chart]");
     if (!chart) return;
-    var pollPath = chart.getAttribute("data-mdl-ohlcv-poll-path") || "";
+    var pollPath =
+      chart.getAttribute("data-mdl-ohlcv-poll-path") ||
+      root.getAttribute("data-canonical-ohlcv-path") ||
+      "";
     var baseIntervalSeconds = Number(
       chart.getAttribute("data-mdl-ohlcv-poll-interval-seconds") || "0"
     );
     if (!pollPath || !(baseIntervalSeconds > 0)) return;
+    // Only local canonical market API paths — never browser-direct OKX/network.
     if (pollPath.indexOf("/api/market/") !== 0) return;
 
     var inFlight = false;
@@ -704,9 +913,12 @@
             "data-mdl-ohlcv-poll-backoff-seconds",
             String(backoffSeconds)
           );
-          setConnectionState(
-            failStreak >= STALE_AFTER_FAILURES ? "DISCONNECTED" : "DEGRADED"
-          );
+          if (failStreak >= STALE_AFTER_FAILURES) {
+            failVisible(String((err && err.message) || "poll_failed"));
+            setConnectionState("DISCONNECTED");
+          } else {
+            setConnectionState("DEGRADED");
+          }
         })
         .then(function () {
           inFlight = false;
@@ -724,6 +936,76 @@
           : "HEALTHY"
     );
     scheduleNext();
+  }
+
+  function bootstrapFromCanonicalMarket() {
+    var marketPath = root.getAttribute("data-canonical-market-path") || "/market";
+    if (marketPath !== "/market") {
+      failVisible("forbidden_noncanonical_market_path");
+      return Promise.resolve(false);
+    }
+    return fetch(marketPath, {
+      method: "GET",
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+    })
+      .then(function (response) {
+        if (!response.ok) throw new Error("market_http_" + response.status);
+        return response.json();
+      })
+      .then(function (body) {
+        if (!body || typeof body !== "object") {
+          throw new Error("market_invalid_body");
+        }
+        if (body.direct_browser_okx) {
+          throw new Error("market_forbidden_direct_okx");
+        }
+        if (body.trading_authority || body.orders) {
+          throw new Error("market_forbidden_trading_authority");
+        }
+        bindCanonicalIdentityFromMarket(body);
+        var rm = body.read_model || {};
+        var bars =
+          (rm.bars && rm.bars.length && rm.bars) ||
+          (rm.ohlcv_projection && rm.ohlcv_projection.bars) ||
+          null;
+        if (bars && bars.length) {
+          applyPollPayload({
+            availability: body.connection_state || rm.connection_state || "",
+            connection_state: body.connection_state || rm.connection_state || "",
+            ohlcv: {
+              bars: bars,
+              bar_count: bars.length,
+              interval: rm.interval,
+              instrument_id: rm.instrument_id || rm.instrument,
+              venue: rm.venue,
+            },
+            read_model: rm,
+            repository_sha: rm.repository_sha,
+            session_id: body.session_id,
+            status: body.connection_state || "OK",
+          });
+        } else if (
+          body.connection_state === "MISSING_SOURCE" ||
+          rm.connection_state === "MISSING_SOURCE"
+        ) {
+          failVisible("MISSING_SOURCE");
+        }
+        root.setAttribute("data-mdl-canonical-market-bound", "true");
+        return true;
+      })
+      .catch(function (err) {
+        failVisible(String((err && err.message) || "market_bootstrap_failed"));
+        return false;
+      });
+  }
+
+  function bootLandscapeClient() {
+    renderOhlcvCanvas();
+    bootstrapFromCanonicalMarket().then(function () {
+      startOhlcvPolling();
+    });
   }
 
   var resizeTimer = null;
@@ -760,12 +1042,10 @@
 
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", function () {
-      renderOhlcvCanvas();
-      startOhlcvPolling();
+      bootLandscapeClient();
     });
   } else {
-    renderOhlcvCanvas();
-    startOhlcvPolling();
+    bootLandscapeClient();
   }
   window.addEventListener("resize", onViewportResize);
   if (typeof ResizeObserver === "function") {

--- a/templates/peak_trade_dashboard/market_landscape_v2.html
+++ b/templates/peak_trade_dashboard/market_landscape_v2.html
@@ -28,6 +28,12 @@
   data-runtime-bridge="{{ runtime_bridge_display }}"
   data-mdl-a11y-baseline="task7"
   data-mdl-density="task1"
+  data-canonical-market-path="{{ canonical_market_path|default('/market') }}"
+  data-canonical-ohlcv-path="{{ canonical_ohlcv_path|default('/api/market/landscape/ohlcv') }}"
+  data-supervised-presentation-only="{{ 'true' if supervised_presentation_only|default(false) else 'false' }}"
+  data-non-authoritative-bootstrap="{{ 'true' if non_authoritative_bootstrap|default(false) else 'false' }}"
+  data-session-id="{{ bootstrap_session_id|default('') }}"
+  data-repository-sha="{{ bootstrap_repository_sha|default('') }}"
 >
   <div class="mdl-v2-shell" data-mdl-outer-workspace="true">
     <header class="mdl-v2-strip" data-mdl-region="GLOBAL_SYSTEM_STRIP" aria-label="Global system strip">
@@ -39,6 +45,8 @@
         {# Strip = compact ops summary. Scope/Regime live in Context; do not alias availability as Freshness. #}
         <div><dt>Instrument</dt><dd data-mdl-field="instrument">{{ global_strip.instrument }}</dd></div>
         <div><dt>Venue</dt><dd data-mdl-field="venue">{{ global_strip.venue }}</dd></div>
+        <div><dt>Session</dt><dd data-mdl-field="session_id">{% if bootstrap_session_id %}{{ bootstrap_session_id }}{% else %}—{% endif %}</dd></div>
+        <div><dt>Repo SHA</dt><dd data-mdl-field="repository_sha">{% if bootstrap_repository_sha %}{{ bootstrap_repository_sha }}{% else %}—{% endif %}</dd></div>
         <div>
           <dt>Runtime</dt>
           <dd data-mdl-field="runtime" title="{{ shell_authority_class }}">{{ global_strip.runtime_state }}</dd>
@@ -158,8 +166,8 @@
           </dl>
           <div class="mdl-v2-chart__stage" role="img" aria-label="{{ chart.message }}" data-mdl-chart-stage="true">
             <p class="mdl-v2-chart__message" data-mdl-chart-message="true">{{ chart.message }}</p>
-            {% if chart.browser_payload %}
-            <script type="application/json" data-mdl-ohlcv-json="true">{{ chart.browser_payload | tojson }}</script>
+            {# Empty/non-authoritative bootstrap always present so JS can bind canonical OHLCV. #}
+            <script type="application/json" data-mdl-ohlcv-json="true">{% if chart.browser_payload %}{{ chart.browser_payload | tojson }}{% else %}{"schema_name":"market_landscape_ohlcv_browser_payload.v1","schema_version":1,"bars":[],"bar_count":0,"non_authoritative_bootstrap":true}{% endif %}</script>
             <canvas
               class="mdl-v2-chart__canvas"
               data-mdl-chart-canvas="true"
@@ -167,7 +175,6 @@
               data-mdl-chart-geometry="absent"
               aria-hidden="true"
             ></canvas>
-            {% endif %}
           </div>
         </div>
       </section>

--- a/tests/ops/test_supervised_graphical_market_landscape_presentation_only_playwright_v1.py
+++ b/tests/ops/test_supervised_graphical_market_landscape_presentation_only_playwright_v1.py
@@ -1,0 +1,266 @@
+"""Playwright owner-route acceptance for supervised Market Landscape presentation.
+
+Bounded browser proof against the supervised O2 host (not run_web_dashboard):
+- Owner URL is text/html
+- CSS and JS load 200
+- Root is visible
+- session_id and repository_sha match canonical JSON APIs
+- Selected future and OHLCV originate exclusively from canonical routes
+- Browser console errors are zero
+- No credentials/private/execution/order adapter is reachable
+- Orders remain zero
+- Only one supervised lane exists (this host)
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+pytest.importorskip("playwright")
+pytest.importorskip("fastapi")
+
+from playwright.sync_api import sync_playwright
+
+from src.ops.canonical_local_launcher_and_process_supervision_v1.dashboard_http_host_v1 import (
+    create_o2_dashboard_http_app_v1,
+    run_uvicorn_loopback_v1,
+)
+from src.ops.canonical_read_model_and_market_dashboard_rebuild_v1.constants_v1 import (
+    CONNECTION_HEALTHY,
+    READ_MODEL_SCHEMA_NAME,
+)
+from src.ops.canonical_read_model_and_market_dashboard_rebuild_v1.durable_read_model_store_v1 import (
+    commit_durable_read_model_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+JS_SRC = REPO / "static/js/market_dashboard_landscape_v2.js"
+HOST_SRC = (
+    REPO / "src/ops/canonical_local_launcher_and_process_supervision_v1/dashboard_http_host_v1.py"
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _healthy_read_model(*, session_id: str, repository_sha: str) -> dict[str, Any]:
+    bars = [
+        {
+            "ts": "2026-08-02T10:00:00Z",
+            "open": 2100.0,
+            "high": 2110.0,
+            "low": 2095.0,
+            "close": 2105.0,
+            "volume": 42.0,
+            "confirm": True,
+        },
+        {
+            "ts": "2026-08-02T11:00:00Z",
+            "open": 2105.0,
+            "high": 2120.0,
+            "low": 2100.0,
+            "close": 2115.5,
+            "volume": 51.0,
+            "confirm": True,
+        },
+    ]
+    return {
+        "schema_name": READ_MODEL_SCHEMA_NAME,
+        "schema_version": 1,
+        "authority_classification": "DERIVED",
+        "read_model_classification": "DERIVED",
+        "read_model_ssot": False,
+        "read_model_authority_effect": "NONE",
+        "authoritative_bar_producer": "o4",
+        "dashboard_transport": "o2_dashboard_http",
+        "selection_bundle_id": "playwright-landscape",
+        "source_session_id": session_id,
+        "repository_sha": repository_sha,
+        "config_digest": "cfg-playwright",
+        "instrument": "ETH-USDT-SWAP",
+        "instrument_id": "ETH-USDT-SWAP",
+        "interval": "PT1H",
+        "venue": "okx",
+        "last_event_time_unix": 1_700_000_200.0,
+        "last_event_time": "2023-11-14T22:16:40Z",
+        "last_projection_time_unix": 1_700_000_210.0,
+        "last_projection_time": "2023-11-14T22:16:50Z",
+        "freshness_age_seconds": 0.5,
+        "connection_state": CONNECTION_HEALTHY,
+        "is_stale": False,
+        "bar_count": len(bars),
+        "bars": bars,
+        "ohlcv_projection": {
+            "bars": bars,
+            "bar_count": len(bars),
+            "interval": "PT1H",
+            "instrument_id": "ETH-USDT-SWAP",
+            "venue": "okx",
+        },
+        "trading_authority": False,
+        "orders": False,
+        "runtime_mutation": False,
+        "risk_authority": False,
+        "write_methods": [],
+        "may_render_healthy": True,
+    }
+
+
+@pytest.fixture()
+def supervised_landscape_base_url(tmp_path: Path) -> str:
+    state_root = tmp_path / "pw_state"
+    session_id = "pw-sess-landscape"
+    repository_sha = "c" * 40
+    commit_durable_read_model_v1(
+        state_root,
+        _healthy_read_model(session_id=session_id, repository_sha=repository_sha),
+    )
+    app = create_o2_dashboard_http_app_v1(state_root=state_root, session_id=session_id)
+    port = _free_port()
+    server = run_uvicorn_loopback_v1(app=app, host="127.0.0.1", port=port)
+    thread = threading.Thread(target=server.run, name="pw-landscape-host", daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 5.0
+    last_err: Exception | None = None
+    while time.time() < deadline:
+        try:
+            with httpx.Client(base_url=base, timeout=1.0) as client:
+                assert client.get("/landscape").status_code == 200
+            break
+        except Exception as exc:  # noqa: BLE001
+            last_err = exc
+            time.sleep(0.05)
+    else:
+        server.should_exit = True
+        raise AssertionError(f"supervised host failed to start: {last_err}")
+    try:
+        yield base
+    finally:
+        server.should_exit = True
+
+
+def test_playwright_owner_route_supervised_landscape_acceptance(
+    supervised_landscape_base_url: str,
+) -> None:
+    base = supervised_landscape_base_url
+    with httpx.Client(base_url=base, timeout=2.0) as client:
+        market = client.get("/market")
+        ohlcv = client.get("/api/market/landscape/ohlcv")
+        landscape_head = client.get("/landscape")
+        css = client.get("/static/css/market_dashboard_landscape_v2.css")
+        js = client.get("/static/js/market_dashboard_landscape_v2.js")
+        # Negative reachability: no credential / order / execution adapters on this host.
+        for forbidden in (
+            "/api/orders",
+            "/execution",
+            "/credentials",
+            "/private",
+            "/api/exchange/order",
+        ):
+            assert client.get(forbidden).status_code in {404, 405, 403}
+
+    assert landscape_head.status_code == 200
+    assert "text/html" in landscape_head.headers.get("content-type", "")
+    assert css.status_code == 200
+    assert js.status_code == 200
+    market_body = market.json()
+    ohlcv_body = ohlcv.json()
+    assert market_body["orders"] is False
+    assert market_body["trading_authority"] is False
+    assert ohlcv_body["trading_authority"] is False
+    assert "browser_payload" not in ohlcv_body
+
+    # Static proof: exactly one supervised host module (no second host created).
+    host_text = HOST_SRC.read_text(encoding="utf-8")
+    assert host_text.count("def create_o2_dashboard_http_app_v1") == 1
+    assert "create_app()" not in host_text
+    js_text = JS_SRC.read_text(encoding="utf-8")
+    assert "direct_browser_okx" in js_text
+    assert "okx.com" not in js_text.lower()
+
+    console_errors: list[str] = []
+    page_errors: list[str] = []
+    requested_urls: list[str] = []
+
+    with sync_playwright() as playwright:
+        try:
+            browser = playwright.chromium.launch(headless=True)
+        except Exception:
+            browser = playwright.firefox.launch(headless=True)
+        context = browser.new_context(viewport={"width": 1440, "height": 900})
+        page = context.new_page()
+        page.on(
+            "console",
+            lambda msg: (
+                console_errors.append(f"{msg.type}:{msg.text}") if msg.type == "error" else None
+            ),
+        )
+        page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+        page.on("request", lambda req: requested_urls.append(req.url))
+
+        page.goto(f"{base}/landscape", wait_until="networkidle")
+        root = page.locator('[data-market-landscape-v2="true"]')
+        assert root.count() == 1
+        assert root.is_visible()
+        assert page.locator("h1.mdl-v2-kicker").count() == 1
+
+        # Wait for canonical market bootstrap binding.
+        page.wait_for_function(
+            """() => {
+              const root = document.querySelector('[data-market-landscape-v2="true"]');
+              return root && root.getAttribute('data-mdl-canonical-market-bound') === 'true';
+            }""",
+            timeout=5000,
+        )
+
+        session_id = root.get_attribute("data-session-id")
+        repository_sha = root.get_attribute("data-repository-sha")
+        assert session_id == market_body["session_id"]
+        assert repository_sha == market_body["read_model"]["repository_sha"]
+        assert session_id == ohlcv_body["session_id"]
+        assert repository_sha == ohlcv_body["repository_sha"]
+
+        instrument_text = page.locator('[data-mdl-field="instrument"]').inner_text()
+        selected_text = page.locator('[data-mdl-field="selected_instrument"]').inner_text()
+        expected_instrument = market_body["read_model"]["instrument_id"]
+        assert expected_instrument in instrument_text
+        assert expected_instrument in selected_text
+
+        interval_text = page.locator('[data-mdl-field="ohlcv_interval"]').inner_text()
+        assert interval_text == (ohlcv_body["ohlcv"].get("interval") or "—")
+        assert page.locator('[data-mdl-field="ohlcv_live_mark"]').inner_text() == "—"
+
+        # Selected future + OHLCV exclusively from canonical routes on this host.
+        allowed_prefixes = (
+            f"{base}/landscape",
+            f"{base}/market",
+            f"{base}/api/market/landscape/ohlcv",
+            f"{base}/static/",
+            f"{base}/favicon",
+        )
+        for url in requested_urls:
+            assert any(url.startswith(prefix) for prefix in allowed_prefixes), url
+            assert "okx.com" not in url.lower()
+            assert "/api/v5/" not in url
+            assert "credentials" not in url.lower()
+            assert "submit_order" not in url.lower()
+
+        assert console_errors == []
+        assert page_errors == []
+        assert root.get_attribute("data-orders") == "false"
+        assert root.get_attribute("data-live-authorized") == "false"
+        assert root.get_attribute("data-supervised-presentation-only") == "true"
+
+        context.close()
+        browser.close()

--- a/tests/ops/test_supervised_graphical_market_landscape_presentation_only_v1.py
+++ b/tests/ops/test_supervised_graphical_market_landscape_presentation_only_v1.py
@@ -44,7 +44,6 @@ JS_SRC = REPO / "static/js/market_dashboard_landscape_v2.js"
 TEMPLATE_SRC = REPO / "templates/peak_trade_dashboard/market_landscape_v2.html"
 
 
-
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))

--- a/tests/ops/test_supervised_graphical_market_landscape_presentation_only_v1.py
+++ b/tests/ops/test_supervised_graphical_market_landscape_presentation_only_v1.py
@@ -1,0 +1,347 @@
+"""Contract tests: supervised graphical Market Landscape presentation-only v1.
+
+Proves:
+- Existing JSON routes (/health, /market, /api/market/landscape/ohlcv) stay
+  semantically compatible (keys/flags unchanged).
+- GET /landscape returns text/html with visible Landscape root.
+- Static CSS/JS return HTTP 200.
+- Canonical session_id / repository_sha / instrument / OHLCV mappings work.
+- Legacy browser_payload is not required.
+- No direct_browser_okx path exists in JS.
+- Failures are visible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from src.ops.canonical_local_launcher_and_process_supervision_v1.dashboard_http_host_v1 import (
+    create_o2_dashboard_http_app_v1,
+    run_uvicorn_loopback_v1,
+)
+from src.ops.canonical_read_model_and_market_dashboard_rebuild_v1.constants_v1 import (
+    CONNECTION_HEALTHY,
+    READ_MODEL_SCHEMA_NAME,
+)
+from src.ops.canonical_read_model_and_market_dashboard_rebuild_v1.durable_read_model_store_v1 import (
+    commit_durable_read_model_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+HOST_SRC = (
+    REPO / "src/ops/canonical_local_launcher_and_process_supervision_v1/dashboard_http_host_v1.py"
+)
+JS_SRC = REPO / "static/js/market_dashboard_landscape_v2.js"
+TEMPLATE_SRC = REPO / "templates/peak_trade_dashboard/market_landscape_v2.html"
+
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+async def _asgi_get(app: Any, path: str) -> httpx.Response:
+    transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 50000))
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as client:
+        return await client.get(path)
+
+
+def _get(app: Any, path: str) -> httpx.Response:
+    return asyncio.run(_asgi_get(app, path))
+
+
+def _healthy_read_model(*, session_id: str, repository_sha: str) -> dict[str, Any]:
+    bars = [
+        {
+            "ts": "2026-08-01T00:00:00Z",
+            "open": 100.0,
+            "high": 101.0,
+            "low": 99.5,
+            "close": 100.5,
+            "volume": 12.0,
+            "confirm": True,
+        },
+        {
+            "ts": "2026-08-01T01:00:00Z",
+            "open": 100.5,
+            "high": 102.0,
+            "low": 100.0,
+            "close": 101.25,
+            "volume": 15.0,
+            "confirm": True,
+        },
+    ]
+    return {
+        "schema_name": READ_MODEL_SCHEMA_NAME,
+        "schema_version": 1,
+        "authority_classification": "DERIVED",
+        "read_model_classification": "DERIVED",
+        "read_model_ssot": False,
+        "read_model_authority_effect": "NONE",
+        "authoritative_bar_producer": "o4",
+        "dashboard_transport": "o2_dashboard_http",
+        "selection_bundle_id": "supervised-landscape-fixture",
+        "source_session_id": session_id,
+        "repository_sha": repository_sha,
+        "config_digest": "cfg-supervised-landscape",
+        "instrument": "ETH-USDT-SWAP",
+        "instrument_id": "ETH-USDT-SWAP",
+        "interval": "PT1H",
+        "venue": "okx",
+        "last_event_time_unix": 1_700_000_100.0,
+        "last_event_time": "2023-11-14T22:15:00Z",
+        "last_projection_time_unix": 1_700_000_110.0,
+        "last_projection_time": "2023-11-14T22:15:10Z",
+        "freshness_age_seconds": 1.0,
+        "connection_state": CONNECTION_HEALTHY,
+        "is_stale": False,
+        "bar_count": len(bars),
+        "bars": bars,
+        "ohlcv_projection": {
+            "bars": bars,
+            "bar_count": len(bars),
+            "interval": "PT1H",
+            "instrument_id": "ETH-USDT-SWAP",
+            "venue": "okx",
+        },
+        "trading_authority": False,
+        "orders": False,
+        "runtime_mutation": False,
+        "risk_authority": False,
+        "write_methods": [],
+        "may_render_healthy": True,
+    }
+
+
+@pytest.fixture()
+def empty_app(tmp_path: Path) -> Any:
+    return create_o2_dashboard_http_app_v1(
+        state_root=tmp_path / "state_empty",
+        session_id="sess-empty",
+    )
+
+
+@pytest.fixture()
+def seeded_app(tmp_path: Path) -> Any:
+    state_root = tmp_path / "state_seeded"
+    commit_durable_read_model_v1(
+        state_root,
+        _healthy_read_model(
+            session_id="sess-seeded",
+            repository_sha="a" * 40,
+        ),
+    )
+    return create_o2_dashboard_http_app_v1(
+        state_root=state_root,
+        session_id="sess-seeded",
+    )
+
+
+def test_existing_json_routes_semantic_keys_unchanged(empty_app: Any) -> None:
+    health = _get(empty_app, "/health")
+    market = _get(empty_app, "/market")
+    ohlcv = _get(empty_app, "/api/market/landscape/ohlcv")
+
+    assert health.status_code in {200, 503}
+    assert market.status_code == 200
+    assert ohlcv.status_code == 200
+
+    health_body = health.json()
+    market_body = market.json()
+    ohlcv_body = ohlcv.json()
+
+    for key in (
+        "ok",
+        "status",
+        "connection_state",
+        "session_id",
+        "dashboard_authority_effect",
+        "trading_authority",
+        "transport",
+        "timestamp_chain",
+    ):
+        assert key in health_body
+
+    for key in (
+        "schema_name",
+        "route",
+        "session_id",
+        "connection_state",
+        "may_render_healthy",
+        "read_model",
+        "backend_binding",
+        "trading_authority",
+        "orders",
+        "write_methods",
+    ):
+        assert key in market_body
+
+    for key in (
+        "schema_name",
+        "schema_version",
+        "poll_path",
+        "status",
+        "availability",
+        "connection_state",
+        "may_render_healthy",
+        "session_id",
+        "ohlcv",
+        "read_model",
+        "trading_authority",
+        "independent_authoritative_recompute",
+        "parallel_ohlcv_producer",
+    ):
+        assert key in ohlcv_body
+
+    assert market_body["schema_name"] == "o2_dashboard_market_json_v1"
+    assert market_body["trading_authority"] is False
+    assert market_body["orders"] is False
+    assert market_body["write_methods"] == []
+    assert "browser_payload" not in market_body
+    assert ohlcv_body["schema_name"] == "market_landscape_ohlcv_poll_response.v1"
+    assert ohlcv_body["parallel_ohlcv_producer"] is False
+    assert ohlcv_body["independent_authoritative_recompute"] is False
+    assert "browser_payload" not in ohlcv_body
+    assert health_body["trading_authority"] is False
+
+
+def test_json_content_type_unchanged(empty_app: Any) -> None:
+    for path in ("/health", "/market", "/api/market/landscape/ohlcv"):
+        response = _get(empty_app, path)
+        assert "application/json" in response.headers.get("content-type", "")
+
+
+def test_landscape_route_returns_text_html(empty_app: Any) -> None:
+    response = _get(empty_app, "/landscape")
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    html = response.text
+    assert 'data-market-landscape-v2="true"' in html
+    assert 'data-supervised-presentation-only="true"' in html
+    assert 'data-canonical-market-path="/market"' in html
+    assert 'data-canonical-ohlcv-path="/api/market/landscape/ohlcv"' in html
+    assert 'data-mdl-ohlcv-poll-path="/api/market/landscape/ohlcv"' in html
+    assert "NOT_BOUND" in html
+    assert 'data-orders="false"' in html
+    assert 'data-live-authorized="false"' in html
+    assert "market_dashboard_landscape_v2.css" in html
+    assert "market_dashboard_landscape_v2.js" in html
+
+
+def test_static_css_js_return_200(empty_app: Any) -> None:
+    css = _get(empty_app, "/static/css/market_dashboard_landscape_v2.css")
+    js = _get(empty_app, "/static/js/market_dashboard_landscape_v2.js")
+    assert css.status_code == 200
+    assert js.status_code == 200
+    assert len(css.content) > 100
+    assert len(js.content) > 100
+
+
+def test_canonical_session_instrument_ohlcv_mappings(seeded_app: Any) -> None:
+    market = _get(seeded_app, "/market").json()
+    ohlcv = _get(seeded_app, "/api/market/landscape/ohlcv").json()
+    html = _get(seeded_app, "/landscape").text
+
+    assert market["session_id"] == "sess-seeded"
+    assert market["read_model"]["repository_sha"] == "a" * 40
+    assert market["read_model"]["instrument_id"] == "ETH-USDT-SWAP"
+    assert ohlcv["session_id"] == "sess-seeded"
+    assert ohlcv["repository_sha"] == "a" * 40
+    assert ohlcv["ohlcv"]["bars"]
+    assert "browser_payload" not in ohlcv
+    assert 'data-session-id="sess-seeded"' in html
+    assert market["read_model"]["bars"][0]["ts"] == ohlcv["ohlcv"]["bars"][0]["ts"]
+
+
+def test_js_accepts_canonical_without_browser_payload() -> None:
+    js = JS_SRC.read_text(encoding="utf-8")
+    assert "extractCanonicalOhlcvPayload" in js
+    assert "body.ohlcv" in js or "picked.kind" in js
+    assert "browser_payload" in js  # legacy still accepted
+    assert "never substitute candle close" in js.lower() or "Never substitute" in js
+    assert "direct_browser_okx" in js
+    assert "poll_forbidden_direct_okx" in js
+    assert "okx.com" not in js.lower()
+    assert 'fetch("https://' not in js
+    assert "CANONICAL_DATA_UNAVAILABLE" in js
+    assert "bootstrapFromCanonicalMarket" in js
+    assert 'marketPath !== "/market"' in js
+
+
+def test_template_and_host_forbid_legacy_hot_path_wiring() -> None:
+    host = HOST_SRC.read_text(encoding="utf-8")
+    template = TEMPLATE_SRC.read_text(encoding="utf-8")
+    assert "market_dashboard_landscape_shell_router_v2" not in host
+    assert "market_dashboard_landscape_producer_binding_v2" not in host
+    assert "run_web_dashboard" not in host
+    assert "refresh_selected_okx" not in host
+    assert 'data-market-landscape-v2="true"' in template
+    assert "non_authoritative_bootstrap" in template
+
+
+def test_fail_visible_when_canonical_absent(empty_app: Any) -> None:
+    market = _get(empty_app, "/market").json()
+    assert market["connection_state"] == "MISSING_SOURCE"
+    html = _get(empty_app, "/landscape").text
+    # Empty bootstrap — JS fail-visible path depends on runtime; HTML itself
+    # must not pretend healthy OHLCV series are bound.
+    assert "non_authoritative_bootstrap" in html
+    assert 'data-mdl-chart-has-series="false"' in html or "NOT_BOUND" in html
+
+
+def test_no_second_host_or_forbidden_imports_in_host() -> None:
+    host = HOST_SRC.read_text(encoding="utf-8")
+    assert "create_app()" not in host
+    assert "uvicorn.workers" not in host
+    assert "exchange_credentials" not in host
+    assert "submit_order" not in host
+    assert "place_order" not in host
+
+
+def test_uvicorn_loopback_serves_landscape_and_json(tmp_path: Path) -> None:
+    state_root = tmp_path / "uv_state"
+    commit_durable_read_model_v1(
+        state_root,
+        _healthy_read_model(session_id="uv-sess", repository_sha="b" * 40),
+    )
+    app = create_o2_dashboard_http_app_v1(state_root=state_root, session_id="uv-sess")
+    port = _free_port()
+    server = run_uvicorn_loopback_v1(app=app, host="127.0.0.1", port=port)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        deadline = time.time() + 5.0
+        last_err: Exception | None = None
+        while time.time() < deadline:
+            try:
+                with httpx.Client(base_url=base, timeout=1.0) as client:
+                    landscape = client.get("/landscape")
+                    market = client.get("/market")
+                    css = client.get("/static/css/market_dashboard_landscape_v2.css")
+                    js = client.get("/static/js/market_dashboard_landscape_v2.js")
+                assert landscape.status_code == 200
+                assert "text/html" in landscape.headers.get("content-type", "")
+                assert 'data-market-landscape-v2="true"' in landscape.text
+                assert market.status_code == 200
+                assert market.json()["session_id"] == "uv-sess"
+                assert css.status_code == 200
+                assert js.status_code == 200
+                return
+            except Exception as exc:  # noqa: BLE001
+                last_err = exc
+                time.sleep(0.05)
+        raise AssertionError(f"uvicorn landscape serve failed: {last_err}")
+    finally:
+        server.should_exit = True


### PR DESCRIPTION
## Summary

Presentation-layer-only adaptation of the Market Landscape to the canonical supervised dashboard host.

**Immutable architecture boundary:** the Landscape adapts to the canonical system; the system and canonical read models are never adapted to the Landscape.

- Existing `GET /market`, `GET /api/market/landscape/ohlcv`, and `GET /health` JSON schemas and semantics are unchanged.
- Additive only: `GET /landscape` (`text/html`) and static asset serving on the existing supervised O2 host (`dashboard_http_host_v1`).
- Direct canonical JS consumption of `/market` and `/api/market/landscape/ohlcv` only; `browser_payload` is optional and not required.
- No second host; no legacy producer / archive rematerialization / OKX refresh in the hot path; no browser-direct OKX access.
- No trading / risk / persistence / execution / credentials changes.
- Running runtime/dashboard session was not touched during implementation or validation.

### Changed files (exactly six)

1. `src/ops/canonical_local_launcher_and_process_supervision_v1/dashboard_http_host_v1.py`
2. `static/css/market_dashboard_landscape_v2.css`
3. `static/js/market_dashboard_landscape_v2.js`
4. `templates/peak_trade_dashboard/market_landscape_v2.html`
5. `tests/ops/test_supervised_graphical_market_landscape_presentation_only_v1.py`
6. `tests/ops/test_supervised_graphical_market_landscape_presentation_only_playwright_v1.py`

Commits: `0c20e20f5` (implementation) + `2483f4f2d` (format-only follow-up).

## Test plan

- [x] Focused unit/contract + Playwright: **11/11 PASS**
- [x] Playwright owner-route acceptance: **PASS**
- [x] `ruff format --check` on changed Python: **PASS**
- [x] PR_BOUNDED_FULL timing proof: **729 passed in 46.377s** (target max 840s; prior bounded run 47.545s)
- [x] Architecture guard disclosure (pre-existing, not introduced by this PR):

```text
Command:
pytest tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py::test_landscape_package_stdlib_and_relative_only

Branch HEAD result: FAIL
  AssertionError: non-stdlib imports in Landscape package:
  ['src/webui/market_dashboard_landscape_v2/presenter.py:src.ops.canonical_read_model_and_market_dashboard_rebuild_v1.ohlcv_adapter_v1']

Clean origin/main @ a50e4c705561bf87274ee7cea8397d38ed6e5bf0: FAIL with identical assertion
presenter.py SHA256 identical on branch and origin/main
```

This PR does not modify code to address that baseline failure.

## Safety

- `LIVE_TRADING_ALLOWED=false`, `TESTNET_ALLOWED=false`, no credentials access, no orders, no network-bound session started, no merge in this step.

Made with [Cursor](https://cursor.com)