### PR TITLE
fix(webui): restore landscape relative-import architecture guard

### DIFF
--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -226,6 +226,7 @@ def build_ohlcv_poll_response_v1(
             ohlcv_payload=ohlcv,
             chart_availability=availability,
             projection_time_unix=projection_unix,
+            adapted_connection_state=str(o5_read_model.get("connection_state") or "DEGRADED"),
         )
     )
     if data_connection_state == "HEALTHY":
@@ -313,7 +314,28 @@ async def market_landscape_dashboard(request: Request) -> Any:
         or page.universe_ranking.selected_instrument_id,
         selected_venue=page.market_instrument.venue,
     )
-    context = present_market_landscape_v2(page, ohlcv_readmodel=ohlcv)
+    # O5 chrome stays at the shell boundary — Landscape package must not import ops.
+    from src.ops.canonical_read_model_and_market_dashboard_rebuild_v1.ohlcv_adapter_v1 import (
+        adapt_derived_ohlcv_payload_to_o5_read_model_v1,
+    )
+
+    chart_availability = page.market_instrument.availability
+    if isinstance(ohlcv, dict) and ohlcv.get("bar_count"):
+        freshness = str(ohlcv.get("freshness_state") or "")
+        if freshness == "stale" or bool(ohlcv.get("is_stale")):
+            chart_availability = Availability.STALE
+        elif chart_availability not in (Availability.AVAILABLE, Availability.STALE):
+            chart_availability = Availability.AVAILABLE
+    o5_chrome = adapt_derived_ohlcv_payload_to_o5_read_model_v1(
+        ohlcv,
+        projection_time_unix=generated_at.timestamp(),
+        availability=chart_availability.value,
+    )
+    context = present_market_landscape_v2(
+        page,
+        ohlcv_readmodel=ohlcv,
+        adapted_ohlcv_connection_state=str(o5_chrome.get("connection_state") or "DEGRADED"),
+    )
     if ohlcv is not None:
         eng = context.setdefault("engineering", {})
         eng["okx_ohlcv"] = {

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -692,14 +692,18 @@ def _ohlcv_data_connection_state(
     chart_availability: Availability,
     disconnected: bool = False,
     projection_time_unix: float | None = None,
+    adapted_connection_state: str | None = None,
 ) -> str:
     """O5 connection vocabulary: HEALTHY/DEGRADED/STALE/DISCONNECTED/MISSING_SOURCE.
 
     Stale or disconnected cached data must never classify as HEALTHY.
+
+    Age/freshness chrome is owned by the O5 ops adapter at the shell boundary.
+    Landscape presentation accepts an optional adapted_connection_state and must
+    not import ops owners (architecture guard: stdlib + relative only).
     """
-    from src.ops.canonical_read_model_and_market_dashboard_rebuild_v1.ohlcv_adapter_v1 import (
-        adapt_derived_ohlcv_payload_to_o5_read_model_v1,
-    )
+    # Retained for call-site compatibility; age chrome arrives via adapted_connection_state.
+    _ = projection_time_unix
 
     if chart_availability is Availability.MISSING_SOURCE:
         return "MISSING_SOURCE"
@@ -713,12 +717,6 @@ def _ohlcv_data_connection_state(
     if bool(source.get("is_stale")) or str(source.get("freshness_state") or "").lower() == "stale":
         return "STALE"
 
-    now = projection_time_unix
-    if now is None:
-        from datetime import datetime, timezone
-
-        now = datetime.now(timezone.utc).timestamp()
-
     if _ohlcv_source_feed_is_live(
         browser_payload=browser_payload,
         ohlcv_payload=ohlcv_payload,
@@ -727,17 +725,18 @@ def _ohlcv_data_connection_state(
         # Authentic open-candle evidence → HEALTHY (explicit stale/disconnected already excluded).
         return "HEALTHY"
 
-    adapted = adapt_derived_ohlcv_payload_to_o5_read_model_v1(
-        ohlcv_payload,
-        projection_time_unix=float(now),
-        availability=chart_availability.value,
-        disconnected=False,
-    )
-    state = str(adapted.get("connection_state") or "DEGRADED")
-    # Source present without authentic live evidence must never invent HEALTHY.
-    if state == "HEALTHY":
-        return "DEGRADED"
-    return state
+    # Prefer O5-adapted chrome injected by the shell / producer boundary.
+    if adapted_connection_state is not None:
+        state = str(adapted_connection_state or "DEGRADED")
+        # Source present without authentic live evidence must never invent HEALTHY.
+        if state == "HEALTHY":
+            return "DEGRADED"
+        return state
+
+    # Presentation without boundary injection: fail-closed, never invent HEALTHY.
+    if ohlcv_payload is None:
+        return "MISSING_SOURCE"
+    return "DEGRADED"
 
 
 def _regime_context_views(snap: Any) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
@@ -802,8 +801,13 @@ def present_market_landscape_v2(
     page: MarketDashboardPageSnapshotV1,
     *,
     ohlcv_readmodel: Mapping[str, Any] | None = None,
+    adapted_ohlcv_connection_state: str | None = None,
 ) -> dict[str, Any]:
-    """Format page snapshot for SSR template context (presentation only)."""
+    """Format page snapshot for SSR template context (presentation only).
+
+    adapted_ohlcv_connection_state: optional O5 connection chrome from the shell
+    boundary (ops adapter). Landscape must not import the ops owner itself.
+    """
     market = _slot_view(page.market_instrument)
     universe = _slot_view(page.universe_ranking)
     scope = _slot_view(page.dynamic_scope)
@@ -1046,6 +1050,7 @@ def present_market_landscape_v2(
                 browser_payload=browser_payload,
                 ohlcv_payload=ohlcv_payload,
                 chart_availability=chart_availability,
+                adapted_connection_state=adapted_ohlcv_connection_state,
             ),
         },
         "timeline": {


### PR DESCRIPTION
## Summary

- **Root cause:** CAPABILITY_O5 (`8fbb57902`) introduced an absolute ops import inside the Landscape package: `presenter.py` → `src.ops.canonical_read_model_and_market_dashboard_rebuild_v1.ohlcv_adapter_v1`. That violates the intentional architecture guard `test_landscape_package_stdlib_and_relative_only` (stdlib + relative imports only). The defect was pre-existing on `main` after O5 merge; it was not introduced by the already squash-merged PR #5695 cleanup.
- **Why the presenter side was corrected (not the guard):** The guard correctly enforces the Landscape package boundary. `ohlcv_adapter_v1` lives outside that package, so a relative import is impossible. Weakening/allowlisting the guard would hide a real boundary violation.
- **Fix:** Remove the ops import from `presenter.py`. Keep O5 adaptation at the existing shell boundary (`market_dashboard_landscape_shell_router_v2.py`), and inject `adapted_connection_state` / `adapted_ohlcv_connection_state` into the presenter. Live-feed HEALTHY demotion rules and O5 vocabulary remain unchanged.
- **No runtime / trading / authority effect:** Only WebUI presentation import wiring changed. No trading, risk, decision authority, producers, or canonical read-model owners were modified. Public connection-state vocabulary and demotion semantics are preserved via boundary injection.

## Test plan

- [x] `test_landscape_package_stdlib_and_relative_only` (was red → green)
- [x] Full `tests/webui/test_market_landscape_dashboard_v2_architecture_guards_v0.py` (19 passed)
- [x] `tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py`
- [x] `tests/ops/test_canonical_read_model_and_market_dashboard_rebuild_v1.py`
- [x] Landscape contracts + shell route tests
- [x] Import smoke + import-order cycle check (PASS)
- [x] `ruff format --check` / `ruff check` on changed files
- [x] Selector `PR_BOUNDED_FULL` targets (729 passed, ~36s)

**Do not merge without explicit Owner-Merge-GO for this PR.**


Made with [Cursor](https://cursor.com)