### PR TITLE
ops: add presentation projection octet orchestrator v1

### DIFF
--- a/scripts/ops/run_presentation_projection_octet_orchestrator_v1.py
+++ b/scripts/ops/run_presentation_projection_octet_orchestrator_v1.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Thin CLI for CAPABILITY_PRESENTATION_PROJECTION_OCTET_ORCHESTRATOR_V1.
+
+Explicit arguments only. No archive discovery. No implicit clock.
+Does not invent family inputs. Exit nonzero only for contract/CLI errors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from src.ops.presentation_projection_octet_orchestrator_v1.constants_v1 import (
+    FAMILY_ORDER,
+)
+from src.ops.presentation_projection_octet_orchestrator_v1.orchestrator_v1 import (
+    run_presentation_projection_octet_orchestrator_v1,
+)
+
+
+def _load_json_object(path: str | None) -> Any | None:
+    if path is None:
+        return None
+    payload = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Manual one-shot presentation projection octet orchestrator. "
+            "Requires explicit --archive-root and --generated-at. "
+            "Does not discover archives, latest artifacts, or invent timestamps."
+        )
+    )
+    parser.add_argument(
+        "--archive-root",
+        required=True,
+        help="Explicit Workflow Dashboard archive root (no discovery).",
+    )
+    parser.add_argument(
+        "--generated-at",
+        required=True,
+        help="Caller-provided ISO-8601 timestamp (never invented by this CLI).",
+    )
+    parser.add_argument(
+        "--families",
+        default=None,
+        help=(
+            "Optional comma-separated family ids. Default: all eight octet families. "
+            f"Known: {','.join(FAMILY_ORDER)}"
+        ),
+    )
+    parser.add_argument("--effective-at", default=None)
+    parser.add_argument("--source-reference", default=None)
+    parser.add_argument("--dynamic-scope-json", default=None)
+    parser.add_argument("--regime-bull-bear-switch-json", default=None)
+    parser.add_argument("--evidence-json", default=None)
+    parser.add_argument("--display-json", default=None)
+    parser.add_argument("--safety-authority-json", default=None)
+    parser.add_argument("--risk-sizing-capital-json", default=None)
+    parser.add_argument("--execution-reconciliation-json", default=None)
+    parser.add_argument("--economic-summary-json", default=None)
+    parser.add_argument(
+        "--per-family-overrides-json",
+        default=None,
+        help="Optional JSON object mapping family_id -> override object.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    families = None
+    if args.families is not None and str(args.families).strip():
+        families = [part.strip() for part in str(args.families).split(",") if part.strip()]
+
+    try:
+        overrides = _load_json_object(args.per_family_overrides_json)
+        if overrides is not None and not isinstance(overrides, dict):
+            print(
+                json.dumps(
+                    {
+                        "contract_ok": False,
+                        "error": "per_family_overrides_json must be a JSON object",
+                    },
+                    sort_keys=True,
+                ),
+                file=sys.stderr,
+            )
+            return 2
+
+        result = run_presentation_projection_octet_orchestrator_v1(
+            archive_root=args.archive_root,
+            generated_at=args.generated_at,
+            families=families,
+            dynamic_scope=_load_json_object(args.dynamic_scope_json),
+            regime_bull_bear_switch=_load_json_object(args.regime_bull_bear_switch_json),
+            evidence=_load_json_object(args.evidence_json),
+            display=_load_json_object(args.display_json),
+            safety_authority=_load_json_object(args.safety_authority_json),
+            risk_sizing_capital=_load_json_object(args.risk_sizing_capital_json),
+            execution_reconciliation=_load_json_object(args.execution_reconciliation_json),
+            economic_summary=_load_json_object(args.economic_summary_json),
+            effective_at=args.effective_at,
+            source_reference=args.source_reference,
+            per_family_overrides=overrides,
+        )
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        print(
+            json.dumps(
+                {
+                    "contract_ok": False,
+                    "error": type(exc).__name__,
+                    "detail": str(exc),
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+
+    print(json.dumps(result.to_dict(), sort_keys=True, ensure_ascii=False, indent=2))
+    return 0 if result.contract_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ops/presentation_projection_octet_orchestrator_v1/__init__.py
+++ b/src/ops/presentation_projection_octet_orchestrator_v1/__init__.py
@@ -1,0 +1,29 @@
+"""CAPABILITY_PRESENTATION_PROJECTION_OCTET_ORCHESTRATOR_V1."""
+
+from src.ops.presentation_projection_octet_orchestrator_v1.constants_v1 import (
+    AUTHORITY_EFFECT,
+    CAPABILITY_ID,
+    DASHBOARD_ROLE,
+    FAMILY_ORDER,
+    ORCHESTRATOR_AUTHORITY_EFFECT,
+    PACKAGE_MARKER,
+)
+from src.ops.presentation_projection_octet_orchestrator_v1.orchestrator_v1 import (
+    OctetFamilyResultV1,
+    OctetOrchestratorResultV1,
+    allowed_projection_relative_paths_v1,
+    run_presentation_projection_octet_orchestrator_v1,
+)
+
+__all__ = [
+    "AUTHORITY_EFFECT",
+    "CAPABILITY_ID",
+    "DASHBOARD_ROLE",
+    "FAMILY_ORDER",
+    "ORCHESTRATOR_AUTHORITY_EFFECT",
+    "OctetFamilyResultV1",
+    "OctetOrchestratorResultV1",
+    "PACKAGE_MARKER",
+    "allowed_projection_relative_paths_v1",
+    "run_presentation_projection_octet_orchestrator_v1",
+]

--- a/src/ops/presentation_projection_octet_orchestrator_v1/constants_v1.py
+++ b/src/ops/presentation_projection_octet_orchestrator_v1/constants_v1.py
@@ -1,0 +1,77 @@
+"""Constants for CAPABILITY_PRESENTATION_PROJECTION_OCTET_ORCHESTRATOR_V1.
+
+AUTHORITY_EFFECT=NONE
+ORCHESTRATOR_AUTHORITY_EFFECT=NONE
+DASHBOARD_ROLE=PURE_CONSUMER
+TRADING_SEMANTIC_CHANGE=false
+RUNTIME_HOOK_ADDED=false
+AUTOMATIC_CALLER_ADDED=false
+"""
+
+from __future__ import annotations
+
+CAPABILITY_ID = "CAPABILITY_PRESENTATION_PROJECTION_OCTET_ORCHESTRATOR_V1"
+PACKAGE_MARKER = "PRESENTATION_PROJECTION_OCTET_ORCHESTRATOR_V1=true"
+OWNER = "ops.presentation_projection_octet_orchestrator_v1"
+AUTHORITY_EFFECT = "NONE"
+ORCHESTRATOR_AUTHORITY_EFFECT = "NONE"
+DASHBOARD_ROLE = "PURE_CONSUMER"
+
+FAMILY_DYNAMIC_SCOPE = "dynamic_scope"
+FAMILY_REGIME_BULL_BEAR_SWITCH = "regime_bull_bear_switch"
+FAMILY_CANONICAL_DECISION = "canonical_decision"
+FAMILY_DOUBLE_PLAY = "double_play"
+FAMILY_SAFETY_AUTHORITY = "safety_authority"
+FAMILY_RISK_SIZING_CAPITAL = "risk_sizing_capital"
+FAMILY_EXECUTION_RECONCILIATION = "execution_reconciliation"
+FAMILY_ECONOMIC_SUMMARY = "economic_summary"
+
+FAMILY_ORDER: tuple[str, ...] = (
+    FAMILY_DYNAMIC_SCOPE,
+    FAMILY_REGIME_BULL_BEAR_SWITCH,
+    FAMILY_CANONICAL_DECISION,
+    FAMILY_DOUBLE_PLAY,
+    FAMILY_SAFETY_AUTHORITY,
+    FAMILY_RISK_SIZING_CAPITAL,
+    FAMILY_EXECUTION_RECONCILIATION,
+    FAMILY_ECONOMIC_SUMMARY,
+)
+
+STATUS_WRITTEN = "WRITTEN"
+STATUS_SKIPPED = "SKIPPED"
+STATUS_MISSING_SOURCE = "MISSING_SOURCE"
+STATUS_FAIL_CLOSED = "FAIL_CLOSED"
+STATUS_BLOCKED = "BLOCKED"
+
+ERROR_GENERATED_AT_REQUIRED = "OCTET_ORCHESTRATOR_GENERATED_AT_REQUIRED"
+ERROR_UNKNOWN_FAMILY = "OCTET_ORCHESTRATOR_UNKNOWN_FAMILY"
+ERROR_SAFETY_CALLER_OBJECT_REQUIRED = "OCTET_ORCHESTRATOR_SAFETY_CALLER_OBJECT_REQUIRED"
+ERROR_INVALID_OVERRIDE = "OCTET_ORCHESTRATOR_INVALID_OVERRIDE"
+ERROR_ARCHIVE_ROOT_REQUIRED = "OCTET_ORCHESTRATOR_ARCHIVE_ROOT_REQUIRED"
+
+# Ratified well-known relative paths under archive_root (no discovery).
+SIBLING_PATH_BY_FAMILY: dict[str, str | None] = {
+    FAMILY_DYNAMIC_SCOPE: "readmodels/dynamic_scope_state_v1.json",
+    FAMILY_REGIME_BULL_BEAR_SWITCH: "readmodels/regime_bull_bear_switch.v1.json",
+    FAMILY_CANONICAL_DECISION: "readmodels/canonical_trading_decision_evidence.v1.json",
+    FAMILY_DOUBLE_PLAY: "readmodels/double_play_dashboard_display.v1.json",
+    FAMILY_SAFETY_AUTHORITY: None,
+    FAMILY_RISK_SIZING_CAPITAL: "readmodels/risk_sizing_capital.v1.json",
+    FAMILY_EXECUTION_RECONCILIATION: "readmodels/execution_reconciliation.v1.json",
+    FAMILY_ECONOMIC_SUMMARY: "readmodels/economic_summary.v1.json",
+}
+
+PROJECTION_PATH_BY_FAMILY: dict[str, str] = {
+    FAMILY_DYNAMIC_SCOPE: "readmodels/dynamic_scope_presentation_projection.v1.json",
+    FAMILY_REGIME_BULL_BEAR_SWITCH: ("readmodels/bull_bear_regime_presentation_projection.v1.json"),
+    FAMILY_CANONICAL_DECISION: "readmodels/canonical_decision_presentation_projection.v1.json",
+    FAMILY_DOUBLE_PLAY: "readmodels/double_play_presentation_projection.v1.json",
+    FAMILY_SAFETY_AUTHORITY: "readmodels/safety_authority.v1.json",
+    FAMILY_RISK_SIZING_CAPITAL: ("readmodels/risk_sizing_capital_presentation_projection.v1.json"),
+    FAMILY_EXECUTION_RECONCILIATION: (
+        "readmodels/execution_reconciliation_presentation_projection.v1.json"
+    ),
+    FAMILY_ECONOMIC_SUMMARY: "readmodels/economic_summary_presentation_projection.v1.json",
+}
+
+ALLOWED_PROJECTION_RELATIVE_PATHS: frozenset[str] = frozenset(PROJECTION_PATH_BY_FAMILY.values())

--- a/src/ops/presentation_projection_octet_orchestrator_v1/orchestrator_v1.py
+++ b/src/ops/presentation_projection_octet_orchestrator_v1/orchestrator_v1.py
@@ -1,0 +1,545 @@
+"""Presentation-only manual one-shot octet orchestrator V1.
+
+CAPABILITY_ID=CAPABILITY_PRESENTATION_PROJECTION_OCTET_ORCHESTRATOR_V1
+
+Dispatches to the eight existing presentation projection materializers.
+Never recomputes trading/regime/risk/safety/execution/economic truth.
+Never autoloads live KillSwitch state. Never invents timestamps.
+Never discovers latest artifacts. Never updates MANIFEST.sha256.
+
+Invariants:
+- AUTHORITY_EFFECT=NONE
+- ORCHESTRATOR_AUTHORITY_EFFECT=NONE
+- DASHBOARD_ROLE=PURE_CONSUMER
+- EXPLICIT_INPUT_OR_WELLKNOWN_SIBLING_ONLY=true
+- PER_FAMILY_FAIL_CLOSED=true
+- PARTIAL_SUCCESS_ALLOWED=true
+- NO_TRADING_STATE_WRITE=true
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from src.ops.presentation_projection_octet_orchestrator_v1.constants_v1 import (
+    ALLOWED_PROJECTION_RELATIVE_PATHS,
+    AUTHORITY_EFFECT,
+    CAPABILITY_ID,
+    DASHBOARD_ROLE,
+    ERROR_ARCHIVE_ROOT_REQUIRED,
+    ERROR_GENERATED_AT_REQUIRED,
+    ERROR_INVALID_OVERRIDE,
+    ERROR_SAFETY_CALLER_OBJECT_REQUIRED,
+    ERROR_UNKNOWN_FAMILY,
+    FAMILY_CANONICAL_DECISION,
+    FAMILY_DOUBLE_PLAY,
+    FAMILY_DYNAMIC_SCOPE,
+    FAMILY_ECONOMIC_SUMMARY,
+    FAMILY_EXECUTION_RECONCILIATION,
+    FAMILY_ORDER,
+    FAMILY_REGIME_BULL_BEAR_SWITCH,
+    FAMILY_RISK_SIZING_CAPITAL,
+    FAMILY_SAFETY_AUTHORITY,
+    ORCHESTRATOR_AUTHORITY_EFFECT,
+    OWNER,
+    PROJECTION_PATH_BY_FAMILY,
+    SIBLING_PATH_BY_FAMILY,
+    STATUS_BLOCKED,
+    STATUS_FAIL_CLOSED,
+    STATUS_MISSING_SOURCE,
+    STATUS_SKIPPED,
+    STATUS_WRITTEN,
+)
+from src.webui.workflow_dashboard_readmodel_v1.bull_bear_regime_presentation_projection_materializer_v1 import (
+    materialize_bull_bear_regime_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.canonical_decision_presentation_projection_materializer_v1 import (
+    materialize_canonical_decision_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.double_play_presentation_projection_materializer_v1 import (
+    materialize_double_play_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.dynamic_scope_presentation_projection_materializer_v1 import (
+    materialize_dynamic_scope_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.economic_summary_presentation_projection_materializer_v1 import (
+    materialize_economic_summary_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.execution_reconciliation_presentation_projection_materializer_v1 import (
+    materialize_execution_reconciliation_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.risk_sizing_capital_presentation_projection_materializer_v1 import (
+    materialize_risk_sizing_capital_presentation_projection_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.safety_authority_presentation_projection_materializer_v1 import (
+    materialize_safety_authority_presentation_projection_v1,
+)
+
+_INPUT_KWARG_BY_FAMILY: dict[str, str] = {
+    FAMILY_DYNAMIC_SCOPE: "dynamic_scope",
+    FAMILY_REGIME_BULL_BEAR_SWITCH: "regime_bull_bear_switch",
+    FAMILY_CANONICAL_DECISION: "evidence",
+    FAMILY_DOUBLE_PLAY: "display",
+    FAMILY_SAFETY_AUTHORITY: "safety_authority",
+    FAMILY_RISK_SIZING_CAPITAL: "risk_sizing_capital",
+    FAMILY_EXECUTION_RECONCILIATION: "execution_reconciliation",
+    FAMILY_ECONOMIC_SUMMARY: "economic_summary",
+}
+
+_MATERIALIZER_BY_FAMILY: dict[str, Callable[..., Any]] = {
+    FAMILY_DYNAMIC_SCOPE: materialize_dynamic_scope_presentation_projection_v1,
+    FAMILY_REGIME_BULL_BEAR_SWITCH: materialize_bull_bear_regime_presentation_projection_v1,
+    FAMILY_CANONICAL_DECISION: materialize_canonical_decision_presentation_projection_v1,
+    FAMILY_DOUBLE_PLAY: materialize_double_play_presentation_projection_v1,
+    FAMILY_SAFETY_AUTHORITY: materialize_safety_authority_presentation_projection_v1,
+    FAMILY_RISK_SIZING_CAPITAL: materialize_risk_sizing_capital_presentation_projection_v1,
+    FAMILY_EXECUTION_RECONCILIATION: (
+        materialize_execution_reconciliation_presentation_projection_v1
+    ),
+    FAMILY_ECONOMIC_SUMMARY: materialize_economic_summary_presentation_projection_v1,
+}
+
+
+@dataclass(frozen=True)
+class OctetFamilyResultV1:
+    """Per-family orchestration outcome."""
+
+    family_id: str
+    status: str
+    written: bool
+    errors: tuple[str, ...]
+    projection_path: str | None = None
+    source_path: str | None = None
+    payload_digest: str | None = None
+    sibling_relative_path: str | None = None
+    caller_object_provided: bool = False
+
+
+@dataclass(frozen=True)
+class OctetOrchestratorResultV1:
+    """Bounded batch result for the presentation octet orchestrator."""
+
+    archive_root: str
+    generated_at: str | None
+    family_results: tuple[OctetFamilyResultV1, ...]
+    written_count: int
+    skipped_count: int
+    missing_source_count: int
+    fail_closed_count: int
+    blocked_count: int
+    contract_ok: bool
+    capability_id: str = CAPABILITY_ID
+    authority_effect: str = AUTHORITY_EFFECT
+    orchestrator_authority_effect: str = ORCHESTRATOR_AUTHORITY_EFFECT
+    dashboard_role: str = DASHBOARD_ROLE
+    owner: str = OWNER
+
+    def to_dict(self) -> dict[str, Any]:
+        """Machine-readable summary (deterministic key order via JSON dumps elsewhere)."""
+        return {
+            "archive_root": self.archive_root,
+            "authority_effect": self.authority_effect,
+            "blocked_count": self.blocked_count,
+            "capability_id": self.capability_id,
+            "contract_ok": self.contract_ok,
+            "dashboard_role": self.dashboard_role,
+            "fail_closed_count": self.fail_closed_count,
+            "family_results": [asdict(item) for item in self.family_results],
+            "generated_at": self.generated_at,
+            "missing_source_count": self.missing_source_count,
+            "orchestrator_authority_effect": self.orchestrator_authority_effect,
+            "owner": self.owner,
+            "skipped_count": self.skipped_count,
+            "written_count": self.written_count,
+        }
+
+
+def _require_nonempty_str(value: object | None) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _empty_family(
+    *,
+    family_id: str,
+    status: str,
+    errors: tuple[str, ...],
+    caller_object_provided: bool = False,
+) -> OctetFamilyResultV1:
+    return OctetFamilyResultV1(
+        family_id=family_id,
+        status=status,
+        written=False,
+        errors=errors,
+        sibling_relative_path=SIBLING_PATH_BY_FAMILY.get(family_id),
+        caller_object_provided=caller_object_provided,
+    )
+
+
+def _normalize_families(
+    families: Sequence[str] | None,
+) -> tuple[tuple[str, ...], tuple[OctetFamilyResultV1, ...]]:
+    if families is None:
+        return FAMILY_ORDER, ()
+
+    selected: list[str] = []
+    blocked: list[OctetFamilyResultV1] = []
+    seen: set[str] = set()
+    for raw in families:
+        family_id = str(raw).strip()
+        if not family_id:
+            continue
+        if family_id not in _MATERIALIZER_BY_FAMILY:
+            blocked.append(
+                _empty_family(
+                    family_id=family_id,
+                    status=STATUS_BLOCKED,
+                    errors=(ERROR_UNKNOWN_FAMILY,),
+                )
+            )
+            continue
+        if family_id in seen:
+            continue
+        seen.add(family_id)
+        selected.append(family_id)
+
+    ordered = tuple(fid for fid in FAMILY_ORDER if fid in seen)
+    return ordered, tuple(blocked)
+
+
+def _override_map(
+    per_family_overrides: Mapping[str, Mapping[str, Any]] | None,
+    family_id: str,
+) -> Mapping[str, Any]:
+    if per_family_overrides is None:
+        return {}
+    raw = per_family_overrides.get(family_id)
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        return {"__invalid__": True}
+    return raw
+
+
+def _resolve_caller_object(
+    *,
+    family_id: str,
+    top_level_inputs: Mapping[str, object | None],
+    override: Mapping[str, Any],
+) -> tuple[object | None, tuple[str, ...]]:
+    if override.get("__invalid__") is True:
+        return None, (ERROR_INVALID_OVERRIDE,)
+
+    input_kwarg = _INPUT_KWARG_BY_FAMILY[family_id]
+    if input_kwarg in override:
+        return override[input_kwarg], ()
+    if "input" in override:
+        return override["input"], ()
+    return top_level_inputs.get(input_kwarg), ()
+
+
+def _resolve_timestamp_fields(
+    *,
+    override: Mapping[str, Any],
+    generated_at: str,
+    effective_at: str | None,
+    source_reference: str | None,
+) -> tuple[str, str | None, str | None, str | None, tuple[str, ...]]:
+    if override.get("__invalid__") is True:
+        return generated_at, effective_at, source_reference, None, (ERROR_INVALID_OVERRIDE,)
+
+    family_generated = override.get("generated_at", generated_at)
+    resolved_generated = _require_nonempty_str(family_generated)
+    if resolved_generated is None:
+        return "", None, None, None, (ERROR_GENERATED_AT_REQUIRED,)
+
+    family_effective = override.get("effective_at", effective_at)
+    resolved_effective = (
+        None if family_effective is None else _require_nonempty_str(family_effective)
+    )
+    if family_effective is not None and resolved_effective is None:
+        return (
+            resolved_generated,
+            None,
+            None,
+            None,
+            (ERROR_INVALID_OVERRIDE, "effective_at_must_be_nonempty_str_or_none"),
+        )
+
+    family_source_ref = override.get("source_reference", source_reference)
+    resolved_source_ref = (
+        None if family_source_ref is None else _require_nonempty_str(family_source_ref)
+    )
+    if family_source_ref is not None and resolved_source_ref is None:
+        return (
+            resolved_generated,
+            resolved_effective,
+            None,
+            None,
+            (ERROR_INVALID_OVERRIDE, "source_reference_must_be_nonempty_str_or_none"),
+        )
+
+    saved_at_raw = override.get("saved_at")
+    resolved_saved_at = None if saved_at_raw is None else _require_nonempty_str(saved_at_raw)
+    if saved_at_raw is not None and resolved_saved_at is None:
+        return (
+            resolved_generated,
+            resolved_effective,
+            resolved_source_ref,
+            None,
+            (ERROR_INVALID_OVERRIDE, "saved_at_must_be_nonempty_str_or_none"),
+        )
+
+    return (
+        resolved_generated,
+        resolved_effective,
+        resolved_source_ref,
+        resolved_saved_at,
+        (),
+    )
+
+
+def _map_materializer_status(status: str) -> str:
+    if status == STATUS_WRITTEN:
+        return STATUS_WRITTEN
+    if status == STATUS_MISSING_SOURCE:
+        return STATUS_MISSING_SOURCE
+    if status == STATUS_FAIL_CLOSED:
+        return STATUS_FAIL_CLOSED
+    # Preserve unknown materializer statuses as fail-closed for the batch report.
+    return STATUS_FAIL_CLOSED
+
+
+def _dispatch_family(
+    *,
+    archive_root: Path,
+    family_id: str,
+    caller_object: object | None,
+    generated_at: str,
+    effective_at: str | None,
+    source_reference: str | None,
+    saved_at: str | None,
+) -> OctetFamilyResultV1:
+    caller_provided = caller_object is not None
+    sibling_relative = SIBLING_PATH_BY_FAMILY[family_id]
+
+    if family_id == FAMILY_SAFETY_AUTHORITY and caller_object is None:
+        return _empty_family(
+            family_id=family_id,
+            status=STATUS_SKIPPED,
+            errors=(ERROR_SAFETY_CALLER_OBJECT_REQUIRED,),
+            caller_object_provided=False,
+        )
+
+    materializer = _MATERIALIZER_BY_FAMILY[family_id]
+    input_kwarg = _INPUT_KWARG_BY_FAMILY[family_id]
+    kwargs: dict[str, Any] = {
+        input_kwarg: caller_object,
+        "generated_at": generated_at,
+        "effective_at": effective_at,
+        "source_reference": source_reference,
+    }
+    if family_id == FAMILY_SAFETY_AUTHORITY:
+        kwargs["saved_at"] = saved_at
+
+    result = materializer(archive_root, **kwargs)
+    status = _map_materializer_status(str(getattr(result, "status", STATUS_FAIL_CLOSED)))
+    errors = tuple(str(item) for item in getattr(result, "errors", ()) or ())
+    projection_path = getattr(result, "projection_path", None)
+    if projection_path is not None:
+        projection_path = str(projection_path)
+        try:
+            relative = (
+                Path(projection_path).resolve().relative_to(archive_root.resolve()).as_posix()
+            )
+        except ValueError:
+            relative = None
+        if relative not in ALLOWED_PROJECTION_RELATIVE_PATHS:
+            return OctetFamilyResultV1(
+                family_id=family_id,
+                status=STATUS_FAIL_CLOSED,
+                written=False,
+                errors=errors + ("OCTET_ORCHESTRATOR_UNEXPECTED_PROJECTION_PATH",),
+                projection_path=projection_path,
+                source_path=(
+                    None
+                    if getattr(result, "source_path", None) is None
+                    else str(result.source_path)
+                ),
+                payload_digest=getattr(result, "payload_digest", None),
+                sibling_relative_path=sibling_relative,
+                caller_object_provided=caller_provided,
+            )
+
+    return OctetFamilyResultV1(
+        family_id=family_id,
+        status=status,
+        written=bool(getattr(result, "written", False)),
+        errors=errors,
+        projection_path=projection_path,
+        source_path=(
+            None if getattr(result, "source_path", None) is None else str(result.source_path)
+        ),
+        payload_digest=getattr(result, "payload_digest", None),
+        sibling_relative_path=sibling_relative,
+        caller_object_provided=caller_provided,
+    )
+
+
+def run_presentation_projection_octet_orchestrator_v1(
+    *,
+    archive_root: str | Path,
+    generated_at: str | None,
+    families: Sequence[str] | None = None,
+    dynamic_scope: object | None = None,
+    regime_bull_bear_switch: object | None = None,
+    evidence: object | None = None,
+    display: object | None = None,
+    safety_authority: object | None = None,
+    risk_sizing_capital: object | None = None,
+    execution_reconciliation: object | None = None,
+    economic_summary: object | None = None,
+    effective_at: str | None = None,
+    source_reference: str | None = None,
+    per_family_overrides: Mapping[str, Mapping[str, Any]] | None = None,
+) -> OctetOrchestratorResultV1:
+    """Run the bounded presentation octet orchestrator against an explicit archive root.
+
+    Caller must provide ``generated_at``. Materializers perform atomic writes only.
+    Partial success is allowed: one family SKIPPED/MISSING_SOURCE/FAIL_CLOSED does
+    not abort the remaining selected families.
+    """
+    if archive_root is None or (isinstance(archive_root, str) and not archive_root.strip()):
+        return OctetOrchestratorResultV1(
+            archive_root="",
+            generated_at=_require_nonempty_str(generated_at),
+            family_results=(
+                _empty_family(
+                    family_id="*",
+                    status=STATUS_FAIL_CLOSED,
+                    errors=(ERROR_ARCHIVE_ROOT_REQUIRED,),
+                ),
+            ),
+            written_count=0,
+            skipped_count=0,
+            missing_source_count=0,
+            fail_closed_count=1,
+            blocked_count=0,
+            contract_ok=False,
+        )
+
+    root = Path(archive_root).expanduser().resolve()
+    selected, blocked_results = _normalize_families(families)
+    top_level_inputs: dict[str, object | None] = {
+        "dynamic_scope": dynamic_scope,
+        "regime_bull_bear_switch": regime_bull_bear_switch,
+        "evidence": evidence,
+        "display": display,
+        "safety_authority": safety_authority,
+        "risk_sizing_capital": risk_sizing_capital,
+        "execution_reconciliation": execution_reconciliation,
+        "economic_summary": economic_summary,
+    }
+
+    batch_generated = _require_nonempty_str(generated_at)
+    family_results: list[OctetFamilyResultV1] = list(blocked_results)
+
+    if batch_generated is None:
+        for family_id in selected:
+            family_results.append(
+                _empty_family(
+                    family_id=family_id,
+                    status=STATUS_FAIL_CLOSED,
+                    errors=(ERROR_GENERATED_AT_REQUIRED,),
+                    caller_object_provided=top_level_inputs.get(_INPUT_KWARG_BY_FAMILY[family_id])
+                    is not None,
+                )
+            )
+    else:
+        for family_id in selected:
+            override = _override_map(per_family_overrides, family_id)
+            caller_object, input_errors = _resolve_caller_object(
+                family_id=family_id,
+                top_level_inputs=top_level_inputs,
+                override=override,
+            )
+            if input_errors:
+                family_results.append(
+                    _empty_family(
+                        family_id=family_id,
+                        status=STATUS_FAIL_CLOSED,
+                        errors=input_errors,
+                        caller_object_provided=False,
+                    )
+                )
+                continue
+
+            (
+                family_generated,
+                family_effective,
+                family_source_ref,
+                family_saved_at,
+                ts_errors,
+            ) = _resolve_timestamp_fields(
+                override=override,
+                generated_at=batch_generated,
+                effective_at=effective_at,
+                source_reference=source_reference,
+            )
+            if ts_errors:
+                family_results.append(
+                    _empty_family(
+                        family_id=family_id,
+                        status=STATUS_FAIL_CLOSED,
+                        errors=ts_errors,
+                        caller_object_provided=caller_object is not None,
+                    )
+                )
+                continue
+
+            family_results.append(
+                _dispatch_family(
+                    archive_root=root,
+                    family_id=family_id,
+                    caller_object=caller_object,
+                    generated_at=family_generated,
+                    effective_at=family_effective,
+                    source_reference=family_source_ref,
+                    saved_at=family_saved_at,
+                )
+            )
+
+    written_count = sum(1 for item in family_results if item.status == STATUS_WRITTEN)
+    skipped_count = sum(1 for item in family_results if item.status == STATUS_SKIPPED)
+    missing_source_count = sum(1 for item in family_results if item.status == STATUS_MISSING_SOURCE)
+    fail_closed_count = sum(1 for item in family_results if item.status == STATUS_FAIL_CLOSED)
+    blocked_count = sum(1 for item in family_results if item.status == STATUS_BLOCKED)
+    # Contract-level failure only for missing archive root / unknown families /
+    # batch generated_at absence. Per-family MISSING_SOURCE/SKIPPED remain success.
+    contract_ok = blocked_count == 0 and not (batch_generated is None and bool(selected))
+
+    return OctetOrchestratorResultV1(
+        archive_root=str(root),
+        generated_at=batch_generated,
+        family_results=tuple(family_results),
+        written_count=written_count,
+        skipped_count=skipped_count,
+        missing_source_count=missing_source_count,
+        fail_closed_count=fail_closed_count,
+        blocked_count=blocked_count,
+        contract_ok=contract_ok,
+    )
+
+
+def allowed_projection_relative_paths_v1() -> frozenset[str]:
+    """Expose the ratified projection write set for tests/gates."""
+    return ALLOWED_PROJECTION_RELATIVE_PATHS
+
+
+def projection_relative_path_for_family_v1(family_id: str) -> str | None:
+    """Return the ratified projection relative path for a family id."""
+    return PROJECTION_PATH_BY_FAMILY.get(family_id)

--- a/tests/ops/test_presentation_projection_octet_orchestrator_v1.py
+++ b/tests/ops/test_presentation_projection_octet_orchestrator_v1.py
@@ -1,0 +1,416 @@
+"""Focused tests: CAPABILITY_PRESENTATION_PROJECTION_OCTET_ORCHESTRATOR_V1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from src.ops.presentation_projection_octet_orchestrator_v1.constants_v1 import (
+    ALLOWED_PROJECTION_RELATIVE_PATHS,
+    AUTHORITY_EFFECT,
+    CAPABILITY_ID,
+    ERROR_GENERATED_AT_REQUIRED,
+    ERROR_SAFETY_CALLER_OBJECT_REQUIRED,
+    ERROR_UNKNOWN_FAMILY,
+    FAMILY_ORDER,
+    ORCHESTRATOR_AUTHORITY_EFFECT,
+    PROJECTION_PATH_BY_FAMILY,
+    SIBLING_PATH_BY_FAMILY,
+    STATUS_BLOCKED,
+    STATUS_FAIL_CLOSED,
+    STATUS_MISSING_SOURCE,
+    STATUS_SKIPPED,
+    STATUS_WRITTEN,
+)
+from src.ops.presentation_projection_octet_orchestrator_v1.orchestrator_v1 import (
+    run_presentation_projection_octet_orchestrator_v1,
+)
+from src.webui.workflow_dashboard_readmodel_v1.dynamic_scope_presentation_projection_materializer_v1 import (
+    SOURCE_STATE_RELATIVE_PATH,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+PACKAGE_DIR = REPO / "src/ops/presentation_projection_octet_orchestrator_v1"
+CLI_PATH = REPO / "scripts/ops/run_presentation_projection_octet_orchestrator_v1.py"
+GENERATED_AT = "2026-07-24T17:30:00Z"
+
+
+def _scope(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "scope_state": "scope_valid",
+        "current_scope_ref": "scope-eth-1",
+        "next_scope_ref": None,
+        "reason_codes": ("SCOPE_INITIALIZED",),
+        "semantic_digest": "c" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def _regime(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "regime_id": "trending",
+        "regime_status": "known",
+        "side_state": "long_active",
+        "previous_side_state": "long_armed",
+        "next_side_state": "long_active",
+        "scope_event_type": "upscope_confirmed",
+        "transition_allowed": True,
+        "transition_reason_code": "UPSCOPE_CONFIRMED",
+        "reason_codes": ("STATE_SWITCH_OK",),
+        "evidence_digest": "b" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def _evidence(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "instrument_id": "ETH-USDT-SWAP",
+        "decision_outcome": "observe",
+        "next_direction_state": "neutral_observe",
+        "decision_id": "decision-orchestrator-1",
+        "evidence_schema_version": "canonical_trading_decision_evidence_v1",
+        "reason_codes": ("WARMUP_ACTIVE", "NO_ENTRY"),
+        "semantic_digest": "b" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def _display(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "overall_status": "display_ready",
+        "panel_summaries": (
+            {
+                "name": "composition",
+                "status": "display_ready",
+                "summary": "Composition: ELIGIBLE_MODEL_ONLY",
+                "blockers": (),
+            },
+        ),
+        "blockers": (),
+        "display_only": True,
+        "live_authorization": False,
+        "evidence_digest": "d" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def _safety(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "kill_switch_state": "KILLED",
+        "veto_active": True,
+        "reason_codes": ("killswitch_block_new",),
+        "evidence_digest": "e" * 64,
+        "schema_version": "v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _risk(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "risk_status": "PASS",
+        "sizing_status": "PASS",
+        "capital_status": "PASS",
+        "quantity": 0.25,
+        "reason_codes": ("PASS",),
+        "evidence_digest": "r" * 64,
+        "schema_version": "v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _execution(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "execution_status": "BOUND_OFFLINE",
+        "reconciliation_status": "RECONCILED",
+        "order_intent_ref": "intent://" + ("a" * 16),
+        "reason_codes": ("PASS",),
+        "evidence_digest": "e" * 64,
+        "schema_version": "v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _metric(*, value: float | None = None, semantic: str = "COMPUTED") -> dict[str, object]:
+    payload: dict[str, object] = {"semantic": semantic}
+    if value is not None:
+        payload["value"] = value
+    return payload
+
+
+def _economic(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "status": "ECONOMICALLY_VIABLE_OFFLINE",
+        "economic_validity_proven": True,
+        "profitability_claim_allowed": False,
+        "policy_threshold_status": "PASS",
+        "policy_version": "economic_validity_policy_v1",
+        "authority_effect": "NONE",
+        "runtime_effect": False,
+        "order_effect": False,
+        "reason_codes": ("SENTINEL_REASON_A",),
+        "profit_factor": _metric(value=1.77),
+        "net_return": _metric(value=0.123),
+        "max_drawdown": _metric(value=-0.045),
+        "sharpe": _metric(value=0.88),
+        "trade_count": _metric(value=42.0),
+        "funding_drag": _metric(value=-0.003),
+        "contract_version": "v1",
+        "owner": "backtest.economic_viability_evidence_v1",
+        "strategy_id": "sentinel_strategy",
+        "strategy_version": "sentinel_v9",
+        "config_digest": "c" * 64,
+        "implementation_digest": "i" * 64,
+        "data_digest": "d" * 64,
+        "manifest_digest": "m" * 64,
+        "wiring_chain_digest": "w" * 64,
+        "policy_digest": "p" * 64,
+        "evidence_digest": "m" * 64,
+        "schema_version": "v1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _read_package_sources() -> dict[str, str]:
+    return {
+        path.name: path.read_text(encoding="utf-8") for path in sorted(PACKAGE_DIR.glob("*.py"))
+    }
+
+
+def test_capability_and_authority_constants_are_stable() -> None:
+    assert CAPABILITY_ID == "CAPABILITY_PRESENTATION_PROJECTION_OCTET_ORCHESTRATOR_V1"
+    assert AUTHORITY_EFFECT == "NONE"
+    assert ORCHESTRATOR_AUTHORITY_EFFECT == "NONE"
+    assert FAMILY_ORDER == (
+        "dynamic_scope",
+        "regime_bull_bear_switch",
+        "canonical_decision",
+        "double_play",
+        "safety_authority",
+        "risk_sizing_capital",
+        "execution_reconciliation",
+        "economic_summary",
+    )
+    assert SIBLING_PATH_BY_FAMILY["safety_authority"] is None
+    assert PROJECTION_PATH_BY_FAMILY["safety_authority"] == "readmodels/safety_authority.v1.json"
+
+
+def test_missing_inputs_write_no_files(tmp_path: Path) -> None:
+    result = run_presentation_projection_octet_orchestrator_v1(
+        archive_root=tmp_path,
+        generated_at=GENERATED_AT,
+    )
+    assert result.written_count == 0
+    assert (tmp_path / "readmodels").exists() is False or not any(
+        (tmp_path / "readmodels").rglob("*")
+    )
+    statuses = {item.family_id: item.status for item in result.family_results}
+    assert statuses["safety_authority"] == STATUS_SKIPPED
+    assert ERROR_SAFETY_CALLER_OBJECT_REQUIRED in next(
+        item.errors for item in result.family_results if item.family_id == "safety_authority"
+    )
+    for family_id in FAMILY_ORDER:
+        if family_id == "safety_authority":
+            continue
+        assert statuses[family_id] == STATUS_MISSING_SOURCE
+    assert result.contract_ok is True
+
+
+def test_missing_generated_at_fail_closed_writes_nothing(tmp_path: Path) -> None:
+    result = run_presentation_projection_octet_orchestrator_v1(
+        archive_root=tmp_path,
+        generated_at=None,
+        dynamic_scope=_scope(),
+        safety_authority=_safety(),
+    )
+    assert result.written_count == 0
+    assert result.contract_ok is False
+    assert all(item.status == STATUS_FAIL_CLOSED for item in result.family_results)
+    assert all(ERROR_GENERATED_AT_REQUIRED in item.errors for item in result.family_results)
+    assert not (tmp_path / "readmodels").exists()
+
+
+def test_partial_success_and_allowed_projection_paths_only(tmp_path: Path) -> None:
+    result = run_presentation_projection_octet_orchestrator_v1(
+        archive_root=tmp_path,
+        generated_at=GENERATED_AT,
+        dynamic_scope=_scope(),
+        safety_authority=_safety(),
+        effective_at=GENERATED_AT,
+        source_reference="presentation://unit-test",
+    )
+    by_id = {item.family_id: item for item in result.family_results}
+    assert by_id["dynamic_scope"].status == STATUS_WRITTEN
+    assert by_id["safety_authority"].status == STATUS_WRITTEN
+    assert by_id["canonical_decision"].status == STATUS_MISSING_SOURCE
+    assert result.written_count == 2
+    assert result.contract_ok is True
+
+    written_files = sorted(
+        path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("*") if path.is_file()
+    )
+    assert set(written_files) <= ALLOWED_PROJECTION_RELATIVE_PATHS
+    assert "readmodels/dynamic_scope_presentation_projection.v1.json" in written_files
+    assert "readmodels/safety_authority.v1.json" in written_files
+    assert "readmodels/MANIFEST.sha256" not in written_files
+
+
+def test_sibling_loading_uses_fixed_relative_path_only(tmp_path: Path) -> None:
+    sibling = tmp_path / SOURCE_STATE_RELATIVE_PATH
+    _write_json(sibling, _scope())
+    # Decoy file that must never be selected via discovery.
+    _write_json(tmp_path / "readmodels" / "latest_dynamic_scope.json", {"scope_state": "bogus"})
+
+    result = run_presentation_projection_octet_orchestrator_v1(
+        archive_root=tmp_path,
+        generated_at=GENERATED_AT,
+        families=("dynamic_scope",),
+        source_reference="presentation://sibling-test",
+    )
+    assert len(result.family_results) == 1
+    item = result.family_results[0]
+    assert item.family_id == "dynamic_scope"
+    assert item.sibling_relative_path == "readmodels/dynamic_scope_state_v1.json"
+    assert item.caller_object_provided is False
+    assert item.status == STATUS_WRITTEN
+    assert (tmp_path / PROJECTION_PATH_BY_FAMILY["dynamic_scope"]).is_file()
+    # Decoy path must not become a projection owner.
+    assert item.source_path is not None
+    assert item.source_path.endswith("dynamic_scope_state_v1.json")
+
+
+def test_caller_objects_pass_through_and_idempotent_digests(tmp_path: Path) -> None:
+    scope = _scope()
+    safety = _safety()
+    first = run_presentation_projection_octet_orchestrator_v1(
+        archive_root=tmp_path,
+        generated_at=GENERATED_AT,
+        families=("dynamic_scope", "safety_authority"),
+        dynamic_scope=scope,
+        safety_authority=safety,
+        effective_at=GENERATED_AT,
+        source_reference="presentation://unit-test",
+    )
+    second = run_presentation_projection_octet_orchestrator_v1(
+        archive_root=tmp_path,
+        generated_at=GENERATED_AT,
+        families=("dynamic_scope", "safety_authority"),
+        dynamic_scope=scope,
+        safety_authority=safety,
+        effective_at=GENERATED_AT,
+        source_reference="presentation://unit-test",
+    )
+    assert first.written_count == 2
+    assert second.written_count == 2
+    digests_first = {
+        item.family_id: item.payload_digest for item in first.family_results if item.written
+    }
+    digests_second = {
+        item.family_id: item.payload_digest for item in second.family_results if item.written
+    }
+    assert digests_first == digests_second
+    assert digests_first["dynamic_scope"]
+    assert digests_first["safety_authority"]
+    # Caller-owned mappings remain untouched.
+    assert scope["current_scope_ref"] == "scope-eth-1"
+    assert safety["kill_switch_state"] == "KILLED"
+
+
+def test_all_eight_families_with_explicit_caller_objects(tmp_path: Path) -> None:
+    result = run_presentation_projection_octet_orchestrator_v1(
+        archive_root=tmp_path,
+        generated_at=GENERATED_AT,
+        dynamic_scope=_scope(),
+        regime_bull_bear_switch=_regime(),
+        evidence=_evidence(),
+        display=_display(),
+        safety_authority=_safety(),
+        risk_sizing_capital=_risk(),
+        execution_reconciliation=_execution(),
+        economic_summary=_economic(),
+        effective_at=GENERATED_AT,
+        source_reference="presentation://unit-test",
+    )
+    assert result.written_count == 8
+    assert result.missing_source_count == 0
+    assert result.skipped_count == 0
+    assert result.blocked_count == 0
+    assert result.contract_ok is True
+    written = {
+        path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("*.json") if path.is_file()
+    }
+    assert written == set(ALLOWED_PROJECTION_RELATIVE_PATHS)
+
+
+def test_unknown_family_is_blocked_fail_closed(tmp_path: Path) -> None:
+    result = run_presentation_projection_octet_orchestrator_v1(
+        archive_root=tmp_path,
+        generated_at=GENERATED_AT,
+        families=("dynamic_scope", "not_a_real_family"),
+        dynamic_scope=_scope(),
+    )
+    assert result.contract_ok is False
+    assert result.blocked_count == 1
+    blocked = next(item for item in result.family_results if item.family_id == "not_a_real_family")
+    assert blocked.status == STATUS_BLOCKED
+    assert ERROR_UNKNOWN_FAMILY in blocked.errors
+    written = next(item for item in result.family_results if item.family_id == "dynamic_scope")
+    assert written.status == STATUS_WRITTEN
+
+
+def test_source_has_no_implicit_time_latest_discovery_or_kill_switch_autoload() -> None:
+    sources = _read_package_sources()
+    joined = "\n".join(sources.values())
+    cli_src = CLI_PATH.read_text(encoding="utf-8")
+    combined = joined + "\n" + cli_src
+
+    assert "datetime.now" not in combined
+    assert "utcnow" not in combined
+    assert "time.time(" not in combined
+    assert "os.walk" not in combined
+    assert "src.risk_layer.kill_switch" not in combined
+    assert "data/kill_switch" not in combined
+    for text in sources.values():
+        tree = ast.parse(text)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in {"glob", "rglob", "walk"}
+            if isinstance(node, ast.Attribute):
+                assert node.attr not in {"utcnow"}
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                rendered = ast.unparse(node)
+                assert "datetime" not in rendered
+                assert "kill_switch" not in rendered
+                assert "KillSwitch" not in rendered
+
+
+def test_dispatch_table_targets_existing_materializers_only() -> None:
+    orchestrator_src = (PACKAGE_DIR / "orchestrator_v1.py").read_text(encoding="utf-8")
+    expected = [
+        "materialize_dynamic_scope_presentation_projection_v1",
+        "materialize_bull_bear_regime_presentation_projection_v1",
+        "materialize_canonical_decision_presentation_projection_v1",
+        "materialize_double_play_presentation_projection_v1",
+        "materialize_safety_authority_presentation_projection_v1",
+        "materialize_risk_sizing_capital_presentation_projection_v1",
+        "materialize_execution_reconciliation_presentation_projection_v1",
+        "materialize_economic_summary_presentation_projection_v1",
+    ]
+    for symbol in expected:
+        assert symbol in orchestrator_src
+    assert "export_dynamic_scope_state_to_archive_sibling_v1" not in orchestrator_src
+    assert "LaunchAgent" not in orchestrator_src
+    assert "supervisor" not in orchestrator_src.lower()


### PR DESCRIPTION
## Summary
- Adds a presentation-only manual one-shot orchestrator that dispatches to the eight existing projection materializers under an explicit archive root.
- Enforces caller-provided `generated_at`, fail-closed partial success, no live KillSwitch autoload, no latest/filesystem discovery, and no MANIFEST/trading-state writes.
- Ships a thin explicit-arg CLI plus focused contract tests; does not execute against any active archive.

## Test plan
- [x] `pytest tests/ops/test_presentation_projection_octet_orchestrator_v1.py` (10 passed)
- [x] Existing eight materializer tests + dynamic-scope exporter tests (124 passed combined with new suite)
- [x] `ruff format --check` / `ruff check` on touched paths
- [x] Docs token policy + docs reference targets
- [x] Selector `PR_BOUNDED_FULL` timing probe (729 passed, ~37s)
- [ ] CI required checks on PR


Made with [Cursor](https://cursor.com)