### PR TITLE
feat(webui): materialize bull/bear regime presentation projection

### DIFF
--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -1,7 +1,8 @@
 """Phase 4.1–4.5 + 4.2B + 4.6B read-only producer binding for Market Landscape V2.
 
 Binds market_instrument, universe_ranking, dynamic_scope lifecycle identity,
-regime_bull_bear_switch (explicit injection; PR #5577), canonical_decision
+regime_bull_bear_switch (injection or durable presentation projection
+auto-bind; PR #5577 field contract), canonical_decision
 evidence (injection or durable presentation projection auto-bind),
 double_play display projection (injection or durable presentation projection
 auto-bind), safety authority KillSwitch/boundary field projection,
@@ -71,6 +72,10 @@ from .workflow_dashboard_archive_root_v1 import (
 from .workflow_dashboard_readmodel_v1.canonical_decision_presentation_projection_v1 import (
     LOAD_ERROR_ABSENT as DECISION_PROJECTION_ABSENT,
     try_load_canonical_decision_presentation_projection_v1,
+)
+from .workflow_dashboard_readmodel_v1.bull_bear_regime_presentation_projection_v1 import (
+    LOAD_ERROR_ABSENT as BULL_BEAR_REGIME_PROJECTION_ABSENT,
+    try_load_bull_bear_regime_presentation_projection_v1,
 )
 from .workflow_dashboard_readmodel_v1.double_play_presentation_projection_v1 import (
     LOAD_ERROR_ABSENT as DOUBLE_PLAY_PROJECTION_ABSENT,
@@ -675,18 +680,44 @@ def _bind_regime_bull_bear_switch(
     as_of: datetime,
     git_sha: str | None,
     regime_bull_bear_switch_fields: Mapping[str, Any] | None,
+    archive_root: Path | None = None,
 ) -> Any:
-    """Project injected Regime / SideState / Switch evidence fields.
+    """Project Regime / SideState / Switch evidence fields.
 
-    No durable dashboard readmodel. Without injection → MISSING_SOURCE.
-    Never calls transition_state, suitability evaluators, or invents SideState.
+    Injection remains supported for tests. Productive auto-bind loads the
+    non-authoritative presentation projection from the Workflow Dashboard
+    archive root when injection is absent. Never calls transition_state,
+    suitability evaluators, or invents SideState.
     """
     if regime_bull_bear_switch_fields is None:
-        return unavailable_regime_bull_bear_switch(
-            availability=Availability.MISSING_SOURCE,
-            generated_at=as_of,
-            reason=REASON_REGIME_BULL_BEAR_SWITCH_NOT_PERSISTED,
-        )
+        if archive_root is None:
+            return unavailable_regime_bull_bear_switch(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_REGIME_BULL_BEAR_SWITCH_NOT_PERSISTED,
+            )
+        loaded = try_load_bull_bear_regime_presentation_projection_v1(archive_root)
+        if not loaded.loaded or loaded.binder_fields is None:
+            reason = REASON_REGIME_BULL_BEAR_SWITCH_NOT_PERSISTED
+            if loaded.load_errors:
+                first = str(loaded.load_errors[0])
+                if first != BULL_BEAR_REGIME_PROJECTION_ABSENT:
+                    reason = first
+            availability = (
+                Availability.MISSING_SOURCE
+                if reason == REASON_REGIME_BULL_BEAR_SWITCH_NOT_PERSISTED
+                or reason == BULL_BEAR_REGIME_PROJECTION_ABSENT
+                else Availability.INVALID
+            )
+            if reason == BULL_BEAR_REGIME_PROJECTION_ABSENT:
+                reason = REASON_REGIME_BULL_BEAR_SWITCH_NOT_PERSISTED
+                availability = Availability.MISSING_SOURCE
+            return unavailable_regime_bull_bear_switch(
+                availability=availability,
+                generated_at=as_of,
+                reason=reason,
+            )
+        regime_bull_bear_switch_fields = loaded.binder_fields
 
     schema_version = regime_bull_bear_switch_fields.get("schema_version")
     if schema_version is not None and str(schema_version) != LANDSCAPE_PROJECTION_SCHEMA_VERSION:
