### PR TITLE
docs(ops): B2 projection octet runtime verify evidence

### DIFF
--- a/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/INVENTORY_RECONCILE.json
+++ b/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/INVENTORY_RECONCILE.json
@@ -1,0 +1,61 @@
+{
+  "schema_name": "market_dashboard_inventory_reconcile.v1",
+  "schema_version": 1,
+  "generated_at": "2026-08-04T19:43:33.462472Z",
+  "origin_main_sha": "8c02f8793411939149eb7f33d6877a68a23a727f",
+  "dashboard_url": "http://127.0.0.1:8000/market",
+  "archive_root": "/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z",
+  "method": "live_dom_data_availability_recount",
+  "old_baseline": {
+    "artifact": "docs/ops/market_dashboard/market_dashboard_missing_source_not_bound_inventory_v1/INVENTORY.json",
+    "generated_at": "2026-08-04T18:30:57.619368Z",
+    "origin_main_sha": "0a3df4827e675c41b8c51cea3d2baea34ef52eee",
+    "MISSING_SOURCE_count": 50,
+    "NOT_BOUND_count": 18,
+    "TOTAL_PRESENTATION_ELEMENTS_INVENTORIED": 73
+  },
+  "new_live_dom": {
+    "MISSING_SOURCE_count": 50,
+    "NOT_BOUND_count": 17,
+    "elements_with_data_availability": 77,
+    "availability_counts": {
+      "STALE": 9,
+      "MISSING_SOURCE": 50,
+      "AVAILABLE": 1,
+      "NOT_BOUND": 17
+    },
+    "html_bytes": 92081
+  },
+  "delta": {
+    "MISSING_SOURCE_delta": 0,
+    "NOT_BOUND_delta": -1,
+    "explanation": "MISSING_SOURCE unchanged at 50 because all eight B2 projection families remain RUNTIME_ARTIFACT_ABSENT. NOT_BOUND decreased 18\u219217 in live DOM recount at HEAD 8c02f879 after universe-selection rail bind (#5710); intentional/blocked unbound surfaces remain; no B2 presentation compensation applied."
+  },
+  "projection_octet": {
+    "families_verified": [
+      "dynamic_scope",
+      "regime_bull_bear_switch",
+      "canonical_decision",
+      "double_play",
+      "safety_authority",
+      "risk_sizing_capital",
+      "execution_reconciliation",
+      "economic_summary"
+    ],
+    "artifacts_present": [],
+    "artifacts_missing": [
+      "dynamic_scope",
+      "regime_bull_bear_switch",
+      "canonical_decision",
+      "double_play",
+      "safety_authority",
+      "risk_sizing_capital",
+      "execution_reconciliation",
+      "economic_summary"
+    ],
+    "schema_invalid_count": 0,
+    "loader_resolved_count": 0
+  },
+  "b3_blockers_mapping_authorized": false,
+  "b3_authorization_reason": "ACTIVE_DOUBLE_PLAY_PROJECTION_ABSENT:readmodels/double_play_presentation_projection.v1.json;DOUBLE_PLAY_LOADER_UNRESOLVED:DOUBLE_PLAY_PRESENTATION_PROJECTION_ABSENT;BLOCKER_FIELD_CONTRACT_NOT_PROVEN_WITHOUT_ACTIVE_ARTIFACT;TEMPLATE_BLOCKERS_STILL_HARDCODED_NOT_BOUND"
+}

--- a/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/PROGRESS_ACCOUNTING.json
+++ b/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/PROGRESS_ACCOUNTING.json
@@ -1,0 +1,96 @@
+{
+  "schema_name": "market_dashboard_presentation_progress_accounting.v1",
+  "schema_version": 1,
+  "generated_at": "2026-08-04T19:43:33.462472Z",
+  "repository_head_sha": "8c02f8793411939149eb7f33d6877a68a23a727f",
+  "batch_executed": "B2_PROJECTION_OCTET_RUNTIME_VERIFY",
+  "dashboard_role": "PURE_CONSUMER",
+  "authority_effect": "NONE",
+  "trading_logic_changed": false,
+  "runtime_changed": false,
+  "producer_changed": false,
+  "materializer_executed": false,
+  "canonical_readmodel_changed": false,
+  "family_count_ratified": 18,
+  "batches": {
+    "B1_ALREADY_BOUND_CLOSEOUT": {
+      "status": "CLOSED_UNCHANGED",
+      "families": [
+        "market_instrument",
+        "universe_selection_rail_facts",
+        "okx_selected_instrument_ohlcv"
+      ],
+      "note": "Phase-1 presentation paths already complete at/before #5710; no B2 mutation."
+    },
+    "B2_PROJECTION_OCTET_RUNTIME_VERIFY": {
+      "status": "COMPLETE_READ_ONLY_VERIFY",
+      "families": [
+        "dynamic_scope",
+        "regime_bull_bear_switch",
+        "canonical_decision",
+        "double_play",
+        "safety_authority",
+        "risk_sizing_capital",
+        "execution_reconciliation",
+        "economic_summary"
+      ],
+      "artifacts_present": [],
+      "artifacts_missing": [
+        "dynamic_scope",
+        "regime_bull_bear_switch",
+        "canonical_decision",
+        "double_play",
+        "safety_authority",
+        "risk_sizing_capital",
+        "execution_reconciliation",
+        "economic_summary"
+      ],
+      "schema_invalid_count": 0,
+      "runtime_artifact_states": {
+        "dynamic_scope": "RUNTIME_ARTIFACT_ABSENT",
+        "regime_bull_bear_switch": "RUNTIME_ARTIFACT_ABSENT",
+        "canonical_decision": "RUNTIME_ARTIFACT_ABSENT",
+        "double_play": "RUNTIME_ARTIFACT_ABSENT",
+        "safety_authority": "RUNTIME_ARTIFACT_ABSENT",
+        "risk_sizing_capital": "RUNTIME_ARTIFACT_ABSENT",
+        "execution_reconciliation": "RUNTIME_ARTIFACT_ABSENT",
+        "economic_summary": "RUNTIME_ARTIFACT_ABSENT"
+      }
+    },
+    "B3_CONDITIONAL_MAPPING_DUO": {
+      "status": "NOT_AUTHORIZED",
+      "decision_strip_blockers_mapping_authorized": false,
+      "reason": "ACTIVE_DOUBLE_PLAY_PROJECTION_ABSENT:readmodels/double_play_presentation_projection.v1.json;DOUBLE_PLAY_LOADER_UNRESOLVED:DOUBLE_PLAY_PRESENTATION_PROJECTION_ABSENT;BLOCKER_FIELD_CONTRACT_NOT_PROVEN_WITHOUT_ACTIVE_ARTIFACT;TEMPLATE_BLOCKERS_STILL_HARDCODED_NOT_BOUND",
+      "families": [
+        "decision_strip_blockers_unbound",
+        "source_health_aggregate"
+      ]
+    },
+    "B4_INTENTIONAL_AND_BLOCKED_FREEZE": {
+      "status": "CLOSED_UNCHANGED",
+      "families": [
+        "decision_strip_confidence_intentional_unbound",
+        "diagnostics_summary_intentional_unbound",
+        "autonomy_stage_intentional_unbound",
+        "timeline_intentional_unbound",
+        "repository_sha_no_canonical_payload_field"
+      ],
+      "note": "Remain intentionally unavailable / blocked; no reduction authorized."
+    }
+  },
+  "counts": {
+    "old_MISSING_SOURCE_count": 50,
+    "new_MISSING_SOURCE_count": 50,
+    "old_NOT_BOUND_count": 18,
+    "new_NOT_BOUND_count": 17
+  },
+  "remaining_bounded_presentation_objectives": [
+    "B3 decision_strip_blockers_unbound \u2014 blocked until active Double Play projection present+schema-valid and blocker contract proven",
+    "B3 source_health_aggregate \u2014 reconcile only after required member-slot runtime availability"
+  ],
+  "unresolved_evidence": [
+    "Active archive lacks all eight authorized durable presentation projections",
+    "Safety Authority GitHub PR number for commit 737dac557 remains unresolved",
+    "Unnamed timeline chrome element stable mapping remains unresolved"
+  ]
+}

