### PR TITLE
docs: close legacy market_surface tombstone terminology ambiguity

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@
 
 **New to Peak_Trade (product overview)?**
 1. Read: [PEAK_TRADE_OVERVIEW.md](PEAK_TRADE_OVERVIEW.md) – Architecture, Strategy Registry, Config, Quick Start
-2. Market Dashboard Landscape V2 (canonical planning/execution runbook; read-only consumer; no runtime/trading authorization): [ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md](ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md) — historical Architecture Reset v1.0: [product/Peak_Trade_Market_Dashboard_Architecture_Reset_and_Rebuild_Master_Runbook_v1.0.md](product/Peak_Trade_Market_Dashboard_Architecture_Reset_and_Rebuild_Master_Runbook_v1.0.md); removed product tombstone: [webui/MARKET_DASHBOARD_REMOVED.md](webui/MARKET_DASHBOARD_REMOVED.md)
+2. Market Dashboard Landscape V2 (canonical planning/execution runbook; read-only consumer; no runtime/trading authorization): [ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md](ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md) — historical Architecture Reset v1.0: [product/Peak_Trade_Market_Dashboard_Architecture_Reset_and_Rebuild_Master_Runbook_v1.0.md](product/Peak_Trade_Market_Dashboard_Architecture_Reset_and_Rebuild_Master_Runbook_v1.0.md); legacy product removal notice (`REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`; no tombstone route/module/path exists): [webui/MARKET_DASHBOARD_REMOVED.md](webui/MARKET_DASHBOARD_REMOVED.md)
 3. Run your first backtest: `python3 scripts&#47;run_strategy_from_config.py --strategy ma_crossover`
 4. Explore: [What changed recently?](DOCUMENTATION_UPDATE_SUMMARY.md)
 

--- a/docs/audits/MONITORING_TOPOLOGY_READ_ONLY_AUDIT_2026-07-17.md
+++ b/docs/audits/MONITORING_TOPOLOGY_READ_ONLY_AUDIT_2026-07-17.md
@@ -27,7 +27,7 @@ A prior in-progress attempt treated Grafana as an expected monitoring component.
 | Surface | Treatment in this audit |
 |---|---|
 | Grafana | **Not expected.** Not inventarized as live/deploy target. Status=`REMOVED_AS_DESIGNED`. Only stale string references counted. |
-| Market Dashboard | Product removed (tombstone). Only stale string references counted. |
+| Market Dashboard | Product removed (`REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`; no tombstone route/module/path exists). Only stale string references counted. |
 | Historical priorities plan / Phase-62 plans | Hints only — not automatic SSOT for topology. |
 
 ## 2. Canonical topology (repo-resolved)
@@ -80,7 +80,7 @@ No notification/test-alert sent.
 | Grafana | `REMOVED_AS_DESIGNED` | No provisioning tree; not audited for reachability |
 | Alertmanager | `REMOVED_AS_DESIGNED` | No `alertmanager.yml`; not expected |
 | CloudWatch Peak_Trade monitoring | `REMOVED_AS_DESIGNED` | Not a Peak_Trade monitoring deploy SSOT |
-| Market Dashboard product | `REMOVED_AS_DESIGNED` | Tombstone `docs/webui/MARKET_DASHBOARD_REMOVED.md` |
+| Market Dashboard product | `REMOVED_AS_DESIGNED` | Removal notice `docs/webui/MARKET_DASHBOARD_REMOVED.md` (`REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`; no active tombstone surface) |
 
 ## 5. Stale references only (excl. `evidence/`)
 

--- a/docs/audits/Peak_Trade_Prioritaetenplan_Systemaudit_2026-07-17.md
+++ b/docs/audits/Peak_Trade_Prioritaetenplan_Systemaudit_2026-07-17.md
@@ -44,7 +44,7 @@ This closeout updates **status / residual-gap / Definition-of-Done** only. It do
 | Item | Status | Evidence |
 |---|---|---|
 | P1 GitHub-SSOT | **DONE** | PR `#5291` — required checks SSOT synced to live main protection |
-| P1 Tombstone documentation | **DONE** | PR `#5292` — market path tombstone normalization |
+| P1 Tombstone documentation | **DONE** | PR `#5292` — market path removal-notice normalization (`REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`; no active tombstone surface; historical campaign key `p1_tombstone_documentation`) |
 | P1 Surface-P contract drift | **DONE** | PR `#5293` — Surface P status contract alignment |
 
 ### 1.2 P2 — Governance inventories

--- a/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
+++ b/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
@@ -3943,7 +3943,7 @@ DOCS_DRIFT_OR_POINTER_INTEGRITY_DEFERRED=true
 |---------|-------|
 | Tape SSR spec + operator enablement | `docs/webui/MARKET_DASHBOARD_REMOVED.md` (product removed; historical tape SSR notes only) |
 | Tape SSR product tests | deleted with Market Dashboard product — live guard: `tests/webui/test_market_dashboard_tombstone_v1.py` |
