### PR TITLE
feat(webui): autobind execution reconciliation presentation projection

### DIFF
--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -8,7 +8,8 @@ evidence (injection or durable presentation projection auto-bind),
 double_play display projection (injection or durable presentation projection
 auto-bind), safety authority KillSwitch/boundary field projection,
 risk/sizing/capital field projection (injection or durable presentation
-projection auto-bind), execution/reconciliation field projection, and
+projection auto-bind), execution/reconciliation field projection (injection
+or durable presentation projection auto-bind), and
 economic summary EconomicViabilityEvidenceV1 field projection.
 Lives outside market_dashboard_landscape_v2 so that package stays free of
 trading/webui producer imports (architecture guard).
@@ -89,6 +90,10 @@ from .workflow_dashboard_readmodel_v1.dynamic_scope_presentation_projection_v1 i
 from .workflow_dashboard_readmodel_v1.risk_sizing_capital_presentation_projection_v1 import (
     LOAD_ERROR_ABSENT as RISK_SIZING_CAPITAL_PROJECTION_ABSENT,
     try_load_risk_sizing_capital_presentation_projection_v1,
+)
+from .workflow_dashboard_readmodel_v1.execution_reconciliation_presentation_projection_v1 import (
+    LOAD_ERROR_ABSENT as EXECUTION_RECONCILIATION_PROJECTION_ABSENT,
+    try_load_execution_reconciliation_presentation_projection_v1,
 )
 from .workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
     FORBIDDEN_SELECTED_SYMBOLS,
@@ -1823,19 +1828,45 @@ def _bind_execution_reconciliation(
     as_of: datetime,
     git_sha: str | None,
     execution_reconciliation_fields: Mapping[str, Any] | None,
+    archive_root: Path | None = None,
 ) -> Any:
-    """Project injected Execution/Reconciliation fields.
+    """Project already-selected Execution/Reconciliation fields.
 
-    No durable dashboard Execution readmodel. Without injection → MISSING_SOURCE.
-    Never builds order intents, never calls execution/order APIs, never mutates
-    reconciliation. reconciliation_status / order_intent_ref may be absent.
+    Injection remains supported for tests. Productive auto-bind loads the
+    non-authoritative presentation projection from the Workflow Dashboard
+    archive root when injection is absent. Never builds order intents, never
+    calls execution/order APIs, never mutates reconciliation.
+    reconciliation_status / order_intent_ref may be absent.
     """
     if execution_reconciliation_fields is None:
-        return unavailable_execution_reconciliation(
-            availability=Availability.MISSING_SOURCE,
-            generated_at=as_of,
-            reason=REASON_EXECUTION_NOT_PERSISTED,
-        )
+        if archive_root is None:
+            return unavailable_execution_reconciliation(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_EXECUTION_NOT_PERSISTED,
+            )
+        loaded = try_load_execution_reconciliation_presentation_projection_v1(archive_root)
+        if not loaded.loaded or loaded.binder_fields is None:
+            reason = REASON_EXECUTION_NOT_PERSISTED
+            if loaded.load_errors:
+                first = str(loaded.load_errors[0])
+                if first != EXECUTION_RECONCILIATION_PROJECTION_ABSENT:
+                    reason = first
+            availability = (
+                Availability.MISSING_SOURCE
+                if reason == REASON_EXECUTION_NOT_PERSISTED
+                or reason == EXECUTION_RECONCILIATION_PROJECTION_ABSENT
+                else Availability.INVALID
+            )
+            if reason == EXECUTION_RECONCILIATION_PROJECTION_ABSENT:
+                reason = REASON_EXECUTION_NOT_PERSISTED
+                availability = Availability.MISSING_SOURCE
+            return unavailable_execution_reconciliation(
+                availability=availability,
+                generated_at=as_of,
+                reason=reason,
+            )
+        execution_reconciliation_fields = loaded.binder_fields
 
     schema_version = execution_reconciliation_fields.get("schema_version")
     if schema_version is not None and str(schema_version) != LANDSCAPE_PROJECTION_SCHEMA_VERSION:
@@ -2005,7 +2036,9 @@ def bind_market_universe_slots(
     execution_reconciliation_fields accepts already-selected Execution/
     Reconciliation display fields (execution_status[/reconciliation_status]/
     order_intent_ref]) plus producer wall-clock timestamps. Without injection,
-    execution_reconciliation is MISSING_SOURCE. Never builds intents or calls
+    productive auto-bind loads
+    execution_reconciliation_presentation_projection.v1 when present;
+    otherwise MISSING_SOURCE. Never builds intents or calls
     execution/order/reconciliation mutation APIs.
 
     economic_viability_evidence_fields accepts already-selected
@@ -2062,6 +2095,7 @@ def bind_market_universe_slots(
         as_of=as_of,
         git_sha=git_sha,
         execution_reconciliation_fields=execution_reconciliation_fields,
+        archive_root=root,
     )
     economic = _bind_economic_summary(
         as_of=as_of,

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -162,15 +162,19 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
         authority_class="execution_intent",
         reuse_status="REUSED",
         notes=(
-            "Phase 4.5: Landscape projects injected Execution/Reconciliation "
-            "fields field-for-field (execution_status/reconciliation_status/"
-            "order_intent_ref/reason_codes); authority owner remains "
-            "src.governance.canonical_order_intent_v1; offline replay adapter is "
-            "non-authority wiring/parity only; dashboard AUTHORITY_EFFECT=NONE; "
-            "explicit injection only; without injection MISSING_SOURCE; "
-            "reconciliation_status may be absent (partial) and must not be "
-            "invented; never import order/execution mutation APIs or call "
-            "build_canonical_order_intent_v1 / evaluate_offline_reconciliation_*."
+            "Phase 4.5 + CAPABILITY_PRESENTATION_EXECUTION_RECONCILIATION_"
+            "PROJECTION_MATERIALIZER_AUTOBIND_V1: Landscape projects "
+            "Execution/Reconciliation fields field-for-field "
+            "(execution_status/reconciliation_status/order_intent_ref/reason_codes); "
+            "authority owner remains src.governance.canonical_order_intent_v1; "
+            "offline replay adapter is non-authority wiring/parity only; "
+            "dashboard AUTHORITY_EFFECT=NONE; durable auto-bind via "
+            "non-authoritative execution_reconciliation_presentation_projection.v1 "
+            "under archive root; injection remains test-compatible; without "
+            "injection/projection MISSING_SOURCE; reconciliation_status may be "
+            "absent (partial) and must not be invented; never import "
+            "order/execution mutation APIs or call build_canonical_order_intent_v1 "
+            "/ evaluate_offline_reconciliation_*."
         ),
     ),
     CanonicalOwnerRefV1(

--- a/src/webui/workflow_dashboard_archive_root_v1.py
+++ b/src/webui/workflow_dashboard_archive_root_v1.py
@@ -11,7 +11,9 @@ bull_bear_regime_presentation_projection.v1,
 dynamic_scope_presentation_projection.v1 (plus its durable source sibling
 dynamic_scope_state_v1.json under the same archive root), and
 risk_sizing_capital_presentation_projection.v1 (plus its durable source sibling
-risk_sizing_capital.v1.json under the same archive root).
+risk_sizing_capital.v1.json under the same archive root), and
+execution_reconciliation_presentation_projection.v1 (plus its durable source sibling
+execution_reconciliation.v1.json under the same archive root).
 """
 
 from __future__ import annotations
