### PR TITLE
fix(ops): accept authentic PT1M open-tip OHLCV same-ts replacements

### DIFF
--- a/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
+++ b/src/ops/okx_selected_instrument_ohlcv_readmodel_v1.py
@@ -199,7 +199,11 @@ def reduce_okx_ohlcv_bars_v1(
     - AUTHENTIC_FULL_REPLACE: longer authentic window / bootstrap alignment from OKX
 
     Open-candle invariants for SAME_TIMESTAMP_REVISION:
-    open fixed; high may only increase; low may only decrease; close/volume follow source.
+    - PT1M (interval_seconds=60): authentic full tip replacement of O/H/L/C/V is
+      allowed while the youngest tip remains unconfirmed.
+    - Other intervals: open fixed; high may only increase; low may only decrease;
+      close/volume follow source (legacy fail-closed tip geometry).
+    Sealed / non-youngest candles remain immutable under same-timestamp revision.
     """
     if not incoming:
         raise OkxOhlcvReadmodelError("OHLCV_REDUCE_EMPTY_INCOMING")
@@ -227,26 +231,35 @@ def reduce_okx_ohlcv_bars_v1(
             # only when historical prefixes for the overlapping closed range are unchanged.
             return nxt, "AUTHENTIC_FULL_REPLACE"
         for older_p, older_n in zip(prev[:-1], nxt[:-1]):
-            if older_p.ts != older_n.ts or _bar_ohlcv_tuple(older_p) != _bar_ohlcv_tuple(older_n):
-                # Authentic upstream correction of sealed history → accept OKX window.
+            if older_p.ts != older_n.ts:
                 return nxt, "AUTHENTIC_FULL_REPLACE"
+            if _bar_ohlcv_tuple(older_p) != _bar_ohlcv_tuple(older_n):
+                # Historical / non-youngest same-timestamp deviation stays fail-closed.
+                raise OkxOhlcvReadmodelError(f"HISTORICAL_REGRESSION:{older_p.ts}")
         if _bar_ohlcv_tuple(prev_last) == _bar_ohlcv_tuple(next_last):
             # Identical OHLCV at same timestamp is a no-op (preserve prior confirm/metadata).
             return prev, "NO_OP"
-        # Open-candle revision rules.
+        if prev_last.confirm or next_last.confirm:
+            # Sealed tip (or attempt to re-open) must not revise in place.
+            raise OkxOhlcvReadmodelError(f"SEALED_TIP_REGRESSION:{prev_last.ts}")
+        if _dec(next_last.volume, field="volume") < 0:
+            raise OkxOhlcvReadmodelError(f"NEGATIVE_VOLUME:{prev_last.ts}")
+        # PT1M open tip: accept authentic full OHLCV replacement from upstream.
+        if interval_seconds == 60:
+            reduced = list(prev[:-1]) + [next_last]
+            return reduced, "SAME_TIMESTAMP_REVISION"
+        # Legacy open-candle revision rules (non-PT1M).
         if _dec(next_last.open, field="open") != _dec(prev_last.open, field="open"):
             raise OkxOhlcvReadmodelError(f"OPEN_REGRESSION:{prev_last.ts}")
         if _dec(next_last.high, field="high") < _dec(prev_last.high, field="high"):
             raise OkxOhlcvReadmodelError(f"HIGH_REGRESSION:{prev_last.ts}")
         if _dec(next_last.low, field="low") > _dec(prev_last.low, field="low"):
             raise OkxOhlcvReadmodelError(f"LOW_REGRESSION:{prev_last.ts}")
-        if _dec(next_last.volume, field="volume") < 0:
-            raise OkxOhlcvReadmodelError(f"NEGATIVE_VOLUME:{prev_last.ts}")
         # Open tip volume is monotonic non-decreasing across authentic revisions
         # (candles + prior trade aggregation must never regress volume).
         prev_vol = _dec(prev_last.volume, field="volume")
         next_vol = _dec(next_last.volume, field="volume")
-        if (not prev_last.confirm) and (not next_last.confirm) and next_vol < prev_vol:
+        if next_vol < prev_vol:
             next_last = OhlcvBarV1(
                 ts=next_last.ts,
                 open=next_last.open,
@@ -313,12 +326,19 @@ def reduce_okx_ohlcv_bars_v1(
 def merge_open_tip_cumulative_interval_volume_v1(
     previous_bars: Sequence[Mapping[str, Any] | OhlcvBarV1] | None,
     next_bars: Sequence[Mapping[str, Any] | OhlcvBarV1],
+    *,
+    interval_seconds: int = 3600,
 ) -> tuple[list[OhlcvBarV1], dict[str, Any]]:
     """MODEL_A: cumulative open-tip volume is monotonic non-decreasing.
 
     OKX ``/market/candles`` tip volume may temporarily under-report relative to a
     prior trade-augmented cumulative tip (AUTHENTIC_FULL_REPLACE / window churn).
     Closed historical candles are never rewritten.
+
+    PT1M (interval_seconds=60): authentic open-tip full replacement may revise
+    O/H/L/C while keeping a cumulative volume floor (max(prev, next)) so trade
+    augmentation cannot block a later authentic tip via false HIGH/LOW/OPEN
+    regressions and cannot double-count volume.
     """
     nxt = [_as_ohlcv_bar(b) for b in next_bars]
     meta: dict[str, Any] = {
@@ -326,6 +346,7 @@ def merge_open_tip_cumulative_interval_volume_v1(
         "open_tip_volume_preserved": False,
         "open_tip_high_merged": False,
         "open_tip_low_merged": False,
+        "open_tip_authentic_replaced": False,
     }
     if not previous_bars or not nxt:
         return nxt, meta
@@ -339,8 +360,6 @@ def merge_open_tip_cumulative_interval_volume_v1(
     if prev_tip.confirm or next_tip.confirm:
         # Sealed tip must remain immutable; do not re-open or rewrite.
         return nxt, meta
-    if _dec(next_tip.open, field="open") != _dec(prev_tip.open, field="open"):
-        raise OkxOhlcvReadmodelError(f"OPEN_REGRESSION:{prev_tip.ts}")
 
     prev_high = _dec(prev_tip.high, field="high")
     next_high = _dec(next_tip.high, field="high")
@@ -348,6 +367,45 @@ def merge_open_tip_cumulative_interval_volume_v1(
     next_low = _dec(next_tip.low, field="low")
     prev_vol = _dec(prev_tip.volume, field="volume")
     next_vol = _dec(next_tip.volume, field="volume")
+    if next_vol < 0:
+        raise OkxOhlcvReadmodelError(f"NEGATIVE_VOLUME:{prev_tip.ts}")
+
+    if interval_seconds == 60:
+        # Authentic PT1M open-tip replacement: take upstream tip geometry; floor volume.
+        merged_vol = max(prev_vol, next_vol)
+        meta["open_tip_volume_preserved"] = merged_vol != next_vol
+        meta["open_tip_authentic_replaced"] = (
+            _dec(next_tip.open, field="open") != _dec(prev_tip.open, field="open")
+            or next_high != prev_high
+            or next_low != prev_low
+            or next_tip.close != prev_tip.close
+            or merged_vol != prev_vol
+        )
+        if (
+            next_tip.open == prev_tip.open
+            and next_high == prev_high
+            and next_low == prev_low
+            and next_tip.close == prev_tip.close
+            and merged_vol == next_vol
+            and merged_vol == prev_vol
+        ):
+            return nxt, meta
+        merged_tip = OhlcvBarV1(
+            ts=next_tip.ts,
+            open=next_tip.open,
+            high=next_tip.high,
+            low=next_tip.low,
+            close=next_tip.close,
+            volume=format(merged_vol, "f"),
+            volume_ccy=next_tip.volume_ccy or prev_tip.volume_ccy,
+            confirm=False,
+            provider_ts_ms=next_tip.provider_ts_ms or prev_tip.provider_ts_ms,
+        )
+        return list(nxt[:-1]) + [merged_tip], meta
+
+    # Legacy non-PT1M: open fixed; expand high/low; floor volume.
+    if _dec(next_tip.open, field="open") != _dec(prev_tip.open, field="open"):
+        raise OkxOhlcvReadmodelError(f"OPEN_REGRESSION:{prev_tip.ts}")
 
     merged_high = max(prev_high, next_high)
     merged_low = min(prev_low, next_low)
@@ -739,7 +797,9 @@ def materialize_selected_okx_ohlcv_readmodel_v1(
             }
             stale_overwrite_rejected = True
 
-    bars, cumulative_meta = merge_open_tip_cumulative_interval_volume_v1(previous_bars, bars)
+    bars, cumulative_meta = merge_open_tip_cumulative_interval_volume_v1(
+        previous_bars, bars, interval_seconds=interval_seconds
+    )
     if trade_revision_kind in {"SAME_TIMESTAMP_REVISION", "NEW_INTERVAL_APPEND"}:
         revision_kind = trade_revision_kind
     elif stale_overwrite_rejected:

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -19,6 +19,7 @@ from src.ops.okx_selected_instrument_ohlcv_readmodel_v1 import (
     OhlcvBarV1,
     OkxOhlcvReadmodelError,
     materialize_selected_okx_ohlcv_readmodel_v1,
+    merge_open_tip_cumulative_interval_volume_v1,
     reduce_okx_ohlcv_bars_v1,
     refresh_selected_okx_ohlcv_readmodel_from_archive_v1,
 )
@@ -302,7 +303,7 @@ def test_open_candle_reducer_same_timestamp_revisions_then_append() -> None:
     assert bars_d[1].ts == t1
     assert bars_d[1].close == "101"
 
-    # Open regression and high/low regressions fail closed.
+    # Non-PT1M (default interval): open regression and high/low regressions fail closed.
     with pytest.raises(OkxOhlcvReadmodelError, match="OPEN_REGRESSION"):
         reduce_okx_ohlcv_bars_v1(
             bars_c,
@@ -318,6 +319,145 @@ def test_open_candle_reducer_same_timestamp_revisions_then_append() -> None:
             bars_c,
             [_bar(ts=t0, o="100", h="103", l="99", c="98", v="3", confirm=False)],
         )
+
+
+def test_pt1m_open_tip_accepts_authentic_full_ohlcv_replacement() -> None:
+    """PT1M open tip: authentic same-ts full O/H/L/C/V replacement is accepted."""
+    t0 = "2026-07-25T00:00:00Z"
+    t1 = "2026-07-25T00:01:00Z"
+    bootstrap = [_bar(ts=t0, o="100", h="100", l="100", c="100", v="1", confirm=False)]
+    bars_a, kind_a = reduce_okx_ohlcv_bars_v1(None, bootstrap, interval_seconds=60)
+    assert kind_a == "BOOTSTRAP"
+
+    # A: open/high/low/close/volume may all change on the open tip.
+    replaced = [_bar(ts=t0, o="99", h="104", l="97", c="101", v="9", confirm=False)]
+    bars_b, kind_b = reduce_okx_ohlcv_bars_v1(bars_a, replaced, interval_seconds=60)
+    assert kind_b == "SAME_TIMESTAMP_REVISION"
+    assert len(bars_b) == 1
+    assert bars_b[0].open == "99"
+    assert bars_b[0].high == "104"
+    assert bars_b[0].low == "97"
+    assert bars_b[0].close == "101"
+    assert bars_b[0].volume == "9"
+
+    # Trade-augmented tip then authentic narrower/lower volume tip: no HIGH/LOW false positive.
+    trade_aug = [_bar(ts=t0, o="99", h="110", l="90", c="105", v="50", confirm=False)]
+    bars_c, kind_c = reduce_okx_ohlcv_bars_v1(bars_b, trade_aug, interval_seconds=60)
+    assert kind_c == "SAME_TIMESTAMP_REVISION"
+    authentic = [_bar(ts=t0, o="98", h="103", l="95", c="102", v="40", confirm=False)]
+    bars_d, kind_d = reduce_okx_ohlcv_bars_v1(bars_c, authentic, interval_seconds=60)
+    assert kind_d == "SAME_TIMESTAMP_REVISION"
+    assert bars_d[0].open == "98"
+    assert bars_d[0].high == "103"
+    assert bars_d[0].low == "95"
+    assert bars_d[0].close == "102"
+    assert bars_d[0].volume == "40"
+    merged, meta = merge_open_tip_cumulative_interval_volume_v1(bars_c, bars_d, interval_seconds=60)
+    assert meta.get("open_tip_authentic_replaced") is True
+    assert merged[-1].open == "98"
+    assert merged[-1].high == "103"
+    assert merged[-1].low == "95"
+    assert merged[-1].close == "102"
+    # Volume floor preserves prior trade-augmented cumulative without double-count.
+    assert merged[-1].volume == "50"
+    assert meta["open_tip_volume_preserved"] is True
+
+    # C: next minute append seals prior tip; sealed tip then immutable.
+    sealed = _bar(ts=t0, o="98", h="103", l="95", c="102", v="50", confirm=True)
+    nxt = _bar(ts=t1, o="102", h="102", l="102", c="102", v="1", confirm=False)
+    bars_e, kind_e = reduce_okx_ohlcv_bars_v1(merged, [sealed, nxt], interval_seconds=60)
+    assert kind_e == "NEW_INTERVAL_APPEND"
+    assert len(bars_e) == 2
+    assert bars_e[0].confirm is True
+    assert bars_e[1].ts == t1
+    with pytest.raises(OkxOhlcvReadmodelError, match="HISTORICAL_REGRESSION"):
+        reduce_okx_ohlcv_bars_v1(
+            bars_e,
+            [
+                _bar(ts=t0, o="97", h="103", l="95", c="102", v="50", confirm=True),
+                nxt,
+            ],
+            interval_seconds=60,
+        )
+    with pytest.raises(OkxOhlcvReadmodelError, match="HISTORICAL_REGRESSION"):
+        reduce_okx_ohlcv_bars_v1(
+            bars_e,
+            [
+                _bar(ts=t0, o="98", h="999", l="95", c="102", v="50", confirm=True),
+                nxt,
+            ],
+            interval_seconds=60,
+        )
+    with pytest.raises(OkxOhlcvReadmodelError, match="SEALED_TIP_REGRESSION"):
+        reduce_okx_ohlcv_bars_v1(
+            [sealed],
+            [_bar(ts=t0, o="97", h="103", l="95", c="102", v="50", confirm=True)],
+            interval_seconds=60,
+        )
+    # Timestamp regression / rewind is accepted only as AUTHENTIC_FULL_REPLACE window.
+    rewind = [_bar(ts="2026-07-24T23:59:00Z", o="1", h="1", l="1", c="1", v="1", confirm=True)]
+    bars_rw, kind_rw = reduce_okx_ohlcv_bars_v1(bars_e, rewind, interval_seconds=60)
+    assert kind_rw == "AUTHENTIC_FULL_REPLACE"
+    assert bars_rw[0].ts == "2026-07-24T23:59:00Z"
+
+
+def test_pt1m_open_tip_replacement_refresh_does_not_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same-ts PT1M tip open revision rematerializes without REFRESH_FAILED."""
+    archive = tmp_path / "archive"
+    selection = _write_universe(archive)
+    monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
+    materialize_selected_okx_ohlcv_readmodel_v1(
+        archive_root=archive,
+        selected_instrument=INSTRUMENT,
+        selected_provider_instrument_id=INSTRUMENT,
+        selected_venue="okx",
+        selection_bundle_id="bundle-a",
+        selection_path=selection,
+        bar="PT1M",
+        client=_FakeOkxClient(  # type: ignore[arg-type]
+            captured_at="2026-07-25T00:00:00Z",
+            open_px="0.000000009100",
+            high_px="0.000000009100",
+            low_px="0.000000009100",
+            close_px="0.000000009100",
+            volume="10",
+            mark_px="0.000000009100",
+        ),
+    )
+    path = archive / "readmodels/okx_selected_instrument_ohlcv_readmodel.v1.json"
+    first = json.loads(path.read_text(encoding="utf-8"))
+    assert first["interval"] == "PT1M"
+    assert len(first["bars"]) >= 1
+    tip_ts = first["bars"][-1]["ts"]
+    result = refresh_selected_okx_ohlcv_readmodel_from_archive_v1(
+        archive_root=archive,
+        bar="PT1M",
+        force=True,
+        client=_FakeOkxClient(  # type: ignore[arg-type]
+            captured_at="2026-07-25T00:00:03Z",
+            open_px="0.000000009050",
+            high_px="0.000000009200",
+            low_px="0.000000009000",
+            close_px="0.000000009150",
+            volume="25",
+            mark_px="0.000000009150",
+        ),
+    )
+    assert result["status"] == "OK"
+    assert result.get("refresh_error") is None
+    second = json.loads(path.read_text(encoding="utf-8"))
+    assert len(second["bars"]) == len(first["bars"])
+    assert second["bars"][-1]["ts"] == tip_ts
+    assert second["bars"][-1]["open"] == "0.000000009050"
+    assert second["bars"][-1]["high"] == "0.000000009200"
+    assert second["bars"][-1]["low"] == "0.000000009000"
+    assert second["bars"][-1]["close"] == "0.000000009150"
+    assert second["bars"][-1]["volume"] == "25"
+    # No duplicate tip timestamps after replacement.
+    tip_times = [b["ts"] for b in second["bars"]]
+    assert len(tip_times) == len(set(tip_times))
 
 
 def test_volume_revision_moves_candle_series_digest(


### PR DESCRIPTION
## Summary
- Accept authentic same-timestamp full OHLCV replacements only for the current open youngest PT1M tip so rematerialize no longer fails with false `OPEN_REGRESSION` / `HIGH_REGRESSION` / `LOW_REGRESSION`.
- Keep historical and sealed candles strictly immutable; preserve instrument/interval/monotonicity/OHLC/volume guards and volume floor against double-count on trade-augmented tips.
- Add focused continuous-refresh coverage for open-tip replacement, refresh success, and historical fail-closed behavior.

## Test plan
- [x] Focused: `tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py`, `tests/ops/test_okx_public_trades_open_candle_v1.py`, `tests/ops/test_okx_selected_instrument_ohlcv_pt1m_live_repaint_v1.py` (47 passed)
- [x] PR-bounded selector targets (729 passed, ~37s)
- [x] `ruff format --check` / `ruff check` on touched files
- [ ] GitHub required checks green
- [ ] No merge without `OWNER_MERGE_GO`


Made with [Cursor](https://cursor.com)