### PR TITLE
fix(webui): Playwright chrome-channel lifecycle close handle

### DIFF
--- a/docs/webui/REVIEW_SERVER_HARNESS_V1.md
+++ b/docs/webui/REVIEW_SERVER_HARNESS_V1.md
@@ -85,8 +85,8 @@ Both paths share the same ASGI target, localhost bind, no `--reload`, and proces
 - Headed Playwright sessions must use `managed_chrome_channel` /
   `ChromeChannelHandle` (guaranteed idempotent `close()`, optional
   SIGINT/SIGTERM cleanup). Approved keepalive entrypoint:
-  `scripts/webui/headed_playwright_keepalive_v1.py <url>`.
-- Normal operator browser open remains `./scripts/webui/review_server.sh open`
+  `scripts&#47;webui&#47;headed_playwright_keepalive_v1.py <url>`.
+- Normal operator browser open remains `./scripts&#47;webui&#47;review_server.sh open`
   → `open -a "Google Chrome"` (not Playwright-managed).
 - Do not create ad-hoc keepalive scripts without a close path
   (`browser.close()` + owned `playwright.stop()` / Handle `__exit__`).

--- a/docs/webui/REVIEW_SERVER_HARNESS_V1.md
+++ b/docs/webui/REVIEW_SERVER_HARNESS_V1.md
@@ -80,6 +80,17 @@ Market Dashboard removed — see [`MARKET_DASHBOARD_REMOVED.md`](./MARKET_DASHBO
 
 Both paths share the same ASGI target, localhost bind, no `--reload`, and process-identity rules.
 
+## Playwright chrome-channel lifecycle
+
+- Headed Playwright sessions must use `managed_chrome_channel` /
+  `ChromeChannelHandle` (guaranteed idempotent `close()`, optional
+  SIGINT/SIGTERM cleanup). Approved keepalive entrypoint:
+  `scripts/webui/headed_playwright_keepalive_v1.py <url>`.
+- Normal operator browser open remains `./scripts/webui/review_server.sh open`
+  → `open -a "Google Chrome"` (not Playwright-managed).
+- Do not create ad-hoc keepalive scripts without a close path
+  (`browser.close()` + owned `playwright.stop()` / Handle `__exit__`).
+
 ## Explicit non-goals
 
 - No `uvicorn --reload` in the review start path

--- a/scripts/webui/headed_playwright_keepalive_v1.py
+++ b/scripts/webui/headed_playwright_keepalive_v1.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Headed Playwright keepalive with a guaranteed close contract.
+
+CAPABILITY_ID=WEBUI_PLAYWRIGHT_CHROME_CHANNEL_LIFECYCLE_CLOSE_V1
+
+Uses managed_chrome_channel only (owns Playwright + opt-in SIGINT/SIGTERM close).
+Does not touch review_server.sh::chrome_open / open -a "Google Chrome".
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_SCRIPTS_WEBUI = Path(__file__).resolve().parent
+if str(_SCRIPTS_WEBUI) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_WEBUI))
+
+from review_server_playwright_webserver_v1 import (  # noqa: E402
+    PRIMARY_BROWSER,
+    PRIMARY_PLAYWRIGHT_CHANNEL,
+    managed_chrome_channel,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Open a headed Playwright chrome-channel session and keep it alive "
+            "until SIGINT/SIGTERM, then close browser and Playwright."
+        )
+    )
+    parser.add_argument(
+        "url",
+        help="Local review URL to open (e.g. http://127.0.0.1:8000/)",
+    )
+    parser.add_argument(
+        "--goto-timeout-ms",
+        type=int,
+        default=60_000,
+        help="page.goto timeout in milliseconds (default: 60000)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    with managed_chrome_channel(
+        headless=False,
+        install_termination_handlers=True,
+    ) as handle:
+        page = handle.browser.new_page()
+        page.goto(args.url, wait_until="domcontentloaded", timeout=args.goto_timeout_ms)
+        print(
+            "HEADED_KEEPALIVE_READY="
+            f"url={args.url} "
+            f"browser={handle.report.get('BROWSER_ACTUAL')} "
+            f"channel={PRIMARY_PLAYWRIGHT_CHANNEL} "
+            f"primary={PRIMARY_BROWSER} "
+            f"owns_playwright={handle.owns_playwright}",
+            flush=True,
+        )
+        print("WAITING_FOR_SIGINT_OR_SIGTERM", flush=True)
+        handle.wait_until_closed()
+        print("HEADED_KEEPALIVE_CLOSED", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/webui/review_server_playwright_webserver_v1.py
+++ b/scripts/webui/review_server_playwright_webserver_v1.py
@@ -22,8 +22,10 @@ from scripts/webui/_dashboard_chrome_playwright_harness_v1.py.
 from __future__ import annotations
 
 import os
+import signal
 import socket
 import subprocess
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -263,3 +265,150 @@ def launch_chrome_channel(playwright: Any, *, headless: bool = True) -> tuple[An
         report["REAL_CHROME_VERIFIED"] = False
         report["launch_error"] = f"{type(exc).__name__}: {exc}"
         return browser, report
+
+
+class ChromeChannelHandle:
+    """Idempotent lifecycle owner for a Playwright chrome-channel browser.
+
+    Does not change launch_chrome_channel's (browser, report) contract.
+    Signal handlers are opt-in via install_termination_handlers=True only.
+    """
+
+    def __init__(
+        self,
+        browser: Any,
+        report: dict[str, Any],
+        *,
+        playwright: Any | None = None,
+        owns_playwright: bool = False,
+        install_termination_handlers: bool = False,
+    ) -> None:
+        self.browser = browser
+        self.report = report
+        self.playwright = playwright
+        self.owns_playwright = bool(owns_playwright)
+        self._closed = False
+        self._closing = False
+        self._stop_event = threading.Event()
+        self._handlers_installed = False
+        self._prev_sigint: Any = None
+        self._prev_sigterm: Any = None
+        if install_termination_handlers:
+            self._install_termination_handlers()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def close(self) -> None:
+        """Close browser (and owned playwright) idempotently."""
+        if self._closed or self._closing:
+            return
+        self._closing = True
+        errors: list[BaseException] = []
+        try:
+            try:
+                if self.browser is not None:
+                    self.browser.close()
+            except BaseException as exc:  # noqa: BLE001 — continue to playwright stop
+                errors.append(exc)
+            try:
+                if self.owns_playwright and self.playwright is not None:
+                    self.playwright.stop()
+            except BaseException as exc:  # noqa: BLE001 — collect after browser close
+                errors.append(exc)
+        finally:
+            self._restore_termination_handlers()
+            self._closed = True
+            self._closing = False
+            self._stop_event.set()
+        if errors:
+            raise errors[0]
+
+    def wait_until_closed(self, timeout: float | None = None) -> bool:
+        """Block until close() runs (e.g. via SIGINT/SIGTERM). Returns True if closed."""
+        return self._stop_event.wait(timeout)
+
+    def __enter__(self) -> ChromeChannelHandle:
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        try:
+            self.close()
+        except BaseException:
+            if exc_type is None:
+                raise
+            # Prefer the original with-block exception; do not swallow it.
+        return False
+
+    def _install_termination_handlers(self) -> None:
+        if self._handlers_installed:
+            return
+        self._prev_sigint = signal.getsignal(signal.SIGINT)
+        self._prev_sigterm = signal.getsignal(signal.SIGTERM)
+
+        def _handler(signum: int, frame: Any) -> None:
+            # Close restores previous handlers so later signals use the prior
+            # disposition. Do not invoke previous handlers here: that would
+            # re-enter pytest/default KeyboardInterrupt paths and can skip a
+            # clean wait_until_closed() exit.
+            try:
+                self.close()
+            except BaseException:  # noqa: BLE001 — signal path must stay non-fatal
+                pass
+
+        signal.signal(signal.SIGINT, _handler)
+        signal.signal(signal.SIGTERM, _handler)
+        self._handlers_installed = True
+
+    def _restore_termination_handlers(self) -> None:
+        if not self._handlers_installed:
+            return
+        try:
+            if self._prev_sigint is not None:
+                signal.signal(signal.SIGINT, self._prev_sigint)
+            if self._prev_sigterm is not None:
+                signal.signal(signal.SIGTERM, self._prev_sigterm)
+        finally:
+            self._handlers_installed = False
+
+
+def managed_chrome_channel(
+    playwright: Any | None = None,
+    *,
+    headless: bool = True,
+    owns_playwright: bool | None = None,
+    install_termination_handlers: bool = False,
+) -> ChromeChannelHandle:
+    """Launch chrome-channel browser wrapped in ChromeChannelHandle.
+
+    Defaults preserve existing test/CI behavior:
+      - headless=True
+      - install_termination_handlers=False
+      - when playwright is provided: owns_playwright=False
+      - when playwright is omitted: starts sync_playwright() and owns_playwright=True
+    """
+    started_here = False
+    pw = playwright
+    if pw is None:
+        from playwright.sync_api import sync_playwright
+
+        pw = sync_playwright().start()
+        started_here = True
+
+    if owns_playwright is None:
+        owned = started_here
+    else:
+        owned = bool(owns_playwright)
+        if started_here:
+            # A playwright we started must always be stopped by this handle.
+            owned = True
+
+    browser, report = launch_chrome_channel(pw, headless=headless)
+    return ChromeChannelHandle(
+        browser,
+        report,
+        playwright=pw,
+        owns_playwright=owned,
+        install_termination_handlers=install_termination_handlers,
+    )

--- a/tests/webui/test_review_server_harness_v1.py
+++ b/tests/webui/test_review_server_harness_v1.py
@@ -452,6 +452,248 @@ def test_playwright_webserver_module_contracts() -> None:
             os.environ["CI"] = old_ci
 
 
+def _load_playwright_webserver_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "review_server_playwright_webserver_v1", PLAYWRIGHT_WEBSERVER
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeBrowser:
+    def __init__(self) -> None:
+        self.close_calls = 0
+        self.close_error: Exception | None = None
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self.close_error is not None:
+            raise self.close_error
+
+
+class _FakePlaywright:
+    def __init__(self) -> None:
+        self.stop_calls = 0
+        self.stop_error: Exception | None = None
+        self.chromium = self
+
+    def launch(self, *args: object, **kwargs: object) -> _FakeBrowser:
+        return _FakeBrowser()
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+        if self.stop_error is not None:
+            raise self.stop_error
+
+
+def test_chrome_channel_handle_context_manager_closes_browser() -> None:
+    mod = _load_playwright_webserver_module()
+    browser = _FakeBrowser()
+    with mod.ChromeChannelHandle(browser, {"ok": True}, owns_playwright=False) as handle:
+        assert handle.browser is browser
+        assert handle.closed is False
+    assert browser.close_calls == 1
+    assert handle.closed is True
+
+
+def test_chrome_channel_handle_close_is_idempotent() -> None:
+    mod = _load_playwright_webserver_module()
+    browser = _FakeBrowser()
+    handle = mod.ChromeChannelHandle(browser, {}, owns_playwright=False)
+    handle.close()
+    handle.close()
+    assert browser.close_calls == 1
+    assert handle.closed is True
+
+
+def test_chrome_channel_handle_closes_on_with_block_exception() -> None:
+    mod = _load_playwright_webserver_module()
+    browser = _FakeBrowser()
+    with pytest.raises(RuntimeError, match="boom"):
+        with mod.ChromeChannelHandle(browser, {}, owns_playwright=False):
+            raise RuntimeError("boom")
+    assert browser.close_calls == 1
+
+
+def test_chrome_channel_handle_stops_playwright_only_when_owned() -> None:
+    mod = _load_playwright_webserver_module()
+    owned_browser = _FakeBrowser()
+    owned_pw = _FakePlaywright()
+    with mod.ChromeChannelHandle(owned_browser, {}, playwright=owned_pw, owns_playwright=True):
+        pass
+    assert owned_browser.close_calls == 1
+    assert owned_pw.stop_calls == 1
+
+    external_browser = _FakeBrowser()
+    external_pw = _FakePlaywright()
+    with mod.ChromeChannelHandle(
+        external_browser, {}, playwright=external_pw, owns_playwright=False
+    ):
+        pass
+    assert external_browser.close_calls == 1
+    assert external_pw.stop_calls == 0
+
+
+def test_chrome_channel_handle_browser_close_error_still_stops_owned_playwright() -> None:
+    mod = _load_playwright_webserver_module()
+    browser = _FakeBrowser()
+    browser.close_error = RuntimeError("browser-close-failed")
+    pw = _FakePlaywright()
+    handle = mod.ChromeChannelHandle(browser, {}, playwright=pw, owns_playwright=True)
+    with pytest.raises(RuntimeError, match="browser-close-failed"):
+        handle.close()
+    assert browser.close_calls == 1
+    assert pw.stop_calls == 1
+    assert handle.closed is True
+
+
+def test_chrome_channel_signal_handlers_opt_in_only() -> None:
+    import signal
+
+    mod = _load_playwright_webserver_module()
+    browser = _FakeBrowser()
+    prev_int = signal.getsignal(signal.SIGINT)
+    prev_term = signal.getsignal(signal.SIGTERM)
+    handle = mod.ChromeChannelHandle(
+        browser, {}, owns_playwright=False, install_termination_handlers=False
+    )
+    assert signal.getsignal(signal.SIGINT) is prev_int
+    assert signal.getsignal(signal.SIGTERM) is prev_term
+    handle.close()
+
+    handle2 = mod.ChromeChannelHandle(
+        browser, {}, owns_playwright=False, install_termination_handlers=True
+    )
+    assert signal.getsignal(signal.SIGINT) is not prev_int
+    assert signal.getsignal(signal.SIGTERM) is not prev_term
+    handle2.close()
+    assert signal.getsignal(signal.SIGINT) is prev_int
+    assert signal.getsignal(signal.SIGTERM) is prev_term
+
+
+def test_chrome_channel_signal_handlers_call_close() -> None:
+    import signal
+
+    mod = _load_playwright_webserver_module()
+    browser = _FakeBrowser()
+    handle = mod.ChromeChannelHandle(
+        browser, {}, owns_playwright=False, install_termination_handlers=True
+    )
+    assert browser.close_calls == 0
+    signal.getsignal(signal.SIGINT)(signal.SIGINT, None)  # type: ignore[misc, operator]
+    assert browser.close_calls == 1
+    assert handle.closed is True
+
+    browser2 = _FakeBrowser()
+    handle2 = mod.ChromeChannelHandle(
+        browser2, {}, owns_playwright=False, install_termination_handlers=True
+    )
+    signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)  # type: ignore[misc, operator]
+    assert browser2.close_calls == 1
+    assert handle2.closed is True
+
+
+def test_launch_chrome_channel_remains_tuple_unpackable(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = _load_playwright_webserver_module()
+    fake_browser = _FakeBrowser()
+
+    class _Chromium:
+        def launch(self, *args: object, **kwargs: object) -> _FakeBrowser:
+            return fake_browser
+
+    class _Pw:
+        chromium = _Chromium()
+
+    browser, report = mod.launch_chrome_channel(_Pw(), headless=True)
+    assert browser is fake_browser
+    assert isinstance(report, dict)
+    assert report["PRIMARY_PLAYWRIGHT_CHANNEL"] == "chrome"
+    assert report["PRIMARY_BROWSER"] == "GOOGLE_CHROME"
+    assert isinstance((browser, report), tuple)
+    assert len((browser, report)) == 2
+
+
+def test_managed_chrome_channel_wraps_external_playwright(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = _load_playwright_webserver_module()
+    fake_browser = _FakeBrowser()
+    fake_pw = _FakePlaywright()
+
+    def _fake_launch(playwright: object, *, headless: bool = True):
+        return fake_browser, {
+            "PRIMARY_BROWSER": "GOOGLE_CHROME",
+            "PRIMARY_PLAYWRIGHT_CHANNEL": "chrome",
+            "BROWSER_ACTUAL": "GOOGLE_CHROME",
+            "CHROMIUM_FALLBACK_USED": False,
+            "REAL_CHROME_VERIFIED": True,
+            "headless": headless,
+        }
+
+    monkeypatch.setattr(mod, "launch_chrome_channel", _fake_launch)
+    with mod.managed_chrome_channel(fake_pw, headless=True) as handle:
+        assert handle.browser is fake_browser
+        assert handle.playwright is fake_pw
+        assert handle.owns_playwright is False
+        assert handle.report["PRIMARY_PLAYWRIGHT_CHANNEL"] == "chrome"
+    assert fake_browser.close_calls == 1
+    assert fake_pw.stop_calls == 0
+
+
+def test_headed_keepalive_entrypoint_cli_contract() -> None:
+    keepalive = REPO_ROOT / "scripts" / "webui" / "headed_playwright_keepalive_v1.py"
+    assert keepalive.is_file()
+    text = keepalive.read_text(encoding="utf-8")
+    assert "managed_chrome_channel" in text
+    assert "install_termination_handlers=True" in text
+    assert "headless=False" in text
+    assert "sync_playwright().start()" not in text
+    assert "while True" not in text
+    assert "chrome_open(" not in text
+    assert "def chrome_open" not in text
+    assert "wait_until_closed" in text
+
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("headed_playwright_keepalive_v1", keepalive)
+    assert spec and spec.loader
+    # Import without executing main; only validate parser wiring.
+    # Avoid importing review helper side effects beyond module load.
+    module_source = text
+    assert "def build_parser()" in module_source
+    assert "def main(" in module_source
+
+    # Lightweight argparse contract without launching a browser.
+    sys_path_scripts = str(REPO_ROOT / "scripts" / "webui")
+    if sys_path_scripts not in sys.path:
+        sys.path.insert(0, sys_path_scripts)
+    # Parse via a tiny exec of build_parser only after stubbing managed import.
+    import types
+
+    stub = types.ModuleType("review_server_playwright_webserver_v1")
+    stub.PRIMARY_BROWSER = "GOOGLE_CHROME"  # type: ignore[attr-defined]
+    stub.PRIMARY_PLAYWRIGHT_CHANNEL = "chrome"  # type: ignore[attr-defined]
+
+    def _unused_managed(*args: object, **kwargs: object):  # pragma: no cover
+        raise AssertionError("browser must not start in CLI contract test")
+
+    stub.managed_chrome_channel = _unused_managed  # type: ignore[attr-defined]
+    sys.modules["review_server_playwright_webserver_v1"] = stub
+    try:
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        parser = mod.build_parser()
+        ns = parser.parse_args(["http://127.0.0.1:8000/"])
+        assert ns.url == "http://127.0.0.1:8000/"
+        assert ns.goto_timeout_ms == 60_000
+    finally:
+        sys.modules.pop("review_server_playwright_webserver_v1", None)
+
+
 def test_playwright_webserver_smoke_and_no_external_network(
     tmp_path: Path, isolated_port: int
 ) -> None:

--- a/tests/webui/test_review_server_harness_v1.py
+++ b/tests/webui/test_review_server_harness_v1.py
@@ -682,7 +682,10 @@ def test_headed_keepalive_entrypoint_cli_contract() -> None:
         raise AssertionError("browser must not start in CLI contract test")
 
     stub.managed_chrome_channel = _unused_managed  # type: ignore[attr-defined]
-    sys.modules["review_server_playwright_webserver_v1"] = stub
+    module_key = "review_server_playwright_webserver_v1"
+    previous_module = sys.modules.get(module_key)
+    had_previous_module = module_key in sys.modules
+    sys.modules[module_key] = stub
     try:
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
@@ -691,7 +694,10 @@ def test_headed_keepalive_entrypoint_cli_contract() -> None:
         assert ns.url == "http://127.0.0.1:8000/"
         assert ns.goto_timeout_ms == 60_000
     finally:
-        sys.modules.pop("review_server_playwright_webserver_v1", None)
+        if had_previous_module:
+            sys.modules[module_key] = previous_module
+        else:
+            sys.modules.pop(module_key, None)
 
 
 def test_playwright_webserver_smoke_and_no_external_network(


### PR DESCRIPTION
## Summary
- Add `ChromeChannelHandle` + `managed_chrome_channel` with idempotent close and opt-in SIGINT/SIGTERM cleanup.
- Preserve `launch_chrome_channel(...) -> (browser, report)` contract unchanged.
- Add versioned headed keepalive entrypoint `scripts/webui/headed_playwright_keepalive_v1.py` that always closes via the managed handle.
- Document headed Playwright lifecycle vs normal `open -a "Google Chrome"` operator path.

## Test plan
- [x] Focused unit contracts in `tests/webui/test_review_server_harness_v1.py` (mocks; no live browser/server)
- [x] `ruff format --check` / `ruff check` on changed Python files
- [ ] CI FOCUSED path confirmation on PR
- [ ] Owner merge GO (do not auto-merge)


Made with [Cursor](https://cursor.com)