### PR TITLE
governance: minimum local CI dedup and bound test evidence reuse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,4 @@ NO_PARALLEL_SEMANTIC_MODEL=true
 - Kein Live-, Testnet-, Order-, Credential- oder Real-Capital-Recht aus Dokumentation ableiten.
 - Git nur im echten lokalen Repository über das lokale Terminal; Cursor-Sandbox-Git ist verboten.
 - Untracked Evidence unverändert erhalten.
+- Lokale CI-Dedup&#47;Reuse-Orchestrierung (Master Runbook §15.3): `docs&#47;ops&#47;specs&#47;GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.md` — kein redundantes Suite-Re-Run nur für Evidence&#47;Verifier&#47;Pre-PR bei identischem gebundenem PASS.

--- a/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
+++ b/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
@@ -203,6 +203,20 @@ Readiness ist nicht Authorization; Authorization ist nicht Execution.
 
 ---
 
+## 8.1 Local verification minimum / CI dedup (navigation only)
+
+| Dokument | Rolle |
+|----------|-------|
+| [`docs/ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.md`](../ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.md) | Governance verification minimum &#47; local CI dedup (navigation pointer; Semantik im Master Runbook §15.3 + JSON-Owner) |
+| [`docs/ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.json`](../ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.json) | Machine-readable policy owner |
+
+```text
+THIS_SECTION_DEFINES_NO_SEMANTICS=true
+CANONICAL_SEMANTICS=docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md#15.3
+```
+
+---
+
 ## 9. Wichtigste Runbooks
 
 | Dokument | Rolle |

--- a/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
+++ b/docs/ops/CI_AUDIT_KNOWN_ISSUES.md
@@ -4044,6 +4044,19 @@ ruff format --check .
 bash scripts/ops/check_no_black_enforcement.sh
 ```
 
+## Governance verification minimum local CI dedup v1
+
+**Scope:** `VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1=true` · **Owners:** `docs&#47;ops&#47;specs&#47;GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.json` + `scripts&#47;ops&#47;verification_minimum_local_ci_dedup_v1.py` · **Runbook:** Master Runbook §15.3
+
+Generic local verification orchestration: one bound capability&#47;owner `PASS`+`EXIT=0` for an exact stand is reusable for evidence seal, static verifier and Pre-PR; GitHub Required Checks remain the binding broad integration&#47;regression layer. Does **not** weaken Safety&#47;Activation&#47;Credential&#47;Order hard-stops. Cap 11.13 remains out of scope.
+
+```bash
+python3 scripts/ops/verification_minimum_local_ci_dedup_v1.py --print-policy
+python3 -m pytest -q tests/ci/test_verification_minimum_local_ci_dedup_v1.py
+```
+
+**Non-authorizing:** governance&#47;verification orchestration only; no runtime&#47;trading&#47;activation&#47;order scope.
+
 ## Canonical pre-PR diff-scoped Ruff + diff-check guard v0
 
 **Scope:** `PREFLIGHT_PRE_PR_RUFF_AND_DIFF_GUARD_V0=true` · **Owner:** `scripts/ops/preflight_pre_pr_ruff_and_diff_guard_v0.py`

--- a/docs/ops/GATES_OVERVIEW.md
+++ b/docs/ops/GATES_OVERVIEW.md
@@ -20,6 +20,8 @@ Jeder PR mit geänderten `*.md` (reine Docs-PR **oder** docs+tests-PR) **muss** 
 | 3 | PR-scoped pytest (docs+tests) | betroffene Contract-/Boundary-Tests | je nach Diff |
 | 4 | Ruff (bei `.py`-Diff) | `ruff check` / `ruff format --check` auf berührte Dateien | `Lint Gate` |
 
+**Local CI dedup (Master Runbook §15.3):** Ein gebundener lokaler Capability&#47;Owner-`PASS`+`EXIT=0` für denselben Stand darf für Evidence&#47;statischen Verifier&#47;Pre-PR wiederverwendet werden; GitHub Required Checks bleiben die verbindliche breite Integrations&#47;Regressionsebene. Owner: `docs&#47;ops&#47;specs&#47;GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.md`.
+
 Runbook: `docs&#47;ops&#47;runbooks&#47;RUNBOOK_DOCS_TOKEN_POLICY_GATE.md` · CI-Audit: `docs&#47;ops&#47;CI_AUDIT_KNOWN_ISSUES.md` (§ Docs Token Policy Guard standard check integration).
 
 ## Gate Catalog (Table)