-| Tape env/schema boundary guard | deleted with Market Dashboard product — see tombstone |
+| Tape env/schema boundary guard | deleted with Market Dashboard product — see `docs/webui/MARKET_DASHBOARD_REMOVED.md` (`REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`) |
 | DOCS_TRUTH_MAP chronicle | `docs/ops/registry/DOCS_TRUTH_MAP.md` (this crosslink section + Änderungsnachweis row) |
 
 ```text
@@ -3975,8 +3975,8 @@ PREFLIGHT_REMAINS_BLOCKED=true
 |---------|-------|
 | Operator Overview IA v1 spec + display-only markers | `docs/webui/MARKET_DASHBOARD_REMOVED.md` (product removed) |
 | Operator Overview product structure tests | deleted with Market Dashboard product — live guard: `tests/webui/test_market_dashboard_tombstone_v1.py` |
-| Operator Overview env boundary guard | deleted with Market Dashboard product — see tombstone |
-| Display-only operator overview wiring (historical) | removed with Market Dashboard product — see tombstone |
+| Operator Overview env boundary guard | deleted with Market Dashboard product — see `docs/webui/MARKET_DASHBOARD_REMOVED.md` (`REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`) |
+| Display-only operator overview wiring (historical) | removed with Market Dashboard product — see `docs/webui/MARKET_DASHBOARD_REMOVED.md` (`REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`) |
 | DOCS_TRUTH_MAP chronicle | `docs/ops/registry/DOCS_TRUTH_MAP.md` (this crosslink section + Änderungsnachweis row) |
 
 ```text

--- a/docs/ops/RUNBOOK_INDEX.md
+++ b/docs/ops/RUNBOOK_INDEX.md
@@ -31,7 +31,7 @@
 | Artefakt | Pfad | Rolle |
 |----------|------|-------|
 | **Canonical Landscape V2 master runbook** | [market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md](market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md) | Planning/Übergabe/Ausführung für Landscape V2; Caps 1–7 technical + Cap8 docs/ownership + PR #5568 daily observation + PR #5577 regime/bull-bear/switch; Operator Product Review PASS on `88f2241819dcc160c3ce688a9c7397e7cc8becec`; `OPERATOR_PRODUCT_GATE=true`; `MARKET_DASHBOARD_PHASE_5_PASS=true`; `DAILY_OBSERVATION_USABLE=true`; `INTRABAR_CAPABILITY=PASS`; `REGIME_BULL_BEAR_SWITCH_BINDING=COMPLETE`; `CONFIDENCE_FIELD_STATE=NOT_AVAILABLE_NO_CANONICAL_FIELD`; `WORKSTREAM_STATE=FINAL_CLOSEOUT_COMPLETE_STOP_IDLE`; `NEXT_CANONICAL_ACTION=STOP_IDLE`; **keine** Trading-/Runtime-/Order-Authority; Capability-PR-only; Documentation Anchor = documentary index only |
-| **Removed product tombstone** | [../webui/MARKET_DASHBOARD_REMOVED.md](../webui/MARKET_DASHBOARD_REMOVED.md) | Legacy product tombstone; Landscape V2 `GET &#47;market` is the authorized read-only replacement surface |
+| **Legacy product removal notice** | [../webui/MARKET_DASHBOARD_REMOVED.md](../webui/MARKET_DASHBOARD_REMOVED.md) | `REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`; legacy `market_surface` fully removed — not an architectural component; no tombstone route/module/path exists; Landscape V2 `GET &#47;market` is the authorized read-only replacement surface |
 
 ## Canonical Runtime Operations / Dashboard / Process Supervision V2.4 (derived domain authority only; non-SSOT)
 

--- a/docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md
+++ b/docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md
@@ -1258,7 +1258,7 @@ STALE_PID_ONLY_BLOCKER=true
 **Tests / evidence**
 
 - Relevant shell / architecture / accessibility / chrome-evidence / contracts /
-  tombstone suites green (67 passed).
+  negative non-regression removal-guard suites green (67 passed).
 - Evidence pack: `evidence/market_dashboard_v2/phase5/task8_performance/`
 
 **Unresolved / still open for Phase 5**
