### PR TITLE
docs(ops): two-stage Pure-Stack owner-values ratification v1

### DIFF
--- a/docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md
+++ b/docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md
@@ -1,0 +1,295 @@
+# Productive Pure-Stack Numeric Policy Calibration Protocol v1
+
+```text
+DOCUMENT_TYPE=NUMERIC_POLICY_SHADOW_CALIBRATION_PROTOCOL
+DOCUMENT_VERSION=1
+STATUS=PROTOCOL_RATIFIED_NO_PRODUCTIVE_NUMERIC_VALUES
+BASELINE_ORIGIN_MAIN_SHA=631dca43601e4efad53a35c19ddf9bf70ebfd177
+TWO_STAGE_RATIFICATION=docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_TWO_STAGE_RATIFICATION_V1.md
+STRUCTURAL_MANIFEST=docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json
+
+ORDERS_ALLOWED=false
+TESTNET_ACTIVATION=false
+LIVE_ACTIVATION=false
+EXCHANGE_CREDENTIAL_USE=false
+REAL_CAPITAL_MOVEMENT=false
+RUNTIME_PRODUCTIVE_BINDING=false
+AUTO_PROMOTION_TO_PRODUCTIVE_CONFIG=false
+RESULTV1_MAPPING_AUTHORIZED=false
+DASHBOARD_ROLE=READ_ONLY_CONSUMER
+SOLE_TRADING_AUTHORITY=run_integrated_offline_trading_logic_replay_v1
+INPUT_AUTHORITY_REMAINS_FALSE=true
+PRODUCTIVE_NUMERIC_VALUES_SET=0
+```
+
+## 0. Purpose
+
+This protocol defines the **only** admissible path to propose numeric values for
+tokens classified `NUMERIC_CALIBRATION_REQUIRED` in the structural manifest.
+
+It is a **no-order**, **fail-closed**, **reproducible shadow** process. Outputs
+are Evidence artifacts. They must not become productive config, flip
+`INPUT_AUTHORITY_*`, activate Stage-1 producers productively, mutate archives as
+authority, or alter the dashboard beyond read-only consumption of Evidence
+labels.
+
+## 1. Scope
+
+**In scope (calibration candidates only):**
+
+```text
+OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS
+OWNER_VALUE_SURVIVAL_LIMIT_MIN_PATH_SURVIVAL_RATIO
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_EARLY_LOSS_TOXICITY
+OWNER_VALUE_SURVIVAL_LIMIT_MIN_MARGIN_BUFFER_AT_RISK_99
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_SEQUENCE_FRAGILITY_INDEX
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_LIQUIDATION_NEAR_MISS_RATE
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_GOVERNANCE_BREACH_FREQUENCY
+OWNER_VALUE_SURVIVAL_LIMIT_MIN_CHOP_SWITCH_SURVIVAL_SCORE
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_EFFECTIVE_LEVERAGE
+OWNER_VALUE_SURVIVAL_LIMIT_MIN_LIQUIDATION_BUFFER
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_ADVERSE_FILL_LOSS
+OWNER_VALUE_CAPITAL_SLOT_PROFIT_STEP_PCT
+OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION
+OWNER_VALUE_CAPITAL_SLOT_MIN_REALIZED_VOLATILITY
+OWNER_VALUE_CAPITAL_SLOT_MIN_ATR_OR_RANGE
+OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP
+OWNER_VALUE_CAPITAL_SLOT_MIN_OPPORTUNITY_SCORE
+OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE
+```
+
+**Out of scope / already structural:**
+
+- All `STRUCTURAL_RATIFIED` tokens from Stage 1
+- `OWNER_VALUE_CAPITAL_SLOT_REINVEST_FRACTION` (mechanical coupling only)
+
+**Hard exclusions:**
+
+- Fixtures, scenario replay scalars, WebUI hardcoded limits
+- Dashboard / presentation projections as calibration truth
+- `CMC.volatility_estimate` as `realized_volatility`
+- ResultV1 → Pure-Stack mapping
+- Optimization on isolated Sharpe or isolated profit
+- Live / Testnet / orders / credentials / real capital
+
+## 2. Binding to Stage-1 definitions
+
+Every calibration run must pin:
+
+1. Structural manifest SHA / digest
+2. Two-stage ratification document SHA
+3. Exact Stage-1 definition IDs used for features (realized vol, ATR, opportunity,
+   activity, spread, sequence metric set, path-survival definition, time quantum)
+4. Sole Trading Authority code SHA
+5. Dataset provenance digests
+
+If any Stage-1 ID is missing or mismatched: **abort fail-closed** (no candidate
+numbers).
+
+## 3. Mandatory protocol elements
+
+### 3.1 Versioned dataset / observation provenance
+
+- Stable `dataset_id`, instrument_id, exchange, market_type, bar interval
+- Event-time ranges, source identifiers, freshness metadata
+- Explicit write/cache flags; no silent cache mutation as truth
+- Digest of the observation pack included in the Evidence manifest
+
+### 3.2 Instrument and market-regime stratification
+
+- Stratify by instrument and by Stage-1 taxonomy labels when available
+  (`low|mid|high|unknown`), plus explicit missing-regime stratum
+- Report metrics per stratum; no pooled-only claim of stability
+
+### 3.3 Train / calibration / validation separation
+
+- Disjoint time segments: train (optional exploratory), calibration (threshold
+  proposal), validation (locked evaluation)
+- No peeking validation labels into calibration selection
+- Hold out at least one forward validation segment
+
+### 3.4 Walk-forward evaluation
+
+- Rolling or expanding walk-forward folds with frozen Stage-1 definitions
+- Publish fold-level primary metrics and threshold candidates
+- Fail closed if fold digests are incomplete
+
+### 3.5 Bootstrap or Monte-Carlo confidence intervals
+
+- Resample paths or fold residuals under a documented seed and method ID
+- Report interval estimates for primary safety metrics
+- Seed + method ID recorded in Evidence
+
+### 3.6 Stress cases
+
+Mandatory stress packs (documented, versioned):
+
+- Observation gaps / missing bars
+- Staleness near and beyond candidate freshness ages
+- Spread expansion / crossed book
+- Volatility shocks (high realized vol / ATR)
+- Liquidation near-miss path families
+- Chop / rapid switch clusters (for sequence metrics)
+
+### 3.7 Sensitivity analysis per threshold
+
+- For each candidate token, vary the proposed number across a documented grid
+- Record how primary safety metrics move
+- Identify brittle cliffs (small Δthreshold → large ΔFalse-Allow)
+
+### 3.8 Stability across instruments and time segments
+
+- Require qualitative consistency of safety ranking across instruments and
+  walk-forward folds
+- Instability → candidate rejected (not auto-averaged into production)
+
+### 3.9 No isolated Sharpe / profit optimization
+
+Forbidden objective as sole selection criterion:
+
+```text
+maximize Sharpe
+maximize profit
+maximize trade count
+```
+
+Economic metrics are **secondary** and may only break ties among candidates that
+already pass primary safety gates.
+
+### 3.10 Primary safety metrics
+
+```text
+block_allow_rate
+false_allow_rate
+false_block_rate
+path_survival
+early_loss_toxicity
+liquidation_near_miss_rate
+governance_breach_frequency
+effective_leverage
+liquidation_buffer
+adverse_fill_loss
+```
+
+Definitions of these metrics in a calibration run must reference Stage-1 sequence
+and arithmetic projection IDs where applicable.
+
+### 3.11 Secondary economic metrics
+
+```text
+profit_factor
+max_drawdown
+turnover
+fees
+slippage
+opportunity_cost
+```
+
+Secondary only; cannot override failed primary safety gates.
+
+### 3.12 Explicit out-of-sample acceptance criteria
+
+Each calibration Evidence pack must declare machine-readable acceptance rules,
+for example (illustrative structure — **not** productive thresholds):
+
+```text
+ACCEPT_IF:
+  validation.false_allow_rate <= DECLARED_MAX_FALSE_ALLOW
+  validation.path_survival_ci_lower >= DECLARED_MIN_PATH_SURVIVAL_CI
+  stress_pack.all_required_cases_executed = true
+  stage1_definition_digests_match = true
+ELSE:
+  REJECT_FAIL_CLOSED
+```
+
+The numeric `DECLARED_*` acceptance bounds used **inside a calibration pack**
+are Evidence hyperparameters for that pack only. They are **not** productive
+Owner Values and do not set `OWNER_VALUE_*` tokens.
+
+### 3.13 Separate Owner decision per productive number
+
+Promotion path:
+
+```text
+Calibration Evidence (shadow)
+  → per-token Owner decision record
+  → productive config bind (separate PR / GO)
+  → only then may INPUT_AUTHORITY considerations be revisited
+```
+
+No batch silent promotion. `REINVEST_FRACTION` still derives only from signed-off
+`CASHFLOW_LOCK_FRACTION`.
+
+### 3.14 Full audit trail
+
+Every Evidence pack must include:
+
+```text
+config_digest
+code_sha
+structural_manifest_digest
+stage1_definition_id_set
+dataset_provenance_digest
+seed_and_method_ids
+fold_digests
+candidate_token_values (proposed only)
+acceptance_verdict
+operator_notes
+NO_ORDER_PROOF=true
+```
+
+## 4. Freshness calibration special rule
+
+`OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS`:
+
+- Calibrate against Futures Input readiness / safety outcomes
+- Must not reuse or imply CMC Numeric-Max-Age Alpha enforcement
+- Demoted CMC max-age research remains non-authorizing for this token
+
+## 5. Capital-slot calibration special rules
+
+- `INITIAL_SLOT_BASE` must not be remapped from ambient account equity
+- `MIN_REALIZED_VOLATILITY` / `MIN_ATR_OR_RANGE` / `MIN_OPPORTUNITY_SCORE` must use
+  Stage-1 units/scales exactly
+- `MAX_TIME_WITHOUT_CASHFLOW_STEP` counts `SOLE_TRADING_AUTHORITY_CYCLE_INDEX`
+  quanta
+- `PROFIT_STEP_PCT` and `CASHFLOW_LOCK_FRACTION` are economic policy; secondary
+  metrics may inform but primary safety gates dominate
+
+## 6. Survival-limit calibration special rules
+
+- Comparison operators remain those ratified in the parent Input Authorities
+  ratification (not recalibrated)
+- Metric functionals remain Stage-1 definition IDs
+- Kernel projection must reuse the canonical futures accounting kernel candidate;
+  no parallel kernel
+
+## 7. Fail-closed defaults for this protocol
+
+```text
+IF stage1_defs_missing OR provenance_incomplete OR oos_fail OR stress_incomplete:
+  CANDIDATE_STATUS=REJECTED
+  PRODUCTIVE_NUMERIC_VALUE=null
+  INPUT_AUTHORITY_UNCHANGED=false_flags_remain
+```
+
+## 8. Explicit non-authorization
+
+```text
+SHADOW_ONLY=true
+PRODUCTIVE_CONFIG_WRITE=UNAUTHORIZED
+INPUT_AUTHORITY_FLIP=UNAUTHORIZED
+ORDERS=UNAUTHORIZED
+LIVE=UNAUTHORIZED
+TESTNET=UNAUTHORIZED
+ARCHIVE_AUTHORITY_MUTATION=UNAUTHORIZED
+DASHBOARD_AUTHORITY_EFFECT=NONE
+AUTO_PROMOTION=UNAUTHORIZED
+```
+
+## 9. References
+
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_OWNER_VALUES_TWO_STAGE_RATIFICATION_V1.md`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_INPUT_AUTHORITIES_OWNER_RATIFICATION_V1.md`
+- `docs&#47;runbooks&#47;canonical&#47;PEAK_TRADE_MASTER_RUNBOOK.md`