--- a/docs/ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.json
+++ b/docs/ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": "1.0.0",
+  "policy_id": "GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1",
+  "document_class": "GOVERNANCE_VERIFICATION_ORCHESTRATION",
+  "runtime_authorization_effect": "NONE",
+  "core_logic_change": false,
+  "activation_effect": "NONE",
+  "capability_11_13_started": false,
+  "canonical_owners": {
+    "policy_json": "docs/ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.json",
+    "policy_markdown": "docs/ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.md",
+    "orchestrator": "scripts/ops/verification_minimum_local_ci_dedup_v1.py",
+    "pre_pr_verifier": "scripts/ops/verify_pre_pr_validation_result_v0.py",
+    "required_checks_ssot": "config/ci/required_status_checks.json",
+    "runbook_section": "docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md#15.3",
+    "contract_tests": "tests/ci/test_verification_minimum_local_ci_dedup_v1.py"
+  },
+  "github_required_checks_role": "BINDING_BROAD_INTEGRATION_AND_REGRESSION_LAYER",
+  "decision_principle": {
+    "A_github_required": "Is this check already executed as a GitHub required check?",
+    "B_local_pre_push_value": "Does a local re-execution add information that is mandatory before push?",
+    "skip_when": "A=true AND B=false",
+    "skip_identical_stand_pass": "If the exact same stand already has a full PASS with EXIT=0 for the same selector/command, do not re-execute."
+  },
+  "test_evidence_reuse_rule": {
+    "sufficient_when": [
+      "identical_commit_or_bound_worktree_diff",
+      "identical_test_selector_or_command",
+      "full_run_completed",
+      "result_PASS",
+      "exit_code_0"
+    ],
+    "invalid_when": [
+      "stand_changed",
+      "incomplete_run",
+      "missing_binding",
+      "exit_code_nonzero",
+      "result_not_PASS"
+    ]
+  },
+  "evidence_reexecution_rule": "Evidence may reference or seal an existing bound PASS; it must not re-start an already-passed expensive suite solely for sealing.",
+  "verifier_reexecution_rule": "Verifiers must validate artifacts, claims, hashes, and bindings statically unless additional runtime information is strictly required.",
+  "pre_pr_reexecution_rule": "Pre-PR must not re-run a suite already bound as PASS for the identical stand; only non-GitHub-covered local invariants and first-diagnosis fail-closed pre-push checks remain.",
+  "local_checks_retained": [
+    {
+      "check_id": "final_diff_freeze_and_sha256",
+      "reason": "Local orchestration invariant; not a GitHub required check context."
+    },
+    {
+      "check_id": "canonical_ci_selector_on_final_diff",
+      "reason": "Determines FOCUSED/NO_OP/FULL and timing-proof necessity before push."
+    },
+    {
+      "check_id": "ruff_format_and_check_on_python_diff",
+      "reason": "Mandatory pre-push first-diagnosis fail-closed; GitHub Lint Gate must not be the first format/lint diagnosis."
+    },
+    {
+      "check_id": "docs_token_policy_on_md_diff",
+      "reason": "Mandatory pre-push first-diagnosis fail-closed for changed Markdown."
+    },
+    {
+      "check_id": "docs_reference_targets_on_md_diff",
+      "reason": "Mandatory pre-push first-diagnosis fail-closed for changed Markdown links."
+    },
+    {
+      "check_id": "bound_capability_or_owner_test_once",
+      "reason": "One full local PASS+EXIT=0 for the exact stand binds local test evidence; not a duplicate of GitHub breadth."
+    },
+    {
+      "check_id": "static_evidence_and_manifest_verify",
+      "reason": "Local durable-evidence integrity; not covered by GitHub required test matrix alone."
+    },
+    {
+      "check_id": "safety_activation_credential_order_hard_stops",
+      "reason": "Must never be weakened; GitHub required checks do not replace these local fail-closed claims."
+    }
+  ],
+  "redundant_local_reexecutions_removed": [
+    {
+      "check_id": "capability_suite_rerun_for_evidence_seal_only",
+      "reason": "Already bound PASS+EXIT=0 for identical stand is sufficient; evidence seals/references it."
+    },
+    {
+      "check_id": "capability_suite_rerun_inside_static_verifier",
+      "reason": "Verifier validates sealed artifacts statically when no additional runtime info is required."
+    },
+    {
+      "check_id": "pre_pr_rerun_of_identical_bound_suite",
+      "reason": "LOCAL_GATE may reuse bound PASS for identical stand/command; GitHub required tests remain the broad layer."
+    },
+    {
+      "check_id": "local_full_suite_mirror_of_github_required_tests",
+      "reason": "GitHub required context tests (3.11) already provides binding broad regression; local full mirror adds no pre-push information when a bound FOCUSED PASS exists."
+    },
+    {
+      "check_id": "timing_proof_rerun_of_identical_already_measured_stand",
+      "reason": "Reuse wallclock from the identical bound full PASS when selector/timing conditions still hold."
+    }
+  ],
+  "github_covered_check_ids_example": [
+    "Lint Gate",
+    "docs-token-policy-gate",
+    "docs-reference-targets-gate",
+    "tests (3.11)",
+    "strategy-smoke",
+    "audit",
+    "dispatch-guard",
+    "docs-drift-guard",
+    "repo-truth-claims",
+    "Policy Critic Gate",
+    "Guard tracked files in reports folders"
+  ],
+  "allowed_local_actions": [
+    "EXECUTE_REQUIRED_LOCAL",
+    "REUSE_BOUND_PASS",
+    "SKIP_GITHUB_COVERED_NO_EXTRA_LOCAL_VALUE"
+  ],
+  "forbidden": [
+    "WEAKEN_SAFETY_ACTIVATION_CREDENTIAL_ORDER_HARD_STOPS",
+    "START_CAPABILITY_11_13",
+    "REEXECUTE_IDENTICAL_BOUND_PASS_FOR_EVIDENCE_ONLY",
+    "REEXECUTE_IDENTICAL_BOUND_PASS_FOR_STATIC_VERIFIER_ONLY",
+    "REEXECUTE_IDENTICAL_BOUND_PASS_FOR_PRE_PR_ONLY",
+    "CLAIM_REUSE_WITHOUT_IDENTICAL_STAND_BINDING"
+  ]
+}

