### PR TITLE
fix(webui): decimal-safe OHLCV price chrome and chart declutter

### DIFF
--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from decimal import Decimal, InvalidOperation
 from typing import Any, Mapping
 
 from .availability import Availability
@@ -27,6 +28,94 @@ OHLCV_POLL_INTERVAL_SECONDS = 1
 def _ohlcv_poll_interval_seconds() -> int:
     """Presentation mirror of the canonical OKX OHLCV poll cadence."""
     return int(OHLCV_POLL_INTERVAL_SECONDS)
+
+
+def _tick_fraction_digits(tick_size: Decimal) -> int | None:
+    """Derive display fraction digits from a positive tick size (presentation only)."""
+    if tick_size <= 0 or not tick_size.is_finite():
+        return None
+    exp = tick_size.normalize().as_tuple().exponent
+    if isinstance(exp, int) and exp < 0:
+        return -exp
+    if isinstance(exp, int):
+        return 0
+    return None
+
+
+def format_market_price_display_v1(
+    value: Any,
+    *,
+    tick_size: Any | None = None,
+) -> str:
+    """Plain-decimal market price for Landscape chrome — never scientific notation.
+
+    Prefer instrument tick_size decimals when available. Otherwise use a
+    documented normalize()/fixed-point fallback. Display string only; does not
+    mutate OHLCV / readmodel / producer values.
+    """
+    if value is None or value == "":
+        return "—"
+    try:
+        decimal_value = Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return "—"
+    if not decimal_value.is_finite():
+        return "—"
+
+    tick_digits: int | None = None
+    if tick_size is not None and tick_size != "":
+        try:
+            tick = Decimal(str(tick_size))
+        except (InvalidOperation, ValueError, TypeError):
+            tick = None
+        if tick is not None:
+            tick_digits = _tick_fraction_digits(tick)
+
+    if tick_digits is not None:
+        quant = Decimal(1).scaleb(-tick_digits)
+        return format(decimal_value.quantize(quant), "f")
+
+    # Documented fallback when tick/precision metadata is absent on this surface.
+    plain = format(decimal_value.normalize(), "f")
+    if plain in {"-0", "-0.0"}:
+        return "0"
+    return plain
+
+
+def format_market_volume_display_v1(value: Any) -> str:
+    """Plain-decimal volume for Landscape chrome — never scientific notation."""
+    if value is None or value == "":
+        return "—"
+    try:
+        decimal_value = Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return "—"
+    if not decimal_value.is_finite() or decimal_value < 0:
+        return "—"
+    if decimal_value == decimal_value.to_integral_value():
+        return format(decimal_value.to_integral_value(), "f")
+    plain = format(decimal_value.normalize(), "f")
+    if plain in {"-0", "-0.0"}:
+        return "0"
+    return plain
+
+
+def format_market_change_pct_display_v1(open_v: Any, close_v: Any) -> str:
+    """Authentic last-candle open→close percent change for meta chrome only."""
+    if open_v is None or open_v == "" or close_v is None or close_v == "":
+        return "—"
+    try:
+        open_d = Decimal(str(open_v))
+        close_d = Decimal(str(close_v))
+    except (InvalidOperation, ValueError, TypeError):
+        return "—"
+    if not open_d.is_finite() or not close_d.is_finite() or open_d == 0:
+        return "—"
+    pct = (close_d - open_d) / open_d * Decimal(100)
+    plain = format(pct.quantize(Decimal("0.0001")), "f")
+    if pct > 0:
+        return f"+{plain}%"
+    return f"{plain}%"
 
 
 AVAILABILITY_LABELS: Mapping[Availability, str] = {
@@ -190,7 +279,7 @@ def resolve_volume_panel_state_v1(
         )
     return (
         "AVAILABLE",
-        "Volume bound to authentic OHLCV bar volume (contracts); not buy/sell delta.",
+        "",
     )
 
 
@@ -968,6 +1057,37 @@ def present_market_landscape_v2(
         ohlcv_payload=ohlcv_payload,
     )
 
+    # Prefer authentic readmodel decimal strings for chrome display when present.
+    last_display_bar: Mapping[str, Any] | None = None
+    if isinstance(ohlcv_payload, Mapping):
+        bars_for_display = ohlcv_payload.get("bars")
+        if isinstance(bars_for_display, list) and bars_for_display:
+            candidate = bars_for_display[-1]
+            if isinstance(candidate, Mapping):
+                last_display_bar = candidate
+    if last_display_bar is None and isinstance(browser_payload, Mapping):
+        bars_for_display = browser_payload.get("bars")
+        if isinstance(bars_for_display, list) and bars_for_display:
+            candidate = bars_for_display[-1]
+            if isinstance(candidate, Mapping):
+                last_display_bar = candidate
+
+    # Optional tick_size may appear on future presentation bindings; never invent.
+    tick_size_raw = None
+    if isinstance(ohlcv_payload, Mapping):
+        tick_size_raw = ohlcv_payload.get("tick_size") or ohlcv_payload.get("tickSz")
+    if tick_size_raw in (None, "") and isinstance(browser_payload, Mapping):
+        tick_size_raw = browser_payload.get("tick_size") or browser_payload.get("tickSz")
+
+    open_raw = None if last_display_bar is None else last_display_bar.get("open")
+    high_raw = None if last_display_bar is None else last_display_bar.get("high")
+    low_raw = None if last_display_bar is None else last_display_bar.get("low")
+    close_raw = None if last_display_bar is None else last_display_bar.get("close")
+    volume_raw = None if last_display_bar is None else last_display_bar.get("volume")
+    live_mark_raw = (browser_payload or {}).get("live_mark_price")
+    if live_mark_raw is None and isinstance(ohlcv_payload, Mapping):
+        live_mark_raw = ohlcv_payload.get("live_mark_price")
+
     ranking_rows: list[dict[str, Any]] = []
     universe_rows: list[dict[str, Any]] = []
     selected_instrument_id = None
@@ -1127,26 +1247,29 @@ def present_market_landscape_v2(
             "chart_digest": (browser_payload or {}).get("chart_digest"),
             "candle_series_digest": (browser_payload or {}).get("candle_series_digest"),
             "metadata_digest": (browser_payload or {}).get("metadata_digest"),
-            "live_mark_price": (browser_payload or {}).get("live_mark_price"),
+            "live_mark_price": None
+            if live_mark_raw is None
+            else format_market_price_display_v1(live_mark_raw, tick_size=tick_size_raw),
             "live_price_kind": (browser_payload or {}).get("live_price_kind"),
             "ohlcv_revision_kind": (browser_payload or ohlcv_payload or {}).get(
                 "ohlcv_revision_kind"
             ),
             "open_price": None
-            if not browser_payload or not browser_payload.get("bars")
-            else browser_payload["bars"][-1].get("open"),
+            if open_raw is None
+            else format_market_price_display_v1(open_raw, tick_size=tick_size_raw),
             "high_price": None
-            if not browser_payload or not browser_payload.get("bars")
-            else browser_payload["bars"][-1].get("high"),
+            if high_raw is None
+            else format_market_price_display_v1(high_raw, tick_size=tick_size_raw),
             "low_price": None
-            if not browser_payload or not browser_payload.get("bars")
-            else browser_payload["bars"][-1].get("low"),
+            if low_raw is None
+            else format_market_price_display_v1(low_raw, tick_size=tick_size_raw),
             "close_price": None
-            if not browser_payload or not browser_payload.get("bars")
-            else browser_payload["bars"][-1].get("close"),
-            "volume": None
-            if not browser_payload or not browser_payload.get("bars")
-            else browser_payload["bars"][-1].get("volume"),
+            if close_raw is None
+            else format_market_price_display_v1(close_raw, tick_size=tick_size_raw),
+            "change_pct": None
+            if open_raw is None or close_raw is None
+            else format_market_change_pct_display_v1(open_raw, close_raw),
+            "volume": None if volume_raw is None else format_market_volume_display_v1(volume_raw),
             "volume_panel_state": volume_panel_state,
             "volume_panel_message": volume_panel_message,
             "is_stale": bool((ohlcv_payload or {}).get("is_stale")),

--- a/static/css/market_dashboard_landscape_v2.css
+++ b/static/css/market_dashboard_landscape_v2.css
@@ -59,10 +59,11 @@
   --mdl-stage-height: 300px;
   /* Compact volume histogram under candles; must not displace candle stage height. */
   --mdl-volume-height: 64px;
-  --mdl-volume-chrome-band: 1rem;
-  --mdl-volume-message-band: 1rem;
+  --mdl-volume-chrome-band: 0px;
+  --mdl-volume-message-band: 0px;
   --mdl-chart-chrome-band: 1.5rem;
-  --mdl-chart-meta-band: 5.5rem;
+  /* Budget for wrapped OHLC meta in right-rail max-height calc only. */
+  --mdl-chart-meta-band: 6.5rem;
   --mdl-chart-message-band: 1.25rem;
   box-sizing: border-box;
   max-width: 100vw;
@@ -282,27 +283,27 @@
 }
 
 .mdl-v2-chart__meta {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 4px 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
   margin: 0 0 6px;
   padding: 0;
-  /* Two reserved rows: provenance + open-candle O/H/L/C/V (no layout growth). */
-  min-height: var(--mdl-chart-meta-band);
-  max-height: var(--mdl-chart-meta-band);
-  overflow: hidden;
+  min-height: 0;
+  max-height: none;
+  overflow: visible;
   align-content: start;
 }
 
 .mdl-v2-chart__meta > div {
   min-width: 0;
+  flex: 0 1 auto;
 }
 
 .mdl-v2-chart__meta dt {
   margin: 0;
   font-size: 10px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  text-transform: none;
   color: #64748b;
   white-space: nowrap;
 }
@@ -313,19 +314,26 @@
   font-size: 11px;
   line-height: 1.25;
   min-height: 1.25em;
-  max-height: 1.25em;
+  max-height: none;
   color: #cbd5e1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  overflow-wrap: normal;
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
-@media (max-width: 1100px) {
+.mdl-v2-chart__meta-ohlc {
+  flex: 1 1 7.5rem;
+}
+
+@media (min-width: 1100px) {
   .mdl-v2-chart__meta {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    min-height: 7.5rem;
-    max-height: 7.5rem;
+    flex-wrap: wrap;
+  }
+
+  .mdl-v2-chart__meta-ohlc {
+    flex: 0 1 auto;
   }
 }
 
@@ -401,20 +409,7 @@
 }
 
 .mdl-v2-last-price-marker__label {
-  position: absolute;
-  right: 0;
-  top: 2px;
-  max-width: 100%;
-  padding: 0 4px;
-  font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 10px;
-  line-height: 1.2;
-  color: #cbd5e1;
-  background: rgba(15, 23, 42, 0.72);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  pointer-events: none;
+  display: none;
 }
 
 .mdl-v2-volume {
@@ -423,44 +418,15 @@
   flex-direction: column;
   margin: 2px 0 0;
   min-height: 0;
-  height: calc(
-    var(--mdl-volume-height) + var(--mdl-volume-chrome-band) + var(--mdl-volume-message-band)
-  );
-  max-height: calc(
-    var(--mdl-volume-height) + var(--mdl-volume-chrome-band) + var(--mdl-volume-message-band)
-  );
+  height: var(--mdl-volume-height);
+  max-height: var(--mdl-volume-height);
   overflow: hidden;
 }
 
-.mdl-v2-volume__chrome {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 8px;
-  height: var(--mdl-volume-chrome-band);
-  min-height: var(--mdl-volume-chrome-band);
-  max-height: var(--mdl-volume-chrome-band);
-  overflow: hidden;
-}
-
-.mdl-v2-volume__label {
-  font-size: 10px;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  color: var(--mdl-muted);
-  font-weight: 600;
-}
-
+.mdl-v2-volume__chrome,
+.mdl-v2-volume__label,
 .mdl-v2-volume__message {
-  margin: 0;
-  height: var(--mdl-volume-message-band);
-  min-height: var(--mdl-volume-message-band);
-  max-height: var(--mdl-volume-message-band);
-  font-size: 11px;
-  color: #94a3b8;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  display: none;
 }
 
 .mdl-v2-volume__canvas {

--- a/static/js/market_dashboard_landscape_v2.js
+++ b/static/js/market_dashboard_landscape_v2.js
@@ -100,7 +100,7 @@
       label.textContent = token;
       label.setAttribute("data-mdl-volume-state", token);
     }
-    if (msg && message) msg.textContent = String(message);
+    if (msg) msg.textContent = message ? String(message) : "";
   }
 
   function setConnectionState(state) {
@@ -276,8 +276,7 @@
     }
     return {
       state: "AVAILABLE",
-      message:
-        "Volume bound to authentic OHLCV bar volume (contracts); not buy/sell delta.",
+      message: "",
     };
   }
 
