### PR TITLE
feat(webui): materialize and autobind safety authority presentation

### DIFF
--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -6,7 +6,9 @@ regime_bull_bear_switch (injection or durable presentation projection
 auto-bind; PR #5577 field contract), canonical_decision
 evidence (injection or durable presentation projection auto-bind),
 double_play display projection (injection or durable presentation projection
-auto-bind), safety authority KillSwitch/boundary field projection,
+auto-bind), safety authority KillSwitch/boundary field projection
+(injection or durable presentation projection auto-bind; never productive
+KillSwitch state-file autoload),
 risk/sizing/capital field projection (injection or durable presentation
 projection auto-bind), execution/reconciliation field projection (injection
 or durable presentation projection auto-bind), and
@@ -94,6 +96,10 @@ from .workflow_dashboard_readmodel_v1.risk_sizing_capital_presentation_projectio
 from .workflow_dashboard_readmodel_v1.execution_reconciliation_presentation_projection_v1 import (
     LOAD_ERROR_ABSENT as EXECUTION_RECONCILIATION_PROJECTION_ABSENT,
     try_load_execution_reconciliation_presentation_projection_v1,
+)
+from .workflow_dashboard_readmodel_v1.safety_authority_presentation_projection_v1 import (
+    LOAD_ERROR_ABSENT as SAFETY_AUTHORITY_PROJECTION_ABSENT,
+    try_load_safety_authority_presentation_projection_v1,
 )
 from .workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
     FORBIDDEN_SELECTED_SYMBOLS,
@@ -1248,20 +1254,49 @@ def _bind_safety_authority(
     as_of: datetime,
     git_sha: str | None,
     safety_authority_fields: Mapping[str, Any] | None,
+    archive_root: Path | None = None,
 ) -> Any:
-    """Project injected KillSwitch / boundary-compatible Safety fields.
+    """Project KillSwitch / boundary-compatible Safety fields.
 
-    No durable dashboard Safety readmodel. Without injection → MISSING_SOURCE.
+    Injection remains supported and strictly preferred. Productive auto-bind
+    loads the non-authoritative presentation projection from the Workflow
+    Dashboard archive root when injection is absent. Without injection and
+    without a valid persisted projection → MISSING_SOURCE.
     Never instantiates KillSwitch, never calls trigger/recover, never calls
     evaluate_offline_killswitch_boundary_v0 or bind_* Safety evaluators, and
-    never auto-loads a live state file.
+    never auto-loads a productive/live KillSwitch state file.
     """
     if safety_authority_fields is None:
-        return unavailable_safety_authority(
-            availability=Availability.MISSING_SOURCE,
-            generated_at=as_of,
-            reason=REASON_SAFETY_NOT_PERSISTED,
-        )
+        if archive_root is None:
+            return unavailable_safety_authority(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_SAFETY_NOT_PERSISTED,
+            )
+        try:
+            loaded = try_load_safety_authority_presentation_projection_v1(archive_root)
+        except Exception:
+            return unavailable_safety_authority(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_SAFETY_NOT_PERSISTED,
+            )
+        if not loaded.loaded or loaded.binder_fields is None:
+            reason = REASON_SAFETY_NOT_PERSISTED
+            if loaded.load_errors:
+                first = str(loaded.load_errors[0])
+                if first != SAFETY_AUTHORITY_PROJECTION_ABSENT:
+                    reason = first
+            # Fail-closed presentation autobind: absent/invalid/wrong-version/
+            # schema errors remain honest MISSING_SOURCE (no invented Safety).
+            if reason == SAFETY_AUTHORITY_PROJECTION_ABSENT:
+                reason = REASON_SAFETY_NOT_PERSISTED
+            return unavailable_safety_authority(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=reason,
+            )
+        safety_authority_fields = loaded.binder_fields
 
     if "kill_switch_state" not in safety_authority_fields:
         raise KeyError("safety_authority_fields missing required keys: ['kill_switch_state']")
@@ -2024,8 +2059,12 @@ def bind_market_universe_slots(
 
     safety_authority_fields accepts already-computed KillSwitch / boundary-
     compatible fields (kill_switch_state, veto_active, reason_codes) plus
-    producer wall-clock timestamps. Without injection, safety_authority is
-    MISSING_SOURCE. Never calls KillSwitch.trigger/recover or offline evaluators.
+    producer wall-clock timestamps. Without injection, productive auto-bind
+    loads safety_authority_presentation_projection.v1 from
+    readmodels/safety_authority.v1.json when present; otherwise
+    MISSING_SOURCE. Explicit injection remains priority over archive autobind.
+    Never calls KillSwitch.trigger/recover or offline evaluators; never
+    auto-loads productive/live KillSwitch state files.
 
     risk_sizing_capital_fields accepts already-selected Risk/Sizing/Capital
     display fields (risk_status/sizing_status/capital_status[/quantity]) plus
@@ -2084,6 +2123,7 @@ def bind_market_universe_slots(
         as_of=as_of,
         git_sha=git_sha,
         safety_authority_fields=safety_authority_fields,
+        archive_root=root,
     )
     risk = _bind_risk_sizing_capital(
         as_of=as_of,

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -146,13 +146,22 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
         authority_class="safety_veto",
         reuse_status="REUSED",
         notes=(
-            "Phase 4.4A: Landscape projects injected KillSwitch/boundary fields "
-            "field-for-field (kill_switch_state/veto_active/reason_codes); "
+            "Phase 4.4A + CAPABILITY_PRESENTATION_SAFETY_AUTHORITY_"
+            "PROJECTION_MATERIALIZER_AUTOBIND_V1: Landscape projects "
+            "KillSwitch/boundary fields field-for-field "
+            "(kill_switch_state/veto_active/reason_codes); "
             "authority owner remains src.risk_layer.kill_switch; "
             "projection/evidence source "
             "trading.master_v2.killswitch_boundary_offline_replay_binding_adapter_v0 "
             "is non-authority wiring/parity only; dashboard AUTHORITY_EFFECT=NONE; "
-            "no trigger/recover; no offline evaluator; no live state-file autoload."
+            "durable auto-bind via non-authoritative "
+            "safety_authority_presentation_projection.v1 persisted at "
+            "readmodels/safety_authority.v1.json under archive root; "
+            "explicit injection remains priority over archive autobind; "
+            "without injection/projection MISSING_SOURCE; "
+            "no trigger/recover; no offline evaluator; "
+            "no productive KillSwitch state-file autoload "
+            "(never live data/kill_switch/state.json)."
         ),
     ),
     CanonicalOwnerRefV1(

--- a/src/webui/workflow_dashboard_archive_root_v1.py
+++ b/src/webui/workflow_dashboard_archive_root_v1.py
@@ -11,9 +11,12 @@ bull_bear_regime_presentation_projection.v1,
 dynamic_scope_presentation_projection.v1 (plus its durable source sibling
 dynamic_scope_state_v1.json under the same archive root), and
 risk_sizing_capital_presentation_projection.v1 (plus its durable source sibling
-risk_sizing_capital.v1.json under the same archive root), and
+risk_sizing_capital.v1.json under the same archive root),
 execution_reconciliation_presentation_projection.v1 (plus its durable source sibling
-execution_reconciliation.v1.json under the same archive root).
+execution_reconciliation.v1.json under the same archive root), and
+safety_authority_presentation_projection.v1 persisted at
+safety_authority.v1.json under the same archive root (presentation-only;
+never a productive KillSwitch state file).
 """
 
 from __future__ import annotations