--- a/docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json
+++ b/docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json
@@ -1,0 +1,262 @@
+{
+  "schema_name": "productive_pure_stack_owner_values_structural_manifest",
+  "schema_version": "productive_pure_stack_owner_values_structural_manifest/v1",
+  "document_class": "OWNER_VALUES_TWO_STAGE_CLASSIFICATION_MANIFEST",
+  "status": "STAGE1_STRUCTURAL_RATIFIED_STAGE2_CALIBRATION_PROTOCOL_ONLY",
+  "baseline_origin_main_sha": "631dca43601e4efad53a35c19ddf9bf70ebfd177",
+  "parent_ratification": "docs/ops/PRODUCTIVE_PURE_STACK_INPUT_AUTHORITIES_OWNER_RATIFICATION_V1.md",
+  "two_stage_ratification_doc": "docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_TWO_STAGE_RATIFICATION_V1.md",
+  "calibration_protocol_doc": "docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md",
+  "sole_trading_authority": "run_integrated_offline_trading_logic_replay_v1",
+  "dashboard_role": "READ_ONLY_CONSUMER",
+  "resultv1_mapping_authorized": false,
+  "new_trading_authority_authorized": false,
+  "input_authority_all_false": true,
+  "productive_numeric_values_set": 0,
+  "runtime_implemented": false,
+  "cmc_volatility_estimate_as_realized_volatility": false,
+  "fixture_scenario_webui_as_authority": false,
+  "token_count": 34,
+  "category_counts": {
+    "STRUCTURAL_RATIFIED": 15,
+    "MECHANICALLY_COUPLED": 1,
+    "NUMERIC_CALIBRATION_REQUIRED": 18,
+    "DEFERRED_FAIL_CLOSED": 0
+  },
+  "allowed_categories": [
+    "STRUCTURAL_RATIFIED",
+    "MECHANICALLY_COUPLED",
+    "NUMERIC_CALIBRATION_REQUIRED",
+    "DEFERRED_FAIL_CLOSED"
+  ],
+  "tokens": [
+    {
+      "token": "OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "A_FRESHNESS",
+      "productive_numeric_value": null,
+      "notes": "Independent safety/readiness policy; not CMC numeric max-age alpha parameter"
+    },
+    {
+      "token": "OWNER_VALUE_REALIZED_VOLATILITY_HORIZON",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "B_REALIZED_VOL",
+      "structural_value": "PT60M",
+      "productive_numeric_value": null,
+      "bound_definition_id": "fps_realized_volatility.population_stdev_mark_log_returns.v1"
+    },
+    {
+      "token": "OWNER_VALUE_REALIZED_VOLATILITY_UNIT",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "B_REALIZED_VOL",
+      "structural_value": "PER_BAR_DECIMAL_RETURN_VOLATILITY",
+      "productive_numeric_value": null,
+      "bound_definition_id": "fps_realized_volatility.population_stdev_mark_log_returns.v1",
+      "notes": "Unit name is Futures Pure-Stack authority; not CMC.volatility_estimate alias"
+    },
+    {
+      "token": "OWNER_VALUE_REALIZED_VOLATILITY_FORMULA_ID",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "B_REALIZED_VOL",
+      "structural_value": "fps_realized_volatility.population_stdev_mark_log_returns.v1",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_ATR_OR_RANGE_WINDOW",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "C_ATR_RANGE",
+      "structural_value": "14_PT1M_BARS",
+      "productive_numeric_value": null,
+      "bound_definition_id": "fps_atr_or_range.wilder_atr_finalized_ohlcv.v1"
+    },
+    {
+      "token": "OWNER_VALUE_ATR_OR_RANGE_UNIT",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "C_ATR_RANGE",
+      "structural_value": "PRICE_QUOTE_CURRENCY_UNITS",
+      "productive_numeric_value": null,
+      "bound_definition_id": "fps_atr_or_range.wilder_atr_finalized_ohlcv.v1"
+    },
+    {
+      "token": "OWNER_VALUE_ATR_OR_RANGE_FORMULA_ID",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "C_ATR_RANGE",
+      "structural_value": "fps_atr_or_range.wilder_atr_finalized_ohlcv.v1",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_VOLATILITY_REGIME_TAXONOMY_ID",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "D_REGIME",
+      "structural_value": "fps_volatility_regime_taxonomy.v1",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_OPPORTUNITY_SCORE_SCALE",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "E_OPPORTUNITY",
+      "structural_value": "UNIT_INTERVAL_0_1",
+      "productive_numeric_value": null,
+      "bound_definition_id": "fps_opportunity_score.fee_slippage_breakeven_movement.v1"
+    },
+    {
+      "token": "OWNER_VALUE_OPPORTUNITY_SCORE_FORMULA_ID",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "E_OPPORTUNITY",
+      "structural_value": "fps_opportunity_score.fee_slippage_breakeven_movement.v1",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_ACTIVITY_OR_INACTIVITY_SCORE_FORMULA_ID",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "E_OPPORTUNITY",
+      "structural_value": "fps_activity_inactivity_score.range_volume_quiescence.v1",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_LIQUIDITY_SPREAD_SOURCE_FORMULA_ID",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "E_OPPORTUNITY",
+      "structural_value": "fps_liquidity_spread.best_bid_ask_mid_bps.v1",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "F_SEQUENCE",
+      "structural_value": "fps_sequence_path_survival_ratio.prearm_path_fraction.v1",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "F_SEQUENCE",
+      "structural_value": "fps_sequence_metric_set.double_play_survival_envelope_v0_fields.v1",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MIN_PATH_SURVIVAL_RATIO",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "G_SURVIVAL_LIMITS",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EARLY_LOSS_TOXICITY",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "G_SURVIVAL_LIMITS",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MIN_MARGIN_BUFFER_AT_RISK_99",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "G_SURVIVAL_LIMITS",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_SEQUENCE_FRAGILITY_INDEX",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "G_SURVIVAL_LIMITS",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_LIQUIDATION_NEAR_MISS_RATE",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "G_SURVIVAL_LIMITS",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_GOVERNANCE_BREACH_FREQUENCY",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "G_SURVIVAL_LIMITS",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MIN_CHOP_SWITCH_SURVIVAL_SCORE",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "G_SURVIVAL_LIMITS",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EFFECTIVE_LEVERAGE",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "G_SURVIVAL_LIMITS",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MIN_LIQUIDATION_BUFFER",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "G_SURVIVAL_LIMITS",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_ADVERSE_FILL_LOSS",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "G_SURVIVAL_LIMITS",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_STRATEGY_SIDE_DECLARATION_SCHEMA_ID",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "H_STRATEGY_SIDE",
+      "structural_value": "strategy_side_declaration.v1",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_PROFIT_STEP_PCT",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "I_CAPITAL_CONFIG",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "I_CAPITAL_CONFIG",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_REINVEST_FRACTION",
+      "category": "MECHANICALLY_COUPLED",
+      "group": "I_CAPITAL_CONFIG",
+      "coupling_rule": "1 - OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION",
+      "productive_numeric_value": null,
+      "notes": "No independent productive numeric; coupled after lock fraction Owner sign-off"
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_MIN_REALIZED_VOLATILITY",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "I_CAPITAL_CONFIG",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_MIN_ATR_OR_RANGE",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "I_CAPITAL_CONFIG",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "I_CAPITAL_CONFIG",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_TIME_QUANTUM",
+      "category": "STRUCTURAL_RATIFIED",
+      "group": "I_CAPITAL_CONFIG",
+      "structural_value": "SOLE_TRADING_AUTHORITY_CYCLE_INDEX",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_MIN_OPPORTUNITY_SCORE",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "I_CAPITAL_CONFIG",
+      "productive_numeric_value": null
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE",
+      "category": "NUMERIC_CALIBRATION_REQUIRED",
+      "group": "J_CAPITAL_STATE",
+      "productive_numeric_value": null
+    }
+  ]
+}

