### PR TITLE
fix(presentation): keep landscape connection state fail-closed

### DIFF
--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -69,6 +69,53 @@
     root.setAttribute("data-mdl-data-connection-state", state);
   }
 
+  // --- connection-state fail-closed helpers (begin) ---
+  // Poll arming and poll payloads must never invent HEALTHY from availability,
+  // timer start, or missing payload fields. Preserve existing DOM truth or
+  // fail closed to MISSING_SOURCE.
+  function normalizeConnectionStateToken(raw) {
+    var state = String(raw || "").trim();
+    if (!state) return "";
+    if (state === "LIVE_DATA") return "HEALTHY";
+    if (
+      state === "HEALTHY" ||
+      state === "DEGRADED" ||
+      state === "DISCONNECTED" ||
+      state === "MISSING_SOURCE" ||
+      state === "STALE"
+    ) {
+      return state;
+    }
+    return "";
+  }
+
+  function readExistingConnectionState() {
+    var node = root.querySelector(
+      ".mdl-v2-chart__chrome [data-mdl-data-connection-state]"
+    );
+    var fromNode = "";
+    if (node) {
+      fromNode = node.getAttribute("data-connection-state") || "";
+      if (!fromNode && node.textContent) fromNode = String(node.textContent);
+    }
+    var fromRoot = root.getAttribute("data-mdl-data-connection-state") || "";
+    return (
+      normalizeConnectionStateToken(fromNode) ||
+      normalizeConnectionStateToken(fromRoot)
+    );
+  }
+
+  function resolveConnectionStateForPollPayload(body) {
+    var payloadRaw =
+      (body && (body.connection_state || body.data_connection_state)) || "";
+    var fromPayload = normalizeConnectionStateToken(payloadRaw);
+    if (fromPayload) return fromPayload;
+    var existing = readExistingConnectionState();
+    if (existing) return existing;
+    return "MISSING_SOURCE";
+  }
+  // --- connection-state fail-closed helpers (end) ---
+
   function setUpdateClass(kind) {
     root.setAttribute("data-mdl-ohlcv-update-class", kind);
   }
@@ -734,14 +781,8 @@
     if (availability) {
       chart.setAttribute("data-availability", availability);
     }
-    var connectionState =
-      body.connection_state ||
-      body.data_connection_state ||
-      (availability === "MISSING_SOURCE"
-        ? "MISSING_SOURCE"
-        : availability === "STALE"
-          ? "STALE"
-          : "HEALTHY");
+    // Fallback: payload → existing DOM → MISSING_SOURCE (never invent HEALTHY).
+    var connectionState = resolveConnectionStateForPollPayload(body);
     // Fail-closed: never promote stale/disconnected/missing to HEALTHY.
     if (
       availability === "STALE" ||
@@ -928,13 +969,9 @@
     }
 
     root.setAttribute("data-mdl-ohlcv-poll-armed", "true");
-    setConnectionState(
-      chart.getAttribute("data-availability") === "MISSING_SOURCE"
-        ? "MISSING_SOURCE"
-        : chart.getAttribute("data-availability") === "STALE"
-          ? "STALE"
-          : "HEALTHY"
-    );
+    // Preserve existing DOM connection truth; never invent HEALTHY from
+    // data-availability, bootstrap success, or poll-timer arming alone.
+    setConnectionState(readExistingConnectionState() || "MISSING_SOURCE");
     scheduleNext();
   }
 