@@ -1881,7 +1912,8 @@ def bind_market_universe_slots(
 
     regime_bull_bear_switch_fields accepts already-computed Regime /
     SideState / StateSwitchEvidenceV1-compatible fields plus producer
-    wall-clock timestamps. Without injection, regime_bull_bear_switch is
+    wall-clock timestamps. Without injection, productive auto-bind loads
+    bull_bear_regime_presentation_projection.v1 when present; otherwise
     MISSING_SOURCE. Never calls transition_state or invents SideState.
 
     canonical_decision_fields accepts already-computed
@@ -1937,6 +1969,7 @@ def bind_market_universe_slots(
         as_of=as_of,
         git_sha=git_sha,
         regime_bull_bear_switch_fields=regime_bull_bear_switch_fields,
+        archive_root=root,
     )
     decision = _bind_canonical_decision(
         as_of=as_of,

--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -6,8 +6,9 @@ Phase 4.1 binds market_instrument / universe_ranking fail-closed from the
 canonical Workflow Dashboard archive root (explicit → Env → platform default)
 via universe_selection_readmodel.v1 — no Env required when the default exists.
 Phase 4.2 binds dynamic_scope lifecycle identity fail-closed (injection only).
-Phase 4.2B binds regime_bull_bear_switch fail-closed (explicit injection only;
-PR #5577 — no transition_state calls).
+Phase 4.2B binds regime_bull_bear_switch fail-closed (injection or durable
+presentation projection auto-bind; PR #5577 field contract — no transition_state
+calls; AUTHORITY_EFFECT=NONE).
 Phase 4.3A binds canonical_decision fail-closed (injection or durable
 presentation projection auto-bind; AUTHORITY_EFFECT=NONE).
 Phase 4.3B binds double_play display fail-closed (injection or durable

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -64,13 +64,17 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
         authority_class="regime_bull_bear_switch",
         reuse_status="REUSED",
         notes=(
-            "Explicit injection only. Regime fields project from "
+            "Phase 4.2B + CAPABILITY_PRESENTATION_BULL_BEAR_REGIME_PROJECTION_"
+            "MATERIALIZER_V1: Regime fields project from "
             "suitability_binding_v1 (regime_id/regime_status). Bull/Bear "
             "projects SideState exactly. Switch projects "
             "StateSwitchEvidenceV1 / TransitionDecision fields "
             "(previous/next side, scope_event_type, transition_allowed, "
             "transition_reason_code). No transition_state calls; no "
-            "SideState derivation; contradictory side fields fail closed."
+            "SideState derivation; contradictory side fields fail closed. "
+            "Durable auto-bind via non-authoritative "
+            "bull_bear_regime_presentation_projection.v1 under archive root; "
+            "injection remains test-compatible; AUTHORITY_EFFECT=NONE."
         ),
     ),
     CanonicalOwnerRefV1(

--- a/src/webui/workflow_dashboard_archive_root_v1.py
+++ b/src/webui/workflow_dashboard_archive_root_v1.py
@@ -5,8 +5,9 @@ Does not create directories, does not write readmodels, and does not authorize
 trading. GET /market consumers may resolve this root (explicit → Env →
 canonical default → discovered governed OKX sibling) to read-only-load
 universe_selection_readmodel.v1 and okx_selected_instrument_ohlcv_readmodel.v1,
-and (when present) canonical_decision_presentation_projection.v1 and
-double_play_presentation_projection.v1.
+and (when present) canonical_decision_presentation_projection.v1,
+double_play_presentation_projection.v1, and
+bull_bear_regime_presentation_projection.v1.
 """
 
 from __future__ import annotations
@@ -46,6 +47,9 @@ CANONICAL_DECISION_PRESENTATION_PROJECTION_RELATIVE = (
 )
 DOUBLE_PLAY_PRESENTATION_PROJECTION_RELATIVE = (
     "readmodels/double_play_presentation_projection.v1.json"
+)
+BULL_BEAR_REGIME_PRESENTATION_PROJECTION_RELATIVE = (
+    "readmodels/bull_bear_regime_presentation_projection.v1.json"
 )
 _DISCOVER_NAME_PREFIX = "workflow_dashboard_v1"
 

--- a/src/webui/workflow_dashboard_readmodel_v1/bull_bear_regime_presentation_projection_materializer_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/bull_bear_regime_presentation_projection_materializer_v1.py
@@ -1,0 +1,438 @@
+"""Non-authoritative materializer for Bull/Bear Regime presentation projection.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_BULL_BEAR_REGIME_PROJECTION_MATERIALIZER_V1
+
+Consumes already-produced regime_bull_bear_switch field payloads (PR #5577
+Landscape binder contract / durable sibling dump under the Workflow Dashboard
+archive root) and writes the non-authoritative presentation projection schema
+to the loader-owned path. This module:
+
+- AUTHORITY_EFFECT=NONE
+- BULL_BEAR_AUTHORITY_EFFECT=NONE
+- never creates, mutates, or evaluates SideState / regime / switch decisions
+- never imports trading.master_v2 producers or evaluators
+- never calls transition_state / compose_double_play_decision /
+  build_dashboard_display_snapshot / KillSwitch / risk / sizing
+- never invents regime facts, timestamps, or default field values beyond the
+  already-ratified projection mapping
+- never treats double_play_dashboard_display_json_route_v0 as a source
+  (explicitly NON_SOURCE / not landscape bull-bear truth)
+- fail-closed: missing source → MISSING_SOURCE and no artifact write;
+  invalid source → FAIL_CLOSED and no artifact write
+- projection remains non-authoritative and must never flow back into runtime
+  or authority chains
+
+Deterministic serialization and atomic replace only. This projection path does
+not own a separate MANIFEST contract; integrity follows the existing loader
+schema/authority/regime checks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from .bull_bear_regime_presentation_projection_v1 import (
+    AUTHORITY_EFFECT,
+    BULL_BEAR_AUTHORITY_EFFECT,
+    LOAD_ERROR_REGIME_INVALID,
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    LOAD_ERROR_TIMESTAMP_MISSING,
+    PROJECTION_ROLE,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    STORAGE_RELATIVE_PATH,
+    map_regime_bull_bear_switch_to_binder_fields_v1,
+)
+
+CAPABILITY_ID = "CAPABILITY_PRESENTATION_BULL_BEAR_REGIME_PROJECTION_MATERIALIZER_V1"
+OWNER_MODULE = (
+    "webui.workflow_dashboard_readmodel_v1.bull_bear_regime_presentation_projection_materializer_v1"
+)
+SOURCE_REGIME_RELATIVE_PATH = "readmodels/regime_bull_bear_switch.v1.json"
+LEGACY_ROUTE_NON_SOURCE = "double_play_dashboard_display_json_route_v0"
+
+STATUS_WRITTEN = "WRITTEN"
+STATUS_MISSING_SOURCE = "MISSING_SOURCE"
+STATUS_FAIL_CLOSED = "FAIL_CLOSED"
+STATUS_NOT_BOUND = "NOT_BOUND"
+
+MATERIALIZE_ERROR_MISSING_SOURCE = "MISSING_SOURCE"
+MATERIALIZE_ERROR_NOT_BOUND = "NOT_BOUND"
+MATERIALIZE_ERROR_INVALID_JSON = "BULL_BEAR_REGIME_PRESENTATION_MATERIALIZER_INVALID_JSON"
+MATERIALIZE_ERROR_INVALID_SOURCE = "BULL_BEAR_REGIME_PRESENTATION_MATERIALIZER_INVALID_SOURCE"
+MATERIALIZE_ERROR_WRITE_FAILED = "BULL_BEAR_REGIME_PRESENTATION_MATERIALIZER_WRITE_FAILED"
+
+_REQUIRED_REGIME_ATTRS = (
+    "regime_id",
+    "regime_status",
+    "side_state",
+    "previous_side_state",
+    "next_side_state",
+    "scope_event_type",
+    "transition_allowed",
+    "transition_reason_code",
+)
+
+
+@dataclass(frozen=True)
+class BullBearRegimePresentationMaterializeResultV1:
+    """Result of a fail-closed presentation projection materialize attempt."""
+
+    written: bool
+    status: str
+    errors: tuple[str, ...]
+    projection_path: str | None = None
+    source_path: str | None = None
+    side_state: str | None = None
+    payload_digest: str | None = None
+
+
+def _empty_result(
+    *,
+    status: str,
+    errors: tuple[str, ...],
+    source_path: str | None = None,
+) -> BullBearRegimePresentationMaterializeResultV1:
+    return BullBearRegimePresentationMaterializeResultV1(
+        written=False,
+        status=status,
+        errors=errors,
+        source_path=source_path,
+    )
+
+
+def _require_nonempty_str(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def coerce_regime_bull_bear_switch_mapping_v1(
+    source: object | None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Normalize caller or durable source into binder-compatible regime fields."""
+    if source is None:
+        return None, (MATERIALIZE_ERROR_MISSING_SOURCE,)
+
+    raw: Mapping[str, Any]
+    if isinstance(source, Mapping):
+        raw = source
+    else:
+        extracted: dict[str, Any] = {}
+        for key in (
+            *_REQUIRED_REGIME_ATTRS,
+            "reason_codes",
+            "evidence_digest",
+            "semantic_digest",
+            "generated_at",
+            "effective_at",
+            "source_reference",
+            "schema_version",
+            "producer_module",
+            "source_kind",
+        ):
+            if hasattr(source, key):
+                extracted[key] = getattr(source, key)
+        raw = extracted
+
+    # Nested projection/regime envelope: {"regime_bull_bear_switch": {...}}.
+    if "regime_bull_bear_switch" in raw and isinstance(raw.get("regime_bull_bear_switch"), Mapping):
+        nested = raw["regime_bull_bear_switch"]
+        top_side = raw.get("side_state")
+        nested_side = nested.get("side_state")
+        if (
+            isinstance(top_side, str)
+            and top_side.strip()
+            and isinstance(nested_side, str)
+            and nested_side.strip()
+            and top_side.strip() != nested_side.strip()
+        ):
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_REGIME_INVALID)
+        if not all(key in raw for key in _REQUIRED_REGIME_ATTRS):
+            raw = nested
+
+    regime = deepcopy(dict(raw))
+
+    # Enum-valued SideState / status carriers → exact string values only.
+    for key in (
+        "regime_id",
+        "regime_status",
+        "side_state",
+        "previous_side_state",
+        "next_side_state",
+        "scope_event_type",
+        "transition_reason_code",
+    ):
+        value = regime.get(key)
+        if isinstance(value, Enum):
+            regime[key] = value.value
+
+    missing = [key for key in _REQUIRED_REGIME_ATTRS if key not in regime]
+    if missing:
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_REGIME_INVALID)
+
+    for key in (
+        "regime_id",
+        "regime_status",
+        "side_state",
+        "previous_side_state",
+        "next_side_state",
+        "scope_event_type",
+        "transition_reason_code",
+    ):
+        if _require_nonempty_str(regime.get(key)) is None:
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_REGIME_INVALID)
+        regime[key] = str(regime[key]).strip()
+
+    if not isinstance(regime.get("transition_allowed"), bool):
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_REGIME_INVALID)
+
+    return regime, ()
+
+
+def build_bull_bear_regime_presentation_projection_payload_v1(
+    *,
+    regime_bull_bear_switch: object,
+    generated_at: str,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Build the loader-compatible projection envelope from regime fields."""
+    regime_mapping, coerce_errors = coerce_regime_bull_bear_switch_mapping_v1(
+        regime_bull_bear_switch
+    )
+    if regime_mapping is None:
+        return None, coerce_errors
+
+    if _require_nonempty_str(generated_at) is None:
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+
+    binder_fields, map_errors = map_regime_bull_bear_switch_to_binder_fields_v1(
+        regime_bull_bear_switch=regime_mapping,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return None, map_errors
+
+    regime_out: dict[str, Any] = {
+        "next_side_state": binder_fields["next_side_state"],
+        "previous_side_state": binder_fields["previous_side_state"],
+        "regime_id": binder_fields["regime_id"],
+        "regime_status": binder_fields["regime_status"],
+        "reason_codes": list(binder_fields.get("reason_codes", ())),
+        "scope_event_type": binder_fields["scope_event_type"],
+        "side_state": binder_fields["side_state"],
+        "transition_allowed": binder_fields["transition_allowed"],
+        "transition_reason_code": binder_fields["transition_reason_code"],
+    }
+    if "evidence_digest" in binder_fields:
+        regime_out["evidence_digest"] = binder_fields["evidence_digest"]
+        regime_out["semantic_digest"] = binder_fields["evidence_digest"]
+
+    payload: dict[str, Any] = {
+        "authority_effect": AUTHORITY_EFFECT,
+        "bull_bear_authority_effect": BULL_BEAR_AUTHORITY_EFFECT,
+        "generated_at": binder_fields["generated_at"],
+        "projection_role": PROJECTION_ROLE,
+        "regime_bull_bear_switch": regime_out,
+        "schema_name": SCHEMA_NAME,
+        "schema_version": SCHEMA_VERSION,
+    }
+    if "effective_at" in binder_fields:
+        payload["effective_at"] = binder_fields["effective_at"]
+    if "source_reference" in binder_fields:
+        payload["source_reference"] = binder_fields["source_reference"]
+    return payload, ()
+
+
+def serialize_bull_bear_regime_presentation_projection_v1(
+    payload: Mapping[str, Any],
+) -> str:
+    """Deterministic JSON serialization for the presentation projection artifact."""
+    return json.dumps(dict(payload), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def _atomic_write_text(*, destination: Path, body: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, destination)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def write_bull_bear_regime_presentation_projection_v1(
+    archive_root: str | Path,
+    payload: Mapping[str, Any],
+) -> BullBearRegimePresentationMaterializeResultV1:
+    """Atomically persist an already-validated projection payload."""
+    if payload.get("schema_name") != SCHEMA_NAME:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_SCHEMA_MISMATCH,),
+        )
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_SCHEMA_MISMATCH,),
+        )
+    if (
+        payload.get("authority_effect") != AUTHORITY_EFFECT
+        or payload.get("bull_bear_authority_effect") != BULL_BEAR_AUTHORITY_EFFECT
+    ):
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(MATERIALIZE_ERROR_INVALID_SOURCE,),
+        )
+
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    body = serialize_bull_bear_regime_presentation_projection_v1(payload)
+    try:
+        _atomic_write_text(destination=path, body=body)
+    except OSError:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(MATERIALIZE_ERROR_WRITE_FAILED,),
+        )
+
+    regime = payload.get("regime_bull_bear_switch")
+    side_state = None
+    if isinstance(regime, Mapping):
+        raw_side = regime.get("side_state")
+        if isinstance(raw_side, str) and raw_side.strip():
+            side_state = raw_side.strip()
+
+    return BullBearRegimePresentationMaterializeResultV1(
+        written=True,
+        status=STATUS_WRITTEN,
+        errors=(),
+        projection_path=str(path),
+        side_state=side_state,
+        payload_digest=hashlib.sha256(body.encode("utf-8")).hexdigest(),
+    )
+
+
+def try_load_regime_bull_bear_switch_source_v1(
+    archive_root: str | Path,
+) -> tuple[dict[str, Any] | None, tuple[str, ...], str | None]:
+    """Load the sole durable producer regime sibling without inventing content."""
+    root = Path(archive_root).expanduser().resolve()
+    path = root / SOURCE_REGIME_RELATIVE_PATH
+    source_path = str(path)
+    if not path.is_file():
+        return None, (MATERIALIZE_ERROR_MISSING_SOURCE,), source_path
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None, (MATERIALIZE_ERROR_INVALID_JSON,), source_path
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None, (MATERIALIZE_ERROR_INVALID_JSON,), source_path
+    if not isinstance(payload, dict):
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE,), source_path
+    regime, errors = coerce_regime_bull_bear_switch_mapping_v1(payload)
+    if regime is None:
+        return None, errors, source_path
+    return regime, (), source_path
+
+
+def materialize_bull_bear_regime_presentation_projection_v1(
+    archive_root: str | Path,
+    *,
+    regime_bull_bear_switch: object | None = None,
+    generated_at: str | None = None,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> BullBearRegimePresentationMaterializeResultV1:
+    """Materialize the presentation projection from regime fields or durable source.
+
+    Missing source yields MISSING_SOURCE and does not write an artifact.
+    Invalid source or missing required timestamps fail closed without writing.
+    Caller-owned regime inputs are never mutated.
+    Legacy route double_play_dashboard_display_json_route_v0 is NON_SOURCE.
+    """
+    _ = LEGACY_ROUTE_NON_SOURCE  # documented non-source; never used as input path
+    _ = STATUS_NOT_BOUND  # binding vocabulary retained for consumer fail-closed states
+    _ = MATERIALIZE_ERROR_NOT_BOUND
+
+    source_path: str | None = None
+    source_obj: object | None = regime_bull_bear_switch
+    if source_obj is None:
+        loaded, load_errors, source_path = try_load_regime_bull_bear_switch_source_v1(archive_root)
+        if loaded is None:
+            status = (
+                STATUS_MISSING_SOURCE
+                if MATERIALIZE_ERROR_MISSING_SOURCE in load_errors
+                else STATUS_FAIL_CLOSED
+            )
+            return _empty_result(status=status, errors=load_errors, source_path=source_path)
+        source_obj = loaded
+
+    if _require_nonempty_str(generated_at) is None:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_TIMESTAMP_MISSING,),
+            source_path=source_path,
+        )
+
+    # Snapshot caller-owned mapping to prove / preserve non-mutation.
+    caller_snapshot = (
+        deepcopy(regime_bull_bear_switch) if isinstance(regime_bull_bear_switch, Mapping) else None
+    )
+
+    payload, build_errors = build_bull_bear_regime_presentation_projection_payload_v1(
+        regime_bull_bear_switch=source_obj,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_reference=source_reference,
+    )
+    if isinstance(regime_bull_bear_switch, Mapping) and caller_snapshot is not None:
+        if dict(regime_bull_bear_switch) != dict(caller_snapshot):
+            return _empty_result(
+                status=STATUS_FAIL_CLOSED,
+                errors=(MATERIALIZE_ERROR_INVALID_SOURCE,),
+                source_path=source_path,
+            )
+    if payload is None:
+        status = (
+            STATUS_MISSING_SOURCE
+            if MATERIALIZE_ERROR_MISSING_SOURCE in build_errors
+            else STATUS_FAIL_CLOSED
+        )
+        return _empty_result(status=status, errors=build_errors, source_path=source_path)
+
+    result = write_bull_bear_regime_presentation_projection_v1(archive_root, payload)
+    if not result.written:
+        return result
+    return BullBearRegimePresentationMaterializeResultV1(
+        written=True,
+        status=STATUS_WRITTEN,
+        errors=(),
+        projection_path=result.projection_path,
+        source_path=source_path,
+        side_state=result.side_state,
+        payload_digest=result.payload_digest,
+    )