@@ -1924,7 +1924,10 @@ CANONICAL_STATIC_SURFACES=[
 CANONICAL_READ_AGGREGATE=MarketDashboardReadServiceV1+present_market_landscape_v2
 CANONICAL_SHELL_ROUTER=src/webui/market_dashboard_landscape_shell_router_v2.py
 CANONICAL_PRODUCER_BINDING=src/webui/market_dashboard_landscape_producer_binding_v2.py
-LEGACY_PRODUCT_TOMBSTONE=docs/webui/MARKET_DASHBOARD_REMOVED.md
+LEGACY_PRODUCT_REMOVAL_NOTICE=docs/webui/MARKET_DASHBOARD_REMOVED.md
+LEGACY_MARKET_SURFACE_STATUS=REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS
+LEGACY_MARKET_SURFACE_IS_ARCHITECTURAL_COMPONENT=false
+ACTIVE_TOMBSTONE_SURFACE=false
 
 MASTER_V2_CANONICAL=true
 DOUBLE_PLAY_CANONICAL=true

--- a/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
+++ b/docs/ops/specs/RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md
@@ -211,7 +211,7 @@ Non-goals:
 | Generic Evidence Run Registry v1 | [build_generic_evidence_run_registry_v1.py](../../../scripts/ops/build_generic_evidence_run_registry_v1.py) |
 | Vocabulary forbidden equalities | [CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md](CANONICAL_VOCAB_AUTHORITY_PROVENANCE_V0.md) |
 | OPS Cockpit non-authority | [OPS_COCKPIT_MASTER_V2_NON_AUTHORITY_CONTRACT_V1.md](OPS_COCKPIT_MASTER_V2_NON_AUTHORITY_CONTRACT_V1.md) |
-| F5 read-only market dashboard (display) — **legacy product removed**; Landscape V2 successor `GET &#47;market` is the authorized read-only consumer (see tombstone) | [MARKET_DASHBOARD_REMOVED.md](../../webui/MARKET_DASHBOARD_REMOVED.md) |
+| F5 read-only market dashboard (display) — **legacy product removed** (`REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`; no tombstone route/module/path exists); Landscape V2 successor `GET &#47;market` is the authorized read-only consumer | [MARKET_DASHBOARD_REMOVED.md](../../webui/MARKET_DASHBOARD_REMOVED.md) |
 | Readiness Evidence Ledger v0 | [build_readiness_evidence_ledger_v0.py](../../../scripts/ops/build_readiness_evidence_ledger_v0.py) |
 | Readiness Ledger Preflight Mirror v0 | [report_readiness_ledger_preflight_mirror_v0.py](../../../scripts/ops/report_readiness_ledger_preflight_mirror_v0.py) |
 | Readiness Gate Snapshot v0 | [report_readiness_gate_snapshot_v0.py](../../../scripts/ops/report_readiness_gate_snapshot_v0.py) |
@@ -1363,7 +1363,7 @@ Static guards: [test_durable_closeout_copy_verify_v0.py](../../../tests/ops/test
 
 Cross-reference: Preflight §2a.1 primary evidence hard gate; §2b.1 mandatory durable closeout; Preflight **§2b.3** durable closeout adapter validation (PR #4127/#4128; `BLOCKER_HINT`; `--durable-closeout-force`; authoritative hierarchy); [primary_evidence_retention_v0.py](../../../scripts/ops/primary_evidence_retention_v0.py); [test_post_closeout_automation_hook_owner_precheck_v0.py](../../../tests/ops/test_post_closeout_automation_hook_owner_precheck_v0.py).
 
-Cross-reference: [MARKET_DASHBOARD_REMOVED.md](../../webui/MARKET_DASHBOARD_REMOVED.md) (Market Dashboard product tombstone; registry overlay consumer §6a.2 remains ops-only); §6a.0.9 payload builder planning; [DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md); Preflight §2b.1 mandatory durable closeout; Preflight §2b.3 adapter closeout validation SSOT.
+Cross-reference: [MARKET_DASHBOARD_REMOVED.md](../../webui/MARKET_DASHBOARD_REMOVED.md) (legacy Market Dashboard / `market_surface` fully removed — `REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`; no tombstone route/module/path exists; registry overlay consumer §6a.2 remains ops-only); §6a.0.9 payload builder planning; [DOCS_TRUTH_MAP.md](../registry/DOCS_TRUTH_MAP.md); Preflight §2b.1 mandatory durable closeout; Preflight §2b.3 adapter closeout validation SSOT.
 
 ### 6a.0.9 Shared Projection Payload Builder Planning Contract v0 (planning-only)
 
@@ -1741,7 +1741,7 @@ Composition records: include `child_lane_refs` / `child_lane_status` pointers on
 
 #### Surface boundaries (legacy product removed; Landscape V2 successor; ops projection fields preserved)
 
-- **Legacy Market Dashboard product removed:** [MARKET_DASHBOARD_REMOVED.md](../../webui/MARKET_DASHBOARD_REMOVED.md) is the tombstone chronicle. Legacy aliases remain intentionally absent (normal HTTP 404; no redirect). Landscape V2 `GET &#47;market` is the authorized read-only successor shell and does **not** enable §6a.2 Registry run projection (`MARKET_DASHBOARD_RUN_PROJECTION_ENABLED=false`).
+- **Legacy Market Dashboard product removed:** [MARKET_DASHBOARD_REMOVED.md](../../webui/MARKET_DASHBOARD_REMOVED.md) is the removal notice (`REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`). Legacy `market_surface` is fully removed and is not an architectural component; no tombstone route, module, presenter, template, source, slot, fallback, compatibility path, authority, producer, read model, or runtime path exists. Legacy aliases remain intentionally absent (normal HTTP 404; no redirect). Landscape V2 `GET &#47;market` is the authorized read-only successor shell and does **not** enable §6a.2 Registry run projection (`MARKET_DASHBOARD_RUN_PROJECTION_ENABLED=false`).
 - **Registry v1 projection fields preserved:** `market_dashboard_projection` / `market_dashboard_projection_allowed` remain ops-only disabled-by-default consumer eligibility markers (this §6a.2).
 - **Master V2 / Double Play domain preserved (not a Market route):** composition **authority** and non-authority boundaries remain unchanged (§9). The surviving read-only display JSON is `GET &#47;api&#47;master-v2&#47;double-play&#47;dashboard-display.json` — independent of the removed legacy Market Dashboard product and of Landscape V2 authority. Registry projection must **not** embed Double Play decision or selection authority.
 
@@ -2259,7 +2259,7 @@ MARKET_DASHBOARD_NO_LIVE_BROKER_EXCHANGE_AUTHORITY=true
 Normative state (post Market Dashboard product removal):
 
 - F5 read-only market dashboard surfaces map to lane_id `dashboard` with authority level `review_input_only` (see §3).
-- Detail owner: [MARKET_DASHBOARD_REMOVED.md](../../webui/MARKET_DASHBOARD_REMOVED.md) — product tombstone; historical F5 / Market Surface contracts deleted.
+- Detail owner: [MARKET_DASHBOARD_REMOVED.md](../../webui/MARKET_DASHBOARD_REMOVED.md) — `REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`; historical F5 / Market Surface contracts deleted; no reactivatable tombstone surface exists.
 - Registry v1 `market_dashboard_projection` consumer fields remain ops-only (§6a.2); `MARKET_DASHBOARD_AUTHORITY=false`.
 - Dashboard display, SSR read models, registry rows, and test status **do not** grant approval, gate clearance, Live/Testnet/broker/exchange permission, scheduler activation, or runtime start.
 - `FORBIDDEN_PROMOTION_DASHBOARD_NOTION_DOCS_AI_TO_APPROVAL` applies (see §5).

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -11,7 +11,10 @@
 **Canonical Landscape V2 planning/execution runbook (read-only consumer; no runtime/trading authorization):**  
 [`docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md`](../ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md)
 
-Previous product surface: removed. See [`docs/webui/MARKET_DASHBOARD_REMOVED.md`](../webui/MARKET_DASHBOARD_REMOVED.md).
+Previous product surface / legacy `market_surface`: fully removed
+(`REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`; not an architectural component;
+no tombstone route/module/path exists). See
+[`docs/webui/MARKET_DASHBOARD_REMOVED.md`](../webui/MARKET_DASHBOARD_REMOVED.md).
 
 Historical Architecture Reset & Rebuild planning SSOT (non-Landscape-V2; not a second implementation authority):  
 [`Peak_Trade_Market_Dashboard_Architecture_Reset_and_Rebuild_Master_Runbook_v1.0.md`](Peak_Trade_Market_Dashboard_Architecture_Reset_and_Rebuild_Master_Runbook_v1.0.md)

--- a/docs/runbooks/canonical/PEAK_TRADE_CANONICAL_RUNTIME_OPERATIONS_DASHBOARD_AND_PROCESS_SUPERVISION_RUNBOOK_V2_4.md
+++ b/docs/runbooks/canonical/PEAK_TRADE_CANONICAL_RUNTIME_OPERATIONS_DASHBOARD_AND_PROCESS_SUPERVISION_RUNBOOK_V2_4.md
@@ -230,7 +230,12 @@ OTHER_OBSERVER_SURFACES:
   health and CI/ops surfaces
 ```
 
-The former legacy Market Dashboard product is tombstoned and must not be resurrected without explicit Owner authorization.
+The former legacy Market Dashboard product / `market_surface` is fully removed
+(`REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`) and is not an architectural
+component. Negative non-regression guards exist solely to prevent
+reintroduction. No tombstone route, module, presenter, template, source, slot,
+fallback, compatibility path, authority, producer, read model, or runtime path
+exists. Do not resurrect it without explicit Owner authorization.
 
 ## 3A.2 Runtime launch families
 

--- a/docs/runbooks/canonical/PEAK_TRADE_CANONICAL_RUNTIME_OPERATIONS_DASHBOARD_AND_PROCESS_SUPERVISION_RUNBOOK_V2_4_RATIFICATION.json
+++ b/docs/runbooks/canonical/PEAK_TRADE_CANONICAL_RUNTIME_OPERATIONS_DASHBOARD_AND_PROCESS_SUPERVISION_RUNBOOK_V2_4_RATIFICATION.json
@@ -1,7 +1,7 @@
 {
   "authority_classification": "DERIVED_DOMAIN_AUTHORITY_ONLY",
   "canonical_document_path": "docs/runbooks/canonical/PEAK_TRADE_CANONICAL_RUNTIME_OPERATIONS_DASHBOARD_AND_PROCESS_SUPERVISION_RUNBOOK_V2_4.md",
-  "canonical_document_sha256": "d71b84a02490607f80132d72e6723acdbfd6cd75e5d2203d3e9a7283774d060c",
+  "canonical_document_sha256": "cbb1c83d0f3f767ac27d684637fc7536502480d551d9a7017a5df832d57fd768",
   "core_logic_changed": false,
   "credentials_used": false,
   "document_class": "CANONICAL_RUNTIME_OPERATIONS_DASHBOARD_AND_PROCESS_SUPERVISION_RUNBOOK",

--- a/docs/webui/MARKET_DASHBOARD_REMOVED.md
+++ b/docs/webui/MARKET_DASHBOARD_REMOVED.md
@@ -1,20 +1,58 @@
-# Market Dashboard — Legacy Product Removed / Landscape V2 Successor
+# Market Dashboard — Legacy Product Fully Removed
 
-The Peak Trade **legacy** Market Dashboard product was intentionally removed and completely deleted.
+**STATUS:** `REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS`
 
-- Legacy packages, templates, Chart.js market shells, OHLCV/depth APIs, and reset-shell markers remain deleted.
-- Legacy aliases (`&#47;market&#47;double-play`, `&#47;market&#47;futures`, `&#47;api&#47;market&#47;ohlcv`, `&#47;api&#47;market&#47;depth`) remain intentionally absent (normal not-found).
-- Independent domain producers (trading, risk, execution, economic, diagnostics, market-data) remain domain-owned.
+```text
+Legacy market_surface is fully removed and is not an architectural component.
+Negative non-regression guards exist solely to prevent its reintroduction.
+No tombstone route, module, presenter, template, source, slot, fallback, compatibility path, authority, producer, read model, or runtime path exists.
+```
+
+Legacy `market_surface` is fully removed and is not an architectural component.
+Negative non-regression guards exist solely to prevent its reintroduction.
+No tombstone route, module, presenter, template, source, slot, fallback,
+compatibility path, authority, producer, read model, or runtime path exists.
+
+## Canonical removal facts
+
+The Peak Trade **legacy** Market Dashboard product (including legacy
+`market_surface`) was intentionally removed and completely deleted.
+
+- Legacy packages, templates, Chart.js market shells, OHLCV/depth APIs, and
+  reset-shell markers remain deleted.
+- Legacy aliases (`&#47;market&#47;double-play`, `&#47;market&#47;futures`,
+  `&#47;api&#47;market&#47;ohlcv`, `&#47;api&#47;market&#47;depth`) remain
+  intentionally absent (normal not-found).
+- There is **no** registry slot, contract, route, module, template, presenter,
+  binder, read model, producer, fallback, authority, runtime path, or
+  reactivation option for legacy `market_surface`.
+- Independent domain producers (trading, risk, execution, economic,
+  diagnostics, market-data) remain domain-owned.
 
 **Current authorized read-only surface (already on main):**  
-`GET &#47;market` remains the **Market Dashboard Landscape V2** read-only consumer shell. Exact route/template/static/bindings stay owned by the canonical Landscape V2 master runbook; this tombstone does **not** redefine them.
+`GET &#47;market` remains the **Market Dashboard Landscape V2** read-only
+consumer shell. Exact route/template/static/bindings stay owned by the
+canonical Landscape V2 master runbook; this removal notice does **not**
+redefine them.
 
 - Pure read-only GET route; no write/action/order/runtime controls.
-- Unbound or missing producers render as `NOT_BOUND` / `MISSING` / `STALE` / `INVALID`.
-- Does **not** authorize runtime activation, orders, scheduler, shadow/paper/testnet, capital changes, promotion, or live trading.
-- `OPERATOR_PRODUCT_GATE=true` is recorded from the Operator Product Review on exact commit `88f2241819dcc160c3ce688a9c7397e7cc8becec` (post PR #5568; read-only daily observation surface). PR #5569 later added docs-only Consumer / Anti-SSOT wording and did not invalidate that review. PR #5577 bound Regime/Bull-Bear/Switch read-only (explicit injection). Final closeout docs hygiene reconciles Class-C drift only (`NEXT_CANONICAL_ACTION=STOP_IDLE`). Technical or Chrome evidence alone must **not** be re-inferred as a new Product PASS. Dashboard remains non-authority / non-SSOT / non-truth-owner. Documentation Anchor = documentary index only.
+- Unbound or missing producers render as `NOT_BOUND` / `MISSING` / `STALE` /
+  `INVALID`.
+- Does **not** authorize runtime activation, orders, scheduler,
+  shadow/paper/testnet, capital changes, promotion, or live trading.
+- `OPERATOR_PRODUCT_GATE=true` is recorded from the Operator Product Review on
+  exact commit `88f2241819dcc160c3ce688a9c7397e7cc8becec` (post PR #5568;
+  read-only daily observation surface). PR #5569 later added docs-only
+  Consumer / Anti-SSOT wording and did not invalidate that review. PR #5577
+  bound Regime/Bull-Bear/Switch read-only (explicit injection). Final closeout
+  docs hygiene reconciles Class-C drift only (`NEXT_CANONICAL_ACTION=STOP_IDLE`).
+  Technical or Chrome evidence alone must **not** be re-inferred as a new
+  Product PASS. Dashboard remains non-authority / non-SSOT / non-truth-owner.
+  Documentation Anchor = documentary index only.
 
 Canonical planning/execution authority:  
 [`docs/ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md`](../ops/market_dashboard/PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md)
 
-Do not resurrect deleted legacy Dashboard code from Git history without explicit operator authorization.
+Do not resurrect deleted legacy Dashboard / `market_surface` code from Git
+history without explicit operator authorization. Absence is enforced by
+negative non-regression guards only; absence is not a reactivatable surface.

--- a/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
+++ b/tests/ops/test_runtime_lane_taxonomy_authority_levels_contract_v0.py
@@ -28,7 +28,9 @@ MARKET_DASHBOARD_SPEC = (
     REPO_ROOT / "docs" / "ops" / "specs" / "FUTURES_READ_ONLY_MARKET_DASHBOARD_CONTRACT_V0.md"
 )
 MARKET_SURFACE_V0 = REPO_ROOT / "docs" / "webui" / "MARKET_SURFACE_V0.md"
-MARKET_DASHBOARD_TOMBSTONE = REPO_ROOT / "docs" / "webui" / "MARKET_DASHBOARD_REMOVED.md"
+MARKET_DASHBOARD_REMOVAL_NOTICE = REPO_ROOT / "docs" / "webui" / "MARKET_DASHBOARD_REMOVED.md"
+# Historical alias retained for guard-name stability.
+MARKET_DASHBOARD_TOMBSTONE = MARKET_DASHBOARD_REMOVAL_NOTICE
 READINESS_LEDGER_SCRIPT = REPO_ROOT / "scripts" / "ops" / "build_readiness_evidence_ledger_v0.py"
 READINESS_MIRROR_SCRIPT = (
     REPO_ROOT / "scripts" / "ops" / "report_readiness_ledger_preflight_mirror_v0.py"
@@ -689,16 +691,23 @@ def test_post_stop_pack_wrapper_marker_aligned() -> None:
     assert "non-authorizing" in preflight.lower()
 
 
-def test_market_dashboard_product_tombstone_present_deleted_surfaces_absent() -> None:
-    assert MARKET_DASHBOARD_TOMBSTONE.is_file()
+def test_market_dashboard_product_removal_notice_present_deleted_surfaces_absent() -> None:
+    assert MARKET_DASHBOARD_REMOVAL_NOTICE.is_file()
     assert not MARKET_DASHBOARD_SPEC.is_file()
     assert not MARKET_SURFACE_V0.is_file()
-    tombstone = MARKET_DASHBOARD_TOMBSTONE.read_text(encoding="utf-8")
-    assert "Market Dashboard" in tombstone
-    assert "removed" in tombstone.lower()
+    notice = MARKET_DASHBOARD_REMOVAL_NOTICE.read_text(encoding="utf-8")
+    assert "Market Dashboard" in notice
+    assert "removed" in notice.lower()
+    assert "REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS" in notice
+    assert "No tombstone route" in notice
     # Docs token policy requires illustrative path encoding (GET &#47;market).
-    assert "GET &#47;market" in tombstone
-    assert "GET /market" not in tombstone
+    assert "GET &#47;market" in notice
+    assert "GET /market" not in notice
+
+
+def test_market_dashboard_product_tombstone_present_deleted_surfaces_absent() -> None:
+    """Historical name retained; asserts removal notice + deleted surfaces."""
+    test_market_dashboard_product_removal_notice_present_deleted_surfaces_absent()
 
 
 def test_market_dashboard_f5_non_authority_taxonomy_cross_ref_aligned() -> None:
@@ -721,12 +730,12 @@ def test_market_dashboard_f5_non_authority_taxonomy_cross_ref_aligned() -> None:
     assert "broker" in taxonomy.lower() or "exchange" in taxonomy.lower()
 
 
-def test_market_dashboard_tombstone_taxonomy_cross_ref_aligned() -> None:
-    assert MARKET_DASHBOARD_TOMBSTONE.is_file()
+def test_market_dashboard_removal_notice_taxonomy_cross_ref_aligned() -> None:
+    assert MARKET_DASHBOARD_REMOVAL_NOTICE.is_file()
     assert not MARKET_SURFACE_V0.is_file()
-    tombstone = MARKET_DASHBOARD_TOMBSTONE.read_text(encoding="utf-8")
+    notice = MARKET_DASHBOARD_REMOVAL_NOTICE.read_text(encoding="utf-8")
     taxonomy = _spec_text()
-    assert "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md" not in tombstone
+    assert "RUNTIME_LANE_TAXONOMY_AUTHORITY_LEVELS_CONTRACT_V0.md" not in notice
     assert "MARKET_DASHBOARD_REMOVED.md" in taxonomy
     assert "`dashboard`" in taxonomy
     assert "review_input_only" in taxonomy
@@ -734,10 +743,18 @@ def test_market_dashboard_tombstone_taxonomy_cross_ref_aligned() -> None:
     assert "FORBIDDEN_PROMOTION_DASHBOARD_NOTION_DOCS_AI_TO_APPROVAL" in taxonomy
     assert "non-authorizing" in taxonomy.lower()
     assert "does not" in taxonomy.lower() or "do not" in taxonomy.lower()
+    assert "REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS" in taxonomy
+    assert "product tombstone" not in taxonomy.lower()
+    assert "is the tombstone" not in taxonomy.lower()
+
+
+def test_market_dashboard_tombstone_taxonomy_cross_ref_aligned() -> None:
+    """Historical name retained; asserts removal-notice / taxonomy alignment."""
+    test_market_dashboard_removal_notice_taxonomy_cross_ref_aligned()
 
 
 def test_market_dashboard_section_6a2_preserves_registry_projection_fields() -> None:
-    """§6a.2 ops consumer field docs remain; product UI surfaces are tombstoned."""
+    """§6a.2 ops consumer field docs remain; legacy product UI surfaces are fully removed."""
     taxonomy = _spec_text()
     assert "### 6a.2 Market Dashboard read-only run projection contract v0" in taxonomy
     assert "market_dashboard_projection" in taxonomy
@@ -745,6 +762,7 @@ def test_market_dashboard_section_6a2_preserves_registry_projection_fields() -> 
     assert "MARKET_DASHBOARD_REMOVED.md" in taxonomy
     assert not MARKET_SURFACE_V0.is_file()
     assert not MARKET_DASHBOARD_SPEC.is_file()
+    assert "are tombstoned" not in taxonomy.lower()
 
 
 def test_autonomy_stage_authority_crosswalk_section_present() -> None:

--- a/tests/webui/test_chartjs_vendor_fallback_wiring_contract_v0.py
+++ b/tests/webui/test_chartjs_vendor_fallback_wiring_contract_v0.py
@@ -82,11 +82,13 @@ def test_chartjs_vendor_primary_r_and_d_charts_v1(client: TestClient) -> None:
 
 
 def test_market_surface_docs_removed_for_chartjs_contract() -> None:
-    tombstone = project_root / "docs/webui/MARKET_DASHBOARD_REMOVED.md"
-    assert tombstone.is_file()
+    removal_notice = project_root / "docs/webui/MARKET_DASHBOARD_REMOVED.md"
+    assert removal_notice.is_file()
     assert not (project_root / "docs/webui/MARKET_SURFACE_V0.md").exists()
-    text = tombstone.read_text(encoding="utf-8")
+    text = removal_notice.read_text(encoding="utf-8")
     assert "intentionally removed" in text.lower() or "intentionally absent" in text.lower()
+    assert "REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS" in text
+    assert "No tombstone route" in text
 
 
 def test_docs_truth_map_chartjs_phase_1b_vendor_primary_v1() -> None:

--- a/tests/webui/test_market_dashboard_tombstone_v1.py
+++ b/tests/webui/test_market_dashboard_tombstone_v1.py
@@ -1,12 +1,19 @@
-"""Tombstone: legacy Market Dashboard product remains deleted.
+"""Negative non-regression guards for removed legacy Market Dashboard / market_surface.
 
-Landscape V2 GET /market (Phase 3 shell) is the authorized successor route.
-Legacy aliases, packages, templates, and product markers must stay absent.
+Canonical status: REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS.
+
+Legacy market_surface is fully removed and is not an architectural component.
+These tests exist solely to prevent reintroduction. They do not define, register,
+or authorize any tombstone route, module, presenter, template, source, slot,
+fallback, compatibility path, authority, producer, read model, or runtime path.
+
+Filename retained for historical guard-reference stability only.
 """
 
 from __future__ import annotations
 
 import importlib
+import re
 from pathlib import Path
 
 import pytest
@@ -17,8 +24,18 @@ from src.webui.app import create_app
 REPO = Path(__file__).resolve().parents[2]
 APP_PATH = REPO / "src" / "webui" / "app.py"
 BASE_HTML = REPO / "templates" / "peak_trade_dashboard" / "base.html"
-TOMBSTONE = REPO / "docs" / "webui" / "MARKET_DASHBOARD_REMOVED.md"
+REMOVAL_NOTICE = REPO / "docs" / "webui" / "MARKET_DASHBOARD_REMOVED.md"
 SHELL_ROUTER = REPO / "src" / "webui" / "market_dashboard_landscape_shell_router_v2.py"
+LANDSCAPE_RUNBOOK = (
+    REPO
+    / "docs"
+    / "ops"
+    / "market_dashboard"
+    / "PEAK_TRADE_MARKET_DASHBOARD_LANDSCAPE_MASTER_RUNBOOK_V2.md"
+)
+
+# Historical alias kept so older call sites / greps remain accurate.
+TOMBSTONE = REMOVAL_NOTICE
 
 DELETED_PACKAGES = (
     "src.webui.market_surface",
@@ -35,6 +52,31 @@ DELETED_TEMPLATES = (
     "market_dashboard_product_v1.html",
     "market_v0.html",
 )
+
+CANONICAL_REMOVAL_STATEMENT = (
+    "Legacy market_surface is fully removed and is not an architectural component."
+)
+
+FORBIDDEN_ACTIVE_CLASSIFICATIONS = (
+    "TOMBSTONED",
+    "DEPRECATED",
+    "COMPATIBILITY",
+    "FALLBACK",
+    "REACTIVATABLE",
+    "REACTIVATION",
+)
+
+# Productive / canonical architecture surfaces that must not classify legacy
+# market_surface as an active, deprecated, compatibility, fallback, or
+# reactivatable component.
+ARCHITECTURE_SCAN_ROOTS = (
+    REPO / "src" / "webui",
+    REPO / "config" / "governance",
+    REPO / "docs" / "ops" / "market_dashboard",
+    REPO / "docs" / "webui",
+)
+
+ARCHITECTURE_SCAN_GLOBS = ("*.py", "*.json", "*.md")
 
 
 @pytest.fixture()
@@ -102,14 +144,23 @@ def test_no_reset_shell_or_legacy_product_surface_markers(client: TestClient) ->
     assert "data-market-landscape-v2" in html
 
 
-def test_tombstone_doc_present() -> None:
-    assert TOMBSTONE.is_file()
-    text = TOMBSTONE.read_text(encoding="utf-8")
+def test_removal_notice_doc_present() -> None:
+    assert REMOVAL_NOTICE.is_file()
+    text = REMOVAL_NOTICE.read_text(encoding="utf-8")
     assert "intentionally" in text.lower()
     # Docs token policy requires illustrative path encoding (GET &#47;market).
     assert "GET &#47;market" in text
     assert "GET /market" not in text
     assert "Landscape V2" in text or "landscape v2" in text.lower()
+    assert "REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS" in text
+    assert CANONICAL_REMOVAL_STATEMENT in text
+    assert "No tombstone route" in text
+    assert "not an architectural component" in text.lower()
+
+
+def test_tombstone_doc_present() -> None:
+    """Historical name retained; asserts the removal notice remains present."""
+    test_removal_notice_doc_present()
 
 
 def test_no_legacy_dashboard_product_tests_or_fixtures_remain() -> None:
@@ -117,3 +168,77 @@ def test_no_legacy_dashboard_product_tests_or_fixtures_remain() -> None:
     assert not (REPO / "tests" / "fixtures" / "market_ranking_funnel_readmodel_v0").exists()
     remaining = sorted((REPO / "tests" / "webui").glob("test_market_dashboard_*.py"))
     assert remaining == [REPO / "tests" / "webui" / "test_market_dashboard_tombstone_v1.py"]
+
+
+def test_legacy_market_surface_not_classified_as_active_or_reactivatable_surface() -> None:
+    """Prove absence of active/tombstone/compatibility classification only."""
+    assert LANDSCAPE_RUNBOOK.is_file()
+    runbook = LANDSCAPE_RUNBOOK.read_text(encoding="utf-8")
+    assert "LEGACY_MARKET_SURFACE_STATUS=REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS" in runbook
+    assert "LEGACY_MARKET_SURFACE_IS_ARCHITECTURAL_COMPONENT=false" in runbook
+    assert "ACTIVE_TOMBSTONE_SURFACE=false" in runbook
+    assert "LEGACY_PRODUCT_TOMBSTONE=" not in runbook
+
+    # Forbidden: classify market_surface itself as a live/compat/fallback surface.
+    # Allowed: deny-lists and explicit REMOVED / not-an-architectural-component wording.
+    classification_near_market_surface = re.compile(
+        r"(?is)market_surface.{0,120}("
+        + "|".join(FORBIDDEN_ACTIVE_CLASSIFICATIONS)
+        + r")|("
+        + "|".join(FORBIDDEN_ACTIVE_CLASSIFICATIONS)
+        + r").{0,120}market_surface"
+    )
+    allowed_context = re.compile(
+        r"(?is)(REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS|"
+        r"not an architectural component|"
+        r"forbidden|"
+        r"rejected|"
+        r"REASON_MARKET_SURFACE_NOT_OBSERVABILITY_TRUTH|"
+        r"Dummy truth|"
+        r"no tombstone)"
+    )
+
+    violations: list[str] = []
+    for root in ARCHITECTURE_SCAN_ROOTS:
+        if not root.exists():
+            continue
+        for pattern in ARCHITECTURE_SCAN_GLOBS:
+            for path in root.rglob(pattern):
+                if path.name == "MARKET_DASHBOARD_REMOVED.md":
+                    # Canonical removal notice may mention "tombstone" only to deny it.
+                    continue
+                if path.name == Path(__file__).name:
+                    continue
+                text = path.read_text(encoding="utf-8")
+                if "market_surface" not in text:
+                    continue
+                for match in classification_near_market_surface.finditer(text):
+                    window = text[max(0, match.start() - 160) : match.end() + 160]
+                    if allowed_context.search(window):
+                        continue
+                    # Deny-list / rejection fixtures are negative controls.
+                    if any(
+                        token in window
+                        for token in (
+                            "FORBIDDEN",
+                            "forbidden",
+                            "rejected",
+                            "reject",
+                            "not_importable",
+                            "DELETED_PACKAGES",
+                            '"market_surface"',
+                            "'market_surface'",
+                        )
+                    ):
+                        continue
+                    violations.append(f"{path.relative_to(REPO)}: {match.group(0)!r}")
+
+    assert violations == [], (
+        "legacy market_surface reclassified as active/compat surface:\n" + "\n".join(violations)
+    )
+
+
+def test_no_productive_market_surface_module_or_template_exists() -> None:
+    assert not (REPO / "src" / "webui" / "market_surface.py").exists()
+    assert not (REPO / "src" / "webui" / "market_surface").exists()
+    assert not (REPO / "docs" / "webui" / "MARKET_SURFACE_V0.md").exists()


### PR DESCRIPTION
## Summary
- Anchors `REMOVED_WITH_NEGATIVE_NON_REGRESSION_GUARDS` as the only allowed status for fully removed legacy `market_surface`.
- Removes ambiguous active “tombstone product/route/chronicle” wording from navigation, taxonomy, runbooks, and removal notice.
- Hardens negative non-regression guards so productive/architecture surfaces cannot classify legacy `market_surface` as TOMBSTONED/DEPRECATED/COMPATIBILITY/FALLBACK/reactivatable.

## Test plan
- [x] `pytest` CONTRACT_FOCUSED targets: taxonomy + chartjs + market_dashboard removal guards (67 passed, 1 skipped)
- [x] docs token policy vs `origin/main`
- [x] docs reference targets
- [x] ruff format/check on changed tests
- [ ] CI confirmation on PR

Capability: `CAPABILITY_PRESENTATION_LEGACY_MARKET_SURFACE_SEMANTIC_CLOSURE_V1`
No trading/runtime/authority/productive path changes.


Made with [Cursor](https://cursor.com)