### PR TITLE
feat(webui): PT1M OHLCV live repaint for market dashboard

### DIFF
--- a/scripts/ops/refresh_okx_market_dashboard_v1.py
+++ b/scripts/ops/refresh_okx_market_dashboard_v1.py
@@ -218,7 +218,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("--market-type", default="swap")
     parser.add_argument("--settle-ccy", default="USDT")
     parser.add_argument("--exclude-underlying", default="BTC")
-    parser.add_argument("--bar", default="1H")
+    parser.add_argument("--bar", default="PT1M")
     parser.add_argument("--verify-manifest", action="store_true", default=True)
     parser.add_argument("--no-verify-manifest", action="store_false", dest="verify_manifest")
     parser.add_argument("--materialize-readmodels", action="store_true", default=True)

--- a/src/ops/okx_public_market_data_client_v1.py
+++ b/src/ops/okx_public_market_data_client_v1.py
@@ -32,7 +32,7 @@ ALLOWED_PATHS = frozenset(
         "/api/v5/market/history-candles",
         "/api/v5/market/candles",
         # Public recent trades (no auth). Used server-side only to revise the
-        # selected instrument's open PT1H candle from authentic prints.
+        # selected instrument's open candle tip from authentic prints (PT1H/PT1M).
         "/api/v5/market/trades",
     }
 )

--- a/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
+++ b/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
@@ -32,21 +32,35 @@ OHLCV_SCHEMA = "okx_selected_instrument_ohlcv_readmodel.v1"
 OHLCV_RELATIVE_PATH = "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
 UNIVERSE_SELECTION_RELATIVE_PATH = "readmodels/universe_selection_readmodel.v1.json"
 REFRESH_LOCK_NAME = ".okx_selected_instrument_ohlcv_refresh.lock"
-DEFAULT_BAR = "1H"
+# Dashboard presentation target: authentic OKX 1m candles + public-trade open tip.
+DEFAULT_BAR = "PT1M"
 DEFAULT_LIMIT = 100
 DEFAULT_TRADES_LIMIT = 100
 MAX_APPLIED_TRADE_IDS = 500
+# Explicit dashboard interval allowlist only — unknown tokens fail closed.
+# Maps normalized input → (okx_bar, canonical_interval_id, duration_seconds).
+DASHBOARD_OHLCV_INTERVAL_ALLOWLIST_V1: dict[str, tuple[str, str, int]] = {
+    "1H": ("1H", "PT1H", 3600),
+    "PT1H": ("1H", "PT1H", 3600),
+    "60M": ("1H", "PT1H", 3600),
+    "1M": ("1m", "PT1M", 60),
+    "PT1M": ("1m", "PT1M", 60),
+}
 # Recent candles endpoint includes the incomplete open candle (confirm=0).
 OKX_CANDLES_PATH = "/api/v5/market/candles"
-# Public recent trades — server-side only; revises the active open PT1H candle.
+# Public recent trades — server-side only; revises the active open candle tip.
 OKX_TRADES_PATH = "/api/v5/market/trades"
 OKX_MARK_PRICE_PATH = "/api/v5/public/mark-price"
 LIVE_MARK_PROJECTION_V1 = "okx_ohlcv_live_mark_v1"
-OPEN_CANDLE_LIVE_SOURCE_V1 = "okx_public_trades_into_pt1h_v1"
+OPEN_CANDLE_LIVE_SOURCE_PT1H_V1 = "okx_public_trades_into_pt1h_v1"
+OPEN_CANDLE_LIVE_SOURCE_PT1M_V1 = "okx_public_trades_into_pt1m_v1"
+# Backward-compatible alias (PT1H path).
+OPEN_CANDLE_LIVE_SOURCE_V1 = OPEN_CANDLE_LIVE_SOURCE_PT1H_V1
 # OKX SWAP trade `sz` is contract count (not quote/base currency).
 TRADE_VOLUME_UNIT = "contracts"
-# Bounded dashboard refresh: visible intrabar feedback ≤5s under normal availability.
-DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS = 3
+# Bounded dashboard refresh: open PT1M tip repaints at least once per second.
+DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS = 1
+TARGET_PRESENTATION_REFRESH_SECONDS = 1
 
 
 def o4_derived_authority_stamp_v1() -> dict[str, object]:
@@ -61,6 +75,25 @@ def o4_derived_authority_stamp_v1() -> dict[str, object]:
 
 class OkxOhlcvReadmodelError(ValueError):
     """Fail-closed OHLCV materialization error."""
+
+
+def normalize_dashboard_ohlcv_interval_v1(raw: str) -> tuple[str, str, int]:
+    """Accept only the explicit dashboard OHLCV allowlist.
+
+    Returns ``(okx_bar, canonical_interval_id, duration_seconds)``.
+    """
+    token = str(raw or "").strip().upper()
+    if token not in DASHBOARD_OHLCV_INTERVAL_ALLOWLIST_V1:
+        raise OkxOhlcvReadmodelError(f"UNSUPPORTED_BAR_INTERVAL:{raw}")
+    return DASHBOARD_OHLCV_INTERVAL_ALLOWLIST_V1[token]
+
+
+def open_candle_live_source_for_interval_v1(interval_id: str) -> str:
+    if interval_id == "PT1M":
+        return OPEN_CANDLE_LIVE_SOURCE_PT1M_V1
+    if interval_id == "PT1H":
+        return OPEN_CANDLE_LIVE_SOURCE_PT1H_V1
+    raise OkxOhlcvReadmodelError(f"UNSUPPORTED_BAR_INTERVAL:{interval_id}")
 
 
 @dataclass(frozen=True)
