### PR TITLE
docs(ops): Stage-2 numeric policy Evidence pack scaffolding v1

### DIFF
--- a/docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_CAMPAIGN_MANIFEST_V1.json
+++ b/docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_CAMPAIGN_MANIFEST_V1.json
@@ -1,0 +1,1269 @@
+{
+  "schema_version": "productive_pure_stack_numeric_policy_evidence_pack/v1",
+  "campaign_id": "productive_pure_stack_numeric_policy_calibration_campaign_v1",
+  "campaign_status": "NOT_STARTED",
+  "origin_main_sha": "80977448775bd4819cbeef9122364e6330d7100f",
+  "stage1_manifest_digest": "187cd375b3d3763de7d37c9f13d56f318ccd2987f1e57ab1db77c26169d862fe",
+  "calibration_protocol_digest": "3352a5f92ba67593409cd4bf4933dd43d6ae33d90b8a99ea15d0c88bd52f3b58",
+  "sole_trading_authority_symbol": "run_integrated_offline_trading_logic_replay_v1",
+  "observation_identity": {
+    "observation_family": "PUBLIC_MARKET_FINALIZED_BARS",
+    "bar_interval": "PT1M",
+    "point_in_time_only": true,
+    "no_lookahead": true,
+    "no_implicit_fill": true,
+    "provenance_required": true,
+    "sole_consumer_authority": "run_integrated_offline_trading_logic_replay_v1"
+  },
+  "producer_identity": {
+    "status": "SCAFFOLD_ONLY",
+    "productive_activation": false,
+    "allowed_producer_classes": [
+      "sole_trading_authority_shadow_calibration_producer"
+    ],
+    "forbidden_producer_classes": [
+      "fixture_scenario_scalar",
+      "webui_hardcoded_limit",
+      "dashboard_presentation_projection",
+      "cmc_volatility_estimate",
+      "SurvivalResultV1",
+      "SuitabilityResultV1",
+      "archive_authority_mutation",
+      "parallel_arithmetic_volatility_opportunity_kernel"
+    ]
+  },
+  "dataset_manifest": {
+    "status": "EMPTY_SCAFFOLD",
+    "populated": false,
+    "entries": [],
+    "digest": null,
+    "notes": "Stage-2 scaffolding only; no calibration dataset populated"
+  },
+  "train_calibration_validation_partition_manifest": {
+    "status": "EMPTY_SCAFFOLD",
+    "populated": false,
+    "entries": [],
+    "digest": null,
+    "notes": "Train/calibration/validation partitions not started"
+  },
+  "walk_forward_manifest": {
+    "status": "EMPTY_SCAFFOLD",
+    "populated": false,
+    "entries": [],
+    "digest": null,
+    "notes": "Walk-forward folds not started"
+  },
+  "bootstrap_monte_carlo_manifest": {
+    "status": "EMPTY_SCAFFOLD",
+    "populated": false,
+    "entries": [],
+    "digest": null,
+    "notes": "Bootstrap/Monte-Carlo not started"
+  },
+  "stress_pack_manifest": {
+    "status": "EMPTY_SCAFFOLD",
+    "populated": false,
+    "entries": [],
+    "digest": null,
+    "notes": "Stress packs not started"
+  },
+  "metric_definition_digests": {
+    "block_allow_rate": null,
+    "false_allow_rate": null,
+    "false_block_rate": null,
+    "path_survival": null,
+    "early_loss_toxicity": null,
+    "liquidation_near_miss_rate": null,
+    "governance_breach_frequency": null,
+    "effective_leverage": null,
+    "liquidation_buffer": null,
+    "adverse_fill_loss": null
+  },
+  "per_token_evidence": [
+    {
+      "token": "OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS",
+      "semantic_role": "Futures Input readiness/safety max age for provenance freshness_state; independent of CMC numeric max-age alpha",
+      "required_producer": "market_data_provenance_producer_feeding_FuturesMarketDataProvenanceStatus",
+      "required_observations": [
+        "public_market_finalized_pt1m_bars",
+        "futures_market_data_provenance_status",
+        "event_time_freshness_metadata"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "stale_unknown_block_rate"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "cmc_numeric_max_age_alpha_reuse",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "primary_safety_gate_fail",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_definition_digest_mismatch"
+      ],
+      "dependency_tokens": [],
+      "allowed_calibration_output_type": "THRESHOLD_SECONDS",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MIN_PATH_SURVIVAL_RATIO",
+      "semantic_role": "Minimum path survival ratio gate for DoublePlaySurvivalEnvelope",
+      "required_producer": "double_play_survival_envelope_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "sequence_metric_set_stage1",
+        "path_survival_ratio_stage1",
+        "canonical_futures_accounting_kernel_projection"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_definition_digest_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "survival_or_suitability_result_v1_as_numeric_authority",
+        "parallel_arithmetic_kernel"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+        "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_RATIO_UNIT_INTERVAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EARLY_LOSS_TOXICITY",
+      "semantic_role": "Maximum early loss toxicity gate for DoublePlaySurvivalEnvelope",
+      "required_producer": "double_play_survival_envelope_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "sequence_metric_set_stage1",
+        "path_survival_ratio_stage1",
+        "canonical_futures_accounting_kernel_projection"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_definition_digest_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "survival_or_suitability_result_v1_as_numeric_authority",
+        "parallel_arithmetic_kernel"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+        "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_RATIO_UNIT_INTERVAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MIN_MARGIN_BUFFER_AT_RISK_99",
+      "semantic_role": "Minimum margin buffer at risk 99 gate for DoublePlaySurvivalEnvelope",
+      "required_producer": "double_play_survival_envelope_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "sequence_metric_set_stage1",
+        "path_survival_ratio_stage1",
+        "canonical_futures_accounting_kernel_projection"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_definition_digest_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "survival_or_suitability_result_v1_as_numeric_authority",
+        "parallel_arithmetic_kernel"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+        "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_RATIO_UNIT_INTERVAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_SEQUENCE_FRAGILITY_INDEX",
+      "semantic_role": "Maximum sequence fragility index gate for DoublePlaySurvivalEnvelope",
+      "required_producer": "double_play_survival_envelope_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "sequence_metric_set_stage1",
+        "path_survival_ratio_stage1",
+        "canonical_futures_accounting_kernel_projection"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_definition_digest_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "survival_or_suitability_result_v1_as_numeric_authority",
+        "parallel_arithmetic_kernel"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+        "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_RATIO_UNIT_INTERVAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_LIQUIDATION_NEAR_MISS_RATE",
+      "semantic_role": "Maximum liquidation near-miss rate gate for DoublePlaySurvivalEnvelope",
+      "required_producer": "double_play_survival_envelope_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "sequence_metric_set_stage1",
+        "path_survival_ratio_stage1",
+        "canonical_futures_accounting_kernel_projection"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_definition_digest_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "survival_or_suitability_result_v1_as_numeric_authority",
+        "parallel_arithmetic_kernel"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+        "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_RATIO_UNIT_INTERVAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_GOVERNANCE_BREACH_FREQUENCY",
+      "semantic_role": "Maximum governance breach frequency gate for DoublePlaySurvivalEnvelope",
+      "required_producer": "double_play_survival_envelope_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "sequence_metric_set_stage1",
+        "path_survival_ratio_stage1",
+        "canonical_futures_accounting_kernel_projection"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_definition_digest_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "survival_or_suitability_result_v1_as_numeric_authority",
+        "parallel_arithmetic_kernel"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+        "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_RATIO_UNIT_INTERVAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MIN_CHOP_SWITCH_SURVIVAL_SCORE",
+      "semantic_role": "Minimum chop/switch survival score gate for DoublePlaySurvivalEnvelope",
+      "required_producer": "double_play_survival_envelope_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "sequence_metric_set_stage1",
+        "path_survival_ratio_stage1",
+        "canonical_futures_accounting_kernel_projection"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_definition_digest_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "survival_or_suitability_result_v1_as_numeric_authority",
+        "parallel_arithmetic_kernel"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+        "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_RATIO_UNIT_INTERVAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EFFECTIVE_LEVERAGE",
+      "semantic_role": "Maximum effective leverage layer limit for DoublePlaySurvivalEnvelope",
+      "required_producer": "double_play_survival_envelope_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "sequence_metric_set_stage1",
+        "path_survival_ratio_stage1",
+        "canonical_futures_accounting_kernel_projection"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_definition_digest_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "survival_or_suitability_result_v1_as_numeric_authority",
+        "parallel_arithmetic_kernel"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+        "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_NONNEGATIVE_REAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MIN_LIQUIDATION_BUFFER",
+      "semantic_role": "Minimum liquidation buffer layer limit for DoublePlaySurvivalEnvelope",
+      "required_producer": "double_play_survival_envelope_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "sequence_metric_set_stage1",
+        "path_survival_ratio_stage1",
+        "canonical_futures_accounting_kernel_projection"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_definition_digest_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "survival_or_suitability_result_v1_as_numeric_authority",
+        "parallel_arithmetic_kernel"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+        "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_NONNEGATIVE_REAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_SURVIVAL_LIMIT_MAX_ADVERSE_FILL_LOSS",
+      "semantic_role": "Maximum adverse fill loss layer limit for DoublePlaySurvivalEnvelope",
+      "required_producer": "double_play_survival_envelope_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "sequence_metric_set_stage1",
+        "path_survival_ratio_stage1",
+        "canonical_futures_accounting_kernel_projection"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_definition_digest_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "survival_or_suitability_result_v1_as_numeric_authority",
+        "parallel_arithmetic_kernel"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID",
+        "OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_NONNEGATIVE_REAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_PROFIT_STEP_PCT",
+      "semantic_role": "Capital-slot profit step as fraction of effective slot base",
+      "required_producer": "capital_slot_config_v1_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "capital_slot_cashflow_step_events",
+        "effective_slot_base_observations"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "isolated_sharpe_or_profit_optimization",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete"
+      ],
+      "dependency_tokens": [],
+      "allowed_calibration_output_type": "THRESHOLD_PERCENT_FRACTION",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION",
+      "semantic_role": "Capital-slot cashflow lock fraction in unit interval; mechanically couples reinvest_fraction",
+      "required_producer": "capital_slot_config_v1_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "capital_slot_cashflow_split_observations"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "independent_reinvest_fraction_value",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_CAPITAL_SLOT_REINVEST_FRACTION"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_FRACTION_UNIT_INTERVAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_MIN_REALIZED_VOLATILITY",
+      "semantic_role": "Minimum realized volatility gate in Stage-1 Pure-Stack units; not CMC.volatility_estimate",
+      "required_producer": "capital_slot_config_v1_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "fps_realized_volatility_population_stdev_mark_log_returns_v1"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "cmc_volatility_estimate_as_realized_volatility_alias",
+        "primary_safety_gate_fail",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete",
+        "stage1_unit_mismatch"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_REALIZED_VOLATILITY_FORMULA_ID",
+        "OWNER_VALUE_REALIZED_VOLATILITY_UNIT",
+        "OWNER_VALUE_REALIZED_VOLATILITY_HORIZON"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_NONNEGATIVE_REAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_MIN_ATR_OR_RANGE",
+      "semantic_role": "Minimum ATR/range gate in Stage-1 price quote currency units",
+      "required_producer": "capital_slot_config_v1_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "fps_atr_or_range_wilder_atr_finalized_ohlcv_v1"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "stage1_unit_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_ATR_OR_RANGE_FORMULA_ID",
+        "OWNER_VALUE_ATR_OR_RANGE_UNIT",
+        "OWNER_VALUE_ATR_OR_RANGE_WINDOW"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_PRICE_QUOTE_UNITS",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP",
+      "semantic_role": "Maximum Sole Trading Authority cycle-index quanta without cashflow step",
+      "required_producer": "capital_slot_config_v1_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "sole_trading_authority_cycle_index",
+        "cashflow_step_event_times_in_cycle_quanta"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "wallclock_seconds_as_time_quantum",
+        "primary_safety_gate_fail",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_CAPITAL_SLOT_TIME_QUANTUM"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_INTEGER_CYCLE_QUANTA",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_MIN_OPPORTUNITY_SCORE",
+      "semantic_role": "Minimum opportunity score gate on Stage-1 unit interval scale",
+      "required_producer": "capital_slot_config_v1_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "fps_opportunity_score_fee_slippage_breakeven_movement_v1"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "primary_safety_gate_fail",
+        "stage1_scale_mismatch",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete"
+      ],
+      "dependency_tokens": [
+        "OWNER_VALUE_OPPORTUNITY_SCORE_FORMULA_ID",
+        "OWNER_VALUE_OPPORTUNITY_SCORE_SCALE"
+      ],
+      "allowed_calibration_output_type": "THRESHOLD_SCORE_UNIT_INTERVAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    },
+    {
+      "token": "OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE",
+      "semantic_role": "Initial capital slot base; Owner policy amount, not ambient account equity remap",
+      "required_producer": "capital_slot_state_store_v1_shadow_calibration_under_sole_trading_authority",
+      "required_observations": [
+        "owner_declared_slot_base_candidate_observations_only"
+      ],
+      "required_stratification": [
+        "instrument_id",
+        "volatility_regime_taxonomy_label_low_mid_high_unknown",
+        "missing_regime_stratum",
+        "time_segment"
+      ],
+      "required_stress_families": [
+        "observation_gaps_missing_bars",
+        "staleness_near_and_beyond_candidate",
+        "spread_expansion_crossed_book",
+        "volatility_shocks_high_realized_vol_atr",
+        "liquidation_near_miss_path_families",
+        "chop_rapid_switch_clusters"
+      ],
+      "primary_safety_metrics": [
+        "block_allow_rate",
+        "false_allow_rate",
+        "false_block_rate",
+        "path_survival",
+        "early_loss_toxicity",
+        "liquidation_near_miss_rate",
+        "governance_breach_frequency",
+        "effective_leverage",
+        "liquidation_buffer",
+        "adverse_fill_loss"
+      ],
+      "secondary_metrics": [
+        "profit_factor",
+        "max_drawdown",
+        "turnover",
+        "fees",
+        "slippage",
+        "opportunity_cost"
+      ],
+      "mandatory_rejection_criteria": [
+        "account_equity_derivation",
+        "primary_safety_gate_fail",
+        "fixture_webui_cmc_dashboard_authority_source",
+        "oos_acceptance_fail",
+        "stress_pack_incomplete"
+      ],
+      "dependency_tokens": [],
+      "allowed_calibration_output_type": "THRESHOLD_NONNEGATIVE_REAL",
+      "productive_numeric_value": null,
+      "input_authority": false,
+      "runtime_implemented": false,
+      "owner_ratification_status": "NOT_RATIFIED",
+      "authority_source": null,
+      "derivation_source": null,
+      "acceptance_gate_results": [],
+      "rejection_reasons": []
+    }
+  ],
+  "acceptance_gate_results": [
+    {
+      "gate_id": "stage2_scaffold_integrity",
+      "status": "NOT_EVALUATED",
+      "notes": "Scaffolding only"
+    },
+    {
+      "gate_id": "oos_acceptance",
+      "status": "NOT_EVALUATED",
+      "notes": null
+    },
+    {
+      "gate_id": "stress_pack_completeness",
+      "status": "NOT_EVALUATED",
+      "notes": null
+    },
+    {
+      "gate_id": "primary_safety_before_economics",
+      "status": "NOT_EVALUATED",
+      "notes": null
+    }
+  ],
+  "rejection_reasons": [],
+  "owner_ratification_status": "NOT_RATIFIED",
+  "productive_numeric_values_set": 0,
+  "evidence_complete": false,
+  "owner_ratified": false,
+  "input_authority": false,
+  "runtime_implemented": false,
+  "dashboard_role": "READ_ONLY_CONSUMER",
+  "forbidden_authority_declarations": {
+    "fixture_scenario_webui_as_authority": false,
+    "cmc_volatility_estimate_as_realized_volatility": false,
+    "survival_result_v1_as_numeric_authority": false,
+    "suitability_result_v1_as_numeric_authority": false,
+    "dashboard_as_authority": false,
+    "archive_as_authority": false,
+    "reinvest_fraction_independent_numeric": false,
+    "capital_slot_time_quantum_wallclock_seconds": false,
+    "initial_slot_base_from_account_equity": false
+  }
+}

