### PR TITLE
feat(webui): materialize and autobind economic summary presentation

### DIFF
--- a/src/webui/market_dashboard_landscape_producer_binding_v2.py
+++ b/src/webui/market_dashboard_landscape_producer_binding_v2.py
@@ -12,7 +12,8 @@ KillSwitch state-file autoload),
 risk/sizing/capital field projection (injection or durable presentation
 projection auto-bind), execution/reconciliation field projection (injection
 or durable presentation projection auto-bind), and
-economic summary EconomicViabilityEvidenceV1 field projection.
+economic summary EconomicViabilityEvidenceV1 field projection (injection or
+durable presentation projection auto-bind).
 Lives outside market_dashboard_landscape_v2 so that package stays free of
 trading/webui producer imports (architecture guard).
 
@@ -32,7 +33,8 @@ Fail-closed:
 - Never call capital/risk/sizing evaluators, order-intent builders,
   or offline reconciliation evaluators; no order/execution mutation imports
 - Never discover/select EconomicViabilityEvidenceV1 instances (no filesystem,
-  registry, latest-file, or environment selector)
+  registry, latest-file, or environment selector); durable auto-bind uses only
+  the single well-known presentation projection path under archive root
 - Never bind promotion_economic_gate_v1 or infer lifecycle labels
 """
 
@@ -100,6 +102,10 @@ from .workflow_dashboard_readmodel_v1.execution_reconciliation_presentation_proj
 from .workflow_dashboard_readmodel_v1.safety_authority_presentation_projection_v1 import (
     LOAD_ERROR_ABSENT as SAFETY_AUTHORITY_PROJECTION_ABSENT,
     try_load_safety_authority_presentation_projection_v1,
+)
+from .workflow_dashboard_readmodel_v1.economic_summary_presentation_projection_v1 import (
+    LOAD_ERROR_ABSENT as ECONOMIC_SUMMARY_PROJECTION_ABSENT,
+    try_load_economic_summary_presentation_projection_v1,
 )
 from .workflow_dashboard_readmodel_v1.universe_selection_contract_v1 import (
     FORBIDDEN_SELECTED_SYMBOLS,
@@ -1502,19 +1508,47 @@ def _bind_economic_summary(
     as_of: datetime,
     git_sha: str | None,
     economic_viability_evidence_fields: Mapping[str, Any] | None,
+    archive_root: Path | None = None,
 ) -> Any:
-    """Project injected EconomicViabilityEvidenceV1-compatible fields.
+    """Project EconomicViabilityEvidenceV1-compatible fields.
 
-    No durable dashboard economic readmodel. Without injection → MISSING_SOURCE.
-    Never discovers evidence files, never binds promotion_economic_gate_v1,
-    and never infers DEVELOPMENT/HOLDOUT/SEALED from paths.
+    Injection remains supported and strictly preferred. Productive auto-bind
+    loads the non-authoritative presentation projection from the Workflow
+    Dashboard archive root when injection is absent. Without injection and
+    without a valid persisted projection → MISSING_SOURCE.
+    Never discovers evidence packs via latest/registry selectors, never binds
+    promotion_economic_gate_v1, and never infers DEVELOPMENT/HOLDOUT/SEALED
+    from paths.
     """
     if economic_viability_evidence_fields is None:
-        return unavailable_economic_summary(
-            availability=Availability.MISSING_SOURCE,
-            generated_at=as_of,
-            reason=REASON_ECONOMIC_NOT_PERSISTED,
-        )
+        if archive_root is None:
+            return unavailable_economic_summary(
+                availability=Availability.MISSING_SOURCE,
+                generated_at=as_of,
+                reason=REASON_ECONOMIC_NOT_PERSISTED,
+            )
+        loaded = try_load_economic_summary_presentation_projection_v1(archive_root)
+        if not loaded.loaded or loaded.binder_fields is None:
+            reason = REASON_ECONOMIC_NOT_PERSISTED
+            if loaded.load_errors:
+                first = str(loaded.load_errors[0])
+                if first != ECONOMIC_SUMMARY_PROJECTION_ABSENT:
+                    reason = first
+            availability = (
+                Availability.MISSING_SOURCE
+                if reason == REASON_ECONOMIC_NOT_PERSISTED
+                or reason == ECONOMIC_SUMMARY_PROJECTION_ABSENT
+                else Availability.INVALID
+            )
+            if reason == ECONOMIC_SUMMARY_PROJECTION_ABSENT:
+                reason = REASON_ECONOMIC_NOT_PERSISTED
+                availability = Availability.MISSING_SOURCE
+            return unavailable_economic_summary(
+                availability=availability,
+                generated_at=as_of,
+                reason=reason,
+            )
+        economic_viability_evidence_fields = loaded.binder_fields
 
     required = (
         "status",
@@ -2082,8 +2116,11 @@ def bind_market_universe_slots(
 
     economic_viability_evidence_fields accepts already-selected
     EconomicViabilityEvidenceV1-compatible fields plus producer wall-clock
-    timestamps. Without injection, economic_summary is MISSING_SOURCE.
-    Never discovers evidence artifacts or binds promotion_economic_gate_v1.
+    timestamps. Without injection, productive auto-bind loads
+    economic_summary_presentation_projection.v1 when present;
+    otherwise MISSING_SOURCE. Explicit injection remains priority over
+    archive autobind. Never discovers evidence artifacts via latest/registry
+    selectors or binds promotion_economic_gate_v1.
     """
     if generated_at.tzinfo is None:
         raise ValueError("generated_at must be timezone-aware")
@@ -2141,6 +2178,7 @@ def bind_market_universe_slots(
         as_of=as_of,
         git_sha=git_sha,
         economic_viability_evidence_fields=economic_viability_evidence_fields,
+        archive_root=root,
     )
 
     if market_instrument_fields is not None:

--- a/src/webui/market_dashboard_landscape_v2/owner_registry.py
+++ b/src/webui/market_dashboard_landscape_v2/owner_registry.py
@@ -193,11 +193,16 @@ CANONICAL_OWNER_REGISTRY_V1: tuple[CanonicalOwnerRefV1, ...] = (
         authority_class="economic_evidence",
         reuse_status="REUSED",
         notes=(
-            "Phase 4.6B: Landscape projects injected EconomicViabilityEvidenceV1 "
-            "field-for-field (economic_viability_status=status enum value; "
+            "Phase 4.6B + CAPABILITY_PRESENTATION_ECONOMIC_SUMMARY_"
+            "PROJECTION_MATERIALIZER_AUTOBIND_V1: Landscape projects "
+            "EconomicViabilityEvidenceV1 field-for-field "
+            "(economic_viability_status=status enum value; "
             "economic_validity_proven/policy_threshold_status/metrics/digests); "
-            "AUTHORITY_EFFECT=NONE; explicit injection only; without injection "
-            "MISSING_SOURCE; no filesystem/registry/latest selector; "
+            "AUTHORITY_EFFECT=NONE; durable auto-bind via non-authoritative "
+            "economic_summary_presentation_projection.v1 under archive root; "
+            "explicit injection only remains priority over archive autobind; "
+            "without injection/projection MISSING_SOURCE; "
+            "no filesystem/registry/latest selector; "
             "promotion_economic_gate_v1 remains a separate owner; lifecycle "
             "labels ABSENT (not inferred)."
         ),

--- a/src/webui/workflow_dashboard_archive_root_v1.py
+++ b/src/webui/workflow_dashboard_archive_root_v1.py
@@ -13,10 +13,13 @@ dynamic_scope_state_v1.json under the same archive root), and
 risk_sizing_capital_presentation_projection.v1 (plus its durable source sibling
 risk_sizing_capital.v1.json under the same archive root),
 execution_reconciliation_presentation_projection.v1 (plus its durable source sibling
-execution_reconciliation.v1.json under the same archive root), and
+execution_reconciliation.v1.json under the same archive root),
 safety_authority_presentation_projection.v1 persisted at
 safety_authority.v1.json under the same archive root (presentation-only;
-never a productive KillSwitch state file).
+never a productive KillSwitch state file), and
+economic_summary_presentation_projection.v1 (plus its durable source sibling
+economic_summary.v1.json under the same archive root; presentation-only;
+never discovers latest EconomicViabilityEvidence packs).
 """
 
 from __future__ import annotations
@@ -73,6 +76,10 @@ EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_RELATIVE = (
     "readmodels/execution_reconciliation_presentation_projection.v1.json"
 )
 SAFETY_AUTHORITY_PRESENTATION_PROJECTION_RELATIVE = "readmodels/safety_authority.v1.json"
+ECONOMIC_SUMMARY_FIELDS_RELATIVE = "readmodels/economic_summary.v1.json"
+ECONOMIC_SUMMARY_PRESENTATION_PROJECTION_RELATIVE = (
+    "readmodels/economic_summary_presentation_projection.v1.json"
+)
 _DISCOVER_NAME_PREFIX = "workflow_dashboard_v1"
 
 
@@ -435,6 +442,8 @@ __all__ = [
     "DOUBLE_PLAY_PRESENTATION_PROJECTION_RELATIVE",
     "DYNAMIC_SCOPE_PRESENTATION_PROJECTION_RELATIVE",
     "DYNAMIC_SCOPE_STATE_RELATIVE",
+    "ECONOMIC_SUMMARY_FIELDS_RELATIVE",
+    "ECONOMIC_SUMMARY_PRESENTATION_PROJECTION_RELATIVE",
     "ENV_ARCHIVE_ROOT",
     "EXECUTION_RECONCILIATION_FIELDS_RELATIVE",
     "EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_RELATIVE",

--- a/src/webui/workflow_dashboard_readmodel_v1/economic_summary_presentation_projection_materializer_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/economic_summary_presentation_projection_materializer_v1.py
@@ -1,0 +1,453 @@
+"""Non-authoritative materializer for Economic Summary presentation projection.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_ECONOMIC_SUMMARY_PROJECTION_MATERIALIZER_AUTOBIND_V1
+
+Consumes already-produced EconomicViabilityEvidenceV1-compatible binder field
+payloads (or the durable sibling dump under the Workflow Dashboard archive root)
+and writes the non-authoritative presentation projection schema to the
+loader-owned path. This module:
+
+- AUTHORITY_EFFECT=NONE
+- ECONOMIC_AUTHORITY_EFFECT=NONE
+- never recomputes metrics, thresholds, or viability status
+- never imports src.backtest.economic_viability_evidence_v1 evaluators
+- never binds promotion_economic_gate_v1
+- never invents status, metrics, digests, or timestamps
+- fail-closed: missing source → MISSING_SOURCE and no artifact write;
+  invalid source → FAIL_CLOSED and no artifact write
+- projection remains non-authoritative and must never flow back into runtime
+  or authority chains
+
+Deterministic serialization and atomic replace only. This projection path does
+not own a separate MANIFEST contract; integrity follows the existing loader
+schema/authority/fields checks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from .economic_summary_presentation_projection_v1 import (
+    AUTHORITY_EFFECT,
+    ECONOMIC_AUTHORITY_EFFECT,
+    LOAD_ERROR_FIELDS_INVALID,
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    LOAD_ERROR_TIMESTAMP_MISSING,
+    PROJECTION_ROLE,
+    SCHEMA_NAME,
+    SCHEMA_VERSION,
+    SOURCE_FIELDS_RELATIVE_PATH,
+    STORAGE_RELATIVE_PATH,
+    map_economic_summary_fields_to_binder_fields_v1,
+)
+
+CAPABILITY_ID = "CAPABILITY_PRESENTATION_ECONOMIC_SUMMARY_PROJECTION_MATERIALIZER_AUTOBIND_V1"
+OWNER_MODULE = (
+    "webui.workflow_dashboard_readmodel_v1.economic_summary_presentation_projection_materializer_v1"
+)
+
+STATUS_WRITTEN = "WRITTEN"
+STATUS_MISSING_SOURCE = "MISSING_SOURCE"
+STATUS_FAIL_CLOSED = "FAIL_CLOSED"
+
+MATERIALIZE_ERROR_MISSING_SOURCE = "MISSING_SOURCE"
+MATERIALIZE_ERROR_INVALID_JSON = "ECONOMIC_SUMMARY_PRESENTATION_MATERIALIZER_INVALID_JSON"
+MATERIALIZE_ERROR_INVALID_SOURCE = "ECONOMIC_SUMMARY_PRESENTATION_MATERIALIZER_INVALID_SOURCE"
+MATERIALIZE_ERROR_WRITE_FAILED = "ECONOMIC_SUMMARY_PRESENTATION_MATERIALIZER_WRITE_FAILED"
+
+_REQUIRED_FIELD_ATTRS = (
+    "status",
+    "economic_validity_proven",
+    "profitability_claim_allowed",
+    "policy_threshold_status",
+    "policy_version",
+    "authority_effect",
+    "runtime_effect",
+    "order_effect",
+    "profit_factor",
+    "net_return",
+    "max_drawdown",
+    "sharpe",
+    "trade_count",
+    "funding_drag",
+    "contract_version",
+    "owner",
+    "strategy_id",
+    "strategy_version",
+    "config_digest",
+    "implementation_digest",
+    "data_digest",
+    "manifest_digest",
+    "wiring_chain_digest",
+    "policy_digest",
+)
+
+
+@dataclass(frozen=True)
+class EconomicSummaryPresentationMaterializeResultV1:
+    """Result of a fail-closed presentation projection materialize attempt."""
+
+    written: bool
+    status: str
+    errors: tuple[str, ...]
+    projection_path: str | None = None
+    source_path: str | None = None
+    economic_status: str | None = None
+    payload_digest: str | None = None
+
+
+def _empty_result(
+    *,
+    status: str,
+    errors: tuple[str, ...],
+    source_path: str | None = None,
+) -> EconomicSummaryPresentationMaterializeResultV1:
+    return EconomicSummaryPresentationMaterializeResultV1(
+        written=False,
+        status=status,
+        errors=errors,
+        source_path=source_path,
+    )
+
+
+def _require_nonempty_str(value: object) -> str | None:
+    if isinstance(value, Enum):
+        value = value.value
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _enum_or_str(value: object) -> object:
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def coerce_economic_summary_fields_mapping_v1(
+    source: object | None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Copy already-selected Economic binder fields without mutation.
+
+    Accepts:
+    - binder-compatible fields (status/metrics/digests/...)
+    - nested projection envelope {"economic_summary": {...}}
+    - objects exposing the binder field attributes
+
+    Never invents metrics, statuses, timestamps, or productive defaults.
+    """
+    if source is None:
+        return None, (MATERIALIZE_ERROR_MISSING_SOURCE,)
+
+    raw: Mapping[str, Any]
+    if isinstance(source, Mapping):
+        raw = source
+    else:
+        extracted: dict[str, Any] = {}
+        for key in (
+            *_REQUIRED_FIELD_ATTRS,
+            "reason_codes",
+            "evidence_digest",
+            "evidence_ref",
+            "schema_version",
+            "generated_at",
+            "effective_at",
+            "source_reference",
+            "producer_module",
+            "source_kind",
+            "economic_summary",
+        ):
+            if hasattr(source, key):
+                extracted[key] = getattr(source, key)
+        raw = extracted
+
+    if "economic_summary" in raw and isinstance(raw.get("economic_summary"), Mapping):
+        nested = raw["economic_summary"]
+        top_status = raw.get("status")
+        nested_status = nested.get("status")
+        if (
+            isinstance(top_status, str)
+            and top_status.strip()
+            and isinstance(nested_status, str)
+            and nested_status.strip()
+            and top_status.strip() != nested_status.strip()
+        ):
+            return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID)
+        if not all(key in raw for key in ("status", "manifest_digest", "profit_factor")):
+            raw = nested
+
+    fields = deepcopy(dict(raw))
+
+    if "status" in fields:
+        fields["status"] = _enum_or_str(fields["status"])
+
+    missing = [key for key in _REQUIRED_FIELD_ATTRS if key not in fields]
+    if missing:
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID)
+
+    if _require_nonempty_str(fields.get("status")) is None:
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE, LOAD_ERROR_FIELDS_INVALID)
+    fields["status"] = str(_enum_or_str(fields["status"])).strip()
+
+    return fields, ()
+
+
+def build_economic_summary_presentation_projection_payload_v1(
+    *,
+    economic_summary: object,
+    generated_at: str,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Build the loader-compatible projection envelope from Economic fields."""
+    fields_mapping, coerce_errors = coerce_economic_summary_fields_mapping_v1(economic_summary)
+    if fields_mapping is None:
+        return None, coerce_errors
+
+    if _require_nonempty_str(generated_at) is None:
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+
+    binder_fields, map_errors = map_economic_summary_fields_to_binder_fields_v1(
+        economic_summary=fields_mapping,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return None, map_errors
+
+    economic_out: dict[str, Any] = {
+        "authority_effect": binder_fields["authority_effect"],
+        "config_digest": binder_fields["config_digest"],
+        "contract_version": binder_fields["contract_version"],
+        "data_digest": binder_fields["data_digest"],
+        "economic_validity_proven": binder_fields["economic_validity_proven"],
+        "funding_drag": dict(binder_fields["funding_drag"]),
+        "implementation_digest": binder_fields["implementation_digest"],
+        "manifest_digest": binder_fields["manifest_digest"],
+        "max_drawdown": dict(binder_fields["max_drawdown"]),
+        "net_return": dict(binder_fields["net_return"]),
+        "order_effect": binder_fields["order_effect"],
+        "owner": binder_fields["owner"],
+        "policy_digest": binder_fields["policy_digest"],
+        "policy_threshold_status": binder_fields["policy_threshold_status"],
+        "policy_version": binder_fields["policy_version"],
+        "profit_factor": dict(binder_fields["profit_factor"]),
+        "profitability_claim_allowed": binder_fields["profitability_claim_allowed"],
+        "reason_codes": list(binder_fields.get("reason_codes", ())),
+        "runtime_effect": binder_fields["runtime_effect"],
+        "sharpe": dict(binder_fields["sharpe"]),
+        "status": binder_fields["status"],
+        "strategy_id": binder_fields["strategy_id"],
+        "strategy_version": binder_fields["strategy_version"],
+        "trade_count": dict(binder_fields["trade_count"]),
+        "wiring_chain_digest": binder_fields["wiring_chain_digest"],
+    }
+    if "evidence_digest" in binder_fields:
+        economic_out["evidence_digest"] = binder_fields["evidence_digest"]
+    if "evidence_ref" in binder_fields:
+        economic_out["evidence_ref"] = binder_fields["evidence_ref"]
+    if "schema_version" in binder_fields:
+        economic_out["schema_version"] = binder_fields["schema_version"]
+    if "producer_module" in binder_fields:
+        economic_out["producer_module"] = binder_fields["producer_module"]
+    if "source_kind" in binder_fields:
+        economic_out["source_kind"] = binder_fields["source_kind"]
+
+    payload: dict[str, Any] = {
+        "authority_effect": AUTHORITY_EFFECT,
+        "economic_authority_effect": ECONOMIC_AUTHORITY_EFFECT,
+        "economic_summary": economic_out,
+        "generated_at": binder_fields["generated_at"],
+        "projection_role": PROJECTION_ROLE,
+        "schema_name": SCHEMA_NAME,
+        "schema_version": SCHEMA_VERSION,
+    }
+    if "effective_at" in binder_fields:
+        payload["effective_at"] = binder_fields["effective_at"]
+    if "source_reference" in binder_fields:
+        payload["source_reference"] = binder_fields["source_reference"]
+    return payload, ()
+
+
+def serialize_economic_summary_presentation_projection_v1(
+    payload: Mapping[str, Any],
+) -> str:
+    """Deterministic JSON serialization for the presentation projection artifact."""
+    return json.dumps(dict(payload), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def _atomic_write_text(*, destination: Path, body: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, destination)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def write_economic_summary_presentation_projection_v1(
+    archive_root: str | Path,
+    payload: Mapping[str, Any],
+) -> EconomicSummaryPresentationMaterializeResultV1:
+    """Atomically persist an already-validated projection payload."""
+    if payload.get("schema_name") != SCHEMA_NAME:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_SCHEMA_MISMATCH,),
+        )
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_SCHEMA_MISMATCH,),
+        )
+    if (
+        payload.get("authority_effect") != AUTHORITY_EFFECT
+        or payload.get("economic_authority_effect") != ECONOMIC_AUTHORITY_EFFECT
+    ):
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(MATERIALIZE_ERROR_INVALID_SOURCE,),
+        )
+
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    body = serialize_economic_summary_presentation_projection_v1(payload)
+    try:
+        _atomic_write_text(destination=path, body=body)
+    except OSError:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(MATERIALIZE_ERROR_WRITE_FAILED,),
+        )
+
+    economic = payload.get("economic_summary")
+    economic_status = None
+    if isinstance(economic, Mapping):
+        raw_status = economic.get("status")
+        if isinstance(raw_status, str) and raw_status.strip():
+            economic_status = raw_status.strip()
+
+    return EconomicSummaryPresentationMaterializeResultV1(
+        written=True,
+        status=STATUS_WRITTEN,
+        errors=(),
+        projection_path=str(path),
+        economic_status=economic_status,
+        payload_digest=hashlib.sha256(body.encode("utf-8")).hexdigest(),
+    )
+
+
+def try_load_economic_summary_fields_source_v1(
+    archive_root: str | Path,
+) -> tuple[dict[str, Any] | None, tuple[str, ...], str | None]:
+    """Load the sole durable Economic fields sibling without inventing content."""
+    root = Path(archive_root).expanduser().resolve()
+    path = root / SOURCE_FIELDS_RELATIVE_PATH
+    source_path = str(path)
+    if not path.is_file():
+        return None, (MATERIALIZE_ERROR_MISSING_SOURCE,), source_path
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None, (MATERIALIZE_ERROR_INVALID_JSON,), source_path
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None, (MATERIALIZE_ERROR_INVALID_JSON,), source_path
+    if not isinstance(payload, dict):
+        return None, (MATERIALIZE_ERROR_INVALID_SOURCE,), source_path
+    fields, errors = coerce_economic_summary_fields_mapping_v1(payload)
+    if fields is None:
+        return None, errors, source_path
+    return fields, (), source_path
+
+
+def materialize_economic_summary_presentation_projection_v1(
+    archive_root: str | Path,
+    *,
+    economic_summary: object | None = None,
+    generated_at: str | None = None,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> EconomicSummaryPresentationMaterializeResultV1:
+    """Materialize the presentation projection from Economic fields or durable source.
+
+    Missing source yields MISSING_SOURCE and does not write an artifact.
+    Invalid source or missing required timestamps fail closed without writing.
+    Caller-owned Economic inputs are never mutated.
+    """
+    source_path: str | None = None
+    source_obj: object | None = economic_summary
+    if source_obj is None:
+        loaded, load_errors, source_path = try_load_economic_summary_fields_source_v1(archive_root)
+        if loaded is None:
+            status = (
+                STATUS_MISSING_SOURCE
+                if MATERIALIZE_ERROR_MISSING_SOURCE in load_errors
+                else STATUS_FAIL_CLOSED
+            )
+            return _empty_result(status=status, errors=load_errors, source_path=source_path)
+        source_obj = loaded
+
+    if _require_nonempty_str(generated_at) is None:
+        return _empty_result(
+            status=STATUS_FAIL_CLOSED,
+            errors=(LOAD_ERROR_TIMESTAMP_MISSING,),
+            source_path=source_path,
+        )
+
+    caller_snapshot = deepcopy(economic_summary) if isinstance(economic_summary, Mapping) else None
+
+    payload, build_errors = build_economic_summary_presentation_projection_payload_v1(
+        economic_summary=source_obj,
+        generated_at=generated_at,
+        effective_at=effective_at,
+        source_reference=source_reference,
+    )
+    if isinstance(economic_summary, Mapping) and caller_snapshot is not None:
+        if dict(economic_summary) != dict(caller_snapshot):
+            return _empty_result(
+                status=STATUS_FAIL_CLOSED,
+                errors=(MATERIALIZE_ERROR_INVALID_SOURCE,),
+                source_path=source_path,
+            )
+    if payload is None:
+        status = (
+            STATUS_MISSING_SOURCE
+            if MATERIALIZE_ERROR_MISSING_SOURCE in build_errors
+            else STATUS_FAIL_CLOSED
+        )
+        return _empty_result(status=status, errors=build_errors, source_path=source_path)
+
+    result = write_economic_summary_presentation_projection_v1(archive_root, payload)
+    if not result.written:
+        return result
+    return EconomicSummaryPresentationMaterializeResultV1(
+        written=True,
+        status=STATUS_WRITTEN,
+        errors=(),
+        projection_path=result.projection_path,
+        source_path=source_path,
+        economic_status=result.economic_status,
+        payload_digest=result.payload_digest,
+    )

--- a/src/webui/workflow_dashboard_readmodel_v1/economic_summary_presentation_projection_v1.py
+++ b/src/webui/workflow_dashboard_readmodel_v1/economic_summary_presentation_projection_v1.py
@@ -1,0 +1,398 @@
+"""Non-authoritative presentation projection for Economic Summary.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_ECONOMIC_SUMMARY_PROJECTION_MATERIALIZER_AUTOBIND_V1
+
+Reads already-produced EconomicViabilityEvidenceV1-compatible binder fields from a
+single durable archive path and maps them field-for-field into Landscape binder
+injection fields. This module:
+
+- AUTHORITY_EFFECT=NONE
+- ECONOMIC_AUTHORITY_EFFECT=NONE
+- never recomputes metrics, thresholds, or viability status
+- never imports src.backtest.economic_viability_evidence_v1 evaluators
+- never binds promotion_economic_gate_v1
+- never invents status, metrics, digests, or timestamps
+- fail-closed: missing, invalid, or ambiguous sources → no fields (MISSING_SOURCE)
+
+Deterministic source selection: exactly one well-known relative path under the
+Workflow Dashboard archive root. No silent multi-candidate "latest" picking.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA_NAME = "economic_summary_presentation_projection.v1"
+SCHEMA_VERSION = 1
+STORAGE_RELATIVE_PATH = "readmodels/economic_summary_presentation_projection.v1.json"
+SOURCE_FIELDS_RELATIVE_PATH = "readmodels/economic_summary.v1.json"
+AUTHORITY_EFFECT = "NONE"
+ECONOMIC_AUTHORITY_EFFECT = "NONE"
+PROJECTION_ROLE = "NON_AUTHORITATIVE_PRESENTATION_PROJECTION"
+OWNER_MODULE = "webui.workflow_dashboard_readmodel_v1.economic_summary_presentation_projection_v1"
+
+LOAD_ERROR_ABSENT = "ECONOMIC_SUMMARY_PRESENTATION_PROJECTION_ABSENT"
+LOAD_ERROR_INVALID_JSON = "ECONOMIC_SUMMARY_PRESENTATION_PROJECTION_INVALID_JSON"
+LOAD_ERROR_SCHEMA_MISMATCH = "ECONOMIC_SUMMARY_PRESENTATION_PROJECTION_SCHEMA_MISMATCH"
+LOAD_ERROR_AUTHORITY_CLAIM = "ECONOMIC_SUMMARY_PRESENTATION_PROJECTION_AUTHORITY_CLAIM"
+LOAD_ERROR_FIELDS_INVALID = "ECONOMIC_SUMMARY_PRESENTATION_PROJECTION_FIELDS_INVALID"
+LOAD_ERROR_AMBIGUOUS = "ECONOMIC_SUMMARY_PRESENTATION_PROJECTION_AMBIGUOUS_SOURCE"
+LOAD_ERROR_TIMESTAMP_MISSING = "ECONOMIC_SUMMARY_PRESENTATION_PROJECTION_TIMESTAMP_MISSING"
+
+_REQUIRED_FIELD_KEYS = (
+    "status",
+    "economic_validity_proven",
+    "profitability_claim_allowed",
+    "policy_threshold_status",
+    "policy_version",
+    "authority_effect",
+    "runtime_effect",
+    "order_effect",
+    "profit_factor",
+    "net_return",
+    "max_drawdown",
+    "sharpe",
+    "trade_count",
+    "funding_drag",
+    "contract_version",
+    "owner",
+    "strategy_id",
+    "strategy_version",
+    "config_digest",
+    "implementation_digest",
+    "data_digest",
+    "manifest_digest",
+    "wiring_chain_digest",
+    "policy_digest",
+)
+
+_REQUIRED_BOOL_KEYS = (
+    "economic_validity_proven",
+    "profitability_claim_allowed",
+    "runtime_effect",
+    "order_effect",
+)
+
+_REQUIRED_STR_KEYS = (
+    "status",
+    "policy_threshold_status",
+    "policy_version",
+    "authority_effect",
+    "contract_version",
+    "owner",
+    "strategy_id",
+    "strategy_version",
+    "config_digest",
+    "implementation_digest",
+    "data_digest",
+    "manifest_digest",
+    "wiring_chain_digest",
+    "policy_digest",
+)
+
+_METRIC_KEYS = (
+    "profit_factor",
+    "net_return",
+    "max_drawdown",
+    "sharpe",
+    "trade_count",
+    "funding_drag",
+)
+
+
+@dataclass(frozen=True)
+class EconomicSummaryPresentationLoadV1:
+    """Result of a fail-closed presentation projection load attempt."""
+
+    loaded: bool
+    load_errors: tuple[str, ...]
+    binder_fields: Mapping[str, Any] | None = None
+    source_path: str | None = None
+    evidence_digest: str | None = None
+    status: str | None = None
+
+
+def _empty(*, load_errors: tuple[str, ...]) -> EconomicSummaryPresentationLoadV1:
+    return EconomicSummaryPresentationLoadV1(loaded=False, load_errors=load_errors)
+
+
+def _require_nonempty_str(payload: Mapping[str, Any], key: str) -> str | None:
+    raw = payload.get(key)
+    if isinstance(raw, Enum):
+        raw = raw.value
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return raw.strip()
+
+
+def _normalize_reason_codes(raw_codes: object) -> tuple[str, ...] | None:
+    if raw_codes is None:
+        raw_codes = ()
+    if not isinstance(raw_codes, (list, tuple)):
+        return None
+    return tuple(str(code) for code in raw_codes)
+
+
+def _normalize_metric(raw: object) -> dict[str, Any] | None:
+    """Accept MetricFieldV1-shaped mappings only; never invent metrics."""
+    if raw is None:
+        return None
+    if hasattr(raw, "to_dict") and callable(raw.to_dict):
+        raw = raw.to_dict()
+    if not isinstance(raw, Mapping):
+        return None
+    semantic = raw.get("semantic")
+    if isinstance(semantic, Enum):
+        semantic = semantic.value
+    if not isinstance(semantic, str) or not semantic.strip():
+        return None
+    out: dict[str, Any] = {"semantic": semantic.strip()}
+    if "value" in raw and raw.get("value") is not None:
+        try:
+            value = float(raw["value"])
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(value):
+            return None
+        out["value"] = value
+    if "reason_code" in raw and raw.get("reason_code") is not None:
+        reason = raw.get("reason_code")
+        if not isinstance(reason, str) or not reason.strip():
+            return None
+        out["reason_code"] = reason.strip()
+    return out
+
+
+def _fields_payload_from_envelope(
+    payload: Mapping[str, Any],
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    """Extract nested economic_summary fields; fail closed on ambiguity."""
+    if "economic_summary" not in payload:
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+    fields = payload.get("economic_summary")
+    if not isinstance(fields, Mapping):
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+    top_level_status = payload.get("status")
+    nested_status = fields.get("status")
+    if (
+        isinstance(top_level_status, str)
+        and top_level_status.strip()
+        and isinstance(nested_status, str)
+        and nested_status.strip()
+        and top_level_status.strip() != nested_status.strip()
+    ):
+        return None, (LOAD_ERROR_AMBIGUOUS,)
+    return fields, ()
+
+
+def _validate_economic_fields(
+    fields: Mapping[str, Any],
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    missing = [key for key in _REQUIRED_FIELD_KEYS if key not in fields]
+    if missing:
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+
+    out: dict[str, Any] = {}
+    for key in _REQUIRED_STR_KEYS:
+        value = _require_nonempty_str(fields, key)
+        if value is None:
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out[key] = value
+
+    for key in _REQUIRED_BOOL_KEYS:
+        raw = fields.get(key)
+        if not isinstance(raw, bool):
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out[key] = raw
+
+    for key in _METRIC_KEYS:
+        metric = _normalize_metric(fields.get(key))
+        if metric is None:
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out[key] = metric
+
+    reason_codes = _normalize_reason_codes(fields.get("reason_codes", ()))
+    if reason_codes is None:
+        return None, (LOAD_ERROR_FIELDS_INVALID,)
+    out["reason_codes"] = reason_codes
+
+    digest = fields.get("evidence_digest")
+    if digest is None:
+        digest = fields.get("manifest_digest")
+    if digest is not None:
+        if not isinstance(digest, str) or not digest.strip():
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["evidence_digest"] = digest.strip()
+
+    evidence_ref = fields.get("evidence_ref")
+    if evidence_ref is not None:
+        if not isinstance(evidence_ref, str):
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["evidence_ref"] = evidence_ref
+
+    source_reference = fields.get("source_reference")
+    if source_reference is not None:
+        if not isinstance(source_reference, str):
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["source_reference"] = source_reference
+
+    producer_module = fields.get("producer_module")
+    if producer_module is not None:
+        if not isinstance(producer_module, str) or not producer_module.strip():
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["producer_module"] = producer_module.strip()
+
+    source_kind = fields.get("source_kind")
+    if source_kind is not None:
+        if not isinstance(source_kind, str) or not source_kind.strip():
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["source_kind"] = source_kind.strip()
+
+    schema_version = fields.get("schema_version")
+    if schema_version is not None:
+        if not isinstance(schema_version, str) or not schema_version.strip():
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        out["schema_version"] = schema_version.strip()
+
+    return out, ()
+
+
+def map_economic_summary_fields_to_binder_fields_v1(
+    *,
+    economic_summary: Mapping[str, Any],
+    generated_at: str,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Map Economic fields → Landscape binder fields (projection only)."""
+    mapped, errors = _validate_economic_fields(economic_summary)
+    if mapped is None:
+        return None, errors
+    if not isinstance(generated_at, str) or not generated_at.strip():
+        return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+    mapped["generated_at"] = generated_at.strip()
+    if effective_at is not None:
+        if not isinstance(effective_at, str) or not effective_at.strip():
+            return None, (LOAD_ERROR_TIMESTAMP_MISSING,)
+        mapped["effective_at"] = effective_at.strip()
+    if source_reference is not None:
+        if not isinstance(source_reference, str):
+            return None, (LOAD_ERROR_FIELDS_INVALID,)
+        mapped["source_reference"] = source_reference
+    return mapped, ()
+
+
+def try_load_economic_summary_presentation_projection_v1(
+    archive_root: str | Path,
+) -> EconomicSummaryPresentationLoadV1:
+    """Verify-before-trust read of the sole durable Economic presentation projection.
+
+    Returns loaded=False with load_errors on any fail-closed condition. Never
+    invents EconomicViabilityEvidence facts or discovers latest evidence packs.
+    """
+    root = Path(archive_root).expanduser().resolve()
+    path = root / STORAGE_RELATIVE_PATH
+    if not path.is_file():
+        return _empty(load_errors=(LOAD_ERROR_ABSENT,))
+
+    sibling = root / SOURCE_FIELDS_RELATIVE_PATH
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    if not isinstance(payload, dict):
+        return _empty(load_errors=(LOAD_ERROR_INVALID_JSON,))
+
+    schema_name = payload.get("schema_name")
+    if schema_name != SCHEMA_NAME:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    schema_version = payload.get("schema_version")
+    if schema_version is not None and int(schema_version) != SCHEMA_VERSION:
+        return _empty(load_errors=(LOAD_ERROR_SCHEMA_MISMATCH,))
+
+    authority = payload.get("authority_effect")
+    economic_authority = payload.get("economic_authority_effect")
+    if authority != AUTHORITY_EFFECT or economic_authority != ECONOMIC_AUTHORITY_EFFECT:
+        return _empty(load_errors=(LOAD_ERROR_AUTHORITY_CLAIM,))
+
+    generated_at = _require_nonempty_str(payload, "generated_at")
+    if generated_at is None:
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+
+    effective_at = payload.get("effective_at")
+    if effective_at is not None and (not isinstance(effective_at, str) or not effective_at.strip()):
+        return _empty(load_errors=(LOAD_ERROR_TIMESTAMP_MISSING,))
+    effective_at_s = None if effective_at is None else str(effective_at).strip()
+
+    fields, field_errors = _fields_payload_from_envelope(payload)
+    if fields is None:
+        return _empty(load_errors=field_errors)
+
+    source_reference = payload.get("source_reference")
+    if source_reference is None:
+        source_reference = f"presentation://{STORAGE_RELATIVE_PATH}"
+    elif not isinstance(source_reference, str):
+        return _empty(load_errors=(LOAD_ERROR_FIELDS_INVALID,))
+
+    binder_fields, map_errors = map_economic_summary_fields_to_binder_fields_v1(
+        economic_summary=fields,
+        generated_at=generated_at,
+        effective_at=effective_at_s,
+        source_reference=source_reference,
+    )
+    if binder_fields is None:
+        return _empty(load_errors=map_errors)
+
+    if sibling.is_file():
+        try:
+            sibling_payload = json.loads(sibling.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        if not isinstance(sibling_payload, dict):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        sibling_fields: Mapping[str, Any] = sibling_payload
+        if "economic_summary" in sibling_payload and isinstance(
+            sibling_payload.get("economic_summary"), Mapping
+        ):
+            sibling_fields = sibling_payload["economic_summary"]
+        sibling_status = str(sibling_fields.get("status") or "").strip()
+        projection_status = str(binder_fields["status"])
+        if not sibling_status or sibling_status != projection_status:
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+        sibling_digest = sibling_fields.get("evidence_digest")
+        if sibling_digest is None:
+            sibling_digest = sibling_fields.get("manifest_digest")
+        projection_digest = binder_fields.get("evidence_digest")
+        if (
+            isinstance(sibling_digest, str)
+            and sibling_digest.strip()
+            and isinstance(projection_digest, str)
+            and projection_digest.strip()
+            and sibling_digest.strip() != projection_digest.strip()
+        ):
+            return _empty(load_errors=(LOAD_ERROR_AMBIGUOUS,))
+
+    return EconomicSummaryPresentationLoadV1(
+        loaded=True,
+        load_errors=(),
+        binder_fields=binder_fields,
+        source_path=str(path),
+        evidence_digest=(
+            None
+            if binder_fields.get("evidence_digest") is None
+            else str(binder_fields.get("evidence_digest"))
+        ),
+        status=str(binder_fields["status"]),
+    )

--- a/tests/webui/test_economic_summary_presentation_projection_materializer_v1.py
+++ b/tests/webui/test_economic_summary_presentation_projection_materializer_v1.py
@@ -1,0 +1,290 @@
+"""Focused tests: CAPABILITY_PRESENTATION_ECONOMIC_SUMMARY_PROJECTION_MATERIALIZER_AUTOBIND_V1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    ECONOMIC_PRODUCER_MODULE,
+    ECONOMIC_SOURCE_KIND,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT
+from src.webui.workflow_dashboard_readmodel_v1.economic_summary_presentation_projection_materializer_v1 import (
+    CAPABILITY_ID,
+    MATERIALIZE_ERROR_MISSING_SOURCE,
+    SOURCE_FIELDS_RELATIVE_PATH,
+    STATUS_FAIL_CLOSED,
+    STATUS_MISSING_SOURCE,
+    STATUS_WRITTEN,
+    build_economic_summary_presentation_projection_payload_v1,
+    materialize_economic_summary_presentation_projection_v1,
+    serialize_economic_summary_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.economic_summary_presentation_projection_v1 import (
+    LOAD_ERROR_FIELDS_INVALID,
+    LOAD_ERROR_TIMESTAMP_MISSING,
+    STORAGE_RELATIVE_PATH,
+    try_load_economic_summary_presentation_projection_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+STAMP = datetime(2026, 7, 24, 18, 0, 0, tzinfo=timezone.utc)
+PRODUCER_FRESH = "2026-07-24T17:30:00Z"
+
+
+def _metric(*, value: float | None = None, semantic: str = "COMPUTED") -> dict[str, object]:
+    payload: dict[str, object] = {"semantic": semantic}
+    if value is not None:
+        payload["value"] = value
+    return payload
+
+
+def _fields(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "status": "ECONOMICALLY_VIABLE_OFFLINE",
+        "economic_validity_proven": True,
+        "profitability_claim_allowed": False,
+        "policy_threshold_status": "PASS",
+        "policy_version": "economic_validity_policy_v1",
+        "authority_effect": "NONE",
+        "runtime_effect": False,
+        "order_effect": False,
+        "reason_codes": ("SENTINEL_REASON_A", "SENTINEL_REASON_B"),
+        "profit_factor": _metric(value=1.77),
+        "net_return": _metric(value=0.123),
+        "max_drawdown": _metric(value=-0.045),
+        "sharpe": _metric(value=0.88),
+        "trade_count": _metric(value=42.0),
+        "funding_drag": _metric(value=-0.003),
+        "contract_version": "v1",
+        "owner": "backtest.economic_viability_evidence_v1",
+        "strategy_id": "sentinel_strategy",
+        "strategy_version": "sentinel_v9",
+        "config_digest": "c" * 64,
+        "implementation_digest": "i" * 64,
+        "data_digest": "d" * 64,
+        "manifest_digest": "m" * 64,
+        "wiring_chain_digest": "w" * 64,
+        "policy_digest": "p" * 64,
+        "evidence_digest": "m" * 64,
+        "schema_version": "v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_source_fields(archive_root: Path, payload: dict[str, object]) -> Path:
+    path = archive_root / SOURCE_FIELDS_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_capability_id_is_stable() -> None:
+    assert CAPABILITY_ID == (
+        "CAPABILITY_PRESENTATION_ECONOMIC_SUMMARY_PROJECTION_MATERIALIZER_AUTOBIND_V1"
+    )
+
+
+def test_build_payload_is_deterministic() -> None:
+    fields = _fields()
+    first, err_a = build_economic_summary_presentation_projection_payload_v1(
+        economic_summary=fields,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://unit-test",
+    )
+    second, err_b = build_economic_summary_presentation_projection_payload_v1(
+        economic_summary=fields,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://unit-test",
+    )
+    assert err_a == ()
+    assert err_b == ()
+    assert first is not None and second is not None
+    assert first == second
+    assert serialize_economic_summary_presentation_projection_v1(
+        first
+    ) == serialize_economic_summary_presentation_projection_v1(second)
+    assert first["schema_name"] == "economic_summary_presentation_projection.v1"
+    assert first["schema_version"] == 1
+    assert first["economic_summary"]["status"] == "ECONOMICALLY_VIABLE_OFFLINE"
+    assert first["economic_summary"]["profit_factor"]["value"] == 1.77
+
+
+def test_materialize_writes_loader_expected_path(tmp_path: Path) -> None:
+    result = materialize_economic_summary_presentation_projection_v1(
+        tmp_path,
+        economic_summary=_fields(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert result.status == STATUS_WRITTEN
+    assert result.errors == ()
+    assert result.projection_path is not None
+    assert result.projection_path.endswith(STORAGE_RELATIVE_PATH)
+    assert (tmp_path / STORAGE_RELATIVE_PATH).is_file()
+
+
+def test_materialize_loader_compatible(tmp_path: Path) -> None:
+    materialize_economic_summary_presentation_projection_v1(
+        tmp_path,
+        economic_summary=_fields(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://materializer-compat",
+    )
+    loaded = try_load_economic_summary_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.load_errors == ()
+    assert loaded.status == "ECONOMICALLY_VIABLE_OFFLINE"
+    assert loaded.evidence_digest == "m" * 64
+    assert loaded.binder_fields is not None
+    assert loaded.binder_fields["policy_threshold_status"] == "PASS"
+    assert loaded.binder_fields["profit_factor"]["value"] == 1.77
+
+
+def test_missing_source_does_not_invent_artifact(tmp_path: Path) -> None:
+    result = materialize_economic_summary_presentation_projection_v1(
+        tmp_path,
+        economic_summary=None,
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_MISSING_SOURCE
+    assert MATERIALIZE_ERROR_MISSING_SOURCE in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+    loaded = try_load_economic_summary_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+
+
+def test_invalid_source_fail_closed(tmp_path: Path) -> None:
+    result = materialize_economic_summary_presentation_projection_v1(
+        tmp_path,
+        economic_summary={"status": "ECONOMICALLY_VIABLE_OFFLINE"},
+        generated_at=PRODUCER_FRESH,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_FIELDS_INVALID in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_missing_generated_at_fail_closed(tmp_path: Path) -> None:
+    result = materialize_economic_summary_presentation_projection_v1(
+        tmp_path,
+        economic_summary=_fields(),
+        generated_at=None,
+    )
+    assert result.written is False
+    assert result.status == STATUS_FAIL_CLOSED
+    assert LOAD_ERROR_TIMESTAMP_MISSING in result.errors
+    assert not (tmp_path / STORAGE_RELATIVE_PATH).exists()
+
+
+def test_does_not_mutate_canonical_inputs(tmp_path: Path) -> None:
+    fields = _fields()
+    snapshot = deepcopy(fields)
+    result = materialize_economic_summary_presentation_projection_v1(
+        tmp_path,
+        economic_summary=fields,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert fields == snapshot
+
+
+def test_materialize_from_durable_fields_source(tmp_path: Path) -> None:
+    _write_source_fields(tmp_path, _fields())
+    result = materialize_economic_summary_presentation_projection_v1(
+        tmp_path,
+        economic_summary=None,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+    )
+    assert result.written is True
+    assert result.status == STATUS_WRITTEN
+    assert result.source_path is not None
+    assert SOURCE_FIELDS_RELATIVE_PATH in result.source_path
+    assert (tmp_path / SOURCE_FIELDS_RELATIVE_PATH).is_file()
+    loaded = try_load_economic_summary_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.status == "ECONOMICALLY_VIABLE_OFFLINE"
+
+
+def test_end_to_end_durable_source_to_autobind_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    _write_source_fields(archive, _fields())
+    result = materialize_economic_summary_presentation_projection_v1(
+        archive,
+        economic_summary=None,
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://e2e-economic-materializer",
+    )
+    assert result.written is True
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    economic = slots["economic_summary"]
+    assert economic.availability is Availability.AVAILABLE
+    assert economic.economic_viability_status == "ECONOMICALLY_VIABLE_OFFLINE"
+    assert economic.policy_threshold_status == "PASS"
+    assert economic.profit_factor == {"semantic": "COMPUTED", "value": 1.77}
+    assert economic.provenance.producer_module == ECONOMIC_PRODUCER_MODULE
+    assert economic.provenance.source_kind == ECONOMIC_SOURCE_KIND
+
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "ECONOMICALLY_VIABLE_OFFLINE" in html
+    assert 'data-mdl-ops="economic_summary"' in html
+    assert 'data-mdl-field="economic"' in html
+    assert "<form" not in html.lower()
+    assert "place_order" not in html.lower()
+
+
+def test_materializer_module_has_no_forbidden_trading_or_backtest_imports() -> None:
+    path = (
+        REPO
+        / "src/webui/workflow_dashboard_readmodel_v1"
+        / "economic_summary_presentation_projection_materializer_v1.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                continue
+            if node.module:
+                imported.add(node.module.split(".", 1)[0])
+    assert "trading" not in imported
+    assert "src" not in imported
+    assert "backtest" not in imported
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in {
+                "evaluate_promotion_economic_gate_v1",
+                "compose_double_play_decision",
+                "KillSwitch",
+            }

--- a/tests/webui/test_market_landscape_economic_summary_presentation_autobind_v1.py
+++ b/tests/webui/test_market_landscape_economic_summary_presentation_autobind_v1.py
@@ -1,0 +1,318 @@
+"""Focused autobind tests: CAPABILITY_PRESENTATION_ECONOMIC_SUMMARY_PROJECTION_MATERIALIZER_AUTOBIND_V1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.webui.app import create_app
+from src.webui.market_dashboard_landscape_producer_binding_v2 import (
+    ECONOMIC_PRODUCER_MODULE,
+    ECONOMIC_SOURCE_KIND,
+    REASON_ECONOMIC_NOT_PERSISTED,
+    bind_market_universe_slots,
+)
+from src.webui.market_dashboard_landscape_v2.availability import Availability
+from src.webui.workflow_dashboard_archive_root_v1 import ENV_ARCHIVE_ROOT
+from src.webui.workflow_dashboard_readmodel_v1.economic_summary_presentation_projection_v1 import (
+    AUTHORITY_EFFECT,
+    ECONOMIC_AUTHORITY_EFFECT,
+    LOAD_ERROR_ABSENT,
+    LOAD_ERROR_AMBIGUOUS,
+    LOAD_ERROR_AUTHORITY_CLAIM,
+    LOAD_ERROR_FIELDS_INVALID,
+    LOAD_ERROR_SCHEMA_MISMATCH,
+    SCHEMA_NAME,
+    SOURCE_FIELDS_RELATIVE_PATH,
+    STORAGE_RELATIVE_PATH,
+    map_economic_summary_fields_to_binder_fields_v1,
+    try_load_economic_summary_presentation_projection_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+STAMP = datetime(2026, 7, 24, 18, 0, 0, tzinfo=timezone.utc)
+PRODUCER_FRESH = "2026-07-24T17:30:00Z"
+
+
+def _metric(*, value: float | None = None, semantic: str = "COMPUTED") -> dict[str, object]:
+    payload: dict[str, object] = {"semantic": semantic}
+    if value is not None:
+        payload["value"] = value
+    return payload
+
+
+def _fields(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "status": "ECONOMICALLY_VIABLE_OFFLINE",
+        "economic_validity_proven": True,
+        "profitability_claim_allowed": False,
+        "policy_threshold_status": "PASS",
+        "policy_version": "economic_validity_policy_v1",
+        "authority_effect": "NONE",
+        "runtime_effect": False,
+        "order_effect": False,
+        "reason_codes": ("PASS",),
+        "profit_factor": _metric(value=1.77),
+        "net_return": _metric(value=0.123),
+        "max_drawdown": _metric(value=-0.045),
+        "sharpe": _metric(value=0.88),
+        "trade_count": _metric(value=42.0),
+        "funding_drag": _metric(value=-0.003),
+        "contract_version": "v1",
+        "owner": "backtest.economic_viability_evidence_v1",
+        "strategy_id": "sentinel_strategy",
+        "strategy_version": "sentinel_v9",
+        "config_digest": "c" * 64,
+        "implementation_digest": "i" * 64,
+        "data_digest": "d" * 64,
+        "manifest_digest": "m" * 64,
+        "wiring_chain_digest": "w" * 64,
+        "policy_digest": "p" * 64,
+        "evidence_digest": "m" * 64,
+        "schema_version": "v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _projection_payload(
+    *,
+    economic_summary: dict[str, object] | None = None,
+    **overrides: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_name": SCHEMA_NAME,
+        "schema_version": 1,
+        "authority_effect": AUTHORITY_EFFECT,
+        "economic_authority_effect": ECONOMIC_AUTHORITY_EFFECT,
+        "projection_role": "NON_AUTHORITATIVE_PRESENTATION_PROJECTION",
+        "generated_at": PRODUCER_FRESH,
+        "effective_at": PRODUCER_FRESH,
+        "source_reference": "presentation://economic_autobind_test",
+        "economic_summary": (economic_summary if economic_summary is not None else _fields()),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_projection(archive_root: Path, payload: dict[str, object]) -> Path:
+    path = archive_root / STORAGE_RELATIVE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_map_fields_to_binder_fields_preserves_producer_facts() -> None:
+    fields, errors = map_economic_summary_fields_to_binder_fields_v1(
+        economic_summary=_fields(),
+        generated_at=PRODUCER_FRESH,
+        effective_at=PRODUCER_FRESH,
+        source_reference="presentation://x",
+    )
+    assert errors == ()
+    assert fields is not None
+    assert fields["status"] == "ECONOMICALLY_VIABLE_OFFLINE"
+    assert fields["policy_threshold_status"] == "PASS"
+    assert fields["profit_factor"]["value"] == 1.77
+    assert fields["evidence_digest"] == "m" * 64
+    assert fields["generated_at"] == PRODUCER_FRESH
+
+
+def test_load_absent_projection_is_missing(tmp_path: Path) -> None:
+    loaded = try_load_economic_summary_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_ABSENT in loaded.load_errors
+    assert loaded.binder_fields is None
+
+
+def test_load_valid_projection_returns_binder_fields(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload())
+    loaded = try_load_economic_summary_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is True
+    assert loaded.load_errors == ()
+    assert loaded.binder_fields is not None
+    assert loaded.status == "ECONOMICALLY_VIABLE_OFFLINE"
+    assert loaded.evidence_digest == "m" * 64
+    assert STORAGE_RELATIVE_PATH in str(loaded.source_path)
+
+
+def test_load_schema_mismatch_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(schema_name="wrong.schema"))
+    loaded = try_load_economic_summary_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_SCHEMA_MISMATCH in loaded.load_errors
+
+
+def test_load_authority_claim_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload(authority_effect="AUTHORIZE"))
+    loaded = try_load_economic_summary_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_AUTHORITY_CLAIM in loaded.load_errors
+
+
+def test_load_invalid_fields_fail_closed(tmp_path: Path) -> None:
+    _write_projection(
+        tmp_path,
+        _projection_payload(economic_summary={"status": "ECONOMICALLY_VIABLE_OFFLINE"}),
+    )
+    loaded = try_load_economic_summary_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_FIELDS_INVALID in loaded.load_errors
+
+
+def test_load_ambiguous_sibling_fail_closed(tmp_path: Path) -> None:
+    _write_projection(tmp_path, _projection_payload())
+    sibling = tmp_path / SOURCE_FIELDS_RELATIVE_PATH
+    sibling.write_text(
+        json.dumps({"status": "RESEARCH_ONLY", "manifest_digest": "z" * 64}) + "\n",
+        encoding="utf-8",
+    )
+    loaded = try_load_economic_summary_presentation_projection_v1(tmp_path)
+    assert loaded.loaded is False
+    assert LOAD_ERROR_AMBIGUOUS in loaded.load_errors
+
+
+def test_autobind_available_from_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    economic = slots["economic_summary"]
+    assert economic.availability is Availability.AVAILABLE
+    assert economic.economic_viability_status == "ECONOMICALLY_VIABLE_OFFLINE"
+    assert economic.economic_validity_proven is True
+    assert economic.policy_threshold_status == "PASS"
+    assert economic.profit_factor == {"semantic": "COMPUTED", "value": 1.77}
+    assert economic.provenance.producer_module == ECONOMIC_PRODUCER_MODULE
+    assert economic.provenance.source_kind == ECONOMIC_SOURCE_KIND
+    assert economic.provenance.source_reference == "presentation://economic_autobind_test"
+    assert economic.provenance.evidence_digest == "m" * 64
+    assert slots["canonical_decision"].availability is Availability.MISSING_SOURCE
+    assert slots["double_play"].availability is Availability.MISSING_SOURCE
+    assert slots["safety_authority"].availability is Availability.MISSING_SOURCE
+    assert slots["dynamic_scope"].availability is Availability.MISSING_SOURCE
+    assert slots["execution_reconciliation"].availability is Availability.MISSING_SOURCE
+    assert slots["risk_sizing_capital"].availability is Availability.MISSING_SOURCE
+    assert slots["regime_bull_bear_switch"].availability is Availability.MISSING_SOURCE
+
+
+def test_autobind_missing_projection_is_missing_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "empty_archive"
+    archive.mkdir()
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["economic_summary"].availability is Availability.MISSING_SOURCE
+    assert REASON_ECONOMIC_NOT_PERSISTED in slots["economic_summary"].reason_codes
+
+
+def test_autobind_invalid_projection_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "bad_archive"
+    _write_projection(archive, _projection_payload(schema_name="nope"))
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(generated_at=STAMP)
+    assert slots["economic_summary"].availability is Availability.INVALID
+    assert LOAD_ERROR_SCHEMA_MISMATCH in slots["economic_summary"].reason_codes
+
+
+def test_explicit_injection_still_overrides_durable_projection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(archive, _projection_payload())
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    slots = bind_market_universe_slots(
+        generated_at=STAMP,
+        economic_viability_evidence_fields={
+            **_fields(
+                status="RESEARCH_ONLY",
+                economic_validity_proven=False,
+                policy_threshold_status="FAIL",
+                profit_factor=_metric(value=0.5),
+                reason_codes=("INJECTED",),
+                evidence_digest="b" * 64,
+                manifest_digest="b" * 64,
+            ),
+            "generated_at": PRODUCER_FRESH,
+            "source_reference": "economic://bounded-test-injection",
+        },
+    )
+    economic = slots["economic_summary"]
+    assert economic.availability is Availability.AVAILABLE
+    assert economic.economic_viability_status == "RESEARCH_ONLY"
+    assert economic.economic_validity_proven is False
+    assert economic.policy_threshold_status == "FAIL"
+    assert economic.profit_factor == {"semantic": "COMPUTED", "value": 0.5}
+    assert economic.provenance.source_reference == "economic://bounded-test-injection"
+
+
+def test_get_market_autobinds_economic_without_injection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "archive"
+    _write_projection(
+        archive,
+        _projection_payload(
+            economic_summary=_fields(
+                status="ECONOMICALLY_VIABLE_OFFLINE",
+                reason_codes=("AUTOBIND_OK",),
+            )
+        ),
+    )
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    client = TestClient(create_app())
+    response = client.get("/market")
+    assert response.status_code == 200
+    html = response.text
+    assert "ECONOMICALLY_VIABLE_OFFLINE" in html
+    assert 'data-mdl-ops="economic_summary"' in html
+    assert 'data-mdl-field="economic"' in html
+    assert 'data-mdl-field="economic_validity"' in html
+    assert 'data-mdl-field="economic_policy_threshold"' in html
+    assert 'data-mdl-field="economic_profit_factor"' in html
+    assert "<form" not in html.lower()
+    assert "place_order" not in html.lower()
+
+
+def test_projection_module_has_no_forbidden_trading_imports() -> None:
+    path = (
+        REPO
+        / "src/webui/workflow_dashboard_readmodel_v1"
+        / "economic_summary_presentation_projection_v1.py"
+    )
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                continue
+            if node.module:
+                imported.add(node.module.split(".", 1)[0])
+    assert "trading" not in imported
+    assert "src" not in imported
+    assert "backtest" not in imported
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in {
+                "evaluate_promotion_economic_gate_v1",
+                "compose_double_play_decision",
+                "KillSwitch",
+            }


### PR DESCRIPTION
## Summary
- Add durable `economic_summary_presentation_projection.v1` plus materializer for already-produced `EconomicViabilityEvidenceV1` binder fields.
- Register archive paths and Landscape fail-closed autobind with explicit injection priority preserved.
- Keep producer/canonical read model/runtime/trading/authority unchanged (`AUTHORITY_EFFECT=NONE`).

## Test plan
- [x] `tests/webui/test_economic_summary_presentation_projection_materializer_v1.py`
- [x] `tests/webui/test_market_landscape_economic_summary_presentation_autobind_v1.py`
- [x] Landscape architecture/contracts/producer-binding/shell + sibling autobind regression batch
- [x] `ruff format --check` / `ruff check` on touched files


Made with [Cursor](https://cursor.com)