### PR TITLE
fix(webui): Landscape V2 bootstrap host contract for HTML /market

### DIFF
--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -2,8 +2,11 @@
  * Market Dashboard Landscape V2 — presentation-only client helpers.
  * No fetch mutation, no decision/risk/sizing logic, no write endpoints.
  * Renders materialized OHLCV from SSR/poll JSON only (never fabricates candles).
- * Consumes only local GET /market and GET /api/market/landscape/ohlcv;
- * never calls OKX or any browser-direct network venue.
+ * Canonical Landscape shell host: GET /market is HTML SSR — do not JSON-bootstrap
+ * that document. Continuous refresh uses GET /api/market/landscape/ohlcv only.
+ * Optional supervised hosts may expose JSON at GET /market from a non-shell page;
+ * that host must not be required for the canonical shell contract.
+ * Never calls OKX or any browser-direct network venue.
  *
  * Canonical OHLCV accepted from body.ohlcv and/or body.read_model (and legacy
  * body.browser_payload when present). Candle close is never used as live mark.
@@ -133,6 +136,14 @@
   function clearFailVisible() {
     root.removeAttribute("data-mdl-canonical-fail");
     root.removeAttribute("data-mdl-canonical-fail-reason");
+    var message = root.querySelector("[data-mdl-chart-message]");
+    if (message) {
+      var text = String(message.textContent || "");
+      if (text.indexOf("CANONICAL_DATA_UNAVAILABLE:") === 0) {
+        // Successful poll / SSR recovery must fully clear the fail-visible text.
+        message.textContent = "";
+      }
+    }
   }
 
   function clientDigest(text) {
@@ -975,12 +986,33 @@
     scheduleNext();
   }
 