--- a/docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_EVIDENCE_PACK_SCAFFOLDING_V1.md
+++ b/docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_EVIDENCE_PACK_SCAFFOLDING_V1.md
@@ -1,0 +1,125 @@
+# Productive Pure-Stack Numeric Policy Evidence Pack Scaffolding v1
+
+```text
+DOCUMENT_TYPE=STAGE2_EVIDENCE_PACK_SCAFFOLDING_GOVERNANCE
+DOCUMENT_VERSION=1
+STATUS=INFRASTRUCTURE_ONLY_NO_CALIBRATION_NO_NUMBERS
+BASELINE_ORIGIN_MAIN_SHA=80977448775bd4819cbeef9122364e6330d7100f
+SCHEMA=docs/ops/schemas/productive_pure_stack_numeric_policy_evidence_pack_v1.schema.json
+REQUIREMENTS=docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_EVIDENCE_REQUIREMENTS_V1.md
+CAMPAIGN_MANIFEST=docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_CAMPAIGN_MANIFEST_V1.json
+VALIDATOR=scripts/ops/validate_productive_pure_stack_numeric_policy_evidence_pack_v1.py
+SOLE_TRADING_AUTHORITY=run_integrated_offline_trading_logic_replay_v1
+DASHBOARD_ROLE=READ_ONLY_CONSUMER
+PRODUCTIVE_NUMERIC_VALUES_SET=0
+INPUT_AUTHORITY=false
+RUNTIME_IMPLEMENTED=false
+```
+
+## 0. What this PR is
+
+This deliverable creates **only** the fail-closed Stage-2 Evidence Pack
+scaffolding for the 18 numeric Owner Values classified
+`NUMERIC_CALIBRATION_REQUIRED` in Stage 1.
+
+It is infrastructure so that later shadow/replay calibration campaigns can
+emit versioned, auditable Evidence packs.
+
+## 1. What this PR is not
+
+```text
+CALIBRATION_EXECUTED=false
+NUMERIC_CANDIDATES_PROPOSED=false
+NUMERIC_DEFAULTS_INSERTED=false
+NUMERIC_RECOMMENDATIONS_INSERTED=false
+NUMERIC_EXAMPLE_VALUES_INSERTED=false
+OWNER_RATIFICATION_OF_ANY_TOKEN=false
+GROUP_AUTO_RATIFICATION=false
+INPUT_AUTHORITY_FLIP=false
+RUNTIME_BINDING=false
+DASHBOARD_MUTATION=false
+ARCHIVE_MUTATION=false
+CONFIG_MUTATION=false
+STATE_MUTATION=false
+ORDERS=false
+LIVE=false
+TESTNET=false
+```
+
+No productive number was proposed, selected, recommended, defaulted, or
+ratified. Every token remains `productive_numeric_value=null`.
+
+## 2. Separation of concerns (hard)
+
+1. **Evidence-pack scaffolding / generation** (this PR family) creates and
+   validates non-productive Evidence structure.
+2. **Productive activation** requires a **separate** PR and explicit Owner GO
+   after per-token ratification.
+
+These must never be collapsed into one silent promotion.
+
+## 3. Ratification rules
+
+```text
+NO_TOKEN_MAY_BE_GROUP_AUTO_RATIFIED=true
+EACH_PRODUCTIVE_VALUE_REQUIRES_SEPARATE_OWNER_RATIFICATION=true
+REINVEST_FRACTION_REMAINS_MECHANICAL_COUPLING_ONLY=true
+```
+
+Batch or family-wide automatic ratification of the 18 tokens is forbidden.
+
+## 4. Metric hierarchy
+
+```text
+PRIMARY=SAFETY_METRICS
+SECONDARY=ECONOMIC_METRICS
+ECONOMICS_MAY_BREAK_TIES_ONLY_AFTER_SAFETY_PASS=true
+ISOLATED_SHARPE_OR_PROFIT_OPTIMIZATION=FORBIDDEN
+```
+
+## 5. Authority boundaries
+
+```text
+SOLE_TRADING_AUTHORITY=run_integrated_offline_trading_logic_replay_v1
+DASHBOARD=READ_ONLY_CONSUMER
+FORBIDDEN_NUMERIC_AUTHORITY_SOURCES=
+  fixtures
+  scenarios
+  WebUI hardcoded limits
+  CMC.volatility_estimate as realized_volatility
+  SurvivalResultV1
+  SuitabilityResultV1
+  dashboard presentation
+  archive mutation as authority
+  parallel arithmetic/volatility/opportunity kernel
+```
+
+## 6. Campaign scaffold state
+
+The empty campaign manifest is intentionally:
+
+```text
+campaign_status=NOT_STARTED
+evidence_complete=false
+owner_ratified=false
+productive_numeric_values_set=0
+input_authority=false
+runtime_implemented=false
+```
+
+## 7. Validator role
+
+`scripts&#47;ops&#47;validate_productive_pure_stack_numeric_policy_evidence_pack_v1.py`
+fail-closed rejects packs that set productive numbers, flip authority flags,
+omit Stage-1/protocol digests, claim forbidden sources, treat
+`REINVEST_FRACTION` as independent, use wallclock seconds for the capital-slot
+time quantum, derive `INITIAL_SLOT_BASE` from account equity, or claim
+completeness with incomplete stress/OOS/partition manifests.
+
+## 8. References
+
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_OWNER_VALUES_TWO_STAGE_RATIFICATION_V1.md`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_EVIDENCE_REQUIREMENTS_V1.md`
+- `docs&#47;runbooks&#47;canonical&#47;PEAK_TRADE_MASTER_RUNBOOK.md`