@@ -379,9 +412,11 @@ def parse_okx_public_trades_v1(rows: Sequence[Any]) -> list[OkxPublicTradeV1]:
 
 def _bucket_start_utc(ts_iso: str, *, interval_seconds: int) -> datetime:
     dt = datetime.fromisoformat(ts_iso.replace("Z", "+00:00")).astimezone(timezone.utc)
-    if interval_seconds != 3600:
-        raise OkxOhlcvReadmodelError("UNSUPPORTED_TRADE_BUCKET_INTERVAL")
-    return dt.replace(minute=0, second=0, microsecond=0)
+    if interval_seconds == 3600:
+        return dt.replace(minute=0, second=0, microsecond=0)
+    if interval_seconds == 60:
+        return dt.replace(second=0, microsecond=0)
+    raise OkxOhlcvReadmodelError("UNSUPPORTED_TRADE_BUCKET_INTERVAL")
 
 
 def apply_okx_public_trades_to_open_candle_v1(
@@ -391,19 +426,23 @@ def apply_okx_public_trades_to_open_candle_v1(
     previously_applied_trade_ids: Sequence[str] | None = None,
     interval_seconds: int = 3600,
 ) -> tuple[list[OhlcvBarV1], str, list[str], dict[str, Any]]:
-    """Revise the active PT1H candle from authentic OKX public trades.
+    """Revise the active open candle from authentic OKX public trades.
 
-    Bootstrap rule: when no trade IDs were applied yet, seed IDs already present in
-    the current bucket without mutating geometry (candle bootstrap already priced
-    them). Subsequent new trade IDs revise the open tip:
+    Supports PT1H (3600s) and PT1M (60s) UTC buckets only. Empty trade seconds
+    never invent candles. Bootstrap rule: when no trade IDs were applied yet,
+    seed IDs already present in the current bucket without mutating geometry
+    (candle bootstrap already priced them). Subsequent new trade IDs revise the
+    open tip:
 
     - open preserved from candle bootstrap (or first trade when appending a bucket)
     - high = max(previous high, trade price)
     - low = min(previous low, trade price)
-    - close = newest applied trade price
+    - close = newest applied trade price (deterministic sort order)
     - volume += trade size (OKX SWAP ``sz`` = contracts)
     - closed historical candles are never rewritten
     """
+    if interval_seconds not in {60, 3600}:
+        raise OkxOhlcvReadmodelError("UNSUPPORTED_TRADE_BUCKET_INTERVAL")
     if not bars:
         raise OkxOhlcvReadmodelError("TRADE_REDUCE_EMPTY_BARS")
     working = [_as_ohlcv_bar(b) for b in bars]
@@ -415,6 +454,7 @@ def apply_okx_public_trades_to_open_candle_v1(
         "new_trade_count": 0,
         "seeded": False,
         "trade_volume_unit": TRADE_VOLUME_UNIT,
+        "interval_seconds": interval_seconds,
     }
     if not trades:
         return working, "NO_OP", sorted(applied)[-MAX_APPLIED_TRADE_IDS:], meta
@@ -455,7 +495,7 @@ def apply_okx_public_trades_to_open_candle_v1(
             continue
 
         if trade_dt >= tip_end:
-            # Next PT1H bucket from an authentic trade print.
+            # Next interval bucket from an authentic trade print.
             bucket_ts = _bucket_start_utc(trade.ts, interval_seconds=interval_seconds)
             # Only append when the trade lands in the immediate next bucket (or later
             # empty buckets advanced one-at-a-time from the tip).
@@ -524,8 +564,12 @@ def apply_okx_public_trades_to_open_candle_v1(
 
 def parse_okx_history_candles(
     rows: Sequence[Sequence[Any]],
+    *,
+    interval_seconds: int = 3600,
 ) -> tuple[list[OhlcvBarV1], list[str]]:
     """Parse OKX candle rows: [ts,o,h,l,c,vol,volCcy,volCcyQuote,confirm]."""
+    if interval_seconds not in {60, 3600}:
+        raise OkxOhlcvReadmodelError("UNSUPPORTED_BAR_INTERVAL")
     bars: list[OhlcvBarV1] = []
     reasons: list[str] = []
     seen_ts: set[str] = set()
@@ -569,15 +613,15 @@ def parse_okx_history_candles(
             )
         )
     bars.sort(key=lambda b: b.ts)
-    # Gap detection for PT1H closed bars only.
+    # Gap detection for closed bars of the requested interval only.
     gap_count = 0
     closed = [b for b in bars if b.confirm]
     for prev, cur in zip(closed, closed[1:]):
         prev_dt = datetime.fromisoformat(prev.ts.replace("Z", "+00:00"))
         cur_dt = datetime.fromisoformat(cur.ts.replace("Z", "+00:00"))
-        delta_h = (cur_dt - prev_dt).total_seconds() / 3600.0
-        if abs(delta_h - 1.0) > 1e-9:
-            gap_count += int(max(0, round(delta_h - 1.0)))
+        delta = (cur_dt - prev_dt).total_seconds() / float(interval_seconds)
+        if abs(delta - 1.0) > 1e-9:
+            gap_count += int(max(0, round(delta - 1.0)))
     return bars, [f"GAP_COUNT:{gap_count}", *reasons]
 
 
@@ -603,9 +647,8 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
             raise OkxOhlcvReadmodelError("SELECTION_IDENTITY_MISMATCH")
     if "BTC" in selected_instrument.upper().split("-"):
         raise OkxOhlcvReadmodelError("BTC_EXCLUDED")
-    if bar.upper() not in {"1H", "PT1H"}:
-        raise OkxOhlcvReadmodelError("UNSUPPORTED_BAR_INTERVAL")
-    okx_bar = "1H"
+    okx_bar, interval_id, interval_seconds = normalize_dashboard_ohlcv_interval_v1(bar)
+    open_candle_live_source = open_candle_live_source_for_interval_v1(interval_id)
 
     http = client or OkxPublicMarketDataClientV1()
     envelope = http.get_json(
@@ -620,7 +663,7 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
     data = payload.get("data")
     if not isinstance(data, list) or not data:
         raise OkxOhlcvReadmodelError("OHLCV_EMPTY")
-    incoming_bars, notes = parse_okx_history_candles(data)
+    incoming_bars, notes = parse_okx_history_candles(data, interval_seconds=interval_seconds)
     if not incoming_bars:
         raise OkxOhlcvReadmodelError("OHLCV_PARSE_EMPTY")
 
@@ -630,10 +673,13 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         isinstance(existing_doc, Mapping)
         and str(existing_doc.get("instrument_id") or "") == selected_instrument
         and str(existing_doc.get("venue") or "").lower() in {"okx", "okx_europe_eea"}
+        and str(existing_doc.get("interval") or "") == interval_id
         and isinstance(existing_doc.get("bars"), list)
     ):
         previous_bars = list(existing_doc["bars"])
-    bars, candle_revision_kind = reduce_okx_ohlcv_bars_v1(previous_bars, incoming_bars)
+    bars, candle_revision_kind = reduce_okx_ohlcv_bars_v1(
+        previous_bars, incoming_bars, interval_seconds=interval_seconds
+    )
 
     # Public trades revise the open candle when the candles endpoint is static.
     trades_envelope = http.get_json(
@@ -666,6 +712,7 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
             bars,
             trades,
             previously_applied_trade_ids=prev_applied,
+            interval_seconds=interval_seconds,
         )
     )
     # Stale trade capture must not overwrite a fresher on-disk open tip.
@@ -772,11 +819,12 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         "fixture_only": False,
         "venue": "okx",
         "market_type": "perpetual",
-        "interval": "PT1H",
+        "interval": interval_id,
         "provider_bar": okx_bar,
+        "interval_seconds": interval_seconds,
         "candle_endpoint": OKX_CANDLES_PATH,
         "trades_endpoint": OKX_TRADES_PATH,
-        "open_candle_live_source": OPEN_CANDLE_LIVE_SOURCE_V1,
+        "open_candle_live_source": open_candle_live_source,
         "open_candle_bootstrap_source": OKX_CANDLES_PATH,
         "instrument_id": selected_instrument,
         "provider_instrument_id": selected_provider_instrument_id,
@@ -819,10 +867,11 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
             f"REVISION_KIND:{revision_kind}",
             f"CANDLE_REVISION_KIND:{candle_revision_kind}",
             f"TRADE_REVISION_KIND:{trade_revision_kind}",
-            f"OPEN_CANDLE_LIVE_SOURCE:{OPEN_CANDLE_LIVE_SOURCE_V1}",
+            f"OPEN_CANDLE_LIVE_SOURCE:{open_candle_live_source}",
             "VOLUME_SEMANTIC_MODEL:MODEL_A_CUMULATIVE_INTERVAL_VOLUME",
             f"OPEN_TIP_VOLUME_PRESERVED:{bool(cumulative_meta.get('open_tip_volume_preserved'))}",
             f"STALE_OVERWRITE_REJECTED:{stale_overwrite_rejected}",
+            f"INTERVAL:{interval_id}",
         ],
         # Additive live-mark projection (v1): authentic OKX public mark only.
         # Distinct fact from candle close — never rewrites OHLCV geometry.
@@ -855,6 +904,7 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
         "last_closed_timestamp": last_closed.ts if last_closed else None,
         "first_timestamp": bars[0].ts,
         "ohlcv_revision_kind": revision_kind,
+        "interval": interval_id,
         "digest": hashlib.sha256(json.dumps(doc, sort_keys=True).encode()).hexdigest(),
     }
 

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -21,7 +21,7 @@ OHLCV_BROWSER_PAYLOAD_SCHEMA = "market_landscape_ohlcv_browser_payload.v1"
 # Must stay equal to DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS in
 # src.ops.okx_selected_instrument_ohlcv_readmodel_v1 (contract-tested).
 # Landscape package must not import ops owners (architecture guard).
-OHLCV_POLL_INTERVAL_SECONDS = 3
+OHLCV_POLL_INTERVAL_SECONDS = 1
 
 
 def _ohlcv_poll_interval_seconds() -> int:

--- a/tests/ops/test_okx_selected_instrument_ohlcv_pt1m_live_repaint_v1.py
+++ b/tests/ops/test_okx_selected_instrument_ohlcv_pt1m_live_repaint_v1.py
@@ -1,0 +1,473 @@
+"""PT1M OHLCV live-repaint contracts for the dashboard readmodel path."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.ops.okx_public_market_data_client_v1 import OkxPublicCaptureEnvelopeV1
+from src.ops.okx_selected_instrument_ohlcv_readmodel_v1 import (
+    DEFAULT_BAR,
+    DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS,
+    OPEN_CANDLE_LIVE_SOURCE_PT1M_V1,
+    OhlcvBarV1,
+    OkxOhlcvReadmodelError,
+    OkxPublicTradeV1,
+    apply_okx_public_trades_to_open_candle_v1,
+    materialize_selected_okx_ohlcv_readmodel_v1,
+    normalize_dashboard_ohlcv_interval_v1,
+    parse_okx_history_candles,
+    reduce_okx_ohlcv_bars_v1,
+)
+from src.webui.market_dashboard_landscape_v2.presenter import OHLCV_POLL_INTERVAL_SECONDS
+
+INSTRUMENT = "ETH-USDT-SWAP"
+
+
+def _ms(iso: str) -> str:
+    dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    return str(int(dt.timestamp() * 1000))
+
+
+def _bar(
+    *,
+    ts: str,
+    o: str,
+    h: str,
+    l: str,
+    c: str,
+    v: str,
+    confirm: bool = False,
+) -> OhlcvBarV1:
+    return OhlcvBarV1(
+        ts=ts,
+        open=o,
+        high=h,
+        low=l,
+        close=c,
+        volume=v,
+        volume_ccy=None,
+        confirm=confirm,
+        provider_ts_ms="0",
+    )
+
+
+def _trade(
+    *,
+    trade_id: str,
+    px: str,
+    sz: str,
+    ts_ms: str,
+    side: str = "buy",
+) -> OkxPublicTradeV1:
+    from src.ops.okx_captured_at_freshness_policy_v1 import provider_ms_to_utc_iso
+
+    ts = provider_ms_to_utc_iso(ts_ms)
+    assert ts is not None
+    return OkxPublicTradeV1(
+        trade_id=trade_id,
+        price=px,
+        size=sz,
+        side=side,
+        ts=ts,
+        provider_ts_ms=ts_ms,
+    )
+
+
+class _FakeOkxClient:
+    def __init__(
+        self,
+        *,
+        captured_at: str,
+        close_px: str = "1874.50",
+        mark_px: str | None = None,
+        high_px: str | None = None,
+        low_px: str | None = None,
+        open_px: str | None = None,
+        volume: str = "10",
+        trades: list[dict[str, str]] | None = None,
+    ) -> None:
+        self.captured_at = captured_at
+        self.close_px = close_px
+        self.open_px = open_px if open_px is not None else close_px
+        self.high_px = high_px if high_px is not None else close_px
+        self.low_px = low_px if low_px is not None else close_px
+        self.volume = volume
+        self.mark_px = mark_px if mark_px is not None else close_px
+        self.trades = list(trades or [])
+        self.paths: list[str] = []
+        self.candle_bars: list[str] = []
+
+    def get_json(self, path: str, params: dict[str, str]) -> OkxPublicCaptureEnvelopeV1:
+        self.paths.append(path)
+        if path == "/api/v5/public/mark-price":
+            body = json.dumps(
+                {
+                    "code": "0",
+                    "msg": "",
+                    "data": [
+                        {
+                            "instId": INSTRUMENT,
+                            "instType": "SWAP",
+                            "markPx": self.mark_px,
+                            "ts": "1784934000123",
+                        }
+                    ],
+                }
+            )
+            return OkxPublicCaptureEnvelopeV1(
+                request_url=f"https://www.okx.com{path}?instId={INSTRUMENT}",
+                request_path=path,
+                query_parameters=dict(params),
+                http_status=200,
+                provider_code="0",
+                provider_message="",
+                capture_started_at=self.captured_at,
+                response_received_at=self.captured_at,
+                captured_at=self.captured_at,
+                effective_at=self.captured_at,
+                provider_timestamp=None,
+                raw_payload_digest="b" * 64,
+                byte_size=len(body.encode("utf-8")),
+                raw_body_utf8=body,
+            )
+        if path == "/api/v5/market/trades":
+            body = json.dumps({"code": "0", "msg": "", "data": self.trades})
+            return OkxPublicCaptureEnvelopeV1(
+                request_url=f"https://www.okx.com{path}?instId={INSTRUMENT}",
+                request_path=path,
+                query_parameters=dict(params),
+                http_status=200,
+                provider_code="0",
+                provider_message="",
+                capture_started_at=self.captured_at,
+                response_received_at=self.captured_at,
+                captured_at=self.captured_at,
+                effective_at=self.captured_at,
+                provider_timestamp=None,
+                raw_payload_digest="c" * 64,
+                byte_size=len(body.encode("utf-8")),
+                raw_body_utf8=body,
+            )
+        assert path == "/api/v5/market/candles"
+        okx_bar = str(params.get("bar") or "")
+        self.candle_bars.append(okx_bar)
+        assert okx_bar in {"1m", "1H"}
+        start = datetime(2026, 7, 20, 18, 0, 0, tzinfo=timezone.utc)
+        step = timedelta(minutes=1) if okx_bar == "1m" else timedelta(hours=1)
+        rows: list[list[str]] = []
+        for i in range(100):
+            ts = start + (step * i)
+            ms = str(int(ts.timestamp() * 1000))
+            confirm = "0" if i == 99 else "1"
+            if i == 99:
+                rows.append(
+                    [
+                        ms,
+                        self.open_px,
+                        self.high_px,
+                        self.low_px,
+                        self.close_px,
+                        self.volume,
+                        self.volume,
+                        self.volume,
+                        confirm,
+                    ]
+                )
+            else:
+                close = "1870.00"
+                rows.append([ms, close, close, close, close, "10", "10", "10", confirm])
+        body = json.dumps({"code": "0", "msg": "", "data": rows})
+        return OkxPublicCaptureEnvelopeV1(
+            request_url=f"https://www.okx.com{path}?instId={INSTRUMENT}&bar={okx_bar}",
+            request_path=path,
+            query_parameters=dict(params),
+            http_status=200,
+            provider_code="0",
+            provider_message="",
+            capture_started_at=self.captured_at,
+            response_received_at=self.captured_at,
+            captured_at=self.captured_at,
+            effective_at=self.captured_at,
+            provider_timestamp=None,
+            raw_payload_digest="a" * 64,
+            byte_size=len(body.encode("utf-8")),
+            raw_body_utf8=body,
+        )
+
+
+def test_interval_allowlist_accepts_pt1m_and_pt1h_rejects_unknown() -> None:
+    assert normalize_dashboard_ohlcv_interval_v1("PT1M") == ("1m", "PT1M", 60)
+    assert normalize_dashboard_ohlcv_interval_v1("1m") == ("1m", "PT1M", 60)
+    assert normalize_dashboard_ohlcv_interval_v1("PT1H") == ("1H", "PT1H", 3600)
+    assert normalize_dashboard_ohlcv_interval_v1("1H") == ("1H", "PT1H", 3600)
+    with pytest.raises(OkxOhlcvReadmodelError, match="UNSUPPORTED_BAR_INTERVAL"):
+        normalize_dashboard_ohlcv_interval_v1("PT5S")
+    with pytest.raises(OkxOhlcvReadmodelError, match="UNSUPPORTED_BAR_INTERVAL"):
+        normalize_dashboard_ohlcv_interval_v1("PT1S")
+    with pytest.raises(OkxOhlcvReadmodelError, match="UNSUPPORTED_BAR_INTERVAL"):
+        normalize_dashboard_ohlcv_interval_v1("5m")
+    assert DEFAULT_BAR == "PT1M"
+
+
+def test_pt1m_bucket_boundaries_are_exact_utc_minutes() -> None:
+    from src.ops.okx_selected_instrument_ohlcv_readmodel_v1 import _bucket_start_utc
+
+    bucket = _bucket_start_utc("2026-07-25T12:34:56.789Z", interval_seconds=60)
+    assert bucket.isoformat().replace("+00:00", "Z") == "2026-07-25T12:34:00Z"
+    assert bucket.second == 0
+    assert bucket.microsecond == 0
+    hour = _bucket_start_utc("2026-07-25T12:34:56Z", interval_seconds=3600)
+    assert hour.isoformat().replace("+00:00", "Z") == "2026-07-25T12:00:00Z"
+
+
+def test_first_trade_sets_open_high_low_close_and_further_trades_revise() -> None:
+    t0 = "2026-07-25T12:34:00Z"
+    # Empty tip geometry seeded by first trade in a fresh append path is covered by
+    # minute-append; here revise an open tip that already has candle bootstrap open.
+    bars = [_bar(ts=t0, o="100", h="100", l="100", c="100", v="1", confirm=False)]
+    seed = _trade(trade_id="s0", px="100", sz="1", ts_ms=_ms("2026-07-25T12:34:01Z"))
+    _, _, applied, _ = apply_okx_public_trades_to_open_candle_v1(
+        bars, [seed], previously_applied_trade_ids=None, interval_seconds=60
+    )
+    t1 = _trade(trade_id="t1", px="103", sz="2", ts_ms=_ms("2026-07-25T12:34:10Z"))
+    t2 = _trade(trade_id="t2", px="98", sz="3", ts_ms=_ms("2026-07-25T12:34:20Z"))
+    revised, kind, applied2, meta = apply_okx_public_trades_to_open_candle_v1(
+        bars, [seed, t1, t2], previously_applied_trade_ids=applied, interval_seconds=60
+    )
+    assert kind == "SAME_TIMESTAMP_REVISION"
+    assert meta["new_trade_count"] == 2
+    assert revised[0].open == "100"
+    assert revised[0].high == "103"
+    assert revised[0].low == "98"
+    assert revised[0].close == "98"
+    assert revised[0].volume == "6"  # 1 + 2 + 3
+    assert set(applied2) == {"s0", "t1", "t2"}
+
+
+def test_open_preserved_within_same_pt1m_candle() -> None:
+    t0 = "2026-07-25T12:34:00Z"
+    bars = [_bar(ts=t0, o="100", h="101", l="99", c="100.5", v="5", confirm=False)]
+    _, _, applied, _ = apply_okx_public_trades_to_open_candle_v1(
+        bars, [], previously_applied_trade_ids=[], interval_seconds=60
+    )
+    trade = _trade(trade_id="x1", px="110", sz="1", ts_ms=_ms("2026-07-25T12:34:40Z"))
+    revised, kind, _, _ = apply_okx_public_trades_to_open_candle_v1(
+        bars, [trade], previously_applied_trade_ids=applied, interval_seconds=60
+    )
+    assert kind == "SAME_TIMESTAMP_REVISION"
+    assert revised[0].open == "100"
+    assert revised[0].high == "110"
+    assert revised[0].close == "110"
+
+
+def test_minute_rollover_seals_and_appends_exactly_one_candle() -> None:
+    t0 = "2026-07-25T12:34:00Z"
+    t1 = "2026-07-25T12:35:00Z"
+    bars = [_bar(ts=t0, o="100", h="102", l="99", c="101", v="10", confirm=False)]
+    _, _, applied, _ = apply_okx_public_trades_to_open_candle_v1(
+        bars,
+        [_trade(trade_id="seed", px="101", sz="1", ts_ms=_ms("2026-07-25T12:34:05Z"))],
+        previously_applied_trade_ids=None,
+        interval_seconds=60,
+    )
+    nxt = _trade(trade_id="n1", px="110", sz="4", ts_ms=_ms("2026-07-25T12:35:01Z"))
+    bars_n, kind_n, _, meta_n = apply_okx_public_trades_to_open_candle_v1(
+        bars, [nxt], previously_applied_trade_ids=applied, interval_seconds=60
+    )
+    assert kind_n == "NEW_INTERVAL_APPEND"
+    assert meta_n["new_trade_count"] == 1
+    assert len(bars_n) == 2
+    assert bars_n[0].ts == t0
+    assert bars_n[0].confirm is True
+    assert bars_n[1].ts == t1
+    assert bars_n[1].open == "110"
+    assert bars_n[1].high == "110"
+    assert bars_n[1].low == "110"
+    assert bars_n[1].close == "110"
+    assert bars_n[1].volume == "4"
+    assert bars_n[1].confirm is False
+
+
+def test_duplicate_trades_are_not_double_counted() -> None:
+    t0 = "2026-07-25T12:34:00Z"
+    bars = [_bar(ts=t0, o="100", h="100", l="100", c="100", v="10", confirm=False)]
+    t1 = _trade(trade_id="dup", px="101", sz="2", ts_ms=_ms("2026-07-25T12:34:10Z"))
+    # Empty list (not None) = post-bootstrap apply mode.
+    bars_r, kind_r, applied_r, _ = apply_okx_public_trades_to_open_candle_v1(
+        bars, [t1], previously_applied_trade_ids=[], interval_seconds=60
+    )
+    assert kind_r == "SAME_TIMESTAMP_REVISION"
+    assert bars_r[0].volume == "12"
+    bars_d, kind_d, _, meta_d = apply_okx_public_trades_to_open_candle_v1(
+        bars_r, [t1], previously_applied_trade_ids=applied_r, interval_seconds=60
+    )
+    assert kind_d == "NO_OP"
+    assert meta_d["duplicate_trade_count"] == 1
+    assert bars_d[0].volume == "12"
+
+
+def test_out_of_order_trades_are_processed_deterministically() -> None:
+    t0 = "2026-07-25T12:34:00Z"
+    bars = [_bar(ts=t0, o="100", h="100", l="100", c="100", v="1", confirm=False)]
+    later = _trade(trade_id="2", px="105", sz="1", ts_ms=_ms("2026-07-25T12:34:40Z"))
+    earlier = _trade(trade_id="1", px="95", sz="1", ts_ms=_ms("2026-07-25T12:34:10Z"))
+    # Input deliberately reverse chronological; apply path expects pre-sorted trades
+    # (materializer sorts via parse_okx_public_trades_v1).
+    ordered = sorted([later, earlier], key=lambda t: (int(t.provider_ts_ms), t.trade_id))
+    revised, kind, _, _ = apply_okx_public_trades_to_open_candle_v1(
+        bars, ordered, previously_applied_trade_ids=[], interval_seconds=60
+    )
+    assert kind == "SAME_TIMESTAMP_REVISION"
+    assert revised[0].open == "100"
+    assert revised[0].high == "105"
+    assert revised[0].low == "95"
+    # Close follows last applied in deterministic sort order (later trade).
+    assert revised[0].close == "105"
+    assert revised[0].volume == "3"
+
+
+def test_empty_trade_seconds_do_not_invent_candles() -> None:
+    t0 = "2026-07-25T12:34:00Z"
+    bars = [_bar(ts=t0, o="100", h="100", l="100", c="100", v="1", confirm=False)]
+    out, kind, applied, meta = apply_okx_public_trades_to_open_candle_v1(
+        bars, [], previously_applied_trade_ids=[], interval_seconds=60
+    )
+    assert kind == "NO_OP"
+    assert len(out) == 1
+    assert out[0].ts == t0
+    assert applied == []
+    assert meta["new_trade_count"] == 0
+
+
+def test_pt1h_path_remains_backward_compatible() -> None:
+    t0 = "2026-07-25T00:00:00Z"
+    t1 = "2026-07-25T01:00:00Z"
+    bars = [_bar(ts=t0, o="100", h="102", l="99", c="101", v="10", confirm=False)]
+    _, _, applied, _ = apply_okx_public_trades_to_open_candle_v1(
+        bars,
+        [_trade(trade_id="seed", px="101", sz="1", ts_ms=_ms("2026-07-25T00:05:00Z"))],
+        previously_applied_trade_ids=None,
+        interval_seconds=3600,
+    )
+    nxt = _trade(trade_id="n1", px="110", sz="4", ts_ms=_ms("2026-07-25T01:00:05Z"))
+    bars_n, kind_n, _, _ = apply_okx_public_trades_to_open_candle_v1(
+        bars, [nxt], previously_applied_trade_ids=applied, interval_seconds=3600
+    )
+    assert kind_n == "NEW_INTERVAL_APPEND"
+    assert bars_n[1].ts == t1
+    reduced, kind = reduce_okx_ohlcv_bars_v1(
+        bars,
+        [
+            _bar(ts=t0, o="100", h="102", l="99", c="101", v="10", confirm=True),
+            _bar(ts=t1, o="110", h="110", l="110", c="110", v="4", confirm=False),
+        ],
+        interval_seconds=3600,
+    )
+    assert kind == "NEW_INTERVAL_APPEND"
+    assert len(reduced) == 2
+
+
+def test_materialize_pt1m_document_reports_interval(
+    tmp_path: Path,
+) -> None:
+    selection = tmp_path / "selection.json"
+    selection.write_text("{}", encoding="utf-8")
+    client = _FakeOkxClient(captured_at="2026-07-25T12:34:30Z")
+    result = materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=tmp_path,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-pt1m",
+        selection_path=selection,
+        bar="PT1M",
+        client=client,  # type: ignore[arg-type]
+    )
+    assert result["interval"] == "PT1M"
+    assert client.candle_bars == ["1m"]
+    doc = json.loads(
+        (tmp_path / "readmodels" / "okx_selected_instrument_ohlcv_readmodel.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert doc["interval"] == "PT1M"
+    assert doc["provider_bar"] == "1m"
+    assert doc["interval_seconds"] == 60
+    assert doc["open_candle_live_source"] == OPEN_CANDLE_LIVE_SOURCE_PT1M_V1
+    assert doc["bar_count"] == 100
+    tip = doc["bars"][-1]
+    tip_dt = datetime.fromisoformat(tip["ts"].replace("Z", "+00:00"))
+    assert tip_dt.second == 0
+    assert tip_dt.microsecond == 0
+    # Contiguous PT1M history: last closed precedes open tip by exactly 60s.
+    closed = [b for b in doc["bars"] if b["confirm"]]
+    assert closed
+    last_closed = datetime.fromisoformat(closed[-1]["ts"].replace("Z", "+00:00"))
+    assert (tip_dt - last_closed).total_seconds() == 60.0
+
+
+def test_materialize_pt1h_still_accepted(tmp_path: Path) -> None:
+    selection = tmp_path / "selection.json"
+    selection.write_text("{}", encoding="utf-8")
+    client = _FakeOkxClient(captured_at="2026-07-25T12:00:30Z")
+    result = materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=tmp_path,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-pt1h",
+        selection_path=selection,
+        bar="PT1H",
+        client=client,  # type: ignore[arg-type]
+    )
+    assert result["interval"] == "PT1H"
+    assert client.candle_bars == ["1H"]
+    doc = json.loads(
+        (tmp_path / "readmodels" / "okx_selected_instrument_ohlcv_readmodel.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert doc["interval"] == "PT1H"
+    assert doc["provider_bar"] == "1H"
+
+
+def test_unknown_bar_rejected_by_materialize(tmp_path: Path) -> None:
+    selection = tmp_path / "selection.json"
+    selection.write_text("{}", encoding="utf-8")
+    with pytest.raises(OkxOhlcvReadmodelError, match="UNSUPPORTED_BAR_INTERVAL"):
+        materialize_selected_okx_ohlcv_readmodel_v1(
+            archive_root=tmp_path,
+            selected_instrument=INSTRUMENT,
+            selected_provider_instrument_id=INSTRUMENT,
+            selected_venue="okx",
+            selection_bundle_id="bundle-bad",
+            selection_path=selection,
+            bar="PT5S",
+            client=_FakeOkxClient(captured_at="2026-07-25T12:00:00Z"),  # type: ignore[arg-type]
+        )
+
+
+def test_frontend_poll_interval_is_one_second() -> None:
+    assert DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS == 1
+    assert OHLCV_POLL_INTERVAL_SECONDS == 1
+    js = (
+        Path(__file__).resolve().parents[2] / "static" / "js" / "market_dashboard_landscape_v2.js"
+    ).read_text(encoding="utf-8")
+    assert "LAST_CANDLE_IN_PLACE" in js
+    assert "SAME_TIMESTAMP_LAST_CANDLE_CHANGE" in js
+    assert "NEW_CANDLE_APPEND" in js
+
+
+def test_parse_pt1m_gap_detection_uses_sixty_second_buckets() -> None:
+    rows = [
+        ["1700000000000", "1", "2", "0.5", "1.5", "10", "10", "15", "1"],
+        ["1700000060000", "1.5", "2.5", "1.0", "2.0", "11", "11", "16", "1"],
+        ["1700000180000", "2.0", "3.0", "1.5", "2.5", "12", "12", "17", "1"],  # +2m gap
+    ]
+    bars, notes = parse_okx_history_candles(rows, interval_seconds=60)
+    assert len(bars) == 3
+    assert "GAP_COUNT:1" in notes

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -140,10 +140,13 @@ class _FakeOkxClient:
             )
         assert path == "/api/v5/market/candles"
         assert params["instId"] == INSTRUMENT
+        okx_bar = str(params.get("bar") or "1m")
+        assert okx_bar in {"1m", "1H"}
         start = datetime(2026, 7, 20, 18, 0, 0, tzinfo=timezone.utc)
+        step = timedelta(minutes=1) if okx_bar == "1m" else timedelta(hours=1)
         rows: list[list[str]] = []
         for i in range(100):
-            ts = start + timedelta(hours=i)
+            ts = start + (step * i)
             ms = str(int(ts.timestamp() * 1000))
             confirm = "0" if i == 99 else "1"
             if i == 99:
@@ -165,7 +168,7 @@ class _FakeOkxClient:
                 rows.append([ms, close, close, close, close, "10", "10", "10", confirm])
         body = json.dumps({"code": "0", "msg": "", "data": rows})
         return OkxPublicCaptureEnvelopeV1(
-            request_url=f"https://www.okx.com{path}?instId={INSTRUMENT}",
+            request_url=f"https://www.okx.com{path}?instId={INSTRUMENT}&bar={okx_bar}",
             request_path=path,
             query_parameters=dict(params),
             http_status=200,
@@ -370,7 +373,7 @@ def test_volume_revision_moves_candle_series_digest(
     assert second_doc.get("ohlcv_revision_kind") == "SAME_TIMESTAMP_REVISION"
     assert second.get("close_source_semantics") == ("okx_market_candles_close_plus_public_trades")
     assert second.get("mark_source_semantics") == ("okx_public_mark_price_markPx_metadata_only")
-    assert second.get("open_candle_live_source") == "okx_public_trades_into_pt1h_v1"
+    assert second.get("open_candle_live_source") == "okx_public_trades_into_pt1m_v1"
     assert second.get("trades_endpoint") == "/api/v5/market/trades"
 
 
@@ -426,7 +429,7 @@ def test_authentic_okx_maps_and_newer_snapshot_advances(
     assert "/api/v5/market/trades" in client_b.paths
     assert "/api/v5/public/mark-price" in client_b.paths
     assert client_b.calls == 3
-    assert second["ohlcv"].get("open_candle_live_source") == "okx_public_trades_into_pt1h_v1"
+    assert second["ohlcv"].get("open_candle_live_source") == "okx_public_trades_into_pt1m_v1"
     assert second["ohlcv"].get("trades_endpoint") == "/api/v5/market/trades"
 
 
@@ -437,9 +440,9 @@ def test_public_trades_revise_open_candle_when_candles_static(
     archive = tmp_path / "archive"
     selection = _write_universe(archive)
     monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
-    tip_ms = "1784926800000"  # FakeOkx open tip 2026-07-24T21:00:00Z
-    seed_ms = "1784926900000"
-    new_ms = "1784927400000"
+    tip_ms = "1784576340000"  # FakeOkx open tip 2026-07-20T19:39:00Z (PT1M)
+    seed_ms = "1784576350000"  # +10s within open minute
+    new_ms = "1784576380000"  # +40s within open minute
     seed_trades = [
         {
             "instId": INSTRUMENT,
@@ -458,7 +461,7 @@ def test_public_trades_revise_open_candle_when_candles_static(
         selection_bundle_id="bundle-a",
         selection_path=selection,
         client=_FakeOkxClient(  # type: ignore[arg-type]
-            captured_at="2026-07-24T21:05:00Z",
+            captured_at="2026-07-20T19:39:10Z",
             open_px="0.000000009100",
             high_px="0.000000009100",
             low_px="0.000000009100",
@@ -469,7 +472,8 @@ def test_public_trades_revise_open_candle_when_candles_static(
     )
     path = archive / "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
     first = json.loads(path.read_text(encoding="utf-8"))
-    assert first["last_timestamp"].startswith("2026-07-24T21:00:00")
+    assert first["interval"] == "PT1M"
+    assert first["last_timestamp"].startswith("2026-07-20T19:39:00")
     assert first["applied_trade_ids"] == ["seed-1"]
     assert first["bars"][-1]["close"] == "0.000000009100"
     assert first["bars"][-1]["volume"] == "10"
@@ -487,7 +491,7 @@ def test_public_trades_revise_open_candle_when_candles_static(
     second = refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
         archive_root=archive,
         client=_FakeOkxClient(  # type: ignore[arg-type]
-            captured_at="2026-07-24T21:10:00Z",
+            captured_at="2026-07-20T19:39:40Z",
             open_px="0.000000009100",
             high_px="0.000000009100",
             low_px="0.000000009100",
@@ -499,7 +503,7 @@ def test_public_trades_revise_open_candle_when_candles_static(
     )
     assert second["status"] == "OK"
     tip = second["ohlcv"]["bars"][-1]
-    assert tip["ts"].startswith("2026-07-24T21:00:00")
+    assert tip["ts"].startswith("2026-07-20T19:39:00")
     assert tip["open"] == "0.000000009100"
     assert tip["high"] == "0.000000009250"
     assert tip["low"] == "0.000000009100"
@@ -1010,9 +1014,10 @@ def test_poll_interval_targets_visible_intrabar_feedback() -> None:
         OHLCV_POLL_INTERVAL_SECONDS,
     )
 
+    assert DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS == 1
+    assert OHLCV_POLL_INTERVAL_SECONDS == DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS
     assert DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS <= 5
     assert DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS >= 1
-    assert OHLCV_POLL_INTERVAL_SECONDS == DEFAULT_DASHBOARD_OHLCV_POLL_INTERVAL_SECONDS
 
 
 def test_ohlcv_refresh_preserves_universe_selection_manifest_binding(


### PR DESCRIPTION
## Summary
- Adds an explicit dashboard OHLCV allowlist for `PT1M`/`1m` (and keeps `PT1H`/`1H`) on the selected-instrument OKX readmodel materializer.
- Materializes authentic OKX `1m` candles for history and revises the open UTC-minute tip from public trades, with 1-second presentation polling and in-place open-candle canvas updates.
- Leaves Dynamic Scope, Universe, Bull/Bear, Double Play, Decision, Risk, Safety, and trading runtime paths unchanged; PT1H remains explicitly accepted.

## Test plan
- [x] `tests/ops/test_okx_selected_instrument_ohlcv_pt1m_live_repaint_v1.py`
- [x] `tests/ops/test_okx_public_trades_open_candle_v1.py`
- [x] `tests/ops/test_okx_selected_instrument_ohlcv_readmodel_v1.py`
- [x] `tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py`
- [x] PR-bounded selector targets + focused OHLCV owners (775 passed, ~51s)
- [ ] Required GitHub checks green


Made with [Cursor](https://cursor.com)