### PR TITLE
feat(webui): synchronized OHLCV volume panel under live candles

### DIFF
--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -107,6 +107,93 @@ def _finite_ohlc_float(raw: Any) -> float | None:
     return value
 
 
+def classify_volume_bar_direction_v1(*, open_v: float, close_v: float) -> str:
+    """Candle-direction class for volume bars — not buy/sell volume semantics."""
+    if close_v > open_v:
+        return "up"
+    if close_v < open_v:
+        return "down"
+    return "neutral"
+
+
+def usable_volume_value_v1(raw: Any) -> float | None:
+    """Accept finite non-negative volume only; never invent zeros for missing/invalid."""
+    value = _finite_ohlc_float(raw)
+    if value is None or value < 0:
+        return None
+    return value
+
+
+def resolve_volume_panel_state_v1(
+    *,
+    browser_payload: Mapping[str, Any] | None,
+    ohlcv_payload: Mapping[str, Any] | None = None,
+) -> tuple[str, str]:
+    """Honest volume-panel availability from existing OHLCV payload facts only."""
+    source = ohlcv_payload if isinstance(ohlcv_payload, Mapping) else None
+    payload = browser_payload if isinstance(browser_payload, Mapping) else None
+    if payload is None and source is None:
+        return (
+            "MISSING_SOURCE",
+            "Volume MISSING_SOURCE — no OHLCV volume field in existing payload.",
+        )
+    if payload is None:
+        return (
+            "NOT_BOUND",
+            "Volume NOT_BOUND — OHLCV present but not browser-serializable for volume.",
+        )
+    bars = payload.get("bars")
+    if not isinstance(bars, list) or not bars:
+        return (
+            "MISSING_SOURCE",
+            "Volume MISSING_SOURCE — empty OHLCV series; no fabricated volume bars.",
+        )
+    usable = 0
+    missing = 0
+    invalid = 0
+    for row in bars:
+        if not isinstance(row, Mapping):
+            invalid += 1
+            continue
+        raw = row.get("volume")
+        if raw is None or raw == "":
+            missing += 1
+            continue
+        if usable_volume_value_v1(raw) is None:
+            invalid += 1
+            continue
+        usable += 1
+    if usable == 0 and missing == len(bars):
+        return (
+            "MISSING_SOURCE",
+            "Volume MISSING_SOURCE — volume field absent on all bars.",
+        )
+    if usable == 0:
+        return (
+            "NOT_BOUND",
+            "Volume NOT_BOUND — volume present but not usable in presentation binding.",
+        )
+    freshness_raw = ""
+    if isinstance(source, Mapping):
+        freshness_raw = str(source.get("freshness_state") or "")
+    if not freshness_raw:
+        freshness_raw = str(payload.get("freshness_state") or "")
+    is_stale = False
+    if isinstance(source, Mapping):
+        is_stale = bool(source.get("is_stale"))
+    if not is_stale:
+        is_stale = bool(payload.get("is_stale"))
+    if freshness_raw.lower() == "stale" or is_stale:
+        return (
+            "STALE",
+            "Volume STALE — canonical OHLCV freshness reports stale; bars retained.",
+        )
+    return (
+        "AVAILABLE",
+        "Volume bound to authentic OHLCV bar volume (contracts); not buy/sell delta.",
+    )
+
+
 def serialize_ohlcv_browser_payload_v1(
     ohlcv_readmodel: Mapping[str, Any] | None,
 ) -> dict[str, Any] | None:
@@ -864,6 +951,11 @@ def present_market_landscape_v2(
     else:
         chart_message = "Primary chart NOT_BOUND — no OHLCV fabricated for Landscape shell."
 
+    volume_panel_state, volume_panel_message = resolve_volume_panel_state_v1(
+        browser_payload=browser_payload,
+        ohlcv_payload=ohlcv_payload,
+    )
+
     ranking_rows: list[dict[str, Any]] = []
     universe_rows: list[dict[str, Any]] = []
     selected_instrument_id = None
@@ -1043,6 +1135,8 @@ def present_market_landscape_v2(
             "volume": None
             if not browser_payload or not browser_payload.get("bars")
             else browser_payload["bars"][-1].get("volume"),
+            "volume_panel_state": volume_panel_state,
+            "volume_panel_message": volume_panel_message,
             "is_stale": bool((ohlcv_payload or {}).get("is_stale")),
             "poll_path": OHLCV_POLL_PATH,
             "poll_interval_seconds": _ohlcv_poll_interval_seconds(),

--- a/static/css/market_dashboard_landscape_v2.css
+++ b/static/css/market_dashboard_landscape_v2.css
@@ -57,6 +57,10 @@
   --mdl-warn: #fbbf24;
   /* Stable primary chart band — leaves room for Decision strip in 982px viewport. */
   --mdl-stage-height: 300px;
+  /* Compact volume histogram under candles; must not displace candle stage height. */
+  --mdl-volume-height: 64px;
+  --mdl-volume-chrome-band: 1rem;
+  --mdl-volume-message-band: 1rem;
   --mdl-chart-chrome-band: 1.5rem;
   --mdl-chart-meta-band: 5.5rem;
   --mdl-chart-message-band: 1.25rem;
@@ -191,8 +195,9 @@
 .mdl-v2-rail--right {
   /* Context rail must not stretch the primary chart column height. */
   max-height: calc(
-    var(--mdl-stage-height) + var(--mdl-chart-meta-band) + var(--mdl-chart-chrome-band) +
-      var(--mdl-chart-message-band) + 24px
+    var(--mdl-stage-height) + var(--mdl-volume-height) + var(--mdl-volume-chrome-band) +
+      var(--mdl-volume-message-band) + var(--mdl-chart-meta-band) +
+      var(--mdl-chart-chrome-band) + var(--mdl-chart-message-band) + 24px
   );
   overflow: auto;
 }
@@ -367,6 +372,66 @@
   height: auto;
   max-width: 100%;
   max-height: 100%;
+}
+
+.mdl-v2-volume {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  margin: 2px 0 0;
+  min-height: 0;
+  height: calc(
+    var(--mdl-volume-height) + var(--mdl-volume-chrome-band) + var(--mdl-volume-message-band)
+  );
+  max-height: calc(
+    var(--mdl-volume-height) + var(--mdl-volume-chrome-band) + var(--mdl-volume-message-band)
+  );
+  overflow: hidden;
+}
+
+.mdl-v2-volume__chrome {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  height: var(--mdl-volume-chrome-band);
+  min-height: var(--mdl-volume-chrome-band);
+  max-height: var(--mdl-volume-chrome-band);
+  overflow: hidden;
+}
+
+.mdl-v2-volume__label {
+  font-size: 10px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--mdl-muted);
+  font-weight: 600;
+}
+
+.mdl-v2-volume__message {
+  margin: 0;
+  height: var(--mdl-volume-message-band);
+  min-height: var(--mdl-volume-message-band);
+  max-height: var(--mdl-volume-message-band);
+  font-size: 11px;
+  color: #94a3b8;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mdl-v2-volume__canvas {
+  display: block;
+  width: 100%;
+  height: var(--mdl-volume-height);
+  min-height: var(--mdl-volume-height);
+  max-height: var(--mdl-volume-height);
+  max-width: 100%;
+}
+
+.mdl-v2-volume[data-mdl-volume-state="MISSING_SOURCE"] .mdl-v2-volume__canvas,
+.mdl-v2-volume[data-mdl-volume-state="NOT_BOUND"] .mdl-v2-volume__canvas {
+  opacity: 0.35;
 }
 
 .mdl-v2-state {

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -25,6 +25,7 @@
   if (!root) return;
 
   var chartLayout = null;
+  var volumeLayout = null;
   var lastBars = null;
   var lastCandleSeriesDigest = "";
   var lastMetadataDigest = "";
@@ -61,6 +62,41 @@
     canvas.setAttribute("data-mdl-chart-blank", "true");
     canvas.setAttribute("data-mdl-chart-bar-count", "0");
     if (reason) canvas.setAttribute("data-mdl-chart-error", reason);
+    markVolumeBlank(reason || "chart_blank");
+  }
+
+  function markVolumeBlank(reason) {
+    var panel = root.querySelector("[data-mdl-volume-panel]");
+    var canvas = root.querySelector("[data-mdl-volume-canvas]");
+    volumeLayout = null;
+    if (panel) {
+      panel.setAttribute("data-mdl-volume-synced-with-chart", "false");
+    }
+    if (canvas) {
+      canvas.setAttribute("data-mdl-volume-geometry", "absent");
+      canvas.setAttribute("data-mdl-volume-bar-count", "0");
+      if (reason) canvas.setAttribute("data-mdl-volume-error", reason);
+      var ctx = canvas.getContext("2d");
+      if (ctx) {
+        var box = resolveCssBox(canvas, canvas.parentElement);
+        syncBackingStore(canvas, box.cssWidth, box.cssHeight);
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+      }
+    }
+  }
+
+  function setVolumePanelState(state, message) {
+    var panel = root.querySelector("[data-mdl-volume-panel]");
+    var label = root.querySelector("[data-mdl-volume-state-label]");
+    var msg = root.querySelector("[data-mdl-volume-message]");
+    var token = String(state || "MISSING_SOURCE");
+    if (panel) panel.setAttribute("data-mdl-volume-state", token);
+    if (label) {
+      label.textContent = token;
+      label.setAttribute("data-mdl-volume-state", token);
+    }
+    if (msg && message) msg.textContent = String(message);
   }
 
   function setConnectionState(state) {
@@ -127,6 +163,11 @@
     root.setAttribute("data-mdl-canonical-fail", "true");
     root.setAttribute("data-mdl-canonical-fail-reason", String(reason || "canonical_unavailable"));
     setConnectionState("MISSING_SOURCE");
+    setVolumePanelState(
+      "MISSING_SOURCE",
+      "Volume MISSING_SOURCE — canonical OHLCV unavailable; no fabricated volume bars."
+    );
+    markVolumeBlank(String(reason || "canonical_unavailable"));
     var message = root.querySelector("[data-mdl-chart-message]");
     if (message) {
       message.textContent = "CANONICAL_DATA_UNAVAILABLE: " + String(reason || "unknown");
@@ -161,6 +202,79 @@
     if (raw === undefined || raw === null || raw === "") return null;
     var n = Number(raw);
     return Number.isFinite(n) ? n : null;
+  }
+
+  function usableVolumeValue(raw) {
+    // Finite non-negative only — never invent zeros for missing/invalid volume.
+    var n = finiteBarNumber(raw);
+    if (n === null || n < 0) return null;
+    return n;
+  }
+
+  function classifyVolumeBarDirection(openV, closeV) {
+    // Candle direction for volume styling — not buy/sell volume semantics.
+    if (closeV > openV) return "up";
+    if (closeV < openV) return "down";
+    return "neutral";
+  }
+
+  function volumeDirectionColor(direction) {
+    if (direction === "up") return "#34d399";
+    if (direction === "down") return "#f87171";
+    return "#94a3b8";
+  }
+
+  function resolveVolumePanelState(payload, bars) {
+    if (!payload || !Array.isArray(bars) || !bars.length) {
+      return {
+        state: "MISSING_SOURCE",
+        message: "Volume MISSING_SOURCE — no OHLCV volume field in existing payload.",
+      };
+    }
+    var usable = 0;
+    var missing = 0;
+    var invalid = 0;
+    var i;
+    for (i = 0; i < bars.length; i += 1) {
+      var row = bars[i] || {};
+      var raw = row.volume;
+      if (raw === undefined || raw === null || raw === "") {
+        missing += 1;
+        continue;
+      }
+      if (usableVolumeValue(raw) === null) {
+        invalid += 1;
+        continue;
+      }
+      usable += 1;
+    }
+    if (usable === 0 && missing === bars.length) {
+      return {
+        state: "MISSING_SOURCE",
+        message: "Volume MISSING_SOURCE — volume field absent on all bars.",
+      };
+    }
+    if (usable === 0) {
+      return {
+        state: "NOT_BOUND",
+        message:
+          "Volume NOT_BOUND — volume present but not usable in presentation binding.",
+      };
+    }
+    var freshness = String(payload.freshness_state || "").toLowerCase();
+    var isStale = payload.is_stale === true || freshness === "stale";
+    if (isStale) {
+      return {
+        state: "STALE",
+        message:
+          "Volume STALE — canonical OHLCV freshness reports stale; bars retained.",
+      };
+    }
+    return {
+      state: "AVAILABLE",
+      message:
+        "Volume bound to authentic OHLCV bar volume (contracts); not buy/sell delta.",
+    };
   }
 
   function normalizeCanonicalBars(rawBars) {
@@ -684,6 +798,167 @@
     return true;
   }
 
+  function paintVolumeFullSeries(payload, bars, sharedLayout, fullClear) {
+    var panel = root.querySelector("[data-mdl-volume-panel]");
+    var canvas = root.querySelector("[data-mdl-volume-canvas]");
+    if (!panel || !canvas || !sharedLayout) {
+      markVolumeBlank("volume_panel_absent");
+      return false;
+    }
+    var stateInfo = resolveVolumePanelState(payload, bars);
+    setVolumePanelState(stateInfo.state, stateInfo.message);
+    if (stateInfo.state === "MISSING_SOURCE" || stateInfo.state === "NOT_BOUND") {
+      markVolumeBlank(stateInfo.state.toLowerCase());
+      panel.setAttribute("data-mdl-volume-synced-with-chart", "false");
+      return false;
+    }
+
+    var box = resolveCssBox(canvas, canvas.parentElement);
+    var store = syncBackingStore(canvas, box.cssWidth, box.cssHeight);
+    var ctx = canvas.getContext("2d");
+    if (!ctx) {
+      markVolumeBlank("no_2d_context");
+      return false;
+    }
+    ctx.setTransform(store.dpr, 0, 0, store.dpr, 0, 0);
+    ctx.clearRect(0, 0, box.cssWidth, box.cssHeight);
+
+    var padL = sharedLayout.padL;
+    var padR = sharedLayout.padR;
+    var padT = 4;
+    var padB = 4;
+    var plotW = Math.max(1, box.cssWidth - padL - padR);
+    var plotH = Math.max(1, box.cssHeight - padT - padB);
+    var n = bars.length;
+    var slot = plotW / n;
+    var bodyW = sharedLayout.bodyW;
+    var volumes = [];
+    var directions = [];
+    var maxV = 0;
+    var i;
+    for (i = 0; i < n; i += 1) {
+      var vol = usableVolumeValue(bars[i].volume);
+      volumes.push(vol);
+      directions.push(
+        classifyVolumeBarDirection(Number(bars[i].open), Number(bars[i].close))
+      );
+      if (vol !== null && vol > maxV) maxV = vol;
+    }
+    if (!(maxV > 0)) {
+      // Authentic all-zero volume: sync geometry but draw no invented bars.
+      maxV = 1;
+    }
+
+    for (i = 0; i < n; i += 1) {
+      if (volumes[i] === null) continue;
+      var xCenter = padL + slot * (i + 0.5);
+      var barH = Math.max(volumes[i] > 0 ? 1 : 0, (volumes[i] / maxV) * plotH);
+      var y = padT + plotH - barH;
+      ctx.fillStyle = volumeDirectionColor(directions[i]);
+      ctx.fillRect(xCenter - bodyW / 2, y, bodyW, Math.max(0, barH));
+    }
+
+    volumeLayout = {
+      cssWidth: box.cssWidth,
+      cssHeight: box.cssHeight,
+      padL: padL,
+      padR: padR,
+      padT: padT,
+      padB: padB,
+      plotW: plotW,
+      plotH: plotH,
+      n: n,
+      slot: slot,
+      bodyW: bodyW,
+      maxV: maxV,
+      dpr: store.dpr,
+      instanceId: sharedLayout.instanceId,
+    };
+
+    canvas.setAttribute("data-mdl-volume-geometry", "nonzero");
+    canvas.setAttribute("data-mdl-volume-bar-count", String(n));
+    canvas.setAttribute("data-mdl-volume-first-ts", String(bars[0].ts || ""));
+    canvas.setAttribute("data-mdl-volume-last-ts", String(bars[n - 1].ts || ""));
+    canvas.setAttribute("data-mdl-volume-slot", String(slot));
+    canvas.setAttribute("data-mdl-volume-pad-l", String(padL));
+    canvas.setAttribute("data-mdl-volume-pad-r", String(padR));
+    canvas.setAttribute("data-mdl-volume-body-w", String(bodyW));
+    canvas.setAttribute(
+      "data-mdl-volume-full-series-clearrect",
+      fullClear ? "true" : "false"
+    );
+    if (volumes[n - 1] !== null) {
+      canvas.setAttribute("data-mdl-volume-last", String(volumes[n - 1]));
+      canvas.setAttribute(
+        "data-mdl-volume-last-direction",
+        String(directions[n - 1])
+      );
+    } else {
+      canvas.removeAttribute("data-mdl-volume-last");
+      canvas.removeAttribute("data-mdl-volume-last-direction");
+    }
+    panel.setAttribute("data-mdl-volume-synced-with-chart", "true");
+    panel.setAttribute("data-mdl-volume-bar-count", String(n));
+    return true;
+  }
+
+  function paintLastVolumeBarInPlace(payload, bars, sharedLayout) {
+    if (
+      !volumeLayout ||
+      !sharedLayout ||
+      volumeLayout.n !== bars.length ||
+      volumeLayout.n !== sharedLayout.n ||
+      volumeLayout.slot !== sharedLayout.slot ||
+      volumeLayout.padL !== sharedLayout.padL ||
+      volumeLayout.bodyW !== sharedLayout.bodyW
+    ) {
+      return paintVolumeFullSeries(payload, bars, sharedLayout, true);
+    }
+    var canvas = root.querySelector("[data-mdl-volume-canvas]");
+    if (!canvas) return false;
+    var stateInfo = resolveVolumePanelState(payload, bars);
+    setVolumePanelState(stateInfo.state, stateInfo.message);
+    if (stateInfo.state === "MISSING_SOURCE" || stateInfo.state === "NOT_BOUND") {
+      markVolumeBlank(stateInfo.state.toLowerCase());
+      return false;
+    }
+    var last = bars.length - 1;
+    var vol = usableVolumeValue(bars[last].volume);
+    if (vol === null) {
+      return paintVolumeFullSeries(payload, bars, sharedLayout, true);
+    }
+    if (vol > volumeLayout.maxV) {
+      return paintVolumeFullSeries(payload, bars, sharedLayout, true);
+    }
+    var ctx = canvas.getContext("2d");
+    if (!ctx) {
+      markVolumeBlank("no_2d_context");
+      return false;
+    }
+    var L = volumeLayout;
+    ctx.setTransform(L.dpr, 0, 0, L.dpr, 0, 0);
+    var clearX = Math.max(0, L.padL + L.slot * (last - 0.15));
+    var clearW = Math.min(L.cssWidth - clearX, L.slot * 1.3);
+    ctx.clearRect(clearX, 0, clearW, L.cssHeight);
+    var xCenter = L.padL + L.slot * (last + 0.5);
+    var barH = Math.max(vol > 0 ? 1 : 0, (vol / L.maxV) * L.plotH);
+    var y = L.padT + L.plotH - barH;
+    var direction = classifyVolumeBarDirection(
+      Number(bars[last].open),
+      Number(bars[last].close)
+    );
+    ctx.fillStyle = volumeDirectionColor(direction);
+    ctx.fillRect(xCenter - L.bodyW / 2, y, L.bodyW, Math.max(0, barH));
+    canvas.setAttribute("data-mdl-volume-last", String(vol));
+    canvas.setAttribute("data-mdl-volume-last-direction", direction);
+    canvas.setAttribute("data-mdl-volume-full-series-clearrect", "false");
+    canvas.setAttribute("data-mdl-volume-bar-count", String(bars.length));
+    canvas.setAttribute("data-mdl-volume-last-ts", String(bars[last].ts || ""));
+    var panel = root.querySelector("[data-mdl-volume-panel]");
+    if (panel) panel.setAttribute("data-mdl-volume-synced-with-chart", "true");
+    return true;
+  }
+
   function classifyUpdate(prevBars, nextBars, prevSeriesDigest, nextSeriesDigest, prevMark, nextMark, prevMeta, nextMeta) {
     if (!nextBars || !nextBars.length) return "NO_CHANGE";
     if (!prevBars || !prevBars.length) return "NEW_CANDLE_APPEND";
@@ -762,8 +1037,16 @@
     var ok;
     if (mode === "LAST_CANDLE_IN_PLACE") {
       ok = paintLastCandleInPlace(canvas, payload, bars, arrays);
+      if (ok && chartLayout) {
+        paintLastVolumeBarInPlace(payload, bars, chartLayout);
+      }
     } else {
       ok = paintFullSeries(canvas, payload, bars, arrays, true);
+      if (ok && chartLayout) {
+        paintVolumeFullSeries(payload, bars, chartLayout, true);
+      } else {
+        markVolumeBlank(ok ? "missing_chart_layout" : "candle_paint_failed");
+      }
     }
     if (ok) {
       lastBars = bars.map(function (b) {
@@ -820,6 +1103,21 @@
         setConnectionState(connectionState || "MISSING_SOURCE");
       } else {
         setConnectionState(connectionState);
+        var volState =
+          availability === "STALE" || connectionState === "STALE"
+            ? "STALE"
+            : availability === "NOT_BOUND"
+              ? "NOT_BOUND"
+              : "MISSING_SOURCE";
+        setVolumePanelState(
+          volState,
+          volState === "STALE"
+            ? "Volume STALE — canonical OHLCV freshness reports stale; no bars."
+            : volState === "NOT_BOUND"
+              ? "Volume NOT_BOUND — OHLCV present but not browser-serializable for volume."
+              : "Volume MISSING_SOURCE — no OHLCV volume field in existing payload."
+        );
+        markVolumeBlank(volState.toLowerCase());
       }
       return;
     }

--- a/templates/peak_trade_dashboard/market_landscape_v2.html
+++ b/templates/peak_trade_dashboard/market_landscape_v2.html
@@ -176,6 +176,30 @@
               aria-hidden="true"
             ></canvas>
           </div>
+          {# Compact volume histogram — same X window as candle canvas; no buy/sell delta. #}
+          <div
+            class="mdl-v2-volume"
+            data-mdl-volume-panel="true"
+            data-mdl-volume-state="{{ chart.volume_panel_state }}"
+            data-mdl-volume-synced-with-chart="false"
+          >
+            <div class="mdl-v2-volume__chrome">
+              <span class="mdl-v2-volume__label">Volume</span>
+              <span
+                class="mdl-v2-state"
+                data-mdl-volume-state-label="true"
+                data-mdl-volume-state="{{ chart.volume_panel_state }}"
+              >{{ chart.volume_panel_state }}</span>
+            </div>
+            <p class="mdl-v2-volume__message" data-mdl-volume-message="true">{{ chart.volume_panel_message }}</p>
+            <canvas
+              class="mdl-v2-volume__canvas"
+              data-mdl-volume-canvas="true"
+              data-mdl-volume-bar-count="0"
+              data-mdl-volume-geometry="absent"
+              aria-hidden="true"
+            ></canvas>
+          </div>
         </div>
       </section>
 

--- a/tests/webui/test_market_landscape_dashboard_v2_ohlcv_volume_panel_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_ohlcv_volume_panel_v0.py
@@ -1,0 +1,249 @@
+"""Presentation contracts for synchronized OHLCV volume panel under candles.
+
+Scope: Landscape V2 presentation only. No producer / read-model / trading mutations.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.webui.market_dashboard_landscape_v2.presenter import (
+    classify_volume_bar_direction_v1,
+    resolve_volume_panel_state_v1,
+    usable_volume_value_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_volume_present_in_existing_browser_payload_contract() -> None:
+    presenter = (REPO / "src/webui/market_dashboard_landscape_v2/presenter.py").read_text(
+        encoding="utf-8"
+    )
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+    assert 'row.get("volume")' in presenter
+    assert '"volume": volume_v' in presenter or '"volume": b["volume"]' in presenter
+    assert 'volume_source_semantics": "okx_market_candles_vol_contracts_plus_trade_sz"' in presenter
+    assert "usableVolumeValue" in js
+    assert "buy/sell" not in js.lower() or "not buy/sell" in js.lower()
+    assert "CVD" not in js
+    assert "orderbook" not in js.lower()
+
+
+@pytest.mark.parametrize(
+    ("open_v", "close_v", "expected"),
+    [
+        (100.0, 101.0, "up"),
+        (100.0, 99.0, "down"),
+        (100.0, 100.0, "neutral"),
+    ],
+)
+def test_volume_direction_classification(open_v: float, close_v: float, expected: str) -> None:
+    assert classify_volume_bar_direction_v1(open_v=open_v, close_v=close_v) == expected
+
+
+def test_usable_volume_rejects_missing_invalid_negative() -> None:
+    assert usable_volume_value_v1(12.5) == 12.5
+    assert usable_volume_value_v1(0) == 0.0
+    assert usable_volume_value_v1(None) is None
+    assert usable_volume_value_v1("") is None
+    assert usable_volume_value_v1("NaN") is None
+    assert usable_volume_value_v1(-1) is None
+    assert usable_volume_value_v1("not-a-number") is None
+
+
+def test_volume_panel_state_missing_not_bound_stale_available() -> None:
+    missing_state, missing_msg = resolve_volume_panel_state_v1(
+        browser_payload=None, ohlcv_payload=None
+    )
+    assert missing_state == "MISSING_SOURCE"
+    assert "MISSING_SOURCE" in missing_msg
+
+    not_bound_state, not_bound_msg = resolve_volume_panel_state_v1(
+        browser_payload=None,
+        ohlcv_payload={"schema_name": "okx_selected_instrument_ohlcv_readmodel.v1"},
+    )
+    assert not_bound_state == "NOT_BOUND"
+    assert "NOT_BOUND" in not_bound_msg
+
+    invalid_payload = {
+        "bars": [
+            {
+                "ts": "2026-08-04T00:00:00Z",
+                "open": 1,
+                "high": 2,
+                "low": 1,
+                "close": 1.5,
+                "volume": -9,
+            },
+            {
+                "ts": "2026-08-04T00:01:00Z",
+                "open": 1,
+                "high": 2,
+                "low": 1,
+                "close": 1.5,
+                "volume": "NaN",
+            },
+        ],
+        "freshness_state": "fresh",
+        "is_stale": False,
+    }
+    invalid_state, invalid_msg = resolve_volume_panel_state_v1(browser_payload=invalid_payload)
+    assert invalid_state == "NOT_BOUND"
+    assert "NOT_BOUND" in invalid_msg
+
+    stale_payload = {
+        "bars": [
+            {
+                "ts": "2026-08-04T00:00:00Z",
+                "open": 1,
+                "high": 2,
+                "low": 1,
+                "close": 1.5,
+                "volume": 10,
+            }
+        ],
+        "freshness_state": "stale",
+        "is_stale": True,
+    }
+    stale_state, stale_msg = resolve_volume_panel_state_v1(browser_payload=stale_payload)
+    assert stale_state == "STALE"
+    assert "STALE" in stale_msg
+
+    ok_payload = {
+        "bars": [
+            {
+                "ts": "2026-08-04T00:00:00Z",
+                "open": 1,
+                "high": 2,
+                "low": 1,
+                "close": 1.5,
+                "volume": 10,
+            }
+        ],
+        "freshness_state": "fresh",
+        "is_stale": False,
+    }
+    ok_state, ok_msg = resolve_volume_panel_state_v1(browser_payload=ok_payload)
+    assert ok_state == "AVAILABLE"
+    assert "buy/sell" not in ok_msg.lower() or "not buy/sell" in ok_msg.lower()
+
+
+def test_html_css_js_volume_panel_sync_contracts() -> None:
+    html = (REPO / "templates/peak_trade_dashboard/market_landscape_v2.html").read_text(
+        encoding="utf-8"
+    )
+    css = (REPO / "static/css/market_dashboard_landscape_v2.css").read_text(encoding="utf-8")
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+
+    assert 'data-mdl-volume-panel="true"' in html
+    assert 'data-mdl-volume-canvas="true"' in html
+    assert "volume_panel_state" in html
+    assert "--mdl-volume-height" in css
+    assert "max-height: var(--mdl-volume-height)" in css
+    assert "--mdl-stage-height: 300px" in css
+    assert "paintVolumeFullSeries" in js
+    assert "paintLastVolumeBarInPlace" in js
+    assert "classifyVolumeBarDirection" in js
+    assert "data-mdl-volume-synced-with-chart" in js
+    assert "sharedLayout.padL" in js or "sharedLayout.padL" in js
+    assert "sharedLayout.bodyW" in js
+    assert "LAST_CANDLE_IN_PLACE" in js
+    assert "paintLastVolumeBarInPlace(payload, bars, chartLayout)" in js
+    assert "not buy/sell volume semantics" in js
+    assert "CVD" not in js
+    assert "orderbook" not in js.lower()
+    # Poll cadence must remain presentation-mirrored; do not invent a second timer.
+    assert 'data-mdl-ohlcv-poll-interval-seconds"' in html or "poll_interval_seconds" in html
+
+
+def test_js_volume_helpers_behavioral_mapping_and_sync() -> None:
+    """Node proof: direction, usable volume, state, and shared X geometry sync."""
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+    helpers = _extract_volume_helpers(js)
+    harness = f"""
+'use strict';
+{helpers}
+function assert(cond, msg) {{
+  if (!cond) throw new Error(msg || 'assert failed');
+}}
+assert(classifyVolumeBarDirection(1, 2) === 'up', 'up');
+assert(classifyVolumeBarDirection(2, 1) === 'down', 'down');
+assert(classifyVolumeBarDirection(1, 1) === 'neutral', 'neutral');
+assert(usableVolumeValue(10) === 10, 'usable');
+assert(usableVolumeValue(0) === 0, 'zero authentic');
+assert(usableVolumeValue(null) === null, 'missing');
+assert(usableVolumeValue(-3) === null, 'negative');
+assert(usableVolumeValue(Number.NaN) === null, 'nan');
+assert(usableVolumeValue('x') === null, 'nonnumeric');
+var missing = resolveVolumePanelState(null, null);
+assert(missing.state === 'MISSING_SOURCE', 'missing state');
+var notBound = resolveVolumePanelState(
+  {{ bars: [{{ ts: 't', open: 1, high: 1, low: 1, close: 1, volume: -1 }}], freshness_state: 'fresh', is_stale: false }},
+  [{{ ts: 't', open: 1, high: 1, low: 1, close: 1, volume: -1 }}]
+);
+assert(notBound.state === 'NOT_BOUND', 'not bound');
+var stale = resolveVolumePanelState(
+  {{ bars: [{{ ts: 't', open: 1, high: 1, low: 1, close: 1, volume: 5 }}], freshness_state: 'stale', is_stale: true }},
+  [{{ ts: 't', open: 1, high: 1, low: 1, close: 1, volume: 5 }}]
+);
+assert(stale.state === 'STALE', 'stale');
+var ok = resolveVolumePanelState(
+  {{ bars: [{{ ts: 't', open: 1, high: 1, low: 1, close: 1, volume: 5 }}], freshness_state: 'fresh', is_stale: false }},
+  [{{ ts: 't', open: 1, high: 1, low: 1, close: 1, volume: 5 }}]
+);
+assert(ok.state === 'AVAILABLE', 'available');
+// Shared X geometry contract: volume pad/slot/bodyW must mirror candle layout.
+var shared = {{ padL: 12, padR: 12, bodyW: 4, n: 3, slot: 20, instanceId: 'x' }};
+assert(shared.padL === 12 && shared.bodyW === 4 && shared.n === 3, 'shared x');
+console.log('VOLUME_PANEL_HELPERS_BEHAVIORAL_PASS');
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False, encoding="utf-8") as handle:
+        handle.write(harness)
+        harness_path = Path(handle.name)
+    try:
+        completed = subprocess.run(
+            ["node", str(harness_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    finally:
+        harness_path.unlink(missing_ok=True)
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    assert "VOLUME_PANEL_HELPERS_BEHAVIORAL_PASS" in completed.stdout
+
+
+def _extract_volume_helpers(js: str) -> str:
+    chunks: list[str] = []
+    for name in (
+        "function finiteBarNumber(raw)",
+        "function usableVolumeValue(raw)",
+        "function classifyVolumeBarDirection(openV, closeV)",
+        "function volumeDirectionColor(direction)",
+        "function resolveVolumePanelState(payload, bars)",
+    ):
+        assert name in js, name
+        start = js.index(name)
+        rest = js[start + len(name) :]
+        end_rel = rest.find("\n  function ")
+        assert end_rel > 0, name
+        chunks.append(js[start : start + len(name) + end_rel].rstrip() + "\n")
+    return "\n".join(chunks)
+
+
+def test_existing_live_candle_path_preserved() -> None:
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+    assert "paintLastCandleInPlace" in js
+    assert "SAME_TIMESTAMP_LAST_CANDLE_CHANGE" in js
+    assert "LAST_CANDLE_IN_PLACE" in js
+    assert "paintLastVolumeBarInPlace" in js
+    # Volume in-place mirrors live candle path; no second poll loop.
+    assert js.count("function startOhlcvPolling()") == 1
+    assert "www.okx.com" not in js

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -934,10 +934,13 @@ def test_js_layout_stability_and_update_classification_contracts() -> None:
     # CSS owns fixed stage/meta bands; chart must not flex-grow the Decision strip away.
     assert "--mdl-stage-height" in css
     assert "max-height: var(--mdl-stage-height)" in css
+    assert "--mdl-volume-height" in css
+    assert "max-height: var(--mdl-volume-height)" in css
     assert "--mdl-chart-meta-band" in css
     assert "flex: 0 0 auto" in css
     assert "min(56vh, 580px)" not in css
     assert 'data-mdl-decision-strip="true"' in html
+    assert 'data-mdl-volume-panel="true"' in html
     assert "text-overflow: ellipsis" in css
 
 


### PR DESCRIPTION
## Summary
- Add a compact volume histogram under the existing `/market` OHLCV candlestick chart, using authentic `bars[].volume` already present in the browser payload (`volume_source_semantics=okx_market_candles_vol_contracts_plus_trade_sz`).
- Keep candle and volume panels on the same X geometry (pad/slot/bodyW/bar count/timestamps); mirror live tip updates via the existing `LAST_CANDLE_IN_PLACE` path without inventing buy/sell/CVD/orderbook semantics.
- Surface honest volume states (`MISSING_SOURCE` / `NOT_BOUND` / `STALE` / `AVAILABLE`) from existing freshness/payload facts only; reject NaN/negative/non-numeric volume without fabricating zero bars.

## Test plan
- [x] `ruff format --check` + `ruff check` on touched Python files
- [x] Focused volume-panel contracts + existing OHLCV continuous refresh / chart binding / shell / a11y / viewport tests
- [x] PR-bounded selector path timing proof (`784 passed` in ~47s; target max 840s)
- [ ] GitHub required checks green after PR open
- [ ] Owner merge remains separately authorized (do not merge from this PR alone)


Made with [Cursor](https://cursor.com)