--- a/docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_EVIDENCE_REQUIREMENTS_V1.md
+++ b/docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_EVIDENCE_REQUIREMENTS_V1.md
@@ -1,0 +1,402 @@
+# Productive Pure-Stack Numeric Policy Evidence Requirements v1
+
+```text
+DOCUMENT_TYPE=STAGE2_NUMERIC_POLICY_EVIDENCE_REQUIREMENTS
+DOCUMENT_VERSION=1
+STATUS=SCAFFOLDING_ONLY_NO_CALIBRATION_EXECUTED
+BASELINE_ORIGIN_MAIN_SHA=80977448775bd4819cbeef9122364e6330d7100f
+STRUCTURAL_MANIFEST=docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json
+CALIBRATION_PROTOCOL=docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md
+EVIDENCE_PACK_SCHEMA=docs/ops/schemas/productive_pure_stack_numeric_policy_evidence_pack_v1.schema.json
+CAMPAIGN_MANIFEST=docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_CAMPAIGN_MANIFEST_V1.json
+SOLE_TRADING_AUTHORITY=run_integrated_offline_trading_logic_replay_v1
+DASHBOARD_ROLE=READ_ONLY_CONSUMER
+PRODUCTIVE_NUMERIC_VALUES_SET=0
+INPUT_AUTHORITY=false
+RUNTIME_IMPLEMENTED=false
+TOKEN_COUNT=18
+```
+
+## 0. Purpose
+
+This document specifies the **per-token Evidence requirements** for the exact 18
+`NUMERIC_CALIBRATION_REQUIRED` Owner Values. It is scaffolding for later
+shadow/replay calibration Evidence packs. It does **not** propose, set, or
+ratify any productive number.
+
+```text
+CALIBRATION_EXECUTED=false
+PRODUCTIVE_NUMERIC_VALUE=null_for_all_18
+OWNER_RATIFICATION=false
+GROUP_AUTO_RATIFICATION=FORBIDDEN
+```
+
+## 1. Global invariants
+
+```text
+INV_NO_PRODUCTIVE_NUMERIC_VALUES=true
+INV_INPUT_AUTHORITY_REMAINS_FALSE=true
+INV_RUNTIME_IMPLEMENTED_FALSE=true
+INV_DASHBOARD_READ_ONLY_CONSUMER=true
+INV_SOLE_TRADING_AUTHORITY_ONLY=true
+INV_NO_FIXTURE_SCENARIO_WEBUI_AUTHORITY=true
+INV_NO_CMC_VOLATILITY_AS_REALIZED_VOLATILITY=true
+INV_NO_SURVIVALRESULTV1_OR_SUITABILITYRESULTV1_NUMERIC_AUTHORITY=true
+INV_NO_PARALLEL_ARITHMETIC_VOLATILITY_OPPORTUNITY_KERNEL=true
+INV_PRIMARY_SAFETY_BEFORE_ECONOMICS=true
+INV_PER_TOKEN_OWNER_RATIFICATION_REQUIRED=true
+INV_REINVEST_FRACTION_MECHANICAL_COUPLING_ONLY=true
+INV_TIME_QUANTUM_IS_CYCLE_INDEX_NOT_WALLCLOCK=true
+INV_INITIAL_SLOT_BASE_NOT_ACCOUNT_EQUITY=true
+```
+
+## 2. Token inventory (exactly 18)
+
+1. `OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS`
+2. `OWNER_VALUE_SURVIVAL_LIMIT_MIN_PATH_SURVIVAL_RATIO`
+3. `OWNER_VALUE_SURVIVAL_LIMIT_MAX_EARLY_LOSS_TOXICITY`
+4. `OWNER_VALUE_SURVIVAL_LIMIT_MIN_MARGIN_BUFFER_AT_RISK_99`
+5. `OWNER_VALUE_SURVIVAL_LIMIT_MAX_SEQUENCE_FRAGILITY_INDEX`
+6. `OWNER_VALUE_SURVIVAL_LIMIT_MAX_LIQUIDATION_NEAR_MISS_RATE`
+7. `OWNER_VALUE_SURVIVAL_LIMIT_MAX_GOVERNANCE_BREACH_FREQUENCY`
+8. `OWNER_VALUE_SURVIVAL_LIMIT_MIN_CHOP_SWITCH_SURVIVAL_SCORE`
+9. `OWNER_VALUE_SURVIVAL_LIMIT_MAX_EFFECTIVE_LEVERAGE`
+10. `OWNER_VALUE_SURVIVAL_LIMIT_MIN_LIQUIDATION_BUFFER`
+11. `OWNER_VALUE_SURVIVAL_LIMIT_MAX_ADVERSE_FILL_LOSS`
+12. `OWNER_VALUE_CAPITAL_SLOT_PROFIT_STEP_PCT`
+13. `OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION`
+14. `OWNER_VALUE_CAPITAL_SLOT_MIN_REALIZED_VOLATILITY`
+15. `OWNER_VALUE_CAPITAL_SLOT_MIN_ATR_OR_RANGE`
+16. `OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP`
+17. `OWNER_VALUE_CAPITAL_SLOT_MIN_OPPORTUNITY_SCORE`
+18. `OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE`
+
+`OWNER_VALUE_CAPITAL_SLOT_REINVEST_FRACTION` is **not** in this set. It remains
+mechanically coupled: `1 - OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION`.
+
+---
+
+## 3. Per-token requirements
+
+For every token below:
+
+```text
+productive_numeric_value=null
+input_authority=false
+runtime_implemented=false
+owner_ratification_status=NOT_RATIFIED
+```
+
+### 3.1 OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS
+
+| Field | Requirement |
+|---|---|
+| semantic role | Futures Input readiness/safety max age for provenance `freshness_state`; independent of CMC numeric max-age alpha |
+| required producer | market-data provenance producer feeding `FuturesMarketDataProvenanceStatus` |
+| required observations | public market finalized PT1M bars; futures market-data provenance status; event-time freshness metadata |
+| required stratification | instrument_id; volatility regime taxonomy (`low&#47;mid&#47;high&#47;unknown`); missing-regime stratum; time segment |
+| required stress families | observation gaps / missing bars; staleness near and beyond candidate; spread expansion / crossed book |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; stale_unknown_block_rate |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | CMC numeric-max-age alpha reuse; fixture/WebUI/CMC/dashboard authority source; primary safety fail; OOS fail; incomplete stress; Stage-1 digest mismatch |
+| dependency tokens | none |
+| allowed calibration output type | `THRESHOLD_SECONDS` |
+| productive_numeric_value | `null` |
+
+### 3.2 OWNER_VALUE_SURVIVAL_LIMIT_MIN_PATH_SURVIVAL_RATIO
+
+| Field | Requirement |
+|---|---|
+| semantic role | Minimum path survival ratio gate for DoublePlaySurvivalEnvelope |
+| required producer | DoublePlay survival-envelope shadow calibration under Sole Trading Authority |
+| required observations | Stage-1 sequence metric set; Stage-1 path-survival ratio; canonical futures accounting kernel projection |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; OOS fail; incomplete stress; Stage-1 digest mismatch; fixture/WebUI/CMC/dashboard authority; SurvivalResultV1 / SuitabilityResultV1 numeric authority; parallel arithmetic kernel |
+| dependency tokens | `OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID`; `OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID` |
+| allowed calibration output type | `THRESHOLD_RATIO_UNIT_INTERVAL` |
+| productive_numeric_value | `null` |
+
+### 3.3 OWNER_VALUE_SURVIVAL_LIMIT_MAX_EARLY_LOSS_TOXICITY
+
+| Field | Requirement |
+|---|---|
+| semantic role | Maximum early loss toxicity gate for DoublePlaySurvivalEnvelope |
+| required producer | DoublePlay survival-envelope shadow calibration under Sole Trading Authority |
+| required observations | Stage-1 sequence metric set; Stage-1 path-survival ratio; canonical futures accounting kernel projection |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; OOS fail; incomplete stress; Stage-1 digest mismatch; fixture/WebUI/CMC/dashboard authority; SurvivalResultV1 / SuitabilityResultV1 numeric authority; parallel arithmetic kernel |
+| dependency tokens | `OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID`; `OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID` |
+| allowed calibration output type | `THRESHOLD_RATIO_UNIT_INTERVAL` |
+| productive_numeric_value | `null` |
+
+### 3.4 OWNER_VALUE_SURVIVAL_LIMIT_MIN_MARGIN_BUFFER_AT_RISK_99
+
+| Field | Requirement |
+|---|---|
+| semantic role | Minimum margin buffer at risk 99 gate for DoublePlaySurvivalEnvelope |
+| required producer | DoublePlay survival-envelope shadow calibration under Sole Trading Authority |
+| required observations | Stage-1 sequence metric set; Stage-1 path-survival ratio; canonical futures accounting kernel projection |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; OOS fail; incomplete stress; Stage-1 digest mismatch; fixture/WebUI/CMC/dashboard authority; SurvivalResultV1 / SuitabilityResultV1 numeric authority; parallel arithmetic kernel |
+| dependency tokens | `OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID`; `OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID` |
+| allowed calibration output type | `THRESHOLD_RATIO_UNIT_INTERVAL` |
+| productive_numeric_value | `null` |
+
+### 3.5 OWNER_VALUE_SURVIVAL_LIMIT_MAX_SEQUENCE_FRAGILITY_INDEX
+
+| Field | Requirement |
+|---|---|
+| semantic role | Maximum sequence fragility index gate for DoublePlaySurvivalEnvelope |
+| required producer | DoublePlay survival-envelope shadow calibration under Sole Trading Authority |
+| required observations | Stage-1 sequence metric set; Stage-1 path-survival ratio; canonical futures accounting kernel projection |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; OOS fail; incomplete stress; Stage-1 digest mismatch; fixture/WebUI/CMC/dashboard authority; SurvivalResultV1 / SuitabilityResultV1 numeric authority; parallel arithmetic kernel |
+| dependency tokens | `OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID`; `OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID` |
+| allowed calibration output type | `THRESHOLD_RATIO_UNIT_INTERVAL` |
+| productive_numeric_value | `null` |
+
+### 3.6 OWNER_VALUE_SURVIVAL_LIMIT_MAX_LIQUIDATION_NEAR_MISS_RATE
+
+| Field | Requirement |
+|---|---|
+| semantic role | Maximum liquidation near-miss rate gate for DoublePlaySurvivalEnvelope |
+| required producer | DoublePlay survival-envelope shadow calibration under Sole Trading Authority |
+| required observations | Stage-1 sequence metric set; Stage-1 path-survival ratio; canonical futures accounting kernel projection |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; OOS fail; incomplete stress; Stage-1 digest mismatch; fixture/WebUI/CMC/dashboard authority; SurvivalResultV1 / SuitabilityResultV1 numeric authority; parallel arithmetic kernel |
+| dependency tokens | `OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID`; `OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID` |
+| allowed calibration output type | `THRESHOLD_RATIO_UNIT_INTERVAL` |
+| productive_numeric_value | `null` |
+
+### 3.7 OWNER_VALUE_SURVIVAL_LIMIT_MAX_GOVERNANCE_BREACH_FREQUENCY
+
+| Field | Requirement |
+|---|---|
+| semantic role | Maximum governance breach frequency gate for DoublePlaySurvivalEnvelope |
+| required producer | DoublePlay survival-envelope shadow calibration under Sole Trading Authority |
+| required observations | Stage-1 sequence metric set; Stage-1 path-survival ratio; canonical futures accounting kernel projection |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; OOS fail; incomplete stress; Stage-1 digest mismatch; fixture/WebUI/CMC/dashboard authority; SurvivalResultV1 / SuitabilityResultV1 numeric authority; parallel arithmetic kernel |
+| dependency tokens | `OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID`; `OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID` |
+| allowed calibration output type | `THRESHOLD_RATIO_UNIT_INTERVAL` |
+| productive_numeric_value | `null` |
+
+### 3.8 OWNER_VALUE_SURVIVAL_LIMIT_MIN_CHOP_SWITCH_SURVIVAL_SCORE
+
+| Field | Requirement |
+|---|---|
+| semantic role | Minimum chop/switch survival score gate for DoublePlaySurvivalEnvelope |
+| required producer | DoublePlay survival-envelope shadow calibration under Sole Trading Authority |
+| required observations | Stage-1 sequence metric set; Stage-1 path-survival ratio; canonical futures accounting kernel projection |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; OOS fail; incomplete stress; Stage-1 digest mismatch; fixture/WebUI/CMC/dashboard authority; SurvivalResultV1 / SuitabilityResultV1 numeric authority; parallel arithmetic kernel |
+| dependency tokens | `OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID`; `OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID` |
+| allowed calibration output type | `THRESHOLD_RATIO_UNIT_INTERVAL` |
+| productive_numeric_value | `null` |
+
+### 3.9 OWNER_VALUE_SURVIVAL_LIMIT_MAX_EFFECTIVE_LEVERAGE
+
+| Field | Requirement |
+|---|---|
+| semantic role | Maximum effective leverage layer limit for DoublePlaySurvivalEnvelope |
+| required producer | DoublePlay survival-envelope shadow calibration under Sole Trading Authority |
+| required observations | Stage-1 sequence metric set; Stage-1 path-survival ratio; canonical futures accounting kernel projection |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; OOS fail; incomplete stress; Stage-1 digest mismatch; fixture/WebUI/CMC/dashboard authority; SurvivalResultV1 / SuitabilityResultV1 numeric authority; parallel arithmetic kernel |
+| dependency tokens | `OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID`; `OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID` |
+| allowed calibration output type | `THRESHOLD_NONNEGATIVE_REAL` |
+| productive_numeric_value | `null` |
+
+### 3.10 OWNER_VALUE_SURVIVAL_LIMIT_MIN_LIQUIDATION_BUFFER
+
+| Field | Requirement |
+|---|---|
+| semantic role | Minimum liquidation buffer layer limit for DoublePlaySurvivalEnvelope |
+| required producer | DoublePlay survival-envelope shadow calibration under Sole Trading Authority |
+| required observations | Stage-1 sequence metric set; Stage-1 path-survival ratio; canonical futures accounting kernel projection |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; OOS fail; incomplete stress; Stage-1 digest mismatch; fixture/WebUI/CMC/dashboard authority; SurvivalResultV1 / SuitabilityResultV1 numeric authority; parallel arithmetic kernel |
+| dependency tokens | `OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID`; `OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID` |
+| allowed calibration output type | `THRESHOLD_NONNEGATIVE_REAL` |
+| productive_numeric_value | `null` |
+
+### 3.11 OWNER_VALUE_SURVIVAL_LIMIT_MAX_ADVERSE_FILL_LOSS
+
+| Field | Requirement |
+|---|---|
+| semantic role | Maximum adverse fill loss layer limit for DoublePlaySurvivalEnvelope |
+| required producer | DoublePlay survival-envelope shadow calibration under Sole Trading Authority |
+| required observations | Stage-1 sequence metric set; Stage-1 path-survival ratio; canonical futures accounting kernel projection |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; OOS fail; incomplete stress; Stage-1 digest mismatch; fixture/WebUI/CMC/dashboard authority; SurvivalResultV1 / SuitabilityResultV1 numeric authority; parallel arithmetic kernel |
+| dependency tokens | `OWNER_VALUE_SEQUENCE_PATH_SURVIVAL_RATIO_DEFINITION_ID`; `OWNER_VALUE_SEQUENCE_METRIC_SET_DEFINITION_ID` |
+| allowed calibration output type | `THRESHOLD_NONNEGATIVE_REAL` |
+| productive_numeric_value | `null` |
+
+### 3.12 OWNER_VALUE_CAPITAL_SLOT_PROFIT_STEP_PCT
+
+| Field | Requirement |
+|---|---|
+| semantic role | Capital-slot profit step as fraction of effective slot base |
+| required producer | `capital_slot_config.v1` shadow calibration under Sole Trading Authority |
+| required observations | capital-slot cashflow step events; effective slot base observations |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; isolated Sharpe/profit optimization; fixture/WebUI/CMC/dashboard authority; OOS fail; incomplete stress |
+| dependency tokens | none |
+| allowed calibration output type | `THRESHOLD_PERCENT_FRACTION` |
+| productive_numeric_value | `null` |
+
+### 3.13 OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION
+
+| Field | Requirement |
+|---|---|
+| semantic role | Capital-slot cashflow lock fraction in unit interval; mechanically couples reinvest fraction |
+| required producer | `capital_slot_config.v1` shadow calibration under Sole Trading Authority |
+| required observations | capital-slot cashflow split observations |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; independent reinvest fraction value; fixture/WebUI/CMC/dashboard authority; OOS fail; incomplete stress |
+| dependency tokens | `OWNER_VALUE_CAPITAL_SLOT_REINVEST_FRACTION` (mechanical coupling only; not an independent Stage-2 token) |
+| allowed calibration output type | `THRESHOLD_FRACTION_UNIT_INTERVAL` |
+| productive_numeric_value | `null` |
+
+### 3.14 OWNER_VALUE_CAPITAL_SLOT_MIN_REALIZED_VOLATILITY
+
+| Field | Requirement |
+|---|---|
+| semantic role | Minimum realized volatility gate in Stage-1 Pure-Stack units; not `CMC.volatility_estimate` |
+| required producer | `capital_slot_config.v1` shadow calibration under Sole Trading Authority |
+| required observations | `fps_realized_volatility.population_stdev_mark_log_returns.v1` outputs |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | CMC.volatility_estimate as realized-volatility alias; primary safety fail; fixture/WebUI/CMC/dashboard authority; OOS fail; incomplete stress; Stage-1 unit mismatch |
+| dependency tokens | `OWNER_VALUE_REALIZED_VOLATILITY_FORMULA_ID`; `OWNER_VALUE_REALIZED_VOLATILITY_UNIT`; `OWNER_VALUE_REALIZED_VOLATILITY_HORIZON` |
+| allowed calibration output type | `THRESHOLD_NONNEGATIVE_REAL` |
+| productive_numeric_value | `null` |
+
+### 3.15 OWNER_VALUE_CAPITAL_SLOT_MIN_ATR_OR_RANGE
+
+| Field | Requirement |
+|---|---|
+| semantic role | Minimum ATR/range gate in Stage-1 price quote currency units |
+| required producer | `capital_slot_config.v1` shadow calibration under Sole Trading Authority |
+| required observations | `fps_atr_or_range.wilder_atr_finalized_ohlcv.v1` outputs |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; Stage-1 unit mismatch; fixture/WebUI/CMC/dashboard authority; OOS fail; incomplete stress |
+| dependency tokens | `OWNER_VALUE_ATR_OR_RANGE_FORMULA_ID`; `OWNER_VALUE_ATR_OR_RANGE_UNIT`; `OWNER_VALUE_ATR_OR_RANGE_WINDOW` |
+| allowed calibration output type | `THRESHOLD_PRICE_QUOTE_UNITS` |
+| productive_numeric_value | `null` |
+
+### 3.16 OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP
+
+| Field | Requirement |
+|---|---|
+| semantic role | Maximum Sole Trading Authority cycle-index quanta without cashflow step |
+| required producer | `capital_slot_config.v1` shadow calibration under Sole Trading Authority |
+| required observations | Sole Trading Authority cycle index; cashflow step event times counted in cycle quanta |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | wallclock seconds as time quantum; primary safety fail; fixture/WebUI/CMC/dashboard authority; OOS fail; incomplete stress |
+| dependency tokens | `OWNER_VALUE_CAPITAL_SLOT_TIME_QUANTUM` |
+| allowed calibration output type | `THRESHOLD_INTEGER_CYCLE_QUANTA` |
+| productive_numeric_value | `null` |
+
+### 3.17 OWNER_VALUE_CAPITAL_SLOT_MIN_OPPORTUNITY_SCORE
+
+| Field | Requirement |
+|---|---|
+| semantic role | Minimum opportunity score gate on Stage-1 unit interval scale |
+| required producer | `capital_slot_config.v1` shadow calibration under Sole Trading Authority |
+| required observations | `fps_opportunity_score.fee_slippage_breakeven_movement.v1` outputs |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | primary safety fail; Stage-1 scale mismatch; fixture/WebUI/CMC/dashboard authority; OOS fail; incomplete stress |
+| dependency tokens | `OWNER_VALUE_OPPORTUNITY_SCORE_FORMULA_ID`; `OWNER_VALUE_OPPORTUNITY_SCORE_SCALE` |
+| allowed calibration output type | `THRESHOLD_SCORE_UNIT_INTERVAL` |
+| productive_numeric_value | `null` |
+
+### 3.18 OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE
+
+| Field | Requirement |
+|---|---|
+| semantic role | Initial capital slot base; Owner policy amount, not ambient account equity remap |
+| required producer | `capital_slot_state_store.v1` shadow calibration under Sole Trading Authority |
+| required observations | Owner-declared slot-base candidate observations only |
+| required stratification | instrument_id; regime taxonomy; missing-regime stratum; time segment |
+| required stress families | gaps; staleness; spread expansion; volatility shocks; liquidation near-miss families; chop / rapid switch clusters |
+| primary safety metrics | block_allow_rate; false_allow_rate; false_block_rate; path_survival; early_loss_toxicity; liquidation_near_miss_rate; governance_breach_frequency; effective_leverage; liquidation_buffer; adverse_fill_loss |
+| secondary metrics | profit_factor; max_drawdown; turnover; fees; slippage; opportunity_cost |
+| mandatory rejection criteria | account-equity derivation; primary safety fail; fixture/WebUI/CMC/dashboard authority; OOS fail; incomplete stress |
+| dependency tokens | none |
+| allowed calibration output type | `THRESHOLD_NONNEGATIVE_REAL` |
+| productive_numeric_value | `null` |
+
+---
+
+## 4. Explicit non-authorization
+
+```text
+EVIDENCE_PACK_SCAFFOLDING_ONLY=true
+CALIBRATION_EXECUTED=false
+PRODUCTIVE_CONFIG_WRITE=UNAUTHORIZED
+INPUT_AUTHORITY_FLIP=UNAUTHORIZED
+ORDERS=UNAUTHORIZED
+LIVE=UNAUTHORIZED
+TESTNET=UNAUTHORIZED
+ARCHIVE_AUTHORITY_MUTATION=UNAUTHORIZED
+DASHBOARD_AUTHORITY_EFFECT=NONE
+AUTO_GROUP_RATIFICATION=UNAUTHORIZED
+```
+
+## 5. References
+
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_OWNER_VALUES_TWO_STAGE_RATIFICATION_V1.md`
+- `docs&#47;ops&#47;schemas&#47;productive_pure_stack_numeric_policy_evidence_pack_v1.schema.json`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_CAMPAIGN_MANIFEST_V1.json`
+- `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_EVIDENCE_PACK_SCAFFOLDING_V1.md`