@@ -69,6 +72,7 @@ EXECUTION_RECONCILIATION_FIELDS_RELATIVE = "readmodels/execution_reconciliation.
 EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_RELATIVE = (
     "readmodels/execution_reconciliation_presentation_projection.v1.json"
 )
+SAFETY_AUTHORITY_PRESENTATION_PROJECTION_RELATIVE = "readmodels/safety_authority.v1.json"
 _DISCOVER_NAME_PREFIX = "workflow_dashboard_v1"
 
 
@@ -441,6 +445,7 @@ __all__ = [
     "PRECEDENCE_DISCOVERED_GOVERNED_OKX",
     "RISK_SIZING_CAPITAL_FIELDS_RELATIVE",
     "RISK_SIZING_CAPITAL_PRESENTATION_PROJECTION_RELATIVE",
+    "SAFETY_AUTHORITY_PRESENTATION_PROJECTION_RELATIVE",
     "UNIVERSE_SELECTION_READMODEL_RELATIVE",
     "WorkflowDashboardArchiveRootError",
     "archive_root_has_governed_okx_futures_readmodels",

--- a/src/webui/workflow_dashboard_readmodel_v1/safety_authority_presentation_projection_materializer_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/safety_authority_presentation_projection_materializer_v1.py
@@ -1,0 +1,389 @@
+"""Non-authoritative materializer for Safety Authority presentation projection.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_SAFETY_AUTHORITY_PROJECTION_MATERIALIZER_AUTOBIND_V1
+
+Consumes already-produced Safety binder-compatible field payloads and writes
+the non-authoritative presentation projection schema to the loader-owned path
+``readmodels/safety_authority.v1.json``. This module:
+
+- AUTHORITY_EFFECT=NONE
+- SAFETY_AUTHORITY_EFFECT=NONE
+- never creates, mutates, triggers, recovers, or evaluates KillSwitch
+- never imports src.risk_layer.kill_switch
+- never imports trading.master_v2.killswitch_boundary_* adapters
+- never accesses productive/live KillSwitch state files
+- never invents kill_switch_state, veto_active, timestamps, or reason_codes
+- fail-closed: missing source → MISSING_SOURCE and no artifact write;
+  invalid source → FAIL_CLOSED and no artifact write
+- projection remains non-authoritative and must never flow back into runtime
+  or authority chains
+
+Deterministic serialization and atomic replace only. This projection path does
+not own a separate MANIFEST contract; integrity follows the existing loader
+schema/authority/fields checks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from .safety_authority_presentation_projection_v1 import (
+    AUTHORITY_EFFECT,
+    LOAD_ERROR_FIELDS_INVALID,
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    LOAD_ERROR_TIMESTAMP_MISSING,
+    PROJECTION_ROLE,
+    SAFETY_AUTHORITY_EFFECT,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    STORAGE_RELATIVE_PATH,
+    map_safety_authority_fields_to_binder_fields_v1,
+    project_safety_authority_presentation_projection_v1,
+)
+
+CAPABILITY_ID = "CAPABILITY_PRESENTATION_SAFETY_AUTHORITY_PROJECTION_MATERIALIZER_AUTOBIND_V1"
+OWNER_MODULE = (
+    "webui.workflow_dashboard_readmodel_v1.safety_authority_presentation_projection_materializer_v1"
+)
+
+STATUS_WRITTEN = "WRITTEN"
+STATUS_MISSING_SOURCE = "MISSING_SOURCE"
+STATUS_FAIL_CLOSED = "FAIL_CLOSED"
+
+MATERIALIZE_ERROR_MISSING_SOURCE = "MISSING_SOURCE"
+MATERIALIZE_ERROR_INVALID_JSON = "SAFETY_AUTHORITY_PRESENTATION_MATERIALIZER_INVALID_JSON"
+MATERIALIZE_ERROR_INVALID_SOURCE = "SAFETY_AUTHORITY_PRESENTATION_MATERIALIZER_INVALID_SOURCE"
+MATERIALIZE_ERROR_WRITE_FAILED = "SAFETY_AUTHORITY_PRESENTATION_MATERIALIZER_WRITE_FAILED"
+
+_REQUIRED_FIELD_ATTRS = (
+    "kill_switch_state",
+    "veto_active",
+)
+
+
+@dataclass(frozen=True)
+class SafetyAuthorityPresentationMaterializeResultV1:
+    """Result of a fail-closed presentation projection materialize attempt."""
+
+    written: bool
+    status: str
+    errors: tuple[str, ...]
+    projection_path: str | None = None
+    source_path: str | None = None
+    kill_switch_state: str | None = None
+    veto_active: bool | None = None
+    payload_digest: str | None = None
+
+
+def _empty_result(
+    *,
+    status: str,
+    errors: tuple[str, ...],
+    source_path: str | None = None,
+) -> SafetyAuthorityPresentationMaterializeResultV1:
+    return SafetyAuthorityPresentationMaterializeResultV1(
+        written=False,
+        status=status,
+        errors=errors,
+        source_path=source_path,
+    )
+
+
+def _require_nonempty_str(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _enum_or_str(value: object) -> object:
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def coerce_safety_authority_fields_mapping_v1(
+    source: object | None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Copy already-selected Safety Authority fields without mutation.
+
+    Accepts:
+    - binder-compatible fields (kill_switch_state/veto_active[/reason_codes])
+    - nested projection envelope {"safety_authority": {...}}
+    - objects exposing SafetyAuthoritySnapshotV1-compatible attributes
+
+    Never invents KillSwitch state, veto, timestamps, or productive defaults.
+    """
+    if source is None:
+        return None, (MATERIALIZE_ERROR_MISSING_SOURCE,)
+
+    raw: Mapping[str, Any]
+    if isinstance(source, Mapping):
+        raw = source
+    else:
+        extracted: dict[str, Any] = {}
+        for key in (
+            *_REQUIRED_FIELD_ATTRS,
+            "reason_codes",
+            "evidence_digest",
+            "semantic_digest",
+            "schema_version",
+            "generated_at",
+            "effective_at",
+            "saved_at",
+            "source_reference",
+            "killswitch_owner_ref",
+            "safety_authority",
+        ):
+            if hasattr(source, key):
+                extracted[key] = getattr(source, key)
+        raw = extracted
+
+    # Nested projection envelope: {"safety_authority": {...}}.
+    if "safety_authority" in raw and isinstance(raw.get("safety_authority"), Mapping):
+        nested = raw["safety_authority"]
+        top_state = raw.get("kill_switch_state")
+        nested_state = nested.get("kill_switch_state")
+        if (
+            isinstance(top_state, str)
+            and top_state.strip()
+            and isinstance(nested_state, str)
+            and nested_state.strip()
+            and top_state.strip() != nested_state.strip()
+        ):
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID)
+        top_veto = raw.get("veto_active")
+        nested_veto = nested.get("veto_active")
+        if (
+            isinstance(top_veto, bool)
+            and isinstance(nested_veto, bool)
+            and top_veto is not nested_veto
+        ):
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID)
+        if not all(key in raw for key in _REQUIRED_FIELD_ATTRS):
+            raw = nested
+
+    fields = deepcopy(dict(raw))
+
+    for key in _REQUIRED_FIELD_ATTRS:
+        value = fields.get(key)
+        if isinstance(value, Enum):
+            fields[key] = value.value
+
+    missing = [key for key in _REQUIRED_FIELD_ATTRS if key not in fields]
+    if missing:
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID)
+
+    if _require_nonempty_str(_enum_or_str(fields.get("kill_switch_state"))) is None:
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID)
+    fields["kill_switch_state"] = str(_enum_or_str(fields["kill_switch_state"])).strip()
+
+    if not isinstance(fields.get("veto_active"), bool):
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID)
+
+    return fields, ()
+
+
+def build_safety_authority_presentation_projection_payload_v1(
+    *,
+    safety_authority: object,
+    generated_at: str,
+    effective_at: str | None = None,
+    saved_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Build the loader-compatible projection envelope from Safety fields."""
+    fields_mapping, coerce_errors = coerce_safety_authority_fields_mapping_v1(safety_authority)
+    if fields_mapping is None:
+        return None, coerce_errors
+
+    if _require_nonempty_str(generated_at) is None:
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+
+    return project_safety_authority_presentation_projection_v1(
+        safety_authority=fields_mapping,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        saved_at=saved_at,
+        source_reference=source_reference,
+    )
+
+
+def serialize_safety_authority_presentation_projection_v1(
+    payload: Mapping[str, Any],
+) -> str:
+    """Deterministic JSON serialization for the presentation projection artifact."""
+    return json.dumps(dict(payload), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def _atomic_write_text(*, destination: Path, body: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, destination)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def write_safety_authority_presentation_projection_v1(
+    archive_root: str | Path,
+    payload: Mapping[str, Any],
+) -> SafetyAuthorityPresentationMaterializeResultV1:
+    """Atomically persist an already-validated projection payload."""
+    if payload.get("schema_name") != SCHEMA_NAME:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_SCHEMA_MISMATCH,),
+        )
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_SCHEMA_MISMATCH,),
+        )
+    if (
+        payload.get("authority_effect") != AUTHORITY_EFFECT
+        or payload.get("safety_authority_effect") != SAFETY_AUTHORITY_EFFECT
+    ):
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(MATERIALIZE_ERROR_INVALID_SOURCE,),
+        )
+
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    body = serialize_safety_authority_presentation_projection_v1(payload)
+    try:
+        _atomic_write_text(destination=path, body=body)
+    except OSError:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(MATERIALIZE_ERROR_WRITE_FAILED,),
+        )
+
+    safety = payload.get("safety_authority")
+    kill_switch_state = None
+    veto_active = None
+    if isinstance(safety, Mapping):
+        raw_state = safety.get("kill_switch_state")
+        if isinstance(raw_state, str) and raw_state.strip():
+            kill_switch_state = raw_state.strip()
+        raw_veto = safety.get("veto_active")
+        if isinstance(raw_veto, bool):
+            veto_active = raw_veto
+
+    return SafetyAuthorityPresentationMaterializeResultV1(
+        written=True,
+        status=STATUS_WRITTEN,
+        errors=(),
+        projection_path=str(path),
+        kill_switch_state=kill_switch_state,
+        veto_active=veto_active,
+        payload_digest=hashlib.sha256(body.encode("utf-8")).hexdigest(),
+    )
+
+
+def materialize_safety_authority_presentation_projection_v1(
+    archive_root: str | Path,
+    *,
+    safety_authority: object | None = None,
+    generated_at: str | None = None,
+    effective_at: str | None = None,
+    saved_at: str | None = None,
+    source_reference: str | None = None,
+) -> SafetyAuthorityPresentationMaterializeResultV1:
+    """Materialize the presentation projection from Safety binder-compatible fields.
+
+    Missing source yields MISSING_SOURCE and does not write an artifact.
+    Invalid source or missing required timestamps fail closed without writing.
+    Caller-owned Safety inputs are never mutated.
+    Never reads productive/live KillSwitch state files.
+    """
+    if safety_authority is None:
+        return _empty_result(
+            status=STATUS_MISSING_SOURCE,
+            errors=(MATERIALIZE_ERROR_MISSING_SOURCE,),
+        )
+
+    if _require_nonempty_str(generated_at) is None:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_TIMESTAMP_MISSING,),
+        )
+
+    # Snapshot caller-owned mapping to prove / preserve non-mutation.
+    caller_snapshot = deepcopy(safety_authority) if isinstance(safety_authority, Mapping) else None
+
+    payload, build_errors = build_safety_authority_presentation_projection_payload_v1(
+        safety_authority=safety_authority,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        saved_at=saved_at,
+        source_reference=source_reference,
+    )
+    if isinstance(safety_authority, Mapping) and caller_snapshot is not None:
+        if dict(safety_authority) != dict(caller_snapshot):
+            return _empty_result(
+                status=STATUS_FAIL_CLOSED,
+                errors=(MATERIALIZE_ERROR_INVALID_SOURCE,),
+            )
+    if payload is None:
+        status = (
+            STATUS_MISSING_SOURCE
+            if MATERIALIZE_ERROR_MISSING_SOURCE in build_errors
+            else STATUS_FAIL_CLOSED
+        )
+        return _empty_result(status=status, errors=build_errors)
+
+    # Re-validate via binder map to ensure invalid payloads are never persisted.
+    nested = payload.get("safety_authority")
+    if not isinstance(nested, Mapping):
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID),
+        )
+    mapped, map_errors = map_safety_authority_fields_to_binder_fields_v1(
+        safety_authority=nested,
+        generated_at=str(payload.get("generated_at") or ""),
+        effective_at=(
+            None if payload.get("effective_at") is None else str(payload.get("effective_at"))
+        ),
+        saved_at=(None if payload.get("saved_at") is None else str(payload.get("saved_at"))),
+        source_reference=(
+            None
+            if payload.get("source_reference") is None
+            else str(payload.get("source_reference"))
+        ),
+    )
+    if mapped is None:
+        return _empty_result(status=STATUS_FAIL_CLOSED, errors=map_errors)
+
+    result = write_safety_authority_presentation_projection_v1(archive_root, payload)
+    if not result.written:
+        return result
+    return SafetyAuthorityPresentationMaterializeResultV1(
+        written=True,
+        status=STATUS_WRITTEN,
+        errors=(),
+        projection_path=result.projection_path,
+        kill_switch_state=result.kill_switch_state,
+        veto_active=result.veto_active,
+        payload_digest=result.payload_digest,
+    )

--- a/src/webui/workflow_dashboard_readmodel_v1/safety_authority_presentation_projection_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/safety_authority_presentation_projection_v1.py
@@ -1,0 +1,340 @@
+"""Non-authoritative presentation projection for Safety Authority.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_SAFETY_AUTHORITY_PROJECTION_MATERIALIZER_AUTOBIND_V1
+
+Reads already-produced Safety binder-compatible fields from a single durable
+archive path and maps them field-for-field into Landscape binder injection
+fields. This module:
+
+- AUTHORITY_EFFECT=NONE
+- SAFETY_AUTHORITY_EFFECT=NONE
+- never creates, mutates, triggers, recovers, or evaluates KillSwitch
+- never imports src.risk_layer.kill_switch
+- never imports trading.master_v2.killswitch_boundary_* adapters
+- never auto-loads productive/live KillSwitch state files
+- never invents kill_switch_state, veto_active, reason_codes, or timestamps
+- fail-closed: missing, invalid, or ambiguous sources → no fields (MISSING_SOURCE)
+
+Deterministic source selection: exactly one well-known relative path under the
+Workflow Dashboard archive root. No silent multi-candidate "latest" picking.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_NAME = "safety_authority_presentation_projection.v1"
+SCHEMA_VERSION = 1
+STORAGE_RELATIVE_PATH = "readmodels/safety_authority.v1.json"
+AUTHORITY_EFFECT = "NONE"
+SAFETY_AUTHORITY_EFFECT = "NONE"
+PROJECTION_ROLE = "NON_AUTHORITATIVE_PRESENTATION_PROJECTION"
+OWNER_MODULE = "webui.workflow_dashboard_readmodel_v1.safety_authority_presentation_projection_v1"
+
+LOAD_ERROR_ABSENT = "SAFETY_AUTHORITY_PRESENTATION_PROJECTION_ABSENT"
+LOAD_ERROR_INVALID_JSON = "SAFETY_AUTHORITY_PRESENTATION_PROJECTION_INVALID_JSON"
+LOAD_ERROR_SCHEMA_MISMATCH = "SAFETY_AUTHORITY_PRESENTATION_PROJECTION_SCHEMA_MISMATCH"
+LOAD_ERROR_AUTHORITY_CLAIM = "SAFETY_AUTHORITY_PRESENTATION_PROJECTION_AUTHORITY_CLAIM"
+LOAD_ERROR_FIELDS_INVALID = "SAFETY_AUTHORITY_PRESENTATION_PROJECTION_FIELDS_INVALID"
+LOAD_ERROR_AMBIGUOUS = "SAFETY_AUTHORITY_PRESENTATION_PROJECTION_AMBIGUOUS_SOURCE"
+LOAD_ERROR_TIMESTAMP_MISSING = "SAFETY_AUTHORITY_PRESENTATION_PROJECTION_TIMESTAMP_MISSING"
+
+_REQUIRED_FIELD_KEYS = (
+    "kill_switch_state",
+    "veto_active",
+)
+
+
+@dataclass(frozen=True)
+class SafetyAuthorityPresentationLoadV1:
+    """Result of a fail-closed presentation projection load attempt."""
+
+    loaded: bool
+    load_errors: tuple[str, ...]
+    binder_fields: Mapping[str, Any] | None = None
+    source_path: str | None = None
+    evidence_digest: str | None = None
+    kill_switch_state: str | None = None
+    veto_active: bool | None = None
+
+
+def _empty(*, load_errors: tuple[str, ...]) -> SafetyAuthorityPresentationLoadV1:
+    return SafetyAuthorityPresentationLoadV1(loaded=False, load_errors=load_errors)
+
+
+def _require_nonempty_str(payload: Mapping[str, Any], key: str) -> str | None:
+    raw = payload.get(key)
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return raw.strip()
+
+
+def _normalize_reason_codes(raw_codes: object) -> tuple[str, ...] | None:
+    """Deterministic reason-code normalization without changing meaning."""
+    if raw_codes is None:
+        raw_codes = ()
+    if not isinstance(raw_codes, (list, tuple)):
+        return None
+    return tuple(str(code) for code in raw_codes)
+
+
+def _fields_payload_from_envelope(
+    payload: Mapping[str, Any],
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    """Extract nested safety_authority fields; fail closed on ambiguity."""
+    if "safety_authority" not in payload:
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+    fields = payload.get("safety_authority")
+    if not isinstance(fields, Mapping):
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+    # Reject dual top-level + nested kill_switch_state with conflicting values.
+    top_level_state = payload.get("kill_switch_state")
+    nested_state = fields.get("kill_switch_state")
+    if (
+        isinstance(top_level_state, str)
+        and top_level_state.strip()
+        and isinstance(nested_state, str)
+        and nested_state.strip()
+        and top_level_state.strip() != nested_state.strip()
+    ):
+        return None, (LOAD_ERROR_AMBIGUOUS,)
+    top_veto = payload.get("veto_active")
+    nested_veto = fields.get("veto_active")
+    if isinstance(top_veto, bool) and isinstance(nested_veto, bool) and top_veto is not nested_veto:
+        return None, (LOAD_ERROR_AMBIGUOUS,)
+    return fields, ()
+
+
+def _validate_safety_fields(
+    fields: Mapping[str, Any],
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    missing = [key for key in _REQUIRED_FIELD_KEYS if key not in fields]
+    if missing:
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+
+    kill_switch_state = _require_nonempty_str(fields, "kill_switch_state")
+    if kill_switch_state is None:
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+
+    veto_raw = fields.get("veto_active")
+    if not isinstance(veto_raw, bool):
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+
+    out: dict[str, Any] = {
+        "kill_switch_state": kill_switch_state,
+        "veto_active": veto_raw,
+    }
+
+    reason_codes = _normalize_reason_codes(fields.get("reason_codes", ()))
+    if reason_codes is None:
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+    out["reason_codes"] = reason_codes
+
+    digest = fields.get("evidence_digest")
+    if digest is None:
+        digest = fields.get("semantic_digest")
+    if digest is not None:
+        if not isinstance(digest, str) or not digest.strip():
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["evidence_digest"] = digest.strip()
+        out["semantic_digest"] = digest.strip()
+
+    source_reference = fields.get("source_reference")
+    if source_reference is None:
+        source_reference = fields.get("killswitch_owner_ref")
+    if source_reference is not None:
+        if not isinstance(source_reference, str):
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["source_reference"] = source_reference
+        out["killswitch_owner_ref"] = source_reference
+
+    schema_version = fields.get("schema_version")
+    if schema_version is not None:
+        if not isinstance(schema_version, str) or not schema_version.strip():
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["schema_version"] = schema_version.strip()
+
+    return out, ()
+
+
+def map_safety_authority_fields_to_binder_fields_v1(
+    *,
+    safety_authority: Mapping[str, Any],
+    generated_at: str,
+    effective_at: str | None = None,
+    saved_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Map Safety Authority fields → Landscape binder fields (projection only)."""
+    mapped, errors = _validate_safety_fields(safety_authority)
+    if mapped is None:
+        return None, errors
+    if not isinstance(generated_at, str) or not generated_at.strip():
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+    mapped["generated_at"] = generated_at.strip()
+    if effective_at is not None:
+        if not isinstance(effective_at, str) or not effective_at.strip():
+            return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+        mapped["effective_at"] = effective_at.strip()
+    if saved_at is not None:
+        if not isinstance(saved_at, str) or not saved_at.strip():
+            return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+        mapped["saved_at"] = saved_at.strip()
+        # Binder treats saved_at as effective_at alias when effective_at absent.
+        if "effective_at" not in mapped:
+            mapped["effective_at"] = saved_at.strip()
+    if source_reference is not None:
+        if not isinstance(source_reference, str):
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        mapped["source_reference"] = source_reference
+        mapped["killswitch_owner_ref"] = source_reference
+    return mapped, ()
+
+
+def project_safety_authority_presentation_projection_v1(
+    *,
+    safety_authority: Mapping[str, Any],
+    generated_at: str,
+    effective_at: str | None = None,
+    saved_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Build the non-authoritative presentation projection envelope.
+
+    Field-faithful projection of already binder-compatible Safety fields only.
+    Never invents KillSwitch state, veto, timestamps, or productive defaults.
+    """
+    binder_fields, map_errors = map_safety_authority_fields_to_binder_fields_v1(
+        safety_authority=safety_authority,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        saved_at=saved_at,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return None, map_errors
+
+    safety_out: dict[str, Any] = {
+        "kill_switch_state": binder_fields["kill_switch_state"],
+        "reason_codes": list(binder_fields.get("reason_codes", ())),
+        "veto_active": binder_fields["veto_active"],
+    }
+    if "evidence_digest" in binder_fields:
+        safety_out["evidence_digest"] = binder_fields["evidence_digest"]
+        safety_out["semantic_digest"] = binder_fields["evidence_digest"]
+    if "schema_version" in binder_fields:
+        safety_out["schema_version"] = binder_fields["schema_version"]
+    if "source_reference" in binder_fields and source_reference is None:
+        # Preserve nested provenance when carried on fields payload.
+        safety_out["source_reference"] = binder_fields["source_reference"]
+        safety_out["killswitch_owner_ref"] = binder_fields["source_reference"]
+
+    payload: dict[str, Any] = {
+        "authority_effect": AUTHORITY_EFFECT,
+        "generated_at": binder_fields["generated_at"],
+        "projection_role": PROJECTION_ROLE,
+        "safety_authority": safety_out,
+        "safety_authority_effect": SAFETY_AUTHORITY_EFFECT,
+        "schema_name": SCHEMA_NAME,
+        "schema_version": SCHEMA_VERSION,
+    }
+    if "effective_at" in binder_fields:
+        payload["effective_at"] = binder_fields["effective_at"]
+    if "saved_at" in binder_fields:
+        payload["saved_at"] = binder_fields["saved_at"]
+    if source_reference is not None:
+        payload["source_reference"] = source_reference
+    elif "source_reference" in binder_fields:
+        payload["source_reference"] = binder_fields["source_reference"]
+    return payload, ()
+
+
+def try_load_safety_authority_presentation_projection_v1(
+    archive_root: str | Path,
+) -> SafetyAuthorityPresentationLoadV1:
+    """Verify-before-trust read of the sole durable Safety presentation projection.
+
+    Returns loaded=False with load_errors on any fail-closed condition. Never
+    invents Safety/KillSwitch facts and never reads productive live state paths.
+    """
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    if not path.is_file():
+        return _empty(load_errors=(LOAD_ERROR_ABSENT,))
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    if not isinstance(payload, dict):
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    schema_name = payload.get("schema_name")
+    if schema_name != SCHEMA_NAME:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    authority = payload.get("authority_effect")
+    safety_authority = payload.get("safety_authority_effect")
+    if authority != AUTHORITY_EFFECT or safety_authority != SAFETY_AUTHORITY_EFFECT:
+        return _empty(load_errors=(LOAD_ERROR_AUTHORITY_CLAIM,))
+
+    generated_at = _require_nonempty_str(payload, "generated_at")
+    if generated_at is None:
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+
+    effective_at = payload.get("effective_at")
+    if effective_at is not None and (not isinstance(effective_at, str) or not effective_at.strip()):
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+    effective_at_s = None if effective_at is None else str(effective_at).strip()
+
+    saved_at = payload.get("saved_at")
+    if saved_at is not None and (not isinstance(saved_at, str) or not saved_at.strip()):
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+    saved_at_s = None if saved_at is None else str(saved_at).strip()
+
+    fields, field_errors = _fields_payload_from_envelope(payload)
+    if fields is None:
+        return _empty(load_errors=field_errors)
+
+    source_reference = payload.get("source_reference")
+    if source_reference is None:
+        source_reference = f"presentation://{STORAGE_RELATIVE_PATH}"
+    elif not isinstance(source_reference, str):
+        return _empty(load_errors=(LOAD_ERROR_FIELDS_INVALID,))
+
+    binder_fields, map_errors = map_safety_authority_fields_to_binder_fields_v1(
+        safety_authority=fields,
+        generated_at=generated_at,
+        effective_at=effective_at_s,
+        saved_at=saved_at_s,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return _empty(load_errors=map_errors)
+
+    return SafetyAuthorityPresentationLoadV1(
+        loaded=True,
+        load_errors=(),
+        binder_fields=binder_fields,
+        source_path=str(path),
+        evidence_digest=(
+            None
+            if binder_fields.get("evidence_digest") is None
+            else str(binder_fields.get("evidence_digest"))
+        ),
+        kill_switch_state=str(binder_fields["kill_switch_state"]),
+        veto_active=bool(binder_fields["veto_active"]),
+    )

--- a/tests/webui/test_market_landscape_safety_authority_presentation_autobind_v1.py
+++ b/tests/webui/test_market_landscape_safety_authority_presentation_autobind_v1.py
@@ -1,0 +1,350 @@
+"""Focused autobind tests: CAPABILITY_PRESENTATION_SAFETY_AUTHORITY_PROJECTION_MATERIALIZER_AUTOBIND_V1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    REASON_SAFETY_NOT_PERSISTED,
+    SAFETY_AUTHORITY_OWNER_MODULE,
+    SAFETY_EVIDENCE_PRODUCER_MODULE,
+    SAFETY_SOURCE_KIND,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT
+from src.webui.workflow_dashboard_readmodel_v1.safety_authority_presentation_projection_v1 import (
+    AUTHORITY_EFFECT,
+    LOAD_ERROR_ABSENT,
+    LOAD_ERROR_AUTHORITY_CLAIM,
+    LOAD_ERROR_FIELDS_INVALID,
+    LOAD_ERROR_INVALID_JSON,
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    SAFETY_AUTHORITY_EFFECT,
+    SCHEMA_NAME,
+    STORAGE_RELATIVE_PATH,
+    map_safety_authority_fields_to_binder_fields_v1,
+    try_load_safety_authority_presentation_projection_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+STAMP = datetime(2026, 7, 24, 18, 0, 0, tzinfo=timezone.utc)
+PRODUCER_FRESH = "2026-07-24T17:30:00Z"
+FORBIDDEN_LIVE_STATE = "live data/kill_switch/state.json"
+
+
+def _fields(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "kill_switch_state": "KILLED",
+        "veto_active": True,
+        "reason_codes": ("killswitch_block_new", "reconciliation_required"),
+        "evidence_digest": "a" * 64,
+        "schema_version": "v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _projection_payload(
+    *,
+    safety_authority: dict[str, object] | None = None,
+    **overrides: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_name": SCHEMA_NAME,
+        "schema_version": 1,
+        "authority_effect": AUTHORITY_EFFECT,
+        "safety_authority_effect": SAFETY_AUTHORITY_EFFECT,
+        "projection_role": "NON_AUTHORITATIVE_PRESENTATION_PROJECTION",
+        "generated_at": PRODUCER_FRESH,
+        "effective_at": PRODUCER_FRESH,
+        "saved_at": PRODUCER_FRESH,
+        "source_reference": "presentation://safety_autobind_test",
+        "safety_authority": (safety_authority if safety_authority is not None else _fields()),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_projection(archive_root: Path, payload: dict[str, object]) -> Path:
+    path = archive_root / STORAGE_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_map_fields_to_binder_fields_preserves_producer_facts() -> None:
+    fields, errors = map_safety_authority_fields_to_binder_fields_v1(
+        safety_authority=_fields(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        saved_at=PRODUCER_FRESH,
+        source_reference="presentation://x",
+    )
+    assert errors == ()
+    assert fields is not None
+    assert fields["kill_switch_state"] == "KILLED"
+    assert fields["veto_active"] is True
+    assert fields["reason_codes"] == ("killswitch_block_new", "reconciliation_required")
+    assert fields["evidence_digest"] == "a" * 64
+    assert fields["generated_at"] == PRODUCER_FRESH
+    assert fields["saved_at"] == PRODUCER_FRESH
+
+
+def test_load_absent_projection_is_missing(tmp_path: Path) -> None:
+    loaded = try_load_safety_authority_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_ABSENT in loaded.load_errors
+    assert loaded.binder_fields is None
+
+
+def test_load_valid_projection_returns_binder_fields(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload())
+    loaded = try_load_safety_authority_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.load_errors == ()
+    assert loaded.binder_fields is not None
+    assert loaded.kill_switch_state == "KILLED"
+    assert loaded.veto_active is True
+    assert loaded.evidence_digest == "a" * 64
+    assert STORAGE_RELATIVE_PATH in str(loaded.source_path)
+
+
+def test_load_schema_mismatch_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(schema_name="wrong.schema"))
+    loaded = try_load_safety_authority_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_SCHEMA_MISMATCH in loaded.load_errors
+
+
+def test_load_wrong_schema_version_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(schema_version=99))
+    loaded = try_load_safety_authority_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_SCHEMA_MISMATCH in loaded.load_errors
+
+
+def test_load_authority_claim_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(authority_effect="SAFETY"))
+    loaded = try_load_safety_authority_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_AUTHORITY_CLAIM in loaded.load_errors
+
+
+def test_load_invalid_fields_fail_closed(tmp_path: Path) -> None:
+    _write_projection(
+        tmp_path,
+        _projection_payload(safety_authority={"veto_active": True}),
+    )
+    loaded = try_load_safety_authority_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_FIELDS_INVALID in loaded.load_errors
+
+
+def test_load_invalid_json_fail_closed(tmp_path: Path) -> None:
+    path = tmp_path / STORAGE_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not-json", encoding="utf-8")
+    loaded = try_load_safety_authority_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_INVALID_JSON in loaded.load_errors
+
+
+def test_autobind_available_from_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    safety = slots["safety_authority"]
+    assert safety.availability is Availability.AVAILABLE
+    assert safety.kill_switch_state == "KILLED"
+    assert safety.veto_active is True
+    assert safety.reason_codes == ("killswitch_block_new", "reconciliation_required")
+    assert safety.provenance.producer_module == SAFETY_EVIDENCE_PRODUCER_MODULE
+    assert safety.provenance.source_kind == SAFETY_SOURCE_KIND
+    assert safety.provenance.source_reference == "presentation://safety_autobind_test"
+    assert safety.provenance.evidence_digest == "a" * 64
+    assert slots["economic_summary"].availability is Availability.MISSING_SOURCE
+
+
+def test_autobind_missing_projection_is_missing_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "empty_archive"
+    archive.mkdir()
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["safety_authority"].availability is Availability.MISSING_SOURCE
+    assert REASON_SAFETY_NOT_PERSISTED in slots["safety_authority"].reason_codes
+
+
+def test_autobind_invalid_json_is_missing_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "bad_json_archive"
+    path = archive / STORAGE_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{broken", encoding="utf-8")
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["safety_authority"].availability is Availability.MISSING_SOURCE
+    assert LOAD_ERROR_INVALID_JSON in slots["safety_authority"].reason_codes
+
+
+def test_autobind_wrong_version_is_missing_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "bad_version_archive"
+    _write_projection(archive, _projection_payload(schema_version=7))
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["safety_authority"].availability is Availability.MISSING_SOURCE
+    assert LOAD_ERROR_SCHEMA_MISMATCH in slots["safety_authority"].reason_codes
+
+
+def test_autobind_schema_error_is_missing_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "bad_schema_archive"
+    _write_projection(archive, _projection_payload(schema_name="nope"))
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["safety_authority"].availability is Availability.MISSING_SOURCE
+    assert LOAD_ERROR_SCHEMA_MISMATCH in slots["safety_authority"].reason_codes
+
+
+def test_explicit_injection_still_overrides_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        safety_authority_fields={
+            "kill_switch_state": "ARMED",
+            "veto_active": False,
+            "reason_codes": ("INJECTED",),
+            "semantic_digest": "b" * 64,
+            "generated_at": PRODUCER_FRESH,
+            "saved_at": PRODUCER_FRESH,
+            "source_reference": "safety://bounded-test-injection",
+            "schema_version": "v1",
+        },
+    )
+    safety = slots["safety_authority"]
+    assert safety.availability is Availability.AVAILABLE
+    assert safety.kill_switch_state == "ARMED"
+    assert safety.veto_active is False
+    assert safety.reason_codes == ("INJECTED",)
+    assert safety.provenance.source_reference == "safety://bounded-test-injection"
+
+
+def test_get_market_autobinds_safety_without_injection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(
+        archive,
+        _projection_payload(
+            safety_authority=_fields(
+                kill_switch_state="KILLED",
+                veto_active=True,
+                reason_codes=("AUTOBIND_OK",),
+            )
+        ),
+    )
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "KILLED" in html
+    assert "veto=True" in html
+    assert 'data-mdl-field="safety"' in html
+    assert "<form" not in html.lower()
+    assert "place_order" not in html.lower()
+    assert FORBIDDEN_LIVE_STATE not in html
+
+
+def test_projection_and_binding_have_no_forbidden_killswitch_imports() -> None:
+    projection_paths = [
+        REPO
+        / "src/webui/workflow_dashboard_readmodel_v1"
+        / "safety_authority_presentation_projection_v1.py",
+        REPO
+        / "src/webui/workflow_dashboard_readmodel_v1"
+        / "safety_authority_presentation_projection_materializer_v1.py",
+    ]
+    binding_path = REPO / "src/webui/market_dashboard_landscape_producer_binding_v2.py"
+    for path in [*projection_paths, binding_path]:
+        text = path.read_text(encoding="utf-8")
+        assert FORBIDDEN_LIVE_STATE not in text
+        assert "kill_switch/state.json" not in text
+        tree = ast.parse(text)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                assert not module.startswith("src.risk_layer")
+                assert "killswitch_boundary" not in module
+                assert module != "src.risk_layer.kill_switch"
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert not alias.name.startswith("src.risk_layer")
+                    assert "killswitch_boundary" not in alias.name
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                assert node.func.id not in {
+                    "KillSwitch",
+                    "evaluate_offline_killswitch_boundary_v0",
+                    "bind_killswitch_boundary_offline_replay_evidence_v0",
+                    "derive_killswitch_boundary_mode_v0",
+                }
+    for path in projection_paths:
+        text = path.read_text(encoding="utf-8")
+        assert "KillSwitch(" not in text
+        tree = ast.parse(text)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported.add(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.level and node.level > 0:
+                    continue
+                if node.module:
+                    imported.add(node.module)
+        for module in imported:
+            assert not module.startswith("src.risk_layer")
+            assert "killswitch_boundary" not in module
+            assert module.split(".", 1)[0] not in {"trading", "src", "risk_layer"}
+
+
+def test_owner_registry_documents_durable_projection_and_injection_priority() -> None:
+    registry = (REPO / "src/webui/market_dashboard_landscape_v2/owner_registry.py").read_text(
+        encoding="utf-8"
+    )
+    safety_block = registry.split('slot="safety_authority"', 1)[1].split("CanonicalOwnerRefV1(", 1)[
+        0
+    ]
+    assert "safety_authority_presentation_projection.v1" in safety_block
+    assert "readmodels/safety_authority.v1.json" in safety_block
+    assert "explicit injection remains priority" in safety_block
+    assert "no productive KillSwitch state-file autoload" in safety_block
+    assert "AUTHORITY_EFFECT=NONE" in safety_block
+    assert SAFETY_AUTHORITY_OWNER_MODULE in safety_block

--- a/tests/webui/test_safety_authority_presentation_projection_materializer_v1.py
+++ b/tests/webui/test_safety_authority_presentation_projection_materializer_v1.py
@@ -1,0 +1,291 @@
+"""Focused tests: CAPABILITY_PRESENTATION_SAFETY_AUTHORITY_PROJECTION_MATERIALIZER_AUTOBIND_V1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    SAFETY_EVIDENCE_PRODUCER_MODULE,
+    SAFETY_SOURCE_KIND,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import (
+    ENV_ARCHIVE_ROOT,
+    SAFETY_AUTHORITY_PRESENTATION_PROJECTION_RELATIVE,
+)
+from src.webui.workflow_dashboard_readmodel_v1.safety_authority_presentation_projection_materializer_v1 import (
+    CAPABILITY_ID,
+    MATERIALIZE_ERROR_MISSING_SOURCE,
+    STATUS_FAIL_CLOSED,
+    STATUS_MISSING_SOURCE,
+    STATUS_WRITTEN,
+    build_safety_authority_presentation_projection_payload_v1,
+    materialize_safety_authority_presentation_projection_v1,
+    serialize_safety_authority_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.safety_authority_presentation_projection_v1 import (
+    LOAD_ERROR_FIELDS_INVALID,
+    LOAD_ERROR_TIMESTAMP_MISSING,
+    SCHEMA_NAME,
+    STORAGE_RELATIVE_PATH,
+    project_safety_authority_presentation_projection_v1,
+    try_load_safety_authority_presentation_projection_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+STAMP = datetime(2026, 7, 24, 18, 0, 0, tzinfo=timezone.utc)
+PRODUCER_FRESH = "2026-07-24T17:30:00Z"
+
+
+def _fields(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "kill_switch_state": "KILLED",
+        "veto_active": True,
+        "reason_codes": ("killswitch_block_new", "reconciliation_required"),
+        "evidence_digest": "e" * 64,
+        "schema_version": "v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_capability_id_is_stable() -> None:
+    assert CAPABILITY_ID == (
+        "CAPABILITY_PRESENTATION_SAFETY_AUTHORITY_PROJECTION_MATERIALIZER_AUTOBIND_V1"
+    )
+
+
+def test_archive_root_registers_exact_presentation_path() -> None:
+    assert SAFETY_AUTHORITY_PRESENTATION_PROJECTION_RELATIVE == STORAGE_RELATIVE_PATH
+    assert STORAGE_RELATIVE_PATH == "readmodels/safety_authority.v1.json"
+
+
+def test_project_payload_is_field_faithful_and_deterministic() -> None:
+    fields = _fields()
+    first, err_a = project_safety_authority_presentation_projection_v1(
+        safety_authority=fields,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        saved_at=PRODUCER_FRESH,
+        source_reference="presentation://unit-test",
+    )
+    second, err_b = build_safety_authority_presentation_projection_payload_v1(
+        safety_authority=fields,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        saved_at=PRODUCER_FRESH,
+        source_reference="presentation://unit-test",
+    )
+    assert err_a == ()
+    assert err_b == ()
+    assert first is not None and second is not None
+    assert first == second
+    assert serialize_safety_authority_presentation_projection_v1(
+        first
+    ) == serialize_safety_authority_presentation_projection_v1(second)
+    assert first["schema_name"] == SCHEMA_NAME
+    assert first["schema_version"] == 1
+    assert first["authority_effect"] == "NONE"
+    assert first["safety_authority_effect"] == "NONE"
+    assert first["safety_authority"]["kill_switch_state"] == "KILLED"
+    assert first["safety_authority"]["veto_active"] is True
+    assert first["safety_authority"]["reason_codes"] == [
+        "killswitch_block_new",
+        "reconciliation_required",
+    ]
+    assert first["generated_at"] == PRODUCER_FRESH
+    assert first["effective_at"] == PRODUCER_FRESH
+    assert first["saved_at"] == PRODUCER_FRESH
+
+
+def test_reason_codes_normalize_deterministically_without_invention() -> None:
+    payload, errors = project_safety_authority_presentation_projection_v1(
+        safety_authority=_fields(reason_codes=["A", 2, "B"]),
+        generated_at=PRODUCER_FRESH,
+    )
+    assert errors == ()
+    assert payload is not None
+    assert payload["safety_authority"]["reason_codes"] == ["A", "2", "B"]
+
+
+def test_materialize_writes_exact_archive_path(tmp_path: Path) -> None:
+    result = materialize_safety_authority_presentation_projection_v1(
+        tmp_path,
+        safety_authority=_fields(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        saved_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert result.status == STATUS_WRITTEN
+    assert result.errors == ()
+    assert result.projection_path is not None
+    assert result.projection_path.endswith(STORAGE_RELATIVE_PATH)
+    written = tmp_path / STORAGE_RELATIVE_PATH
+    assert written.is_file()
+    assert written == tmp_path / "readmodels" / "safety_authority.v1.json"
+
+
+def test_materialize_atomic_conventions(tmp_path: Path) -> None:
+    result = materialize_safety_authority_presentation_projection_v1(
+        tmp_path,
+        safety_authority=_fields(),
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    readmodels = tmp_path / "readmodels"
+    leftovers = [p for p in readmodels.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []
+    assert (readmodels / "safety_authority.v1.json").is_file()
+
+
+def test_materialize_roundtrip(tmp_path: Path) -> None:
+    materialize_safety_authority_presentation_projection_v1(
+        tmp_path,
+        safety_authority=_fields(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        saved_at=PRODUCER_FRESH,
+        source_reference="presentation://materializer-compat",
+    )
+    loaded = try_load_safety_authority_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.load_errors == ()
+    assert loaded.kill_switch_state == "KILLED"
+    assert loaded.veto_active is True
+    assert loaded.evidence_digest == "e" * 64
+    assert loaded.binder_fields is not None
+    assert loaded.binder_fields["reason_codes"] == (
+        "killswitch_block_new",
+        "reconciliation_required",
+    )
+    assert loaded.binder_fields["generated_at"] == PRODUCER_FRESH
+    assert loaded.binder_fields["effective_at"] == PRODUCER_FRESH
+    assert loaded.binder_fields["saved_at"] == PRODUCER_FRESH
+
+
+def test_missing_source_does_not_invent_artifact(tmp_path: Path) -> None:
+    result = materialize_safety_authority_presentation_projection_v1(
+        tmp_path,
+        safety_authority=None,
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_MISSING_SOURCE
+    assert MATERIALIZE_ERROR_MISSING_SOURCE in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+    loaded = try_load_safety_authority_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+
+
+def test_invalid_source_fail_closed(tmp_path: Path) -> None:
+    result = materialize_safety_authority_presentation_projection_v1(
+        tmp_path,
+        safety_authority={"veto_active": True},
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_FIELDS_INVALID in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_missing_generated_at_fail_closed(tmp_path: Path) -> None:
+    result = materialize_safety_authority_presentation_projection_v1(
+        tmp_path,
+        safety_authority=_fields(),
+        generated_at=None,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_TIMESTAMP_MISSING in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_does_not_mutate_caller_inputs(tmp_path: Path) -> None:
+    fields = _fields()
+    snapshot = deepcopy(fields)
+    result = materialize_safety_authority_presentation_projection_v1(
+        tmp_path,
+        safety_authority=fields,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert fields == snapshot
+
+
+def test_end_to_end_materialize_to_autobind_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    result = materialize_safety_authority_presentation_projection_v1(
+        archive,
+        safety_authority=_fields(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://e2e-safety-materializer",
+    )
+    assert result.written is True
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    safety = slots["safety_authority"]
+    assert safety.availability is Availability.AVAILABLE
+    assert safety.kill_switch_state == "KILLED"
+    assert safety.veto_active is True
+    assert safety.provenance.producer_module == SAFETY_EVIDENCE_PRODUCER_MODULE
+    assert safety.provenance.source_kind == SAFETY_SOURCE_KIND
+
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "KILLED" in html
+    assert 'data-mdl-field="safety"' in html
+    assert "<form" not in html.lower()
+    assert "place_order" not in html.lower()
+
+
+def test_materializer_and_projection_have_no_forbidden_imports() -> None:
+    for relative in (
+        "src/webui/workflow_dashboard_readmodel_v1/safety_authority_presentation_projection_v1.py",
+        "src/webui/workflow_dashboard_readmodel_v1/"
+        "safety_authority_presentation_projection_materializer_v1.py",
+    ):
+        path = REPO / relative
+        text = path.read_text(encoding="utf-8")
+        assert "live data/kill_switch" not in text
+        assert "KillSwitch(" not in text
+        tree = ast.parse(text)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported.add(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.level and node.level > 0:
+                    continue
+                if node.module:
+                    imported.add(node.module)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                assert node.func.id not in {
+                    "KillSwitch",
+                    "evaluate_offline_killswitch_boundary_v0",
+                    "bind_killswitch_boundary_offline_replay_evidence_v0",
+                }
+        for module in imported:
+            root = module.split(".", 1)[0]
+            assert root not in {"trading", "src", "risk_layer"}
+            assert not module.startswith("src.risk_layer")
+            assert "killswitch_boundary" not in module


### PR DESCRIPTION
## Summary
- Closes the confirmed presentation-only gap for `safety_authority` using already binder-compatible fields from `_bind_safety_authority` / `SafetyAuthoritySnapshotV1` (`kill_switch_state`, `veto_active`, `reason_codes`, provenance timestamps).
- Adds non-authoritative `safety_authority_presentation_projection.v1` plus deterministic materializer writing exactly `readmodels/safety_authority.v1.json` under the Workflow Dashboard archive root.
- Enables fail-closed archive autobind in producer binding with **explicit injection priority**; absent/invalid/wrong-version/schema → honest `MISSING_SOURCE`.
- Registers the presentation archive path, documents durable projection + injection priority in owner registry, and keeps `AUTHORITY_EFFECT=NONE`.

## Authority / boundaries
- No productive KillSwitch state autoload (never `live data/kill_switch/state.json` or comparable operative paths).
- No KillSwitch construct/trigger/recover/evaluate; no `src.risk_layer/**` or `killswitch_boundary_*` imports in projection/materializer.
- No Safety/Risk/Trading/Runtime authority changes; producers and canonical read-model semantics unchanged.
- `PRODUCER_CHANGED=false`, `CANONICAL_READ_MODEL_CHANGED=false`, `TRADING_LOGIC_CHANGED=false`, `RUNTIME_CHANGED=false`, `RISK_LOGIC_CHANGED=false`, `SAFETY_LOGIC_CHANGED=false`.

## Tests
- New: `tests/webui/test_safety_authority_presentation_projection_materializer_v1.py`
- New: `tests/webui/test_market_landscape_safety_authority_presentation_autobind_v1.py`
- Sibling risk/execution projection+autobind, producer binding, archive root, architecture guards (pre-existing unrelated `test_landscape_package_stdlib_and_relative_only` failure in `presenter.py` ohlcv adapter import documented, not repaired).
- Ruff format/check on allowed files: PASS.

## Test plan
- [x] Focused materializer + autobind tests green
- [x] Sibling risk/execution presentation tests green
- [x] Producer binding + archive root green
- [x] Diff limited to allowed `src/webui/**` + `tests/webui/**` files
- [ ] Owner merge GO required (do not merge without explicit GO)


Made with [Cursor](https://cursor.com)