### PR TITLE
fix(section-11.12.8): serialize Conditional OKX LIMIT px

### DIFF
--- a/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/campaign_executor_v1.py
+++ b/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/campaign_executor_v1.py
@@ -9,6 +9,7 @@ from typing import Any, Callable
 from uuid import uuid4
 
 from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.constants_v1 import (
+    CANONICAL_LIMIT_PX_FOR_VENUE_NATIVE_BODY_V1,
     NEXT_OPERATION_AFTER_STUBBED_BOUNDARY,
     OFFLINE_PROOF_CADENCE_SECONDS,
     OFFLINE_PROOF_MAX_CYCLES,
@@ -180,6 +181,7 @@ def run_campaign_lifecycle_v1(
     monotonic_fn: Callable[[], float] = time.monotonic,
     sleep_fn: Callable[[float], None] = time.sleep,
     campaign_id: str | None = None,
+    limit_px: str = CANONICAL_LIMIT_PX_FOR_VENUE_NATIVE_BODY_V1,
 ) -> CampaignLifecycleRecordV1:
     """Bounded long-running campaign loop.
 
@@ -292,6 +294,9 @@ def run_campaign_lifecycle_v1(
             do_submit = cycle_index == 0
 
         if do_submit:
+            px_text = str(limit_px).strip()
+            if not px_text:
+                raise ActualStartExecutorError("LIMIT_ORDER_PX_REQUIRED_BEFORE_WIRE")
             client_order_id = f"coid-{record.campaign_id[:8]}-{cycle_index}"
             effect = port.submit_order_v1(
                 client_order_id=client_order_id,
@@ -299,6 +304,7 @@ def run_campaign_lifecycle_v1(
                 order_type="LIMIT",
                 side="buy",
                 quantity="1",
+                px=px_text,
             )
             order_attempted = True
             record.order_attempt_count += 1

--- a/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/constants_v1.py
+++ b/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/constants_v1.py
@@ -96,6 +96,9 @@ CANONICAL_RUNTIME_MODE = "TESTNET"
 CANONICAL_VENUE = "OKX"
 CANONICAL_INSTRUMENT_SCOPE: tuple[str, ...] = ("BTC-USDT-SWAP",)
 CANONICAL_ALLOWED_ORDER_TYPES: tuple[str, ...] = ("LIMIT",)
+# Far-below reference px for BTC-USDT-SWAP LIMIT serialization on the §11.12.8
+# proof path only. Satisfies OKX Conditional px; not a trading signal / MD quote.
+CANONICAL_LIMIT_PX_FOR_VENUE_NATIVE_BODY_V1 = "10000"
 CANONICAL_POSITION_COUNT_LIMIT = 1
 CANONICAL_EMERGENCY_COMMANDS: tuple[str, ...] = CAP_11_5_EMERGENCY_COMMANDS
 CANONICAL_SECRET_REFERENCE = "secretref://vault/peak-trade/testnet-demo"

--- a/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/okx_response_mapper_v1.py
+++ b/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/okx_response_mapper_v1.py
@@ -53,6 +53,22 @@ class OkxOrderResponseV1:
         }
 
 
+# OKX Place Order: Conditional px required for these ordType values.
+_OKX_ORD_TYPES_REQUIRING_PX: frozenset[str] = frozenset(
+    {
+        "limit",
+        "post_only",
+        "fok",
+        "ioc",
+        "optimal_limit_ioc",
+        "mmp",
+        "mmp_and_post_only",
+        "op_fok",
+        "op_ioc",
+    }
+)
+
+
 def build_venue_native_order_body_v1(
     *,
     client_order_id: str,
@@ -61,16 +77,28 @@ def build_venue_native_order_body_v1(
     side: str,
     quantity: str,
     td_mode: str = "cross",
+    px: str | None = None,
 ) -> dict[str, Any]:
-    """Cap 11.4 venue-native field mapping (productive; dry_run omitted)."""
-    return {
+    """Cap 11.4 venue-native field mapping (productive; dry_run omitted).
+
+    For LIMIT-class ordType, OKX Conditional ``px`` MUST be present in the
+    final request body. Missing/blank px fails closed before wire.
+    """
+    ord_type = order_type.lower()
+    body: dict[str, Any] = {
         "clOrdId": client_order_id,
         "instId": instrument,
         "side": side.lower(),
-        "ordType": order_type.lower(),
+        "ordType": ord_type,
         "sz": quantity,
         "tdMode": td_mode,
     }
+    if ord_type in _OKX_ORD_TYPES_REQUIRING_PX:
+        px_text = "" if px is None else str(px).strip()
+        if not px_text:
+            raise OkxResponseMapperError("LIMIT_ORDER_PX_REQUIRED_BEFORE_WIRE")
+        body["px"] = px_text
+    return body
 
 
 def parse_okx_order_response_v1(

--- a/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/productive_execution_port_v1.py
+++ b/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/productive_execution_port_v1.py
@@ -53,6 +53,7 @@ class ProductiveTestnetExecutionPortV1:
         order_type: str,
         side: str,
         quantity: str,
+        px: str,
     ) -> dict[str, Any]:
         if not self.authorized:
             raise ActualStartPortError("SUBMIT_FORBIDDEN_WITHOUT_AUTHORIZATION")
@@ -71,6 +72,7 @@ class ProductiveTestnetExecutionPortV1:
             order_type=order_type,
             side=side,
             quantity=quantity,
+            px=px,
         )
         result = self.transport.request(
             method="POST",
@@ -109,6 +111,7 @@ class ProductiveTestnetExecutionPortV1:
             "order_type": order_type,
             "side": side,
             "quantity": quantity,
+            "px": px,
             "venue_native_body": venue_body,
             "stubbed": stubbed_result,
             # submitted means order attempt reached transport; NOT exchange ACK

--- a/tests/ops/test_section_11_12_8_actual_productive_testnet_campaign_run_start_v1.py
+++ b/tests/ops/test_section_11_12_8_actual_productive_testnet_campaign_run_start_v1.py
@@ -338,6 +338,7 @@ def test_productive_port_and_transport() -> None:
         order_type="LIMIT",
         side="buy",
         quantity="1",
+        px="10000",
     )
     assert effect["stubbed"] is True
     assert effect["live_order_effect"] == "NONE"

--- a/tests/ops/test_section_11_12_8_bounded_long_running_productive_testnet_campaign_v1.py
+++ b/tests/ops/test_section_11_12_8_bounded_long_running_productive_testnet_campaign_v1.py
@@ -344,13 +344,33 @@ def test_okx_accept_reject_and_wire_not_ack() -> None:
         order_type="LIMIT",
         side="buy",
         quantity="1",
+        px="10000",
     )
     assert body["clOrdId"] == "c1"
     assert body["instId"] == "BTC-USDT-SWAP"
     assert "client_order_id" not in body
-    # Forensic: productive LIMIT body currently omits Conditional OKX px.
-    assert "px" not in body
+    # OKX Conditional px MUST be present for LIMIT before any Order-POST.
+    assert body["px"] == "10000"
     assert body["ordType"] == "limit"
+
+    with pytest.raises(OkxResponseMapperError, match="LIMIT_ORDER_PX_REQUIRED_BEFORE_WIRE"):
+        build_venue_native_order_body_v1(
+            client_order_id="c1",
+            instrument="BTC-USDT-SWAP",
+            order_type="LIMIT",
+            side="buy",
+            quantity="1",
+            px=None,
+        )
+    with pytest.raises(OkxResponseMapperError, match="LIMIT_ORDER_PX_REQUIRED_BEFORE_WIRE"):
+        build_venue_native_order_body_v1(
+            client_order_id="c1",
+            instrument="BTC-USDT-SWAP",
+            order_type="limit",
+            side="buy",
+            quantity="1",
+            px="   ",
+        )
 
 
 def test_fill_only_when_evidenced() -> None:
@@ -518,6 +538,7 @@ def test_exchange_order_id_persisted_on_port_attempt() -> None:
         order_type="LIMIT",
         side="buy",
         quantity="1",
+        px="10000",
     )
     assert effect["wire_sent"] is True
     assert effect["order_acknowledged"] is True

--- a/tests/ops/test_section_11_12_8_real_productive_testnet_execute_path_unlock_v1.py
+++ b/tests/ops/test_section_11_12_8_real_productive_testnet_execute_path_unlock_v1.py
@@ -259,6 +259,7 @@ def test_bound_client_post_signed_body_equals_wire_body(
         order_type="LIMIT",
         side="buy",
         quantity="1",
+        px="10000",
     )
     expected_text = json.dumps(venue_body, separators=(",", ":"))
     expected_sha = hashlib.sha256(expected_text.encode("utf-8")).hexdigest()


### PR DESCRIPTION
## Summary
- Diagnose §11.12.8 OKX EEA Demo Order-POST `code=50124`: on `origin/main`, productive LIMIT bodies omit Conditional OKX `px` → HARD STOP before any retry.
- Minimal fix: require/serialize `px` for LIMIT-class `ordType`, fail-closed with `LIMIT_ORDER_PX_REQUIRED_BEFORE_WIRE`, thread `px` through productive port + campaign executor.
- No trading/risk/live-gate changes; no Order-POST in this PR.

## Test plan
- [x] Focused §11.12.8 owner tests (52 passed)
- [x] PR-bounded selector targets (729 passed, ~36s)
- [x] `ruff format --check` + `ruff check` on touched files
- [ ] GitHub required checks on PR

```text
NEXT_CANONICAL_STEP=OWNER_MERGE_GO_<PR>_NO_ORDER_RETRY
SECTION_11_12_8_STATUS=OPEN_NOT_CLOSED
SECTION_11_13_STARTED=false
LIVE_ORDER_EFFECT=NONE
ORDER_ATTEMPT_COUNT=0
```

Made with [Cursor](https://cursor.com)