### PR TITLE
fix(webui): decouple SSR OHLCV connection chrome from stale identity

### DIFF
--- a/src/webui/market_dashboard_landscape_shell_router_v2.py
+++ b/src/webui/market_dashboard_landscape_shell_router_v2.py
@@ -41,6 +41,7 @@ from .market_dashboard_landscape_v2.availability import Availability
 from .market_dashboard_landscape_v2.page_aggregate import MarketDashboardReadServiceV1
 from .market_dashboard_landscape_v2.presenter import (
     OHLCV_POLL_PATH,
+    _chart_availability_for_ohlcv,
     _ohlcv_data_connection_state,
     present_market_landscape_v2,
     serialize_ohlcv_browser_payload_v1,
@@ -63,15 +64,6 @@ def get_templates() -> Jinja2Templates:
             "Market landscape shell not configured. Call set_market_landscape_shell_config()."
         )
     return _TEMPLATES
-
-
-def _chart_availability_for_ohlcv(ohlcv: dict[str, Any] | None) -> Availability:
-    if ohlcv is None:
-        return Availability.MISSING_SOURCE
-    freshness = str(ohlcv.get("freshness_state") or "").lower()
-    if freshness == "stale" or bool(ohlcv.get("is_stale")):
-        return Availability.STALE
-    return Availability.AVAILABLE
 
 
 def build_ohlcv_poll_response_v1(
@@ -319,13 +311,8 @@ async def market_landscape_dashboard(request: Request) -> Any:
         adapt_derived_ohlcv_payload_to_o5_read_model_v1,
     )
 
