### PR TITLE
docs(security): Stage-2 Surface B cybersecurity mirror sync post #5731

### DIFF
--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -1,10 +1,10 @@
 # Security Notes — Peak_Trade Cybersecurity Baseline Pointers
 
 **Scope ID:** `PEAK_TRADE_CYBERSECURITY_BASELINE_REFRESH_V1`
-**Capability overlay:** `CYBER_CI_SUPPLY_CHAIN_HARDENING_V1` (2026-07-26); `SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1` (2026-07-26); `SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1` (2026-07-26); `BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1` (2026-07-26); `WEBUI_LOCAL_ADMIN_WRITE_SURFACE_AUTH_GATE_V1` (2026-07-26); `POST_CAPABILITY_7_2_CYBERSECURITY_REVIEW_V1` (2026-08-02)
-**Last Reviewed (repo-static):** 2026-08-02 (Post-Capability-7.2 cybersecurity review against `origin&#47;main@08b19c8c83f76ab29d99c8c03b8f34504d2b0021`; prior supply-chain/baseline overlays unchanged)
+**Capability overlay:** `CYBER_CI_SUPPLY_CHAIN_HARDENING_V1` (2026-07-26); `SECRET_HYGIENE_AND_REDACTION_UNIFICATION_V1` (2026-07-26); `SECRET_SCANNING_AND_PUSH_PROTECTION_GOVERNANCE_V1` (2026-07-26); `BRANCH_RULESET_ENFORCEMENT_GOVERNANCE_V1` (2026-07-26); `WEBUI_LOCAL_ADMIN_WRITE_SURFACE_AUTH_GATE_V1` (2026-07-26); `POST_CAPABILITY_7_2_CYBERSECURITY_REVIEW_V1` (2026-08-02); `STAGE2_SURFACE_B_CYBERSECURITY_MIRROR_SYNC_V1` (2026-08-05)
+**Last Reviewed (repo-static):** 2026-08-05 (Stage-2 Surface B cybersecurity mirror sync against `origin&#47;main@6db2d4920ace92cab8fc2bab834b75446808d1a1` after PRs #5729/#5730/#5731; Cap-7.2 review and prior supply-chain/baseline overlays unchanged)
 **Mode:** Documentation + pointers to existing SSOT owners. **Non-authorizing.**
-**Does not:** rotate secrets, change GitHub org/repo security toggles, enable live/testnet/orders, start a public-MD network session, consume authorization, or claim unverified scanner results.
+**Does not:** rotate secrets, change GitHub org/repo security toggles, enable live/testnet/orders, start a public-MD network session, consume authorization, flip productive input authority, set productive numeric Owner values, or claim unverified scanner results.
 
 ---
 
@@ -29,6 +29,7 @@
 | Dependency audit workflow | [`.github/workflows/audit.yml`](.github/workflows/audit.yml) |
 | Manual full audit + optional SBOM export | [`.github/workflows/full_audit_weekly.yml`](.github/workflows/full_audit_weekly.yml) + [`scripts/ops/run_full_audit.sh`](scripts/ops/run_full_audit.sh) |
 | Post-Capability-7.2 no-order runtime cybersecurity review | [`docs/evidence/post_capability_7_2_cybersecurity_review_v1/`](docs/evidence/post_capability_7_2_cybersecurity_review_v1/) + Truth Map `CYBERSECURITY_REVIEW_CURRENT` in [`docs/governance/PEAK_TRADE_CANONICAL_RUNTIME_TRUTH_MAP_V1.md`](docs/governance/PEAK_TRADE_CANONICAL_RUNTIME_TRUTH_MAP_V1.md) |
+| Stage-2 Surface B cybersecurity mirror sync (post #5731) | [`docs/ops/PRODUCTIVE_PURE_STACK_STAGE2_CYBERSECURITY_MIRROR_SYNC_V1.md`](docs/ops/PRODUCTIVE_PURE_STACK_STAGE2_CYBERSECURITY_MIRROR_SYNC_V1.md) + Owner ratification [`docs/ops/PRODUCTIVE_PURE_STACK_STAGE2_SHADOW_CAMPAIGN_INPUT_AUTHORITY_OWNER_RATIFICATION_V1.md`](docs/ops/PRODUCTIVE_PURE_STACK_STAGE2_SHADOW_CAMPAIGN_INPUT_AUTHORITY_OWNER_RATIFICATION_V1.md) |
 
 **Docs ≠ Approval. AI ≠ Authority. Secret names ≠ secret values.**
 
@@ -118,7 +119,7 @@ Do **not** treat this file as live authorization. Relevant gates live in Master 
 
 - `LIVE_AUTHORIZED=false`
 - `ORDERS=false`
-- `SHADOW=false`
+- `SHADOW=false` (agent trading-shadow arming remains false; see §6.2 for evidence-only `SHADOW_CAMPAIGN_STARTABLE`)
 - `TESTNET=false`
 
 Docs live-enable pattern guard: [`scripts/ci/check_docs_no_live_enable_patterns.sh`](scripts/ci/check_docs_no_live_enable_patterns.sh).
@@ -144,6 +145,24 @@ Read-only security review of the activated single-future stateful no-order runti
 
 Durable evidence: [`docs/evidence/post_capability_7_2_cybersecurity_review_v1/`](docs/evidence/post_capability_7_2_cybersecurity_review_v1/). Residual low hardening note only: PSO `confirm_token` log-redaction helper is token-key focused; Cap 7.2 never constructs auth headers, and canonical `scripts/security/secret_hygiene_redaction_v1.py` redacts Authorization headers for logging/evidence export.
 
+### 6.2 Stage-2 Surface B cybersecurity mirror sync (2026-08-05)
+
+Documentary cybersecurity-mirror sync after Owner-ratified Stage-2 Authority Surface **B** (PRs #5729/#5730) and Notion mirror attestation (#5731), bound to `origin&#47;main@6db2d4920ace92cab8fc2bab834b75446808d1a1`.
+
+| Boundary | Required security reading |
+|----------|---------------------------|
+| Surface B | Ratified **input-authority structure** only — not active productive input authority |
+| `INPUT_AUTHORITY` | `false` |
+| `RUNTIME_IMPLEMENTED` | `false` (no authorized runtime producer / productive emission) |
+| `PRODUCTIVE_NUMERIC_VALUES_SET` | `0` |
+| `SHADOW_CAMPAIGN_STARTABLE` | `true` = evidence-collection startability only; **not** order, paper, testnet, live, credential, or real-capital release |
+| Dashboard | `DASHBOARD_AUTHORITY_EFFECT=NONE` — consumer only; no authority / semantics / decision logic |
+| Notion | Mirror/consumer only (`NOTION_SSOT=false`); no authority / semantics / decision logic |
+| Repository | Sole technical SSOT (`REPOSITORY_IS_SSOT=true`) |
+| Exchange credentials / order adapters | Unauthorized / unreachable under this sync |
+
+Attestation owner: [`docs/ops/PRODUCTIVE_PURE_STACK_STAGE2_CYBERSECURITY_MIRROR_SYNC_V1.md`](docs/ops/PRODUCTIVE_PURE_STACK_STAGE2_CYBERSECURITY_MIRROR_SYNC_V1.md). This section does **not** authorize Stage-2 productive calibration, input-authority flips, runtime activation, or any exchange side effect.
+
 ---
 
 ## 7. Residual risks & follow-ups (owner: ops)
@@ -168,8 +187,12 @@ This document and the baseline refresh **must not** be read as proof that:
 - secrets were rotated,
 - Dependabot / CodeQL / private vulnerability reporting were enabled,
 - external org policies changed,
-- live/testnet/orders/shadow were armed,
+- live/testnet/orders/trading-shadow were armed,
+- productive `INPUT_AUTHORITY` or runtime producers were activated,
+- productive numeric Owner values were set,
 - or a full dependency CVE sweep was executed in this change.
+
+`SHADOW_CAMPAIGN_STARTABLE=true` (Stage-2 evidence-collection) must **not** be conflated with arming trading shadow, orders, credentials, or capital movement.
 
 ---
 

--- a/docs/ops/PRODUCTIVE_PURE_STACK_STAGE2_CYBERSECURITY_MIRROR_SYNC_V1.md
+++ b/docs/ops/PRODUCTIVE_PURE_STACK_STAGE2_CYBERSECURITY_MIRROR_SYNC_V1.md
@@ -1,0 +1,118 @@
+# Stage-2 Shadow Campaign — Cybersecurity Mirror Sync Attestation v1
+
+```text
+DOCUMENT_TYPE=CYBERSECURITY_MIRROR_SYNC_ATTESTATION
+DOCUMENT_VERSION=1
+STATUS=MIRROR_SYNCED_TO_ORIGIN_MAIN
+ORIGIN_MAIN_SHA=6db2d4920ace92cab8fc2bab834b75446808d1a1
+AUTHORITY_SURFACE=B
+PR_5729_RATIFIED=true
+PR_5730_MERGED=true
+PR_5731_MERGED=true
+SHADOW_CAMPAIGN_STARTABLE=true
+INPUT_AUTHORITY=false
+RUNTIME_IMPLEMENTED=false
+PRODUCTIVE_NUMERIC_VALUES_SET=0
+DASHBOARD_AUTHORITY_EFFECT=NONE
+TRADING_LOGIC_CHANGED=false
+ORDERS_TESTNET_LIVE_PAPER_EFFECTS=false
+EXCHANGE_CREDENTIAL_EFFECTS=false
+PRODUCTIVE_RUNTIME_AUTHORITY=false
+NUMERIC_CALIBRATION=false
+NOTION_SSOT=false
+REPOSITORY_IS_SSOT=true
+RUNTIME_AUTHORIZATION_EFFECT=NONE
+CYBERSECURITY_SYNC_REQUIRED=true
+```
+
+## 0. Binding effect
+
+This document is a **documentary Cybersecurity Mirror sync attestation**
+only.
+
+It records that the Peak_Trade cybersecurity baseline pointer
+(`SECURITY_NOTES.md`) was updated to reflect the Owner-ratified
+repository security boundaries after:
+
+- PR [#5729](https://github.com/rauterfrank-ui/Peak_Trade/pull/5729)
+  (Authority Surface B ratification + bounded scaffolding)
+- PR [#5730](https://github.com/rauterfrank-ui/Peak_Trade/pull/5730)
+  (Surface-B evidence-collection collector + PIT/provenance/stale guards)
+- PR [#5731](https://github.com/rauterfrank-ui/Peak_Trade/pull/5731)
+  (Notion Mirror sync attestation; Notion remains mirror-only)
+
+Repository `origin&#47;main` remains the sole technical SSOT. This
+attestation and `SECURITY_NOTES.md` are non-authorizing documentation.
+They do not authorize runtime producers, productive input authority,
+orders, credentials, or capital movement.
+
+## 1. Mirrored security truth
+
+```text
+ORIGIN_MAIN_SHA=6db2d4920ace92cab8fc2bab834b75446808d1a1
+AUTHORITY_SURFACE=B
+SHADOW_CAMPAIGN_STARTABLE=true
+INPUT_AUTHORITY=false
+RUNTIME_IMPLEMENTED=false
+PRODUCTIVE_NUMERIC_VALUES_SET=0
+DASHBOARD_AUTHORITY_EFFECT=NONE
+TRADING_LOGIC_CHANGED=false
+ORDERS_TESTNET_LIVE_PAPER_EFFECTS=false
+EXCHANGE_CREDENTIAL_EFFECTS=false
+REPOSITORY_IS_SSOT=true
+NOTION_SSOT=false
+```
+
+Surface **B** is the Owner-ratified **input-authority structure** for
+Stage-2 Shadow Evidence Campaign consumption only. Active productive
+input authority remains false. `SHADOW_CAMPAIGN_STARTABLE=true` means
+evidence-collection startability only and does **not** authorize orders,
+paper exchange, testnet, live trading, credentials, or real-capital
+movement.
+
+## 2. Security boundaries mirrored into SECURITY_NOTES
+
+| Boundary | Required value |
+|---|---|
+| Surface B role | ratified input-authority **structure** only |
+| `INPUT_AUTHORITY` | `false` (no productive input authority) |
+| Runtime producer / productive emission | unauthorized (`RUNTIME_IMPLEMENTED=false`) |
+| Productive numeric Owner values | `PRODUCTIVE_NUMERIC_VALUES_SET=0` |
+| Shadow-campaign startability | evidence-collection only; no order/capital release |
+| Dashboard | `DASHBOARD_AUTHORITY_EFFECT=NONE` (consumer only) |
+| Notion | mirror/consumer only (`NOTION_SSOT=false`) |
+| Repository | sole SSOT (`REPOSITORY_IS_SSOT=true`) |
+| Exchange credentials / order adapters | unreachable / unauthorized |
+
+## 3. Explicit non-effects
+
+```text
+INPUT_AUTHORITY=false
+RUNTIME_IMPLEMENTED=false
+PRODUCTIVE_NUMERIC_VALUES_SET=0
+PRODUCTIVE_CALIBRATION_AUTHORIZED=false
+DASHBOARD_AUTHORITY_EFFECT=NONE
+ORDERS=false
+TESTNET=false
+LIVE=false
+PAPER_EXCHANGE_ORDERS=false
+EXCHANGE_CREDENTIAL_USE=false
+REAL_CAPITAL_MOVEMENT=false
+CORE_LOGIC_CHANGE=false
+NOTION_SSOT=false
+CYBERSECURITY_RUNTIME_AUTHORIZATION_EFFECT=NONE
+```
+
+## 4. Canonical repository pointers
+
+- Cybersecurity baseline pointer: `SECURITY_NOTES.md`
+- Owner ratification:
+  `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_STAGE2_SHADOW_CAMPAIGN_INPUT_AUTHORITY_OWNER_RATIFICATION_V1.md`
+- Decisions manifest:
+  `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_STAGE2_SHADOW_CAMPAIGN_INPUT_AUTHORITY_DECISIONS_V1.json`
+- Implementation plan:
+  `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_STAGE2_SHADOW_CAMPAIGN_INPUT_AUTHORITY_IMPLEMENTATION_PLAN_V1.md`
+- Notion mirror sync (consumer only):
+  `docs&#47;ops&#47;PRODUCTIVE_PURE_STACK_STAGE2_NOTION_MIRROR_SYNC_V1.md`
+- Surface-B package:
+  `src&#47;ops&#47;productive_pure_stack_stage2_shadow_campaign_input_authority_v1&#47;`

--- a/tests/ops/test_productive_pure_stack_stage2_cybersecurity_mirror_sync_v1.py
+++ b/tests/ops/test_productive_pure_stack_stage2_cybersecurity_mirror_sync_v1.py
@@ -1,0 +1,82 @@
+"""Static contract: Stage-2 Cybersecurity Mirror sync attestation v1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ATTESTATION = (
+    REPO_ROOT / "docs" / "ops" / "PRODUCTIVE_PURE_STACK_STAGE2_CYBERSECURITY_MIRROR_SYNC_V1.md"
+)
+SECURITY_NOTES = REPO_ROOT / "SECURITY_NOTES.md"
+
+REQUIRED_MARKERS: tuple[str, ...] = (
+    "DOCUMENT_TYPE=CYBERSECURITY_MIRROR_SYNC_ATTESTATION",
+    "STATUS=MIRROR_SYNCED_TO_ORIGIN_MAIN",
+    "ORIGIN_MAIN_SHA=6db2d4920ace92cab8fc2bab834b75446808d1a1",
+    "AUTHORITY_SURFACE=B",
+    "PR_5729_RATIFIED=true",
+    "PR_5730_MERGED=true",
+    "PR_5731_MERGED=true",
+    "SHADOW_CAMPAIGN_STARTABLE=true",
+    "INPUT_AUTHORITY=false",
+    "RUNTIME_IMPLEMENTED=false",
+    "PRODUCTIVE_NUMERIC_VALUES_SET=0",
+    "DASHBOARD_AUTHORITY_EFFECT=NONE",
+    "TRADING_LOGIC_CHANGED=false",
+    "ORDERS_TESTNET_LIVE_PAPER_EFFECTS=false",
+    "EXCHANGE_CREDENTIAL_EFFECTS=false",
+    "NOTION_SSOT=false",
+    "REPOSITORY_IS_SSOT=true",
+)
+
+FORBIDDEN_CLAIMS: tuple[str, ...] = (
+    "INPUT_AUTHORITY=true",
+    "RUNTIME_IMPLEMENTED=true",
+    "PRODUCTIVE_NUMERIC_VALUES_SET=1",
+    "NOTION_SSOT=true",
+    "DASHBOARD_AUTHORITY_EFFECT=AUTHORITATIVE",
+    "ORDERS_TESTNET_LIVE_PAPER_EFFECTS=true",
+    "EXCHANGE_CREDENTIAL_EFFECTS=true",
+    "TRADING_LOGIC_CHANGED=true",
+)
+
+SECURITY_NOTES_REQUIRED: tuple[str, ...] = (
+    "STAGE2_SURFACE_B_CYBERSECURITY_MIRROR_SYNC_V1",
+    "6db2d4920ace92cab8fc2bab834b75446808d1a1",
+    "PRODUCTIVE_PURE_STACK_STAGE2_CYBERSECURITY_MIRROR_SYNC_V1.md",
+    "INPUT_AUTHORITY",
+    "SHADOW_CAMPAIGN_STARTABLE",
+    "DASHBOARD_AUTHORITY_EFFECT=NONE",
+    "NOTION_SSOT=false",
+    "REPOSITORY_IS_SSOT=true",
+)
+
+
+def test_stage2_cybersecurity_mirror_attestation_exists_v1() -> None:
+    assert ATTESTATION.is_file()
+
+
+def test_stage2_cybersecurity_mirror_attestation_markers_v1() -> None:
+    text = ATTESTATION.read_text(encoding="utf-8")
+    for marker in REQUIRED_MARKERS:
+        assert marker in text, marker
+    for claim in FORBIDDEN_CLAIMS:
+        assert claim not in text, claim
+
+
+def test_stage2_cybersecurity_mirror_attestation_non_authorizing_v1() -> None:
+    text = ATTESTATION.read_text(encoding="utf-8")
+    assert "documentary Cybersecurity Mirror sync attestation" in text
+    assert "PRODUCTIVE_CALIBRATION_AUTHORIZED=false" in text
+    assert "CYBERSECURITY_RUNTIME_AUTHORIZATION_EFFECT=NONE" in text
+    assert "evidence-collection startability only" in text
+
+
+def test_security_notes_mirror_stage2_surface_b_boundaries_v1() -> None:
+    notes = SECURITY_NOTES.read_text(encoding="utf-8")
+    for marker in SECURITY_NOTES_REQUIRED:
+        assert marker in notes, marker
+    assert "### 6.2 Stage-2 Surface B cybersecurity mirror sync" in notes
+    assert "not active productive input authority" in notes
+    assert "Exchange credentials / order adapters" in notes


### PR DESCRIPTION
## Summary
- Documentary Cybersecurity Mirror sync for Stage-2 Shadow Campaign Input Authority Surface **B** after PRs #5729/#5730/#5731.
- Updates `SECURITY_NOTES.md` §6.2 so Surface B is recorded as ratified input-authority **structure** only (`INPUT_AUTHORITY=false`), with `SHADOW_CAMPAIGN_STARTABLE=true` as evidence-collection only (no orders/credentials/capital).
- Adds attestation + static contract tests; no runtime/trading changes.

## Test plan
- [x] Static cybersecurity-mirror attestation contract tests
- [x] Related `SECURITY_NOTES` baseline anchor contract
- [x] `ruff format --check` + `ruff check` (test file)
- [x] Docs token policy + docs-reference-targets
- [x] CI selector `NO_OP` (`docs_workflow_or_static_contract_only`) — timing proof not required
- [ ] GitHub required checks green
- [ ] **Do not merge** without separate explicit `OWNER_MERGE_GO`

## Forbidden effects (must remain false)
```text
INPUT_AUTHORITY=false
RUNTIME_IMPLEMENTED=false
PRODUCTIVE_NUMERIC_VALUES_SET=0
DASHBOARD_AUTHORITY_EFFECT=NONE
TRADING_LOGIC_CHANGED=false
ORDERS_TESTNET_LIVE_PAPER_EFFECTS=false
EXCHANGE_CREDENTIAL_EFFECTS=false
NOTION_SSOT=false
REPOSITORY_IS_SSOT=true
```

Made with [Cursor](https://cursor.com)