--- a/docs/ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.md
+++ b/docs/ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.md
@@ -1,0 +1,110 @@
+---
+docs_token: DOCS_TOKEN_GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1
+status: active
+scope: Governance verification orchestration only; no trading&#47;activation&#47;order semantics
+policy_id: GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1
+architecture_spec: PEAK_TRADE_MASTER_RUNBOOK
+last_updated: 2026-08-08
+---
+
+# Governance Verification — Minimum Local CI Dedup V1
+
+## Goal
+
+Reduce local verification to the necessary minimum and forbid redundant
+re-execution of checks that GitHub Required Checks already bind as the
+broad integration&#47;regression layer.
+
+```text
+CORE_LOGIC_CHANGE=false
+ACTIVATION_STATE=not_activated
+NETWORK_SESSION_STARTED=false
+CREDENTIAL_ACCESS=false
+ORDER_SUBMIT_REACHABLE=false
+CAPABILITY_11_13_STARTED=false
+RUNTIME_AUTHORIZATION_EFFECT=NONE
+```
+
+## Target architecture
+
+```text
+Capability&#47;owner test once locally
+→ PASS + EXIT=0 binds local test evidence for that exact stand
+→ Evidence seals&#47;references the bound proof (no suite re-start)
+→ Verifier validates artifacts&#47;claims&#47;hashes&#47;bindings statically
+→ Pre-PR checks only additional Non-GitHub local invariants
+→ Push&#47;PR
+→ GitHub Required Checks provide binding broad regression
+```
+
+## Decision principle (every local check)
+
+Before executing a local check:
+
+1. **A** — Is this check already executed as a GitHub Required Check?
+2. **B** — Does a local repetition add information mandatory before push?
+
+If `A=true` and `B=false`: **do not execute locally**.
+
+If the exact same stand already has a full `PASS` with `EXIT=0` for the
+same selector&#47;command: **do not re-execute**.
+
+## Reuse binding (fail-closed)
+
+A local PASS may be reused only when all of the following hold:
+
+- identical commit **or** unambiguously bound worktree&#47;diff
+- identical test selector&#47;command
+- full run completed
+- result `PASS`
+- `EXIT=0`
+
+Otherwise the proof is invalid and the suite must run once.
+
+## Local checks retained (why GitHub does not replace them)
+
+| Check | Why retained |
+| --- | --- |
+| Final diff freeze + `FINAL_DIFF_SHA256` | Local orchestration; not a required GitHub context |
+| Canonical CI selector on final diff | Determines `NO_OP`&#47;`FOCUSED`&#47;`FULL` and timing necessity |
+| Ruff format&#47;check on Python diff | Pre-push first diagnosis (GitHub must not be first lint diagnosis) |
+| Docs token policy on `.md` diff | Pre-push first diagnosis for token policy |
+| Docs reference targets on `.md` diff | Pre-push first diagnosis for link targets |
+| One bound capability&#47;owner test | Creates the reusable local PASS binding |
+| Static evidence + manifest verify | Durable evidence integrity |
+| Safety&#47;activation&#47;credential&#47;order hard-stops | Must never be weakened |
+
+## Redundant local re-executions removed
+
+| Pattern | Why removed |
+| --- | --- |
+| Capability suite re-run only to seal evidence | Seal&#47;reference the bound PASS |
+| Capability suite re-run inside static verifier | Verify artifacts statically |
+| Pre-PR re-run of the identical bound suite | Reuse bound PASS; GitHub remains broad layer |
+| Local full-suite mirror of GitHub `tests (3.11)` | No extra pre-push information when bound FOCUSED PASS exists |
+| Timing-proof re-run of identical already-measured stand | Reuse wallclock from bound PASS when still valid |
+
+## Hard stops preserved
+
+This policy does **not** authorize:
+
+- weakening Safety&#47;Governance&#47;Activation&#47;Credential&#47;Order hard-stops
+- starting Capability 11.13
+- claiming reuse without an identical-stand binding
+- replacing GitHub Required Checks with local opinion
+
+## Canonical owners
+
+| Surface | Owner |
+| --- | --- |
+| Machine-readable policy | `docs&#47;ops&#47;specs&#47;GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.json` |
+| Orchestrator | `scripts&#47;ops&#47;verification_minimum_local_ci_dedup_v1.py` |
+| Pre-PR envelope verifier | `scripts&#47;ops&#47;verify_pre_pr_validation_result_v0.py` |
+| Required checks SSOT | `config&#47;ci&#47;required_status_checks.json` |
+| Runbook binding | Master Runbook §15.3 |
+| Contract tests | `tests&#47;ci&#47;test_verification_minimum_local_ci_dedup_v1.py` |
+
+## Generic (not Cap-11.12-specific)
+
+This policy is capability-generic. It must not invent Cap-11.12-only
+bypass paths. Cap 11.13 remains out of scope and must not be started.

--- a/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
+++ b/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
@@ -650,10 +650,10 @@ DOCUMENTATION_RUNTIME_DRIFT=false
 program inception. It is not the current runtime truth. Current-truth
 claims in this section are reconciled against
 `CURRENT_FORENSIC_TRUTH_SHA`, bound to the Phase 9.2 Step-7 ladder-closeout
-`origin/main` SHA `642db05919634b899329679a811f1ad25a0fd818`. Later
+`origin&#47;main` SHA `642db05919634b899329679a811f1ad25a0fd818`. Later
 docs-only merges may advance HEAD without rewriting this program-truth
 binding. Every later implementation capability must still revalidate the
-actual `origin/main` SHA. Older Cap 6.1--7.2 and typed-volatility evidence
+actual `origin&#47;main` SHA. Older Cap 6.1--7.2 and typed-volatility evidence
 packages remain historical predecessor evidence for their merge SHAs and
 must not be silently rewritten.
 
