### PR TITLE
ops: bind hardening_v2 Cap-6.3 decision-config literals (DoD residual-2)

### DIFF
--- a/docs/architecture/canonical/PEAK_TRADE_CANONICAL_END_STATE_WIRING_MAP.md
+++ b/docs/architecture/canonical/PEAK_TRADE_CANONICAL_END_STATE_WIRING_MAP.md
@@ -314,7 +314,7 @@ no-order host must remain physically separate.
 | W2 | Public-MD natural Entry/Exit lifecycle | Deterministic Cap 7.1 proven; natural Public-MD open | Natural lifecycle evidenced | `EVIDENCE_GAP` | Yes for Phase 9.2 DoD |
 | W3 | Step 4 rate-limit/reconnect session | Components exist; no productive session binding / governed fault path | Bound + outcome-observed + verified | `WIRING_GAP` | Yes for Step 4 |
 | W4 | Step 3 restart/recovery real session | Binding implemented (PR #5750); `RESTART_RECOVERY_LADDER_STEP_CLOSED=false` | Governed real session verifier PASS | `EVIDENCE_GAP` | Yes — before ladder advance |
-| W5 | hardening_v2 distance literals | Residual host-consumer literals after Cap 6.3 | Owned typed config consumers | `CONFIG_DRIFT` (partial residual) | Review-only; no threshold mutation authorized |
+| W5 | hardening_v2 distance literals | Closed by Residual-2 Cap-6.3 binding | Owned typed config consumers | `CONFIG_DRIFT=false_for_in_scope` | Binding-only; effective values unchanged |
 | W6 | Runbook `CURRENT_FORENSIC_TRUTH_SHA` vs `origin/main` | Bound to Step-7 ladder-closeout SHA `642db059…`; `DOCUMENTATION_RUNTIME_DRIFT=false` | Reconciled current-truth SHA | `DOCUMENTATION_DRIFT` closed by Residual-1 docs closeout | Docs freshness closed |
 | W7 | Numeric vol max-age | Non-enforcing | Separate Phase 10 decision | `INTENTIONAL_SAFETY_BARRIER` / intentional current phase | No |
 | W8 | Multi-future runtime | Unauthorized | Future program only | `INTENTIONAL_SAFETY_BARRIER` | Multi-future only |
@@ -398,7 +398,7 @@ conflicts hard-stop before Alpha advances.
 | --- | --- | --- | --- |
 | Cap 7.2 activation | `config/runtime/single_future_stateful_no_order_runtime_activation_v1.json` | Cap 7.2 package | `CONFIG_EXISTS` `CONFIG_CONSUMED` |
 | Cap 6.3 confirmed keys (`confirmation_epochs`, distances) | Typed decision-config ownership (Cap 6.3) | Confirmation / scope path | `CONFIG_CONSUMED`; numerics unchanged |
-| hardening_v2 local distance literals | Host residual | hardening_v2 bridge | `CONFIG_DRIFT` residual; review-only |
+| hardening_v2 local distance literals | Closed | hardening_v2 Cap-6.3 binding | `CONFIG_DRIFT=false_for_in_scope`; values unchanged |
 | Phase 9.2 smoke session | `config/ops/phase_9_2_public_md_smoke_session_contract_v1.json` | Phase 9.2 preflight | `CONFIG_EXISTS` `CONFIG_CONSUMED` |
 | Phase 9.2 restart session | `config/ops/phase_9_2_restart_recovery_session_contract_v1.json` | Restart harness | `CONFIG_EXISTS` |
 | Phase 9.2 Step 3 wallclock binding | `config/ops/phase_9_2_productive_public_md_restart_recovery_real_network_wallclock_binding_v1.json` | Binding package | `CONFIG_EXISTS` `CONFIG_CONSUMED`; `network_session_allowed_by_capability_config=false` |
@@ -882,7 +882,7 @@ those modes.
 Cap 6.0 Preflight (historical)
 → Cap 6.1 Confirmation/C1
 → Cap 6.2 Dynamic Scope
-→ Cap 6.3 Config ownership (residual review item)
+→ Cap 6.3 Config ownership (confirmed keys + hardening_v2 host binding)
 → Cap 6.4 Atomic restart
 → Cap 6.5 Exit-policy producers
 → Cap 7.1 Deterministic simulated lifecycle evidence

--- a/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
+++ b/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
@@ -774,8 +774,8 @@ The following are no longer to be treated as missing greenfield work:
                                       restart-proven.
 
   Cap 6.3 confirmed config keys       Migrated without numeric change;
-                                      residual hardening_v2 host-consumer
-                                      literals remain documented.
+                                      hardening_v2 host-consumer Cap-6.3
+                                      literals bound to typed owner.
 
   Cap 6.4 decision-path restart       Deterministic stateful no-order
                                       restart proven.
@@ -847,13 +847,13 @@ lifecycle proof.
 CORE_LOGIC_DEFECT_DETECTED=false
 WIRING_DEFECTS_DETECTED=false_for_closed_Cap6_1_to_6_5_scope
 STATE_PERSISTENCE_DEFECTS_DETECTED=false_for_closed_Cap6_1_to_6_4_scope
-CONFIG_DRIFT_DETECTED=partial_residual_host_consumer_literals
+CONFIG_DRIFT_DETECTED=false_for_in_scope_runtime_values
 DOCUMENTATION_DRIFT_DETECTED=false
 EVIDENCE_CLAIM_DEFECTS_DETECTED=false_for_corrected_capability_claims
 PUBLIC_MD_NATURAL_LIFECYCLE_EVIDENCE_GAP=false_for_phase_9_2_session_ladder_continuity
 PHASE_9_2_LADDER_INCOMPLETE_BEYOND_SMOKE=false
 WALLCLOCK_HARDENING_V2_CALL_GRAPH_OMITS_EXPLICIT_C1_C2_STAGES_VS_CAP72_HOST=true
-HARDENING_V2_LOCAL_DISTANCE_LITERALS_RESIDUAL_AFTER_CAP63=true
+HARDENING_V2_LOCAL_DISTANCE_LITERALS_RESIDUAL_AFTER_CAP63=false
 LEGACY_PARALLEL_AUTHORITY_DETECTED=false
 REGIME_UNCLASSIFIED_FAIL_CLOSED_IS_DEFECT=false
 ```
@@ -1126,16 +1126,18 @@ decision-config ownership surface without changing numeric values.
 ### Residual host-consumer review item after Cap 6.3
 
 ``` text
-HARDENING_V2_LOCAL_DISTANCE_LITERALS_RESIDUAL_AFTER_CAP63=true
-RESIDUAL_CLASSIFICATION=HOST_CONSUMER_DOCUMENTATION_RESIDUAL
+HARDENING_V2_LOCAL_DISTANCE_LITERALS_RESIDUAL_AFTER_CAP63=false
+RESIDUAL_CLASSIFICATION=CLOSED_BY_NO_ORDER_PROGRAM_DOD_RESIDUAL_2_HARDENING_V2_CANONICAL_DECISION_CONFIG_BINDING_V1
 THRESHOLD_OR_DISTANCE_MUTATION_AUTHORIZED=false
+EFFECTIVE_NUMERIC_VALUES_UNCHANGED=true
+CONFIG_RUNTIME_DRIFT=false_for_in_scope_runtime_values
 ```
 
-The wallclock hardening_v2 bridge still embeds local distance /
-confirmation literals at the same numeric values. This residual must be
-documented and may later be reviewed under a separate Owner-GO. It does
-not authorize any threshold, distance or core-logic change in this
-truth-reconciliation.
+The wallclock hardening_v2 bridge consumes the Cap-6.3 typed decision-config
+owner via `host_binding_v1` / `decision_cfg` (same effective values
+`2` / `200.0` / `80.0` / `120.0`). Local Cap-6.3 distance / confirmation
+literals are removed. Threshold, distance and core-logic mutation remain
+unauthorized.
 
 ### Config ownership review required
 
@@ -1239,10 +1241,11 @@ INTENTIONAL_* = intentional non-blocking current phase
   incomplete                was `RESTART_GAP`                                 no-order decision-path restart      
                                                                                proven.                            
 
-  `G07` Bridge parameters   `PARTIALLY_CLOSED`                          MEDIUM Cap 6.3 closed confirmed keys       Residual host
-  hardcoded                 was `CONFIG_DRIFT`                                without numeric change. Residual:   consumer review
-                                                                               hardening_v2 local distance        
-                                                                               literals at unchanged values.      
+  `G07` Bridge parameters   `CLOSED`                                       n/a Cap 6.3 confirmed keys + Residual-2 Historical only
+  hardcoded                 was `CONFIG_DRIFT` /                              hardening_v2 Cap-6.3 binding;       
+                            `PARTIALLY_CLOSED`                                effective values unchanged;         
+                                                                               `CONFIG_RUNTIME_DRIFT=false_for_`   
+                                                                               `in_scope_runtime_values`.         
                                                                                No threshold mutation authorized.  
 
   `G08` Exit-policy         `CLOSED`                                       n/a Cap 6.5 exit-policy producers       Historical only
@@ -1573,10 +1576,11 @@ CORE_LOGIC_CHANGE=false
 ## Capability status
 
 ``` text
-CAPABILITY_STATUS=COMPLETED_FOR_CONFIRMED_KEYS_WITH_RESIDUAL_HOST_CONSUMER_REVIEW_ITEM
+CAPABILITY_STATUS=COMPLETED_FOR_CONFIRMED_KEYS_AND_HARDENING_V2_HOST_CONSUMER_BINDING
 CONFIRMED_KEYS_MIGRATED=confirmation_epochs,up_distance,adverse_exit_distance,reversal_distance
 EFFECTIVE_NUMERIC_VALUES_UNCHANGED=true
-HARDENING_V2_LOCAL_DISTANCE_LITERALS_RESIDUAL_AFTER_CAP63=true
+HARDENING_V2_LOCAL_DISTANCE_LITERALS_RESIDUAL_AFTER_CAP63=false
+CONFIG_RUNTIME_DRIFT=false_for_in_scope_runtime_values
 THRESHOLD_OR_DISTANCE_MUTATION_AUTHORIZED=false
 ```
 
@@ -2078,7 +2082,7 @@ Owner ratification.
 
 ``` text
 CAPABILITY_STATUS=HISTORICAL_COMPLETED_EVIDENCE_PROVEN
-ACTUAL_NEXT_CAPABILITY=NO_ORDER_PROGRAM_DOD_RESIDUAL_2_CONFIG_RUNTIME_DRIFT_HOST_CONSUMER_REVIEW_V1
+ACTUAL_NEXT_CAPABILITY=NONE_IN_SCOPE_NO_ORDER_PROGRAM_DOD_CLOSED_SEPARATE_OWNER_GO_REQUIRED_FOR_PHASE_10_11
 PHASE_9_2_PUBLIC_MD_SMOKE_SESSION_PASS=true
 PHASE_9_2_ONE_HOUR_GOVERNED_SESSION_PASS_ON_CURRENT_TRUTH_SHA=true
 PHASE_9_2_LADDER_NEXT_STEP=NONE
@@ -2267,7 +2271,7 @@ STEP7_BINDING_PASS_IS_NOT_CAMPAIGN_CLOSEOUT=true
 STEP7_PATH_PASS_IS_NOT_CAMPAIGN_CLOSEOUT=true
 STEP7_OWNER_PASS_IS_NOT_CAMPAIGN_CLOSEOUT=true
 STEP7_CAMPAIGN_VERIFIER_PASS_IS_LADDER_CLOSEOUT_AUTHORITY=true
-NEXT_SAFE_STEP=OWNER_GO_NO_ORDER_PROGRAM_DOD_RESIDUAL_2_CONFIG_RUNTIME_DRIFT_HOST_CONSUMER_REVIEW_V1
+NEXT_SAFE_STEP=SEPARATE_OWNER_GO_REQUIRED_FOR_PHASE_10_OR_PHASE_11_ONLY
 ```
 
 ### Step-7 Confirm &#47; Authorization Channels (governance)
@@ -3827,7 +3831,7 @@ Evidence-reconciled current status against
 
 ``` text
 DOCUMENTATION_RUNTIME_DRIFT=false
-CONFIG_RUNTIME_DRIFT=partial_residual_host_consumer_literals
+CONFIG_RUNTIME_DRIFT=false_for_in_scope_runtime_values
 DASHBOARD_AUTHORITY=false
 UNIVERSE_TRADING_AUTHORITY_EXPLICIT=true
 SINGLE_SELECTED_FUTURE_RUNTIME_CLOSED=true
@@ -3864,6 +3868,7 @@ PHASE_9_2_STEP_7_STATUS=CLOSED_PASS
 TYPED_VOLATILITY_PRODUCER_TO_CMC_BINDING=CLOSED_AND_COLD_START_PROVEN
 REQUIRED_WINDOW_COMPLETE_DECOUPLED_FROM_FEATURES_OK=true
 REGIME_UNCLASSIFIED_ALONE_IS_NOT_A_DEFECT=true
+HARDENING_V2_LOCAL_DISTANCE_LITERALS_RESIDUAL_AFTER_CAP63=false
 VOL_MAX_AGE_ENFORCEMENT=false
 MULTI_FUTURE_RUNTIME_AUTHORIZED=false
 LIVE_ORDERS=false
@@ -3884,18 +3889,19 @@ no-order closure standard.
 
 Phase 9.2 Step-7 repeated multi-session continuity campaign execution is
 complete (`CLOSED_PASS`). The Phase 9.2 Public-MD session ladder is
-complete. Residual-1 forensic/current-truth documentation closeout binds
-`CURRENT_FORENSIC_TRUTH_SHA` to that ladder-closeout SHA and sets
-`DOCUMENTATION_RUNTIME_DRIFT=false`. Immediate Next is residual Cap-6.3 /
-G07 host-consumer config review only. Separately authorized Phase 10 /
-Phase 11 work require explicit Owner-GO and must not reopen the closed
-ladder. This docs closeout does not clear `CONFIG_RUNTIME_DRIFT` and does
-not authorize threshold, core-logic, order, credential or network-session
-changes:
+complete. Residual-1 forensic/current-truth documentation closeout and
+Residual-2 hardening_v2 Cap-6.3 decision-config binding closeout are
+complete. `DOCUMENTATION_RUNTIME_DRIFT=false` and
+`CONFIG_RUNTIME_DRIFT=false_for_in_scope_runtime_values`. The in-scope
+no-order program Definition of Done is closed for confirmed runtime
+values. Separately authorized Phase 10 / Phase 11 work require explicit
+Owner-GO and must not reopen the closed ladder. This residual closeout
+does not authorize threshold, core-logic, order, credential or
+network-session changes:
 
 ``` text
-LAST_COMPLETED_CAPABILITY=NO_ORDER_PROGRAM_DOD_RESIDUAL_1_FORENSIC_CURRENT_TRUTH_DOCS_CLOSEOUT_V1
-ACTUAL_NEXT_CAPABILITY=NO_ORDER_PROGRAM_DOD_RESIDUAL_2_CONFIG_RUNTIME_DRIFT_HOST_CONSUMER_REVIEW_V1
+LAST_COMPLETED_CAPABILITY=NO_ORDER_PROGRAM_DOD_RESIDUAL_2_HARDENING_V2_CANONICAL_DECISION_CONFIG_BINDING_V1
+ACTUAL_NEXT_CAPABILITY=NONE_IN_SCOPE_NO_ORDER_PROGRAM_DOD_CLOSED_SEPARATE_OWNER_GO_REQUIRED_FOR_PHASE_10_11
 PHASE_9_2_STEP_6_STATUS=CLOSED_PASS
 PHASE_9_2_STEP_7_STATUS=CLOSED_PASS
 STEP7_BINDING_IMPLEMENTED=true
@@ -3917,7 +3923,9 @@ STEP7_CAMPAIGN_VERIFIER_PASS_IS_LADDER_CLOSEOUT_AUTHORITY=true
 PHASE_9_2_SESSION_LADDER_COMPLETE=true
 DOCUMENTATION_RUNTIME_DRIFT=false
 CURRENT_FORENSIC_TRUTH_SHA=642db05919634b899329679a811f1ad25a0fd818
-CONFIG_RUNTIME_DRIFT=partial_residual_host_consumer_literals
+CONFIG_RUNTIME_DRIFT=false_for_in_scope_runtime_values
+HARDENING_V2_LOCAL_DISTANCE_LITERALS_RESIDUAL_AFTER_CAP63=false
+NO_ORDER_PROGRAM_DOD_STATUS=CLOSED_FOR_IN_SCOPE_NO_ORDER_PROGRAM
 NETWORK_SESSION_STARTED=false
 CAMPAIGN_EXECUTED=true
 SESSION_COUNT_COMPLETED=2
@@ -3927,7 +3935,7 @@ STEP7_EVIDENCE_SEALED=true
 STEP7_CAMPAIGN_EVIDENCE_DIR=evidence/ops/phase_9_2_step_7_repeated_multi_session_continuity_campaign_execution_v1/campaign_20260807T142727Z
 NEXT_OPEN_PHASE_9_2_STEP=NONE
 DESKTOP_RUNBOOK_USED_AS_AUTHORITY=false
-NEXT_SAFE_STEP=OWNER_GO_NO_ORDER_PROGRAM_DOD_RESIDUAL_2_CONFIG_RUNTIME_DRIFT_HOST_CONSUMER_REVIEW_V1
+NEXT_SAFE_STEP=SEPARATE_OWNER_GO_REQUIRED_FOR_PHASE_10_OR_PHASE_11_ONLY
 ```
 
 Mandatory dependencies / freezes:
@@ -3957,7 +3965,7 @@ Historical completed finish-sequence record (not Immediate Next):
 ``` text
 6.1 = C1/C2/C3 productive binding + stable confirmation persistence = HISTORICAL_COMPLETED
 6.2 = Dynamic Scope persistence = HISTORICAL_COMPLETED
-6.3 = Decision config ownership for confirmed keys = COMPLETED_WITH_RESIDUAL_HOST_CONSUMER_REVIEW_ITEM
+6.3 = Decision config ownership for confirmed keys = COMPLETED_FOR_CONFIRMED_KEYS_AND_HARDENING_V2_HOST_CONSUMER_BINDING
 6.4 = Full decision-path atomic restart closure = HISTORICAL_COMPLETED
 6.5 = Exit-policy producer binding = HISTORICAL_COMPLETED
 7.1 = Deterministic simulated lifecycle evidence = HISTORICAL_COMPLETED
@@ -4023,7 +4031,7 @@ current critical path, is:
 Read-only Preflight 6.0 = HISTORICAL_COMPLETED
 → 6.1 Confirmation/C1 binding = HISTORICAL_COMPLETED
 → 6.2 Dynamic Scope persistence = HISTORICAL_COMPLETED
-→ 6.3 Config ownership = COMPLETED_FOR_CONFIRMED_KEYS_WITH_RESIDUAL
+→ 6.3 Config ownership = COMPLETED_FOR_CONFIRMED_KEYS_AND_HARDENING_V2_HOST_CONSUMER_BINDING
 → 6.4 Atomic restart closure = HISTORICAL_COMPLETED
 → 6.5 Exit-policy producer binding = HISTORICAL_COMPLETED
 → 7.1 Simulated lifecycle evidence = HISTORICAL_COMPLETED

--- a/src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2/hardening_cycle_bridge_v2.py
+++ b/src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2/hardening_cycle_bridge_v2.py
@@ -11,6 +11,17 @@ from pathlib import Path
 from typing import Any, Mapping, Optional, Sequence
 
 from src.ops.bounded_futures_testnet_venue_binding_v0 import PRODUCTION_INSTRUMENT_ID
+from src.ops.decision_config_ownership_and_consumer_closure_v1.canonical_values_v1 import (
+    CANONICAL_CONFIRMATION_EPOCHS,
+)
+from src.ops.decision_config_ownership_and_consumer_closure_v1.constants_v1 import (
+    CALL_GRAPH_CONFIG_BIND_STEP,
+)
+from src.ops.decision_config_ownership_and_consumer_closure_v1.host_binding_v1 import (
+    HostDecisionConfigBindingV1,
+    ensure_host_decision_config_binding_v1,
+    require_bound_decision_config_v1,
+)
 from src.ops.integrated_paper_shadow_observation_session_v1.portfolio_economics_model_v1 import (
     PortfolioEconomicsModelParamsV1,
     SimulatedFillV1,
@@ -174,6 +185,7 @@ def derive_required_window_complete_v2(*, warmup_complete: bool, features_ok: bo
 
 CALL_GRAPH_V2: tuple[str, ...] = (
     "okx_public_market_data",
+    CALL_GRAPH_CONFIG_BIND_STEP,
     "feature_pipeline",
     "regime_pipeline",
     "canonical_volatility_productive_runtime_cmc_typed_binding",
@@ -188,6 +200,8 @@ CALL_GRAPH_V2: tuple[str, ...] = (
     "evidence",
     "full_economic_reconstruction_verifier",
 )
+
+_HARDENING_V2_DECISION_CONFIG_REPOSITORY_SHA = "OFFLINE_HARDENING_V2_ANALYTICAL"
 
 _DEFAULT_VOL_TYPED_BINDING_VENUE = "okx_europe"
 _DEFAULT_VOL_TYPED_BINDING_VENUE_INSTRUMENT_ID = PRODUCTION_INSTRUMENT_ID
@@ -257,7 +271,7 @@ def _default_policies() -> IntegratedOfflineReplayPoliciesV1:
             observe_signal_threshold=0.001,
             candidate_signal_threshold=0.005,
             confirmation_signal_threshold=0.01,
-            confirmation_epochs=2,
+            confirmation_epochs=int(CANONICAL_CONFIRMATION_EPOCHS),
             validity_epochs=3,
             policy_version=DIRECTIONAL_ASSESSMENT_POLICY_VERSION,
         ),
@@ -381,6 +395,12 @@ class HardenedBridgeSessionStateV2:
     max_age_research_evidence_ledger_path: Path | None = None
     # Optional productive research-evidence accumulation (diagnostic only).
     productive_evidence_accumulation_state: ProductiveEvidenceAccumulationStateV1 | None = None
+    # Cap 6.3 / G07: typed canonical decision-runtime config binding (no local Cap-6.3 literals).
+    decision_config_binding: HostDecisionConfigBindingV1 = field(
+        default_factory=HostDecisionConfigBindingV1
+    )
+    decision_config_state_root: str | None = None
+    decision_config_repository_sha: str = _HARDENING_V2_DECISION_CONFIG_REPOSITORY_SHA
 
     def append_mid(self, mid: float) -> None:
         self.mid_prices.append(float(mid))
@@ -482,6 +502,23 @@ def run_hardened_bridge_cycle_v2(
     state.cycle_index += 1
     state.append_mid(mid_price)
     cycle_id = make_scoped_id("cycle", session_id, state.cycle_index)
+
+    # Capability 6.3 / G07 residual closeout: bind Cap-6.3 typed decision config before alpha.
+    ensure_host_decision_config_binding_v1(
+        state.decision_config_binding,
+        repository_sha=str(
+            state.decision_config_repository_sha or _HARDENING_V2_DECISION_CONFIG_REPOSITORY_SHA
+        ),
+        state_root=(
+            Path(state.decision_config_state_root) if state.decision_config_state_root else None
+        ),
+        persist=bool(state.decision_config_state_root),
+    )
+    if state.decision_config_binding.alpha_blocked:
+        raise RuntimeError(
+            "DECISION_CONFIG_ALPHA_BLOCKED:" + state.decision_config_binding.alpha_block_reason
+        )
+    decision_cfg = require_bound_decision_config_v1(state.decision_config_binding)
 
     basis = price_basis or build_explicit_mid_price_basis_v2(
         mid_price=float(mid_price),
@@ -644,10 +681,10 @@ def run_hardened_bridge_cycle_v2(
             remaining_epochs=0,
             policy_version=SCOPE_EVENT_GENERATOR_POLICY_VERSION,
         ),
-        up_distance=200.0,
-        adverse_exit_distance=80.0,
-        reversal_distance=120.0,
-        confirmation_epochs=2,
+        up_distance=float(decision_cfg.up_distance),
+        adverse_exit_distance=float(decision_cfg.adverse_exit_distance),
+        reversal_distance=float(decision_cfg.reversal_distance),
+        confirmation_epochs=int(decision_cfg.confirmation_epochs),
         current_price=mark,
         price_path=price_path,
         directional_confirmation_state=DirectionalConfirmationStateV1(
@@ -865,6 +902,17 @@ def run_hardened_bridge_cycle_v2(
         "reason_codes": list(replay.evidence.reason_codes),
         "blockers": list(features.blockers),
         "call_graph": list(CALL_GRAPH_V2),
+        "decision_config_binding": {
+            "initialized": bool(state.decision_config_binding.initialized),
+            "config_version": str(decision_cfg.config_version),
+            "schema_version": str(decision_cfg.schema_version),
+            "config_digest": str(decision_cfg.config_digest()),
+            "confirmation_epochs": int(decision_cfg.confirmation_epochs),
+            "up_distance": float(decision_cfg.up_distance),
+            "adverse_exit_distance": float(decision_cfg.adverse_exit_distance),
+            "reversal_distance": float(decision_cfg.reversal_distance),
+            "owner": str(decision_cfg.owner),
+        },
         "orders_authorized": ORDERS_AUTHORIZED,
         "testnet_authorized": TESTNET_AUTHORIZED,
         "live_authorized": LIVE_AUTHORIZED,

--- a/tests/ops/test_decision_config_ownership_and_consumer_closure_v1.py
+++ b/tests/ops/test_decision_config_ownership_and_consumer_closure_v1.py
@@ -83,8 +83,11 @@ def test_constants_and_call_graph_bound() -> None:
     assert CORE_LOGIC_CHANGE is False
     assert CALL_GRAPH_CONFIG_BIND_STEP in CALL_GRAPH_AFTER
     assert CALL_GRAPH_CONFIG_BIND_STEP not in CALL_GRAPH_BEFORE
-    assert CALL_GRAPH_V1 == REQUIRED_CALL_GRAPH
+    # Cap 7.2 may extend CALL_GRAPH_V1 beyond the Cap-6.3 verifier REQUIRED subset;
+    # Cap-6.3 bind step must remain in both, and REQUIRED must stay a subset of V1.
     assert CALL_GRAPH_CONFIG_BIND_STEP in CALL_GRAPH_V1
+    assert CALL_GRAPH_CONFIG_BIND_STEP in REQUIRED_CALL_GRAPH
+    assert all(node in CALL_GRAPH_V1 for node in REQUIRED_CALL_GRAPH)
     assert CANONICAL_CONFIRMATION_EPOCHS == EXPECTED_CONFIRMATION_EPOCHS == 2
     assert CANONICAL_UP_DISTANCE == EXPECTED_UP_DISTANCE == 200.0
     assert CANONICAL_ADVERSE_EXIT_DISTANCE == EXPECTED_ADVERSE_EXIT_DISTANCE == 80.0
@@ -266,3 +269,44 @@ def test_full_capability_evidence(tmp_path: Path) -> None:
     assert payload["claims"]["CONFIG_DIGEST_MISMATCH_FAIL_CLOSED"] is True
     assert payload["claims"]["NO_LIVE_ORDER_PATH"] is True
     assert payload["effective_values_before"] == payload["effective_values_after"]
+
+
+def test_hardening_v2_residual_host_consumer_bound_to_cap63_owner() -> None:
+    """Residual-2: hardening_v2 consumes Cap-6.3 owner; local Cap-6.3 literals removed."""
+    import re
+
+    from src.ops.wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2.hardening_cycle_bridge_v2 import (
+        CALL_GRAPH_V2,
+        HardenedBridgeSessionStateV2,
+        run_hardened_bridge_cycles_from_mids_v2,
+    )
+
+    host = Path(
+        "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2/"
+        "hardening_cycle_bridge_v2.py"
+    )
+    src = host.read_text(encoding="utf-8")
+    assert not re.search(r"confirmation_epochs\s*=\s*2\b", src)
+    assert not re.search(r"up_distance\s*=\s*200(?:\.0)?\b", src)
+    assert not re.search(r"adverse_exit_distance\s*=\s*80(?:\.0)?\b", src)
+    assert not re.search(r"reversal_distance\s*=\s*120(?:\.0)?\b", src)
+    assert CALL_GRAPH_CONFIG_BIND_STEP in CALL_GRAPH_V2
+
+    state, cycles = run_hardened_bridge_cycles_from_mids_v2(
+        [3500.0],
+        session_id="cap63-residual2-hardening-v2",
+    )
+    assert isinstance(state, HardenedBridgeSessionStateV2)
+    assert state.decision_config_binding.initialized is True
+    assert state.decision_config_binding.confirmation_epochs == EXPECTED_CONFIRMATION_EPOCHS == 2
+    assert state.decision_config_binding.up_distance == EXPECTED_UP_DISTANCE == 200.0
+    assert (
+        state.decision_config_binding.adverse_exit_distance
+        == EXPECTED_ADVERSE_EXIT_DISTANCE
+        == 80.0
+    )
+    assert state.decision_config_binding.reversal_distance == EXPECTED_REVERSAL_DISTANCE == 120.0
+    assert cycles[0]["decision_config_binding"]["confirmation_epochs"] == 2
+    assert cycles[0]["decision_config_binding"]["up_distance"] == 200.0
+    assert cycles[0]["decision_config_binding"]["adverse_exit_distance"] == 80.0
+    assert cycles[0]["decision_config_binding"]["reversal_distance"] == 120.0

--- a/tests/ops/test_wallclock_bridge_hardening_v2.py
+++ b/tests/ops/test_wallclock_bridge_hardening_v2.py
@@ -567,3 +567,100 @@ def test_required_window_incomplete_still_emitted_when_warmup_incomplete() -> No
     assert cycles[0]["required_window_complete"] is False
     assert cycles[0]["mid_prices_len"] == 1
     assert state.cycle_index == 1
+
+
+def test_hardening_v2_binds_cap63_canonical_decision_config_no_local_literals() -> None:
+    """G07 residual closeout: Cap-6.3 values from typed owner; no local Cap-6.3 literals."""
+    import re
+
+    from src.ops.decision_config_ownership_and_consumer_closure_v1.canonical_values_v1 import (
+        CANONICAL_ADVERSE_EXIT_DISTANCE,
+        CANONICAL_CONFIRMATION_EPOCHS,
+        CANONICAL_REVERSAL_DISTANCE,
+        CANONICAL_UP_DISTANCE,
+    )
+    from src.ops.decision_config_ownership_and_consumer_closure_v1.constants_v1 import (
+        CALL_GRAPH_CONFIG_BIND_STEP,
+        EXPECTED_ADVERSE_EXIT_DISTANCE,
+        EXPECTED_CONFIRMATION_EPOCHS,
+        EXPECTED_REVERSAL_DISTANCE,
+        EXPECTED_UP_DISTANCE,
+    )
+    from src.ops.wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2.hardening_cycle_bridge_v2 import (
+        CALL_GRAPH_V2,
+        _default_policies,
+    )
+
+    host_path = (
+        REPO_ROOT
+        / "src/ops/wallclock_full_canonical_decision_to_simulated_economics_runtime_bridge_hardening_v2"
+        / "hardening_cycle_bridge_v2.py"
+    )
+    src = host_path.read_text(encoding="utf-8")
+    # Residual Cap-6.3 literals must not remain as local kwargs/assignments.
+    assert not re.search(r"confirmation_epochs\s*=\s*2\b", src)
+    assert not re.search(r"up_distance\s*=\s*200(?:\.0)?\b", src)
+    assert not re.search(r"adverse_exit_distance\s*=\s*80(?:\.0)?\b", src)
+    assert not re.search(r"reversal_distance\s*=\s*120(?:\.0)?\b", src)
+    assert "ensure_host_decision_config_binding_v1" in src
+    assert "require_bound_decision_config_v1" in src
+    assert "CANONICAL_CONFIRMATION_EPOCHS" in src
+    assert CALL_GRAPH_CONFIG_BIND_STEP in CALL_GRAPH_V2
+
+    assert CANONICAL_CONFIRMATION_EPOCHS == EXPECTED_CONFIRMATION_EPOCHS == 2
+    assert CANONICAL_UP_DISTANCE == EXPECTED_UP_DISTANCE == 200.0
+    assert CANONICAL_ADVERSE_EXIT_DISTANCE == EXPECTED_ADVERSE_EXIT_DISTANCE == 80.0
+    assert CANONICAL_REVERSAL_DISTANCE == EXPECTED_REVERSAL_DISTANCE == 120.0
+
+    policies = _default_policies()
+    assert int(policies.directional.confirmation_epochs) == 2
+
+    state, cycles = run_hardened_bridge_cycles_from_mids_v2(
+        [3500.0, 3510.0],
+        session_id="cap63-hardening-v2-bind",
+    )
+    assert state.decision_config_binding.initialized is True
+    assert state.decision_config_binding.confirmation_epochs == 2
+    assert state.decision_config_binding.up_distance == 200.0
+    assert state.decision_config_binding.adverse_exit_distance == 80.0
+    assert state.decision_config_binding.reversal_distance == 120.0
+    assert cycles
+    cfg = cycles[-1]["decision_config_binding"]
+    assert cfg["confirmation_epochs"] == 2
+    assert cfg["up_distance"] == 200.0
+    assert cfg["adverse_exit_distance"] == 80.0
+    assert cfg["reversal_distance"] == 120.0
+    assert CALL_GRAPH_CONFIG_BIND_STEP in cycles[-1]["call_graph"]
+
+
+def test_hardening_v2_decision_config_drift_guard_fail_closed(tmp_path: Path) -> None:
+    from src.ops.decision_config_ownership_and_consumer_closure_v1.config_loader_v1 import (
+        DecisionConfigError,
+    )
+    from src.ops.decision_config_ownership_and_consumer_closure_v1.host_binding_v1 import (
+        ensure_host_decision_config_binding_v1,
+    )
+    from src.ops.decision_config_ownership_and_consumer_closure_v1.reason_codes_v1 import (
+        DecisionConfigFailureCodeV1,
+    )
+
+    drifted = tmp_path / "drifted.toml"
+    drifted.write_text(
+        "[canonical_decision_runtime_config_v1]\n"
+        'config_version = "v1"\n'
+        'schema_version = "canonical_decision_runtime_config.v1"\n'
+        "confirmation_epochs = 2\n"
+        "up_distance = 201.0\n"
+        "adverse_exit_distance = 80.0\n"
+        "reversal_distance = 120.0\n",
+        encoding="utf-8",
+    )
+    state = HardenedBridgeSessionStateV2()
+    with pytest.raises(DecisionConfigError) as exc:
+        ensure_host_decision_config_binding_v1(
+            state.decision_config_binding,
+            repository_sha="OFFLINE_HARDENING_V2_ANALYTICAL",
+            config_path=drifted,
+            persist=False,
+        )
+    assert exc.value.code is DecisionConfigFailureCodeV1.CONFIG_EFFECTIVE_VALUE_DRIFT


### PR DESCRIPTION
## Summary
- Bind wallclock `hardening_v2` to Cap-6.3 canonical decision-config owner via existing `host_binding_v1` / `decision_cfg` (no parallel config authority).
- Replace the four residual local Cap-6.3 literals (`confirmation_epochs`, `up_distance`, `adverse_exit_distance`, `reversal_distance`) with canonically derived values; effective numerics remain `2` / `200.0` / `80.0` / `120.0`.
- Close No-Order Program DoD residual-2: `HARDENING_V2_LOCAL_DISTANCE_LITERALS_RESIDUAL_AFTER_CAP63=false`, `CONFIG_RUNTIME_DRIFT=false_for_in_scope_runtime_values`.

## Test plan
- [x] `tests/ops/test_decision_config_ownership_and_consumer_closure_v1.py`
- [x] `tests/ops/test_wallclock_bridge_hardening_v2.py`
- [x] PR_BOUNDED_FULL selector targets + owner tests (766 passed, ~38s)
- [x] `ruff format --check` / `ruff check` on touched Python
- [x] Docs token policy + changed docs reference targets
- [ ] CI confirmation on PR (do not merge in this task)


Made with [Cursor](https://cursor.com)