@@ -438,12 +437,122 @@
     return true;
   }
 
-  function formatMetaNumber(value) {
-    if (value === undefined || value === null || value === "") return "—";
+  function resolvePresentationTickSize(payload) {
+    var fromRoot = root.getAttribute("data-mdl-tick-size");
+    if (fromRoot && String(fromRoot).trim()) return String(fromRoot).trim();
+    if (payload && payload.tick_size != null && String(payload.tick_size).trim()) {
+      return String(payload.tick_size).trim();
+    }
+    if (payload && payload.tickSz != null && String(payload.tickSz).trim()) {
+      return String(payload.tickSz).trim();
+    }
+    return null;
+  }
+
+  function tickFractionDigits(tickSize) {
+    if (tickSize === undefined || tickSize === null || tickSize === "") return null;
+    var raw = String(tickSize).trim();
+    if (!raw) return null;
+    var n = Number(raw);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    if (raw.indexOf("e") >= 0 || raw.indexOf("E") >= 0) {
+      var expanded = expandScientificToPlain(raw);
+      if (!expanded) return null;
+      raw = expanded;
+    }
+    var dot = raw.indexOf(".");
+    if (dot < 0) return 0;
+    return raw.length - dot - 1;
+  }
+
+  function expandScientificToPlain(raw) {
+    var s = String(raw).trim();
+    var match = /^([+-]?)(\d+)(?:\.(\d+))?e([+-]?\d+)$/i.exec(s);
+    if (!match) return null;
+    var sign = match[1] === "-" ? "-" : "";
+    var intPart = match[2];
+    var fracPart = match[3] || "";
+    var exp = parseInt(match[4], 10);
+    if (!Number.isFinite(exp)) return null;
+    var digits = intPart + fracPart;
+    var exponent = exp - fracPart.length;
+    if (exponent >= 0) {
+      return sign + digits + new Array(exponent + 1).join("0");
+    }
+    var pointAt = digits.length + exponent;
+    if (pointAt <= 0) {
+      return sign + "0." + new Array(1 - pointAt).join("0") + digits;
+    }
+    return sign + digits.slice(0, pointAt) + "." + digits.slice(pointAt);
+  }
+
+  function decimalSafePlainFromInput(value) {
+    if (value === undefined || value === null || value === "") return null;
+    if (typeof value === "string") {
+      var trimmed = value.trim();
+      if (!trimmed) return null;
+      if (/[eE]/.test(trimmed)) {
+        return expandScientificToPlain(trimmed);
+      }
+      if (!Number.isFinite(Number(trimmed))) return null;
+      return trimmed;
+    }
     var n = Number(value);
-    if (!Number.isFinite(n)) return String(value);
-    if (Math.abs(n) > 0 && Math.abs(n) < 1e-4) return n.toExponential(3);
-    return String(n);
+    if (!Number.isFinite(n)) return null;
+    var asString = String(n);
+    if (/[eE]/.test(asString)) {
+      return expandScientificToPlain(asString);
+    }
+    return asString;
+  }
+
+  function formatMarketPriceDisplay(value, tickSize) {
+    // Presentation-only plain decimal; never toExponential. Prefer tick decimals.
+    var plain = decimalSafePlainFromInput(value);
+    if (plain === null) {
+      if (value === undefined || value === null || value === "") return "—";
+      return String(value);
+    }
+    var digits = tickFractionDigits(tickSize);
+    if (digits !== null) {
+      var num = Number(plain);
+      if (!Number.isFinite(num)) return plain;
+      // Display-only fixed digits from tick; avoid scientific via plain expansion.
+      var fixed = num.toFixed(digits);
+      if (/[eE]/.test(fixed)) {
+        var expandedFixed = expandScientificToPlain(fixed);
+        return expandedFixed || plain;
+      }
+      return fixed;
+    }
+    // Documented fallback when tick/precision metadata is absent.
+    return plain;
+  }
+
+  function formatMarketVolumeDisplay(value) {
+    var plain = decimalSafePlainFromInput(value);
+    if (plain === null) {
+      if (value === undefined || value === null || value === "") return "—";
+      return String(value);
+    }
+    var num = Number(plain);
+    if (Number.isFinite(num) && Number.isInteger(num)) return String(num);
+    return plain;
+  }
+
+  function formatMarketChangePctDisplay(openV, closeV) {
+    var o = Number(openV);
+    var c = Number(closeV);
+    if (!Number.isFinite(o) || !Number.isFinite(c) || o === 0) return "—";
+    var pct = ((c - o) / o) * 100;
+    if (!Number.isFinite(pct)) return "—";
+    var plain = pct.toFixed(4);
+    if (pct > 0) return "+" + plain + "%";
+    return plain + "%";
+  }
+
+  function formatMetaNumber(value, tickSize) {
+    return formatMarketPriceDisplay(value, tickSize);
   }
 
   /**
@@ -475,11 +584,12 @@
   }
 
   function formatLastPriceMarkerLabel(close, delta, deltaPct) {
+    // Retained for contract tests; in-chart text box is intentionally unused.
     if (!Number.isFinite(close)) return "";
-    var parts = ["close " + formatMetaNumber(close)];
+    var parts = ["Close " + formatMetaNumber(close)];
     if (Number.isFinite(delta)) {
       var sign = delta > 0 ? "+" : "";
-      parts.push("Δ " + sign + formatMetaNumber(delta));
+      parts.push("Change " + sign + formatMetaNumber(delta));
     }
     if (Number.isFinite(deltaPct)) {
       var pctSign = deltaPct > 0 ? "+" : "";
@@ -500,11 +610,10 @@
     el.setAttribute("aria-hidden", "true");
     el.setAttribute(
       "title",
-      "Presentation observation of last candle close and poll delta; not a trading signal."
+      "Presentation observation of last candle close; not a trading signal."
     );
     el.innerHTML =
-      '<div class="mdl-v2-last-price-marker__line" data-mdl-last-price-line="true"></div>' +
-      '<div class="mdl-v2-last-price-marker__label" data-mdl-last-price-label="true"></div>';
+      '<div class="mdl-v2-last-price-marker__line" data-mdl-last-price-line="true"></div>';
     stage.appendChild(el);
     return el;
   }
@@ -574,14 +683,9 @@
     );
     el.setAttribute("data-mdl-last-price-y", String(yCss));
     el.setAttribute("data-mdl-last-price-ts", resolved.ts);
+    // No in-chart close/Δ text box — authentic values stay in the meta row.
     var label = el.querySelector("[data-mdl-last-price-label]");
-    if (label) {
-      label.textContent = formatLastPriceMarkerLabel(
-        resolved.close,
-        resolved.delta,
-        resolved.deltaPct
-      );
-    }
+    if (label) label.textContent = "";
     canvas.setAttribute("data-mdl-last-price-close", String(resolved.close));
     canvas.setAttribute("data-mdl-last-price-delta", String(resolved.delta));
     canvas.setAttribute(
@@ -610,9 +714,11 @@
     var highNode = root.querySelector('[data-mdl-field="ohlcv_high"]');
     var lowNode = root.querySelector('[data-mdl-field="ohlcv_low"]');
     var closeNode = root.querySelector('[data-mdl-field="ohlcv_close"]');
+    var changeNode = root.querySelector('[data-mdl-field="ohlcv_change"]');
     var volumeNode = root.querySelector('[data-mdl-field="ohlcv_volume"]');
     var availNode = root.querySelector("[data-mdl-chart-availability]");
     var last = lastBarFromPayload(payload);
+    var tickSize = resolvePresentationTickSize(payload);
     if (intervalNode) {
       intervalNode.textContent = (payload && payload.interval) || "—";
     }
@@ -625,13 +731,15 @@
     }
     if (markNode) {
       // Absent optional mark → em dash. Never substitute candle close.
-      var mark =
+      if (
         payload &&
         payload.live_mark_price !== undefined &&
         payload.live_mark_price !== null
-          ? String(payload.live_mark_price)
-          : "—";
-      markNode.textContent = mark;
+      ) {
+        markNode.textContent = formatMarketPriceDisplay(payload.live_mark_price, tickSize);
+      } else {
+        markNode.textContent = "—";
+      }
     }
     if (revisionNode) {
       revisionNode.textContent =
@@ -639,11 +747,26 @@
         root.getAttribute("data-mdl-ohlcv-update-class") ||
         "—";
     }
-    if (openNode) openNode.textContent = last ? formatMetaNumber(last.open) : "—";
-    if (highNode) highNode.textContent = last ? formatMetaNumber(last.high) : "—";
-    if (lowNode) lowNode.textContent = last ? formatMetaNumber(last.low) : "—";
-    if (closeNode) closeNode.textContent = last ? formatMetaNumber(last.close) : "—";
-    if (volumeNode) volumeNode.textContent = last ? formatMetaNumber(last.volume) : "—";
+    if (openNode) {
+      openNode.textContent = last ? formatMarketPriceDisplay(last.open, tickSize) : "—";
+    }
+    if (highNode) {
+      highNode.textContent = last ? formatMarketPriceDisplay(last.high, tickSize) : "—";
+    }
+    if (lowNode) {
+      lowNode.textContent = last ? formatMarketPriceDisplay(last.low, tickSize) : "—";
+    }
+    if (closeNode) {
+      closeNode.textContent = last ? formatMarketPriceDisplay(last.close, tickSize) : "—";
+    }
+    if (changeNode) {
+      changeNode.textContent = last
+        ? formatMarketChangePctDisplay(last.open, last.close)
+        : "—";
+    }
+    if (volumeNode) {
+      volumeNode.textContent = last ? formatMarketVolumeDisplay(last.volume) : "—";
+    }
     if (availNode && availability) {
       availNode.textContent = availability;
       availNode.setAttribute("data-availability", availability);

--- a/templates/peak_trade_dashboard/market_landscape_v2.html
+++ b/templates/peak_trade_dashboard/market_landscape_v2.html
@@ -143,23 +143,27 @@
               <dt>Revision</dt>
               <dd data-mdl-field="ohlcv_revision">{% if chart.ohlcv_revision_kind %}{{ chart.ohlcv_revision_kind }}{% else %}—{% endif %}</dd>
             </div>
-            <div>
+            <div class="mdl-v2-chart__meta-ohlc">
               <dt>Open</dt>
               <dd data-mdl-field="ohlcv_open">{% if chart.open_price is not none %}{{ chart.open_price }}{% else %}—{% endif %}</dd>
             </div>
-            <div>
+            <div class="mdl-v2-chart__meta-ohlc">
               <dt>High</dt>
               <dd data-mdl-field="ohlcv_high">{% if chart.high_price is not none %}{{ chart.high_price }}{% else %}—{% endif %}</dd>
             </div>
-            <div>
+            <div class="mdl-v2-chart__meta-ohlc">
               <dt>Low</dt>
               <dd data-mdl-field="ohlcv_low">{% if chart.low_price is not none %}{{ chart.low_price }}{% else %}—{% endif %}</dd>
             </div>
-            <div>
+            <div class="mdl-v2-chart__meta-ohlc">
               <dt>Close</dt>
               <dd data-mdl-field="ohlcv_close">{% if chart.close_price is not none %}{{ chart.close_price }}{% else %}—{% endif %}</dd>
             </div>
-            <div>
+            <div class="mdl-v2-chart__meta-ohlc">
+              <dt>Change</dt>
+              <dd data-mdl-field="ohlcv_change">{% if chart.change_pct is not none %}{{ chart.change_pct }}{% else %}—{% endif %}</dd>
+            </div>
+            <div class="mdl-v2-chart__meta-ohlc">
               <dt>Volume</dt>
               <dd data-mdl-field="ohlcv_volume">{% if chart.volume is not none %}{{ chart.volume }}{% else %}—{% endif %}</dd>
             </div>
@@ -183,15 +187,6 @@
             data-mdl-volume-state="{{ chart.volume_panel_state }}"
             data-mdl-volume-synced-with-chart="false"
           >
-            <div class="mdl-v2-volume__chrome">
-              <span class="mdl-v2-volume__label">Volume</span>
-              <span
-                class="mdl-v2-state"
-                data-mdl-volume-state-label="true"
-                data-mdl-volume-state="{{ chart.volume_panel_state }}"
-              >{{ chart.volume_panel_state }}</span>
-            </div>
-            <p class="mdl-v2-volume__message" data-mdl-volume-message="true">{{ chart.volume_panel_message }}</p>
             <canvas
               class="mdl-v2-volume__canvas"
               data-mdl-volume-canvas="true"

--- a/tests/webui/test_market_landscape_dashboard_v2_ohlcv_price_display_format_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_ohlcv_price_display_format_v0.py
@@ -1,0 +1,133 @@
+"""Presentation-only market price display formatting for Landscape V2.
+
+Scope: chrome formatting only. No producer / readmodel / trading mutations.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.webui.market_dashboard_landscape_v2.presenter import (
+    format_market_change_pct_display_v1,
+    format_market_price_display_v1,
+    format_market_volume_display_v1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize(
+    ("value", "tick_size", "expected"),
+    [
+        ("0.000000009724", None, "0.000000009724"),
+        ("9.724e-9", None, "0.000000009724"),
+        (9.724e-9, None, "0.000000009724"),
+        ("1919.06", None, "1919.06"),
+        (1919.06, None, "1919.06"),
+        ("0.000000009724", "0.000000000001", "0.000000009724"),
+        ("100.5", "0.1", "100.5"),
+        ("100.5", "0.01", "100.50"),
+    ],
+)
+def test_format_market_price_display_plain_decimal(
+    value: object, tick_size: str | None, expected: str
+) -> None:
+    rendered = format_market_price_display_v1(value, tick_size=tick_size)
+    assert rendered == expected
+    assert "e-" not in rendered.lower()
+    assert "e+" not in rendered.lower()
+
+
+def test_format_market_price_tick_precision_preferred_over_fallback() -> None:
+    assert format_market_price_display_v1("1.234567", tick_size="0.01") == "1.23"
+    # Absent tick → documented significant/normalize fallback (no invented tick).
+    assert format_market_price_display_v1("1.234567", tick_size=None) == "1.234567"
+
+
+def test_format_market_volume_and_change_display() -> None:
+    assert format_market_volume_display_v1(929) == "929"
+    assert format_market_volume_display_v1("929.0") == "929"
+    assert format_market_volume_display_v1("12.5") == "12.5"
+    assert format_market_change_pct_display_v1("100", "99.5") == "-0.5000%"
+    assert format_market_change_pct_display_v1("100", "100.5") == "+0.5000%"
+
+
+def test_html_css_declutters_volume_and_expands_ohlc_labels() -> None:
+    html = (REPO / "templates/peak_trade_dashboard/market_landscape_v2.html").read_text(
+        encoding="utf-8"
+    )
+    css = (REPO / "static/css/market_dashboard_landscape_v2.css").read_text(encoding="utf-8")
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+
+    assert "<dt>Open</dt>" in html
+    assert "<dt>High</dt>" in html
+    assert "<dt>Low</dt>" in html
+    assert "<dt>Close</dt>" in html
+    assert "<dt>Change</dt>" in html
+    assert "<dt>Volume</dt>" in html
+    assert 'data-mdl-field="ohlcv_change"' in html
+    assert 'mdl-v2-volume__label">Volume' not in html
+    assert "Volume bound to authentic OHLCV bar volume" not in html
+    assert "Volume bound to authentic OHLCV bar volume" not in js
+    assert ".toExponential(" not in js
+    assert "function formatMarketPriceDisplay(" in js
+    assert "mdl-v2-last-price-marker__label" in css
+    assert "--mdl-volume-chrome-band: 0px" in css
+    assert "--mdl-volume-message-band: 0px" in css
+
+
+def test_js_price_display_helpers_behavioral_small_normal_tick() -> None:
+    js = (REPO / "static/js/market_dashboard_landscape_v2.js").read_text(encoding="utf-8")
+
+    def _extract(name: str) -> str:
+        start = js.index(name)
+        rest = js[start + len(name) :]
+        end_rel = rest.find("\n  function ")
+        assert end_rel > 0, name
+        return js[start : start + len(name) + end_rel].rstrip() + "\n"
+
+    helpers = "\n".join(
+        [
+            _extract("function expandScientificToPlain(raw)"),
+            _extract("function decimalSafePlainFromInput(value)"),
+            _extract("function tickFractionDigits(tickSize)"),
+            _extract("function formatMarketPriceDisplay(value, tickSize)"),
+            _extract("function formatMarketVolumeDisplay(value)"),
+            _extract("function formatMarketChangePctDisplay(openV, closeV)"),
+        ]
+    )
+    harness = f"""
+'use strict';
+{helpers}
+function assert(cond, msg) {{
+  if (!cond) throw new Error(msg || 'assert failed');
+}}
+var tiny = formatMarketPriceDisplay('9.724e-9', null);
+assert(tiny === '0.000000009724', 'tiny plain');
+assert(tiny.indexOf('e') === -1 && tiny.indexOf('E') === -1, 'no sci');
+var normal = formatMarketPriceDisplay(1919.06, null);
+assert(String(normal).indexOf('e') === -1, 'normal no sci');
+assert(formatMarketPriceDisplay('100.5', '0.01') === '100.50', 'tick digits');
+assert(formatMarketVolumeDisplay(929) === '929', 'volume int');
+assert(formatMarketChangePctDisplay(100, 99.5) === '-0.5000%', 'change');
+console.log('PRICE_DISPLAY_HELPERS_BEHAVIORAL_PASS');
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False, encoding="utf-8") as handle:
+        handle.write(harness)
+        harness_path = Path(handle.name)
+    try:
+        completed = subprocess.run(
+            ["node", str(harness_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    finally:
+        harness_path.unlink(missing_ok=True)
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    assert "PRICE_DISPLAY_HELPERS_BEHAVIORAL_PASS" in completed.stdout

--- a/tests/webui/test_market_landscape_dashboard_v2_ohlcv_volume_panel_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_ohlcv_volume_panel_v0.py
@@ -131,7 +131,9 @@ def test_volume_panel_state_missing_not_bound_stale_available() -> None:
     }
     ok_state, ok_msg = resolve_volume_panel_state_v1(browser_payload=ok_payload)
     assert ok_state == "AVAILABLE"
-    assert "buy/sell" not in ok_msg.lower() or "not buy/sell" in ok_msg.lower()
+    assert ok_msg == ""
+    assert "Volume bound to authentic" not in ok_msg
+    assert "buy/sell" not in ok_msg.lower()
 
 
 def test_html_css_js_volume_panel_sync_contracts() -> None:

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_continuous_refresh_v0.py
@@ -1106,6 +1106,9 @@ def test_js_last_price_marker_presentation_contracts() -> None:
     assert "mdl-v2-last-price-marker" in css
     assert "mdl-v2-last-price-marker__line" in css
     assert "mdl-v2-last-price-marker__label" in css
+    assert "display: none" in css
+    # In-chart close/Δ text box must stay cleared; meta row owns OHLC telemetry.
+    assert "No in-chart close/Δ text box" in js or 'label.textContent = ""' in js
     # Geometry owners must remain untouched by this presentation overlay.
     assert "minP -= span * 0.04" in js
     assert "maxP += span * 0.04" in js
@@ -1133,7 +1136,11 @@ def test_js_last_price_poll_delta_behavioral_contracts() -> None:
 
     helpers = "\n".join(
         [
-            _extract("function formatMetaNumber(value)"),
+            _extract("function expandScientificToPlain(raw)"),
+            _extract("function decimalSafePlainFromInput(value)"),
+            _extract("function tickFractionDigits(tickSize)"),
+            _extract("function formatMarketPriceDisplay(value, tickSize)"),
+            _extract("function formatMetaNumber(value, tickSize)"),
             _extract("function resolveLastPricePollDelta(prevClose, prevTs, nextClose, nextTs)"),
             _extract("function formatLastPriceMarkerLabel(close, delta, deltaPct)"),
         ]
@@ -1163,8 +1170,8 @@ assert(bad.close === null && bad.delta === null, 'nonfinite');
 var missingTs = resolveLastPricePollDelta(100, 't1', 101, '');
 assert(missingTs.close === null && missingTs.delta === null, 'empty ts');
 var label = formatLastPriceMarkerLabel(100.5, 0.5, 0.5);
-assert(label.indexOf('close') === 0, 'label close');
-assert(label.indexOf('Δ') >= 0, 'label delta');
+assert(label.indexOf('Close') === 0, 'label close');
+assert(label.indexOf('Change') >= 0, 'label change');
 assert(label.indexOf('%') >= 0, 'label pct');
 // yFor contract: marker Y uses authentic close against frozen layout domain.
 var layout = {{ padT: 16, minP: 90, span: 20, plotH: 200 }};


### PR DESCRIPTION
## Summary
- Presentation-only Landscape V2 chrome: plain-decimal market prices (tick size when available, significant/normalize fallback otherwise); no scientific notation in visible OHLC/Mark values.
- Reuse/improve the existing chart meta row with expanded Open/High/Low/Close plus Change and Volume; remove Volume heading/explanation and the in-chart close/Δ text box while preserving the live price marker line and OHLCV geometry.

## Test plan
- [x] Focused: `tests/webui/test_market_landscape_dashboard_v2_ohlcv_price_display_format_v0.py`
- [x] Related volume/marker/chart owners
- [x] Selector PR-bounded suite + Ruff format/check
- [ ] Required GitHub checks green before Owner merge GO


Made with [Cursor](https://cursor.com)