### PR TITLE
feat(webui): add truthful live price marker for active OHLCV candle

### DIFF
--- a/static/css/market_dashboard_landscape_v2.css
+++ b/static/css/market_dashboard_landscape_v2.css
@@ -374,6 +374,49 @@
   max-height: 100%;
 }
 
+/* Presentation-only last close marker — not a signal/authority cue. */
+.mdl-v2-last-price-marker {
+  position: absolute;
+  z-index: 2;
+  height: 0;
+  pointer-events: none;
+  display: none;
+  margin: 0;
+  padding: 0;
+  transform: translateY(-0.5px);
+}
+
+.mdl-v2-last-price-marker[data-mdl-last-price-visible="true"] {
+  display: block;
+}
+
+.mdl-v2-last-price-marker__line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 0;
+  border-top: 1px dashed #94a3b8;
+  opacity: 0.85;
+}
+
+.mdl-v2-last-price-marker__label {
+  position: absolute;
+  right: 0;
+  top: 2px;
+  max-width: 100%;
+  padding: 0 4px;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 10px;
+  line-height: 1.2;
+  color: #cbd5e1;
+  background: rgba(15, 23, 42, 0.72);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+}
+
 .mdl-v2-volume {
   flex: 0 0 auto;
   display: flex;

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -30,6 +30,9 @@
   var lastCandleSeriesDigest = "";
   var lastMetadataDigest = "";
   var lastMark = null;
+  // Presentation-only poll-close baseline for authentic last-price delta (not a signal).
+  var lastPricePollClose = null;
+  var lastPricePollTs = null;
   var chartInstanceId = "mdl-chart-" + String(Date.now());
 
   var engineering = root.querySelector("[data-mdl-engineering]");
@@ -62,6 +65,7 @@
     canvas.setAttribute("data-mdl-chart-blank", "true");
     canvas.setAttribute("data-mdl-chart-bar-count", "0");
     if (reason) canvas.setAttribute("data-mdl-chart-error", reason);
+    clearLastPriceMarker(canvas);
     markVolumeBlank(reason || "chart_blank");
   }
 
@@ -442,6 +446,155 @@
     return String(n);
   }
 
