### PR TITLE
feat(webui): autobind canonical double-play presentation

### DIFF
--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -3,9 +3,10 @@
 Binds market_instrument, universe_ranking, dynamic_scope lifecycle identity,
 regime_bull_bear_switch (explicit injection; PR #5577), canonical_decision
 evidence (injection or durable presentation projection auto-bind),
-double_play display projection, safety authority KillSwitch/boundary
-field projection, risk/sizing/capital field projection, execution/reconciliation
-field projection, and economic summary EconomicViabilityEvidenceV1 field
+double_play display projection (injection or durable presentation projection
+auto-bind), safety authority KillSwitch/boundary field projection,
+risk/sizing/capital field projection, execution/reconciliation field
+projection, and economic summary EconomicViabilityEvidenceV1 field
 projection.
 Lives outside market_dashboard_landscape_v2 so that package stays free of
 trading/webui producer imports (architecture guard).
@@ -70,6 +71,10 @@ from .workflow_dashboard_archive_root_v1 import (
 from .workflow_dashboard_readmodel_v1.canonical_decision_presentation_projection_v1 import (
     LOAD_ERROR_ABSENT as DECISION_PROJECTION_ABSENT,
     try_load_canonical_decision_presentation_projection_v1,
+)
+from .workflow_dashboard_readmodel_v1.double_play_presentation_projection_v1 import (
+    LOAD_ERROR_ABSENT as DOUBLE_PLAY_PROJECTION_ABSENT,
+    try_load_double_play_presentation_projection_v1,
 )
 from .workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
     FORBIDDEN_SELECTED_SYMBOLS,
@@ -1009,19 +1014,45 @@ def _bind_double_play_display(
     as_of: datetime,
     git_sha: str | None,
     double_play_fields: Mapping[str, Any] | None,
+    archive_root: Path | None = None,
 ) -> Any:
-    """Project injected DoublePlayDashboardDisplaySnapshot-compatible fields.
+    """Project DoublePlayDashboardDisplaySnapshot-compatible fields.
 
-    No durable dashboard Double Play readmodel. Without injection → MISSING_SOURCE.
-    Never calls compose_double_play_decision or build_dashboard_display_snapshot.
+    Injection remains supported for tests. Productive auto-bind loads the
+    non-authoritative presentation projection from the Workflow Dashboard
+    archive root when injection is absent. Never calls
+    compose_double_play_decision or build_dashboard_display_snapshot.
     Pending/Armed are not on the display snapshot — remain unbound elsewhere.
     """
     if double_play_fields is None:
-        return unavailable_double_play(
-            availability=Availability.MISSING_SOURCE,
-            generated_at=as_of,
-            reason=REASON_DOUBLE_PLAY_NOT_PERSISTED,
-        )
+        if archive_root is None:
+            return unavailable_double_play(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_DOUBLE_PLAY_NOT_PERSISTED,
+            )
+        loaded = try_load_double_play_presentation_projection_v1(archive_root)
+        if not loaded.loaded or loaded.binder_fields is None:
+            reason = REASON_DOUBLE_PLAY_NOT_PERSISTED
+            if loaded.load_errors:
+                first = str(loaded.load_errors[0])
+                if first != DOUBLE_PLAY_PROJECTION_ABSENT:
+                    reason = first
+            availability = (
+                Availability.MISSING_SOURCE
+                if reason == REASON_DOUBLE_PLAY_NOT_PERSISTED
+                or reason == DOUBLE_PLAY_PROJECTION_ABSENT
+                else Availability.INVALID
+            )
+            if reason == DOUBLE_PLAY_PROJECTION_ABSENT:
+                reason = REASON_DOUBLE_PLAY_NOT_PERSISTED
+                availability = Availability.MISSING_SOURCE
+            return unavailable_double_play(
+                availability=availability,
+                generated_at=as_of,
+                reason=reason,
+            )
+        double_play_fields = loaded.binder_fields
 
     if "overall_status" not in double_play_fields:
         raise KeyError("double_play_fields missing required keys: ['overall_status']")
@@ -1861,8 +1892,10 @@ def bind_market_universe_slots(
 
     double_play_fields accepts already-computed
     DoublePlayDashboardDisplaySnapshot-compatible fields plus producer
-    wall-clock timestamps. Without injection, double_play is MISSING_SOURCE.
-    Never calls compose/build Double Play owners.
+    wall-clock timestamps. Without injection, double_play auto-binds from the
+    durable non-authoritative presentation projection under the archive root;
+    absent/invalid projection → MISSING_SOURCE / INVALID. Never calls
+    compose/build Double Play owners.
 
     safety_authority_fields accepts already-computed KillSwitch / boundary-
     compatible fields (kill_switch_state, veto_active, reason_codes) plus
@@ -1915,6 +1948,7 @@ def bind_market_universe_slots(
         as_of=as_of,
         git_sha=git_sha,
         double_play_fields=double_play_fields,
+        archive_root=root,
     )
     safety = _bind_safety_authority(
         as_of=as_of,

--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -10,7 +10,8 @@ Phase 4.2B binds regime_bull_bear_switch fail-closed (explicit injection only;
 PR #5577 — no transition_state calls).
 Phase 4.3A binds canonical_decision fail-closed (injection or durable
 presentation projection auto-bind; AUTHORITY_EFFECT=NONE).
-Phase 4.3B binds double_play display fail-closed (injection only).
+Phase 4.3B binds double_play display fail-closed (injection or durable
+presentation projection auto-bind; AUTHORITY_EFFECT=NONE).
 OHLCV binds from materialized okx_selected_instrument_ohlcv_readmodel.v1 only.
 CAPABILITY_O4: that readmodel is DERIVED (HTTP_JSON_POLL); authoritative bars are
 owned by CanonicalPublicMdBarProducerV1 — no independent authoritative recomputation.

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -97,10 +97,14 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
         authority_class="double_play",
         reuse_status="REUSED",
         notes=(
-            "Phase 4.3B: Landscape projects DoublePlayDashboardDisplaySnapshot "
+            "Phase 4.3B + CAPABILITY_PRESENTATION_DOUBLE_PLAY_AUTOBIND_V1: "
+            "Landscape projects DoublePlayDashboardDisplaySnapshot "
             "field-for-field (overall_status/panel_summaries/blockers); "
             "display_only=True; live_authorization=False; no compose/build calls; "
-            "pending/armed remain unbound (not on display snapshot)."
+            "pending/armed remain unbound (not on display snapshot). "
+            "Durable auto-bind via non-authoritative "
+            "double_play_presentation_projection.v1 under archive root; "
+            "injection remains test-compatible; AUTHORITY_EFFECT=NONE."
         ),
     ),
     CanonicalOwnerRefV1(

--- a/src/webui/workflow_dashboard_archive_root_v1.py
+++ b/src/webui/workflow_dashboard_archive_root_v1.py
@@ -5,7 +5,8 @@ Does not create directories, does not write readmodels, and does not authorize
 trading. GET /market consumers may resolve this root (explicit → Env →
 canonical default → discovered governed OKX sibling) to read-only-load
 universe_selection_readmodel.v1 and okx_selected_instrument_ohlcv_readmodel.v1,
-and (when present) canonical_decision_presentation_projection.v1.
+and (when present) canonical_decision_presentation_projection.v1 and
+double_play_presentation_projection.v1.
 """
 
 from __future__ import annotations
@@ -42,6 +43,9 @@ UNIVERSE_SELECTION_READMODEL_RELATIVE = "readmodels/universe_selection_readmodel
 OKX_OHLCV_READMODEL_RELATIVE = "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
 CANONICAL_DECISION_PRESENTATION_PROJECTION_RELATIVE = (
     "readmodels/canonical_decision_presentation_projection.v1.json"
+)
+DOUBLE_PLAY_PRESENTATION_PROJECTION_RELATIVE = (
+    "readmodels/double_play_presentation_projection.v1.json"
 )
 _DISCOVER_NAME_PREFIX = "workflow_dashboard_v1"
 

--- a/src/webui/workflow_dashboard_readmodel_v1/double_play_presentation_projection_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/double_play_presentation_projection_v1.py
@@ -1,0 +1,269 @@
+"""Non-authoritative presentation projection for Double Play display.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_DOUBLE_PLAY_AUTOBIND_V1
+
+Reads already-produced DoublePlayDashboardDisplaySnapshot-compatible field
+payloads from a single durable archive path and maps them field-for-field into
+Landscape binder injection fields. This module:
+
+- AUTHORITY_EFFECT=NONE
+- DOUBLE_PLAY_AUTHORITY_EFFECT=NONE
+- never creates, mutates, or evaluates Double Play decisions
+- never imports trading.master_v2 Double Play composers or display builders
+- never calls compose_double_play_decision / build_dashboard_display_snapshot /
+  transition_state / KillSwitch / risk / sizing
+- fail-closed: missing, invalid, or ambiguous sources → no fields (MISSING_SOURCE)
+
+Deterministic source selection: exactly one well-known relative path under the
+Workflow Dashboard archive root. No silent multi-candidate "latest" picking.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_NAME = "double_play_presentation_projection.v1"
+SCHEMA_VERSION = 1
+STORAGE_RELATIVE_PATH = "readmodels/double_play_presentation_projection.v1.json"
+AUTHORITY_EFFECT = "NONE"
+DOUBLE_PLAY_AUTHORITY_EFFECT = "NONE"
+PROJECTION_ROLE = "NON_AUTHORITATIVE_PRESENTATION_PROJECTION"
+OWNER_MODULE = "webui.workflow_dashboard_readmodel_v1.double_play_presentation_projection_v1"
+
+LOAD_ERROR_ABSENT = "DOUBLE_PLAY_PRESENTATION_PROJECTION_ABSENT"
+LOAD_ERROR_INVALID_JSON = "DOUBLE_PLAY_PRESENTATION_PROJECTION_INVALID_JSON"
+LOAD_ERROR_SCHEMA_MISMATCH = "DOUBLE_PLAY_PRESENTATION_PROJECTION_SCHEMA_MISMATCH"
+LOAD_ERROR_AUTHORITY_CLAIM = "DOUBLE_PLAY_PRESENTATION_PROJECTION_AUTHORITY_CLAIM"
+LOAD_ERROR_DISPLAY_INVALID = "DOUBLE_PLAY_PRESENTATION_PROJECTION_DISPLAY_INVALID"
+LOAD_ERROR_AMBIGUOUS = "DOUBLE_PLAY_PRESENTATION_PROJECTION_AMBIGUOUS_SOURCE"
+LOAD_ERROR_TIMESTAMP_MISSING = "DOUBLE_PLAY_PRESENTATION_PROJECTION_TIMESTAMP_MISSING"
+
+_REQUIRED_DISPLAY_KEYS = (
+    "overall_status",
+    "panel_summaries",
+)
+
+
+@dataclass(frozen=True)
+class DoublePlayPresentationLoadV1:
+    """Result of a fail-closed presentation projection load attempt."""
+
+    loaded: bool
+    load_errors: tuple[str, ...]
+    binder_fields: Mapping[str, Any] | None = None
+    source_path: str | None = None
+    evidence_digest: str | None = None
+    overall_status: str | None = None
+
+
+def _empty(*, load_errors: tuple[str, ...]) -> DoublePlayPresentationLoadV1:
+    return DoublePlayPresentationLoadV1(loaded=False, load_errors=load_errors)
+
+
+def _require_nonempty_str(payload: Mapping[str, Any], key: str) -> str | None:
+    raw = payload.get(key)
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return raw.strip()
+
+
+def _display_payload_from_envelope(
+    payload: Mapping[str, Any],
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    """Extract nested display snapshot fields; fail closed on ambiguity."""
+    if "display" not in payload:
+        return None, (LOAD_ERROR_DISPLAY_INVALID,)
+    display = payload.get("display")
+    if not isinstance(display, Mapping):
+        return None, (LOAD_ERROR_DISPLAY_INVALID,)
+    # Reject dual top-level + nested overall_status with conflicting values.
+    top_level_status = payload.get("overall_status")
+    nested_status = display.get("overall_status")
+    if (
+        isinstance(top_level_status, str)
+        and top_level_status.strip()
+        and isinstance(nested_status, str)
+        and nested_status.strip()
+        and top_level_status.strip() != nested_status.strip()
+    ):
+        return None, (LOAD_ERROR_AMBIGUOUS,)
+    return display, ()
+
+
+def _validate_display_fields(
+    display: Mapping[str, Any],
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    missing = [key for key in _REQUIRED_DISPLAY_KEYS if key not in display]
+    if missing:
+        return None, (LOAD_ERROR_DISPLAY_INVALID,)
+
+    overall_status = _require_nonempty_str(display, "overall_status")
+    if overall_status is None:
+        return None, (LOAD_ERROR_DISPLAY_INVALID,)
+
+    raw_panels = display.get("panel_summaries")
+    if isinstance(raw_panels, Mapping):
+        return None, (LOAD_ERROR_DISPLAY_INVALID,)
+    try:
+        panel_summaries = tuple(dict(row) for row in (raw_panels or ()))
+    except (TypeError, ValueError):
+        return None, (LOAD_ERROR_DISPLAY_INVALID,)
+
+    out: dict[str, Any] = {
+        "overall_status": overall_status,
+        "panel_summaries": panel_summaries,
+    }
+
+    display_only = display.get("display_only", True)
+    if display_only is not True:
+        return None, (LOAD_ERROR_DISPLAY_INVALID,)
+    out["display_only"] = True
+
+    live_authorization = display.get("live_authorization", False)
+    if live_authorization is not False:
+        return None, (LOAD_ERROR_DISPLAY_INVALID,)
+    out["live_authorization"] = False
+
+    raw_blockers = display.get("blockers", ()) or ()
+    if not isinstance(raw_blockers, (list, tuple)):
+        return None, (LOAD_ERROR_DISPLAY_INVALID,)
+    out["blockers"] = tuple(str(code) for code in raw_blockers)
+
+    digest = display.get("evidence_digest")
+    if digest is not None:
+        if not isinstance(digest, str) or not digest.strip():
+            return None, (LOAD_ERROR_DISPLAY_INVALID,)
+        out["evidence_digest"] = digest.strip()
+
+    return out, ()
+
+
+def map_double_play_display_to_binder_fields_v1(
+    *,
+    display: Mapping[str, Any],
+    generated_at: str,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Map display snapshot fields → Landscape binder fields (projection only)."""
+    mapped, errors = _validate_display_fields(display)
+    if mapped is None:
+        return None, errors
+    if not isinstance(generated_at, str) or not generated_at.strip():
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+    mapped["generated_at"] = generated_at.strip()
+    if effective_at is not None:
+        if not isinstance(effective_at, str) or not effective_at.strip():
+            return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+        mapped["effective_at"] = effective_at.strip()
+    if source_reference is not None:
+        if not isinstance(source_reference, str):
+            return None, (LOAD_ERROR_DISPLAY_INVALID,)
+        mapped["source_reference"] = source_reference
+    return mapped, ()
+
+
+def try_load_double_play_presentation_projection_v1(
+    archive_root: str | Path,
+) -> DoublePlayPresentationLoadV1:
+    """Verify-before-trust read of the sole durable Double Play presentation projection.
+
+    Returns loaded=False with load_errors on any fail-closed condition. Never
+    invents Double Play display facts.
+    """
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    if not path.is_file():
+        return _empty(load_errors=(LOAD_ERROR_ABSENT,))
+
+    # Ambiguity guard: a second durable producer dump beside the projection is
+    # allowed only when identical evidence_digest (when both present);
+    # otherwise fail closed.
+    sibling = root / "readmodels" / "double_play_dashboard_display.v1.json"
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    if not isinstance(payload, dict):
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    schema_name = payload.get("schema_name")
+    if schema_name != SCHEMA_NAME:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    authority = payload.get("authority_effect")
+    double_play_authority = payload.get("double_play_authority_effect")
+    if authority != AUTHORITY_EFFECT or double_play_authority != DOUBLE_PLAY_AUTHORITY_EFFECT:
+        return _empty(load_errors=(LOAD_ERROR_AUTHORITY_CLAIM,))
+
+    generated_at = _require_nonempty_str(payload, "generated_at")
+    if generated_at is None:
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+
+    effective_at = payload.get("effective_at")
+    if effective_at is not None and (not isinstance(effective_at, str) or not effective_at.strip()):
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+    effective_at_s = None if effective_at is None else str(effective_at).strip()
+
+    display, display_errors = _display_payload_from_envelope(payload)
+    if display is None:
+        return _empty(load_errors=display_errors)
+
+    source_reference = payload.get("source_reference")
+    if source_reference is None:
+        source_reference = f"presentation://{STORAGE_RELATIVE_PATH}"
+    elif not isinstance(source_reference, str):
+        return _empty(load_errors=(LOAD_ERROR_DISPLAY_INVALID,))
+
+    binder_fields, map_errors = map_double_play_display_to_binder_fields_v1(
+        display=display,
+        generated_at=generated_at,
+        effective_at=effective_at_s,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return _empty(load_errors=map_errors)
+
+    if sibling.is_file():
+        try:
+            sibling_payload = json.loads(sibling.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        if not isinstance(sibling_payload, dict):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        sibling_digest = sibling_payload.get("evidence_digest")
+        projection_digest = binder_fields.get("evidence_digest")
+        if (
+            not isinstance(sibling_digest, str)
+            or not sibling_digest.strip()
+            or not isinstance(projection_digest, str)
+            or not projection_digest.strip()
+            or sibling_digest.strip() != projection_digest.strip()
+        ):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+
+    return DoublePlayPresentationLoadV1(
+        loaded=True,
+        load_errors=(),
+        binder_fields=binder_fields,
+        source_path=str(path),
+        evidence_digest=(
+            None
+            if binder_fields.get("evidence_digest") is None
+            else str(binder_fields.get("evidence_digest"))
+        ),
+        overall_status=str(binder_fields["overall_status"]),
+    )

--- a/tests/webui/test_market_landscape_double_play_presentation_autobind_v1.py
+++ b/tests/webui/test_market_landscape_double_play_presentation_autobind_v1.py
@@ -1,0 +1,303 @@
+"""Focused tests: CAPABILITY_PRESENTATION_DOUBLE_PLAY_AUTOBIND_V1."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    DOUBLE_PLAY_PRODUCER_MODULE,
+    DOUBLE_PLAY_SOURCE_KIND,
+    REASON_DOUBLE_PLAY_NOT_PERSISTED,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT
+from src.webui.workflow_dashboard_readmodel_v1.double_play_presentation_projection_v1 import (
+    AUTHORITY_EFFECT,
+    DOUBLE_PLAY_AUTHORITY_EFFECT,
+    LOAD_ERROR_ABSENT,
+    LOAD_ERROR_AMBIGUOUS,
+    LOAD_ERROR_AUTHORITY_CLAIM,
+    LOAD_ERROR_DISPLAY_INVALID,
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    SCHEMA_NAME,
+    STORAGE_RELATIVE_PATH,
+    map_double_play_display_to_binder_fields_v1,
+    try_load_double_play_presentation_projection_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+STAMP = datetime(2026, 7, 24, 18, 0, 0, tzinfo=timezone.utc)
+PRODUCER_FRESH = "2026-07-24T17:30:00Z"
+
+
+def _display(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "overall_status": "display_ready",
+        "panel_summaries": (
+            {
+                "name": "composition",
+                "status": "display_ready",
+                "summary": "Composition: ELIGIBLE_MODEL_ONLY — data-only; not trading-ready.",
+                "blockers": (),
+            },
+            {
+                "name": "state_transition",
+                "status": "display_ready",
+                "summary": "Transition allowed (model label): NOOP",
+                "blockers": (),
+            },
+        ),
+        "blockers": (),
+        "display_only": True,
+        "live_authorization": False,
+        "evidence_digest": "d" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def _projection_payload(
+    *,
+    display: dict[str, object] | None = None,
+    **overrides: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_name": SCHEMA_NAME,
+        "schema_version": 1,
+        "authority_effect": AUTHORITY_EFFECT,
+        "double_play_authority_effect": DOUBLE_PLAY_AUTHORITY_EFFECT,
+        "projection_role": "NON_AUTHORITATIVE_PRESENTATION_PROJECTION",
+        "generated_at": PRODUCER_FRESH,
+        "effective_at": PRODUCER_FRESH,
+        "source_reference": "presentation://double_play_autobind_test",
+        "display": display if display is not None else _display(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_projection(archive_root: Path, payload: dict[str, object]) -> Path:
+    path = archive_root / STORAGE_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_map_display_to_binder_fields_preserves_producer_facts() -> None:
+    fields, errors = map_double_play_display_to_binder_fields_v1(
+        display=_display(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://x",
+    )
+    assert errors == ()
+    assert fields is not None
+    assert fields["overall_status"] == "display_ready"
+    assert fields["panel_summaries"][0]["name"] == "composition"
+    assert fields["display_only"] is True
+    assert fields["live_authorization"] is False
+    assert fields["evidence_digest"] == "d" * 64
+    assert fields["generated_at"] == PRODUCER_FRESH
+
+
+def test_load_absent_projection_is_missing(tmp_path: Path) -> None:
+    loaded = try_load_double_play_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_ABSENT in loaded.load_errors
+    assert loaded.binder_fields is None
+
+
+def test_load_valid_projection_returns_binder_fields(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload())
+    loaded = try_load_double_play_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.load_errors == ()
+    assert loaded.binder_fields is not None
+    assert loaded.overall_status == "display_ready"
+    assert loaded.evidence_digest == "d" * 64
+    assert STORAGE_RELATIVE_PATH in str(loaded.source_path)
+
+
+def test_load_schema_mismatch_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(schema_name="wrong.schema"))
+    loaded = try_load_double_play_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_SCHEMA_MISMATCH in loaded.load_errors
+
+
+def test_load_authority_claim_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(authority_effect="DECISION"))
+    loaded = try_load_double_play_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_AUTHORITY_CLAIM in loaded.load_errors
+
+
+def test_load_invalid_display_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(display={"overall_status": "x"}))
+    loaded = try_load_double_play_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_DISPLAY_INVALID in loaded.load_errors
+
+
+def test_load_ambiguous_sibling_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload())
+    sibling = tmp_path / "readmodels" / "double_play_dashboard_display.v1.json"
+    sibling.write_text(
+        json.dumps({"evidence_digest": "e" * 64, "overall_status": "display_ready"}) + "\n",
+        encoding="utf-8",
+    )
+    loaded = try_load_double_play_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_AMBIGUOUS in loaded.load_errors
+
+
+def test_autobind_available_from_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    dp = slots["double_play"]
+    assert dp.availability is Availability.AVAILABLE
+    assert dp.overall_status == "display_ready"
+    assert dp.panel_summaries[0]["name"] == "composition"
+    assert dp.display_only is True
+    assert dp.live_authorization is False
+    assert dp.provenance.producer_module == DOUBLE_PLAY_PRODUCER_MODULE
+    assert dp.provenance.source_kind == DOUBLE_PLAY_SOURCE_KIND
+    assert dp.provenance.source_reference == "presentation://double_play_autobind_test"
+    assert dp.provenance.evidence_digest == "d" * 64
+    # Other injection-only slots remain unbound / missing.
+    assert slots["dynamic_scope"].availability is Availability.MISSING_SOURCE
+    assert slots["canonical_decision"].availability is Availability.MISSING_SOURCE
+    assert slots["safety_authority"].availability is Availability.MISSING_SOURCE
+    assert slots["risk_sizing_capital"].availability is Availability.MISSING_SOURCE
+    assert slots["execution_reconciliation"].availability is Availability.MISSING_SOURCE
+    assert slots["economic_summary"].availability is Availability.MISSING_SOURCE
+    assert slots["regime_bull_bear_switch"].availability is Availability.MISSING_SOURCE
+
+
+def test_autobind_missing_projection_is_missing_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "empty_archive"
+    archive.mkdir()
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["double_play"].availability is Availability.MISSING_SOURCE
+    assert REASON_DOUBLE_PLAY_NOT_PERSISTED in slots["double_play"].blockers
+
+
+def test_autobind_invalid_projection_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "bad_archive"
+    _write_projection(archive, _projection_payload(schema_name="nope"))
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["double_play"].availability is Availability.INVALID
+    assert LOAD_ERROR_SCHEMA_MISMATCH in slots["double_play"].blockers
+
+
+def test_explicit_injection_still_overrides_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        double_play_fields={
+            "overall_status": "display_warning",
+            "panel_summaries": (
+                {
+                    "name": "composition",
+                    "status": "display_warning",
+                    "summary": "Injected warning panel",
+                    "blockers": ("INJECTED",),
+                },
+            ),
+            "blockers": ("INJECTED",),
+            "display_only": True,
+            "live_authorization": False,
+            "evidence_digest": "b" * 64,
+            "generated_at": PRODUCER_FRESH,
+            "source_reference": "double-play://bounded-test-injection",
+        },
+    )
+    dp = slots["double_play"]
+    assert dp.availability is Availability.AVAILABLE
+    assert dp.overall_status == "display_warning"
+    assert dp.blockers == ("INJECTED",)
+    assert dp.provenance.source_reference == "double-play://bounded-test-injection"
+
+
+def test_get_market_autobinds_double_play_without_injection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    # Wall-clock GET /market uses datetime.now(UTC); keep producer fresh.
+    fresh = datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+    _write_projection(
+        archive,
+        _projection_payload(
+            generated_at=fresh,
+            effective_at=fresh,
+            display=_display(
+                overall_status="display_ready",
+                blockers=("AUTOBIND_DP_OK",),
+            ),
+        ),
+    )
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "display_ready" in html
+    assert 'data-mdl-field="double_play"' in html
+    assert 'data-mdl-field="double_play" data-availability="AVAILABLE"' in html
+    assert "<form" not in html.lower()
+    assert "place_order" not in html.lower()
+
+
+def test_projection_module_has_no_forbidden_trading_imports() -> None:
+    import ast
+
+    path = (
+        REPO / "src/webui/workflow_dashboard_readmodel_v1/double_play_presentation_projection_v1.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                continue
+            if node.module:
+                imported.add(node.module.split(".", 1)[0])
+    assert "trading" not in imported
+    assert "src" not in imported
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in {
+                "transition_state",
+                "compose_double_play_decision",
+                "build_dashboard_display_snapshot",
+                "KillSwitch",
+            }


### PR DESCRIPTION
## Summary
- Add non-authoritative durable presentation projection `double_play_presentation_projection.v1` under the Workflow Dashboard archive root.
- Auto-bind `double_play` in `bind_market_universe_slots` / `GET /market` from that projection when injection is absent; keep explicit injection for tests.
- Preserve fail-closed `MISSING_SOURCE` / invalid-source semantics; leave all other presentation slots unchanged.

## Authority / Non-claims
- `AUTHORITY_EFFECT=NONE`
- `TRADING_LOGIC_CHANGED=false`
- `DOUBLE_PLAY_SEMANTICS_CHANGED=false`
- `PRODUCER_CHANGED=false`
- `CANONICAL_READ_MODELS_CHANGED=false`
- `RUNTIME_TRADING_BEHAVIOR_CHANGED=false`

## Capability
`CAPABILITY_PRESENTATION_DOUBLE_PLAY_AUTOBIND_V1`

## Test plan
- [x] Focused autobind unit/integration tests (valid / missing / invalid / ambiguous / provenance / injection override / GET /market)
- [x] Existing producer-binding double_play suite + architecture guards (excluding pre-existing unrelated `presenter.py` stdlib-import drift)
- [x] Shell-route regression + canonical decision autobind non-regression
- [x] Ruff format/check on touched files
- [x] PR-bounded FULL selector path timing proof (~39s wallclock)

Made with [Cursor](https://cursor.com)