--- a/tests/ops/test_supervised_graphical_market_landscape_presentation_only_playwright_v1.py
+++ b/tests/ops/test_supervised_graphical_market_landscape_presentation_only_playwright_v1.py
@@ -311,7 +311,15 @@ def test_playwright_owner_route_supervised_landscape_acceptance(
             assert preserved == "DEGRADED"
             assert preserved != "HEALTHY"
         else:
-            assert conn in {None, "", "MISSING_SOURCE", "DEGRADED", "DISCONNECTED", "STALE", "HEALTHY"}
+            assert conn in {
+                None,
+                "",
+                "MISSING_SOURCE",
+                "DEGRADED",
+                "DISCONNECTED",
+                "STALE",
+                "HEALTHY",
+            }
 
         context.close()
         browser.close()
@@ -324,7 +332,4 @@ def test_playwright_js_source_connection_state_fail_closed_contract() -> None:
     arm_idx = js_text.index('data-mdl-ohlcv-poll-armed", "true"')
     arm_block = js_text[arm_idx : arm_idx + 450]
     assert ': "HEALTHY"' not in arm_block
-    assert (
-        'availability === "STALE"\n          ? "STALE"\n          : "HEALTHY"'
-        not in js_text
-    )
+    assert 'availability === "STALE"\n          ? "STALE"\n          : "HEALTHY"' not in js_text

--- a/tests/ops/test_supervised_graphical_market_landscape_presentation_only_playwright_v1.py
+++ b/tests/ops/test_supervised_graphical_market_landscape_presentation_only_playwright_v1.py
@@ -262,5 +262,69 @@ def test_playwright_owner_route_supervised_landscape_acceptance(
         assert root.get_attribute("data-live-authorized") == "false"
         assert root.get_attribute("data-supervised-presentation-only") == "true"
 
+        # Connection-state fail-closed: poll arm preserves DOM; never invents HEALTHY.
+        js_text = JS_SRC.read_text(encoding="utf-8")
+        assert "readExistingConnectionState" in js_text
+        assert 'readExistingConnectionState() || "MISSING_SOURCE"' in js_text
+        assert "resolveConnectionStateForPollPayload" in js_text
+        armed = root.get_attribute("data-mdl-ohlcv-poll-armed")
+        conn = root.get_attribute("data-mdl-data-connection-state")
+        if armed == "true":
+            # Seeded HEALTHY read-model may legitimately show HEALTHY after canonical bind;
+            # arming alone must not invent HEALTHY when DOM is non-healthy.
+            page.evaluate(
+                """() => {
+                  const root = document.querySelector('[data-market-landscape-v2="true"]');
+                  root.setAttribute('data-mdl-data-connection-state', 'DEGRADED');
+                  const node = root.querySelector(
+                    '.mdl-v2-chart__chrome [data-mdl-data-connection-state]'
+                  );
+                  if (node) {
+                    node.setAttribute('data-connection-state', 'DEGRADED');
+                    node.textContent = 'DEGRADED';
+                  }
+                }"""
+            )
+            preserved = page.evaluate(
+                """() => {
+                  const root = document.querySelector('[data-market-landscape-v2="true"]');
+                  const node = root.querySelector(
+                    '.mdl-v2-chart__chrome [data-mdl-data-connection-state]'
+                  );
+                  const fromNode = node
+                    ? (node.getAttribute('data-connection-state') || node.textContent || '')
+                    : '';
+                  const fromRoot = root.getAttribute('data-mdl-data-connection-state') || '';
+                  const raw = String(fromNode || fromRoot || '').trim();
+                  const vocab = {
+                    HEALTHY: true,
+                    DEGRADED: true,
+                    DISCONNECTED: true,
+                    MISSING_SOURCE: true,
+                    STALE: true,
+                  };
+                  const existing = vocab[raw] ? raw : '';
+                  // Mirror production arming rule.
+                  return existing || 'MISSING_SOURCE';
+                }"""
+            )
+            assert preserved == "DEGRADED"
+            assert preserved != "HEALTHY"
+        else:
+            assert conn in {None, "", "MISSING_SOURCE", "DEGRADED", "DISCONNECTED", "STALE", "HEALTHY"}
+
         context.close()
         browser.close()
+
+
+def test_playwright_js_source_connection_state_fail_closed_contract() -> None:
+    js_text = JS_SRC.read_text(encoding="utf-8")
+    assert "resolveConnectionStateForPollPayload(body)" in js_text
+    assert 'readExistingConnectionState() || "MISSING_SOURCE"' in js_text
+    arm_idx = js_text.index('data-mdl-ohlcv-poll-armed", "true"')
+    arm_block = js_text[arm_idx : arm_idx + 450]
+    assert ': "HEALTHY"' not in arm_block
+    assert (
+        'availability === "STALE"\n          ? "STALE"\n          : "HEALTHY"'
+        not in js_text
+    )

--- a/tests/ops/test_supervised_graphical_market_landscape_presentation_only_v1.py
+++ b/tests/ops/test_supervised_graphical_market_landscape_presentation_only_v1.py
@@ -278,6 +278,24 @@ def test_js_accepts_canonical_without_browser_payload() -> None:
     assert 'marketPath !== "/market"' in js
 
 
+def test_js_connection_state_poll_arm_fail_closed_presentation_contract() -> None:
+    """Presentation-only: poll arm / payload must not invent HEALTHY."""
+    js = JS_SRC.read_text(encoding="utf-8")
+    assert "readExistingConnectionState" in js
+    assert "resolveConnectionStateForPollPayload" in js
+    assert 'readExistingConnectionState() || "MISSING_SOURCE"' in js
+    assert "resolveConnectionStateForPollPayload(body)" in js
+    # Honest presentation: arming must not promote arbitrary availability to HEALTHY.
+    arm_idx = js.index('data-mdl-ohlcv-poll-armed", "true"')
+    arm_block = js[arm_idx : arm_idx + 450]
+    assert 'setConnectionState(readExistingConnectionState() || "MISSING_SOURCE")' in arm_block
+    assert ': "HEALTHY"' not in arm_block
+    assert "DEGRADED" in js
+    assert "DISCONNECTED" in js
+    assert "MISSING_SOURCE" in js
+    assert "HEALTHY" in js  # explicit canonical HEALTHY still in vocabulary
+
+
 def test_template_and_host_forbid_legacy_hot_path_wiring() -> None:
     host = HOST_SRC.read_text(encoding="utf-8")
     template = TEMPLATE_SRC.read_text(encoding="utf-8")

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -1112,3 +1112,164 @@ def test_stale_and_missing_source_fail_closed(
     assert poll["availability"] == "STALE"
     assert poll["is_stale"] is True
     assert poll["browser_payload"] is not None
+
+
+def _extract_connection_state_fail_closed_helpers(js: str) -> str:
+    begin = "// --- connection-state fail-closed helpers (begin) ---"
+    end = "// --- connection-state fail-closed helpers (end) ---"
+    assert begin in js
+    assert end in js
+    return js.split(begin, 1)[1].split(end, 1)[0]
+
+
+def test_js_connection_state_poll_arm_and_payload_fail_closed_contracts() -> None:
+    """Static proof: poll arm / payload never invent HEALTHY without canonical truth."""
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+    assert "readExistingConnectionState" in js
+    assert "resolveConnectionStateForPollPayload" in js
+    assert "normalizeConnectionStateToken" in js
+    # Arming preserves DOM or fails closed — never availability→HEALTHY.
+    assert 'readExistingConnectionState() || "MISSING_SOURCE"' in js
+    assert "data-mdl-ohlcv-poll-armed" in js
+    # Forbidden: invent HEALTHY from non-MISSING/STALE availability at arming.
+    arm_idx = js.index('data-mdl-ohlcv-poll-armed", "true"')
+    arm_tail = js[arm_idx : arm_idx + 450]
+    assert ': "HEALTHY"' not in arm_tail
+    assert '=== "MISSING_SOURCE"' not in arm_tail or "readExistingConnectionState" in arm_tail
+    assert 'setConnectionState(readExistingConnectionState() || "MISSING_SOURCE")' in arm_tail
+    # Payload resolution order is payload → DOM → MISSING_SOURCE.
+    assert "resolveConnectionStateForPollPayload(body)" in js
+    assert 'return "MISSING_SOURCE"' in js
+    # Explicit canonical HEALTHY remains representable.
+    assert 'state === "HEALTHY"' in js
+    assert "never invent HEALTHY" in js.lower() or "never invent HEALTHY" in js
+    # Prior inventing availability ternary must be gone from applyPollPayload.
+    assert (
+        'availability === "STALE"\n          ? "STALE"\n          : "HEALTHY"' not in js
+    )
+    assert (
+        'availability === "MISSING_SOURCE"\n        ? "MISSING_SOURCE"\n'
+        '        : availability === "STALE"'
+    ) not in js
+
+
+def test_js_connection_state_fail_closed_behavioral_regressions_a_through_f() -> None:
+    """A–F behavioral regressions against production helper source (Node)."""
+    import subprocess
+    import tempfile
+
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+    helpers = _extract_connection_state_fail_closed_helpers(js)
+    harness = f"""
+'use strict';
+function makeRoot(attrs) {{
+  attrs = attrs || {{}};
+  var chromeState = attrs.chrome || '';
+  var rootState = attrs.root || '';
+  var chromeNode = {{
+    textContent: chromeState,
+    getAttribute: function (name) {{
+      if (name === 'data-connection-state') return chromeState;
+      return null;
+    }},
+    setAttribute: function (name, value) {{
+      if (name === 'data-connection-state') chromeState = String(value);
+    }},
+  }};
+  var root = {{
+    _rootState: rootState,
+    querySelector: function (sel) {{
+      if (sel.indexOf('data-mdl-data-connection-state') !== -1) {{
+        return chromeState || rootState || attrs.forceChrome ? chromeNode : null;
+      }}
+      return null;
+    }},
+    getAttribute: function (name) {{
+      if (name === 'data-mdl-data-connection-state') return root._rootState;
+      return null;
+    }},
+    setAttribute: function (name, value) {{
+      if (name === 'data-mdl-data-connection-state') root._rootState = String(value);
+    }},
+  }};
+  return root;
+}}
+
+var root;
+{helpers}
+
+function armPoll() {{
+  return readExistingConnectionState() || 'MISSING_SOURCE';
+}}
+
+function assertEq(label, actual, expected) {{
+  if (actual !== expected) {{
+    throw new Error(label + ': expected ' + JSON.stringify(expected) + ' got ' + JSON.stringify(actual));
+  }}
+}}
+
+// A. POLL ARM PRESERVES DEGRADED
+root = makeRoot({{ chrome: 'DEGRADED', root: 'DEGRADED', forceChrome: true }});
+assertEq('A_arm_preserves_degraded', armPoll(), 'DEGRADED');
+
+// B. POLL ARM DOES NOT INVENT HEALTHY FOR NOT_BOUND
+root = makeRoot({{ chrome: '', root: '' }});
+assertEq('B_not_bound_no_healthy', armPoll(), 'MISSING_SOURCE');
+assertEq('B_not_healthy', armPoll() === 'HEALTHY', false);
+
+// C. POLL ARM DOES NOT INVENT HEALTHY FOR INVALID
+root = makeRoot({{ chrome: 'bogus', root: 'INVALID' }});
+assertEq('C_invalid_no_healthy', armPoll(), 'MISSING_SOURCE');
+
+// D. PAYLOAD WITHOUT CONNECTION_STATE PRESERVES DOM STATE
+root = makeRoot({{ chrome: 'DEGRADED', root: 'DEGRADED', forceChrome: true }});
+assertEq(
+  'D_preserve_degraded',
+  resolveConnectionStateForPollPayload({{ availability: 'AVAILABLE' }}),
+  'DEGRADED'
+);
+root = makeRoot({{ chrome: 'DISCONNECTED', root: 'DISCONNECTED', forceChrome: true }});
+assertEq(
+  'D_preserve_disconnected',
+  resolveConnectionStateForPollPayload({{ availability: 'AVAILABLE' }}),
+  'DISCONNECTED'
+);
+
+// E. PAYLOAD WITHOUT STATE FAILS CLOSED
+root = makeRoot({{ chrome: '', root: '' }});
+assertEq(
+  'E_fail_closed_missing_source',
+  resolveConnectionStateForPollPayload({{ availability: 'AVAILABLE' }}),
+  'MISSING_SOURCE'
+);
+assertEq(
+  'E_never_healthy',
+  resolveConnectionStateForPollPayload({{}}) === 'HEALTHY',
+  false
+);
+
+// F. EXPLICIT CANONICAL HEALTHY REMAINS ALLOWED
+root = makeRoot({{ chrome: 'DEGRADED', root: 'DEGRADED', forceChrome: true }});
+assertEq(
+  'F_explicit_healthy',
+  resolveConnectionStateForPollPayload({{ connection_state: 'HEALTHY' }}),
+  'HEALTHY'
+);
+
+console.log('CONNECTION_STATE_FAIL_CLOSED_REGRESSIONS_PASS');
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False, encoding="utf-8") as handle:
+        handle.write(harness)
+        harness_path = Path(handle.name)
+    try:
+        completed = subprocess.run(
+            ["node", str(harness_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    finally:
+        harness_path.unlink(missing_ok=True)
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    assert "CONNECTION_STATE_FAIL_CLOSED_REGRESSIONS_PASS" in completed.stdout

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -1144,9 +1144,7 @@ def test_js_connection_state_poll_arm_and_payload_fail_closed_contracts() -> Non
     assert 'state === "HEALTHY"' in js
     assert "never invent HEALTHY" in js.lower() or "never invent HEALTHY" in js
     # Prior inventing availability ternary must be gone from applyPollPayload.
-    assert (
-        'availability === "STALE"\n          ? "STALE"\n          : "HEALTHY"' not in js
-    )
+    assert 'availability === "STALE"\n          ? "STALE"\n          : "HEALTHY"' not in js
     assert (
         'availability === "MISSING_SOURCE"\n        ? "MISSING_SOURCE"\n'
         '        : availability === "STALE"'


### PR DESCRIPTION
## Summary

- **Proven gap:** `startOhlcvPolling()` armed the Landscape V2 connection state as `HEALTHY` whenever `data-availability` was not `MISSING_SOURCE` or `STALE`. That overwrote existing canonical/SSR truth (`DEGRADED`, `DISCONNECTED`, `NOT_BOUND`, `INVALID`, etc.) without a new canonical healthy signal. `applyPollPayload()` likewise defaulted missing/empty payload `connection_state` to `HEALTHY`.
- **Fix (presentation-only):** Poll arming now preserves a valid existing DOM connection state, otherwise fails closed to `MISSING_SOURCE` — never invents `HEALTHY` from availability, bootstrap success, or timer start. Payload fallback order is: (a) valid canonical payload `connection_state` → (b) valid existing DOM state → (c) `MISSING_SOURCE`. Explicit canonical `connection_state=HEALTHY` remains allowed.
- **Scope confirmation:** No producer, canonical read-model, runtime, trading, risk, safety, decision, order, host, or authority-chain changes. Only `static/js/market_dashboard_landscape_v2.js` plus presentation regression tests.

## Regression coverage

- A poll arm preserves `DEGRADED`
- B/C poll arm does not invent `HEALTHY` for unbound/invalid existing state
- D payload without `connection_state` preserves DOM `DEGRADED`/`DISCONNECTED`
- E missing payload + missing DOM fails closed to `MISSING_SOURCE`
- F explicit canonical `HEALTHY` payload remains allowed

## Test plan

- [x] Targeted `-k 'connection or HEALTHY or DEGRADED or DISCONNECTED or MISSING_SOURCE or bootstrap or poll'`
- [x] Full affected files: continuous refresh, supervised presentation, playwright, shell route
- [x] Architecture/contracts/producer-binding guards executed (one pre-existing `origin/main` failure in `test_landscape_package_stdlib_and_relative_only` unrelated to this presentation diff; not in allowed mutation scope)


Made with [Cursor](https://cursor.com)