### PR TITLE
Fix Step-7 campaign wallclock invoke packaging (no session_id kwargs)

### DIFF
--- a/scripts/ops/run_phase_9_2_step_7_delegated_cursor_secure_confirm_campaign_operator_entrypoint_v1.py
+++ b/scripts/ops/run_phase_9_2_step_7_delegated_cursor_secure_confirm_campaign_operator_entrypoint_v1.py
@@ -50,6 +50,9 @@ from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1
 from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.governed_campaign_execution_v1 import (  # noqa: E402
     execute_governed_step7_campaign_v1,
 )
+from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.wallclock_packaging_v1 import (  # noqa: E402
+    prove_step7_wallclock_packaging_bound_v1,
+)
 from src.ops.single_future_stateful_no_order_runtime_activation_v1.config_v1 import (  # noqa: E402
     load_activation_config_v1,
 )
@@ -110,6 +113,29 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, sort_keys=True, indent=2 if args.json else None))
         return 2
 
+    packaging = prove_step7_wallclock_packaging_bound_v1()
+    if not packaging.get("ok"):
+        payload = {
+            "ok": False,
+            "blockers": sorted(
+                set(
+                    list(packaging.get("blockers") or [])
+                    + ["STEP7_WALLCLOCK_PACKAGING_BINDING_FAILED"]
+                )
+            ),
+            "AUTHORIZATION_CHANNEL": AUTH_CHANNEL_DELEGATED_CURSOR_SECURE_CONFIRM,
+            "TOKEN_ROLE": CONFIRM_TOKEN_ROLE_EPHEMERAL_EXECUTION_LATCH,
+            "network_session_started": False,
+            "confirm_token_minted": False,
+            "confirm_token_consumed": False,
+            "confirm_token_plaintext_exposed": False,
+            "STEP7_WALLCLOCK_PACKAGING_BOUND": False,
+            "REAL_TTY_VERIFIED": False,
+            "DELEGATED_SECURE_CONFIRM_VERIFIED": False,
+        }
+        print(json.dumps(payload, sort_keys=True, indent=2 if args.json else None))
+        return 2
+
     sha = args.expected_repository_sha or _repo_sha()
     cfg = _cfg()
     latch = mint_delegated_cursor_secure_confirm_latch_v1()
@@ -141,6 +167,7 @@ def main(argv: list[str] | None = None) -> int:
         payload["confirm_token_digest_sha256"] = token_digest
         payload["AUTHORIZATION_CHANNEL"] = AUTH_CHANNEL_DELEGATED_CURSOR_SECURE_CONFIRM
         payload["TOKEN_ROLE"] = CONFIRM_TOKEN_ROLE_EPHEMERAL_EXECUTION_LATCH
+        payload["STEP7_WALLCLOCK_PACKAGING_BOUND"] = True
         # Hard disclosure guard: never emit latch repr secrets (digest-only already).
         blob = json.dumps(payload, sort_keys=True, indent=2 if args.json else None)
         print(blob)

--- a/scripts/ops/run_phase_9_2_step_7_real_tty_campaign_operator_entrypoint_v1.py
+++ b/scripts/ops/run_phase_9_2_step_7_real_tty_campaign_operator_entrypoint_v1.py
@@ -52,6 +52,9 @@ from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1
 from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.governed_campaign_execution_v1 import (  # noqa: E402
     execute_governed_step7_campaign_v1,
 )
+from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.wallclock_packaging_v1 import (  # noqa: E402
+    prove_step7_wallclock_packaging_bound_v1,
+)
 from src.ops.single_future_stateful_no_order_runtime_activation_v1.config_v1 import (  # noqa: E402
     load_activation_config_v1,
 )
@@ -110,6 +113,27 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, sort_keys=True, indent=2 if args.json else None))
         return 2
 
+    packaging = prove_step7_wallclock_packaging_bound_v1()
+    if not packaging.get("ok"):
+        payload = {
+            "ok": False,
+            "blockers": sorted(
+                set(
+                    list(packaging.get("blockers") or [])
+                    + ["STEP7_WALLCLOCK_PACKAGING_BINDING_FAILED"]
+                )
+            ),
+            "AUTHORIZATION_CHANNEL": AUTH_CHANNEL_REAL_TTY_HUMAN_CONFIRM,
+            "TOKEN_ROLE": CONFIRM_TOKEN_ROLE_EPHEMERAL_EXECUTION_LATCH,
+            "network_session_started": False,
+            "confirm_token_minted": False,
+            "confirm_token_consumed": False,
+            "confirm_token_plaintext_exposed": False,
+            "STEP7_WALLCLOCK_PACKAGING_BOUND": False,
+        }
+        print(json.dumps(payload, sort_keys=True, indent=2 if args.json else None))
+        return 2
+
     sha = args.expected_repository_sha or _repo_sha()
     cfg = _cfg()
 
@@ -136,6 +160,7 @@ def main(argv: list[str] | None = None) -> int:
     payload = result.to_dict()
     payload["AUTHORIZATION_CHANNEL"] = AUTH_CHANNEL_REAL_TTY_HUMAN_CONFIRM
     payload["TOKEN_ROLE"] = CONFIRM_TOKEN_ROLE_EPHEMERAL_EXECUTION_LATCH