@@ -3487,6 +3487,94 @@ Operational rule:
 This requirement exists because chat context is not guaranteed to persist
 across independent Cursor conversations. Therefore every new chat must
 explicitly establish the current canonical runbook before implementation.
+
+
+### 15.3 Minimum Local CI Dedup / Bound Test Evidence Reuse (Binding)
+
+The following operational rules are mandatory for local verification,
+evidence sealing, static verifiers and Pre-PR orchestration. They override
+ambiguous or redundant local re-execution guidance when GitHub Required
+Checks already provide the binding broad integration&#47;regression layer.
+
+Machine-readable owner:
+
+```text
+docs/ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.json
+scripts/ops/verification_minimum_local_ci_dedup_v1.py
+```
+
+Canonical rules:
+
+```text
+TEST_EVIDENCE_REUSE_RULE=
+  one full local capability&#47;owner PASS + EXIT=0 for an exact unchanged stand
+  is sufficient local test proof for that identical stand&#47;command
+EVIDENCE_REEXECUTION_RULE=
+  evidence may seal&#47;reference a bound PASS; it must not re-start the same
+  expensive suite solely for sealing
+VERIFIER_REEXECUTION_RULE=
+  verifiers validate artifacts&#47;claims&#47;hashes&#47;bindings statically unless
+  additional runtime information is strictly required
+PRE_PR_REEXECUTION_RULE=
+  Pre-PR must not re-run an identical bound PASS; only Non-GitHub local
+  invariants and mandatory pre-push first-diagnosis checks remain
+GITHUB_REQUIRED_CHECKS_ROLE=
+  BINDING_BROAD_INTEGRATION_AND_REGRESSION_LAYER
+```
+
+Decision principle for every local check:
+
+```text
+A = already executed as a GitHub Required Check?
+B = local repetition adds mandatory pre-push information?
+IF A=true AND B=false: DO NOT EXECUTE LOCALLY
+IF identical stand already has full PASS + EXIT=0 for same command:
+  DO NOT RE-EXECUTE
+```
+
+Reuse is valid only when all hold:
+
+```text
+identical commit OR unambiguously bound worktree&#47;diff
+identical test selector&#47;command
+full run completed
+result=PASS
+EXIT=0
+```
+
+Local checks that remain mandatory (GitHub does not replace them):
+
+```text
+final diff freeze + FINAL_DIFF_SHA256
+canonical CI selector on final diff
+ruff format&#47;check on Python diff (pre-push first diagnosis)
+docs token policy + docs reference targets on Markdown diff
+one bound capability&#47;owner test PASS for the exact stand
+static evidence + MANIFEST verify
+Safety&#47;Activation&#47;Credential&#47;Order hard-stops
+```
+
+Redundant local re-executions that are forbidden when a bound PASS exists:
+
+```text
+capability suite re-run only to seal evidence
+capability suite re-run inside a static verifier
+Pre-PR re-run of the identical bound suite
+local full-suite mirror of GitHub required tests (3.11) without extra local value
+timing-proof re-run of an identical already-measured stand
+```
+
+Hard stops preserved:
+
+```text
+NO weakening of Safety&#47;Governance&#47;Activation&#47;Credential&#47;Order gates
+CAPABILITY_11_13_STARTED=false
+CORE_LOGIC_CHANGE=false unless separately authorized
+RUNTIME_AUTHORIZATION_EFFECT=NONE
+```
+
+This section is capability-generic. It must not create a Cap-11.12-only
+bypass. Cap 11.13 must not be started from this policy.
 
 
 # 16. Cursor Assignment Contract