+  /**
+   * Authentic poll-to-poll close delta for the active candle only.
+   * Same ts: delta = nextClose - prevClose.
+   * New ts / missing prev: baseline reset → delta 0 (not inventing cross-candle motion).
+   * Never fabricates closes; returns nulls when inputs are non-finite.
+   */
+  function resolveLastPricePollDelta(prevClose, prevTs, nextClose, nextTs) {
+    var close = Number(nextClose);
+    var ts = nextTs === undefined || nextTs === null ? "" : String(nextTs);
+    if (!Number.isFinite(close) || !ts) {
+      return { close: null, ts: "", delta: null, deltaPct: null, baselineReset: true };
+    }
+    var prevC = Number(prevClose);
+    var prevT = prevTs === undefined || prevTs === null ? "" : String(prevTs);
+    if (Number.isFinite(prevC) && prevT && prevT === ts) {
+      var delta = close - prevC;
+      var deltaPct = prevC !== 0 ? (delta / prevC) * 100 : null;
+      return {
+        close: close,
+        ts: ts,
+        delta: delta,
+        deltaPct: deltaPct,
+        baselineReset: false,
+      };
+    }
+    return { close: close, ts: ts, delta: 0, deltaPct: 0, baselineReset: true };
+  }
+
+  function formatLastPriceMarkerLabel(close, delta, deltaPct) {
+    if (!Number.isFinite(close)) return "";
+    var parts = ["close " + formatMetaNumber(close)];
+    if (Number.isFinite(delta)) {
+      var sign = delta > 0 ? "+" : "";
+      parts.push("Δ " + sign + formatMetaNumber(delta));
+    }
+    if (Number.isFinite(deltaPct)) {
+      var pctSign = deltaPct > 0 ? "+" : "";
+      parts.push("(" + pctSign + formatMetaNumber(deltaPct) + "%)");
+    }
+    return parts.join(" · ");
+  }
+
+  function ensureLastPriceMarkerEl() {
+    var stage = root.querySelector("[data-mdl-chart-stage]");
+    if (!stage) return null;
+    var el = stage.querySelector("[data-mdl-last-price-marker]");
+    if (el) return el;
+    el = document.createElement("div");
+    el.className = "mdl-v2-last-price-marker";
+    el.setAttribute("data-mdl-last-price-marker", "true");
+    el.setAttribute("data-mdl-last-price-visible", "false");
+    el.setAttribute("aria-hidden", "true");
+    el.setAttribute(
+      "title",
+      "Presentation observation of last candle close and poll delta; not a trading signal."
+    );
+    el.innerHTML =
+      '<div class="mdl-v2-last-price-marker__line" data-mdl-last-price-line="true"></div>' +
+      '<div class="mdl-v2-last-price-marker__label" data-mdl-last-price-label="true"></div>';
+    stage.appendChild(el);
+    return el;
+  }
+
+  function clearLastPriceMarker(canvas) {
+    lastPricePollClose = null;
+    lastPricePollTs = null;
+    var el = root.querySelector("[data-mdl-last-price-marker]");
+    if (el) {
+      el.setAttribute("data-mdl-last-price-visible", "false");
+      el.removeAttribute("data-mdl-last-price-close");
+      el.removeAttribute("data-mdl-last-price-delta");
+      el.removeAttribute("data-mdl-last-price-delta-pct");
+      el.removeAttribute("data-mdl-last-price-y");
+      el.removeAttribute("data-mdl-last-price-ts");
+      var label = el.querySelector("[data-mdl-last-price-label]");
+      if (label) label.textContent = "";
+    }
+    if (canvas) {
+      canvas.removeAttribute("data-mdl-last-price-close");
+      canvas.removeAttribute("data-mdl-last-price-delta");
+      canvas.removeAttribute("data-mdl-last-price-delta-pct");
+      canvas.removeAttribute("data-mdl-last-price-y");
+      canvas.removeAttribute("data-mdl-last-price-ts");
+    }
+  }
+
+  function syncLastPriceMarker(canvas, bars, layout) {
+    if (!canvas || !layout || !Array.isArray(bars) || !bars.length) {
+      clearLastPriceMarker(canvas);
+      return false;
+    }
+    var last = bars[bars.length - 1];
+    var resolved = resolveLastPricePollDelta(
+      lastPricePollClose,
+      lastPricePollTs,
+      last && last.close,
+      last && last.ts
+    );
+    if (resolved.close === null) {
+      clearLastPriceMarker(canvas);
+      return false;
+    }
+    var yCss =
+      layout.padT +
+      (1 - (resolved.close - layout.minP) / layout.span) * layout.plotH;
+    if (!Number.isFinite(yCss)) {
+      clearLastPriceMarker(canvas);
+      return false;
+    }
+    var el = ensureLastPriceMarkerEl();
+    if (!el) return false;
+    var stage = root.querySelector("[data-mdl-chart-stage]");
+    if (!stage) return false;
+    var canvasTop = canvas.offsetTop;
+    var canvasLeft = canvas.offsetLeft;
+    el.style.display = "block";
+    el.style.top = canvasTop + yCss + "px";
+    el.style.left = canvasLeft + layout.padL + "px";
+    el.style.width = Math.max(1, layout.plotW) + "px";
+    el.setAttribute("data-mdl-last-price-visible", "true");
+    el.setAttribute("data-mdl-last-price-close", String(resolved.close));
+    el.setAttribute("data-mdl-last-price-delta", String(resolved.delta));
+    el.setAttribute(
+      "data-mdl-last-price-delta-pct",
+      resolved.deltaPct === null ? "" : String(resolved.deltaPct)
+    );
+    el.setAttribute("data-mdl-last-price-y", String(yCss));
+    el.setAttribute("data-mdl-last-price-ts", resolved.ts);
+    var label = el.querySelector("[data-mdl-last-price-label]");
+    if (label) {
+      label.textContent = formatLastPriceMarkerLabel(
+        resolved.close,
+        resolved.delta,
+        resolved.deltaPct
+      );
+    }
+    canvas.setAttribute("data-mdl-last-price-close", String(resolved.close));
+    canvas.setAttribute("data-mdl-last-price-delta", String(resolved.delta));
+    canvas.setAttribute(
+      "data-mdl-last-price-delta-pct",
+      resolved.deltaPct === null ? "" : String(resolved.deltaPct)
+    );
+    canvas.setAttribute("data-mdl-last-price-y", String(yCss));
+    canvas.setAttribute("data-mdl-last-price-ts", resolved.ts);
+    lastPricePollClose = resolved.close;
+    lastPricePollTs = resolved.ts;
+    return true;
+  }
+
   function lastBarFromPayload(payload) {
     if (!payload || !Array.isArray(payload.bars) || !payload.bars.length) return null;
     return payload.bars[payload.bars.length - 1];
@@ -658,6 +811,11 @@
 
     var geometryOk = drawnPixels > 0 && canvas.width > 0 && canvas.height > 0;
     finishCanvasAttrs(canvas, payload, bars, arrays.closes[n - 1], geometryOk, forceResize);
+    if (geometryOk) {
+      syncLastPriceMarker(canvas, bars, chartLayout);
+    } else {
+      clearLastPriceMarker(canvas);
+    }
     return geometryOk;
   }
 