+    payload["STEP7_WALLCLOCK_PACKAGING_BOUND"] = True
     print(json.dumps(payload, sort_keys=True, indent=2 if args.json else None))
     return 0 if result.ok else 2
 

--- a/src/ops/phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1/campaign_start_invoke_v1.py
+++ b/src/ops/phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1/campaign_start_invoke_v1.py
@@ -3,17 +3,21 @@
 This module owns the missing call-graph edge:
 
   campaign_may_start
-  + Owner-GO + NETWORK_SESSION_GO + Real-TTY + Hidden-Confirm consume
+  + Owner-GO + NETWORK_SESSION_GO + channel-bound confirm consume
   → strictly more than one run_productive_wallclock_session_v1(...)
     under TARGET_CAMPAIGN_CAPABILITY_ID
     with Public-MD fetcher binding and Step-7 harness/verifier handoff
+
+Wallclock kwargs are signature-filtered via wallclock_packaging_v1
+(reusing Step-4 build_canonical_wallclock_runner_kwargs_v1). Campaign
+``session_id`` / index metadata is never forwarded as unexpected kwargs.
 
 Default permanent constants remain false. Tests inject wallclock_runner doubles.
 """
 
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping, MutableMapping
+from typing import Any, Callable, Mapping, MutableMapping, Sequence
 
 from src.ops.integrated_paper_shadow_productive_authorization_issuance_and_real_network_execution_v1.productive_run_entrypoint_v1 import (
     run_productive_wallclock_session_v1,
@@ -29,6 +33,11 @@ from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1
     TARGET_SESSION_ID_PREFIX,
     is_target_campaign_capability_id_v1,
     multi_session_requirement_satisfied_v1,
+)
+from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.wallclock_packaging_v1 import (
+    package_step7_wallclock_runner_kwargs_v1,
+    prove_step7_wallclock_packaging_bound_v1,
+    resolve_step7_session_package_v1,
 )
 
 WallclockRunnerFn = Callable[..., Any]
@@ -49,6 +58,7 @@ def invoke_step7_productive_campaign_sessions_v1(
     planned_session_count: int,
     runtime_overrides: Mapping[str, Any] | None = None,
     wallclock_kwargs: Mapping[str, Any] | None = None,
+    per_session_wallclock_packages: Sequence[Mapping[str, Any]] | None = None,
     wallclock_runner: WallclockRunnerFn | None = None,
     campaign_start_state: MutableMapping[str, Any] | None = None,
     allow_real_network: bool = False,
@@ -61,7 +71,26 @@ def invoke_step7_productive_campaign_sessions_v1(
         f"CANONICAL_WALLCLOCK_RUNNER={CANONICAL_WALLCLOCK_RUNNER}",
         f"MULTI_SESSION_REQUIREMENT_EXPRESSION={MULTI_SESSION_REQUIREMENT_EXPRESSION}",
         "PER_SESSION_WALLCLOCK_INVOKE_GUARD=true",
+        "STEP7_WALLCLOCK_PACKAGING_BOUND=true",
+        "SESSION_ID_IS_METADATA_NOT_RUNNER_KWARG=true",
     ]
+    packaging_proof = prove_step7_wallclock_packaging_bound_v1()
+    if not packaging_proof.get("ok"):
+        blockers.extend(list(packaging_proof.get("blockers") or []))
+        blockers.append("STEP7_WALLCLOCK_PACKAGING_BINDING_FAILED")
+        return {
+            "ok": False,
+            "blockers": blockers,
+            "notes": notes,
+            "wallclock_invoked_count": 0,
+            "planned_session_count": int(planned_session_count),
+            "completed_session_count": 0,
+            "network_session_started": False,
+            "public_md_fetcher_bound": False,
+            "session_results": [],
+            "packaging_proof": packaging_proof,
+        }
+
     if not is_target_campaign_capability_id_v1(target_campaign_capability_id):
         blockers.append("WRONG_CAPABILITY_ID")
         return {
@@ -74,6 +103,7 @@ def invoke_step7_productive_campaign_sessions_v1(
             "network_session_started": False,
             "public_md_fetcher_bound": False,
             "session_results": [],
+            "packaging_proof": packaging_proof,
         }
 
     if not multi_session_requirement_satisfied_v1(planned_session_count):
@@ -88,6 +118,7 @@ def invoke_step7_productive_campaign_sessions_v1(
             "network_session_started": False,
             "public_md_fetcher_bound": True,
             "session_results": [],
+            "packaging_proof": packaging_proof,
         }
 
     fetcher_proof = prove_public_md_fetcher_symbol_bound_v1()
@@ -103,6 +134,7 @@ def invoke_step7_productive_campaign_sessions_v1(
             "network_session_started": False,
             "public_md_fetcher_bound": False,
             "session_results": [],
+            "packaging_proof": packaging_proof,
         }
 
     state = campaign_start_state if campaign_start_state is not None else {}
@@ -120,23 +152,56 @@ def invoke_step7_productive_campaign_sessions_v1(
             "network_session_started": bool(state.get("network_session_started")),
             "public_md_fetcher_bound": True,
             "session_results": list(state.get("session_results") or []),
+            "packaging_proof": packaging_proof,
         }
 
     overrides = dict(runtime_overrides or {})
     session_results: list[dict[str, Any]] = []
     invoked = 0
+    packages_list = (
+        [dict(p) for p in per_session_wallclock_packages]
+        if per_session_wallclock_packages is not None
+        else None
+    )
+    require_complete = wallclock_runner is None
 
     for idx in range(1, planned + 1):
         session_id = f"{TARGET_SESSION_ID_PREFIX}_{idx:03d}"
-        call_kwargs = dict(wallclock_kwargs or {})
-        existing_overrides = dict(call_kwargs.get("runtime_overrides") or {})
+        try:
+            session_package = resolve_step7_session_package_v1(
+                shared_wallclock_kwargs=wallclock_kwargs,
+                per_session_wallclock_packages=packages_list,
+                session_index=idx,
+                planned_session_count=planned,
+                campaign_session_id=session_id,
+            )
+        except ValueError as exc:
+            blockers.append(str(exc))
+            break
+
+        existing_overrides = dict(session_package.get("runtime_overrides") or {})
         existing_overrides.update(overrides)
-        call_kwargs["runtime_overrides"] = existing_overrides
-        if "use_real_network" not in call_kwargs:
-            call_kwargs["use_real_network"] = bool(allow_real_network)
-        call_kwargs.setdefault("session_id", session_id)
-        call_kwargs.setdefault("campaign_session_index", idx)
-        call_kwargs.setdefault("campaign_planned_session_count", planned)
+        session_package["runtime_overrides"] = existing_overrides
+        if "use_real_network" not in session_package:
+            session_package["use_real_network"] = bool(allow_real_network)
+
+        try:
+            call_kwargs = package_step7_wallclock_runner_kwargs_v1(
+                session_package,
+                require_complete=require_complete,
+            )
+        except ValueError as exc:
+            blockers.append(str(exc))
+            notes.append(f"STEP7_WALLCLOCK_PACKAGING_FAIL_CLOSED_SESSION_{idx:03d}=true")
+            break
+
+        # Hard guard: never forward campaign metadata / unknown session_id kwarg.
+        if "session_id" in call_kwargs:
+            blockers.append("SESSION_ID_LEAKED_INTO_RUNNER_KWARGS")
+            break
+        if "campaign_session_index" in call_kwargs:
+            blockers.append("CAMPAIGN_SESSION_INDEX_LEAKED_INTO_RUNNER_KWARGS")
+            break
 
         state["wallclock_invoked_count"] = prior + idx
         state["start_reserved"] = True
@@ -150,10 +215,15 @@ def invoke_step7_productive_campaign_sessions_v1(
             # PRODUCTIVE CALLSITE (AST-visible): Step-7 multi-session invoke edge.
             result = run_productive_wallclock_session_v1(**call_kwargs)
 
+        package_session_id = str(session_package.get("session_id") or session_id)
+        evidence_root = call_kwargs.get("evidence_root")
         session_results.append(
             {
                 "session_index": idx,
                 "session_id": session_id,
+                "package_session_id": package_session_id,
+                "evidence_root": str(evidence_root) if evidence_root is not None else None,
+                "runner_kwarg_keys": sorted(call_kwargs.keys()),
                 "ok": True if not isinstance(result, Mapping) else bool(result.get("ok", True)),
                 "result_type": type(result).__name__,
             }
@@ -165,7 +235,9 @@ def invoke_step7_productive_campaign_sessions_v1(
         state["network_session_started"] = False
         notes.append("TEST_DOUBLE_INVOKE_DOES_NOT_CLAIM_REAL_NETWORK_SESSION=true")
     else:
-        state["network_session_started"] = bool(allow_real_network and invoked > 0)
+        state["network_session_started"] = bool(
+            allow_real_network and invoked > 0 and not blockers and len(session_results) == planned
+        )
 
     ok = (
         not blockers
@@ -182,6 +254,7 @@ def invoke_step7_productive_campaign_sessions_v1(
         "network_session_started": bool(state.get("network_session_started")),
         "public_md_fetcher_bound": True,
         "fetcher_proof": fetcher_proof,
+        "packaging_proof": packaging_proof,
         "runtime_overrides_keys": sorted(overrides.keys()),
         "session_results": session_results,
         "target_campaign_capability_id": TARGET_CAMPAIGN_CAPABILITY_ID,

--- a/src/ops/phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1/constants_v1.py
+++ b/src/ops/phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1/constants_v1.py
@@ -221,6 +221,8 @@ CALL_GRAPH_AFTER = [
     "dual confirm channels: REAL_TTY_HUMAN_CONFIRM | DELEGATED_CURSOR_SECURE_CONFIRM",
     "campaign_may_start + Owner-GO + NETWORK_SESSION_GO + channel-bound confirm latch",
     "TOKEN_ROLE=EPHEMERAL_EXECUTION_LATCH (not human TTY presence proof)",
+    "wallclock kwargs packaged via Step-4 build_canonical_wallclock_runner_kwargs_v1",
+    "session_id is campaign metadata only (never runner kwarg)",
     "MULTI_SESSION_REQUIREMENT_EXPRESSION=>1",
     "reuse Step-7 harness + verifier + per-session evidence + campaign bundle",
     "reuse Step-3 restart / Step-4 reconnect / Step-6 stale-adverse",

--- a/src/ops/phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1/governed_campaign_execution_v1.py
+++ b/src/ops/phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1/governed_campaign_execution_v1.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, Sequence
 
 from src.ops.phase_9_2_step_6_governed_adverse_stale_data_session_execution_v1.network_boundary_v1 import (
     prove_public_md_only_boundary_v1,
@@ -27,6 +27,9 @@ from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1
 from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.campaign_start_invoke_v1 import (
     invoke_step7_productive_campaign_sessions_v1,
     prove_public_md_fetcher_symbol_bound_v1,
+)
+from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.wallclock_packaging_v1 import (
+    prove_step7_wallclock_packaging_bound_v1,
 )
 from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.confirm_token_path_v1 import (
     reject_confirm_token_argv_v1,
@@ -279,6 +282,11 @@ def prove_step7_campaign_execution_owner_implementation_v1(
     if not callable(verify_campaign_bundle_v1):
         blockers.append("STEP7_CAMPAIGN_VERIFIER_UNRESOLVED")
 
+    packaging_proof = prove_step7_wallclock_packaging_bound_v1()
+    if not packaging_proof.get("ok"):
+        blockers.extend(list(packaging_proof.get("blockers") or []))
+        blockers.append("STEP7_WALLCLOCK_PACKAGING_BINDING_FAILED")
+
     if repo_root is not None:
         for label, rel in (
             ("CAMPAIGN_OWNER_ENTRYPOINT_MISSING", PRODUCTIVE_ENTRYPOINT_PATH),
@@ -418,6 +426,7 @@ def prove_step7_campaign_execution_owner_implementation_v1(
         and bool(harness.get("ok"))
         and bool(handoff.get("ok"))
         and bool(delegated_broker.get("ok"))
+        and bool(packaging_proof.get("ok"))
         and bool(reuse.get("ok"))
         and bool(fetcher_proof.get("ok"))
         and STEP7_PRODUCTIVE_CAMPAIGN_INVOKE_EDGE_PRESENT
@@ -466,6 +475,8 @@ def prove_step7_campaign_execution_owner_implementation_v1(
         "TOKEN_ROLE": CONFIRM_TOKEN_ROLE_EPHEMERAL_EXECUTION_LATCH,
         "HIDDEN_CONFIRM_HANDOFF_BOUND": bool(handoff.get("ok")),
         "DELEGATED_CURSOR_SECURE_CONFIRM_BROKER_BOUND": bool(delegated_broker.get("ok")),
+        "STEP7_WALLCLOCK_PACKAGING_BOUND": bool(packaging_proof.get("ok")),
+        "SESSION_IDENTITY_PACKAGING_PATH": packaging_proof.get("session_identity_packaging_path"),
         "HIDDEN_CONFIRM_HANDOFF_USED": False,
         "CONFIRM_TOKEN_MINTED": False,
         "CONFIRM_TOKEN_CONSUMED": False,
@@ -530,6 +541,7 @@ def prove_step7_campaign_execution_owner_implementation_v1(
             "reuse": reuse,
             "hidden_pty_handoff": handoff,
             "delegated_cursor_secure_confirm_broker": delegated_broker,
+            "wallclock_packaging": packaging_proof,
             "boundary": boundary,
             "fetcher_proof": fetcher_proof,
             "gate_single_session": {k: v for k, v in one_session.items() if k != "notes"},
@@ -731,6 +743,7 @@ def execute_governed_step7_campaign_v1(
     expected_capability_id: str = TARGET_CAMPAIGN_CAPABILITY_ID,
     wallclock_runner: Callable[..., Any] | None = None,
     wallclock_kwargs: Mapping[str, Any] | None = None,
+    per_session_wallclock_packages: Sequence[Mapping[str, Any]] | None = None,
     campaign_start_state: dict[str, Any] | None = None,
     runtime_overrides: Mapping[str, Any] | None = None,
     authorization_channel: str | None = None,
@@ -976,6 +989,7 @@ def execute_governed_step7_campaign_v1(
             planned_session_count=planned_session_count,
             runtime_overrides=dict(runtime_overrides or {}),
             wallclock_kwargs=wallclock_kwargs,
+            per_session_wallclock_packages=per_session_wallclock_packages,
             wallclock_runner=wallclock_runner,
             campaign_start_state=start_state,
             allow_real_network=True,

--- a/src/ops/phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1/wallclock_packaging_v1.py
+++ b/src/ops/phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1/wallclock_packaging_v1.py
@@ -1,0 +1,131 @@
+"""Step-7 Campaign→Wallclock packaging adapter (signature-compatible).
+
+Reuses the Step-4 canonical runner-invoke binder. Session identity for the
+productive wallclock runner lives in ``prereg`` / ``go`` contracts (and
+``evidence_root`` packaging paths). Campaign bookkeeping keys such as
+``session_id`` / ``campaign_session_index`` are metadata only and must never
+be forwarded as unexpected kwargs to ``run_productive_wallclock_session_v1``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from src.ops.phase_9_2_productive_public_md_rate_limit_reconnect_wallclock_binding_v1.runner_invoke_binding_v1 import (
+    ALLOWED_RUNNER_KWARGS,
+    REQUIRED_RUNNER_KWARGS,
+    build_canonical_wallclock_runner_kwargs_v1,
+    discover_canonical_wallclock_runner_signature_v1,
+)
+from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.constants_v1 import (
+    CANONICAL_WALLCLOCK_RUNNER,
+    OWNER,
+)
+
+# Campaign-local metadata — never part of the wallclock runner API contract.
+CAMPAIGN_METADATA_KEYS = frozenset(
+    {
+        "session_id",
+        "campaign_session_index",
+        "campaign_planned_session_count",
+        "instrument",
+        "capability_id",
+        "notes",
+        "owner_session_permit",
+        "per_session_packages",
+    }
+)
+
+STEP7_WALLCLOCK_PACKAGING_OWNER = f"{OWNER}.wallclock_packaging_v1"
+SESSION_IDENTITY_PACKAGING_PATH = (
+    "prereg.session_id + go.session_id + evidence_root "
+    "(via Step-4 build_canonical_wallclock_runner_kwargs_v1; "
+    "campaign session_id is metadata-only)"
+)
+
+
+def strip_campaign_metadata_keys_v1(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a shallow copy without campaign/bookkeeping metadata keys."""
+    return {k: v for k, v in dict(payload).items() if k not in CAMPAIGN_METADATA_KEYS}
+
+
+def filter_allowed_runner_kwargs_present_v1(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Keep only keys that exist on the canonical wallclock runner signature."""
+    return {k: v for k, v in dict(payload).items() if k in ALLOWED_RUNNER_KWARGS}
+
+
+def package_step7_wallclock_runner_kwargs_v1(
+    session_package: Mapping[str, Any] | None,
+    *,
+    require_complete: bool,
+) -> dict[str, Any]:
+    """Package one session request into exact wallclock runner kwargs.
+
+    When ``require_complete`` is True (productive callsite), reuse the Step-4
+    binder which fail-closes on missing required keys / unknown keys.
+    When False (injected test doubles), only filter to allowed signature keys.
+    """
+    raw = dict(session_package or {})
+    # Ensure binder sees session_id as metadata (stripped), never as runner kwarg.
+    filtered_meta = strip_campaign_metadata_keys_v1(raw)
+    # Re-attach session_id only as binder metadata (allowed non-forwarded).
+    if "session_id" in raw:
+        binder_input = dict(filtered_meta)
+        binder_input["session_id"] = raw["session_id"]
+    else:
+        binder_input = filtered_meta
+
+    if require_complete:
+        return build_canonical_wallclock_runner_kwargs_v1(binder_input)
+    return filter_allowed_runner_kwargs_present_v1(binder_input)
+
+
+def resolve_step7_session_package_v1(
+    *,
+    shared_wallclock_kwargs: Mapping[str, Any] | None,
+    per_session_wallclock_packages: list[Mapping[str, Any]] | None,
+    session_index: int,
+    planned_session_count: int,
+    campaign_session_id: str,
+) -> dict[str, Any]:
+    """Merge shared + per-session packaging; attach campaign metadata (non-forwarded)."""
+    package: dict[str, Any] = dict(shared_wallclock_kwargs or {})
+    packages = list(per_session_wallclock_packages or [])
+    if packages:
+        if len(packages) != int(planned_session_count):
+            raise ValueError(
+                "STEP7_PER_SESSION_PACKAGES_COUNT_MISMATCH:"
+                f"expected={int(planned_session_count)}:got={len(packages)}"
+            )
+        idx = int(session_index) - 1
+        package.update(dict(packages[idx]))
+    package.setdefault("session_id", campaign_session_id)
+    package["campaign_session_index"] = int(session_index)
+    package["campaign_planned_session_count"] = int(planned_session_count)
+    return package
+
+
+def prove_step7_wallclock_packaging_bound_v1() -> dict[str, Any]:
+    """Offline proof that Step-7 packaging reuses the canonical runner signature."""
+    discovered = discover_canonical_wallclock_runner_signature_v1()
+    blockers: list[str] = []
+    if not discovered.get("ok"):
+        blockers.append("CANONICAL_WALLCLOCK_SIGNATURE_DISCOVERY_FAILED")
+    if "session_id" in list(REQUIRED_RUNNER_KWARGS):
+        blockers.append("SESSION_ID_MUST_NOT_BE_REQUIRED_RUNNER_KWARG")
+    if "session_id" in ALLOWED_RUNNER_KWARGS:
+        blockers.append("SESSION_ID_MUST_NOT_BE_ALLOWED_RUNNER_KWARG")
+    return {
+        "ok": not blockers,
+        "blockers": blockers,
+        "owner": STEP7_WALLCLOCK_PACKAGING_OWNER,
+        "canonical_wallclock_runner": CANONICAL_WALLCLOCK_RUNNER,
+        "session_identity_packaging_path": SESSION_IDENTITY_PACKAGING_PATH,
+        "reuses_step4_runner_invoke_binding": True,
+        "campaign_metadata_keys": sorted(CAMPAIGN_METADATA_KEYS),
+        "required_runner_kwargs": list(REQUIRED_RUNNER_KWARGS),
+        "allowed_runner_kwargs": sorted(ALLOWED_RUNNER_KWARGS),
+        "signature": discovered,
+        "NETWORK_SESSION_STARTED": False,
+        "CONFIRM_TOKEN_MINTED": False,
+    }

--- a/tests/ops/test_phase_9_2_step_7_campaign_invoke_wallclock_packaging_v1.py
+++ b/tests/ops/test_phase_9_2_step_7_campaign_invoke_wallclock_packaging_v1.py
@@ -1,0 +1,344 @@
+"""Contract/regression tests for Step-7 Campaign→Wallclock packaging.
+
+No network session. No confirm-token mint via operator entrypoint execution
+that would start a campaign. Latch minting in-process is limited to offline
+broker/unit checks already covered elsewhere; packaging tests use doubles.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.ops.integrated_paper_shadow_productive_authorization_issuance_and_real_network_execution_v1.productive_run_entrypoint_v1 import (
+    run_productive_wallclock_session_v1,
+)
+from src.ops.phase_9_2_productive_public_md_rate_limit_reconnect_wallclock_binding_v1.runner_invoke_binding_v1 import (
+    ALLOWED_RUNNER_KWARGS,
+    REQUIRED_RUNNER_KWARGS,
+    discover_canonical_wallclock_runner_signature_v1,
+)
+from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.campaign_start_invoke_v1 import (
+    invoke_step7_productive_campaign_sessions_v1,
+)
+from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.constants_v1 import (
+    AUTH_CHANNEL_DELEGATED_CURSOR_SECURE_CONFIRM,
+    AUTH_CHANNEL_REAL_TTY_HUMAN_CONFIRM,
+    CONFIRM_TOKEN_ROLE_EPHEMERAL_EXECUTION_LATCH,
+    TARGET_CAMPAIGN_CAPABILITY_ID,
+    TARGET_SESSION_ID_PREFIX,
+)
+from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.delegated_cursor_secure_confirm_broker_v1 import (
+    mint_delegated_cursor_secure_confirm_latch_v1,
+)
+from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.governed_campaign_execution_v1 import (
+    execute_governed_step7_campaign_v1,
+)
+from src.ops.phase_9_2_step_7_governed_productive_real_tty_campaign_execution_v1.wallclock_packaging_v1 import (
+    SESSION_IDENTITY_PACKAGING_PATH,
+    package_step7_wallclock_runner_kwargs_v1,
+    prove_step7_wallclock_packaging_bound_v1,
+)
+from src.ops.single_future_stateful_no_order_runtime_activation_v1.config_v1 import (
+    load_activation_config_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _sha() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=str(REPO_ROOT), text=True
+    ).strip()
+
+
+def _cfg() -> str:
+    return str(
+        load_activation_config_v1(
+            config_path=REPO_ROOT
+            / "config/runtime/single_future_stateful_no_order_runtime_activation_v1.json"
+        ).config_digest
+    )
+
+
+def _package(
+    tmp_path: Path,
+    *,
+    session_id: str,
+    sha: str,
+    suffix: str,
+) -> dict[str, Any]:
+    return {
+        "session_id": session_id,
+        "prereg": {"test_double": f"prereg_{suffix}", "session_id": session_id},
+        "go": {"test_double": f"go_{suffix}", "session_id": session_id},
+        "confirm_token": f"WIRING_TEST_TOKEN_{suffix}_IN_MEMORY_ONLY",
+        "artifact_path": str(tmp_path / f"auth_{suffix}.json"),
+        "evidence_root": str(tmp_path / f"ev_{suffix}"),
+        "expected_repository_sha": sha,
+        "fingerprint_ledger_path": str(tmp_path / f"fp_{suffix}.txt"),
+        "use_real_network": False,
+    }
+
+
+def test_wallclock_actual_signature_matches_step4_contract() -> None:
+    sig = inspect.signature(run_productive_wallclock_session_v1)
+    names = list(sig.parameters)
+    assert names == list(REQUIRED_RUNNER_KWARGS) + [
+        p for p in sig.parameters if p not in REQUIRED_RUNNER_KWARGS
+    ]
+    assert "session_id" not in sig.parameters
+    assert "campaign_session_index" not in sig.parameters
+    assert "campaign_planned_session_count" not in sig.parameters
+    for name, param in sig.parameters.items():
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+        assert name in ALLOWED_RUNNER_KWARGS
+    discovered = discover_canonical_wallclock_runner_signature_v1()
+    assert discovered["ok"] is True
+    assert discovered["keyword_only"] is True
+    assert "session_id" not in discovered["required_kwargs"]
+
+
+def test_regression_session_id_kwarg_typeerror_on_raw_wallclock_call(tmp_path: Path) -> None:
+    """Reproduce the historical TypeError; packaging must prevent forwarding."""
+    sha = _sha()
+    base = _package(tmp_path, session_id="raw_should_fail", sha=sha, suffix="raw")
+    # Drop metadata and add illegal kwarg the old invoke edge forwarded.
+    illegal = {
+        "prereg": base["prereg"],
+        "go": base["go"],
+        "confirm_token": base["confirm_token"],
+        "artifact_path": Path(base["artifact_path"]),
+        "evidence_root": Path(base["evidence_root"]),
+        "expected_repository_sha": sha,
+        "fingerprint_ledger_path": Path(base["fingerprint_ledger_path"]),
+        "session_id": "phase_9_2_public_md_multi_session_continuity_session_v1_001",
+    }
+    with pytest.raises(TypeError, match="unexpected keyword argument 'session_id'"):
+        run_productive_wallclock_session_v1(**illegal)
+
+    packaged = package_step7_wallclock_runner_kwargs_v1(base, require_complete=True)
+    assert "session_id" not in packaged
+    # Signature-compatible: inspect.bind must succeed.
+    inspect.signature(run_productive_wallclock_session_v1).bind(**packaged)
+
+
+def test_step7_packaging_two_distinct_session_contexts_no_network(tmp_path: Path) -> None:
+    sha = _sha()
+    calls: list[dict[str, Any]] = []
+
+    def runner(**kwargs: Any) -> dict[str, Any]:
+        calls.append(dict(kwargs))
+        return {"ok": True, "NETWORK_SESSION_STARTED": False}
+
+    packages = [
+        _package(
+            tmp_path,
+            session_id=f"{TARGET_SESSION_ID_PREFIX}_ctx_a",
+            sha=sha,
+            suffix="a",
+        ),
+        _package(
+            tmp_path,
+            session_id=f"{TARGET_SESSION_ID_PREFIX}_ctx_b",
+            sha=sha,
+            suffix="b",
+        ),
+    ]
+    result = invoke_step7_productive_campaign_sessions_v1(
+        planned_session_count=2,
+        per_session_wallclock_packages=packages,
+        wallclock_runner=runner,
+        allow_real_network=False,
+        campaign_start_state={},
+    )
+    assert result["ok"] is True
+    assert result["network_session_started"] is False
+    assert len(calls) == 2
+    assert "session_id" not in calls[0]
+    assert "session_id" not in calls[1]
+    assert "campaign_session_index" not in calls[0]
+    assert calls[0]["evidence_root"] != calls[1]["evidence_root"]
+    assert str(calls[0]["evidence_root"]).endswith("ev_a")
+    assert str(calls[1]["evidence_root"]).endswith("ev_b")
+    assert result["session_results"][0]["package_session_id"].endswith("ctx_a")
+    assert result["session_results"][1]["package_session_id"].endswith("ctx_b")
+    proof = prove_step7_wallclock_packaging_bound_v1()
+    assert proof["ok"] is True
+    assert proof["session_identity_packaging_path"] == SESSION_IDENTITY_PACKAGING_PATH
+
+
+def test_delegated_cursor_path_packaging_no_token_exposure(tmp_path: Path) -> None:
+    sha, cfg = _sha(), _cfg()
+    calls: list[dict[str, Any]] = []
+
+    def runner(**kwargs: Any) -> dict[str, Any]:
+        calls.append(dict(kwargs))
+        return {"ok": True}
+
+    packages = [
+        _package(tmp_path, session_id="delegated_a", sha=sha, suffix="da"),
+        _package(tmp_path, session_id="delegated_b", sha=sha, suffix="db"),
+    ]
+    latch = mint_delegated_cursor_secure_confirm_latch_v1()
+    digest = latch.digest
+    result = execute_governed_step7_campaign_v1(
+        expected_repository_sha=sha,
+        expected_config_digest=cfg,
+        owner_go=True,
+        operator_authorization_explicit=True,
+        network_session_go=True,
+        authorization_valid=True,
+        confirm_token_valid=True,
+        planned_session_count=2,
+        allow_real_network_side_effects=True,
+        invoke_executor=True,
+        stdin_isatty=False,
+        getpass_fn=None,
+        wallclock_runner=runner,
+        per_session_wallclock_packages=packages,
+        campaign_start_state={},
+        repo_root=REPO_ROOT,
+        authorization_channel=AUTH_CHANNEL_DELEGATED_CURSOR_SECURE_CONFIRM,
+        delegated_confirm_latch=latch,
+        head_equals_origin_main=True,
+        tracked_worktree_clean=True,
+    )
+    assert result.ok is True
+    assert result.claims["AUTHORIZATION_CHANNEL"] == AUTH_CHANNEL_DELEGATED_CURSOR_SECURE_CONFIRM
+    assert result.claims["TOKEN_ROLE"] == CONFIRM_TOKEN_ROLE_EPHEMERAL_EXECUTION_LATCH
+    assert result.claims["CONFIRM_TOKEN_PLAINTEXT_EXPOSED"] is False
+    assert result.claims["DELEGATED_SECURE_CONFIRM_VERIFIED"] is True
+    assert result.claims["NETWORK_SESSION_STARTED"] is False
+    assert len(calls) == 2
+    assert all("session_id" not in c for c in calls)
+    blob = json.dumps(result.to_dict(), sort_keys=True)
+    assert digest in blob
+    # Digest-only attestation is required.
+    assert result.claims.get("confirm_token_fingerprint") == digest
+
+
+def test_ephemeral_latch_one_time_still_bound(tmp_path: Path) -> None:
+    sha, cfg = _sha(), _cfg()
+    latch = mint_delegated_cursor_secure_confirm_latch_v1()
+
+    def runner(**_kwargs: Any) -> dict[str, Any]:
+        return {"ok": True}
+
+    packages = [
+        _package(tmp_path, session_id="once_a", sha=sha, suffix="oa"),
+        _package(tmp_path, session_id="once_b", sha=sha, suffix="ob"),
+    ]
+    first = execute_governed_step7_campaign_v1(
+        expected_repository_sha=sha,
+        expected_config_digest=cfg,
+        owner_go=True,
+        operator_authorization_explicit=True,
+        network_session_go=True,
+        authorization_valid=True,
+        confirm_token_valid=True,
+        planned_session_count=2,
+        allow_real_network_side_effects=True,
+        invoke_executor=True,
+        stdin_isatty=False,
+        wallclock_runner=runner,
+        per_session_wallclock_packages=packages,
+        campaign_start_state={},
+        repo_root=REPO_ROOT,
+        authorization_channel=AUTH_CHANNEL_DELEGATED_CURSOR_SECURE_CONFIRM,
+        delegated_confirm_latch=latch,
+        head_equals_origin_main=True,
+        tracked_worktree_clean=True,
+    )
+    assert first.ok is True
+    assert latch.consumed is True
+
+    # Replay same latch must fail-closed.
+    second = execute_governed_step7_campaign_v1(
+        expected_repository_sha=sha,
+        expected_config_digest=cfg,
+        owner_go=True,
+        operator_authorization_explicit=True,
+        network_session_go=True,
+        authorization_valid=True,
+        confirm_token_valid=True,
+        planned_session_count=2,
+        allow_real_network_side_effects=True,
+        invoke_executor=True,
+        stdin_isatty=False,
+        wallclock_runner=runner,
+        per_session_wallclock_packages=packages,
+        campaign_start_state={},
+        repo_root=REPO_ROOT,
+        authorization_channel=AUTH_CHANNEL_DELEGATED_CURSOR_SECURE_CONFIRM,
+        delegated_confirm_latch=latch,
+        head_equals_origin_main=True,
+        tracked_worktree_clean=True,
+    )
+    assert second.ok is False
+    assert second.claims["NETWORK_SESSION_STARTED"] is False
+
+
+def test_real_tty_path_still_accepts_injected_runner_without_session_id_kwarg(
+    tmp_path: Path,
+) -> None:
+    sha, cfg = _sha(), _cfg()
+    calls: list[dict[str, Any]] = []
+
+    def runner(**kwargs: Any) -> dict[str, Any]:
+        calls.append(dict(kwargs))
+        return {"ok": True}
+
+    packages = [
+        _package(tmp_path, session_id="tty_a", sha=sha, suffix="ta"),
+        _package(tmp_path, session_id="tty_b", sha=sha, suffix="tb"),
+    ]
+    gate_box = ["hidden-confirm-token-for-test-only"]
+
+    def _getpass(_prompt: str = "") -> str:
+        return gate_box.pop() if gate_box else ""
+
+    result = execute_governed_step7_campaign_v1(
+        expected_repository_sha=sha,
+        expected_config_digest=cfg,
+        owner_go=True,
+        operator_authorization_explicit=True,
+        network_session_go=True,
+        authorization_valid=True,
+        confirm_token_valid=True,
+        planned_session_count=2,
+        allow_real_network_side_effects=True,
+        invoke_executor=True,
+        stdin_isatty=True,
+        getpass_fn=_getpass,
+        wallclock_runner=runner,
+        per_session_wallclock_packages=packages,
+        campaign_start_state={},
+        repo_root=REPO_ROOT,
+        authorization_channel=AUTH_CHANNEL_REAL_TTY_HUMAN_CONFIRM,
+        expected_capability_id=TARGET_CAMPAIGN_CAPABILITY_ID,
+    )
+    assert result.ok is True
+    assert result.claims["AUTHORIZATION_CHANNEL"] == AUTH_CHANNEL_REAL_TTY_HUMAN_CONFIRM
+    assert result.claims["NETWORK_SESSION_STARTED"] is False
+    assert len(calls) == 2
+    assert all("session_id" not in c for c in calls)
+
+
+def test_productive_path_fail_closed_when_packaging_incomplete() -> None:
+    result = invoke_step7_productive_campaign_sessions_v1(
+        planned_session_count=2,
+        wallclock_kwargs={"session_id": "only_metadata"},
+        wallclock_runner=None,
+        allow_real_network=True,
+        campaign_start_state={},
+    )
+    assert result["ok"] is False
+    assert result["network_session_started"] is False
+    assert result["wallclock_invoked_count"] == 0
+    assert any("RUNNER_INVOKE_BINDING_MISSING_REQUIRED" in b for b in result["blockers"])


### PR DESCRIPTION
## Summary
- Repair the Step-7 Campaign→Wallclock invoke edge so `session_id` / campaign index metadata are never forwarded as unexpected kwargs to `run_productive_wallclock_session_v1`.
- Reuse the existing Step-4 `build_canonical_wallclock_runner_kwargs_v1` packaging binder; session identity continues via `prereg` / `go` / `evidence_root`, with optional per-session packages for multi-session continuity.
- Bind packaging prove into both Delegated-Cursor and Real-TTY operator entrypoints. No network session, no confirm mint in this PR, no trading/order/credential changes.

## Test plan
- [x] `tests/ops/test_phase_9_2_step_7_campaign_invoke_wallclock_packaging_v1.py` (signature contract, TypeError regression, two session contexts, delegated no-expose, latch one-time, Real-TTY path, incomplete packaging fail-closed)
- [x] Existing `tests/ops/test_phase_9_2_step_7_delegated_cursor_secure_confirm_v1.py`
- [x] Existing `tests/ops/test_phase_9_2_step_7_productive_real_tty_campaign_execution_owner_v1.py`
- [x] PR-bounded selector batch (761 passed, ~53s wallclock) + ruff format/check
- [ ] CI confirmation on PR
- [ ] **Do not merge without separate `OWNER_MERGE_GO`**
- [ ] **Do not start productive Step-7 campaign from this PR**


Made with [Cursor](https://cursor.com)