### PR TITLE
ops: add Dynamic Scope archive sibling exporter CLI v1

### DIFF
--- a/scripts/ops/run_dynamic_scope_archive_sibling_exporter_v1.py
+++ b/scripts/ops/run_dynamic_scope_archive_sibling_exporter_v1.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Operational CLI for Dynamic Scope archive sibling export (PR B).
+
+Reads canonical Dynamic Scope durable state unchanged and exports the existing
+source-sibling payload via ``export_archive_sibling_json_v1`` only.
+
+Invariants:
+- DEFAULT_DRY_RUN=true
+- write only when dry_run=false AND write_authorized=true
+- target relative path fixed: readmodels/dynamic_scope_state_v1.json
+- no archive discovery / latest fallback / active-archive auto-selection
+- no producer, scheduler, runtime, dashboard, or trading mutation
+- AUTHORITY_EFFECT=NONE
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from src.ops.archive_sibling_export_contract_v1 import (
+    ArchiveSiblingExportEffectV1,
+    export_archive_sibling_json_v1,
+)
+from src.ops.dynamic_scope_archive_sibling_exporter_v1.constants_v1 import (
+    AUTHORITY_EFFECT,
+    CAPABILITY_ID,
+    SOURCE_SCHEMA,
+    SOURCE_STATE_VERSION,
+    TARGET_RELATIVE_PATH,
+)
+from src.ops.dynamic_scope_persistence_binding_v1.constants_v1 import (
+    SCHEMA_VERSION,
+    STATE_VERSION,
+)
+from src.ops.dynamic_scope_persistence_binding_v1.models_v1 import (
+    CanonicalDynamicScopeStateV1,
+)
+from src.ops.dynamic_scope_persistence_binding_v1.persistence_v1 import (
+    DynamicScopePersistenceError,
+    load_dynamic_scope_state_v1,
+    scope_state_path,
+)
+from src.ops.dynamic_scope_persistence_binding_v1.reason_codes_v1 import (
+    DynamicScopeBindingFailureCodeV1,
+)
+
+CLI_ID = "run_dynamic_scope_archive_sibling_exporter_v1"
+CONTRACT_NAME = SOURCE_SCHEMA
+DEFAULT_DRY_RUN = True
+REQUIRED_PAYLOAD_FIELDS: tuple[str, ...] = (
+    "schema_version",
+    "state_version",
+    "scope_session_id",
+    "instrument_id",
+)
+
+ERROR_SOURCE_MISSING = "DYNAMIC_SCOPE_CLI_SOURCE_MISSING"
+ERROR_SOURCE_CORRUPT = "DYNAMIC_SCOPE_CLI_SOURCE_CORRUPT"
+ERROR_SOURCE_SCHEMA_MISMATCH = "DYNAMIC_SCOPE_CLI_SOURCE_SCHEMA_MISMATCH"
+ERROR_SOURCE_STATE_VERSION_MISMATCH = "DYNAMIC_SCOPE_CLI_SOURCE_STATE_VERSION_MISMATCH"
+ERROR_SOURCE_LOAD_FAILED = "DYNAMIC_SCOPE_CLI_SOURCE_LOAD_FAILED"
+ERROR_SOURCE_TYPE_MISMATCH = "DYNAMIC_SCOPE_CLI_SOURCE_TYPE_MISMATCH"
+ERROR_EXPORT_BLOCKED = "DYNAMIC_SCOPE_CLI_EXPORT_BLOCKED"
+
+
+@dataclass(frozen=True)
+class CliExportOutcomeV1:
+    """Machine-readable CLI outcome without payload content or secrets."""
+
+    ok: bool
+    effect: str
+    write_performed: bool
+    dry_run: bool
+    write_authorized: bool
+    archive_root: str
+    dynamic_scope_state_root: str
+    source_path: str
+    target_relative_path: str
+    target_path: str | None
+    contract_name: str
+    source_digest: str | None = None
+    target_digest_before: str | None = None
+    target_digest_after: str | None = None
+    expected_target_digest: str | None = None
+    block_reason: str | None = None
+    error_code: str | None = None
+    schema_version: str | None = None
+    state_version: str | None = None
+    capability_id: str = CAPABILITY_ID
+    cli_id: str = CLI_ID
+    authority_effect: str = AUTHORITY_EFFECT
+    export_contract: str = "export_archive_sibling_json_v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "effect": self.effect,
+            "write_performed": self.write_performed,
+            "dry_run": self.dry_run,
+            "write_authorized": self.write_authorized,
+            "archive_root": self.archive_root,
+            "dynamic_scope_state_root": self.dynamic_scope_state_root,
+            "source_path": self.source_path,
+            "target_relative_path": self.target_relative_path,
+            "target_path": self.target_path,
+            "contract_name": self.contract_name,
+            "source_digest": self.source_digest,
+            "target_digest_before": self.target_digest_before,
+            "target_digest_after": self.target_digest_after,
+            "expected_target_digest": self.expected_target_digest,
+            "block_reason": self.block_reason,
+            "error_code": self.error_code,
+            "schema_version": self.schema_version,
+            "state_version": self.state_version,
+            "capability_id": self.capability_id,
+            "cli_id": self.cli_id,
+            "authority_effect": self.authority_effect,
+            "export_contract": self.export_contract,
+            "default_dry_run": DEFAULT_DRY_RUN,
+        }
+
+
+def _blocked_outcome(
+    *,
+    dry_run: bool,
+    write_authorized: bool,
+    archive_root: str,
+    dynamic_scope_state_root: str,
+    source_path: str,
+    error_code: str,
+    block_reason: str,
+    schema_version: str | None = None,
+    state_version: str | None = None,
+) -> CliExportOutcomeV1:
+    return CliExportOutcomeV1(
+        ok=False,
+        effect=ArchiveSiblingExportEffectV1.BLOCKED.value,
+        write_performed=False,
+        dry_run=dry_run,
+        write_authorized=write_authorized,
+        archive_root=archive_root,
+        dynamic_scope_state_root=dynamic_scope_state_root,
+        source_path=source_path,
+        target_relative_path=TARGET_RELATIVE_PATH,
+        target_path=None,
+        contract_name=CONTRACT_NAME,
+        block_reason=block_reason,
+        error_code=error_code,
+        schema_version=schema_version,
+        state_version=state_version,
+    )
+
+
+def _map_load_error(exc: DynamicScopePersistenceError) -> tuple[str, str]:
+    detail = " ".join(str(a) for a in exc.args)
+    if (
+        exc.code is DynamicScopeBindingFailureCodeV1.STATE_VERSION_MISMATCH
+        or "UNSUPPORTED_DYNAMIC_SCOPE_STATE_VERSION:" in detail
+    ):
+        return ERROR_SOURCE_STATE_VERSION_MISMATCH, detail or ERROR_SOURCE_STATE_VERSION_MISMATCH
+    if exc.code is DynamicScopeBindingFailureCodeV1.CORRUPTED_CHECKPOINT:
+        return ERROR_SOURCE_CORRUPT, detail or ERROR_SOURCE_CORRUPT
+    if exc.code in {
+        DynamicScopeBindingFailureCodeV1.CHECKPOINT_MISSING_BEFORE_FIRST_STATE,
+        DynamicScopeBindingFailureCodeV1.CHECKPOINT_MISSING_AFTER_PRIOR_COMMIT,
+    }:
+        return ERROR_SOURCE_MISSING, detail or ERROR_SOURCE_MISSING
+    return ERROR_SOURCE_LOAD_FAILED, detail or ERROR_SOURCE_LOAD_FAILED
+
+
+def load_dynamic_scope_export_payload_v1(
+    *,
+    dynamic_scope_state_root: Path | str,
+) -> tuple[dict[str, Any], Path] | CliExportOutcomeV1:
+    """Load canonical durable state and return ``to_dict()`` payload + source path.
+
+    On failure returns a blocked CLI outcome (fail-closed; no write attempted).
+    """
+    state_root = Path(dynamic_scope_state_root).expanduser()
+    source_path = scope_state_path(state_root)
+    root_str = str(state_root)
+    source_str = str(source_path)
+
+    if not source_path.is_file():
+        return _blocked_outcome(
+            dry_run=True,
+            write_authorized=False,
+            archive_root="",
+            dynamic_scope_state_root=root_str,
+            source_path=source_str,
+            error_code=ERROR_SOURCE_MISSING,
+            block_reason=f"missing source file: {source_str}",
+        )
+
+    try:
+        loaded = load_dynamic_scope_state_v1(state_root, require_present=True)
+    except DynamicScopePersistenceError as exc:
+        code, reason = _map_load_error(exc)
+        return _blocked_outcome(
+            dry_run=True,
+            write_authorized=False,
+            archive_root="",
+            dynamic_scope_state_root=root_str,
+            source_path=source_str,
+            error_code=code,
+            block_reason=reason,
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-closed wrapper
+        return _blocked_outcome(
+            dry_run=True,
+            write_authorized=False,
+            archive_root="",
+            dynamic_scope_state_root=root_str,
+            source_path=source_str,
+            error_code=ERROR_SOURCE_LOAD_FAILED,
+            block_reason=str(exc),
+        )
+
+    if loaded is None:
+        return _blocked_outcome(
+            dry_run=True,
+            write_authorized=False,
+            archive_root="",
+            dynamic_scope_state_root=root_str,
+            source_path=source_str,
+            error_code=ERROR_SOURCE_MISSING,
+            block_reason="load_dynamic_scope_state_v1 returned None",
+        )
+
+    if not isinstance(loaded, CanonicalDynamicScopeStateV1):
+        return _blocked_outcome(
+            dry_run=True,
+            write_authorized=False,
+            archive_root="",
+            dynamic_scope_state_root=root_str,
+            source_path=source_str,
+            error_code=ERROR_SOURCE_TYPE_MISMATCH,
+            block_reason="loaded object is not CanonicalDynamicScopeStateV1",
+        )
+
+    payload = loaded.to_dict()
+    schema_version = str(payload.get("schema_version") or "")
+    state_version = str(payload.get("state_version") or "")
+    if schema_version != SCHEMA_VERSION or schema_version != SOURCE_SCHEMA:
+        return _blocked_outcome(
+            dry_run=True,
+            write_authorized=False,
+            archive_root="",
+            dynamic_scope_state_root=root_str,
+            source_path=source_str,
+            error_code=ERROR_SOURCE_SCHEMA_MISMATCH,
+            block_reason=f"schema_version={schema_version!r} expected={SCHEMA_VERSION!r}",
+            schema_version=schema_version or None,
+            state_version=state_version or None,
+        )
+    if state_version != STATE_VERSION or state_version != SOURCE_STATE_VERSION:
+        return _blocked_outcome(
+            dry_run=True,
+            write_authorized=False,
+            archive_root="",
+            dynamic_scope_state_root=root_str,
+            source_path=source_str,
+            error_code=ERROR_SOURCE_STATE_VERSION_MISMATCH,
+            block_reason=f"state_version={state_version!r} expected={STATE_VERSION!r}",
+            schema_version=schema_version or None,
+            state_version=state_version or None,
+        )
+
+    return payload, source_path
+
+
+def run_dynamic_scope_archive_sibling_exporter_cli_v1(
+    *,
+    archive_root: Path | str,
+    dynamic_scope_state_root: Path | str,
+    dry_run: bool = DEFAULT_DRY_RUN,
+    write_authorized: bool = False,
+) -> CliExportOutcomeV1:
+    """Export Dynamic Scope source sibling via PR-A contract only."""
+    archive = Path(archive_root).expanduser()
+    state_root = Path(dynamic_scope_state_root).expanduser()
+    effective_dry_run = bool(dry_run)
+    authorized = bool(write_authorized)
+
+    loaded = load_dynamic_scope_export_payload_v1(dynamic_scope_state_root=state_root)
+    if isinstance(loaded, CliExportOutcomeV1):
+        # Preserve caller dry_run / write_authorized flags on source failures.
+        return CliExportOutcomeV1(
+            ok=False,
+            effect=loaded.effect,
+            write_performed=False,
+            dry_run=effective_dry_run,
+            write_authorized=authorized,
+            archive_root=str(archive),
+            dynamic_scope_state_root=str(state_root),
+            source_path=loaded.source_path,
+            target_relative_path=TARGET_RELATIVE_PATH,
+            target_path=None,
+            contract_name=CONTRACT_NAME,
+            block_reason=loaded.block_reason,
+            error_code=loaded.error_code,
+            schema_version=loaded.schema_version,
+            state_version=loaded.state_version,
+        )
+
+    payload, source_path = loaded
+    schema_version = str(payload.get("schema_version") or "")
+    state_version = str(payload.get("state_version") or "")
+
+    # Exclusive write path: PR-A contract only (no local atomic/digest/path guard).
+    result = export_archive_sibling_json_v1(
+        payload=payload,
+        archive_root=archive,
+        target_relative_path=TARGET_RELATIVE_PATH,
+        contract_name=CONTRACT_NAME,
+        required_fields=REQUIRED_PAYLOAD_FIELDS,
+        dry_run=effective_dry_run,
+        write_authorized=authorized,
+    )
+
+    ok = result.effect != ArchiveSiblingExportEffectV1.BLOCKED and result.block_reason is None
+    error_code = None if ok else ERROR_EXPORT_BLOCKED
+    return CliExportOutcomeV1(
+        ok=ok,
+        effect=result.effect.value,
+        write_performed=bool(result.write_performed),
+        dry_run=bool(result.dry_run),
+        write_authorized=authorized,
+        archive_root=str(archive),
+        dynamic_scope_state_root=str(state_root),
+        source_path=str(source_path),
+        target_relative_path=TARGET_RELATIVE_PATH,
+        target_path=result.target_path,
+        contract_name=result.contract_name,
+        source_digest=result.source_digest,
+        target_digest_before=result.target_digest_before,
+        target_digest_after=result.target_digest_after,
+        expected_target_digest=result.expected_target_digest,
+        block_reason=result.block_reason,
+        error_code=error_code,
+        schema_version=schema_version or None,
+        state_version=state_version or None,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export CanonicalDynamicScopeStateV1 as archive sibling under "
+            "readmodels/dynamic_scope_state_v1.json via export_archive_sibling_json_v1. "
+            "Default is dry-run; write requires --no-dry-run and --write-authorized. "
+            "Does not discover archives or select latest."
+        )
+    )
+    parser.add_argument(
+        "--archive-root",
+        required=True,
+        help="Explicit archive root (no discovery / no latest fallback).",
+    )
+    parser.add_argument(
+        "--dynamic-scope-state-root",
+        required=True,
+        help=(
+            "Repository-backed Dynamic Scope durable state root containing "
+            "dynamic_scope_state_v1.json (canonical loader path)."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=DEFAULT_DRY_RUN,
+        help=f"Dry-run mode (default: {str(DEFAULT_DRY_RUN).lower()}).",
+    )
+    parser.add_argument(
+        "--write-authorized",
+        action="store_true",
+        default=False,
+        help="Explicit write authorization; required together with --no-dry-run.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    outcome = run_dynamic_scope_archive_sibling_exporter_cli_v1(
+        archive_root=args.archive_root,
+        dynamic_scope_state_root=args.dynamic_scope_state_root,
+        dry_run=bool(args.dry_run),
+        write_authorized=bool(args.write_authorized),
+    )
+    print(json.dumps(outcome.to_dict(), sort_keys=True, ensure_ascii=False))
+    return 0 if outcome.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_run_dynamic_scope_archive_sibling_exporter_v1.py
+++ b/tests/ops/test_run_dynamic_scope_archive_sibling_exporter_v1.py
@@ -1,0 +1,382 @@
+"""Focused tests: Dynamic Scope archive sibling exporter CLI (PR B)."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import inspect
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.ops.archive_sibling_export_contract_v1 import (
+    ArchiveSiblingExportEffectV1,
+    ArchiveSiblingExportResultV1,
+    canonical_digest_v1,
+)
+from src.ops.archive_sibling_export_contract_v1.contracts import (
+    BLOCK_WRITE_NOT_AUTHORIZED,
+)
+from src.ops.dynamic_scope_archive_sibling_exporter_v1.constants_v1 import (
+    TARGET_RELATIVE_PATH,
+)
+from src.ops.dynamic_scope_persistence_binding_v1.cycle_harness_v1 import (
+    ScopeHarnessEventV1,
+    run_dynamic_scope_harness_v1,
+)
+from src.ops.dynamic_scope_persistence_binding_v1.models_v1 import (
+    CanonicalDynamicScopeStateV1,
+)
+from src.ops.dynamic_scope_persistence_binding_v1.persistence_v1 import (
+    load_dynamic_scope_state_v1,
+    scope_state_path,
+)
+from src.ops.stateful_confirmation_and_c1_productive_binding_v1.host_binding_v1 import (
+    ObservationCycleKindV1,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+CLI_PATH = REPO / "scripts/ops/run_dynamic_scope_archive_sibling_exporter_v1.py"
+REPO_SHA = "7beeba1ce93013461d45773a0390d7c9148571c8"
+FORBIDDEN_IMPORT_TOKENS = (
+    "src.webui",
+    "playwright",
+    "presentation_projection_octet",
+    "workflow_dashboard",
+)
+FORBIDDEN_IMPORT_PREFIXES = (
+    "src.webui",
+    "webui",
+    "playwright",
+)
+
+
+def _load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "run_dynamic_scope_archive_sibling_exporter_v1",
+        CLI_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+CLI = _load_cli()
+
+
+def _market(mid: float) -> ScopeHarnessEventV1:
+    return ScopeHarnessEventV1(kind=ObservationCycleKindV1.MARKET_SAMPLE, mid_price=mid)
+
+
+def _persist_valid_state(tmp_path: Path) -> Path:
+    state_root = tmp_path / "dynamic_scope_state_root"
+    result = run_dynamic_scope_harness_v1(
+        [_market(100.0 + i) for i in range(6)],
+        repository_sha=REPO_SHA,
+        dynamic_scope_state_root=state_root,
+    )
+    assert result.ok
+    assert scope_state_path(state_root).is_file()
+    loaded = load_dynamic_scope_state_v1(state_root, require_present=True)
+    assert isinstance(loaded, CanonicalDynamicScopeStateV1)
+    return state_root
+
+
+def _list_files(root: Path) -> set[str]:
+    if not root.exists():
+        return set()
+    return {p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()}
+
+
+def test_cli_defaults_dry_run_true() -> None:
+    parser = CLI.build_parser()
+    args = parser.parse_args(
+        [
+            "--archive-root",
+            "/tmp/archive",
+            "--dynamic-scope-state-root",
+            "/tmp/state",
+        ]
+    )
+    assert args.dry_run is True
+    assert args.write_authorized is False
+    assert CLI.DEFAULT_DRY_RUN is True
+
+    sig = inspect.signature(CLI.run_dynamic_scope_archive_sibling_exporter_cli_v1)
+    assert sig.parameters["dry_run"].default is True
+    assert sig.parameters["write_authorized"].default is False
+
+
+def test_default_dry_run_mutates_nothing(tmp_path: Path) -> None:
+    state_root = _persist_valid_state(tmp_path)
+    archive_root = tmp_path / "archive_root"
+    source = scope_state_path(state_root)
+    source_before = source.read_bytes()
+    before = _list_files(tmp_path)
+
+    out = CLI.run_dynamic_scope_archive_sibling_exporter_cli_v1(
+        archive_root=archive_root,
+        dynamic_scope_state_root=state_root,
+    )
+    assert out.ok is True
+    assert out.dry_run is True
+    assert out.write_performed is False
+    assert out.effect == ArchiveSiblingExportEffectV1.CREATE.value
+    assert out.target_relative_path == "readmodels/dynamic_scope_state_v1.json"
+    assert out.target_relative_path == TARGET_RELATIVE_PATH
+    assert not archive_root.exists()
+    assert source.read_bytes() == source_before
+    assert _list_files(tmp_path) == before
+
+
+def test_missing_write_authorization_blocks(tmp_path: Path) -> None:
+    state_root = _persist_valid_state(tmp_path)
+    archive_root = tmp_path / "archive_root"
+    before = _list_files(tmp_path)
+
+    out = CLI.run_dynamic_scope_archive_sibling_exporter_cli_v1(
+        archive_root=archive_root,
+        dynamic_scope_state_root=state_root,
+        dry_run=False,
+        write_authorized=False,
+    )
+    assert out.ok is False
+    assert out.write_performed is False
+    assert out.effect == ArchiveSiblingExportEffectV1.BLOCKED.value
+    assert out.block_reason == BLOCK_WRITE_NOT_AUTHORIZED
+    assert not (archive_root / TARGET_RELATIVE_PATH).exists()
+    assert _list_files(tmp_path) == before
+
+
+def test_authorized_write_uses_pr_a_contract_exactly(tmp_path: Path) -> None:
+    state_root = _persist_valid_state(tmp_path)
+    archive_root = tmp_path / "archive_root"
+    loaded = load_dynamic_scope_state_v1(state_root, require_present=True)
+    assert loaded is not None
+    expected_payload = loaded.to_dict()
+    expected_digest = canonical_digest_v1(expected_payload)
+
+    captured: dict[str, object] = {}
+
+    def _spy(**kwargs: object) -> ArchiveSiblingExportResultV1:
+        captured.update(kwargs)
+        return ArchiveSiblingExportResultV1(
+            effect=ArchiveSiblingExportEffectV1.CREATE,
+            write_performed=True,
+            dry_run=False,
+            contract_name=str(kwargs["contract_name"]),
+            target_path=str(Path(str(kwargs["archive_root"])) / TARGET_RELATIVE_PATH),
+            source_digest=expected_digest,
+            target_digest_before=None,
+            target_digest_after=expected_digest,
+            expected_target_digest=expected_digest,
+            block_reason=None,
+            schema_name=str(kwargs["contract_name"]),
+        )
+
+    with patch.object(CLI, "export_archive_sibling_json_v1", side_effect=_spy) as mocked:
+        out = CLI.run_dynamic_scope_archive_sibling_exporter_cli_v1(
+            archive_root=archive_root,
+            dynamic_scope_state_root=state_root,
+            dry_run=False,
+            write_authorized=True,
+        )
+
+    assert mocked.call_count == 1
+    assert captured["target_relative_path"] == TARGET_RELATIVE_PATH
+    assert captured["target_relative_path"] == "readmodels/dynamic_scope_state_v1.json"
+    assert captured["dry_run"] is False
+    assert captured["write_authorized"] is True
+    assert captured["contract_name"] == CLI.CONTRACT_NAME
+    assert captured["required_fields"] == CLI.REQUIRED_PAYLOAD_FIELDS
+    assert captured["payload"] == expected_payload
+    assert out.ok is True
+    assert out.write_performed is True
+    assert out.export_contract == "export_archive_sibling_json_v1"
+    assert out.source_digest == expected_digest
+
+
+def test_authorized_write_payload_semantically_unchanged(tmp_path: Path) -> None:
+    state_root = _persist_valid_state(tmp_path)
+    archive_root = tmp_path / "archive_root"
+    source = scope_state_path(state_root)
+    source_before = source.read_bytes()
+    loaded = load_dynamic_scope_state_v1(state_root, require_present=True)
+    assert loaded is not None
+    expected_payload = loaded.to_dict()
+    expected_digest = canonical_digest_v1(expected_payload)
+
+    out = CLI.run_dynamic_scope_archive_sibling_exporter_cli_v1(
+        archive_root=archive_root,
+        dynamic_scope_state_root=state_root,
+        dry_run=False,
+        write_authorized=True,
+    )
+    assert out.ok is True
+    assert out.write_performed is True
+    assert out.effect == ArchiveSiblingExportEffectV1.CREATE.value
+    assert out.target_relative_path == "readmodels/dynamic_scope_state_v1.json"
+
+    target = archive_root / TARGET_RELATIVE_PATH
+    assert target.is_file()
+    written = json.loads(target.read_text(encoding="utf-8"))
+    assert written == expected_payload
+    assert canonical_digest_v1(written) == expected_digest
+    assert out.source_digest == expected_digest
+    assert out.target_digest_after == expected_digest
+    assert source.read_bytes() == source_before
+
+
+def test_missing_source_fail_closed(tmp_path: Path) -> None:
+    state_root = tmp_path / "missing_state_root"
+    state_root.mkdir()
+    archive_root = tmp_path / "archive_root"
+    out = CLI.run_dynamic_scope_archive_sibling_exporter_cli_v1(
+        archive_root=archive_root,
+        dynamic_scope_state_root=state_root,
+        dry_run=False,
+        write_authorized=True,
+    )
+    assert out.ok is False
+    assert out.write_performed is False
+    assert out.error_code == CLI.ERROR_SOURCE_MISSING
+    assert not archive_root.exists()
+
+
+def test_corrupt_source_fail_closed(tmp_path: Path) -> None:
+    state_root = tmp_path / "corrupt_state_root"
+    state_root.mkdir()
+    scope_state_path(state_root).write_text("{not-json", encoding="utf-8")
+    archive_root = tmp_path / "archive_root"
+    out = CLI.run_dynamic_scope_archive_sibling_exporter_cli_v1(
+        archive_root=archive_root,
+        dynamic_scope_state_root=state_root,
+        dry_run=False,
+        write_authorized=True,
+    )
+    assert out.ok is False
+    assert out.write_performed is False
+    assert out.error_code == CLI.ERROR_SOURCE_CORRUPT
+    assert not (archive_root / TARGET_RELATIVE_PATH).exists()
+
+
+def test_invalid_state_version_fail_closed(tmp_path: Path) -> None:
+    state_root = _persist_valid_state(tmp_path)
+    source = scope_state_path(state_root)
+    payload = json.loads(source.read_text(encoding="utf-8"))
+    payload["state_version"] = "v999-invalid"
+    source.write_text(json.dumps(payload), encoding="utf-8")
+    archive_root = tmp_path / "archive_root"
+
+    out = CLI.run_dynamic_scope_archive_sibling_exporter_cli_v1(
+        archive_root=archive_root,
+        dynamic_scope_state_root=state_root,
+        dry_run=False,
+        write_authorized=True,
+    )
+    assert out.ok is False
+    assert out.write_performed is False
+    assert out.error_code == CLI.ERROR_SOURCE_STATE_VERSION_MISMATCH
+    assert not (archive_root / TARGET_RELATIVE_PATH).exists()
+
+
+def test_symlink_escape_blocked(tmp_path: Path) -> None:
+    state_root = _persist_valid_state(tmp_path)
+    archive = tmp_path / "archive"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    escape_target = outside / "dynamic_scope_state_v1.json"
+    escape_target.write_text('{"schema_version":"x"}\n', encoding="utf-8")
+
+    readmodels = archive / "readmodels"
+    readmodels.mkdir(parents=True)
+    link = readmodels / "dynamic_scope_state_v1.json"
+    link.symlink_to(escape_target)
+
+    outside_before = escape_target.read_bytes()
+    out = CLI.run_dynamic_scope_archive_sibling_exporter_cli_v1(
+        archive_root=archive,
+        dynamic_scope_state_root=state_root,
+        dry_run=False,
+        write_authorized=True,
+    )
+    assert out.ok is False
+    assert out.write_performed is False
+    assert out.effect == ArchiveSiblingExportEffectV1.BLOCKED.value
+    assert out.block_reason is not None
+    assert "PATH_INVALID" in out.block_reason
+    assert escape_target.read_bytes() == outside_before
+
+
+def test_result_output_has_no_payload_or_secrets(tmp_path: Path) -> None:
+    state_root = _persist_valid_state(tmp_path)
+    archive_root = tmp_path / "archive_root"
+    out = CLI.run_dynamic_scope_archive_sibling_exporter_cli_v1(
+        archive_root=archive_root,
+        dynamic_scope_state_root=state_root,
+    )
+    payload = out.to_dict()
+    text = json.dumps(payload, sort_keys=True)
+    assert "price_path_tail" not in payload
+    assert "position_context" not in payload
+    assert "existing_scope" not in payload
+    assert "runtime_scope_state" not in payload
+    assert '"payload"' not in text
+    assert "api_key" not in text.lower()
+    assert "secret" not in text.lower()
+    assert "password" not in text.lower()
+
+
+def test_cli_main_dry_run_exit_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    state_root = _persist_valid_state(tmp_path)
+    archive_root = tmp_path / "archive_root"
+    rc = CLI.main(
+        [
+            "--archive-root",
+            str(archive_root),
+            "--dynamic-scope-state-root",
+            str(state_root),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    printed = json.loads(captured.out)
+    assert printed["ok"] is True
+    assert printed["dry_run"] is True
+    assert printed["write_performed"] is False
+    assert printed["target_relative_path"] == "readmodels/dynamic_scope_state_v1.json"
+    assert not archive_root.exists()
+
+
+def test_forbidden_imports_and_no_atomic_write_duplication() -> None:
+    src = CLI_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            imported.add(mod)
+
+    for name in imported:
+        assert not name.startswith(FORBIDDEN_IMPORT_PREFIXES), name
+        for token in FORBIDDEN_IMPORT_TOKENS:
+            assert token not in name, name
+
+    assert "export_archive_sibling_json_v1" in src
+    assert "atomic_write_text_v1" not in src
+    assert "tempfile" not in src
+    assert "os.replace" not in src
+    assert "export_dynamic_scope_state_to_archive_sibling_v1" not in src
+    assert "TARGET_RELATIVE_PATH" in src
+    assert "latest" not in src.lower() or "no latest" in src.lower()
+    assert "playwright" not in src.lower()
+    assert "src.webui" not in src


### PR DESCRIPTION
## Summary
- Add dry-run-default operational CLI `scripts/ops/run_dynamic_scope_archive_sibling_exporter_v1.py` that reads canonical Dynamic Scope durable state unchanged and exports the existing source-sibling payload.
- Writes exclusively through `export_archive_sibling_json_v1` (PR A) to fixed relative path `readmodels/dynamic_scope_state_v1.json` under an explicit `--archive-root`.
- Enforce write gate `dry_run=false AND write_authorized=true`; no archive discovery, latest fallback, producer/runtime/dashboard mutation, or active-archive execution in this PR.

## Test plan
- [x] Focused owner: `tests/ops/test_run_dynamic_scope_archive_sibling_exporter_v1.py` (12 passed)
- [x] Related bounded: PR-A contract + existing exporter library tests (48 passed, ~1s)
- [x] Selector: `CONTRACT_FOCUSED` / `focused_script_or_test_diff`
- [x] Ruff format/check PASS
- [x] Forbidden-import scan PASS (no webui/playwright/dashboard; no atomic-write duplication)

## Contract flags
DASHBOARD_ROLE=PURE_CONSUMER
AUTHORITY_EFFECT=NONE
DEFAULT_DRY_RUN=true
WRITE_GATE=dry_run=false_AND_write_authorized=true
TARGET_RELATIVE_PATH=readmodels/dynamic_scope_state_v1.json
EXPORT_CONTRACT=export_archive_sibling_json_v1
ACTIVE_ARCHIVE_MUTATED=false
TRADING_LOGIC_CHANGED=false
CANONICAL_READMODEL_CHANGED=false
RUNTIME_CHANGED=false
DASHBOARD_CHANGED=false
ORDER_PATH_ACCESSED=false
NONCANONICAL_FALLBACK_ADDED=false


Made with [Cursor](https://cursor.com)