@@ -795,6 +953,7 @@
     }
 
     finishCanvasAttrs(canvas, payload, bars, arrays.closes[last], true, false);
+    syncLastPriceMarker(canvas, bars, L);
     return true;
   }
 

--- a/tests/webui/test_market_landscape_dashboard_v2_ohlcv_volume_panel_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_ohlcv_volume_panel_v0.py
@@ -158,6 +158,11 @@ def test_html_css_js_volume_panel_sync_contracts() -> None:
     assert "not buy/sell volume semantics" in js
     assert "CVD" not in js
     assert "orderbook" not in js.lower()
+    # Live price marker must not alter volume geometry owners.
+    assert "paintVolumeFullSeries" in js
+    assert "sharedLayout.padL" in js
+    assert "sharedLayout.bodyW" in js
+    assert "mdl-v2-last-price-marker" in css or "syncLastPriceMarker" in js
     # Poll cadence must remain presentation-mirrored; do not invent a second timer.
     assert 'data-mdl-ohlcv-poll-interval-seconds"' in html or "poll_interval_seconds" in html
 
@@ -247,3 +252,14 @@ def test_existing_live_candle_path_preserved() -> None:
     # Volume in-place mirrors live candle path; no second poll loop.
     assert js.count("function startOhlcvPolling()") == 1
     assert "www.okx.com" not in js
+    # Marker is presentation overlay; candle/volume geometry functions remain independent.
+    assert "syncLastPriceMarker" in js
+    assert "function domainFor(highs, lows)" in js
+    paint_last = js.split("function paintLastCandleInPlace", 1)[1].split(
+        "function paintVolumeFullSeries", 1
+    )[0]
+    assert "Math.max(1, Math.abs(yC - yO))" in paint_last
+    assert "syncLastPriceMarker(canvas, bars, L)" in paint_last
+    # Marker must not rewrite OHLC arrays or invent closes into candle bodies.
+    assert "arrays.closes[last] =" not in paint_last
+    assert "bars[last].close =" not in paint_last

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -944,6 +944,111 @@ def test_js_layout_stability_and_update_classification_contracts() -> None:
     assert "text-overflow: ellipsis" in css
 
 