--- a/src/webui/workflow_dashboard_readmodel_v1/bull_bear_regime_presentation_projection_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/bull_bear_regime_presentation_projection_v1.py
@@ -1,0 +1,317 @@
+"""Non-authoritative presentation projection for Regime/Bull-Bear/Switch.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_BULL_BEAR_REGIME_PROJECTION_MATERIALIZER_V1
+
+Reads already-produced regime_bull_bear_switch field payloads (PR #5577 binder
+contract) from a single durable archive path and maps them field-for-field into
+Landscape binder injection fields. This module:
+
+- AUTHORITY_EFFECT=NONE
+- BULL_BEAR_AUTHORITY_EFFECT=NONE
+- never creates, mutates, or evaluates SideState / regime / switch decisions
+- never imports trading.master_v2 producers or evaluators
+- never calls transition_state / compose_double_play / KillSwitch / risk / sizing
+- never invents BULL/BEAR/NEUTRAL labels from prices or signals; SideState and
+  regime fields pass through exactly when present
+- fail-closed: missing, invalid, or ambiguous sources → no fields (MISSING_SOURCE)
+
+Deterministic source selection: exactly one well-known relative path under the
+Workflow Dashboard archive root. No silent multi-candidate "latest" picking.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_NAME = "bull_bear_regime_presentation_projection.v1"
+SCHEMA_VERSION = 1
+STORAGE_RELATIVE_PATH = "readmodels/bull_bear_regime_presentation_projection.v1.json"
+AUTHORITY_EFFECT = "NONE"
+BULL_BEAR_AUTHORITY_EFFECT = "NONE"
+PROJECTION_ROLE = "NON_AUTHORITATIVE_PRESENTATION_PROJECTION"
+OWNER_MODULE = "webui.workflow_dashboard_readmodel_v1.bull_bear_regime_presentation_projection_v1"
+
+LOAD_ERROR_ABSENT = "BULL_BEAR_REGIME_PRESENTATION_PROJECTION_ABSENT"
+LOAD_ERROR_INVALID_JSON = "BULL_BEAR_REGIME_PRESENTATION_PROJECTION_INVALID_JSON"
+LOAD_ERROR_SCHEMA_MISMATCH = "BULL_BEAR_REGIME_PRESENTATION_PROJECTION_SCHEMA_MISMATCH"
+LOAD_ERROR_AUTHORITY_CLAIM = "BULL_BEAR_REGIME_PRESENTATION_PROJECTION_AUTHORITY_CLAIM"
+LOAD_ERROR_REGIME_INVALID = "BULL_BEAR_REGIME_PRESENTATION_PROJECTION_REGIME_INVALID"
+LOAD_ERROR_AMBIGUOUS = "BULL_BEAR_REGIME_PRESENTATION_PROJECTION_AMBIGUOUS_SOURCE"
+LOAD_ERROR_TIMESTAMP_MISSING = "BULL_BEAR_REGIME_PRESENTATION_PROJECTION_TIMESTAMP_MISSING"
+
+# Exact PR #5577 Landscape binder contract — no semantic reinterpretation.
+_REQUIRED_REGIME_KEYS = (
+    "regime_id",
+    "regime_status",
+    "side_state",
+    "previous_side_state",
+    "next_side_state",
+    "scope_event_type",
+    "transition_allowed",
+    "transition_reason_code",
+)
+
+# Canonical SideState vocabulary (pass-through only; includes NEUTRAL via neutral_observe).
+KNOWN_SIDE_STATES = frozenset(
+    {
+        "neutral_observe",
+        "long_armed",
+        "long_active",
+        "long_blocked",
+        "short_armed",
+        "short_active",
+        "short_blocked",
+        "switch_long_to_short_pending",
+        "switch_short_to_long_pending",
+        "chop_guard_block",
+        "kill_all",
+    }
+)
+KNOWN_REGIME_STATUSES = frozenset({"known", "unknown"})
+
+
+@dataclass(frozen=True)
+class BullBearRegimePresentationLoadV1:
+    """Result of a fail-closed presentation projection load attempt."""
+
+    loaded: bool
+    load_errors: tuple[str, ...]
+    binder_fields: Mapping[str, Any] | None = None
+    source_path: str | None = None
+    evidence_digest: str | None = None
+    side_state: str | None = None
+
+
+def _empty(*, load_errors: tuple[str, ...]) -> BullBearRegimePresentationLoadV1:
+    return BullBearRegimePresentationLoadV1(loaded=False, load_errors=load_errors)
+
+
+def _require_nonempty_str(payload: Mapping[str, Any], key: str) -> str | None:
+    raw = payload.get(key)
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return raw.strip()
+
+
+def _regime_payload_from_envelope(
+    payload: Mapping[str, Any],
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    """Extract nested regime_bull_bear_switch fields; fail closed on ambiguity."""
+    if "regime_bull_bear_switch" not in payload:
+        return None, (LOAD_ERROR_REGIME_INVALID,)
+    regime = payload.get("regime_bull_bear_switch")
+    if not isinstance(regime, Mapping):
+        return None, (LOAD_ERROR_REGIME_INVALID,)
+    # Reject dual top-level + nested side_state with conflicting values.
+    top_level_side = payload.get("side_state")
+    nested_side = regime.get("side_state")
+    if (
+        isinstance(top_level_side, str)
+        and top_level_side.strip()
+        and isinstance(nested_side, str)
+        and nested_side.strip()
+        and top_level_side.strip() != nested_side.strip()
+    ):
+        return None, (LOAD_ERROR_AMBIGUOUS,)
+    return regime, ()
+
+
+def _validate_regime_fields(
+    regime: Mapping[str, Any],
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    missing = [key for key in _REQUIRED_REGIME_KEYS if key not in regime]
+    if missing:
+        return None, (LOAD_ERROR_REGIME_INVALID,)
+
+    regime_id = _require_nonempty_str(regime, "regime_id")
+    regime_status = _require_nonempty_str(regime, "regime_status")
+    side_state = _require_nonempty_str(regime, "side_state")
+    previous_side_state = _require_nonempty_str(regime, "previous_side_state")
+    next_side_state = _require_nonempty_str(regime, "next_side_state")
+    scope_event_type = _require_nonempty_str(regime, "scope_event_type")
+    transition_reason_code = _require_nonempty_str(regime, "transition_reason_code")
+    transition_allowed = regime.get("transition_allowed")
+
+    if (
+        regime_id is None
+        or regime_status is None
+        or side_state is None
+        or previous_side_state is None
+        or next_side_state is None
+        or scope_event_type is None
+        or transition_reason_code is None
+    ):
+        return None, (LOAD_ERROR_REGIME_INVALID,)
+    if not isinstance(transition_allowed, bool):
+        return None, (LOAD_ERROR_REGIME_INVALID,)
+    if regime_status not in KNOWN_REGIME_STATUSES:
+        return None, (LOAD_ERROR_SCHEMA_MISMATCH,)
+    if side_state not in KNOWN_SIDE_STATES:
+        return None, (LOAD_ERROR_SCHEMA_MISMATCH,)
+    if previous_side_state not in KNOWN_SIDE_STATES or next_side_state not in KNOWN_SIDE_STATES:
+        return None, (LOAD_ERROR_SCHEMA_MISMATCH,)
+    # Fail-closed contradiction guard (same as Landscape binder): side must match next.
+    if side_state != next_side_state:
+        return None, (LOAD_ERROR_REGIME_INVALID,)
+
+    out: dict[str, Any] = {
+        "regime_id": regime_id,
+        "regime_status": regime_status,
+        "side_state": side_state,
+        "previous_side_state": previous_side_state,
+        "next_side_state": next_side_state,
+        "scope_event_type": scope_event_type,
+        "transition_allowed": transition_allowed,
+        "transition_reason_code": transition_reason_code,
+    }
+
+    raw_codes = regime.get("reason_codes", ())
+    if raw_codes is None:
+        raw_codes = ()
+    if not isinstance(raw_codes, (list, tuple)):
+        return None, (LOAD_ERROR_REGIME_INVALID,)
+    out["reason_codes"] = tuple(str(code) for code in raw_codes)
+
+    digest = regime.get("evidence_digest")
+    if digest is None:
+        digest = regime.get("semantic_digest")
+    if digest is not None:
+        if not isinstance(digest, str) or not digest.strip():
+            return None, (LOAD_ERROR_REGIME_INVALID,)
+        out["evidence_digest"] = digest.strip()
+        out["semantic_digest"] = digest.strip()
+
+    return out, ()
+
+
+def map_regime_bull_bear_switch_to_binder_fields_v1(
+    *,
+    regime_bull_bear_switch: Mapping[str, Any],
+    generated_at: str,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Map regime/bull-bear/switch fields → Landscape binder fields (projection only)."""
+    mapped, errors = _validate_regime_fields(regime_bull_bear_switch)
+    if mapped is None:
+        return None, errors
+    if not isinstance(generated_at, str) or not generated_at.strip():
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+    mapped["generated_at"] = generated_at.strip()
+    if effective_at is not None:
+        if not isinstance(effective_at, str) or not effective_at.strip():
+            return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+        mapped["effective_at"] = effective_at.strip()
+    if source_reference is not None:
+        if not isinstance(source_reference, str):
+            return None, (LOAD_ERROR_REGIME_INVALID,)
+        mapped["source_reference"] = source_reference
+    return mapped, ()
+
+
+def try_load_bull_bear_regime_presentation_projection_v1(
+    archive_root: str | Path,
+) -> BullBearRegimePresentationLoadV1:
+    """Verify-before-trust read of the sole durable bull/bear regime projection.
+
+    Returns loaded=False with load_errors on any fail-closed condition. Never
+    invents regime or SideState facts.
+    """
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    if not path.is_file():
+        return _empty(load_errors=(LOAD_ERROR_ABSENT,))
+
+    # Ambiguity guard: a second durable producer dump beside the projection is
+    # allowed only when identical evidence_digest (when both present);
+    # otherwise fail closed.
+    sibling = root / "readmodels" / "regime_bull_bear_switch.v1.json"
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    if not isinstance(payload, dict):
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    schema_name = payload.get("schema_name")
+    if schema_name != SCHEMA_NAME:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    authority = payload.get("authority_effect")
+    bull_bear_authority = payload.get("bull_bear_authority_effect")
+    if authority != AUTHORITY_EFFECT or bull_bear_authority != BULL_BEAR_AUTHORITY_EFFECT:
+        return _empty(load_errors=(LOAD_ERROR_AUTHORITY_CLAIM,))
+
+    generated_at = _require_nonempty_str(payload, "generated_at")
+    if generated_at is None:
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+
+    effective_at = payload.get("effective_at")
+    if effective_at is not None and (not isinstance(effective_at, str) or not effective_at.strip()):
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+    effective_at_s = None if effective_at is None else str(effective_at).strip()
+
+    regime, regime_errors = _regime_payload_from_envelope(payload)
+    if regime is None:
+        return _empty(load_errors=regime_errors)
+
+    source_reference = payload.get("source_reference")
+    if source_reference is None:
+        source_reference = f"presentation://{STORAGE_RELATIVE_PATH}"
+    elif not isinstance(source_reference, str):
+        return _empty(load_errors=(LOAD_ERROR_REGIME_INVALID,))
+
+    binder_fields, map_errors = map_regime_bull_bear_switch_to_binder_fields_v1(
+        regime_bull_bear_switch=regime,
+        generated_at=generated_at,
+        effective_at=effective_at_s,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return _empty(load_errors=map_errors)
+
+    if sibling.is_file():
+        try:
+            sibling_payload = json.loads(sibling.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        if not isinstance(sibling_payload, dict):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        sibling_digest = sibling_payload.get("evidence_digest")
+        if sibling_digest is None:
+            sibling_digest = sibling_payload.get("semantic_digest")
+        projection_digest = binder_fields.get("evidence_digest")
+        if (
+            not isinstance(sibling_digest, str)
+            or not sibling_digest.strip()
+            or not isinstance(projection_digest, str)
+            or not projection_digest.strip()
+            or sibling_digest.strip() != projection_digest.strip()
+        ):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+
+    return BullBearRegimePresentationLoadV1(
+        loaded=True,
+        load_errors=(),
+        binder_fields=binder_fields,
+        source_path=str(path),
+        evidence_digest=(
+            None
+            if binder_fields.get("evidence_digest") is None
+            else str(binder_fields.get("evidence_digest"))
+        ),
+        side_state=str(binder_fields["side_state"]),
+    )

--- a/tests/webui/test_bull_bear_regime_presentation_projection_materializer_v1.py
+++ b/tests/webui/test_bull_bear_regime_presentation_projection_materializer_v1.py
@@ -1,0 +1,368 @@
+"""Focused tests: CAPABILITY_PRESENTATION_BULL_BEAR_REGIME_PROJECTION_MATERIALIZER_V1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    REGIME_BULL_BEAR_SWITCH_PRODUCER_MODULE,
+    REGIME_BULL_BEAR_SWITCH_SOURCE_KIND,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT
+from src.webui.workflow_dashboard_readmodel_v1.bull_bear_regime_presentation_projection_materializer_v1 import (
+    CAPABILITY_ID,
+    LEGACY_ROUTE_NON_SOURCE,
+    MATERIALIZE_ERROR_MISSING_SOURCE,
+    SOURCE_REGIME_RELATIVE_PATH,
+    STATUS_FAIL_CLOSED,
+    STATUS_MISSING_SOURCE,
+    STATUS_NOT_BOUND,
+    STATUS_WRITTEN,
+    build_bull_bear_regime_presentation_projection_payload_v1,
+    materialize_bull_bear_regime_presentation_projection_v1,
+    serialize_bull_bear_regime_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.bull_bear_regime_presentation_projection_v1 import (
+    LOAD_ERROR_REGIME_INVALID,
+    LOAD_ERROR_TIMESTAMP_MISSING,
+    STORAGE_RELATIVE_PATH,
+    try_load_bull_bear_regime_presentation_projection_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+PRODUCER_FRESH = "2026-07-24T17:30:00Z"
+
+
+def _regime(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "regime_id": "trending",
+        "regime_status": "known",
+        "side_state": "long_active",
+        "previous_side_state": "long_armed",
+        "next_side_state": "long_active",
+        "scope_event_type": "upscope_confirmed",
+        "transition_allowed": True,
+        "transition_reason_code": "UPSCOPE_CONFIRMED",
+        "reason_codes": ("STATE_SWITCH_OK",),
+        "evidence_digest": "b" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_source_regime(archive_root: Path, payload: dict[str, object]) -> Path:
+    path = archive_root / SOURCE_REGIME_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_capability_id_and_artifact_path_are_stable() -> None:
+    assert CAPABILITY_ID == ("CAPABILITY_PRESENTATION_BULL_BEAR_REGIME_PROJECTION_MATERIALIZER_V1")
+    assert STORAGE_RELATIVE_PATH == ("readmodels/bull_bear_regime_presentation_projection.v1.json")
+    assert SOURCE_REGIME_RELATIVE_PATH == "readmodels/regime_bull_bear_switch.v1.json"
+    assert LEGACY_ROUTE_NON_SOURCE == "double_play_dashboard_display_json_route_v0"
+    assert STATUS_NOT_BOUND == "NOT_BOUND"
+    assert STATUS_MISSING_SOURCE == "MISSING_SOURCE"
+
+
+def test_build_payload_is_deterministic() -> None:
+    regime = _regime()
+    first, err_a = build_bull_bear_regime_presentation_projection_payload_v1(
+        regime_bull_bear_switch=regime,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://unit-test",
+    )
+    second, err_b = build_bull_bear_regime_presentation_projection_payload_v1(
+        regime_bull_bear_switch=regime,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://unit-test",
+    )
+    assert err_a == ()
+    assert err_b == ()
+    assert first is not None and second is not None
+    assert first == second
+    assert serialize_bull_bear_regime_presentation_projection_v1(
+        first
+    ) == serialize_bull_bear_regime_presentation_projection_v1(second)
+
+
+@pytest.mark.parametrize(
+    ("side_state", "label"),
+    [
+        ("long_active", "BULL"),
+        ("short_active", "BEAR"),
+        ("neutral_observe", "NEUTRAL"),
+    ],
+)
+def test_canonical_side_state_pass_through_without_reinterpretation(
+    side_state: str,
+    label: str,
+    tmp_path: Path,
+) -> None:
+    """Canonical SideState values pass through; no invented BULL/BEAR gloss."""
+    _ = label  # vocabulary coverage marker for BULL/BEAR/NEUTRAL distinctions
+    regime = _regime(
+        side_state=side_state,
+        previous_side_state=side_state,
+        next_side_state=side_state,
+        scope_event_type="noop",
+        transition_allowed=False,
+        transition_reason_code="NOOP",
+    )
+    result = materialize_bull_bear_regime_presentation_projection_v1(
+        tmp_path,
+        regime_bull_bear_switch=regime,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert result.side_state == side_state
+    loaded = try_load_bull_bear_regime_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.side_state == side_state
+    assert loaded.binder_fields is not None
+    assert loaded.binder_fields["side_state"] == side_state
+    # Must not invent directional gloss strings.
+    body = (tmp_path / STORAGE_RELATIVE_PATH).read_text(encoding="utf-8")
+    assert "bullish" not in body.lower()
+    assert "bearish" not in body.lower()
+    assert '"BULL"' not in body
+    assert '"BEAR"' not in body
+
+
+def test_materialize_writes_loader_expected_path(tmp_path: Path) -> None:
+    result = materialize_bull_bear_regime_presentation_projection_v1(
+        tmp_path,
+        regime_bull_bear_switch=_regime(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert result.status == STATUS_WRITTEN
+    assert result.errors == ()
+    assert result.projection_path is not None
+    assert result.projection_path.endswith(STORAGE_RELATIVE_PATH)
+    assert (tmp_path / STORAGE_RELATIVE_PATH).is_file()
+
+
+def test_materialize_loader_compatible(tmp_path: Path) -> None:
+    materialize_bull_bear_regime_presentation_projection_v1(
+        tmp_path,
+        regime_bull_bear_switch=_regime(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://materializer-compat",
+    )
+    loaded = try_load_bull_bear_regime_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.load_errors == ()
+    assert loaded.side_state == "long_active"
+    assert loaded.evidence_digest == "b" * 64
+    assert loaded.binder_fields is not None
+    assert loaded.binder_fields["regime_id"] == "trending"
+    assert loaded.binder_fields["regime_status"] == "known"
+    assert loaded.binder_fields["transition_allowed"] is True
+
+
+def test_missing_source_does_not_invent_artifact(tmp_path: Path) -> None:
+    result = materialize_bull_bear_regime_presentation_projection_v1(
+        tmp_path,
+        regime_bull_bear_switch=None,
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_MISSING_SOURCE
+    assert MATERIALIZE_ERROR_MISSING_SOURCE in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+    loaded = try_load_bull_bear_regime_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+
+
+def test_unbound_vocabulary_is_explicit() -> None:
+    assert STATUS_NOT_BOUND == "NOT_BOUND"
+    assert STATUS_MISSING_SOURCE == "MISSING_SOURCE"
+
+
+def test_invalid_source_fail_closed(tmp_path: Path) -> None:
+    result = materialize_bull_bear_regime_presentation_projection_v1(
+        tmp_path,
+        regime_bull_bear_switch={"regime_id": "trending", "side_state": "long_active"},
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_REGIME_INVALID in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_contradiction_fail_closed(tmp_path: Path) -> None:
+    result = materialize_bull_bear_regime_presentation_projection_v1(
+        tmp_path,
+        regime_bull_bear_switch=_regime(
+            side_state="long_active",
+            next_side_state="short_active",
+        ),
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_REGIME_INVALID in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_missing_generated_at_fail_closed(tmp_path: Path) -> None:
+    result = materialize_bull_bear_regime_presentation_projection_v1(
+        tmp_path,
+        regime_bull_bear_switch=_regime(),
+        generated_at=None,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_TIMESTAMP_MISSING in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_does_not_mutate_canonical_inputs(tmp_path: Path) -> None:
+    regime = _regime()
+    snapshot = deepcopy(regime)
+    result = materialize_bull_bear_regime_presentation_projection_v1(
+        tmp_path,
+        regime_bull_bear_switch=regime,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert regime == snapshot
+
+
+def test_materialize_from_durable_producer_regime_source(tmp_path: Path) -> None:
+    _write_source_regime(tmp_path, _regime())
+    result = materialize_bull_bear_regime_presentation_projection_v1(
+        tmp_path,
+        regime_bull_bear_switch=None,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert result.status == STATUS_WRITTEN
+    assert result.source_path is not None
+    assert SOURCE_REGIME_RELATIVE_PATH in result.source_path
+    loaded = try_load_bull_bear_regime_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.side_state == "long_active"
+
+
+def test_legacy_route_is_non_source_and_unused() -> None:
+    materializer = (
+        REPO
+        / "src/webui/workflow_dashboard_readmodel_v1"
+        / "bull_bear_regime_presentation_projection_materializer_v1.py"
+    ).read_text(encoding="utf-8")
+    assert LEGACY_ROUTE_NON_SOURCE in materializer
+    assert "NON_SOURCE" in materializer
+    assert "double_play_dashboard_display_json_route_v0" in materializer
+    # Must never import or call the legacy route module as truth.
+    assert "from src.webui.double_play_dashboard_display_json_route_v0" not in materializer
+    assert "build_static_dashboard_display_dict" not in materializer
+
+
+def test_end_to_end_projection_to_autobind_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    fresh = datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+    _write_source_regime(archive, _regime(side_state="long_active", next_side_state="long_active"))
+    result = materialize_bull_bear_regime_presentation_projection_v1(
+        archive,
+        regime_bull_bear_switch=None,
+        generated_at=fresh,
+        effective_at=fresh,
+        source_reference="presentation://e2e-materializer",
+    )
+    assert result.written is True
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=datetime.now(timezone.utc))
+    snap = slots["regime_bull_bear_switch"]
+    assert snap.availability is Availability.AVAILABLE
+    assert snap.side_state == "long_active"
+    assert snap.regime_id == "trending"
+    assert snap.regime_status == "known"
+    assert snap.provenance.producer_module == REGIME_BULL_BEAR_SWITCH_PRODUCER_MODULE
+    assert snap.provenance.source_kind == REGIME_BULL_BEAR_SWITCH_SOURCE_KIND
+    assert snap.provenance.source_reference == "presentation://e2e-materializer"
+    assert snap.provenance.evidence_digest == "b" * 64
+
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "long_active" in html
+    assert 'data-mdl-field="bull_bear"' in html
+    assert 'data-mdl-field="bull_bear" data-availability="AVAILABLE"' in html
+    assert "<form" not in html.lower()
+    assert "place_order" not in html.lower()
+
+
+def test_existing_presentation_autobind_paths_remain_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Decision/Double-Play autobind remains MISSING_SOURCE when absent; no crash."""
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=datetime.now(timezone.utc))
+    assert slots["regime_bull_bear_switch"].availability is Availability.MISSING_SOURCE
+    assert slots["canonical_decision"].availability is Availability.MISSING_SOURCE
+    assert slots["double_play"].availability is Availability.MISSING_SOURCE
+
+
+def test_materializer_module_has_no_forbidden_trading_imports() -> None:
+    path = (
+        REPO
+        / "src/webui/workflow_dashboard_readmodel_v1"
+        / "bull_bear_regime_presentation_projection_materializer_v1.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                continue
+            if node.module:
+                imported.add(node.module.split(".", 1)[0])
+    assert "trading" not in imported
+    assert "src" not in imported
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in {
+                "transition_state",
+                "compose_double_play_decision",
+                "build_dashboard_display_snapshot",
+                "KillSwitch",
+                "derive_active_side",
+            }
+    source = path.read_text(encoding="utf-8")
+    assert CAPABILITY_ID in source
+    assert "STORAGE_RELATIVE_PATH" in source
+    assert "map_regime_bull_bear_switch_to_binder_fields_v1" in source
+    assert LEGACY_ROUTE_NON_SOURCE in source
+    assert "NON_SOURCE" in source


### PR DESCRIPTION
## Summary
- Adds non-authoritative `bull_bear_regime_presentation_projection.v1` loader/schema and materializer for the existing PR #5577 `regime_bull_bear_switch` Landscape field contract.
- Atomically writes `readmodels/bull_bear_regime_presentation_projection.v1.json` from in-memory fields or durable `readmodels/regime_bull_bear_switch.v1.json`; missing source stays fail-closed `MISSING_SOURCE`.
- Wires Landscape auto-bind for the projection while keeping injection test-compatible; legacy `double_play_dashboard_display_json_route_v0` remains NON_SOURCE. No producer, trading, bull/bear logic, Double Play, Dynamic Scope, or runtime authority changes.

## Test plan
- [x] `pytest tests/webui/test_bull_bear_regime_presentation_projection_materializer_v1.py` (18 passed)
- [x] PR-bounded selector targets + focused materializer + decision/double-play autobind non-reg (773 passed, ~38s)
- [x] Regime producer-binding focused non-reg (7 passed)
- [x] `ruff format --check` / `ruff check`
- [x] docs token policy + docs reference targets


Made with [Cursor](https://cursor.com)