### PR TITLE
fix(webui): remove bound OHLCV chart status line

### DIFF
--- a/src/webui/market_dashboard_landscape_v2/presenter.py
+++ b/src/webui/market_dashboard_landscape_v2/presenter.py
@@ -1030,11 +1030,8 @@ def present_market_landscape_v2(
             )
         else:
             ohlcv_bound = True
-            chart_message = (
-                "Primary chart bound to materialized OKX OHLCV readmodel "
-                f"(bars={browser_payload.get('bar_count')}, interval="
-                f"{ohlcv_readmodel.get('interval')})."
-            )
+            # Success path: no technical status line above the live chart.
+            chart_message = ""
     elif instrument_availability in (Availability.AVAILABLE, Availability.STALE):
         chart_message = (
             "Primary chart market instrument bound; OHLCV producer still unbound "

--- a/static/css/market_dashboard_landscape_v2.css
+++ b/static/css/market_dashboard_landscape_v2.css
@@ -64,7 +64,8 @@
   --mdl-chart-chrome-band: 1.5rem;
   /* Budget for wrapped OHLC meta in right-rail max-height calc only. */
   --mdl-chart-meta-band: 6.5rem;
-  --mdl-chart-message-band: 1.25rem;
+  /* Bound success path leaves chart message empty; fail/unbound still render text. */
+  --mdl-chart-message-band: 0px;
   box-sizing: border-box;
   max-width: 100vw;
   min-height: 0;
@@ -369,6 +370,14 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.mdl-v2-chart__message:empty {
+  display: none;
+  margin: 0;
+  height: 0;
+  min-height: 0;
+  max-height: 0;
 }
 
 .mdl-v2-chart__canvas {

--- a/templates/peak_trade_dashboard/market_landscape_v2.html
+++ b/templates/peak_trade_dashboard/market_landscape_v2.html
@@ -168,7 +168,7 @@
               <dd data-mdl-field="ohlcv_volume">{% if chart.volume is not none %}{{ chart.volume }}{% else %}—{% endif %}</dd>
             </div>
           </dl>
-          <div class="mdl-v2-chart__stage" role="img" aria-label="{{ chart.message }}" data-mdl-chart-stage="true">
+          <div class="mdl-v2-chart__stage" role="img" aria-label="{% if chart.message %}{{ chart.message }}{% else %}OHLCV chart{% endif %}" data-mdl-chart-stage="true">
             <p class="mdl-v2-chart__message" data-mdl-chart-message="true">{{ chart.message }}</p>
             {# Empty/non-authoritative bootstrap always present so JS can bind canonical OHLCV. #}
             <script type="application/json" data-mdl-ohlcv-json="true">{% if chart.browser_payload %}{{ chart.browser_payload | tojson }}{% else %}{"schema_name":"market_landscape_ohlcv_browser_payload.v1","schema_version":1,"bars":[],"bar_count":0,"non_authoritative_bootstrap":true}{% endif %}</script>

--- a/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_chart_binding_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_okx_ohlcv_chart_binding_v0.py
@@ -200,8 +200,9 @@ def test_route_presenter_receives_100_canonical_ohlcv_bars(
     response = client.get("/market")
     assert response.status_code == 200
     html = response.text
-    assert "Primary chart bound to materialized OKX OHLCV readmodel" in html
-    assert f"(bars={BAR_COUNT}" in html
+    assert "Primary chart bound to materialized OKX OHLCV readmodel" not in html
+    assert f"(bars={BAR_COUNT}" not in html
+    assert ctx["chart"]["message"] == ""
     assert 'data-mdl-field="venue">OKX</dd>' in html
     assert 'data-mdl-ohlcv-json="true"' in html
     assert 'data-mdl-chart-canvas="true"' in html
@@ -262,8 +263,9 @@ def test_real_chrome_visible_chart_geometry_and_venue_guard(
     monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
     client = TestClient(create_app())
     html = client.get("/market").text
-    assert "chart bound" in html.lower()
+    assert "Primary chart bound to materialized OKX OHLCV readmodel" not in html
     assert 'data-mdl-ohlcv-json="true"' in html
+    assert 'data-mdl-chart-has-series="true"' in html
 
     console_errors: list[str] = []
     page_errors: list[str] = []
@@ -355,7 +357,8 @@ def test_real_chrome_visible_chart_geometry_and_venue_guard(
                 assert metrics["first_ts"] == FIRST_TS
                 assert metrics["last_ts"] == LAST_TS
                 assert metrics["width"] > 0 and metrics["height"] > 0
-                assert "chart bound" in metrics["message"].lower()
+                assert metrics["message"].strip() == ""
+                assert "Primary chart bound" not in metrics["message"]
                 assert metrics["bound_without_geometry"] == "false"
                 assert metrics["overflow"] is False
                 context.close()
@@ -371,12 +374,12 @@ def test_chart_bound_text_cannot_pass_without_embedded_series(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Static guard: bound message requires browser payload embedding."""
+    """Static guard: bound OHLCV requires browser payload embedding, not status text."""
     archive = _write_okx_universe_and_ohlcv(tmp_path / "archive")
     monkeypatch.setenv(ENV_ARCHIVE_ROOT, str(archive))
     html = TestClient(create_app()).get("/market").text
-    assert "chart bound" in html.lower()
+    assert "Primary chart bound to materialized OKX OHLCV readmodel" not in html
     assert 'data-mdl-ohlcv-json="true"' in html
     assert 'data-mdl-chart-canvas="true"' in html
-    # Message alone is insufficient without series mount points.
+    # Series mount points remain the productive bound proof — not a status line.
     assert 'data-mdl-chart-has-series="true"' in html

--- a/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
+++ b/tests/webui/test_market_landscape_dashboard_v2_shell_route_v0.py
@@ -62,7 +62,10 @@ def test_get_market_returns_200_with_landmarks(client: TestClient) -> None:
     assert (
         "no ohlcv fabricated" in html.lower()
         or "ohlcv producer still unbound" in html.lower()
-        or "primary chart bound to materialized okx ohlcv readmodel" in html.lower()
+        or (
+            'data-mdl-chart-has-series="true"' in html
+            and "primary chart bound to materialized okx ohlcv readmodel" not in html.lower()
+        )
     )
     assert "BTC/USD" not in html
     assert "btc_usd_dummy" not in html.lower()


### PR DESCRIPTION
## Summary
- Remove the technical SSR success hint above the Market Landscape OHLCV chart (`Primary chart bound to materialized OKX OHLCV readmodel...`).
- Keep fail-closed unbound/error chart messages, OHLC meta, volume panel, live marker, and all OHLCV data bindings unchanged (presentation-only).

## Test plan
- [x] `ruff format --check` / `ruff check` on changed Python files
- [x] Focused webui tests: chart binding + shell route
- [x] PR-bounded selector path + focused owners (747 passed, ~41s)
- [x] Local dashboard restart + SSR HTML verification (hint absent, canvas/OHLC/volume present)
- [ ] Chrome visible acceptance on http://127.0.0.1:8000/market
- [ ] Required GitHub checks green → owner squash-merge


Made with [Cursor](https://cursor.com)