+def test_js_last_price_marker_presentation_contracts() -> None:
+    """Presentation-only last-price marker: authentic close line + poll delta."""
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+    css = (REPO / "static/css/market_dashboard_landscape_v2.css").read_text(encoding="utf-8")
+
+    assert "function resolveLastPricePollDelta(" in js
+    assert "function formatLastPriceMarkerLabel(" in js
+    assert "function syncLastPriceMarker(" in js
+    assert "function clearLastPriceMarker(" in js
+    assert "data-mdl-last-price-marker" in js
+    assert "data-mdl-last-price-line" in js
+    assert "data-mdl-last-price-close" in js
+    assert "data-mdl-last-price-delta" in js
+    assert "data-mdl-last-price-y" in js
+    assert "syncLastPriceMarker(canvas, bars, chartLayout)" in js
+    assert "syncLastPriceMarker(canvas, bars, L)" in js
+    # Line Y must derive from layout yFor(last.close) math — no candle body inflation.
+    assert "(1 - (resolved.close - layout.minP) / layout.span) * layout.plotH" in js
+    assert "not a trading signal" in js
+    assert "mdl-v2-last-price-marker" in css
+    assert "mdl-v2-last-price-marker__line" in css
+    assert "mdl-v2-last-price-marker__label" in css
+    # Geometry owners must remain untouched by this presentation overlay.
+    assert "minP -= span * 0.04" in js
+    assert "maxP += span * 0.04" in js
+    assert "function domainFor(highs, lows)" in js
+    assert "Math.max(1, Math.abs(yC - yO))" in js
+    assert "paintLastVolumeBarInPlace" in js
+
+
+def test_js_last_price_poll_delta_behavioral_contracts() -> None:
+    """Node proof: poll delta from authentic closes; minute reset; identical → 0."""
+    import subprocess
+    import tempfile
+
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+    assert "function resolveLastPricePollDelta(" in js
+    assert "function formatLastPriceMarkerLabel(" in js
+    assert "function formatMetaNumber(" in js
+
+    def _extract(name: str) -> str:
+        start = js.index(name)
+        rest = js[start + len(name) :]
+        end_rel = rest.find("\n  function ")
+        assert end_rel > 0, name
+        return js[start : start + len(name) + end_rel].rstrip() + "\n"
+
+    helpers = "\n".join(
+        [
+            _extract("function formatMetaNumber(value)"),
+            _extract("function resolveLastPricePollDelta(prevClose, prevTs, nextClose, nextTs)"),
+            _extract("function formatLastPriceMarkerLabel(close, delta, deltaPct)"),
+        ]
+    )
+    harness = f"""
+'use strict';
+{helpers}
+function assert(cond, msg) {{
+  if (!cond) throw new Error(msg || 'assert failed');
+}}
+// First observation / new candle baseline reset → delta 0.
+var first = resolveLastPricePollDelta(null, null, 100, 't1');
+assert(first.close === 100 && first.delta === 0 && first.baselineReset === true, 'first');
+// In-place same-ts close change → authentic poll delta.
+var moved = resolveLastPricePollDelta(100, 't1', 100.5, 't1');
+assert(moved.delta === 0.5, 'same-ts delta');
+assert(Math.abs(moved.deltaPct - 0.5) < 1e-12, 'pct');
+// Identical successive closes → zero delta (no false motion).
+var same = resolveLastPricePollDelta(100.5, 't1', 100.5, 't1');
+assert(same.delta === 0 && same.deltaPct === 0, 'identical');
+// Minute / ts change resets baseline deterministically (no cross-candle invent).
+var minute = resolveLastPricePollDelta(100.5, 't1', 101, 't2');
+assert(minute.delta === 0 && minute.baselineReset === true, 'minute reset');
+// Missing/non-finite close fails closed without invented values.
+var bad = resolveLastPricePollDelta(100, 't1', Number.NaN, 't1');
+assert(bad.close === null && bad.delta === null, 'nonfinite');
+var missingTs = resolveLastPricePollDelta(100, 't1', 101, '');
+assert(missingTs.close === null && missingTs.delta === null, 'empty ts');
+var label = formatLastPriceMarkerLabel(100.5, 0.5, 0.5);
+assert(label.indexOf('close') === 0, 'label close');
+assert(label.indexOf('Δ') >= 0, 'label delta');
+assert(label.indexOf('%') >= 0, 'label pct');
+// yFor contract: marker Y uses authentic close against frozen layout domain.
+var layout = {{ padT: 16, minP: 90, span: 20, plotH: 200 }};
+var y = layout.padT + (1 - (100.5 - layout.minP) / layout.span) * layout.plotH;
+assert(Math.abs(y - (16 + (1 - 10.5 / 20) * 200)) < 1e-9, 'yFor close');
+console.log('LAST_PRICE_MARKER_BEHAVIORAL_PASS');
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False, encoding="utf-8") as handle:
+        handle.write(harness)
+        harness_path = Path(handle.name)
+    try:
+        completed = subprocess.run(
+            ["node", str(harness_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    finally:
+        harness_path.unlink(missing_ok=True)
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    assert "LAST_PRICE_MARKER_BEHAVIORAL_PASS" in completed.stdout
+
+
 def test_live_data_requires_fresh_ohlcv_source_not_mark_cosmetics(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Adds a presentation-only last-price marker overlay for the active PT1M candle: horizontal line at `yFor(last.close)` plus numeric close/poll-delta/% from authentic payload closes.
- Resets delta baseline deterministically on minute/ts change; identical successive closes yield delta 0; invalid/missing last candle clears the marker without inventing values.
- Leaves candle, wick, volume geometry and full-series Y-domain (`domainFor` ±4%) mathematically unchanged; marker is explicitly non-signal/non-authority.

## Test plan
- [x] `test_js_last_price_marker_presentation_contracts`
- [x] `test_js_last_price_poll_delta_behavioral_contracts` (Node: same-ts delta, identical→0, minute reset, fail-closed)
- [x] Volume panel contracts remain green
- [x] PR-bounded selector path + focused webui owners (761 passed, ~40s)
- [ ] CI required checks confirm on PR


Made with [Cursor](https://cursor.com)