### PR TITLE
ops: add fail-closed archive sibling export contract v1

### DIFF
--- a/src/ops/archive_sibling_export_contract_v1/__init__.py
+++ b/src/ops/archive_sibling_export_contract_v1/__init__.py
@@ -1,0 +1,45 @@
+"""CAPABILITY_ARCHIVE_SIBLING_EXPORT_CONTRACT_V1 — semantics-free export infra."""
+
+from src.ops.archive_sibling_export_contract_v1.atomic_write import (
+    AtomicWriteErrorV1,
+    atomic_write_text_v1,
+)
+from src.ops.archive_sibling_export_contract_v1.canonical_digest import (
+    CanonicalJsonErrorV1,
+    canonical_digest_v1,
+    canonical_json_file_body_v1,
+    canonical_json_text_v1,
+)
+from src.ops.archive_sibling_export_contract_v1.contracts import (
+    AUTHORITY_EFFECT,
+    CAPABILITY_ID,
+    CONTRACT_ID,
+    export_archive_sibling_json_v1,
+)
+from src.ops.archive_sibling_export_contract_v1.path_guard import (
+    ArchiveSiblingPathErrorV1,
+    READMODELS_DIRNAME,
+    resolve_archive_sibling_target_v1,
+)
+from src.ops.archive_sibling_export_contract_v1.result_types import (
+    ArchiveSiblingExportEffectV1,
+    ArchiveSiblingExportResultV1,
+)
+
+__all__ = [
+    "AUTHORITY_EFFECT",
+    "ArchiveSiblingExportEffectV1",
+    "ArchiveSiblingExportResultV1",
+    "ArchiveSiblingPathErrorV1",
+    "AtomicWriteErrorV1",
+    "CAPABILITY_ID",
+    "CONTRACT_ID",
+    "CanonicalJsonErrorV1",
+    "READMODELS_DIRNAME",
+    "atomic_write_text_v1",
+    "canonical_digest_v1",
+    "canonical_json_file_body_v1",
+    "canonical_json_text_v1",
+    "export_archive_sibling_json_v1",
+    "resolve_archive_sibling_target_v1",
+]

