### PR TITLE
feat(webui): autobind dynamic scope presentation projection

### DIFF
--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -1,6 +1,7 @@
 """Phase 4.1–4.5 + 4.2B + 4.6B read-only producer binding for Market Landscape V2.
 
-Binds market_instrument, universe_ranking, dynamic_scope lifecycle identity,
+Binds market_instrument, universe_ranking, dynamic_scope lifecycle identity
+(injection or durable presentation projection auto-bind),
 regime_bull_bear_switch (injection or durable presentation projection
 auto-bind; PR #5577 field contract), canonical_decision
 evidence (injection or durable presentation projection auto-bind),
@@ -80,6 +81,10 @@ from .workflow_dashboard_readmodel_v1.bull_bear_regime_presentation_projection_v
 from .workflow_dashboard_readmodel_v1.double_play_presentation_projection_v1 import (
     LOAD_ERROR_ABSENT as DOUBLE_PLAY_PROJECTION_ABSENT,
     try_load_double_play_presentation_projection_v1,
+)
+from .workflow_dashboard_readmodel_v1.dynamic_scope_presentation_projection_v1 import (
+    LOAD_ERROR_ABSENT as DYNAMIC_SCOPE_PROJECTION_ABSENT,
+    try_load_dynamic_scope_presentation_projection_v1,
 )
 from .workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
     FORBIDDEN_SELECTED_SYMBOLS,
@@ -565,18 +570,43 @@ def _bind_dynamic_scope_lifecycle(
     as_of: datetime,
     git_sha: str | None,
     dynamic_scope_fields: Mapping[str, Any] | None,
+    archive_root: Path | None = None,
 ) -> Any:
-    """Project injected CanonicalScopeSnapshotV1-compatible lifecycle fields.
+    """Project CanonicalScopeSnapshotV1-compatible lifecycle identity fields.
 
-    No durable dashboard scope readmodel. Without injection → MISSING_SOURCE.
-    Never runs canonical scope initialization or switch-transition owners.
+    Injection remains supported for tests. Productive auto-bind loads the
+    non-authoritative presentation projection from the Workflow Dashboard
+    archive root when injection is absent. Never runs canonical scope
+    initialization or switch-transition owners.
     """
     if dynamic_scope_fields is None:
-        return unavailable_dynamic_scope(
-            availability=Availability.MISSING_SOURCE,
-            generated_at=as_of,
-            reason=REASON_SCOPE_NOT_PERSISTED,
-        )
+        if archive_root is None:
+            return unavailable_dynamic_scope(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_SCOPE_NOT_PERSISTED,
+            )
+        loaded = try_load_dynamic_scope_presentation_projection_v1(archive_root)
+        if not loaded.loaded or loaded.binder_fields is None:
+            reason = REASON_SCOPE_NOT_PERSISTED
+            if loaded.load_errors:
+                first = str(loaded.load_errors[0])
+                if first != DYNAMIC_SCOPE_PROJECTION_ABSENT:
+                    reason = first
+            availability = (
+                Availability.MISSING_SOURCE
+                if reason == REASON_SCOPE_NOT_PERSISTED or reason == DYNAMIC_SCOPE_PROJECTION_ABSENT
+                else Availability.INVALID
+            )
+            if reason == DYNAMIC_SCOPE_PROJECTION_ABSENT:
+                reason = REASON_SCOPE_NOT_PERSISTED
+                availability = Availability.MISSING_SOURCE
+            return unavailable_dynamic_scope(
+                availability=availability,
+                generated_at=as_of,
+                reason=reason,
+            )
+        dynamic_scope_fields = loaded.binder_fields
 
     if "scope_state" in dynamic_scope_fields and dynamic_scope_fields["scope_state"] is not None:
         scope_state = _enum_or_str(dynamic_scope_fields["scope_state"])