--- a/docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_TWO_STAGE_RATIFICATION_V1.md
+++ b/docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_TWO_STAGE_RATIFICATION_V1.md
@@ -1,0 +1,360 @@
+# Productive Pure-Stack Owner Values — Two-Stage Ratification v1
+
+```text
+DOCUMENT_TYPE=OWNER_VALUES_TWO_STAGE_RATIFICATION
+DOCUMENT_VERSION=1
+STATUS=STAGE1_STRUCTURAL_RATIFIED_STAGE2_CALIBRATION_PROTOCOL_ONLY
+BASELINE_ORIGIN_MAIN_SHA=631dca43601e4efad53a35c19ddf9bf70ebfd177
+PARENT_AUTHORITY_RATIFICATION=docs/ops/PRODUCTIVE_PURE_STACK_INPUT_AUTHORITIES_OWNER_RATIFICATION_V1.md
+STRUCTURAL_MANIFEST=docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json
+CALIBRATION_PROTOCOL=docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md
+
+SOLE_TRADING_AUTHORITY=run_integrated_offline_trading_logic_replay_v1
+DASHBOARD_ROLE=READ_ONLY_CONSUMER
+DASHBOARD_AUTHORITY_EFFECT=NONE
+RESULTV1_MAPPING_AUTHORIZED=false
+NEW_TRADING_AUTHORITY_AUTHORIZED=false
+INPUT_AUTHORITY_FUTURES_INPUT_SNAPSHOT=false
+INPUT_AUTHORITY_SURVIVAL_ENVELOPE=false
+INPUT_AUTHORITY_SUITABILITY_PROJECTION=false
+INPUT_AUTHORITY_CAPITAL_SLOT_CONFIG=false
+INPUT_AUTHORITY_CAPITAL_SLOT_STATE_INIT=false
+PRODUCTIVE_NUMERIC_VALUES_SET=0
+STAGE1_PRODUCERS_PRODUCTIVE_ACTIVATION=false
+RUNTIME_IMPLEMENTED=false
+RUNTIME_AUTHORIZATION_EFFECT=NONE
+LIVE_ORDERS=false
+TESTNET_ORDERS=false
+PAPER_EXCHANGE_ORDERS=false
+EXCHANGE_CREDENTIAL_USE=false
+REAL_CAPITAL_MOVEMENT=false
+ARCHIVE_MUTATIONS=false
+CMC_VOLATILITY_ESTIMATE_AS_REALIZED_VOLATILITY=false
+FIXTURE_SCENARIO_WEBUI_AS_AUTHORITY=false
+```
+
+## 0. Purpose
+
+This document is the Owner two-stage ratification for the 34
+`OWNER_VALUE_*` tokens named in
+`PRODUCTIVE_PURE_STACK_INPUT_AUTHORITIES_OWNER_RATIFICATION_V1.md`.
+
+**Stage 1** ratifies only semantic and structural authorities: observation
+identity, formulas, units, horizons/windows, taxonomy IDs, score scales and
+definitions, sequence-metric definitions, strategy-side schema, capital-slot
+time quantum, and the cashflow reinvest mechanical coupling.
+
+**Stage 2** does **not** set productive numeric thresholds. It binds the
+no-order, fail-closed, reproducible shadow calibration protocol in
+`PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md`. Calibration
+outputs remain Evidence until a **separate** Owner sign-off promotes each
+number into productive config.
+
+## 1. Non-negotiable invariants
+
+```text
+INV_NO_INVENTED_PRODUCTIVE_NUMERIC_THRESHOLDS=true
+INV_NO_CMC_VOLATILITY_AS_REALIZED_VOLATILITY=true
+INV_NO_RESULTV1_MAPPING=true
+INV_NO_FIXTURE_SCENARIO_WEBUI_AUTHORITY=true
+INV_DASHBOARD_READ_ONLY_CONSUMER=true
+INV_SOLE_TRADING_AUTHORITY_ONLY=true
+INV_INPUT_AUTHORITY_REMAINS_FALSE=true
+INV_STAGE1_PRODUCERS_NOT_PRODUCTIVELY_ACTIVATED=true
+INV_NO_ORDERS_TESTNET_LIVE=true
+INV_NO_AUTO_PROMOTION_OF_CALIBRATION_OUTPUTS=true
+INV_MISSING_OR_INVALID_FAIL_CLOSED=true
+INV_FRESHNESS_INDEPENDENT_OF_CMC_NUMERIC_MAX_AGE=true
+```
+
+## 2. Classification summary
+
+Machine-authoritative classification lives in
+`docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json`.
+
+| Category | Count | Meaning |
+|---|---:|---|
+| `STRUCTURAL_RATIFIED` | 15 | Stage-1 identifiers and structural parameters ratified here |
+| `MECHANICALLY_COUPLED` | 1 | `REINVEST_FRACTION = 1 - CASHFLOW_LOCK_FRACTION` |
+| `NUMERIC_CALIBRATION_REQUIRED` | 18 | Stage-2 calibration; productive number null |
+| `DEFERRED_FAIL_CLOSED` | 0 | Unused in this revision |
+
+```text
+TOKEN_COUNT=34
+PRODUCTIVE_NUMERIC_VALUES_SET=0
+```
+
+## 3. Forbidden sources (unchanged)
+
+```text
+FORBIDDEN_CMC_VOLATILITY_ESTIMATE_AS_REALIZED_VOLATILITY
+FORBIDDEN_RESULTV1_TO_PURE_STACK_MAPPING
+FORBIDDEN_DASHBOARD_PRESENTATION_AS_AUTHORITY
+FORBIDDEN_FIXTURE_SCENARIO_WEBUI_THRESHOLDS_AS_PRODUCTIVE_LAW
+FORBIDDEN_SYNTHETIC_DEFAULT_SCALARS
+FORBIDDEN_PARALLEL_TRADING_AUTHORITY
+FORBIDDEN_AUTO_PROMOTION_CALIBRATION_TO_CONFIG
+```
+
+---
+
+## 4. Stage 1 — Structural ratification
+
+All Stage-1 producers remain **unauthorized for productive activation**.
+Definitions may later be implemented under Sole Trading Authority only after
+a separate GO that still keeps `INPUT_AUTHORITY_*=false` until numeric Stage-2
+sign-off and binding are complete.
+
+Observation identity (all Stage-1 market formulas):
+
+```text
+OBSERVATION_FAMILY=PUBLIC_MARKET_FINALIZED_BARS
+BAR_INTERVAL=PT1M
+POINT_IN_TIME_ONLY=true
+NO_LOOKAHEAD=true
+NO_IMPLICIT_FILL=true
+PROVENANCE_REQUIRED=true
+SOLE_CONSUMER_AUTHORITY=run_integrated_offline_trading_logic_replay_v1
+```
+
+### 4.1 Realized volatility (Futures Pure-Stack; not CMC)
+
+```text
+OWNER_VALUE_REALIZED_VOLATILITY_FORMULA_ID=fps_realized_volatility.population_stdev_mark_log_returns.v1
+OWNER_VALUE_REALIZED_VOLATILITY_UNIT=PER_BAR_DECIMAL_RETURN_VOLATILITY
+OWNER_VALUE_REALIZED_VOLATILITY_HORIZON=PT60M
+```
+
+**Definition (versioned):**
+
+- Price field: venue `mark_price` on finalized PT1M bars only.
+- Return: `ln(mark_price_t / mark_price_t_minus_1)`.
+- Estimator: population standard deviation of the last 60 contiguous log returns
+  (`ddof=0`) ending at observation `t`.
+- Warmup: 61 valid prices / 60 returns; else `NULL` fail-closed.
+- Annualization: `NONE` (not annualized).
+- Output: dimensionless per-bar decimal return volatility.
+
+**Non-alias declaration:**
+
+```text
+CMC.volatility_estimate != FuturesVolatilityProfile.realized_volatility
+CMC.canonical_volatility_estimate != FuturesVolatilityProfile.realized_volatility
+fps_realized_volatility.population_stdev_mark_log_returns.v1
+  IS_NOT_A_BINDING_TO_canonical_volatility_estimate_feature_contract/v1
+```
+
+Shared mathematical resemblance to the CMC feature contract, if any, does
+**not** create identity, binding, or authority transfer.
+
+### 4.2 ATR / range
+
+```text
+OWNER_VALUE_ATR_OR_RANGE_FORMULA_ID=fps_atr_or_range.wilder_atr_finalized_ohlcv.v1
+OWNER_VALUE_ATR_OR_RANGE_UNIT=PRICE_QUOTE_CURRENCY_UNITS
+OWNER_VALUE_ATR_OR_RANGE_WINDOW=14_PT1M_BARS
+```
+
+**Definition:**
+
+- Input: finalized PT1M OHLCV for the selected instrument with provenance.
+- True range at `t`:
+  `max(high_t - low_t, abs(high_t - close_{t-1}), abs(low_t - close_{t-1}))`.
+- ATR: Wilder recursive average over window `N=14` PT1M bars.
+- Warmup incomplete → `NULL` fail-closed.
+- Unit: price in the instrument quote currency (not percent, not annualized).
+
+### 4.3 Volatility regime taxonomy
+
+```text
+OWNER_VALUE_VOLATILITY_REGIME_TAXONOMY_ID=fps_volatility_regime_taxonomy.v1
+```
+
+**Allowed labels (closed set):**
+
+```text
+low | mid | high | unknown
+```
+
+**Assignment rule (structural only; no productive numeric cut-points here):**
+
+- Labels may be attached only by a Sole-Trading-Authority-authorized producer
+  that documents its cut-point digest.
+- Cut-points themselves are **not** productive Owner Values in this PR and must
+  remain fail-closed / Evidence-only until a separate numeric Owner sign-off.
+- Until cut-points exist: emit `unknown` or omit regime (`None`) → downstream
+  volatility completeness rules apply.
+- Dashboard regime presentation is non-authoritative and must not feed this
+  taxonomy.
+
+### 4.4 Opportunity / activity / liquidity
+
+```text
+OWNER_VALUE_OPPORTUNITY_SCORE_SCALE=UNIT_INTERVAL_0_1
+OWNER_VALUE_OPPORTUNITY_SCORE_FORMULA_ID=fps_opportunity_score.fee_slippage_breakeven_movement.v1
+OWNER_VALUE_ACTIVITY_OR_INACTIVITY_SCORE_FORMULA_ID=fps_activity_inactivity_score.range_volume_quiescence.v1
+OWNER_VALUE_LIQUIDITY_SPREAD_SOURCE_FORMULA_ID=fps_liquidity_spread.best_bid_ask_mid_bps.v1
+```
+
+**Opportunity score (`fps_opportunity_score.fee_slippage_breakeven_movement.v1`):**
+
+- Scale: `[0, 1]` (`UNIT_INTERVAL_0_1`).
+- Semantic: monotonic transform of recent movement relative to an explicit
+  fee+slippage breakeven band derived from instrument metadata and ratified
+  fee/slippage model inputs under Sole Trading Authority.
+- Missing fee/slippage/movement inputs → `NULL` fail-closed (no default `0`).
+- Not a trade signal; not selector authority.
+
+**Activity / inactivity (`fps_activity_inactivity_score.range_volume_quiescence.v1`):**
+
+- Scale: `[0, 1]` where higher means more inactivity / quiescence.
+- Semantic: combine short-horizon range compression and quote-volume quiescence
+  on finalized PT1M bars with provenance.
+- Missing inputs → `NULL` fail-closed.
+
+**Liquidity spread (`fps_liquidity_spread.best_bid_ask_mid_bps.v1`):**
+
+- `spread_bps = 1e4 * (best_ask - best_bid) / mid` with `mid = (best_bid + best_ask) / 2`.
+- Requires explicit best bid/ask observation identity and freshness.
+- Invalid/crossed/missing book → fail-closed incomplete liquidity profile.
+- Not a dashboard ticker label authority.
+
+### 4.5 Sequence survival metric definitions
+
+```text
+OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID=fps_sequence_path_survival_ratio.prearm_path_fraction.v1
+OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID=fps_sequence_metric_set.double_play_survival_envelope_v0_fields.v1
+```
+
+**Metric set (`fps_sequence_metric_set.double_play_survival_envelope_v0_fields.v1`):**
+
+Exactly the pure DTO fields of `SequenceSurvivalMetrics` in
+`src&#47;trading&#47;master_v2&#47;double_play_survival.py`:
+
+```text
+path_survival_ratio
+early_loss_toxicity
+margin_buffer_at_risk_99
+sequence_fragility_index
+liquidation_near_miss_rate
+governance_breach_frequency
+chop_switch_survival_score
+```
+
+**Path survival ratio (`fps_sequence_path_survival_ratio.prearm_path_fraction.v1`):**
+
+- Fraction of pre-arm evaluated stress paths that remain above the governed
+  ruin/liquidation barrier for the shared Long/Short pair under the arithmetic
+  kernel projection.
+- Path ensemble identity must be version-digested; hot-path heavy recompute is
+  forbidden.
+- Numeric acceptance thresholds remain Stage-2 (`OWNER_VALUE_SURVIVAL_LIMIT_*`).
+
+### 4.6 Strategy side declaration schema
+
+```text
+OWNER_VALUE_STRATEGY_SIDE_DECLARATION_SCHEMA_ID=strategy_side_declaration.v1
+```
+
+**Required artifact fields:**
+
+| Field | Type | Rule |
+|---|---|---|
+| `schema_id` | string | must equal `strategy_side_declaration.v1` |
+| `strategy_id` | string | opaque non-empty |
+| `declared_side` | enum | exactly `SideCompatibility`: `long_bull`, `short_bear`, `both`, `neutral_range`, `unknown` |
+| `explicit_side_evidence` | bool | must be explicit; names/registry/dashboard must not set it |
+| `declaration_digest` | string | non-empty content digest |
+| `schema_version` | string | `v1` |
+
+Forbidden inference sources: strategy name, family label, ECM/Armstrong surface,
+dashboard label, AI summary, registry label alone.
+
+### 4.7 Capital-slot time quantum
+
+```text
+OWNER_VALUE_CAPITAL_SLOT_TIME_QUANTUM=SOLE_TRADING_AUTHORITY_CYCLE_INDEX
+```
+
+**Meaning:** one quantum equals one Sole Trading Authority cycle index increment
+for the selected future. `time_without_cashflow_step` counts these quanta.
+Wallclock seconds are not the quantum unless a later Owner revision changes this
+ID.
+
+### 4.8 Cashflow reinvest mechanical coupling
+
+```text
+OWNER_VALUE_CAPITAL_SLOT_REINVEST_FRACTION
+CATEGORY=MECHANICALLY_COUPLED
+COUPLING_RULE=1 - OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION
+```
+
+- No independent productive numeric is ratified for reinvest.
+- After Stage-2 Owner sign-off of `CASHFLOW_LOCK_FRACTION`, reinvest must be set
+  exclusively by the coupling rule (eps per `cashflow_split_valid`).
+- Independent reinvest values are invalid and fail closed.
+
+---
+
+## 5. Stage 2 — Numeric calibration required (no productive numbers)
+
+The following tokens remain `productive_numeric_value=null` and
+`NUMERIC_CALIBRATION_REQUIRED`. Calibration must use Stage-1 definitions only
+and follow
+`docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md`.
+
+```text
+OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS
+OWNER_VALUE_SURVIVAL_LIMIT_MIN_PATH_SURVIVAL_RATIO
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_EARLY_LOSS_TOXICITY
+OWNER_VALUE_SURVIVAL_LIMIT_MIN_MARGIN_BUFFER_AT_RISK_99
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_SEQUENCE_FRAGILITY_INDEX
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_LIQUIDATION_NEAR_MISS_RATE
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_GOVERNANCE_BREACH_FREQUENCY
+OWNER_VALUE_SURVIVAL_LIMIT_MIN_CHOP_SWITCH_SURVIVAL_SCORE
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_EFFECTIVE_LEVERAGE
+OWNER_VALUE_SURVIVAL_LIMIT_MIN_LIQUIDATION_BUFFER
+OWNER_VALUE_SURVIVAL_LIMIT_MAX_ADVERSE_FILL_LOSS
+OWNER_VALUE_CAPITAL_SLOT_PROFIT_STEP_PCT
+OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION
+OWNER_VALUE_CAPITAL_SLOT_MIN_REALIZED_VOLATILITY
+OWNER_VALUE_CAPITAL_SLOT_MIN_ATR_OR_RANGE
+OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP
+OWNER_VALUE_CAPITAL_SLOT_MIN_OPPORTUNITY_SCORE
+OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE
+```
+
+**Freshness note:** `OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS` is an
+independent Futures Input safety/readiness policy. It is **not** the demoted
+CMC Numeric-Max-Age Alpha parameter (`VOLATILITY_NUMERIC_MAX_AGE_ENFORCING=false`).
+
+Calibration Evidence must not become productive config without a **separate**
+Owner decision **per token**.
+
+## 6. Explicit non-authorization
+
+```text
+PRODUCTIVE_EMISSION_AUTHORIZED=false
+STAGE1_PRODUCER_PRODUCTIVE_ACTIVATION=false
+INPUT_AUTHORITY_FLIP=UNAUTHORIZED
+NUMERIC_PRODUCTIVE_CONFIG_WRITE=UNAUTHORIZED
+ORDERS=UNAUTHORIZED
+LIVE=UNAUTHORIZED
+TESTNET=UNAUTHORIZED
+ARCHIVE_MUTATION=UNAUTHORIZED
+DASHBOARD_MUTATION=UNAUTHORIZED
+RESULTV1_MAPPING=UNAUTHORIZED
+CMC_ALIAS_BINDING=UNAUTHORIZED
+```
+
+## 7. References
+
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_INPUT_AUTHORITIES_OWNER_RATIFICATION_V1.md`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_DISPLAY_DECISION_HOST_BINDING_V1_OPTION_A_OWNER_RATIFICATION_V1.md`
+- `src&#47;trading&#47;master_v2&#47;double_play_futures_input.py`
+- `src&#47;trading&#47;master_v2&#47;double_play_survival.py`
+- `src&#47;trading&#47;master_v2&#47;double_play_suitability.py`
+- `src&#47;trading&#47;master_v2&#47;double_play_capital_slot.py`
+- `src&#47;ops&#47;productive_pure_stack_display_decision_host_binding_v1&#47;constants_v1.py`