--- a/scripts/ops/verification_minimum_local_ci_dedup_v1.py
+++ b/scripts/ops/verification_minimum_local_ci_dedup_v1.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Minimum local CI dedup / bound-test-evidence reuse orchestration (v1).
+
+Generic governance verification orchestration. Does not mutate trading,
+activation, credential, order, or Cap-11.13 surfaces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+POLICY_ID = "GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1"
+PACKAGE_MARKER = "VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1=true"
+POLICY_REL_PATH = "docs/ops/specs/GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.json"
+REQUIRED_CHECKS_REL_PATH = "config/ci/required_status_checks.json"
+
+ACTION_EXECUTE = "EXECUTE_REQUIRED_LOCAL"
+ACTION_REUSE = "REUSE_BOUND_PASS"
+ACTION_SKIP_GITHUB = "SKIP_GITHUB_COVERED_NO_EXTRA_LOCAL_VALUE"
+
+REUSE_STATUS_EXECUTED = "EXECUTED"
+REUSE_STATUS_REUSED = "REUSED"
+REUSE_STATUS_NA = "N/A"
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def policy_path(*, repo_root: Path | None = None) -> Path:
+    root = repo_root or _REPO_ROOT
+    return root / POLICY_REL_PATH
+
+
+def load_policy(*, repo_root: Path | None = None) -> dict[str, Any]:
+    path = policy_path(repo_root=repo_root)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("policy_id") != POLICY_ID:
+        raise ValueError(f"policy_id mismatch in {path}")
+    if payload.get("runtime_authorization_effect") != "NONE":
+        raise ValueError("runtime_authorization_effect must remain NONE")
+    if payload.get("capability_11_13_started") is not False:
+        raise ValueError("capability_11_13_started must remain false")
+    return payload
+
+
+def load_required_contexts(*, repo_root: Path | None = None) -> frozenset[str]:
+    root = repo_root or _REPO_ROOT
+    path = root / REQUIRED_CHECKS_REL_PATH
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    required = set(payload.get("required_contexts") or [])
+    ignored = set(payload.get("ignored_contexts") or [])
+    return frozenset(required - ignored)
+
+
+def classify_local_check(
+    *,
+    check_id: str,
+    github_required_contexts: frozenset[str] | set[str],
+    github_context_name: str | None = None,
+    local_pre_push_value_required: bool,
+    bound_pass_reusable: bool = False,
+) -> str:
+    """Return one of EXECUTE / REUSE / SKIP_GITHUB actions."""
+    if bound_pass_reusable:
+        return ACTION_REUSE
+    covered = False
+    if github_context_name and github_context_name in github_required_contexts:
+        covered = True
+    if check_id in github_required_contexts:
+        covered = True
+    if covered and not local_pre_push_value_required:
+        return ACTION_SKIP_GITHUB
+    return ACTION_EXECUTE
+
+
+def validate_bound_test_evidence(binding: Mapping[str, Any]) -> list[str]:
+    """Fail-closed validation for a reusable local test PASS binding."""
+    errors: list[str] = []
+    stand = str(binding.get("bound_stand_sha256") or "").strip()
+    if not stand:
+        errors.append("missing bound_stand_sha256")
+    command = binding.get("test_selector_or_command")
+    if isinstance(command, list):
+        if not command:
+            errors.append("empty test_selector_or_command")
+    elif not str(command or "").strip():
+        errors.append("missing test_selector_or_command")
+    if binding.get("full_run") is not True:
+        errors.append("full_run must be true")
+    if str(binding.get("result") or "").upper() != "PASS":
+        errors.append("result must be PASS")
+    try:
+        exit_code = int(binding.get("exit_code"))
+    except (TypeError, ValueError):
+        errors.append("exit_code must be int 0")
+    else:
+        if exit_code != 0:
+            errors.append(f"exit_code must be 0 (got {exit_code})")
+    return errors
+
+
+def bound_pass_is_reusable(
+    *,
+    binding: Mapping[str, Any],
+    current_stand_sha256: str,
+    current_test_selector_or_command: str | list[str],
+) -> bool:
+    if validate_bound_test_evidence(binding):
+        return False
+    if str(binding.get("bound_stand_sha256") or "").strip() != current_stand_sha256.strip():
+        return False
+    bound_cmd = binding.get("test_selector_or_command")
+    if isinstance(bound_cmd, list) or isinstance(current_test_selector_or_command, list):
+        left = [str(x) for x in (bound_cmd if isinstance(bound_cmd, list) else [bound_cmd])]
+        right = [
+            str(x)
+            for x in (
+                current_test_selector_or_command
+                if isinstance(current_test_selector_or_command, list)
+                else [current_test_selector_or_command]
+            )
+        ]
+        if left != right:
+            return False
+    elif str(bound_cmd).strip() != str(current_test_selector_or_command).strip():
+        return False
+    return True
+
+
+def validate_pre_pr_reuse_fields(data: Mapping[str, str]) -> list[str]:
+    """Optional PRE_PR reuse surface. Absent fields are allowed (legacy envelopes)."""
+    status = str(data.get("LOCAL_TEST_EVIDENCE_REUSE_STATUS") or "").strip()
+    if not status:
+        return []
+    errors: list[str] = []
+    allowed = {REUSE_STATUS_EXECUTED, REUSE_STATUS_REUSED, REUSE_STATUS_NA}
+    if status not in allowed:
+        errors.append(
+            f"LOCAL_TEST_EVIDENCE_REUSE_STATUS must be one of {sorted(allowed)} (got {status!r})"
+        )
+        return errors
+    if status == REUSE_STATUS_NA:
+        return errors
+    stand = str(data.get("BOUND_LOCAL_TEST_STAND_SHA256") or "").strip()
+    command = str(data.get("BOUND_LOCAL_TEST_COMMAND") or "").strip()
+    if status in {REUSE_STATUS_EXECUTED, REUSE_STATUS_REUSED}:
+        if not stand:
+            errors.append("BOUND_LOCAL_TEST_STAND_SHA256 required for reuse status")
+        if not command:
+            errors.append("BOUND_LOCAL_TEST_COMMAND required for reuse status")
+    if status == REUSE_STATUS_REUSED:
+        exit_raw = str(data.get("BOUND_LOCAL_TEST_EXIT_CODE") or "").strip()
+        result = str(data.get("BOUND_LOCAL_TEST_RESULT") or "").strip().upper()
+        full_run = str(data.get("BOUND_LOCAL_TEST_FULL_RUN") or "").strip().lower()
+        if exit_raw != "0":
+            errors.append("BOUND_LOCAL_TEST_EXIT_CODE must be 0 when REUSED")
+        if result != "PASS":
+            errors.append("BOUND_LOCAL_TEST_RESULT must be PASS when REUSED")
+        if full_run not in {"true", "1", "yes"}:
+            errors.append("BOUND_LOCAL_TEST_FULL_RUN must be true when REUSED")
+        binding = {
+            "bound_stand_sha256": stand,
+            "test_selector_or_command": command,
+            "full_run": full_run in {"true", "1", "yes"},
+            "result": result or "FAIL",
+            "exit_code": int(exit_raw) if exit_raw.isdigit() else -1,
+        }
+        errors.extend(validate_bound_test_evidence(binding))
+    return errors
+
+
+def retained_check_ids(*, repo_root: Path | None = None) -> list[str]:
+    policy = load_policy(repo_root=repo_root)
+    return [str(row["check_id"]) for row in policy.get("local_checks_retained") or []]
+
+
+def redundant_check_ids(*, repo_root: Path | None = None) -> list[str]:
+    policy = load_policy(repo_root=repo_root)
+    return [
+        str(row["check_id"]) for row in policy.get("redundant_local_reexecutions_removed") or []
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Minimum local CI dedup orchestrator v1")
+    parser.add_argument("--repo-root", type=Path, default=_REPO_ROOT)
+    parser.add_argument(
+        "--print-policy",
+        action="store_true",
+        help="Print machine-readable policy summary JSON",
+    )
+    parser.add_argument(
+        "--classify",
+        metavar="CHECK_ID",
+        help="Classify one local check id",
+    )
+    parser.add_argument("--github-context", default=None)
+    parser.add_argument(
+        "--local-pre-push-value",
+        choices=("true", "false"),
+        default="false",
+    )
+    parser.add_argument(
+        "--bound-pass-reusable",
+        choices=("true", "false"),
+        default="false",
+    )
+    parser.add_argument(
+        "--validate-binding-json",
+        type=Path,
+        default=None,
+        help="Validate a bound test evidence JSON object",
+    )
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve()
+
+    if args.print_policy:
+        policy = load_policy(repo_root=repo_root)
+        summary = {
+            "ok": True,
+            "PACKAGE_MARKER": PACKAGE_MARKER,
+            "policy_id": policy["policy_id"],
+            "github_required_checks_role": policy["github_required_checks_role"],
+            "retained": retained_check_ids(repo_root=repo_root),
+            "redundant_removed": redundant_check_ids(repo_root=repo_root),
+            "required_contexts": sorted(load_required_contexts(repo_root=repo_root)),
+        }
+        print(json.dumps(summary, sort_keys=True, indent=2))
+        return 0
+
+    if args.validate_binding_json is not None:
+        binding = json.loads(args.validate_binding_json.read_text(encoding="utf-8"))
+        errors = validate_bound_test_evidence(binding)
+        if errors:
+            print(json.dumps({"ok": False, "errors": errors}, sort_keys=True))
+            return 1
+        print(json.dumps({"ok": True, "reusable": True}, sort_keys=True))
+        return 0
+
+    if args.classify:
+        action = classify_local_check(
+            check_id=args.classify,
+            github_required_contexts=load_required_contexts(repo_root=repo_root),
+            github_context_name=args.github_context,
+            local_pre_push_value_required=args.local_pre_push_value == "true",
+            bound_pass_reusable=args.bound_pass_reusable == "true",
+        )
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "check_id": args.classify,
+                    "action": action,
+                    "PACKAGE_MARKER": PACKAGE_MARKER,
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    parser.error("one of --print-policy / --classify / --validate-binding-json is required")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/verify_pre_pr_validation_result_v0.py
+++ b/scripts/ops/verify_pre_pr_validation_result_v0.py
@@ -19,6 +19,13 @@ from pathlib import Path
 CANONICAL_RESULT_PATH = Path(".cursor/PRE_PR_VALIDATION_RESULT.env")
 PRE_PR_RESULT_REL_PATH = ".cursor/PRE_PR_VALIDATION_RESULT.env"
 
+_OPS_DIR = Path(__file__).resolve().parent
+if str(_OPS_DIR) not in sys.path:
+    sys.path.insert(0, str(_OPS_DIR))
+from verification_minimum_local_ci_dedup_v1 import (  # noqa: E402
+    validate_pre_pr_reuse_fields,
+)
+
 ALLOWED_VERDICTS = frozenset(
     {
         "PRE_PR_VALIDATION_PASS",
@@ -248,6 +255,9 @@ def verify_pre_pr_validation_result(
             errors.append(
                 f"TIMING_WALLCLOCK_SECONDS={wallclock} reached hard stop; cannot claim timing not required"
             )
+
+    # Optional minimum-local-CI dedup reuse surface (absent = legacy envelope OK).
+    errors.extend(validate_pre_pr_reuse_fields(data))
 
     if check_binding:
         for key in REQUIRED_BINDING_FIELDS:

--- a/tests/ci/test_cursor_auto_pr_pre_pr_validation_enforcement_contract_v0.py
+++ b/tests/ci/test_cursor_auto_pr_pre_pr_validation_enforcement_contract_v0.py
@@ -194,6 +194,30 @@ def test_local_gate_not_pass_blocks() -> None:
     assert verify_pre_pr_validation_result(data)
 
 
+def test_local_test_evidence_reuse_valid_allows() -> None:
+    data = _valid_timing_not_required_data(
+        LOCAL_TEST_EVIDENCE_REUSE_STATUS="REUSED",
+        BOUND_LOCAL_TEST_STAND_SHA256="abc123",
+        BOUND_LOCAL_TEST_COMMAND="pytest -q tests/ci/test_verification_minimum_local_ci_dedup_v1.py",
+        BOUND_LOCAL_TEST_EXIT_CODE="0",
+        BOUND_LOCAL_TEST_RESULT="PASS",
+        BOUND_LOCAL_TEST_FULL_RUN="true",
+    )
+    assert verify_pre_pr_validation_result(data) == []
+
+
+def test_local_test_evidence_reuse_invalid_exit_blocks() -> None:
+    data = _valid_timing_not_required_data(
+        LOCAL_TEST_EVIDENCE_REUSE_STATUS="REUSED",
+        BOUND_LOCAL_TEST_STAND_SHA256="abc123",
+        BOUND_LOCAL_TEST_COMMAND="pytest -q tests/ci/test_verification_minimum_local_ci_dedup_v1.py",
+        BOUND_LOCAL_TEST_EXIT_CODE="2",
+        BOUND_LOCAL_TEST_RESULT="PASS",
+        BOUND_LOCAL_TEST_FULL_RUN="true",
+    )
+    assert verify_pre_pr_validation_result(data)
+
+
 def test_manifest_verify_rc_nonzero_blocks() -> None:
     data = _valid_pass_data(MANIFEST_VERIFY_RC="1")
     assert verify_pre_pr_validation_result(data)

--- a/tests/ci/test_verification_minimum_local_ci_dedup_v1.py
+++ b/tests/ci/test_verification_minimum_local_ci_dedup_v1.py
@@ -1,0 +1,196 @@
+"""Contract tests for GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POLICY_JSON = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.json"
+)
+POLICY_MD = (
+    REPO_ROOT / "docs" / "ops" / "specs" / "GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.md"
+)
+ORCHESTRATOR = REPO_ROOT / "scripts" / "ops" / "verification_minimum_local_ci_dedup_v1.py"
+RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "canonical" / "PEAK_TRADE_MASTER_RUNBOOK.md"
+REQUIRED_CHECKS = REPO_ROOT / "config" / "ci" / "required_status_checks.json"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ops"))
+import verification_minimum_local_ci_dedup_v1 as dedup  # noqa: E402
+from verify_pre_pr_validation_result_v0 import (  # noqa: E402
+    verify_pre_pr_validation_result,
+)
+
+
+def _valid_pre_pr(**overrides: str) -> dict[str, str]:
+    base = {
+        "PRE_PR_VALIDATION_VERDICT": "PRE_PR_VALIDATION_PASS_TIMING_NOT_REQUIRED",
+        "FINAL_DIFF_FROZEN": "true",
+        "FINAL_FILES_MATCH": "true",
+        "FINAL_DIFF_PATH_EQUIVALENCE_CONFIRMED": "true",
+        "REUSE_BEFORE_NEW_CHECKED": "true",
+        "LOCAL_GATE_BATCH_RESULT": "PASS",
+        "UNVALIDATED_FILES_REMAIN": "false",
+        "COMMIT_ALLOWED": "true",
+        "PUSH_ALLOWED": "true",
+        "PR_ALLOWED": "true",
+        "MANIFEST_VERIFY_RC": "0",
+        "TIMING_PROOF_REQUIRED": "false",
+        "TIMING_PROOF_STATUS": "TIMING_PROOF_NOT_REQUIRED_JUSTIFIED",
+        "TIMING_PROOF_NOT_REQUIRED_JUSTIFICATION": "selector FOCUSED small governance dedup",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_policy_owners_exist() -> None:
+    assert POLICY_JSON.is_file()
+    assert POLICY_MD.is_file()
+    assert ORCHESTRATOR.is_file()
+    assert "15.3 Minimum Local CI Dedup" in RUNBOOK.read_text(encoding="utf-8")
+
+
+def test_policy_json_invariants() -> None:
+    payload = json.loads(POLICY_JSON.read_text(encoding="utf-8"))
+    assert payload["policy_id"] == dedup.POLICY_ID
+    assert payload["runtime_authorization_effect"] == "NONE"
+    assert payload["core_logic_change"] is False
+    assert payload["capability_11_13_started"] is False
+    assert payload["github_required_checks_role"] == (
+        "BINDING_BROAD_INTEGRATION_AND_REGRESSION_LAYER"
+    )
+    retained = {row["check_id"] for row in payload["local_checks_retained"]}
+    redundant = {row["check_id"] for row in payload["redundant_local_reexecutions_removed"]}
+    assert "safety_activation_credential_order_hard_stops" in retained
+    assert "bound_capability_or_owner_test_once" in retained
+    assert "capability_suite_rerun_for_evidence_seal_only" in redundant
+    assert "pre_pr_rerun_of_identical_bound_suite" in redundant
+    assert "WEAKEN_SAFETY_ACTIVATION_CREDENTIAL_ORDER_HARD_STOPS" in payload["forbidden"]
+    assert "START_CAPABILITY_11_13" in payload["forbidden"]
+
+
+def test_load_policy_and_required_contexts() -> None:
+    policy = dedup.load_policy(repo_root=REPO_ROOT)
+    assert policy["policy_id"] == dedup.POLICY_ID
+    contexts = dedup.load_required_contexts(repo_root=REPO_ROOT)
+    live = json.loads(REQUIRED_CHECKS.read_text(encoding="utf-8"))
+    expected = set(live["required_contexts"]) - set(live.get("ignored_contexts") or [])
+    assert contexts == frozenset(expected)
+    assert "tests (3.11)" in contexts
+    assert "Lint Gate" in contexts
+
+
+def test_classify_skip_github_covered_without_local_value() -> None:
+    contexts = dedup.load_required_contexts(repo_root=REPO_ROOT)
+    action = dedup.classify_local_check(
+        check_id="local_full_suite_mirror_of_github_required_tests",
+        github_required_contexts=contexts,
+        github_context_name="tests (3.11)",
+        local_pre_push_value_required=False,
+    )
+    assert action == dedup.ACTION_SKIP_GITHUB
+
+
+def test_classify_retain_ruff_first_diagnosis() -> None:
+    contexts = dedup.load_required_contexts(repo_root=REPO_ROOT)
+    action = dedup.classify_local_check(
+        check_id="ruff_format_and_check_on_python_diff",
+        github_required_contexts=contexts,
+        github_context_name="Lint Gate",
+        local_pre_push_value_required=True,
+    )
+    assert action == dedup.ACTION_EXECUTE
+
+
+def test_classify_reuse_bound_pass() -> None:
+    contexts = dedup.load_required_contexts(repo_root=REPO_ROOT)
+    action = dedup.classify_local_check(
+        check_id="pre_pr_rerun_of_identical_bound_suite",
+        github_required_contexts=contexts,
+        local_pre_push_value_required=True,
+        bound_pass_reusable=True,
+    )
+    assert action == dedup.ACTION_REUSE
+
+
+def test_bound_evidence_reuse_fail_closed() -> None:
+    good = {
+        "bound_stand_sha256": "abc123",
+        "test_selector_or_command": "pytest -q tests/ci/test_verification_minimum_local_ci_dedup_v1.py",
+        "full_run": True,
+        "result": "PASS",
+        "exit_code": 0,
+    }
+    assert dedup.validate_bound_test_evidence(good) == []
+    assert dedup.bound_pass_is_reusable(
+        binding=good,
+        current_stand_sha256="abc123",
+        current_test_selector_or_command=good["test_selector_or_command"],
+    )
+    assert not dedup.bound_pass_is_reusable(
+        binding=good,
+        current_stand_sha256="changed",
+        current_test_selector_or_command=good["test_selector_or_command"],
+    )
+    bad = dict(good, exit_code=1, result="FAIL")
+    assert dedup.validate_bound_test_evidence(bad)
+    assert not dedup.bound_pass_is_reusable(
+        binding=bad,
+        current_stand_sha256="abc123",
+        current_test_selector_or_command=good["test_selector_or_command"],
+    )
+
+
+def test_pre_pr_legacy_envelope_without_reuse_fields_still_passes() -> None:
+    assert verify_pre_pr_validation_result(_valid_pre_pr()) == []
+
+
+def test_pre_pr_reuse_fields_valid() -> None:
+    data = _valid_pre_pr(
+        LOCAL_TEST_EVIDENCE_REUSE_STATUS="REUSED",
+        BOUND_LOCAL_TEST_STAND_SHA256="deadbeef",
+        BOUND_LOCAL_TEST_COMMAND="pytest -q tests/ci/test_verification_minimum_local_ci_dedup_v1.py",
+        BOUND_LOCAL_TEST_EXIT_CODE="0",
+        BOUND_LOCAL_TEST_RESULT="PASS",
+        BOUND_LOCAL_TEST_FULL_RUN="true",
+    )
+    assert verify_pre_pr_validation_result(data) == []
+
+
+def test_pre_pr_reuse_fields_invalid_exit_blocks() -> None:
+    data = _valid_pre_pr(
+        LOCAL_TEST_EVIDENCE_REUSE_STATUS="REUSED",
+        BOUND_LOCAL_TEST_STAND_SHA256="deadbeef",
+        BOUND_LOCAL_TEST_COMMAND="pytest -q tests/ci/test_verification_minimum_local_ci_dedup_v1.py",
+        BOUND_LOCAL_TEST_EXIT_CODE="1",
+        BOUND_LOCAL_TEST_RESULT="PASS",
+        BOUND_LOCAL_TEST_FULL_RUN="true",
+    )
+    errors = verify_pre_pr_validation_result(data)
+    assert errors
+
+
+def test_cli_print_policy() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(ORCHESTRATOR), "--print-policy"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["ok"] is True
+    assert payload["policy_id"] == dedup.POLICY_ID
+    assert "capability_suite_rerun_for_evidence_seal_only" in payload["redundant_removed"]
+
+
+def test_generic_not_cap_11_12_special_case() -> None:
+    text = POLICY_MD.read_text(encoding="utf-8")
+    assert "capability-generic" in text.lower() or "Cap-11.12-only" in text
+    assert "CAPABILITY_11_13_STARTED=false" in text
+    orch = ORCHESTRATOR.read_text(encoding="utf-8")
+    assert "Cap-11.13" in orch or "capability_11_13" in orch


### PR DESCRIPTION
## Summary
- Codifies Master Runbook §15.3 + machine-readable policy for minimum local CI dedup: one bound local capability/owner `PASS`+`EXIT=0` is reusable for evidence seal, static verifiers, and Pre-PR.
- GitHub Required Checks remain the binding broad integration/regression layer; redundant local re-runs of identical stands or GitHub-covered checks without pre-push value are forbidden.
- Wires optional Pre-PR reuse fields into `verify_pre_pr_validation_result_v0.py` with fail-closed validation; adds contract tests. No trading/activation/order/Cap-11.13 changes.

## Test plan
- [x] `ruff format --check` + `ruff check` on touched Python
- [x] `pytest -q tests/ci/test_verification_minimum_local_ci_dedup_v1.py tests/ci/test_cursor_auto_pr_pre_pr_validation_enforcement_contract_v0.py` (53 passed)
- [x] Docs token policy + docs reference targets on changed Markdown
- [x] Selector `FOCUSED` / `focused_script_or_test_diff` on final diff
- [ ] GitHub Required Checks on PR (binding broad confirmation)


Made with [Cursor](https://cursor.com)