--- a/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/VERIFY.json
+++ b/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/VERIFY.json
@@ -1,0 +1,470 @@
+{
+  "schema_name": "market_dashboard_projection_octet_runtime_verify.v1",
+  "batch_id": "B2_PROJECTION_OCTET_RUNTIME_VERIFY",
+  "generated_at": "2026-08-04T19:43:33.462472Z",
+  "origin_main_sha": "8c02f8793411939149eb7f33d6877a68a23a727f",
+  "repository_head_sha": "8c02f8793411939149eb7f33d6877a68a23a727f",
+  "dashboard_url": "http://127.0.0.1:8000/market",
+  "dashboard_http_status": 200,
+  "archive_root": "/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z",
+  "read_only": true,
+  "materializer_executed": false,
+  "producer_changed": false,
+  "trading_logic_changed": false,
+  "runtime_changed": false,
+  "canonical_readmodel_changed": false,
+  "dashboard_authority_effect": "NONE",
+  "dashboard_role": "PURE_CONSUMER",
+  "kill_switch_live_autoload_used": false,
+  "latest_evidence_auto_selected": false,
+  "presenter_available": true,
+  "presenter_error": null,
+  "serializer_available": true,
+  "serializer_error": null,
+  "presenter_carries_blockers": true,
+  "families": [
+    {
+      "family_id": "dynamic_scope",
+      "authorized_artifact_relative_path": "readmodels/dynamic_scope_presentation_projection.v1.json",
+      "authorized_artifact_absolute_path": "/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z/readmodels/dynamic_scope_presentation_projection.v1.json",
+      "artifact_present": false,
+      "schema_id_expected": "dynamic_scope_presentation_projection.v1",
+      "schema_id_observed": null,
+      "family_id_observed": null,
+      "revision": null,
+      "digest": null,
+      "schema_invalid": false,
+      "loader_name": "try_load_dynamic_scope_presentation_projection_v1",
+      "loader_result_loaded": false,
+      "loader_errors": [
+        "DYNAMIC_SCOPE_PRESENTATION_PROJECTION_ABSENT"
+      ],
+      "loader_source_path": null,
+      "payload_meta": {},
+      "presenter_available": true,
+      "serializer_available": true,
+      "fallback_or_substitution_used": false,
+      "kill_switch_live_autoload_used": false,
+      "latest_evidence_auto_selected": false,
+      "expected_dom_availability": "MISSING_SOURCE",
+      "runtime_artifact_state": "RUNTIME_ARTIFACT_ABSENT",
+      "rendered_dom_states": [
+        {
+          "field": "scope_lifecycle",
+          "slot": null,
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        },
+        {
+          "field": "current_scope_ref",
+          "slot": null,
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        },
+        {
+          "field": "next_scope_ref",
+          "slot": null,
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        },
+        {
+          "field": null,
+          "slot": "dynamic_scope",
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        }
+      ],
+      "dom_has_missing_source": true,
+      "dom_has_not_bound": false
+    },
+    {
+      "family_id": "regime_bull_bear_switch",
+      "authorized_artifact_relative_path": "readmodels/bull_bear_regime_presentation_projection.v1.json",
+      "authorized_artifact_absolute_path": "/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z/readmodels/bull_bear_regime_presentation_projection.v1.json",
+      "artifact_present": false,
+      "schema_id_expected": "bull_bear_regime_presentation_projection.v1",
+      "schema_id_observed": null,
+      "family_id_observed": null,
+      "revision": null,
+      "digest": null,
+      "schema_invalid": false,
+      "loader_name": "try_load_bull_bear_regime_presentation_projection_v1",
+      "loader_result_loaded": false,
+      "loader_errors": [
+        "BULL_BEAR_REGIME_PRESENTATION_PROJECTION_ABSENT"
+      ],
+      "loader_source_path": null,
+      "payload_meta": {},
+      "presenter_available": true,
+      "serializer_available": true,
+      "fallback_or_substitution_used": false,
+      "kill_switch_live_autoload_used": false,
+      "latest_evidence_auto_selected": false,
+      "expected_dom_availability": "MISSING_SOURCE",
+      "runtime_artifact_state": "RUNTIME_ARTIFACT_ABSENT",
+      "rendered_dom_states": [
+        {
+          "field": "regime",
+          "slot": null,
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        },
+        {
+          "field": "bull_bear",
+          "slot": null,
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        },
+        {
+          "field": "switch",
+          "slot": null,
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        },
+        {
+          "field": null,
+          "slot": "regime_bull_bear_switch",
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        }
+      ],
+      "dom_has_missing_source": true,
+      "dom_has_not_bound": false
+    },
+    {
+      "family_id": "canonical_decision",
+      "authorized_artifact_relative_path": "readmodels/canonical_decision_presentation_projection.v1.json",
+      "authorized_artifact_absolute_path": "/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z/readmodels/canonical_decision_presentation_projection.v1.json",
+      "artifact_present": false,
+      "schema_id_expected": "canonical_decision_presentation_projection.v1",
+      "schema_id_observed": null,
+      "family_id_observed": null,
+      "revision": null,
+      "digest": null,
+      "schema_invalid": false,
+      "loader_name": "try_load_canonical_decision_presentation_projection_v1",
+      "loader_result_loaded": false,
+      "loader_errors": [
+        "CANONICAL_DECISION_PRESENTATION_PROJECTION_ABSENT"
+      ],
+      "loader_source_path": null,
+      "payload_meta": {},
+      "presenter_available": true,
+      "serializer_available": true,
+      "fallback_or_substitution_used": false,
+      "kill_switch_live_autoload_used": false,
+      "latest_evidence_auto_selected": false,
+      "expected_dom_availability": "MISSING_SOURCE",
+      "runtime_artifact_state": "RUNTIME_ARTIFACT_ABSENT",
+      "rendered_dom_states": [
+        {
+          "field": null,
+          "slot": "canonical_decision",
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        },
+        {
+          "field": "decision",
+          "slot": null,
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        }
+      ],
+      "dom_has_missing_source": true,
+      "dom_has_not_bound": false
+    },
+    {
+      "family_id": "double_play",
+      "authorized_artifact_relative_path": "readmodels/double_play_presentation_projection.v1.json",
+      "authorized_artifact_absolute_path": "/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z/readmodels/double_play_presentation_projection.v1.json",
+      "artifact_present": false,
+      "schema_id_expected": "double_play_presentation_projection.v1",
+      "schema_id_observed": null,
+      "family_id_observed": null,
+      "revision": null,
+      "digest": null,
+      "schema_invalid": false,
+      "loader_name": "try_load_double_play_presentation_projection_v1",
+      "loader_result_loaded": false,
+      "loader_errors": [
+        "DOUBLE_PLAY_PRESENTATION_PROJECTION_ABSENT"
+      ],
+      "loader_source_path": null,
+      "payload_meta": {},
+      "presenter_available": true,
+      "serializer_available": true,
+      "fallback_or_substitution_used": false,
+      "kill_switch_live_autoload_used": false,
+      "latest_evidence_auto_selected": false,
+      "expected_dom_availability": "MISSING_SOURCE",
+      "runtime_artifact_state": "RUNTIME_ARTIFACT_ABSENT",
+      "rendered_dom_states": [
+        {
+          "field": null,
+          "slot": "double_play",
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        }
+      ],
+      "dom_has_missing_source": true,
+      "dom_has_not_bound": false
+    },
+    {
+      "family_id": "safety_authority",
+      "authorized_artifact_relative_path": "readmodels/safety_authority.v1.json",
+      "authorized_artifact_absolute_path": "/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z/readmodels/safety_authority.v1.json",
+      "artifact_present": false,
+      "schema_id_expected": "safety_authority_presentation_projection.v1",
+      "schema_id_observed": null,
+      "family_id_observed": null,
+      "revision": null,
+      "digest": null,
+      "schema_invalid": false,
+      "loader_name": "try_load_safety_authority_presentation_projection_v1",
+      "loader_result_loaded": false,
+      "loader_errors": [
+        "SAFETY_AUTHORITY_PRESENTATION_PROJECTION_ABSENT"
+      ],
+      "loader_source_path": null,
+      "payload_meta": {},
+      "presenter_available": true,
+      "serializer_available": true,
+      "fallback_or_substitution_used": false,
+      "kill_switch_live_autoload_used": false,
+      "latest_evidence_auto_selected": false,
+      "expected_dom_availability": "MISSING_SOURCE",
+      "runtime_artifact_state": "RUNTIME_ARTIFACT_ABSENT",
+      "rendered_dom_states": [
+        {
+          "field": "safety",
+          "slot": null,
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": "CANONICAL_SAFETY_AUTHORITY_NOT_PERSISTED_FOR_DASHBOARD"
+        },
+        {
+          "field": null,
+          "slot": "safety_authority",
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        }
+      ],
+      "dom_has_missing_source": true,
+      "dom_has_not_bound": false
+    },
+    {
+      "family_id": "risk_sizing_capital",
+      "authorized_artifact_relative_path": "readmodels/risk_sizing_capital_presentation_projection.v1.json",
+      "authorized_artifact_absolute_path": "/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z/readmodels/risk_sizing_capital_presentation_projection.v1.json",
+      "artifact_present": false,
+      "schema_id_expected": "risk_sizing_capital_presentation_projection.v1",
+      "schema_id_observed": null,
+      "family_id_observed": null,
+      "revision": null,
+      "digest": null,
+      "schema_invalid": false,
+      "loader_name": "try_load_risk_sizing_capital_presentation_projection_v1",
+      "loader_result_loaded": false,
+      "loader_errors": [
+        "RISK_SIZING_CAPITAL_PRESENTATION_PROJECTION_ABSENT"
+      ],
+      "loader_source_path": null,
+      "payload_meta": {},
+      "presenter_available": true,
+      "serializer_available": true,
+      "fallback_or_substitution_used": false,
+      "kill_switch_live_autoload_used": false,
+      "latest_evidence_auto_selected": false,
+      "expected_dom_availability": "MISSING_SOURCE",
+      "runtime_artifact_state": "RUNTIME_ARTIFACT_ABSENT",
+      "rendered_dom_states": [
+        {
+          "field": null,
+          "slot": "risk_sizing_capital",
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        }
+      ],
+      "dom_has_missing_source": true,
+      "dom_has_not_bound": false
+    },
+    {
+      "family_id": "execution_reconciliation",
+      "authorized_artifact_relative_path": "readmodels/execution_reconciliation_presentation_projection.v1.json",
+      "authorized_artifact_absolute_path": "/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z/readmodels/execution_reconciliation_presentation_projection.v1.json",
+      "artifact_present": false,
+      "schema_id_expected": "execution_reconciliation_presentation_projection.v1",
+      "schema_id_observed": null,
+      "family_id_observed": null,
+      "revision": null,
+      "digest": null,
+      "schema_invalid": false,
+      "loader_name": "try_load_execution_reconciliation_presentation_projection_v1",
+      "loader_result_loaded": false,
+      "loader_errors": [
+        "EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_ABSENT"
+      ],
+      "loader_source_path": null,
+      "payload_meta": {},
+      "presenter_available": true,
+      "serializer_available": true,
+      "fallback_or_substitution_used": false,
+      "kill_switch_live_autoload_used": false,
+      "latest_evidence_auto_selected": false,
+      "expected_dom_availability": "MISSING_SOURCE",
+      "runtime_artifact_state": "RUNTIME_ARTIFACT_ABSENT",
+      "rendered_dom_states": [
+        {
+          "field": null,
+          "slot": "execution_reconciliation",
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        }
+      ],
+      "dom_has_missing_source": true,
+      "dom_has_not_bound": false
+    },
+    {
+      "family_id": "economic_summary",
+      "authorized_artifact_relative_path": "readmodels/economic_summary_presentation_projection.v1.json",
+      "authorized_artifact_absolute_path": "/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z/readmodels/economic_summary_presentation_projection.v1.json",
+      "artifact_present": false,
+      "schema_id_expected": "economic_summary_presentation_projection.v1",
+      "schema_id_observed": null,
+      "family_id_observed": null,
+      "revision": null,
+      "digest": null,
+      "schema_invalid": false,
+      "loader_name": "try_load_economic_summary_presentation_projection_v1",
+      "loader_result_loaded": false,
+      "loader_errors": [
+        "ECONOMIC_SUMMARY_PRESENTATION_PROJECTION_ABSENT"
+      ],
+      "loader_source_path": null,
+      "payload_meta": {},
+      "presenter_available": true,
+      "serializer_available": true,
+      "fallback_or_substitution_used": false,
+      "kill_switch_live_autoload_used": false,
+      "latest_evidence_auto_selected": false,
+      "expected_dom_availability": "MISSING_SOURCE",
+      "runtime_artifact_state": "RUNTIME_ARTIFACT_ABSENT",
+      "rendered_dom_states": [
+        {
+          "field": null,
+          "slot": "economic_summary",
+          "eng": null,
+          "availability": "MISSING_SOURCE",
+          "title": null
+        }
+      ],
+      "dom_has_missing_source": true,
+      "dom_has_not_bound": false
+    }
+  ],
+  "summary": {
+    "families_verified": [
+      "dynamic_scope",
+      "regime_bull_bear_switch",
+      "canonical_decision",
+      "double_play",
+      "safety_authority",
+      "risk_sizing_capital",
+      "execution_reconciliation",
+      "economic_summary"
+    ],
+    "artifacts_present": [],
+    "artifacts_missing": [
+      "dynamic_scope",
+      "regime_bull_bear_switch",
+      "canonical_decision",
+      "double_play",
+      "safety_authority",
+      "risk_sizing_capital",
+      "execution_reconciliation",
+      "economic_summary"
+    ],
+    "schema_invalid_count": 0,
+    "loader_resolved_count": 0
+  },
+  "live_dom": {
+    "html_bytes": 92081,
+    "elements_with_data_availability": 77,
+    "availability_counts": {
+      "STALE": 9,
+      "MISSING_SOURCE": 50,
+      "AVAILABLE": 1,
+      "NOT_BOUND": 17
+    },
+    "MISSING_SOURCE_count": 50,
+    "NOT_BOUND_count": 17,
+    "old_baseline_MISSING_SOURCE": 50,
+    "old_baseline_NOT_BOUND": 18,
+    "blockers_dom": [
+      {
+        "tag": "dd",
+        "availability": "NOT_BOUND",
+        "field": "blockers",
+        "slot": null,
+        "eng": null,
+        "region": null,
+        "title": null
+      }
+    ]
+  },
+  "inventory_reconcile": {
+    "method": "live_dom_data_availability_recount_at_origin_main_head",
+    "old_MISSING_SOURCE_count": 50,
+    "new_MISSING_SOURCE_count": 50,
+    "old_NOT_BOUND_count": 18,
+    "new_NOT_BOUND_count": 17,
+    "prior_inventory_artifact": "docs/ops/market_dashboard/market_dashboard_missing_source_not_bound_inventory_v1/INVENTORY.json",
+    "prior_inventory_generated_at": "2026-08-04T18:30:57.619368Z",
+    "prior_inventory_origin_main_sha": "0a3df4827e675c41b8c51cea3d2baea34ef52eee",
+    "note": "Baseline 50/18 remains the ratified inventory snapshot; new counts are post-#5710 live-DOM remeasure at HEAD 8c02f879."
+  },
+  "b1_progress": {
+    "batch_id": "B1_ALREADY_BOUND_CLOSEOUT",
+    "status": "CLOSED_UNCHANGED",
+    "families": [
+      "market_instrument",
+      "universe_selection_rail_facts",
+      "okx_selected_instrument_ohlcv"
+    ]
+  },
+  "b4_progress": {
+    "batch_id": "B4_INTENTIONAL_AND_BLOCKED_FREEZE",
+    "status": "CLOSED_UNCHANGED",
+    "families": [
+      "decision_strip_confidence_intentional_unbound",
+      "diagnostics_summary_intentional_unbound",
+      "autonomy_stage_intentional_unbound",
+      "timeline_intentional_unbound",
+      "repository_sha_no_canonical_payload_field"
+    ]
+  },
+  "b3_authorization": {
+    "batch_id": "B3_CONDITIONAL_MAPPING_DUO",
+    "decision_strip_blockers_mapping_authorized": false,
+    "reason": "ACTIVE_DOUBLE_PLAY_PROJECTION_ABSENT:readmodels/double_play_presentation_projection.v1.json;DOUBLE_PLAY_LOADER_UNRESOLVED:DOUBLE_PLAY_PRESENTATION_PROJECTION_ABSENT;BLOCKER_FIELD_CONTRACT_NOT_PROVEN_WITHOUT_ACTIVE_ARTIFACT;TEMPLATE_BLOCKERS_STILL_HARDCODED_NOT_BOUND",
+    "double_play_artifact_present": false,
+    "double_play_schema_valid": false,
+    "blocker_contract_proven": false,
+    "presenter_carries_blockers": true,
+    "blocker_template_hits": []
+  }
+}