--- a/src/ops/archive_sibling_export_contract_v1/atomic_write.py
+++ b/src/ops/archive_sibling_export_contract_v1/atomic_write.py
@@ -1,0 +1,58 @@
+"""Atomic single-file write: temp + fsync + os.replace (+ best-effort dir fsync)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+class AtomicWriteErrorV1(OSError):
+    """Atomic write failed after validation."""
+
+
+def atomic_write_text_v1(*, destination: Path, body: str) -> None:
+    """Write ``body`` atomically into ``destination``.
+
+    - Creates parent directories when missing (authorized write path only).
+    - Temp file is created in the destination directory.
+    - On failure, best-effort temp cleanup is performed.
+    - No transactional multi-file rollback is claimed.
+    """
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd: int | None = None
+    tmp_name: str | None = None
+    try:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=destination.name + ".",
+            dir=str(destination.parent),
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = None  # ownership transferred to fdopen
+            handle.write(body)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, destination)
+        tmp_name = None
+        try:
+            dir_fd = os.open(str(destination.parent), os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            # Directory fsync is best-effort / platform-dependent.
+            pass
+    except OSError as exc:
+        raise AtomicWriteErrorV1(str(exc)) from exc
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if tmp_name is not None and os.path.exists(tmp_name):
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass

--- a/src/ops/archive_sibling_export_contract_v1/canonical_digest.py
+++ b/src/ops/archive_sibling_export_contract_v1/canonical_digest.py
@@ -1,0 +1,47 @@
+"""Canonical JSON serialization and digests (no semantic normalization)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any
+
+
+class CanonicalJsonErrorV1(ValueError):
+    """Payload is not safely JSON-serializable under the contract rules."""
+
+
+def canonical_json_text_v1(payload: Mapping[str, Any]) -> str:
+    """Return deterministic compact JSON text for a JSON object.
+
+    Rules:
+    - sort_keys=True (key order independent of input insertion order)
+    - UTF-8 text (ensure_ascii=False)
+    - separators=(',', ':') — no insignificant whitespace
+    - allow_nan=False — reject NaN/Inf
+    - no field invention, enum coercion, or float rounding
+    """
+    if not isinstance(payload, Mapping):
+        raise CanonicalJsonErrorV1("payload must be a mapping/JSON object")
+    try:
+        return json.dumps(
+            dict(payload),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise CanonicalJsonErrorV1(str(exc)) from exc
+
+
+def canonical_json_file_body_v1(payload: Mapping[str, Any]) -> str:
+    """Canonical on-disk body: compact JSON + trailing newline."""
+    return canonical_json_text_v1(payload) + "\n"
+
+
+def canonical_digest_v1(payload: Mapping[str, Any]) -> str:
+    """SHA-256 hex digest over the canonical JSON text (no trailing newline)."""
+    body = canonical_json_text_v1(payload)
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()

--- a/src/ops/archive_sibling_export_contract_v1/contracts.py
+++ b/src/ops/archive_sibling_export_contract_v1/contracts.py
@@ -1,0 +1,284 @@
+"""Public export API for CAPABILITY_ARCHIVE_SIBLING_EXPORT_CONTRACT_V1.
+
+Semantics-free infrastructure only:
+- no trading / presentation / materializer imports
+- no archive discovery, latest selection, or env authority
+- default dry_run=True; write requires dry_run=False and write_authorized=True
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Collection, Mapping
+from pathlib import Path
+from typing import Any
+
+from src.ops.archive_sibling_export_contract_v1.atomic_write import (
+    AtomicWriteErrorV1,
+    atomic_write_text_v1,
+)
+from src.ops.archive_sibling_export_contract_v1.canonical_digest import (
+    CanonicalJsonErrorV1,
+    canonical_digest_v1,
+    canonical_json_file_body_v1,
+)
+from src.ops.archive_sibling_export_contract_v1.path_guard import (
+    ArchiveSiblingPathErrorV1,
+    resolve_archive_sibling_target_v1,
+)
+from src.ops.archive_sibling_export_contract_v1.result_types import (
+    ArchiveSiblingExportEffectV1,
+    ArchiveSiblingExportResultV1,
+)
+
+CONTRACT_ID = "archive_sibling_export_contract_v1"
+CAPABILITY_ID = "CAPABILITY_ARCHIVE_SIBLING_EXPORT_CONTRACT_V1"
+AUTHORITY_EFFECT = "NONE"
+
+BLOCK_WRITE_NOT_AUTHORIZED = "ARCHIVE_SIBLING_EXPORT_WRITE_NOT_AUTHORIZED"
+BLOCK_PAYLOAD_NOT_OBJECT = "ARCHIVE_SIBLING_EXPORT_PAYLOAD_NOT_OBJECT"
+BLOCK_PAYLOAD_NOT_SERIALIZABLE = "ARCHIVE_SIBLING_EXPORT_PAYLOAD_NOT_SERIALIZABLE"
+BLOCK_REQUIRED_FIELD_MISSING = "ARCHIVE_SIBLING_EXPORT_REQUIRED_FIELD_MISSING"
+BLOCK_PATH_INVALID = "ARCHIVE_SIBLING_EXPORT_PATH_INVALID"
+BLOCK_TARGET_NOT_FILE = "ARCHIVE_SIBLING_EXPORT_TARGET_NOT_FILE"
+BLOCK_TARGET_INVALID_JSON = "ARCHIVE_SIBLING_EXPORT_TARGET_INVALID_JSON"
+BLOCK_TARGET_NOT_OBJECT = "ARCHIVE_SIBLING_EXPORT_TARGET_NOT_OBJECT"
+BLOCK_WRITE_FAILED = "ARCHIVE_SIBLING_EXPORT_WRITE_FAILED"
+BLOCK_POST_WRITE_VERIFY_FAILED = "ARCHIVE_SIBLING_EXPORT_POST_WRITE_VERIFY_FAILED"
+BLOCK_CONTRACT_NAME_EMPTY = "ARCHIVE_SIBLING_EXPORT_CONTRACT_NAME_EMPTY"
+
+
+def _blocked(
+    *,
+    dry_run: bool,
+    contract_name: str,
+    reason: str,
+    target_path: str | None = None,
+    source_digest: str | None = None,
+    target_digest_before: str | None = None,
+    expected_target_digest: str | None = None,
+    schema_name: str | None = None,
+) -> ArchiveSiblingExportResultV1:
+    return ArchiveSiblingExportResultV1(
+        effect=ArchiveSiblingExportEffectV1.BLOCKED,
+        write_performed=False,
+        dry_run=dry_run,
+        contract_name=contract_name,
+        target_path=target_path,
+        source_digest=source_digest,
+        target_digest_before=target_digest_before,
+        target_digest_after=None,
+        expected_target_digest=expected_target_digest,
+        block_reason=reason,
+        schema_name=schema_name,
+    )
+
+
+def _inspect_existing_target(
+    target_path: Path,
+) -> tuple[str | None, str | None]:
+    """Return (digest_before, block_reason). block_reason None means usable."""
+    if not target_path.exists():
+        return None, None
+    if not target_path.is_file():
+        return None, BLOCK_TARGET_NOT_FILE
+    try:
+        raw = target_path.read_text(encoding="utf-8")
+        parsed: Any = json.loads(raw)
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None, BLOCK_TARGET_INVALID_JSON
+    if not isinstance(parsed, dict):
+        return None, BLOCK_TARGET_NOT_OBJECT
+    try:
+        return canonical_digest_v1(parsed), None
+    except CanonicalJsonErrorV1:
+        return None, BLOCK_TARGET_INVALID_JSON
+
+
+def export_archive_sibling_json_v1(
+    *,
+    payload: Mapping[str, object],
+    archive_root: Path | str,
+    target_relative_path: Path | str,
+    contract_name: str,
+    required_fields: Collection[str] = (),
+    dry_run: bool = True,
+    write_authorized: bool = False,
+) -> ArchiveSiblingExportResultV1:
+    """Validate and optionally atomically persist a JSON-object archive sibling.
+
+    Write occurs only when ``dry_run is False`` and ``write_authorized is True``.
+    All other combinations never mutate the filesystem.
+    """
+    name = str(contract_name or "").strip()
+    schema_name = name or None
+    effective_dry_run = bool(dry_run)
+
+    if not name:
+        return _blocked(
+            dry_run=effective_dry_run,
+            contract_name="",
+            reason=BLOCK_CONTRACT_NAME_EMPTY,
+            schema_name=None,
+        )
+
+    if not isinstance(payload, Mapping) or isinstance(payload, (str, bytes, bytearray)):
+        return _blocked(
+            dry_run=effective_dry_run,
+            contract_name=name,
+            reason=BLOCK_PAYLOAD_NOT_OBJECT,
+            schema_name=schema_name,
+        )
+
+    # Plain dict snapshot only (no field invention / coercion / rounding).
+    try:
+        object_payload = dict(payload)
+    except Exception:  # noqa: BLE001 — fail-closed for hostile/unreadable mappings
+        return _blocked(
+            dry_run=effective_dry_run,
+            contract_name=name,
+            reason=BLOCK_PAYLOAD_NOT_OBJECT,
+            schema_name=schema_name,
+        )
+
+    missing = [str(field) for field in required_fields if field not in object_payload]
+    if missing:
+        return _blocked(
+            dry_run=effective_dry_run,
+            contract_name=name,
+            reason=f"{BLOCK_REQUIRED_FIELD_MISSING}:{','.join(missing)}",
+            schema_name=schema_name,
+        )
+
+    try:
+        source_digest = canonical_digest_v1(object_payload)
+        body = canonical_json_file_body_v1(object_payload)
+    except CanonicalJsonErrorV1:
+        return _blocked(
+            dry_run=effective_dry_run,
+            contract_name=name,
+            reason=BLOCK_PAYLOAD_NOT_SERIALIZABLE,
+            schema_name=schema_name,
+        )
+
+    try:
+        resolved = resolve_archive_sibling_target_v1(
+            archive_root=archive_root,
+            target_relative_path=target_relative_path,
+        )
+    except ArchiveSiblingPathErrorV1 as exc:
+        return _blocked(
+            dry_run=effective_dry_run,
+            contract_name=name,
+            reason=f"{BLOCK_PATH_INVALID}:{exc}",
+            source_digest=source_digest,
+            expected_target_digest=source_digest,
+            schema_name=schema_name,
+        )
+
+    target_path = resolved.target_path
+    target_str = str(target_path)
+
+    digest_before, target_block = _inspect_existing_target(target_path)
+    if target_block is not None:
+        return _blocked(
+            dry_run=effective_dry_run,
+            contract_name=name,
+            reason=target_block,
+            target_path=target_str,
+            source_digest=source_digest,
+            target_digest_before=digest_before,
+            expected_target_digest=source_digest,
+            schema_name=schema_name,
+        )
+
+    if digest_before is None:
+        effect = ArchiveSiblingExportEffectV1.CREATE
+    elif digest_before == source_digest:
+        effect = ArchiveSiblingExportEffectV1.NO_CHANGE
+    else:
+        effect = ArchiveSiblingExportEffectV1.REPLACE
+
+    if effect == ArchiveSiblingExportEffectV1.NO_CHANGE:
+        return ArchiveSiblingExportResultV1(
+            effect=effect,
+            write_performed=False,
+            dry_run=effective_dry_run,
+            contract_name=name,
+            target_path=target_str,
+            source_digest=source_digest,
+            target_digest_before=digest_before,
+            target_digest_after=digest_before,
+            expected_target_digest=source_digest,
+            block_reason=None,
+            schema_name=schema_name,
+        )
+
+    if effective_dry_run:
+        return ArchiveSiblingExportResultV1(
+            effect=effect,
+            write_performed=False,
+            dry_run=True,
+            contract_name=name,
+            target_path=target_str,
+            source_digest=source_digest,
+            target_digest_before=digest_before,
+            target_digest_after=None,
+            expected_target_digest=source_digest,
+            block_reason=None,
+            schema_name=schema_name,
+        )
+
+    if not write_authorized:
+        return _blocked(
+            dry_run=False,
+            contract_name=name,
+            reason=BLOCK_WRITE_NOT_AUTHORIZED,
+            target_path=target_str,
+            source_digest=source_digest,
+            target_digest_before=digest_before,
+            expected_target_digest=source_digest,
+            schema_name=schema_name,
+        )
+
+    # Authorized write path — validation is complete before any temp/mkdir/replace.
+    try:
+        atomic_write_text_v1(destination=target_path, body=body)
+    except AtomicWriteErrorV1 as exc:
+        return _blocked(
+            dry_run=False,
+            contract_name=name,
+            reason=f"{BLOCK_WRITE_FAILED}:{exc}",
+            target_path=target_str,
+            source_digest=source_digest,
+            target_digest_before=digest_before,
+            expected_target_digest=source_digest,
+            schema_name=schema_name,
+        )
+
+    after_digest, after_block = _inspect_existing_target(target_path)
+    if after_block is not None or after_digest != source_digest:
+        return _blocked(
+            dry_run=False,
+            contract_name=name,
+            reason=BLOCK_POST_WRITE_VERIFY_FAILED,
+            target_path=target_str,
+            source_digest=source_digest,
+            target_digest_before=digest_before,
+            expected_target_digest=source_digest,
+            schema_name=schema_name,
+        )
+
+    return ArchiveSiblingExportResultV1(
+        effect=effect,
+        write_performed=True,
+        dry_run=False,
+        contract_name=name,
+        target_path=target_str,
+        source_digest=source_digest,
+        target_digest_before=digest_before,
+        target_digest_after=after_digest,
+        expected_target_digest=source_digest,
+        block_reason=None,
+        schema_name=schema_name,
+    )

--- a/src/ops/archive_sibling_export_contract_v1/path_guard.py
+++ b/src/ops/archive_sibling_export_contract_v1/path_guard.py
@@ -1,0 +1,96 @@
+"""Path confinement for archive sibling writes under readmodels/."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+
+READMODELS_DIRNAME = "readmodels"
+
+
+class ArchiveSiblingPathErrorV1(ValueError):
+    """Caller misuse or unusable path arguments (not an operator BLOCKED result)."""
+
+
+@dataclass(frozen=True)
+class ResolvedArchiveSiblingPathV1:
+    """Resolved, confined target path under ``<archive_root>/readmodels``."""
+
+    archive_root: Path
+    readmodels_root: Path
+    target_path: Path
+    target_relative_posix: str
+
+
+def _as_path(value: Path | str, *, field: str) -> Path:
+    if isinstance(value, Path):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ArchiveSiblingPathErrorV1(f"{field} must be non-empty")
+        return Path(text)
+    raise ArchiveSiblingPathErrorV1(f"{field} must be Path or str")
+
+
+def resolve_archive_sibling_target_v1(
+    *,
+    archive_root: Path | str,
+    target_relative_path: Path | str,
+) -> ResolvedArchiveSiblingPathV1:
+    """Resolve and confine ``target_relative_path`` under archive ``readmodels/``.
+
+    Fail-closed rules:
+    - ``target_relative_path`` must be relative (absolute blocked)
+    - no ``..`` traversal segments
+    - must live under ``<archive_root>/readmodels``
+    - resolved realpath must stay under resolved readmodels root (symlink escape)
+    - no archive discovery / latest / fallback
+    """
+    root = _as_path(archive_root, field="archive_root").expanduser()
+    rel = _as_path(target_relative_path, field="target_relative_path")
+
+    if rel.is_absolute():
+        raise ArchiveSiblingPathErrorV1("target_relative_path must be relative")
+
+    # Normalize to posix segments for traversal checks (independent of OS sep).
+    posix = PurePosixPath(rel.as_posix())
+    if posix.is_absolute() or str(posix).startswith("/"):
+        raise ArchiveSiblingPathErrorV1("target_relative_path must be relative")
+    if any(part == ".." for part in posix.parts):
+        raise ArchiveSiblingPathErrorV1("target_relative_path must not contain '..'")
+    if not posix.parts:
+        raise ArchiveSiblingPathErrorV1("target_relative_path must not be empty")
+    if posix.parts[0] != READMODELS_DIRNAME:
+        raise ArchiveSiblingPathErrorV1(
+            f"target_relative_path must be under readmodels/ (got {posix.as_posix()!r})"
+        )
+    if len(posix.parts) < 2:
+        raise ArchiveSiblingPathErrorV1("target_relative_path must name a file under readmodels/")
+
+    try:
+        archive_resolved = root.resolve(strict=False)
+    except OSError as exc:
+        raise ArchiveSiblingPathErrorV1(f"archive_root resolve failed: {exc}") from exc
+
+    readmodels_root = (archive_resolved / READMODELS_DIRNAME).resolve(strict=False)
+    # Build candidate without trusting pre-existing symlinks for relative join.
+    candidate = (archive_resolved / Path(*posix.parts)).resolve(strict=False)
+
+    try:
+        candidate.relative_to(readmodels_root)
+    except ValueError as exc:
+        raise ArchiveSiblingPathErrorV1(
+            "resolved target escaped <archive_root>/readmodels"
+        ) from exc
+
+    if candidate == readmodels_root:
+        raise ArchiveSiblingPathErrorV1("target_relative_path must name a file under readmodels/")
+
+    return ResolvedArchiveSiblingPathV1(
+        archive_root=archive_resolved,
+        readmodels_root=readmodels_root,
+        target_path=candidate,
+        target_relative_posix=posix.as_posix(),
+    )

--- a/src/ops/archive_sibling_export_contract_v1/result_types.py
+++ b/src/ops/archive_sibling_export_contract_v1/result_types.py
@@ -1,0 +1,39 @@
+"""Result types for CAPABILITY_ARCHIVE_SIBLING_EXPORT_CONTRACT_V1."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any
+
+
+class ArchiveSiblingExportEffectV1(str, Enum):
+    """Operator-facing dry-run / write effect classification."""
+
+    CREATE = "CREATE"
+    REPLACE = "REPLACE"
+    NO_CHANGE = "NO_CHANGE"
+    BLOCKED = "BLOCKED"
+
+
+@dataclass(frozen=True)
+class ArchiveSiblingExportResultV1:
+    """Fail-closed, audit-friendly archive-sibling export outcome."""
+
+    effect: ArchiveSiblingExportEffectV1
+    write_performed: bool
+    dry_run: bool
+    contract_name: str
+    target_path: str | None
+    source_digest: str | None = None
+    target_digest_before: str | None = None
+    target_digest_after: str | None = None
+    expected_target_digest: str | None = None
+    block_reason: str | None = None
+    schema_name: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Machine-readable summary with enum values as strings."""
+        payload = asdict(self)
+        payload["effect"] = self.effect.value
+        return payload

--- a/tests/ops/test_archive_sibling_export_contract_v1.py
+++ b/tests/ops/test_archive_sibling_export_contract_v1.py
@@ -1,0 +1,471 @@
+"""Focused tests: CAPABILITY_ARCHIVE_SIBLING_EXPORT_CONTRACT_V1."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.ops.archive_sibling_export_contract_v1 import (
+    AUTHORITY_EFFECT,
+    CAPABILITY_ID,
+    ArchiveSiblingExportEffectV1,
+    canonical_digest_v1,
+    export_archive_sibling_json_v1,
+)
+from src.ops.archive_sibling_export_contract_v1.atomic_write import atomic_write_text_v1
+from src.ops.archive_sibling_export_contract_v1.contracts import (
+    BLOCK_WRITE_NOT_AUTHORIZED,
+    export_archive_sibling_json_v1 as export_fn,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+PACKAGE = REPO / "src/ops/archive_sibling_export_contract_v1"
+CONTRACT = "unit_test_archive_sibling_contract_v1"
+TARGET_REL = Path("readmodels/unit_sibling.v1.json")
+
+FORBIDDEN_IMPORT_PREFIXES = (
+    "trading",
+    "src.trading",
+    "src.risk_layer",
+    "src.governance",
+    "src.backtest",
+    "src.webui",
+    "src.execution",
+)
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "alpha": 1,
+        "beta": "x",
+        "nested": {"z": 3, "a": 2},
+    }
+    base.update(overrides)
+    return base
+
+
+def _list_files(root: Path) -> list[str]:
+    if not root.exists():
+        return []
+    return sorted(p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file())
+
+
+def test_capability_constants() -> None:
+    assert CAPABILITY_ID == "CAPABILITY_ARCHIVE_SIBLING_EXPORT_CONTRACT_V1"
+    assert AUTHORITY_EFFECT == "NONE"
+
+
+def test_digest_deterministic_across_key_order() -> None:
+    left = {"b": 2, "a": 1, "nested": {"y": 2, "x": 1}}
+    right = {"nested": {"x": 1, "y": 2}, "a": 1, "b": 2}
+    assert canonical_digest_v1(left) == canonical_digest_v1(right)
+
+
+def test_public_api_defaults_to_dry_run() -> None:
+    sig = inspect.signature(export_archive_sibling_json_v1)
+    assert sig.parameters["dry_run"].default is True
+    assert sig.parameters["write_authorized"].default is False
+
+
+def test_create_dry_run_no_filesystem_mutation(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    before = _list_files(tmp_path)
+    result = export_archive_sibling_json_v1(
+        payload=_payload(),
+        archive_root=archive,
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+        required_fields=("alpha", "beta"),
+    )
+    assert result.effect == ArchiveSiblingExportEffectV1.CREATE
+    assert result.dry_run is True
+    assert result.write_performed is False
+    assert result.source_digest
+    assert result.expected_target_digest == result.source_digest
+    assert result.target_digest_after is None
+    assert _list_files(tmp_path) == before
+    assert not archive.exists()
+
+
+def test_create_authorized_write(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    payload = _payload()
+    digest = canonical_digest_v1(payload)
+    result = export_archive_sibling_json_v1(
+        payload=payload,
+        archive_root=archive,
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+        required_fields=("alpha",),
+        dry_run=False,
+        write_authorized=True,
+    )
+    target = archive / TARGET_REL
+    assert result.effect == ArchiveSiblingExportEffectV1.CREATE
+    assert result.write_performed is True
+    assert result.dry_run is False
+    assert result.source_digest == digest
+    assert result.target_digest_after == digest
+    assert target.is_file()
+    loaded = json.loads(target.read_text(encoding="utf-8"))
+    assert loaded == payload
+    assert canonical_digest_v1(loaded) == digest
+
+
+def test_no_change_skips_write(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    payload = _payload()
+    first = export_archive_sibling_json_v1(
+        payload=payload,
+        archive_root=archive,
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+        dry_run=False,
+        write_authorized=True,
+    )
+    assert first.write_performed is True
+    target = archive / TARGET_REL
+    before_bytes = target.read_bytes()
+    mtime_before = target.stat().st_mtime_ns
+
+    second = export_archive_sibling_json_v1(
+        payload={"nested": payload["nested"], "beta": "x", "alpha": 1},
+        archive_root=archive,
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+        dry_run=False,
+        write_authorized=True,
+    )
+    assert second.effect == ArchiveSiblingExportEffectV1.NO_CHANGE
+    assert second.write_performed is False
+    assert target.read_bytes() == before_bytes
+    assert target.stat().st_mtime_ns == mtime_before
+
+
+def test_replace_dry_run_and_authorized_write(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    original = _payload(alpha=1)
+    export_archive_sibling_json_v1(
+        payload=original,
+        archive_root=archive,
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+        dry_run=False,
+        write_authorized=True,
+    )
+    target = archive / TARGET_REL
+    before_bytes = target.read_bytes()
+    updated = _payload(alpha=99)
+
+    dry = export_archive_sibling_json_v1(
+        payload=updated,
+        archive_root=archive,
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+    )
+    assert dry.effect == ArchiveSiblingExportEffectV1.REPLACE
+    assert dry.write_performed is False
+    assert dry.target_digest_before == canonical_digest_v1(original)
+    assert dry.expected_target_digest == canonical_digest_v1(updated)
+    assert target.read_bytes() == before_bytes
+
+    written = export_archive_sibling_json_v1(
+        payload=updated,
+        archive_root=archive,
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+        dry_run=False,
+        write_authorized=True,
+    )
+    assert written.effect == ArchiveSiblingExportEffectV1.REPLACE
+    assert written.write_performed is True
+    assert written.target_digest_after == canonical_digest_v1(updated)
+    assert json.loads(target.read_text(encoding="utf-8"))["alpha"] == 99
+
+
+def test_dry_run_false_without_write_authorized_blocked(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    result = export_archive_sibling_json_v1(
+        payload=_payload(),
+        archive_root=archive,
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+        dry_run=False,
+        write_authorized=False,
+    )
+    assert result.effect == ArchiveSiblingExportEffectV1.BLOCKED
+    assert result.block_reason == BLOCK_WRITE_NOT_AUTHORIZED
+    assert result.write_performed is False
+    assert not (archive / TARGET_REL).exists()
+
+
+def test_write_authorized_true_with_dry_run_still_dry(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    result = export_archive_sibling_json_v1(
+        payload=_payload(),
+        archive_root=archive,
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+        dry_run=True,
+        write_authorized=True,
+    )
+    assert result.effect == ArchiveSiblingExportEffectV1.CREATE
+    assert result.dry_run is True
+    assert result.write_performed is False
+    assert not archive.exists()
+
+
+def test_missing_required_field_blocked(tmp_path: Path) -> None:
+    result = export_archive_sibling_json_v1(
+        payload=_payload(),
+        archive_root=tmp_path / "archive",
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+        required_fields=("alpha", "missing_field"),
+    )
+    assert result.effect == ArchiveSiblingExportEffectV1.BLOCKED
+    assert result.block_reason is not None
+    assert "REQUIRED_FIELD_MISSING" in result.block_reason
+    assert "missing_field" in result.block_reason
+
+
+def test_payload_not_object_blocked(tmp_path: Path) -> None:
+    result = export_archive_sibling_json_v1(
+        payload=["not", "an", "object"],  # type: ignore[arg-type]
+        archive_root=tmp_path / "archive",
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+    )
+    assert result.effect == ArchiveSiblingExportEffectV1.BLOCKED
+    assert result.block_reason is not None
+    assert "PAYLOAD_NOT_OBJECT" in result.block_reason
+
+
+def test_non_serializable_payload_blocked(tmp_path: Path) -> None:
+    result = export_archive_sibling_json_v1(
+        payload={"ok": 1, "bad": {1, 2, 3}},
+        archive_root=tmp_path / "archive",
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+    )
+    assert result.effect == ArchiveSiblingExportEffectV1.BLOCKED
+    assert result.block_reason is not None
+    assert "NOT_SERIALIZABLE" in result.block_reason
+
+
+def test_absolute_target_blocked(tmp_path: Path) -> None:
+    result = export_archive_sibling_json_v1(
+        payload=_payload(),
+        archive_root=tmp_path / "archive",
+        target_relative_path=tmp_path / "readmodels" / "x.json",
+        contract_name=CONTRACT,
+    )
+    assert result.effect == ArchiveSiblingExportEffectV1.BLOCKED
+    assert result.block_reason is not None
+    assert "PATH_INVALID" in result.block_reason
+
+
+def test_path_traversal_blocked(tmp_path: Path) -> None:
+    result = export_archive_sibling_json_v1(
+        payload=_payload(),
+        archive_root=tmp_path / "archive",
+        target_relative_path=Path("readmodels/../secret.json"),
+        contract_name=CONTRACT,
+    )
+    assert result.effect == ArchiveSiblingExportEffectV1.BLOCKED
+    assert result.block_reason is not None
+    assert "PATH_INVALID" in result.block_reason
+
+
+def test_target_outside_readmodels_blocked(tmp_path: Path) -> None:
+    result = export_archive_sibling_json_v1(
+        payload=_payload(),
+        archive_root=tmp_path / "archive",
+        target_relative_path=Path("other/unit_sibling.v1.json"),
+        contract_name=CONTRACT,
+    )
+    assert result.effect == ArchiveSiblingExportEffectV1.BLOCKED
+    assert result.block_reason is not None
+    assert "PATH_INVALID" in result.block_reason
+
+
+def test_symlink_escape_blocked(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    escape_target = outside / "escaped.json"
+    escape_target.write_text('{"alpha":1}\n', encoding="utf-8")
+
+    readmodels = archive / "readmodels"
+    readmodels.mkdir(parents=True)
+    link = readmodels / "escape_link"
+    link.symlink_to(outside)
+
+    result = export_archive_sibling_json_v1(
+        payload=_payload(),
+        archive_root=archive,
+        target_relative_path=Path("readmodels/escape_link/escaped.json"),
+        contract_name=CONTRACT,
+        dry_run=False,
+        write_authorized=True,
+    )
+    assert result.effect == ArchiveSiblingExportEffectV1.BLOCKED
+    assert result.block_reason is not None
+    assert "PATH_INVALID" in result.block_reason
+    assert escape_target.read_text(encoding="utf-8") == '{"alpha":1}\n'
+
+
+def test_invalid_existing_json_blocked_and_unchanged(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    target = archive / TARGET_REL
+    target.parent.mkdir(parents=True)
+    original = b"{not-json"
+    target.write_bytes(original)
+
+    result = export_archive_sibling_json_v1(
+        payload=_payload(),
+        archive_root=archive,
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+        dry_run=False,
+        write_authorized=True,
+    )
+    assert result.effect == ArchiveSiblingExportEffectV1.BLOCKED
+    assert result.block_reason is not None
+    assert "TARGET_INVALID_JSON" in result.block_reason
+    assert target.read_bytes() == original
+
+
+def test_blocked_cases_preserve_existing_bytes(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    payload = _payload()
+    export_archive_sibling_json_v1(
+        payload=payload,
+        archive_root=archive,
+        target_relative_path=TARGET_REL,
+        contract_name=CONTRACT,
+        dry_run=False,
+        write_authorized=True,
+    )
+    target = archive / TARGET_REL
+    before = target.read_bytes()
+
+    blocked_cases = [
+        dict(
+            payload=_payload(alpha=2),
+            dry_run=False,
+            write_authorized=False,
+        ),
+        dict(
+            payload=_payload(),
+            required_fields=("nope",),
+        ),
+        dict(
+            payload=_payload(),
+            target_relative_path=Path("readmodels/../x.json"),
+        ),
+    ]
+    for kwargs in blocked_cases:
+        call: dict[str, Any] = {
+            "payload": _payload(),
+            "archive_root": archive,
+            "target_relative_path": TARGET_REL,
+            "contract_name": CONTRACT,
+        }
+        call.update(kwargs)
+        result = export_archive_sibling_json_v1(**call)
+        assert result.effect == ArchiveSiblingExportEffectV1.BLOCKED
+        assert target.read_bytes() == before
+
+
+def test_temp_cleanup_on_write_failure(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    target = archive / TARGET_REL
+
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated_replace_failure")
+
+    with patch(
+        "src.ops.archive_sibling_export_contract_v1.atomic_write.os.replace",
+        side_effect=boom,
+    ):
+        with pytest.raises(Exception):
+            atomic_write_text_v1(destination=target, body='{"a":1}\n')
+
+    leftovers = list(target.parent.glob(target.name + ".*")) if target.parent.exists() else []
+    assert leftovers == []
+
+
+def test_os_replace_only_after_validation(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    calls: list[str] = []
+
+    real_replace = os.replace
+
+    def tracked_replace(src: str, dst: str) -> None:
+        calls.append("replace")
+        real_replace(src, dst)
+
+    with patch(
+        "src.ops.archive_sibling_export_contract_v1.atomic_write.os.replace",
+        side_effect=tracked_replace,
+    ):
+        blocked = export_archive_sibling_json_v1(
+            payload=_payload(),
+            archive_root=archive,
+            target_relative_path=Path("readmodels/../evil.json"),
+            contract_name=CONTRACT,
+            dry_run=False,
+            write_authorized=True,
+        )
+        assert blocked.effect == ArchiveSiblingExportEffectV1.BLOCKED
+        assert calls == []
+
+        ok = export_archive_sibling_json_v1(
+            payload=_payload(),
+            archive_root=archive,
+            target_relative_path=TARGET_REL,
+            contract_name=CONTRACT,
+            dry_run=False,
+            write_authorized=True,
+        )
+        assert ok.write_performed is True
+        assert calls == ["replace"]
+
+
+def test_no_mkdir_in_dry_run(tmp_path: Path) -> None:
+    archive = tmp_path / "archive"
+    with patch("pathlib.Path.mkdir") as mkdir_mock:
+        result = export_archive_sibling_json_v1(
+            payload=_payload(),
+            archive_root=archive,
+            target_relative_path=TARGET_REL,
+            contract_name=CONTRACT,
+        )
+        assert result.effect == ArchiveSiblingExportEffectV1.CREATE
+        mkdir_mock.assert_not_called()
+
+
+def test_forbidden_domain_imports_absent() -> None:
+    for path in sorted(PACKAGE.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    for prefix in FORBIDDEN_IMPORT_PREFIXES:
+                        assert not alias.name.startswith(prefix), path
+            elif isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                for prefix in FORBIDDEN_IMPORT_PREFIXES:
+                    assert not mod.startswith(prefix), path
+
+
+def test_export_fn_alias_is_public_api() -> None:
+    assert export_fn is export_archive_sibling_json_v1


### PR DESCRIPTION
## Summary
- Add semantics-free `archive_sibling_export_contract_v1` for dry-run-default, fail-closed atomic JSON sibling exports under `<archive-root>/readmodels`.
- Enforce explicit write authorization, path confinement (no absolute/`..`/symlink escape), canonical digests, and CREATE/REPLACE/NO_CHANGE/BLOCKED effects.
- Add focused owner tests covering digest determinism, dry-run non-mutation, write gates, and forbidden domain imports.

## Contract flags
DASHBOARD_ROLE=PURE_CONSUMER
AUTHORITY_EFFECT=NONE
TRADING_LOGIC_CHANGED=false
TRADING_STATE_MUTATION_PATH_ADDED=false
CANONICAL_READMODEL_CHANGED=false
ORDER_OR_COMMAND_PATH_ADDED=false
NONCANONICAL_FALLBACK_ADDED=false
ACTIVE_ARCHIVE_MUTATED=false
DEFAULT_MODE=DRY_RUN
WRITE_REQUIRES_EXPLICIT_AUTHORIZATION=true
TRANSACTIONAL_ROLLBACK_CLAIMED=false

## Test plan
- [x] `pytest tests/ops/test_archive_sibling_export_contract_v1.py` (23 passed)
- [x] ruff format/check on changed files
- [x] local PR_BOUNDED_FULL timing proof (~37s, 729 passed)
- [ ] GitHub required checks


Made with [Cursor](https://cursor.com)