--- a/docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_TWO_STAGE_RATIFICATION_V1.md
+++ b/docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_TWO_STAGE_RATIFICATION_V1.md
@@ -128,7 +128,7 @@ OWNER_VALUE_REALIZED_VOLATILITY_HORIZON=PT60M
 **Definition (versioned):**
 
 - Price field: venue `mark_price` on finalized PT1M bars only.
-- Return: `ln(mark_price_t / mark_price_t_minus_1)`.
+- Return: `ln(mark_price_t &#47; mark_price_t_minus_1)`.
 - Estimator: population standard deviation of the last 60 contiguous log returns
   (`ddof=0`) ending at observation `t`.
 - Warmup: 61 valid prices / 60 returns; else `NULL` fail-closed.
@@ -214,7 +214,8 @@ OWNER_VALUE_LIQUIDITY_SPREAD_SOURCE_FORMULA_ID=fps_liquidity_spread.best_bid_ask
 
 **Liquidity spread (`fps_liquidity_spread.best_bid_ask_mid_bps.v1`):**
 
-- `spread_bps = 1e4 * (best_ask - best_bid) / mid` with `mid = (best_bid + best_ask) / 2`.
+- `spread_bps = 1e4 * (best_ask - best_bid) &#47; mid` with
+  `mid = (best_bid + best_ask) &#47; 2`.
 - Requires explicit best bid/ask observation identity and freshness.
 - Invalid/crossed/missing book → fail-closed incomplete liquidity profile.
 - Not a dashboard ticker label authority.