+  function isCanonicalHtmlShellHostDocument() {
+    // Canonical Landscape shell serves HTML at GET /market. JSON-fetching that
+    // document causes response.json() to fail and falsely paints
+    // CANONICAL_DATA_UNAVAILABLE over working SSR/OHLCV presentation.
+    var pathname =
+      typeof window !== "undefined" && window.location
+        ? String(window.location.pathname || "")
+        : "";
+    if (pathname === "/market") return true;
+    // Non-supervised documents already carry SSR shell truth.
+    return root.getAttribute("data-supervised-presentation-only") !== "true";
+  }
+
   function bootstrapFromCanonicalMarket() {
     var marketPath = root.getAttribute("data-canonical-market-path") || "/market";
     if (marketPath !== "/market") {
       failVisible("forbidden_noncanonical_market_path");
       return Promise.resolve(false);
     }
+    if (isCanonicalHtmlShellHostDocument()) {
+      // Host contract: rely on SSR DOM + /api/market/landscape/ohlcv polling.
+      // Do not presuppose a separate O2 JSON /market host.
+      root.setAttribute("data-mdl-canonical-market-bound", "true");
+      root.setAttribute("data-mdl-canonical-bootstrap-mode", "ssr_html_shell");
+      return Promise.resolve(true);
+    }
+    // Optional supervised host only: JSON /market from a non-shell page.
     return fetch(marketPath, {
       method: "GET",
       credentials: "same-origin",
@@ -989,6 +1021,11 @@
     })
       .then(function (response) {
         if (!response.ok) throw new Error("market_http_" + response.status);
+        var contentType = String(response.headers.get("content-type") || "");
+        if (contentType.indexOf("application/json") === -1) {
+          // Fail closed without JSON-parsing HTML; do not overwrite SSR truth.
+          throw new Error("market_non_json_content_type");
+        }
         return response.json();
       })
       .then(function (body) {
@@ -1030,6 +1067,7 @@
           failVisible("MISSING_SOURCE");
         }
         root.setAttribute("data-mdl-canonical-market-bound", "true");
+        root.setAttribute("data-mdl-canonical-bootstrap-mode", "optional_json_market");
         return true;
       })
       .catch(function (err) {

--- a/tests/ops/test_supervised_graphical_market_landscape_presentation_only_v1.py
+++ b/tests/ops/test_supervised_graphical_market_landscape_presentation_only_v1.py
@@ -276,6 +276,8 @@ def test_js_accepts_canonical_without_browser_payload() -> None:
     assert "CANONICAL_DATA_UNAVAILABLE" in js
     assert "bootstrapFromCanonicalMarket" in js
     assert 'marketPath !== "/market"' in js
+    assert "isCanonicalHtmlShellHostDocument" in js
+    assert "ssr_html_shell" in js
 
 
 def test_js_connection_state_poll_arm_fail_closed_presentation_contract() -> None:

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -1271,3 +1271,131 @@ console.log('CONNECTION_STATE_FAIL_CLOSED_REGRESSIONS_PASS');
         harness_path.unlink(missing_ok=True)
     assert completed.returncode == 0, completed.stderr or completed.stdout
     assert "CONNECTION_STATE_FAIL_CLOSED_REGRESSIONS_PASS" in completed.stdout
+
+
+def test_js_canonical_shell_bootstrap_host_contract_skips_html_json_parse() -> None:
+    """Canonical shell GET /market is HTML; bootstrap must not response.json() it."""
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+    assert "isCanonicalHtmlShellHostDocument" in js
+    assert 'data-mdl-canonical-bootstrap-mode", "ssr_html_shell"' in js
+    assert "ssr_html_shell" in js
+    assert "optional_json_market" in js
+    assert "market_non_json_content_type" in js
+    # Shell-host short-circuit must precede unconditional response.json() on /market.
+    shell_idx = js.index("isCanonicalHtmlShellHostDocument()")
+    bootstrap_idx = js.index("function bootstrapFromCanonicalMarket()")
+    assert bootstrap_idx < shell_idx or "if (isCanonicalHtmlShellHostDocument())" in js
+    boot_fn = js.split("function bootstrapFromCanonicalMarket()", 1)[1].split(
+        "function bootLandscapeClient()", 1
+    )[0]
+    assert "ssr_html_shell" in boot_fn
+    assert "startOhlcvPolling" not in boot_fn  # polling remains in bootLandscapeClient
+    assert 'cache: "no-store"' in js
+    assert "/api/market/landscape/ohlcv" in js
+    assert "SAME_TIMESTAMP_LAST_CANDLE_CHANGE" in js
+    assert "LAST_CANDLE_IN_PLACE" in js
+    assert "FULL_SERIES" in js
+    # clearFailVisible must fully remove CANONICAL_DATA_UNAVAILABLE text.
+    clear_fn = js.split("function clearFailVisible()", 1)[1].split("function ", 1)[0]
+    assert "CANONICAL_DATA_UNAVAILABLE:" in clear_fn
+    assert 'message.textContent = ""' in clear_fn
+
+
+def test_js_canonical_shell_bootstrap_behavioral_no_json_parse_on_html_shell() -> None:
+    """Node proof: shell host bootstrap binds without fetching /market as JSON."""
+    import subprocess
+    import tempfile
+
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+    helpers = _extract_bootstrap_host_contract_helpers(js)
+    harness = f"""
+'use strict';
+var fetchCalls = [];
+var attrs = {{
+  'data-market-landscape-v2': 'true',
+  'data-supervised-presentation-only': 'false',
+  'data-canonical-market-path': '/market',
+  'data-mdl-data-connection-state': 'HEALTHY',
+}};
+var message = {{ textContent: 'Primary chart bound to materialized OKX OHLCV readmodel.' }};
+var root = {{
+  getAttribute: function (name) {{
+    return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null;
+  }},
+  setAttribute: function (name, value) {{ attrs[name] = String(value); }},
+  removeAttribute: function (name) {{ delete attrs[name]; }},
+  querySelector: function (sel) {{
+    if (sel === '[data-mdl-chart-message]') return message;
+    return null;
+  }},
+}};
+var window = {{ location: {{ pathname: '/market' }} }};
+function fetch(url, opts) {{
+  fetchCalls.push({{ url: url, opts: opts }});
+  return Promise.reject(new Error('fetch_must_not_run_on_html_shell'));
+}}
+{helpers}
+function assert(cond, msg) {{
+  if (!cond) throw new Error(msg || 'assert failed');
+}}
+assert(isCanonicalHtmlShellHostDocument() === true, 'shell pathname must detect HTML host');
+bootstrapFromCanonicalMarket().then(function (ok) {{
+  assert(ok === true, 'bootstrap must succeed');
+  assert(fetchCalls.length === 0, 'must not fetch /market JSON on HTML shell');
+  assert(attrs['data-mdl-canonical-market-bound'] === 'true', 'must mark bound');
+  assert(attrs['data-mdl-canonical-bootstrap-mode'] === 'ssr_html_shell', 'mode');
+  assert(!Object.prototype.hasOwnProperty.call(attrs, 'data-mdl-canonical-fail'), 'no fail');
+  assert(message.textContent.indexOf('CANONICAL_DATA_UNAVAILABLE') === -1, 'ssr msg');
+  message.textContent = 'CANONICAL_DATA_UNAVAILABLE: market_bootstrap_failed';
+  root.setAttribute('data-mdl-canonical-fail', 'true');
+  clearFailVisible();
+  assert(!Object.prototype.hasOwnProperty.call(attrs, 'data-mdl-canonical-fail'), 'cleared');
+  assert(message.textContent === '', 'error text fully cleared');
+  // Supervised optional path still allowed to fetch JSON /market.
+  attrs['data-supervised-presentation-only'] = 'true';
+  delete attrs['data-mdl-canonical-market-bound'];
+  delete attrs['data-mdl-canonical-bootstrap-mode'];
+  window.location.pathname = '/landscape';
+  assert(isCanonicalHtmlShellHostDocument() === false, 'supervised landscape may JSON bootstrap');
+  console.log('BOOTSTRAP_HOST_CONTRACT_BEHAVIORAL_PASS');
+}}).catch(function (err) {{
+  console.error(String(err && err.stack || err));
+  process.exit(1);
+}});
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False, encoding="utf-8") as handle:
+        handle.write(harness)
+        harness_path = Path(handle.name)
+    try:
+        completed = subprocess.run(
+            ["node", str(harness_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    finally:
+        harness_path.unlink(missing_ok=True)
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    assert "BOOTSTRAP_HOST_CONTRACT_BEHAVIORAL_PASS" in completed.stdout
+
+
+def _extract_bootstrap_host_contract_helpers(js: str) -> str:
+    """Extract clear/detect/bootstrap helpers for Node behavioral proof."""
+    chunks: list[str] = []
+    for name in (
+        "function clearFailVisible()",
+        "function isCanonicalHtmlShellHostDocument()",
+        "function bootstrapFromCanonicalMarket()",
+    ):
+        assert name in js, name
+        start = js.index(name)
+        rest = js[start + len(name) :]
+        end_rel = rest.find("\n  function ")
+        assert end_rel > 0, name
+        chunks.append(js[start : start + len(name) + end_rel].rstrip() + "\n")
+    stubs = """
+function bindCanonicalIdentityFromMarket() { return false; }
+function applyPollPayload() { return; }
+"""
+    return stubs + "\n".join(chunks)

--- a/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
@@ -51,8 +51,10 @@ def client() -> TestClient:
 def test_get_market_returns_200_with_landmarks(client: TestClient) -> None:
     response = client.get("/market")
     assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
     html = response.text
     assert 'data-market-landscape-v2="true"' in html
+    assert "application/json" not in response.headers.get("content-type", "")
     for landmark in LANDMARKS:
         assert landmark in html, landmark
     assert "PHASE_5_CAPABILITY_7_PRODUCT_MATURITY_TECHNICAL" in html


### PR DESCRIPTION
## Summary
- Fixes canonical Landscape shell bootstrap so `GET /market` (HTML SSR) is no longer JSON-parsed client-side.
- Prevents false `CANONICAL_DATA_UNAVAILABLE` overwrite of working SSR/OHLCV presentation.
- Preserves 3s OHLCV polling via `/api/market/landscape/ohlcv`, update classes, and honest MISSING_SOURCE/NOT_BOUND presentation.
- Optional supervised JSON `/market` path remains available but is not required.

## Capability
`CAPABILITY_PRESENTATION_MARKET_LANDSCAPE_CANONICAL_BOOTSTRAP_HOST_CONTRACT_FIX_V1`

## Test plan
- [x] Shell `/market` returns `text/html`
- [x] JS host-contract static + Node behavioral proofs (no HTML JSON parse; fail text cleared on recovery)
- [x] Landscape continuous refresh / shell / architecture-guard / contracts / supervised presentation tests
- [x] PR_BOUNDED_FULL selector targets
- [ ] Required GitHub checks green


Made with [Cursor](https://cursor.com)