--- a/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/VERIFY.md
+++ b/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/VERIFY.md
@@ -1,0 +1,74 @@
+# Market Dashboard Projection Octet Runtime Verify V1
+
+Generated: `2026-08-04T19:43:33.462472Z`
+Repository HEAD / origin/main: `8c02f8793411939149eb7f33d6877a68a23a727f`
+Dashboard: http://127.0.0.1:8000/market
+Archive root: `&#47;Users&#47;frnkhrz&#47;Library&#47;Application Support&#47;Peak_Trade&#47;workflow_dashboard_v1_okx_fresh_20260724T214822Z`
+
+## Batch
+
+`BATCH_ID=B2_PROJECTION_OCTET_RUNTIME_VERIFY`
+
+Read-only runtime/archive verification of eight presentation-bound projection families.
+No trading, runtime, producer, materializer, or read-model mutation. No projection artifact creation.
+
+## Consumer invariants
+
+- `DASHBOARD_ROLE=PURE_CONSUMER`
+- `AUTHORITY_EFFECT=NONE`
+- `TRADING_LOGIC_CHANGED=false`
+- `RUNTIME_CHANGED=false`
+- `PRODUCER_CHANGED=false`
+- `MATERIALIZER_EXECUTED=false`
+- `CANONICAL_READMODEL_CHANGED=false`
+- `KILL_SWITCH_LIVE_AUTOLOAD_USED=false`
+- `LATEST_EVIDENCE_AUTO_SELECTED=false`
+
+## Family verification results
+
+| Family | Authorized path | Present | Schema | Loader | Runtime state | DOM |
+|---|---|---|---|---|---|---|
+| `dynamic_scope` | `readmodels&#47;dynamic_scope_presentation_projection.v1.json` | NO | `dynamic_scope_presentation_projection.v1` | ABSENT/DYNAMIC_SCOPE_PRESENTATION_PROJECTION_ABSENT | `RUNTIME_ARTIFACT_ABSENT` | `MISSING_SOURCE` |
+| `regime_bull_bear_switch` | `readmodels&#47;bull_bear_regime_presentation_projection.v1.json` | NO | `bull_bear_regime_presentation_projection.v1` | ABSENT/BULL_BEAR_REGIME_PRESENTATION_PROJECTION_ABSENT | `RUNTIME_ARTIFACT_ABSENT` | `MISSING_SOURCE` |
+| `canonical_decision` | `readmodels&#47;canonical_decision_presentation_projection.v1.json` | NO | `canonical_decision_presentation_projection.v1` | ABSENT/CANONICAL_DECISION_PRESENTATION_PROJECTION_ABSENT | `RUNTIME_ARTIFACT_ABSENT` | `MISSING_SOURCE` |
+| `double_play` | `readmodels&#47;double_play_presentation_projection.v1.json` | NO | `double_play_presentation_projection.v1` | ABSENT/DOUBLE_PLAY_PRESENTATION_PROJECTION_ABSENT | `RUNTIME_ARTIFACT_ABSENT` | `MISSING_SOURCE` |
+| `safety_authority` | `readmodels&#47;safety_authority.v1.json` | NO | `safety_authority_presentation_projection.v1` | ABSENT/SAFETY_AUTHORITY_PRESENTATION_PROJECTION_ABSENT | `RUNTIME_ARTIFACT_ABSENT` | `MISSING_SOURCE` |
+| `risk_sizing_capital` | `readmodels&#47;risk_sizing_capital_presentation_projection.v1.json` | NO | `risk_sizing_capital_presentation_projection.v1` | ABSENT/RISK_SIZING_CAPITAL_PRESENTATION_PROJECTION_ABSENT | `RUNTIME_ARTIFACT_ABSENT` | `MISSING_SOURCE` |
+| `execution_reconciliation` | `readmodels&#47;execution_reconciliation_presentation_projection.v1.json` | NO | `execution_reconciliation_presentation_projection.v1` | ABSENT/EXECUTION_RECONCILIATION_PRESENTATION_PROJECTION_ABSENT | `RUNTIME_ARTIFACT_ABSENT` | `MISSING_SOURCE` |
+| `economic_summary` | `readmodels&#47;economic_summary_presentation_projection.v1.json` | NO | `economic_summary_presentation_projection.v1` | ABSENT/ECONOMIC_SUMMARY_PRESENTATION_PROJECTION_ABSENT | `RUNTIME_ARTIFACT_ABSENT` | `MISSING_SOURCE` |
+
+## Summary
+
+- Families verified: **8**
+- Artifacts present: **0**
+- Artifacts missing: **8**
+- Schema invalid: **0** (absent, not invalid)
+- Presenter available: **True**
+- Serializer available: **True**
+- Fallback/substitution used: **false**
+
+## Live-DOM inventory reconcile
+
+- OLD_MISSING_SOURCE_COUNT=**50**
+- NEW_MISSING_SOURCE_COUNT=**50**
+- OLD_NOT_BOUND_COUNT=**18**
+- NEW_NOT_BOUND_COUNT=**17**
+
+MISSING_SOURCE unchanged at 50 because all eight B2 projection families remain RUNTIME_ARTIFACT_ABSENT. NOT_BOUND decreased 18→17 in live DOM recount at HEAD 8c02f879 after universe-selection rail bind (#5710); intentional/blocked unbound surfaces remain; no B2 presentation compensation applied.
+
+## Progress accounting
+
+- B1 `B1_ALREADY_BOUND_CLOSEOUT`: CLOSED_UNCHANGED
+- B2 `B2_PROJECTION_OCTET_RUNTIME_VERIFY`: COMPLETE_READ_ONLY_VERIFY
+- B3 `decision_strip_blockers_unbound`: **NOT AUTHORIZED**
+  - Reason: `ACTIVE_DOUBLE_PLAY_PROJECTION_ABSENT:readmodels&#47;double_play_presentation_projection.v1.json;DOUBLE_PLAY_LOADER_UNRESOLVED:DOUBLE_PLAY_PRESENTATION_PROJECTION_ABSENT;BLOCKER_FIELD_CONTRACT_NOT_PROVEN_WITHOUT_ACTIVE_ARTIFACT;TEMPLATE_BLOCKERS_STILL_HARDCODED_NOT_BOUND`
+- B4 `B4_INTENTIONAL_AND_BLOCKED_FREEZE`: CLOSED_UNCHANGED
+
+## Artifacts in this folder
+
+- `VERIFY.json` — machine-readable family verify cycle
+- `INVENTORY_RECONCILE.json` — old/new MISSING_SOURCE and NOT_BOUND counts
+- `PROGRESS_ACCOUNTING.json` — B1/B2/B3/B4 accounting
+- `live_market.html` — live DOM capture at HEAD
+- `live_data_availability.json` — MISSING_SOURCE/NOT_BOUND element extract
+

--- a/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/live_data_availability.json
+++ b/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/live_data_availability.json
@@ -1,0 +1,605 @@
+[
+  {
+    "state": "MISSING_SOURCE",
+    "field": "safety",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"safety\" data-availability=\"MISSING_SOURCE\"",
+    "title": "CANONICAL_SAFETY_AUTHORITY_NOT_PERSISTED_FOR_DASHBOARD"
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "scope_lifecycle",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"scope_lifecycle\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "current_scope_ref",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"current_scope_ref\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "next_scope_ref",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"next_scope_ref\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "regime",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"regime\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "bull_bear",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"bull_bear\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "switch",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"switch\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "source_health",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"source_health\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": null,
+    "slot": "autonomy_stage",
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "li data-mdl-source-slot=\"autonomy_stage\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": "canonical_decision",
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "li data-mdl-source-slot=\"canonical_decision\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": null,
+    "slot": "diagnostics_summary",
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "li data-mdl-source-slot=\"diagnostics_summary\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": "double_play",
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "li data-mdl-source-slot=\"double_play\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": "dynamic_scope",
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "li data-mdl-source-slot=\"dynamic_scope\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": "economic_summary",
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "li data-mdl-source-slot=\"economic_summary\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": "execution_reconciliation",
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "li data-mdl-source-slot=\"execution_reconciliation\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": "regime_bull_bear_switch",
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "li data-mdl-source-slot=\"regime_bull_bear_switch\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": "risk_sizing_capital",
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "li data-mdl-source-slot=\"risk_sizing_capital\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": "safety_authority",
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "li data-mdl-source-slot=\"safety_authority\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "decision",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"decision\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "reason_codes",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"reason_codes\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "blockers",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"blockers\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "direction",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"direction\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "double_play",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"double_play\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "confidence",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"confidence\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "risk_summary",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "p data-mdl-field=\"risk_summary\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "risk_status",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"risk_status\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "sizing_status",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"sizing_status\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "capital_status",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"capital_status\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "risk_quantity",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"risk_quantity\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "risk_reasons",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"risk_reasons\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "execution_summary",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "p data-mdl-field=\"execution_summary\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "execution_status",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"execution_status\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "reconciliation_status",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"reconciliation_status\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "order_intent_ref",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"order_intent_ref\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "execution_reasons",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"execution_reasons\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "economic",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "p data-mdl-field=\"economic\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "economic_validity",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"economic_validity\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "economic_policy_threshold",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"economic_policy_threshold\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "economic_profit_factor",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"economic_profit_factor\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "economic_net_return",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"economic_net_return\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "economic_max_drawdown",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"economic_max_drawdown\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "economic_funding_drag",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"economic_funding_drag\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "economic_trade_count",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"economic_trade_count\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "economic_evidence_ref",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"economic_evidence_ref\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "economic_evidence_digest",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"economic_evidence_digest\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": "economic_reasons",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"economic_reasons\" data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "diagnostics_status",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "p data-mdl-field=\"diagnostics_status\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "diagnostics_authority",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"diagnostics_authority\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "diagnostics_owner",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"diagnostics_owner\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "governance_summary",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "p data-mdl-field=\"governance_summary\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "autonomy_stage",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"autonomy_stage\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "promotion_eligibility",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"promotion_eligibility\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "activation_eligibility",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"activation_eligibility\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "runtime_bridge_lock",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"runtime_bridge_lock\" data-availability=\"NOT_BOUND\"",
+    "title": "product_shell_constant_non_authoritative \u00b7 intentional lock \u00b7 not autonomy-stage source"
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "operator_go_required",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"operator_go_required\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": "governance_lock_class",
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "dd data-mdl-field=\"governance_lock_class\" data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": null,
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "span data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": null,
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "article data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "article data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "NOT_BOUND",
+    "field": null,
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "article data-availability=\"NOT_BOUND\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "article data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "article data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "article data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "article data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "article data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "article data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  },
+  {
+    "state": "MISSING_SOURCE",
+    "field": null,
+    "slot": null,
+    "eng": null,
+    "section_attr": null,
+    "tag_snip": "article data-availability=\"MISSING_SOURCE\"",
+    "title": null
+  }
+]

--- a/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/live_market.html
+++ b/docs/ops/market_dashboard/market_dashboard_projection_octet_runtime_verify_v1/live_market.html
@@ -1,0 +1,1532 @@
+<!-- templates/peak_trade_dashboard/base.html -->
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <title>Market Dashboard Landscape V2 — Peak_Trade</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- Phase 1B: self-hosted design tokens + layout + purged utilities (no Tailwind CDN) -->
+    <link
+      rel="stylesheet"
+      href="/static/css/peak_trade_dashboard_design_tokens_v1.css"
+      data-market-design-token-owner-v1="true"
+      data-canonical-design-token-owner="true"
+    />
+    <link rel="stylesheet" href="/static/css/peak_trade_dashboard_layout_v1.css" />
+    <link
+      rel="stylesheet"
+      href="/static/css/peak_trade_dashboard_utilities_v1.css"
+      data-market-utilities-css-v1="true"
+    />
+    <meta name="peak-trade-browser-network-allowlist" content="self-only" />
+    <style>
+      /* Custom animation for running indicator */
+      @keyframes pulse-dot { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+      .pulse-dot { animation: pulse-dot 1.5s ease-in-out infinite; }
+    </style>
+    
+<link rel="stylesheet" href="/static/css/market_dashboard_landscape_v2.css" />
+<meta name="peak-trade-market-landscape-v2" content="phase5-capability-7-product-maturity-technical" />
+<meta name="peak-trade-dashboard-authority" content="false" />
+<meta name="peak-trade-live-authorized" content="false" />
+
+  </head>
+  <body class="bg-slate-950 text-slate-100 mdl-v2-body">
+    <div class="min-h-screen">
+      
+<header class="mdl-v2-app-chrome" data-mdl-app-chrome="true">
+  <a href="/" class="mdl-v2-app-chrome__home">Peak_Trade</a>
+  <span class="mdl-v2-app-chrome__label">Market Landscape V2</span>
+  <span class="mdl-v2-chip">READ-ONLY · LIVE LOCKED</span>
+</header>
+
+
+      <main class="mdl-v2-main">
+        
+
+<div
+  class="mdl-v2"
+  data-market-landscape-v2="true"
+  data-market-dashboard-authority="false"
+  data-live-authorized="false"
+  data-orders="false"
+  data-phase="PHASE_5_CAPABILITY_7_PRODUCT_MATURITY_TECHNICAL"
+  data-runtime-bridge="BOUND_NOT_ACTIVATED"
+  data-mdl-a11y-baseline="task7"
+  data-mdl-density="task1"
+  data-canonical-market-path="/market"
+  data-canonical-ohlcv-path="/api/market/landscape/ohlcv"
+  data-supervised-presentation-only="false"
+  data-non-authoritative-bootstrap="false"
+  data-session-id="okx_governed_20260724T214823Z_57b32a24599d"
+  data-repository-sha=""
+>
+  <div class="mdl-v2-shell" data-mdl-outer-workspace="true">
+    <header class="mdl-v2-strip" data-mdl-region="GLOBAL_SYSTEM_STRIP" aria-label="Global system strip">
+      <div class="mdl-v2-strip__brand">
+        <h1 class="mdl-v2-kicker">Market Landscape</h1>
+        <span class="mdl-v2-chip mdl-v2-chip--quiet">READ-ONLY CONSUMER</span>
+      </div>
+      <dl class="mdl-v2-strip__facts">
+        
+        <div><dt>Instrument</dt><dd data-mdl-field="instrument">SATS-USDT-SWAP</dd></div>
+        <div><dt>Venue</dt><dd data-mdl-field="venue">OKX</dd></div>
+        <div>
+          <dt>Session</dt>
+          <dd
+            data-mdl-field="session_id"
+            data-availability="STALE"
+          >okx_governed_20260724T214823Z_57b32a24599d</dd>
+        </div>
+        <div><dt>Repo SHA</dt><dd data-mdl-field="repository_sha">—</dd></div>
+        <div>
+          <dt>Runtime</dt>
+          <dd data-mdl-field="runtime" title="product_shell_constant_non_authoritative">BOUND_NOT_ACTIVATED</dd>
+        </div>
+        <div>
+          <dt>Safety</dt>
+          <dd
+            data-mdl-field="safety"
+            data-availability="MISSING_SOURCE"
+            title="CANONICAL_SAFETY_AUTHORITY_NOT_PERSISTED_FOR_DASHBOARD"
+          >MISSING_SOURCE</dd>
+        </div>
+      </dl>
+    </header>
+
+    <div class="mdl-v2-workspace" data-mdl-workspace="true">
+      <aside class="mdl-v2-rail mdl-v2-rail--left" data-mdl-region="UNIVERSE_RANK_RAIL" aria-label="Universe and rank">
+        <h2>Universe</h2>
+        <ul class="mdl-v2-rail-rows" aria-label="Universe projection">
+          <li>
+            <span class="mdl-v2-rail-rows__label">Watchlist</span>
+            <span class="mdl-v2-state" data-availability="STALE" data-mdl-field="universe_watchlist">60</span>
+          </li>
+          <li>
+            <span class="mdl-v2-rail-rows__label">Selected</span>
+            <span class="mdl-v2-state" data-mdl-field="selected_instrument">
+              SATS-USDT-SWAP
+            </span>
+          </li>
+          <li>
+            <span class="mdl-v2-rail-rows__label">Membership</span>
+            <span class="mdl-v2-state" data-availability="STALE" data-mdl-field="universe_membership">IN_UNIVERSE</span>
+          </li>
+          <li>
+            <span class="mdl-v2-rail-rows__label">Rank</span>
+            <span class="mdl-v2-state" data-availability="STALE" data-mdl-field="rank_status">#1</span>
+          </li>
+          <li>
+            <span class="mdl-v2-rail-rows__label">Selection Reason</span>
+            <span
+              class="mdl-v2-state"
+              data-availability="STALE"
+              data-mdl-field="selection_reason"
+            >upstream_explicit_selection</span>
+          </li>
+        </ul>
+        
+        <ul class="mdl-v2-rail-rows mdl-v2-rail-rows--ranked" aria-label="Ranking rows" data-mdl-ranking-rows="true">
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#1 SATS-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#2 PEPE-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#3 SHIB-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#4 BONK-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#5 FLOKI-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#6 PUMP-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#7 HMSTR-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#8 NEIRO-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#9 DOGE-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#10 HOME-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#11 CAP-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+          <li>
+            <span class="mdl-v2-rail-rows__label">#12 BILL-USDT-SWAP</span>
+            <span class="mdl-v2-state">—</span>
+          </li>
+          
+        </ul>
+        
+      </aside>
+
+      <section
+        class="mdl-v2-primary"
+        data-mdl-region="PRIMARY_MARKET_WORKSPACE"
+        data-mdl-chart-region="true"
+        aria-label="Primary market workspace"
+      >
+        <div
+          class="mdl-v2-chart"
+          data-mdl-chart="true"
+          data-chart-bound="true"
+          data-mdl-chart-has-series="true"
+          data-mdl-ohlcv-poll-path="/api/market/landscape/ohlcv"
+          data-mdl-ohlcv-poll-interval-seconds="1"
+        >
+          <div class="mdl-v2-chart__chrome">
+            <h2>Chart</h2>
+            <span
+              class="mdl-v2-state"
+              data-mdl-data-connection-state="true"
+              data-connection-state="HEALTHY"
+            >HEALTHY</span>
+            
+            <span class="mdl-v2-state" data-availability="AVAILABLE" data-mdl-chart-availability="true">AVAILABLE</span>
+            
+          </div>
+          <dl class="mdl-v2-chart__meta" data-mdl-ohlcv-meta="true" aria-label="Open candle OHLCV and freshness">
+            <div>
+              <dt>Interval</dt>
+              <dd data-mdl-field="ohlcv_interval">PT1M</dd>
+            </div>
+            <div>
+              <dt>Candle start</dt>
+              <dd data-mdl-field="ohlcv_latest_candle_at">2026-08-04T19:29:00Z</dd>
+            </div>
+            <div>
+              <dt>Captured</dt>
+              <dd data-mdl-field="ohlcv_captured_at">2026-08-04T19:29:36Z</dd>
+            </div>
+            <div>
+              <dt>Mark</dt>
+              <dd data-mdl-field="ohlcv_live_mark">0.000000009803</dd>
+            </div>
+            <div>
+              <dt>Revision</dt>
+              <dd data-mdl-field="ohlcv_revision">NO_OP</dd>
+            </div>
+            <div class="mdl-v2-chart__meta-ohlc">
+              <dt>Open</dt>
+              <dd data-mdl-field="ohlcv_open">0.000000009804</dd>
+            </div>
+            <div class="mdl-v2-chart__meta-ohlc">
+              <dt>High</dt>
+              <dd data-mdl-field="ohlcv_high">0.000000009804</dd>
+            </div>
+            <div class="mdl-v2-chart__meta-ohlc">
+              <dt>Low</dt>
+              <dd data-mdl-field="ohlcv_low">0.000000009804</dd>
+            </div>
+            <div class="mdl-v2-chart__meta-ohlc">
+              <dt>Close</dt>
+              <dd data-mdl-field="ohlcv_close">0.000000009804</dd>
+            </div>
+            <div class="mdl-v2-chart__meta-ohlc">
+              <dt>Change</dt>
+              <dd data-mdl-field="ohlcv_change">0.0000%</dd>
+            </div>
+            <div class="mdl-v2-chart__meta-ohlc">
+              <dt>Volume</dt>
+              <dd data-mdl-field="ohlcv_volume">0</dd>
+            </div>
+          </dl>
+          <div class="mdl-v2-chart__stage" role="img" aria-label="OHLCV chart" data-mdl-chart-stage="true">
+            <p class="mdl-v2-chart__message" data-mdl-chart-message="true"></p>
+            
+            <script type="application/json" data-mdl-ohlcv-json="true">{"bar_count": 100, "bars": [{"close": 9.71e-09, "confirm": true, "display_close": 9.71e-09, "display_high": 9.71e-09, "display_low": 9.7e-09, "high": 9.71e-09, "low": 9.7e-09, "open": 9.702e-09, "provisional": false, "ts": "2026-08-04T17:50:00Z", "volume": 4717.0}, {"close": 9.706e-09, "confirm": true, "display_close": 9.706e-09, "display_high": 9.707e-09, "display_low": 9.706e-09, "high": 9.707e-09, "low": 9.706e-09, "open": 9.707e-09, "provisional": false, "ts": "2026-08-04T17:51:00Z", "volume": 488.0}, {"close": 9.718e-09, "confirm": true, "display_close": 9.718e-09, "display_high": 9.718e-09, "display_low": 9.71e-09, "high": 9.718e-09, "low": 9.71e-09, "open": 9.71e-09, "provisional": false, "ts": "2026-08-04T17:52:00Z", "volume": 2757.0}, {"close": 9.721e-09, "confirm": true, "display_close": 9.721e-09, "display_high": 9.723e-09, "display_low": 9.719e-09, "high": 9.723e-09, "low": 9.719e-09, "open": 9.72e-09, "provisional": false, "ts": "2026-08-04T17:53:00Z", "volume": 574.0}, {"close": 9.721e-09, "confirm": true, "display_close": 9.721e-09, "display_high": 9.721e-09, "display_low": 9.721e-09, "high": 9.721e-09, "low": 9.721e-09, "open": 9.721e-09, "provisional": false, "ts": "2026-08-04T17:54:00Z", "volume": 0.0}, {"close": 9.714e-09, "confirm": true, "display_close": 9.714e-09, "display_high": 9.715e-09, "display_low": 9.712e-09, "high": 9.715e-09, "low": 9.712e-09, "open": 9.715e-09, "provisional": false, "ts": "2026-08-04T17:55:00Z", "volume": 1165.0}, {"close": 9.712e-09, "confirm": true, "display_close": 9.712e-09, "display_high": 9.718e-09, "display_low": 9.712e-09, "high": 9.718e-09, "low": 9.712e-09, "open": 9.716e-09, "provisional": false, "ts": "2026-08-04T17:56:00Z", "volume": 770.0}, {"close": 9.705e-09, "confirm": true, "display_close": 9.705e-09, "display_high": 9.71e-09, "display_low": 9.704e-09, "high": 9.71e-09, "low": 9.704e-09, "open": 9.71e-09, "provisional": false, "ts": "2026-08-04T17:57:00Z", "volume": 5310.0}, {"close": 9.699e-09, "confirm": true, "display_close": 9.699e-09, "display_high": 9.702e-09, "display_low": 9.699e-09, "high": 9.702e-09, "low": 9.699e-09, "open": 9.702e-09, "provisional": false, "ts": "2026-08-04T17:58:00Z", "volume": 777.0}, {"close": 9.691e-09, "confirm": true, "display_close": 9.691e-09, "display_high": 9.697e-09, "display_low": 9.691e-09, "high": 9.697e-09, "low": 9.691e-09, "open": 9.697e-09, "provisional": false, "ts": "2026-08-04T17:59:00Z", "volume": 1251.0}, {"close": 9.7e-09, "confirm": true, "display_close": 9.7e-09, "display_high": 9.7e-09, "display_low": 9.691e-09, "high": 9.7e-09, "low": 9.691e-09, "open": 9.691e-09, "provisional": false, "ts": "2026-08-04T18:00:00Z", "volume": 4800.0}, {"close": 9.7e-09, "confirm": true, "display_close": 9.7e-09, "display_high": 9.704e-09, "display_low": 9.697e-09, "high": 9.704e-09, "low": 9.697e-09, "open": 9.701e-09, "provisional": false, "ts": "2026-08-04T18:01:00Z", "volume": 3276.0}, {"close": 9.705e-09, "confirm": true, "display_close": 9.705e-09, "display_high": 9.709e-09, "display_low": 9.7e-09, "high": 9.709e-09, "low": 9.7e-09, "open": 9.7e-09, "provisional": false, "ts": "2026-08-04T18:02:00Z", "volume": 11045.0}, {"close": 9.715e-09, "confirm": true, "display_close": 9.715e-09, "display_high": 9.715e-09, "display_low": 9.707e-09, "high": 9.715e-09, "low": 9.707e-09, "open": 9.707e-09, "provisional": false, "ts": "2026-08-04T18:03:00Z", "volume": 442.0}, {"close": 9.716e-09, "confirm": true, "display_close": 9.716e-09, "display_high": 9.72e-09, "display_low": 9.715e-09, "high": 9.72e-09, "low": 9.715e-09, "open": 9.716e-09, "provisional": false, "ts": "2026-08-04T18:04:00Z", "volume": 939.0}, {"close": 9.731e-09, "confirm": true, "display_close": 9.731e-09, "display_high": 9.731e-09, "display_low": 9.718e-09, "high": 9.731e-09, "low": 9.718e-09, "open": 9.718e-09, "provisional": false, "ts": "2026-08-04T18:05:00Z", "volume": 825.0}, {"close": 9.736e-09, "confirm": true, "display_close": 9.736e-09, "display_high": 9.738e-09, "display_low": 9.73e-09, "high": 9.738e-09, "low": 9.73e-09, "open": 9.732e-09, "provisional": false, "ts": "2026-08-04T18:06:00Z", "volume": 537.0}, {"close": 9.727e-09, "confirm": true, "display_close": 9.727e-09, "display_high": 9.744e-09, "display_low": 9.727e-09, "high": 9.744e-09, "low": 9.727e-09, "open": 9.737e-09, "provisional": false, "ts": "2026-08-04T18:07:00Z", "volume": 3875.0}, {"close": 9.722e-09, "confirm": true, "display_close": 9.722e-09, "display_high": 9.736e-09, "display_low": 9.722e-09, "high": 9.736e-09, "low": 9.722e-09, "open": 9.728e-09, "provisional": false, "ts": "2026-08-04T18:08:00Z", "volume": 270.0}, {"close": 9.723e-09, "confirm": true, "display_close": 9.723e-09, "display_high": 9.728e-09, "display_low": 9.723e-09, "high": 9.728e-09, "low": 9.723e-09, "open": 9.726e-09, "provisional": false, "ts": "2026-08-04T18:09:00Z", "volume": 487.0}, {"close": 9.718e-09, "confirm": true, "display_close": 9.718e-09, "display_high": 9.726e-09, "display_low": 9.718e-09, "high": 9.726e-09, "low": 9.718e-09, "open": 9.726e-09, "provisional": false, "ts": "2026-08-04T18:10:00Z", "volume": 292.0}, {"close": 9.72e-09, "confirm": true, "display_close": 9.72e-09, "display_high": 9.725e-09, "display_low": 9.716e-09, "high": 9.725e-09, "low": 9.716e-09, "open": 9.72e-09, "provisional": false, "ts": "2026-08-04T18:11:00Z", "volume": 4134.0}, {"close": 9.735e-09, "confirm": true, "display_close": 9.735e-09, "display_high": 9.736e-09, "display_low": 9.724e-09, "high": 9.736e-09, "low": 9.724e-09, "open": 9.724e-09, "provisional": false, "ts": "2026-08-04T18:12:00Z", "volume": 1426.0}, {"close": 9.732e-09, "confirm": true, "display_close": 9.732e-09, "display_high": 9.735e-09, "display_low": 9.727e-09, "high": 9.735e-09, "low": 9.727e-09, "open": 9.735e-09, "provisional": false, "ts": "2026-08-04T18:13:00Z", "volume": 253.0}, {"close": 9.735e-09, "confirm": true, "display_close": 9.735e-09, "display_high": 9.735e-09, "display_low": 9.732e-09, "high": 9.735e-09, "low": 9.732e-09, "open": 9.732e-09, "provisional": false, "ts": "2026-08-04T18:14:00Z", "volume": 370.0}, {"close": 9.744e-09, "confirm": true, "display_close": 9.744e-09, "display_high": 9.744e-09, "display_low": 9.736e-09, "high": 9.744e-09, "low": 9.736e-09, "open": 9.736e-09, "provisional": false, "ts": "2026-08-04T18:15:00Z", "volume": 283.0}, {"close": 9.725e-09, "confirm": true, "display_close": 9.725e-09, "display_high": 9.743e-09, "display_low": 9.725e-09, "high": 9.743e-09, "low": 9.725e-09, "open": 9.743e-09, "provisional": false, "ts": "2026-08-04T18:16:00Z", "volume": 433.0}, {"close": 9.728e-09, "confirm": true, "display_close": 9.728e-09, "display_high": 9.738e-09, "display_low": 9.728e-09, "high": 9.738e-09, "low": 9.728e-09, "open": 9.731e-09, "provisional": false, "ts": "2026-08-04T18:17:00Z", "volume": 1371.0}, {"close": 9.728e-09, "confirm": true, "display_close": 9.728e-09, "display_high": 9.728e-09, "display_low": 9.728e-09, "high": 9.728e-09, "low": 9.728e-09, "open": 9.728e-09, "provisional": false, "ts": "2026-08-04T18:18:00Z", "volume": 0.0}, {"close": 9.733e-09, "confirm": true, "display_close": 9.733e-09, "display_high": 9.733e-09, "display_low": 9.732e-09, "high": 9.733e-09, "low": 9.732e-09, "open": 9.732e-09, "provisional": false, "ts": "2026-08-04T18:19:00Z", "volume": 56.0}, {"close": 9.738e-09, "confirm": true, "display_close": 9.738e-09, "display_high": 9.738e-09, "display_low": 9.736e-09, "high": 9.738e-09, "low": 9.736e-09, "open": 9.736e-09, "provisional": false, "ts": "2026-08-04T18:20:00Z", "volume": 22.0}, {"close": 9.753e-09, "confirm": true, "display_close": 9.753e-09, "display_high": 9.753e-09, "display_low": 9.74e-09, "high": 9.753e-09, "low": 9.74e-09, "open": 9.74e-09, "provisional": false, "ts": "2026-08-04T18:21:00Z", "volume": 4986.0}, {"close": 9.749e-09, "confirm": true, "display_close": 9.749e-09, "display_high": 9.761e-09, "display_low": 9.742e-09, "high": 9.761e-09, "low": 9.742e-09, "open": 9.754e-09, "provisional": false, "ts": "2026-08-04T18:22:00Z", "volume": 30871.0}, {"close": 9.747e-09, "confirm": true, "display_close": 9.747e-09, "display_high": 9.753e-09, "display_low": 9.741e-09, "high": 9.753e-09, "low": 9.741e-09, "open": 9.752e-09, "provisional": false, "ts": "2026-08-04T18:23:00Z", "volume": 1130.0}, {"close": 9.746e-09, "confirm": true, "display_close": 9.746e-09, "display_high": 9.747e-09, "display_low": 9.746e-09, "high": 9.747e-09, "low": 9.746e-09, "open": 9.747e-09, "provisional": false, "ts": "2026-08-04T18:24:00Z", "volume": 126.0}, {"close": 9.759e-09, "confirm": true, "display_close": 9.759e-09, "display_high": 9.759e-09, "display_low": 9.748e-09, "high": 9.759e-09, "low": 9.748e-09, "open": 9.748e-09, "provisional": false, "ts": "2026-08-04T18:25:00Z", "volume": 4346.0}, {"close": 9.748e-09, "confirm": true, "display_close": 9.748e-09, "display_high": 9.751e-09, "display_low": 9.747e-09, "high": 9.751e-09, "low": 9.747e-09, "open": 9.75e-09, "provisional": false, "ts": "2026-08-04T18:26:00Z", "volume": 292.0}, {"close": 9.754e-09, "confirm": true, "display_close": 9.754e-09, "display_high": 9.754e-09, "display_low": 9.751e-09, "high": 9.754e-09, "low": 9.751e-09, "open": 9.751e-09, "provisional": false, "ts": "2026-08-04T18:27:00Z", "volume": 65.0}, {"close": 9.746e-09, "confirm": true, "display_close": 9.746e-09, "display_high": 9.752e-09, "display_low": 9.746e-09, "high": 9.752e-09, "low": 9.746e-09, "open": 9.752e-09, "provisional": false, "ts": "2026-08-04T18:28:00Z", "volume": 1185.0}, {"close": 9.755e-09, "confirm": true, "display_close": 9.755e-09, "display_high": 9.755e-09, "display_low": 9.748e-09, "high": 9.755e-09, "low": 9.748e-09, "open": 9.748e-09, "provisional": false, "ts": "2026-08-04T18:29:00Z", "volume": 628.0}, {"close": 9.756e-09, "confirm": true, "display_close": 9.756e-09, "display_high": 9.756e-09, "display_low": 9.751e-09, "high": 9.756e-09, "low": 9.751e-09, "open": 9.753e-09, "provisional": false, "ts": "2026-08-04T18:30:00Z", "volume": 836.0}, {"close": 9.755e-09, "confirm": true, "display_close": 9.755e-09, "display_high": 9.755e-09, "display_low": 9.754e-09, "high": 9.755e-09, "low": 9.754e-09, "open": 9.755e-09, "provisional": false, "ts": "2026-08-04T18:31:00Z", "volume": 233.0}, {"close": 9.755e-09, "confirm": true, "display_close": 9.755e-09, "display_high": 9.755e-09, "display_low": 9.755e-09, "high": 9.755e-09, "low": 9.755e-09, "open": 9.755e-09, "provisional": false, "ts": "2026-08-04T18:32:00Z", "volume": 0.0}, {"close": 9.748e-09, "confirm": true, "display_close": 9.748e-09, "display_high": 9.75e-09, "display_low": 9.748e-09, "high": 9.75e-09, "low": 9.748e-09, "open": 9.75e-09, "provisional": false, "ts": "2026-08-04T18:33:00Z", "volume": 190.0}, {"close": 9.744e-09, "confirm": true, "display_close": 9.744e-09, "display_high": 9.749e-09, "display_low": 9.74e-09, "high": 9.749e-09, "low": 9.74e-09, "open": 9.749e-09, "provisional": false, "ts": "2026-08-04T18:34:00Z", "volume": 4721.0}, {"close": 9.749e-09, "confirm": true, "display_close": 9.749e-09, "display_high": 9.749e-09, "display_low": 9.748e-09, "high": 9.749e-09, "low": 9.748e-09, "open": 9.748e-09, "provisional": false, "ts": "2026-08-04T18:35:00Z", "volume": 58.0}, {"close": 9.747e-09, "confirm": true, "display_close": 9.747e-09, "display_high": 9.748e-09, "display_low": 9.747e-09, "high": 9.748e-09, "low": 9.747e-09, "open": 9.748e-09, "provisional": false, "ts": "2026-08-04T18:36:00Z", "volume": 183.0}, {"close": 9.739e-09, "confirm": true, "display_close": 9.739e-09, "display_high": 9.743e-09, "display_low": 9.739e-09, "high": 9.743e-09, "low": 9.739e-09, "open": 9.743e-09, "provisional": false, "ts": "2026-08-04T18:37:00Z", "volume": 945.0}, {"close": 9.724e-09, "confirm": true, "display_close": 9.724e-09, "display_high": 9.738e-09, "display_low": 9.724e-09, "high": 9.738e-09, "low": 9.724e-09, "open": 9.738e-09, "provisional": false, "ts": "2026-08-04T18:38:00Z", "volume": 7977.0}, {"close": 9.73e-09, "confirm": true, "display_close": 9.73e-09, "display_high": 9.73e-09, "display_low": 9.73e-09, "high": 9.73e-09, "low": 9.73e-09, "open": 9.73e-09, "provisional": false, "ts": "2026-08-04T18:39:00Z", "volume": 1349.0}, {"close": 9.72e-09, "confirm": true, "display_close": 9.72e-09, "display_high": 9.729e-09, "display_low": 9.72e-09, "high": 9.729e-09, "low": 9.72e-09, "open": 9.729e-09, "provisional": false, "ts": "2026-08-04T18:40:00Z", "volume": 416.0}, {"close": 9.734e-09, "confirm": true, "display_close": 9.734e-09, "display_high": 9.734e-09, "display_low": 9.723e-09, "high": 9.734e-09, "low": 9.723e-09, "open": 9.723e-09, "provisional": false, "ts": "2026-08-04T18:41:00Z", "volume": 2508.0}, {"close": 9.724e-09, "confirm": true, "display_close": 9.724e-09, "display_high": 9.727e-09, "display_low": 9.724e-09, "high": 9.727e-09, "low": 9.724e-09, "open": 9.727e-09, "provisional": false, "ts": "2026-08-04T18:42:00Z", "volume": 505.0}, {"close": 9.73e-09, "confirm": true, "display_close": 9.73e-09, "display_high": 9.73e-09, "display_low": 9.725e-09, "high": 9.73e-09, "low": 9.725e-09, "open": 9.726e-09, "provisional": false, "ts": "2026-08-04T18:43:00Z", "volume": 802.0}, {"close": 9.73e-09, "confirm": true, "display_close": 9.73e-09, "display_high": 9.734e-09, "display_low": 9.727e-09, "high": 9.734e-09, "low": 9.727e-09, "open": 9.73e-09, "provisional": false, "ts": "2026-08-04T18:44:00Z", "volume": 822.0}, {"close": 9.732e-09, "confirm": true, "display_close": 9.732e-09, "display_high": 9.736e-09, "display_low": 9.73e-09, "high": 9.736e-09, "low": 9.73e-09, "open": 9.73e-09, "provisional": false, "ts": "2026-08-04T18:45:00Z", "volume": 651.0}, {"close": 9.73e-09, "confirm": true, "display_close": 9.73e-09, "display_high": 9.732e-09, "display_low": 9.73e-09, "high": 9.732e-09, "low": 9.73e-09, "open": 9.732e-09, "provisional": false, "ts": "2026-08-04T18:46:00Z", "volume": 1146.0}, {"close": 9.728e-09, "confirm": true, "display_close": 9.728e-09, "display_high": 9.728e-09, "display_low": 9.728e-09, "high": 9.728e-09, "low": 9.728e-09, "open": 9.728e-09, "provisional": false, "ts": "2026-08-04T18:47:00Z", "volume": 256.0}, {"close": 9.723e-09, "confirm": true, "display_close": 9.723e-09, "display_high": 9.734e-09, "display_low": 9.723e-09, "high": 9.734e-09, "low": 9.723e-09, "open": 9.728e-09, "provisional": false, "ts": "2026-08-04T18:48:00Z", "volume": 745.0}, {"close": 9.722e-09, "confirm": true, "display_close": 9.722e-09, "display_high": 9.727e-09, "display_low": 9.722e-09, "high": 9.727e-09, "low": 9.722e-09, "open": 9.726e-09, "provisional": false, "ts": "2026-08-04T18:49:00Z", "volume": 115.0}, {"close": 9.726e-09, "confirm": true, "display_close": 9.726e-09, "display_high": 9.726e-09, "display_low": 9.726e-09, "high": 9.726e-09, "low": 9.726e-09, "open": 9.726e-09, "provisional": false, "ts": "2026-08-04T18:50:00Z", "volume": 90.0}, {"close": 9.728e-09, "confirm": true, "display_close": 9.728e-09, "display_high": 9.728e-09, "display_low": 9.726e-09, "high": 9.728e-09, "low": 9.726e-09, "open": 9.726e-09, "provisional": false, "ts": "2026-08-04T18:51:00Z", "volume": 378.0}, {"close": 9.727e-09, "confirm": true, "display_close": 9.727e-09, "display_high": 9.729e-09, "display_low": 9.727e-09, "high": 9.729e-09, "low": 9.727e-09, "open": 9.729e-09, "provisional": false, "ts": "2026-08-04T18:52:00Z", "volume": 3173.0}, {"close": 9.735e-09, "confirm": true, "display_close": 9.735e-09, "display_high": 9.737e-09, "display_low": 9.727e-09, "high": 9.737e-09, "low": 9.727e-09, "open": 9.727e-09, "provisional": false, "ts": "2026-08-04T18:53:00Z", "volume": 1161.0}, {"close": 9.728e-09, "confirm": true, "display_close": 9.728e-09, "display_high": 9.737e-09, "display_low": 9.715e-09, "high": 9.737e-09, "low": 9.715e-09, "open": 9.735e-09, "provisional": false, "ts": "2026-08-04T18:54:00Z", "volume": 2927.0}, {"close": 9.731e-09, "confirm": true, "display_close": 9.731e-09, "display_high": 9.731e-09, "display_low": 9.726e-09, "high": 9.731e-09, "low": 9.726e-09, "open": 9.726e-09, "provisional": false, "ts": "2026-08-04T18:55:00Z", "volume": 4000.0}, {"close": 9.731e-09, "confirm": true, "display_close": 9.731e-09, "display_high": 9.738e-09, "display_low": 9.731e-09, "high": 9.738e-09, "low": 9.731e-09, "open": 9.732e-09, "provisional": false, "ts": "2026-08-04T18:56:00Z", "volume": 717.0}, {"close": 9.732e-09, "confirm": true, "display_close": 9.732e-09, "display_high": 9.732e-09, "display_low": 9.732e-09, "high": 9.732e-09, "low": 9.732e-09, "open": 9.732e-09, "provisional": false, "ts": "2026-08-04T18:57:00Z", "volume": 682.0}, {"close": 9.73e-09, "confirm": true, "display_close": 9.73e-09, "display_high": 9.736e-09, "display_low": 9.73e-09, "high": 9.736e-09, "low": 9.73e-09, "open": 9.732e-09, "provisional": false, "ts": "2026-08-04T18:58:00Z", "volume": 2344.0}, {"close": 9.735e-09, "confirm": true, "display_close": 9.735e-09, "display_high": 9.736e-09, "display_low": 9.733e-09, "high": 9.736e-09, "low": 9.733e-09, "open": 9.735e-09, "provisional": false, "ts": "2026-08-04T18:59:00Z", "volume": 410.0}, {"close": 9.736e-09, "confirm": true, "display_close": 9.736e-09, "display_high": 9.739e-09, "display_low": 9.736e-09, "high": 9.739e-09, "low": 9.736e-09, "open": 9.738e-09, "provisional": false, "ts": "2026-08-04T19:00:00Z", "volume": 2751.0}, {"close": 9.74e-09, "confirm": true, "display_close": 9.74e-09, "display_high": 9.74e-09, "display_low": 9.737e-09, "high": 9.74e-09, "low": 9.737e-09, "open": 9.737e-09, "provisional": false, "ts": "2026-08-04T19:01:00Z", "volume": 381.0}, {"close": 9.747e-09, "confirm": true, "display_close": 9.747e-09, "display_high": 9.747e-09, "display_low": 9.741e-09, "high": 9.747e-09, "low": 9.741e-09, "open": 9.741e-09, "provisional": false, "ts": "2026-08-04T19:02:00Z", "volume": 5967.0}, {"close": 9.744e-09, "confirm": true, "display_close": 9.744e-09, "display_high": 9.748e-09, "display_low": 9.739e-09, "high": 9.748e-09, "low": 9.739e-09, "open": 9.747e-09, "provisional": false, "ts": "2026-08-04T19:03:00Z", "volume": 431.0}, {"close": 9.74e-09, "confirm": true, "display_close": 9.74e-09, "display_high": 9.744e-09, "display_low": 9.74e-09, "high": 9.744e-09, "low": 9.74e-09, "open": 9.744e-09, "provisional": false, "ts": "2026-08-04T19:04:00Z", "volume": 38.0}, {"close": 9.736e-09, "confirm": true, "display_close": 9.736e-09, "display_high": 9.736e-09, "display_low": 9.733e-09, "high": 9.736e-09, "low": 9.733e-09, "open": 9.736e-09, "provisional": false, "ts": "2026-08-04T19:05:00Z", "volume": 392.0}, {"close": 9.748e-09, "confirm": true, "display_close": 9.748e-09, "display_high": 9.751e-09, "display_low": 9.742e-09, "high": 9.751e-09, "low": 9.742e-09, "open": 9.742e-09, "provisional": false, "ts": "2026-08-04T19:06:00Z", "volume": 1514.0}, {"close": 9.764e-09, "confirm": true, "display_close": 9.764e-09, "display_high": 9.764e-09, "display_low": 9.744e-09, "high": 9.764e-09, "low": 9.744e-09, "open": 9.745e-09, "provisional": false, "ts": "2026-08-04T19:07:00Z", "volume": 3341.0}, {"close": 9.766e-09, "confirm": true, "display_close": 9.766e-09, "display_high": 9.777e-09, "display_low": 9.752e-09, "high": 9.777e-09, "low": 9.752e-09, "open": 9.764e-09, "provisional": false, "ts": "2026-08-04T19:08:00Z", "volume": 22619.0}, {"close": 9.766e-09, "confirm": true, "display_close": 9.766e-09, "display_high": 9.771e-09, "display_low": 9.754e-09, "high": 9.771e-09, "low": 9.754e-09, "open": 9.765e-09, "provisional": false, "ts": "2026-08-04T19:09:00Z", "volume": 21449.0}, {"close": 9.781e-09, "confirm": true, "display_close": 9.781e-09, "display_high": 9.781e-09, "display_low": 9.769e-09, "high": 9.781e-09, "low": 9.769e-09, "open": 9.769e-09, "provisional": false, "ts": "2026-08-04T19:10:00Z", "volume": 10986.0}, {"close": 9.781e-09, "confirm": true, "display_close": 9.781e-09, "display_high": 9.782e-09, "display_low": 9.781e-09, "high": 9.782e-09, "low": 9.781e-09, "open": 9.782e-09, "provisional": false, "ts": "2026-08-04T19:11:00Z", "volume": 5353.0}, {"close": 9.786e-09, "confirm": true, "display_close": 9.786e-09, "display_high": 9.786e-09, "display_low": 9.781e-09, "high": 9.786e-09, "low": 9.781e-09, "open": 9.782e-09, "provisional": false, "ts": "2026-08-04T19:12:00Z", "volume": 37742.0}, {"close": 9.777e-09, "confirm": true, "display_close": 9.777e-09, "display_high": 9.782e-09, "display_low": 9.772e-09, "high": 9.782e-09, "low": 9.772e-09, "open": 9.782e-09, "provisional": false, "ts": "2026-08-04T19:13:00Z", "volume": 9798.0}, {"close": 9.779e-09, "confirm": true, "display_close": 9.779e-09, "display_high": 9.779e-09, "display_low": 9.777e-09, "high": 9.779e-09, "low": 9.777e-09, "open": 9.777e-09, "provisional": false, "ts": "2026-08-04T19:14:00Z", "volume": 484.0}, {"close": 9.78e-09, "confirm": true, "display_close": 9.78e-09, "display_high": 9.781e-09, "display_low": 9.78e-09, "high": 9.781e-09, "low": 9.78e-09, "open": 9.781e-09, "provisional": false, "ts": "2026-08-04T19:15:00Z", "volume": 53.0}, {"close": 9.78e-09, "confirm": true, "display_close": 9.78e-09, "display_high": 9.78e-09, "display_low": 9.78e-09, "high": 9.78e-09, "low": 9.78e-09, "open": 9.78e-09, "provisional": false, "ts": "2026-08-04T19:16:00Z", "volume": 0.0}, {"close": 9.784e-09, "confirm": true, "display_close": 9.784e-09, "display_high": 9.784e-09, "display_low": 9.779e-09, "high": 9.784e-09, "low": 9.779e-09, "open": 9.779e-09, "provisional": false, "ts": "2026-08-04T19:17:00Z", "volume": 3869.0}, {"close": 9.784e-09, "confirm": true, "display_close": 9.784e-09, "display_high": 9.784e-09, "display_low": 9.784e-09, "high": 9.784e-09, "low": 9.784e-09, "open": 9.784e-09, "provisional": false, "ts": "2026-08-04T19:18:00Z", "volume": 0.0}, {"close": 9.785e-09, "confirm": true, "display_close": 9.785e-09, "display_high": 9.785e-09, "display_low": 9.784e-09, "high": 9.785e-09, "low": 9.784e-09, "open": 9.784e-09, "provisional": false, "ts": "2026-08-04T19:19:00Z", "volume": 3618.0}, {"close": 9.793e-09, "confirm": true, "display_close": 9.793e-09, "display_high": 9.81e-09, "display_low": 9.784e-09, "high": 9.81e-09, "low": 9.784e-09, "open": 9.785e-09, "provisional": false, "ts": "2026-08-04T19:20:00Z", "volume": 39643.0}, {"close": 9.798e-09, "confirm": true, "display_close": 9.798e-09, "display_high": 9.801e-09, "display_low": 9.79e-09, "high": 9.801e-09, "low": 9.79e-09, "open": 9.79e-09, "provisional": false, "ts": "2026-08-04T19:21:00Z", "volume": 1551.0}, {"close": 9.787e-09, "confirm": true, "display_close": 9.787e-09, "display_high": 9.799e-09, "display_low": 9.787e-09, "high": 9.799e-09, "low": 9.787e-09, "open": 9.797e-09, "provisional": false, "ts": "2026-08-04T19:22:00Z", "volume": 9437.0}, {"close": 9.797e-09, "confirm": true, "display_close": 9.797e-09, "display_high": 9.797e-09, "display_low": 9.787e-09, "high": 9.797e-09, "low": 9.787e-09, "open": 9.787e-09, "provisional": false, "ts": "2026-08-04T19:23:00Z", "volume": 1383.0}, {"close": 9.795e-09, "confirm": true, "display_close": 9.795e-09, "display_high": 9.797e-09, "display_low": 9.792e-09, "high": 9.797e-09, "low": 9.792e-09, "open": 9.797e-09, "provisional": false, "ts": "2026-08-04T19:24:00Z", "volume": 504.0}, {"close": 9.803e-09, "confirm": true, "display_close": 9.803e-09, "display_high": 9.803e-09, "display_low": 9.792e-09, "high": 9.803e-09, "low": 9.792e-09, "open": 9.795e-09, "provisional": false, "ts": "2026-08-04T19:25:00Z", "volume": 5465.0}, {"close": 9.806e-09, "confirm": true, "display_close": 9.806e-09, "display_high": 9.806e-09, "display_low": 9.802e-09, "high": 9.806e-09, "low": 9.802e-09, "open": 9.802e-09, "provisional": false, "ts": "2026-08-04T19:26:00Z", "volume": 197.0}, {"close": 9.791e-09, "confirm": true, "display_close": 9.791e-09, "display_high": 9.808e-09, "display_low": 9.771e-09, "high": 9.808e-09, "low": 9.771e-09, "open": 9.808e-09, "provisional": false, "ts": "2026-08-04T19:27:00Z", "volume": 99206.0}, {"close": 9.804e-09, "confirm": true, "display_close": 9.804e-09, "display_high": 9.804e-09, "display_low": 9.793e-09, "high": 9.804e-09, "low": 9.793e-09, "open": 9.793e-09, "provisional": false, "ts": "2026-08-04T19:28:00Z", "volume": 3647.0}, {"close": 9.804e-09, "confirm": false, "display_close": 9.804e-09, "display_high": 9.804e-09, "display_low": 9.804e-09, "high": 9.804e-09, "low": 9.804e-09, "open": 9.804e-09, "provisional": true, "ts": "2026-08-04T19:29:00Z", "volume": 0.0}], "candle_captured_at": "2026-08-04T19:29:36Z", "candle_endpoint": "/api/v5/market/candles", "candle_revision_kind": "NO_OP", "candle_series_digest": "adf22f143ea2b2db0c9f22d2a6a3a522d2ae85d1c917f3c33047064004cb7183", "captured_at": "2026-08-04T19:29:36Z", "chart_digest": "adf22f143ea2b2db0c9f22d2a6a3a522d2ae85d1c917f3c33047064004cb7183", "close_source_semantics": "okx_market_candles_close_plus_public_trades", "effective_at": "2026-08-04T19:28:56Z", "first_timestamp": "2026-08-04T17:50:00Z", "freshness_state": "fresh", "gap_count": 0, "instrument_id": "SATS-USDT-SWAP", "interval": "PT1M", "is_stale": false, "last_closed_timestamp": "2026-08-04T19:28:00Z", "last_timestamp": "2026-08-04T19:29:00Z", "live_mark_captured_at": "2026-08-04T19:29:37Z", "live_mark_price": 9.803e-09, "live_mark_projection": "okx_ohlcv_live_mark_v1", "live_mark_provider_ts": "2026-08-04T19:29:36Z", "live_price_kind": "mark", "mark_source_semantics": "okx_public_mark_price_markPx_metadata_only", "metadata_digest": "2c3a494c9c7e49d0bc98b880f3a8170881ba4b1e240c5610bc90c2f808afaddc", "ohlcv_revision_kind": "NO_OP", "open_candle_bootstrap_source": "/api/v5/market/candles", "open_candle_live_source": "okx_public_trades_into_pt1m_v1", "payload_digest": "d88c7e1be9d5958d1557a7e8e2c3262534c79ae52521a1e5ce48efb66d0c29ab", "raw_capture_digest": "8942005e7345f059eefaf87dc0d38f56e8c9b0ed94f8c3d17a4fe8503cb7237b", "schema_name": "market_landscape_ohlcv_browser_payload.v1", "schema_version": 1, "trade_revision_kind": "NO_OP", "trades_captured_at": "2026-08-04T19:29:36Z", "trades_endpoint": "/api/v5/market/trades", "trades_raw_capture_digest": "55d37e6679f39995b816ccafcb6b49314496fab6a3814ffde2e640be14804c57", "venue": "OKX", "volume_source_semantics": "okx_market_candles_vol_contracts_plus_trade_sz"}</script>
+            <canvas
+              class="mdl-v2-chart__canvas"
+              data-mdl-chart-canvas="true"
+              data-mdl-chart-bar-count="0"
+              data-mdl-chart-geometry="absent"
+              aria-hidden="true"
+            ></canvas>
+          </div>
+          
+          <div
+            class="mdl-v2-volume"
+            data-mdl-volume-panel="true"
+            data-mdl-volume-state="AVAILABLE"
+            data-mdl-volume-synced-with-chart="false"
+          >
+            <canvas
+              class="mdl-v2-volume__canvas"
+              data-mdl-volume-canvas="true"
+              data-mdl-volume-bar-count="0"
+              data-mdl-volume-geometry="absent"
+              aria-hidden="true"
+            ></canvas>
+          </div>
+        </div>
+      </section>
+
+      <aside class="mdl-v2-rail mdl-v2-rail--right" data-mdl-region="SYSTEM_CONTEXT_RAIL" aria-label="System context" tabindex="-1">
+        <h2>Context</h2>
+        <dl class="mdl-v2-kv">
+          <div>
+            <dt>Lifecycle</dt>
+            <dd data-mdl-field="scope_lifecycle" data-availability="MISSING_SOURCE">MISSING_SOURCE</dd>
+          </div>
+          <div>
+            <dt>Current Scope</dt>
+            <dd data-mdl-field="current_scope_ref" data-availability="MISSING_SOURCE">MISSING_SOURCE</dd>
+          </div>
+          <div>
+            <dt>Next Scope</dt>
+            <dd data-mdl-field="next_scope_ref" data-availability="MISSING_SOURCE">MISSING_SOURCE</dd>
+          </div>
+          <div>
+            <dt>Regime</dt>
+            <dd data-mdl-field="regime" data-availability="MISSING_SOURCE">MISSING_SOURCE</dd>
+          </div>
+          <div>
+            <dt>Bull/Bear</dt>
+            <dd data-mdl-field="bull_bear" data-availability="MISSING_SOURCE">MISSING_SOURCE</dd>
+          </div>
+          <div>
+            <dt>Switch</dt>
+            <dd data-mdl-field="switch" data-availability="MISSING_SOURCE">MISSING_SOURCE</dd>
+          </div>
+          <div class="mdl-v2-source-health" data-mdl-source-health="true">
+            <dt>Source Health</dt>
+            <dd
+              class="mdl-v2-source-health__body"
+              data-mdl-field="source_health"
+              data-availability="MISSING_SOURCE"
+            >
+              <span
+                class="mdl-v2-source-health__summary"
+                data-mdl-source-health-summary="true"
+              >MISSING_SOURCE · 2026-08-04T19:43:33.441134Z</span>
+              <ul class="mdl-v2-source-health__sources" aria-label="Source availability and freshness" tabindex="-1">
+                
+                <li
+                  data-mdl-source-slot="autonomy_stage"
+                  data-availability="NOT_BOUND"
+                  data-freshness="2026-08-04T19:43:33.441134Z"
+                >
+                  <span class="mdl-v2-source-health__name">Autonomy</span>
+                  <span class="mdl-v2-source-health__line">NOT_BOUND · 2026-08-04T19:43:33.441134Z</span>
+                </li>
+                
+                <li
+                  data-mdl-source-slot="canonical_decision"
+                  data-availability="MISSING_SOURCE"
+                  data-freshness="2026-08-04T19:43:33.441134Z"
+                >
+                  <span class="mdl-v2-source-health__name">Decision</span>
+                  <span class="mdl-v2-source-health__line">MISSING_SOURCE · 2026-08-04T19:43:33.441134Z</span>
+                </li>
+                
+                <li
+                  data-mdl-source-slot="diagnostics_summary"
+                  data-availability="NOT_BOUND"
+                  data-freshness="2026-08-04T19:43:33.441134Z"
+                >
+                  <span class="mdl-v2-source-health__name">Diagnostics</span>
+                  <span class="mdl-v2-source-health__line">NOT_BOUND · 2026-08-04T19:43:33.441134Z</span>
+                </li>
+                
+                <li
+                  data-mdl-source-slot="double_play"
+                  data-availability="MISSING_SOURCE"
+                  data-freshness="2026-08-04T19:43:33.441134Z"
+                >
+                  <span class="mdl-v2-source-health__name">Double Play</span>
+                  <span class="mdl-v2-source-health__line">MISSING_SOURCE · 2026-08-04T19:43:33.441134Z</span>
+                </li>
+                
+                <li
+                  data-mdl-source-slot="dynamic_scope"
+                  data-availability="MISSING_SOURCE"
+                  data-freshness="2026-08-04T19:43:33.441134Z"
+                >
+                  <span class="mdl-v2-source-health__name">Scope</span>
+                  <span class="mdl-v2-source-health__line">MISSING_SOURCE · 2026-08-04T19:43:33.441134Z</span>
+                </li>
+                
+                <li
+                  data-mdl-source-slot="economic_summary"
+                  data-availability="MISSING_SOURCE"
+                  data-freshness="2026-08-04T19:43:33.441134Z"
+                >
+                  <span class="mdl-v2-source-health__name">Economic</span>
+                  <span class="mdl-v2-source-health__line">MISSING_SOURCE · 2026-08-04T19:43:33.441134Z</span>
+                </li>
+                
+                <li
+                  data-mdl-source-slot="execution_reconciliation"
+                  data-availability="MISSING_SOURCE"
+                  data-freshness="2026-08-04T19:43:33.441134Z"
+                >
+                  <span class="mdl-v2-source-health__name">Execution</span>
+                  <span class="mdl-v2-source-health__line">MISSING_SOURCE · 2026-08-04T19:43:33.441134Z</span>
+                </li>
+                
+                <li
+                  data-mdl-source-slot="market_instrument"
+                  data-availability="STALE"
+                  data-freshness="2026-07-24T21:48:23Z"
+                >
+                  <span class="mdl-v2-source-health__name">Market</span>
+                  <span class="mdl-v2-source-health__line">STALE · 2026-07-24T21:48:23Z</span>
+                </li>
+                
+                <li
+                  data-mdl-source-slot="regime_bull_bear_switch"
+                  data-availability="MISSING_SOURCE"
+                  data-freshness="2026-08-04T19:43:33.441134Z"
+                >
+                  <span class="mdl-v2-source-health__name">Regime/Bull-Bear/Switch</span>
+                  <span class="mdl-v2-source-health__line">MISSING_SOURCE · 2026-08-04T19:43:33.441134Z</span>
+                </li>
+                
+                <li
+                  data-mdl-source-slot="risk_sizing_capital"
+                  data-availability="MISSING_SOURCE"
+                  data-freshness="2026-08-04T19:43:33.441134Z"
+                >
+                  <span class="mdl-v2-source-health__name">Risk</span>
+                  <span class="mdl-v2-source-health__line">MISSING_SOURCE · 2026-08-04T19:43:33.441134Z</span>
+                </li>
+                
+                <li
+                  data-mdl-source-slot="safety_authority"
+                  data-availability="MISSING_SOURCE"
+                  data-freshness="2026-08-04T19:43:33.441134Z"
+                >
+                  <span class="mdl-v2-source-health__name">Safety</span>
+                  <span class="mdl-v2-source-health__line">MISSING_SOURCE · 2026-08-04T19:43:33.441134Z</span>
+                </li>
+                
+                <li
+                  data-mdl-source-slot="universe_ranking"
+                  data-availability="STALE"
+                  data-freshness="2026-07-24T21:48:23Z"
+                >
+                  <span class="mdl-v2-source-health__name">Universe</span>
+                  <span class="mdl-v2-source-health__line">STALE · 2026-07-24T21:48:23Z</span>
+                </li>
+                
+              </ul>
+            </dd>
+          </div>
+        </dl>
+      </aside>
+    </div>
+
+    <section
+      class="mdl-v2-decision"
+      data-mdl-region="CANONICAL_DECISION_STRIP"
+      data-mdl-decision-strip="true"
+      aria-label="Canonical decision strip"
+    >
+      
+      <dl
+        class="mdl-v2-decision__primary"
+        data-mdl-decision-primary="true"
+        aria-label="Primary decision reading flow"
+      >
+        <div class="mdl-v2-decision__fact mdl-v2-decision__fact--primary" data-mdl-decision-primary-fact="decision">
+          <dt>Decision</dt>
+          <dd data-mdl-field="decision" data-availability="MISSING_SOURCE">
+            MISSING_SOURCE
+          </dd>
+        </div>
+        <div class="mdl-v2-decision__fact mdl-v2-decision__fact--primary mdl-v2-decision__fact--why" data-mdl-decision-primary-fact="why">
+          <dt>Why</dt>
+          <dd
+            class="mdl-v2-decision__why"
+            data-mdl-field="reason_codes"
+            data-mdl-why-primary="true"
+            data-availability="MISSING_SOURCE"
+          >
+            
+              MISSING_SOURCE · CANONICAL_DECISION_EVIDENCE_NOT_PERSISTED_FOR_DASHBOARD
+            
+          </dd>
+        </div>
+        <div class="mdl-v2-decision__fact mdl-v2-decision__fact--primary" data-mdl-decision-primary-fact="blockers">
+          <dt>Blockers</dt>
+          <dd data-mdl-field="blockers" data-availability="NOT_BOUND">NOT_BOUND</dd>
+        </div>
+      </dl>
+      <dl
+        class="mdl-v2-decision__secondary"
+        data-mdl-decision-secondary="true"
+        aria-label="Secondary decision context"
+      >
+        <div class="mdl-v2-decision__fact mdl-v2-decision__fact--secondary" data-mdl-decision-secondary-fact="direction">
+          <dt>Direction</dt>
+          <dd data-mdl-field="direction" data-availability="MISSING_SOURCE">
+            MISSING_SOURCE
+          </dd>
+        </div>
+        <div class="mdl-v2-decision__fact mdl-v2-decision__fact--secondary" data-mdl-decision-secondary-fact="double_play">
+          <dt>Double Play</dt>
+          <dd data-mdl-field="double_play" data-availability="MISSING_SOURCE">
+            MISSING_SOURCE
+          </dd>
+        </div>
+        <div class="mdl-v2-decision__fact mdl-v2-decision__fact--secondary" data-mdl-decision-secondary-fact="confidence">
+          <dt>Confidence</dt>
+          <dd data-mdl-field="confidence" data-availability="NOT_BOUND">NOT_BOUND</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="mdl-v2-ops" data-mdl-region="SECONDARY_STATUS_REGION" aria-label="Operations band">
+      <div class="mdl-v2-ops__col" data-mdl-ops="risk_sizing_capital">
+        <h3>Risk / Sizing / Capital</h3>
+        <p
+          class="mdl-v2-state"
+          data-availability="MISSING_SOURCE"
+          data-mdl-field="risk_summary"
+        >MISSING_SOURCE</p>
+        <dl class="mdl-v2-kv">
+          <div>
+            <dt>Risk</dt>
+            <dd data-mdl-field="risk_status" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Sizing</dt>
+            <dd data-mdl-field="sizing_status" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Capital</dt>
+            <dd data-mdl-field="capital_status" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Quantity</dt>
+            <dd data-mdl-field="risk_quantity" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Reasons</dt>
+            <dd data-mdl-field="risk_reasons" data-availability="MISSING_SOURCE">CANONICAL_RISK_SIZING_CAPITAL_NOT_PERSISTED_FOR_DASHBOARD</dd>
+          </div>
+        </dl>
+      </div>
+      <div class="mdl-v2-ops__col" data-mdl-ops="execution_reconciliation">
+        <h3>Execution / Reconciliation</h3>
+        <p
+          class="mdl-v2-state"
+          data-availability="MISSING_SOURCE"
+          data-mdl-field="execution_summary"
+        >MISSING_SOURCE</p>
+        <dl class="mdl-v2-kv">
+          <div>
+            <dt>Execution</dt>
+            <dd data-mdl-field="execution_status" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Reconciliation</dt>
+            <dd data-mdl-field="reconciliation_status" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Intent Ref</dt>
+            <dd data-mdl-field="order_intent_ref" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Reasons</dt>
+            <dd data-mdl-field="execution_reasons" data-availability="MISSING_SOURCE">CANONICAL_EXECUTION_RECONCILIATION_NOT_PERSISTED_FOR_DASHBOARD</dd>
+          </div>
+        </dl>
+      </div>
+      <div class="mdl-v2-ops__col" data-mdl-ops="economic_summary">
+        <h3>Economic</h3>
+        <p
+          class="mdl-v2-state"
+          data-availability="MISSING_SOURCE"
+          data-mdl-field="economic"
+          data-mdl-classification="EVIDENCE_ONLY"
+        >MISSING_SOURCE</p>
+        <p class="mdl-v2-ops__note" data-mdl-field="economic_classification">EVIDENCE_ONLY</p>
+        <dl class="mdl-v2-kv">
+          <div>
+            <dt>Validity</dt>
+            <dd data-mdl-field="economic_validity" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Policy Threshold</dt>
+            <dd data-mdl-field="economic_policy_threshold" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Profit Factor</dt>
+            <dd data-mdl-field="economic_profit_factor" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Net Return</dt>
+            <dd data-mdl-field="economic_net_return" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Max Drawdown</dt>
+            <dd data-mdl-field="economic_max_drawdown" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Funding Drag</dt>
+            <dd data-mdl-field="economic_funding_drag" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Trade Count</dt>
+            <dd data-mdl-field="economic_trade_count" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Evidence Ref</dt>
+            <dd data-mdl-field="economic_evidence_ref" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Evidence Digest</dt>
+            <dd data-mdl-field="economic_evidence_digest" data-availability="MISSING_SOURCE">—</dd>
+          </div>
+          <div>
+            <dt>Reasons</dt>
+            <dd data-mdl-field="economic_reasons" data-availability="MISSING_SOURCE">CANONICAL_ECONOMIC_EVIDENCE_NOT_PERSISTED_FOR_DASHBOARD</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+
+    <section class="mdl-v2-gov" data-mdl-region="GOVERNANCE_DIAGNOSTICS_REGION" aria-label="Governance and diagnostics">
+      <div class="mdl-v2-gov__col" data-mdl-ops="diagnostics_summary">
+        <h3>Diagnostics</h3>
+        <p
+          class="mdl-v2-state mdl-v2-state--non-authoritative"
+          data-availability="NOT_BOUND"
+          data-mdl-field="diagnostics_status"
+          data-mdl-authority="NON_AUTHORITATIVE"
+        >NOT_BOUND</p>
+        <dl class="mdl-v2-kv">
+          <div>
+            <dt>Authority</dt>
+            <dd data-mdl-field="diagnostics_authority" data-availability="NOT_BOUND">NON_AUTHORITATIVE</dd>
+          </div>
+          <div>
+            <dt>Owner</dt>
+            <dd data-mdl-field="diagnostics_owner" data-availability="NOT_BOUND">UNRESOLVED</dd>
+          </div>
+        </dl>
+      </div>
+      <div class="mdl-v2-gov__col" data-mdl-ops="governance_autonomy">
+        <h3>Governance / Autonomy</h3>
+        <p
+          class="mdl-v2-state"
+          data-availability="NOT_BOUND"
+          data-mdl-field="governance_summary"
+          data-mdl-lock="INTENTIONAL_LOCK"
+        >NOT_BOUND · BOUND_NOT_ACTIVATED</p>
+        <dl class="mdl-v2-kv">
+          <div>
+            <dt>Autonomy Stage</dt>
+            <dd data-mdl-field="autonomy_stage" data-availability="NOT_BOUND">NOT_BOUND</dd>
+          </div>
+          <div>
+            <dt>Promotion</dt>
+            <dd data-mdl-field="promotion_eligibility" data-availability="NOT_BOUND">NOT_BOUND</dd>
+          </div>
+          <div>
+            <dt>Activation</dt>
+            <dd data-mdl-field="activation_eligibility" data-availability="NOT_BOUND">NOT_BOUND</dd>
+          </div>
+          <div>
+            <dt>Runtime Bridge</dt>
+            <dd
+              data-mdl-field="runtime_bridge_lock"
+              data-availability="NOT_BOUND"
+              data-mdl-lock-state="BOUND_NOT_ACTIVATED"
+              title="product_shell_constant_non_authoritative · intentional lock · not autonomy-stage source"
+            >BOUND_NOT_ACTIVATED</dd>
+          </div>
+          <div>
+            <dt>Operator GO</dt>
+            <dd
+              data-mdl-field="operator_go_required"
+              data-availability="NOT_BOUND"
+              data-operator-go-required="true"
+            >REQUIRED=true</dd>
+          </div>
+          <div>
+            <dt>Lock Class</dt>
+            <dd data-mdl-field="governance_lock_class" data-availability="NOT_BOUND">INTENTIONAL_LOCK</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+
+    <section class="mdl-v2-timeline" data-mdl-region="EVENT_DECISION_TIMELINE" aria-label="Event and decision timeline">
+      <div class="mdl-v2-timeline__head">
+        <h2>Timeline</h2>
+        <span class="mdl-v2-state" data-availability="NOT_BOUND">NOT_BOUND</span>
+      </div>
+      <p class="mdl-v2-timeline__empty">Event / Decision Timeline NOT_BOUND — no invented history.</p>
+    </section>
+
+    <details
+      class="mdl-v2-engineering"
+      data-mdl-region="ENGINEERING_DRAWER"
+      data-mdl-engineering="true"
+    >
+      <summary>Engineering · provenance / schemas / diagnostics</summary>
+      <div
+        class="mdl-v2-engineering__body"
+        id="mdl-v2-engineering-body"
+        data-mdl-engineering-body="true"
+      >
+        
+        <p class="mdl-v2-engineering__meta" data-mdl-engineering-label="true">Engineering drawer — diagnostic / non-authoritative</p>
+        <p><strong>Generated:</strong> <span class="font-mono">2026-08-04T19:43:33.441134Z</span></p>
+        <p><strong>Page schema:</strong> <span class="font-mono">market_dashboard_landscape_page_snapshot.v1</span></p>
+        <p><strong>Runtime bridge:</strong> <span class="font-mono">BOUND_NOT_ACTIVATED</span> (product_shell_constant_non_authoritative)</p>
+        <p><strong>Incomplete slots:</strong> autonomy_stage, canonical_decision, diagnostics_summary, double_play, dynamic_scope, economic_summary, execution_reconciliation, market_instrument, regime_bull_bear_switch, risk_sizing_capital, safety_authority, universe_ranking</p>
+        
+        <p>
+          <strong>Missing-state vocabulary:</strong>
+          <span class="font-mono" data-mdl-engineering-missing-hints="true">SCHEMA_MISMATCH, INVALID_PROVENANCE</span>
+        </p>
+        
+        <div class="mdl-v2-engineering__slots" data-mdl-engineering-slots="true">
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="autonomy_stage"
+            data-availability="NOT_BOUND"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">autonomy_stage</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">NOT_BOUND</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.autonomy_stage.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">NONE</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">unavailable:NOT_BOUND</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">LANDSCAPE_V2_SLOT_NOT_BOUND</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">false</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono">LANDSCAPE_V2_SLOT_NOT_BOUND</dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="canonical_decision"
+            data-availability="MISSING_SOURCE"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">canonical_decision</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.canonical_decision.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">trading.master_v2.canonical_trading_decision_evidence_v1</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">unavailable:MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">CANONICAL_DECISION_EVIDENCE_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">false</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono">CANONICAL_DECISION_EVIDENCE_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="diagnostics_summary"
+            data-availability="NOT_BOUND"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">diagnostics_summary</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">NOT_BOUND</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.diagnostics_summary.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">UNRESOLVED</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">unavailable:NOT_BOUND</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">LANDSCAPE_V2_SLOT_NOT_BOUND</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">false</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono">LANDSCAPE_V2_SLOT_NOT_BOUND</dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="double_play"
+            data-availability="MISSING_SOURCE"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">double_play</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.double_play.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">trading.master_v2.double_play_dashboard_display</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">unavailable:MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">CANONICAL_DOUBLE_PLAY_DISPLAY_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">false</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono"></dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="dynamic_scope"
+            data-availability="MISSING_SOURCE"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">dynamic_scope</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.dynamic_scope.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">trading.master_v2.canonical_scope_initialization_v1</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">unavailable:MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">CANONICAL_SCOPE_SNAPSHOT_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">false</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono">CANONICAL_SCOPE_SNAPSHOT_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="economic_summary"
+            data-availability="MISSING_SOURCE"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">economic_summary</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.economic_summary.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">backtest.economic_viability_evidence_v1</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">unavailable:MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">CANONICAL_ECONOMIC_EVIDENCE_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">false</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono">CANONICAL_ECONOMIC_EVIDENCE_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="execution_reconciliation"
+            data-availability="MISSING_SOURCE"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">execution_reconciliation</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.execution_reconciliation.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">trading.master_v2.canonical_order_intent_offline_replay_binding_adapter_v0</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">unavailable:MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">CANONICAL_EXECUTION_RECONCILIATION_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">false</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono">CANONICAL_EXECUTION_RECONCILIATION_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="market_instrument"
+            data-availability="STALE"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">market_instrument</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">STALE</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.market_instrument.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">universe_selection_selected_instrument</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z/readmodels/universe_selection_readmodel.v1.json</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-07-24T21:48:23Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">2026-07-24T21:48:23Z</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-07-24T21:48:23Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">true</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">PRODUCER_DATA_EXCEEDED_LANDSCAPE_MAX_AGE</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono">SELECTED_INSTRUMENT_IDENTITY_FROM_UNIVERSE_SELECTION, PRODUCER_DATA_EXCEEDED_LANDSCAPE_MAX_AGE</dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="regime_bull_bear_switch"
+            data-availability="MISSING_SOURCE"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">regime_bull_bear_switch</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.regime_bull_bear_switch.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">trading.master_v2.double_play_state</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">unavailable:MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">CANONICAL_REGIME_BULL_BEAR_SWITCH_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">false</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono">CANONICAL_REGIME_BULL_BEAR_SWITCH_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="risk_sizing_capital"
+            data-availability="MISSING_SOURCE"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">risk_sizing_capital</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.risk_sizing_capital.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">trading.master_v2.capital_risk_sizing_offline_replay_binding_adapter_v0</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">unavailable:MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">CANONICAL_RISK_SIZING_CAPITAL_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">false</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono">CANONICAL_RISK_SIZING_CAPITAL_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="safety_authority"
+            data-availability="MISSING_SOURCE"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">safety_authority</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.safety_authority.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">src.risk_layer.kill_switch</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">unavailable:MISSING_SOURCE</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">CANONICAL_SAFETY_AUTHORITY_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-08-04T19:43:33.441134Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">false</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono">CANONICAL_SAFETY_AUTHORITY_NOT_PERSISTED_FOR_DASHBOARD</dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+          <article
+            class="mdl-v2-engineering__slot"
+            data-mdl-engineering-slot="universe_ranking"
+            data-availability="STALE"
+          >
+            <h3 class="mdl-v2-engineering__slot-name">universe_ranking</h3>
+            <dl class="mdl-v2-engineering__kv">
+              <div>
+                <dt>availability</dt>
+                <dd data-mdl-eng-field="availability">STALE</dd>
+              </div>
+              <div>
+                <dt>schema_id</dt>
+                <dd data-mdl-eng-field="schema_id" class="font-mono">market_dashboard_landscape_projection.universe_ranking.v1</dd>
+              </div>
+              <div>
+                <dt>schema_version</dt>
+                <dd data-mdl-eng-field="schema_version" class="font-mono">v1</dd>
+              </div>
+              <div>
+                <dt>producer_module</dt>
+                <dd data-mdl-eng-field="producer_module" class="font-mono">webui.workflow_dashboard_readmodel_v1.universe_selection_contract_v1</dd>
+              </div>
+              <div>
+                <dt>source_kind</dt>
+                <dd data-mdl-eng-field="source_kind" class="font-mono">universe_selection_readmodel</dd>
+              </div>
+              <div>
+                <dt>source_reference</dt>
+                <dd data-mdl-eng-field="source_reference" class="font-mono">/Users/frnkhrz/Library/Application Support/Peak_Trade/workflow_dashboard_v1_okx_fresh_20260724T214822Z/readmodels/universe_selection_readmodel.v1.json</dd>
+              </div>
+              <div>
+                <dt>provenance.generated_at</dt>
+                <dd data-mdl-eng-field="provenance_generated_at" class="font-mono">2026-07-24T21:48:23Z</dd>
+              </div>
+              <div>
+                <dt>provenance.effective_at</dt>
+                <dd data-mdl-eng-field="provenance_effective_at" class="font-mono">2026-07-24T21:48:23Z</dd>
+              </div>
+              <div>
+                <dt>freshness.observed_at</dt>
+                <dd data-mdl-eng-field="freshness_observed_at" class="font-mono">2026-07-24T21:48:23Z</dd>
+              </div>
+              <div>
+                <dt>freshness.is_stale</dt>
+                <dd data-mdl-eng-field="freshness_is_stale" class="font-mono">true</dd>
+              </div>
+              <div>
+                <dt>freshness.stale_reason</dt>
+                <dd data-mdl-eng-field="freshness_stale_reason" class="font-mono">PRODUCER_DATA_EXCEEDED_LANDSCAPE_MAX_AGE</dd>
+              </div>
+              <div>
+                <dt>reason_codes</dt>
+                <dd data-mdl-eng-field="reason_codes" class="font-mono">UNIVERSE_SELECTION_READMODEL_PROJECTED, PRODUCER_DATA_EXCEEDED_LANDSCAPE_MAX_AGE</dd>
+              </div>
+              <div>
+                <dt>evidence_digest</dt>
+                <dd data-mdl-eng-field="evidence_digest" class="font-mono">null</dd>
+              </div>
+              <div>
+                <dt>git_sha</dt>
+                <dd data-mdl-eng-field="git_sha" class="font-mono">null</dd>
+              </div>
+            </dl>
+          </article>
+          
+        </div>
+      </div>
+    </details>
+  </div>
+</div>
+<script src="/static/js/market_dashboard_landscape_v2.js" defer></script>
+
+      </main>
+
+      <footer class="border-t border-slate-800/50 bg-slate-900/30 mt-8">
+        <div class="max-w-6xl mx-auto px-4 py-3 text-xs text-slate-500 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
+          <span>Peak_Trade Dashboard v1.2 · Read-Only · Shadow/Testnet Mode · R&D Dashboard (Phase 76)
+            · Companion Run UI default <code class="text-slate-400">127.0.0.1:8010</code> (local;
+            README)</span>
+          <span>🔒 Live-Execution ist deaktiviert</span>
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Read-only Batch `B2_PROJECTION_OCTET_RUNTIME_VERIFY` evidence for eight presentation projection families against active archive + live DOM at `origin/main` HEAD `8c02f879`.
- All eight authorized durable projection artifacts are **absent**; loaders fail closed; no fallback, materializer, producer, KillSwitch autoload, or latest-evidence selection.
- Live-DOM reconcile: MISSING_SOURCE 50→50, NOT_BOUND 18→17. Progress accounting: B1/B4 CLOSED_UNCHANGED; B3 blockers mapping **NOT AUTHORIZED** (Double Play projection absent).

## Consumer invariants
- `DASHBOARD_ROLE=PURE_CONSUMER`
- `AUTHORITY_EFFECT=NONE`
- `TRADING_LOGIC_CHANGED=false`
- `RUNTIME_CHANGED=false`
- `PRODUCER_CHANGED=false`
- `MATERIALIZER_EXECUTED=false`
- `CANONICAL_READMODEL_CHANGED=false`

## Test plan
- [x] Canonical CI selector: `NO_OP` (`docs_workflow_or_static_contract_only`)
- [x] Docs token policy + docs reference targets on changed Markdown
- [x] No Python/runtime/src mutation in diff
- [ ] Required GitHub checks green (confirmation only)


Made with [Cursor](https://cursor.com)