@@ -1908,7 +1938,9 @@ def bind_market_universe_slots(
 
     dynamic_scope_fields accepts already-computed CanonicalScopeSnapshotV1-
     compatible lifecycle identity fields plus producer wall-clock timestamps.
-    Without injection, dynamic_scope is MISSING_SOURCE (no durable readmodel).
+    Without injection, productive auto-bind loads
+    dynamic_scope_presentation_projection.v1 when present; otherwise
+    MISSING_SOURCE. Never calls scope initializers or invents next_scope_ref.
 
     regime_bull_bear_switch_fields accepts already-computed Regime /
     SideState / StateSwitchEvidenceV1-compatible fields plus producer
@@ -1964,6 +1996,7 @@ def bind_market_universe_slots(
         as_of=as_of,
         git_sha=git_sha,
         dynamic_scope_fields=dynamic_scope_fields,
+        archive_root=root,
     )
     regime_bbs = _bind_regime_bull_bear_switch(
         as_of=as_of,

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -52,9 +52,17 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
         authority_class="dynamic_scope",
         reuse_status="REUSED",
         notes=(
-            "Phase 4.2: Landscape projects CanonicalScopeSnapshotV1 lifecycle "
-            "identity only (scope_state/current_scope_ref). Regime/Bull-Bear/"
-            "Switch bind via separate slot regime_bull_bear_switch."
+            "Phase 4.2 + CAPABILITY_PRESENTATION_DYNAMIC_SCOPE_PROJECTION_"
+            "MATERIALIZER_AUTOBIND_V1: Landscape projects "
+            "CanonicalScopeSnapshotV1 lifecycle identity only "
+            "(scope_state/current_scope_ref[/next_scope_ref]); no scope "
+            "initializer or transition calls; no invented next_scope_ref. "
+            "Durable auto-bind via non-authoritative "
+            "dynamic_scope_presentation_projection.v1 under archive root "
+            "(materialized from durable dynamic_scope_state_v1.json); "
+            "injection remains test-compatible; AUTHORITY_EFFECT=NONE. "
+            "Regime/Bull-Bear/Switch bind via separate slot "
+            "regime_bull_bear_switch."
         ),
     ),
     CanonicalOwnerRefV1(

--- a/src/webui/workflow_dashboard_archive_root_v1.py
+++ b/src/webui/workflow_dashboard_archive_root_v1.py
@@ -6,8 +6,10 @@ trading. GET /market consumers may resolve this root (explicit → Env →
 canonical default → discovered governed OKX sibling) to read-only-load
 universe_selection_readmodel.v1 and okx_selected_instrument_ohlcv_readmodel.v1,
 and (when present) canonical_decision_presentation_projection.v1,
-double_play_presentation_projection.v1, and
-bull_bear_regime_presentation_projection.v1.
+double_play_presentation_projection.v1,
+bull_bear_regime_presentation_projection.v1, and
+dynamic_scope_presentation_projection.v1 (plus its durable source sibling
+dynamic_scope_state_v1.json under the same archive root).
 """
 
 from __future__ import annotations
@@ -50,6 +52,10 @@ DOUBLE_PLAY_PRESENTATION_PROJECTION_RELATIVE = (
 )
 BULL_BEAR_REGIME_PRESENTATION_PROJECTION_RELATIVE = (
     "readmodels/bull_bear_regime_presentation_projection.v1.json"
+)
+DYNAMIC_SCOPE_STATE_RELATIVE = "readmodels/dynamic_scope_state_v1.json"
+DYNAMIC_SCOPE_PRESENTATION_PROJECTION_RELATIVE = (
+    "readmodels/dynamic_scope_presentation_projection.v1.json"
 )
 _DISCOVER_NAME_PREFIX = "workflow_dashboard_v1"
 
@@ -405,9 +411,14 @@ def resolve_workflow_dashboard_archive_root(
 
 
 __all__ = [
+    "BULL_BEAR_REGIME_PRESENTATION_PROJECTION_RELATIVE",
+    "CANONICAL_DECISION_PRESENTATION_PROJECTION_RELATIVE",
     "CONFIG_CONTRACT_RELATIVE_PATH",
     "CONTRACT_ID",
     "CONTRACT_SCHEMA_VERSION",
+    "DOUBLE_PLAY_PRESENTATION_PROJECTION_RELATIVE",
+    "DYNAMIC_SCOPE_PRESENTATION_PROJECTION_RELATIVE",
+    "DYNAMIC_SCOPE_STATE_RELATIVE",
     "ENV_ARCHIVE_ROOT",
     "OKX_OHLCV_READMODEL_RELATIVE",
     "OWNER_MODULE",

--- a/src/webui/workflow_dashboard_readmodel_v1/dynamic_scope_presentation_projection_materializer_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/dynamic_scope_presentation_projection_materializer_v1.py
@@ -1,0 +1,470 @@
+"""Non-authoritative materializer for Dynamic Scope presentation projection.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_DYNAMIC_SCOPE_PROJECTION_MATERIALIZER_AUTOBIND_V1
+
+Consumes already-produced durable Dynamic Scope state
+(``dynamic_scope_state_v1.json``) or binder-compatible lifecycle identity fields
+under the Workflow Dashboard archive root and writes the non-authoritative
+presentation projection schema to the loader-owned path. This module:
+
+- AUTHORITY_EFFECT=NONE
+- DYNAMIC_SCOPE_AUTHORITY_EFFECT=NONE
+- never creates, mutates, or evaluates Dynamic Scope state
+- never imports trading.master_v2 scope initializers or transition owners
+- never imports ops.dynamic_scope_persistence_binding_v1 writers or mutation APIs
+- never invents scope facts, timestamps, or default productive values
+- never derives next_scope_ref when absent from source
+- fail-closed: missing source → MISSING_SOURCE and no artifact write;
+  invalid source → FAIL_CLOSED and no artifact write
+- projection remains non-authoritative and must never flow back into runtime
+  or authority chains
+
+Deterministic serialization and atomic replace only. This projection path does
+not own a separate MANIFEST contract; integrity follows the existing loader
+schema/authority/scope checks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from .dynamic_scope_presentation_projection_v1 import (
+    AUTHORITY_EFFECT,
+    DYNAMIC_SCOPE_AUTHORITY_EFFECT,
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    LOAD_ERROR_SCOPE_INVALID,
+    LOAD_ERROR_TIMESTAMP_MISSING,
+    PROJECTION_ROLE,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    STORAGE_RELATIVE_PATH,
+    map_dynamic_scope_fields_to_binder_fields_v1,
+)
+
+CAPABILITY_ID = "CAPABILITY_PRESENTATION_DYNAMIC_SCOPE_PROJECTION_MATERIALIZER_AUTOBIND_V1"
+OWNER_MODULE = (
+    "webui.workflow_dashboard_readmodel_v1.dynamic_scope_presentation_projection_materializer_v1"
+)
+SOURCE_STATE_RELATIVE_PATH = "readmodels/dynamic_scope_state_v1.json"
+PRODUCER_STATE_SCHEMA_VERSION = "dynamic_scope_persistence_binding.v1"
+PRODUCER_STATE_VERSION = "v1"
+
+STATUS_WRITTEN = "WRITTEN"
+STATUS_MISSING_SOURCE = "MISSING_SOURCE"
+STATUS_FAIL_CLOSED = "FAIL_CLOSED"
+
+MATERIALIZE_ERROR_MISSING_SOURCE = "MISSING_SOURCE"
+MATERIALIZE_ERROR_INVALID_JSON = "DYNAMIC_SCOPE_PRESENTATION_MATERIALIZER_INVALID_JSON"
+MATERIALIZE_ERROR_INVALID_SOURCE = "DYNAMIC_SCOPE_PRESENTATION_MATERIALIZER_INVALID_SOURCE"
+MATERIALIZE_ERROR_WRITE_FAILED = "DYNAMIC_SCOPE_PRESENTATION_MATERIALIZER_WRITE_FAILED"
+
+_REQUIRED_SCOPE_ATTRS = (
+    "scope_state",
+    "current_scope_ref",
+)
+
+
+@dataclass(frozen=True)
+class DynamicScopePresentationMaterializeResultV1:
+    """Result of a fail-closed presentation projection materialize attempt."""
+
+    written: bool
+    status: str
+    errors: tuple[str, ...]
+    projection_path: str | None = None
+    source_path: str | None = None
+    current_scope_ref: str | None = None
+    payload_digest: str | None = None
+
+
+def _empty_result(
+    *,
+    status: str,
+    errors: tuple[str, ...],
+    source_path: str | None = None,
+) -> DynamicScopePresentationMaterializeResultV1:
+    return DynamicScopePresentationMaterializeResultV1(
+        written=False,
+        status=status,
+        errors=errors,
+        source_path=source_path,
+    )
+
+
+def _require_nonempty_str(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _enum_or_str(value: object) -> object:
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def coerce_dynamic_scope_state_mapping_v1(
+    source: object | None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Copy persisted Dynamic Scope fields without mutating the caller-owned source.
+
+    Accepts:
+    - binder-compatible fields (scope_state/current_scope_ref or aliases)
+    - durable CanonicalDynamicScopeStateV1 JSON (existing_scope nested)
+    - nested projection envelope {"dynamic_scope": {...}}
+
+    Never invents next_scope_ref, timestamps, or productive defaults.
+    """
+    if source is None:
+        return None, (MATERIALIZE_ERROR_MISSING_SOURCE,)
+
+    raw: Mapping[str, Any]
+    if isinstance(source, Mapping):
+        raw = source
+    else:
+        extracted: dict[str, Any] = {}
+        for key in (
+            *_REQUIRED_SCOPE_ATTRS,
+            "lifecycle_state",
+            "scope_id",
+            "next_scope_ref",
+            "reason_codes",
+            "semantic_digest",
+            "evidence_digest",
+            "existing_scope",
+            "schema_version",
+            "state_version",
+            "generated_at",
+            "effective_at",
+            "source_reference",
+        ):
+            if hasattr(source, key):
+                extracted[key] = getattr(source, key)
+        raw = extracted
+
+    # Nested projection envelope: {"dynamic_scope": {...}}.
+    if "dynamic_scope" in raw and isinstance(raw.get("dynamic_scope"), Mapping):
+        nested = raw["dynamic_scope"]
+        top_ref = raw.get("current_scope_ref")
+        nested_ref = nested.get("current_scope_ref")
+        if (
+            isinstance(top_ref, str)
+            and top_ref.strip()
+            and isinstance(nested_ref, str)
+            and nested_ref.strip()
+            and top_ref.strip() != nested_ref.strip()
+        ):
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_SCOPE_INVALID)
+        if not all(key in raw for key in _REQUIRED_SCOPE_ATTRS):
+            raw = nested
+
+    scope = deepcopy(dict(raw))
+
+    # Durable CanonicalDynamicScopeStateV1 shape → extract existing_scope fields only.
+    existing = scope.get("existing_scope")
+    looks_like_durable_state = (
+        isinstance(existing, Mapping)
+        or scope.get("schema_version") == PRODUCER_STATE_SCHEMA_VERSION
+        or scope.get("state_version") == PRODUCER_STATE_VERSION
+        or "scope_session_id" in scope
+    )
+    if looks_like_durable_state:
+        schema_version = scope.get("schema_version")
+        if schema_version is not None and schema_version != PRODUCER_STATE_SCHEMA_VERSION:
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_SCHEMA_MISMATCH)
+        state_version = scope.get("state_version")
+        if state_version is not None and state_version != PRODUCER_STATE_VERSION:
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_SCHEMA_MISMATCH)
+        if not isinstance(existing, Mapping):
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_SCOPE_INVALID)
+        mapped: dict[str, Any] = {}
+        lifecycle = _enum_or_str(existing.get("lifecycle_state"))
+        scope_id = existing.get("scope_id")
+        if _require_nonempty_str(lifecycle) is None or _require_nonempty_str(scope_id) is None:
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_SCOPE_INVALID)
+        mapped["scope_state"] = str(lifecycle).strip()
+        mapped["current_scope_ref"] = str(scope_id).strip()
+        # next_scope_ref is not part of durable CanonicalDynamicScopeStateV1 —
+        # only pass through when explicitly present on the durable payload.
+        if "next_scope_ref" in scope:
+            mapped["next_scope_ref"] = scope.get("next_scope_ref")
+        if "reason_codes" in existing:
+            mapped["reason_codes"] = existing.get("reason_codes")
+        digest = existing.get("semantic_digest")
+        if digest is None:
+            digest = existing.get("evidence_digest")
+        if digest is not None:
+            mapped["semantic_digest"] = digest
+            mapped["evidence_digest"] = digest
+        scope = mapped
+
+    # Binder alias normalization (exact field copy; no semantic reinterpretation).
+    if "scope_state" not in scope and "lifecycle_state" in scope:
+        scope["scope_state"] = _enum_or_str(scope.get("lifecycle_state"))
+    if "current_scope_ref" not in scope and "scope_id" in scope:
+        scope["current_scope_ref"] = scope.get("scope_id")
+
+    for key in ("scope_state", "current_scope_ref"):
+        value = scope.get(key)
+        if isinstance(value, Enum):
+            scope[key] = value.value
+
+    missing = [key for key in _REQUIRED_SCOPE_ATTRS if key not in scope]
+    if missing:
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_SCOPE_INVALID)
+
+    if _require_nonempty_str(scope.get("scope_state")) is None:
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_SCOPE_INVALID)
+    if _require_nonempty_str(scope.get("current_scope_ref")) is None:
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_SCOPE_INVALID)
+    scope["scope_state"] = str(scope["scope_state"]).strip()
+    scope["current_scope_ref"] = str(scope["current_scope_ref"]).strip()
+
+    if "next_scope_ref" in scope:
+        raw_next = scope.get("next_scope_ref")
+        if raw_next is None:
+            scope["next_scope_ref"] = None
+        elif isinstance(raw_next, Enum):
+            scope["next_scope_ref"] = str(raw_next.value).strip() or None
+        elif isinstance(raw_next, str):
+            stripped = raw_next.strip()
+            scope["next_scope_ref"] = stripped if stripped else None
+        else:
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_SCOPE_INVALID)
+
+    return scope, ()
+
+
+def build_dynamic_scope_presentation_projection_payload_v1(
+    *,
+    dynamic_scope: object,
+    generated_at: str,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Build the loader-compatible projection envelope from Dynamic Scope fields."""
+    scope_mapping, coerce_errors = coerce_dynamic_scope_state_mapping_v1(dynamic_scope)
+    if scope_mapping is None:
+        return None, coerce_errors
+
+    if _require_nonempty_str(generated_at) is None:
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+
+    binder_fields, map_errors = map_dynamic_scope_fields_to_binder_fields_v1(
+        dynamic_scope=scope_mapping,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return None, map_errors
+
+    scope_out: dict[str, Any] = {
+        "current_scope_ref": binder_fields["current_scope_ref"],
+        "reason_codes": list(binder_fields.get("reason_codes", ())),
+        "scope_state": binder_fields["scope_state"],
+    }
+    if "next_scope_ref" in binder_fields:
+        scope_out["next_scope_ref"] = binder_fields["next_scope_ref"]
+    if "semantic_digest" in binder_fields:
+        scope_out["semantic_digest"] = binder_fields["semantic_digest"]
+        scope_out["evidence_digest"] = binder_fields["semantic_digest"]
+
+    payload: dict[str, Any] = {
+        "authority_effect": AUTHORITY_EFFECT,
+        "dynamic_scope": scope_out,
+        "dynamic_scope_authority_effect": DYNAMIC_SCOPE_AUTHORITY_EFFECT,
+        "generated_at": binder_fields["generated_at"],
+        "projection_role": PROJECTION_ROLE,
+        "schema_name": SCHEMA_NAME,
+        "schema_version": SCHEMA_VERSION,
+    }
+    if "effective_at" in binder_fields:
+        payload["effective_at"] = binder_fields["effective_at"]
+    if "source_reference" in binder_fields:
+        payload["source_reference"] = binder_fields["source_reference"]
+    return payload, ()
+
+
+def serialize_dynamic_scope_presentation_projection_v1(
+    payload: Mapping[str, Any],
+) -> str:
+    """Deterministic JSON serialization for the presentation projection artifact."""
+    return json.dumps(dict(payload), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def _atomic_write_text(*, destination: Path, body: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, destination)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def write_dynamic_scope_presentation_projection_v1(
+    archive_root: str | Path,
+    payload: Mapping[str, Any],
+) -> DynamicScopePresentationMaterializeResultV1:
+    """Atomically persist an already-validated projection payload."""
+    if payload.get("schema_name") != SCHEMA_NAME:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_SCHEMA_MISMATCH,),
+        )
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_SCHEMA_MISMATCH,),
+        )
+    if (
+        payload.get("authority_effect") != AUTHORITY_EFFECT
+        or payload.get("dynamic_scope_authority_effect") != DYNAMIC_SCOPE_AUTHORITY_EFFECT
+    ):
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(MATERIALIZE_ERROR_INVALID_SOURCE,),
+        )
+
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    body = serialize_dynamic_scope_presentation_projection_v1(payload)
+    try:
+        _atomic_write_text(destination=path, body=body)
+    except OSError:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(MATERIALIZE_ERROR_WRITE_FAILED,),
+        )
+
+    scope = payload.get("dynamic_scope")
+    current_scope_ref = None
+    if isinstance(scope, Mapping):
+        raw_ref = scope.get("current_scope_ref")
+        if isinstance(raw_ref, str) and raw_ref.strip():
+            current_scope_ref = raw_ref.strip()
+
+    return DynamicScopePresentationMaterializeResultV1(
+        written=True,
+        status=STATUS_WRITTEN,
+        errors=(),
+        projection_path=str(path),
+        current_scope_ref=current_scope_ref,
+        payload_digest=hashlib.sha256(body.encode("utf-8")).hexdigest(),
+    )
+
+
+def try_load_dynamic_scope_state_source_v1(
+    archive_root: str | Path,
+) -> tuple[dict[str, Any] | None, tuple[str, ...], str | None]:
+    """Load the sole durable Dynamic Scope state sibling without inventing content."""
+    root = Path(archive_root).expanduser().resolve()
+    path = root / SOURCE_STATE_RELATIVE_PATH
+    source_path = str(path)
+    if not path.is_file():
+        return None, (MATERIALIZE_ERROR_MISSING_SOURCE,), source_path
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None, (MATERIALIZE_ERROR_INVALID_JSON,), source_path
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None, (MATERIALIZE_ERROR_INVALID_JSON,), source_path
+    if not isinstance(payload, dict):
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE,), source_path
+    scope, errors = coerce_dynamic_scope_state_mapping_v1(payload)
+    if scope is None:
+        return None, errors, source_path
+    return scope, (), source_path
+
+
+def materialize_dynamic_scope_presentation_projection_v1(
+    archive_root: str | Path,
+    *,
+    dynamic_scope: object | None = None,
+    generated_at: str | None = None,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> DynamicScopePresentationMaterializeResultV1:
+    """Materialize the presentation projection from Dynamic Scope fields or durable source.
+
+    Missing source yields MISSING_SOURCE and does not write an artifact.
+    Invalid source or missing required timestamps fail closed without writing.
+    Caller-owned Dynamic Scope inputs are never mutated.
+    """
+    source_path: str | None = None
+    source_obj: object | None = dynamic_scope
+    if source_obj is None:
+        loaded, load_errors, source_path = try_load_dynamic_scope_state_source_v1(archive_root)
+        if loaded is None:
+            status = (
+                STATUS_MISSING_SOURCE
+                if MATERIALIZE_ERROR_MISSING_SOURCE in load_errors
+                else STATUS_FAIL_CLOSED
+            )
+            return _empty_result(status=status, errors=load_errors, source_path=source_path)
+        source_obj = loaded
+
+    if _require_nonempty_str(generated_at) is None:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_TIMESTAMP_MISSING,),
+            source_path=source_path,
+        )
+
+    # Snapshot caller-owned mapping to prove / preserve non-mutation.
+    caller_snapshot = deepcopy(dynamic_scope) if isinstance(dynamic_scope, Mapping) else None
+
+    payload, build_errors = build_dynamic_scope_presentation_projection_payload_v1(
+        dynamic_scope=source_obj,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_reference=source_reference,
+    )
+    if isinstance(dynamic_scope, Mapping) and caller_snapshot is not None:
+        if dict(dynamic_scope) != dict(caller_snapshot):
+            return _empty_result(
+                status=STATUS_FAIL_CLOSED,
+                errors=(MATERIALIZE_ERROR_INVALID_SOURCE,),
+                source_path=source_path,
+            )
+    if payload is None:
+        status = (
+            STATUS_MISSING_SOURCE
+            if MATERIALIZE_ERROR_MISSING_SOURCE in build_errors
+            else STATUS_FAIL_CLOSED
+        )
+        return _empty_result(status=status, errors=build_errors, source_path=source_path)
+
+    result = write_dynamic_scope_presentation_projection_v1(archive_root, payload)
+    if not result.written:
+        return result
+    return DynamicScopePresentationMaterializeResultV1(
+        written=True,
+        status=STATUS_WRITTEN,
+        errors=(),
+        projection_path=result.projection_path,
+        source_path=source_path,
+        current_scope_ref=result.current_scope_ref,
+        payload_digest=result.payload_digest,
+    )

