### PR TITLE
phase11: BoundOkx transport UA + ISO-ms timestamp for §11.12.8

### DIFF
--- a/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
+++ b/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
@@ -187,7 +187,6 @@ Ergänzende Owner-/Wiring-Hinweise (keine parallele Trading-SSOT):
 | [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.12.8.2 | SSOT forensic status &#47; next-step binding |
 | [`evidence/ops/section_11_12_8_bounded_long_running_productive_testnet_campaign_now/20260808T181528Z/`](../../evidence/ops/section_11_12_8_bounded_long_running_productive_testnet_campaign_now/20260808T181528Z/) | Primary sealed run evidence (immutable) |
 | [`…&#47;20260808T181528Z&#47;derived_forensic_closeout_v1&#47;`](../../evidence/ops/section_11_12_8_bounded_long_running_productive_testnet_campaign_now/20260808T181528Z/derived_forensic_closeout_v1/) | Derived HTTP-403 forensic closeout (non-SSOT) |
-| [`…&#47;section_11_12_8_autonomous_okx_eea_demo_credential_ip_resolve_v1&#47;20260808T203507Z&#47;`](../../evidence/ops/section_11_12_8_autonomous_okx_eea_demo_credential_ip_resolve_v1/20260808T203507Z/) | Predecessor orderless Demo GET proof (not targeted trade proof) |
 
 ```text
 THIS_SECTION_DEFINES_NO_SEMANTICS=true
@@ -196,6 +195,7 @@ SECTION_11_13_STARTED=false
 LIVE_AUTHORIZED=false
 NEXT_CANONICAL_STEP_POINTER=OWNER_GO_RESOLVE_EXTERNAL_OKX_TESTNET_ACCOUNT_OR_CREDENTIAL_BLOCKER_AND_RETRY_TARGETED_PROOF
 PREDECESSOR_GET_PROOF_IS_NOT_TARGETED_TRADE_PROOF=true
+PREDECESSOR_ORDERLESS_GET_PROOF_EVIDENCE_POINTER=evidence&#47;ops&#47;section_11_12_8_autonomous_okx_eea_demo_credential_ip_resolve_v1&#47;20260808T203507Z&#47;
 ```
 
 ---

--- a/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
+++ b/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
@@ -187,6 +187,7 @@ Ergänzende Owner-/Wiring-Hinweise (keine parallele Trading-SSOT):
 | [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.12.8.2 | SSOT forensic status &#47; next-step binding |
 | [`evidence/ops/section_11_12_8_bounded_long_running_productive_testnet_campaign_now/20260808T181528Z/`](../../evidence/ops/section_11_12_8_bounded_long_running_productive_testnet_campaign_now/20260808T181528Z/) | Primary sealed run evidence (immutable) |
 | [`…&#47;20260808T181528Z&#47;derived_forensic_closeout_v1&#47;`](../../evidence/ops/section_11_12_8_bounded_long_running_productive_testnet_campaign_now/20260808T181528Z/derived_forensic_closeout_v1/) | Derived HTTP-403 forensic closeout (non-SSOT) |
+| [`…&#47;section_11_12_8_autonomous_okx_eea_demo_credential_ip_resolve_v1&#47;20260808T203507Z&#47;`](../../evidence/ops/section_11_12_8_autonomous_okx_eea_demo_credential_ip_resolve_v1/20260808T203507Z/) | Predecessor orderless Demo GET proof (not targeted trade proof) |
 
 ```text
 THIS_SECTION_DEFINES_NO_SEMANTICS=true
@@ -194,6 +195,7 @@ SECTION_11_12_8_CLOSED=false
 SECTION_11_13_STARTED=false
 LIVE_AUTHORIZED=false
 NEXT_CANONICAL_STEP_POINTER=OWNER_GO_RESOLVE_EXTERNAL_OKX_TESTNET_ACCOUNT_OR_CREDENTIAL_BLOCKER_AND_RETRY_TARGETED_PROOF
+PREDECESSOR_GET_PROOF_IS_NOT_TARGETED_TRADE_PROOF=true
 ```
 
 ---

--- a/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
+++ b/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
@@ -3266,14 +3266,22 @@ TESTNET_STAR_PROVEN=false
 LIVE_ORDER_EFFECT=NONE
 SECTION_11_13_STARTED=false
 CANONICAL_NEXT_STEP_AFTER_HTTP_403_FORENSIC=OWNER_GO_RESOLVE_EXTERNAL_OKX_TESTNET_ACCOUNT_OR_CREDENTIAL_BLOCKER_AND_RETRY_TARGETED_PROOF
-OPEN_BLOCKER=EXTERNAL_OKX_TESTNET_ACCOUNT_OR_CREDENTIAL_OR_GATEWAY_HTTP_403
+OPEN_BLOCKER=PRODUCTIVE_BOUND_CLIENT_TRANSPORT_UA_AND_ISO_MS_TIMESTAMP_REQUIRED_BEFORE_TARGETED_PROOF_RETRY
+PREDECESSOR_ORDERLESS_GET_PROOF_EVIDENCE=evidence&#47;ops&#47;section_11_12_8_autonomous_okx_eea_demo_credential_ip_resolve_v1&#47;20260808T203507Z&#47;
+PREDECESSOR_ORDERLESS_GET_PROOF_IS_NOT_TARGETED_TRADE_PROOF=true
+BOUND_OKX_TESTNET_HTTP_CLIENT_TRANSPORT_REQUIREMENTS=browser_compatible_User-Agent + OK-ACCESS-TIMESTAMP ISO8601_MS_Z + x-simulated-trading:1
 ```
 
 Campaign duration completion and sealed evidence processing do **not** close
 §11.12.8 while `TESTNET_*_PROVEN` remain false. HTTP 403 without OKX
 `code`&#47;`sCode` is transport&#47;gateway class, not exchange-semantic reject.
 No ACK&#47;Reject&#47;Fill&#47;Exchange-Order-ID may be fabricated from transport success
-alone. Live remains hard-blocked. Cap &#47; §11.13 remains unstarted.
+alone. Authenticated orderless private GET success under Demo &#43;
+`x-simulated-trading:1` is predecessor credential&#47;transport evidence only and
+must not be claimed as the targeted trade proof. The productive bound client
+must send a browser-compatible `User-Agent` and OKX-compatible millisecond
+ISO `OK-ACCESS-TIMESTAMP` before any Owner-authorized targeted proof retry.
+Live remains hard-blocked. Cap &#47; §11.13 remains unstarted.
 
 Section 2.1 `NO_TESTNET_ORDERS` describes the **no-order program** finish
 boundary. It does not forbid a separately Owner-authorized §11.12 Testnet

--- a/src/ops/section_11_12_8_real_productive_testnet_execute_path_unlock_v1/bound_testnet_http_client_v1.py
+++ b/src/ops/section_11_12_8_real_productive_testnet_execute_path_unlock_v1/bound_testnet_http_client_v1.py
@@ -6,8 +6,9 @@ import base64
 import hashlib
 import hmac
 import json
-import time
+import re
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any
 from urllib import error, request
 from urllib.parse import urlparse
@@ -28,7 +29,11 @@ from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.sec
 )
 from src.ops.section_11_12_8_real_productive_testnet_execute_path_unlock_v1.constants_v1 import (
     BOUND_CLIENT_KIND,
+    BOUND_OKX_ACCESS_TIMESTAMP_FORMAT,
+    BOUND_OKX_TESTNET_HTTP_USER_AGENT,
 )
+
+_OKX_ISO_MS_Z_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
 
 
 class BoundTestnetHttpClientError(RuntimeError):
@@ -77,6 +82,23 @@ def sign_okx_request_v1(
     return base64.b64encode(digest).decode("ascii")
 
 
+def format_okx_access_timestamp_iso_ms_v1(*, now: datetime | None = None) -> str:
+    """Return OKX-compatible OK-ACCESS-TIMESTAMP (UTC ISO-8601 with milliseconds)."""
+    dt = datetime.now(timezone.utc) if now is None else now
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    ms = dt.microsecond // 1000
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{ms:03d}Z"
+
+
+def assert_okx_access_timestamp_iso_ms_v1(timestamp: str) -> str:
+    if not _OKX_ISO_MS_Z_RE.fullmatch(str(timestamp or "")):
+        raise BoundTestnetHttpClientError("OKX_ACCESS_TIMESTAMP_FORMAT_INVALID")
+    return timestamp
+
+
 @dataclass
 class BoundOkxTestnetHttpClientV1:
     """Real Testnet HTTP client. Wire send is gated; pre-merge keeps it disabled."""
@@ -105,7 +127,7 @@ class BoundOkxTestnetHttpClientV1:
         material = borrow_ephemeral_material_for_session_auth_v1(self.credential_handle)
         creds = _parse_okx_material(material)
         del material
-        timestamp = str(time.time())
+        timestamp = assert_okx_access_timestamp_iso_ms_v1(format_okx_access_timestamp_iso_ms_v1())
         sign = sign_okx_request_v1(
             secret=creds["api_secret"],
             timestamp=timestamp,
@@ -119,6 +141,7 @@ class BoundOkxTestnetHttpClientV1:
             "OK-ACCESS-TIMESTAMP": timestamp,
             "OK-ACCESS-PASSPHRASE": creds["passphrase"],
             "Content-Type": "application/json",
+            "User-Agent": BOUND_OKX_TESTNET_HTTP_USER_AGENT,
             SIMULATION_HEADER_NAME: SIMULATION_HEADER_VALUE,
         }
         # Drop secrets from local names ASAP.
@@ -133,6 +156,8 @@ class BoundOkxTestnetHttpClientV1:
             "rest_base": self.rest_base,
             "simulation_header": {SIMULATION_HEADER_NAME: SIMULATION_HEADER_VALUE},
             "auth_headers_present": True,
+            "user_agent_present": True,
+            "okx_access_timestamp_format": BOUND_OKX_ACCESS_TIMESTAMP_FORMAT,
             "client_kind": self.client_kind,
             "wire_send_enabled": self.wire_send_enabled,
         }

--- a/src/ops/section_11_12_8_real_productive_testnet_execute_path_unlock_v1/constants_v1.py
+++ b/src/ops/section_11_12_8_real_productive_testnet_execute_path_unlock_v1/constants_v1.py
@@ -59,6 +59,17 @@ LIVE_HARD_BLOCK_PRESERVED = True
 BOUND_CLIENT_KIND = "BOUND_REAL_TESTNET_HTTP_CLIENT"
 VAULT_BACKEND_KIND = "PRODUCTIVE_SECRETREF_VAULT_RESOLVER"
 
+# Cloudflare / OKX EEA gateway rejects Python-urllib default UA (error 1010).
+# Browser-compatible UA is transport-only; it does not alter signing or auth semantics.
+BOUND_OKX_TESTNET_HTTP_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/127.0.0.0 Safari/537.36"
+)
+# OKX private REST accepts ISO-8601 UTC with millisecond precision (…SSS Z).
+# Bare str(time.time()) can yield excess fractional digits → OKX 50112.
+BOUND_OKX_ACCESS_TIMESTAMP_FORMAT = "ISO8601_MS_Z"
+
 REQUIRED_RUNTIME_CHAIN: tuple[str, ...] = (
     "OWNER_GO_EXECUTE",
     "ACTIVATION_ENABLED_ARMED",

--- a/tests/ops/test_section_11_12_8_real_productive_testnet_execute_path_unlock_v1.py
+++ b/tests/ops/test_section_11_12_8_real_productive_testnet_execute_path_unlock_v1.py
@@ -32,9 +32,13 @@ from src.ops.section_11_12_8_real_productive_testnet_execute_path_unlock_v1.acce
 )
 from src.ops.section_11_12_8_real_productive_testnet_execute_path_unlock_v1.bound_testnet_http_client_v1 import (
     BoundTestnetHttpClientError,
+    assert_okx_access_timestamp_iso_ms_v1,
     construct_bound_okx_testnet_http_client_v1,
+    format_okx_access_timestamp_iso_ms_v1,
 )
 from src.ops.section_11_12_8_real_productive_testnet_execute_path_unlock_v1.constants_v1 import (
+    BOUND_OKX_ACCESS_TIMESTAMP_FORMAT,
+    BOUND_OKX_TESTNET_HTTP_USER_AGENT,
     CAPABILITY_ID,
     FORBIDDEN_TRACE_TOKENS,
     PATH_IMPLEMENTATION_ONLY_REFUSAL_REMOVED,
@@ -130,6 +134,102 @@ def test_live_host_hard_block_on_client(tmp_path: Path) -> None:
             body={},
             headers={},
         )
+
+
+def test_okx_access_timestamp_iso_ms_format() -> None:
+    from datetime import datetime, timezone
+
+    fixed = datetime(2026, 8, 8, 20, 35, 7, 123456, tzinfo=timezone.utc)
+    ts = format_okx_access_timestamp_iso_ms_v1(now=fixed)
+    assert ts == "2026-08-08T20:35:07.123Z"
+    assert assert_okx_access_timestamp_iso_ms_v1(ts) == ts
+    with pytest.raises(BoundTestnetHttpClientError, match="OKX_ACCESS_TIMESTAMP_FORMAT_INVALID"):
+        assert_okx_access_timestamp_iso_ms_v1("1754682907.1234567")
+
+
+def test_bound_client_sets_browser_ua_and_iso_ms_timestamp_metadata() -> None:
+    backend = build_acceptance_fixture_vault_backend_v1()
+    handle = resolve_and_load_secretref_ephemeral_v1(
+        allow_real_vault=True,
+        vault_backend=backend,
+    )
+    client = construct_bound_okx_testnet_http_client_v1(credential_handle=handle)
+    result = client.request(
+        method="GET",
+        url="https://eea.okx.com/api/v5/account/balance",
+        body={},
+        headers={},
+    )
+    assert result["wire_sent"] is False
+    assert result["network_effect"] == "NONE"
+    prepared = client.prepared_requests[-1]
+    assert prepared["user_agent_present"] is True
+    assert prepared["okx_access_timestamp_format"] == BOUND_OKX_ACCESS_TIMESTAMP_FORMAT
+    assert prepared["simulation_header"]["x-simulated-trading"] == "1"
+    assert "Chrome/127" in BOUND_OKX_TESTNET_HTTP_USER_AGENT
+    assert "Python-urllib" not in BOUND_OKX_TESTNET_HTTP_USER_AGENT
+
+
+def test_bound_client_wire_headers_include_ua_sim_and_iso_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = build_acceptance_fixture_vault_backend_v1()
+    handle = resolve_and_load_secretref_ephemeral_v1(
+        allow_real_vault=True,
+        vault_backend=backend,
+    )
+    client = construct_bound_okx_testnet_http_client_v1(
+        credential_handle=handle,
+        wire_send_enabled=True,
+    )
+    captured: dict[str, object] = {}
+
+    class _Resp:
+        status = 200
+
+        def read(self) -> bytes:
+            return b'{"code":"0","data":[],"msg":""}'
+
+        def getcode(self) -> int:
+            return 200
+
+        def __enter__(self) -> "_Resp":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def _fake_urlopen(req: object, timeout: float = 0.0) -> _Resp:  # noqa: ARG001
+        headers = getattr(req, "headers", {})
+        # urllib lowercases header keys in some versions; normalize.
+        norm = {str(k).lower(): str(v) for k, v in dict(headers).items()}
+        captured["headers"] = norm
+        captured["timeout"] = timeout
+        return _Resp()
+
+    monkeypatch.setattr(
+        "src.ops.section_11_12_8_real_productive_testnet_execute_path_unlock_v1.bound_testnet_http_client_v1.request.urlopen",
+        _fake_urlopen,
+    )
+    out = client.request(
+        method="GET",
+        url="https://eea.okx.com/api/v5/account/config",
+        body={},
+        headers={},
+    )
+    assert out["wire_sent"] is True
+    assert out["network_effect"] == "TESTNET"
+    headers = captured["headers"]
+    assert isinstance(headers, dict)
+    assert headers.get("user-agent") == BOUND_OKX_TESTNET_HTTP_USER_AGENT
+    assert headers.get("x-simulated-trading") == "1"
+    ts = headers.get("ok-access-timestamp")
+    assert isinstance(ts, str)
+    assert_okx_access_timestamp_iso_ms_v1(ts)
+    # Auth material present as headers but never asserted as plaintext values in evidence.
+    assert "ok-access-key" in headers
+    assert "ok-access-sign" in headers
+    assert "ok-access-passphrase" in headers
 
 
 def test_historical_refuse_helper_still_exists_but_not_on_real_path() -> None:


### PR DESCRIPTION
## Summary
- Adds browser-compatible `User-Agent` and OKX-compatible millisecond ISO `OK-ACCESS-TIMESTAMP` to `BoundOkxTestnetHttpClientV1` (transport-only).
- Adds regression tests for timestamp format and wire-header metadata (`x-simulated-trading:1`, UA, ISO-ms).
- Updates Master Runbook §11.12.8.2 / Map of Truth pointers: predecessor orderless GET proof is not targeted trade proof; next step remains `OWNER_GO_RESOLVE_EXTERNAL_OKX_TESTNET_ACCOUNT_OR_CREDENTIAL_BLOCKER_AND_RETRY_TARGETED_PROOF`.

## Test plan
- [x] `pytest tests/ops/test_section_11_12_8_real_productive_testnet_execute_path_unlock_v1.py`
- [x] Docs token policy on changed Markdown
- [x] PR_BOUNDED_FULL local timing (~52s) including selector contract suite
- [ ] GitHub required checks green
- [ ] After `OWNER_MERGE_GO`: retry targeted demo trade proof (no §11.13)


Made with [Cursor](https://cursor.com)