### PR TITLE
docs(ops): Stage-2 Surface B Notion mirror sync post #5730

### DIFF
--- a/docs/ops/PRODUCTIVE_PURE_STACK_STAGE2_NOTION_MIRROR_SYNC_V1.md
+++ b/docs/ops/PRODUCTIVE_PURE_STACK_STAGE2_NOTION_MIRROR_SYNC_V1.md
@@ -1,0 +1,97 @@
+# Stage-2 Shadow Campaign — Notion Mirror Sync Attestation v1
+
+```text
+DOCUMENT_TYPE=NOTION_MIRROR_SYNC_ATTESTATION
+DOCUMENT_VERSION=1
+STATUS=MIRROR_SYNCED_TO_ORIGIN_MAIN
+ORIGIN_MAIN_SHA=c7111c748300b53884394569da679fcb91993007
+AUTHORITY_SURFACE=B
+PR_5729_RATIFIED=true
+PR_5730_MERGED=true
+SHADOW_CAMPAIGN_STARTABLE=true
+INPUT_AUTHORITY=false
+RUNTIME_IMPLEMENTED=false
+PRODUCTIVE_NUMERIC_VALUES_SET=0
+DASHBOARD_AUTHORITY_EFFECT=NONE
+TRADING_LOGIC_CHANGED=false
+ORDERS_TESTNET_LIVE_PAPER_EFFECTS=false
+PRODUCTIVE_RUNTIME_AUTHORITY=false
+NUMERIC_CALIBRATION=false
+NOTION_SSOT=false
+REPOSITORY_IS_SSOT=true
+RUNTIME_AUTHORIZATION_EFFECT=NONE
+```
+
+## 0. Binding effect
+
+This document is a **documentary Notion Mirror sync attestation** only.
+
+It records that the Peak_Trade Notion Mirror was updated to reflect the
+Owner-ratified repository state after:
+
+- PR [#5729](https://github.com/rauterfrank-ui/Peak_Trade/pull/5729)
+  (Authority Surface B ratification + bounded scaffolding)
+- PR [#5730](https://github.com/rauterfrank-ui/Peak_Trade/pull/5730)
+  (Surface-B evidence-collection collector + PIT/provenance/stale guards)
+
+Repository `origin&#47;main` remains the sole technical SSOT. Notion is a
+read-only mirror/consumer and has no runtime, trading, security, or
+numeric-policy authority.
+
+## 1. Mirrored repository truth
+
+```text
+ORIGIN_MAIN_SHA=c7111c748300b53884394569da679fcb91993007
+AUTHORITY_SURFACE=B
+SHADOW_CAMPAIGN_STARTABLE=true
+INPUT_AUTHORITY=false
+RUNTIME_IMPLEMENTED=false
+PRODUCTIVE_NUMERIC_VALUES_SET=0
+DASHBOARD_AUTHORITY_EFFECT=NONE
+TRADING_LOGIC_CHANGED=false
+ORDERS_TESTNET_LIVE_PAPER_EFFECTS=false
+```
+
+Stage-2 Shadow Evidence Campaign may be started as evidence-collection
+only. Productive runtime authority and numeric calibration remain false /
+unauthorized.
+
+## 2. Notion mirror targets (consumer pages)
+
+| Page | Role |
+|---|---|
+| Peak_Trade Knowledge Graph (Current) | Current-state mirror |
+| Docs / Runbooks / Truth Maps | Docs/truth-map mirror |
+| Evidence / Readiness | Evidence/readiness mirror |
+
+Notion page updates are documentary only and do not authorize orders,
+paper exchange, testnet, live trading, credentials, or capital movement.
+
+## 3. Explicit non-effects
+
+```text
+INPUT_AUTHORITY=false
+RUNTIME_IMPLEMENTED=false
+PRODUCTIVE_NUMERIC_VALUES_SET=0
+PRODUCTIVE_CALIBRATION_AUTHORIZED=false
+DASHBOARD_AUTHORITY_EFFECT=NONE
+ORDERS=false
+TESTNET=false
+LIVE=false
+PAPER_EXCHANGE_ORDERS=false
+EXCHANGE_CREDENTIAL_USE=false
+REAL_CAPITAL_MOVEMENT=false
+CORE_LOGIC_CHANGE=false
+NOTION_SSOT=false
+```
+
+## 4. Canonical repository pointers
+
+- Owner ratification:
+  `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_STAGE2_SHADOW_CAMPAIGN_INPUT_AUTHORITY_OWNER_RATIFICATION_V1.md`
+- Decisions manifest:
+  `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_STAGE2_SHADOW_CAMPAIGN_INPUT_AUTHORITY_DECISIONS_V1.json`
+- Implementation plan:
+  `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_STAGE2_SHADOW_CAMPAIGN_INPUT_AUTHORITY_IMPLEMENTATION_PLAN_V1.md`
+- Surface-B package:
+  `src&#47;ops&#47;productive_pure_stack_stage2_shadow_campaign_input_authority_v1&#47;`

--- a/tests/ops/test_productive_pure_stack_stage2_notion_mirror_sync_v1.py
+++ b/tests/ops/test_productive_pure_stack_stage2_notion_mirror_sync_v1.py
@@ -1,0 +1,55 @@
+"""Static contract: Stage-2 Notion Mirror sync attestation v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ATTESTATION = REPO_ROOT / "docs" / "ops" / "PRODUCTIVE_PURE_STACK_STAGE2_NOTION_MIRROR_SYNC_V1.md"
+
+REQUIRED_MARKERS: tuple[str, ...] = (
+    "DOCUMENT_TYPE=NOTION_MIRROR_SYNC_ATTESTATION",
+    "STATUS=MIRROR_SYNCED_TO_ORIGIN_MAIN",
+    "ORIGIN_MAIN_SHA=c7111c748300b53884394569da679fcb91993007",
+    "AUTHORITY_SURFACE=B",
+    "PR_5729_RATIFIED=true",
+    "PR_5730_MERGED=true",
+    "SHADOW_CAMPAIGN_STARTABLE=true",
+    "INPUT_AUTHORITY=false",
+    "RUNTIME_IMPLEMENTED=false",
+    "PRODUCTIVE_NUMERIC_VALUES_SET=0",
+    "DASHBOARD_AUTHORITY_EFFECT=NONE",
+    "TRADING_LOGIC_CHANGED=false",
+    "ORDERS_TESTNET_LIVE_PAPER_EFFECTS=false",
+    "NOTION_SSOT=false",
+    "REPOSITORY_IS_SSOT=true",
+)
+
+FORBIDDEN_CLAIMS: tuple[str, ...] = (
+    "INPUT_AUTHORITY=true",
+    "RUNTIME_IMPLEMENTED=true",
+    "PRODUCTIVE_NUMERIC_VALUES_SET=1",
+    "NOTION_SSOT=true",
+    "DASHBOARD_AUTHORITY_EFFECT=AUTHORITATIVE",
+    "ORDERS_TESTNET_LIVE_PAPER_EFFECTS=true",
+    "TRADING_LOGIC_CHANGED=true",
+)
+
+
+def test_stage2_notion_mirror_attestation_exists_v1() -> None:
+    assert ATTESTATION.is_file()
+
+
+def test_stage2_notion_mirror_attestation_markers_v1() -> None:
+    text = ATTESTATION.read_text(encoding="utf-8")
+    for marker in REQUIRED_MARKERS:
+        assert marker in text, marker
+    for claim in FORBIDDEN_CLAIMS:
+        assert claim not in text, claim
+
+
+def test_stage2_notion_mirror_attestation_non_authorizing_v1() -> None:
+    text = ATTESTATION.read_text(encoding="utf-8")
+    assert "documentary Notion Mirror sync attestation" in text
+    assert "no runtime, trading, security, or" in text
+    assert "PRODUCTIVE_CALIBRATION_AUTHORIZED=false" in text


### PR DESCRIPTION
## Summary
- Documentary Notion Mirror sync attestation for Stage-2 Shadow Campaign Input Authority Surface **B** after PR #5729 (ratified) and PR #5730 (merged).
- Records repository SSOT `origin/main@c7111c748300b53884394569da679fcb91993007` with `SHADOW_CAMPAIGN_STARTABLE=true` and all forbidden authority/runtime/trading effects remaining false.
- Notion pages updated as read-only mirror/consumer only (`NOTION_SSOT=false`); no trading/runtime/security model changes.

## Test plan
- [x] Static Notion-mirror attestation contract tests
- [x] `ruff format --check` + `ruff check` (test file)
- [x] Docs token policy + docs-reference-targets
- [x] CI selector `NO_OP` (`docs_workflow_or_static_contract_only`) — timing proof not required
- [ ] GitHub required checks green
- [ ] **Do not merge** without separate explicit `OWNER_MERGE_GO`

## Forbidden effects (must remain false)
```text
INPUT_AUTHORITY=false
RUNTIME_IMPLEMENTED=false
PRODUCTIVE_NUMERIC_VALUES_SET=0
DASHBOARD_AUTHORITY_EFFECT=NONE
TRADING_LOGIC_CHANGED=false
ORDERS_TESTNET_LIVE_PAPER_EFFECTS=false
NOTION_SSOT=false
```