--- a/src/webui/workflow_dashboard_readmodel_v1/dynamic_scope_presentation_projection_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/dynamic_scope_presentation_projection_v1.py
@@ -1,0 +1,283 @@
+"""Non-authoritative presentation projection for Dynamic Scope lifecycle identity.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_DYNAMIC_SCOPE_PROJECTION_MATERIALIZER_AUTOBIND_V1
+
+Reads already-produced Dynamic Scope lifecycle identity fields from a single
+durable archive path and maps them field-for-field into Landscape binder
+injection fields. This module:
+
+- AUTHORITY_EFFECT=NONE
+- DYNAMIC_SCOPE_AUTHORITY_EFFECT=NONE
+- never creates, mutates, or evaluates Dynamic Scope state
+- never imports trading.master_v2 scope initializers or transition owners
+- never imports ops.dynamic_scope_persistence_binding_v1 writers
+- never calls initialize/transition/persist Dynamic Scope APIs
+- fail-closed: missing, invalid, or ambiguous sources → no fields (MISSING_SOURCE)
+
+Deterministic source selection: exactly one well-known relative path under the
+Workflow Dashboard archive root. No silent multi-candidate "latest" picking.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_NAME = "dynamic_scope_presentation_projection.v1"
+SCHEMA_VERSION = 1
+STORAGE_RELATIVE_PATH = "readmodels/dynamic_scope_presentation_projection.v1.json"
+AUTHORITY_EFFECT = "NONE"
+DYNAMIC_SCOPE_AUTHORITY_EFFECT = "NONE"
+PROJECTION_ROLE = "NON_AUTHORITATIVE_PRESENTATION_PROJECTION"
+OWNER_MODULE = "webui.workflow_dashboard_readmodel_v1.dynamic_scope_presentation_projection_v1"
+
+LOAD_ERROR_ABSENT = "DYNAMIC_SCOPE_PRESENTATION_PROJECTION_ABSENT"
+LOAD_ERROR_INVALID_JSON = "DYNAMIC_SCOPE_PRESENTATION_PROJECTION_INVALID_JSON"
+LOAD_ERROR_SCHEMA_MISMATCH = "DYNAMIC_SCOPE_PRESENTATION_PROJECTION_SCHEMA_MISMATCH"
+LOAD_ERROR_AUTHORITY_CLAIM = "DYNAMIC_SCOPE_PRESENTATION_PROJECTION_AUTHORITY_CLAIM"
+LOAD_ERROR_SCOPE_INVALID = "DYNAMIC_SCOPE_PRESENTATION_PROJECTION_SCOPE_INVALID"
+LOAD_ERROR_AMBIGUOUS = "DYNAMIC_SCOPE_PRESENTATION_PROJECTION_AMBIGUOUS_SOURCE"
+LOAD_ERROR_TIMESTAMP_MISSING = "DYNAMIC_SCOPE_PRESENTATION_PROJECTION_TIMESTAMP_MISSING"
+
+# Exact Landscape binder contract — lifecycle identity only; no reinterpretation.
+_REQUIRED_SCOPE_KEYS = (
+    "scope_state",
+    "current_scope_ref",
+)
+
+# Pass-through vocabulary from CanonicalScopeLifecycleState (no derivation).
+KNOWN_SCOPE_STATES = frozenset(
+    {
+        "scope_uninitialized",
+        "scope_warming_up",
+        "scope_valid",
+        "scope_stale",
+        "scope_invalid",
+    }
+)
+
+
+@dataclass(frozen=True)
+class DynamicScopePresentationLoadV1:
+    """Result of a fail-closed presentation projection load attempt."""
+
+    loaded: bool
+    load_errors: tuple[str, ...]
+    binder_fields: Mapping[str, Any] | None = None
+    source_path: str | None = None
+    evidence_digest: str | None = None
+    current_scope_ref: str | None = None
+
+
+def _empty(*, load_errors: tuple[str, ...]) -> DynamicScopePresentationLoadV1:
+    return DynamicScopePresentationLoadV1(loaded=False, load_errors=load_errors)
+
+
+def _require_nonempty_str(payload: Mapping[str, Any], key: str) -> str | None:
+    raw = payload.get(key)
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return raw.strip()
+
+
+def _scope_payload_from_envelope(
+    payload: Mapping[str, Any],
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    """Extract nested dynamic_scope fields; fail closed on ambiguity."""
+    if "dynamic_scope" not in payload:
+        return None, (LOAD_ERROR_SCOPE_INVALID,)
+    scope = payload.get("dynamic_scope")
+    if not isinstance(scope, Mapping):
+        return None, (LOAD_ERROR_SCOPE_INVALID,)
+    # Reject dual top-level + nested current_scope_ref with conflicting values.
+    top_level_ref = payload.get("current_scope_ref")
+    nested_ref = scope.get("current_scope_ref")
+    if (
+        isinstance(top_level_ref, str)
+        and top_level_ref.strip()
+        and isinstance(nested_ref, str)
+        and nested_ref.strip()
+        and top_level_ref.strip() != nested_ref.strip()
+    ):
+        return None, (LOAD_ERROR_AMBIGUOUS,)
+    return scope, ()
+
+
+def _validate_scope_fields(
+    scope: Mapping[str, Any],
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    missing = [key for key in _REQUIRED_SCOPE_KEYS if key not in scope]
+    if missing:
+        return None, (LOAD_ERROR_SCOPE_INVALID,)
+
+    scope_state = _require_nonempty_str(scope, "scope_state")
+    current_scope_ref = _require_nonempty_str(scope, "current_scope_ref")
+    if scope_state is None or current_scope_ref is None:
+        return None, (LOAD_ERROR_SCOPE_INVALID,)
+    if scope_state not in KNOWN_SCOPE_STATES:
+        return None, (LOAD_ERROR_SCHEMA_MISMATCH,)
+
+    out: dict[str, Any] = {
+        "scope_state": scope_state,
+        "current_scope_ref": current_scope_ref,
+    }
+
+    if "next_scope_ref" in scope:
+        raw_next = scope.get("next_scope_ref")
+        if raw_next is None:
+            out["next_scope_ref"] = None
+        elif isinstance(raw_next, str):
+            stripped = raw_next.strip()
+            out["next_scope_ref"] = stripped if stripped else None
+        else:
+            return None, (LOAD_ERROR_SCOPE_INVALID,)
+
+    raw_codes = scope.get("reason_codes", ())
+    if raw_codes is None:
+        raw_codes = ()
+    if not isinstance(raw_codes, (list, tuple)):
+        return None, (LOAD_ERROR_SCOPE_INVALID,)
+    out["reason_codes"] = tuple(str(code) for code in raw_codes)
+
+    digest = scope.get("semantic_digest")
+    if digest is None:
+        digest = scope.get("evidence_digest")
+    if digest is not None:
+        if not isinstance(digest, str) or not digest.strip():
+            return None, (LOAD_ERROR_SCOPE_INVALID,)
+        out["semantic_digest"] = digest.strip()
+        out["evidence_digest"] = digest.strip()
+
+    return out, ()
+
+
+def map_dynamic_scope_fields_to_binder_fields_v1(
+    *,
+    dynamic_scope: Mapping[str, Any],
+    generated_at: str,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Map Dynamic Scope lifecycle fields → Landscape binder fields (projection only)."""
+    mapped, errors = _validate_scope_fields(dynamic_scope)
+    if mapped is None:
+        return None, errors
+    if not isinstance(generated_at, str) or not generated_at.strip():
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+    mapped["generated_at"] = generated_at.strip()
+    if effective_at is not None:
+        if not isinstance(effective_at, str) or not effective_at.strip():
+            return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+        mapped["effective_at"] = effective_at.strip()
+    if source_reference is not None:
+        if not isinstance(source_reference, str):
+            return None, (LOAD_ERROR_SCOPE_INVALID,)
+        mapped["source_reference"] = source_reference
+    return mapped, ()
+
+
+def try_load_dynamic_scope_presentation_projection_v1(
+    archive_root: str | Path,
+) -> DynamicScopePresentationLoadV1:
+    """Verify-before-trust read of the sole durable Dynamic Scope presentation projection.
+
+    Returns loaded=False with load_errors on any fail-closed condition. Never
+    invents Dynamic Scope lifecycle facts.
+    """
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    if not path.is_file():
+        return _empty(load_errors=(LOAD_ERROR_ABSENT,))
+
+    # Ambiguity guard: a second durable producer dump beside the projection is
+    # allowed only when identical current_scope_ref / scope_id; otherwise fail closed.
+    sibling = root / "readmodels" / "dynamic_scope_state_v1.json"
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    if not isinstance(payload, dict):
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    schema_name = payload.get("schema_name")
+    if schema_name != SCHEMA_NAME:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    authority = payload.get("authority_effect")
+    scope_authority = payload.get("dynamic_scope_authority_effect")
+    if authority != AUTHORITY_EFFECT or scope_authority != DYNAMIC_SCOPE_AUTHORITY_EFFECT:
+        return _empty(load_errors=(LOAD_ERROR_AUTHORITY_CLAIM,))
+
+    generated_at = _require_nonempty_str(payload, "generated_at")
+    if generated_at is None:
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+
+    effective_at = payload.get("effective_at")
+    if effective_at is not None and (not isinstance(effective_at, str) or not effective_at.strip()):
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+    effective_at_s = None if effective_at is None else str(effective_at).strip()
+
+    scope, scope_errors = _scope_payload_from_envelope(payload)
+    if scope is None:
+        return _empty(load_errors=scope_errors)
+
+    source_reference = payload.get("source_reference")
+    if source_reference is None:
+        source_reference = f"presentation://{STORAGE_RELATIVE_PATH}"
+    elif not isinstance(source_reference, str):
+        return _empty(load_errors=(LOAD_ERROR_SCOPE_INVALID,))
+
+    binder_fields, map_errors = map_dynamic_scope_fields_to_binder_fields_v1(
+        dynamic_scope=scope,
+        generated_at=generated_at,
+        effective_at=effective_at_s,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return _empty(load_errors=map_errors)
+
+    if sibling.is_file():
+        try:
+            sibling_payload = json.loads(sibling.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        if not isinstance(sibling_payload, dict):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        sibling_ref = sibling_payload.get("current_scope_ref")
+        if sibling_ref is None:
+            sibling_ref = sibling_payload.get("scope_id")
+        if sibling_ref is None:
+            existing = sibling_payload.get("existing_scope")
+            if isinstance(existing, Mapping):
+                sibling_ref = existing.get("scope_id")
+        if (
+            not isinstance(sibling_ref, str)
+            or not sibling_ref.strip()
+            or sibling_ref.strip() != binder_fields["current_scope_ref"]
+        ):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+
+    return DynamicScopePresentationLoadV1(
+        loaded=True,
+        load_errors=(),
+        binder_fields=binder_fields,
+        source_path=str(path),
+        evidence_digest=(
+            None
+            if binder_fields.get("semantic_digest") is None
+            else str(binder_fields.get("semantic_digest"))
+        ),
+        current_scope_ref=str(binder_fields["current_scope_ref"]),
+    )

--- a/tests/webui/test_dynamic_scope_presentation_projection_materializer_v1.py
+++ b/tests/webui/test_dynamic_scope_presentation_projection_materializer_v1.py
@@ -1,0 +1,340 @@
+"""Focused tests: CAPABILITY_PRESENTATION_DYNAMIC_SCOPE_PROJECTION_MATERIALIZER_AUTOBIND_V1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    SCOPE_PRODUCER_MODULE,
+    SCOPE_SOURCE_KIND,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT
+from src.webui.workflow_dashboard_readmodel_v1.dynamic_scope_presentation_projection_materializer_v1 import (
+    CAPABILITY_ID,
+    MATERIALIZE_ERROR_MISSING_SOURCE,
+    PRODUCER_STATE_SCHEMA_VERSION,
+    SOURCE_STATE_RELATIVE_PATH,
+    STATUS_FAIL_CLOSED,
+    STATUS_MISSING_SOURCE,
+    STATUS_WRITTEN,
+    build_dynamic_scope_presentation_projection_payload_v1,
+    materialize_dynamic_scope_presentation_projection_v1,
+    serialize_dynamic_scope_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.dynamic_scope_presentation_projection_v1 import (
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    LOAD_ERROR_SCOPE_INVALID,
+    LOAD_ERROR_TIMESTAMP_MISSING,
+    STORAGE_RELATIVE_PATH,
+    try_load_dynamic_scope_presentation_projection_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+STAMP = datetime(2026, 7, 24, 18, 0, 0, tzinfo=timezone.utc)
+PRODUCER_FRESH = "2026-07-24T17:30:00Z"
+
+
+def _binder_scope(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "scope_state": "scope_valid",
+        "current_scope_ref": "scope-eth-1",
+        "next_scope_ref": None,
+        "reason_codes": ("SCOPE_INITIALIZED",),
+        "semantic_digest": "c" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def _durable_state(**overrides: object) -> dict[str, object]:
+    existing: dict[str, object] = {
+        "scope_id": "scope-eth-1",
+        "instrument_id": "ETH-USDT-SWAP",
+        "initialized_at_trading_epoch": 1,
+        "source_market_context_id": "ctx-1",
+        "source_input_digest": "d" * 64,
+        "lifecycle_state": "scope_valid",
+        "reference_price": 100.0,
+        "volatility_estimate": 0.01,
+        "initial_volatility_distance": 1.0,
+        "scope_band": 2.0,
+        "neutral_upper_boundary": 102.0,
+        "neutral_lower_boundary": 98.0,
+        "trailing_anchor": 100.0,
+        "min_scope_band": 0.5,
+        "max_scope_band": 5.0,
+        "policy_version": "canonical_scope_initialization_policy_v1",
+        "semantic_digest": "c" * 64,
+        "reason_codes": ["SCOPE_INITIALIZED"],
+    }
+    base: dict[str, object] = {
+        "schema_version": PRODUCER_STATE_SCHEMA_VERSION,
+        "capability_id": "CAPABILITY_6_2_DYNAMIC_SCOPE_PERSISTENCE_BINDING_V1",
+        "state_version": "v1",
+        "scope_session_id": "session-1",
+        "instrument_id": "ETH-USDT-SWAP",
+        "venue": "OKX",
+        "existing_scope": existing,
+        "runtime_scope_state": None,
+        "runtime_scope_bound_instrument_id": "ETH-USDT-SWAP",
+        "confirmation_session_id": "",
+        "market_observation_epoch": 1,
+        "last_market_event_time": 1700000006.0,
+        "last_accepted_observation_identity_digest": "e" * 64,
+        "position_context": {},
+        "scope_direction_state": "LONG",
+        "side_state": "neutral_observe",
+        "host_trading_epoch": 1,
+        "price_path_tail": [],
+        "repository_sha": "a" * 40,
+        "config_digest": "f" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_source_state(archive_root: Path, payload: dict[str, object]) -> Path:
+    path = archive_root / SOURCE_STATE_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_capability_id_is_stable() -> None:
+    assert CAPABILITY_ID == (
+        "CAPABILITY_PRESENTATION_DYNAMIC_SCOPE_PROJECTION_MATERIALIZER_AUTOBIND_V1"
+    )
+
+
+def test_build_payload_is_deterministic() -> None:
+    scope = _binder_scope()
+    first, err_a = build_dynamic_scope_presentation_projection_payload_v1(
+        dynamic_scope=scope,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://unit-test",
+    )
+    second, err_b = build_dynamic_scope_presentation_projection_payload_v1(
+        dynamic_scope=scope,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://unit-test",
+    )
+    assert err_a == ()
+    assert err_b == ()
+    assert first is not None and second is not None
+    assert first == second
+    assert serialize_dynamic_scope_presentation_projection_v1(
+        first
+    ) == serialize_dynamic_scope_presentation_projection_v1(second)
+    assert first["schema_name"] == "dynamic_scope_presentation_projection.v1"
+    assert first["schema_version"] == 1
+    assert first["dynamic_scope"]["scope_state"] == "scope_valid"
+    assert first["dynamic_scope"]["current_scope_ref"] == "scope-eth-1"
+    assert first["dynamic_scope"]["next_scope_ref"] is None
+
+
+def test_invalid_schema_rejected_by_contract(tmp_path: Path) -> None:
+    result = materialize_dynamic_scope_presentation_projection_v1(
+        tmp_path,
+        dynamic_scope=_binder_scope(scope_state="not_a_known_lifecycle"),
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_SCHEMA_MISMATCH in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_materialize_writes_loader_expected_path(tmp_path: Path) -> None:
+    result = materialize_dynamic_scope_presentation_projection_v1(
+        tmp_path,
+        dynamic_scope=_binder_scope(next_scope_ref="scope-eth-2"),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert result.status == STATUS_WRITTEN
+    assert result.errors == ()
+    assert result.projection_path is not None
+    assert result.projection_path.endswith(STORAGE_RELATIVE_PATH)
+    assert (tmp_path / STORAGE_RELATIVE_PATH).is_file()
+
+
+def test_materialize_from_durable_state_projection_exact(tmp_path: Path) -> None:
+    source = _durable_state()
+    source_snapshot = deepcopy(source)
+    result = materialize_dynamic_scope_presentation_projection_v1(
+        tmp_path,
+        dynamic_scope=source,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://durable-scope",
+    )
+    assert result.written is True
+    assert source == source_snapshot  # source unchanged
+    loaded = try_load_dynamic_scope_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.binder_fields is not None
+    assert loaded.binder_fields["scope_state"] == "scope_valid"
+    assert loaded.binder_fields["current_scope_ref"] == "scope-eth-1"
+    assert "next_scope_ref" not in loaded.binder_fields  # not invented
+    assert loaded.binder_fields["semantic_digest"] == "c" * 64
+    # No invented productive fields beyond landscape contract.
+    assert set(loaded.binder_fields.keys()) <= {
+        "scope_state",
+        "current_scope_ref",
+        "next_scope_ref",
+        "reason_codes",
+        "semantic_digest",
+        "evidence_digest",
+        "generated_at",
+        "effective_at",
+        "source_reference",
+    }
+
+
+def test_missing_source_does_not_invent_artifact(tmp_path: Path) -> None:
+    result = materialize_dynamic_scope_presentation_projection_v1(
+        tmp_path,
+        dynamic_scope=None,
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_MISSING_SOURCE
+    assert MATERIALIZE_ERROR_MISSING_SOURCE in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+    loaded = try_load_dynamic_scope_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+
+
+def test_invalid_source_fail_closed(tmp_path: Path) -> None:
+    result = materialize_dynamic_scope_presentation_projection_v1(
+        tmp_path,
+        dynamic_scope={"scope_state": "scope_valid"},
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_SCOPE_INVALID in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_invalid_durable_schema_fail_closed(tmp_path: Path) -> None:
+    result = materialize_dynamic_scope_presentation_projection_v1(
+        tmp_path,
+        dynamic_scope=_durable_state(schema_version="wrong.schema"),
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_SCHEMA_MISMATCH in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_missing_generated_at_fail_closed(tmp_path: Path) -> None:
+    result = materialize_dynamic_scope_presentation_projection_v1(
+        tmp_path,
+        dynamic_scope=_binder_scope(),
+        generated_at=None,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_TIMESTAMP_MISSING in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_materialize_from_durable_producer_state_source(tmp_path: Path) -> None:
+    _write_source_state(tmp_path, _durable_state())
+    result = materialize_dynamic_scope_presentation_projection_v1(
+        tmp_path,
+        dynamic_scope=None,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert result.status == STATUS_WRITTEN
+    assert result.source_path is not None
+    assert SOURCE_STATE_RELATIVE_PATH in result.source_path
+    # Source file remains present and unchanged relative path.
+    assert (tmp_path / SOURCE_STATE_RELATIVE_PATH).is_file()
+    loaded = try_load_dynamic_scope_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.current_scope_ref == "scope-eth-1"
+
+
+def test_end_to_end_durable_state_to_autobind_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    _write_source_state(archive, _durable_state())
+    result = materialize_dynamic_scope_presentation_projection_v1(
+        archive,
+        dynamic_scope=None,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://e2e-scope-materializer",
+    )
+    assert result.written is True
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    scope = slots["dynamic_scope"]
+    assert scope.availability is Availability.AVAILABLE
+    assert scope.scope_state == "scope_valid"
+    assert scope.current_scope_ref == "scope-eth-1"
+    assert scope.next_scope_ref is None
+    assert scope.provenance.producer_module == SCOPE_PRODUCER_MODULE
+    assert scope.provenance.source_kind == SCOPE_SOURCE_KIND
+
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "scope_valid" in html
+    assert "scope-eth-1" in html
+    assert 'data-mdl-field="scope_lifecycle"' in html
+    assert 'data-mdl-region="SYSTEM_CONTEXT_RAIL"' in html
+    assert "<form" not in html.lower()
+    assert "place_order" not in html.lower()
+
+
+def test_materializer_module_has_no_forbidden_trading_or_ops_imports() -> None:
+    path = (
+        REPO
+        / "src/webui/workflow_dashboard_readmodel_v1"
+        / "dynamic_scope_presentation_projection_materializer_v1.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                continue
+            if node.module:
+                imported.add(node.module.split(".", 1)[0])
+    assert "trading" not in imported
+    assert "src" not in imported
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in {
+                "persist_dynamic_scope_state_atomic_v1",
+                "transition_state",
+                "initialize_canonical_scope",
+                "compose_double_play_decision",
+                "KillSwitch",
+            }

--- a/tests/webui/test_market_landscape_dynamic_scope_presentation_autobind_v1.py
+++ b/tests/webui/test_market_landscape_dynamic_scope_presentation_autobind_v1.py
@@ -1,0 +1,288 @@
+"""Focused tests: CAPABILITY_PRESENTATION_DYNAMIC_SCOPE_PROJECTION_MATERIALIZER_AUTOBIND_V1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    REASON_SCOPE_NOT_PERSISTED,
+    SCOPE_PRODUCER_MODULE,
+    SCOPE_SOURCE_KIND,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT
+from src.webui.workflow_dashboard_readmodel_v1.dynamic_scope_presentation_projection_v1 import (
+    AUTHORITY_EFFECT,
+    DYNAMIC_SCOPE_AUTHORITY_EFFECT,
+    LOAD_ERROR_ABSENT,
+    LOAD_ERROR_AMBIGUOUS,
+    LOAD_ERROR_AUTHORITY_CLAIM,
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    LOAD_ERROR_SCOPE_INVALID,
+    SCHEMA_NAME,
+    STORAGE_RELATIVE_PATH,
+    map_dynamic_scope_fields_to_binder_fields_v1,
+    try_load_dynamic_scope_presentation_projection_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+STAMP = datetime(2026, 7, 24, 18, 0, 0, tzinfo=timezone.utc)
+PRODUCER_FRESH = "2026-07-24T17:30:00Z"
+
+
+def _scope(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "scope_state": "scope_valid",
+        "current_scope_ref": "scope-autobind-1",
+        "next_scope_ref": "scope-autobind-2",
+        "reason_codes": ("SCOPE_INITIALIZED",),
+        "semantic_digest": "a" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def _projection_payload(
+    *,
+    dynamic_scope: dict[str, object] | None = None,
+    **overrides: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_name": SCHEMA_NAME,
+        "schema_version": 1,
+        "authority_effect": AUTHORITY_EFFECT,
+        "dynamic_scope_authority_effect": DYNAMIC_SCOPE_AUTHORITY_EFFECT,
+        "projection_role": "NON_AUTHORITATIVE_PRESENTATION_PROJECTION",
+        "generated_at": PRODUCER_FRESH,
+        "effective_at": PRODUCER_FRESH,
+        "source_reference": "presentation://dynamic_scope_autobind_test",
+        "dynamic_scope": dynamic_scope if dynamic_scope is not None else _scope(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_projection(archive_root: Path, payload: dict[str, object]) -> Path:
+    path = archive_root / STORAGE_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_map_scope_to_binder_fields_preserves_producer_facts() -> None:
+    fields, errors = map_dynamic_scope_fields_to_binder_fields_v1(
+        dynamic_scope=_scope(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://x",
+    )
+    assert errors == ()
+    assert fields is not None
+    assert fields["scope_state"] == "scope_valid"
+    assert fields["current_scope_ref"] == "scope-autobind-1"
+    assert fields["next_scope_ref"] == "scope-autobind-2"
+    assert fields["semantic_digest"] == "a" * 64
+    assert fields["generated_at"] == PRODUCER_FRESH
+
+
+def test_load_absent_projection_is_missing(tmp_path: Path) -> None:
+    loaded = try_load_dynamic_scope_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_ABSENT in loaded.load_errors
+    assert loaded.binder_fields is None
+
+
+def test_load_valid_projection_returns_binder_fields(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload())
+    loaded = try_load_dynamic_scope_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.load_errors == ()
+    assert loaded.binder_fields is not None
+    assert loaded.current_scope_ref == "scope-autobind-1"
+    assert loaded.evidence_digest == "a" * 64
+    assert STORAGE_RELATIVE_PATH in str(loaded.source_path)
+
+
+def test_load_schema_mismatch_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(schema_name="wrong.schema"))
+    loaded = try_load_dynamic_scope_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_SCHEMA_MISMATCH in loaded.load_errors
+
+
+def test_load_authority_claim_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(authority_effect="SCOPE"))
+    loaded = try_load_dynamic_scope_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_AUTHORITY_CLAIM in loaded.load_errors
+
+
+def test_load_invalid_scope_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(dynamic_scope={"scope_state": "scope_valid"}))
+    loaded = try_load_dynamic_scope_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_SCOPE_INVALID in loaded.load_errors
+
+
+def test_load_ambiguous_sibling_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload())
+    sibling = tmp_path / "readmodels" / "dynamic_scope_state_v1.json"
+    sibling.write_text(
+        json.dumps(
+            {
+                "existing_scope": {
+                    "scope_id": "other-scope",
+                    "lifecycle_state": "scope_valid",
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    loaded = try_load_dynamic_scope_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_AMBIGUOUS in loaded.load_errors
+
+
+def test_autobind_available_from_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    scope = slots["dynamic_scope"]
+    assert scope.availability is Availability.AVAILABLE
+    assert scope.scope_state == "scope_valid"
+    assert scope.current_scope_ref == "scope-autobind-1"
+    assert scope.next_scope_ref == "scope-autobind-2"
+    assert scope.provenance.producer_module == SCOPE_PRODUCER_MODULE
+    assert scope.provenance.source_kind == SCOPE_SOURCE_KIND
+    assert scope.provenance.source_reference == "presentation://dynamic_scope_autobind_test"
+    assert scope.provenance.evidence_digest == "a" * 64
+    # Other injection-only slots remain unbound / missing.
+    assert slots["canonical_decision"].availability is Availability.MISSING_SOURCE
+    assert slots["double_play"].availability is Availability.MISSING_SOURCE
+    assert slots["safety_authority"].availability is Availability.MISSING_SOURCE
+    assert slots["risk_sizing_capital"].availability is Availability.MISSING_SOURCE
+    assert slots["execution_reconciliation"].availability is Availability.MISSING_SOURCE
+    assert slots["economic_summary"].availability is Availability.MISSING_SOURCE
+    assert slots["regime_bull_bear_switch"].availability is Availability.MISSING_SOURCE
+
+
+def test_autobind_missing_projection_is_missing_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "empty_archive"
+    archive.mkdir()
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["dynamic_scope"].availability is Availability.MISSING_SOURCE
+    assert REASON_SCOPE_NOT_PERSISTED in slots["dynamic_scope"].reason_codes
+
+
+def test_autobind_invalid_projection_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "bad_archive"
+    _write_projection(archive, _projection_payload(schema_name="nope"))
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["dynamic_scope"].availability is Availability.INVALID
+    assert LOAD_ERROR_SCHEMA_MISMATCH in slots["dynamic_scope"].reason_codes
+
+
+def test_explicit_injection_still_overrides_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        dynamic_scope_fields={
+            "lifecycle_state": "scope_stale",
+            "scope_id": "injected-scope",
+            "next_scope_ref": "injected-next",
+            "reason_codes": ("INJECTED",),
+            "semantic_digest": "b" * 64,
+            "generated_at": PRODUCER_FRESH,
+            "source_reference": "scope://bounded-test-injection",
+        },
+    )
+    scope = slots["dynamic_scope"]
+    assert scope.availability is Availability.AVAILABLE
+    assert scope.scope_state == "scope_stale"
+    assert scope.current_scope_ref == "injected-scope"
+    assert scope.next_scope_ref == "injected-next"
+    assert scope.provenance.source_reference == "scope://bounded-test-injection"
+
+
+def test_get_market_autobinds_dynamic_scope_without_injection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(
+        archive,
+        _projection_payload(
+            dynamic_scope=_scope(
+                scope_state="scope_valid",
+                current_scope_ref="scope-shell-1",
+                next_scope_ref=None,
+                reason_codes=("AUTOBIND_OK",),
+            )
+        ),
+    )
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "scope_valid" in html
+    assert "scope-shell-1" in html
+    assert 'data-mdl-field="scope_lifecycle"' in html
+    assert 'data-mdl-field="current_scope_ref"' in html
+    assert 'data-mdl-region="SYSTEM_CONTEXT_RAIL"' in html
+    assert "<form" not in html.lower()
+    assert "place_order" not in html.lower()
+
+
+def test_projection_module_has_no_forbidden_trading_imports() -> None:
+    path = (
+        REPO
+        / "src/webui/workflow_dashboard_readmodel_v1/dynamic_scope_presentation_projection_v1.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                continue
+            if node.module:
+                imported.add(node.module.split(".", 1)[0])
+    assert "trading" not in imported
+    assert "src" not in imported
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in {
+                "persist_dynamic_scope_state_atomic_v1",
+                "transition_state",
+                "compose_double_play_decision",
+                "KillSwitch",
+            }


### PR DESCRIPTION
## Summary

- **Capability-ID:** `CAPABILITY_PRESENTATION_DYNAMIC_SCOPE_PROJECTION_MATERIALIZER_AUTOBIND_V1`
- **Problem:** Durable Dynamic-Scope persistence ended before Landscape presentation (`dynamic_scope` remained `DURABLE_SOURCE_BUT_PRESENTATION_GAP` / `MISSING_SOURCE` without injection).
- **Solution:** Presentation-only projection contract + materializer + archive path + producer-binding autobind, following Bull/Bear, Canonical Decision, and Double Play patterns.
- Source-State (`dynamic_scope_state_v1.json`) remains unchanged; projection is a separate non-authoritative artifact.
- No Trading-/Runtime-/Authority-Änderung; UI adapts to existing truth only.
- Missing projection artifact continues to surface honest `MISSING_SOURCE` (`CANONICAL_SCOPE_SNAPSHOT_NOT_PERSISTED_FOR_DASHBOARD`).
- Explicit injection remains higher priority than archive autobind.
- Tombstone negative guard (`tests/webui/test_market_dashboard_tombstone_v1.py`) unchanged; no tombstone reintroduction.

## Presentation boundary confirmation

Allowed path only:

`Durable Dynamic-Scope-State → Presentation Projection → Materializer → Archive Artifact → Producer Binding Autobind → Landscape-v2 Slot → Shell GET /market`

Unchanged / forbidden:

- `src/ops/dynamic_scope_persistence_binding_v1/**`
- `src/trading/**`
- Dynamic-Scope trading logic, transitions, canonical authority, runtime/producer mutation
- Legacy market dashboard product resurrection (`market_surface`, `create_market_router`, legacy templates/CSS)

## Tests

- Focused: `test_dynamic_scope_presentation_projection_materializer_v1.py`, `test_market_landscape_dynamic_scope_presentation_autobind_v1.py` (25 passed)
- Bounded regression: bull/bear, decision, double play, producer binding, archive root, shell route, contracts, tombstone guard (230 passed)
- Architecture guards (capability-relevant / excluding pre-existing `origin/main` presenter ops-import failure outside this diff): 18 passed
- PR-bounded selector targets: 729 passed
- Ruff format/check: pass

## Test plan

- [x] Projection contract + materializer unit coverage
- [x] Autobind without injection; missing artifact; injection priority
- [x] Shell reachability `GET /market`
- [x] Presentation-layer architecture guards (no trading/ops mutation imports)
- [x] Sibling presentation regression + tombstone negative guard unchanged
- [ ] Required GitHub checks confirm green
- [ ] Owner merge GO before merge (do not merge without explicit Owner-GO)


Made with [Cursor](https://cursor.com)