-    chart_availability = page.market_instrument.availability
-    if isinstance(ohlcv, dict) and ohlcv.get("bar_count"):
-        freshness = str(ohlcv.get("freshness_state") or "")
-        if freshness == "stale" or bool(ohlcv.get("is_stale")):
-            chart_availability = Availability.STALE
-        elif chart_availability not in (Availability.AVAILABLE, Availability.STALE):
-            chart_availability = Availability.AVAILABLE
+    # SSR connection chrome from OHLCV/O5 only — never inherit instrument identity STALE.
+    chart_availability = _chart_availability_for_ohlcv(ohlcv)
     o5_chrome = adapt_derived_ohlcv_payload_to_o5_read_model_v1(
         ohlcv,
         projection_time_unix=generated_at.timestamp(),

--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -748,6 +748,21 @@ def _open_candle_projection_is_valid(
     return (not confirm) and bool(provisional)
 
 
+def _chart_availability_for_ohlcv(ohlcv: Mapping[str, Any] | None) -> Availability:
+    """Derive chart/OHLCV availability from the OHLCV readmodel only.
+
+    Instrument-identity freshness (market_instrument / universe_selection) must
+    never flow into chart connection chrome. Missing or empty OHLCV stays
+    MISSING_SOURCE; stale OHLCV stays STALE; fresh bars are AVAILABLE.
+    """
+    if not isinstance(ohlcv, Mapping) or not ohlcv.get("bar_count"):
+        return Availability.MISSING_SOURCE
+    freshness = str(ohlcv.get("freshness_state") or "").lower()
+    if freshness == "stale" or bool(ohlcv.get("is_stale")):
+        return Availability.STALE
+    return Availability.AVAILABLE
+
+
 def _ohlcv_source_feed_is_live(
     *,
     browser_payload: Mapping[str, Any] | None,
@@ -910,17 +925,14 @@ def present_market_landscape_v2(
     diagnostics = _slot_view(page.diagnostics_summary)
     health = page.source_health
 
-    chart_availability = page.market_instrument.availability
+    # Chart chrome availability is OHLCV-only — never inherit instrument identity STALE.
+    chart_availability = _chart_availability_for_ohlcv(ohlcv_readmodel)
+    instrument_availability = page.market_instrument.availability
     ohlcv_bound = False
     ohlcv_payload: dict[str, Any] | None = None
     browser_payload = serialize_ohlcv_browser_payload_v1(ohlcv_readmodel)
     if isinstance(ohlcv_readmodel, Mapping) and ohlcv_readmodel.get("bar_count"):
         ohlcv_payload = dict(ohlcv_readmodel)
-        freshness = str(ohlcv_readmodel.get("freshness_state") or "")
-        if freshness == "stale":
-            chart_availability = Availability.STALE
-        elif chart_availability not in (Availability.AVAILABLE, Availability.STALE):
-            chart_availability = Availability.AVAILABLE
         if browser_payload is None:
             ohlcv_bound = False
             chart_message = (
@@ -934,17 +946,17 @@ def present_market_landscape_v2(
                 f"(bars={browser_payload.get('bar_count')}, interval="
                 f"{ohlcv_readmodel.get('interval')})."
             )
-    elif chart_availability in (Availability.AVAILABLE, Availability.STALE):
+    elif instrument_availability in (Availability.AVAILABLE, Availability.STALE):
         chart_message = (
             "Primary chart market instrument bound; OHLCV producer still unbound "
             "(no fabricated candles)."
         )
-    elif chart_availability is Availability.MISSING_SOURCE:
+    elif instrument_availability is Availability.MISSING_SOURCE:
         chart_message = (
             "Primary chart MISSING_SOURCE — market identity / OHLCV not persisted "
             "for dashboard; no OHLCV fabricated."
         )
-    elif chart_availability is Availability.INVALID:
+    elif instrument_availability is Availability.INVALID:
         chart_message = (
             "Primary chart INVALID — market producer output rejected; no OHLCV fabricated."
         )

--- a/tests/webui/test_market_landscape_v2_ssr_ohlcv_connection_chrome_decouple_from_stale_identity_v1.py
+++ b/tests/webui/test_market_landscape_v2_ssr_ohlcv_connection_chrome_decouple_from_stale_identity_v1.py
@@ -1,0 +1,237 @@
+"""SSR OHLCV connection chrome must not inherit instrument-identity STALE.
+
+Capability:
+MARKET_LANDSCAPE_V2_SSR_OHLCV_CONNECTION_CHROME_DECOUPLE_FROM_STALE_IDENTITY_V1
+
+Presentation-only: identity freshness and OHLCV/O5 connection state stay separate.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from src.webui.market_dashboard_landscape_v2 import (
+    Availability,
+    MarketDashboardReadServiceV1,
+    present_market_landscape_v2,
+)
+from src.webui.market_dashboard_landscape_v2.presenter import (
+    _chart_availability_for_ohlcv,
+    _ohlcv_data_connection_state,
+    serialize_ohlcv_browser_payload_v1,
+)
+from src.webui.market_dashboard_landscape_v2.projections import (
+    project_market_instrument_snapshot_v1,
+)
+
+STAMP = datetime(2026, 8, 4, 15, 0, 0, tzinfo=timezone.utc)
+INSTRUMENT = "ETH-USDT-SWAP"
+
+
+def _stale_instrument() -> Any:
+    return project_market_instrument_snapshot_v1(
+        instrument_id=INSTRUMENT,
+        venue="okx",
+        market_type="perpetual",
+        mark_price=None,
+        reason_codes=("PRODUCER_DATA_STALE",),
+        generated_at=STAMP,
+        effective_at=STAMP,
+        source_reference="test://stale_instrument",
+        availability=Availability.STALE,
+        is_stale=True,
+        stale_reason="PRODUCER_DATA_STALE",
+    )
+
+
+def _fresh_instrument() -> Any:
+    return project_market_instrument_snapshot_v1(
+        instrument_id=INSTRUMENT,
+        venue="okx",
+        market_type="perpetual",
+        mark_price=None,
+        reason_codes=(),
+        generated_at=STAMP,
+        effective_at=STAMP,
+        source_reference="test://fresh_instrument",
+        availability=Availability.AVAILABLE,
+        is_stale=False,
+    )
+
+
+def _ohlcv(
+    *,
+    freshness_state: str = "fresh",
+    is_stale: bool = False,
+    live: bool = False,
+) -> dict[str, Any]:
+    tip_confirm = False if live else True
+    payload: dict[str, Any] = {
+        "schema_name": "okx_selected_instrument_ohlcv_readmodel.v1",
+        "schema_version": 1,
+        "venue": "okx",
+        "instrument_id": INSTRUMENT,
+        "interval": "PT1M",
+        "captured_at": "2026-08-04T15:00:00Z",
+        "candle_captured_at": "2026-08-04T15:00:00Z",
+        "effective_at": "2026-08-04T15:00:00Z",
+        "freshness_state": freshness_state,
+        "is_stale": is_stale,
+        "bar_count": 2,
+        "bars": [
+            {
+                "ts": "2026-08-04T14:58:00Z",
+                "open": "100",
+                "high": "101",
+                "low": "99",
+                "close": "100.5",
+                "volume": "10",
+                "confirm": True,
+            },
+            {
+                "ts": "2026-08-04T14:59:00Z",
+                "open": "100.5",
+                "high": "102",
+                "low": "100",
+                "close": "101",
+                "volume": "12",
+                "confirm": tip_confirm,
+            },
+        ],
+    }
+    if live:
+        payload["open_candle_live_source"] = "okx_public_trades_into_pt1m_v1"
+        payload["candle_endpoint"] = "https://www.okx.com/api/v5/market/candles"
+        payload["trades_endpoint"] = "https://www.okx.com/api/v5/market/trades"
+    return payload
+
+
+def _page(*, instrument: Any) -> Any:
+    return MarketDashboardReadServiceV1().load_page_snapshot(
+        generated_at=STAMP,
+        git_sha=None,
+        slot_overrides={"market_instrument": instrument},
+    )
+
+
+def test_chart_availability_helper_is_ohlcv_only() -> None:
+    assert _chart_availability_for_ohlcv(None) is Availability.MISSING_SOURCE
+    assert _chart_availability_for_ohlcv({}) is Availability.MISSING_SOURCE
+    assert _chart_availability_for_ohlcv(_ohlcv()) is Availability.AVAILABLE
+    assert (
+        _chart_availability_for_ohlcv(_ohlcv(freshness_state="stale", is_stale=True))
+        is Availability.STALE
+    )
+
+
+def test_case1_instrument_stale_ohlcv_fresh_o5_healthy_connection_not_stale() -> None:
+    """Instrument STALE + OHLCV fresh/AVAILABLE + O5 HEALTHY → connection HEALTHY."""
+    ohlcv = _ohlcv(live=True)
+    page = _page(instrument=_stale_instrument())
+    ctx = present_market_landscape_v2(
+        page,
+        ohlcv_readmodel=ohlcv,
+        adapted_ohlcv_connection_state="HEALTHY",
+    )
+    assert ctx["market"]["availability"] == "STALE"
+    assert ctx["market"]["is_stale"] is True
+    assert ctx["chart"]["availability"] == "AVAILABLE"
+    assert ctx["chart"]["data_connection_state"] == "HEALTHY"
+    assert ctx["chart"]["data_connection_state"] != "STALE"
+
+
+def test_case2_instrument_fresh_ohlcv_stale_connection_stale() -> None:
+    ohlcv = _ohlcv(freshness_state="stale", is_stale=True)
+    page = _page(instrument=_fresh_instrument())
+    ctx = present_market_landscape_v2(
+        page,
+        ohlcv_readmodel=ohlcv,
+        adapted_ohlcv_connection_state="STALE",
+    )
+    assert ctx["market"]["availability"] == "AVAILABLE"
+    assert ctx["chart"]["availability"] == "STALE"
+    assert ctx["chart"]["data_connection_state"] == "STALE"
+
+
+def test_case3_instrument_stale_ohlcv_missing_connection_missing_source() -> None:
+    page = _page(instrument=_stale_instrument())
+    ctx = present_market_landscape_v2(page, ohlcv_readmodel=None)
+    assert ctx["market"]["availability"] == "STALE"
+    assert ctx["chart"]["availability"] == "MISSING_SOURCE"
+    assert ctx["chart"]["data_connection_state"] == "MISSING_SOURCE"
+
+
+def test_case4_instrument_stale_ohlcv_unhealthy_stays_honest() -> None:
+    ohlcv = _ohlcv(freshness_state="stale", is_stale=True)
+    page = _page(instrument=_stale_instrument())
+    ctx = present_market_landscape_v2(
+        page,
+        ohlcv_readmodel=ohlcv,
+        adapted_ohlcv_connection_state="STALE",
+    )
+    assert ctx["market"]["availability"] == "STALE"
+    assert ctx["chart"]["availability"] == "STALE"
+    assert ctx["chart"]["data_connection_state"] == "STALE"
+
+
+def test_case5_no_ohlcv_o5_evidence_never_invents_healthy() -> None:
+    page = _page(instrument=_stale_instrument())
+    ctx = present_market_landscape_v2(
+        page,
+        ohlcv_readmodel=None,
+        adapted_ohlcv_connection_state="HEALTHY",
+    )
+    assert ctx["chart"]["data_connection_state"] != "HEALTHY"
+    assert ctx["chart"]["data_connection_state"] == "MISSING_SOURCE"
+
+    assert (
+        _ohlcv_data_connection_state(
+            browser_payload=None,
+            ohlcv_payload=None,
+            chart_availability=Availability.MISSING_SOURCE,
+            adapted_connection_state="HEALTHY",
+        )
+        == "MISSING_SOURCE"
+    )
+
+
+def test_shell_ssr_path_decouples_identity_stale_from_ohlcv_connection() -> None:
+    """Shell SSR O5 availability input must come from OHLCV, not instrument STALE."""
+    from src.webui.market_dashboard_landscape_shell_router_v2 import (
+        _chart_availability_for_ohlcv,
+    )
+    from src.ops.canonical_read_model_and_market_dashboard_rebuild_v1.ohlcv_adapter_v1 import (
+        adapt_derived_ohlcv_payload_to_o5_read_model_v1,
+    )
+
+    ohlcv = _ohlcv(live=True)
+    # Identity STALE must not be passed into O5 adaptation for connection chrome.
+    chart_availability = _chart_availability_for_ohlcv(ohlcv)
+    assert chart_availability is Availability.AVAILABLE
+    o5 = adapt_derived_ohlcv_payload_to_o5_read_model_v1(
+        ohlcv,
+        projection_time_unix=STAMP.timestamp(),
+        availability=chart_availability.value,
+    )
+    assert o5["connection_state"] == "HEALTHY"
+    browser = serialize_ohlcv_browser_payload_v1(ohlcv)
+    assert (
+        _ohlcv_data_connection_state(
+            browser_payload=browser,
+            ohlcv_payload=ohlcv,
+            chart_availability=chart_availability,
+            adapted_connection_state=str(o5["connection_state"]),
+        )
+        == "HEALTHY"
+    )
+    # Contrast: legacy bug path would have forced STALE via instrument availability.
+    assert (
+        _ohlcv_data_connection_state(
+            browser_payload=browser,
+            ohlcv_payload=ohlcv,
+            chart_availability=Availability.STALE,
+            adapted_connection_state="HEALTHY",
+        )
+        == "STALE"
+    )


### PR DESCRIPTION
## Summary
- Decouples Market Landscape v2 SSR OHLCV `data-connection-state` from `market_instrument` / universe identity freshness.
- Chart connection chrome now derives only from canonical OHLCV/O5 availability; identity may still render STALE separately.
- Adds regression coverage for the five honest state matrix cases (identity STALE + OHLCV fresh/HEALTHY, OHLCV stale, OHLCV missing, unhealthy OHLCV, no invented HEALTHY).

## Test plan
- [x] Focused decoupling tests (`test_market_landscape_v2_ssr_ohlcv_connection_chrome_decouple_from_stale_identity_v1.py`)
- [x] Related landscape/O5 shell tests
- [x] Ruff format/check
- [x] Canonical selector `PR_BOUNDED_FULL` + local timing proof (~43s / 805 passed)
- [ ] Required GitHub checks green
- [ ] Owner merge only after separate `OWNER_MERGE_GO`

Capability: `MARKET_LANDSCAPE_V2_SSR_OHLCV_CONNECTION_CHROME_DECOUPLE_FROM_STALE_IDENTITY_V1`
Base: `74e08b85c1fefc12edafb2da73f290d09ee128ec`

Made with [Cursor](https://cursor.com)