--- a/docs/ops/schemas/productive_pure_stack_numeric_policy_evidence_pack_v1.schema.json
+++ b/docs/ops/schemas/productive_pure_stack_numeric_policy_evidence_pack_v1.schema.json
@@ -1,0 +1,419 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "docs/ops/schemas/productive_pure_stack_numeric_policy_evidence_pack_v1.schema.json",
+  "title": "ProductivePureStackNumericPolicyEvidencePackV1",
+  "description": "Fail-closed Stage-2 Evidence Pack for Pure-Stack numeric Owner Values. Scaffolding and shadow calibration only. Does not authorize INPUT_AUTHORITY_*, productive numbers, runtime binding, orders, Live, Testnet, or dashboard authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "campaign_id",
+    "campaign_status",
+    "origin_main_sha",
+    "stage1_manifest_digest",
+    "calibration_protocol_digest",
+    "sole_trading_authority_symbol",
+    "observation_identity",
+    "producer_identity",
+    "dataset_manifest",
+    "train_calibration_validation_partition_manifest",
+    "walk_forward_manifest",
+    "bootstrap_monte_carlo_manifest",
+    "stress_pack_manifest",
+    "metric_definition_digests",
+    "per_token_evidence",
+    "acceptance_gate_results",
+    "rejection_reasons",
+    "owner_ratification_status",
+    "productive_numeric_values_set",
+    "evidence_complete",
+    "owner_ratified",
+    "input_authority",
+    "runtime_implemented",
+    "dashboard_role",
+    "forbidden_authority_declarations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "productive_pure_stack_numeric_policy_evidence_pack/v1"
+    },
+    "campaign_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "campaign_status": {
+      "type": "string",
+      "enum": [
+        "NOT_STARTED",
+        "IN_PROGRESS",
+        "EVIDENCE_COMPLETE_PENDING_OWNER",
+        "OWNER_RATIFIED_PER_TOKEN",
+        "REJECTED_FAIL_CLOSED"
+      ]
+    },
+    "origin_main_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "stage1_manifest_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "sha256 of docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json"
+    },
+    "calibration_protocol_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "sha256 of docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md"
+    },
+    "sole_trading_authority_symbol": {
+      "const": "run_integrated_offline_trading_logic_replay_v1"
+    },
+    "observation_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observation_family",
+        "bar_interval",
+        "point_in_time_only",
+        "no_lookahead",
+        "no_implicit_fill",
+        "provenance_required",
+        "sole_consumer_authority"
+      ],
+      "properties": {
+        "observation_family": {
+          "const": "PUBLIC_MARKET_FINALIZED_BARS"
+        },
+        "bar_interval": {
+          "const": "PT1M"
+        },
+        "point_in_time_only": {
+          "const": true
+        },
+        "no_lookahead": {
+          "const": true
+        },
+        "no_implicit_fill": {
+          "const": true
+        },
+        "provenance_required": {
+          "const": true
+        },
+        "sole_consumer_authority": {
+          "const": "run_integrated_offline_trading_logic_replay_v1"
+        }
+      }
+    },
+    "producer_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "productive_activation",
+        "allowed_producer_classes",
+        "forbidden_producer_classes"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["SCAFFOLD_ONLY", "SHADOW_DECLARED", "BOUND"]
+        },
+        "productive_activation": {
+          "const": false
+        },
+        "allowed_producer_classes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "forbidden_producer_classes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "dataset_manifest": {
+      "$ref": "#/$defs/EmptyCapableManifest"
+    },
+    "train_calibration_validation_partition_manifest": {
+      "$ref": "#/$defs/EmptyCapableManifest"
+    },
+    "walk_forward_manifest": {
+      "$ref": "#/$defs/EmptyCapableManifest"
+    },
+    "bootstrap_monte_carlo_manifest": {
+      "$ref": "#/$defs/EmptyCapableManifest"
+    },
+    "stress_pack_manifest": {
+      "$ref": "#/$defs/EmptyCapableManifest"
+    },
+    "metric_definition_digests": {
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string", "null"]
+      }
+    },
+    "per_token_evidence": {
+      "type": "array",
+      "minItems": 18,
+      "maxItems": 18,
+      "items": {
+        "$ref": "#/$defs/PerTokenEvidence"
+      }
+    },
+    "acceptance_gate_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["gate_id", "status"],
+        "properties": {
+          "gate_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": ["NOT_EVALUATED", "PASS", "FAIL", "REJECTED_FAIL_CLOSED"]
+          },
+          "notes": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "rejection_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "owner_ratification_status": {
+      "type": "string",
+      "enum": [
+        "NOT_RATIFIED",
+        "PARTIAL_PER_TOKEN",
+        "ALL_TOKENS_RATIFIED",
+        "REJECTED"
+      ]
+    },
+    "productive_numeric_values_set": {
+      "const": 0
+    },
+    "evidence_complete": {
+      "type": "boolean"
+    },
+    "owner_ratified": {
+      "type": "boolean"
+    },
+    "input_authority": {
+      "const": false
+    },
+    "runtime_implemented": {
+      "const": false
+    },
+    "dashboard_role": {
+      "const": "READ_ONLY_CONSUMER"
+    },
+    "forbidden_authority_declarations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fixture_scenario_webui_as_authority",
+        "cmc_volatility_estimate_as_realized_volatility",
+        "survival_result_v1_as_numeric_authority",
+        "suitability_result_v1_as_numeric_authority",
+        "dashboard_as_authority",
+        "archive_as_authority",
+        "reinvest_fraction_independent_numeric",
+        "capital_slot_time_quantum_wallclock_seconds",
+        "initial_slot_base_from_account_equity"
+      ],
+      "properties": {
+        "fixture_scenario_webui_as_authority": {
+          "const": false
+        },
+        "cmc_volatility_estimate_as_realized_volatility": {
+          "const": false
+        },
+        "survival_result_v1_as_numeric_authority": {
+          "const": false
+        },
+        "suitability_result_v1_as_numeric_authority": {
+          "const": false
+        },
+        "dashboard_as_authority": {
+          "const": false
+        },
+        "archive_as_authority": {
+          "const": false
+        },
+        "reinvest_fraction_independent_numeric": {
+          "const": false
+        },
+        "capital_slot_time_quantum_wallclock_seconds": {
+          "const": false
+        },
+        "initial_slot_base_from_account_equity": {
+          "const": false
+        }
+      }
+    }
+  },
+  "$defs": {
+    "EmptyCapableManifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "populated", "entries"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["EMPTY_SCAFFOLD", "DECLARED", "COMPLETE"]
+        },
+        "populated": {
+          "type": "boolean"
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "digest": {
+          "type": ["string", "null"]
+        },
+        "notes": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "PerTokenEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "token",
+        "semantic_role",
+        "required_producer",
+        "required_observations",
+        "required_stratification",
+        "required_stress_families",
+        "primary_safety_metrics",
+        "secondary_metrics",
+        "mandatory_rejection_criteria",
+        "dependency_tokens",
+        "allowed_calibration_output_type",
+        "productive_numeric_value",
+        "input_authority",
+        "runtime_implemented",
+        "owner_ratification_status",
+        "authority_source",
+        "derivation_source",
+        "acceptance_gate_results",
+        "rejection_reasons"
+      ],
+      "properties": {
+        "token": {
+          "type": "string",
+          "pattern": "^OWNER_VALUE_[A-Z0-9_]+$"
+        },
+        "semantic_role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required_producer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required_observations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "required_stratification": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "required_stress_families": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "primary_safety_metrics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "secondary_metrics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mandatory_rejection_criteria": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dependency_tokens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowed_calibration_output_type": {
+          "type": "string",
+          "enum": [
+            "THRESHOLD_SECONDS",
+            "THRESHOLD_RATIO_UNIT_INTERVAL",
+            "THRESHOLD_NONNEGATIVE_REAL",
+            "THRESHOLD_INTEGER_CYCLE_QUANTA",
+            "THRESHOLD_PRICE_QUOTE_UNITS",
+            "THRESHOLD_SCORE_UNIT_INTERVAL",
+            "THRESHOLD_FRACTION_UNIT_INTERVAL",
+            "THRESHOLD_PERCENT_FRACTION"
+          ]
+        },
+        "productive_numeric_value": {
+          "type": "null"
+        },
+        "input_authority": {
+          "const": false
+        },
+        "runtime_implemented": {
+          "const": false
+        },
+        "owner_ratification_status": {
+          "type": "string",
+          "enum": ["NOT_RATIFIED", "RATIFIED", "REJECTED"]
+        },
+        "authority_source": {
+          "type": ["string", "null"]
+        },
+        "derivation_source": {
+          "type": ["string", "null"]
+        },
+        "acceptance_gate_results": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "rejection_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/ops/validate_productive_pure_stack_numeric_policy_evidence_pack_v1.py
+++ b/scripts/ops/validate_productive_pure_stack_numeric_policy_evidence_pack_v1.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Validate Pure-Stack Stage-2 numeric policy Evidence packs (fail-closed).
+
+Read-only validator for scaffolding and later shadow calibration Evidence packs.
+Does not authorize INPUT_AUTHORITY_*, productive numbers, runtime binding,
+orders, Live, Testnet, dashboard authority, or archive mutation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+VALIDATOR_CONTRACT = "productive_pure_stack_numeric_policy_evidence_pack_validator_v1"
+SCHEMA_VERSION = "productive_pure_stack_numeric_policy_evidence_pack/v1"
+SOLE_TRADING_AUTHORITY = "run_integrated_offline_trading_logic_replay_v1"
+
+STAGE1_MANIFEST_REL = Path(
+    "docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json"
+)
+CALIBRATION_PROTOCOL_REL = Path(
+    "docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md"
+)
+
+STAGE2_TOKENS: tuple[str, ...] = (
+    "OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_PATH_SURVIVAL_RATIO",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EARLY_LOSS_TOXICITY",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_MARGIN_BUFFER_AT_RISK_99",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_SEQUENCE_FRAGILITY_INDEX",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_LIQUIDATION_NEAR_MISS_RATE",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_GOVERNANCE_BREACH_FREQUENCY",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_CHOP_SWITCH_SURVIVAL_SCORE",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EFFECTIVE_LEVERAGE",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_LIQUIDATION_BUFFER",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_ADVERSE_FILL_LOSS",
+    "OWNER_VALUE_CAPITAL_SLOT_PROFIT_STEP_PCT",
+    "OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION",
+    "OWNER_VALUE_CAPITAL_SLOT_MIN_REALIZED_VOLATILITY",
+    "OWNER_VALUE_CAPITAL_SLOT_MIN_ATR_OR_RANGE",
+    "OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP",
+    "OWNER_VALUE_CAPITAL_SLOT_MIN_OPPORTUNITY_SCORE",
+    "OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE",
+)
+
+REQUIRED_TOP_LEVEL = (
+    "schema_version",
+    "campaign_id",
+    "campaign_status",
+    "origin_main_sha",
+    "stage1_manifest_digest",
+    "calibration_protocol_digest",
+    "sole_trading_authority_symbol",
+    "observation_identity",
+    "producer_identity",
+    "dataset_manifest",
+    "train_calibration_validation_partition_manifest",
+    "walk_forward_manifest",
+    "bootstrap_monte_carlo_manifest",
+    "stress_pack_manifest",
+    "metric_definition_digests",
+    "per_token_evidence",
+    "acceptance_gate_results",
+    "rejection_reasons",
+    "owner_ratification_status",
+    "productive_numeric_values_set",
+    "evidence_complete",
+    "owner_ratified",
+    "input_authority",
+    "runtime_implemented",
+    "dashboard_role",
+    "forbidden_authority_declarations",
+)
+
+PARTITION_KEYS = (
+    "train_calibration_validation_partition_manifest",
+    "walk_forward_manifest",
+    "bootstrap_monte_carlo_manifest",
+    "stress_pack_manifest",
+    "dataset_manifest",
+)
+
+FORBIDDEN_AUTHORITY_MARKERS = (
+    "fixture",
+    "scenario",
+    "webui",
+    "dashboard",
+    "cmc.volatility_estimate",
+    "cmc_volatility_estimate",
+    "survivalresultv1",
+    "suitabilityresultv1",
+    "archive_authority",
+)
+
+FORBIDDEN_DECLARATION_KEYS = (
+    "fixture_scenario_webui_as_authority",
+    "cmc_volatility_estimate_as_realized_volatility",
+    "survival_result_v1_as_numeric_authority",
+    "suitability_result_v1_as_numeric_authority",
+    "dashboard_as_authority",
+    "archive_as_authority",
+    "reinvest_fraction_independent_numeric",
+    "capital_slot_time_quantum_wallclock_seconds",
+    "initial_slot_base_from_account_equity",
+)
+
+
+def repo_root_from_here() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _norm(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().lower()
+
+
+def _contains_forbidden_authority(text: str) -> str | None:
+    lowered = text.lower()
+    for marker in FORBIDDEN_AUTHORITY_MARKERS:
+        if marker in lowered:
+            return marker
+    return None
+
+
+def _manifest_incomplete(manifest: Any) -> bool:
+    if not isinstance(manifest, dict):
+        return True
+    status = manifest.get("status")
+    populated = manifest.get("populated")
+    entries = manifest.get("entries")
+    if status not in {"EMPTY_SCAFFOLD", "DECLARED", "COMPLETE"}:
+        return True
+    if not isinstance(entries, list):
+        return True
+    if status == "EMPTY_SCAFFOLD":
+        return populated is not False or len(entries) != 0
+    if status == "DECLARED":
+        return populated is not True or len(entries) == 0
+    if status == "COMPLETE":
+        return populated is not True or len(entries) == 0 or not manifest.get("digest")
+    return True
+
+
+def validate_pack(
+    pack: dict[str, Any],
+    *,
+    repo_root: Path | None = None,
+    expected_origin_main_sha: str | None = None,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    root = repo_root or repo_root_from_here()
+
+    if not isinstance(pack, dict):
+        return {
+            "contract": VALIDATOR_CONTRACT,
+            "ok": False,
+            "errors": ["pack_must_be_object"],
+            "token_count": 0,
+            "productive_numeric_values_set": None,
+            "input_authority": None,
+            "runtime_implemented": None,
+            "non_authorizing": True,
+        }
+
+    for key in REQUIRED_TOP_LEVEL:
+        if key not in pack:
+            errors.append(f"missing_top_level:{key}")
+
+    if pack.get("schema_version") != SCHEMA_VERSION:
+        errors.append("invalid_schema_version")
+
+    if pack.get("sole_trading_authority_symbol") != SOLE_TRADING_AUTHORITY:
+        errors.append("invalid_sole_trading_authority_symbol")
+
+    if pack.get("dashboard_role") != "READ_ONLY_CONSUMER":
+        errors.append("dashboard_must_be_read_only_consumer")
+
+    if pack.get("input_authority") is not False:
+        errors.append("input_authority_must_be_false")
+
+    if pack.get("runtime_implemented") is not False:
+        errors.append("runtime_implemented_must_be_false")
+
+    if pack.get("productive_numeric_values_set") != 0:
+        errors.append("productive_numeric_values_set_must_be_0")
+
+    if pack.get("evidence_complete") is not False and pack.get("campaign_status") == "NOT_STARTED":
+        errors.append("not_started_must_have_evidence_complete_false")
+
+    if pack.get("owner_ratified") is not False and pack.get("campaign_status") == "NOT_STARTED":
+        errors.append("not_started_must_have_owner_ratified_false")
+
+    stage1_path = root / STAGE1_MANIFEST_REL
+    protocol_path = root / CALIBRATION_PROTOCOL_REL
+    if not stage1_path.is_file():
+        errors.append("missing_stage1_manifest_file")
+    if not protocol_path.is_file():
+        errors.append("missing_calibration_protocol_file")
+
+    stage1_digest = pack.get("stage1_manifest_digest")
+    protocol_digest = pack.get("calibration_protocol_digest")
+    if not isinstance(stage1_digest, str) or len(stage1_digest) != 64:
+        errors.append("missing_or_invalid_stage1_manifest_digest")
+    elif stage1_path.is_file() and stage1_digest != sha256_file(stage1_path):
+        errors.append("stage1_manifest_digest_mismatch")
+
+    if not isinstance(protocol_digest, str) or len(protocol_digest) != 64:
+        errors.append("missing_or_invalid_calibration_protocol_digest")
+    elif protocol_path.is_file() and protocol_digest != sha256_file(protocol_path):
+        errors.append("calibration_protocol_digest_mismatch")
+
+    if expected_origin_main_sha is not None:
+        if pack.get("origin_main_sha") != expected_origin_main_sha:
+            errors.append("origin_main_sha_mismatch")
+
+    decls = pack.get("forbidden_authority_declarations")
+    if not isinstance(decls, dict):
+        errors.append("missing_forbidden_authority_declarations")
+    else:
+        for key in FORBIDDEN_DECLARATION_KEYS:
+            if decls.get(key) is not False:
+                errors.append(f"forbidden_authority_declaration_not_false:{key}")
+
+    # Completeness: empty scaffold OK for NOT_STARTED; otherwise reject incomplete.
+    campaign_status = pack.get("campaign_status")
+    completeness_required = campaign_status not in {"NOT_STARTED", "REJECTED_FAIL_CLOSED"} or bool(
+        pack.get("evidence_complete")
+    )
+    for key in PARTITION_KEYS:
+        manifest = pack.get(key)
+        incomplete = _manifest_incomplete(manifest)
+        if completeness_required and incomplete:
+            errors.append(f"incomplete_manifest:{key}")
+        if campaign_status == "NOT_STARTED":
+            if not isinstance(manifest, dict):
+                errors.append(f"incomplete_manifest:{key}")
+            elif (
+                manifest.get("status") != "EMPTY_SCAFFOLD" or manifest.get("populated") is not False
+            ):
+                # NOT_STARTED may only carry empty scaffolds.
+                if incomplete:
+                    errors.append(f"incomplete_manifest:{key}")
+
+    if pack.get("evidence_complete") is True:
+        for key in PARTITION_KEYS:
+            if _manifest_incomplete(pack.get(key)) or (
+                isinstance(pack.get(key), dict) and pack[key].get("status") != "COMPLETE"
+            ):
+                errors.append(f"incomplete_manifest:{key}")
+
+    rows = pack.get("per_token_evidence")
+    if not isinstance(rows, list):
+        errors.append("per_token_evidence_must_be_list")
+        rows = []
+
+    tokens = [row.get("token") for row in rows if isinstance(row, dict)]
+    token_set = {t for t in tokens if isinstance(t, str)}
+    expected = set(STAGE2_TOKENS)
+
+    if len(rows) != 18 or token_set != expected:
+        missing = sorted(expected - token_set)
+        unknown = sorted(token_set - expected)
+        if missing:
+            errors.append("missing_tokens:" + ",".join(missing))
+        if unknown:
+            errors.append("unknown_tokens:" + ",".join(unknown))
+        if len(rows) != 18:
+            errors.append(f"token_count_must_be_18_got_{len(rows)}")
+
+    if "OWNER_VALUE_CAPITAL_SLOT_REINVEST_FRACTION" in token_set:
+        errors.append("independent_reinvest_fraction_token_forbidden")
+
+    productive_set_count = 0
+    for idx, row in enumerate(rows):
+        if not isinstance(row, dict):
+            errors.append(f"per_token_row_not_object:{idx}")
+            continue
+
+        token = row.get("token")
+        if row.get("productive_numeric_value") is not None:
+            errors.append(f"productive_numeric_value_must_be_null:{token}")
+            productive_set_count += 1
+
+        if row.get("input_authority") is not False:
+            errors.append(f"input_authority_must_be_false:{token}")
+
+        if row.get("runtime_implemented") is not False:
+            errors.append(f"runtime_implemented_must_be_false:{token}")
+
+        for field in ("authority_source", "derivation_source"):
+            marker = _contains_forbidden_authority(_norm(row.get(field)))
+            if marker:
+                if marker in {"fixture", "scenario", "webui", "dashboard"}:
+                    errors.append(
+                        f"forbidden_fixture_webui_cmc_dashboard_authority:{token}:{field}"
+                    )
+                if marker in {"cmc.volatility_estimate", "cmc_volatility_estimate"}:
+                    errors.append(f"cmc_volatility_estimate_as_realized_volatility:{token}")
+                if marker == "survivalresultv1":
+                    errors.append(f"survival_result_v1_as_numeric_authority:{token}")
+                if marker == "suitabilityresultv1":
+                    errors.append(f"suitability_result_v1_as_numeric_authority:{token}")
+
+        authority_blob = " ".join(
+            [
+                _norm(row.get("authority_source")),
+                _norm(row.get("derivation_source")),
+            ]
+        )
+        if (
+            (
+                "cmc.volatility_estimate" in authority_blob
+                or "cmc_volatility_estimate" in authority_blob
+            )
+            and "realized" in authority_blob
+            and " not " not in f" {authority_blob} "
+        ):
+            errors.append(f"cmc_volatility_estimate_as_realized_volatility:{token}")
+        compact = authority_blob.replace("_", "").replace(" ", "")
+        if "survivalresultv1" in compact:
+            errors.append(f"survival_result_v1_as_numeric_authority:{token}")
+        if "suitabilityresultv1" in compact:
+            errors.append(f"suitability_result_v1_as_numeric_authority:{token}")
+
+        if token == "OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP":
+            quantum_blob = " ".join(
+                [
+                    _norm(row.get("derivation_source")),
+                    _norm(row.get("authority_source")),
+                    _norm(row.get("allowed_calibration_output_type")),
+                ]
+            )
+            if "wallclock" in quantum_blob or "wall_clock" in quantum_blob:
+                errors.append("capital_slot_time_quantum_wallclock_seconds")
+            if row.get("allowed_calibration_output_type") == "THRESHOLD_SECONDS":
+                errors.append("capital_slot_time_quantum_wallclock_seconds")
+
+        if token == "OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE":
+            derive = _norm(row.get("derivation_source"))
+            if "account_equity" in derive or "account-equity" in derive:
+                errors.append("initial_slot_base_from_account_equity")
+
+        if token == "OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION":
+            if _norm(row.get("derivation_source")) in {
+                "independent_reinvest_fraction",
+                "reinvest_fraction_independent",
+            }:
+                errors.append("independent_reinvest_fraction_value")
+            if row.get("productive_numeric_value") is not None and (
+                "reinvest" in _norm(row.get("authority_source"))
+            ):
+                errors.append("independent_reinvest_fraction_value")
+
+    # Pack-level independent REINVEST / quantum / equity claims via declarations.
+    # Mentioning the mechanical-coupling token as a dependency is allowed.
+    if decls and decls.get("reinvest_fraction_independent_numeric") is True:
+        errors.append("independent_reinvest_fraction_value")
+    if decls and decls.get("capital_slot_time_quantum_wallclock_seconds") is True:
+        errors.append("capital_slot_time_quantum_wallclock_seconds")
+    if decls and decls.get("initial_slot_base_from_account_equity") is True:
+        errors.append("initial_slot_base_from_account_equity")
+
+    # Observation identity must stay Sole-Trading-Authority bound
+    obs = pack.get("observation_identity")
+    if isinstance(obs, dict):
+        if obs.get("sole_consumer_authority") != SOLE_TRADING_AUTHORITY:
+            errors.append("observation_identity_sole_consumer_mismatch")
+
+    producer = pack.get("producer_identity")
+    if isinstance(producer, dict) and producer.get("productive_activation") is not False:
+        errors.append("producer_productive_activation_must_be_false")
+
+    unique_errors = sorted(set(errors))
+    return {
+        "contract": VALIDATOR_CONTRACT,
+        "ok": not unique_errors,
+        "errors": unique_errors,
+        "token_count": len(token_set),
+        "expected_token_count": 18,
+        "productive_numeric_values_set": productive_set_count,
+        "input_authority": pack.get("input_authority"),
+        "runtime_implemented": pack.get("runtime_implemented"),
+        "campaign_status": pack.get("campaign_status"),
+        "non_authorizing": True,
+    }
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("json_root_must_be_object")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail-closed validator for Pure-Stack Stage-2 numeric policy Evidence packs. "
+            "Non-authorizing. No runtime/archive/dashboard mutation."
+        )
+    )
+    parser.add_argument(
+        "--pack-json",
+        type=Path,
+        required=True,
+        help="Path to Evidence pack / campaign manifest JSON",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root for Stage-1/protocol digest checks",
+    )
+    parser.add_argument(
+        "--expected-origin-main-sha",
+        type=str,
+        default=None,
+        help="Optional exact origin/main SHA pin",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        pack = load_json(args.pack_json)
+    except Exception as exc:  # noqa: BLE001 — CLI boundary
+        payload = {
+            "contract": VALIDATOR_CONTRACT,
+            "ok": False,
+            "errors": [f"pack_load_error:{exc}"],
+            "non_authorizing": True,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 1
+
+    result = validate_pack(
+        pack,
+        repo_root=args.repo_root or repo_root_from_here(),
+        expected_origin_main_sha=args.expected_origin_main_sha,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_validate_productive_pure_stack_numeric_policy_evidence_pack_v1.py
+++ b/tests/ops/test_validate_productive_pure_stack_numeric_policy_evidence_pack_v1.py
@@ -1,0 +1,321 @@
+"""Fail-closed tests for Stage-2 numeric policy Evidence pack scaffolding v1.
+
+Docs/validator-only. Non-authorizing. No runtime, dashboard, archive, or config mutation.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI = REPO_ROOT / "scripts/ops/validate_productive_pure_stack_numeric_policy_evidence_pack_v1.py"
+CAMPAIGN = (
+    REPO_ROOT
+    / "docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_CAMPAIGN_MANIFEST_V1.json"
+)
+SCHEMA = (
+    REPO_ROOT / "docs/ops/schemas/productive_pure_stack_numeric_policy_evidence_pack_v1.schema.json"
+)
+REQUIREMENTS = (
+    REPO_ROOT / "docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_EVIDENCE_REQUIREMENTS_V1.md"
+)
+SCAFFOLDING = (
+    REPO_ROOT / "docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_EVIDENCE_PACK_SCAFFOLDING_V1.md"
+)
+STAGE1 = REPO_ROOT / "docs/ops/PRODUCTIVE_PURE_STACK_OWNER_VALUES_STRUCTURAL_MANIFEST_V1.json"
+PROTOCOL = REPO_ROOT / "docs/ops/PRODUCTIVE_PURE_STACK_NUMERIC_POLICY_CALIBRATION_PROTOCOL_V1.md"
+
+STAGE2_TOKENS: tuple[str, ...] = (
+    "OWNER_VALUE_FUTURES_INPUT_FRESHNESS_MAX_AGE_SECONDS",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_PATH_SURVIVAL_RATIO",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EARLY_LOSS_TOXICITY",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_MARGIN_BUFFER_AT_RISK_99",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_SEQUENCE_FRAGILITY_INDEX",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_LIQUIDATION_NEAR_MISS_RATE",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_GOVERNANCE_BREACH_FREQUENCY",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_CHOP_SWITCH_SURVIVAL_SCORE",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_EFFECTIVE_LEVERAGE",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MIN_LIQUIDATION_BUFFER",
+    "OWNER_VALUE_SURVIVAL_LIMIT_MAX_ADVERSE_FILL_LOSS",
+    "OWNER_VALUE_CAPITAL_SLOT_PROFIT_STEP_PCT",
+    "OWNER_VALUE_CAPITAL_SLOT_CASHFLOW_LOCK_FRACTION",
+    "OWNER_VALUE_CAPITAL_SLOT_MIN_REALIZED_VOLATILITY",
+    "OWNER_VALUE_CAPITAL_SLOT_MIN_ATR_OR_RANGE",
+    "OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP",
+    "OWNER_VALUE_CAPITAL_SLOT_MIN_OPPORTUNITY_SCORE",
+    "OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE",
+)
+
+FORBIDDEN_IMPORT_MARKERS = (
+    "market_dashboard",
+    "from src.execution",
+    "import execution",
+    "src.archive",
+    "durable_closeout",
+    "run_integrated_offline_trading_logic_replay_v1",
+)
+
+
+def _load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "validate_productive_pure_stack_numeric_policy_evidence_pack_v1",
+        CLI,
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_campaign() -> dict:
+    return json.loads(CAMPAIGN.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def cli():
+    return _load_cli()
+
+
+def test_artifacts_exist_v1() -> None:
+    assert CLI.is_file()
+    assert CAMPAIGN.is_file()
+    assert SCHEMA.is_file()
+    assert REQUIREMENTS.is_file()
+    assert SCAFFOLDING.is_file()
+    assert STAGE1.is_file()
+    assert PROTOCOL.is_file()
+
+
+def test_valid_empty_not_started_manifest_v1(cli) -> None:
+    pack = _load_campaign()
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is True, result["errors"]
+    assert pack["campaign_status"] == "NOT_STARTED"
+    assert pack["evidence_complete"] is False
+    assert pack["owner_ratified"] is False
+    assert pack["productive_numeric_values_set"] == 0
+    assert pack["input_authority"] is False
+    assert pack["runtime_implemented"] is False
+
+
+def test_exactly_18_stage2_tokens_v1(cli) -> None:
+    pack = _load_campaign()
+    tokens = [row["token"] for row in pack["per_token_evidence"]]
+    assert len(tokens) == 18
+    assert set(tokens) == set(STAGE2_TOKENS)
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["token_count"] == 18
+    assert result["ok"] is True
+
+
+def test_productive_numeric_values_remain_null_v1() -> None:
+    pack = _load_campaign()
+    assert pack["productive_numeric_values_set"] == 0
+    for row in pack["per_token_evidence"]:
+        assert row["productive_numeric_value"] is None
+        assert row["input_authority"] is False
+        assert row["runtime_implemented"] is False
+
+
+def test_reject_unknown_or_missing_tokens_v1(cli) -> None:
+    pack = _load_campaign()
+    bad = deepcopy(pack)
+    bad["per_token_evidence"] = bad["per_token_evidence"][:-1]
+    result = cli.validate_pack(bad, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert any(
+        e.startswith("missing_tokens:") or "token_count_must_be_18" in e for e in result["errors"]
+    )
+
+    bad2 = deepcopy(pack)
+    bad2["per_token_evidence"][0]["token"] = "OWNER_VALUE_NOT_A_STAGE2_TOKEN"
+    result2 = cli.validate_pack(bad2, repo_root=REPO_ROOT)
+    assert result2["ok"] is False
+    assert any(e.startswith("unknown_tokens:") for e in result2["errors"])
+
+
+def test_reject_productive_numeric_value_not_null_v1(cli) -> None:
+    pack = deepcopy(_load_campaign())
+    pack["per_token_evidence"][0]["productive_numeric_value"] = 42
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert any(e.startswith("productive_numeric_value_must_be_null:") for e in result["errors"])
+
+
+def test_reject_input_authority_not_false_v1(cli) -> None:
+    pack = deepcopy(_load_campaign())
+    pack["input_authority"] = True
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert "input_authority_must_be_false" in result["errors"]
+
+
+def test_reject_runtime_implemented_not_false_v1(cli) -> None:
+    pack = deepcopy(_load_campaign())
+    pack["runtime_implemented"] = True
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert "runtime_implemented_must_be_false" in result["errors"]
+
+
+def test_reject_missing_stage1_or_protocol_digests_v1(cli) -> None:
+    pack = deepcopy(_load_campaign())
+    pack["stage1_manifest_digest"] = ""
+    pack["calibration_protocol_digest"] = "deadbeef"
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert "missing_or_invalid_stage1_manifest_digest" in result["errors"]
+    assert "missing_or_invalid_calibration_protocol_digest" in result["errors"]
+
+    pack2 = deepcopy(_load_campaign())
+    pack2["stage1_manifest_digest"] = "0" * 64
+    pack2["calibration_protocol_digest"] = "1" * 64
+    result2 = cli.validate_pack(pack2, repo_root=REPO_ROOT)
+    assert result2["ok"] is False
+    assert "stage1_manifest_digest_mismatch" in result2["errors"]
+    assert "calibration_protocol_digest_mismatch" in result2["errors"]
+
+
+def test_reject_fixture_webui_cmc_dashboard_authority_v1(cli) -> None:
+    pack = deepcopy(_load_campaign())
+    pack["per_token_evidence"][0]["authority_source"] = "webui_hardcoded_limit"
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert any("forbidden_fixture_webui_cmc_dashboard_authority:" in e for e in result["errors"])
+
+
+def test_reject_cmc_volatility_estimate_as_realized_volatility_v1(cli) -> None:
+    pack = deepcopy(_load_campaign())
+    for row in pack["per_token_evidence"]:
+        if row["token"] == "OWNER_VALUE_CAPITAL_SLOT_MIN_REALIZED_VOLATILITY":
+            row["authority_source"] = "CMC.volatility_estimate as realized_volatility"
+            break
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert any("cmc_volatility_estimate_as_realized_volatility:" in e for e in result["errors"])
+
+
+def test_reject_survival_or_suitability_result_v1_authority_v1(cli) -> None:
+    pack = deepcopy(_load_campaign())
+    pack["per_token_evidence"][1]["authority_source"] = "SurvivalResultV1"
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert any("survival_result_v1_as_numeric_authority:" in e for e in result["errors"])
+
+    pack2 = deepcopy(_load_campaign())
+    pack2["per_token_evidence"][1]["authority_source"] = "SuitabilityResultV1"
+    result2 = cli.validate_pack(pack2, repo_root=REPO_ROOT)
+    assert result2["ok"] is False
+    assert any("suitability_result_v1_as_numeric_authority:" in e for e in result2["errors"])
+
+
+def test_reject_incomplete_stress_oos_partition_manifests_v1(cli) -> None:
+    pack = deepcopy(_load_campaign())
+    pack["campaign_status"] = "IN_PROGRESS"
+    pack["evidence_complete"] = True
+    pack["stress_pack_manifest"] = {
+        "status": "DECLARED",
+        "populated": True,
+        "entries": [],
+        "digest": None,
+        "notes": "incomplete",
+    }
+    pack["train_calibration_validation_partition_manifest"] = {
+        "status": "EMPTY_SCAFFOLD",
+        "populated": False,
+        "entries": [],
+        "digest": None,
+        "notes": None,
+    }
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert any(e.startswith("incomplete_manifest:") for e in result["errors"])
+
+
+def test_reject_independent_reinvest_fraction_v1(cli) -> None:
+    pack = deepcopy(_load_campaign())
+    pack["forbidden_authority_declarations"]["reinvest_fraction_independent_numeric"] = True
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert "independent_reinvest_fraction_value" in result["errors"]
+
+    pack2 = deepcopy(_load_campaign())
+    extra = deepcopy(pack2["per_token_evidence"][0])
+    extra["token"] = "OWNER_VALUE_CAPITAL_SLOT_REINVEST_FRACTION"
+    pack2["per_token_evidence"].append(extra)
+    result2 = cli.validate_pack(pack2, repo_root=REPO_ROOT)
+    assert result2["ok"] is False
+    assert "independent_reinvest_fraction_token_forbidden" in result2["errors"]
+
+
+def test_reject_wallclock_seconds_for_time_quantum_v1(cli) -> None:
+    pack = deepcopy(_load_campaign())
+    for row in pack["per_token_evidence"]:
+        if row["token"] == "OWNER_VALUE_CAPITAL_SLOT_MAX_TIME_WITHOUT_CASHFLOW_STEP":
+            row["derivation_source"] = "wallclock_seconds"
+            row["allowed_calibration_output_type"] = "THRESHOLD_SECONDS"
+            break
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert "capital_slot_time_quantum_wallclock_seconds" in result["errors"]
+
+
+def test_reject_account_equity_derivation_for_initial_slot_base_v1(cli) -> None:
+    pack = deepcopy(_load_campaign())
+    for row in pack["per_token_evidence"]:
+        if row["token"] == "OWNER_VALUE_CAPITAL_SLOT_INITIAL_SLOT_BASE":
+            row["derivation_source"] = "account_equity"
+            break
+    result = cli.validate_pack(pack, repo_root=REPO_ROOT)
+    assert result["ok"] is False
+    assert "initial_slot_base_from_account_equity" in result["errors"]
+
+
+def test_validator_does_not_import_or_mutate_runtime_dashboard_archive_v1() -> None:
+    source = CLI.read_text(encoding="utf-8")
+    for marker in FORBIDDEN_IMPORT_MARKERS:
+        # Symbol name may appear as a string constant (authority pin), but not as import.
+        if marker.startswith("from ") or marker.startswith("import ") or marker.startswith("src."):
+            assert marker not in source
+    tree = ast.parse(source)
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.append(node.module or "")
+    joined = " ".join(imported)
+    assert "market_dashboard" not in joined
+    assert "execution" not in joined
+    assert "archive" not in joined
+    assert "src." not in joined
+    # No Path.write / open write side effects in validator module body beyond CLI stdout.
+    assert "write_text" not in source
+    assert "Path.open" not in source or "read" in source
+
+
+def test_requirements_doc_covers_all_18_tokens_v1() -> None:
+    text = REQUIREMENTS.read_text(encoding="utf-8")
+    for token in STAGE2_TOKENS:
+        assert token in text
+    assert "productive_numeric_value=null" in text or "productive_numeric_value | `null`" in text
+    assert "TOKEN_COUNT=18" in text
+    assert "CALIBRATION_EXECUTED=false" in text
+
+
+def test_scaffolding_governance_assertions_v1() -> None:
+    text = SCAFFOLDING.read_text(encoding="utf-8")
+    assert "INFRASTRUCTURE_ONLY_NO_CALIBRATION_NO_NUMBERS" in text
+    assert "CALIBRATION_EXECUTED=false" in text
+    assert "NO_TOKEN_MAY_BE_GROUP_AUTO_RATIFIED=true" in text
+    assert "EACH_PRODUCTIVE_VALUE_REQUIRES_SEPARATE_OWNER_RATIFICATION=true" in text
+    assert "PRIMARY=SAFETY_METRICS" in text
+    assert "separate" in text.lower()


### PR DESCRIPTION
## Summary
- Fail-closed Stage-2 Evidence Pack scaffolding for the exact 18 `NUMERIC_CALIBRATION_REQUIRED` Owner Values (schema, empty `NOT_STARTED` campaign manifest, per-token requirements, validator, tests, governance doc).
- No productive numbers, candidates, defaults, recommendations, or example values; `productive_numeric_value=null` for all 18 tokens.
- `INPUT_AUTHORITY=false`, `RUNTIME_IMPLEMENTED=false`; dashboard remains read-only consumer; Sole Trading Authority unchanged.

## Test plan
- [x] `pytest tests/ops/test_validate_productive_pure_stack_numeric_policy_evidence_pack_v1.py` (19 passed)
- [x] `ruff format --check` / `ruff check` on validator + tests
- [x] docs token policy + docs reference targets
- [x] empty campaign manifest validates via `validate_productive_pure_stack_numeric_policy_evidence_pack_v1.py`

## Non-authorization
- `PRODUCTIVE_NUMERIC_VALUES_SET=0`
- No calibration executed; no Owner ratification of numbers
- Evidence-pack scaffolding and productive activation remain separate PRs

Made with [Cursor](https://cursor.com)