--- a/tests/ops/test_productive_pure_stack_owner_values_two_stage_ratification_v1.py
+++ b/tests/ops/test_productive_pure_stack_owner_values_two_stage_ratification_v1.py
@@ -1,0 +1,278 @@
+"""Static contract: Pure-Stack Owner Values two-stage ratification v1.
+
+Docs/manifest-only. Non-authorizing. No runtime, orders, archive, or dashboard mutation.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_OPS = REPO_ROOT / "docs" / "ops"
+
+TWO_STAGE = DOCS_OPS / "PRODUCTIVE_PURE_STACK_OWNER_VALUES_TWO_STAGE_RATIFICATION_V1.md"
+CALIBRATION = DOCS_OPS / "PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md"
+MANIFEST = DOCS_OPS / "PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json"
+PARENT = DOCS_OPS / "PRODUCTIVE_PURE_STACK_INPUT_AUTHORITIES_OWNER_RATIFICATION_V1.md"
+HOST_CONSTANTS = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "productive_pure_stack_display_decision_host_binding_v1"
+    / "constants_v1.py"
+)
+
+ALLOWED_CATEGORIES = frozenset(
+    {
+        "STRUCTURAL_RATIFIED",
+        "MECHANICALLY_COUPLED",
+        "NUMERIC_CALIBRATION_REQUIRED",
+        "DEFERRED_FAIL_CLOSED",
+    }
+)
+
+EXPECTED_TOKENS: tuple[str, ...] = (
+    "OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS",
+    "OWNER_VALUE_REALIZED_VOLATILITY_HORIZON",
+    "OWNER_VALUE_REALIZED_VOLATILITY_UNIT",
+    "OWNER_VALUE_REALIZED_VOLATILITY_FORMULA_ID",
+    "OWNER_VALUE_ATR_OR_RANGE_WINDOW",
+    "OWNER_VALUE_ATR_OR_RANGE_UNIT",
+    "OWNER_VALUE_ATR_OR_RANGE_FORMULA_ID",
+    "OWNER_VALUE_VOLATILITY_REGIME_TAXONOMY_ID",
+    "OWNER_VALUE_OPPORTUNITY_SCORE_SCALE",
+    "OWNER_VALUE_OPPORTUNITY_SCORE_FORMULA_ID",
+    "OWNER_VALUE_ACTIVITY_OR_INACTIVITY_SCORE_FORMULA_ID",
+    "OWNER_VALUE_LIQUIDITY_SPREAD_SOURCE_FORMULA_ID",
+    "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+    "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_PATH_SURVIVAL_RATIO",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EARLY_LOSS_TOXICITY",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_MARGIN_BUFFER_AT_RISK_99",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_SEQUENCE_FRAGILITY_INDEX",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_LIQUIDATION_NEAR_MISS_RATE",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_GOVERNANCE_BREACH_FREQUENCY",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_CHOP_SWITCH_SURVIVAL_SCORE",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EFFECTIVE_LEVERAGE",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_LIQUIDATION_BUFFER",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_ADVERSE_FILL_LOSS",
+    "OWNER_VALUE_STRATEGY_SIDE_DECLARATION_SCHEMA_ID",
+    "OWNER_VALUE_CAPITAL_SLOT_PROFIT_STEP_PCT",
+    "OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION",
+    "OWNER_VALUE_CAPITAL_SLOT_REINVEST_FRACTION",
+    "OWNER_VALUE_CAPITAL_SLOT_MIN_REALIZED_VOLATILITY",
+    "OWNER_VALUE_CAPITAL_SLOT_MIN_ATR_OR_RANGE",
+    "OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP",
+    "OWNER_VALUE_CAPITAL_SLOT_TIME_QUANTUM",
+    "OWNER_VALUE_CAPITAL_SLOT_MIN_OPPORTUNITY_SCORE",
+    "OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE",
+)
+
+STRUCTURAL_EXPECTED: frozenset[str] = frozenset(
+    {
+        "OWNER_VALUE_REALIZED_VOLATILITY_HORIZON",
+        "OWNER_VALUE_REALIZED_VOLATILITY_UNIT",
+        "OWNER_VALUE_REALIZED_VOLATILITY_FORMULA_ID",
+        "OWNER_VALUE_ATR_OR_RANGE_WINDOW",
+        "OWNER_VALUE_ATR_OR_RANGE_UNIT",
+        "OWNER_VALUE_ATR_OR_RANGE_FORMULA_ID",
+        "OWNER_VALUE_VOLATILITY_REGIME_TAXONOMY_ID",
+        "OWNER_VALUE_OPPORTUNITY_SCORE_SCALE",
+        "OWNER_VALUE_OPPORTUNITY_SCORE_FORMULA_ID",
+        "OWNER_VALUE_ACTIVITY_OR_INACTIVITY_SCORE_FORMULA_ID",
+        "OWNER_VALUE_LIQUIDITY_SPREAD_SOURCE_FORMULA_ID",
+        "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+        "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID",
+        "OWNER_VALUE_STRATEGY_SIDE_DECLARATION_SCHEMA_ID",
+        "OWNER_VALUE_CAPITAL_SLOT_TIME_QUANTUM",
+    }
+)
+
+NUMERIC_EXPECTED: frozenset[str] = frozenset(
+    {
+        "OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS",
+        "OWNER_VALUE_SURVIVAL_LIMIT_MIN_PATH_SURVIVAL_RATIO",
+        "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EARLY_LOSS_TOXICITY",
+        "OWNER_VALUE_SURVIVAL_LIMIT_MIN_MARGIN_BUFFER_AT_RISK_99",
+        "OWNER_VALUE_SURVIVAL_LIMIT_MAX_SEQUENCE_FRAGILITY_INDEX",
+        "OWNER_VALUE_SURVIVAL_LIMIT_MAX_LIQUIDATION_NEAR_MISS_RATE",
+        "OWNER_VALUE_SURVIVAL_LIMIT_MAX_GOVERNANCE_BREACH_FREQUENCY",
+        "OWNER_VALUE_SURVIVAL_LIMIT_MIN_CHOP_SWITCH_SURVIVAL_SCORE",
+        "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EFFECTIVE_LEVERAGE",
+        "OWNER_VALUE_SURVIVAL_LIMIT_MIN_LIQUIDATION_BUFFER",
+        "OWNER_VALUE_SURVIVAL_LIMIT_MAX_ADVERSE_FILL_LOSS",
+        "OWNER_VALUE_CAPITAL_SLOT_PROFIT_STEP_PCT",
+        "OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION",
+        "OWNER_VALUE_CAPITAL_SLOT_MIN_REALIZED_VOLATILITY",
+        "OWNER_VALUE_CAPITAL_SLOT_MIN_ATR_OR_RANGE",
+        "OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP",
+        "OWNER_VALUE_CAPITAL_SLOT_MIN_OPPORTUNITY_SCORE",
+        "OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE",
+    }
+)
+
+FORBIDDEN_AUTHORITY_CLAIMS: tuple[str, ...] = (
+    "CMC.volatility_estimate = FuturesVolatilityProfile.realized_volatility",
+    "CMC_VOLATILITY_ESTIMATE_AS_REALIZED_VOLATILITY=true",
+    "RESULTV1_MAPPING_AUTHORIZED=true",
+    "INPUT_AUTHORITY_FUTURES_INPUT_SNAPSHOT=true",
+    "FIXTURE_SCENARIO_WEBUI_AS_AUTHORITY=true",
+    "PRODUCTIVE_NUMERIC_VALUES_SET=1",
+    "profit_step_pct=0.10 ratified productive",
+    "min_path_survival_ratio=0.5 ratified productive",
+)
+
+
+def _load_manifest() -> dict:
+    assert MANIFEST.is_file(), f"missing manifest: {MANIFEST}"
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_artifacts_exist_v1() -> None:
+    assert TWO_STAGE.is_file()
+    assert CALIBRATION.is_file()
+    assert MANIFEST.is_file()
+    assert PARENT.is_file()
+
+
+def test_exactly_34_tokens_classified_v1() -> None:
+    manifest = _load_manifest()
+    tokens = manifest["tokens"]
+    assert len(EXPECTED_TOKENS) == 34
+    assert int(manifest["token_count"]) == 34
+    assert len(tokens) == 34
+    names = [t["token"] for t in tokens]
+    assert names == list(EXPECTED_TOKENS)
+    assert len(set(names)) == 34
+
+
+def test_categories_exact_partition_v1() -> None:
+    manifest = _load_manifest()
+    by_cat: dict[str, list[str]] = {c: [] for c in ALLOWED_CATEGORIES}
+    for entry in manifest["tokens"]:
+        cat = entry["category"]
+        assert cat in ALLOWED_CATEGORIES
+        by_cat[cat].append(entry["token"])
+        assert "productive_numeric_value" in entry
+        assert entry["productive_numeric_value"] is None
+
+    assert set(by_cat["STRUCTURAL_RATIFIED"]) == STRUCTURAL_EXPECTED
+    assert by_cat["MECHANICALLY_COUPLED"] == ["OWNER_VALUE_CAPITAL_SLOT_REINVEST_FRACTION"]
+    assert set(by_cat["NUMERIC_CALIBRATION_REQUIRED"]) == NUMERIC_EXPECTED
+    assert by_cat["DEFERRED_FAIL_CLOSED"] == []
+    counts = manifest["category_counts"]
+    assert counts["STRUCTURAL_RATIFIED"] == 15
+    assert counts["MECHANICALLY_COUPLED"] == 1
+    assert counts["NUMERIC_CALIBRATION_REQUIRED"] == 18
+    assert counts["DEFERRED_FAIL_CLOSED"] == 0
+
+
+def test_reinvest_coupled_exclusively_from_lock_v1() -> None:
+    manifest = _load_manifest()
+    reinvest = next(
+        t for t in manifest["tokens"] if t["token"] == "OWNER_VALUE_CAPITAL_SLOT_REINVEST_FRACTION"
+    )
+    assert reinvest["category"] == "MECHANICALLY_COUPLED"
+    assert reinvest["coupling_rule"] == "1 - OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION"
+    assert reinvest["productive_numeric_value"] is None
+    two_stage = _read(TWO_STAGE)
+    assert "COUPLING_RULE=1 - OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION" in two_stage
+    assert "Independent reinvest values are invalid" in two_stage
+
+
+def test_no_fixture_scenario_webui_or_cmc_alias_ratified_v1() -> None:
+    two_stage = _read(TWO_STAGE)
+    calibration = _read(CALIBRATION)
+    manifest = _read(MANIFEST)
+    blob = "\n".join([two_stage, calibration, manifest])
+    for claim in FORBIDDEN_AUTHORITY_CLAIMS:
+        assert claim not in blob, f"forbidden claim present: {claim}"
+    assert "CMC_VOLATILITY_ESTIMATE_AS_REALIZED_VOLATILITY=false" in two_stage
+    assert "CMC.volatility_estimate != FuturesVolatilityProfile.realized_volatility" in two_stage
+    assert "FIXTURE_SCENARIO_WEBUI_AS_AUTHORITY=false" in two_stage
+    assert "Forbidden" in calibration or "FORBIDDEN" in calibration
+    assert "fixture" in calibration.lower()
+
+
+def test_no_productive_numeric_threshold_set_v1() -> None:
+    manifest = _load_manifest()
+    assert int(manifest["productive_numeric_values_set"]) == 0
+    for entry in manifest["tokens"]:
+        assert entry["productive_numeric_value"] is None
+    two_stage = _read(TWO_STAGE)
+    assert "PRODUCTIVE_NUMERIC_VALUES_SET=0" in two_stage
+    assert "STATUS=STAGE1_STRUCTURAL_RATIFIED_STAGE2_CALIBRATION_PROTOCOL_ONLY" in two_stage
+    calibration = _read(CALIBRATION)
+    assert "PRODUCTIVE_NUMERIC_VALUES_SET=0" in calibration
+    assert "AUTO_PROMOTION_TO_PRODUCTIVE_CONFIG=false" in calibration
+
+
+def test_input_authority_flags_remain_false_v1() -> None:
+    constants = _read(HOST_CONSTANTS)
+    for flag in (
+        "INPUT_AUTHORITY_FUTURES_INPUT_SNAPSHOT = False",
+        "INPUT_AUTHORITY_SURVIVAL_ENVELOPE = False",
+        "INPUT_AUTHORITY_SUITABILITY_PROJECTION = False",
+        "INPUT_AUTHORITY_CAPITAL_SLOT_CONFIG = False",
+        "INPUT_AUTHORITY_CAPITAL_SLOT_STATE_INIT = False",
+        "RESULTV1_MAPPING_AUTHORIZED = False",
+        'DASHBOARD_ROLE = "READ_ONLY_CONSUMER"',
+    ):
+        assert flag in constants, f"host constant drift: {flag}"
+    two_stage = _read(TWO_STAGE)
+    assert "INPUT_AUTHORITY_FUTURES_INPUT_SNAPSHOT=false" in two_stage
+    assert "RESULTV1_MAPPING_AUTHORIZED=false" in two_stage
+    assert "DASHBOARD_ROLE=READ_ONLY_CONSUMER" in two_stage
+    assert "STAGE1_PRODUCERS_PRODUCTIVE_ACTIVATION=false" in two_stage
+
+
+def test_parent_tokens_covered_exactly_v1() -> None:
+    parent = _read(PARENT)
+    parent_tokens = re.findall(r"^OWNER_VALUE_[A-Z0-9_]+$", parent, re.MULTILINE)
+    assert sorted(parent_tokens) == sorted(EXPECTED_TOKENS)
+    assert len(parent_tokens) == 34
+
+
+def test_calibration_protocol_required_elements_v1() -> None:
+    text = _read(CALIBRATION)
+    required = (
+        "Versioned dataset / observation provenance",
+        "Instrument and market-regime stratification",
+        "Train / calibration / validation separation",
+        "Walk-forward evaluation",
+        "Bootstrap or Monte-Carlo",
+        "Stress cases",
+        "Sensitivity analysis per threshold",
+        "Stability across instruments",
+        "No isolated Sharpe / profit optimization",
+        "Primary safety metrics",
+        "Secondary economic metrics",
+        "out-of-sample acceptance",
+        "Separate Owner decision per productive number",
+        "Full audit trail",
+        "false_allow_rate",
+        "path_survival",
+        "liquidation_near_miss_rate",
+        "ORDERS_ALLOWED=false",
+        "CMC Numeric-Max-Age",
+    )
+    for marker in required:
+        assert marker in text, f"missing calibration element: {marker}"
+
+
+def test_structural_values_documented_in_two_stage_doc_v1() -> None:
+    text = _read(TWO_STAGE)
+    manifest = _load_manifest()
+    for entry in manifest["tokens"]:
+        if entry["category"] != "STRUCTURAL_RATIFIED":
+            continue
+        value = entry["structural_value"]
+        assert value in text, f"structural value missing from doc: {value}"
+        assert entry["token"] in text


### PR DESCRIPTION
## Summary
- Stage 1: structural ratification of formulas, units, horizons/windows, taxonomy, score definitions, sequence metric defs, strategy-side schema, capital-slot time quantum, and reinvest mechanical coupling.
- Stage 2: no-order shadow calibration protocol for all numeric policy tokens; no productive numeric values set.
- Machine-readable manifest classifies all 34 `OWNER_VALUE_*` tokens; `INPUT_AUTHORITY` remains false; CMC≠realized_volatility; ResultV1 mapping remains forbidden.

## Test plan
- [x] `pytest tests/ops/test_productive_pure_stack_owner_values_two_stage_ratification_v1.py`
- [x] ruff format/check on touched Python
- [x] docs token policy + docs reference targets
- [x] selector `NO_OP`


Made with [Cursor](https://cursor.com)