@@ -62,6 +64,10 @@ DYNAMIC_SCOPE_PRESENTATION_PROJECTION_RELATIVE = (
 RISK_SIZING_CAPITAL_FIELDS_RELATIVE = "readmodels/risk_sizing_capital.v1.json"
 RISK_SIZING_CAPITAL_PRESENTATION_PROJECTION_RELATIVE = (
     "readmodels/risk_sizing_capital_presentation_projection.v1.json"
+)
+EXECUTION_RECONCILIATION_FIELDS_RELATIVE = "readmodels/execution_reconciliation.v1.json"
+EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_RELATIVE = (
+    "readmodels/execution_reconciliation_presentation_projection.v1.json"
 )
 _DISCOVER_NAME_PREFIX = "workflow_dashboard_v1"
 
@@ -426,6 +432,8 @@ __all__ = [
     "DYNAMIC_SCOPE_PRESENTATION_PROJECTION_RELATIVE",
     "DYNAMIC_SCOPE_STATE_RELATIVE",
     "ENV_ARCHIVE_ROOT",
+    "EXECUTION_RECONCILIATION_FIELDS_RELATIVE",
+    "EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_RELATIVE",
     "OKX_OHLCV_READMODEL_RELATIVE",
     "OWNER_MODULE",
     "OWNER_SYMBOL",

--- a/src/webui/workflow_dashboard_readmodel_v1/execution_reconciliation_presentation_projection_materializer_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/execution_reconciliation_presentation_projection_materializer_v1.py
@@ -1,0 +1,423 @@
+"""Non-authoritative materializer for Execution/Reconciliation presentation projection.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_EXECUTION_RECONCILIATION_PROJECTION_MATERIALIZER_AUTOBIND_V1
+
+Consumes already-produced Execution/Reconciliation binder-compatible field
+payloads (or the durable sibling dump under the Workflow Dashboard archive root)
+and writes the non-authoritative presentation projection schema to the
+loader-owned path. This module:
+
+- AUTHORITY_EFFECT=NONE
+- EXECUTION_AUTHORITY_EFFECT=NONE
+- never creates, mutates, or evaluates order intents / reconciliation
+- never imports src.governance.canonical_order_intent_v1 builders
+- never imports trading.master_v2 order-intent offline adapters
+- never invents execution_status, reconciliation_status, order_intent_ref,
+  timestamps, or reason_codes
+- fail-closed: missing source → MISSING_SOURCE and no artifact write;
+  invalid source → FAIL_CLOSED and no artifact write
+- projection remains non-authoritative and must never flow back into runtime
+  or authority chains
+
+Deterministic serialization and atomic replace only. This projection path does
+not own a separate MANIFEST contract; integrity follows the existing loader
+schema/authority/fields checks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from .execution_reconciliation_presentation_projection_v1 import (
+    AUTHORITY_EFFECT,
+    EXECUTION_AUTHORITY_EFFECT,
+    LOAD_ERROR_FIELDS_INVALID,
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    LOAD_ERROR_TIMESTAMP_MISSING,
+    PROJECTION_ROLE,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    SOURCE_FIELDS_RELATIVE_PATH,
+    STORAGE_RELATIVE_PATH,
+    map_execution_reconciliation_fields_to_binder_fields_v1,
+)
+
+CAPABILITY_ID = (
+    "CAPABILITY_PRESENTATION_EXECUTION_RECONCILIATION_PROJECTION_MATERIALIZER_AUTOBIND_V1"
+)
+OWNER_MODULE = (
+    "webui.workflow_dashboard_readmodel_v1."
+    "execution_reconciliation_presentation_projection_materializer_v1"
+)
+
+STATUS_WRITTEN = "WRITTEN"
+STATUS_MISSING_SOURCE = "MISSING_SOURCE"
+STATUS_FAIL_CLOSED = "FAIL_CLOSED"
+
+MATERIALIZE_ERROR_MISSING_SOURCE = "MISSING_SOURCE"
+MATERIALIZE_ERROR_INVALID_JSON = "EXECUTION_RECONCILIATION_PRESENTATION_MATERIALIZER_INVALID_JSON"
+MATERIALIZE_ERROR_INVALID_SOURCE = (
+    "EXECUTION_RECONCILIATION_PRESENTATION_MATERIALIZER_INVALID_SOURCE"
+)
+MATERIALIZE_ERROR_WRITE_FAILED = "EXECUTION_RECONCILIATION_PRESENTATION_MATERIALIZER_WRITE_FAILED"
+
+_REQUIRED_FIELD_ATTRS = ("execution_status",)
+
+
+@dataclass(frozen=True)
+class ExecutionReconciliationPresentationMaterializeResultV1:
+    """Result of a fail-closed presentation projection materialize attempt."""
+
+    written: bool
+    status: str
+    errors: tuple[str, ...]
+    projection_path: str | None = None
+    source_path: str | None = None
+    execution_status: str | None = None
+    payload_digest: str | None = None
+
+
+def _empty_result(
+    *,
+    status: str,
+    errors: tuple[str, ...],
+    source_path: str | None = None,
+) -> ExecutionReconciliationPresentationMaterializeResultV1:
+    return ExecutionReconciliationPresentationMaterializeResultV1(
+        written=False,
+        status=status,
+        errors=errors,
+        source_path=source_path,
+    )
+
+
+def _require_nonempty_str(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _enum_or_str(value: object) -> object:
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def coerce_execution_reconciliation_fields_mapping_v1(
+    source: object | None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Copy already-selected Execution/Reconciliation fields without mutation.
+
+    Accepts:
+    - binder-compatible fields (execution_status[/reconciliation_status|/order_intent_ref])
+    - nested projection envelope {"execution_reconciliation": {...}}
+    - objects exposing ExecutionReconciliationSnapshotV1-compatible attributes
+
+    Never invents statuses, refs, timestamps, or productive defaults.
+    """
+    if source is None:
+        return None, (MATERIALIZE_ERROR_MISSING_SOURCE,)
+
+    raw: Mapping[str, Any]
+    if isinstance(source, Mapping):
+        raw = source
+    else:
+        extracted: dict[str, Any] = {}
+        for key in (
+            *_REQUIRED_FIELD_ATTRS,
+            "reconciliation_status",
+            "order_intent_ref",
+            "reason_codes",
+            "evidence_digest",
+            "semantic_digest",
+            "schema_version",
+            "generated_at",
+            "effective_at",
+            "source_reference",
+            "execution_reconciliation",
+        ):
+            if hasattr(source, key):
+                extracted[key] = getattr(source, key)
+        raw = extracted
+
+    # Nested projection envelope: {"execution_reconciliation": {...}}.
+    if "execution_reconciliation" in raw and isinstance(
+        raw.get("execution_reconciliation"), Mapping
+    ):
+        nested = raw["execution_reconciliation"]
+        top_status = raw.get("execution_status")
+        nested_status = nested.get("execution_status")
+        if (
+            isinstance(top_status, str)
+            and top_status.strip()
+            and isinstance(nested_status, str)
+            and nested_status.strip()
+            and top_status.strip() != nested_status.strip()
+        ):
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID)
+        if not all(key in raw for key in _REQUIRED_FIELD_ATTRS):
+            raw = nested
+
+    fields = deepcopy(dict(raw))
+
+    for key in _REQUIRED_FIELD_ATTRS:
+        value = fields.get(key)
+        if isinstance(value, Enum):
+            fields[key] = value.value
+
+    missing = [key for key in _REQUIRED_FIELD_ATTRS if key not in fields]
+    if missing:
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID)
+
+    for key in _REQUIRED_FIELD_ATTRS:
+        if _require_nonempty_str(_enum_or_str(fields.get(key))) is None:
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID)
+        fields[key] = str(_enum_or_str(fields[key])).strip()
+
+    return fields, ()
+
+
+def build_execution_reconciliation_presentation_projection_payload_v1(
+    *,
+    execution_reconciliation: object,
+    generated_at: str,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Build the loader-compatible projection envelope from Execution fields."""
+    fields_mapping, coerce_errors = coerce_execution_reconciliation_fields_mapping_v1(
+        execution_reconciliation
+    )
+    if fields_mapping is None:
+        return None, coerce_errors
+
+    if _require_nonempty_str(generated_at) is None:
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+
+    binder_fields, map_errors = map_execution_reconciliation_fields_to_binder_fields_v1(
+        execution_reconciliation=fields_mapping,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return None, map_errors
+
+    execution_out: dict[str, Any] = {
+        "execution_status": binder_fields["execution_status"],
+        "reason_codes": list(binder_fields.get("reason_codes", ())),
+    }
+    if "reconciliation_status" in binder_fields:
+        execution_out["reconciliation_status"] = binder_fields["reconciliation_status"]
+    if "order_intent_ref" in binder_fields:
+        execution_out["order_intent_ref"] = binder_fields["order_intent_ref"]
+    if "evidence_digest" in binder_fields:
+        execution_out["evidence_digest"] = binder_fields["evidence_digest"]
+        execution_out["semantic_digest"] = binder_fields["evidence_digest"]
+    if "schema_version" in binder_fields:
+        execution_out["schema_version"] = binder_fields["schema_version"]
+
+    payload: dict[str, Any] = {
+        "authority_effect": AUTHORITY_EFFECT,
+        "execution_authority_effect": EXECUTION_AUTHORITY_EFFECT,
+        "execution_reconciliation": execution_out,
+        "generated_at": binder_fields["generated_at"],
+        "projection_role": PROJECTION_ROLE,
+        "schema_name": SCHEMA_NAME,
+        "schema_version": SCHEMA_VERSION,
+    }
+    if "effective_at" in binder_fields:
+        payload["effective_at"] = binder_fields["effective_at"]
+    if "source_reference" in binder_fields:
+        payload["source_reference"] = binder_fields["source_reference"]
+    return payload, ()
+
+
+def serialize_execution_reconciliation_presentation_projection_v1(
+    payload: Mapping[str, Any],
+) -> str:
+    """Deterministic JSON serialization for the presentation projection artifact."""
+    return json.dumps(dict(payload), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def _atomic_write_text(*, destination: Path, body: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, destination)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def write_execution_reconciliation_presentation_projection_v1(
+    archive_root: str | Path,
+    payload: Mapping[str, Any],
+) -> ExecutionReconciliationPresentationMaterializeResultV1:
+    """Atomically persist an already-validated projection payload."""
+    if payload.get("schema_name") != SCHEMA_NAME:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_SCHEMA_MISMATCH,),
+        )
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_SCHEMA_MISMATCH,),
+        )
+    if (
+        payload.get("authority_effect") != AUTHORITY_EFFECT
+        or payload.get("execution_authority_effect") != EXECUTION_AUTHORITY_EFFECT
+    ):
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(MATERIALIZE_ERROR_INVALID_SOURCE,),
+        )
+
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    body = serialize_execution_reconciliation_presentation_projection_v1(payload)
+    try:
+        _atomic_write_text(destination=path, body=body)
+    except OSError:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(MATERIALIZE_ERROR_WRITE_FAILED,),
+        )
+
+    execution = payload.get("execution_reconciliation")
+    execution_status = None
+    if isinstance(execution, Mapping):
+        raw_status = execution.get("execution_status")
+        if isinstance(raw_status, str) and raw_status.strip():
+            execution_status = raw_status.strip()
+
+    return ExecutionReconciliationPresentationMaterializeResultV1(
+        written=True,
+        status=STATUS_WRITTEN,
+        errors=(),
+        projection_path=str(path),
+        execution_status=execution_status,
+        payload_digest=hashlib.sha256(body.encode("utf-8")).hexdigest(),
+    )
+
+
+def try_load_execution_reconciliation_fields_source_v1(
+    archive_root: str | Path,
+) -> tuple[dict[str, Any] | None, tuple[str, ...], str | None]:
+    """Load the sole durable Execution fields sibling without inventing content."""
+    root = Path(archive_root).expanduser().resolve()
+    path = root / SOURCE_FIELDS_RELATIVE_PATH
+    source_path = str(path)
+    if not path.is_file():
+        return None, (MATERIALIZE_ERROR_MISSING_SOURCE,), source_path
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None, (MATERIALIZE_ERROR_INVALID_JSON,), source_path
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None, (MATERIALIZE_ERROR_INVALID_JSON,), source_path
+    if not isinstance(payload, dict):
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE,), source_path
+    fields, errors = coerce_execution_reconciliation_fields_mapping_v1(payload)
+    if fields is None:
+        return None, errors, source_path
+    return fields, (), source_path
+
+
+def materialize_execution_reconciliation_presentation_projection_v1(
+    archive_root: str | Path,
+    *,
+    execution_reconciliation: object | None = None,
+    generated_at: str | None = None,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> ExecutionReconciliationPresentationMaterializeResultV1:
+    """Materialize the presentation projection from Execution fields or durable source.
+
+    Missing source yields MISSING_SOURCE and does not write an artifact.
+    Invalid source or missing required timestamps fail closed without writing.
+    Caller-owned Execution inputs are never mutated.
+    """
+    source_path: str | None = None
+    source_obj: object | None = execution_reconciliation
+    if source_obj is None:
+        loaded, load_errors, source_path = try_load_execution_reconciliation_fields_source_v1(
+            archive_root
+        )
+        if loaded is None:
+            status = (
+                STATUS_MISSING_SOURCE
+                if MATERIALIZE_ERROR_MISSING_SOURCE in load_errors
+                else STATUS_FAIL_CLOSED
+            )
+            return _empty_result(status=status, errors=load_errors, source_path=source_path)
+        source_obj = loaded
+
+    if _require_nonempty_str(generated_at) is None:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_TIMESTAMP_MISSING,),
+            source_path=source_path,
+        )
+
+    # Snapshot caller-owned mapping to prove / preserve non-mutation.
+    caller_snapshot = (
+        deepcopy(execution_reconciliation)
+        if isinstance(execution_reconciliation, Mapping)
+        else None
+    )
+
+    payload, build_errors = build_execution_reconciliation_presentation_projection_payload_v1(
+        execution_reconciliation=source_obj,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_reference=source_reference,
+    )
+    if isinstance(execution_reconciliation, Mapping) and caller_snapshot is not None:
+        if dict(execution_reconciliation) != dict(caller_snapshot):
+            return _empty_result(
+                status=STATUS_FAIL_CLOSED,
+                errors=(MATERIALIZE_ERROR_INVALID_SOURCE,),
+                source_path=source_path,
+            )
+    if payload is None:
+        status = (
+            STATUS_MISSING_SOURCE
+            if MATERIALIZE_ERROR_MISSING_SOURCE in build_errors
+            else STATUS_FAIL_CLOSED
+        )
+        return _empty_result(status=status, errors=build_errors, source_path=source_path)
+
+    result = write_execution_reconciliation_presentation_projection_v1(archive_root, payload)
+    if not result.written:
+        return result
+    return ExecutionReconciliationPresentationMaterializeResultV1(
+        written=True,
+        status=STATUS_WRITTEN,
+        errors=(),
+        projection_path=result.projection_path,
+        source_path=source_path,
+        execution_status=result.execution_status,
+        payload_digest=result.payload_digest,
+    )

--- a/src/webui/workflow_dashboard_readmodel_v1/execution_reconciliation_presentation_projection_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/execution_reconciliation_presentation_projection_v1.py
@@ -1,0 +1,293 @@
+"""Non-authoritative presentation projection for Execution/Reconciliation.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_EXECUTION_RECONCILIATION_PROJECTION_MATERIALIZER_AUTOBIND_V1
+
+Reads already-produced Execution/Reconciliation binder-compatible fields from a
+single durable archive path and maps them field-for-field into Landscape binder
+injection fields. This module:
+
+- AUTHORITY_EFFECT=NONE
+- EXECUTION_AUTHORITY_EFFECT=NONE
+- never creates, mutates, or evaluates order intents / reconciliation
+- never imports src.governance.canonical_order_intent_v1 builders
+- never imports trading.master_v2 order-intent offline adapters
+- never invents execution_status, reconciliation_status, or order_intent_ref
+- fail-closed: missing, invalid, or ambiguous sources → no fields (MISSING_SOURCE)
+
+Deterministic source selection: exactly one well-known relative path under the
+Workflow Dashboard archive root. No silent multi-candidate "latest" picking.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_NAME = "execution_reconciliation_presentation_projection.v1"
+SCHEMA_VERSION = 1
+STORAGE_RELATIVE_PATH = "readmodels/execution_reconciliation_presentation_projection.v1.json"
+SOURCE_FIELDS_RELATIVE_PATH = "readmodels/execution_reconciliation.v1.json"
+AUTHORITY_EFFECT = "NONE"
+EXECUTION_AUTHORITY_EFFECT = "NONE"
+PROJECTION_ROLE = "NON_AUTHORITATIVE_PRESENTATION_PROJECTION"
+OWNER_MODULE = (
+    "webui.workflow_dashboard_readmodel_v1.execution_reconciliation_presentation_projection_v1"
+)
+
+LOAD_ERROR_ABSENT = "EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_ABSENT"
+LOAD_ERROR_INVALID_JSON = "EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_INVALID_JSON"
+LOAD_ERROR_SCHEMA_MISMATCH = "EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_SCHEMA_MISMATCH"
+LOAD_ERROR_AUTHORITY_CLAIM = "EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_AUTHORITY_CLAIM"
+LOAD_ERROR_FIELDS_INVALID = "EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_FIELDS_INVALID"
+LOAD_ERROR_AMBIGUOUS = "EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_AMBIGUOUS_SOURCE"
+LOAD_ERROR_TIMESTAMP_MISSING = "EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_TIMESTAMP_MISSING"
+
+_REQUIRED_FIELD_KEYS = ("execution_status",)
+
+
+@dataclass(frozen=True)
+class ExecutionReconciliationPresentationLoadV1:
+    """Result of a fail-closed presentation projection load attempt."""
+
+    loaded: bool
+    load_errors: tuple[str, ...]
+    binder_fields: Mapping[str, Any] | None = None
+    source_path: str | None = None
+    evidence_digest: str | None = None
+    execution_status: str | None = None
+
+
+def _empty(*, load_errors: tuple[str, ...]) -> ExecutionReconciliationPresentationLoadV1:
+    return ExecutionReconciliationPresentationLoadV1(loaded=False, load_errors=load_errors)
+
+
+def _require_nonempty_str(payload: Mapping[str, Any], key: str) -> str | None:
+    raw = payload.get(key)
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return raw.strip()
+
+
+def _fields_payload_from_envelope(
+    payload: Mapping[str, Any],
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    """Extract nested execution_reconciliation fields; fail closed on ambiguity."""
+    if "execution_reconciliation" not in payload:
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+    fields = payload.get("execution_reconciliation")
+    if not isinstance(fields, Mapping):
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+    # Reject dual top-level + nested execution_status with conflicting values.
+    top_level_status = payload.get("execution_status")
+    nested_status = fields.get("execution_status")
+    if (
+        isinstance(top_level_status, str)
+        and top_level_status.strip()
+        and isinstance(nested_status, str)
+        and nested_status.strip()
+        and top_level_status.strip() != nested_status.strip()
+    ):
+        return None, (LOAD_ERROR_AMBIGUOUS,)
+    return fields, ()
+
+
+def _validate_execution_fields(
+    fields: Mapping[str, Any],
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    missing = [key for key in _REQUIRED_FIELD_KEYS if key not in fields]
+    if missing:
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+
+    execution_status = _require_nonempty_str(fields, "execution_status")
+    if execution_status is None:
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+
+    out: dict[str, Any] = {"execution_status": execution_status}
+
+    if "reconciliation_status" in fields and fields.get("reconciliation_status") is not None:
+        recon = fields.get("reconciliation_status")
+        if not isinstance(recon, str) or not recon.strip():
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["reconciliation_status"] = recon.strip()
+
+    if "order_intent_ref" in fields and fields.get("order_intent_ref") is not None:
+        intent_ref = fields.get("order_intent_ref")
+        if not isinstance(intent_ref, str) or not intent_ref.strip():
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["order_intent_ref"] = intent_ref.strip()
+
+    raw_codes = fields.get("reason_codes", ())
+    if raw_codes is None:
+        raw_codes = ()
+    if not isinstance(raw_codes, (list, tuple)):
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+    out["reason_codes"] = tuple(str(code) for code in raw_codes)
+
+    digest = fields.get("evidence_digest")
+    if digest is None:
+        digest = fields.get("semantic_digest")
+    if digest is not None:
+        if not isinstance(digest, str) or not digest.strip():
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["evidence_digest"] = digest.strip()
+        out["semantic_digest"] = digest.strip()
+
+    schema_version = fields.get("schema_version")
+    if schema_version is not None:
+        if not isinstance(schema_version, str) or not schema_version.strip():
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["schema_version"] = schema_version.strip()
+
+    return out, ()
+
+
+def map_execution_reconciliation_fields_to_binder_fields_v1(
+    *,
+    execution_reconciliation: Mapping[str, Any],
+    generated_at: str,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Map Execution/Reconciliation fields → Landscape binder fields (projection only)."""
+    mapped, errors = _validate_execution_fields(execution_reconciliation)
+    if mapped is None:
+        return None, errors
+    if not isinstance(generated_at, str) or not generated_at.strip():
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+    mapped["generated_at"] = generated_at.strip()
+    if effective_at is not None:
+        if not isinstance(effective_at, str) or not effective_at.strip():
+            return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+        mapped["effective_at"] = effective_at.strip()
+    if source_reference is not None:
+        if not isinstance(source_reference, str):
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        mapped["source_reference"] = source_reference
+    return mapped, ()
+
+
+def try_load_execution_reconciliation_presentation_projection_v1(
+    archive_root: str | Path,
+) -> ExecutionReconciliationPresentationLoadV1:
+    """Verify-before-trust read of the sole durable Execution presentation projection.
+
+    Returns loaded=False with load_errors on any fail-closed condition. Never
+    invents Execution/Reconciliation facts.
+    """
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    if not path.is_file():
+        return _empty(load_errors=(LOAD_ERROR_ABSENT,))
+
+    # Ambiguity guard: a second durable producer dump beside the projection is
+    # allowed only when identical execution_status (and optional fields/digest
+    # when both present); otherwise fail closed.
+    sibling = root / SOURCE_FIELDS_RELATIVE_PATH
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    if not isinstance(payload, dict):
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    schema_name = payload.get("schema_name")
+    if schema_name != SCHEMA_NAME:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    authority = payload.get("authority_effect")
+    execution_authority = payload.get("execution_authority_effect")
+    if authority != AUTHORITY_EFFECT or execution_authority != EXECUTION_AUTHORITY_EFFECT:
+        return _empty(load_errors=(LOAD_ERROR_AUTHORITY_CLAIM,))
+
+    generated_at = _require_nonempty_str(payload, "generated_at")
+    if generated_at is None:
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+
+    effective_at = payload.get("effective_at")
+    if effective_at is not None and (not isinstance(effective_at, str) or not effective_at.strip()):
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+    effective_at_s = None if effective_at is None else str(effective_at).strip()
+
+    fields, field_errors = _fields_payload_from_envelope(payload)
+    if fields is None:
+        return _empty(load_errors=field_errors)
+
+    source_reference = payload.get("source_reference")
+    if source_reference is None:
+        source_reference = f"presentation://{STORAGE_RELATIVE_PATH}"
+    elif not isinstance(source_reference, str):
+        return _empty(load_errors=(LOAD_ERROR_FIELDS_INVALID,))
+
+    binder_fields, map_errors = map_execution_reconciliation_fields_to_binder_fields_v1(
+        execution_reconciliation=fields,
+        generated_at=generated_at,
+        effective_at=effective_at_s,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return _empty(load_errors=map_errors)
+
+    if sibling.is_file():
+        try:
+            sibling_payload = json.loads(sibling.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        if not isinstance(sibling_payload, dict):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        sibling_fields: Mapping[str, Any] = sibling_payload
+        if "execution_reconciliation" in sibling_payload and isinstance(
+            sibling_payload.get("execution_reconciliation"), Mapping
+        ):
+            sibling_fields = sibling_payload["execution_reconciliation"]
+        sibling_status = str(sibling_fields.get("execution_status") or "").strip()
+        projection_status = str(binder_fields["execution_status"])
+        if not sibling_status or sibling_status != projection_status:
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        for optional_key in ("reconciliation_status", "order_intent_ref"):
+            sibling_opt = sibling_fields.get(optional_key)
+            projection_opt = binder_fields.get(optional_key)
+            if (
+                isinstance(sibling_opt, str)
+                and sibling_opt.strip()
+                and isinstance(projection_opt, str)
+                and projection_opt.strip()
+                and sibling_opt.strip() != projection_opt.strip()
+            ):
+                return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        sibling_digest = sibling_fields.get("evidence_digest")
+        if sibling_digest is None:
+            sibling_digest = sibling_fields.get("semantic_digest")
+        projection_digest = binder_fields.get("evidence_digest")
+        if (
+            isinstance(sibling_digest, str)
+            and sibling_digest.strip()
+            and isinstance(projection_digest, str)
+            and projection_digest.strip()
+            and sibling_digest.strip() != projection_digest.strip()
+        ):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+
+    return ExecutionReconciliationPresentationLoadV1(
+        loaded=True,
+        load_errors=(),
+        binder_fields=binder_fields,
+        source_path=str(path),
+        evidence_digest=(
+            None
+            if binder_fields.get("evidence_digest") is None
+            else str(binder_fields.get("evidence_digest"))
+        ),
+        execution_status=str(binder_fields["execution_status"]),
+    )

--- a/tests/webui/test_execution_reconciliation_presentation_projection_materializer_v1.py
+++ b/tests/webui/test_execution_reconciliation_presentation_projection_materializer_v1.py
@@ -1,0 +1,263 @@
+"""Focused tests: CAPABILITY_PRESENTATION_EXECUTION_RECONCILIATION_PROJECTION_MATERIALIZER_AUTOBIND_V1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    EXECUTION_PRODUCER_MODULE,
+    EXECUTION_SOURCE_KIND,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT
+from src.webui.workflow_dashboard_readmodel_v1.execution_reconciliation_presentation_projection_materializer_v1 import (
+    CAPABILITY_ID,
+    MATERIALIZE_ERROR_MISSING_SOURCE,
+    SOURCE_FIELDS_RELATIVE_PATH,
+    STATUS_FAIL_CLOSED,
+    STATUS_MISSING_SOURCE,
+    STATUS_WRITTEN,
+    build_execution_reconciliation_presentation_projection_payload_v1,
+    materialize_execution_reconciliation_presentation_projection_v1,
+    serialize_execution_reconciliation_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.execution_reconciliation_presentation_projection_v1 import (
+    LOAD_ERROR_FIELDS_INVALID,
+    LOAD_ERROR_TIMESTAMP_MISSING,
+    STORAGE_RELATIVE_PATH,
+    try_load_execution_reconciliation_presentation_projection_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+STAMP = datetime(2026, 7, 24, 18, 0, 0, tzinfo=timezone.utc)
+PRODUCER_FRESH = "2026-07-24T17:30:00Z"
+
+
+def _fields(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "execution_status": "BOUND_OFFLINE",
+        "reconciliation_status": "RECONCILED",
+        "order_intent_ref": "intent://" + ("a" * 16),
+        "reason_codes": ("PASS",),
+        "evidence_digest": "e" * 64,
+        "schema_version": "v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_source_fields(archive_root: Path, payload: dict[str, object]) -> Path:
+    path = archive_root / SOURCE_FIELDS_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_capability_id_is_stable() -> None:
+    assert CAPABILITY_ID == (
+        "CAPABILITY_PRESENTATION_EXECUTION_RECONCILIATION_PROJECTION_MATERIALIZER_AUTOBIND_V1"
+    )
+
+
+def test_build_payload_is_deterministic() -> None:
+    fields = _fields()
+    first, err_a = build_execution_reconciliation_presentation_projection_payload_v1(
+        execution_reconciliation=fields,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://unit-test",
+    )
+    second, err_b = build_execution_reconciliation_presentation_projection_payload_v1(
+        execution_reconciliation=fields,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://unit-test",
+    )
+    assert err_a == ()
+    assert err_b == ()
+    assert first is not None and second is not None
+    assert first == second
+    assert serialize_execution_reconciliation_presentation_projection_v1(
+        first
+    ) == serialize_execution_reconciliation_presentation_projection_v1(second)
+    assert first["schema_name"] == "execution_reconciliation_presentation_projection.v1"
+    assert first["schema_version"] == 1
+    assert first["execution_reconciliation"]["execution_status"] == "BOUND_OFFLINE"
+    assert first["execution_reconciliation"]["reconciliation_status"] == "RECONCILED"
+
+
+def test_materialize_writes_loader_expected_path(tmp_path: Path) -> None:
+    result = materialize_execution_reconciliation_presentation_projection_v1(
+        tmp_path,
+        execution_reconciliation=_fields(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert result.status == STATUS_WRITTEN
+    assert result.errors == ()
+    assert result.projection_path is not None
+    assert result.projection_path.endswith(STORAGE_RELATIVE_PATH)
+    assert (tmp_path / STORAGE_RELATIVE_PATH).is_file()
+
+
+def test_materialize_loader_compatible(tmp_path: Path) -> None:
+    materialize_execution_reconciliation_presentation_projection_v1(
+        tmp_path,
+        execution_reconciliation=_fields(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://materializer-compat",
+    )
+    loaded = try_load_execution_reconciliation_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.load_errors == ()
+    assert loaded.execution_status == "BOUND_OFFLINE"
+    assert loaded.evidence_digest == "e" * 64
+    assert loaded.binder_fields is not None
+    assert loaded.binder_fields["reconciliation_status"] == "RECONCILED"
+    assert loaded.binder_fields["order_intent_ref"] == "intent://" + ("a" * 16)
+
+
+def test_missing_source_does_not_invent_artifact(tmp_path: Path) -> None:
+    result = materialize_execution_reconciliation_presentation_projection_v1(
+        tmp_path,
+        execution_reconciliation=None,
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_MISSING_SOURCE
+    assert MATERIALIZE_ERROR_MISSING_SOURCE in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+    loaded = try_load_execution_reconciliation_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+
+
+def test_invalid_source_fail_closed(tmp_path: Path) -> None:
+    result = materialize_execution_reconciliation_presentation_projection_v1(
+        tmp_path,
+        execution_reconciliation={"reconciliation_status": "RECONCILED"},
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_FIELDS_INVALID in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_missing_generated_at_fail_closed(tmp_path: Path) -> None:
+    result = materialize_execution_reconciliation_presentation_projection_v1(
+        tmp_path,
+        execution_reconciliation=_fields(),
+        generated_at=None,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_TIMESTAMP_MISSING in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_does_not_mutate_canonical_inputs(tmp_path: Path) -> None:
+    fields = _fields()
+    snapshot = deepcopy(fields)
+    result = materialize_execution_reconciliation_presentation_projection_v1(
+        tmp_path,
+        execution_reconciliation=fields,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert fields == snapshot
+
+
+def test_materialize_from_durable_fields_source(tmp_path: Path) -> None:
+    _write_source_fields(tmp_path, _fields())
+    result = materialize_execution_reconciliation_presentation_projection_v1(
+        tmp_path,
+        execution_reconciliation=None,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert result.status == STATUS_WRITTEN
+    assert result.source_path is not None
+    assert SOURCE_FIELDS_RELATIVE_PATH in result.source_path
+    assert (tmp_path / SOURCE_FIELDS_RELATIVE_PATH).is_file()
+    loaded = try_load_execution_reconciliation_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.execution_status == "BOUND_OFFLINE"
+
+
+def test_end_to_end_durable_source_to_autobind_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    _write_source_fields(archive, _fields())
+    result = materialize_execution_reconciliation_presentation_projection_v1(
+        archive,
+        execution_reconciliation=None,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://e2e-execution-materializer",
+    )
+    assert result.written is True
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    execution = slots["execution_reconciliation"]
+    assert execution.availability is Availability.AVAILABLE
+    assert execution.execution_status == "BOUND_OFFLINE"
+    assert execution.reconciliation_status == "RECONCILED"
+    assert execution.order_intent_ref == "intent://" + ("a" * 16)
+    assert execution.provenance.producer_module == EXECUTION_PRODUCER_MODULE
+    assert execution.provenance.source_kind == EXECUTION_SOURCE_KIND
+
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "BOUND_OFFLINE" in html
+    assert 'data-mdl-ops="execution_reconciliation"' in html
+    assert 'data-mdl-field="execution_status"' in html
+    assert "<form" not in html.lower()
+    assert "place_order" not in html.lower()
+
+
+def test_materializer_module_has_no_forbidden_trading_or_governance_imports() -> None:
+    path = (
+        REPO
+        / "src/webui/workflow_dashboard_readmodel_v1"
+        / "execution_reconciliation_presentation_projection_materializer_v1.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                continue
+            if node.module:
+                imported.add(node.module.split(".", 1)[0])
+    assert "trading" not in imported
+    assert "src" not in imported
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in {
+                "build_canonical_order_intent_v1",
+                "bind_canonical_order_intent_offline_replay_evidence_v0",
+                "evaluate_offline_reconciliation",
+                "compose_double_play_decision",
+                "KillSwitch",
+            }

--- a/tests/webui/test_market_landscape_execution_reconciliation_presentation_autobind_v1.py
+++ b/tests/webui/test_market_landscape_execution_reconciliation_presentation_autobind_v1.py
@@ -1,0 +1,288 @@
+"""Focused autobind tests: CAPABILITY_PRESENTATION_EXECUTION_RECONCILIATION_PROJECTION_MATERIALIZER_AUTOBIND_V1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    EXECUTION_PRODUCER_MODULE,
+    EXECUTION_SOURCE_KIND,
+    REASON_EXECUTION_NOT_PERSISTED,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT
+from src.webui.workflow_dashboard_readmodel_v1.execution_reconciliation_presentation_projection_v1 import (
+    AUTHORITY_EFFECT,
+    EXECUTION_AUTHORITY_EFFECT,
+    LOAD_ERROR_ABSENT,
+    LOAD_ERROR_AMBIGUOUS,
+    LOAD_ERROR_AUTHORITY_CLAIM,
+    LOAD_ERROR_FIELDS_INVALID,
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    SCHEMA_NAME,
+    SOURCE_FIELDS_RELATIVE_PATH,
+    STORAGE_RELATIVE_PATH,
+    map_execution_reconciliation_fields_to_binder_fields_v1,
+    try_load_execution_reconciliation_presentation_projection_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+STAMP = datetime(2026, 7, 24, 18, 0, 0, tzinfo=timezone.utc)
+PRODUCER_FRESH = "2026-07-24T17:30:00Z"
+
+
+def _fields(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "execution_status": "BOUND_OFFLINE",
+        "reconciliation_status": "RECONCILED",
+        "order_intent_ref": "intent://" + ("a" * 16),
+        "reason_codes": ("PASS",),
+        "evidence_digest": "a" * 64,
+        "schema_version": "v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _projection_payload(
+    *,
+    execution_reconciliation: dict[str, object] | None = None,
+    **overrides: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_name": SCHEMA_NAME,
+        "schema_version": 1,
+        "authority_effect": AUTHORITY_EFFECT,
+        "execution_authority_effect": EXECUTION_AUTHORITY_EFFECT,
+        "projection_role": "NON_AUTHORITATIVE_PRESENTATION_PROJECTION",
+        "generated_at": PRODUCER_FRESH,
+        "effective_at": PRODUCER_FRESH,
+        "source_reference": "presentation://execution_autobind_test",
+        "execution_reconciliation": (
+            execution_reconciliation if execution_reconciliation is not None else _fields()
+        ),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_projection(archive_root: Path, payload: dict[str, object]) -> Path:
+    path = archive_root / STORAGE_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_map_fields_to_binder_fields_preserves_producer_facts() -> None:
+    fields, errors = map_execution_reconciliation_fields_to_binder_fields_v1(
+        execution_reconciliation=_fields(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://x",
+    )
+    assert errors == ()
+    assert fields is not None
+    assert fields["execution_status"] == "BOUND_OFFLINE"
+    assert fields["reconciliation_status"] == "RECONCILED"
+    assert fields["order_intent_ref"] == "intent://" + ("a" * 16)
+    assert fields["evidence_digest"] == "a" * 64
+    assert fields["generated_at"] == PRODUCER_FRESH
+
+
+def test_load_absent_projection_is_missing(tmp_path: Path) -> None:
+    loaded = try_load_execution_reconciliation_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_ABSENT in loaded.load_errors
+    assert loaded.binder_fields is None
+
+
+def test_load_valid_projection_returns_binder_fields(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload())
+    loaded = try_load_execution_reconciliation_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.load_errors == ()
+    assert loaded.binder_fields is not None
+    assert loaded.execution_status == "BOUND_OFFLINE"
+    assert loaded.evidence_digest == "a" * 64
+    assert STORAGE_RELATIVE_PATH in str(loaded.source_path)
+
+
+def test_load_schema_mismatch_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(schema_name="wrong.schema"))
+    loaded = try_load_execution_reconciliation_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_SCHEMA_MISMATCH in loaded.load_errors
+
+
+def test_load_authority_claim_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(authority_effect="EXECUTION"))
+    loaded = try_load_execution_reconciliation_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_AUTHORITY_CLAIM in loaded.load_errors
+
+
+def test_load_invalid_fields_fail_closed(tmp_path: Path) -> None:
+    _write_projection(
+        tmp_path,
+        _projection_payload(execution_reconciliation={"reconciliation_status": "RECONCILED"}),
+    )
+    loaded = try_load_execution_reconciliation_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_FIELDS_INVALID in loaded.load_errors
+
+
+def test_load_ambiguous_sibling_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload())
+    sibling = tmp_path / SOURCE_FIELDS_RELATIVE_PATH
+    sibling.write_text(
+        json.dumps(
+            {
+                "execution_status": "FAILED",
+                "reconciliation_status": "RECONCILED",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    loaded = try_load_execution_reconciliation_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_AMBIGUOUS in loaded.load_errors
+
+
+def test_autobind_available_from_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    execution = slots["execution_reconciliation"]
+    assert execution.availability is Availability.AVAILABLE
+    assert execution.execution_status == "BOUND_OFFLINE"
+    assert execution.reconciliation_status == "RECONCILED"
+    assert execution.order_intent_ref == "intent://" + ("a" * 16)
+    assert execution.provenance.producer_module == EXECUTION_PRODUCER_MODULE
+    assert execution.provenance.source_kind == EXECUTION_SOURCE_KIND
+    assert execution.provenance.source_reference == "presentation://execution_autobind_test"
+    assert execution.provenance.evidence_digest == "a" * 64
+    # Other injection-only / unbound slots remain missing when not projected.
+    assert slots["safety_authority"].availability is Availability.MISSING_SOURCE
+    assert slots["economic_summary"].availability is Availability.MISSING_SOURCE
+
+
+def test_autobind_missing_projection_is_missing_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "empty_archive"
+    archive.mkdir()
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["execution_reconciliation"].availability is Availability.MISSING_SOURCE
+    assert REASON_EXECUTION_NOT_PERSISTED in slots["execution_reconciliation"].reason_codes
+
+
+def test_autobind_invalid_projection_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "bad_archive"
+    _write_projection(archive, _projection_payload(schema_name="nope"))
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["execution_reconciliation"].availability is Availability.INVALID
+    assert LOAD_ERROR_SCHEMA_MISMATCH in slots["execution_reconciliation"].reason_codes
+
+
+def test_explicit_injection_still_overrides_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        execution_reconciliation_fields={
+            "execution_status": "FAILED",
+            "reconciliation_status": "UNKNOWN",
+            "order_intent_ref": "intent://injected",
+            "reason_codes": ("INJECTED",),
+            "semantic_digest": "b" * 64,
+            "generated_at": PRODUCER_FRESH,
+            "source_reference": "execution://bounded-test-injection",
+            "schema_version": "v1",
+        },
+    )
+    execution = slots["execution_reconciliation"]
+    assert execution.availability is Availability.AVAILABLE
+    assert execution.execution_status == "FAILED"
+    assert execution.reconciliation_status == "UNKNOWN"
+    assert execution.order_intent_ref == "intent://injected"
+    assert execution.provenance.source_reference == "execution://bounded-test-injection"
+
+
+def test_get_market_autobinds_execution_without_injection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(
+        archive,
+        _projection_payload(
+            execution_reconciliation=_fields(
+                execution_status="BOUND_OFFLINE",
+                reconciliation_status="RECONCILED",
+                reason_codes=("AUTOBIND_OK",),
+            )
+        ),
+    )
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "BOUND_OFFLINE" in html
+    assert "RECONCILED" in html
+    assert 'data-mdl-ops="execution_reconciliation"' in html
+    assert 'data-mdl-field="execution_status"' in html
+    assert 'data-mdl-field="reconciliation_status"' in html
+    assert "<form" not in html.lower()
+    assert "place_order" not in html.lower()
+
+
+def test_projection_module_has_no_forbidden_trading_imports() -> None:
+    path = (
+        REPO
+        / "src/webui/workflow_dashboard_readmodel_v1"
+        / "execution_reconciliation_presentation_projection_v1.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                continue
+            if node.module:
+                imported.add(node.module.split(".", 1)[0])
+    assert "trading" not in imported
+    assert "src" not in imported
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in {
+                "build_canonical_order_intent_v1",
+                "compose_double_play_decision",
+                "KillSwitch",
+            }


### PR DESCRIPTION
## Summary
- Adds non-authoritative `execution_reconciliation_presentation_projection.v1` loader/materializer under the Workflow Dashboard archive root.
- Wires fail-closed Landscape auto-bind when explicit injection is absent; missing/invalid artifacts stay `MISSING_SOURCE` / `INVALID`.
- Updates archive-root path constants and owner-registry presentation metadata only; authority remains `src.governance.canonical_order_intent_v1`.

## Capability
`CAPABILITY_PRESENTATION_EXECUTION_RECONCILIATION_PROJECTION_MATERIALIZER_AUTOBIND_V1`

## Test plan
- [x] Focused materializer + autobind tests (24 passed)
- [x] Regression: producer binding, contracts, risk_sizing autobind, archive root, architecture guards (except pre-existing stdlib guard on main)
- [x] Bounded PR batch: 161 passed
- [x] Timing proof (selector PR_BOUNDED_FULL targets + focused): 753 passed in ~39s
- [ ] Await GitHub CI confirmation
- [ ] Owner-merge only after separate explicit Owner-Merge-GO

## Boundaries
- No producer / trading / runtime / authority / reconciliation logic changes
- Explicit injection priority preserved
- Do not merge without Owner-Merge-GO


Made with [Cursor](https://cursor.com)