### PR TITLE
phase11: persist OKX msg + attest signed==wire body for §11.12.8

### DIFF
--- a/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/okx_response_mapper_v1.py
+++ b/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/okx_response_mapper_v1.py
@@ -18,6 +18,7 @@ class OkxOrderResponseV1:
     wire_sent: bool
     body_parsed: bool
     exchange_code: str | None
+    msg: str | None
     s_code: str | None
     s_msg: str | None
     client_order_id: str | None
@@ -37,6 +38,7 @@ class OkxOrderResponseV1:
             "wire_sent": self.wire_sent,
             "body_parsed": self.body_parsed,
             "exchange_code": self.exchange_code,
+            "msg": self.msg,
             "s_code": self.s_code,
             "s_msg": self.s_msg,
             "client_order_id": self.client_order_id,
@@ -113,6 +115,7 @@ def parse_okx_order_response_v1(
             wire_sent=True,
             body_parsed=False,
             exchange_code=None,
+            msg=None,
             s_code=None,
             s_msg=None,
             client_order_id=None,
@@ -133,6 +136,7 @@ def parse_okx_order_response_v1(
             wire_sent=False,
             body_parsed=body_parsed,
             exchange_code=None,
+            msg=None,
             s_code=None,
             s_msg=None,
             client_order_id=None,
@@ -148,6 +152,9 @@ def parse_okx_order_response_v1(
 
     assert body_obj is not None
     exchange_code = str(body_obj.get("code")) if body_obj.get("code") is not None else None
+    # Top-level OKX msg must be retained for forensic reject diagnosis (e.g. 50124).
+    top_msg = body_obj.get("msg")
+    msg = str(top_msg) if top_msg is not None and str(top_msg) != "" else None
     data = body_obj.get("data")
     item: dict[str, Any] = {}
     if isinstance(data, list) and data and isinstance(data[0], dict):
@@ -184,6 +191,7 @@ def parse_okx_order_response_v1(
         wire_sent=True,
         body_parsed=True,
         exchange_code=exchange_code,
+        msg=msg,
         s_code=s_code,
         s_msg=s_msg,
         client_order_id=cl_ord,

--- a/src/ops/section_11_12_8_real_productive_testnet_execute_path_unlock_v1/bound_testnet_http_client_v1.py
+++ b/src/ops/section_11_12_8_real_productive_testnet_execute_path_unlock_v1/bound_testnet_http_client_v1.py
@@ -123,7 +123,10 @@ class BoundOkxTestnetHttpClientV1:
         if method_u not in {"GET", "POST"}:
             raise BoundTestnetHttpClientError(f"METHOD_FORBIDDEN:{method}")
         body_obj = body or {}
+        # Single serialization used for BOTH OKX prehash body and wire bytes.
         body_text = "" if method_u == "GET" else json.dumps(body_obj, separators=(",", ":"))
+        wire_body_bytes = body_text.encode("utf-8") if body_text else b""
+        signed_body_sha256 = hashlib.sha256(wire_body_bytes).hexdigest()
         material = borrow_ephemeral_material_for_session_auth_v1(self.credential_handle)
         creds = _parse_okx_material(material)
         del material
@@ -160,6 +163,11 @@ class BoundOkxTestnetHttpClientV1:
             "okx_access_timestamp_format": BOUND_OKX_ACCESS_TIMESTAMP_FORMAT,
             "client_kind": self.client_kind,
             "wire_send_enabled": self.wire_send_enabled,
+            "content_type": "application/json",
+            "signed_body_sha256": signed_body_sha256,
+            "wire_body_sha256": signed_body_sha256,
+            "signed_body_equals_wire_body": True,
+            "body_byte_len": len(wire_body_bytes),
         }
         self.prepared_requests.append(prepared)
 
@@ -174,11 +182,12 @@ class BoundOkxTestnetHttpClientV1:
                 "response_body": None,
                 "account_identity": "acct-uid-testnet-demo",
                 "client_kind": self.client_kind,
+                "signed_body_equals_wire_body": True,
             }
 
         req = request.Request(
             url,
-            data=body_text.encode("utf-8") if body_text else None,
+            data=wire_body_bytes if wire_body_bytes else None,
             method=method_u,
             headers=merged,
         )

--- a/tests/ops/test_section_11_12_8_bounded_long_running_productive_testnet_campaign_v1.py
+++ b/tests/ops/test_section_11_12_8_bounded_long_running_productive_testnet_campaign_v1.py
@@ -317,6 +317,21 @@ def test_okx_accept_reject_and_wire_not_ack() -> None:
     assert rejected.exchange_rejected is True
     assert rejected.order_acknowledged is False
 
+    # Top-level exchange msg must persist for auth-class rejects (predecessor 50124 gap).
+    auth_reject = parse_okx_order_response_v1(
+        transport_result={
+            "ok": False,
+            "http_status": 401,
+            "response_body": {"code": "50124", "msg": "captured-exchange-msg"},
+        },
+        wire_sent=True,
+    )
+    assert auth_reject.exchange_rejected is True
+    assert auth_reject.exchange_code == "50124"
+    assert auth_reject.msg == "captured-exchange-msg"
+    assert auth_reject.order_acknowledged is False
+    assert "msg" in auth_reject.raw_keys
+
     with pytest.raises(OkxResponseMapperError, match="INVALID_OKX_RESPONSE_JSON"):
         parse_okx_order_response_v1(
             transport_result={"ok": True, "http_status": 200, "response_body": b"{not-json"},
@@ -333,6 +348,9 @@ def test_okx_accept_reject_and_wire_not_ack() -> None:
     assert body["clOrdId"] == "c1"
     assert body["instId"] == "BTC-USDT-SWAP"
     assert "client_order_id" not in body
+    # Forensic: productive LIMIT body currently omits Conditional OKX px.
+    assert "px" not in body
+    assert body["ordType"] == "limit"
 
 
 def test_fill_only_when_evidenced() -> None:

--- a/tests/ops/test_section_11_12_8_real_productive_testnet_execute_path_unlock_v1.py
+++ b/tests/ops/test_section_11_12_8_real_productive_testnet_execute_path_unlock_v1.py
@@ -232,6 +232,78 @@ def test_bound_client_wire_headers_include_ua_sim_and_iso_timestamp(
     assert "ok-access-passphrase" in headers
 
 
+def test_bound_client_post_signed_body_equals_wire_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import hashlib
+    import io
+    import json
+    from urllib import error as urlerror
+
+    from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.okx_response_mapper_v1 import (
+        build_venue_native_order_body_v1,
+    )
+
+    backend = build_acceptance_fixture_vault_backend_v1()
+    handle = resolve_and_load_secretref_ephemeral_v1(
+        allow_real_vault=True,
+        vault_backend=backend,
+    )
+    client = construct_bound_okx_testnet_http_client_v1(
+        credential_handle=handle,
+        wire_send_enabled=True,
+    )
+    venue_body = build_venue_native_order_body_v1(
+        client_order_id="coid-diag-1",
+        instrument="BTC-USDT-SWAP",
+        order_type="LIMIT",
+        side="buy",
+        quantity="1",
+    )
+    expected_text = json.dumps(venue_body, separators=(",", ":"))
+    expected_sha = hashlib.sha256(expected_text.encode("utf-8")).hexdigest()
+    captured: dict[str, object] = {}
+
+    def _fake_urlopen_http_error(req: object, timeout: float = 0.0) -> object:  # noqa: ARG001
+        data = getattr(req, "data", None)
+        captured["data"] = data
+        headers = getattr(req, "headers", {})
+        captured["headers"] = {str(k).lower(): str(v) for k, v in dict(headers).items()}
+        raise urlerror.HTTPError(
+            url="https://eea.okx.com/api/v5/trade/order",
+            code=401,
+            msg="Unauthorized",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=io.BytesIO(b'{"code":"50124","msg":"fixture-msg-only"}'),
+        )
+
+    monkeypatch.setattr(
+        "src.ops.section_11_12_8_real_productive_testnet_execute_path_unlock_v1.bound_testnet_http_client_v1.request.urlopen",
+        _fake_urlopen_http_error,
+    )
+    out = client.request(
+        method="POST",
+        url="https://eea.okx.com/api/v5/trade/order",
+        body=venue_body,
+        headers={},
+    )
+    assert out["wire_sent"] is True
+    assert out["http_status"] == 401
+    assert out["response_body"] == {"code": "50124", "msg": "fixture-msg-only"}
+    assert captured["data"] == expected_text.encode("utf-8")
+    prepared = client.prepared_requests[-1]
+    assert prepared["method"] == "POST"
+    assert prepared["path"] == "/api/v5/trade/order"
+    assert prepared["signed_body_equals_wire_body"] is True
+    assert prepared["signed_body_sha256"] == expected_sha
+    assert prepared["wire_body_sha256"] == expected_sha
+    assert prepared["content_type"] == "application/json"
+    headers = captured["headers"]
+    assert isinstance(headers, dict)
+    assert headers.get("content-type") == "application/json"
+    assert headers.get("x-simulated-trading") == "1"
+
+
 def test_historical_refuse_helper_still_exists_but_not_on_real_path() -> None:
     with pytest.raises(ActualStartConsumerError, match="FORBIDDEN_IN_IMPLEMENTATION"):
         refuse_real_productive_campaign_in_implementation_go_v1()


### PR DESCRIPTION
## Summary
- Persist top-level OKX `msg` in `okx_response_mapper_v1` so exchange rejects (e.g. predecessor `50124`) remain diagnostically usable.
- Attest `signed_body_sha256 == wire_body_sha256` on `BoundOkxTestnetHttpClientV1` prepared requests (single serialization; no trading-logic change).
- Add focused regression coverage for auth-class reject msg persistence and POST signed-body/wire-body identity.

## Diagnosis note (no order POST in this PR)
- Predecessor sealed evidence dropped top-level `msg` while retaining `code=50124`.
- Public OKX EN/ZH error tables do not document `50124` (catalog ends at `50122`).
- Productive LIMIT body still omits Conditional `px` (separate defect; not claimed as proven `50124` cause).
- **STOP before merge / no retry order until OWNER_MERGE_GO.**

## Test plan
- [x] `ruff format --check` + `ruff check` on touched files
- [x] `pytest` unlock + bounded campaign suites (32 passed)
- [ ] GitHub required checks on PR


Made with [Cursor](https://cursor.com)