### PR TITLE
feat(webui): auto-bind canonical decision presentation

### DIFF
--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -2,7 +2,8 @@
 
 Binds market_instrument, universe_ranking, dynamic_scope lifecycle identity,
 regime_bull_bear_switch (explicit injection; PR #5577), canonical_decision
-evidence, double_play display projection, safety authority KillSwitch/boundary
+evidence (injection or durable presentation projection auto-bind),
+double_play display projection, safety authority KillSwitch/boundary
 field projection, risk/sizing/capital field projection, execution/reconciliation
 field projection, and economic summary EconomicViabilityEvidenceV1 field
 projection.
@@ -65,6 +66,10 @@ from .workflow_dashboard_archive_root_v1 import (
     ENV_ARCHIVE_ROOT,
     WorkflowDashboardArchiveRootError,
     resolve_workflow_dashboard_archive_root,
+)
+from .workflow_dashboard_readmodel_v1.canonical_decision_presentation_projection_v1 import (
+    LOAD_ERROR_ABSENT as DECISION_PROJECTION_ABSENT,
+    try_load_canonical_decision_presentation_projection_v1,
 )
 from .workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
     FORBIDDEN_SELECTED_SYMBOLS,
@@ -852,19 +857,44 @@ def _bind_canonical_decision(
     as_of: datetime,
     git_sha: str | None,
     canonical_decision_fields: Mapping[str, Any] | None,
+    archive_root: Path | None = None,
 ) -> Any:
-    """Project injected CanonicalTradingDecisionEvidenceV1-compatible fields.
+    """Project CanonicalTradingDecisionEvidenceV1-compatible fields.
 
-    No durable dashboard decision readmodel. Without injection → MISSING_SOURCE.
-    Never runs decision producers, Double Play composers, or switch owners.
-    Blockers remain empty — evidence has no direct blockers field.
+    Injection remains supported for tests. Productive auto-bind loads the
+    non-authoritative presentation projection from the Workflow Dashboard
+    archive root when injection is absent. Never runs decision producers,
+    Double Play composers, or switch owners. Blockers remain empty — evidence
+    has no direct blockers field.
     """
     if canonical_decision_fields is None:
-        return unavailable_canonical_decision(
-            availability=Availability.MISSING_SOURCE,
-            generated_at=as_of,
-            reason=REASON_DECISION_NOT_PERSISTED,
-        )
+        if archive_root is None:
+            return unavailable_canonical_decision(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_DECISION_NOT_PERSISTED,
+            )
+        loaded = try_load_canonical_decision_presentation_projection_v1(archive_root)
+        if not loaded.loaded or loaded.binder_fields is None:
+            reason = REASON_DECISION_NOT_PERSISTED
+            if loaded.load_errors:
+                first = str(loaded.load_errors[0])
+                if first != DECISION_PROJECTION_ABSENT:
+                    reason = first
+            availability = (
+                Availability.MISSING_SOURCE
+                if reason == REASON_DECISION_NOT_PERSISTED or reason == DECISION_PROJECTION_ABSENT
+                else Availability.INVALID
+            )
+            if reason == DECISION_PROJECTION_ABSENT:
+                reason = REASON_DECISION_NOT_PERSISTED
+                availability = Availability.MISSING_SOURCE
+            return unavailable_canonical_decision(
+                availability=availability,
+                generated_at=as_of,
+                reason=reason,
+            )
+        canonical_decision_fields = loaded.binder_fields
 
     required = (
         "instrument_id",
@@ -1825,8 +1855,9 @@ def bind_market_universe_slots(
 
     canonical_decision_fields accepts already-computed
     CanonicalTradingDecisionEvidenceV1-compatible fields plus producer
-    wall-clock timestamps. Without injection, canonical_decision is
-    MISSING_SOURCE (no durable readmodel).
+    wall-clock timestamps. Without injection, canonical_decision auto-binds
+    from the durable non-authoritative presentation projection under the
+    archive root; absent/invalid projection → MISSING_SOURCE / INVALID.
 
     double_play_fields accepts already-computed
     DoublePlayDashboardDisplaySnapshot-compatible fields plus producer
@@ -1878,6 +1909,7 @@ def bind_market_universe_slots(
         as_of=as_of,
         git_sha=git_sha,
         canonical_decision_fields=canonical_decision_fields,
+        archive_root=root,
     )
     double_play = _bind_double_play_display(
         as_of=as_of,

--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -8,7 +8,8 @@ via universe_selection_readmodel.v1 — no Env required when the default exists.
 Phase 4.2 binds dynamic_scope lifecycle identity fail-closed (injection only).
 Phase 4.2B binds regime_bull_bear_switch fail-closed (explicit injection only;
 PR #5577 — no transition_state calls).
-Phase 4.3A binds canonical_decision fail-closed (injection only).
+Phase 4.3A binds canonical_decision fail-closed (injection or durable
+presentation projection auto-bind; AUTHORITY_EFFECT=NONE).
 Phase 4.3B binds double_play display fail-closed (injection only).
 OHLCV binds from materialized okx_selected_instrument_ohlcv_readmodel.v1 only.
 CAPABILITY_O4: that readmodel is DERIVED (HTTP_JSON_POLL); authoritative bars are

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -80,10 +80,14 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
         authority_class="decision",
         reuse_status="REUSED",
         notes=(
-            "Phase 4.3A: Landscape projects CanonicalTradingDecisionEvidenceV1 "
+            "Phase 4.3A + CAPABILITY_PRESENTATION_CANONICAL_DECISION_AUTOBIND_V1: "
+            "Landscape projects CanonicalTradingDecisionEvidenceV1 "
             "field-for-field (decision_outcome/next_direction_state/reason_codes/"
             "decision_id); blockers remain empty (no direct evidence field); "
-            "no recomputation; Double Play is a separate Phase 4.3B slot."
+            "no recomputation; Double Play is a separate Phase 4.3B slot. "
+            "Durable auto-bind via non-authoritative "
+            "canonical_decision_presentation_projection.v1 under archive root; "
+            "injection remains test-compatible; AUTHORITY_EFFECT=NONE."
         ),
     ),
     CanonicalOwnerRefV1(

--- a/src/webui/workflow_dashboard_archive_root_v1.py
+++ b/src/webui/workflow_dashboard_archive_root_v1.py
@@ -4,7 +4,8 @@ Sole owner of archive-root *location* resolution for dashboard consumers.
 Does not create directories, does not write readmodels, and does not authorize
 trading. GET /market consumers may resolve this root (explicit → Env →
 canonical default → discovered governed OKX sibling) to read-only-load
-universe_selection_readmodel.v1 and okx_selected_instrument_ohlcv_readmodel.v1.
+universe_selection_readmodel.v1 and okx_selected_instrument_ohlcv_readmodel.v1,
+and (when present) canonical_decision_presentation_projection.v1.
 """
 
 from __future__ import annotations
@@ -39,6 +40,9 @@ PRECEDENCE_CHAIN: tuple[str, ...] = (
 
 UNIVERSE_SELECTION_READMODEL_RELATIVE = "readmodels/universe_selection_readmodel.v1.json"
 OKX_OHLCV_READMODEL_RELATIVE = "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
+CANONICAL_DECISION_PRESENTATION_PROJECTION_RELATIVE = (
+    "readmodels/canonical_decision_presentation_projection.v1.json"
+)
 _DISCOVER_NAME_PREFIX = "workflow_dashboard_v1"
 
 

--- a/src/webui/workflow_dashboard_readmodel_v1/canonical_decision_presentation_projection_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/canonical_decision_presentation_projection_v1.py
@@ -1,0 +1,264 @@
+"""Non-authoritative presentation projection for canonical decision evidence.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_CANONICAL_DECISION_AUTOBIND_V1
+
+Reads already-produced CanonicalTradingDecisionEvidenceV1 field payloads from a
+single durable archive path and maps them field-for-field into Landscape binder
+injection fields. This module:
+
+- AUTHORITY_EFFECT=NONE
+- DECISION_AUTHORITY_EFFECT=NONE
+- never creates, mutates, or evaluates trading decisions
+- never imports trading.master_v2 decision producers or evaluators
+- never calls transition_state / compose_double_play / KillSwitch / risk / sizing
+- fail-closed: missing, invalid, or ambiguous sources → no fields (MISSING_SOURCE)
+
+Deterministic source selection: exactly one well-known relative path under the
+Workflow Dashboard archive root. No silent multi-candidate "latest" picking.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_NAME = "canonical_decision_presentation_projection.v1"
+SCHEMA_VERSION = 1
+STORAGE_RELATIVE_PATH = "readmodels/canonical_decision_presentation_projection.v1.json"
+PRODUCER_EVIDENCE_SCHEMA_VERSION = "canonical_trading_decision_evidence_v1"
+AUTHORITY_EFFECT = "NONE"
+DECISION_AUTHORITY_EFFECT = "NONE"
+PROJECTION_ROLE = "NON_AUTHORITATIVE_PRESENTATION_PROJECTION"
+OWNER_MODULE = "webui.workflow_dashboard_readmodel_v1.canonical_decision_presentation_projection_v1"
+
+LOAD_ERROR_ABSENT = "CANONICAL_DECISION_PRESENTATION_PROJECTION_ABSENT"
+LOAD_ERROR_INVALID_JSON = "CANONICAL_DECISION_PRESENTATION_PROJECTION_INVALID_JSON"
+LOAD_ERROR_SCHEMA_MISMATCH = "CANONICAL_DECISION_PRESENTATION_PROJECTION_SCHEMA_MISMATCH"
+LOAD_ERROR_AUTHORITY_CLAIM = "CANONICAL_DECISION_PRESENTATION_PROJECTION_AUTHORITY_CLAIM"
+LOAD_ERROR_EVIDENCE_INVALID = "CANONICAL_DECISION_PRESENTATION_PROJECTION_EVIDENCE_INVALID"
+LOAD_ERROR_AMBIGUOUS = "CANONICAL_DECISION_PRESENTATION_PROJECTION_AMBIGUOUS_SOURCE"
+LOAD_ERROR_TIMESTAMP_MISSING = "CANONICAL_DECISION_PRESENTATION_PROJECTION_TIMESTAMP_MISSING"
+
+_REQUIRED_EVIDENCE_KEYS = (
+    "instrument_id",
+    "decision_outcome",
+    "next_direction_state",
+    "decision_id",
+    "evidence_schema_version",
+)
+
+
+@dataclass(frozen=True)
+class CanonicalDecisionPresentationLoadV1:
+    """Result of a fail-closed presentation projection load attempt."""
+
+    loaded: bool
+    load_errors: tuple[str, ...]
+    binder_fields: Mapping[str, Any] | None = None
+    source_path: str | None = None
+    evidence_digest: str | None = None
+    decision_id: str | None = None
+
+
+def _empty(*, load_errors: tuple[str, ...]) -> CanonicalDecisionPresentationLoadV1:
+    return CanonicalDecisionPresentationLoadV1(loaded=False, load_errors=load_errors)
+
+
+def _require_nonempty_str(payload: Mapping[str, Any], key: str) -> str | None:
+    raw = payload.get(key)
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return raw.strip()
+
+
+def _evidence_payload_from_envelope(
+    payload: Mapping[str, Any],
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    """Extract nested producer evidence; fail closed on ambiguity."""
+    if "evidence" not in payload:
+        return None, (LOAD_ERROR_EVIDENCE_INVALID,)
+    evidence = payload.get("evidence")
+    if not isinstance(evidence, Mapping):
+        return None, (LOAD_ERROR_EVIDENCE_INVALID,)
+    # Reject dual top-level + nested producer identity (ambiguous source shape).
+    top_level_decision_id = payload.get("decision_id")
+    nested_decision_id = evidence.get("decision_id")
+    if (
+        isinstance(top_level_decision_id, str)
+        and top_level_decision_id.strip()
+        and isinstance(nested_decision_id, str)
+        and nested_decision_id.strip()
+        and top_level_decision_id.strip() != nested_decision_id.strip()
+    ):
+        return None, (LOAD_ERROR_AMBIGUOUS,)
+    return evidence, ()
+
+
+def _validate_evidence_fields(
+    evidence: Mapping[str, Any],
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    missing = [key for key in _REQUIRED_EVIDENCE_KEYS if key not in evidence]
+    if missing:
+        return None, (LOAD_ERROR_EVIDENCE_INVALID,)
+
+    schema_version = _require_nonempty_str(evidence, "evidence_schema_version")
+    if schema_version != PRODUCER_EVIDENCE_SCHEMA_VERSION:
+        return None, (LOAD_ERROR_SCHEMA_MISMATCH,)
+
+    instrument_id = _require_nonempty_str(evidence, "instrument_id")
+    decision_outcome = _require_nonempty_str(evidence, "decision_outcome")
+    next_direction_state = _require_nonempty_str(evidence, "next_direction_state")
+    decision_id = _require_nonempty_str(evidence, "decision_id")
+    if not instrument_id or not decision_outcome or not next_direction_state or not decision_id:
+        return None, (LOAD_ERROR_EVIDENCE_INVALID,)
+
+    out: dict[str, Any] = {
+        "instrument_id": instrument_id,
+        "decision_outcome": decision_outcome,
+        "next_direction_state": next_direction_state,
+        "decision_id": decision_id,
+        "evidence_schema_version": schema_version,
+    }
+
+    raw_codes = evidence.get("reason_codes", ())
+    if raw_codes is None:
+        raw_codes = ()
+    if not isinstance(raw_codes, (list, tuple)):
+        return None, (LOAD_ERROR_EVIDENCE_INVALID,)
+    out["reason_codes"] = tuple(str(code) for code in raw_codes)
+
+    digest = evidence.get("semantic_digest")
+    if digest is None:
+        digest = evidence.get("evidence_digest")
+    if digest is not None:
+        if not isinstance(digest, str) or not digest.strip():
+            return None, (LOAD_ERROR_EVIDENCE_INVALID,)
+        out["semantic_digest"] = digest.strip()
+
+    return out, ()
+
+
+def map_canonical_decision_evidence_to_binder_fields_v1(
+    *,
+    evidence: Mapping[str, Any],
+    generated_at: str,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Map producer evidence fields → Landscape binder fields (projection only)."""
+    mapped, errors = _validate_evidence_fields(evidence)
+    if mapped is None:
+        return None, errors
+    if not isinstance(generated_at, str) or not generated_at.strip():
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+    mapped["generated_at"] = generated_at.strip()
+    if effective_at is not None:
+        if not isinstance(effective_at, str) or not effective_at.strip():
+            return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+        mapped["effective_at"] = effective_at.strip()
+    if source_reference is not None:
+        if not isinstance(source_reference, str):
+            return None, (LOAD_ERROR_EVIDENCE_INVALID,)
+        mapped["source_reference"] = source_reference
+    return mapped, ()
+
+
+def try_load_canonical_decision_presentation_projection_v1(
+    archive_root: str | Path,
+) -> CanonicalDecisionPresentationLoadV1:
+    """Verify-before-trust read of the sole durable decision presentation projection.
+
+    Returns loaded=False with load_errors on any fail-closed condition. Never
+    invents decision facts.
+    """
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    if not path.is_file():
+        return _empty(load_errors=(LOAD_ERROR_ABSENT,))
+
+    # Ambiguity guard: a second durable producer dump beside the projection is
+    # allowed only when identical decision_id; otherwise fail closed.
+    sibling = root / "readmodels" / "canonical_trading_decision_evidence.v1.json"
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    if not isinstance(payload, dict):
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    schema_name = payload.get("schema_name")
+    if schema_name != SCHEMA_NAME:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    authority = payload.get("authority_effect")
+    decision_authority = payload.get("decision_authority_effect")
+    if authority != AUTHORITY_EFFECT or decision_authority != DECISION_AUTHORITY_EFFECT:
+        return _empty(load_errors=(LOAD_ERROR_AUTHORITY_CLAIM,))
+
+    generated_at = _require_nonempty_str(payload, "generated_at")
+    if generated_at is None:
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+
+    effective_at = payload.get("effective_at")
+    if effective_at is not None and (not isinstance(effective_at, str) or not effective_at.strip()):
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+    effective_at_s = None if effective_at is None else str(effective_at).strip()
+
+    evidence, evidence_errors = _evidence_payload_from_envelope(payload)
+    if evidence is None:
+        return _empty(load_errors=evidence_errors)
+
+    source_reference = payload.get("source_reference")
+    if source_reference is None:
+        source_reference = f"presentation://{STORAGE_RELATIVE_PATH}"
+    elif not isinstance(source_reference, str):
+        return _empty(load_errors=(LOAD_ERROR_EVIDENCE_INVALID,))
+
+    binder_fields, map_errors = map_canonical_decision_evidence_to_binder_fields_v1(
+        evidence=evidence,
+        generated_at=generated_at,
+        effective_at=effective_at_s,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return _empty(load_errors=map_errors)
+
+    if sibling.is_file():
+        try:
+            sibling_payload = json.loads(sibling.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        if not isinstance(sibling_payload, dict):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        sibling_decision_id = sibling_payload.get("decision_id")
+        if (
+            not isinstance(sibling_decision_id, str)
+            or not sibling_decision_id.strip()
+            or sibling_decision_id.strip() != binder_fields["decision_id"]
+        ):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+
+    return CanonicalDecisionPresentationLoadV1(
+        loaded=True,
+        load_errors=(),
+        binder_fields=binder_fields,
+        source_path=str(path),
+        evidence_digest=(
+            None
+            if binder_fields.get("semantic_digest") is None
+            else str(binder_fields.get("semantic_digest"))
+        ),
+        decision_id=str(binder_fields["decision_id"]),
+    )

--- a/tests/webui/test_market_landscape_canonical_decision_presentation_autobind_v1.py
+++ b/tests/webui/test_market_landscape_canonical_decision_presentation_autobind_v1.py
@@ -1,0 +1,281 @@
+"""Focused tests: CAPABILITY_PRESENTATION_CANONICAL_DECISION_AUTOBIND_V1."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    DECISION_EVIDENCE_SCHEMA_VERSION,
+    DECISION_PRODUCER_MODULE,
+    DECISION_SOURCE_KIND,
+    REASON_DECISION_NOT_PERSISTED,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT
+from src.webui.workflow_dashboard_readmodel_v1.canonical_decision_presentation_projection_v1 import (
+    AUTHORITY_EFFECT,
+    DECISION_AUTHORITY_EFFECT,
+    LOAD_ERROR_ABSENT,
+    LOAD_ERROR_AMBIGUOUS,
+    LOAD_ERROR_AUTHORITY_CLAIM,
+    LOAD_ERROR_EVIDENCE_INVALID,
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    SCHEMA_NAME,
+    STORAGE_RELATIVE_PATH,
+    map_canonical_decision_evidence_to_binder_fields_v1,
+    try_load_canonical_decision_presentation_projection_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+STAMP = datetime(2026, 7, 24, 18, 0, 0, tzinfo=timezone.utc)
+PRODUCER_FRESH = "2026-07-24T17:30:00Z"
+
+
+def _evidence(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "instrument_id": "ETH-USDT-SWAP",
+        "decision_outcome": "observe",
+        "next_direction_state": "neutral_observe",
+        "decision_id": "decision-autobind-1",
+        "evidence_schema_version": DECISION_EVIDENCE_SCHEMA_VERSION,
+        "reason_codes": ("WARMUP_ACTIVE", "NO_ENTRY"),
+        "semantic_digest": "a" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def _projection_payload(
+    *,
+    evidence: dict[str, object] | None = None,
+    **overrides: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_name": SCHEMA_NAME,
+        "schema_version": 1,
+        "authority_effect": AUTHORITY_EFFECT,
+        "decision_authority_effect": DECISION_AUTHORITY_EFFECT,
+        "projection_role": "NON_AUTHORITATIVE_PRESENTATION_PROJECTION",
+        "generated_at": PRODUCER_FRESH,
+        "effective_at": PRODUCER_FRESH,
+        "source_reference": "presentation://canonical_decision_autobind_test",
+        "evidence": evidence if evidence is not None else _evidence(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_projection(archive_root: Path, payload: dict[str, object]) -> Path:
+    path = archive_root / STORAGE_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_map_evidence_to_binder_fields_preserves_producer_facts() -> None:
+    fields, errors = map_canonical_decision_evidence_to_binder_fields_v1(
+        evidence=_evidence(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://x",
+    )
+    assert errors == ()
+    assert fields is not None
+    assert fields["instrument_id"] == "ETH-USDT-SWAP"
+    assert fields["decision_outcome"] == "observe"
+    assert fields["next_direction_state"] == "neutral_observe"
+    assert fields["decision_id"] == "decision-autobind-1"
+    assert fields["semantic_digest"] == "a" * 64
+    assert fields["generated_at"] == PRODUCER_FRESH
+
+
+def test_load_absent_projection_is_missing(tmp_path: Path) -> None:
+    loaded = try_load_canonical_decision_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_ABSENT in loaded.load_errors
+    assert loaded.binder_fields is None
+
+
+def test_load_valid_projection_returns_binder_fields(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload())
+    loaded = try_load_canonical_decision_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.load_errors == ()
+    assert loaded.binder_fields is not None
+    assert loaded.decision_id == "decision-autobind-1"
+    assert loaded.evidence_digest == "a" * 64
+    assert STORAGE_RELATIVE_PATH in str(loaded.source_path)
+
+
+def test_load_schema_mismatch_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(schema_name="wrong.schema"))
+    loaded = try_load_canonical_decision_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_SCHEMA_MISMATCH in loaded.load_errors
+
+
+def test_load_authority_claim_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(authority_effect="DECISION"))
+    loaded = try_load_canonical_decision_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_AUTHORITY_CLAIM in loaded.load_errors
+
+
+def test_load_invalid_evidence_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(evidence={"instrument_id": "X"}))
+    loaded = try_load_canonical_decision_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_EVIDENCE_INVALID in loaded.load_errors
+
+
+def test_load_ambiguous_sibling_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload())
+    sibling = tmp_path / "readmodels" / "canonical_trading_decision_evidence.v1.json"
+    sibling.write_text(
+        json.dumps({"decision_id": "other-decision", "instrument_id": "ETH-USDT-SWAP"}) + "\n",
+        encoding="utf-8",
+    )
+    loaded = try_load_canonical_decision_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_AMBIGUOUS in loaded.load_errors
+
+
+def test_autobind_available_from_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    decision = slots["canonical_decision"]
+    assert decision.availability is Availability.AVAILABLE
+    assert decision.decision == "observe"
+    assert decision.direction == "neutral_observe"
+    assert decision.decision_id == "decision-autobind-1"
+    assert decision.provenance.producer_module == DECISION_PRODUCER_MODULE
+    assert decision.provenance.source_kind == DECISION_SOURCE_KIND
+    assert decision.provenance.source_reference == "presentation://canonical_decision_autobind_test"
+    assert decision.provenance.evidence_digest == "a" * 64
+    # Other injection-only slots remain unbound / missing.
+    assert slots["dynamic_scope"].availability is Availability.MISSING_SOURCE
+    assert slots["double_play"].availability is Availability.MISSING_SOURCE
+    assert slots["safety_authority"].availability is Availability.MISSING_SOURCE
+    assert slots["risk_sizing_capital"].availability is Availability.MISSING_SOURCE
+    assert slots["execution_reconciliation"].availability is Availability.MISSING_SOURCE
+    assert slots["economic_summary"].availability is Availability.MISSING_SOURCE
+    assert slots["regime_bull_bear_switch"].availability is Availability.MISSING_SOURCE
+
+
+def test_autobind_missing_projection_is_missing_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "empty_archive"
+    archive.mkdir()
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["canonical_decision"].availability is Availability.MISSING_SOURCE
+    assert REASON_DECISION_NOT_PERSISTED in slots["canonical_decision"].reason_codes
+
+
+def test_autobind_invalid_projection_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "bad_archive"
+    _write_projection(archive, _projection_payload(schema_name="nope"))
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["canonical_decision"].availability is Availability.INVALID
+    assert LOAD_ERROR_SCHEMA_MISMATCH in slots["canonical_decision"].reason_codes
+
+
+def test_explicit_injection_still_overrides_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        canonical_decision_fields={
+            "instrument_id": "BTC-USDT-SWAP",
+            "decision_outcome": "hold",
+            "next_direction_state": "flat",
+            "decision_id": "injected-decision",
+            "evidence_schema_version": DECISION_EVIDENCE_SCHEMA_VERSION,
+            "reason_codes": ("INJECTED",),
+            "semantic_digest": "b" * 64,
+            "generated_at": PRODUCER_FRESH,
+            "source_reference": "decision://bounded-test-injection",
+        },
+    )
+    decision = slots["canonical_decision"]
+    assert decision.availability is Availability.AVAILABLE
+    assert decision.decision == "hold"
+    assert decision.decision_id == "injected-decision"
+    assert decision.provenance.source_reference == "decision://bounded-test-injection"
+
+
+def test_get_market_autobinds_decision_without_injection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(
+        archive,
+        _projection_payload(
+            evidence=_evidence(
+                decision_outcome="observe",
+                reason_codes=("AUTOBIND_OK",),
+            )
+        ),
+    )
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "observe" in html
+    assert "AUTOBIND_OK" in html
+    assert 'data-mdl-region="CANONICAL_DECISION_STRIP"' in html
+    assert "<form" not in html.lower()
+    assert "place_order" not in html.lower()
+
+
+def test_projection_module_has_no_forbidden_trading_imports() -> None:
+    import ast
+
+    path = (
+        REPO
+        / "src/webui/workflow_dashboard_readmodel_v1/canonical_decision_presentation_projection_v1.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                continue
+            if node.module:
+                imported.add(node.module.split(".", 1)[0])
+    assert "trading" not in imported
+    assert "src" not in imported
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in {
+                "transition_state",
+                "compose_double_play_decision",
+                "KillSwitch",
+            }


### PR DESCRIPTION
## Summary
- Add non-authoritative durable presentation projection `canonical_decision_presentation_projection.v1` under the Workflow Dashboard archive root.
- Auto-bind `canonical_decision` in `bind_market_universe_slots` / `GET /market` from that projection when injection is absent; keep explicit injection for tests.
- Preserve fail-closed `MISSING_SOURCE` / invalid-source semantics; leave all other presentation slots unchanged.

## Authority / Non-claims
- `AUTHORITY_EFFECT=NONE`
- `TRADING_LOGIC_CHANGED=false`
- `CANONICAL_DECISION_SEMANTICS_CHANGED=false`
- `PRODUCER_CHANGED=false`
- `RUNTIME_TRADING_BEHAVIOR_CHANGED=false`
- `OTHER_PRESENTATION_SLOTS_CHANGED=false`

## Capability
`CAPABILITY_PRESENTATION_CANONICAL_DECISION_AUTOBIND_V1`

## Test plan
- [x] Focused autobind unit/integration tests (valid / missing / invalid / ambiguous / provenance / injection override / GET /market)
- [x] Existing producer-binding + architecture-guard suite (excluding pre-existing unrelated `presenter.py` stdlib-import drift)
- [x] Shell-route regression
- [x] Ruff format/check on touched files
- [x] PR-bounded FULL selector path timing proof (~52s wallclock)


Made with [Cursor](https://cursor.com)