### PR TITLE
docs(ops): archive private ZIP import provenance (2026-08-11)

### DIFF
--- a/docs/ops/DOCS_REFERENCE_TARGETS_IGNORE.txt
+++ b/docs/ops/DOCS_REFERENCE_TARGETS_IGNORE.txt
@@ -31,6 +31,7 @@ docs/analysis/**
 
 # Ops archive copies (historical snapshots)
 docs/ops/archives/**
+docs/ops/_archive/**
 
 # Time-boxed exploratory spikes (may reference removed or superseded paths)
 docs/ops/spikes/**

--- a/docs/ops/_archive/private_zip_import_20260811/IMPORT_PROVENANCE.json
+++ b/docs/ops/_archive/private_zip_import_20260811/IMPORT_PROVENANCE.json
@@ -1,0 +1,77 @@
+{
+  "document_class": "HISTORICAL_ARCHIVE_ONLY",
+  "runtime_authorization_effect": "NONE",
+  "import_date": "2026-08-11",
+  "owner_go": "OWNER_GO_IMPORT_LOCAL_PRIVATE_ZIPS_TO_PEAK_TRADE",
+  "localized_source_dir_resolved": "/Users/frnkhrz/Documents/Dokumente Privat",
+  "requested_source_dir": "~/Documents/Privat/",
+  "canonical_ssot_overwrite": false,
+  "sources": [
+    {
+      "id": "SOURCE_1",
+      "original_filename": "peak_trade_ai_autonomy_audit_docs.zip",
+      "absolute_path": "/Users/frnkhrz/Documents/Dokumente Privat/peak_trade_ai_autonomy_audit_docs.zip",
+      "size_bytes": 6158,
+      "sha256": "c41e43eb628bc193c30254f6855da7b8164d04e6c3cc5419a565ab05245645b8",
+      "classification": "PEAK_TRADE_AI_AUTONOMY_AUDIT_DOCS_HISTORICAL",
+      "decision": "HISTORICAL_ARCHIVE_ONLY",
+      "git_committed_content": true,
+      "target_paths": [
+        "docs/ops/_archive/private_zip_import_20260811/historical_ai_autonomy_audit_docs/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md.archived",
+        "docs/ops/_archive/private_zip_import_20260811/historical_ai_autonomy_audit_docs/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md.archived"
+      ],
+      "external_original_zip_copy": "/Users/frnkhrz/Documents/Peak_Trade_Archive/private_zip_import_20260811_peak_trade_ai_autonomy_audit/original_zip_copy/peak_trade_ai_autonomy_audit_docs.zip",
+      "active_canonical_owners": [
+        "docs/governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md",
+        "docs/governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md",
+        "docs/governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md"
+      ],
+      "members": [
+        {
+          "zip_path": "docs/governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md",
+          "sha256": "e4bb4303ec8bc0c3d4bfa13a9523e7bfe0102092bed2f98e395ec14f6a638d62",
+          "size_bytes": 8641,
+          "archived_as": "docs/ops/_archive/private_zip_import_20260811/historical_ai_autonomy_audit_docs/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md.archived"
+        },
+        {
+          "zip_path": "docs/governance/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md",
+          "sha256": "1f81dff5957f2dc56e44c5b28ecc4d6442326f2d82a11d1301a2c860b0b437d1",
+          "size_bytes": 3567,
+          "archived_as": "docs/ops/_archive/private_zip_import_20260811/historical_ai_autonomy_audit_docs/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md.archived"
+        }
+      ]
+    },
+    {
+      "id": "SOURCE_2",
+      "original_filename": "83940723_20251006_05533c0e0a08 2.zip",
+      "absolute_path": "/Users/frnkhrz/Documents/Dokumente Privat/83940723_20251006_05533c0e0a08 2.zip",
+      "size_bytes": 2332682,
+      "sha256": "10d8cc1e9a1096fbef2ecfe3a2c1d045d345decf464ee2355cb92298f14ed256",
+      "classification": "NON_PEAK_TRADE_PERSONAL_LEGAL_ESIGN_CONTRACT_PACK",
+      "decision": "EXTERNAL_ARCHIVE_ONLY_NO_GIT_PDF_BYTES",
+      "git_committed_content": false,
+      "sensitive_reason": "Personal/legal eSign contract PDFs (AGB/Vertragsunterlagen); no Peak_Trade relevance",
+      "external_archive_root": "/Users/frnkhrz/Documents/Peak_Trade_Archive/private_zip_import_20260811_non_peak_trade_personal_legal",
+      "target_paths": [
+        "docs/ops/_archive/private_zip_import_20260811/IMPORT_PROVENANCE.json",
+        "docs/ops/_archive/private_zip_import_20260811/README.md"
+      ],
+      "members": [
+        {
+          "zip_path": "AGB eSign.pdf",
+          "sha256": "8f5f63492c6b600c5fed3cde81731137ea2609fd2fbbb9b459781079442bd4ac",
+          "size_bytes": 335900,
+          "git_committed": false,
+          "external_path": "/Users/frnkhrz/Documents/Peak_Trade_Archive/private_zip_import_20260811_non_peak_trade_personal_legal/extracted/AGB eSign.pdf"
+        },
+        {
+          "zip_path": "Vertragsunterlagen.pdf",
+          "sha256": "b5cf939eeb8bf51215c7e6e3af953749cdcd67a335f290ce510a42e489ce2658",
+          "size_bytes": 1996506,
+          "git_committed": false,
+          "external_path": "/Users/frnkhrz/Documents/Peak_Trade_Archive/private_zip_import_20260811_non_peak_trade_personal_legal/extracted/Vertragsunterlagen.pdf"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/ops/_archive/private_zip_import_20260811/README.md
+++ b/docs/ops/_archive/private_zip_import_20260811/README.md
@@ -1,0 +1,95 @@
+# Private ZIP import archive — 2026-08-11
+
+```text
+DOCUMENT_CLASS=HISTORICAL_ARCHIVE_ONLY
+DOCUMENT_ROLE=NON_CANONICAL_IMPORT_PROVENANCE
+STATUS=HISTORICAL / NON_AUTHORIZING
+RUNTIME_AUTHORIZATION_EFFECT=NONE
+LIVE_AUTHORIZED=false
+TESTNET_AUTHORIZED=false
+ORDERS_ALLOWED=false
+CANONICAL_SSOT_OVERWRITE=false
+IMPORT_DATE=2026-08-11
+OWNER_GO=OWNER_GO_IMPORT_LOCAL_PRIVATE_ZIPS_TO_PEAK_TRADE
+```
+
+**Rule:** Canonical Peak_Trade docs, Master Runbook, Map of Truth, gates, and specs
+supersede everything here. This archive does **not** authorize Live, Testnet, Paper
+Exchange, credentials, orders, or autonomy activation.
+
+Localized macOS source directory resolved from `~/Documents/Privat/` →
+`/Users/frnkhrz/Documents/Dokumente Privat/`.
+
+---
+
+## Source 1 — Peak_Trade AI autonomy audit docs
+
+| Field | Value |
+|-------|-------|
+| Original filename | `peak_trade_ai_autonomy_audit_docs.zip` |
+| Absolute source path | `/Users/frnkhrz/Documents/Dokumente Privat/peak_trade_ai_autonomy_audit_docs.zip` |
+| Size (bytes) | `6158` |
+| SHA256 | `c41e43eb628bc193c30254f6855da7b8164d04e6c3cc5419a565ab05245645b8` |
+| Classification | `PEAK_TRADE_AI_AUTONOMY_AUDIT_DOCS_HISTORICAL` |
+| Decision | `HISTORICAL_ARCHIVE_ONLY` — do **not** overwrite active governance |
+
+### Contained members
+
+| Member (zip-internal path; not a live repo claim) | Member SHA256 | In-repo archive path |
+|---------------------------------------------------|---------------|----------------------|
+| ZIP member GO_NO_GO overview <!-- pt:ref-target-ignore --> | `e4bb4303ec8bc0c3d4bfa13a9523e7bfe0102092bed2f98e395ec14f6a638d62` | [historical_ai_autonomy_audit_docs/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md.archived](historical_ai_autonomy_audit_docs/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md.archived) |
+| ZIP member Evidence Pack template <!-- pt:ref-target-ignore --> | `1f81dff5957f2dc56e44c5b28ecc4d6442326f2d82a11d1301a2c860b0b437d1` | [historical_ai_autonomy_audit_docs/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md.archived](historical_ai_autonomy_audit_docs/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md.archived) |
+
+### Active canonical owners (do not replace with this archive)
+
+| Topic | Active canonical path |
+|-------|------------------------|
+| AI Autonomy Go/No-Go | `docs/governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md` (repo copy is newer / more complete than ZIP) |
+| Evidence Pack Template | `docs/governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md` |
+| Evidence Pack Template v2 | `docs/governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE_V2.md` |
+| Layer/Model matrix | `docs/governance/matrix/AI_AUTONOMY_LAYER_MAP_MODEL_MATRIX.md` |
+
+Operator recovery copy of the original ZIP (outside git):
+
+`/Users/frnkhrz/Documents/Peak_Trade_Archive/private_zip_import_20260811_peak_trade_ai_autonomy_audit/original_zip_copy/peak_trade_ai_autonomy_audit_docs.zip`
+
+---
+
+## Source 2 — eSign / Vertragsunterlagen pack
+
+| Field | Value |
+|-------|-------|
+| Original filename | `83940723_20251006_05533c0e0a08 2.zip` |
+| Absolute source path | `/Users/frnkhrz/Documents/Dokumente Privat/83940723_20251006_05533c0e0a08 2.zip` |
+| Size (bytes) | `2332682` |
+| SHA256 | `10d8cc1e9a1096fbef2ecfe3a2c1d045d345decf464ee2355cb92298f14ed256` |
+| Classification | `NON_PEAK_TRADE_PERSONAL_LEGAL_ESIGN_CONTRACT_PACK` |
+| Decision | `EXTERNAL_ARCHIVE_ONLY` — **not** mixed into active Peak_Trade docs; **PDF bytes not committed** |
+
+### Contained members (metadata only in git)
+
+| Member | Size | Member SHA256 | Git committed? |
+|--------|------|---------------|----------------|
+| `AGB eSign.pdf` | `335900` | `8f5f63492c6b600c5fed3cde81731137ea2609fd2fbbb9b459781079442bd4ac` | `false` |
+| `Vertragsunterlagen.pdf` | `1996506` | `b5cf939eeb8bf51215c7e6e3af953749cdcd67a335f290ce510a42e489ce2658` | `false` |
+
+### Why not in Peak_Trade git
+
+- No Peak_Trade / AI / Autonomy / Runbook relevance.
+- Personal/legal eSign contract material (`AGB`, `Vertragsunterlagen`, SEPA keyword signal).
+- Fail-closed: do not commit personal/legal PDFs into the repository tree.
+
+External (non-git) archive path:
+
+`/Users/frnkhrz/Documents/Peak_Trade_Archive/private_zip_import_20260811_non_peak_trade_personal_legal/`
+
+Machine-readable provenance: [IMPORT_PROVENANCE.json](IMPORT_PROVENANCE.json)
+
+---
+
+## Safety notes
+
+- Zip-slip / path traversal: none observed.
+- No executable members observed.
+- No canonical SSOT/runbook status fields were mutated by this import.
+- No trading logic, Live/Testnet/Paper execution, or credentials touched.

--- a/docs/ops/_archive/private_zip_import_20260811/historical_ai_autonomy_audit_docs/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md.archived
+++ b/docs/ops/_archive/private_zip_import_20260811/historical_ai_autonomy_audit_docs/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md.archived
@@ -1,0 +1,123 @@
+# EVP — Evidence Pack (Template)
+**Evidence Pack ID:** EVP_YYYYMMDD_<session>_<env>  
+**Related Policy Doc:** PT-GOV-AI-001  
+**Env:** SHADOW / PAPER / LIVE_MANUAL_ONLY / LIVE_BOUNDED_AUTO  
+**Date:** YYYY-MM-DD  
+**Owner:** <name>  
+**Reviewers:** <names>  
+**TTL (Autonomy Lease):** <expires YYYY-MM-DD HH:MM TZ>
+
+---
+
+## 1. Scope (Day Trading)
+- **Instrument Universe:** <symbols/venues>
+- **Session Window:** <start/end times>
+- **Flat-by-Time:** <time + enforcement mechanism>
+- **Max Trades/Day:** <number>
+- **Max Exposure:** <definition>
+- **Daily Loss Limit:** <value + enforcement>
+
+---
+
+## 2. System Identity (Reproducibility)
+- **Repo Root:** <path>
+- **Commit SHA:** <sha>
+- **Branch/Tag:** <branch/tag>
+- **Build/Package Version:** <version>
+- **Config Snapshot:** <path or embedded excerpt, secrets redacted>
+- **Runtime Mode:** <paper/live/shadow>
+- **Dependencies Lock:** <poetry/uv/pip freeze ref, optional>
+
+---
+
+## 3. Governance / Policy
+- **Go/No-Go Decision:** GO / NO_GO
+- **Target State:** PAPER_GO / LIVE_MANUAL_ONLY / LIVE_BOUNDED_AUTO
+- **Policy Version (PT-GOV-AI-001):** <version>
+- **AI Roles Matrix Version:** <doc + version>
+- **Model Placement Doc Version:** <doc + version>
+
+### 3.1 Autonomy Lease (if GO)
+- **TTL Expiry:** <timestamp>
+- **Scope:** <instruments, sessions, constraints>
+- **Autonomy Budget:** <limits: loss, exposure, trades, leverage>
+- **Revocation Mechanism:** <how revoke is enforced + proof link>
+
+---
+
+## 4. Risk & Safety Controls (MUST)
+### 4.1 Controls Status
+- [ ] Risk can block orders (proof attached)
+- [ ] Kill Switch functional and tested
+- [ ] Daily Loss Limit functional and tested
+- [ ] Flat-by-Time functional and tested
+- [ ] Cooldown/Circuit Breaker rules defined and tested
+- [ ] No online-learning influences live behavior (proof attached)
+
+### 4.2 Proof / Artefacts
+- **Risk Block Test Output:** <file/link>
+- **Kill Switch Drill Output:** <file/link>
+- **Limit Breach Simulation Output:** <file/link>
+- **Flat-by-Time Evidence:** <file/link>
+- **Runbook References:** <links>
+
+---
+
+## 5. Execution & Hot Path Integrity
+- [ ] Order-Path works without AI dependency
+- [ ] Execution is deterministic relative to inputs (as designed)
+- [ ] Latency budget respected (if applicable)
+- [ ] Error budget defined + monitored
+
+**Artefacts:**
+- **Execution Health Logs:** <file/link>
+- **Latency/Errors Snapshot:** <file/link>
+
+---
+
+## 6. Reconstruction (Audit Trail)
+### 6.1 Correlation & Event IDs
+- **Decision Event IDs:** <list>
+- **Order IDs / Broker IDs:** <list>
+- **Correlation ID Scheme:** <description>
+
+### 6.2 Decision Logs
+- **Hold Reasons present:** yes/no
+- **Inputs captured:** yes/no
+- **Outputs captured:** yes/no
+- **Policy/Model/Prompt versioning captured (if AI used):** yes/no
+
+**Artefacts:**
+- <paths/links>
+
+---
+
+## 7. Monitoring & Alerting
+- **Primary On-Call:** <name/contact>
+- **Escalation Path:** <steps>
+- **Alert Channels:** <slack/email/ops dashboard>
+- **Key Signals:** data feed, execution errors, limit breaches, drawdown, position flat-by-time
+
+**Artefacts:**
+- <paths/links>
+
+---
+
+## 8. Decision Summary
+**Why GO/NO_GO (1–2 Absätze, klar, testbar):**  
+<text>
+
+**Known Risks & Mitigations:**  
+- <risk> → <mitigation>
+
+**Rollback/Stop Plan:**  
+<text + runbook links>
+
+---
+
+## 9. Sign-off (Audit)
+- **Owner (Constitution Authority):** ___________________ Date: ________
+- **Risk Owner (if separate):** ________________________ Date: ________
+- **Compliance/Observer (optional):** ___________________ Date: ________
+
+**Next Review Trigger:** <time/event-based>

--- a/docs/ops/_archive/private_zip_import_20260811/historical_ai_autonomy_audit_docs/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md.archived
+++ b/docs/ops/_archive/private_zip_import_20260811/historical_ai_autonomy_audit_docs/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md.archived
@@ -1,0 +1,242 @@
+# PT-GOV-AI-001 — AI Autonomy: Go / No-Go Overview (Audit-Stable)
+## Best-Practice Leitplanke für AI-gestütztes DAY TRADING
+
+**Status:** Controlled Document (Governance)  
+**Owner:** System Owner (Constitution Authority)  
+**Approver:** Governance / Risk Owner (falls getrennt)  
+**Effective Date:** YYYY-MM-DD  
+**Version:** 1.0.0  
+**Review Cadence:** mindestens quarterly oder bei jeder Live-Policy-Änderung  
+**Applies To:** Peak_Trade — alle Umgebungen (Shadow, Paper, Live)  
+**Primary Goal:** DAY TRADING (hoch riskant, kurze Feedbackschleifen)
+
+---
+
+## 0. Normative Sprache
+
+Die Schlüsselwörter **MUST**, **MUST NOT**, **SHOULD**, **MAY** sind normativ zu verstehen (Audit/Policy-Sprache).
+Dieses Dokument ist eine **Governance-Leitplanke**. Es ist **keine** Implementierung und **keine** Live-Freischaltung.
+
+---
+
+## 1. Zweck
+
+Dieses Dokument definiert **auf Governance-Ebene**, wann Peak_Trade **Live-Handeln** zulassen darf (GO) und wann es **verboten** ist (NO-GO), insbesondere im Kontext von **AI-Unterstützung** und **Autonomie**.
+
+Es dient als:
+- Entscheidungsrahmen für Go/No-Go
+- Audit-Grundlage (prüfbare Kriterien + Evidence-Pflichten)
+- Schutz gegen „Performance-First“-Fehlentscheidungen
+
+---
+
+## 2. Definitionen (Day-Trading-spezifisch)
+
+### 2.1 Betriebsmodi
+- **SHADOW:** Daten & Signale laufen, keine Orders.
+- **PAPER:** Orders werden simuliert / Paper-Broker; keine realen Trades.
+- **LIVE:** Orders gehen an Broker/Exchange und können Kapital bewegen.
+
+### 2.2 Autonomie (operativ definiert)
+Autonomie ist ein **zeitlich begrenztes Recht**, das das System erhält, innerhalb klarer Grenzen Entscheidungen **auszuführen**.
+
+- **Autonomy Lease:** Freigabe mit Ablaufzeit (TTL), Scope (Instrumente/Session), Budget (Risiko/Exposure/Trade Count).
+- **Autonomy Budget:** quantifizierte Grenzen (z.B. Daily Loss Limit, Max Exposure, Max Orders/Tag).
+
+### 2.3 Day-Trading-Non-Negotiables (MUST)
+Für LIVE (egal ob manual-only oder bounded-auto) gelten zwingend:
+- **Daily Loss Limit** (harte Sperre)
+- **Kill Switch / Emergency Stop** (sofort wirksam)
+- **Flat-by-Time** (Positionsabbau bis definierter Zeit)
+- **Max Trades/Tag** und **Max Exposure** (harte Limits)
+- **Cooldown / Circuit Breaker** nach Störungen oder Limit-Ereignissen
+
+---
+
+## 3. Nicht verhandelbare Grundannahmen
+
+- Day-Trading ist **hochgradig riskant**.
+- AI kann Analysequalität erhöhen, erhöht aber **nicht automatisch** Sicherheit.
+- **Governance steht über AI.**
+- **Default ist immer NO-GO.**
+- Autonomie ist ein **Recht auf Zeit**, kein Dauerzustand.
+
+---
+
+## 4. Rollenverständnis: Was AI ist – und was nicht
+
+### 4.1 AI ist (Allowed Use)
+AI kann eingesetzt werden als:
+- Denk- und Analyseinstanz
+- Erklär- und Auditinstanz (Narrative + Rekonstruktion)
+- Entscheidungs-Vorbereiter (Recommendations, nicht final)
+- Policy-/Autonomie-Wächter (Governor) im Sinne von **Prüfen, Flaggen, Blockieren** auf Basis von Policy
+
+### 4.2 AI ist nicht (Forbidden Use)
+AI **MUST NOT** sein:
+- Order-Placer (direktes Order-Placement)
+- Autor von Risk-Regeln im Live-Betrieb
+- Ausnahme-Entscheider (Overrides/Exceptions)
+- Live-Optimierer (Parameter-Tweaks on-the-fly im Live-Betrieb)
+
+---
+
+## 5. Verhältnis zu Peak_Trade Layern (Architektur-Invariante)
+
+Die folgenden Invarianten **MUST** gelten:
+- Strategy Layer bleibt **deterministisch** (reproduzierbare Outputs bei gleichen Inputs).
+- Risk Layer bleibt **hart und final** (Risk kann blockieren; Risk gewinnt immer).
+- Execution bleibt **dumm und schnell** (keine Modellabhängigkeit im Hot Path).
+- AI sitzt **darüber**, nicht **dazwischen**.
+- Go/No-Go ist die **oberste Instanz** (über Strategy/Risk/Execution).
+
+**Audit-Kernregel:** Der Order-Path **MUST** auch ohne AI vollständig funktionieren.
+
+---
+
+## 6. Go/No-Go State Machine (Audit-Fundament)
+
+### 6.1 Zustände
+- **NO_GO:** Kein Live-Order-Placement. Shadow/Paper erlaubt.
+- **PAPER_GO:** Paper-Execution erlaubt; Live verboten.
+- **LIVE_MANUAL_ONLY:** Live ist erlaubt, aber jede Order wird manuell bestätigt.
+- **LIVE_BOUNDED_AUTO:** Live ist erlaubt innerhalb Autonomy Lease + Autonomy Budget.
+- **EMERGENCY_STOP:** Harte Sperre; nur Recovery-Runbook.
+
+### 6.2 Transition-Regeln (MUST)
+- Jede Transition in einen „stärkeren“ Zustand (z.B. PAPER_GO → LIVE_MANUAL_ONLY) **MUST** ein Evidence Pack haben (siehe Abschnitt 10).
+- Jede GO-Freigabe **MUST** als Autonomy Lease mit TTL erteilt werden.
+- Jede GO-Freigabe **MUST** jederzeit widerrufbar sein; Widerruf **MUST** sofort wirksam sein (vor nächstem Order-Submit).
+- Jede Transition **MUST** geloggt werden (wer, wann, warum, welche Evidence, welche Versionen).
+
+---
+
+## 7. Zentrale Frage (entscheidungsleitend)
+
+Die zentrale Frage ist:
+
+> **Ist dieses System aktuell in der Lage, Verantwortung für eigenes Handeln zu tragen?**
+
+Nicht:
+- „Ist das Modell gut?“
+- „Ist die Performance hoch?“
+
+Sondern:
+- Erklärbarkeit
+- Kontrollierbarkeit
+- Risikodominanz
+- Auditierbarkeit
+
+---
+
+## 8. Harte NO-GO Gründe (MUST → NO_GO oder EMERGENCY_STOP)
+
+Die folgenden Bedingungen **MUST** zu NO_GO führen (oder bei akuter Gefahr zu EMERGENCY_STOP):
+
+1) **AI nicht vollständig integriert** (unklarer Einfluss, „KI nicht drauf“, unklare Pipeline).  
+2) **Entscheidungen nicht rekonstruierbar** (fehlende Logs/Inputs/Outputs/IDs/Versionen).  
+3) Kein klares „Warum nicht handeln“ / kein Hold-Reasoning.  
+4) **Risk kann nicht blockieren** (Risk-Override fehlt / technisch unwirksam).  
+5) Lernen beeinflusst Live-Verhalten (ungeprüfte Online-Learning-Änderungen).  
+6) Autonomie-Entzug ist nicht sofort wirksam.  
+7) Order-Path hängt an Modellverfügbarkeit (Modell-Ausfall = Trading-Ausfall).  
+8) Kill Switch / Daily Loss Limit / Flat-by-Time nicht aktiv oder nicht getestet.
+
+---
+
+## 9. Rolle des Owners (Constitution Authority)
+
+Der Owner ist:
+- Verfassungsinstanz
+- darf Autonomie entziehen
+- darf Live stoppen
+- verantwortet die Dokumente/Policies/Sign-offs
+
+Der Owner ist nicht:
+- Trade-Entscheider im operativen Sinne
+- Ausnahme-Genehmiger außerhalb des Change-Prozesses
+- Parameter-Tweaker im Live-Betrieb
+
+**Grundsatz:** Owner darf das System **abschalten**, aber nicht „live steuern“.
+
+---
+
+## 10. Evidence & Audit (MUST)
+
+### 10.1 Evidence Pack Pflicht
+Jede GO-Freigabe (PAPER_GO, LIVE_MANUAL_ONLY, LIVE_BOUNDED_AUTO) **MUST** ein Evidence Pack haben, gespeichert im Repo (versioniert), mit eindeutigem Identifier.
+
+Empfohlenes Pfadschema:
+- `docs/governance/evidence/EVP_YYYYMMDD_<session>_<env>.md`
+
+### 10.2 Mindest-Evidence (Checkliste)
+Ein Evidence Pack **MUST** mindestens enthalten:
+
+**A) System-Identität**
+- Commit SHA / Tag / Release-ID
+- Config Snapshot (redacted secrets)
+- Env (Shadow/Paper/Live), Instrument-Universum, Session-Zeiten
+
+**B) Governance & Policy**
+- Aktive Go/No-Go Policy Version
+- Autonomy Lease (TTL, Scope, Budget)
+- Rollenmatrix-Referenz (AI_Roles_Matrix)
+
+**C) Risiko & Safety**
+- Nachweis: Risk kann blockieren (Test/Drill-Output)
+- Daily Loss Limit, Kill Switch, Flat-by-Time: aktiv + getestet
+- Incident/Recovery Runbook Links
+
+**D) Rekonstruktion**
+- Event IDs / Correlation IDs
+- Logs: Inputs/Outputs/Decisions (inkl. Hold-Reasons)
+- Modell-/Prompt-/Policy-Versionen (falls AI beteiligt)
+
+**E) Monitoring**
+- Live Health Signals (Data feed, execution health, latency, error budget)
+- Alerting (wer bekommt Alerts, wie schnell, Eskalationspfad)
+
+**F) Sign-off**
+- Owner Sign-off (Name/Datum)
+- Risk/Compliance Sign-off (falls getrennt)
+- Gültigkeitsdauer (TTL) + Review Trigger
+
+---
+
+## 11. Modell-Platzierung & Deep Research (Governance-Regel)
+
+### 11.1 Grundregel
+**Deep Research (web-/syntheseorientiert)** ist **MUST NOT** im Trading-Hot-Path.
+Deep Research ist erlaubt für:
+- Pre-market / Post-market Research
+- Regime-/News-Synthese für Strategiewahl auf Governance-Ebene
+- Dokumentations-/Policy-Synthese
+
+### 11.2 Model Routing Dokument
+Die konkrete Modellzuordnung (welches Modell für welche Aufgabe) wird separat gepflegt:
+- `docs/governance/MODEL_PLACEMENT_AND_ROUTING.md`
+
+---
+
+## 12. Change Control (Audit-Stabilität)
+
+Änderungen an:
+- Go/No-Go Kriterien
+- Rollenabgrenzung
+- Autonomy Budget/Lease Defaultwerte
+- Risk/Execution invariants
+
+**MUST** über einen dokumentierten Change-Prozess laufen:
+- PR mit Review
+- Evidence (Tests/Drills)
+- Version bump dieses Dokuments (SemVer oder Date-Version)
+- Aktualisierung des Evidence Pack Templates (falls nötig)
+
+---
+
+## 13. Abschluss (Prinzip)
+
+Ein gutes Day-Trading-System scheitert selten an fehlender Intelligenz,
+sondern an fehlender Selbstbegrenzung.
+
+Dieses Dokument existiert, um genau das zu verhindern.

--- a/docs/ops/_archive/private_zip_import_20260811/historical_ai_autonomy_audit_docs/README.md
+++ b/docs/ops/_archive/private_zip_import_20260811/historical_ai_autonomy_audit_docs/README.md
@@ -1,0 +1,17 @@
+# Historical AI autonomy audit ZIP members (byte-exact)
+
+```text
+DOCUMENT_CLASS=HISTORICAL_ARCHIVE_ONLY
+RUNTIME_AUTHORIZATION_EFFECT=NONE
+CANONICAL_SSOT_OVERWRITE=false
+```
+
+Files use the suffix `.md.archived` so they remain **byte-exact** ZIP members and are not
+treated as live markdown navigation surfaces by docs-reference gates.
+
+| Archived file | Member SHA256 | Active canonical owner |
+|---------------|---------------|------------------------|
+| [AI_AUTONOMY_GO_NO_GO_OVERVIEW.md.archived](AI_AUTONOMY_GO_NO_GO_OVERVIEW.md.archived) | `e4bb4303ec8bc0c3d4bfa13a9523e7bfe0102092bed2f98e395ec14f6a638d62` | `docs/governance/AI_AUTONOMY_GO_NO_GO_OVERVIEW.md` |
+| [AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md.archived](AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md.archived) | `1f81dff5957f2dc56e44c5b28ecc4d6442326f2d82a11d1301a2c860b0b437d1` | `docs/governance/templates/AI_AUTONOMY_EVIDENCE_PACK_TEMPLATE.md` |
+
+Parent provenance: [../README.md](../README.md), [../IMPORT_PROVENANCE.json](../IMPORT_PROVENANCE.json)


### PR DESCRIPTION
## Summary
- Archives historical Peak_Trade AI autonomy audit ZIP members under `docs/ops/_archive/private_zip_import_20260811/` without overwriting canonical governance SSOT.
- Records metadata-only provenance for a non-Peak_Trade personal/legal eSign ZIP; PDF bytes are kept outside git under `~/Documents/Peak_Trade_Archive/...`.
- Extends docs-reference ignore coverage for `docs/ops/_archive/**` (full-scan hygiene).

## Test plan
- [x] Safe ZIP inventory + zip-slip checks
- [x] Member SHA256 match to archived `.md.archived` bytes
- [x] Sensitive-pattern scan on commit scope (PASS; no PDFs committed)
- [x] `verify_docs_reference_targets.sh --changed --base origin/main` (PASS)
- [x] `preflight_docs_token_policy_changed.sh` (PASS)
- [x] CI selector `NO_OP` for docs/static-only diff
- [ ] GitHub required checks on PR

Made with [Cursor](https://cursor.com)